### PR TITLE
fix(cli): improve error for nonexistent import paths

### DIFF
--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -4189,6 +4189,12 @@ fn import_requests(args: &ImportArgs) -> Result<Vec<SourceInfo>> {
             .unwrap_or(ProviderArg::Codex)
             .capture_provider();
         let source = explicit_path_source(provider, path.clone());
+        if !source.exists {
+            return Err(anyhow!(
+                "import path does not exist: {}",
+                source.path.display()
+            ));
+        }
         validate_source_import_supported(&source)?;
         return Ok(vec![source]);
     }

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -4189,7 +4189,11 @@ fn import_requests(args: &ImportArgs) -> Result<Vec<SourceInfo>> {
             .unwrap_or(ProviderArg::Codex)
             .capture_provider();
         let source = explicit_path_source(provider, path.clone());
-        if !source.exists {
+        if !source
+            .path
+            .try_exists()
+            .with_context(|| format!("check import path {}", source.path.display()))?
+        {
             return Err(anyhow!(
                 "import path does not exist: {}",
                 source.path.display()

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -4749,18 +4749,17 @@ fn pi_cli_rejects_directory_import_path() {
 #[test]
 fn import_rejects_nonexistent_path() {
     let temp = tempdir();
+    let path = temp.path().join("missing-codex-history");
+    let path = path.to_str().unwrap();
 
     ctx(&temp)
-        .args([
-            "import",
-            "--provider",
-            "codex",
-            "--path",
-            "/nonexistent-ctx-test-path",
-        ])
+        .args(["import", "--provider", "codex", "--path", path])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("import path does not exist"));
+        .stderr(
+            predicate::str::contains("import path does not exist")
+                .and(predicate::str::contains(path)),
+        );
 }
 
 #[test]

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -4747,6 +4747,23 @@ fn pi_cli_rejects_directory_import_path() {
 }
 
 #[test]
+fn import_rejects_nonexistent_path() {
+    let temp = tempdir();
+
+    ctx(&temp)
+        .args([
+            "import",
+            "--provider",
+            "codex",
+            "--path",
+            "/nonexistent-ctx-test-path",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("import path does not exist"));
+}
+
+#[test]
 fn codex_cli_marks_deleted_raw_source_citations_unavailable() {
     let temp = tempdir();
     let source = PathBuf::from(provider_history_fixture("codex-sessions"));


### PR DESCRIPTION
## Summary

When `ctx import --path` is given a path that doesn't exist, the command currently falls through to the filesystem scan and returns a generic OS error.

This adds an early check for explicit import paths and returns a clearer error message instead. It also adds an integration test to cover this behavior.

### Before

<img width="229" height="70" alt="Screenshot 2026-07-02 at 10 28 58 AM" src="https://github.com/user-attachments/assets/054cc866-0cc2-465a-8729-2e20f212dd0c" />


### After

<img width="499" height="85" alt="Screenshot 2026-07-02 at 12 29 00 PM" src="https://github.com/user-attachments/assets/fa8117ad-ad1b-4370-9efe-8b5aa11906aa" />


## Validation

- Added an integration test for `ctx import --path` with a nonexistent path
- New test passes