### PR TITLE
Allow auto-upgrade probes after JSON commands

### DIFF
--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -738,12 +738,7 @@ fn main() -> Result<()> {
         );
     }
     if result.is_ok() && allow_background_upgrade {
-        upgrade::maybe_spawn_auto_upgrade(
-            &data_root,
-            &config,
-            json_output,
-            &mut analytics_properties,
-        );
+        upgrade::maybe_spawn_auto_upgrade(&data_root, &config, &mut analytics_properties);
     }
     if sends_analytics {
         analytics::send_cli_event(

--- a/crates/ctx-cli/src/upgrade/command.rs
+++ b/crates/ctx-cli/src/upgrade/command.rs
@@ -195,7 +195,6 @@ pub fn run(
 pub fn maybe_spawn_auto_upgrade(
     data_root: &Path,
     config: &AppConfig,
-    json_output: bool,
     analytics_properties: &mut AnalyticsProperties,
 ) {
     analytics::insert_bool(analytics_properties, "auto_upgrade_probe", true);
@@ -206,14 +205,6 @@ pub fn maybe_spawn_auto_upgrade(
         "upgrade_channel",
         upgrade_channel_bucket(&config.upgrade.channel),
     );
-    if json_output {
-        analytics::insert_str(
-            analytics_properties,
-            "auto_upgrade_spawn_status",
-            "json_output",
-        );
-        return;
-    }
     if !auto_mode_is_apply(config) {
         analytics::insert_str(
             analytics_properties,

--- a/crates/ctx-cli/tests/analytics.rs
+++ b/crates/ctx-cli/tests/analytics.rs
@@ -80,6 +80,38 @@ fn analytics_sends_coarse_cli_metadata_when_enabled() {
 }
 
 #[test]
+fn eligible_json_command_analytics_reports_normal_auto_upgrade_status() {
+    let temp = tempdir();
+    let events_path = temp.path().join("analytics.jsonl");
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let data_root = temp.path().join("data");
+    fs::create_dir_all(&home).unwrap();
+
+    ctx(&temp)
+        .args(["doctor", "--json"])
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env_remove("CTX_ANALYTICS_OFF")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
+        .assert()
+        .success();
+
+    let event = read_analytics_events(&events_path).remove(0);
+    let properties = analytics_event_properties(&event);
+    assert_eq!(properties["action"], "doctor");
+    assert_eq!(properties["json_output"], true);
+    assert_eq!(properties["auto_upgrade_probe"], true);
+    assert_eq!(properties["auto_upgrade_due"], true);
+    assert_eq!(properties["auto_upgrade_spawned"], false);
+    assert_eq!(properties["auto_upgrade_spawn_status"], "marker_invalid");
+    assert_ne!(properties["auto_upgrade_spawn_status"], "json_output");
+    assert_analytics_properties_are_allowlisted(properties);
+}
+
+#[test]
 fn capability_snapshot_is_sent_once_after_successful_delivery() {
     let temp = tempdir();
     let events_path = temp.path().join("analytics.jsonl");

--- a/crates/ctx-cli/tests/upgrade.rs
+++ b/crates/ctx-cli/tests/upgrade.rs
@@ -466,7 +466,7 @@ fn upgrade_rejects_unsafe_metadata_and_bad_artifacts() {
 
 #[cfg(unix)]
 #[test]
-fn json_commands_do_not_spawn_background_upgrade() {
+fn status_json_does_not_spawn_background_upgrade() {
     let temp = tempdir();
     let release = fake_release(&temp, "9.9.9");
 
@@ -482,6 +482,68 @@ fn json_commands_do_not_spawn_background_upgrade() {
     assert!(
         !temp.path().join("upgrade-state.json").exists(),
         "JSON status must not start a background upgrade"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn eligible_json_command_spawns_background_upgrade_without_polluting_output() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let binary = copied_ctx_binary(&temp);
+    let before = fs::read(&binary).unwrap();
+    let current_sha = sha256_hex(&before);
+    fs::write(
+        install_marker_path(&binary),
+        serde_json::to_vec_pretty(&json!({
+            "schema_version": 1,
+            "manager": "ctx-hosted-installer",
+            "install_attempt_id": "ia_test_doctor_json_background",
+            "install_path": binary.display().to_string(),
+            "platform": test_platform_key().replace('_', "-"),
+            "channel": "stable",
+            "version": env!("CARGO_PKG_VERSION"),
+            "sha256": current_sha,
+            "metadata_url": null,
+            "artifact_url": null,
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let mut command = ctx_from_binary(&temp, &binary);
+    let output = command
+        .args(["doctor", "--json"])
+        .env("CTX_RELEASE_METADATA_URL", file_url(&release.metadata))
+        .env(
+            "CTX_RELEASE_METADATA_SIGNATURE_URL",
+            file_url(&release.signature),
+        )
+        .env(
+            "CTX_RELEASE_METADATA_PUBLIC_KEY_PEM",
+            TEST_RELEASE_PUBLIC_KEY_PEM,
+        )
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let doctor: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(doctor["schema_version"], 1);
+    assert_eq!(
+        output.stderr, b"",
+        "background upgrade must not write to JSON command stderr"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while Instant::now() < deadline {
+        if fs::read_to_string(&binary).unwrap_or_default() == "#!/bin/sh\nprintf 'ctx 9.9.9\\n'\n" {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!(
+        "eligible JSON command did not apply background upgrade; state: {:?}",
+        fs::read_to_string(temp.path().join("upgrade-state.json")).ok()
     );
 }
 


### PR DESCRIPTION
## Summary
- allow eligible JSON-output commands to run the same silent detached auto-upgrade probe as text commands
- keep existing command eligibility, auto mode, due interval, CI/env, background-child, and managed-marker gates
- remove the now-unused JSON-output parameter from the internal auto-upgrade probe helper
- add regressions for status --json remaining ineligible, doctor --json preserving clean output while spawning, and analytics reporting normal probe status for JSON commands

## Verification
- plan reviewed by subagent: no blockers after requested test constraints
- implementer agent completed patch and self-checks
- adversarial review after implementation: no findings
- final adversarial review after signature cleanup: no findings
- cargo test -p ctx --test analytics
- cargo test -p ctx --test upgrade -- --test-threads=1
- cargo test -p ctx --test upgrade eligible_json_command_spawns_background_upgrade_without_polluting_output -- --nocapture
- cargo test -p ctx --test upgrade status_json_does_not_spawn_background_upgrade -- --nocapture
- cargo test -p ctx --test analytics eligible_json_command_analytics_reports_normal_auto_upgrade_status -- --nocapture
- git diff --check