### PR TITLE
Normalize lookup identifiers in TypeScript SDK

### DIFF
--- a/sdks/typescript/src/index.js
+++ b/sdks/typescript/src/index.js
@@ -174,8 +174,8 @@ export class LocalAgentHistoryClient {
   }
 
   async showEvent(id, options = {}) {
-    requireId("event id", id);
-    const args = ["show", "event", id, "--format", "json"];
+    const normalizedId = normalizeLookupId("event id", id);
+    const args = ["show", "event", normalizedId, "--format", "json"];
     appendOptionalNumber(args, "--before", options.before);
     appendOptionalNumber(args, "--after", options.after);
     appendOptionalNumber(args, "--window", options.window);
@@ -194,8 +194,8 @@ export class LocalAgentHistoryClient {
   }
 
   async locateEvent(id) {
-    requireId("event id", id);
-    return this.#agentHistoryJson("locateEvent", ["locate", "event", id, "--format", "json"]);
+    const normalizedId = normalizeLookupId("event id", id);
+    return this.#agentHistoryJson("locateEvent", ["locate", "event", normalizedId, "--format", "json"]);
   }
 
   async locateSession(idOrOptions) {
@@ -463,12 +463,13 @@ function hasSearchText(value) {
 
 function appendSessionLookupArgs(args, options) {
   if (options.id) {
-    args.push(options.id);
+    args.push(normalizeLookupId("session id", options.id));
     return;
   }
   appendOptional(args, "--provider", options.provider);
-  appendOptional(args, "--provider-session", options.providerSession);
-  if (!options.provider || !options.providerSession) {
+  const providerSession = normalizeLookupId("provider session id", options.providerSession);
+  appendOptional(args, "--provider-session", providerSession);
+  if (!options.provider || !providerSession) {
     throw new CtxValidationError(
       "session lookup requires either id or provider with providerSession",
       { details: { options } },
@@ -501,12 +502,21 @@ function appendFlag(args, flag, value) {
   }
 }
 
-function requireId(label, id) {
-  if (!id || typeof id !== "string") {
+function normalizeLookupId(label, value) {
+  if (typeof value !== "string") {
     throw new CtxValidationError(`${label} is required`, {
-      details: { value: id },
+      details: { value },
     });
   }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new CtxValidationError(`${label} is required`, {
+      details: { value },
+    });
+  }
+
+  return trimmed;
 }
 
 function cliError(message, result) {

--- a/sdks/typescript/test/client.test.js
+++ b/sdks/typescript/test/client.test.js
@@ -289,6 +289,48 @@ test("wraps show and locate commands by ctx id and provider session id", async (
   );
 });
 
+test("rejects whitespace-only lookup identifiers before invoking CLI", async () => {
+  const { client, calls } = mockClient(() => {
+    throw new Error("runner should not be called");
+  });
+
+  await assert.rejects(() => client.showEvent("   "), CtxValidationError);
+  await assert.rejects(() => client.locateEvent("   "), CtxValidationError);
+  await assert.rejects(
+    () => client.showSession({ provider: "codex", providerSession: "   " }),
+    CtxValidationError,
+  );
+  await assert.rejects(
+    () => client.locateSession({ provider: "codex", providerSession: "   " }),
+    CtxValidationError,
+  );
+
+  assert.equal(calls.length, 0);
+});
+
+test("trims lookup identifiers before invoking CLI", async () => {
+  const { client, calls } = mockClient(() => "{}");
+
+  await client.showEvent("   abc   ");
+  await client.locateEvent("   abc   ");
+  await client.showSession("   abc   ");
+  await client.locateSession("   abc   ");
+  await client.showSession({ provider: "codex", providerSession: "   abc   " });
+  await client.locateSession({ provider: "codex", providerSession: "   abc   " });
+
+  assert.deepEqual(
+    calls.map((call) => call.args.slice(2)),
+    [
+      ["show", "event", "abc", "--format", "json"],
+      ["locate", "event", "abc", "--format", "json"],
+      ["show", "session", "abc", "--mode", "lite", "--format", "json"],
+      ["locate", "session", "abc", "--format", "json"],
+      ["show", "session", "--provider", "codex", "--provider-session", "abc", "--mode", "lite", "--format", "json"],
+      ["locate", "session", "--provider", "codex", "--provider-session", "abc", "--format", "json"],
+    ],
+  );
+});
+
 test("reports versioning metadata", async () => {
   const { client } = mockClient(() => "ctx 1.2.3\n");
 


### PR DESCRIPTION
## Summary

Normalize lookup identifiers before invoking the local CLI.

This aligns the TypeScript SDK with the CLI by:

- trimming lookup identifiers before transport
- rejecting whitespace-only identifiers
- forwarding the normalized value

Adds regression tests covering both whitespace-only and whitespace-padded inputs.