### PR TITLE
fix keep grep fallback consistent with rg

### DIFF
--- a/scripts/bazel-test.sh
+++ b/scripts/bazel-test.sh
@@ -59,6 +59,7 @@ run_source_diff_check() {
 
   if grep -R -n -E '^(<<<<<<<|=======|>>>>>>>)' . \
     --exclude-dir=target \
+    --exclude-dir='bazel-*' \
     --exclude='Cargo.lock'; then
     fail 'conflict markers found'
   fi


### PR DESCRIPTION
## Summary

The `rg` and `grep` conflict-marker scans used different directory exclusions.

This updates the `grep` fallback to match the `rg` behavior by excluding generated `bazel-*` directories.

## Testing

- Reproduced the mismatch.
- Verified both paths now behave consistently.