### PR TITLE
[codex] Tighten search intent contract

### DIFF
--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -459,6 +459,51 @@ impl From<&SearchArgs> for SourceIdentityFilterArgs {
     }
 }
 
+pub(crate) struct SearchIntentInput<'a> {
+    query: Option<&'a str>,
+    terms: &'a [String],
+    file: Option<&'a Path>,
+}
+
+pub(crate) fn search_has_intent(input: SearchIntentInput<'_>) -> bool {
+    input.query.is_some_and(has_search_token)
+        || input.terms.iter().any(|term| has_search_token(term))
+        || input
+            .file
+            .and_then(|path| path.to_str())
+            .is_some_and(|file| !file.trim().is_empty())
+}
+
+fn has_search_token(value: &str) -> bool {
+    value.split_whitespace().any(|term| {
+        term.trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_' && ch != '-')
+            .chars()
+            .any(char::is_alphanumeric)
+    })
+}
+
+pub(crate) fn missing_search_intent_error() -> anyhow::Error {
+    anyhow!(
+        "search needs a query, --term, or --file\n\nTry:\n  ctx search \"failed migration\"\n  ctx search --term \"failed migration\" --term rollback\n  ctx search --file crates/foo/src/lib.rs"
+    )
+}
+
+fn search_no_results_target(query: &str, terms: &[String]) -> String {
+    if !query.trim().is_empty() {
+        return shell_quote_arg(query);
+    }
+    let rendered_terms = terms
+        .iter()
+        .filter(|term| !term.trim().is_empty())
+        .map(|term| format!("--term {}", shell_quote_arg(term)))
+        .collect::<Vec<_>>();
+    if rendered_terms.is_empty() {
+        "search".to_owned()
+    } else {
+        rendered_terms.join(" ")
+    }
+}
+
 impl CommandRoot {
     fn name(&self) -> &'static str {
         match self {
@@ -4275,6 +4320,14 @@ fn run_search(
     data_root: PathBuf,
     analytics_properties: &mut AnalyticsProperties,
 ) -> Result<()> {
+    if !search_has_intent(SearchIntentInput {
+        query: args.query.as_deref(),
+        terms: &args.term,
+        file: args.file.as_deref(),
+    }) {
+        return Err(missing_search_intent_error());
+    }
+
     let refresh_started = Instant::now();
     let refresh = refresh_before_search(&args, &data_root)?;
     analytics::insert_duration(
@@ -4395,10 +4448,26 @@ fn run_search(
             }
         }
         if packet.results.is_empty() {
-            println!("no results");
-            if query.trim().is_empty() && !uses_composed_terms {
-                println!("next: ctx search \"what changed recently\" --limit 20");
+            if let Some(file) = args
+                .file
+                .as_deref()
+                .filter(|_| query.trim().is_empty() && !uses_composed_terms)
+            {
+                println!("no indexed events touched {}", file.display());
+                let indexed_items = indexed_history_item_count(&store)?;
+                if indexed_items == 0 {
+                    println!("next: ctx import --all");
+                } else {
+                    println!(
+                        "next: ctx search {}",
+                        shell_quote_arg(&file.display().to_string())
+                    );
+                }
             } else {
+                println!(
+                    "no results for {}",
+                    search_no_results_target(&query, &args.term)
+                );
                 let indexed_items = indexed_history_item_count(&store)?;
                 if indexed_items == 0 {
                     println!("next: ctx import --all");

--- a/crates/ctx-cli/src/mcp.rs
+++ b/crates/ctx-cli/src/mcp.rs
@@ -19,9 +19,9 @@ use uuid::Uuid;
 use super::{
     compact_json, config::CONFIG_FILE, discovered_plugin_sources_json, discovered_sources,
     event_window, event_window_json, indexed_history_item_count, mark_share_safe,
-    raw_sql_result_json, search_filters, session_transcript_json, sources_json, OutputFormat,
-    ProviderArg, RefreshArg, SearchDto, SearchFilterInput, SearchRefreshReport,
-    SourceIdentityFilterArgs, TranscriptMode, MAX_SEARCH_LIMIT,
+    raw_sql_result_json, search_filters, search_has_intent, session_transcript_json, sources_json,
+    OutputFormat, ProviderArg, RefreshArg, SearchDto, SearchFilterInput, SearchIntentInput,
+    SearchRefreshReport, SourceIdentityFilterArgs, TranscriptMode, MAX_SEARCH_LIMIT,
 };
 
 const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
@@ -320,7 +320,6 @@ fn tool_sources(data_root: &Path) -> Result<Value> {
 }
 
 fn tool_search(arguments: &Value, data_root: &Path) -> Result<Value> {
-    let store = open_existing_store(data_root)?;
     let query = optional_string(arguments, "query")?.unwrap_or_default();
     let limit = optional_usize(arguments, "limit")?.unwrap_or(20);
     if !(1..=MAX_SEARCH_LIMIT).contains(&limit) {
@@ -338,6 +337,14 @@ fn tool_search(arguments: &Value, data_root: &Path) -> Result<Value> {
     let include_subagents = optional_bool(arguments, "include_subagents")?.unwrap_or(false);
     let event_type = optional_string(arguments, "event_type")?;
     let file = optional_string(arguments, "file")?.map(PathBuf::from);
+    if !search_has_intent(SearchIntentInput {
+        query: Some(&query),
+        terms: &[],
+        file: file.as_deref(),
+    }) {
+        return Err(anyhow!("search needs a query or file"));
+    }
+    let store = open_existing_store(data_root)?;
     let events = optional_bool(arguments, "events")?.unwrap_or(false) || session.is_some();
     let include_current_session =
         optional_bool(arguments, "include_current_session")?.unwrap_or(false);
@@ -505,9 +512,9 @@ fn tool_definitions() -> Vec<Value> {
         json!({
             "name": "search",
             "title": "Search",
-            "description": "Search the existing local ctx index. This does not refresh or import provider history.",
+            "description": "Search the existing local ctx index by query text or touched-file path. This does not refresh or import provider history.",
             "inputSchema": object_schema(json!({
-                "query": { "type": "string" },
+                "query": { "type": "string", "description": "Non-empty text query. Required unless file is provided." },
                 "limit": { "type": "integer", "minimum": 1, "maximum": MAX_SEARCH_LIMIT, "default": 20 },
                 "provider": { "type": "string", "enum": provider_names() },
                 "history_source": { "type": "string", "description": "Custom history source selector as plugin/source or provider_key/source_id." },
@@ -518,7 +525,7 @@ fn tool_definitions() -> Vec<Value> {
                 "since": { "type": "string", "description": "RFC3339 timestamp or day window such as 30d." },
                 "include_subagents": { "type": "boolean", "default": false, "description": "Include subagent sessions in addition to primary-agent sessions." },
                 "event_type": { "type": "string", "enum": event_type_names() },
-                "file": { "type": "string" },
+                "file": { "type": "string", "description": "Indexed touched-file path. Required unless query is provided." },
                 "session": { "type": "string", "description": "ctx session id." },
                 "events": { "type": "boolean", "default": false },
                 "include_current_session": { "type": "boolean", "default": false, "description": "Include the active Codex session tree when CODEX_THREAD_ID is set." }

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -3718,6 +3718,49 @@ fn mcp_search_and_show_tools_return_structured_json_without_refresh() {
 }
 
 #[test]
+fn mcp_search_requires_query_term_or_file_without_opening_store() {
+    let temp = tempdir();
+    let responses = mcp_roundtrip(
+        &temp,
+        &[
+            json!({
+                "jsonrpc": "2.0",
+                "id": "init",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": { "name": "ctx-test", "version": "0" }
+                }
+            }),
+            json!({
+                "jsonrpc": "2.0",
+                "id": "search",
+                "method": "tools/call",
+                "params": {
+                    "name": "search",
+                    "arguments": {
+                        "provider": "codex",
+                        "limit": 5
+                    }
+                }
+            }),
+        ],
+    );
+
+    let result = &responses[1]["result"];
+    assert_eq!(result["isError"], true);
+    assert!(result["structuredContent"]["error"]
+        .as_str()
+        .unwrap()
+        .contains("search needs a query or file"));
+    assert!(
+        !temp.path().join("work.sqlite").exists(),
+        "invalid MCP search should fail before opening the ctx store"
+    );
+}
+
+#[test]
 fn mcp_sources_and_search_support_history_source_plugins() {
     let temp = tempdir();
     let plugin = write_history_source_plugin(&temp, "hermes", false, None);
@@ -5937,7 +5980,7 @@ fn human_search_reports_no_results() {
         .stdout
         .clone();
     let fresh = String::from_utf8(fresh).unwrap();
-    assert!(fresh.contains("no results"));
+    assert!(fresh.contains("no results for definitely-no-results-here"));
     assert!(fresh.contains("next: ctx import --all"));
 
     let fixture = provider_history_fixture("codex-sessions");
@@ -5961,8 +6004,81 @@ fn human_search_reports_no_results() {
         .stdout
         .clone();
     let indexed = String::from_utf8(indexed).unwrap();
-    assert!(indexed.contains("no results"));
+    assert!(indexed.contains("no results for definitely-no-results-here"));
     assert!(indexed.contains("next: try broader terms with ctx search --term"));
+
+    let term_only = ctx(&temp)
+        .args(["search", "--term", "term-only-no-results"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let term_only = String::from_utf8(term_only).unwrap();
+    assert!(term_only.contains("no results for --term term-only-no-results"));
+}
+
+#[test]
+fn search_requires_query_term_or_file_before_refreshing() {
+    let temp = tempdir();
+    let stderr = failure_stderr(ctx(&temp).args(["search", "--provider", "codex"]));
+    assert!(
+        stderr.contains("search needs a query, --term, or --file"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("ctx search \"failed migration\""),
+        "{stderr}"
+    );
+    assert!(
+        !temp.path().join("work.sqlite").exists(),
+        "invalid search should fail before creating the ctx store"
+    );
+
+    let punctuation = failure_stderr(ctx(&temp).args(["search", "!!!"]));
+    assert!(
+        punctuation.contains("search needs a query, --term, or --file"),
+        "{punctuation}"
+    );
+    let hyphen_only = failure_stderr(ctx(&temp).args(["search", "--", "---"]));
+    assert!(
+        hyphen_only.contains("search needs a query, --term, or --file"),
+        "{hyphen_only}"
+    );
+    let underscore_term = failure_stderr(ctx(&temp).args(["search", "--term", "___"]));
+    assert!(
+        underscore_term.contains("search needs a query, --term, or --file"),
+        "{underscore_term}"
+    );
+}
+
+#[test]
+fn file_only_search_returns_touched_file_matches() {
+    let temp = tempdir();
+    let fixture = provider_history_fixture("codex-rich-sessions");
+    json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "codex",
+        "--path",
+        &fixture,
+        "--json",
+    ]));
+
+    let search = json_output(ctx(&temp).args(["search", "--file", "src/main.rs", "--json"]));
+    assert_eq!(search["query"], "");
+    let results = search["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    assert!(results[0]["why_matched"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|reason| reason == "file_touched"));
+    assert!(results[0]["citations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|citation| citation["item_type"] == "file" && citation["label"] == "file touched"));
 }
 
 #[test]

--- a/crates/ctx-history-search/src/lib.rs
+++ b/crates/ctx-history-search/src/lib.rs
@@ -1055,6 +1055,13 @@ fn ranked_candidates(
     let mut candidates = Vec::new();
     let mut seen = BTreeSet::<Uuid>::new();
     let mut scan_budget_exhausted = false;
+    let file_only = terms.is_empty() && file_scope.is_some();
+    if terms.is_empty() && !file_only {
+        return Ok(CandidateSearch {
+            candidates,
+            scan_budget_exhausted,
+        });
+    }
 
     if filtered {
         let page_size = FILTERED_SEARCH_PAGE_SIZE.max(target_candidates);
@@ -1062,11 +1069,15 @@ fn ranked_candidates(
         let mut pages_scanned = 0_usize;
         loop {
             pages_scanned = pages_scanned.saturating_add(1);
-            let records = match query {
-                Some(query) if !query.trim().is_empty() => {
-                    store.search_records_page(query, page_size, offset)?
+            let records = if file_only {
+                store.list_records_page(page_size, offset)?
+            } else {
+                match query {
+                    Some(query) if !query.trim().is_empty() => {
+                        store.search_records_page(query, page_size, offset)?
+                    }
+                    _ => Vec::new(),
                 }
-                _ => store.list_records_page(page_size, offset)?,
             };
             let page_len = records.len();
 
@@ -1103,9 +1114,15 @@ fn ranked_candidates(
         }
     } else {
         let fetch_limit = target_candidates;
-        let records = match query {
-            Some(query) if !query.trim().is_empty() => store.search_records(query, fetch_limit)?,
-            _ => store.list_records(fetch_limit)?,
+        let records = if file_only {
+            store.list_records(fetch_limit)?
+        } else {
+            match query {
+                Some(query) if !query.trim().is_empty() => {
+                    store.search_records(query, fetch_limit)?
+                }
+                _ => Vec::new(),
+            }
         };
         for record in records {
             if !seen.insert(record.id) {
@@ -1256,6 +1273,37 @@ fn analyze_record(
     let mut citations = Vec::new();
 
     if terms.is_empty() {
+        if filters
+            .file
+            .as_ref()
+            .is_some_and(|file| !file.trim().is_empty())
+        {
+            let mut primary_hit = None;
+            for section in search_sections(record, context, filters)
+                .into_iter()
+                .filter(|section| section.reason == "file_touched")
+            {
+                if primary_hit.is_none() {
+                    primary_hit = Some(section.hit.clone());
+                }
+                score += section.weight;
+                add_match(
+                    &mut why,
+                    &mut citations,
+                    section.reason,
+                    section.citation,
+                    &section.hit,
+                );
+            }
+            if !why.is_empty() {
+                return MatchAnalysis {
+                    score,
+                    why_matched: why,
+                    citations,
+                    primary_hit,
+                };
+            }
+        }
         add_match(
             &mut why,
             &mut citations,
@@ -2209,7 +2257,7 @@ fn query_terms(query: &str) -> Vec<String> {
         .split(|ch: char| !ch.is_alphanumeric() && ch != '_' && ch != '-')
         .filter_map(|term| {
             let term = term.trim().to_lowercase();
-            if term.is_empty() {
+            if term.is_empty() || !term.chars().any(char::is_alphanumeric) {
                 None
             } else {
                 Some(term)
@@ -3521,6 +3569,33 @@ mod tests {
                 && citation.cursor.as_deref() == Some("line:8")
         }));
 
+        let file_only = search_packet(
+            &store,
+            "",
+            &PacketOptions {
+                limit: 10,
+                filters: SearchFilters {
+                    provider: Some(CaptureProvider::Codex),
+                    file: Some("source_filter.rs".into()),
+                    ..SearchFilters::default()
+                },
+                ..PacketOptions::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(file_only.results.len(), 1);
+        assert!(file_only.results[0]
+            .why_matched
+            .iter()
+            .any(|reason| reason == "file_touched"));
+        assert!(!file_only.results[0]
+            .why_matched
+            .iter()
+            .any(|reason| reason == "recent_activity"));
+        assert!(file_only.results[0].citations.iter().any(|citation| {
+            citation.citation_type == ContextCitationType::File && citation.id == file.id
+        }));
+
         let wrong_provider = search_packet(
             &store,
             "source-filter-needle",
@@ -4164,7 +4239,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_query_filtered_search_stops_at_scan_budget() {
+    fn empty_query_filtered_search_returns_empty_without_scanning() {
         let (_temp, store) = test_store();
         let mut records = Vec::new();
         for index in 0..=(FILTERED_SEARCH_PAGE_SIZE * FILTERED_SEARCH_MAX_PAGES) {
@@ -4197,8 +4272,29 @@ mod tests {
         .unwrap();
 
         assert!(packet.results.is_empty());
-        assert!(packet.truncation.truncated);
-        assert_eq!(packet.truncation.reason.as_deref(), Some("scan_budget"));
+        assert!(!packet.truncation.truncated);
+        assert_eq!(packet.truncation.reason.as_deref(), None);
+    }
+
+    #[test]
+    fn no_token_query_returns_empty_without_recent_activity() {
+        let (_temp, store) = test_store();
+        let record = HistoryRecord::new(
+            "No-token query decoy",
+            "This record should not be returned for punctuation-only search.",
+            Vec::new(),
+            "task",
+            Some("/workspace/punctuation".into()),
+        );
+        store.upsert_record(&record).unwrap();
+
+        for query in ["!!!", "---", "___"] {
+            let packet =
+                search_packet(&store, query, &PacketOptions::default()).expect("search packet");
+
+            assert!(packet.results.is_empty(), "{query}");
+            assert!(!packet.truncation.truncated, "{query}");
+        }
     }
 
     #[test]

--- a/crates/ctx-history-store/src/lib.rs
+++ b/crates/ctx-history-store/src/lib.rs
@@ -3534,6 +3534,9 @@ impl Store {
         limit: usize,
         offset: usize,
     ) -> Result<Vec<HistoryRecord>> {
+        if fts_match_query(query).is_none() {
+            return Ok(Vec::new());
+        }
         if let Some(records) = self.search_records_fts(query, limit, offset)? {
             return Ok(records);
         }
@@ -3558,7 +3561,7 @@ impl Store {
             return Ok(None);
         }
         let Some(match_query) = fts_match_query(query) else {
-            return Ok(Some(self.list_records_page(limit, offset)?));
+            return Ok(Some(Vec::new()));
         };
         let has_event_search = table_exists(&self.conn, "event_search")?;
         let has_artifact_search = table_exists(&self.conn, "artifact_search")?;
@@ -5396,7 +5399,7 @@ fn fts_match_query(query: &str) -> Option<String> {
     let terms = query
         .split_whitespace()
         .map(|term| term.trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_' && ch != '-'))
-        .filter(|term| !term.is_empty())
+        .filter(|term| term.chars().any(char::is_alphanumeric))
         .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
         .collect::<Vec<_>>();
     if terms.is_empty() {
@@ -7638,6 +7641,20 @@ mod search_order_tests {
         drop(store);
         let reopened = Store::open(&path).unwrap();
         assert_search_order(&reopened, &expected);
+    }
+
+    #[test]
+    fn search_records_empty_or_no_token_query_returns_empty() {
+        let temp = tempdir();
+        let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+        let record = stable_tie_record(1);
+        store.insert_record(&record).unwrap();
+
+        assert!(store.search_records("", 10).unwrap().is_empty());
+        assert!(store.search_records("!!!", 10).unwrap().is_empty());
+        assert!(store.search_records("---", 10).unwrap().is_empty());
+        assert!(store.search_records("___", 10).unwrap().is_empty());
+        assert!(store.search_records_page("", 10, 0).unwrap().is_empty());
     }
 
     #[test]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -213,8 +213,9 @@ querying. Use `--refresh off` to search the existing index without refreshing, o
 `--refresh strict` to fail when the pre-search refresh cannot run or import
 successfully. Preview native sources such as NanoClaw and AstrBot are searched
 from the existing index until they are explicitly imported through a supported
-path. The query argument is optional so file or metadata filters can drive a
-search. Default results are session-diverse: ctx
+path. Search requires a non-empty query, at least one non-empty `--term`, or
+`--file <path>`; provider, workspace, time, session, event, source, and result
+flags only narrow an actual search. Default results are session-diverse: ctx
 returns the strongest matching span from each session, plus
 `more_matches_in_session` and `session_importance` when more indexed events from
 that session also matched. Use `--session <ctx-session-id>` after a default
@@ -433,7 +434,7 @@ ctx show session <ctx-session-id> --format json
 ctx show event <ctx-event-id> --format json
 ctx locate session <ctx-session-id> --format json
 ctx locate event <ctx-event-id> --format json
-ctx search [query] --json
+ctx search <query>|--term <term>|--file <path> --json
 ctx sql "SELECT COUNT(*) FROM ctx_sessions" --json
 ctx docs list --json
 ctx docs search <query> --json

--- a/docs/contracts/json.md
+++ b/docs/contracts/json.md
@@ -199,7 +199,7 @@ artifact. JSON and JSONL artifact rows use the same ctx-owned ID fields as
 ## Search
 
 ```bash
-ctx search [query] --json
+ctx search <query>|--term <term>|--file <path> --json
 ```
 
 Returns:

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -33,7 +33,8 @@ shipped.
 - Large outputs may be represented as bounded previews.
 - Ranking is deterministic for the same local database and options, but it is
   not a claim of semantic understanding.
-- Empty or very broad queries can return metadata-driven matches.
+- Empty or punctuation-only search is invalid. Broad valid queries can still
+  return metadata-driven matches.
 
 ## Retrieval Semantics
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -90,6 +90,11 @@ for a file, or combine it with query terms to find sessions that both mention a
 topic and touched that path. It searches paths recorded during import; it does
 not inspect the current filesystem.
 
+Search requires a non-empty query, at least one non-empty `--term`, or
+`--file <path>`. Provider, workspace, time, session, event, source, and result
+flags only narrow an actual search; by themselves they do not browse recent
+history.
+
 The default searches primary-agent sessions so human intent and decisions stay
 prominent. Use `--include-subagents` when you want implementation details, code
 review notes, test output, or failure analysis from subagent sessions too.

--- a/sdks/dotnet/README.md
+++ b/sdks/dotnet/README.md
@@ -55,7 +55,7 @@ Console.WriteLine(results.ToJsonObject().ToJsonString());
 - `SourcesAsync()`
 - `ImportHistoryAsync(ImportOptions?)`
 - `SyncAsync(ImportOptions?)`
-- `SearchAsync(SearchOptions?)`
+- `SearchAsync(SearchOptions)` with a query, term, or file option
 - `ShowEventAsync(string, ShowEventOptions?)`
 - `ShowSessionAsync(string, ShowSessionOptions?)`
 - `ShowSessionAsync(ShowSessionOptions)`

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -39,7 +39,7 @@ The public methods mirror the agent-history-v1 client surface:
 - `init()` for `ctx setup --json`
 - `sources()`
 - `import_()` and `sync()` (`import` is a reserved Python keyword)
-- `search()`
+- `search()` with a query, term, or file option
 - `show_event()` / `showEvent()`
 - `show_session()` / `showSession()`
 - `locate_event()` / `locateEvent()`

--- a/sdks/swift/README.md
+++ b/sdks/swift/README.md
@@ -45,7 +45,7 @@ The public client mirrors the `agent-history-v1` operations:
 - `sources()`
 - `importHistory()`
 - `sync()`
-- `search()`
+- `search()` with a query, term, or file option
 - `showEvent()`
 - `showSession()`
 - `locateEvent()`

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -21,7 +21,8 @@ const results = await client.search("sqlite storage", { refresh: "off" });
 - `sources()` wraps `ctx sources --json`.
 - `import(options)` wraps `ctx import --json`.
 - `sync(options)` is an alias for `import(options)`.
-- `search(query, options)` and `search(options)` wrap `ctx search --json`.
+- `search(query, options)` and file/term-based `search(options)` wrap
+  `ctx search --json`.
 - `showEvent(id, { before, after, window })` wraps `ctx show event --format json`.
 - `showSession(id, { mode })` wraps `ctx show session --format json`.
 - `showSession({ provider, providerSession, mode })` looks up by provider-owned session ID.


### PR DESCRIPTION
## Summary

- reject `ctx search` calls that do not provide a real query, `--term`, or `--file` before refresh/store access
- remove empty/no-token text-search fallback to recent/listed records in search/store layers
- preserve explicit file-only search with touched-file evidence, and align CLI/MCP/docs/SDK README wording

## Validation

- `cargo fmt --all --check`
- `cargo check -p ctx --tests`
- `cargo test -p ctx-history-search no_token_query_returns_empty_without_recent_activity`
- `cargo test -p ctx-history-search search_filters_and_citations_expose_source_metadata`
- `cargo test -p ctx-history-store search_records_empty_or_no_token_query_returns_empty`
- `cargo test -p ctx --test cli search_requires_query_term_or_file_before_refreshing`
- `cargo test -p ctx --test cli mcp_search_requires_query_term_or_file_without_opening_store`
- `cargo test -p ctx --test cli file_only_search_returns_touched_file_matches`
- `cargo test -p ctx --test cli human_search_reports_no_results`
- `cargo test -p ctx --test cli fresh_home_search_mvp_flow`
