### PR TITLE
Fix Linux x64 release glibc baseline

### DIFF
--- a/docs/unmanaged-installs.md
+++ b/docs/unmanaged-installs.md
@@ -34,6 +34,12 @@ Stable releases publish prebuilt binaries on GitHub Releases:
 
 Each release also publishes `SHA256SUMS` for the binary assets.
 
+Official Linux release binaries are checked to require no newer than glibc
+2.39. The Linux x64 artifact is built in an Ubuntu 24.04 container because its
+semantic-search native dependency currently requires a modern glibc baseline.
+Older Linux distributions may need a future legacy build without that x64
+native dependency. The macOS binaries currently target macOS 13 or newer.
+
 For pinned installs, GitHub release asset URLs use this pattern:
 
 ```text

--- a/scripts/build-public-cli-artifact.sh
+++ b/scripts/build-public-cli-artifact.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 ZIG_VERSION="0.14.1"
 ZIG_LINUX_X64_URL="https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz"
 ZIG_LINUX_X64_SHA256="24aeeec8af16c381934a6cd7d95c807a8cb2cf7df9fa40d359aa884195c4716c"
+ZIG_LINUX_AARCH64_URL="https://ziglang.org/download/${ZIG_VERSION}/zig-aarch64-linux-${ZIG_VERSION}.tar.xz"
+ZIG_LINUX_AARCH64_SHA256="f7a654acc967864f7a050ddacfaa778c7504a0eca8d2b678839c21eea47c992b"
 CARGO_ZIGBUILD_VERSION="0.23.0"
+LINUX_GLIBC_BASELINE="2.39"
+LINUX_RELEASE_IMAGE_UBUNTU="24.04"
+MACOS_DEPLOYMENT_TARGET="13.0"
 
 usage() {
   cat >&2 <<'USAGE'
@@ -24,26 +29,32 @@ fi
 case "${platform}" in
   linux-x64)
     target="x86_64-unknown-linux-gnu"
+    build_target="${target}"
     binary_name="ctx"
     ;;
   linux-aarch64)
     target="aarch64-unknown-linux-gnu"
+    build_target="${target}"
     binary_name="ctx-linux-aarch64"
     ;;
   macos-arm64)
     target="aarch64-apple-darwin"
+    build_target="${target}"
     binary_name="ctx-macos-arm64"
     ;;
   macos-x64)
     target="x86_64-apple-darwin"
+    build_target="${target}"
     binary_name="ctx-macos-x64"
     ;;
   windows-x64)
     target="x86_64-pc-windows-gnu"
+    build_target="${target}"
     binary_name="ctx.exe"
     ;;
   freebsd-x64)
     target="x86_64-unknown-freebsd"
+    build_target="${target}"
     binary_name="ctx-freebsd-x64"
     ;;
   *)
@@ -55,7 +66,28 @@ esac
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${root_dir}"
 
-ensure_zig_for_linux_x64() {
+zig_host_archive() {
+  case "$(uname -m)" in
+    x86_64|amd64)
+      printf '%s\t%s\t%s\n' \
+        "zig-x86_64-linux-${ZIG_VERSION}" \
+        "${ZIG_LINUX_X64_URL}" \
+        "${ZIG_LINUX_X64_SHA256}"
+      ;;
+    aarch64|arm64)
+      printf '%s\t%s\t%s\n' \
+        "zig-aarch64-linux-${ZIG_VERSION}" \
+        "${ZIG_LINUX_AARCH64_URL}" \
+        "${ZIG_LINUX_AARCH64_SHA256}"
+      ;;
+    *)
+      echo "error: automatic Zig bootstrap does not support Linux $(uname -m)" >&2
+      exit 127
+      ;;
+  esac
+}
+
+ensure_zig_for_linux_host() {
   if command -v zig >/dev/null 2>&1; then
     return
   fi
@@ -64,13 +96,6 @@ ensure_zig_for_linux_x64() {
     echo "error: zig is required to cross-build ${platform} from $(uname -s)" >&2
     exit 127
   fi
-  case "$(uname -m)" in
-    x86_64|amd64) ;;
-    *)
-      echo "error: automatic Zig bootstrap only supports Linux x86_64, got $(uname -m)" >&2
-      exit 127
-      ;;
-  esac
 
   for required_tool in curl tar; do
     if ! command -v "${required_tool}" >/dev/null 2>&1; then
@@ -79,13 +104,14 @@ ensure_zig_for_linux_x64() {
     fi
   done
 
+  IFS=$'\t' read -r zig_archive_dir zig_url zig_sha256 < <(zig_host_archive)
   toolchain_dir="${CTX_PUBLIC_CLI_TOOLCHAIN_DIR:-target/public-cli-toolchain}"
-  install_dir="${toolchain_dir}/zig-x86_64-linux-${ZIG_VERSION}"
+  install_dir="${toolchain_dir}/${zig_archive_dir}"
   if [[ ! -x "${install_dir}/zig" ]]; then
     mkdir -p "${toolchain_dir}"
-    archive="${toolchain_dir}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz"
+    archive="${toolchain_dir}/${zig_archive_dir}.tar.xz"
     tmp_archive="${archive}.tmp"
-    curl -fsSL "${ZIG_LINUX_X64_URL}" -o "${tmp_archive}"
+    curl -fsSL "${zig_url}" -o "${tmp_archive}"
     if command -v sha256sum >/dev/null 2>&1; then
       actual_sha="$(sha256sum "${tmp_archive}" | awk '{ print $1 }')"
     elif command -v shasum >/dev/null 2>&1; then
@@ -94,8 +120,8 @@ ensure_zig_for_linux_x64() {
       echo "error: sha256sum or shasum is required to verify Zig ${ZIG_VERSION}" >&2
       exit 127
     fi
-    if [[ "${actual_sha}" != "${ZIG_LINUX_X64_SHA256}" ]]; then
-      echo "error: Zig ${ZIG_VERSION} checksum mismatch: expected ${ZIG_LINUX_X64_SHA256}, got ${actual_sha}" >&2
+    if [[ "${actual_sha}" != "${zig_sha256}" ]]; then
+      echo "error: Zig ${ZIG_VERSION} checksum mismatch: expected ${zig_sha256}, got ${actual_sha}" >&2
       exit 1
     fi
     mv "${tmp_archive}" "${archive}"
@@ -109,12 +135,71 @@ ensure_darwin_cross_tools() {
   if ! command -v cargo-zigbuild >/dev/null 2>&1; then
     cargo install cargo-zigbuild --version "${CARGO_ZIGBUILD_VERSION}" --locked
   fi
-  ensure_zig_for_linux_x64
+  ensure_zig_for_linux_host
   command -v zig >/dev/null 2>&1 || {
     echo "error: zig is required to cross-build ${platform} from $(uname -s)" >&2
     exit 127
   }
 }
+
+run_linux_container_build() {
+  if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "error: ${platform} artifacts must be built from Linux" >&2
+    exit 1
+  fi
+  case "${platform}:$(uname -m)" in
+    linux-x64:x86_64|linux-x64:amd64|linux-aarch64:aarch64|linux-aarch64:arm64)
+      ;;
+    *)
+      echo "error: ${platform} artifacts must be built on matching Linux, got $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "error: docker is required to build Linux release artifacts" >&2
+    exit 127
+  fi
+
+  local rust_toolchain="${CTX_RUST_TOOLCHAIN:-1.88.0}"
+  local image="ctx-public-cli-linux:rust-${rust_toolchain}-ubuntu-${LINUX_RELEASE_IMAGE_UBUNTU}"
+  local out_dir="${CTX_PUBLIC_CLI_ARTIFACT_DIR:-target/public-cli-artifacts}"
+  local cargo_target_dir="${CARGO_TARGET_DIR:-target/public-cli-linux/${platform}}"
+
+  case "${out_dir}" in
+    /*)
+      echo "error: absolute CTX_PUBLIC_CLI_ARTIFACT_DIR is not supported for container Linux builds" >&2
+      exit 1
+      ;;
+  esac
+  case "${cargo_target_dir}" in
+    /*)
+      echo "error: absolute CARGO_TARGET_DIR is not supported for container Linux builds" >&2
+      exit 1
+      ;;
+  esac
+
+  mkdir -p "${out_dir}" "${cargo_target_dir}"
+  docker build \
+    --build-arg "RUST_TOOLCHAIN=${rust_toolchain}" \
+    -t "${image}" \
+    -f scripts/docker/linux-release.Dockerfile \
+    scripts/docker
+  docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    -e "CTX_PUBLIC_CLI_IN_CONTAINER=1" \
+    -e "CTX_PUBLIC_CLI_ARTIFACT_DIR=${out_dir}" \
+    -e "CARGO_TARGET_DIR=${cargo_target_dir}" \
+    -e "HOME=/tmp" \
+    -v "${root_dir}:/work" \
+    -w /work \
+    "${image}" \
+    bash scripts/build-public-cli-artifact.sh "${platform}"
+}
+
+if [[ "${platform}" == "linux-x64" && "${CTX_PUBLIC_CLI_IN_CONTAINER:-}" != "1" ]]; then
+  run_linux_container_build
+  exit 0
+fi
 
 version="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next(pkg["version"] for pkg in data["packages"] if pkg["name"] == "ctx"))')"
 if [[ -z "${version}" ]]; then
@@ -143,9 +228,15 @@ out_dir="${CTX_PUBLIC_CLI_ARTIFACT_DIR:-target/public-cli-artifacts}"
 mkdir -p "${out_dir}"
 build_target_dir="${CARGO_TARGET_DIR:-target}"
 
-if [[ "${platform}" == macos-* && "$(uname -s)" != "Darwin" ]]; then
+if [[ "${platform}" == macos-* ]]; then
+  export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-${MACOS_DEPLOYMENT_TARGET}}"
+fi
+
+if [[ "${platform}" == linux-* ]]; then
+  cargo build -p ctx --release --target "${build_target}" --locked
+elif [[ "${platform}" == macos-* && "$(uname -s)" != "Darwin" ]]; then
   ensure_darwin_cross_tools
-  cargo zigbuild -p ctx --release --target "${target}" --locked
+  cargo zigbuild -p ctx --release --target "${build_target}" --locked
 elif [[ "${platform}" == "freebsd-x64" ]]; then
   if ! command -v cross >/dev/null 2>&1; then
     cargo install cross --locked
@@ -156,10 +247,13 @@ elif [[ "${platform}" == "freebsd-x64" ]]; then
   fi
   cross build -p ctx --release --target "${target}" --locked
 else
-  cargo build -p ctx --release --target "${target}" --locked
+  cargo build -p ctx --release --target "${build_target}" --locked
 fi
 
 target_binary="${build_target_dir}/${target}/release/ctx"
+if [[ ! -f "${target_binary}" && "${build_target}" != "${target}" ]]; then
+  target_binary="${build_target_dir}/${build_target}/release/ctx"
+fi
 if [[ "${platform}" == "windows-x64" ]]; then
   target_binary="${target_binary}.exe"
 fi

--- a/scripts/check-buildkite-pipeline.sh
+++ b/scripts/check-buildkite-pipeline.sh
@@ -3,8 +3,14 @@ set -euo pipefail
 
 pipeline=".buildkite/pipeline.yml"
 public_ci_script="scripts/buildkite-public-ci.sh"
+artifact_script="scripts/build-public-cli-artifact.sh"
+artifact_check_script="scripts/check-public-cli-artifact.sh"
+compat_check_script="scripts/check-release-binary-compat.sh"
 test -f "${pipeline}"
 test -f "${public_ci_script}"
+test -f "${artifact_script}"
+test -f "${artifact_check_script}"
+test -f "${compat_check_script}"
 
 if [[ -e ".github/workflows/public-ci.yml" ]]; then
   printf 'public GitHub Actions CI workflow should be migrated to Buildkite\n' >&2
@@ -104,18 +110,32 @@ for required in \
   'scripts/build-public-cli-artifact.sh freebsd-x64' \
   'scripts/build-public-cli-artifact.sh macos-arm64' \
   'scripts/build-public-cli-artifact.sh macos-x64' \
-  'cargo zigbuild -p ctx --release --target "${target}" --locked' \
+  'cargo zigbuild -p ctx --release --target "${build_target}" --locked' \
+  'LINUX_GLIBC_BASELINE="2.39"' \
+  'LINUX_RELEASE_IMAGE_UBUNTU="24.04"' \
+  'scripts/check-release-binary-compat.sh' \
+  'LINUX_GLIBC_MAX_VERSION="2.39"' \
+  'scripts/docker/linux-release.Dockerfile' \
+  'CTX_PUBLIC_CLI_IN_CONTAINER=1' \
+  'MACOS_DEPLOYMENT_TARGET="13.0"' \
   'CARGO_ZIGBUILD_VERSION' \
-  'ZIG_LINUX_X64_SHA256'; do
-  if ! grep -F -q "${required}" "${pipeline}"; then
-    if ! grep -F -q "${required}" "${public_ci_script}"; then
-      if ! grep -F -q "${required}" scripts/build-public-cli-artifact.sh; then
-        printf 'pipeline, public CI script, or artifact script missing required snippet: %s\n' "${required}" >&2
-        exit 1
-      fi
-      continue
+  'ZIG_LINUX_X64_SHA256' \
+  'ZIG_LINUX_AARCH64_SHA256'; do
+  found=0
+  for checked_file in \
+    "${pipeline}" \
+    "${public_ci_script}" \
+    "${artifact_script}" \
+    "${artifact_check_script}" \
+    "${compat_check_script}"; do
+    if grep -F -q "${required}" "${checked_file}"; then
+      found=1
+      break
     fi
-    continue
+  done
+  if [[ "${found}" != "1" ]]; then
+    printf 'pipeline or release scripts missing required snippet: %s\n' "${required}" >&2
+    exit 1
   fi
 done
 

--- a/scripts/check-github-release-assets.sh
+++ b/scripts/check-github-release-assets.sh
@@ -12,6 +12,7 @@ USAGE
 
 tag="${1:-}"
 repo="${2:-ctxrs/ctx}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 if [[ -z "${tag}" || "${tag}" == "-h" || "${tag}" == "--help" ]]; then
   usage
@@ -71,14 +72,16 @@ for asset in "${expected_assets[@]}"; do
 done
 
 cd "${tmp_dir}"
-for asset in \
-  ctx-linux-aarch64 \
-  ctx-linux-x64 \
-  ctx-macos-arm64 \
-  ctx-macos-x64 \
-  ctx-windows-x64.exe \
-  ctx-freebsd-x64; do
+for asset in "${expected_assets[@]}"; do
+  [[ "${asset}" == "SHA256SUMS" ]] && continue
   grep "  ${asset}$" SHA256SUMS | sha256_check
 done
+
+bash "${repo_root}/scripts/check-release-binary-compat.sh" linux-aarch64 ctx-linux-aarch64
+bash "${repo_root}/scripts/check-release-binary-compat.sh" linux-x64 ctx-linux-x64
+bash "${repo_root}/scripts/check-release-binary-compat.sh" macos-arm64 ctx-macos-arm64
+bash "${repo_root}/scripts/check-release-binary-compat.sh" macos-x64 ctx-macos-x64
+bash "${repo_root}/scripts/check-release-binary-compat.sh" windows-x64 ctx-windows-x64.exe
+bash "${repo_root}/scripts/check-release-binary-compat.sh" freebsd-x64 ctx-freebsd-x64
 
 printf 'GitHub release assets ok: %s %s\n' "${repo}" "${tag}"

--- a/scripts/check-loc-exceptions.tsv
+++ b/scripts/check-loc-exceptions.tsv
@@ -1,5 +1,5 @@
 path	max_lines	kind	reason	review_after
-crates/ctx-history-capture/src/tests/native_json.rs	2694	test	native JSON import regression matrix with shared fixtures; split after provider fixture consolidation lands	2026-10-01
+crates/ctx-history-capture/src/tests/native_json.rs	2796	test	native JSON import regression matrix with shared fixtures; split after provider fixture consolidation lands	2026-10-01
 crates/ctx-history-capture/src/tests/native_providers.rs	2430	test	native provider parser matrix with cross-provider fixture setup; split after provider fixture consolidation lands	2026-10-01
 crates/ctx-cli/src/integrations/mcp.rs	1638	source	MCP config writer matrix spans many agent formats; split after the initial integrations installer surface stabilizes	2026-10-01
 crates/ctx-history-capture/src/tests/support.rs	2074	test	shared capture test fixture support plus hermetic fixture roots; splitting now would add indirection without narrowing callers	2026-10-01

--- a/scripts/check-public-cli-artifact.sh
+++ b/scripts/check-public-cli-artifact.sh
@@ -136,4 +136,6 @@ case "${actual_version}" in
     ;;
 esac
 
+bash scripts/check-release-binary-compat.sh "${platform}" "${artifact}"
+
 printf 'public CLI artifact ok: %s sha256=%s\n' "${platform}" "${actual_sha}"

--- a/scripts/check-release-binary-compat.sh
+++ b/scripts/check-release-binary-compat.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LINUX_GLIBC_MAX_VERSION="2.39"
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/check-release-binary-compat.sh PLATFORM BINARY
+
+Checks platform compatibility constraints for a public ctx release binary.
+Platforms: linux-x64, linux-aarch64, macos-arm64, macos-x64, windows-x64,
+freebsd-x64.
+USAGE
+}
+
+platform="${1:-}"
+binary="${2:-}"
+if [[ -z "${platform}" || -z "${binary}" || "${platform}" == "-h" || "${platform}" == "--help" ]]; then
+  usage
+  exit 2
+fi
+
+if [[ ! -f "${binary}" ]]; then
+  printf 'release binary missing: %s\n' "${binary}" >&2
+  exit 1
+fi
+
+version_le() {
+  local lhs="$1"
+  local rhs="$2"
+  [[ "$(printf '%s\n%s\n' "${lhs}" "${rhs}" | sort -V | tail -n 1)" == "${rhs}" ]]
+}
+
+max_symbol_version() {
+  local prefix="$1"
+  local path="$2"
+
+  readelf --version-info "${path}" \
+    | { grep -oE "${prefix}_[0-9]+\\.[0-9]+(\\.[0-9]+)?" || true; } \
+    | sed "s/^${prefix}_//" \
+    | sort -Vu \
+    | tail -n 1
+}
+
+check_linux_elf() {
+  if ! command -v readelf >/dev/null 2>&1; then
+    printf 'readelf is required for Linux release compatibility checks\n' >&2
+    exit 127
+  fi
+
+  local glibc_version
+  glibc_version="$(max_symbol_version GLIBC "${binary}")"
+  if [[ -z "${glibc_version}" ]]; then
+    printf 'could not determine GLIBC requirement for %s\n' "${binary}" >&2
+    exit 1
+  fi
+
+  if ! version_le "${glibc_version}" "${LINUX_GLIBC_MAX_VERSION}"; then
+    printf 'Linux release binary requires GLIBC_%s, above supported floor GLIBC_%s: %s\n' \
+      "${glibc_version}" "${LINUX_GLIBC_MAX_VERSION}" "${binary}" >&2
+    exit 1
+  fi
+
+}
+
+case "${platform}" in
+  linux-x64|linux-aarch64)
+    check_linux_elf
+    ;;
+  macos-arm64|macos-x64|windows-x64|freebsd-x64)
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+printf 'release binary compatibility ok: %s %s\n' "${platform}" "${binary}"

--- a/scripts/docker/linux-release.Dockerfile
+++ b/scripts/docker/linux-release.Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:24.04
+
+ARG RUST_TOOLCHAIN=1.88.0
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV RUSTUP_HOME=/opt/rustup
+ENV PATH=/opt/cargo/bin:${PATH}
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    pkg-config \
+    python3 \
+    xz-utils \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://sh.rustup.rs -o /tmp/rustup-init.sh \
+  && chmod +x /tmp/rustup-init.sh \
+  && CARGO_HOME=/opt/cargo /tmp/rustup-init.sh -y \
+    --no-modify-path \
+    --profile minimal \
+    --default-toolchain "${RUST_TOOLCHAIN}" \
+  && rm /tmp/rustup-init.sh \
+  && chmod -R a+rx /opt/cargo /opt/rustup
+
+ENV CARGO_HOME=/tmp/cargo-home


### PR DESCRIPTION
## Summary
- build Linux x64 public CLI artifacts inside an Ubuntu 24.04 release container so host glibc does not leak into published binaries
- add a release compatibility check that rejects Linux artifacts requiring newer than glibc 2.39
- run the new compatibility check against staged artifacts and downloaded GitHub release assets
- document the Linux/macOS release baselines and why older x64 glibc support is constrained by the native semantic-search dependency
- refresh the existing native JSON LOC exception to match current `main`, unblocking the public smoke gate after #107

Fixes #112

## Testing
- `CTX_PUBLIC_CLI_ARTIFACT_DIR=target/noble-artifacts CARGO_TARGET_DIR=target/noble-build scripts/build-public-cli-artifact.sh linux-x64`
- new x64 artifact max glibc requirement: `GLIBC_2.39`
- new x64 artifact runs on `ubuntu:24.04` and `debian:sid`
- new x64 artifact intentionally fails on `ubuntu:22.04` because the dependency baseline is newer
- old v0.24.0 x64 artifact fails the new compatibility check as expected
- existing v0.24.0 linux-aarch64 artifact passes the new compatibility check
- `bash -n scripts/build-public-cli-artifact.sh scripts/check-release-binary-compat.sh scripts/check-public-cli-artifact.sh scripts/check-github-release-assets.sh scripts/check-buildkite-pipeline.sh`
- `bash scripts/check-buildkite-pipeline.sh`
- `bash scripts/check-docs.sh`
- `bash scripts/check-loc.sh`
- `bash scripts/bazel-test.sh buildkite_pipeline_check`
- `bash scripts/bazel-test.sh docs_check`
- `TMPDIR=/tmp/ctx-ci-tmp /home/daddy/.local/bin/bazel --output_user_root=/tmp/ctx-ci-bazel-output test //:buildkite_pipeline_check //:cargo_check //:cargo_fmt_check //:docs_check //:installer_path_smoke //:loc_check //:package_audit_fast //:source_diff_check --config=ci --jobs=2 --local_resources=cpu=2 --local_resources=memory=4096`
- `git diff --check`