### PR TITLE
fix ci: report missing required docs paths

### DIFF
--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -36,7 +36,10 @@ required_paths=(
 )
 
 for path in "${required_paths[@]}"; do
-  test -f "${path}"
+  if ! test -f "${path}"; then
+    printf 'missing required path: %s\n' "${path}" >&2
+    exit 1
+  fi
 done
 
 if command -v jq >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

When a required path is missing, `scripts/check-docs.sh` exits without indicating which path caused the failure.

This adds a small diagnostic before exiting to make the failure easier to identify.

## Testing

- Verified the script reports the missing path before exiting.
- Verified the exit status is unchanged.