### PR TITLE
Fix Factory AI Droid import failures, support old and new session formats w/ nested message content/role

### DIFF
--- a/crates/ctx-cli/tests/support/native_fixtures/json_tree.rs
+++ b/crates/ctx-cli/tests/support/native_fixtures/json_tree.rs
@@ -712,7 +712,7 @@ pub(crate) fn write_native_factory_droid_fixture(temp: &TempDir, query: &str) ->
             "{}\n{}\n",
             json!({
                 "type": "session_start",
-                "sessionId": "droid-cli-native",
+                "id": "droid-cli-native",
                 "timestamp": "2026-06-24T12:00:00Z",
                 "cwd": "/workspace",
                 "model": "factory/droid"
@@ -721,8 +721,10 @@ pub(crate) fn write_native_factory_droid_fixture(temp: &TempDir, query: &str) ->
                 "type": "message",
                 "id": "droid-cli-native-user",
                 "timestamp": "2026-06-24T12:00:01Z",
-                "role": "user",
-                "content": [{"type": "text", "text": query}]
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": query}]
+                }
             })
         ),
     )

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl.rs
@@ -355,7 +355,12 @@ pub(crate) fn native_jsonl_header_session_id(
         }
         CaptureProvider::FactoryAiDroid => (value.get("type").and_then(Value::as_str)
             == Some("session_start"))
-        .then(|| value.get("sessionId").and_then(Value::as_str))
+        .then(|| {
+            value
+                .get("sessionId")
+                .or_else(|| value.get("id"))
+                .and_then(Value::as_str)
+        })
         .flatten(),
         CaptureProvider::CopilotCli => (value.get("type").and_then(Value::as_str)
             == Some("session.start"))
@@ -768,7 +773,12 @@ pub(crate) fn native_jsonl_role(provider: CaptureProvider, value: &Value) -> Eve
                 _ => EventRole::System,
             }
         }
-        CaptureProvider::FactoryAiDroid => provider_role(value.get("role").and_then(Value::as_str)),
+        CaptureProvider::FactoryAiDroid => provider_role(
+            value
+                .get("role")
+                .or_else(|| value.pointer("/message/role"))
+                .and_then(Value::as_str),
+        ),
         CaptureProvider::CopilotCli => match value.get("type").and_then(Value::as_str) {
             Some("user.message") => EventRole::User,
             Some("assistant.message") => EventRole::Assistant,
@@ -837,6 +847,7 @@ pub(crate) fn native_jsonl_event_text(
             .unwrap_or_default(),
         CaptureProvider::FactoryAiDroid => value
             .get("content")
+            .or_else(|| value.pointer("/message/content"))
             .and_then(provider_value_text)
             .or_else(|| {
                 value
@@ -909,6 +920,7 @@ pub(crate) fn native_jsonl_model(provider: CaptureProvider, value: &Value) -> Op
         CaptureProvider::FactoryAiDroid => value
             .get("model")
             .cloned()
+            .or_else(|| value.pointer("/message/model").cloned())
             .or_else(|| value.pointer("/metadata/model").cloned()),
         CaptureProvider::CopilotCli => value.pointer("/data/selectedModel").cloned(),
         CaptureProvider::QwenCode => value
@@ -941,6 +953,7 @@ pub(crate) fn gemini_tool_calls_have_result(value: &Value) -> bool {
 pub(crate) fn droid_content_has(value: &Value, expected: &str) -> bool {
     value
         .get("content")
+        .or_else(|| value.pointer("/message/content"))
         .and_then(Value::as_array)
         .map(|blocks| {
             blocks

--- a/crates/ctx-history-capture/src/tests/native_json.rs
+++ b/crates/ctx-history-capture/src/tests/native_json.rs
@@ -2692,3 +2692,105 @@ fn native_lingma_normalizer_rejects_symlinked_sqlite() {
                 && reason == "symlinked provider transcript files are rejected"
     ));
 }
+
+#[test]
+fn native_factory_ai_droid_supports_new_session_format() {
+    // Use project temp dir to avoid macOS /var symlink issues
+    let temp_dir = std::env::current_dir().unwrap().join("target/test-temp");
+    fs::create_dir_all(&temp_dir).unwrap();
+    let temp = tempfile::Builder::new().tempdir_in(&temp_dir).unwrap();
+    let root = temp.path().join("droid/sessions/project");
+    fs::create_dir_all(&root).unwrap();
+
+    // Test the new format: "id" instead of "sessionId", nested message.content/role
+    let new_content = concat!(
+        "{\"type\":\"session_start\",\"id\":\"droid-new\",\"timestamp\":\"2026-06-24T12:00:00Z\",\"cwd\":\"/workspace\",\"model\":\"factory/droid\"}\n",
+        "{\"type\":\"message\",\"id\":\"msg-1\",\"timestamp\":\"2026-06-24T12:00:01Z\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"droid new format prompt\"}]}}\n",
+        "{\"type\":\"message\",\"id\":\"msg-2\",\"timestamp\":\"2026-06-24T12:00:02Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"tool-1\",\"name\":\"droid_worker\"}]}}\n",
+        "{\"type\":\"message\",\"id\":\"msg-3\",\"timestamp\":\"2026-06-24T12:00:03Z\",\"message\":{\"role\":\"tool\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"tool-1\",\"is_error\":false,\"content\":\"result\"}]}}\n",
+    );
+    fs::write(root.join("droid-new-format.jsonl"), new_content).unwrap();
+
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_factory_ai_droid_sessions(
+        &root,
+        &mut store,
+        FactoryAiDroidImportOptions {
+            source_path: Some(root.clone()),
+            allow_partial_failures: true,
+            ..FactoryAiDroidImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.imported_sessions, 1);
+    assert_eq!(summary.imported_events, 4);
+
+    let session_id =
+        stored_provider_session_id(&store, CaptureProvider::FactoryAiDroid, "droid-new");
+    let events = store.events_for_session(session_id).unwrap();
+    assert_eq!(events.len(), 4);
+    assert_event_type_count(&events, EventType::Message, 1);
+    assert_event_type_count(&events, EventType::ToolCall, 1);
+    assert_event_type_count(&events, EventType::ToolOutput, 1);
+    assert_event_with_role(&events, EventType::ToolOutput, EventRole::Tool);
+    assert_events_have_provider_citations(&events);
+
+    let rendered = serde_json::to_string(&events).unwrap();
+    assert!(rendered.contains("droid new format prompt"));
+    assert!(rendered.contains("droid_worker"));
+    assert!(!rendered.contains("DROID_RAW_TOOL_OUTPUT_SHOULD_NOT_SEARCH"));
+}
+
+#[test]
+fn native_factory_ai_droid_supports_legacy_session_format() {
+    // Use project temp dir to avoid macOS /var symlink issues
+    let temp_dir = std::env::current_dir().unwrap().join("target/test-temp");
+    fs::create_dir_all(&temp_dir).unwrap();
+    let temp = tempfile::Builder::new().tempdir_in(&temp_dir).unwrap();
+    let root = temp.path().join("droid/sessions/project");
+    fs::create_dir_all(&root).unwrap();
+
+    // Test the legacy format: "sessionId" at root, "content" and "role" at message root
+    let legacy_content = concat!(
+        "{\"type\":\"session_start\",\"sessionId\":\"droid-legacy\",\"timestamp\":\"2026-06-24T12:00:00Z\",\"cwd\":\"/workspace\",\"model\":\"factory/droid\"}\n",
+        "{\"type\":\"message\",\"id\":\"msg-1\",\"timestamp\":\"2026-06-24T12:00:01Z\",\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"droid legacy prompt\"}]}\n",
+        "{\"type\":\"message\",\"id\":\"msg-2\",\"timestamp\":\"2026-06-24T12:00:02Z\",\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"tool-1\",\"name\":\"droid_worker\"}]}\n",
+        "{\"type\":\"message\",\"id\":\"msg-3\",\"timestamp\":\"2026-06-24T12:00:03Z\",\"role\":\"tool\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"tool-1\",\"content\":\"legacy result\"}]}\n",
+    );
+    fs::write(root.join("droid-legacy.jsonl"), legacy_content).unwrap();
+
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_factory_ai_droid_sessions(
+        &root,
+        &mut store,
+        FactoryAiDroidImportOptions {
+            source_path: Some(root.clone()),
+            allow_partial_failures: true,
+            ..FactoryAiDroidImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.imported_sessions, 1);
+    assert_eq!(summary.imported_events, 4);
+
+    let session_id =
+        stored_provider_session_id(&store, CaptureProvider::FactoryAiDroid, "droid-legacy");
+    let events = store.events_for_session(session_id).unwrap();
+    assert_eq!(events.len(), 4);
+    assert_event_type_count(&events, EventType::Message, 1);
+    assert_event_type_count(&events, EventType::ToolCall, 1);
+    assert_event_type_count(&events, EventType::ToolOutput, 1);
+    assert_event_with_role(&events, EventType::ToolOutput, EventRole::Tool);
+    assert_events_have_provider_citations(&events);
+
+    let rendered = serde_json::to_string(&events).unwrap();
+    assert!(rendered.contains("droid legacy prompt"));
+    assert!(rendered.contains("droid_worker"));
+    assert!(!rendered.contains("DROID_RAW_TOOL_OUTPUT_SHOULD_NOT_SEARCH"));
+}

--- a/crates/ctx-history-capture/src/tests/support.rs
+++ b/crates/ctx-history-capture/src/tests/support.rs
@@ -1695,18 +1695,18 @@ pub(super) fn write_droid_smoke_fixture(temp: &TempDir) -> PathBuf {
     fs::write(
             root.join("droid-root.jsonl"),
             concat!(
-                "{\"type\":\"session_start\",\"sessionId\":\"droid-root\",\"timestamp\":\"2026-06-24T12:00:00Z\",\"cwd\":\"/workspace\",\"model\":\"factory/droid\"}\n",
-                "{\"type\":\"message\",\"id\":\"droid-user\",\"timestamp\":\"2026-06-24T12:00:01Z\",\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"droid jsonl oracle prompt\"}]}\n",
-                "{\"type\":\"message\",\"id\":\"droid-tool\",\"timestamp\":\"2026-06-24T12:00:02Z\",\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"tool-1\",\"name\":\"droid_worker\"}]}\n",
-                "{\"type\":\"message\",\"id\":\"droid-tool-result\",\"timestamp\":\"2026-06-24T12:00:03Z\",\"role\":\"tool\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"tool-1\",\"content\":\"DROID_RAW_TOOL_OUTPUT_SHOULD_NOT_SEARCH\"}]}\n",
+                "{\"type\":\"session_start\",\"id\":\"droid-root\",\"timestamp\":\"2026-06-24T12:00:00Z\",\"cwd\":\"/workspace\",\"model\":\"factory/droid\"}\n",
+                "{\"type\":\"message\",\"id\":\"droid-user\",\"timestamp\":\"2026-06-24T12:00:01Z\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"droid jsonl oracle prompt\"}]}}\n",
+                "{\"type\":\"message\",\"id\":\"droid-tool\",\"timestamp\":\"2026-06-24T12:00:02Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"tool-1\",\"name\":\"droid_worker\"}]}}\n",
+                "{\"type\":\"message\",\"id\":\"droid-tool-result\",\"timestamp\":\"2026-06-24T12:00:03Z\",\"message\":{\"role\":\"tool\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"tool-1\",\"content\":\"DROID_RAW_TOOL_OUTPUT_SHOULD_NOT_SEARCH\"}]}}\n",
             ),
         )
         .unwrap();
     fs::write(
             root.join("droid-child.jsonl"),
             concat!(
-                "{\"type\":\"session_start\",\"sessionId\":\"droid-child\",\"timestamp\":\"2026-06-24T12:00:04Z\",\"cwd\":\"/workspace\",\"model\":\"factory/droid\",\"parent\":\"droid-root\",\"decompSessionType\":\"worker\"}\n",
-                "{\"type\":\"message\",\"id\":\"droid-child-user\",\"timestamp\":\"2026-06-24T12:00:05Z\",\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"droid child oracle prompt\"}]}\n",
+                "{\"type\":\"session_start\",\"id\":\"droid-child\",\"timestamp\":\"2026-06-24T12:00:04Z\",\"cwd\":\"/workspace\",\"model\":\"factory/droid\",\"parent\":\"droid-root\",\"decompSessionType\":\"worker\"}\n",
+                "{\"type\":\"message\",\"id\":\"droid-child-user\",\"timestamp\":\"2026-06-24T12:00:05Z\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"droid child oracle prompt\"}]}}\n",
             ),
         )
         .unwrap();


### PR DESCRIPTION
# Fix Factory AI Droid Session Import (new format) + support both formats

## Summary
Fixes the "no importable native JSONL session header" error when importing Factory AI Droid sessions. The adapter now handles both the legacy session format (`sessionId` at root, `role`/`content` at message root) and the new session format (`id` instead of `sessionId`, nested `message.content`/`message.role`).

After investigating trade-offs, this PR focuses on fixing Factory AI Droid session import for users on newer Factory AI Droid versions, while keeping backward compatibility. Discovered, tested and solved for v0.168.2.

Solves https://github.com/ctxrs/ctx/issues/106 and implements backwards compatibility (although I couldn't verify e2e as I don't have the old format, so relying for that in current impl + tests).


## Problem

The Factory AI Droid native JSONL importer only recognized the legacy format:
```json
{"type":"session_start","sessionId":"abc","timestamp":"...","cwd":"/workspace","model":"factory/droid"}
{"type":"message","id":"msg-1","timestamp":"...","role":"user","content":[{"type":"text","text":"prompt"}]}
```

But Factory AI Droid now writes sessions in a new format:
```json
{"type":"session_start","id":"abc","timestamp":"...","cwd":"/workspace","model":"factory/droid"}
{"type":"message","id":"msg-1","timestamp":"...","message":{"role":"user","content":[{"type":"text","text":"prompt"}]}}
```

This caused imports to fail with "no importable native JSONL session header".

## Changes

**crates/ctx-history-capture/src/provider/providers/native_jsonl.rs**
- `native_jsonl_header_session_id`: Accept both `sessionId` and `id`
- `native_jsonl_role`: Check both `role` and `/message/role`
- `native_jsonl_event_text`: Check both `content` and `/message/content`
- `native_jsonl_model`: Check both `model` and `/message/model`
- `droid_content_has`: Check both `content` and `/message/content`

**crates/ctx-history-capture/src/tests/native_json.rs**
- Added `native_factory_ai_droid_supports_new_session_format` test
- Added `native_factory_ai_droid_supports_legacy_session_format` test

## Testing

All new tests pass:
- `native_factory_ai_droid_supports_new_session_format` 
- `native_factory_ai_droid_supports_legacy_session_format` 

Checks:
- All 12 existing provider fixture replay tests (important for back compat)
- `cargo fmt --check --all` 
- `cargo clippy -p ctx-history-capture` 

Before:
```
❯ ctx import --provider factory-ai-droid
Preparing local history...
Found 1 history source (71.8 MiB).
importing factory_ai_droid /Users/<user>/.factory/sessions (183 files, 71.8 MiB)
Error: import factory_ai_droid source /Users/<user>/.factory/sessions failed with 183 failure(s); first failure: line 1: no importable native JSONL session header
```

After this work:
```
❯ ctx import --provider factory-ai-droid
Preparing local history...
Found 1 history source (74.3 MiB).
importing factory_ai_droid /Users/<user>/.factory/sessions (189 files, 74.3 MiB)
Indexed Factory AI Droid.
imported factory_ai_droid: sessions=2 events=930 edges=2 skipped=20939 failed=0
Optimizing search index...
Checkpointing search database...
Indexed 189 source files.
source_files: 189
source_bytes: 77953994
imported_sources: 1
failed_sources: 0
imported_sessions: 2
imported_events: 930
imported_edges: 2
skipped_sessions: 187
skipped_events: 20691
skipped_edges: 95
skipped: 20939
failed: 0
resume: false
resume_mode: normal_scan
```

## Breaking Changes
None, as it should be fully backward compatible with legacy format.
