### PR TITLE
Report coarse local execution capabilities

### DIFF
--- a/crates/ctx-cli/src/analytics.rs
+++ b/crates/ctx-cli/src/analytics.rs
@@ -5,7 +5,7 @@ use ctx_history_core::utc_now;
 use serde_json::{json, Map, Value};
 use uuid::Uuid;
 
-use crate::{config::AppConfig, identity, install_marker, net};
+use crate::{config::AppConfig, execution_capabilities, identity, install_marker, net};
 
 pub type AnalyticsProperties = Map<String, Value>;
 
@@ -40,6 +40,10 @@ pub(crate) fn send_cli_event_inner(
     let duration_ms = event.duration.as_millis().min(i64::MAX as u128) as i64;
     let install_marker = install_marker::current_exe_install_marker();
     let mut properties = event.properties;
+    let capability_snapshot = execution_capabilities::pending(data_root).ok().flatten();
+    if let Some(snapshot) = capability_snapshot.as_ref() {
+        snapshot.insert_properties(&mut properties);
+    }
     properties.insert("action".to_owned(), Value::String(event.action.to_owned()));
     properties.insert("json_output".to_owned(), Value::Bool(event.json_output));
     properties.insert(
@@ -97,7 +101,11 @@ pub(crate) fn send_cli_event_inner(
         "events": [cli_event]
     });
     let body = serde_json::to_vec(&payload)?;
-    net::post_json(&config.analytics.endpoint, &body)
+    net::post_json(&config.analytics.endpoint, &body)?;
+    if let Some(snapshot) = capability_snapshot {
+        snapshot.mark_reported()?;
+    }
+    Ok(())
 }
 
 pub fn empty_properties() -> AnalyticsProperties {

--- a/crates/ctx-cli/src/execution_capabilities.rs
+++ b/crates/ctx-cli/src/execution_capabilities.rs
@@ -1,0 +1,429 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+#[cfg(target_os = "linux")]
+use std::io::Read;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use crate::{analytics::AnalyticsProperties, identity};
+
+const SNAPSHOT_SCHEMA: u64 = 1;
+const CLAIM_FILE: &str = "execution-capabilities-v1.claim";
+const REPORTED_FILE: &str = "execution-capabilities-v1.reported";
+#[cfg(target_os = "linux")]
+const MAX_NATIVE_FILE_BYTES: usize = 64 * 1024;
+const GIB: u64 = 1024 * 1024 * 1024;
+
+pub(crate) struct PendingSnapshot {
+    claim_path: PathBuf,
+    reported_path: PathBuf,
+    snapshot: Snapshot,
+}
+
+impl PendingSnapshot {
+    pub(crate) fn insert_properties(&self, properties: &mut AnalyticsProperties) {
+        properties.insert(
+            "capability_snapshot_schema".to_owned(),
+            Value::Number(SNAPSHOT_SCHEMA.into()),
+        );
+        properties.insert(
+            "available_parallelism_bucket".to_owned(),
+            Value::String(self.snapshot.available_parallelism_bucket.to_owned()),
+        );
+        properties.insert(
+            "host_memory_bucket".to_owned(),
+            Value::String(self.snapshot.host_memory_bucket.to_owned()),
+        );
+        properties.insert(
+            "cpu_vector_tier".to_owned(),
+            Value::String(self.snapshot.cpu_vector_tier.to_owned()),
+        );
+        properties.insert(
+            "acceleration_candidate".to_owned(),
+            Value::String(self.snapshot.acceleration_candidate.to_owned()),
+        );
+    }
+
+    pub(crate) fn mark_reported(self) -> Result<()> {
+        match fs::rename(&self.claim_path, &self.reported_path) {
+            Ok(()) => Ok(()),
+            Err(_) if path_entry_exists(&self.reported_path)? => {
+                let _ = fs::remove_file(&self.claim_path);
+                Ok(())
+            }
+            Err(err) => Err(err).with_context(|| {
+                format!(
+                    "promote {} to {}",
+                    self.claim_path.display(),
+                    self.reported_path.display()
+                )
+            }),
+        }
+    }
+}
+
+pub(crate) fn pending(data_root: &Path) -> Result<Option<PendingSnapshot>> {
+    let claim_path = identity::device_state_path(CLAIM_FILE, data_root)?;
+    let reported_path = identity::device_state_path(REPORTED_FILE, data_root)?;
+    if path_entry_exists(&reported_path)? || path_entry_exists(&claim_path)? {
+        return Ok(None);
+    }
+    if let Some(parent) = claim_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    match identity::create_private_file(&claim_path, b"schema_version=1\n") {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => return Ok(None),
+        Err(err) => {
+            return Err(err).with_context(|| format!("claim {}", claim_path.display()));
+        }
+    }
+    Ok(Some(PendingSnapshot {
+        claim_path,
+        reported_path,
+        snapshot: Snapshot::collect(),
+    }))
+}
+
+fn path_entry_exists(path: &Path) -> io::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Snapshot {
+    available_parallelism_bucket: &'static str,
+    host_memory_bucket: &'static str,
+    cpu_vector_tier: &'static str,
+    acceleration_candidate: &'static str,
+}
+
+impl Snapshot {
+    fn collect() -> Self {
+        Self {
+            available_parallelism_bucket: std::thread::available_parallelism()
+                .ok()
+                .map(|value| parallelism_bucket(value.get()))
+                .unwrap_or("unknown"),
+            host_memory_bucket: host_memory_bytes().map(memory_bucket).unwrap_or("unknown"),
+            cpu_vector_tier: cpu_vector_tier(),
+            acceleration_candidate: acceleration_candidate(),
+        }
+    }
+}
+
+fn parallelism_bucket(parallelism: usize) -> &'static str {
+    match parallelism {
+        0 => "unknown",
+        1 => "1",
+        2 => "2",
+        3..=4 => "3-4",
+        5..=8 => "5-8",
+        9..=16 => "9-16",
+        17..=32 => "17-32",
+        33..=64 => "33-64",
+        _ => "65+",
+    }
+}
+
+fn memory_bucket(bytes: u64) -> &'static str {
+    if bytes == 0 {
+        "unknown"
+    } else if bytes < 4 * GIB {
+        "lt_4gb"
+    } else if bytes < 8 * GIB {
+        "4-8gb"
+    } else if bytes < 16 * GIB {
+        "8-16gb"
+    } else if bytes < 32 * GIB {
+        "16-32gb"
+    } else if bytes < 64 * GIB {
+        "32-64gb"
+    } else {
+        "64gb+"
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn host_memory_bytes() -> Option<u64> {
+    let body = read_bounded(Path::new("/proc/meminfo"), MAX_NATIVE_FILE_BYTES).ok()?;
+    parse_meminfo_total_bytes(std::str::from_utf8(&body).ok()?)
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_meminfo_total_bytes(text: &str) -> Option<u64> {
+    text.lines().find_map(|line| {
+        let rest = line.strip_prefix("MemTotal:")?;
+        let mut fields = rest.split_whitespace();
+        let kib = fields.next()?.parse::<u64>().ok()?;
+        if fields.next()? != "kB" || fields.next().is_some() {
+            return None;
+        }
+        kib.checked_mul(1024)
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn host_memory_bytes() -> Option<u64> {
+    sysctl_u64(b"hw.memsize\0")
+}
+
+#[cfg(target_os = "freebsd")]
+fn host_memory_bytes() -> Option<u64> {
+    sysctl_u64(b"hw.physmem\0")
+}
+
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+fn sysctl_u64(name: &'static [u8]) -> Option<u64> {
+    let mut bytes = 0_u64;
+    let mut size = std::mem::size_of::<u64>();
+    let result = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr().cast(),
+            (&mut bytes as *mut u64).cast(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    (result == 0 && size == std::mem::size_of::<u64>()).then_some(bytes)
+}
+
+#[cfg(target_os = "windows")]
+fn host_memory_bytes() -> Option<u64> {
+    #[repr(C)]
+    struct MemoryStatusEx {
+        length: u32,
+        memory_load: u32,
+        total_phys: u64,
+        avail_phys: u64,
+        total_page_file: u64,
+        avail_page_file: u64,
+        total_virtual: u64,
+        avail_virtual: u64,
+        avail_extended_virtual: u64,
+    }
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn GlobalMemoryStatusEx(buffer: *mut MemoryStatusEx) -> i32;
+    }
+    let mut status = MemoryStatusEx {
+        length: std::mem::size_of::<MemoryStatusEx>() as u32,
+        memory_load: 0,
+        total_phys: 0,
+        avail_phys: 0,
+        total_page_file: 0,
+        avail_page_file: 0,
+        total_virtual: 0,
+        avail_virtual: 0,
+        avail_extended_virtual: 0,
+    };
+    (unsafe { GlobalMemoryStatusEx(&mut status) } != 0).then_some(status.total_phys)
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows",
+    target_os = "freebsd"
+)))]
+fn host_memory_bytes() -> Option<u64> {
+    None
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn cpu_vector_tier() -> &'static str {
+    if std::arch::is_x86_feature_detected!("avx512f") {
+        "avx512"
+    } else if std::arch::is_x86_feature_detected!("avx2") {
+        "avx2"
+    } else {
+        "x86_baseline"
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn cpu_vector_tier() -> &'static str {
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        "arm_neon"
+    } else {
+        "other"
+    }
+}
+
+#[cfg(target_arch = "arm")]
+fn cpu_vector_tier() -> &'static str {
+    if std::arch::is_arm_feature_detected!("neon") {
+        "arm_neon"
+    } else {
+        "other"
+    }
+}
+
+#[cfg(not(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "arm"
+)))]
+fn cpu_vector_tier() -> &'static str {
+    "other"
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn acceleration_candidate() -> &'static str {
+    "apple_ane"
+}
+
+#[cfg(all(target_os = "macos", not(target_arch = "aarch64")))]
+fn acceleration_candidate() -> &'static str {
+    "not_detected"
+}
+
+#[cfg(target_os = "linux")]
+fn acceleration_candidate() -> &'static str {
+    match linux_nvidia_driver_has_device() {
+        Ok(true) => "nvidia_cuda",
+        Ok(false) => match linux_drm_has_nvidia_device() {
+            Ok(true) | Err(_) => "unknown",
+            Ok(false) => "not_detected",
+        },
+        Err(_) => "unknown",
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_nvidia_driver_has_device() -> io::Result<bool> {
+    match fs::read_dir("/proc/driver/nvidia/gpus") {
+        Ok(entries) => Ok(entries.take(32).filter_map(Result::ok).next().is_some()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_drm_has_nvidia_device() -> io::Result<bool> {
+    let entries = fs::read_dir("/sys/class/drm")?;
+    for entry in entries.take(128) {
+        let entry = entry?;
+        if !entry.file_name().to_string_lossy().starts_with("card") {
+            continue;
+        }
+        let vendor = entry.path().join("device/vendor");
+        let value = match read_bounded(&vendor, 32) {
+            Ok(value) => value,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+            Err(err) => return Err(err),
+        };
+        if std::str::from_utf8(&value)
+            .ok()
+            .is_some_and(|value| value.trim().eq_ignore_ascii_case("0x10de"))
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(target_os = "windows")]
+fn acceleration_candidate() -> &'static str {
+    match windows_system_directory() {
+        Some(path) => match fs::symlink_metadata(path.join("nvcuda.dll")) {
+            Ok(metadata) if metadata.is_file() => "nvidia_cuda",
+            Ok(_) => "unknown",
+            Err(err) if err.kind() == io::ErrorKind::NotFound => "not_detected",
+            Err(_) => "unknown",
+        },
+        None => "unknown",
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_system_directory() -> Option<PathBuf> {
+    use std::{ffi::OsString, os::windows::ffi::OsStringExt};
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn GetSystemDirectoryW(buffer: *mut u16, size: u32) -> u32;
+    }
+
+    let mut buffer = vec![0_u16; 32_768];
+    let length = unsafe { GetSystemDirectoryW(buffer.as_mut_ptr(), buffer.len() as u32) } as usize;
+    if length == 0 || length >= buffer.len() {
+        return None;
+    }
+    Some(PathBuf::from(OsString::from_wide(&buffer[..length])))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+fn acceleration_candidate() -> &'static str {
+    "unknown"
+}
+
+#[cfg(target_os = "linux")]
+fn read_bounded(path: &Path, max_bytes: usize) -> io::Result<Vec<u8>> {
+    let file = fs::File::open(path)?;
+    let mut body = Vec::new();
+    file.take((max_bytes as u64).saturating_add(1))
+        .read_to_end(&mut body)?;
+    if body.len() > max_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "native capability input exceeds size limit",
+        ));
+    }
+    Ok(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parallelism_buckets_are_coarse_and_exhaustive() {
+        assert_eq!(parallelism_bucket(0), "unknown");
+        assert_eq!(parallelism_bucket(1), "1");
+        assert_eq!(parallelism_bucket(2), "2");
+        assert_eq!(parallelism_bucket(4), "3-4");
+        assert_eq!(parallelism_bucket(8), "5-8");
+        assert_eq!(parallelism_bucket(16), "9-16");
+        assert_eq!(parallelism_bucket(32), "17-32");
+        assert_eq!(parallelism_bucket(64), "33-64");
+        assert_eq!(parallelism_bucket(65), "65+");
+    }
+
+    #[test]
+    fn memory_buckets_do_not_expose_byte_counts() {
+        assert_eq!(memory_bucket(0), "unknown");
+        assert_eq!(memory_bucket(4 * GIB - 1), "lt_4gb");
+        assert_eq!(memory_bucket(4 * GIB), "4-8gb");
+        assert_eq!(memory_bucket(8 * GIB), "8-16gb");
+        assert_eq!(memory_bucket(16 * GIB), "16-32gb");
+        assert_eq!(memory_bucket(32 * GIB), "32-64gb");
+        assert_eq!(memory_bucket(64 * GIB), "64gb+");
+    }
+
+    #[test]
+    fn parses_linux_memory_strictly() {
+        assert_eq!(
+            parse_meminfo_total_bytes("MemFree: 10 kB\nMemTotal: 16384 kB\n"),
+            Some(16 * 1024 * 1024)
+        );
+        assert_eq!(parse_meminfo_total_bytes("MemTotal: 16 MB\n"), None);
+    }
+
+    #[test]
+    fn cpu_vector_tier_is_an_allowlisted_scalar() {
+        assert!(matches!(
+            cpu_vector_tier(),
+            "avx512" | "avx2" | "x86_baseline" | "arm_neon" | "other"
+        ));
+    }
+}

--- a/crates/ctx-cli/src/identity.rs
+++ b/crates/ctx-cli/src/identity.rs
@@ -68,7 +68,11 @@ pub fn device_id(data_root: &Path) -> Result<String> {
 }
 
 pub fn device_path(data_root: &Path) -> Result<PathBuf> {
-    let path = device_state_dir()?.join(DEVICE_FILE);
+    device_state_path(DEVICE_FILE, data_root)
+}
+
+pub(crate) fn device_state_path(file_name: &str, data_root: &Path) -> Result<PathBuf> {
+    let path = device_state_dir()?.join(file_name);
     ensure_device_path_outside_data_root(&path, data_root)?;
     Ok(path)
 }
@@ -76,13 +80,45 @@ pub fn device_path(data_root: &Path) -> Result<PathBuf> {
 pub(crate) fn ensure_device_path_outside_data_root(path: &Path, data_root: &Path) -> Result<()> {
     let normalized_path = normalize_for_prefix_check(path);
     let normalized_data_root = normalize_for_prefix_check(data_root);
-    if normalized_path.starts_with(&normalized_data_root) {
+    let resolved_path = resolve_for_prefix_check(&normalized_path)?;
+    let resolved_data_root = resolve_for_prefix_check(&normalized_data_root)?;
+    if normalized_path.starts_with(&normalized_data_root)
+        || resolved_path.starts_with(&resolved_data_root)
+    {
         bail!(
-            "refusing to store telemetry device identity under ctx data root: {}",
+            "refusing to store telemetry state under ctx data root: {}",
             path.display()
         );
     }
     Ok(())
+}
+
+fn resolve_for_prefix_check(path: &Path) -> Result<PathBuf> {
+    let mut existing = path.to_path_buf();
+    let mut missing = Vec::new();
+    loop {
+        match fs::symlink_metadata(&existing) {
+            Ok(_) => break,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                let name = existing
+                    .file_name()
+                    .context("resolve telemetry state path")?
+                    .to_os_string();
+                missing.push(name);
+                existing = existing
+                    .parent()
+                    .context("resolve telemetry state parent")?
+                    .to_path_buf();
+            }
+            Err(err) => return Err(err).with_context(|| format!("inspect {}", existing.display())),
+        }
+    }
+    let mut resolved =
+        fs::canonicalize(&existing).with_context(|| format!("resolve {}", existing.display()))?;
+    for name in missing.into_iter().rev() {
+        resolved.push(name);
+    }
+    Ok(resolved)
 }
 
 pub(crate) fn normalize_for_prefix_check(path: &Path) -> PathBuf {
@@ -152,20 +188,69 @@ pub(crate) fn home_dir() -> Option<PathBuf> {
 
 #[cfg(unix)]
 pub(crate) fn write_private_file(path: &Path, body: &[u8]) -> Result<()> {
-    use std::{fs::OpenOptions, io::Write, os::unix::fs::OpenOptionsExt};
+    use std::{
+        fs::OpenOptions,
+        io::Write,
+        os::unix::fs::{OpenOptionsExt, PermissionsExt},
+    };
 
     let mut file = OpenOptions::new()
         .create(true)
         .truncate(true)
         .write(true)
         .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
         .open(path)?;
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
     file.write_all(body)?;
     Ok(())
 }
 
-#[cfg(not(unix))]
+#[cfg(target_os = "windows")]
 pub(crate) fn write_private_file(path: &Path, body: &[u8]) -> Result<()> {
+    use std::{fs::OpenOptions, io::Write, os::windows::fs::OpenOptionsExt};
+
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    if file.metadata()?.file_type().is_symlink() {
+        bail!("refusing to write telemetry state through a symlink");
+    }
+    file.set_len(0)?;
+    file.write_all(body)?;
+    Ok(())
+}
+
+#[cfg(not(any(unix, target_os = "windows")))]
+pub(crate) fn write_private_file(path: &Path, body: &[u8]) -> Result<()> {
+    if fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        bail!("refusing to write telemetry state through a symlink");
+    }
     fs::write(path, body)?;
     Ok(())
+}
+
+#[cfg(unix)]
+pub(crate) fn create_private_file(path: &Path, body: &[u8]) -> std::io::Result<()> {
+    use std::{fs::OpenOptions, io::Write, os::unix::fs::OpenOptionsExt};
+
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    file.write_all(body)
+}
+
+#[cfg(not(unix))]
+pub(crate) fn create_private_file(path: &Path, body: &[u8]) -> std::io::Result<()> {
+    use std::{fs::OpenOptions, io::Write};
+
+    let mut file = OpenOptions::new().create_new(true).write(true).open(path)?;
+    file.write_all(body)
 }

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -11,6 +11,7 @@ mod analytics;
 mod commands;
 mod config;
 mod docs;
+mod execution_capabilities;
 mod history_source_plugins;
 mod identity;
 mod install_marker;

--- a/crates/ctx-cli/tests/analytics.rs
+++ b/crates/ctx-cli/tests/analytics.rs
@@ -56,6 +56,7 @@ fn analytics_sends_coarse_cli_metadata_when_enabled() {
         event["events"][0]["properties"]["auto_upgrade_spawned"],
         false
     );
+    assert_capability_snapshot_is_coarse(analytics_event_properties(&event));
     assert_analytics_properties_are_allowlisted(analytics_event_properties(&event));
     for forbidden in [
         "command",
@@ -76,6 +77,261 @@ fn analytics_sends_coarse_cli_metadata_when_enabled() {
             "analytics leaked forbidden property {forbidden}: {event:#}"
         );
     }
+}
+
+#[test]
+fn capability_snapshot_is_sent_once_after_successful_delivery() {
+    let temp = tempdir();
+    let events_path = temp.path().join("analytics.jsonl");
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let data_root = temp.path().join("data");
+    fs::create_dir_all(&home).unwrap();
+
+    for _ in 0..2 {
+        ctx(&temp)
+            .arg("doctor")
+            .env("CTX_DATA_ROOT", &data_root)
+            .env("HOME", &home)
+            .env("XDG_STATE_HOME", &state)
+            .env("LOCALAPPDATA", &state)
+            .env_remove("CTX_ANALYTICS_OFF")
+            .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+            .env("CTX_UPGRADE_OFF", "1")
+            .assert()
+            .success();
+    }
+
+    let events = read_analytics_events(&events_path);
+    assert_eq!(events.len(), 2, "one request should be made per invocation");
+    assert!(events
+        .iter()
+        .all(|event| event["events"].as_array().unwrap().len() == 1));
+    let first_properties = analytics_event_properties(&events[0]);
+    assert_capability_snapshot_is_coarse(first_properties);
+    assert_analytics_properties_are_allowlisted(first_properties);
+    let second_properties = analytics_event_properties(&events[1]);
+    for key in CAPABILITY_PROPERTY_KEYS {
+        assert!(
+            !second_properties.contains_key(key),
+            "capability property {key} was sent more than once: {events:#?}"
+        );
+    }
+    assert_analytics_properties_are_allowlisted(second_properties);
+
+    let marker_path = expected_capability_marker_path(&home, &state);
+    assert!(marker_path.exists());
+    assert!(!marker_path.starts_with(&data_root));
+    assert_eq!(
+        fs::read_to_string(&marker_path).unwrap(),
+        "schema_version=1\n"
+    );
+    assert!(!expected_capability_claim_path(&home, &state).exists());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode = fs::metadata(marker_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+}
+
+#[test]
+fn capability_snapshot_failure_keeps_claim_and_suppresses_replay() {
+    let temp = tempdir();
+    let delivery_dir = temp.path().join("missing-delivery-dir");
+    let events_path = delivery_dir.join("analytics.jsonl");
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let data_root = temp.path().join("data");
+    fs::create_dir_all(&home).unwrap();
+
+    ctx(&temp)
+        .arg("doctor")
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+        .env("CTX_UPGRADE_OFF", "1")
+        .assert()
+        .success();
+
+    let marker_path = expected_capability_marker_path(&home, &state);
+    let claim_path = expected_capability_claim_path(&home, &state);
+    assert!(!events_path.exists());
+    assert!(
+        !marker_path.exists(),
+        "failed delivery must not look successfully reported"
+    );
+    assert!(
+        claim_path.exists(),
+        "uncertain delivery must retain the claim"
+    );
+
+    fs::create_dir_all(&delivery_dir).unwrap();
+    ctx(&temp)
+        .arg("doctor")
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+        .env("CTX_UPGRADE_OFF", "1")
+        .assert()
+        .success();
+
+    let events = read_analytics_events(&events_path);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["events"].as_array().unwrap().len(), 1);
+    let properties = analytics_event_properties(&events[0]);
+    for key in CAPABILITY_PROPERTY_KEYS {
+        assert!(!properties.contains_key(key));
+    }
+    assert_analytics_properties_are_allowlisted(properties);
+    assert!(!marker_path.exists());
+    assert!(claim_path.exists());
+}
+
+#[test]
+fn concurrent_invocations_claim_at_most_one_capability_snapshot() {
+    let temp = tempdir();
+    let binary = copied_ctx_binary(&temp);
+    let events_path = temp.path().join("analytics.jsonl");
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    fs::create_dir_all(&home).unwrap();
+
+    let mut children = Vec::new();
+    for index in 0..8 {
+        children.push(
+            std::process::Command::new(&binary)
+                .arg("doctor")
+                .env("CTX_DATA_ROOT", temp.path().join(format!("data-{index}")))
+                .env("HOME", &home)
+                .env("XDG_STATE_HOME", &state)
+                .env("LOCALAPPDATA", &state)
+                .env_remove("CTX_ANALYTICS_OFF")
+                .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+                .env("CTX_UPGRADE_OFF", "1")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .unwrap(),
+        );
+    }
+    for mut child in children {
+        assert!(child.wait().unwrap().success());
+    }
+
+    let body = fs::read_to_string(&events_path).unwrap();
+    assert_eq!(body.matches("capability_snapshot_schema").count(), 1);
+    assert!(expected_capability_marker_path(&home, &state).exists());
+    assert!(!expected_capability_claim_path(&home, &state).exists());
+}
+
+#[test]
+fn existing_claim_suppresses_replay_without_being_rewritten() {
+    let temp = tempdir();
+    let events_path = temp.path().join("analytics.jsonl");
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let data_root = temp.path().join("data");
+    let claim_path = expected_capability_claim_path(&home, &state);
+    fs::create_dir_all(claim_path.parent().unwrap()).unwrap();
+    fs::write(&claim_path, "existing-claim\n").unwrap();
+
+    ctx(&temp)
+        .arg("doctor")
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+        .env("CTX_UPGRADE_OFF", "1")
+        .assert()
+        .success();
+
+    let event = read_analytics_events(&events_path).remove(0);
+    for key in CAPABILITY_PROPERTY_KEYS {
+        assert!(!analytics_event_properties(&event).contains_key(key));
+    }
+    assert_eq!(fs::read_to_string(claim_path).unwrap(), "existing-claim\n");
+}
+
+#[cfg(unix)]
+#[test]
+fn capability_claim_symlink_is_never_followed_or_overwritten() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir();
+    let events_path = temp.path().join("analytics.jsonl");
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let data_root = temp.path().join("data");
+    let sentinel = temp.path().join("sentinel.txt");
+    let claim_path = expected_capability_claim_path(&home, &state);
+    fs::create_dir_all(claim_path.parent().unwrap()).unwrap();
+    fs::write(&sentinel, "do-not-touch\n").unwrap();
+    symlink(&sentinel, &claim_path).unwrap();
+
+    ctx(&temp)
+        .arg("doctor")
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+        .env("CTX_UPGRADE_OFF", "1")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&sentinel).unwrap(), "do-not-touch\n");
+    assert!(fs::symlink_metadata(claim_path)
+        .unwrap()
+        .file_type()
+        .is_symlink());
+}
+
+#[cfg(unix)]
+#[test]
+fn analytics_device_identity_symlink_is_never_followed_or_overwritten() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir();
+    let events_path = temp.path().join("analytics.jsonl");
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let data_root = temp.path().join("data");
+    let sentinel = temp.path().join("sentinel.json");
+    let device_path = expected_device_path(&home, &state);
+    fs::create_dir_all(device_path.parent().unwrap()).unwrap();
+    fs::write(&sentinel, "{}\n").unwrap();
+    symlink(&sentinel, &device_path).unwrap();
+
+    ctx(&temp)
+        .arg("doctor")
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+        .env("CTX_UPGRADE_OFF", "1")
+        .assert()
+        .success();
+
+    assert!(!events_path.exists());
+    assert_eq!(fs::read_to_string(&sentinel).unwrap(), "{}\n");
+    assert!(fs::symlink_metadata(device_path)
+        .unwrap()
+        .file_type()
+        .is_symlink());
 }
 
 #[test]
@@ -111,6 +367,11 @@ fn status_does_not_emit_analytics_or_create_identities_when_enabled() {
         !expected_device_path(&home, &state).exists(),
         "status must not create a device identity"
     );
+    assert!(
+        !expected_capability_marker_path(&home, &state).exists(),
+        "status must not create a capability marker"
+    );
+    assert_no_capability_state(&home, &state);
 }
 
 #[test]
@@ -146,6 +407,11 @@ fn daemon_status_does_not_emit_analytics_or_create_identities_when_enabled() {
         !expected_device_path(&home, &state).exists(),
         "daemon status must not create a device identity"
     );
+    assert!(
+        !expected_capability_marker_path(&home, &state).exists(),
+        "daemon status must not create a capability marker"
+    );
+    assert_no_capability_state(&home, &state);
 }
 
 #[test]
@@ -878,6 +1144,10 @@ fn setup_analytics_emits_start_and_completion_events() {
     assert!(started_properties
         .get("has_indexed_content_after_setup")
         .is_none());
+    assert_capability_snapshot_is_coarse(started_properties);
+    for key in CAPABILITY_PROPERTY_KEYS {
+        assert!(!completed_properties.contains_key(key));
+    }
     assert_eq!(completed_properties["setup_completed"], true);
     assert_eq!(completed_properties["setup_result"], "success");
     assert_eq!(
@@ -928,6 +1198,10 @@ fn setup_analytics_emits_failure_completion_event() {
     assert!(completed_properties
         .get("has_indexed_content_after_setup")
         .is_none());
+    assert_capability_snapshot_is_coarse(started_properties);
+    for key in CAPABILITY_PROPERTY_KEYS {
+        assert!(!completed_properties.contains_key(key));
+    }
     for event in &events {
         assert_analytics_properties_are_allowlisted(analytics_event_properties(event));
     }
@@ -965,6 +1239,11 @@ fn setup_analytics_opt_out_suppresses_start_completion_and_identities() {
         !expected_device_path(&home, &state).exists(),
         "setup analytics opt-out should not create a device identity"
     );
+    assert!(
+        !expected_capability_marker_path(&home, &state).exists(),
+        "setup analytics opt-out should not create a capability marker"
+    );
+    assert_no_capability_state(&home, &state);
 }
 
 #[test]
@@ -1001,6 +1280,11 @@ fn setup_analytics_dry_run_suppresses_start_completion_and_identities() {
         !expected_device_path(&home, &state).exists(),
         "setup analytics dry run should not create a device identity"
     );
+    assert!(
+        !expected_capability_marker_path(&home, &state).exists(),
+        "setup analytics dry run should not create a capability marker"
+    );
+    assert_no_capability_state(&home, &state);
 }
 
 #[test]
@@ -1035,6 +1319,11 @@ fn analytics_config_opt_out_suppresses_delivery() {
         !expected_device_path(temp.path(), &state).exists(),
         "disabled analytics should not create a device identity"
     );
+    assert!(
+        !expected_capability_marker_path(temp.path(), &state).exists(),
+        "disabled analytics should not create a capability marker"
+    );
+    assert_no_capability_state(temp.path(), &state);
 }
 
 #[test]
@@ -1061,18 +1350,25 @@ fn analytics_env_opt_out_wins_over_enable_flag() {
         !expected_device_path(temp.path(), &state).exists(),
         "hard opt-out should not create a device identity"
     );
+    assert!(
+        !expected_capability_marker_path(temp.path(), &state).exists(),
+        "hard opt-out should not create a capability marker"
+    );
+    assert_no_capability_state(temp.path(), &state);
 }
 
 #[test]
 fn analytics_refuses_device_identity_under_data_root() {
     let temp = tempdir();
     let data_root = temp.path().join("ctx-data");
+    let home = data_root.clone();
     let state = data_root.join("state");
     let events_path = temp.path().join("analytics.jsonl");
 
     ctx(&temp)
         .arg("doctor")
         .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
         .env("XDG_STATE_HOME", &state)
         .env("LOCALAPPDATA", &state)
         .env_remove("CTX_ANALYTICS_OFF")
@@ -1088,4 +1384,30 @@ fn analytics_refuses_device_identity_under_data_root() {
         !state.join("ctx").join("device.json").exists(),
         "device identity must not be created under CTX_DATA_ROOT"
     );
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn analytics_refuses_symlinked_state_directory_under_data_root() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir();
+    let data_root = temp.path().join("ctx-data");
+    let state_link = temp.path().join("state-link");
+    let events_path = temp.path().join("analytics.jsonl");
+    fs::create_dir_all(&data_root).unwrap();
+    symlink(&data_root, &state_link).unwrap();
+
+    ctx(&temp)
+        .arg("doctor")
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("XDG_STATE_HOME", &state_link)
+        .env("LOCALAPPDATA", &state_link)
+        .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+        .assert()
+        .success();
+
+    assert!(!events_path.exists());
+    assert!(!data_root.join("ctx").exists());
 }

--- a/crates/ctx-cli/tests/support/analytics.rs
+++ b/crates/ctx-cli/tests/support/analytics.rs
@@ -5,6 +5,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
+pub(crate) const CAPABILITY_PROPERTY_KEYS: [&str; 5] = [
+    "capability_snapshot_schema",
+    "available_parallelism_bucket",
+    "host_memory_bucket",
+    "cpu_vector_tier",
+    "acceleration_candidate",
+];
+
 pub(crate) fn read_analytics_events(path: &Path) -> Vec<Value> {
     fs::read_to_string(path)
         .unwrap()
@@ -21,10 +29,10 @@ pub(crate) fn analytics_cli_event(event: &Value) -> &Value {
     &event["events"][0]
 }
 
-pub(crate) fn expected_device_path(_home: &Path, state: &Path) -> PathBuf {
+pub(crate) fn expected_device_path(_home: &Path, _state: &Path) -> PathBuf {
     #[cfg(target_os = "windows")]
     {
-        state.join("ctx").join("device.json")
+        _state.join("ctx").join("device.json")
     }
     #[cfg(target_os = "macos")]
     {
@@ -36,8 +44,81 @@ pub(crate) fn expected_device_path(_home: &Path, state: &Path) -> PathBuf {
     }
     #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
     {
-        state.join("ctx").join("device.json")
+        _state.join("ctx").join("device.json")
     }
+}
+
+pub(crate) fn expected_capability_marker_path(home: &Path, state: &Path) -> PathBuf {
+    expected_device_path(home, state).with_file_name("execution-capabilities-v1.reported")
+}
+
+pub(crate) fn expected_capability_claim_path(home: &Path, state: &Path) -> PathBuf {
+    expected_device_path(home, state).with_file_name("execution-capabilities-v1.claim")
+}
+
+pub(crate) fn assert_no_capability_state(home: &Path, state: &Path) {
+    assert!(!expected_capability_marker_path(home, state).exists());
+    assert!(!expected_capability_claim_path(home, state).exists());
+}
+
+pub(crate) fn assert_capability_snapshot_is_coarse(properties: &serde_json::Map<String, Value>) {
+    assert_eq!(properties["capability_snapshot_schema"], 1);
+    assert_string_property_is_one_of(
+        properties,
+        "available_parallelism_bucket",
+        &[
+            "unknown", "1", "2", "3-4", "5-8", "9-16", "17-32", "33-64", "65+",
+        ],
+    );
+    assert_string_property_is_one_of(
+        properties,
+        "host_memory_bucket",
+        &[
+            "unknown", "lt_4gb", "4-8gb", "8-16gb", "16-32gb", "32-64gb", "64gb+",
+        ],
+    );
+    assert_string_property_is_one_of(
+        properties,
+        "cpu_vector_tier",
+        &["avx512", "avx2", "x86_baseline", "arm_neon", "other"],
+    );
+    assert_string_property_is_one_of(
+        properties,
+        "acceleration_candidate",
+        &["apple_ane", "nvidia_cuda", "not_detected", "unknown"],
+    );
+
+    for raw_key in [
+        "available_parallelism",
+        "host_memory_bucket_raw",
+        "host_memory_bytes",
+        "cpu_model",
+        "cpu_name",
+        "gpu_model",
+        "gpu_name",
+        "cuda_device_name",
+        "hardware_id",
+        "serial_number",
+    ] {
+        assert!(
+            !properties.contains_key(raw_key),
+            "analytics exposed raw hardware property {raw_key}: {properties:#?}"
+        );
+    }
+}
+
+fn assert_string_property_is_one_of(
+    properties: &serde_json::Map<String, Value>,
+    key: &str,
+    allowed: &[&str],
+) {
+    let value = properties[key]
+        .as_str()
+        .unwrap_or_else(|| panic!("capability property {key} must be a string: {properties:#?}"));
+    assert!(
+        allowed.contains(&value),
+        "unexpected capability property {key}={value:?}: {properties:#?}"
+    );
 }
 
 pub(crate) fn assert_no_json_string_contains(value: &Value, forbidden: &[&str]) {
@@ -68,9 +149,11 @@ pub(crate) fn assert_analytics_properties_are_allowlisted(
     properties: &serde_json::Map<String, Value>,
 ) {
     let allowed = [
+        "acceleration_candidate",
         "action",
         "all_sources",
         "analytics_client",
+        "available_parallelism_bucket",
         "available_sources_bucket",
         "auto_upgrade_allowed",
         "auto_upgrade_due",
@@ -78,10 +161,12 @@ pub(crate) fn assert_analytics_properties_are_allowlisted(
         "auto_upgrade_spawn_status",
         "auto_upgrade_spawned",
         "background",
+        "capability_snapshot_schema",
         "catalog_only",
         "catalog_source_bytes_bucket",
         "cataloged_sessions_bucket",
         "citation_count_bucket",
+        "cpu_vector_tier",
         "db_size_bucket",
         "daemon_command",
         "dry_run",
@@ -101,6 +186,7 @@ pub(crate) fn assert_analytics_properties_are_allowlisted(
         "has_session_filter",
         "has_since_filter",
         "has_workspace_filter",
+        "host_memory_bucket",
         "had_existing_store_before_search",
         "had_indexed_content_before_search",
         "include_current_session",

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -320,8 +320,10 @@ First-party analytics are default-on and may create `install.json` plus a
 separate device identity file in OS user state, then send coarse product
 metadata. They do not send session text, prompts, transcripts, search queries,
 result snippets, source paths, repository or branch names, native session IDs,
-command text, command output, usernames, hostnames, raw IP addresses, or
-hardware-derived machine fingerprints.
+command text, command output, usernames, hostnames, raw IP addresses, exact
+CPU or GPU names, serial numbers, hardware IDs, live utilization, or benchmark
+results. Coarse capability ranges are bucketed before they are sent and are not
+used to derive a machine identity.
 
 Analytics may include:
 
@@ -331,6 +333,10 @@ Analytics may include:
 - JSON-output and option booleans such as whether a search used filters;
 - bucketed counts such as indexed sessions, import totals, result counts, and
   validation finding counts;
+- a versioned coarse execution-capability snapshot, including available
+  parallelism, host-visible memory range, CPU vector support, and whether the
+  platform is a candidate for Apple Neural Engine or NVIDIA CUDA acceleration,
+  without loading an accelerator runtime or collecting component names;
 - bucketed search query length and term count, but not query content;
 - provider identifiers such as `codex` or `claude` when selected as filters;
 - coarse Cloudflare-derived geography such as country, region, colo, ASN, and
@@ -341,6 +347,11 @@ root and represents that local index. The device identifier is a random UUID
 created only when analytics are enabled and an event is sent; it lives outside
 the ctx data root in OS user state, such as `$XDG_STATE_HOME/ctx/device.json` or
 `~/.local/state/ctx/device.json` on Linux.
+When a capability snapshot is eligible, ctx also creates a private versioned
+claim in that state directory and promotes it to a version marker after
+delivery. This avoids routinely sending the same snapshot again. If delivery
+fails or is interrupted, the claim remains in place so ctx does not risk
+replaying a snapshot whose delivery status is uncertain.
 
 `ctx sql` and MCP do not send first-party analytics events.
 


### PR DESCRIPTION
## Summary

This adds a versioned, coarse execution-capability snapshot to the existing CLI analytics request so we can prioritize compatibility and performance work across the machines people use.

- reports bucketed available parallelism and host-visible memory
- reports an allowlisted CPU vector tier and passive accelerator candidate
- sends the snapshot at most once per schema version using private local state
- respects the existing analytics opt-out, dry-run, and command eligibility behavior

The snapshot does not include component names, serial numbers, hardware IDs, exact memory sizes, utilization, or benchmark results. Accelerator checks do not load a runtime or model.

## Validation

- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo check -p ctx --target x86_64-pc-windows-gnu --locked`
- `cargo check -p ctx --target x86_64-unknown-freebsd --locked`
- exact 11-target Bazel public smoke gate
- native Linux and Apple Silicon payload smoke tests
- independent adversarial privacy, security, concurrency, and portability review