### PR TITLE
Clarify local preview redaction state

### DIFF
--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -1087,7 +1087,7 @@ impl ProviderCaptureAdapter for CodexHistoryJsonlAdapter {
                             role: Some(EventRole::User),
                             occurred_at,
                             fidelity: Fidelity::SummaryOnly,
-                            redaction_state: RedactionState::SafePreview,
+                            redaction_state: RedactionState::LocalPreview,
                             idempotency_key: Some(format!(
                                 "provider-event:{}:{}:{}",
                                 CaptureProvider::Codex.as_str(),
@@ -4918,7 +4918,7 @@ fn codex_session_event(
                 .get("payload")
                 .and_then(codex_json_text)
                 .unwrap_or_else(|| "context compacted".to_owned());
-            let (text, truncated) = codex_safe_preview(&text, CODEX_MAX_TEXT_CHARS);
+            let (text, truncated) = codex_local_preview(&text, CODEX_MAX_TEXT_CHARS);
             Some(codex_provider_event(
                 line_number,
                 occurred_at,
@@ -5061,7 +5061,7 @@ fn codex_tool_call_event(
                 format!("{tool_name}: {arguments_preview}")
             }
         });
-    let (text, text_truncated) = codex_safe_preview(&text, CODEX_MAX_METADATA_TEXT_CHARS);
+    let (text, text_truncated) = codex_local_preview(&text, CODEX_MAX_METADATA_TEXT_CHARS);
 
     if let Some(call_id) = call_id {
         call_contexts.insert(
@@ -5152,7 +5152,7 @@ fn codex_tool_output_event(
     };
     let (output_preview, output_truncated) = if keep_preview {
         output_text_ref
-            .map(|text| codex_safe_preview(text, preview_limit))
+            .map(|text| codex_local_preview(text, preview_limit))
             .unwrap_or_else(|| (String::new(), false))
     } else {
         (String::new(), output_bytes > 0)
@@ -5187,7 +5187,7 @@ fn codex_tool_output_event(
             format!("{tool_name} output{command}: {status}{duration}, output_bytes={output_bytes}{timeout}{preview}")
         }
     };
-    let (text, text_truncated) = codex_safe_preview(&text, CODEX_MAX_OUTPUT_PREVIEW_CHARS);
+    let (text, text_truncated) = codex_local_preview(&text, CODEX_MAX_OUTPUT_PREVIEW_CHARS);
 
     Some(codex_provider_event(
         line_number,
@@ -5244,7 +5244,7 @@ fn codex_reasoning_event(
                 .and_then(Value::as_str)
                 .map(str::to_owned)
         })?;
-    let (summary, truncated) = codex_safe_preview(&summary, CODEX_MAX_TEXT_CHARS);
+    let (summary, truncated) = codex_local_preview(&summary, CODEX_MAX_TEXT_CHARS);
     Some(codex_provider_event(
         line_number,
         occurred_at,
@@ -5319,7 +5319,7 @@ fn codex_provider_event(
         role,
         occurred_at,
         fidelity: Fidelity::Imported,
-        redaction_state: RedactionState::SafePreview,
+        redaction_state: RedactionState::LocalPreview,
         idempotency_key: Some(format!("provider-event:codex-session:{line_number}")),
         artifacts: Vec::new(),
         payload,
@@ -5335,7 +5335,7 @@ fn codex_lifecycle_body(payload: &Value, msg_type: &str) -> Value {
         .or_else(|| payload.get("stderr"))
         .and_then(codex_json_text)
         .unwrap_or_else(|| format!("Codex lifecycle: {msg_type}"));
-    let (text, truncated) = codex_safe_preview(&preview, CODEX_MAX_METADATA_TEXT_CHARS);
+    let (text, truncated) = codex_local_preview(&preview, CODEX_MAX_METADATA_TEXT_CHARS);
     json!({
         "text": text,
         "event_msg_type": msg_type,
@@ -5373,7 +5373,7 @@ fn codex_command_preview(tool_name: &str, argument_value: Option<&Value>) -> Opt
         .or_else(|| parsed.get("shell_command"))
         .and_then(Value::as_str)
         .or_else(|| value.as_str())?;
-    Some(codex_safe_preview(command, CODEX_MAX_METADATA_TEXT_CHARS).0)
+    Some(codex_local_preview(command, CODEX_MAX_METADATA_TEXT_CHARS).0)
 }
 
 fn codex_value_preview(value: &Value, max_chars: usize) -> (String, bool) {
@@ -5382,10 +5382,10 @@ fn codex_value_preview(value: &Value, max_chars: usize) -> (String, bool) {
         Value::Null => String::new(),
         _ => serde_json::to_string(value).unwrap_or_else(|_| value.to_string()),
     };
-    codex_safe_preview(&rendered, max_chars)
+    codex_local_preview(&rendered, max_chars)
 }
 
-fn codex_safe_preview(value: &str, max_chars: usize) -> (String, bool) {
+fn codex_local_preview(value: &str, max_chars: usize) -> (String, bool) {
     capped_text(value, max_chars)
 }
 
@@ -5521,7 +5521,7 @@ fn capped_text(value: &str, max_chars: usize) -> (String, bool) {
     (out, truncated)
 }
 
-fn provider_safe_preview(value: &str, max_chars: usize) -> (String, bool) {
+fn provider_local_preview(value: &str, max_chars: usize) -> (String, bool) {
     capped_text(value, max_chars)
 }
 
@@ -6213,7 +6213,7 @@ fn claude_event(
             String::new()
         }
     });
-    let (text, truncated) = provider_safe_preview(&text, PROVIDER_MAX_TEXT_CHARS);
+    let (text, truncated) = provider_local_preview(&text, PROVIDER_MAX_TEXT_CHARS);
 
     Some(ProviderEventEnvelope {
         provider_event_index: (line_number - 1) as u64,
@@ -6223,7 +6223,7 @@ fn claude_event(
         role,
         occurred_at,
         fidelity: Fidelity::Imported,
-        redaction_state: RedactionState::SafePreview,
+        redaction_state: RedactionState::LocalPreview,
         idempotency_key: value
             .get("uuid")
             .and_then(Value::as_str)
@@ -6292,12 +6292,12 @@ fn provider_capped_json(value: &Value, max_chars: usize) -> Value {
     match value {
         Value::Null => Value::Null,
         Value::String(text) => {
-            let (text, truncated) = provider_safe_preview(text, max_chars);
+            let (text, truncated) = provider_local_preview(text, max_chars);
             json!({ "text": text, "truncated": truncated })
         }
         _ => {
             let rendered = serde_json::to_string(value).unwrap_or_else(|_| value.to_string());
-            let (json_text, truncated) = provider_safe_preview(&rendered, max_chars);
+            let (json_text, truncated) = provider_local_preview(&rendered, max_chars);
             json!({ "json": json_text, "truncated": truncated })
         }
     }
@@ -6306,7 +6306,7 @@ fn provider_capped_json(value: &Value, max_chars: usize) -> Value {
 fn provider_capped_json_value(value: &Value, max_string_chars: usize) -> Value {
     match value {
         Value::String(text) => {
-            let (text, truncated) = provider_safe_preview(text, max_string_chars);
+            let (text, truncated) = provider_local_preview(text, max_string_chars);
             if truncated {
                 json!({ "text": text, "truncated": true })
             } else {
@@ -6539,7 +6539,7 @@ struct NativeEventDraft {
 }
 
 fn native_event(draft: NativeEventDraft) -> ProviderEventEnvelope {
-    let (text, truncated) = provider_safe_preview(&draft.text, PROVIDER_MAX_TEXT_CHARS);
+    let (text, truncated) = provider_local_preview(&draft.text, PROVIDER_MAX_TEXT_CHARS);
     ProviderEventEnvelope {
         provider_event_index: draft.provider_event_index,
         provider_event_hash: draft.provider_event_hash,
@@ -6548,7 +6548,7 @@ fn native_event(draft: NativeEventDraft) -> ProviderEventEnvelope {
         role: draft.role,
         occurred_at: draft.occurred_at,
         fidelity: Fidelity::Imported,
-        redaction_state: RedactionState::SafePreview,
+        redaction_state: RedactionState::LocalPreview,
         idempotency_key: Some(format!(
             "provider-event:{}:{}:{}",
             draft.provider.as_str(),
@@ -8664,7 +8664,7 @@ fn opencode_event(
     let event_type = opencode_event_type(&row.entry_type, data);
     let role = Some(provider_role(Some(&row.entry_type)));
     let text = opencode_event_text(&row.entry_type, data, event_type);
-    let (text, truncated) = provider_safe_preview(&text, PROVIDER_MAX_TEXT_CHARS);
+    let (text, truncated) = provider_local_preview(&text, PROVIDER_MAX_TEXT_CHARS);
     ProviderEventEnvelope {
         provider_event_index: row.seq.max(0) as u64,
         provider_event_hash: Some(row.id.clone()),
@@ -8676,7 +8676,7 @@ fn opencode_event(
         role,
         occurred_at,
         fidelity: Fidelity::Imported,
-        redaction_state: RedactionState::SafePreview,
+        redaction_state: RedactionState::LocalPreview,
         idempotency_key: Some(format!(
             "provider-event:opencode:{}:{}",
             row.session_id, row.id
@@ -9187,7 +9187,7 @@ fn native_jsonl_event(
     let entry_type = native_jsonl_entry_type(provider, value);
     let role = native_jsonl_role(provider, value);
     let text = native_jsonl_event_text(provider, value, event_type, &entry_type);
-    let (text, truncated) = provider_safe_preview(&text, PROVIDER_MAX_TEXT_CHARS);
+    let (text, truncated) = provider_local_preview(&text, PROVIDER_MAX_TEXT_CHARS);
     let event_id = native_jsonl_event_id(provider, value, line_number);
     let tool_calls = if provider == CaptureProvider::Antigravity {
         value
@@ -9205,7 +9205,7 @@ fn native_jsonl_event(
         role: Some(role),
         occurred_at,
         fidelity: Fidelity::Imported,
-        redaction_state: RedactionState::SafePreview,
+        redaction_state: RedactionState::LocalPreview,
         idempotency_key: Some(format!(
             "provider-event:{}:{source_format}:{event_id}",
             provider.as_str()
@@ -9630,7 +9630,7 @@ fn pi_session_event(entry: &Value, line_number: usize) -> ProviderEventEnvelope 
         role,
         occurred_at,
         fidelity: Fidelity::Imported,
-        redaction_state: RedactionState::SafePreview,
+        redaction_state: RedactionState::LocalPreview,
         idempotency_key: Some(format!("provider-event:pi:{line_number}")),
         artifacts: Vec::new(),
         payload: json!({
@@ -10395,7 +10395,7 @@ fn fixture_line_to_capture(
             role: event.role,
             occurred_at: event.occurred_at,
             fidelity,
-            redaction_state: RedactionState::SafePreview,
+            redaction_state: RedactionState::LocalPreview,
             idempotency_key: Some(format!(
                 "provider-event:{}:{}:{}",
                 fixture.provider.as_str(),
@@ -10422,7 +10422,7 @@ fn effective_event_redaction_state(
         RedactionState::Redacted => RedactionState::Redacted,
         RedactionState::Raw if !sanitizer_redacted => RedactionState::Raw,
         _ if sanitizer_redacted => RedactionState::Redacted,
-        _ => RedactionState::SafePreview,
+        _ => RedactionState::LocalPreview,
     }
 }
 
@@ -11609,7 +11609,7 @@ mod tests {
         let session_id = provider_session_uuid(CaptureProvider::Pi, "pi-session-1");
         let events = store.events_for_session(session_id).unwrap();
         assert_eq!(events.len(), 2);
-        assert_eq!(events[1].redaction_state, RedactionState::SafePreview);
+        assert_eq!(events[1].redaction_state, RedactionState::LocalPreview);
         assert!(events[1]
             .sync
             .metadata
@@ -12413,7 +12413,7 @@ mod tests {
             role: Some(EventRole::Assistant),
             occurred_at: "2026-06-24T01:00:00Z".parse().unwrap(),
             fidelity: Fidelity::Imported,
-            redaction_state: RedactionState::SafePreview,
+            redaction_state: RedactionState::LocalPreview,
             idempotency_key: None,
             artifacts: Vec::new(),
             payload: serde_json::json!({}),
@@ -12482,7 +12482,7 @@ mod tests {
             role: Some(EventRole::Assistant),
             occurred_at: "2026-06-24T01:00:00Z".parse().unwrap(),
             fidelity: Fidelity::Imported,
-            redaction_state: RedactionState::SafePreview,
+            redaction_state: RedactionState::LocalPreview,
             idempotency_key: None,
             artifacts: Vec::new(),
             payload: serde_json::json!({}),

--- a/crates/ctx-history-core/src/lib.rs
+++ b/crates/ctx-history-core/src/lib.rs
@@ -148,13 +148,26 @@ text_enum! {
 }
 
 text_enum! {
+    /// Payload handling state.
+    ///
+    /// The serialized value `safe_preview` is legacy contract spelling for a
+    /// local searchable preview. It is not a promise that output is share-safe.
     pub enum RedactionState {
         Raw => "raw",
         Redacted => "redacted",
-        SafePreview => "safe_preview",
+        LocalPreview => "safe_preview",
         Withheld => "withheld",
     }
-    default SafePreview
+    default LocalPreview
+}
+
+impl RedactionState {
+    /// Compatibility alias for the legacy Rust API name.
+    ///
+    /// New code should prefer `LocalPreview`, which better matches the local
+    /// search contract while preserving the serialized `safe_preview` value.
+    #[allow(non_upper_case_globals)]
+    pub const SafePreview: Self = Self::LocalPreview;
 }
 
 text_enum! {
@@ -1481,7 +1494,7 @@ mod tests {
         assert_eq!(Fidelity::default(), Fidelity::Partial);
         assert_eq!(SyncState::default(), SyncState::LocalOnly);
         assert_eq!(Confidence::default(), Confidence::Unknown);
-        assert_eq!(RedactionState::default(), RedactionState::SafePreview);
+        assert_eq!(RedactionState::default(), RedactionState::LocalPreview);
         assert_eq!(
             serde_json::from_str::<CaptureProvider>("\"copilot_cli\"").unwrap(),
             CaptureProvider::CopilotCli
@@ -1509,6 +1522,20 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(outbox.sync_state, SyncState::Pending);
+    }
+
+    #[test]
+    fn safe_preview_is_legacy_local_preview_spelling() {
+        assert_eq!(RedactionState::LocalPreview.as_str(), "safe_preview");
+        assert_eq!(
+            "safe_preview".parse::<RedactionState>().unwrap(),
+            RedactionState::LocalPreview
+        );
+        assert_eq!(
+            serde_json::to_string(&RedactionState::LocalPreview).unwrap(),
+            "\"safe_preview\""
+        );
+        assert_eq!(RedactionState::SafePreview, RedactionState::LocalPreview);
     }
 
     #[test]

--- a/crates/ctx-history-store/src/lib.rs
+++ b/crates/ctx-history-store/src/lib.rs
@@ -973,6 +973,8 @@ CREATE INDEX IF NOT EXISTS idx_local_workspaces_vcs_workspace_id ON local_worksp
 CREATE INDEX IF NOT EXISTS idx_audit_log_source_id ON audit_log(source_id);
 "#;
 
+// `safe_preview_text` is legacy schema naming. It stores local searchable
+// preview text and must not be interpreted as share-safe redaction.
 const FTS_TABLES_SQL: &str = r#"
 CREATE VIRTUAL TABLE IF NOT EXISTS ctx_history_search USING fts5(
     record_id UNINDEXED,
@@ -6045,8 +6047,8 @@ mod archive_validation_tests {
             blob_hash,
             byte_size,
             media_type: Some("text/markdown".into()),
-            preview_text: Some("synthetic public-safe blob".into()),
-            redaction_state: RedactionState::SafePreview,
+            preview_text: Some("synthetic local preview blob".into()),
+            redaction_state: RedactionState::LocalPreview,
             timestamps: EntityTimestamps {
                 created_at: fixed_time(),
                 updated_at: fixed_time(),
@@ -7509,6 +7511,36 @@ mod search_order_tests {
             .with_timezone(&Utc)
     }
 
+    fn sync_metadata() -> SyncMetadata {
+        SyncMetadata {
+            visibility: Visibility::LocalOnly,
+            fidelity: Fidelity::Imported,
+            sync_state: SyncState::LocalOnly,
+            sync_version: 0,
+            deleted_at: None,
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    fn local_preview_event(seq: u64, text: &str, redaction_state: RedactionState) -> Event {
+        Event {
+            id: new_id(),
+            seq,
+            history_record_id: None,
+            session_id: None,
+            run_id: None,
+            event_type: EventType::Message,
+            role: Some(EventRole::User),
+            occurred_at: fixed_time(),
+            capture_source_id: None,
+            payload: serde_json::json!({ "text": text }),
+            payload_blob_id: None,
+            dedupe_key: None,
+            redaction_state,
+            sync: sync_metadata(),
+        }
+    }
+
     #[test]
     fn indexed_history_item_count_uses_sessions_and_events() {
         let temp = tempdir();
@@ -7655,6 +7687,46 @@ mod search_order_tests {
         assert!(store.search_records("---", 10).unwrap().is_empty());
         assert!(store.search_records("___", 10).unwrap().is_empty());
         assert!(store.search_records_page("", 10, 0).unwrap().is_empty());
+    }
+
+    #[test]
+    fn event_search_local_preview_preserves_private_text_but_raw_is_withheld() {
+        let temp = tempdir();
+        let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+        let local_event = local_preview_event(
+            1,
+            "cwd=/home/example/private token=ghp_1234567890abcdef",
+            RedactionState::LocalPreview,
+        );
+        let raw_event = local_preview_event(
+            2,
+            "raw cwd=/home/example/private token=ghp_1234567890abcdef",
+            RedactionState::Raw,
+        );
+
+        store.upsert_event(&local_event).unwrap();
+        store.upsert_event(&raw_event).unwrap();
+
+        let local_preview: String = store
+            .conn
+            .query_row(
+                "SELECT safe_preview_text FROM event_search WHERE event_id = ?1",
+                [local_event.id.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(local_preview.contains("/home/example/private"));
+        assert!(local_preview.contains("ghp_1234567890abcdef"));
+
+        let raw_preview: String = store
+            .conn
+            .query_row(
+                "SELECT safe_preview_text FROM event_search WHERE event_id = ?1",
+                [raw_event.id.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(raw_preview, "raw event payload withheld");
     }
 
     #[test]
@@ -8838,7 +8910,7 @@ mod catalog_tests {
                 payload: serde_json::json!({"text": "migration source reference"}),
                 payload_blob_id: None,
                 dedupe_key: None,
-                redaction_state: RedactionState::SafePreview,
+                redaction_state: RedactionState::LocalPreview,
                 sync: sync_metadata(),
             };
             event_id = event.id;

--- a/docs/contracts/json.md
+++ b/docs/contracts/json.md
@@ -163,6 +163,13 @@ Writes nothing and returns:
 `occurred_at`, `source`, `cursor`, `text` or `preview`, and
 `redaction_state`.
 
+`redaction_state` values describe local payload handling, not whether a row is
+safe to publish. In particular, `safe_preview` is legacy contract spelling for a
+local searchable preview: the text may be truncated or projected from provider
+payloads, but it can still include absolute paths, token-shaped strings, command
+output, and other private transcript content. Treat `safe_preview` output as
+private unless a user separately reviews and redacts it.
+
 ## Locate
 
 ```bash

--- a/docs/redaction-corpus.md
+++ b/docs/redaction-corpus.md
@@ -15,4 +15,6 @@ credentials before indexing or display. Corpus tests should cover at least:
 Passing the corpus does not make output safe to share. It proves local
 search/show/SQLite projections preserve representative transcript text so users
 and agents can find exact local history. Share-safe or shared-service redaction
-is outside the current local CLI contract.
+is outside the current local CLI contract. Rows marked
+`redaction_state: "safe_preview"` use that legacy spelling for a local searchable
+preview and must still be treated as private local history.

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -32,6 +32,8 @@ the local retrieval product.
 - Search/show/locate JSON and SQLite search projections preserve local
   transcript text by default, including absolute paths and secret-shaped
   strings. They must be treated as private local data.
+- The legacy `safe_preview` state and `safe_preview_text` columns mean local
+  searchable preview text, not share-safe redaction.
 - Unsupported providers remain explicit in the provider support matrix.
 
 ## Static Docs Checks

--- a/docs/sql.md
+++ b/docs/sql.md
@@ -61,7 +61,7 @@ are implementation details and can change between versions.
 | `role` | Event role such as `user`, `assistant`, or `tool`, when known. |
 | `occurred_at_ms` | Unix epoch milliseconds. |
 | `payload_json` | Local private event payload. |
-| `redaction_state` | Payload redaction/preview state. |
+| `redaction_state` | Local payload handling state. `safe_preview` is legacy spelling for a local searchable preview, not share-safe redaction. |
 | `fidelity` | Import fidelity. |
 | `cwd`, `source_path` | Captured source context, when known. |
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -219,6 +219,9 @@ not remove provider-owned history such as `~/.codex/sessions`.
 No local search index can be considered share-safe by default. Indexed prompts,
 code, commands, file paths, and output previews may contain credentials,
 customer data, private repository names, or proprietary design notes.
+The persisted `safe_preview` redaction state and `safe_preview_text` search
+columns are legacy local-index names for searchable previews; they do not mean
+the stored text has been redacted for sharing.
 
 Recommended handling:
 


### PR DESCRIPTION
## Summary

- Rename Rust code paths to LocalPreview while preserving the serialized/storage value `safe_preview` for compatibility.
- Rename capture preview helpers from safe-preview wording to local-preview wording.
- Document that `safe_preview` / `safe_preview_text` are local searchable previews, not share-safe redaction.

## Tests

- `cargo test -p ctx-history-core safe_preview_is_legacy_local_preview_spelling`
- `cargo test -p ctx-history-store event_search_local_preview_preserves_private_text_but_raw_is_withheld`
- `cargo check -p ctx-history-search -p ctx`
- `bash scripts/check-docs.sh`
- `git diff --check`
