### PR TITLE
[codex] Prepare 0.17.0 release hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "ctx"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-capture"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "ctx-history-core",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "directories",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-search"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "ctx-history-core",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-store"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "ctx-history-core",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,1 +1,1 @@
-module(name = "ctx_search", version = "0.13.0")
+module(name = "ctx_search", version = "0.17.0")

--- a/crates/ctx-cli/Cargo.toml
+++ b/crates/ctx-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx"
-version = "0.16.0"
+version = "0.17.0"
 description = "Local CLI for indexing and searching agent session history"
 edition.workspace = true
 autobins = false

--- a/crates/ctx-cli/src/upgrade.rs
+++ b/crates/ctx-cli/src/upgrade.rs
@@ -126,7 +126,22 @@ struct UpgradePlan {
     update_available: bool,
     managed: bool,
     warnings: Vec<String>,
+    path: PathDiagnostics,
     metadata: ReleaseMetadata,
+}
+
+#[derive(Debug, Clone)]
+struct PathDiagnostics {
+    current_exe: PathBuf,
+    entries: Vec<PathDiagnosticEntry>,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct PathDiagnosticEntry {
+    path: PathBuf,
+    version: Option<String>,
+    current: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -164,8 +179,26 @@ impl UpgradeOutcome {
             "artifact_url": plan.map(|plan| plan.artifact_url.as_str()),
             "install_path": plan.map(|plan| plan.install_path.display().to_string()),
             "managed": plan.map(|plan| plan.managed).unwrap_or(false),
+            "path": plan.map(|plan| plan.path.json()),
             "applied": self.applied,
             "dry_run": self.dry_run,
+            "warnings": self.warnings,
+        })
+    }
+}
+
+impl PathDiagnostics {
+    fn json(&self) -> Value {
+        json!({
+            "current_exe": self.current_exe.display().to_string(),
+            "first_ctx": self.entries.first().map(|entry| entry.path.display().to_string()),
+            "entries": self.entries.iter().map(|entry| {
+                json!({
+                    "path": entry.path.display().to_string(),
+                    "version": entry.version.as_deref(),
+                    "current": entry.current,
+                })
+            }).collect::<Vec<_>>(),
             "warnings": self.warnings,
         })
     }
@@ -400,6 +433,9 @@ fn build_upgrade_plan(
         &current_version,
         &mut warnings,
     )?;
+    let managed = warnings.is_empty();
+    let path = path_diagnostics(&marker.install_path, &current_version);
+    warnings.extend(path.warnings.clone());
     let metadata_url = metadata_url(config, &channel);
     let signature_url = metadata_signature_url(&metadata_url);
     let metadata_bytes = net::get_bytes(&metadata_url)
@@ -425,8 +461,9 @@ fn build_upgrade_plan(
         artifact_sha256: metadata.sha256.clone(),
         install_path: marker.install_path.clone(),
         update_available,
-        managed: warnings.is_empty(),
+        managed,
         warnings,
+        path,
         metadata,
     })
 }
@@ -450,6 +487,11 @@ fn render_status(data_root: &Path, json_output: bool) -> Result<()> {
             "status": "never_checked"
         })
     });
+    let current_version = env!("CARGO_PKG_VERSION");
+    let current_exe = current_install_path().ok();
+    let path_diagnostics = current_exe
+        .as_ref()
+        .map(|path| path_diagnostics(path, current_version));
     let marker = read_verified_install_marker_for_current_exe()
         .map(|marker| {
             json!({
@@ -470,8 +512,14 @@ fn render_status(data_root: &Path, json_output: bool) -> Result<()> {
     let value = json!({
         "schema_version": 1,
         "command": "upgrade_status",
+        "current_version": current_version,
         "state": state,
         "install": marker,
+        "path": path_diagnostics.as_ref().map(PathDiagnostics::json),
+        "warnings": path_diagnostics
+            .as_ref()
+            .map(|diagnostics| diagnostics.warnings.clone())
+            .unwrap_or_default(),
     });
     if json_output {
         println!("{}", serde_json::to_string_pretty(&value)?);
@@ -484,10 +532,28 @@ fn render_status(data_root: &Path, json_output: bool) -> Result<()> {
         if let Some(path) = marker.get("install_path").and_then(Value::as_str) {
             println!("install: {path}");
         }
+        if let Some(diagnostics) = &path_diagnostics {
+            println!("current_exe: {}", diagnostics.current_exe.display());
+            if let Some(first) = diagnostics.entries.first() {
+                println!("path_ctx: {}", first.path.display());
+            }
+            for warning in &diagnostics.warnings {
+                eprintln!("warning: {warning}");
+            }
+        }
     } else {
         println!("ctx upgrade status: unmanaged install");
         if let Some(reason) = marker.get("reason").and_then(Value::as_str) {
             println!("{reason}");
+        }
+        if let Some(diagnostics) = &path_diagnostics {
+            println!("current_exe: {}", diagnostics.current_exe.display());
+            if let Some(first) = diagnostics.entries.first() {
+                println!("path_ctx: {}", first.path.display());
+            }
+            for warning in &diagnostics.warnings {
+                eprintln!("warning: {warning}");
+            }
         }
     }
     Ok(())
@@ -1002,6 +1068,91 @@ fn current_binary_sha() -> Result<String> {
     let path = current_install_path()?;
     let bytes = fs::read(&path).with_context(|| format!("read {}", path.display()))?;
     Ok(sha256_hex(&bytes))
+}
+
+fn path_diagnostics(current_exe: &Path, current_version: &str) -> PathDiagnostics {
+    let current_identity = path_identity(current_exe);
+    let current_display = current_exe.display().to_string();
+    let binary_name = if cfg!(windows) { "ctx.exe" } else { "ctx" };
+    let mut entries = Vec::new();
+    for dir in env::var_os("PATH")
+        .map(|path| env::split_paths(&path).collect::<Vec<_>>())
+        .unwrap_or_default()
+    {
+        let candidate = dir.join(binary_name);
+        if !candidate.is_file() {
+            continue;
+        }
+        if entries
+            .iter()
+            .any(|entry: &PathDiagnosticEntry| same_path(&entry.path, &candidate))
+        {
+            continue;
+        }
+        let current = path_identity(&candidate) == current_identity;
+        entries.push(PathDiagnosticEntry {
+            version: ctx_binary_version(&candidate).ok(),
+            path: candidate,
+            current,
+        });
+    }
+
+    let mut warnings = Vec::new();
+    match entries.first() {
+        Some(first) if !first.current => warnings.push(format!(
+            "PATH resolves ctx to {} before the current executable {}; your shell may keep using the earlier binary after upgrade",
+            first.path.display(),
+            current_display
+        )),
+        None => warnings.push(format!(
+            "current ctx executable {current_display} is not discoverable on PATH"
+        )),
+        _ => {}
+    }
+    if entries.len() > 1 {
+        warnings.push(format!(
+            "multiple ctx binaries are on PATH; first is {}",
+            entries[0].path.display()
+        ));
+    }
+    let expected = format!("ctx {current_version}");
+    for entry in &entries {
+        if let Some(version) = &entry.version {
+            if version != &expected {
+                warnings.push(format!(
+                    "ctx on PATH at {} reports {version}; current binary reports {expected}",
+                    entry.path.display()
+                ));
+            }
+        }
+    }
+
+    PathDiagnostics {
+        current_exe: current_exe.to_path_buf(),
+        entries,
+        warnings,
+    }
+}
+
+fn path_identity(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn same_path(left: &Path, right: &Path) -> bool {
+    path_identity(left) == path_identity(right)
+}
+
+fn ctx_binary_version(path: &Path) -> Result<String> {
+    let output = Command::new(path)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| format!("run {} --version", path.display()))?;
+    if !output.status.success() {
+        return Err(anyhow!("{} --version failed", path.display()));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout.lines().next().unwrap_or_default().trim().to_owned())
 }
 
 fn write_state_checked(data_root: &Path, plan: &UpgradePlan, status: &str) -> Result<()> {

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -2361,6 +2361,42 @@ fn upgrade_status_check_and_apply_support_managed_installs() {
 
 #[cfg(unix)]
 #[test]
+fn upgrade_status_reports_path_shadowing() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let shadow_dir = temp.path().join("shadow-bin");
+    fs::create_dir_all(&shadow_dir).unwrap();
+    let shadow_ctx = shadow_dir.join("ctx");
+    write_fake_ctx_binary(&shadow_ctx, "0.9.0");
+    let managed_dir = release.target.parent().unwrap();
+    let path = std::env::join_paths([shadow_dir.as_path(), managed_dir]).unwrap();
+
+    let mut command = ctx(&temp);
+    command
+        .args(["upgrade", "status", "--json"])
+        .env("PATH", path);
+    let status = json_output(fake_release_env(&mut command, &release));
+
+    assert_eq!(status["current_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(
+        status["path"]["entries"][0]["path"],
+        shadow_ctx.display().to_string()
+    );
+    assert_eq!(status["path"]["entries"][0]["version"], "ctx 0.9.0");
+    assert!(status["warnings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|warning| { warning.as_str().unwrap().contains("PATH resolves ctx to") }));
+    assert!(status["warnings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|warning| { warning.as_str().unwrap().contains("reports ctx 0.9.0") }));
+}
+
+#[cfg(unix)]
+#[test]
 fn upgrade_rejects_unmanaged_install_before_network() {
     let temp = tempdir();
     let stderr = failure_stderr(

--- a/crates/ctx-history-capture/Cargo.toml
+++ b/crates/ctx-history-capture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-capture"
-version = "0.16.0"
+version = "0.17.0"
 description = "Internal provider import adapters for ctx local agent history"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-core/Cargo.toml
+++ b/crates/ctx-history-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-core"
-version = "0.16.0"
+version = "0.17.0"
 description = "Internal core types for ctx local agent history indexing"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-search/Cargo.toml
+++ b/crates/ctx-history-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-search"
-version = "0.16.0"
+version = "0.17.0"
 description = "Internal search projection and ranking helpers for ctx"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-store/Cargo.toml
+++ b/crates/ctx-history-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-store"
-version = "0.16.0"
+version = "0.17.0"
 description = "Internal SQLite storage layer for ctx local agent history"
 edition.workspace = true
 license.workspace = true

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -389,6 +389,9 @@ binary, such as `~/.local/bin/ctx.install.json`, recording the managed install
 path, platform, version, channel, binary SHA-256, metadata URL, and artifact
 URL. Source builds, `cargo install`, package-manager installs, copied binaries,
 and mismatched sidecars are treated as unmanaged and will not self-upgrade.
+`ctx upgrade status --json` also reports the current executable and every `ctx`
+binary found on `PATH`, with warnings when an older binary shadows the managed
+install or multiple `ctx` binaries are present.
 
 Official installer-managed installs default to background auto-upgrade after
 successful normal commands when signed release metadata explicitly allows

--- a/docs/first-10-minutes.md
+++ b/docs/first-10-minutes.md
@@ -115,8 +115,8 @@ ctx upgrade status
 ```
 
 `ctx docs` is embedded in the binary for humans and agents. `ctx upgrade status`
-shows whether the current binary is managed by the official installer and
-eligible for signed self-upgrades.
+shows whether the current binary is managed by the official installer, eligible
+for signed self-upgrades, and shadowed by another `ctx` binary on `PATH`.
 
 ## Failure Paths
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -19,6 +19,8 @@ The installer writes a sidecar marker next to the binary, such as
 version, channel, binary SHA-256, metadata URL, and artifact URL. Source builds,
 `cargo install`, package-manager installs, copied binaries, and mismatched
 sidecars are treated as unmanaged and will not self-upgrade.
+`ctx upgrade status --json` also lists every `ctx` binary found on `PATH` and
+warns when another binary shadows the managed install.
 
 Official installer-managed installs default to background auto-upgrade after
 successful normal commands when signed release metadata explicitly allows

--- a/scripts/build-public-cli-artifact.sh
+++ b/scripts/build-public-cli-artifact.sh
@@ -113,10 +113,11 @@ ensure_darwin_cross_tools() {
 }
 
 version="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next(pkg["version"] for pkg in data["packages"] if pkg["name"] == "ctx"))')"
-if [[ "${version}" != "0.16.0" ]]; then
-  echo "error: ctx package version must be 0.16.0 for this release, got ${version}" >&2
+if [[ -z "${version}" ]]; then
+  echo "error: could not determine ctx package version from Cargo metadata" >&2
   exit 1
 fi
+echo "building ctx ${version} for ${platform}"
 
 rustup target add "${target}" >/dev/null
 out_dir="${CTX_PUBLIC_CLI_ARTIFACT_DIR:-target/public-cli-artifacts}"
@@ -156,12 +157,12 @@ fi
 case "${platform}" in
   linux-x64)
     "${staged}" --version | tee "${staged}.version"
-    grep -Fx "ctx 0.16.0" "${staged}.version" >/dev/null
+    grep -Fx "ctx ${version}" "${staged}.version" >/dev/null
     ;;
   macos-arm64)
     if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
       "${staged}" --version | tee "${staged}.version"
-      grep -Fx "ctx 0.16.0" "${staged}.version" >/dev/null
+      grep -Fx "ctx ${version}" "${staged}.version" >/dev/null
     else
       printf 'not run on this host: %s\n' "${platform}" > "${staged}.version"
     fi
@@ -169,7 +170,7 @@ case "${platform}" in
   macos-x64)
     if [[ "$(uname -s)" == "Darwin" ]] && /usr/bin/arch -x86_64 /usr/bin/true >/dev/null 2>&1; then
       /usr/bin/arch -x86_64 "${staged}" --version | tee "${staged}.version"
-      grep -Fx "ctx 0.16.0" "${staged}.version" >/dev/null
+      grep -Fx "ctx ${version}" "${staged}.version" >/dev/null
     else
       printf 'not run on this host: %s\n' "${platform}" > "${staged}.version"
     fi


### PR DESCRIPTION
## What changed
- Bumped public CLI/history crates and lockfile from `0.16.0` to `0.17.0`.
- Aligned `MODULE.bazel` with the public CLI release version.
- Removed the hard-coded `0.16.0` release guard/version grep from `scripts/build-public-cli-artifact.sh`; it now uses Cargo metadata.
- Added PATH diagnostics to `ctx upgrade status --json` and `ctx upgrade check --json`, including current executable, PATH `ctx` entries, versions, and shadowing warnings.
- Documented upgrade PATH shadowing diagnostics.

## Why
The local machine had multiple stale `ctx` binaries (`~/.local/bin` and `~/.cargo/bin`) with different versions. Release/upgrade tooling should make that visible and avoid per-release hard-coding that blocks the next candidate.

## Validation
- `cargo fmt --all --check`
- `cargo check -p ctx --tests`
- `cargo test -p ctx --test cli upgrade_status_reports_path_shadowing`
- `cargo test -p ctx --test cli upgrade_status_check_and_apply_support_managed_installs`
- `cargo test -p ctx --test cli upgrade_`
- `cargo run -p ctx -- --version` -> `ctx 0.17.0`
- `bash -n scripts/build-public-cli-artifact.sh scripts/check-public-cli-artifact.sh`
- `cargo metadata --no-deps --format-version 1` confirmed CLI/history crates at `0.17.0`, protocol/SDK at `0.12.0`
- `git diff --check`
