### PR TITLE
Reconcile completed scheduled upgrades in status

### DIFF
--- a/crates/ctx-cli/src/upgrade/command.rs
+++ b/crates/ctx-cli/src/upgrade/command.rs
@@ -648,7 +648,9 @@ fn render_status(data_root: &Path, json_output: bool) -> Result<()> {
     let path_diagnostics = current_exe
         .as_ref()
         .map(|path| path_diagnostics(path, current_version));
-    let marker = read_verified_install_marker_for_current_exe()
+    let marker_result = read_verified_install_marker_for_current_exe();
+    let state = reconcile_scheduled_state(state, marker_result.as_ref().ok());
+    let marker = marker_result
         .map(|marker| {
             json!({
                 "managed": true,
@@ -718,4 +720,36 @@ fn render_status(data_root: &Path, json_output: bool) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn reconcile_scheduled_state(
+    mut state: Value,
+    marker: Option<&super::install::InstallMarker>,
+) -> Value {
+    if state.get("status").and_then(Value::as_str) != Some("scheduled") {
+        return state;
+    }
+    let Some(marker) = marker else {
+        return state;
+    };
+    let Some(latest_version) = state.get("latest_version").and_then(Value::as_str) else {
+        return state;
+    };
+    let Some(install_path) = state.get("install_path").and_then(Value::as_str) else {
+        return state;
+    };
+    if Path::new(install_path) != marker.install_path {
+        return state;
+    }
+    if marker.version == latest_version {
+        if let Some(object) = state.as_object_mut() {
+            object.insert("status".to_owned(), Value::String("applied".to_owned()));
+            object.insert("applied".to_owned(), Value::Bool(true));
+            object.insert(
+                "reconciled_from".to_owned(),
+                Value::String("scheduled".to_owned()),
+            );
+        }
+    }
+    state
 }

--- a/crates/ctx-cli/tests/upgrade.rs
+++ b/crates/ctx-cli/tests/upgrade.rs
@@ -86,6 +86,49 @@ fn upgrade_status_text_output_shows_error_details() {
 
 #[cfg(unix)]
 #[test]
+fn upgrade_status_reconciles_completed_scheduled_replacement() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    write_fake_ctx_binary(&release.target, "9.9.9");
+
+    let mut marker: Value =
+        serde_json::from_slice(&fs::read(install_marker_path(&release.target)).unwrap()).unwrap();
+    marker["version"] = Value::String("9.9.9".to_owned());
+    marker["sha256"] = Value::String(release.artifact_sha.clone());
+    fs::write(
+        install_marker_path(&release.target),
+        serde_json::to_vec_pretty(&marker).unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("upgrade-state.json"),
+        serde_json::to_vec_pretty(&json!({
+            "status": "scheduled",
+            "current_version": env!("CARGO_PKG_VERSION"),
+            "latest_version": "9.9.9",
+            "update_available": true,
+            "channel": "stable",
+            "platform": test_platform_key().replace('_', "-"),
+            "install_path": release.target,
+            "managed": true
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let status = json_output(fake_release_env(
+        ctx(&temp).args(["upgrade", "status", "--json"]),
+        &release,
+    ));
+
+    assert_eq!(status["state"]["status"], "applied");
+    assert_eq!(status["state"]["applied"], true);
+    assert_eq!(status["state"]["reconciled_from"], "scheduled");
+    assert_eq!(status["install"]["version"], "9.9.9");
+}
+
+#[cfg(unix)]
+#[test]
 fn upgrade_status_reports_path_shadowing() {
     let temp = tempdir();
     let release = fake_release(&temp, "9.9.9");


### PR DESCRIPTION
## Summary
- make `ctx upgrade status` report a scheduled upgrade as applied when the verified current install marker already matches the scheduled latest version
- require the state install path to match the verified marker path before reconciling
- add a regression that simulates the scheduled replacement having actually installed the new binary and marker

## Verification
- `cargo test -p ctx --test upgrade upgrade_status_reconciles_completed_scheduled_replacement -- --nocapture`
- `cargo test -p ctx --test analytics upgrade_analytics_reports_background`
- `git diff --check`

## Note
- The full `cargo test -p ctx --test upgrade` suite still hit the existing timing-sensitive `upgrade_commands_do_not_execute_hanging_shadow_path_ctx` assertion under local load; the focused test passes and the reviewer found no remaining issues.