### PR TITLE
fix(opencode): import actual session messages, not just metadata

### DIFF
--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -17394,7 +17394,11 @@ fn opencode_session_messages(
 ) -> Result<Vec<OpenCodeMessageRow>> {
     if sqlite_table_exists(conn, "session_message")? {
         let rows = opencode_session_message_rows(conn, dialect)?;
-        if !rows.is_empty() {
+        if !rows.is_empty()
+            && rows
+                .iter()
+                .any(|r| OPCODE_KNOWN_MESSAGE_TYPES.contains(&r.entry_type.as_str()))
+        {
             return Ok(rows);
         }
     }
@@ -17701,6 +17705,8 @@ fn opencode_event(
         }),
     }
 }
+
+const OPCODE_KNOWN_MESSAGE_TYPES: &[&str] = &["assistant", "user", "system", "shell"];
 
 fn opencode_event_type(entry_type: &str, data: &Value) -> EventType {
     match entry_type {


### PR DESCRIPTION
## Summary

- \opencode_session_messages()\ short-circuits on \session_message\ having any rows, but in current OpenCode schema this table only stores agent-switched/model-switched metadata
- Actual conversation lives in \message\ table with \data.role\ = user/assistant — never reached
- Fix: guard the \session_message\ path by checking for known conversation entry types before accepting rows; fall through to \message\ table when only metadata exists

## Validation

- \cargo build --release\ (Rust 1.96.1, Windows)
- Re-imported: \ctx import --provider opencode --reset-cursor\
- Before: 112 notice events, 65 sessions
- After: 53678 message events (45521 assistant + 8157 user), 1511 sessions
- \ctx search\ returns real message content