### PR TITLE
Fix index wait default when semantic indexing is disabled

### DIFF
--- a/crates/ctx-cli/src/commands/index.rs
+++ b/crates/ctx-cli/src/commands/index.rs
@@ -114,11 +114,12 @@ fn run_index_watch(args: IndexWatchArgs, data_root: &Path, quiet: bool) -> Resul
 }
 
 fn run_index_wait(args: IndexWaitArgs, data_root: &Path, quiet: bool) -> Result<()> {
-    let selection = IndexSelection::from_wait_args(&args);
+    let explicit_selection = IndexSelection::from_wait_args(&args);
     let interval = Duration::from_secs(args.interval_seconds);
     let started = Instant::now();
     loop {
         let status = index_status_snapshot(data_root)?;
+        let selection = explicit_selection.unwrap_or_else(|| IndexSelection::default_for(&status));
         if index_ready(&status, selection) {
             if args.json {
                 print_json(index_wait_json(status, selection, "ready"))?;
@@ -366,14 +367,23 @@ impl IndexSelection {
         }
     }
 
-    fn from_wait_args(args: &IndexWaitArgs) -> Self {
-        if args.all || (!args.lexical && !args.semantic) {
-            Self::all()
-        } else {
-            Self {
+    fn from_wait_args(args: &IndexWaitArgs) -> Option<Self> {
+        if args.all {
+            Some(Self::all())
+        } else if args.lexical || args.semantic {
+            Some(Self {
                 lexical: args.lexical,
                 semantic: args.semantic,
-            }
+            })
+        } else {
+            None
+        }
+    }
+
+    fn default_for(status: &Value) -> Self {
+        Self {
+            lexical: true,
+            semantic: bool_at(status, &["semantic", "enabled"]),
         }
     }
 }

--- a/crates/ctx-cli/tests/index.rs
+++ b/crates/ctx-cli/tests/index.rs
@@ -144,3 +144,111 @@ fn index_wait_lexical_reports_ready_after_import() {
     assert_eq!(wait["local_only"], true);
     assert_eq!(wait["read_only"], true);
 }
+
+#[test]
+fn index_wait_default_skips_semantic_when_disabled_after_import() {
+    let temp = tempdir();
+    let fixture = provider_history_fixture("codex-sessions");
+    json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "codex",
+        "--path",
+        &fixture,
+        "--json",
+    ]));
+
+    let wait = json_output(ctx(&temp).args([
+        "index",
+        "wait",
+        "--json",
+        "--timeout-seconds",
+        "1",
+        "--interval-seconds",
+        "1",
+    ]));
+    assert_eq!(wait["schema_version"], 1);
+    assert_eq!(wait["status"], "ready");
+    assert_eq!(wait["selection"]["lexical"], true);
+    assert_eq!(wait["selection"]["semantic"], false);
+    assert_eq!(wait["index"]["lexical"]["status"], "ready");
+    assert_eq!(wait["index"]["semantic"]["enabled"], false);
+    assert_eq!(wait["index"]["semantic"]["config_source"], "default");
+}
+
+#[test]
+fn index_wait_semantic_stays_strict_when_semantic_is_disabled() {
+    let temp = tempdir();
+    let fixture = provider_history_fixture("codex-sessions");
+    json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "codex",
+        "--path",
+        &fixture,
+        "--json",
+    ]));
+
+    let output = ctx(&temp)
+        .args([
+            "index",
+            "wait",
+            "--semantic",
+            "--json",
+            "--timeout-seconds",
+            "1",
+            "--interval-seconds",
+            "1",
+        ])
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let stdout: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert_eq!(stdout["schema_version"], 1);
+    assert_eq!(stdout["status"], "blocked");
+    assert_eq!(stdout["selection"]["lexical"], false);
+    assert_eq!(stdout["selection"]["semantic"], true);
+    assert_eq!(stdout["index"]["semantic"]["enabled"], false);
+    assert!(stderr.contains("semantic indexing is disabled"), "{stderr}");
+}
+
+#[test]
+fn index_wait_all_stays_strict_when_semantic_is_disabled() {
+    let temp = tempdir();
+    let fixture = provider_history_fixture("codex-sessions");
+    json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "codex",
+        "--path",
+        &fixture,
+        "--json",
+    ]));
+
+    let output = ctx(&temp)
+        .args([
+            "index",
+            "wait",
+            "--all",
+            "--json",
+            "--timeout-seconds",
+            "1",
+            "--interval-seconds",
+            "1",
+        ])
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let stdout: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert_eq!(stdout["schema_version"], 1);
+    assert_eq!(stdout["status"], "blocked");
+    assert_eq!(stdout["selection"]["lexical"], true);
+    assert_eq!(stdout["selection"]["semantic"], true);
+    assert_eq!(stdout["index"]["lexical"]["status"], "ready");
+    assert_eq!(stdout["index"]["semantic"]["enabled"], false);
+    assert!(stderr.contains("semantic indexing is disabled"), "{stderr}");
+}


### PR DESCRIPTION
## Summary
- make bare `ctx index wait` wait for lexical readiness and only include semantic when semantic indexing is enabled
- preserve strict behavior for explicit `--semantic` and `--all`
- add regressions for default, explicit semantic, and all-mode behavior

## Verification
- `cargo test -p ctx --test index`
- adversarial reviewer found no issues after review