### PR TITLE
[codex] Require providers for native path imports

### DIFF
--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -133,7 +133,10 @@ struct DoctorArgs {
 struct ImportArgs {
     #[arg(long, value_enum)]
     provider: Option<NativeProviderArg>,
-    #[arg(long)]
+    #[arg(
+        long,
+        help = "Import exactly this path; native provider paths require --provider"
+    )]
     path: Option<PathBuf>,
     #[arg(long = "history-source", conflicts_with_all = ["provider", "path", "format", "all"])]
     history_source: Option<String>,
@@ -2030,6 +2033,7 @@ fn run_import_internal(
     analytics_properties: &mut AnalyticsProperties,
     options: ImportRunOptions,
 ) -> Result<ImportReport> {
+    validate_import_args(args)?;
     fs::create_dir_all(&data_root)?;
     config::write_default_config(&data_root)?;
     let db_path = database_path(data_root.clone());
@@ -4900,6 +4904,15 @@ fn run_doctor(
     Ok(())
 }
 
+fn validate_import_args(args: &ImportArgs) -> Result<()> {
+    if args.path.is_some() && args.format.is_none() && args.provider.is_none() {
+        return Err(anyhow!(
+            "ctx import --path requires --provider for native provider history; use `ctx import --provider codex --path <path>` or `ctx import --format ctx-history-jsonl-v1 --path <file>`"
+        ));
+    }
+    Ok(())
+}
+
 fn import_requests(args: &ImportArgs) -> Result<Vec<SourceInfo>> {
     if args.history_source.is_some() || !args.history_source_manifest.is_empty() {
         return Ok(Vec::new());
@@ -4907,7 +4920,7 @@ fn import_requests(args: &ImportArgs) -> Result<Vec<SourceInfo>> {
     if let Some(path) = &args.path {
         let provider = args
             .provider
-            .unwrap_or(NativeProviderArg::Codex)
+            .context("ctx import --path requires --provider for native provider history")?
             .capture_provider();
         let source = explicit_path_source(provider, path.clone());
         if !source

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -6258,15 +6258,25 @@ fn import_rejects_nonexistent_path() {
             predicate::str::contains("import path does not exist")
                 .and(predicate::str::contains(path)),
         );
+}
+
+#[test]
+fn import_path_requires_provider_before_opening_store() {
+    let temp = tempdir();
+    let path = temp.path().join("missing-codex-history");
+    let path = path.to_str().unwrap();
 
     ctx(&temp)
         .args(["import", "--path", path])
         .assert()
         .failure()
-        .stderr(
-            predicate::str::contains("import path does not exist")
-                .and(predicate::str::contains(path)),
-        );
+        .stderr(predicate::str::contains(
+            "ctx import --path requires --provider",
+        ));
+    assert!(
+        !temp.path().join("work.sqlite").exists(),
+        "native path import without provider should fail before opening the store"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/ctx-history-capture/src/provider_sources.rs
+++ b/crates/ctx-history-capture/src/provider_sources.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashSet,
     env,
+    io::ErrorKind,
     path::{Path, PathBuf},
 };
 
@@ -536,23 +537,37 @@ fn provider_source_from_location(
     location: &ProviderDefaultLocation,
     path: PathBuf,
 ) -> ProviderSource {
-    let exists = path.exists();
-    let status = if matches!(spec.import_support, ProviderImportSupport::Unsupported) {
-        ProviderSourceStatus::Unsupported
-    } else if !exists {
-        ProviderSourceStatus::Missing
-    } else {
-        match default_location_import_probe(spec.provider, location, &path) {
-            BoundedProbe::Found => ProviderSourceStatus::Available,
-            BoundedProbe::NotFound => ProviderSourceStatus::Empty,
-            BoundedProbe::BudgetExhausted => ProviderSourceStatus::Unknown,
-        }
-    };
-    let unsupported_reason = match status {
-        ProviderSourceStatus::Empty => empty_source_reason(spec.provider),
-        ProviderSourceStatus::Unknown => unknown_source_reason(spec.provider),
-        _ => spec.unsupported_reason,
-    };
+    let path_exists = path.try_exists();
+    let exists = path_exists.as_ref().copied().unwrap_or(true);
+    let (status, unsupported_reason) =
+        if matches!(spec.import_support, ProviderImportSupport::Unsupported) {
+            (ProviderSourceStatus::Unsupported, spec.unsupported_reason)
+        } else {
+            match path_exists {
+                Ok(false) => (ProviderSourceStatus::Missing, spec.unsupported_reason),
+                Err(_) => (
+                    ProviderSourceStatus::Unknown,
+                    probe_io_error_reason(spec.provider),
+                ),
+                Ok(true) => match default_location_import_probe(spec.provider, location, &path) {
+                    BoundedProbe::Found => {
+                        (ProviderSourceStatus::Available, spec.unsupported_reason)
+                    }
+                    BoundedProbe::NotFound => (
+                        ProviderSourceStatus::Empty,
+                        empty_source_reason(spec.provider),
+                    ),
+                    BoundedProbe::BudgetExhausted => (
+                        ProviderSourceStatus::Unknown,
+                        unknown_source_reason(spec.provider),
+                    ),
+                    BoundedProbe::IoError => (
+                        ProviderSourceStatus::Unknown,
+                        probe_io_error_reason(spec.provider),
+                    ),
+                },
+            }
+        };
     ProviderSource {
         provider: spec.provider,
         path,
@@ -633,6 +648,51 @@ fn unknown_source_reason(provider: CaptureProvider) -> Option<&'static str> {
     }
 }
 
+fn probe_io_error_reason(provider: CaptureProvider) -> Option<&'static str> {
+    match provider {
+        CaptureProvider::Codex => {
+            Some("path exists but Codex session transcripts could not be read; check permissions")
+        }
+        CaptureProvider::Pi => {
+            Some("path exists but the Pi session file could not be read; check permissions")
+        }
+        CaptureProvider::Claude => {
+            Some("path exists but Claude project transcripts could not be read; check permissions")
+        }
+        CaptureProvider::OpenCode => {
+            Some("path exists but the OpenCode database could not be read; check permissions")
+        }
+        CaptureProvider::Antigravity => {
+            Some("path exists but Antigravity transcripts could not be read; check permissions")
+        }
+        CaptureProvider::Gemini => {
+            Some("path exists but Gemini CLI chat transcripts could not be read; check permissions")
+        }
+        CaptureProvider::Cursor => {
+            Some("path exists but Cursor agent transcripts could not be read; check permissions")
+        }
+        CaptureProvider::CopilotCli => {
+            Some("path exists but Copilot CLI session events could not be read; check permissions")
+        }
+        CaptureProvider::FactoryAiDroid => {
+            Some("path exists but Factory AI Droid sessions could not be read; check permissions")
+        }
+        CaptureProvider::OpenClaw => Some(
+            "path exists but OpenClaw session transcripts could not be read; check permissions",
+        ),
+        CaptureProvider::Hermes => {
+            Some("path exists but the Hermes state database could not be read; check permissions")
+        }
+        CaptureProvider::NanoClaw => {
+            Some("path exists but the NanoClaw project store could not be read; check permissions")
+        }
+        CaptureProvider::AstrBot => {
+            Some("path exists but the AstrBot data database could not be read; check permissions")
+        }
+        _ => None,
+    }
+}
+
 fn default_location_import_probe(
     provider: CaptureProvider,
     location: &ProviderDefaultLocation,
@@ -640,16 +700,16 @@ fn default_location_import_probe(
 ) -> BoundedProbe {
     match provider {
         CaptureProvider::Codex if location.source_format == "codex_history_jsonl" => {
-            BoundedProbe::from_bool(path.is_file())
+            path_is_file_probe(path)
         }
         CaptureProvider::Codex => has_jsonl_file_under_matching(path, 10_000, |_| true),
-        CaptureProvider::Pi => BoundedProbe::from_bool(path.is_file()),
-        CaptureProvider::OpenCode => BoundedProbe::from_bool(path.is_file()),
+        CaptureProvider::Pi => path_is_file_probe(path),
+        CaptureProvider::OpenCode => path_is_file_probe(path),
         CaptureProvider::Claude => has_jsonl_file_under_matching(path, 10_000, |_| true),
         CaptureProvider::OpenClaw => has_openclaw_session_jsonl(path, 10_000),
-        CaptureProvider::Hermes => BoundedProbe::from_bool(path.is_file()),
+        CaptureProvider::Hermes => path_is_file_probe(path),
         CaptureProvider::NanoClaw => has_nanoclaw_project(path),
-        CaptureProvider::AstrBot => BoundedProbe::from_bool(path.is_file()),
+        CaptureProvider::AstrBot => path_is_file_probe(path),
         CaptureProvider::Antigravity => has_jsonl_file_under_matching(path, 10_000, |candidate| {
             matches!(
                 candidate.file_name().and_then(|name| name.to_str()),
@@ -664,29 +724,45 @@ fn default_location_import_probe(
             candidate.file_name().and_then(|name| name.to_str()) == Some("events.jsonl")
         }),
         CaptureProvider::FactoryAiDroid => has_jsonl_file_under_matching(path, 10_000, |_| true),
-        _ => BoundedProbe::from_bool(path.exists()),
+        CaptureProvider::Shell
+        | CaptureProvider::Git
+        | CaptureProvider::Jj
+        | CaptureProvider::Gh
+        | CaptureProvider::Custom
+        | CaptureProvider::Unknown => BoundedProbe::NotFound,
     }
 }
 
 fn has_gemini_chat_jsonl(root: &Path, max_entries: usize) -> BoundedProbe {
     let tmp = root.join("tmp");
-    if !tmp.is_dir() {
-        return BoundedProbe::NotFound;
+    match path_is_dir_probe(&tmp) {
+        BoundedProbe::Found => {}
+        BoundedProbe::IoError => return BoundedProbe::IoError,
+        _ => return BoundedProbe::NotFound,
     }
     has_jsonl_file_under_matching(&tmp, max_entries, |path| path_has_component(path, "chats"))
 }
 
 fn has_openclaw_session_jsonl(root: &Path, max_entries: usize) -> BoundedProbe {
-    if root.is_file() {
-        return BoundedProbe::from_bool(
-            root.extension().and_then(|ext| ext.to_str()) == Some("jsonl"),
-        );
+    match path_metadata_probe(root) {
+        PathProbe::File => {
+            return BoundedProbe::from_bool(
+                root.extension().and_then(|ext| ext.to_str()) == Some("jsonl"),
+            );
+        }
+        PathProbe::Dir => {}
+        PathProbe::Missing | PathProbe::Other => return BoundedProbe::NotFound,
+        PathProbe::IoError => return BoundedProbe::IoError,
     }
     let agents = root.join("agents");
-    if agents.is_dir() {
-        return has_jsonl_file_under_matching(&agents, max_entries, |path| {
-            path_has_component(path, "sessions")
-        });
+    match path_is_dir_probe(&agents) {
+        BoundedProbe::Found => {
+            return has_jsonl_file_under_matching(&agents, max_entries, |path| {
+                path_has_component(path, "sessions")
+            });
+        }
+        BoundedProbe::IoError => return BoundedProbe::IoError,
+        _ => {}
     }
     has_jsonl_file_under_matching(root, max_entries, |path| {
         path_has_component(path, "sessions")
@@ -694,9 +770,14 @@ fn has_openclaw_session_jsonl(root: &Path, max_entries: usize) -> BoundedProbe {
 }
 
 fn has_nanoclaw_project(root: &Path) -> BoundedProbe {
-    BoundedProbe::from_bool(
-        root.join("data").join("v2.db").is_file() && root.join("data").join("v2-sessions").is_dir(),
-    )
+    match (
+        path_is_file_probe(&root.join("data").join("v2.db")),
+        path_is_dir_probe(&root.join("data").join("v2-sessions")),
+    ) {
+        (BoundedProbe::Found, BoundedProbe::Found) => BoundedProbe::Found,
+        (BoundedProbe::IoError, _) | (_, BoundedProbe::IoError) => BoundedProbe::IoError,
+        _ => BoundedProbe::NotFound,
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -704,6 +785,7 @@ enum BoundedProbe {
     Found,
     NotFound,
     BudgetExhausted,
+    IoError,
 }
 
 impl BoundedProbe {
@@ -716,38 +798,81 @@ impl BoundedProbe {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PathProbe {
+    File,
+    Dir,
+    Other,
+    Missing,
+    IoError,
+}
+
+fn path_metadata_probe(path: &Path) -> PathProbe {
+    match path.metadata() {
+        Ok(metadata) if metadata.is_file() => PathProbe::File,
+        Ok(metadata) if metadata.is_dir() => PathProbe::Dir,
+        Ok(_) => PathProbe::Other,
+        Err(err) if err.kind() == ErrorKind::NotFound => PathProbe::Missing,
+        Err(_) => PathProbe::IoError,
+    }
+}
+
+fn path_is_file_probe(path: &Path) -> BoundedProbe {
+    match path_metadata_probe(path) {
+        PathProbe::File => BoundedProbe::Found,
+        PathProbe::IoError => BoundedProbe::IoError,
+        _ => BoundedProbe::NotFound,
+    }
+}
+
+fn path_is_dir_probe(path: &Path) -> BoundedProbe {
+    match path_metadata_probe(path) {
+        PathProbe::Dir => BoundedProbe::Found,
+        PathProbe::IoError => BoundedProbe::IoError,
+        _ => BoundedProbe::NotFound,
+    }
+}
+
 fn has_jsonl_file_under_matching(
     root: &Path,
     max_entries: usize,
     matches_path: impl Fn(&Path) -> bool,
 ) -> BoundedProbe {
-    if root.is_file() {
-        return if root.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
-            && matches_path(root)
-        {
-            BoundedProbe::Found
-        } else {
-            BoundedProbe::NotFound
-        };
-    }
-    if !root.is_dir() {
-        return BoundedProbe::NotFound;
+    match path_metadata_probe(root) {
+        PathProbe::File => {
+            return if root.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+                && matches_path(root)
+            {
+                BoundedProbe::Found
+            } else {
+                BoundedProbe::NotFound
+            };
+        }
+        PathProbe::Dir => {}
+        PathProbe::Missing | PathProbe::Other => return BoundedProbe::NotFound,
+        PathProbe::IoError => return BoundedProbe::IoError,
     }
 
     let mut visited = 0usize;
     let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
-        let Ok(entries) = std::fs::read_dir(&dir) else {
-            continue;
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => return BoundedProbe::IoError,
         };
-        for entry in entries.flatten() {
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => return BoundedProbe::IoError,
+            };
             visited = visited.saturating_add(1);
             if visited > max_entries {
                 return BoundedProbe::BudgetExhausted;
             }
             let path = entry.path();
-            let Ok(file_type) = entry.file_type() else {
-                continue;
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(_) => return BoundedProbe::IoError,
             };
             if file_type.is_dir() {
                 stack.push(path);
@@ -943,6 +1068,55 @@ mod tests {
             CaptureProvider::Claude,
             ProviderSourceStatus::Unknown,
         );
+    }
+
+    #[test]
+    fn default_location_probe_does_not_fallback_to_path_existence_for_unhandled_providers() {
+        let temp = tempfile::tempdir().unwrap();
+        let existing = temp.path().join("shell-history");
+        std::fs::write(&existing, "{}\n").unwrap();
+        let location = ProviderDefaultLocation {
+            path_components: &["shell-history"],
+            source_format: "shell_history",
+            source_kind: ProviderSourceKind::NativeHistory,
+        };
+
+        assert_eq!(
+            default_location_import_probe(CaptureProvider::Shell, &location, &existing),
+            BoundedProbe::NotFound
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn default_source_probe_reports_unreadable_directory_as_unknown() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let sessions = temp.path().join(".codex/sessions");
+        std::fs::create_dir_all(&sessions).unwrap();
+        let original_permissions = std::fs::metadata(&sessions).unwrap().permissions();
+        std::fs::set_permissions(&sessions, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        if std::fs::read_dir(&sessions).is_ok() {
+            std::fs::set_permissions(&sessions, original_permissions).unwrap();
+            return;
+        }
+
+        let source = discover_provider_sources(temp.path())
+            .into_iter()
+            .find(|source| {
+                source.provider == CaptureProvider::Codex
+                    && source.source_format == "codex_session_jsonl_tree"
+            })
+            .unwrap();
+        std::fs::set_permissions(&sessions, original_permissions).unwrap();
+
+        assert_eq!(source.status, ProviderSourceStatus::Unknown);
+        assert!(source
+            .unsupported_reason
+            .unwrap()
+            .contains("could not be read"));
     }
 
     fn assert_source_status(

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -93,7 +93,7 @@ ctx import --provider gemini
 ctx import --provider cursor
 ctx import --provider copilot-cli
 ctx import --provider factory-ai-droid
-ctx import --path ~/.codex/sessions
+ctx import --provider codex --path ~/.codex/sessions
 ctx import --provider pi --path ~/.pi/sessions.jsonl
 ctx import --format ctx-history-jsonl-v1 --path ./history.jsonl
 ctx import --history-source example-agent/default
@@ -135,8 +135,8 @@ Import selection rules:
   history JSONL file;
 - with `--history-source`, import matching local plugin sources;
 - with `--history-source-manifest`, import sources from that manifest path;
-- with `--path`, import exactly that path;
-- with `--path` and no provider, parse the path as Codex format.
+- with `--provider <provider> --path <path>`, import exactly that native
+  provider path.
 
 Preview providers such as NanoClaw and AstrBot are not included in `--all` or
 pre-search refresh. Import them explicitly with `--provider` when discovery

--- a/docs/first-10-minutes.md
+++ b/docs/first-10-minutes.md
@@ -121,7 +121,8 @@ eligible for signed self-upgrades.
 ## Failure Paths
 
 - No sources listed: this machine may not have supported local provider
-  history. Use `ctx import --path` only for a known supported format.
+  history. Use `ctx import --provider <provider> --path <path>` only for a
+  known supported native provider format.
 - Import fails on a file: rerun with `--json` and inspect the per-source
   `failed` count.
 - Search returns no results: confirm `ctx status` shows indexed items, then

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,7 +65,7 @@ ctx import --all
 ctx import --provider codex
 ctx import --provider pi
 ctx import --provider cursor
-ctx import --path ~/.codex/sessions
+ctx import --provider codex --path ~/.codex/sessions
 ctx import --resume --json
 ```
 
@@ -79,7 +79,8 @@ After upgrading an older data root to `0.10.x` or newer, the first refresh or im
 re-read previously indexed provider transcripts once. That rebuilds search
 content with touched-file metadata and local/private transcript text.
 
-When `--path` is used without `--provider`, ctx treats the path as Codex format.
+Native provider `--path` imports require `--provider`. Custom JSONL imports use
+`--format ctx-history-jsonl-v1 --path <file>` instead.
 
 ## 5. Search
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -125,7 +125,7 @@ Re-import or update the index:
 ```bash
 ctx import --all
 ctx import --resume
-ctx import --path ~/.codex/sessions
+ctx import --provider codex --path ~/.codex/sessions
 ctx import --format ctx-history-jsonl-v1 --path ./history.jsonl
 ctx import --history-source example-agent/default
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,7 +12,7 @@ Confirm the provider keeps history on this machine and pass an explicit path if
 needed:
 
 ```bash
-ctx import --path ~/.codex/sessions
+ctx import --provider codex --path ~/.codex/sessions
 ```
 
 ## Search Misses Recent Work

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -64,7 +64,10 @@ class LocalCliAdapterTests(unittest.TestCase):
             self.assertEqual(client.init(catalog_only=True)["operation"], "init")
             self.assertEqual(client.sources()["operation"], "sources")
             self.assertEqual(client.import_(provider="codex", resume=True)["operation"], "import")
-            self.assertEqual(client.sync(path="/tmp/history.jsonl")["operation"], "sync")
+            self.assertEqual(
+                client.sync(provider="codex", path="/tmp/history.jsonl")["operation"],
+                "sync",
+            )
             self.assertEqual(
                 client.search(
                     "sqlite",


### PR DESCRIPTION
## What changed
- Native `ctx import --path <path>` now requires an explicit `--provider` unless `--format ctx-history-jsonl-v1` is used.
- Removed the silent Codex default for arbitrary native import paths.
- Hardened native provider discovery probes so IO/read errors report `unknown` instead of being treated as empty, and unhandled provider probes no longer fall back to path existence.
- Updated docs and the Python SDK test to use `--provider codex --path ...` for native path imports.

## Why
Path imports need an explicit native provider contract. The old Codex fallback made arbitrary paths look valid under the wrong parser and could hide mistakes in docs, SDK examples, and user workflows.

## Validation
- `cargo fmt --all --check`
- `cargo check -p ctx --tests`
- `cargo test -p ctx --test cli import_path_requires_provider_before_opening_store`
- `cargo test -p ctx --test cli import_rejects_nonexistent_path`
- `cargo test -p ctx-history-capture provider_sources`
- `cargo test -p ctx --test cli provider_help_matches_implemented_importers`
- `cargo test -p ctx --test cli mcp_status_and_tools_list_are_read_only_without_initialized_store`
- `cargo test -p ctx --test cli public_subcommand_help_is_golden_enough_for_session_retrieval`
- `python3 -m unittest sdks.python.tests.test_client`
- `git diff --check`

## Notes
MCP provider schema/parser parity was already present on current main, so this PR does not change MCP provider parsing.
