### PR TITLE
Add OMP (~/.omp/agent/sessions) to Pi provider default locations

### DIFF
--- a/crates/ctx-history-capture/src/provider_sources.rs
+++ b/crates/ctx-history-capture/src/provider_sources.rs
@@ -104,11 +104,18 @@ const CODEX_DEFAULTS: &[ProviderDefaultLocation] = &[
     },
 ];
 
-const PI_DEFAULTS: &[ProviderDefaultLocation] = &[ProviderDefaultLocation {
-    path_components: &[".pi", "agent", "sessions"],
-    source_format: "pi_session_jsonl",
-    source_kind: ProviderSourceKind::NativeHistory,
-}];
+const PI_DEFAULTS: &[ProviderDefaultLocation] = &[
+    ProviderDefaultLocation {
+        path_components: &[".pi", "agent", "sessions"],
+        source_format: "pi_session_jsonl",
+        source_kind: ProviderSourceKind::NativeHistory,
+    },
+    ProviderDefaultLocation {
+        path_components: &[".omp", "agent", "sessions"],
+        source_format: "pi_session_jsonl",
+        source_kind: ProviderSourceKind::NativeHistory,
+    },
+];
 
 const CLAUDE_DEFAULTS: &[ProviderDefaultLocation] = &[ProviderDefaultLocation {
     path_components: &[".claude", "projects"],
@@ -1006,6 +1013,21 @@ mod tests {
             .unwrap();
         assert_eq!(pi_source.status, ProviderSourceStatus::Available);
         assert_eq!(pi_source.path, temp.path().join(".pi/agent/sessions"));
+
+        let omp = temp.path().join(".omp/agent/sessions");
+        std::fs::create_dir_all(omp.join("--workspace--")).unwrap();
+        let omp_source = discover_provider_sources(temp.path())
+            .into_iter()
+            .find(|source| source.provider == CaptureProvider::Pi && source.path == omp)
+            .unwrap();
+        assert_eq!(omp_source.status, ProviderSourceStatus::Empty);
+        assert_eq!(omp_source.source_format, "pi_session_jsonl");
+        std::fs::write(omp.join("--workspace--/session.jsonl"), "{}\n").unwrap();
+        let omp_source = discover_provider_sources(temp.path())
+            .into_iter()
+            .find(|source| source.provider == CaptureProvider::Pi && source.path == omp)
+            .unwrap();
+        assert_eq!(omp_source.status, ProviderSourceStatus::Available);
 
         let antigravity = temp.path().join(".gemini/antigravity-cli/brain");
         std::fs::create_dir_all(antigravity.join("session/.system_generated/logs")).unwrap();

--- a/docs/provider-support-matrix.json
+++ b/docs/provider-support-matrix.json
@@ -88,12 +88,14 @@
           ],
           "notes": [
             "Reads Pi session JSONL files under ~/.pi/agent/sessions, including per-cwd session directories produced by current Pi releases.",
-            "An explicit Pi session JSONL file path remains supported with ctx import --provider pi --path."
+            "An explicit Pi session JSONL file path remains supported with ctx import --provider pi --path.",
+            "Also reads ~/.omp/agent/sessions from Oh My Pi (OMP), a Pi fork, using the identical pi_session_jsonl format."
           ]
         }
       ],
       "history_locations": [
-        "~/.pi/agent/sessions"
+        "~/.pi/agent/sessions",
+        "~/.omp/agent/sessions"
       ],
       "imports_existing_history": true,
       "captures_new_runs_passively": false,

--- a/docs/provider-support.md
+++ b/docs/provider-support.md
@@ -23,7 +23,7 @@ is:
 | Provider | Status | Public import path | Public smoke |
 | --- | --- | --- | --- |
 | Codex | `local_import` | `~/.codex/sessions`, `~/.codex/history.jsonl`, or an explicit Codex path. | Static local-history fixture smoke. |
-| Pi | `local_import_when_supported` | `~/.pi/agent/sessions` or an explicit Pi session JSONL path. | Static local-history fixture smoke. |
+| Pi | `local_import_when_supported` | `~/.pi/agent/sessions`, `~/.omp/agent/sessions` (Oh My Pi fork), or an explicit Pi session JSONL path. | Static local-history fixture smoke. |
 | Claude | `local_import_when_supported` | `~/.claude/projects` or an explicit Claude projects JSONL tree. | Static local-history fixture smoke. |
 | OpenCode | `local_import_when_supported` | `~/.local/share/opencode/opencode.db` or an explicit OpenCode SQLite DB. | Static local-history fixture smoke. |
 | OpenClaw | `local_import_when_supported` | `OPENCLAW_STATE_DIR`, `~/.openclaw`, legacy `~/.clawdbot`/`~/.moltbot`, or an explicit OpenClaw state tree. | Static local-history fixture smoke; beta storage-contract notes in the matrix. |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -10,7 +10,8 @@ The current CLI imports local history for:
 
 - Codex session JSONL trees under `~/.codex/sessions`;
 - Codex `~/.codex/history.jsonl`;
-- Pi session JSONL files under `~/.pi/agent/sessions`;
+- Pi session JSONL files under `~/.pi/agent/sessions` or `~/.omp/agent/sessions`
+  (Oh My Pi fork);
 - Claude Code project JSONL transcripts under `~/.claude/projects`;
 - OpenCode SQLite history under `~/.local/share/opencode/opencode.db`;
 - OpenClaw session JSONL trees under `OPENCLAW_STATE_DIR`, `~/.openclaw`,


### PR DESCRIPTION
## Motivation

[OMP (Oh My Pi)](https://github.com/can1357/oh-my-pi) is a Pi fork that renames the config root from `.pi` to `.omp`. Session history lives at `~/.omp/agent/sessions` in the identical per-session JSONL format Pi already uses.

Source (upstream OMP): `packages/utils/src/dirs.ts` — `CONFIG_DIR_NAME = ".omp"`, and `getSessionsDir()` resolves to `~/.omp/agent/sessions`.

Without this change, `ctx sources` / `ctx import --all` never discover OMP history natively; only an explicit `ctx import --provider pi --path ~/.omp/agent/sessions` works.

## Approach

Adds a second `ProviderDefaultLocation` entry to `PI_DEFAULTS` (`crates/ctx-history-capture/src/provider_sources.rs`) for `~/.omp/agent/sessions`, reusing the existing `pi_session_jsonl` format — no new provider or source format needed since the on-disk schema is identical to `~/.pi/agent/sessions`.

This mirrors the `OPENCLAW_DEFAULTS` precedent, which already lists three default locations (`.openclaw`, `.clawdbot`, `.moltbot`) under a single provider. `discover_provider_sources_for_spec` and `default_location_import_probe` key off the provider (not the individual location), so both Pi default locations are probed/discovered/deduped automatically with no other code changes.

Follows up #40/#41 (0.19 Pi tree discovery support). No overlap with draft #43 (env-var-based custom directory discovery) — verified against its diff; it adds a new match arm elsewhere in `discover_provider_sources_for_spec` and never touches the `PI_DEFAULTS` constant.

## Validation

- Real-world OMP install: 326 sessions / 40k+ events previously importable only via explicit `--path`; discovery now finds the source natively.
- Added a regression test in `provider_sources.rs` mirroring the existing `.pi/agent/sessions` assertions (empty → available transitions, correct `source_format`) for the new `.omp/agent/sessions` location.
- Updated `docs/providers.md`, `docs/provider-support.md`, and `docs/provider-support-matrix.json` per the "Required Evidence For Promotion" checklist.
- `cargo test -p ctx-history-capture`: 86 passed, 1 ignored.
- `cargo test -p ctx-history-core provider_support`: 2 passed (matrix JSON still parses/matches schema).
- `cargo clippy -p ctx-history-capture --all-targets -- -D warnings`: clean.
- `cargo fmt`: clean.
