### PR TITLE
[codex] make ctx status strictly read-only

### DIFF
--- a/contracts/agent-history-v1/fixtures/status.ready.json
+++ b/contracts/agent-history-v1/fixtures/status.ready.json
@@ -9,6 +9,7 @@
   "status": {
     "initialized": true,
     "localOnly": true,
+    "readOnly": true,
     "dataRoot": "/tmp/ctx-sdk-fixture",
     "indexedItems": 3,
     "indexedSources": 1,

--- a/contracts/agent-history-v1/schema.json
+++ b/contracts/agent-history-v1/schema.json
@@ -52,6 +52,7 @@
       "properties": {
         "initialized": { "type": "boolean" },
         "localOnly": { "type": "boolean" },
+        "readOnly": { "type": "boolean" },
         "dataRoot": { "type": ["string", "null"] },
         "indexedItems": { "type": "integer", "minimum": 0 },
         "indexedSources": { "type": "integer", "minimum": 0 },

--- a/crates/ctx-cli/src/commands/status.rs
+++ b/crates/ctx-cli/src/commands/status.rs
@@ -4,24 +4,18 @@ use anyhow::Result;
 use serde_json::json;
 
 use ctx_history_core::database_path;
-use ctx_history_store::Store;
 
-use crate::analytics::AnalyticsProperties;
-use crate::commands::setup::insert_db_size_bucket;
 use crate::config::CONFIG_FILE;
 use crate::output::print_json;
-use crate::{analytics, JsonArgs};
+use crate::store_util::open_existing_store_snapshot_read_only;
+use crate::JsonArgs;
 
-pub(crate) fn run_status(
-    args: JsonArgs,
-    data_root: PathBuf,
-    analytics_properties: &mut AnalyticsProperties,
-) -> Result<()> {
+pub(crate) fn run_status(args: JsonArgs, data_root: PathBuf) -> Result<()> {
     let db_path = database_path(data_root.clone());
     let initialized = db_path.exists();
     let config_path = data_root.join(CONFIG_FILE);
     let (records, sessions, events, sources, catalog_counts) = if initialized {
-        let store = Store::open(&db_path)?;
+        let store = open_existing_store_snapshot_read_only(&db_path, "status")?;
         let counts = store.indexed_history_counts()?;
         (
             counts.items(),
@@ -33,25 +27,6 @@ pub(crate) fn run_status(
     } else {
         (0, 0, 0, 0, Default::default())
     };
-    analytics::insert_bool(analytics_properties, "initialized", initialized);
-    analytics::insert_count_bucket(analytics_properties, "indexed_items_bucket", records as u64);
-    analytics::insert_count_bucket(
-        analytics_properties,
-        "indexed_sessions_bucket",
-        sessions as u64,
-    );
-    analytics::insert_count_bucket(analytics_properties, "indexed_events_bucket", events as u64);
-    analytics::insert_count_bucket(
-        analytics_properties,
-        "indexed_sources_bucket",
-        sources as u64,
-    );
-    analytics::insert_count_bucket(
-        analytics_properties,
-        "cataloged_sessions_bucket",
-        catalog_counts.total as u64,
-    );
-    insert_db_size_bucket(analytics_properties, &db_path);
 
     if args.json {
         print_json(json!({
@@ -70,6 +45,7 @@ pub(crate) fn run_status(
             "failed_catalog_sessions": catalog_counts.failed,
             "stale_catalog_sessions": catalog_counts.stale,
             "local_only": true,
+            "read_only": true,
         }))?;
     } else {
         println!("data_root: {}", data_root.display());
@@ -84,6 +60,7 @@ pub(crate) fn run_status(
         println!("failed_catalog_sessions: {}", catalog_counts.failed);
         println!("stale_catalog_sessions: {}", catalog_counts.stale);
         println!("local_only: true");
+        println!("read_only: true");
     }
     Ok(())
 }

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -445,7 +445,7 @@ impl CommandRoot {
 
     fn sends_analytics(&self) -> bool {
         match self {
-            Self::Sql(_) | Self::Mcp(_) => false,
+            Self::Status(_) | Self::Sql(_) | Self::Mcp(_) => false,
             Self::Upgrade(args) if args.background() => false,
             _ => true,
         }
@@ -472,7 +472,7 @@ impl CommandRoot {
     fn allows_background_upgrade(&self) -> bool {
         !matches!(
             self,
-            Self::Docs(_) | Self::Mcp(_) | Self::Sql(_) | Self::Upgrade(_)
+            Self::Status(_) | Self::Docs(_) | Self::Mcp(_) | Self::Sql(_) | Self::Upgrade(_)
         )
     }
 }
@@ -526,7 +526,7 @@ fn main() -> Result<()> {
 
     let result = match cli.command {
         CommandRoot::Setup(args) => run_setup(args, data_root.clone(), &mut analytics_properties),
-        CommandRoot::Status(args) => run_status(args, data_root.clone(), &mut analytics_properties),
+        CommandRoot::Status(args) => run_status(args, data_root.clone()),
         CommandRoot::Sources(args) => {
             run_sources(args, data_root.clone(), &mut analytics_properties)
         }

--- a/crates/ctx-cli/src/store_util.rs
+++ b/crates/ctx-cli/src/store_util.rs
@@ -5,16 +5,36 @@ use anyhow::{anyhow, Context, Result};
 use ctx_history_store::{Store, StoreError};
 
 pub(crate) fn open_existing_store_read_only(db_path: &Path, command: &str) -> Result<Store> {
+    open_existing_store_read_only_with(db_path, command, false)
+}
+
+pub(crate) fn open_existing_store_snapshot_read_only(
+    db_path: &Path,
+    command: &str,
+) -> Result<Store> {
+    open_existing_store_read_only_with(db_path, command, true)
+}
+
+fn open_existing_store_read_only_with(
+    db_path: &Path,
+    command: &str,
+    snapshot: bool,
+) -> Result<Store> {
     if !db_path.exists() {
         return Err(anyhow!(
             "ctx store is not initialized at {}; run `ctx setup` or `ctx import` first",
             db_path.display()
         ));
     }
-    match Store::open_read_only(db_path) {
+    let opened = if snapshot {
+        Store::open_read_only_snapshot(db_path)
+    } else {
+        Store::open_read_only(db_path)
+    };
+    match opened {
         Ok(store) => Ok(store),
         Err(StoreError::UnsupportedSchemaVersion(version)) => Err(anyhow!(
-            "ctx store schema version {version} is not supported by this ctx binary; run `ctx status` once to migrate before using `{command}`"
+            "ctx store schema version {version} is not supported by this ctx binary; run a writable command such as `ctx setup` or `ctx import` with a compatible ctx binary to migrate before using `{command}`"
         )),
         Err(err) => {
             Err(err).with_context(|| format!("open read-only ctx store {}", db_path.display()))

--- a/crates/ctx-cli/tests/analytics.rs
+++ b/crates/ctx-cli/tests/analytics.rs
@@ -12,7 +12,7 @@ fn analytics_sends_coarse_cli_metadata_when_enabled() {
     fs::create_dir_all(&home).unwrap();
 
     ctx(&temp)
-        .arg("status")
+        .arg("doctor")
         .env("CTX_DATA_ROOT", &data_root)
         .env("HOME", &home)
         .env("XDG_STATE_HOME", &state)
@@ -37,29 +37,15 @@ fn analytics_sends_coarse_cli_metadata_when_enabled() {
         event["events"][0]["origin_device_id"],
         event["broker_device_id"]
     );
-    assert_eq!(event["events"][0]["properties"]["action"], "status");
+    assert_eq!(event["events"][0]["properties"]["action"], "doctor");
     assert_eq!(
         event["events"][0]["properties"]["analytics_client"],
         "ctx-cli"
     );
-    assert_eq!(event["events"][0]["properties"]["initialized"], false);
     assert_eq!(
-        event["events"][0]["properties"]["indexed_items_bucket"],
-        "0"
+        event["events"][0]["properties"]["finding_count_bucket"],
+        "2-5"
     );
-    assert_eq!(
-        event["events"][0]["properties"]["cataloged_sessions_bucket"],
-        "0"
-    );
-    assert_eq!(
-        event["events"][0]["properties"]["indexed_sessions_bucket"],
-        "0"
-    );
-    assert_eq!(
-        event["events"][0]["properties"]["indexed_events_bucket"],
-        "0"
-    );
-    assert_eq!(event["events"][0]["properties"]["db_size_bucket"], "0");
     assert_analytics_properties_are_allowlisted(analytics_event_properties(&event));
     for forbidden in [
         "command",
@@ -83,6 +69,41 @@ fn analytics_sends_coarse_cli_metadata_when_enabled() {
 }
 
 #[test]
+fn status_does_not_emit_analytics_or_create_identities_when_enabled() {
+    let temp = tempdir();
+    let events_path = temp.path().join("analytics.jsonl");
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let data_root = temp.path().join("data");
+    fs::create_dir_all(&home).unwrap();
+
+    ctx(&temp)
+        .arg("status")
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+        .env("CTX_UPGRADE_OFF", "1")
+        .assert()
+        .success();
+
+    assert!(
+        !events_path.exists(),
+        "status must not write analytics events"
+    );
+    assert!(
+        !data_root.exists(),
+        "status must not create the data root for install identity"
+    );
+    assert!(
+        !expected_device_path(&home, &state).exists(),
+        "status must not create a device identity"
+    );
+}
+
+#[test]
 fn analytics_device_id_persists_across_data_roots() {
     let temp = tempdir();
     let home = temp.path().join("home");
@@ -94,7 +115,7 @@ fn analytics_device_id_persists_across_data_roots() {
 
     for data_root in [&data_root_a, &data_root_b] {
         ctx(&temp)
-            .arg("status")
+            .arg("doctor")
             .env("CTX_DATA_ROOT", data_root)
             .env("HOME", &home)
             .env("XDG_STATE_HOME", &state)
@@ -291,7 +312,7 @@ fn hosted_install_marker_enriches_analytics_event_without_properties_leak() {
     .unwrap();
 
     ctx_from_binary(&temp, &binary)
-        .arg("status")
+        .arg("doctor")
         .env("CTX_DATA_ROOT", &data_root)
         .env("HOME", &home)
         .env("XDG_STATE_HOME", &state)
@@ -333,7 +354,7 @@ fn malformed_hosted_install_marker_is_ignored() {
     .unwrap();
 
     ctx_from_binary(&temp, &binary)
-        .arg("status")
+        .arg("doctor")
         .env("CTX_DATA_ROOT", &data_root)
         .env("HOME", &home)
         .env("XDG_STATE_HOME", &state)
@@ -479,7 +500,7 @@ fn analytics_config_opt_out_suppresses_delivery() {
     let events_path = temp.path().join("analytics.jsonl");
 
     ctx(&temp)
-        .arg("status")
+        .arg("doctor")
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
@@ -508,7 +529,7 @@ fn analytics_env_opt_out_wins_over_enable_flag() {
     let events_path = temp.path().join("analytics.jsonl");
 
     ctx(&temp)
-        .arg("status")
+        .arg("doctor")
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env("CTX_ANALYTICS_OFF", "1")
@@ -535,7 +556,7 @@ fn analytics_refuses_device_identity_under_data_root() {
     let events_path = temp.path().join("analytics.jsonl");
 
     ctx(&temp)
-        .arg("status")
+        .arg("doctor")
         .env("CTX_DATA_ROOT", &data_root)
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)

--- a/crates/ctx-cli/tests/setup_sources_import.rs
+++ b/crates/ctx-cli/tests/setup_sources_import.rs
@@ -85,6 +85,155 @@ fn malformed_present_config_fails_before_setup_and_analytics_side_effects() {
 }
 
 #[test]
+fn status_missing_store_is_read_only_and_does_not_initialize_files() {
+    let temp = tempdir();
+    let data_root = temp.path().join("ctx-data");
+
+    let status = json_output(
+        ctx(&temp)
+            .args(["status", "--json"])
+            .env("CTX_DATA_ROOT", &data_root),
+    );
+    assert_eq!(status["schema_version"], 1);
+    assert_eq!(status["initialized"], false);
+    assert_eq!(status["local_only"], true);
+    assert_eq!(status["read_only"], true);
+    assert_eq!(status["indexed_items"], 0);
+    assert_eq!(status["indexed_sources"], 0);
+    assert_eq!(status["cataloged_sessions"], 0);
+
+    let output = ctx(&temp)
+        .arg("status")
+        .env("CTX_DATA_ROOT", &data_root)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output = String::from_utf8(output).unwrap();
+    assert!(output.contains("initialized: false"), "{output}");
+    assert!(output.contains("local_only: true"), "{output}");
+    assert!(output.contains("read_only: true"), "{output}");
+
+    assert!(
+        !data_root.exists(),
+        "status must not create the missing data root"
+    );
+    assert!(!data_root.join("work.sqlite").exists());
+    assert!(!data_root.join("config.toml").exists());
+    assert!(!data_root.join("objects").exists());
+    assert!(!data_root.join("spool").exists());
+}
+
+#[test]
+fn status_existing_wal_mode_store_does_not_create_sqlite_sidecars() {
+    let temp = tempdir();
+    ctx(&temp).arg("setup").assert().success();
+    let db_path = temp.path().join("work.sqlite");
+    let wal_path = sqlite_sidecar_path(&db_path, "-wal");
+    let shm_path = sqlite_sidecar_path(&db_path, "-shm");
+    assert!(db_path.exists());
+    assert!(
+        !wal_path.exists(),
+        "setup should close a clean checkpointed store"
+    );
+    assert!(
+        !shm_path.exists(),
+        "setup should close a clean checkpointed store"
+    );
+
+    let status = json_output(ctx(&temp).args(["status", "--json"]));
+
+    assert_eq!(status["initialized"], true);
+    assert_eq!(status["read_only"], true);
+    assert!(
+        !wal_path.exists(),
+        "status must not create a SQLite WAL sidecar"
+    );
+    assert!(
+        !shm_path.exists(),
+        "status must not create a SQLite SHM sidecar"
+    );
+}
+
+fn sqlite_sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
+    let mut path = db_path.as_os_str().to_os_string();
+    path.push(suffix);
+    PathBuf::from(path)
+}
+
+#[test]
+fn status_rejects_unsupported_schema_without_migrating_or_creating_side_dirs() {
+    let temp = tempdir();
+    let db_path = temp.path().join("work.sqlite");
+    let conn = Connection::open(&db_path).unwrap();
+    conn.pragma_update(None, "user_version", 1).unwrap();
+    drop(conn);
+
+    let stderr = failure_stderr(ctx(&temp).args(["status", "--json"]));
+    assert!(stderr.contains("schema version 1"), "{stderr}");
+    assert!(stderr.contains("writable command"), "{stderr}");
+    assert!(!stderr.contains("ctx status"), "{stderr}");
+
+    let conn = Connection::open(&db_path).unwrap();
+    let user_version: i64 = conn
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(user_version, 1);
+    assert!(!temp.path().join("config.toml").exists());
+    assert!(!temp.path().join("objects").exists());
+    assert!(!temp.path().join("spool").exists());
+}
+
+#[test]
+fn status_does_not_repair_empty_search_projection() {
+    let temp = tempdir();
+    let fixture = custom_history_fixture("basic.jsonl");
+
+    let imported = json_output(ctx(&temp).args([
+        "import",
+        "--format",
+        "ctx-history-jsonl-v1",
+        "--path",
+        &fixture,
+        "--json",
+        "--progress",
+        "none",
+    ]));
+    assert!(imported["totals"]["imported_events"].as_u64().unwrap() > 0);
+
+    let db_path = temp.path().join("work.sqlite");
+    let conn = Connection::open(&db_path).unwrap();
+    assert!(
+        sqlite_count(&conn, "SELECT COUNT(*) FROM event_search") > 0,
+        "fixture import should create searchable event projections"
+    );
+    conn.execute_batch(
+        "DELETE FROM ctx_history_search;\
+         DELETE FROM event_search;\
+         DELETE FROM artifact_search;",
+    )
+    .unwrap();
+    drop(conn);
+
+    let status = json_output(ctx(&temp).args(["status", "--json"]));
+    assert_eq!(status["initialized"], true);
+    assert_eq!(status["read_only"], true);
+    assert!(status["indexed_items"].as_u64().unwrap() > 0);
+
+    let conn = Connection::open(&db_path).unwrap();
+    assert_eq!(
+        sqlite_count(&conn, "SELECT COUNT(*) FROM ctx_history_search"),
+        0
+    );
+    assert_eq!(sqlite_count(&conn, "SELECT COUNT(*) FROM event_search"), 0);
+    assert_eq!(
+        sqlite_count(&conn, "SELECT COUNT(*) FROM artifact_search"),
+        0
+    );
+}
+
+#[test]
 fn setup_catalog_only_catalogs_codex_sessions_without_import() {
     let temp = tempdir();
     let sessions = temp
@@ -109,6 +258,7 @@ fn setup_catalog_only_catalogs_codex_sessions_without_import() {
     assert_eq!(status["cataloged_sessions"], 1);
     assert_eq!(status["indexed_catalog_sessions"], 0);
     assert_eq!(status["indexed_items"], 0);
+    assert_eq!(status["read_only"], true);
 
     let human_setup = ctx(&temp)
         .args(["setup", "--catalog-only", "--progress", "none"])
@@ -120,7 +270,7 @@ fn setup_catalog_only_catalogs_codex_sessions_without_import() {
     let human_setup = String::from_utf8(human_setup).unwrap();
     assert!(human_setup.contains("ctx catalog is ready; import is still pending"));
     assert!(human_setup.contains("  ctx import --all"));
-    assert!(!human_setup.contains("ctx search \"what failed before\""));
+    assert!(!human_setup.contains("ctx search \"test failure\""));
 }
 
 #[test]
@@ -160,6 +310,7 @@ fn setup_imports_discovered_codex_sessions_by_default() {
     assert_eq!(status["indexed_catalog_sessions"], 1);
     assert_eq!(status["pending_catalog_sessions"], 0);
     assert!(status["indexed_items"].as_u64().unwrap() > 0);
+    assert_eq!(status["read_only"], true);
 
     let human_setup = ctx(&temp)
         .args(["setup", "--progress", "none"])
@@ -170,8 +321,8 @@ fn setup_imports_discovered_codex_sessions_by_default() {
         .clone();
     let human_setup = String::from_utf8(human_setup).unwrap();
     assert!(human_setup.contains("ctx local agent history search is ready"));
-    assert!(human_setup.contains("imported_sources: 1"));
-    assert!(human_setup.contains("  ctx search \"what failed before\""));
+    assert!(human_setup.contains("from 1 source(s)."));
+    assert!(human_setup.contains("  ctx search \"test failure\""));
 }
 
 #[test]

--- a/crates/ctx-cli/tests/upgrade.rs
+++ b/crates/ctx-cli/tests/upgrade.rs
@@ -404,3 +404,56 @@ fn json_commands_do_not_spawn_background_upgrade() {
         "JSON status must not start a background upgrade"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn status_command_does_not_spawn_background_upgrade_even_for_managed_installs() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let binary = copied_ctx_binary(&temp);
+    let before = fs::read(&binary).unwrap();
+    let current_sha = sha256_hex(&before);
+    fs::write(
+        install_marker_path(&binary),
+        serde_json::to_vec_pretty(&json!({
+            "schema_version": 1,
+            "manager": "ctx-hosted-installer",
+            "install_attempt_id": "ia_test_status_no_background",
+            "install_path": binary.display().to_string(),
+            "platform": test_platform_key().replace('_', "-"),
+            "channel": "stable",
+            "version": env!("CARGO_PKG_VERSION"),
+            "sha256": current_sha,
+            "metadata_url": null,
+            "artifact_url": null,
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    ctx_from_binary(&temp, &binary)
+        .arg("status")
+        .env("CTX_RELEASE_METADATA_URL", file_url(&release.metadata))
+        .env(
+            "CTX_RELEASE_METADATA_SIGNATURE_URL",
+            file_url(&release.signature),
+        )
+        .env(
+            "CTX_RELEASE_METADATA_PUBLIC_KEY_PEM",
+            TEST_RELEASE_PUBLIC_KEY_PEM,
+        )
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("read_only: true"));
+
+    std::thread::sleep(Duration::from_millis(1_000));
+    assert_eq!(
+        fs::read(&binary).unwrap(),
+        before,
+        "status must not spawn a background upgrade that replaces the binary"
+    );
+    assert!(
+        !temp.path().join("upgrade-state.json").exists(),
+        "status must not write background upgrade state"
+    );
+}

--- a/crates/ctx-history-store/src/connection.rs
+++ b/crates/ctx-history-store/src/connection.rs
@@ -24,11 +24,27 @@ impl Store {
 
     pub fn open_read_only(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref().to_path_buf();
+        Self::open_read_only_connection(path, false)
+    }
+
+    pub fn open_read_only_snapshot(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        Self::open_read_only_connection(path, true)
+    }
+
+    fn open_read_only_connection(path: PathBuf, immutable_snapshot: bool) -> Result<Self> {
         let object_dir = path
             .parent()
             .map(|parent| parent.join(OBJECTS_DIR))
             .unwrap_or_else(|| PathBuf::from(OBJECTS_DIR));
-        let conn = Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let conn = if immutable_snapshot {
+            Connection::open_with_flags(
+                sqlite_read_only_immutable_uri(&path),
+                OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+            )?
+        } else {
+            Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY)?
+        };
         configure_read_only_connection(&conn, BUSY_TIMEOUT)?;
         let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
         if user_version != SCHEMA_VERSION {
@@ -176,6 +192,23 @@ pub(crate) fn configure_connection(conn: &Connection, busy_timeout: Duration) ->
         "#,
     )?;
     Ok(())
+}
+
+pub(crate) fn sqlite_read_only_immutable_uri(path: &Path) -> String {
+    let mut uri = String::from("file:");
+    for byte in path.to_string_lossy().as_bytes() {
+        match *byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'/' | b':' | b'.' | b'_' | b'-' => {
+                uri.push(*byte as char)
+            }
+            byte => {
+                uri.push('%');
+                uri.push_str(&format!("{byte:02X}"));
+            }
+        }
+    }
+    uri.push_str("?mode=ro&immutable=1");
+    uri
 }
 
 pub(crate) fn configure_read_only_connection(

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -35,15 +35,16 @@ ctx doctor --json
   fast inventory or troubleshooting, but it does not make history searchable.
 - `status` reports the ctx root, database path, config path, indexed item
   count, indexed source count, catalog session counters, initialization state,
-  and local-only marker.
+  local-only marker, and read-only marker. It does not initialize, migrate, or
+  repair the store.
 - `doctor` opens local storage and reports validation findings.
 
 Setup and health checks do not change shell startup files, install repository
 integrations, write into source repositories, call model APIs, or require API
 keys. Core storage checks use the configured data root, and JSON stdout remains
 structured. Installer-managed binaries can run a signed background upgrade
-check after successful non-JSON commands; that check is separate from provider
-history indexing.
+check after successful non-JSON commands other than `ctx status`; that check is
+separate from provider history indexing.
 
 ## Agent Skill
 
@@ -338,8 +339,8 @@ ctx sql "SELECT ctx_session_id FROM ctx_sessions LIMIT 5" --format raw
 `sql` runs one read-only SQL statement against the existing local ctx SQLite
 index. It does not create or migrate the store, refresh provider history, import
 sources, run background upgrade checks, or write provider files or source
-repositories. If the store is missing or uses an old schema, run `ctx setup`,
-`ctx import`, or `ctx status` first.
+repositories. If the store is missing or uses an old schema, run a writable
+command such as `ctx setup` or `ctx import` first.
 
 Prefer stable read-only `ctx_*` views for scripts:
 
@@ -442,11 +443,11 @@ install or multiple `ctx` binaries are present.
 
 Official installer-managed installs default to background auto-upgrade after
 successful normal commands when signed release metadata explicitly allows
-auto-upgrade. Background checks never run for `--json` commands, MCP, `ctx
-docs`, `ctx upgrade`, CI, or unmanaged installs. They write state and logs under
-the ctx data root and do not write to stdout or stderr. Use `CTX_UPGRADE_OFF=1`
-or `CTX_DISABLE_AUTO_UPGRADE=1` for process-level opt-out, or `ctx upgrade
-disable` to write `upgrade.auto = "off"` in `config.toml`.
+auto-upgrade. Background checks never run for `ctx status`, `--json` commands,
+MCP, `ctx docs`, `ctx sql`, `ctx upgrade`, CI, or unmanaged installs. They write
+state and logs under the ctx data root and do not write to stdout or stderr. Use
+`CTX_UPGRADE_OFF=1` or `CTX_DISABLE_AUTO_UPGRADE=1` for process-level opt-out,
+or `ctx upgrade disable` to write `upgrade.auto = "off"` in `config.toml`.
 
 Manual `ctx upgrade` can print progress and errors. It verifies signed release
 metadata, explicit self-upgrade policy, artifact SHA-256, the current managed

--- a/docs/contracts/json.md
+++ b/docs/contracts/json.md
@@ -52,7 +52,8 @@ Reads local storage state and returns:
 - `pending_catalog_sessions`;
 - `failed_catalog_sessions`;
 - `stale_catalog_sessions`;
-- `local_only: true`.
+- `local_only: true`;
+- `read_only: true`.
 
 ## Sources
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,8 +61,8 @@ CTX_DATA_ROOT=/tmp/ctx-demo ctx status
 
 Setup does not write to source repositories, call model APIs, or require API
 keys. Official installer-managed binaries can run a signed background
-auto-upgrade check after later successful non-JSON commands; that updater does
-not collect provider history.
+auto-upgrade check after later successful non-JSON commands other than
+`ctx status`; that updater does not collect provider history.
 
 ## 3. See Available Sources
 

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -13,6 +13,8 @@ the local retrieval product.
   configured ctx data root before querying.
 - `ctx show` and `ctx locate` write nothing in local-only security mode, except
   `ctx show session --out` writes only the explicit path when one is provided.
+- `ctx status` is strictly read-only: missing stores stay missing, and existing
+  stores are not migrated, repaired, or used to create search projections.
 - `ctx sql` opens only the existing SQLite index, rejects write statements and
   multiple statements, and does not run background upgrade checks.
 - In local-only security mode, setup/import/search do not use network access or
@@ -23,9 +25,9 @@ the local retrieval product.
 - `ctx upgrade` uses signed release metadata with explicit self-upgrade policy
   and applies only to official installer-managed binaries with a matching
   install sidecar.
-- Background auto-upgrade is managed-install-only, skipped for JSON/MCP/docs/sql/
-  upgrade commands, requires explicit signed auto-upgrade policy, and must not
-  collect provider history or pollute command stdout/stderr.
+- Background auto-upgrade is managed-install-only, skipped for status/JSON/MCP/
+  docs/sql/upgrade commands, requires explicit signed auto-upgrade policy, and
+  must not collect provider history or pollute command stdout/stderr.
 - Provider files are read as sources and not modified.
 - Provider transcript imports reject symlinked JSONL files by default.
 - JSON output is private by default and must not be described as share-safe.

--- a/docs/sql.md
+++ b/docs/sql.md
@@ -5,8 +5,8 @@ when normal `ctx search` does not express the question: counts, audits, joins,
 file/session metadata lookups, or scripts that need structured output.
 
 `ctx sql` does not refresh provider history, import files, initialize storage, or
-migrate schemas. Run `ctx status`, `ctx setup`, or `ctx import` first if the
-local store needs to be created or migrated.
+migrate schemas. Run a writable command such as `ctx setup` or `ctx import` first
+if the local store needs to be created or migrated.
 
 ## Examples
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -80,7 +80,7 @@ analytics marker described under network behavior.
 | Command | Reads | Writes |
 | --- | --- | --- |
 | `ctx setup` | provider transcript files and home path metadata for source discovery | data root, `work.sqlite`, `config.toml`, and SQLite index |
-| `ctx status` | data root metadata and existing SQLite store | none |
+| `ctx status` | data root metadata and existing SQLite store, opened read-only when present | none |
 | `ctx sources` | known provider paths under the user's home and local history-source plugin manifests | none |
 | `ctx import` | provider transcript files and path metadata, the explicit custom history JSONL file passed with `--format ctx-history-jsonl-v1 --path`, or stdout from an explicit history-source plugin command | data root, `config.toml` if missing, and SQLite index |
 | `ctx show` | SQLite index | selected `--out` path for `show session` when provided |
@@ -178,8 +178,9 @@ does not express, such as exact counts, joins, audits, and one-off scripts. It
 opens the existing SQLite store in read-only mode, rejects writes, rejects
 multiple statements, enforces row/column/value caps, and times out long-running
 queries. It also applies SQLite runtime limits to bound SQL text and generated
-value allocation. It does not initialize or migrate the store; run `ctx
-status`, `ctx setup`, or `ctx import` first when a schema migration is required.
+value allocation. It does not initialize or migrate the store; run a writable
+command such as `ctx setup` or `ctx import` first when a schema migration is
+required.
 
 Stable read-only views are the preferred compatibility surface:
 
@@ -246,11 +247,12 @@ behavior.
 
 Official installer-managed binaries can contact the signed release metadata
 endpoint for `ctx upgrade` and for background auto-upgrade checks after
-successful normal commands. These checks are skipped for JSON commands, MCP,
-`ctx docs`, `ctx sql`, `ctx upgrade`, CI, unmanaged installs, and process-level
-opt-outs such as `CTX_UPGRADE_OFF=1` or `CTX_DISABLE_AUTO_UPGRADE=1`. Upgrade
-metadata checks do not send provider transcript text, search queries, result
-snippets, source paths, repository names, or command output.
+successful normal commands. These checks are skipped for `ctx status`, JSON
+commands, MCP, `ctx docs`, `ctx sql`, `ctx upgrade`, CI, unmanaged installs, and
+process-level opt-outs such as `CTX_UPGRADE_OFF=1` or
+`CTX_DISABLE_AUTO_UPGRADE=1`. Upgrade metadata checks do not send provider
+transcript text, search queries, result snippets, source paths, repository
+names, or command output.
 
 First-party analytics are default-on and may create `install.json` plus a
 separate device identity file in OS user state, then send coarse product

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -13,8 +13,9 @@ The current CLI protects a local search index for developer agent history.
 ## Boundaries
 
 ctx reads provider history and writes only to the configured ctx data root
-during normal setup and import commands. Search, show, sources, status, and
-doctor read local data and should not write outside the ctx data root. `ctx show
+during normal setup and import commands. Search, show, sources, and doctor read
+local data and should not write outside the ctx data root. `ctx status` is
+strictly read-only and does not initialize or migrate local storage. `ctx show
 session --out` writes only the explicit output path requested by the user.
 
 Source repositories and provider homes remain outside ctx ownership. Provider

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -25,9 +25,9 @@ warns when another binary shadows the managed install.
 Official installer-managed installs default to background auto-upgrade after
 successful normal commands when signed release metadata explicitly allows
 auto-upgrade. Background checks never run for `--json` commands, MCP,
-`ctx docs`, `ctx sql`, `ctx upgrade`, CI, unmanaged installs, or process-level
-opt-outs. They write state and logs under the ctx data root and do not write to
-stdout or stderr.
+`ctx status`, `ctx docs`, `ctx sql`, `ctx upgrade`, CI, unmanaged installs, or
+process-level opt-outs. They write state and logs under the ctx data root and do
+not write to stdout or stderr.
 
 Use `CTX_UPGRADE_OFF=1` or `CTX_DISABLE_AUTO_UPGRADE=1` for process-level
 opt-out, or `ctx upgrade disable` to write `upgrade.auto = "off"` in


### PR DESCRIPTION
## Summary
- make `ctx status` open the store read-only and avoid background upgrades, analytics identity creation, or config/data-root initialization
- expose `read_only: true` in the status JSON/contract surface
- update CLI, storage, upgrade, SQL, and threat-model docs to document status as observation-only

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p ctx --test setup_sources_import status_`
- `cargo test -p ctx --test analytics status_does_not_emit_analytics_or_create_identities_when_enabled`
- `cargo test -p ctx --test upgrade status_command_does_not_spawn_background_upgrade_even_for_managed_installs`
- `scripts/check-agent-history-contract.py`
- `bash scripts/check-docs.sh`
- `git diff --check`

## Review Notes
- Rebased on latest `origin/main` before push.
- Test warnings are existing unused imports in shared CLI test support.