### PR TITLE
Skip native JSONL files with no importable session header

### DIFF
--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -10007,6 +10007,14 @@ fn normalize_native_jsonl_session_file(
             .iter()
             .position(|(_, value)| native_jsonl_header_session_id(provider, value).is_some())
         else {
+            if let Some((line_number, _)) = rows.first() {
+                result.summary.failed += 1;
+                result.summary.failures.push(ProviderImportFailure {
+                    line: *line_number,
+                    error: "no importable native JSONL session header".to_owned(),
+                });
+                return Ok(result);
+            }
             return Err(CaptureError::InvalidProviderTranscriptPath {
                 path: path.to_path_buf(),
                 reason: native_jsonl_missing_reason(provider),
@@ -15641,7 +15649,7 @@ mod tests {
     }
 
     #[test]
-    fn native_jsonl_tree_rejects_headerless_native_files() {
+    fn native_jsonl_tree_skips_headerless_native_files() {
         let temp = tempdir();
         let root = temp.path().join("gemini/.gemini/tmp/project/chats");
         fs::create_dir_all(&root).unwrap();
@@ -15652,7 +15660,7 @@ mod tests {
         .unwrap();
         let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
 
-        let err = import_gemini_cli_history(
+        let summary = import_gemini_cli_history(
             temp.path().join("gemini/.gemini"),
             &mut store,
             GeminiCliImportOptions {
@@ -15660,11 +15668,13 @@ mod tests {
                 ..GeminiCliImportOptions::default()
             },
         )
-        .unwrap_err();
+        .unwrap();
 
-        assert!(err
-            .to_string()
-            .contains("no Gemini CLI chat JSONL transcripts found under chats"));
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.imported_events, 0);
+        assert!(summary.failures[0]
+            .error
+            .contains("no importable native JSONL session header"));
     }
 
     fn write_claude_smoke_fixture(temp: &TempDir) -> PathBuf {

--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -10003,6 +10003,9 @@ fn normalize_native_jsonl_session_file(
         }
         0
     } else {
+        if rows.is_empty() {
+            return Ok(result);
+        }
         let Some(header_index) = rows
             .iter()
             .position(|(_, value)| native_jsonl_header_session_id(provider, value).is_some())
@@ -15675,6 +15678,102 @@ mod tests {
         assert!(summary.failures[0]
             .error
             .contains("no importable native JSONL session header"));
+    }
+
+    #[test]
+    fn native_jsonl_tree_tolerates_unimportable_siblings_for_shared_providers() {
+        let temp = tempdir();
+        let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+        let gemini = write_gemini_smoke_fixture(&temp);
+        write_unimportable_jsonl_siblings(
+            &temp.path().join("gemini/.gemini/tmp/project/chats"),
+            "gemini",
+        );
+        let gemini_summary = import_gemini_cli_history(
+            &gemini,
+            &mut store,
+            GeminiCliImportOptions {
+                allow_partial_failures: true,
+                ..GeminiCliImportOptions::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(gemini_summary.failed, 2, "{:?}", gemini_summary.failures);
+        assert_eq!(gemini_summary.imported_sessions, 2);
+        assert_eq!(gemini_summary.imported_events, 5);
+        assert_provider_failures_include_headerless_and_malformed(&gemini_summary);
+
+        let droid = write_droid_smoke_fixture(&temp);
+        write_unimportable_jsonl_siblings(&temp.path().join("droid/sessions/project"), "droid");
+        let droid_summary = import_factory_ai_droid_sessions(
+            &droid,
+            &mut store,
+            FactoryAiDroidImportOptions {
+                allow_partial_failures: true,
+                ..FactoryAiDroidImportOptions::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(droid_summary.failed, 2, "{:?}", droid_summary.failures);
+        assert_eq!(droid_summary.imported_sessions, 2);
+        assert_eq!(droid_summary.imported_events, 5);
+        assert_provider_failures_include_headerless_and_malformed(&droid_summary);
+
+        let copilot = write_copilot_smoke_fixture(&temp);
+        write_unimportable_copilot_siblings(&temp.path().join("copilot/session-state"));
+        let copilot_summary = import_copilot_cli_session_events(
+            &copilot,
+            &mut store,
+            CopilotCliImportOptions {
+                allow_partial_failures: true,
+                ..CopilotCliImportOptions::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(copilot_summary.failed, 2, "{:?}", copilot_summary.failures);
+        assert_eq!(copilot_summary.imported_sessions, 1);
+        assert_eq!(copilot_summary.imported_events, 5);
+        assert_provider_failures_include_headerless_and_malformed(&copilot_summary);
+    }
+
+    fn write_unimportable_jsonl_siblings(root: &Path, prefix: &str) {
+        fs::write(root.join(format!("{prefix}-empty.jsonl")), "").unwrap();
+        fs::write(
+            root.join(format!("{prefix}-malformed.jsonl")),
+            "{\"not valid\"\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join(format!("{prefix}-headerless.jsonl")),
+            "{\"type\":\"message\",\"content\":\"missing session header\"}\n",
+        )
+        .unwrap();
+    }
+
+    fn write_unimportable_copilot_siblings(root: &Path) {
+        for (session, content) in [
+            ("copilot-empty", ""),
+            ("copilot-malformed", "{\"not valid\"\n"),
+            (
+                "copilot-headerless",
+                "{\"type\":\"user.message\",\"data\":{\"content\":\"missing session header\"}}\n",
+            ),
+        ] {
+            let path = root.join(session);
+            fs::create_dir_all(&path).unwrap();
+            fs::write(path.join("events.jsonl"), content).unwrap();
+        }
+    }
+
+    fn assert_provider_failures_include_headerless_and_malformed(summary: &ProviderImportSummary) {
+        assert!(summary.failures.iter().any(|failure| failure
+            .error
+            .contains("no importable native JSONL session header")));
+        assert!(summary
+            .failures
+            .iter()
+            .any(|failure| failure.error.contains("malformed JSONL")));
     }
 
     fn write_claude_smoke_fixture(temp: &TempDir) -> PathBuf {

--- a/crates/ctx-history-capture/tests/cursor_native.rs
+++ b/crates/ctx-history-capture/tests/cursor_native.rs
@@ -48,6 +48,13 @@ fn imports_cursor_agent_transcript_jsonl_tree() {
     let temp = tempdir();
     let db_path = temp.path().join("work.sqlite");
     let fixture = materialized_provider_history_fixture(&temp, "cursor/2026.06.24/projects");
+    let aborted = fixture.join("sanitized-workspace/agent-transcripts/cursor-aborted-stub-session");
+    fs::create_dir_all(&aborted).unwrap();
+    fs::write(
+        aborted.join("cursor-aborted-stub-session.jsonl"),
+        r#"{"type":"turn_ended","status":"aborted","error":"User aborted/interrupted manually."}"#,
+    )
+    .unwrap();
     let mut store = Store::open(&db_path).unwrap();
 
     let summary = import_cursor_native_history(
@@ -62,7 +69,7 @@ fn imports_cursor_agent_transcript_jsonl_tree() {
     )
     .unwrap();
 
-    assert_eq!(summary.failed, 1, "{:?}", summary.failures);
+    assert_eq!(summary.failed, 2, "{:?}", summary.failures);
     assert_eq!(summary.imported_sessions, 2);
     assert_eq!(summary.imported_events, 6);
     drop(store);
@@ -118,4 +125,29 @@ fn reports_malformed_cursor_agent_transcript_when_partial_disallowed() {
     assert_eq!(summary.failed, 1);
     assert_eq!(summary.imported_events, 0);
     assert!(summary.failures[0].error.contains("malformed JSONL"));
+}
+
+#[test]
+fn reports_aborted_stub_cursor_agent_transcript_when_partial_disallowed() {
+    let temp = tempdir();
+    let fixture = temp
+        .path()
+        .join("cursor/projects/sanitized-workspace/agent-transcripts/cursor-aborted-stub-session");
+    fs::create_dir_all(&fixture).unwrap();
+    fs::write(
+        fixture.join("cursor-aborted-stub-session.jsonl"),
+        r#"{"type":"turn_ended","status":"aborted","error":"User aborted/interrupted manually."}"#,
+    )
+    .unwrap();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let options = CursorNativeImportOptions::default();
+    let summary = import_cursor_native_history(&fixture, &mut store, options).unwrap();
+
+    assert_eq!(summary.failed, 1);
+    assert_eq!(summary.imported_events, 0);
+    assert_eq!(
+        summary.failures[0].error,
+        "no importable native JSONL session header"
+    );
 }

--- a/crates/ctx-history-capture/tests/cursor_native.rs
+++ b/crates/ctx-history-capture/tests/cursor_native.rs
@@ -55,6 +55,17 @@ fn imports_cursor_agent_transcript_jsonl_tree() {
         r#"{"type":"turn_ended","status":"aborted","error":"User aborted/interrupted manually."}"#,
     )
     .unwrap();
+    let empty = fixture.join("sanitized-workspace/agent-transcripts/cursor-empty-stub-session");
+    fs::create_dir_all(&empty).unwrap();
+    fs::write(empty.join("cursor-empty-stub-session.jsonl"), "").unwrap();
+    let malformed =
+        fixture.join("sanitized-workspace/agent-transcripts/cursor-malformed-stub-session");
+    fs::create_dir_all(&malformed).unwrap();
+    fs::write(
+        malformed.join("cursor-malformed-stub-session.jsonl"),
+        "{\"not valid\"\n",
+    )
+    .unwrap();
     let mut store = Store::open(&db_path).unwrap();
 
     let summary = import_cursor_native_history(
@@ -69,7 +80,7 @@ fn imports_cursor_agent_transcript_jsonl_tree() {
     )
     .unwrap();
 
-    assert_eq!(summary.failed, 2, "{:?}", summary.failures);
+    assert_eq!(summary.failed, 3, "{:?}", summary.failures);
     assert_eq!(summary.imported_sessions, 2);
     assert_eq!(summary.imported_events, 6);
     drop(store);
@@ -125,6 +136,47 @@ fn reports_malformed_cursor_agent_transcript_when_partial_disallowed() {
     assert_eq!(summary.failed, 1);
     assert_eq!(summary.imported_events, 0);
     assert!(summary.failures[0].error.contains("malformed JSONL"));
+}
+
+#[test]
+fn reports_all_malformed_cursor_agent_transcript_when_partial_disallowed() {
+    let temp = tempdir();
+    let fixture = temp
+        .path()
+        .join("cursor/projects/sanitized-workspace/agent-transcripts/cursor-malformed-session");
+    fs::create_dir_all(&fixture).unwrap();
+    fs::write(
+        fixture.join("cursor-malformed-session.jsonl"),
+        "{\"not valid\"\n",
+    )
+    .unwrap();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary =
+        import_cursor_native_history(&fixture, &mut store, CursorNativeImportOptions::default())
+            .unwrap();
+
+    assert_eq!(summary.failed, 1);
+    assert_eq!(summary.imported_events, 0);
+    assert!(summary.failures[0].error.contains("malformed JSONL"));
+}
+
+#[test]
+fn ignores_empty_cursor_agent_transcript_when_partial_disallowed() {
+    let temp = tempdir();
+    let fixture = temp
+        .path()
+        .join("cursor/projects/sanitized-workspace/agent-transcripts/cursor-empty-session");
+    fs::create_dir_all(&fixture).unwrap();
+    fs::write(fixture.join("cursor-empty-session.jsonl"), "").unwrap();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary =
+        import_cursor_native_history(&fixture, &mut store, CursorNativeImportOptions::default())
+            .unwrap();
+
+    assert_eq!(summary.failed, 0);
+    assert_eq!(summary.imported_events, 0);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #56

## Motivation

`ctx import --provider cursor` aborts when a transcript JSONL contains parseable rows but no importable session header, such as Cursor `turn_ended` / aborted-only stubs. The failure is reported as `InvalidProviderTranscriptPath`, so it aborts the provider import before partial-failure handling can keep processing the rest of the tree.

## Approach

Treat non-empty headerless native JSONL files as per-file normalization failures and return a summary instead of raising `InvalidProviderTranscriptPath`. That lets tree imports keep valid transcripts while still surfacing the bad file in `summary.failures`.

- Cover Cursor aborted-only stubs in both tree import and explicit single-path import tests
- Update the Gemini headerless native JSONL regression to the new behavior

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ctx-history-capture --test cursor_native --locked`
- `cargo test -p ctx-history-capture --locked`
- `cargo test -p ctx --test cli native_provider_cli`