### PR TITLE
[codex] Harden read-only search and doctor paths

### DIFF
--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -4025,27 +4025,28 @@ fn prune_null_json(value: &mut Value) {
     }
 }
 
-fn run_sql(args: SqlArgs, data_root: PathBuf) -> Result<()> {
-    let sql = read_sql_input(&args)?;
-    let db_path = database_path(data_root);
+fn open_existing_store_read_only(db_path: &Path, command: &str) -> Result<Store> {
     if !db_path.exists() {
         return Err(anyhow!(
             "ctx store is not initialized at {}; run `ctx setup` or `ctx import` first",
             db_path.display()
         ));
     }
-    let store = match Store::open_read_only(&db_path) {
-        Ok(store) => store,
-        Err(StoreError::UnsupportedSchemaVersion(version)) => {
-            return Err(anyhow!(
-                "ctx store schema version {version} is not supported by this ctx binary; run `ctx status` once to migrate before using `ctx sql`"
-            ));
-        }
+    match Store::open_read_only(db_path) {
+        Ok(store) => Ok(store),
+        Err(StoreError::UnsupportedSchemaVersion(version)) => Err(anyhow!(
+            "ctx store schema version {version} is not supported by this ctx binary; run `ctx status` once to migrate before using `{command}`"
+        )),
         Err(err) => {
-            return Err(err)
-                .with_context(|| format!("open read-only ctx store {}", db_path.display()));
+            Err(err).with_context(|| format!("open read-only ctx store {}", db_path.display()))
         }
-    };
+    }
+}
+
+fn run_sql(args: SqlArgs, data_root: PathBuf) -> Result<()> {
+    let sql = read_sql_input(&args)?;
+    let db_path = database_path(data_root);
+    let store = open_existing_store_read_only(&db_path, "ctx sql")?;
     let result = store.raw_sql_query(
         &sql,
         RawSqlOptions {
@@ -4328,6 +4329,8 @@ fn run_search(
         return Err(missing_search_intent_error());
     }
 
+    let db_path = database_path(data_root.clone());
+    let had_existing_store = db_path.exists();
     let refresh_started = Instant::now();
     let refresh = refresh_before_search(&args, &data_root)?;
     analytics::insert_duration(
@@ -4350,9 +4353,22 @@ fn run_search(
         "search_refresh_source_count_bucket",
         refresh.source_count as u64,
     );
-    let db_path = database_path(data_root);
     insert_db_size_bucket(analytics_properties, &db_path);
-    let store = Store::open(&db_path)?;
+    if refresh.status == "failed" && args.refresh == RefreshArg::Auto && !had_existing_store {
+        return Err(anyhow!(
+            "search refresh failed and no existing ctx index is available; run `ctx import` first or retry with `--refresh strict`: {}",
+            refresh.error.as_deref().unwrap_or("unknown refresh error")
+        ));
+    }
+    let store = if args.refresh == RefreshArg::Off
+        || refresh.status == "failed"
+        || refresh.status == "completed"
+        || had_existing_store
+    {
+        open_existing_store_read_only(&db_path, "ctx search")?
+    } else {
+        Store::open(&db_path)?
+    };
     insert_store_analytics_counts(analytics_properties, &store)?;
     let source_identity = SourceIdentityFilterArgs::from(&args);
     let query = args.query.unwrap_or_default();
@@ -4835,14 +4851,23 @@ fn run_doctor(
 ) -> Result<()> {
     let progress = ProgressReporter::new(args.progress, args.json, "doctor", 0);
     progress.message("opening", "opening ctx store");
-    let store = Store::open(database_path(data_root.clone()))?;
-    progress.message(
-        "checking",
-        "running sqlite integrity and foreign key checks",
-    );
-    let mut findings = store.validate()?;
+    let db_path = database_path(data_root.clone());
+    let mut findings = Vec::new();
     if !data_root.exists() {
         findings.push(format!("data root does not exist: {}", data_root.display()));
+    }
+    if !db_path.exists() {
+        findings.push(format!(
+            "ctx store is not initialized at {}; run `ctx setup` or `ctx import` first",
+            db_path.display()
+        ));
+    } else {
+        let store = open_existing_store_read_only(&db_path, "ctx doctor")?;
+        progress.message(
+            "checking",
+            "running sqlite integrity and foreign key checks",
+        );
+        findings.extend(store.validate()?);
     }
     analytics::insert_count_bucket(
         analytics_properties,

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -3464,6 +3464,30 @@ fn fresh_home_search_mvp_flow() {
 }
 
 #[test]
+fn doctor_reports_missing_store_without_creating_it() {
+    let temp = tempdir();
+
+    let doctor = json_output(ctx(&temp).args(["doctor", "--json"]));
+
+    assert_eq!(doctor["schema_version"], 1);
+    assert_eq!(doctor["ok"], false);
+    assert!(doctor["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|finding| {
+            finding
+                .as_str()
+                .unwrap()
+                .contains("ctx store is not initialized")
+        }));
+    assert!(
+        !temp.path().join("work.sqlite").exists(),
+        "doctor should not create the ctx store"
+    );
+}
+
+#[test]
 fn mcp_status_and_tools_list_are_read_only_without_initialized_store() {
     let temp = tempdir();
     let responses = mcp_roundtrip(
@@ -4077,13 +4101,22 @@ fn search_refreshes_discovered_codex_sessions_before_query() {
 #[test]
 fn search_refresh_off_serves_existing_index_without_importing() {
     let temp = tempdir();
-    let fixture = PathBuf::from(provider_history_fixture("codex-sessions"));
+    let indexed_fixture = provider_history_fixture("codex-sessions");
+    json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "codex",
+        "--path",
+        &indexed_fixture,
+        "--json",
+    ]));
+    let discovered_fixture = provider_history_fixture("codex-rich-sessions");
     let discovered = temp.path().join(".codex").join("sessions");
-    copy_dir_all(&fixture, &discovered);
+    copy_dir_all(&PathBuf::from(discovered_fixture), &discovered);
 
     let stale = json_output(ctx(&temp).args([
         "search",
-        "onboarding",
+        "redacted sample app",
         "--provider",
         "codex",
         "--refresh",
@@ -4095,8 +4128,8 @@ fn search_refresh_off_serves_existing_index_without_importing() {
     assert!(stale["results"].as_array().unwrap().is_empty());
 
     let status = json_output(ctx(&temp).args(["status", "--json"]));
-    assert_eq!(status["cataloged_sessions"], 0);
-    assert_eq!(status["indexed_catalog_sessions"], 0);
+    assert_eq!(status["cataloged_sessions"], 2);
+    assert_eq!(status["indexed_catalog_sessions"], 2);
 
     let fresh =
         json_output(ctx(&temp).args(["search", "onboarding", "--provider", "codex", "--json"]));
@@ -4263,6 +4296,7 @@ fn search_refresh_provider_filter_does_not_execute_history_source_plugins() {
 #[test]
 fn search_refresh_off_does_not_execute_history_source_plugins() {
     let temp = tempdir();
+    json_output(ctx(&temp).args(["setup", "--json"]));
     let plugin =
         write_history_source_plugin_with_refresh(&temp, "hermes", true, Some("auto"), None);
 
@@ -4364,6 +4398,78 @@ sys.exit(23)
 }
 
 #[test]
+fn search_refresh_auto_failure_without_prior_store_fails_instead_of_serving_empty_index() {
+    let temp = tempdir();
+    let script = r#"#!/usr/bin/env python3
+import sys
+print("plugin exploded", file=sys.stderr)
+sys.exit(23)
+"#;
+    let plugin = write_raw_history_source_plugin_with_options(
+        &temp,
+        "badplugin",
+        script,
+        true,
+        Some("auto"),
+    );
+
+    let stderr = failure_stderr(
+        ctx(&temp)
+            .env("CTX_HISTORY_PLUGIN_PATH", &plugin.manifest_dir)
+            .args(["search", "anything", "--provider", "custom", "--json"]),
+    );
+
+    assert!(
+        stderr.contains("search refresh failed and no existing ctx index is available"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("history source plugin badplugin/default failed"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("plugin exploded"), "{stderr}");
+}
+
+#[test]
+fn search_refresh_auto_failure_serves_prior_index() {
+    let temp = tempdir();
+    let fixture = provider_history_fixture("codex-sessions");
+    let script = r#"#!/usr/bin/env python3
+import sys
+print("plugin exploded", file=sys.stderr)
+sys.exit(23)
+"#;
+    let plugin = write_raw_history_source_plugin_with_options(
+        &temp,
+        "badplugin",
+        script,
+        true,
+        Some("auto"),
+    );
+    json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "codex",
+        "--path",
+        &fixture,
+        "--json",
+    ]));
+
+    let search = json_output(
+        ctx(&temp)
+            .env("CTX_HISTORY_PLUGIN_PATH", &plugin.manifest_dir)
+            .args(["search", "onboarding", "--json"]),
+    );
+
+    assert_eq!(search["freshness"]["status"], "failed");
+    assert!(search["freshness"]["error"]
+        .as_str()
+        .unwrap()
+        .contains("history source plugin badplugin/default failed"));
+    assert!(!search["results"].as_array().unwrap().is_empty());
+}
+
+#[test]
 fn search_refresh_strict_times_out_when_plugin_helper_keeps_stdout_open() {
     let temp = tempdir();
     let script = r#"#!/usr/bin/env python3
@@ -4423,9 +4529,9 @@ subprocess.Popen(["sh", "-c", "sleep 5"])
 fn search_refresh_auto_imports_fresh_work_despite_large_existing_catalog() {
     let temp = tempdir();
     let fixture = PathBuf::from(provider_history_fixture("codex-sessions"));
+    let _ = json_output(ctx(&temp).args(["setup", "--json"]));
     let discovered = temp.path().join(".codex").join("sessions");
     copy_dir_all(&fixture, &discovered);
-    let _ = json_output(ctx(&temp).args(["search", "anything", "--refresh", "off", "--json"]));
 
     let mut conn = Connection::open(temp.path().join("work.sqlite")).unwrap();
     let tx = conn.transaction().unwrap();
@@ -6049,6 +6155,18 @@ fn search_requires_query_term_or_file_before_refreshing() {
     assert!(
         underscore_term.contains("search needs a query, --term, or --file"),
         "{underscore_term}"
+    );
+}
+
+#[test]
+fn search_refresh_off_requires_existing_store_without_creating_one() {
+    let temp = tempdir();
+    let stderr = failure_stderr(ctx(&temp).args(["search", "anything", "--refresh", "off"]));
+
+    assert!(stderr.contains("ctx store is not initialized"), "{stderr}");
+    assert!(
+        !temp.path().join("work.sqlite").exists(),
+        "refresh-off search should not create the ctx store"
     );
 }
 


### PR DESCRIPTION
## What changed
- Added a shared CLI helper for opening an existing ctx store read-only.
- Made `ctx search --refresh off` require an existing index without creating `work.sqlite`.
- Made auto-refresh failures serve only a preexisting index; cold-start auto-refresh failures now error instead of serving a just-created empty/partial fallback.
- Made `ctx doctor` report missing data/store findings without creating the store.
- Tightened refresh tests so refresh-off is not used as an implicit setup path.

## Why
`Store::open` initializes directories, SQLite files, and store layout. Search fallback paths and doctor diagnostics should not mutate local state when the user asked to inspect existing history.

## Validation
- `cargo fmt --all --check`
- `cargo check -p ctx --tests`
- `cargo test -p ctx --test cli search_refresh`
- `cargo test -p ctx --test cli search_refresh_off_serves_existing_index_without_importing`
- `cargo test -p ctx --test cli doctor_reports_missing_store_without_creating_it`
- `cargo test -p ctx --test cli sql_is_read_only_and_does_not_initialize_store`
- `cargo test -p ctx --test cli mcp_search_requires_query_term_or_file_without_opening_store`
- `cargo test -p ctx --test cli search_requires_query_term_or_file_before_refreshing`
- `git diff --check`

## Review
A read-only sidecar review found one low-severity test weakness in the refresh-off native-source test; the test was updated to seed one fixture and place a distinct unindexed fixture in the discovered path.
