### PR TITLE
Prepare ctx 0.24.0 release candidate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "ctx"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-capture"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "chrono",
  "directories",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-search"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "chrono",
  "ctx-history-core",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-store"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "chrono",
  "ctx-history-core",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,8 +1,12 @@
-module(name = "ctx_search", version = "0.22.0")
+module(
+    name = "ctx_search",
+    version = "0.22.0",
+)
 
 bazel_dep(name = "rules_rust", version = "0.71.3")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+
 # Native Bazel Rust uses the same toolchain as public CI. The workspace
 # rust-version remains package MSRV metadata; MSRV enforcement belongs in a
 # separate explicit lane rather than in this CI parity graph.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -97,16 +97,16 @@
         "usagesDigest": "trZT1wMYy/tgV92a1ogDlCDavOm0R9plXCfxm6DTWdw=",
         "recordedFileInputs": {
           "@@//crates/ctx-sdk/Cargo.toml": "36d7b44b8415faf5a6b81989f92d421ad145f43a8bf822a08599ebf5c56b2b2c",
-          "@@//crates/ctx-cli/Cargo.toml": "89857fdac9e37ee1c92edc7048417662383425fddc2b04cafab326f8fcf82791",
-          "@@//crates/ctx-history-core/Cargo.toml": "d9de142ec35f3a17ef8a0c6a2993b541681a217aeed74b5942f233c29ce64127",
+          "@@//crates/ctx-cli/Cargo.toml": "b4dddb0f96739adf6946aa716a41735598cac2d0ea33250e87a17921dfe9ddc9",
+          "@@//crates/ctx-history-core/Cargo.toml": "b96429c1c01bc372c165697d51c62c814f1d9f5b3f78df538f8eca42239b105a",
           "@@//Cargo.toml": "6efe5f0db516ea552124aba34912d46d4075cc956fcb0f4dde1e0f4f9b059ef6",
-          "@@//Cargo.lock": "a7ab59634d425d5746598146dd8d82112d526bb07ecac3b10abd523148f5cce9",
+          "@@//Cargo.lock": "28bcfe1349c3b96727d26eb4d6f4cf08e44e2d13e7fa4e5da1ad868b45d84d2d",
           "@@//crates/ctx-protocol/Cargo.toml": "e9e75a7c7ca116f86e58ee0e09d174612607c8c45cce0213e66825e403046bce",
-          "@@//crates/ctx-history-store/Cargo.toml": "d4d30eb58b46fbea6c5b22697dceea3c04ea043d5d8a354e3944aebb196b406f",
+          "@@//crates/ctx-history-store/Cargo.toml": "082c0a34d1ac15f957d43b582c80b868be113a80bf648475b3172b40699b82e1",
           "@@//MODULE.bazel": "af5bf753c78e7ff90e70ecf56be23084a9496332722600ddc72ac42e899f448f",
           "@@rules_rust~~rust_host_tools~rust_host_tools//rust_host_tools": "ENOENT",
-          "@@//crates/ctx-history-search/Cargo.toml": "fd6ad521656e0128b5af111b261b746e6815bfb46a30535e9746d9437b4bafe2",
-          "@@//crates/ctx-history-capture/Cargo.toml": "01c355f01ae979d67cd9238127ce9e926dc54b095de67bf67a464b085e38f589"
+          "@@//crates/ctx-history-search/Cargo.toml": "0453edbe6568f321cbe47d7eaabdacb619df575bcb832fbd3b3224f58554cf53",
+          "@@//crates/ctx-history-capture/Cargo.toml": "3812ff4f4e7f257c8856ecbd5f719059c164bcf53e73da551898fccf5226efec"
         },
         "recordedDirentsInputs": {},
         "envVariables": {

--- a/crates/ctx-cli/Cargo.toml
+++ b/crates/ctx-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx"
-version = "0.23.0"
+version = "0.24.0"
 description = "Local CLI for indexing and searching agent session history"
 edition.workspace = true
 autobins = false

--- a/crates/ctx-history-capture/Cargo.toml
+++ b/crates/ctx-history-capture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-capture"
-version = "0.23.0"
+version = "0.24.0"
 description = "Internal provider import adapters for ctx local agent history"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-core/Cargo.toml
+++ b/crates/ctx-history-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-core"
-version = "0.23.0"
+version = "0.24.0"
 description = "Internal core types for ctx local agent history indexing"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-search/Cargo.toml
+++ b/crates/ctx-history-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-search"
-version = "0.23.0"
+version = "0.24.0"
 description = "Internal search projection and ranking helpers for ctx"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-store/Cargo.toml
+++ b/crates/ctx-history-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-store"
-version = "0.23.0"
+version = "0.24.0"
 description = "Internal SQLite storage layer for ctx local agent history"
 edition.workspace = true
 license.workspace = true

--- a/docs/unmanaged-installs.md
+++ b/docs/unmanaged-installs.md
@@ -43,8 +43,8 @@ https://github.com/ctxrs/ctx/releases/download/vVERSION/ASSET
 For example:
 
 ```text
-https://github.com/ctxrs/ctx/releases/download/v0.23.0/ctx-linux-x64
-https://github.com/ctxrs/ctx/releases/download/v0.23.0/SHA256SUMS
+https://github.com/ctxrs/ctx/releases/download/v0.24.0/ctx-linux-x64
+https://github.com/ctxrs/ctx/releases/download/v0.24.0/SHA256SUMS
 ```
 
 ## Direct GitHub Download
@@ -85,7 +85,7 @@ mise use -g 'github:ctxrs/ctx[bin=ctx]@latest'
 For a pinned install, replace `latest` with a release version:
 
 ```bash
-mise use -g 'github:ctxrs/ctx[bin=ctx]@0.23.0'
+mise use -g 'github:ctxrs/ctx[bin=ctx]@0.24.0'
 ```
 
 mise owns upgrades for this install. Re-run `ctx integrations install skills` after upgrading

--- a/scripts/real-harness-codex-skill-e2e.sh
+++ b/scripts/real-harness-codex-skill-e2e.sh
@@ -136,12 +136,12 @@ main() {
 
   require_contains "${stdout_file}" 'fixture-ctx-skill-ok'
   require_contains "${stderr_file}" "/bin/bash -lc 'ctx --version'"
-  require_contains "${stderr_file}" 'ctx 0.23.0'
+  require_contains "${stderr_file}" 'ctx 0.24.0'
   require_contains "${log_file}" '"has_ctx_skill":true'
   require_contains "${log_file}" '"has_ctx_skill_description":true'
   require_contains "${log_file}" '"has_ctx_skill_path":true'
   require_contains "${log_file}" '"call_id":"call_ctx_version"'
-  require_contains "${log_file}" 'ctx 0.23.0'
+  require_contains "${log_file}" 'ctx 0.24.0'
 
   printf 'real Codex skill harness E2E passed: %s\n' "${run_root}"
 }


### PR DESCRIPTION
## Summary

- Prepare ctx 0.24.0 release candidate after the semantic search/daemon indexing merge.
- Bump public CLI/runtime crate versions and Cargo.lock from 0.23.0 to 0.24.0.
- Refresh Bazel module lock metadata and unmanaged install examples for v0.24.0.

## Validation

- `cargo metadata --no-deps --format-version 1 --locked`
- `bazel mod tidy`
- `scripts/build-public-cli-artifact.sh linux-x64`
- `scripts/check-public-cli-artifact.sh linux-x64 target/public-cli-artifacts`
- Isolated local smoke with staged binary: empty status, setup without daemon/config write, custom JSONL import, lexical search, daemon disabled status, hybrid fallback to lexical with `semantic_disabled`.

## Local Release Smoke

- Artifact: `target/public-cli-artifacts/ctx`
- Version: `ctx 0.24.0`
- SHA256: `c2219c2b15203fbee50b3137e08bb01d2e8e5fbfc2051fd5bd6865e159fc9c21`
- Build timing: `6:37.01` wall, peak RSS `740856 KB`.
