### PR TITLE
Prefer conversational events in search ranking

### DIFF
--- a/crates/ctx-history-search/src/ranking.rs
+++ b/crates/ctx-history-search/src/ranking.rs
@@ -390,9 +390,10 @@ pub(crate) fn search_sections(
     filters: &SearchFilters,
 ) -> Vec<SearchSection> {
     let mut sections = Vec::new();
+    let event_type_search = filters.event_type.is_some();
     let record_hit = record_context_display_hit(context, filters, record.updated_at);
     let include_record_bookkeeping_text = !is_agent_history_bookkeeping_record(record);
-    if include_record_bookkeeping_text {
+    if include_record_bookkeeping_text && !event_type_search {
         sections.push(SearchSection {
             reason: "title",
             weight: 8.0,
@@ -406,7 +407,8 @@ pub(crate) fn search_sections(
             hit: record_hit.clone(),
         });
     }
-    let include_record_text = include_record_bookkeeping_text
+    let include_record_text = !event_type_search
+        && include_record_bookkeeping_text
         && record_text_matches_agent_scope(context, filters)
         && !context_has_excluded_provider_session(context, filters);
     if include_record_text {
@@ -440,6 +442,9 @@ pub(crate) fn search_sections(
         }
     }
     for session in &context.sessions {
+        if event_type_search {
+            continue;
+        }
         if !session_matches_agent_scope(session, filters)
             || !source_id_matches_history_source_filter(session.capture_source_id, context, filters)
         {
@@ -468,6 +473,9 @@ pub(crate) fn search_sections(
     }
 
     for run in &context.runs {
+        if event_type_search {
+            continue;
+        }
         if !item_matches_agent_scope(run.session_id, run.source_id, context, filters) {
             continue;
         }
@@ -496,6 +504,12 @@ pub(crate) fn search_sections(
     }
 
     for event in &context.events {
+        if filters
+            .event_type
+            .is_some_and(|event_type| event.event_type != event_type)
+        {
+            continue;
+        }
         if !item_matches_agent_scope(event.session_id, event.capture_source_id, context, filters) {
             continue;
         }
@@ -509,6 +523,8 @@ pub(crate) fn search_sections(
                 ctx_history_core::EventType::CommandStarted
                 | ctx_history_core::EventType::CommandOutput
                 | ctx_history_core::EventType::CommandFinished => "command_event",
+                ctx_history_core::EventType::Summary => "summary",
+                ctx_history_core::EventType::Notice => "notice",
                 _ => "event",
             },
             weight: event_weight(event),
@@ -524,6 +540,9 @@ pub(crate) fn search_sections(
     }
 
     for artifact in &context.artifacts {
+        if event_type_search {
+            continue;
+        }
         if !item_matches_agent_scope(None, artifact.source_id, context, filters) {
             continue;
         }
@@ -548,6 +567,9 @@ pub(crate) fn search_sections(
     }
 
     for file in &context.files_touched {
+        if event_type_search {
+            continue;
+        }
         let session_id = file.event_id.and_then(|id| {
             context
                 .events
@@ -574,6 +596,9 @@ pub(crate) fn search_sections(
     }
 
     for change in &context.vcs_changes {
+        if event_type_search {
+            continue;
+        }
         if !item_matches_agent_scope(None, change.source_id, context, filters) {
             continue;
         }
@@ -604,6 +629,9 @@ pub(crate) fn search_sections(
     }
 
     for summary in &context.summaries {
+        if event_type_search {
+            continue;
+        }
         if !item_matches_agent_scope(None, summary.source_id, context, filters) {
             continue;
         }

--- a/crates/ctx-history-search/src/search.rs
+++ b/crates/ctx-history-search/src/search.rs
@@ -93,7 +93,12 @@ pub fn semantic_event_search_packet(
     if hybrid {
         let page_size = FILTERED_SEARCH_PAGE_SIZE.max(target_results.saturating_mul(8).max(50));
         let mut lexical_rank = 0_usize;
-        for hit in store.search_event_hits_page(query, page_size, 0)? {
+        let lexical_hits = if options.filters.event_type.is_some() {
+            store.search_event_hits_page(query, page_size, 0)?
+        } else {
+            store.search_event_hits_page_prefer_conversation(query, page_size, 0)?
+        };
+        for hit in lexical_hits {
             if !event_hit_matches_filters(&hit, &options.filters, file_scope) {
                 continue;
             }
@@ -362,7 +367,11 @@ fn fast_event_search_packet(
 
     loop {
         pages_scanned = pages_scanned.saturating_add(1);
-        let hits = store.search_event_hits_page(query, page_size, offset)?;
+        let hits = if options.filters.event_type.is_some() {
+            store.search_event_hits_page(query, page_size, offset)?
+        } else {
+            store.search_event_hits_page_prefer_conversation(query, page_size, offset)?
+        };
         let page_len = hits.len();
 
         for hit in hits {

--- a/crates/ctx-history-search/src/snippets.rs
+++ b/crates/ctx-history-search/src/snippets.rs
@@ -22,7 +22,7 @@ pub(crate) fn joined<const N: usize>(parts: [&str; N]) -> String {
 
 pub(crate) fn event_weight(event: &Event) -> f32 {
     match event.event_type {
-        ctx_history_core::EventType::Message => 4.0,
+        ctx_history_core::EventType::Message | ctx_history_core::EventType::Summary => 4.0,
         ctx_history_core::EventType::ToolCall | ctx_history_core::EventType::ToolOutput => 3.5,
         ctx_history_core::EventType::CommandStarted
         | ctx_history_core::EventType::CommandOutput

--- a/crates/ctx-history-search/src/tests/fast_path.rs
+++ b/crates/ctx-history-search/src/tests/fast_path.rs
@@ -7,6 +7,141 @@ use super::{
 };
 
 #[test]
+fn fast_search_prefers_messages_and_summaries_in_event_and_session_modes() {
+    let (_temp, store) = test_store();
+    let record = HistoryRecord::new(
+        "Large mixed event history",
+        "single imported agent-history record",
+        Vec::new(),
+        "agent_history",
+        Some("/workspace/ctx".into()),
+    );
+    store.insert_record(&record).unwrap();
+    let needle = "fast-event-type-ranking-needle";
+    let event_types = [
+        EventType::ToolCall,
+        EventType::CommandStarted,
+        EventType::ToolOutput,
+        EventType::Message,
+        EventType::Summary,
+    ];
+    let mut matching_event_ids = Vec::new();
+    let mut matching_sessions = Vec::new();
+
+    for (index, event_type) in event_types.into_iter().enumerate() {
+        let session_id =
+            Uuid::parse_str(&format!("018f45d0-0000-7000-8000-00000005{index:04x}")).unwrap();
+        matching_sessions.push(session_id);
+        store
+            .upsert_session(&Session {
+                id: session_id,
+                history_record_id: Some(record.id),
+                parent_session_id: None,
+                root_session_id: None,
+                capture_source_id: None,
+                provider: CaptureProvider::Codex,
+                external_session_id: Some(format!("mixed-event-session-{index}")),
+                external_agent_id: None,
+                agent_type: AgentType::Primary,
+                role_hint: Some("primary".into()),
+                is_primary: true,
+                status: SessionStatus::Imported,
+                transcript_blob_id: None,
+                started_at: fixed_time(),
+                ended_at: None,
+                timestamps: timestamps(),
+                sync: sync_metadata(),
+            })
+            .unwrap();
+        let event_id =
+            Uuid::parse_str(&format!("018f45d0-0000-7000-8000-00000006{index:04x}")).unwrap();
+        matching_event_ids.push(event_id);
+        let payload = if event_type == EventType::ToolOutput {
+            serde_json::json!({"text": needle, "exit_code": 1})
+        } else {
+            serde_json::json!({"text": needle})
+        };
+        store
+            .upsert_event(&Event {
+                id: event_id,
+                seq: 10 + index as u64,
+                history_record_id: Some(record.id),
+                session_id: Some(session_id),
+                run_id: None,
+                event_type,
+                role: Some(EventRole::Assistant),
+                occurred_at: fixed_time(),
+                capture_source_id: None,
+                payload,
+                payload_blob_id: None,
+                dedupe_key: None,
+                sync: sync_metadata(),
+            })
+            .unwrap();
+    }
+    for index in 0..(LARGE_EVENT_CORPUS_THRESHOLD as usize - matching_event_ids.len()) {
+        store
+            .upsert_event(&Event {
+                id: Uuid::parse_str(&format!("018f45d0-0000-7000-8000-00000007{index:04x}"))
+                    .unwrap(),
+                seq: 1_000 + index as u64,
+                history_record_id: Some(record.id),
+                session_id: Some(matching_sessions[0]),
+                run_id: None,
+                event_type: EventType::Message,
+                role: Some(EventRole::Assistant),
+                occurred_at: fixed_time(),
+                capture_source_id: None,
+                payload: serde_json::json!({"text": format!("unrelated event {index}")}),
+                payload_blob_id: None,
+                dedupe_key: None,
+                sync: sync_metadata(),
+            })
+            .unwrap();
+    }
+
+    for result_mode in [SearchResultMode::Events, SearchResultMode::Sessions] {
+        let packet = search_packet(
+            &store,
+            needle,
+            &PacketOptions {
+                limit: matching_event_ids.len(),
+                result_mode,
+                ..PacketOptions::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(packet.results.len(), matching_event_ids.len());
+        assert!(matches!(
+            packet.results[0].why_matched.as_slice(),
+            [reason] if reason == "message" || reason == "summary"
+        ));
+        assert!(matches!(
+            packet.results[1].why_matched.as_slice(),
+            [reason] if reason == "message" || reason == "summary"
+        ));
+    }
+
+    let tool_only = search_packet(
+        &store,
+        needle,
+        &PacketOptions {
+            limit: 5,
+            result_mode: SearchResultMode::Events,
+            filters: SearchFilters {
+                event_type: Some(EventType::ToolOutput),
+                ..SearchFilters::default()
+            },
+            ..PacketOptions::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(tool_only.results.len(), 1);
+    assert_eq!(tool_only.results[0].event_id, Some(matching_event_ids[2]));
+    assert_eq!(tool_only.results[0].why_matched, vec!["tool_output"]);
+}
+
+#[test]
 fn large_agent_history_search_returns_event_hits() {
     let (_temp, store) = test_store();
     let record = HistoryRecord::new(

--- a/crates/ctx-history-search/src/tests/ranking.rs
+++ b/crates/ctx-history-search/src/tests/ranking.rs
@@ -1,7 +1,7 @@
 use super::{
     fixed_time, search_packet, search_packet_terms, sync_metadata, test_store, timestamps,
-    Confidence, FileChangeKind, FileTouched, HistoryRecord, PacketOptions, SearchFilters,
-    Serialize, Uuid,
+    Confidence, Event, EventRole, EventType, FileChangeKind, FileTouched, HistoryRecord,
+    PacketOptions, SearchFilters, Serialize, Uuid,
 };
 
 fn deterministic_tie_record(id: &str) -> HistoryRecord {
@@ -22,6 +22,74 @@ fn packet_without_generated_at<T: Serialize>(packet: &T) -> serde_json::Value {
     let mut value = serde_json::to_value(packet).unwrap();
     value.as_object_mut().unwrap().remove("generated_at");
     value
+}
+
+#[test]
+fn candidate_ranking_prefers_messages_and_summaries_and_honors_event_type_filter() {
+    let (_temp, store) = test_store();
+    let needle = "candidate-event-type-ranking-needle";
+    let event_types = [
+        EventType::ToolCall,
+        EventType::CommandStarted,
+        EventType::Message,
+        EventType::Summary,
+    ];
+    for (index, event_type) in event_types.into_iter().enumerate() {
+        let mut record = HistoryRecord::new(
+            format!("Mixed event record {index}"),
+            "agent history record",
+            Vec::new(),
+            "agent_history",
+            None,
+        );
+        record.id =
+            Uuid::parse_str(&format!("018f45d0-0000-7000-8000-00000008{index:04x}")).unwrap();
+        store.insert_record(&record).unwrap();
+        store
+            .upsert_event(&Event {
+                id: Uuid::parse_str(&format!("018f45d0-0000-7000-8000-00000009{index:04x}"))
+                    .unwrap(),
+                seq: index as u64,
+                history_record_id: Some(record.id),
+                session_id: None,
+                run_id: None,
+                event_type,
+                role: Some(EventRole::Assistant),
+                occurred_at: fixed_time(),
+                capture_source_id: None,
+                payload: serde_json::json!({"text": needle}),
+                payload_blob_id: None,
+                dedupe_key: None,
+                sync: sync_metadata(),
+            })
+            .unwrap();
+    }
+
+    let packet = search_packet(&store, needle, &PacketOptions::default()).unwrap();
+    assert_eq!(packet.results.len(), event_types.len());
+    assert!(matches!(
+        packet.results[0].why_matched.as_slice(),
+        [reason] if reason == "message" || reason == "summary"
+    ));
+    assert!(matches!(
+        packet.results[1].why_matched.as_slice(),
+        [reason] if reason == "message" || reason == "summary"
+    ));
+
+    let filtered = search_packet(
+        &store,
+        needle,
+        &PacketOptions {
+            filters: SearchFilters {
+                event_type: Some(EventType::ToolCall),
+                ..SearchFilters::default()
+            },
+            ..PacketOptions::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(filtered.results.len(), 1);
+    assert_eq!(filtered.results[0].why_matched, vec!["tool_call"]);
 }
 
 #[test]

--- a/crates/ctx-history-store/src/search/projections.rs
+++ b/crates/ctx-history-store/src/search/projections.rs
@@ -107,6 +107,25 @@ impl Store {
         limit: usize,
         offset: usize,
     ) -> Result<Vec<EventSearchHit>> {
+        self.search_event_hits_page_with_ranking(query, limit, offset, false)
+    }
+
+    pub fn search_event_hits_page_prefer_conversation(
+        &self,
+        query: &str,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<EventSearchHit>> {
+        self.search_event_hits_page_with_ranking(query, limit, offset, true)
+    }
+
+    fn search_event_hits_page_with_ranking(
+        &self,
+        query: &str,
+        limit: usize,
+        offset: usize,
+        prefer_conversation: bool,
+    ) -> Result<Vec<EventSearchHit>> {
         if !table_exists(&self.conn, "event_search")? {
             return Ok(Vec::new());
         }
@@ -139,8 +158,8 @@ impl Store {
                     "#,
                     event_search_hit_sql(
                         "ranked JOIN event_search ON event_search.event_id = ranked.event_id",
-                        "ranked.score",
-                        "ORDER BY ranked.score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
+                        &event_search_score("ranked.score", prefer_conversation),
+                        "ORDER BY search_score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
                     )
                 );
                 let mut stmt = self.conn.prepare(&sql)?;
@@ -160,7 +179,7 @@ impl Store {
                     "{} LIMIT ?2 OFFSET ?3",
                     event_search_hit_sql(
                         "event_search",
-                        "bm25(event_search)",
+                        &event_search_score("bm25(event_search)", prefer_conversation),
                         "WHERE event_search MATCH ?1 ORDER BY search_score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
                     )
                 );
@@ -176,7 +195,10 @@ impl Store {
                     "{} LIMIT ?2 OFFSET ?3",
                     event_search_hit_sql(
                         "event_search_scriptgram JOIN event_search ON event_search.event_id = event_search_scriptgram.event_id",
-                        "bm25(event_search_scriptgram) + 0.35",
+                        &event_search_score(
+                            "bm25(event_search_scriptgram) + 0.35",
+                            prefer_conversation,
+                        ),
                         "WHERE event_search_scriptgram MATCH ?1 ORDER BY search_score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
                     )
                 );
@@ -508,6 +530,16 @@ impl Store {
                 [],
             )?;
         Ok(())
+    }
+}
+
+fn event_search_score(score_sql: &str, prefer_conversation: bool) -> String {
+    if prefer_conversation {
+        format!(
+            "CASE WHEN e.event_type IN ('message', 'summary') THEN ({score_sql}) - (ABS({score_sql}) * 0.15) ELSE ({score_sql}) END"
+        )
+    } else {
+        score_sql.to_owned()
     }
 }
 

--- a/crates/ctx-history-store/src/search/tests.rs
+++ b/crates/ctx-history-store/src/search/tests.rs
@@ -115,6 +115,92 @@ fn with_occurred_at(mut event: Event, offset_minutes: i64) -> Event {
 }
 
 #[test]
+fn preferred_event_search_ranks_conversation_above_equal_tool_events() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let needle = "conversation-ranking-needle";
+    let events = [
+        policy_event(
+            1,
+            EventType::ToolCall,
+            Some(EventRole::Assistant),
+            serde_json::json!({"text": needle}),
+        ),
+        policy_event(
+            2,
+            EventType::CommandStarted,
+            Some(EventRole::Assistant),
+            serde_json::json!({"command": needle}),
+        ),
+        policy_event(
+            3,
+            EventType::Message,
+            Some(EventRole::Assistant),
+            serde_json::json!({"text": needle}),
+        ),
+        policy_event(
+            4,
+            EventType::Summary,
+            Some(EventRole::Assistant),
+            serde_json::json!({"summary": needle}),
+        ),
+    ];
+    for event in &events {
+        store.upsert_event(event).unwrap();
+    }
+
+    let hits = store
+        .search_event_hits_page_prefer_conversation(needle, 10, 0)
+        .unwrap();
+    assert_eq!(hits.len(), events.len());
+    assert!(matches!(
+        hits[0].event_type,
+        EventType::Message | EventType::Summary
+    ));
+    assert!(matches!(
+        hits[1].event_type,
+        EventType::Message | EventType::Summary
+    ));
+    assert!(matches!(
+        hits[2].event_type,
+        EventType::ToolCall | EventType::CommandStarted
+    ));
+    assert!(matches!(
+        hits[3].event_type,
+        EventType::ToolCall | EventType::CommandStarted
+    ));
+}
+
+#[test]
+fn preferred_event_search_keeps_materially_stronger_tool_evidence_first() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let needle = "exact-tool-evidence-needle";
+    let message = policy_event(
+        1,
+        EventType::Message,
+        Some(EventRole::Assistant),
+        serde_json::json!({
+            "text": format!("{needle} {}", "unrelated context ".repeat(100))
+        }),
+    );
+    let tool = policy_event(
+        2,
+        EventType::ToolCall,
+        Some(EventRole::Assistant),
+        serde_json::json!({"text": format!("{needle} {needle} {needle}")}),
+    );
+    store.upsert_event(&message).unwrap();
+    store.upsert_event(&tool).unwrap();
+
+    let hits = store
+        .search_event_hits_page_prefer_conversation(needle, 10, 0)
+        .unwrap();
+    assert_eq!(hits.len(), 2);
+    assert_eq!(hits[0].event_id, tool.id);
+}
+
+#[test]
 fn indexed_history_item_count_uses_sessions_and_events() {
     let temp = tempdir();
     let store = Store::open(temp.path().join("work.sqlite")).unwrap();


### PR DESCRIPTION
## Summary

- prefer message and provider-produced summary events over similarly relevant tool, command, and notice events
- apply the same soft ranking preference to small-corpus candidate search and the large-corpus fast/hybrid lexical path
- keep explicit event-type searches neutral and restricted to the requested type

## Why

Raw BM25 ordering allowed tool output and command noise to displace user/assistant conversation and provider summaries. The new ranking profile improves message and summary BM25 scores by 15% of their absolute magnitude. This is a soft preference: materially stronger tool evidence can still rank first.

## Validation

- cargo test -p ctx-history-store --lib search::tests (20 passed)
- cargo test -p ctx-history-search --lib (28 passed, 1 ignored manual perf test)
- cargo clippy -p ctx-history-store -p ctx-history-search --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check

Focused regressions cover small-corpus ranking, large fast-path event and session modes, explicit tool-output filtering, equal-relevance ordering, and a stronger tool match remaining first.