### PR TITLE
Make usage analytics opt-in with install-time disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ ctx is written in Rust and stores a local SQLite index, so searches are fast, sc
 
 The index is local and private by default. Transcript text is preserved rather than hiding local paths or secret-shaped strings, so review copied output before sharing it outside the machine.
 
+## Private by default
+
+Your agent history is sensitive, and ctx treats it that way:
+
+- Indexing, search, and SQL run entirely on your machine. Transcript content, search queries, and file paths never leave it.
+- Anonymous usage analytics are **opt-in and off by default**. If you want to help improve ctx, run `ctx analytics enable` — this shares coarse product metadata only (command name, success state, bucketed counts), never session text, queries, or paths. Opt back out anytime with `ctx analytics disable`.
+- Installer-managed binaries check for signed upgrades once a day. Disable with `ctx upgrade disable`.
+
+The full storage and privacy contract, including the exact analytics payload when enabled, is documented in [docs/storage.md](docs/storage.md).
+
 ```bash
 # Index all of your existing local agent sessions
 ctx setup

--- a/crates/ctx-cli/src/config.rs
+++ b/crates/ctx-cli/src/config.rs
@@ -34,7 +34,9 @@ impl Default for AppConfig {
     fn default() -> Self {
         Self {
             analytics: AnalyticsConfig {
-                enabled: true,
+                // Privacy default: analytics are opt-in. Enable with
+                // `ctx analytics enable` or `[analytics] enabled = true`.
+                enabled: false,
                 endpoint: "https://cli.ctx.rs/functions/v1/analytics".to_owned(),
             },
             upgrade: UpgradeConfig {
@@ -304,6 +306,64 @@ fn env_flag(key: &str) -> bool {
     })
 }
 
+pub(crate) fn set_analytics_enabled(data_root: &Path, enabled: bool) -> Result<()> {
+    fs::create_dir_all(data_root)?;
+    let config_path = data_root.join(CONFIG_FILE);
+    let existing = fs::read_to_string(&config_path).unwrap_or_default();
+    let next = set_toml_section_value(
+        &existing,
+        "analytics",
+        "enabled",
+        if enabled { "true" } else { "false" },
+    );
+    fs::write(&config_path, next).with_context(|| format!("write {}", config_path.display()))?;
+    println!(
+        "ctx analytics {}",
+        if enabled { "enabled" } else { "disabled" }
+    );
+    Ok(())
+}
+
+pub(crate) fn set_toml_section_value(input: &str, section: &str, key: &str, value: &str) -> String {
+    let mut lines = Vec::new();
+    let mut in_section = false;
+    let mut saw_section = false;
+    let mut wrote_key = false;
+    for raw in input.lines() {
+        let trimmed = raw.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            if in_section && !wrote_key {
+                lines.push(format!("{key} = {value}"));
+                wrote_key = true;
+            }
+            in_section = trimmed == format!("[{section}]");
+            saw_section |= in_section;
+            lines.push(raw.to_owned());
+            continue;
+        }
+        if in_section
+            && (trimmed.starts_with(&format!("{key} ")) || trimmed.starts_with(&format!("{key}=")))
+        {
+            lines.push(format!("{key} = {value}"));
+            wrote_key = true;
+        } else {
+            lines.push(raw.to_owned());
+        }
+    }
+    if saw_section {
+        if in_section && !wrote_key {
+            lines.push(format!("{key} = {value}"));
+        }
+    } else {
+        if !lines.is_empty() && lines.last().is_some_and(|line| !line.is_empty()) {
+            lines.push(String::new());
+        }
+        lines.push(format!("[{section}]"));
+        lines.push(format!("{key} = {value}"));
+    }
+    lines.join("\n") + "\n"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -313,7 +373,7 @@ mod tests {
         let values = parse_toml_subset(
             r#"
 [analytics]
-enabled = false
+enabled = true
 
 [upgrade]
 auto = "off"
@@ -327,10 +387,10 @@ interval_seconds = 60
             config.analytics.endpoint,
             "https://cli.ctx.rs/functions/v1/analytics"
         );
-        assert!(config.analytics.enabled);
+        assert!(!config.analytics.enabled);
         assert_eq!(config.upgrade.auto, "apply");
         config.apply_values(&values).unwrap();
-        assert!(!config.analytics.enabled);
+        assert!(config.analytics.enabled);
         assert_eq!(config.upgrade.auto, "off");
         assert_eq!(config.upgrade.channel, "beta");
         assert_eq!(config.upgrade.interval, Duration::from_secs(60));
@@ -342,10 +402,23 @@ interval_seconds = 60
 
         let config = AppConfig::load(temp.path()).unwrap();
 
-        assert!(config.analytics.enabled);
+        assert!(!config.analytics.enabled, "analytics must be opt-in");
         assert_eq!(config.upgrade.auto, "apply");
         assert_eq!(config.upgrade.channel, "stable");
         assert_eq!(config.upgrade.interval, Duration::from_secs(24 * 60 * 60));
+    }
+
+    #[test]
+    fn set_analytics_enabled_writes_and_round_trips() {
+        let temp = tempfile::tempdir().unwrap();
+
+        set_analytics_enabled(temp.path(), true).unwrap();
+        let config = AppConfig::load(temp.path()).unwrap();
+        assert!(config.analytics.enabled);
+
+        set_analytics_enabled(temp.path(), false).unwrap();
+        let config = AppConfig::load(temp.path()).unwrap();
+        assert!(!config.analytics.enabled);
     }
 
     #[test]
@@ -355,7 +428,7 @@ interval_seconds = 60
             temp.path().join(CONFIG_FILE),
             r#"
 [analytics]
-enabled = false
+enabled = true
 endpoint = "file:///tmp/ctx-analytics.jsonl"
 
 [upgrade]
@@ -369,7 +442,7 @@ functions_base = "https://example.test/functions/v1"
 
         let config = AppConfig::load(temp.path()).unwrap();
 
-        assert!(!config.analytics.enabled);
+        assert!(config.analytics.enabled);
         assert_eq!(config.analytics.endpoint, "file:///tmp/ctx-analytics.jsonl");
         assert_eq!(config.upgrade.auto, "off");
         assert_eq!(config.upgrade.channel, "beta");

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -114,8 +114,26 @@ enum CommandRoot {
     Mcp(mcp::McpArgs),
     #[command(about = "Check or apply signed ctx CLI upgrades")]
     Upgrade(upgrade::UpgradeArgs),
+    #[command(about = "Show, enable, or disable anonymous usage analytics (opt-in)")]
+    Analytics(AnalyticsSettingsArgs),
     #[command(about = "Check local ctx health")]
     Doctor(DoctorArgs),
+}
+
+#[derive(Debug, Args)]
+struct AnalyticsSettingsArgs {
+    #[command(subcommand)]
+    command: Option<AnalyticsSettingsCommand>,
+}
+
+#[derive(Debug, Subcommand)]
+enum AnalyticsSettingsCommand {
+    #[command(about = "Opt in to sending anonymous usage analytics")]
+    Enable,
+    #[command(about = "Opt out of sending anonymous usage analytics")]
+    Disable,
+    #[command(about = "Show whether anonymous usage analytics are enabled")]
+    Status,
 }
 
 #[derive(Debug, Args)]
@@ -455,12 +473,16 @@ impl CommandRoot {
             Self::Integrations(_) => "integrations",
             Self::Mcp(_) => "mcp",
             Self::Upgrade(_) => "upgrade",
+            Self::Analytics(_) => "analytics",
             Self::Doctor(_) => "doctor",
         }
     }
 
     fn sends_analytics(&self) -> bool {
-        !matches!(self, Self::Status(_) | Self::Sql(_) | Self::Mcp(_))
+        !matches!(
+            self,
+            Self::Status(_) | Self::Sql(_) | Self::Mcp(_) | Self::Analytics(_)
+        )
     }
 
     fn json_output(&self) -> bool {
@@ -477,6 +499,7 @@ impl CommandRoot {
             Self::Integrations(args) => args.json_output(),
             Self::Mcp(_) => false,
             Self::Upgrade(args) => args.json_output(),
+            Self::Analytics(_) => false,
             Self::Doctor(args) => args.json,
         }
     }
@@ -484,7 +507,12 @@ impl CommandRoot {
     fn allows_background_upgrade(&self) -> bool {
         !matches!(
             self,
-            Self::Status(_) | Self::Docs(_) | Self::Mcp(_) | Self::Sql(_) | Self::Upgrade(_)
+            Self::Status(_)
+                | Self::Docs(_)
+                | Self::Mcp(_)
+                | Self::Sql(_)
+                | Self::Upgrade(_)
+                | Self::Analytics(_)
         )
     }
 }
@@ -560,6 +588,7 @@ fn main() -> Result<()> {
             config.clone(),
             &mut analytics_properties,
         ),
+        CommandRoot::Analytics(args) => run_analytics_settings(args, &data_root, &config),
         CommandRoot::Doctor(args) => run_doctor(args, data_root.clone(), &mut analytics_properties),
     };
     if is_setup {
@@ -594,6 +623,28 @@ fn main() -> Result<()> {
     result
 }
 
+fn run_analytics_settings(
+    args: AnalyticsSettingsArgs,
+    data_root: &PathBuf,
+    config: &AppConfig,
+) -> Result<()> {
+    match args.command {
+        Some(AnalyticsSettingsCommand::Enable) => config::set_analytics_enabled(data_root, true),
+        Some(AnalyticsSettingsCommand::Disable) => config::set_analytics_enabled(data_root, false),
+        Some(AnalyticsSettingsCommand::Status) | None => {
+            println!(
+                "ctx analytics {}",
+                if config.analytics.enabled {
+                    "enabled"
+                } else {
+                    "disabled (default; opt in with `ctx analytics enable`)"
+                }
+            );
+            Ok(())
+        }
+    }
+}
+
 fn command_analytics_properties(command: &CommandRoot) -> AnalyticsProperties {
     let mut properties = analytics::empty_properties();
     match command {
@@ -608,6 +659,7 @@ fn command_analytics_properties(command: &CommandRoot) -> AnalyticsProperties {
         CommandRoot::Status(_)
         | CommandRoot::Sources(_)
         | CommandRoot::Sql(_)
+        | CommandRoot::Analytics(_)
         | CommandRoot::Doctor(_) => {}
         CommandRoot::Import(args) => {
             analytics::insert_bool(&mut properties, "resume", args.resume);

--- a/crates/ctx-cli/src/upgrade/state.rs
+++ b/crates/ctx-cli/src/upgrade/state.rs
@@ -259,48 +259,9 @@ pub(super) fn set_auto_mode(data_root: &Path, mode: &str) -> Result<()> {
     fs::create_dir_all(data_root)?;
     let config_path = data_root.join(crate::config::CONFIG_FILE);
     let existing = fs::read_to_string(&config_path).unwrap_or_default();
-    let next = set_toml_section_value(&existing, "upgrade", "auto", &format!("\"{mode}\""));
+    let next =
+        crate::config::set_toml_section_value(&existing, "upgrade", "auto", &format!("\"{mode}\""));
     fs::write(&config_path, next).with_context(|| format!("write {}", config_path.display()))?;
     println!("ctx background auto-upgrade {mode}");
     Ok(())
-}
-
-fn set_toml_section_value(input: &str, section: &str, key: &str, value: &str) -> String {
-    let mut lines = Vec::new();
-    let mut in_section = false;
-    let mut saw_section = false;
-    let mut wrote_key = false;
-    for raw in input.lines() {
-        let trimmed = raw.trim();
-        if trimmed.starts_with('[') && trimmed.ends_with(']') {
-            if in_section && !wrote_key {
-                lines.push(format!("{key} = {value}"));
-                wrote_key = true;
-            }
-            in_section = trimmed == format!("[{section}]");
-            saw_section |= in_section;
-            lines.push(raw.to_owned());
-            continue;
-        }
-        if in_section
-            && (trimmed.starts_with(&format!("{key} ")) || trimmed.starts_with(&format!("{key}=")))
-        {
-            lines.push(format!("{key} = {value}"));
-            wrote_key = true;
-        } else {
-            lines.push(raw.to_owned());
-        }
-    }
-    if saw_section {
-        if in_section && !wrote_key {
-            lines.push(format!("{key} = {value}"));
-        }
-    } else {
-        if !lines.is_empty() && lines.last().is_some_and(|line| !line.is_empty()) {
-            lines.push(String::new());
-        }
-        lines.push(format!("[{section}]"));
-        lines.push(format!("{key} = {value}"));
-    }
-    lines.join("\n") + "\n"
 }

--- a/crates/ctx-cli/tests/analytics.rs
+++ b/crates/ctx-cli/tests/analytics.rs
@@ -18,6 +18,7 @@ fn analytics_sends_coarse_cli_metadata_when_enabled() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .assert()
         .success();
@@ -94,6 +95,7 @@ fn status_does_not_emit_analytics_or_create_identities_when_enabled() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .env("CTX_UPGRADE_OFF", "1")
         .assert()
@@ -131,6 +133,7 @@ fn analytics_device_id_persists_across_data_roots() {
             .env("XDG_STATE_HOME", &state)
             .env("LOCALAPPDATA", &state)
             .env_remove("CTX_ANALYTICS_OFF")
+            .env("CTX_ANALYTICS_ENABLED", "true")
             .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
             .assert()
             .success();
@@ -197,6 +200,7 @@ fn analytics_payloads_omit_sensitive_command_data() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .assert()
         .success();
@@ -208,6 +212,7 @@ fn analytics_payloads_omit_sensitive_command_data() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .assert()
         .success();
@@ -219,6 +224,7 @@ fn analytics_payloads_omit_sensitive_command_data() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .assert()
         .success();
@@ -230,6 +236,7 @@ fn analytics_payloads_omit_sensitive_command_data() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .assert()
         .failure();
@@ -327,6 +334,7 @@ fn search_analytics_reports_when_search_creates_empty_store() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .env("CTX_UPGRADE_OFF", "1")
         .assert()
@@ -380,6 +388,7 @@ fn search_analytics_reports_existing_indexed_content() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .env("CTX_UPGRADE_OFF", "1")
         .assert()
@@ -416,6 +425,7 @@ fn upgrade_analytics_reports_manual_dry_run_outcome() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .env("CTX_UPGRADE_OFF", "1");
     fake_release_env(&mut command, &release).assert().success();
@@ -460,6 +470,7 @@ fn upgrade_analytics_reports_manual_apply_success() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .env("CTX_UPGRADE_OFF", "1");
     fake_release_env(&mut command, &release).assert().success();
@@ -515,6 +526,7 @@ fn upgrade_analytics_reports_manual_failure_kind() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .env("CTX_UPGRADE_OFF", "1");
     fake_release_env(&mut command, &release).assert().failure();
@@ -552,6 +564,7 @@ fn upgrade_analytics_reports_background_auto_upgrade_outcome() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path));
     fake_release_env(&mut command, &release).assert().success();
 
@@ -605,6 +618,7 @@ fn upgrade_analytics_reports_background_failure_kind() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path));
     fake_release_env(&mut command, &release).assert().failure();
 
@@ -652,6 +666,7 @@ fn upgrade_analytics_reports_background_locked_skip_and_backs_off() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path));
     fake_release_env(&mut command, &release).assert().success();
 
@@ -692,6 +707,7 @@ fn upgrade_analytics_reports_background_skipped_in_ci() {
         .env("LOCALAPPDATA", &state)
         .env("CI", "1")
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .assert()
         .success();
@@ -738,6 +754,7 @@ fn hosted_install_marker_enriches_analytics_event_without_properties_leak() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .env("CTX_UPGRADE_OFF", "1")
         .assert()
@@ -780,6 +797,7 @@ fn malformed_hosted_install_marker_is_ignored() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .env("CTX_UPGRADE_OFF", "1")
         .assert()
@@ -813,6 +831,7 @@ fn setup_analytics_emits_start_and_completion_events() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .env("CTX_UPGRADE_OFF", "1")
         .assert()
@@ -870,6 +889,7 @@ fn setup_analytics_emits_failure_completion_event() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .env("CTX_UPGRADE_OFF", "1")
         .assert()
@@ -944,6 +964,7 @@ fn setup_analytics_dry_run_suppresses_start_completion_and_identities() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_DRY_RUN", "1")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .env("CTX_UPGRADE_OFF", "1")
@@ -980,6 +1001,7 @@ fn analytics_config_opt_out_suppresses_delivery() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .assert()
         .success();
@@ -1037,6 +1059,7 @@ fn analytics_refuses_device_identity_under_data_root() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .assert()
         .success();
@@ -1049,4 +1072,45 @@ fn analytics_refuses_device_identity_under_data_root() {
         !state.join("ctx").join("device.json").exists(),
         "device identity must not be created under CTX_DATA_ROOT"
     );
+}
+
+#[test]
+fn analytics_disabled_by_default_without_opt_in() {
+    let temp = tempdir();
+    let state = temp.path().join("state");
+    let events_path = temp.path().join("analytics.jsonl");
+
+    ctx(&temp)
+        .arg("doctor")
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+        .assert()
+        .success();
+
+    assert!(
+        !events_path.exists(),
+        "analytics must be opt-in: no events may be sent without explicit enablement"
+    );
+    assert!(
+        !state.join("ctx").join("device.json").exists(),
+        "no device identity may be created without an analytics opt-in"
+    );
+}
+
+#[test]
+fn analytics_settings_command_writes_config_opt_in_and_out() {
+    let temp = tempdir();
+
+    ctx(&temp).args(["analytics", "enable"]).assert().success();
+    let config = fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(config.contains("[analytics]"), "{config}");
+    assert!(config.contains("enabled = true"), "{config}");
+
+    ctx(&temp).args(["analytics", "disable"]).assert().success();
+    let config = fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(config.contains("enabled = false"), "{config}");
+
+    ctx(&temp).args(["analytics", "status"]).assert().success();
 }

--- a/crates/ctx-cli/tests/setup_sources_import.rs
+++ b/crates/ctx-cli/tests/setup_sources_import.rs
@@ -78,6 +78,7 @@ fn malformed_present_config_fails_before_setup_and_analytics_side_effects() {
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
         .assert()
         .failure()

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -533,6 +533,21 @@ the installed binary. On Windows, replacement may be scheduled by a helper that
 finishes after the running `ctx.exe` exits; JSON reports `status: "scheduled"`
 and `applied: false` until replacement completes.
 
+## Analytics
+
+```bash
+ctx analytics status
+ctx analytics enable
+ctx analytics disable
+```
+
+Anonymous usage analytics are opt-in and disabled by default. `enable` writes
+`[analytics] enabled = true` to `config.toml` under the configured data root;
+`disable` writes `enabled = false`; `status` (also the bare `ctx analytics`)
+reports the current state. The `ctx analytics` command itself never emits an
+analytics event. See the storage documentation for exactly what enabled
+analytics do and do not send.
+
 ## Progress Output
 
 `setup` and `import` accept `--progress auto|plain|json|none`. `auto` writes

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -262,14 +262,16 @@ process-level opt-outs such as `CTX_UPGRADE_OFF=1` or
 transcript text, search queries, result snippets, source paths, repository
 names, or command output.
 
-First-party analytics are default-on and may create `install.json` plus a
-separate device identity file in OS user state, then send coarse product
-metadata. They do not send session text, prompts, transcripts, search queries,
-result snippets, source paths, repository or branch names, native session IDs,
-command text, command output, usernames, hostnames, raw IP addresses, or
-hardware-derived machine fingerprints.
+First-party analytics are opt-in and disabled by default: a fresh install sends
+no analytics events. When explicitly enabled with `ctx analytics enable` (or
+`[analytics] enabled = true` in `config.toml`), ctx may create `install.json`
+plus a separate device identity file in OS user state, then send coarse product
+metadata. Enabled analytics do not send session text, prompts, transcripts,
+search queries, result snippets, source paths, repository or branch names,
+native session IDs, command text, command output, usernames, hostnames, raw IP
+addresses, or hardware-derived machine fingerprints.
 
-Analytics may include:
+When enabled, analytics may include:
 
 - generated random install and device identifiers that are hashed server-side;
 - ctx version, OS, architecture, command name, success state, and duration
@@ -290,13 +292,17 @@ the ctx data root in OS user state, such as `$XDG_STATE_HOME/ctx/device.json` or
 
 `ctx sql` and MCP do not send first-party analytics events.
 
-To disable analytics, add:
+To opt in and help improve ctx, run `ctx analytics enable`, or add:
 
 ```toml
 [analytics]
-enabled = false
+enabled = true
 ```
 
-Equivalent environment opt-outs are `CTX_ANALYTICS_OFF=1`,
-`CTX_DISABLE_ANALYTICS=1`, or `CTX_ANALYTICS_ENABLED=false`. Use an opt-out when
-a strict local-only no-network mode is required.
+To opt back out, run `ctx analytics disable` (equivalent to
+`[analytics] enabled = false`), and `ctx analytics status` reports the current
+state. The environment opt-outs `CTX_ANALYTICS_OFF=1`,
+`CTX_DISABLE_ANALYTICS=1`, and `CTX_ANALYTICS_ENABLED=false` force analytics
+off for a single process regardless of config. For a strict local-only
+no-network mode, leave analytics disabled and also disable background
+auto-upgrade with `ctx upgrade disable`.

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -57,9 +57,12 @@ public_docs=(
   plugins/ctx-agent-history-search/commands/ctx-history.md
 )
 
+# Analytics disclosure is allowed in the README (user-facing consent copy),
+# docs/storage.md (the full contract), and docs/cli-reference.md (the
+# `ctx analytics` command); all other public copy must stay analytics-free.
 analytics_scope=()
 for path in "${public_docs[@]}"; do
-  if [[ "${path}" != "docs/storage.md" ]]; then
+  if [[ "${path}" != "docs/storage.md" && "${path}" != "README.md" && "${path}" != "docs/cli-reference.md" ]]; then
     analytics_scope+=("${path}")
   fi
 done
@@ -89,7 +92,7 @@ if scan_docs "${private_path_pattern}" "${public_docs[@]}"; then
 fi
 
 if scan_docs 'analytics|telemetry' "${analytics_scope[@]}"; then
-  printf 'public analytics copy must stay limited to docs/storage.md\n' >&2
+  printf 'public analytics copy must stay limited to README.md, docs/storage.md, and docs/cli-reference.md\n' >&2
   exit 1
 fi
 

--- a/scripts/dev-install-from-metadata.sh
+++ b/scripts/dev-install-from-metadata.sh
@@ -35,8 +35,17 @@ Options:
   --all-skill-agents     Install the skill into all supported agent skill dirs.
   --no-man               Do not install generated man pages.
   --man-dir DIR          Man page directory. Defaults to $HOME/.local/share/man/man1.
+  --enable-analytics     Opt in to anonymous usage analytics (coarse product
+                         metadata only; never transcripts, queries, or paths).
+  --no-analytics         Skip the interactive analytics question; leave
+                         analytics disabled (the default).
   --dry-run              Validate metadata and print the planned install.
   -h, --help             Show this help.
+
+Privacy: indexing and search are fully local. Anonymous usage analytics are
+opt-in and disabled by default; an interactive install asks once, and
+non-interactive installs leave them off unless --enable-analytics or
+CTX_INSTALL_ENABLE_ANALYTICS=1 is passed. Details: docs/storage.md.
 
 Local launch pattern:
   bash scripts/dev-install-from-metadata.sh --metadata ./ctx-release-metadata.env
@@ -410,6 +419,7 @@ explicit_skill_request=0
 all_skill_agents=0
 skill_agents=()
 install_man=1
+enable_analytics=""
 
 while (($# > 0)); do
   case "$1" in
@@ -451,6 +461,12 @@ while (($# > 0)); do
     --man-dir)
       shift
       man_dir="${1:-}"
+      ;;
+    --enable-analytics)
+      enable_analytics=1
+      ;;
+    --no-analytics)
+      enable_analytics=0
       ;;
     --dry-run)
       dry_run=1
@@ -528,6 +544,12 @@ if [[ "${CTX_INSTALL_NO_SETUP:-0}" == "1" ]]; then
   run_setup=0
 fi
 
+if [[ "${CTX_INSTALL_ENABLE_ANALYTICS:-}" == "1" ]]; then
+  enable_analytics=1
+elif [[ "${CTX_INSTALL_ENABLE_ANALYTICS:-}" == "0" ]]; then
+  enable_analytics=0
+fi
+
 if [[ "${CTX_INSTALL_ALL_SKILL_AGENTS:-0}" == "1" ]]; then
   all_skill_agents=1
   explicit_skill_request=1
@@ -561,6 +583,29 @@ fi
 
 if ((! run_setup && ! explicit_skill_request)); then
   run_skill=0
+fi
+
+# Disclose before doing anything: what stays local, what (optionally) does not.
+printf 'Privacy:\n'
+printf '  history index: built and searched locally; transcript content never leaves this machine\n'
+printf '  usage analytics: opt-in, disabled by default (coarse product metadata only when enabled)\n'
+printf '  auto-upgrade: managed installs check for signed releases daily (ctx upgrade disable to stop)\n'
+
+# Ask once when interactive and undecided; default and non-interactive answer is No.
+if [[ -z "${enable_analytics}" ]] && ((! dry_run)) && [[ -r /dev/tty && -w /dev/tty ]]; then
+  printf 'Share anonymous usage analytics to help improve ctx? [y/N] ' >/dev/tty
+  if IFS= read -r analytics_answer </dev/tty; then
+    case "${analytics_answer}" in
+      [Yy]|[Yy][Ee][Ss])
+        enable_analytics=1
+        ;;
+      *)
+        enable_analytics=0
+        ;;
+    esac
+  else
+    enable_analytics=0
+  fi
 fi
 
 if ((dry_run)); then
@@ -611,6 +656,14 @@ if ((install_man)); then
   fi
 fi
 printf '\nInstalled ctx binary.\n'
+
+if [[ "${enable_analytics}" == "1" ]]; then
+  if ! "${install_path}" analytics enable; then
+    printf 'warning: could not record the analytics opt-in; run %s analytics enable to retry\n' "${install_path}" >&2
+  fi
+else
+  printf 'Anonymous usage analytics: disabled (opt in later with %s analytics enable)\n' "${install_path}"
+fi
 
 if ((run_skill)); then
   skill_args=(integrations install skills)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -9,6 +9,7 @@ param(
     [string[]]$SkillAgent = @(),
     [switch]$AllSkillAgents,
     [string]$SetupProgress = "",
+    [switch]$EnableAnalytics,
     [switch]$DryRun
 )
 
@@ -250,6 +251,13 @@ try {
         $runSkill = $false
     }
     $modifyPath = -not $NoModifyPath -and $env:CTX_INSTALL_NO_MODIFY_PATH -ne "1"
+    $optInAnalytics = $EnableAnalytics -or $env:CTX_INSTALL_ENABLE_ANALYTICS -eq "1"
+
+    # Disclose before doing anything: what stays local, what (optionally) does not.
+    Write-Host "Privacy:"
+    Write-Host "  history index: built and searched locally; transcript content never leaves this machine"
+    Write-Host "  usage analytics: opt-in, disabled by default (coarse product metadata only when enabled)"
+    Write-Host "  auto-upgrade: managed installs check for signed releases daily (ctx upgrade disable to stop)"
 
     if ($DryRun) {
         Write-Host "Dry run: would install ctx $version ($Platform)"
@@ -310,6 +318,15 @@ try {
     [System.IO.File]::WriteAllText($markerPath, $markerJson + [Environment]::NewLine, $utf8NoBom)
     Write-Host ""
     Write-Host "Installed ctx binary."
+
+    if ($optInAnalytics) {
+        & $installPath analytics enable
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "could not record the analytics opt-in; run $installPath analytics enable to retry"
+        }
+    } else {
+        Write-Host "Anonymous usage analytics: disabled (opt in later with $installPath analytics enable)"
+    }
 
     if ($runSkill) {
         $skillArgs = @("integrations", "install", "skills")


### PR DESCRIPTION
## Make usage analytics opt-in and disclose data collection up front

ctx indexes users' full agent conversation history — some of the most sensitive data on a developer's machine. The engineering already respects that (local-only indexing, no transcript egress, honest `docs/storage.md`), but the consent model doesn't match: analytics are default-on, the only disclosure lives in `docs/storage.md`, and `scripts/check-docs.sh` actively fails CI if the word "analytics" appears in the README. A user who runs `curl -fsSL https://ctx.rs/install | sh` starts transmitting install/device identifiers before they've had any chance to learn the behavior exists.

This PR aligns the consent model with the engineering:

### Changes

- **Analytics are now opt-in (default off).** `AppConfig::default()` sets `analytics.enabled = false`. A fresh install sends no events and creates no device identity.
- **New `ctx analytics enable | disable | status` subcommand**, mirroring `ctx upgrade enable/disable`. `enable` writes `[analytics] enabled = true` to `config.toml`; the command itself never emits an analytics event.
- **Installers disclose before acting and make opting in easy.** `scripts/install.sh` and `scripts/install.ps1` print a three-line `Privacy:` block (local index, opt-in analytics, daily auto-upgrade) before doing anything. Interactive `install.sh` runs ask once — `Share anonymous usage analytics to help improve ctx? [y/N]` via `/dev/tty`, defaulting to No; non-interactive runs stay off unless `--enable-analytics` / `CTX_INSTALL_ENABLE_ANALYTICS=1` (PowerShell: `-EnableAnalytics`).
- **README gains a "Private by default" section** stating the contract in plain language, with a pointer to `docs/storage.md` for the full payload details.
- **`docs/storage.md` and `docs/cli-reference.md` updated** from "default-on, here's the opt-out" to "off by default, here's how to opt in."
- **`scripts/check-docs.sh`** now permits analytics copy in `README.md` and `docs/cli-reference.md` (still banned everywhere else).
- **Tests:** all analytics integration tests now opt in explicitly (`CTX_ANALYTICS_ENABLED=true`); two new regression tests pin the contract — a default invocation sends nothing and creates no device identity, and the settings command round-trips `config.toml`.

### Not covered here (needs hosted-side changes)

The production hosted installer at `https://ctx.rs/install` is not in this repository. It currently POSTs stage-by-stage install diagnostics tagged with a per-download `install_attempt_id` before the user has seen any disclosure. Suggest porting the same pattern there: print the `Privacy:` block first, make the stage diagnostics opt-in (or at minimum gate them on the same prompt), and forward the analytics answer to the CLI.

### Why default-off matters for this tool in particular

For a general dev tool, default-on coarse analytics is a defensible norm. ctx is different: its entire value proposition is "point me at every secret-laden transcript on your machine, trust me that nothing leaves." The docs make exactly that promise ("local and private by default"). Default-on identifier transmission — however coarse — undercuts the trust the product depends on, and the users most likely to adopt ctx are precisely the ones most likely to notice. Opt-in costs some analytics volume, but an explicit install-time prompt should recover much of it while making every remaining data point consensual.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
