### PR TITLE
Document unmanaged install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ ctx keeps retrieval tied to sessions and events, so another agent can inspect th
 | [Install](https://ctx.rs/getting-started/install) | Install ctx, initialize local storage, and index discovered local history. |
 | [Quickstart](https://ctx.rs/first-search) | Search local history, inspect an event, open the session, and use JSON output. |
 | [Install the ctx skill](https://ctx.rs/skill) | Install the agent-history search skill with the open skills installer. |
+| [Package managers and unmanaged installs](docs/unmanaged-installs.md) | Install from GitHub Releases, mise, Homebrew, or source builds. |
 | [Agent plugin installs](docs/agent-skill-install.md) | Install the ctx skill through Codex, Claude Code, Cursor, or a raw skill folder. |
 | [SDKs](docs/sdks.md) | Use ctx agent history search from TypeScript, Python, Rust, Go, JVM, Swift, or .NET code. |
 | [Custom history plugins](docs/history-source-plugins.md) | Build an advanced local adapter for agent formats ctx does not support natively. |

--- a/crates/ctx-cli/src/docs.rs
+++ b/crates/ctx-cli/src/docs.rs
@@ -161,6 +161,15 @@ const TOPICS: &[DocTopic] = &[
         body: include_str!("../../../docs/upgrade.md"),
     },
     DocTopic {
+        id: "unmanaged-installs",
+        title: "Package Managers And Unmanaged Installs",
+        audience: "human",
+        summary: "GitHub release binaries, mise, Homebrew, source builds, and unmanaged install behavior.",
+        tags: &["install", "github", "mise", "homebrew", "package-manager"],
+        source_path: "docs/unmanaged-installs.md",
+        body: include_str!("../../../docs/unmanaged-installs.md"),
+    },
+    DocTopic {
         id: "agent-usage",
         title: "Agent Usage",
         audience: "agent",

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -35,4 +35,6 @@ Useful starting points:
 - `ctx docs show sql` for stable read-only SQL views;
 - `ctx docs show mcp` for read-only MCP tools;
 - `ctx docs show upgrade` for managed upgrade and auto-upgrade behavior;
+- `ctx docs show unmanaged-installs` for GitHub release binaries, mise,
+  Homebrew, and source builds;
 - `ctx docs show json-contracts` for structured output contracts.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,6 +39,9 @@ install, use `--skill-agent codex`, repeat `--skill-agent`, or use
 When working from source, use `cargo build -p ctx` or
 `cargo install --path crates/ctx-cli`.
 
+For GitHub release binaries, mise, Homebrew, and source builds, see
+[Package Managers And Unmanaged Installs](unmanaged-installs.md).
+
 ## 2. Set Up And Index
 
 ```bash

--- a/docs/unmanaged-installs.md
+++ b/docs/unmanaged-installs.md
@@ -1,0 +1,112 @@
+# Package Managers And Unmanaged Installs
+
+The official installer is the recommended way to install ctx. It installs the
+CLI, installs the bundled agent-history skill, runs initial setup, and writes
+the installer marker used by `ctx upgrade` and background self-upgrade.
+
+Use an unmanaged install when you want to manage the binary yourself. This page
+is for users who prefer a direct release binary, mise, Homebrew, or a source
+build.
+
+After any unmanaged install, run:
+
+```bash
+ctx skill install
+ctx setup
+```
+
+Unmanaged installs do not write the official installer marker. `ctx upgrade`
+and background self-upgrade will not apply; use the same tool or manual process
+that installed ctx to upgrade it.
+
+## Release Assets
+
+Stable releases publish prebuilt binaries on GitHub Releases:
+
+| Platform | Asset |
+| --- | --- |
+| Linux x64 | `ctx-linux-x64` |
+| macOS Apple Silicon | `ctx-macos-arm64` |
+| macOS Intel | `ctx-macos-x64` |
+| Windows x64 | `ctx-windows-x64.exe` |
+| FreeBSD x64 | `ctx-freebsd-x64` |
+
+Each release also publishes `SHA256SUMS` for the binary assets.
+
+For pinned installs, GitHub release asset URLs use this pattern:
+
+```text
+https://github.com/ctxrs/ctx/releases/download/vVERSION/ASSET
+```
+
+For example:
+
+```text
+https://github.com/ctxrs/ctx/releases/download/v0.20.0/ctx-linux-x64
+https://github.com/ctxrs/ctx/releases/download/v0.20.0/SHA256SUMS
+```
+
+## Direct GitHub Download
+
+On Linux x64:
+
+```bash
+curl -fL -O https://github.com/ctxrs/ctx/releases/latest/download/ctx-linux-x64
+curl -fL -O https://github.com/ctxrs/ctx/releases/latest/download/SHA256SUMS
+grep '  ctx-linux-x64$' SHA256SUMS | sha256sum -c -
+mkdir -p ~/.local/bin
+install -m 0755 ctx-linux-x64 ~/.local/bin/ctx
+```
+
+On macOS, choose the asset for your CPU and verify it with `shasum`:
+
+```bash
+curl -fL -O https://github.com/ctxrs/ctx/releases/latest/download/ctx-macos-arm64
+curl -fL -O https://github.com/ctxrs/ctx/releases/latest/download/SHA256SUMS
+grep '  ctx-macos-arm64$' SHA256SUMS | shasum -a 256 -c -
+mkdir -p ~/.local/bin
+install -m 0755 ctx-macos-arm64 ~/.local/bin/ctx
+```
+
+For Windows x64, download `ctx-windows-x64.exe` and `SHA256SUMS`, verify the
+file hash, then place it on `Path` as `ctx.exe`.
+
+## mise
+
+mise can install ctx directly from GitHub Releases:
+
+```bash
+mise use -g 'github:ctxrs/ctx[bin=ctx]@latest'
+```
+
+For a pinned install, replace `latest` with a release version:
+
+```bash
+mise use -g 'github:ctxrs/ctx[bin=ctx]@0.20.0'
+```
+
+mise owns upgrades for this install. Re-run `ctx skill install` after upgrading
+when you want to refresh the bundled agent skill.
+
+## Homebrew
+
+The ctx org maintains a Homebrew tap:
+
+```bash
+brew install ctxrs/tap/ctx
+```
+
+Homebrew owns upgrades for this install. Run `ctx skill install` and
+`ctx setup` after installing.
+
+## Source Builds
+
+For source builds from a checkout:
+
+```bash
+cargo build -p ctx --release
+cargo install --path crates/ctx-cli
+```
+
+Source builds are unmanaged. They do not use the official release metadata or
+installer-managed upgrade path.

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -27,6 +27,7 @@ required_paths=(
   docs/provider-adapter-api.md
   docs/redaction-corpus.md
   docs/agent-skill-install.md
+  docs/unmanaged-installs.md
   docs/sdks.md
   skills/ctx-agent-history-search/SKILL.md
   plugins/ctx-agent-history-search/skills/ctx-agent-history-search/SKILL.md

--- a/scripts/check-github-release-assets.sh
+++ b/scripts/check-github-release-assets.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/check-github-release-assets.sh TAG [REPO]
+
+Checks that a published GitHub Release has the expected ctx binary assets and
+that SHA256SUMS verifies them. REPO defaults to ctxrs/ctx.
+USAGE
+}
+
+tag="${1:-}"
+repo="${2:-ctxrs/ctx}"
+
+if [[ -z "${tag}" || "${tag}" == "-h" || "${tag}" == "--help" ]]; then
+  usage
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  printf 'gh is required\n' >&2
+  exit 127
+fi
+
+sha256_check() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c -
+    return
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c -
+    return
+  fi
+
+  printf 'sha256sum or shasum is required\n' >&2
+  exit 127
+}
+
+expected_assets=(
+  ctx-freebsd-x64
+  ctx-linux-x64
+  ctx-macos-arm64
+  ctx-macos-x64
+  ctx-windows-x64.exe
+  SHA256SUMS
+)
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/ctx-github-release-assets.XXXXXX")"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+expected_file="${tmp_dir}/expected.txt"
+actual_file="${tmp_dir}/actual.txt"
+
+printf '%s\n' "${expected_assets[@]}" | sort > "${expected_file}"
+gh release view "${tag}" --repo "${repo}" --json assets --jq '.assets[].name' | sort > "${actual_file}"
+
+if ! cmp -s "${expected_file}" "${actual_file}"; then
+  printf 'GitHub release assets for %s do not match expected set\n' "${tag}" >&2
+  printf '\nExpected:\n' >&2
+  cat "${expected_file}" >&2
+  printf '\nActual:\n' >&2
+  cat "${actual_file}" >&2
+  exit 1
+fi
+
+for asset in "${expected_assets[@]}"; do
+  gh release download "${tag}" --repo "${repo}" --dir "${tmp_dir}" --pattern "${asset}" --clobber
+done
+
+cd "${tmp_dir}"
+for asset in \
+  ctx-linux-x64 \
+  ctx-macos-arm64 \
+  ctx-macos-x64 \
+  ctx-windows-x64.exe \
+  ctx-freebsd-x64; do
+  grep "  ${asset}$" SHA256SUMS | sha256_check
+done
+
+printf 'GitHub release assets ok: %s %s\n' "${repo}" "${tag}"

--- a/scripts/stage-github-release-assets.sh
+++ b/scripts/stage-github-release-assets.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/stage-github-release-assets.sh [ARTIFACT_DIR] [OUT_DIR]
+
+Stages public GitHub Release assets from built public CLI artifacts.
+
+Inputs default to target/public-cli-artifacts.
+Outputs default to target/github-release-assets.
+USAGE
+}
+
+artifact_dir="${1:-target/public-cli-artifacts}"
+out_dir="${2:-target/github-release-assets}"
+
+if [[ "${artifact_dir}" == "-h" || "${artifact_dir}" == "--help" ]]; then
+  usage
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+sha256_file() {
+  local path="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${path}" | awk '{ print $1 }'
+    return
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${path}" | awk '{ print $1 }'
+    return
+  fi
+
+  printf 'sha256sum or shasum is required\n' >&2
+  exit 127
+}
+
+stage_asset() {
+  local source_name="$1"
+  local dest_name="$2"
+  local source_path="${artifact_dir%/}/${source_name}"
+  local dest_path="${out_dir%/}/${dest_name}"
+
+  if [[ ! -f "${source_path}" ]]; then
+    printf 'missing public CLI artifact: %s\n' "${source_path}" >&2
+    exit 1
+  fi
+
+  install -m 0755 "${source_path}" "${dest_path}"
+  printf '%s  %s\n' "$(sha256_file "${dest_path}")" "${dest_name}" >> "${out_dir%/}/SHA256SUMS"
+}
+
+mkdir -p "${out_dir}"
+rm -f \
+  "${out_dir%/}/ctx-linux-x64" \
+  "${out_dir%/}/ctx-macos-arm64" \
+  "${out_dir%/}/ctx-macos-x64" \
+  "${out_dir%/}/ctx-windows-x64.exe" \
+  "${out_dir%/}/ctx-freebsd-x64" \
+  "${out_dir%/}/SHA256SUMS"
+
+stage_asset ctx ctx-linux-x64
+stage_asset ctx-macos-arm64 ctx-macos-arm64
+stage_asset ctx-macos-x64 ctx-macos-x64
+stage_asset ctx.exe ctx-windows-x64.exe
+stage_asset ctx-freebsd-x64 ctx-freebsd-x64
+
+printf 'staged GitHub release assets in %s\n' "${out_dir}"


### PR DESCRIPTION
## Summary

- add `docs/unmanaged-installs.md` as the fallback page for users who want direct-binary, mise, Homebrew, or source-build installs instead of the official hosted installer
- document the user-facing GitHub release asset names, checksum file, pinned URL shape, and unmanaged-install behavior
- link the new page from README, getting started, and embedded `ctx docs` without adding these paths to the primary install recommendation
- add release helpers to stage the public GitHub asset names and verify published release assets plus `SHA256SUMS`

## Notes

The unmanaged-install page is part of the public product docs set, so it is mirrored into `ctx docs` along with the other repo docs. Generated man pages remain separate and continue to come from the CLI command tree rather than this page.

The ctx org has a Homebrew tap at `ctxrs/homebrew-tap`; this PR documents `brew install ctxrs/tap/ctx`. Keeping that tap in sync is release-process work and is now documented in `ctx-private`.

## Verification

- `bash scripts/check-docs.sh`
- `cargo fmt --check`
- `git diff --check`
- `scripts/check-github-release-assets.sh v0.20.0 ctxrs/ctx`
- staged dummy public CLI artifacts with `scripts/stage-github-release-assets.sh` and verified generated `SHA256SUMS`