### PR TITLE
Tolerate malformed rows during search refresh

### DIFF
--- a/crates/ctx-cli/src/commands/search.rs
+++ b/crates/ctx-cli/src/commands/search.rs
@@ -10,7 +10,9 @@ use anyhow::{anyhow, Context, Result};
 use clap::ValueEnum;
 use serde_json::{json, Value};
 
-use ctx_history_capture::{discover_provider_sources_for_provider, ProviderSourceStatus};
+use ctx_history_capture::{
+    discover_provider_sources_for_provider, ProviderImportSummary, ProviderSourceStatus,
+};
 use ctx_history_core::database_path;
 use ctx_history_store::Store;
 
@@ -536,6 +538,10 @@ pub(crate) fn refresh_sources_for_search(
     );
     let mut totals = ImportTotals::default();
     let mut first_refresh_failure = None::<String>;
+    // Provider histories are live, append-only data and may contain isolated
+    // malformed rows. Refresh all valid history while preserving hard errors
+    // for source-level and system-level failures.
+    let allow_partial_failures = true;
     if should_parallelize_import(&planned_sources) {
         let source_states = Arc::new(Mutex::new(
             planned_sources
@@ -563,7 +569,7 @@ pub(crate) fn refresh_sources_for_search(
                         &plan.source,
                         progress_callback,
                         false,
-                        false,
+                        allow_partial_failures,
                         &plan.preinventory,
                     )?;
                     Ok(ImportSourceOutcome {
@@ -592,6 +598,12 @@ pub(crate) fn refresh_sources_for_search(
         }
         outcomes.sort_by_key(|outcome| outcome.index);
         for outcome in outcomes {
+            warn_on_partial_refresh(
+                &progress,
+                json_output,
+                outcome.source.provider.as_str(),
+                &outcome.summary,
+            );
             totals.add(&outcome.summary, &outcome.stats);
         }
     } else {
@@ -610,11 +622,17 @@ pub(crate) fn refresh_sources_for_search(
                 &plan.source,
                 source_progress,
                 false,
-                false,
+                allow_partial_failures,
                 &plan.preinventory,
             );
             match import_result {
                 Ok(summary) => {
+                    warn_on_partial_refresh(
+                        &progress,
+                        json_output,
+                        plan.source.provider.as_str(),
+                        &summary,
+                    );
                     totals.add(&summary, &plan.stats);
                     progress.done(
                         "refreshing",
@@ -648,13 +666,22 @@ pub(crate) fn refresh_sources_for_search(
                 "refreshing",
                 format!("running history source plugin {}", plugin_source.label()),
             );
-            let import_result =
-                import_history_source_plugin(&mut store, &plugin_source, data_root, false, false)
-                    .with_context(|| {
-                        format!("refresh history source plugin {}", plugin_source.label())
-                    });
+            let import_result = import_history_source_plugin(
+                &mut store,
+                &plugin_source,
+                data_root,
+                false,
+                allow_partial_failures,
+            )
+            .with_context(|| format!("refresh history source plugin {}", plugin_source.label()));
             match import_result {
                 Ok((summary, stats)) => {
+                    warn_on_partial_refresh(
+                        &progress,
+                        json_output,
+                        &plugin_source.label(),
+                        &summary,
+                    );
                     totals.add(&summary, &stats);
                     progress.done(
                         "refreshing",
@@ -693,4 +720,34 @@ pub(crate) fn refresh_sources_for_search(
 
     Store::open(&db_path)?.checkpoint_wal_truncate_if_larger_than(WAL_TRUNCATE_MIN_BYTES)?;
     Ok(totals)
+}
+
+fn warn_on_partial_refresh(
+    progress: &ProgressReporter,
+    json_output: bool,
+    source: &str,
+    summary: &ProviderImportSummary,
+) {
+    if summary.failed == 0 {
+        return;
+    }
+    let first_failure = summary
+        .failures
+        .first()
+        .map(|failure| {
+            format!(
+                "; first failure at line {}: {}",
+                failure.line, failure.error
+            )
+        })
+        .unwrap_or_default();
+    let warning = format!(
+        "partially refreshed {source}: skipped {} invalid history record(s){first_failure}",
+        summary.failed
+    );
+    if progress.is_enabled() {
+        progress.warning(warning);
+    } else if !json_output {
+        eprintln!("warning: {warning}");
+    }
 }

--- a/crates/ctx-cli/tests/search_refresh.rs
+++ b/crates/ctx-cli/tests/search_refresh.rs
@@ -31,6 +31,89 @@ fn search_refreshes_discovered_codex_sessions_before_query() {
 }
 
 #[test]
+fn search_refresh_wait_skips_malformed_jsonl_rows() {
+    let temp = tempdir();
+    write_malformed_claude_session(&temp);
+
+    let output = ctx(&temp)
+        .args([
+            "search",
+            "partial refresh search marker",
+            "--provider",
+            "claude",
+            "--refresh",
+            "wait",
+            "--json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let search: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_search_provider_oracle(
+        &search,
+        "claude",
+        "partial refresh search marker",
+        1,
+        "message",
+    );
+    assert_eq!(search["freshness"]["status"], "completed");
+    assert!(
+        search["freshness"]["totals"]["failed"].as_u64().unwrap() >= 1,
+        "{search:#}"
+    );
+
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("partially refreshed claude"), "{stderr}");
+    assert!(stderr.contains("malformed JSONL"), "{stderr}");
+    assert!(stderr.contains("claude-session.jsonl"), "{stderr}");
+}
+
+#[test]
+fn search_refresh_wait_warns_when_progress_is_not_interactive() {
+    let temp = tempdir();
+    write_malformed_claude_session(&temp);
+
+    let output = ctx(&temp)
+        .args([
+            "search",
+            "partial refresh search marker",
+            "--provider",
+            "claude",
+            "--refresh",
+            "wait",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("partial refresh search marker"), "{stdout}");
+
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("partially refreshed claude"), "{stderr}");
+    assert!(stderr.contains("malformed JSONL"), "{stderr}");
+    assert!(stderr.contains("claude-session.jsonl"), "{stderr}");
+}
+
+fn write_malformed_claude_session(temp: &TempDir) {
+    let project = temp.path().join(".claude").join("projects").join("-repo");
+    fs::create_dir_all(&project).unwrap();
+    fs::write(
+        project.join("claude-session.jsonl"),
+        concat!(
+            r#"{"sessionId":"claude-session","timestamp":"2026-06-24T10:00:00Z","cwd":"/repo","version":"test","type":"user","message":{"role":"user","content":[{"type":"text","text":"partial refresh search marker"}]},"uuid":"claude-user"}"#,
+            "\n",
+            "{malformed-jsonl-row\n",
+            r#"{"sessionId":"claude-session","timestamp":"2026-06-24T10:00:01Z","cwd":"/repo","version":"test","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"valid rows remain searchable"}]},"uuid":"claude-assistant"}"#,
+            "\n"
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
 fn search_refresh_off_serves_existing_index_without_importing() {
     let temp = tempdir();
     let indexed_fixture = provider_history_fixture("codex-sessions");

--- a/crates/ctx-history-capture/src/provider/providers/claude.rs
+++ b/crates/ctx-history-capture/src/provider/providers/claude.rs
@@ -51,7 +51,7 @@ pub(crate) fn normalize_claude_projects_jsonl_file(
                 result.summary.failed += 1;
                 result.summary.failures.push(ProviderImportFailure {
                     line: line_number,
-                    error: format!("malformed JSONL: {err}"),
+                    error: format!("malformed JSONL in {}: {err}", path.display()),
                 });
                 continue;
             }

--- a/crates/ctx-history-capture/src/tests/native_json.rs
+++ b/crates/ctx-history-capture/src/tests/native_json.rs
@@ -1216,6 +1216,7 @@ fn native_claude_projects_reports_malformed_jsonl() {
     assert_eq!(summary.imported_sessions, 1);
     assert_eq!(summary.imported_events, 1);
     assert!(summary.failures[0].error.contains("malformed JSONL"));
+    assert!(summary.failures[0].error.contains("claude-malformed.jsonl"));
 }
 
 #[test]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -381,7 +381,9 @@ visible through `ctx status`, `ctx index status`, and the search JSON
 during search, does not create the semantic sidecar from the query path, and
 does not start semantic indexing. Use `--refresh off` to search the existing
 index without refreshing or scheduling semantic work, or `--refresh wait` to run
-foreground text refresh and fail when it cannot complete. Explicit-only native sources such as
+foreground text refresh and fail when it cannot complete. Foreground refresh skips isolated
+malformed history records with a warning and commits valid records; source-level and system-level
+failures remain fatal. Explicit-only native sources such as
 NanoClaw, plus search-only sources without native import support, are searched
 from the existing index until they are explicitly imported through a supported
 path. Supported AstrBot `data_v4.db` locations participate in bounded native

--- a/docs/search.md
+++ b/docs/search.md
@@ -167,9 +167,11 @@ lets daemon maintenance refresh lexical and semantic indexes. If daemon
 maintenance is disabled, `background` uses the bounded foreground text-refresh
 path for discovered native provider sources and enabled auto history-source
 plugins. `wait` runs that foreground text refresh and fails if it cannot
-complete; it does not wait for full semantic coverage. `off` skips foreground
-refresh, never runs plugin commands, and does not schedule or run semantic
-indexing. Explicit-only native sources such as
+complete; isolated malformed history records are skipped with a warning while
+valid records are committed. Source-level and system-level failures still fail
+the refresh. `wait` does not wait for full semantic coverage. `off` skips
+foreground refresh, never runs plugin commands, and does not schedule or run
+semantic indexing. Explicit-only native sources such as
 NanoClaw, plus search-only sources without native import support, are searched
 from the existing index until they are explicitly imported through a supported
 path. Supported AstrBot `data_v4.db` locations participate in bounded native


### PR DESCRIPTION
## Summary

- make foreground and bounded background search refresh use the existing partial-import path
- commit valid history records while warning about isolated malformed records
- include the exact Claude transcript path in malformed-row diagnostics
- preserve fatal behavior for source-level and system-level failures
- document the partial-refresh behavior

## Why

Live provider histories can contain isolated truncated or malformed JSONL rows. A single bad row should not make `ctx search --refresh wait` discard all valid refreshed history.

## Verification

- `cargo fmt --check`
- `cargo test -p ctx-history-capture native_claude_projects_reports_malformed_jsonl`
- `cargo test -p ctx --test search_refresh -- --test-threads=1` (19 passed)
- `cargo clippy -p ctx -p ctx-history-capture --all-targets -- -D warnings`
- independent code review: no remaining findings

Closes #128
