### PR TITLE
[codex] Improve installer setup flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,13 @@
 *.db
 *.sqlite
 *.sqlite3
+
+# SDK build artifacts
+/sdks/dotnet/**/bin/
+/sdks/dotnet/**/obj/
+/sdks/jvm/build/
+/sdks/swift/.build/
+
+# Python bytecode
+__pycache__/
+*.py[cod]

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -64,6 +64,13 @@ sh_test(
 )
 
 sh_test(
+    name = "installer_path_smoke",
+    srcs = ["scripts/bazel-test.sh"],
+    args = ["installer_path_smoke"],
+    data = CTX_GATE_DATA,
+)
+
+sh_test(
     name = "buildkite_pipeline_check",
     srcs = ["scripts/bazel-test.sh"],
     args = ["buildkite_pipeline_check"],
@@ -140,6 +147,7 @@ test_suite(
         ":cargo_check",
         ":cli_contract_tests",
         ":docs_check",
+        ":installer_path_smoke",
         ":buildkite_pipeline_check",
         ":source_diff_check",
         ":package_audit_fast",

--- a/README.md
+++ b/README.md
@@ -17,10 +17,13 @@ ctx indexes those logs into SQLite on your machine, then gives current and futur
 curl -fsSL https://ctx.rs/install | sh
 ```
 
-Optional but recommended for agent sessions:
+The hosted installer also runs the bundled agent-history skill installer and
+`ctx setup` by default. For source builds, package-manager installs, or later
+skill refreshes, run:
 
 ```bash
-npx skills add ctxrs/ctx
+ctx skill install
+ctx setup
 ```
 
 For marketplace/plugin installs in Codex, Claude Code, Cursor, and raw Agent
@@ -118,7 +121,7 @@ ctx keeps retrieval tied to sessions and events, so another agent can inspect th
 | --- | --- |
 | [Install](https://ctx.rs/getting-started/install) | Install ctx, initialize local storage, and index discovered local history. |
 | [Quickstart](https://ctx.rs/first-search) | Search local history, inspect an event, open the session, and use JSON output. |
-| [Install the ctx skill](https://ctx.rs/skill) | Install the agent-history search skill with the open skills installer. |
+| [Install the ctx skill](https://ctx.rs/skill) | Install or refresh the bundled agent-history search skill with `ctx skill install`. |
 | [Agent plugin installs](docs/agent-skill-install.md) | Install the ctx skill through Codex, Claude Code, Cursor, or a raw skill folder. |
 | [SDKs](docs/sdks.md) | Use ctx agent history search from TypeScript, Python, Rust, Go, JVM, Swift, or .NET code. |
 | [Custom history plugins](docs/history-source-plugins.md) | Build an advanced local adapter for agent formats ctx does not support natively. |

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -23,6 +23,7 @@ mod identity;
 mod install_marker;
 mod mcp;
 mod net;
+mod skill;
 mod upgrade;
 
 #[cfg(test)]
@@ -104,6 +105,8 @@ enum CommandRoot {
     Sql(SqlArgs),
     #[command(about = "Read embedded ctx documentation")]
     Docs(docs::DocsArgs),
+    #[command(about = "Install or inspect the bundled ctx agent skill")]
+    Skill(skill::SkillArgs),
     #[command(about = "Serve read-only ctx tools over MCP")]
     Mcp(mcp::McpArgs),
     #[command(about = "Check or apply signed ctx CLI upgrades")]
@@ -526,6 +529,7 @@ impl CommandRoot {
             Self::Search(_) => "search",
             Self::Sql(_) => "sql",
             Self::Docs(_) => "docs",
+            Self::Skill(_) => "skill",
             Self::Mcp(_) => "mcp",
             Self::Upgrade(_) => "upgrade",
             Self::Doctor(_) => "doctor",
@@ -551,6 +555,7 @@ impl CommandRoot {
             Self::Search(args) => args.json,
             Self::Sql(args) => args.json_output(),
             Self::Docs(args) => args.json_output(),
+            Self::Skill(args) => args.json_output(),
             Self::Mcp(_) => false,
             Self::Upgrade(args) => args.json_output(),
             Self::Doctor(args) => args.json,
@@ -1427,6 +1432,7 @@ fn main() -> Result<()> {
         CommandRoot::Search(args) => run_search(args, data_root.clone(), &mut analytics_properties),
         CommandRoot::Sql(args) => run_sql(args, data_root.clone()),
         CommandRoot::Docs(args) => docs::run(args),
+        CommandRoot::Skill(args) => skill::run(args, &mut analytics_properties),
         CommandRoot::Mcp(args) => mcp::run(args, data_root.clone()),
         CommandRoot::Upgrade(args) => upgrade::run(args, data_root.clone(), config.clone()),
         CommandRoot::Doctor(args) => run_doctor(args, data_root.clone(), &mut analytics_properties),
@@ -1583,6 +1589,9 @@ fn command_analytics_properties(command: &CommandRoot) -> AnalyticsProperties {
         }
         CommandRoot::Mcp(_) => {}
         CommandRoot::Docs(_) => {}
+        CommandRoot::Skill(args) => {
+            args.add_initial_analytics(&mut properties);
+        }
         CommandRoot::Upgrade(args) => {
             analytics::insert_bool(&mut properties, "dry_run", args.dry_run);
             analytics::insert_bool(&mut properties, "background", args.background());

--- a/crates/ctx-cli/src/skill.rs
+++ b/crates/ctx-cli/src/skill.rs
@@ -1,0 +1,1299 @@
+use std::{
+    collections::BTreeMap,
+    env, fs,
+    io::{self, IsTerminal, Write},
+    path::{Component, Path, PathBuf},
+};
+
+use anyhow::{anyhow, Context, Result};
+use clap::{Args, Subcommand, ValueEnum};
+use ctx_history_core::utc_now;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use crate::{analytics, AnalyticsProperties};
+
+const BUNDLED_SKILL_NAME: &str = "ctx-agent-history-search";
+const BUNDLED_SKILL_BODY: &str = include_str!("../../../skills/ctx-agent-history-search/SKILL.md");
+const METADATA_FILE: &str = ".ctx-skill.json";
+
+#[derive(Debug, Args)]
+pub(crate) struct SkillArgs {
+    #[command(subcommand)]
+    command: SkillCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum SkillCommand {
+    #[command(about = "Install or refresh the bundled ctx agent-history skill")]
+    Install(SkillInstallArgs),
+    #[command(about = "Check whether the bundled ctx agent-history skill is installed")]
+    Status(SkillStatusArgs),
+}
+
+#[derive(Debug, Args)]
+struct SkillInstallArgs {
+    #[arg(long = "agent", value_enum, conflicts_with = "all_agents")]
+    agent: Vec<SkillAgentArg>,
+    #[arg(long, conflicts_with = "agent")]
+    all_agents: bool,
+    #[arg(
+        long,
+        help = "Install into the current project instead of global agent dirs"
+    )]
+    project: bool,
+    #[arg(long)]
+    json: bool,
+    #[arg(long, help = "Overwrite locally modified bundled skill files")]
+    force: bool,
+}
+
+#[derive(Debug, Args)]
+struct SkillStatusArgs {
+    #[arg(long = "agent", value_enum, conflicts_with = "all_agents")]
+    agent: Vec<SkillAgentArg>,
+    #[arg(long, conflicts_with = "agent")]
+    all_agents: bool,
+    #[arg(
+        long,
+        help = "Check the current project's skill dirs instead of global dirs"
+    )]
+    project: bool,
+    #[arg(long)]
+    json: bool,
+}
+
+impl SkillArgs {
+    pub(crate) fn json_output(&self) -> bool {
+        match &self.command {
+            SkillCommand::Install(args) => args.json,
+            SkillCommand::Status(args) => args.json,
+        }
+    }
+
+    pub(crate) fn add_initial_analytics(&self, properties: &mut AnalyticsProperties) {
+        analytics::insert_str(properties, "skill_name", BUNDLED_SKILL_NAME);
+        match &self.command {
+            SkillCommand::Install(args) => {
+                analytics::insert_str(properties, "skill_action", "install");
+                insert_target_analytics(properties, &args.agent, args.all_agents, args.project);
+            }
+            SkillCommand::Status(args) => {
+                analytics::insert_str(properties, "skill_action", "status");
+                insert_target_analytics(properties, &args.agent, args.all_agents, args.project);
+            }
+        }
+    }
+}
+
+fn insert_target_analytics(
+    properties: &mut AnalyticsProperties,
+    agents: &[SkillAgentArg],
+    all_agents: bool,
+    project: bool,
+) {
+    analytics::insert_str(
+        properties,
+        "skill_scope",
+        if project { "project" } else { "global" },
+    );
+    analytics::insert_str(
+        properties,
+        "target_agent_group",
+        if all_agents {
+            "all"
+        } else if agents.is_empty() {
+            "default"
+        } else {
+            "explicit"
+        },
+    );
+    let count = if all_agents {
+        SkillAgentArg::ALL.len()
+    } else {
+        agents.len().max(1)
+    };
+    analytics::insert_count_bucket(properties, "target_agents_count_bucket", count as u64);
+}
+
+pub(crate) fn run(args: SkillArgs, analytics_properties: &mut AnalyticsProperties) -> Result<()> {
+    let context = PathContext::from_env()?;
+    match args.command {
+        SkillCommand::Install(args) => run_install(args, &context, analytics_properties),
+        SkillCommand::Status(args) => run_status(args, &context, analytics_properties),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+enum SkillAgentArg {
+    #[value(name = "universal", alias = "agents")]
+    Universal,
+    Codex,
+    #[value(name = "claude-code", alias = "claude")]
+    ClaudeCode,
+    Cursor,
+    #[value(name = "opencode", alias = "open-code")]
+    OpenCode,
+    Amp,
+    #[value(name = "gemini-cli", alias = "gemini")]
+    GeminiCli,
+    Antigravity,
+    #[value(name = "antigravity-cli")]
+    AntigravityCli,
+    #[value(name = "github-copilot", alias = "copilot")]
+    GitHubCopilot,
+    Pi,
+    Goose,
+}
+
+impl SkillAgentArg {
+    const ALL: &'static [Self] = &[
+        Self::Universal,
+        Self::Codex,
+        Self::ClaudeCode,
+        Self::Cursor,
+        Self::OpenCode,
+        Self::Amp,
+        Self::GeminiCli,
+        Self::Antigravity,
+        Self::AntigravityCli,
+        Self::GitHubCopilot,
+        Self::Pi,
+        Self::Goose,
+    ];
+
+    fn id(self) -> &'static str {
+        match self {
+            Self::Universal => "universal",
+            Self::Codex => "codex",
+            Self::ClaudeCode => "claude-code",
+            Self::Cursor => "cursor",
+            Self::OpenCode => "opencode",
+            Self::Amp => "amp",
+            Self::GeminiCli => "gemini-cli",
+            Self::Antigravity => "antigravity",
+            Self::AntigravityCli => "antigravity-cli",
+            Self::GitHubCopilot => "github-copilot",
+            Self::Pi => "pi",
+            Self::Goose => "goose",
+        }
+    }
+
+    fn display_name(self) -> &'static str {
+        match self {
+            Self::Universal => "Universal .agents",
+            Self::Codex => "Codex",
+            Self::ClaudeCode => "Claude Code",
+            Self::Cursor => "Cursor",
+            Self::OpenCode => "OpenCode",
+            Self::Amp => "Amp",
+            Self::GeminiCli => "Gemini CLI",
+            Self::Antigravity => "Antigravity",
+            Self::AntigravityCli => "Antigravity CLI",
+            Self::GitHubCopilot => "GitHub Copilot",
+            Self::Pi => "Pi",
+            Self::Goose => "Goose",
+        }
+    }
+
+    fn project_skills_dir(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => ".claude/skills",
+            Self::Pi => ".pi/skills",
+            Self::Goose => ".goose/skills",
+            Self::Universal
+            | Self::Codex
+            | Self::Cursor
+            | Self::OpenCode
+            | Self::Amp
+            | Self::GeminiCli
+            | Self::Antigravity
+            | Self::AntigravityCli
+            | Self::GitHubCopilot => ".agents/skills",
+        }
+    }
+
+    fn global_skills_dir(self, context: &PathContext) -> PathBuf {
+        match self {
+            Self::Universal => context.home.join(".agents").join("skills"),
+            Self::Codex => context
+                .env_or_home_child("CODEX_HOME", ".codex")
+                .join("skills"),
+            Self::ClaudeCode => context
+                .env_or_home_child("CLAUDE_CONFIG_DIR", ".claude")
+                .join("skills"),
+            Self::Cursor => context.home.join(".cursor").join("skills"),
+            Self::OpenCode => context.xdg_config_home.join("opencode").join("skills"),
+            Self::Amp => context.xdg_config_home.join("agents").join("skills"),
+            Self::GeminiCli => context.home.join(".gemini").join("skills"),
+            Self::Antigravity => context
+                .home
+                .join(".gemini")
+                .join("antigravity")
+                .join("skills"),
+            Self::AntigravityCli => context
+                .home
+                .join(".gemini")
+                .join("antigravity-cli")
+                .join("skills"),
+            Self::GitHubCopilot => context.home.join(".copilot").join("skills"),
+            Self::Pi => context.home.join(".pi").join("agent").join("skills"),
+            Self::Goose => context.xdg_config_home.join("goose").join("skills"),
+        }
+    }
+
+    fn needs_agent_specific_default(self) -> bool {
+        self.project_skills_dir() != ".agents/skills"
+    }
+
+    fn detect_dir(self, context: &PathContext) -> Option<PathBuf> {
+        match self {
+            Self::Universal => Some(context.home.join(".agents")),
+            Self::Codex => Some(context.env_or_home_child("CODEX_HOME", ".codex")),
+            Self::ClaudeCode => Some(context.env_or_home_child("CLAUDE_CONFIG_DIR", ".claude")),
+            Self::Cursor => Some(context.home.join(".cursor")),
+            Self::OpenCode => Some(context.xdg_config_home.join("opencode")),
+            Self::Amp => Some(context.xdg_config_home.join("amp")),
+            Self::GeminiCli => Some(context.home.join(".gemini")),
+            Self::Antigravity => Some(context.home.join(".gemini").join("antigravity")),
+            Self::AntigravityCli => Some(context.home.join(".gemini").join("antigravity-cli")),
+            Self::GitHubCopilot => Some(context.home.join(".copilot")),
+            Self::Pi => Some(context.home.join(".pi").join("agent")),
+            Self::Goose => Some(context.xdg_config_home.join("goose")),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PathContext {
+    home: PathBuf,
+    xdg_config_home: PathBuf,
+    cwd: PathBuf,
+    env_overrides: BTreeMap<String, PathBuf>,
+}
+
+impl PathContext {
+    fn from_env() -> Result<Self> {
+        let home = home_dir().context("resolve home directory")?;
+        let xdg_config_home =
+            non_empty_env_path("XDG_CONFIG_HOME").unwrap_or_else(|| home.join(".config"));
+        let mut env_overrides = BTreeMap::new();
+        for key in ["CODEX_HOME", "CLAUDE_CONFIG_DIR"] {
+            if let Some(path) = non_empty_env_path(key) {
+                env_overrides.insert(key.to_owned(), path);
+            }
+        }
+        Ok(Self {
+            home,
+            xdg_config_home,
+            cwd: env::current_dir().context("resolve current directory")?,
+            env_overrides,
+        })
+    }
+
+    #[cfg(test)]
+    fn for_tests(home: PathBuf, cwd: PathBuf) -> Self {
+        Self {
+            xdg_config_home: home.join(".config"),
+            home,
+            cwd,
+            env_overrides: BTreeMap::new(),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_env_override(mut self, key: &str, value: PathBuf) -> Self {
+        self.env_overrides.insert(key.to_owned(), value);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_xdg_config_home(mut self, value: PathBuf) -> Self {
+        self.xdg_config_home = value;
+        self
+    }
+
+    fn env_or_home_child(&self, key: &str, fallback_child: &str) -> PathBuf {
+        self.env_overrides
+            .get(key)
+            .cloned()
+            .unwrap_or_else(|| self.home.join(fallback_child))
+    }
+
+    fn agent_detected(&self, agent: SkillAgentArg) -> bool {
+        if agent == SkillAgentArg::Codex
+            && !self.env_overrides.contains_key("CODEX_HOME")
+            && Path::new("/etc/codex").exists()
+        {
+            return true;
+        }
+        agent.detect_dir(self).is_some_and(|path| path.exists())
+    }
+}
+
+fn home_dir() -> Option<PathBuf> {
+    non_empty_env_path("HOME").or_else(|| non_empty_env_path("USERPROFILE"))
+}
+
+fn non_empty_env_path(key: &str) -> Option<PathBuf> {
+    env::var_os(key)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+#[derive(Debug, Clone)]
+struct SkillTarget {
+    agent: SkillAgentArg,
+    scope: SkillScope,
+    base_dir: PathBuf,
+    skill_dir: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SkillScope {
+    Global,
+    Project,
+}
+
+impl SkillScope {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Global => "global",
+            Self::Project => "project",
+        }
+    }
+}
+
+#[cfg(test)]
+fn explicit_selected_agents(
+    agents: &[SkillAgentArg],
+    all_agents: bool,
+) -> Option<Vec<SkillAgentArg>> {
+    if all_agents {
+        Some(SkillAgentArg::ALL.to_vec())
+    } else if agents.is_empty() {
+        None
+    } else {
+        Some(dedupe_agents(agents.iter().copied()))
+    }
+}
+
+fn dedupe_agents(agents: impl IntoIterator<Item = SkillAgentArg>) -> Vec<SkillAgentArg> {
+    let mut deduped = Vec::new();
+    for agent in agents {
+        if !deduped.contains(&agent) {
+            deduped.push(agent);
+        }
+    }
+    deduped
+}
+
+fn detected_agents(context: &PathContext) -> Vec<SkillAgentArg> {
+    picker_agents()
+        .iter()
+        .copied()
+        .filter(|agent| context.agent_detected(*agent))
+        .collect()
+}
+
+fn detected_agent_specific_agents(context: &PathContext) -> Vec<SkillAgentArg> {
+    detected_agents(context)
+        .into_iter()
+        .filter(|agent| agent.needs_agent_specific_default())
+        .collect()
+}
+
+fn default_noninteractive_agents(
+    context: &PathContext,
+) -> (Vec<SkillAgentArg>, SkillSelectionSource) {
+    let mut agents = vec![SkillAgentArg::Universal];
+    let detected_specific = detected_agent_specific_agents(context);
+    let source = if detected_specific.is_empty() {
+        SkillSelectionSource::Fallback
+    } else {
+        agents.extend(detected_specific);
+        SkillSelectionSource::Detected
+    };
+    (agents, source)
+}
+
+fn default_picker_agents(context: &PathContext) -> Vec<SkillAgentArg> {
+    let (agents, _) = default_noninteractive_agents(context);
+    agents
+}
+
+fn picker_agents() -> &'static [SkillAgentArg] {
+    &[
+        SkillAgentArg::Universal,
+        SkillAgentArg::ClaudeCode,
+        SkillAgentArg::Codex,
+        SkillAgentArg::Cursor,
+        SkillAgentArg::OpenCode,
+        SkillAgentArg::GeminiCli,
+        SkillAgentArg::Antigravity,
+        SkillAgentArg::AntigravityCli,
+        SkillAgentArg::GitHubCopilot,
+        SkillAgentArg::Pi,
+        SkillAgentArg::Goose,
+        SkillAgentArg::Amp,
+    ]
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkillSelectionSource {
+    Explicit,
+    All,
+    Picker,
+    Detected,
+    Fallback,
+}
+
+impl SkillSelectionSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Explicit => "explicit",
+            Self::All => "all",
+            Self::Picker => "picker",
+            Self::Detected => "detected",
+            Self::Fallback => "fallback",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SkillAgentSelection {
+    agents: Vec<SkillAgentArg>,
+    source: SkillSelectionSource,
+}
+
+fn install_agent_selection(
+    args: &SkillInstallArgs,
+    context: &PathContext,
+) -> Result<SkillAgentSelection> {
+    if args.all_agents {
+        return Ok(SkillAgentSelection {
+            agents: SkillAgentArg::ALL.to_vec(),
+            source: SkillSelectionSource::All,
+        });
+    }
+    if !args.agent.is_empty() {
+        return Ok(SkillAgentSelection {
+            agents: dedupe_agents(args.agent.iter().copied()),
+            source: SkillSelectionSource::Explicit,
+        });
+    }
+    if args.json || !can_prompt() {
+        let (agents, source) = default_noninteractive_agents(context);
+        return Ok(SkillAgentSelection { agents, source });
+    }
+    let agents = prompt_for_agents(context)?;
+    Ok(SkillAgentSelection {
+        agents,
+        source: SkillSelectionSource::Picker,
+    })
+}
+
+fn status_agent_selection(args: &SkillStatusArgs, context: &PathContext) -> SkillAgentSelection {
+    if args.all_agents {
+        return SkillAgentSelection {
+            agents: SkillAgentArg::ALL.to_vec(),
+            source: SkillSelectionSource::All,
+        };
+    }
+    if !args.agent.is_empty() {
+        return SkillAgentSelection {
+            agents: dedupe_agents(args.agent.iter().copied()),
+            source: SkillSelectionSource::Explicit,
+        };
+    }
+    let (agents, source) = default_noninteractive_agents(context);
+    SkillAgentSelection { agents, source }
+}
+
+fn can_prompt() -> bool {
+    io::stdin().is_terminal() && io::stderr().is_terminal()
+}
+
+fn prompt_for_agents(context: &PathContext) -> Result<Vec<SkillAgentArg>> {
+    let options = picker_agents();
+    let detected = detected_agents(context);
+    let defaults = default_picker_agents(context);
+    let mut stderr = io::stderr();
+    writeln!(
+        stderr,
+        "Select where to install {BUNDLED_SKILL_NAME}. Detected agents are preselected."
+    )?;
+    writeln!(
+        stderr,
+        "Press Enter for the marked defaults, or enter numbers like 1,2."
+    )?;
+    for (index, agent) in options.iter().enumerate() {
+        let marker = if defaults.contains(agent) { "*" } else { " " };
+        let detected_hint = if detected.contains(agent) {
+            " detected"
+        } else {
+            ""
+        };
+        let target = single_target(*agent, false, context)?;
+        writeln!(
+            stderr,
+            "  {}. [{}] {} -> {}{}",
+            index + 1,
+            marker,
+            agent.display_name(),
+            target.skill_dir.display(),
+            detected_hint
+        )?;
+    }
+    loop {
+        write!(stderr, "Install target(s): ")?;
+        stderr.flush()?;
+        let mut line = String::new();
+        io::stdin()
+            .read_line(&mut line)
+            .context("read skill install selection")?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return Ok(defaults);
+        }
+        if matches!(
+            trimmed.to_ascii_lowercase().as_str(),
+            "q" | "quit" | "cancel"
+        ) {
+            return Err(anyhow!("skill install canceled"));
+        }
+        match parse_picker_selection(trimmed, options) {
+            Ok(agents) => return Ok(agents),
+            Err(err) => {
+                writeln!(stderr, "{err}")?;
+            }
+        }
+    }
+}
+
+fn parse_picker_selection(input: &str, options: &[SkillAgentArg]) -> Result<Vec<SkillAgentArg>> {
+    let input = input.trim();
+    if input.eq_ignore_ascii_case("all") {
+        return Ok(options.to_vec());
+    }
+    let mut selected = Vec::new();
+    for raw in input
+        .split(|ch: char| ch == ',' || ch == ' ' || ch == '\t')
+        .filter(|part| !part.trim().is_empty())
+    {
+        let token = raw.trim();
+        let agent = if let Ok(index) = token.parse::<usize>() {
+            options
+                .get(index.saturating_sub(1))
+                .copied()
+                .ok_or_else(|| anyhow!("invalid selection {token}: choose 1-{}", options.len()))?
+        } else {
+            agent_from_name(token).ok_or_else(|| anyhow!("unknown agent: {token}"))?
+        };
+        if !selected.contains(&agent) {
+            selected.push(agent);
+        }
+    }
+    if selected.is_empty() {
+        return Err(anyhow!("choose at least one install target"));
+    }
+    Ok(selected)
+}
+
+fn agent_from_name(value: &str) -> Option<SkillAgentArg> {
+    match value.to_ascii_lowercase().as_str() {
+        "universal" | "agents" | ".agents" => Some(SkillAgentArg::Universal),
+        "codex" => Some(SkillAgentArg::Codex),
+        "claude" | "claude-code" | "claudecode" => Some(SkillAgentArg::ClaudeCode),
+        "cursor" => Some(SkillAgentArg::Cursor),
+        "opencode" | "open-code" => Some(SkillAgentArg::OpenCode),
+        "amp" => Some(SkillAgentArg::Amp),
+        "gemini" | "gemini-cli" => Some(SkillAgentArg::GeminiCli),
+        "antigravity" => Some(SkillAgentArg::Antigravity),
+        "antigravity-cli" => Some(SkillAgentArg::AntigravityCli),
+        "github-copilot" | "copilot" => Some(SkillAgentArg::GitHubCopilot),
+        "pi" => Some(SkillAgentArg::Pi),
+        "goose" => Some(SkillAgentArg::Goose),
+        _ => None,
+    }
+}
+
+fn single_target(
+    agent: SkillAgentArg,
+    project: bool,
+    context: &PathContext,
+) -> Result<SkillTarget> {
+    let skill_name = sanitize_skill_name(BUNDLED_SKILL_NAME)?;
+    let (scope, base_dir) = if project {
+        (
+            SkillScope::Project,
+            context.cwd.join(agent.project_skills_dir()),
+        )
+    } else {
+        (SkillScope::Global, agent.global_skills_dir(context))
+    };
+    let skill_dir = base_dir.join(&skill_name);
+    ensure_path_inside(&base_dir, &skill_dir)
+        .with_context(|| format!("resolve {} skill path", agent.id()))?;
+    Ok(SkillTarget {
+        agent,
+        scope,
+        base_dir,
+        skill_dir,
+    })
+}
+
+#[cfg(test)]
+fn resolve_targets(
+    agents: &[SkillAgentArg],
+    all_agents: bool,
+    project: bool,
+    context: &PathContext,
+) -> Result<Vec<SkillTarget>> {
+    let selected = explicit_selected_agents(agents, all_agents)
+        .unwrap_or_else(|| vec![SkillAgentArg::Universal]);
+    resolve_targets_for_agents(&selected, project, context)
+}
+
+fn resolve_targets_for_agents(
+    agents: &[SkillAgentArg],
+    project: bool,
+    context: &PathContext,
+) -> Result<Vec<SkillTarget>> {
+    agents
+        .iter()
+        .copied()
+        .map(|agent| single_target(agent, project, context))
+        .collect()
+}
+
+fn run_install(
+    args: SkillInstallArgs,
+    context: &PathContext,
+    analytics_properties: &mut AnalyticsProperties,
+) -> Result<()> {
+    let selection = install_agent_selection(&args, context)?;
+    insert_selection_analytics(analytics_properties, &selection);
+    let targets = resolve_targets_for_agents(&selection.agents, args.project, context)?;
+    let mut results = Vec::with_capacity(targets.len());
+    for target in &targets {
+        results.push(install_target(target, args.force)?);
+    }
+    let failed = results.iter().filter(|result| !result.success).count();
+    let already_installed = results.iter().all(|result| result.already_installed);
+    let updated = results.iter().any(|result| result.updated);
+    analytics::insert_str(
+        analytics_properties,
+        "install_result",
+        if failed == 0 { "ok" } else { "partial_error" },
+    );
+    analytics::insert_bool(analytics_properties, "already_installed", already_installed);
+    analytics::insert_bool(analytics_properties, "updated", updated);
+    if args.json {
+        println!(
+            "{}",
+            json!({
+                "skill": BUNDLED_SKILL_NAME,
+                "scope": if args.project { "project" } else { "global" },
+                "results": results.iter().map(InstallResult::to_json).collect::<Vec<_>>(),
+            })
+        );
+    } else {
+        print_install_results(&results);
+    }
+    if failed > 0 {
+        return Err(anyhow!("failed to install skill for {failed} target(s)"));
+    }
+    Ok(())
+}
+
+fn run_status(
+    args: SkillStatusArgs,
+    context: &PathContext,
+    analytics_properties: &mut AnalyticsProperties,
+) -> Result<()> {
+    let selection = status_agent_selection(&args, context);
+    insert_selection_analytics(analytics_properties, &selection);
+    let targets = resolve_targets_for_agents(&selection.agents, args.project, context)?;
+    let results = targets
+        .iter()
+        .map(status_target)
+        .collect::<Result<Vec<_>>>()?;
+    let current_count = results
+        .iter()
+        .filter(|result| result.status == SkillInstallStatus::Current)
+        .count();
+    analytics::insert_str(
+        analytics_properties,
+        "status_result",
+        if current_count == results.len() {
+            "all_current"
+        } else if current_count == 0 {
+            "none_current"
+        } else {
+            "partially_current"
+        },
+    );
+    analytics::insert_count_bucket(
+        analytics_properties,
+        "current_targets_bucket",
+        current_count as u64,
+    );
+    if args.json {
+        println!(
+            "{}",
+            json!({
+                "skill": BUNDLED_SKILL_NAME,
+                "scope": if args.project { "project" } else { "global" },
+                "results": results.iter().map(StatusResult::to_json).collect::<Vec<_>>(),
+            })
+        );
+    } else {
+        print_status_results(&results);
+    }
+    Ok(())
+}
+
+fn insert_selection_analytics(
+    analytics_properties: &mut AnalyticsProperties,
+    selection: &SkillAgentSelection,
+) {
+    analytics::insert_str(
+        analytics_properties,
+        "target_agent_group",
+        selection.source.as_str(),
+    );
+    analytics::insert_count_bucket(
+        analytics_properties,
+        "target_agents_count_bucket",
+        selection.agents.len() as u64,
+    );
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkillInstallStatus {
+    Current,
+    Stale,
+    Modified,
+    Missing,
+}
+
+impl SkillInstallStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Current => "current",
+            Self::Stale => "stale",
+            Self::Modified => "modified",
+            Self::Missing => "missing",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct StatusResult {
+    target: SkillTarget,
+    status: SkillInstallStatus,
+    metadata: Option<SkillMetadata>,
+    installed_hash: Option<String>,
+}
+
+impl StatusResult {
+    fn to_json(&self) -> Value {
+        json!({
+            "agent": self.target.agent.id(),
+            "agent_display_name": self.target.agent.display_name(),
+            "scope": self.target.scope.as_str(),
+            "status": self.status.as_str(),
+            "path": self.target.skill_dir,
+            "installed_hash": self.installed_hash,
+            "bundled_hash": bundled_hash(),
+            "metadata": self.metadata.as_ref().map(|metadata| json!({
+                "schema_version": metadata.schema_version,
+                "skill_name": metadata.skill_name,
+                "skill_hash": metadata.skill_hash,
+                "ctx_cli_version": metadata.ctx_cli_version,
+            })),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct InstallResult {
+    target: SkillTarget,
+    success: bool,
+    previous_status: SkillInstallStatus,
+    status: SkillInstallStatus,
+    already_installed: bool,
+    updated: bool,
+    error: Option<String>,
+}
+
+impl InstallResult {
+    fn to_json(&self) -> Value {
+        json!({
+            "agent": self.target.agent.id(),
+            "agent_display_name": self.target.agent.display_name(),
+            "scope": self.target.scope.as_str(),
+            "path": self.target.skill_dir,
+            "success": self.success,
+            "previous_status": self.previous_status.as_str(),
+            "status": self.status.as_str(),
+            "already_installed": self.already_installed,
+            "updated": self.updated,
+            "error": self.error,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SkillMetadata {
+    schema_version: u32,
+    installer: String,
+    skill_name: String,
+    skill_hash: String,
+    ctx_cli_version: String,
+    installed_at: String,
+}
+
+impl SkillMetadata {
+    fn current() -> Self {
+        Self {
+            schema_version: 1,
+            installer: "ctx-cli".to_owned(),
+            skill_name: BUNDLED_SKILL_NAME.to_owned(),
+            skill_hash: bundled_hash(),
+            ctx_cli_version: env!("CARGO_PKG_VERSION").to_owned(),
+            installed_at: utc_now().to_rfc3339(),
+        }
+    }
+}
+
+fn install_target(target: &SkillTarget, force: bool) -> Result<InstallResult> {
+    let previous = status_target(target)?;
+    if previous.status == SkillInstallStatus::Current {
+        if !metadata_is_current(previous.metadata.as_ref()) {
+            write_metadata(target)?;
+        }
+        return Ok(InstallResult {
+            target: target.clone(),
+            success: true,
+            previous_status: previous.status,
+            status: SkillInstallStatus::Current,
+            already_installed: true,
+            updated: false,
+            error: None,
+        });
+    }
+    if previous.status == SkillInstallStatus::Modified && !force {
+        return Ok(InstallResult {
+            target: target.clone(),
+            success: false,
+            previous_status: previous.status,
+            status: previous.status,
+            already_installed: false,
+            updated: false,
+            error: Some("local skill edits detected; rerun with --force to overwrite".to_owned()),
+        });
+    }
+    write_skill_dir(target)?;
+    Ok(InstallResult {
+        target: target.clone(),
+        success: true,
+        previous_status: previous.status,
+        status: SkillInstallStatus::Current,
+        already_installed: false,
+        updated: matches!(
+            previous.status,
+            SkillInstallStatus::Stale | SkillInstallStatus::Modified
+        ),
+        error: None,
+    })
+}
+
+fn status_target(target: &SkillTarget) -> Result<StatusResult> {
+    ensure_path_inside(&target.base_dir, &target.skill_dir)?;
+    let skill_file = target.skill_dir.join("SKILL.md");
+    let metadata = read_metadata(&target.skill_dir);
+    let installed_hash = match fs::read(&skill_file) {
+        Ok(body) => Some(sha256_hex(&body)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => return Err(err).with_context(|| format!("read {}", skill_file.display())),
+    };
+    let status = match installed_hash.as_deref() {
+        None => SkillInstallStatus::Missing,
+        Some(hash) if hash == bundled_hash() => SkillInstallStatus::Current,
+        Some(hash) => match metadata.as_ref() {
+            Some(metadata) if metadata.skill_hash == hash => SkillInstallStatus::Stale,
+            _ => SkillInstallStatus::Modified,
+        },
+    };
+    Ok(StatusResult {
+        target: target.clone(),
+        status,
+        metadata,
+        installed_hash,
+    })
+}
+
+fn read_metadata(skill_dir: &Path) -> Option<SkillMetadata> {
+    let path = skill_dir.join(METADATA_FILE);
+    let body = fs::read(path).ok()?;
+    serde_json::from_slice(&body).ok()
+}
+
+fn metadata_is_current(metadata: Option<&SkillMetadata>) -> bool {
+    metadata.is_some_and(|metadata| {
+        metadata.schema_version == 1
+            && metadata.installer == "ctx-cli"
+            && metadata.skill_name == BUNDLED_SKILL_NAME
+            && metadata.skill_hash == bundled_hash()
+    })
+}
+
+fn write_skill_dir(target: &SkillTarget) -> Result<()> {
+    ensure_path_inside(&target.base_dir, &target.skill_dir)?;
+    remove_existing_target(&target.skill_dir)
+        .with_context(|| format!("remove existing {}", target.skill_dir.display()))?;
+    fs::create_dir_all(&target.skill_dir)
+        .with_context(|| format!("create {}", target.skill_dir.display()))?;
+    fs::write(target.skill_dir.join("SKILL.md"), BUNDLED_SKILL_BODY)
+        .with_context(|| format!("write {}", target.skill_dir.join("SKILL.md").display()))?;
+    write_metadata(target)
+}
+
+fn write_metadata(target: &SkillTarget) -> Result<()> {
+    fs::create_dir_all(&target.skill_dir)
+        .with_context(|| format!("create {}", target.skill_dir.display()))?;
+    let metadata = serde_json::to_vec_pretty(&SkillMetadata::current())?;
+    fs::write(target.skill_dir.join(METADATA_FILE), metadata)
+        .with_context(|| format!("write {}", target.skill_dir.join(METADATA_FILE).display()))
+}
+
+fn remove_existing_target(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || metadata.is_file() => {
+            fs::remove_file(path)?;
+        }
+        Ok(metadata) if metadata.is_dir() => {
+            fs::remove_dir_all(path)?;
+        }
+        Ok(_) => {
+            fs::remove_file(path)?;
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err.into()),
+    }
+    Ok(())
+}
+
+fn print_install_results(results: &[InstallResult]) {
+    println!("ctx skill install: {BUNDLED_SKILL_NAME}");
+    for result in results {
+        let verb = if result.already_installed {
+            "current"
+        } else if !result.success {
+            "skipped"
+        } else if result.updated {
+            "updated"
+        } else {
+            "installed"
+        };
+        let detail = result
+            .error
+            .as_deref()
+            .map(|error| format!(": {error}"))
+            .unwrap_or_default();
+        println!(
+            "  {verb}: {} ({}) -> {}{}",
+            result.target.agent.display_name(),
+            result.target.scope.as_str(),
+            result.target.skill_dir.display(),
+            detail
+        );
+    }
+}
+
+fn print_status_results(results: &[StatusResult]) {
+    println!("ctx skill status: {BUNDLED_SKILL_NAME}");
+    for result in results {
+        println!(
+            "  {}: {} ({}) -> {}",
+            result.status.as_str(),
+            result.target.agent.display_name(),
+            result.target.scope.as_str(),
+            result.target.skill_dir.display()
+        );
+    }
+}
+
+fn sanitize_skill_name(name: &str) -> Result<String> {
+    let mut sanitized = String::with_capacity(name.len());
+    let mut previous_dash = false;
+    for ch in name.trim().chars().flat_map(char::to_lowercase) {
+        let allowed = ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '.' || ch == '_';
+        if allowed {
+            sanitized.push(ch);
+            previous_dash = false;
+        } else if !previous_dash {
+            sanitized.push('-');
+            previous_dash = true;
+        }
+    }
+    let sanitized = sanitized
+        .trim_matches(|ch| ch == '.' || ch == '-')
+        .chars()
+        .take(255)
+        .collect::<String>();
+    if sanitized.is_empty() || sanitized == "." || sanitized == ".." {
+        return Err(anyhow!("invalid skill name"));
+    }
+    Ok(sanitized)
+}
+
+fn ensure_path_inside(base: &Path, target: &Path) -> Result<()> {
+    if has_parent_component(base) || has_parent_component(target) {
+        return Err(anyhow!("skill path contains parent traversal"));
+    }
+    if !target.starts_with(base) {
+        return Err(anyhow!("skill path escapes target directory"));
+    }
+    Ok(())
+}
+
+fn has_parent_component(path: &Path) -> bool {
+    path.components()
+        .any(|component| matches!(component, Component::ParentDir))
+}
+
+fn bundled_hash() -> String {
+    sha256_hex(BUNDLED_SKILL_BODY.as_bytes())
+}
+
+fn sha256_hex(body: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(body);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_target_is_global_canonical_agents_dir() {
+        let context = PathContext::for_tests(PathBuf::from("/home/tester"), PathBuf::from("/repo"));
+        let targets = resolve_targets(&[], false, false, &context).unwrap();
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].agent, SkillAgentArg::Universal);
+        assert_eq!(
+            targets[0].skill_dir,
+            PathBuf::from("/home/tester/.agents/skills/ctx-agent-history-search")
+        );
+    }
+
+    #[test]
+    fn agent_global_paths_preserve_env_and_xdg_rules() {
+        let context = PathContext::for_tests(PathBuf::from("/home/tester"), PathBuf::from("/repo"))
+            .with_xdg_config_home(PathBuf::from("/xdg"))
+            .with_env_override("CODEX_HOME", PathBuf::from("/codex-home"))
+            .with_env_override("CLAUDE_CONFIG_DIR", PathBuf::from("/claude-home"));
+        let targets = resolve_targets(
+            &[
+                SkillAgentArg::Codex,
+                SkillAgentArg::ClaudeCode,
+                SkillAgentArg::OpenCode,
+                SkillAgentArg::Amp,
+            ],
+            false,
+            false,
+            &context,
+        )
+        .unwrap();
+        let paths = targets
+            .iter()
+            .map(|target| (target.agent.id(), target.skill_dir.clone()))
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(
+            paths["codex"],
+            PathBuf::from("/codex-home/skills/ctx-agent-history-search")
+        );
+        assert_eq!(
+            paths["claude-code"],
+            PathBuf::from("/claude-home/skills/ctx-agent-history-search")
+        );
+        assert_eq!(
+            paths["opencode"],
+            PathBuf::from("/xdg/opencode/skills/ctx-agent-history-search")
+        );
+        assert_eq!(
+            paths["amp"],
+            PathBuf::from("/xdg/agents/skills/ctx-agent-history-search")
+        );
+    }
+
+    #[test]
+    fn project_paths_are_agent_specific_and_relative_to_cwd() {
+        let context = PathContext::for_tests(PathBuf::from("/home/tester"), PathBuf::from("/repo"));
+        let targets = resolve_targets(
+            &[SkillAgentArg::ClaudeCode, SkillAgentArg::Codex],
+            false,
+            true,
+            &context,
+        )
+        .unwrap();
+        let paths = targets
+            .iter()
+            .map(|target| (target.agent.id(), target.skill_dir.clone()))
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(
+            paths["claude-code"],
+            PathBuf::from("/repo/.claude/skills/ctx-agent-history-search")
+        );
+        assert_eq!(
+            paths["codex"],
+            PathBuf::from("/repo/.agents/skills/ctx-agent-history-search")
+        );
+    }
+
+    #[test]
+    fn default_selection_includes_universal_and_detected_agent_specific_dirs() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("home");
+        fs::create_dir_all(home.join(".claude")).unwrap();
+        fs::create_dir_all(home.join(".codex")).unwrap();
+        let context = PathContext::for_tests(home, temp.path().join("repo"));
+
+        assert_eq!(
+            detected_agents(&context),
+            vec![SkillAgentArg::ClaudeCode, SkillAgentArg::Codex]
+        );
+
+        let selection = install_agent_selection(
+            &SkillInstallArgs {
+                agent: Vec::new(),
+                all_agents: false,
+                project: false,
+                json: true,
+                force: false,
+            },
+            &context,
+        )
+        .unwrap();
+        assert_eq!(selection.source, SkillSelectionSource::Detected);
+        assert_eq!(
+            selection.agents,
+            vec![SkillAgentArg::Universal, SkillAgentArg::ClaudeCode]
+        );
+    }
+
+    #[test]
+    fn picker_defaults_to_universal_when_nothing_detected() {
+        let temp = tempfile::tempdir().unwrap();
+        let context = PathContext::for_tests(temp.path().join("home"), temp.path().join("repo"))
+            .with_env_override("CODEX_HOME", temp.path().join("missing-codex"));
+        assert_eq!(
+            default_picker_agents(&context),
+            vec![SkillAgentArg::Universal]
+        );
+        assert_eq!(
+            default_noninteractive_agents(&context),
+            (
+                vec![SkillAgentArg::Universal],
+                SkillSelectionSource::Fallback
+            )
+        );
+    }
+
+    #[test]
+    fn picker_selection_accepts_numbers_names_and_all() {
+        let options = picker_agents();
+        assert_eq!(
+            parse_picker_selection("1,2 claude", options).unwrap(),
+            vec![SkillAgentArg::Universal, SkillAgentArg::ClaudeCode]
+        );
+        assert_eq!(
+            parse_picker_selection("cursor universal", options).unwrap(),
+            vec![SkillAgentArg::Cursor, SkillAgentArg::Universal]
+        );
+        assert_eq!(parse_picker_selection("all", options).unwrap(), options);
+        assert!(parse_picker_selection("99", options).is_err());
+        assert!(parse_picker_selection("not-an-agent", options).is_err());
+    }
+
+    #[test]
+    fn sanitize_blocks_path_traversal_shapes() {
+        assert_eq!(
+            sanitize_skill_name("../Ctx Agent History Search!!").unwrap(),
+            "ctx-agent-history-search"
+        );
+        assert!(sanitize_skill_name("..").is_err());
+        assert!(ensure_path_inside(Path::new("/base"), Path::new("/base/../evil")).is_err());
+    }
+
+    #[test]
+    fn status_distinguishes_current_stale_modified_and_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let context = PathContext::for_tests(temp.path().join("home"), temp.path().join("repo"));
+        let target = resolve_targets(&[], false, false, &context)
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(
+            status_target(&target).unwrap().status,
+            SkillInstallStatus::Missing
+        );
+
+        write_skill_dir(&target).unwrap();
+        assert_eq!(
+            status_target(&target).unwrap().status,
+            SkillInstallStatus::Current
+        );
+
+        fs::write(target.skill_dir.join("SKILL.md"), "old bundled content\n").unwrap();
+        let old_hash = sha256_hex(b"old bundled content\n");
+        let mut metadata = SkillMetadata::current();
+        metadata.skill_hash = old_hash;
+        fs::write(
+            target.skill_dir.join(METADATA_FILE),
+            serde_json::to_vec_pretty(&metadata).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            status_target(&target).unwrap().status,
+            SkillInstallStatus::Stale
+        );
+
+        fs::write(target.skill_dir.join("SKILL.md"), "local edits\n").unwrap();
+        assert_eq!(
+            status_target(&target).unwrap().status,
+            SkillInstallStatus::Modified
+        );
+    }
+
+    #[test]
+    fn analytics_properties_are_coarse_and_path_free() {
+        let args = SkillArgs {
+            command: SkillCommand::Install(SkillInstallArgs {
+                agent: vec![SkillAgentArg::Codex, SkillAgentArg::ClaudeCode],
+                all_agents: false,
+                project: true,
+                json: true,
+                force: false,
+            }),
+        };
+        let mut properties = analytics::empty_properties();
+        args.add_initial_analytics(&mut properties);
+
+        assert_eq!(properties["skill_action"], "install");
+        assert_eq!(properties["skill_name"], BUNDLED_SKILL_NAME);
+        assert_eq!(properties["skill_scope"], "project");
+        assert_eq!(properties["target_agent_group"], "explicit");
+        for key in properties.keys() {
+            assert!(
+                !key.contains("path") && !key.contains("home") && !key.contains("dir"),
+                "unexpected path-like analytics key: {key}"
+            );
+        }
+    }
+}

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -7,6 +7,7 @@ use ring::{
 };
 use rusqlite::{params, Connection};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use std::{
     collections::BTreeSet,
     fs,
@@ -7488,4 +7489,236 @@ fn local_transcript_oracle_preserves_cli_json_and_sqlite() {
         &sqlite_text,
         local_sqlite_markers(),
     );
+}
+
+#[test]
+fn skill_install_defaults_to_global_canonical_agents_dir_and_is_idempotent() {
+    let temp = tempdir();
+
+    let first = json_output(
+        ctx(&temp)
+            .env("CODEX_HOME", temp.path().join("missing-codex"))
+            .args(["skill", "install", "--json"]),
+    );
+    assert_eq!(first["skill"], "ctx-agent-history-search");
+    assert_eq!(first["results"][0]["agent"], "universal");
+    assert_eq!(first["results"][0]["previous_status"], "missing");
+    assert_eq!(first["results"][0]["status"], "current");
+    assert_eq!(first["results"][0]["already_installed"], false);
+
+    let skill_dir = temp
+        .path()
+        .join(".agents")
+        .join("skills")
+        .join("ctx-agent-history-search");
+    assert!(skill_dir.join("SKILL.md").exists());
+    assert!(skill_dir.join(".ctx-skill.json").exists());
+
+    let second = json_output(
+        ctx(&temp)
+            .env("CODEX_HOME", temp.path().join("missing-codex"))
+            .args(["skill", "install", "--json"]),
+    );
+    assert_eq!(second["results"][0]["previous_status"], "current");
+    assert_eq!(second["results"][0]["already_installed"], true);
+    assert_eq!(second["results"][0]["updated"], false);
+
+    let status = json_output(
+        ctx(&temp)
+            .env("CODEX_HOME", temp.path().join("missing-codex"))
+            .args(["skill", "status", "--json"]),
+    );
+    assert_eq!(status["results"][0]["status"], "current");
+}
+
+#[test]
+fn skill_install_auto_targets_universal_and_detected_claude_code() {
+    let temp = tempdir();
+    fs::create_dir_all(temp.path().join(".claude")).unwrap();
+
+    let install = json_output(
+        ctx(&temp)
+            .env("CODEX_HOME", temp.path().join("missing-codex"))
+            .args(["skill", "install", "--json"]),
+    );
+    assert_eq!(install["results"].as_array().unwrap().len(), 2);
+    assert_eq!(install["results"][0]["agent"], "universal");
+    assert_eq!(install["results"][1]["agent"], "claude-code");
+    assert_eq!(install["results"][0]["status"], "current");
+    assert_eq!(install["results"][1]["status"], "current");
+
+    assert!(temp
+        .path()
+        .join(".agents")
+        .join("skills")
+        .join("ctx-agent-history-search")
+        .join("SKILL.md")
+        .exists());
+    assert!(temp
+        .path()
+        .join(".claude")
+        .join("skills")
+        .join("ctx-agent-history-search")
+        .join("SKILL.md")
+        .exists());
+}
+
+#[test]
+fn skill_install_refreshes_stale_bundled_copy() {
+    let temp = tempdir();
+    let skill_dir = temp
+        .path()
+        .join(".agents")
+        .join("skills")
+        .join("ctx-agent-history-search");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), "old instructions\n").unwrap();
+    let old_hash = format!("sha256:{:x}", Sha256::digest(b"old instructions\n"));
+    fs::write(
+        skill_dir.join(".ctx-skill.json"),
+        json!({
+            "schema_version": 1,
+            "installer": "ctx-cli",
+            "skill_name": "ctx-agent-history-search",
+            "skill_hash": old_hash,
+            "ctx_cli_version": "0.0.0",
+            "installed_at": "2026-01-01T00:00:00Z"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let stale = json_output(ctx(&temp).args(["skill", "status", "--agent", "universal", "--json"]));
+    assert_eq!(stale["results"][0]["status"], "stale");
+
+    let install =
+        json_output(ctx(&temp).args(["skill", "install", "--agent", "universal", "--json"]));
+    assert_eq!(install["results"][0]["previous_status"], "stale");
+    assert_eq!(install["results"][0]["updated"], true);
+    assert!(fs::read_to_string(skill_dir.join("SKILL.md"))
+        .unwrap()
+        .contains("ctx Agent History Search"));
+}
+
+#[test]
+fn skill_install_preserves_modified_copy_unless_forced() {
+    let temp = tempdir();
+    let skill_dir = temp
+        .path()
+        .join(".agents")
+        .join("skills")
+        .join("ctx-agent-history-search");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), "local custom instructions\n").unwrap();
+
+    let output = ctx(&temp)
+        .args(["skill", "install", "--agent", "universal", "--json"])
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["results"][0]["success"], false);
+    assert_eq!(json["results"][0]["previous_status"], "modified");
+    assert_eq!(json["results"][0]["status"], "modified");
+    assert!(json["results"][0]["error"]
+        .as_str()
+        .unwrap()
+        .contains("--force"));
+    assert_eq!(
+        fs::read_to_string(skill_dir.join("SKILL.md")).unwrap(),
+        "local custom instructions\n"
+    );
+
+    let forced = json_output(ctx(&temp).args([
+        "skill",
+        "install",
+        "--agent",
+        "universal",
+        "--force",
+        "--json",
+    ]));
+    assert_eq!(forced["results"][0]["success"], true);
+    assert_eq!(forced["results"][0]["previous_status"], "modified");
+    assert_eq!(forced["results"][0]["status"], "current");
+    assert!(fs::read_to_string(skill_dir.join("SKILL.md"))
+        .unwrap()
+        .contains("ctx Agent History Search"));
+}
+
+#[test]
+fn skill_install_agent_paths_respect_env_xdg_and_project_scope() {
+    let temp = tempdir();
+    let home = temp.path();
+    let xdg = temp.path().join("xdg-config");
+    let codex_home = temp.path().join("custom-codex");
+    let claude_home = temp.path().join("custom-claude");
+
+    let global = json_output(
+        ctx(&temp)
+            .env("XDG_CONFIG_HOME", &xdg)
+            .env("CODEX_HOME", &codex_home)
+            .env("CLAUDE_CONFIG_DIR", &claude_home)
+            .args([
+                "skill",
+                "install",
+                "--agent",
+                "codex",
+                "--agent",
+                "claude-code",
+                "--agent",
+                "opencode",
+                "--json",
+            ]),
+    );
+    assert_eq!(global["results"].as_array().unwrap().len(), 3);
+    assert!(codex_home
+        .join("skills")
+        .join("ctx-agent-history-search")
+        .join("SKILL.md")
+        .exists());
+    assert!(claude_home
+        .join("skills")
+        .join("ctx-agent-history-search")
+        .join("SKILL.md")
+        .exists());
+    assert!(xdg
+        .join("opencode")
+        .join("skills")
+        .join("ctx-agent-history-search")
+        .join("SKILL.md")
+        .exists());
+
+    let project = temp.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    let mut command = ctx(&temp);
+    command.current_dir(&project).args([
+        "skill",
+        "install",
+        "--project",
+        "--agent",
+        "codex",
+        "--agent",
+        "claude-code",
+        "--json",
+    ]);
+    let project_output = json_output(&mut command);
+    assert_eq!(project_output["scope"], "project");
+    assert!(project
+        .join(".agents")
+        .join("skills")
+        .join("ctx-agent-history-search")
+        .join("SKILL.md")
+        .exists());
+    assert!(project
+        .join(".claude")
+        .join("skills")
+        .join("ctx-agent-history-search")
+        .join("SKILL.md")
+        .exists());
+    assert!(!home
+        .join(".codex")
+        .join("skills")
+        .join("ctx-agent-history-search")
+        .exists());
 }

--- a/docs/agent-skill-install.md
+++ b/docs/agent-skill-install.md
@@ -6,6 +6,72 @@ The name follows the public product language: ctx is local agent history search,
 not a model memory or graph database. Use the skill when an agent should query
 past local coding-agent sessions before starting work.
 
+## Native ctx CLI
+
+The hosted ctx installer runs the native skill install by default:
+
+```bash
+curl -fsSL https://ctx.rs/install | sh
+```
+
+Use the native ctx CLI directly when you installed ctx from source or a package
+manager, when you skipped installer setup, or when you want to refresh the skill
+after upgrading:
+
+```bash
+ctx skill install
+```
+
+By default this opens a small picker when run in an interactive terminal, with
+the universal `~/.agents/skills/ctx-agent-history-search` location selected
+plus detected agent-specific folders for tools that need them. In
+non-interactive runs, ctx installs to the universal folder and also writes
+detected agent-specific folders, such as Claude Code, only when ctx sees
+evidence that the agent is installed. Re-run the same command whenever you
+upgrade ctx or want to refresh the installed skill instructions.
+
+Install into specific agent skill folders when an agent does not read the
+universal `.agents/skills` location:
+
+```bash
+ctx skill install --agent codex
+ctx skill install --agent claude-code --agent cursor
+ctx skill install --all-agents
+```
+
+Use project scope when you want a repository-local skill folder:
+
+```bash
+ctx skill install --project
+ctx skill install --project --agent claude-code
+```
+
+Check installed state with:
+
+```bash
+ctx skill status
+ctx skill status --agent codex --json
+```
+
+`status` reports `current`, `stale`, `modified`, or `missing` for the bundled
+`ctx-agent-history-search` skill. The installer writes a small
+`.ctx-skill.json` metadata file beside `SKILL.md` so ctx can tell stale bundled
+copies from local edits.
+
+`ctx skill install` refreshes stale bundled copies automatically, but it does
+not overwrite locally modified skill files unless you pass `--force`.
+
+Installer flags mirror the direct CLI controls:
+
+```bash
+curl -fsSL https://ctx.rs/install | sh -s -- --no-skill
+curl -fsSL https://ctx.rs/install | sh -s -- --skill-agent codex --skill-agent claude-code
+curl -fsSL https://ctx.rs/install | sh -s -- --all-skill-agents
+```
+
+`--no-setup` is install-only mode and skips both skill setup and history
+indexing unless you pass a skill option explicitly.
+
 ## Codex
 
 This repository includes a Codex marketplace catalog at

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -45,6 +45,36 @@ structured. Installer-managed binaries can run a signed background upgrade
 check after successful non-JSON commands; that check is separate from provider
 history indexing.
 
+## Agent Skill
+
+```bash
+ctx skill install
+ctx skill install --agent codex --agent claude-code
+ctx skill install --all-agents
+ctx skill install --project
+ctx skill install --force
+ctx skill status
+ctx skill status --agent codex --json
+```
+
+`skill install` installs or refreshes ctx's bundled
+`ctx-agent-history-search` skill. With no target flags in an interactive
+terminal, it opens a small agent picker with the universal `~/.agents/skills`
+location selected plus detected agent-specific folders for tools that need
+them. In non-interactive runs, it installs to the universal folder and also
+writes detected agent-specific folders, such as Claude Code, only when ctx sees
+evidence that the agent is installed. `--agent` targets native global skill
+folders for supported agents such as Claude Code, Codex, Cursor, OpenCode,
+Gemini CLI, Antigravity, GitHub Copilot, Pi, and Goose. `--all-agents` writes
+all supported target folders. `--project` switches from global paths to the
+current project's skill folders.
+
+`skill status` reports whether the bundled skill is `current`, `stale`,
+`modified`, or `missing`. `skill install` refreshes stale bundled copies
+automatically, but it refuses to overwrite locally modified skill files unless
+you pass `--force`. The command only manages the bundled ctx skill and does not
+fetch arbitrary remote skills.
+
 ## Sources
 
 ```bash

--- a/docs/first-10-minutes.md
+++ b/docs/first-10-minutes.md
@@ -18,6 +18,12 @@ curl -fsSL https://ctx.rs/install | sh
 The Unix installer requires `curl` and OpenSSL to verify signed release
 metadata. On Windows, use `irm https://ctx.rs/install.ps1 | iex`.
 
+The hosted installer runs the bundled agent-history skill installer and
+`ctx setup` by default. The skill step opens an agent picker when interactive
+and otherwise installs the universal skill copy plus detected agent-specific
+folders. Use `--no-setup` only for install-only automation; it also skips skill
+setup unless you pass an explicit skill option.
+
 ## 2. Set Up And Index
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,9 +12,29 @@ curl -fsSL https://ctx.rs/install | sh
 The Unix installer requires `curl` and OpenSSL to verify signed release
 metadata. On Windows, use `irm https://ctx.rs/install.ps1 | iex`.
 
-The install script installs `ctx` and runs `ctx setup` so discovered local
-history is indexed before it exits. Use `sh -s -- --no-setup` on Unix, or set
+On Unix, the installer places `ctx` in `${CTX_BIN_DIR:-$HOME/.local/bin}`. If
+that directory is not already on `PATH`, the installer adds an idempotent ctx
+PATH snippet to your shell startup file and prints the command to use for the
+current shell session. On Windows, the installer places `ctx.exe` in
+`$HOME\.local\bin` by default, adds that directory to the user `Path`, and
+updates the current PowerShell session. Use `sh -s -- --no-modify-path` on Unix,
+`-NoModifyPath` on Windows, or set `CTX_INSTALL_NO_MODIFY_PATH=1` when you want
+to manage `PATH` yourself.
+
+The install script installs `ctx`, runs the bundled agent-history skill
+installer, and runs `ctx setup` so discovered local history is indexed before it
+exits. The skill installer opens an agent picker when interactive; otherwise it
+installs the universal `~/.agents/skills` copy plus detected agent-specific
+folders for tools that need them. Use `sh -s -- --no-setup` on Unix, or set
 `CTX_INSTALL_NO_SETUP=1` on Windows, for install-only CI or packaging flows.
+Install-only mode also skips skill setup unless you explicitly pass a skill
+option.
+
+To skip only the skill step, use `--no-skill` on Unix or `-NoSkill` on Windows,
+or set `CTX_INSTALL_NO_SKILL=1`. To target agent-specific skill folders during
+install, use `--skill-agent codex`, repeat `--skill-agent`, or use
+`--all-skill-agents`; Windows exposes the same controls as `-SkillAgent` and
+`-AllSkillAgents`.
 
 When working from source, use `cargo build -p ctx` or
 `cargo install --path crates/ctx-cli`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,31 @@
 # Troubleshooting
 
+## ctx: Command Not Found After Install
+
+On Unix, the hosted installer places `ctx` in
+`${CTX_BIN_DIR:-$HOME/.local/bin}`. If that directory was not already on
+`PATH`, the installer updates your shell startup file and prints the command to
+use immediately. Existing shells do not inherit startup-file edits
+automatically, so open a new terminal or run:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+ctx status
+```
+
+On Windows, the hosted installer places `ctx.exe` in `$HOME\.local\bin` by
+default, adds that directory to the user `Path`, and updates the current
+PowerShell session. If `ctx` is still unavailable, open a new PowerShell window
+or run:
+
+```powershell
+$env:Path = "$HOME\.local\bin;$env:Path"
+ctx status
+```
+
+If you installed with `--no-modify-path`, `-NoModifyPath`, or
+`CTX_INSTALL_NO_MODIFY_PATH=1`, add the install directory to `PATH` yourself.
+
 ## No Sources Found
 
 Run:

--- a/scripts/bazel-test.sh
+++ b/scripts/bazel-test.sh
@@ -96,6 +96,9 @@ case "${mode}" in
   docs_check)
     run bash scripts/check-docs.sh
     ;;
+  installer_path_smoke)
+    run bash scripts/install-path-smoke.sh
+    ;;
   buildkite_pipeline_check)
     run bash scripts/check-buildkite-pipeline.sh
     ;;

--- a/scripts/install-path-smoke.sh
+++ b/scripts/install-path-smoke.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf 'install path smoke requires %s\n' "$1" >&2
+    exit 127
+  }
+}
+
+sha256_file() {
+  local path="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${path}" | awk '{ print $1 }'
+    return 0
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${path}" | awk '{ print $1 }'
+    return 0
+  fi
+
+  printf 'install path smoke requires sha256sum or shasum\n' >&2
+  exit 127
+}
+
+require_cmd awk
+require_cmd bash
+require_cmd curl
+require_cmd openssl
+require_cmd python3
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/ctx-install-path-smoke.XXXXXX")"
+server_pid=""
+
+cleanup() {
+  if [[ -n "${server_pid}" ]]; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+artifact="${tmp_dir}/ctx-linux-x64"
+cat > "${artifact}" <<'SH'
+#!/usr/bin/env sh
+if [ "${1:-}" = "setup" ]; then
+  exit "${CTX_FAKE_SETUP_EXIT:-0}"
+fi
+exit 0
+SH
+chmod +x "${artifact}"
+checksum="$(sha256_file "${artifact}")"
+
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout "${tmp_dir}/key.pem" \
+  -out "${tmp_dir}/cert.pem" \
+  -subj '/CN=127.0.0.1' \
+  -addext 'subjectAltName=IP:127.0.0.1,DNS:localhost' \
+  -days 1 >/dev/null 2>&1
+
+port="$(
+  python3 - <<'PY'
+import socket
+sock = socket.socket()
+sock.bind(("127.0.0.1", 0))
+print(sock.getsockname()[1])
+sock.close()
+PY
+)"
+
+python3 - "${tmp_dir}" "${port}" "${tmp_dir}/cert.pem" "${tmp_dir}/key.pem" <<'PY' >"${tmp_dir}/server.log" 2>&1 &
+import functools
+import http.server
+import ssl
+import sys
+
+root, port, cert, key = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
+handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=root)
+server = http.server.ThreadingHTTPServer(("127.0.0.1", port), handler)
+context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+context.load_cert_chain(certfile=cert, keyfile=key)
+server.socket = context.wrap_socket(server.socket, server_side=True)
+server.serve_forever()
+PY
+server_pid="$!"
+
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if CURL_CA_BUNDLE="${tmp_dir}/cert.pem" curl -fsS "https://127.0.0.1:${port}/ctx-linux-x64" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.2
+done
+CURL_CA_BUNDLE="${tmp_dir}/cert.pem" curl -fsS "https://127.0.0.1:${port}/ctx-linux-x64" >/dev/null
+
+metadata="${tmp_dir}/metadata.env"
+{
+  printf 'CTX_RELEASE_SCHEMA_VERSION=1\n'
+  printf 'CTX_RELEASE_VERSION=0.0.0-smoke\n'
+  printf 'CTX_RELEASE_BASE_URL=https://127.0.0.1:%s\n' "${port}"
+  printf 'CTX_RELEASE_ARTIFACT_linux_x64=ctx-linux-x64\n'
+  printf 'CTX_RELEASE_SHA256_linux_x64=%s\n' "${checksum}"
+} > "${metadata}"
+
+base_env=(CURL_CA_BUNDLE="${tmp_dir}/cert.pem" CTX_INSTALL_NO_MAN=1)
+installer=(bash "${repo_root}/scripts/install.sh" --metadata "${metadata}" --platform linux-x64)
+
+home_idem="${tmp_dir}/home-idem"
+mkdir -p "${home_idem}"
+env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_idem}" SHELL="/bin/bash" "${installer[@]}" --no-setup > "${tmp_dir}/idem-1.out"
+env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_idem}" SHELL="/bin/bash" "${installer[@]}" --no-setup > "${tmp_dir}/idem-2.out"
+test "$(grep -c 'ctx installer PATH setup' "${home_idem}/.bashrc")" = 1
+grep -F 'found existing PATH setup' "${tmp_dir}/idem-2.out" >/dev/null
+
+home_on_path="${tmp_dir}/home-on-path"
+mkdir -p "${home_on_path}"
+env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="${home_on_path}/.local/bin:/usr/bin:/bin" HOME="${home_on_path}" SHELL="/bin/bash" "${installer[@]}" --no-setup > "${tmp_dir}/on-path.out"
+test ! -e "${home_on_path}/.bashrc"
+
+home_env_bin="${tmp_dir}/home-env-bin"
+env_bin="${tmp_dir}/ctx-env-bin"
+mkdir -p "${home_env_bin}"
+env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_env_bin}" SHELL="/bin/bash" CTX_BIN_DIR="${env_bin}" "${installer[@]}" --no-setup > "${tmp_dir}/env-bin.out"
+test -x "${env_bin}/ctx"
+grep -F "${env_bin}" "${home_env_bin}/.bashrc" >/dev/null
+
+home_bin_override="${tmp_dir}/home-bin-override"
+env_override_bin="${tmp_dir}/ctx-env-override-bin"
+flag_override_bin="${tmp_dir}/ctx-flag-override-bin"
+mkdir -p "${home_bin_override}"
+env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_bin_override}" SHELL="/bin/bash" CTX_BIN_DIR="${env_override_bin}" "${installer[@]}" --bin-dir "${flag_override_bin}" --no-setup > "${tmp_dir}/bin-override.out"
+test ! -e "${env_override_bin}/ctx"
+test -x "${flag_override_bin}/ctx"
+grep -F "${flag_override_bin}" "${home_bin_override}/.bashrc" >/dev/null
+
+home_marker_change="${tmp_dir}/home-marker-change"
+old_marker_bin="${tmp_dir}/old-marker-bin"
+new_marker_bin="${tmp_dir}/new-marker-bin"
+mkdir -p "${home_marker_change}"
+{
+  printf '# ctx installer PATH setup\n'
+  printf 'case ":${PATH}:" in\n'
+  printf '  *":%s:"*) ;;\n' "${old_marker_bin}"
+  printf '  *) export PATH="%s:${PATH}" ;;\n' "${old_marker_bin}"
+  printf 'esac\n'
+} > "${home_marker_change}/.bashrc"
+env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_marker_change}" SHELL="/bin/bash" "${installer[@]}" --bin-dir "${new_marker_bin}" --no-setup > "${tmp_dir}/marker-change.out"
+grep -F "${new_marker_bin}" "${home_marker_change}/.bashrc" >/dev/null
+PATH="/usr/bin:/bin" HOME="${home_marker_change}" bash -c 'source "$HOME/.bashrc"; command -v ctx' >/dev/null
+
+home_comment_path="${tmp_dir}/home-comment-path"
+comment_path_bin="${tmp_dir}/comment-path-bin"
+mkdir -p "${home_comment_path}"
+printf '# PATH may include %s later\n' "${comment_path_bin}" > "${home_comment_path}/.bashrc"
+env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_comment_path}" SHELL="/bin/bash" "${installer[@]}" --bin-dir "${comment_path_bin}" --no-setup > "${tmp_dir}/comment-path.out"
+test "$(grep -c 'ctx installer PATH setup' "${home_comment_path}/.bashrc")" = 1
+PATH="/usr/bin:/bin" HOME="${home_comment_path}" bash -c 'source "$HOME/.bashrc"; command -v ctx' >/dev/null
+
+home_env_no="${tmp_dir}/home-env-no"
+mkdir -p "${home_env_no}"
+env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_env_no}" SHELL="/bin/bash" CTX_INSTALL_NO_MODIFY_PATH=1 "${installer[@]}" --no-setup > "${tmp_dir}/env-no.out"
+test ! -e "${home_env_no}/.bashrc"
+grep -F 'shell startup file update skipped' "${tmp_dir}/env-no.out" >/dev/null
+
+home_flag_no="${tmp_dir}/home-flag-no"
+github_path_no="${tmp_dir}/github-path-no"
+mkdir -p "${home_flag_no}"
+: > "${github_path_no}"
+env -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_flag_no}" SHELL="/bin/bash" GITHUB_PATH="${github_path_no}" "${installer[@]}" --no-setup --no-modify-path > "${tmp_dir}/flag-no.out"
+test ! -e "${home_flag_no}/.bashrc"
+test ! -s "${github_path_no}"
+grep -F 'shell startup file update skipped' "${tmp_dir}/flag-no.out" >/dev/null
+
+home_gha="${tmp_dir}/home-gha"
+github_path="${tmp_dir}/github-path"
+mkdir -p "${home_gha}"
+: > "${github_path}"
+env -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_gha}" SHELL="/bin/bash" GITHUB_PATH="${github_path}" "${installer[@]}" --no-setup > "${tmp_dir}/gha.out"
+grep -F "${home_gha}/.local/bin" "${github_path}" >/dev/null
+test ! -e "${home_gha}/.bashrc"
+
+home_ci="${tmp_dir}/home-ci"
+mkdir -p "${home_ci}"
+env -u GITHUB_PATH "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_ci}" SHELL="/bin/bash" CI=true "${installer[@]}" --no-setup > "${tmp_dir}/ci.out"
+test ! -e "${home_ci}/.bashrc"
+grep -F 'CI detected' "${tmp_dir}/ci.out" >/dev/null
+
+home_shell_empty="${tmp_dir}/home-shell-empty"
+mkdir -p "${home_shell_empty}"
+env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_shell_empty}" SHELL="" "${installer[@]}" --no-setup > "${tmp_dir}/shell-empty.out"
+grep -F 'ctx installer PATH setup' "${home_shell_empty}/.profile" >/dev/null
+
+if command -v zsh >/dev/null 2>&1; then
+  home_zsh="${tmp_dir}/home-zsh"
+  mkdir -p "${home_zsh}"
+  zsh_bin="$(command -v zsh)"
+  env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_zsh}" SHELL="${zsh_bin}" "${installer[@]}" --no-setup > "${tmp_dir}/zsh.out"
+  grep -F 'ctx installer PATH setup' "${home_zsh}/.zshrc" >/dev/null
+  PATH="/usr/bin:/bin" HOME="${home_zsh}" "${zsh_bin}" -c 'source "$HOME/.zshrc"; command -v ctx' >/dev/null
+else
+  printf 'zsh not found; skipping zsh PATH execution check\n'
+fi
+
+if command -v fish >/dev/null 2>&1; then
+  home_fish="${tmp_dir}/home-fish"
+  mkdir -p "${home_fish}"
+  fish_bin="$(command -v fish)"
+  env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_fish}" SHELL="${fish_bin}" "${installer[@]}" --no-setup > "${tmp_dir}/fish.out"
+  grep -F 'ctx installer PATH setup' "${home_fish}/.config/fish/config.fish" >/dev/null
+  env PATH="/usr/bin:/bin" HOME="${home_fish}" "${fish_bin}" -c 'source "$HOME/.config/fish/config.fish"; command -q ctx'
+else
+  printf 'fish not found; skipping fish PATH execution check\n'
+fi
+
+home_fail="${tmp_dir}/home-fail"
+mkdir -p "${home_fail}"
+set +e
+env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_fail}" SHELL="/bin/bash" CTX_FAKE_SETUP_EXIT=42 "${installer[@]}" --no-skill > "${tmp_dir}/setup-fail.out" 2>"${tmp_dir}/setup-fail.err"
+setup_status="$?"
+set -e
+test "${setup_status}" = 42
+grep -F 'ctx installer PATH setup' "${home_fail}/.bashrc" >/dev/null
+grep -F 'ctx setup failed after install' "${tmp_dir}/setup-fail.err" >/dev/null
+
+printf 'install path smoke ok\n'

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3,7 +3,11 @@ param(
     [string]$Metadata,
     [string]$Platform = "",
     [string]$BinDir = "",
+    [switch]$NoModifyPath,
     [switch]$NoSetup,
+    [switch]$NoSkill,
+    [string[]]$SkillAgent = @(),
+    [switch]$AllSkillAgents,
     [string]$SetupProgress = "",
     [switch]$DryRun
 )
@@ -64,6 +68,95 @@ function Get-Sha256([string]$Path) {
     return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
 }
 
+function Normalize-PathEntry([string]$Path) {
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return ""
+    }
+    return $Path.Trim().Trim('"').TrimEnd("\", "/")
+}
+
+function Test-PathContainsDirectory([string]$PathValue, [string]$Directory) {
+    $needle = Normalize-PathEntry $Directory
+    if ([string]::IsNullOrWhiteSpace($needle)) {
+        return $false
+    }
+    foreach ($entry in ($PathValue -split [regex]::Escape([System.IO.Path]::PathSeparator))) {
+        if ((Normalize-PathEntry $entry).Equals($needle, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Format-CurrentPathCommand([string]$Directory) {
+    $escaped = $Directory.Replace('`', '``').Replace('"', '`"')
+    return "`$env:Path = `"$escaped;`$env:Path`""
+}
+
+function Write-CurrentPathCommand([string]$Directory) {
+    Write-Host "for this PowerShell session, run:"
+    Write-Host ("  " + (Format-CurrentPathCommand $Directory))
+}
+
+function Add-InstallDirToPathIfNeeded([string]$Directory, [bool]$ModifyPath) {
+    $dir = $Directory.TrimEnd("\", "/")
+    if (Test-PathContainsDirectory -PathValue $env:Path -Directory $dir) {
+        return
+    }
+
+    if (-not $ModifyPath) {
+        Write-Host "$dir is not on PATH; user PATH update skipped"
+        Write-CurrentPathCommand $dir
+        return
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_PATH)) {
+        Add-Content -LiteralPath $env:GITHUB_PATH -Value $dir
+        if (-not (Test-PathContainsDirectory -PathValue $env:Path -Directory $dir)) {
+            $env:Path = "$dir$([System.IO.Path]::PathSeparator)$env:Path"
+        }
+        Write-Host "added $dir to GITHUB_PATH for later GitHub Actions steps"
+        return
+    }
+
+    if ($env:CI -eq "1" -or $env:CI -eq "true") {
+        $env:Path = "$dir$([System.IO.Path]::PathSeparator)$env:Path"
+        Write-Host "$dir is not on PATH; CI detected, not editing the user PATH"
+        Write-CurrentPathCommand $dir
+        return
+    }
+
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if (Test-PathContainsDirectory -PathValue $userPath -Directory $dir) {
+        Write-Host "found existing user PATH setup for $dir"
+    } else {
+        if ([string]::IsNullOrWhiteSpace($userPath)) {
+            $newUserPath = $dir
+        } else {
+            $newUserPath = "$dir$([System.IO.Path]::PathSeparator)$userPath"
+        }
+        try {
+            [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
+            Write-Host "added $dir to the user PATH"
+        } catch {
+            Write-Warning "could not update the user PATH: $($_.Exception.Message)"
+        }
+    }
+
+    $updatedCurrentPath = $false
+    if (-not (Test-PathContainsDirectory -PathValue $env:Path -Directory $dir)) {
+        $env:Path = "$dir$([System.IO.Path]::PathSeparator)$env:Path"
+        $updatedCurrentPath = $true
+    }
+    if ($updatedCurrentPath) {
+        Write-Host "$dir was not on PATH at startup; this PowerShell session has been updated"
+    }
+    Write-Host "open a new PowerShell window or run:"
+    Write-Host ("  " + (Format-CurrentPathCommand $dir))
+    Write-Host "then verify with:"
+    Write-Host "  ctx status"
+}
+
 if ([string]::IsNullOrWhiteSpace($Platform)) {
     $Platform = Detect-Platform
 }
@@ -115,7 +208,62 @@ try {
     $downloadPath = Join-Path $tempRoot $artifact
     $installPath = Join-Path $BinDir "ctx.exe"
 
+    $skillAgents = @()
+    foreach ($agent in $SkillAgent) {
+        $trimmed = $agent.Trim()
+        if (-not [string]::IsNullOrWhiteSpace($trimmed)) {
+            $skillAgents += $trimmed
+        }
+    }
+    $allSkillAgentsRequested = [bool]$AllSkillAgents
+    $explicitSkillRequest = $allSkillAgentsRequested -or $skillAgents.Count -gt 0
+
+    if ($env:CTX_INSTALL_ALL_SKILL_AGENTS -eq "1") {
+        $allSkillAgentsRequested = $true
+        $explicitSkillRequest = $true
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:CTX_INSTALL_SKILL_AGENTS)) {
+        foreach ($agent in ($env:CTX_INSTALL_SKILL_AGENTS -split ",")) {
+            $trimmed = $agent.Trim()
+            if (-not [string]::IsNullOrWhiteSpace($trimmed)) {
+                $skillAgents += $trimmed
+                $explicitSkillRequest = $true
+            }
+        }
+    }
+
+    $noSkillRequested = [bool]$NoSkill -or $env:CTX_INSTALL_NO_SKILL -eq "1"
+    if ($noSkillRequested -and $explicitSkillRequest) {
+        Fail "cannot combine -NoSkill or CTX_INSTALL_NO_SKILL=1 with skill agent options"
+    }
+    if ($allSkillAgentsRequested -and $skillAgents.Count -gt 0) {
+        Fail "cannot combine -AllSkillAgents with -SkillAgent or CTX_INSTALL_SKILL_AGENTS"
+    }
+
+    $runSetup = -not $NoSetup -and $env:CTX_INSTALL_NO_SETUP -ne "1"
+    $runSkill = -not $noSkillRequested
+    if (-not $runSetup -and -not $explicitSkillRequest) {
+        $runSkill = $false
+    }
+    $modifyPath = -not $NoModifyPath -and $env:CTX_INSTALL_NO_MODIFY_PATH -ne "1"
+
     Write-Host "ctx install plan: version=$version platform=$Platform artifact=$artifact bin=$installPath"
+    if (-not (Test-PathContainsDirectory -PathValue $env:Path -Directory $BinDir)) {
+        if ($modifyPath) {
+            Write-Host "ctx PATH plan: add $BinDir to the user PATH when installing"
+        } else {
+            Write-Host "ctx PATH plan: do not update the user PATH"
+        }
+    }
+    if ($runSkill) {
+        if ($allSkillAgentsRequested) {
+            Write-Host "ctx skill plan: install bundled skill for all supported agents"
+        } elseif ($skillAgents.Count -gt 0) {
+            Write-Host ("ctx skill plan: install bundled skill for agents=" + ($skillAgents -join ","))
+        } else {
+            Write-Host "ctx skill plan: install universal skill plus detected agent-specific folders"
+        }
+    }
     if ($DryRun) {
         exit 0
     }
@@ -154,7 +302,25 @@ try {
     [System.IO.File]::WriteAllText($markerPath, $markerJson + [Environment]::NewLine, $utf8NoBom)
     Write-Host "wrote ctx managed install marker to $markerPath"
 
-    $runSetup = -not $NoSetup -and $env:CTX_INSTALL_NO_SETUP -ne "1"
+    if ($runSkill) {
+        $skillArgs = @("skill", "install")
+        if ($allSkillAgentsRequested) {
+            $skillArgs += "--all-agents"
+        } else {
+            foreach ($agent in $skillAgents) {
+                $skillArgs += @("--agent", $agent)
+            }
+        }
+        Write-Host "installing ctx agent skill (pass -NoSkill or set CTX_INSTALL_NO_SKILL=1 to skip next time)"
+        & $installPath @skillArgs
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "ctx skill install failed after install; run $installPath skill install to retry"
+        }
+    } else {
+        Write-Host "skill setup skipped; run $installPath skill install to install the bundled agent skill"
+    }
+
+    $setupStatus = 0
     if ($runSetup) {
         if ([string]::IsNullOrWhiteSpace($SetupProgress)) {
             if ([string]::IsNullOrWhiteSpace($env:CTX_SETUP_PROGRESS)) {
@@ -166,10 +332,17 @@ try {
         Write-Host "running ctx setup to index local history (pass -NoSetup or set CTX_INSTALL_NO_SETUP=1 to skip next time)"
         & $installPath setup --progress $SetupProgress
         if ($LASTEXITCODE -ne 0) {
-            Fail "ctx setup failed after install"
+            $setupStatus = $LASTEXITCODE
+            Write-Warning "ctx setup failed after install; run $installPath setup --progress $SetupProgress to retry"
         }
     } else {
         Write-Host "setup skipped; run $installPath setup to index local history"
+    }
+
+    Add-InstallDirToPathIfNeeded -Directory $BinDir -ModifyPath $modifyPath
+
+    if ($setupStatus -ne 0) {
+        exit $setupStatus
     }
 } finally {
     Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,11 +3,12 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-usage: scripts/install.sh --metadata PATH_OR_URL [--platform PLATFORM] [--bin-dir DIR] [--no-setup] [--no-man]
+usage: scripts/install.sh --metadata PATH_OR_URL [--platform PLATFORM] [--bin-dir DIR] [--no-modify-path] [--no-setup] [--no-skill] [--skill-agent AGENT] [--all-skill-agents] [--no-man]
 
 Installs the ctx binary from explicit release metadata with pinned SHA-256
-checksums, then runs ctx setup to index discovered local history. The installer
-never evaluates remote scripts or metadata as shell.
+checksums, installs the bundled ctx agent skill, then runs ctx setup to index
+discovered local history. The installer never evaluates remote scripts or
+metadata as shell.
 
 This helper is for local development and explicit-metadata testing. The
 production hosted installer is https://cli.ctx.rs/install and verifies detached
@@ -17,8 +18,16 @@ Options:
   --metadata PATH_OR_URL  Required. Local metadata file or HTTPS URL.
   --platform PLATFORM    linux-x64, macos-arm64, macos-x64, or freebsd-x64.
                          Defaults to the current host when it can be detected.
-  --bin-dir DIR          Install directory. Defaults to $HOME/.local/bin.
-  --no-setup             Install only; do not run ctx setup after install.
+  --bin-dir DIR          Install directory. Defaults to
+                         ${CTX_BIN_DIR:-$HOME/.local/bin}.
+  --no-modify-path       Do not update shell startup files when the install
+                         directory is not on PATH.
+  --no-setup             Install only; do not install the skill or run ctx setup
+                         unless a skill flag is also passed.
+  --no-skill             Do not install the bundled ctx agent skill.
+  --skill-agent AGENT    Install the skill into a specific agent skill dir.
+                         Repeat for multiple agents.
+  --all-skill-agents     Install the skill into all supported agent skill dirs.
   --no-man               Do not install generated man pages.
   --man-dir DIR          Man page directory. Defaults to $HOME/.local/share/man/man1.
   --dry-run              Validate metadata and print the planned install.
@@ -157,8 +166,200 @@ sha256_file() {
   fail "sha256sum, shasum, or sha256 is required"
 }
 
+lowercase() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
 json_escape() {
   printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+shell_double_quote_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/`/\\`/g; s/\$/\\$/g'
+}
+
+path_contains_dir() {
+  local dir="${1%/}"
+  local entry old_ifs path_entries
+
+  old_ifs="${IFS}"
+  IFS=:
+  read -r -a path_entries <<< "${PATH:-}"
+  IFS="${old_ifs}"
+  for entry in "${path_entries[@]}"; do
+    if [[ "${entry%/}" == "${dir}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+profile_has_path_line() {
+  local profile="$1"
+  local needle="$2"
+
+  awk -v needle="${needle}" '
+    $0 ~ /^[[:space:]]*#/ { next }
+    index($0, needle) && ($0 ~ /PATH/ || $0 ~ /fish_user_paths/ || $0 ~ /fish_add_path/) {
+      found = 1
+      exit
+    }
+    END { exit found ? 0 : 1 }
+  ' "${profile}"
+}
+
+path_setup_profile() {
+  local shell_name="$1"
+
+  test -n "${HOME:-}" || return 1
+
+  case "${shell_name}" in
+    fish)
+      printf '%s/.config/fish/config.fish\n' "${HOME}"
+      ;;
+    zsh)
+      printf '%s/.zshrc\n' "${ZDOTDIR:-${HOME}}"
+      ;;
+    bash)
+      if [[ -f "${HOME}/.bashrc" ]]; then
+        printf '%s/.bashrc\n' "${HOME}"
+      elif [[ -f "${HOME}/.bash_profile" ]]; then
+        printf '%s/.bash_profile\n' "${HOME}"
+      elif [[ -f "${HOME}/.profile" ]]; then
+        printf '%s/.profile\n' "${HOME}"
+      elif [[ "${platform}" == macos-* ]]; then
+        printf '%s/.bash_profile\n' "${HOME}"
+      else
+        printf '%s/.bashrc\n' "${HOME}"
+      fi
+      ;;
+    *)
+      printf '%s/.profile\n' "${HOME}"
+      ;;
+  esac
+}
+
+profile_contains_path_setup() {
+  local profile="$1"
+  local dir="${2%/}"
+  local dir_escaped home_prefix rel
+
+  [[ -f "${profile}" ]] || return 1
+  profile_has_path_line "${profile}" "${dir}" && return 0
+  dir_escaped="$(shell_double_quote_escape "${dir}")"
+  profile_has_path_line "${profile}" "${dir_escaped}" && return 0
+
+  if [[ -n "${HOME:-}" ]]; then
+    home_prefix="${HOME%/}/"
+    if [[ "${dir}" == "${home_prefix}"* ]]; then
+      rel="${dir#"${home_prefix}"}"
+      profile_has_path_line "${profile}" "\$HOME/${rel}" && return 0
+      profile_has_path_line "${profile}" "~/${rel}" && return 0
+    fi
+  fi
+
+  return 1
+}
+
+path_setup_snippet() {
+  local shell_name="$1"
+  local dir_escaped
+  dir_escaped="$(shell_double_quote_escape "$2")"
+
+  case "${shell_name}" in
+    fish)
+      cat <<EOF
+
+# ctx installer PATH setup
+if not contains -- "${dir_escaped}" \$PATH
+    set -gx PATH "${dir_escaped}" \$PATH
+end
+EOF
+      ;;
+    *)
+      cat <<EOF
+
+# ctx installer PATH setup
+case ":\${PATH}:" in
+  *":${dir_escaped}:"*) ;;
+  *) export PATH="${dir_escaped}:\${PATH}" ;;
+esac
+EOF
+      ;;
+  esac
+}
+
+print_current_path_command() {
+  local shell_name="$1"
+  local dir_escaped
+  dir_escaped="$(shell_double_quote_escape "$2")"
+
+  case "${shell_name}" in
+    fish)
+      printf '  set -gx PATH "%s" $PATH\n' "${dir_escaped}"
+      ;;
+    *)
+      printf '  export PATH="%s:${PATH}"\n' "${dir_escaped}"
+      ;;
+  esac
+}
+
+configure_path_if_needed() {
+  local dir="${bin_dir%/}"
+  local shell_name profile profile_dir
+
+  if path_contains_dir "${dir}"; then
+    return 0
+  fi
+
+  shell_name="${SHELL:-}"
+  shell_name="${shell_name##*/}"
+  if [[ -z "${shell_name}" ]]; then
+    shell_name="sh"
+  fi
+
+  if (( ! modify_path )); then
+    printf '%s is not on PATH; shell startup file update skipped\n' "${dir}"
+    printf 'for this shell session, run:\n'
+    print_current_path_command "${shell_name}" "${dir}"
+    return 0
+  fi
+
+  if [[ -n "${GITHUB_PATH:-}" ]]; then
+    printf '%s\n' "${dir}" >> "${GITHUB_PATH}"
+    printf 'added %s to GITHUB_PATH for later GitHub Actions steps\n' "${dir}"
+    return 0
+  fi
+
+  if [[ "${CI:-}" == "1" || "${CI:-}" == "true" ]]; then
+    printf '%s is not on PATH; CI detected, not editing shell startup files\n' "${dir}"
+    printf 'for this shell session, run:\n'
+    print_current_path_command "${shell_name}" "${dir}"
+    return 0
+  fi
+
+  if ! profile="$(path_setup_profile "${shell_name}")"; then
+    printf '%s is not on PATH; HOME is unavailable, so no shell startup file was updated\n' "${dir}"
+    printf 'for this shell session, run:\n'
+    print_current_path_command "${shell_name}" "${dir}"
+    return 0
+  fi
+
+  if profile_contains_path_setup "${profile}" "${dir}"; then
+    printf 'found existing PATH setup for %s in %s\n' "${dir}" "${profile}"
+  else
+    profile_dir="$(dirname "${profile}")"
+    if mkdir -p "${profile_dir}" && path_setup_snippet "${shell_name}" "${dir}" >> "${profile}"; then
+      printf 'added ctx PATH setup to %s\n' "${profile}"
+    else
+      printf 'warning: could not update shell startup file %s\n' "${profile}" >&2
+    fi
+  fi
+
+  printf '%s is not on the current PATH; restart your shell or run:\n' "${dir}"
+  print_current_path_command "${shell_name}" "${dir}"
+  printf 'then verify with:\n'
+  printf '  ctx status\n'
 }
 
 write_install_marker() {
@@ -190,10 +391,16 @@ EOF
 
 metadata_source=""
 platform=""
-bin_dir="${HOME:-}/.local/bin"
+bin_dir="${CTX_BIN_DIR:-${HOME:-}/.local/bin}"
 man_dir="${CTX_MAN_DIR:-${HOME:-}/.local/share/man/man1}"
 dry_run=0
+modify_path=1
 run_setup=1
+run_skill=1
+no_skill_requested=0
+explicit_skill_request=0
+all_skill_agents=0
+skill_agents=()
 install_man=1
 
 while (($# > 0)); do
@@ -210,8 +417,25 @@ while (($# > 0)); do
       shift
       bin_dir="${1:-}"
       ;;
+    --no-modify-path)
+      modify_path=0
+      ;;
     --no-setup)
       run_setup=0
+      ;;
+    --no-skill)
+      run_skill=0
+      no_skill_requested=1
+      ;;
+    --skill-agent)
+      shift
+      test -n "${1:-}" || fail "--skill-agent requires a value"
+      skill_agents+=("$1")
+      explicit_skill_request=1
+      ;;
+    --all-skill-agents)
+      all_skill_agents=1
+      explicit_skill_request=1
       ;;
     --no-man)
       install_man=0
@@ -284,10 +508,72 @@ case "${artifact}" in
 esac
 install_path="${bin_dir%/}/${install_name}"
 
+if [[ "${CTX_INSTALL_NO_MAN:-0}" == "1" ]]; then
+  install_man=0
+fi
+
+if [[ "${CTX_INSTALL_NO_MODIFY_PATH:-0}" == "1" ]]; then
+  modify_path=0
+fi
+
+if [[ "${CTX_INSTALL_NO_SETUP:-0}" == "1" ]]; then
+  run_setup=0
+fi
+
+if [[ "${CTX_INSTALL_ALL_SKILL_AGENTS:-0}" == "1" ]]; then
+  all_skill_agents=1
+  explicit_skill_request=1
+fi
+
+if [[ -n "${CTX_INSTALL_SKILL_AGENTS:-}" ]]; then
+  explicit_skill_request=1
+  IFS=',' read -r -a env_skill_agents <<< "${CTX_INSTALL_SKILL_AGENTS}"
+  for agent in "${env_skill_agents[@]}"; do
+    agent="${agent//[[:space:]]/}"
+    if [[ -n "${agent}" ]]; then
+      skill_agents+=("${agent}")
+    fi
+  done
+fi
+
+if [[ "${CTX_INSTALL_NO_SKILL:-0}" == "1" ]]; then
+  run_skill=0
+  no_skill_requested=1
+fi
+
+if ((no_skill_requested && explicit_skill_request)); then
+  fail "cannot combine --no-skill or CTX_INSTALL_NO_SKILL=1 with skill agent options"
+fi
+
+if ((all_skill_agents && ${#skill_agents[@]} > 0)); then
+  fail "cannot combine --all-skill-agents with --skill-agent or CTX_INSTALL_SKILL_AGENTS"
+fi
+
+if ((! run_setup && ! explicit_skill_request)); then
+  run_skill=0
+fi
+
 printf 'ctx install plan: version=%s platform=%s artifact=%s bin=%s\n' \
   "${version}" "${platform}" "${artifact}" "${install_path}"
 if ((install_man)); then
   printf 'ctx man page plan: dir=%s\n' "${man_dir}"
+fi
+if path_contains_dir "${bin_dir%/}"; then
+  :
+elif ((modify_path)); then
+  printf 'ctx PATH plan: add %s to shell startup files when installing\n' "${bin_dir%/}"
+else
+  printf 'ctx PATH plan: do not update shell startup files\n'
+fi
+if ((run_skill)); then
+  if ((all_skill_agents)); then
+    printf 'ctx skill plan: install bundled skill for all supported agents\n'
+  elif ((${#skill_agents[@]} > 0)); then
+    skill_agent_list="$(IFS=,; printf '%s' "${skill_agents[*]}")"
+    printf 'ctx skill plan: install bundled skill for agents=%s\n' "${skill_agent_list}"
+  else
+    printf 'ctx skill plan: install universal skill plus detected agent-specific folders\n'
+  fi
 fi
 
 if ((dry_run)); then
@@ -296,7 +582,7 @@ fi
 
 download_file "${artifact_url}" "${download_path}"
 actual_checksum="$(sha256_file "${download_path}")"
-if [[ "${actual_checksum,,}" != "${checksum,,}" ]]; then
+if [[ "$(lowercase "${actual_checksum}")" != "$(lowercase "${checksum}")" ]]; then
   fail "checksum mismatch for ${artifact}: expected ${checksum}, got ${actual_checksum}"
 fi
 
@@ -307,10 +593,6 @@ printf 'installed ctx to %s\n' "${install_path}"
 write_install_marker "${install_path}.install.json" "${metadata_source}" "${source_commit}" "${published_at}"
 printf 'wrote ctx managed install marker to %s\n' "${install_path}.install.json"
 
-if [[ "${CTX_INSTALL_NO_MAN:-0}" == "1" ]]; then
-  install_man=0
-fi
-
 if ((install_man)); then
   mkdir -p "${man_dir}"
   if "${install_path}" docs man --out "${man_dir}"; then
@@ -320,14 +602,40 @@ if ((install_man)); then
   fi
 fi
 
-if [[ "${CTX_INSTALL_NO_SETUP:-0}" == "1" ]]; then
-  run_setup=0
+if ((run_skill)); then
+  skill_args=(skill install)
+  if ((all_skill_agents)); then
+    skill_args+=(--all-agents)
+  else
+    for agent in "${skill_agents[@]}"; do
+      skill_args+=(--agent "${agent}")
+    done
+  fi
+  printf 'installing ctx agent skill (pass --no-skill or set CTX_INSTALL_NO_SKILL=1 to skip next time)\n'
+  if ! "${install_path}" "${skill_args[@]}"; then
+    printf 'warning: ctx skill install failed after install; run %s skill install to retry\n' "${install_path}" >&2
+  fi
+else
+  printf 'skill setup skipped; run %s skill install to install the bundled agent skill\n' "${install_path}"
 fi
 
 if ((run_setup)); then
   setup_progress="${CTX_SETUP_PROGRESS:-auto}"
   printf 'running ctx setup to index local history (pass --no-setup or set CTX_INSTALL_NO_SETUP=1 to skip next time)\n'
-  "${install_path}" setup --progress "${setup_progress}"
+  setup_status=0
+  if "${install_path}" setup --progress "${setup_progress}"; then
+    :
+  else
+    setup_status=$?
+    printf 'warning: ctx setup failed after install; run %s setup --progress %s to retry\n' "${install_path}" "${setup_progress}" >&2
+  fi
 else
+  setup_status=0
   printf 'setup skipped; run %s setup to index local history\n' "${install_path}"
+fi
+
+configure_path_if_needed
+
+if ((setup_status != 0)); then
+  exit "${setup_status}"
 fi


### PR DESCRIPTION
## What changed

- Add default PATH setup to the Unix installer when the install directory is not already on `PATH`, covering bash, zsh, fish, fallback profiles, CI, and GitHub Actions.
- Add default user `Path` setup to the PowerShell installer while keeping `-NoModifyPath` and `CTX_INSTALL_NO_MODIFY_PATH=1` opt-outs.
- Add `ctx skill install` / `ctx skill status` so the bundled agent-history skill can be installed and refreshed directly by ctx.
- Update Getting Started, First 10 Minutes, troubleshooting, CLI reference, and skill install docs.
- Add installer PATH smoke coverage and ignore generated SDK build outputs.

## Why

Users could install ctx successfully but still fail to run `ctx` afterward when the default install directory was not on their shell `PATH`. The installer now fixes the common case by default while keeping explicit controls for CI, packaging, and users who manage shell startup files themselves.

## Validation

- `bash -n scripts/install.sh scripts/install-path-smoke.sh scripts/bazel-test.sh`
- `bash scripts/install-path-smoke.sh`
- `bazel test //:installer_path_smoke --config=ci`
- `cargo test -p ctx --test cli skill_install --locked`
- `cargo test -p ctx skill:: --locked`
- `cargo fmt --all -- --check`
- `scripts/check-docs.sh`
- `git diff --check`
- VM smoke: macOS 15.7.7 x86_64 bash/zsh
- VM smoke: FreeBSD 15.1-RELEASE-p1 bash
- Windows PowerShell smoke passed earlier for the PowerShell installer path update

Fixes #51
