### PR TITLE
fix(store): reset stale index metadata when cataloged files change

### DIFF
--- a/crates/ctx-history-store/src/lib.rs
+++ b/crates/ctx-history-store/src/lib.rs
@@ -1502,19 +1502,19 @@ impl Store {
                     WHEN catalog_sessions.file_size_bytes = excluded.file_size_bytes
                      AND catalog_sessions.file_modified_at_ms = excluded.file_modified_at_ms
                     THEN catalog_sessions.indexed_at_ms
-                    ELSE catalog_sessions.indexed_at_ms
+                    ELSE NULL
                 END,
                 indexed_file_size_bytes = CASE
                     WHEN catalog_sessions.file_size_bytes = excluded.file_size_bytes
                      AND catalog_sessions.file_modified_at_ms = excluded.file_modified_at_ms
                     THEN catalog_sessions.indexed_file_size_bytes
-                    ELSE catalog_sessions.indexed_file_size_bytes
+                    ELSE NULL
                 END,
                 indexed_file_modified_at_ms = CASE
                     WHEN catalog_sessions.file_size_bytes = excluded.file_size_bytes
                      AND catalog_sessions.file_modified_at_ms = excluded.file_modified_at_ms
                     THEN catalog_sessions.indexed_file_modified_at_ms
-                    ELSE catalog_sessions.indexed_file_modified_at_ms
+                    ELSE NULL
                 END,
                 indexed_status = CASE
                     WHEN catalog_sessions.file_size_bytes = excluded.file_size_bytes
@@ -1532,7 +1532,7 @@ impl Store {
                     WHEN catalog_sessions.file_size_bytes = excluded.file_size_bytes
                      AND catalog_sessions.file_modified_at_ms = excluded.file_modified_at_ms
                     THEN catalog_sessions.indexed_event_count
-                    ELSE catalog_sessions.indexed_event_count
+                    ELSE NULL
                 END,
                 metadata_json = excluded.metadata_json
             WHERE catalog_sessions.provider IS NOT excluded.provider
@@ -7469,9 +7469,9 @@ mod catalog_tests {
             )
             .unwrap();
         assert_eq!(status, CatalogIndexedStatus::Pending.as_str());
-        assert_eq!(indexed_size, Some(42));
-        assert_eq!(indexed_mtime, Some(cataloged_at_ms));
-        assert_eq!(indexed_event_count, Some(3));
+        assert_eq!(indexed_size, None);
+        assert_eq!(indexed_mtime, None);
+        assert_eq!(indexed_event_count, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When a cataloged transcript changes, `indexed_status` is reset to `pending`, but the remaining `indexed_*` metadata continues to retain its previous values because the corresponding `CASE` expressions return the existing value in both branches.

This updates those fields to reset to `NULL` when the file changes, avoiding stale indexing metadata and bringing the behavior in line with the existing `source_import_files` UPSERT and `invalidate_provider_import_indexes()`.

## Validation

- Updated the existing `catalog_upsert_preserves_index_state_until_file_changes` test
- All tests pass