### PR TITLE
fix(cli): validate explicit format import paths

### DIFF
--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -2491,10 +2491,7 @@ fn run_explicit_format_import(
         .try_exists()
         .with_context(|| format!("check import path {}", path.display()))?
     {
-        return Err(anyhow!(
-            "import path does not exist: {}",
-            path.display()
-        ));
+        return Err(anyhow!("import path does not exist: {}", path.display()));
     }
     let stats =
         source_stats(path).with_context(|| format!("scan import source {}", path.display()))?;

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -2487,6 +2487,15 @@ fn run_explicit_format_import(
         .path
         .as_ref()
         .context("--format requires an explicit --path")?;
+    if !path
+        .try_exists()
+        .with_context(|| format!("check import path {}", path.display()))?
+    {
+        return Err(anyhow!(
+            "import path does not exist: {}",
+            path.display()
+        ));
+    }
     let stats =
         source_stats(path).with_context(|| format!("scan import source {}", path.display()))?;
     analytics::insert_count_bucket(analytics_properties, "sources_seen_bucket", 1);

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -6875,6 +6875,22 @@ fn import_rejects_nonexistent_path() {
 }
 
 #[test]
+fn import_rejects_nonexistent_explicit_format_path() {
+    let temp = tempdir();
+    let path = temp.path().join("missing-file.jsonl");
+    let path = path.to_str().unwrap();
+
+    ctx(&temp)
+        .args(["import", "--format", "ctx-history-jsonl-v1", "--path", path])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("import path does not exist")
+                .and(predicate::str::contains(path)),
+        );
+}
+
+#[test]
 fn import_path_requires_provider_before_opening_store() {
     let temp = tempdir();
     let path = temp.path().join("missing-codex-history");


### PR DESCRIPTION
## Summary

The explicit `--format` import path currently falls through to `source_stats()` when the supplied path doesn't exist, resulting in a low-level filesystem error.

This changes it to perform the same early path validation already used by the native `--provider ... --path` import path, so both commands report a consistent, user-friendly error.

## Reproduction

```bash
./target/debug/ctx import \
  --format ctx-history-jsonl-v1 \
  --path /tmp/does-not-exist
```

## Validation

- Added a regression test for the explicit format import path
- Verified the new behavior manually
### Before

<img width="390" height="93" alt="before" src="https://github.com/user-attachments/assets/279d236f-f9fb-4abe-ba73-e66b52103033" />


### After
<img width="465" height="55" alt="after" src="https://github.com/user-attachments/assets/674db1a0-f253-45f5-adc9-ada9703c597b" />

