### PR TITLE
fix(cli): avoid initializing the store for read-only commands

### DIFF
--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -2979,7 +2979,8 @@ fn run_show(
     data_root: PathBuf,
     analytics_properties: &mut AnalyticsProperties,
 ) -> Result<()> {
-    let store = Store::open(database_path(data_root))?;
+    let db_path = database_path(data_root);
+    let store = open_existing_store_read_only(&db_path, "ctx show")?;
     match args.target {
         ShowTarget::Session(args) => {
             let session = resolve_session(
@@ -3026,7 +3027,8 @@ fn run_locate(
     data_root: PathBuf,
     _analytics_properties: &mut AnalyticsProperties,
 ) -> Result<()> {
-    let store = Store::open(database_path(data_root))?;
+    let db_path = database_path(data_root);
+    let store = open_existing_store_read_only(&db_path, "ctx locate")?;
     match args.target {
         LocateTarget::Session(args) => {
             let session = resolve_session(

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -2241,6 +2241,22 @@ fn sql_is_read_only_and_does_not_initialize_store() {
 }
 
 #[test]
+fn show_does_not_initialize_store() {
+    let temp = tempdir();
+    let stderr = failure_stderr(ctx(&temp).args(["show", "event", "deadbeef"]));
+    assert!(stderr.contains("ctx store is not initialized"));
+    assert!(!temp.path().join("work.sqlite").exists());
+}
+
+#[test]
+fn locate_does_not_initialize_store() {
+    let temp = tempdir();
+    let stderr = failure_stderr(ctx(&temp).args(["locate", "event", "deadbeef"]));
+    assert!(stderr.contains("ctx store is not initialized"));
+    assert!(!temp.path().join("work.sqlite").exists());
+}
+
+#[test]
 fn docs_commands_expose_embedded_docs_and_man_pages() {
     let temp = tempdir();
 


### PR DESCRIPTION
### Before

`ctx locate` created `work.sqlite` even though the store wasn't initialized.

<img width="1000" height="113" alt="Screenshot 2026-07-04 at 2 12 32 PM" src="https://github.com/user-attachments/assets/4298c3f8-5d1c-4833-a383-11bf73134e00" />


### After

`ctx locate` now reports that the store isn't initialized and no `work.sqlite` is created.

<img width="1349" height="118" alt="Screenshot 2026-07-04 at 2 14 57 PM" src="https://github.com/user-attachments/assets/42891ec9-4a6d-4383-9250-ec4e2b0135e6" />


## Reproduction

```bash
tmp=$(mktemp -d)

CTX_ANALYTICS_OFF=1 \
CTX_DATA_ROOT="$tmp/data" \
./target/debug/ctx locate event deadbeef

find "$tmp" -maxdepth 2 -type f | sort
```

Before this change, `work.sqlite` was created even though the command was read-only.

After this change, the command reports that the store is not initialized and no database is created.