### PR TITLE
fix(mcp): return tool results in content[0].text instead of only structuredContent

### DIFF
--- a/crates/ctx-cli/src/mcp.rs
+++ b/crates/ctx-cli/src/mcp.rs
@@ -28,6 +28,14 @@ use super::{
 const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
 const MCP_MAX_LINE_BYTES: usize = 1024 * 1024;
 const MCP_MAX_SESSION_EVENTS: usize = 200;
+const MCP_TEXT_MAX_SEARCH_RESULTS: usize = 5;
+const MCP_TEXT_MAX_SOURCES: usize = 12;
+const MCP_TEXT_MAX_SQL_ROWS: usize = 8;
+const MCP_TEXT_MAX_SQL_COLUMNS: usize = 6;
+const MCP_TEXT_MAX_EVENTS: usize = 8;
+const MCP_TEXT_MAX_SNIPPET_CHARS: usize = 320;
+const MCP_TEXT_MAX_EVENT_CHARS: usize = 500;
+const MCP_TEXT_MAX_CELL_CHARS: usize = 80;
 
 enum McpInputLine {
     Line(String),
@@ -254,7 +262,7 @@ fn initialize_result() -> Value {
             "name": "ctx",
             "version": env!("CARGO_PKG_VERSION")
         },
-        "instructions": "Read-only access to the local ctx index. Tool output is private local history and may include absolute paths, source metadata, snippets, transcript text, and raw SQL query results; MCP hosts may log or forward it. This minimal server supports initialize, ping, tools/list, and tools/call over newline-delimited stdio. It does not expose MCP resources or prompts, and tools do not import provider history, write provider files, or write repositories."
+        "instructions": "Read-only access to the local ctx index. Tool output may include absolute paths, source metadata, snippets, transcript text, and raw SQL query results; MCP hosts may log or forward it. This minimal server supports initialize, ping, tools/list, and tools/call over newline-delimited stdio. It does not expose MCP resources or prompts, and tools do not import provider history, write provider files, or write repositories."
     })
 }
 
@@ -562,15 +570,500 @@ fn open_existing_store(data_root: &Path) -> Result<Store> {
 }
 
 fn tool_result(structured: Value) -> Value {
+    let text = render_tool_text(&structured);
     json!({
         "content": [
             {
                 "type": "text",
-                "text": serde_json::to_string(&structured).unwrap_or_default(),
+                "text": text,
             }
         ],
         "structuredContent": structured,
     })
+}
+
+fn render_tool_text(value: &Value) -> String {
+    match value.get("item_type").and_then(Value::as_str) {
+        Some("sql_result") => render_sql_text(value),
+        Some("session_transcript") => render_session_text(value),
+        Some("event_window") => render_event_window_text(value),
+        _ if value.get("results").and_then(Value::as_array).is_some() => render_search_text(value),
+        _ if value.get("sources").and_then(Value::as_array).is_some() => render_sources_text(value),
+        _ if value.get("initialized").and_then(Value::as_bool).is_some() => {
+            render_status_text(value)
+        }
+        _ => render_generic_text(value),
+    }
+}
+
+fn render_status_text(value: &Value) -> String {
+    let mut out = String::from("ctx status\n");
+    push_key_value(&mut out, "initialized", value.get("initialized"));
+    push_key_value(&mut out, "data_root", value.get("data_root"));
+    push_key_value(&mut out, "database_path", value.get("database_path"));
+    push_key_value(&mut out, "indexed_items", value.get("indexed_items"));
+    push_key_value(&mut out, "indexed_sources", value.get("indexed_sources"));
+    push_key_value(
+        &mut out,
+        "cataloged_sessions",
+        value.get("cataloged_sessions"),
+    );
+    push_key_value(
+        &mut out,
+        "indexed_catalog_sessions",
+        value.get("indexed_catalog_sessions"),
+    );
+    push_key_value(
+        &mut out,
+        "pending_catalog_sessions",
+        value.get("pending_catalog_sessions"),
+    );
+    push_key_value(
+        &mut out,
+        "failed_catalog_sessions",
+        value.get("failed_catalog_sessions"),
+    );
+    push_key_value(&mut out, "read_only", value.get("read_only"));
+    push_key_value(&mut out, "local_only", value.get("local_only"));
+    out
+}
+
+fn render_sources_text(value: &Value) -> String {
+    let sources = value
+        .get("sources")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let available = sources
+        .iter()
+        .filter(|source| source.get("status").and_then(Value::as_str) == Some("available"))
+        .count();
+    let importable = sources
+        .iter()
+        .filter(|source| source.get("importable").and_then(Value::as_bool) == Some(true))
+        .count();
+
+    let mut out = String::from("ctx sources\n");
+    out.push_str(&format!("sources: {}\n", sources.len()));
+    out.push_str(&format!("available: {available}\n"));
+    out.push_str(&format!("importable: {importable}\n"));
+    if sources.is_empty() {
+        return out;
+    }
+
+    let mut visible_sources = sources.iter().collect::<Vec<_>>();
+    visible_sources.sort_by_key(|source| {
+        (
+            source.get("status").and_then(Value::as_str) != Some("available"),
+            source.get("importable").and_then(Value::as_bool) != Some(true),
+            value_field(source, "provider").unwrap_or_default(),
+            value_field(source, "history_source")
+                .or_else(|| value_field(source, "path"))
+                .unwrap_or_default(),
+        )
+    });
+
+    out.push_str("\n| provider | status | import | source |\n");
+    out.push_str("| --- | --- | --- | --- |\n");
+    for source in visible_sources.iter().take(MCP_TEXT_MAX_SOURCES) {
+        let provider = value_field(source, "provider").unwrap_or_else(|| "-".to_owned());
+        let status = value_field(source, "status").unwrap_or_else(|| "-".to_owned());
+        let import = value_field(source, "import_support")
+            .or_else(|| value_field(source, "native_import"))
+            .unwrap_or_else(|| "-".to_owned());
+        let source_label = value_field(source, "history_source")
+            .or_else(|| value_field(source, "path"))
+            .or_else(|| value_field(source, "manifest_path"))
+            .or_else(|| value_field(source, "source_format"))
+            .unwrap_or_else(|| "-".to_owned());
+        out.push_str(&format!(
+            "| {} | {} | {} | {} |\n",
+            table_cell(&provider, MCP_TEXT_MAX_CELL_CHARS),
+            table_cell(&status, MCP_TEXT_MAX_CELL_CHARS),
+            table_cell(&import, MCP_TEXT_MAX_CELL_CHARS),
+            table_cell(&source_label, MCP_TEXT_MAX_CELL_CHARS)
+        ));
+    }
+    push_omitted_line(&mut out, sources.len(), MCP_TEXT_MAX_SOURCES, "sources");
+    out
+}
+
+fn render_search_text(value: &Value) -> String {
+    let results = value
+        .get("results")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let mut out = String::from("ctx search\n");
+    if let Some(query) = value.get("query").and_then(Value::as_str) {
+        out.push_str(&format!(
+            "query: {}\n",
+            clip_inline(query, MCP_TEXT_MAX_SNIPPET_CHARS)
+        ));
+    }
+    if let Some(freshness) = value.get("freshness") {
+        let mode = value_field(freshness, "mode");
+        let status = value_field(freshness, "status");
+        match (mode, status) {
+            (Some(mode), Some(status)) => out.push_str(&format!("freshness: {mode}/{status}\n")),
+            (Some(mode), None) => out.push_str(&format!("freshness: {mode}\n")),
+            (None, Some(status)) => out.push_str(&format!("freshness: {status}\n")),
+            (None, None) => {}
+        }
+    }
+    push_filter_summary(&mut out, value.get("filters"));
+    out.push_str(&format!("results: {}\n", results.len()));
+    if results.is_empty() {
+        return out;
+    }
+
+    for (index, result) in results.iter().take(MCP_TEXT_MAX_SEARCH_RESULTS).enumerate() {
+        let heading = value_field(result, "title")
+            .filter(|title| !title.trim().is_empty())
+            .or_else(|| value_field(result, "item_type"))
+            .unwrap_or_else(|| "result".to_owned());
+        out.push_str(&format!(
+            "\n{}. {}\n",
+            index + 1,
+            clip_inline(&heading, MCP_TEXT_MAX_SNIPPET_CHARS)
+        ));
+        push_indented_key_value(&mut out, "ctx_session_id", result.get("ctx_session_id"));
+        push_indented_key_value(&mut out, "ctx_event_id", result.get("ctx_event_id"));
+        push_indented_key_value(&mut out, "provider", result.get("provider"));
+        push_indented_key_value(&mut out, "timestamp", result.get("timestamp"));
+        if let Some(snippet) = value_field(result, "snippet").filter(|snippet| !snippet.is_empty())
+        {
+            out.push_str(&format!(
+                "   snippet: {}\n",
+                clip_inline(&snippet, MCP_TEXT_MAX_SNIPPET_CHARS)
+            ));
+        }
+        if let Some(commands) = result
+            .get("suggested_next_commands")
+            .and_then(Value::as_array)
+        {
+            for command in commands.iter().filter_map(Value::as_str).take(2) {
+                out.push_str(&format!("   next: {command}\n"));
+            }
+        }
+    }
+    push_omitted_line(
+        &mut out,
+        results.len(),
+        MCP_TEXT_MAX_SEARCH_RESULTS,
+        "results",
+    );
+    out
+}
+
+fn push_filter_summary(out: &mut String, filters: Option<&Value>) {
+    let Some(filters) = filters.and_then(Value::as_object) else {
+        return;
+    };
+    let filter_parts = [
+        "provider",
+        "history_source",
+        "provider_key",
+        "source_id",
+        "source_format",
+        "workspace",
+        "since",
+        "event_type",
+        "file",
+        "session",
+    ]
+    .into_iter()
+    .filter_map(|key| value_field(filters.get(key)?, "").map(|value| format!("{key}={value}")))
+    .collect::<Vec<_>>();
+    if !filter_parts.is_empty() {
+        out.push_str(&format!("filters: {}\n", filter_parts.join(", ")));
+    }
+}
+
+fn render_sql_text(value: &Value) -> String {
+    let columns = value
+        .get("columns")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let rows = value
+        .get("rows")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+
+    let mut out = String::from("ctx sql\n");
+    push_key_value(&mut out, "returned_rows", value.get("returned_rows"));
+    if let Some(truncated) = value.get("truncated") {
+        let rows_truncated = value_field(truncated, "rows").unwrap_or_else(|| "false".to_owned());
+        let values_truncated =
+            value_field(truncated, "values").unwrap_or_else(|| "false".to_owned());
+        out.push_str(&format!(
+            "truncated: rows={rows_truncated}, values={values_truncated}\n"
+        ));
+    }
+    push_key_value(&mut out, "elapsed_ms", value.get("elapsed_ms"));
+    if columns.is_empty() {
+        out.push_str("columns: 0\n");
+        return out;
+    }
+
+    let visible_column_count = columns.len().min(MCP_TEXT_MAX_SQL_COLUMNS);
+    let headers = columns
+        .iter()
+        .take(visible_column_count)
+        .map(|column| table_cell(&scalar_text(column), MCP_TEXT_MAX_CELL_CHARS))
+        .collect::<Vec<_>>();
+    out.push_str("\n| ");
+    out.push_str(&headers.join(" | "));
+    out.push_str(" |\n| ");
+    out.push_str(
+        &(0..visible_column_count)
+            .map(|_| "---")
+            .collect::<Vec<_>>()
+            .join(" | "),
+    );
+    out.push_str(" |\n");
+    for row in rows.iter().take(MCP_TEXT_MAX_SQL_ROWS) {
+        let cells = row
+            .as_array()
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+            .iter()
+            .take(visible_column_count)
+            .map(sql_cell_text)
+            .collect::<Vec<_>>();
+        out.push_str("| ");
+        out.push_str(&cells.join(" | "));
+        out.push_str(" |\n");
+    }
+    push_omitted_line(&mut out, rows.len(), MCP_TEXT_MAX_SQL_ROWS, "rows");
+    push_omitted_line(&mut out, columns.len(), MCP_TEXT_MAX_SQL_COLUMNS, "columns");
+    out
+}
+
+fn render_session_text(value: &Value) -> String {
+    let events = value
+        .get("events")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let mut out = String::from("ctx show session\n");
+    push_key_value(&mut out, "ctx_session_id", value.get("ctx_session_id"));
+    push_key_value(&mut out, "provider", value.get("provider"));
+    push_key_value(
+        &mut out,
+        "provider_session_id",
+        value.get("provider_session_id"),
+    );
+    push_key_value(&mut out, "mode", value.get("mode"));
+    out.push_str(&format!("events: {}\n", events.len()));
+    if let Some(max_events) = value
+        .get("truncated")
+        .and_then(|truncated| truncated.get("max_events"))
+        .and_then(Value::as_u64)
+    {
+        out.push_str(&format!("event list capped at {max_events} events\n"));
+    }
+
+    for (index, event) in events.iter().take(MCP_TEXT_MAX_EVENTS).enumerate() {
+        push_event_summary(&mut out, index + 1, event);
+    }
+    push_omitted_line(&mut out, events.len(), MCP_TEXT_MAX_EVENTS, "events");
+    out
+}
+
+fn render_event_window_text(value: &Value) -> String {
+    let events = value
+        .get("events")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let mut out = String::from("ctx show event\n");
+    push_key_value(&mut out, "ctx_event_id", value.get("ctx_event_id"));
+    push_key_value(&mut out, "ctx_session_id", value.get("ctx_session_id"));
+    out.push_str(&format!("events: {}\n", events.len()));
+    if let Some(event) = value.get("event") {
+        out.push_str("\nselected event\n");
+        push_event_summary(&mut out, 1, event);
+    }
+
+    let selected_event_id = value.get("ctx_event_id").and_then(Value::as_str);
+    let window_events = events
+        .iter()
+        .filter(|event| value_field(event, "ctx_event_id").as_deref() != selected_event_id)
+        .collect::<Vec<_>>();
+    if !window_events.is_empty() {
+        out.push_str("\nwindow\n");
+        for (index, event) in window_events.iter().take(MCP_TEXT_MAX_EVENTS).enumerate() {
+            push_event_summary(&mut out, index + 1, event);
+        }
+        push_omitted_line(&mut out, window_events.len(), MCP_TEXT_MAX_EVENTS, "events");
+    }
+    out
+}
+
+fn push_event_summary(out: &mut String, index: usize, event: &Value) {
+    let sequence = value_field(event, "sequence")
+        .map(|sequence| format!("#{sequence} "))
+        .unwrap_or_default();
+    let role = value_field(event, "role")
+        .filter(|role| !role.is_empty())
+        .unwrap_or_else(|| "-".to_owned());
+    let event_type = value_field(event, "event_type").unwrap_or_else(|| "event".to_owned());
+    let occurred_at = value_field(event, "occurred_at").unwrap_or_default();
+    let suffix = if occurred_at.is_empty() {
+        String::new()
+    } else {
+        format!(" {occurred_at}")
+    };
+    out.push_str(&format!(
+        "\n{}. {sequence}{role} {event_type}{suffix}\n",
+        index
+    ));
+    push_indented_key_value(out, "ctx_event_id", event.get("ctx_event_id"));
+    if let Some(text) = value_field(event, "text")
+        .or_else(|| value_field(event, "preview"))
+        .filter(|text| !text.is_empty())
+    {
+        out.push_str(&format!(
+            "   text: {}\n",
+            clip_inline(&text, MCP_TEXT_MAX_EVENT_CHARS)
+        ));
+    }
+}
+
+fn push_key_value(out: &mut String, key: &str, value: Option<&Value>) {
+    if let Some(value) = value.and_then(value_to_text) {
+        out.push_str(&format!("{key}: {value}\n"));
+    }
+}
+
+fn push_indented_key_value(out: &mut String, key: &str, value: Option<&Value>) {
+    if let Some(value) = value.and_then(value_to_text) {
+        out.push_str(&format!("   {key}: {value}\n"));
+    }
+}
+
+fn value_field(value: &Value, key: &str) -> Option<String> {
+    if key.is_empty() {
+        return value_to_text(value);
+    }
+    value.get(key).and_then(value_to_text)
+}
+
+fn value_to_text(value: &Value) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::String(text) => Some(text.clone()),
+        Value::Bool(value) => Some(value.to_string()),
+        Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn scalar_text(value: &Value) -> String {
+    value_to_text(value).unwrap_or_else(|| match value {
+        Value::Array(values) => format!("[{} values]", values.len()),
+        Value::Object(object) => format!("[{} fields]", object.len()),
+        Value::Null => "null".to_owned(),
+        Value::String(_) | Value::Bool(_) | Value::Number(_) => unreachable!(),
+    })
+}
+
+fn render_generic_text(value: &Value) -> String {
+    let mut out = String::from("ctx tool result\n");
+    match value {
+        Value::Object(object) => {
+            for (key, value) in object.iter().take(12) {
+                match value {
+                    Value::Array(values) => {
+                        out.push_str(&format!("{key}: [{} items]\n", values.len()));
+                    }
+                    Value::Object(fields) => {
+                        out.push_str(&format!("{key}: [{} fields]\n", fields.len()));
+                    }
+                    _ => push_key_value(&mut out, key, Some(value)),
+                }
+            }
+            push_omitted_line(&mut out, object.len(), 12, "fields");
+        }
+        Value::Array(values) => {
+            out.push_str(&format!("items: {}\n", values.len()));
+            for (index, value) in values.iter().take(12).enumerate() {
+                out.push_str(&format!("{}. {}\n", index + 1, scalar_text(value)));
+            }
+            push_omitted_line(&mut out, values.len(), 12, "items");
+        }
+        _ => push_key_value(&mut out, "value", Some(value)),
+    }
+    out
+}
+
+fn sql_cell_text(value: &Value) -> String {
+    let text = match value {
+        Value::Object(object) => match object.get("type").and_then(Value::as_str) {
+            Some("text") => {
+                let mut text = object
+                    .get("value")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_owned();
+                if object.get("truncated").and_then(Value::as_bool) == Some(true) {
+                    text.push_str("... (truncated)");
+                }
+                text
+            }
+            Some("blob") => {
+                let bytes = object
+                    .get("bytes")
+                    .and_then(Value::as_u64)
+                    .map(|bytes| bytes.to_string())
+                    .unwrap_or_else(|| "?".to_owned());
+                let preview = object
+                    .get("preview_hex")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let suffix = if object.get("truncated").and_then(Value::as_bool) == Some(true) {
+                    " truncated"
+                } else {
+                    ""
+                };
+                format!("blob {bytes} bytes {preview}{suffix}")
+            }
+            _ => scalar_text(value),
+        },
+        _ => scalar_text(value),
+    };
+    table_cell(&text, MCP_TEXT_MAX_CELL_CHARS)
+}
+
+fn table_cell(text: &str, max_chars: usize) -> String {
+    clip_inline(text, max_chars).replace('|', "\\|")
+}
+
+fn clip_inline(text: &str, max_chars: usize) -> String {
+    let compact = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    clip_chars(&compact, max_chars)
+}
+
+fn clip_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_owned();
+    }
+    let keep = max_chars.saturating_sub(15);
+    let mut clipped = text.chars().take(keep).collect::<String>();
+    clipped.push_str("... [truncated]");
+    clipped
+}
+
+fn push_omitted_line(out: &mut String, total: usize, shown: usize, noun: &str) {
+    if total > shown {
+        out.push_str(&format!(
+            "... {} more {noun} omitted from text.\n",
+            total - shown
+        ));
+    }
 }
 
 fn tool_error_result(err: anyhow::Error) -> Value {

--- a/crates/ctx-cli/src/mcp.rs
+++ b/crates/ctx-cli/src/mcp.rs
@@ -566,7 +566,7 @@ fn tool_result(structured: Value) -> Value {
         "content": [
             {
                 "type": "text",
-                "text": "ctx returned structured JSON in structuredContent. Treat it as private local history.",
+                "text": serde_json::to_string(&structured).unwrap_or_default(),
             }
         ],
         "structuredContent": structured,

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -557,6 +557,29 @@ fn mcp_raw_roundtrip_bytes(temp: &TempDir, stdin: Vec<u8>) -> Vec<Value> {
         .collect()
 }
 
+fn mcp_content_text(result: &Value) -> &str {
+    result["content"][0]["text"].as_str().unwrap()
+}
+
+fn assert_useful_mcp_text<'a>(result: &'a Value, expected: &[&str]) -> &'a str {
+    let text = mcp_content_text(result);
+    assert!(
+        !text.trim_start().starts_with('{'),
+        "MCP content text should not be raw JSON:\n{text}"
+    );
+    assert!(
+        !text.contains("ctx returned structured JSON"),
+        "MCP content text should not be the old stub:\n{text}"
+    );
+    for needle in expected {
+        assert!(
+            text.contains(needle),
+            "MCP content text missing {needle:?}:\n{text}"
+        );
+    }
+    text
+}
+
 fn assert_omits_keys(value: &Value, forbidden_keys: &[&str]) {
     match value {
         Value::Object(map) => {
@@ -4610,15 +4633,21 @@ fn mcp_status_and_tools_list_are_read_only_without_initialized_store() {
     assert!(providers.iter().any(|provider| provider == "cline"));
     assert!(providers.iter().any(|provider| provider == "roo"));
     assert!(providers.iter().any(|provider| provider == "roo_code"));
-    let status: Value = serde_json::from_str(
-        responses[2]["result"]["content"][0]["text"]
-            .as_str()
-            .unwrap(),
-    )
-    .unwrap();
+    let status = &responses[2]["result"]["structuredContent"];
     assert_eq!(status["schema_version"], 1);
     assert_eq!(status["initialized"], false);
     assert_eq!(status["read_only"], true);
+    assert_useful_mcp_text(
+        &responses[2]["result"],
+        &[
+            "ctx status",
+            "initialized: false",
+            "database_path:",
+            "indexed_items: 0",
+            "read_only: true",
+            "local_only: true",
+        ],
+    );
     assert!(
         !temp.path().join("work.sqlite").exists(),
         "MCP status should not initialize the ctx store"
@@ -4748,31 +4777,38 @@ fn mcp_sql_tool_returns_structured_json_and_rejects_writes() {
         ],
     );
 
-    let sql: Value = serde_json::from_str(
-        responses[1]["result"]["content"][0]["text"]
-            .as_str()
-            .unwrap(),
-    )
-    .unwrap();
+    let sql = &responses[1]["result"]["structuredContent"];
     assert_eq!(sql["item_type"], "sql_result");
     assert_eq!(sql["read_only"], true);
     assert_eq!(sql["share_safe"], false);
     assert_eq!(sql["columns"], json!(["sessions"]));
     assert_eq!(sql["rows"], json!([[0]]));
+    assert_useful_mcp_text(
+        &responses[1]["result"],
+        &[
+            "ctx sql",
+            "returned_rows: 1",
+            "truncated: rows=false, values=false",
+            "| sessions |",
+            "| 0 |",
+        ],
+    );
 
     let write = &responses[2]["result"];
     assert_eq!(write["isError"], true);
-    assert!(write["content"][0]["text"]
+    assert!(write["structuredContent"]["error"]
         .as_str()
         .unwrap()
         .contains("SQL query must be read-only"));
+    assert!(mcp_content_text(write).contains("SQL query must be read-only"));
 
     let budget = &responses[3]["result"];
     assert_eq!(budget["isError"], true);
-    assert!(budget["content"][0]["text"]
+    assert!(budget["structuredContent"]["error"]
         .as_str()
         .unwrap()
         .contains("SQL result preview budget"));
+    assert!(mcp_content_text(budget).contains("SQL result preview budget"));
 }
 
 #[test]
@@ -4845,15 +4881,25 @@ fn mcp_show_session_caps_transcript_events() {
         ],
     );
 
-    let transcript: Value = serde_json::from_str(
-        responses[1]["result"]["content"][0]["text"]
-            .as_str()
-            .unwrap(),
-    )
-    .unwrap();
+    let transcript = &responses[1]["result"]["structuredContent"];
     assert_eq!(transcript["truncated"]["events"], true);
     assert_eq!(transcript["truncated"]["max_events"], 200);
     assert_eq!(transcript["events"].as_array().unwrap().len(), 200);
+    let text = assert_useful_mcp_text(
+        &responses[1]["result"],
+        &[
+            "ctx show session",
+            session_id,
+            "events: 200",
+            "event list capped at 200 events",
+            "mcp transcript event 0",
+            "... 192 more events omitted from text",
+        ],
+    );
+    assert!(
+        !text.contains("mcp transcript event 199"),
+        "session text should summarize rather than dump all events:\n{text}"
+    );
 }
 
 #[test]
@@ -4900,17 +4946,26 @@ fn mcp_search_and_show_tools_return_structured_json_without_refresh() {
             }),
         ],
     );
-    let search: Value = serde_json::from_str(
-        search_responses[1]["result"]["content"][0]["text"]
-            .as_str()
-            .unwrap(),
-    )
-    .unwrap();
+    let search = &search_responses[1]["result"]["structuredContent"];
     assert_eq!(search["schema_version"], 1);
     assert_eq!(search["query"], "onboarding");
     assert_eq!(search["freshness"]["mode"], "off");
     assert_eq!(search["freshness"]["status"], "skipped");
     assert_eq!(search["share_safe"], false);
+    assert_useful_mcp_text(
+        &search_responses[1]["result"],
+        &[
+            "ctx search",
+            "query: onboarding",
+            "freshness: off/skipped",
+            "filters: provider=codex",
+            "results: 1",
+            "ctx_session_id:",
+            "ctx_event_id:",
+            "snippet:",
+            "next: ctx show",
+        ],
+    );
     let first_result = &search["results"][0];
     let ctx_session_id = first_result["ctx_session_id"].as_str().unwrap();
     let ctx_event_id = first_result["ctx_event_id"].as_str().unwrap();
@@ -4955,29 +5010,43 @@ fn mcp_search_and_show_tools_return_structured_json_without_refresh() {
         ],
     );
 
-    let session: Value = serde_json::from_str(
-        show_responses[1]["result"]["content"][0]["text"]
-            .as_str()
-            .unwrap(),
-    )
-    .unwrap();
+    let session = &show_responses[1]["result"]["structuredContent"];
     assert_eq!(session["item_type"], "session_transcript");
     assert_eq!(session["ctx_session_id"], ctx_session_id);
     assert_eq!(session["mode"], "lite");
     assert!(session["events"].as_array().unwrap().iter().all(|event| {
         event["ctx_session_id"] == ctx_session_id && event["ctx_event_id"].is_string()
     }));
+    assert_useful_mcp_text(
+        &show_responses[1]["result"],
+        &[
+            "ctx show session",
+            ctx_session_id,
+            "provider: codex",
+            "mode: lite",
+            "events:",
+            "ctx_event_id:",
+            "text:",
+        ],
+    );
 
-    let event: Value = serde_json::from_str(
-        show_responses[2]["result"]["content"][0]["text"]
-            .as_str()
-            .unwrap(),
-    )
-    .unwrap();
+    let event = &show_responses[2]["result"]["structuredContent"];
     assert_eq!(event["item_type"], "event_window");
     assert_eq!(event["ctx_event_id"], ctx_event_id);
     assert_eq!(event["ctx_session_id"], ctx_session_id);
     assert!(!event["events"].as_array().unwrap().is_empty());
+    assert_useful_mcp_text(
+        &show_responses[2]["result"],
+        &[
+            "ctx show event",
+            ctx_event_id,
+            ctx_session_id,
+            "selected event",
+            "window",
+            "ctx_event_id:",
+            "text:",
+        ],
+    );
 }
 
 #[test]
@@ -5039,22 +5108,25 @@ fn mcp_search_requires_query_term_or_file_without_opening_store() {
 
     let result = &responses[1]["result"];
     assert_eq!(result["isError"], true);
-    assert!(result["content"][0]["text"]
+    assert!(result["structuredContent"]["error"]
         .as_str()
         .unwrap()
         .contains("search needs a query or file"));
+    assert!(mcp_content_text(result).contains("search needs a query or file"));
     let hidden_provider = &responses[2]["result"];
     assert_eq!(hidden_provider["isError"], true);
-    assert!(hidden_provider["content"][0]["text"]
+    assert!(hidden_provider["structuredContent"]["error"]
         .as_str()
         .unwrap()
         .contains("provider must be one of"));
+    assert!(mcp_content_text(hidden_provider).contains("provider must be one of"));
     let alias_result = &responses[3]["result"];
     assert_eq!(alias_result["isError"], true);
-    assert!(alias_result["content"][0]["text"]
+    assert!(alias_result["structuredContent"]["error"]
         .as_str()
         .unwrap()
         .contains("ctx store is not initialized"));
+    assert!(mcp_content_text(alias_result).contains("ctx store is not initialized"));
     assert!(
         !temp.path().join("work.sqlite").exists(),
         "invalid MCP search should fail before opening the ctx store"
@@ -5121,27 +5193,39 @@ fn mcp_sources_and_search_support_history_source_plugins() {
         )],
     );
 
-    let sources: Value = serde_json::from_str(
-        responses[1]["result"]["content"][0]["text"]
-            .as_str()
-            .unwrap(),
-    )
-    .unwrap();
-    assert!(sources["sources"]
+    let sources = responses[1]["result"]["structuredContent"]["sources"]
         .as_array()
-        .unwrap()
+        .unwrap();
+    assert!(sources
         .iter()
         .any(|source| source["history_source"] == "hermes/default"));
+    assert_useful_mcp_text(
+        &responses[1]["result"],
+        &[
+            "ctx sources",
+            "sources:",
+            "available:",
+            "importable:",
+            "custom",
+            "available",
+            "hermes/default",
+        ],
+    );
 
-    let search: Value = serde_json::from_str(
-        responses[2]["result"]["content"][0]["text"]
-            .as_str()
-            .unwrap(),
-    )
-    .unwrap();
+    let search = &responses[2]["result"]["structuredContent"];
     assert_eq!(search["filters"]["provider"], "custom");
     assert_eq!(search["filters"]["history_source"], "hermes/default");
     assert_eq!(search["results"][0]["history_source"], "hermes/default");
+    assert_useful_mcp_text(
+        &responses[2]["result"],
+        &[
+            "ctx search",
+            "query: hermes plugin initial marker",
+            "filters: provider=custom, history_source=hermes/default",
+            "hermes/default",
+            "snippet:",
+        ],
+    );
 }
 
 #[test]
@@ -5188,12 +5272,7 @@ fn mcp_search_excludes_active_codex_session_by_default_when_available() {
         ],
         &[("CODEX_THREAD_ID", "codex-session-root")],
     );
-    let excluded_search: Value = serde_json::from_str(
-        excluded[1]["result"]["content"][0]["text"]
-            .as_str()
-            .unwrap(),
-    )
-    .unwrap();
+    let excluded_search = &excluded[1]["result"]["structuredContent"];
     assert_eq!(excluded_search["results"].as_array().unwrap().len(), 0);
     assert_eq!(
         excluded_search["filters"]["exclude_provider_session"]["provider"],
@@ -5230,12 +5309,7 @@ fn mcp_search_excludes_active_codex_session_by_default_when_available() {
         ],
         &[("CODEX_THREAD_ID", "codex-session-root")],
     );
-    let included_search: Value = serde_json::from_str(
-        included[1]["result"]["content"][0]["text"]
-            .as_str()
-            .unwrap(),
-    )
-    .unwrap();
+    let included_search = &included[1]["result"]["structuredContent"];
     assert_eq!(included_search["results"].as_array().unwrap().len(), 1);
     assert!(included_search["filters"]["exclude_provider_session"].is_null());
 }

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -4610,7 +4610,12 @@ fn mcp_status_and_tools_list_are_read_only_without_initialized_store() {
     assert!(providers.iter().any(|provider| provider == "cline"));
     assert!(providers.iter().any(|provider| provider == "roo"));
     assert!(providers.iter().any(|provider| provider == "roo_code"));
-    let status = &responses[2]["result"]["structuredContent"];
+    let status: Value = serde_json::from_str(
+        responses[2]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
     assert_eq!(status["schema_version"], 1);
     assert_eq!(status["initialized"], false);
     assert_eq!(status["read_only"], true);
@@ -4743,7 +4748,12 @@ fn mcp_sql_tool_returns_structured_json_and_rejects_writes() {
         ],
     );
 
-    let sql = &responses[1]["result"]["structuredContent"];
+    let sql: Value = serde_json::from_str(
+        responses[1]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
     assert_eq!(sql["item_type"], "sql_result");
     assert_eq!(sql["read_only"], true);
     assert_eq!(sql["share_safe"], false);
@@ -4752,14 +4762,14 @@ fn mcp_sql_tool_returns_structured_json_and_rejects_writes() {
 
     let write = &responses[2]["result"];
     assert_eq!(write["isError"], true);
-    assert!(write["structuredContent"]["error"]
+    assert!(write["content"][0]["text"]
         .as_str()
         .unwrap()
         .contains("SQL query must be read-only"));
 
     let budget = &responses[3]["result"];
     assert_eq!(budget["isError"], true);
-    assert!(budget["structuredContent"]["error"]
+    assert!(budget["content"][0]["text"]
         .as_str()
         .unwrap()
         .contains("SQL result preview budget"));
@@ -4835,7 +4845,12 @@ fn mcp_show_session_caps_transcript_events() {
         ],
     );
 
-    let transcript = &responses[1]["result"]["structuredContent"];
+    let transcript: Value = serde_json::from_str(
+        responses[1]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
     assert_eq!(transcript["truncated"]["events"], true);
     assert_eq!(transcript["truncated"]["max_events"], 200);
     assert_eq!(transcript["events"].as_array().unwrap().len(), 200);
@@ -4885,16 +4900,17 @@ fn mcp_search_and_show_tools_return_structured_json_without_refresh() {
             }),
         ],
     );
-    let search = &search_responses[1]["result"]["structuredContent"];
+    let search: Value = serde_json::from_str(
+        search_responses[1]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
     assert_eq!(search["schema_version"], 1);
     assert_eq!(search["query"], "onboarding");
     assert_eq!(search["freshness"]["mode"], "off");
     assert_eq!(search["freshness"]["status"], "skipped");
     assert_eq!(search["share_safe"], false);
-    assert_eq!(
-        search_responses[1]["result"]["content"][0]["text"],
-        "ctx returned structured JSON in structuredContent. Treat it as private local history."
-    );
     let first_result = &search["results"][0];
     let ctx_session_id = first_result["ctx_session_id"].as_str().unwrap();
     let ctx_event_id = first_result["ctx_event_id"].as_str().unwrap();
@@ -4939,7 +4955,12 @@ fn mcp_search_and_show_tools_return_structured_json_without_refresh() {
         ],
     );
 
-    let session = &show_responses[1]["result"]["structuredContent"];
+    let session: Value = serde_json::from_str(
+        show_responses[1]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
     assert_eq!(session["item_type"], "session_transcript");
     assert_eq!(session["ctx_session_id"], ctx_session_id);
     assert_eq!(session["mode"], "lite");
@@ -4947,7 +4968,12 @@ fn mcp_search_and_show_tools_return_structured_json_without_refresh() {
         event["ctx_session_id"] == ctx_session_id && event["ctx_event_id"].is_string()
     }));
 
-    let event = &show_responses[2]["result"]["structuredContent"];
+    let event: Value = serde_json::from_str(
+        show_responses[2]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
     assert_eq!(event["item_type"], "event_window");
     assert_eq!(event["ctx_event_id"], ctx_event_id);
     assert_eq!(event["ctx_session_id"], ctx_session_id);
@@ -5013,19 +5039,19 @@ fn mcp_search_requires_query_term_or_file_without_opening_store() {
 
     let result = &responses[1]["result"];
     assert_eq!(result["isError"], true);
-    assert!(result["structuredContent"]["error"]
+    assert!(result["content"][0]["text"]
         .as_str()
         .unwrap()
         .contains("search needs a query or file"));
     let hidden_provider = &responses[2]["result"];
     assert_eq!(hidden_provider["isError"], true);
-    assert!(hidden_provider["structuredContent"]["error"]
+    assert!(hidden_provider["content"][0]["text"]
         .as_str()
         .unwrap()
         .contains("provider must be one of"));
     let alias_result = &responses[3]["result"];
     assert_eq!(alias_result["isError"], true);
-    assert!(alias_result["structuredContent"]["error"]
+    assert!(alias_result["content"][0]["text"]
         .as_str()
         .unwrap()
         .contains("ctx store is not initialized"));
@@ -5095,14 +5121,24 @@ fn mcp_sources_and_search_support_history_source_plugins() {
         )],
     );
 
-    let sources = responses[1]["result"]["structuredContent"]["sources"]
+    let sources: Value = serde_json::from_str(
+        responses[1]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
+    assert!(sources["sources"]
         .as_array()
-        .unwrap();
-    assert!(sources
+        .unwrap()
         .iter()
         .any(|source| source["history_source"] == "hermes/default"));
 
-    let search = &responses[2]["result"]["structuredContent"];
+    let search: Value = serde_json::from_str(
+        responses[2]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
     assert_eq!(search["filters"]["provider"], "custom");
     assert_eq!(search["filters"]["history_source"], "hermes/default");
     assert_eq!(search["results"][0]["history_source"], "hermes/default");
@@ -5152,7 +5188,12 @@ fn mcp_search_excludes_active_codex_session_by_default_when_available() {
         ],
         &[("CODEX_THREAD_ID", "codex-session-root")],
     );
-    let excluded_search = &excluded[1]["result"]["structuredContent"];
+    let excluded_search: Value = serde_json::from_str(
+        excluded[1]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
     assert_eq!(excluded_search["results"].as_array().unwrap().len(), 0);
     assert_eq!(
         excluded_search["filters"]["exclude_provider_session"]["provider"],
@@ -5189,7 +5230,12 @@ fn mcp_search_excludes_active_codex_session_by_default_when_available() {
         ],
         &[("CODEX_THREAD_ID", "codex-session-root")],
     );
-    let included_search = &included[1]["result"]["structuredContent"];
+    let included_search: Value = serde_json::from_str(
+        included[1]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
     assert_eq!(included_search["results"].as_array().unwrap().len(), 1);
     assert!(included_search["filters"]["exclude_provider_session"].is_null());
 }


### PR DESCRIPTION
## Summary

- MCP tool results now include useful text in `content[0].text` for clients and models that do not read `structuredContent`.
- The visible text is semantic and capped for token use across status, sources, search, SQL, session, and event-window results instead of dumping minified JSON.
- `structuredContent` is preserved unchanged for clients that consume machine-readable results.
- MCP server copy avoids privacy/compliance framing while still noting that local tool output may include paths, snippets, transcript text, and SQL results.

## Validation

- `cargo test -p ctx mcp_ --test cli`
- `cargo fmt --all -- --check`
- `git diff --check HEAD`