### PR TITLE
harden import source UX

### DIFF
--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -4213,13 +4213,16 @@ fn import_requests(args: &ImportArgs) -> Result<Vec<SourceInfo>> {
             .collect());
     }
     let provider = args.provider.expect("checked provider").capture_provider();
-    let sources = discovered_sources()
-        .into_iter()
+    let discovered = discovered_sources_for_provider(provider);
+    let sources = discovered
+        .iter()
         .filter(|source| {
             source.provider == provider
                 && source.exists
+                && source.import_support.is_importable()
                 && source.status == ProviderSourceStatus::Available
         })
+        .cloned()
         .collect::<Vec<_>>();
     if sources.is_empty() {
         let spec = provider_source_spec(provider);
@@ -4234,15 +4237,36 @@ fn import_requests(args: &ImportArgs) -> Result<Vec<SourceInfo>> {
                 provider.as_str()
             ));
         }
-        return Err(anyhow!(
-            "no native {} history found; use `ctx sources` to inspect discovered provider paths",
-            provider.as_str()
-        ));
+        return Err(no_importable_provider_sources_error(provider, &discovered));
     }
     for source in &sources {
         validate_source_import_supported(source)?;
     }
     Ok(sources)
+}
+
+fn no_importable_provider_sources_error(
+    provider: CaptureProvider,
+    sources: &[SourceInfo],
+) -> anyhow::Error {
+    let mut message = format!("no importable {} history found", provider.as_str());
+    if sources.is_empty() {
+        message.push_str("; no default paths are registered for this provider");
+    } else {
+        message.push_str("\nchecked paths:");
+        for source in sources {
+            message.push_str(&format!(
+                "\n  {} ({})",
+                source.path.display(),
+                source.status.as_str()
+            ));
+            if let Some(reason) = source.unsupported_reason {
+                message.push_str(&format!(" - {reason}"));
+            }
+        }
+    }
+    message.push_str("\nuse `ctx sources` to inspect discovery, or pass --path");
+    anyhow!(message)
 }
 
 fn validate_source_import_supported(source: &SourceInfo) -> Result<()> {
@@ -4660,7 +4684,8 @@ fn collect_source_import_files(source: &SourceInfo) -> Result<Vec<SourceImportFi
 }
 
 fn collect_source_import_paths(source: &SourceInfo) -> Result<Vec<PathBuf>> {
-    let metadata = fs::symlink_metadata(&source.path)?;
+    let metadata = fs::symlink_metadata(&source.path)
+        .with_context(|| format!("stat import source {}", source.path.display()))?;
     if metadata.file_type().is_symlink() {
         return Err(anyhow!(
             "symlinked provider transcript roots are rejected: {}",
@@ -4681,10 +4706,15 @@ fn collect_source_import_paths(source: &SourceInfo) -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
     let mut stack = vec![source.path.clone()];
     while let Some(dir) = stack.pop() {
-        for entry in fs::read_dir(&dir)? {
-            let entry = entry?;
+        for entry in fs::read_dir(&dir)
+            .with_context(|| format!("read import source directory {}", dir.display()))?
+        {
+            let entry = entry
+                .with_context(|| format!("read import source entry under {}", dir.display()))?;
             let path = entry.path();
-            let file_type = entry.file_type()?;
+            let file_type = entry
+                .file_type()
+                .with_context(|| format!("stat import source entry {}", path.display()))?;
             if file_type.is_dir() {
                 stack.push(path);
             } else if file_type.is_file() && source_import_file_matches(source, &path) {
@@ -5014,7 +5044,8 @@ fn codex_include_notices() -> bool {
 }
 
 fn source_stats(path: &Path) -> Result<SourceStats> {
-    let metadata = fs::symlink_metadata(path)?;
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("stat import source {}", path.display()))?;
     if metadata.file_type().is_file() {
         return Ok(SourceStats {
             files: 1,
@@ -5028,13 +5059,21 @@ fn source_stats(path: &Path) -> Result<SourceStats> {
     let mut stats = SourceStats::default();
     let mut stack = vec![path.to_path_buf()];
     while let Some(dir) = stack.pop() {
-        for entry in fs::read_dir(&dir)? {
-            let entry = entry?;
-            let file_type = entry.file_type()?;
+        for entry in fs::read_dir(&dir)
+            .with_context(|| format!("read import source directory {}", dir.display()))?
+        {
+            let entry = entry
+                .with_context(|| format!("read import source entry under {}", dir.display()))?;
+            let entry_path = entry.path();
+            let file_type = entry
+                .file_type()
+                .with_context(|| format!("stat import source entry {}", entry_path.display()))?;
             if file_type.is_dir() {
-                stack.push(entry.path());
+                stack.push(entry_path);
             } else if file_type.is_file() {
-                let metadata = entry.metadata()?;
+                let metadata = entry
+                    .metadata()
+                    .with_context(|| format!("stat import source file {}", entry_path.display()))?;
                 stats.files += 1;
                 stats.bytes = stats.bytes.saturating_add(metadata.len());
             }
@@ -5068,6 +5107,13 @@ fn discovered_sources() -> Vec<SourceInfo> {
     home_dir()
         .as_deref()
         .map(discover_provider_sources)
+        .unwrap_or_default()
+}
+
+fn discovered_sources_for_provider(provider: CaptureProvider) -> Vec<SourceInfo> {
+    home_dir()
+        .as_deref()
+        .map(|home| discover_provider_sources_for_provider(home, provider))
         .unwrap_or_default()
 }
 

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -778,6 +778,15 @@ fn import_all_discovers_and_imports_providers_together() {
 }
 
 #[test]
+fn import_all_without_sources_does_not_report_missing_explicit_path() {
+    let temp = tempdir();
+    let stderr = failure_stderr(ctx(&temp).args(["import", "--all", "--json"]));
+
+    assert!(stderr.contains("no importable provider history sources found"));
+    assert!(!stderr.contains("import path does not exist"), "{stderr}");
+}
+
+#[test]
 fn import_all_skips_empty_gemini_source() {
     let temp = tempdir();
     copy_dir_all(
@@ -4585,27 +4594,36 @@ fn personal_agent_sqlite_imports_report_corrupt_databases() {
 #[test]
 fn native_provider_cli_requires_existing_history_or_explicit_path() {
     for (cli_provider, expected_blocker) in [
-        ("claude", "no native claude history found"),
-        ("opencode", "no native opencode history found"),
-        ("antigravity", "no native antigravity history found"),
-        ("gemini", "no native gemini history found"),
-        ("cursor", "no native cursor history found"),
-        ("copilot-cli", "no native copilot_cli history found"),
+        ("claude", "no importable claude history found"),
+        ("opencode", "no importable opencode history found"),
+        ("antigravity", "no importable antigravity history found"),
+        ("gemini", "no importable gemini history found"),
+        ("cursor", "no importable cursor history found"),
+        ("copilot-cli", "no importable copilot_cli history found"),
         (
             "factory-ai-droid",
-            "no native factory_ai_droid history found",
+            "no importable factory_ai_droid history found",
         ),
-        ("openclaw", "no native openclaw history found"),
-        ("hermes", "no native hermes history found"),
-        ("nanoclaw", "no native nanoclaw history found"),
-        ("astrbot", "no native astrbot history found"),
+        ("openclaw", "no importable openclaw history found"),
+        ("hermes", "no importable hermes history found"),
+        ("nanoclaw", "no importable nanoclaw history found"),
+        ("astrbot", "no importable astrbot history found"),
     ] {
         let temp = tempdir();
-        ctx(&temp)
-            .args(["import", "--provider", cli_provider, "--json"])
-            .assert()
-            .failure()
-            .stderr(predicate::str::contains(expected_blocker));
+        let stderr =
+            failure_stderr(ctx(&temp).args(["import", "--provider", cli_provider, "--json"]));
+
+        assert!(stderr.contains(expected_blocker), "{stderr}");
+        assert!(stderr.contains("use `ctx sources`"), "{stderr}");
+        if cli_provider == "nanoclaw" {
+            assert!(
+                stderr.contains("no default paths are registered for this provider"),
+                "{stderr}"
+            );
+        } else {
+            assert!(stderr.contains("checked paths:"), "{stderr}");
+            assert!(stderr.contains(temp.path().to_str().unwrap()), "{stderr}");
+        }
     }
 }
 
@@ -4743,7 +4761,32 @@ fn pi_cli_rejects_directory_import_path() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("no importable pi history files"));
+        .stderr(
+            predicate::str::contains("no importable pi history files")
+                .and(predicate::str::contains(path.to_str().unwrap())),
+        );
+}
+
+#[test]
+fn pi_cli_rejects_wrong_file_import_path() {
+    let temp = tempdir();
+    let path = temp.path().join("pi-session.txt");
+    fs::write(&path, "{}\n").unwrap();
+
+    ctx(&temp)
+        .args([
+            "import",
+            "--provider",
+            "pi",
+            "--path",
+            path.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("no importable pi history files")
+                .and(predicate::str::contains(path.to_str().unwrap())),
+        );
 }
 
 #[test]
@@ -4760,6 +4803,69 @@ fn import_rejects_nonexistent_path() {
             predicate::str::contains("import path does not exist")
                 .and(predicate::str::contains(path)),
         );
+
+    ctx(&temp)
+        .args(["import", "--path", path])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("import path does not exist")
+                .and(predicate::str::contains(path)),
+        );
+}
+
+#[cfg(unix)]
+#[test]
+fn import_rejects_symlinked_provider_root() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir();
+    let target = temp.path().join("pi-sessions");
+    fs::create_dir_all(&target).unwrap();
+    let path = temp.path().join("pi-sessions-link");
+    symlink(&target, &path).unwrap();
+
+    ctx(&temp)
+        .args([
+            "import",
+            "--provider",
+            "pi",
+            "--path",
+            path.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("symlinked provider transcript roots are rejected")
+                .and(predicate::str::contains(path.to_str().unwrap())),
+        );
+}
+
+#[cfg(unix)]
+#[test]
+fn import_reports_unreadable_directory_with_path_context() {
+    if unsafe { libc::geteuid() } == 0 {
+        return;
+    }
+
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir();
+    let path = temp.path().join("unreadable-pi-sessions");
+    fs::create_dir_all(&path).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let stderr = failure_stderr(ctx(&temp).args([
+        "import",
+        "--provider",
+        "pi",
+        "--path",
+        path.to_str().unwrap(),
+    ]));
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+
+    assert!(stderr.contains("read import source directory"), "{stderr}");
+    assert!(stderr.contains(path.to_str().unwrap()), "{stderr}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- report checked provider paths when `ctx import --provider` finds no importable source
- preserve strict explicit `--path` handling while adding path-specific filesystem context
- expand CLI coverage for `--all`, provider discovery, missing paths, wrong files, symlink roots, and unreadable directories

## Validation

- `cargo test -p ctx --test cli`
- `cargo test -p ctx`
