### PR TITLE
Add multilingual scriptgram search

### DIFF
--- a/crates/ctx-history-search/src/tests/fast_path.rs
+++ b/crates/ctx-history-search/src/tests/fast_path.rs
@@ -160,6 +160,96 @@ fn large_agent_history_search_returns_event_hits() {
 }
 
 #[test]
+fn large_event_fast_search_recalls_cjk_preview_term() {
+    let (_temp, store) = test_store();
+    let record = HistoryRecord::new(
+        "Large multilingual provider history",
+        "single imported agent-history record",
+        Vec::new(),
+        "agent_history",
+        Some("/workspace/ctx".into()),
+    );
+    store.insert_record(&record).unwrap();
+
+    let session = Session {
+        id: Uuid::parse_str("018f45d0-0000-7000-8000-000000000611").unwrap(),
+        history_record_id: Some(record.id),
+        parent_session_id: None,
+        root_session_id: None,
+        capture_source_id: None,
+        provider: CaptureProvider::Codex,
+        external_session_id: Some("large-multilingual-history-session".into()),
+        external_agent_id: None,
+        agent_type: AgentType::Primary,
+        role_hint: Some("primary".into()),
+        is_primary: true,
+        status: SessionStatus::Imported,
+        transcript_blob_id: None,
+        started_at: fixed_time(),
+        ended_at: None,
+        timestamps: timestamps(),
+        sync: sync_metadata(),
+    };
+    store.upsert_session(&session).unwrap();
+
+    let target_event_id = Uuid::parse_str("018f45d0-0000-7000-8000-0000000006fe").unwrap();
+    for index in 0..=(LARGE_EVENT_CORPUS_THRESHOLD as u64) {
+        let event_id = if index == LARGE_EVENT_CORPUS_THRESHOLD as u64 {
+            target_event_id
+        } else {
+            Uuid::parse_str(&format!("018f45d0-0000-7000-8000-0000003{index:05x}")).unwrap()
+        };
+        let text = if event_id == target_event_id {
+            "OAuth認証の検索状態をfast path previewから見つける"
+        } else {
+            "ordinary large multilingual history event"
+        };
+        store
+            .upsert_event(&Event {
+                id: event_id,
+                seq: 50_000 + index,
+                history_record_id: Some(record.id),
+                session_id: Some(session.id),
+                run_id: None,
+                event_type: EventType::Message,
+                role: Some(EventRole::Assistant),
+                occurred_at: fixed_time() + chrono::Duration::milliseconds(index as i64),
+                capture_source_id: None,
+                payload: serde_json::json!({
+                    "cursor": format!("line:{index}"),
+                    "body": { "text": text }
+                }),
+                payload_blob_id: None,
+                dedupe_key: Some(format!("large-multilingual-history-{index}")),
+                sync: sync_metadata(),
+            })
+            .unwrap();
+    }
+    store.refresh_search_index().unwrap();
+
+    let packet = search_packet(
+        &store,
+        "認証",
+        &PacketOptions {
+            limit: 5,
+            snippet_chars: 200,
+            result_mode: SearchResultMode::Events,
+            ..PacketOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert!(
+        !packet.results.is_empty(),
+        "large fast-path search should not return zero results for a literal CJK preview term"
+    );
+    assert!(packet
+        .results
+        .iter()
+        .any(|result| result.event_id == Some(target_event_id)));
+}
+
+#[test]
 fn clustered_fast_search_pages_past_dominant_first_session() {
     let (_temp, store) = test_store();
     let dominant_record = HistoryRecord::new(

--- a/crates/ctx-history-store/src/lib.rs
+++ b/crates/ctx-history-store/src/lib.rs
@@ -40,7 +40,7 @@ use std::{path::PathBuf, time::Duration};
 
 use rusqlite::Connection;
 
-pub(crate) const SCHEMA_VERSION: i64 = 44;
+pub(crate) const SCHEMA_VERSION: i64 = 45;
 
 pub struct Store {
     path: PathBuf,

--- a/crates/ctx-history-store/src/records.rs
+++ b/crates/ctx-history-store/src/records.rs
@@ -7,7 +7,11 @@ use crate::connection::{
     parse_text_enum, parse_time, parse_uuid, timestamp_ms,
 };
 use crate::schema::ddl::table_exists;
-use crate::search::projections::{fts_match_query, upsert_record_search_projection};
+use crate::search::analyzer::scriptgram_match_query;
+use crate::search::projections::{
+    event_scriptgram_table_ready, fts_match_query, record_scriptgram_table_ready,
+    upsert_record_search_projection,
+};
 use crate::sync::sync_metadata_from_row;
 use crate::{Result, Store, StoreError};
 
@@ -230,7 +234,7 @@ impl Store {
         limit: usize,
         offset: usize,
     ) -> Result<Vec<HistoryRecord>> {
-        if fts_match_query(query).is_none() {
+        if fts_match_query(query).is_none() && scriptgram_match_query(query).is_none() {
             return Ok(Vec::new());
         }
         if let Some(records) = self.search_records_fts(query, limit, offset)? {
@@ -256,25 +260,160 @@ impl Store {
         if !table_exists(&self.conn, "ctx_history_search")? {
             return Ok(None);
         }
-        let Some(match_query) = fts_match_query(query) else {
-            return Ok(Some(Vec::new()));
-        };
+        let match_query = fts_match_query(query);
         let has_event_search = table_exists(&self.conn, "event_search")?;
         let has_artifact_search = table_exists(&self.conn, "artifact_search")?;
-        let sql = if has_event_search && has_artifact_search {
-            r#"
-                WITH matches(record_id, score) AS (
+        let has_record_scriptgram = record_scriptgram_table_ready(&self.conn)?;
+        let has_event_scriptgram = event_scriptgram_table_ready(&self.conn)?;
+        let scriptgram_query = if has_record_scriptgram || has_event_scriptgram {
+            scriptgram_match_query(query)
+        } else {
+            None
+        };
+        match (match_query, scriptgram_query) {
+            (Some(match_query), Some(scriptgram_query)) => {
+                let mut selects = vec![r#"
                     SELECT record_id, bm25(ctx_history_search)
                     FROM ctx_history_search
                     WHERE ctx_history_search MATCH ?1
+                    "#
+                .to_owned()];
+                if has_event_search && has_artifact_search {
+                    selects.push(
+                        r#"
+                        SELECT history_record_id, bm25(event_search)
+                        FROM event_search
+                        WHERE event_search MATCH ?1 AND history_record_id IS NOT NULL
+                        "#
+                        .to_owned(),
+                    );
+                    selects.push(
+                        r#"
+                        SELECT history_record_id, bm25(artifact_search)
+                        FROM artifact_search
+                        WHERE artifact_search MATCH ?1 AND history_record_id IS NOT NULL
+                        "#
+                        .to_owned(),
+                    );
+                }
+                if has_record_scriptgram {
+                    selects.push(
+                        r#"
+                        SELECT record_id, bm25(ctx_history_search_scriptgram) + 0.35
+                        FROM ctx_history_search_scriptgram
+                        WHERE ctx_history_search_scriptgram MATCH ?2
+                        "#
+                        .to_owned(),
+                    );
+                }
+                if has_event_scriptgram {
+                    selects.push(
+                        r#"
+                        SELECT history_record_id, bm25(event_search_scriptgram) + 0.35
+                        FROM event_search_scriptgram
+                        WHERE event_search_scriptgram MATCH ?2 AND history_record_id IS NOT NULL
+                        "#
+                        .to_owned(),
+                    );
+                }
+                let sql = format!(
+                    r#"
+                    WITH matches(record_id, score) AS (
+                        {}
+                    )
+                    SELECT record_id
+                    FROM matches
+                    WHERE record_id IS NOT NULL
+                    GROUP BY record_id
+                    ORDER BY MIN(score), record_id
+                    LIMIT ?3 OFFSET ?4
+                    "#,
+                    selects.join(" UNION ALL ")
+                );
+                let mut stmt = self.conn.prepare(&sql)?;
+                let rows = stmt.query_map(
+                    params![match_query, scriptgram_query, limit as i64, offset as i64],
+                    |row| row.get::<_, String>(0),
+                )?;
+                let mut records = Vec::new();
+                for row in rows {
+                    records.push(self.get_record(parse_uuid(row?)?)?);
+                }
+                Ok(Some(records))
+            }
+            (Some(match_query), None) => {
+                let records = if has_event_search && has_artifact_search {
+                    r#"
+                    WITH matches(record_id, score) AS (
+                        SELECT record_id, bm25(ctx_history_search)
+                        FROM ctx_history_search
+                        WHERE ctx_history_search MATCH ?1
+                        UNION ALL
+                        SELECT history_record_id, bm25(event_search)
+                        FROM event_search
+                        WHERE event_search MATCH ?1 AND history_record_id IS NOT NULL
+                        UNION ALL
+                        SELECT history_record_id, bm25(artifact_search)
+                        FROM artifact_search
+                        WHERE artifact_search MATCH ?1 AND history_record_id IS NOT NULL
+                    )
+                    SELECT record_id
+                    FROM matches
+                    WHERE record_id IS NOT NULL
+                    GROUP BY record_id
+                    ORDER BY MIN(score), record_id
+                    LIMIT ?2 OFFSET ?3
+                    "#
+                } else {
+                    r#"
+                    SELECT record_id
+                    FROM ctx_history_search
+                    WHERE ctx_history_search MATCH ?1
+                    ORDER BY bm25(ctx_history_search), record_id
+                    LIMIT ?2 OFFSET ?3
+                    "#
+                };
+                let mut stmt = self.conn.prepare(records)?;
+                let rows = stmt
+                    .query_map(params![match_query, limit as i64, offset as i64], |row| {
+                        row.get::<_, String>(0)
+                    })?;
+                let mut records = Vec::new();
+                for row in rows {
+                    records.push(self.get_record(parse_uuid(row?)?)?);
+                }
+                Ok(Some(records))
+            }
+            (None, Some(_)) => self.search_records_scriptgram(query, limit, offset),
+            (None, None) => Ok(Some(Vec::new())),
+        }
+    }
+
+    fn search_records_scriptgram(
+        &self,
+        query: &str,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Option<Vec<HistoryRecord>>> {
+        let has_record_scriptgram = record_scriptgram_table_ready(&self.conn)?;
+        let has_event_scriptgram = event_scriptgram_table_ready(&self.conn)?;
+        if !has_record_scriptgram && !has_event_scriptgram {
+            return Ok(Some(Vec::new()));
+        }
+        let Some(match_query) = scriptgram_match_query(query) else {
+            return Ok(Some(Vec::new()));
+        };
+        let sql = match (has_record_scriptgram, has_event_scriptgram) {
+            (true, true) => {
+                r#"
+                WITH matches(record_id, score) AS (
+                    SELECT record_id, bm25(ctx_history_search_scriptgram) + 0.35
+                    FROM ctx_history_search_scriptgram
+                    WHERE ctx_history_search_scriptgram MATCH ?1
                     UNION ALL
-                    SELECT history_record_id, bm25(event_search)
-                    FROM event_search
-                    WHERE event_search MATCH ?1 AND history_record_id IS NOT NULL
-                    UNION ALL
-                    SELECT history_record_id, bm25(artifact_search)
-                    FROM artifact_search
-                    WHERE artifact_search MATCH ?1 AND history_record_id IS NOT NULL
+                    SELECT history_record_id, bm25(event_search_scriptgram) + 0.35
+                    FROM event_search_scriptgram
+                    WHERE event_search_scriptgram MATCH ?1 AND history_record_id IS NOT NULL
                 )
                 SELECT record_id
                 FROM matches
@@ -283,14 +422,27 @@ impl Store {
                 ORDER BY MIN(score), record_id
                 LIMIT ?2 OFFSET ?3
                 "#
-        } else {
-            r#"
+            }
+            (true, false) => {
+                r#"
                 SELECT record_id
-                FROM ctx_history_search
-                WHERE ctx_history_search MATCH ?1
-                ORDER BY bm25(ctx_history_search), record_id
+                FROM ctx_history_search_scriptgram
+                WHERE ctx_history_search_scriptgram MATCH ?1
+                ORDER BY bm25(ctx_history_search_scriptgram), record_id
                 LIMIT ?2 OFFSET ?3
                 "#
+            }
+            (false, true) => {
+                r#"
+                SELECT history_record_id
+                FROM event_search_scriptgram
+                WHERE event_search_scriptgram MATCH ?1 AND history_record_id IS NOT NULL
+                GROUP BY history_record_id
+                ORDER BY MIN(bm25(event_search_scriptgram)), history_record_id
+                LIMIT ?2 OFFSET ?3
+                "#
+            }
+            (false, false) => unreachable!("scriptgram tables checked above"),
         };
         let mut stmt = self.conn.prepare(sql)?;
         let rows = stmt.query_map(params![match_query, limit as i64, offset as i64], |row| {

--- a/crates/ctx-history-store/src/schema/fts.rs
+++ b/crates/ctx-history-store/src/schema/fts.rs
@@ -27,6 +27,20 @@ CREATE VIRTUAL TABLE IF NOT EXISTS artifact_search USING fts5(
     history_record_id UNINDEXED,
     preview_text
 );
+
+CREATE VIRTUAL TABLE IF NOT EXISTS ctx_history_search_scriptgram USING fts5(
+    record_id UNINDEXED,
+    token_text
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS event_search_scriptgram USING fts5(
+    event_id UNINDEXED,
+    history_record_id UNINDEXED,
+    session_id UNINDEXED,
+    role UNINDEXED,
+    token_text,
+    rank_bucket UNINDEXED
+);
 "#;
 
 pub(crate) fn create_fts_tables_if_supported(conn: &Connection) -> Result<()> {

--- a/crates/ctx-history-store/src/schema/migrations.rs
+++ b/crates/ctx-history-store/src/schema/migrations.rs
@@ -69,7 +69,10 @@ pub(crate) fn run_migrations(conn: &Connection, user_version: i64) -> Result<()>
         migrate_to_v43(conn)?;
     }
     if user_version < 44 {
-        migrate_to_v44(conn)?;
+        migrate_to_v44(conn, false)?;
+    }
+    if user_version < 45 {
+        migrate_to_v45(conn)?;
     }
     Ok(())
 }
@@ -618,7 +621,7 @@ fn migrate_to_v43(conn: &Connection) -> Result<()> {
     }
 }
 
-fn migrate_to_v44(conn: &Connection) -> Result<()> {
+fn migrate_to_v44(conn: &Connection, rebuild_search_projection_now: bool) -> Result<()> {
     let foreign_keys_enabled: i64 = conn.query_row("PRAGMA foreign_keys", [], |row| row.get(0))?;
     conn.execute_batch("PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE;")?;
     let migration = (|| -> Result<()> {
@@ -631,7 +634,9 @@ fn migrate_to_v44(conn: &Connection) -> Result<()> {
         create_fts_tables_if_supported(conn)?;
         conn.execute_batch(INDEXES_SQL)?;
         create_stable_sql_views(conn)?;
-        rebuild_search_projection(conn)?;
+        if rebuild_search_projection_now {
+            rebuild_search_projection(conn)?;
+        }
         conn.execute_batch("PRAGMA user_version = 44;")?;
         Ok(())
     })();
@@ -650,6 +655,31 @@ fn migrate_to_v44(conn: &Connection) -> Result<()> {
             }
             if foreign_keys_enabled != 0 {
                 conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+            }
+            Err(err)
+        }
+    }
+}
+
+fn migrate_to_v45(conn: &Connection) -> Result<()> {
+    conn.execute_batch("BEGIN IMMEDIATE;")?;
+    let migration = (|| -> Result<()> {
+        drop_fts_table_if_exists(conn, "ctx_history_search_scriptgram")?;
+        drop_fts_table_if_exists(conn, "event_search_scriptgram")?;
+        create_fts_tables_if_supported(conn)?;
+        rebuild_search_projection(conn)?;
+        conn.execute_batch("PRAGMA user_version = 45;")?;
+        Ok(())
+    })();
+
+    match migration {
+        Ok(()) => {
+            conn.execute_batch("COMMIT;")?;
+            Ok(())
+        }
+        Err(err) => {
+            if let Err(rollback_err) = conn.execute_batch("ROLLBACK;") {
+                return Err(StoreError::Sql(rollback_err));
             }
             Err(err)
         }

--- a/crates/ctx-history-store/src/schema/tests.rs
+++ b/crates/ctx-history-store/src/schema/tests.rs
@@ -118,6 +118,96 @@ fn schema_v8_migrates_legacy_history_record_table_names() {
 }
 
 #[test]
+fn schema_v45_rebuilds_scriptgram_sidecars() {
+    let temp = tempdir();
+    let path = temp.path().join("work.sqlite");
+    let record_id = new_id().to_string();
+    let event_id = new_id().to_string();
+    {
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(CREATE_TABLES_SQL).unwrap();
+        conn.execute_batch(FTS_TABLES_SQL).unwrap();
+        conn.execute_batch(INDEXES_SQL).unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO history_records (id, title, body, created_at, updated_at)
+            VALUES (?1, 'v44 multilingual record', 'OAuth認証の検索状態を確認します。', '2026-06-23T12:00:00+00:00', '2026-06-23T12:00:00+00:00')
+            "#,
+            [record_id.as_str()],
+        )
+        .unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO events (id, seq, history_record_id, event_type, role, occurred_at_ms, payload_json)
+            VALUES (?1, 1, ?2, 'message', 'user', 0, '{"text":"OAuth認証の検索状態をイベントにも残します。"}')
+            "#,
+            params![event_id.as_str(), record_id.as_str()],
+        )
+        .unwrap();
+        conn.execute_batch(
+            r#"
+            DROP TABLE IF EXISTS ctx_history_search_scriptgram;
+            DROP TABLE IF EXISTS event_search_scriptgram;
+            CREATE VIRTUAL TABLE ctx_history_search_scriptgram USING fts5(record_id UNINDEXED, body);
+            CREATE VIRTUAL TABLE event_search_scriptgram USING fts5(event_id UNINDEXED, token_text);
+            PRAGMA user_version = 44;
+            "#,
+        )
+        .unwrap();
+    }
+
+    let store = Store::open(&path).unwrap();
+    let version: i64 = store
+        .conn
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(version, SCHEMA_VERSION);
+    for column in ["record_id", "token_text"] {
+        assert!(table_has_column(&store.conn, "ctx_history_search_scriptgram", column).unwrap());
+    }
+    for column in [
+        "event_id",
+        "history_record_id",
+        "session_id",
+        "role",
+        "token_text",
+        "rank_bucket",
+    ] {
+        assert!(table_has_column(&store.conn, "event_search_scriptgram", column).unwrap());
+    }
+
+    let record_tokens: String = store
+        .conn
+        .query_row(
+            "SELECT token_text FROM ctx_history_search_scriptgram WHERE record_id = ?1",
+            [record_id.as_str()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(record_tokens
+        .split_whitespace()
+        .any(|token| token == "認証"));
+    let event_tokens: String = store
+        .conn
+        .query_row(
+            "SELECT token_text FROM event_search_scriptgram WHERE event_id = ?1",
+            [event_id.as_str()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(event_tokens.split_whitespace().any(|token| token == "認証"));
+
+    let record_hits = store.search_records("認証", 10).unwrap();
+    assert!(record_hits
+        .iter()
+        .any(|record| record.id.to_string() == record_id));
+    let event_hits = store.search_event_hits("認証", 10).unwrap();
+    assert!(event_hits
+        .iter()
+        .any(|hit| hit.event_id.to_string() == event_id));
+}
+
+#[test]
 fn schema_v12_invalidates_provider_import_indexes_for_reimport() {
     let temp = tempdir();
     let path = temp.path().join("work.sqlite");

--- a/crates/ctx-history-store/src/search/analyzer.rs
+++ b/crates/ctx-history-store/src/search/analyzer.rs
@@ -1,0 +1,853 @@
+pub(crate) fn scriptgram_index_text(text: &str) -> String {
+    if !contains_grammed_script(text) {
+        return String::new();
+    }
+    generated_index_terms(text).join(" ")
+}
+
+pub(crate) fn scriptgram_match_query(query: &str) -> Option<String> {
+    if !contains_grammed_script(query) {
+        return None;
+    }
+    let clauses = query
+        .split_whitespace()
+        .filter_map(query_term_clause)
+        .collect::<Vec<_>>();
+    if clauses.is_empty() {
+        None
+    } else {
+        Some(clauses.join(" AND "))
+    }
+}
+
+fn query_term_clause(term: &str) -> Option<String> {
+    let trimmed = trim_fts_term(term);
+    if !trimmed.chars().any(char::is_alphanumeric) {
+        return None;
+    }
+    if !contains_grammed_script(trimmed) {
+        return Some(quoted_fts_term(trimmed));
+    }
+
+    let clauses = query_term_clauses(trimmed);
+    if clauses.is_empty() {
+        Some(quoted_fts_term(trimmed))
+    } else if clauses.len() == 1 {
+        Some(clauses.into_iter().next().expect("one query clause"))
+    } else {
+        Some(clauses.join(" AND "))
+    }
+}
+
+fn query_term_clauses(term: &str) -> Vec<String> {
+    let mut clauses = Vec::new();
+    let mut current = String::new();
+    let mut current_kind: Option<QueryRunKind> = None;
+
+    for ch in term.chars() {
+        let kind = QueryRunKind::from_char(ch);
+        match kind {
+            QueryRunKind::Mark => {
+                if current.is_empty() {
+                    continue;
+                }
+                current.push(ch);
+            }
+            QueryRunKind::Separator => {
+                flush_query_run(&mut clauses, &mut current, current_kind);
+                current_kind = None;
+            }
+            kind => {
+                if current_kind == Some(kind) {
+                    current.push(ch);
+                } else {
+                    flush_query_run(&mut clauses, &mut current, current_kind);
+                    current.push(ch);
+                    current_kind = Some(kind);
+                }
+            }
+        }
+    }
+    flush_query_run(&mut clauses, &mut current, current_kind);
+    clauses
+}
+
+fn flush_query_run(
+    clauses: &mut Vec<String>,
+    current: &mut String,
+    current_kind: Option<QueryRunKind>,
+) {
+    if current.is_empty() {
+        return;
+    }
+
+    match current_kind {
+        Some(QueryRunKind::Gram) => {
+            let grams = grammed_query_terms(current);
+            clauses.extend(grams.into_iter().map(|term| quoted_fts_term(&term)));
+        }
+        Some(QueryRunKind::Word) if current.chars().any(char::is_alphanumeric) => {
+            clauses.push(quoted_fts_term(current));
+        }
+        _ => {}
+    }
+
+    current.clear();
+}
+
+fn generated_index_terms(text: &str) -> Vec<String> {
+    let mut terms = Vec::new();
+    let mut current = String::new();
+    let mut current_kind: Option<IndexRunKind> = None;
+
+    for ch in text.chars() {
+        let kind = IndexRunKind::from_char(ch);
+        match kind {
+            IndexRunKind::Mark => {
+                if current.is_empty() {
+                    continue;
+                }
+                current.push(ch);
+            }
+            IndexRunKind::Separator => {
+                flush_index_run(&mut terms, &mut current, current_kind);
+                current_kind = None;
+            }
+            kind => {
+                if current_kind == Some(kind) {
+                    current.push(ch);
+                } else {
+                    flush_index_run(&mut terms, &mut current, current_kind);
+                    current.push(ch);
+                    current_kind = Some(kind);
+                }
+            }
+        }
+    }
+    flush_index_run(&mut terms, &mut current, current_kind);
+    terms
+}
+
+fn flush_index_run(
+    terms: &mut Vec<String>,
+    current: &mut String,
+    current_kind: Option<IndexRunKind>,
+) {
+    if current.is_empty() {
+        return;
+    }
+
+    match current_kind {
+        Some(IndexRunKind::Gram) => {
+            terms.push(current.clone());
+            terms.extend(adjacent_grams(current));
+        }
+        Some(IndexRunKind::Word) if current.chars().any(char::is_alphanumeric) => {
+            terms.push(current.clone());
+        }
+        _ => {}
+    }
+
+    current.clear();
+}
+
+fn grammed_query_terms(run: &str) -> Vec<String> {
+    let units = graphemeish_units(run);
+    match units.len() {
+        0 => Vec::new(),
+        1 | 2 => vec![run.to_owned()],
+        _ => adjacent_grams_from_units(&units),
+    }
+}
+
+fn adjacent_grams(run: &str) -> Vec<String> {
+    let units = graphemeish_units(run);
+    adjacent_grams_from_units(&units)
+}
+
+fn adjacent_grams_from_units(units: &[String]) -> Vec<String> {
+    units
+        .windows(2)
+        .map(|window| {
+            let mut gram = String::with_capacity(window[0].len() + window[1].len());
+            gram.push_str(&window[0]);
+            gram.push_str(&window[1]);
+            gram
+        })
+        .collect()
+}
+
+fn graphemeish_units(run: &str) -> Vec<String> {
+    let mut units: Vec<String> = Vec::new();
+    for ch in run.chars() {
+        if char_is_mark(ch) || char_is_joiner(ch) {
+            if let Some(unit) = units.last_mut() {
+                unit.push(ch);
+            }
+            continue;
+        }
+
+        let mut unit = String::new();
+        unit.push(ch);
+        units.push(unit);
+    }
+
+    merge_hangul_jamo_units(units)
+}
+
+fn merge_hangul_jamo_units(units: Vec<String>) -> Vec<String> {
+    let mut merged = Vec::<String>::new();
+    for unit in units {
+        let Some(ch) = unit.chars().next() else {
+            continue;
+        };
+        if is_hangul_jamo(ch) && !is_hangul_leading_jamo(ch) {
+            if let Some(previous) = merged.last_mut() {
+                if previous.chars().next().is_some_and(is_hangul_jamo) {
+                    previous.push_str(&unit);
+                    continue;
+                }
+            }
+        }
+        merged.push(unit);
+    }
+    merged
+}
+
+fn contains_grammed_script(text: &str) -> bool {
+    text.chars()
+        .any(|ch| SearchScript::from_char(ch).is_some_and(SearchScript::is_grammed))
+}
+
+fn trim_fts_term(term: &str) -> &str {
+    term.trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_' && ch != '-')
+}
+
+fn quoted_fts_term(term: &str) -> String {
+    format!("\"{}\"", term.replace('"', "\"\""))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IndexRunKind {
+    Word,
+    Gram,
+    Mark,
+    Separator,
+}
+
+impl IndexRunKind {
+    fn from_char(ch: char) -> Self {
+        if char_is_mark(ch) || char_is_joiner(ch) {
+            return Self::Mark;
+        }
+        match SearchScript::from_char(ch) {
+            Some(script) if script.is_grammed() => Self::Gram,
+            _ if ch.is_alphanumeric() || ch == '_' || ch == '-' => Self::Word,
+            _ => Self::Separator,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QueryRunKind {
+    Word,
+    Gram,
+    Mark,
+    Separator,
+}
+
+impl QueryRunKind {
+    fn from_char(ch: char) -> Self {
+        if char_is_mark(ch) || char_is_joiner(ch) {
+            return Self::Mark;
+        }
+        match SearchScript::from_char(ch) {
+            Some(script) if script.is_grammed() => Self::Gram,
+            _ if ch.is_alphanumeric() || ch == '_' || ch == '-' => Self::Word,
+            _ => Self::Separator,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchScript {
+    Han,
+    Hiragana,
+    Katakana,
+    Hangul,
+    Thai,
+    Lao,
+    Khmer,
+    Myanmar,
+    Bengali,
+    Devanagari,
+    Gujarati,
+    Gurmukhi,
+    Kannada,
+    Malayalam,
+    Oriya,
+    Sinhala,
+    Tamil,
+    Telugu,
+}
+
+impl SearchScript {
+    fn from_char(ch: char) -> Option<Self> {
+        let code = u32::from(ch);
+        if in_ranges(
+            code,
+            &[
+                (0x3400, 0x4DBF),
+                (0x4E00, 0x9FFF),
+                (0xF900, 0xFAFF),
+                (0x20000, 0x2A6DF),
+                (0x2A700, 0x2B73F),
+                (0x2B740, 0x2B81F),
+                (0x2B820, 0x2CEAF),
+                (0x2CEB0, 0x2EBEF),
+                (0x30000, 0x3134F),
+                (0x31350, 0x323AF),
+            ],
+        ) {
+            return Some(Self::Han);
+        }
+        if in_ranges(code, &[(0x3040, 0x309F)]) {
+            return Some(Self::Hiragana);
+        }
+        if in_ranges(
+            code,
+            &[(0x30A0, 0x30FF), (0x31F0, 0x31FF), (0xFF66, 0xFF9F)],
+        ) {
+            return Some(Self::Katakana);
+        }
+        if in_ranges(
+            code,
+            &[
+                (0x1100, 0x11FF),
+                (0x3130, 0x318F),
+                (0xA960, 0xA97F),
+                (0xAC00, 0xD7AF),
+                (0xD7B0, 0xD7FF),
+            ],
+        ) {
+            return Some(Self::Hangul);
+        }
+        if in_ranges(code, &[(0x0E00, 0x0E7F)]) {
+            return Some(Self::Thai);
+        }
+        if in_ranges(code, &[(0x0E80, 0x0EFF)]) {
+            return Some(Self::Lao);
+        }
+        if in_ranges(code, &[(0x1780, 0x17FF), (0x19E0, 0x19FF)]) {
+            return Some(Self::Khmer);
+        }
+        if in_ranges(
+            code,
+            &[(0x1000, 0x109F), (0xAA60, 0xAA7F), (0xA9E0, 0xA9FF)],
+        ) {
+            return Some(Self::Myanmar);
+        }
+        if in_ranges(code, &[(0x0980, 0x09FF)]) {
+            return Some(Self::Bengali);
+        }
+        if in_ranges(code, &[(0x0900, 0x097F), (0xA8E0, 0xA8FF)]) {
+            return Some(Self::Devanagari);
+        }
+        if in_ranges(code, &[(0x0A80, 0x0AFF)]) {
+            return Some(Self::Gujarati);
+        }
+        if in_ranges(code, &[(0x0A00, 0x0A7F)]) {
+            return Some(Self::Gurmukhi);
+        }
+        if in_ranges(code, &[(0x0C80, 0x0CFF)]) {
+            return Some(Self::Kannada);
+        }
+        if in_ranges(code, &[(0x0D00, 0x0D7F)]) {
+            return Some(Self::Malayalam);
+        }
+        if in_ranges(code, &[(0x0B00, 0x0B7F)]) {
+            return Some(Self::Oriya);
+        }
+        if in_ranges(code, &[(0x0D80, 0x0DFF)]) {
+            return Some(Self::Sinhala);
+        }
+        if in_ranges(code, &[(0x0B80, 0x0BFF)]) {
+            return Some(Self::Tamil);
+        }
+        if in_ranges(code, &[(0x0C00, 0x0C7F)]) {
+            return Some(Self::Telugu);
+        }
+        None
+    }
+
+    fn is_grammed(self) -> bool {
+        true
+    }
+}
+
+fn in_ranges(code: u32, ranges: &[(u32, u32)]) -> bool {
+    ranges
+        .iter()
+        .any(|(start, end)| *start <= code && code <= *end)
+}
+
+fn char_is_mark(ch: char) -> bool {
+    let code = u32::from(ch);
+    in_ranges(
+        code,
+        &[
+            (0x0300, 0x036F),
+            (0x0483, 0x0489),
+            (0x0591, 0x05BD),
+            (0x05BF, 0x05BF),
+            (0x05C1, 0x05C2),
+            (0x05C4, 0x05C5),
+            (0x05C7, 0x05C7),
+            (0x0610, 0x061A),
+            (0x064B, 0x065F),
+            (0x0670, 0x0670),
+            (0x06D6, 0x06DC),
+            (0x06DF, 0x06E4),
+            (0x06E7, 0x06E8),
+            (0x06EA, 0x06ED),
+            (0x0711, 0x0711),
+            (0x0730, 0x074A),
+            (0x07A6, 0x07B0),
+            (0x07EB, 0x07F3),
+            (0x0816, 0x0819),
+            (0x081B, 0x0823),
+            (0x0825, 0x0827),
+            (0x0829, 0x082D),
+            (0x0859, 0x085B),
+            (0x08D3, 0x08E1),
+            (0x08E3, 0x0903),
+            (0x093A, 0x093C),
+            (0x093E, 0x094F),
+            (0x0951, 0x0957),
+            (0x0962, 0x0963),
+            (0x0981, 0x0983),
+            (0x09BC, 0x09BC),
+            (0x09BE, 0x09C4),
+            (0x09C7, 0x09C8),
+            (0x09CB, 0x09CD),
+            (0x09D7, 0x09D7),
+            (0x09E2, 0x09E3),
+            (0x0A01, 0x0A03),
+            (0x0A3C, 0x0A3C),
+            (0x0A3E, 0x0A42),
+            (0x0A47, 0x0A48),
+            (0x0A4B, 0x0A4D),
+            (0x0A51, 0x0A51),
+            (0x0A70, 0x0A71),
+            (0x0A75, 0x0A75),
+            (0x0A81, 0x0A83),
+            (0x0ABC, 0x0ABC),
+            (0x0ABE, 0x0AC5),
+            (0x0AC7, 0x0AC9),
+            (0x0ACB, 0x0ACD),
+            (0x0AE2, 0x0AE3),
+            (0x0AFA, 0x0AFF),
+            (0x0B01, 0x0B03),
+            (0x0B3C, 0x0B3C),
+            (0x0B3E, 0x0B44),
+            (0x0B47, 0x0B48),
+            (0x0B4B, 0x0B4D),
+            (0x0B55, 0x0B57),
+            (0x0B62, 0x0B63),
+            (0x0B82, 0x0B82),
+            (0x0BBE, 0x0BC2),
+            (0x0BC6, 0x0BC8),
+            (0x0BCA, 0x0BCD),
+            (0x0BD7, 0x0BD7),
+            (0x0C00, 0x0C04),
+            (0x0C3C, 0x0C3C),
+            (0x0C3E, 0x0C44),
+            (0x0C46, 0x0C48),
+            (0x0C4A, 0x0C4D),
+            (0x0C55, 0x0C56),
+            (0x0C62, 0x0C63),
+            (0x0C81, 0x0C83),
+            (0x0CBC, 0x0CBC),
+            (0x0CBE, 0x0CC4),
+            (0x0CC6, 0x0CC8),
+            (0x0CCA, 0x0CCD),
+            (0x0CD5, 0x0CD6),
+            (0x0CE2, 0x0CE3),
+            (0x0D00, 0x0D03),
+            (0x0D3B, 0x0D3C),
+            (0x0D3E, 0x0D44),
+            (0x0D46, 0x0D48),
+            (0x0D4A, 0x0D4D),
+            (0x0D57, 0x0D57),
+            (0x0D62, 0x0D63),
+            (0x0D81, 0x0D83),
+            (0x0DCA, 0x0DCA),
+            (0x0DCF, 0x0DD4),
+            (0x0DD6, 0x0DD6),
+            (0x0DD8, 0x0DDF),
+            (0x0DF2, 0x0DF3),
+            (0x0E31, 0x0E31),
+            (0x0E34, 0x0E3A),
+            (0x0E47, 0x0E4E),
+            (0x0EB1, 0x0EB1),
+            (0x0EB4, 0x0EBC),
+            (0x0EC8, 0x0ECD),
+            (0x0F18, 0x0F19),
+            (0x0F35, 0x0F35),
+            (0x0F37, 0x0F37),
+            (0x0F39, 0x0F39),
+            (0x0F3E, 0x0F3F),
+            (0x0F71, 0x0F84),
+            (0x0F86, 0x0F87),
+            (0x0F8D, 0x0FBC),
+            (0x0FC6, 0x0FC6),
+            (0x102B, 0x103E),
+            (0x1056, 0x1059),
+            (0x105E, 0x1060),
+            (0x1062, 0x1064),
+            (0x1067, 0x106D),
+            (0x1071, 0x1074),
+            (0x1082, 0x108D),
+            (0x108F, 0x108F),
+            (0x109A, 0x109D),
+            (0x135D, 0x135F),
+            (0x1712, 0x1715),
+            (0x1732, 0x1734),
+            (0x1752, 0x1753),
+            (0x1772, 0x1773),
+            (0x17B4, 0x17D3),
+            (0x17DD, 0x17DD),
+            (0x180B, 0x180F),
+            (0x1885, 0x1886),
+            (0x18A9, 0x18A9),
+            (0x1920, 0x192B),
+            (0x1930, 0x193B),
+            (0x1A17, 0x1A1B),
+            (0x1A55, 0x1A5E),
+            (0x1A60, 0x1A7C),
+            (0x1A7F, 0x1A7F),
+            (0x1AB0, 0x1AFF),
+            (0x1B00, 0x1B04),
+            (0x1B34, 0x1B44),
+            (0x1B6B, 0x1B73),
+            (0x1B80, 0x1B82),
+            (0x1BA1, 0x1BAD),
+            (0x1BE6, 0x1BF3),
+            (0x1C24, 0x1C37),
+            (0x1CD0, 0x1CD2),
+            (0x1CD4, 0x1CE8),
+            (0x1CED, 0x1CED),
+            (0x1CF4, 0x1CF4),
+            (0x1CF7, 0x1CF9),
+            (0x1DC0, 0x1DFF),
+            (0x20D0, 0x20FF),
+            (0x2CEF, 0x2CF1),
+            (0x2D7F, 0x2D7F),
+            (0x2DE0, 0x2DFF),
+            (0x302A, 0x302F),
+            (0x3099, 0x309A),
+            (0xA66F, 0xA672),
+            (0xA674, 0xA67D),
+            (0xA69E, 0xA69F),
+            (0xA6F0, 0xA6F1),
+            (0xA802, 0xA802),
+            (0xA806, 0xA806),
+            (0xA80B, 0xA80B),
+            (0xA823, 0xA827),
+            (0xA880, 0xA881),
+            (0xA8B4, 0xA8C5),
+            (0xA8E0, 0xA8F1),
+            (0xA8FF, 0xA8FF),
+            (0xA926, 0xA92D),
+            (0xA947, 0xA953),
+            (0xA980, 0xA983),
+            (0xA9B3, 0xA9C0),
+            (0xA9E5, 0xA9E5),
+            (0xAA29, 0xAA36),
+            (0xAA43, 0xAA43),
+            (0xAA4C, 0xAA4D),
+            (0xAA7B, 0xAA7D),
+            (0xAAB0, 0xAAB0),
+            (0xAAB2, 0xAAB4),
+            (0xAAB7, 0xAAB8),
+            (0xAABE, 0xAABF),
+            (0xAAC1, 0xAAC1),
+            (0xAAEB, 0xAAEF),
+            (0xAAF5, 0xAAF6),
+            (0xABE3, 0xABEA),
+            (0xABEC, 0xABED),
+            (0xFB1E, 0xFB1E),
+            (0xFE00, 0xFE0F),
+            (0xFE20, 0xFE2F),
+            (0x101FD, 0x101FD),
+            (0x102E0, 0x102E0),
+            (0x10376, 0x1037A),
+            (0x10A01, 0x10A03),
+            (0x10A05, 0x10A06),
+            (0x10A0C, 0x10A0F),
+            (0x10A38, 0x10A3A),
+            (0x10A3F, 0x10A3F),
+            (0x10AE5, 0x10AE6),
+            (0x10D24, 0x10D27),
+            (0x10EAB, 0x10EAC),
+            (0x10F46, 0x10F50),
+            (0x10F82, 0x10F85),
+            (0x11000, 0x11002),
+            (0x11038, 0x11046),
+            (0x11070, 0x11070),
+            (0x11073, 0x11074),
+            (0x1107F, 0x11082),
+            (0x110B0, 0x110BA),
+            (0x11100, 0x11102),
+            (0x11127, 0x11134),
+            (0x11145, 0x11146),
+            (0x11173, 0x11173),
+            (0x11180, 0x11182),
+            (0x111B3, 0x111C0),
+            (0x111CA, 0x111CC),
+            (0x1122C, 0x11237),
+            (0x1123E, 0x1123E),
+            (0x112DF, 0x112EA),
+            (0x11300, 0x11303),
+            (0x1133B, 0x1133C),
+            (0x1133E, 0x11344),
+            (0x11347, 0x11348),
+            (0x1134B, 0x1134D),
+            (0x11357, 0x11357),
+            (0x11362, 0x11363),
+            (0x11366, 0x1136C),
+            (0x11370, 0x11374),
+            (0x11435, 0x11446),
+            (0x1145E, 0x1145E),
+            (0x114B0, 0x114C3),
+            (0x115AF, 0x115B5),
+            (0x115B8, 0x115C0),
+            (0x115DC, 0x115DD),
+            (0x11630, 0x11640),
+            (0x116AB, 0x116B7),
+            (0x1171D, 0x1172B),
+            (0x1182C, 0x1183A),
+            (0x11930, 0x11935),
+            (0x11937, 0x11938),
+            (0x1193B, 0x1193E),
+            (0x11940, 0x11940),
+            (0x11942, 0x11943),
+            (0x119D1, 0x119D7),
+            (0x119DA, 0x119E0),
+            (0x119E4, 0x119E4),
+            (0x11A01, 0x11A0A),
+            (0x11A33, 0x11A39),
+            (0x11A3B, 0x11A3E),
+            (0x11A47, 0x11A47),
+            (0x11A51, 0x11A5B),
+            (0x11A8A, 0x11A99),
+            (0x11C2F, 0x11C36),
+            (0x11C38, 0x11C3F),
+            (0x11C92, 0x11CA7),
+            (0x11CA9, 0x11CB6),
+            (0x11D31, 0x11D36),
+            (0x11D3A, 0x11D3A),
+            (0x11D3C, 0x11D3D),
+            (0x11D3F, 0x11D45),
+            (0x11D47, 0x11D47),
+            (0x11D8A, 0x11D8E),
+            (0x11D90, 0x11D91),
+            (0x11D93, 0x11D97),
+            (0x11EF3, 0x11EF6),
+            (0x16AF0, 0x16AF4),
+            (0x16B30, 0x16B36),
+            (0x16F4F, 0x16F4F),
+            (0x16F51, 0x16F87),
+            (0x16F8F, 0x16F92),
+            (0x16FE4, 0x16FE4),
+            (0x1BC9D, 0x1BC9E),
+            (0x1CF00, 0x1CF2D),
+            (0x1CF30, 0x1CF46),
+            (0x1D165, 0x1D169),
+            (0x1D16D, 0x1D172),
+            (0x1D17B, 0x1D182),
+            (0x1D185, 0x1D18B),
+            (0x1D1AA, 0x1D1AD),
+            (0x1D242, 0x1D244),
+            (0x1DA00, 0x1DA36),
+            (0x1DA3B, 0x1DA6C),
+            (0x1DA75, 0x1DA75),
+            (0x1DA84, 0x1DA84),
+            (0x1DA9B, 0x1DA9F),
+            (0x1DAA1, 0x1DAAF),
+            (0x1E000, 0x1E006),
+            (0x1E008, 0x1E018),
+            (0x1E01B, 0x1E021),
+            (0x1E023, 0x1E024),
+            (0x1E026, 0x1E02A),
+            (0x1E130, 0x1E136),
+            (0x1E2EC, 0x1E2EF),
+            (0x1E8D0, 0x1E8D6),
+            (0x1E944, 0x1E94A),
+            (0xE0100, 0xE01EF),
+        ],
+    )
+}
+
+fn char_is_joiner(ch: char) -> bool {
+    matches!(ch, '\u{200C}' | '\u{200D}')
+}
+
+fn is_hangul_jamo(ch: char) -> bool {
+    in_ranges(
+        u32::from(ch),
+        &[
+            (0x1100, 0x11FF),
+            (0x3130, 0x318F),
+            (0xA960, 0xA97F),
+            (0xD7B0, 0xD7FF),
+        ],
+    )
+}
+
+fn is_hangul_leading_jamo(ch: char) -> bool {
+    in_ranges(u32::from(ch), &[(0x1100, 0x115F), (0xA960, 0xA97C)])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latin_only_text_and_queries_do_not_use_scriptgram() {
+        for query in [
+            "",
+            "!!!",
+            "---",
+            "___",
+            "OAuth/API/parser",
+            " failed-migration parser_v2 ",
+            "\"quoted\" token",
+            "path/to/src/lib.rs",
+            "rust::module::Name",
+            "C++ compile error",
+        ] {
+            assert_eq!(scriptgram_match_query(query), None);
+        }
+
+        assert_eq!(
+            scriptgram_index_text("OAuth/API/parser touched src/lib.rs"),
+            ""
+        );
+    }
+
+    #[test]
+    fn index_text_preserves_latin_code_tokens() {
+        let analyzed = scriptgram_index_text("OAuth/API/parser touched OAuth認証のバグ");
+
+        assert!(has_token(&analyzed, "OAuth"));
+        assert!(has_token(&analyzed, "API"));
+        assert!(has_token(&analyzed, "parser"));
+        assert!(has_token(&analyzed, "touched"));
+        assert!(has_token(&analyzed, "認証"));
+        assert!(has_token(&analyzed, "バグ"));
+    }
+
+    #[test]
+    fn cjk_kana_and_hangul_index_terms_include_adjacent_bigrams() {
+        let terms = generated_index_terms("OAuth認証のバグ 오류를 状態管理");
+
+        assert!(has_exact(&terms, "OAuth"));
+        assert!(has_exact(&terms, "認証のバグ"));
+        assert!(has_exact(&terms, "認証"));
+        assert!(has_exact(&terms, "証の"));
+        assert!(has_exact(&terms, "のバ"));
+        assert!(has_exact(&terms, "バグ"));
+        assert!(has_exact(&terms, "오류를"));
+        assert!(has_exact(&terms, "오류"));
+        assert!(has_exact(&terms, "류를"));
+        assert!(has_exact(&terms, "状態管理"));
+        assert!(has_exact(&terms, "状態"));
+        assert!(has_exact(&terms, "態管"));
+        assert!(has_exact(&terms, "管理"));
+    }
+
+    #[test]
+    fn script_queries_use_terms_that_index_analyzer_generates() {
+        let index_terms = generated_index_terms("OAuth認証のバグ 食べる 오류를 状態管理 テストを");
+
+        for term in ["認証", "오류", "状態", "管理"] {
+            assert!(has_exact(&index_terms, term), "missing index term {term}");
+            assert_eq!(scriptgram_match_query(term), Some(format!("\"{term}\"")));
+        }
+        assert_eq!(
+            scriptgram_match_query("状態 管理"),
+            Some("\"状態\" AND \"管理\"".to_owned())
+        );
+        assert_eq!(
+            scriptgram_match_query("状態管理"),
+            Some("\"状態\" AND \"態管\" AND \"管理\"".to_owned())
+        );
+        assert_eq!(
+            scriptgram_match_query("テスト"),
+            Some("\"テス\" AND \"スト\"".to_owned())
+        );
+        for term in ["状態", "管理", "テス", "スト"] {
+            assert!(has_exact(&index_terms, term), "missing index term {term}");
+        }
+        assert!(
+            has_exact(&index_terms, "食べ"),
+            "missing Japanese boundary bigram"
+        );
+        assert!(
+            has_exact(&index_terms, "証の"),
+            "missing Japanese boundary bigram"
+        );
+        assert_eq!(scriptgram_match_query("食べ"), Some("\"食べ\"".to_owned()));
+        assert_eq!(scriptgram_match_query("証の"), Some("\"証の\"".to_owned()));
+    }
+
+    #[test]
+    fn mixed_query_terms_split_at_script_boundaries() {
+        assert_eq!(
+            scriptgram_match_query("OAuth認証"),
+            Some("\"OAuth\" AND \"認証\"".to_owned())
+        );
+        assert_eq!(
+            scriptgram_match_query("API/parser認証"),
+            Some("\"API\" AND \"parser\" AND \"認証\"".to_owned())
+        );
+    }
+
+    #[test]
+    fn thai_myanmar_and_indic_runs_generate_graphemeish_bigrams() {
+        let thai = generated_index_terms("ภาษาไทย");
+        assert!(has_exact(&thai, "ภาษาไทย"));
+        assert!(has_exact(&thai, "ภา"));
+        assert!(has_exact(&thai, "ษา"));
+
+        let myanmar = generated_index_terms("မြန်မာ");
+        assert!(has_exact(&myanmar, "မြန်မာ"));
+        assert!(has_exact(&myanmar, "မြန်"));
+        assert!(has_exact(&myanmar, "န်မာ"));
+
+        let devanagari = generated_index_terms("कर्म");
+        assert!(has_exact(&devanagari, "कर्म"));
+        assert!(has_exact(&devanagari, "कर्"));
+        assert!(has_exact(&devanagari, "र्म"));
+        assert_eq!(
+            scriptgram_match_query("कर्म"),
+            Some("\"कर्\" AND \"र्म\"".to_owned())
+        );
+    }
+
+    #[test]
+    fn punctuation_only_queries_still_return_none() {
+        for query in ["", " ", "!!!", "...", "/"] {
+            assert_eq!(scriptgram_match_query(query), None);
+        }
+    }
+
+    fn has_token(text: &str, token: &str) -> bool {
+        text.split_whitespace().any(|candidate| candidate == token)
+    }
+
+    fn has_exact(terms: &[String], expected: &str) -> bool {
+        terms.iter().any(|term| term == expected)
+    }
+}

--- a/crates/ctx-history-store/src/search/mod.rs
+++ b/crates/ctx-history-store/src/search/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod analyzer;
 pub(crate) mod projections;
 #[cfg(test)]
 mod tests;

--- a/crates/ctx-history-store/src/search/projections.rs
+++ b/crates/ctx-history-store/src/search/projections.rs
@@ -9,6 +9,7 @@ use crate::connection::{
 };
 use crate::records::{record_from_row, record_select_sql};
 use crate::schema::ddl::table_exists;
+use crate::search::analyzer::{scriptgram_index_text, scriptgram_match_query};
 use crate::{Result, Store};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -48,7 +49,13 @@ impl Store {
     }
 
     pub fn optimize_search_index(&self) -> Result<()> {
-        for table in ["ctx_history_search", "event_search", "artifact_search"] {
+        for table in [
+            "ctx_history_search",
+            "event_search",
+            "artifact_search",
+            "ctx_history_search_scriptgram",
+            "event_search_scriptgram",
+        ] {
             if table_exists(&self.conn, table)? {
                 self.conn.execute(
                     format!("INSERT INTO {table}({table}) VALUES ('optimize')").as_str(),
@@ -80,87 +87,85 @@ impl Store {
         if !table_exists(&self.conn, "event_search")? {
             return Ok(Vec::new());
         }
-        let Some(match_query) = fts_match_query(query) else {
-            return Ok(Vec::new());
+        let match_query = fts_match_query(query);
+        let scriptgram_query = if event_scriptgram_table_ready(&self.conn)? {
+            scriptgram_match_query(query)
+        } else {
+            None
         };
-        let mut stmt = self.conn.prepare(
-                r#"
-                SELECT event_search.event_id,
-                       COALESCE(e.history_record_id, event_search.history_record_id, s.history_record_id, rs.history_record_id),
-                       COALESCE(e.session_id, event_search.session_id, s.id, rs.id),
-                       e.run_id,
-                       e.seq,
-                       e.event_type,
-                       e.role,
-                       e.occurred_at_ms,
-                       event_search.preview_text,
-                       bm25(event_search),
-                       COALESCE(s.provider, rs.provider, event_source.provider, session_source.provider, run_source.provider),
-                       COALESCE(s.external_session_id, rs.external_session_id),
-                       COALESCE(s.parent_session_id, rs.parent_session_id),
-                       COALESCE(s.root_session_id, rs.root_session_id),
-                       COALESCE(s.agent_type, rs.agent_type),
-                       COALESCE(s.is_primary, rs.is_primary),
-                       COALESCE(event_source.cwd, session_source.cwd, run_source.cwd),
-                       COALESCE(event_source.raw_source_path, session_source.raw_source_path, run_source.raw_source_path),
-                       e.payload_json,
-                       COALESCE(event_source.metadata_json, session_source.metadata_json, run_source.metadata_json),
-                       wr.title,
-                       wr.kind,
-                       wr.workspace
-                FROM event_search
-                JOIN events e ON e.id = event_search.event_id
-                LEFT JOIN runs r ON r.id = e.run_id
-                LEFT JOIN sessions s ON s.id = COALESCE(e.session_id, event_search.session_id)
-                LEFT JOIN sessions rs ON rs.id = r.session_id
-                LEFT JOIN capture_sources event_source ON event_source.id = e.capture_source_id
-                LEFT JOIN capture_sources session_source ON session_source.id = COALESCE(s.capture_source_id, rs.capture_source_id)
-                LEFT JOIN capture_sources run_source ON run_source.id = r.source_id
-                LEFT JOIN history_records wr ON wr.id = COALESCE(e.history_record_id, event_search.history_record_id, s.history_record_id, rs.history_record_id, r.history_record_id)
-                WHERE event_search MATCH ?1
-                ORDER BY bm25(event_search), e.occurred_at_ms DESC, e.seq DESC, event_search.event_id
-                LIMIT ?2 OFFSET ?3
-                "#,
-            )?;
-        let rows = stmt.query_map(
-            params![match_query, limit.max(1) as i64, offset as i64],
-            |row| {
-                let payload_json = row.get::<_, String>(18)?;
-                let source_metadata_json = row.get::<_, Option<String>>(19)?;
-                let source_identity =
-                    event_search_source_identity(source_metadata_json.as_deref())?;
-                Ok(EventSearchHit {
-                    event_id: parse_uuid(row.get::<_, String>(0)?)?,
-                    history_record_id: parse_optional_uuid(row.get(1)?)?,
-                    session_id: parse_optional_uuid(row.get(2)?)?,
-                    run_id: parse_optional_uuid(row.get(3)?)?,
-                    seq: nonnegative_i64_to_u64(row.get(4)?)?,
-                    event_type: parse_text_enum::<EventType>(row.get::<_, String>(5)?)?,
-                    role: parse_optional_text_enum::<EventRole>(row.get(6)?)?,
-                    occurred_at: ms_to_time(row.get(7)?)?,
-                    preview: row.get(8)?,
-                    score: row.get(9)?,
-                    provider: parse_optional_text_enum::<CaptureProvider>(row.get(10)?)?,
-                    session_external_session_id: row.get(11)?,
-                    history_source: source_identity.history_source,
-                    history_source_plugin: source_identity.history_source_plugin,
-                    provider_key: source_identity.provider_key,
-                    source_id: source_identity.source_id,
-                    source_format: source_identity.source_format,
-                    session_parent_session_id: parse_optional_uuid(row.get(12)?)?,
-                    session_root_session_id: parse_optional_uuid(row.get(13)?)?,
-                    agent_type: parse_optional_text_enum::<AgentType>(row.get(14)?)?,
-                    session_is_primary: row.get::<_, Option<i64>>(15)?.map(|value| value != 0),
-                    cwd: row.get(16)?,
-                    raw_source_path: row.get(17)?,
-                    cursor: event_search_cursor(&payload_json, source_metadata_json.as_deref())?,
-                    record_title: row.get(20)?,
-                    record_kind: row.get(21)?,
-                    record_workspace: row.get(22)?,
-                })
-            },
-        )?;
-        collect_rows(rows)
+        match (match_query, scriptgram_query) {
+            (Some(match_query), Some(scriptgram_query)) => {
+                let sql = format!(
+                    r#"
+                    WITH matches(event_id, score) AS (
+                        SELECT event_search.event_id, bm25(event_search)
+                        FROM event_search
+                        WHERE event_search MATCH ?1
+                        UNION ALL
+                        SELECT event_search_scriptgram.event_id, bm25(event_search_scriptgram) + 0.35
+                        FROM event_search_scriptgram
+                        WHERE event_search_scriptgram MATCH ?2
+                    ),
+                    ranked(event_id, score) AS (
+                        SELECT event_id, MIN(score)
+                        FROM matches
+                        GROUP BY event_id
+                    )
+                    {}
+                    LIMIT ?3 OFFSET ?4
+                    "#,
+                    event_search_hit_sql(
+                        "ranked JOIN event_search ON event_search.event_id = ranked.event_id",
+                        "ranked.score",
+                        "ORDER BY ranked.score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
+                    )
+                );
+                let mut stmt = self.conn.prepare(&sql)?;
+                let rows = stmt.query_map(
+                    params![
+                        match_query,
+                        scriptgram_query,
+                        limit.max(1) as i64,
+                        offset as i64
+                    ],
+                    event_search_hit_from_row,
+                )?;
+                collect_rows(rows)
+            }
+            (Some(match_query), None) => {
+                let sql = format!(
+                    "{} LIMIT ?2 OFFSET ?3",
+                    event_search_hit_sql(
+                        "event_search",
+                        "bm25(event_search)",
+                        "WHERE event_search MATCH ?1 ORDER BY search_score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
+                    )
+                );
+                let mut stmt = self.conn.prepare(&sql)?;
+                let rows = stmt.query_map(
+                    params![match_query, limit.max(1) as i64, offset as i64],
+                    event_search_hit_from_row,
+                )?;
+                collect_rows(rows)
+            }
+            (None, Some(scriptgram_query)) => {
+                let sql = format!(
+                    "{} LIMIT ?2 OFFSET ?3",
+                    event_search_hit_sql(
+                        "event_search_scriptgram JOIN event_search ON event_search.event_id = event_search_scriptgram.event_id",
+                        "bm25(event_search_scriptgram) + 0.35",
+                        "WHERE event_search_scriptgram MATCH ?1 ORDER BY search_score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
+                    )
+                );
+                let mut stmt = self.conn.prepare(&sql)?;
+                let rows = stmt.query_map(
+                    params![scriptgram_query, limit.max(1) as i64, offset as i64],
+                    event_search_hit_from_row,
+                )?;
+                collect_rows(rows)
+            }
+            (None, None) => Ok(Vec::new()),
+        }
     }
 
     pub(crate) fn rebuild_search_projection(&self) -> Result<()> {
@@ -180,15 +185,97 @@ impl Store {
     }
 }
 
+fn event_search_hit_sql(from_sql: &str, score_sql: &str, tail_sql: &str) -> String {
+    format!(
+        r#"
+        SELECT event_search.event_id,
+               COALESCE(e.history_record_id, event_search.history_record_id, s.history_record_id, rs.history_record_id),
+               COALESCE(e.session_id, event_search.session_id, s.id, rs.id),
+               e.run_id,
+               e.seq,
+               e.event_type,
+               e.role,
+               e.occurred_at_ms,
+               event_search.preview_text,
+               {score_sql} AS search_score,
+               COALESCE(s.provider, rs.provider, event_source.provider, session_source.provider, run_source.provider),
+               COALESCE(s.external_session_id, rs.external_session_id),
+               COALESCE(s.parent_session_id, rs.parent_session_id),
+               COALESCE(s.root_session_id, rs.root_session_id),
+               COALESCE(s.agent_type, rs.agent_type),
+               COALESCE(s.is_primary, rs.is_primary),
+               COALESCE(event_source.cwd, session_source.cwd, run_source.cwd),
+               COALESCE(event_source.raw_source_path, session_source.raw_source_path, run_source.raw_source_path),
+               e.payload_json,
+               COALESCE(event_source.metadata_json, session_source.metadata_json, run_source.metadata_json),
+               wr.title,
+               wr.kind,
+               wr.workspace
+        FROM {from_sql}
+        JOIN events e ON e.id = event_search.event_id
+        LEFT JOIN runs r ON r.id = e.run_id
+        LEFT JOIN sessions s ON s.id = COALESCE(e.session_id, event_search.session_id)
+        LEFT JOIN sessions rs ON rs.id = r.session_id
+        LEFT JOIN capture_sources event_source ON event_source.id = e.capture_source_id
+        LEFT JOIN capture_sources session_source ON session_source.id = COALESCE(s.capture_source_id, rs.capture_source_id)
+        LEFT JOIN capture_sources run_source ON run_source.id = r.source_id
+        LEFT JOIN history_records wr ON wr.id = COALESCE(e.history_record_id, event_search.history_record_id, s.history_record_id, rs.history_record_id, r.history_record_id)
+        {tail_sql}
+        "#
+    )
+}
+
+fn event_search_hit_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EventSearchHit> {
+    let payload_json = row.get::<_, String>(18)?;
+    let source_metadata_json = row.get::<_, Option<String>>(19)?;
+    let source_identity = event_search_source_identity(source_metadata_json.as_deref())?;
+    Ok(EventSearchHit {
+        event_id: parse_uuid(row.get::<_, String>(0)?)?,
+        history_record_id: parse_optional_uuid(row.get(1)?)?,
+        session_id: parse_optional_uuid(row.get(2)?)?,
+        run_id: parse_optional_uuid(row.get(3)?)?,
+        seq: nonnegative_i64_to_u64(row.get(4)?)?,
+        event_type: parse_text_enum::<EventType>(row.get::<_, String>(5)?)?,
+        role: parse_optional_text_enum::<EventRole>(row.get(6)?)?,
+        occurred_at: ms_to_time(row.get(7)?)?,
+        preview: row.get(8)?,
+        score: row.get(9)?,
+        provider: parse_optional_text_enum::<CaptureProvider>(row.get(10)?)?,
+        session_external_session_id: row.get(11)?,
+        history_source: source_identity.history_source,
+        history_source_plugin: source_identity.history_source_plugin,
+        provider_key: source_identity.provider_key,
+        source_id: source_identity.source_id,
+        source_format: source_identity.source_format,
+        session_parent_session_id: parse_optional_uuid(row.get(12)?)?,
+        session_root_session_id: parse_optional_uuid(row.get(13)?)?,
+        agent_type: parse_optional_text_enum::<AgentType>(row.get(14)?)?,
+        session_is_primary: row.get::<_, Option<i64>>(15)?.map(|value| value != 0),
+        cwd: row.get(16)?,
+        raw_source_path: row.get(17)?,
+        cursor: event_search_cursor(&payload_json, source_metadata_json.as_deref())?,
+        record_title: row.get(20)?,
+        record_kind: row.get(21)?,
+        record_workspace: row.get(22)?,
+    })
+}
+
 pub(crate) fn rebuild_search_projection(conn: &Connection) -> Result<()> {
     if !table_exists(conn, "ctx_history_search")? {
         return Ok(());
     }
 
     conn.execute("DELETE FROM ctx_history_search", [])?;
+    let has_record_scriptgram = record_scriptgram_table_ready(conn)?;
+    if has_record_scriptgram {
+        conn.execute("DELETE FROM ctx_history_search_scriptgram", [])?;
+    }
     let has_event_search = table_exists(conn, "event_search")?;
     if has_event_search {
         conn.execute("DELETE FROM event_search", [])?;
+        if event_scriptgram_table_ready(conn)? {
+            conn.execute("DELETE FROM event_search_scriptgram", [])?;
+        }
         populate_event_search_projection(conn)?;
     }
     if table_exists(conn, "artifact_search")? {
@@ -208,6 +295,17 @@ pub(crate) fn rebuild_search_projection(conn: &Connection) -> Result<()> {
         VALUES (?1, ?2, ?3, ?4, '', ?5, ?6)
         "#,
     )?;
+    let mut insert_record_scriptgram = if has_record_scriptgram {
+        Some(conn.prepare(
+            r#"
+            INSERT INTO ctx_history_search_scriptgram
+            (record_id, token_text)
+            VALUES (?1, ?2)
+            "#,
+        )?)
+    } else {
+        None
+    };
     for record in records {
         insert_record_search.execute(params![
             record.id.to_string(),
@@ -217,6 +315,12 @@ pub(crate) fn rebuild_search_projection(conn: &Connection) -> Result<()> {
             "",
             local_preview(&record.tags.join(" "), 1024),
         ])?;
+        if let Some(insert_record_scriptgram) = insert_record_scriptgram.as_mut() {
+            let token_text = scriptgram_index_text(&record_search_scriptgram_source(&record));
+            if !token_text.is_empty() {
+                insert_record_scriptgram.execute(params![record.id.to_string(), token_text])?;
+            }
+        }
     }
 
     Ok(())
@@ -233,6 +337,12 @@ pub(crate) fn upsert_record_search_projection(
         "DELETE FROM ctx_history_search WHERE record_id = ?1",
         params![record.id.to_string()],
     )?;
+    if record_scriptgram_table_ready(conn)? {
+        conn.execute(
+            "DELETE FROM ctx_history_search_scriptgram WHERE record_id = ?1",
+            params![record.id.to_string()],
+        )?;
+    }
     conn.execute(
         r#"
         INSERT INTO ctx_history_search
@@ -248,7 +358,67 @@ pub(crate) fn upsert_record_search_projection(
             local_preview(&record.tags.join(" "), 1024),
         ],
     )?;
+    if record_scriptgram_table_ready(conn)? {
+        let token_text = scriptgram_index_text(&record_search_scriptgram_source(record));
+        if !token_text.is_empty() {
+            conn.execute(
+                r#"
+                INSERT INTO ctx_history_search_scriptgram
+                (record_id, token_text)
+                VALUES (?1, ?2)
+                "#,
+                params![record.id.to_string(), token_text],
+            )?;
+        }
+    }
     Ok(())
+}
+
+fn record_search_scriptgram_source(record: &HistoryRecord) -> String {
+    [
+        local_preview(&record.title, 512),
+        local_preview(&record.body, 2048),
+        local_preview(&record.tags.join(" "), 1024),
+    ]
+    .into_iter()
+    .filter(|part| !part.trim().is_empty())
+    .collect::<Vec<_>>()
+    .join(" ")
+}
+
+pub(crate) fn record_scriptgram_table_ready(conn: &Connection) -> Result<bool> {
+    fts_table_has_columns(
+        conn,
+        "ctx_history_search_scriptgram",
+        &["record_id", "token_text"],
+    )
+}
+
+pub(crate) fn event_scriptgram_table_ready(conn: &Connection) -> Result<bool> {
+    fts_table_has_columns(
+        conn,
+        "event_search_scriptgram",
+        &[
+            "event_id",
+            "history_record_id",
+            "session_id",
+            "role",
+            "token_text",
+            "rank_bucket",
+        ],
+    )
+}
+
+fn fts_table_has_columns(conn: &Connection, table: &str, required: &[&str]) -> Result<bool> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    let mut columns = Vec::new();
+    for row in rows {
+        columns.push(row?);
+    }
+    Ok(required
+        .iter()
+        .all(|required| columns.iter().any(|column| column == required)))
 }
 
 fn ensure_search_projection_initialized(conn: &Connection) -> Result<()> {
@@ -259,6 +429,9 @@ fn ensure_search_projection_initialized(conn: &Connection) -> Result<()> {
     let mut projection_rows = table_row_count(conn, "ctx_history_search")?;
     if table_exists(conn, "event_search")? {
         projection_rows += table_row_count(conn, "event_search")?;
+    }
+    if event_scriptgram_table_ready(conn)? {
+        projection_rows += table_row_count(conn, "event_search_scriptgram")?;
     }
     if table_exists(conn, "artifact_search")? {
         projection_rows += table_row_count(conn, "artifact_search")?;
@@ -279,8 +452,14 @@ fn ensure_search_projection_initialized(conn: &Connection) -> Result<()> {
 
 fn table_row_count(conn: &Connection, table: &str) -> Result<i64> {
     match table {
-        "artifacts" | "artifact_search" | "events" | "event_search" | "history_records"
-        | "ctx_history_search" => {}
+        "artifacts"
+        | "artifact_search"
+        | "events"
+        | "event_search"
+        | "event_search_scriptgram"
+        | "history_records"
+        | "ctx_history_search"
+        | "ctx_history_search_scriptgram" => {}
         _ => unreachable!("invalid table {table}"),
     }
     let sql = format!("SELECT COUNT(*) FROM {table}");
@@ -325,6 +504,18 @@ fn populate_event_search_projection(conn: &Connection) -> Result<()> {
         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
         "#,
     )?;
+    let has_event_scriptgram = event_scriptgram_table_ready(conn)?;
+    let mut insert_event_scriptgram = if has_event_scriptgram {
+        Some(conn.prepare(
+            r#"
+            INSERT INTO event_search_scriptgram
+            (event_id, history_record_id, session_id, role, token_text, rank_bucket)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            "#,
+        )?)
+    } else {
+        None
+    };
     for row in rows {
         let (event_id, history_record_id, session_id, role, event_type, payload_json) = row?;
         let event_type = event_type.parse::<EventType>().map_err(|err| {
@@ -353,6 +544,19 @@ fn populate_event_search_projection(conn: &Connection) -> Result<()> {
             preview,
             event_type.as_str()
         ])?;
+        if let Some(insert_event_scriptgram) = insert_event_scriptgram.as_mut() {
+            let token_text = scriptgram_index_text(&preview);
+            if !token_text.is_empty() {
+                insert_event_scriptgram.execute(params![
+                    event_id,
+                    history_record_id,
+                    session_id,
+                    role.map(|role| role.as_str()),
+                    token_text,
+                    event_type.as_str()
+                ])?;
+            }
+        }
     }
     Ok(())
 }
@@ -361,7 +565,16 @@ pub(crate) fn insert_event_search_projection_for_event(
     conn: &Connection,
     event: &Event,
 ) -> Result<()> {
-    insert_event_search_projection_for_event_id(conn, event.id, event)
+    if !table_exists(conn, "event_search")? {
+        return Ok(());
+    }
+    let has_event_scriptgram = event_scriptgram_table_ready(conn)?;
+    insert_event_search_projection_for_event_id_with_sidecar(
+        conn,
+        event.id,
+        event,
+        has_event_scriptgram,
+    )
 }
 
 pub(crate) fn upsert_event_search_projection_for_event(
@@ -372,21 +585,31 @@ pub(crate) fn upsert_event_search_projection_for_event(
     if !table_exists(conn, "event_search")? {
         return Ok(());
     }
+    let has_event_scriptgram = event_scriptgram_table_ready(conn)?;
     conn.execute(
         "DELETE FROM event_search WHERE event_id = ?1",
         params![event_id.to_string()],
     )?;
-    insert_event_search_projection_for_event_id(conn, event_id, event)
+    if has_event_scriptgram {
+        conn.execute(
+            "DELETE FROM event_search_scriptgram WHERE event_id = ?1",
+            params![event_id.to_string()],
+        )?;
+    }
+    insert_event_search_projection_for_event_id_with_sidecar(
+        conn,
+        event_id,
+        event,
+        has_event_scriptgram,
+    )
 }
 
-pub(crate) fn insert_event_search_projection_for_event_id(
+fn insert_event_search_projection_for_event_id_with_sidecar(
     conn: &Connection,
     event_id: Uuid,
     event: &Event,
+    has_event_scriptgram: bool,
 ) -> Result<()> {
-    if !table_exists(conn, "event_search")? {
-        return Ok(());
-    }
     let preview = event_search_preview_from_payload(event.event_type, event.role, &event.payload);
     if preview.trim().is_empty() {
         return Ok(());
@@ -406,6 +629,26 @@ pub(crate) fn insert_event_search_projection_for_event_id(
         preview,
         event.event_type.as_str(),
     ])?;
+    if has_event_scriptgram {
+        let token_text = scriptgram_index_text(&preview);
+        if !token_text.is_empty() {
+            conn.prepare_cached(
+                r#"
+                INSERT INTO event_search_scriptgram
+                (event_id, history_record_id, session_id, role, token_text, rank_bucket)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                "#,
+            )?
+            .execute(params![
+                event_id.to_string(),
+                optional_uuid_string(event.history_record_id),
+                optional_uuid_string(event.session_id),
+                event.role.map(|role| role.as_str()),
+                token_text,
+                event.event_type.as_str(),
+            ])?;
+        }
+    }
     Ok(())
 }
 

--- a/crates/ctx-history-store/src/search/tests.rs
+++ b/crates/ctx-history-store/src/search/tests.rs
@@ -177,6 +177,20 @@ fn stable_tie_record(index: u16) -> HistoryRecord {
     record
 }
 
+fn record_with_id(id: &str, title: &str, body: &str) -> HistoryRecord {
+    let mut record = HistoryRecord::new(
+        title,
+        body,
+        Vec::new(),
+        "task",
+        Some("/workspace/multilingual".into()),
+    );
+    record.id = Uuid::parse_str(id).unwrap();
+    record.created_at = fixed_time();
+    record.updated_at = fixed_time();
+    record
+}
+
 fn assert_search_order(store: &Store, expected: &[Uuid]) {
     let actual = store
         .search_records("stabletie", 10)
@@ -227,6 +241,90 @@ fn search_records_empty_or_no_token_query_returns_empty() {
 }
 
 #[test]
+fn search_records_still_matches_latin_code_tokens() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let record = record_with_id(
+        "018f45d0-0000-7000-8000-000000080001",
+        "Latin code search",
+        "SearchResultScope Event remains discoverable through normal Latin code tokens.",
+    );
+    store.insert_record(&record).unwrap();
+
+    let hits = store.search_records("SearchResultScope", 10).unwrap();
+    assert!(hits.iter().any(|hit| hit.id == record.id));
+    let sidecar_rows: i64 = store
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM ctx_history_search_scriptgram",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(sidecar_rows, 0);
+}
+
+#[test]
+fn search_records_recalls_unspaced_cjk_and_mixed_script_terms() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let record = record_with_id(
+        "018f45d0-0000-7000-8000-000000080002",
+        "Multilingual script search",
+        "OAuth認証の検索状態を確認し、寿司APIの状態を保存します。中文登录态异常需要重新认证。Korean OAuth인증오류를 재현했습니다.",
+    );
+    store.insert_record(&record).unwrap();
+
+    let mut missing = Vec::new();
+    for (label, query) in [
+        ("japanese auth", "認証"),
+        ("japanese search", "検索"),
+        ("japanese sushi", "寿司"),
+        ("mixed oauth auth", "OAuth 認証"),
+        ("mixed api status", "API 状態"),
+        ("chinese two-char", "认证"),
+        ("chinese three-char", "登录态"),
+        ("korean particle stem", "오류"),
+        ("korean auth", "인증"),
+    ] {
+        let hits = store.search_records(query, 10).unwrap();
+        if !hits.iter().any(|hit| hit.id == record.id) {
+            missing.push(format!("{label}: {query}"));
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "missing multilingual record hits for {}",
+        missing.join(", ")
+    );
+}
+
+#[test]
+fn search_records_merges_fts_and_scriptgram_hits_for_same_query() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let spaced = record_with_id(
+        "018f45d0-0000-7000-8000-000000080003",
+        "Spaced Japanese auth",
+        "認証 検索 tokens remain discoverable through the default FTS tokenizer.",
+    );
+    let unspaced = record_with_id(
+        "018f45d0-0000-7000-8000-000000080004",
+        "Unspaced Japanese auth",
+        "OAuth認証の検索状態を確認します。",
+    );
+    store.insert_record(&spaced).unwrap();
+    store.insert_record(&unspaced).unwrap();
+
+    let hits = store.search_records("認証", 10).unwrap();
+    let hit_ids = hits.iter().map(|hit| hit.id).collect::<Vec<_>>();
+
+    assert!(hit_ids.contains(&spaced.id), "missing default FTS hit");
+    assert!(hit_ids.contains(&unspaced.id), "missing scriptgram hit");
+}
+
+#[test]
 fn event_search_preserves_local_payload_text() {
     let temp = tempdir();
     let store = Store::open(temp.path().join("work.sqlite")).unwrap();
@@ -265,6 +363,57 @@ fn event_search_preserves_local_payload_text() {
 
     let hits = store.search_event_hits("rawmarker", 10).unwrap();
     assert!(hits.iter().any(|hit| hit.event_id == raw_event.id));
+}
+
+#[test]
+fn event_search_recalls_unspaced_cjk_and_mixed_script_terms() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let japanese = local_preview_event(
+        1,
+        "OAuth認証の検索状態を確認し、寿司APIの状態を保存します。",
+    );
+    let chinese = local_preview_event(2, "中文登录态异常需要重新认证并检查搜索索引。");
+    let korean = local_preview_event(3, "OAuth인증오류를 재현하고 API상태를 기록했습니다.");
+    let latin = local_preview_event(
+        4,
+        "SearchResultScope Event remains discoverable through normal Latin code tokens.",
+    );
+    for event in [&japanese, &chinese, &korean, &latin] {
+        store.upsert_event(event).unwrap();
+    }
+    let sidecar_rows: i64 = store
+        .conn
+        .query_row("SELECT COUNT(*) FROM event_search_scriptgram", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(sidecar_rows, 3);
+
+    let mut missing = Vec::new();
+    for (label, query, expected_event_id) in [
+        ("japanese auth", "認証", japanese.id),
+        ("japanese search", "検索", japanese.id),
+        ("japanese sushi", "寿司", japanese.id),
+        ("mixed oauth auth", "OAuth 認証", japanese.id),
+        ("mixed api status", "API 状態", japanese.id),
+        ("chinese two-char", "认证", chinese.id),
+        ("chinese three-char", "登录态", chinese.id),
+        ("korean particle stem", "오류", korean.id),
+        ("korean auth", "인증", korean.id),
+        ("latin code", "SearchResultScope", latin.id),
+    ] {
+        let hits = store.search_event_hits(query, 10).unwrap();
+        if !hits.iter().any(|hit| hit.event_id == expected_event_id) {
+            missing.push(format!("{label}: {query}"));
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "missing multilingual event hits for {}",
+        missing.join(", ")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add scriptgram FTS sidecar tables for scripts that default SQLite FTS tokenizes poorly
- merge scriptgram hits with normal record/event FTS only for covered non-Latin queries
- add v45 migration/backfill plus multilingual regression coverage

## Impact
English/code-only text and queries stay on the existing FTS path and do not populate the sidecar. Multilingual rows get additional sidecar tokens for Japanese, Chinese, Korean, Thai/Lao/Khmer/Myanmar, and major Indic scripts.

## Validation
- cargo test -p ctx-history-store
- cargo test -p ctx-history-search
- cargo test --workspace
- dogfooded real ctx import/search against ctx-history-jsonl-v1 fixture for 認証, OAuth 認証, 登录态, 오류, and SearchResultScope