### PR TITLE
fix(cli): reject empty provider session values

### DIFF
--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -3103,12 +3103,17 @@ fn resolve_session(
             "session lookup requires either a ctx session id or --provider with --provider-session"
         )
     })?;
-    let provider_session = provider_session
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            anyhow!("session lookup requires --provider-session when no ctx session id is provided")
-        })?;
+    let provider_session = match provider_session {
+        Some(v) => v.trim(),
+        None => {
+            return Err(anyhow!(
+                "session lookup requires --provider-session when no ctx session id is provided"
+            ))
+        }
+    };
+    if provider_session.is_empty() {
+        return Err(anyhow!("--provider-session cannot be empty"));
+    }
     let matches = store.sessions_by_external_session_limited(provider, provider_session, 2)?;
     match matches.as_slice() {
         [session] => Ok(session.clone()),

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -3131,6 +3131,37 @@ fn provider_session_lookup_requires_explicit_provider_flags_in_help() {
 }
 
 #[test]
+fn provider_session_rejects_whitespace_only_value() {
+    let temp = tempdir();
+    ctx(&temp).arg("setup").assert().success();
+
+    for args in [
+        vec![
+            "show",
+            "session",
+            "--provider",
+            "codex",
+            "--provider-session",
+            " ",
+        ],
+        vec![
+            "locate",
+            "session",
+            "--provider",
+            "codex",
+            "--provider-session",
+            " ",
+        ],
+    ] {
+        let stderr = failure_stderr(ctx(&temp).args(&args));
+        assert!(
+            stderr.contains("--provider-session cannot be empty"),
+            "expected empty-value error for {args:?}, got: {stderr}"
+        );
+    }
+}
+
+#[test]
 fn analytics_sends_coarse_cli_metadata_when_enabled() {
     let temp = tempdir();
     let events_path = temp.path().join("analytics.jsonl");


### PR DESCRIPTION
## Summary

`--provider-session` currently treats whitespace-only values the same as if the flag had been omitted, so both `ctx show` and `ctx locate` return the generic "requires --provider-session" error.

This changes the validation to reject present-but-empty values explicitly with `--provider-session cannot be empty`, matching the existing CLI validation pattern.

## Reproduction

```bash
./target/debug/ctx show session \
  --provider codex \
  --provider-session " "
```

Before:

```text
session lookup requires --provider-session when no ctx session id is provided
```

After:

```text
--provider-session cannot be empty
```

`ctx locate` now behaves the same way.

## Testing

- Added a regression test covering both `ctx show` and `ctx locate`.
- Verified the updated behavior manually.