### PR TITLE
feat(capture): emit synthetic events for oversized SQLite rows

### DIFF
--- a/crates/ctx-history-capture/src/provider/providers/opencode.rs
+++ b/crates/ctx-history-capture/src/provider/providers/opencode.rs
@@ -10,7 +10,7 @@ use ctx_history_core::{
     ProviderRedactionBoundary, ProviderSessionEnvelope, ProviderSourceEnvelope,
     ProviderSourceTrust, RedactionState, SessionStatus, PROVIDER_CAPTURE_ENVELOPE_SCHEMA_VERSION,
 };
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 use serde_json::{json, Value};
 
 use crate::compute_payload_hash;
@@ -27,8 +27,8 @@ use crate::provider::native::{
 use crate::provider::providers::real_content::text_has_real_content;
 use crate::{
     CaptureError, ProviderAdapterContext, ProviderNormalizationResult, Result,
-    KILO_SQLITE_SOURCE_FORMAT, OPENCODE_SQLITE_SOURCE_FORMAT, PROVIDER_MAX_PREVIEW_CHARS,
-    PROVIDER_MAX_TEXT_CHARS,
+    KILO_SQLITE_SOURCE_FORMAT, MAX_PROVIDER_SQLITE_VALUE_BYTES, OPENCODE_SQLITE_SOURCE_FORMAT,
+    PROVIDER_MAX_PREVIEW_CHARS, PROVIDER_MAX_TEXT_CHARS,
 };
 
 pub(crate) struct OpenCodeSqliteDialect {
@@ -66,6 +66,9 @@ pub(crate) struct OpenCodeMessageSelection {
     pub(crate) rows: Vec<OpenCodeMessageRow>,
     pub(crate) source_table: Option<&'static str>,
     pub(crate) skipped_non_conversational_rows: usize,
+    /// Message rows whose `data` column exceeded `MAX_PROVIDER_SQLITE_VALUE_BYTES`
+    /// and were filtered out at read time so the rest of the source can still import.
+    pub(crate) skipped_oversized_rows: usize,
 }
 
 pub(crate) fn normalize_opencode_sqlite(
@@ -83,7 +86,7 @@ pub(crate) fn normalize_opencode_sqlite(
         .iter()
         .map(|session| session.id.clone())
         .collect::<BTreeSet<_>>();
-    let message_selection = opencode_session_messages(&conn, dialect, &session_ids)?;
+    let message_selection = opencode_session_messages(path, &conn, dialect, &session_ids)?;
     let mut result = ProviderNormalizationResult::default();
     if message_selection.rows.is_empty() {
         push_provider_import_failure(
@@ -113,6 +116,16 @@ pub(crate) fn normalize_opencode_sqlite(
     let raw_source_path = path.display().to_string();
     let message_source_table = message_selection.source_table;
     let skipped_non_conversational_rows = message_selection.skipped_non_conversational_rows;
+    let skipped_oversized_rows = message_selection.skipped_oversized_rows;
+    // Oversized rows are intentionally dropped at the SQL layer (see
+    // `oversized_message_row_ids`); they are not import failures. Counting
+    // them via `push_provider_import_failure` would set `summary.failed > 0`,
+    // which causes `import_normalized_provider_captures` to early-exit and
+    // `import_one_source_inner` to return `Err`, aborting `ctx search
+    // --refresh strict` and `ctx import` for the whole source even though
+    // every other row imported cleanly. Increment `summary.skipped` instead
+    // so the source stays usable.
+    result.summary.skipped += skipped_oversized_rows;
 
     for row in message_selection.rows {
         let provider_event_index =
@@ -343,18 +356,22 @@ pub(crate) fn opencode_sessions(
 }
 
 pub(crate) fn opencode_session_messages(
+    path: &Path,
     conn: &Connection,
     dialect: &OpenCodeSqliteDialect,
     session_ids: &BTreeSet<String>,
 ) -> Result<OpenCodeMessageSelection> {
     let mut skipped_non_conversational_rows = 0usize;
+    let mut skipped_oversized_rows = 0usize;
     if sqlite_table_exists(conn, "session_message")? {
-        let rows = opencode_session_message_rows(conn, dialect)?;
+        let (rows, oversized) = opencode_session_message_rows(path, conn, dialect)?;
+        skipped_oversized_rows += oversized;
         if opencode_rows_have_import_blocking_errors(&rows, session_ids, dialect) {
             return Ok(OpenCodeMessageSelection {
                 rows,
                 source_table: Some("session_message"),
                 skipped_non_conversational_rows,
+                skipped_oversized_rows,
             });
         }
         if opencode_rows_have_real_message_content(&rows) {
@@ -362,17 +379,20 @@ pub(crate) fn opencode_session_messages(
                 rows,
                 source_table: Some("session_message"),
                 skipped_non_conversational_rows,
+                skipped_oversized_rows,
             });
         }
         skipped_non_conversational_rows += rows.len();
     }
     if sqlite_table_exists(conn, "session_entry")? {
-        let rows = opencode_session_entry_rows(conn, dialect)?;
+        let (rows, oversized) = opencode_session_entry_rows(path, conn, dialect)?;
+        skipped_oversized_rows += oversized;
         if opencode_rows_have_import_blocking_errors(&rows, session_ids, dialect) {
             return Ok(OpenCodeMessageSelection {
                 rows,
                 source_table: Some("session_entry"),
                 skipped_non_conversational_rows,
+                skipped_oversized_rows,
             });
         }
         if opencode_rows_have_real_message_content(&rows) {
@@ -380,17 +400,20 @@ pub(crate) fn opencode_session_messages(
                 rows,
                 source_table: Some("session_entry"),
                 skipped_non_conversational_rows,
+                skipped_oversized_rows,
             });
         }
         skipped_non_conversational_rows += rows.len();
     }
     if sqlite_table_exists(conn, "message")? {
-        let rows = opencode_message_rows(conn, dialect)?;
+        let (rows, oversized) = opencode_message_rows(path, conn, dialect)?;
+        skipped_oversized_rows += oversized;
         if opencode_rows_have_import_blocking_errors(&rows, session_ids, dialect) {
             return Ok(OpenCodeMessageSelection {
                 rows,
                 source_table: Some("message"),
                 skipped_non_conversational_rows,
+                skipped_oversized_rows,
             });
         }
         if opencode_rows_have_real_message_content(&rows) {
@@ -398,6 +421,7 @@ pub(crate) fn opencode_session_messages(
                 rows,
                 source_table: Some("message"),
                 skipped_non_conversational_rows,
+                skipped_oversized_rows,
             });
         }
         skipped_non_conversational_rows += rows.len();
@@ -406,13 +430,71 @@ pub(crate) fn opencode_session_messages(
         rows: Vec::new(),
         source_table: None,
         skipped_non_conversational_rows,
+        skipped_oversized_rows,
     })
 }
 
+/// Build a `where id not in (?, ?, ...)` clause for the given id set, or an
+/// empty string when there are no ids to exclude. Used to keep oversized rows
+/// out of the bounded read cursor entirely — `sqlite3_step()` materializes
+/// every column of the current row, so filtering at the SQL layer is the only
+/// way to avoid `SQLITE_TOOBIG` on the bounded connection.
+fn exclude_ids_clause(ids: &std::collections::BTreeSet<String>) -> String {
+    if ids.is_empty() {
+        String::new()
+    } else {
+        let placeholders = std::iter::repeat("?")
+            .take(ids.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("where id not in ({placeholders})")
+    }
+}
+
+/// Whether a rusqlite error reports that a row's value exceeded the connection's
+/// `SQLITE_LIMIT_LENGTH`. Such rows are skipped during message ingestion rather
+/// than aborting the whole source — providers (notably the locally-installed
+/// Z.ai Kilo client) can carry single messages > 100 MB that legitimately exceed
+/// the per-value byte cap.
+fn is_sqlite_too_big(err: &rusqlite::Error) -> bool {
+    matches!(
+        err,
+        rusqlite::Error::SqliteFailure(ref fail, _)
+            if fail.code == rusqlite::ErrorCode::TooBig
+    )
+}
+
+/// Collect row ids from `{table}` whose `data` column exceeds the per-value
+/// import cap, so the caller can exclude them from the bounded read.
+///
+/// This opens a separate read-only connection WITHOUT the per-value
+/// `SQLITE_LIMIT_LENGTH` set, because the limit is enforced when SQLite
+/// materializes the value to compute its byte length — even `length()` triggers
+/// it. The unbounded connection is only used to scan ids (no row data crosses
+/// back into ctx's memory), then dropped before the bounded read path runs.
+fn oversized_message_row_ids(path: &Path, table: &str) -> Result<std::collections::BTreeSet<String>> {
+    let conn = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    let mut stmt = conn.prepare(&format!(
+        "select id from {table} where length(cast(data as blob)) > ?",
+    ))?;
+    let rows = stmt.query_map([MAX_PROVIDER_SQLITE_VALUE_BYTES as i64], |row| {
+        row.get::<_, String>(0)
+    })?;
+    let mut ids = std::collections::BTreeSet::new();
+    for id in rows {
+        ids.insert(id?);
+    }
+    Ok(ids)
+}
+
 pub(crate) fn opencode_session_message_rows(
+    path: &Path,
     conn: &Connection,
     dialect: &OpenCodeSqliteDialect,
-) -> Result<Vec<OpenCodeMessageRow>> {
+) -> Result<(Vec<OpenCodeMessageRow>, usize)> {
     let columns = sqlite_table_columns(conn, "session_message")?;
     ensure_sqlite_table_columns(
         &columns,
@@ -429,30 +511,45 @@ pub(crate) fn opencode_session_message_rows(
     } else {
         ("NULL", "id")
     };
+    // Pre-scan for oversized rows AFTER schema validation so the bounded
+    // connection's "missing required column" error still surfaces first for
+    // databases with future/incompatible schemas. The pre-scan uses an
+    // unbounded connection (see `oversized_message_row_ids`).
+    let oversized_ids = oversized_message_row_ids(path, "session_message")?;
+    let skipped_oversized = oversized_ids.len();
+    // Excluding oversized row ids at the SQL layer (rather than skipping them
+    // after `rows.next()`) is required because `sqlite3_step()` materializes
+    // every column of the current row before rusqlite hands it back — so even
+    // reading `id` from an oversized row triggers SQLITE_TOOBIG under the
+    // bounded connection.
+    let exclude_clause = exclude_ids_clause(&oversized_ids);
     let sql = format!(
         "select id, session_id, {entry_type}, {seq_expr}, {time_created}, {time_updated}, data \
-         from session_message order by session_id, {order_expr}"
+         from session_message \
+         {exclude_clause} \
+         order by session_id, {order_expr}",
     );
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, String>(2)?,
-            row.get::<_, Option<i64>>(3)?,
-            row.get::<_, i64>(4)?,
-            row.get::<_, i64>(5)?,
-            row.get::<_, String>(6)?,
-        ))
-    })?;
-    let rows = rows
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(CaptureError::from)?;
+    let mut rows = stmt.query(rusqlite::params_from_iter(oversized_ids.iter()))?;
     let mut messages = Vec::new();
     let mut next_seq_by_session = BTreeMap::<String, i64>::new();
-    for (id, session_id, entry_type, seq, time_created, time_updated, data) in rows {
+    while let Some(row) = rows.next()? {
+        let id = row.get::<_, String>(0)?;
+        // Per-row safety net: a row whose byte count slipped past the
+        // pre-scan (e.g. an in-flight insert between the two connections)
+        // still gets skipped here rather than aborting the source.
+        let data: String = match row.get::<_, String>(6) {
+            Ok(value) => value,
+            Err(err) if is_sqlite_too_big(&err) => continue,
+            Err(err) => return Err(CaptureError::from(err)),
+        };
+        let session_id = row.get::<_, String>(1)?;
+        let entry_type_raw = row.get::<_, String>(2)?;
+        let seq = row.get::<_, Option<i64>>(3)?;
+        let time_created = row.get::<_, i64>(4)?;
+        let time_updated = row.get::<_, i64>(5)?;
         let seq = seq.unwrap_or_else(|| next_opencode_seq(&mut next_seq_by_session, &session_id));
-        let entry_type = opencode_entry_type_from_data(&entry_type, &data);
+        let entry_type = opencode_entry_type_from_data(&entry_type_raw, &data);
         messages.push(OpenCodeMessageRow {
             id,
             session_id,
@@ -463,7 +560,7 @@ pub(crate) fn opencode_session_message_rows(
             data,
         });
     }
-    Ok(messages)
+    Ok((messages, skipped_oversized))
 }
 
 pub(crate) fn opencode_entry_type_from_data(fallback: &str, data: &str) -> String {
@@ -477,9 +574,10 @@ pub(crate) fn opencode_entry_type_from_data(fallback: &str, data: &str) -> Strin
 }
 
 pub(crate) fn opencode_session_entry_rows(
+    path: &Path,
     conn: &Connection,
     dialect: &OpenCodeSqliteDialect,
-) -> Result<Vec<OpenCodeMessageRow>> {
+) -> Result<(Vec<OpenCodeMessageRow>, usize)> {
     let columns = sqlite_table_columns(conn, "session_entry")?;
     ensure_sqlite_table_columns(
         &columns,
@@ -493,24 +591,30 @@ pub(crate) fn opencode_session_entry_rows(
             "data",
         ],
     )?;
-    let mut stmt = conn.prepare(
+    let oversized_ids = oversized_message_row_ids(path, "session_entry")?;
+    let skipped_oversized = oversized_ids.len();
+    let exclude_clause = exclude_ids_clause(&oversized_ids);
+    let sql = format!(
         "select id, session_id, type, time_created, time_updated, data \
-         from session_entry order by session_id, time_created, id",
-    )?;
-    let rows = stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, String>(2)?,
-            row.get::<_, i64>(3)?,
-            row.get::<_, i64>(4)?,
-            row.get::<_, String>(5)?,
-        ))
-    })?;
+         from session_entry \
+         {exclude_clause} \
+         order by session_id, time_created, id",
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(rusqlite::params_from_iter(oversized_ids.iter()))?;
     let mut messages = Vec::new();
     let mut next_seq_by_session = BTreeMap::<String, i64>::new();
-    for row in rows {
-        let (id, session_id, entry_type, time_created, time_updated, data) = row?;
+    while let Some(row) = rows.next()? {
+        let id = row.get::<_, String>(0)?;
+        let data: String = match row.get::<_, String>(5) {
+            Ok(value) => value,
+            Err(err) if is_sqlite_too_big(&err) => continue,
+            Err(err) => return Err(CaptureError::from(err)),
+        };
+        let session_id = row.get::<_, String>(1)?;
+        let entry_type = row.get::<_, String>(2)?;
+        let time_created = row.get::<_, i64>(3)?;
+        let time_updated = row.get::<_, i64>(4)?;
         let seq = next_opencode_seq(&mut next_seq_by_session, &session_id);
         messages.push(OpenCodeMessageRow {
             id,
@@ -522,36 +626,43 @@ pub(crate) fn opencode_session_entry_rows(
             data,
         });
     }
-    Ok(messages)
+    Ok((messages, skipped_oversized))
 }
 
 pub(crate) fn opencode_message_rows(
+    path: &Path,
     conn: &Connection,
     dialect: &OpenCodeSqliteDialect,
-) -> Result<Vec<OpenCodeMessageRow>> {
+) -> Result<(Vec<OpenCodeMessageRow>, usize)> {
     let columns = sqlite_table_columns(conn, "message")?;
     ensure_sqlite_table_columns(
         &columns,
         &format!("{} SQLite message table", dialect.display_name),
         &["id", "session_id", "time_created", "time_updated", "data"],
     )?;
-    let mut stmt = conn.prepare(
+    let oversized_ids = oversized_message_row_ids(path, "message")?;
+    let skipped_oversized = oversized_ids.len();
+    let exclude_clause = exclude_ids_clause(&oversized_ids);
+    let sql = format!(
         "select id, session_id, time_created, time_updated, data \
-         from message order by session_id, time_created, id",
-    )?;
-    let rows = stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, i64>(2)?,
-            row.get::<_, i64>(3)?,
-            row.get::<_, String>(4)?,
-        ))
-    })?;
+         from message \
+         {exclude_clause} \
+         order by session_id, time_created, id",
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(rusqlite::params_from_iter(oversized_ids.iter()))?;
     let mut messages = Vec::new();
     let mut next_seq_by_session = BTreeMap::<String, i64>::new();
-    for row in rows {
-        let (id, session_id, time_created, time_updated, data) = row?;
+    while let Some(row) = rows.next()? {
+        let id = row.get::<_, String>(0)?;
+        let data: String = match row.get::<_, String>(4) {
+            Ok(value) => value,
+            Err(err) if is_sqlite_too_big(&err) => continue,
+            Err(err) => return Err(CaptureError::from(err)),
+        };
+        let session_id = row.get::<_, String>(1)?;
+        let time_created = row.get::<_, i64>(2)?;
+        let time_updated = row.get::<_, i64>(3)?;
         let seq = next_opencode_seq(&mut next_seq_by_session, &session_id);
         let entry_type = serde_json::from_str::<Value>(&data)
             .ok()
@@ -567,7 +678,7 @@ pub(crate) fn opencode_message_rows(
             data,
         });
     }
-    Ok(messages)
+    Ok((messages, skipped_oversized))
 }
 
 pub(crate) fn next_opencode_seq(

--- a/crates/ctx-history-capture/src/provider/providers/opencode.rs
+++ b/crates/ctx-history-capture/src/provider/providers/opencode.rs
@@ -66,8 +66,6 @@ pub(crate) struct OpenCodeMessageSelection {
     pub(crate) rows: Vec<OpenCodeMessageRow>,
     pub(crate) source_table: Option<&'static str>,
     pub(crate) skipped_non_conversational_rows: usize,
-    /// Message rows whose `data` column exceeded `MAX_PROVIDER_SQLITE_VALUE_BYTES`
-    /// and were filtered out at read time so the rest of the source can still import.
     pub(crate) skipped_oversized_rows: usize,
 }
 
@@ -117,14 +115,6 @@ pub(crate) fn normalize_opencode_sqlite(
     let message_source_table = message_selection.source_table;
     let skipped_non_conversational_rows = message_selection.skipped_non_conversational_rows;
     let skipped_oversized_rows = message_selection.skipped_oversized_rows;
-    // Oversized rows are intentionally dropped at the SQL layer (see
-    // `oversized_message_row_ids`); they are not import failures. Counting
-    // them via `push_provider_import_failure` would set `summary.failed > 0`,
-    // which causes `import_normalized_provider_captures` to early-exit and
-    // `import_one_source_inner` to return `Err`, aborting `ctx search
-    // --refresh strict` and `ctx import` for the whole source even though
-    // every other row imported cleanly. Increment `summary.skipped` instead
-    // so the source stays usable.
     result.summary.skipped += skipped_oversized_rows;
 
     for row in message_selection.rows {
@@ -434,11 +424,6 @@ pub(crate) fn opencode_session_messages(
     })
 }
 
-/// Build a `where id not in (?, ?, ...)` clause for the given id set, or an
-/// empty string when there are no ids to exclude. Used to keep oversized rows
-/// out of the bounded read cursor entirely — `sqlite3_step()` materializes
-/// every column of the current row, so filtering at the SQL layer is the only
-/// way to avoid `SQLITE_TOOBIG` on the bounded connection.
 fn exclude_ids_clause(ids: &std::collections::BTreeSet<String>) -> String {
     if ids.is_empty() {
         String::new()
@@ -451,11 +436,6 @@ fn exclude_ids_clause(ids: &std::collections::BTreeSet<String>) -> String {
     }
 }
 
-/// Whether a rusqlite error reports that a row's value exceeded the connection's
-/// `SQLITE_LIMIT_LENGTH`. Such rows are skipped during message ingestion rather
-/// than aborting the whole source — providers (notably the locally-installed
-/// Z.ai Kilo client) can carry single messages > 100 MB that legitimately exceed
-/// the per-value byte cap.
 fn is_sqlite_too_big(err: &rusqlite::Error) -> bool {
     matches!(
         err,
@@ -464,14 +444,6 @@ fn is_sqlite_too_big(err: &rusqlite::Error) -> bool {
     )
 }
 
-/// Collect row ids from `{table}` whose `data` column exceeds the per-value
-/// import cap, so the caller can exclude them from the bounded read.
-///
-/// This opens a separate read-only connection WITHOUT the per-value
-/// `SQLITE_LIMIT_LENGTH` set, because the limit is enforced when SQLite
-/// materializes the value to compute its byte length — even `length()` triggers
-/// it. The unbounded connection is only used to scan ids (no row data crosses
-/// back into ctx's memory), then dropped before the bounded read path runs.
 fn oversized_message_row_ids(path: &Path, table: &str) -> Result<std::collections::BTreeSet<String>> {
     let conn = Connection::open_with_flags(
         path,
@@ -511,17 +483,8 @@ pub(crate) fn opencode_session_message_rows(
     } else {
         ("NULL", "id")
     };
-    // Pre-scan for oversized rows AFTER schema validation so the bounded
-    // connection's "missing required column" error still surfaces first for
-    // databases with future/incompatible schemas. The pre-scan uses an
-    // unbounded connection (see `oversized_message_row_ids`).
     let oversized_ids = oversized_message_row_ids(path, "session_message")?;
     let skipped_oversized = oversized_ids.len();
-    // Excluding oversized row ids at the SQL layer (rather than skipping them
-    // after `rows.next()`) is required because `sqlite3_step()` materializes
-    // every column of the current row before rusqlite hands it back — so even
-    // reading `id` from an oversized row triggers SQLITE_TOOBIG under the
-    // bounded connection.
     let exclude_clause = exclude_ids_clause(&oversized_ids);
     let sql = format!(
         "select id, session_id, {entry_type}, {seq_expr}, {time_created}, {time_updated}, data \
@@ -535,9 +498,6 @@ pub(crate) fn opencode_session_message_rows(
     let mut next_seq_by_session = BTreeMap::<String, i64>::new();
     while let Some(row) = rows.next()? {
         let id = row.get::<_, String>(0)?;
-        // Per-row safety net: a row whose byte count slipped past the
-        // pre-scan (e.g. an in-flight insert between the two connections)
-        // still gets skipped here rather than aborting the source.
         let data: String = match row.get::<_, String>(6) {
             Ok(value) => value,
             Err(err) if is_sqlite_too_big(&err) => continue,

--- a/crates/ctx-history-capture/src/provider/providers/opencode.rs
+++ b/crates/ctx-history-capture/src/provider/providers/opencode.rs
@@ -114,8 +114,7 @@ pub(crate) fn normalize_opencode_sqlite(
     let raw_source_path = path.display().to_string();
     let message_source_table = message_selection.source_table;
     let skipped_non_conversational_rows = message_selection.skipped_non_conversational_rows;
-    let skipped_oversized_rows = message_selection.skipped_oversized_rows;
-    result.summary.skipped += skipped_oversized_rows;
+    let _skipped_oversized_rows = message_selection.skipped_oversized_rows;
 
     for row in message_selection.rows {
         let provider_event_index =
@@ -462,6 +461,77 @@ fn oversized_message_row_ids(path: &Path, table: &str) -> Result<std::collection
     Ok(ids)
 }
 
+fn truncated_oversized_message_rows(
+    path: &Path,
+    table: &str,
+    dialect: &OpenCodeSqliteDialect,
+    has_type_column: bool,
+    has_seq_column: bool,
+) -> Result<Vec<OpenCodeMessageRow>> {
+    let conn = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    let type_expr: &str = if has_type_column { "type" } else { "'message'" };
+    let seq_expr: &str = if has_seq_column { "seq" } else { "NULL" };
+    let sql = format!(
+        "select id, session_id, {type_expr}, {seq_expr}, time_created, time_updated, \
+         substr(data, 1, ?), length(cast(data as blob)) \
+         from {table} \
+         where length(cast(data as blob)) > ? \
+         order by session_id, time_created, id"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query([
+        PROVIDER_MAX_TEXT_CHARS as i64,
+        MAX_PROVIDER_SQLITE_VALUE_BYTES as i64,
+    ])?;
+    let mut messages = Vec::new();
+    let mut next_seq_by_session = BTreeMap::<String, i64>::new();
+    while let Some(row) = rows.next()? {
+        let id = row.get::<_, String>(0)?;
+        let session_id = row.get::<_, String>(1)?;
+        let entry_type_raw = row.get::<_, Option<String>>(2)?;
+        let seq = row.get::<_, Option<i64>>(3)?;
+        let time_created = row.get::<_, i64>(4)?;
+        let time_updated = row.get::<_, i64>(5)?;
+        let preview: String = row.get::<_, String>(6)?;
+        let original_bytes: i64 = row.get::<_, i64>(7)?;
+        let preview_value: Option<Value> = serde_json::from_str(&preview).ok();
+        let role = preview_value
+            .as_ref()
+            .and_then(opencode_message_type_from_data)
+            .unwrap_or_else(|| "user".to_string());
+        let entry_type = entry_type_raw
+            .filter(|s| !s.is_empty() && s != "message")
+            .or_else(|| Some(role.clone()))
+            .unwrap_or_else(|| "message".to_string());
+        let seq = seq.unwrap_or_else(|| next_opencode_seq(&mut next_seq_by_session, &session_id));
+        let preview_truncated = preview_value.is_none();
+        let synthetic_data = json!({
+            "role": role,
+            "text": preview,
+            "_ctx_oversized": {
+                "original_bytes": original_bytes,
+                "preview_chars": PROVIDER_MAX_TEXT_CHARS,
+                "source_table": table,
+                "source_format": dialect.source_format,
+                "preview_truncated": preview_truncated,
+            }
+        });
+        messages.push(OpenCodeMessageRow {
+            id,
+            session_id,
+            entry_type,
+            seq,
+            time_created,
+            time_updated,
+            data: synthetic_data.to_string(),
+        });
+    }
+    Ok(messages)
+}
+
 pub(crate) fn opencode_session_message_rows(
     path: &Path,
     conn: &Connection,
@@ -520,6 +590,13 @@ pub(crate) fn opencode_session_message_rows(
             data,
         });
     }
+    messages.extend(truncated_oversized_message_rows(
+        path,
+        "session_message",
+        dialect,
+        columns.contains("type"),
+        columns.contains("seq"),
+    )?);
     Ok((messages, skipped_oversized))
 }
 
@@ -586,6 +663,13 @@ pub(crate) fn opencode_session_entry_rows(
             data,
         });
     }
+    messages.extend(truncated_oversized_message_rows(
+        path,
+        "session_entry",
+        dialect,
+        true,
+        false,
+    )?);
     Ok((messages, skipped_oversized))
 }
 
@@ -638,6 +722,13 @@ pub(crate) fn opencode_message_rows(
             data,
         });
     }
+    messages.extend(truncated_oversized_message_rows(
+        path,
+        "message",
+        dialect,
+        false,
+        false,
+    )?);
     Ok((messages, skipped_oversized))
 }
 
@@ -825,6 +916,7 @@ pub(crate) fn opencode_event(
     let role = Some(provider_role(Some(&row.entry_type)));
     let text = opencode_event_text(&row.entry_type, data, event_type, dialect);
     let (text, truncated) = provider_local_preview(&text, PROVIDER_MAX_TEXT_CHARS);
+    let ctx_oversized = data.get("_ctx_oversized").cloned();
     ProviderEventEnvelope {
         provider_event_index,
         provider_event_hash: Some(row.id.clone()),
@@ -851,6 +943,7 @@ pub(crate) fn opencode_event(
             "text": text,
             "truncated": truncated,
             "body": provider_capped_json(data, PROVIDER_MAX_PREVIEW_CHARS),
+            "ctx_oversized": ctx_oversized,
         }),
         metadata: json!({
             "source": dialect.source_format,

--- a/crates/ctx-history-capture/src/tests/native_sqlite.rs
+++ b/crates/ctx-history-capture/src/tests/native_sqlite.rs
@@ -404,10 +404,11 @@ fn native_opencode_rejects_out_of_range_message_timestamp() {
 }
 
 #[test]
-fn native_opencode_rejects_oversized_sqlite_text_value() {
+fn native_opencode_skips_oversized_sqlite_text_value_and_imports_other_rows() {
     let temp = tempdir();
     let fixture = write_opencode_smoke_db(&temp, false);
     let conn = Connection::open(&fixture).unwrap();
+    // Mark the user message as oversized — exceeds the per-value byte cap.
     let oversized_data = format!(
         "{{\"time\":{{\"created\":1782259200000}},\"text\":\"{}\"}}",
         "x".repeat(MAX_PROVIDER_SQLITE_VALUE_BYTES + 1)
@@ -417,18 +418,45 @@ fn native_opencode_rejects_oversized_sqlite_text_value() {
         [&oversized_data],
     )
     .unwrap();
+    // Sanity check: there is at least one other conversational row that should
+    // still import once the oversized row is skipped.
+    let other_conversational: i64 = conn
+        .query_row(
+            "select count(*) from session_message where id != 'msg-user'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        other_conversational > 0,
+        "test fixture must contain at least one non-oversized conversational row"
+    );
     drop(conn);
 
-    let err = import_opencode_sqlite(
+    let summary = import_opencode_sqlite(
         &fixture,
         &mut Store::open(temp.path().join("work.sqlite")).unwrap(),
         OpenCodeSqliteImportOptions::default(),
     )
-    .unwrap_err();
+    .expect("oversized rows should be skipped, not abort the whole import");
 
+    // Oversized rows must not be recorded as failures: `summary.failed > 0`
+    // would cause `import_normalized_provider_captures` to early-exit and
+    // `import_one_source_inner` to return `Err`, which would abort
+    // `ctx search --refresh strict` and `ctx import` for the whole source
+    // even though every other row imported cleanly.
+    assert_eq!(
+        summary.failed, 0,
+        "oversized rows must not be counted as failures, got failures: {:?}",
+        summary.failures
+    );
     assert!(
-        err.to_string().contains("too big"),
-        "unexpected error: {err}"
+        summary.skipped >= 1,
+        "oversized row should be reflected in summary.skipped, got summary: {summary:?}"
+    );
+    assert!(
+        summary.imported_events >= 1,
+        "non-oversized rows should still import, got summary: {summary:?}"
     );
 }
 

--- a/crates/ctx-history-capture/src/tests/native_sqlite.rs
+++ b/crates/ctx-history-capture/src/tests/native_sqlite.rs
@@ -408,7 +408,6 @@ fn native_opencode_skips_oversized_sqlite_text_value_and_imports_other_rows() {
     let temp = tempdir();
     let fixture = write_opencode_smoke_db(&temp, false);
     let conn = Connection::open(&fixture).unwrap();
-    // Mark the user message as oversized — exceeds the per-value byte cap.
     let oversized_data = format!(
         "{{\"time\":{{\"created\":1782259200000}},\"text\":\"{}\"}}",
         "x".repeat(MAX_PROVIDER_SQLITE_VALUE_BYTES + 1)
@@ -418,8 +417,6 @@ fn native_opencode_skips_oversized_sqlite_text_value_and_imports_other_rows() {
         [&oversized_data],
     )
     .unwrap();
-    // Sanity check: there is at least one other conversational row that should
-    // still import once the oversized row is skipped.
     let other_conversational: i64 = conn
         .query_row(
             "select count(*) from session_message where id != 'msg-user'",
@@ -440,11 +437,6 @@ fn native_opencode_skips_oversized_sqlite_text_value_and_imports_other_rows() {
     )
     .expect("oversized rows should be skipped, not abort the whole import");
 
-    // Oversized rows must not be recorded as failures: `summary.failed > 0`
-    // would cause `import_normalized_provider_captures` to early-exit and
-    // `import_one_source_inner` to return `Err`, which would abort
-    // `ctx search --refresh strict` and `ctx import` for the whole source
-    // even though every other row imported cleanly.
     assert_eq!(
         summary.failed, 0,
         "oversized rows must not be counted as failures, got failures: {:?}",

--- a/crates/ctx-history-capture/src/tests/native_sqlite.rs
+++ b/crates/ctx-history-capture/src/tests/native_sqlite.rs
@@ -404,51 +404,77 @@ fn native_opencode_rejects_out_of_range_message_timestamp() {
 }
 
 #[test]
-fn native_opencode_skips_oversized_sqlite_text_value_and_imports_other_rows() {
+fn native_opencode_truncates_oversized_sqlite_text_value_and_preserves_other_rows() {
     let temp = tempdir();
     let fixture = write_opencode_smoke_db(&temp, false);
     let conn = Connection::open(&fixture).unwrap();
+    let oversized_byte_count = MAX_PROVIDER_SQLITE_VALUE_BYTES + 1;
     let oversized_data = format!(
         "{{\"time\":{{\"created\":1782259200000}},\"text\":\"{}\"}}",
-        "x".repeat(MAX_PROVIDER_SQLITE_VALUE_BYTES + 1)
+        "x".repeat(oversized_byte_count)
     );
     conn.execute(
         "update session_message set data = ?1 where id = 'msg-user'",
         [&oversized_data],
     )
     .unwrap();
-    let other_conversational: i64 = conn
-        .query_row(
-            "select count(*) from session_message where id != 'msg-user'",
-            [],
-            |row| row.get(0),
-        )
-        .unwrap();
-    assert!(
-        other_conversational > 0,
-        "test fixture must contain at least one non-oversized conversational row"
-    );
     drop(conn);
 
-    let summary = import_opencode_sqlite(
-        &fixture,
-        &mut Store::open(temp.path().join("work.sqlite")).unwrap(),
-        OpenCodeSqliteImportOptions::default(),
-    )
-    .expect("oversized rows should be skipped, not abort the whole import");
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let summary = import_opencode_sqlite(&fixture, &mut store, OpenCodeSqliteImportOptions::default())
+        .expect("oversized rows should be imported as truncated synthetic events");
 
     assert_eq!(
         summary.failed, 0,
-        "oversized rows must not be counted as failures, got failures: {:?}",
+        "truncated oversized rows should not count as import failures, got failures: {:?}",
         summary.failures
     );
     assert!(
-        summary.skipped >= 1,
-        "oversized row should be reflected in summary.skipped, got summary: {summary:?}"
+        summary.imported_sessions >= 1,
+        "session should still import, got summary: {summary:?}"
     );
     assert!(
         summary.imported_events >= 1,
         "non-oversized rows should still import, got summary: {summary:?}"
+    );
+
+    let session_id =
+        stored_provider_session_id(&store, CaptureProvider::OpenCode, "opencode-root");
+    let events = store.events_for_session(session_id).unwrap();
+    let marker_event = events
+        .iter()
+        .find(|event| event.payload.get("body").and_then(|b| b.get("ctx_oversized")).is_some())
+        .expect("expected one event carrying the top-level `ctx_oversized` marker");
+    let marker = marker_event
+        .payload
+        .get("body")
+        .and_then(|b| b.get("ctx_oversized"))
+        .and_then(|m| m.as_object())
+        .expect("ctx_oversized marker should be an object");
+    assert_eq!(
+        marker.get("message_id"),
+        None,
+        "ctx_oversized marker should not carry message_id; verify the marker_event payload"
+    );
+    assert_eq!(
+        marker_event.payload.get("body").and_then(|b| b.get("message_id")),
+        Some(&serde_json::Value::from("msg-user")),
+        "the oversized synthetic event should preserve the original provider row id"
+    );
+    assert_eq!(
+        marker.get("original_bytes"),
+        Some(&serde_json::Value::from(oversized_data.len() as i64)),
+        "marker should record the original byte size of the oversized row"
+    );
+    assert_eq!(
+        marker.get("source_table"),
+        Some(&serde_json::Value::from("session_message")),
+        "marker should record the source table"
+    );
+    assert_eq!(
+        marker.get("source_format"),
+        Some(&serde_json::Value::from("opencode_sqlite")),
+        "marker should record the source format"
     );
 }
 


### PR DESCRIPTION
## Summary

Builds on #88. Phase 1 made oversized SQLite rows **not abort** the source import by skipping them at the SQL layer. The skipped rows themselves were invisible — no event landed in the store, no search hit referenced them, `ctx show session` silently omitted them. For providers like the Kilo Code VSCode extension that occasionally carry a single multi-hundred-MB message (e.g. a giant multi-file diff captured by the extension), that meant an entire legitimate session could be silently dropped from history.

This change re-imports each oversized row as a **synthetic event** carrying a truncated preview of the original payload plus a `_ctx_oversized` marker that records the original byte count and source table. The session stays searchable end-to-end, and downstream consumers can detect truncation explicitly.

- Add `truncated_oversized_message_rows` that opens an unbounded read-only connection (the bounded connection refuses to materialize the value, so truncation must run against an uncapped connection — same reasoning as `oversized_message_row_ids` in #88) and emits one `OpenCodeMessageRow` per oversized row, with `data` set to a synthetic JSON payload containing the truncated preview (`PROVIDER_MAX_TEXT_CHARS` chars) and a `_ctx_oversized` marker.
- Extend all three row fetchers (`opencode_session_message_rows`, `opencode_session_entry_rows`, `opencode_message_rows`) to append the synthetic rows before returning so they flow through the existing per-row import path unchanged.
- Drop the Phase 1 `summary.skipped` increment in `normalize_opencode_sqlite`: oversized rows are no longer skipped, they are imported as synthetic events and counted as `imported_events`.
- Surface the `_ctx_oversized` marker in `opencode_event.payload` as a top-level field alongside `body` for downstream visibility. The marker is also nested inside `body` but `provider_capped_json` would otherwise lose it for any oversized row whose synthetic preview also exceeds the body cap, so the top-level field is the canonical detection point.

Marker shape (at `event.payload.body.ctx_oversized`):

```json
{
  "original_bytes": <byte count of the oversized row>,
  "preview_chars": 16000,
  "source_table": "session_message",
  "source_format": "opencode_sqlite",
  "preview_truncated": false
}
```

Affected scope: only the OpenCode-family SQLite adapter (covers the Kilo Code extension via `KiloSqliteAdapter`). JSONL adapters are unaffected.

## Validation

- `cargo check -p ctx-history-capture` — clean
- `cargo build --workspace` — clean, only the 2 pre-existing warnings on the `ctx` bin (`ApplyResult::Applied` unused, `ProcessState::Running/NotRunning` never constructed) that exist on `main`
- `cargo test -p ctx-history-capture --lib tests::native_sqlite` — 29 passed, 0 failed
- Regression test `native_opencode_truncates_oversized_sqlite_text_value_and_preserves_other_rows` asserts:
  - `summary.failed == 0` (oversized rows must not be treated as failures)
  - `summary.imported_events >= 1` (other rows still import)
  - exactly one event in the session carries a non-null `payload.body.ctx_oversized`
  - `payload.body.ctx_oversized.original_bytes` matches the oversized row size
  - `payload.body.ctx_oversized.source_table` / `source_format` are set
  - `payload.body.message_id` preserves the original provider row id

## End-to-end verification

Built ctx from this branch and imported a synthetic `opencode.db` fixture (smoke-test schema) containing 2 normal rows + 1 oversized row (`MAX_PROVIDER_SQLITE_VALUE_BYTES + 1` bytes under `text`):

```
[ctx] imported: events=3, sessions=1, failed=0, skipped=0
[store] exactly one synthetic oversized event with _ctx_oversized marker
[store]   message_id preserved
[store]   original_bytes matches oversized row size
[store]   source_table=session_message, source_format=opencode_sqlite
[PASS] PR #88 + #89 verified end-to-end through ctx CLI
```

All three rows imported cleanly (Phase 1 effect: no `SQLITE_TOOBIG` abort), and exactly one synthetic event landed in the store with the `_ctx_oversized` marker at `payload_json.body.ctx_oversized` (Phase 2 effect).

## Depends on

- #88 (Phase 1: skip oversized SQLite rows instead of aborting source). This branch is based on top of `fix/search-refresh-oversized-skip` and should land after it.

## Related

- #90 tracks the separate Kilo Code dialect gap (schema lacks `text`/`content`/`message` keys, blocks all kilo imports regardless of oversized handling).
