### PR TITLE
Default lexical search to OR semantics

### DIFF
--- a/crates/ctx-history-search/src/model.rs
+++ b/crates/ctx-history-search/src/model.rs
@@ -10,6 +10,7 @@ pub(crate) struct Candidate {
     pub(crate) record: HistoryRecord,
     pub(crate) context: RecordContext,
     pub(crate) score: f32,
+    pub(crate) matched_term_count: usize,
     pub(crate) why_matched: Vec<String>,
     pub(crate) citations: Vec<ContextCitation>,
     pub(crate) primary_hit: Option<HitMetadata>,

--- a/crates/ctx-history-search/src/query.rs
+++ b/crates/ctx-history-search/src/query.rs
@@ -125,15 +125,16 @@ pub(crate) fn composed_search_terms(query: &str, terms: &[String]) -> Vec<String
 }
 
 pub(crate) fn query_terms(query: &str) -> Vec<String> {
-    query
-        .split(|ch: char| !ch.is_alphanumeric() && ch != '_' && ch != '-')
-        .filter_map(|term| {
-            let term = term.trim().to_lowercase();
-            if term.is_empty() || !term.chars().any(char::is_alphanumeric) {
-                None
-            } else {
-                Some(term)
-            }
-        })
-        .collect()
+    let mut terms = Vec::new();
+    for term in query.split(|ch: char| !ch.is_alphanumeric() && ch != '_' && ch != '-') {
+        let term = term.trim().to_lowercase();
+        if term.is_empty()
+            || !term.chars().any(char::is_alphanumeric)
+            || terms.iter().any(|existing| existing == &term)
+        {
+            continue;
+        }
+        terms.push(term);
+    }
+    terms
 }

--- a/crates/ctx-history-search/src/ranking.rs
+++ b/crates/ctx-history-search/src/ranking.rs
@@ -18,7 +18,7 @@ use crate::query::{
     query_terms, PacketOptions, Result, SearchFilters, FILTERED_SEARCH_MAX_PAGES,
     FILTERED_SEARCH_PAGE_SIZE,
 };
-use crate::snippets::{event_text, event_weight, joined, matches_terms};
+use crate::snippets::{event_text, event_weight, joined, matching_term_count};
 use crate::source::{
     artifact_hit, citation, empty_hit, event_hit, file_hit, file_touched_search_text,
     record_context_display_hit, run_hit, session_hit, source_hit,
@@ -176,6 +176,7 @@ pub(crate) fn candidate_for_record(
             record,
             context,
             score: analysis.score,
+            matched_term_count: analysis.matched_term_count,
             why_matched: analysis.why_matched,
             citations: analysis.citations,
             primary_hit: analysis.primary_hit,
@@ -258,6 +259,7 @@ pub(crate) fn hydrate_record_context(
 
 struct MatchAnalysis {
     score: f32,
+    matched_term_count: usize,
     why_matched: Vec<String>,
     citations: Vec<ContextCitation>,
     primary_hit: Option<HitMetadata>,
@@ -295,6 +297,7 @@ fn analyze_record(
             if !why.is_empty() {
                 return MatchAnalysis {
                     score,
+                    matched_term_count: 0,
                     why_matched: why,
                     citations,
                     primary_hit,
@@ -321,6 +324,7 @@ fn analyze_record(
         );
         return MatchAnalysis {
             score: 1.0,
+            matched_term_count: 0,
             why_matched: why,
             citations,
             primary_hit: None,
@@ -328,15 +332,23 @@ fn analyze_record(
     }
 
     let mut primary_hit = None;
-    let mut primary_weight = f32::MIN;
+    let mut primary_match = (0_usize, f32::MIN);
+    let mut matched_terms = BTreeSet::new();
     for section in search_sections(record, context, filters) {
         if hit_matches_excluded_provider_session(&section.hit, filters) {
             continue;
         }
-        if matches_terms(&section.text, terms) {
-            score += section.weight;
-            if section.weight > primary_weight {
-                primary_weight = section.weight;
+        let section_match_count = matching_term_count(&section.text, terms);
+        if section_match_count > 0 {
+            let haystack = section.text.to_lowercase();
+            for (index, term) in terms.iter().enumerate() {
+                if haystack.contains(term) {
+                    matched_terms.insert(index);
+                }
+            }
+            score += section.weight * section_match_count as f32;
+            if (section_match_count, section.weight) > primary_match {
+                primary_match = (section_match_count, section.weight);
                 primary_hit = Some(section.hit.clone());
             }
             add_match(
@@ -351,6 +363,7 @@ fn analyze_record(
 
     MatchAnalysis {
         score,
+        matched_term_count: matched_terms.len(),
         why_matched: why,
         citations,
         primary_hit,
@@ -654,6 +667,14 @@ pub(crate) fn search_sections(
 }
 
 pub(crate) fn normalize_scores(candidates: &mut [Candidate]) {
+    let max_relevance_score = candidates
+        .iter()
+        .map(|candidate| candidate.score)
+        .fold(0.0_f32, f32::max);
+    let coverage_stride = max_relevance_score + 1.0;
+    for candidate in candidates.iter_mut() {
+        candidate.score += candidate.matched_term_count as f32 * coverage_stride;
+    }
     let max_score = candidates
         .iter()
         .map(|candidate| candidate.score)

--- a/crates/ctx-history-search/src/snippets.rs
+++ b/crates/ctx-history-search/src/snippets.rs
@@ -112,12 +112,12 @@ pub(crate) fn non_blank(value: &str) -> Option<String> {
     }
 }
 
-pub(crate) fn matches_terms(value: &str, terms: &[String]) -> bool {
-    if terms.is_empty() {
-        return false;
-    }
+pub(crate) fn matching_term_count(value: &str, terms: &[String]) -> usize {
     let haystack = value.to_lowercase();
-    terms.iter().all(|term| haystack.contains(term))
+    terms
+        .iter()
+        .filter(|term| haystack.contains(term.as_str()))
+        .count()
 }
 
 pub(crate) fn search_snippet(
@@ -128,13 +128,20 @@ pub(crate) fn search_snippet(
     filters: &SearchFilters,
 ) -> String {
     let terms = query_terms(query);
+    let mut best_section = None;
+    let mut best_match_count = 0;
     for section in search_sections(record, context, filters) {
         if hit_matches_excluded_provider_session(&section.hit, filters) {
             continue;
         }
-        if matches_terms(&section.text, &terms) {
-            return matched_snippet(&section.text, &terms, max_chars);
+        let match_count = matching_term_count(&section.text, &terms);
+        if match_count > best_match_count {
+            best_match_count = match_count;
+            best_section = Some(section);
         }
+    }
+    if let Some(section) = best_section {
+        return matched_snippet(&section.text, &terms, max_chars);
     }
     if !record.body.trim().is_empty()
         && !is_agent_history_bookkeeping_record(record)

--- a/crates/ctx-history-search/src/tests/fast_path.rs
+++ b/crates/ctx-history-search/src/tests/fast_path.rs
@@ -219,7 +219,7 @@ fn large_agent_history_search_returns_event_hits() {
             Uuid::from_bytes(bytes)
         };
         let text = if event_id == target_event_id {
-            "large-fast-event-needle from one transcript"
+            "large-fast-event-needle ordinary result from one transcript"
         } else {
             "ordinary large history event"
         };
@@ -248,16 +248,20 @@ fn large_agent_history_search_returns_event_hits() {
 
     let packet = search_packet(
         &store,
-        "large-fast-event-needle",
+        "large-fast-event-needle ordinary",
         &PacketOptions {
             limit: 5,
             snippet_chars: 200,
+            filters: SearchFilters {
+                repo: Some("ctx".into()),
+                ..SearchFilters::default()
+            },
             ..PacketOptions::default()
         },
     )
     .unwrap();
 
-    assert_eq!(packet.results.len(), 1);
+    assert_eq!(packet.results.len(), 2);
     let result = &packet.results[0];
     assert_eq!(result.result_scope, SearchResultScope::Session);
     assert_eq!(result.record_id, target_event_id);
@@ -266,7 +270,7 @@ fn large_agent_history_search_returns_event_hits() {
     assert_eq!(result.provider, Some(CaptureProvider::Codex));
     assert_eq!(
         result.snippet,
-        "large-fast-event-needle from one transcript"
+        "large-fast-event-needle ordinary result from one transcript"
     );
     assert_eq!(result.why_matched, vec!["message"]);
     assert!(result.citations.iter().any(|citation| {
@@ -277,7 +281,7 @@ fn large_agent_history_search_returns_event_hits() {
 
     let event_packet = search_packet(
         &store,
-        "large-fast-event-needle",
+        "large-fast-event-needle ordinary",
         &PacketOptions {
             limit: 5,
             snippet_chars: 200,
@@ -286,7 +290,7 @@ fn large_agent_history_search_returns_event_hits() {
         },
     )
     .unwrap();
-    assert_eq!(event_packet.results.len(), 1);
+    assert_eq!(event_packet.results.len(), 5);
     assert_eq!(
         event_packet.results[0].result_scope,
         SearchResultScope::Event

--- a/crates/ctx-history-search/src/tests/ranking.rs
+++ b/crates/ctx-history-search/src/tests/ranking.rs
@@ -176,9 +176,14 @@ fn filtered_search_scores_full_fetched_page_before_limiting() {
 }
 
 #[test]
-fn search_packet_terms_merges_broad_queries_without_requiring_all_terms() {
+fn ordinary_multi_word_search_returns_partial_matches_with_full_coverage_first() {
     let (_temp, store) = test_store();
     for (id, title, body) in [
+        (
+            "018f45d0-0000-7000-8000-000000020000",
+            "Signed metadata Buildkite release",
+            "signed metadata verification in the buildkite release pipeline",
+        ),
         (
             "018f45d0-0000-7000-8000-000000020001",
             "Signed metadata release",
@@ -202,8 +207,33 @@ fn search_packet_terms_merges_broad_queries_without_requiring_all_terms() {
         ..PacketOptions::default()
     };
 
-    let exact = search_packet(&store, "signed metadata buildkite", &options).unwrap();
-    assert_eq!(exact.results.len(), 0);
+    let ordinary = search_packet(&store, "signed metadata buildkite", &options).unwrap();
+    let ordinary_titles = ordinary
+        .results
+        .iter()
+        .map(|result| result.title.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ordinary_titles.first().map(String::as_str),
+        Some("Signed metadata Buildkite release")
+    );
+    assert!(ordinary_titles
+        .iter()
+        .any(|title| title == "Signed metadata release"));
+    assert!(ordinary_titles
+        .iter()
+        .any(|title| title == "Buildkite worker setup"));
+    let duplicate_titles = search_packet(
+        &store,
+        "signed SIGNED metadata buildkite BUILDKITE",
+        &options,
+    )
+    .unwrap()
+    .results
+    .into_iter()
+    .map(|result| result.title)
+    .collect::<Vec<_>>();
+    assert_eq!(duplicate_titles, ordinary_titles);
 
     let broad = search_packet_terms(
         &store,

--- a/crates/ctx-history-store/src/records.rs
+++ b/crates/ctx-history-store/src/records.rs
@@ -1,5 +1,5 @@
 use ctx_history_core::{EntityTimestamps, HistoryRecord, HistoryRecordLink};
-use rusqlite::{params, OptionalExtension};
+use rusqlite::{params, params_from_iter, types::Value, OptionalExtension};
 use uuid::Uuid;
 
 use crate::connection::{
@@ -7,10 +7,12 @@ use crate::connection::{
     parse_text_enum, parse_time, parse_uuid, timestamp_ms,
 };
 use crate::schema::ddl::table_exists;
-use crate::search::analyzer::scriptgram_match_query;
+use crate::search::analyzer::{
+    lexical_query_terms, scriptgram_match_clauses, scriptgram_match_query,
+};
 use crate::search::projections::{
-    event_scriptgram_table_ready, fts_match_query, record_scriptgram_table_ready,
-    upsert_record_search_projection,
+    event_scriptgram_table_ready, fts_match_clauses, fts_match_query,
+    record_scriptgram_table_ready, upsert_record_search_projection,
 };
 use crate::sync::sync_metadata_from_row;
 use crate::{Result, Store, StoreError};
@@ -240,14 +242,34 @@ impl Store {
         if let Some(records) = self.search_records_fts(query, limit, offset)? {
             return Ok(records);
         }
-        let like = format!("%{query}%");
-        let mut stmt = self.conn.prepare(
-                record_select_sql(
-                    "WHERE title LIKE ?1 OR body LIKE ?1 OR tags_json LIKE ?1 ORDER BY created_at DESC, id LIMIT ?2 OFFSET ?3",
-                )
-                .as_str(),
-            )?;
-        let rows = stmt.query_map(params![like, limit as i64, offset as i64], record_from_row)?;
+        let terms = lexical_query_terms(query);
+        if terms.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut values = terms
+            .iter()
+            .map(|term| Value::Text(format!("%{term}%")))
+            .collect::<Vec<_>>();
+        let predicates = (1..=terms.len())
+            .map(|index| {
+                format!("title LIKE ?{index} OR body LIKE ?{index} OR tags_json LIKE ?{index}")
+            })
+            .collect::<Vec<_>>();
+        let coverage = predicates
+            .iter()
+            .map(|predicate| format!("CASE WHEN {predicate} THEN 1 ELSE 0 END"))
+            .collect::<Vec<_>>()
+            .join(" + ");
+        values.push(Value::Integer(limit as i64));
+        let limit_parameter = values.len();
+        values.push(Value::Integer(offset as i64));
+        let offset_parameter = values.len();
+        let tail = format!(
+            "WHERE ({}) ORDER BY ({coverage}) DESC, created_at DESC, id LIMIT ?{limit_parameter} OFFSET ?{offset_parameter}",
+            predicates.join(") OR (")
+        );
+        let mut stmt = self.conn.prepare(&record_select_sql(&tail))?;
+        let rows = stmt.query_map(params_from_iter(values), record_from_row)?;
         collect_rows(rows)
     }
 
@@ -260,194 +282,76 @@ impl Store {
         if !table_exists(&self.conn, "ctx_history_search")? {
             return Ok(None);
         }
-        let match_query = fts_match_query(query);
+        let match_clauses = fts_match_clauses(query);
         let has_event_search = table_exists(&self.conn, "event_search")?;
         let has_artifact_search = table_exists(&self.conn, "artifact_search")?;
         let has_record_scriptgram = record_scriptgram_table_ready(&self.conn)?;
         let has_event_scriptgram = event_scriptgram_table_ready(&self.conn)?;
-        let scriptgram_query = if has_record_scriptgram || has_event_scriptgram {
-            scriptgram_match_query(query)
+        let scriptgram_clauses = if has_record_scriptgram || has_event_scriptgram {
+            scriptgram_match_clauses(query)
         } else {
-            None
+            Vec::new()
         };
-        match (match_query, scriptgram_query) {
-            (Some(match_query), Some(scriptgram_query)) => {
-                let mut selects = vec![r#"
-                    SELECT record_id, bm25(ctx_history_search)
-                    FROM ctx_history_search
-                    WHERE ctx_history_search MATCH ?1
-                    "#
-                .to_owned()];
-                if has_event_search && has_artifact_search {
-                    selects.push(
-                        r#"
-                        SELECT history_record_id, bm25(event_search)
-                        FROM event_search
-                        WHERE event_search MATCH ?1 AND history_record_id IS NOT NULL
-                        "#
-                        .to_owned(),
-                    );
-                    selects.push(
-                        r#"
-                        SELECT history_record_id, bm25(artifact_search)
-                        FROM artifact_search
-                        WHERE artifact_search MATCH ?1 AND history_record_id IS NOT NULL
-                        "#
-                        .to_owned(),
-                    );
-                }
-                if has_record_scriptgram {
-                    selects.push(
-                        r#"
-                        SELECT record_id, bm25(ctx_history_search_scriptgram) + 0.35
-                        FROM ctx_history_search_scriptgram
-                        WHERE ctx_history_search_scriptgram MATCH ?2
-                        "#
-                        .to_owned(),
-                    );
-                }
-                if has_event_scriptgram {
-                    selects.push(
-                        r#"
-                        SELECT history_record_id, bm25(event_search_scriptgram) + 0.35
-                        FROM event_search_scriptgram
-                        WHERE event_search_scriptgram MATCH ?2 AND history_record_id IS NOT NULL
-                        "#
-                        .to_owned(),
-                    );
-                }
-                let sql = format!(
-                    r#"
-                    WITH matches(record_id, score) AS (
-                        {}
-                    )
-                    SELECT record_id
-                    FROM matches
-                    WHERE record_id IS NOT NULL
-                    GROUP BY record_id
-                    ORDER BY MIN(score), record_id
-                    LIMIT ?3 OFFSET ?4
-                    "#,
-                    selects.join(" UNION ALL ")
-                );
-                let mut stmt = self.conn.prepare(&sql)?;
-                let rows = stmt.query_map(
-                    params![match_query, scriptgram_query, limit as i64, offset as i64],
-                    |row| row.get::<_, String>(0),
-                )?;
-                let mut records = Vec::new();
-                for row in rows {
-                    records.push(self.get_record(parse_uuid(row?)?)?);
-                }
-                Ok(Some(records))
-            }
-            (Some(match_query), None) => {
-                let records = if has_event_search && has_artifact_search {
-                    r#"
-                    WITH matches(record_id, score) AS (
-                        SELECT record_id, bm25(ctx_history_search)
-                        FROM ctx_history_search
-                        WHERE ctx_history_search MATCH ?1
-                        UNION ALL
-                        SELECT history_record_id, bm25(event_search)
-                        FROM event_search
-                        WHERE event_search MATCH ?1 AND history_record_id IS NOT NULL
-                        UNION ALL
-                        SELECT history_record_id, bm25(artifact_search)
-                        FROM artifact_search
-                        WHERE artifact_search MATCH ?1 AND history_record_id IS NOT NULL
-                    )
-                    SELECT record_id
-                    FROM matches
-                    WHERE record_id IS NOT NULL
-                    GROUP BY record_id
-                    ORDER BY MIN(score), record_id
-                    LIMIT ?2 OFFSET ?3
-                    "#
-                } else {
-                    r#"
-                    SELECT record_id
-                    FROM ctx_history_search
-                    WHERE ctx_history_search MATCH ?1
-                    ORDER BY bm25(ctx_history_search), record_id
-                    LIMIT ?2 OFFSET ?3
-                    "#
-                };
-                let mut stmt = self.conn.prepare(records)?;
-                let rows = stmt
-                    .query_map(params![match_query, limit as i64, offset as i64], |row| {
-                        row.get::<_, String>(0)
-                    })?;
-                let mut records = Vec::new();
-                for row in rows {
-                    records.push(self.get_record(parse_uuid(row?)?)?);
-                }
-                Ok(Some(records))
-            }
-            (None, Some(_)) => self.search_records_scriptgram(query, limit, offset),
-            (None, None) => Ok(Some(Vec::new())),
+        if match_clauses.is_empty() && scriptgram_clauses.is_empty() {
+            return Ok(Some(Vec::new()));
         }
-    }
 
-    fn search_records_scriptgram(
-        &self,
-        query: &str,
-        limit: usize,
-        offset: usize,
-    ) -> Result<Option<Vec<HistoryRecord>>> {
-        let has_record_scriptgram = record_scriptgram_table_ready(&self.conn)?;
-        let has_event_scriptgram = event_scriptgram_table_ready(&self.conn)?;
-        if !has_record_scriptgram && !has_event_scriptgram {
-            return Ok(Some(Vec::new()));
+        let mut selects = Vec::new();
+        let mut values = Vec::<Value>::new();
+        for (term_index, clause) in match_clauses.into_iter().enumerate() {
+            values.push(Value::Text(clause));
+            let parameter = values.len();
+            selects.push(format!(
+                "SELECT record_id, {term_index}, bm25(ctx_history_search) FROM ctx_history_search WHERE ctx_history_search MATCH ?{parameter}"
+            ));
+            if has_event_search && has_artifact_search {
+                selects.push(format!(
+                    "SELECT history_record_id, {term_index}, bm25(event_search) FROM event_search WHERE event_search MATCH ?{parameter} AND history_record_id IS NOT NULL"
+                ));
+                selects.push(format!(
+                    "SELECT history_record_id, {term_index}, bm25(artifact_search) FROM artifact_search WHERE artifact_search MATCH ?{parameter} AND history_record_id IS NOT NULL"
+                ));
+            }
         }
-        let Some(match_query) = scriptgram_match_query(query) else {
-            return Ok(Some(Vec::new()));
-        };
-        let sql = match (has_record_scriptgram, has_event_scriptgram) {
-            (true, true) => {
-                r#"
-                WITH matches(record_id, score) AS (
-                    SELECT record_id, bm25(ctx_history_search_scriptgram) + 0.35
-                    FROM ctx_history_search_scriptgram
-                    WHERE ctx_history_search_scriptgram MATCH ?1
-                    UNION ALL
-                    SELECT history_record_id, bm25(event_search_scriptgram) + 0.35
-                    FROM event_search_scriptgram
-                    WHERE event_search_scriptgram MATCH ?1 AND history_record_id IS NOT NULL
-                )
-                SELECT record_id
+        for (term_index, clause) in scriptgram_clauses {
+            values.push(Value::Text(clause));
+            let parameter = values.len();
+            if has_record_scriptgram {
+                selects.push(format!(
+                    "SELECT record_id, {term_index}, bm25(ctx_history_search_scriptgram) + 0.35 FROM ctx_history_search_scriptgram WHERE ctx_history_search_scriptgram MATCH ?{parameter}"
+                ));
+            }
+            if has_event_scriptgram {
+                selects.push(format!(
+                    "SELECT history_record_id, {term_index}, bm25(event_search_scriptgram) + 0.35 FROM event_search_scriptgram WHERE event_search_scriptgram MATCH ?{parameter} AND history_record_id IS NOT NULL"
+                ));
+            }
+        }
+        values.push(Value::Integer(limit as i64));
+        let limit_parameter = values.len();
+        values.push(Value::Integer(offset as i64));
+        let offset_parameter = values.len();
+        let sql = format!(
+            r#"
+            WITH matches(record_id, term_index, score) AS MATERIALIZED (
+                {}
+            ),
+            term_matches(record_id, term_index, score) AS (
+                SELECT record_id, term_index, MIN(score)
                 FROM matches
                 WHERE record_id IS NOT NULL
-                GROUP BY record_id
-                ORDER BY MIN(score), record_id
-                LIMIT ?2 OFFSET ?3
-                "#
-            }
-            (true, false) => {
-                r#"
-                SELECT record_id
-                FROM ctx_history_search_scriptgram
-                WHERE ctx_history_search_scriptgram MATCH ?1
-                ORDER BY bm25(ctx_history_search_scriptgram), record_id
-                LIMIT ?2 OFFSET ?3
-                "#
-            }
-            (false, true) => {
-                r#"
-                SELECT history_record_id
-                FROM event_search_scriptgram
-                WHERE event_search_scriptgram MATCH ?1 AND history_record_id IS NOT NULL
-                GROUP BY history_record_id
-                ORDER BY MIN(bm25(event_search_scriptgram)), history_record_id
-                LIMIT ?2 OFFSET ?3
-                "#
-            }
-            (false, false) => unreachable!("scriptgram tables checked above"),
-        };
-        let mut stmt = self.conn.prepare(sql)?;
-        let rows = stmt.query_map(params![match_query, limit as i64, offset as i64], |row| {
-            row.get::<_, String>(0)
-        })?;
+                GROUP BY record_id, term_index
+            )
+            SELECT record_id
+            FROM term_matches
+            GROUP BY record_id
+            ORDER BY COUNT(*) DESC, SUM(score), record_id
+            LIMIT ?{limit_parameter} OFFSET ?{offset_parameter}
+            "#,
+            selects.join(" UNION ALL ")
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(values), |row| row.get::<_, String>(0))?;
         let mut records = Vec::new();
         for row in rows {
             records.push(self.get_record(parse_uuid(row?)?)?);

--- a/crates/ctx-history-store/src/search/analyzer.rs
+++ b/crates/ctx-history-store/src/search/analyzer.rs
@@ -6,18 +6,46 @@ pub(crate) fn scriptgram_index_text(text: &str) -> String {
 }
 
 pub(crate) fn scriptgram_match_query(query: &str) -> Option<String> {
-    if !contains_grammed_script(query) {
-        return None;
-    }
-    let clauses = query
-        .split_whitespace()
-        .filter_map(query_term_clause)
-        .collect::<Vec<_>>();
+    let clauses = scriptgram_match_clauses(query);
     if clauses.is_empty() {
         None
     } else {
-        Some(clauses.join(" AND "))
+        Some(
+            clauses
+                .into_iter()
+                .map(|(_, clause)| clause)
+                .collect::<Vec<_>>()
+                .join(" OR "),
+        )
     }
+}
+
+pub(crate) fn scriptgram_match_clauses(query: &str) -> Vec<(usize, String)> {
+    if !contains_grammed_script(query) {
+        return Vec::new();
+    }
+    lexical_query_terms(query)
+        .into_iter()
+        .enumerate()
+        .filter_map(|(term_index, term)| query_term_clause(term).map(|clause| (term_index, clause)))
+        .collect()
+}
+
+pub(crate) fn lexical_query_terms(query: &str) -> Vec<&str> {
+    let mut seen = Vec::<String>::new();
+    let mut terms = Vec::new();
+    for term in query.split_whitespace().map(trim_fts_term) {
+        if !term.chars().any(char::is_alphanumeric) {
+            continue;
+        }
+        let normalized = term.to_lowercase();
+        if seen.iter().any(|existing| existing == &normalized) {
+            continue;
+        }
+        seen.push(normalized);
+        terms.push(term);
+    }
+    terms
 }
 
 fn query_term_clause(term: &str) -> Option<String> {
@@ -777,7 +805,7 @@ mod tests {
         }
         assert_eq!(
             scriptgram_match_query("状態 管理"),
-            Some("\"状態\" AND \"管理\"".to_owned())
+            Some("\"状態\" OR \"管理\"".to_owned())
         );
         assert_eq!(
             scriptgram_match_query("状態管理"),
@@ -811,6 +839,18 @@ mod tests {
         assert_eq!(
             scriptgram_match_query("API/parser認証"),
             Some("\"API\" AND \"parser\" AND \"認証\"".to_owned())
+        );
+    }
+
+    #[test]
+    fn logical_query_terms_are_deduplicated_and_keep_scriptgram_indexes() {
+        assert_eq!(
+            lexical_query_terms("OAuth oauth 認証 OAUTH"),
+            vec!["OAuth", "認証"]
+        );
+        assert_eq!(
+            scriptgram_match_clauses("OAuth oauth 認証 OAUTH"),
+            vec![(0, "\"OAuth\"".to_owned()), (1, "\"認証\"".to_owned())]
         );
     }
 

--- a/crates/ctx-history-store/src/search/projections.rs
+++ b/crates/ctx-history-store/src/search/projections.rs
@@ -5,7 +5,7 @@ use ctx_history_core::{
     utc_now, AgentType, CaptureProvider, Event, EventRole, EventType, HistoryRecord,
     RedactionState, SyncState, Visibility,
 };
-use rusqlite::{params, params_from_iter, Connection, OptionalExtension};
+use rusqlite::{params, params_from_iter, types::Value, Connection, OptionalExtension};
 use uuid::Uuid;
 
 use crate::connection::{
@@ -14,7 +14,9 @@ use crate::connection::{
 };
 use crate::records::{record_from_row, record_select_sql};
 use crate::schema::ddl::{table_exists, table_has_column};
-use crate::search::analyzer::{scriptgram_index_text, scriptgram_match_query};
+use crate::search::analyzer::{
+    lexical_query_terms, scriptgram_index_text, scriptgram_match_clauses,
+};
 use crate::{Result, Store};
 
 const SEMANTIC_SEARCHABLE_ITEMS_STAT_KEY: &str = "semantic_searchable_lite_turn_items_v2";
@@ -129,88 +131,69 @@ impl Store {
         if !table_exists(&self.conn, "event_search")? {
             return Ok(Vec::new());
         }
-        let match_query = fts_match_query(query);
-        let scriptgram_query = if event_scriptgram_table_ready(&self.conn)? {
-            scriptgram_match_query(query)
+        let match_clauses = fts_match_clauses(query);
+        let scriptgram_clauses = if event_scriptgram_table_ready(&self.conn)? {
+            scriptgram_match_clauses(query)
         } else {
-            None
+            Vec::new()
         };
-        match (match_query, scriptgram_query) {
-            (Some(match_query), Some(scriptgram_query)) => {
-                let sql = format!(
-                    r#"
-                    WITH matches(event_id, score) AS (
-                        SELECT event_search.event_id, bm25(event_search)
-                        FROM event_search
-                        WHERE event_search MATCH ?1
-                        UNION ALL
-                        SELECT event_search_scriptgram.event_id, bm25(event_search_scriptgram) + 0.35
-                        FROM event_search_scriptgram
-                        WHERE event_search_scriptgram MATCH ?2
-                    ),
-                    ranked(event_id, score) AS (
-                        SELECT event_id, MIN(score)
-                        FROM matches
-                        GROUP BY event_id
-                    )
-                    {}
-                    LIMIT ?3 OFFSET ?4
-                    "#,
-                    event_search_hit_sql(
-                        "ranked JOIN event_search ON event_search.event_id = ranked.event_id",
-                        &event_search_score("ranked.score", prefer_conversation),
-                        "ORDER BY search_score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
-                    )
-                );
-                let mut stmt = self.conn.prepare(&sql)?;
-                let rows = stmt.query_map(
-                    params![
-                        match_query,
-                        scriptgram_query,
-                        limit.max(1) as i64,
-                        offset as i64
-                    ],
-                    event_search_hit_from_row,
-                )?;
-                collect_rows(rows)
-            }
-            (Some(match_query), None) => {
-                let sql = format!(
-                    "{} LIMIT ?2 OFFSET ?3",
-                    event_search_hit_sql(
-                        "event_search",
-                        &event_search_score("bm25(event_search)", prefer_conversation),
-                        "WHERE event_search MATCH ?1 ORDER BY search_score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
-                    )
-                );
-                let mut stmt = self.conn.prepare(&sql)?;
-                let rows = stmt.query_map(
-                    params![match_query, limit.max(1) as i64, offset as i64],
-                    event_search_hit_from_row,
-                )?;
-                collect_rows(rows)
-            }
-            (None, Some(scriptgram_query)) => {
-                let sql = format!(
-                    "{} LIMIT ?2 OFFSET ?3",
-                    event_search_hit_sql(
-                        "event_search_scriptgram JOIN event_search ON event_search.event_id = event_search_scriptgram.event_id",
-                        &event_search_score(
-                            "bm25(event_search_scriptgram) + 0.35",
-                            prefer_conversation,
-                        ),
-                        "WHERE event_search_scriptgram MATCH ?1 ORDER BY search_score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
-                    )
-                );
-                let mut stmt = self.conn.prepare(&sql)?;
-                let rows = stmt.query_map(
-                    params![scriptgram_query, limit.max(1) as i64, offset as i64],
-                    event_search_hit_from_row,
-                )?;
-                collect_rows(rows)
-            }
-            (None, None) => Ok(Vec::new()),
+        if match_clauses.is_empty() && scriptgram_clauses.is_empty() {
+            return Ok(Vec::new());
         }
+
+        let mut selects = Vec::new();
+        let mut values = Vec::<Value>::new();
+        for (term_index, clause) in match_clauses.into_iter().enumerate() {
+            values.push(Value::Text(clause));
+            selects.push(format!(
+                r#"SELECT event_search.event_id, {term_index}, bm25(event_search)
+                   FROM event_search
+                   WHERE event_search MATCH ?{}"#,
+                values.len()
+            ));
+        }
+        for (term_index, clause) in scriptgram_clauses {
+            values.push(Value::Text(clause));
+            selects.push(format!(
+                r#"SELECT event_search_scriptgram.event_id, {term_index},
+                          bm25(event_search_scriptgram) + 0.35
+                   FROM event_search_scriptgram
+                   WHERE event_search_scriptgram MATCH ?{}"#,
+                values.len()
+            ));
+        }
+        values.push(Value::Integer(limit.max(1) as i64));
+        let limit_parameter = values.len();
+        values.push(Value::Integer(offset as i64));
+        let offset_parameter = values.len();
+        let sql = format!(
+            r#"
+            WITH matches(event_id, term_index, score) AS MATERIALIZED (
+                {}
+            ),
+            term_matches(event_id, term_index, score) AS (
+                SELECT event_id, term_index, MIN(score)
+                FROM matches
+                GROUP BY event_id, term_index
+            ),
+            ranked(event_id, matched_terms, score) AS (
+                SELECT event_id, COUNT(*), SUM(score)
+                FROM term_matches
+                GROUP BY event_id
+            )
+            {}
+            LIMIT ?{limit_parameter} OFFSET ?{offset_parameter}
+            "#,
+            selects.join(" UNION ALL "),
+            event_search_hit_sql(
+                "ranked JOIN event_search ON event_search.event_id = ranked.event_id",
+                &event_search_score("ranked.score", prefer_conversation),
+                "ORDER BY ranked.matched_terms DESC, search_score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
+            )
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(values), event_search_hit_from_row)?;
+        collect_rows(rows)
     }
 
     pub fn semantic_event_hits_by_id(
@@ -1819,17 +1802,19 @@ fn non_blank(value: &str) -> Option<String> {
 }
 
 pub(crate) fn fts_match_query(query: &str) -> Option<String> {
-    let terms = query
-        .split_whitespace()
-        .map(|term| term.trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_' && ch != '-'))
-        .filter(|term| term.chars().any(char::is_alphanumeric))
-        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
-        .collect::<Vec<_>>();
+    let terms = fts_match_clauses(query);
     if terms.is_empty() {
         None
     } else {
-        Some(terms.join(" AND "))
+        Some(terms.join(" OR "))
     }
+}
+
+pub(crate) fn fts_match_clauses(query: &str) -> Vec<String> {
+    lexical_query_terms(query)
+        .into_iter()
+        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
+        .collect()
 }
 
 fn event_search_cursor(

--- a/crates/ctx-history-store/src/search/tests.rs
+++ b/crates/ctx-history-store/src/search/tests.rs
@@ -201,6 +201,33 @@ fn preferred_event_search_keeps_materially_stronger_tool_evidence_first() {
 }
 
 #[test]
+fn preferred_event_search_keeps_term_coverage_ahead_of_event_type_preference() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let message = policy_event(
+        1,
+        EventType::Message,
+        Some(EventRole::Assistant),
+        serde_json::json!({"text": "coverage-alpha"}),
+    );
+    let tool = policy_event(
+        2,
+        EventType::ToolCall,
+        Some(EventRole::Assistant),
+        serde_json::json!({"text": "coverage-alpha coverage-beta"}),
+    );
+    store.upsert_event(&message).unwrap();
+    store.upsert_event(&tool).unwrap();
+
+    let hits = store
+        .search_event_hits_page_prefer_conversation("coverage-alpha coverage-beta", 10, 0)
+        .unwrap();
+    assert_eq!(hits.len(), 2);
+    assert_eq!(hits[0].event_id, tool.id);
+    assert_eq!(hits[1].event_id, message.id);
+}
+
+#[test]
 fn indexed_history_item_count_uses_sessions_and_events() {
     let temp = tempdir();
     let store = Store::open(temp.path().join("work.sqlite")).unwrap();
@@ -362,6 +389,76 @@ fn search_records_empty_or_no_token_query_returns_empty() {
 }
 
 #[test]
+fn multi_word_record_search_returns_partial_matches_and_orders_by_term_coverage() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let all_terms = record_with_id(
+        "018f45d0-0000-7000-8000-000000080010",
+        "Complete migration diagnosis",
+        "sqlite rollback checksum",
+    );
+    let sqlite_only = record_with_id(
+        "018f45d0-0000-7000-8000-000000080011",
+        "SQLite diagnosis",
+        "sqlite investigation",
+    );
+    let rollback_only = record_with_id(
+        "018f45d0-0000-7000-8000-000000080012",
+        "Rollback diagnosis",
+        "rollback investigation",
+    );
+    for record in [&sqlite_only, &all_terms, &rollback_only] {
+        store.insert_record(record).unwrap();
+    }
+
+    let first = store
+        .search_records("sqlite rollback checksum", 10)
+        .unwrap();
+    let second = store
+        .search_records("sqlite rollback checksum", 10)
+        .unwrap();
+    let ids = first.iter().map(|record| record.id).collect::<Vec<_>>();
+
+    assert_eq!(ids.first(), Some(&all_terms.id));
+    assert!(ids.contains(&sqlite_only.id));
+    assert!(ids.contains(&rollback_only.id));
+    assert_eq!(first, second, "multi-word ordering must be deterministic");
+    assert_eq!(
+        first,
+        store
+            .search_records("sqlite SQLITE rollback ROLLBACK checksum", 10)
+            .unwrap(),
+        "duplicate query words must not change coverage or ordering"
+    );
+}
+
+#[test]
+fn multi_word_record_search_fallback_uses_the_same_or_semantics() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let all_terms = record_with_id(
+        "018f45d0-0000-7000-8000-000000080013",
+        "Complete fallback match",
+        "sqlite rollback",
+    );
+    let partial = record_with_id(
+        "018f45d0-0000-7000-8000-000000080014",
+        "Partial fallback match",
+        "sqlite only",
+    );
+    store.insert_record(&partial).unwrap();
+    store.insert_record(&all_terms).unwrap();
+    store
+        .conn
+        .execute_batch("DROP TABLE ctx_history_search")
+        .unwrap();
+
+    let hits = store.search_records("sqlite rollback", 10).unwrap();
+    let ids = hits.iter().map(|record| record.id).collect::<Vec<_>>();
+    assert_eq!(ids, vec![all_terms.id, partial.id]);
+}
+
+#[test]
 fn search_records_still_matches_latin_code_tokens() {
     let temp = tempdir();
     let store = Store::open(temp.path().join("work.sqlite")).unwrap();
@@ -484,6 +581,56 @@ fn event_search_preserves_local_payload_text() {
 
     let hits = store.search_event_hits("rawmarker", 10).unwrap();
     assert!(hits.iter().any(|hit| hit.event_id == raw_event.id));
+}
+
+#[test]
+fn multi_word_event_search_returns_partial_matches_and_orders_by_term_coverage() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let all_terms = local_preview_event(1, "sqlite rollback checksum");
+    let sqlite_only = local_preview_event(2, "sqlite investigation");
+    let rollback_only = local_preview_event(3, "rollback investigation");
+    for event in [&sqlite_only, &all_terms, &rollback_only] {
+        store.upsert_event(event).unwrap();
+    }
+
+    let first = store
+        .search_event_hits("sqlite rollback checksum", 10)
+        .unwrap();
+    let second = store
+        .search_event_hits("sqlite rollback checksum", 10)
+        .unwrap();
+    let ids = first.iter().map(|hit| hit.event_id).collect::<Vec<_>>();
+
+    assert_eq!(ids.first(), Some(&all_terms.id));
+    assert!(ids.contains(&sqlite_only.id));
+    assert!(ids.contains(&rollback_only.id));
+    assert_eq!(first, second, "multi-word ordering must be deterministic");
+    assert_eq!(
+        first,
+        store
+            .search_event_hits("sqlite SQLITE rollback ROLLBACK checksum", 10)
+            .unwrap(),
+        "duplicate query words must not change coverage or ordering"
+    );
+}
+
+#[test]
+fn mixed_script_event_search_keeps_logical_term_coverage_aligned() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let all_terms = local_preview_event(1, "OAuth認証を修正しました");
+    let oauth_only = local_preview_event(2, "OAuth integration notes");
+    let auth_only = local_preview_event(3, "認証を確認しました");
+    for event in [&oauth_only, &auth_only, &all_terms] {
+        store.upsert_event(event).unwrap();
+    }
+
+    let hits = store.search_event_hits("OAuth 認証", 10).unwrap();
+    let ids = hits.iter().map(|hit| hit.event_id).collect::<Vec<_>>();
+    assert_eq!(ids.first(), Some(&all_terms.id));
+    assert!(ids.contains(&oauth_only.id));
+    assert!(ids.contains(&auth_only.id));
 }
 
 #[test]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -397,9 +397,11 @@ that session also matched. Use `--session <ctx-session-id>` after a default
 search has identified a session to inspect; scoped session search returns dense
 event hits. Session/event commands accept full ctx IDs or unambiguous ctx ID
 prefixes of at least eight hex characters. Use `--events` without `--session`
-for dense event-level results across sessions. Repeat
+for dense event-level results across sessions. Lexical search matches any word
+in an ordinary multi-word query and ranks results matching more query words
+ahead of partial matches. Repeat
 `--term <query-or-keyword>` when you want to broaden a search across several
-related words or phrases and merge the ranked results; `--term` is OR-style
+related queries or keywords and merge the ranked results; `--term` is OR-style
 broadening, not a must-include filter.
 Custom history imports can be filtered by `--history-source` using
 `plugin/source` or `provider_key/source_id`, or by exact `--provider-key`,
@@ -441,7 +443,7 @@ Filters:
 - `--file <path>`, indexed touched-file path metadata, not the current
   filesystem;
 - `--session <ctx-session-id-or-prefix>`, for dense event results within one session;
-- `--term <query-or-keyword>`, repeatable broadening terms merged with OR-style semantics;
+- `--term <query-or-keyword>`, repeatable broadening queries or keywords merged with OR-style semantics;
 - `--events`, for dense event-level results instead of the default session-diverse results;
 - `--backend hybrid|semantic|lexical`, where `hybrid` blends lexical and
   semantic evidence only when existing sidecar coverage is complete and dirty

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,6 +139,10 @@ ctx show event <ctx-event-id> --window 3
 ctx show session <ctx-session-id>
 ```
 
+Lexical search treats words in a multi-word query as alternatives and ranks
+results matching more of those words ahead of partial matches. Repeated
+`--term` values merge additional queries or keywords into the same result set.
+
 Use `ctx_event_id` with `ctx show event` when you need a hit plus surrounding
 events. Use `ctx_session_id` with `ctx show session` when you need the
 transcript. Commands accept full ctx IDs or unambiguous ID prefixes of at least


### PR DESCRIPTION
## Summary
- make ordinary multi-word lexical queries return matches for any logical term
- rank by distinct matched-term coverage before BM25 and conversational event preference
- keep record fallback scoring, snippets, filters, session diversity, repeated --term behavior, and mixed-script search consistent
- document the OR default and add deterministic, duplicate-term, mixed-script, fallback, filtered, and large-corpus regressions

## Validation
- cargo fmt --all -- --check
- cargo test -p ctx-history-store --no-fail-fast (96 passed)
- cargo test -p ctx-history-search --no-fail-fast (28 passed, 1 ignored manual perf benchmark)
- cargo clippy -p ctx-history-store -p ctx-history-search --all-targets -- -D warnings
- git diff --check

## Ranking interaction
Term coverage is the primary ordering key. Within an equal-coverage bucket, the existing 15% soft preference for message/summary events remains active for ordinary fast and hybrid searches. Explicit event-type searches remain neutral.