### PR TITLE
fix(cli): normalize whitespace-only search filters

### DIFF
--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -6423,7 +6423,9 @@ fn search_filters(
         provider_key: source_identity.provider_key,
         source_id: source_identity.source_id,
         source_format: source_identity.source_format,
-        repo: input.workspace,
+        repo: input
+            .workspace
+            .and_then(|s| if s.trim().is_empty() { None } else { Some(s) }),
         since: input.since.as_deref().map(parse_since_filter).transpose()?,
         primary_only: input.primary_only,
         include_subagents: input.include_subagents && !input.primary_only,
@@ -6433,7 +6435,10 @@ fn search_filters(
             .map(EventType::from_str)
             .transpose()
             .map_err(|err| anyhow!("{err}"))?,
-        file: input.file.map(|path| path.display().to_string()),
+        file: input.file.and_then(|path| {
+            let s = path.display().to_string();
+            if s.trim().is_empty() { None } else { Some(s) }
+        }),
         exclude_provider_session,
     })
 }

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -6437,7 +6437,11 @@ fn search_filters(
             .map_err(|err| anyhow!("{err}"))?,
         file: input.file.and_then(|path| {
             let s = path.display().to_string();
-            if s.trim().is_empty() { None } else { Some(s) }
+            if s.trim().is_empty() {
+                None
+            } else {
+                Some(s)
+            }
         }),
         exclude_provider_session,
     })

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -7172,6 +7172,31 @@ fn file_only_search_returns_touched_file_matches() {
 }
 
 #[test]
+fn search_normalizes_whitespace_only_filters() {
+    let temp = tempdir();
+    let no_file = json_output(
+        ctx(&temp).args(["search", "test", "--file", " ", "--json"]),
+    );
+    assert!(
+        !no_file["filters"].as_object().unwrap().contains_key("file"),
+        "expected no \"file\" key in filters, got: {}",
+        no_file["filters"],
+    );
+
+    let no_workspace = json_output(
+        ctx(&temp).args(["search", "test", "--workspace", " ", "--json"]),
+    );
+    assert!(
+        !no_workspace["filters"]
+            .as_object()
+            .unwrap()
+            .contains_key("workspace"),
+        "expected no \"workspace\" key in filters, got: {}",
+        no_workspace["filters"],
+    );
+}
+
+#[test]
 fn pi_cli_imports_directory_tree_path() {
     let temp = tempdir();
     let path = temp.path().join("pi-sessions-dir");

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -7174,18 +7174,15 @@ fn file_only_search_returns_touched_file_matches() {
 #[test]
 fn search_normalizes_whitespace_only_filters() {
     let temp = tempdir();
-    let no_file = json_output(
-        ctx(&temp).args(["search", "test", "--file", " ", "--json"]),
-    );
+    let no_file = json_output(ctx(&temp).args(["search", "test", "--file", " ", "--json"]));
     assert!(
         !no_file["filters"].as_object().unwrap().contains_key("file"),
         "expected no \"file\" key in filters, got: {}",
         no_file["filters"],
     );
 
-    let no_workspace = json_output(
-        ctx(&temp).args(["search", "test", "--workspace", " ", "--json"]),
-    );
+    let no_workspace =
+        json_output(ctx(&temp).args(["search", "test", "--workspace", " ", "--json"]));
     assert!(
         !no_workspace["filters"]
             .as_object()


### PR DESCRIPTION
## Summary

While looking at the search filters, I noticed that whitespace-only values passed to `--file` and `--workspace` were being ignored by the search pipeline, but they still appeared in the JSON `filters` output.

This normalizes both fields when building `SearchFilters`, so the JSON output reflects the filters that are actually applied.

## Reproduction

```bash
./target/debug/ctx search foo --file " " --json | jq '.filters'
```

Before:

```json
{
  "file": " ",
  "include_subagents": false
}
```

After:

Whitespace-only values are normalized away, so the `file` filter is no longer included in the JSON output. The same behavior now applies to `--workspace`.
<img width="496" height="75" alt="Screenshot 2026-07-05 at 6 42 57 PM" src="https://github.com/user-attachments/assets/3ee7ea91-15e2-4c31-9725-b22971d7f608" />

## Testing

- Added a regression test covering both `--file` and `--workspace`.
- Verified the updated JSON output manually.