### PR TITLE
Use the canonical command label in ctx status

### DIFF
--- a/crates/ctx-cli/src/commands/status.rs
+++ b/crates/ctx-cli/src/commands/status.rs
@@ -28,7 +28,7 @@ pub(crate) fn run_status(args: JsonArgs, data_root: PathBuf, quiet: bool) -> Res
         semantic,
         daemon,
     ) = if initialized {
-        let store = open_existing_store_snapshot_read_only(&db_path, "status")?;
+        let store = open_existing_store_snapshot_read_only(&db_path, "ctx status")?;
         let counts = store.indexed_history_counts()?;
         let semantic_report = semantic_worker_report_cached(&data_root, Some(&store))?;
         let daemon = daemon_report(&data_root, &semantic_report);

--- a/crates/ctx-cli/tests/setup_sources_import.rs
+++ b/crates/ctx-cli/tests/setup_sources_import.rs
@@ -192,7 +192,7 @@ fn status_rejects_unsupported_schema_without_migrating_or_creating_side_dirs() {
     let stderr = failure_stderr(ctx(&temp).args(["status", "--json"]));
     assert!(stderr.contains("schema version 1"), "{stderr}");
     assert!(stderr.contains("writable command"), "{stderr}");
-    assert!(!stderr.contains("ctx status"), "{stderr}");
+    assert!(stderr.contains("ctx status"), "{stderr}");
 
     let conn = Connection::open(&db_path).unwrap();
     let user_version: i64 = conn


### PR DESCRIPTION
## Summary

Use the canonical command label when opening the read-only store for `ctx status`.

This makes the unsupported schema-version error message consistent with the
other commands that use the read-only store helpers.