### PR TITLE
fix(cli): prevent overflow panic in --since parsing

### DIFF
--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -6414,7 +6414,12 @@ fn parse_since_filter(value: &str) -> Result<chrono::DateTime<Utc>> {
         let days: i64 = days
             .parse()
             .with_context(|| format!("invalid --since day window: {value}"))?;
-        return Ok(utc_now() - Duration::days(days));
+        let duration =
+            Duration::try_days(days).ok_or_else(|| anyhow!("invalid --since day window: {value}: value too large"))?;
+        let since = utc_now()
+            .checked_sub_signed(duration)
+            .ok_or_else(|| anyhow!("invalid --since day window: {value}: value too large"))?;
+        return Ok(since);
     }
     Ok(chrono::DateTime::parse_from_rfc3339(trimmed)
         .with_context(|| format!("invalid --since value: {value}"))?
@@ -6443,7 +6448,7 @@ fn home_dir() -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{catalog_import_checkpoint_matches, sha256_file_prefix_hex, shell_quote_arg};
+    use super::{catalog_import_checkpoint_matches, parse_since_filter, sha256_file_prefix_hex, shell_quote_arg};
     use std::{fs, io::Write};
     use tempfile::tempdir;
 
@@ -6453,6 +6458,16 @@ mod tests {
         assert_eq!(
             shell_quote_arg("$(touch /tmp/ctx-owned)'s"),
             "'$(touch /tmp/ctx-owned)'\\''s'"
+        );
+    }
+
+    #[test]
+    fn parse_since_filter_rejects_large_day_window() {
+        let err = parse_since_filter("500000000d").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("invalid --since day window"),
+            "expected error about invalid day window, got: {msg}"
         );
     }
 


### PR DESCRIPTION
## Summary

While testing `--since`, I noticed that passing a very large day value (for example `500000000d`) causes the CLI to panic because of unchecked date arithmetic.

This changes that behavior to return a normal user-facing error instead of panicking. I've also added a regression test to cover this case.

### Before

```console
$ ctx search foo --since 500000000d

thread 'main' panicked at crates/ctx-cli/src/main.rs:6417:19:
DateTime - TimeDelta overflowed
```

### After

```console
$ ctx search foo --since 500000000d

Error: invalid --since day window: 500000000d: value too large
```

## Validation

- Added a regression test for oversized `--since` values
- Relevant unit tests pass