### PR TITLE
[codex] reject metadata-only provider imports

### DIFF
--- a/crates/ctx-history-capture/src/provider/providers/mod.rs
+++ b/crates/ctx-history-capture/src/provider/providers/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod openclaw;
 pub(crate) mod opencode;
 pub(crate) mod openhands;
 pub(crate) mod pi;
+pub(crate) mod real_content;
 pub(crate) mod rovodev;
 pub(crate) mod shelley;
 pub(crate) mod task_json;

--- a/crates/ctx-history-capture/src/provider/providers/opencode.rs
+++ b/crates/ctx-history-capture/src/provider/providers/opencode.rs
@@ -24,6 +24,7 @@ use crate::provider::native::{
     provider_line_from_index, provider_local_preview, provider_nonnegative_i64_to_u64,
     provider_required_timestamp_millis, provider_role, provider_value_text,
 };
+use crate::provider::providers::real_content::text_has_real_content;
 use crate::{
     CaptureError, ProviderAdapterContext, ProviderNormalizationResult, Result,
     KILO_SQLITE_SOURCE_FORMAT, OPENCODE_SQLITE_SOURCE_FORMAT, PROVIDER_MAX_PREVIEW_CHARS,
@@ -60,6 +61,13 @@ pub(crate) const KILO_SQLITE_DIALECT: OpenCodeSqliteDialect = OpenCodeSqliteDial
     event_time_created_field: "Kilo event time.created",
 };
 
+#[derive(Debug, Clone)]
+pub(crate) struct OpenCodeMessageSelection {
+    pub(crate) rows: Vec<OpenCodeMessageRow>,
+    pub(crate) source_table: Option<&'static str>,
+    pub(crate) skipped_non_conversational_rows: usize,
+}
+
 pub(crate) fn normalize_opencode_sqlite(
     path: &Path,
     context: &ProviderAdapterContext,
@@ -71,8 +79,23 @@ pub(crate) fn normalize_opencode_sqlite(
     let legacy_message_rows = opencode_count(&conn, "message").unwrap_or(0);
     let legacy_part_rows = opencode_count(&conn, "part").unwrap_or(0);
     let sessions = opencode_sessions(&conn, dialect)?;
-    let messages = opencode_session_messages(&conn, dialect)?;
+    let session_ids = sessions
+        .iter()
+        .map(|session| session.id.clone())
+        .collect::<BTreeSet<_>>();
+    let message_selection = opencode_session_messages(&conn, dialect, &session_ids)?;
     let mut result = ProviderNormalizationResult::default();
+    if message_selection.rows.is_empty() {
+        push_provider_import_failure(
+            &mut result.summary,
+            0,
+            format!(
+                "{} SQLite database contained no real conversational message rows",
+                dialect.display_name
+            ),
+        );
+        return Ok(result);
+    }
     let mut session_started = BTreeMap::new();
     for session in &sessions {
         session_started.insert(
@@ -88,8 +111,10 @@ pub(crate) fn normalize_opencode_sqlite(
         .map(|session| (session.id.clone(), session))
         .collect::<BTreeMap<_, _>>();
     let raw_source_path = path.display().to_string();
+    let message_source_table = message_selection.source_table;
+    let skipped_non_conversational_rows = message_selection.skipped_non_conversational_rows;
 
-    for row in messages {
+    for row in message_selection.rows {
         let provider_event_index =
             match provider_nonnegative_i64_to_u64(row.seq, dialect.session_message_seq_field) {
                 Ok(value) => value,
@@ -236,7 +261,9 @@ pub(crate) fn normalize_opencode_sqlite(
                         "legacy_projection": {
                             "message_rows": legacy_message_rows,
                             "part_rows": legacy_part_rows,
-                            "import_policy": "session_message is authoritative; legacy message/part rows are retained as schema reference rows to avoid duplicate turn import"
+                            "selected_message_table": message_source_table,
+                            "skipped_non_conversational_rows": skipped_non_conversational_rows,
+                            "import_policy": "session_message/session_entry are authoritative only when they contain real conversational content; otherwise legacy message rows may be used"
                         },
                     }),
                 },
@@ -318,23 +345,68 @@ pub(crate) fn opencode_sessions(
 pub(crate) fn opencode_session_messages(
     conn: &Connection,
     dialect: &OpenCodeSqliteDialect,
-) -> Result<Vec<OpenCodeMessageRow>> {
+    session_ids: &BTreeSet<String>,
+) -> Result<OpenCodeMessageSelection> {
+    let mut skipped_non_conversational_rows = 0usize;
     if sqlite_table_exists(conn, "session_message")? {
         let rows = opencode_session_message_rows(conn, dialect)?;
-        if !rows.is_empty() {
-            return Ok(rows);
+        if opencode_rows_have_import_blocking_errors(&rows, session_ids, dialect) {
+            return Ok(OpenCodeMessageSelection {
+                rows,
+                source_table: Some("session_message"),
+                skipped_non_conversational_rows,
+            });
         }
+        if opencode_rows_have_real_message_content(&rows) {
+            return Ok(OpenCodeMessageSelection {
+                rows,
+                source_table: Some("session_message"),
+                skipped_non_conversational_rows,
+            });
+        }
+        skipped_non_conversational_rows += rows.len();
     }
     if sqlite_table_exists(conn, "session_entry")? {
         let rows = opencode_session_entry_rows(conn, dialect)?;
-        if !rows.is_empty() {
-            return Ok(rows);
+        if opencode_rows_have_import_blocking_errors(&rows, session_ids, dialect) {
+            return Ok(OpenCodeMessageSelection {
+                rows,
+                source_table: Some("session_entry"),
+                skipped_non_conversational_rows,
+            });
         }
+        if opencode_rows_have_real_message_content(&rows) {
+            return Ok(OpenCodeMessageSelection {
+                rows,
+                source_table: Some("session_entry"),
+                skipped_non_conversational_rows,
+            });
+        }
+        skipped_non_conversational_rows += rows.len();
     }
     if sqlite_table_exists(conn, "message")? {
-        return opencode_message_rows(conn, dialect);
+        let rows = opencode_message_rows(conn, dialect)?;
+        if opencode_rows_have_import_blocking_errors(&rows, session_ids, dialect) {
+            return Ok(OpenCodeMessageSelection {
+                rows,
+                source_table: Some("message"),
+                skipped_non_conversational_rows,
+            });
+        }
+        if opencode_rows_have_real_message_content(&rows) {
+            return Ok(OpenCodeMessageSelection {
+                rows,
+                source_table: Some("message"),
+                skipped_non_conversational_rows,
+            });
+        }
+        skipped_non_conversational_rows += rows.len();
     }
-    Ok(Vec::new())
+    Ok(OpenCodeMessageSelection {
+        rows: Vec::new(),
+        source_table: None,
+        skipped_non_conversational_rows,
+    })
 }
 
 pub(crate) fn opencode_session_message_rows(
@@ -380,6 +452,7 @@ pub(crate) fn opencode_session_message_rows(
     let mut next_seq_by_session = BTreeMap::<String, i64>::new();
     for (id, session_id, entry_type, seq, time_created, time_updated, data) in rows {
         let seq = seq.unwrap_or_else(|| next_opencode_seq(&mut next_seq_by_session, &session_id));
+        let entry_type = opencode_entry_type_from_data(&entry_type, &data);
         messages.push(OpenCodeMessageRow {
             id,
             session_id,
@@ -391,6 +464,16 @@ pub(crate) fn opencode_session_message_rows(
         });
     }
     Ok(messages)
+}
+
+pub(crate) fn opencode_entry_type_from_data(fallback: &str, data: &str) -> String {
+    if !fallback.trim().is_empty() && fallback != "message" {
+        return fallback.to_owned();
+    }
+    serde_json::from_str::<Value>(data)
+        .ok()
+        .and_then(|value| opencode_message_type_from_data(&value))
+        .unwrap_or_else(|| fallback.to_owned())
 }
 
 pub(crate) fn opencode_session_entry_rows(
@@ -505,6 +588,88 @@ pub(crate) fn opencode_message_type_from_data(data: &Value) -> Option<String> {
         .and_then(Value::as_str)
         .filter(|value| !value.trim().is_empty())
         .map(str::to_owned)
+}
+
+pub(crate) fn opencode_rows_have_real_message_content(rows: &[OpenCodeMessageRow]) -> bool {
+    rows.iter().any(opencode_message_row_has_real_content)
+}
+
+pub(crate) fn opencode_rows_have_import_blocking_errors(
+    rows: &[OpenCodeMessageRow],
+    session_ids: &BTreeSet<String>,
+    dialect: &OpenCodeSqliteDialect,
+) -> bool {
+    rows.iter().any(|row| {
+        provider_nonnegative_i64_to_u64(row.seq, dialect.session_message_seq_field).is_err()
+            || !session_ids.contains(&row.session_id)
+            || opencode_row_has_invalid_time_or_json(row, dialect)
+    })
+}
+
+pub(crate) fn opencode_row_has_invalid_time_or_json(
+    row: &OpenCodeMessageRow,
+    dialect: &OpenCodeSqliteDialect,
+) -> bool {
+    let Ok(data) = serde_json::from_str::<Value>(&row.data) else {
+        return true;
+    };
+    match opencode_event_time(&data, dialect) {
+        Ok(Some(_)) => false,
+        Ok(None) => provider_required_timestamp_millis(
+            row.time_created,
+            dialect.session_message_time_created_field,
+        )
+        .is_err(),
+        Err(_) => true,
+    }
+}
+
+pub(crate) fn opencode_message_row_has_real_content(row: &OpenCodeMessageRow) -> bool {
+    let Ok(data) = serde_json::from_str::<Value>(&row.data) else {
+        return false;
+    };
+    opencode_data_has_real_message_content(&row.entry_type, &data)
+}
+
+pub(crate) fn opencode_data_has_real_message_content(entry_type: &str, data: &Value) -> bool {
+    if !matches!(entry_type, "assistant" | "user" | "system") {
+        return false;
+    }
+    ["text", "content", "message"]
+        .into_iter()
+        .any(|key| data.get(key).is_some_and(opencode_value_has_real_content))
+}
+
+pub(crate) fn opencode_value_has_real_content(value: &Value) -> bool {
+    match value {
+        Value::String(text) => text_has_real_content(Some(text)),
+        Value::Array(values) => values.iter().any(opencode_value_has_real_content),
+        Value::Object(object) => {
+            if object
+                .get("type")
+                .and_then(Value::as_str)
+                .is_some_and(|kind| {
+                    matches!(
+                        kind,
+                        "tool"
+                            | "tool_use"
+                            | "toolCall"
+                            | "function_call"
+                            | "agent"
+                            | "tool_result"
+                    )
+                })
+            {
+                return false;
+            }
+            [
+                "text", "content", "output", "summary", "thinking", "command",
+            ]
+            .into_iter()
+            .any(|key| object.get(key).is_some_and(opencode_value_has_real_content))
+        }
+        Value::Number(_) | Value::Bool(_) | Value::Null => false,
+    }
 }
 
 pub(crate) fn sqlite_table_exists(conn: &Connection, table: &str) -> Result<bool> {

--- a/crates/ctx-history-capture/src/provider/providers/pi.rs
+++ b/crates/ctx-history-capture/src/provider/providers/pi.rs
@@ -14,6 +14,7 @@ use ctx_history_core::{
 use serde_json::{json, Value};
 
 use crate::provider::providers::native_jsonl::native_jsonl_missing_reason;
+use crate::provider::providers::real_content::event_has_real_conversation_content;
 
 use crate::common::io::{
     collect_jsonl_paths, ensure_regular_provider_transcript_file, read_provider_jsonl_line,
@@ -92,6 +93,8 @@ pub(crate) fn normalize_pi_session_jsonl_file(
     let mut reader = BufReader::new(file);
     let mut result = ProviderNormalizationResult::default();
     let mut header = None;
+    let mut captures = Vec::new();
+    let mut has_real_message_content = false;
     let mut line = Vec::new();
     let mut line_number = 0usize;
 
@@ -119,9 +122,7 @@ pub(crate) fn normalize_pi_session_jsonl_file(
         if entry_type == "session" {
             match pi_session_header(value) {
                 Ok(parsed) => {
-                    let capture = pi_session_capture(&parsed, None, line_number, context)?;
                     header = Some(parsed);
-                    result.captures.push((line_number, capture));
                 }
                 Err(err) => {
                     result.summary.failed += 1;
@@ -143,7 +144,16 @@ pub(crate) fn normalize_pi_session_jsonl_file(
             continue;
         };
         match pi_session_capture(header, Some(value), line_number, context) {
-            Ok(capture) => result.captures.push((line_number, capture)),
+            Ok(capture) => {
+                if capture
+                    .event
+                    .as_ref()
+                    .is_some_and(pi_event_has_real_message_content)
+                {
+                    has_real_message_content = true;
+                }
+                captures.push((line_number, capture));
+            }
             Err(err) => {
                 result.summary.failed += 1;
                 result.summary.failures.push(ProviderImportFailure {
@@ -154,8 +164,26 @@ pub(crate) fn normalize_pi_session_jsonl_file(
         }
     }
 
+    if has_real_message_content {
+        result.captures = captures;
+    } else if result.summary.failed == 0 {
+        result.summary.failed += 1;
+        result.summary.failures.push(ProviderImportFailure {
+            line: line_number,
+            error: "pi session JSONL contained no real message content".to_owned(),
+        });
+    }
+
     Ok(result)
 }
+
+pub(crate) fn pi_event_has_real_message_content(event: &ProviderEventEnvelope) -> bool {
+    event_has_real_conversation_content(
+        event.event_type,
+        event.payload.get("text").and_then(Value::as_str),
+    )
+}
+
 pub(crate) fn pi_session_header(value: Value) -> Result<PiSessionHeader> {
     let id = value
         .get("id")

--- a/crates/ctx-history-capture/src/provider/providers/real_content.rs
+++ b/crates/ctx-history-capture/src/provider/providers/real_content.rs
@@ -1,0 +1,16 @@
+use ctx_history_core::EventType;
+
+pub(crate) fn text_has_real_content(text: Option<&str>) -> bool {
+    text.is_some_and(|text| !text.trim().is_empty())
+}
+
+pub(crate) fn event_type_is_real_conversation(event_type: EventType) -> bool {
+    matches!(event_type, EventType::Message)
+}
+
+pub(crate) fn event_has_real_conversation_content(
+    event_type: EventType,
+    text: Option<&str>,
+) -> bool {
+    event_type_is_real_conversation(event_type) && text_has_real_content(text)
+}

--- a/crates/ctx-history-capture/src/tests/native_sqlite.rs
+++ b/crates/ctx-history-capture/src/tests/native_sqlite.rs
@@ -455,7 +455,7 @@ fn native_opencode_reports_malformed_and_corrupt_db() {
 }
 
 #[test]
-fn native_opencode_accepts_schema_without_model_column() {
+fn native_opencode_rejects_empty_current_schema_without_model_column() {
     let temp = tempdir();
     let fixture = write_opencode_current_schema_db(&temp, false);
     let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
@@ -470,9 +470,13 @@ fn native_opencode_accepts_schema_without_model_column() {
     )
     .unwrap();
 
-    assert_eq!(summary.failed, 0);
+    assert_eq!(summary.failed, 1);
+    assert!(summary.failures[0]
+        .error
+        .contains("no real conversational message rows"));
     assert_eq!(summary.imported_sessions, 0);
     assert_eq!(summary.imported_events, 0);
+    assert!(store.list_sessions().unwrap().is_empty());
 }
 
 #[test]
@@ -502,6 +506,204 @@ fn native_opencode_imports_legacy_message_table_when_session_message_is_absent()
         events[0].sync.metadata["source_format"].as_str(),
         Some(OPENCODE_SQLITE_SOURCE_FORMAT)
     );
+    assert!(events[0].payload.to_string().contains("legacy hello"));
+}
+
+#[test]
+fn native_opencode_falls_back_when_session_message_is_metadata_only() {
+    let temp = tempdir();
+    let fixture = write_opencode_session_message_metadata_with_legacy_message_db(&temp);
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_opencode_sqlite(
+        &fixture,
+        &mut store,
+        OpenCodeSqliteImportOptions {
+            allow_partial_failures: true,
+            ..OpenCodeSqliteImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.imported_sessions, 1);
+    assert_eq!(summary.imported_events, 1);
+    let session_id = store
+        .session_by_external_session(CaptureProvider::OpenCode, "strict-root")
+        .unwrap()
+        .unwrap()
+        .id;
+    let events = store.events_for_session(session_id).unwrap();
+    assert_eq!(events.len(), 1);
+    assert!(events[0]
+        .payload
+        .to_string()
+        .contains("legacy fallback prompt"));
+    let session = store.get_session(session_id).unwrap();
+    assert_eq!(
+        session.sync.metadata["metadata"]["legacy_projection"]["selected_message_table"].as_str(),
+        Some("message")
+    );
+}
+
+#[test]
+fn native_opencode_rejects_malformed_authoritative_rows_without_legacy_fallback() {
+    let temp = tempdir();
+    let fixture = write_opencode_session_message_malformed_with_legacy_message_db(&temp);
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_opencode_sqlite(
+        &fixture,
+        &mut store,
+        OpenCodeSqliteImportOptions {
+            allow_partial_failures: true,
+            ..OpenCodeSqliteImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 1, "{:?}", summary.failures);
+    assert!(summary.failures[0].error.contains("invalid JSON"));
+    assert_eq!(summary.imported_sessions, 0);
+    assert_eq!(summary.imported_events, 0);
+    assert!(store.list_sessions().unwrap().is_empty());
+}
+
+#[test]
+fn native_opencode_rejects_malformed_metadata_authoritative_rows_without_legacy_fallback() {
+    let temp = tempdir();
+    let fixture = write_opencode_session_message_metadata_bad_seq_with_legacy_message_db(&temp);
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_opencode_sqlite(
+        &fixture,
+        &mut store,
+        OpenCodeSqliteImportOptions {
+            allow_partial_failures: true,
+            ..OpenCodeSqliteImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 1, "{summary:?}");
+    assert!(summary.failures[0]
+        .error
+        .contains("OpenCode session_message seq must be nonnegative"));
+    assert_eq!(summary.imported_sessions, 0);
+    assert_eq!(summary.imported_events, 0);
+    assert!(store.list_sessions().unwrap().is_empty());
+}
+
+#[test]
+fn native_opencode_rejects_tool_only_sqlite_rows() {
+    let temp = tempdir();
+    let fixture = write_opencode_tool_only_db(&temp, "opencode-tool-only.db");
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_opencode_sqlite(
+        &fixture,
+        &mut store,
+        OpenCodeSqliteImportOptions {
+            allow_partial_failures: true,
+            ..OpenCodeSqliteImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 1);
+    assert!(summary.failures[0]
+        .error
+        .contains("no real conversational message rows"));
+    assert_eq!(summary.imported_sessions, 0);
+    assert_eq!(summary.imported_events, 0);
+    assert!(store.list_sessions().unwrap().is_empty());
+}
+
+#[test]
+fn native_opencode_falls_back_when_session_entry_is_metadata_only() {
+    let temp = tempdir();
+    let fixture = write_opencode_session_entry_metadata_with_legacy_message_db(&temp);
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_opencode_sqlite(
+        &fixture,
+        &mut store,
+        OpenCodeSqliteImportOptions {
+            allow_partial_failures: true,
+            ..OpenCodeSqliteImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.imported_sessions, 1);
+    assert_eq!(summary.imported_events, 1);
+    let session_id = store
+        .session_by_external_session(CaptureProvider::OpenCode, "strict-root")
+        .unwrap()
+        .unwrap()
+        .id;
+    let events = store.events_for_session(session_id).unwrap();
+    assert_eq!(events.len(), 1);
+    assert!(events[0]
+        .payload
+        .to_string()
+        .contains("legacy fallback prompt"));
+    let session = store.get_session(session_id).unwrap();
+    assert_eq!(
+        session.sync.metadata["metadata"]["legacy_projection"]["selected_message_table"].as_str(),
+        Some("message")
+    );
+}
+
+#[test]
+fn native_kilo_rejects_metadata_only_sqlite_rows() {
+    let temp = tempdir();
+    let fixture = write_opencode_all_metadata_db(&temp, "kilo-all-metadata.db");
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_kilo_sqlite(
+        &fixture,
+        &mut store,
+        KiloSqliteImportOptions {
+            allow_partial_failures: true,
+            ..KiloSqliteImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 1);
+    assert!(summary.failures[0]
+        .error
+        .contains("no real conversational message rows"));
+    assert_eq!(summary.imported_sessions, 0);
+    assert_eq!(summary.imported_events, 0);
+    assert!(store.list_sessions().unwrap().is_empty());
+}
+
+#[test]
+fn native_kilo_rejects_tool_only_sqlite_rows() {
+    let temp = tempdir();
+    let fixture = write_opencode_tool_only_db(&temp, "kilo-tool-only.db");
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_kilo_sqlite(
+        &fixture,
+        &mut store,
+        KiloSqliteImportOptions {
+            allow_partial_failures: true,
+            ..KiloSqliteImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 1);
+    assert!(summary.failures[0]
+        .error
+        .contains("no real conversational message rows"));
+    assert_eq!(summary.imported_sessions, 0);
+    assert_eq!(summary.imported_events, 0);
+    assert!(store.list_sessions().unwrap().is_empty());
 }
 
 #[test]

--- a/crates/ctx-history-capture/src/tests/spool_provider.rs
+++ b/crates/ctx-history-capture/src/tests/spool_provider.rs
@@ -274,6 +274,34 @@ fn pi_session_import_replays_documented_session_jsonl_and_is_idempotent() {
 }
 
 #[test]
+fn pi_session_import_rejects_header_only_session_jsonl() {
+    let temp = tempdir();
+    let path = temp.path().join("header-only-pi.jsonl");
+    fs::write(
+        &path,
+        jsonl_line(json!({
+            "type": "session",
+            "id": "pi-header-only",
+            "timestamp": "2026-07-03T12:00:00Z",
+            "version": 1
+        })),
+    )
+    .unwrap();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary =
+        import_pi_session_jsonl(&path, &mut store, PiSessionImportOptions::default()).unwrap();
+
+    assert_eq!(summary.failed, 1);
+    assert!(summary.failures[0]
+        .error
+        .contains("no real message content"));
+    assert_eq!(summary.imported_sessions, 0);
+    assert_eq!(summary.imported_events, 0);
+    assert!(store.list_sessions().unwrap().is_empty());
+}
+
+#[test]
 fn pi_session_import_rejects_malformed_event_timestamp() {
     let temp = tempdir();
     let path = temp.path().join("bad-timestamp-pi.jsonl");
@@ -557,13 +585,86 @@ fn pi_session_import_reuses_legacy_line_indexed_event_by_entry_id_after_line_shi
 }
 
 #[test]
-fn pi_session_import_extracts_text_from_non_message_entries() {
+fn pi_session_import_rejects_non_message_only_entries() {
+    let temp = tempdir();
+    let fixture = temp.path().join("pi-non-message-only.jsonl");
+    fs::write(
+        &fixture,
+        concat!(
+            "{\"type\":\"session\",\"version\":3,\"id\":\"pi-non-message-only\",\"timestamp\":\"2026-06-24T12:00:00Z\",\"cwd\":\"/workspace\"}\n",
+            "{\"type\":\"compaction\",\"id\":\"compact-entry\",\"timestamp\":\"2026-06-24T12:00:01Z\",\"summary\":\"compacted plan only\"}\n",
+            "{\"type\":\"model_change\",\"id\":\"model-entry\",\"timestamp\":\"2026-06-24T12:00:02Z\",\"provider\":\"google\",\"modelId\":\"gemini-2.5-flash\"}\n",
+            "{\"type\":\"label\",\"id\":\"label-entry\",\"timestamp\":\"2026-06-24T12:00:03Z\",\"label\":\"label only\"}\n",
+        ),
+    )
+    .unwrap();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_pi_session_jsonl(
+        &fixture,
+        &mut store,
+        PiSessionImportOptions {
+            source_path: Some(fixture.clone()),
+            imported_at: "2026-06-24T16:00:00Z".parse().unwrap(),
+            ..PiSessionImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 1);
+    assert!(summary.failures[0]
+        .error
+        .contains("no real message content"));
+    assert_eq!(summary.imported_sessions, 0);
+    assert_eq!(summary.imported_events, 0);
+    assert!(store.list_sessions().unwrap().is_empty());
+}
+
+#[test]
+fn pi_session_import_rejects_tool_only_entries() {
+    let temp = tempdir();
+    let fixture = temp.path().join("pi-tool-only.jsonl");
+    fs::write(
+        &fixture,
+        concat!(
+            "{\"type\":\"session\",\"version\":3,\"id\":\"pi-tool-only\",\"timestamp\":\"2026-06-24T12:00:00Z\",\"cwd\":\"/workspace\"}\n",
+            "{\"type\":\"message\",\"id\":\"tool-call-entry\",\"timestamp\":\"2026-06-24T12:00:01Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"toolCall\",\"name\":\"bash\",\"input\":{\"command\":\"true\"}}]}}\n",
+            "{\"type\":\"message\",\"id\":\"tool-result-entry\",\"timestamp\":\"2026-06-24T12:00:02Z\",\"message\":{\"role\":\"toolResult\",\"content\":\"ok\"}}\n",
+            "{\"type\":\"message\",\"id\":\"bash-entry\",\"timestamp\":\"2026-06-24T12:00:03Z\",\"message\":{\"role\":\"bashExecution\",\"command\":\"true\",\"output\":\"ok\"}}\n",
+        ),
+    )
+    .unwrap();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_pi_session_jsonl(
+        &fixture,
+        &mut store,
+        PiSessionImportOptions {
+            source_path: Some(fixture.clone()),
+            imported_at: "2026-06-24T16:00:00Z".parse().unwrap(),
+            ..PiSessionImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 1);
+    assert!(summary.failures[0]
+        .error
+        .contains("no real message content"));
+    assert_eq!(summary.imported_sessions, 0);
+    assert_eq!(summary.imported_events, 0);
+    assert!(store.list_sessions().unwrap().is_empty());
+}
+
+#[test]
+fn pi_session_import_keeps_metadata_entries_when_real_messages_exist() {
     let temp = tempdir();
     let fixture = temp.path().join("pi-non-message-text.jsonl");
     fs::write(
             &fixture,
             concat!(
                 "{\"type\":\"session\",\"version\":3,\"id\":\"pi-non-message-text\",\"timestamp\":\"2026-06-24T12:00:00Z\",\"cwd\":\"/workspace\"}\n",
+                "{\"type\":\"message\",\"id\":\"real-user-entry\",\"timestamp\":\"2026-06-24T12:00:00.500Z\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"mixed real prompt\"}]}}\n",
                 "{\"type\":\"compaction\",\"id\":\"compact-entry\",\"timestamp\":\"2026-06-24T12:00:01Z\",\"summary\":\"compacted plan oracle\"}\n",
                 "{\"type\":\"branch_summary\",\"id\":\"branch-entry\",\"timestamp\":\"2026-06-24T12:00:02Z\",\"summary\":\"branch summary oracle\"}\n",
                 "{\"type\":\"custom_message\",\"id\":\"custom-message-entry\",\"timestamp\":\"2026-06-24T12:00:03Z\",\"content\":[{\"type\":\"text\",\"text\":\"custom message oracle\"}]}\n",
@@ -589,7 +690,7 @@ fn pi_session_import_extracts_text_from_non_message_entries() {
     .unwrap();
 
     assert_eq!(summary.failed, 0, "{:?}", summary.failures);
-    assert_eq!(summary.imported_events, 8);
+    assert_eq!(summary.imported_events, 9);
     let session_id = provider_session_uuid(CaptureProvider::Pi, "pi-non-message-text");
     let events = store.events_for_session(session_id).unwrap();
     let texts = events
@@ -597,6 +698,7 @@ fn pi_session_import_extracts_text_from_non_message_entries() {
         .filter_map(|event| event.payload.pointer("/body/text").and_then(Value::as_str))
         .collect::<Vec<_>>();
     for expected in [
+        "mixed real prompt",
         "compacted plan oracle",
         "branch summary oracle",
         "custom message oracle",

--- a/crates/ctx-history-capture/src/tests/support.rs
+++ b/crates/ctx-history-capture/src/tests/support.rs
@@ -734,6 +734,175 @@ pub(super) fn write_opencode_current_schema_db(temp: &TempDir, with_message: boo
     path
 }
 
+pub(super) fn write_opencode_session_message_metadata_with_legacy_message_db(
+    temp: &TempDir,
+) -> PathBuf {
+    write_opencode_strict_real_content_db(
+        temp,
+        "opencode-session-message-metadata-legacy.db",
+        true,
+        false,
+        true,
+        false,
+    )
+}
+
+pub(super) fn write_opencode_session_message_malformed_with_legacy_message_db(
+    temp: &TempDir,
+) -> PathBuf {
+    let path = write_opencode_strict_real_content_db(
+        temp,
+        "opencode-session-message-malformed-legacy.db",
+        true,
+        false,
+        true,
+        false,
+    );
+    let conn = Connection::open(&path).unwrap();
+    conn.execute(
+        "update session_message set data = ?1 where id = 'metadata-session-message'",
+        ["{\"time\":{\"created\":1782259200000},\"text\":"],
+    )
+    .unwrap();
+    path
+}
+
+pub(super) fn write_opencode_session_message_metadata_bad_seq_with_legacy_message_db(
+    temp: &TempDir,
+) -> PathBuf {
+    let path = write_opencode_session_message_metadata_with_legacy_message_db(temp);
+    let conn = Connection::open(&path).unwrap();
+    conn.execute(
+        "update session_message set seq = -1 where id = 'metadata-session-message'",
+        [],
+    )
+    .unwrap();
+    path
+}
+
+pub(super) fn write_opencode_session_entry_metadata_with_legacy_message_db(
+    temp: &TempDir,
+) -> PathBuf {
+    write_opencode_strict_real_content_db(
+        temp,
+        "opencode-session-entry-metadata-legacy.db",
+        false,
+        true,
+        true,
+        false,
+    )
+}
+
+pub(super) fn write_opencode_all_metadata_db(temp: &TempDir, name: &str) -> PathBuf {
+    write_opencode_strict_real_content_db(temp, name, true, true, false, true)
+}
+
+pub(super) fn write_opencode_tool_only_db(temp: &TempDir, name: &str) -> PathBuf {
+    let path = write_opencode_strict_real_content_db(temp, name, false, false, false, false);
+    let conn = Connection::open(&path).unwrap();
+    conn.execute(
+        "insert into session_message values (
+                'tool-only-session-message', 'strict-root', 'assistant', 1,
+                1782259200000, 1782259200000, ?1
+            )",
+        ["{\"time\":{\"created\":1782259200000},\"content\":[{\"type\":\"tool\",\"name\":\"bash\",\"input\":{\"command\":\"true\"}}]}"],
+    )
+    .unwrap();
+    path
+}
+
+fn write_opencode_strict_real_content_db(
+    temp: &TempDir,
+    name: &str,
+    session_message_metadata: bool,
+    session_entry_metadata: bool,
+    legacy_real_message: bool,
+    legacy_metadata_message: bool,
+) -> PathBuf {
+    let path = temp.path().join(name);
+    let conn = Connection::open(&path).unwrap();
+    conn.execute_batch(
+        "create table session (
+                id text primary key,
+                title text not null,
+                directory text not null,
+                time_created integer not null,
+                time_updated integer not null
+            );
+            create table session_message (
+                id text primary key,
+                session_id text not null,
+                type text not null,
+                seq integer not null,
+                time_created integer not null,
+                time_updated integer not null,
+                data text not null
+            );
+            create table session_entry (
+                id text primary key,
+                session_id text not null,
+                type text not null,
+                time_created integer not null,
+                time_updated integer not null,
+                data text not null
+            );
+            create table message (
+                id text primary key,
+                session_id text not null,
+                time_created integer not null,
+                time_updated integer not null,
+                data text not null
+            );",
+    )
+    .unwrap();
+    conn.execute(
+        "insert into session values (
+                'strict-root', 'strict root', '/workspace', 1782259200000, 1782259200000
+            )",
+        [],
+    )
+    .unwrap();
+    if session_message_metadata {
+        conn.execute(
+                "insert into session_message values (
+                    'metadata-session-message', 'strict-root', 'model_change', 1,
+                    1782259200000, 1782259200000, ?1
+                )",
+                ["{\"time\":{\"created\":1782259200000},\"provider\":\"openai\",\"model\":\"metadata-only\"}"],
+            )
+            .unwrap();
+    }
+    if session_entry_metadata {
+        conn.execute(
+            "insert into session_entry values (
+                    'metadata-session-entry', 'strict-root', 'label',
+                    1782259200001, 1782259200001, ?1
+                )",
+            ["{\"time\":{\"created\":1782259200001},\"label\":\"metadata-only\"}"],
+        )
+        .unwrap();
+    }
+    if legacy_real_message {
+        conn.execute(
+            "insert into message values (
+                    'legacy-real-message', 'strict-root', 1782259200002, 1782259200002, ?1
+                )",
+            ["{\"role\":\"user\",\"time\":{\"created\":1782259200002},\"text\":\"legacy fallback prompt\"}"],
+        )
+        .unwrap();
+    }
+    if legacy_metadata_message {
+        conn.execute(
+            "insert into message values (
+                    'legacy-metadata-message', 'strict-root', 1782259200002, 1782259200002, ?1
+                )",
+            ["{\"type\":\"model_change\",\"time\":{\"created\":1782259200002},\"model\":\"metadata-only-legacy\"}"],
+        )
+        .unwrap();
+    }
+    path
+}
+
 pub(super) fn write_opencode_future_incomplete_schema_db(temp: &TempDir) -> PathBuf {
     let path = temp.path().join("opencode-future-incomplete.db");
     let conn = Connection::open(&path).unwrap();


### PR DESCRIPTION
## Summary
- add a shared real-conversation-content gate for provider imports
- reject metadata/header-only OpenCode, Kilo, and Pi histories when real messages are required
- allow OpenCode legacy fallback only when authoritative tables are metadata-only, not malformed
- add focused regressions for metadata-only and malformed-authoritative-row cases

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p ctx-history-capture native_opencode`
- `cargo test -p ctx-history-capture pi_session_import`
- `cargo test -p ctx-history-capture native_kilo_rejects_metadata_only_sqlite_rows`
- `git diff --check`

## Adversarial Review Fixes
- prevented malformed current OpenCode rows from being masked by legacy table fallback
- added tool/header-only coverage so imports cannot pass with no real conversational content

## Review Notes
- Rebased on latest `origin/main` before push.