### PR TITLE
Normalise lookup indentifiers in the python SDK

### DIFF
--- a/sdks/python/src/ctx_agent_history/transport.py
+++ b/sdks/python/src/ctx_agent_history/transport.py
@@ -41,7 +41,7 @@ from .types import (
     StatusResponse,
     SyncResponse,
 )
-from .validation import validate_search_intent
+from .validation import normalize_lookup_id, validate_search_intent
 
 
 class AgentHistoryTransport(Protocol):
@@ -285,7 +285,7 @@ class LocalCliAdapter:
         before: Optional[int] = None,
         after: Optional[int] = None,
     ) -> ShowEventResponse:
-        args = ["show", "event", event_id, "--format", "json"]
+        args = ["show", "event", normalize_lookup_id("event id", event_id), "--format", "json"]
         if window is not None:
             args.extend(["--window", str(window)])
         if before is not None:
@@ -303,7 +303,7 @@ class LocalCliAdapter:
         )
 
     def show_session(self, session_id: str, *, mode: Optional[str] = None) -> ShowSessionResponse:
-        args = ["show", "session", session_id, "--format", "json"]
+        args = ["show", "session", normalize_lookup_id("session id", session_id), "--format", "json"]
         if mode is not None:
             args.extend(["--mode", mode])
         raw = self._json(args)
@@ -317,7 +317,7 @@ class LocalCliAdapter:
         )
 
     def locate_event(self, event_id: str) -> LocateEventResponse:
-        raw = self._json(["locate", "event", event_id, "--format", "json"])
+        raw = self._json(["locate", "event", normalize_lookup_id("event id", event_id), "--format", "json"])
         return cast(
             LocateEventResponse,
             envelope(
@@ -328,7 +328,7 @@ class LocalCliAdapter:
         )
 
     def locate_session(self, session_id: str) -> LocateSessionResponse:
-        raw = self._json(["locate", "session", session_id, "--format", "json"])
+        raw = self._json(["locate", "session", normalize_lookup_id("session id", session_id), "--format", "json"])
         return cast(
             LocateSessionResponse,
             envelope(

--- a/sdks/python/src/ctx_agent_history/validation.py
+++ b/sdks/python/src/ctx_agent_history/validation.py
@@ -33,6 +33,16 @@ def _has_text(value: object) -> bool:
     return isinstance(value, str) and bool(value.strip())
 
 
+def normalize_lookup_id(label: str, value: Optional[str]) -> str:
+    if not isinstance(value, str):
+        raise CtxAgentHistoryValidationError(f"{label} is required", details={"value": value})
+
+    trimmed = value.strip()
+    if not trimmed:
+        raise CtxAgentHistoryValidationError(f"{label} is required", details={"value": value})
+    return trimmed
+
+
 def _term_details(terms: Optional[Sequence[str]]) -> list[str]:
     if terms is None:
         return []

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -100,6 +100,42 @@ class LocalCliAdapterTests(unittest.TestCase):
             self.assertEqual(client.locate_session("session-1")["operation"], "locateSession")
             self.assertEqual(client.locateSession("session-1")["operation"], "locateSession")
 
+    def test_rejects_whitespace_only_lookup_identifiers_before_cli(self) -> None:
+        adapter = RecordingLookupAdapter()
+        client = AgentHistoryClient(adapter)
+
+        for call in (
+            lambda: client.show_event("   "),
+            lambda: client.locate_event("   "),
+            lambda: client.show_session("   "),
+            lambda: client.locate_session("   "),
+        ):
+            with self.subTest(call=call):
+                with self.assertRaises(CtxAgentHistoryValidationError) as raised:
+                    call()
+                self.assertEqual(raised.exception.code, "invalid_request")
+
+        self.assertEqual(adapter.calls, [])
+
+    def test_trims_lookup_identifiers_before_cli(self) -> None:
+        adapter = RecordingLookupAdapter()
+        client = AgentHistoryClient(adapter)
+
+        self.assertEqual(client.show_event("   abc   ")["operation"], "showEvent")
+        self.assertEqual(client.locate_event("   abc   ")["operation"], "locateEvent")
+        self.assertEqual(client.show_session("   abc   ")["operation"], "showSession")
+        self.assertEqual(client.locate_session("   abc   ")["operation"], "locateSession")
+
+        self.assertEqual(
+            adapter.calls,
+            [
+                ["show", "event", "abc", "--format", "json"],
+                ["locate", "event", "abc", "--format", "json"],
+                ["show", "session", "abc", "--format", "json"],
+                ["locate", "session", "abc", "--format", "json"],
+            ],
+        )
+
     def test_search_requires_query_term_or_file_before_cli(self) -> None:
         with fake_ctx(fail=True) as cli:
             client = AgentHistoryClient.local(ctx_binary=str(cli))
@@ -335,6 +371,44 @@ class RecordingSearchAdapter(LocalCliAdapter):
     def _json(self, args: typing.Sequence[str]) -> dict[str, object]:
         self.calls.append(list(args))
         return self.raw
+
+
+class RecordingLookupAdapter(LocalCliAdapter):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[list[str]] = []
+
+    def _json(self, args: typing.Sequence[str]) -> dict[str, object]:
+        self.calls.append(list(args))
+        match args[:2]:
+            case ["show", "event"]:
+                return {
+                    "event": {"ctx_event_id": args[2]},
+                    "events": [],
+                }
+            case ["show", "session"]:
+                return {
+                    "session": {"ctx_session_id": args[2], "provider": "codex"},
+                    "events": [],
+                    "source": {"path": "/tmp/session.jsonl", "exists": True},
+                    "mode": "lite",
+                    "format": "json",
+                }
+            case ["locate", "event"]:
+                return {
+                    "ctx_event_id": args[2],
+                    "ctx_session_id": "session-1",
+                    "provider": "codex",
+                    "source": {"path": "/tmp/session.jsonl", "exists": True},
+                }
+            case ["locate", "session"]:
+                return {
+                    "ctx_session_id": args[2],
+                    "provider": "codex",
+                    "source": {"path": "/tmp/session.jsonl", "exists": True},
+                }
+            case _:
+                return {}
 
 
 class fake_ctx:


### PR DESCRIPTION
## Summary

Normalize lookup identifiers before invoking the local CLI.

This aligns the Python SDK with the CLI by:

- trimming lookup identifiers before transport
- rejecting whitespace-only identifiers
- forwarding the normalized value

Adds regression tests covering whitespace-only and whitespace-padded inputs.