### PR TITLE
Harden ctx release and archive coverage

### DIFF
--- a/crates/ctx-cli/src/net.rs
+++ b/crates/ctx-cli/src/net.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 
 pub fn post_json(endpoint: &str, body: &[u8]) -> Result<()> {
-    if let Some(path) = file_url_path(endpoint) {
+    if let Some(path) = file_url_path(endpoint)? {
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
@@ -28,7 +28,7 @@ pub fn post_json(endpoint: &str, body: &[u8]) -> Result<()> {
 }
 
 pub fn get_bytes(endpoint: &str) -> Result<Vec<u8>> {
-    if let Some(path) = file_url_path(endpoint) {
+    if let Some(path) = file_url_path(endpoint)? {
         return fs::read(&path).with_context(|| format!("read {}", path.display()));
     }
     require_https_or_localhost(endpoint)?;
@@ -44,8 +44,14 @@ pub fn get_bytes(endpoint: &str) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
-fn file_url_path(url: &str) -> Option<PathBuf> {
-    url.strip_prefix("file://").map(PathBuf::from)
+fn file_url_path(url: &str) -> Result<Option<PathBuf>> {
+    let Some(path) = url.strip_prefix("file://") else {
+        return Ok(None);
+    };
+    if path.is_empty() || !path.starts_with('/') {
+        return Err(anyhow!("file URL must use an absolute local path: {url}"));
+    }
+    Ok(Some(PathBuf::from(path)))
 }
 
 fn require_https_or_localhost(url: &str) -> Result<()> {
@@ -54,9 +60,53 @@ fn require_https_or_localhost(url: &str) -> Result<()> {
     }
     if let Some(rest) = url.strip_prefix("http://") {
         let host = rest.split('/').next().unwrap_or_default();
-        if matches!(host, "localhost" | "127.0.0.1" | "[::1]") {
+        if is_localhost_authority(host) {
             return Ok(());
         }
     }
     Err(anyhow!("refusing non-HTTPS endpoint: {url}"))
+}
+
+fn is_localhost_authority(authority: &str) -> bool {
+    if authority.contains('@') {
+        return false;
+    }
+    let host = if let Some(rest) = authority.strip_prefix("[::1]") {
+        if rest.is_empty() || rest.starts_with(':') {
+            "[::1]"
+        } else {
+            return false;
+        }
+    } else {
+        authority.split(':').next().unwrap_or_default()
+    };
+    matches!(host, "localhost" | "127.0.0.1" | "[::1]")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_urls_must_be_absolute_local_paths() {
+        assert_eq!(
+            file_url_path("file:///tmp/ctx-release-metadata.env")
+                .unwrap()
+                .unwrap(),
+            PathBuf::from("/tmp/ctx-release-metadata.env")
+        );
+        assert!(file_url_path("file://relative/path").is_err());
+        assert!(file_url_path("file://").is_err());
+        assert!(file_url_path("https://example.com").unwrap().is_none());
+    }
+
+    #[test]
+    fn endpoint_validation_allows_https_and_localhost_http_only() {
+        require_https_or_localhost("https://example.com/releases").unwrap();
+        require_https_or_localhost("http://localhost:8080/events").unwrap();
+        require_https_or_localhost("http://127.0.0.1/events").unwrap();
+        require_https_or_localhost("http://[::1]:8080/events").unwrap();
+        assert!(require_https_or_localhost("http://example.com/events").is_err());
+        assert!(require_https_or_localhost("http://example.com@localhost/events").is_err());
+    }
 }

--- a/crates/ctx-cli/src/upgrade.rs
+++ b/crates/ctx-cli/src/upgrade.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     env, fs,
     io::Write,
     path::{Path, PathBuf},
@@ -567,7 +568,8 @@ fn parse_release_metadata(
     expected_channel: &str,
 ) -> Result<ReleaseMetadata> {
     let text = std::str::from_utf8(bytes).context("release metadata is not UTF-8")?;
-    let value = |key: &str| metadata_value(text, key);
+    let metadata = parse_metadata_map(text)?;
+    let value = |key: &str| metadata_value(&metadata, key);
     let schema = value("CTX_RELEASE_SCHEMA_VERSION")
         .ok_or_else(|| anyhow!("metadata missing CTX_RELEASE_SCHEMA_VERSION"))?;
     if schema != "1" {
@@ -596,27 +598,45 @@ fn parse_release_metadata(
         sha256,
         source_commit: value("CTX_RELEASE_SOURCE_COMMIT"),
         published_at: value("CTX_RELEASE_PUBLISHED_AT"),
-        self_upgrade_allowed: metadata_bool(text, "CTX_RELEASE_SELF_UPGRADE_ALLOWED", false),
-        auto_upgrade_allowed: metadata_bool(text, "CTX_RELEASE_AUTO_UPGRADE_ALLOWED", false),
+        self_upgrade_allowed: metadata_bool(&metadata, "CTX_RELEASE_SELF_UPGRADE_ALLOWED", false)?,
+        auto_upgrade_allowed: metadata_bool(&metadata, "CTX_RELEASE_AUTO_UPGRADE_ALLOWED", false)?,
         store_schema_version: value("CTX_RELEASE_STORE_SCHEMA_VERSION"),
     })
 }
 
-fn metadata_value(text: &str, key: &str) -> Option<String> {
-    text.lines().find_map(|line| {
+fn parse_metadata_map(text: &str) -> Result<BTreeMap<String, String>> {
+    let mut metadata = BTreeMap::new();
+    for line in text.lines() {
         let line = line.trim();
         if line.starts_with('#') || line.is_empty() {
-            return None;
+            continue;
         }
-        let (candidate, value) = line.split_once('=')?;
-        (candidate == key).then(|| value.trim_end_matches('\r').to_owned())
-    })
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if metadata
+            .insert(key.to_owned(), value.trim_end_matches('\r').to_owned())
+            .is_some()
+        {
+            return Err(anyhow!("metadata contains duplicate key {key}"));
+        }
+    }
+    Ok(metadata)
 }
 
-fn metadata_bool(text: &str, key: &str, default: bool) -> bool {
-    metadata_value(text, key).map_or(default, |value| {
-        matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes")
-    })
+fn metadata_value(metadata: &BTreeMap<String, String>, key: &str) -> Option<String> {
+    metadata.get(key).cloned()
+}
+
+fn metadata_bool(metadata: &BTreeMap<String, String>, key: &str, default: bool) -> Result<bool> {
+    let Some(value) = metadata_value(metadata, key) else {
+        return Ok(default);
+    };
+    match value.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" => Ok(true),
+        "0" | "false" | "no" => Ok(false),
+        _ => Err(anyhow!("metadata {key} must be a boolean")),
+    }
 }
 
 fn verify_metadata_signature(metadata: &[u8], signature: &[u8]) -> Result<()> {

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -1508,11 +1508,56 @@ fn upgrade_verifies_signed_metadata_and_fails_closed() {
         stderr.contains("download release metadata signature"),
         "{stderr}"
     );
+
+    let default_signature_path = tempdir();
+    let release = fake_release(&default_signature_path, "9.9.9");
+    let check = json_output(
+        ctx(&default_signature_path)
+            .args(["upgrade", "check", "--json"])
+            .env("CTX_UPGRADE_TARGET", &release.target)
+            .env("CTX_RELEASE_METADATA_URL", file_url(&release.metadata))
+            .env(
+                "CTX_RELEASE_METADATA_PUBLIC_KEY_PEM",
+                TEST_RELEASE_PUBLIC_KEY_PEM,
+            ),
+    );
+    assert_eq!(check["status"], "available");
 }
 
 #[cfg(unix)]
 #[test]
 fn upgrade_rejects_unsafe_metadata_and_bad_artifacts() {
+    let duplicate_key = tempdir();
+    let release = fake_release(&duplicate_key, "9.9.9");
+    rewrite_fake_release_metadata(&release, |metadata| {
+        format!("{metadata}CTX_RELEASE_VERSION=8.8.8\n")
+    });
+    let stderr = failure_stderr(fake_release_env(
+        ctx(&duplicate_key).args(["upgrade", "check"]),
+        &release,
+    ));
+    assert!(
+        stderr.contains("metadata contains duplicate key CTX_RELEASE_VERSION"),
+        "{stderr}"
+    );
+
+    let malformed_bool = tempdir();
+    let release = fake_release(&malformed_bool, "9.9.9");
+    rewrite_fake_release_metadata(&release, |metadata| {
+        metadata.replace(
+            "CTX_RELEASE_SELF_UPGRADE_ALLOWED=true\n",
+            "CTX_RELEASE_SELF_UPGRADE_ALLOWED=definitely\n",
+        )
+    });
+    let stderr = failure_stderr(fake_release_env(
+        ctx(&malformed_bool).args(["upgrade", "check"]),
+        &release,
+    ));
+    assert!(
+        stderr.contains("metadata CTX_RELEASE_SELF_UPGRADE_ALLOWED must be a boolean"),
+        "{stderr}"
+    );
+
     let missing_policy = tempdir();
     let release = fake_release(&missing_policy, "9.9.9");
     rewrite_fake_release_metadata(&release, |metadata| {

--- a/crates/ctx-history-search/src/lib.rs
+++ b/crates/ctx-history-search/src/lib.rs
@@ -2275,6 +2275,17 @@ mod tests {
         }
     }
 
+    fn excluded_filter(session_id: Option<Uuid>) -> SearchFilters {
+        SearchFilters {
+            exclude_provider_session: Some(ProviderSessionFilter {
+                provider: CaptureProvider::Codex,
+                provider_session_id: "provider-session-1".into(),
+                session_id,
+            }),
+            ..SearchFilters::default()
+        }
+    }
+
     fn test_store() -> (tempfile::TempDir, ctx_history_store::Store) {
         let temp = tempdir();
         let path = temp.path().join("work.sqlite");
@@ -2316,6 +2327,121 @@ mod tests {
         let preview = event_preview_text(&event);
         assert_eq!(preview, "raw event payload withheld");
         assert!(!preview.contains("secret payload"));
+    }
+
+    #[test]
+    fn excluded_provider_session_matches_provider_external_id_for_hits() {
+        let filters = excluded_filter(None);
+        let hit = HitMetadata {
+            provider: Some(CaptureProvider::Codex),
+            provider_session_id: Some("provider-session-1".into()),
+            ..empty_hit(fixed_time())
+        };
+        assert!(hit_matches_excluded_provider_session(&hit, &filters));
+
+        let event_hit = EventSearchHit {
+            event_id: Uuid::parse_str("018f45d0-0000-7000-8000-000000001001").unwrap(),
+            history_record_id: None,
+            session_id: None,
+            session_parent_session_id: None,
+            session_root_session_id: None,
+            run_id: None,
+            seq: 1,
+            event_type: EventType::Message,
+            role: Some(EventRole::User),
+            occurred_at: fixed_time(),
+            preview: "synthetic preview".into(),
+            score: 1.0,
+            provider: Some(CaptureProvider::Codex),
+            session_external_session_id: Some("provider-session-1".into()),
+            agent_type: Some(AgentType::Primary),
+            session_is_primary: Some(true),
+            cwd: None,
+            raw_source_path: None,
+            cursor: None,
+            record_title: None,
+            record_kind: None,
+            record_workspace: None,
+        };
+        assert!(event_hit_matches_excluded_provider_session(
+            &event_hit, &filters
+        ));
+
+        let mut different_provider = event_hit;
+        different_provider.provider = Some(CaptureProvider::Claude);
+        assert!(!event_hit_matches_excluded_provider_session(
+            &different_provider,
+            &filters
+        ));
+    }
+
+    #[test]
+    fn excluded_provider_session_matches_parent_and_root_session_tree() {
+        let excluded_session_id = Uuid::parse_str("018f45d0-0000-7000-8000-000000001100").unwrap();
+        let child_session_id = Uuid::parse_str("018f45d0-0000-7000-8000-000000001101").unwrap();
+        let grandchild_session_id =
+            Uuid::parse_str("018f45d0-0000-7000-8000-000000001102").unwrap();
+        let filters = excluded_filter(Some(excluded_session_id));
+
+        let parent_hit = HitMetadata {
+            session_id: Some(child_session_id),
+            parent_session_id: Some(excluded_session_id),
+            ..empty_hit(fixed_time())
+        };
+        assert!(hit_matches_excluded_provider_session(&parent_hit, &filters));
+
+        let root_event_hit = EventSearchHit {
+            event_id: Uuid::parse_str("018f45d0-0000-7000-8000-000000001103").unwrap(),
+            history_record_id: None,
+            session_id: Some(grandchild_session_id),
+            session_parent_session_id: Some(child_session_id),
+            session_root_session_id: Some(excluded_session_id),
+            run_id: None,
+            seq: 1,
+            event_type: EventType::Message,
+            role: Some(EventRole::Assistant),
+            occurred_at: fixed_time(),
+            preview: "synthetic preview".into(),
+            score: 1.0,
+            provider: None,
+            session_external_session_id: None,
+            agent_type: Some(AgentType::Subagent),
+            session_is_primary: Some(false),
+            cwd: None,
+            raw_source_path: None,
+            cursor: None,
+            record_title: None,
+            record_kind: None,
+            record_workspace: None,
+        };
+        assert!(event_hit_matches_excluded_provider_session(
+            &root_event_hit,
+            &filters
+        ));
+
+        let context = RecordContext {
+            sessions: vec![Session {
+                id: grandchild_session_id,
+                history_record_id: None,
+                parent_session_id: Some(child_session_id),
+                root_session_id: Some(excluded_session_id),
+                capture_source_id: None,
+                provider: CaptureProvider::Claude,
+                external_session_id: Some("different-provider-session".into()),
+                external_agent_id: None,
+                agent_type: AgentType::Subagent,
+                role_hint: None,
+                is_primary: false,
+                status: SessionStatus::Imported,
+                transcript_blob_id: None,
+                started_at: fixed_time(),
+                ended_at: None,
+                timestamps: timestamps(),
+                sync: sync_metadata(),
+            }],
+            ..RecordContext::default()
+        };
+        assert!(context_has_excluded_provider_session(&context, &filters));
     }
 
     #[test]

--- a/crates/ctx-history-store/src/lib.rs
+++ b/crates/ctx-history-store/src/lib.rs
@@ -5889,6 +5889,160 @@ fn existing_history_record_link_by_identity(
     .map_err(StoreError::from)
 }
 
+#[cfg(test)]
+mod archive_validation_tests {
+    use super::*;
+
+    fn tempdir() -> tempfile::TempDir {
+        let root = std::env::current_dir().unwrap().join("target/test-data");
+        fs::create_dir_all(&root).unwrap();
+        tempfile::Builder::new()
+            .prefix("ctx-history-store-archive-validation-")
+            .tempdir_in(root)
+            .unwrap()
+    }
+
+    fn fixed_time() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-23T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn artifact(id: Uuid, blob_hash: String, byte_size: u64) -> Artifact {
+        Artifact {
+            id,
+            kind: ArtifactKind::Markdown,
+            blob_path: object_relative_path(&blob_hash),
+            blob_hash,
+            byte_size,
+            media_type: Some("text/markdown".into()),
+            preview_text: Some("synthetic public-safe blob".into()),
+            redaction_state: RedactionState::SafePreview,
+            timestamps: EntityTimestamps {
+                created_at: fixed_time(),
+                updated_at: fixed_time(),
+            },
+            source_id: None,
+            sync: SyncMetadata {
+                visibility: Visibility::LocalOnly,
+                fidelity: Fidelity::Imported,
+                sync_state: SyncState::LocalOnly,
+                sync_version: 0,
+                deleted_at: None,
+                metadata: serde_json::json!({}),
+            },
+        }
+    }
+
+    fn write_blob(blob_dir: &Path, blob_hash: &str, content: &[u8]) {
+        let path = blob_dir.join(&blob_hash[..2]).join(blob_hash);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, content).unwrap();
+    }
+
+    fn assert_artifact_error(
+        error: StoreError,
+        matches_expected: impl FnOnce(&StoreError) -> bool,
+    ) {
+        assert!(
+            matches_expected(&error),
+            "unexpected archive artifact validation error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn archive_blob_validation_fails_closed_when_blob_is_missing() {
+        let temp = tempdir();
+        let content = b"missing synthetic blob";
+        let artifact = artifact(new_id(), sha256_hex(content), content.len() as u64);
+
+        let error = validate_archive_artifact_record_blob(temp.path(), &artifact).unwrap_err();
+        assert_artifact_error(
+            error,
+            |error| matches!(error, StoreError::ArchiveArtifactMissingContent { id } if *id == artifact.id),
+        );
+    }
+
+    #[test]
+    fn archive_blob_validation_fails_closed_when_hash_differs() {
+        let temp = tempdir();
+        let stored_content = b"stored bytes";
+        let expected_content = b"expected bytes";
+        let artifact = artifact(
+            new_id(),
+            sha256_hex(expected_content),
+            stored_content.len() as u64,
+        );
+        write_blob(temp.path(), &artifact.blob_hash, stored_content);
+
+        let error = validate_archive_artifact_record_blob(temp.path(), &artifact).unwrap_err();
+        assert_artifact_error(
+            error,
+            |error| matches!(error, StoreError::ArchiveArtifactHashMismatch { id } if *id == artifact.id),
+        );
+    }
+
+    #[test]
+    fn archive_blob_validation_fails_closed_when_byte_size_differs() {
+        let temp = tempdir();
+        let content = b"size checked bytes";
+        let artifact = artifact(new_id(), sha256_hex(content), content.len() as u64 + 1);
+        write_blob(temp.path(), &artifact.blob_hash, content);
+
+        let error = validate_archive_artifact_record_blob(temp.path(), &artifact).unwrap_err();
+        assert_artifact_error(
+            error,
+            |error| matches!(error, StoreError::ArchiveArtifactSizeMismatch { id } if *id == artifact.id),
+        );
+    }
+
+    #[test]
+    fn archive_blob_validation_fails_closed_when_blob_path_mismatches_hash() {
+        let temp = tempdir();
+        let content = b"path checked bytes";
+        let mut artifact = artifact(new_id(), sha256_hex(content), content.len() as u64);
+        artifact.blob_path = "objects/ff/not-the-recorded-hash".into();
+        write_blob(temp.path(), &artifact.blob_hash, content);
+
+        let error = validate_archive_artifact_record_blob(temp.path(), &artifact).unwrap_err();
+        assert_artifact_error(
+            error,
+            |error| matches!(error, StoreError::ArchiveArtifactPathMismatch { id } if *id == artifact.id),
+        );
+    }
+
+    #[test]
+    fn archive_blob_validation_fails_closed_when_blob_is_not_regular_file() {
+        let temp = tempdir();
+        let content = b"directory at blob path";
+        let artifact = artifact(new_id(), sha256_hex(content), content.len() as u64);
+        let path = temp
+            .path()
+            .join(&artifact.blob_hash[..2])
+            .join(&artifact.blob_hash);
+        fs::create_dir_all(&path).unwrap();
+
+        let error = validate_archive_artifact_record_blob(temp.path(), &artifact).unwrap_err();
+        assert_artifact_error(
+            error,
+            |error| matches!(error, StoreError::ArchiveArtifactNonRegularFile { id, .. } if *id == artifact.id),
+        );
+    }
+
+    #[test]
+    fn archive_version_validation_rejects_future_version() {
+        let mut archive = SessionHistoryArchive::default();
+        archive.schema_version = 3;
+        archive.version = 3;
+
+        let error = validate_archive_version(&archive).unwrap_err();
+        assert!(matches!(
+            error,
+            StoreError::UnsupportedArchiveVersion(version) if version == 3
+        ));
+    }
+}
+
 fn expected_archive_blob_path(id: Uuid, blob_hash: &str) -> Result<String> {
     if blob_hash.get(..2).is_none() {
         return Err(StoreError::ArchiveArtifactPathMismatch { id });


### PR DESCRIPTION
Adds focused public ctx coverage for signed release metadata parsing, endpoint validation, provider-session exclusion, and archive/blob fail-closed validation.\n\nValidated with:\n- bazel test --test_env=RUSTUP_TOOLCHAIN=stable //:cargo_fmt_check //:cargo_check //:cargo_test_default //:docs_check