### PR TITLE
Bound Hermes import and FTS merge WAL growth

### DIFF
--- a/crates/ctx-cli/src/commands/import/catalog.rs
+++ b/crates/ctx-cli/src/commands/import/catalog.rs
@@ -332,6 +332,7 @@ pub(crate) fn source_uses_incremental_event_search(source: &SourceInfo) -> bool 
             | CaptureProvider::Firebender
             | CaptureProvider::ForgeCode
             | CaptureProvider::DeepAgents
+            | CaptureProvider::Hermes
             | CaptureProvider::MistralVibe
             | CaptureProvider::Mux
             | CaptureProvider::RovoDev

--- a/crates/ctx-history-capture/src/provider/api/json_sources.rs
+++ b/crates/ctx-history-capture/src/provider/api/json_sources.rs
@@ -9,7 +9,8 @@ use crate::provider::adapter::{
     ProviderCaptureAdapter, RooTaskJsonAdapter,
 };
 use crate::provider::importer::{
-    import_native_jsonl_tree, import_normalized_provider_captures, NativeJsonlTreeImport,
+    import_native_jsonl_tree, import_normalized_provider_captures,
+    import_normalized_provider_captures_in_batches, NativeJsonlTreeImport,
 };
 use crate::provider::providers::trae::normalize_trae_history;
 use crate::{
@@ -323,17 +324,25 @@ pub fn import_hermes_sqlite(
             imported_at: options.imported_at,
         },
     )?;
-    import_normalized_provider_captures(
-        store,
-        normalization,
-        NormalizedProviderImportOptions {
-            history_record_id: options.history_record_id,
-            allow_partial_failures: options.allow_partial_failures,
-            persist_cursors: true,
-            wrap_transaction: true,
-            fast_event_inserts: true,
-        },
-    )
+    const HERMES_TRANSACTION_BATCH_MESSAGES: usize = 64;
+    let allow_partial_failures = options.allow_partial_failures;
+    let import_options = NormalizedProviderImportOptions {
+        history_record_id: options.history_record_id,
+        allow_partial_failures,
+        persist_cursors: true,
+        wrap_transaction: true,
+        fast_event_inserts: true,
+    };
+    if allow_partial_failures {
+        import_normalized_provider_captures_in_batches(
+            store,
+            normalization,
+            import_options,
+            HERMES_TRANSACTION_BATCH_MESSAGES,
+        )
+    } else {
+        import_normalized_provider_captures(store, normalization, import_options)
+    }
 }
 
 pub fn import_auggie_history(

--- a/crates/ctx-history-capture/src/provider/api/json_sources.rs
+++ b/crates/ctx-history-capture/src/provider/api/json_sources.rs
@@ -10,7 +10,8 @@ use crate::provider::adapter::{
 };
 use crate::provider::importer::{
     import_native_jsonl_tree, import_normalized_provider_captures,
-    import_normalized_provider_captures_in_batches, NativeJsonlTreeImport,
+    import_normalized_provider_captures_in_batches,
+    import_normalized_provider_captures_with_bulk_search, NativeJsonlTreeImport,
 };
 use crate::provider::providers::trae::normalize_trae_history;
 use crate::{
@@ -341,7 +342,7 @@ pub fn import_hermes_sqlite(
             HERMES_TRANSACTION_BATCH_MESSAGES,
         )
     } else {
-        import_normalized_provider_captures(store, normalization, import_options)
+        import_normalized_provider_captures_with_bulk_search(store, normalization, import_options)
     }
 }
 

--- a/crates/ctx-history-capture/src/provider/importer.rs
+++ b/crates/ctx-history-capture/src/provider/importer.rs
@@ -24,6 +24,7 @@ use crate::{
     ProviderNormalizationResult, Result,
 };
 
+mod batches;
 mod commands;
 mod cursors;
 mod identity;
@@ -101,12 +102,15 @@ pub fn import_normalized_provider_captures(
     normalization: ProviderNormalizationResult,
     options: NormalizedProviderImportOptions,
 ) -> Result<ProviderImportSummary> {
-    let ProviderNormalizationResult {
-        summary,
-        captures,
-        files_touched,
-    } = normalization;
-    import_provider_capture_lines(store, options, summary, captures, files_touched)
+    batches::import_normalized_provider_captures(store, normalization, options, false)
+}
+
+pub(crate) fn import_normalized_provider_captures_with_bulk_search(
+    store: &mut Store,
+    normalization: ProviderNormalizationResult,
+    options: NormalizedProviderImportOptions,
+) -> Result<ProviderImportSummary> {
+    batches::import_normalized_provider_captures(store, normalization, options, true)
 }
 
 pub(crate) fn import_normalized_provider_captures_in_batches(
@@ -115,18 +119,11 @@ pub(crate) fn import_normalized_provider_captures_in_batches(
     options: NormalizedProviderImportOptions,
     transaction_batch_size: usize,
 ) -> Result<ProviderImportSummary> {
-    let ProviderNormalizationResult {
-        summary,
-        captures,
-        files_touched,
-    } = normalization;
-    import_provider_capture_lines_with_batch_size(
+    batches::import_normalized_provider_captures_in_batches(
         store,
+        normalization,
         options,
-        summary,
-        captures,
-        files_touched,
-        Some(transaction_batch_size.max(1)),
+        transaction_batch_size,
     )
 }
 
@@ -137,133 +134,7 @@ pub(crate) fn import_provider_capture_lines(
     captures: Vec<(usize, ProviderCaptureEnvelope)>,
     files_touched: Vec<(usize, ProviderFileTouchedEnvelope)>,
 ) -> Result<ProviderImportSummary> {
-    import_provider_capture_lines_with_batch_size(
-        store,
-        options,
-        summary,
-        captures,
-        files_touched,
-        None,
-    )
-}
-
-fn import_provider_capture_lines_with_batch_size(
-    store: &mut Store,
-    options: NormalizedProviderImportOptions,
-    mut summary: ProviderImportSummary,
-    mut captures: Vec<(usize, ProviderCaptureEnvelope)>,
-    mut files_touched: Vec<(usize, ProviderFileTouchedEnvelope)>,
-    transaction_batch_size: Option<usize>,
-) -> Result<ProviderImportSummary> {
-    let mut caches = ProviderImportCaches::default();
-    filter_provider_capture_lines_without_real_session_messages(
-        &mut summary,
-        &mut captures,
-        &mut files_touched,
-    );
-    let supplied_file_touch_lines = files_touched
-        .iter()
-        .map(|(line_number, _)| *line_number)
-        .collect::<BTreeSet<_>>();
-    if summary.failed == 0 && !provider_capture_lines_have_real_message(&captures) {
-        let line = captures
-            .first()
-            .map(|(line_number, _)| *line_number)
-            .or_else(|| files_touched.first().map(|(line_number, _)| *line_number))
-            .unwrap_or(0);
-        summary.failed += 1;
-        summary.failures.push(ProviderImportFailure {
-            line,
-            error: "provider source contained no real conversation message".to_owned(),
-        });
-        return Ok(summary);
-    }
-    for (line_number, capture) in &captures {
-        if capture.provider == CaptureProvider::Codex {
-            continue;
-        }
-        if supplied_file_touch_lines.contains(line_number) {
-            continue;
-        }
-        if let Some(event) = &capture.event {
-            files_touched.extend(provider_file_touches_from_event(
-                capture.provider,
-                &capture.session.provider_session_id,
-                &capture.source.source_format,
-                capture.source.raw_source_path.as_deref(),
-                capture.source.source_root.as_deref(),
-                event,
-                *line_number,
-            ));
-        }
-    }
-    let has_captures = !captures.is_empty() || !files_touched.is_empty();
-
-    if summary.failed > 0 && !options.allow_partial_failures {
-        return Ok(summary);
-    }
-
-    if has_captures && options.wrap_transaction {
-        store.begin_immediate_batch()?;
-    }
-    let mut captures_in_transaction = 0usize;
-    let capture_count = captures.len();
-    for (capture_index, (line_number, capture)) in captures.into_iter().enumerate() {
-        match import_provider_capture_line(store, &capture, &options, line_number, &mut caches) {
-            Ok(line_summary) => summary.merge(line_summary),
-            Err(err) => {
-                summary.failed += 1;
-                summary.failures.push(ProviderImportFailure {
-                    line: line_number,
-                    error: err.to_string(),
-                });
-            }
-        }
-        captures_in_transaction += 1;
-        if has_captures
-            && options.wrap_transaction
-            && transaction_batch_size
-                .is_some_and(|batch_size| captures_in_transaction >= batch_size)
-            && capture_index + 1 < capture_count
-        {
-            if let Err(err) = store.commit_batch() {
-                let _ = store.rollback_batch();
-                return Err(err.into());
-            }
-            store.checkpoint_wal_truncate()?;
-            store.begin_immediate_batch()?;
-            captures_in_transaction = 0;
-        }
-    }
-    if let Err(err) = resolve_pending_provider_edges(store, &mut summary, &mut caches) {
-        if has_captures && options.wrap_transaction {
-            let _ = store.rollback_batch();
-        }
-        return Err(err);
-    }
-    for (line_number, file) in files_touched {
-        if let Err(err) = import_provider_file_touched_line(store, &file, &options) {
-            summary.failed += 1;
-            summary.failures.push(ProviderImportFailure {
-                line: line_number,
-                error: err.to_string(),
-            });
-        }
-    }
-    if summary.failed > 0 && !options.allow_partial_failures {
-        if has_captures && options.wrap_transaction {
-            let _ = store.rollback_batch();
-        }
-        return Ok(summary);
-    }
-    if has_captures && options.wrap_transaction {
-        if let Err(err) = store.commit_batch() {
-            let _ = store.rollback_batch();
-            return Err(err.into());
-        }
-    }
-
-    Ok(summary)
+    batches::import_provider_capture_lines(store, options, summary, captures, files_touched)
 }
 
 fn filter_provider_capture_lines_without_real_session_messages(
@@ -999,53 +870,60 @@ pub(crate) fn resolve_pending_provider_edges(
 ) -> Result<()> {
     let pending = std::mem::take(&mut caches.pending_edges);
     for (edge_id, edge) in pending {
-        if caches.processed_edges.contains(&edge_id) {
-            update_session_parent_if_needed(store, &edge, caches)?;
-            continue;
-        }
-        if !provider_session_exists_cached(
-            store,
-            edge.parent_session_id,
-            &mut caches.session_exists,
-        )? {
-            summary.skipped_edges += 1;
-            summary.skipped += 1;
-            continue;
-        }
-        let root_session_id = resolve_pending_root_session_id(store, &edge, caches)?;
-        update_session_parent(store, &edge, root_session_id)?;
-        caches.session_exists.insert(edge.session_id, true);
+        resolve_pending_provider_edge(store, summary, caches, edge_id, edge)?;
+    }
+    Ok(())
+}
 
-        let was_present = store.session_edge_exists(edge_id)?;
-        let session_edge = SessionEdge {
-            id: edge_id,
-            from_session_id: edge.parent_session_id,
-            to_session_id: edge.session_id,
-            edge_type: SessionEdgeType::ParentChild,
-            confidence: Confidence::Explicit,
-            source_id: Some(edge.source_id),
-            timestamps: timestamps(edge.imported_at),
-            sync: provider_sync_metadata(
-                edge.fidelity,
-                json!({
-                    "provider_session_id": edge.provider_session_id,
-                    "parent_provider_session_id": edge.parent_provider_session_id,
-                    "source_format": edge.source_format,
-                    "fixture_line": edge.line_number,
-                    "imported_at": edge.imported_at,
-                    "deferred_edge_resolution": true,
-                }),
-            ),
-        };
-        store.upsert_session_edge(&session_edge)?;
-        caches.processed_edges.insert(edge_id);
-        if !was_present && caches.imported_edges.insert(edge_id) {
-            summary.imported_edges += 1;
-            summary.imported += 1;
-        } else {
-            summary.skipped_edges += 1;
-            summary.skipped += 1;
-        }
+fn resolve_pending_provider_edge(
+    store: &mut Store,
+    summary: &mut ProviderImportSummary,
+    caches: &mut ProviderImportCaches,
+    edge_id: Uuid,
+    edge: PendingProviderEdge,
+) -> Result<()> {
+    if caches.processed_edges.contains(&edge_id) {
+        update_session_parent_if_needed(store, &edge, caches)?;
+        return Ok(());
+    }
+    if !provider_session_exists_cached(store, edge.parent_session_id, &mut caches.session_exists)? {
+        summary.skipped_edges += 1;
+        summary.skipped += 1;
+        return Ok(());
+    }
+    let root_session_id = resolve_pending_root_session_id(store, &edge, caches)?;
+    update_session_parent(store, &edge, root_session_id)?;
+    caches.session_exists.insert(edge.session_id, true);
+
+    let was_present = store.session_edge_exists(edge_id)?;
+    let session_edge = SessionEdge {
+        id: edge_id,
+        from_session_id: edge.parent_session_id,
+        to_session_id: edge.session_id,
+        edge_type: SessionEdgeType::ParentChild,
+        confidence: Confidence::Explicit,
+        source_id: Some(edge.source_id),
+        timestamps: timestamps(edge.imported_at),
+        sync: provider_sync_metadata(
+            edge.fidelity,
+            json!({
+                "provider_session_id": edge.provider_session_id,
+                "parent_provider_session_id": edge.parent_provider_session_id,
+                "source_format": edge.source_format,
+                "fixture_line": edge.line_number,
+                "imported_at": edge.imported_at,
+                "deferred_edge_resolution": true,
+            }),
+        ),
+    };
+    store.upsert_session_edge(&session_edge)?;
+    caches.processed_edges.insert(edge_id);
+    if !was_present && caches.imported_edges.insert(edge_id) {
+        summary.imported_edges += 1;
+        summary.imported += 1;
+    } else {
+        summary.skipped_edges += 1;
+        summary.skipped += 1;
     }
     Ok(())
 }

--- a/crates/ctx-history-capture/src/provider/importer.rs
+++ b/crates/ctx-history-capture/src/provider/importer.rs
@@ -108,12 +108,52 @@ pub fn import_normalized_provider_captures(
     } = normalization;
     import_provider_capture_lines(store, options, summary, captures, files_touched)
 }
+
+pub(crate) fn import_normalized_provider_captures_in_batches(
+    store: &mut Store,
+    normalization: ProviderNormalizationResult,
+    options: NormalizedProviderImportOptions,
+    transaction_batch_size: usize,
+) -> Result<ProviderImportSummary> {
+    let ProviderNormalizationResult {
+        summary,
+        captures,
+        files_touched,
+    } = normalization;
+    import_provider_capture_lines_with_batch_size(
+        store,
+        options,
+        summary,
+        captures,
+        files_touched,
+        Some(transaction_batch_size.max(1)),
+    )
+}
+
 pub(crate) fn import_provider_capture_lines(
+    store: &mut Store,
+    options: NormalizedProviderImportOptions,
+    summary: ProviderImportSummary,
+    captures: Vec<(usize, ProviderCaptureEnvelope)>,
+    files_touched: Vec<(usize, ProviderFileTouchedEnvelope)>,
+) -> Result<ProviderImportSummary> {
+    import_provider_capture_lines_with_batch_size(
+        store,
+        options,
+        summary,
+        captures,
+        files_touched,
+        None,
+    )
+}
+
+fn import_provider_capture_lines_with_batch_size(
     store: &mut Store,
     options: NormalizedProviderImportOptions,
     mut summary: ProviderImportSummary,
     mut captures: Vec<(usize, ProviderCaptureEnvelope)>,
     mut files_touched: Vec<(usize, ProviderFileTouchedEnvelope)>,
+    transaction_batch_size: Option<usize>,
 ) -> Result<ProviderImportSummary> {
     let mut caches = ProviderImportCaches::default();
     filter_provider_capture_lines_without_real_session_messages(
@@ -166,7 +206,9 @@ pub(crate) fn import_provider_capture_lines(
     if has_captures && options.wrap_transaction {
         store.begin_immediate_batch()?;
     }
-    for (line_number, capture) in captures {
+    let mut captures_in_transaction = 0usize;
+    let capture_count = captures.len();
+    for (capture_index, (line_number, capture)) in captures.into_iter().enumerate() {
         match import_provider_capture_line(store, &capture, &options, line_number, &mut caches) {
             Ok(line_summary) => summary.merge(line_summary),
             Err(err) => {
@@ -176,6 +218,21 @@ pub(crate) fn import_provider_capture_lines(
                     error: err.to_string(),
                 });
             }
+        }
+        captures_in_transaction += 1;
+        if has_captures
+            && options.wrap_transaction
+            && transaction_batch_size
+                .is_some_and(|batch_size| captures_in_transaction >= batch_size)
+            && capture_index + 1 < capture_count
+        {
+            if let Err(err) = store.commit_batch() {
+                let _ = store.rollback_batch();
+                return Err(err.into());
+            }
+            store.checkpoint_wal_truncate()?;
+            store.begin_immediate_batch()?;
+            captures_in_transaction = 0;
         }
     }
     if let Err(err) = resolve_pending_provider_edges(store, &mut summary, &mut caches) {

--- a/crates/ctx-history-capture/src/provider/importer/batches.rs
+++ b/crates/ctx-history-capture/src/provider/importer/batches.rs
@@ -1,0 +1,379 @@
+use std::{collections::BTreeSet, io::Write, num::NonZeroUsize};
+
+use serde::Serialize;
+
+use super::*;
+
+const PROVIDER_IMPORT_TRANSACTION_BATCH_BYTES: usize = 8 * 1024 * 1024;
+
+pub(super) fn import_normalized_provider_captures(
+    store: &mut Store,
+    normalization: ProviderNormalizationResult,
+    options: NormalizedProviderImportOptions,
+    suppress_search_merges: bool,
+) -> Result<ProviderImportSummary> {
+    let ProviderNormalizationResult {
+        summary,
+        captures,
+        files_touched,
+    } = normalization;
+    import_provider_capture_lines_with_batch_size(
+        store,
+        options,
+        summary,
+        captures,
+        files_touched,
+        None,
+        suppress_search_merges,
+    )
+}
+
+pub(super) fn import_normalized_provider_captures_in_batches(
+    store: &mut Store,
+    normalization: ProviderNormalizationResult,
+    options: NormalizedProviderImportOptions,
+    transaction_batch_size: usize,
+) -> Result<ProviderImportSummary> {
+    if !options.allow_partial_failures {
+        return Err(CaptureError::InvalidPayload(
+            "batched provider import requires allow_partial_failures".to_owned(),
+        ));
+    }
+    if !options.wrap_transaction {
+        return Err(CaptureError::InvalidPayload(
+            "batched provider import requires transaction wrapping".to_owned(),
+        ));
+    }
+    let transaction_batch_size = NonZeroUsize::new(transaction_batch_size).ok_or_else(|| {
+        CaptureError::InvalidPayload(
+            "provider import batch size must be greater than zero".to_owned(),
+        )
+    })?;
+    let ProviderNormalizationResult {
+        summary,
+        captures,
+        files_touched,
+    } = normalization;
+    import_provider_capture_lines_with_batch_size(
+        store,
+        options,
+        summary,
+        captures,
+        files_touched,
+        Some(transaction_batch_size),
+        true,
+    )
+}
+
+pub(super) fn import_provider_capture_lines(
+    store: &mut Store,
+    options: NormalizedProviderImportOptions,
+    summary: ProviderImportSummary,
+    captures: Vec<(usize, ProviderCaptureEnvelope)>,
+    files_touched: Vec<(usize, ProviderFileTouchedEnvelope)>,
+) -> Result<ProviderImportSummary> {
+    import_provider_capture_lines_with_batch_size(
+        store,
+        options,
+        summary,
+        captures,
+        files_touched,
+        None,
+        false,
+    )
+}
+
+fn import_provider_capture_lines_with_batch_size(
+    store: &mut Store,
+    options: NormalizedProviderImportOptions,
+    mut summary: ProviderImportSummary,
+    mut captures: Vec<(usize, ProviderCaptureEnvelope)>,
+    mut files_touched: Vec<(usize, ProviderFileTouchedEnvelope)>,
+    transaction_batch_size: Option<NonZeroUsize>,
+    suppress_search_merges: bool,
+) -> Result<ProviderImportSummary> {
+    let caches = ProviderImportCaches::default();
+    filter_provider_capture_lines_without_real_session_messages(
+        &mut summary,
+        &mut captures,
+        &mut files_touched,
+    );
+    let supplied_file_touch_lines = files_touched
+        .iter()
+        .map(|(line_number, _)| *line_number)
+        .collect::<BTreeSet<_>>();
+    if summary.failed == 0 && !provider_capture_lines_have_real_message(&captures) {
+        let line = captures
+            .first()
+            .map(|(line_number, _)| *line_number)
+            .or_else(|| files_touched.first().map(|(line_number, _)| *line_number))
+            .unwrap_or(0);
+        summary.failed += 1;
+        summary.failures.push(ProviderImportFailure {
+            line,
+            error: "provider source contained no real conversation message".to_owned(),
+        });
+        return Ok(summary);
+    }
+    for (line_number, capture) in &captures {
+        if capture.provider == CaptureProvider::Codex
+            || supplied_file_touch_lines.contains(line_number)
+        {
+            continue;
+        }
+        if let Some(event) = &capture.event {
+            files_touched.extend(provider_file_touches_from_event(
+                capture.provider,
+                &capture.session.provider_session_id,
+                &capture.source.source_format,
+                capture.source.raw_source_path.as_deref(),
+                capture.source.source_root.as_deref(),
+                event,
+                *line_number,
+            ));
+        }
+    }
+    let has_captures = !captures.is_empty() || !files_touched.is_empty();
+    if summary.failed > 0 && !options.allow_partial_failures {
+        return Ok(summary);
+    }
+
+    let bulk_search_mode = suppress_search_merges && has_captures && options.wrap_transaction;
+    let bulk_search_guard = bulk_search_mode
+        .then(|| store.begin_event_search_bulk_mode())
+        .transpose()?;
+    let import_result = persist_provider_capture_lines(
+        store,
+        &options,
+        summary,
+        captures,
+        files_touched,
+        has_captures,
+        transaction_batch_size,
+        caches,
+    );
+    let finish_result = match &bulk_search_guard {
+        Some(guard) => store
+            .finish_event_search_bulk_mode(guard)
+            .map_err(CaptureError::from),
+        None => Ok(()),
+    };
+    match (import_result, finish_result) {
+        (Ok(summary), Ok(())) => Ok(summary),
+        (Err(err), _) => Err(err),
+        (Ok(_), Err(err)) => Err(err),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn persist_provider_capture_lines(
+    store: &mut Store,
+    options: &NormalizedProviderImportOptions,
+    mut summary: ProviderImportSummary,
+    captures: Vec<(usize, ProviderCaptureEnvelope)>,
+    files_touched: Vec<(usize, ProviderFileTouchedEnvelope)>,
+    has_captures: bool,
+    transaction_batch_size: Option<NonZeroUsize>,
+    mut caches: ProviderImportCaches,
+) -> Result<ProviderImportSummary> {
+    let mut transaction = ProviderImportTransaction::begin(
+        store,
+        has_captures && options.wrap_transaction,
+        transaction_batch_size,
+    )?;
+    for (line_number, capture) in captures {
+        let unit_bytes = serialized_len_or_rollback(&mut transaction, store, &capture)?;
+        prepare_or_rollback(&mut transaction, store, unit_bytes)?;
+        match import_provider_capture_line(store, &capture, options, line_number, &mut caches) {
+            Ok(line_summary) => summary.merge(line_summary),
+            Err(err) => {
+                summary.failed += 1;
+                summary.failures.push(ProviderImportFailure {
+                    line: line_number,
+                    error: err.to_string(),
+                });
+            }
+        }
+        record_or_rollback(&mut transaction, store, unit_bytes)?;
+    }
+    let pending = std::mem::take(&mut caches.pending_edges);
+    for (edge_id, edge) in pending {
+        let unit_bytes = pending_edge_estimated_len(&edge);
+        prepare_or_rollback(&mut transaction, store, unit_bytes)?;
+        if let Err(err) =
+            resolve_pending_provider_edge(store, &mut summary, &mut caches, edge_id, edge)
+        {
+            transaction.rollback(store);
+            return Err(err);
+        }
+        record_or_rollback(&mut transaction, store, unit_bytes)?;
+    }
+    for (line_number, file) in files_touched {
+        let unit_bytes = serialized_len_or_rollback(&mut transaction, store, &file)?;
+        prepare_or_rollback(&mut transaction, store, unit_bytes)?;
+        if let Err(err) = import_provider_file_touched_line(store, &file, options) {
+            summary.failed += 1;
+            summary.failures.push(ProviderImportFailure {
+                line: line_number,
+                error: err.to_string(),
+            });
+        }
+        record_or_rollback(&mut transaction, store, unit_bytes)?;
+    }
+    if summary.failed > 0 && !options.allow_partial_failures {
+        transaction.rollback(store);
+        return Ok(summary);
+    }
+    if let Err(err) = transaction.commit(store) {
+        transaction.rollback(store);
+        return Err(err);
+    }
+    Ok(summary)
+}
+
+fn prepare_or_rollback(
+    transaction: &mut ProviderImportTransaction,
+    store: &Store,
+    unit_bytes: usize,
+) -> Result<()> {
+    if let Err(err) = transaction.prepare_unit(store, unit_bytes) {
+        transaction.rollback(store);
+        return Err(err);
+    }
+    Ok(())
+}
+
+fn record_or_rollback(
+    transaction: &mut ProviderImportTransaction,
+    store: &Store,
+    unit_bytes: usize,
+) -> Result<()> {
+    if let Err(err) = transaction.record_unit(store, unit_bytes) {
+        transaction.rollback(store);
+        return Err(err);
+    }
+    Ok(())
+}
+
+fn serialized_len(value: &impl Serialize) -> Result<usize> {
+    let mut counter = ByteCounter::default();
+    serde_json::to_writer(&mut counter, value)?;
+    Ok(counter.bytes)
+}
+
+fn serialized_len_or_rollback(
+    transaction: &mut ProviderImportTransaction,
+    store: &Store,
+    value: &impl Serialize,
+) -> Result<usize> {
+    match serialized_len(value) {
+        Ok(bytes) => Ok(bytes),
+        Err(err) => {
+            transaction.rollback(store);
+            Err(err)
+        }
+    }
+}
+
+fn pending_edge_estimated_len(edge: &PendingProviderEdge) -> usize {
+    edge.provider_session_id
+        .len()
+        .saturating_add(
+            edge.parent_provider_session_id
+                .as_deref()
+                .map_or(0, str::len),
+        )
+        .saturating_add(edge.source_format.len())
+        .saturating_add(256)
+}
+
+#[derive(Default)]
+struct ByteCounter {
+    bytes: usize,
+}
+
+impl Write for ByteCounter {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.bytes = self.bytes.saturating_add(buffer.len());
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+struct ProviderImportTransaction {
+    active: bool,
+    batch_size: Option<NonZeroUsize>,
+    units: usize,
+    bytes: usize,
+}
+
+impl ProviderImportTransaction {
+    fn begin(store: &Store, has_work: bool, batch_size: Option<NonZeroUsize>) -> Result<Self> {
+        if has_work {
+            store.begin_immediate_batch()?;
+        }
+        Ok(Self {
+            active: has_work,
+            batch_size,
+            units: 0,
+            bytes: 0,
+        })
+    }
+
+    fn prepare_unit(&mut self, store: &Store, unit_bytes: usize) -> Result<()> {
+        if self.active
+            && self.batch_size.is_some()
+            && self.units > 0
+            && self.bytes.saturating_add(unit_bytes) > PROVIDER_IMPORT_TRANSACTION_BATCH_BYTES
+        {
+            self.rotate(store)?;
+        }
+        Ok(())
+    }
+
+    fn record_unit(&mut self, store: &Store, unit_bytes: usize) -> Result<()> {
+        if !self.active {
+            return Ok(());
+        }
+        self.units = self.units.saturating_add(1);
+        self.bytes = self.bytes.saturating_add(unit_bytes);
+        let below_unit_limit = self
+            .batch_size
+            .is_none_or(|batch_size| self.units < batch_size.get());
+        let below_byte_limit =
+            self.batch_size.is_none() || self.bytes < PROVIDER_IMPORT_TRANSACTION_BATCH_BYTES;
+        if below_unit_limit && below_byte_limit {
+            return Ok(());
+        }
+        self.rotate(store)
+    }
+
+    fn rotate(&mut self, store: &Store) -> Result<()> {
+        store.commit_batch()?;
+        self.active = false;
+        store.checkpoint_wal_truncate_required()?;
+        store.begin_immediate_batch()?;
+        self.active = true;
+        self.units = 0;
+        self.bytes = 0;
+        Ok(())
+    }
+
+    fn commit(&mut self, store: &Store) -> Result<()> {
+        if self.active {
+            store.commit_batch()?;
+            self.active = false;
+        }
+        Ok(())
+    }
+
+    fn rollback(&mut self, store: &Store) {
+        if self.active {
+            let _ = store.rollback_batch();
+            self.active = false;
+        }
+    }
+}

--- a/crates/ctx-history-capture/src/tests.rs
+++ b/crates/ctx-history-capture/src/tests.rs
@@ -2,6 +2,7 @@ mod support;
 
 mod codex;
 mod custom_history;
+mod hermes_batching;
 mod native_json;
 mod native_providers;
 mod native_real_shapes;

--- a/crates/ctx-history-capture/src/tests/hermes_batching.rs
+++ b/crates/ctx-history-capture/src/tests/hermes_batching.rs
@@ -1,0 +1,119 @@
+use super::support::*;
+
+#[test]
+fn native_hermes_partial_import_crosses_batches_and_replays_idempotently() {
+    let temp = tempdir();
+    let fixture = write_hermes_batched_db(&temp, 130);
+    let db_path = temp.path().join("work.sqlite");
+    let mut store = Store::open(&db_path).unwrap();
+    let options = HermesSqliteImportOptions {
+        source_path: Some(fixture.clone()),
+        allow_partial_failures: true,
+        ..HermesSqliteImportOptions::default()
+    };
+
+    let first = import_hermes_sqlite(&fixture, &mut store, options.clone()).unwrap();
+    assert_eq!(first.failed, 0, "{:?}", first.failures);
+    assert_eq!(first.imported_sessions, 1);
+    assert_eq!(first.imported_events, 130);
+    assert_eq!(
+        store
+            .search_event_hits("hermes batched message 129", 10)
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_bounded_wal(&db_path);
+
+    let replay = import_hermes_sqlite(&fixture, &mut store, options).unwrap();
+    assert_eq!(replay.failed, 0, "{:?}", replay.failures);
+    assert_eq!(replay.imported_events, 0);
+    assert_eq!(replay.skipped_events, 130);
+    assert_eq!(
+        store
+            .search_event_hits("hermes batched message 129", 10)
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn native_hermes_nonpartial_import_preserves_atomic_search_projection() {
+    let temp = tempdir();
+    let fixture = write_hermes_batched_db(&temp, 70);
+    let db_path = temp.path().join("work.sqlite");
+    let mut store = Store::open(&db_path).unwrap();
+
+    let summary = import_hermes_sqlite(
+        &fixture,
+        &mut store,
+        HermesSqliteImportOptions {
+            source_path: Some(fixture.clone()),
+            ..HermesSqliteImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.imported_events, 70);
+    assert_eq!(
+        store
+            .search_event_hits("hermes batched message 69", 10)
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_bounded_wal(&db_path);
+}
+
+fn assert_bounded_wal(db_path: &Path) {
+    let wal_path = PathBuf::from(format!("{}-wal", db_path.display()));
+    let wal_bytes = fs::metadata(&wal_path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    assert!(
+        wal_bytes <= 4 * 1024 * 1024,
+        "WAL remained at {wal_bytes} bytes"
+    );
+}
+
+fn write_hermes_batched_db(temp: &TempDir, messages: usize) -> PathBuf {
+    let path = temp.path().join("hermes-batched.db");
+    let mut conn = Connection::open(&path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            started_at REAL NOT NULL
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            timestamp REAL NOT NULL,
+            active INTEGER NOT NULL DEFAULT 1,
+            compacted INTEGER NOT NULL DEFAULT 0
+        );
+        INSERT INTO sessions VALUES ('hermes-batched', 'acp', 1782259200.0);",
+    )
+    .unwrap();
+    let transaction = conn.transaction().unwrap();
+    for index in 0..messages {
+        let role = if index % 2 == 0 { "user" } else { "assistant" };
+        transaction
+            .execute(
+                "INSERT INTO messages (session_id, role, content, timestamp)
+                 VALUES ('hermes-batched', ?1, ?2, ?3)",
+                rusqlite::params![
+                    role,
+                    format!("hermes batched message {index}"),
+                    1782259201.0 + index as f64,
+                ],
+            )
+            .unwrap();
+    }
+    transaction.commit().unwrap();
+    path
+}

--- a/crates/ctx-history-capture/src/tests/provider_fixture.rs
+++ b/crates/ctx-history-capture/src/tests/provider_fixture.rs
@@ -1,6 +1,346 @@
 use super::support::*;
 
 #[test]
+fn batched_provider_import_rejects_nonpartial_unwrapped_and_zero_sized_modes() {
+    let temp = tempdir();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let occurred_at = DateTime::parse_from_rfc3339("2026-07-11T11:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let capture = provider_collision_capture(
+        CaptureProvider::Hermes,
+        "invalid-batch-options",
+        "hermes_state_sqlite",
+        "/tmp/invalid-batch-options.db",
+        occurred_at,
+    );
+    let normalization = ProviderNormalizationResult {
+        summary: ProviderImportSummary::default(),
+        captures: vec![(1, capture)],
+        files_touched: Vec::new(),
+    };
+
+    let nonpartial = import_normalized_provider_captures_in_batches(
+        &mut store,
+        normalization.clone(),
+        NormalizedProviderImportOptions::default(),
+        1,
+    )
+    .unwrap_err();
+    assert!(nonpartial
+        .to_string()
+        .contains("requires allow_partial_failures"));
+
+    let unwrapped = import_normalized_provider_captures_in_batches(
+        &mut store,
+        normalization.clone(),
+        NormalizedProviderImportOptions {
+            allow_partial_failures: true,
+            wrap_transaction: false,
+            ..NormalizedProviderImportOptions::default()
+        },
+        1,
+    )
+    .unwrap_err();
+    assert!(unwrapped
+        .to_string()
+        .contains("requires transaction wrapping"));
+
+    let zero = import_normalized_provider_captures_in_batches(
+        &mut store,
+        normalization,
+        NormalizedProviderImportOptions {
+            allow_partial_failures: true,
+            ..NormalizedProviderImportOptions::default()
+        },
+        0,
+    )
+    .unwrap_err();
+    assert!(zero
+        .to_string()
+        .contains("batch size must be greater than zero"));
+}
+
+#[test]
+fn batched_provider_import_stops_on_pinned_wal_and_resumes_idempotently() {
+    let temp = tempdir();
+    let db_path = temp.path().join("work.sqlite");
+    let mut store =
+        Store::open_with_busy_timeout(&db_path, std::time::Duration::from_millis(10)).unwrap();
+    let occurred_at = DateTime::parse_from_rfc3339("2026-07-11T12:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let source_path = temp.path().join("batched-provider.jsonl");
+    let source_path = source_path.display().to_string();
+    let mut first = provider_collision_capture(
+        CaptureProvider::Hermes,
+        "batched-provider-first",
+        "hermes_state_sqlite",
+        &source_path,
+        occurred_at,
+    );
+    first.event.as_mut().unwrap().payload = json!({"text": "first batch oracle"});
+    let mut second = provider_collision_capture(
+        CaptureProvider::Hermes,
+        "batched-provider-second",
+        "hermes_state_sqlite",
+        &source_path,
+        occurred_at + chrono::Duration::seconds(1),
+    );
+    second.event.as_mut().unwrap().payload = json!({"text": "second batch oracle"});
+    let normalization = ProviderNormalizationResult {
+        summary: ProviderImportSummary::default(),
+        captures: vec![(1, first), (2, second)],
+        files_touched: Vec::new(),
+    };
+    let options = NormalizedProviderImportOptions {
+        allow_partial_failures: true,
+        fast_event_inserts: true,
+        ..NormalizedProviderImportOptions::default()
+    };
+
+    let reader = Connection::open(&db_path).unwrap();
+    reader.execute_batch("BEGIN").unwrap();
+    let initial_events = reader
+        .query_row("SELECT COUNT(*) FROM events", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .unwrap();
+    assert_eq!(initial_events, 0);
+
+    let error = import_normalized_provider_captures_in_batches(
+        &mut store,
+        normalization.clone(),
+        options.clone(),
+        1,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("ctx index is busy"), "{error}");
+    reader.execute_batch("ROLLBACK").unwrap();
+
+    assert_eq!(store.list_sessions().unwrap().len(), 1);
+    assert_eq!(
+        store
+            .search_event_hits("first batch oracle", 10)
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(store
+        .search_event_hits("second batch oracle", 10)
+        .unwrap()
+        .is_empty());
+
+    let resumed = import_normalized_provider_captures_in_batches(
+        &mut store,
+        normalization.clone(),
+        options.clone(),
+        1,
+    )
+    .unwrap();
+    assert_eq!(resumed.failed, 0, "{:?}", resumed.failures);
+    assert_eq!(resumed.imported_events, 1);
+    assert_eq!(store.list_sessions().unwrap().len(), 2);
+    assert_eq!(
+        store
+            .search_event_hits("second batch oracle", 10)
+            .unwrap()
+            .len(),
+        1
+    );
+
+    let replayed =
+        import_normalized_provider_captures_in_batches(&mut store, normalization, options, 1)
+            .unwrap();
+    assert_eq!(replayed.imported_events, 0);
+    assert_eq!(replayed.skipped_events, 2);
+    assert_eq!(
+        store.search_event_hits("batch oracle", 10).unwrap().len(),
+        2
+    );
+}
+
+#[test]
+fn batched_provider_import_rotates_on_serialized_byte_budget() {
+    let temp = tempdir();
+    let db_path = temp.path().join("work.sqlite");
+    let mut store =
+        Store::open_with_busy_timeout(&db_path, std::time::Duration::from_millis(10)).unwrap();
+    let occurred_at = DateTime::parse_from_rfc3339("2026-07-11T12:30:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let source_path = temp.path().join("byte-batched-provider.db");
+    let source_path = source_path.display().to_string();
+    let mut first = provider_collision_capture(
+        CaptureProvider::Hermes,
+        "byte-batched-first",
+        "hermes_state_sqlite",
+        &source_path,
+        occurred_at,
+    );
+    first.event.as_mut().unwrap().payload =
+        json!({"text": format!("first byte-budget oracle {}", "a".repeat(4_500_000))});
+    let mut second = provider_collision_capture(
+        CaptureProvider::Hermes,
+        "byte-batched-second",
+        "hermes_state_sqlite",
+        &source_path,
+        occurred_at + chrono::Duration::seconds(1),
+    );
+    second.event.as_mut().unwrap().payload =
+        json!({"text": format!("second byte-budget oracle {}", "b".repeat(4_500_000))});
+
+    let reader = Connection::open(&db_path).unwrap();
+    reader.execute_batch("BEGIN").unwrap();
+    assert_eq!(
+        reader
+            .query_row("SELECT COUNT(*) FROM events", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        0
+    );
+    let error = import_normalized_provider_captures_in_batches(
+        &mut store,
+        ProviderNormalizationResult {
+            summary: ProviderImportSummary::default(),
+            captures: vec![(1, first), (2, second)],
+            files_touched: Vec::new(),
+        },
+        NormalizedProviderImportOptions {
+            allow_partial_failures: true,
+            fast_event_inserts: true,
+            ..NormalizedProviderImportOptions::default()
+        },
+        64,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("ctx index is busy"), "{error}");
+    reader.execute_batch("ROLLBACK").unwrap();
+
+    assert_eq!(store.list_sessions().unwrap().len(), 1);
+    assert_eq!(
+        store
+            .search_event_hits("first byte-budget oracle", 10)
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(store
+        .search_event_hits("second byte-budget oracle", 10)
+        .unwrap()
+        .is_empty());
+    store.optimize_search_index().unwrap();
+}
+
+#[test]
+fn batched_provider_import_chunks_edges_and_file_touches() {
+    let temp = tempdir();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let occurred_at = DateTime::parse_from_rfc3339("2026-07-11T13:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let source_path = temp.path().join("batched-graph.jsonl");
+    let source_path = source_path.display().to_string();
+    let parent = provider_collision_capture(
+        CaptureProvider::Hermes,
+        "batched-parent",
+        "hermes_state_sqlite",
+        &source_path,
+        occurred_at,
+    );
+    let mut child = provider_collision_capture(
+        CaptureProvider::Hermes,
+        "batched-child",
+        "hermes_state_sqlite",
+        &source_path,
+        occurred_at + chrono::Duration::seconds(1),
+    );
+    child.session.parent_provider_session_id = Some("batched-parent".to_owned());
+    let files_touched = vec![
+        (
+            1,
+            provider_collision_file_touch(
+                CaptureProvider::Hermes,
+                "batched-parent",
+                "hermes_state_sqlite",
+                &source_path,
+                occurred_at,
+            ),
+        ),
+        (
+            2,
+            provider_collision_file_touch(
+                CaptureProvider::Hermes,
+                "batched-child",
+                "hermes_state_sqlite",
+                &source_path,
+                occurred_at + chrono::Duration::seconds(1),
+            ),
+        ),
+    ];
+    let summary = import_normalized_provider_captures_in_batches(
+        &mut store,
+        ProviderNormalizationResult {
+            summary: ProviderImportSummary::default(),
+            captures: vec![(1, parent), (2, child)],
+            files_touched,
+        },
+        NormalizedProviderImportOptions {
+            allow_partial_failures: true,
+            fast_event_inserts: true,
+            ..NormalizedProviderImportOptions::default()
+        },
+        1,
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.imported_edges, 1);
+    assert_eq!(store.export_archive().unwrap().files_touched.len(), 2);
+}
+
+#[test]
+fn nonpartial_provider_import_remains_source_atomic() {
+    let temp = tempdir();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let occurred_at = DateTime::parse_from_rfc3339("2026-07-11T14:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let source_path = temp.path().join("atomic-conflict.jsonl");
+    let source_path = source_path.display().to_string();
+    let first = provider_collision_capture(
+        CaptureProvider::Hermes,
+        "atomic-conflict",
+        "hermes_state_sqlite",
+        &source_path,
+        occurred_at,
+    );
+    let mut conflicting = first.clone();
+    conflicting.event.as_mut().unwrap().payload = json!({"text": "conflicting payload"});
+
+    let summary = import_normalized_provider_captures(
+        &mut store,
+        ProviderNormalizationResult {
+            summary: ProviderImportSummary::default(),
+            captures: vec![(1, first), (2, conflicting)],
+            files_touched: Vec::new(),
+        },
+        NormalizedProviderImportOptions {
+            fast_event_inserts: true,
+            ..NormalizedProviderImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 1, "{:?}", summary.failures);
+    assert!(store.list_sessions().unwrap().is_empty());
+    assert!(store
+        .search_event_hits("same provider event payload", 10)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
 fn provider_fixture_replay_supports_antigravity_gemini_and_cursor() {
     let temp = tempdir();
     let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();

--- a/crates/ctx-history-capture/src/tests/support.rs
+++ b/crates/ctx-history-capture/src/tests/support.rs
@@ -9,10 +9,10 @@ pub(super) use crate::provider::custom_history_jsonl::{
 };
 pub(super) use crate::provider::file_touches::provider_file_touches_from_raw_value;
 pub(super) use crate::provider::importer::{
-    import_normalized_provider_captures, provider_command_run_from_event, provider_cursor_stream,
-    provider_event_import_identity, provider_event_seq, provider_event_uuid,
-    provider_file_touch_uuid, provider_scoped_source_uuid, provider_session_uuid,
-    provider_source_cursor_stream, provider_source_edge_uuid,
+    import_normalized_provider_captures, import_normalized_provider_captures_in_batches,
+    provider_command_run_from_event, provider_cursor_stream, provider_event_import_identity,
+    provider_event_seq, provider_event_uuid, provider_file_touch_uuid, provider_scoped_source_uuid,
+    provider_session_uuid, provider_source_cursor_stream, provider_source_edge_uuid,
     provider_source_event_import_identity, provider_source_event_seq, provider_source_event_uuid,
     provider_source_root_identity, provider_source_session_uuid, provider_source_uuid,
     provider_sync_metadata, timestamps, ProviderCommandRunInput,

--- a/crates/ctx-history-store/src/bulk_search.rs
+++ b/crates/ctx-history-store/src/bulk_search.rs
@@ -1,0 +1,434 @@
+//! Crash-safe FTS5 merge suppression and bounded compaction for bulk imports.
+//!
+//! FTS5 may perform an automatic or crisis merge inside a single row insert,
+//! producing a WAL far larger than the imported data. Bulk mode persists a
+//! recovery marker before disabling those merges. Event rows and their search
+//! projections still commit together; interrupted work remains searchable.
+//! Bounded merge steps run before the saved settings and marker are cleared.
+
+use ctx_history_core::utc_now;
+use std::{ffi::OsString, path::PathBuf, time::Duration};
+
+use rusqlite::{params, Connection, ErrorCode, OptionalExtension};
+
+use crate::object_store::restrict_private_file;
+use crate::schema::ddl::table_exists;
+use crate::{Result, Store, StoreError};
+
+const EVENT_SEARCH_FTS_TABLES: [&str; 2] = ["event_search", "event_search_scriptgram"];
+const ALL_FTS_TABLES: [&str; 5] = [
+    "ctx_history_search",
+    "event_search",
+    "artifact_search",
+    "ctx_history_search_scriptgram",
+    "event_search_scriptgram",
+];
+const BULK_MODE_MARKER_KEY: &str = "event_search_bulk_mode_v1";
+const BULK_MODE_AUTOMERGE_KEY_PREFIX: &str = "event_search_bulk_mode_v1:automerge:";
+const BULK_MODE_CRISISMERGE_KEY_PREFIX: &str = "event_search_bulk_mode_v1:crisismerge:";
+const BULK_MODE_MERGE_STARTED_KEY_PREFIX: &str = "event_search_bulk_mode_v1:merge_started:";
+const FTS_AUTOMERGE_DEFAULT: i64 = 4;
+const FTS_CRISISMERGE_DEFAULT: i64 = 16;
+const FTS_BULK_CRISISMERGE: i64 = 1_000_000;
+const FTS_MERGE_PAGE_BUDGET: i64 = 1024;
+const BULK_LOCK_SUFFIX: &str = ".event-search-bulk.lock.sqlite";
+
+/// Owns the cross-process lock for one event-search bulk operation.
+///
+/// SQLite releases the sidecar database's writer lock if the process exits,
+/// including after an unclean exit. The guard intentionally cannot be cloned.
+pub struct EventSearchBulkGuard {
+    lock_conn: Connection,
+    store_path: PathBuf,
+}
+
+impl Drop for EventSearchBulkGuard {
+    fn drop(&mut self) {
+        let _ = self.lock_conn.execute_batch("ROLLBACK");
+    }
+}
+
+impl Store {
+    /// Acquire the bulk-import lock and persist merge suppression.
+    pub fn begin_event_search_bulk_mode(&self) -> Result<EventSearchBulkGuard> {
+        let guard = self
+            .acquire_event_search_bulk_lock(self.busy_timeout)?
+            .ok_or(StoreError::BulkSearchImportBusy)?;
+        self.begin_immediate_batch()?;
+        let result = (|| {
+            ensure_search_projection_stats_table(self)?;
+            if !bulk_mode_pending(self)? {
+                for table in EVENT_SEARCH_FTS_TABLES {
+                    if !table_exists(&self.conn, table)? {
+                        continue;
+                    }
+                    save_bulk_mode_config(
+                        self,
+                        &format!("{BULK_MODE_AUTOMERGE_KEY_PREFIX}{table}"),
+                        fts_config_value(self, table, "automerge", FTS_AUTOMERGE_DEFAULT)?,
+                    )?;
+                    save_bulk_mode_config(
+                        self,
+                        &format!("{BULK_MODE_CRISISMERGE_KEY_PREFIX}{table}"),
+                        fts_config_value(self, table, "crisismerge", FTS_CRISISMERGE_DEFAULT)?,
+                    )?;
+                }
+                save_bulk_mode_config(self, BULK_MODE_MARKER_KEY, 1)?;
+            }
+            suppress_event_search_merges(self)
+        })();
+        if let Err(err) = result {
+            let _ = self.rollback_batch();
+            return Err(err);
+        }
+        if let Err(err) = self.commit_batch() {
+            let _ = self.rollback_batch();
+            return Err(err);
+        }
+        Ok(guard)
+    }
+
+    /// Compact all bulk segments in bounded steps, then restore saved settings.
+    pub fn finish_event_search_bulk_mode(&self, guard: &EventSearchBulkGuard) -> Result<()> {
+        if guard.store_path != self.path {
+            return Err(StoreError::InvalidBulkSearchGuard);
+        }
+        if !bulk_mode_pending(self)? {
+            return Ok(());
+        }
+        for table in EVENT_SEARCH_FTS_TABLES {
+            let progress_key = format!("{BULK_MODE_MERGE_STARTED_KEY_PREFIX}{table}");
+            let start_full_merge = bulk_mode_config(self, &progress_key)?.is_none();
+            if start_full_merge && table_exists(&self.conn, table)? {
+                self.merge_fts_table_step(table, -FTS_MERGE_PAGE_BUDGET, Some(&progress_key))?;
+            }
+        }
+        loop {
+            if self.finish_event_search_bulk_mode_step()? {
+                return Ok(());
+            }
+        }
+    }
+
+    pub(crate) fn recover_event_search_bulk_mode(&self) -> Result<()> {
+        // Check and reassert under one writer lock. A guarded importer may
+        // restore settings and clear the marker while another connection is
+        // waiting for this transaction, so an earlier check would be stale.
+        self.begin_immediate_batch()?;
+        let result = (|| {
+            let pending = bulk_mode_pending(self)?;
+            if pending {
+                suppress_event_search_merges(self)?;
+            }
+            Ok(pending)
+        })();
+        let pending = match result {
+            Ok(pending) => pending,
+            Err(err) => {
+                let _ = self.rollback_batch();
+                return Err(err);
+            }
+        };
+        if let Err(err) = self.commit_batch() {
+            let _ = self.rollback_batch();
+            return Err(err);
+        }
+        if !pending {
+            return Ok(());
+        }
+        // A live importer owns this lock. A stale marker has no owner, so the
+        // next writable open adopts and completes its bounded recovery.
+        if let Some(guard) = self.acquire_event_search_bulk_lock(Duration::ZERO)? {
+            self.finish_event_search_bulk_mode(&guard)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn merge_all_fts_tables_bounded(&self) -> Result<()> {
+        // Serialize unconditionally. Reading the marker before acquiring the
+        // lock would let a new bulk import start in the handoff window.
+        let guard = self
+            .acquire_event_search_bulk_lock(self.busy_timeout)?
+            .ok_or(StoreError::BulkSearchImportBusy)?;
+        if bulk_mode_pending(self)? {
+            self.finish_event_search_bulk_mode(&guard)?;
+        }
+        for table in ALL_FTS_TABLES {
+            self.merge_fts_table_bounded(table, true, None)?;
+        }
+        Ok(())
+    }
+
+    fn merge_fts_table_bounded(
+        &self,
+        table: &'static str,
+        mut start_full_merge: bool,
+        progress_key: Option<&str>,
+    ) -> Result<()> {
+        if !table_exists(&self.conn, table)? {
+            return Ok(());
+        }
+        loop {
+            let page_budget = if start_full_merge {
+                -FTS_MERGE_PAGE_BUDGET
+            } else {
+                FTS_MERGE_PAGE_BUDGET
+            };
+            let changed = self.merge_fts_table_step(
+                table,
+                page_budget,
+                start_full_merge.then_some(progress_key).flatten(),
+            )?;
+            start_full_merge = false;
+            if !changed {
+                return Ok(());
+            }
+        }
+    }
+
+    fn merge_fts_table_step(
+        &self,
+        table: &'static str,
+        page_budget: i64,
+        progress_key: Option<&str>,
+    ) -> Result<bool> {
+        self.begin_immediate_batch()?;
+        let result = (|| {
+            let changed = merge_fts_table_in_transaction(self, table, page_budget)?;
+            if let Some(progress_key) = progress_key {
+                save_bulk_mode_config(self, progress_key, 1)?;
+            }
+            Ok(changed)
+        })();
+        let changed = match result {
+            Ok(changed) => changed,
+            Err(err) => {
+                let _ = self.rollback_batch();
+                return Err(err);
+            }
+        };
+        if let Err(err) = self.commit_batch() {
+            let _ = self.rollback_batch();
+            return Err(err);
+        }
+        self.checkpoint_wal_truncate_required()?;
+        Ok(changed)
+    }
+
+    /// Perform one bounded merge on both tables from the same writer snapshot.
+    /// A quiescent pass is checkpointed before a second locked pass may restore
+    /// settings, so a failed large-WAL checkpoint always leaves recovery marked.
+    fn finish_event_search_bulk_mode_step(&self) -> Result<bool> {
+        self.begin_immediate_batch()?;
+        let result = (|| {
+            if !bulk_mode_pending(self)? {
+                return Ok(true);
+            }
+            Ok(!merge_event_search_tables_in_transaction(self)?)
+        })();
+        let quiescent = match result {
+            Ok(quiescent) => quiescent,
+            Err(err) => {
+                let _ = self.rollback_batch();
+                return Err(err);
+            }
+        };
+        if let Err(err) = self.commit_batch() {
+            let _ = self.rollback_batch();
+            return Err(err);
+        }
+        self.checkpoint_wal_truncate_required()?;
+        if !quiescent {
+            return Ok(false);
+        }
+        self.restore_event_search_bulk_mode_if_quiescent()
+    }
+
+    /// Recheck both tables and restore settings while holding one writer lock.
+    /// If the final config-only checkpoint is pinned, the preceding potentially
+    /// large merge WAL has already been truncated successfully.
+    fn restore_event_search_bulk_mode_if_quiescent(&self) -> Result<bool> {
+        self.begin_immediate_batch()?;
+        let result = (|| {
+            if !bulk_mode_pending(self)? {
+                return Ok(true);
+            }
+            let changed = merge_event_search_tables_in_transaction(self)?;
+            if !changed {
+                restore_event_search_merge_config(self)?;
+                clear_bulk_mode_state(self)?;
+            }
+            Ok(!changed)
+        })();
+        let finished = match result {
+            Ok(finished) => finished,
+            Err(err) => {
+                let _ = self.rollback_batch();
+                return Err(err);
+            }
+        };
+        if let Err(err) = self.commit_batch() {
+            let _ = self.rollback_batch();
+            return Err(err);
+        }
+        self.checkpoint_wal_truncate_required()?;
+        Ok(finished)
+    }
+
+    fn acquire_event_search_bulk_lock(
+        &self,
+        busy_timeout: Duration,
+    ) -> Result<Option<EventSearchBulkGuard>> {
+        let lock_path = event_search_bulk_lock_path(&self.path);
+        let lock_conn = Connection::open(&lock_path)?;
+        restrict_private_file(&lock_path)?;
+        lock_conn.busy_timeout(busy_timeout)?;
+        let result = lock_conn.execute_batch(
+            "PRAGMA journal_mode=DELETE;\
+             CREATE TABLE IF NOT EXISTS bulk_search_lock (id INTEGER PRIMARY KEY);\
+             BEGIN IMMEDIATE",
+        );
+        match result {
+            Ok(()) => Ok(Some(EventSearchBulkGuard {
+                lock_conn,
+                store_path: self.path.clone(),
+            })),
+            Err(err) if sqlite_is_busy(&err) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+}
+
+fn merge_fts_table_in_transaction(
+    store: &Store,
+    table: &'static str,
+    page_budget: i64,
+) -> Result<bool> {
+    let before = store.conn.total_changes();
+    let sql = format!("INSERT INTO {table}({table}, rank) VALUES ('merge', ?1)");
+    store.conn.execute(&sql, params![page_budget])?;
+    Ok(store.conn.total_changes().saturating_sub(before) >= 2)
+}
+
+fn merge_event_search_tables_in_transaction(store: &Store) -> Result<bool> {
+    let mut changed = false;
+    for table in EVENT_SEARCH_FTS_TABLES {
+        if table_exists(&store.conn, table)? {
+            changed |= merge_fts_table_in_transaction(store, table, FTS_MERGE_PAGE_BUDGET)?;
+        }
+    }
+    Ok(changed)
+}
+
+fn event_search_bulk_lock_path(store_path: &std::path::Path) -> PathBuf {
+    let mut value = OsString::from(store_path.as_os_str());
+    value.push(BULK_LOCK_SUFFIX);
+    PathBuf::from(value)
+}
+
+fn sqlite_is_busy(err: &rusqlite::Error) -> bool {
+    matches!(
+        err,
+        rusqlite::Error::SqliteFailure(failure, _)
+            if matches!(failure.code, ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
+    )
+}
+
+fn suppress_event_search_merges(store: &Store) -> Result<()> {
+    for table in EVENT_SEARCH_FTS_TABLES {
+        if !table_exists(&store.conn, table)? {
+            continue;
+        }
+        set_fts_config(store, table, "automerge", 0)?;
+        set_fts_config(store, table, "crisismerge", FTS_BULK_CRISISMERGE)?;
+    }
+    Ok(())
+}
+
+fn restore_event_search_merge_config(store: &Store) -> Result<()> {
+    for table in EVENT_SEARCH_FTS_TABLES {
+        if !table_exists(&store.conn, table)? {
+            continue;
+        }
+        let automerge =
+            bulk_mode_config(store, &format!("{BULK_MODE_AUTOMERGE_KEY_PREFIX}{table}"))?
+                .unwrap_or(FTS_AUTOMERGE_DEFAULT);
+        let crisismerge =
+            bulk_mode_config(store, &format!("{BULK_MODE_CRISISMERGE_KEY_PREFIX}{table}"))?
+                .unwrap_or(FTS_CRISISMERGE_DEFAULT);
+        set_fts_config(store, table, "automerge", automerge)?;
+        set_fts_config(store, table, "crisismerge", crisismerge)?;
+    }
+    Ok(())
+}
+
+fn set_fts_config(store: &Store, table: &'static str, key: &str, value: i64) -> Result<()> {
+    debug_assert!(ALL_FTS_TABLES.contains(&table));
+    let sql = format!("INSERT INTO {table}({table}, rank) VALUES (?1, ?2)");
+    store.conn.execute(&sql, params![key, value])?;
+    Ok(())
+}
+
+fn fts_config_value(store: &Store, table: &'static str, key: &str, default: i64) -> Result<i64> {
+    debug_assert!(ALL_FTS_TABLES.contains(&table));
+    let sql = format!("SELECT v FROM {table}_config WHERE k = ?1");
+    Ok(store
+        .conn
+        .query_row(&sql, params![key], |row| row.get(0))
+        .optional()?
+        .unwrap_or(default))
+}
+
+fn ensure_search_projection_stats_table(store: &Store) -> Result<()> {
+    store.conn.execute(
+        r#"
+        CREATE TABLE IF NOT EXISTS search_projection_stats (
+            key TEXT PRIMARY KEY NOT NULL,
+            value INTEGER NOT NULL,
+            updated_at_ms INTEGER NOT NULL
+        )
+        "#,
+        [],
+    )?;
+    Ok(())
+}
+
+fn bulk_mode_pending(store: &Store) -> Result<bool> {
+    if !table_exists(&store.conn, "search_projection_stats")? {
+        return Ok(false);
+    }
+    Ok(bulk_mode_config(store, BULK_MODE_MARKER_KEY)?.is_some())
+}
+
+fn bulk_mode_config(store: &Store, key: &str) -> Result<Option<i64>> {
+    Ok(store
+        .conn
+        .query_row(
+            "SELECT value FROM search_projection_stats WHERE key = ?1",
+            params![key],
+            |row| row.get(0),
+        )
+        .optional()?)
+}
+
+fn save_bulk_mode_config(store: &Store, key: &str, value: i64) -> Result<()> {
+    store.conn.execute(
+        r#"
+        INSERT INTO search_projection_stats (key, value, updated_at_ms)
+        VALUES (?1, ?2, ?3)
+        ON CONFLICT(key) DO UPDATE SET
+            value = excluded.value,
+            updated_at_ms = excluded.updated_at_ms
+        "#,
+        params![key, value, utc_now().timestamp_millis()],
+    )?;
+    Ok(())
+}
+
+fn clear_bulk_mode_state(store: &Store) -> Result<()> {
+    store.conn.execute(
+        "DELETE FROM search_projection_stats WHERE key = ?1 OR key LIKE ?2",
+        params![BULK_MODE_MARKER_KEY, "event_search_bulk_mode_v1:%"],
+    )?;
+    Ok(())
+}

--- a/crates/ctx-history-store/src/connection.rs
+++ b/crates/ctx-history-store/src/connection.rs
@@ -86,6 +86,7 @@ impl Store {
             busy_timeout,
         };
         store.migrate()?;
+        store.recover_event_search_bulk_mode()?;
         if migrated_legacy_layout {
             store.normalize_legacy_blob_paths()?;
         }
@@ -113,14 +114,23 @@ impl Store {
     }
 
     pub fn checkpoint_wal_passive(&self) -> Result<()> {
-        self.conn
-            .query_row("PRAGMA wal_checkpoint(PASSIVE)", [], |_| Ok(()))?;
+        let _ = self.checkpoint_wal("PASSIVE")?;
         Ok(())
     }
 
     pub fn checkpoint_wal_truncate(&self) -> Result<()> {
-        self.conn
-            .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()))?;
+        let _ = self.checkpoint_wal("TRUNCATE")?;
+        Ok(())
+    }
+
+    pub fn checkpoint_wal_truncate_required(&self) -> Result<()> {
+        let outcome = self.checkpoint_wal("TRUNCATE")?;
+        if outcome.busy {
+            return Err(StoreError::WalCheckpointBusy {
+                log_frames: outcome.log_frames,
+                checkpointed_frames: outcome.checkpointed_frames,
+            });
+        }
         Ok(())
     }
 
@@ -160,6 +170,23 @@ impl Store {
         }
     }
 
+    fn checkpoint_wal(&self, mode: &'static str) -> Result<WalCheckpointOutcome> {
+        let sql = match mode {
+            "PASSIVE" => "PRAGMA wal_checkpoint(PASSIVE)",
+            "TRUNCATE" => "PRAGMA wal_checkpoint(TRUNCATE)",
+            _ => unreachable!("unsupported WAL checkpoint mode"),
+        };
+        self.conn
+            .query_row(sql, [], |row| {
+                Ok(WalCheckpointOutcome {
+                    busy: row.get::<_, i64>(0)? != 0,
+                    log_frames: row.get(1)?,
+                    checkpointed_frames: row.get(2)?,
+                })
+            })
+            .map_err(StoreError::from)
+    }
+
     pub fn validate(&self) -> Result<Vec<String>> {
         let integrity: String = self
             .conn
@@ -177,6 +204,13 @@ impl Store {
         }
         Ok(findings)
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WalCheckpointOutcome {
+    busy: bool,
+    log_frames: i64,
+    checkpointed_frames: i64,
 }
 
 pub(crate) fn configure_connection(conn: &Connection, busy_timeout: Duration) -> Result<()> {

--- a/crates/ctx-history-store/src/connection_tests.rs
+++ b/crates/ctx-history-store/src/connection_tests.rs
@@ -1,0 +1,302 @@
+use std::time::Duration;
+
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::{Store, StoreError};
+
+fn tempdir() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("ctx-history-store-connection-")
+        .tempdir()
+        .unwrap()
+}
+
+fn fts_config(store: &Store, table: &str, key: &str, default: i64) -> i64 {
+    let sql = format!("SELECT v FROM {table}_config WHERE k = ?1");
+    store
+        .conn
+        .query_row(&sql, params![key], |row| row.get(0))
+        .optional()
+        .unwrap()
+        .unwrap_or(default)
+}
+
+fn set_fts_config(store: &Store, table: &str, key: &str, value: i64) {
+    let sql = format!("INSERT INTO {table}({table}, rank) VALUES (?1, ?2)");
+    store.conn.execute(&sql, params![key, value]).unwrap();
+}
+
+fn bulk_mode_marker(store: &Store) -> Option<i64> {
+    store
+        .conn
+        .query_row(
+            "SELECT value FROM search_projection_stats WHERE key = 'event_search_bulk_mode_v1'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .unwrap()
+}
+
+#[test]
+fn strict_truncating_checkpoint_reports_pinned_reader() {
+    let temp = tempdir();
+    let db_path = temp.path().join("work.sqlite");
+    let store = Store::open_with_busy_timeout(&db_path, Duration::from_millis(10)).unwrap();
+    store
+        .conn
+        .execute_batch("CREATE TABLE checkpoint_probe(value INTEGER); INSERT INTO checkpoint_probe VALUES (1);")
+        .unwrap();
+
+    let reader = Connection::open(&db_path).unwrap();
+    reader.execute_batch("BEGIN").unwrap();
+    let count = reader
+        .query_row("SELECT COUNT(*) FROM checkpoint_probe", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .unwrap();
+    assert_eq!(count, 1);
+
+    store
+        .conn
+        .execute("INSERT INTO checkpoint_probe VALUES (2)", [])
+        .unwrap();
+    let error = store.checkpoint_wal_truncate_required().unwrap_err();
+    assert!(matches!(
+        error,
+        StoreError::WalCheckpointBusy {
+            log_frames,
+            checkpointed_frames,
+        } if log_frames > checkpointed_frames
+    ));
+
+    reader.execute_batch("ROLLBACK").unwrap();
+    store.checkpoint_wal_truncate_required().unwrap();
+}
+
+#[test]
+fn bulk_search_mode_recovers_on_reopen_and_restores_saved_config() {
+    let temp = tempdir();
+    let db_path = temp.path().join("work.sqlite");
+    let store = Store::open(&db_path).unwrap();
+    for table in ["event_search", "event_search_scriptgram"] {
+        set_fts_config(&store, table, "automerge", 8);
+        set_fts_config(&store, table, "crisismerge", 32);
+    }
+
+    let guard = store.begin_event_search_bulk_mode().unwrap();
+    assert_eq!(bulk_mode_marker(&store), Some(1));
+    for table in ["event_search", "event_search_scriptgram"] {
+        assert_eq!(fts_config(&store, table, "automerge", 4), 0);
+        assert_eq!(fts_config(&store, table, "crisismerge", 16), 1_000_000);
+    }
+    drop(store);
+    drop(guard);
+
+    let reopened = Store::open(&db_path).unwrap();
+    assert_eq!(bulk_mode_marker(&reopened), None);
+    for table in ["event_search", "event_search_scriptgram"] {
+        assert_eq!(fts_config(&reopened, table, "automerge", 4), 8);
+        assert_eq!(fts_config(&reopened, table, "crisismerge", 16), 32);
+    }
+}
+
+#[test]
+fn bulk_search_recovery_without_marker_preserves_custom_config() {
+    let temp = tempdir();
+    let db_path = temp.path().join("work.sqlite");
+    let store = Store::open(&db_path).unwrap();
+    for table in ["event_search", "event_search_scriptgram"] {
+        set_fts_config(&store, table, "automerge", 8);
+        set_fts_config(&store, table, "crisismerge", 32);
+    }
+
+    store.recover_event_search_bulk_mode().unwrap();
+
+    assert_eq!(bulk_mode_marker(&store), None);
+    for table in ["event_search", "event_search_scriptgram"] {
+        assert_eq!(fts_config(&store, table, "automerge", 4), 8);
+        assert_eq!(fts_config(&store, table, "crisismerge", 16), 32);
+    }
+}
+
+#[test]
+fn overlapping_bulk_search_mode_is_rejected_until_guard_releases() {
+    let temp = tempdir();
+    let db_path = temp.path().join("work.sqlite");
+    let first = Store::open(&db_path).unwrap();
+    let guard = first.begin_event_search_bulk_mode().unwrap();
+    let second = Store::open_with_busy_timeout(&db_path, Duration::from_millis(10)).unwrap();
+
+    let error = second.begin_event_search_bulk_mode().err().unwrap();
+    assert!(matches!(error, StoreError::BulkSearchImportBusy));
+    assert_eq!(bulk_mode_marker(&second), Some(1));
+    for table in ["event_search", "event_search_scriptgram"] {
+        assert_eq!(fts_config(&second, table, "automerge", 4), 0);
+        assert_eq!(fts_config(&second, table, "crisismerge", 16), 1_000_000);
+    }
+
+    first.finish_event_search_bulk_mode(&guard).unwrap();
+    drop(guard);
+    let next_guard = second.begin_event_search_bulk_mode().unwrap();
+    second.finish_event_search_bulk_mode(&next_guard).unwrap();
+}
+
+#[test]
+fn optimize_serializes_with_bulk_guard_even_without_visible_marker() {
+    let temp = tempdir();
+    let db_path = temp.path().join("work.sqlite");
+    let first = Store::open(&db_path).unwrap();
+    let guard = first.begin_event_search_bulk_mode().unwrap();
+    first
+        .conn
+        .execute(
+            "DELETE FROM search_projection_stats WHERE key = ?1 OR key LIKE ?2",
+            params!["event_search_bulk_mode_v1", "event_search_bulk_mode_v1:%"],
+        )
+        .unwrap();
+    for table in ["event_search", "event_search_scriptgram"] {
+        set_fts_config(&first, table, "automerge", 4);
+        set_fts_config(&first, table, "crisismerge", 16);
+    }
+    let second = Store::open_with_busy_timeout(&db_path, Duration::from_millis(10)).unwrap();
+
+    let error = second.optimize_search_index().unwrap_err();
+    assert!(matches!(error, StoreError::BulkSearchImportBusy));
+
+    drop(guard);
+    second.optimize_search_index().unwrap();
+}
+
+#[test]
+fn bulk_search_mode_crosses_crisis_threshold_without_automatic_merge() {
+    let temp = tempdir();
+    let db_path = temp.path().join("work.sqlite");
+    let store = Store::open(&db_path).unwrap();
+    let guard = store.begin_event_search_bulk_mode().unwrap();
+
+    let mut peak_wal_bytes = 0;
+    for index in 0..20 {
+        store
+            .conn
+            .execute(
+                r#"
+                INSERT INTO event_search
+                (event_id, history_record_id, session_id, role, preview_text, rank_bucket)
+                VALUES (?1, NULL, NULL, 'user', ?2, 'message')
+                "#,
+                params![
+                    format!("bulk-event-{index}"),
+                    format!("bulk token {index} {}", "payload ".repeat(2_048))
+                ],
+            )
+            .unwrap();
+        let wal_path = format!("{}-wal", db_path.display());
+        peak_wal_bytes = peak_wal_bytes.max(
+            std::fs::metadata(wal_path)
+                .map(|metadata| metadata.len())
+                .unwrap_or(0),
+        );
+    }
+
+    let segments = store
+        .conn
+        .query_row(
+            "SELECT COUNT(DISTINCT segid) FROM event_search_idx",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert!(segments >= 20, "expected unmerged segments, got {segments}");
+    assert!(
+        peak_wal_bytes <= 4 * 1024 * 1024,
+        "bulk FTS writes grew WAL to {peak_wal_bytes} bytes"
+    );
+
+    store.finish_event_search_bulk_mode(&guard).unwrap();
+    assert_eq!(bulk_mode_marker(&store), None);
+    let compacted_segments = store
+        .conn
+        .query_row(
+            "SELECT COUNT(DISTINCT segid) FROM event_search_idx",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(compacted_segments, 1);
+    assert_eq!(
+        store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM event_search WHERE event_search MATCH 'bulk'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        20
+    );
+}
+
+#[test]
+fn interrupted_bounded_merge_resumes_after_reopen() {
+    let temp = tempdir();
+    let db_path = temp.path().join("work.sqlite");
+    let store = Store::open_with_busy_timeout(&db_path, Duration::from_millis(10)).unwrap();
+    let guard = store.begin_event_search_bulk_mode().unwrap();
+    for index in 0..20 {
+        store
+            .conn
+            .execute(
+                r#"
+                INSERT INTO event_search
+                (event_id, history_record_id, session_id, role, preview_text, rank_bucket)
+                VALUES (?1, NULL, NULL, 'user', ?2, 'message')
+                "#,
+                params![
+                    format!("resume-event-{index}"),
+                    format!("resume token {index}")
+                ],
+            )
+            .unwrap();
+    }
+
+    let reader = Connection::open(&db_path).unwrap();
+    reader.execute_batch("BEGIN").unwrap();
+    let visible = reader
+        .query_row("SELECT COUNT(*) FROM event_search", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .unwrap();
+    assert_eq!(visible, 20);
+
+    let error = store.finish_event_search_bulk_mode(&guard).unwrap_err();
+    assert!(matches!(error, StoreError::WalCheckpointBusy { .. }));
+    assert_eq!(bulk_mode_marker(&store), Some(1));
+    reader.execute_batch("ROLLBACK").unwrap();
+    drop(reader);
+    drop(store);
+    drop(guard);
+
+    let reopened = Store::open(&db_path).unwrap();
+    assert_eq!(bulk_mode_marker(&reopened), None);
+    let segments = reopened
+        .conn
+        .query_row(
+            "SELECT COUNT(DISTINCT segid) FROM event_search_idx",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(segments, 1);
+    assert_eq!(
+        reopened
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM event_search WHERE event_search MATCH 'resume'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        20
+    );
+}

--- a/crates/ctx-history-store/src/error.rs
+++ b/crates/ctx-history-store/src/error.rs
@@ -21,6 +21,17 @@ pub enum StoreError {
     UnsupportedSchemaVersion(i64),
     #[error("unsupported session history archive version: {0}")]
     UnsupportedArchiveVersion(u32),
+    #[error(
+        "ctx index is busy: WAL checkpoint could not complete ({log_frames} log frames, {checkpointed_frames} checkpointed)"
+    )]
+    WalCheckpointBusy {
+        log_frames: i64,
+        checkpointed_frames: i64,
+    },
+    #[error("ctx index is busy: another bulk search import is active")]
+    BulkSearchImportBusy,
+    #[error("bulk search guard belongs to a different ctx index")]
+    InvalidBulkSearchGuard,
     #[error("archive conflicts with existing {kind}: {id}")]
     ImportConflict { kind: &'static str, id: Uuid },
     #[error("archive artifact {id} content does not match its blob hash")]

--- a/crates/ctx-history-store/src/lib.rs
+++ b/crates/ctx-history-store/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod archive;
 mod artifacts;
+mod bulk_search;
 mod catalog;
 mod connection;
 mod error;
@@ -19,6 +20,7 @@ mod sync;
 mod vcs;
 
 pub use archive::validate_archive_version;
+pub use bulk_search::EventSearchBulkGuard;
 pub use catalog::{
     CatalogCounts, CatalogIndexedStatus, CatalogSession, CatalogSourceIndexState,
     CatalogSourceIndexUpdate, IndexedHistoryCounts, SourceImportFile, SourceImportFileCounts,
@@ -48,3 +50,6 @@ pub struct Store {
     conn: Connection,
     busy_timeout: Duration,
 }
+
+#[cfg(test)]
+mod connection_tests;

--- a/crates/ctx-history-store/src/search/projections.rs
+++ b/crates/ctx-history-store/src/search/projections.rs
@@ -80,21 +80,7 @@ impl Store {
     }
 
     pub fn optimize_search_index(&self) -> Result<()> {
-        for table in [
-            "ctx_history_search",
-            "event_search",
-            "artifact_search",
-            "ctx_history_search_scriptgram",
-            "event_search_scriptgram",
-        ] {
-            if table_exists(&self.conn, table)? {
-                self.conn.execute(
-                    format!("INSERT INTO {table}({table}) VALUES ('optimize')").as_str(),
-                    [],
-                )?;
-            }
-        }
-        Ok(())
+        self.merge_all_fts_tables_bounded()
     }
 
     pub fn event_search_projection_needs_backfill(&self) -> Result<bool> {


### PR DESCRIPTION
## What changed

- batch partial Hermes imports at 64 logical units or 8 MiB of serialized input, including deferred edges and file touches
- keep event rows and both FTS projections transactionally consistent and immediately searchable
- persistently suppress FTS5 automatic/crisis merges during Hermes bulk ingest
- compact FTS segments afterward in bounded 1,024-page transactions with strict WAL checkpoints
- serialize bulk imports and optimization with a crash-releasing cross-process guard
- automatically recover interrupted bulk state on the next writable store open
- preserve source-atomic behavior when partial import is disabled

## Why

The original transaction-batching draft did not fully solve the reported failure. On the contributor's 206–260 MB Hermes corpus, FTS5 could still perform a crisis/incremental merge inside a single INSERT and grow the WAL by multiple GiB, even with one capture per transaction. A checkpoint cannot bound work performed inside that statement.

This replacement prevents those automatic merges during ingest and performs the merge work explicitly in bounded, recoverable transactions.

## Validation

- `cargo test -p ctx-history-store -p ctx-history-capture -p ctx --no-fail-fast`
- `cargo clippy -p ctx-history-store -p ctx-history-capture -p ctx --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `scripts/check-loc.sh`
- crash recovery, pinned-reader, overlapping-import, optimizer-race, byte-budget, search-consistency, and idempotent-replay regressions
- monitored CLI import of 1,100 Hermes messages with approximately 16 KiB content each: 18.6 MB source, 5.39 MB peak WAL, zero final WAL, 1,100 events imported
- independent final review found no remaining P0/P1 issues

The contributor's private 206–260 MB corpus was not available for direct reproduction.