### PR TITLE
Harden CI test environment

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,12 +16,19 @@ test:ci --flaky_test_attempts=1
 test:ci --test_env=BUILDKITE
 test:ci --test_env=BUILDKITE_BUILD_ID
 test:ci --test_env=CI
+test:ci --test_env=GITHUB_ACTIONS
 test:ci --test_env=CTX_CARGO_LOCKED=1
 test:ci --test_env=CTX_LOCAL_RESOURCE_CAP=1
+test:ci --test_env=CTX_ISOLATE_TOOL_ENV
+test:ci --test_env=CTX_SHARED_CARGO_TARGET_DIR
+# CI may provide isolated tool roots; bazel-test.sh supplies TEST_TMPDIR defaults when these are unset.
 test:ci --test_env=HOME
 test:ci --test_env=PATH
+test:ci --test_env=CARGO_BUILD_JOBS
 test:ci --test_env=CARGO_HOME
+test:ci --test_env=CARGO_TARGET_DIR
 test:ci --test_env=RUSTUP_HOME
+test:ci --test_env=RUST_TEST_THREADS
 test:ci --test_env=TMPDIR
 test:ci --test_env=CARGO_TERM_COLOR=always
 test:ci --test_output=errors

--- a/crates/ctx-cli/tests/support/fixtures.rs
+++ b/crates/ctx-cli/tests/support/fixtures.rs
@@ -33,9 +33,13 @@ pub(crate) fn materialized_fixture(category: &str, name: &str) -> String {
             .join(name),
         _ => panic!("unknown fixture category {category}"),
     };
-    let materialized_root = std::env::current_dir()
-        .unwrap()
-        .join("target/test-data/materialized-fixtures");
+    let materialized_root = std::env::var_os("TEST_TMPDIR")
+        .map(|path| PathBuf::from(path).join("test-data/materialized-fixtures"))
+        .unwrap_or_else(|| {
+            std::env::current_dir()
+                .unwrap()
+                .join("target/test-data/materialized-fixtures")
+        });
     fs::create_dir_all(&materialized_root).unwrap();
     let unique = format!(
         "{}-{}-{}-{}",

--- a/crates/ctx-history-capture/src/tests/support.rs
+++ b/crates/ctx-history-capture/src/tests/support.rs
@@ -158,8 +158,12 @@ pub(super) fn materialized_fixture(category: &str, name: &str) -> PathBuf {
             .join(name),
         _ => panic!("unknown fixture category {category}"),
     };
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../target/test-data/materialized-fixtures");
+    let root = std::env::var_os("TEST_TMPDIR")
+        .map(|path| PathBuf::from(path).join("test-data/materialized-fixtures"))
+        .unwrap_or_else(|| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../../target/test-data/materialized-fixtures")
+        });
     fs::create_dir_all(&root).unwrap();
     let unique = format!(
         "{}-{}-{}-{}",

--- a/crates/ctx-history-search/src/tests/support.rs
+++ b/crates/ctx-history-search/src/tests/support.rs
@@ -5,11 +5,15 @@ use super::{
 };
 
 fn tempdir() -> tempfile::TempDir {
-    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(2)
-        .unwrap()
-        .join("target/test-data");
+    let root = std::env::var_os("TEST_TMPDIR")
+        .map(|path| std::path::PathBuf::from(path).join("test-data"))
+        .unwrap_or_else(|| {
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .ancestors()
+                .nth(2)
+                .unwrap()
+                .join("target/test-data")
+        });
     std::fs::create_dir_all(&root).unwrap();
     tempfile::Builder::new()
         .prefix("ctx-history-search-")

--- a/crates/ctx-history-store/src/archive/tests.rs
+++ b/crates/ctx-history-store/src/archive/tests.rs
@@ -12,7 +12,9 @@ use crate::object_store::{object_relative_path, sha256_hex};
 use crate::StoreError;
 
 fn tempdir() -> tempfile::TempDir {
-    let root = std::env::current_dir().unwrap().join("target/test-data");
+    let root = std::env::var_os("TEST_TMPDIR")
+        .map(|path| std::path::PathBuf::from(path).join("test-data"))
+        .unwrap_or_else(|| std::env::current_dir().unwrap().join("target/test-data"));
     fs::create_dir_all(&root).unwrap();
     tempfile::Builder::new()
         .prefix("ctx-history-store-archive-validation-")

--- a/crates/ctx-history-store/src/catalog/tests.rs
+++ b/crates/ctx-history-store/src/catalog/tests.rs
@@ -34,7 +34,9 @@ type CatalogSessionCheckpointRow = (
 );
 
 fn tempdir() -> tempfile::TempDir {
-    let root = std::env::current_dir().unwrap().join("target/test-data");
+    let root = std::env::var_os("TEST_TMPDIR")
+        .map(|path| std::path::PathBuf::from(path).join("test-data"))
+        .unwrap_or_else(|| std::env::current_dir().unwrap().join("target/test-data"));
     fs::create_dir_all(&root).unwrap();
     tempfile::Builder::new()
         .prefix("ctx-history-store-catalog-")

--- a/crates/ctx-history-store/src/schema/tests.rs
+++ b/crates/ctx-history-store/src/schema/tests.rs
@@ -18,7 +18,9 @@ use crate::schema::migrations::{
 use crate::{Store, SCHEMA_VERSION};
 
 fn tempdir() -> tempfile::TempDir {
-    let root = std::env::current_dir().unwrap().join("target/test-data");
+    let root = std::env::var_os("TEST_TMPDIR")
+        .map(|path| std::path::PathBuf::from(path).join("test-data"))
+        .unwrap_or_else(|| std::env::current_dir().unwrap().join("target/test-data"));
     fs::create_dir_all(&root).unwrap();
     tempfile::Builder::new()
         .prefix("ctx-history-store-schema-")

--- a/crates/ctx-history-store/src/search/tests.rs
+++ b/crates/ctx-history-store/src/search/tests.rs
@@ -11,7 +11,9 @@ use uuid::Uuid;
 use crate::Store;
 
 fn tempdir() -> tempfile::TempDir {
-    let root = std::env::current_dir().unwrap().join("target/test-data");
+    let root = std::env::var_os("TEST_TMPDIR")
+        .map(|path| std::path::PathBuf::from(path).join("test-data"))
+        .unwrap_or_else(|| std::env::current_dir().unwrap().join("target/test-data"));
     fs::create_dir_all(&root).unwrap();
     tempfile::Builder::new()
         .prefix("ctx-history-store-search-order-")

--- a/scripts/bazel-test.sh
+++ b/scripts/bazel-test.sh
@@ -21,18 +21,12 @@ find_repo_root() {
 
 init_env() {
   find_repo_root
+  # shellcheck source=scripts/ci-common.sh
+  source "${PWD}/scripts/ci-common.sh"
+  ctx_init_bazel_test_env
+  ctx_init_resource_env
   export CARGO_TERM_COLOR="${CARGO_TERM_COLOR:-always}"
   export RUST_TEST_THREADS="${RUST_TEST_THREADS:-2}"
-  if [[ -z "${HOME:-}" ]]; then
-    local user_home
-    user_home="$(getent passwd "$(id -un)" | cut -d: -f6 || true)"
-    if [[ -n "${user_home}" && -d "${user_home}" ]]; then
-      export HOME="${user_home}"
-    else
-      export HOME="${PWD}/target/bazel-home"
-    fi
-  fi
-  mkdir -p "${HOME}"
 }
 
 run() {

--- a/scripts/check-loc-exceptions.tsv
+++ b/scripts/check-loc-exceptions.tsv
@@ -1,4 +1,4 @@
 path	max_lines	kind	reason	review_after
-crates/ctx-history-capture/src/tests/support.rs	1634	test	shared capture test fixture support; splitting now would add indirection without narrowing callers	2026-10-01
+crates/ctx-history-capture/src/tests/support.rs	1638	test	shared capture test fixture support plus hermetic fixture roots; splitting now would add indirection without narrowing callers	2026-10-01
 crates/ctx-cli/tests/native_providers.rs	1589	test	native provider public CLI scenario matrix; fixtures are already modular and splitting would scatter end-to-end coverage	2026-10-01
 crates/ctx-cli/src/commands/import/native.rs	1110	source	native provider dispatcher plus manifest helpers inherited over source cap; immediate split would couple CI gate to importer redesign	2026-10-01

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -4,11 +4,6 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${repo_root}"
 
-if [[ -z "${HOME:-}" ]]; then
-  export HOME="${repo_root}/target/bazel-home"
-fi
-mkdir -p "${HOME}"
-
 # shellcheck source=scripts/ci-common.sh
 source "${repo_root}/scripts/ci-common.sh"
 
@@ -19,6 +14,7 @@ init_bazel() {
     return 0
   fi
 
+  ctx_init_tool_env_defaults
   ctx_init_resource_env
   ctx_print_resource_env
 

--- a/scripts/ci-common.sh
+++ b/scripts/ci-common.sh
@@ -7,6 +7,88 @@ ctx_positive_int() {
   [[ "${1:-}" =~ ^[0-9]+$ ]] && (( "$1" > 0 ))
 }
 
+ctx_truthy() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+ctx_is_ci() {
+  [[ -n "${CI:-}" || -n "${GITHUB_ACTIONS:-}" || -n "${BUILDKITE:-}" || -n "${BUILDKITE_BUILD_ID:-}" ]]
+}
+
+ctx_default_tmpdir() {
+  if [[ -n "${TEST_TMPDIR:-}" ]]; then
+    printf '%s\n' "${TEST_TMPDIR}/tmp"
+  else
+    printf '%s\n' "${CTX_REPO_ROOT}/target/tmp"
+  fi
+}
+
+ctx_init_tool_env_defaults() {
+  local root
+
+  root="${CTX_TOOL_ENV_ROOT:-${CTX_REPO_ROOT}/target/tool-env}"
+  export HOME="${HOME:-${root}/home}"
+  export TMPDIR="${TMPDIR:-$(ctx_default_tmpdir)}"
+  export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${root}/cargo-target}"
+  if ctx_truthy "${CTX_ISOLATE_TOOL_ENV:-0}"; then
+    export CARGO_HOME="${CARGO_HOME:-${root}/cargo-home}"
+    export RUSTUP_HOME="${RUSTUP_HOME:-${root}/rustup-home}"
+  fi
+  mkdir -p "${HOME}" "${TMPDIR}" "${CARGO_TARGET_DIR}"
+  if [[ -n "${CARGO_HOME:-}" ]]; then
+    mkdir -p "${CARGO_HOME}"
+  fi
+  if [[ -n "${RUSTUP_HOME:-}" ]]; then
+    mkdir -p "${RUSTUP_HOME}"
+  fi
+}
+
+ctx_init_bazel_test_env() {
+  local root isolated_home
+
+  if [[ -n "${CTX_BAZEL_TEST_ENV_ROOT:-}" ]]; then
+    root="${CTX_BAZEL_TEST_ENV_ROOT}"
+  elif [[ -n "${TEST_TMPDIR:-}" ]]; then
+    root="${TEST_TMPDIR}/ctx-env"
+  else
+    root="${CTX_REPO_ROOT}/target-local/bazel-test-env"
+  fi
+
+  isolated_home=0
+  if [[ -z "${HOME:-}" || "${HOME}" == "${CTX_REPO_ROOT}/target/tool-env/home" || "${HOME}" == "${CTX_REPO_ROOT}/target/bazel-home" ]]; then
+    export HOME="${root}/home"
+    isolated_home=1
+  fi
+  if [[ -z "${TMPDIR:-}" || "${TMPDIR}" == "${CTX_REPO_ROOT}/target/tmp" || "${TMPDIR}" == "${CTX_REPO_ROOT}/target/tool-env/tmp" ]]; then
+    export TMPDIR="${root}/tmp"
+  fi
+  if [[ -z "${CARGO_HOME:-}" ]] && { ctx_truthy "${CTX_ISOLATE_TOOL_ENV:-0}" || (( isolated_home == 1 )); }; then
+    export CARGO_HOME="${root}/cargo-home"
+  fi
+  if [[ -z "${RUSTUP_HOME:-}" ]] && { ctx_truthy "${CTX_ISOLATE_TOOL_ENV:-0}" || (( isolated_home == 1 )); }; then
+    export RUSTUP_HOME="${root}/rustup-home"
+  fi
+  if [[ -n "${TEST_TMPDIR:-}" ]] && ! ctx_truthy "${CTX_SHARED_CARGO_TARGET_DIR:-0}"; then
+    export CARGO_TARGET_DIR="${root}/cargo-target"
+  else
+    export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${root}/cargo-target}"
+  fi
+  mkdir -p "${HOME}" "${TMPDIR}" "${CARGO_TARGET_DIR}"
+  if [[ -n "${CARGO_HOME:-}" ]]; then
+    mkdir -p "${CARGO_HOME}"
+  fi
+  if [[ -n "${RUSTUP_HOME:-}" ]]; then
+    mkdir -p "${RUSTUP_HOME}"
+  fi
+}
+
 ctx_detect_cpu_count() {
   local cores
 
@@ -183,6 +265,11 @@ ctx_ensure_rust_toolchain() {
     return 0
   fi
 
+  if ! ctx_truthy "${CTX_BOOTSTRAP_RUSTUP:-0}"; then
+    printf 'Rust toolchain is incomplete; cargo, rustc, rustfmt, and clippy are required. Set CTX_BOOTSTRAP_RUSTUP=1 for explicit local rustup bootstrap.\n' >&2
+    return 127
+  fi
+
   lock_file="${CTX_RUSTUP_LOCK:-${TMPDIR:-${CTX_REPO_ROOT}/target/tmp}/ctx-rustup.lock}"
   mkdir -p "$(dirname "${lock_file}")"
   if command -v flock >/dev/null 2>&1; then
@@ -212,6 +299,11 @@ ctx_ensure_rust_build_toolchain() {
 
   if ctx_rust_build_tools_available; then
     return 0
+  fi
+
+  if ! ctx_truthy "${CTX_BOOTSTRAP_RUSTUP:-0}"; then
+    printf 'Rust build toolchain is missing; cargo and rustc are required. Set CTX_BOOTSTRAP_RUSTUP=1 for explicit local rustup bootstrap.\n' >&2
+    return 127
   fi
 
   ctx_ensure_rust_toolchain
@@ -249,7 +341,7 @@ ctx_init_resource_env() {
 
   export CTX_CPU_COUNT="${cpu_count}"
   export CTX_TOTAL_MEMORY_GB="${memory_gb}"
-  export TMPDIR="${TMPDIR:-${CTX_REPO_ROOT}/target/tmp}"
+  export TMPDIR="${TMPDIR:-$(ctx_default_tmpdir)}"
   export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-${CTX_CARGO_JOBS:-${default_jobs}}}"
   export RUST_TEST_THREADS="${RUST_TEST_THREADS:-${CTX_TEST_THREADS:-${CARGO_BUILD_JOBS}}}"
   export CARGO_TERM_COLOR="${CARGO_TERM_COLOR:-always}"
@@ -440,7 +532,8 @@ ctx_find_bazel() {
     command -v bazelisk
     return 0
   fi
-  if [[ "${CTX_REQUIRE_BAZEL:-0}" == "1" || "${CTX_BOOTSTRAP_BAZELISK:-0}" == "1" ]]; then
+  if ctx_truthy "${CTX_BOOTSTRAP_BAZELISK:-0}"; then
+    printf 'Bazelisk network bootstrap explicitly enabled with CTX_BOOTSTRAP_BAZELISK=1\n' >&2
     ctx_bootstrap_bazelisk
     return $?
   fi

--- a/scripts/install-path-smoke.sh
+++ b/scripts/install-path-smoke.sh
@@ -35,6 +35,7 @@ require_cmd python3
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/ctx-install-path-smoke.XXXXXX")"
 server_pid=""
+port=""
 
 cleanup() {
   if [[ -n "${server_pid}" ]]; then
@@ -63,31 +64,44 @@ openssl req -x509 -newkey rsa:2048 -nodes \
   -addext 'subjectAltName=IP:127.0.0.1,DNS:localhost' \
   -days 1 >/dev/null 2>&1
 
-port="$(
-  python3 - <<'PY'
-import socket
-sock = socket.socket()
-sock.bind(("127.0.0.1", 0))
-print(sock.getsockname()[1])
-sock.close()
-PY
-)"
-
-python3 - "${tmp_dir}" "${port}" "${tmp_dir}/cert.pem" "${tmp_dir}/key.pem" <<'PY' >"${tmp_dir}/server.log" 2>&1 &
+port_file="${tmp_dir}/server.port"
+python3 - "${tmp_dir}" "${tmp_dir}/cert.pem" "${tmp_dir}/key.pem" "${port_file}" <<'PY' >"${tmp_dir}/server.log" 2>&1 &
 import functools
 import http.server
+import os
 import ssl
 import sys
 
-root, port, cert, key = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
+root, cert, key, port_file = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=root)
-server = http.server.ThreadingHTTPServer(("127.0.0.1", port), handler)
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
 context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
 context.load_cert_chain(certfile=cert, keyfile=key)
 server.socket = context.wrap_socket(server.socket, server_side=True)
+tmp_port_file = port_file + ".tmp"
+with open(tmp_port_file, "w", encoding="utf-8") as handle:
+    print(server.server_address[1], file=handle)
+os.replace(tmp_port_file, port_file)
 server.serve_forever()
 PY
 server_pid="$!"
+
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if [[ -s "${port_file}" ]]; then
+    port="$(cat "${port_file}")"
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    cat "${tmp_dir}/server.log" >&2 || true
+    exit 1
+  fi
+  sleep 0.2
+done
+if [[ -z "${port}" ]]; then
+  printf 'install path smoke server did not publish a port\n' >&2
+  cat "${tmp_dir}/server.log" >&2 || true
+  exit 1
+fi
 
 for _ in 1 2 3 4 5 6 7 8 9 10; do
   if CURL_CA_BUNDLE="${tmp_dir}/cert.pem" curl -fsS "https://127.0.0.1:${port}/ctx-linux-x64" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- centralize CI/Bazel environment setup in scripts/ci-common.sh
- make Bazel test temp/cache roots explicit and TEST_TMPDIR-aware
- harden installer path smoke with dynamic local HTTPS port selection
- update shared test fixture roots to respect TEST_TMPDIR

## Validation
- bash -n scripts/check.sh scripts/bazel-test.sh scripts/ci-common.sh scripts/install-path-smoke.sh
- cargo fmt --all -- --check
- git diff --check
- bash scripts/check-loc.sh
- bash scripts/install-path-smoke.sh
- bazel test //:installer_path_smoke --config=ci
- bash scripts/check.sh --mode=fast
- simulated GitHub Actions Rust env: cargo --version succeeds without synthetic CARGO_HOME/RUSTUP_HOME
- simulated Bazel TEST_TMPDIR env: CARGO_TARGET_DIR defaults to TEST_TMPDIR/ctx-env/cargo-target unless CTX_SHARED_CARGO_TARGET_DIR is set

## Notes
GitHub Actions checks are expected to fail to start while the repository account is locked for a billing issue; local validation above is the authoritative signal for this PR until billing is fixed.