### PR TITLE
Improve error for nonexistent history source manifest paths

### DIFF
--- a/crates/ctx-cli/src/history_source_plugins.rs
+++ b/crates/ctx-cli/src/history_source_plugins.rs
@@ -647,6 +647,15 @@ fn plugin_manifest_paths(data_root: &Path) -> Vec<PathBuf> {
 fn explicit_plugin_manifest_paths(extra_manifests: &[PathBuf]) -> Result<Vec<PathBuf>> {
     let mut candidates = BTreeSet::new();
     for path in extra_manifests {
+        if !path
+            .try_exists()
+            .with_context(|| format!("check import path {}", path.display()))?
+        {
+            return Err(anyhow!(
+                "import path does not exist: {}",
+                path.display()
+            ));
+        }
         let before = candidates.len();
         collect_manifest_path_candidates(path, &mut candidates);
         if candidates.len() == before {

--- a/crates/ctx-cli/src/history_source_plugins.rs
+++ b/crates/ctx-cli/src/history_source_plugins.rs
@@ -651,10 +651,7 @@ fn explicit_plugin_manifest_paths(extra_manifests: &[PathBuf]) -> Result<Vec<Pat
             .try_exists()
             .with_context(|| format!("check import path {}", path.display()))?
         {
-            return Err(anyhow!(
-                "import path does not exist: {}",
-                path.display()
-            ));
+            return Err(anyhow!("import path does not exist: {}", path.display()));
         }
         let before = candidates.len();
         collect_manifest_path_candidates(path, &mut candidates);

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -1420,6 +1420,23 @@ fn explicit_history_source_manifest_reports_parse_errors() {
 }
 
 #[test]
+fn explicit_history_source_manifest_reports_nonexistent_path() {
+    let temp = tempdir();
+    let path = temp.path().join("no-such-manifest.json");
+
+    let stderr = failure_stderr(ctx(&temp).args([
+        "import",
+        "--history-source-manifest",
+        path.to_str().unwrap(),
+        "--progress",
+        "none",
+    ]));
+
+    assert!(stderr.contains("import path does not exist"), "{stderr}");
+    assert!(stderr.contains(path.to_str().unwrap()), "{stderr}");
+}
+
+#[test]
 fn failed_history_source_plugin_import_does_not_leave_record_metadata() {
     let temp = tempdir();
     let script = r#"#!/usr/bin/env python3


### PR DESCRIPTION
## Summary

The `--history-source-manifest` import path currently reports that the supplied path "did not contain" `ctx-history-plugin.json` even when the path does not exist.

This adds the same early path validation already used by the other explicit import paths, so nonexistent paths report the existing `import path does not exist` error instead.

## Reproduction

```bash
./target/debug/ctx import \
  --history-source-manifest /tmp/no-such-manifest.json
```

## Validation

- Added a regression test for nonexistent manifest paths
- Verified the new behavior manually

### Before

<img width="933" height="39" alt="beforectx" src="https://github.com/user-attachments/assets/64e84ca4-36f8-472b-a0d9-196381e1a285" />


### After


<img width="522" height="40" alt="afterctx" src="https://github.com/user-attachments/assets/f8807184-e16a-4244-bee1-6c25a6ee1f7b" />

