### PR TITLE
Add CLI install handoff diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "ctx"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-capture"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "ctx-history-core",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "directories",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-search"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "ctx-history-core",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-store"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "ctx-history-core",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,1 +1,1 @@
-module(name = "ctx_search", version = "0.17.0")
+module(name = "ctx_search", version = "0.18.0")

--- a/crates/ctx-cli/Cargo.toml
+++ b/crates/ctx-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx"
-version = "0.17.0"
+version = "0.18.0"
 description = "Local CLI for indexing and searching agent session history"
 edition.workspace = true
 autobins = false

--- a/crates/ctx-cli/src/analytics.rs
+++ b/crates/ctx-cli/src/analytics.rs
@@ -5,7 +5,7 @@ use ctx_history_core::utc_now;
 use serde_json::{json, Map, Value};
 use uuid::Uuid;
 
-use crate::{config::AppConfig, identity, net};
+use crate::{config::AppConfig, identity, install_marker, net};
 
 pub type AnalyticsProperties = Map<String, Value>;
 
@@ -38,6 +38,7 @@ fn send_cli_event_inner(
     let install_id = identity::install_id(data_root)?;
     let status = if event.success { "ok" } else { "error" };
     let duration_ms = event.duration.as_millis().min(i64::MAX as u128) as i64;
+    let install_marker = install_marker::current_exe_install_marker();
     let mut properties = event.properties;
     properties.insert("action".to_owned(), Value::String(event.action.to_owned()));
     properties.insert("json_output".to_owned(), Value::Bool(event.json_output));
@@ -45,11 +46,46 @@ fn send_cli_event_inner(
         "analytics_client".to_owned(),
         Value::String("ctx-cli".to_owned()),
     );
+    if install_marker.is_some() {
+        properties.insert(
+            "install_manager".to_owned(),
+            Value::String("ctx-hosted-installer".to_owned()),
+        );
+    }
     if !event.success {
         properties.insert(
             "failure_kind".to_owned(),
             Value::String("command_error".to_owned()),
         );
+    }
+    let mut cli_event = json!({
+        "event_id": Uuid::now_v7().to_string(),
+        "event_name": "cli_invocation",
+        "event_version": 1,
+        "occurred_at": utc_now(),
+        "plane": "product",
+        "delivery": "remote",
+        "origin_runtime": "cli",
+        "origin_install_id": install_id,
+        "origin_device_id": device_id,
+        "app_version": env!("CARGO_PKG_VERSION"),
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+        "surface": "cli",
+        "source": "ctx-cli",
+        "duration_ms": duration_ms,
+        "duration_bucket": duration_bucket(event.duration),
+        "status": status,
+        "success": event.success,
+        "properties": properties
+    });
+    if let Some(marker) = install_marker {
+        if let Some(object) = cli_event.as_object_mut() {
+            object.insert(
+                "install_attempt_id".to_owned(),
+                Value::String(marker.install_attempt_id),
+            );
+        }
     }
     let payload = json!({
         "broker_install_id": install_id,
@@ -58,27 +94,7 @@ fn send_cli_event_inner(
         "broker_app_version": env!("CARGO_PKG_VERSION"),
         "broker_os": std::env::consts::OS,
         "broker_arch": std::env::consts::ARCH,
-        "events": [{
-            "event_id": Uuid::now_v7().to_string(),
-            "event_name": "cli_invocation",
-            "event_version": 1,
-            "occurred_at": utc_now(),
-            "plane": "product",
-            "delivery": "remote",
-            "origin_runtime": "cli",
-            "origin_install_id": install_id,
-            "origin_device_id": device_id,
-            "app_version": env!("CARGO_PKG_VERSION"),
-            "os": std::env::consts::OS,
-            "arch": std::env::consts::ARCH,
-            "surface": "cli",
-            "source": "ctx-cli",
-            "duration_ms": duration_ms,
-            "duration_bucket": duration_bucket(event.duration),
-            "status": status,
-            "success": event.success,
-            "properties": properties
-        }]
+        "events": [cli_event]
     });
     let body = serde_json::to_vec(&payload)?;
     net::post_json(&config.analytics.endpoint, &body)

--- a/crates/ctx-cli/src/install_marker.rs
+++ b/crates/ctx-cli/src/install_marker.rs
@@ -1,0 +1,106 @@
+use std::{
+    env, fs,
+    io::Read,
+    path::{Path, PathBuf},
+};
+
+use serde_json::Value;
+
+const MAX_MARKER_BYTES: u64 = 16 * 1024;
+const MAX_INSTALL_ATTEMPT_ID_CHARS: usize = 128;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstallMarker {
+    pub install_attempt_id: String,
+}
+
+pub fn current_exe_install_marker() -> Option<InstallMarker> {
+    let exe = env::current_exe().ok()?;
+    read_install_marker(&install_marker_path(&exe))
+}
+
+fn read_install_marker(path: &Path) -> Option<InstallMarker> {
+    let metadata = fs::metadata(path).ok()?;
+    if !metadata.is_file() || metadata.len() > MAX_MARKER_BYTES {
+        return None;
+    }
+    let file = fs::File::open(path).ok()?;
+    let mut reader = file.take(MAX_MARKER_BYTES + 1);
+    let mut bytes = Vec::new();
+    if reader.read_to_end(&mut bytes).is_err() || bytes.len() as u64 > MAX_MARKER_BYTES {
+        return None;
+    }
+    parse_install_marker(&bytes)
+}
+
+fn parse_install_marker(bytes: &[u8]) -> Option<InstallMarker> {
+    let value: Value = serde_json::from_slice(bytes).ok()?;
+    let id = value.get("install_attempt_id")?.as_str()?.trim();
+    if is_valid_install_attempt_id(id) {
+        Some(InstallMarker {
+            install_attempt_id: id.to_owned(),
+        })
+    } else {
+        None
+    }
+}
+
+fn is_valid_install_attempt_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().count() <= MAX_INSTALL_ATTEMPT_ID_CHARS
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+
+fn install_marker_path(exe: &Path) -> PathBuf {
+    let mut marker = exe.as_os_str().to_owned();
+    marker.push(".install.json");
+    PathBuf::from(marker)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bounded_install_attempt_id() {
+        let marker = parse_install_marker(br#"{"install_attempt_id":"attempt_01-HOSTED"}"#)
+            .expect("valid marker");
+
+        assert_eq!(marker.install_attempt_id, "attempt_01-HOSTED");
+    }
+
+    #[test]
+    fn ignores_malformed_or_unbounded_install_attempt_id() {
+        assert!(parse_install_marker(b"{not-json").is_none());
+        assert!(parse_install_marker(br#"{"install_attempt_id":""}"#).is_none());
+        assert!(parse_install_marker(br#"{"install_attempt_id":"contains space"}"#).is_none());
+        assert!(parse_install_marker(
+            format!(
+                r#"{{"install_attempt_id":"{}"}}"#,
+                "a".repeat(MAX_INSTALL_ATTEMPT_ID_CHARS + 1)
+            )
+            .as_bytes()
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn appends_marker_suffix_to_full_exe_path() {
+        assert_eq!(
+            install_marker_path(Path::new("/tmp/ctx.exe")),
+            PathBuf::from("/tmp/ctx.exe.install.json")
+        );
+    }
+
+    #[test]
+    fn ignores_missing_or_oversized_marker_file() {
+        let temp = tempfile::tempdir().unwrap();
+        assert!(read_install_marker(&temp.path().join("missing.install.json")).is_none());
+
+        let path = temp.path().join("ctx.install.json");
+        fs::write(&path, vec![b'a'; MAX_MARKER_BYTES as usize + 1]).unwrap();
+        assert!(read_install_marker(&path).is_none());
+    }
+}

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -20,6 +20,7 @@ mod config;
 mod docs;
 mod history_source_plugins;
 mod identity;
+mod install_marker;
 mod mcp;
 mod net;
 mod upgrade;
@@ -1389,6 +1390,19 @@ fn main() -> Result<()> {
         .unwrap_or_else(default_data_root)
         .context("resolve ctx data root")?;
     let config = AppConfig::load(&data_root)?;
+    if matches!(&cli.command, CommandRoot::Setup(_)) && sends_analytics {
+        analytics::send_cli_event(
+            &data_root,
+            &config,
+            AnalyticsEvent {
+                action: "setup_started",
+                json_output,
+                success: true,
+                duration: StdDuration::ZERO,
+                properties: analytics_properties.clone(),
+            },
+        );
+    }
 
     let result = match cli.command {
         CommandRoot::Setup(args) => run_setup(args, data_root.clone(), &mut analytics_properties),

--- a/crates/ctx-cli/src/upgrade.rs
+++ b/crates/ctx-cli/src/upgrade.rs
@@ -24,6 +24,7 @@ const LOG_FILE: &str = "logs/upgrade.log";
 const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 const VERSION_PROBE_OUTPUT_LIMIT: usize = 4096;
 const STALE_UPGRADE_LOCK_AFTER: Duration = Duration::from_secs(30 * 60);
+const MAX_INSTALL_ATTEMPT_ID_CHARS: usize = 128;
 const DEFAULT_METADATA_PUBLIC_KEY_PEM: &str = r#"-----BEGIN RSA PUBLIC KEY-----
 MIIBigKCAYEAyBPNIx3H/NwWlN9CPHY5kOEe9kQEshOJEMpv3Atq086H1FWqliTm
 3BCWiO4s/89wNMn11Pla2JetCWNiWsbxm3BIxCd1o6cq8y9ur6Zk1RGOQBLQgqhF
@@ -848,7 +849,8 @@ fn replace_binary(staged: &Path, plan: &UpgradePlan) -> Result<ApplyResult> {
     let script = staged.with_extension("ps1");
     let marker_tmp = staged.with_extension("install.json.tmp");
     let marker_path = install_marker_path(target);
-    write_install_marker_to(&marker_tmp, plan)?;
+    let install_attempt_id = existing_install_attempt_id(&marker_path);
+    write_install_marker_to(&marker_tmp, plan, install_attempt_id.as_deref())?;
     let parent = std::process::id();
     let body = format!(
         r#"$ErrorActionPreference = 'Stop'
@@ -1016,11 +1018,16 @@ fn verify_install_marker(marker: &InstallMarker, platform: &str) -> Result<()> {
 
 fn write_install_marker_after_upgrade(plan: &UpgradePlan) -> Result<()> {
     let marker_path = install_marker_path(&plan.install_path);
-    write_install_marker_to(&marker_path, plan)
+    let install_attempt_id = existing_install_attempt_id(&marker_path);
+    write_install_marker_to(&marker_path, plan, install_attempt_id.as_deref())
 }
 
-fn write_install_marker_to(marker_path: &Path, plan: &UpgradePlan) -> Result<()> {
-    let body = json!({
+fn write_install_marker_to(
+    marker_path: &Path,
+    plan: &UpgradePlan,
+    install_attempt_id: Option<&str>,
+) -> Result<()> {
+    let mut body = json!({
         "schema_version": 1,
         "manager": "ctx-hosted-installer",
         "install_path": plan.install_path,
@@ -1035,7 +1042,32 @@ fn write_install_marker_to(marker_path: &Path, plan: &UpgradePlan) -> Result<()>
         "store_schema_version": plan.metadata.store_schema_version,
         "installed_at": utc_now(),
     });
+    if let Some(install_attempt_id) = install_attempt_id {
+        if let Some(object) = body.as_object_mut() {
+            object.insert(
+                "install_attempt_id".to_owned(),
+                Value::String(install_attempt_id.to_owned()),
+            );
+        }
+    }
     atomic_write_json(marker_path, &body)
+}
+
+fn existing_install_attempt_id(marker_path: &Path) -> Option<String> {
+    read_json_file(marker_path).and_then(|value| optional_install_attempt_id(&value))
+}
+
+fn optional_install_attempt_id(value: &Value) -> Option<String> {
+    let id = value.get("install_attempt_id")?.as_str()?.trim();
+    is_valid_install_attempt_id(id).then(|| id.to_owned())
+}
+
+fn is_valid_install_attempt_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().count() <= MAX_INSTALL_ATTEMPT_ID_CHARS
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }
 
 fn string_field(value: &Value, key: &str) -> Result<String> {

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -28,6 +28,39 @@ fn ctx(temp: &TempDir) -> Command {
     command
 }
 
+fn ctx_from_binary(temp: &TempDir, binary: &Path) -> Command {
+    let mut command = Command::new(binary);
+    command.env("CTX_DATA_ROOT", temp.path());
+    command.env("HOME", temp.path());
+    command.env("CTX_ANALYTICS_OFF", "1");
+    command
+}
+
+fn copied_ctx_binary(temp: &TempDir) -> PathBuf {
+    let source = PathBuf::from(Command::cargo_bin("ctx").unwrap().get_program().to_owned());
+    let target = temp.path().join(if cfg!(windows) {
+        "ctx-test-copy.exe"
+    } else {
+        "ctx-test-copy"
+    });
+    fs::copy(&source, &target).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(&target).unwrap().permissions();
+        permissions.set_mode(permissions.mode() | 0o700);
+        fs::set_permissions(&target, permissions).unwrap();
+    }
+    target
+}
+
+fn hosted_install_marker_path(binary: &Path) -> PathBuf {
+    let mut marker = binary.as_os_str().to_owned();
+    marker.push(".install.json");
+    PathBuf::from(marker)
+}
+
 fn initialize_empty_store(temp: &TempDir) {
     fs::create_dir_all(temp.path().join(".codex").join("sessions")).unwrap();
     ctx(temp)
@@ -363,6 +396,10 @@ fn read_analytics_events(path: &Path) -> Vec<Value> {
 
 fn analytics_event_properties(event: &Value) -> &serde_json::Map<String, Value> {
     event["events"][0]["properties"].as_object().unwrap()
+}
+
+fn analytics_cli_event(event: &Value) -> &Value {
+    &event["events"][0]
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
@@ -2321,6 +2358,7 @@ fn fake_release(temp: &TempDir, latest_version: &str) -> FakeRelease {
     let marker = json!({
         "schema_version": 1,
         "manager": "ctx-hosted-installer",
+        "install_attempt_id": "ia_test_upgrade_attempt",
         "install_path": target,
         "platform": test_platform_key().replace('_', "-"),
         "channel": "stable",
@@ -2435,6 +2473,7 @@ fn upgrade_status_check_and_apply_support_managed_installs() {
         serde_json::from_slice(&fs::read(install_marker_path(&release.target)).unwrap()).unwrap();
     assert_eq!(marker["version"], "9.9.9");
     assert_eq!(marker["sha256"], release.artifact_sha);
+    assert_eq!(marker["install_attempt_id"], "ia_test_upgrade_attempt");
 }
 
 #[cfg(unix)]
@@ -3117,6 +3156,204 @@ fn analytics_payloads_omit_sensitive_command_data() {
 }
 
 #[test]
+fn hosted_install_marker_enriches_analytics_event_without_properties_leak() {
+    let temp = tempdir();
+    let data_root = temp.path().join("ctx-data");
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let events_path = temp.path().join("analytics.jsonl");
+    let binary = copied_ctx_binary(&temp);
+    let install_attempt_id = "attempt_01JZCTXHOSTED";
+    let marker_secret = "marker-secret-must-not-leak";
+    fs::write(
+        hosted_install_marker_path(&binary),
+        serde_json::to_vec_pretty(&json!({
+            "schema_version": 1,
+            "install_attempt_id": install_attempt_id,
+            "installer_private_note": marker_secret,
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    ctx_from_binary(&temp, &binary)
+        .arg("status")
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+        .env("CTX_UPGRADE_OFF", "1")
+        .assert()
+        .success();
+
+    let events = read_analytics_events(&events_path);
+    assert_eq!(events.len(), 1);
+    let cli_event = analytics_cli_event(&events[0]);
+    assert_eq!(cli_event["install_attempt_id"], install_attempt_id);
+    let properties = analytics_event_properties(&events[0]);
+    assert_eq!(properties["install_manager"], "ctx-hosted-installer");
+    assert!(
+        properties.get("install_attempt_id").is_none(),
+        "raw marker id must stay out of analytics properties: {properties:#?}"
+    );
+    assert_no_json_string_contains(
+        &Value::Object(properties.clone()),
+        &[install_attempt_id, marker_secret],
+    );
+}
+
+#[test]
+fn malformed_hosted_install_marker_is_ignored() {
+    let temp = tempdir();
+    let data_root = temp.path().join("ctx-data");
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let events_path = temp.path().join("analytics.jsonl");
+    let binary = copied_ctx_binary(&temp);
+    fs::write(
+        hosted_install_marker_path(&binary),
+        b"{not-json marker-secret-must-not-leak",
+    )
+    .unwrap();
+
+    ctx_from_binary(&temp, &binary)
+        .arg("status")
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+        .env("CTX_UPGRADE_OFF", "1")
+        .assert()
+        .success();
+
+    let events = read_analytics_events(&events_path);
+    assert_eq!(events.len(), 1);
+    let cli_event = analytics_cli_event(&events[0]);
+    assert!(cli_event.get("install_attempt_id").is_none());
+    let properties = analytics_event_properties(&events[0]);
+    assert!(properties.get("install_manager").is_none());
+    assert_no_json_string_contains(
+        &Value::Object(properties.clone()),
+        &["marker-secret-must-not-leak"],
+    );
+}
+
+#[test]
+fn setup_analytics_emits_start_and_completion_events() {
+    let temp = tempdir();
+    let data_root = temp.path().join("ctx-data");
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let events_path = temp.path().join("analytics.jsonl");
+    fs::create_dir_all(home.join(".codex").join("sessions")).unwrap();
+
+    ctx(&temp)
+        .args(["setup", "--catalog-only", "--progress", "none"])
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+        .env("CTX_UPGRADE_OFF", "1")
+        .assert()
+        .success();
+
+    let events = read_analytics_events(&events_path);
+    assert_eq!(events.len(), 2);
+    let actions = events
+        .iter()
+        .map(|event| {
+            analytics_event_properties(event)["action"]
+                .as_str()
+                .unwrap()
+                .to_owned()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(actions, ["setup_started", "setup"]);
+    for event in &events {
+        assert_eq!(analytics_cli_event(event)["event_name"], "cli_invocation");
+        assert_eq!(analytics_cli_event(event)["status"], "ok");
+        assert_eq!(analytics_cli_event(event)["success"], true);
+        assert_analytics_properties_are_allowlisted(analytics_event_properties(event));
+    }
+}
+
+#[test]
+fn setup_analytics_opt_out_suppresses_start_completion_and_identities() {
+    let temp = tempdir();
+    let data_root = temp.path().join("ctx-data");
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let events_path = temp.path().join("analytics.jsonl");
+    fs::create_dir_all(home.join(".codex").join("sessions")).unwrap();
+
+    ctx(&temp)
+        .args(["setup", "--catalog-only", "--progress", "none"])
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+        .env("CTX_UPGRADE_OFF", "1")
+        .assert()
+        .success();
+
+    assert!(
+        !events_path.exists(),
+        "setup analytics opt-out should suppress start and completion events"
+    );
+    assert!(
+        !data_root.join("install.json").exists(),
+        "setup analytics opt-out should not create an install identity"
+    );
+    assert!(
+        !expected_device_path(&home, &state).exists(),
+        "setup analytics opt-out should not create a device identity"
+    );
+}
+
+#[test]
+fn setup_analytics_dry_run_suppresses_start_completion_and_identities() {
+    let temp = tempdir();
+    let data_root = temp.path().join("ctx-data");
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let events_path = temp.path().join("analytics.jsonl");
+    fs::create_dir_all(home.join(".codex").join("sessions")).unwrap();
+
+    ctx(&temp)
+        .args(["setup", "--catalog-only", "--progress", "none"])
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_DRY_RUN", "1")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+        .env("CTX_UPGRADE_OFF", "1")
+        .assert()
+        .success();
+
+    assert!(
+        !events_path.exists(),
+        "setup analytics dry run should suppress start and completion events"
+    );
+    assert!(
+        !data_root.join("install.json").exists(),
+        "setup analytics dry run should not create an install identity"
+    );
+    assert!(
+        !expected_device_path(&home, &state).exists(),
+        "setup analytics dry run should not create a device identity"
+    );
+}
+
+#[test]
 fn analytics_config_opt_out_suppresses_delivery() {
     let temp = tempdir();
     let state = temp.path().join("state");
@@ -3278,6 +3515,7 @@ fn assert_analytics_properties_are_allowlisted(properties: &serde_json::Map<Stri
         "indexed_items_bucket",
         "indexed_sessions_bucket",
         "indexed_sources_bucket",
+        "install_manager",
         "initialized",
         "json_output",
         "limit_bucket",

--- a/crates/ctx-history-capture/Cargo.toml
+++ b/crates/ctx-history-capture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-capture"
-version = "0.17.0"
+version = "0.18.0"
 description = "Internal provider import adapters for ctx local agent history"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-core/Cargo.toml
+++ b/crates/ctx-history-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-core"
-version = "0.17.0"
+version = "0.18.0"
 description = "Internal core types for ctx local agent history indexing"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-search/Cargo.toml
+++ b/crates/ctx-history-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-search"
-version = "0.17.0"
+version = "0.18.0"
 description = "Internal search projection and ranking helpers for ctx"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-store/Cargo.toml
+++ b/crates/ctx-history-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-store"
-version = "0.17.0"
+version = "0.18.0"
 description = "Internal SQLite storage layer for ctx local agent history"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Summary:
- bump CLI release crates to 0.18.0
- attach hosted installer handoff IDs to CLI events without leaking marker contents into properties
- emit setup start/completion analytics and preserve install handoff IDs across managed upgrades

Checks:
- cargo test --workspace
- bash scripts/check.sh --mode=ci
- cargo fmt --check --all
- git diff --check