### PR TITLE
feat(cli): add --quiet flag to suppress non-essential output

### DIFF
--- a/crates/ctx-cli/src/commands/setup.rs
+++ b/crates/ctx-cli/src/commands/setup.rs
@@ -26,6 +26,7 @@ pub(crate) fn run_setup(
     args: SetupArgs,
     data_root: PathBuf,
     analytics_properties: &mut AnalyticsProperties,
+    quiet: bool,
 ) -> Result<()> {
     fs::create_dir_all(&data_root)?;
     let db_path = database_path(data_root.clone());
@@ -133,42 +134,44 @@ pub(crate) fn run_setup(
             catalog_counts.pending,
             indexed_items,
         );
-        if !setup_has_indexed_content(indexed_items) && catalog.cataloged_sessions > 0 {
-            println!("Cataloged {} session(s).", catalog.cataloged_sessions);
-        }
-        if let Some(report) = &import_report {
-            if report.totals.imported_sources > 0
-                || report.totals.imported_sessions > 0
-                || report.totals.imported_events > 0
-            {
-                println!(
-                    "Imported {} session(s), {} event(s) from {} source(s).",
-                    report.totals.imported_sessions,
-                    report.totals.imported_events,
-                    report.totals.imported_sources
-                );
+        if !quiet {
+            if !setup_has_indexed_content(indexed_items) && catalog.cataloged_sessions > 0 {
+                println!("Cataloged {} session(s).", catalog.cataloged_sessions);
             }
-            if report.totals.failed_sources > 0 {
-                println!("Skipped {} source(s).", report.totals.failed_sources);
+            if let Some(report) = &import_report {
+                if report.totals.imported_sources > 0
+                    || report.totals.imported_sessions > 0
+                    || report.totals.imported_events > 0
+                {
+                    println!(
+                        "Imported {} session(s), {} event(s) from {} source(s).",
+                        report.totals.imported_sessions,
+                        report.totals.imported_events,
+                        report.totals.imported_sources
+                    );
+                }
+                if report.totals.failed_sources > 0 {
+                    println!("Skipped {} source(s).", report.totals.failed_sources);
+                }
             }
-        }
-        println!("Data: {}", data_root.display());
-        println!();
-        println!("Get started:");
-        if args.catalog_only {
-            println!("  ctx import --all");
-            println!("  ctx sources");
-        } else if setup_has_indexed_content(indexed_items) {
-            println!("  ctx search \"test failure\"");
-            println!("  ctx show event <event-id> --window 3");
-            println!("  ctx show session <session-id>");
-            println!("  ctx sources");
-            if setup_has_failed_sources(import_report.as_ref()) {
-                println!("  ctx import --provider <provider>");
+            println!("Data: {}", data_root.display());
+            println!();
+            println!("Get started:");
+            if args.catalog_only {
+                println!("  ctx import --all");
+                println!("  ctx sources");
+            } else if setup_has_indexed_content(indexed_items) {
+                println!("  ctx search \"test failure\"");
+                println!("  ctx show event <event-id> --window 3");
+                println!("  ctx show session <session-id>");
+                println!("  ctx sources");
+                if setup_has_failed_sources(import_report.as_ref()) {
+                    println!("  ctx import --provider <provider>");
+                }
+            } else {
+                println!("  ctx sources");
+                println!("  ctx import --all");
             }
-        } else {
-            println!("  ctx sources");
-            println!("  ctx import --all");
         }
     }
     Ok(())

--- a/crates/ctx-cli/src/commands/setup.rs
+++ b/crates/ctx-cli/src/commands/setup.rs
@@ -18,7 +18,7 @@ use crate::commands::import::{
 };
 use crate::config::CONFIG_FILE;
 use crate::output::print_json;
-use crate::progress::ProgressReporter;
+use crate::progress::{ProgressArg, ProgressReporter};
 use crate::provider_sources::{discovered_sources, sources_json, SourceInfo};
 use crate::{analytics, config, ImportArgs, SetupArgs};
 
@@ -34,7 +34,8 @@ pub(crate) fn run_setup(
     let config_path = data_root.join(CONFIG_FILE);
     config::write_default_config(&data_root)?;
     let sources = discovered_sources();
-    let progress = ProgressReporter::new(args.progress, args.json, "setup", 0);
+    let progress_arg = setup_progress_arg(args.progress, quiet);
+    let progress = ProgressReporter::new(progress_arg, args.json, "setup", 0);
     progress.message("cataloging", "cataloging discovered Codex sessions");
     let (catalog, catalog_sources) = catalog_available_sources(&store, &sources)?;
     progress.done(
@@ -78,14 +79,14 @@ pub(crate) fn run_setup(
             resume: false,
             partial: false,
             json: args.json,
-            progress: args.progress,
+            progress: progress_arg,
         };
         Some(run_import_internal(
             &import_args,
             data_root.clone(),
             analytics_properties,
             ImportRunOptions {
-                progress: args.progress,
+                progress: progress_arg,
                 json: args.json,
                 print_human: false,
                 allow_empty_sources: true,
@@ -128,13 +129,13 @@ pub(crate) fn run_setup(
         }))?;
     } else {
         progress.finish_line();
-        print_setup_status_line(
-            import_report.as_ref(),
-            args.catalog_only,
-            catalog_counts.pending,
-            indexed_items,
-        );
         if !quiet {
+            print_setup_status_line(
+                import_report.as_ref(),
+                args.catalog_only,
+                catalog_counts.pending,
+                indexed_items,
+            );
             if !setup_has_indexed_content(indexed_items) && catalog.cataloged_sessions > 0 {
                 println!("Cataloged {} session(s).", catalog.cataloged_sessions);
             }
@@ -175,6 +176,14 @@ pub(crate) fn run_setup(
         }
     }
     Ok(())
+}
+
+fn setup_progress_arg(progress: ProgressArg, quiet: bool) -> ProgressArg {
+    if quiet && progress == ProgressArg::Auto {
+        ProgressArg::None
+    } else {
+        progress
+    }
 }
 
 pub(crate) fn setup_import_json(report: Option<&ImportReport>) -> Value {

--- a/crates/ctx-cli/src/commands/status.rs
+++ b/crates/ctx-cli/src/commands/status.rs
@@ -10,7 +10,11 @@ use crate::output::print_json;
 use crate::store_util::open_existing_store_snapshot_read_only;
 use crate::JsonArgs;
 
-pub(crate) fn run_status(args: JsonArgs, data_root: PathBuf) -> Result<()> {
+pub(crate) fn run_status(
+    args: JsonArgs,
+    data_root: PathBuf,
+    quiet: bool,
+) -> Result<()> {
     let db_path = database_path(data_root.clone());
     let initialized = db_path.exists();
     let config_path = data_root.join(CONFIG_FILE);
@@ -47,7 +51,7 @@ pub(crate) fn run_status(args: JsonArgs, data_root: PathBuf) -> Result<()> {
             "local_only": true,
             "read_only": true,
         }))?;
-    } else {
+    } else if !quiet {
         println!("data_root: {}", data_root.display());
         println!("database_path: {}", db_path.display());
         println!("config_path: {}", config_path.display());

--- a/crates/ctx-cli/src/commands/status.rs
+++ b/crates/ctx-cli/src/commands/status.rs
@@ -10,11 +10,7 @@ use crate::output::print_json;
 use crate::store_util::open_existing_store_snapshot_read_only;
 use crate::JsonArgs;
 
-pub(crate) fn run_status(
-    args: JsonArgs,
-    data_root: PathBuf,
-    quiet: bool,
-) -> Result<()> {
+pub(crate) fn run_status(args: JsonArgs, data_root: PathBuf, quiet: bool) -> Result<()> {
     let db_path = database_path(data_root.clone());
     let initialized = db_path.exists();
     let config_path = data_root.join(CONFIG_FILE);

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -1,4 +1,5 @@
 use std::{
+    env,
     path::PathBuf,
     time::{Duration as StdDuration, Instant},
 };
@@ -77,6 +78,12 @@ const DEFAULT_VISIBLE_SOURCE_PROVIDERS: &[CaptureProvider] = &[
 struct Cli {
     #[arg(long, env = "CTX_DATA_ROOT", global = true)]
     data_root: Option<PathBuf>,
+    #[arg(
+        long,
+        global = true,
+        help = "Suppress non-essential setup/status output (also via CTX_QUIET=1)"
+    )]
+    quiet: bool,
     #[command(subcommand)]
     command: CommandRoot,
 }
@@ -508,6 +515,7 @@ fn main() -> Result<()> {
     let json_output = cli.command.json_output();
     let allow_background_upgrade = cli.command.allows_background_upgrade();
     let mut analytics_properties = command_analytics_properties(&cli.command);
+    let quiet = quiet_output(cli.quiet);
     let data_root = cli
         .data_root
         .clone()
@@ -530,8 +538,10 @@ fn main() -> Result<()> {
     }
 
     let result = match cli.command {
-        CommandRoot::Setup(args) => run_setup(args, data_root.clone(), &mut analytics_properties),
-        CommandRoot::Status(args) => run_status(args, data_root.clone()),
+        CommandRoot::Setup(args) => {
+            run_setup(args, data_root.clone(), &mut analytics_properties, quiet)
+        }
+        CommandRoot::Status(args) => run_status(args, data_root.clone(), quiet),
         CommandRoot::Sources(args) => {
             run_sources(args, data_root.clone(), &mut analytics_properties)
         }

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -731,6 +731,20 @@ fn parse_search_limit(value: &str) -> std::result::Result<usize, String> {
     Ok(limit)
 }
 
+fn quiet_output(flag: bool) -> bool {
+    flag || env_truthy("CTX_QUIET")
+}
+
+fn env_truthy(key: &str) -> bool {
+    env::var_os(key).is_some_and(|value| {
+        let value = value.to_string_lossy();
+        !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        )
+    })
+}
+
 fn parse_event_window_limit(value: &str) -> std::result::Result<usize, String> {
     let limit = value
         .parse::<usize>()

--- a/crates/ctx-cli/tests/setup_sources_import.rs
+++ b/crates/ctx-cli/tests/setup_sources_import.rs
@@ -2,6 +2,25 @@ mod support;
 
 use support::*;
 
+fn write_codex_setup_session(temp: &TempDir) {
+    let sessions = temp
+        .path()
+        .join(".codex")
+        .join("sessions")
+        .join("2026/06/24");
+    fs::create_dir_all(&sessions).unwrap();
+    fs::write(
+        sessions.join("rollout-2026-06-24T10-00-00-codex-session-setup.jsonl"),
+        concat!(
+            r#"{"timestamp":"2026-06-24T10:00:00.000Z","type":"session_meta","payload":{"id":"codex-session-setup","timestamp":"2026-06-24T10:00:00.000Z","cwd":"/repo/app","originator":"codex-cli","cli_version":"0.200.0","source":"cli","model_provider":"openai"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-06-24T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"setup should import"}]}}"#,
+            "\n"
+        ),
+    )
+    .unwrap();
+}
+
 #[test]
 fn setup_does_not_migrate_legacy_shim_directory() {
     let temp = tempdir();
@@ -274,24 +293,80 @@ fn setup_catalog_only_catalogs_codex_sessions_without_import() {
 }
 
 #[test]
+fn quiet_setup_suppresses_success_output_but_not_json() {
+    let temp = tempdir();
+    ctx(&temp)
+        .args(["--quiet", "setup", "--catalog-only"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    let temp = tempdir();
+    ctx(&temp)
+        .args(["setup", "--quiet", "--catalog-only", "--progress", "none"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    let temp = tempdir();
+    ctx(&temp)
+        .args(["setup", "--catalog-only", "--progress", "none"])
+        .env("CTX_QUIET", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    let temp = tempdir();
+    let setup = json_output(ctx(&temp).args([
+        "--quiet",
+        "setup",
+        "--catalog-only",
+        "--json",
+        "--progress",
+        "none",
+    ]));
+    assert_eq!(setup["schema_version"], 1);
+    assert_eq!(setup["mode"], "catalog_only");
+}
+
+#[test]
+fn quiet_status_suppresses_success_output_but_not_json() {
+    let temp = tempdir();
+    ctx(&temp)
+        .args(["--quiet", "status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    ctx(&temp)
+        .args(["status", "--quiet"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    ctx(&temp)
+        .arg("status")
+        .env("CTX_QUIET", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    ctx(&temp)
+        .arg("status")
+        .env("CTX_QUIET", "0")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("initialized: false"));
+
+    let status = json_output(ctx(&temp).args(["--quiet", "status", "--json"]));
+    assert_eq!(status["schema_version"], 1);
+    assert_eq!(status["initialized"], false);
+}
+
+#[test]
 fn setup_imports_discovered_codex_sessions_by_default() {
     let temp = tempdir();
-    let sessions = temp
-        .path()
-        .join(".codex")
-        .join("sessions")
-        .join("2026/06/24");
-    fs::create_dir_all(&sessions).unwrap();
-    fs::write(
-        sessions.join("rollout-2026-06-24T10-00-00-codex-session-setup.jsonl"),
-        concat!(
-            r#"{"timestamp":"2026-06-24T10:00:00.000Z","type":"session_meta","payload":{"id":"codex-session-setup","timestamp":"2026-06-24T10:00:00.000Z","cwd":"/repo/app","originator":"codex-cli","cli_version":"0.200.0","source":"cli","model_provider":"openai"}}"#,
-            "\n",
-            r#"{"timestamp":"2026-06-24T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"setup should import"}]}}"#,
-            "\n"
-        ),
-    )
-    .unwrap();
+    write_codex_setup_session(&temp);
 
     let setup = json_output(ctx(&temp).args(["setup", "--json", "--progress", "none"]));
     assert_eq!(setup["catalog"]["cataloged_sessions"], 1);
@@ -312,7 +387,9 @@ fn setup_imports_discovered_codex_sessions_by_default() {
     assert!(status["indexed_items"].as_u64().unwrap() > 0);
     assert_eq!(status["read_only"], true);
 
-    let human_setup = ctx(&temp)
+    let human_temp = tempdir();
+    write_codex_setup_session(&human_temp);
+    let human_setup = ctx(&human_temp)
         .args(["setup", "--progress", "none"])
         .assert()
         .success()

--- a/crates/ctx-cli/tests/support/runner.rs
+++ b/crates/ctx-cli/tests/support/runner.rs
@@ -26,6 +26,7 @@ pub(crate) fn apply_hermetic_env(command: &mut Command, temp: &TempDir) {
     command.env("CTX_DATA_ROOT", temp.path());
     command.env("HOME", temp.path());
     command.env("CTX_ANALYTICS_OFF", "1");
+    command.env_remove("CTX_QUIET");
     // Drop provider override variables inherited from the developer
     // machine so discovery never escapes the temp directory.
     command.env_remove("OPENCLAW_STATE_DIR");

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -7,11 +7,18 @@ ctx is a local CLI for indexing and searching agent session history.
 ```bash
 ctx --data-root /tmp/ctx status
 CTX_DATA_ROOT=/tmp/ctx ctx status
+ctx --quiet setup
+CTX_QUIET=1 ctx status
 ```
 
 `--data-root` overrides the default ctx root for every command. The environment
 variable `CTX_DATA_ROOT` provides the same value. The root is used directly; ctx
 does not append another product directory.
+
+`--quiet` suppresses successful human status/onboarding output for `setup` and
+top-level `status`. `CTX_QUIET=1` provides the same default for scripts and
+installer wrappers. JSON output, errors, and command results from commands such
+as `search`, `show`, `sources`, and `docs` are not suppressed.
 
 ## Setup And Health
 
@@ -33,10 +40,15 @@ ctx doctor --json
   history-source plugin commands.
 - `setup --catalog-only` stops after discovery/cataloging. It is useful for
   fast inventory or troubleshooting, but it does not make history searchable.
+- `setup --quiet` performs setup without printing success status lines, import
+  summaries, data-root details, or get-started tips. It still exits nonzero and
+  prints errors on failure.
 - `status` reports the ctx root, database path, config path, indexed item
   count, indexed source count, catalog session counters, initialization state,
   local-only marker, and read-only marker. It does not initialize, migrate, or
   repair the store.
+- `status --quiet` performs the same local checks but prints nothing on
+  success. Use `status --json` when scripts need the actual state.
 - `doctor` opens local storage and reports validation findings.
 
 Setup and health checks do not change shell startup files, install repository


### PR DESCRIPTION
## Summary

- Add `--quiet` global flag to `Cli` that suppresses setup get-started tips, import details, and status info
- Human output for `ctx setup` and `ctx status` is skipped when `--quiet` is passed; JSON output and progress lines are unaffected
- `--quiet` is a global flag available on any subcommand and also set via `CTX_QUIET` env var

## Validation

- `cargo check -p ctx` (2 pre-existing warnings, no new warnings)
- `cargo check -p ctx-history-core`
- Manual: `ctx --quiet setup` suppresses get-started block but still prints progress/status
- Manual: `ctx setup --quiet` (flag after subcommand) works via clap global flag propagation