### PR TITLE
Prepare 0.19.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "ctx"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-capture"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "ctx-history-core",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-core"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "directories",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-search"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "ctx-history-core",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-store"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "ctx-history-core",

--- a/crates/ctx-cli/Cargo.toml
+++ b/crates/ctx-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx"
-version = "0.18.0"
+version = "0.19.0"
 description = "Local CLI for indexing and searching agent session history"
 edition.workspace = true
 autobins = false

--- a/crates/ctx-history-capture/Cargo.toml
+++ b/crates/ctx-history-capture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-capture"
-version = "0.18.0"
+version = "0.19.0"
 description = "Internal provider import adapters for ctx local agent history"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-core/Cargo.toml
+++ b/crates/ctx-history-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-core"
-version = "0.18.0"
+version = "0.19.0"
 description = "Internal core types for ctx local agent history indexing"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-search/Cargo.toml
+++ b/crates/ctx-history-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-search"
-version = "0.18.0"
+version = "0.19.0"
 description = "Internal search projection and ranking helpers for ctx"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-store/Cargo.toml
+++ b/crates/ctx-history-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-store"
-version = "0.18.0"
+version = "0.19.0"
 description = "Internal SQLite storage layer for ctx local agent history"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## What

- Bump the public `ctx` CLI crate and internal history crates to `0.19.0`.
- Refresh `Cargo.lock` package versions for the local release build.

## Why

Cut the Pi session directory import fix as the next minor release after #41.

## Checks

- `scripts/check.sh --mode ci` passed: 16/16 Bazel targets.
- `scripts/build-public-cli-artifact.sh linux-x64` passed and staged `ctx 0.19.0` with SHA-256 sidecar.
- Synthetic Pi smoke with `~/.pi/agent/sessions/.../*.jsonl`: sources, import, search all passed.
- Live Pi 0.80.3 isolated-HOME smoke: Pi created a real `.pi/agent/sessions/.../*.jsonl`; ctx 0.19.0 discovered/imported/searched it with zero failures.
