### PR TITLE
Fix Pi session directory imports

### DIFF
--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -1678,11 +1678,11 @@ fn import_all_discovers_and_imports_providers_together() {
         Path::new(&provider_history_fixture("codex-sessions")),
         &temp.path().join(".codex").join("sessions"),
     );
-    let pi_home = temp.path().join(".pi");
+    let pi_home = temp.path().join(".pi/agent/sessions/--workspace-example--");
     fs::create_dir_all(&pi_home).unwrap();
     fs::copy(
         provider_history_fixture("pi-session.jsonl"),
-        pi_home.join("sessions.jsonl"),
+        pi_home.join("2026-06-24T12-00-00-000Z_pi-session-docs-1.jsonl"),
     )
     .unwrap();
 
@@ -5665,29 +5665,40 @@ fn install_default_claude_fixture(temp: &TempDir, query: &str) {
     copy_dir_all(&source, &temp.path().join(".claude").join("projects"));
 }
 
-fn install_default_pi_fixture(temp: &TempDir, query: &str) {
-    let root = temp.path().join(".pi");
-    fs::create_dir_all(&root).unwrap();
+fn write_pi_session_jsonl(path: &Path, id: &str, query: &str) {
     fs::write(
-        root.join("sessions.jsonl"),
+        path,
         format!(
             "{}\n{}\n",
             json!({
                 "type": "session",
                 "version": 3,
-                "id": "pi-default-refresh",
+                "id": id,
                 "timestamp": "2026-06-24T12:00:00.000Z",
                 "cwd": "/workspace"
             }),
             json!({
                 "type": "message",
-                "id": "pi-default-refresh-user",
+                "id": format!("{id}-user"),
                 "timestamp": "2026-06-24T12:00:01.000Z",
-                "message": {"role": "user", "content": query}
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": query}]
+                }
             })
         ),
     )
     .unwrap();
+}
+
+fn install_default_pi_fixture(temp: &TempDir, query: &str) {
+    let root = temp.path().join(".pi/agent/sessions/--workspace--");
+    fs::create_dir_all(&root).unwrap();
+    write_pi_session_jsonl(
+        &root.join("2026-06-24T12-00-00-000Z_pi-default-refresh.jsonl"),
+        "pi-default-refresh",
+        query,
+    );
 }
 
 fn install_default_cursor_fixture(temp: &TempDir, query: &str) {
@@ -6649,26 +6660,41 @@ fn file_only_search_returns_touched_file_matches() {
 }
 
 #[test]
-fn pi_cli_rejects_directory_import_path() {
+fn pi_cli_imports_directory_tree_path() {
     let temp = tempdir();
     let path = temp.path().join("pi-sessions-dir");
-    fs::create_dir_all(&path).unwrap();
+    let project = path.join("--workspace--");
+    fs::create_dir_all(&project).unwrap();
+    write_pi_session_jsonl(
+        &project.join("2026-06-24T12-00-00-000Z_pi-dir-alpha.jsonl"),
+        "pi-dir-alpha",
+        "pi directory alpha oracle",
+    );
+    write_pi_session_jsonl(
+        &project.join("2026-06-24T12-01-00-000Z_pi-dir-beta.jsonl"),
+        "pi-dir-beta",
+        "pi directory beta oracle",
+    );
 
-    ctx(&temp)
-        .args([
-            "import",
-            "--provider",
-            "pi",
-            "--path",
-            path.to_str().unwrap(),
-            "--json",
-        ])
-        .assert()
-        .failure()
-        .stderr(
-            predicate::str::contains("no importable pi history files")
-                .and(predicate::str::contains(path.to_str().unwrap())),
-        );
+    let imported = json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "pi",
+        "--path",
+        path.to_str().unwrap(),
+        "--json",
+    ]));
+    assert_eq!(imported["totals"]["imported_sessions"], 2);
+    assert_eq!(imported["totals"]["imported_events"], 2);
+
+    let search = json_output(ctx(&temp).args([
+        "search",
+        "pi directory beta oracle",
+        "--provider",
+        "pi",
+        "--json",
+    ]));
+    assert_search_provider_oracle(&search, "pi", "pi directory beta oracle", 1, "message");
 }
 
 #[test]
@@ -6688,7 +6714,7 @@ fn pi_cli_rejects_wrong_file_import_path() {
         .assert()
         .failure()
         .stderr(
-            predicate::str::contains("no importable pi history files")
+            predicate::str::contains("no importable pi history files found")
                 .and(predicate::str::contains(path.to_str().unwrap())),
         );
 }

--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -1375,68 +1375,105 @@ impl ProviderCaptureAdapter for PiSessionJsonlAdapter {
         path: &Path,
         context: &ProviderAdapterContext,
     ) -> Result<ProviderNormalizationResult> {
-        ensure_regular_provider_transcript_file(path)?;
-        let file = File::open(path)?;
-        let reader = BufReader::new(file);
-        let mut result = ProviderNormalizationResult::default();
-        let mut header = None;
+        normalize_pi_session_jsonl_path(path, context)
+    }
+}
 
-        for (index, line) in reader.lines().enumerate() {
-            let line_number = index + 1;
-            let line = line?;
-            if line.trim().is_empty() {
+fn normalize_pi_session_jsonl_path(
+    path: &Path,
+    context: &ProviderAdapterContext,
+) -> Result<ProviderNormalizationResult> {
+    if fs::symlink_metadata(path)?.file_type().is_file() {
+        return normalize_pi_session_jsonl_file(path, context);
+    }
+
+    let mut paths = Vec::new();
+    collect_jsonl_paths(path, &mut paths)?;
+    paths.sort();
+    if paths.is_empty() {
+        return Err(CaptureError::InvalidProviderTranscriptPath {
+            path: path.to_path_buf(),
+            reason: native_jsonl_missing_reason(CaptureProvider::Pi),
+        });
+    }
+
+    let mut merged = ProviderNormalizationResult::default();
+    for path in paths {
+        let mut file_context = context.clone();
+        file_context.source_path = Some(path.clone());
+        let mut result = normalize_pi_session_jsonl_file(&path, &file_context)?;
+        merged.summary.merge(result.summary);
+        merged.captures.append(&mut result.captures);
+        merged.files_touched.append(&mut result.files_touched);
+    }
+    Ok(merged)
+}
+
+fn normalize_pi_session_jsonl_file(
+    path: &Path,
+    context: &ProviderAdapterContext,
+) -> Result<ProviderNormalizationResult> {
+    ensure_regular_provider_transcript_file(path)?;
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut result = ProviderNormalizationResult::default();
+    let mut header = None;
+
+    for (index, line) in reader.lines().enumerate() {
+        let line_number = index + 1;
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(value) => value,
+            Err(err) => {
+                result.summary.failed += 1;
+                result.summary.failures.push(ProviderImportFailure {
+                    line: line_number,
+                    error: err.to_string(),
+                });
                 continue;
             }
-
-            let value: Value = match serde_json::from_str(&line) {
-                Ok(value) => value,
+        };
+        let entry_type = value
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        if entry_type == "session" {
+            match pi_session_header(value) {
+                Ok(parsed) => {
+                    let capture = pi_session_capture(&parsed, None, line_number, context);
+                    header = Some(parsed);
+                    result.captures.push((line_number, capture));
+                }
                 Err(err) => {
                     result.summary.failed += 1;
                     result.summary.failures.push(ProviderImportFailure {
                         line: line_number,
                         error: err.to_string(),
                     });
-                    continue;
                 }
-            };
-            let entry_type = value
-                .get("type")
-                .and_then(Value::as_str)
-                .unwrap_or("unknown");
-            if entry_type == "session" {
-                match pi_session_header(value) {
-                    Ok(parsed) => {
-                        let capture = pi_session_capture(&parsed, None, line_number, context);
-                        header = Some(parsed);
-                        result.captures.push((line_number, capture));
-                    }
-                    Err(err) => {
-                        result.summary.failed += 1;
-                        result.summary.failures.push(ProviderImportFailure {
-                            line: line_number,
-                            error: err.to_string(),
-                        });
-                    }
-                }
-                continue;
             }
-
-            let Some(header) = header.as_ref() else {
-                result.summary.failed += 1;
-                result.summary.failures.push(ProviderImportFailure {
-                    line: line_number,
-                    error: "pi session entry appeared before session header".to_owned(),
-                });
-                continue;
-            };
-            result.captures.push((
-                line_number,
-                pi_session_capture(header, Some(value), line_number, context),
-            ));
+            continue;
         }
 
-        Ok(result)
+        let Some(header) = header.as_ref() else {
+            result.summary.failed += 1;
+            result.summary.failures.push(ProviderImportFailure {
+                line: line_number,
+                error: "pi session entry appeared before session header".to_owned(),
+            });
+            continue;
+        };
+        result.captures.push((
+            line_number,
+            pi_session_capture(header, Some(value), line_number, context),
+        ));
     }
+
+    Ok(result)
 }
 
 impl ProviderCaptureAdapter for ClaudeProjectsJsonlAdapter {
@@ -8877,6 +8914,7 @@ fn normalize_jsonl_tree(
 
 fn native_jsonl_missing_reason(provider: CaptureProvider) -> &'static str {
     match provider {
+        CaptureProvider::Pi => "no Pi session JSONL files found",
         CaptureProvider::Antigravity => {
             "no Antigravity transcript JSONL files found under brain/*/.system_generated/logs"
         }
@@ -9614,7 +9652,7 @@ fn pi_session_capture(
     line_number: usize,
     context: &ProviderAdapterContext,
 ) -> ProviderCaptureEnvelope {
-    let event = entry.map(|entry| pi_session_event(&entry, line_number));
+    let event = entry.map(|entry| pi_session_event(header, &entry, line_number));
     let cursor = event.as_ref().and_then(|event| {
         event.cursor.as_ref().map(|cursor| ProviderCursorRange {
             before: None,
@@ -9680,7 +9718,11 @@ fn pi_session_capture(
     }
 }
 
-fn pi_session_event(entry: &Value, line_number: usize) -> ProviderEventEnvelope {
+fn pi_session_event(
+    header: &PiSessionHeader,
+    entry: &Value,
+    line_number: usize,
+) -> ProviderEventEnvelope {
     let entry_type = entry
         .get("type")
         .and_then(Value::as_str)
@@ -9708,7 +9750,7 @@ fn pi_session_event(entry: &Value, line_number: usize) -> ProviderEventEnvelope 
         occurred_at,
         fidelity: Fidelity::Imported,
         redaction_state: RedactionState::LocalPreview,
-        idempotency_key: Some(format!("provider-event:pi:{line_number}")),
+        idempotency_key: Some(format!("provider-event:pi:{}:{line_number}", header.id)),
         artifacts: Vec::new(),
         payload: json!({
             "entry_type": entry_type,
@@ -11955,6 +11997,64 @@ mod tests {
         assert!(events[3].payload.to_string().contains("cargo test"));
         assert!(events[3].payload.to_string().contains("fixture-secret"));
         assert!(!events[3].payload.to_string().contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn pi_session_import_replays_default_session_directory_tree() {
+        let temp = tempdir();
+        let root = temp.path().join(".pi/agent/sessions/--workspace--");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            root.join("2026-06-24T12-00-00-000Z_pi-dir-alpha.jsonl"),
+            concat!(
+                "{\"type\":\"session\",\"version\":3,\"id\":\"pi-dir-alpha\",\"timestamp\":\"2026-06-24T12:00:00Z\",\"cwd\":\"/workspace\"}\n",
+                "{\"type\":\"message\",\"id\":\"pi-dir-alpha-user\",\"timestamp\":\"2026-06-24T12:00:01Z\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"alpha directory import\"}]}}\n",
+            ),
+        )
+        .unwrap();
+        fs::write(
+            root.join("2026-06-24T12-01-00-000Z_pi-dir-beta.jsonl"),
+            concat!(
+                "{\"type\":\"session\",\"version\":3,\"id\":\"pi-dir-beta\",\"timestamp\":\"2026-06-24T12:01:00Z\",\"cwd\":\"/workspace\"}\n",
+                "{\"type\":\"message\",\"id\":\"pi-dir-beta-user\",\"timestamp\":\"2026-06-24T12:01:01Z\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"beta directory import\"}]}}\n",
+            ),
+        )
+        .unwrap();
+        let sessions_root = temp.path().join(".pi/agent/sessions");
+        let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+        let first = import_pi_session_jsonl(
+            &sessions_root,
+            &mut store,
+            PiSessionImportOptions {
+                source_path: Some(sessions_root.clone()),
+                imported_at: "2026-06-24T16:00:00Z".parse().unwrap(),
+                ..PiSessionImportOptions::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(first.failed, 0, "{:?}", first.failures);
+        assert_eq!(first.imported_sessions, 2);
+        assert_eq!(first.imported_events, 2);
+
+        let second = import_pi_session_jsonl(
+            &sessions_root,
+            &mut store,
+            PiSessionImportOptions {
+                source_path: Some(sessions_root.clone()),
+                imported_at: "2026-06-24T16:00:00Z".parse().unwrap(),
+                ..PiSessionImportOptions::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(second.failed, 0, "{:?}", second.failures);
+        assert_eq!(second.imported_events, 0);
+        assert_eq!(second.skipped_events, 2);
+
+        let alpha = provider_session_uuid(CaptureProvider::Pi, "pi-dir-alpha");
+        let beta = provider_session_uuid(CaptureProvider::Pi, "pi-dir-beta");
+        assert_eq!(store.events_for_session(alpha).unwrap().len(), 1);
+        assert_eq!(store.events_for_session(beta).unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/ctx-history-capture/src/provider_sources.rs
+++ b/crates/ctx-history-capture/src/provider_sources.rs
@@ -105,7 +105,7 @@ const CODEX_DEFAULTS: &[ProviderDefaultLocation] = &[
 ];
 
 const PI_DEFAULTS: &[ProviderDefaultLocation] = &[ProviderDefaultLocation {
-    path_components: &[".pi", "sessions.jsonl"],
+    path_components: &[".pi", "agent", "sessions"],
     source_format: "pi_session_jsonl",
     source_kind: ProviderSourceKind::NativeHistory,
 }];
@@ -586,7 +586,7 @@ fn provider_source_from_location(
 fn empty_source_reason(provider: CaptureProvider) -> Option<&'static str> {
     match provider {
         CaptureProvider::Codex => Some("path exists but no Codex JSONL sessions were found"),
-        CaptureProvider::Pi => Some("path exists but no Pi session JSONL file was found"),
+        CaptureProvider::Pi => Some("path exists but no Pi session JSONL files were found"),
         CaptureProvider::Claude => {
             Some("path exists but no Claude project JSONL transcripts were found")
         }
@@ -623,6 +623,9 @@ fn unknown_source_reason(provider: CaptureProvider) -> Option<&'static str> {
         CaptureProvider::Codex => {
             Some("path exists but the Codex session transcript probe hit its scan budget")
         }
+        CaptureProvider::Pi => {
+            Some("path exists but the Pi session transcript probe hit its scan budget")
+        }
         CaptureProvider::Claude => {
             Some("path exists but the Claude transcript probe hit its scan budget")
         }
@@ -654,7 +657,7 @@ fn probe_io_error_reason(provider: CaptureProvider) -> Option<&'static str> {
             Some("path exists but Codex session transcripts could not be read; check permissions")
         }
         CaptureProvider::Pi => {
-            Some("path exists but the Pi session file could not be read; check permissions")
+            Some("path exists but Pi session transcripts could not be read; check permissions")
         }
         CaptureProvider::Claude => {
             Some("path exists but Claude project transcripts could not be read; check permissions")
@@ -703,7 +706,7 @@ fn default_location_import_probe(
             path_is_file_probe(path)
         }
         CaptureProvider::Codex => has_jsonl_file_under_matching(path, 10_000, |_| true),
-        CaptureProvider::Pi => path_is_file_probe(path),
+        CaptureProvider::Pi => has_jsonl_file_under_matching(path, 10_000, |_| true),
         CaptureProvider::OpenCode => path_is_file_probe(path),
         CaptureProvider::Claude => has_jsonl_file_under_matching(path, 10_000, |_| true),
         CaptureProvider::OpenClaw => has_openclaw_session_jsonl(path, 10_000),
@@ -956,6 +959,21 @@ mod tests {
     #[test]
     fn native_provider_default_discovery_uses_importer_specific_file_predicates() {
         let temp = tempfile::tempdir().unwrap();
+
+        let pi = temp.path().join(".pi/agent/sessions");
+        std::fs::create_dir_all(pi.join("--workspace--")).unwrap();
+        assert_source_status(
+            temp.path(),
+            CaptureProvider::Pi,
+            ProviderSourceStatus::Empty,
+        );
+        std::fs::write(pi.join("--workspace--/session.jsonl"), "{}\n").unwrap();
+        let pi_source = discover_provider_sources(temp.path())
+            .into_iter()
+            .find(|source| source.provider == CaptureProvider::Pi)
+            .unwrap();
+        assert_eq!(pi_source.status, ProviderSourceStatus::Available);
+        assert_eq!(pi_source.path, temp.path().join(".pi/agent/sessions"));
 
         let antigravity = temp.path().join(".gemini/antigravity-cli/brain");
         std::fs::create_dir_all(antigravity.join("session/.system_generated/logs")).unwrap();

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -57,7 +57,7 @@ machine. Current rows include:
 
 - Codex session trees at `~/.codex/sessions`;
 - Codex prompt history at `~/.codex/history.jsonl`;
-- Pi session JSONL at `~/.pi/sessions.jsonl`;
+- Pi session JSONL files under `~/.pi/agent/sessions`;
 - native rows for supported Antigravity, Claude, OpenCode, OpenClaw, Hermes,
   Gemini, Cursor, Copilot CLI, and Factory AI Droid local history locations;
 - preview rows for NanoClaw project roots and AstrBot SQLite history when those
@@ -94,7 +94,7 @@ ctx import --provider cursor
 ctx import --provider copilot-cli
 ctx import --provider factory-ai-droid
 ctx import --provider codex --path ~/.codex/sessions
-ctx import --provider pi --path ~/.pi/sessions.jsonl
+ctx import --provider pi --path ~/.pi/agent/sessions
 ctx import --format ctx-history-jsonl-v1 --path ./history.jsonl
 ctx import --history-source example-agent/default
 ctx import --history-source-manifest ./ctx-history-plugin.json

--- a/docs/first-10-minutes.md
+++ b/docs/first-10-minutes.md
@@ -61,7 +61,7 @@ you want to repair, re-run, resume, or pass an explicit path:
 
 ```bash
 ctx import --provider codex --path ~/.codex/sessions
-ctx import --provider pi --path ~/.pi/sessions.jsonl
+ctx import --provider pi --path ~/.pi/agent/sessions
 ctx import --provider cursor --path ~/.cursor/projects
 ctx import --provider hermes --path ~/.hermes/state.db
 ctx import --provider nanoclaw --path /path/to/nanoclaw-project

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -7,8 +7,9 @@ shipped.
 ## Provider Coverage
 
 - Codex local import is supported for documented local JSONL sources.
-- Pi local import is supported only when a matching local `sessions.jsonl` file
-  exists.
+- Pi local import is supported when matching local session JSONL files exist
+  under `~/.pi/agent/sessions`, or when an explicit Pi session JSONL file is
+  passed with `--path`.
 - Antigravity, Claude, OpenCode, OpenClaw, Hermes, Gemini, Cursor, Copilot CLI,
   and Factory AI Droid local import is supported only when their documented
   local history paths exist and match the supported native formats in the

--- a/docs/provider-support-matrix.json
+++ b/docs/provider-support-matrix.json
@@ -87,12 +87,13 @@
             "ctx import --provider pi"
           ],
           "notes": [
-            "Reads ~/.pi/sessions.jsonl when that file exists and matches the supported JSONL format."
+            "Reads Pi session JSONL files under ~/.pi/agent/sessions, including per-cwd session directories produced by current Pi releases.",
+            "An explicit Pi session JSONL file path remains supported with ctx import --provider pi --path."
           ]
         }
       ],
       "history_locations": [
-        "~/.pi/sessions.jsonl"
+        "~/.pi/agent/sessions"
       ],
       "imports_existing_history": true,
       "captures_new_runs_passively": false,

--- a/docs/provider-support.md
+++ b/docs/provider-support.md
@@ -23,7 +23,7 @@ is:
 | Provider | Status | Public import path | Public smoke |
 | --- | --- | --- | --- |
 | Codex | `local_import` | `~/.codex/sessions`, `~/.codex/history.jsonl`, or an explicit Codex path. | Static local-history fixture smoke. |
-| Pi | `local_import_when_supported` | `~/.pi/sessions.jsonl` or an explicit Pi JSONL path. | Static local-history fixture smoke. |
+| Pi | `local_import_when_supported` | `~/.pi/agent/sessions` or an explicit Pi session JSONL path. | Static local-history fixture smoke. |
 | Claude | `local_import_when_supported` | `~/.claude/projects` or an explicit Claude projects JSONL tree. | Static local-history fixture smoke. |
 | OpenCode | `local_import_when_supported` | `~/.local/share/opencode/opencode.db` or an explicit OpenCode SQLite DB. | Static local-history fixture smoke. |
 | OpenClaw | `local_import_when_supported` | `OPENCLAW_STATE_DIR`, `~/.openclaw`, legacy `~/.clawdbot`/`~/.moltbot`, or an explicit OpenClaw state tree. | Static local-history fixture smoke; beta storage-contract notes in the matrix. |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -10,8 +10,7 @@ The current CLI imports local history for:
 
 - Codex session JSONL trees under `~/.codex/sessions`;
 - Codex `~/.codex/history.jsonl`;
-- Pi `~/.pi/sessions.jsonl` when that local file exists and matches the
-  supported JSONL format;
+- Pi session JSONL files under `~/.pi/agent/sessions`;
 - Claude Code project JSONL transcripts under `~/.claude/projects`;
 - OpenCode SQLite history under `~/.local/share/opencode/opencode.db`;
 - OpenClaw session JSONL trees under `OPENCLAW_STATE_DIR`, `~/.openclaw`,


### PR DESCRIPTION
## What

- Move Pi default discovery from the obsolete `~/.pi/sessions.jsonl` file to current Pi session trees under `~/.pi/agent/sessions`.
- Import Pi directory trees by replaying discovered JSONL files while preserving explicit Pi JSONL file imports.
- Scope Pi event idempotency by session id so separate session files do not collide on matching line numbers.
- Update provider docs and CLI tests to match current Pi storage.

## Why

Current Pi releases write per-cwd JSONL sessions under `~/.pi/agent/sessions`, so `ctx sources` incorrectly reported a missing `~/.pi/sessions.jsonl` source.

Fixes https://github.com/ctxrs/ctx/issues/40.

## Checks

- `cargo fmt --check`
- `cargo test -p ctx-history-capture pi_session`
- `cargo test -p ctx-history-capture native_provider_default_discovery_uses_importer_specific_file_predicates`
- `cargo test -p ctx pi_cli`
- `cargo test -p ctx search_refresh_auto_imports_discovered_top_provider_sources`
- `cargo test -p ctx import_all_discovers_and_imports_providers_together`
- `scripts/check-provider-support-matrix.py`
- `scripts/check-docs.sh`
- `scripts/check.sh --mode fast`
- Manual smoke against a Pi 0.80.3-style `~/.pi/agent/sessions/.../*.jsonl` tree with `ctx sources`, `ctx import --provider pi`, and search.
