### PR TITLE
Clarify installer PATH setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ ctx indexes those logs into SQLite on your machine, then gives current and futur
 curl -fsSL https://ctx.rs/install | sh
 ```
 
+The Unix installer places the binary in `~/.local/bin` by default. If your
+shell cannot find `ctx` after installation, run `~/.local/bin/ctx` directly or
+add `~/.local/bin` to your `PATH`.
+
 Optional but recommended for agent sessions:
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,6 +15,9 @@ metadata. On Windows, use `irm https://ctx.rs/install.ps1 | iex`.
 The install script installs `ctx` and runs `ctx setup` so discovered local
 history is indexed before it exits. Use `sh -s -- --no-setup` on Unix, or set
 `CTX_INSTALL_NO_SETUP=1` on Windows, for install-only CI or packaging flows.
+The Unix installer places the binary in `~/.local/bin` by default. If your
+shell cannot find `ctx` after installation, run `~/.local/bin/ctx` directly or
+add `~/.local/bin` to your `PATH`.
 
 When working from source, use `cargo build -p ctx` or
 `cargo install --path crates/ctx-cli`.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -136,6 +136,22 @@ validate_safe_value() {
   esac
 }
 
+warn_if_bin_dir_not_on_path() {
+  local needle="${bin_dir%/}"
+  local entry
+  local -a path_entries
+
+  IFS=: read -r -a path_entries <<< "${PATH:-}"
+  for entry in "${path_entries[@]}"; do
+    if [[ "${entry%/}" == "${needle}" ]]; then
+      return 0
+    fi
+  done
+
+  printf 'note: %s is not on PATH; use %s or add %s to PATH\n' \
+    "${bin_dir}" "${install_path}" "${bin_dir}" >&2
+}
+
 sha256_file() {
   local path="$1"
 
@@ -303,6 +319,7 @@ fi
 mkdir -p "${bin_dir}"
 install -m 0755 "${download_path}" "${install_path}"
 printf 'installed ctx to %s\n' "${install_path}"
+warn_if_bin_dir_not_on_path
 
 write_install_marker "${install_path}.install.json" "${metadata_source}" "${source_commit}" "${published_at}"
 printf 'wrote ctx managed install marker to %s\n' "${install_path}.install.json"


### PR DESCRIPTION
## Summary

- Document that the Unix installer places `ctx` in `~/.local/bin` by default.
- Tell users to run `~/.local/bin/ctx` directly or add `~/.local/bin` to `PATH` when `ctx` is not found.
- Add a PATH warning to `scripts/install.sh` after installing the binary.

## Why

A successful install can look like a failure when the user's shell cannot resolve `ctx` because `~/.local/bin` is not on `PATH`.

Closes #51.

## Validation

- `bash -n scripts/install.sh`
- `git diff --check`
