### PR TITLE
Canonicalize workspace and file filters in the search runtime

### DIFF
--- a/crates/ctx-cli/tests/search_show_locate_sql.rs
+++ b/crates/ctx-cli/tests/search_show_locate_sql.rs
@@ -1169,6 +1169,58 @@ fn search_normalizes_whitespace_only_filters() {
 }
 
 #[test]
+fn search_trims_whitespace_padded_workspace_and_file_filters() {
+    let temp = tempdir();
+    let fixture = provider_history_fixture("codex-rich-sessions");
+    json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "codex",
+        "--path",
+        &fixture,
+        "--json",
+    ]));
+
+    let with_workspace = json_output(ctx(&temp).args([
+        "search",
+        "diagnostic",
+        "--workspace",
+        " ctx-rich-fixture ",
+        "--json",
+    ]));
+    assert_eq!(
+        with_workspace["filters"]["workspace"], "ctx-rich-fixture",
+        "workspace filter value should be trimmed; got filters: {}",
+        with_workspace["filters"],
+    );
+    assert!(
+        !with_workspace["results"].as_array().unwrap().is_empty(),
+        "workspace-filtered search should match using the trimmed value"
+    );
+
+    let with_file = json_output(ctx(&temp).args(["search", "--file", " src/main.rs ", "--json"]));
+    assert_eq!(
+        with_file["filters"]["file"], "src/main.rs",
+        "file filter value should be trimmed; got filters: {}",
+        with_file["filters"],
+    );
+
+    let results = with_file["results"].as_array().unwrap();
+    assert!(
+        !results.is_empty(),
+        "file-filtered search should return results with trimmed path"
+    );
+    assert!(
+        results[0]["why_matched"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|reason| reason == "file_touched"),
+        "result should match by file_touched"
+    );
+}
+
+#[test]
 fn pi_cli_imports_directory_tree_path() {
     let temp = tempdir();
     let path = temp.path().join("pi-sessions-dir");

--- a/crates/ctx-history-search/src/filters.rs
+++ b/crates/ctx-history-search/src/filters.rs
@@ -37,12 +37,7 @@ pub(crate) fn event_hit_matches_filters(
             return false;
         }
     }
-    if let Some(repo) = filters
-        .repo
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
+    if let Some(repo) = filters.repo.as_deref() {
         let repo = repo.to_lowercase();
         let matches_repo = [
             hit.cwd.as_deref(),
@@ -143,12 +138,7 @@ pub(crate) fn file_filter_scope(
     store: &Store,
     filters: &SearchFilters,
 ) -> Result<Option<FileTouchScope>> {
-    let Some(file) = filters
-        .file
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    else {
+    let Some(file) = filters.file.as_deref() else {
         return Ok(None);
     };
     Ok(Some(store.file_touch_scope(file)?))
@@ -364,18 +354,12 @@ pub(crate) fn source_identity_matches_history_source_filter(
 pub(crate) fn has_filters(filters: &SearchFilters) -> bool {
     filters.session.is_some()
         || filters.provider.is_some()
-        || filters
-            .repo
-            .as_ref()
-            .is_some_and(|value| !value.trim().is_empty())
+        || filters.repo.is_some()
         || filters.since.is_some()
         || filters.primary_only
         || !filters.include_subagents
         || filters.event_type.is_some()
-        || filters
-            .file
-            .as_ref()
-            .is_some_and(|value| !value.trim().is_empty())
+        || filters.file.is_some()
         || filters.exclude_provider_session.is_some()
         || has_history_source_filter(filters)
 }
@@ -481,12 +465,7 @@ pub(crate) fn record_matches_filters(
         }
     }
 
-    if let Some(repo) = filters
-        .repo
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
+    if let Some(repo) = filters.repo.as_deref() {
         let repo = repo.to_lowercase();
         let matches_record = record
             .workspace
@@ -516,12 +495,7 @@ pub(crate) fn record_matches_filters(
         }
     }
 
-    if let Some(file) = filters
-        .file
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
+    if let Some(file) = filters.file.as_deref() {
         if let Some(scope) = file_scope {
             if !record_context_matches_file_scope(scope, record, context) {
                 return false;

--- a/crates/ctx-history-search/src/query.rs
+++ b/crates/ctx-history-search/src/query.rs
@@ -76,6 +76,22 @@ pub struct SearchFilters {
     pub exclude_provider_session: Option<ProviderSessionFilter>,
 }
 
+impl SearchFilters {
+    fn normalized(&self) -> Self {
+        let mut normalized = self.clone();
+        normalized.repo = normalized_text_filter(self.repo.as_deref());
+        normalized.file = normalized_text_filter(self.file.as_deref());
+        normalized
+    }
+}
+
+fn normalized_text_filter(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ProviderSessionFilter {
     pub provider: ctx_history_core::CaptureProvider,
@@ -88,7 +104,7 @@ pub(crate) fn normalized_options(options: &PacketOptions) -> PacketOptions {
     PacketOptions {
         limit: options.limit.clamp(1, MAX_RESULT_LIMIT),
         snippet_chars: options.snippet_chars.clamp(32, 2_000),
-        filters: options.filters.clone(),
+        filters: options.filters.normalized(),
         result_mode: options.result_mode,
     }
 }

--- a/crates/ctx-history-search/src/ranking.rs
+++ b/crates/ctx-history-search/src/ranking.rs
@@ -194,12 +194,11 @@ pub(crate) fn hydrate_record_context(
     let runs = store.runs_for_record(record_id)?;
     let events = store.events_for_record(record_id)?;
     let artifacts = store.artifacts_for_record(record_id)?;
-    let files_touched =
-        if let Some(file) = file_filter.map(str::trim).filter(|value| !value.is_empty()) {
-            store.files_touched_for_record_matching(record_id, file)?
-        } else {
-            store.files_touched_for_record(record_id)?
-        };
+    let files_touched = if let Some(file) = file_filter {
+        store.files_touched_for_record_matching(record_id, file)?
+    } else {
+        store.files_touched_for_record(record_id)?
+    };
     let vcs_changes = store.vcs_changes_for_record(record_id)?;
     let summaries = store.summaries_for_record(record_id)?;
     let mut source_ids = BTreeSet::new();
@@ -275,11 +274,7 @@ fn analyze_record(
     let mut citations = Vec::new();
 
     if terms.is_empty() {
-        if filters
-            .file
-            .as_ref()
-            .is_some_and(|file| !file.trim().is_empty())
-        {
+        if filters.file.is_some() {
             let mut primary_hit = None;
             for section in search_sections(record, context, filters)
                 .into_iter()

--- a/crates/ctx-history-search/src/tests/filter_scans.rs
+++ b/crates/ctx-history-search/src/tests/filter_scans.rs
@@ -465,6 +465,43 @@ fn no_token_query_returns_empty_without_recent_activity() {
 }
 
 #[test]
+fn search_packet_normalizes_workspace_and_file_filters_for_library_callers() {
+    let (_temp, store) = test_store();
+    let packet = search_packet(
+        &store,
+        "normalization-no-result",
+        &PacketOptions {
+            filters: SearchFilters {
+                repo: Some(" workspace ".into()),
+                file: Some(" src/main.rs ".into()),
+                ..SearchFilters::default()
+            },
+            ..PacketOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(packet.filters.repo.as_deref(), Some("workspace"));
+    assert_eq!(packet.filters.file.as_deref(), Some("src/main.rs"));
+
+    let packet = search_packet(
+        &store,
+        "normalization-no-result",
+        &PacketOptions {
+            filters: SearchFilters {
+                repo: Some(" \t ".into()),
+                file: Some(" \n ".into()),
+                ..SearchFilters::default()
+            },
+            ..PacketOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(packet.filters, SearchFilters::default());
+}
+
+#[test]
 fn search_result_limit_is_capped() {
     let (_temp, store) = test_store();
     let query = "limit-cap-needle";


### PR DESCRIPTION
## Summary

Workspace and file filters were trimmed while matching, but search packets could echo the original padded values. This made the reported filters differ from the values actually used for execution.

Canonicalize these filters once at the shared `ctx-history-search` options boundary, then use the canonical values for matching and packet serialization. CLI, MCP, and SDK adapters do not duplicate the runtime policy. Redundant downstream trimming was removed.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ctx-history-search` (26 passed; 1 manual performance test ignored)
- `cargo test -p ctx --test search_show_locate_sql` (28 passed)
- `cargo clippy -p ctx-history-search --all-targets -- -D warnings`
- `git diff --check`