### PR TITLE
Fix public CI clippy baseline

### DIFF
--- a/crates/ctx-cli/src/commands/import/report.rs
+++ b/crates/ctx-cli/src/commands/import/report.rs
@@ -271,7 +271,7 @@ pub(crate) fn error_summary(error: &anyhow::Error) -> String {
     let top = error.to_string();
     let root = error
         .chain()
-        .last()
+        .next_back()
         .map(ToString::to_string)
         .unwrap_or_else(|| top.clone());
     if is_sqlite_busy_text(&top) || is_sqlite_busy_text(&root) {

--- a/crates/ctx-history-search/src/tests/fast_path.rs
+++ b/crates/ctx-history-search/src/tests/fast_path.rs
@@ -222,27 +222,25 @@ fn clustered_fast_search_pages_past_dominant_first_session() {
     store.upsert_session(&later_session).unwrap();
 
     for index in 0..=(LARGE_EVENT_CORPUS_THRESHOLD as u64) {
-        let (record_id, session_id, text, occurred_at) = if index < 600 {
-            (
+        let (record_id, session_id, text, occurred_at) = match index.cmp(&600) {
+            std::cmp::Ordering::Less => (
                 dominant_record.id,
                 dominant_session.id,
                 "cluster-paging-needle dominant hit",
                 fixed_time() + chrono::Duration::milliseconds(2_000 - index as i64),
-            )
-        } else if index == 600 {
-            (
+            ),
+            std::cmp::Ordering::Equal => (
                 later_record.id,
                 later_session.id,
                 "cluster-paging-needle later hit",
                 fixed_time(),
-            )
-        } else {
-            (
+            ),
+            std::cmp::Ordering::Greater => (
                 dominant_record.id,
                 dominant_session.id,
                 "ordinary large history event",
                 fixed_time() - chrono::Duration::milliseconds(index as i64),
-            )
+            ),
         };
         store
             .upsert_event(&Event {


### PR DESCRIPTION
## Summary
- make the import error-summary root-cause iterator clippy-clean
- rewrite the clustered fast-path test branch as an explicit ordering match

## Validation
- RUSTUP_TOOLCHAIN=1.86.0 cargo clippy --workspace --all-targets --locked -- -D warnings
- bash scripts/check.sh -- test //:cargo_clippy //:source_diff_check --config=ci
- full local public gate passed before this follow-up: bash scripts/check.sh --mode=ci (18/18 targets)