### PR TITLE
fix(cli): create parent directories for docs show output

### DIFF
--- a/crates/ctx-cli/src/docs.rs
+++ b/crates/ctx-cli/src/docs.rs
@@ -422,6 +422,9 @@ fn show_doc(args: DocsShowArgs) -> Result<()> {
         }
     };
     if let Some(path) = args.out {
+        if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+            fs::create_dir_all(parent)?;
+        }
         fs::write(&path, body).with_context(|| format!("write {}", path.display()))?;
     } else {
         println!("{body}");

--- a/crates/ctx-cli/src/docs.rs
+++ b/crates/ctx-cli/src/docs.rs
@@ -422,7 +422,10 @@ fn show_doc(args: DocsShowArgs) -> Result<()> {
         }
     };
     if let Some(path) = args.out {
-        if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
             fs::create_dir_all(parent)?;
         }
         fs::write(&path, body).with_context(|| format!("write {}", path.display()))?;

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -2503,6 +2503,27 @@ fn docs_commands_expose_embedded_docs_and_man_pages() {
     assert!(man.contains("Search local agent history"));
 }
 
+#[test]
+fn docs_show_out_creates_parent_directories() {
+    let temp = tempdir();
+    let out = temp.path().join("nested").join("doc.txt");
+
+    ctx(&temp)
+        .args([
+            "docs",
+            "show",
+            "cli-reference",
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(out.exists(), "docs show --out should write the requested file");
+    let body = fs::read_to_string(&out).unwrap();
+    assert!(body.contains("CLI Reference"), "{body}");
+}
+
 #[cfg(unix)]
 #[derive(Debug)]
 struct FakeRelease {

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -2519,7 +2519,10 @@ fn docs_show_out_creates_parent_directories() {
         .assert()
         .success();
 
-    assert!(out.exists(), "docs show --out should write the requested file");
+    assert!(
+        out.exists(),
+        "docs show --out should write the requested file"
+    );
     let body = fs::read_to_string(&out).unwrap();
     assert!(body.contains("CLI Reference"), "{body}");
 }


### PR DESCRIPTION
## Summary

`ctx docs show --out` currently fails when the output path contains directories that don't already exist.

This mirrors the existing behavior of `ctx show ... --out` and `ctx docs man --out` by creating parent directories before writing the output file.

## Reproduction

```bash
tmp=$(mktemp -d)
cd "$tmp"

/path/to/ctx/target/debug/ctx docs show \
  cli-reference \
  --out nested/doc.txt
```

Before:

<img width="365" height="105" alt="Screenshot 2026-07-05 at 1 18 43 PM" src="https://github.com/user-attachments/assets/f04775ef-6b2b-47f3-a611-9a9f541bb780" />



After:


<img width="584" height="151" alt="Screenshot 2026-07-05 at 1 30 17 PM" src="https://github.com/user-attachments/assets/b70b1e0e-cd1a-434b-9296-4597c9f8a450" />


## Validation

- Added a regression test covering nested output paths.
- Verified the behavior manually.