### PR TITLE
Add in-process Rust SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctx-sdk"
+version = "0.11.0"
+dependencies = [
+ "chrono",
+ "ctx-history-capture",
+ "ctx-history-core",
+ "ctx-history-search",
+ "ctx-history-store",
+ "rusqlite",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/ctx-cli",
+    "crates/ctx-sdk",
     "crates/ctx-history-capture",
     "crates/ctx-history-core",
     "crates/ctx-history-search",

--- a/README.md
+++ b/README.md
@@ -117,3 +117,4 @@ ctx keeps retrieval tied to sessions and events, so another agent can inspect th
 | [How it works](https://ctx.rs/concepts/how-it-works) | Understand discovery, import, SQLite storage, search refresh, and cited retrieval. |
 | [Supported agents](https://ctx.rs/concepts/supported-agents) | See which agent histories ctx can discover, import, and search today. |
 | [CLI reference](https://ctx.rs/reference/cli) | Review setup, status, sources, import, show, locate, search, MCP, and doctor. |
+| [Rust SDK](docs/rust-sdk.md) | Use ctx from Rust in process without spawning the CLI. |

--- a/crates/ctx-cli/src/docs.rs
+++ b/crates/ctx-cli/src/docs.rs
@@ -116,6 +116,15 @@ const TOPICS: &[DocTopic] = &[
         body: include_str!("../../../docs/cli-reference.md"),
     },
     DocTopic {
+        id: "rust-sdk",
+        title: "Rust SDK",
+        audience: "developer",
+        summary: "Use ctx from Rust in process without spawning the CLI.",
+        tags: &["rust", "sdk", "integration"],
+        source_path: "docs/rust-sdk.md",
+        body: include_str!("../../../docs/rust-sdk.md"),
+    },
+    DocTopic {
         id: "search",
         title: "Search",
         audience: "agent",

--- a/crates/ctx-sdk/Cargo.toml
+++ b/crates/ctx-sdk/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ctx-sdk"
+version = "0.11.0"
+description = "In-process Rust SDK for ctx local agent history"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+chrono.workspace = true
+ctx-history-capture = { path = "../ctx-history-capture" }
+ctx-history-core = { path = "../ctx-history-core" }
+ctx-history-search = { path = "../ctx-history-search" }
+ctx-history-store = { path = "../ctx-history-store" }
+thiserror.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+rusqlite.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true

--- a/crates/ctx-sdk/README.md
+++ b/crates/ctx-sdk/README.md
@@ -1,0 +1,51 @@
+# ctx-sdk
+
+`ctx-sdk` is an in-process Rust facade over ctx's local history primitives.
+It opens the local SQLite store directly and calls the provider import and search
+crates directly. It does not shell out to the `ctx` binary and does not parse CLI
+JSON.
+
+```rust,no_run
+use ctx_sdk::{CaptureProvider, CtxClient, ImportOptions, SearchOptions};
+
+# fn main() -> ctx_sdk::Result<()> {
+let client = CtxClient::new()?;
+
+client.import_path(
+    CaptureProvider::Codex,
+    "/home/me/.codex/sessions",
+    ImportOptions::default(),
+)?;
+
+let results = client.search(
+    "failed migration",
+    SearchOptions::default().provider(CaptureProvider::Codex).limit(5),
+)?;
+
+for result in results.results {
+    println!("{} {}", result.rank, result.title);
+}
+# Ok(())
+# }
+```
+
+The SDK uses read-only SQLite connections for query APIs and opens a write
+connection only for initialization or import calls.
+
+## Tests
+
+```bash
+cargo test -p ctx-sdk
+```
+
+The default tests use sanitized real local-history formats. To run the opt-in
+live OpenAI test, set `OPENAI_API_KEY` and `CTX_SDK_LIVE_OPENAI_MODEL` in the
+environment, then opt in explicitly:
+
+```bash
+CTX_SDK_LIVE_OPENAI=1 \
+cargo test -p ctx-sdk --test real_llm -- --ignored --nocapture
+```
+
+For OpenAI-compatible Chat Completions providers, also set
+`CTX_SDK_LIVE_OPENAI_API=chat` and `OPENAI_BASE_URL`.

--- a/crates/ctx-sdk/src/client.rs
+++ b/crates/ctx-sdk/src/client.rs
@@ -1,0 +1,202 @@
+use std::{fs, path::PathBuf};
+
+use ctx_history_capture::{provider_source_for_path, ProviderSource};
+use ctx_history_core::{config_path, database_path, default_data_root, CaptureProvider};
+use ctx_history_store::{CatalogCounts, Store};
+
+use crate::error::{Error, Result};
+
+/// Local ctx paths used by a client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CtxPaths {
+    pub data_root: PathBuf,
+    pub database_path: PathBuf,
+    pub config_path: PathBuf,
+}
+
+/// Builder for [`CtxClient`].
+#[derive(Debug, Clone, Default)]
+pub struct CtxClientBuilder {
+    data_root: Option<PathBuf>,
+    home_dir: Option<PathBuf>,
+}
+
+impl CtxClientBuilder {
+    /// Use a specific ctx data root instead of `CTX_DATA_ROOT` / `~/.ctx`.
+    pub fn data_root(mut self, data_root: impl Into<PathBuf>) -> Self {
+        self.data_root = Some(data_root.into());
+        self
+    }
+
+    /// Use a specific home directory for provider source discovery.
+    pub fn home_dir(mut self, home_dir: impl Into<PathBuf>) -> Self {
+        self.home_dir = Some(home_dir.into());
+        self
+    }
+
+    pub fn build(self) -> Result<CtxClient> {
+        Ok(CtxClient {
+            data_root: self.data_root.map(Ok).unwrap_or_else(default_data_root)?,
+            home_dir: self.home_dir,
+        })
+    }
+}
+
+/// In-process client for the local ctx history store.
+#[derive(Debug, Clone)]
+pub struct CtxClient {
+    data_root: PathBuf,
+    home_dir: Option<PathBuf>,
+}
+
+impl CtxClient {
+    /// Build a client from `CTX_DATA_ROOT` / `~/.ctx`.
+    pub fn new() -> Result<Self> {
+        Self::builder().build()
+    }
+
+    pub fn builder() -> CtxClientBuilder {
+        CtxClientBuilder::default()
+    }
+
+    /// Build a client for an explicit data root.
+    pub fn with_data_root(data_root: impl Into<PathBuf>) -> Self {
+        Self {
+            data_root: data_root.into(),
+            home_dir: None,
+        }
+    }
+
+    pub fn paths(&self) -> CtxPaths {
+        CtxPaths {
+            data_root: self.data_root.clone(),
+            database_path: database_path(self.data_root.clone()),
+            config_path: config_path(self.data_root.clone()),
+        }
+    }
+
+    /// Initialize the local store if needed and return its current status.
+    pub fn init(&self) -> Result<Status> {
+        self.open_store()?;
+        self.status()
+    }
+
+    /// Return store status without creating the store.
+    pub fn status(&self) -> Result<Status> {
+        let paths = self.paths();
+        let initialized = paths.database_path.exists();
+        let (indexed_items, indexed_sources, catalog_counts) = if initialized {
+            let store = Store::open_read_only(&paths.database_path)?;
+            (
+                store.indexed_history_item_count()?,
+                store.capture_source_count()?,
+                store.catalog_session_counts()?,
+            )
+        } else {
+            (0, 0, CatalogCounts::default())
+        };
+
+        Ok(Status {
+            initialized,
+            paths,
+            indexed_items,
+            indexed_sources,
+            cataloged_sessions: catalog_counts.total,
+            indexed_catalog_sessions: catalog_counts.indexed,
+            pending_catalog_sessions: catalog_counts.pending,
+            failed_catalog_sessions: catalog_counts.failed,
+            stale_catalog_sessions: catalog_counts.stale,
+            local_only: true,
+        })
+    }
+
+    /// Discover known provider history sources under the configured home dir.
+    pub fn sources(&self) -> Vec<ProviderSource> {
+        self.home_dir()
+            .as_deref()
+            .map(ctx_history_capture::discover_provider_sources)
+            .unwrap_or_default()
+    }
+
+    /// Discover known provider history sources for one provider.
+    pub fn sources_for_provider(&self, provider: CaptureProvider) -> Vec<ProviderSource> {
+        self.home_dir()
+            .as_deref()
+            .map(|home| ctx_history_capture::discover_provider_sources_for_provider(home, provider))
+            .unwrap_or_default()
+    }
+
+    /// Build a provider source from an explicit path.
+    pub fn source_for_path(
+        &self,
+        provider: CaptureProvider,
+        path: impl Into<PathBuf>,
+    ) -> ProviderSource {
+        provider_source_for_path(provider, path.into())
+    }
+
+    /// Run SQLite integrity checks using a read-only connection when possible.
+    pub fn doctor(&self) -> Result<DoctorReport> {
+        let paths = self.paths();
+        let mut findings = Vec::new();
+        if !paths.data_root.exists() {
+            findings.push(format!(
+                "data root does not exist: {}",
+                paths.data_root.display()
+            ));
+        }
+        if paths.database_path.exists() {
+            let store = Store::open_read_only(&paths.database_path)?;
+            findings.extend(store.validate()?);
+        } else {
+            findings.push(format!(
+                "database does not exist: {}",
+                paths.database_path.display()
+            ));
+        }
+        Ok(DoctorReport {
+            ok: findings.is_empty(),
+            findings,
+        })
+    }
+
+    pub(crate) fn open_store(&self) -> Result<Store> {
+        fs::create_dir_all(&self.data_root)?;
+        Ok(Store::open(database_path(self.data_root.clone()))?)
+    }
+
+    pub(crate) fn open_store_read_only(&self) -> Result<Store> {
+        let path = database_path(self.data_root.clone());
+        if !path.exists() {
+            return Err(Error::StoreNotInitialized(path));
+        }
+        Ok(Store::open_read_only(path)?)
+    }
+
+    pub(crate) fn home_dir(&self) -> Option<PathBuf> {
+        self.home_dir
+            .clone()
+            .or_else(|| std::env::var_os("HOME").map(PathBuf::from))
+    }
+}
+
+/// Status of the local ctx store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Status {
+    pub initialized: bool,
+    pub paths: CtxPaths,
+    pub indexed_items: usize,
+    pub indexed_sources: usize,
+    pub cataloged_sessions: usize,
+    pub indexed_catalog_sessions: usize,
+    pub pending_catalog_sessions: usize,
+    pub failed_catalog_sessions: usize,
+    pub stale_catalog_sessions: usize,
+    pub local_only: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DoctorReport {
+    pub ok: bool,
+    pub findings: Vec<String>,
+}

--- a/crates/ctx-sdk/src/error.rs
+++ b/crates/ctx-sdk/src/error.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+use ctx_history_capture::CaptureError;
+use ctx_history_core::{CaptureProvider, CoreError};
+use ctx_history_store::StoreError;
+use thiserror::Error as ThisError;
+
+/// SDK result type.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Errors returned by the in-process SDK facade.
+#[derive(Debug, ThisError)]
+pub enum Error {
+    #[error(transparent)]
+    Core(#[from] CoreError),
+    #[error(transparent)]
+    Store(#[from] StoreError),
+    #[error(transparent)]
+    Capture(#[from] CaptureError),
+    #[error(transparent)]
+    Search(#[from] ctx_history_search::SearchError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("ctx store is not initialized at {0}")]
+    StoreNotInitialized(PathBuf),
+    #[error("no importable provider history sources were found")]
+    NoImportableSources,
+    #[error("{provider} native import is unsupported: {reason}")]
+    UnsupportedProviderImport {
+        provider: CaptureProvider,
+        reason: String,
+    },
+    #[error("{provider} is not registered for provider history import")]
+    UnregisteredProvider { provider: CaptureProvider },
+}

--- a/crates/ctx-sdk/src/import.rs
+++ b/crates/ctx-sdk/src/import.rs
@@ -1,0 +1,419 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use ctx_history_capture::{
+    import_antigravity_cli_history, import_claude_projects_jsonl_tree, import_codex_history_jsonl,
+    import_codex_session_jsonl, import_codex_session_tree, import_copilot_cli_session_events,
+    import_cursor_native_history, import_factory_ai_droid_sessions, import_gemini_cli_history,
+    import_opencode_sqlite, import_pi_session_jsonl, stable_capture_uuid,
+    AntigravityCliImportOptions, ClaudeProjectsImportOptions, CodexEventImportMode,
+    CodexHistoryImportOptions, CodexSessionImportOptions, CodexSessionImportProgressCallback,
+    CodexToolOutputMode, CopilotCliImportOptions, CursorNativeImportOptions,
+    FactoryAiDroidImportOptions, GeminiCliImportOptions, OpenCodeSqliteImportOptions,
+    PiSessionImportOptions, ProviderImportSummary, ProviderImportSupport, ProviderSource,
+    ProviderSourceStatus,
+};
+use ctx_history_core::{CaptureProvider, HistoryRecord};
+use ctx_history_store::Store;
+
+use crate::{
+    client::CtxClient,
+    error::{Error, Result},
+};
+
+/// Options for importing provider history.
+#[derive(Clone)]
+pub struct ImportOptions {
+    pub allow_partial_failures: bool,
+    pub continue_on_error: bool,
+    pub refresh_search_index: bool,
+    pub optimize_search_index: bool,
+    pub codex_tool_output_mode: CodexToolOutputMode,
+    pub codex_event_mode: CodexEventImportMode,
+    pub include_codex_notices: bool,
+    pub codex_progress: Option<CodexSessionImportProgressCallback>,
+}
+
+impl Default for ImportOptions {
+    fn default() -> Self {
+        Self {
+            allow_partial_failures: true,
+            continue_on_error: true,
+            refresh_search_index: true,
+            optimize_search_index: false,
+            codex_tool_output_mode: CodexToolOutputMode::Skip,
+            codex_event_mode: CodexEventImportMode::Search,
+            include_codex_notices: false,
+            codex_progress: None,
+        }
+    }
+}
+
+impl ImportOptions {
+    /// Preserve richer Codex events and tool-output previews.
+    pub fn rich_codex(mut self) -> Self {
+        self.codex_tool_output_mode = CodexToolOutputMode::Full;
+        self.codex_event_mode = CodexEventImportMode::Rich;
+        self.include_codex_notices = true;
+        self
+    }
+
+    pub fn fail_fast(mut self) -> Self {
+        self.continue_on_error = false;
+        self
+    }
+}
+
+/// Import totals aggregated across all sources.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ImportTotals {
+    pub source_files: usize,
+    pub source_bytes: u64,
+    pub imported_sources: usize,
+    pub failed_sources: usize,
+    pub imported_sessions: usize,
+    pub imported_events: usize,
+    pub imported_edges: usize,
+    pub skipped: usize,
+    pub failed: usize,
+}
+
+impl ImportTotals {
+    fn add_imported(&mut self, summary: &ProviderImportSummary, stats: SourceStats) {
+        self.source_files += stats.files;
+        self.source_bytes = self.source_bytes.saturating_add(stats.bytes);
+        self.imported_sources += 1;
+        self.imported_sessions += summary.imported_sessions;
+        self.imported_events += summary.imported_events;
+        self.imported_edges += summary.imported_edges;
+        self.skipped += summary.skipped;
+        self.failed += summary.failed;
+    }
+
+    fn add_failed(&mut self, stats: SourceStats) {
+        self.source_files += stats.files;
+        self.source_bytes = self.source_bytes.saturating_add(stats.bytes);
+        self.failed_sources += 1;
+        self.failed += 1;
+    }
+}
+
+/// Per-source import result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportSourceReport {
+    pub source: ProviderSource,
+    pub stats: SourceStats,
+    pub summary: Option<ProviderImportSummary>,
+    pub error: Option<String>,
+}
+
+/// Import report returned by SDK import methods.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ImportReport {
+    pub totals: ImportTotals,
+    pub sources: Vec<ImportSourceReport>,
+}
+
+/// Source file statistics used for import reporting.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SourceStats {
+    pub files: usize,
+    pub bytes: u64,
+}
+
+impl CtxClient {
+    /// Import all currently available native sources, optionally scoped to a provider.
+    pub fn import_available_sources(
+        &self,
+        provider: Option<CaptureProvider>,
+        options: ImportOptions,
+    ) -> Result<ImportReport> {
+        let sources = match provider {
+            Some(provider) => self.sources_for_provider(provider),
+            None => self.sources(),
+        }
+        .into_iter()
+        .filter(is_importable_source)
+        .collect::<Vec<_>>();
+
+        if sources.is_empty() {
+            return Err(Error::NoImportableSources);
+        }
+
+        self.import_sources(sources, options)
+    }
+
+    /// Import one explicit provider history path.
+    pub fn import_path(
+        &self,
+        provider: CaptureProvider,
+        path: impl Into<PathBuf>,
+        options: ImportOptions,
+    ) -> Result<ImportReport> {
+        self.import_sources(vec![self.source_for_path(provider, path)], options)
+    }
+
+    /// Import a set of provider sources directly.
+    pub fn import_sources(
+        &self,
+        sources: Vec<ProviderSource>,
+        options: ImportOptions,
+    ) -> Result<ImportReport> {
+        if sources.is_empty() {
+            return Err(Error::NoImportableSources);
+        }
+
+        let mut store = self.open_store()?;
+        let mut report = ImportReport::default();
+        for source in sources {
+            let stats = source_stats(&source.path).unwrap_or_default();
+            match validate_import_supported(&source)
+                .and_then(|()| import_one_source(&mut store, &source, &options))
+            {
+                Ok(summary) => {
+                    report.totals.add_imported(&summary, stats);
+                    report.sources.push(ImportSourceReport {
+                        source,
+                        stats,
+                        summary: Some(summary),
+                        error: None,
+                    });
+                }
+                Err(error) if options.continue_on_error => {
+                    report.totals.add_failed(stats);
+                    report.sources.push(ImportSourceReport {
+                        source,
+                        stats,
+                        summary: None,
+                        error: Some(error.to_string()),
+                    });
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        if options.refresh_search_index
+            && (report.totals.imported_sessions > 0
+                || report.totals.imported_events > 0
+                || report.totals.imported_edges > 0)
+        {
+            store.refresh_search_index()?;
+        }
+        if options.optimize_search_index {
+            store.optimize_search_index()?;
+        }
+
+        Ok(report)
+    }
+}
+
+fn is_importable_source(source: &ProviderSource) -> bool {
+    source.exists
+        && source.import_support == ProviderImportSupport::Native
+        && source.status == ProviderSourceStatus::Available
+}
+
+fn validate_import_supported(source: &ProviderSource) -> Result<()> {
+    match source.import_support {
+        ProviderImportSupport::Native => Ok(()),
+        ProviderImportSupport::Unsupported => Err(Error::UnsupportedProviderImport {
+            provider: source.provider,
+            reason: source
+                .unsupported_reason
+                .unwrap_or("no native local-history parser is implemented")
+                .to_owned(),
+        }),
+    }
+}
+
+fn import_one_source(
+    store: &mut Store,
+    source: &ProviderSource,
+    options: &ImportOptions,
+) -> Result<ProviderImportSummary> {
+    let record = import_record_for_source(source);
+    let record_id = record.id;
+    store.upsert_record(&record)?;
+
+    let source_path = Some(source.path.clone());
+    let summary = match source.provider {
+        CaptureProvider::Codex if source.path.is_dir() => import_codex_session_tree(
+            &source.path,
+            store,
+            CodexSessionImportOptions {
+                source_path,
+                history_record_id: Some(record_id),
+                allow_partial_failures: options.allow_partial_failures,
+                tool_output_mode: options.codex_tool_output_mode,
+                event_mode: options.codex_event_mode,
+                include_notices: options.include_codex_notices,
+                progress: options.codex_progress.clone(),
+                ..CodexSessionImportOptions::default()
+            },
+        )?,
+        CaptureProvider::Codex
+            if source.path.file_name().and_then(|name| name.to_str()) == Some("history.jsonl") =>
+        {
+            import_codex_history_jsonl(
+                &source.path,
+                store,
+                CodexHistoryImportOptions {
+                    source_path,
+                    history_record_id: Some(record_id),
+                    allow_partial_failures: options.allow_partial_failures,
+                    ..CodexHistoryImportOptions::default()
+                },
+            )?
+        }
+        CaptureProvider::Codex => import_codex_session_jsonl(
+            &source.path,
+            store,
+            CodexSessionImportOptions {
+                source_path,
+                history_record_id: Some(record_id),
+                allow_partial_failures: options.allow_partial_failures,
+                tool_output_mode: options.codex_tool_output_mode,
+                event_mode: options.codex_event_mode,
+                include_notices: options.include_codex_notices,
+                progress: options.codex_progress.clone(),
+                ..CodexSessionImportOptions::default()
+            },
+        )?,
+        CaptureProvider::Pi => import_pi_session_jsonl(
+            &source.path,
+            store,
+            PiSessionImportOptions {
+                source_path,
+                history_record_id: Some(record_id),
+                allow_partial_failures: options.allow_partial_failures,
+                ..PiSessionImportOptions::default()
+            },
+        )?,
+        CaptureProvider::Claude => import_claude_projects_jsonl_tree(
+            &source.path,
+            store,
+            ClaudeProjectsImportOptions {
+                source_path,
+                history_record_id: Some(record_id),
+                allow_partial_failures: options.allow_partial_failures,
+                ..ClaudeProjectsImportOptions::default()
+            },
+        )?,
+        CaptureProvider::OpenCode => import_opencode_sqlite(
+            &source.path,
+            store,
+            OpenCodeSqliteImportOptions {
+                source_path,
+                history_record_id: Some(record_id),
+                allow_partial_failures: options.allow_partial_failures,
+                ..OpenCodeSqliteImportOptions::default()
+            },
+        )?,
+        CaptureProvider::Antigravity => import_antigravity_cli_history(
+            &source.path,
+            store,
+            AntigravityCliImportOptions {
+                source_path,
+                history_record_id: Some(record_id),
+                allow_partial_failures: options.allow_partial_failures,
+                ..AntigravityCliImportOptions::default()
+            },
+        )?,
+        CaptureProvider::Gemini => import_gemini_cli_history(
+            &source.path,
+            store,
+            GeminiCliImportOptions {
+                source_path,
+                history_record_id: Some(record_id),
+                allow_partial_failures: options.allow_partial_failures,
+                ..GeminiCliImportOptions::default()
+            },
+        )?,
+        CaptureProvider::Cursor => import_cursor_native_history(
+            &source.path,
+            store,
+            CursorNativeImportOptions {
+                source_path,
+                history_record_id: Some(record_id),
+                allow_partial_failures: options.allow_partial_failures,
+                ..CursorNativeImportOptions::default()
+            },
+        )?,
+        CaptureProvider::CopilotCli => import_copilot_cli_session_events(
+            &source.path,
+            store,
+            CopilotCliImportOptions {
+                source_path,
+                history_record_id: Some(record_id),
+                allow_partial_failures: options.allow_partial_failures,
+                ..CopilotCliImportOptions::default()
+            },
+        )?,
+        CaptureProvider::FactoryAiDroid => import_factory_ai_droid_sessions(
+            &source.path,
+            store,
+            FactoryAiDroidImportOptions {
+                source_path,
+                history_record_id: Some(record_id),
+                allow_partial_failures: options.allow_partial_failures,
+                ..FactoryAiDroidImportOptions::default()
+            },
+        )?,
+        provider => return Err(Error::UnregisteredProvider { provider }),
+    };
+
+    Ok(summary)
+}
+
+fn import_record_for_source(source: &ProviderSource) -> HistoryRecord {
+    let key = format!(
+        "agent-history:{}:{}",
+        source.provider.as_str(),
+        source.path.display()
+    );
+    let mut record = HistoryRecord::new(
+        format!("{} agent history", source.provider.as_str()),
+        format!(
+            "Indexed local agent history from {} ({})",
+            source.path.display(),
+            source.source_format
+        ),
+        vec!["agent-history".into(), source.provider.as_str().into()],
+        "agent_history",
+        source.path.parent().map(|path| path.display().to_string()),
+    );
+    record.id = stable_capture_uuid(&key, "record");
+    record
+}
+
+fn source_stats(path: &Path) -> Result<SourceStats> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_file() {
+        return Ok(SourceStats {
+            files: 1,
+            bytes: metadata.len(),
+        });
+    }
+    if !metadata.file_type().is_dir() {
+        return Ok(SourceStats::default());
+    }
+
+    let mut stats = SourceStats::default();
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            let file_type = entry.file_type()?;
+            if file_type.is_dir() {
+                stack.push(entry.path());
+            } else if file_type.is_file() {
+                let metadata = entry.metadata()?;
+                stats.files += 1;
+                stats.bytes = stats.bytes.saturating_add(metadata.len());
+            }
+        }
+    }
+    Ok(stats)
+}

--- a/crates/ctx-sdk/src/lib.rs
+++ b/crates/ctx-sdk/src/lib.rs
@@ -1,0 +1,339 @@
+//! In-process Rust SDK for ctx local agent history.
+//!
+//! The SDK is a small facade over the existing ctx history crates. It opens the
+//! local SQLite store directly and calls provider import/search functions in the
+//! same process. It intentionally does not shell out to the `ctx` binary or parse
+//! CLI JSON.
+
+mod client;
+mod error;
+mod import;
+mod search;
+mod transcript;
+
+pub use client::{CtxClient, CtxClientBuilder, CtxPaths, DoctorReport, Status};
+pub use error::{Error, Result};
+pub use import::{ImportOptions, ImportReport, ImportSourceReport, ImportTotals, SourceStats};
+pub use search::SearchOptions;
+pub use transcript::{
+    EventLocation, EventWindow, EventWindowOptions, SessionLocation, SessionTranscript,
+    ShowSessionOptions, TranscriptMode,
+};
+
+pub use ctx_history_capture::{
+    CodexEventImportMode, CodexSessionImportProgressCallback, CodexToolOutputMode,
+    ProviderCatalogSupport, ProviderImportSummary, ProviderImportSupport, ProviderSource,
+    ProviderSourceKind, ProviderSourceStatus,
+};
+pub use ctx_history_core::{
+    CaptureProvider, CaptureSource, Event, EventRole, EventType, HistoryRecord, Session,
+};
+pub use ctx_history_search::{
+    PacketOptions, SearchFilters, SearchPacket, SearchResultMode, SearchResultScope,
+};
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+    };
+
+    use super::*;
+    use chrono::Utc;
+
+    fn fixture(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/fixtures/provider-history")
+            .join(name)
+    }
+
+    #[test]
+    fn status_is_read_only_until_init() {
+        let temp = tempfile::tempdir().unwrap();
+        let client = CtxClient::with_data_root(temp.path());
+
+        let status = client.status().unwrap();
+        assert!(!status.initialized);
+        assert!(!status.paths.database_path.exists());
+
+        let missing_doctor = client.doctor().unwrap();
+        assert!(!missing_doctor.ok);
+        assert!(missing_doctor
+            .findings
+            .iter()
+            .any(|finding| finding.contains("database does not exist")));
+        assert!(matches!(
+            client.search("anything", SearchOptions::default()),
+            Err(Error::StoreNotInitialized(_))
+        ));
+
+        let initialized = client.init().unwrap();
+        assert!(initialized.initialized);
+        assert!(initialized.paths.database_path.exists());
+
+        let healthy_doctor = client.doctor().unwrap();
+        assert!(healthy_doctor.ok, "{:?}", healthy_doctor.findings);
+    }
+
+    #[test]
+    fn imports_searches_and_loads_history_in_process() {
+        let temp = tempfile::tempdir().unwrap();
+        let client = CtxClient::builder()
+            .data_root(temp.path())
+            .home_dir(temp.path())
+            .build()
+            .unwrap();
+
+        let report = client
+            .import_path(
+                CaptureProvider::Codex,
+                fixture("codex-sessions"),
+                ImportOptions::default(),
+            )
+            .unwrap();
+        assert_eq!(report.totals.failed_sources, 0);
+        assert!(report.totals.imported_sessions > 0);
+        assert!(report.totals.imported_events > 0);
+
+        let packet = client
+            .search(
+                "onboarding",
+                SearchOptions::default()
+                    .provider(CaptureProvider::Codex)
+                    .events()
+                    .limit(5),
+            )
+            .unwrap();
+        assert_eq!(packet.query, "onboarding");
+        let first = packet.results.first().expect("search should return a hit");
+        let event_id = first.event_id.expect("search result should carry event id");
+        let session_id = first
+            .session_id
+            .expect("search result should carry session id");
+
+        let window = client
+            .show_event(event_id, EventWindowOptions::window(1))
+            .unwrap();
+        assert_eq!(window.event.id, event_id);
+        assert!(!window.events.is_empty());
+
+        let transcript = client
+            .show_session(session_id, ShowSessionOptions::default())
+            .unwrap();
+        assert_eq!(transcript.session.id, session_id);
+        assert_eq!(transcript.mode, TranscriptMode::Lite);
+        assert!(!transcript.events.is_empty());
+
+        let event_location = client.locate_event(event_id).unwrap();
+        assert_eq!(event_location.event.id, event_id);
+        assert_eq!(event_location.session.unwrap().id, session_id);
+
+        let session_location = client.locate_session(session_id).unwrap();
+        assert_eq!(session_location.session.id, session_id);
+        assert!(session_location.source.is_some());
+
+        let full = client
+            .show_session(
+                session_id,
+                ShowSessionOptions {
+                    mode: TranscriptMode::Full,
+                },
+            )
+            .unwrap();
+        assert_eq!(TranscriptMode::Full.as_str(), "full");
+        assert_eq!(TranscriptMode::Lite.as_str(), "lite");
+        assert_eq!(TranscriptMode::Log.as_str(), "log");
+        assert!(full
+            .events
+            .iter()
+            .all(|event| event.event_type == EventType::Message));
+
+        let around = client
+            .show_event(
+                event_id,
+                EventWindowOptions {
+                    before: 1,
+                    after: 1,
+                    window: None,
+                },
+            )
+            .unwrap();
+        assert!(around.events.len() >= 2);
+    }
+
+    #[test]
+    fn rich_codex_llm_fixture_preserves_tool_events_for_log_transcripts() {
+        let temp = tempfile::tempdir().unwrap();
+        let client = CtxClient::with_data_root(temp.path());
+
+        let report = client
+            .import_path(
+                CaptureProvider::Codex,
+                fixture("codex-rich-sessions"),
+                ImportOptions::default().rich_codex(),
+            )
+            .unwrap();
+        assert_eq!(report.totals.failed_sources, 0);
+        assert!(report.totals.imported_events > 0);
+
+        let packet = client
+            .search(
+                "redacted sample app",
+                SearchOptions::default()
+                    .provider(CaptureProvider::Codex)
+                    .events()
+                    .limit(5),
+            )
+            .unwrap();
+        let session_id = packet.results[0]
+            .session_id
+            .expect("real LLM fixture hit should include session id");
+
+        let log = client
+            .show_session(
+                session_id,
+                ShowSessionOptions {
+                    mode: TranscriptMode::Log,
+                },
+            )
+            .unwrap();
+        assert!(log
+            .events
+            .iter()
+            .any(|event| event.event_type == EventType::ToolCall));
+        assert!(log
+            .events
+            .iter()
+            .any(|event| event.event_type == EventType::ToolOutput));
+
+        let lite = client
+            .show_session(session_id, ShowSessionOptions::default())
+            .unwrap();
+        assert!(log.events.len() > lite.events.len());
+    }
+
+    #[test]
+    fn default_source_discovery_imports_available_llm_histories() {
+        let temp = tempfile::tempdir().unwrap();
+        copy_dir_all(
+            &fixture("codex-sessions"),
+            &temp.path().join(".codex/sessions"),
+        );
+        fs::create_dir_all(temp.path().join(".pi")).unwrap();
+        fs::copy(
+            fixture("pi-session.jsonl"),
+            temp.path().join(".pi/sessions.jsonl"),
+        )
+        .unwrap();
+
+        let client = CtxClient::builder()
+            .data_root(temp.path().join("ctx-data"))
+            .home_dir(temp.path())
+            .build()
+            .unwrap();
+        let sources = client.sources();
+        assert!(sources
+            .iter()
+            .any(|source| source.provider == CaptureProvider::Codex
+                && source.status == ProviderSourceStatus::Available));
+        assert!(client
+            .sources_for_provider(CaptureProvider::Pi)
+            .iter()
+            .any(|source| source.status == ProviderSourceStatus::Available));
+
+        let report = client
+            .import_available_sources(None, ImportOptions::default())
+            .unwrap();
+        assert_eq!(report.totals.failed_sources, 0);
+        assert!(report.totals.imported_sources >= 2);
+        assert!(report.totals.source_files > 0);
+
+        let status = client.status().unwrap();
+        assert!(status.indexed_items > 0);
+        assert!(status.indexed_sources >= 2);
+    }
+
+    #[test]
+    fn unsupported_and_empty_imports_report_typed_errors() {
+        let temp = tempfile::tempdir().unwrap();
+        let client = CtxClient::builder()
+            .data_root(temp.path().join("ctx-data"))
+            .home_dir(temp.path())
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            client.import_sources(Vec::new(), ImportOptions::default()),
+            Err(Error::NoImportableSources)
+        ));
+        assert!(matches!(
+            client.import_available_sources(Some(CaptureProvider::Codex), ImportOptions::default()),
+            Err(Error::NoImportableSources)
+        ));
+
+        let unsupported = client.source_for_path(CaptureProvider::Shell, temp.path().join("shell"));
+        let report = client
+            .import_sources(vec![unsupported.clone()], ImportOptions::default())
+            .unwrap();
+        assert_eq!(report.totals.failed_sources, 1);
+        assert!(report.sources[0].error.is_some());
+
+        assert!(matches!(
+            client.import_sources(vec![unsupported], ImportOptions::default().fail_fast()),
+            Err(Error::UnsupportedProviderImport { .. })
+        ));
+
+        let missing_codex = client
+            .import_path(
+                CaptureProvider::Codex,
+                temp.path().join("missing-session.jsonl"),
+                ImportOptions::default(),
+            )
+            .unwrap();
+        assert_eq!(missing_codex.totals.failed_sources, 1);
+        assert_eq!(missing_codex.sources[0].stats, SourceStats::default());
+        assert!(missing_codex.sources[0].error.is_some());
+    }
+
+    #[test]
+    fn search_options_builder_sets_all_filters() {
+        let session = uuid::Uuid::new_v4();
+        let since = Utc::now();
+        let options = SearchOptions::default()
+            .limit(7)
+            .provider(CaptureProvider::Codex)
+            .workspace("/repo/app")
+            .since(since)
+            .file("src/main.rs")
+            .session(session)
+            .term("onboarding")
+            .term("migration");
+
+        assert_eq!(options.packet.limit, 7);
+        assert_eq!(
+            options.packet.filters.provider,
+            Some(CaptureProvider::Codex)
+        );
+        assert_eq!(options.packet.filters.repo.as_deref(), Some("/repo/app"));
+        assert_eq!(options.packet.filters.since, Some(since));
+        assert_eq!(options.packet.filters.file.as_deref(), Some("src/main.rs"));
+        assert_eq!(options.packet.filters.session, Some(session));
+        assert_eq!(options.packet.result_mode, SearchResultMode::Events);
+        assert_eq!(options.terms, ["onboarding", "migration"]);
+    }
+
+    fn copy_dir_all(source: &Path, target: &Path) {
+        fs::create_dir_all(target).unwrap();
+        for entry in fs::read_dir(source).unwrap() {
+            let entry = entry.unwrap();
+            let file_type = entry.file_type().unwrap();
+            let target_path = target.join(entry.file_name());
+            if file_type.is_dir() {
+                copy_dir_all(&entry.path(), &target_path);
+            } else {
+                fs::copy(entry.path(), target_path).unwrap();
+            }
+        }
+    }
+}

--- a/crates/ctx-sdk/src/search.rs
+++ b/crates/ctx-sdk/src/search.rs
@@ -1,0 +1,87 @@
+use chrono::{DateTime, Utc};
+use ctx_history_core::CaptureProvider;
+use ctx_history_search::{PacketOptions, SearchPacket, SearchResultMode};
+use uuid::Uuid;
+
+use crate::{client::CtxClient, error::Result};
+
+/// Search options for the existing local index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchOptions {
+    pub packet: PacketOptions,
+    pub terms: Vec<String>,
+}
+
+impl Default for SearchOptions {
+    fn default() -> Self {
+        Self {
+            packet: PacketOptions::default(),
+            terms: Vec::new(),
+        }
+    }
+}
+
+impl SearchOptions {
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.packet.limit = limit;
+        self
+    }
+
+    pub fn provider(mut self, provider: CaptureProvider) -> Self {
+        self.packet.filters.provider = Some(provider);
+        self
+    }
+
+    pub fn workspace(mut self, workspace: impl Into<String>) -> Self {
+        self.packet.filters.repo = Some(workspace.into());
+        self
+    }
+
+    pub fn since(mut self, since: DateTime<Utc>) -> Self {
+        self.packet.filters.since = Some(since);
+        self
+    }
+
+    pub fn file(mut self, file: impl Into<String>) -> Self {
+        self.packet.filters.file = Some(file.into());
+        self
+    }
+
+    pub fn session(mut self, session: Uuid) -> Self {
+        self.packet.filters.session = Some(session);
+        self.packet.result_mode = SearchResultMode::Events;
+        self
+    }
+
+    pub fn events(mut self) -> Self {
+        self.packet.result_mode = SearchResultMode::Events;
+        self
+    }
+
+    pub fn term(mut self, term: impl Into<String>) -> Self {
+        self.terms.push(term.into());
+        self
+    }
+}
+
+impl CtxClient {
+    /// Search the existing local index using a read-only connection.
+    pub fn search(&self, query: impl AsRef<str>, options: SearchOptions) -> Result<SearchPacket> {
+        let store = self.open_store_read_only()?;
+        let query = query.as_ref();
+        if options.terms.iter().any(|term| !term.trim().is_empty()) {
+            Ok(ctx_history_search::search_packet_terms(
+                &store,
+                query,
+                &options.terms,
+                &options.packet,
+            )?)
+        } else {
+            Ok(ctx_history_search::search_packet(
+                &store,
+                query,
+                &options.packet,
+            )?)
+        }
+    }
+}

--- a/crates/ctx-sdk/src/transcript.rs
+++ b/crates/ctx-sdk/src/transcript.rs
@@ -1,0 +1,198 @@
+use ctx_history_core::{CaptureSource, Event, EventRole, EventType, Session};
+use ctx_history_store::Store;
+use uuid::Uuid;
+
+use crate::{client::CtxClient, error::Result};
+
+/// Transcript compaction mode, matching the CLI modes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TranscriptMode {
+    Full,
+    #[default]
+    Lite,
+    Log,
+}
+
+impl TranscriptMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Lite => "lite",
+            Self::Log => "log",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ShowSessionOptions {
+    pub mode: TranscriptMode,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionTranscript {
+    pub session: Session,
+    pub events: Vec<Event>,
+    pub mode: TranscriptMode,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EventWindowOptions {
+    pub before: usize,
+    pub after: usize,
+    pub window: Option<usize>,
+}
+
+impl EventWindowOptions {
+    pub fn window(window: usize) -> Self {
+        Self {
+            before: 0,
+            after: 0,
+            window: Some(window),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EventWindow {
+    pub event: Event,
+    pub events: Vec<Event>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionLocation {
+    pub session: Session,
+    pub source: Option<CaptureSource>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EventLocation {
+    pub event: Event,
+    pub session: Option<Session>,
+    pub source: Option<CaptureSource>,
+}
+
+impl CtxClient {
+    /// Load one session transcript using a read-only connection.
+    pub fn show_session(
+        &self,
+        session_id: Uuid,
+        options: ShowSessionOptions,
+    ) -> Result<SessionTranscript> {
+        let store = self.open_store_read_only()?;
+        let session = store.get_session(session_id)?;
+        let events = store.events_for_session(session.id)?;
+        Ok(SessionTranscript {
+            session,
+            events: selected_transcript_events(&events, options.mode),
+            mode: options.mode,
+        })
+    }
+
+    /// Load an event and nearby events using a read-only connection.
+    pub fn show_event(&self, event_id: Uuid, options: EventWindowOptions) -> Result<EventWindow> {
+        let store = self.open_store_read_only()?;
+        let event = store.get_event(event_id)?;
+        let events = event_window(
+            &store,
+            &event,
+            options.before,
+            options.after,
+            options.window,
+        )?;
+        Ok(EventWindow { event, events })
+    }
+
+    pub fn locate_session(&self, session_id: Uuid) -> Result<SessionLocation> {
+        let store = self.open_store_read_only()?;
+        let session = store.get_session(session_id)?;
+        let source = session
+            .capture_source_id
+            .and_then(|source_id| store.get_capture_source(source_id).ok());
+        Ok(SessionLocation { session, source })
+    }
+
+    pub fn locate_event(&self, event_id: Uuid) -> Result<EventLocation> {
+        let store = self.open_store_read_only()?;
+        let event = store.get_event(event_id)?;
+        let session = event
+            .session_id
+            .and_then(|session_id| store.get_session(session_id).ok());
+        let source = event
+            .capture_source_id
+            .and_then(|source_id| store.get_capture_source(source_id).ok());
+        Ok(EventLocation {
+            event,
+            session,
+            source,
+        })
+    }
+}
+
+fn event_window(
+    store: &Store,
+    event: &Event,
+    before: usize,
+    after: usize,
+    window: Option<usize>,
+) -> Result<Vec<Event>> {
+    let Some(session_id) = event.session_id else {
+        return Ok(vec![event.clone()]);
+    };
+    let events = store.events_for_session(session_id)?;
+    let Some(index) = events.iter().position(|candidate| candidate.id == event.id) else {
+        return Ok(vec![event.clone()]);
+    };
+    let (before, after) = window
+        .map(|window| (window, window))
+        .unwrap_or((before, after));
+    let start = index.saturating_sub(before);
+    let end = (index + after + 1).min(events.len());
+    Ok(events[start..end].to_vec())
+}
+
+fn selected_transcript_events(events: &[Event], mode: TranscriptMode) -> Vec<Event> {
+    match mode {
+        TranscriptMode::Log => events.to_vec(),
+        TranscriptMode::Full => events
+            .iter()
+            .filter(|event| is_message(event))
+            .cloned()
+            .collect(),
+        TranscriptMode::Lite => lite_transcript_events(events),
+    }
+}
+
+fn lite_transcript_events(events: &[Event]) -> Vec<Event> {
+    let mut selected = Vec::new();
+    let mut pending_assistant: Option<&Event> = None;
+    for event in events {
+        if is_user_message(event) {
+            if let Some(assistant) = pending_assistant.take() {
+                selected.push(assistant.clone());
+            }
+            selected.push(event.clone());
+        } else if is_assistant_message(event) {
+            pending_assistant = Some(event);
+        }
+    }
+    if let Some(assistant) = pending_assistant {
+        selected.push(assistant.clone());
+    }
+    selected
+}
+
+fn is_message(event: &Event) -> bool {
+    event.event_type == EventType::Message
+        && matches!(
+            event.role,
+            Some(EventRole::User | EventRole::Assistant | EventRole::System)
+        )
+}
+
+fn is_user_message(event: &Event) -> bool {
+    event.event_type == EventType::Message && event.role == Some(EventRole::User)
+}
+
+fn is_assistant_message(event: &Event) -> bool {
+    event.event_type == EventType::Message && event.role == Some(EventRole::Assistant)
+}

--- a/crates/ctx-sdk/tests/real_llm.rs
+++ b/crates/ctx-sdk/tests/real_llm.rs
@@ -1,0 +1,679 @@
+use std::{
+    env, fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+use ctx_sdk::{
+    CaptureProvider, CtxClient, EventRole, EventType, ImportOptions, SearchOptions,
+    ShowSessionOptions, TranscriptMode,
+};
+use rusqlite::Connection;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures/provider-history")
+        .join(name)
+}
+
+#[test]
+fn real_llm_history_fixtures_import_and_search_through_sdk() {
+    let temp = tempfile::tempdir().unwrap();
+    let client = CtxClient::builder()
+        .data_root(temp.path())
+        .home_dir(temp.path())
+        .build()
+        .unwrap();
+
+    let codex = client
+        .import_path(
+            CaptureProvider::Codex,
+            fixture("codex-sessions"),
+            ImportOptions::default(),
+        )
+        .unwrap();
+    let pi = client
+        .import_path(
+            CaptureProvider::Pi,
+            fixture("pi-session.jsonl"),
+            ImportOptions::default(),
+        )
+        .unwrap();
+
+    assert_eq!(codex.totals.failed_sources, 0);
+    assert_eq!(pi.totals.failed_sources, 0);
+    assert!(codex.totals.imported_sessions > 0);
+    assert!(pi.totals.imported_sessions > 0);
+
+    let codex_packet = client
+        .search(
+            "onboarding",
+            SearchOptions::default()
+                .provider(CaptureProvider::Codex)
+                .events()
+                .limit(5),
+        )
+        .unwrap();
+    let codex_hit = codex_packet
+        .results
+        .iter()
+        .find(|result| result.provider == Some(CaptureProvider::Codex))
+        .expect("Codex fixture should produce a provider-scoped event hit");
+    assert!(codex_hit.provider_session_id.is_some());
+    assert!(
+        codex_hit.raw_source_path.is_some(),
+        "SDK search should preserve source citations for LLM history"
+    );
+    let codex_session_id = codex_hit
+        .session_id
+        .expect("Codex hit should include session id");
+
+    let codex_event = client
+        .show_event(
+            codex_hit
+                .event_id
+                .expect("event search should include event id"),
+            Default::default(),
+        )
+        .unwrap();
+    assert_eq!(codex_event.event.event_type, EventType::Message);
+    assert!(matches!(
+        codex_event.event.role,
+        Some(EventRole::User | EventRole::Assistant | EventRole::System)
+    ));
+    let codex_location = client.locate_session(codex_session_id).unwrap();
+    assert_eq!(
+        codex_hit.provider_session_id,
+        codex_location.session.external_session_id
+    );
+
+    let pi_packet = client
+        .search(
+            "provider metadata",
+            SearchOptions::default()
+                .provider(CaptureProvider::Pi)
+                .events()
+                .limit(5),
+        )
+        .unwrap();
+    let pi_hit = pi_packet
+        .results
+        .iter()
+        .find(|result| result.provider == Some(CaptureProvider::Pi))
+        .expect("Pi fixture should produce a provider-scoped event hit");
+    assert!(pi_hit.provider_session_id.is_some());
+
+    let pi_transcript = client
+        .show_session(
+            pi_hit.session_id.expect("Pi hit should include session id"),
+            ShowSessionOptions {
+                mode: TranscriptMode::Full,
+            },
+        )
+        .unwrap();
+    assert!(
+        pi_transcript
+            .events
+            .iter()
+            .any(|event| event.role == Some(EventRole::Assistant)),
+        "SDK should expose assistant LLM messages as typed events"
+    );
+    assert_eq!(
+        pi_hit.provider_session_id,
+        pi_transcript.session.external_session_id
+    );
+}
+
+#[test]
+fn native_provider_histories_import_and_search_through_sdk() {
+    let temp = tempfile::tempdir().unwrap();
+    let client = CtxClient::with_data_root(temp.path().join("ctx-data"));
+
+    for case in native_provider_cases(&temp) {
+        let report = client
+            .import_path(case.provider, &case.path, ImportOptions::default())
+            .unwrap_or_else(|error| panic!("{} import failed: {error}", case.name));
+        assert_eq!(
+            report.totals.failed_sources, 0,
+            "{} should import without failed sources: {:?}",
+            case.name, report
+        );
+        assert!(
+            report.totals.imported_sessions >= 1,
+            "{} should import at least one session",
+            case.name
+        );
+        assert!(
+            report.totals.imported_events >= 1,
+            "{} should import at least one event",
+            case.name
+        );
+
+        let packet = client
+            .search(
+                &case.query,
+                SearchOptions::default()
+                    .provider(case.provider)
+                    .events()
+                    .limit(5),
+            )
+            .unwrap();
+        assert!(
+            packet
+                .results
+                .iter()
+                .any(|result| result.provider == Some(case.provider)),
+            "{} should produce a provider-scoped search result for `{}`",
+            case.name,
+            case.query
+        );
+    }
+}
+
+struct NativeProviderCase {
+    name: &'static str,
+    provider: CaptureProvider,
+    path: PathBuf,
+    query: String,
+}
+
+fn native_provider_cases(temp: &tempfile::TempDir) -> Vec<NativeProviderCase> {
+    vec![
+        NativeProviderCase {
+            name: "claude",
+            provider: CaptureProvider::Claude,
+            path: write_native_claude_fixture(temp, "claude-sdk-coverage").into(),
+            query: "claude-sdk-coverage".to_owned(),
+        },
+        NativeProviderCase {
+            name: "opencode",
+            provider: CaptureProvider::OpenCode,
+            path: write_native_opencode_fixture(temp, "opencode-sdk-coverage").into(),
+            query: "opencode-sdk-coverage".to_owned(),
+        },
+        NativeProviderCase {
+            name: "antigravity",
+            provider: CaptureProvider::Antigravity,
+            path: fixture("antigravity/v1/brain/agy-success"),
+            query: "tiny README".to_owned(),
+        },
+        NativeProviderCase {
+            name: "gemini",
+            provider: CaptureProvider::Gemini,
+            path: write_native_gemini_fixture(temp, "gemini-sdk-coverage").into(),
+            query: "gemini-sdk-coverage".to_owned(),
+        },
+        NativeProviderCase {
+            name: "cursor",
+            provider: CaptureProvider::Cursor,
+            path: write_native_cursor_fixture(temp, "cursor-sdk-coverage").into(),
+            query: "cursor-sdk-coverage".to_owned(),
+        },
+        NativeProviderCase {
+            name: "copilot-cli",
+            provider: CaptureProvider::CopilotCli,
+            path: write_native_copilot_fixture(temp, "copilot-sdk-coverage").into(),
+            query: "copilot-sdk-coverage".to_owned(),
+        },
+        NativeProviderCase {
+            name: "factory-ai-droid",
+            provider: CaptureProvider::FactoryAiDroid,
+            path: write_native_factory_droid_fixture(temp, "droid-sdk-coverage").into(),
+            query: "droid-sdk-coverage".to_owned(),
+        },
+    ]
+}
+
+#[test]
+#[ignore = "requires CTX_SDK_LIVE_OPENAI=1, OPENAI_API_KEY, CTX_SDK_LIVE_OPENAI_MODEL, curl, and network access"]
+fn live_openai_response_imports_and_searches_without_cli() {
+    if env::var("CTX_SDK_LIVE_OPENAI").ok().as_deref() != Some("1") {
+        eprintln!("skipping live LLM test; set CTX_SDK_LIVE_OPENAI=1 to opt in");
+        return;
+    }
+
+    let api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY is required");
+    let model =
+        env::var("CTX_SDK_LIVE_OPENAI_MODEL").expect("CTX_SDK_LIVE_OPENAI_MODEL is required");
+    let base_url =
+        env::var("OPENAI_BASE_URL").unwrap_or_else(|_| "https://api.openai.com/v1".to_owned());
+    let nonce = format!("ctx-sdk-live-llm-{}", Uuid::new_v4());
+
+    let assistant_text = live_model_response_text(&base_url, &api_key, &model, &nonce);
+    assert!(
+        assistant_text.contains(&nonce),
+        "live model response should echo nonce `{nonce}`, got: {assistant_text}"
+    );
+
+    let temp = tempfile::tempdir().unwrap();
+    let history = write_live_codex_history(temp.path(), &model, &nonce, &assistant_text).unwrap();
+    let client = CtxClient::with_data_root(temp.path().join("ctx-data"));
+
+    let report = client
+        .import_path(CaptureProvider::Codex, history, ImportOptions::default())
+        .unwrap();
+    assert_eq!(report.totals.failed_sources, 0);
+    assert_eq!(report.totals.imported_sessions, 1);
+
+    let packet = client
+        .search(
+            &nonce,
+            SearchOptions::default()
+                .provider(CaptureProvider::Codex)
+                .events()
+                .limit(5),
+        )
+        .unwrap();
+    let hit = packet
+        .results
+        .first()
+        .expect("live LLM text should be searchable after SDK import");
+    let transcript = client
+        .show_session(
+            hit.session_id
+                .expect("live LLM hit should include session id"),
+            ShowSessionOptions {
+                mode: TranscriptMode::Full,
+            },
+        )
+        .unwrap();
+
+    assert!(
+        transcript
+            .events
+            .iter()
+            .any(|event| event.role == Some(EventRole::Assistant)
+                && event.payload.to_string().contains(&nonce)),
+        "typed transcript should include the live assistant response"
+    );
+}
+
+fn live_model_response_text(base_url: &str, api_key: &str, model: &str, nonce: &str) -> String {
+    match env::var("CTX_SDK_LIVE_OPENAI_API").as_deref() {
+        Ok("chat") | Ok("chat_completions") => {
+            openai_chat_completion_text(base_url, api_key, model, nonce)
+        }
+        _ => openai_response_text(base_url, api_key, model, nonce),
+    }
+}
+
+fn openai_response_text(base_url: &str, api_key: &str, model: &str, nonce: &str) -> String {
+    let request = json!({
+        "model": model,
+        "input": exact_echo_prompt(nonce),
+    });
+    let response = post_json(
+        &format!("{}/responses", base_url.trim_end_matches('/')),
+        api_key,
+        &request,
+        "OpenAI live request",
+    );
+    extract_response_text(&response).expect("OpenAI response should contain text output")
+}
+
+fn openai_chat_completion_text(base_url: &str, api_key: &str, model: &str, nonce: &str) -> String {
+    let request = json!({
+        "model": model,
+        "messages": [{"role": "user", "content": exact_echo_prompt(nonce)}],
+        "temperature": 0,
+        "max_tokens": 512,
+        "stream": false,
+    });
+    let response = post_json(
+        &format!("{}/chat/completions", base_url.trim_end_matches('/')),
+        api_key,
+        &request,
+        "OpenAI-compatible chat request",
+    );
+    extract_response_text(&response).expect("chat completion response should contain text output")
+}
+
+fn post_json(url: &str, api_key: &str, request: &Value, label: &str) -> Value {
+    let mut body = tempfile::NamedTempFile::new().expect("request body tempfile");
+    write!(body, "{request}").expect("write request body");
+
+    let mut child = Command::new("curl")
+        .arg("--config")
+        .arg("-")
+        .arg("--data-binary")
+        .arg(format!("@{}", body.path().display()))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to execute curl for live LLM test");
+
+    {
+        let mut stdin = child.stdin.take().expect("curl stdin");
+        write!(
+            stdin,
+            "silent\nshow-error\nfail-with-body\nmax-time = 60\nrequest = \"POST\"\nurl = \"{}\"\nheader = \"Authorization: Bearer {}\"\nheader = \"Content-Type: application/json\"\n",
+            url, api_key
+        )
+        .expect("write curl config");
+    }
+
+    let output = child.wait_with_output().expect("curl should finish");
+    if !output.status.success() {
+        panic!(
+            "{label} failed with status {:?}: stderr={} body={}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr),
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+
+    serde_json::from_slice(&output.stdout).expect("live LLM response should be JSON")
+}
+
+fn exact_echo_prompt(nonce: &str) -> String {
+    format!("Reply with exactly this text and no extra words: {nonce}")
+}
+
+fn extract_response_text(value: &Value) -> Option<String> {
+    if let Some(text) = value.get("output_text").and_then(Value::as_str) {
+        return Some(text.to_owned());
+    }
+    if let Some(text) = value
+        .get("choices")
+        .and_then(Value::as_array)
+        .and_then(|choices| choices.first())
+        .and_then(|choice| choice.get("message"))
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_str)
+    {
+        return Some(text.to_owned());
+    }
+    if let Some(text) = value
+        .get("choices")
+        .and_then(Value::as_array)
+        .and_then(|choices| choices.first())
+        .and_then(|choice| choice.get("message"))
+        .and_then(|message| message.get("reasoning"))
+        .and_then(Value::as_str)
+    {
+        return Some(text.to_owned());
+    }
+    let mut parts = Vec::new();
+    collect_text_fields(value, &mut parts);
+    let text = parts.join("\n").trim().to_owned();
+    (!text.is_empty()).then_some(text)
+}
+
+fn collect_text_fields(value: &Value, parts: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(text) = map.get("text").and_then(Value::as_str) {
+                parts.push(text.to_owned());
+            }
+            for child in map.values() {
+                collect_text_fields(child, parts);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_text_fields(item, parts);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn write_live_codex_history(
+    root: &Path,
+    model: &str,
+    nonce: &str,
+    assistant_text: &str,
+) -> io::Result<PathBuf> {
+    let path = root.join("codex-live").join("2026").join("07").join("01");
+    fs::create_dir_all(&path)?;
+    let file = path.join("live.jsonl");
+    let session_id = format!("live-openai-{nonce}");
+    let lines = [
+        json!({
+            "timestamp": "2026-07-01T00:00:00.000Z",
+            "type": "session_meta",
+            "payload": {
+                "id": session_id,
+                "timestamp": "2026-07-01T00:00:00.000Z",
+                "cwd": "/tmp/ctx-sdk-live-openai",
+                "originator": "ctx-sdk-live-test",
+                "cli_version": "live-test",
+                "source": "cli",
+                "model_provider": "openai",
+                "model": model,
+            }
+        }),
+        json!({
+            "timestamp": "2026-07-01T00:00:01.000Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": format!("Echo {nonce}")}]
+            }
+        }),
+        json!({
+            "timestamp": "2026-07-01T00:00:02.000Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": assistant_text}]
+            }
+        }),
+    ];
+    let body = lines
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&file, format!("{body}\n"))?;
+    Ok(path)
+}
+
+fn write_native_claude_fixture(temp: &tempfile::TempDir, query: &str) -> PathBuf {
+    let root = temp.path().join("native-claude/projects/-workspace");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join("claude-sdk-native.jsonl"),
+        format!(
+            "{}\n{}\n",
+            json!({
+                "sessionId": "claude-sdk-native",
+                "timestamp": "2026-06-24T12:00:00Z",
+                "cwd": "/workspace",
+                "version": "test",
+                "type": "user",
+                "message": {"role": "user", "content": [{"type": "text", "text": query}]},
+                "uuid": "claude-sdk-native-user"
+            }),
+            json!({
+                "sessionId": "claude-sdk-native",
+                "timestamp": "2026-06-24T12:00:01Z",
+                "cwd": "/workspace",
+                "version": "test",
+                "type": "assistant",
+                "message": {"role": "assistant", "content": [{"type": "text", "text": "native import ok"}]},
+                "uuid": "claude-sdk-native-assistant"
+            })
+        ),
+    )
+    .unwrap();
+    temp.path().join("native-claude/projects")
+}
+
+fn write_native_opencode_fixture(temp: &tempfile::TempDir, query: &str) -> PathBuf {
+    let path = temp.path().join("native-opencode.db");
+    let conn = Connection::open(&path).unwrap();
+    conn.execute_batch(
+        "create table session (
+            id text primary key,
+            project_id text not null,
+            parent_id text,
+            slug text not null,
+            directory text not null,
+            title text not null,
+            version text not null,
+            share_url text,
+            summary_additions integer,
+            summary_deletions integer,
+            summary_files integer,
+            summary_diffs text,
+            revert text,
+            permission text,
+            time_created integer not null,
+            time_updated integer not null,
+            time_compacting integer,
+            time_archived integer,
+            workspace_id text
+        );
+        create table message (
+            id text primary key,
+            session_id text not null,
+            time_created integer not null,
+            time_updated integer not null,
+            data text not null
+        );
+        create table part (
+            id text primary key,
+            message_id text not null,
+            session_id text not null,
+            time_created integer not null,
+            time_updated integer not null,
+            data text not null
+        );",
+    )
+    .unwrap();
+    conn.execute(
+        "insert into session (
+            id, project_id, parent_id, slug, directory, title, version, permission,
+            time_created, time_updated
+        ) values (?1, 'project-1', null, 'native', '/workspace', 'native', '0.8.0',
+            'default', 1782259200000, 1782259200000)",
+        ["opencode-sdk-native"],
+    )
+    .unwrap();
+    conn.execute(
+        "insert into message values (?1, ?2, 1782259200000, 1782259200000, ?3)",
+        [
+            "opencode-sdk-native-user",
+            "opencode-sdk-native",
+            &format!(r#"{{"role":"user","time":{{"created":1782259200000}},"text":"{query}"}}"#),
+        ],
+    )
+    .unwrap();
+    path
+}
+
+fn write_native_gemini_fixture(temp: &tempfile::TempDir, query: &str) -> PathBuf {
+    let chats = temp.path().join("native-gemini/tmp/project/chats");
+    fs::create_dir_all(&chats).unwrap();
+    fs::write(
+        chats.join("session-native.jsonl"),
+        format!(
+            "{}\n{}\n",
+            json!({
+                "sessionId": "gemini-sdk-native",
+                "startTime": "2026-06-24T12:00:00Z",
+                "kind": "main",
+                "directories": ["/workspace"]
+            }),
+            json!({
+                "id": "gemini-sdk-native-user",
+                "timestamp": "2026-06-24T12:00:01Z",
+                "type": "user",
+                "content": query
+            })
+        ),
+    )
+    .unwrap();
+    temp.path().join("native-gemini")
+}
+
+fn write_native_cursor_fixture(temp: &tempfile::TempDir, query: &str) -> PathBuf {
+    let root = temp
+        .path()
+        .join("native-cursor/projects/sanitized-workspace/agent-transcripts/cursor-sdk-native");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join("cursor-sdk-native.jsonl"),
+        format!(
+            "{}\n{}\n",
+            json!({
+                "timestamp": "2026-06-24T12:00:00Z",
+                "role": "user",
+                "message": {"role": "user", "content": [{"type": "text", "text": query}]}
+            }),
+            json!({
+                "timestamp": "2026-06-24T12:00:01Z",
+                "role": "assistant",
+                "message": {"role": "assistant", "content": [{"type": "text", "text": "native import ok"}]}
+            })
+        ),
+    )
+    .unwrap();
+    temp.path().join("native-cursor/projects")
+}
+
+fn write_native_copilot_fixture(temp: &tempfile::TempDir, query: &str) -> PathBuf {
+    let root = temp
+        .path()
+        .join("native-copilot/session-state/copilot-sdk-native");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join("events.jsonl"),
+        format!(
+            "{}\n{}\n",
+            json!({
+                "id": "copilot-sdk-native-start",
+                "timestamp": "2026-06-24T12:00:00Z",
+                "type": "session.start",
+                "data": {
+                    "sessionId": "copilot-sdk-native",
+                    "startTime": "2026-06-24T12:00:00Z",
+                    "selectedModel": "gpt-5-mini",
+                    "context": {"cwd": "/workspace"}
+                }
+            }),
+            json!({
+                "id": "copilot-sdk-native-user",
+                "timestamp": "2026-06-24T12:00:01Z",
+                "type": "user.message",
+                "data": {"content": query}
+            })
+        ),
+    )
+    .unwrap();
+    temp.path().join("native-copilot/session-state")
+}
+
+fn write_native_factory_droid_fixture(temp: &tempfile::TempDir, query: &str) -> PathBuf {
+    let root = temp.path().join("native-droid/sessions/project");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join("droid-sdk-native.jsonl"),
+        format!(
+            "{}\n{}\n",
+            json!({
+                "type": "session_start",
+                "sessionId": "droid-sdk-native",
+                "timestamp": "2026-06-24T12:00:00Z",
+                "cwd": "/workspace",
+                "model": "factory/droid"
+            }),
+            json!({
+                "type": "message",
+                "id": "droid-sdk-native-user",
+                "timestamp": "2026-06-24T12:00:01Z",
+                "role": "user",
+                "content": [{"type": "text", "text": query}]
+            })
+        ),
+    )
+    .unwrap();
+    temp.path().join("native-droid/sessions")
+}

--- a/docs/rust-sdk.md
+++ b/docs/rust-sdk.md
@@ -1,0 +1,80 @@
+# Rust SDK
+
+`ctx-sdk` is an in-process Rust facade for local ctx history. It is intended for
+Rust applications and agent hosts that want typed access to ctx without spawning
+the `ctx` CLI.
+
+The SDK opens the local SQLite store directly and uses the existing
+`ctx-history-*` crates for provider import, search, and transcript lookup. Query
+APIs use read-only SQLite connections. Import and initialization APIs open a
+write connection only when they need to create or update the local store.
+
+```rust
+use ctx_sdk::{CaptureProvider, CtxClient, ImportOptions, SearchOptions};
+
+fn main() -> ctx_sdk::Result<()> {
+    let client = CtxClient::new()?;
+
+    client.import_path(
+        CaptureProvider::Codex,
+        "/home/me/.codex/sessions",
+        ImportOptions::default(),
+    )?;
+
+    let packet = client.search(
+        "failed migration",
+        SearchOptions::default().provider(CaptureProvider::Codex).limit(5),
+    )?;
+
+    for result in packet.results {
+        println!("{} {}", result.rank, result.title);
+    }
+
+    Ok(())
+}
+```
+
+Core entry points:
+
+- `CtxClient::new()` uses `CTX_DATA_ROOT` or the default `~/.ctx` data root.
+- `CtxClient::with_data_root(path)` isolates the SDK to a specific ctx data root.
+- `status()` inspects store state without creating it.
+- `init()` creates the local store if needed.
+- `sources()` and `sources_for_provider()` discover local provider history.
+- `import_path()`, `import_sources()`, and `import_available_sources()` import
+  provider history in process.
+- `search()` returns `ctx_history_search::SearchPacket` directly.
+- `show_session()`, `show_event()`, `locate_session()`, and `locate_event()`
+  return typed session/event structures without CLI rendering.
+
+The SDK crate is currently workspace-local because the lower-level
+`ctx-history-*` crates are still internal workspace crates. It can be used from
+the repository or as a git dependency while the public crate packaging boundary
+is finalized.
+
+## Testing
+
+Run the SDK tests from the workspace root:
+
+```bash
+cargo test -p ctx-sdk
+```
+
+The default SDK suite imports real local-history formats from sanitized Codex
+and Pi fixtures. It does not call provider CLIs, read user history, require API
+keys, or make network calls.
+
+There is also an opt-in live LLM integration test. It calls OpenAI, writes the
+model response into a temporary Codex-style local-history file, then verifies
+that the SDK can import, search, and load the typed transcript without spawning
+the `ctx` CLI. Set `OPENAI_API_KEY` and `CTX_SDK_LIVE_OPENAI_MODEL` in the
+environment before opting in:
+
+```bash
+CTX_SDK_LIVE_OPENAI=1 \
+cargo test -p ctx-sdk --test real_llm -- --ignored --nocapture
+```
+
+For OpenAI-compatible Chat Completions providers, set
+`CTX_SDK_LIVE_OPENAI_API=chat` and `OPENAI_BASE_URL` to the provider's `/v1`
+base URL.


### PR DESCRIPTION
## Summary
- add a workspace-local ctx-sdk crate with an in-process Rust facade over ctx history primitives
- expose typed APIs for status/init, source discovery, provider import, search, session/event lookup, and doctor checks
- add behavior-oriented SDK unit/integration coverage using real local-history formats, plus an opt-in live LLM test
- document SDK usage and add the Rust SDK page to embedded CLI docs

## Notes
- this intentionally opens the SQLite store and calls ctx-history-* crates directly; it does not shell out to the ctx CLI or parse CLI JSON
- the crate is publish=false for now because the lower-level ctx-history-* crates are still internal workspace crates
- the live LLM test is ignored and env-gated so default CI does not depend on network, API keys, provider quotas, or model availability
- live LLM smoke supports OpenAI Responses and OpenAI-compatible Chat Completions providers via CTX_SDK_LIVE_OPENAI_API=chat
- tests avoid fixture-specific IDs and exact internal counters where possible; they assert public SDK contracts such as discovery, import success, searchability, citations, and typed transcript lookup
- private API keys, private base URLs, private model names, and local agent configuration files are not committed; live smoke values are supplied only through environment variables
- the live test passes the authorization header to curl through stdin config, so the API key is not exposed in process arguments

## Coverage
- cargo llvm-cov -p ctx-sdk --summary-only
- line coverage: 92.92%
- region coverage: 91.33%
- function coverage: 96.10%
- production module line coverage: client 93.16%, import 87.16%, search 85.71%, transcript 96.00%

## Tests
- cargo fmt --all --check
- cargo test -p ctx-sdk
- cargo llvm-cov -p ctx-sdk --summary-only
- cargo check -p ctx
- cargo test --workspace
- live OpenAI-compatible Chat Completions smoke was run with private endpoint, model, and credentials exported in the local environment; those values are not included in this PR