### PR TITLE
Skip oversized Codex JSONL events

### DIFF
--- a/crates/ctx-history-capture/src/common/io.rs
+++ b/crates/ctx-history-capture/src/common/io.rs
@@ -6,7 +6,7 @@ use std::{
 
 use serde_json::Value;
 
-use crate::{CaptureError, Result, MAX_PROVIDER_JSONL_LINE_BYTES};
+use crate::{CaptureError, ProviderImportSummary, Result, MAX_PROVIDER_JSONL_LINE_BYTES};
 
 pub(crate) fn collect_jsonl_paths(root: &Path, paths: &mut Vec<PathBuf>) -> Result<()> {
     let metadata = fs::symlink_metadata(root)?;
@@ -112,6 +112,28 @@ pub(crate) enum ProviderJsonlLineRead {
     Eof,
     Line { bytes: usize },
     Oversized { bytes: usize },
+}
+
+pub(crate) fn read_provider_jsonl_record_or_skip_oversized(
+    reader: &mut impl BufRead,
+    buffer: &mut Vec<u8>,
+    line_number: &mut usize,
+    summary: &mut ProviderImportSummary,
+) -> Result<bool> {
+    loop {
+        match read_provider_jsonl_line_or_skip_oversized(reader, buffer)? {
+            ProviderJsonlLineRead::Eof => return Ok(false),
+            ProviderJsonlLineRead::Line { .. } => {
+                *line_number = line_number.saturating_add(1);
+                return Ok(true);
+            }
+            ProviderJsonlLineRead::Oversized { .. } => {
+                *line_number = line_number.saturating_add(1);
+                summary.skipped += 1;
+                summary.skipped_events += 1;
+            }
+        }
+    }
 }
 
 pub(crate) fn read_provider_jsonl_line_or_skip_oversized(

--- a/crates/ctx-history-capture/src/common/io.rs
+++ b/crates/ctx-history-capture/src/common/io.rs
@@ -100,29 +100,61 @@ pub(crate) fn read_provider_jsonl_line(
     reader: &mut impl BufRead,
     buffer: &mut Vec<u8>,
 ) -> Result<bool> {
+    match read_provider_jsonl_line_or_skip_oversized(reader, buffer)? {
+        ProviderJsonlLineRead::Eof => Ok(false),
+        ProviderJsonlLineRead::Line { .. } => Ok(true),
+        ProviderJsonlLineRead::Oversized { .. } => Err(provider_jsonl_line_too_large()),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProviderJsonlLineRead {
+    Eof,
+    Line { bytes: usize },
+    Oversized { bytes: usize },
+}
+
+pub(crate) fn read_provider_jsonl_line_or_skip_oversized(
+    reader: &mut impl BufRead,
+    buffer: &mut Vec<u8>,
+) -> Result<ProviderJsonlLineRead> {
     buffer.clear();
     let mut total = 0usize;
     loop {
         let available = reader.fill_buf()?;
         if available.is_empty() {
-            return Ok(total > 0);
+            return Ok(if total > 0 {
+                ProviderJsonlLineRead::Line { bytes: total }
+            } else {
+                ProviderJsonlLineRead::Eof
+            });
         }
         if let Some(newline_index) = available.iter().position(|byte| *byte == b'\n') {
             let bytes_to_consume = newline_index + 1;
             if total.saturating_add(bytes_to_consume) > MAX_PROVIDER_JSONL_LINE_BYTES {
                 reader.consume(bytes_to_consume);
-                return Err(provider_jsonl_line_too_large());
+                buffer.clear();
+                return Ok(ProviderJsonlLineRead::Oversized {
+                    bytes: total.saturating_add(bytes_to_consume),
+                });
             }
             buffer.extend_from_slice(&available[..bytes_to_consume]);
             reader.consume(bytes_to_consume);
-            return Ok(true);
+            return Ok(ProviderJsonlLineRead::Line {
+                bytes: total.saturating_add(bytes_to_consume),
+            });
         }
 
         let bytes_to_consume = available.len();
         if total.saturating_add(bytes_to_consume) > MAX_PROVIDER_JSONL_LINE_BYTES {
             reader.consume(bytes_to_consume);
-            discard_provider_jsonl_line(reader)?;
-            return Err(provider_jsonl_line_too_large());
+            let discarded = discard_provider_jsonl_line(reader)?;
+            buffer.clear();
+            return Ok(ProviderJsonlLineRead::Oversized {
+                bytes: total
+                    .saturating_add(bytes_to_consume)
+                    .saturating_add(discarded),
+            });
         }
         buffer.extend_from_slice(available);
         reader.consume(bytes_to_consume);
@@ -130,11 +162,12 @@ pub(crate) fn read_provider_jsonl_line(
     }
 }
 
-pub(crate) fn discard_provider_jsonl_line(reader: &mut impl BufRead) -> Result<()> {
+pub(crate) fn discard_provider_jsonl_line(reader: &mut impl BufRead) -> Result<usize> {
+    let mut discarded = 0usize;
     loop {
         let available = reader.fill_buf()?;
         if available.is_empty() {
-            return Ok(());
+            return Ok(discarded);
         }
         let bytes_to_consume = available
             .iter()
@@ -145,8 +178,9 @@ pub(crate) fn discard_provider_jsonl_line(reader: &mut impl BufRead) -> Result<(
             .get(bytes_to_consume.saturating_sub(1))
             .is_some_and(|byte| *byte == b'\n');
         reader.consume(bytes_to_consume);
+        discarded = discarded.saturating_add(bytes_to_consume);
         if found_newline {
-            return Ok(());
+            return Ok(discarded);
         }
     }
 }

--- a/crates/ctx-history-capture/src/provider/adapter_impls/fixture.rs
+++ b/crates/ctx-history-capture/src/provider/adapter_impls/fixture.rs
@@ -2,7 +2,9 @@ use std::{fs::File, io::BufReader, path::Path};
 
 use ctx_history_core::CaptureProvider;
 
-use crate::common::io::{ensure_regular_provider_transcript_file, read_provider_jsonl_line};
+use crate::common::io::{
+    ensure_regular_provider_transcript_file, read_provider_jsonl_record_or_skip_oversized,
+};
 use crate::provider::adapter::ProviderFixtureJsonlAdapter;
 use crate::provider::importer::fixture_line_to_capture;
 use crate::{
@@ -31,8 +33,12 @@ impl ProviderCaptureAdapter for ProviderFixtureJsonlAdapter {
         let mut line = Vec::new();
         let mut line_number = 0usize;
 
-        while read_provider_jsonl_line(&mut reader, &mut line)? {
-            line_number += 1;
+        while read_provider_jsonl_record_or_skip_oversized(
+            &mut reader,
+            &mut line,
+            &mut line_number,
+            &mut result.summary,
+        )? {
             if line.iter().all(u8::is_ascii_whitespace) {
                 continue;
             }

--- a/crates/ctx-history-capture/src/provider/codex/catalog.rs
+++ b/crates/ctx-history-capture/src/provider/codex/catalog.rs
@@ -11,7 +11,9 @@ use ctx_history_core::{AgentType, CaptureProvider};
 use ctx_history_store::{CatalogSession, Store};
 use serde_json::{json, Value};
 
-use crate::common::io::{collect_jsonl_paths, read_provider_jsonl_line};
+use crate::common::io::{
+    collect_jsonl_paths, read_provider_jsonl_line_or_skip_oversized, ProviderJsonlLineRead,
+};
 use crate::common::time::{parse_rfc3339_utc, system_time_ms};
 use crate::{
     CaptureError, CatalogSummary, CodexSessionCatalogOptions, Result, CODEX_SESSION_SOURCE_FORMAT,
@@ -354,8 +356,10 @@ pub(crate) fn read_codex_session_meta(path: &Path) -> Result<Option<Value>> {
     let mut reader = BufReader::new(file);
     let mut line = Vec::new();
     for _ in 0..32 {
-        if !read_provider_jsonl_line(&mut reader, &mut line)? {
-            break;
+        match read_provider_jsonl_line_or_skip_oversized(&mut reader, &mut line)? {
+            ProviderJsonlLineRead::Eof => break,
+            ProviderJsonlLineRead::Line { .. } => {}
+            ProviderJsonlLineRead::Oversized { .. } => continue,
         }
         if !line.contains(&b'{') || !contains_bytes(&line, br#""session_meta""#) {
             continue;

--- a/crates/ctx-history-capture/src/provider/codex/fast_import.rs
+++ b/crates/ctx-history-capture/src/provider/codex/fast_import.rs
@@ -19,7 +19,10 @@ use crate::provider::importer::{
     provider_session_uuid, provider_source_identity, provider_source_root, ProviderCommandRunInput,
 };
 
-use crate::common::io::{ensure_regular_provider_transcript_file, read_provider_jsonl_line};
+use crate::common::io::{
+    ensure_regular_provider_transcript_file, read_provider_jsonl_line_or_skip_oversized,
+    ProviderJsonlLineRead,
+};
 use crate::provider::importer::{
     import_provider_capture_line, import_provider_file_touched_line, provider_scoped_source_uuid,
     provider_sync_metadata, resolve_pending_provider_edges, ProviderImportCaches,
@@ -224,8 +227,19 @@ pub(crate) fn import_codex_session_path_fast(
     let mut call_contexts: BTreeMap<String, CodexToolCallContext> = BTreeMap::new();
     let mut line_number = 0usize;
     let mut line = Vec::new();
-    while read_provider_jsonl_line(&mut reader, &mut line)? {
-        line_number += 1;
+    loop {
+        match read_provider_jsonl_line_or_skip_oversized(&mut reader, &mut line)? {
+            ProviderJsonlLineRead::Eof => break,
+            ProviderJsonlLineRead::Line { .. } => {
+                line_number += 1;
+            }
+            ProviderJsonlLineRead::Oversized { .. } => {
+                line_number += 1;
+                summary.skipped += 1;
+                summary.skipped_events += 1;
+                continue;
+            }
+        }
         if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }

--- a/crates/ctx-history-capture/src/provider/codex/history.rs
+++ b/crates/ctx-history-capture/src/provider/codex/history.rs
@@ -13,7 +13,9 @@ use serde_json::json;
 
 use crate::CodexHistoryJsonlAdapter;
 
-use crate::common::io::{ensure_regular_provider_transcript_file, read_provider_jsonl_line};
+use crate::common::io::{
+    ensure_regular_provider_transcript_file, read_provider_jsonl_record_or_skip_oversized,
+};
 use crate::provider::importer::{import_normalized_provider_captures, provider_cursor_stream};
 use crate::{
     CodexHistoryImportOptions, NormalizedProviderImportOptions, ProviderAdapterContext,
@@ -50,8 +52,12 @@ impl ProviderCaptureAdapter for CodexHistoryJsonlAdapter {
         let mut line = Vec::new();
         let mut line_number = 0usize;
 
-        while read_provider_jsonl_line(&mut reader, &mut line)? {
-            line_number += 1;
+        while read_provider_jsonl_record_or_skip_oversized(
+            &mut reader,
+            &mut line,
+            &mut line_number,
+            &mut result.summary,
+        )? {
             if line.iter().all(u8::is_ascii_whitespace) {
                 continue;
             }

--- a/crates/ctx-history-capture/src/provider/codex/session.rs
+++ b/crates/ctx-history-capture/src/provider/codex/session.rs
@@ -14,6 +14,7 @@ use crate::CodexSessionJsonlAdapter;
 
 use crate::common::io::{
     collect_jsonl_paths, ensure_regular_provider_transcript_file, read_provider_jsonl_line,
+    read_provider_jsonl_line_or_skip_oversized, ProviderJsonlLineRead,
 };
 use crate::provider::importer::{
     import_normalized_provider_captures, import_provider_capture_line,
@@ -64,8 +65,19 @@ impl ProviderCaptureAdapter for CodexSessionJsonlAdapter {
 
         let mut line_number = 0usize;
         let mut line = Vec::new();
-        while read_provider_jsonl_line(&mut reader, &mut line)? {
-            line_number += 1;
+        loop {
+            match read_provider_jsonl_line_or_skip_oversized(&mut reader, &mut line)? {
+                ProviderJsonlLineRead::Eof => break,
+                ProviderJsonlLineRead::Line { .. } => {
+                    line_number += 1;
+                }
+                ProviderJsonlLineRead::Oversized { .. } => {
+                    line_number += 1;
+                    result.summary.skipped += 1;
+                    result.summary.skipped_events += 1;
+                    continue;
+                }
+            }
             if line.iter().all(u8::is_ascii_whitespace) {
                 continue;
             }
@@ -445,12 +457,20 @@ pub fn import_codex_session_jsonl_tail(
         let header = codex_session_header(header_value)?;
 
         while position < start_offset {
-            if !read_provider_jsonl_line(&mut reader, &mut line)? {
-                return Ok(summary);
+            match read_provider_jsonl_line_or_skip_oversized(&mut reader, &mut line)? {
+                ProviderJsonlLineRead::Eof => return Ok(summary),
+                ProviderJsonlLineRead::Line { bytes } => {
+                    line_number += 1;
+                    position = position.saturating_add(bytes as u64);
+                }
+                ProviderJsonlLineRead::Oversized { bytes } => {
+                    line_number += 1;
+                    position = position.saturating_add(bytes as u64);
+                    summary.skipped += 1;
+                    summary.skipped_events += 1;
+                    continue;
+                }
             }
-            line_number += 1;
-            let read = line.len();
-            position = position.saturating_add(read as u64);
         }
 
         store.begin_immediate_batch()?;
@@ -467,10 +487,30 @@ pub fn import_codex_session_jsonl_tail(
 
         let mut call_contexts: BTreeMap<String, CodexToolCallContext> = BTreeMap::new();
         let mut completed_bytes = 0u64;
-        while read_provider_jsonl_line(&mut reader, &mut line)? {
-            line_number += 1;
-            let read = line.len();
-            completed_bytes = completed_bytes.saturating_add(read as u64);
+        loop {
+            match read_provider_jsonl_line_or_skip_oversized(&mut reader, &mut line)? {
+                ProviderJsonlLineRead::Eof => break,
+                ProviderJsonlLineRead::Line { bytes } => {
+                    line_number += 1;
+                    completed_bytes = completed_bytes.saturating_add(bytes as u64);
+                }
+                ProviderJsonlLineRead::Oversized { bytes } => {
+                    line_number += 1;
+                    completed_bytes = completed_bytes.saturating_add(bytes as u64);
+                    summary.skipped += 1;
+                    summary.skipped_events += 1;
+                    report_codex_import_progress(
+                        &options,
+                        1,
+                        total_bytes - start_offset,
+                        0,
+                        completed_bytes,
+                        &summary,
+                        false,
+                    );
+                    continue;
+                }
+            }
             if line.iter().all(u8::is_ascii_whitespace) {
                 continue;
             }

--- a/crates/ctx-history-capture/src/provider/custom_history_jsonl.rs
+++ b/crates/ctx-history-capture/src/provider/custom_history_jsonl.rs
@@ -18,7 +18,9 @@ use serde_json::{json, Value};
 
 use crate::stable_capture_uuid;
 
-use crate::common::io::{ensure_regular_provider_transcript_file, read_provider_jsonl_line};
+use crate::common::io::{
+    ensure_regular_provider_transcript_file, read_provider_jsonl_record_or_skip_oversized,
+};
 use crate::{
     ProviderAdapterContext, ProviderFileTouchedEnvelope, ProviderImportFailure,
     ProviderImportSummary, ProviderNormalizationResult, Result,
@@ -76,8 +78,12 @@ pub(crate) fn normalize_custom_history_jsonl_v1_reader(
     let mut line = Vec::new();
     let mut line_number = 0usize;
 
-    while read_provider_jsonl_line(&mut reader, &mut line)? {
-        line_number += 1;
+    while read_provider_jsonl_record_or_skip_oversized(
+        &mut reader,
+        &mut line,
+        &mut line_number,
+        &mut summary,
+    )? {
         if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }

--- a/crates/ctx-history-capture/src/provider/providers/claude.rs
+++ b/crates/ctx-history-capture/src/provider/providers/claude.rs
@@ -9,7 +9,9 @@ use ctx_history_core::{
 };
 use serde_json::{json, Value};
 
-use crate::common::io::{ensure_regular_provider_transcript_file, read_provider_jsonl_line};
+use crate::common::io::{
+    ensure_regular_provider_transcript_file, read_provider_jsonl_record_or_skip_oversized,
+};
 use crate::common::time::parse_rfc3339_utc;
 use crate::provider::file_touches::provider_file_touches_from_raw_value;
 use crate::provider::importer::provider_cursor_stream;
@@ -34,8 +36,12 @@ pub(crate) fn normalize_claude_projects_jsonl_file(
     let mut line = Vec::new();
     let mut line_number = 0usize;
 
-    while read_provider_jsonl_line(&mut reader, &mut line)? {
-        line_number += 1;
+    while read_provider_jsonl_record_or_skip_oversized(
+        &mut reader,
+        &mut line,
+        &mut line_number,
+        &mut result.summary,
+    )? {
         if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }

--- a/crates/ctx-history-capture/src/provider/providers/junie.rs
+++ b/crates/ctx-history-capture/src/provider/providers/junie.rs
@@ -14,7 +14,10 @@ use serde_json::{json, Value};
 
 use crate::JUNIE_SESSION_EVENTS_SOURCE_FORMAT;
 
-use crate::common::io::{ensure_regular_provider_transcript_file, read_provider_jsonl_line};
+use crate::common::io::{
+    ensure_regular_provider_transcript_file, read_provider_jsonl_line_or_skip_oversized,
+    read_provider_jsonl_record_or_skip_oversized, ProviderJsonlLineRead,
+};
 use crate::provider::custom_history_jsonl::push_provider_import_failure;
 use crate::provider::native::{
     native_event, native_provider_capture, provider_capped_json_value, provider_timestamp_millis,
@@ -182,7 +185,12 @@ pub(crate) fn junie_read_index(path: &Path) -> Result<Vec<JunieIndexMeta>> {
     let mut reader = BufReader::new(file);
     let mut metas = Vec::new();
     let mut line = Vec::new();
-    while read_provider_jsonl_line(&mut reader, &mut line)? {
+    loop {
+        match read_provider_jsonl_line_or_skip_oversized(&mut reader, &mut line)? {
+            ProviderJsonlLineRead::Eof => break,
+            ProviderJsonlLineRead::Line { .. } => {}
+            ProviderJsonlLineRead::Oversized { .. } => continue,
+        }
         if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }
@@ -330,8 +338,12 @@ pub(crate) fn normalize_junie_session_events_file(
     let mut reader = BufReader::new(file);
     let mut line = Vec::new();
     let mut line_number = 0usize;
-    while read_provider_jsonl_line(&mut reader, &mut line)? {
-        line_number += 1;
+    while read_provider_jsonl_record_or_skip_oversized(
+        &mut reader,
+        &mut line,
+        &mut line_number,
+        &mut result.summary,
+    )? {
         let import_line = base_line.saturating_add(line_number);
         if line.iter().all(u8::is_ascii_whitespace) {
             continue;

--- a/crates/ctx-history-capture/src/provider/providers/kimi.rs
+++ b/crates/ctx-history-capture/src/provider/providers/kimi.rs
@@ -16,8 +16,9 @@ use crate::provider::providers::native_jsonl::native_jsonl_missing_reason;
 use crate::provider::providers::openclaw::provider_path_has_component;
 
 use crate::common::io::{
-    collect_jsonl_paths, ensure_regular_provider_transcript_file, read_provider_jsonl_line,
-    read_text_file_limited,
+    collect_jsonl_paths, ensure_regular_provider_transcript_file,
+    read_provider_jsonl_line_or_skip_oversized, read_provider_jsonl_record_or_skip_oversized,
+    read_text_file_limited, ProviderJsonlLineRead,
 };
 use crate::common::time::parse_rfc3339_utc;
 use crate::provider::custom_history_jsonl::push_provider_import_failure;
@@ -80,8 +81,12 @@ pub(crate) fn normalize_kimi_wire_jsonl_file(
     let mut line = Vec::new();
     let mut line_number = 0usize;
 
-    while read_provider_jsonl_line(&mut reader, &mut line)? {
-        line_number += 1;
+    while read_provider_jsonl_record_or_skip_oversized(
+        &mut reader,
+        &mut line,
+        &mut line_number,
+        &mut result.summary,
+    )? {
         if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }
@@ -531,16 +536,23 @@ pub(crate) fn kimi_session_index(path: &Path) -> BTreeMap<String, KimiSessionInd
 }
 
 pub(crate) fn read_kimi_session_index(path: &Path) -> BTreeMap<String, KimiSessionIndexEntry> {
-    let Ok(text) = read_text_file_limited(
-        path,
-        MAX_PROVIDER_JSONL_LINE_BYTES,
-        "Kimi Code CLI session_index.jsonl",
-    ) else {
+    let Ok(file) = File::open(path) else {
         return BTreeMap::new();
     };
+    let mut reader = BufReader::new(file);
+    let mut line = Vec::new();
     let mut entries = BTreeMap::new();
-    for line in text.lines() {
-        let Ok(value) = serde_json::from_str::<Value>(line) else {
+    loop {
+        match read_provider_jsonl_line_or_skip_oversized(&mut reader, &mut line) {
+            Ok(ProviderJsonlLineRead::Eof) => break,
+            Ok(ProviderJsonlLineRead::Line { .. }) => {}
+            Ok(ProviderJsonlLineRead::Oversized { .. }) => continue,
+            Err(_) => return BTreeMap::new(),
+        }
+        if line.iter().all(u8::is_ascii_whitespace) {
+            continue;
+        }
+        let Ok(value) = serde_json::from_slice::<Value>(&line) else {
             continue;
         };
         let Some(session_id) = value

--- a/crates/ctx-history-capture/src/provider/providers/mistral_vibe.rs
+++ b/crates/ctx-history-capture/src/provider/providers/mistral_vibe.rs
@@ -17,7 +17,7 @@ use crate::provider::providers::native_jsonl::{
 
 use crate::common::io::{
     ensure_provider_path_parents_are_not_symlinks, ensure_regular_provider_transcript_file,
-    read_provider_jsonl_line, read_text_file_limited,
+    read_provider_jsonl_record_or_skip_oversized, read_text_file_limited,
 };
 use crate::common::time::parse_rfc3339_utc;
 use crate::provider::custom_history_jsonl::push_provider_import_failure;
@@ -134,8 +134,12 @@ pub(crate) fn normalize_mistral_vibe_session_source(
     let mut line = Vec::new();
     let mut line_number = 0usize;
 
-    while read_provider_jsonl_line(&mut reader, &mut line)? {
-        line_number += 1;
+    while read_provider_jsonl_record_or_skip_oversized(
+        &mut reader,
+        &mut line,
+        &mut line_number,
+        &mut result.summary,
+    )? {
         if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }

--- a/crates/ctx-history-capture/src/provider/providers/mux.rs
+++ b/crates/ctx-history-capture/src/provider/providers/mux.rs
@@ -15,7 +15,7 @@ use crate::provider::providers::native_jsonl::native_jsonl_missing_reason;
 
 use crate::common::io::{
     ensure_provider_path_parents_are_not_symlinks, ensure_regular_provider_transcript_file,
-    read_provider_jsonl_line, read_text_file_limited,
+    read_provider_jsonl_record_or_skip_oversized, read_text_file_limited,
 };
 use crate::common::time::parse_rfc3339_utc;
 use crate::provider::custom_history_jsonl::push_provider_import_failure;
@@ -190,8 +190,12 @@ pub(crate) fn normalize_mux_session_source(
         let mut reader = BufReader::new(file);
         let mut line = Vec::new();
         let mut line_number = 0usize;
-        while read_provider_jsonl_line(&mut reader, &mut line)? {
-            line_number += 1;
+        while read_provider_jsonl_record_or_skip_oversized(
+            &mut reader,
+            &mut line,
+            &mut line_number,
+            &mut result.summary,
+        )? {
             if line.iter().all(u8::is_ascii_whitespace) {
                 continue;
             }

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl.rs
@@ -15,7 +15,8 @@ use ctx_history_core::{
 use serde_json::{json, Value};
 
 use crate::common::io::{
-    collect_jsonl_paths, ensure_regular_provider_transcript_file, read_provider_jsonl_line,
+    collect_jsonl_paths, ensure_regular_provider_transcript_file,
+    read_provider_jsonl_record_or_skip_oversized,
 };
 use crate::common::time::parse_rfc3339_utc;
 use crate::provider::file_touches::provider_file_touches_from_raw_value;
@@ -169,8 +170,12 @@ pub(crate) fn normalize_native_jsonl_session_file(
     let mut line = Vec::new();
     let mut line_number = 0usize;
 
-    while read_provider_jsonl_line(&mut reader, &mut line)? {
-        line_number += 1;
+    while read_provider_jsonl_record_or_skip_oversized(
+        &mut reader,
+        &mut line,
+        &mut line_number,
+        &mut result.summary,
+    )? {
         if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }

--- a/crates/ctx-history-capture/src/provider/providers/openclaw.rs
+++ b/crates/ctx-history-capture/src/provider/providers/openclaw.rs
@@ -13,8 +13,8 @@ use ctx_history_core::{
 use serde_json::{json, Value};
 
 use crate::common::io::{
-    collect_jsonl_paths, ensure_regular_provider_transcript_file, read_provider_jsonl_line,
-    read_text_file_limited,
+    collect_jsonl_paths, ensure_regular_provider_transcript_file,
+    read_provider_jsonl_record_or_skip_oversized, read_text_file_limited,
 };
 use crate::provider::native::{
     native_event, native_provider_capture, provider_capped_json, provider_role,
@@ -215,8 +215,12 @@ pub(crate) fn normalize_openclaw_jsonl_file(
     let mut header_seen = false;
     let mut line_number = 0usize;
     let mut line = Vec::new();
-    while read_provider_jsonl_line(&mut reader, &mut line)? {
-        line_number += 1;
+    while read_provider_jsonl_record_or_skip_oversized(
+        &mut reader,
+        &mut line,
+        &mut line_number,
+        &mut result.summary,
+    )? {
         if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }

--- a/crates/ctx-history-capture/src/provider/providers/pi.rs
+++ b/crates/ctx-history-capture/src/provider/providers/pi.rs
@@ -17,7 +17,8 @@ use crate::provider::providers::native_jsonl::native_jsonl_missing_reason;
 use crate::provider::providers::real_content::event_has_real_conversation_content;
 
 use crate::common::io::{
-    collect_jsonl_paths, ensure_regular_provider_transcript_file, read_provider_jsonl_line,
+    collect_jsonl_paths, ensure_regular_provider_transcript_file,
+    read_provider_jsonl_record_or_skip_oversized,
 };
 use crate::common::time::parse_optional_rfc3339_field;
 use crate::provider::adapter::PiSessionJsonlAdapter;
@@ -101,8 +102,12 @@ pub(crate) fn normalize_pi_session_jsonl_file(
     let mut line = Vec::new();
     let mut line_number = 0usize;
 
-    while read_provider_jsonl_line(&mut reader, &mut line)? {
-        line_number += 1;
+    while read_provider_jsonl_record_or_skip_oversized(
+        &mut reader,
+        &mut line,
+        &mut line_number,
+        &mut result.summary,
+    )? {
         if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }

--- a/crates/ctx-history-capture/src/tests/codex.rs
+++ b/crates/ctx-history-capture/src/tests/codex.rs
@@ -155,14 +155,14 @@ fn codex_session_catalog_large_noop_uses_metadata_cache() {
 }
 
 #[test]
-fn codex_session_catalog_rejects_oversized_metadata_line() {
+fn codex_session_catalog_skips_oversized_metadata_probe_line() {
     let temp = tempdir();
     let root = temp.path().join("sessions/2026/07/03");
     fs::create_dir_all(&root).unwrap();
     write_oversized_jsonl_line(&root.join("oversized.jsonl"));
     let store = Store::open(temp.path().join("work.sqlite")).unwrap();
 
-    let err = catalog_codex_session_tree(
+    let summary = catalog_codex_session_tree(
         temp.path().join("sessions"),
         &store,
         CodexSessionCatalogOptions {
@@ -172,12 +172,12 @@ fn codex_session_catalog_rejects_oversized_metadata_line() {
             ..CodexSessionCatalogOptions::default()
         },
     )
-    .unwrap_err();
+    .unwrap();
 
-    assert!(
-        err.to_string().contains("provider JSONL line exceeds"),
-        "{err}"
-    );
+    assert_eq!(summary.source_files, 1);
+    assert_eq!(summary.cataloged_sessions, 1);
+    assert_eq!(summary.parsed_sessions, 1);
+    assert_eq!(summary.failed_sessions, 0);
 }
 
 #[test]

--- a/crates/ctx-history-capture/src/tests/codex.rs
+++ b/crates/ctx-history-capture/src/tests/codex.rs
@@ -627,16 +627,108 @@ fn codex_session_tree_rejects_symlinked_jsonl_files() {
     assert!(store.list_sessions().unwrap().is_empty());
 }
 
+fn write_codex_session_with_oversized_event(path: &Path) {
+    fs::write(
+        path,
+        [
+            jsonl_line(json!({
+                "timestamp": "2026-07-03T12:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "codex-oversized-skip",
+                    "timestamp": "2026-07-03T12:00:00Z",
+                    "cwd": "/workspace",
+                    "originator": "codex-cli"
+                }
+            })),
+            jsonl_line(json!({
+                "timestamp": "2026-07-03T12:00:01Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "before oversized event"}]
+                }
+            })),
+            jsonl_line(json!({
+                "timestamp": "2026-07-03T12:00:02Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "patch_apply_end",
+                    "stdout": "x".repeat(MAX_PROVIDER_JSONL_LINE_BYTES + 1),
+                    "stderr": "",
+                    "success": true
+                }
+            })),
+            jsonl_line(json!({
+                "timestamp": "2026-07-03T12:00:03Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "after oversized event"}]
+                }
+            })),
+        ]
+        .concat(),
+    )
+    .unwrap();
+}
+
 #[test]
-fn codex_session_jsonl_rejects_oversized_line() {
+fn codex_session_jsonl_skips_oversized_line_and_normalizes_remaining_events() {
     let temp = tempdir();
     let path = temp.path().join("oversized-codex.jsonl");
-    write_oversized_jsonl_line(&path);
+    write_codex_session_with_oversized_event(&path);
 
-    let err = CodexSessionJsonlAdapter
+    let normalized = CodexSessionJsonlAdapter
         .normalize_path(&path, &ProviderAdapterContext::default())
-        .unwrap_err();
-    assert!(err.to_string().contains("provider JSONL line exceeds"));
+        .unwrap();
+
+    assert_eq!(
+        normalized.summary.failed, 0,
+        "{:?}",
+        normalized.summary.failures
+    );
+    assert_eq!(normalized.summary.skipped, 1);
+    assert_eq!(normalized.summary.skipped_events, 1);
+    assert_eq!(normalized.captures.len(), 3);
+}
+
+#[test]
+fn codex_session_jsonl_fast_import_skips_one_oversized_line() {
+    let temp = tempdir();
+    let path = temp.path().join("oversized-codex.jsonl");
+    write_codex_session_with_oversized_event(&path);
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_codex_session_jsonl(
+        &path,
+        &mut store,
+        CodexSessionImportOptions {
+            imported_at: "2026-07-03T12:30:00Z".parse().unwrap(),
+            ..CodexSessionImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.skipped_events, 1);
+    assert_eq!(summary.imported_sessions, 1);
+    assert_eq!(summary.imported_events, 2);
+
+    let session_id =
+        stored_provider_session_id(&store, CaptureProvider::Codex, "codex-oversized-skip");
+    let events = store.events_for_session(session_id).unwrap();
+    assert_eq!(events.len(), 2);
+    let payloads = events
+        .iter()
+        .map(|event| event.payload.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(payloads.contains("before oversized event"), "{payloads}");
+    assert!(payloads.contains("after oversized event"), "{payloads}");
+    assert!(!payloads.contains("patch_apply_end"), "{payloads}");
 }
 
 #[test]

--- a/crates/ctx-history-capture/src/tests/custom_history.rs
+++ b/crates/ctx-history-capture/src/tests/custom_history.rs
@@ -279,21 +279,135 @@ fn custom_history_jsonl_malformed_import_is_atomic_by_default() {
 }
 
 #[test]
-fn custom_history_jsonl_rejects_oversized_line() {
+fn codex_history_jsonl_skips_oversized_line_and_imports_remaining_records() {
     let temp = tempdir();
-    let path = temp.path().join("oversized-custom.jsonl");
-    write_oversized_jsonl_line(&path);
+    let path = temp.path().join("codex-history-oversized.jsonl");
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(
+        jsonl_line(json!({
+            "session_id": "codex-history-oversized",
+            "ts": 1783170000,
+            "text": "before oversized codex history"
+        }))
+        .as_bytes(),
+    );
+    bytes.extend_from_slice(&oversized_jsonl_line());
+    bytes.extend_from_slice(
+        jsonl_line(json!({
+            "session_id": "codex-history-oversized",
+            "ts": 1783170001,
+            "text": "after oversized codex history"
+        }))
+        .as_bytes(),
+    );
+    fs::write(&path, bytes).unwrap();
     let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
 
-    let err = import_custom_history_jsonl_v1(
+    let summary = import_codex_history_jsonl(
         &path,
         &mut store,
-        CustomHistoryJsonlV1ImportOptions::default(),
+        CodexHistoryImportOptions {
+            source_path: Some(path.clone()),
+            imported_at: "2026-07-04T13:30:00Z".parse().unwrap(),
+            ..CodexHistoryImportOptions::default()
+        },
     )
-    .unwrap_err();
+    .unwrap();
 
-    assert!(err.to_string().contains("provider JSONL line exceeds"));
-    assert_eq!(store.capture_source_count().unwrap(), 0);
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.skipped, 1);
+    assert_eq!(summary.skipped_events, 1);
+    assert_eq!(summary.imported_sessions, 1);
+    assert_eq!(summary.imported_events, 2);
+    let session_id = provider_import_session_id_for_path(
+        CaptureProvider::Codex,
+        "codex_history_jsonl",
+        &path,
+        "codex-history-oversized",
+    );
+    let events = store.events_for_session(session_id).unwrap();
+    let rendered = serde_json::to_string(&events).unwrap();
+    assert!(rendered.contains("before oversized codex history"));
+    assert!(rendered.contains("after oversized codex history"));
+}
+
+#[test]
+fn custom_history_jsonl_skips_oversized_record_and_imports_remaining_records() {
+    let temp = tempdir();
+    let path = temp.path().join("oversized-custom.jsonl");
+    let mut bytes = Vec::new();
+    for line in [
+        jsonl_line(json!({
+            "record_type": "manifest",
+            "schema_version": "ctx-history-jsonl-v1"
+        })),
+        jsonl_line(json!({
+            "record_type": "source",
+            "source_id": "src",
+            "provider_key": "custom-agent",
+            "source_format": "demo"
+        })),
+        jsonl_line(json!({
+            "record_type": "session",
+            "source_id": "src",
+            "session_id": "run",
+            "started_at": "2026-07-04T13:00:00Z"
+        })),
+        jsonl_line(json!({
+            "record_type": "event",
+            "source_id": "src",
+            "session_id": "run",
+            "event_index": 0,
+            "event_type": "message",
+            "role": "user",
+            "occurred_at": "2026-07-04T13:00:01Z",
+            "preview": "before oversized custom history"
+        })),
+    ] {
+        bytes.extend_from_slice(line.as_bytes());
+    }
+    bytes.extend_from_slice(&oversized_jsonl_line());
+    bytes.extend_from_slice(
+        jsonl_line(json!({
+            "record_type": "event",
+            "source_id": "src",
+            "session_id": "run",
+            "event_index": 1,
+            "event_type": "message",
+            "role": "assistant",
+            "occurred_at": "2026-07-04T13:00:02Z",
+            "preview": "after oversized custom history"
+        }))
+        .as_bytes(),
+    );
+    fs::write(&path, bytes).unwrap();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_custom_history_jsonl_v1(
+        &path,
+        &mut store,
+        CustomHistoryJsonlV1ImportOptions {
+            source_path: Some(path.clone()),
+            imported_at: "2026-07-04T13:30:00Z".parse().unwrap(),
+            ..CustomHistoryJsonlV1ImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.skipped, 1);
+    assert_eq!(summary.skipped_events, 1);
+    assert_eq!(summary.imported_sessions, 1);
+    assert_eq!(summary.imported_events, 2);
+    let session_id = provider_session_uuid(
+        CaptureProvider::Custom,
+        &custom_history_internal_session_id("custom-agent", "src", "run"),
+    );
+    let events = store.events_for_session(session_id).unwrap();
+    assert_eq!(events.len(), 2);
+    let rendered = serde_json::to_string(&events).unwrap();
+    assert!(rendered.contains("before oversized custom history"));
+    assert!(rendered.contains("after oversized custom history"));
 }
 
 #[test]

--- a/crates/ctx-history-capture/src/tests/native_json.rs
+++ b/crates/ctx-history-capture/src/tests/native_json.rs
@@ -190,6 +190,64 @@ fn native_claude_empty_project_jsonl_rejects_no_real_message() {
 }
 
 #[test]
+fn native_claude_projects_skips_oversized_jsonl_record() {
+    let temp = tempdir();
+    let root = temp.path().join("claude/projects/-workspace");
+    fs::create_dir_all(&root).unwrap();
+    let path = root.join("oversized-claude.jsonl");
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(
+        jsonl_line(json!({
+            "sessionId": "claude-oversized",
+            "timestamp": "2026-07-04T14:00:00Z",
+            "cwd": "/workspace",
+            "version": "test",
+            "type": "user",
+            "message": {"role": "user", "content": "before oversized claude"},
+            "uuid": "claude-oversized-before"
+        }))
+        .as_bytes(),
+    );
+    bytes.extend_from_slice(&oversized_jsonl_line());
+    bytes.extend_from_slice(
+        jsonl_line(json!({
+            "sessionId": "claude-oversized",
+            "timestamp": "2026-07-04T14:00:01Z",
+            "cwd": "/workspace",
+            "version": "test",
+            "type": "assistant",
+            "message": {"role": "assistant", "content": "after oversized claude"},
+            "uuid": "claude-oversized-after"
+        }))
+        .as_bytes(),
+    );
+    fs::write(&path, bytes).unwrap();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_claude_projects_jsonl_tree(
+        temp.path().join("claude/projects"),
+        &mut store,
+        ClaudeProjectsImportOptions {
+            source_path: Some(temp.path().join("claude/projects")),
+            imported_at: "2026-07-04T14:30:00Z".parse().unwrap(),
+            ..ClaudeProjectsImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.skipped, 1);
+    assert_eq!(summary.skipped_events, 1);
+    assert_eq!(summary.imported_sessions, 1);
+    assert_eq!(summary.imported_events, 2);
+    let session_id =
+        stored_provider_session_id(&store, CaptureProvider::Claude, "claude-oversized");
+    let rendered = serde_json::to_string(&store.events_for_session(session_id).unwrap()).unwrap();
+    assert!(rendered.contains("before oversized claude"));
+    assert!(rendered.contains("after oversized claude"));
+}
+
+#[test]
 fn antigravity_native_history_imports_transcripts_and_preserves_previews() {
     let temp = tempdir();
     let fixture = provider_history_fixture("antigravity/v1/brain");

--- a/crates/ctx-history-capture/src/tests/native_providers.rs
+++ b/crates/ctx-history-capture/src/tests/native_providers.rs
@@ -928,6 +928,48 @@ fn native_mux_fixture_imports_searches_reimports_and_subagents() {
 }
 
 #[test]
+fn native_mux_skips_oversized_chat_record() {
+    let temp = tempdir();
+    let fixture = provider_history_fixture("mux/v0.27.0/sessions");
+    let chat_path = fixture.join("mux-parent-session/chat.jsonl");
+    let original = fs::read(&chat_path).unwrap();
+    let first_line_end = original
+        .iter()
+        .position(|byte| *byte == b'\n')
+        .map(|index| index + 1)
+        .unwrap();
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&original[..first_line_end]);
+    bytes.extend_from_slice(&oversized_jsonl_line());
+    bytes.extend_from_slice(&original[first_line_end..]);
+    fs::write(&chat_path, bytes).unwrap();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_mux_history(
+        &fixture,
+        &mut store,
+        MuxImportOptions {
+            source_path: Some(fixture.clone()),
+            allow_partial_failures: true,
+            imported_at: "2026-07-04T19:30:00Z".parse().unwrap(),
+            ..MuxImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.skipped, 1);
+    assert_eq!(summary.skipped_events, 1);
+    assert_eq!(summary.imported_sessions, 2);
+    assert_eq!(summary.imported_events, 6);
+    assert!(store
+        .search_event_hits("mux jsonl oracle prompt", 10)
+        .unwrap()
+        .iter()
+        .any(|hit| hit.provider == Some(CaptureProvider::Mux)));
+}
+
+#[test]
 fn native_mux_reports_malformed_jsonl_partially() {
     let temp = tempdir();
     let fixture = provider_history_fixture("mux/malformed/sessions");
@@ -1132,6 +1174,56 @@ fn native_jsonl_tree_imports_gemini_droid_and_copilot_smokes() {
 }
 
 #[test]
+fn native_jsonl_tree_skips_oversized_record_and_continues_session() {
+    let temp = tempdir();
+    let chats = temp.path().join("gemini/.gemini/tmp/project/chats");
+    fs::create_dir_all(&chats).unwrap();
+    let path = chats.join("oversized-gemini.jsonl");
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(
+        jsonl_line(json!({
+            "sessionId": "gemini-oversized",
+            "startTime": "2026-07-04T15:00:00Z",
+            "directories": ["/workspace"]
+        }))
+        .as_bytes(),
+    );
+    bytes.extend_from_slice(&oversized_jsonl_line());
+    bytes.extend_from_slice(
+        jsonl_line(json!({
+            "id": "gemini-after-oversized",
+            "timestamp": "2026-07-04T15:00:01Z",
+            "type": "user",
+            "content": "after oversized gemini"
+        }))
+        .as_bytes(),
+    );
+    fs::write(&path, bytes).unwrap();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_gemini_cli_history(
+        temp.path().join("gemini/.gemini"),
+        &mut store,
+        GeminiCliImportOptions {
+            source_path: Some(temp.path().join("gemini/.gemini")),
+            imported_at: "2026-07-04T15:30:00Z".parse().unwrap(),
+            ..GeminiCliImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.skipped, 1);
+    assert_eq!(summary.skipped_events, 1);
+    assert_eq!(summary.imported_sessions, 1);
+    assert_eq!(summary.imported_events, 2);
+    let session_id =
+        stored_provider_session_id(&store, CaptureProvider::Gemini, "gemini-oversized");
+    let rendered = serde_json::to_string(&store.events_for_session(session_id).unwrap()).unwrap();
+    assert!(rendered.contains("after oversized gemini"));
+}
+
+#[test]
 fn native_jsonl_tree_imports_qwen_and_kimi_smokes_are_idempotent() {
     let temp = tempdir();
     let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
@@ -1245,6 +1337,60 @@ fn native_jsonl_tree_imports_qwen_and_kimi_smokes_are_idempotent() {
     assert_eq!(kimi_second.imported_events, 0);
     assert_eq!(kimi_second.imported_edges, 0);
 }
+
+#[test]
+fn native_kimi_skips_oversized_index_and_wire_records() {
+    let temp = tempdir();
+    let kimi = write_kimi_smoke_fixture(&temp);
+    let index_path = kimi.join("session_index.jsonl");
+    let original_index = fs::read(&index_path).unwrap();
+    let mut index_bytes = oversized_jsonl_line();
+    index_bytes.extend_from_slice(&original_index);
+    fs::write(&index_path, index_bytes).unwrap();
+
+    let wire_path = kimi.join("sessions/wd_demo_abc123/kimi-smoke/agents/main/wire.jsonl");
+    let original_wire = fs::read(&wire_path).unwrap();
+    let first_line_end = original_wire
+        .iter()
+        .position(|byte| *byte == b'\n')
+        .map(|index| index + 1)
+        .unwrap();
+    let mut wire_bytes = Vec::new();
+    wire_bytes.extend_from_slice(&original_wire[..first_line_end]);
+    wire_bytes.extend_from_slice(&oversized_jsonl_line());
+    wire_bytes.extend_from_slice(&original_wire[first_line_end..]);
+    fs::write(&wire_path, wire_bytes).unwrap();
+
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let summary = import_kimi_code_cli_history(
+        &kimi,
+        &mut store,
+        KimiCodeCliImportOptions {
+            allow_partial_failures: true,
+            imported_at: "2026-07-04T15:30:00Z".parse().unwrap(),
+            ..KimiCodeCliImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.skipped, 1);
+    assert_eq!(summary.skipped_events, 1);
+    assert_eq!(summary.imported_sessions, 2);
+    assert_eq!(summary.imported_events, 7);
+    let session_id = stored_provider_session_id(&store, CaptureProvider::KimiCodeCli, "kimi-smoke");
+    let source = store
+        .capture_source_by_external_session(CaptureProvider::KimiCodeCli, "kimi-smoke")
+        .unwrap()
+        .unwrap();
+    assert_eq!(source.descriptor.cwd.as_deref(), Some("/workspace/kimi"));
+    assert_eq!(
+        store.events_for_session(session_id).unwrap().len(),
+        5,
+        "main wire events should resume after the oversized record"
+    );
+}
+
 #[test]
 fn native_jsonl_tree_skips_headerless_native_files() {
     let temp = tempdir();

--- a/crates/ctx-history-capture/src/tests/support.rs
+++ b/crates/ctx-history-capture/src/tests/support.rs
@@ -126,6 +126,12 @@ pub(super) fn write_oversized_jsonl_line(path: &Path) {
     fs::write(path, vec![b'x'; MAX_PROVIDER_JSONL_LINE_BYTES + 1]).unwrap();
 }
 
+pub(super) fn oversized_jsonl_line() -> Vec<u8> {
+    let mut line = vec![b'x'; MAX_PROVIDER_JSONL_LINE_BYTES + 1];
+    line.push(b'\n');
+    line
+}
+
 pub(super) fn jsonl_line(value: Value) -> String {
     serde_json::to_string(&value).unwrap() + "\n"
 }


### PR DESCRIPTION
## Summary
- add a JSONL reader mode that can discard one oversized record while preserving strict behavior for callers that need it
- make oversized JSONL records skip/count across provider families outside SQLite, including Codex history/catalog, custom history, fixtures, Claude/Pi/native JSONL, Junie/Kimi/Mistral/Mux/OpenClaw streams
- cover Codex, custom history, native JSONL, Claude, Kimi, and Mux oversized-record paths with regression tests

## Verification
- cargo fmt --check
- cargo test -p ctx-history-capture
- cargo clippy -p ctx-history-capture --all-targets -- -D warnings