### PR TITLE
Require search intent in SDKs

### DIFF
--- a/contracts/agent-history-v1/README.md
+++ b/contracts/agent-history-v1/README.md
@@ -70,7 +70,7 @@ them into `agent-history-v1` wrappers:
 - `ctx setup --json`
 - `ctx sources --json`
 - `ctx import --json`
-- `ctx search ... --json`
+- `ctx search <query>|--term <term>|--file <path> --json`
 - `ctx show event ... --format json`
 - `ctx show session ... --format json`
 - `ctx locate event ... --format json`

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -2885,7 +2885,7 @@ fn error_summary(error: &anyhow::Error) -> String {
         .map(ToString::to_string)
         .unwrap_or_else(|| top.clone());
     if is_sqlite_busy_text(&top) || is_sqlite_busy_text(&root) {
-        return "ctx index is busy because another ctx import or search refresh is writing to the local database; retry in a moment, or use `ctx search --refresh off` to search the existing index".to_owned();
+        return "ctx index is busy because another ctx import or search refresh is writing to the local database; retry in a moment, or rerun the search with `--refresh off` to use the existing index".to_owned();
     }
     if root == top || top.contains(&root) {
         top
@@ -3355,14 +3355,14 @@ fn push_session_metadata_markdown(
 fn resolve_session_by_id_text(store: &Store, value: &str) -> Result<Session> {
     if let Ok(id) = Uuid::parse_str(value.trim()) {
         return store.get_session(id).with_context(|| {
-            format!("session {id} was not found; use `ctx search --verbose` to get ctx_session_id")
+            format!("session {id} was not found; rerun the search that found it with `--verbose` to get ctx_session_id")
         });
     }
     let prefix = normalize_uuid_prefix(value, "session")?;
     match store.sessions_by_id_prefix(&prefix)?.as_slice() {
         [session] => Ok(session.clone()),
         [] => Err(anyhow!(
-            "session id prefix {prefix:?} was not found; use `ctx search --verbose` to get ctx_session_id"
+            "session id prefix {prefix:?} was not found; rerun the search that found it with `--verbose` to get ctx_session_id"
         )),
         matches => Err(anyhow!(
             "session id prefix {prefix:?} is ambiguous; first matches are {} and {}; use a longer ctx_session_id",
@@ -3380,7 +3380,7 @@ fn resolve_event(store: &Store, value: &str) -> Result<Event> {
     if let Ok(id) = Uuid::parse_str(value.trim()) {
         return store.get_event(id).with_context(|| {
             format!(
-                "event {id} was not found; use `ctx search --events --verbose` to get ctx_event_id"
+                "event {id} was not found; rerun the event search with `--events --verbose` to get ctx_event_id"
             )
         });
     }
@@ -3388,7 +3388,7 @@ fn resolve_event(store: &Store, value: &str) -> Result<Event> {
     match store.events_by_id_prefix(&prefix)?.as_slice() {
         [event] => Ok(event.clone()),
         [] => Err(anyhow!(
-            "event id prefix {prefix:?} was not found; use `ctx search --events --verbose` to get ctx_event_id"
+            "event id prefix {prefix:?} was not found; rerun the event search with `--events --verbose` to get ctx_event_id"
         )),
         matches => Err(anyhow!(
             "event id prefix {prefix:?} is ambiguous; first matches are {} and {}; use a longer ctx_event_id",
@@ -3407,7 +3407,7 @@ fn normalize_uuid_prefix(value: &str, kind: &str) -> Result<String> {
     }
     if prefix.contains('-') || !prefix.chars().all(|ch| ch.is_ascii_hexdigit()) {
         return Err(anyhow!(
-            "{kind} id must be a full ctx UUID or an unambiguous hex prefix from `ctx search --verbose`"
+            "{kind} id must be a full ctx UUID or an unambiguous hex prefix from verbose search output"
         ));
     }
     Ok(prefix.to_ascii_lowercase())
@@ -4492,7 +4492,7 @@ fn run_search(
                 if indexed_items == 0 {
                     println!("next: ctx import --all");
                 } else {
-                    println!("next: try broader terms with ctx search --term");
+                    println!("next: try broader terms with ctx search --term \"<term>\"");
                 }
             }
         }
@@ -4665,7 +4665,7 @@ fn refresh_before_search(args: &SearchArgs, data_root: &Path) -> Result<SearchRe
     if sources.is_empty() && plugin_sources.is_empty() {
         if args.refresh == RefreshArg::Strict {
             return Err(anyhow!(
-                "strict search refresh found no supported discovered native provider or enabled auto history-source plugin sources; use --refresh off to search the existing index"
+                "strict search refresh found no supported discovered native provider or enabled auto history-source plugin sources; rerun the search with --refresh off to use the existing index"
             ));
         }
         return Ok(SearchRefreshReport::skipped(args.refresh, "no_sources"));

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -6147,7 +6147,7 @@ fn human_search_reports_no_results() {
         .clone();
     let indexed = String::from_utf8(indexed).unwrap();
     assert!(indexed.contains("no results for definitely-no-results-here"));
-    assert!(indexed.contains("next: try broader terms with ctx search --term"));
+    assert!(indexed.contains("next: try broader terms with ctx search --term \"<term>\""));
 
     let term_only = ctx(&temp)
         .args(["search", "--term", "term-only-no-results"])

--- a/crates/ctx-sdk/src/lib.rs
+++ b/crates/ctx-sdk/src/lib.rs
@@ -115,6 +115,21 @@ impl Default for SearchOptions {
     }
 }
 
+impl SearchOptions {
+    fn has_intent(&self) -> bool {
+        self.query
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|query| !query.is_empty())
+            || self.terms.iter().any(|term| !term.trim().is_empty())
+            || self
+                .file
+                .as_ref()
+                .map(|path| !path.to_string_lossy().trim().is_empty())
+                .unwrap_or(false)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SearchRefresh {
     Auto,
@@ -215,6 +230,13 @@ impl AgentHistoryClient {
         &self,
         options: SearchOptions,
     ) -> Result<AgentHistoryEnvelope, AgentHistoryError> {
+        if !options.has_intent() {
+            return Err(AgentHistoryError::new(
+                AgentHistoryErrorCode::InvalidRequest,
+                "search requires a query, term, or file option",
+                false,
+            ));
+        }
         let mut owned = Vec::<String>::new();
         owned.push("search".to_owned());
         if let Some(query) = options.query {
@@ -673,6 +695,31 @@ mod tests {
         };
         assert_eq!(options.refresh.as_arg(), "off");
         assert_eq!(options.terms, vec!["ctx"]);
+    }
+
+    #[test]
+    fn search_requires_query_term_or_file_before_cli() {
+        let client = AgentHistoryClient::local(LocalBackendConfig {
+            ctx_binary: PathBuf::from("/definitely/missing/ctx"),
+            data_root: None,
+            timeout: Duration::from_secs(1),
+        });
+
+        for options in [
+            SearchOptions::default(),
+            SearchOptions {
+                refresh: SearchRefresh::Off,
+                ..SearchOptions::default()
+            },
+            SearchOptions {
+                query: Some("   ".to_owned()),
+                terms: vec!["".to_owned(), "   ".to_owned()],
+                ..SearchOptions::default()
+            },
+        ] {
+            let err = client.search(options).unwrap_err();
+            assert_eq!(err.body.code, AgentHistoryErrorCode::InvalidRequest);
+        }
     }
 
     #[test]

--- a/docs/agent-usage.md
+++ b/docs/agent-usage.md
@@ -18,9 +18,9 @@ ctx show event <ctx-event-id> --window 5
 ```
 
 Normal `ctx search` uses `--refresh auto`, which can import newly discovered
-provider history into the local ctx index before querying. Use
-`ctx search ... --refresh off` when the task requires a strictly read-only
-query over the existing index.
+provider history into the local ctx index before querying. Rerun the same
+search with `--refresh off` when the task requires a strictly read-only query
+over the existing index.
 
 Use `ctx sql` only when normal search does not express the question, such as
 exact counts, joins, audits, or scripting over stable `ctx_*` views. It is

--- a/docs/contracts/json.md
+++ b/docs/contracts/json.md
@@ -256,7 +256,7 @@ external publication.
 - `error`, present when refresh failed but results were still served.
 
 `suggested_next_commands` can include `ctx show event`, `ctx show session`,
-`ctx search ... --session <ctx-session-id>`, `ctx locate event`, and
+`ctx search "<query>" --session <ctx-session-id>`, `ctx locate event`, and
 `ctx locate session` command strings when the required ctx IDs are known.
 
 When ctx can identify the active Codex provider session through

--- a/docs/search.md
+++ b/docs/search.md
@@ -135,9 +135,10 @@ only retrieves indexed local evidence; it does not synthesize conclusions.
 
 ## Machine Output
 
-Use default text output for agent reading. Use `ctx search --json` for scripts,
-`jq`, or exact field extraction. JSON results include the same result metadata
-and citations as the human output, plus a top-level `freshness` object
+Use default text output for agent reading. Use `ctx search <query> --json` or a
+term/file search with `--json` for scripts, `jq`, or exact field extraction.
+JSON results include the same result metadata and citations as the human output,
+plus a top-level `freshness` object
 describing the pre-search refresh mode and outcome. A citation with
 `source_exists: false` means ctx can return indexed text, but the raw provider
 file was not available at the stored path when the result was built.

--- a/plugins/ctx-agent-history-search/skills/ctx-agent-history-search/SKILL.md
+++ b/plugins/ctx-agent-history-search/skills/ctx-agent-history-search/SKILL.md
@@ -63,9 +63,9 @@ Use this skill in two modes:
 
    When the prompt asks for a topic history or report across multiple sessions,
    run several `ctx search` queries with different wording and filters to find
-   promising sessions. Use scoped `ctx search ... --session <ctx-session-id>`
-   when a session looks relevant and you need dense event-level matches from
-   that session.
+   promising sessions. Use scoped
+   `ctx search "<query>" --session <ctx-session-id>` when a session looks
+   relevant and you need dense event-level matches from that session.
 
    Default search returns primary-agent sessions so human intent and decisions
    stay prominent. Use `--include-subagents` when implementation details, code
@@ -144,7 +144,7 @@ material.
    chronology, alternatives, or detailed evidence.
 2. Run several targeted searches. Vary query terms across user wording, file or
    module names, error text, commands, branch names, and decision terms. Start
-   with default `ctx search`, then broaden with `--term` or narrow with
+   with `ctx search "<topic>"`, then broaden with `--term` or narrow with
    `--workspace`, `--provider`, `--file`, `--since`, or
    `--session <ctx-session-id>`.
    Use `--include-subagents` when reviews, implementation attempts, test output,

--- a/sdks/dotnet/README.md
+++ b/sdks/dotnet/README.md
@@ -81,7 +81,7 @@ future fields remain additive and accessible. SDK failures derive from
 - `ctx setup --json`
 - `ctx sources --json`
 - `ctx import --json`
-- `ctx search ... --json`
+- `ctx search <query>|--term <term>|--file <path> --json`
 - `ctx show event ... --format json`
 - `ctx show session ... --format json`
 - `ctx locate event ... --format json`

--- a/sdks/dotnet/src/Ctx.AgentHistory/AgentHistoryClient.cs
+++ b/sdks/dotnet/src/Ctx.AgentHistory/AgentHistoryClient.cs
@@ -71,6 +71,7 @@ public sealed class AgentHistoryClient
     public async Task<SearchResponse> SearchAsync(SearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         options ??= new SearchOptions();
+        RequireSearchIntent(options);
         var args = new List<string> { "search" };
         if (!string.IsNullOrWhiteSpace(options.Query))
         {
@@ -250,6 +251,18 @@ public sealed class AgentHistoryClient
             throw new CtxAgentHistoryValidationException($"{kind} lookup requires an id or provider session id");
         }
         return args;
+    }
+
+    private static void RequireSearchIntent(SearchOptions options)
+    {
+        if (!string.IsNullOrWhiteSpace(options.Query)
+            || !string.IsNullOrWhiteSpace(options.File)
+            || (options.Terms?.Any(term => !string.IsNullOrWhiteSpace(term)) ?? false))
+        {
+            return;
+        }
+
+        throw new CtxAgentHistoryValidationException("search requires a query, term, or file option");
     }
 
     private static void RequireValue(string value, string name)

--- a/sdks/dotnet/tests/Ctx.AgentHistory.Tests/Program.cs
+++ b/sdks/dotnet/tests/Ctx.AgentHistory.Tests/Program.cs
@@ -12,6 +12,7 @@ internal static class Program
             ("builds local CLI operation arguments", BuildsOperationArguments),
             ("normalizes setup init status", NormalizesSetupInitStatus),
             ("builds search flags", BuildsSearchFlags),
+            ("rejects search without intent", RejectsSearchWithoutIntent),
             ("wraps show and locate commands", WrapsShowAndLocate),
             ("reports versioning metadata", ReportsVersioning),
             ("uses agent-history-v1 error codes", UsesAgentHistoryV1ErrorCodes),
@@ -127,6 +128,25 @@ internal static class Program
         Equal("off", response.Search.Freshness!.Mode ?? "");
     }
 
+    private static async Task RejectsSearchWithoutIntent()
+    {
+        var transport = new RecordingTransport("""{"schema_version":1,"results":[]}""");
+        var client = new AgentHistoryClient(transport);
+
+        await ThrowsAsync<CtxAgentHistoryValidationException>(() => client.SearchAsync());
+        await ThrowsAsync<CtxAgentHistoryValidationException>(() => client.SearchAsync(new SearchOptions
+        {
+            Refresh = "off",
+            Limit = 5
+        }));
+        await ThrowsAsync<CtxAgentHistoryValidationException>(() => client.SearchAsync(new SearchOptions
+        {
+            Query = "   "
+        }));
+
+        Equal(0, transport.Calls.Count);
+    }
+
     private static async Task WrapsShowAndLocate()
     {
         var transport = new RecordingTransport("""{"schema_version":1,"events":[],"source":{"path":"/tmp/source.jsonl"},"ctx_session_id":"session-1","provider":"codex"}""");
@@ -227,7 +247,7 @@ internal static class Program
                     }
                     break;
                 case "search":
-                    _ = (await ClientFor(node["search"]).SearchAsync()).Search.Results;
+                    _ = (await ClientFor(node["search"]).SearchAsync(new SearchOptions { Query = "fixture search" })).Search.Results;
                     break;
                 case "showEvent":
                     _ = (await ClientFor(node["event"]).ShowEventAsync("event-1")).Event.Events;

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -58,8 +58,9 @@ client := ctxagenthistory.NewLocalClient(
 ```
 
 The adapter runs JSON-producing CLI commands such as `ctx status --json`,
-`ctx search --json`, and `ctx show event --format json`, then normalizes CLI
-JSON into `agent-history-v1` wrappers with `contractVersion` and `schemaVersion`.
+`ctx search <query>|--term <term>|--file <path> --json`, and
+`ctx show event --format json`, then normalizes CLI JSON into
+`agent-history-v1` wrappers with `contractVersion` and `schemaVersion`.
 
 ## Errors
 

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // Operation is the adapter-neutral command executed by a transport.
@@ -156,6 +157,9 @@ func (c *Client) Sync(ctx context.Context, opts ImportOptions) (*ImportResponse,
 }
 
 func (c *Client) Search(ctx context.Context, opts SearchOptions) (*SearchResponse, error) {
+	if !opts.hasIntent() {
+		return nil, sdkError(ErrorKindInvalidArgument, "search requires a query, term, or file option", nil)
+	}
 	args := []string{"search"}
 	if opts.Query != "" {
 		args = append(args, opts.Query)
@@ -196,6 +200,18 @@ func (c *Client) Search(ctx context.Context, opts SearchOptions) (*SearchRespons
 		return nil, err
 	}
 	return &out, nil
+}
+
+func (opts SearchOptions) hasIntent() bool {
+	if strings.TrimSpace(opts.Query) != "" || strings.TrimSpace(opts.File) != "" {
+		return true
+	}
+	for _, term := range opts.Terms {
+		if strings.TrimSpace(term) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) ShowSession(ctx context.Context, opts ShowSessionOptions) (*ShowSessionResponse, error) {

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -91,6 +91,27 @@ func TestSearchBuildsAgentHistoryV1Operation(t *testing.T) {
 	}
 }
 
+func TestSearchRequiresQueryTermOrFileBeforeTransport(t *testing.T) {
+	transport := &recordingTransport{response: `{"schema_version":1,"results":[]}`}
+	client := NewClient(WithTransport(transport))
+
+	for name, opts := range map[string]SearchOptions{
+		"empty":        {},
+		"filters only": {Refresh: "off", Limit: 5},
+		"blank query":  {Query: "   "},
+		"blank terms":  {Terms: []string{"", "   "}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := client.Search(context.Background(), opts); !IsErrorKind(err, ErrorKindInvalidArgument) {
+				t.Fatalf("Search error kind mismatch: %v", err)
+			}
+		})
+	}
+	if transport.op.Args != nil {
+		t.Fatalf("Search invoked transport despite invalid input: %#v", transport.op.Args)
+	}
+}
+
 func TestShowAndLocateValidateRequiredEventID(t *testing.T) {
 	client := NewClient(WithTransport(fakeTransport{response: `{}`}))
 	if _, err := client.ShowEvent(context.Background(), ShowEventOptions{}); !IsErrorKind(err, ErrorKindInvalidArgument) {

--- a/sdks/jvm/src/main/java/rs/ctx/agenthistory/AgentHistoryClient.java
+++ b/sdks/jvm/src/main/java/rs/ctx/agenthistory/AgentHistoryClient.java
@@ -84,6 +84,7 @@ public class AgentHistoryClient {
 
     public SearchResponse search(AgentHistoryOptions.Search options) {
         AgentHistoryOptions.Search safe = options == null ? AgentHistoryOptions.search() : options;
+        requireSearchIntent(safe);
         List<String> args = new ArrayList<>();
         args.add("search");
         if (safe.query() != null && !safe.query().isEmpty()) {
@@ -110,6 +111,18 @@ public class AgentHistoryClient {
         if (safe.events()) args.add("--events");
         if (safe.includeCurrentSession()) args.add("--include-current-session");
         return new SearchResponse(executeEnvelope("search", args));
+    }
+
+    private static void requireSearchIntent(AgentHistoryOptions.Search options) {
+        if (hasText(options.query()) || hasText(options.file())) {
+            return;
+        }
+        for (String term : options.terms()) {
+            if (hasText(term)) {
+                return;
+            }
+        }
+        throw new CtxAgentHistoryException.Validation("search requires a query, term, or file option");
     }
 
     public ShowEventResponse showEvent(String id, AgentHistoryOptions.ShowEvent options) {
@@ -232,6 +245,10 @@ public class AgentHistoryClient {
             args.add(flag);
             args.add(value);
         }
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
     }
 
     private static void addInt(List<String> args, String flag, Integer value) {

--- a/sdks/jvm/src/test/java/rs/ctx/agenthistory/AgentHistoryClientTest.java
+++ b/sdks/jvm/src/test/java/rs/ctx/agenthistory/AgentHistoryClientTest.java
@@ -15,6 +15,7 @@ public final class AgentHistoryClientTest {
         decodesAllCanonicalFixturesThroughTypedResponses();
         normalizesRawShowAndLocateResponses();
         buildsSearchCommand();
+        searchRequiresIntent();
         hostedIsExplicitlyUnsupported();
     }
 
@@ -173,6 +174,21 @@ public final class AgentHistoryClientTest {
         assertContainsInOrder(transport.lastOperation.args(), "--refresh", "off");
     }
 
+    private static void searchRequiresIntent() {
+        FakeTransport transport = new FakeTransport(
+                "local-cli",
+                "{\"schema_version\":1,\"query\":\"client\",\"results\":[]}");
+        AgentHistoryClient client = AgentHistoryClient.withTransport(transport);
+
+        assertValidation(() -> client.search());
+        assertValidation(() -> client.search(AgentHistoryOptions.search().refresh("off").limit(5)));
+        assertValidation(() -> client.search("   "));
+        assertValidation(() -> client.search(AgentHistoryOptions.search().term("   ")));
+        if (transport.lastOperation != null) {
+            throw new AssertionError("invalid search invoked transport: " + transport.lastOperation.args());
+        }
+    }
+
     private static void hostedIsExplicitlyUnsupported() {
         AgentHistoryClient client = AgentHistoryClient.hosted(HostedConfig.builder().baseUrl("https://ctx.example.invalid").build());
         try {
@@ -212,6 +228,16 @@ public final class AgentHistoryClientTest {
         if (want == null ? got != null : !want.equals(got)) {
             throw new AssertionError("want " + want + " got " + got);
         }
+    }
+
+    private static void assertValidation(Runnable action) {
+        try {
+            action.run();
+        } catch (CtxAgentHistoryException.Validation error) {
+            assertEquals("invalid_request", error.code());
+            return;
+        }
+        throw new AssertionError("expected validation error");
     }
 
     private static final class FakeTransport implements AgentHistoryTransport {

--- a/sdks/python/src/ctx_agent_history/__init__.py
+++ b/sdks/python/src/ctx_agent_history/__init__.py
@@ -7,6 +7,7 @@ from .errors import (
     CtxAgentHistoryError,
     CtxAgentHistoryProtocolError,
     CtxAgentHistoryTimeoutError,
+    CtxAgentHistoryValidationError,
     HostedTransportNotImplementedError,
 )
 from .types import (
@@ -35,6 +36,7 @@ __all__ = [
     "CtxAgentHistoryError",
     "CtxAgentHistoryProtocolError",
     "CtxAgentHistoryTimeoutError",
+    "CtxAgentHistoryValidationError",
     "ErrorResponse",
     "HostedConfig",
     "HostedTransportNotImplementedError",

--- a/sdks/python/src/ctx_agent_history/client.py
+++ b/sdks/python/src/ctx_agent_history/client.py
@@ -20,6 +20,7 @@ from .types import (
     StatusResponse,
     SyncResponse,
 )
+from .validation import validate_search_intent
 from .version import API_VERSION, SDK_VERSION, VersionInfo
 
 Pathish = Union[str, Path]
@@ -134,13 +135,15 @@ class AgentHistoryClient:
         refresh: Optional[str] = None,
         include_current_session: bool = False,
     ) -> SearchResponse:
+        file_value = str(file) if file is not None else None
+        validate_search_intent(query=query, terms=terms, file=file_value)
         return self._transport.search(
             query=query,
             provider=provider,
             workspace=workspace,
             since=since,
             event_type=event_type,
-            file=str(file) if file is not None else None,
+            file=file_value,
             session=session,
             terms=list(terms) if terms is not None else None,
             events=events,

--- a/sdks/python/src/ctx_agent_history/errors.py
+++ b/sdks/python/src/ctx_agent_history/errors.py
@@ -84,6 +84,25 @@ class CtxAgentHistoryProtocolError(CtxAgentHistoryError):
         )
 
 
+class CtxAgentHistoryValidationError(CtxAgentHistoryError):
+    """Raised before invoking ctx for invalid SDK input."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        details: Optional[Mapping[str, Any]] = None,
+        cause: Optional[BaseException] = None,
+    ) -> None:
+        super().__init__(
+            message,
+            code="invalid_request",
+            details=details,
+            retryable=False,
+            cause=cause,
+        )
+
+
 class CtxAgentHistoryTimeoutError(CtxAgentHistoryError):
     """Raised when the local ctx CLI exceeds the configured timeout."""
 

--- a/sdks/python/src/ctx_agent_history/transport.py
+++ b/sdks/python/src/ctx_agent_history/transport.py
@@ -40,6 +40,7 @@ from .types import (
     StatusResponse,
     SyncResponse,
 )
+from .validation import validate_search_intent
 
 
 class AgentHistoryTransport(Protocol):
@@ -235,6 +236,7 @@ class LocalCliAdapter:
         refresh: Optional[str] = None,
         include_current_session: bool = False,
     ) -> SearchResponse:
+        validate_search_intent(query=query, terms=terms, file=file)
         args = ["search", "--json"]
         if query is not None:
             args.append(query)

--- a/sdks/python/src/ctx_agent_history/validation.py
+++ b/sdks/python/src/ctx_agent_history/validation.py
@@ -1,0 +1,41 @@
+"""SDK input validation helpers."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from .errors import CtxAgentHistoryValidationError
+
+
+def validate_search_intent(
+    *,
+    query: Optional[str],
+    terms: Optional[Sequence[str]],
+    file: Optional[str],
+) -> None:
+    if _has_text(query) or _has_text(file) or _has_term(terms):
+        return
+    raise CtxAgentHistoryValidationError(
+        "search requires a query, term, or file option",
+        details={"query": query, "terms": _term_details(terms), "file": file},
+    )
+
+
+def _has_term(terms: Optional[Sequence[str]]) -> bool:
+    if terms is None:
+        return False
+    if isinstance(terms, str):
+        return _has_text(terms)
+    return any(_has_text(term) for term in terms)
+
+
+def _has_text(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _term_details(terms: Optional[Sequence[str]]) -> list[str]:
+    if terms is None:
+        return []
+    if isinstance(terms, str):
+        return [terms]
+    return list(terms)

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -22,7 +22,7 @@ from ctx_agent_history import (
     AgentHistoryClient,
 )
 from ctx_agent_history.errors import CtxAgentHistoryCliError, CtxAgentHistoryProtocolError
-from ctx_agent_history.errors import CtxAgentHistoryTimeoutError
+from ctx_agent_history.errors import CtxAgentHistoryTimeoutError, CtxAgentHistoryValidationError
 from ctx_agent_history.types import AgentHistoryErrorCode
 import dogfood_local
 
@@ -98,6 +98,20 @@ class LocalCliAdapterTests(unittest.TestCase):
             self.assertEqual(client.locateEvent("event-1")["operation"], "locateEvent")
             self.assertEqual(client.locate_session("session-1")["operation"], "locateSession")
             self.assertEqual(client.locateSession("session-1")["operation"], "locateSession")
+
+    def test_search_requires_query_term_or_file_before_cli(self) -> None:
+        with fake_ctx(fail=True) as cli:
+            client = AgentHistoryClient.local(ctx_binary=str(cli))
+
+            for call in (
+                lambda: client.search(),
+                lambda: client.search(refresh="off", limit=5),
+                lambda: client.search("   "),
+            ):
+                with self.subTest(call=call):
+                    with self.assertRaises(CtxAgentHistoryValidationError) as raised:
+                        call()
+                    self.assertEqual(raised.exception.code, "invalid_request")
 
     def test_versioning_reports_sdk_api_transport_and_ctx_version(self) -> None:
         with fake_ctx() as cli:

--- a/sdks/swift/Sources/CtxAgentHistory/AgentHistoryClient.swift
+++ b/sdks/swift/Sources/CtxAgentHistory/AgentHistoryClient.swift
@@ -70,6 +70,7 @@ public struct AgentHistoryClient: Sendable {
     }
 
     public func search(_ query: String? = nil, options: SearchOptions = SearchOptions()) throws -> SearchResponse {
+        try requireSearchIntent(query: query, options: options)
         var arguments = ["search"]
         if let query {
             arguments.append(query)
@@ -291,6 +292,23 @@ private func appendOption(_ arguments: inout [String], _ name: String, _ value: 
     if let value, !value.isEmpty {
         arguments.append(contentsOf: [name, value])
     }
+}
+
+private func requireSearchIntent(query: String?, options: SearchOptions) throws {
+    if hasSearchText(query) || hasSearchText(options.file) || options.terms.contains(where: { hasSearchText($0) }) {
+        return
+    }
+    throw CtxAgentHistorySDKError(
+        code: .invalidRequest,
+        message: "search requires a query, term, or file option"
+    )
+}
+
+private func hasSearchText(_ value: String?) -> Bool {
+    guard let value else {
+        return false
+    }
+    return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 }
 
 private func requireID(_ name: String, _ id: String) throws {

--- a/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
+++ b/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
@@ -188,6 +188,12 @@ final class CtxAgentHistoryTests: XCTestCase {
         XCTAssertThrowsError(try parse.showSession(ShowSessionOptions(provider: "codex"))) { error in
             XCTAssertEqual((error as? CtxAgentHistorySDKError)?.code, .invalidRequest)
         }
+        XCTAssertThrowsError(try parse.search(options: SearchOptions(refresh: "off"))) { error in
+            XCTAssertEqual((error as? CtxAgentHistorySDKError)?.code, .invalidRequest)
+        }
+        XCTAssertThrowsError(try parse.search("   ")) { error in
+            XCTAssertEqual((error as? CtxAgentHistorySDKError)?.code, .invalidRequest)
+        }
     }
 
     func testAllStructuredErrorCodesRoundTripThroughContractError() throws {

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -22,7 +22,7 @@ const results = await client.search("sqlite storage", { refresh: "off" });
 - `import(options)` wraps `ctx import --json`.
 - `sync(options)` is an alias for `import(options)`.
 - `search(query, options)` and file/term-based `search(options)` wrap
-  `ctx search --json`.
+  `ctx search <query>|--term <term>|--file <path> --json`.
 - `showEvent(id, { before, after, window })` wraps `ctx show event --format json`.
 - `showSession(id, { mode })` wraps `ctx show session --format json`.
 - `showSession({ provider, providerSession, mode })` looks up by provider-owned session ID.

--- a/sdks/typescript/src/index.d.ts
+++ b/sdks/typescript/src/index.d.ts
@@ -91,6 +91,13 @@ export interface SearchOptions {
   includeCurrentSession?: boolean;
 }
 
+export type SearchIntentOptions = SearchOptions & (
+  | { query: string }
+  | { term: string | string[] }
+  | { terms: [string, ...string[]] }
+  | { file: string }
+);
+
 export interface ShowEventOptions {
   before?: number;
   after?: number;
@@ -408,8 +415,8 @@ export declare class LocalAgentHistoryClient {
   sources(): Promise<SourcesEnvelope>;
   import(options?: ImportOptions): Promise<ImportEnvelope<"import">>;
   sync(options?: ImportOptions): Promise<ImportEnvelope<"sync">>;
-  search(query?: string, options?: SearchOptions): Promise<SearchEnvelope>;
-  search(options?: SearchOptions): Promise<SearchEnvelope>;
+  search(query: string, options?: Omit<SearchOptions, "query">): Promise<SearchEnvelope>;
+  search(options: SearchIntentOptions): Promise<SearchEnvelope>;
   showEvent(id: string, options?: ShowEventOptions): Promise<ShowEventEnvelope>;
   showSession(id: string, options?: Omit<ShowSessionOptions, "id">): Promise<ShowSessionEnvelope>;
   showSession(options: ShowSessionOptions): Promise<ShowSessionEnvelope>;

--- a/sdks/typescript/src/index.js
+++ b/sdks/typescript/src/index.js
@@ -163,6 +163,7 @@ export class LocalAgentHistoryClient {
       typeof queryOrOptions === "string"
         ? { ...maybeOptions, query: queryOrOptions }
         : { ...queryOrOptions };
+    validateSearchIntent(options);
     const args = ["search"];
     if (options.query) {
       args.push(options.query);
@@ -429,6 +430,27 @@ function appendSearchArgs(args, options) {
   appendFlag(args, "--events", options.events);
   appendOptional(args, "--refresh", options.refresh);
   appendFlag(args, "--include-current-session", options.includeCurrentSession);
+}
+
+function validateSearchIntent(options) {
+  if (hasSearchText(options.query) || hasSearchText(options.file) || hasSearchTerm(options)) {
+    return;
+  }
+  throw new CtxValidationError("search requires a query, term, or file option", {
+    details: { options },
+  });
+}
+
+function hasSearchTerm(options) {
+  const value = options.terms ?? options.term;
+  if (Array.isArray(value)) {
+    return value.some(hasSearchText);
+  }
+  return hasSearchText(value);
+}
+
+function hasSearchText(value) {
+  return typeof value === "string" && value.trim().length > 0;
 }
 
 function appendSessionLookupArgs(args, options) {

--- a/sdks/typescript/test/client.test.js
+++ b/sdks/typescript/test/client.test.js
@@ -178,6 +178,18 @@ test("builds search flags and normalizes nested CLI search output", async () => 
   ]);
 });
 
+test("rejects search without query, term, or file before invoking CLI", async () => {
+  const { client, calls } = mockClient(() => {
+    throw new Error("runner should not be called");
+  });
+
+  await assert.rejects(() => client.search(), CtxValidationError);
+  await assert.rejects(() => client.search({ refresh: "off", limit: 5 }), CtxValidationError);
+  await assert.rejects(() => client.search("   "), CtxValidationError);
+
+  assert.equal(calls.length, 0);
+});
+
 test("wraps show and locate commands by ctx id and provider session id", async () => {
   const { client, calls } = mockClient(() => "{}");
 

--- a/sdks/typescript/test/types.test.ts
+++ b/sdks/typescript/test/types.test.ts
@@ -44,6 +44,15 @@ expectType<string | null | undefined>(search.search.results[0]!.ctxEventId);
 // @ts-expect-error search results expose ctxEventId, not ctx_event_id.
 search.search.results[0]!.ctx_event_id;
 
+const termSearch = await client.search({ terms: ["local agent history"], refresh: "off" });
+expectType<SearchEnvelope>(termSearch);
+const fileSearch = await client.search({ file: "src/lib.rs", refresh: "off" });
+expectType<SearchEnvelope>(fileSearch);
+// @ts-expect-error search requires a query, term, or file option.
+await client.search();
+// @ts-expect-error search filters alone are not a search intent.
+await client.search({ refresh: "off", limit: 5 });
+
 const shown = await client.showEvent("11111111-1111-4111-8111-111111111111");
 expectType<ShowEventEnvelope>(shown);
 expectType<string | null | undefined>(shown.event.events[0]!.ctxSessionId);

--- a/skills/ctx-agent-history-search/SKILL.md
+++ b/skills/ctx-agent-history-search/SKILL.md
@@ -63,9 +63,9 @@ Use this skill in two modes:
 
    When the prompt asks for a topic history or report across multiple sessions,
    run several `ctx search` queries with different wording and filters to find
-   promising sessions. Use scoped `ctx search ... --session <ctx-session-id>`
-   when a session looks relevant and you need dense event-level matches from
-   that session.
+   promising sessions. Use scoped
+   `ctx search "<query>" --session <ctx-session-id>` when a session looks
+   relevant and you need dense event-level matches from that session.
 
    Default search returns primary-agent sessions so human intent and decisions
    stay prominent. Use `--include-subagents` when implementation details, code
@@ -144,7 +144,7 @@ material.
    chronology, alternatives, or detailed evidence.
 2. Run several targeted searches. Vary query terms across user wording, file or
    module names, error text, commands, branch names, and decision terms. Start
-   with default `ctx search`, then broaden with `--term` or narrow with
+   with `ctx search "<topic>"`, then broaden with `--term` or narrow with
    `--workspace`, `--provider`, `--file`, `--since`, or
    `--session <ctx-session-id>`.
    Use `--include-subagents` when reviews, implementation attempts, test output,


### PR DESCRIPTION
## Summary

- Validate SDK search intent locally before invoking ctx across TypeScript, Python, Go, Swift, .NET, JVM, and Rust SDKs.
- Update SDK types/tests so filters-only or blank searches fail as invalid_request.
- Fix docs/help/skill examples that implied bare `ctx search` or bare `ctx search --json/--refresh off` was valid.

## Tests

- `npm test --prefix sdks/typescript`
- `python3 -m unittest discover -s tests` in `sdks/python`
- `go test ./...` in `sdks/go`
- `sdks/jvm/scripts/test`
- `dotnet run --project sdks/dotnet/tests/Ctx.AgentHistory.Tests/Ctx.AgentHistory.Tests.csproj`
- `swift test` in `sdks/swift`
- `cargo test -p ctx-sdk`
- `cargo test -p ctx --test cli human_search_reports_no_results`
- `scripts/check-docs.sh`
- `git diff --check`
- `rg` check for invalid bare search examples
