### PR TITLE
fix(capture): skip oversized SQLite rows instead of aborting source

### DIFF
--- a/crates/ctx-history-capture/src/provider/providers/opencode.rs
+++ b/crates/ctx-history-capture/src/provider/providers/opencode.rs
@@ -10,7 +10,7 @@ use ctx_history_core::{
     ProviderRedactionBoundary, ProviderSessionEnvelope, ProviderSourceEnvelope,
     ProviderSourceTrust, RedactionState, SessionStatus, PROVIDER_CAPTURE_ENVELOPE_SCHEMA_VERSION,
 };
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 use serde_json::{json, Value};
 
 use crate::compute_payload_hash;
@@ -27,8 +27,8 @@ use crate::provider::native::{
 use crate::provider::providers::real_content::text_has_real_content;
 use crate::{
     CaptureError, ProviderAdapterContext, ProviderNormalizationResult, Result,
-    KILO_SQLITE_SOURCE_FORMAT, OPENCODE_SQLITE_SOURCE_FORMAT, PROVIDER_MAX_PREVIEW_CHARS,
-    PROVIDER_MAX_TEXT_CHARS,
+    KILO_SQLITE_SOURCE_FORMAT, MAX_PROVIDER_SQLITE_VALUE_BYTES, OPENCODE_SQLITE_SOURCE_FORMAT,
+    PROVIDER_MAX_PREVIEW_CHARS, PROVIDER_MAX_TEXT_CHARS,
 };
 
 pub(crate) struct OpenCodeSqliteDialect {
@@ -66,6 +66,9 @@ pub(crate) struct OpenCodeMessageSelection {
     pub(crate) rows: Vec<OpenCodeMessageRow>,
     pub(crate) source_table: Option<&'static str>,
     pub(crate) skipped_non_conversational_rows: usize,
+    /// Message rows whose `data` column exceeded `MAX_PROVIDER_SQLITE_VALUE_BYTES`
+    /// and were filtered out at read time so the rest of the source can still import.
+    pub(crate) skipped_oversized_rows: usize,
 }
 
 pub(crate) fn normalize_opencode_sqlite(
@@ -83,7 +86,7 @@ pub(crate) fn normalize_opencode_sqlite(
         .iter()
         .map(|session| session.id.clone())
         .collect::<BTreeSet<_>>();
-    let message_selection = opencode_session_messages(&conn, dialect, &session_ids)?;
+    let message_selection = opencode_session_messages(path, &conn, dialect, &session_ids)?;
     let mut result = ProviderNormalizationResult::default();
     if message_selection.rows.is_empty() {
         push_provider_import_failure(
@@ -113,6 +116,16 @@ pub(crate) fn normalize_opencode_sqlite(
     let raw_source_path = path.display().to_string();
     let message_source_table = message_selection.source_table;
     let skipped_non_conversational_rows = message_selection.skipped_non_conversational_rows;
+    let skipped_oversized_rows = message_selection.skipped_oversized_rows;
+    // Oversized rows are intentionally dropped at the SQL layer (see
+    // `oversized_message_row_ids`); they are not import failures. Counting
+    // them via `push_provider_import_failure` would set `summary.failed > 0`,
+    // which causes `import_normalized_provider_captures` to early-exit and
+    // `import_one_source_inner` to return `Err`, aborting `ctx search
+    // --refresh strict` and `ctx import` for the whole source even though
+    // every other row imported cleanly. Increment `summary.skipped` instead
+    // so the source stays usable.
+    result.summary.skipped += skipped_oversized_rows;
 
     for row in message_selection.rows {
         let provider_event_index =
@@ -343,18 +356,22 @@ pub(crate) fn opencode_sessions(
 }
 
 pub(crate) fn opencode_session_messages(
+    path: &Path,
     conn: &Connection,
     dialect: &OpenCodeSqliteDialect,
     session_ids: &BTreeSet<String>,
 ) -> Result<OpenCodeMessageSelection> {
     let mut skipped_non_conversational_rows = 0usize;
+    let mut skipped_oversized_rows = 0usize;
     if sqlite_table_exists(conn, "session_message")? {
-        let rows = opencode_session_message_rows(conn, dialect)?;
+        let (rows, oversized) = opencode_session_message_rows(path, conn, dialect)?;
+        skipped_oversized_rows += oversized;
         if opencode_rows_have_import_blocking_errors(&rows, session_ids, dialect) {
             return Ok(OpenCodeMessageSelection {
                 rows,
                 source_table: Some("session_message"),
                 skipped_non_conversational_rows,
+                skipped_oversized_rows,
             });
         }
         if opencode_rows_have_real_message_content(&rows) {
@@ -362,17 +379,20 @@ pub(crate) fn opencode_session_messages(
                 rows,
                 source_table: Some("session_message"),
                 skipped_non_conversational_rows,
+                skipped_oversized_rows,
             });
         }
         skipped_non_conversational_rows += rows.len();
     }
     if sqlite_table_exists(conn, "session_entry")? {
-        let rows = opencode_session_entry_rows(conn, dialect)?;
+        let (rows, oversized) = opencode_session_entry_rows(path, conn, dialect)?;
+        skipped_oversized_rows += oversized;
         if opencode_rows_have_import_blocking_errors(&rows, session_ids, dialect) {
             return Ok(OpenCodeMessageSelection {
                 rows,
                 source_table: Some("session_entry"),
                 skipped_non_conversational_rows,
+                skipped_oversized_rows,
             });
         }
         if opencode_rows_have_real_message_content(&rows) {
@@ -380,17 +400,20 @@ pub(crate) fn opencode_session_messages(
                 rows,
                 source_table: Some("session_entry"),
                 skipped_non_conversational_rows,
+                skipped_oversized_rows,
             });
         }
         skipped_non_conversational_rows += rows.len();
     }
     if sqlite_table_exists(conn, "message")? {
-        let rows = opencode_message_rows(conn, dialect)?;
+        let (rows, oversized) = opencode_message_rows(path, conn, dialect)?;
+        skipped_oversized_rows += oversized;
         if opencode_rows_have_import_blocking_errors(&rows, session_ids, dialect) {
             return Ok(OpenCodeMessageSelection {
                 rows,
                 source_table: Some("message"),
                 skipped_non_conversational_rows,
+                skipped_oversized_rows,
             });
         }
         if opencode_rows_have_real_message_content(&rows) {
@@ -398,6 +421,7 @@ pub(crate) fn opencode_session_messages(
                 rows,
                 source_table: Some("message"),
                 skipped_non_conversational_rows,
+                skipped_oversized_rows,
             });
         }
         skipped_non_conversational_rows += rows.len();
@@ -406,13 +430,71 @@ pub(crate) fn opencode_session_messages(
         rows: Vec::new(),
         source_table: None,
         skipped_non_conversational_rows,
+        skipped_oversized_rows,
     })
 }
 
+/// Build a `where id not in (?, ?, ...)` clause for the given id set, or an
+/// empty string when there are no ids to exclude. Used to keep oversized rows
+/// out of the bounded read cursor entirely — `sqlite3_step()` materializes
+/// every column of the current row, so filtering at the SQL layer is the only
+/// way to avoid `SQLITE_TOOBIG` on the bounded connection.
+fn exclude_ids_clause(ids: &std::collections::BTreeSet<String>) -> String {
+    if ids.is_empty() {
+        String::new()
+    } else {
+        let placeholders = std::iter::repeat("?")
+            .take(ids.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("where id not in ({placeholders})")
+    }
+}
+
+/// Whether a rusqlite error reports that a row's value exceeded the connection's
+/// `SQLITE_LIMIT_LENGTH`. Such rows are skipped during message ingestion rather
+/// than aborting the whole source — providers (notably the locally-installed
+/// Z.ai Kilo client) can carry single messages > 100 MB that legitimately exceed
+/// the per-value byte cap.
+fn is_sqlite_too_big(err: &rusqlite::Error) -> bool {
+    matches!(
+        err,
+        rusqlite::Error::SqliteFailure(ref fail, _)
+            if fail.code == rusqlite::ErrorCode::TooBig
+    )
+}
+
+/// Collect row ids from `{table}` whose `data` column exceeds the per-value
+/// import cap, so the caller can exclude them from the bounded read.
+///
+/// This opens a separate read-only connection WITHOUT the per-value
+/// `SQLITE_LIMIT_LENGTH` set, because the limit is enforced when SQLite
+/// materializes the value to compute its byte length — even `length()` triggers
+/// it. The unbounded connection is only used to scan ids (no row data crosses
+/// back into ctx's memory), then dropped before the bounded read path runs.
+fn oversized_message_row_ids(path: &Path, table: &str) -> Result<std::collections::BTreeSet<String>> {
+    let conn = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    let mut stmt = conn.prepare(&format!(
+        "select id from {table} where length(cast(data as blob)) > ?",
+    ))?;
+    let rows = stmt.query_map([MAX_PROVIDER_SQLITE_VALUE_BYTES as i64], |row| {
+        row.get::<_, String>(0)
+    })?;
+    let mut ids = std::collections::BTreeSet::new();
+    for id in rows {
+        ids.insert(id?);
+    }
+    Ok(ids)
+}
+
 pub(crate) fn opencode_session_message_rows(
+    path: &Path,
     conn: &Connection,
     dialect: &OpenCodeSqliteDialect,
-) -> Result<Vec<OpenCodeMessageRow>> {
+) -> Result<(Vec<OpenCodeMessageRow>, usize)> {
     let columns = sqlite_table_columns(conn, "session_message")?;
     ensure_sqlite_table_columns(
         &columns,
@@ -429,30 +511,45 @@ pub(crate) fn opencode_session_message_rows(
     } else {
         ("NULL", "id")
     };
+    // Pre-scan for oversized rows AFTER schema validation so the bounded
+    // connection's "missing required column" error still surfaces first for
+    // databases with future/incompatible schemas. The pre-scan uses an
+    // unbounded connection (see `oversized_message_row_ids`).
+    let oversized_ids = oversized_message_row_ids(path, "session_message")?;
+    let skipped_oversized = oversized_ids.len();
+    // Excluding oversized row ids at the SQL layer (rather than skipping them
+    // after `rows.next()`) is required because `sqlite3_step()` materializes
+    // every column of the current row before rusqlite hands it back — so even
+    // reading `id` from an oversized row triggers SQLITE_TOOBIG under the
+    // bounded connection.
+    let exclude_clause = exclude_ids_clause(&oversized_ids);
     let sql = format!(
         "select id, session_id, {entry_type}, {seq_expr}, {time_created}, {time_updated}, data \
-         from session_message order by session_id, {order_expr}"
+         from session_message \
+         {exclude_clause} \
+         order by session_id, {order_expr}",
     );
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, String>(2)?,
-            row.get::<_, Option<i64>>(3)?,
-            row.get::<_, i64>(4)?,
-            row.get::<_, i64>(5)?,
-            row.get::<_, String>(6)?,
-        ))
-    })?;
-    let rows = rows
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(CaptureError::from)?;
+    let mut rows = stmt.query(rusqlite::params_from_iter(oversized_ids.iter()))?;
     let mut messages = Vec::new();
     let mut next_seq_by_session = BTreeMap::<String, i64>::new();
-    for (id, session_id, entry_type, seq, time_created, time_updated, data) in rows {
+    while let Some(row) = rows.next()? {
+        let id = row.get::<_, String>(0)?;
+        // Per-row safety net: a row whose byte count slipped past the
+        // pre-scan (e.g. an in-flight insert between the two connections)
+        // still gets skipped here rather than aborting the source.
+        let data: String = match row.get::<_, String>(6) {
+            Ok(value) => value,
+            Err(err) if is_sqlite_too_big(&err) => continue,
+            Err(err) => return Err(CaptureError::from(err)),
+        };
+        let session_id = row.get::<_, String>(1)?;
+        let entry_type_raw = row.get::<_, String>(2)?;
+        let seq = row.get::<_, Option<i64>>(3)?;
+        let time_created = row.get::<_, i64>(4)?;
+        let time_updated = row.get::<_, i64>(5)?;
         let seq = seq.unwrap_or_else(|| next_opencode_seq(&mut next_seq_by_session, &session_id));
-        let entry_type = opencode_entry_type_from_data(&entry_type, &data);
+        let entry_type = opencode_entry_type_from_data(&entry_type_raw, &data);
         messages.push(OpenCodeMessageRow {
             id,
             session_id,
@@ -463,7 +560,7 @@ pub(crate) fn opencode_session_message_rows(
             data,
         });
     }
-    Ok(messages)
+    Ok((messages, skipped_oversized))
 }
 
 pub(crate) fn opencode_entry_type_from_data(fallback: &str, data: &str) -> String {
@@ -477,9 +574,10 @@ pub(crate) fn opencode_entry_type_from_data(fallback: &str, data: &str) -> Strin
 }
 
 pub(crate) fn opencode_session_entry_rows(
+    path: &Path,
     conn: &Connection,
     dialect: &OpenCodeSqliteDialect,
-) -> Result<Vec<OpenCodeMessageRow>> {
+) -> Result<(Vec<OpenCodeMessageRow>, usize)> {
     let columns = sqlite_table_columns(conn, "session_entry")?;
     ensure_sqlite_table_columns(
         &columns,
@@ -493,24 +591,30 @@ pub(crate) fn opencode_session_entry_rows(
             "data",
         ],
     )?;
-    let mut stmt = conn.prepare(
+    let oversized_ids = oversized_message_row_ids(path, "session_entry")?;
+    let skipped_oversized = oversized_ids.len();
+    let exclude_clause = exclude_ids_clause(&oversized_ids);
+    let sql = format!(
         "select id, session_id, type, time_created, time_updated, data \
-         from session_entry order by session_id, time_created, id",
-    )?;
-    let rows = stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, String>(2)?,
-            row.get::<_, i64>(3)?,
-            row.get::<_, i64>(4)?,
-            row.get::<_, String>(5)?,
-        ))
-    })?;
+         from session_entry \
+         {exclude_clause} \
+         order by session_id, time_created, id",
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(rusqlite::params_from_iter(oversized_ids.iter()))?;
     let mut messages = Vec::new();
     let mut next_seq_by_session = BTreeMap::<String, i64>::new();
-    for row in rows {
-        let (id, session_id, entry_type, time_created, time_updated, data) = row?;
+    while let Some(row) = rows.next()? {
+        let id = row.get::<_, String>(0)?;
+        let data: String = match row.get::<_, String>(5) {
+            Ok(value) => value,
+            Err(err) if is_sqlite_too_big(&err) => continue,
+            Err(err) => return Err(CaptureError::from(err)),
+        };
+        let session_id = row.get::<_, String>(1)?;
+        let entry_type = row.get::<_, String>(2)?;
+        let time_created = row.get::<_, i64>(3)?;
+        let time_updated = row.get::<_, i64>(4)?;
         let seq = next_opencode_seq(&mut next_seq_by_session, &session_id);
         messages.push(OpenCodeMessageRow {
             id,
@@ -522,36 +626,43 @@ pub(crate) fn opencode_session_entry_rows(
             data,
         });
     }
-    Ok(messages)
+    Ok((messages, skipped_oversized))
 }
 
 pub(crate) fn opencode_message_rows(
+    path: &Path,
     conn: &Connection,
     dialect: &OpenCodeSqliteDialect,
-) -> Result<Vec<OpenCodeMessageRow>> {
+) -> Result<(Vec<OpenCodeMessageRow>, usize)> {
     let columns = sqlite_table_columns(conn, "message")?;
     ensure_sqlite_table_columns(
         &columns,
         &format!("{} SQLite message table", dialect.display_name),
         &["id", "session_id", "time_created", "time_updated", "data"],
     )?;
-    let mut stmt = conn.prepare(
+    let oversized_ids = oversized_message_row_ids(path, "message")?;
+    let skipped_oversized = oversized_ids.len();
+    let exclude_clause = exclude_ids_clause(&oversized_ids);
+    let sql = format!(
         "select id, session_id, time_created, time_updated, data \
-         from message order by session_id, time_created, id",
-    )?;
-    let rows = stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, i64>(2)?,
-            row.get::<_, i64>(3)?,
-            row.get::<_, String>(4)?,
-        ))
-    })?;
+         from message \
+         {exclude_clause} \
+         order by session_id, time_created, id",
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(rusqlite::params_from_iter(oversized_ids.iter()))?;
     let mut messages = Vec::new();
     let mut next_seq_by_session = BTreeMap::<String, i64>::new();
-    for row in rows {
-        let (id, session_id, time_created, time_updated, data) = row?;
+    while let Some(row) = rows.next()? {
+        let id = row.get::<_, String>(0)?;
+        let data: String = match row.get::<_, String>(4) {
+            Ok(value) => value,
+            Err(err) if is_sqlite_too_big(&err) => continue,
+            Err(err) => return Err(CaptureError::from(err)),
+        };
+        let session_id = row.get::<_, String>(1)?;
+        let time_created = row.get::<_, i64>(2)?;
+        let time_updated = row.get::<_, i64>(3)?;
         let seq = next_opencode_seq(&mut next_seq_by_session, &session_id);
         let entry_type = serde_json::from_str::<Value>(&data)
             .ok()
@@ -567,7 +678,7 @@ pub(crate) fn opencode_message_rows(
             data,
         });
     }
-    Ok(messages)
+    Ok((messages, skipped_oversized))
 }
 
 pub(crate) fn next_opencode_seq(

--- a/crates/ctx-history-capture/src/provider/providers/opencode.rs
+++ b/crates/ctx-history-capture/src/provider/providers/opencode.rs
@@ -66,8 +66,6 @@ pub(crate) struct OpenCodeMessageSelection {
     pub(crate) rows: Vec<OpenCodeMessageRow>,
     pub(crate) source_table: Option<&'static str>,
     pub(crate) skipped_non_conversational_rows: usize,
-    /// Message rows whose `data` column exceeded `MAX_PROVIDER_SQLITE_VALUE_BYTES`
-    /// and were filtered out at read time so the rest of the source can still import.
     pub(crate) skipped_oversized_rows: usize,
 }
 
@@ -117,14 +115,6 @@ pub(crate) fn normalize_opencode_sqlite(
     let message_source_table = message_selection.source_table;
     let skipped_non_conversational_rows = message_selection.skipped_non_conversational_rows;
     let skipped_oversized_rows = message_selection.skipped_oversized_rows;
-    // Oversized rows are intentionally dropped at the SQL layer (see
-    // `oversized_message_row_ids`); they are not import failures. Counting
-    // them via `push_provider_import_failure` would set `summary.failed > 0`,
-    // which causes `import_normalized_provider_captures` to early-exit and
-    // `import_one_source_inner` to return `Err`, aborting `ctx search
-    // --refresh strict` and `ctx import` for the whole source even though
-    // every other row imported cleanly. Increment `summary.skipped` instead
-    // so the source stays usable.
     result.summary.skipped += skipped_oversized_rows;
 
     for row in message_selection.rows {
@@ -434,11 +424,6 @@ pub(crate) fn opencode_session_messages(
     })
 }
 
-/// Build a `where id not in (?, ?, ...)` clause for the given id set, or an
-/// empty string when there are no ids to exclude. Used to keep oversized rows
-/// out of the bounded read cursor entirely — `sqlite3_step()` materializes
-/// every column of the current row, so filtering at the SQL layer is the only
-/// way to avoid `SQLITE_TOOBIG` on the bounded connection.
 fn exclude_ids_clause(ids: &std::collections::BTreeSet<String>) -> String {
     if ids.is_empty() {
         String::new()
@@ -451,11 +436,6 @@ fn exclude_ids_clause(ids: &std::collections::BTreeSet<String>) -> String {
     }
 }
 
-/// Whether a rusqlite error reports that a row's value exceeded the connection's
-/// `SQLITE_LIMIT_LENGTH`. Such rows are skipped during message ingestion rather
-/// than aborting the whole source — providers (notably the locally-installed
-/// Z.ai Kilo client) can carry single messages > 100 MB that legitimately exceed
-/// the per-value byte cap.
 fn is_sqlite_too_big(err: &rusqlite::Error) -> bool {
     matches!(
         err,
@@ -464,14 +444,6 @@ fn is_sqlite_too_big(err: &rusqlite::Error) -> bool {
     )
 }
 
-/// Collect row ids from `{table}` whose `data` column exceeds the per-value
-/// import cap, so the caller can exclude them from the bounded read.
-///
-/// This opens a separate read-only connection WITHOUT the per-value
-/// `SQLITE_LIMIT_LENGTH` set, because the limit is enforced when SQLite
-/// materializes the value to compute its byte length — even `length()` triggers
-/// it. The unbounded connection is only used to scan ids (no row data crosses
-/// back into ctx's memory), then dropped before the bounded read path runs.
 fn oversized_message_row_ids(path: &Path, table: &str) -> Result<std::collections::BTreeSet<String>> {
     let conn = Connection::open_with_flags(
         path,
@@ -511,17 +483,8 @@ pub(crate) fn opencode_session_message_rows(
     } else {
         ("NULL", "id")
     };
-    // Pre-scan for oversized rows AFTER schema validation so the bounded
-    // connection's "missing required column" error still surfaces first for
-    // databases with future/incompatible schemas. The pre-scan uses an
-    // unbounded connection (see `oversized_message_row_ids`).
     let oversized_ids = oversized_message_row_ids(path, "session_message")?;
     let skipped_oversized = oversized_ids.len();
-    // Excluding oversized row ids at the SQL layer (rather than skipping them
-    // after `rows.next()`) is required because `sqlite3_step()` materializes
-    // every column of the current row before rusqlite hands it back — so even
-    // reading `id` from an oversized row triggers SQLITE_TOOBIG under the
-    // bounded connection.
     let exclude_clause = exclude_ids_clause(&oversized_ids);
     let sql = format!(
         "select id, session_id, {entry_type}, {seq_expr}, {time_created}, {time_updated}, data \
@@ -535,9 +498,6 @@ pub(crate) fn opencode_session_message_rows(
     let mut next_seq_by_session = BTreeMap::<String, i64>::new();
     while let Some(row) = rows.next()? {
         let id = row.get::<_, String>(0)?;
-        // Per-row safety net: a row whose byte count slipped past the
-        // pre-scan (e.g. an in-flight insert between the two connections)
-        // still gets skipped here rather than aborting the source.
         let data: String = match row.get::<_, String>(6) {
             Ok(value) => value,
             Err(err) if is_sqlite_too_big(&err) => continue,

--- a/crates/ctx-history-capture/src/provider/providers/opencode.rs
+++ b/crates/ctx-history-capture/src/provider/providers/opencode.rs
@@ -10,7 +10,7 @@ use ctx_history_core::{
     ProviderRedactionBoundary, ProviderSessionEnvelope, ProviderSourceEnvelope,
     ProviderSourceTrust, RedactionState, SessionStatus, PROVIDER_CAPTURE_ENVELOPE_SCHEMA_VERSION,
 };
-use rusqlite::{Connection, OpenFlags};
+use rusqlite::Connection;
 use serde_json::{json, Value};
 
 use crate::compute_payload_hash;
@@ -25,10 +25,11 @@ use crate::provider::native::{
     provider_required_timestamp_millis, provider_role, provider_value_text,
 };
 use crate::provider::providers::real_content::text_has_real_content;
+use crate::provider::sqlite::{sqlite_is_too_big, sqlite_row_ids_with_oversized_value};
 use crate::{
     CaptureError, ProviderAdapterContext, ProviderNormalizationResult, Result,
-    KILO_SQLITE_SOURCE_FORMAT, MAX_PROVIDER_SQLITE_VALUE_BYTES, OPENCODE_SQLITE_SOURCE_FORMAT,
-    PROVIDER_MAX_PREVIEW_CHARS, PROVIDER_MAX_TEXT_CHARS,
+    KILO_SQLITE_SOURCE_FORMAT, OPENCODE_SQLITE_SOURCE_FORMAT, PROVIDER_MAX_PREVIEW_CHARS,
+    PROVIDER_MAX_TEXT_CHARS,
 };
 
 pub(crate) struct OpenCodeSqliteDialect {
@@ -66,7 +67,7 @@ pub(crate) struct OpenCodeMessageSelection {
     pub(crate) rows: Vec<OpenCodeMessageRow>,
     pub(crate) source_table: Option<&'static str>,
     pub(crate) skipped_non_conversational_rows: usize,
-    pub(crate) skipped_oversized_rows: usize,
+    pub(crate) skipped_oversized_values: usize,
 }
 
 pub(crate) fn normalize_opencode_sqlite(
@@ -86,15 +87,21 @@ pub(crate) fn normalize_opencode_sqlite(
         .collect::<BTreeSet<_>>();
     let message_selection = opencode_session_messages(path, &conn, dialect, &session_ids)?;
     let mut result = ProviderNormalizationResult::default();
+    result.summary.skipped += message_selection.skipped_oversized_values;
+    result.summary.skipped_events += message_selection.skipped_oversized_values;
     if message_selection.rows.is_empty() {
-        push_provider_import_failure(
-            &mut result.summary,
-            0,
-            format!(
-                "{} SQLite database contained no real conversational message rows",
-                dialect.display_name
-            ),
-        );
+        if message_selection.skipped_oversized_values == 0
+            || message_selection.skipped_non_conversational_rows > 0
+        {
+            push_provider_import_failure(
+                &mut result.summary,
+                0,
+                format!(
+                    "{} SQLite database contained no real conversational message rows",
+                    dialect.display_name
+                ),
+            );
+        }
         return Ok(result);
     }
     let mut session_started = BTreeMap::new();
@@ -114,8 +121,6 @@ pub(crate) fn normalize_opencode_sqlite(
     let raw_source_path = path.display().to_string();
     let message_source_table = message_selection.source_table;
     let skipped_non_conversational_rows = message_selection.skipped_non_conversational_rows;
-    let skipped_oversized_rows = message_selection.skipped_oversized_rows;
-    result.summary.skipped += skipped_oversized_rows;
 
     for row in message_selection.rows {
         let provider_event_index =
@@ -352,16 +357,16 @@ pub(crate) fn opencode_session_messages(
     session_ids: &BTreeSet<String>,
 ) -> Result<OpenCodeMessageSelection> {
     let mut skipped_non_conversational_rows = 0usize;
-    let mut skipped_oversized_rows = 0usize;
+    let mut skipped_oversized_values = 0usize;
     if sqlite_table_exists(conn, "session_message")? {
         let (rows, oversized) = opencode_session_message_rows(path, conn, dialect)?;
-        skipped_oversized_rows += oversized;
+        skipped_oversized_values += oversized;
         if opencode_rows_have_import_blocking_errors(&rows, session_ids, dialect) {
             return Ok(OpenCodeMessageSelection {
                 rows,
                 source_table: Some("session_message"),
                 skipped_non_conversational_rows,
-                skipped_oversized_rows,
+                skipped_oversized_values,
             });
         }
         if opencode_rows_have_real_message_content(&rows) {
@@ -369,20 +374,20 @@ pub(crate) fn opencode_session_messages(
                 rows,
                 source_table: Some("session_message"),
                 skipped_non_conversational_rows,
-                skipped_oversized_rows,
+                skipped_oversized_values,
             });
         }
         skipped_non_conversational_rows += rows.len();
     }
     if sqlite_table_exists(conn, "session_entry")? {
         let (rows, oversized) = opencode_session_entry_rows(path, conn, dialect)?;
-        skipped_oversized_rows += oversized;
+        skipped_oversized_values += oversized;
         if opencode_rows_have_import_blocking_errors(&rows, session_ids, dialect) {
             return Ok(OpenCodeMessageSelection {
                 rows,
                 source_table: Some("session_entry"),
                 skipped_non_conversational_rows,
-                skipped_oversized_rows,
+                skipped_oversized_values,
             });
         }
         if opencode_rows_have_real_message_content(&rows) {
@@ -390,20 +395,20 @@ pub(crate) fn opencode_session_messages(
                 rows,
                 source_table: Some("session_entry"),
                 skipped_non_conversational_rows,
-                skipped_oversized_rows,
+                skipped_oversized_values,
             });
         }
         skipped_non_conversational_rows += rows.len();
     }
     if sqlite_table_exists(conn, "message")? {
         let (rows, oversized) = opencode_message_rows(path, conn, dialect)?;
-        skipped_oversized_rows += oversized;
+        skipped_oversized_values += oversized;
         if opencode_rows_have_import_blocking_errors(&rows, session_ids, dialect) {
             return Ok(OpenCodeMessageSelection {
                 rows,
                 source_table: Some("message"),
                 skipped_non_conversational_rows,
-                skipped_oversized_rows,
+                skipped_oversized_values,
             });
         }
         if opencode_rows_have_real_message_content(&rows) {
@@ -411,7 +416,7 @@ pub(crate) fn opencode_session_messages(
                 rows,
                 source_table: Some("message"),
                 skipped_non_conversational_rows,
-                skipped_oversized_rows,
+                skipped_oversized_values,
             });
         }
         skipped_non_conversational_rows += rows.len();
@@ -420,11 +425,11 @@ pub(crate) fn opencode_session_messages(
         rows: Vec::new(),
         source_table: None,
         skipped_non_conversational_rows,
-        skipped_oversized_rows,
+        skipped_oversized_values,
     })
 }
 
-fn exclude_ids_clause(ids: &std::collections::BTreeSet<String>) -> String {
+fn exclude_ids_clause(ids: &BTreeSet<String>) -> String {
     if ids.is_empty() {
         String::new()
     } else {
@@ -436,30 +441,8 @@ fn exclude_ids_clause(ids: &std::collections::BTreeSet<String>) -> String {
     }
 }
 
-fn is_sqlite_too_big(err: &rusqlite::Error) -> bool {
-    matches!(
-        err,
-        rusqlite::Error::SqliteFailure(ref fail, _)
-            if fail.code == rusqlite::ErrorCode::TooBig
-    )
-}
-
-fn oversized_message_row_ids(path: &Path, table: &str) -> Result<std::collections::BTreeSet<String>> {
-    let conn = Connection::open_with_flags(
-        path,
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )?;
-    let mut stmt = conn.prepare(&format!(
-        "select id from {table} where length(cast(data as blob)) > ?",
-    ))?;
-    let rows = stmt.query_map([MAX_PROVIDER_SQLITE_VALUE_BYTES as i64], |row| {
-        row.get::<_, String>(0)
-    })?;
-    let mut ids = std::collections::BTreeSet::new();
-    for id in rows {
-        ids.insert(id?);
-    }
-    Ok(ids)
+fn oversized_sqlite_data_row_ids(path: &Path, table: &str) -> Result<BTreeSet<String>> {
+    sqlite_row_ids_with_oversized_value(path, table, "id", "data")
 }
 
 pub(crate) fn opencode_session_message_rows(
@@ -483,8 +466,8 @@ pub(crate) fn opencode_session_message_rows(
     } else {
         ("NULL", "id")
     };
-    let oversized_ids = oversized_message_row_ids(path, "session_message")?;
-    let skipped_oversized = oversized_ids.len();
+    let oversized_ids = oversized_sqlite_data_row_ids(path, "session_message")?;
+    let mut skipped_oversized = oversized_ids.len();
     let exclude_clause = exclude_ids_clause(&oversized_ids);
     let sql = format!(
         "select id, session_id, {entry_type}, {seq_expr}, {time_created}, {time_updated}, data \
@@ -500,7 +483,10 @@ pub(crate) fn opencode_session_message_rows(
         let id = row.get::<_, String>(0)?;
         let data: String = match row.get::<_, String>(6) {
             Ok(value) => value,
-            Err(err) if is_sqlite_too_big(&err) => continue,
+            Err(err) if sqlite_is_too_big(&err) => {
+                skipped_oversized += 1;
+                continue;
+            }
             Err(err) => return Err(CaptureError::from(err)),
         };
         let session_id = row.get::<_, String>(1)?;
@@ -551,8 +537,8 @@ pub(crate) fn opencode_session_entry_rows(
             "data",
         ],
     )?;
-    let oversized_ids = oversized_message_row_ids(path, "session_entry")?;
-    let skipped_oversized = oversized_ids.len();
+    let oversized_ids = oversized_sqlite_data_row_ids(path, "session_entry")?;
+    let mut skipped_oversized = oversized_ids.len();
     let exclude_clause = exclude_ids_clause(&oversized_ids);
     let sql = format!(
         "select id, session_id, type, time_created, time_updated, data \
@@ -568,7 +554,10 @@ pub(crate) fn opencode_session_entry_rows(
         let id = row.get::<_, String>(0)?;
         let data: String = match row.get::<_, String>(5) {
             Ok(value) => value,
-            Err(err) if is_sqlite_too_big(&err) => continue,
+            Err(err) if sqlite_is_too_big(&err) => {
+                skipped_oversized += 1;
+                continue;
+            }
             Err(err) => return Err(CaptureError::from(err)),
         };
         let session_id = row.get::<_, String>(1)?;
@@ -600,8 +589,8 @@ pub(crate) fn opencode_message_rows(
         &format!("{} SQLite message table", dialect.display_name),
         &["id", "session_id", "time_created", "time_updated", "data"],
     )?;
-    let oversized_ids = oversized_message_row_ids(path, "message")?;
-    let skipped_oversized = oversized_ids.len();
+    let oversized_ids = oversized_sqlite_data_row_ids(path, "message")?;
+    let mut skipped_oversized = oversized_ids.len();
     let exclude_clause = exclude_ids_clause(&oversized_ids);
     let sql = format!(
         "select id, session_id, time_created, time_updated, data \
@@ -617,7 +606,10 @@ pub(crate) fn opencode_message_rows(
         let id = row.get::<_, String>(0)?;
         let data: String = match row.get::<_, String>(4) {
             Ok(value) => value,
-            Err(err) if is_sqlite_too_big(&err) => continue,
+            Err(err) if sqlite_is_too_big(&err) => {
+                skipped_oversized += 1;
+                continue;
+            }
             Err(err) => return Err(CaptureError::from(err)),
         };
         let session_id = row.get::<_, String>(1)?;

--- a/crates/ctx-history-capture/src/provider/sqlite.rs
+++ b/crates/ctx-history-capture/src/provider/sqlite.rs
@@ -3,8 +3,8 @@ use std::{collections::BTreeSet, path::Path};
 use rusqlite::{Connection, OpenFlags};
 use serde_json::json;
 
-use crate::compute_payload_hash;
 use crate::common::io::ensure_regular_provider_transcript_file;
+use crate::compute_payload_hash;
 
 use crate::{CaptureError, Result, MAX_PROVIDER_SQLITE_VALUE_BYTES};
 

--- a/crates/ctx-history-capture/src/provider/sqlite.rs
+++ b/crates/ctx-history-capture/src/provider/sqlite.rs
@@ -1,11 +1,12 @@
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, path::Path};
 
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 use serde_json::json;
 
 use crate::compute_payload_hash;
+use crate::common::io::ensure_regular_provider_transcript_file;
 
-use crate::{CaptureError, Result};
+use crate::{CaptureError, Result, MAX_PROVIDER_SQLITE_VALUE_BYTES};
 
 pub(crate) fn sqlite_table_exists(conn: &Connection, table: &str) -> Result<bool> {
     let exists: i64 = conn.query_row(
@@ -57,6 +58,42 @@ pub(crate) fn ensure_sqlite_table_columns(
 
 pub(crate) fn sqlite_ident(value: &str) -> String {
     format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+pub(crate) fn sqlite_is_too_big(err: &rusqlite::Error) -> bool {
+    matches!(
+        err,
+        rusqlite::Error::SqliteFailure(ref fail, _)
+            if fail.code == rusqlite::ErrorCode::TooBig
+    )
+}
+
+pub(crate) fn sqlite_row_ids_with_oversized_value(
+    path: &Path,
+    table: &str,
+    id_column: &str,
+    value_column: &str,
+) -> Result<BTreeSet<String>> {
+    ensure_regular_provider_transcript_file(path)?;
+    let conn = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    conn.busy_timeout(std::time::Duration::from_secs(5))?;
+    conn.pragma_update(None, "query_only", true)?;
+    // This prescan intentionally omits SQLITE_LIMIT_LENGTH: bounded connections
+    // can raise SQLITE_TOOBIG before returning ids, and this query returns ids only.
+    let mut stmt = conn.prepare(&format!(
+        "select {} from {} where length(cast({} as blob)) > ?",
+        sqlite_ident(id_column),
+        sqlite_ident(table),
+        sqlite_ident(value_column),
+    ))?;
+    let rows = stmt.query_map([MAX_PROVIDER_SQLITE_VALUE_BYTES as i64], |row| {
+        row.get::<_, String>(0)
+    })?;
+    rows.collect::<std::result::Result<BTreeSet<_>, _>>()
+        .map_err(CaptureError::from)
 }
 
 pub(crate) fn opencode_schema_fingerprint(conn: &Connection) -> Result<String> {

--- a/crates/ctx-history-capture/src/tests/native_sqlite.rs
+++ b/crates/ctx-history-capture/src/tests/native_sqlite.rs
@@ -404,10 +404,11 @@ fn native_opencode_rejects_out_of_range_message_timestamp() {
 }
 
 #[test]
-fn native_opencode_rejects_oversized_sqlite_text_value() {
+fn native_opencode_skips_oversized_sqlite_text_value_and_imports_other_rows() {
     let temp = tempdir();
     let fixture = write_opencode_smoke_db(&temp, false);
     let conn = Connection::open(&fixture).unwrap();
+    // Mark the user message as oversized — exceeds the per-value byte cap.
     let oversized_data = format!(
         "{{\"time\":{{\"created\":1782259200000}},\"text\":\"{}\"}}",
         "x".repeat(MAX_PROVIDER_SQLITE_VALUE_BYTES + 1)
@@ -417,18 +418,45 @@ fn native_opencode_rejects_oversized_sqlite_text_value() {
         [&oversized_data],
     )
     .unwrap();
+    // Sanity check: there is at least one other conversational row that should
+    // still import once the oversized row is skipped.
+    let other_conversational: i64 = conn
+        .query_row(
+            "select count(*) from session_message where id != 'msg-user'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        other_conversational > 0,
+        "test fixture must contain at least one non-oversized conversational row"
+    );
     drop(conn);
 
-    let err = import_opencode_sqlite(
+    let summary = import_opencode_sqlite(
         &fixture,
         &mut Store::open(temp.path().join("work.sqlite")).unwrap(),
         OpenCodeSqliteImportOptions::default(),
     )
-    .unwrap_err();
+    .expect("oversized rows should be skipped, not abort the whole import");
 
+    // Oversized rows must not be recorded as failures: `summary.failed > 0`
+    // would cause `import_normalized_provider_captures` to early-exit and
+    // `import_one_source_inner` to return `Err`, which would abort
+    // `ctx search --refresh strict` and `ctx import` for the whole source
+    // even though every other row imported cleanly.
+    assert_eq!(
+        summary.failed, 0,
+        "oversized rows must not be counted as failures, got failures: {:?}",
+        summary.failures
+    );
     assert!(
-        err.to_string().contains("too big"),
-        "unexpected error: {err}"
+        summary.skipped >= 1,
+        "oversized row should be reflected in summary.skipped, got summary: {summary:?}"
+    );
+    assert!(
+        summary.imported_events >= 1,
+        "non-oversized rows should still import, got summary: {summary:?}"
     );
 }
 

--- a/crates/ctx-history-capture/src/tests/native_sqlite.rs
+++ b/crates/ctx-history-capture/src/tests/native_sqlite.rs
@@ -408,7 +408,6 @@ fn native_opencode_skips_oversized_sqlite_text_value_and_imports_other_rows() {
     let temp = tempdir();
     let fixture = write_opencode_smoke_db(&temp, false);
     let conn = Connection::open(&fixture).unwrap();
-    // Mark the user message as oversized — exceeds the per-value byte cap.
     let oversized_data = format!(
         "{{\"time\":{{\"created\":1782259200000}},\"text\":\"{}\"}}",
         "x".repeat(MAX_PROVIDER_SQLITE_VALUE_BYTES + 1)
@@ -418,8 +417,6 @@ fn native_opencode_skips_oversized_sqlite_text_value_and_imports_other_rows() {
         [&oversized_data],
     )
     .unwrap();
-    // Sanity check: there is at least one other conversational row that should
-    // still import once the oversized row is skipped.
     let other_conversational: i64 = conn
         .query_row(
             "select count(*) from session_message where id != 'msg-user'",
@@ -440,11 +437,6 @@ fn native_opencode_skips_oversized_sqlite_text_value_and_imports_other_rows() {
     )
     .expect("oversized rows should be skipped, not abort the whole import");
 
-    // Oversized rows must not be recorded as failures: `summary.failed > 0`
-    // would cause `import_normalized_provider_captures` to early-exit and
-    // `import_one_source_inner` to return `Err`, which would abort
-    // `ctx search --refresh strict` and `ctx import` for the whole source
-    // even though every other row imported cleanly.
     assert_eq!(
         summary.failed, 0,
         "oversized rows must not be counted as failures, got failures: {:?}",

--- a/crates/ctx-history-capture/src/tests/native_sqlite.rs
+++ b/crates/ctx-history-capture/src/tests/native_sqlite.rs
@@ -447,6 +447,7 @@ fn native_opencode_skips_oversized_sqlite_text_value_and_imports_other_rows() {
         summary.failures
     );
     assert_eq!(summary.skipped, 1, "unexpected summary: {summary:?}");
+    assert_eq!(summary.skipped_events, 1, "unexpected summary: {summary:?}");
     assert!(
         summary.imported_events >= 1,
         "non-oversized rows should still import, got summary: {summary:?}"
@@ -481,8 +482,32 @@ fn native_opencode_skips_all_oversized_sqlite_text_values_without_failure() {
         summary.failures
     );
     assert_eq!(summary.skipped, 1, "unexpected summary: {summary:?}");
+    assert_eq!(summary.skipped_events, 1, "unexpected summary: {summary:?}");
     assert_eq!(summary.imported_sessions, 0);
     assert_eq!(summary.imported_events, 0);
+}
+
+#[test]
+fn native_opencode_skips_oversized_legacy_message_value_without_failure() {
+    let temp = tempdir();
+    let fixture = write_opencode_current_schema_db(&temp, true);
+    let conn = Connection::open(&fixture).unwrap();
+    let oversized_data = oversized_opencode_text_payload();
+    conn.execute("update message set data = ?1", [&oversized_data])
+        .unwrap();
+    drop(conn);
+
+    let summary = import_opencode_sqlite(
+        &fixture,
+        &mut Store::open(temp.path().join("work.sqlite")).unwrap(),
+        OpenCodeSqliteImportOptions::default(),
+    )
+    .expect("oversized legacy message rows should be skipped without import failure");
+
+    assert_eq!(summary.failed, 0, "{summary:?}");
+    assert_eq!(summary.skipped, 1, "{summary:?}");
+    assert_eq!(summary.skipped_events, 1, "{summary:?}");
+    assert_eq!(summary.imported_events, 0, "{summary:?}");
 }
 
 #[test]

--- a/crates/ctx-history-capture/src/tests/native_sqlite.rs
+++ b/crates/ctx-history-capture/src/tests/native_sqlite.rs
@@ -403,15 +403,19 @@ fn native_opencode_rejects_out_of_range_message_timestamp() {
     assert_eq!(summary.imported_events, 2);
 }
 
+fn oversized_opencode_text_payload() -> String {
+    format!(
+        "{{\"time\":{{\"created\":1782259200000}},\"text\":\"{}\"}}",
+        "x".repeat(MAX_PROVIDER_SQLITE_VALUE_BYTES + 1)
+    )
+}
+
 #[test]
 fn native_opencode_skips_oversized_sqlite_text_value_and_imports_other_rows() {
     let temp = tempdir();
     let fixture = write_opencode_smoke_db(&temp, false);
     let conn = Connection::open(&fixture).unwrap();
-    let oversized_data = format!(
-        "{{\"time\":{{\"created\":1782259200000}},\"text\":\"{}\"}}",
-        "x".repeat(MAX_PROVIDER_SQLITE_VALUE_BYTES + 1)
-    );
+    let oversized_data = oversized_opencode_text_payload();
     conn.execute(
         "update session_message set data = ?1 where id = 'msg-user'",
         [&oversized_data],
@@ -442,14 +446,43 @@ fn native_opencode_skips_oversized_sqlite_text_value_and_imports_other_rows() {
         "oversized rows must not be counted as failures, got failures: {:?}",
         summary.failures
     );
-    assert!(
-        summary.skipped >= 1,
-        "oversized row should be reflected in summary.skipped, got summary: {summary:?}"
-    );
+    assert_eq!(summary.skipped, 1, "unexpected summary: {summary:?}");
     assert!(
         summary.imported_events >= 1,
         "non-oversized rows should still import, got summary: {summary:?}"
     );
+}
+
+#[test]
+fn native_opencode_skips_all_oversized_sqlite_text_values_without_failure() {
+    let temp = tempdir();
+    let fixture = write_opencode_smoke_db(&temp, false);
+    let conn = Connection::open(&fixture).unwrap();
+    conn.execute("delete from session_message where id != 'msg-user'", [])
+        .unwrap();
+    let oversized_data = oversized_opencode_text_payload();
+    conn.execute(
+        "update session_message set data = ?1 where id = 'msg-user'",
+        [&oversized_data],
+    )
+    .unwrap();
+    drop(conn);
+
+    let summary = import_opencode_sqlite(
+        &fixture,
+        &mut Store::open(temp.path().join("work.sqlite")).unwrap(),
+        OpenCodeSqliteImportOptions::default(),
+    )
+    .expect("oversized rows should be skipped without fabricating import failures");
+
+    assert_eq!(
+        summary.failed, 0,
+        "unexpected failures: {:?}",
+        summary.failures
+    );
+    assert_eq!(summary.skipped, 1, "unexpected summary: {summary:?}");
+    assert_eq!(summary.imported_sessions, 0);
+    assert_eq!(summary.imported_events, 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Provider SQLite databases can contain `data` values larger than ctx's 16 MiB per-value import cap. Before this PR, materializing one oversized value could abort the entire source import with `SQLITE_TOOBIG`, leaving otherwise readable rows unindexed.

This keeps the cap and makes the OpenCode-family SQLite adapter omit oversized values at the SQL layer instead of aborting the source:

- pre-scan relevant tables with a read-only, query-only connection that returns row ids only;
- exclude oversized ids from the bounded import query before SQLite materializes `data`;
- keep a per-row `SQLITE_TOOBIG` safety net for rows that slip past the prescan;
- count omitted rows as `skipped` / `skipped_events`, not failures;
- continue importing every other readable row.

No synthetic text, fake previews, truncated diffs, or summary events are generated. Oversized payload content is omitted.

Affected scope: OpenCode-family SQLite rows currently read by `normalize_opencode_sqlite`, including OpenCode/Kilo dialects. JSONL adapters are unchanged.

## Validation

- `cargo fmt --check`
- `cargo test -p ctx-history-capture --lib tests::native_sqlite`
- `cargo test -p ctx-history-capture`

Regression coverage includes mixed readable + oversized rows, all-oversized rows, and legacy `message` table rows.