### PR TITLE
Polish installer setup UX

### DIFF
--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -1636,9 +1636,7 @@ struct ProgressLine {
 fn render_progress_line(line: &ProgressLine, elapsed: StdDuration) -> String {
     let percent = progress_percent(line.completed_bytes, line.total_bytes);
     let bar = progress_bar(percent, 20);
-    let eta = eta_seconds(line.completed_bytes, line.total_bytes, elapsed)
-        .map(format_seconds)
-        .unwrap_or_else(|| "estimating".to_owned());
+    let eta = eta_seconds(line.completed_bytes, line.total_bytes, elapsed).map(format_seconds);
     let files = match (line.completed_files, line.total_files) {
         (Some(done), Some(total)) if total > 0 => format!(" {done}/{total} files"),
         _ => String::new(),
@@ -1649,8 +1647,10 @@ fn render_progress_line(line: &ProgressLine, elapsed: StdDuration) -> String {
         .unwrap_or_default();
     let remaining = if line.done {
         "done".to_owned()
-    } else {
+    } else if let Some(eta) = eta {
         format!("{eta} left")
+    } else {
+        "working".to_owned()
     };
     format!(
         "{:<10} [{}] {:>5.1}% {}/{}{}{} {} - {}",
@@ -2003,7 +2003,7 @@ fn run_setup(
             ImportRunOptions {
                 progress: args.progress,
                 json: args.json,
-                print_human: !args.json,
+                print_human: false,
                 allow_empty_sources: true,
                 include_history_source_plugins: false,
                 operation: "setup",
@@ -2050,32 +2050,35 @@ fn run_setup(
             catalog_counts.pending,
             indexed_items,
         );
-        println!("data_root: {}", data_root.display());
-        println!("database_path: {}", db_path.display());
-        println!("config_path: {}", config_path.display());
-        println!("indexed_items: {indexed_items}");
-        println!("cataloged_sessions: {}", catalog.cataloged_sessions);
-        println!("cached_catalog_sessions: {}", catalog.cached_sessions);
-        println!("parsed_catalog_sessions: {}", catalog.parsed_sessions);
-        println!("indexed_catalog_sessions: {}", catalog_counts.indexed);
-        println!("pending_catalog_sessions: {}", catalog_counts.pending);
-        println!("failed_catalog_sessions: {}", catalog_counts.failed);
-        println!("stale_catalog_sessions: {}", catalog_counts.stale);
-        println!("catalog_source_files: {}", catalog.source_files);
-        println!("catalog_source_bytes: {}", catalog.source_bytes);
-        if let Some(report) = &import_report {
-            println!("imported_sources: {}", report.totals.imported_sources);
-            println!("failed_sources: {}", report.totals.failed_sources);
-            println!("imported_sessions: {}", report.totals.imported_sessions);
-            println!("imported_events: {}", report.totals.imported_events);
-            println!("imported_edges: {}", report.totals.imported_edges);
+        if !setup_has_indexed_content(indexed_items) && catalog.cataloged_sessions > 0 {
+            println!("Cataloged {} session(s).", catalog.cataloged_sessions);
         }
-        println!("next_steps:");
+        if let Some(report) = &import_report {
+            if report.totals.imported_sources > 0
+                || report.totals.imported_sessions > 0
+                || report.totals.imported_events > 0
+            {
+                println!(
+                    "Imported {} session(s), {} event(s) from {} source(s).",
+                    report.totals.imported_sessions,
+                    report.totals.imported_events,
+                    report.totals.imported_sources
+                );
+            }
+            if report.totals.failed_sources > 0 {
+                println!("Skipped {} source(s).", report.totals.failed_sources);
+            }
+        }
+        println!("Data: {}", data_root.display());
+        println!();
+        println!("Get started:");
         if args.catalog_only {
             println!("  ctx import --all");
             println!("  ctx sources");
         } else if setup_has_indexed_content(indexed_items) {
-            println!("  ctx search \"what failed before\"");
+            println!("  ctx search \"test failure\"");
+            println!("  ctx show event <event-id> --window 3");
+            println!("  ctx show session <session-id>");
             println!("  ctx sources");
             if setup_has_failed_sources(import_report.as_ref()) {
                 println!("  ctx import --provider <provider>");

--- a/crates/ctx-cli/src/skill.rs
+++ b/crates/ctx-cli/src/skill.rs
@@ -988,7 +988,24 @@ fn remove_existing_target(path: &Path) -> Result<()> {
 }
 
 fn print_install_results(results: &[InstallResult]) {
-    println!("ctx skill install: {BUNDLED_SKILL_NAME}");
+    let all_success = !results.is_empty() && results.iter().all(|result| result.success);
+    let all_current = all_success && results.iter().all(|result| result.already_installed);
+    let any_updated = results
+        .iter()
+        .any(|result| result.success && result.updated);
+    let any_installed = results
+        .iter()
+        .any(|result| result.success && !result.already_installed && !result.updated);
+    let heading = if all_current {
+        "Agent skill already installed"
+    } else if all_success && any_updated && !any_installed {
+        "Agent skill updated"
+    } else if all_success {
+        "Agent skill installed"
+    } else {
+        "Agent skill"
+    };
+    println!("{heading}: {BUNDLED_SKILL_NAME}");
     for result in results {
         let verb = if result.already_installed {
             "current"
@@ -1002,15 +1019,9 @@ fn print_install_results(results: &[InstallResult]) {
         let detail = result
             .error
             .as_deref()
-            .map(|error| format!(": {error}"))
+            .map(|error| format!(" - {error}"))
             .unwrap_or_default();
-        println!(
-            "  {verb}: {} ({}) -> {}{}",
-            result.target.agent.display_name(),
-            result.target.scope.as_str(),
-            result.target.skill_dir.display(),
-            detail
-        );
+        println!("  {verb}: {}{}", result.target.agent.display_name(), detail);
     }
 }
 

--- a/crates/ctx-cli/tests/cli.rs
+++ b/crates/ctx-cli/tests/cli.rs
@@ -1040,6 +1040,8 @@ fn setup_catalog_only_catalogs_codex_sessions_without_import() {
         .clone();
     let human_setup = String::from_utf8(human_setup).unwrap();
     assert!(human_setup.contains("ctx catalog is ready; import is still pending"));
+    assert!(human_setup.contains("Cataloged 1 session(s)."));
+    assert!(human_setup.contains("Get started:"));
     assert!(human_setup.contains("  ctx import --all"));
     assert!(!human_setup.contains("ctx search \"what failed before\""));
 }
@@ -1091,8 +1093,11 @@ fn setup_imports_discovered_codex_sessions_by_default() {
         .clone();
     let human_setup = String::from_utf8(human_setup).unwrap();
     assert!(human_setup.contains("ctx local agent history search is ready"));
-    assert!(human_setup.contains("imported_sources: 1"));
-    assert!(human_setup.contains("  ctx search \"what failed before\""));
+    assert!(human_setup.contains("Get started:"));
+    assert!(human_setup.contains("  ctx search \"test failure\""));
+    assert!(human_setup.contains("  ctx show event <event-id> --window 3"));
+    assert!(human_setup.contains("  ctx show session <session-id>"));
+    assert!(!human_setup.contains("ctx search \"what failed before\""));
 }
 
 #[test]
@@ -9975,6 +9980,20 @@ fn local_transcript_oracle_preserves_cli_json_and_sqlite() {
 #[test]
 fn skill_install_defaults_to_global_canonical_agents_dir_and_is_idempotent() {
     let temp = tempdir();
+
+    let human_temp = tempdir();
+    let human = ctx(&human_temp)
+        .env("CODEX_HOME", human_temp.path().join("missing-codex"))
+        .args(["skill", "install"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let human = String::from_utf8(human).unwrap();
+    assert!(human.contains("Agent skill installed: ctx-agent-history-search"));
+    assert!(human.contains("  installed: Universal .agents"));
+    assert!(!human.contains(" -> "));
 
     let first = json_output(
         ctx(&temp)

--- a/scripts/install-path-smoke.sh
+++ b/scripts/install-path-smoke.sh
@@ -109,12 +109,19 @@ metadata="${tmp_dir}/metadata.env"
 base_env=(CURL_CA_BUNDLE="${tmp_dir}/cert.pem" CTX_INSTALL_NO_MAN=1)
 installer=(bash "${repo_root}/scripts/install.sh" --metadata "${metadata}" --platform linux-x64)
 
+home_dry_run="${tmp_dir}/home-dry-run"
+mkdir -p "${home_dry_run}"
+env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_dry_run}" SHELL="/bin/bash" "${installer[@]}" --dry-run --no-setup > "${tmp_dir}/dry-run.out"
+grep -F 'Dry run: would install ctx 0.0.0-smoke (linux-x64)' "${tmp_dir}/dry-run.out" >/dev/null
+! grep -F 'Installing ctx 0.0.0-smoke (linux-x64)' "${tmp_dir}/dry-run.out" >/dev/null
+! grep -F 'Installed ctx binary.' "${tmp_dir}/dry-run.out" >/dev/null
+
 home_idem="${tmp_dir}/home-idem"
 mkdir -p "${home_idem}"
 env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_idem}" SHELL="/bin/bash" "${installer[@]}" --no-setup > "${tmp_dir}/idem-1.out"
 env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_idem}" SHELL="/bin/bash" "${installer[@]}" --no-setup > "${tmp_dir}/idem-2.out"
 test "$(grep -c 'ctx installer PATH setup' "${home_idem}/.bashrc")" = 1
-grep -F 'found existing PATH setup' "${tmp_dir}/idem-2.out" >/dev/null
+grep -F 'Found existing PATH setup' "${tmp_dir}/idem-2.out" >/dev/null
 
 home_on_path="${tmp_dir}/home-on-path"
 mkdir -p "${home_on_path}"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -94,7 +94,7 @@ function Format-CurrentPathCommand([string]$Directory) {
 }
 
 function Write-CurrentPathCommand([string]$Directory) {
-    Write-Host "for this PowerShell session, run:"
+    Write-Host "For this PowerShell session, run:"
     Write-Host ("  " + (Format-CurrentPathCommand $Directory))
 }
 
@@ -105,7 +105,8 @@ function Add-InstallDirToPathIfNeeded([string]$Directory, [bool]$ModifyPath) {
     }
 
     if (-not $ModifyPath) {
-        Write-Host "$dir is not on PATH; user PATH update skipped"
+        Write-Host ""
+        Write-Host "$dir is not on PATH; user PATH update skipped."
         Write-CurrentPathCommand $dir
         return
     }
@@ -115,20 +116,23 @@ function Add-InstallDirToPathIfNeeded([string]$Directory, [bool]$ModifyPath) {
         if (-not (Test-PathContainsDirectory -PathValue $env:Path -Directory $dir)) {
             $env:Path = "$dir$([System.IO.Path]::PathSeparator)$env:Path"
         }
-        Write-Host "added $dir to GITHUB_PATH for later GitHub Actions steps"
+        Write-Host ""
+        Write-Host "Added $dir to GITHUB_PATH for later GitHub Actions steps."
         return
     }
 
     if ($env:CI -eq "1" -or $env:CI -eq "true") {
         $env:Path = "$dir$([System.IO.Path]::PathSeparator)$env:Path"
-        Write-Host "$dir is not on PATH; CI detected, not editing the user PATH"
+        Write-Host ""
+        Write-Host "$dir is not on PATH; CI detected, not editing the user PATH."
         Write-CurrentPathCommand $dir
         return
     }
 
     $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    Write-Host ""
     if (Test-PathContainsDirectory -PathValue $userPath -Directory $dir) {
-        Write-Host "found existing user PATH setup for $dir"
+        Write-Host "Found existing user PATH setup for $dir."
     } else {
         if ([string]::IsNullOrWhiteSpace($userPath)) {
             $newUserPath = $dir
@@ -137,7 +141,7 @@ function Add-InstallDirToPathIfNeeded([string]$Directory, [bool]$ModifyPath) {
         }
         try {
             [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
-            Write-Host "added $dir to the user PATH"
+            Write-Host "Added $dir to the user PATH."
         } catch {
             Write-Warning "could not update the user PATH: $($_.Exception.Message)"
         }
@@ -149,11 +153,11 @@ function Add-InstallDirToPathIfNeeded([string]$Directory, [bool]$ModifyPath) {
         $updatedCurrentPath = $true
     }
     if ($updatedCurrentPath) {
-        Write-Host "$dir was not on PATH at startup; this PowerShell session has been updated"
+        Write-Host "$dir was not on PATH at startup; this PowerShell session has been updated."
     }
-    Write-Host "open a new PowerShell window or run:"
+    Write-Host "Open a new PowerShell window or run:"
     Write-Host ("  " + (Format-CurrentPathCommand $dir))
-    Write-Host "then verify with:"
+    Write-Host "Then verify with:"
     Write-Host "  ctx status"
 }
 
@@ -247,22 +251,27 @@ try {
     }
     $modifyPath = -not $NoModifyPath -and $env:CTX_INSTALL_NO_MODIFY_PATH -ne "1"
 
-    Write-Host "ctx install plan: version=$version platform=$Platform artifact=$artifact bin=$installPath"
-    if (-not (Test-PathContainsDirectory -PathValue $env:Path -Directory $BinDir)) {
-        if ($modifyPath) {
-            Write-Host "ctx PATH plan: add $BinDir to the user PATH when installing"
-        } else {
-            Write-Host "ctx PATH plan: do not update the user PATH"
-        }
+    if ($DryRun) {
+        Write-Host "Dry run: would install ctx $version ($Platform)"
+    } else {
+        Write-Host "Installing ctx $version ($Platform)"
     }
+    Write-Host "  binary: $installPath"
     if ($runSkill) {
         if ($allSkillAgentsRequested) {
-            Write-Host "ctx skill plan: install bundled skill for all supported agents"
+            Write-Host "  skill: all supported agents"
         } elseif ($skillAgents.Count -gt 0) {
-            Write-Host ("ctx skill plan: install bundled skill for agents=" + ($skillAgents -join ","))
+            Write-Host ("  skill: " + ($skillAgents -join ","))
         } else {
-            Write-Host "ctx skill plan: install universal skill plus detected agent-specific folders"
+            Write-Host "  skill: universal + detected agent folders"
         }
+    } else {
+        Write-Host "  skill: skipped"
+    }
+    if ($runSetup) {
+        Write-Host "  history: index discovered sessions"
+    } else {
+        Write-Host "  history: skipped"
     }
     if ($DryRun) {
         exit 0
@@ -280,7 +289,6 @@ try {
 
     New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
     Copy-Item -LiteralPath $downloadPath -Destination $installPath -Force
-    Write-Host "installed ctx to $installPath"
 
     $markerPath = "$installPath.install.json"
     $marker = [ordered]@{
@@ -300,7 +308,8 @@ try {
     $markerJson = $marker | ConvertTo-Json -Depth 4
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
     [System.IO.File]::WriteAllText($markerPath, $markerJson + [Environment]::NewLine, $utf8NoBom)
-    Write-Host "wrote ctx managed install marker to $markerPath"
+    Write-Host ""
+    Write-Host "Installed ctx binary."
 
     if ($runSkill) {
         $skillArgs = @("skill", "install")
@@ -311,13 +320,14 @@ try {
                 $skillArgs += @("--agent", $agent)
             }
         }
-        Write-Host "installing ctx agent skill (pass -NoSkill or set CTX_INSTALL_NO_SKILL=1 to skip next time)"
+        Write-Host ""
         & $installPath @skillArgs
         if ($LASTEXITCODE -ne 0) {
             Write-Warning "ctx skill install failed after install; run $installPath skill install to retry"
         }
     } else {
-        Write-Host "skill setup skipped; run $installPath skill install to install the bundled agent skill"
+        Write-Host ""
+        Write-Host "Agent skill skipped. Run $installPath skill install to install it later."
     }
 
     $setupStatus = 0
@@ -329,14 +339,16 @@ try {
                 $SetupProgress = $env:CTX_SETUP_PROGRESS
             }
         }
-        Write-Host "running ctx setup to index local history (pass -NoSetup or set CTX_INSTALL_NO_SETUP=1 to skip next time)"
+        Write-Host ""
+        Write-Host "Indexing local agent history..."
         & $installPath setup --progress $SetupProgress
         if ($LASTEXITCODE -ne 0) {
             $setupStatus = $LASTEXITCODE
             Write-Warning "ctx setup failed after install; run $installPath setup --progress $SetupProgress to retry"
         }
     } else {
-        Write-Host "setup skipped; run $installPath setup to index local history"
+        Write-Host ""
+        Write-Host "Setup skipped. Run $installPath setup to index local history."
     }
 
     Add-InstallDirToPathIfNeeded -Directory $BinDir -ModifyPath $modifyPath

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -319,38 +319,39 @@ configure_path_if_needed() {
   fi
 
   if (( ! modify_path )); then
-    printf '%s is not on PATH; shell startup file update skipped\n' "${dir}"
-    printf 'for this shell session, run:\n'
+    printf '\n%s is not on PATH; shell startup file update skipped.\n' "${dir}"
+    printf 'For this shell session, run:\n'
     print_current_path_command "${shell_name}" "${dir}"
     return 0
   fi
 
   if [[ -n "${GITHUB_PATH:-}" ]]; then
     printf '%s\n' "${dir}" >> "${GITHUB_PATH}"
-    printf 'added %s to GITHUB_PATH for later GitHub Actions steps\n' "${dir}"
+    printf '\nAdded %s to GITHUB_PATH for later GitHub Actions steps.\n' "${dir}"
     return 0
   fi
 
   if [[ "${CI:-}" == "1" || "${CI:-}" == "true" ]]; then
-    printf '%s is not on PATH; CI detected, not editing shell startup files\n' "${dir}"
-    printf 'for this shell session, run:\n'
+    printf '\n%s is not on PATH; CI detected, not editing shell startup files.\n' "${dir}"
+    printf 'For this shell session, run:\n'
     print_current_path_command "${shell_name}" "${dir}"
     return 0
   fi
 
   if ! profile="$(path_setup_profile "${shell_name}")"; then
-    printf '%s is not on PATH; HOME is unavailable, so no shell startup file was updated\n' "${dir}"
-    printf 'for this shell session, run:\n'
+    printf '\n%s is not on PATH; HOME is unavailable, so no shell startup file was updated.\n' "${dir}"
+    printf 'For this shell session, run:\n'
     print_current_path_command "${shell_name}" "${dir}"
     return 0
   fi
 
+  printf '\n'
   if profile_contains_path_setup "${profile}" "${dir}"; then
-    printf 'found existing PATH setup for %s in %s\n' "${dir}" "${profile}"
+    printf 'Found existing PATH setup for %s in %s.\n' "${dir}" "${profile}"
   else
     profile_dir="$(dirname "${profile}")"
     if mkdir -p "${profile_dir}" && path_setup_snippet "${shell_name}" "${dir}" >> "${profile}"; then
-      printf 'added ctx PATH setup to %s\n' "${profile}"
+      printf 'Added ctx PATH setup to %s.\n' "${profile}"
     else
       printf 'warning: could not update shell startup file %s\n' "${profile}" >&2
     fi
@@ -358,7 +359,7 @@ configure_path_if_needed() {
 
   printf '%s is not on the current PATH; restart your shell or run:\n' "${dir}"
   print_current_path_command "${shell_name}" "${dir}"
-  printf 'then verify with:\n'
+  printf 'Then verify with:\n'
   printf '  ctx status\n'
 }
 
@@ -528,12 +529,14 @@ fi
 if [[ -n "${CTX_INSTALL_SKILL_AGENTS:-}" ]]; then
   explicit_skill_request=1
   IFS=',' read -r -a env_skill_agents <<< "${CTX_INSTALL_SKILL_AGENTS}"
-  for agent in "${env_skill_agents[@]}"; do
-    agent="${agent//[[:space:]]/}"
-    if [[ -n "${agent}" ]]; then
-      skill_agents+=("${agent}")
-    fi
-  done
+  if ((${#env_skill_agents[@]} > 0)); then
+    for agent in "${env_skill_agents[@]}"; do
+      agent="${agent//[[:space:]]/}"
+      if [[ -n "${agent}" ]]; then
+        skill_agents+=("${agent}")
+      fi
+    done
+  fi
 fi
 
 if [[ "${CTX_INSTALL_NO_SKILL:-0}" == "1" ]]; then
@@ -553,27 +556,28 @@ if ((! run_setup && ! explicit_skill_request)); then
   run_skill=0
 fi
 
-printf 'ctx install plan: version=%s platform=%s artifact=%s bin=%s\n' \
-  "${version}" "${platform}" "${artifact}" "${install_path}"
-if ((install_man)); then
-  printf 'ctx man page plan: dir=%s\n' "${man_dir}"
-fi
-if path_contains_dir "${bin_dir%/}"; then
-  :
-elif ((modify_path)); then
-  printf 'ctx PATH plan: add %s to shell startup files when installing\n' "${bin_dir%/}"
+if ((dry_run)); then
+  printf 'Dry run: would install ctx %s (%s)\n' "${version}" "${platform}"
 else
-  printf 'ctx PATH plan: do not update shell startup files\n'
+  printf 'Installing ctx %s (%s)\n' "${version}" "${platform}"
 fi
+printf '  binary: %s\n' "${install_path}"
 if ((run_skill)); then
   if ((all_skill_agents)); then
-    printf 'ctx skill plan: install bundled skill for all supported agents\n'
+    printf '  skill: all supported agents\n'
   elif ((${#skill_agents[@]} > 0)); then
     skill_agent_list="$(IFS=,; printf '%s' "${skill_agents[*]}")"
-    printf 'ctx skill plan: install bundled skill for agents=%s\n' "${skill_agent_list}"
+    printf '  skill: %s\n' "${skill_agent_list}"
   else
-    printf 'ctx skill plan: install universal skill plus detected agent-specific folders\n'
+    printf '  skill: universal + detected agent folders\n'
   fi
+else
+  printf '  skill: skipped\n'
+fi
+if ((run_setup)); then
+  printf '  history: index discovered sessions\n'
+else
+  printf '  history: skipped\n'
 fi
 
 if ((dry_run)); then
@@ -588,40 +592,39 @@ fi
 
 mkdir -p "${bin_dir}"
 install -m 0755 "${download_path}" "${install_path}"
-printf 'installed ctx to %s\n' "${install_path}"
 
 write_install_marker "${install_path}.install.json" "${metadata_source}" "${source_commit}" "${published_at}"
-printf 'wrote ctx managed install marker to %s\n' "${install_path}.install.json"
 
 if ((install_man)); then
   mkdir -p "${man_dir}"
-  if "${install_path}" docs man --out "${man_dir}"; then
-    printf 'installed ctx man pages to %s\n' "${man_dir}"
+  if "${install_path}" docs man --out "${man_dir}" >/dev/null; then
+    :
   else
     printf 'warning: failed to install ctx man pages to %s\n' "${man_dir}" >&2
   fi
 fi
+printf '\nInstalled ctx binary.\n'
 
 if ((run_skill)); then
   skill_args=(skill install)
   if ((all_skill_agents)); then
     skill_args+=(--all-agents)
-  else
+  elif ((${#skill_agents[@]} > 0)); then
     for agent in "${skill_agents[@]}"; do
       skill_args+=(--agent "${agent}")
     done
   fi
-  printf 'installing ctx agent skill (pass --no-skill or set CTX_INSTALL_NO_SKILL=1 to skip next time)\n'
+  printf '\n'
   if ! "${install_path}" "${skill_args[@]}"; then
     printf 'warning: ctx skill install failed after install; run %s skill install to retry\n' "${install_path}" >&2
   fi
 else
-  printf 'skill setup skipped; run %s skill install to install the bundled agent skill\n' "${install_path}"
+  printf '\nAgent skill skipped. Run %s skill install to install it later.\n' "${install_path}"
 fi
 
 if ((run_setup)); then
   setup_progress="${CTX_SETUP_PROGRESS:-auto}"
-  printf 'running ctx setup to index local history (pass --no-setup or set CTX_INSTALL_NO_SETUP=1 to skip next time)\n'
+  printf '\nIndexing local agent history...\n'
   setup_status=0
   if "${install_path}" setup --progress "${setup_progress}"; then
     :
@@ -631,7 +634,7 @@ if ((run_setup)); then
   fi
 else
   setup_status=0
-  printf 'setup skipped; run %s setup to index local history\n' "${install_path}"
+  printf '\nSetup skipped. Run %s setup to index local history.\n' "${install_path}"
 fi
 
 configure_path_if_needed


### PR DESCRIPTION
## Summary

- tighten `install.sh` / `install.ps1` stdout around install plan, binary install, skill setup, history indexing, and PATH follow-up
- make `ctx setup` human output focus on readiness, import totals, data location, and simple get-started commands
- make `ctx skill install` human output concise and path-free by default
- add/adjust CLI and installer smoke assertions for the new output

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p ctx --test cli setup_`
- `cargo test -p ctx --test cli skill_install_defaults_to_global_canonical_agents_dir_and_is_idempotent`
- `bash scripts/install-path-smoke.sh`
- `cargo check --workspace`
- `bash scripts/check-docs.sh`
- `cargo build -p ctx`
- Linux full installer smoke with real `target/debug/ctx`, HTTPS artifact server, isolated home/data root, and tiny Codex fixture
- Windows VM installer smoke with real `ctx.exe`, HTTPS artifact server, isolated home/data root, and tiny Codex fixture
- macOS VM installer script smoke with HTTPS artifact stub to validate Bash 3.2/path/output behavior; Linux host cannot cross-link a real macOS binary
