### PR TITLE
Align Codex oversized JSONL skip semantics

### DIFF
--- a/crates/ctx-history-capture/src/provider/codex/fast_import.rs
+++ b/crates/ctx-history-capture/src/provider/codex/fast_import.rs
@@ -40,7 +40,7 @@ use crate::provider::codex::events::{
     CodexToolCallContext,
 };
 use crate::provider::codex::session::{
-    codex_session_file_has_real_conversation, should_parse_codex_session_line,
+    codex_session_file_conversation_scan, should_parse_codex_session_line,
     should_skip_codex_tool_output_line,
 };
 
@@ -195,7 +195,25 @@ pub(crate) fn import_codex_session_path_fast(
     caches: &mut ProviderImportCaches,
 ) -> Result<()> {
     ensure_regular_provider_transcript_file(path)?;
-    if !codex_session_file_has_real_conversation(path)? {
+    let conversation_scan = codex_session_file_conversation_scan(path)?;
+    if !conversation_scan.has_real_conversation
+        && !conversation_scan.has_malformed_header
+        && !conversation_scan.has_malformed_relevant_line
+    {
+        if conversation_scan.oversized_required_header {
+            summary.skipped += 1;
+            summary.skipped_sessions += 1;
+            return Ok(());
+        }
+        if conversation_scan.oversized_events > 0 {
+            summary.skipped = summary
+                .skipped
+                .saturating_add(conversation_scan.oversized_events);
+            summary.skipped_events = summary
+                .skipped_events
+                .saturating_add(conversation_scan.oversized_events);
+            return Ok(());
+        }
         summary.failed += 1;
         summary.failures.push(ProviderImportFailure {
             line: 0,
@@ -236,6 +254,10 @@ pub(crate) fn import_codex_session_path_fast(
             ProviderJsonlLineRead::Oversized { .. } => {
                 line_number += 1;
                 summary.skipped += 1;
+                if header.is_none() {
+                    summary.skipped_sessions += 1;
+                    return Ok(());
+                }
                 summary.skipped_events += 1;
                 continue;
             }

--- a/crates/ctx-history-capture/src/provider/codex/session.rs
+++ b/crates/ctx-history-capture/src/provider/codex/session.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 use crate::CodexSessionJsonlAdapter;
 
 use crate::common::io::{
-    collect_jsonl_paths, ensure_regular_provider_transcript_file, read_provider_jsonl_line,
+    collect_jsonl_paths, ensure_regular_provider_transcript_file,
     read_provider_jsonl_line_or_skip_oversized, ProviderJsonlLineRead,
 };
 use crate::provider::importer::{
@@ -58,6 +58,7 @@ impl ProviderCaptureAdapter for CodexSessionJsonlAdapter {
         let mut header = None;
         let mut call_contexts: BTreeMap<String, CodexToolCallContext> = BTreeMap::new();
         let mut has_real_message_content = false;
+        let mut skipped_oversized_events = 0usize;
         let raw_source_path = context
             .source_path
             .as_ref()
@@ -74,6 +75,11 @@ impl ProviderCaptureAdapter for CodexSessionJsonlAdapter {
                 ProviderJsonlLineRead::Oversized { .. } => {
                     line_number += 1;
                     result.summary.skipped += 1;
+                    if header.is_none() {
+                        result.summary.skipped_sessions += 1;
+                        return Ok(result);
+                    }
+                    skipped_oversized_events = skipped_oversized_events.saturating_add(1);
                     result.summary.skipped_events += 1;
                     continue;
                 }
@@ -186,7 +192,7 @@ impl ProviderCaptureAdapter for CodexSessionJsonlAdapter {
         if !has_real_message_content {
             result.captures.clear();
             result.files_touched.clear();
-            if result.summary.failed == 0 {
+            if skipped_oversized_events == 0 && result.summary.failed == 0 {
                 result.summary.failed += 1;
                 result.summary.failures.push(ProviderImportFailure {
                     line: line_number,
@@ -197,6 +203,15 @@ impl ProviderCaptureAdapter for CodexSessionJsonlAdapter {
 
         Ok(result)
     }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct CodexSessionConversationScan {
+    pub(crate) has_real_conversation: bool,
+    pub(crate) has_malformed_header: bool,
+    pub(crate) has_malformed_relevant_line: bool,
+    pub(crate) oversized_required_header: bool,
+    pub(crate) oversized_events: usize,
 }
 
 pub(crate) fn codex_event_has_real_conversation_content(event: &ProviderEventEnvelope) -> bool {
@@ -212,18 +227,47 @@ pub(crate) fn codex_event_has_real_conversation_content(event: &ProviderEventEnv
             .is_some_and(|text| !text.trim().is_empty())
 }
 
-pub(crate) fn codex_session_file_has_real_conversation(path: &Path) -> Result<bool> {
+pub(crate) fn codex_session_file_conversation_scan(
+    path: &Path,
+) -> Result<CodexSessionConversationScan> {
     ensure_regular_provider_transcript_file(path)?;
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
     let mut line = Vec::new();
-    while read_provider_jsonl_line(&mut reader, &mut line)? {
+    let mut scan = CodexSessionConversationScan::default();
+    let mut header_seen = false;
+    loop {
+        match read_provider_jsonl_line_or_skip_oversized(&mut reader, &mut line)? {
+            ProviderJsonlLineRead::Eof => break,
+            ProviderJsonlLineRead::Line { .. } => {}
+            ProviderJsonlLineRead::Oversized { .. } => {
+                if header_seen {
+                    scan.oversized_events = scan.oversized_events.saturating_add(1);
+                    continue;
+                }
+                scan.oversized_required_header = true;
+                return Ok(scan);
+            }
+        }
         if line.iter().all(u8::is_ascii_whitespace) {
             continue;
         }
-        let Ok(value) = serde_json::from_slice::<Value>(&line) else {
-            continue;
+        let value = match serde_json::from_slice::<Value>(&line) {
+            Ok(value) => value,
+            Err(_) if should_parse_codex_session_line(&line) => {
+                scan.has_malformed_relevant_line = true;
+                return Ok(scan);
+            }
+            Err(_) => continue,
         };
+        if value.get("type").and_then(Value::as_str) == Some("session_meta") {
+            if codex_session_header(value.clone()).is_ok() {
+                header_seen = true;
+            } else {
+                scan.has_malformed_header = true;
+                return Ok(scan);
+            }
+        }
         let Some(payload) = value
             .get("payload")
             .filter(|_| value.get("type").and_then(Value::as_str) == Some("response_item"))
@@ -244,10 +288,11 @@ pub(crate) fn codex_session_file_has_real_conversation(path: &Path) -> Result<bo
             .and_then(crate::provider::codex::events::codex_content_text)
             .is_some_and(|text| !text.trim().is_empty())
         {
-            return Ok(true);
+            scan.has_real_conversation = true;
+            return Ok(scan);
         }
     }
-    Ok(false)
+    Ok(scan)
 }
 pub(crate) fn should_parse_codex_session_line(line: &[u8]) -> bool {
     if contains_bytes(line, br#""type":"session_meta""#)
@@ -380,6 +425,9 @@ pub fn import_codex_session_jsonl(
             imported_at: options.imported_at,
         },
     )?;
+    if codex_normalization_is_skipped_only(&normalization) {
+        return Ok(normalization.summary);
+    }
 
     import_normalized_provider_captures(
         store,
@@ -447,12 +495,18 @@ pub fn import_codex_session_jsonl_tail(
         let mut line_number = 0usize;
         let mut position = 0u64;
 
-        if !read_provider_jsonl_line(&mut reader, &mut line)? {
-            return Ok(summary);
+        match read_provider_jsonl_line_or_skip_oversized(&mut reader, &mut line)? {
+            ProviderJsonlLineRead::Eof => return Ok(summary),
+            ProviderJsonlLineRead::Line { bytes } => {
+                line_number += 1;
+                position = position.saturating_add(bytes as u64);
+            }
+            ProviderJsonlLineRead::Oversized { .. } => {
+                summary.skipped += 1;
+                summary.skipped_sessions += 1;
+                return Ok(summary);
+            }
         }
-        line_number += 1;
-        let read = line.len();
-        position = position.saturating_add(read as u64);
         let header_value: Value = serde_json::from_slice(&line)?;
         let header = codex_session_header(header_value)?;
 
@@ -751,6 +805,25 @@ pub(crate) fn import_codex_session_paths_parallel_normalized(
             chunk_captures.extend(normalization.captures);
             chunk_files_touched.extend(normalization.files_touched);
         }
+        if chunk_summary.failed == 0
+            && chunk_summary.skipped > 0
+            && chunk_captures.is_empty()
+            && chunk_files_touched.is_empty()
+        {
+            merged.merge(chunk_summary);
+            completed_files += chunk.len();
+            completed_bytes = completed_bytes.saturating_add(chunk_bytes);
+            report_codex_import_progress(
+                &options,
+                total_files,
+                total_bytes,
+                completed_files,
+                completed_bytes,
+                &merged,
+                false,
+            );
+            continue;
+        }
         let summary = match import_provider_capture_lines(
             store,
             NormalizedProviderImportOptions {
@@ -815,6 +888,14 @@ pub(crate) fn import_codex_session_paths_parallel_normalized(
     );
     Ok(merged)
 }
+
+fn codex_normalization_is_skipped_only(normalization: &ProviderNormalizationResult) -> bool {
+    normalization.summary.failed == 0
+        && normalization.summary.skipped > 0
+        && normalization.captures.is_empty()
+        && normalization.files_touched.is_empty()
+}
+
 pub(crate) fn normalize_codex_session_paths_parallel(
     paths: &[PathBuf],
     options: &CodexSessionImportOptions,

--- a/crates/ctx-history-capture/src/tests/codex.rs
+++ b/crates/ctx-history-capture/src/tests/codex.rs
@@ -732,6 +732,279 @@ fn codex_session_jsonl_fast_import_skips_one_oversized_line() {
 }
 
 #[test]
+fn codex_session_jsonl_skips_oversized_required_header_without_failure() {
+    let temp = tempdir();
+    let path = temp.path().join("oversized-header-codex.jsonl");
+    let mut bytes = oversized_jsonl_line();
+    bytes.extend_from_slice(
+        jsonl_line(json!({
+            "timestamp": "2026-07-03T12:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "should not import without header"}]
+            }
+        }))
+        .as_bytes(),
+    );
+    fs::write(&path, bytes).unwrap();
+
+    let normalized = CodexSessionJsonlAdapter
+        .normalize_path(&path, &ProviderAdapterContext::default())
+        .unwrap();
+    assert_eq!(
+        normalized.summary.failed, 0,
+        "{:?}",
+        normalized.summary.failures
+    );
+    assert_eq!(normalized.summary.skipped, 1);
+    assert_eq!(normalized.summary.skipped_sessions, 1);
+    assert!(normalized.captures.is_empty());
+
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let summary = import_codex_session_jsonl(
+        &path,
+        &mut store,
+        CodexSessionImportOptions {
+            imported_at: "2026-07-03T12:30:00Z".parse().unwrap(),
+            ..CodexSessionImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.skipped, 1);
+    assert_eq!(summary.skipped_sessions, 1);
+    assert_eq!(summary.imported_sessions, 0);
+    assert_eq!(summary.imported_events, 0);
+    assert!(store.list_sessions().unwrap().is_empty());
+}
+
+#[test]
+fn codex_session_jsonl_skips_only_oversized_events_without_fake_session() {
+    let temp = tempdir();
+    let path = temp.path().join("only-oversized-event-codex.jsonl");
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(
+        jsonl_line(json!({
+            "timestamp": "2026-07-03T12:00:00Z",
+            "type": "session_meta",
+            "payload": {
+                "id": "codex-only-oversized-event",
+                "timestamp": "2026-07-03T12:00:00Z",
+                "cwd": "/workspace",
+                "originator": "codex-cli"
+            }
+        }))
+        .as_bytes(),
+    );
+    bytes.extend_from_slice(&oversized_jsonl_line());
+    fs::write(&path, bytes).unwrap();
+
+    let normalized = CodexSessionJsonlAdapter
+        .normalize_path(&path, &ProviderAdapterContext::default())
+        .unwrap();
+    assert_eq!(
+        normalized.summary.failed, 0,
+        "{:?}",
+        normalized.summary.failures
+    );
+    assert_eq!(normalized.summary.skipped, 1);
+    assert_eq!(normalized.summary.skipped_events, 1);
+    assert!(normalized.captures.is_empty());
+
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let summary = import_codex_session_jsonl(
+        &path,
+        &mut store,
+        CodexSessionImportOptions {
+            imported_at: "2026-07-03T12:30:00Z".parse().unwrap(),
+            ..CodexSessionImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.skipped, 1);
+    assert_eq!(summary.skipped_events, 1);
+    assert_eq!(summary.imported_sessions, 0);
+    assert_eq!(summary.imported_events, 0);
+    assert!(store.list_sessions().unwrap().is_empty());
+
+    let mut slow_store = Store::open(temp.path().join("slow-work.sqlite")).unwrap();
+    let slow_summary = import_codex_session_jsonl(
+        &path,
+        &mut slow_store,
+        CodexSessionImportOptions {
+            imported_at: "2026-07-03T12:31:00Z".parse().unwrap(),
+            fast_event_inserts: false,
+            ..CodexSessionImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(slow_summary.failed, 0, "{:?}", slow_summary.failures);
+    assert_eq!(slow_summary.skipped, 1);
+    assert_eq!(slow_summary.skipped_events, 1);
+    assert_eq!(slow_summary.imported_sessions, 0);
+    assert_eq!(slow_summary.imported_events, 0);
+    assert!(slow_store.list_sessions().unwrap().is_empty());
+}
+
+#[test]
+fn codex_session_jsonl_malformed_header_is_not_hidden_by_oversized_line() {
+    let temp = tempdir();
+    let path = temp
+        .path()
+        .join("malformed-header-before-oversized-codex.jsonl");
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(
+        jsonl_line(json!({
+            "timestamp": "2026-07-03T12:00:00Z",
+            "type": "session_meta",
+            "payload": {
+                "timestamp": "2026-07-03T12:00:00Z",
+                "cwd": "/workspace",
+                "originator": "codex-cli"
+            }
+        }))
+        .as_bytes(),
+    );
+    bytes.extend_from_slice(&oversized_jsonl_line());
+    fs::write(&path, bytes).unwrap();
+
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let summary = import_codex_session_jsonl(
+        &path,
+        &mut store,
+        CodexSessionImportOptions {
+            imported_at: "2026-07-03T12:30:00Z".parse().unwrap(),
+            ..CodexSessionImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 1, "{:?}", summary.failures);
+    assert!(summary.failures[0]
+        .error
+        .contains("codex session_meta missing id"));
+    assert_eq!(summary.imported_sessions, 0);
+    assert_eq!(summary.imported_events, 0);
+    assert!(store.list_sessions().unwrap().is_empty());
+}
+
+#[test]
+fn codex_session_jsonl_malformed_relevant_line_is_not_hidden_by_oversized_line() {
+    let temp = tempdir();
+    let path = temp
+        .path()
+        .join("malformed-relevant-before-oversized-codex.jsonl");
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(
+        jsonl_line(json!({
+            "timestamp": "2026-07-03T12:00:00Z",
+            "type": "session_meta",
+            "payload": {
+                "id": "codex-malformed-before-oversized",
+                "timestamp": "2026-07-03T12:00:00Z",
+                "cwd": "/workspace",
+                "originator": "codex-cli"
+            }
+        }))
+        .as_bytes(),
+    );
+    bytes.extend_from_slice(
+        br#"{"timestamp":"2026-07-03T12:00:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":["unterminated"]"#,
+    );
+    bytes.push(b'\n');
+    bytes.extend_from_slice(&oversized_jsonl_line());
+    fs::write(&path, bytes).unwrap();
+
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let summary = import_codex_session_jsonl(
+        &path,
+        &mut store,
+        CodexSessionImportOptions {
+            imported_at: "2026-07-03T12:30:00Z".parse().unwrap(),
+            ..CodexSessionImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 1, "{:?}", summary.failures);
+    assert!(
+        summary.failures[0].error.contains("EOF while parsing")
+            || summary.failures[0].error.contains("expected")
+    );
+    assert_eq!(summary.imported_events, 0);
+    assert!(store.list_sessions().unwrap().is_empty());
+}
+
+#[test]
+fn codex_session_probe_skips_oversized_line_before_first_real_message() {
+    let temp = tempdir();
+    let path = temp.path().join("oversized-before-message-codex.jsonl");
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(
+        jsonl_line(json!({
+            "timestamp": "2026-07-03T12:00:00Z",
+            "type": "session_meta",
+            "payload": {
+                "id": "codex-oversized-before-message",
+                "timestamp": "2026-07-03T12:00:00Z",
+                "cwd": "/workspace",
+                "originator": "codex-cli"
+            }
+        }))
+        .as_bytes(),
+    );
+    bytes.extend_from_slice(&oversized_jsonl_line());
+    bytes.extend_from_slice(
+        jsonl_line(json!({
+            "timestamp": "2026-07-03T12:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "message after oversized probe line"}]
+            }
+        }))
+        .as_bytes(),
+    );
+    fs::write(&path, bytes).unwrap();
+
+    assert!(
+        codex_session_file_conversation_scan(&path)
+            .unwrap()
+            .has_real_conversation
+    );
+
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let summary = import_codex_session_jsonl(
+        &path,
+        &mut store,
+        CodexSessionImportOptions {
+            imported_at: "2026-07-03T12:30:00Z".parse().unwrap(),
+            ..CodexSessionImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.skipped_events, 1);
+    assert_eq!(summary.imported_sessions, 1);
+    assert_eq!(summary.imported_events, 1);
+    assert_eq!(
+        store
+            .search_event_hits("message after oversized probe line", 10)
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
 fn codex_session_jsonl_rejects_malformed_event_timestamp() {
     let temp = tempdir();
     let path = temp.path().join("bad-timestamp-codex.jsonl");
@@ -1041,6 +1314,46 @@ fn codex_session_tail_rejects_malformed_append_atomically() {
         .search_event_hits("tail valid should rollback", 10)
         .unwrap()
         .is_empty());
+}
+
+#[test]
+fn codex_session_tail_skips_oversized_required_header_without_failure() {
+    let temp = tempdir();
+    let path = temp.path().join("tail-oversized-header-codex.jsonl");
+    let mut bytes = oversized_jsonl_line();
+    let tail_start = bytes.len() as u64;
+    bytes.extend_from_slice(
+        jsonl_line(json!({
+            "timestamp": "2026-07-03T12:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "tail should not invent header"}]
+            }
+        }))
+        .as_bytes(),
+    );
+    fs::write(&path, bytes).unwrap();
+
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let summary = import_codex_session_jsonl_tail(
+        &path,
+        tail_start,
+        &mut store,
+        CodexSessionImportOptions {
+            imported_at: "2026-07-03T12:31:00Z".parse().unwrap(),
+            ..CodexSessionImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.skipped, 1);
+    assert_eq!(summary.skipped_sessions, 1);
+    assert_eq!(summary.imported_sessions, 0);
+    assert_eq!(summary.imported_events, 0);
+    assert!(store.list_sessions().unwrap().is_empty());
 }
 
 #[test]

--- a/crates/ctx-history-capture/src/tests/support.rs
+++ b/crates/ctx-history-capture/src/tests/support.rs
@@ -1,7 +1,8 @@
 pub(super) use crate::provider::adapter::ProviderCaptureAdapter;
 pub(super) use crate::provider::codex::events::codex_tool_output_event;
 pub(super) use crate::provider::codex::session::{
-    should_parse_codex_session_line, should_skip_codex_tool_output_line,
+    codex_session_file_conversation_scan, should_parse_codex_session_line,
+    should_skip_codex_tool_output_line,
 };
 pub(super) use crate::provider::custom_history_jsonl::{
     custom_history_internal_session_id, custom_history_jsonl_v1_cursor_stream,


### PR DESCRIPTION
## Summary
- treats oversized Codex JSONL records before a readable session header as skipped sessions instead of hard failures
- treats valid-header sessions with only oversized event records as skipped-only imports without fabricating sessions
- keeps malformed headers and malformed parse-relevant JSON as failures even when oversized records are also present
- keeps internal spool JSONL strict; provider imports remain skip-aware

## Verification
- cargo fmt --check
- git diff --check
- cargo test -p ctx-history-capture (219 passed, 1 ignored; plus 5 cursor_native tests)
- cargo test -p ctx --test native_providers (31 passed)
- bash scripts/check-docs.sh
- python3 scripts/check-provider-support-matrix.py

## Review
- local YAGNI/policy review: no blocking findings
- local correctness review: issues addressed; final focused re-review reported no findings
