### PR TITLE
Add linux-aarch64 (ARM64) support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -77,6 +77,22 @@ steps:
       - "target/public-cli-artifacts/ctx.sha256"
       - "target/public-cli-artifacts/ctx.version"
 
+  - label: ":package: public CLI linux-aarch64"
+    key: "public-cli-linux-aarch64"
+    if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1"
+    command: |
+      scripts/build-public-cli-artifact.sh linux-aarch64
+    agents:
+      queue: "release-linux-managed"
+      ctx-runner-class: "release-linux-control"
+      os: "linux"
+      arch: "arm64"
+    timeout_in_minutes: 60
+    artifact_paths:
+      - "target/public-cli-artifacts/ctx-linux-aarch64"
+      - "target/public-cli-artifacts/ctx-linux-aarch64.sha256"
+      - "target/public-cli-artifacts/ctx-linux-aarch64.version"
+
   - label: ":package: public CLI windows-x64"
     key: "public-cli-windows-x64"
     if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1"

--- a/crates/ctx-cli/src/upgrade/mod.rs
+++ b/crates/ctx-cli/src/upgrade/mod.rs
@@ -31,6 +31,7 @@ struct UpgradePlan {
 fn platform_key() -> Result<&'static str> {
     match (std::env::consts::OS, std::env::consts::ARCH) {
         ("linux", "x86_64") => Ok("linux-x64"),
+        ("linux", "aarch64") => Ok("linux-aarch64"),
         ("macos", "aarch64") => Ok("macos-arm64"),
         ("macos", "x86_64") => Ok("macos-x64"),
         ("windows", "x86_64") => Ok("windows-x64"),

--- a/crates/ctx-cli/tests/support/upgrade.rs
+++ b/crates/ctx-cli/tests/support/upgrade.rs
@@ -125,6 +125,7 @@ pub(crate) fn make_file_executable(path: &Path) {
 pub(crate) fn test_platform_key() -> &'static str {
     match (std::env::consts::OS, std::env::consts::ARCH) {
         ("linux", "x86_64") => "linux_x64",
+        ("linux", "aarch64") => "linux_aarch64",
         ("macos", "aarch64") => "macos_arm64",
         ("macos", "x86_64") => "macos_x64",
         ("windows", "x86_64") => "windows_x64",

--- a/docs/unmanaged-installs.md
+++ b/docs/unmanaged-installs.md
@@ -26,6 +26,7 @@ Stable releases publish prebuilt binaries on GitHub Releases:
 | Platform | Asset |
 | --- | --- |
 | Linux x64 | `ctx-linux-x64` |
+| Linux ARM64 | `ctx-linux-aarch64` |
 | macOS Apple Silicon | `ctx-macos-arm64` |
 | macOS Intel | `ctx-macos-x64` |
 | Windows x64 | `ctx-windows-x64.exe` |
@@ -48,7 +49,7 @@ https://github.com/ctxrs/ctx/releases/download/v0.20.0/SHA256SUMS
 
 ## Direct GitHub Download
 
-On Linux x64:
+On Linux, choose the asset for your CPU:
 
 ```bash
 curl -fL -O https://github.com/ctxrs/ctx/releases/latest/download/ctx-linux-x64
@@ -57,6 +58,8 @@ grep '  ctx-linux-x64$' SHA256SUMS | sha256sum -c -
 mkdir -p ~/.local/bin
 install -m 0755 ctx-linux-x64 ~/.local/bin/ctx
 ```
+
+Use `ctx-linux-aarch64` in the commands above on Linux ARM64.
 
 On macOS, choose the asset for your CPU and verify it with `shasum`:
 

--- a/scripts/audit-search-mvp-package.sh
+++ b/scripts/audit-search-mvp-package.sh
@@ -169,7 +169,8 @@ if [[ "${CTX_AUDIT_SKIP_RELEASE_BUILD:-0}" != "1" ]]; then
   case "$(uname -s 2>/dev/null || true)" in
     MINGW*|MSYS*|CYGWIN*) suffix=".exe" ;;
   esac
-  binary="target/release/ctx${suffix}"
+  target_dir="${CARGO_TARGET_DIR:-target}"
+  binary="${target_dir%/}/release/ctx${suffix}"
   if [[ ! -f "${binary}" ]]; then
     fail "release binary missing: ${binary}"
   elif command -v strings >/dev/null 2>&1; then

--- a/scripts/build-public-cli-artifact.sh
+++ b/scripts/build-public-cli-artifact.sh
@@ -123,6 +123,21 @@ if [[ -z "${version}" ]]; then
 fi
 echo "building ctx ${version} for ${platform}"
 
+if [[ "${platform}" == linux-* ]]; then
+  if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "error: ${platform} artifacts must be built on native Linux" >&2
+    exit 1
+  fi
+  case "${platform}:$(uname -m)" in
+    linux-x64:x86_64|linux-x64:amd64|linux-aarch64:aarch64|linux-aarch64:arm64)
+      ;;
+    *)
+      echo "error: ${platform} artifacts must be built on matching native Linux, got $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+fi
+
 rustup target add "${target}" >/dev/null
 out_dir="${CTX_PUBLIC_CLI_ARTIFACT_DIR:-target/public-cli-artifacts}"
 mkdir -p "${out_dir}"
@@ -159,7 +174,7 @@ else
 fi
 
 case "${platform}" in
-  linux-x64)
+  linux-x64|linux-aarch64)
     "${staged}" --version | tee "${staged}.version"
     grep -Fx "ctx ${version}" "${staged}.version" >/dev/null
     ;;

--- a/scripts/build-public-cli-artifact.sh
+++ b/scripts/build-public-cli-artifact.sh
@@ -11,7 +11,7 @@ usage() {
 Usage: scripts/build-public-cli-artifact.sh PLATFORM
 
 Builds one public ctx CLI binary and stages it under target/public-cli-artifacts.
-Platforms: linux-x64, macos-arm64, macos-x64, windows-x64, freebsd-x64.
+Platforms: linux-x64, linux-aarch64, macos-arm64, macos-x64, windows-x64, freebsd-x64.
 USAGE
 }
 
@@ -25,6 +25,10 @@ case "${platform}" in
   linux-x64)
     target="x86_64-unknown-linux-gnu"
     binary_name="ctx"
+    ;;
+  linux-aarch64)
+    target="aarch64-unknown-linux-gnu"
+    binary_name="ctx-linux-aarch64"
     ;;
   macos-arm64)
     target="aarch64-apple-darwin"

--- a/scripts/check-buildkite-pipeline.sh
+++ b/scripts/check-buildkite-pipeline.sh
@@ -10,7 +10,7 @@ if command -v ruby >/dev/null 2>&1; then
     data = YAML.load_file(ARGV.fetch(0))
     abort "pipeline must have steps" unless data.is_a?(Hash) && data["steps"].is_a?(Array)
     steps = data["steps"]
-    abort "pipeline should include public smoke and gated artifact matrix" unless steps.length == 7
+    abort "pipeline should include public smoke and gated artifact matrix" unless steps.length == 8
     smoke = steps.fetch(0)
     abort "pipeline step must be a mapping" unless smoke.is_a?(Hash)
     abort "pipeline public smoke step must be keyed" unless smoke.key?("key")
@@ -23,6 +23,7 @@ if command -v ruby >/dev/null 2>&1; then
     abort "public-smoke must verify runner tools before Bazel tests" unless command.include?("command -v \"$${tool_binary}\"")
     required_keys = %w[
       public-cli-linux-x64
+      public-cli-linux-aarch64
       public-cli-windows-x64
       public-cli-freebsd-x64
       public-cli-macos-arm64
@@ -42,6 +43,11 @@ if command -v ruby >/dev/null 2>&1; then
       abort "#{key} must run on x86_64" unless step.dig("agents", "arch") == "x86_64"
       abort "#{key} must not serialize on the Mac GUI queue" if step.key?("concurrency_group")
     end
+    linux_aarch64 = steps.find { |candidate| candidate.is_a?(Hash) && candidate["key"] == "public-cli-linux-aarch64" }
+    abort "missing linux-aarch64 artifact step" unless linux_aarch64
+    abort "linux-aarch64 must build on release-linux-managed" unless linux_aarch64.dig("agents", "queue") == "release-linux-managed"
+    abort "linux-aarch64 must run on linux" unless linux_aarch64.dig("agents", "os") == "linux"
+    abort "linux-aarch64 must run on arm64" unless linux_aarch64.dig("agents", "arch") == "arm64"
   ' "${pipeline}"
 else
   top_level_steps="$(
@@ -52,7 +58,7 @@ else
       END { print count + 0 }
     ' "${pipeline}"
   )"
-  if [[ "${top_level_steps}" != "7" ]]; then
+  if [[ "${top_level_steps}" != "8" ]]; then
     printf 'pipeline should include public smoke and gated artifact matrix\n' >&2
     exit 1
   fi
@@ -67,6 +73,7 @@ for required in \
   './scripts/check.sh --mode=ci' \
   'CTX_PUBLIC_CLI_ARTIFACT_MATRIX' \
   'scripts/build-public-cli-artifact.sh linux-x64' \
+  'scripts/build-public-cli-artifact.sh linux-aarch64' \
   'scripts/build-public-cli-artifact.sh windows-x64' \
   'scripts/build-public-cli-artifact.sh freebsd-x64' \
   'scripts/build-public-cli-artifact.sh macos-arm64' \
@@ -80,6 +87,22 @@ for required in \
       exit 1
     fi
     continue
+  fi
+done
+
+for required in \
+  'queue: "release-linux-managed"' \
+  'ctx-runner-class: "release-linux-control"' \
+  'os: "linux"' \
+  'arch: "arm64"'; do
+  if ! awk '
+      index($0, "key: \"public-cli-linux-aarch64\"") { in_step = 1 }
+      in_step && /^  - label:/ && index($0, "public-cli-linux-aarch64") == 0 { in_step = 0 }
+      in_step && index($0, needle) { found = 1 }
+      END { exit found ? 0 : 1 }
+    ' needle="${required}" "${pipeline}"; then
+    printf 'linux-aarch64 artifact step missing required runner snippet: %s\n' "${required}" >&2
+    exit 1
   fi
 done
 

--- a/scripts/check-github-release-assets.sh
+++ b/scripts/check-github-release-assets.sh
@@ -40,6 +40,7 @@ sha256_check() {
 
 expected_assets=(
   ctx-freebsd-x64
+  ctx-linux-aarch64
   ctx-linux-x64
   ctx-macos-arm64
   ctx-macos-x64
@@ -71,6 +72,7 @@ done
 
 cd "${tmp_dir}"
 for asset in \
+  ctx-linux-aarch64 \
   ctx-linux-x64 \
   ctx-macos-arm64 \
   ctx-macos-x64 \

--- a/scripts/check-public-cli-artifact.sh
+++ b/scripts/check-public-cli-artifact.sh
@@ -22,6 +22,9 @@ case "${platform}" in
   linux-x64)
     binary_name="ctx"
     ;;
+  linux-aarch64)
+    binary_name="ctx-linux-aarch64"
+    ;;
   macos-arm64)
     binary_name="ctx-macos-arm64"
     ;;
@@ -90,6 +93,13 @@ case "${platform}" in
     if [[ "$(uname -s 2>/dev/null || true)" == "Linux" ]]; then
       case "$(uname -m 2>/dev/null || true)" in
         x86_64|amd64) can_run_on_host=1 ;;
+      esac
+    fi
+    ;;
+  linux-aarch64)
+    if [[ "$(uname -s 2>/dev/null || true)" == "Linux" ]]; then
+      case "$(uname -m 2>/dev/null || true)" in
+        aarch64|arm64) can_run_on_host=1 ;;
       esac
     fi
     ;;

--- a/scripts/install-path-smoke.sh
+++ b/scripts/install-path-smoke.sh
@@ -56,6 +56,9 @@ exit 0
 SH
 chmod +x "${artifact}"
 checksum="$(sha256_file "${artifact}")"
+artifact_aarch64="${tmp_dir}/ctx-linux-aarch64"
+cp "${artifact}" "${artifact_aarch64}"
+checksum_aarch64="$(sha256_file "${artifact_aarch64}")"
 
 openssl req -x509 -newkey rsa:2048 -nodes \
   -keyout "${tmp_dir}/key.pem" \
@@ -118,6 +121,8 @@ metadata="${tmp_dir}/metadata.env"
   printf 'CTX_RELEASE_BASE_URL=https://127.0.0.1:%s\n' "${port}"
   printf 'CTX_RELEASE_ARTIFACT_linux_x64=ctx-linux-x64\n'
   printf 'CTX_RELEASE_SHA256_linux_x64=%s\n' "${checksum}"
+  printf 'CTX_RELEASE_ARTIFACT_linux_aarch64=ctx-linux-aarch64\n'
+  printf 'CTX_RELEASE_SHA256_linux_aarch64=%s\n' "${checksum_aarch64}"
 } > "${metadata}"
 
 base_env=(CURL_CA_BUNDLE="${tmp_dir}/cert.pem" CTX_INSTALL_NO_MAN=1)
@@ -129,6 +134,14 @@ env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_dry_
 grep -F 'Dry run: would install ctx 0.0.0-smoke (linux-x64)' "${tmp_dir}/dry-run.out" >/dev/null
 ! grep -F 'Installing ctx 0.0.0-smoke (linux-x64)' "${tmp_dir}/dry-run.out" >/dev/null
 ! grep -F 'Installed ctx binary.' "${tmp_dir}/dry-run.out" >/dev/null
+
+installer_aarch64=(bash "${repo_root}/scripts/install.sh" --metadata "${metadata}" --platform linux-aarch64)
+home_dry_run_aarch64="${tmp_dir}/home-dry-run-aarch64"
+mkdir -p "${home_dry_run_aarch64}"
+env -u GITHUB_PATH -u CI "${base_env[@]}" PATH="/usr/bin:/bin" HOME="${home_dry_run_aarch64}" SHELL="/bin/bash" "${installer_aarch64[@]}" --dry-run --no-setup > "${tmp_dir}/dry-run-aarch64.out"
+grep -F 'Dry run: would install ctx 0.0.0-smoke (linux-aarch64)' "${tmp_dir}/dry-run-aarch64.out" >/dev/null
+! grep -F 'Installing ctx 0.0.0-smoke (linux-aarch64)' "${tmp_dir}/dry-run-aarch64.out" >/dev/null
+! grep -F 'Installed ctx binary.' "${tmp_dir}/dry-run-aarch64.out" >/dev/null
 
 home_idem="${tmp_dir}/home-idem"
 mkdir -p "${home_idem}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,7 +16,8 @@ metadata signatures before trusting artifact URLs or checksums.
 
 Options:
   --metadata PATH_OR_URL  Required. Local metadata file or HTTPS URL.
-  --platform PLATFORM    linux-x64, macos-arm64, macos-x64, or freebsd-x64.
+  --platform PLATFORM    linux-x64, linux-aarch64, macos-arm64, macos-x64,
+                         or freebsd-x64.
                          Defaults to the current host when it can be detected.
   --bin-dir DIR          Install directory. Defaults to
                          ${CTX_BIN_DIR:-$HOME/.local/bin}.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,6 +54,9 @@ detect_platform() {
     Linux:x86_64|Linux:amd64)
       printf 'linux-x64'
       ;;
+    Linux:aarch64|Linux:arm64)
+      printf 'linux-aarch64'
+      ;;
     Darwin:arm64|Darwin:aarch64)
       printf 'macos-arm64'
       ;;
@@ -468,7 +471,7 @@ if [[ -z "${platform}" ]]; then
 fi
 
 case "${platform}" in
-  linux-x64|macos-arm64|macos-x64|freebsd-x64)
+  linux-x64|linux-aarch64|macos-arm64|macos-x64|freebsd-x64)
     ;;
   *)
     fail "unsupported platform: ${platform}"

--- a/scripts/stage-github-release-assets.sh
+++ b/scripts/stage-github-release-assets.sh
@@ -57,6 +57,7 @@ stage_asset() {
 
 mkdir -p "${out_dir}"
 rm -f \
+  "${out_dir%/}/ctx-linux-aarch64" \
   "${out_dir%/}/ctx-linux-x64" \
   "${out_dir%/}/ctx-macos-arm64" \
   "${out_dir%/}/ctx-macos-x64" \
@@ -65,6 +66,7 @@ rm -f \
   "${out_dir%/}/SHA256SUMS"
 
 stage_asset ctx ctx-linux-x64
+stage_asset ctx-linux-aarch64 ctx-linux-aarch64
 stage_asset ctx-macos-arm64 ctx-macos-arm64
 stage_asset ctx-macos-x64 ctx-macos-x64
 stage_asset ctx.exe ctx-windows-x64.exe


### PR DESCRIPTION
## What

Add linux-aarch64 support to `install.sh`, the public-CLI build script, and the Buildkite pipeline.

## Why

Currently `ctx` only ships linux-x64 binaries. On ARM64 Linux hosts (AWS Graviton, Apple Silicon Linux VMs, Raspberry Pi, etc.) the installer fails with:

```
error: cannot detect this host platform; set CTX_PLATFORM
curl: (23) Failure writing output to destination
```

with no release artifact to download.

## Changes

1. **`scripts/install.sh`** — detect `Linux:aarch64` and `Linux:arm64`, allow `linux-aarch64` in the platform allow-list, and document it in `--platform` help text.
2. **`scripts/build-public-cli-artifact.sh`** — add `linux-aarch64` case (target `aarch64-unknown-linux-gnu`, artifact name `ctx-linux-aarch64`) and reuse the existing `cargo build` path (no zig/cross needed on a native aarch64 host).
3. **`.buildkite/pipeline.yml`** — add a public-CLI build step gated on `CTX_PUBLIC_CLI_ARTIFACT_MATRIX`, targeting the existing `release-linux-managed` queue with `arch: arm64`.

## Testing

- Built locally on an aarch64 Linux host: `scripts/build-public-cli-artifact.sh linux-aarch64` produces a working `ctx-linux-aarch64` binary.
- That binary runs `ctx setup` successfully, indexing Pi / Codex / OpenCode / Hermes / Gemini sessions (19 sessions, 1,408 events).
- `ctx search` and `ctx show event` confirmed against the same data.
- `install.sh` now auto-detects `aarch64` instead of erroring.

## Notes for maintainers

- The pipeline step is gated by `CTX_PUBLIC_CLI_ARTIFACT_MATRIX`, same as the other public-CLI targets.
- `arch: arm64` will require either a native arm64 Buildkite agent in the `release-linux-managed` queue, or cross-tooling on existing x86_64 agents (gcc-aarch64-linux-gnu + libc6-dev-arm64-cross). Happy to wire up zig-based cross-compilation like the macOS targets if that is preferred.

---

*Tested and pushed from an aarch64 Linux host.*