### PR TITLE
Harden CLI and provider import boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +285,7 @@ dependencies = [
  "ctx-history-store",
  "libc",
  "predicates",
+ "proptest",
  "ring",
  "rusqlite",
  "serde",
@@ -458,6 +474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,13 +535,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -793,6 +827,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +875,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,9 +910,53 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "redox_users"
@@ -973,6 +1085,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "serde"
@@ -1148,6 +1272,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,6 +1367,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1454,6 +1593,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ directories = "5.0"
 ed25519-dalek = "2.1"
 libc = "0.2"
 predicates = "3.1"
+proptest = "1"
 regex = "1.10"
 ring = "0.17"
 rusqlite = { version = "0.32", features = ["bundled", "hooks", "limits"] }

--- a/crates/ctx-cli/Cargo.toml
+++ b/crates/ctx-cli/Cargo.toml
@@ -38,5 +38,6 @@ libc.workspace = true
 [dev-dependencies]
 assert_cmd.workspace = true
 predicates.workspace = true
+proptest.workspace = true
 rusqlite.workspace = true
 tempfile.workspace = true

--- a/crates/ctx-cli/src/history_source_plugins.rs
+++ b/crates/ctx-cli/src/history_source_plugins.rs
@@ -19,6 +19,7 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 const PLUGIN_MANIFEST_FILE: &str = "ctx-history-plugin.json";
+const MAX_PLUGIN_MANIFEST_BYTES: usize = 1024 * 1024;
 const DEFAULT_PLUGIN_TIMEOUT_SECONDS: u64 = 300;
 const MAX_PLUGIN_STDOUT_BYTES: usize = 64 * 1024 * 1024;
 const MAX_PLUGIN_STDERR_BYTES: usize = 256 * 1024;
@@ -548,8 +549,7 @@ fn cleanup_cursor_file(path: Option<&PathBuf>) {
 }
 
 fn read_plugin_manifest(path: &Path) -> Result<Vec<HistorySourcePluginSource>> {
-    let raw = fs::read_to_string(path)
-        .with_context(|| format!("read history source plugin manifest {}", path.display()))?;
+    let raw = read_plugin_manifest_text(path)?;
     let manifest: HistorySourcePluginManifest = serde_json::from_str(&raw)
         .with_context(|| format!("parse history source plugin manifest {}", path.display()))?;
     validate_plugin_id("plugin name", &manifest.name)?;
@@ -610,6 +610,27 @@ fn read_plugin_manifest(path: &Path) -> Result<Vec<HistorySourcePluginSource>> {
         });
     }
     Ok(sources)
+}
+
+fn read_plugin_manifest_text(path: &Path) -> Result<String> {
+    let file = fs::File::open(path)
+        .with_context(|| format!("read history source plugin manifest {}", path.display()))?;
+    let mut bytes = Vec::new();
+    file.take((MAX_PLUGIN_MANIFEST_BYTES as u64).saturating_add(1))
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("read history source plugin manifest {}", path.display()))?;
+    if bytes.len() > MAX_PLUGIN_MANIFEST_BYTES {
+        return Err(anyhow!(
+            "history source plugin manifest {} exceeds max bytes ({MAX_PLUGIN_MANIFEST_BYTES})",
+            path.display()
+        ));
+    }
+    String::from_utf8(bytes).with_context(|| {
+        format!(
+            "history source plugin manifest {} is not UTF-8",
+            path.display()
+        )
+    })
 }
 
 fn plugin_manifest_paths(data_root: &Path) -> Vec<PathBuf> {

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -73,6 +73,7 @@ const LARGE_IMPORT_SOURCE_FILES_WARNING: usize = 10_000;
 const LARGE_IMPORT_SOURCE_BYTES_WARNING: u64 = 1024 * 1024 * 1024;
 const MAX_SEARCH_LIMIT: usize = 200;
 pub(crate) const MAX_EVENT_WINDOW: usize = 50;
+const MAX_HISTORY_SOURCE_PLUGIN_JSONL_LINE_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Debug, Parser)]
 #[command(name = "ctx", version, about = "Search local agent history")]
@@ -5169,15 +5170,8 @@ fn annotate_history_source_plugin_output(
     source: &HistorySourcePluginSource,
     stdout: &[u8],
 ) -> Result<Vec<u8>> {
-    let text = std::str::from_utf8(stdout).with_context(|| {
-        format!(
-            "history source plugin {} emitted non-UTF-8 ctx-history-jsonl-v1 output",
-            source.label()
-        )
-    })?;
     let mut out = Vec::with_capacity(stdout.len());
-    for (index, line) in text.lines().enumerate() {
-        let line_number = index + 1;
+    for (line_number, line) in history_source_plugin_stdout_lines(source, stdout)? {
         if line.trim().is_empty() {
             continue;
         }
@@ -5230,16 +5224,9 @@ fn validate_history_source_plugin_output(
     machine_id: &str,
     require_after_cursor: bool,
 ) -> Result<()> {
-    let text = std::str::from_utf8(stdout).with_context(|| {
-        format!(
-            "history source plugin {} emitted non-UTF-8 ctx-history-jsonl-v1 output",
-            source.label()
-        )
-    })?;
     let mut saw_source = false;
     let mut saw_after_cursor = false;
-    for (index, line) in text.lines().enumerate() {
-        let line_number = index + 1;
+    for (line_number, line) in history_source_plugin_stdout_lines(source, stdout)? {
         if line.trim().is_empty() {
             continue;
         }
@@ -5298,6 +5285,52 @@ fn validate_history_source_plugin_output(
         ));
     }
     Ok(())
+}
+
+fn history_source_plugin_stdout_lines<'a>(
+    source: &HistorySourcePluginSource,
+    stdout: &'a [u8],
+) -> Result<Vec<(usize, &'a str)>> {
+    let mut lines = Vec::new();
+    let mut start = 0usize;
+    let mut line_number = 1usize;
+    for (index, byte) in stdout.iter().enumerate() {
+        let len = index.saturating_add(1).saturating_sub(start);
+        if len > MAX_HISTORY_SOURCE_PLUGIN_JSONL_LINE_BYTES {
+            return Err(anyhow!(
+                "history source plugin {} emitted ctx-history-jsonl-v1 line {line_number} exceeding max bytes ({MAX_HISTORY_SOURCE_PLUGIN_JSONL_LINE_BYTES})",
+                source.label()
+            ));
+        }
+        if *byte == b'\n' {
+            let line = std::str::from_utf8(&stdout[start..index]).with_context(|| {
+                format!(
+                    "history source plugin {} emitted non-UTF-8 ctx-history-jsonl-v1 output at line {line_number}",
+                    source.label()
+                )
+            })?;
+            lines.push((line_number, line));
+            start = index + 1;
+            line_number += 1;
+        }
+    }
+    if start < stdout.len() {
+        let len = stdout.len().saturating_sub(start);
+        if len > MAX_HISTORY_SOURCE_PLUGIN_JSONL_LINE_BYTES {
+            return Err(anyhow!(
+                "history source plugin {} emitted ctx-history-jsonl-v1 line {line_number} exceeding max bytes ({MAX_HISTORY_SOURCE_PLUGIN_JSONL_LINE_BYTES})",
+                source.label()
+            ));
+        }
+        let line = std::str::from_utf8(&stdout[start..]).with_context(|| {
+            format!(
+                "history source plugin {} emitted non-UTF-8 ctx-history-jsonl-v1 output at line {line_number}",
+                source.label()
+            )
+        })?;
+        lines.push((line_number, line));
+    }
+    Ok(lines)
 }
 
 fn history_source_plugin_import_failure(

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -3091,14 +3091,7 @@ fn resolve_session(
         .ok_or_else(|| {
             anyhow!("session lookup requires --provider-session when no ctx session id is provided")
         })?;
-    let matches = store
-        .list_sessions()?
-        .into_iter()
-        .filter(|session| {
-            session.provider == provider
-                && session.external_session_id.as_deref() == Some(provider_session)
-        })
-        .collect::<Vec<_>>();
+    let matches = store.sessions_by_external_session_limited(provider, provider_session, 2)?;
     match matches.as_slice() {
         [session] => Ok(session.clone()),
         [] => Err(anyhow!(

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -3117,22 +3117,10 @@ fn event_window(
     after: usize,
     window: Option<usize>,
 ) -> Result<Vec<Event>> {
-    let Some(session_id) = event.session_id else {
-        return Ok(vec![event.clone()]);
-    };
-    let events = store.events_for_session(session_id)?;
-    let Some(index) = events.iter().position(|candidate| candidate.id == event.id) else {
-        return Ok(vec![event.clone()]);
-    };
     let (before, after) = window
         .map(|window| (window, window))
         .unwrap_or((before, after));
-    let start = index.saturating_sub(before);
-    let end = index
-        .saturating_add(after)
-        .saturating_add(1)
-        .min(events.len());
-    Ok(events[start..end].to_vec())
+    Ok(store.events_for_session_window(event, before, after)?)
 }
 
 fn write_rendered_session(

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -25,6 +25,9 @@ mod mcp;
 mod net;
 mod upgrade;
 
+#[cfg(test)]
+mod parser_prop_tests;
+
 use analytics::{AnalyticsEvent, AnalyticsProperties};
 use config::{AppConfig, CONFIG_FILE};
 use ctx_history_capture::{
@@ -57,7 +60,7 @@ use ctx_history_store::{
     CatalogSession, CatalogSourceIndexUpdate, RawSqlOptions, RawSqlResult, RawSqlValue,
     SourceImportFile, SourceImportFileIndexUpdate, Store, StoreError, RAW_SQL_DEFAULT_MAX_COLUMNS,
     RAW_SQL_DEFAULT_MAX_ROWS, RAW_SQL_DEFAULT_MAX_SQL_BYTES, RAW_SQL_DEFAULT_MAX_VALUE_BYTES,
-    RAW_SQL_MAX_TIMEOUT,
+    RAW_SQL_MAX_SQL_BYTES_CAP, RAW_SQL_MAX_TIMEOUT,
 };
 use history_source_plugins::{
     discover_history_source_plugins, discover_history_source_plugins_with_diagnostics,
@@ -69,6 +72,7 @@ const WAL_TRUNCATE_MIN_BYTES: u64 = 64 * 1024 * 1024;
 const LARGE_IMPORT_SOURCE_FILES_WARNING: usize = 10_000;
 const LARGE_IMPORT_SOURCE_BYTES_WARNING: u64 = 1024 * 1024 * 1024;
 const MAX_SEARCH_LIMIT: usize = 200;
+pub(crate) const MAX_EVENT_WINDOW: usize = 50;
 
 #[derive(Debug, Parser)]
 #[command(name = "ctx", version, about = "Search local agent history")]
@@ -202,11 +206,11 @@ struct ShowSessionArgs {
 struct ShowEventArgs {
     #[arg(help = "ctx event id or unambiguous id prefix")]
     id: String,
-    #[arg(long, default_value_t = 0)]
+    #[arg(long, default_value_t = 0, value_parser = parse_event_window_limit)]
     before: usize,
-    #[arg(long, default_value_t = 0)]
+    #[arg(long, default_value_t = 0, value_parser = parse_event_window_limit)]
     after: usize,
-    #[arg(long)]
+    #[arg(long, value_parser = parse_event_window_limit)]
     window: Option<usize>,
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
     format: OutputFormat,
@@ -3124,7 +3128,10 @@ fn event_window(
         .map(|window| (window, window))
         .unwrap_or((before, after));
     let start = index.saturating_sub(before);
-    let end = (index + after + 1).min(events.len());
+    let end = index
+        .saturating_add(after)
+        .saturating_add(1)
+        .min(events.len());
     Ok(events[start..end].to_vec())
 }
 
@@ -4001,6 +4008,18 @@ fn parse_search_limit(value: &str) -> std::result::Result<usize, String> {
     Ok(limit)
 }
 
+fn parse_event_window_limit(value: &str) -> std::result::Result<usize, String> {
+    let limit = value
+        .parse::<usize>()
+        .map_err(|err| format!("invalid event window: {err}"))?;
+    if limit > MAX_EVENT_WINDOW {
+        return Err(format!(
+            "event window must be between 0 and {MAX_EVENT_WINDOW}"
+        ));
+    }
+    Ok(limit)
+}
+
 fn parse_sql_timeout(value: &str) -> std::result::Result<StdDuration, String> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
@@ -4091,23 +4110,37 @@ fn run_sql(args: SqlArgs, data_root: PathBuf) -> Result<()> {
 }
 
 fn read_sql_input(args: &SqlArgs) -> Result<String> {
+    let max_sql_bytes = args.max_sql_bytes.min(RAW_SQL_MAX_SQL_BYTES_CAP);
     match (&args.sql, &args.file) {
         (Some(sql), None) if sql == "-" => {
-            let mut input = String::new();
-            std::io::stdin()
-                .read_to_string(&mut input)
-                .context("read SQL from stdin")?;
-            Ok(input)
+            read_sql_limited(std::io::stdin().lock(), max_sql_bytes, "stdin")
         }
         (Some(sql), None) => Ok(sql.clone()),
         (None, Some(path)) => {
-            fs::read_to_string(path).with_context(|| format!("read SQL from {}", path.display()))
+            let file = fs::File::open(path)
+                .with_context(|| format!("read SQL from {}", path.display()))?;
+            read_sql_limited(file, max_sql_bytes, &path.display().to_string())
         }
         (None, None) => Err(anyhow!(
             "SQL is required; pass a statement, --file <path>, or '-' for stdin"
         )),
         (Some(_), Some(_)) => unreachable!("clap rejects --file with inline SQL"),
     }
+}
+
+fn read_sql_limited(mut reader: impl Read, max_sql_bytes: usize, label: &str) -> Result<String> {
+    let mut input = String::new();
+    reader
+        .by_ref()
+        .take((max_sql_bytes as u64).saturating_add(1))
+        .read_to_string(&mut input)
+        .with_context(|| format!("read SQL from {label}"))?;
+    if input.len() > max_sql_bytes {
+        return Err(anyhow!(
+            "SQL input from {label} exceeds max_sql_bytes ({max_sql_bytes})"
+        ));
+    }
+    Ok(input)
 }
 
 fn print_sql_table(result: &RawSqlResult) -> Result<()> {
@@ -6446,8 +6479,8 @@ fn parse_since_filter(value: &str) -> Result<chrono::DateTime<Utc>> {
         let days: i64 = days
             .parse()
             .with_context(|| format!("invalid --since day window: {value}"))?;
-        let duration =
-            Duration::try_days(days).ok_or_else(|| anyhow!("invalid --since day window: {value}: value too large"))?;
+        let duration = Duration::try_days(days)
+            .ok_or_else(|| anyhow!("invalid --since day window: {value}: value too large"))?;
         let since = utc_now()
             .checked_sub_signed(duration)
             .ok_or_else(|| anyhow!("invalid --since day window: {value}: value too large"))?;
@@ -6480,8 +6513,12 @@ fn home_dir() -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{catalog_import_checkpoint_matches, parse_since_filter, sha256_file_prefix_hex, shell_quote_arg};
-    use std::{fs, io::Write};
+    use super::{
+        catalog_import_checkpoint_matches, normalize_uuid_prefix, parse_event_window_limit,
+        parse_search_limit, parse_since_filter, parse_sql_timeout, sha256_file_prefix_hex,
+        shell_quote_arg,
+    };
+    use std::{fs, io::Write, panic};
     use tempfile::tempdir;
 
     #[test]
@@ -6501,6 +6538,56 @@ mod tests {
             msg.contains("invalid --since day window"),
             "expected error about invalid day window, got: {msg}"
         );
+    }
+
+    #[test]
+    fn cli_value_parsers_do_not_panic_on_adversarial_inputs() {
+        let inputs = [
+            "",
+            " ",
+            "0",
+            "-1",
+            "1",
+            "30d",
+            "500000000d",
+            "9223372036854775807d",
+            "-9223372036854775808d",
+            "999999999999999999999999999999d",
+            "NaN",
+            "inf",
+            "1e309",
+            "1.5d",
+            "1970-01-01T00:00:00Z",
+            "999999-99-99T99:99:99Z",
+            "zzzzzzzz",
+            "ffffffff",
+            "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "\0",
+            "１２３",
+        ];
+
+        for input in inputs {
+            assert!(
+                panic::catch_unwind(|| parse_since_filter(input)).is_ok(),
+                "parse_since_filter panicked for {input:?}"
+            );
+            assert!(
+                panic::catch_unwind(|| parse_search_limit(input)).is_ok(),
+                "parse_search_limit panicked for {input:?}"
+            );
+            assert!(
+                panic::catch_unwind(|| parse_event_window_limit(input)).is_ok(),
+                "parse_event_window_limit panicked for {input:?}"
+            );
+            assert!(
+                panic::catch_unwind(|| parse_sql_timeout(input)).is_ok(),
+                "parse_sql_timeout panicked for {input:?}"
+            );
+            assert!(
+                panic::catch_unwind(|| normalize_uuid_prefix(input, "test")).is_ok(),
+                "normalize_uuid_prefix panicked for {input:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/ctx-cli/src/mcp.rs
+++ b/crates/ctx-cli/src/mcp.rs
@@ -27,9 +27,11 @@ use super::{
 
 const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
 const MCP_MAX_LINE_BYTES: usize = 1024 * 1024;
+const MCP_MAX_SESSION_EVENTS: usize = 200;
 
 enum McpInputLine {
     Line(String),
+    InvalidUtf8,
     TooLarge,
 }
 
@@ -73,6 +75,12 @@ fn serve_stdio(data_root: PathBuf) -> Result<()> {
                 }
                 handle_line(line, &data_root, &mut initialized)
             }
+            McpInputLine::InvalidUtf8 => Some(error_response(
+                Value::Null,
+                -32700,
+                "Parse error",
+                Some(json!({ "error": "MCP message is not valid UTF-8" })),
+            )),
             McpInputLine::TooLarge => Some(error_response(
                 Value::Null,
                 -32700,
@@ -121,10 +129,10 @@ fn read_mcp_input_line(reader: &mut impl BufRead) -> Result<Option<McpInputLine>
         reader.consume(bytes_to_consume);
     }
 
-    Ok(Some(McpInputLine::Line(
-        String::from_utf8(buffer)
-            .map_err(|err| anyhow!("read MCP JSON-RPC line as UTF-8: {err}"))?,
-    )))
+    Ok(Some(match String::from_utf8(buffer) {
+        Ok(line) => McpInputLine::Line(line),
+        Err(_) => McpInputLine::InvalidUtf8,
+    }))
 }
 
 fn discard_until_newline(reader: &mut impl BufRead) -> Result<()> {
@@ -497,14 +505,24 @@ fn tool_show_session(arguments: &Value, data_root: &Path) -> Result<Value> {
     let session_id = required_uuid(arguments, "ctx_session_id")?;
     let mode = optional_transcript_mode(arguments, "mode")?.unwrap_or(TranscriptMode::Lite);
     let session = store.get_session(session_id)?;
-    let events = store.events_for_session(session.id)?;
-    Ok(session_transcript_json(
-        &store,
-        &session,
-        &events,
-        mode,
-        OutputFormat::Json,
-    ))
+    let mut events = store.events_for_session_limited(session.id, MCP_MAX_SESSION_EVENTS + 1)?;
+    let truncated = events.len() > MCP_MAX_SESSION_EVENTS;
+    if truncated {
+        events.truncate(MCP_MAX_SESSION_EVENTS);
+    }
+    let mut value = session_transcript_json(&store, &session, &events, mode, OutputFormat::Json);
+    if truncated {
+        if let Some(object) = value.as_object_mut() {
+            object.insert(
+                "truncated".to_owned(),
+                json!({
+                    "events": true,
+                    "max_events": MCP_MAX_SESSION_EVENTS,
+                }),
+            );
+        }
+    }
+    Ok(value)
 }
 
 fn tool_show_event(arguments: &Value, data_root: &Path) -> Result<Value> {

--- a/crates/ctx-cli/src/mcp.rs
+++ b/crates/ctx-cli/src/mcp.rs
@@ -26,6 +26,12 @@ use super::{
 };
 
 const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
+const MCP_MAX_LINE_BYTES: usize = 1024 * 1024;
+
+enum McpInputLine {
+    Line(String),
+    TooLarge,
+}
 
 #[derive(Debug, Args)]
 pub(crate) struct McpArgs {
@@ -54,21 +60,93 @@ pub(crate) fn run(args: McpArgs, data_root: PathBuf) -> Result<()> {
 fn serve_stdio(data_root: PathBuf) -> Result<()> {
     let stdin = io::stdin();
     let stdout = io::stdout();
+    let mut stdin = stdin.lock();
     let mut stdout = stdout.lock();
     let mut initialized = false;
 
-    for line in stdin.lock().lines() {
-        let line = line?;
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        if let Some(response) = handle_line(line, &data_root, &mut initialized) {
+    while let Some(input) = read_mcp_input_line(&mut stdin)? {
+        let response = match input {
+            McpInputLine::Line(line) => {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                handle_line(line, &data_root, &mut initialized)
+            }
+            McpInputLine::TooLarge => Some(error_response(
+                Value::Null,
+                -32700,
+                "Parse error",
+                Some(json!({
+                    "error": format!("MCP message exceeds max line bytes ({MCP_MAX_LINE_BYTES})")
+                })),
+            )),
+        };
+        if let Some(response) = response {
             writeln!(stdout, "{}", serde_json::to_string(&response)?)?;
             stdout.flush()?;
         }
     }
     Ok(())
+}
+
+fn read_mcp_input_line(reader: &mut impl BufRead) -> Result<Option<McpInputLine>> {
+    let mut buffer = Vec::new();
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            if buffer.is_empty() {
+                return Ok(None);
+            }
+            break;
+        }
+        if let Some(newline_index) = available.iter().position(|byte| *byte == b'\n') {
+            let bytes_to_consume = newline_index + 1;
+            if buffer.len().saturating_add(bytes_to_consume) > MCP_MAX_LINE_BYTES {
+                reader.consume(bytes_to_consume);
+                return Ok(Some(McpInputLine::TooLarge));
+            }
+            buffer.extend_from_slice(&available[..bytes_to_consume]);
+            reader.consume(bytes_to_consume);
+            break;
+        }
+
+        let bytes_to_consume = available.len();
+        if buffer.len().saturating_add(bytes_to_consume) > MCP_MAX_LINE_BYTES {
+            reader.consume(bytes_to_consume);
+            discard_until_newline(reader)?;
+            return Ok(Some(McpInputLine::TooLarge));
+        }
+        buffer.extend_from_slice(available);
+        reader.consume(bytes_to_consume);
+    }
+
+    Ok(Some(McpInputLine::Line(
+        String::from_utf8(buffer)
+            .map_err(|err| anyhow!("read MCP JSON-RPC line as UTF-8: {err}"))?,
+    )))
+}
+
+fn discard_until_newline(reader: &mut impl BufRead) -> Result<()> {
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            return Ok(());
+        }
+        let bytes_to_consume = available
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map(|index| index + 1)
+            .unwrap_or(available.len());
+        let found_newline = bytes_to_consume <= available.len()
+            && available
+                .get(bytes_to_consume.saturating_sub(1))
+                .is_some_and(|byte| *byte == b'\n');
+        reader.consume(bytes_to_consume);
+        if found_newline {
+            return Ok(());
+        }
+    }
 }
 
 fn handle_line(line: &str, data_root: &Path, initialized: &mut bool) -> Option<Value> {

--- a/crates/ctx-cli/src/mcp.rs
+++ b/crates/ctx-cli/src/mcp.rs
@@ -21,11 +21,11 @@ use super::{
     event_window, event_window_json, indexed_history_item_count, mark_share_safe,
     raw_sql_result_json, search_filters, search_has_intent, session_transcript_json, sources_json,
     OutputFormat, ProviderArg, RefreshArg, SearchDto, SearchFilterInput, SearchIntentInput,
-    SearchRefreshReport, SourceIdentityFilterArgs, TranscriptMode, MAX_SEARCH_LIMIT,
+    SearchRefreshReport, SourceIdentityFilterArgs, TranscriptMode, MAX_EVENT_WINDOW,
+    MAX_SEARCH_LIMIT,
 };
 
 const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
-const MCP_MAX_EVENT_WINDOW: usize = 50;
 
 #[derive(Debug, Args)]
 pub(crate) struct McpArgs {
@@ -435,12 +435,12 @@ fn tool_show_event(arguments: &Value, data_root: &Path) -> Result<Value> {
     let before = optional_usize(arguments, "before")?.unwrap_or(0);
     let after = optional_usize(arguments, "after")?.unwrap_or(0);
     let window = optional_usize(arguments, "window")?;
-    if before > MCP_MAX_EVENT_WINDOW
-        || after > MCP_MAX_EVENT_WINDOW
-        || window.is_some_and(|window| window > MCP_MAX_EVENT_WINDOW)
+    if before > MAX_EVENT_WINDOW
+        || after > MAX_EVENT_WINDOW
+        || window.is_some_and(|window| window > MAX_EVENT_WINDOW)
     {
         return Err(anyhow!(
-            "show_event before/after/window must be {MCP_MAX_EVENT_WINDOW} or less"
+            "show_event before/after/window must be {MAX_EVENT_WINDOW} or less"
         ));
     }
     let event = store.get_event(event_id)?;

--- a/crates/ctx-cli/src/net.rs
+++ b/crates/ctx-cli/src/net.rs
@@ -27,20 +27,33 @@ pub fn post_json(endpoint: &str, body: &[u8]) -> Result<()> {
         .map_err(|err| anyhow!("POST {endpoint}: {err}"))
 }
 
-pub fn get_bytes(endpoint: &str) -> Result<Vec<u8>> {
+pub fn get_bytes_limited(endpoint: &str, max_bytes: usize) -> Result<Vec<u8>> {
     if let Some(path) = file_url_path(endpoint)? {
-        return fs::read(&path).with_context(|| format!("read {}", path.display()));
+        let file = fs::File::open(&path).with_context(|| format!("read {}", path.display()))?;
+        return read_limited(file, max_bytes, &format!("read {}", path.display()));
     }
     require_https_or_localhost(endpoint)?;
     let response = ureq::get(endpoint)
         .timeout(std::time::Duration::from_secs(20))
         .call()
         .map_err(|err| anyhow!("GET {endpoint}: {err}"))?;
-    let mut reader = response.into_reader();
+    read_limited(
+        response.into_reader(),
+        max_bytes,
+        &format!("GET {endpoint}"),
+    )
+}
+
+fn read_limited(mut reader: impl Read, max_bytes: usize, label: &str) -> Result<Vec<u8>> {
     let mut bytes = Vec::new();
     reader
+        .by_ref()
+        .take((max_bytes as u64).saturating_add(1))
         .read_to_end(&mut bytes)
-        .map_err(|err| anyhow!("read GET {endpoint}: {err}"))?;
+        .map_err(|err| anyhow!("{label}: {err}"))?;
+    if bytes.len() > max_bytes {
+        return Err(anyhow!("{label} exceeds max bytes ({max_bytes})"));
+    }
     Ok(bytes)
 }
 
@@ -108,5 +121,14 @@ mod tests {
         require_https_or_localhost("http://[::1]:8080/events").unwrap();
         assert!(require_https_or_localhost("http://example.com/events").is_err());
         assert!(require_https_or_localhost("http://example.com@localhost/events").is_err());
+    }
+
+    #[test]
+    fn get_bytes_limited_rejects_oversized_file_urls() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("oversized.bin");
+        fs::write(&path, b"12345").unwrap();
+        let err = get_bytes_limited(&format!("file://{}", path.display()), 4).unwrap_err();
+        assert!(err.to_string().contains("exceeds max bytes (4)"));
     }
 }

--- a/crates/ctx-cli/src/parser_prop_tests.rs
+++ b/crates/ctx-cli/src/parser_prop_tests.rs
@@ -1,0 +1,48 @@
+use super::{
+    normalize_uuid_prefix, parse_event_window_limit, parse_search_limit, parse_since_filter,
+    parse_sql_timeout, MAX_EVENT_WINDOW, MAX_SEARCH_LIMIT,
+};
+use proptest::prelude::*;
+use std::panic;
+
+proptest! {
+    #[test]
+    fn cli_value_parsers_never_panic_for_generated_strings(input in ".{0,256}") {
+        prop_assert!(panic::catch_unwind(|| parse_since_filter(&input)).is_ok());
+        prop_assert!(panic::catch_unwind(|| parse_search_limit(&input)).is_ok());
+        prop_assert!(panic::catch_unwind(|| parse_event_window_limit(&input)).is_ok());
+        prop_assert!(panic::catch_unwind(|| parse_sql_timeout(&input)).is_ok());
+        prop_assert!(panic::catch_unwind(|| normalize_uuid_prefix(&input, "test")).is_ok());
+    }
+
+    #[test]
+    fn parse_search_limit_accepts_only_public_limit_range(limit in 1usize..=MAX_SEARCH_LIMIT) {
+        prop_assert_eq!(parse_search_limit(&limit.to_string()), Ok(limit));
+    }
+
+    #[test]
+    fn parse_search_limit_rejects_values_above_public_limit(limit in (MAX_SEARCH_LIMIT + 1)..=usize::MAX) {
+        prop_assert!(parse_search_limit(&limit.to_string()).is_err());
+    }
+
+    #[test]
+    fn parse_event_window_limit_accepts_only_public_window_range(limit in 0usize..=MAX_EVENT_WINDOW) {
+        prop_assert_eq!(parse_event_window_limit(&limit.to_string()), Ok(limit));
+    }
+
+    #[test]
+    fn parse_event_window_limit_rejects_values_above_public_window(limit in (MAX_EVENT_WINDOW + 1)..=usize::MAX) {
+        prop_assert!(parse_event_window_limit(&limit.to_string()).is_err());
+    }
+
+    #[test]
+    fn parse_since_filter_rejects_unrepresentable_day_windows(days in any::<i64>()) {
+        if chrono::Duration::try_days(days)
+            .and_then(|duration| crate::utc_now().checked_sub_signed(duration))
+            .is_none()
+        {
+            let input = format!("{days}d");
+            prop_assert!(parse_since_filter(&input).is_err());
+        }
+    }
+}

--- a/crates/ctx-cli/src/upgrade.rs
+++ b/crates/ctx-cli/src/upgrade.rs
@@ -21,6 +21,9 @@ use crate::{config::AppConfig, net};
 const STATE_FILE: &str = "upgrade-state.json";
 const LOCK_FILE: &str = "upgrade.lock";
 const LOG_FILE: &str = "logs/upgrade.log";
+const RELEASE_METADATA_MAX_BYTES: usize = 1024 * 1024;
+const RELEASE_METADATA_SIGNATURE_MAX_BYTES: usize = 64 * 1024;
+const RELEASE_ARTIFACT_MAX_BYTES: usize = 128 * 1024 * 1024;
 const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 const VERSION_PROBE_OUTPUT_LIMIT: usize = 4096;
 const STALE_UPGRADE_LOCK_AFTER: Duration = Duration::from_secs(30 * 60);
@@ -380,7 +383,7 @@ fn apply_upgrade(
             warnings,
         });
     }
-    let bytes = net::get_bytes(&plan.artifact_url)
+    let bytes = net::get_bytes_limited(&plan.artifact_url, RELEASE_ARTIFACT_MAX_BYTES)
         .with_context(|| format!("download {}", plan.artifact_url))?;
     verify_artifact_sha(&bytes, &plan.artifact_sha256)?;
     let apply_result = apply_artifact(&plan, &bytes)?;
@@ -444,10 +447,11 @@ fn build_upgrade_plan(
     warnings.extend(path.warnings.clone());
     let metadata_url = metadata_url(config, &channel);
     let signature_url = metadata_signature_url(&metadata_url);
-    let metadata_bytes = net::get_bytes(&metadata_url)
+    let metadata_bytes = net::get_bytes_limited(&metadata_url, RELEASE_METADATA_MAX_BYTES)
         .with_context(|| format!("download release metadata {metadata_url}"))?;
-    let signature_bytes = net::get_bytes(&signature_url)
-        .with_context(|| format!("download release metadata signature {signature_url}"))?;
+    let signature_bytes =
+        net::get_bytes_limited(&signature_url, RELEASE_METADATA_SIGNATURE_MAX_BYTES)
+            .with_context(|| format!("download release metadata signature {signature_url}"))?;
     verify_metadata_signature(&metadata_bytes, &signature_bytes)?;
     let metadata = parse_release_metadata(&metadata_bytes, &platform, &channel)?;
     let artifact_url = format!(

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -1491,6 +1491,31 @@ for record in records:
 }
 
 #[test]
+fn history_source_plugin_rejects_oversized_stdout_line() {
+    let temp = tempdir();
+    let script = r#"#!/usr/bin/env python3
+import sys
+sys.stdout.write("x" * (17 * 1024 * 1024) + "\n")
+"#;
+    let plugin = write_raw_history_source_plugin(&temp, "bigline", script);
+
+    let stderr = failure_stderr(
+        ctx(&temp)
+            .env("CTX_HISTORY_PLUGIN_PATH", &plugin.manifest_dir)
+            .args([
+                "import",
+                "--history-source",
+                "bigline/default",
+                "--json",
+                "--progress",
+                "none",
+            ]),
+    );
+
+    assert!(stderr.contains("line 1 exceeding max bytes"), "{stderr}");
+}
+
+#[test]
 fn history_source_plugin_reset_requires_fresh_after_cursor() {
     let temp = tempdir();
     let script = r#"#!/usr/bin/env python3

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -43,7 +43,9 @@ fn copied_ctx_binary(temp: &TempDir) -> PathBuf {
     } else {
         "ctx-test-copy"
     });
-    fs::copy(&source, &target).unwrap();
+    if fs::hard_link(&source, &target).is_err() {
+        fs::copy(&source, &target).unwrap();
+    }
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -510,6 +510,10 @@ fn mcp_roundtrip_with_env(temp: &TempDir, messages: &[Value], envs: &[(&str, &st
 }
 
 fn mcp_raw_roundtrip(temp: &TempDir, stdin: String) -> Vec<Value> {
+    mcp_raw_roundtrip_bytes(temp, stdin.into_bytes())
+}
+
+fn mcp_raw_roundtrip_bytes(temp: &TempDir, stdin: Vec<u8>) -> Vec<Value> {
     let output = ctx(temp)
         .args(["mcp", "serve"])
         .write_stdin(stdin)
@@ -4141,6 +4145,33 @@ fn mcp_rejects_oversized_input_line_and_continues() {
 }
 
 #[test]
+fn mcp_rejects_invalid_utf8_input_line_and_continues() {
+    let temp = tempdir();
+    let initialize = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": { "name": "ctx-test", "version": "0" }
+        }
+    });
+    let mut stdin = vec![0xff, b'\n'];
+    stdin.extend_from_slice(serde_json::to_string(&initialize).unwrap().as_bytes());
+    stdin.push(b'\n');
+
+    let responses = mcp_raw_roundtrip_bytes(&temp, stdin);
+    assert_eq!(responses.len(), 2);
+    assert_eq!(responses[0]["error"]["code"], -32700);
+    assert_eq!(
+        responses[0]["error"]["data"]["error"],
+        "MCP message is not valid UTF-8"
+    );
+    assert_eq!(responses[1]["result"]["serverInfo"]["name"], "ctx");
+}
+
+#[test]
 fn mcp_sql_tool_returns_structured_json_and_rejects_writes() {
     let temp = tempdir();
     ctx(&temp)
@@ -4184,6 +4215,23 @@ fn mcp_sql_tool_returns_structured_json_and_rejects_writes() {
                     }
                 }
             }),
+            json!({
+                "jsonrpc": "2.0",
+                "id": "budget",
+                "method": "tools/call",
+                "params": {
+                    "name": "sql",
+                    "arguments": {
+                        "sql": format!(
+                            "SELECT {}",
+                            (0..256).map(|index| format!("1 AS c{index}")).collect::<Vec<_>>().join(", ")
+                        ),
+                        "max_rows": 10000,
+                        "max_columns": 256,
+                        "max_value_bytes": 32
+                    }
+                }
+            }),
         ],
     );
 
@@ -4200,6 +4248,89 @@ fn mcp_sql_tool_returns_structured_json_and_rejects_writes() {
         .as_str()
         .unwrap()
         .contains("SQL query must be read-only"));
+
+    let budget = &responses[3]["result"];
+    assert_eq!(budget["isError"], true);
+    assert!(budget["structuredContent"]["error"]
+        .as_str()
+        .unwrap()
+        .contains("SQL result preview budget"));
+}
+
+#[test]
+fn mcp_show_session_caps_transcript_events() {
+    let temp = tempdir();
+    ctx(&temp)
+        .args(["setup", "--catalog-only", "--progress", "none"])
+        .assert()
+        .success();
+
+    let session_id = "018f45d0-0000-7000-8000-000000010001";
+    let conn = Connection::open(temp.path().join("work.sqlite")).unwrap();
+    conn.execute(
+        r#"
+        INSERT INTO sessions
+        (
+            id, provider, external_session_id, agent_type, is_primary, status, fidelity,
+            started_at_ms, created_at_ms, updated_at_ms
+        )
+        VALUES (?1, 'codex', 'mcp-large-session', 'primary', 1, 'imported', 'imported', 1, 1, 1)
+        "#,
+        [session_id],
+    )
+    .unwrap();
+    for index in 0..201 {
+        let event_id = format!("018f45d0-0000-7000-8000-{index:012x}");
+        conn.execute(
+            r#"
+            INSERT INTO events
+            (id, seq, session_id, event_type, role, occurred_at_ms, payload_json)
+            VALUES (?1, ?2, ?3, 'message', 'assistant', ?4, ?5)
+            "#,
+            params![
+                event_id,
+                index,
+                session_id,
+                index + 1,
+                format!(r#"{{"text":"mcp transcript event {index}"}}"#)
+            ],
+        )
+        .unwrap();
+    }
+    drop(conn);
+
+    let responses = mcp_roundtrip(
+        &temp,
+        &[
+            json!({
+                "jsonrpc": "2.0",
+                "id": "init",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": { "name": "ctx-test", "version": "0" }
+                }
+            }),
+            json!({
+                "jsonrpc": "2.0",
+                "id": "show",
+                "method": "tools/call",
+                "params": {
+                    "name": "show_session",
+                    "arguments": {
+                        "ctx_session_id": session_id,
+                        "mode": "log"
+                    }
+                }
+            }),
+        ],
+    );
+
+    let transcript = &responses[1]["result"]["structuredContent"];
+    assert_eq!(transcript["truncated"]["events"], true);
+    assert_eq!(transcript["truncated"]["max_events"], 200);
+    assert_eq!(transcript["events"].as_array().unwrap().len(), 200);
 }
 
 #[test]

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -1256,6 +1256,36 @@ fn invalid_installed_history_source_plugin_is_listed_as_invalid() {
 }
 
 #[test]
+fn oversized_installed_history_source_plugin_is_listed_as_invalid() {
+    let temp = tempdir();
+    let plugin_root = temp.path().join("history-plugins");
+    let bad_dir = plugin_root.join("oversized");
+    fs::create_dir_all(&bad_dir).unwrap();
+    fs::write(
+        bad_dir.join("ctx-history-plugin.json"),
+        vec![b' '; 2 * 1024 * 1024],
+    )
+    .unwrap();
+
+    let sources = json_output(
+        ctx(&temp)
+            .env("CTX_HISTORY_PLUGIN_PATH", &plugin_root)
+            .args(["sources", "--json"]),
+    );
+    let invalid = sources["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|source| source["kind"] == "history_source_plugin" && source["status"] == "invalid")
+        .unwrap();
+    assert_eq!(invalid["importable"], false);
+    assert!(invalid["error"]
+        .as_str()
+        .unwrap()
+        .contains("exceeds max bytes"));
+}
+
+#[test]
 fn invalid_installed_history_source_plugin_does_not_block_valid_import() {
     let temp = tempdir();
     let plugin_root = temp.path().join("history-plugins");

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -509,6 +509,22 @@ fn mcp_roundtrip_with_env(temp: &TempDir, messages: &[Value], envs: &[(&str, &st
         .collect()
 }
 
+fn mcp_raw_roundtrip(temp: &TempDir, stdin: String) -> Vec<Value> {
+    let output = ctx(temp)
+        .args(["mcp", "serve"])
+        .write_stdin(stdin)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    String::from_utf8(output)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
 fn assert_omits_keys(value: &Value, forbidden_keys: &[&str]) {
     match value {
         Value::Object(map) => {
@@ -4090,6 +4106,38 @@ fn mcp_status_and_tools_list_are_read_only_without_initialized_store() {
         !temp.path().join("work.sqlite").exists(),
         "MCP status should not initialize the ctx store"
     );
+}
+
+#[test]
+fn mcp_rejects_oversized_input_line_and_continues() {
+    let temp = tempdir();
+    let initialize = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": { "name": "ctx-test", "version": "0" }
+        }
+    });
+    let mut stdin = "x".repeat(1024 * 1024 + 1);
+    stdin.push('\n');
+    stdin.push_str(&serde_json::to_string(&initialize).unwrap());
+    stdin.push('\n');
+
+    let responses = mcp_raw_roundtrip(&temp, stdin);
+    assert_eq!(responses.len(), 2);
+    assert_eq!(responses[0]["error"]["code"], -32700);
+    assert!(
+        responses[0]["error"]["data"]["error"]
+            .as_str()
+            .unwrap()
+            .contains("exceeds max line bytes"),
+        "{:#}",
+        responses[0]
+    );
+    assert_eq!(responses[1]["result"]["serverInfo"]["name"], "ctx");
 }
 
 #[test]

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -2202,6 +2202,32 @@ fn sql_reads_existing_store_and_supports_formats_and_input_sources() {
         "value,n\n\"a,b\",2\n"
     );
 
+    let oversized_file_stderr = failure_stderr(
+        ctx(&temp)
+            .arg("sql")
+            .arg("--file")
+            .arg(&query_file)
+            .args(["--max-sql-bytes", "4"]),
+    );
+    assert!(
+        oversized_file_stderr.contains("exceeds max_sql_bytes (4)"),
+        "{oversized_file_stderr}"
+    );
+
+    let oversized_stdin_stderr = ctx(&temp)
+        .args(["sql", "-", "--max-sql-bytes", "4"])
+        .write_stdin("SELECT 1")
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    let oversized_stdin_stderr = String::from_utf8(oversized_stdin_stderr).unwrap();
+    assert!(
+        oversized_stdin_stderr.contains("exceeds max_sql_bytes (4)"),
+        "{oversized_stdin_stderr}"
+    );
+
     let raw_output = ctx(&temp)
         .args(["sql", "-", "--format", "raw"])
         .write_stdin("SELECT 'abc' AS value")
@@ -3837,6 +3863,30 @@ fn fresh_home_search_mvp_flow() {
         "json",
     ]));
     assert_eq!(show_event_prefix["event"]["ctx_event_id"], ctx_event_id);
+
+    let oversized_after = failure_stderr(ctx(&temp).args([
+        "show",
+        "event",
+        &ctx_event_id,
+        "--after",
+        "18446744073709551615",
+    ]));
+    assert!(
+        oversized_after.contains("event window must be between 0 and 50"),
+        "{oversized_after}"
+    );
+
+    let oversized_window = failure_stderr(ctx(&temp).args([
+        "show",
+        "event",
+        &ctx_event_id,
+        "--window",
+        "18446744073709551615",
+    ]));
+    assert!(
+        oversized_window.contains("event window must be between 0 and 50"),
+        "{oversized_window}"
+    );
 
     let show_session =
         json_output(ctx(&temp).args(["show", "session", &ctx_session_id, "--format", "json"]));

--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -9004,12 +9004,7 @@ fn normalize_opencode_sqlite(
     path: &Path,
     context: &ProviderAdapterContext,
 ) -> Result<ProviderNormalizationResult> {
-    let conn = Connection::open_with_flags(
-        path,
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )?;
-    conn.busy_timeout(std::time::Duration::from_secs(5))?;
-    conn.pragma_update(None, "query_only", true)?;
+    let conn = open_provider_sqlite_readonly(path)?;
     let user_version: i64 = conn.pragma_query_value(None, "user_version", |row| row.get(0))?;
     let schema_fingerprint = opencode_schema_fingerprint(&conn)?;
     let legacy_message_rows = opencode_count(&conn, "message").unwrap_or(0);
@@ -13888,6 +13883,25 @@ mod tests {
             events[0].sync.metadata["source_format"].as_str(),
             Some(OPENCODE_SQLITE_SOURCE_FORMAT)
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn native_opencode_normalizer_rejects_symlinked_sqlite() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir();
+        let fixture = write_opencode_smoke_db(&temp, false);
+        let link = temp.path().join("linked-opencode.db");
+        symlink(&fixture, &link).unwrap();
+
+        let err = normalize_opencode_sqlite(&link, &ProviderAdapterContext::default()).unwrap_err();
+        assert!(matches!(
+            err,
+            CaptureError::InvalidProviderTranscriptPath { path, reason }
+                if path.ends_with("linked-opencode.db")
+                    && reason == "symlinked provider transcript files are rejected"
+        ));
     }
 
     #[test]

--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     env,
     fs::{self, File},
-    io::{BufRead, BufReader, BufWriter, Write},
+    io::{BufRead, BufReader, BufWriter, Read, Write},
     path::{Path, PathBuf},
     sync::Arc,
     thread,
@@ -42,6 +42,9 @@ pub use provider_sources::{
 pub const CAPTURE_SCHEMA_VERSION: u32 = 1;
 const MAX_PROVIDER_JSONL_LINE_BYTES: usize = 16 * 1024 * 1024;
 const MAX_PROVIDER_SQLITE_VALUE_BYTES: usize = MAX_PROVIDER_JSONL_LINE_BYTES;
+const MAX_OPENCLAW_SESSION_INDEX_BYTES: usize = 1024 * 1024;
+const MAX_OPENCLAW_SESSION_INDEX_PATHS: usize = 256;
+const MAX_OPENCLAW_SESSION_INDEX_VISITED_PATHS: usize = 4096;
 #[derive(Debug, Error)]
 pub enum CaptureError {
     #[error("io error: {0}")]
@@ -4888,6 +4891,20 @@ fn ensure_provider_path_parents_are_not_symlinks(path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn read_text_file_limited(path: &Path, max_bytes: usize, label: &str) -> Result<String> {
+    let file = File::open(path)?;
+    let mut reader = file.take((max_bytes as u64).saturating_add(1));
+    let mut bytes = Vec::new();
+    reader.read_to_end(&mut bytes)?;
+    if bytes.len() > max_bytes {
+        return Err(CaptureError::InvalidPayload(format!(
+            "{label} exceeds max bytes ({max_bytes})"
+        )));
+    }
+    String::from_utf8(bytes)
+        .map_err(|err| CaptureError::InvalidPayload(format!("{label} is not valid UTF-8: {err}")))
+}
+
 fn read_provider_jsonl_line(reader: &mut impl BufRead, buffer: &mut Vec<u8>) -> Result<bool> {
     buffer.clear();
     let mut total = 0usize;
@@ -6954,9 +6971,21 @@ fn provider_path_has_component(path: &Path, expected: &str) -> bool {
 fn openclaw_session_indexes(root: &Path) -> BTreeMap<String, Value> {
     let mut indexes = BTreeMap::new();
     let mut paths = Vec::new();
-    collect_named_paths(root, "sessions.json", &mut paths);
+    let mut visited = 0usize;
+    collect_named_paths(
+        root,
+        "sessions.json",
+        &mut paths,
+        &mut visited,
+        MAX_OPENCLAW_SESSION_INDEX_PATHS,
+        MAX_OPENCLAW_SESSION_INDEX_VISITED_PATHS,
+    );
     for path in paths {
-        let Ok(text) = fs::read_to_string(&path) else {
+        let Ok(text) = read_text_file_limited(
+            &path,
+            MAX_OPENCLAW_SESSION_INDEX_BYTES,
+            "OpenClaw sessions.json",
+        ) else {
             continue;
         };
         let Ok(value) = serde_json::from_str::<Value>(&text) else {
@@ -7015,7 +7044,18 @@ fn openclaw_session_index_entries(value: Value) -> Vec<(String, Value)> {
     }
 }
 
-fn collect_named_paths(root: &Path, name: &str, paths: &mut Vec<PathBuf>) {
+fn collect_named_paths(
+    root: &Path,
+    name: &str,
+    paths: &mut Vec<PathBuf>,
+    visited: &mut usize,
+    max_paths: usize,
+    max_visited: usize,
+) {
+    if paths.len() >= max_paths || *visited >= max_visited {
+        return;
+    }
+    *visited += 1;
     let Ok(metadata) = fs::symlink_metadata(root) else {
         return;
     };
@@ -7035,7 +7075,10 @@ fn collect_named_paths(root: &Path, name: &str, paths: &mut Vec<PathBuf>) {
         return;
     };
     for entry in entries.flatten() {
-        collect_named_paths(&entry.path(), name, paths);
+        if paths.len() >= max_paths || *visited >= max_visited {
+            break;
+        }
+        collect_named_paths(&entry.path(), name, paths, visited, max_paths, max_visited);
     }
 }
 
@@ -14527,6 +14570,62 @@ mod tests {
         assert!(err
             .to_string()
             .contains("OpenCode SQLite message table missing required column(s): data"));
+    }
+
+    #[test]
+    fn openclaw_import_ignores_oversized_session_index_sidecar() {
+        let temp = tempdir();
+        let root = temp.path().join("openclaw");
+        let sessions = root.join("agents/personal-agent/sessions");
+        fs::create_dir_all(&sessions).unwrap();
+        fs::write(
+            sessions.join("sessions.json"),
+            vec![b'x'; MAX_OPENCLAW_SESSION_INDEX_BYTES + 1],
+        )
+        .unwrap();
+        fs::write(
+            sessions.join("openclaw-oversized-index.jsonl"),
+            format!(
+                "{}\n{}\n",
+                json!({
+                    "type": "session",
+                    "id": "openclaw-oversized-index",
+                    "timestamp": "2026-06-24T12:00:00Z",
+                    "cwd": "/workspace"
+                }),
+                json!({
+                    "type": "message",
+                    "id": "openclaw-oversized-index-user",
+                    "timestamp": "2026-06-24T12:00:01Z",
+                    "message": {"role": "user", "content": "oversized sidecar should not block import"}
+                })
+            ),
+        )
+        .unwrap();
+        let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+        let summary = import_openclaw_history(
+            &root,
+            &mut store,
+            OpenClawImportOptions {
+                allow_partial_failures: true,
+                ..OpenClawImportOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.imported_sessions, 1);
+        assert_eq!(summary.imported_events, 1);
+        let session_id = provider_session_uuid(
+            CaptureProvider::OpenClaw,
+            "personal-agent/openclaw-oversized-index",
+        );
+        let session = store.get_session(session_id).unwrap();
+        assert_eq!(
+            session.external_session_id.as_deref(),
+            Some("personal-agent/openclaw-oversized-index")
+        );
     }
 
     #[test]

--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -6854,19 +6854,33 @@ fn provider_line_from_index(index: u64) -> usize {
     index.min(usize::MAX as u64) as usize
 }
 
-fn provider_timestamp_seconds(value: Option<f64>, fallback: DateTime<Utc>) -> DateTime<Utc> {
-    let Some(value) = value else {
-        return fallback;
-    };
+fn provider_timestamp_seconds_to_datetime(value: f64) -> Option<DateTime<Utc>> {
     if !value.is_finite() {
-        return fallback;
+        return None;
     }
     let millis = if value.abs() > 1_000_000_000_000.0 {
-        value.round() as i64
+        value.round()
     } else {
-        (value * 1000.0).round() as i64
+        (value * 1000.0).round()
     };
-    DateTime::<Utc>::from_timestamp_millis(millis).unwrap_or(fallback)
+    if millis < i64::MIN as f64 || millis > i64::MAX as f64 {
+        return None;
+    }
+    DateTime::<Utc>::from_timestamp_millis(millis as i64)
+}
+
+fn provider_timestamp_seconds(value: Option<f64>, fallback: DateTime<Utc>) -> DateTime<Utc> {
+    value
+        .and_then(provider_timestamp_seconds_to_datetime)
+        .unwrap_or(fallback)
+}
+
+fn provider_required_timestamp_seconds(value: f64, field: &'static str) -> Result<DateTime<Utc>> {
+    provider_timestamp_seconds_to_datetime(value).ok_or_else(|| {
+        CaptureError::InvalidPayload(format!(
+            "{field} is outside representable timestamp range: {value}"
+        ))
+    })
 }
 
 fn provider_timestamp_millis(value: Option<i64>, fallback: DateTime<Utc>) -> DateTime<Utc> {
@@ -7457,11 +7471,37 @@ fn normalize_hermes_sqlite(
             continue;
         };
         let provider_session_id = session.id.clone();
-        let occurred_at = provider_timestamp_seconds(Some(row.timestamp), context.imported_at);
-        let started_at = provider_timestamp_seconds(Some(session.started_at), occurred_at);
-        let ended_at = session
+        let occurred_at =
+            match provider_required_timestamp_seconds(row.timestamp, "Hermes message timestamp") {
+                Ok(timestamp) => timestamp,
+                Err(err) => {
+                    push_provider_import_failure(&mut result.summary, line, err.to_string());
+                    continue;
+                }
+            };
+        let started_at = match provider_required_timestamp_seconds(
+            session.started_at,
+            "Hermes session started_at",
+        ) {
+            Ok(timestamp) => timestamp,
+            Err(err) => {
+                push_provider_import_failure(&mut result.summary, line, err.to_string());
+                continue;
+            }
+        };
+        let ended_at = match session
             .ended_at
-            .map(|timestamp| provider_timestamp_seconds(Some(timestamp), context.imported_at));
+            .map(|timestamp| {
+                provider_required_timestamp_seconds(timestamp, "Hermes session ended_at")
+            })
+            .transpose()
+        {
+            Ok(timestamp) => timestamp,
+            Err(err) => {
+                push_provider_import_failure(&mut result.summary, line, err.to_string());
+                continue;
+            }
+        };
         let content = hermes_decode_content(row.content.as_deref());
         let text = provider_value_text(&content).unwrap_or_else(|| {
             row.tool_name
@@ -14387,6 +14427,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn native_hermes_rejects_out_of_range_message_timestamp() {
+        let temp = tempdir();
+        let fixture = write_hermes_smoke_db(&temp);
+        let conn = Connection::open(&fixture).unwrap();
+        conn.execute(
+            "update messages set timestamp = ?1 where content = 'bad timestamp'",
+            [1.0e300_f64],
+        )
+        .unwrap();
+        drop(conn);
+        let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+        let summary = import_hermes_sqlite(
+            &fixture,
+            &mut store,
+            HermesSqliteImportOptions {
+                allow_partial_failures: true,
+                ..HermesSqliteImportOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.failed, 1);
+        assert!(summary.failures[0]
+            .error
+            .contains("Hermes message timestamp"));
+        assert_eq!(summary.imported_events, 1);
+    }
+
     #[cfg(unix)]
     #[test]
     fn native_opencode_normalizer_rejects_symlinked_sqlite() {
@@ -15123,6 +15193,44 @@ mod tests {
         conn.execute(
             "insert into session_message values (?1, ?2, 'assistant', 1, 1782259202000, 1782259202000, ?3)",
             ["msg-child", "opencode-child", child_data],
+        )
+        .unwrap();
+        path
+    }
+
+    fn write_hermes_smoke_db(temp: &TempDir) -> PathBuf {
+        let path = temp.path().join("hermes-state.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "create table sessions (
+                id text primary key,
+                source text not null,
+                started_at real not null
+            );
+            create table messages (
+                id integer primary key autoincrement,
+                session_id text not null,
+                role text not null,
+                content text,
+                timestamp real not null,
+                active integer not null default 1,
+                compacted integer not null default 0
+            );",
+        )
+        .unwrap();
+        conn.execute(
+            "insert into sessions values (?1, 'acp', 1782259200.0)",
+            ["hermes-root"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into messages (session_id, role, content, timestamp) values (?1, 'user', 'bad timestamp', 1782259201.0)",
+            ["hermes-root"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into messages (session_id, role, content, timestamp) values (?1, 'assistant', 'good timestamp', 1782259202.0)",
+            ["hermes-root"],
         )
         .unwrap();
         path

--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -3311,17 +3311,18 @@ fn catalog_codex_session_file(
     })
 }
 
-fn read_codex_session_meta(path: &Path) -> std::io::Result<Option<Value>> {
+fn read_codex_session_meta(path: &Path) -> Result<Option<Value>> {
     let file = File::open(path)?;
-    let reader = BufReader::new(file);
-    for line in reader.lines().take(32) {
-        let line = line?;
-        if !line.as_bytes().contains(&b'{')
-            || !contains_bytes(line.as_bytes(), br#""session_meta""#)
-        {
+    let mut reader = BufReader::new(file);
+    let mut line = Vec::new();
+    for _ in 0..32 {
+        if !read_provider_jsonl_line(&mut reader, &mut line)? {
+            break;
+        }
+        if !line.contains(&b'{') || !contains_bytes(&line, br#""session_meta""#) {
             continue;
         }
-        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+        let Ok(value) = serde_json::from_slice::<Value>(&line) else {
             continue;
         };
         if value.get("type").and_then(Value::as_str) == Some("session_meta") {
@@ -13182,6 +13183,32 @@ mod tests {
         assert_eq!(third.cached_sessions, session_count - 1);
         assert_eq!(third.parsed_sessions, 1);
         assert_eq!(third.failed_sessions, 0);
+    }
+
+    #[test]
+    fn codex_session_catalog_rejects_oversized_metadata_line() {
+        let temp = tempdir();
+        let root = temp.path().join("sessions/2026/07/03");
+        fs::create_dir_all(&root).unwrap();
+        write_oversized_jsonl_line(&root.join("oversized.jsonl"));
+        let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+        let err = catalog_codex_session_tree(
+            temp.path().join("sessions"),
+            &store,
+            CodexSessionCatalogOptions {
+                source_root: Some(temp.path().join("sessions")),
+                cataloged_at: "2026-07-03T12:00:00Z".parse().unwrap(),
+                allow_partial_failures: false,
+                ..CodexSessionCatalogOptions::default()
+            },
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("provider JSONL line exceeds"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -6693,6 +6693,16 @@ fn open_provider_sqlite_readonly(path: &Path) -> Result<Connection> {
     Ok(conn)
 }
 
+fn provider_nonnegative_i64_to_u64(value: i64, field: &'static str) -> Result<u64> {
+    u64::try_from(value).map_err(|_| {
+        CaptureError::InvalidPayload(format!("{field} must be nonnegative, got {value}"))
+    })
+}
+
+fn provider_line_from_index(index: u64) -> usize {
+    index.min(usize::MAX as u64) as usize
+}
+
 fn provider_timestamp_seconds(value: Option<f64>, fallback: DateTime<Utc>) -> DateTime<Utc> {
     let Some(value) = value else {
         return fallback;
@@ -7246,15 +7256,24 @@ fn normalize_hermes_sqlite(
     let mut result = ProviderNormalizationResult::default();
 
     for row in messages {
+        let provider_event_index =
+            match provider_nonnegative_i64_to_u64(row.id, "Hermes message id") {
+                Ok(value) => value,
+                Err(err) => {
+                    push_provider_import_failure(&mut result.summary, 0, err.to_string());
+                    continue;
+                }
+            };
+        let line = provider_line_from_index(provider_event_index);
         let Some(session) = sessions_by_id.get(&row.session_id) else {
-            result.summary.failed += 1;
-            result.summary.failures.push(ProviderImportFailure {
-                line: row.id.max(0) as usize,
-                error: format!(
+            push_provider_import_failure(
+                &mut result.summary,
+                line,
+                format!(
                     "Hermes message {} references missing session {}",
                     row.id, row.session_id
                 ),
-            });
+            );
             continue;
         };
         let provider_session_id = session.id.clone();
@@ -7276,7 +7295,7 @@ fn normalize_hermes_sqlite(
             provider: CaptureProvider::Hermes,
             source_format: HERMES_SQLITE_SOURCE_FORMAT,
             provider_session_id: provider_session_id.clone(),
-            provider_event_index: row.id.max(0) as u64,
+            provider_event_index,
             provider_event_hash: Some(format!("message:{}", row.id)),
             cursor: format!("messages:id:{}", row.id),
             event_type,
@@ -7309,7 +7328,7 @@ fn normalize_hermes_sqlite(
             }),
         });
         result.captures.push((
-            row.id.max(0) as usize,
+            line,
             native_provider_capture(
                 NativeSessionDraft {
                     provider: CaptureProvider::Hermes,
@@ -7609,6 +7628,17 @@ fn normalize_nanoclaw_project(
             )
         });
         for message in messages {
+            let seq = match message
+                .seq
+                .map(|seq| provider_nonnegative_i64_to_u64(seq, "NanoClaw message seq"))
+                .transpose()
+            {
+                Ok(seq) => seq,
+                Err(err) => {
+                    push_provider_import_failure(&mut result.summary, 0, err.to_string());
+                    continue;
+                }
+            };
             let provider_session_id = format!("{}/{}", session.agent_group_id, session.id);
             let occurred_at = provider_timestamp_millis(message.timestamp, context.imported_at);
             let started_at = provider_timestamp_millis(session.created_at, occurred_at);
@@ -7623,7 +7653,7 @@ fn normalize_nanoclaw_project(
                     message.kind.as_deref().unwrap_or(message.source)
                 )
             });
-            let event_index = nanoclaw_event_index(&message);
+            let event_index = nanoclaw_event_index(&message, seq);
             let role = if message.source == "inbound" {
                 Some(EventRole::User)
             } else {
@@ -7738,15 +7768,15 @@ fn nanoclaw_project_root(path: &Path) -> Result<PathBuf> {
     })
 }
 
-fn nanoclaw_event_index(message: &NanoClawMessageRow) -> u64 {
-    if let Some(seq) = message.seq {
+fn nanoclaw_event_index(message: &NanoClawMessageRow, seq: Option<u64>) -> u64 {
+    if let Some(seq) = seq {
         let source_bucket = if message.source == "outbound" {
             500_000
         } else {
             0
         };
         let row_bucket = fnv1a64(format!("{}:{}", message.source, message.id).as_bytes()) % 500_000;
-        return (seq.max(0) as u64)
+        return seq
             .saturating_mul(1_000_000)
             .saturating_add(source_bucket)
             .saturating_add(row_bucket);
@@ -8560,6 +8590,16 @@ fn normalize_astrbot_sqlite(
     let mut checkpoint_sessions = BTreeMap::<String, String>::new();
 
     for conversation in &conversations {
+        let conversation_line = match provider_nonnegative_i64_to_u64(
+            conversation.row_id,
+            "AstrBot conversation row id",
+        ) {
+            Ok(value) => provider_line_from_index(value),
+            Err(err) => {
+                push_provider_import_failure(&mut result.summary, 0, err.to_string());
+                continue;
+            }
+        };
         let provider_session_id = astrbot_provider_session_id(conversation);
         let started_at = provider_timestamp_millis(conversation.created_at, context.imported_at);
         let ended_at = conversation
@@ -8636,7 +8676,7 @@ fn normalize_astrbot_sqlite(
                 }),
             });
             result.captures.push((
-                conversation.row_id.max(0) as usize,
+                conversation_line,
                 astrbot_capture(
                     AstrBotCaptureDraft {
                         conversation,
@@ -8660,6 +8700,14 @@ fn normalize_astrbot_sqlite(
         .map(|conversation| (astrbot_provider_session_id(conversation), conversation))
         .collect::<BTreeMap<_, _>>();
     for message in platform_messages {
+        let message_id =
+            match provider_nonnegative_i64_to_u64(message.id, "AstrBot platform message id") {
+                Ok(value) => value,
+                Err(err) => {
+                    push_provider_import_failure(&mut result.summary, 0, err.to_string());
+                    continue;
+                }
+            };
         let provider_session_id = message
             .llm_checkpoint_id
             .as_ref()
@@ -8689,7 +8737,7 @@ fn normalize_astrbot_sqlite(
         } else {
             Some(EventRole::Assistant)
         };
-        let event_index = 1_000_000u64.saturating_add(message.id.max(0) as u64);
+        let event_index = 1_000_000u64.saturating_add(message_id);
         let event = native_event(NativeEventDraft {
             provider: CaptureProvider::AstrBot,
             source_format: ASTRBOT_SQLITE_SOURCE_FORMAT,
@@ -9028,25 +9076,34 @@ fn normalize_opencode_sqlite(
     let raw_source_path = path.display().to_string();
 
     for row in messages {
+        let provider_event_index =
+            match provider_nonnegative_i64_to_u64(row.seq, "OpenCode session_message seq") {
+                Ok(value) => value,
+                Err(err) => {
+                    push_provider_import_failure(&mut result.summary, 0, err.to_string());
+                    continue;
+                }
+            };
+        let line = provider_line_from_index(provider_event_index);
         let Some(session) = sessions_by_id.get(&row.session_id) else {
-            result.summary.failed += 1;
-            result.summary.failures.push(ProviderImportFailure {
-                line: row.seq.max(0) as usize,
-                error: format!(
+            push_provider_import_failure(
+                &mut result.summary,
+                line,
+                format!(
                     "OpenCode session_message {} references missing session {}",
                     row.id, row.session_id
                 ),
-            });
+            );
             continue;
         };
         let data: Value = match serde_json::from_str(&row.data) {
             Ok(data) => data,
             Err(err) => {
-                result.summary.failed += 1;
-                result.summary.failures.push(ProviderImportFailure {
-                    line: row.seq.max(0) as usize,
-                    error: format!("invalid JSON in session_message {}: {err}", row.id),
-                });
+                push_provider_import_failure(
+                    &mut result.summary,
+                    line,
+                    format!("invalid JSON in session_message {}: {err}", row.id),
+                );
                 continue;
             }
         };
@@ -9057,7 +9114,7 @@ fn normalize_opencode_sqlite(
             .get(&session.id)
             .copied()
             .unwrap_or(occurred_at);
-        let event = opencode_event(&row, &data, occurred_at);
+        let event = opencode_event(&row, &data, occurred_at, provider_event_index);
         result
             .files_touched
             .extend(provider_file_touches_from_raw_value(
@@ -9067,11 +9124,11 @@ fn normalize_opencode_sqlite(
                 Some(raw_source_path.as_str()),
                 &data,
                 &event,
-                row.seq.max(0) as usize,
+                line,
             ));
         let is_subagent = session.parent_id.is_some();
         result.captures.push((
-            row.seq.max(0) as usize,
+            line,
             ProviderCaptureEnvelope {
                 schema_version: PROVIDER_CAPTURE_ENVELOPE_SCHEMA_VERSION,
                 provider: CaptureProvider::OpenCode,
@@ -9465,13 +9522,14 @@ fn opencode_event(
     row: &OpenCodeMessageRow,
     data: &Value,
     occurred_at: DateTime<Utc>,
+    provider_event_index: u64,
 ) -> ProviderEventEnvelope {
     let event_type = opencode_event_type(&row.entry_type, data);
     let role = Some(provider_role(Some(&row.entry_type)));
     let text = opencode_event_text(&row.entry_type, data, event_type);
     let (text, truncated) = provider_local_preview(&text, PROVIDER_MAX_TEXT_CHARS);
     ProviderEventEnvelope {
-        provider_event_index: row.seq.max(0) as u64,
+        provider_event_index,
         provider_event_hash: Some(row.id.clone()),
         cursor: Some(format!(
             "session_message:{}:seq:{}",
@@ -13936,6 +13994,43 @@ mod tests {
             Some(2)
         );
         assert_ne!(events[0].id, events[1].id);
+    }
+
+    #[test]
+    fn native_opencode_rejects_negative_session_message_seq() {
+        let temp = tempdir();
+        let fixture = write_opencode_smoke_db(&temp, false);
+        let conn = Connection::open(&fixture).unwrap();
+        conn.execute(
+            "update session_message set seq = -1 where id = 'msg-user'",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+        let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+        let summary = import_opencode_sqlite(
+            &fixture,
+            &mut store,
+            OpenCodeSqliteImportOptions {
+                allow_partial_failures: true,
+                ..OpenCodeSqliteImportOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.failed, 1);
+        assert!(summary.failures[0]
+            .error
+            .contains("OpenCode session_message seq must be nonnegative"));
+        assert_eq!(summary.imported_events, 2);
+        let session_id = provider_session_uuid(CaptureProvider::OpenCode, "opencode-root");
+        let events = store.events_for_session(session_id).unwrap();
+        assert!(events.iter().all(|event| {
+            event.payload["body"]["session_message_seq"]
+                .as_i64()
+                .is_some_and(|seq| seq >= 0)
+        }));
     }
 
     #[test]

--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -6875,6 +6875,14 @@ fn provider_timestamp_millis(value: Option<i64>, fallback: DateTime<Utc>) -> Dat
         .unwrap_or(fallback)
 }
 
+fn provider_required_timestamp_millis(value: i64, field: &'static str) -> Result<DateTime<Utc>> {
+    DateTime::<Utc>::from_timestamp_millis(value).ok_or_else(|| {
+        CaptureError::InvalidPayload(format!(
+            "{field} is outside representable timestamp range: {value}"
+        ))
+    })
+}
+
 fn provider_timestamp_value(value: Option<&Value>, fallback: DateTime<Utc>) -> DateTime<Utc> {
     match value {
         Some(Value::String(raw)) => parse_rfc3339_utc(raw)
@@ -9232,15 +9240,16 @@ fn normalize_opencode_sqlite(
     let sessions = opencode_sessions(&conn)?;
     let messages = opencode_session_messages(&conn)?;
     let mut result = ProviderNormalizationResult::default();
-    let session_started = sessions
-        .iter()
-        .map(|session| {
-            (
-                session.id.clone(),
-                timestamp_millis_utc(session.time_created, context.imported_at),
-            )
-        })
-        .collect::<BTreeMap<_, _>>();
+    let mut session_started = BTreeMap::new();
+    for session in &sessions {
+        session_started.insert(
+            session.id.clone(),
+            provider_required_timestamp_millis(
+                session.time_created,
+                "OpenCode session time_created",
+            )?,
+        );
+    }
     let sessions_by_id = sessions
         .into_iter()
         .map(|session| (session.id.clone(), session))
@@ -9279,9 +9288,23 @@ fn normalize_opencode_sqlite(
                 continue;
             }
         };
-        let occurred_at = opencode_event_time(&data)
-            .or_else(|| Some(timestamp_millis_utc(row.time_created, context.imported_at)))
-            .unwrap_or(context.imported_at);
+        let occurred_at = match opencode_event_time(&data) {
+            Ok(Some(time)) => time,
+            Ok(None) => match provider_required_timestamp_millis(
+                row.time_created,
+                "OpenCode session_message time_created",
+            ) {
+                Ok(time) => time,
+                Err(err) => {
+                    push_provider_import_failure(&mut result.summary, line, err.to_string());
+                    continue;
+                }
+            },
+            Err(err) => {
+                push_provider_import_failure(&mut result.summary, line, err.to_string());
+                continue;
+            }
+        };
         let started_at = session_started
             .get(&session.id)
             .copied()
@@ -9788,14 +9811,16 @@ fn opencode_content_has_tool(data: &Value) -> bool {
         .unwrap_or(false)
 }
 
-fn opencode_event_time(data: &Value) -> Option<DateTime<Utc>> {
-    data.pointer("/time/created")
-        .and_then(Value::as_i64)
-        .and_then(DateTime::<Utc>::from_timestamp_millis)
-}
-
-fn timestamp_millis_utc(millis: i64, fallback: DateTime<Utc>) -> DateTime<Utc> {
-    DateTime::<Utc>::from_timestamp_millis(millis).unwrap_or(fallback)
+fn opencode_event_time(data: &Value) -> Result<Option<DateTime<Utc>>> {
+    let Some(value) = data.pointer("/time/created") else {
+        return Ok(None);
+    };
+    let millis = value.as_i64().ok_or_else(|| {
+        CaptureError::InvalidPayload(
+            "OpenCode event time.created must be integer millis".to_owned(),
+        )
+    })?;
+    provider_required_timestamp_millis(millis, "OpenCode event time.created").map(Some)
 }
 
 fn parse_json_object_string(value: Option<&str>) -> Value {
@@ -14450,6 +14475,37 @@ mod tests {
                 .as_i64()
                 .is_some_and(|seq| seq >= 0)
         }));
+    }
+
+    #[test]
+    fn native_opencode_rejects_out_of_range_message_timestamp() {
+        let temp = tempdir();
+        let fixture = write_opencode_smoke_db(&temp, false);
+        let conn = Connection::open(&fixture).unwrap();
+        let data_without_payload_time = json!({"text": "bad timestamp fallback"}).to_string();
+        conn.execute(
+            "update session_message set time_created = ?1, data = ?2 where id = 'msg-user'",
+            rusqlite::params![i64::MAX, data_without_payload_time],
+        )
+        .unwrap();
+        drop(conn);
+        let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+        let summary = import_opencode_sqlite(
+            &fixture,
+            &mut store,
+            OpenCodeSqliteImportOptions {
+                allow_partial_failures: true,
+                ..OpenCodeSqliteImportOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.failed, 1);
+        assert!(summary.failures[0]
+            .error
+            .contains("OpenCode session_message time_created"));
+        assert_eq!(summary.imported_events, 2);
     }
 
     #[test]

--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -4791,6 +4791,7 @@ fn collect_jsonl_paths(root: &Path, paths: &mut Vec<PathBuf>) -> Result<()> {
             reason: "symlinked provider transcript roots are rejected",
         });
     }
+    ensure_provider_path_parents_are_not_symlinks(root)?;
     if file_type.is_file() {
         if root.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
             ensure_regular_provider_transcript_file(root)?;
@@ -4829,6 +4830,28 @@ fn ensure_regular_provider_transcript_file(path: &Path) -> Result<()> {
             path: path.to_path_buf(),
             reason: "provider transcript paths must be regular files",
         });
+    }
+    ensure_provider_path_parents_are_not_symlinks(path)?;
+    Ok(())
+}
+
+fn ensure_provider_path_parents_are_not_symlinks(path: &Path) -> Result<()> {
+    let parent_count = path.components().count().saturating_sub(1);
+    let mut current = PathBuf::new();
+    for component in path.components().take(parent_count) {
+        current.push(component.as_os_str());
+        if current.as_os_str().is_empty() {
+            continue;
+        }
+        let Ok(metadata) = fs::symlink_metadata(&current) else {
+            continue;
+        };
+        if metadata.file_type().is_symlink() {
+            return Err(CaptureError::InvalidProviderTranscriptPath {
+                path: path.to_path_buf(),
+                reason: "symlinked provider transcript path components are rejected",
+            });
+        }
     }
     Ok(())
 }
@@ -13389,6 +13412,40 @@ mod tests {
             CaptureError::InvalidProviderTranscriptPath { path, reason }
                 if path.ends_with("linked-root.jsonl")
                     && reason == "symlinked provider transcript files are rejected"
+        ));
+        assert!(store.list_sessions().unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_session_file_rejects_symlinked_parent_components() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir();
+        let real_dir = temp.path().join("real-parent");
+        fs::create_dir_all(&real_dir).unwrap();
+        let fixture = provider_history_fixture("codex-sessions").join("2026/06/23/root.jsonl");
+        fs::copy(&fixture, real_dir.join("root.jsonl")).unwrap();
+        let link_dir = temp.path().join("linked-parent");
+        symlink(&real_dir, &link_dir).unwrap();
+        let linked_file = link_dir.join("root.jsonl");
+
+        let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+        let err = import_codex_session_jsonl(
+            &linked_file,
+            &mut store,
+            CodexSessionImportOptions {
+                imported_at: "2026-06-23T16:30:00Z".parse().unwrap(),
+                ..CodexSessionImportOptions::default()
+            },
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            CaptureError::InvalidProviderTranscriptPath { path, reason }
+                if path.ends_with("linked-parent/root.jsonl")
+                    && reason == "symlinked provider transcript path components are rejected"
         ));
         assert!(store.list_sessions().unwrap().is_empty());
     }

--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -1232,11 +1232,17 @@ impl ProviderCaptureAdapter for CodexSessionJsonlAdapter {
                 });
                 continue;
             };
-            let occurred_at = value
-                .get("timestamp")
-                .and_then(Value::as_str)
-                .and_then(parse_rfc3339_utc)
-                .unwrap_or(header.timestamp);
+            let occurred_at = match codex_session_line_timestamp(&value, header.timestamp) {
+                Ok(occurred_at) => occurred_at,
+                Err(err) => {
+                    result.summary.failed += 1;
+                    result.summary.failures.push(ProviderImportFailure {
+                        line: line_number,
+                        error: err.to_string(),
+                    });
+                    continue;
+                }
+            };
             let mut line_capture = codex_session_line_capture(
                 header,
                 &value,
@@ -1467,7 +1473,7 @@ fn normalize_pi_session_jsonl_file(
         if entry_type == "session" {
             match pi_session_header(value) {
                 Ok(parsed) => {
-                    let capture = pi_session_capture(&parsed, None, line_number, context);
+                    let capture = pi_session_capture(&parsed, None, line_number, context)?;
                     header = Some(parsed);
                     result.captures.push((line_number, capture));
                 }
@@ -1490,10 +1496,16 @@ fn normalize_pi_session_jsonl_file(
             });
             continue;
         };
-        result.captures.push((
-            line_number,
-            pi_session_capture(header, Some(value), line_number, context),
-        ));
+        match pi_session_capture(header, Some(value), line_number, context) {
+            Ok(capture) => result.captures.push((line_number, capture)),
+            Err(err) => {
+                result.summary.failed += 1;
+                result.summary.failures.push(ProviderImportFailure {
+                    line: line_number,
+                    error: err.to_string(),
+                });
+            }
+        }
     }
 
     Ok(result)
@@ -2262,11 +2274,20 @@ pub fn import_codex_session_jsonl_tail(
             {
                 continue;
             }
-            let occurred_at = value
-                .get("timestamp")
-                .and_then(Value::as_str)
-                .and_then(parse_rfc3339_utc)
-                .unwrap_or(header.timestamp);
+            let occurred_at = match codex_session_line_timestamp(&value, header.timestamp) {
+                Ok(occurred_at) => occurred_at,
+                Err(err) => {
+                    summary.failed += 1;
+                    summary.failures.push(ProviderImportFailure {
+                        line: line_number,
+                        error: err.to_string(),
+                    });
+                    if !options.allow_partial_failures {
+                        return Ok(summary);
+                    }
+                    continue;
+                }
+            };
             let mut line_capture = codex_session_line_capture(
                 &header,
                 &value,
@@ -2803,11 +2824,20 @@ fn import_codex_session_path_fast(
             }
             continue;
         };
-        let occurred_at = value
-            .get("timestamp")
-            .and_then(Value::as_str)
-            .and_then(parse_rfc3339_utc)
-            .unwrap_or(header.timestamp);
+        let occurred_at = match codex_session_line_timestamp(&value, header.timestamp) {
+            Ok(occurred_at) => occurred_at,
+            Err(err) => {
+                summary.failed += 1;
+                summary.failures.push(ProviderImportFailure {
+                    line: line_number,
+                    error: err.to_string(),
+                });
+                if !options.allow_partial_failures {
+                    return Ok(());
+                }
+                continue;
+            }
+        };
         let mut line_capture = codex_session_line_capture(
             header,
             &value,
@@ -2886,7 +2916,7 @@ fn import_codex_provider_event_fast(
         event,
         payload: &payload,
         event_hash: &event_hash,
-    });
+    })?;
     let normalized_event = Event {
         id: event_identity.id,
         seq: event_identity.seq,
@@ -4918,6 +4948,27 @@ fn parse_rfc3339_utc(value: &str) -> Option<DateTime<Utc>> {
     DateTime::parse_from_rfc3339(value)
         .ok()
         .map(|time| time.with_timezone(&Utc))
+}
+
+fn parse_optional_rfc3339_field(
+    value: &Value,
+    field: &'static str,
+) -> Result<Option<DateTime<Utc>>> {
+    let Some(raw_value) = value.get(field) else {
+        return Ok(None);
+    };
+    let raw = raw_value.as_str().ok_or_else(|| {
+        CaptureError::InvalidPayload(format!("{field} must be an RFC3339 string"))
+    })?;
+    parse_rfc3339_utc(raw)
+        .ok_or_else(|| {
+            CaptureError::InvalidPayload(format!("{field} is not a valid RFC3339 timestamp"))
+        })
+        .map(Some)
+}
+
+fn codex_session_line_timestamp(value: &Value, fallback: DateTime<Utc>) -> Result<DateTime<Utc>> {
+    Ok(parse_optional_rfc3339_field(value, "timestamp")?.unwrap_or(fallback))
 }
 
 fn codex_session_header(value: Value) -> Result<CodexSessionHeader> {
@@ -10473,8 +10524,10 @@ fn pi_session_capture(
     entry: Option<Value>,
     line_number: usize,
     context: &ProviderAdapterContext,
-) -> ProviderCaptureEnvelope {
-    let event = entry.map(|entry| pi_session_event(header, &entry, line_number));
+) -> Result<ProviderCaptureEnvelope> {
+    let event = entry
+        .map(|entry| pi_session_event(header, &entry, line_number))
+        .transpose()?;
     let cursor = event.as_ref().and_then(|event| {
         event.cursor.as_ref().map(|cursor| ProviderCursorRange {
             before: None,
@@ -10486,7 +10539,7 @@ fn pi_session_capture(
         })
     });
 
-    ProviderCaptureEnvelope {
+    Ok(ProviderCaptureEnvelope {
         schema_version: PROVIDER_CAPTURE_ENVELOPE_SCHEMA_VERSION,
         provider: CaptureProvider::Pi,
         source: ProviderSourceEnvelope {
@@ -10537,14 +10590,14 @@ fn pi_session_capture(
             }),
         },
         event,
-    }
+    })
 }
 
 fn pi_session_event(
     header: &PiSessionHeader,
     entry: &Value,
     line_number: usize,
-) -> ProviderEventEnvelope {
+) -> Result<ProviderEventEnvelope> {
     let entry_type = entry
         .get("type")
         .and_then(Value::as_str)
@@ -10553,17 +10606,14 @@ fn pi_session_event(
     let message_role = message
         .and_then(|message| message.get("role"))
         .and_then(Value::as_str);
-    let occurred_at = entry
-        .get("timestamp")
-        .and_then(Value::as_str)
-        .and_then(|timestamp| DateTime::parse_from_rfc3339(timestamp).ok())
-        .map(|time| time.with_timezone(&Utc))
-        .unwrap_or_else(utc_now);
+    let occurred_at = parse_optional_rfc3339_field(entry, "timestamp")?.ok_or_else(|| {
+        CaptureError::InvalidPayload("pi session event missing timestamp".to_owned())
+    })?;
     let event_type = pi_event_type(entry_type, message);
     let role = message_role.map(pi_event_role);
     let text = message.and_then(pi_message_text);
 
-    ProviderEventEnvelope {
+    Ok(ProviderEventEnvelope {
         provider_event_index: (line_number - 1) as u64,
         provider_event_hash: None,
         cursor: entry.get("id").and_then(Value::as_str).map(str::to_owned),
@@ -10598,7 +10648,7 @@ fn pi_session_event(
                 .and_then(Value::as_str),
             "usage": message.and_then(|message| message.get("usage")).cloned(),
         }),
-    }
+    })
 }
 
 fn pi_event_type(entry_type: &str, message: Option<&Value>) -> EventType {
@@ -11088,7 +11138,7 @@ fn import_provider_capture_line(
             event,
             payload: &payload,
             event_hash: &event_hash,
-        });
+        })?;
         let normalized_event = Event {
             id: event_identity.id,
             seq: event_identity.seq,
@@ -11899,7 +11949,7 @@ struct ProviderCommandRunInput<'a> {
     event_hash: &'a str,
 }
 
-fn provider_command_run_from_event(input: ProviderCommandRunInput<'_>) -> Option<Run> {
+fn provider_command_run_from_event(input: ProviderCommandRunInput<'_>) -> Result<Option<Run>> {
     let ProviderCommandRunInput {
         provider,
         provider_session_id,
@@ -11912,7 +11962,7 @@ fn provider_command_run_from_event(input: ProviderCommandRunInput<'_>) -> Option
         event_hash,
     } = input;
     if event.event_type != EventType::CommandOutput {
-        return None;
+        return Ok(None);
     }
     let command_preview = payload
         .get("command")
@@ -11921,16 +11971,29 @@ fn provider_command_run_from_event(input: ProviderCommandRunInput<'_>) -> Option
         .map(str::to_owned);
     let call_id = payload.get("call_id").and_then(Value::as_str);
     let key = call_id.unwrap_or(event_hash);
-    let duration_ms = payload.get("duration_ms").and_then(Value::as_i64);
+    let duration_ms = provider_command_duration_ms(payload)?;
     let ended_at = Some(event.occurred_at);
-    let started_at = duration_ms
-        .and_then(|duration| {
+    let started_at = match duration_ms {
+        Some(duration) => {
+            let duration_value = duration;
+            let duration = chrono::Duration::try_milliseconds(duration_value).ok_or_else(|| {
+                CaptureError::InvalidPayload(format!(
+                    "duration_ms is not representable as milliseconds: {duration_value}"
+                ))
+            })?;
             event
                 .occurred_at
-                .checked_sub_signed(chrono::Duration::milliseconds(duration.max(0)))
-        })
-        .unwrap_or(event.occurred_at);
-    Some(Run {
+                .checked_sub_signed(duration)
+                .ok_or_else(|| {
+                    CaptureError::InvalidPayload(format!(
+                        "duration_ms moves command start before representable time: {}",
+                        duration_value
+                    ))
+                })?
+        }
+        None => event.occurred_at,
+    };
+    Ok(Some(Run {
         id: run_source_id
             .map(|source_id| provider_source_run_uuid(source_id, key))
             .unwrap_or_else(|| provider_run_uuid(provider, provider_session_id, key)),
@@ -11960,7 +12023,25 @@ fn provider_command_run_from_event(input: ProviderCommandRunInput<'_>) -> Option
                 "source": "provider_command_output",
             }),
         ),
-    })
+    }))
+}
+
+fn provider_command_duration_ms(payload: &Value) -> Result<Option<i64>> {
+    let Some(value) = payload.get("duration_ms") else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let duration = value
+        .as_i64()
+        .ok_or_else(|| CaptureError::InvalidPayload("duration_ms must be an integer".to_owned()))?;
+    if duration < 0 {
+        return Err(CaptureError::InvalidPayload(format!(
+            "duration_ms must be nonnegative, got {duration}"
+        )));
+    }
+    Ok(Some(duration))
 }
 
 fn provider_command_run_status(payload: &Value) -> RunStatus {
@@ -12227,6 +12308,27 @@ mod tests {
 
     fn write_oversized_jsonl_line(path: &Path) {
         fs::write(path, vec![b'x'; MAX_PROVIDER_JSONL_LINE_BYTES + 1]).unwrap();
+    }
+
+    fn jsonl_line(value: Value) -> String {
+        serde_json::to_string(&value).unwrap() + "\n"
+    }
+
+    fn test_provider_event(event_type: EventType) -> ProviderEventEnvelope {
+        ProviderEventEnvelope {
+            provider_event_index: 0,
+            provider_event_hash: Some("event-hash".to_owned()),
+            cursor: None,
+            event_type,
+            role: Some(EventRole::Tool),
+            occurred_at: "2026-07-03T12:00:00Z".parse().unwrap(),
+            fidelity: Fidelity::Imported,
+            redaction_state: RedactionState::LocalPreview,
+            idempotency_key: None,
+            artifacts: Vec::new(),
+            payload: json!({}),
+            metadata: json!({}),
+        }
     }
 
     fn materialized_fixture(category: &str, name: &str) -> PathBuf {
@@ -12823,6 +12925,51 @@ mod tests {
         assert!(events[3].payload.to_string().contains("cargo test"));
         assert!(events[3].payload.to_string().contains("fixture-secret"));
         assert!(!events[3].payload.to_string().contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn pi_session_import_rejects_malformed_event_timestamp() {
+        let temp = tempdir();
+        let path = temp.path().join("bad-timestamp-pi.jsonl");
+        fs::write(
+            &path,
+            [
+                jsonl_line(json!({
+                    "type": "session",
+                    "id": "pi-bad-timestamp",
+                    "timestamp": "2026-07-03T12:00:00Z",
+                    "version": 1
+                })),
+                jsonl_line(json!({
+                    "type": "message",
+                    "id": "pi-bad-event",
+                    "timestamp": "not-rfc3339",
+                    "message": {
+                        "role": "user",
+                        "content": "bad timestamp should not import"
+                    }
+                })),
+            ]
+            .concat(),
+        )
+        .unwrap();
+
+        let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+        let summary = import_pi_session_jsonl(
+            &path,
+            &mut store,
+            PiSessionImportOptions {
+                imported_at: "2026-07-03T12:30:00Z".parse().unwrap(),
+                ..PiSessionImportOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.failed, 1, "{:?}", summary.failures);
+        assert!(summary.failures[0]
+            .error
+            .contains("timestamp is not a valid RFC3339 timestamp"));
+        assert!(store.list_sessions().unwrap().is_empty());
     }
 
     #[test]
@@ -13491,6 +13638,80 @@ mod tests {
             .normalize_path(&path, &ProviderAdapterContext::default())
             .unwrap_err();
         assert!(err.to_string().contains("provider JSONL line exceeds"));
+    }
+
+    #[test]
+    fn codex_session_jsonl_rejects_malformed_event_timestamp() {
+        let temp = tempdir();
+        let path = temp.path().join("bad-timestamp-codex.jsonl");
+        fs::write(
+            &path,
+            [
+                jsonl_line(json!({
+                    "timestamp": "2026-07-03T12:00:00Z",
+                    "type": "session_meta",
+                    "payload": {
+                        "id": "codex-bad-timestamp",
+                        "timestamp": "2026-07-03T12:00:00Z",
+                        "cwd": "/workspace",
+                        "originator": "codex-cli"
+                    }
+                })),
+                jsonl_line(json!({
+                    "timestamp": "not-rfc3339",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "bad timestamp should not import"}
+                        ]
+                    }
+                })),
+            ]
+            .concat(),
+        )
+        .unwrap();
+
+        let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+        let summary = import_codex_session_jsonl(
+            &path,
+            &mut store,
+            CodexSessionImportOptions {
+                imported_at: "2026-07-03T12:30:00Z".parse().unwrap(),
+                fast_event_inserts: false,
+                ..CodexSessionImportOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.failed, 1, "{:?}", summary.failures);
+        assert!(summary.failures[0]
+            .error
+            .contains("timestamp is not a valid RFC3339 timestamp"));
+        assert!(store.list_sessions().unwrap().is_empty());
+    }
+
+    #[test]
+    fn provider_command_run_rejects_negative_duration() {
+        let event = test_provider_event(EventType::CommandOutput);
+        let err = provider_command_run_from_event(ProviderCommandRunInput {
+            provider: CaptureProvider::Codex,
+            provider_session_id: "duration-session",
+            session_id: new_id(),
+            source_id: new_id(),
+            run_source_id: None,
+            history_record_id: None,
+            event: &event,
+            payload: &json!({
+                "command": "cargo test",
+                "duration_ms": -1
+            }),
+            event_hash: "event-hash",
+        })
+        .unwrap_err();
+
+        assert!(err.to_string().contains("duration_ms must be nonnegative"));
     }
 
     #[test]

--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -25,7 +25,7 @@ use ctx_history_core::{
     CTX_HISTORY_JSONL_V1_SCHEMA_VERSION, PROVIDER_CAPTURE_ENVELOPE_SCHEMA_VERSION,
 };
 use ctx_history_store::{CatalogSession, Store, StoreError};
-use rusqlite::{Connection, OpenFlags, OptionalExtension};
+use rusqlite::{limits::Limit, Connection, OpenFlags, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use thiserror::Error;
@@ -41,6 +41,7 @@ pub use provider_sources::{
 
 pub const CAPTURE_SCHEMA_VERSION: u32 = 1;
 const MAX_PROVIDER_JSONL_LINE_BYTES: usize = 16 * 1024 * 1024;
+const MAX_PROVIDER_SQLITE_VALUE_BYTES: usize = MAX_PROVIDER_JSONL_LINE_BYTES;
 #[derive(Debug, Error)]
 pub enum CaptureError {
     #[error("io error: {0}")]
@@ -6815,6 +6816,12 @@ fn open_provider_sqlite_readonly(path: &Path) -> Result<Connection> {
         path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )?;
+    let value_limit = i32::try_from(MAX_PROVIDER_SQLITE_VALUE_BYTES).map_err(|_| {
+        CaptureError::InvalidPayload(format!(
+            "provider SQLite value byte limit is unrepresentable: {MAX_PROVIDER_SQLITE_VALUE_BYTES}"
+        ))
+    })?;
+    conn.set_limit(Limit::SQLITE_LIMIT_LENGTH, value_limit);
     conn.busy_timeout(std::time::Duration::from_secs(5))?;
     conn.pragma_update(None, "query_only", true)?;
     Ok(conn)
@@ -14400,6 +14407,35 @@ mod tests {
                 .as_i64()
                 .is_some_and(|seq| seq >= 0)
         }));
+    }
+
+    #[test]
+    fn native_opencode_rejects_oversized_sqlite_text_value() {
+        let temp = tempdir();
+        let fixture = write_opencode_smoke_db(&temp, false);
+        let conn = Connection::open(&fixture).unwrap();
+        let oversized_data = format!(
+            "{{\"time\":{{\"created\":1782259200000}},\"text\":\"{}\"}}",
+            "x".repeat(MAX_PROVIDER_SQLITE_VALUE_BYTES + 1)
+        );
+        conn.execute(
+            "update session_message set data = ?1 where id = 'msg-user'",
+            [&oversized_data],
+        )
+        .unwrap();
+        drop(conn);
+
+        let err = import_opencode_sqlite(
+            &fixture,
+            &mut Store::open(temp.path().join("work.sqlite")).unwrap(),
+            OpenCodeSqliteImportOptions::default(),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("too big"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -40,6 +40,7 @@ pub use provider_sources::{
 };
 
 pub const CAPTURE_SCHEMA_VERSION: u32 = 1;
+const MAX_PROVIDER_JSONL_LINE_BYTES: usize = 16 * 1024 * 1024;
 #[derive(Debug, Error)]
 pub enum CaptureError {
     #[error("io error: {0}")]
@@ -913,17 +914,18 @@ impl ProviderCaptureAdapter for ProviderFixtureJsonlAdapter {
     ) -> Result<ProviderNormalizationResult> {
         ensure_regular_provider_transcript_file(path)?;
         let file = File::open(path)?;
-        let reader = BufReader::new(file);
+        let mut reader = BufReader::new(file);
         let mut result = ProviderNormalizationResult::default();
+        let mut line = Vec::new();
+        let mut line_number = 0usize;
 
-        for (index, line) in reader.lines().enumerate() {
-            let line_number = index + 1;
-            let line = line?;
-            if line.trim().is_empty() {
+        while read_provider_jsonl_line(&mut reader, &mut line)? {
+            line_number += 1;
+            if line.iter().all(u8::is_ascii_whitespace) {
                 continue;
             }
 
-            let fixture: ProviderFixtureLine = match serde_json::from_str(&line) {
+            let fixture: ProviderFixtureLine = match serde_json::from_slice(&line) {
                 Ok(fixture) => fixture,
                 Err(err) => {
                     result.summary.failed += 1;
@@ -975,19 +977,20 @@ impl ProviderCaptureAdapter for CodexHistoryJsonlAdapter {
     ) -> Result<ProviderNormalizationResult> {
         ensure_regular_provider_transcript_file(path)?;
         let file = File::open(path)?;
-        let reader = BufReader::new(file);
+        let mut reader = BufReader::new(file);
         let mut result = ProviderNormalizationResult::default();
         let mut parsed = Vec::new();
         let mut first_seen = BTreeMap::new();
+        let mut line = Vec::new();
+        let mut line_number = 0usize;
 
-        for (index, line) in reader.lines().enumerate() {
-            let line_number = index + 1;
-            let line = line?;
-            if line.trim().is_empty() {
+        while read_provider_jsonl_line(&mut reader, &mut line)? {
+            line_number += 1;
+            if line.iter().all(u8::is_ascii_whitespace) {
                 continue;
             }
 
-            let history: CodexHistoryLine = match serde_json::from_str(&line) {
+            let history: CodexHistoryLine = match serde_json::from_slice(&line) {
                 Ok(history) => history,
                 Err(err) => {
                     result.summary.failed += 1;
@@ -1167,12 +1170,7 @@ impl ProviderCaptureAdapter for CodexSessionJsonlAdapter {
 
         let mut line_number = 0usize;
         let mut line = Vec::new();
-        loop {
-            line.clear();
-            let read = reader.read_until(b'\n', &mut line)?;
-            if read == 0 {
-                break;
-            }
+        while read_provider_jsonl_line(&mut reader, &mut line)? {
             line_number += 1;
             if line.iter().all(u8::is_ascii_whitespace) {
                 continue;
@@ -1439,18 +1437,19 @@ fn normalize_pi_session_jsonl_file(
 ) -> Result<ProviderNormalizationResult> {
     ensure_regular_provider_transcript_file(path)?;
     let file = File::open(path)?;
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
     let mut result = ProviderNormalizationResult::default();
     let mut header = None;
+    let mut line = Vec::new();
+    let mut line_number = 0usize;
 
-    for (index, line) in reader.lines().enumerate() {
-        let line_number = index + 1;
-        let line = line?;
-        if line.trim().is_empty() {
+    while read_provider_jsonl_line(&mut reader, &mut line)? {
+        line_number += 1;
+        if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }
 
-        let value: Value = match serde_json::from_str(&line) {
+        let value: Value = match serde_json::from_slice(&line) {
             Ok(value) => value,
             Err(err) => {
                 result.summary.failed += 1;
@@ -1853,18 +1852,20 @@ pub fn read_jsonl(path: impl AsRef<Path>) -> Result<Vec<CaptureEnvelope>> {
     let path = path.as_ref();
     ensure_regular_spool_file(path)?;
     let file = File::open(path)?;
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
     let mut envelopes = Vec::new();
+    let mut line = Vec::new();
+    let mut line_number = 0usize;
 
-    for (index, line) in reader.lines().enumerate() {
-        let line = line?;
-        if line.trim().is_empty() {
+    while read_provider_jsonl_line(&mut reader, &mut line)? {
+        line_number += 1;
+        if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }
         let envelope: CaptureEnvelope =
-            serde_json::from_str(&line).map_err(|source| CaptureError::InvalidJsonLine {
+            serde_json::from_slice(&line).map_err(|source| CaptureError::InvalidJsonLine {
                 path: path.to_path_buf(),
-                line: index + 1,
+                line: line_number,
                 source,
             })?;
         validate_envelope(&envelope)?;
@@ -2192,22 +2193,21 @@ pub fn import_codex_session_jsonl_tail(
         let mut line_number = 0usize;
         let mut position = 0u64;
 
-        let read = reader.read_until(b'\n', &mut line)?;
-        if read == 0 {
+        if !read_provider_jsonl_line(&mut reader, &mut line)? {
             return Ok(summary);
         }
         line_number += 1;
+        let read = line.len();
         position = position.saturating_add(read as u64);
         let header_value: Value = serde_json::from_slice(&line)?;
         let header = codex_session_header(header_value)?;
 
         while position < start_offset {
-            line.clear();
-            let read = reader.read_until(b'\n', &mut line)?;
-            if read == 0 {
+            if !read_provider_jsonl_line(&mut reader, &mut line)? {
                 return Ok(summary);
             }
             line_number += 1;
+            let read = line.len();
             position = position.saturating_add(read as u64);
         }
 
@@ -2225,13 +2225,9 @@ pub fn import_codex_session_jsonl_tail(
 
         let mut call_contexts: BTreeMap<String, CodexToolCallContext> = BTreeMap::new();
         let mut completed_bytes = 0u64;
-        loop {
-            line.clear();
-            let read = reader.read_until(b'\n', &mut line)?;
-            if read == 0 {
-                break;
-            }
+        while read_provider_jsonl_line(&mut reader, &mut line)? {
             line_number += 1;
+            let read = line.len();
             completed_bytes = completed_bytes.saturating_add(read as u64);
             if line.iter().all(u8::is_ascii_whitespace) {
                 continue;
@@ -2729,12 +2725,7 @@ fn import_codex_session_path_fast(
     let mut call_contexts: BTreeMap<String, CodexToolCallContext> = BTreeMap::new();
     let mut line_number = 0usize;
     let mut line = Vec::new();
-    loop {
-        line.clear();
-        let read = reader.read_until(b'\n', &mut line)?;
-        if read == 0 {
-            break;
-        }
+    while read_provider_jsonl_line(&mut reader, &mut line)? {
         line_number += 1;
         if line.iter().all(u8::is_ascii_whitespace) {
             continue;
@@ -3858,16 +3849,18 @@ fn normalize_custom_history_jsonl_v1_reader(
     reader: impl BufRead,
     context: &ProviderAdapterContext,
 ) -> Result<CustomHistoryJsonlV1NormalizationResult> {
+    let mut reader = reader;
     let mut summary = ProviderImportSummary::default();
     let mut records = Vec::new();
+    let mut line = Vec::new();
+    let mut line_number = 0usize;
 
-    for (index, line) in reader.lines().enumerate() {
-        let line_number = index + 1;
-        let line = line?;
-        if line.trim().is_empty() {
+    while read_provider_jsonl_line(&mut reader, &mut line)? {
+        line_number += 1;
+        if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }
-        match serde_json::from_str::<CtxHistoryJsonlRecord>(&line) {
+        match serde_json::from_slice::<CtxHistoryJsonlRecord>(&line) {
             Ok(record) => records.push((line_number, record)),
             Err(err) => push_provider_import_failure(&mut summary, line_number, err.to_string()),
         }
@@ -4838,6 +4831,64 @@ fn ensure_regular_provider_transcript_file(path: &Path) -> Result<()> {
         });
     }
     Ok(())
+}
+
+fn read_provider_jsonl_line(reader: &mut impl BufRead, buffer: &mut Vec<u8>) -> Result<bool> {
+    buffer.clear();
+    let mut total = 0usize;
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            return Ok(total > 0);
+        }
+        if let Some(newline_index) = available.iter().position(|byte| *byte == b'\n') {
+            let bytes_to_consume = newline_index + 1;
+            if total.saturating_add(bytes_to_consume) > MAX_PROVIDER_JSONL_LINE_BYTES {
+                reader.consume(bytes_to_consume);
+                return Err(provider_jsonl_line_too_large());
+            }
+            buffer.extend_from_slice(&available[..bytes_to_consume]);
+            reader.consume(bytes_to_consume);
+            return Ok(true);
+        }
+
+        let bytes_to_consume = available.len();
+        if total.saturating_add(bytes_to_consume) > MAX_PROVIDER_JSONL_LINE_BYTES {
+            reader.consume(bytes_to_consume);
+            discard_provider_jsonl_line(reader)?;
+            return Err(provider_jsonl_line_too_large());
+        }
+        buffer.extend_from_slice(available);
+        reader.consume(bytes_to_consume);
+        total = total.saturating_add(bytes_to_consume);
+    }
+}
+
+fn discard_provider_jsonl_line(reader: &mut impl BufRead) -> Result<()> {
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            return Ok(());
+        }
+        let bytes_to_consume = available
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map(|index| index + 1)
+            .unwrap_or(available.len());
+        let found_newline = available
+            .get(bytes_to_consume.saturating_sub(1))
+            .is_some_and(|byte| *byte == b'\n');
+        reader.consume(bytes_to_consume);
+        if found_newline {
+            return Ok(());
+        }
+    }
+}
+
+fn provider_jsonl_line_too_large() -> CaptureError {
+    CaptureError::InvalidPayload(format!(
+        "provider JSONL line exceeds max bytes ({MAX_PROVIDER_JSONL_LINE_BYTES})"
+    ))
 }
 
 fn parse_rfc3339_utc(value: &str) -> Option<DateTime<Utc>> {
@@ -6191,17 +6242,18 @@ fn normalize_claude_projects_jsonl_file(
 ) -> Result<ProviderNormalizationResult> {
     ensure_regular_provider_transcript_file(path)?;
     let file = File::open(path)?;
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
     let mut result = ProviderNormalizationResult::default();
     let mut rows = Vec::new();
+    let mut line = Vec::new();
+    let mut line_number = 0usize;
 
-    for (index, line) in reader.lines().enumerate() {
-        let line_number = index + 1;
-        let line = line?;
-        if line.trim().is_empty() {
+    while read_provider_jsonl_line(&mut reader, &mut line)? {
+        line_number += 1;
+        if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }
-        let value: Value = match serde_json::from_str(&line) {
+        let value: Value = match serde_json::from_slice(&line) {
             Ok(value) => value,
             Err(err) => {
                 result.summary.failed += 1;
@@ -6957,12 +7009,7 @@ fn normalize_openclaw_jsonl_file(
     let mut header_seen = false;
     let mut line_number = 0usize;
     let mut line = Vec::new();
-    loop {
-        line.clear();
-        let read = reader.read_until(b'\n', &mut line)?;
-        if read == 0 {
-            break;
-        }
+    while read_provider_jsonl_line(&mut reader, &mut line)? {
         line_number += 1;
         if line.iter().all(u8::is_ascii_whitespace) {
             continue;
@@ -9730,17 +9777,18 @@ fn normalize_native_jsonl_session_file(
 ) -> Result<ProviderNormalizationResult> {
     ensure_regular_provider_transcript_file(path)?;
     let file = File::open(path)?;
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
     let mut result = ProviderNormalizationResult::default();
     let mut rows = Vec::new();
+    let mut line = Vec::new();
+    let mut line_number = 0usize;
 
-    for (index, line) in reader.lines().enumerate() {
-        let line_number = index + 1;
-        let line = line?;
-        if line.trim().is_empty() {
+    while read_provider_jsonl_line(&mut reader, &mut line)? {
+        line_number += 1;
+        if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }
-        let value: Value = match serde_json::from_str(&line) {
+        let value: Value = match serde_json::from_slice(&line) {
             Ok(value) => value,
             Err(err) => {
                 result.summary.failed += 1;
@@ -12154,6 +12202,10 @@ mod tests {
         materialized_fixture("custom-history-jsonl", name)
     }
 
+    fn write_oversized_jsonl_line(path: &Path) {
+        fs::write(path, vec![b'x'; MAX_PROVIDER_JSONL_LINE_BYTES + 1]).unwrap();
+    }
+
     fn materialized_fixture(category: &str, name: &str) -> PathBuf {
         let source = match category {
             "provider" => PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -13370,6 +13422,18 @@ mod tests {
                     && reason == "symlinked provider transcript files are rejected"
         ));
         assert!(store.list_sessions().unwrap().is_empty());
+    }
+
+    #[test]
+    fn codex_session_jsonl_rejects_oversized_line() {
+        let temp = tempdir();
+        let path = temp.path().join("oversized-codex.jsonl");
+        write_oversized_jsonl_line(&path);
+
+        let err = CodexSessionJsonlAdapter
+            .normalize_path(&path, &ProviderAdapterContext::default())
+            .unwrap_err();
+        assert!(err.to_string().contains("provider JSONL line exceeds"));
     }
 
     #[test]
@@ -15992,6 +16056,24 @@ mod tests {
             .unwrap();
         assert_eq!(sessions, 0);
         assert_eq!(events, 0);
+    }
+
+    #[test]
+    fn custom_history_jsonl_rejects_oversized_line() {
+        let temp = tempdir();
+        let path = temp.path().join("oversized-custom.jsonl");
+        write_oversized_jsonl_line(&path);
+        let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+        let err = import_custom_history_jsonl_v1(
+            &path,
+            &mut store,
+            CustomHistoryJsonlV1ImportOptions::default(),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("provider JSONL line exceeds"));
+        assert_eq!(store.capture_source_count().unwrap(), 0);
     }
 
     #[test]

--- a/crates/ctx-history-store/src/lib.rs
+++ b/crates/ctx-history-store/src/lib.rs
@@ -3759,7 +3759,7 @@ impl Store {
                     history_record_id: parse_optional_uuid(row.get(1)?)?,
                     session_id: parse_optional_uuid(row.get(2)?)?,
                     run_id: parse_optional_uuid(row.get(3)?)?,
-                    seq: row.get::<_, i64>(4)? as u64,
+                    seq: nonnegative_i64_to_u64(row.get(4)?)?,
                     event_type: parse_text_enum::<EventType>(row.get::<_, String>(5)?)?,
                     role: parse_optional_text_enum::<EventRole>(row.get(6)?)?,
                     occurred_at: ms_to_time(row.get(7)?)?,
@@ -5540,6 +5540,10 @@ fn nonnegative_i64_to_u64(value: i64) -> rusqlite::Result<u64> {
     u64::try_from(value).map_err(|err| rusqlite::Error::ToSqlConversionFailure(Box::new(err)))
 }
 
+fn nonnegative_i64_to_u32(value: i64) -> rusqlite::Result<u32> {
+    u32::try_from(value).map_err(|err| rusqlite::Error::ToSqlConversionFailure(Box::new(err)))
+}
+
 fn time_ms(value: i64) -> DateTime<Utc> {
     DateTime::<Utc>::from_timestamp_millis(value).unwrap_or(DateTime::<Utc>::UNIX_EPOCH)
 }
@@ -6940,7 +6944,10 @@ fn capture_source_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CaptureS
             kind: parse_text_enum::<ctx_history_core::CaptureSourceKind>(row.get::<_, String>(1)?)?,
             provider: parse_text_enum::<CaptureProvider>(row.get::<_, String>(2)?)?,
             machine_id: row.get(3)?,
-            process_id: row.get::<_, Option<i64>>(4)?.map(|value| value as u32),
+            process_id: row
+                .get::<_, Option<i64>>(4)?
+                .map(nonnegative_i64_to_u32)
+                .transpose()?,
             cwd: row.get(5)?,
             raw_source_path: row.get(6)?,
             external_session_id: row.get(7)?,
@@ -6951,7 +6958,7 @@ fn capture_source_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CaptureS
             fidelity: parse_text_enum::<Fidelity>(row.get::<_, String>(10)?)?,
             visibility: parse_text_enum::<Visibility>(row.get::<_, String>(11)?)?,
             sync_state: parse_text_enum::<SyncState>(row.get::<_, String>(12)?)?,
-            sync_version: row.get::<_, i64>(13)? as u64,
+            sync_version: nonnegative_i64_to_u64(row.get(13)?)?,
             deleted_at: None,
             metadata: parse_json(row.get::<_, String>(14)?)?,
         },
@@ -7114,7 +7121,7 @@ fn event_select_sql(tail: &str) -> String {
 fn event_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Event> {
     Ok(Event {
         id: parse_uuid(row.get::<_, String>(0)?)?,
-        seq: row.get::<_, i64>(1)? as u64,
+        seq: nonnegative_i64_to_u64(row.get(1)?)?,
         history_record_id: parse_optional_uuid(row.get(2)?)?,
         session_id: parse_optional_uuid(row.get(3)?)?,
         run_id: parse_optional_uuid(row.get(4)?)?,
@@ -7145,7 +7152,7 @@ fn artifact_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Artifact> {
         kind: parse_text_enum::<ArtifactKind>(row.get::<_, String>(1)?)?,
         blob_hash: row.get(2)?,
         blob_path: row.get(3)?,
-        byte_size: row.get::<_, i64>(4)? as u64,
+        byte_size: nonnegative_i64_to_u64(row.get(4)?)?,
         media_type: row.get(5)?,
         preview_text: row.get(6)?,
         redaction_state: parse_text_enum::<RedactionState>(row.get::<_, String>(7)?)?,
@@ -7321,7 +7328,7 @@ fn sync_metadata_from_row(
         visibility: parse_text_enum::<Visibility>(row.get::<_, String>(visibility_index)?)?,
         fidelity: parse_text_enum::<Fidelity>(row.get::<_, String>(fidelity_index)?)?,
         sync_state: parse_text_enum::<SyncState>(row.get::<_, String>(sync_state_index)?)?,
-        sync_version: row.get::<_, i64>(sync_version_index)? as u64,
+        sync_version: nonnegative_i64_to_u64(row.get(sync_version_index)?)?,
         deleted_at: optional_ms_to_time(row.get(deleted_at_index)?)?,
         metadata: parse_json(row.get::<_, String>(metadata_index)?)?,
     })
@@ -7908,6 +7915,29 @@ mod catalog_tests {
             timestamps: timestamps(),
             sync: sync_metadata(),
         }
+    }
+
+    fn artifact_record(id: Uuid, byte_size: u64) -> Artifact {
+        Artifact {
+            id,
+            kind: ArtifactKind::Markdown,
+            blob_hash: format!("{:064x}", 1),
+            blob_path: format!("{OBJECTS_DIR}/00/test-artifact"),
+            byte_size,
+            media_type: Some("text/markdown".to_owned()),
+            preview_text: Some("artifact preview".to_owned()),
+            redaction_state: RedactionState::LocalPreview,
+            timestamps: timestamps(),
+            source_id: None,
+            sync: sync_metadata(),
+        }
+    }
+
+    fn assert_sql_conversion_error<T: std::fmt::Debug>(result: Result<T>) {
+        assert!(
+            matches!(result, Err(StoreError::Sql(_))),
+            "expected sqlite conversion error, got {result:?}"
+        );
     }
 
     #[test]
@@ -8638,6 +8668,84 @@ mod catalog_tests {
         );
         assert!(result.truncated.rows);
         assert!(result.truncated.values);
+    }
+
+    #[test]
+    fn row_readers_reject_negative_unsigned_columns() {
+        let temp = tempdir();
+        let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+        let bad_process_id = new_id();
+        store
+            .conn
+            .execute(
+                r#"
+                INSERT INTO capture_sources
+                (
+                    id, kind, provider, machine_id, process_id, cwd, raw_source_path,
+                    external_session_id, started_at_ms, fidelity, sync_version
+                )
+                VALUES (?1, 'provider_import', 'codex', 'test-machine', -1, '/repo', '/tmp/session.jsonl', 'session', 1, 'imported', 0)
+                "#,
+                params![bad_process_id.to_string()],
+            )
+            .unwrap();
+        assert_sql_conversion_error(store.get_capture_source(bad_process_id));
+
+        let bad_sync_version = new_id();
+        store
+            .conn
+            .execute(
+                r#"
+                INSERT INTO capture_sources
+                (
+                    id, kind, provider, machine_id, cwd, raw_source_path,
+                    external_session_id, started_at_ms, fidelity, sync_version
+                )
+                VALUES (?1, 'provider_import', 'codex', 'test-machine', '/repo', '/tmp/session.jsonl', 'session', 1, 'imported', -1)
+                "#,
+                params![bad_sync_version.to_string()],
+            )
+            .unwrap();
+        assert_sql_conversion_error(store.get_capture_source(bad_sync_version));
+
+        let event = Event {
+            id: new_id(),
+            seq: 1,
+            history_record_id: None,
+            session_id: None,
+            run_id: None,
+            event_type: EventType::Message,
+            role: Some(EventRole::Assistant),
+            occurred_at: fixed_time(),
+            capture_source_id: None,
+            payload: serde_json::json!({"text": "negative seq marker"}),
+            payload_blob_id: None,
+            dedupe_key: None,
+            redaction_state: RedactionState::LocalPreview,
+            sync: sync_metadata(),
+        };
+        store.upsert_event(&event).unwrap();
+        store
+            .conn
+            .execute(
+                "UPDATE events SET seq = -1 WHERE id = ?1",
+                params![event.id.to_string()],
+            )
+            .unwrap();
+        assert_sql_conversion_error(store.get_event(event.id));
+        assert_sql_conversion_error(store.search_event_hits("negative seq marker", 1));
+
+        let artifact = artifact_record(new_id(), 1);
+        store.upsert_artifact(&artifact).unwrap();
+        store
+            .conn
+            .execute(
+                "UPDATE artifacts SET byte_size = -1 WHERE id = ?1",
+                params![artifact.id.to_string()],
+            )
+            .unwrap();
+        assert_sql_conversion_error(store.list_artifacts());
     }
 
     #[test]

--- a/crates/ctx-history-store/src/lib.rs
+++ b/crates/ctx-history-store/src/lib.rs
@@ -112,6 +112,7 @@ pub const RAW_SQL_MAX_COLUMNS_CAP: usize = 256;
 pub const RAW_SQL_DEFAULT_MAX_VALUE_BYTES: usize = 512;
 pub const RAW_SQL_MAX_VALUE_BYTES_CAP: usize = 1_048_576;
 pub const RAW_SQL_MAX_RESULT_PREVIEW_BYTES: usize = 64 * 1024 * 1024;
+pub const RAW_SQL_MAX_RESULT_CELLS: usize = 262_144;
 const RAW_SQL_MIN_SQLITE_LENGTH_LIMIT_BYTES: usize = 64 * 1024;
 const RAW_SQL_VALUE_LENGTH_MARGIN_BYTES: usize = 1024;
 pub const RAW_SQL_DEFAULT_MAX_SQL_BYTES: usize = 64 * 1024;
@@ -1215,6 +1216,7 @@ impl Store {
                 max_columns: options.max_columns,
             });
         }
+        validate_raw_sql_result_preview_budget(&options, column_count)?;
 
         let columns = stmt
             .column_names()
@@ -2690,6 +2692,21 @@ impl Store {
         collect_rows(rows)
     }
 
+    pub fn events_for_session_limited(&self, session_id: Uuid, limit: usize) -> Result<Vec<Event>> {
+        let mut stmt = self.conn.prepare(
+            event_select_sql("WHERE session_id = ?1 ORDER BY seq, occurred_at_ms LIMIT ?2")
+                .as_str(),
+        )?;
+        let rows = stmt.query_map(
+            params![
+                session_id.to_string(),
+                i64::try_from(limit).unwrap_or(i64::MAX)
+            ],
+            event_from_row,
+        )?;
+        collect_rows(rows)
+    }
+
     pub fn events_for_record(&self, record_id: Uuid) -> Result<Vec<Event>> {
         let mut stmt = self.conn.prepare(
             event_select_sql(
@@ -3952,7 +3969,6 @@ fn validate_raw_sql_options(options: &RawSqlOptions) -> Result<()> {
             max: usize::try_from(duration_ms(RAW_SQL_MAX_TIMEOUT)).unwrap_or(usize::MAX),
         });
     }
-    validate_raw_sql_result_preview_budget(options)?;
     Ok(())
 }
 
@@ -3960,13 +3976,23 @@ fn validate_raw_sql_statement_bytes(sql: &str, options: &RawSqlOptions) -> Resul
     validate_raw_sql_usize("sql_bytes", sql.len(), 1, options.max_sql_bytes)
 }
 
-fn validate_raw_sql_result_preview_budget(options: &RawSqlOptions) -> Result<()> {
-    let per_cell_bytes = options.max_value_bytes.saturating_mul(2).max(32);
+fn validate_raw_sql_result_preview_budget(
+    options: &RawSqlOptions,
+    column_count: usize,
+) -> Result<()> {
+    let estimated_cells = options.max_rows.saturating_mul(column_count);
+    let per_cell_bytes = options
+        .max_value_bytes
+        .saturating_mul(4)
+        .saturating_add(64)
+        .max(128);
     let estimated_bytes = options
         .max_rows
-        .saturating_mul(options.max_columns)
+        .saturating_mul(column_count)
         .saturating_mul(per_cell_bytes);
-    if estimated_bytes > RAW_SQL_MAX_RESULT_PREVIEW_BYTES {
+    if estimated_cells > RAW_SQL_MAX_RESULT_CELLS
+        || estimated_bytes > RAW_SQL_MAX_RESULT_PREVIEW_BYTES
+    {
         return Err(StoreError::RawSqlResultBudgetTooLarge {
             estimated_bytes,
             max_result_bytes: RAW_SQL_MAX_RESULT_PREVIEW_BYTES,
@@ -8752,9 +8778,13 @@ mod catalog_tests {
     fn raw_sql_query_rejects_excessive_result_preview_budget() {
         let temp = tempdir();
         let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+        let many_columns = (0..RAW_SQL_MAX_COLUMNS_CAP)
+            .map(|index| format!("1 AS c{index}"))
+            .collect::<Vec<_>>()
+            .join(", ");
         let err = store
             .raw_sql_query(
-                "SELECT 1",
+                &format!("SELECT {many_columns}"),
                 RawSqlOptions {
                     max_rows: RAW_SQL_MAX_ROWS_CAP,
                     max_columns: RAW_SQL_MAX_COLUMNS_CAP,
@@ -8770,6 +8800,25 @@ mod catalog_tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn raw_sql_query_budgets_against_actual_column_count() {
+        let temp = tempdir();
+        let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+        let result = store
+            .raw_sql_query(
+                "SELECT 1",
+                RawSqlOptions {
+                    max_rows: RAW_SQL_MAX_ROWS_CAP,
+                    max_columns: RAW_SQL_MAX_COLUMNS_CAP,
+                    max_value_bytes: 32,
+                    ..RawSqlOptions::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(result.returned_rows, 1);
+        assert_eq!(result.rows[0][0], RawSqlValue::Integer(1));
     }
 
     #[test]

--- a/crates/ctx-history-store/src/lib.rs
+++ b/crates/ctx-history-store/src/lib.rs
@@ -2284,6 +2284,29 @@ impl Store {
             .map_err(StoreError::from)
     }
 
+    pub fn sessions_by_external_session_limited(
+        &self,
+        provider: CaptureProvider,
+        external_session_id: &str,
+        limit: usize,
+    ) -> Result<Vec<Session>> {
+        let mut stmt = self.conn.prepare(
+            session_select_sql(
+                "WHERE provider = ?1 AND external_session_id = ?2 ORDER BY started_at_ms DESC LIMIT ?3",
+            )
+            .as_str(),
+        )?;
+        let rows = stmt.query_map(
+            params![
+                provider.as_str(),
+                external_session_id,
+                i64::try_from(limit).unwrap_or(i64::MAX)
+            ],
+            session_from_row,
+        )?;
+        collect_rows(rows)
+    }
+
     pub fn sessions_for_record(&self, record_id: Uuid) -> Result<Vec<Session>> {
         let mut stmt = self.conn.prepare(
             session_select_sql("WHERE history_record_id = ?1 ORDER BY started_at_ms, id").as_str(),
@@ -8116,6 +8139,31 @@ mod catalog_tests {
             .map(|event| event.seq)
             .collect::<Vec<_>>();
         assert_eq!(last, vec![8, 9]);
+    }
+
+    #[test]
+    fn sessions_by_external_session_limited_caps_ambiguity_scan() {
+        let temp = tempdir();
+        let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+        for index in 0..5 {
+            let mut session = imported_session("shared-provider-session");
+            session.started_at = fixed_time() + chrono::Duration::seconds(index);
+            store.upsert_session(&session).unwrap();
+        }
+
+        let matches = store
+            .sessions_by_external_session_limited(
+                CaptureProvider::Codex,
+                "shared-provider-session",
+                2,
+            )
+            .unwrap();
+
+        assert_eq!(matches.len(), 2);
+        assert_eq!(
+            matches[0].external_session_id.as_deref(),
+            Some("shared-provider-session")
+        );
     }
 
     #[test]

--- a/crates/ctx-history-store/src/lib.rs
+++ b/crates/ctx-history-store/src/lib.rs
@@ -87,6 +87,11 @@ pub enum StoreError {
         min: usize,
         max: usize,
     },
+    #[error("SQL result preview budget {estimated_bytes} bytes exceeds maximum {max_result_bytes}; lower max_rows, max_columns, or max_value_bytes")]
+    RawSqlResultBudgetTooLarge {
+        estimated_bytes: usize,
+        max_result_bytes: usize,
+    },
     #[error("SQL query timed out after {timeout_ms}ms")]
     RawSqlTimedOut { timeout_ms: u64 },
 }
@@ -106,6 +111,7 @@ pub const RAW_SQL_DEFAULT_MAX_COLUMNS: usize = 64;
 pub const RAW_SQL_MAX_COLUMNS_CAP: usize = 256;
 pub const RAW_SQL_DEFAULT_MAX_VALUE_BYTES: usize = 512;
 pub const RAW_SQL_MAX_VALUE_BYTES_CAP: usize = 1_048_576;
+pub const RAW_SQL_MAX_RESULT_PREVIEW_BYTES: usize = 64 * 1024 * 1024;
 const RAW_SQL_MIN_SQLITE_LENGTH_LIMIT_BYTES: usize = 64 * 1024;
 const RAW_SQL_VALUE_LENGTH_MARGIN_BYTES: usize = 1024;
 pub const RAW_SQL_DEFAULT_MAX_SQL_BYTES: usize = 64 * 1024;
@@ -3946,11 +3952,27 @@ fn validate_raw_sql_options(options: &RawSqlOptions) -> Result<()> {
             max: usize::try_from(duration_ms(RAW_SQL_MAX_TIMEOUT)).unwrap_or(usize::MAX),
         });
     }
+    validate_raw_sql_result_preview_budget(options)?;
     Ok(())
 }
 
 fn validate_raw_sql_statement_bytes(sql: &str, options: &RawSqlOptions) -> Result<()> {
     validate_raw_sql_usize("sql_bytes", sql.len(), 1, options.max_sql_bytes)
+}
+
+fn validate_raw_sql_result_preview_budget(options: &RawSqlOptions) -> Result<()> {
+    let per_cell_bytes = options.max_value_bytes.saturating_mul(2).max(32);
+    let estimated_bytes = options
+        .max_rows
+        .saturating_mul(options.max_columns)
+        .saturating_mul(per_cell_bytes);
+    if estimated_bytes > RAW_SQL_MAX_RESULT_PREVIEW_BYTES {
+        return Err(StoreError::RawSqlResultBudgetTooLarge {
+            estimated_bytes,
+            max_result_bytes: RAW_SQL_MAX_RESULT_PREVIEW_BYTES,
+        });
+    }
+    Ok(())
 }
 
 struct RawSqlLimitGuard<'a> {
@@ -8616,6 +8638,30 @@ mod catalog_tests {
         );
         assert!(result.truncated.rows);
         assert!(result.truncated.values);
+    }
+
+    #[test]
+    fn raw_sql_query_rejects_excessive_result_preview_budget() {
+        let temp = tempdir();
+        let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+        let err = store
+            .raw_sql_query(
+                "SELECT 1",
+                RawSqlOptions {
+                    max_rows: RAW_SQL_MAX_ROWS_CAP,
+                    max_columns: RAW_SQL_MAX_COLUMNS_CAP,
+                    max_value_bytes: 32,
+                    ..RawSqlOptions::default()
+                },
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            StoreError::RawSqlResultBudgetTooLarge {
+                max_result_bytes: RAW_SQL_MAX_RESULT_PREVIEW_BYTES,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/ctx-history-store/src/lib.rs
+++ b/crates/ctx-history-store/src/lib.rs
@@ -2707,6 +2707,58 @@ impl Store {
         collect_rows(rows)
     }
 
+    pub fn events_for_session_window(
+        &self,
+        event: &Event,
+        before: usize,
+        after: usize,
+    ) -> Result<Vec<Event>> {
+        let Some(session_id) = event.session_id else {
+            return Ok(vec![event.clone()]);
+        };
+        let event_seq = i64::try_from(event.seq).unwrap_or(i64::MAX);
+        let mut events = if before == 0 {
+            Vec::new()
+        } else {
+            let mut stmt = self.conn.prepare(
+                event_select_sql(
+                    "WHERE session_id = ?1 AND seq < ?2 ORDER BY seq DESC, occurred_at_ms DESC LIMIT ?3",
+                )
+                .as_str(),
+            )?;
+            let rows = stmt.query_map(
+                params![
+                    session_id.to_string(),
+                    event_seq,
+                    i64::try_from(before).unwrap_or(i64::MAX)
+                ],
+                event_from_row,
+            )?;
+            let mut rows = collect_rows(rows)?;
+            rows.reverse();
+            rows
+        };
+        events.push(event.clone());
+        if after > 0 {
+            let mut stmt = self.conn.prepare(
+                event_select_sql(
+                    "WHERE session_id = ?1 AND seq > ?2 ORDER BY seq, occurred_at_ms LIMIT ?3",
+                )
+                .as_str(),
+            )?;
+            let rows = stmt.query_map(
+                params![
+                    session_id.to_string(),
+                    event_seq,
+                    i64::try_from(after).unwrap_or(i64::MAX)
+                ],
+                event_from_row,
+            )?;
+            events.extend(collect_rows(rows)?);
+        }
+        Ok(events)
+    }
+
     pub fn events_for_record(&self, record_id: Uuid) -> Result<Vec<Event>> {
         let mut stmt = self.conn.prepare(
             event_select_sql(
@@ -7943,6 +7995,25 @@ mod catalog_tests {
         }
     }
 
+    fn session_event(session_id: Uuid, index: u64) -> Event {
+        Event {
+            id: new_id(),
+            seq: index,
+            history_record_id: None,
+            session_id: Some(session_id),
+            run_id: None,
+            event_type: EventType::Message,
+            role: Some(EventRole::Assistant),
+            occurred_at: fixed_time() + chrono::Duration::seconds(index as i64),
+            capture_source_id: None,
+            payload: serde_json::json!({"index": index}),
+            payload_blob_id: None,
+            dedupe_key: None,
+            redaction_state: RedactionState::LocalPreview,
+            sync: sync_metadata(),
+        }
+    }
+
     fn artifact_record(id: Uuid, byte_size: u64) -> Artifact {
         Artifact {
             id,
@@ -8006,6 +8077,45 @@ mod catalog_tests {
             .query_row("SELECT total_changes()", [], |row| row.get(0))
             .unwrap();
         assert!(after_changed > after_noop);
+    }
+
+    #[test]
+    fn events_for_session_window_returns_bounded_neighbors() {
+        let temp = tempdir();
+        let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+        let session = imported_session("window-session");
+        store.upsert_session(&session).unwrap();
+        let events = (0..10)
+            .map(|index| {
+                let event = session_event(session.id, index);
+                store.upsert_event(&event).unwrap();
+                event
+            })
+            .collect::<Vec<_>>();
+
+        let middle = store
+            .events_for_session_window(&events[5], 2, 3)
+            .unwrap()
+            .into_iter()
+            .map(|event| event.seq)
+            .collect::<Vec<_>>();
+        assert_eq!(middle, vec![3, 4, 5, 6, 7, 8]);
+
+        let first = store
+            .events_for_session_window(&events[0], 50, 1)
+            .unwrap()
+            .into_iter()
+            .map(|event| event.seq)
+            .collect::<Vec<_>>();
+        assert_eq!(first, vec![0, 1]);
+
+        let last = store
+            .events_for_session_window(&events[9], 1, 50)
+            .unwrap()
+            .into_iter()
+            .map(|event| event.seq)
+            .collect::<Vec<_>>();
+        assert_eq!(last, vec![8, 9]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- harden CLI parser, MCP, SQL, upgrade, plugin, provider JSONL, and native provider import boundaries
- reject corrupt provider timestamps, durations, indexes, and oversized native/provider inputs instead of silently normalizing them
- add focused public regressions for resource caps, malformed timestamps, event-window lookup, and test binary copy races

## Validation

- cargo fmt --check
- cargo test --workspace --locked
- private adversarial harness against this public head: 144 cases, 0 failures
