### PR TITLE
Add opt-in cross-platform semantic daemon

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,6 +43,21 @@ steps:
     if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1"
     command: |
       scripts/build-public-cli-artifact.sh linux-x64
+      scripts/build-onnxruntime-sidecar.sh linux-x64
+      scripts/stage-github-release-assets.sh --transcode-runtime linux-x64
+      if [[ "${CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX:-0}" == "1" ]]; then
+        smoke_root="target/public-cli-native-smoke/linux-x64"
+        mkdir -p "${smoke_root}"
+        scripts/smoke-daemon-semantic-release.sh \
+          --runtime-archive target/public-cli-artifacts/ctx-onnxruntime-linux-x64.tar.gz \
+          --runtime-platform linux-x64 \
+          --ctx target/public-cli-artifacts/ctx \
+          --data-root "${smoke_root}" \
+          --proof-output target/public-cli-artifacts/ctx-linux-x64.native-runtime-proof.txt \
+          --keep-root >"${smoke_root}/smoke.log" 2>&1
+        grep -Fxq 'runtime_authority=authoritative' \
+          target/public-cli-artifacts/ctx-linux-x64.native-runtime-proof.txt
+      fi
     agents:
       queue: "release-linux-managed"
       ctx-runner-class: "release-linux-control"
@@ -54,12 +69,34 @@ steps:
       - "target/public-cli-artifacts/ctx.sha256"
       - "target/public-cli-artifacts/ctx.version"
       - "target/public-cli-artifacts/ctx.build-info.json"
+      - "target/public-cli-artifacts/ctx-onnxruntime-linux-x64.tar.gz"
+      - "target/public-cli-artifacts/ctx-onnxruntime-linux-x64.tar.gz.sha256"
+      - "target/public-cli-artifacts/ctx-linux-x64.native-runtime-proof.txt"
+      - "target/public-cli-native-smoke/linux-x64/smoke.log"
+      - "target/public-cli-native-smoke/linux-x64/**/daemon-smoke.log"
+      - "target/public-cli-native-smoke/linux-x64/**/daemon-status.*"
+      - "target/public-cli-native-smoke/linux-x64/**/semantic-search.*"
 
   - label: ":package: public CLI linux-aarch64"
     key: "public-cli-linux-aarch64"
     if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1"
     command: |
       scripts/build-public-cli-artifact.sh linux-aarch64
+      scripts/build-onnxruntime-sidecar.sh linux-aarch64
+      scripts/stage-github-release-assets.sh --transcode-runtime linux-aarch64
+      if [[ "${CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX:-0}" == "1" ]]; then
+        smoke_root="target/public-cli-native-smoke/linux-aarch64"
+        mkdir -p "${smoke_root}"
+        scripts/smoke-daemon-semantic-release.sh \
+          --runtime-archive target/public-cli-artifacts/ctx-onnxruntime-linux-aarch64.tar.gz \
+          --runtime-platform linux-aarch64 \
+          --ctx target/public-cli-artifacts/ctx-linux-aarch64 \
+          --data-root "${smoke_root}" \
+          --proof-output target/public-cli-artifacts/ctx-linux-aarch64.native-runtime-proof.txt \
+          --keep-root >"${smoke_root}/smoke.log" 2>&1
+        grep -Fxq 'runtime_authority=authoritative' \
+          target/public-cli-artifacts/ctx-linux-aarch64.native-runtime-proof.txt
+      fi
     agents:
       queue: "release-linux-managed"
       ctx-runner-class: "release-linux-control"
@@ -71,12 +108,20 @@ steps:
       - "target/public-cli-artifacts/ctx-linux-aarch64.sha256"
       - "target/public-cli-artifacts/ctx-linux-aarch64.version"
       - "target/public-cli-artifacts/ctx-linux-aarch64.build-info.json"
+      - "target/public-cli-artifacts/ctx-onnxruntime-linux-aarch64.tar.gz"
+      - "target/public-cli-artifacts/ctx-onnxruntime-linux-aarch64.tar.gz.sha256"
+      - "target/public-cli-artifacts/ctx-linux-aarch64.native-runtime-proof.txt"
+      - "target/public-cli-native-smoke/linux-aarch64/smoke.log"
+      - "target/public-cli-native-smoke/linux-aarch64/**/daemon-smoke.log"
+      - "target/public-cli-native-smoke/linux-aarch64/**/daemon-status.*"
+      - "target/public-cli-native-smoke/linux-aarch64/**/semantic-search.*"
 
   - label: ":package: public CLI windows-x64"
     key: "public-cli-windows-x64"
     if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1"
     command: |
       scripts/build-public-cli-artifact.sh windows-x64
+      scripts/build-onnxruntime-sidecar.sh windows-x64
     agents:
       queue: "release-linux-managed"
       ctx-runner-class: "release-linux-control"
@@ -88,6 +133,8 @@ steps:
       - "target/public-cli-artifacts/ctx.exe.sha256"
       - "target/public-cli-artifacts/ctx.exe.version"
       - "target/public-cli-artifacts/ctx.exe.build-info.json"
+      - "target/public-cli-artifacts/ctx-onnxruntime-windows-x64.zip"
+      - "target/public-cli-artifacts/ctx-onnxruntime-windows-x64.zip.sha256"
 
   - label: ":package: public CLI freebsd-x64"
     key: "public-cli-freebsd-x64"
@@ -111,31 +158,202 @@ steps:
     if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1"
     command: |
       scripts/build-public-cli-artifact.sh macos-arm64
+      scripts/build-onnxruntime-sidecar.sh macos-arm64
+      scripts/stage-github-release-assets.sh --transcode-runtime macos-arm64
+      if [[ "${CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX:-0}" == "1" ]]; then
+        smoke_root="target/public-cli-native-smoke/macos-arm64/coreml"
+        mkdir -p "${smoke_root}"
+        if ! scripts/smoke-daemon-semantic-release.sh \
+          --coreml \
+          --runtime-platform macos-arm64 \
+          --ctx target/public-cli-artifacts/ctx-macos-arm64 \
+          --data-root "${smoke_root}" \
+          --proof-output target/public-cli-artifacts/ctx-macos-arm64.coreml-runtime-proof.txt \
+          --keep-root >"${smoke_root}/smoke.log" 2>&1; then
+          cat "${smoke_root}/smoke.log"
+          exit 1
+        fi
+        cat "${smoke_root}/smoke.log"
+        proof="$(find "${smoke_root}" -name packaged-runtime-proof.txt -type f -print -quit)"
+        [[ -n "${proof}" ]]
+        grep -Fxq 'runtime_authority=authoritative' "${proof}"
+
+        onnx_smoke_root="target/public-cli-native-smoke/macos-arm64/onnxruntime"
+        mkdir -p "${onnx_smoke_root}"
+        if ! scripts/smoke-daemon-semantic-release.sh \
+          --runtime-archive target/public-cli-artifacts/ctx-onnxruntime-macos-arm64.tar.gz \
+          --runtime-platform macos-arm64 \
+          --ctx target/public-cli-artifacts/ctx-macos-arm64 \
+          --data-root "${onnx_smoke_root}" \
+          --proof-output target/public-cli-artifacts/ctx-macos-arm64.native-runtime-proof.txt \
+          --keep-root >"${onnx_smoke_root}/smoke.log" 2>&1; then
+          cat "${onnx_smoke_root}/smoke.log"
+          exit 1
+        fi
+        cat "${onnx_smoke_root}/smoke.log"
+        grep -Fxq 'runtime_authority=authoritative' \
+          target/public-cli-artifacts/ctx-macos-arm64.native-runtime-proof.txt
+      fi
     agents:
-      queue: "release-linux-managed"
-      ctx-runner-class: "release-linux-control"
-      os: "linux"
-      arch: "x86_64"
+      queue: "mac-shared"
+      os: "darwin"
+      arch: "arm64"
+    concurrency: 1
+    concurrency_group: "ctx-public-cli-macos-native"
     timeout_in_minutes: 60
     artifact_paths:
       - "target/public-cli-artifacts/ctx-macos-arm64"
       - "target/public-cli-artifacts/ctx-macos-arm64.sha256"
       - "target/public-cli-artifacts/ctx-macos-arm64.version"
       - "target/public-cli-artifacts/ctx-macos-arm64.build-info.json"
+      - "target/public-cli-artifacts/ctx-onnxruntime-macos-arm64.tar.gz"
+      - "target/public-cli-artifacts/ctx-onnxruntime-macos-arm64.tar.gz.sha256"
+      - "target/public-cli-artifacts/ctx-macos-arm64.native-runtime-proof.txt"
+      - "target/public-cli-artifacts/ctx-macos-arm64.coreml-runtime-proof.txt"
+      - "target/public-cli-native-smoke/macos-arm64/**/smoke.log"
+      - "target/public-cli-native-smoke/macos-arm64/**/packaged-runtime-proof.txt"
+      - "target/public-cli-native-smoke/macos-arm64/**/daemon-smoke.log"
+      - "target/public-cli-native-smoke/macos-arm64/**/daemon-status.*"
+      - "target/public-cli-native-smoke/macos-arm64/**/semantic-search.*"
 
   - label: ":package: public CLI macos-x64"
     key: "public-cli-macos-x64"
     if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1"
     command: |
       scripts/build-public-cli-artifact.sh macos-x64
+      if [[ "${CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX:-0}" == "1" ]]; then
+        smoke_root="target/public-cli-native-smoke/macos-x64"
+        mkdir -p "${smoke_root}"
+        if ! scripts/smoke-daemon-semantic-release.sh \
+          --coreml \
+          --runtime-platform macos-x64 \
+          --ctx target/public-cli-artifacts/ctx-macos-x64 \
+          --data-root "${smoke_root}" \
+          --keep-root >"${smoke_root}/smoke.log" 2>&1; then
+          cat "${smoke_root}/smoke.log"
+          exit 1
+        fi
+        cat "${smoke_root}/smoke.log"
+        proof="$(find "${smoke_root}" -name packaged-runtime-proof.txt -type f -print -quit)"
+        [[ -n "${proof}" ]]
+        grep -Fxq 'runtime_authority=non_authoritative' "${proof}"
+      fi
     agents:
-      queue: "release-linux-managed"
-      ctx-runner-class: "release-linux-control"
-      os: "linux"
-      arch: "x86_64"
+      queue: "mac-shared"
+      os: "darwin"
+      arch: "arm64"
+    concurrency: 1
+    concurrency_group: "ctx-public-cli-macos-native"
     timeout_in_minutes: 60
     artifact_paths:
       - "target/public-cli-artifacts/ctx-macos-x64"
       - "target/public-cli-artifacts/ctx-macos-x64.sha256"
       - "target/public-cli-artifacts/ctx-macos-x64.version"
       - "target/public-cli-artifacts/ctx-macos-x64.build-info.json"
+      - "target/public-cli-native-smoke/macos-x64/smoke.log"
+      - "target/public-cli-native-smoke/macos-x64/**/packaged-runtime-proof.txt"
+      - "target/public-cli-native-smoke/macos-x64/**/daemon-smoke.log"
+      - "target/public-cli-native-smoke/macos-x64/**/daemon-status.*"
+      - "target/public-cli-native-smoke/macos-x64/**/semantic-search.*"
+
+  - label: ":test_tube: public CLI macos-x64 native semantic"
+    key: "public-cli-macos-x64-native-smoke"
+    depends_on: "public-cli-macos-x64"
+    if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1" && build.env("CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX") == "1"
+    command: |
+      buildkite-agent artifact download \
+        "target/public-cli-artifacts/ctx-macos-x64*" . \
+        --step public-cli-macos-x64
+      scripts/build-onnxruntime-sidecar.sh macos-x64
+      scripts/stage-github-release-assets.sh --transcode-runtime macos-x64
+      smoke_root="target/public-cli-native-smoke/macos-x64-native"
+      mkdir -p "${smoke_root}"
+      if ! scripts/smoke-daemon-semantic-release.sh \
+        --runtime-archive target/public-cli-artifacts/ctx-onnxruntime-macos-x64.tar.gz \
+        --runtime-platform macos-x64 \
+        --ctx target/public-cli-artifacts/ctx-macos-x64 \
+        --data-root "${smoke_root}" \
+        --proof-output target/public-cli-artifacts/ctx-macos-x64.native-runtime-proof.txt \
+        --keep-root >"${smoke_root}/smoke.log" 2>&1; then
+        cat "${smoke_root}/smoke.log"
+        exit 1
+      fi
+      cat "${smoke_root}/smoke.log"
+      grep -Fxq 'runtime_authority=authoritative' \
+        target/public-cli-artifacts/ctx-macos-x64.native-runtime-proof.txt
+    agents:
+      queue: "ctx-mac-gui-shared-x64"
+      os: "darwin"
+      arch: "x86_64"
+    concurrency: 1
+    concurrency_group: "ctx-public-cli-macos-intel-native"
+    timeout_in_minutes: 180
+    artifact_paths:
+      - "target/public-cli-artifacts/ctx-onnxruntime-macos-x64.tar.gz"
+      - "target/public-cli-artifacts/ctx-onnxruntime-macos-x64.tar.gz.sha256"
+      - "target/public-cli-artifacts/ctx-macos-x64.native-runtime-proof.txt"
+      - "target/public-cli-native-smoke/macos-x64-native/smoke.log"
+      - "target/public-cli-native-smoke/macos-x64-native/**/daemon-smoke.log"
+      - "target/public-cli-native-smoke/macos-x64-native/**/daemon-status.*"
+      - "target/public-cli-native-smoke/macos-x64-native/**/semantic-search.*"
+
+  - label: ":test_tube: public CLI windows-x64 native semantic"
+    key: "public-cli-windows-x64-native-smoke"
+    depends_on: "public-cli-windows-x64"
+    if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1" && build.env("CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX") == "1"
+    command: |
+      buildkite-agent artifact download "target/public-cli-artifacts/ctx.exe*" . --step public-cli-windows-x64
+      buildkite-agent artifact download "target/public-cli-artifacts/ctx-onnxruntime-windows-x64.zip*" . --step public-cli-windows-x64
+      powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/smoke-daemon-semantic-release.ps1 -Ctx target/public-cli-artifacts/ctx.exe -RuntimeArchive target/public-cli-artifacts/ctx-onnxruntime-windows-x64.zip -RuntimePlatform windows-x64 -DataRoot target/public-cli-native-smoke/windows-x64 -ProofOutput target/public-cli-artifacts/ctx-windows-x64.native-runtime-proof.txt -RequireAuthoritative -KeepRoot
+    agents:
+      queue: "windows-x64"
+      os: "windows"
+      arch: "x86_64"
+    concurrency: 1
+    concurrency_group: "ctx-public-cli-windows-native"
+    timeout_in_minutes: 90
+    artifact_paths:
+      - "target/public-cli-artifacts/ctx-windows-x64.native-runtime-proof.txt"
+      - "target/public-cli-native-smoke/windows-x64/**/packaged-runtime-proof.txt"
+      - "target/public-cli-native-smoke/windows-x64/**/daemon-smoke.log"
+
+  - label: ":test_tube: public CLI freebsd-x64 native semantic"
+    key: "public-cli-freebsd-x64-native-smoke"
+    depends_on: "public-cli-freebsd-x64"
+    if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1" && build.env("CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX") == "1"
+    command: |
+      buildkite-agent artifact download \
+        "target/public-cli-artifacts/ctx-freebsd-x64*" . \
+        --step public-cli-freebsd-x64
+      scripts/build-onnxruntime-sidecar.sh freebsd-x64
+      scripts/stage-github-release-assets.sh --transcode-runtime freebsd-x64
+      smoke_root="target/public-cli-native-smoke/freebsd-x64"
+      mkdir -p "${smoke_root}"
+      if ! scripts/smoke-daemon-semantic-release.sh \
+        --runtime-archive target/public-cli-artifacts/ctx-onnxruntime-freebsd-x64.tar.gz \
+        --runtime-platform freebsd-x64 \
+        --ctx target/public-cli-artifacts/ctx-freebsd-x64 \
+        --data-root "${smoke_root}" \
+        --proof-output target/public-cli-artifacts/ctx-freebsd-x64.native-runtime-proof.txt \
+        --keep-root >"${smoke_root}/smoke.log" 2>&1; then
+        cat "${smoke_root}/smoke.log"
+        exit 1
+      fi
+      cat "${smoke_root}/smoke.log"
+      grep -Fxq 'runtime_authority=authoritative' \
+        target/public-cli-artifacts/ctx-freebsd-x64.native-runtime-proof.txt
+    agents:
+      queue: "freebsd-x64"
+      os: "freebsd"
+      arch: "x86_64"
+    concurrency: 1
+    concurrency_group: "ctx-public-cli-freebsd-native"
+    timeout_in_minutes: 240
+    artifact_paths:
+      - "target/public-cli-artifacts/ctx-onnxruntime-freebsd-x64.tar.gz"
+      - "target/public-cli-artifacts/ctx-onnxruntime-freebsd-x64.tar.gz.sha256"
+      - "target/public-cli-artifacts/ctx-freebsd-x64.native-runtime-proof.txt"
+      - "target/public-cli-native-smoke/freebsd-x64/smoke.log"
+      - "target/public-cli-native-smoke/freebsd-x64/**/daemon-smoke.log"
+      - "target/public-cli-native-smoke/freebsd-x64/**/daemon-status.*"
+      - "target/public-cli-native-smoke/freebsd-x64/**/semantic-search.*"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -28,6 +30,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -101,10 +109,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -143,6 +163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,10 +189,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
-name = "cc"
-version = "1.2.66"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -176,6 +226,23 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -244,10 +311,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "coreml-native"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322ddf1574fe27fb381f4c259f6e87fbb8e5ca7eba4e7dad0aa128274b95cb9f"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-core-ml",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -260,6 +404,31 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -277,16 +446,22 @@ version = "0.24.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "clap_mangen",
+ "coreml-native",
  "ctx-history-capture",
  "ctx-history-core",
  "ctx-history-search",
  "ctx-history-store",
+ "fastembed",
+ "flate2",
+ "fs2",
+ "hf-hub",
  "jsonc-parser",
  "libc",
+ "ort",
  "predicates",
  "proptest",
  "ring",
@@ -295,17 +470,22 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "sqlite-vec",
+ "tar",
  "tempfile",
+ "tokenizers",
  "toml_edit",
- "ureq",
+ "ureq 2.12.1",
  "uuid",
+ "windows-sys 0.61.2",
+ "xz2",
 ]
 
 [[package]]
 name = "ctx-history-capture"
 version = "0.24.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "ctx-history-core",
  "ctx-history-store",
@@ -314,7 +494,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "uuid",
  "zstd",
@@ -329,7 +509,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -344,7 +524,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -358,7 +538,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -378,7 +558,88 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -403,7 +664,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -414,8 +684,30 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -428,6 +720,27 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -446,6 +759,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,10 +780,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastembed"
+version = "5.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545e4fb17fc48768ff36c2a3854aa5b0b809d0ed595ab5530fa8ac94f31bd0ea"
+dependencies = [
+ "anyhow",
+ "hf-hub",
+ "ndarray",
+ "ort",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "tokenizers",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -495,6 +843,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,10 +858,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -522,7 +918,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -544,8 +944,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -567,8 +969,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -578,6 +983,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -600,6 +1018,124 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hf-hub"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
+dependencies = [
+ "dirs",
+ "http",
+ "indicatif",
+ "libc",
+ "log",
+ "rand 0.9.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ureq 3.3.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "icu_collections"
@@ -684,6 +1220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,10 +1257,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -764,6 +1334,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,16 +1376,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -818,10 +1453,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -830,6 +1547,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-ml"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201b055e6acfa0f9f15568255d3f03ce2b54bc86d1814442dc69138e36813e18"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-image-io",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-image-io"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -845,10 +1676,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "git+https://github.com/ctxrs/ort.git?rev=7cc21d66952354c3ecc6d1b88c2f27b700850807#7cc21d66952354c3ecc6d1b88c2f27b700850807"
+dependencies = [
+ "libloading",
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "git+https://github.com/ctxrs/ort.git?rev=7cc21d66952354c3ecc6d1b88c2f27b700850807#7cc21d66952354c3ecc6d1b88c2f27b700850807"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -869,6 +1745,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +1767,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -935,7 +1832,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.5",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -949,6 +1846,62 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "quote"
@@ -973,12 +1926,23 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -988,7 +1952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1001,12 +1965,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1017,14 +2033,25 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1034,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1048,6 +2075,47 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots 1.0.8",
+]
 
 [[package]]
 name = "ring"
@@ -1102,6 +2170,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,6 +2209,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1172,6 +2247,19 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
+dependencies = [
+ "hashbrown 0.16.1",
+ "libc",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
 
 [[package]]
 name = "serde"
@@ -1217,6 +2305,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,7 +2336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1265,10 +2365,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = "git+https://github.com/ctxrs/sqlite-vec.git?rev=c1762b6065bccdedf1f68a904096d46f91d3a486#c1762b6065bccdedf1f68a904096d46f91d3a486"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1294,6 +2441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +2458,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -1329,7 +2496,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1344,6 +2520,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +2568,92 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "indicatif",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.5",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1378,6 +2681,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +2767,39 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1413,7 +2819,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
@@ -1421,6 +2827,39 @@ dependencies = [
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -1434,6 +2873,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -1481,6 +2926,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,6 +2960,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1541,6 +3005,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +3054,28 @@ checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -1734,6 +3253,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,18 +3296,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,19 @@ serde_json = "1.0"
 sha2 = "0.10"
 tempfile = "3.10"
 thiserror = "1.0"
+tar = "0.4"
 url = "2.5"
 uuid = { version = "1.10", features = ["serde", "v4", "v7"] }
+xz2 = "0.1"
 zstd = "0.13"
+
+[patch.crates-io]
+# `ort` 2.0.0-rc.12 does not select the default load-dynamic library name on
+# FreeBSD. This fork is exactly rc.12 plus that one-line target cfg fix. Drop
+# the patch once a crates.io release includes the fix.
+ort = { git = "https://github.com/ctxrs/ort.git", rev = "7cc21d66952354c3ecc6d1b88c2f27b700850807" }
+
+# `sqlite-vec` 0.1.9 redeclares stdint types on Unix, which conflicts with the
+# FreeBSD headers. This fork is the stable crate plus the upstream three-typedef
+# removal from asg017/sqlite-vec#219. Drop it once a stable release includes it.
+sqlite-vec = { git = "https://github.com/ctxrs/sqlite-vec.git", rev = "c1762b6065bccdedf1f68a904096d46f91d3a486" }

--- a/crates/ctx-cli/Cargo.toml
+++ b/crates/ctx-cli/Cargo.toml
@@ -37,10 +37,28 @@ ctx-history-search = { path = "../ctx-history-search" }
 ctx-history-store = { path = "../ctx-history-store" }
 
 [target.'cfg(unix)'.dependencies]
+flate2 = "1"
 libc.workspace = true
+tar.workspace = true
 
+[target.'cfg(target_os = "macos")'.dependencies]
+coreml-native = "=0.2.0"
+tokenizers = "0.22.2"
+xz2.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Threading"] }
+
+[target.'cfg(any(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64"), target_env = "gnu"), all(target_os = "macos", any(target_arch = "x86_64", target_arch = "aarch64")), all(target_os = "windows", target_arch = "x86_64"), all(target_os = "freebsd", target_arch = "x86_64")))'.dependencies]
+fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-rustls-tls", "ort-load-dynamic"] }
+fs2 = "0.4.3"
+hf-hub = { version = "0.5.0", default-features = false, features = ["ureq", "rustls-tls"] }
+ort = { version = "=2.0.0-rc.12", default-features = false, features = ["load-dynamic", "ndarray", "std", "api-24"] }
+sqlite-vec = "=0.1.9"
 [dev-dependencies]
 assert_cmd.workspace = true
 predicates.workspace = true
 proptest.workspace = true
+tar.workspace = true
 tempfile.workspace = true
+xz2.workspace = true

--- a/crates/ctx-cli/build.rs
+++ b/crates/ctx-cli/build.rs
@@ -1,8 +1,30 @@
+use std::env;
+
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(ctx_semantic_fastembed)");
     println!("cargo:rustc-check-cfg=cfg(ctx_sqlite_vec)");
 
-    // Current binaries are intentionally lexical-only. The previous x64-only
-    // native semantic dependencies imposed an undocumented CPU floor and made
-    // otherwise identical platform artifacts behave differently.
+    let os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+
+    let fastembed_supported = public_semantic_platform(&os, &arch, &target_env);
+
+    if fastembed_supported {
+        println!("cargo:rustc-cfg=ctx_semantic_fastembed");
+    }
+
+    if fastembed_supported {
+        println!("cargo:rustc-cfg=ctx_sqlite_vec");
+    }
+}
+
+fn public_semantic_platform(os: &str, arch: &str, target_env: &str) -> bool {
+    match (os, arch) {
+        ("linux", "x86_64" | "aarch64") => target_env == "gnu",
+        ("macos", "x86_64" | "aarch64") => true,
+        ("windows", "x86_64") => true,
+        ("freebsd", "x86_64") => true,
+        _ => false,
+    }
 }

--- a/crates/ctx-cli/src/commands/index.rs
+++ b/crates/ctx-cli/src/commands/index.rs
@@ -16,7 +16,7 @@ use crate::progress::format_count;
 use crate::semantic::{
     daemon_report, semantic_worker_report_cached, semantic_worker_report_configured_json,
 };
-use crate::store_util::open_existing_store_snapshot_read_only;
+use crate::store_util::open_existing_store_read_only;
 
 #[derive(Debug, Args)]
 pub(crate) struct IndexArgs {
@@ -169,7 +169,7 @@ fn index_status_snapshot(data_root: &Path) -> Result<Value> {
         semantic,
         daemon,
     ) = if initialized {
-        let store = open_existing_store_snapshot_read_only(&db_path, "ctx index status")?;
+        let store = open_existing_store_read_only(&db_path, "ctx index status")?;
         let indexed_counts = store.indexed_history_counts()?;
         let catalog_counts = store.catalog_session_counts()?;
         let source_import_file_counts = store.source_import_file_counts()?;

--- a/crates/ctx-cli/src/commands/search.rs
+++ b/crates/ctx-cli/src/commands/search.rs
@@ -173,6 +173,7 @@ pub(crate) fn run_search(
     let semantic_enabled = config.semantic_search_enabled();
     if args.refresh == RefreshArg::Background
         && semantic_enabled
+        && semantic::semantic_query_service_supported()
         && matches!(
             requested_backend,
             SearchBackendArg::Semantic | SearchBackendArg::Hybrid
@@ -370,26 +371,28 @@ pub(crate) fn resolve_search_backend(
     config: &config::AppConfig,
 ) -> Result<SearchBackendArg> {
     let semantic_enabled = config.semantic_search_enabled();
-    if semantic_enabled
-        && !semantic::semantic_query_service_supported()
-        && !matches!(backend, Some(SearchBackendArg::Lexical))
-    {
-        return Err(anyhow!(
-            "local semantic search is not supported on this platform yet. Set [search] semantic = false or use --backend lexical"
-        ));
-    }
-    if semantic_enabled
-        && !config.daemon.enabled
-        && !matches!(backend, Some(SearchBackendArg::Lexical))
-    {
-        return Err(anyhow!(
-            "local semantic search requires the ctx daemon. Set [daemon] enabled = true, set [search] semantic = false, or use --backend lexical"
-        ));
-    }
     match backend {
         Some(SearchBackendArg::Semantic) if !semantic_enabled => Err(anyhow!(
             "semantic search is disabled. Set [search] semantic = true in ctx config to enable the local semantic preview"
         )),
+        Some(SearchBackendArg::Semantic) if !semantic::semantic_query_service_supported() => Err(
+            anyhow!(
+                "local semantic search is not supported on this platform yet. Set [search] semantic = false or use --backend lexical"
+            ),
+        ),
+        Some(SearchBackendArg::Semantic) if !config.daemon.enabled => Err(anyhow!(
+            "local semantic search requires the ctx daemon. Set [daemon] enabled = true, set [search] semantic = false, or use --backend lexical"
+        )),
+        value
+            if semantic_enabled
+                && semantic::semantic_query_service_supported()
+                && !config.daemon.enabled
+                && !matches!(value, Some(SearchBackendArg::Lexical)) =>
+        {
+            Err(anyhow!(
+                "local semantic search requires the ctx daemon. Set [daemon] enabled = true, set [search] semantic = false, or use --backend lexical"
+            ))
+        }
         Some(value) => Ok(value),
         None if semantic_enabled => Ok(SearchBackendArg::Hybrid),
         None => Ok(SearchBackendArg::Lexical),
@@ -517,6 +520,7 @@ pub(crate) fn refresh_sources_for_search(
     config::write_default_config(data_root)?;
     let db_path = database_path(data_root.to_path_buf());
     let store = Store::open(&db_path)?;
+    let had_indexed_content = store.indexed_history_item_count()? > 0;
     let inventory = inventory_import_sources(&store, sources, false)?;
     let planned_sources = inventory.sources;
     let planned_total_bytes = inventory.totals.source_bytes;
@@ -708,12 +712,24 @@ pub(crate) fn refresh_sources_for_search(
         }
     }
 
+    let all_sources_failed = totals.imported_sources == 0 && totals.failed_sources > 0;
+    let all_partial_items_failed_without_prior_index = !had_indexed_content
+        && totals.imported_sessions == 0
+        && totals.imported_events == 0
+        && totals.failed > 0;
     if refresh == RefreshArg::Background
-        && totals.imported_sources == 0
-        && totals.failed_sources > 0
+        && (all_sources_failed || all_partial_items_failed_without_prior_index)
     {
         let detail = first_refresh_failure
             .map(|error| format!("; first failure: {error}"))
+            .or_else(|| {
+                (totals.failed > 0).then(|| {
+                    format!(
+                        "; background refresh imported no content and reported {} failure(s)",
+                        totals.failed
+                    )
+                })
+            })
             .unwrap_or_default();
         return Err(anyhow!("all search refresh sources failed{detail}"));
     }

--- a/crates/ctx-cli/src/commands/setup.rs
+++ b/crates/ctx-cli/src/commands/setup.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs,
+    env, fs,
     path::{Path, PathBuf},
 };
 
@@ -33,12 +33,9 @@ pub(crate) fn run_setup(
     let store = Store::open(&db_path)?;
     let config_path = data_root.join(CONFIG_FILE);
     config::write_default_config(&data_root)?;
-    if config.semantic_search_enabled() && !semantic_query_service_supported() {
-        bail!(
-            "local semantic search is not supported on this platform yet. Set [search] semantic = false"
-        );
-    }
-    if config.semantic_search_enabled() && (!config.daemon.enabled || args.no_daemon) {
+    let semantic_enabled = config.semantic_search_enabled();
+    let semantic_supported = semantic_query_service_supported();
+    if semantic_enabled && semantic_supported && (!config.daemon.enabled || args.no_daemon) {
         bail!(
             "local semantic search requires the ctx daemon. Set [daemon] enabled = true, remove --no-daemon, or set [search] semantic = false"
         );
@@ -151,7 +148,7 @@ pub(crate) fn run_setup(
     let background_indexing_enabled = daemon_backgrounding_enabled
         && !args.catalog_only
         && !foreground_import
-        && (pending_inventory_units > 0 || config.semantic_search_enabled());
+        && (pending_inventory_units > 0 || (semantic_enabled && semantic_supported));
 
     if args.json {
         print_json(json!({
@@ -193,7 +190,8 @@ pub(crate) fn run_setup(
                 &inventory_totals,
                 inventory_units,
                 background_indexing_enabled,
-                config.semantic_search_enabled(),
+                semantic_enabled,
+                semantic_supported,
                 args.json
             ),
             "network_required": false,
@@ -247,7 +245,8 @@ pub(crate) fn run_setup(
                 print_background_indexing_guidance(
                     &inventory_totals,
                     inventory_units,
-                    config.semantic_search_enabled(),
+                    semantic_enabled,
+                    semantic_supported,
                 );
             }
             println!("Get started:");
@@ -406,15 +405,20 @@ fn setup_background_indexing_json(
     units: usize,
     enabled: bool,
     semantic_enabled: bool,
+    semantic_supported: bool,
     json_output: bool,
 ) -> Value {
+    let semantic_estimate = semantic_index_estimate(inventory);
     json!({
         "enabled": enabled,
         "semantic_enabled": semantic_enabled,
+        "semantic_supported": semantic_supported,
         "units": units,
         "source_bytes": inventory.source_bytes,
         "lexical_estimate_seconds": enabled.then(|| estimate_lexical_index_seconds(inventory)),
-        "semantic_estimate_seconds": (enabled && semantic_enabled).then(|| estimate_semantic_index_seconds(inventory)),
+        "semantic_estimate_seconds": (enabled && semantic_enabled && semantic_supported).then_some(semantic_estimate.expected_seconds),
+        "semantic_estimate_backend": (enabled && semantic_enabled && semantic_supported).then_some(semantic_estimate.backend),
+        "semantic_cpu_fallback_estimate_seconds": (enabled && semantic_enabled && semantic_supported).then_some(semantic_estimate.cpu_fallback_seconds).flatten(),
         "daemon_autostart": setup_daemon_autostart_json(enabled, json_output),
         "status_command": "ctx index status",
         "watch_command": "ctx index watch",
@@ -448,6 +452,7 @@ fn print_background_indexing_guidance(
     inventory: &InventoryTotals,
     units: usize,
     semantic_enabled: bool,
+    semantic_supported: bool,
 ) {
     println!("ctx queued your local agent history for background indexing.");
     println!(
@@ -460,14 +465,26 @@ fn print_background_indexing_guidance(
         "Estimated lexical indexing: {}.",
         format_duration_estimate(estimate_lexical_index_seconds(inventory))
     );
-    if semantic_enabled {
+    if semantic_enabled && semantic_supported {
+        let estimate = semantic_index_estimate(inventory);
         println!(
             "Semantic search: enabled; the daemon will download the local embedding model if needed."
         );
-        println!(
-            "Estimated semantic indexing: {}.",
-            format_duration_estimate(estimate_semantic_index_seconds(inventory))
-        );
+        if let Some(cpu_fallback_seconds) = estimate.cpu_fallback_seconds {
+            println!(
+                "Estimated semantic indexing: {} with CoreML; CPU fallback can take about {}.",
+                format_duration_estimate(estimate.expected_seconds),
+                format_duration_estimate(cpu_fallback_seconds)
+            );
+        } else {
+            println!(
+                "Estimated semantic indexing: {} with {}.",
+                format_duration_estimate(estimate.expected_seconds),
+                estimate.backend
+            );
+        }
+    } else if semantic_enabled {
+        println!("Semantic search: unavailable on this platform; lexical indexing will continue.");
     } else {
         println!("Semantic search: disabled.");
     }
@@ -485,8 +502,56 @@ fn estimate_lexical_index_seconds(inventory: &InventoryTotals) -> u64 {
     estimate_seconds_for_bytes(inventory.source_bytes, 16 * 1024 * 1024)
 }
 
-fn estimate_semantic_index_seconds(inventory: &InventoryTotals) -> u64 {
-    estimate_seconds_for_bytes(inventory.source_bytes, 5 * 1024 * 1024)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SemanticIndexEstimate {
+    expected_seconds: u64,
+    backend: &'static str,
+    cpu_fallback_seconds: Option<u64>,
+}
+
+fn semantic_index_estimate(inventory: &InventoryTotals) -> SemanticIndexEstimate {
+    let preference = env::var("CTX_INTERNAL_SEMANTIC_BACKEND").ok();
+    semantic_index_estimate_for(
+        inventory,
+        preference.as_deref(),
+        cfg!(all(target_os = "macos", target_arch = "aarch64")),
+    )
+}
+
+fn semantic_index_estimate_for(
+    inventory: &InventoryTotals,
+    preference: Option<&str>,
+    apple_silicon: bool,
+) -> SemanticIndexEstimate {
+    const COREML_BYTES_PER_SECOND: u64 = 5 * 1024 * 1024 / 4;
+    const CPU_BYTES_PER_SECOND: u64 = 256 * 1024;
+
+    // These are measured end-to-end planning rates under the quiet daemon
+    // policy, not startup benchmarks. Unknown internal overrides use the
+    // conservative CPU estimate; backend acquisition will report their error.
+    let preference = preference.map(str::trim).filter(|value| !value.is_empty());
+    let coreml_expected =
+        apple_silicon && matches!(preference, None | Some("auto") | Some("coreml"));
+    if coreml_expected {
+        SemanticIndexEstimate {
+            expected_seconds: estimate_seconds_for_bytes(
+                inventory.source_bytes,
+                COREML_BYTES_PER_SECOND,
+            ),
+            backend: "CoreML",
+            cpu_fallback_seconds: matches!(preference, None | Some("auto"))
+                .then(|| estimate_seconds_for_bytes(inventory.source_bytes, CPU_BYTES_PER_SECOND)),
+        }
+    } else {
+        SemanticIndexEstimate {
+            expected_seconds: estimate_seconds_for_bytes(
+                inventory.source_bytes,
+                CPU_BYTES_PER_SECOND,
+            ),
+            backend: "CPU",
+            cpu_fallback_seconds: None,
+        }
+    }
 }
 
 fn estimate_seconds_for_bytes(bytes: u64, bytes_per_second: u64) -> u64 {
@@ -509,8 +574,9 @@ fn format_duration_estimate(seconds: u64) -> String {
             plural(minutes as usize, "minute", "minutes")
         )
     } else {
-        let hours = seconds / 3_600;
-        let minutes = (seconds % 3_600).div_ceil(60);
+        let rounded_minutes = seconds.div_ceil(60);
+        let hours = rounded_minutes / 60;
+        let minutes = rounded_minutes % 60;
         if minutes == 0 {
             format!("{} {}", hours, plural(hours as usize, "hour", "hours"))
         } else {
@@ -564,4 +630,35 @@ pub(crate) fn insert_db_size_bucket(
 
 pub(crate) fn setup_has_failed_sources(report: Option<&ImportReport>) -> bool {
     report.is_some_and(|report| report.totals.failed_sources > 0)
+}
+
+#[cfg(test)]
+mod setup_estimate_tests {
+    use super::*;
+
+    #[test]
+    fn semantic_estimate_uses_quiet_backend_throughput() {
+        let inventory = InventoryTotals {
+            source_bytes: 15 * 1024 * 1024 * 1024,
+            ..InventoryTotals::default()
+        };
+        let coreml = semantic_index_estimate_for(&inventory, None, true);
+        assert_eq!(coreml.expected_seconds, 12_288);
+        assert_eq!(coreml.backend, "CoreML");
+        assert_eq!(coreml.cpu_fallback_seconds, Some(61_440));
+
+        let forced_cpu = semantic_index_estimate_for(&inventory, Some("cpu"), true);
+        assert_eq!(forced_cpu.expected_seconds, 61_440);
+        assert_eq!(forced_cpu.backend, "CPU");
+        assert_eq!(forced_cpu.cpu_fallback_seconds, None);
+
+        let conservative = semantic_index_estimate_for(&inventory, None, false);
+        assert_eq!(conservative.expected_seconds, 61_440);
+        assert_eq!(conservative.backend, "CPU");
+    }
+
+    #[test]
+    fn duration_estimate_carries_rounded_minutes_into_hours() {
+        assert_eq!(format_duration_estimate(7_199), "2 hours");
+    }
 }

--- a/crates/ctx-cli/src/commands/status.rs
+++ b/crates/ctx-cli/src/commands/status.rs
@@ -10,7 +10,7 @@ use crate::output::print_json;
 use crate::semantic::{
     daemon_report, semantic_worker_report_cached, semantic_worker_report_configured_json,
 };
-use crate::store_util::open_existing_store_snapshot_read_only;
+use crate::store_util::open_existing_store_read_only;
 use crate::JsonArgs;
 
 pub(crate) fn run_status(args: JsonArgs, data_root: PathBuf, quiet: bool) -> Result<()> {
@@ -28,7 +28,7 @@ pub(crate) fn run_status(args: JsonArgs, data_root: PathBuf, quiet: bool) -> Res
         semantic,
         daemon,
     ) = if initialized {
-        let store = open_existing_store_snapshot_read_only(&db_path, "ctx status")?;
+        let store = open_existing_store_read_only(&db_path, "ctx status")?;
         let counts = store.indexed_history_counts()?;
         let semantic_report = semantic_worker_report_cached(&data_root, Some(&store))?;
         let daemon = daemon_report(&data_root, &semantic_report);

--- a/crates/ctx-cli/src/net.rs
+++ b/crates/ctx-cli/src/net.rs
@@ -3,6 +3,7 @@ use std::{
     fs::OpenOptions,
     io::{Read, Write},
     path::PathBuf,
+    time::{Duration, Instant},
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -42,6 +43,81 @@ pub fn get_bytes_limited(endpoint: &str, max_bytes: usize) -> Result<Vec<u8>> {
         max_bytes,
         &format!("GET {endpoint}"),
     )
+}
+
+#[cfg_attr(not(any(target_os = "macos", test)), allow(dead_code))]
+pub(crate) fn get_to_writer_limited(
+    endpoint: &str,
+    max_bytes: u64,
+    timeout: Duration,
+    writer: &mut impl Write,
+) -> Result<u64> {
+    let started = Instant::now();
+    if let Some(path) = file_url_path(endpoint)? {
+        let file = fs::File::open(&path).with_context(|| format!("read {}", path.display()))?;
+        return copy_limited(
+            file,
+            writer,
+            max_bytes,
+            timeout,
+            started,
+            "read local artifact",
+        );
+    }
+    require_https_or_localhost(endpoint)?;
+    let response = ureq::get(endpoint)
+        .timeout(timeout)
+        .call()
+        .map_err(|err| anyhow!("GET artifact: {err}"))?;
+    if response
+        .header("content-length")
+        .and_then(|value| value.parse::<u64>().ok())
+        .is_some_and(|length| length > max_bytes)
+    {
+        return Err(anyhow!("GET artifact exceeds max bytes ({max_bytes})"));
+    }
+    copy_limited(
+        response.into_reader(),
+        writer,
+        max_bytes,
+        timeout,
+        started,
+        "GET artifact",
+    )
+}
+
+#[cfg_attr(not(any(target_os = "macos", test)), allow(dead_code))]
+fn copy_limited(
+    mut reader: impl Read,
+    writer: &mut impl Write,
+    max_bytes: u64,
+    timeout: Duration,
+    started: Instant,
+    label: &str,
+) -> Result<u64> {
+    let mut total = 0_u64;
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        if started.elapsed() > timeout {
+            return Err(anyhow!("{label} exceeded time limit"));
+        }
+        let count = reader
+            .read(&mut buffer)
+            .with_context(|| format!("{label}: read response"))?;
+        if count == 0 {
+            break;
+        }
+        total = total
+            .checked_add(count as u64)
+            .ok_or_else(|| anyhow!("{label} size overflow"))?;
+        if total > max_bytes {
+            return Err(anyhow!("{label} exceeds max bytes ({max_bytes})"));
+        }
+        writer
+            .write_all(&buffer[..count])
+            .with_context(|| format!("{label}: write destination"))?;
+    }
+    Ok(total)
 }
 
 pub(crate) fn read_limited(
@@ -134,5 +210,21 @@ mod tests {
         fs::write(&path, b"12345").unwrap();
         let err = get_bytes_limited(&format!("file://{}", path.display()), 4).unwrap_err();
         assert!(err.to_string().contains("exceeds max bytes (4)"));
+    }
+
+    #[test]
+    fn streaming_get_enforces_compressed_limit() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("artifact.bin");
+        fs::write(&path, b"12345").unwrap();
+        let mut output = Vec::new();
+        let error = get_to_writer_limited(
+            &format!("file://{}", path.display()),
+            4,
+            Duration::from_secs(1),
+            &mut output,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("exceeds max bytes"));
     }
 }

--- a/crates/ctx-cli/src/semantic.rs
+++ b/crates/ctx-cli/src/semantic.rs
@@ -1,8 +1,24 @@
 include!("semantic/preamble.rs");
+#[cfg(any(target_os = "macos", test))]
+mod model_bundle {
+    include!("semantic/model_bundle.rs");
+}
+#[cfg(any(target_os = "macos", test))]
+mod model_acquisition {
+    include!("semantic/model_acquisition.rs");
+}
+#[cfg(any(target_os = "macos", test))]
+use model_acquisition::*;
+#[cfg(target_os = "macos")]
+use model_bundle::*;
+include!("semantic/resource_policy.rs");
+include!("semantic/embedding_backend.rs");
 include!("semantic/vector_store_schema.rs");
 include!("semantic/vector_store_state.rs");
 include!("semantic/vector_store_search.rs");
+include!("semantic/ort_runtime.rs");
 include!("semantic/paths_status.rs");
+include!("semantic/query_service_transport.rs");
 include!("semantic/daemon.rs");
 include!("semantic/health_search.rs");
 include!("semantic/indexing.rs");

--- a/crates/ctx-cli/src/semantic/daemon.rs
+++ b/crates/ctx-cli/src/semantic/daemon.rs
@@ -21,22 +21,300 @@ fn daemon_runtime_embedder_loaded(runtime: &DaemonRuntime) -> bool {
 fn lock_daemon_runtime_embedder(
     runtime: &DaemonRuntime,
 ) -> Result<std::sync::MutexGuard<'_, Option<SemanticEmbedder>>> {
-    runtime
-        .semantic_embedder
+    lock_shared_semantic_embedder(&runtime.semantic_embedder)
+}
+
+fn lock_shared_semantic_embedder(
+    embedder: &Arc<Mutex<Option<SemanticEmbedder>>>,
+) -> Result<std::sync::MutexGuard<'_, Option<SemanticEmbedder>>> {
+    embedder
         .lock()
         .map_err(|_| anyhow!("semantic embedder lock is poisoned"))
 }
 
-#[cfg(unix)]
+fn shared_semantic_embedder_policy_status_json(
+    embedder: &Arc<Mutex<Option<SemanticEmbedder>>>,
+) -> Result<Value> {
+    let guard = lock_shared_semantic_embedder(embedder)?;
+    Ok(semantic_embedder_policy_status_json(&guard))
+}
+
+fn shared_semantic_embedder_runtime_status_json(
+    embedder: &Arc<Mutex<Option<SemanticEmbedder>>>,
+) -> Result<Option<Value>> {
+    let guard = lock_shared_semantic_embedder(embedder)?;
+    Ok(semantic_embedder_runtime_status_json(&guard))
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn embed_documents_with_shared_runtime(
+    shared: &Arc<Mutex<Option<SemanticEmbedder>>>,
+    cache_dir: &Path,
+    texts: Vec<String>,
+    deadline: Option<Instant>,
+) -> Result<(Vec<Vec<f32>>, SemanticQuietPolicy)> {
+    let mut guard = lock_shared_semantic_embedder(shared)?;
+    let started = Instant::now();
+    let first = guard
+        .as_mut()
+        .ok_or_else(|| anyhow!("semantic embedder was not initialized"))?
+        .embed_documents(texts.clone());
+    let embeddings = match first {
+        Ok(embeddings) => embeddings,
+        Err(first_error) => {
+            let runtime = guard
+                .as_ref()
+                .ok_or_else(|| anyhow!("semantic embedder disappeared after inference failure"))?
+                .runtime_info();
+            *guard = None;
+            let mut replacement = reacquire_semantic_embedder(cache_dir, &runtime)
+                .context("reinitialize semantic embedder after document inference failure")?;
+            let retry = replacement.embed_documents(texts).with_context(|| {
+                format!("semantic document inference failed twice; first failure: {first_error:#}")
+            })?;
+            *guard = Some(replacement);
+            retry
+        }
+    };
+    let quiet_policy = guard
+        .as_ref()
+        .ok_or_else(|| anyhow!("semantic embedder was not initialized"))?
+        .quiet_policy();
+    drop(guard);
+    let active = started.elapsed();
+    let remaining = deadline.map(|deadline| deadline.saturating_duration_since(Instant::now()));
+    throttle_semantic_batch(active, quiet_policy, remaining);
+    Ok((embeddings, quiet_policy))
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn embed_query_with_shared_runtime(
+    shared: &Arc<Mutex<Option<SemanticEmbedder>>>,
+    cache_dir: &Path,
+    query: String,
+) -> Result<(Vec<f32>, SemanticEmbeddingRuntimeInfo)> {
+    let mut guard = lock_shared_semantic_embedder(shared)?;
+    let first = guard
+        .as_mut()
+        .ok_or_else(|| anyhow!("semantic embedder was not initialized"))?
+        .embed_query(query.clone());
+    let embedding = match first {
+        Ok(embedding) => embedding,
+        Err(first_error) => {
+            let runtime = guard
+                .as_ref()
+                .ok_or_else(|| anyhow!("semantic embedder disappeared after inference failure"))?
+                .runtime_info();
+            *guard = None;
+            let mut replacement = reacquire_semantic_embedder(cache_dir, &runtime)
+                .context("reinitialize semantic embedder after query inference failure")?;
+            let retry = replacement.embed_query(query).with_context(|| {
+                format!("semantic query inference failed twice; first failure: {first_error:#}")
+            })?;
+            *guard = Some(replacement);
+            retry
+        }
+    };
+    let runtime = guard
+        .as_ref()
+        .ok_or_else(|| anyhow!("semantic embedder was not initialized"))?
+        .runtime_info();
+    Ok((embedding, runtime))
+}
+
 struct DaemonQueryService {
-    path: PathBuf,
+    data_root: PathBuf,
+    activity: Arc<DaemonQueryActivity>,
+    thread: Option<std::thread::JoinHandle<()>>,
+    #[cfg(unix)]
+    socket_path: PathBuf,
+    #[cfg(unix)]
+    socket_runtime_dir: Option<PathBuf>,
+    #[cfg(windows)]
+    pipe_name: String,
+}
+
+const DAEMON_QUERY_REQUEST_MAX_BYTES: usize = 256 * 1024;
+const DAEMON_QUERY_REQUEST_READ_TIMEOUT: StdDuration = StdDuration::from_secs(2);
+
+impl Drop for DaemonQueryService {
+    fn drop(&mut self) {
+        remove_daemon_query_endpoint(&self.data_root);
+        self.activity.stop();
+        #[cfg(windows)]
+        wake_windows_daemon_query_pipe(&self.pipe_name);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+        #[cfg(unix)]
+        {
+            let _ = fs::remove_file(&self.socket_path);
+            if let Some(dir) = self.socket_runtime_dir.as_ref() {
+                let _ = fs::remove_dir(dir);
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct DaemonQueryActivity {
+    state: Mutex<DaemonQueryActivityState>,
+}
+
+#[derive(Default)]
+struct DaemonQueryActivityState {
+    accepting: bool,
+    stopping: bool,
+    active_requests: usize,
+    generation: u64,
+}
+
+struct DaemonQueryRequestGuard {
+    activity: Arc<DaemonQueryActivity>,
+}
+
+impl DaemonQueryActivity {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(DaemonQueryActivityState {
+                accepting: true,
+                ..DaemonQueryActivityState::default()
+            }),
+        }
+    }
+
+    fn state(&self) -> std::sync::MutexGuard<'_, DaemonQueryActivityState> {
+        self.state.lock().unwrap_or_else(|error| error.into_inner())
+    }
+
+    fn begin_request(self: &Arc<Self>) -> Option<DaemonQueryRequestGuard> {
+        let mut state = self.state();
+        if !state.accepting || state.stopping {
+            return None;
+        }
+        state.active_requests = state.active_requests.saturating_add(1);
+        state.generation = state.generation.wrapping_add(1);
+        drop(state);
+        Some(DaemonQueryRequestGuard {
+            activity: self.clone(),
+        })
+    }
+
+    fn snapshot(&self) -> (usize, u64) {
+        let state = self.state();
+        (state.active_requests, state.generation)
+    }
+
+    fn try_stop_accepting_if_idle(&self, observed_generation: u64) -> bool {
+        let mut state = self.state();
+        if state.active_requests != 0 || state.generation != observed_generation {
+            return false;
+        }
+        state.accepting = false;
+        true
+    }
+
+    fn stop(&self) {
+        let mut state = self.state();
+        state.accepting = false;
+        state.stopping = true;
+    }
+
+    fn stopping(&self) -> bool {
+        self.state().stopping
+    }
+}
+
+impl Drop for DaemonQueryRequestGuard {
+    fn drop(&mut self) {
+        let mut state = self.activity.state();
+        state.active_requests = state.active_requests.saturating_sub(1);
+        state.generation = state.generation.wrapping_add(1);
+    }
+}
+
+fn observe_daemon_query_activity(
+    activity: Option<&DaemonQueryActivity>,
+    idle_since: &mut Option<Instant>,
+    observed_generation: &mut u64,
+) {
+    let Some(activity) = activity else {
+        return;
+    };
+    let (active_requests, generation) = activity.snapshot();
+    if active_requests != 0 || generation != *observed_generation {
+        *idle_since = None;
+        *observed_generation = generation;
+    }
+}
+
+fn daemon_can_begin_idle_shutdown(
+    activity: Option<&DaemonQueryActivity>,
+    observed_generation: u64,
+) -> bool {
+    activity.is_none_or(|activity| activity.try_stop_accepting_if_idle(observed_generation))
 }
 
 #[cfg(unix)]
-impl Drop for DaemonQueryService {
-    fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
+const DAEMON_QUERY_SOCKET_PATH_SAFE_BYTES: usize = 90;
+
+#[cfg(unix)]
+fn bind_daemon_query_listener(
+    data_root: &Path,
+) -> Result<(UnixListener, PathBuf, Option<PathBuf>)> {
+    let preferred = daemon_query_socket_path(data_root);
+    if preferred.as_os_str().as_bytes().len() <= DAEMON_QUERY_SOCKET_PATH_SAFE_BYTES {
+        let _ = fs::remove_file(&preferred);
+        let listener = UnixListener::bind(&preferred)
+            .with_context(|| format!("bind daemon query socket {}", preferred.display()))?;
+        return Ok((listener, preferred, None));
     }
+
+    let mut roots = vec![PathBuf::from("/tmp")];
+    let env_tmp = env::temp_dir();
+    if env_tmp != roots[0] {
+        roots.push(env_tmp);
+    }
+    let mut failures = Vec::new();
+    for root in roots {
+        if !root.is_dir() {
+            continue;
+        }
+        for _ in 0..8 {
+            let runtime_dir = root.join(format!("ctx-q-{}", Uuid::new_v4().simple()));
+            match fs::create_dir(&runtime_dir) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(error) => {
+                    failures.push(format!("create {}: {error}", runtime_dir.display()));
+                    break;
+                }
+            }
+            if let Err(error) = fs::set_permissions(&runtime_dir, fs::Permissions::from_mode(0o700)) {
+                let _ = fs::remove_dir(&runtime_dir);
+                failures.push(format!("secure {}: {error}", runtime_dir.display()));
+                continue;
+            }
+            let path = runtime_dir.join("q.sock");
+            if path.as_os_str().as_bytes().len() > DAEMON_QUERY_SOCKET_PATH_SAFE_BYTES {
+                let _ = fs::remove_dir(&runtime_dir);
+                failures.push(format!("fallback socket path is still too long: {}", path.display()));
+                continue;
+            }
+            match UnixListener::bind(&path) {
+                Ok(listener) => return Ok((listener, path, Some(runtime_dir))),
+                Err(error) => {
+                    let _ = fs::remove_file(&path);
+                    let _ = fs::remove_dir(&runtime_dir);
+                    failures.push(format!("bind {}: {error}", path.display()));
+                }
+            }
+        }
+    }
+    Err(anyhow!(
+        "daemon query socket path is too long and no short private runtime directory was available: {}",
+        failures.join("; ")
+    ))
 }
 
 #[cfg(unix)]
@@ -44,37 +322,457 @@ fn start_daemon_query_service(
     data_root: &Path,
     embedder: Arc<Mutex<Option<SemanticEmbedder>>>,
 ) -> Result<DaemonQueryService> {
-    let root = daemon_root_path(data_root);
-    create_private_dir_all(&root)?;
-    let path = daemon_query_socket_path(data_root);
-    let _ = fs::remove_file(&path);
-    let listener =
-        UnixListener::bind(&path).with_context(|| format!("bind daemon query socket {}", path.display()))?;
-    fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
-        .with_context(|| format!("set daemon query socket permissions {}", path.display()))?;
-    let thread_data_root = data_root.to_path_buf();
-    std::thread::Builder::new()
-        .name("ctx-daemon-query".to_owned())
-        .spawn(move || {
-            for stream in listener.incoming() {
-                match stream {
-                    Ok(stream) => handle_daemon_query_stream(&thread_data_root, &embedder, stream),
-                    Err(_) => break,
-                }
-            }
-        })
-        .context("start daemon query service thread")?;
-    Ok(DaemonQueryService { path })
+    start_daemon_query_service_with_request_timeout(
+        data_root,
+        embedder,
+        DAEMON_QUERY_REQUEST_READ_TIMEOUT,
+    )
 }
 
 #[cfg(unix)]
-fn handle_daemon_query_stream(
+fn start_daemon_query_service_with_request_timeout(
+    data_root: &Path,
+    embedder: Arc<Mutex<Option<SemanticEmbedder>>>,
+    request_read_timeout: StdDuration,
+) -> Result<DaemonQueryService> {
+    let root = daemon_root_path(data_root);
+    create_private_dir_all(&root)?;
+    let (listener, path, socket_runtime_dir) = bind_daemon_query_listener(data_root)?;
+    listener
+        .set_nonblocking(true)
+        .context("make daemon query socket nonblocking")?;
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("set daemon query socket permissions {}", path.display()))?;
+    let endpoint = DaemonQueryEndpoint::Unix {
+        path,
+        token: Uuid::new_v4().simple().to_string(),
+    };
+    let socket_path = match &endpoint {
+        DaemonQueryEndpoint::Unix { path, .. } => path.clone(),
+    };
+    if let Err(error) = write_daemon_query_endpoint(data_root, &endpoint) {
+        let _ = fs::remove_file(socket_path);
+        if let Some(dir) = socket_runtime_dir.as_ref() {
+            let _ = fs::remove_dir(dir);
+        }
+        return Err(error);
+    }
+    let thread_data_root = data_root.to_path_buf();
+    let thread_token = endpoint.token().to_owned();
+    let activity = Arc::new(DaemonQueryActivity::new());
+    let thread_activity = activity.clone();
+    let spawn_result = std::thread::Builder::new()
+        .name("ctx-daemon-query".to_owned())
+        .spawn(move || {
+            while !thread_activity.stopping() {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        // Accepted Unix sockets inherit nonblocking mode on
+                        // macOS. A 384-float response exceeds the default
+                        // socket buffer, so restore bounded blocking writes
+                        // before serving the request.
+                        if configure_daemon_query_stream_unix(
+                            &stream,
+                            request_read_timeout,
+                        )
+                        .is_err()
+                        {
+                            continue;
+                        }
+                        let Some(_request) = thread_activity.begin_request() else {
+                            continue;
+                        };
+                        let request = read_daemon_query_request_unix(
+                            &mut stream,
+                            DAEMON_QUERY_REQUEST_MAX_BYTES,
+                            request_read_timeout,
+                        );
+                        handle_daemon_query_stream(
+                            &thread_data_root,
+                            &embedder,
+                            &thread_token,
+                            stream,
+                            request,
+                        );
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(StdDuration::from_millis(25));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+    let thread = match spawn_result {
+        Ok(thread) => thread,
+        Err(error) => {
+            remove_daemon_query_endpoint(data_root);
+            let _ = fs::remove_file(socket_path);
+            if let Some(dir) = socket_runtime_dir.as_ref() {
+                let _ = fs::remove_dir(dir);
+            }
+            return Err(error).context("start daemon query service thread");
+        }
+    };
+    Ok(DaemonQueryService {
+        data_root: data_root.to_path_buf(),
+        activity,
+        thread: Some(thread),
+        socket_path: match endpoint {
+            DaemonQueryEndpoint::Unix { path, .. } => path,
+        },
+        socket_runtime_dir,
+    })
+}
+
+#[cfg(unix)]
+fn configure_daemon_query_stream_unix(
+    stream: &UnixStream,
+    write_timeout: StdDuration,
+) -> std::io::Result<()> {
+    stream.set_nonblocking(false)?;
+    stream.set_write_timeout(Some(write_timeout))
+}
+
+#[cfg(windows)]
+fn start_daemon_query_service(
+    data_root: &Path,
+    embedder: Arc<Mutex<Option<SemanticEmbedder>>>,
+) -> Result<DaemonQueryService> {
+    start_daemon_query_service_with_request_timeout(
+        data_root,
+        embedder,
+        DAEMON_QUERY_REQUEST_READ_TIMEOUT,
+    )
+}
+
+#[cfg(windows)]
+fn start_daemon_query_service_with_request_timeout(
+    data_root: &Path,
+    embedder: Arc<Mutex<Option<SemanticEmbedder>>>,
+    request_read_timeout: StdDuration,
+) -> Result<DaemonQueryService> {
+    let root = daemon_root_path(data_root);
+    create_private_dir_all(&root)?;
+    let endpoint = DaemonQueryEndpoint::WindowsNamedPipe {
+        pipe_name: daemon_query_pipe_name(),
+        token: Uuid::new_v4().simple().to_string(),
+    };
+    let pipe_name = match &endpoint {
+        DaemonQueryEndpoint::WindowsNamedPipe { pipe_name, .. } => pipe_name.clone(),
+    };
+    let first_stream = create_windows_daemon_query_pipe(&pipe_name, true)?;
+    if let Err(error) = write_daemon_query_endpoint(data_root, &endpoint) {
+        drop(first_stream);
+        return Err(error);
+    }
+    let thread_data_root = data_root.to_path_buf();
+    let thread_token = endpoint.token().to_owned();
+    let activity = Arc::new(DaemonQueryActivity::new());
+    let thread_activity = activity.clone();
+    let thread_pipe_name = pipe_name.clone();
+    let spawn_result = std::thread::Builder::new()
+        .name("ctx-daemon-query".to_owned())
+        .spawn(move || {
+            let mut next_stream = Some(first_stream);
+            while !thread_activity.stopping() {
+                let stream = match next_stream.take() {
+                    Some(stream) => stream,
+                    None => match create_windows_daemon_query_pipe(&thread_pipe_name, false) {
+                        Ok(stream) => stream,
+                        Err(_) => break,
+                    },
+                };
+                if connect_windows_daemon_query_pipe(&stream).is_err() {
+                    break;
+                }
+                let Some(_request) = thread_activity.begin_request() else {
+                    break;
+                };
+                let stream = stream;
+                let request = read_daemon_query_request_windows(
+                    &stream,
+                    DAEMON_QUERY_REQUEST_MAX_BYTES,
+                    request_read_timeout,
+                );
+                handle_daemon_query_stream(
+                    &thread_data_root,
+                    &embedder,
+                    &thread_token,
+                    stream,
+                    request,
+                );
+            }
+        });
+    let thread = match spawn_result {
+        Ok(thread) => thread,
+        Err(error) => {
+            remove_daemon_query_endpoint(data_root);
+            return Err(error).context("start daemon query service thread");
+        }
+    };
+    Ok(DaemonQueryService {
+        data_root: data_root.to_path_buf(),
+        activity,
+        thread: Some(thread),
+        pipe_name,
+    })
+}
+
+#[cfg(windows)]
+struct WindowsDaemonQueryPipe {
+    handle: windows_sys::Win32::Foundation::HANDLE,
+}
+
+#[cfg(windows)]
+unsafe impl Send for WindowsDaemonQueryPipe {}
+
+#[cfg(windows)]
+impl Drop for WindowsDaemonQueryPipe {
+    fn drop(&mut self) {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Pipes::DisconnectNamedPipe;
+
+        unsafe {
+            let _ = DisconnectNamedPipe(self.handle);
+            let _ = CloseHandle(self.handle);
+        }
+    }
+}
+
+#[cfg(windows)]
+struct WindowsDaemonQueryRequestReader<'a> {
+    pipe: &'a WindowsDaemonQueryPipe,
+    deadline: WindowsIoDeadline,
+}
+
+#[cfg(windows)]
+impl WindowsDaemonQueryRequestReader<'_> {
+    fn new(
+        pipe: &WindowsDaemonQueryPipe,
+        timeout: StdDuration,
+    ) -> WindowsDaemonQueryRequestReader<'_> {
+        WindowsDaemonQueryRequestReader {
+            pipe,
+            deadline: WindowsIoDeadline::new(timeout),
+        }
+    }
+}
+
+#[cfg(windows)]
+impl std::io::Read for WindowsDaemonQueryRequestReader<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        use windows_sys::Win32::Foundation::{
+            GetLastError, ERROR_BROKEN_PIPE, ERROR_NO_DATA, ERROR_PIPE_NOT_CONNECTED,
+        };
+        use windows_sys::Win32::Storage::FileSystem::ReadFile;
+        use windows_sys::Win32::System::Pipes::PeekNamedPipe;
+
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        loop {
+            let mut available = 0u32;
+            let ok = unsafe {
+                PeekNamedPipe(
+                    self.pipe.handle,
+                    std::ptr::null_mut(),
+                    0,
+                    std::ptr::null_mut(),
+                    &mut available,
+                    std::ptr::null_mut(),
+                )
+            };
+            if ok == 0 {
+                let error = unsafe { GetLastError() };
+                if matches!(
+                    error,
+                    ERROR_BROKEN_PIPE | ERROR_NO_DATA | ERROR_PIPE_NOT_CONNECTED
+                ) {
+                    return Ok(0);
+                }
+                return Err(std::io::Error::from_raw_os_error(error as i32));
+            }
+            if available == 0 {
+                let wait_ms = self.deadline.remaining_ms("request read")?.min(10);
+                std::thread::sleep(StdDuration::from_millis(u64::from(wait_ms)));
+                continue;
+            }
+
+            let mut bytes_read = 0u32;
+            let read_len = buf.len().min(available as usize).min(u32::MAX as usize) as u32;
+            let ok = unsafe {
+                ReadFile(
+                    self.pipe.handle,
+                    buf.as_mut_ptr(),
+                    read_len,
+                    &mut bytes_read,
+                    std::ptr::null_mut(),
+                )
+            };
+            if ok == 0 {
+                let error = unsafe { GetLastError() };
+                if matches!(
+                    error,
+                    ERROR_BROKEN_PIPE | ERROR_NO_DATA | ERROR_PIPE_NOT_CONNECTED
+                ) {
+                    return Ok(0);
+                }
+                return Err(std::io::Error::from_raw_os_error(error as i32));
+            }
+            return Ok(bytes_read as usize);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn read_daemon_query_request_windows(
+    pipe: &WindowsDaemonQueryPipe,
+    max_bytes: usize,
+    timeout: StdDuration,
+) -> Result<String> {
+    read_daemon_query_request(
+        &mut WindowsDaemonQueryRequestReader::new(pipe, timeout),
+        max_bytes,
+    )
+}
+
+#[cfg(windows)]
+impl std::io::Write for WindowsDaemonQueryPipe {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        use windows_sys::Win32::Storage::FileSystem::WriteFile;
+
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let mut bytes_written = 0u32;
+        let write_len = u32::try_from(buf.len()).unwrap_or(u32::MAX);
+        let ok = unsafe {
+            WriteFile(
+                self.handle,
+                buf.as_ptr(),
+                write_len,
+                &mut bytes_written,
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(bytes_written as usize)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        // FlushFileBuffers waits for the client to drain a named pipe and lets a
+        // stalled client block the single query-service thread indefinitely.
+        // WriteFile has already copied the response into the pipe buffer.
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn create_windows_daemon_query_pipe(
+    pipe_name: &str,
+    first_instance: bool,
+) -> Result<WindowsDaemonQueryPipe> {
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_FIRST_PIPE_INSTANCE, PIPE_ACCESS_DUPLEX,
+    };
+    use windows_sys::Win32::System::Pipes::{
+        CreateNamedPipeW, PIPE_READMODE_BYTE, PIPE_REJECT_REMOTE_CLIENTS, PIPE_TYPE_BYTE,
+        PIPE_WAIT,
+    };
+
+    if !windows_named_pipe_name_is_local(pipe_name) {
+        return Err(anyhow!("daemon query pipe name is not local"));
+    }
+    let pipe_name_w = windows_wide_null(pipe_name);
+    let access = PIPE_ACCESS_DUPLEX
+        | if first_instance {
+            FILE_FLAG_FIRST_PIPE_INSTANCE
+        } else {
+            0
+        };
+    let handle = unsafe {
+        CreateNamedPipeW(
+            pipe_name_w.as_ptr(),
+            access,
+            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+            1,
+            1024 * 1024,
+            256 * 1024,
+            0,
+            std::ptr::null(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("create daemon query named pipe {pipe_name}"));
+    }
+    Ok(WindowsDaemonQueryPipe { handle })
+}
+
+#[cfg(windows)]
+fn connect_windows_daemon_query_pipe(stream: &WindowsDaemonQueryPipe) -> Result<()> {
+    use windows_sys::Win32::Foundation::{GetLastError, ERROR_PIPE_CONNECTED};
+    use windows_sys::Win32::System::Pipes::ConnectNamedPipe;
+
+    let ok = unsafe { ConnectNamedPipe(stream.handle, std::ptr::null_mut()) };
+    if ok != 0 {
+        return Ok(());
+    }
+    let error = unsafe { GetLastError() };
+    if error == ERROR_PIPE_CONNECTED {
+        return Ok(());
+    }
+    Err(std::io::Error::last_os_error()).context("connect daemon query named pipe")
+}
+
+#[cfg(windows)]
+fn wake_windows_daemon_query_pipe(pipe_name: &str) {
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_GENERIC_READ, FILE_GENERIC_WRITE, OPEN_EXISTING,
+    };
+
+    let pipe_name_w = windows_wide_null(pipe_name);
+    let handle = unsafe {
+        CreateFileW(
+            pipe_name_w.as_ptr(),
+            FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+            0,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            0,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle != INVALID_HANDLE_VALUE {
+        unsafe {
+            let _ = CloseHandle(handle);
+        }
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn start_daemon_query_service(
+    _data_root: &Path,
+    _embedder: Arc<Mutex<Option<SemanticEmbedder>>>,
+) -> Result<DaemonQueryService> {
+    Err(anyhow!("daemon query service is not supported on this platform"))
+}
+
+fn handle_daemon_query_stream<S: std::io::Write>(
     data_root: &Path,
     embedder: &Arc<Mutex<Option<SemanticEmbedder>>>,
-    stream: UnixStream,
+    token: &str,
+    mut stream: S,
+    request: Result<String>,
 ) {
-    let mut stream = stream;
-    let result = handle_daemon_query_stream_inner(data_root, embedder, &mut stream);
+    let result = request.and_then(|body| {
+        handle_daemon_query_stream_inner(data_root, embedder, token, &mut stream, &body)
+    });
     if let Err(error) = result {
         let _ = writeln!(
             stream,
@@ -88,26 +786,40 @@ fn handle_daemon_query_stream(
     }
 }
 
-#[cfg(unix)]
-fn handle_daemon_query_stream_inner(
+fn handle_daemon_query_stream_inner<S: std::io::Write>(
     data_root: &Path,
     embedder: &Arc<Mutex<Option<SemanticEmbedder>>>,
-    stream: &mut UnixStream,
+    token: &str,
+    stream: &mut S,
+    body: &str,
 ) -> Result<()> {
-    let mut body = String::new();
-    stream
-        .take(256 * 1024)
-        .read_to_string(&mut body)
-        .context("read daemon query request")?;
-    let request: Value = serde_json::from_str(&body).context("parse daemon query request")?;
+    let request: Value = serde_json::from_str(body).context("parse daemon query request")?;
+    if request.get("token").and_then(Value::as_str) != Some(token) {
+        return Err(anyhow!("daemon query authentication failed"));
+    }
     let op = request.get("op").and_then(Value::as_str).unwrap_or("");
     if op == "ping" {
+        let (runtime, busy) = match embedder.try_lock() {
+            Ok(guard) => (
+                guard
+                    .as_ref()
+                    .map(|embedder| embedder.runtime_info().to_json()),
+                false,
+            ),
+            Err(std::sync::TryLockError::WouldBlock) => (None, true),
+            Err(std::sync::TryLockError::Poisoned(_)) => {
+                return Err(anyhow!("semantic embedder lock is poisoned"));
+            }
+        };
         writeln!(
             stream,
             "{}",
             serde_json::to_string(&compact_json(json!({
                 "ok": true,
                 "schema_version": 1,
+                "model_key": semantic_model_key(),
+                "embedding_runtime": runtime,
+                "busy": busy,
             })))?
         )?;
         return Ok(());
@@ -116,7 +828,7 @@ fn handle_daemon_query_stream_inner(
         return Err(anyhow!("unknown daemon query operation `{op}`"));
     }
     let model_key = request.get("model_key").and_then(Value::as_str).unwrap_or("");
-    if model_key != SEMANTIC_MODEL_KEY {
+    if model_key != semantic_model_key() {
         return Err(anyhow!("daemon query model key mismatch"));
     }
     let text = request
@@ -128,30 +840,27 @@ fn handle_daemon_query_stream_inner(
         return Err(anyhow!("daemon query text is empty"));
     }
     let started = Instant::now();
-    let mut guard = embedder
-        .lock()
-        .map_err(|_| anyhow!("semantic embedder lock is poisoned"))?;
-    if guard.is_none() {
+    {
+        let mut guard = lock_shared_semantic_embedder(embedder)?;
+        if guard.is_none() {
         let cache_dir = semantic_worker_cache_dir(data_root);
         if !semantic_model_cache_available(&cache_dir) {
             return Err(anyhow!("semantic model cache is not available to daemon query service"));
         }
-        *guard = Some(new_semantic_embedder(&cache_dir)?);
+            *guard = Some(new_semantic_embedder(&cache_dir)?);
+        }
     }
-    let embedder = guard
-        .as_mut()
-        .ok_or_else(|| anyhow!("semantic embedder was not initialized"))?;
-    let mut embeddings = embed_texts(embedder, vec![text.to_owned()])?;
-    let embedding = embeddings
-        .pop()
-        .ok_or_else(|| anyhow!("semantic query embedding was empty"))?;
+    let cache_dir = semantic_worker_cache_dir(data_root);
+    let (embedding, runtime) =
+        embed_query_with_shared_runtime(embedder, &cache_dir, text.to_owned())?;
     let query_embed_ms = started.elapsed().as_millis() as u64;
     writeln!(
         stream,
         "{}",
         serde_json::to_string(&compact_json(json!({
             "ok": true,
-            "model_key": SEMANTIC_MODEL_KEY,
+            "model_key": semantic_model_key(),
+            "embedding_runtime": runtime.to_json(),
             "query_embed_ms": query_embed_ms,
             "embedding": embedding,
         })))?
@@ -308,6 +1017,28 @@ fn print_daemon_status_human(daemon: &Value) {
             .and_then(Value::as_str)
             .unwrap_or("unknown")
     );
+    let embedding_runtime = daemon
+        .get("jobs")
+        .and_then(|jobs| jobs.get("semantic_index"))
+        .and_then(|job| job.get("embedding_runtime"));
+    if let Some(backend) = embedding_runtime
+        .and_then(|runtime| runtime.get("backend"))
+        .and_then(Value::as_str)
+    {
+        println!("semantic_embedding_backend: {backend}");
+    }
+    if let Some(compute_mode) = embedding_runtime
+        .and_then(|runtime| runtime.get("compute_mode"))
+        .and_then(Value::as_str)
+    {
+        println!("semantic_embedding_compute_mode: {compute_mode}");
+    }
+    if let Some(fallback) = embedding_runtime
+        .and_then(|runtime| runtime.get("acquisition_fallback"))
+        .and_then(Value::as_str)
+    {
+        println!("semantic_embedding_fallback: {fallback}");
+    }
     println!(
         "cloud_sync_status: {}",
         daemon
@@ -327,17 +1058,15 @@ fn run_daemon(args: DaemonRunArgs, data_root: PathBuf, config: &AppConfig) -> Re
             "daemon autostart metadata flags are internal; run `ctx daemon run` without --start-mode or --trigger-command"
         ));
     }
-    if config.semantic_search_enabled() && !semantic_query_service_supported() {
-        return Err(anyhow!(
-            "local semantic search is not supported on this platform yet. Set [search] semantic = false"
-        ));
+    let semantic_enabled = config.semantic_search_enabled() && semantic_query_service_supported();
+    if semantic_enabled {
+        lower_semantic_worker_priority();
     }
-    lower_semantic_worker_priority();
     let report = match run_daemon_inner(
         args.clone(),
         &data_root,
         config.daemon.enabled,
-        config.semantic_search_enabled(),
+        semantic_enabled,
     ) {
         Ok(report) => report,
         Err(error) => {
@@ -396,16 +1125,38 @@ fn run_daemon_inner(
     write_daemon_lifecycle_status(data_root, &args, "running", started_at_ms, None, None)?;
 
     let mut runtime = DaemonRuntime::default();
-    #[cfg(unix)]
-    let _query_service = if semantic_enabled {
+    let query_service = if semantic_enabled {
         Some(start_daemon_query_service(data_root, runtime.semantic_embedder.clone())?)
     } else {
         None
     };
     let mut idle_since: Option<Instant> = None;
+    let mut observed_query_generation = 0;
     loop {
+        observe_daemon_query_activity(
+            query_service
+                .as_ref()
+                .map(|service| service.activity.as_ref()),
+            &mut idle_since,
+            &mut observed_query_generation,
+        );
         if idle_since.is_some_and(|idle| idle.elapsed() >= idle_exit) {
-            break;
+            if daemon_can_begin_idle_shutdown(
+                query_service
+                    .as_ref()
+                    .map(|service| service.activity.as_ref()),
+                observed_query_generation,
+            ) {
+                break;
+            }
+            observe_daemon_query_activity(
+                query_service
+                    .as_ref()
+                    .map(|service| service.activity.as_ref()),
+                &mut idle_since,
+                &mut observed_query_generation,
+            );
+            continue;
         }
         let iteration = run_daemon_once(&args, data_root, &mut runtime, None, semantic_enabled)?;
         write_daemon_lifecycle_status(data_root, &args, "running", started_at_ms, None, None)?;
@@ -416,6 +1167,13 @@ fn run_daemon_inner(
         if run_once {
             break;
         }
+        observe_daemon_query_activity(
+            query_service
+                .as_ref()
+                .map(|service| service.activity.as_ref()),
+            &mut idle_since,
+            &mut observed_query_generation,
+        );
         if iteration.did_work {
             idle_since = None;
         } else if idle_since.is_none() {
@@ -432,6 +1190,10 @@ fn run_daemon_inner(
         Some(utc_now().timestamp_millis()),
         failed.then_some("one or more daemon jobs failed".to_owned()),
     )?;
+    // Keep daemon ownership until the query service has removed its endpoint
+    // and joined its listener thread. Otherwise a replacement can publish a
+    // new endpoint that this service's destructor then removes.
+    drop(query_service);
     drop(_lock);
     let semantic_report = semantic_worker_report_for_daemon(data_root);
     Ok(daemon_report_with_disabled_status(
@@ -758,16 +1520,6 @@ fn run_daemon_semantic_job(
             None,
         ));
     }
-    if before.queued_items_estimate == 0 {
-        return Ok(daemon_semantic_job_json(
-            "ready",
-            None,
-            last_run_at_ms,
-            &before,
-            None,
-            None,
-        ));
-    }
     let min_remaining_secs = if daemon_runtime_embedder_loaded(runtime) {
         DAEMON_MIN_REMAINING_FOR_JOB_SECS
     } else {
@@ -784,23 +1536,51 @@ fn run_daemon_semantic_job(
             None,
         ));
     }
-    if !before.model_cache_available && !daemon_runtime_embedder_loaded(runtime) {
+    if semantic_daemon_model_load_needed(&before, daemon_runtime_embedder_loaded(runtime)) {
         let cache_dir = semantic_worker_cache_dir(data_root);
         let _ = write_semantic_model_acquisition_status(data_root, "acquiring_model", None);
         match acquire_semantic_embedder(&cache_dir) {
             Ok(embedder) => {
                 *lock_daemon_runtime_embedder(runtime)? = Some(embedder);
+                let embedding_runtime =
+                    shared_semantic_embedder_runtime_status_json(&runtime.semantic_embedder)?;
+                let embed_policy =
+                    shared_semantic_embedder_policy_status_json(&runtime.semantic_embedder)?;
+                let _ = write_semantic_model_acquired_status(
+                    data_root,
+                    embedding_runtime,
+                    embed_policy,
+                );
+                before = semantic_worker_report(data_root, Some(&store))?;
+            }
+            Err(error) if error.downcast_ref::<SemanticModelLoadDeferred>().is_some() => {
+                let deferred = error
+                    .downcast_ref::<SemanticModelLoadDeferred>()
+                    .expect("matched semantic model load deferral");
+                let _ = write_semantic_model_load_deferred_status(data_root, deferred);
+                let report = semantic_worker_report(data_root, Some(&store))?;
+                return Ok(daemon_semantic_model_load_deferred_job(
+                    last_run_at_ms,
+                    &report,
+                    deferred,
+                ));
             }
             Err(error) => {
                 let message = format!("{error:#}");
+                let integrity_failure = semantic_model_acquisition_integrity_error(&error);
+                let failure_code = if integrity_failure {
+                    "model_integrity_failed"
+                } else {
+                    "model_acquisition_failed"
+                };
                 let _ = write_semantic_model_acquisition_status(
                     data_root,
-                    "model_acquisition_failed",
+                    failure_code,
                     Some(message.clone()),
                 );
                 return Ok(daemon_semantic_job_json(
                     "skipped",
-                    Some("model_acquisition_failed"),
+                    Some(failure_code),
                     last_run_at_ms,
                     &before,
                     None,
@@ -808,6 +1588,16 @@ fn run_daemon_semantic_job(
                 ));
             }
         }
+    }
+    if before.queued_items_estimate == 0 {
+        return Ok(daemon_semantic_job_json(
+            "ready",
+            None,
+            last_run_at_ms,
+            &before,
+            None,
+            None,
+        ));
     }
     drop(store);
 
@@ -827,11 +1617,22 @@ fn run_daemon_semantic_job(
         max_chunks: args.max_chunks,
         max_seconds: Some(worker_max_seconds),
     };
-    let worker_result = {
-        let mut embedder = lock_daemon_runtime_embedder(runtime)?;
-        run_semantic_worker_inner_with_embedder(worker_args, data_root, None, &mut embedder)
-    };
+    let worker_result = run_semantic_worker_inner_with_embedder(
+        worker_args,
+        data_root,
+        None,
+        &runtime.semantic_embedder,
+    );
     if let Err(error) = worker_result {
+        if let Some(deferred) = error.downcast_ref::<SemanticModelLoadDeferred>() {
+            let _ = write_semantic_model_load_deferred_status(data_root, deferred);
+            let report = semantic_worker_report_for_daemon(data_root);
+            return Ok(daemon_semantic_model_load_deferred_job(
+                last_run_at_ms,
+                &report,
+                deferred,
+            ));
+        }
         let message = format!("{error:#}");
         let _ = write_semantic_worker_failure_status(data_root, message.clone());
         let report = semantic_worker_report_for_daemon(data_root);
@@ -873,6 +1674,13 @@ fn daemon_semantic_requested_seconds(args: &DaemonRunArgs) -> u64 {
         max_chunks: args.max_chunks,
         max_seconds: args.max_seconds,
     })
+}
+
+fn semantic_daemon_model_load_needed(
+    report: &SemanticWorkerReport,
+    runtime_loaded: bool,
+) -> bool {
+    report.searchable_items > 0 && !runtime_loaded
 }
 
 fn daemon_semantic_worker_seconds_budget(args: &DaemonRunArgs, deadline: Option<Instant>) -> u64 {
@@ -921,14 +1729,16 @@ fn daemon_semantic_job_json(
     compact_json(json!({
         "schema_version": 1,
         "status": status,
-        "model_key": SEMANTIC_MODEL_KEY,
+        "model_key": semantic_model_key(),
         "enabled": true,
         "reason": reason,
         "last_run_at_ms": last_run_at_ms,
         "last_error": last_error,
         "indexed_chunks": indexed_chunks,
         "model_cache_available": report.model_cache_available,
+        "model_acquisition": report.model_acquisition.clone(),
         "embed_policy": report.embed_policy.clone(),
+        "embedding_runtime": report.embedding_runtime.clone(),
         "worker_status": report.status,
         "coverage": {
             "searchable_items": report.searchable_items,
@@ -939,6 +1749,26 @@ fn daemon_semantic_job_json(
             "queued_items_estimate": report.queued_items_estimate,
         },
     }))
+}
+
+fn daemon_semantic_model_load_deferred_job(
+    last_run_at_ms: i64,
+    report: &SemanticWorkerReport,
+    deferred: &SemanticModelLoadDeferred,
+) -> Value {
+    let mut value = daemon_semantic_job_json(
+        "skipped",
+        Some("memory_pressure"),
+        last_run_at_ms,
+        report,
+        None,
+        None,
+    );
+    value["retryable"] = Value::Bool(true);
+    value["available_memory_bytes"] = json!(deferred.available_memory_bytes);
+    value["required_available_memory_bytes"] =
+        json!(deferred.required_available_memory_bytes);
+    compact_json(value)
 }
 
 fn daemon_cloud_sync_disabled_job(last_run_at_ms: Option<i64>) -> Value {
@@ -982,7 +1812,7 @@ fn write_daemon_lifecycle_status(
 fn semantic_worker_report_for_daemon(data_root: &Path) -> SemanticWorkerReport {
     let db_path = database_path(data_root.to_path_buf());
     if db_path.exists() {
-        match open_existing_store_snapshot_read_only(&db_path, "ctx daemon status") {
+        match open_existing_store_read_only(&db_path, "ctx daemon status") {
             Ok(store) => {
                 return semantic_worker_report_cached(data_root, Some(&store)).unwrap_or_else(|error| {
                     SemanticWorkerReport::unavailable(data_root, format!("{error:#}"))
@@ -1003,11 +1833,14 @@ fn write_semantic_worker_failure_status(data_root: &Path, message: String) -> Re
         &json!({
             "schema_version": 1,
             "status": "failed",
-            "model_key": SEMANTIC_MODEL_KEY,
+            "model_key": semantic_model_key(),
             "pid": process::id(),
             "heartbeat_at_ms": now,
             "finished_at_ms": now,
             "last_error": message,
+            "model_acquisition": semantic_model_acquisition_status_json(
+                &semantic_worker_cache_dir(data_root),
+            ),
             "embed_policy": semantic_embed_policy_status_json(),
         }),
     )
@@ -1024,12 +1857,69 @@ fn write_semantic_model_acquisition_status(
         &json!({
             "schema_version": 1,
             "status": status,
-            "model_key": SEMANTIC_MODEL_KEY,
+            "model_key": semantic_model_key(),
             "pid": process::id(),
             "heartbeat_at_ms": now,
-            "finished_at_ms": (status == "model_acquisition_failed").then_some(now),
+            "finished_at_ms": matches!(
+                status,
+                "model_acquisition_failed" | "model_integrity_failed"
+            )
+            .then_some(now),
             "last_error": message,
+            "model_acquisition": semantic_model_acquisition_status_json(
+                &semantic_worker_cache_dir(data_root),
+            ),
             "embed_policy": semantic_embed_policy_status_json(),
+        }),
+    )
+}
+
+fn write_semantic_model_load_deferred_status(
+    data_root: &Path,
+    deferred: &SemanticModelLoadDeferred,
+) -> Result<()> {
+    let now = utc_now().timestamp_millis();
+    write_semantic_worker_status(
+        data_root,
+        &compact_json(json!({
+            "schema_version": 1,
+            "status": "model_load_deferred",
+            "model_key": semantic_model_key(),
+            "pid": process::id(),
+            "heartbeat_at_ms": now,
+            "finished_at_ms": now,
+            "last_error": null,
+            "retryable": true,
+            "available_memory_bytes": deferred.available_memory_bytes,
+            "required_available_memory_bytes": deferred.required_available_memory_bytes,
+            "model_acquisition": semantic_model_acquisition_status_json(
+                &semantic_worker_cache_dir(data_root),
+            ),
+            "embed_policy": semantic_embed_policy_status_json(),
+        })),
+    )
+}
+
+fn write_semantic_model_acquired_status(
+    data_root: &Path,
+    embedding_runtime: Option<Value>,
+    embed_policy: Value,
+) -> Result<()> {
+    let now = utc_now().timestamp_millis();
+    write_semantic_worker_status(
+        data_root,
+        &json!({
+            "schema_version": 1,
+            "status": "model_acquired",
+            "model_key": semantic_model_key(),
+            "pid": process::id(),
+            "heartbeat_at_ms": now,
+            "finished_at_ms": now,
+            "model_acquisition": semantic_model_acquisition_status_json(
+                &semantic_worker_cache_dir(data_root),
+            ),
+            "embedding_runtime": embedding_runtime,
+            "embed_policy": embed_policy,
         }),
     )
 }
@@ -1038,7 +1928,7 @@ fn run_semantic_worker_inner_with_embedder(
     args: SemanticWorkerArgs,
     data_root: &Path,
     query_hint: Option<String>,
-    embedder: &mut Option<SemanticEmbedder>,
+    embedder: &Arc<Mutex<Option<SemanticEmbedder>>>,
 ) -> Result<()> {
     let Some(_lock) = SemanticWorkerLock::acquire(data_root)? else {
         return Ok(());
@@ -1051,7 +1941,9 @@ fn run_semantic_worker_inner_with_embedder(
         ));
     }
     let cache_dir = semantic_worker_cache_dir(data_root);
-    if embedder.is_none() && !semantic_model_cache_available(&cache_dir) {
+    if lock_shared_semantic_embedder(embedder)?.is_none()
+        && !semantic_model_cache_available(&cache_dir)
+    {
         return Err(anyhow!(
             "semantic model is not available in the local cache; background indexing will not initialize or download {SEMANTIC_MODEL_ID}"
         ));
@@ -1074,13 +1966,14 @@ fn run_semantic_worker_inner_with_embedder(
         semantic_worker_status_was_ready_for_stats(data_root, initial_stats);
     let continue_past_indexed_pages = !was_ready_before_worker
         || initial_queued_items_estimate > SEMANTIC_DIRTY_QUEUE_RECENT_LIMIT;
-    let starting_embed_policy = semantic_embedder_policy_status_json(embedder);
+    let starting_embed_policy = shared_semantic_embedder_policy_status_json(embedder)?;
+    let starting_embedding_runtime = shared_semantic_embedder_runtime_status_json(embedder)?;
     write_semantic_worker_status(
         data_root,
         &json!({
             "schema_version": 1,
             "status": "running",
-            "model_key": SEMANTIC_MODEL_KEY,
+            "model_key": semantic_model_key(),
             "pid": process::id(),
             "started_at_ms": started_at_ms,
             "heartbeat_at_ms": started_at_ms,
@@ -1092,6 +1985,7 @@ fn run_semantic_worker_inner_with_embedder(
             "embedded_chunks": initial_stats.embedded_chunks,
             "dirty_items": initial_dirty_items,
             "embed_policy": starting_embed_policy,
+            "embedding_runtime": starting_embedding_runtime,
             "last_error": null,
         }),
     )?;
@@ -1117,7 +2011,8 @@ fn run_semantic_worker_inner_with_embedder(
         )?
     };
     let elapsed = started.elapsed();
-    let finished_embed_policy = semantic_embedder_policy_status_json(embedder);
+    let finished_embed_policy = shared_semantic_embedder_policy_status_json(embedder)?;
+    let finished_embedding_runtime = shared_semantic_embedder_runtime_status_json(embedder)?;
     let elapsed_ms = elapsed.as_millis() as u64;
     let final_stats = vector_store
         .cached_stats()?
@@ -1142,7 +2037,7 @@ fn run_semantic_worker_inner_with_embedder(
         &json!({
             "schema_version": 1,
             "status": status,
-            "model_key": SEMANTIC_MODEL_KEY,
+            "model_key": semantic_model_key(),
             "pid": process::id(),
             "started_at_ms": started_at_ms,
             "heartbeat_at_ms": finished_at_ms,
@@ -1157,6 +2052,7 @@ fn run_semantic_worker_inner_with_embedder(
             "embedded_chunks": final_stats.embedded_chunks,
             "dirty_items": final_dirty_items,
             "embed_policy": finished_embed_policy,
+            "embedding_runtime": finished_embedding_runtime,
             "last_error": null,
         }),
     )?;
@@ -1339,51 +2235,24 @@ fn maybe_autostart_daemon_inner(
 }
 
 pub(crate) fn semantic_query_service_supported() -> bool {
-    cfg!(all(unix, ctx_semantic_fastembed, ctx_sqlite_vec))
+    cfg!(ctx_semantic_fastembed)
 }
 
-#[cfg(unix)]
 pub(crate) fn daemon_query_service_available(data_root: &Path) -> bool {
-    let path = daemon_query_socket_path(data_root);
-    if !path.exists() {
-        return false;
-    }
-    let Ok(mut stream) = UnixStream::connect(path) else {
-        return false;
-    };
-    let _ = stream.set_read_timeout(Some(StdDuration::from_secs(1)));
-    let _ = stream.set_write_timeout(Some(StdDuration::from_secs(1)));
-    if writeln!(
-        stream,
-        "{}",
-        serde_json::to_string(&compact_json(json!({
+    let response = daemon_query_request(
+        data_root,
+        compact_json(json!({
             "schema_version": 1,
             "op": "ping",
-        })))
-        .unwrap_or_else(|_| "{\"schema_version\":1,\"op\":\"ping\"}".to_owned())
-    )
-    .is_err()
-    {
-        return false;
-    }
-    let _ = stream.shutdown(Shutdown::Write);
-    let mut body = String::new();
-    if stream
-        .take(1024)
-        .read_to_string(&mut body)
-        .is_err()
-    {
-        return false;
-    }
-    serde_json::from_str::<Value>(&body)
+        })),
+        StdDuration::from_secs(1),
+        1024,
+    );
+    response
         .ok()
+        .flatten()
         .and_then(|value| value.get("ok").and_then(Value::as_bool))
         == Some(true)
-}
-
-#[cfg(not(unix))]
-pub(crate) fn daemon_query_service_available(_data_root: &Path) -> bool {
-    false
 }
 
 pub(crate) fn wait_for_daemon_query_service(data_root: &Path, timeout: StdDuration) -> bool {

--- a/crates/ctx-cli/src/semantic/embedding_backend.rs
+++ b/crates/ctx-cli/src/semantic/embedding_backend.rs
@@ -1,0 +1,1361 @@
+const SEMANTIC_BACKEND_PREFERENCE_ENV: &str = "CTX_INTERNAL_SEMANTIC_BACKEND";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SemanticModelAccess {
+    ForegroundCacheOnly,
+    DaemonNetwork,
+}
+
+impl SemanticModelAccess {
+    fn network_allowed(self) -> bool {
+        self == Self::DaemonNetwork
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackendPreference {
+    Auto,
+    Cpu,
+    CoreMl,
+}
+
+impl BackendPreference {
+    fn from_env() -> Result<Self> {
+        Self::parse(env::var(SEMANTIC_BACKEND_PREFERENCE_ENV).ok().as_deref())
+    }
+
+    fn parse(value: Option<&str>) -> Result<Self> {
+        match value.map(str::trim).filter(|value| !value.is_empty()) {
+            None | Some("auto") => Ok(Self::Auto),
+            Some("cpu") => Ok(Self::Cpu),
+            Some("coreml") => Ok(Self::CoreMl),
+            Some(value) => Err(anyhow!(
+                "unsupported {SEMANTIC_BACKEND_PREFERENCE_ENV} value {value:?}; expected auto, cpu, or coreml"
+            )),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Cpu => "cpu",
+            Self::CoreMl => "coreml",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SemanticEmbeddingRuntimeInfo {
+    preference: BackendPreference,
+    backend: &'static str,
+    compute_class: SemanticComputeClass,
+    compute_mode: Option<&'static str>,
+    acquisition_source: &'static str,
+    acquisition_fallback: Option<&'static str>,
+}
+
+impl SemanticEmbeddingRuntimeInfo {
+    fn to_json(&self) -> Value {
+        compact_json(json!({
+            "preference": self.preference.as_str(),
+            "backend": self.backend,
+            "compute_class": self.compute_class.as_str(),
+            "compute_mode": self.compute_mode,
+            "model_id": SEMANTIC_MODEL_ID,
+            "model_key": semantic_model_key(),
+            "dimensions": SEMANTIC_DIMENSIONS,
+            "acquisition_source": self.acquisition_source,
+            "acquisition_fallback": self.acquisition_fallback,
+        }))
+    }
+}
+
+#[cfg(ctx_semantic_fastembed)]
+enum SemanticEmbeddingBackend {
+    Cpu(fastembed::TextEmbedding),
+    #[cfg(target_os = "macos")]
+    CoreMl(CoreMlE5Embedder),
+}
+
+#[cfg(ctx_semantic_fastembed)]
+impl SemanticEmbeddingBackend {
+    fn embed_query(&mut self, query: String) -> Result<Vec<f32>> {
+        let query = semantic_e5_query_text_value(&query);
+        let raw = match self {
+            Self::Cpu(model) => model
+                .embed(vec![query], Some(1))
+                .with_context(|| format!("embed query with semantic model {SEMANTIC_MODEL_ID}"))?,
+            #[cfg(target_os = "macos")]
+            Self::CoreMl(model) => vec![model.embed_query(query)?],
+        };
+        let mut embeddings = normalize_and_validate_embeddings(raw, 1)?;
+        embeddings
+            .pop()
+            .ok_or_else(|| anyhow!("semantic query embedding was empty"))
+    }
+
+    fn embed_documents(
+        &mut self,
+        documents: Vec<String>,
+        batch_size: usize,
+    ) -> Result<Vec<Vec<f32>>> {
+        let expected = documents.len();
+        if expected == 0 {
+            return Ok(Vec::new());
+        }
+        let documents = documents
+            .into_iter()
+            .map(|text| semantic_e5_passage_text(&text))
+            .collect::<Vec<_>>();
+        let raw = match self {
+            Self::Cpu(model) => model.embed(documents, Some(batch_size)).with_context(|| {
+                format!("embed documents with semantic model {SEMANTIC_MODEL_ID}")
+            })?,
+            #[cfg(target_os = "macos")]
+            Self::CoreMl(model) => model.embed_documents(documents)?,
+        };
+        normalize_and_validate_embeddings(raw, expected)
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Cpu(_) => "cpu",
+            #[cfg(target_os = "macos")]
+            Self::CoreMl(_) => "coreml",
+        }
+    }
+
+    fn compute_class(&self) -> SemanticComputeClass {
+        match self {
+            Self::Cpu(_) => SemanticComputeClass::Cpu,
+            #[cfg(target_os = "macos")]
+            Self::CoreMl(model) => model.compute_class,
+        }
+    }
+
+    fn compute_mode(&self) -> Option<&'static str> {
+        match self {
+            Self::Cpu(_) => None,
+            #[cfg(target_os = "macos")]
+            Self::CoreMl(model) => Some(model.compute_mode),
+        }
+    }
+}
+
+#[cfg(ctx_semantic_fastembed)]
+struct SemanticEmbedder {
+    backend: SemanticEmbeddingBackend,
+    batch_size: usize,
+    policy: SemanticEmbedPolicy,
+    preference: BackendPreference,
+    acquisition_source: &'static str,
+    acquisition_fallback: Option<&'static str>,
+}
+
+#[cfg(ctx_semantic_fastembed)]
+impl SemanticEmbedder {
+    fn embed_query(&mut self, query: String) -> Result<Vec<f32>> {
+        self.backend.embed_query(query)
+    }
+
+    fn embed_documents(&mut self, documents: Vec<String>) -> Result<Vec<Vec<f32>>> {
+        self.backend.embed_documents(documents, self.batch_size)
+    }
+
+    fn runtime_info(&self) -> SemanticEmbeddingRuntimeInfo {
+        SemanticEmbeddingRuntimeInfo {
+            preference: self.preference,
+            backend: self.backend.name(),
+            compute_class: self.backend.compute_class(),
+            compute_mode: self.backend.compute_mode(),
+            acquisition_source: self.acquisition_source,
+            acquisition_fallback: self.acquisition_fallback,
+        }
+    }
+
+    fn quiet_policy(&self) -> SemanticQuietPolicy {
+        semantic_quiet_policy(
+            SemanticSystemResources::current(),
+            self.backend.compute_class(),
+        )
+    }
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn normalize_and_validate_embeddings(
+    mut embeddings: Vec<Vec<f32>>,
+    expected_count: usize,
+) -> Result<Vec<Vec<f32>>> {
+    if embeddings.len() != expected_count {
+        return Err(anyhow!(
+            "semantic model returned {} embeddings, expected {expected_count}",
+            embeddings.len()
+        ));
+    }
+    for embedding in &mut embeddings {
+        if embedding.len() != SEMANTIC_DIMENSIONS {
+            return Err(anyhow!(
+                "semantic model returned {} dimensions, expected {}",
+                embedding.len(),
+                SEMANTIC_DIMENSIONS
+            ));
+        }
+        if embedding.iter().any(|value| !value.is_finite()) {
+            return Err(anyhow!(
+                "semantic model returned a non-finite embedding value"
+            ));
+        }
+        let norm = embedding
+            .iter()
+            .map(|value| f64::from(*value) * f64::from(*value))
+            .sum::<f64>()
+            .sqrt();
+        if !norm.is_finite() || norm <= f64::EPSILON {
+            return Err(anyhow!("semantic model returned a zero-norm embedding"));
+        }
+        for value in embedding {
+            *value = (f64::from(*value) / norm) as f32;
+        }
+    }
+    Ok(embeddings)
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn new_semantic_embedder(cache_dir: &Path) -> Result<SemanticEmbedder> {
+    acquire_semantic_embedder_with_mode(cache_dir, SemanticModelAccess::ForegroundCacheOnly)
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn acquire_semantic_embedder(cache_dir: &Path) -> Result<SemanticEmbedder> {
+    acquire_semantic_embedder_with_mode(cache_dir, SemanticModelAccess::DaemonNetwork)
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn acquire_semantic_embedder_with_mode(
+    cache_dir: &Path,
+    access: SemanticModelAccess,
+) -> Result<SemanticEmbedder> {
+    let preference = BackendPreference::from_env()?;
+    match preference {
+        BackendPreference::Cpu => acquire_cpu_backend(
+            cache_dir,
+            semantic_embed_policy_for(SemanticComputeClass::Cpu),
+            preference,
+            access.network_allowed(),
+        ),
+        BackendPreference::CoreMl => {
+            acquire_coreml_backend(cache_dir, preference, None, access.network_allowed())
+        }
+        BackendPreference::Auto => {
+            #[cfg(target_os = "macos")]
+            match acquire_coreml_backend(cache_dir, preference, None, access.network_allowed()) {
+                Ok(embedder) => return Ok(embedder),
+                Err(error) if model_acquisition_integrity_error(&error) => return Err(error),
+                Err(error) => {
+                    let fallback = coreml_fallback_reason(&error);
+                    return acquire_cpu_backend(
+                        cache_dir,
+                        semantic_embed_policy_for(SemanticComputeClass::Cpu),
+                        preference,
+                        access.network_allowed(),
+                    )
+                    .map(|mut embedder| {
+                        embedder.acquisition_fallback = Some(fallback);
+                        embedder
+                    });
+                }
+            }
+            #[cfg(not(target_os = "macos"))]
+            acquire_cpu_backend(
+                cache_dir,
+                semantic_embed_policy_for(SemanticComputeClass::Cpu),
+                preference,
+                access.network_allowed(),
+            )
+        }
+    }
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn reacquire_semantic_embedder(
+    cache_dir: &Path,
+    runtime: &SemanticEmbeddingRuntimeInfo,
+) -> Result<SemanticEmbedder> {
+    match runtime.backend {
+        "cpu" => acquire_cpu_backend(
+            cache_dir,
+            semantic_embed_policy_for(SemanticComputeClass::Cpu),
+            runtime.preference,
+            false,
+        )
+        .map(|mut embedder| {
+            embedder.acquisition_fallback = runtime.acquisition_fallback;
+            embedder
+        }),
+        "coreml" => acquire_coreml_backend(
+            cache_dir,
+            runtime.preference,
+            runtime.acquisition_fallback,
+            false,
+        ),
+        backend => Err(anyhow!(
+            "cannot reacquire unsupported semantic backend {backend:?}"
+        )),
+    }
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn acquire_cpu_backend(
+    cache_dir: &Path,
+    policy: SemanticEmbedPolicy,
+    preference: BackendPreference,
+    allow_download: bool,
+) -> Result<SemanticEmbedder> {
+    if let Some(deferred) = semantic_cpu_model_load_deferred(policy.available_memory_bytes) {
+        return Err(deferred.into());
+    }
+    if env::var_os("CTX_SEMANTIC_MODEL_ONNX").is_some() {
+        return Err(anyhow!(
+            "CTX_SEMANTIC_MODEL_ONNX is no longer accepted; CPU embeddings use the verified {SEMANTIC_MODEL_ID} cache"
+        ));
+    }
+    let (snapshot, downloaded) = match semantic_cpu_cache_snapshot(cache_dir) {
+        Ok(snapshot) => (snapshot, false),
+        Err(error) if allow_download && semantic_cpu_cache_repairable(&error) => (
+            replace_cpu_model_cache_from_pinned_revision(cache_dir)?,
+            true,
+        ),
+        Err(error) => return Err(error),
+    };
+    let model = load_cached_cpu_model(&snapshot, cache_dir, &policy)?;
+    Ok(SemanticEmbedder {
+        backend: SemanticEmbeddingBackend::Cpu(model),
+        batch_size: policy.batch_size,
+        policy,
+        preference,
+        acquisition_source: if downloaded { "download" } else { "cache" },
+        acquisition_fallback: None,
+    })
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn load_cached_cpu_model(
+    snapshot: &Path,
+    cache_dir: &Path,
+    policy: &SemanticEmbedPolicy,
+) -> Result<fastembed::TextEmbedding> {
+    use fastembed::{
+        EmbeddingModel, InitOptionsUserDefined, Pooling, TextEmbedding, TokenizerFiles,
+        UserDefinedEmbeddingModel,
+    };
+
+    let _runtime = ensure_semantic_onnxruntime_loaded(cache_dir)?;
+    let model_info = TextEmbedding::get_model_info(&EmbeddingModel::MultilingualE5Small)?;
+    let tokenizer_files = TokenizerFiles {
+        tokenizer_file: read_semantic_model_file(snapshot, "tokenizer.json")?,
+        config_file: read_semantic_model_file(snapshot, "config.json")?,
+        special_tokens_map_file: read_semantic_model_file(snapshot, "special_tokens_map.json")?,
+        tokenizer_config_file: read_semantic_model_file(snapshot, "tokenizer_config.json")?,
+    };
+    let model_path = snapshot.join(&model_info.model_file);
+    let mut user_model = UserDefinedEmbeddingModel::new(
+        fs::read(&model_path)
+            .with_context(|| format!("read semantic model file {}", model_path.display()))?,
+        tokenizer_files,
+    )
+    .with_pooling(
+        TextEmbedding::get_default_pooling_method(&EmbeddingModel::MultilingualE5Small)
+            .unwrap_or(Pooling::Mean),
+    )
+    .with_quantization(TextEmbedding::get_quantization_mode(
+        &EmbeddingModel::MultilingualE5Small,
+    ));
+    user_model.output_key = model_info.output_key.clone();
+    TextEmbedding::try_new_from_user_defined(
+        user_model,
+        InitOptionsUserDefined::new().with_intra_threads(policy.threads),
+    )
+    .with_context(|| format!("initialize semantic embedding model {SEMANTIC_MODEL_ID}"))
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn semantic_cpu_cache_snapshot(cache_dir: &Path) -> Result<PathBuf> {
+    let mut repairable_error = None;
+    for model_root in semantic_model_cache_roots(cache_dir) {
+        let snapshot = model_root.join("snapshots").join(SEMANTIC_MODEL_REVISION);
+        match fs::metadata(&snapshot) {
+            Ok(metadata) if metadata.is_dir() => match verify_semantic_cpu_snapshot(&snapshot) {
+                Ok(()) => return Ok(snapshot),
+                Err(error) if semantic_cpu_cache_repairable(&error) => {
+                    repairable_error.get_or_insert(error);
+                }
+                Err(error) => return Err(error),
+            },
+            Ok(_) => {
+                repairable_error.get_or_insert_with(|| {
+                    SemanticCpuModelIntegrityError(format!(
+                        "semantic CPU model snapshot {} is not a directory",
+                        snapshot.display()
+                    ))
+                    .into()
+                });
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("inspect semantic model cache {}", snapshot.display())
+                });
+            }
+        }
+    }
+    Err(repairable_error.unwrap_or_else(|| {
+        SemanticCpuModelCacheMissing(format!(
+            "semantic model cache is incomplete at {}",
+            cache_dir.display()
+        ))
+        .into()
+    }))
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn semantic_cpu_cache_repairable(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<SemanticCpuModelCacheMissing>()
+        .is_some()
+        || error
+            .downcast_ref::<SemanticCpuModelIntegrityError>()
+            .is_some()
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn verify_semantic_cpu_snapshot(snapshot: &Path) -> Result<()> {
+    for expected in SEMANTIC_REQUIRED_MODEL_FILES {
+        verify_semantic_cpu_file(&snapshot.join(expected.path), *expected)?;
+    }
+    Ok(())
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn verify_semantic_cpu_file(path: &Path, expected: SemanticModelFile) -> Result<()> {
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(SemanticCpuModelCacheMissing(format!(
+                "semantic CPU model file {} is missing",
+                path.display()
+            ))
+            .into());
+        }
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("inspect semantic CPU model file {}", path.display()));
+        }
+    };
+    if !metadata.is_file() || metadata.len() != expected.size {
+        return Err(SemanticCpuModelIntegrityError(format!(
+            "semantic CPU model file {} has size {}, expected {}",
+            path.display(),
+            metadata.len(),
+            expected.size
+        ))
+        .into());
+    }
+    let mut file = match fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(SemanticCpuModelCacheMissing(format!(
+                "semantic CPU model file {} disappeared during verification",
+                path.display()
+            ))
+            .into());
+        }
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("open semantic CPU model file {}", path.display()));
+        }
+    };
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 128 * 1024];
+    loop {
+        let count = file
+            .read(&mut buffer)
+            .with_context(|| format!("read semantic CPU model file {}", path.display()))?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    let actual = format!("{:x}", hasher.finalize());
+    if actual != expected.sha256 {
+        return Err(SemanticCpuModelIntegrityError(format!(
+            "semantic CPU model file {} has SHA-256 {actual}, expected {}",
+            path.display(),
+            expected.sha256
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn replace_cpu_model_cache_from_pinned_revision(cache_dir: &Path) -> Result<PathBuf> {
+    use hf_hub::{api::sync::ApiBuilder, Repo, RepoType};
+
+    let managed_root = cache_dir.join(SEMANTIC_MANAGED_MODEL_CACHE_DIR);
+    fs::create_dir_all(&managed_root)
+        .with_context(|| format!("create semantic model cache {}", managed_root.display()))?;
+    let _lock = lock_semantic_model_acquisition(&managed_root)?;
+
+    match semantic_cpu_cache_snapshot(cache_dir) {
+        Ok(snapshot) => return Ok(snapshot),
+        Err(error) if semantic_cpu_cache_repairable(&error) => {}
+        Err(error) => return Err(error),
+    }
+
+    let download_cache = managed_root.join("download-cache");
+    let model_root = managed_root.join(SEMANTIC_HF_MODEL_CACHE_DIR);
+    let mut verified_staging_root = None;
+    for attempt in 0..2 {
+        if attempt > 0 && download_cache.exists() {
+            fs::remove_dir_all(&download_cache).with_context(|| {
+                format!(
+                    "discard corrupt ctx-managed model download cache {}",
+                    download_cache.display()
+                )
+            })?;
+        }
+        fs::create_dir_all(&download_cache).with_context(|| {
+            format!(
+                "create semantic model download cache {}",
+                download_cache.display()
+            )
+        })?;
+        let api = ApiBuilder::new()
+            .with_cache_dir(download_cache.clone())
+            .with_progress(false)
+            .build()
+            .context("initialize pinned semantic model downloader")?;
+        let repo = api.repo(Repo::with_revision(
+            SEMANTIC_MODEL_ID.to_owned(),
+            RepoType::Model,
+            SEMANTIC_MODEL_REVISION.to_owned(),
+        ));
+        let staging_root = managed_root.join(format!(
+            ".{SEMANTIC_HF_MODEL_CACHE_DIR}.staging-{}",
+            Uuid::new_v4().simple()
+        ));
+        let staging_snapshot = staging_root.join("snapshots").join(SEMANTIC_MODEL_REVISION);
+        let staged = (|| -> Result<()> {
+            for expected in SEMANTIC_REQUIRED_MODEL_FILES {
+                let downloaded = repo.download(expected.path).with_context(|| {
+                    format!(
+                        "download {SEMANTIC_MODEL_ID}@{SEMANTIC_MODEL_REVISION}/{}",
+                        expected.path
+                    )
+                })?;
+                let destination = staging_snapshot.join(expected.path);
+                if let Some(parent) = destination.parent() {
+                    fs::create_dir_all(parent).with_context(|| {
+                        format!(
+                            "create semantic model staging directory {}",
+                            parent.display()
+                        )
+                    })?;
+                }
+                fs::copy(&downloaded, &destination).with_context(|| {
+                    format!(
+                        "stage semantic model file {} at {}",
+                        downloaded.display(),
+                        destination.display()
+                    )
+                })?;
+            }
+            verify_semantic_cpu_snapshot(&staging_snapshot).with_context(|| {
+                format!(
+                    "downloaded semantic CPU model failed verification in {}",
+                    staging_snapshot.display()
+                )
+            })
+        })();
+        match staged {
+            Ok(()) => {
+                verified_staging_root = Some(staging_root);
+                break;
+            }
+            Err(error) if attempt == 0 && semantic_cpu_cache_repairable(&error) => {
+                let _ = fs::remove_dir_all(&staging_root);
+            }
+            Err(error) => {
+                let _ = fs::remove_dir_all(&staging_root);
+                return Err(error);
+            }
+        }
+    }
+    let staging_root = verified_staging_root.ok_or_else(|| {
+        anyhow!("semantic CPU model download did not produce a verified snapshot")
+    })?;
+
+    if let Err(error) = publish_semantic_cpu_model_root(&staging_root, &model_root) {
+        let _ = fs::remove_dir_all(&staging_root);
+        return Err(error);
+    }
+    Ok(model_root.join("snapshots").join(SEMANTIC_MODEL_REVISION))
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn lock_semantic_model_acquisition(managed_root: &Path) -> Result<fs::File> {
+    use fs2::FileExt;
+
+    fs::create_dir_all(managed_root)
+        .with_context(|| format!("create semantic model cache {}", managed_root.display()))?;
+    let lock_path = managed_root.join("acquisition.lock");
+    let lock = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .with_context(|| {
+            format!(
+                "open semantic model acquisition lock {}",
+                lock_path.display()
+            )
+        })?;
+    lock.lock_exclusive()
+        .with_context(|| format!("lock semantic model acquisition {}", lock_path.display()))?;
+    Ok(lock)
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn publish_semantic_cpu_model_root(staging_root: &Path, model_root: &Path) -> Result<()> {
+    let managed_root = model_root
+        .parent()
+        .ok_or_else(|| anyhow!("semantic model root has no parent"))?;
+    let backup_root = managed_root.join(format!(
+        ".{SEMANTIC_HF_MODEL_CACHE_DIR}.backup-{}",
+        Uuid::new_v4().simple()
+    ));
+    let had_previous = model_root.exists();
+    if had_previous {
+        fs::rename(model_root, &backup_root).with_context(|| {
+            format!(
+                "preserve previous semantic model cache {}",
+                model_root.display()
+            )
+        })?;
+    }
+    if let Err(error) = fs::rename(staging_root, model_root) {
+        let restore = if had_previous {
+            fs::rename(&backup_root, model_root).err()
+        } else {
+            None
+        };
+        return Err(anyhow!(match restore {
+            Some(restore) => format!(
+                "publish semantic model cache {}: {error}; restore previous cache: {restore}",
+                model_root.display()
+            ),
+            None => format!(
+                "publish semantic model cache {}: {error}",
+                model_root.display()
+            ),
+        }));
+    }
+    if had_previous {
+        // Publication is already committed. A cleanup failure must not turn a
+        // valid model into a retry loop; a later acquisition may remove it.
+        let _ = fs::remove_dir_all(&backup_root);
+    }
+    Ok(())
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn read_semantic_model_file(snapshot: &Path, relative: &str) -> Result<Vec<u8>> {
+    let path = snapshot.join(relative);
+    fs::read(&path).with_context(|| format!("read semantic model file {}", path.display()))
+}
+
+#[cfg(all(ctx_semantic_fastembed, not(target_os = "macos")))]
+fn acquire_coreml_backend(
+    _cache_dir: &Path,
+    _preference: BackendPreference,
+    _fallback: Option<&'static str>,
+    _allow_download: bool,
+) -> Result<SemanticEmbedder> {
+    Err(anyhow!("Core ML semantic embeddings require macOS"))
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+fn acquire_coreml_backend(
+    cache_dir: &Path,
+    preference: BackendPreference,
+    fallback: Option<&'static str>,
+    allow_download: bool,
+) -> Result<SemanticEmbedder> {
+    let compute = coreml_compute_units_from_env()?;
+    if let Some(deferred) = semantic_model_load_deferred(
+        SemanticSystemResources::current().available_memory_bytes,
+        compute.compute_class,
+    ) {
+        return Err(deferred.into());
+    }
+    let acquired = if allow_download {
+        Some(acquire_coreml_bundle_for_daemon(cache_dir)?)
+    } else {
+        None
+    };
+    let model = CoreMlE5Embedder::acquire(cache_dir, acquired, compute)?;
+    let policy = semantic_embed_policy_for(model.compute_class);
+    let acquisition_source = model.acquisition_source;
+    Ok(SemanticEmbedder {
+        batch_size: model.document.batch_size.min(policy.batch_size).max(1),
+        backend: SemanticEmbeddingBackend::CoreMl(model),
+        policy,
+        preference,
+        acquisition_source,
+        acquisition_fallback: fallback,
+    })
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+fn coreml_fallback_reason(error: &anyhow::Error) -> &'static str {
+    match model_acquisition_error_kind(error) {
+        Some(ModelAcquisitionErrorKind::Unavailable) if !coreml_descriptor_provisioned() => {
+            "descriptor_unprovisioned"
+        }
+        Some(ModelAcquisitionErrorKind::Unavailable) => "coreml_unavailable",
+        Some(ModelAcquisitionErrorKind::Integrity) => "integrity_failure",
+        None => "coreml_load_error",
+    }
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+struct CoreMlRoleModel {
+    model: coreml_native::Model,
+    batch_size: usize,
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+struct CoreMlE5Embedder {
+    document: CoreMlRoleModel,
+    query: Option<CoreMlRoleModel>,
+    tokenizer: tokenizers::Tokenizer,
+    sequence_length: usize,
+    acquisition_source: &'static str,
+    compute_class: SemanticComputeClass,
+    compute_mode: &'static str,
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+impl CoreMlE5Embedder {
+    fn acquire(
+        cache_dir: &Path,
+        acquired: Option<AcquiredCoreMlBundle>,
+        compute: CoreMlComputeConfig,
+    ) -> Result<Self> {
+        let acquired = match acquired {
+            Some(acquired) => acquired,
+            None => AcquiredCoreMlBundle {
+                bundle: cached_coreml_bundle(cache_dir)?.ok_or_else(|| {
+                    anyhow!("verified Core ML model bundle is not available in the local cache")
+                })?,
+                source: CoreMlAcquisitionSource::Cache,
+            },
+        };
+        let bundle = acquired.bundle;
+        validate_coreml_bundle_identity(&bundle)?;
+        let query_path = bundle.query_model_path();
+        let document_model = load_coreml_role_model(
+            &bundle.document_model_path(),
+            cache_dir,
+            &bundle.manifest_sha256,
+            "document",
+            compute.units,
+            bundle.manifest.tensor_contract.document_batch_size as usize,
+            bundle.manifest.tensor_contract.max_sequence_length as usize,
+        )?;
+        let query_batch_size = bundle.manifest.tensor_contract.query_batch_size;
+        let query_model = query_path
+            .map(|path| {
+                let expected_batch_size = query_batch_size.ok_or_else(|| {
+                    anyhow!("Core ML query model has no signed query batch contract")
+                })? as usize;
+                load_coreml_role_model(
+                    &path,
+                    cache_dir,
+                    &bundle.manifest_sha256,
+                    "query",
+                    compute.units,
+                    expected_batch_size,
+                    bundle.manifest.tensor_contract.max_sequence_length as usize,
+                )
+            })
+            .transpose()?;
+        let sequence_length = bundle.manifest.tensor_contract.max_sequence_length as usize;
+        let tokenizer = load_coreml_tokenizer(&bundle.tokenizer_path(), sequence_length)?;
+        Ok(Self {
+            document: document_model,
+            query: query_model,
+            tokenizer,
+            sequence_length,
+            acquisition_source: match acquired.source {
+                CoreMlAcquisitionSource::Cache => "cache",
+                CoreMlAcquisitionSource::Download => "download",
+            },
+            compute_class: compute.compute_class,
+            compute_mode: compute.mode,
+        })
+    }
+
+    fn embed_query(&self, query: String) -> Result<Vec<f32>> {
+        let model = self.query.as_ref().unwrap_or(&self.document);
+        let mut embeddings = self.embed_role(model, vec![query], SEMANTIC_QUERY_PREFIX)?;
+        embeddings
+            .pop()
+            .ok_or_else(|| anyhow!("native Core ML query embedding was empty"))
+    }
+
+    fn embed_documents(&self, documents: Vec<String>) -> Result<Vec<Vec<f32>>> {
+        self.embed_role(&self.document, documents, SEMANTIC_PASSAGE_PREFIX)
+    }
+
+    fn embed_role(
+        &self,
+        role_model: &CoreMlRoleModel,
+        texts: Vec<String>,
+        padding_text: &str,
+    ) -> Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+        let original_len = texts.len();
+        let texts = pad_role_batch(texts, role_model.batch_size, padding_text)?;
+        let mut embeddings = Vec::with_capacity(texts.len());
+        for batch in texts.chunks(role_model.batch_size) {
+            embeddings.extend(self.embed_batch(&role_model.model, batch)?);
+        }
+        embeddings.truncate(original_len);
+        Ok(embeddings)
+    }
+
+    fn embed_batch(&self, model: &coreml_native::Model, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        use coreml_native::{AsMultiArray, BorrowedTensor};
+
+        let encodings = self
+            .tokenizer
+            .encode_batch(texts.to_vec(), true)
+            .map_err(|error| anyhow!("tokenize native Core ML batch: {error}"))?;
+        let batch_size = encodings.len();
+        let element_count = batch_size.saturating_mul(self.sequence_length);
+        let mut input_ids = Vec::with_capacity(element_count);
+        let mut attention_mask = Vec::with_capacity(element_count);
+        let mut token_type_ids = Vec::with_capacity(element_count);
+        for encoding in encodings {
+            if encoding.len() != self.sequence_length {
+                return Err(anyhow!(
+                    "native Core ML tokenizer returned sequence length {}, expected {}",
+                    encoding.len(),
+                    self.sequence_length
+                ));
+            }
+            input_ids.extend(encoding.get_ids().iter().map(|value| *value as i32));
+            attention_mask.extend(
+                encoding
+                    .get_attention_mask()
+                    .iter()
+                    .map(|value| *value as i32),
+            );
+            token_type_ids.extend(encoding.get_type_ids().iter().map(|value| *value as i32));
+        }
+        let shape = [batch_size, self.sequence_length];
+        let input_ids = BorrowedTensor::from_i32(&input_ids, &shape)
+            .map_err(|error| anyhow!("create Core ML input_ids: {error}"))?;
+        let attention_mask = BorrowedTensor::from_i32(&attention_mask, &shape)
+            .map_err(|error| anyhow!("create Core ML attention_mask: {error}"))?;
+        let token_type_ids = BorrowedTensor::from_i32(&token_type_ids, &shape)
+            .map_err(|error| anyhow!("create Core ML token_type_ids: {error}"))?;
+        let inputs: [(&str, &dyn AsMultiArray); 3] = [
+            ("input_ids", &input_ids),
+            ("attention_mask", &attention_mask),
+            ("token_type_ids", &token_type_ids),
+        ];
+        let prediction = model
+            .predict(&inputs)
+            .map_err(|error| anyhow!("run native Core ML embedding: {error}"))?;
+        let (values, output_shape) = prediction
+            .get_f32("sentence_embeddings")
+            .map_err(|error| anyhow!("read native Core ML embedding: {error}"))?;
+        if output_shape != [batch_size, SEMANTIC_DIMENSIONS] {
+            return Err(anyhow!(
+                "native Core ML output shape is {output_shape:?}, expected [{batch_size}, {SEMANTIC_DIMENSIONS}]"
+            ));
+        }
+        Ok(values
+            .chunks_exact(SEMANTIC_DIMENSIONS)
+            .map(<[f32]>::to_vec)
+            .collect())
+    }
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+fn validate_coreml_bundle_identity(bundle: &VerifiedModelBundle) -> Result<()> {
+    if bundle.manifest.model.embedding_space_id != semantic_model_key() {
+        return Err(anyhow!(
+            "Core ML bundle embedding space {:?} does not match required {:?}",
+            bundle.manifest.model.embedding_space_id,
+            semantic_model_key()
+        ));
+    }
+    if bundle.manifest.model.id != SEMANTIC_MODEL_ID
+        || bundle.manifest.model.source_revision != SEMANTIC_MODEL_REVISION
+    {
+        return Err(anyhow!(
+            "Core ML bundle does not match the required {SEMANTIC_MODEL_ID} revision"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(any(all(ctx_semantic_fastembed, target_os = "macos"), test))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CoreMlComputeMode {
+    All,
+    CpuAndNeuralEngine,
+    CpuAndGpu,
+    CpuOnly,
+}
+
+#[cfg(any(all(ctx_semantic_fastembed, target_os = "macos"), test))]
+impl CoreMlComputeMode {
+    fn parse(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "all" => Ok(Self::All),
+            "ane" | "cpu-ane" => Ok(Self::CpuAndNeuralEngine),
+            "gpu" | "cpu-gpu" => Ok(Self::CpuAndGpu),
+            "cpu" => Ok(Self::CpuOnly),
+            value => Err(anyhow!(
+                "unsupported CTX_SEMANTIC_COREML_NATIVE_COMPUTE mode {value:?}"
+            )),
+        }
+    }
+
+    fn compute_class(self) -> SemanticComputeClass {
+        match self {
+            Self::CpuOnly => SemanticComputeClass::Cpu,
+            Self::All | Self::CpuAndNeuralEngine | Self::CpuAndGpu => {
+                SemanticComputeClass::Accelerator
+            }
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::CpuAndNeuralEngine => "cpu_and_neural_engine",
+            Self::CpuAndGpu => "cpu_and_gpu",
+            Self::CpuOnly => "cpu_only",
+        }
+    }
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+#[derive(Clone, Copy)]
+struct CoreMlComputeConfig {
+    units: coreml_native::ComputeUnits,
+    compute_class: SemanticComputeClass,
+    mode: &'static str,
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+fn coreml_compute_units_from_env() -> Result<CoreMlComputeConfig> {
+    use coreml_native::ComputeUnits;
+
+    let mode = CoreMlComputeMode::parse(
+        &env::var("CTX_SEMANTIC_COREML_NATIVE_COMPUTE").unwrap_or_else(|_| "all".to_owned()),
+    )?;
+    let units = match mode {
+        CoreMlComputeMode::All => ComputeUnits::All,
+        CoreMlComputeMode::CpuAndNeuralEngine => ComputeUnits::CpuAndNeuralEngine,
+        CoreMlComputeMode::CpuAndGpu => ComputeUnits::CpuAndGpu,
+        CoreMlComputeMode::CpuOnly => ComputeUnits::CpuOnly,
+    };
+    Ok(CoreMlComputeConfig {
+        units,
+        compute_class: mode.compute_class(),
+        mode: mode.as_str(),
+    })
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+fn load_coreml_role_model(
+    source: &Path,
+    cache_dir: &Path,
+    manifest_sha256: &str,
+    role: &str,
+    compute_units: coreml_native::ComputeUnits,
+    expected_batch_size: usize,
+    expected_sequence_length: usize,
+) -> Result<CoreMlRoleModel> {
+    let (load_path, reused_cache) =
+        compiled_coreml_model_path(source, cache_dir, manifest_sha256, role)?;
+    match load_and_validate_coreml_role_model(
+        &load_path,
+        role,
+        compute_units,
+        expected_batch_size,
+        expected_sequence_length,
+    ) {
+        Ok(model) => Ok(model),
+        Err(first_error) if reused_cache => {
+            invalidate_compiled_model_cache(&load_path)
+                .with_context(|| format!("invalidate corrupt Core ML {role} compiled cache"))?;
+            let (rebuilt_path, reused_after_invalidation) =
+                compiled_coreml_model_path(source, cache_dir, manifest_sha256, role)?;
+            if reused_after_invalidation {
+                return Err(anyhow!(
+                    "Core ML {role} compiled cache remained present after invalidation"
+                ));
+            }
+            load_and_validate_coreml_role_model(
+                &rebuilt_path,
+                role,
+                compute_units,
+                expected_batch_size,
+                expected_sequence_length,
+            )
+            .with_context(|| {
+                format!(
+                    "rebuild Core ML {role} compiled cache after load failure; first failure: {first_error:#}"
+                )
+            })
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+fn load_and_validate_coreml_role_model(
+    path: &Path,
+    role: &str,
+    compute_units: coreml_native::ComputeUnits,
+    expected_batch_size: usize,
+    expected_sequence_length: usize,
+) -> Result<CoreMlRoleModel> {
+    let model = coreml_native::Model::load(path, compute_units)
+        .map_err(|error| anyhow!("load native Core ML {role} model: {error}"))?;
+    let batch_size = validate_coreml_model_contract(
+        &model,
+        role,
+        expected_batch_size,
+        expected_sequence_length,
+    )?;
+    Ok(CoreMlRoleModel { model, batch_size })
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+fn compiled_coreml_model_path(
+    source: &Path,
+    cache_dir: &Path,
+    manifest_sha256: &str,
+    role: &str,
+) -> Result<(PathBuf, bool)> {
+    const COMPILER_IDENTITY: &str = "coreml-native-0.2.0:MLModel.compileModelAtURL";
+
+    if source.extension().and_then(|value| value.to_str()) != Some("mlpackage") {
+        return Err(anyhow!(
+            "verified Core ML {role} artifact must be an mlpackage"
+        ));
+    }
+    create_private_dir_all(cache_dir)?;
+    let destination =
+        prepare_compile_destination(cache_dir, manifest_sha256, role, COMPILER_IDENTITY)?;
+    if destination.final_path.is_dir() {
+        discard_compile_destination(&destination)?;
+        return Ok((destination.final_path, true));
+    }
+
+    let temporary = coreml_native::compile_model(source)
+        .map_err(|error| anyhow!("compile native Core ML {role} model: {error}"))?;
+    let result = (|| -> Result<()> {
+        copy_directory_contents(&temporary, &destination.staging_path)?;
+        commit_compile_destination(&destination)?;
+        Ok(())
+    })();
+    let _ = fs::remove_dir_all(&temporary);
+    if let Err(error) = result {
+        let _ = discard_compile_destination(&destination);
+        return Err(error);
+    }
+    Ok((destination.final_path, false))
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+fn copy_directory_contents(source: &Path, destination: &Path) -> Result<()> {
+    for entry in fs::read_dir(source)
+        .with_context(|| format!("read compiled Core ML directory {}", source.display()))?
+    {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            fs::create_dir(&destination_path)?;
+            copy_directory_contents(&source_path, &destination_path)?;
+        } else if file_type.is_file() {
+            fs::copy(&source_path, &destination_path)?;
+        } else {
+            return Err(anyhow!(
+                "compiled Core ML model contains unsupported entry {}",
+                source_path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+fn validate_coreml_model_contract(
+    model: &coreml_native::Model,
+    role: &str,
+    expected_batch_size: usize,
+    expected_sequence_length: usize,
+) -> Result<usize> {
+    use coreml_native::{DataType, FeatureType};
+
+    let inputs = model.inputs();
+    let mut batch_size = None;
+    for name in ["input_ids", "attention_mask", "token_type_ids"] {
+        let input = inputs
+            .iter()
+            .find(|input| input.name() == name)
+            .ok_or_else(|| anyhow!("Core ML {role} model is missing input {name}"))?;
+        if input.feature_type() != &FeatureType::MultiArray
+            || input.data_type() != Some(DataType::Int32)
+        {
+            return Err(anyhow!(
+                "Core ML {role} input {name} has an incompatible type"
+            ));
+        }
+        let shape = input
+            .shape()
+            .ok_or_else(|| anyhow!("Core ML {role} input {name} has no fixed shape"))?;
+        if shape.len() != 2
+            || shape[0] != expected_batch_size
+            || shape[1] != expected_sequence_length
+        {
+            return Err(anyhow!(
+                "Core ML {role} input {name} shape {shape:?} is incompatible with signed contract [{expected_batch_size}, {expected_sequence_length}]"
+            ));
+        }
+        if batch_size
+            .replace(shape[0])
+            .is_some_and(|batch| batch != shape[0])
+        {
+            return Err(anyhow!(
+                "Core ML {role} inputs do not share one fixed batch size"
+            ));
+        }
+    }
+    if inputs.len() != 3 {
+        return Err(anyhow!(
+            "Core ML {role} model must expose exactly three inputs"
+        ));
+    }
+    let batch_size = batch_size.ok_or_else(|| anyhow!("Core ML {role} batch size is missing"))?;
+    let outputs = model.outputs();
+    let output = outputs
+        .iter()
+        .find(|output| output.name() == "sentence_embeddings")
+        .ok_or_else(|| anyhow!("Core ML {role} model is missing sentence_embeddings output"))?;
+    if outputs.len() != 1
+        || output.feature_type() != &FeatureType::MultiArray
+        || output.data_type() != Some(DataType::Float32)
+        || output.shape() != Some([batch_size, SEMANTIC_DIMENSIONS].as_slice())
+    {
+        return Err(anyhow!(
+            "Core ML {role} sentence_embeddings output contract is incompatible"
+        ));
+    }
+    Ok(batch_size)
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+fn load_coreml_tokenizer(path: &Path, sequence_length: usize) -> Result<tokenizers::Tokenizer> {
+    use tokenizers::{PaddingParams, PaddingStrategy, TruncationParams};
+
+    const E5_PAD_TOKEN: &str = "<pad>";
+    const E5_PAD_ID: u32 = 1;
+
+    let mut tokenizer = tokenizers::Tokenizer::from_file(path)
+        .map_err(|error| anyhow!("load Core ML tokenizer {}: {error}", path.display()))?;
+    let pad_id = tokenizer
+        .token_to_id(E5_PAD_TOKEN)
+        .ok_or_else(|| anyhow!("Core ML tokenizer does not define {E5_PAD_TOKEN}"))?;
+    if pad_id != E5_PAD_ID {
+        return Err(anyhow!(
+            "Core ML tokenizer {E5_PAD_TOKEN} id {pad_id} does not match pinned id {E5_PAD_ID}"
+        ));
+    }
+    tokenizer.with_padding(Some(PaddingParams {
+        strategy: PaddingStrategy::Fixed(sequence_length),
+        pad_id,
+        pad_token: E5_PAD_TOKEN.to_owned(),
+        ..Default::default()
+    }));
+    tokenizer
+        .with_truncation(Some(TruncationParams {
+            max_length: sequence_length,
+            ..Default::default()
+        }))
+        .map_err(|error| anyhow!("configure Core ML tokenizer truncation: {error}"))?;
+    Ok(tokenizer)
+}
+
+#[cfg(any(all(ctx_semantic_fastembed, target_os = "macos"), test))]
+fn pad_role_batch(
+    mut texts: Vec<String>,
+    exact_batch_size: usize,
+    padding_text: &str,
+) -> Result<Vec<String>> {
+    if exact_batch_size == 0 {
+        return Err(anyhow!("semantic fixed batch must be positive"));
+    }
+    let remainder = texts.len() % exact_batch_size;
+    if remainder != 0 {
+        texts.extend(std::iter::repeat_n(
+            padding_text.to_owned(),
+            exact_batch_size - remainder,
+        ));
+    }
+    Ok(texts)
+}
+
+#[cfg(all(test, ctx_semantic_fastembed))]
+fn pad_texts_to_exact_batch(texts: Vec<String>, exact_batch_size: usize) -> Result<Vec<String>> {
+    pad_role_batch(texts, exact_batch_size, SEMANTIC_PASSAGE_PREFIX)
+}
+
+#[cfg(all(test, ctx_semantic_fastembed))]
+fn semantic_fixed_shape_from_values(
+    batch_size: Option<&str>,
+    sequence_length: Option<&str>,
+) -> Result<Option<(usize, usize)>> {
+    match (batch_size, sequence_length) {
+        (None, None) => Ok(None),
+        (Some(batch_size), Some(sequence_length)) => {
+            let batch_size = batch_size
+                .trim()
+                .parse::<usize>()
+                .ok()
+                .filter(|value| *value > 0);
+            let sequence_length = sequence_length
+                .trim()
+                .parse::<usize>()
+                .ok()
+                .filter(|value| *value > 0);
+            match (batch_size, sequence_length) {
+                (Some(batch_size), Some(sequence_length)) => {
+                    Ok(Some((batch_size, sequence_length)))
+                }
+                _ => Err(anyhow!("fixed shape values must be positive integers")),
+            }
+        }
+        _ => Err(anyhow!("fixed shape values must be provided together")),
+    }
+}
+
+#[cfg(not(ctx_semantic_fastembed))]
+struct SemanticEmbedder;
+
+#[cfg(not(ctx_semantic_fastembed))]
+fn new_semantic_embedder(_cache_dir: &Path) -> Result<SemanticEmbedder> {
+    Err(anyhow!(
+        "semantic embedding model {SEMANTIC_MODEL_ID} is not supported on this platform"
+    ))
+}
+
+#[cfg(not(ctx_semantic_fastembed))]
+fn acquire_semantic_embedder(_cache_dir: &Path) -> Result<SemanticEmbedder> {
+    Err(anyhow!(
+        "semantic embedding model {SEMANTIC_MODEL_ID} is not supported on this platform"
+    ))
+}
+
+#[cfg(all(test, ctx_semantic_fastembed))]
+mod embedding_backend_tests {
+    use super::*;
+
+    #[test]
+    fn backend_preference_is_strict() {
+        assert_eq!(
+            BackendPreference::parse(None).unwrap(),
+            BackendPreference::Auto
+        );
+        assert_eq!(
+            BackendPreference::parse(Some("cpu")).unwrap(),
+            BackendPreference::Cpu
+        );
+        assert_eq!(
+            BackendPreference::parse(Some("coreml")).unwrap(),
+            BackendPreference::CoreMl
+        );
+        assert!(BackendPreference::parse(Some("gpu")).is_err());
+        assert!(BackendPreference::parse(Some("CPU")).is_err());
+    }
+
+    #[test]
+    fn foreground_model_access_is_cache_only() {
+        assert!(!SemanticModelAccess::ForegroundCacheOnly.network_allowed());
+        assert!(SemanticModelAccess::DaemonNetwork.network_allowed());
+    }
+
+    #[test]
+    fn coreml_cpu_only_uses_cpu_quiet_policy_class() {
+        let cpu_only = CoreMlComputeMode::parse("cpu").unwrap();
+        assert_eq!(cpu_only.compute_class(), SemanticComputeClass::Cpu);
+        assert_eq!(cpu_only.as_str(), "cpu_only");
+        let all = CoreMlComputeMode::parse("all").unwrap();
+        assert_eq!(all.compute_class(), SemanticComputeClass::Accelerator);
+
+        let available = 5 * 512 * 1024 * 1024;
+        assert!(semantic_model_load_deferred(Some(available), cpu_only.compute_class()).is_none());
+        assert!(semantic_model_load_deferred(Some(available), all.compute_class()).is_some());
+    }
+
+    #[test]
+    fn normalization_is_central_and_strict() {
+        let mut vector = vec![0.0; SEMANTIC_DIMENSIONS];
+        vector[0] = 3.0;
+        vector[1] = 4.0;
+        let normalized = normalize_and_validate_embeddings(vec![vector], 1).unwrap();
+        assert!((normalized[0][0] - 0.6).abs() < 1e-6);
+        assert!((normalized[0][1] - 0.8).abs() < 1e-6);
+
+        assert!(normalize_and_validate_embeddings(Vec::new(), 1).is_err());
+        assert!(normalize_and_validate_embeddings(vec![vec![1.0]], 1).is_err());
+        assert!(
+            normalize_and_validate_embeddings(vec![vec![0.0; SEMANTIC_DIMENSIONS]], 1).is_err()
+        );
+        let mut non_finite = vec![1.0; SEMANTIC_DIMENSIONS];
+        non_finite[0] = f32::NAN;
+        assert!(normalize_and_validate_embeddings(vec![non_finite], 1).is_err());
+    }
+
+    #[test]
+    fn runtime_info_keeps_space_identity_backend_independent() {
+        let cpu = SemanticEmbeddingRuntimeInfo {
+            preference: BackendPreference::Auto,
+            backend: "cpu",
+            compute_class: SemanticComputeClass::Cpu,
+            compute_mode: None,
+            acquisition_source: "cache",
+            acquisition_fallback: None,
+        };
+        let coreml = SemanticEmbeddingRuntimeInfo {
+            backend: "coreml",
+            ..cpu.clone()
+        };
+        assert_eq!(cpu.to_json()["model_key"], coreml.to_json()["model_key"]);
+        assert_ne!(cpu.to_json()["backend"], coreml.to_json()["backend"]);
+    }
+}

--- a/crates/ctx-cli/src/semantic/health_search.rs
+++ b/crates/ctx-cli/src/semantic/health_search.rs
@@ -10,14 +10,14 @@ fn semantic_env_flag(name: &str) -> bool {
 pub(crate) fn semantic_health_findings(data_root: &Path) -> Vec<String> {
     let mut findings = Vec::new();
     let semantic_lock = semantic_worker_lock_path(data_root);
-    if semantic_lock.exists() && semantic_worker_lock_is_stale(&semantic_lock) {
+    if semantic_lock.exists() && pid_lock_file_is_orphaned(&semantic_lock) {
         findings.push(format!(
             "semantic worker lock is stale: {}",
             semantic_lock.display()
         ));
     }
     let daemon_lock = daemon_lock_path(data_root);
-    if daemon_lock.exists() && daemon_lock_is_stale(&daemon_lock) {
+    if daemon_lock.exists() && pid_lock_file_is_orphaned(&daemon_lock) {
         findings.push(format!("daemon lock is stale: {}", daemon_lock.display()));
     }
     if let Some(status) = read_semantic_worker_status(data_root) {
@@ -92,6 +92,59 @@ fn private_create_new_file(path: &Path) -> std::io::Result<fs::File> {
     #[cfg(unix)]
     options.mode(0o600);
     options.open(path)
+}
+
+#[cfg(unix)]
+fn private_create_new_lock_file(path: &Path) -> std::io::Result<fs::File> {
+    fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn private_create_new_lock_file(path: &Path) -> std::io::Result<fs::File> {
+    fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(path)
+}
+
+#[cfg(unix)]
+fn private_open_existing_lock_file(path: &Path) -> std::io::Result<fs::File> {
+    fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(windows)]
+fn private_open_existing_lock_file(path: &Path) -> std::io::Result<fs::File> {
+    use std::os::windows::fs::OpenOptionsExt;
+    use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT;
+
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "ctx process lock is not a regular file",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn private_open_existing_lock_file(path: &Path) -> std::io::Result<fs::File> {
+    fs::OpenOptions::new().read(true).write(true).open(path)
 }
 
 #[cfg(unix)]
@@ -267,37 +320,20 @@ fn semantic_hits_for_text_query(
     Ok((semantic_hit_search.hits, diagnostics))
 }
 
-#[cfg(unix)]
 fn daemon_query_embedding(data_root: &Path, semantic_text: &str) -> Result<Option<(Vec<f32>, u64)>> {
-    let path = daemon_query_socket_path(data_root);
-    if !path.exists() {
-        return Ok(None);
-    }
-    let mut stream =
-        UnixStream::connect(&path).with_context(|| format!("connect daemon query socket {}", path.display()))?;
-    stream
-        .set_read_timeout(Some(StdDuration::from_secs(30)))
-        .context("set daemon query read timeout")?;
-    stream
-        .set_write_timeout(Some(StdDuration::from_secs(30)))
-        .context("set daemon query write timeout")?;
-    writeln!(
-        stream,
-        "{}",
-        serde_json::to_string(&compact_json(json!({
+    let Some(response) = daemon_query_request(
+        data_root,
+        compact_json(json!({
             "schema_version": 1,
             "op": "embed_query",
-            "model_key": SEMANTIC_MODEL_KEY,
+            "model_key": semantic_model_key(),
             "text": semantic_text,
-        })))?
-    )?;
-    let _ = stream.shutdown(Shutdown::Write);
-    let mut body = String::new();
-    stream
-        .take(1024 * 1024)
-        .read_to_string(&mut body)
-        .context("read daemon query response")?;
-    let response: Value = serde_json::from_str(&body).context("parse daemon query response")?;
+        })),
+        StdDuration::from_secs(30),
+        1024 * 1024,
+    )? else {
+        return Ok(None);
+    };
     if response.get("ok").and_then(Value::as_bool) != Some(true) {
         let message = response
             .get("error")
@@ -306,7 +342,7 @@ fn daemon_query_embedding(data_root: &Path, semantic_text: &str) -> Result<Optio
         return Err(anyhow!("{message}"));
     }
     let model_key = response.get("model_key").and_then(Value::as_str).unwrap_or("");
-    if model_key != SEMANTIC_MODEL_KEY {
+    if model_key != semantic_model_key() {
         return Err(anyhow!("daemon query response model key mismatch"));
     }
     let query_embed_ms = response
@@ -335,34 +371,6 @@ fn daemon_query_embedding(data_root: &Path, semantic_text: &str) -> Result<Optio
     Ok(Some((embedding, query_embed_ms)))
 }
 
-#[cfg(not(unix))]
-fn daemon_query_embedding(
-    _data_root: &Path,
-    _semantic_text: &str,
-) -> Result<Option<(Vec<f32>, u64)>> {
-    Ok(None)
-}
-
-#[cfg(ctx_semantic_fastembed)]
-struct SemanticEmbedder {
-    model: TextEmbedding,
-    batch_size: usize,
-    policy: SemanticEmbedPolicy,
-}
-
-#[cfg(ctx_semantic_fastembed)]
-static FASTEMBED_ACQUIRE_ENV_LOCK: Mutex<()> = Mutex::new(());
-
-#[cfg(not(ctx_semantic_fastembed))]
-struct SemanticEmbedder;
-
-#[cfg(ctx_semantic_fastembed)]
-#[derive(Debug, Clone, Copy)]
-struct SemanticMemorySnapshot {
-    total_bytes: Option<u64>,
-    available_bytes: Option<u64>,
-}
-
 #[cfg(ctx_semantic_fastembed)]
 #[derive(Debug, Clone)]
 struct SemanticEmbedPolicy {
@@ -371,6 +379,8 @@ struct SemanticEmbedPolicy {
     memory_budget_bytes: u64,
     total_memory_bytes: Option<u64>,
     available_memory_bytes: Option<u64>,
+    active_percent: u8,
+    compute_class: SemanticComputeClass,
     source: &'static str,
 }
 
@@ -384,139 +394,26 @@ impl SemanticEmbedPolicy {
             "memory_budget_bytes": self.memory_budget_bytes,
             "total_memory_bytes": self.total_memory_bytes,
             "available_memory_bytes": self.available_memory_bytes,
+            "active_percent": self.active_percent,
+            "compute_class": match self.compute_class {
+                SemanticComputeClass::Cpu => "cpu",
+                SemanticComputeClass::Accelerator => "accelerator",
+            },
         }))
     }
 }
 
 #[cfg(ctx_semantic_fastembed)]
-fn new_semantic_embedder(cache_dir: &Path) -> Result<SemanticEmbedder> {
-    let snapshot = semantic_model_cache_snapshot_dir(cache_dir).ok_or_else(|| {
-        anyhow!(
-            "semantic model cache is incomplete at {}",
-            cache_dir.display()
-        )
-    })?;
-    let policy = semantic_embed_policy();
-    let model_info = TextEmbedding::get_model_info(&EmbeddingModel::AllMiniLML6V2)?;
-    let tokenizer_files = TokenizerFiles {
-        tokenizer_file: fs::read(snapshot.join("tokenizer.json"))
-            .with_context(|| format!("read semantic tokenizer.json from {}", snapshot.display()))?,
-        config_file: fs::read(snapshot.join("config.json"))
-            .with_context(|| format!("read semantic config.json from {}", snapshot.display()))?,
-        special_tokens_map_file: fs::read(snapshot.join("special_tokens_map.json")).with_context(
-            || {
-                format!(
-                    "read semantic special_tokens_map.json from {}",
-                    snapshot.display()
-                )
-            },
-        )?,
-        tokenizer_config_file: fs::read(snapshot.join("tokenizer_config.json")).with_context(
-            || {
-                format!(
-                    "read semantic tokenizer_config.json from {}",
-                    snapshot.display()
-                )
-            },
-        )?,
-    };
-    let mut user_model = UserDefinedEmbeddingModel::new(
-        fs::read(snapshot.join(&model_info.model_file)).with_context(|| {
-            format!(
-                "read semantic model file {} from {}",
-                model_info.model_file,
-                snapshot.display()
-            )
-        })?,
-        tokenizer_files,
-    )
-    .with_pooling(
-        TextEmbedding::get_default_pooling_method(&EmbeddingModel::AllMiniLML6V2)
-            .unwrap_or(Pooling::Mean),
-    )
-    .with_quantization(TextEmbedding::get_quantization_mode(
-        &EmbeddingModel::AllMiniLML6V2,
-    ));
-    user_model.output_key = model_info.output_key.clone();
-    let options = InitOptionsUserDefined::new().with_intra_threads(policy.threads);
-    let model = TextEmbedding::try_new_from_user_defined(user_model, options)
-        .with_context(|| format!("initialize semantic embedding model {SEMANTIC_MODEL_ID}"))?;
-    Ok(SemanticEmbedder {
-        model,
-        batch_size: policy.batch_size,
-        policy,
-    })
-}
-
-#[cfg(ctx_semantic_fastembed)]
-fn acquire_semantic_embedder(cache_dir: &Path) -> Result<SemanticEmbedder> {
-    let _cache_env = FastembedCacheEnvGuard::new(cache_dir);
-    let policy = semantic_embed_policy();
-    let options = InitOptions::new(EmbeddingModel::AllMiniLML6V2)
-        .with_cache_dir(cache_dir.to_path_buf())
-        .with_show_download_progress(false)
-        .with_intra_threads(policy.threads);
-    let model = TextEmbedding::try_new(options)
-        .with_context(|| format!("download and initialize semantic model {SEMANTIC_MODEL_ID}"))?;
-    if !semantic_model_cache_available(cache_dir) {
-        return Err(anyhow!(
-            "semantic model download completed but cache verification failed at {}",
-            cache_dir.display()
-        ));
-    }
-    Ok(SemanticEmbedder {
-        model,
-        batch_size: policy.batch_size,
-        policy,
-    })
-}
-
-#[cfg(ctx_semantic_fastembed)]
-struct FastembedCacheEnvGuard {
-    _lock: std::sync::MutexGuard<'static, ()>,
-    hf_home: Option<std::ffi::OsString>,
-}
-
-#[cfg(ctx_semantic_fastembed)]
-impl FastembedCacheEnvGuard {
-    fn new(cache_dir: &Path) -> Self {
-        let lock = FASTEMBED_ACQUIRE_ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
-        let hf_home = env::var_os("HF_HOME");
-        env::set_var("HF_HOME", cache_dir);
-        Self {
-            _lock: lock,
-            hf_home,
-        }
-    }
-}
-
-#[cfg(ctx_semantic_fastembed)]
-impl Drop for FastembedCacheEnvGuard {
-    fn drop(&mut self) {
-        match &self.hf_home {
-            Some(value) => env::set_var("HF_HOME", value),
-            None => env::remove_var("HF_HOME"),
-        }
-    }
-}
-
-#[cfg(not(ctx_semantic_fastembed))]
-fn new_semantic_embedder(_cache_dir: &Path) -> Result<SemanticEmbedder> {
-    Err(anyhow!(
-        "semantic embedding model {SEMANTIC_MODEL_ID} is not supported on this platform"
-    ))
-}
-
-#[cfg(not(ctx_semantic_fastembed))]
-fn acquire_semantic_embedder(_cache_dir: &Path) -> Result<SemanticEmbedder> {
-    Err(anyhow!(
-        "semantic embedding model {SEMANTIC_MODEL_ID} is not supported on this platform"
-    ))
-}
-
-#[cfg(ctx_semantic_fastembed)]
 fn semantic_embed_policy() -> SemanticEmbedPolicy {
-    semantic_embed_policy_from_env_and_memory(SemanticMemorySnapshot::current())
+    semantic_embed_policy_for(SemanticComputeClass::Cpu)
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn semantic_embed_policy_for(compute_class: SemanticComputeClass) -> SemanticEmbedPolicy {
+    semantic_embed_policy_from_env_and_resources(
+        compute_class,
+        SemanticSystemResources::current(),
+    )
 }
 
 #[cfg(ctx_semantic_fastembed)]
@@ -545,11 +442,34 @@ fn semantic_embedder_policy_status_json(_embedder: &Option<SemanticEmbedder>) ->
 }
 
 #[cfg(ctx_semantic_fastembed)]
-fn semantic_embed_policy_from_env_and_memory(
-    snapshot: SemanticMemorySnapshot,
+fn semantic_embedder_runtime_status_json(embedder: &Option<SemanticEmbedder>) -> Option<Value> {
+    embedder
+        .as_ref()
+        .map(|embedder| embedder.runtime_info().to_json())
+}
+
+#[cfg(not(ctx_semantic_fastembed))]
+fn semantic_embedder_runtime_status_json(_embedder: &Option<SemanticEmbedder>) -> Option<Value> {
+    None
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn semantic_embed_policy_from_env_and_resources(
+    compute_class: SemanticComputeClass,
+    resources: SemanticSystemResources,
 ) -> SemanticEmbedPolicy {
-    let mut policy = semantic_adaptive_embed_policy(snapshot);
-    let mut source = "adaptive";
+    let quiet = semantic_quiet_policy(resources, compute_class);
+    let mut policy = SemanticEmbedPolicy {
+        threads: quiet.threads,
+        batch_size: quiet.batch_size,
+        memory_budget_bytes: quiet.memory_budget_bytes,
+        total_memory_bytes: resources.total_memory_bytes,
+        available_memory_bytes: resources.available_memory_bytes,
+        active_percent: quiet.active_percent,
+        compute_class,
+        source: "dynamic_quiet",
+    };
+    let mut source = "dynamic_quiet";
     if let Some(threads) = env_usize("CTX_SEMANTIC_THREADS") {
         policy.threads = threads.min(SEMANTIC_EMBED_THREADS_MAX);
         source = "env_override";
@@ -560,97 +480,6 @@ fn semantic_embed_policy_from_env_and_memory(
     }
     policy.source = source;
     policy
-}
-
-#[cfg(ctx_semantic_fastembed)]
-fn semantic_adaptive_embed_policy(snapshot: SemanticMemorySnapshot) -> SemanticEmbedPolicy {
-    let memory_budget_bytes = semantic_adaptive_memory_budget_bytes(snapshot);
-    let parallelism = std::thread::available_parallelism()
-        .ok()
-        .map(|threads| threads.get())
-        .unwrap_or(SEMANTIC_EMBED_THREADS_FALLBACK);
-    let budget_gib_ceiling = usize::try_from(
-        memory_budget_bytes.saturating_add((1024 * 1024 * 1024) - 1) / (1024 * 1024 * 1024),
-    )
-    .unwrap_or(SEMANTIC_EMBED_THREADS_MAX);
-    let threads = budget_gib_ceiling
-        .clamp(SEMANTIC_EMBED_THREADS_FALLBACK, SEMANTIC_EMBED_THREADS_MAX)
-        .min(parallelism.max(1));
-    let raw_batch =
-        usize::try_from(memory_budget_bytes / SEMANTIC_EMBED_BATCH_TARGET_BYTES)
-            .unwrap_or(SEMANTIC_EMBED_BATCH_ADAPTIVE_MAX);
-    let batch_size = (raw_batch / 16 * 16).clamp(
-        SEMANTIC_EMBED_BATCH_FALLBACK,
-        SEMANTIC_EMBED_BATCH_ADAPTIVE_MAX,
-    );
-    SemanticEmbedPolicy {
-        threads,
-        batch_size,
-        memory_budget_bytes,
-        total_memory_bytes: snapshot.total_bytes,
-        available_memory_bytes: snapshot.available_bytes,
-        source: "adaptive",
-    }
-}
-
-#[cfg(ctx_semantic_fastembed)]
-fn semantic_adaptive_memory_budget_bytes(snapshot: SemanticMemorySnapshot) -> u64 {
-    let by_total = snapshot.total_bytes.map(|bytes| bytes / 5);
-    let by_available = snapshot.available_bytes.map(|bytes| bytes / 2);
-    let budget = by_total
-        .into_iter()
-        .chain(by_available)
-        .min()
-        .unwrap_or(SEMANTIC_MEMORY_BUDGET_FALLBACK_BYTES);
-    budget.clamp(
-        SEMANTIC_MEMORY_BUDGET_MIN_BYTES,
-        SEMANTIC_MEMORY_BUDGET_MAX_BYTES,
-    )
-}
-
-#[cfg(ctx_semantic_fastembed)]
-impl SemanticMemorySnapshot {
-    fn current() -> Self {
-        semantic_memory_snapshot()
-    }
-}
-
-#[cfg(all(ctx_semantic_fastembed, target_os = "linux"))]
-fn semantic_memory_snapshot() -> SemanticMemorySnapshot {
-    let Ok(text) = fs::read_to_string("/proc/meminfo") else {
-        return SemanticMemorySnapshot {
-            total_bytes: None,
-            available_bytes: None,
-        };
-    };
-    let mut total_bytes = None;
-    let mut available_bytes = None;
-    for line in text.lines() {
-        if let Some(bytes) = meminfo_kib_line_bytes(line, "MemTotal:") {
-            total_bytes = Some(bytes);
-        } else if let Some(bytes) = meminfo_kib_line_bytes(line, "MemAvailable:") {
-            available_bytes = Some(bytes);
-        }
-    }
-    SemanticMemorySnapshot {
-        total_bytes,
-        available_bytes,
-    }
-}
-
-#[cfg(all(ctx_semantic_fastembed, not(target_os = "linux")))]
-fn semantic_memory_snapshot() -> SemanticMemorySnapshot {
-    SemanticMemorySnapshot {
-        total_bytes: None,
-        available_bytes: None,
-    }
-}
-
-#[cfg(all(ctx_semantic_fastembed, target_os = "linux"))]
-fn meminfo_kib_line_bytes(line: &str, key: &str) -> Option<u64> {
-    let rest = line.strip_prefix(key)?;
-    let kib = rest.split_whitespace().next()?.parse::<u64>().ok()?;
-    kib.checked_mul(1024)
 }
 
 fn semantic_worker_cache_dir(data_root: &Path) -> PathBuf {
@@ -743,6 +572,53 @@ fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
 
 fn semantic_model_cache_available(cache_dir: &Path) -> bool {
     semantic_model_cache_snapshot_dir(cache_dir).is_some()
+        || semantic_coreml_model_cache_available(cache_dir)
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn semantic_coreml_model_cache_available(cache_dir: &Path) -> bool {
+    coreml_bundle_cache_available(cache_dir)
+}
+
+#[cfg(not(any(target_os = "macos", test)))]
+fn semantic_coreml_model_cache_available(_cache_dir: &Path) -> bool {
+    false
+}
+
+fn semantic_model_acquisition_status_json(cache_dir: &Path) -> Value {
+    let cpu_available = semantic_model_cache_snapshot_dir(cache_dir).is_some();
+    #[cfg(any(target_os = "macos", test))]
+    let coreml = coreml_acquisition_status_json(cache_dir);
+    #[cfg(not(any(target_os = "macos", test)))]
+    let coreml = json!({
+        "cache_status": "unsupported",
+        "descriptor_provisioned": false,
+        "network_scope": "daemon_only",
+    });
+    compact_json(json!({
+        "network_scope": "daemon_only",
+        "cpu": {
+            "cache_status": if cpu_available { "present" } else { "missing" },
+            "verification": "sha256_on_load",
+            "source_revision": SEMANTIC_MODEL_REVISION,
+        },
+        "coreml": coreml,
+    }))
+}
+
+fn semantic_model_acquisition_integrity_error(error: &anyhow::Error) -> bool {
+    if error
+        .downcast_ref::<SemanticCpuModelIntegrityError>()
+        .is_some()
+    {
+        return true;
+    }
+    #[cfg(any(target_os = "macos", test))]
+    {
+        model_acquisition_integrity_error(error)
+    }
+    #[cfg(not(any(target_os = "macos", test)))]
+    false
 }
 
 fn semantic_model_cache_snapshot_dir(cache_dir: &Path) -> Option<PathBuf> {
@@ -762,6 +638,12 @@ fn semantic_model_cache_snapshot_dir(cache_dir: &Path) -> Option<PathBuf> {
 
 fn semantic_model_cache_roots(cache_dir: &Path) -> Vec<PathBuf> {
     let mut roots = Vec::new();
+    push_unique_path(
+        &mut roots,
+        cache_dir
+            .join(SEMANTIC_MANAGED_MODEL_CACHE_DIR)
+            .join(SEMANTIC_HF_MODEL_CACHE_DIR),
+    );
     if cache_dir
         .file_name()
         .and_then(|name| name.to_str())
@@ -778,23 +660,13 @@ fn semantic_model_cache_roots(cache_dir: &Path) -> Vec<PathBuf> {
 }
 
 fn semantic_model_snapshot_from_root(model_root: &Path) -> Option<PathBuf> {
-    let snapshot_ref = fs::read_to_string(model_root.join("refs").join("main")).ok()?;
-    let snapshot_ref = snapshot_ref.trim();
-    if snapshot_ref.is_empty()
-        || snapshot_ref.contains('/')
-        || snapshot_ref.contains('\\')
-        || snapshot_ref == "."
-        || snapshot_ref == ".."
-    {
-        return None;
-    }
-    let snapshot = model_root.join("snapshots").join(snapshot_ref);
+    let snapshot = model_root.join("snapshots").join(SEMANTIC_MODEL_REVISION);
     if !snapshot.is_dir() {
         return None;
     }
     if SEMANTIC_REQUIRED_MODEL_FILES.iter().all(|file| {
-        fs::metadata(snapshot.join(file))
-            .map(|metadata| metadata.is_file() && metadata.len() > 0)
+        fs::metadata(snapshot.join(file.path))
+            .map(|metadata| metadata.is_file() && metadata.len() == file.size)
             .unwrap_or(false)
     }) {
         Some(snapshot)

--- a/crates/ctx-cli/src/semantic/indexing.rs
+++ b/crates/ctx-cli/src/semantic/indexing.rs
@@ -1,34 +1,8 @@
-#[cfg(ctx_semantic_fastembed)]
-fn embed_texts(embedder: &mut SemanticEmbedder, texts: Vec<String>) -> Result<Vec<Vec<f32>>> {
-    let mut embeddings = embedder
-        .model
-        .embed(texts, Some(embedder.batch_size))
-        .with_context(|| format!("embed text with semantic model {SEMANTIC_MODEL_ID}"))?;
-    for embedding in &mut embeddings {
-        if embedding.len() != SEMANTIC_DIMENSIONS {
-            return Err(anyhow!(
-                "semantic model returned {} dimensions, expected {}",
-                embedding.len(),
-                SEMANTIC_DIMENSIONS
-            ));
-        }
-        normalize_embedding(embedding);
-    }
-    Ok(embeddings)
-}
-
-#[cfg(not(ctx_semantic_fastembed))]
-fn embed_texts(_embedder: &mut SemanticEmbedder, _texts: Vec<String>) -> Result<Vec<Vec<f32>>> {
-    Err(anyhow!(
-        "semantic embedding model {SEMANTIC_MODEL_ID} is not supported on this platform"
-    ))
-}
-
 #[allow(clippy::too_many_arguments)]
 fn backfill_semantic_embeddings(
     store: &Store,
     vector_store: &mut SemanticVectorStore,
-    embedder: &mut Option<SemanticEmbedder>,
+    embedder: &Arc<Mutex<Option<SemanticEmbedder>>>,
     model_init_ms: &mut Option<u64>,
     cache_dir: &Path,
     query_text: Option<&str>,
@@ -112,6 +86,14 @@ fn backfill_semantic_embeddings(
         if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
             break;
         }
+        let embedder_batch_size = lock_shared_semantic_embedder(embedder)?
+            .as_ref()
+            .map(|embedder| embedder.batch_size);
+        if embedder_batch_size.is_some_and(|batch_size| {
+            max_to_index.saturating_sub(indexed) < batch_size
+        }) {
+            break;
+        }
         let docs = store.recent_event_embedding_documents(before, 512)?;
         if docs.is_empty() {
             if continue_past_indexed_pages {
@@ -137,16 +119,10 @@ fn backfill_semantic_embeddings(
         )?;
         let added = outcome.indexed_chunks;
         indexed = indexed.saturating_add(added);
-        let consumed_event_ids = outcome
-            .consumed_event_ids
-            .iter()
-            .copied()
-            .collect::<HashSet<_>>();
-        let consumed_cursor = doc_cursors
-            .iter()
-            .rev()
-            .find(|(event_id, _)| consumed_event_ids.contains(event_id))
-            .map(|(_, cursor)| *cursor);
+        let consumed_cursor = semantic_contiguous_consumed_cursor(
+            &doc_cursors,
+            &outcome.consumed_event_ids,
+        );
         if !json_output {
             eprintln!("semantic index: embedded {indexed} chunks (scanned {scanned} events)");
         }
@@ -171,6 +147,18 @@ fn backfill_semantic_embeddings(
     Ok(indexed)
 }
 
+fn semantic_contiguous_consumed_cursor(
+    doc_cursors: &[(Uuid, (i64, u64))],
+    consumed_event_ids: &[Uuid],
+) -> Option<(i64, u64)> {
+    let consumed = consumed_event_ids.iter().copied().collect::<HashSet<_>>();
+    doc_cursors
+        .iter()
+        .take_while(|(event_id, _)| consumed.contains(event_id))
+        .last()
+        .map(|(_, cursor)| *cursor)
+}
+
 fn extend_existing_hashes_for_docs(
     vector_store: &SemanticVectorStore,
     existing_hashes: &mut HashMap<Uuid, String>,
@@ -191,7 +179,7 @@ fn extend_existing_hashes_for_docs(
 #[allow(clippy::too_many_arguments)]
 fn index_semantic_documents(
     vector_store: &mut SemanticVectorStore,
-    embedder: &mut Option<SemanticEmbedder>,
+    embedder: &Arc<Mutex<Option<SemanticEmbedder>>>,
     model_init_ms: &mut Option<u64>,
     cache_dir: &Path,
     existing_hashes: &mut HashMap<Uuid, String>,
@@ -205,7 +193,7 @@ fn index_semantic_documents(
     }
     let mut pending = Vec::<SemanticChunkDocument>::new();
     let mut unchanged_event_ids = Vec::new();
-    let mut pending_event_ids = Vec::new();
+    let mut considered_event_ids = Vec::new();
     for doc in docs {
         let source_text = semantic_source_text(&doc.text);
         let text_hash = semantic_document_hash(&doc, &source_text);
@@ -214,6 +202,7 @@ fn index_semantic_documents(
             .is_some_and(|existing| existing == &text_hash)
         {
             unchanged_event_ids.push(doc.event_id);
+            considered_event_ids.push(doc.event_id);
             continue;
         }
         let chunks = semantic_chunks_for_document(&doc, &source_text, &text_hash);
@@ -223,7 +212,7 @@ fn index_semantic_documents(
         if pending.len().saturating_add(chunks.len()) > limit && !pending.is_empty() {
             break;
         }
-        pending_event_ids.push(doc.event_id);
+        considered_event_ids.push(doc.event_id);
         pending.extend(chunks);
         if pending.len() >= limit {
             break;
@@ -232,28 +221,54 @@ fn index_semantic_documents(
     if pending.is_empty() {
         return Ok(SemanticIndexOutcome {
             indexed_chunks: 0,
-            consumed_event_ids: unchanged_event_ids,
+            consumed_event_ids: considered_event_ids,
         });
     }
     let texts = pending
         .iter()
         .map(|doc| doc.text.clone())
         .collect::<Vec<_>>();
-    if embedder.is_none() {
-        if !semantic_deadline_has_model_init_budget(deadline) {
-            return Ok(SemanticIndexOutcome {
-                indexed_chunks: 0,
-                consumed_event_ids: unchanged_event_ids,
-            });
+    {
+        let mut guard = lock_shared_semantic_embedder(embedder)?;
+        if guard.is_none() {
+            if !semantic_deadline_has_model_init_budget(deadline) {
+                return Ok(SemanticIndexOutcome {
+                    indexed_chunks: 0,
+                    consumed_event_ids: semantic_contiguous_consumed_event_ids(
+                        &considered_event_ids,
+                        &unchanged_event_ids,
+                    ),
+                });
+            }
+            let model_init_started = Instant::now();
+            *guard = Some(new_semantic_embedder(cache_dir)?);
+            *model_init_ms = Some(model_init_started.elapsed().as_millis() as u64);
         }
-        let model_init_started = Instant::now();
-        *embedder = Some(new_semantic_embedder(cache_dir)?);
-        *model_init_ms = Some(model_init_started.elapsed().as_millis() as u64);
     }
-    let embedder = embedder
-        .as_mut()
-        .ok_or_else(|| anyhow!("semantic embedder was not initialized"))?;
-    let embeddings = embed_texts(embedder, texts)?;
+    let batch_size = {
+        let guard = lock_shared_semantic_embedder(embedder)?;
+        let embedder = guard
+            .as_ref()
+            .ok_or_else(|| anyhow!("semantic embedder was not initialized"))?;
+        embedder
+            .batch_size
+            .min(embedder.quiet_policy().batch_size)
+            .max(1)
+    };
+    let mut embeddings = Vec::with_capacity(texts.len());
+    for batch in texts.chunks(batch_size) {
+        if semantic_deadline_reached(deadline) {
+            break;
+        }
+        let (batch_embeddings, _) =
+            embed_documents_with_shared_runtime(embedder, cache_dir, batch.to_vec(), deadline)?;
+        embeddings.extend(batch_embeddings);
+    }
+    let complete_prefix = semantic_complete_embedding_prefix(&pending, embeddings.len());
+    pending.truncate(complete_prefix);
+    embeddings.truncate(complete_prefix);
+    let mut completed_event_ids = pending.iter().map(|doc| doc.event_id).collect::<Vec<_>>();
+    completed_event_ids.dedup();
     let items = pending
         .into_iter()
         .zip(embeddings)
@@ -263,11 +278,48 @@ fn index_semantic_documents(
         })
         .collect::<Vec<_>>();
     vector_store.upsert_chunk_embeddings(&items)?;
-    unchanged_event_ids.extend(pending_event_ids);
+    unchanged_event_ids.extend(completed_event_ids);
+    let consumed_event_ids =
+        semantic_contiguous_consumed_event_ids(&considered_event_ids, &unchanged_event_ids);
     Ok(SemanticIndexOutcome {
         indexed_chunks: items.len(),
-        consumed_event_ids: unchanged_event_ids,
+        consumed_event_ids,
     })
+}
+
+fn semantic_contiguous_consumed_event_ids(
+    considered_event_ids: &[Uuid],
+    completed_event_ids: &[Uuid],
+) -> Vec<Uuid> {
+    let completed = completed_event_ids.iter().copied().collect::<HashSet<_>>();
+    considered_event_ids
+        .iter()
+        .copied()
+        .take_while(|event_id| completed.contains(event_id))
+        .collect()
+}
+
+fn semantic_deadline_reached(deadline: Option<Instant>) -> bool {
+    deadline.is_some_and(|deadline| Instant::now() >= deadline)
+}
+
+fn semantic_complete_embedding_prefix(
+    pending: &[SemanticChunkDocument],
+    embedded_len: usize,
+) -> usize {
+    let embedded_len = embedded_len.min(pending.len());
+    if embedded_len == 0 || embedded_len == pending.len() {
+        return embedded_len;
+    }
+    let last_embedded_event = pending[embedded_len - 1].event_id;
+    if pending[embedded_len].event_id != last_embedded_event {
+        return embedded_len;
+    }
+    pending[..embedded_len]
+        .iter()
+        .rposition(|doc| doc.event_id != last_embedded_event)
+        .map(|index| index + 1)
+        .unwrap_or(0)
 }
 
 fn semantic_deadline_chunk_limit(limit: usize, deadline: Option<Instant>) -> usize {
@@ -356,11 +408,29 @@ fn semantic_embedded_document_text(doc: &EventEmbeddingDocument, body: &str) -> 
 
 fn semantic_embedded_chunk_text(doc: &EventEmbeddingDocument, body: &str) -> String {
     let header = semantic_document_header(doc);
-    if header.is_empty() {
+    let text = if header.is_empty() {
         body.to_owned()
     } else {
         format!("{header}\n\n{body}")
+    };
+    semantic_e5_passage_text(&text)
+}
+
+fn semantic_e5_prefixed_text(prefix: &str, text: &str) -> String {
+    let text = text.trim_start();
+    if text.starts_with(prefix) {
+        text.to_owned()
+    } else {
+        format!("{prefix}{text}")
     }
+}
+
+fn semantic_e5_passage_text(text: &str) -> String {
+    semantic_e5_prefixed_text(SEMANTIC_PASSAGE_PREFIX, text)
+}
+
+fn semantic_e5_query_text_value(text: &str) -> String {
+    semantic_e5_prefixed_text(SEMANTIC_QUERY_PREFIX, text)
 }
 
 fn semantic_document_header(doc: &EventEmbeddingDocument) -> String {
@@ -475,16 +545,6 @@ fn semantic_text_hash(text: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(text.as_bytes());
     format!("{:x}", hasher.finalize())
-}
-
-#[cfg(ctx_semantic_fastembed)]
-fn normalize_embedding(values: &mut [f32]) {
-    let norm = values.iter().map(|value| value * value).sum::<f32>().sqrt();
-    if norm > 0.0 {
-        for value in values {
-            *value /= norm;
-        }
-    }
 }
 
 fn semantic_tokens(text: &str) -> Vec<String> {

--- a/crates/ctx-cli/src/semantic/model_acquisition.rs
+++ b/crates/ctx-cli/src/semantic/model_acquisition.rs
@@ -1,0 +1,1424 @@
+use std::{
+    collections::BTreeSet,
+    fmt, fs,
+    io::{self, Read, Write},
+    path::{Component, Path, PathBuf},
+    process,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+
+use anyhow::{anyhow, Context, Result};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use crate::output::compact_json;
+
+use super::model_bundle::{
+    completion_marker_matches, completion_marker_path, content_addressed_bundle_path,
+    validate_relative_path, verify_model_bundle, write_completion_marker_atomic,
+    VerifiedModelBundle, MANIFEST_SCHEMA_VERSION, MAX_BUNDLE_BYTES, MAX_BUNDLE_DIRECTORIES,
+    MAX_BUNDLE_FILES, MAX_FILE_BYTES,
+};
+
+const UNPROVISIONED_SHA256: &str =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+const MAX_ARCHIVE_BYTES: u64 = 1024 * 1024 * 1024;
+const MAX_EXPANDED_ARCHIVE_BYTES: u64 = MAX_BUNDLE_BYTES + 64 * 1024 * 1024;
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+const ARTIFACT_CACHE_DIR: &str = "semantic-model-artifacts";
+const ACQUISITION_LOCK_FILE: &str = "acquisition.lock";
+
+static ACQUISITION_NONCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CoreMlBundleDescriptor<'a> {
+    pub artifact_url: &'a str,
+    pub artifact_name: &'a str,
+    pub archive_sha256: &'a str,
+    pub manifest_sha256: &'a str,
+    pub bundle_id: &'a str,
+    pub bundle_version: &'a str,
+    pub schema_version: u32,
+    pub source_revision: &'a str,
+    pub minimum_macos: &'a str,
+    pub document_batch_size: u32,
+    pub query_batch_size: Option<u32>,
+    pub max_sequence_length: u32,
+    pub embedding_dimensions: u32,
+    pub document_prefix: &'a str,
+    pub query_prefix: &'a str,
+    pub pooling: &'a str,
+    pub normalization: &'a str,
+}
+
+// Update these values together after producing and independently verifying the
+// final deterministic archive. Zero hashes keep an unfinished descriptor inert.
+pub(crate) const COREML_BUNDLE_DESCRIPTOR: CoreMlBundleDescriptor<'static> =
+    CoreMlBundleDescriptor {
+        artifact_url: "https://cli.ctx.rs/storage/v1/object/public/releases/artifacts/ctx-multilingual-e5-small-coreml-fp16-1.0.0.tar.xz",
+        artifact_name: "ctx-multilingual-e5-small-coreml-fp16-1.0.0.tar.xz",
+        archive_sha256: "94c6fac5c4250079401d383adf1b10270fe5d370f2091dbad17bf4823222321e",
+        manifest_sha256: "576c68756563333fdf442e6859f2392ca0065b09a2cb5d73983e30de75df1ad6",
+        bundle_id: "ctx.multilingual-e5-small.coreml.fp16",
+        bundle_version: "1.0.0",
+        schema_version: MANIFEST_SCHEMA_VERSION,
+        source_revision: "614241f622f53c4eeff9890bdc4f31cfecc418b3",
+        minimum_macos: "13.0",
+        document_batch_size: 16,
+        query_batch_size: Some(1),
+        max_sequence_length: 512,
+        embedding_dimensions: 384,
+        document_prefix: "passage: ",
+        query_prefix: "query: ",
+        pooling: "attention_mask_mean",
+        normalization: "l2",
+    };
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ModelAcquisitionErrorKind {
+    Unavailable,
+    Integrity,
+}
+
+#[derive(Debug)]
+pub(crate) struct ModelAcquisitionError {
+    kind: ModelAcquisitionErrorKind,
+    message: String,
+}
+
+impl fmt::Display for ModelAcquisitionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let class = match self.kind {
+            ModelAcquisitionErrorKind::Unavailable => "unavailable",
+            ModelAcquisitionErrorKind::Integrity => "integrity failure",
+        };
+        write!(formatter, "Core ML model {class}: {}", self.message)
+    }
+}
+
+impl std::error::Error for ModelAcquisitionError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CoreMlAcquisitionSource {
+    Cache,
+    Download,
+}
+
+#[derive(Debug)]
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) struct AcquiredCoreMlBundle {
+    pub bundle: VerifiedModelBundle,
+    pub source: CoreMlAcquisitionSource,
+}
+
+pub(crate) fn model_acquisition_error_kind(
+    error: &anyhow::Error,
+) -> Option<ModelAcquisitionErrorKind> {
+    error
+        .downcast_ref::<ModelAcquisitionError>()
+        .map(|error| error.kind)
+}
+
+pub(crate) fn model_acquisition_integrity_error(error: &anyhow::Error) -> bool {
+    model_acquisition_error_kind(error) == Some(ModelAcquisitionErrorKind::Integrity)
+}
+
+pub(crate) fn coreml_descriptor_provisioned() -> bool {
+    descriptor_provisioned(&COREML_BUNDLE_DESCRIPTOR)
+}
+
+pub(crate) fn coreml_bundle_cache_available(cache_root: &Path) -> bool {
+    descriptor_cache_complete(cache_root, &COREML_BUNDLE_DESCRIPTOR)
+}
+
+pub(crate) fn coreml_acquisition_status_json(cache_root: &Path) -> Value {
+    let descriptor = &COREML_BUNDLE_DESCRIPTOR;
+    let provisioned = descriptor_provisioned(descriptor);
+    let cache_status = if !provisioned {
+        "descriptor_unprovisioned"
+    } else {
+        descriptor_cache_status(cache_root, descriptor)
+    };
+    compact_json(json!({
+        "artifact_name": descriptor.artifact_name,
+        "bundle_id": descriptor.bundle_id,
+        "bundle_version": descriptor.bundle_version,
+        "schema_version": descriptor.schema_version,
+        "source_revision": descriptor.source_revision,
+        "minimum_macos": descriptor.minimum_macos,
+        "tensor_contract": {
+            "document_batch_size": descriptor.document_batch_size,
+            "query_batch_size": descriptor.query_batch_size,
+            "max_sequence_length": descriptor.max_sequence_length,
+            "embedding_dimensions": descriptor.embedding_dimensions,
+            "document_prefix": descriptor.document_prefix,
+            "query_prefix": descriptor.query_prefix,
+            "pooling": descriptor.pooling,
+            "normalization": descriptor.normalization,
+        },
+        "descriptor_provisioned": provisioned,
+        "cache_status": cache_status,
+        "network_scope": "daemon_only",
+    }))
+}
+
+pub(crate) fn cached_coreml_bundle(cache_root: &Path) -> Result<Option<VerifiedModelBundle>> {
+    cached_coreml_bundle_for(cache_root, &COREML_BUNDLE_DESCRIPTOR)
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) fn acquire_coreml_bundle_for_daemon(cache_root: &Path) -> Result<AcquiredCoreMlBundle> {
+    acquire_coreml_bundle_for(cache_root, &COREML_BUNDLE_DESCRIPTOR)
+}
+
+fn descriptor_provisioned(descriptor: &CoreMlBundleDescriptor<'_>) -> bool {
+    descriptor.archive_sha256 != UNPROVISIONED_SHA256
+        && descriptor.manifest_sha256 != UNPROVISIONED_SHA256
+}
+
+fn validate_descriptor(descriptor: &CoreMlBundleDescriptor<'_>) -> Result<()> {
+    if !descriptor_provisioned(descriptor) {
+        return Err(acquisition_error(
+            ModelAcquisitionErrorKind::Unavailable,
+            "compiled bundle descriptor is awaiting final artifact hashes",
+        ));
+    }
+    for (name, digest) in [
+        ("archive", descriptor.archive_sha256),
+        ("manifest", descriptor.manifest_sha256),
+    ] {
+        if digest.len() != 64
+            || !digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(acquisition_error(
+                ModelAcquisitionErrorKind::Integrity,
+                format!("compiled {name} SHA-256 is invalid"),
+            ));
+        }
+    }
+    if descriptor.schema_version != MANIFEST_SCHEMA_VERSION
+        || descriptor.artifact_name.is_empty()
+        || descriptor.artifact_name.contains('/')
+        || !descriptor.artifact_name.ends_with(".tar.xz")
+        || !descriptor.artifact_url.ends_with(descriptor.artifact_name)
+    {
+        return Err(acquisition_error(
+            ModelAcquisitionErrorKind::Integrity,
+            "compiled bundle descriptor is internally inconsistent",
+        ));
+    }
+    Ok(())
+}
+
+fn descriptor_bundle_path(
+    cache_root: &Path,
+    descriptor: &CoreMlBundleDescriptor<'_>,
+) -> Result<PathBuf> {
+    content_addressed_bundle_path(cache_root, descriptor.manifest_sha256)
+        .map_err(|error| acquisition_error(ModelAcquisitionErrorKind::Integrity, error.to_string()))
+}
+
+fn descriptor_cache_complete(cache_root: &Path, descriptor: &CoreMlBundleDescriptor<'_>) -> bool {
+    if validate_descriptor(descriptor).is_err() {
+        return false;
+    }
+    let Ok(path) = descriptor_bundle_path(cache_root, descriptor) else {
+        return false;
+    };
+    path.is_dir() && completion_marker_matches(&path, descriptor.manifest_sha256).unwrap_or(false)
+}
+
+fn descriptor_cache_status(
+    cache_root: &Path,
+    descriptor: &CoreMlBundleDescriptor<'_>,
+) -> &'static str {
+    let Ok(path) = descriptor_bundle_path(cache_root, descriptor) else {
+        return "integrity_error";
+    };
+    let Ok(marker) = completion_marker_path(&path) else {
+        return "integrity_error";
+    };
+    let path_exists = fs::symlink_metadata(&path).is_ok();
+    let marker_exists = fs::symlink_metadata(&marker).is_ok();
+    match (path_exists, marker_exists) {
+        (false, false) => "missing",
+        (true, true)
+            if completion_marker_matches(&path, descriptor.manifest_sha256).unwrap_or(false) =>
+        {
+            "available"
+        }
+        _ => "integrity_error",
+    }
+}
+
+fn cached_coreml_bundle_for(
+    cache_root: &Path,
+    descriptor: &CoreMlBundleDescriptor<'_>,
+) -> Result<Option<VerifiedModelBundle>> {
+    validate_descriptor(descriptor)?;
+    ensure_macos_version_supported(descriptor.minimum_macos)?;
+    let path = descriptor_bundle_path(cache_root, descriptor)?;
+    let marker = completion_marker_path(&path).map_err(|error| {
+        acquisition_error(ModelAcquisitionErrorKind::Integrity, error.to_string())
+    })?;
+    let path_exists = fs::symlink_metadata(&path).is_ok();
+    let marker_exists = fs::symlink_metadata(&marker).is_ok();
+    if !path_exists && !marker_exists {
+        return Ok(None);
+    }
+    if !path_exists || !marker_exists {
+        return Err(acquisition_error(
+            ModelAcquisitionErrorKind::Integrity,
+            "content-addressed cache entry is incomplete",
+        ));
+    }
+    if !completion_marker_matches(&path, descriptor.manifest_sha256).map_err(|error| {
+        acquisition_error(ModelAcquisitionErrorKind::Integrity, error.to_string())
+    })? {
+        return Err(acquisition_error(
+            ModelAcquisitionErrorKind::Integrity,
+            "content-addressed cache completion marker does not match the descriptor",
+        ));
+    }
+    let bundle = verify_descriptor_bundle(&path, descriptor)?;
+    Ok(Some(bundle))
+}
+
+fn acquire_coreml_bundle_for(
+    cache_root: &Path,
+    descriptor: &CoreMlBundleDescriptor<'_>,
+) -> Result<AcquiredCoreMlBundle> {
+    validate_descriptor(descriptor)?;
+    ensure_macos_version_supported(descriptor.minimum_macos)?;
+    create_private_dir_all(cache_root)?;
+    let artifacts = cache_root.join(ARTIFACT_CACHE_DIR);
+    create_private_dir_all(&artifacts)?;
+    let _acquisition_lock = lock_coreml_acquisition(&artifacts)?;
+
+    repair_interrupted_cache_publication(cache_root, descriptor)?;
+    if let Some(bundle) = cached_coreml_bundle_for(cache_root, descriptor)? {
+        return Ok(AcquiredCoreMlBundle {
+            bundle,
+            source: CoreMlAcquisitionSource::Cache,
+        });
+    }
+    let archive_path = unique_child(&artifacts, "download", "tar.xz");
+    let staging_path = unique_child(&artifacts, "extract", "bundle");
+
+    let result = (|| -> Result<AcquiredCoreMlBundle> {
+        let mut archive_file = create_new_private_file(&archive_path)
+            .with_context(|| "create Core ML archive staging file")?;
+        crate::net::get_to_writer_limited(
+            descriptor.artifact_url,
+            MAX_ARCHIVE_BYTES,
+            DOWNLOAD_TIMEOUT,
+            &mut archive_file,
+        )
+        .map_err(|error| {
+            acquisition_error(
+                ModelAcquisitionErrorKind::Unavailable,
+                format!("artifact download failed: {error}"),
+            )
+        })?;
+        archive_file
+            .sync_all()
+            .context("sync Core ML archive staging file")?;
+        drop(archive_file);
+        verify_archive_hash(&archive_path, descriptor.archive_sha256)?;
+
+        fs::create_dir(&staging_path).context("create Core ML extraction staging directory")?;
+        extract_archive(&archive_path, &staging_path, descriptor)?;
+        let bundle = verify_descriptor_bundle(&staging_path, descriptor)?;
+        let final_path = descriptor_bundle_path(cache_root, descriptor)?;
+        install_bundle(&staging_path, &final_path, descriptor)?;
+        let installed = cached_coreml_bundle_for(cache_root, descriptor)?.ok_or_else(|| {
+            acquisition_error(
+                ModelAcquisitionErrorKind::Integrity,
+                "installed bundle was not visible after atomic publication",
+            )
+        })?;
+        debug_assert_eq!(bundle.manifest_sha256, installed.manifest_sha256);
+        Ok(AcquiredCoreMlBundle {
+            bundle: installed,
+            source: CoreMlAcquisitionSource::Download,
+        })
+    })();
+
+    let _ = fs::remove_file(&archive_path);
+    remove_real_directory_if_present(&staging_path);
+    result
+}
+
+fn repair_interrupted_cache_publication(
+    cache_root: &Path,
+    descriptor: &CoreMlBundleDescriptor<'_>,
+) -> Result<()> {
+    validate_descriptor(descriptor)?;
+    let path = descriptor_bundle_path(cache_root, descriptor)?;
+    let marker = completion_marker_path(&path).map_err(|error| {
+        acquisition_error(ModelAcquisitionErrorKind::Integrity, error.to_string())
+    })?;
+    let path_metadata = metadata_if_present(&path)?;
+    let marker_metadata = metadata_if_present(&marker)?;
+
+    match (path_metadata, marker_metadata) {
+        (Some(metadata), None) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
+            ensure_repair_target_inside_cache(cache_root, &path)?;
+            fs::remove_dir_all(&path).map_err(|error| {
+                acquisition_error(
+                    ModelAcquisitionErrorKind::Unavailable,
+                    format!(
+                        "remove interrupted Core ML bundle publication {}: {error}",
+                        path.display()
+                    ),
+                )
+            })?;
+        }
+        (None, Some(metadata)) if metadata.is_file() && !metadata.file_type().is_symlink() => {
+            ensure_repair_target_inside_cache(cache_root, &marker)?;
+            fs::remove_file(&marker).map_err(|error| {
+                acquisition_error(
+                    ModelAcquisitionErrorKind::Unavailable,
+                    format!(
+                        "remove interrupted Core ML completion marker {}: {error}",
+                        marker.display()
+                    ),
+                )
+            })?;
+        }
+        (Some(_), None) | (None, Some(_)) => {
+            return Err(acquisition_error(
+                ModelAcquisitionErrorKind::Integrity,
+                "refusing to repair incomplete content-addressed cache entry with an unexpected filesystem type",
+            ));
+        }
+        (None, None) | (Some(_), Some(_)) => {}
+    }
+    Ok(())
+}
+
+fn ensure_repair_target_inside_cache(cache_root: &Path, target: &Path) -> Result<()> {
+    let canonical_root = fs::canonicalize(cache_root).map_err(|error| {
+        acquisition_error(
+            ModelAcquisitionErrorKind::Integrity,
+            format!(
+                "resolve Core ML cache root {} before repair: {error}",
+                cache_root.display()
+            ),
+        )
+    })?;
+    let parent = target.parent().ok_or_else(|| {
+        acquisition_error(
+            ModelAcquisitionErrorKind::Integrity,
+            "Core ML cache repair target has no parent",
+        )
+    })?;
+    let canonical_parent = fs::canonicalize(parent).map_err(|error| {
+        acquisition_error(
+            ModelAcquisitionErrorKind::Integrity,
+            format!(
+                "resolve Core ML cache repair parent {}: {error}",
+                parent.display()
+            ),
+        )
+    })?;
+    if !canonical_parent.starts_with(&canonical_root) {
+        return Err(acquisition_error(
+            ModelAcquisitionErrorKind::Integrity,
+            "refusing to repair a content-addressed cache entry outside the configured cache root",
+        ));
+    }
+    Ok(())
+}
+
+fn metadata_if_present(path: &Path) -> Result<Option<fs::Metadata>> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(acquisition_error(
+            ModelAcquisitionErrorKind::Unavailable,
+            format!("inspect Core ML cache path {}: {error}", path.display()),
+        )),
+    }
+}
+
+fn verify_archive_hash(path: &Path, expected: &str) -> Result<()> {
+    let mut file = fs::File::open(path).context("open downloaded Core ML archive")?;
+    let mut digest = Sha256::new();
+    let mut count = 0_u64;
+    let mut buffer = [0_u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer).context("hash Core ML archive")?;
+        if read == 0 {
+            break;
+        }
+        count = count.saturating_add(read as u64);
+        if count > MAX_ARCHIVE_BYTES {
+            return Err(acquisition_error(
+                ModelAcquisitionErrorKind::Integrity,
+                "downloaded archive exceeds compressed size limit",
+            ));
+        }
+        digest.update(&buffer[..read]);
+    }
+    let actual = format!("{:x}", digest.finalize());
+    if actual != expected {
+        return Err(acquisition_error(
+            ModelAcquisitionErrorKind::Integrity,
+            "downloaded archive SHA-256 does not match the compiled descriptor",
+        ));
+    }
+    Ok(())
+}
+
+fn extract_archive(
+    archive_path: &Path,
+    destination: &Path,
+    descriptor: &CoreMlBundleDescriptor<'_>,
+) -> Result<()> {
+    let file = fs::File::open(archive_path).context("open verified Core ML archive")?;
+    let decoder = xz2::read::XzDecoder::new(file);
+    let bounded = ExpandedReader::new(decoder, MAX_EXPANDED_ARCHIVE_BYTES);
+    let mut archive = tar::Archive::new(bounded);
+    let expected_root = descriptor
+        .artifact_name
+        .strip_suffix(".tar.xz")
+        .ok_or_else(|| {
+            acquisition_error(ModelAcquisitionErrorKind::Integrity, "invalid archive name")
+        })?;
+    let mut seen = BTreeSet::new();
+    let mut directories = BTreeSet::new();
+    let mut files = 0_usize;
+    let mut payload_bytes = 0_u64;
+    let entries = archive.entries().map_err(archive_error)?;
+    for item in entries {
+        let mut entry = item.map_err(archive_error)?;
+        let raw_path = entry.path().map_err(archive_error)?;
+        let relative = archive_relative_path(&raw_path, expected_root)?;
+        if relative.is_empty() {
+            if !entry.header().entry_type().is_dir() || !seen.insert(String::new()) {
+                return Err(archive_integrity(
+                    "archive root entry is invalid or duplicated",
+                ));
+            }
+            continue;
+        }
+        validate_relative_path(&relative).map_err(|error| archive_integrity(error.to_string()))?;
+        if !seen.insert(relative.clone()) {
+            return Err(archive_integrity("archive contains duplicate paths"));
+        }
+        let target = destination.join(&relative);
+        let entry_type = entry.header().entry_type();
+        if entry_type.is_dir() {
+            register_directory(destination, &target, &relative, &mut directories)?;
+            continue;
+        }
+        if !entry_type.is_file() {
+            return Err(archive_integrity(
+                "archive contains a link, device, sparse, or unknown entry type",
+            ));
+        }
+        files += 1;
+        if files > MAX_BUNDLE_FILES {
+            return Err(archive_integrity("archive contains too many files"));
+        }
+        let size = entry.header().size().map_err(archive_error)?;
+        if size > MAX_FILE_BYTES {
+            return Err(archive_integrity(
+                "archive member exceeds per-file size limit",
+            ));
+        }
+        payload_bytes = payload_bytes
+            .checked_add(size)
+            .ok_or_else(|| archive_integrity("archive payload size overflow"))?;
+        if payload_bytes > MAX_BUNDLE_BYTES {
+            return Err(archive_integrity(
+                "archive exceeds expanded payload size limit",
+            ));
+        }
+        create_parent_directories(destination, &target, &relative, &mut directories)?;
+        let mut output = create_new_private_file(&target)
+            .map_err(|error| archive_integrity(format!("create extracted file: {error}")))?;
+        let copied = copy_exact_limited(&mut entry, &mut output, size)?;
+        if copied != size {
+            return Err(archive_integrity(
+                "archive member size does not match its header",
+            ));
+        }
+        output
+            .sync_all()
+            .map_err(|error| archive_integrity(format!("sync extracted file: {error}")))?;
+    }
+    if files == 0 {
+        return Err(archive_integrity("archive contains no payload files"));
+    }
+    Ok(())
+}
+
+fn archive_relative_path(path: &Path, expected_root: &str) -> Result<String> {
+    let mut components = path.components();
+    let Some(Component::Normal(root)) = components.next() else {
+        return Err(archive_integrity(
+            "archive path has no normal root component",
+        ));
+    };
+    if root.to_str() != Some(expected_root) {
+        return Err(archive_integrity(
+            "archive path has an unexpected root directory",
+        ));
+    }
+    let mut parts = Vec::new();
+    for component in components {
+        let Component::Normal(component) = component else {
+            return Err(archive_integrity("archive path contains traversal"));
+        };
+        parts.push(
+            component
+                .to_str()
+                .ok_or_else(|| archive_integrity("archive path is not UTF-8"))?,
+        );
+    }
+    Ok(parts.join("/"))
+}
+
+fn register_directory(
+    destination: &Path,
+    target: &Path,
+    relative: &str,
+    directories: &mut BTreeSet<String>,
+) -> Result<()> {
+    create_parent_directories(destination, target, relative, directories)?;
+    if directories.insert(relative.to_owned()) {
+        if directories.len() > MAX_BUNDLE_DIRECTORIES {
+            return Err(archive_integrity("archive contains too many directories"));
+        }
+        match fs::create_dir(target) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists && target.is_dir() => {}
+            Err(error) => {
+                return Err(archive_integrity(format!(
+                    "create extracted directory: {error}"
+                )))
+            }
+        }
+    }
+    Ok(())
+}
+
+fn create_parent_directories(
+    destination: &Path,
+    target: &Path,
+    relative: &str,
+    directories: &mut BTreeSet<String>,
+) -> Result<()> {
+    let Some(parent) = target.parent() else {
+        return Err(archive_integrity("archive target has no parent"));
+    };
+    if parent == destination {
+        return Ok(());
+    }
+    let mut current = destination.to_path_buf();
+    let mut name = String::new();
+    let parent_relative = Path::new(relative)
+        .parent()
+        .ok_or_else(|| archive_integrity("archive path parent is invalid"))?;
+    for component in parent_relative.components() {
+        let Component::Normal(component) = component else {
+            return Err(archive_integrity("archive parent path contains traversal"));
+        };
+        let component = component
+            .to_str()
+            .ok_or_else(|| archive_integrity("archive parent path is not UTF-8"))?;
+        if !name.is_empty() {
+            name.push('/');
+        }
+        name.push_str(component);
+        current.push(component);
+        if directories.insert(name.clone()) {
+            if directories.len() > MAX_BUNDLE_DIRECTORIES {
+                return Err(archive_integrity("archive contains too many directories"));
+            }
+            fs::create_dir(&current).map_err(|error| {
+                archive_integrity(format!("create extracted parent directory: {error}"))
+            })?;
+        } else if !current.is_dir() {
+            return Err(archive_integrity(
+                "archive path collides with a non-directory entry",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn copy_exact_limited(
+    reader: &mut impl Read,
+    writer: &mut impl Write,
+    expected: u64,
+) -> Result<u64> {
+    let mut limited = reader.take(expected.saturating_add(1));
+    let copied = io::copy(&mut limited, writer)
+        .map_err(|error| archive_integrity(format!("extract archive member: {error}")))?;
+    if copied > expected {
+        return Err(archive_integrity(
+            "archive member exceeds its declared size",
+        ));
+    }
+    Ok(copied)
+}
+
+fn verify_descriptor_bundle(
+    root: &Path,
+    descriptor: &CoreMlBundleDescriptor<'_>,
+) -> Result<VerifiedModelBundle> {
+    let bundle = verify_model_bundle(root).map_err(|error| {
+        acquisition_error(ModelAcquisitionErrorKind::Integrity, error.to_string())
+    })?;
+    if bundle.manifest_sha256 != descriptor.manifest_sha256
+        || bundle.manifest.schema_version != descriptor.schema_version
+        || bundle.manifest.bundle_id != descriptor.bundle_id
+        || bundle.manifest.bundle_version != descriptor.bundle_version
+        || bundle.manifest.model.source_revision != descriptor.source_revision
+        || bundle.manifest.tensor_contract.document_batch_size != descriptor.document_batch_size
+        || bundle.manifest.tensor_contract.query_batch_size != descriptor.query_batch_size
+        || bundle.manifest.tensor_contract.max_sequence_length != descriptor.max_sequence_length
+        || bundle.manifest.tensor_contract.embedding_dimensions != descriptor.embedding_dimensions
+        || bundle.manifest.tensor_contract.document_prefix != descriptor.document_prefix
+        || bundle.manifest.tensor_contract.query_prefix != descriptor.query_prefix
+        || bundle.manifest.tensor_contract.pooling != descriptor.pooling
+        || bundle.manifest.tensor_contract.normalization != descriptor.normalization
+    {
+        return Err(acquisition_error(
+            ModelAcquisitionErrorKind::Integrity,
+            "bundle manifest does not match the compiled descriptor",
+        ));
+    }
+    Ok(bundle)
+}
+
+fn install_bundle(
+    staging: &Path,
+    final_path: &Path,
+    descriptor: &CoreMlBundleDescriptor<'_>,
+) -> Result<()> {
+    let parent = final_path
+        .parent()
+        .ok_or_else(|| archive_integrity("bundle cache path has no parent"))?;
+    create_private_dir_all(parent)?;
+    match fs::rename(staging, final_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists || final_path.exists() => {
+            verify_descriptor_bundle(final_path, descriptor)?;
+            remove_real_directory_if_present(staging);
+        }
+        Err(error) => {
+            return Err(acquisition_error(
+                ModelAcquisitionErrorKind::Unavailable,
+                format!("atomically publish model bundle: {error}"),
+            ))
+        }
+    }
+    write_completion_marker_atomic(final_path).map_err(|error| {
+        acquisition_error(ModelAcquisitionErrorKind::Integrity, error.to_string())
+    })?;
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn ensure_macos_version_supported(minimum: &str) -> Result<()> {
+    let output = std::process::Command::new("sw_vers")
+        .arg("-productVersion")
+        .output()
+        .map_err(|error| {
+            acquisition_error(
+                ModelAcquisitionErrorKind::Unavailable,
+                format!("could not determine macOS version: {error}"),
+            )
+        })?;
+    if !output.status.success() {
+        return Err(acquisition_error(
+            ModelAcquisitionErrorKind::Unavailable,
+            "could not determine macOS version",
+        ));
+    }
+    let actual = String::from_utf8_lossy(&output.stdout);
+    if !version_at_least(actual.trim(), minimum)? {
+        return Err(acquisition_error(
+            ModelAcquisitionErrorKind::Unavailable,
+            format!("requires macOS {minimum} or newer"),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn ensure_macos_version_supported(_minimum: &str) -> Result<()> {
+    #[cfg(test)]
+    return Ok(());
+    #[cfg(not(test))]
+    Err(acquisition_error(
+        ModelAcquisitionErrorKind::Unavailable,
+        "Core ML requires macOS",
+    ))
+}
+
+fn version_at_least(actual: &str, minimum: &str) -> Result<bool> {
+    fn parse(value: &str) -> Result<Vec<u64>> {
+        let parts = value
+            .split('.')
+            .map(|part| part.parse::<u64>())
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|_| {
+                acquisition_error(
+                    ModelAcquisitionErrorKind::Unavailable,
+                    "macOS version has invalid syntax",
+                )
+            })?;
+        if parts.is_empty() || parts.len() > 3 {
+            return Err(acquisition_error(
+                ModelAcquisitionErrorKind::Unavailable,
+                "macOS version has invalid syntax",
+            ));
+        }
+        Ok(parts)
+    }
+    let mut actual = parse(actual)?;
+    let mut minimum = parse(minimum)?;
+    actual.resize(3, 0);
+    minimum.resize(3, 0);
+    Ok(actual >= minimum)
+}
+
+fn create_private_dir_all(path: &Path) -> Result<()> {
+    fs::create_dir_all(path)
+        .with_context(|| format!("create model cache directory {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
+}
+
+fn create_new_private_file(path: &Path) -> io::Result<fs::File> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
+}
+
+fn lock_coreml_acquisition(artifacts: &Path) -> Result<fs::File> {
+    let lock_path = artifacts.join(ACQUISITION_LOCK_FILE);
+    if let Some(metadata) = metadata_if_present(&lock_path)? {
+        if !metadata.is_file() || metadata.file_type().is_symlink() {
+            return Err(acquisition_error(
+                ModelAcquisitionErrorKind::Integrity,
+                "Core ML acquisition lock has an unexpected filesystem type",
+            ));
+        }
+    }
+
+    let mut options = fs::OpenOptions::new();
+    options.create(true).truncate(false).read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let lock = options.open(&lock_path).map_err(|error| {
+        acquisition_error(
+            ModelAcquisitionErrorKind::Unavailable,
+            format!(
+                "open Core ML acquisition lock {}: {error}",
+                lock_path.display()
+            ),
+        )
+    })?;
+    let metadata = fs::symlink_metadata(&lock_path).map_err(|error| {
+        acquisition_error(
+            ModelAcquisitionErrorKind::Unavailable,
+            format!(
+                "inspect Core ML acquisition lock {}: {error}",
+                lock_path.display()
+            ),
+        )
+    })?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return Err(acquisition_error(
+            ModelAcquisitionErrorKind::Integrity,
+            "Core ML acquisition lock has an unexpected filesystem type",
+        ));
+    }
+
+    match fs2::FileExt::try_lock_exclusive(&lock) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+            #[cfg(test)]
+            notify_acquisition_lock_contended();
+            fs2::FileExt::lock_exclusive(&lock).map_err(|error| {
+                acquisition_error(
+                    ModelAcquisitionErrorKind::Unavailable,
+                    format!("lock Core ML acquisition {}: {error}", lock_path.display()),
+                )
+            })?;
+        }
+        Err(error) => {
+            return Err(acquisition_error(
+                ModelAcquisitionErrorKind::Unavailable,
+                format!("lock Core ML acquisition {}: {error}", lock_path.display()),
+            ));
+        }
+    }
+    Ok(lock)
+}
+
+#[cfg(test)]
+std::thread_local! {
+    static ACQUISITION_LOCK_CONTENDED_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(test)]
+fn set_acquisition_lock_contended_hook(hook: impl FnOnce() + 'static) {
+    ACQUISITION_LOCK_CONTENDED_HOOK.with(|slot| {
+        *slot.borrow_mut() = Some(Box::new(hook));
+    });
+}
+
+#[cfg(test)]
+fn notify_acquisition_lock_contended() {
+    ACQUISITION_LOCK_CONTENDED_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+fn unique_child(parent: &Path, purpose: &str, extension: &str) -> PathBuf {
+    let nonce = ACQUISITION_NONCE.fetch_add(1, Ordering::Relaxed);
+    parent.join(format!(
+        ".ctx-coreml-{purpose}-{}-{nonce}.{extension}",
+        process::id()
+    ))
+}
+
+fn remove_real_directory_if_present(path: &Path) {
+    if fs::symlink_metadata(path)
+        .map(|metadata| metadata.is_dir() && !metadata.file_type().is_symlink())
+        .unwrap_or(false)
+    {
+        let _ = fs::remove_dir_all(path);
+    }
+}
+
+fn acquisition_error(kind: ModelAcquisitionErrorKind, message: impl Into<String>) -> anyhow::Error {
+    anyhow!(ModelAcquisitionError {
+        kind,
+        message: message.into(),
+    })
+}
+
+fn archive_integrity(message: impl Into<String>) -> anyhow::Error {
+    acquisition_error(ModelAcquisitionErrorKind::Integrity, message)
+}
+
+fn archive_error(error: io::Error) -> anyhow::Error {
+    archive_integrity(format!("read compressed archive: {error}"))
+}
+
+struct ExpandedReader<R> {
+    inner: R,
+    read: u64,
+    maximum: u64,
+}
+
+impl<R> ExpandedReader<R> {
+    fn new(inner: R, maximum: u64) -> Self {
+        Self {
+            inner,
+            read: 0,
+            maximum,
+        }
+    }
+}
+
+impl<R: Read> Read for ExpandedReader<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        let count = self.inner.read(buffer)?;
+        self.read = self.read.saturating_add(count as u64);
+        if self.read > self.maximum {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "expanded archive exceeds size limit",
+            ));
+        }
+        Ok(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const A_HASH: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const B_HASH: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    #[test]
+    fn production_descriptor_is_hash_pinned_and_cache_probe_is_offline() {
+        assert!(coreml_descriptor_provisioned());
+        assert_eq!(COREML_BUNDLE_DESCRIPTOR.document_batch_size, 16);
+        assert_eq!(COREML_BUNDLE_DESCRIPTOR.query_batch_size, Some(1));
+        let temp = tempfile::tempdir().unwrap();
+        assert!(cached_coreml_bundle(temp.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn cache_only_probe_never_reads_artifact_url() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp
+            .path()
+            .join("ctx-multilingual-e5-small-coreml-fp16-1.0.0.tar.xz");
+        let artifact_url = format!("file://{}", missing.display());
+        let descriptor = test_descriptor(&artifact_url, A_HASH, B_HASH);
+        assert!(cached_coreml_bundle_for(temp.path(), &descriptor)
+            .unwrap()
+            .is_none());
+        assert!(!missing.exists());
+    }
+
+    #[test]
+    fn archive_hash_mismatch_is_an_integrity_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        let archive = temp
+            .path()
+            .join("ctx-multilingual-e5-small-coreml-fp16-1.0.0.tar.xz");
+        fs::write(&archive, b"not an archive").unwrap();
+        let artifact_url = format!("file://{}", archive.display());
+        let descriptor = test_descriptor(&artifact_url, A_HASH, B_HASH);
+        let error = acquire_coreml_bundle_for(temp.path(), &descriptor).unwrap_err();
+        assert!(model_acquisition_integrity_error(&error));
+        assert!(format!("{error:#}").contains("SHA-256"));
+    }
+
+    #[test]
+    fn archive_paths_and_entry_types_fail_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        for (path, entry_type) in [
+            (
+                "ctx-multilingual-e5-small-coreml-fp16-1.0.0/../escape",
+                tar::EntryType::Regular,
+            ),
+            (
+                "ctx-multilingual-e5-small-coreml-fp16-1.0.0/link",
+                tar::EntryType::Symlink,
+            ),
+            (
+                "ctx-multilingual-e5-small-coreml-fp16-1.0.0/device",
+                tar::EntryType::Char,
+            ),
+            (
+                "ctx-multilingual-e5-small-coreml-fp16-1.0.0/hardlink",
+                tar::EntryType::Link,
+            ),
+            (
+                "ctx-multilingual-e5-small-coreml-fp16-1.0.0/fifo",
+                tar::EntryType::Fifo,
+            ),
+            (
+                "ctx-multilingual-e5-small-coreml-fp16-1.0.0/unknown",
+                tar::EntryType::new(b'Z'),
+            ),
+        ] {
+            let archive = temp
+                .path()
+                .join(format!("{}.tar.xz", path.rsplit('/').next().unwrap()));
+            write_test_archive(&archive, &[(path, entry_type, b"x")]);
+            let output = temp.path().join(format!("out-{}", entry_type.as_byte()));
+            fs::create_dir(&output).unwrap();
+            let descriptor = test_descriptor("file:///unused", A_HASH, B_HASH);
+            let error = extract_archive(&archive, &output, &descriptor).unwrap_err();
+            assert!(model_acquisition_integrity_error(&error));
+        }
+    }
+
+    #[test]
+    fn archive_duplicate_paths_are_rejected() {
+        let temp = tempfile::tempdir().unwrap();
+        let archive = temp.path().join("duplicate.tar.xz");
+        write_test_archive(
+            &archive,
+            &[
+                (
+                    "ctx-multilingual-e5-small-coreml-fp16-1.0.0/file",
+                    tar::EntryType::Regular,
+                    b"a",
+                ),
+                (
+                    "ctx-multilingual-e5-small-coreml-fp16-1.0.0/file",
+                    tar::EntryType::Regular,
+                    b"b",
+                ),
+            ],
+        );
+        let output = temp.path().join("output");
+        fs::create_dir(&output).unwrap();
+        let descriptor = test_descriptor("file:///unused", A_HASH, B_HASH);
+        let error = extract_archive(&archive, &output, &descriptor).unwrap_err();
+        assert!(format!("{error:#}").contains("duplicate"));
+    }
+
+    #[test]
+    fn macos_versions_compare_numerically() {
+        assert!(version_at_least("14.7.5", "13.0").unwrap());
+        assert!(version_at_least("13.0", "13.0").unwrap());
+        assert!(!version_at_least("12.6.9", "13.0").unwrap());
+        assert!(version_at_least("13.0.1", "13.0").unwrap());
+    }
+
+    #[test]
+    fn verified_archive_installs_content_addressed_and_then_uses_cache_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let (archive_path, archive_sha256, manifest_sha256) =
+            create_test_bundle_archive(temp.path());
+        let artifact_url = format!("file://{}", archive_path.display());
+        let descriptor = test_descriptor(&artifact_url, &archive_sha256, &manifest_sha256);
+        let cache = temp.path().join("cache");
+
+        let acquired = acquire_coreml_bundle_for(&cache, &descriptor).unwrap();
+        assert_eq!(acquired.source, CoreMlAcquisitionSource::Download);
+        assert_eq!(acquired.bundle.manifest_sha256, manifest_sha256);
+        let installed = descriptor_bundle_path(&cache, &descriptor).unwrap();
+        assert!(completion_marker_matches(&installed, &manifest_sha256).unwrap());
+
+        fs::remove_file(&archive_path).unwrap();
+        let cached = acquire_coreml_bundle_for(&cache, &descriptor).unwrap();
+        assert_eq!(cached.source, CoreMlAcquisitionSource::Cache);
+        assert_eq!(cached.bundle.manifest_sha256, manifest_sha256);
+    }
+
+    #[test]
+    fn acquisition_lock_keeps_repair_away_from_active_publication() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("source");
+        fs::create_dir(&source).unwrap();
+        let manifest_sha256 = create_test_bundle(&source);
+        let missing_archive = temp.path().join(COREML_BUNDLE_DESCRIPTOR.artifact_name);
+        let artifact_url = format!("file://{}", missing_archive.display());
+        let descriptor = test_descriptor(&artifact_url, A_HASH, &manifest_sha256);
+        let cache = temp.path().join("cache");
+        let artifacts = cache.join(ARTIFACT_CACHE_DIR);
+        create_private_dir_all(&artifacts).unwrap();
+
+        let publisher_lock = lock_coreml_acquisition(&artifacts).unwrap();
+        let installed = descriptor_bundle_path(&cache, &descriptor).unwrap();
+        create_private_dir_all(installed.parent().unwrap()).unwrap();
+        fs::rename(&source, &installed).unwrap();
+        let marker = completion_marker_path(&installed).unwrap();
+        assert!(installed.is_dir());
+        assert!(!marker.exists());
+
+        let (contended_tx, contended_rx) = std::sync::mpsc::channel();
+        std::thread::scope(|scope| {
+            let second = scope.spawn(|| {
+                set_acquisition_lock_contended_hook(move || {
+                    contended_tx.send(()).unwrap();
+                });
+                acquire_coreml_bundle_for(&cache, &descriptor)
+            });
+
+            if let Err(error) = contended_rx.recv_timeout(Duration::from_secs(5)) {
+                write_completion_marker_atomic(&installed).unwrap();
+                drop(publisher_lock);
+                let second_result = second.join();
+                panic!(
+                    "second acquirer did not report lock contention: {error}; result: {second_result:?}"
+                );
+            }
+            assert!(installed.is_dir());
+            assert!(!marker.exists());
+
+            write_completion_marker_atomic(&installed).unwrap();
+            drop(publisher_lock);
+
+            let acquired = second.join().unwrap().unwrap();
+            assert_eq!(acquired.source, CoreMlAcquisitionSource::Cache);
+            assert!(completion_marker_matches(&installed, &manifest_sha256).unwrap());
+        });
+    }
+
+    #[test]
+    fn daemon_acquisition_repairs_bundle_published_without_marker() {
+        let temp = tempfile::tempdir().unwrap();
+        let (archive_path, archive_sha256, manifest_sha256) =
+            create_test_bundle_archive(temp.path());
+        let artifact_url = format!("file://{}", archive_path.display());
+        let descriptor = test_descriptor(&artifact_url, &archive_sha256, &manifest_sha256);
+        let cache = temp.path().join("cache");
+        acquire_coreml_bundle_for(&cache, &descriptor).unwrap();
+
+        let installed = descriptor_bundle_path(&cache, &descriptor).unwrap();
+        let marker = completion_marker_path(&installed).unwrap();
+        fs::remove_file(marker).unwrap();
+        fs::write(installed.join("interrupted-publication"), b"stale").unwrap();
+
+        let repaired = acquire_coreml_bundle_for(&cache, &descriptor).unwrap();
+        assert_eq!(repaired.source, CoreMlAcquisitionSource::Download);
+        assert!(!installed.join("interrupted-publication").exists());
+        assert!(completion_marker_matches(&installed, &manifest_sha256).unwrap());
+    }
+
+    #[test]
+    fn daemon_acquisition_repairs_marker_published_without_bundle() {
+        let temp = tempfile::tempdir().unwrap();
+        let (archive_path, archive_sha256, manifest_sha256) =
+            create_test_bundle_archive(temp.path());
+        let artifact_url = format!("file://{}", archive_path.display());
+        let descriptor = test_descriptor(&artifact_url, &archive_sha256, &manifest_sha256);
+        let cache = temp.path().join("cache");
+        acquire_coreml_bundle_for(&cache, &descriptor).unwrap();
+
+        let installed = descriptor_bundle_path(&cache, &descriptor).unwrap();
+        let marker = completion_marker_path(&installed).unwrap();
+        fs::remove_dir_all(&installed).unwrap();
+        assert!(marker.is_file());
+
+        let repaired = acquire_coreml_bundle_for(&cache, &descriptor).unwrap();
+        assert_eq!(repaired.source, CoreMlAcquisitionSource::Download);
+        assert!(completion_marker_matches(&installed, &manifest_sha256).unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_acquisition_refuses_to_repair_symlinked_incomplete_entries() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let missing_archive = temp.path().join("missing.tar.xz");
+        let artifact_url = format!("file://{}", missing_archive.display());
+        let descriptor = test_descriptor(&artifact_url, A_HASH, B_HASH);
+
+        let directory_cache = temp.path().join("directory-cache");
+        let directory_path = descriptor_bundle_path(&directory_cache, &descriptor).unwrap();
+        fs::create_dir_all(directory_path.parent().unwrap()).unwrap();
+        let directory_target = temp.path().join("directory-target");
+        fs::create_dir(&directory_target).unwrap();
+        fs::write(directory_target.join("keep"), b"keep").unwrap();
+        symlink(&directory_target, &directory_path).unwrap();
+        let error = acquire_coreml_bundle_for(&directory_cache, &descriptor).unwrap_err();
+        assert!(model_acquisition_integrity_error(&error));
+        assert_eq!(fs::read(directory_target.join("keep")).unwrap(), b"keep");
+
+        let marker_cache = temp.path().join("marker-cache");
+        let bundle_path = descriptor_bundle_path(&marker_cache, &descriptor).unwrap();
+        fs::create_dir_all(bundle_path.parent().unwrap()).unwrap();
+        let marker = completion_marker_path(&bundle_path).unwrap();
+        let marker_target = temp.path().join("marker-target");
+        fs::write(&marker_target, b"keep").unwrap();
+        symlink(&marker_target, &marker).unwrap();
+        let error = acquire_coreml_bundle_for(&marker_cache, &descriptor).unwrap_err();
+        assert!(model_acquisition_integrity_error(&error));
+        assert_eq!(fs::read(marker_target).unwrap(), b"keep");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_acquisition_refuses_to_repair_through_symlinked_parent() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let missing_archive = temp.path().join("missing.tar.xz");
+        let artifact_url = format!("file://{}", missing_archive.display());
+        let descriptor = test_descriptor(&artifact_url, A_HASH, B_HASH);
+        let cache = temp.path().join("cache");
+        let installed = descriptor_bundle_path(&cache, &descriptor).unwrap();
+        let digest_parent = installed.parent().unwrap();
+        fs::create_dir_all(digest_parent.parent().unwrap()).unwrap();
+        let outside = temp.path().join("outside");
+        fs::create_dir(&outside).unwrap();
+        symlink(&outside, digest_parent).unwrap();
+        let outside_bundle = outside.join(installed.file_name().unwrap());
+        fs::create_dir(&outside_bundle).unwrap();
+        fs::write(outside_bundle.join("keep"), b"keep").unwrap();
+
+        let error = acquire_coreml_bundle_for(&cache, &descriptor).unwrap_err();
+        assert!(model_acquisition_integrity_error(&error));
+        assert_eq!(fs::read(outside_bundle.join("keep")).unwrap(), b"keep");
+    }
+
+    #[test]
+    fn daemon_acquisition_does_not_repair_completed_integrity_failures() {
+        let temp = tempfile::tempdir().unwrap();
+        let (archive_path, archive_sha256, manifest_sha256) =
+            create_test_bundle_archive(temp.path());
+        let artifact_url = format!("file://{}", archive_path.display());
+        let descriptor = test_descriptor(&artifact_url, &archive_sha256, &manifest_sha256);
+
+        let marker_cache = temp.path().join("marker-cache");
+        acquire_coreml_bundle_for(&marker_cache, &descriptor).unwrap();
+        let marker_bundle = descriptor_bundle_path(&marker_cache, &descriptor).unwrap();
+        let marker = completion_marker_path(&marker_bundle).unwrap();
+        fs::write(
+            &marker,
+            format!(r#"{{"schema_version":1,"manifest_sha256":"{B_HASH}"}}"#),
+        )
+        .unwrap();
+        let error = acquire_coreml_bundle_for(&marker_cache, &descriptor).unwrap_err();
+        assert!(model_acquisition_integrity_error(&error));
+        assert!(marker_bundle.is_dir());
+
+        let content_cache = temp.path().join("content-cache");
+        acquire_coreml_bundle_for(&content_cache, &descriptor).unwrap();
+        let content_bundle = descriptor_bundle_path(&content_cache, &descriptor).unwrap();
+        let model = content_bundle.join("document.mlpackage/Data/model.bin");
+        fs::write(&model, b"tampered").unwrap();
+        let error = acquire_coreml_bundle_for(&content_cache, &descriptor).unwrap_err();
+        assert!(model_acquisition_integrity_error(&error));
+        assert_eq!(fs::read(model).unwrap(), b"tampered");
+        assert!(completion_marker_matches(&content_bundle, &manifest_sha256).unwrap());
+    }
+
+    fn test_descriptor<'a>(
+        artifact_url: &'a str,
+        archive_sha256: &'a str,
+        manifest_sha256: &'a str,
+    ) -> CoreMlBundleDescriptor<'a> {
+        CoreMlBundleDescriptor {
+            artifact_url,
+            artifact_name: "ctx-multilingual-e5-small-coreml-fp16-1.0.0.tar.xz",
+            archive_sha256,
+            manifest_sha256,
+            query_batch_size: None,
+            ..COREML_BUNDLE_DESCRIPTOR
+        }
+    }
+
+    fn write_test_archive(path: &Path, entries: &[(&str, tar::EntryType, &[u8])]) {
+        let file = fs::File::create(path).unwrap();
+        let encoder = xz2::write::XzEncoder::new(file, 1);
+        let mut archive = tar::Builder::new(encoder);
+        for (path, entry_type, body) in entries {
+            let mut header = tar::Header::new_ustar();
+            header.set_entry_type(*entry_type);
+            header.set_mode(0o600);
+            header.set_size(body.len() as u64);
+            let name = path.as_bytes();
+            assert!(name.len() < 100);
+            header.as_mut_bytes()[..100].fill(0);
+            header.as_mut_bytes()[..name.len()].copy_from_slice(name);
+            header.set_cksum();
+            archive.append(&header, *body).unwrap();
+        }
+        let encoder = archive.into_inner().unwrap();
+        encoder.finish().unwrap();
+    }
+
+    fn create_test_bundle_archive(root: &Path) -> (PathBuf, String, String) {
+        let root_name = "ctx-multilingual-e5-small-coreml-fp16-1.0.0";
+        let source = root.join(root_name);
+        fs::create_dir(&source).unwrap();
+        let manifest_sha256 = create_test_bundle(&source);
+        let archive_path = root.join(format!("{root_name}.tar.xz"));
+        write_bundle_archive(&archive_path, &source, root_name);
+        let archive_sha256 = sha256_path(&archive_path);
+        (archive_path, archive_sha256, manifest_sha256)
+    }
+
+    fn create_test_bundle(root: &Path) -> String {
+        let payloads = [
+            ("LICENSES/MODEL_LICENSE.txt", b"license\n".as_slice()),
+            ("PROVENANCE.json", b"{}".as_slice()),
+            ("THIRD_PARTY_NOTICES.md", b"notices\n".as_slice()),
+            ("document.mlpackage/Data/model.bin", b"model".as_slice()),
+            ("tokenizer.json", b"{}".as_slice()),
+        ];
+        let mut files = Vec::new();
+        for (relative, body) in payloads {
+            let path = root.join(relative);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, body).unwrap();
+            files.push(json!({
+                "path": relative,
+                "size_bytes": body.len(),
+                "sha256": format!("{:x}", Sha256::digest(body)),
+            }));
+        }
+        files.sort_by(|left, right| left["path"].as_str().cmp(&right["path"].as_str()));
+        let manifest = json!({
+            "schema_version": 1,
+            "bundle_id": "ctx.multilingual-e5-small.coreml.fp16",
+            "bundle_version": "1.0.0",
+            "model": {
+                "id": "intfloat/multilingual-e5-small",
+                "source_revision": "614241f622f53c4eeff9890bdc4f31cfecc418b3",
+                "embedding_space_id": "e5-small-v1:mean-pool:l2:query-passage",
+                "precision": "fp16",
+            },
+            "tensor_contract": {
+                "inputs": [
+                    {"name": "input_ids", "dtype": "int32", "shape": [16, 512]},
+                    {"name": "attention_mask", "dtype": "int32", "shape": [16, 512]},
+                    {"name": "token_type_ids", "dtype": "int32", "shape": [16, 512]},
+                ],
+                "output": {"name": "sentence_embeddings", "dtype": "float32", "shape": [16, 384]},
+                "document_batch_size": 16,
+                "max_sequence_length": 512,
+                "embedding_dimensions": 384,
+                "document_prefix": "passage: ",
+                "query_prefix": "query: ",
+                "pooling": "attention_mask_mean",
+                "normalization": "l2",
+            },
+            "artifacts": {
+                "tokenizer": "tokenizer.json",
+                "document_model": "document.mlpackage",
+            },
+            "files": files,
+        });
+        let mut bytes = serde_json::to_vec_pretty(&manifest).unwrap();
+        bytes.push(b'\n');
+        fs::write(root.join("manifest.json"), &bytes).unwrap();
+        format!("{:x}", Sha256::digest(bytes))
+    }
+
+    fn write_bundle_archive(path: &Path, root: &Path, root_name: &str) {
+        let file = fs::File::create(path).unwrap();
+        let encoder = xz2::write::XzEncoder::new(file, 1);
+        let mut archive = tar::Builder::new(encoder);
+        archive.append_dir(root_name, root).unwrap();
+        let mut paths = Vec::new();
+        collect_paths(root, root, &mut paths);
+        paths.sort();
+        for relative in paths {
+            let source = root.join(&relative);
+            let archive_name = Path::new(root_name).join(&relative);
+            if source.is_dir() {
+                archive.append_dir(archive_name, source).unwrap();
+            } else {
+                archive.append_path_with_name(source, archive_name).unwrap();
+            }
+        }
+        let encoder = archive.into_inner().unwrap();
+        encoder.finish().unwrap();
+    }
+
+    fn collect_paths(root: &Path, directory: &Path, paths: &mut Vec<PathBuf>) {
+        for entry in fs::read_dir(directory).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            paths.push(path.strip_prefix(root).unwrap().to_path_buf());
+            if path.is_dir() {
+                collect_paths(root, &path, paths);
+            }
+        }
+    }
+
+    fn sha256_path(path: &Path) -> String {
+        format!("{:x}", Sha256::digest(fs::read(path).unwrap()))
+    }
+}

--- a/crates/ctx-cli/src/semantic/model_bundle.rs
+++ b/crates/ctx-cli/src/semantic/model_bundle.rs
@@ -1,0 +1,1445 @@
+use std::{
+    collections::BTreeSet,
+    fs::{self, File, OpenOptions},
+    io::{self, Read, Write},
+    path::{Component, Path, PathBuf},
+    process,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub(crate) const MANIFEST_FILE: &str = "manifest.json";
+pub(crate) const MANIFEST_SCHEMA_VERSION: u32 = 1;
+pub(crate) const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
+pub(crate) const MAX_BUNDLE_FILES: usize = 4096;
+pub(crate) const MAX_BUNDLE_DIRECTORIES: usize = 1024;
+pub(crate) const MAX_FILE_BYTES: u64 = 1024 * 1024 * 1024;
+pub(crate) const MAX_BUNDLE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+const MAX_TOKENIZER_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_METADATA_FILE_BYTES: u64 = 4 * 1024 * 1024;
+
+const MAX_PATH_BYTES: usize = 512;
+const MAX_PATH_COMPONENTS: usize = 64;
+const MAX_STRING_BYTES: usize = 512;
+const EXPECTED_BUNDLE_ID: &str = "ctx.multilingual-e5-small.coreml.fp16";
+const EXPECTED_MODEL_ID: &str = "intfloat/multilingual-e5-small";
+const EXPECTED_SOURCE_REVISION: &str = "614241f622f53c4eeff9890bdc4f31cfecc418b3";
+const EXPECTED_PRECISION: &str = "fp16";
+const EXPECTED_EMBEDDING_SPACE_ID: &str = "e5-small-v1:mean-pool:l2:query-passage";
+const EXPECTED_INPUTS: [(&str, &str); 3] = [
+    ("input_ids", "int32"),
+    ("attention_mask", "int32"),
+    ("token_type_ids", "int32"),
+];
+const EXPECTED_OUTPUT_NAME: &str = "sentence_embeddings";
+const EXPECTED_OUTPUT_DTYPE: &str = "float32";
+const EXPECTED_DIMENSIONS: u32 = 384;
+const EXPECTED_DOCUMENT_BATCH_SIZE: u32 = 16;
+const EXPECTED_QUERY_BATCH_SIZE: u32 = 1;
+const EXPECTED_SEQUENCE_LENGTH: u32 = 512;
+const CACHE_NAMESPACE: &str = "semantic-model-bundles";
+const COMPLETION_SUFFIX: &str = ".complete.json";
+
+static STAGING_NONCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ModelBundleManifest {
+    pub schema_version: u32,
+    pub bundle_id: String,
+    pub bundle_version: String,
+    pub model: ModelIdentity,
+    pub tensor_contract: TensorContract,
+    pub artifacts: BundleArtifacts,
+    pub files: Vec<BundleFile>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ModelIdentity {
+    pub id: String,
+    pub source_revision: String,
+    pub embedding_space_id: String,
+    pub precision: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TensorContract {
+    pub inputs: Vec<TensorSpec>,
+    pub output: TensorSpec,
+    pub document_batch_size: u32,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_non_null",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub query_batch_size: Option<u32>,
+    pub max_sequence_length: u32,
+    pub embedding_dimensions: u32,
+    pub document_prefix: String,
+    pub query_prefix: String,
+    pub pooling: String,
+    pub normalization: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TensorSpec {
+    pub name: String,
+    pub dtype: String,
+    pub shape: Vec<u32>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct BundleArtifacts {
+    pub tokenizer: String,
+    pub document_model: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_non_null",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub query_model: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct BundleFile {
+    pub path: String,
+    pub size_bytes: u64,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct VerifiedModelBundle {
+    pub root: PathBuf,
+    pub manifest: ModelBundleManifest,
+    pub manifest_sha256: String,
+}
+
+impl VerifiedModelBundle {
+    pub(crate) fn tokenizer_path(&self) -> PathBuf {
+        self.root.join(&self.manifest.artifacts.tokenizer)
+    }
+
+    pub(crate) fn document_model_path(&self) -> PathBuf {
+        self.root.join(&self.manifest.artifacts.document_model)
+    }
+
+    pub(crate) fn query_model_path(&self) -> Option<PathBuf> {
+        self.manifest
+            .artifacts
+            .query_model
+            .as_ref()
+            .map(|path| self.root.join(path))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CompletionMarker {
+    schema_version: u32,
+    manifest_sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CompileDestination {
+    pub final_path: PathBuf,
+    pub staging_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AtomicCommit {
+    Installed,
+    AlreadyPresent,
+}
+
+pub(crate) fn verify_model_bundle(root: &Path) -> Result<VerifiedModelBundle> {
+    require_real_directory(root, "model bundle root")?;
+    let manifest_path = root.join(MANIFEST_FILE);
+    let manifest_bytes = read_bounded_regular_file(&manifest_path, MAX_MANIFEST_BYTES)
+        .with_context(|| format!("read model bundle manifest {}", manifest_path.display()))?;
+    let manifest_sha256 = sha256_bytes(&manifest_bytes);
+    let manifest: ModelBundleManifest = serde_json::from_slice(&manifest_bytes)
+        .with_context(|| format!("parse model bundle manifest {}", manifest_path.display()))?;
+    validate_manifest(&manifest)?;
+
+    let actual_files = collect_bundle_files(root)?;
+    let expected_files: BTreeSet<String> = manifest
+        .files
+        .iter()
+        .map(|file| file.path.clone())
+        .collect();
+    if actual_files != expected_files {
+        let missing: Vec<_> = expected_files.difference(&actual_files).cloned().collect();
+        let unexpected: Vec<_> = actual_files.difference(&expected_files).cloned().collect();
+        bail!(
+            "model bundle file set does not match manifest (missing: {missing:?}, unexpected: {unexpected:?})"
+        );
+    }
+
+    for entry in &manifest.files {
+        let path = checked_join(root, &entry.path)?;
+        verify_file(&path, entry)?;
+    }
+
+    Ok(VerifiedModelBundle {
+        root: root.to_path_buf(),
+        manifest,
+        manifest_sha256,
+    })
+}
+
+pub(crate) fn content_addressed_bundle_path(
+    cache_root: &Path,
+    manifest_sha256: &str,
+) -> Result<PathBuf> {
+    validate_sha256(manifest_sha256, "manifest_sha256")?;
+    Ok(cache_root
+        .join(CACHE_NAMESPACE)
+        .join("sha256")
+        .join(&manifest_sha256[..2])
+        .join(manifest_sha256))
+}
+
+pub(crate) fn completion_marker_path(bundle_cache_path: &Path) -> Result<PathBuf> {
+    let name = bundle_cache_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow!("bundle cache path has no UTF-8 file name"))?;
+    validate_sha256(name, "bundle cache directory name")?;
+    Ok(bundle_cache_path.with_file_name(format!("{name}{COMPLETION_SUFFIX}")))
+}
+
+pub(crate) fn completion_marker_matches(
+    bundle_cache_path: &Path,
+    manifest_sha256: &str,
+) -> Result<bool> {
+    validate_sha256(manifest_sha256, "manifest_sha256")?;
+    let marker_path = completion_marker_path(bundle_cache_path)?;
+    let bytes = match read_bounded_regular_file(&marker_path, 4096) {
+        Ok(bytes) => bytes,
+        Err(error)
+            if error
+                .downcast_ref::<io::Error>()
+                .is_some_and(|e| e.kind() == io::ErrorKind::NotFound) =>
+        {
+            return Ok(false);
+        }
+        Err(error) => return Err(error),
+    };
+    let marker: CompletionMarker = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parse completion marker {}", marker_path.display()))?;
+    Ok(marker.schema_version == MANIFEST_SCHEMA_VERSION
+        && marker.manifest_sha256 == manifest_sha256)
+}
+
+pub(crate) fn write_completion_marker_atomic(
+    bundle_cache_path: &Path,
+) -> Result<VerifiedModelBundle> {
+    let verified = verify_model_bundle(bundle_cache_path)?;
+    let manifest_sha256 = verified.manifest_sha256.as_str();
+    let directory_hash = bundle_cache_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow!("bundle cache path has no UTF-8 file name"))?;
+    if directory_hash != manifest_sha256 {
+        bail!("bundle cache directory does not match manifest SHA-256");
+    }
+    require_real_directory(bundle_cache_path, "completed bundle cache directory")?;
+    if completion_marker_matches(bundle_cache_path, manifest_sha256)? {
+        return Ok(verified);
+    }
+
+    let marker_path = completion_marker_path(bundle_cache_path)?;
+    reject_symlink_if_present(&marker_path)?;
+    let temporary = unique_sibling(&marker_path, "marker")?;
+    let marker = CompletionMarker {
+        schema_version: MANIFEST_SCHEMA_VERSION,
+        manifest_sha256: manifest_sha256.to_owned(),
+    };
+    let mut body = serde_json::to_vec(&marker)?;
+    body.push(b'\n');
+    let result = (|| -> Result<()> {
+        let mut file = create_new_nofollow(&temporary)?;
+        file.write_all(&body)
+            .with_context(|| format!("write completion marker {}", temporary.display()))?;
+        file.sync_all()
+            .with_context(|| format!("sync completion marker {}", temporary.display()))?;
+        drop(file);
+        fs::rename(&temporary, &marker_path)
+            .with_context(|| format!("publish completion marker {}", marker_path.display()))?;
+        sync_parent(&marker_path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result?;
+    Ok(verified)
+}
+
+pub(crate) fn prepare_compile_destination(
+    compiled_cache_root: &Path,
+    manifest_sha256: &str,
+    model_role: &str,
+    compiler_identity: &str,
+) -> Result<CompileDestination> {
+    validate_sha256(manifest_sha256, "manifest_sha256")?;
+    let role = match model_role {
+        "document" | "query" => model_role,
+        _ => bail!("compile model role must be document or query"),
+    };
+    validate_bounded_identifier(compiler_identity, "compiler_identity")?;
+    let compiler_hash = sha256_bytes(compiler_identity.as_bytes());
+    let parent = compiled_cache_root
+        .join("coreml-compiled")
+        .join("sha256")
+        .join(manifest_sha256)
+        .join(compiler_hash);
+    create_directory_tree_nofollow(compiled_cache_root, &parent)?;
+    let final_path = parent.join(format!("{role}.mlmodelc"));
+    reject_symlink_if_present(&final_path)?;
+    let staging_path = unique_sibling(&final_path, "compile")?;
+    fs::create_dir(&staging_path).with_context(|| {
+        format!(
+            "create compile staging directory {}",
+            staging_path.display()
+        )
+    })?;
+    sync_parent(&staging_path)?;
+    Ok(CompileDestination {
+        final_path,
+        staging_path,
+    })
+}
+
+pub(crate) fn commit_compile_destination(destination: &CompileDestination) -> Result<AtomicCommit> {
+    validate_staging_pair(destination)?;
+    require_real_directory(
+        &destination.staging_path,
+        "compiled model staging directory",
+    )?;
+    reject_symlinks_recursive(&destination.staging_path)?;
+    sync_tree(&destination.staging_path)?;
+
+    match fs::rename(&destination.staging_path, &destination.final_path) {
+        Ok(()) => {
+            sync_parent(&destination.final_path)?;
+            Ok(AtomicCommit::Installed)
+        }
+        Err(rename_error) => {
+            reject_symlink_if_present(&destination.final_path)?;
+            if destination.final_path.is_dir() {
+                fs::remove_dir_all(&destination.staging_path).with_context(|| {
+                    format!(
+                        "remove redundant compile staging directory {}",
+                        destination.staging_path.display()
+                    )
+                })?;
+                Ok(AtomicCommit::AlreadyPresent)
+            } else {
+                Err(rename_error).with_context(|| {
+                    format!(
+                        "atomically publish compiled model {}",
+                        destination.final_path.display()
+                    )
+                })
+            }
+        }
+    }
+}
+
+pub(crate) fn discard_compile_destination(destination: &CompileDestination) -> Result<()> {
+    validate_staging_pair(destination)?;
+    match fs::symlink_metadata(&destination.staging_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            bail!("refusing to remove symlinked compile staging path")
+        }
+        Ok(metadata) if metadata.is_dir() => fs::remove_dir_all(&destination.staging_path)
+            .with_context(|| {
+                format!(
+                    "remove compile staging directory {}",
+                    destination.staging_path.display()
+                )
+            }),
+        Ok(_) => bail!("compile staging path is not a directory"),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| {
+            format!(
+                "inspect compile staging path {}",
+                destination.staging_path.display()
+            )
+        }),
+    }
+}
+
+pub(crate) fn invalidate_compiled_model_cache(path: &Path) -> Result<()> {
+    let file_name = path.file_name().and_then(|value| value.to_str());
+    if !matches!(file_name, Some("document.mlmodelc" | "query.mlmodelc")) {
+        bail!("refusing to invalidate unexpected compiled model cache path");
+    }
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("inspect compiled model cache {}", path.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        bail!("refusing to invalidate non-directory compiled model cache");
+    }
+    fs::remove_dir_all(path)
+        .with_context(|| format!("invalidate compiled model cache {}", path.display()))
+}
+
+fn validate_manifest(manifest: &ModelBundleManifest) -> Result<()> {
+    if manifest.schema_version != MANIFEST_SCHEMA_VERSION {
+        bail!("unsupported model bundle manifest schema version");
+    }
+    if manifest.bundle_id != EXPECTED_BUNDLE_ID {
+        bail!("model bundle has unsupported bundle id");
+    }
+    validate_semver(&manifest.bundle_version)?;
+    if manifest.model.id != EXPECTED_MODEL_ID {
+        bail!("model bundle has unsupported model id");
+    }
+    if manifest.model.precision != EXPECTED_PRECISION {
+        bail!("model bundle must use fp16 precision");
+    }
+    validate_revision(&manifest.model.source_revision)?;
+    if manifest.model.source_revision != EXPECTED_SOURCE_REVISION {
+        bail!("model bundle has unsupported source revision");
+    }
+    if manifest.model.embedding_space_id != EXPECTED_EMBEDDING_SPACE_ID {
+        bail!("model bundle has unsupported embedding space id");
+    }
+    if manifest.artifacts.tokenizer != "tokenizer.json" {
+        bail!("tokenizer artifact must be tokenizer.json");
+    }
+    if manifest.artifacts.document_model != "document.mlpackage" {
+        bail!("document model artifact must be document.mlpackage");
+    }
+    if manifest
+        .artifacts
+        .query_model
+        .as_deref()
+        .is_some_and(|path| path != "query.mlpackage")
+    {
+        bail!("query model artifact must be query.mlpackage when present");
+    }
+    validate_tensor_contract(
+        &manifest.tensor_contract,
+        manifest.artifacts.query_model.is_some(),
+    )?;
+    if manifest.files.is_empty() || manifest.files.len() > MAX_BUNDLE_FILES {
+        bail!("model bundle file count is outside the allowed range");
+    }
+
+    let mut paths = BTreeSet::new();
+    let mut total_bytes = 0_u64;
+    let mut previous_path: Option<&str> = None;
+    for file in &manifest.files {
+        validate_relative_path(&file.path)?;
+        if !allowed_payload_path(&file.path, manifest.artifacts.query_model.is_some()) {
+            bail!(
+                "model bundle contains unsupported payload path {}",
+                file.path
+            );
+        }
+        if !paths.insert(file.path.as_str()) {
+            bail!("duplicate model bundle file path {}", file.path);
+        }
+        if previous_path.is_some_and(|previous| previous >= file.path.as_str()) {
+            bail!("model bundle file records must be sorted by path");
+        }
+        previous_path = Some(&file.path);
+        if file.size_bytes > MAX_FILE_BYTES {
+            bail!("model bundle file {} exceeds size limit", file.path);
+        }
+        if file.size_bytes > payload_size_limit(&file.path) {
+            bail!(
+                "model bundle file {} exceeds role-specific size limit",
+                file.path
+            );
+        }
+        total_bytes = total_bytes
+            .checked_add(file.size_bytes)
+            .ok_or_else(|| anyhow!("model bundle total size overflow"))?;
+        if total_bytes > MAX_BUNDLE_BYTES {
+            bail!("model bundle exceeds total size limit");
+        }
+        validate_sha256(&file.sha256, "file sha256")?;
+    }
+
+    require_manifest_file(&paths, "tokenizer.json")?;
+    require_manifest_prefix(&paths, "document.mlpackage/")?;
+    if manifest.artifacts.query_model.is_some() {
+        require_manifest_prefix(&paths, "query.mlpackage/")?;
+    } else if paths
+        .iter()
+        .any(|path| path.starts_with("query.mlpackage/"))
+    {
+        bail!("query model files are present without a query model artifact");
+    }
+    require_manifest_file(&paths, "PROVENANCE.json")?;
+    require_manifest_file(&paths, "THIRD_PARTY_NOTICES.md")?;
+    require_manifest_prefix(&paths, "LICENSES/")?;
+    Ok(())
+}
+
+fn validate_tensor_contract(contract: &TensorContract, has_query_model: bool) -> Result<()> {
+    if contract.inputs.len() != EXPECTED_INPUTS.len() {
+        bail!("tensor contract must contain exactly three inputs");
+    }
+    if contract.document_batch_size != EXPECTED_DOCUMENT_BATCH_SIZE
+        || contract.max_sequence_length != EXPECTED_SEQUENCE_LENGTH
+    {
+        bail!("document tensor contract must use fixed batch 16 and sequence length 512");
+    }
+    match (has_query_model, contract.query_batch_size) {
+        (true, Some(EXPECTED_QUERY_BATCH_SIZE)) | (false, None) => {}
+        (true, _) => bail!("query tensor contract must use fixed batch 1 when present"),
+        (false, Some(_)) => {
+            bail!("query batch size requires a query model artifact")
+        }
+    }
+    if contract.embedding_dimensions != EXPECTED_DIMENSIONS {
+        bail!("tensor contract embedding dimension must be 384");
+    }
+    for (input, (expected_name, expected_dtype)) in contract.inputs.iter().zip(EXPECTED_INPUTS) {
+        validate_tensor_spec(
+            input,
+            expected_name,
+            expected_dtype,
+            contract.document_batch_size,
+            contract.max_sequence_length,
+        )?;
+    }
+    validate_tensor_spec(
+        &contract.output,
+        EXPECTED_OUTPUT_NAME,
+        EXPECTED_OUTPUT_DTYPE,
+        contract.document_batch_size,
+        contract.embedding_dimensions,
+    )?;
+    if contract.document_prefix != "passage: " || contract.query_prefix != "query: " {
+        bail!("tensor contract has incompatible E5 role prefixes");
+    }
+    if contract.pooling != "attention_mask_mean" || contract.normalization != "l2" {
+        bail!("tensor contract has incompatible pooling or normalization");
+    }
+    Ok(())
+}
+
+fn validate_tensor_spec(
+    spec: &TensorSpec,
+    expected_name: &str,
+    expected_dtype: &str,
+    expected_batch: u32,
+    expected_width: u32,
+) -> Result<()> {
+    if spec.name != expected_name || spec.dtype != expected_dtype {
+        bail!("tensor contract contains an incompatible tensor");
+    }
+    let expected_shape = [expected_batch, expected_width];
+    if spec.shape.as_slice() != expected_shape {
+        bail!("tensor {} has an incompatible shape", spec.name);
+    }
+    Ok(())
+}
+
+fn validate_semver(value: &str) -> Result<()> {
+    validate_short_string(value, "bundle_version")?;
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'+'))
+        || value.matches('+').count() > 1
+    {
+        bail!("bundle_version must use semantic version syntax");
+    }
+    let (without_build, build) = value
+        .split_once('+')
+        .map_or((value, None), |(core, suffix)| (core, Some(suffix)));
+    let (core, prerelease) = without_build
+        .split_once('-')
+        .map_or((without_build, None), |(core, suffix)| (core, Some(suffix)));
+    let parts: Vec<_> = core.split('.').collect();
+    if parts.len() != 3
+        || parts.iter().any(|part| {
+            part.is_empty()
+                || !part.bytes().all(|byte| byte.is_ascii_digit())
+                || (part.len() > 1 && part.starts_with('0'))
+        })
+        || [prerelease, build]
+            .into_iter()
+            .flatten()
+            .any(|suffix| suffix.split('.').any(str::is_empty))
+    {
+        bail!("bundle_version must use semantic version syntax");
+    }
+    Ok(())
+}
+
+fn validate_revision(value: &str) -> Result<()> {
+    if !matches!(value.len(), 40 | 64)
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        bail!("source_revision must be a 40- or 64-character hexadecimal revision");
+    }
+    Ok(())
+}
+
+fn deserialize_optional_non_null<'de, D, T>(
+    deserializer: D,
+) -> std::result::Result<Option<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    T::deserialize(deserializer).map(Some)
+}
+
+fn validate_bounded_identifier(value: &str, name: &str) -> Result<()> {
+    validate_short_string(value, name)?;
+    if !value.bytes().all(|byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'/' | b':' | b'_' | b'-')
+    }) {
+        bail!("{name} contains unsupported characters");
+    }
+    Ok(())
+}
+
+fn validate_short_string(value: &str, name: &str) -> Result<()> {
+    if value.is_empty() || value.len() > MAX_STRING_BYTES || value.chars().any(char::is_control) {
+        bail!("{name} is empty, too long, or contains control characters");
+    }
+    Ok(())
+}
+
+fn allowed_payload_path(path: &str, query_model: bool) -> bool {
+    path == "tokenizer.json"
+        || path == "PROVENANCE.json"
+        || path == "THIRD_PARTY_NOTICES.md"
+        || path.starts_with("LICENSES/")
+        || path.starts_with("document.mlpackage/")
+        || (query_model && path.starts_with("query.mlpackage/"))
+}
+
+fn payload_size_limit(path: &str) -> u64 {
+    if path == "tokenizer.json" {
+        MAX_TOKENIZER_BYTES
+    } else if path == "PROVENANCE.json"
+        || path == "THIRD_PARTY_NOTICES.md"
+        || path.starts_with("LICENSES/")
+    {
+        MAX_METADATA_FILE_BYTES
+    } else {
+        MAX_FILE_BYTES
+    }
+}
+
+fn require_manifest_file(paths: &BTreeSet<&str>, path: &str) -> Result<()> {
+    if !paths.contains(path) {
+        bail!("model bundle manifest is missing required file {path}");
+    }
+    Ok(())
+}
+
+fn require_manifest_prefix(paths: &BTreeSet<&str>, prefix: &str) -> Result<()> {
+    if !paths.iter().any(|path| path.starts_with(prefix)) {
+        bail!("model bundle manifest is missing required path {prefix}");
+    }
+    Ok(())
+}
+
+fn collect_bundle_files(root: &Path) -> Result<BTreeSet<String>> {
+    fn visit(
+        root: &Path,
+        directory: &Path,
+        files: &mut BTreeSet<String>,
+        directory_count: &mut usize,
+    ) -> Result<()> {
+        *directory_count += 1;
+        if *directory_count > MAX_BUNDLE_DIRECTORIES {
+            bail!("model bundle contains too many directories");
+        }
+        let mut entries = fs::read_dir(directory)
+            .with_context(|| format!("read model bundle directory {}", directory.display()))?
+            .collect::<io::Result<Vec<_>>>()?;
+        entries.sort_by_key(|entry| entry.file_name());
+        if entries.is_empty() && directory != root {
+            bail!(
+                "model bundle contains empty directory {}",
+                directory.display()
+            );
+        }
+        for entry in entries {
+            let path = entry.path();
+            let metadata = fs::symlink_metadata(&path)
+                .with_context(|| format!("inspect model bundle path {}", path.display()))?;
+            if metadata.file_type().is_symlink() {
+                bail!("model bundle contains symlink {}", path.display());
+            }
+            if metadata.is_dir() {
+                visit(root, &path, files, directory_count)?;
+            } else if metadata.is_file() {
+                let relative = path
+                    .strip_prefix(root)
+                    .map_err(|_| anyhow!("model bundle path escaped root"))?
+                    .to_str()
+                    .ok_or_else(|| anyhow!("model bundle path is not UTF-8"))?
+                    .replace(std::path::MAIN_SEPARATOR, "/");
+                validate_relative_path(&relative)?;
+                if relative != MANIFEST_FILE {
+                    if files.len() >= MAX_BUNDLE_FILES {
+                        bail!("model bundle contains too many files");
+                    }
+                    files.insert(relative);
+                }
+            } else {
+                bail!("model bundle contains unsupported path {}", path.display());
+            }
+        }
+        Ok(())
+    }
+
+    let mut files = BTreeSet::new();
+    let mut directory_count = 0;
+    visit(root, root, &mut files, &mut directory_count)?;
+    Ok(files)
+}
+
+fn verify_file(path: &Path, entry: &BundleFile) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("inspect model bundle file {}", path.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        bail!(
+            "model bundle path is not a regular file: {}",
+            path.display()
+        );
+    }
+    if metadata.len() != entry.size_bytes {
+        bail!("model bundle file size mismatch for {}", entry.path);
+    }
+    let mut file = open_read_nofollow(path)?;
+    let opened_metadata = file
+        .metadata()
+        .with_context(|| format!("inspect opened model bundle file {}", path.display()))?;
+    if !opened_metadata.is_file() || opened_metadata.len() != entry.size_bytes {
+        bail!("model bundle file changed while opening: {}", entry.path);
+    }
+    let actual = sha256_reader(&mut file, entry.size_bytes, path)?;
+    if actual != entry.sha256 {
+        bail!("model bundle SHA-256 mismatch for {}", entry.path);
+    }
+    let after = fs::symlink_metadata(path)
+        .with_context(|| format!("reinspect model bundle file {}", path.display()))?;
+    if after.file_type().is_symlink() || !same_file_metadata(&opened_metadata, &after) {
+        bail!(
+            "model bundle file changed during verification: {}",
+            entry.path
+        );
+    }
+    Ok(())
+}
+
+fn sha256_reader(file: &mut File, expected_size: u64, path: &Path) -> Result<String> {
+    let mut hasher = Sha256::new();
+    let mut read_bytes = 0_u64;
+    let mut buffer = [0_u8; 1024 * 1024];
+    loop {
+        let count = file
+            .read(&mut buffer)
+            .with_context(|| format!("hash model bundle file {}", path.display()))?;
+        if count == 0 {
+            break;
+        }
+        read_bytes = read_bytes
+            .checked_add(count as u64)
+            .ok_or_else(|| anyhow!("model bundle file size overflow"))?;
+        if read_bytes > expected_size || read_bytes > MAX_FILE_BYTES {
+            bail!("model bundle file grew while hashing: {}", path.display());
+        }
+        hasher.update(&buffer[..count]);
+    }
+    if read_bytes != expected_size {
+        bail!(
+            "model bundle file changed size while hashing: {}",
+            path.display()
+        );
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn read_bounded_regular_file(path: &Path, maximum: u64) -> Result<Vec<u8>> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        bail!("path is not a regular non-symlink file: {}", path.display());
+    }
+    if metadata.len() > maximum {
+        bail!("file exceeds size limit: {}", path.display());
+    }
+    let mut file = open_read_nofollow(path)?;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    Read::by_ref(&mut file)
+        .take(maximum + 1)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > maximum {
+        bail!("file exceeds size limit: {}", path.display());
+    }
+    Ok(bytes)
+}
+
+fn checked_join(root: &Path, relative: &str) -> Result<PathBuf> {
+    validate_relative_path(relative)?;
+    let mut path = root.to_path_buf();
+    for component in Path::new(relative).components() {
+        let Component::Normal(component) = component else {
+            bail!("invalid model bundle path {relative}");
+        };
+        path.push(component);
+        let metadata = fs::symlink_metadata(&path)
+            .with_context(|| format!("inspect model bundle path {}", path.display()))?;
+        if metadata.file_type().is_symlink() {
+            bail!("model bundle path traverses symlink {}", path.display());
+        }
+    }
+    Ok(path)
+}
+
+pub(crate) fn validate_relative_path(path: &str) -> Result<()> {
+    if path.is_empty()
+        || path.len() > MAX_PATH_BYTES
+        || path.contains('\\')
+        || path.contains(':')
+        || path.starts_with('/')
+        || path.ends_with('/')
+    {
+        bail!("invalid model bundle relative path {path:?}");
+    }
+    let components: Vec<_> = Path::new(path).components().collect();
+    if components.is_empty()
+        || components.len() > MAX_PATH_COMPONENTS
+        || components
+            .iter()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        bail!("invalid model bundle relative path {path:?}");
+    }
+    if path
+        .split('/')
+        .any(|part| part.is_empty() || part == "." || part == "..")
+    {
+        bail!("invalid model bundle relative path {path:?}");
+    }
+    Ok(())
+}
+
+fn validate_sha256(value: &str, name: &str) -> Result<()> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        bail!("{name} must be 64 lowercase hexadecimal characters");
+    }
+    Ok(())
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn require_real_directory(path: &Path, description: &str) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("inspect {description} {}", path.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        bail!("{description} must be a real directory: {}", path.display());
+    }
+    Ok(())
+}
+
+fn create_directory_tree_nofollow(base: &Path, leaf: &Path) -> Result<()> {
+    let relative = leaf
+        .strip_prefix(base)
+        .map_err(|_| anyhow!("cache path escaped its root"))?;
+    require_real_directory(base, "compiled cache root")?;
+    let mut current = base.to_path_buf();
+    for component in relative.components() {
+        let Component::Normal(component) = component else {
+            bail!("compiled cache path contains invalid component");
+        };
+        current.push(component);
+        match fs::create_dir(&current) {
+            Ok(()) => sync_parent(&current)?,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("create compiled cache directory {}", current.display())
+                });
+            }
+        }
+        require_real_directory(&current, "compiled cache directory")?;
+    }
+    Ok(())
+}
+
+fn reject_symlink_if_present(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            bail!("refusing symlink path {}", path.display())
+        }
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("inspect path {}", path.display())),
+    }
+}
+
+fn reject_symlinks_recursive(root: &Path) -> Result<()> {
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        let metadata = fs::symlink_metadata(&path)?;
+        if metadata.file_type().is_symlink() {
+            bail!(
+                "compiled model staging tree contains symlink {}",
+                path.display()
+            );
+        }
+        if metadata.is_dir() {
+            reject_symlinks_recursive(&path)?;
+        } else if !metadata.is_file() {
+            bail!(
+                "compiled model staging tree contains unsupported path {}",
+                path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn sync_tree(root: &Path) -> Result<()> {
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        let metadata = fs::symlink_metadata(&path)?;
+        if metadata.is_dir() {
+            sync_tree(&path)?;
+        } else if metadata.is_file() {
+            File::open(&path)?.sync_all()?;
+        }
+    }
+    sync_directory(root)
+}
+
+fn unique_sibling(destination: &Path, purpose: &str) -> Result<PathBuf> {
+    let parent = destination
+        .parent()
+        .ok_or_else(|| anyhow!("destination has no parent"))?;
+    let name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow!("destination has no UTF-8 file name"))?;
+    for _ in 0..128 {
+        let nonce = STAGING_NONCE.fetch_add(1, Ordering::Relaxed);
+        let candidate = parent.join(format!(".{name}.{purpose}.{}.{}.tmp", process::id(), nonce));
+        if !candidate.exists() {
+            reject_symlink_if_present(&candidate)?;
+            return Ok(candidate);
+        }
+    }
+    bail!("could not allocate unique staging path")
+}
+
+fn validate_staging_pair(destination: &CompileDestination) -> Result<()> {
+    if destination.final_path.parent() != destination.staging_path.parent() {
+        bail!("compile staging and final paths must share a parent");
+    }
+    let final_name = destination
+        .final_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow!("compile final path has no UTF-8 file name"))?;
+    let staging_name = destination
+        .staging_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow!("compile staging path has no UTF-8 file name"))?;
+    if !staging_name.starts_with(&format!(".{final_name}.compile."))
+        || !staging_name.ends_with(".tmp")
+    {
+        bail!("compile staging path is not associated with final path");
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn open_read_nofollow(path: &Path) -> Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(path)
+        .with_context(|| {
+            format!(
+                "open regular file without following symlinks {}",
+                path.display()
+            )
+        })
+}
+
+#[cfg(windows)]
+fn open_read_nofollow(path: &Path) -> Result<File> {
+    use std::os::windows::fs::OpenOptionsExt;
+    use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT;
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+        .with_context(|| {
+            format!(
+                "open regular file without following reparse points {}",
+                path.display()
+            )
+        })
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_read_nofollow(path: &Path) -> Result<File> {
+    OpenOptions::new()
+        .read(true)
+        .open(path)
+        .with_context(|| format!("open regular file {}", path.display()))
+}
+
+#[cfg(unix)]
+fn create_new_nofollow(path: &Path) -> Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(path)
+        .with_context(|| format!("create file without following symlinks {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn create_new_nofollow(path: &Path) -> Result<File> {
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .with_context(|| format!("create file {}", path.display()))
+}
+
+#[cfg(unix)]
+fn same_file_metadata(before: &fs::Metadata, after: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    before.dev() == after.dev()
+        && before.ino() == after.ino()
+        && before.len() == after.len()
+        && before.mtime() == after.mtime()
+        && before.mtime_nsec() == after.mtime_nsec()
+}
+
+#[cfg(not(unix))]
+fn same_file_metadata(before: &fs::Metadata, after: &fs::Metadata) -> bool {
+    before.len() == after.len() && before.modified().ok() == after.modified().ok()
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> Result<()> {
+    File::open(path)
+        .with_context(|| format!("open directory for sync {}", path.display()))?
+        .sync_all()
+        .with_context(|| format!("sync directory {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn sync_parent(path: &Path) -> Result<()> {
+    let parent = path.parent().ok_or_else(|| anyhow!("path has no parent"))?;
+    sync_directory(parent)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, bytes: &[u8]) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, bytes).unwrap();
+    }
+
+    fn valid_manifest(root: &Path) -> ModelBundleManifest {
+        let payloads = [
+            ("tokenizer.json", b"{}".as_slice()),
+            ("document.mlpackage/Data/model.bin", b"model".as_slice()),
+            ("PROVENANCE.json", b"{}".as_slice()),
+            ("THIRD_PARTY_NOTICES.md", b"notices\n".as_slice()),
+            ("LICENSES/MODEL_LICENSE.txt", b"license\n".as_slice()),
+        ];
+        let mut files: Vec<_> = payloads
+            .into_iter()
+            .map(|(path, body)| {
+                write(&root.join(path), body);
+                BundleFile {
+                    path: path.to_owned(),
+                    size_bytes: body.len() as u64,
+                    sha256: sha256_bytes(body),
+                }
+            })
+            .collect();
+        files.sort_by(|left, right| left.path.cmp(&right.path));
+        ModelBundleManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            bundle_id: "ctx.multilingual-e5-small.coreml.fp16".to_owned(),
+            bundle_version: "1.0.0".to_owned(),
+            model: ModelIdentity {
+                id: EXPECTED_MODEL_ID.to_owned(),
+                source_revision: "614241f622f53c4eeff9890bdc4f31cfecc418b3".to_owned(),
+                embedding_space_id: "e5-small-v1:mean-pool:l2:query-passage".to_owned(),
+                precision: EXPECTED_PRECISION.to_owned(),
+            },
+            tensor_contract: TensorContract {
+                inputs: EXPECTED_INPUTS
+                    .into_iter()
+                    .map(|(name, dtype)| TensorSpec {
+                        name: name.to_owned(),
+                        dtype: dtype.to_owned(),
+                        shape: vec![16, 512],
+                    })
+                    .collect(),
+                output: TensorSpec {
+                    name: EXPECTED_OUTPUT_NAME.to_owned(),
+                    dtype: EXPECTED_OUTPUT_DTYPE.to_owned(),
+                    shape: vec![16, EXPECTED_DIMENSIONS],
+                },
+                document_batch_size: 16,
+                query_batch_size: None,
+                max_sequence_length: 512,
+                embedding_dimensions: EXPECTED_DIMENSIONS,
+                document_prefix: "passage: ".to_owned(),
+                query_prefix: "query: ".to_owned(),
+                pooling: "attention_mask_mean".to_owned(),
+                normalization: "l2".to_owned(),
+            },
+            artifacts: BundleArtifacts {
+                tokenizer: "tokenizer.json".to_owned(),
+                document_model: "document.mlpackage".to_owned(),
+                query_model: None,
+            },
+            files,
+        }
+    }
+
+    fn create_valid_bundle(root: &Path) -> ModelBundleManifest {
+        let manifest = valid_manifest(root);
+        write_manifest(root, &manifest);
+        manifest
+    }
+
+    fn add_query_model(root: &Path, manifest: &mut ModelBundleManifest) {
+        let path = "query.mlpackage/Data/model.bin";
+        let body = b"query model";
+        write(&root.join(path), body);
+        manifest.files.push(BundleFile {
+            path: path.to_owned(),
+            size_bytes: body.len() as u64,
+            sha256: sha256_bytes(body),
+        });
+        manifest
+            .files
+            .sort_by(|left, right| left.path.cmp(&right.path));
+        manifest.artifacts.query_model = Some("query.mlpackage".to_owned());
+        manifest.tensor_contract.query_batch_size = Some(1);
+    }
+
+    fn write_manifest(root: &Path, manifest: &ModelBundleManifest) {
+        let mut bytes = serde_json::to_vec_pretty(&manifest).unwrap();
+        bytes.push(b'\n');
+        fs::write(root.join(MANIFEST_FILE), bytes).unwrap();
+    }
+
+    #[test]
+    fn verifies_complete_bundle_and_reports_artifacts() {
+        let temp = tempfile::tempdir().unwrap();
+        create_valid_bundle(temp.path());
+        let verified = verify_model_bundle(temp.path()).unwrap();
+        assert_eq!(verified.manifest.model.id, EXPECTED_MODEL_ID);
+        assert_eq!(
+            verified.tokenizer_path(),
+            temp.path().join("tokenizer.json")
+        );
+        assert_eq!(
+            verified.document_model_path(),
+            temp.path().join("document.mlpackage")
+        );
+        assert_eq!(verified.query_model_path(), None);
+        validate_sha256(&verified.manifest_sha256, "test hash").unwrap();
+    }
+
+    #[test]
+    fn verifies_distinct_document_and_query_batch_contracts() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut manifest = valid_manifest(temp.path());
+        add_query_model(temp.path(), &mut manifest);
+        write_manifest(temp.path(), &manifest);
+
+        let verified = verify_model_bundle(temp.path()).unwrap();
+        assert_eq!(verified.manifest.tensor_contract.document_batch_size, 16);
+        assert_eq!(verified.manifest.tensor_contract.query_batch_size, Some(1));
+        assert_eq!(
+            verified.query_model_path(),
+            Some(temp.path().join("query.mlpackage"))
+        );
+    }
+
+    #[test]
+    fn rejects_hash_mismatch_and_unlisted_payload() {
+        let temp = tempfile::tempdir().unwrap();
+        create_valid_bundle(temp.path());
+        fs::write(temp.path().join("tokenizer.json"), b"changed").unwrap();
+        assert!(verify_model_bundle(temp.path())
+            .unwrap_err()
+            .to_string()
+            .contains("size mismatch"));
+
+        let temp = tempfile::tempdir().unwrap();
+        create_valid_bundle(temp.path());
+        fs::write(temp.path().join("unexpected"), b"x").unwrap();
+        assert!(verify_model_bundle(temp.path())
+            .unwrap_err()
+            .to_string()
+            .contains("file set"));
+    }
+
+    #[test]
+    fn rejects_traversal_unknown_fields_and_oversized_manifest() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut manifest = create_valid_bundle(temp.path());
+        manifest.files[0].path = "../tokenizer.json".to_owned();
+        fs::write(
+            temp.path().join(MANIFEST_FILE),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+        assert!(verify_model_bundle(temp.path())
+            .unwrap_err()
+            .to_string()
+            .contains("relative path"));
+
+        let temp = tempfile::tempdir().unwrap();
+        create_valid_bundle(temp.path());
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&fs::read(temp.path().join(MANIFEST_FILE)).unwrap()).unwrap();
+        value["unknown"] = serde_json::json!(true);
+        fs::write(
+            temp.path().join(MANIFEST_FILE),
+            serde_json::to_vec(&value).unwrap(),
+        )
+        .unwrap();
+        assert!(verify_model_bundle(temp.path()).is_err());
+
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join(MANIFEST_FILE),
+            vec![b' '; MAX_MANIFEST_BYTES as usize + 1],
+        )
+        .unwrap();
+        let error = verify_model_bundle(temp.path()).unwrap_err();
+        assert!(format!("{error:#}").contains("size limit"));
+    }
+
+    #[test]
+    fn rejects_unpinned_model_source_revision() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut manifest = create_valid_bundle(temp.path());
+        manifest.model.source_revision = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned();
+        fs::write(
+            temp.path().join(MANIFEST_FILE),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+        assert!(verify_model_bundle(temp.path())
+            .unwrap_err()
+            .to_string()
+            .contains("source revision"));
+    }
+
+    #[test]
+    fn rejects_nonproduction_document_tensor_shape() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut manifest = create_valid_bundle(temp.path());
+        manifest.tensor_contract.document_batch_size = 512;
+        for input in &mut manifest.tensor_contract.inputs {
+            input.shape[0] = 512;
+        }
+        manifest.tensor_contract.output.shape[0] = 512;
+        fs::write(
+            temp.path().join(MANIFEST_FILE),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+        assert!(verify_model_bundle(temp.path())
+            .unwrap_err()
+            .to_string()
+            .contains("document tensor contract must use fixed batch 16"));
+    }
+
+    #[test]
+    fn rejects_swapped_role_batches_and_query_contract_mismatches() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut manifest = valid_manifest(temp.path());
+        add_query_model(temp.path(), &mut manifest);
+        manifest.tensor_contract.document_batch_size = 1;
+        manifest.tensor_contract.query_batch_size = Some(16);
+        for input in &mut manifest.tensor_contract.inputs {
+            input.shape[0] = 1;
+        }
+        manifest.tensor_contract.output.shape[0] = 1;
+        write_manifest(temp.path(), &manifest);
+        assert!(verify_model_bundle(temp.path())
+            .unwrap_err()
+            .to_string()
+            .contains("document tensor contract must use fixed batch 16"));
+
+        let temp = tempfile::tempdir().unwrap();
+        let mut manifest = valid_manifest(temp.path());
+        add_query_model(temp.path(), &mut manifest);
+        manifest.tensor_contract.query_batch_size = None;
+        write_manifest(temp.path(), &manifest);
+        assert!(verify_model_bundle(temp.path())
+            .unwrap_err()
+            .to_string()
+            .contains("query tensor contract must use fixed batch 1"));
+
+        let temp = tempfile::tempdir().unwrap();
+        let mut manifest = valid_manifest(temp.path());
+        manifest.tensor_contract.query_batch_size = Some(1);
+        write_manifest(temp.path(), &manifest);
+        assert!(verify_model_bundle(temp.path())
+            .unwrap_err()
+            .to_string()
+            .contains("query batch size requires a query model artifact"));
+    }
+
+    #[test]
+    fn rejects_legacy_batch_size_field() {
+        let temp = tempfile::tempdir().unwrap();
+        create_valid_bundle(temp.path());
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&fs::read(temp.path().join(MANIFEST_FILE)).unwrap()).unwrap();
+        value["tensor_contract"]["batch_size"] = serde_json::json!(16);
+        value["tensor_contract"]
+            .as_object_mut()
+            .unwrap()
+            .remove("document_batch_size");
+        fs::write(
+            temp.path().join(MANIFEST_FILE),
+            serde_json::to_vec(&value).unwrap(),
+        )
+        .unwrap();
+        assert!(verify_model_bundle(temp.path()).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlinks_in_bundle_and_manifest() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        create_valid_bundle(temp.path());
+        fs::remove_file(temp.path().join("tokenizer.json")).unwrap();
+        symlink("PROVENANCE.json", temp.path().join("tokenizer.json")).unwrap();
+        assert!(verify_model_bundle(temp.path())
+            .unwrap_err()
+            .to_string()
+            .contains("symlink"));
+
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        symlink(outside.path(), root.path().join(MANIFEST_FILE)).unwrap();
+        assert!(verify_model_bundle(root.path()).is_err());
+    }
+
+    #[test]
+    fn builds_content_addressed_path_and_atomic_marker() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("source");
+        fs::create_dir(&source).unwrap();
+        create_valid_bundle(&source);
+        let hash = verify_model_bundle(&source).unwrap().manifest_sha256;
+        let bundle = content_addressed_bundle_path(temp.path(), &hash).unwrap();
+        fs::create_dir_all(bundle.parent().unwrap()).unwrap();
+        fs::rename(&source, &bundle).unwrap();
+        assert!(bundle.ends_with(format!("{}/{hash}", &hash[..2])));
+        assert!(!completion_marker_matches(&bundle, &hash).unwrap());
+        write_completion_marker_atomic(&bundle).unwrap();
+        assert!(completion_marker_matches(&bundle, &hash).unwrap());
+        assert!(content_addressed_bundle_path(temp.path(), &"A".repeat(64)).is_err());
+    }
+
+    #[test]
+    fn compile_destination_commits_atomically_and_reuses_winner() {
+        let temp = tempfile::tempdir().unwrap();
+        let hash = "b".repeat(64);
+        let first =
+            prepare_compile_destination(temp.path(), &hash, "document", "coremltools-8.3").unwrap();
+        write(&first.staging_path.join("model.bin"), b"compiled");
+        assert_eq!(
+            commit_compile_destination(&first).unwrap(),
+            AtomicCommit::Installed
+        );
+        assert_eq!(
+            fs::read(first.final_path.join("model.bin")).unwrap(),
+            b"compiled"
+        );
+
+        let second =
+            prepare_compile_destination(temp.path(), &hash, "document", "coremltools-8.3").unwrap();
+        write(&second.staging_path.join("model.bin"), b"loser");
+        assert_eq!(
+            commit_compile_destination(&second).unwrap(),
+            AtomicCommit::AlreadyPresent
+        );
+        assert!(!second.staging_path.exists());
+        assert_eq!(
+            fs::read(second.final_path.join("model.bin")).unwrap(),
+            b"compiled"
+        );
+    }
+
+    #[test]
+    fn corrupt_compiled_cache_can_be_invalidated_once() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache = temp.path().join("document.mlmodelc");
+        fs::create_dir(&cache).unwrap();
+        write(&cache.join("corrupt.bin"), b"corrupt");
+        invalidate_compiled_model_cache(&cache).unwrap();
+        assert!(!cache.exists());
+        assert!(invalidate_compiled_model_cache(&cache).is_err());
+        assert!(invalidate_compiled_model_cache(&temp.path().join("unexpected")).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn compile_destination_rejects_symlinked_output_tree() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let destination =
+            prepare_compile_destination(temp.path(), &"c".repeat(64), "query", "coremltools-8.3")
+                .unwrap();
+        symlink("missing", destination.staging_path.join("link")).unwrap();
+        assert!(commit_compile_destination(&destination).is_err());
+        discard_compile_destination(&destination).unwrap();
+    }
+}

--- a/crates/ctx-cli/src/semantic/ort_runtime.rs
+++ b/crates/ctx-cli/src/semantic/ort_runtime.rs
@@ -1,0 +1,495 @@
+#[cfg(ctx_semantic_fastembed)]
+const CTX_ONNXRUNTIME_DYLIB_ENV: &str = "CTX_ONNXRUNTIME_DYLIB";
+#[cfg(ctx_semantic_fastembed)]
+const CTX_ONNXRUNTIME_DIR_ENV: &str = "CTX_ONNXRUNTIME_DIR";
+#[cfg(ctx_semantic_fastembed)]
+const CTX_ONNXRUNTIME_CACHE_DIR_ENV: &str = "CTX_ONNXRUNTIME_CACHE_DIR";
+#[cfg(ctx_semantic_fastembed)]
+const CTX_RUNTIME_DIR_ENV: &str = "CTX_RUNTIME_DIR";
+#[cfg(ctx_semantic_fastembed)]
+const ORT_DYLIB_PATH_ENV: &str = "ORT_DYLIB_PATH";
+#[cfg(ctx_semantic_fastembed)]
+const SEMANTIC_ONNXRUNTIME_VERSION: &str = "1.27.0";
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "windows"))]
+const SEMANTIC_ONNXRUNTIME_DYLIB: &str = "onnxruntime.dll";
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
+const SEMANTIC_ONNXRUNTIME_DYLIB: &str = "libonnxruntime.dylib";
+#[cfg(all(
+    ctx_semantic_fastembed,
+    not(target_os = "windows"),
+    not(target_os = "macos")
+))]
+const SEMANTIC_ONNXRUNTIME_DYLIB: &str = "libonnxruntime.so";
+
+#[cfg(ctx_semantic_fastembed)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SemanticOnnxRuntimeCandidate {
+    source: &'static str,
+    path: PathBuf,
+    try_even_if_missing: bool,
+}
+
+#[cfg(ctx_semantic_fastembed)]
+#[derive(Debug, Clone, Default)]
+struct SemanticOnnxRuntimeEnv {
+    ctx_dylib: Option<PathBuf>,
+    ort_dylib: Option<PathBuf>,
+    ctx_dir: Option<PathBuf>,
+    cache_dir: Option<PathBuf>,
+    runtime_dir: Option<PathBuf>,
+    exe_dir: Option<PathBuf>,
+}
+
+#[cfg(ctx_semantic_fastembed)]
+impl SemanticOnnxRuntimeEnv {
+    fn current() -> Self {
+        Self {
+            ctx_dylib: env_path(CTX_ONNXRUNTIME_DYLIB_ENV),
+            ort_dylib: env_path(ORT_DYLIB_PATH_ENV),
+            ctx_dir: env_path(CTX_ONNXRUNTIME_DIR_ENV),
+            cache_dir: env_path(CTX_ONNXRUNTIME_CACHE_DIR_ENV),
+            runtime_dir: env_path(CTX_RUNTIME_DIR_ENV)
+                .or_else(|| default_data_root().ok().map(|root| root.join("runtime"))),
+            exe_dir: env::current_exe()
+                .ok()
+                .and_then(|path| path.parent().map(Path::to_path_buf)),
+        }
+    }
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn ensure_semantic_onnxruntime_loaded(model_cache_dir: &Path) -> Result<PathBuf> {
+    static INIT: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    static INIT_LOCK: Mutex<()> = Mutex::new(());
+
+    if let Some(path) = INIT.get() {
+        return Ok(path.clone());
+    }
+
+    let _lock = INIT_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+    if let Some(path) = INIT.get() {
+        return Ok(path.clone());
+    }
+
+    let path = load_semantic_onnxruntime(model_cache_dir, &SemanticOnnxRuntimeEnv::current())?;
+    let _ = INIT.set(path.clone());
+    Ok(path)
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn load_semantic_onnxruntime(
+    model_cache_dir: &Path,
+    env: &SemanticOnnxRuntimeEnv,
+) -> Result<PathBuf> {
+    let mut failures = Vec::new();
+    for candidate in semantic_onnxruntime_load_candidates(model_cache_dir, env) {
+        if !candidate.try_even_if_missing && !candidate.path.exists() {
+            continue;
+        }
+        match ort::init_from(&candidate.path) {
+            Ok(builder) => {
+                let _ = builder.commit();
+                return Ok(candidate.path);
+            }
+            Err(error) => failures.push(format!(
+                "{} {}: {error}",
+                candidate.source,
+                candidate.path.display()
+            )),
+        }
+    }
+    let detail = if failures.is_empty() {
+        format!(
+            "no ONNX Runtime dynamic library candidates were found for {}; set an absolute path with {CTX_ONNXRUNTIME_DYLIB_ENV}, {ORT_DYLIB_PATH_ENV}, {CTX_ONNXRUNTIME_DIR_ENV}, {CTX_ONNXRUNTIME_CACHE_DIR_ENV}, or {CTX_RUNTIME_DIR_ENV}",
+            semantic_onnxruntime_platform_dir()
+        )
+    } else {
+        format!(
+            "failed to load ONNX Runtime dynamic library; tried {}",
+            failures.join("; ")
+        )
+    };
+    Err(anyhow!(detail))
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn semantic_onnxruntime_load_candidates(
+    model_cache_dir: &Path,
+    env: &SemanticOnnxRuntimeEnv,
+) -> Vec<SemanticOnnxRuntimeCandidate> {
+    let mut candidates = semantic_onnxruntime_candidates(model_cache_dir, env);
+    let explicit_source = if env.ctx_dylib.is_some() {
+        Some("ctx_env_dylib")
+    } else if env.ort_dylib.is_some() {
+        Some("ort_env_dylib")
+    } else if env.ctx_dir.is_some() {
+        Some("ctx_env_dir")
+    } else {
+        None
+    };
+    if let Some(source) = explicit_source {
+        candidates.retain(|candidate| candidate.source == source);
+    }
+    candidates
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn semantic_onnxruntime_candidates(
+    model_cache_dir: &Path,
+    env: &SemanticOnnxRuntimeEnv,
+) -> Vec<SemanticOnnxRuntimeCandidate> {
+    let mut candidates = Vec::new();
+    if let Some(path) = env.ctx_dylib.as_ref() {
+        push_onnxruntime_candidate(&mut candidates, "ctx_env_dylib", path.clone(), true);
+    }
+    if let Some(path) = env.ort_dylib.as_ref() {
+        push_onnxruntime_candidate(&mut candidates, "ort_env_dylib", path.clone(), true);
+    }
+    if let Some(path) = env.ctx_dir.as_ref() {
+        push_onnxruntime_candidate(
+            &mut candidates,
+            "ctx_env_dir",
+            path.join(SEMANTIC_ONNXRUNTIME_DYLIB),
+            true,
+        );
+    }
+    if let Some(path) = env.cache_dir.as_ref() {
+        push_onnxruntime_cache_candidates(&mut candidates, "ctx_runtime_cache", path);
+    }
+    if let Some(path) = env.runtime_dir.as_ref() {
+        push_onnxruntime_cache_candidates(&mut candidates, "ctx_installed_runtime", path);
+    }
+    if let Some(path) = semantic_onnxruntime_selected_data_root(model_cache_dir) {
+        push_onnxruntime_cache_candidates(
+            &mut candidates,
+            "ctx_selected_data_root_runtime",
+            &path.join("runtime"),
+        );
+    }
+    push_onnxruntime_cache_candidates(
+        &mut candidates,
+        "ctx_default_runtime_cache",
+        &semantic_onnxruntime_default_cache_dir(model_cache_dir),
+    );
+    if let Some(path) = env.exe_dir.as_ref() {
+        push_onnxruntime_candidate(
+            &mut candidates,
+            "exe_dir",
+            path.join(SEMANTIC_ONNXRUNTIME_DYLIB),
+            false,
+        );
+        push_onnxruntime_candidate(
+            &mut candidates,
+            "exe_onnxruntime_platform_dir",
+            path.join("onnxruntime")
+                .join(semantic_onnxruntime_platform_dir())
+                .join(SEMANTIC_ONNXRUNTIME_DYLIB),
+            false,
+        );
+        push_onnxruntime_cache_candidates(&mut candidates, "exe_onnxruntime_cache", path);
+        push_onnxruntime_candidate(
+            &mut candidates,
+            "exe_onnxruntime_dir",
+            path.join("onnxruntime").join(SEMANTIC_ONNXRUNTIME_DYLIB),
+            false,
+        );
+        push_onnxruntime_candidate(
+            &mut candidates,
+            "exe_lib_dir",
+            path.join("lib").join(SEMANTIC_ONNXRUNTIME_DYLIB),
+            false,
+        );
+        if let Some(parent) = path.parent() {
+            push_onnxruntime_candidate(
+                &mut candidates,
+                "install_lib_dir",
+                parent.join("lib").join(SEMANTIC_ONNXRUNTIME_DYLIB),
+                false,
+            );
+        }
+    }
+    candidates
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn semantic_onnxruntime_selected_data_root(model_cache_dir: &Path) -> Option<&Path> {
+    (model_cache_dir.file_name().and_then(|name| name.to_str())
+        == Some("semantic-model-cache"))
+    .then(|| model_cache_dir.parent())
+    .flatten()
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn semantic_onnxruntime_default_cache_dir(model_cache_dir: &Path) -> PathBuf {
+    if let Some(parent) = semantic_onnxruntime_selected_data_root(model_cache_dir) {
+        return parent.join("semantic-runtime");
+    }
+    model_cache_dir.join("semantic-runtime")
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn push_onnxruntime_cache_candidates(
+    candidates: &mut Vec<SemanticOnnxRuntimeCandidate>,
+    source: &'static str,
+    root: &Path,
+) {
+    let platform = semantic_onnxruntime_platform_dir();
+    push_onnxruntime_candidate(
+        candidates,
+        source,
+        root.join("onnxruntime")
+            .join(SEMANTIC_ONNXRUNTIME_VERSION)
+            .join(platform)
+            .join("lib")
+            .join(SEMANTIC_ONNXRUNTIME_DYLIB),
+        false,
+    );
+    push_onnxruntime_candidate(
+        candidates,
+        source,
+        root.join("onnxruntime")
+            .join(SEMANTIC_ONNXRUNTIME_VERSION)
+            .join(platform)
+            .join(SEMANTIC_ONNXRUNTIME_DYLIB),
+        false,
+    );
+    push_onnxruntime_candidate(
+        candidates,
+        source,
+        root.join(platform).join(SEMANTIC_ONNXRUNTIME_DYLIB),
+        false,
+    );
+    push_onnxruntime_candidate(
+        candidates,
+        source,
+        root.join(SEMANTIC_ONNXRUNTIME_DYLIB),
+        false,
+    );
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn push_onnxruntime_candidate(
+    candidates: &mut Vec<SemanticOnnxRuntimeCandidate>,
+    source: &'static str,
+    path: PathBuf,
+    try_even_if_missing: bool,
+) {
+    if path.is_absolute()
+        && !candidates
+            .iter()
+            .any(|candidate| candidate.path == path)
+    {
+        candidates.push(SemanticOnnxRuntimeCandidate {
+            source,
+            path,
+            try_even_if_missing,
+        });
+    }
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "linux", target_arch = "x86_64"))]
+fn semantic_onnxruntime_platform_dir() -> &'static str {
+    "linux-x64"
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "linux", target_arch = "aarch64"))]
+fn semantic_onnxruntime_platform_dir() -> &'static str {
+    "linux-aarch64"
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos", target_arch = "x86_64"))]
+fn semantic_onnxruntime_platform_dir() -> &'static str {
+    "macos-x64"
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "macos", target_arch = "aarch64"))]
+fn semantic_onnxruntime_platform_dir() -> &'static str {
+    "macos-arm64"
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "windows", target_arch = "x86_64"))]
+fn semantic_onnxruntime_platform_dir() -> &'static str {
+    "windows-x64"
+}
+
+#[cfg(all(ctx_semantic_fastembed, target_os = "freebsd", target_arch = "x86_64"))]
+fn semantic_onnxruntime_platform_dir() -> &'static str {
+    "freebsd-x64"
+}
+
+#[cfg(test)]
+#[cfg(ctx_semantic_fastembed)]
+mod ort_runtime_tests {
+    use super::*;
+
+    fn test_absolute_path(path: &str) -> PathBuf {
+        let root = if cfg!(windows) {
+            PathBuf::from(r"C:\ctx-test")
+        } else {
+            PathBuf::from("/tmp/ctx-test")
+        };
+        root.join(path)
+    }
+
+    #[test]
+    fn onnxruntime_candidates_prefer_explicit_dylib_env() {
+        let env = SemanticOnnxRuntimeEnv {
+            ctx_dylib: Some(test_absolute_path("custom").join(SEMANTIC_ONNXRUNTIME_DYLIB)),
+            ort_dylib: Some(test_absolute_path("ort").join(SEMANTIC_ONNXRUNTIME_DYLIB)),
+            ctx_dir: Some(test_absolute_path("ctx-dir")),
+            cache_dir: None,
+            runtime_dir: None,
+            exe_dir: None,
+        };
+        let candidates = semantic_onnxruntime_candidates(&test_absolute_path("model-cache"), &env);
+        assert_eq!(candidates[0].source, "ctx_env_dylib");
+        assert_eq!(candidates[1].source, "ort_env_dylib");
+        assert_eq!(candidates[2].source, "ctx_env_dir");
+        assert!(candidates[0].try_even_if_missing);
+    }
+
+    #[test]
+    fn onnxruntime_load_candidates_do_not_fallback_from_explicit_dylib() {
+        let explicit = test_absolute_path("explicit").join(SEMANTIC_ONNXRUNTIME_DYLIB);
+        let env = SemanticOnnxRuntimeEnv {
+            ctx_dylib: Some(explicit.clone()),
+            ort_dylib: Some(test_absolute_path("ort").join(SEMANTIC_ONNXRUNTIME_DYLIB)),
+            ctx_dir: Some(test_absolute_path("ctx-dir")),
+            cache_dir: Some(test_absolute_path("cache")),
+            runtime_dir: Some(test_absolute_path("runtime")),
+            exe_dir: Some(test_absolute_path("bin")),
+        };
+        let candidates =
+            semantic_onnxruntime_load_candidates(&test_absolute_path("model-cache"), &env);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].source, "ctx_env_dylib");
+        assert_eq!(candidates[0].path, explicit);
+    }
+
+    #[test]
+    fn onnxruntime_candidates_include_platform_cache_dir() {
+        let env = SemanticOnnxRuntimeEnv {
+            cache_dir: Some(test_absolute_path("runtime-cache")),
+            ..SemanticOnnxRuntimeEnv::default()
+        };
+        let candidates = semantic_onnxruntime_candidates(&test_absolute_path("model-cache"), &env);
+        assert!(candidates.iter().any(|candidate| {
+            candidate.path
+                == test_absolute_path("runtime-cache")
+                    .join("onnxruntime")
+                    .join(SEMANTIC_ONNXRUNTIME_VERSION)
+                    .join(semantic_onnxruntime_platform_dir())
+                    .join("lib")
+                    .join(SEMANTIC_ONNXRUNTIME_DYLIB)
+        }));
+    }
+
+    #[test]
+    fn onnxruntime_candidates_include_default_ctx_cache_dir() {
+        let model_cache = test_absolute_path("ctx-data/semantic-model-cache");
+        let candidates =
+            semantic_onnxruntime_candidates(&model_cache, &SemanticOnnxRuntimeEnv::default());
+        assert!(candidates.iter().any(|candidate| {
+            candidate.path
+                == test_absolute_path("ctx-data")
+                    .join("semantic-runtime")
+                    .join("onnxruntime")
+                    .join(SEMANTIC_ONNXRUNTIME_VERSION)
+                    .join(semantic_onnxruntime_platform_dir())
+                    .join("lib")
+                    .join(SEMANTIC_ONNXRUNTIME_DYLIB)
+        }));
+    }
+
+    #[test]
+    fn onnxruntime_candidates_include_selected_data_root_upgrade_dir() {
+        let model_cache = test_absolute_path("custom-data-root/semantic-model-cache");
+        let candidates =
+            semantic_onnxruntime_candidates(&model_cache, &SemanticOnnxRuntimeEnv::default());
+        assert!(candidates.iter().any(|candidate| {
+            candidate.source == "ctx_selected_data_root_runtime"
+                && candidate.path
+                    == test_absolute_path("custom-data-root")
+                        .join("runtime")
+                        .join("onnxruntime")
+                        .join(SEMANTIC_ONNXRUNTIME_VERSION)
+                        .join(semantic_onnxruntime_platform_dir())
+                        .join("lib")
+                        .join(SEMANTIC_ONNXRUNTIME_DYLIB)
+        }));
+    }
+
+    #[test]
+    fn onnxruntime_candidates_include_installer_runtime_dir() {
+        let env = SemanticOnnxRuntimeEnv {
+            runtime_dir: Some(test_absolute_path("ctx-runtime")),
+            ..SemanticOnnxRuntimeEnv::default()
+        };
+        let candidates = semantic_onnxruntime_candidates(&test_absolute_path("model-cache"), &env);
+        assert!(candidates.iter().any(|candidate| {
+            candidate.path
+                == test_absolute_path("ctx-runtime")
+                    .join("onnxruntime")
+                    .join(SEMANTIC_ONNXRUNTIME_VERSION)
+                    .join(semantic_onnxruntime_platform_dir())
+                    .join("lib")
+                    .join(SEMANTIC_ONNXRUNTIME_DYLIB)
+        }));
+    }
+
+    #[test]
+    fn onnxruntime_sidecar_paths_document_macos_x64_and_freebsd_layout() {
+        assert_eq!(
+            PathBuf::from("/cache")
+                .join("onnxruntime")
+                .join(SEMANTIC_ONNXRUNTIME_VERSION)
+                .join("macos-x64")
+                .join("lib")
+                .join("libonnxruntime.dylib"),
+            PathBuf::from("/cache/onnxruntime/1.27.0/macos-x64/lib/libonnxruntime.dylib")
+        );
+        assert_eq!(
+            PathBuf::from("/cache")
+                .join("onnxruntime")
+                .join(SEMANTIC_ONNXRUNTIME_VERSION)
+                .join("freebsd-x64")
+                .join("lib")
+                .join("libonnxruntime.so"),
+            PathBuf::from("/cache/onnxruntime/1.27.0/freebsd-x64/lib/libonnxruntime.so")
+        );
+    }
+
+    #[test]
+    fn onnxruntime_candidates_deduplicate_paths() {
+        let dylib = test_absolute_path("onnxruntime").join(SEMANTIC_ONNXRUNTIME_DYLIB);
+        let env = SemanticOnnxRuntimeEnv {
+            ctx_dylib: Some(dylib.clone()),
+            ort_dylib: Some(dylib.clone()),
+            ..SemanticOnnxRuntimeEnv::default()
+        };
+        let candidates = semantic_onnxruntime_candidates(Path::new(""), &env);
+        assert_eq!(
+            candidates
+                .iter()
+                .filter(|candidate| candidate.path == dylib)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn onnxruntime_candidates_reject_relative_paths() {
+        let env = SemanticOnnxRuntimeEnv {
+            ctx_dylib: Some(PathBuf::from(SEMANTIC_ONNXRUNTIME_DYLIB)),
+            ort_dylib: Some(PathBuf::from("runtime").join(SEMANTIC_ONNXRUNTIME_DYLIB)),
+            ctx_dir: Some(PathBuf::from("runtime")),
+            cache_dir: Some(PathBuf::from("cache")),
+            runtime_dir: Some(PathBuf::from("runtime")),
+            exe_dir: Some(PathBuf::from("bin")),
+        };
+
+        assert!(semantic_onnxruntime_candidates(Path::new("model-cache"), &env).is_empty());
+        assert!(semantic_onnxruntime_load_candidates(Path::new("model-cache"), &env).is_empty());
+    }
+}

--- a/crates/ctx-cli/src/semantic/paths_status.rs
+++ b/crates/ctx-cli/src/semantic/paths_status.rs
@@ -26,6 +26,7 @@ fn daemon_status_path(data_root: &Path) -> PathBuf {
     daemon_root_path(data_root).join(DAEMON_STATUS_FILE)
 }
 
+#[cfg(unix)]
 fn daemon_query_socket_path(data_root: &Path) -> PathBuf {
     daemon_root_path(data_root).join(DAEMON_QUERY_SOCKET_FILE)
 }
@@ -43,7 +44,7 @@ fn daemon_cloud_sync_job_path(data_root: &Path) -> PathBuf {
 }
 
 struct DaemonLock {
-    path: PathBuf,
+    _inner: PidFileLock,
 }
 
 impl DaemonLock {
@@ -51,86 +52,133 @@ impl DaemonLock {
         create_private_dir_all(data_root)?;
         let root = daemon_root_path(data_root);
         create_private_dir_all(&root)?;
-        let path = daemon_lock_path(data_root);
-        for attempt in 0..2 {
-            match private_create_new_file(&path) {
-                Ok(mut file) => {
-                    let payload = json!({
-                        "pid": process::id(),
-                        "started_at_ms": utc_now().timestamp_millis(),
-                        "binary": env::current_exe().ok(),
-                        "data_root": data_root,
-                    });
-                    writeln!(file, "{}", serde_json::to_string(&payload)?)?;
-                    return Ok(Some(Self { path }));
-                }
-                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-                    if attempt == 0 && daemon_lock_is_stale(&path) {
-                        let _ = fs::remove_file(&path);
-                        continue;
-                    }
-                    return Ok(None);
-                }
-                Err(err) => {
-                    return Err(err)
-                        .with_context(|| format!("create ctx daemon lock {}", path.display()));
-                }
-            }
-        }
-        Ok(None)
-    }
-}
-
-impl Drop for DaemonLock {
-    fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
+        let payload = pid_lock_payload(json!({
+            "binary": env::current_exe().ok(),
+            "data_root": data_root,
+        }));
+        Ok(PidFileLock::acquire(&daemon_lock_path(data_root), payload)?
+            .map(|inner| Self { _inner: inner }))
     }
 }
 
 struct SemanticWorkerLock {
-    path: PathBuf,
+    _inner: PidFileLock,
 }
 
 impl SemanticWorkerLock {
     fn acquire(data_root: &Path) -> Result<Option<Self>> {
         create_private_dir_all(data_root)?;
-        let path = semantic_worker_lock_path(data_root);
-        for attempt in 0..2 {
-            match private_create_new_file(&path) {
-                Ok(mut file) => {
-                    let payload = json!({
-                        "pid": process::id(),
-                        "started_at_ms": utc_now().timestamp_millis(),
-                    });
-                    writeln!(file, "{}", serde_json::to_string(&payload)?)?;
-                    return Ok(Some(Self { path }));
-                }
-                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-                    if attempt == 0 && semantic_worker_lock_is_stale(&path) {
-                        let _ = fs::remove_file(&path);
-                        continue;
-                    }
-                    return Ok(None);
-                }
-                Err(err) => {
-                    return Err(err).with_context(|| {
-                        format!("create semantic worker lock {}", path.display())
-                    });
-                }
-            }
+        Ok(PidFileLock::acquire(
+            &semantic_worker_lock_path(data_root),
+            pid_lock_payload(json!({})),
+        )?
+        .map(|inner| Self { _inner: inner }))
+    }
+}
+
+struct PidFileLock {
+    guard: fs::File,
+    path: PathBuf,
+    payload: Value,
+}
+
+impl PidFileLock {
+    fn acquire(path: &Path, payload: Value) -> Result<Option<Self>> {
+        let guard_path = pid_lock_guard_path(path);
+        let (guard, _) = open_or_create_pid_lock_file(&guard_path)
+            .with_context(|| format!("open ctx process guard {}", guard_path.display()))?;
+        secure_private_file_permissions(&guard_path)?;
+        if !try_lock_pid_file(&guard)
+            .with_context(|| format!("lock ctx process guard {}", guard_path.display()))?
+        {
+            return Ok(None);
         }
-        Ok(None)
+
+        let previous = read_pid_lock_json(path);
+        // A legacy process may already be committed to unlinking this path and
+        // cannot see the guard file. A live or incomplete legacy owner wins;
+        // stale legacy metadata is reclaimable for supported upgrade handoff.
+        if path.exists()
+            && !previous.as_ref().is_some_and(pid_lock_uses_advisory_protocol)
+            && !legacy_pid_lock_value_is_stale(path, previous.as_ref())
+        {
+            let _ = fs2::FileExt::unlock(&guard);
+            return Ok(None);
+        }
+        if !publish_pid_lock_metadata(path, &payload)? {
+            let _ = fs2::FileExt::unlock(&guard);
+            return Ok(None);
+        }
+        Ok(Some(Self {
+            guard,
+            path: path.to_path_buf(),
+            payload,
+        }))
     }
 }
 
-impl Drop for SemanticWorkerLock {
+impl Drop for PidFileLock {
     fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
+        if pid_lock_path_has_owner(&self.path, &self.payload) {
+            if let Some(object) = self.payload.as_object_mut() {
+                object.insert("released".to_owned(), Value::Bool(true));
+            }
+            let _ = publish_pid_lock_metadata(&self.path, &self.payload);
+        }
+        let _ = fs2::FileExt::unlock(&self.guard);
     }
 }
 
-fn semantic_worker_lock_is_stale(path: &Path) -> bool {
-    pid_lock_file_is_stale(path)
+fn pid_lock_guard_path(path: &Path) -> PathBuf {
+    path.with_extension("guard")
+}
+
+fn open_or_create_pid_lock_file(path: &Path) -> std::io::Result<(fs::File, bool)> {
+    match private_create_new_lock_file(path) {
+        Ok(file) => Ok((file, true)),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            private_open_existing_lock_file(path).map(|file| (file, false))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn publish_pid_lock_metadata(path: &Path, payload: &Value) -> Result<bool> {
+    for attempt in 0..3 {
+        let (mut file, created) = open_or_create_pid_lock_file(path)
+            .with_context(|| format!("open ctx process lock metadata {}", path.display()))?;
+        secure_private_file_permissions(path)?;
+        let previous = (!created).then(|| read_pid_lock_json(path)).flatten();
+        if !created
+            && !previous.as_ref().is_some_and(pid_lock_uses_advisory_protocol)
+            && !legacy_pid_lock_value_is_stale(path, previous.as_ref())
+        {
+            return Ok(false);
+        }
+        write_pid_lock_json(&mut file, payload)
+            .with_context(|| format!("publish ctx process lock metadata {}", path.display()))?;
+        if pid_lock_path_has_owner(path, payload) {
+            return Ok(true);
+        }
+        if attempt < 2 {
+            std::thread::sleep(PID_LOCK_ACQUIRE_RETRY);
+        }
+    }
+    Ok(false)
+}
+
+fn pid_lock_payload(extra: Value) -> Value {
+    let mut payload = json!({
+        "lock_protocol": PID_LOCK_PROTOCOL,
+        "owner_id": Uuid::now_v7().to_string(),
+        "pid": process::id(),
+        "released": false,
+        "started_at_ms": utc_now().timestamp_millis(),
+    });
+    if let (Some(payload), Some(extra)) = (payload.as_object_mut(), extra.as_object()) {
+        payload.extend(extra.clone());
+    }
+    payload
 }
 
 fn daemon_lock_is_stale(path: &Path) -> bool {
@@ -138,16 +186,114 @@ fn daemon_lock_is_stale(path: &Path) -> bool {
 }
 
 fn pid_lock_file_is_stale(path: &Path) -> bool {
-    let Some(value) = read_pid_lock_json(path) else {
-        return path.exists();
-    };
-    if lock_started_at_is_stale(&value) {
-        return true;
+    if let Some(observation) = observe_pid_advisory_lock(path) {
+        return !observation.held;
     }
-    let Some(pid) = pid_from_lock_json(&value) else {
-        return true;
+    let value = read_pid_lock_json(path);
+    legacy_pid_lock_value_is_stale(path, value.as_ref())
+}
+
+fn pid_lock_file_is_orphaned(path: &Path) -> bool {
+    if let Some(observation) = observe_pid_advisory_lock(path) {
+        return !observation.held && !observation.released;
+    }
+    let value = read_pid_lock_json(path);
+    legacy_pid_lock_value_is_stale(path, value.as_ref())
+}
+
+fn legacy_pid_lock_value_is_stale(path: &Path, value: Option<&Value>) -> bool {
+    let Some(value) = value else {
+        return incomplete_pid_lock_is_stale(path);
     };
-    !pid_is_running(pid)
+    let Some(pid) = pid_from_lock_json(value) else {
+        return incomplete_pid_lock_is_stale(path);
+    };
+    match process_state(pid) {
+        ProcessState::Running => false,
+        ProcessState::NotRunning => true,
+        ProcessState::Unknown => lock_started_at_is_stale(value),
+    }
+}
+
+fn incomplete_pid_lock_is_stale(path: &Path) -> bool {
+    fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .is_some_and(|age| age > PID_LOCK_INCOMPLETE_GRACE)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PidAdvisoryLockObservation {
+    held: bool,
+    released: bool,
+}
+
+fn observe_pid_advisory_lock(path: &Path) -> Option<PidAdvisoryLockObservation> {
+    let guard = private_open_existing_lock_file(&pid_lock_guard_path(path)).ok()?;
+    match fs2::FileExt::try_lock_shared(&guard) {
+        Ok(()) => {
+            let observation = read_pid_lock_json(path)
+                .filter(pid_lock_uses_advisory_protocol)
+                .map(|value| PidAdvisoryLockObservation {
+                    held: false,
+                    released: value
+                        .get("released")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false),
+                });
+            let _ = fs2::FileExt::unlock(&guard);
+            observation
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+            Some(PidAdvisoryLockObservation {
+                held: true,
+                released: false,
+            })
+        }
+        Err(_) => None,
+    }
+}
+
+fn try_lock_pid_file(file: &fs::File) -> std::io::Result<bool> {
+    for attempt in 0..PID_LOCK_ACQUIRE_ATTEMPTS {
+        match fs2::FileExt::try_lock_exclusive(file) {
+            Ok(()) => return Ok(true),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                if attempt + 1 < PID_LOCK_ACQUIRE_ATTEMPTS {
+                    std::thread::sleep(PID_LOCK_ACQUIRE_RETRY);
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(false)
+}
+
+fn pid_lock_path_has_owner(path: &Path, payload: &Value) -> bool {
+    let owner_id = payload.get("owner_id").and_then(Value::as_str);
+    owner_id.is_some()
+        && read_pid_lock_json(path)
+            .as_ref()
+            .and_then(|value| value.get("owner_id"))
+            .and_then(Value::as_str)
+            == owner_id
+}
+
+fn pid_lock_uses_advisory_protocol(value: &Value) -> bool {
+    value.get("lock_protocol").and_then(Value::as_str) == Some(PID_LOCK_PROTOCOL)
+}
+
+fn pid_lock_file_reports_running(
+    path: &Path,
+    lock_state: Option<ProcessState>,
+    status: &str,
+) -> bool {
+    if let Some(observation) = observe_pid_advisory_lock(path) {
+        return observation.held;
+    }
+    matches!(lock_state, Some(ProcessState::Running))
+        || unknown_process_lock_reports_running(path, lock_state, status)
 }
 
 fn read_pid_lock_file(path: &Path) -> Option<u32> {
@@ -157,6 +303,15 @@ fn read_pid_lock_file(path: &Path) -> Option<u32> {
 fn read_pid_lock_json(path: &Path) -> Option<Value> {
     let text = fs::read_to_string(path).ok()?;
     serde_json::from_str(&text).ok()
+}
+
+fn write_pid_lock_json(file: &mut fs::File, value: &Value) -> Result<()> {
+    file.set_len(0)?;
+    file.seek(SeekFrom::Start(0))?;
+    serde_json::to_writer(&mut *file, value)?;
+    file.write_all(b"\n")?;
+    file.flush()?;
+    Ok(())
 }
 
 fn pid_from_lock_json(value: &Value) -> Option<u32> {
@@ -173,21 +328,70 @@ fn lock_started_at_is_stale(value: &Value) -> bool {
     utc_now().timestamp_millis().saturating_sub(started_at_ms) > DAEMON_LOCK_STALE_AFTER_MS
 }
 
-#[cfg(unix)]
-fn pid_is_running(pid: u32) -> bool {
-    if pid == 0 {
-        return false;
-    }
-    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
-    if result == 0 {
-        return true;
-    }
-    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProcessState {
+    Running,
+    NotRunning,
+    Unknown,
 }
 
-#[cfg(not(unix))]
-fn pid_is_running(pid: u32) -> bool {
-    pid != 0
+#[cfg(unix)]
+fn process_state(pid: u32) -> ProcessState {
+    if pid == 0 {
+        return ProcessState::NotRunning;
+    }
+    let Ok(pid) = libc::pid_t::try_from(pid) else {
+        return ProcessState::NotRunning;
+    };
+    let result = unsafe { libc::kill(pid, 0) };
+    if result == 0 {
+        return ProcessState::Running;
+    }
+    match std::io::Error::last_os_error().raw_os_error() {
+        Some(libc::ESRCH) => ProcessState::NotRunning,
+        Some(libc::EPERM) => ProcessState::Running,
+        _ => ProcessState::Unknown,
+    }
+}
+
+#[cfg(windows)]
+fn process_state(pid: u32) -> ProcessState {
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, ERROR_ACCESS_DENIED};
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    if pid == 0 {
+        return ProcessState::NotRunning;
+    }
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if !handle.is_null() {
+        unsafe {
+            CloseHandle(handle);
+        }
+        return ProcessState::Running;
+    }
+    match unsafe { GetLastError() } {
+        windows_sys::Win32::Foundation::ERROR_INVALID_PARAMETER => ProcessState::NotRunning,
+        ERROR_ACCESS_DENIED => ProcessState::Running,
+        _ => ProcessState::Unknown,
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn process_state(_pid: u32) -> ProcessState {
+    ProcessState::Unknown
+}
+
+fn unknown_process_lock_reports_running(
+    lock_path: &Path,
+    state: Option<ProcessState>,
+    status: &str,
+) -> bool {
+    matches!(state, Some(ProcessState::Unknown))
+        && status == "running"
+        && lock_path.exists()
+        && !pid_lock_file_is_stale(lock_path)
 }
 
 #[cfg(unix)]
@@ -252,7 +456,7 @@ fn read_daemon_job_status(path: &Path) -> Option<Value> {
 fn semantic_status_file_model_matches(status_value: Option<&Value>) -> bool {
     status_value
         .and_then(|value| json_string(value, "model_key"))
-        .is_some_and(|model_key| model_key == SEMANTIC_MODEL_KEY)
+        .is_some_and(|model_key| model_key == semantic_model_key())
 }
 
 fn semantic_status_file_searchable_items(status_value: Option<&Value>) -> Option<usize> {
@@ -354,7 +558,13 @@ fn semantic_worker_report_with_count_mode(
     let status_path = semantic_worker_status_path(data_root);
     let lock_path = semantic_worker_lock_path(data_root);
     let lock_pid = read_pid_lock_file(&lock_path);
-    let running = lock_pid.is_some_and(pid_is_running);
+    let lock_state = lock_pid.map(process_state);
+    let status_file_status = current_status_value.and_then(|value| json_string(value, "status"));
+    let running = pid_lock_file_reports_running(
+        &lock_path,
+        lock_state,
+        status_file_status.as_deref().unwrap_or("unknown"),
+    );
     let pid = if running {
         lock_pid
     } else {
@@ -363,9 +573,7 @@ fn semantic_worker_report_with_count_mode(
     let queued_items_estimate = searchable_items
         .saturating_sub(embedded_items)
         .max(dirty_items);
-    let mut status = current_status_value
-        .and_then(|value| json_string(value, "status"))
-        .unwrap_or_else(|| {
+    let mut status = status_file_status.unwrap_or_else(|| {
             if !searchable_items_known || store.is_none() {
                 "unknown".to_owned()
             } else if searchable_items == 0 {
@@ -390,7 +598,9 @@ fn semantic_worker_report_with_count_mode(
         };
         let preserve_status = (status == "budget_exhausted" && queued_items_estimate > 0)
             || status == "acquiring_model"
+            || status == "model_load_deferred"
             || status == "model_acquisition_failed"
+            || status == "model_integrity_failed"
             || (status == "failed"
                 && sidecar_error.is_none()
                 && embedded_items == 0
@@ -400,7 +610,7 @@ fn semantic_worker_report_with_count_mode(
     if running {
         status = "running".to_owned();
     } else if lock_path.exists()
-        && semantic_worker_lock_is_stale(&lock_path)
+        && pid_lock_file_is_orphaned(&lock_path)
         && queued_items_estimate > 0
     {
         status = "stale_lock".to_owned();
@@ -424,9 +634,16 @@ fn semantic_worker_report_with_count_mode(
         dirty_items,
         queued_items_estimate,
         model_cache_available,
+        model_acquisition: current_status_value
+            .and_then(|value| value.get("model_acquisition").cloned())
+            .unwrap_or_else(|| {
+                semantic_model_acquisition_status_json(&semantic_worker_cache_dir(data_root))
+            }),
         embed_policy: current_status_value
             .and_then(|value| value.get("embed_policy").cloned())
             .or_else(|| Some(semantic_embed_policy_status_json())),
+        embedding_runtime: current_status_value
+            .and_then(|value| value.get("embedding_runtime").cloned()),
         vector_path,
         lock_path,
         status_path,
@@ -452,12 +669,13 @@ fn daemon_report_with_disabled_status(
     let lock_path = daemon_lock_path(data_root);
     let status_path = daemon_status_path(data_root);
     let lock_pid = read_pid_lock_file(&lock_path);
-    let running = lock_pid.is_some_and(pid_is_running);
-    let stale_lock = lock_path.exists() && daemon_lock_is_stale(&lock_path);
     let mut status = status_value
         .as_ref()
         .and_then(|value| json_string(value, "status"))
         .unwrap_or_else(|| "unknown".to_owned());
+    let lock_state = lock_pid.map(process_state);
+    let running = pid_lock_file_reports_running(&lock_path, lock_state, status.as_str());
+    let stale_lock = lock_path.exists() && pid_lock_file_is_orphaned(&lock_path);
     let stale_running_status = !running && status == "running";
     if running {
         status = "running".to_owned();
@@ -596,7 +814,10 @@ fn daemon_semantic_job_report(
         "unavailable"
     } else if semantic_report.status == "acquiring_model" {
         "acquiring_model"
-    } else if semantic_report.status == "model_acquisition_failed" {
+    } else if matches!(
+        semantic_report.status.as_str(),
+        "model_load_deferred" | "model_acquisition_failed" | "model_integrity_failed"
+    ) {
         "skipped"
     } else if !semantic_report.searchable_items_known {
         "unknown"
@@ -627,8 +848,12 @@ fn daemon_semantic_job_report(
         Some("sidecar_unavailable".to_owned())
     } else if semantic_report.status == "acquiring_model" {
         Some("acquiring_model".to_owned())
+    } else if semantic_report.status == "model_load_deferred" {
+        Some("memory_pressure".to_owned())
     } else if semantic_report.status == "model_acquisition_failed" {
         Some("model_acquisition_failed".to_owned())
+    } else if semantic_report.status == "model_integrity_failed" {
+        Some("model_integrity_failed".to_owned())
     } else if !semantic_report.searchable_items_known {
         Some("searchable_items_unknown".to_owned())
     } else if semantic_report.searchable_items == 0 {
@@ -656,12 +881,29 @@ fn daemon_semantic_job_report(
             .as_ref()
             .and_then(|value| json_string(value, "last_error"))
             .or_else(|| semantic_report.last_error.clone()),
+        "retryable": status_value
+            .as_ref()
+            .and_then(|value| value.get("retryable").and_then(Value::as_bool)),
+        "available_memory_bytes": status_value
+            .as_ref()
+            .and_then(|value| value.get("available_memory_bytes").and_then(Value::as_u64)),
+        "required_available_memory_bytes": status_value
+            .as_ref()
+            .and_then(|value| value.get("required_available_memory_bytes").and_then(Value::as_u64)),
         "indexed_chunks": status_value.as_ref().and_then(|value| json_usize(value, "indexed_chunks")),
         "model_cache_available": semantic_report.model_cache_available,
+        "model_acquisition": status_value
+            .as_ref()
+            .and_then(|value| value.get("model_acquisition").cloned())
+            .unwrap_or_else(|| semantic_report.model_acquisition.clone()),
         "embed_policy": status_value
             .as_ref()
             .and_then(|value| value.get("embed_policy").cloned())
             .or_else(|| semantic_report.embed_policy.clone()),
+        "embedding_runtime": status_value
+            .as_ref()
+            .and_then(|value| value.get("embedding_runtime").cloned())
+            .or_else(|| semantic_report.embedding_runtime.clone()),
         "worker_status": semantic_report.status,
         "coverage": {
             "searchable_items": semantic_report.searchable_items,

--- a/crates/ctx-cli/src/semantic/preamble.rs
+++ b/crates/ctx-cli/src/semantic/preamble.rs
@@ -1,16 +1,20 @@
 use std::{
     collections::{HashMap, HashSet},
-    env, fs,
-    io::{Read, Write},
-    net::Shutdown,
+    env, fmt, fs,
+    io::{Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     process::{self, Command, Stdio},
     sync::{Arc, Mutex},
-    time::{Duration as StdDuration, Instant},
+    time::{Duration as StdDuration, Instant, SystemTime},
 };
 
 #[cfg(unix)]
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::net::Shutdown;
+#[cfg(unix)]
+use std::os::unix::{
+    ffi::OsStrExt,
+    fs::{OpenOptionsExt, PermissionsExt},
+};
 #[cfg(unix)]
 use std::os::unix::net::{UnixListener, UnixStream};
 #[cfg(ctx_sqlite_vec)]
@@ -22,11 +26,6 @@ use std::sync::{
 };
 
 use anyhow::{anyhow, Context, Result};
-#[cfg(ctx_semantic_fastembed)]
-use fastembed::{
-    EmbeddingModel, InitOptions, InitOptionsUserDefined, Pooling, TextEmbedding, TokenizerFiles,
-    UserDefinedEmbeddingModel,
-};
 use rusqlite::{
     params, params_from_iter, types::Value as SqlValue, Connection, OpenFlags, OptionalExtension,
 };
@@ -34,7 +33,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use ctx_history_core::{database_path, utc_now};
+use ctx_history_core::{database_path, default_data_root, utc_now};
 use ctx_history_store::{EventEmbeddingDocument, Store};
 
 use crate::commands::{
@@ -46,24 +45,105 @@ use crate::commands::{
 };
 use crate::config::{self, AppConfig, CONFIG_FILE};
 use crate::output::{compact_json, print_json};
-use crate::store_util::open_existing_store_snapshot_read_only;
+use crate::store_util::open_existing_store_read_only;
 use crate::{
     DaemonArgs, DaemonCommand, DaemonRunArgs, DaemonStartModeArg, DaemonTriggerCommandArg,
     JsonArgs, SearchBackendArg,
 };
 
-const SEMANTIC_BACKEND: &str = "fastembed";
-const SEMANTIC_MODEL_KEY: &str = "fastembed:all-MiniLM-L6-v2:semantic-lite-turn-1200-200-v2";
-const SEMANTIC_MODEL_ID: &str = "sentence-transformers/all-MiniLM-L6-v2";
-const SEMANTIC_HF_MODEL_CACHE_DIR: &str = "models--Qdrant--all-MiniLM-L6-v2-onnx";
-const SEMANTIC_REQUIRED_MODEL_FILES: &[&str] = &[
-    "model.onnx",
-    "tokenizer.json",
-    "config.json",
-    "special_tokens_map.json",
-    "tokenizer_config.json",
+const SEMANTIC_BACKEND: &str = "multilingual-e5";
+const SEMANTIC_MODEL_KEY: &str = "e5-small-v1:mean-pool:l2:query-passage";
+const SEMANTIC_MODEL_ID: &str = "intfloat/multilingual-e5-small";
+const SEMANTIC_MODEL_REVISION: &str = "614241f622f53c4eeff9890bdc4f31cfecc418b3";
+const SEMANTIC_HF_MODEL_CACHE_DIR: &str = "models--intfloat--multilingual-e5-small";
+const SEMANTIC_MANAGED_MODEL_CACHE_DIR: &str = "ctx-semantic-models";
+const SEMANTIC_REQUIRED_MODEL_FILES: &[SemanticModelFile] = &[
+    SemanticModelFile::new(
+        "onnx/model.onnx",
+        470_268_510,
+        "ca456c06b3a9505ddfd9131408916dd79290368331e7d76bb621f1cba6bc8665",
+    ),
+    SemanticModelFile::new(
+        "tokenizer.json",
+        17_082_730,
+        "0b44a9d7b51c3c62626640cda0e2c2f70fdacdc25bbbd68038369d14ebdf4c39",
+    ),
+    SemanticModelFile::new(
+        "config.json",
+        655,
+        "69137736cab8b8903a07fe8afaafdda25aac55415a12a55d1bffa9f581abf959",
+    ),
+    SemanticModelFile::new(
+        "special_tokens_map.json",
+        167,
+        "d05497f1da52c5e09554c0cd874037a083e1dc1b9cfd48034d1c717f1afc07a7",
+    ),
+    SemanticModelFile::new(
+        "tokenizer_config.json",
+        443,
+        "a1d6bc8734a6f635dc158508bef000f8e2e5a759c7d92f984b2c86e5ff53425b",
+    ),
 ];
 const SEMANTIC_DIMENSIONS: usize = 384;
+const SEMANTIC_PASSAGE_PREFIX: &str = "passage: ";
+const SEMANTIC_QUERY_PREFIX: &str = "query: ";
+
+#[derive(Clone, Copy, Debug)]
+struct SemanticModelFile {
+    path: &'static str,
+    size: u64,
+    sha256: &'static str,
+}
+
+impl SemanticModelFile {
+    const fn new(path: &'static str, size: u64, sha256: &'static str) -> Self {
+        Self { path, size, sha256 }
+    }
+}
+
+#[derive(Debug)]
+struct SemanticCpuModelIntegrityError(String);
+
+impl fmt::Display for SemanticCpuModelIntegrityError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for SemanticCpuModelIntegrityError {}
+
+#[derive(Debug)]
+struct SemanticCpuModelCacheMissing(String);
+
+impl fmt::Display for SemanticCpuModelCacheMissing {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for SemanticCpuModelCacheMissing {}
+
+#[derive(Debug)]
+struct SemanticModelLoadDeferred {
+    available_memory_bytes: u64,
+    required_available_memory_bytes: u64,
+}
+
+impl fmt::Display for SemanticModelLoadDeferred {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "semantic CPU model load deferred: {} bytes available, {} required",
+            self.available_memory_bytes, self.required_available_memory_bytes
+        )
+    }
+}
+
+impl std::error::Error for SemanticModelLoadDeferred {}
+
+fn semantic_model_key() -> &'static str {
+    SEMANTIC_MODEL_KEY
+}
 const SEMANTIC_SEARCH_CANDIDATES: usize = 200;
 const SEMANTIC_SOFT_FILTER_SEARCH_CANDIDATES: usize = 1_000;
 const SEMANTIC_CHUNK_TARGET_CHARS: usize = 1_200;
@@ -76,30 +156,16 @@ const SEMANTIC_VECTOR_BACKEND_RUST: &str = "rust_blob_scan";
 const SEMANTIC_VECTOR_BACKEND_SQLITE_VEC: &str = "sqlite_vec0";
 const SEMANTIC_SQLITE_VEC0_MAX_K: usize = 4_096;
 #[cfg(ctx_semantic_fastembed)]
-const SEMANTIC_EMBED_THREADS_FALLBACK: usize = 2;
-#[cfg(ctx_semantic_fastembed)]
 const SEMANTIC_EMBED_THREADS_MAX: usize = 8;
 #[cfg(ctx_semantic_fastembed)]
-const SEMANTIC_EMBED_BATCH_FALLBACK: usize = 16;
-#[cfg(ctx_semantic_fastembed)]
 const SEMANTIC_EMBED_BATCH_MAX: usize = 512;
-#[cfg(ctx_semantic_fastembed)]
-const SEMANTIC_EMBED_BATCH_ADAPTIVE_MAX: usize = 128;
-#[cfg(ctx_semantic_fastembed)]
-const SEMANTIC_MEMORY_BUDGET_MIN_BYTES: u64 = 1024 * 1024 * 1024;
-#[cfg(ctx_semantic_fastembed)]
-const SEMANTIC_MEMORY_BUDGET_MAX_BYTES: u64 = 10 * 1024 * 1024 * 1024;
-#[cfg(ctx_semantic_fastembed)]
-const SEMANTIC_MEMORY_BUDGET_FALLBACK_BYTES: u64 = 2 * 1024 * 1024 * 1024;
-#[cfg(ctx_semantic_fastembed)]
-const SEMANTIC_EMBED_BATCH_TARGET_BYTES: u64 = 80 * 1024 * 1024;
 const SEMANTIC_DIRTY_QUEUE_RECENT_LIMIT: usize = 512;
 const SEMANTIC_WORKER_LOCK_FILE: &str = "semantic-worker.lock";
 const SEMANTIC_WORKER_STATUS_FILE: &str = "semantic-worker.json";
 const SEMANTIC_WORKER_BATCH_DEFAULT: usize = 5_000;
-pub(crate) const SEMANTIC_WORKER_BATCH_MAX: usize = 5_000;
+pub(crate) const SEMANTIC_WORKER_BATCH_MAX: usize = 1_000_000;
 const SEMANTIC_WORKER_MAX_SECONDS_DEFAULT: u64 = 60;
-pub(crate) const SEMANTIC_WORKER_MAX_SECONDS_CAP: u64 = 3_600;
+pub(crate) const SEMANTIC_WORKER_MAX_SECONDS_CAP: u64 = 86_400;
 const SEMANTIC_MODEL_INIT_MIN_REMAINING_SECS: u64 = 15;
 const SEMANTIC_VECTOR_BUSY_TIMEOUT_MS: u64 = 30_000;
 const SEMANTIC_PRUNE_EVENTS_PER_PASS: usize = 256;
@@ -110,7 +176,9 @@ const DAEMON_DIR: &str = "daemon";
 const DAEMON_JOBS_DIR: &str = "jobs";
 const DAEMON_LOCK_FILE: &str = "daemon.lock";
 const DAEMON_STATUS_FILE: &str = "status.json";
+#[cfg(unix)]
 const DAEMON_QUERY_SOCKET_FILE: &str = "query.sock";
+const DAEMON_QUERY_ENDPOINT_FILE: &str = "query-endpoint.json";
 const DAEMON_HISTORY_REFRESH_JOB_FILE: &str = "history-refresh.json";
 const DAEMON_SEMANTIC_JOB_FILE: &str = "semantic-index.json";
 const DAEMON_CLOUD_SYNC_JOB_FILE: &str = "cloud-sync.json";
@@ -123,6 +191,10 @@ const DAEMON_BACKGROUND_CHILD_ENV: &str = "CTX_DAEMON_BACKGROUND_CHILD";
 const DAEMON_AUTOSTART_OFF_ENV: &str = "CTX_DAEMON_AUTOSTART_OFF";
 const DAEMON_SEMANTIC_BOOTSTRAP_PASSES_BEFORE_REFRESH: usize = 1;
 const DAEMON_LOCK_STALE_AFTER_MS: i64 = 25 * 60 * 60 * 1_000;
+const PID_LOCK_INCOMPLETE_GRACE: StdDuration = StdDuration::from_secs(30);
+const PID_LOCK_PROTOCOL: &str = "advisory-v1";
+const PID_LOCK_ACQUIRE_ATTEMPTS: usize = 20;
+const PID_LOCK_ACQUIRE_RETRY: StdDuration = StdDuration::from_millis(2);
 const DAEMON_SEMANTIC_RESERVE_GRACE_SECS: u64 = 10;
 const DAEMON_MIN_REMAINING_FOR_JOB_SECS: u64 = 2;
 
@@ -150,7 +222,9 @@ pub(crate) struct SemanticWorkerReport {
     dirty_items: usize,
     queued_items_estimate: usize,
     model_cache_available: bool,
+    model_acquisition: Value,
     embed_policy: Option<Value>,
+    embedding_runtime: Option<Value>,
     vector_path: PathBuf,
     lock_path: PathBuf,
     status_path: PathBuf,
@@ -177,7 +251,11 @@ impl SemanticWorkerReport {
             model_cache_available: semantic_model_cache_available(&semantic_worker_cache_dir(
                 data_root,
             )),
+            model_acquisition: semantic_model_acquisition_status_json(
+                &semantic_worker_cache_dir(data_root),
+            ),
             embed_policy: Some(semantic_embed_policy_status_json()),
+            embedding_runtime: None,
             vector_path: semantic_vector_path(data_root),
             lock_path: semantic_worker_lock_path(data_root),
             status_path: semantic_worker_status_path(data_root),
@@ -195,7 +273,7 @@ impl SemanticWorkerReport {
     pub(crate) fn to_json(&self) -> Value {
         compact_json(json!({
             "status": self.status,
-            "model_key": SEMANTIC_MODEL_KEY,
+            "model_key": semantic_model_key(),
             "running": self.running,
             "pid": self.pid,
             "started_at_ms": self.started_at_ms,
@@ -214,7 +292,9 @@ impl SemanticWorkerReport {
                 "coverage_ratio": self.coverage_ratio(),
             },
             "model_cache_available": self.model_cache_available,
+            "model_acquisition": self.model_acquisition.clone(),
             "embed_policy": self.embed_policy.clone(),
+            "embedding_runtime": self.embedding_runtime.clone(),
             "vector_path": self.vector_path.display().to_string(),
             "lock_path": self.lock_path.display().to_string(),
             "status_path": self.status_path.display().to_string(),
@@ -451,6 +531,32 @@ pub(crate) fn search_packet_with_backend(
         return Ok((lexical_search_packet()?, retrieval));
     }
 
+    if !semantic_query_service_supported()
+        && matches!(
+            requested_backend,
+            SearchBackendArg::Semantic | SearchBackendArg::Hybrid
+        )
+    {
+        if requested_backend == SearchBackendArg::Semantic {
+            return Err(anyhow!(
+                "local semantic search is not supported on this platform yet"
+            ));
+        }
+        let mut retrieval = SemanticRetrievalReport::lexical(requested_backend, 0);
+        retrieval.effective_mode = SearchBackendArg::Lexical;
+        retrieval.semantic_weight = 0.0;
+        retrieval.semantic_status = "unavailable";
+        retrieval.set_semantic_fallback(
+            "unsupported_platform",
+            "local semantic search is not supported on this platform yet",
+        );
+        warn_if(
+            emit_warnings,
+            "warning: local semantic search is not supported on this platform; falling back to lexical search",
+        );
+        return Ok((lexical_search_packet()?, retrieval));
+    }
+
     let semantic_cache_dir = semantic_worker_cache_dir(data_root);
     let vector_path = semantic_vector_path(data_root);
 
@@ -601,12 +707,6 @@ fn semantic_or_hybrid_search_packet(
                     "warning: semantic index is empty; falling back to lexical search",
                 );
                 return lexical_search_packet();
-            }
-
-            if effective_backend == SearchBackendArg::Semantic && worker_report.running {
-                return Err(anyhow!(
-                    "semantic worker is currently indexing; semantic-only search will not initialize a query embedding model while background indexing is active; retry when indexing is idle or use --backend hybrid"
-                ));
             }
 
             if effective_backend == SearchBackendArg::Hybrid

--- a/crates/ctx-cli/src/semantic/query_service_transport.rs
+++ b/crates/ctx-cli/src/semantic/query_service_transport.rs
@@ -1,0 +1,612 @@
+#[derive(Debug, Clone)]
+enum DaemonQueryEndpoint {
+    #[cfg(unix)]
+    Unix { path: PathBuf, token: String },
+    #[cfg(windows)]
+    WindowsNamedPipe { pipe_name: String, token: String },
+    #[cfg(not(any(unix, windows)))]
+    #[allow(dead_code)]
+    Unsupported,
+}
+
+impl DaemonQueryEndpoint {
+    fn token(&self) -> &str {
+        match self {
+            #[cfg(unix)]
+            Self::Unix { token, .. } => token,
+            #[cfg(windows)]
+            Self::WindowsNamedPipe { token, .. } => token,
+            #[cfg(not(any(unix, windows)))]
+            Self::Unsupported => "",
+        }
+    }
+}
+
+fn daemon_query_endpoint_path(data_root: &Path) -> PathBuf {
+    daemon_root_path(data_root).join(DAEMON_QUERY_ENDPOINT_FILE)
+}
+
+fn write_daemon_query_endpoint(data_root: &Path, endpoint: &DaemonQueryEndpoint) -> Result<()> {
+    let value = match endpoint {
+        #[cfg(unix)]
+        DaemonQueryEndpoint::Unix { path, token } => compact_json(json!({
+            "schema_version": 1,
+            "transport": "unix",
+            "path": path,
+            "token": token,
+            "pid": process::id(),
+        })),
+        #[cfg(windows)]
+        DaemonQueryEndpoint::WindowsNamedPipe { pipe_name, token } => compact_json(json!({
+            "schema_version": 1,
+            "transport": "windows_named_pipe",
+            "pipe_name": pipe_name,
+            "token": token,
+            "pid": process::id(),
+        })),
+        #[cfg(not(any(unix, windows)))]
+        DaemonQueryEndpoint::Unsupported => {
+            return Err(anyhow!(
+                "daemon query service is not supported on this platform"
+            ));
+        }
+    };
+    write_private_json_file(&daemon_query_endpoint_path(data_root), &value)
+}
+
+fn remove_daemon_query_endpoint(data_root: &Path) {
+    let _ = fs::remove_file(daemon_query_endpoint_path(data_root));
+}
+
+fn read_daemon_query_endpoint(data_root: &Path) -> Result<Option<DaemonQueryEndpoint>> {
+    let path = daemon_query_endpoint_path(data_root);
+    let text = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("read daemon query endpoint {}", path.display()));
+        }
+    };
+    let value: Value = serde_json::from_str(&text)
+        .with_context(|| format!("parse daemon query endpoint {}", path.display()))?;
+    if value.get("schema_version").and_then(Value::as_u64) != Some(1) {
+        return Ok(None);
+    }
+    read_daemon_query_endpoint_value(value)
+}
+
+fn read_daemon_query_endpoint_value(value: Value) -> Result<Option<DaemonQueryEndpoint>> {
+    let Some(token) = value
+        .get("token")
+        .and_then(Value::as_str)
+        .filter(|token| token.len() >= 32)
+        .map(str::to_owned)
+    else {
+        return Ok(None);
+    };
+    match value.get("transport").and_then(Value::as_str) {
+        #[cfg(unix)]
+        Some("unix") => {
+            let path = value.get("path").and_then(Value::as_str).map(PathBuf::from);
+            Ok(path.map(|path| DaemonQueryEndpoint::Unix { path, token }))
+        }
+        #[cfg(windows)]
+        Some("windows_named_pipe") => {
+            let pipe_name = value
+                .get("pipe_name")
+                .and_then(Value::as_str)
+                .filter(|pipe_name| windows_named_pipe_name_is_local(pipe_name))
+                .map(str::to_owned);
+            Ok(pipe_name.map(|pipe_name| DaemonQueryEndpoint::WindowsNamedPipe {
+                pipe_name,
+                token,
+            }))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn daemon_query_request(
+    data_root: &Path,
+    mut request: Value,
+    timeout: StdDuration,
+    max_response_bytes: u64,
+) -> Result<Option<Value>> {
+    let Some(endpoint) = read_daemon_query_endpoint(data_root)? else {
+        return Ok(None);
+    };
+    request["token"] = Value::String(endpoint.token().to_owned());
+    let request = format!("{}\n", serde_json::to_string(&compact_json(request))?);
+    let body = daemon_query_roundtrip(&endpoint, request.as_bytes(), timeout, max_response_bytes)?;
+    let response: Value = serde_json::from_str(&body).context("parse daemon query response")?;
+    Ok(Some(response))
+}
+
+fn daemon_query_roundtrip(
+    endpoint: &DaemonQueryEndpoint,
+    request: &[u8],
+    timeout: StdDuration,
+    max_response_bytes: u64,
+) -> Result<String> {
+    match endpoint {
+        #[cfg(unix)]
+        DaemonQueryEndpoint::Unix { path, .. } => {
+            if !path.exists() {
+                return Err(anyhow!("daemon query socket does not exist"));
+            }
+            let mut stream = UnixStream::connect(path)
+                .with_context(|| format!("connect daemon query socket {}", path.display()))?;
+            stream
+                .set_read_timeout(Some(timeout))
+                .context("set daemon query read timeout")?;
+            stream
+                .set_write_timeout(Some(timeout))
+                .context("set daemon query write timeout")?;
+            stream
+                .write_all(request)
+                .context("write daemon query request")?;
+            let _ = stream.shutdown(Shutdown::Write);
+            let mut body = String::new();
+            stream
+                .take(max_response_bytes)
+                .read_to_string(&mut body)
+                .context("read daemon query response")?;
+            Ok(body)
+        }
+        #[cfg(windows)]
+        DaemonQueryEndpoint::WindowsNamedPipe { pipe_name, .. } => {
+            daemon_query_roundtrip_windows(pipe_name, request, timeout, max_response_bytes)
+        }
+        #[cfg(not(any(unix, windows)))]
+        DaemonQueryEndpoint::Unsupported => Err(anyhow!(
+            "daemon query service is not supported on this platform"
+        )),
+    }
+}
+
+fn read_daemon_query_request<S: std::io::Read>(stream: &mut S, max_bytes: usize) -> Result<String> {
+    let mut body = Vec::new();
+    let mut chunk = [0u8; 8 * 1024];
+    while body.len() < max_bytes {
+        let read_limit = (max_bytes - body.len()).min(chunk.len());
+        let read = stream
+            .read(&mut chunk[..read_limit])
+            .context("read daemon query request")?;
+        if read == 0 {
+            break;
+        }
+        if let Some(newline) = chunk[..read].iter().position(|byte| *byte == b'\n') {
+            body.extend_from_slice(&chunk[..newline]);
+            return String::from_utf8(body).context("daemon query request is not UTF-8");
+        }
+        body.extend_from_slice(&chunk[..read]);
+    }
+    if body.len() >= max_bytes {
+        return Err(anyhow!("daemon query request is too large"));
+    }
+    String::from_utf8(body).context("daemon query request is not UTF-8")
+}
+
+#[cfg(unix)]
+fn read_daemon_query_request_unix(
+    stream: &mut UnixStream,
+    max_bytes: usize,
+    timeout: StdDuration,
+) -> Result<String> {
+    struct DeadlineReader<'a> {
+        stream: &'a mut UnixStream,
+        started: Instant,
+        timeout: StdDuration,
+    }
+
+    impl std::io::Read for DeadlineReader<'_> {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let remaining = self.timeout.saturating_sub(self.started.elapsed());
+            if remaining.is_zero() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "daemon query request read timed out",
+                ));
+            }
+            self.stream.set_read_timeout(Some(remaining))?;
+            self.stream.read(buffer).map_err(|error| {
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+                ) {
+                    std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "daemon query request read timed out",
+                    )
+                } else {
+                    error
+                }
+            })
+        }
+    }
+
+    read_daemon_query_request(
+        &mut DeadlineReader {
+            stream,
+            started: Instant::now(),
+            timeout,
+        },
+        max_bytes,
+    )
+}
+
+#[cfg(windows)]
+fn daemon_query_pipe_name() -> String {
+    format!(
+        r"\\.\pipe\ctx-daemon-query-{}",
+        Uuid::new_v4().simple()
+    )
+}
+
+#[cfg(windows)]
+fn windows_named_pipe_name_is_local(pipe_name: &str) -> bool {
+    pipe_name
+        .strip_prefix(r"\\.\pipe\ctx-daemon-query-")
+        .is_some_and(|suffix| {
+            suffix.len() == 32 && suffix.bytes().all(|byte| byte.is_ascii_hexdigit())
+        })
+}
+
+#[cfg(windows)]
+fn daemon_query_roundtrip_windows(
+    pipe_name: &str,
+    request: &[u8],
+    timeout: StdDuration,
+    max_response_bytes: u64,
+) -> Result<String> {
+    if !windows_named_pipe_name_is_local(pipe_name) {
+        return Err(anyhow!("daemon query pipe name is not local"));
+    }
+    if max_response_bytes == 0 {
+        return Err(anyhow!(
+            "daemon query response limit must be positive for Windows named pipe"
+        ));
+    }
+    let response_limit = usize::try_from(max_response_bytes)
+        .ok()
+        .ok_or_else(|| anyhow!("daemon query response limit is too large for Windows named pipe"))?;
+    let deadline = WindowsIoDeadline::new(timeout);
+    let pipe_name = windows_wide_null(pipe_name);
+    let pipe = open_windows_daemon_query_pipe(&pipe_name, &deadline)?;
+    write_all_windows_daemon_query_pipe(&pipe, request, &deadline)?;
+    let response = read_windows_daemon_query_pipe(&pipe, response_limit, &deadline)?;
+    String::from_utf8(response).context("daemon query response is not UTF-8")
+}
+
+#[cfg(windows)]
+struct WindowsQueryHandle(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl Drop for WindowsQueryHandle {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = windows_sys::Win32::Foundation::CloseHandle(self.0);
+        }
+    }
+}
+
+#[cfg(windows)]
+struct WindowsIoDeadline {
+    started: std::time::Instant,
+    timeout: StdDuration,
+}
+
+#[cfg(windows)]
+impl WindowsIoDeadline {
+    fn new(timeout: StdDuration) -> Self {
+        Self {
+            started: std::time::Instant::now(),
+            timeout,
+        }
+    }
+
+    fn remaining_ms(&self, operation: &str) -> std::io::Result<u32> {
+        let remaining = self.timeout.saturating_sub(self.started.elapsed());
+        if remaining.is_zero() {
+            return Err(windows_daemon_query_timeout(operation));
+        }
+        let millis = remaining.as_millis().max(1).min(u128::from(u32::MAX - 1));
+        Ok(millis as u32)
+    }
+}
+
+#[cfg(windows)]
+fn windows_daemon_query_timeout(operation: &str) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::TimedOut,
+        format!("daemon query named pipe {operation} timed out"),
+    )
+}
+
+#[cfg(windows)]
+fn open_windows_daemon_query_pipe(
+    pipe_name: &[u16],
+    deadline: &WindowsIoDeadline,
+) -> Result<WindowsQueryHandle> {
+    use windows_sys::Win32::Foundation::{
+        GetLastError, GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE, ERROR_PIPE_BUSY,
+        ERROR_SEM_TIMEOUT,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_FLAG_OVERLAPPED, OPEN_EXISTING,
+    };
+    use windows_sys::Win32::System::Pipes::WaitNamedPipeW;
+
+    loop {
+        let handle = unsafe {
+            CreateFileW(
+                pipe_name.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                0,
+                std::ptr::null(),
+                OPEN_EXISTING,
+                FILE_FLAG_OVERLAPPED,
+                std::ptr::null_mut(),
+            )
+        };
+        if handle != INVALID_HANDLE_VALUE {
+            return Ok(WindowsQueryHandle(handle));
+        }
+        let error = unsafe { GetLastError() };
+        if error != ERROR_PIPE_BUSY {
+            return Err(std::io::Error::from_raw_os_error(error as i32))
+                .context("open daemon query named pipe");
+        }
+
+        let wait_ms = deadline
+            .remaining_ms("connect")
+            .context("wait for daemon query named pipe")?;
+        let ok = unsafe { WaitNamedPipeW(pipe_name.as_ptr(), wait_ms) };
+        if ok == 0 {
+            let error = unsafe { GetLastError() };
+            if error == ERROR_SEM_TIMEOUT {
+                return Err(windows_daemon_query_timeout("connect"))
+                    .context("wait for daemon query named pipe");
+            }
+            return Err(std::io::Error::from_raw_os_error(error as i32))
+                .context("wait for daemon query named pipe");
+        }
+    }
+}
+
+#[cfg(windows)]
+fn write_all_windows_daemon_query_pipe(
+    pipe: &WindowsQueryHandle,
+    mut request: &[u8],
+    deadline: &WindowsIoDeadline,
+) -> Result<()> {
+    use windows_sys::Win32::Storage::FileSystem::WriteFile;
+
+    while !request.is_empty() {
+        let write_len = request.len().min(u32::MAX as usize) as u32;
+        let written = windows_overlapped_io(pipe, deadline, "write", |transferred, overlapped| unsafe {
+            WriteFile(
+                pipe.0,
+                request.as_ptr(),
+                write_len,
+                transferred,
+                overlapped,
+            )
+        })
+        .context("write daemon query named pipe")?;
+        if written == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "daemon query named pipe wrote zero bytes",
+            ))
+            .context("write daemon query named pipe");
+        }
+        request = &request[written as usize..];
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn read_windows_daemon_query_pipe(
+    pipe: &WindowsQueryHandle,
+    response_limit: usize,
+    deadline: &WindowsIoDeadline,
+) -> Result<Vec<u8>> {
+    use windows_sys::Win32::Foundation::{
+        ERROR_BROKEN_PIPE, ERROR_NO_DATA, ERROR_PIPE_NOT_CONNECTED,
+    };
+    use windows_sys::Win32::Storage::FileSystem::ReadFile;
+
+    const READ_CHUNK_BYTES: usize = 64 * 1024;
+    let mut response = Vec::with_capacity(response_limit.min(READ_CHUNK_BYTES));
+    let mut chunk = vec![0u8; READ_CHUNK_BYTES];
+    loop {
+        let read_limit = (response_limit - response.len())
+            .saturating_add(1)
+            .min(chunk.len());
+        let read = windows_overlapped_io(pipe, deadline, "read", |transferred, overlapped| unsafe {
+            ReadFile(
+                pipe.0,
+                chunk.as_mut_ptr(),
+                read_limit as u32,
+                transferred,
+                overlapped,
+            )
+        });
+        let read = match read {
+            Ok(read) => read as usize,
+            Err(error)
+                if matches!(
+                    error.raw_os_error().map(|code| code as u32),
+                    Some(ERROR_BROKEN_PIPE) | Some(ERROR_NO_DATA) | Some(ERROR_PIPE_NOT_CONNECTED)
+                ) =>
+            {
+                break;
+            }
+            Err(error) => return Err(error).context("read daemon query named pipe"),
+        };
+        if read == 0 {
+            break;
+        }
+        response.extend_from_slice(&chunk[..read]);
+        if response.len() > response_limit {
+            return Err(anyhow!("daemon query response is too large"));
+        }
+    }
+    Ok(response)
+}
+
+#[cfg(windows)]
+fn windows_overlapped_io<F>(
+    pipe: &WindowsQueryHandle,
+    deadline: &WindowsIoDeadline,
+    operation: &str,
+    start: F,
+) -> std::io::Result<u32>
+where
+    F: FnOnce(
+        *mut u32,
+        *mut windows_sys::Win32::System::IO::OVERLAPPED,
+    ) -> windows_sys::core::BOOL,
+{
+    use windows_sys::Win32::Foundation::{
+        GetLastError, ERROR_IO_PENDING, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
+    };
+    use windows_sys::Win32::System::IO::{GetOverlappedResult, OVERLAPPED};
+    use windows_sys::Win32::System::Threading::{CreateEventW, WaitForSingleObject};
+
+    let event = unsafe { CreateEventW(std::ptr::null(), 1, 0, std::ptr::null()) };
+    if event.is_null() {
+        return Err(std::io::Error::last_os_error());
+    }
+    let event = WindowsQueryHandle(event);
+    let mut overlapped = OVERLAPPED {
+        hEvent: event.0,
+        ..OVERLAPPED::default()
+    };
+    let mut transferred = 0u32;
+    let ok = start(&mut transferred, &mut overlapped);
+    if ok != 0 {
+        return Ok(transferred);
+    }
+    let error = unsafe { GetLastError() };
+    if error != ERROR_IO_PENDING {
+        return Err(std::io::Error::from_raw_os_error(error as i32));
+    }
+
+    let wait_ms = match deadline.remaining_ms(operation) {
+        Ok(wait_ms) => wait_ms,
+        Err(error) => {
+            cancel_and_drain_windows_io(pipe, &overlapped);
+            return Err(error);
+        }
+    };
+    match unsafe { WaitForSingleObject(event.0, wait_ms) } {
+        WAIT_OBJECT_0 => {}
+        WAIT_TIMEOUT => {
+            cancel_and_drain_windows_io(pipe, &overlapped);
+            return Err(windows_daemon_query_timeout(operation));
+        }
+        WAIT_FAILED => {
+            let error = std::io::Error::last_os_error();
+            cancel_and_drain_windows_io(pipe, &overlapped);
+            return Err(error);
+        }
+        status => {
+            cancel_and_drain_windows_io(pipe, &overlapped);
+            return Err(std::io::Error::other(format!(
+                "unexpected Windows wait status {status}"
+            )));
+        }
+    }
+
+    let ok = unsafe { GetOverlappedResult(pipe.0, &overlapped, &mut transferred, 0) };
+    if ok == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(transferred)
+}
+
+#[cfg(windows)]
+fn cancel_and_drain_windows_io(
+    pipe: &WindowsQueryHandle,
+    overlapped: &windows_sys::Win32::System::IO::OVERLAPPED,
+) {
+    use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult};
+
+    unsafe {
+        let _ = CancelIoEx(pipe.0, overlapped);
+        let mut transferred = 0u32;
+        let _ = GetOverlappedResult(pipe.0, overlapped, &mut transferred, 1);
+    }
+}
+
+#[cfg(windows)]
+fn windows_wide_null(value: &str) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+
+    std::ffi::OsStr::new(value)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+#[cfg(all(test, windows))]
+mod windows_query_transport_tests {
+    use super::*;
+
+    #[test]
+    fn byte_pipe_roundtrip_uses_stream_protocol() {
+        let pipe_name = daemon_query_pipe_name();
+        let server =
+            create_windows_daemon_query_pipe(&pipe_name, true).expect("create test pipe");
+        let server_thread = std::thread::spawn(move || {
+            let mut server = server;
+            connect_windows_daemon_query_pipe(&server).expect("connect test pipe");
+            assert_eq!(
+                read_daemon_query_request_windows(&server, 1024, StdDuration::from_secs(2))
+                    .expect("read request"),
+                r#"{"ping":true}"#
+            );
+            server
+                .write_all(b"{\"ok\":true}\n")
+                .expect("write response");
+        });
+
+        let response = daemon_query_roundtrip_windows(
+            &pipe_name,
+            b"{\"ping\":true}\n",
+            StdDuration::from_secs(2),
+            1024,
+        )
+        .expect("roundtrip");
+        assert_eq!(response, "{\"ok\":true}\n");
+        server_thread.join().expect("server thread");
+    }
+
+    #[test]
+    fn stalled_byte_pipe_read_obeys_end_to_end_deadline() {
+        let pipe_name = daemon_query_pipe_name();
+        let server =
+            create_windows_daemon_query_pipe(&pipe_name, true).expect("create test pipe");
+        let server_thread = std::thread::spawn(move || {
+            connect_windows_daemon_query_pipe(&server).expect("connect test pipe");
+            read_daemon_query_request_windows(&server, 1024, StdDuration::from_secs(2))
+                .expect("read request");
+            std::thread::sleep(StdDuration::from_millis(500));
+        });
+
+        let started = std::time::Instant::now();
+        let error = daemon_query_roundtrip_windows(
+            &pipe_name,
+            b"{\"ping\":true}\n",
+            StdDuration::from_millis(50),
+            1024,
+        )
+        .expect_err("stalled response must time out");
+        assert!(format!("{error:#}").contains("timed out"));
+        assert!(started.elapsed() < StdDuration::from_millis(450));
+        server_thread.join().expect("server thread");
+    }
+}

--- a/crates/ctx-cli/src/semantic/resource_policy.rs
+++ b/crates/ctx-cli/src/semantic/resource_policy.rs
@@ -1,0 +1,580 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SemanticComputeClass {
+    Cpu,
+    #[cfg_attr(not(any(target_os = "macos", test)), allow(dead_code))]
+    Accelerator,
+}
+
+impl SemanticComputeClass {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Cpu => "cpu",
+            Self::Accelerator => "accelerator",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct SemanticSystemResources {
+    total_memory_bytes: Option<u64>,
+    available_memory_bytes: Option<u64>,
+    available_parallelism: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SemanticQuietPolicy {
+    threads: usize,
+    batch_size: usize,
+    // Heuristic sizing target for batch selection, not an OS-enforced memory limit.
+    memory_budget_bytes: u64,
+    active_percent: u8,
+}
+
+const SEMANTIC_CPU_MODEL_LOAD_MIN_AVAILABLE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+const SEMANTIC_ACCELERATOR_MODEL_LOAD_MIN_AVAILABLE_BYTES: u64 = 3 * 1024 * 1024 * 1024;
+
+fn semantic_model_load_deferred(
+    available_memory_bytes: Option<u64>,
+    compute_class: SemanticComputeClass,
+) -> Option<SemanticModelLoadDeferred> {
+    let available_memory_bytes = available_memory_bytes?;
+    let required_available_memory_bytes = match compute_class {
+        SemanticComputeClass::Cpu => SEMANTIC_CPU_MODEL_LOAD_MIN_AVAILABLE_BYTES,
+        SemanticComputeClass::Accelerator => {
+            SEMANTIC_ACCELERATOR_MODEL_LOAD_MIN_AVAILABLE_BYTES
+        }
+    };
+    (available_memory_bytes < required_available_memory_bytes).then_some(
+        SemanticModelLoadDeferred {
+            available_memory_bytes,
+            required_available_memory_bytes,
+        },
+    )
+}
+
+fn semantic_cpu_model_load_deferred(
+    available_memory_bytes: Option<u64>,
+) -> Option<SemanticModelLoadDeferred> {
+    semantic_model_load_deferred(available_memory_bytes, SemanticComputeClass::Cpu)
+}
+
+impl SemanticSystemResources {
+    fn current() -> Self {
+        let (total_memory_bytes, available_memory_bytes) = semantic_system_memory();
+        Self {
+            total_memory_bytes,
+            available_memory_bytes,
+            available_parallelism: std::thread::available_parallelism()
+                .map(|value| value.get())
+                .unwrap_or(1),
+        }
+    }
+}
+
+fn semantic_quiet_policy(
+    resources: SemanticSystemResources,
+    compute_class: SemanticComputeClass,
+) -> SemanticQuietPolicy {
+    const MIB: u64 = 1024 * 1024;
+    const GIB: u64 = 1024 * MIB;
+    const TWO_GIB: u64 = 2 * GIB;
+
+    let memory_budget_bytes = resources
+        .total_memory_bytes
+        .map(|bytes| bytes / 10)
+        .into_iter()
+        .chain(resources.available_memory_bytes.map(|bytes| bytes / 4))
+        .min()
+        .unwrap_or(GIB)
+        .clamp(512 * MIB, 4 * GIB);
+    let parallelism = resources.available_parallelism.max(1);
+    match compute_class {
+        SemanticComputeClass::Cpu => {
+            let threads = (parallelism / 4).clamp(1, 4);
+            let batch_size = match memory_budget_bytes {
+                0..GIB => 4,
+                GIB..TWO_GIB => 8,
+                TWO_GIB.. => 16,
+            };
+            SemanticQuietPolicy {
+                threads,
+                batch_size,
+                memory_budget_bytes,
+                active_percent: 25,
+            }
+        }
+        SemanticComputeClass::Accelerator => SemanticQuietPolicy {
+            threads: (parallelism / 8).clamp(1, 2),
+            batch_size: match memory_budget_bytes {
+                0..GIB => 32,
+                GIB..=2_147_483_647 => 64,
+                _ => 128,
+            },
+            memory_budget_bytes,
+            active_percent: 50,
+        },
+    }
+}
+
+fn semantic_batch_rest(active: StdDuration, active_percent: u8) -> StdDuration {
+    if active.is_zero() || !(1..100).contains(&active_percent) {
+        return StdDuration::ZERO;
+    }
+    let active_nanos = active.as_nanos();
+    let total_nanos = active_nanos
+        .saturating_mul(100)
+        .checked_div(u128::from(active_percent))
+        .unwrap_or(active_nanos);
+    let rest_nanos = total_nanos.saturating_sub(active_nanos);
+    StdDuration::from_nanos(rest_nanos.min(u128::from(u64::MAX)) as u64)
+}
+
+fn semantic_limited_batch_rest(
+    active: StdDuration,
+    active_percent: u8,
+    remaining: Option<StdDuration>,
+) -> StdDuration {
+    let rest = semantic_batch_rest(active, active_percent);
+    remaining
+        .map(|remaining| rest.min(remaining))
+        .unwrap_or(rest)
+}
+
+fn throttle_semantic_batch(
+    active: StdDuration,
+    policy: SemanticQuietPolicy,
+    remaining: Option<StdDuration>,
+) {
+    let rest = semantic_limited_batch_rest(active, policy.active_percent, remaining);
+    if !rest.is_zero() {
+        std::thread::sleep(rest);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn semantic_system_memory() -> (Option<u64>, Option<u64>) {
+    let Ok(text) = fs::read_to_string("/proc/meminfo") else {
+        return (None, None);
+    };
+    let mut total = None;
+    let mut available = None;
+    for line in text.lines() {
+        if let Some(value) = semantic_meminfo_kib(line, "MemTotal:") {
+            total = Some(value);
+        } else if let Some(value) = semantic_meminfo_kib(line, "MemAvailable:") {
+            available = Some(value);
+        }
+    }
+    let (cgroup_limit, cgroup_available) = semantic_linux_cgroup_memory();
+    semantic_effective_linux_memory(total, available, cgroup_limit, cgroup_available)
+}
+
+#[cfg(target_os = "linux")]
+fn semantic_linux_cgroup_memory() -> (Option<u64>, Option<u64>) {
+    let cgroup = fs::read_to_string("/proc/self/cgroup").unwrap_or_default();
+    semantic_linux_cgroup_memory_at(Path::new("/sys/fs/cgroup"), &cgroup)
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn semantic_linux_cgroup_memory_at(root: &Path, cgroup: &str) -> (Option<u64>, Option<u64>) {
+    let mut v2_candidates = Vec::new();
+    let mut v1_candidates = Vec::new();
+    for line in cgroup.lines() {
+        let mut fields = line.splitn(3, ':');
+        let _hierarchy = fields.next();
+        let controllers = fields.next().unwrap_or_default();
+        let relative = semantic_cgroup_relative_path(fields.next().unwrap_or_default());
+        if controllers.is_empty() {
+            semantic_push_cgroup_ancestors(&mut v2_candidates, root, &relative);
+        } else if controllers.split(',').any(|value| value == "memory") {
+            semantic_push_cgroup_ancestors(&mut v1_candidates, &root.join("memory"), &relative);
+        }
+    }
+    if v2_candidates.is_empty() {
+        v2_candidates.push(root.to_path_buf());
+    }
+
+    let mut effective_limit = None;
+    let mut effective_available = None;
+    for directory in v2_candidates {
+        semantic_tighten_cgroup_memory(
+            &directory,
+            "memory.max",
+            "memory.current",
+            &mut effective_limit,
+            &mut effective_available,
+        );
+    }
+    for directory in v1_candidates {
+        semantic_tighten_cgroup_memory(
+            &directory,
+            "memory.limit_in_bytes",
+            "memory.usage_in_bytes",
+            &mut effective_limit,
+            &mut effective_available,
+        );
+    }
+    (effective_limit, effective_available)
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn semantic_cgroup_relative_path(path: &str) -> PathBuf {
+    path.split('/')
+        .filter(|component| !component.is_empty() && *component != "." && *component != "..")
+        .collect()
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn semantic_push_cgroup_ancestors(candidates: &mut Vec<PathBuf>, root: &Path, relative: &Path) {
+    let mut directory = root.join(relative);
+    loop {
+        if !candidates.iter().any(|candidate| candidate == &directory) {
+            candidates.push(directory.clone());
+        }
+        if directory == root || !directory.pop() || !directory.starts_with(root) {
+            break;
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn semantic_tighten_cgroup_memory(
+    directory: &Path,
+    limit_name: &str,
+    current_name: &str,
+    effective_limit: &mut Option<u64>,
+    effective_available: &mut Option<u64>,
+) {
+    let limit = fs::read_to_string(directory.join(limit_name))
+        .ok()
+        .and_then(|value| semantic_parse_cgroup_memory_value(&value));
+    let current = fs::read_to_string(directory.join(current_name))
+        .ok()
+        .and_then(|value| semantic_parse_cgroup_memory_value(&value));
+    if let Some(limit) = limit {
+        *effective_limit = Some(effective_limit.map_or(limit, |known| known.min(limit)));
+        let available = limit.saturating_sub(current.unwrap_or(0));
+        *effective_available = Some(
+            effective_available.map_or(available, |known| known.min(available)),
+        );
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn semantic_parse_cgroup_memory_value(value: &str) -> Option<u64> {
+    let value = value.trim();
+    if value.is_empty() || value == "max" {
+        return None;
+    }
+    value.parse().ok()
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn semantic_effective_linux_memory(
+    host_total: Option<u64>,
+    host_available: Option<u64>,
+    cgroup_limit: Option<u64>,
+    cgroup_available: Option<u64>,
+) -> (Option<u64>, Option<u64>) {
+    let total = match (host_total, cgroup_limit) {
+        (Some(host), Some(limit)) => Some(host.min(limit)),
+        (host, limit) => host.or(limit),
+    };
+    let available = match (host_available, cgroup_available) {
+        (Some(host), Some(cgroup)) => Some(host.min(cgroup)),
+        (host, cgroup) => host.or(cgroup),
+    };
+    (total, available)
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn semantic_meminfo_kib(line: &str, key: &str) -> Option<u64> {
+    let mut fields = line.strip_prefix(key)?.split_whitespace();
+    let kib = fields.next()?.parse::<u64>().ok()?;
+    if fields.next()? != "kB" || fields.next().is_some() {
+        return None;
+    }
+    kib.checked_mul(1024)
+}
+
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+fn semantic_sysctl_number(name: &'static [u8]) -> Option<u64> {
+    let mut value = 0_u64;
+    let mut size = std::mem::size_of::<u64>();
+    let result = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr().cast(),
+            (&mut value as *mut u64).cast(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if result != 0 {
+        return None;
+    }
+    match size {
+        4 => Some(value & u64::from(u32::MAX)),
+        8 => Some(value),
+        _ => None,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn semantic_system_memory() -> (Option<u64>, Option<u64>) {
+    let total = semantic_sysctl_number(b"hw.memsize\0");
+    let page_size = semantic_sysctl_number(b"hw.pagesize\0");
+    let available_pages = [
+        b"vm.page_free_count\0".as_slice(),
+        b"vm.page_inactive_count\0".as_slice(),
+        b"vm.page_speculative_count\0".as_slice(),
+        b"vm.page_purgeable_count\0".as_slice(),
+    ]
+    .into_iter()
+    .map(semantic_sysctl_number)
+    .try_fold(0_u64, |total, value| total.checked_add(value?));
+    let available = page_size.and_then(|size| available_pages?.checked_mul(size));
+    (total, available)
+}
+
+#[cfg(target_os = "freebsd")]
+fn semantic_system_memory() -> (Option<u64>, Option<u64>) {
+    let total = semantic_sysctl_number(b"hw.physmem\0");
+    let page_size = semantic_sysctl_number(b"vm.stats.vm.v_page_size\0");
+    let available_pages = [
+        b"vm.stats.vm.v_free_count\0".as_slice(),
+        b"vm.stats.vm.v_inactive_count\0".as_slice(),
+        b"vm.stats.vm.v_cache_count\0".as_slice(),
+    ]
+    .into_iter()
+    .map(semantic_sysctl_number)
+    .try_fold(0_u64, |total, value| total.checked_add(value?));
+    let available = page_size.and_then(|size| available_pages?.checked_mul(size));
+    (total, available)
+}
+
+#[cfg(target_os = "windows")]
+fn semantic_system_memory() -> (Option<u64>, Option<u64>) {
+    #[repr(C)]
+    struct MemoryStatusEx {
+        length: u32,
+        memory_load: u32,
+        total_phys: u64,
+        avail_phys: u64,
+        total_page_file: u64,
+        avail_page_file: u64,
+        total_virtual: u64,
+        avail_virtual: u64,
+        avail_extended_virtual: u64,
+    }
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn GlobalMemoryStatusEx(buffer: *mut MemoryStatusEx) -> i32;
+    }
+
+    let mut status = MemoryStatusEx {
+        length: std::mem::size_of::<MemoryStatusEx>() as u32,
+        memory_load: 0,
+        total_phys: 0,
+        avail_phys: 0,
+        total_page_file: 0,
+        avail_page_file: 0,
+        total_virtual: 0,
+        avail_virtual: 0,
+        avail_extended_virtual: 0,
+    };
+    if unsafe { GlobalMemoryStatusEx(&mut status) } == 0 {
+        return (None, None);
+    }
+    (Some(status.total_phys), Some(status.avail_phys))
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "windows"
+)))]
+fn semantic_system_memory() -> (Option<u64>, Option<u64>) {
+    (None, None)
+}
+
+#[cfg(test)]
+mod semantic_resource_policy_tests {
+    use super::*;
+
+    #[test]
+    fn quiet_cpu_policy_caps_threads_batch_and_memory_target() {
+        let policy = semantic_quiet_policy(
+            SemanticSystemResources {
+                total_memory_bytes: Some(64 * 1024 * 1024 * 1024),
+                available_memory_bytes: Some(32 * 1024 * 1024 * 1024),
+                available_parallelism: 32,
+            },
+            SemanticComputeClass::Cpu,
+        );
+        assert_eq!(policy.threads, 4);
+        assert_eq!(policy.batch_size, 16);
+        assert_eq!(policy.memory_budget_bytes, 4 * 1024 * 1024 * 1024);
+        assert_eq!(policy.active_percent, 25);
+    }
+
+    #[test]
+    fn quiet_cpu_batch_scales_at_memory_target_boundaries() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        const TWO_GIB: u64 = 2 * GIB;
+
+        for (memory_target_bytes, expected_batch_size) in
+            [(GIB - 1, 4), (GIB, 8), (TWO_GIB - 1, 8), (TWO_GIB, 16)]
+        {
+            let policy = semantic_quiet_policy(
+                SemanticSystemResources {
+                    total_memory_bytes: None,
+                    available_memory_bytes: Some(memory_target_bytes * 4),
+                    available_parallelism: 8,
+                },
+                SemanticComputeClass::Cpu,
+            );
+            assert_eq!(policy.memory_budget_bytes, memory_target_bytes);
+            assert_eq!(policy.batch_size, expected_batch_size);
+        }
+    }
+
+    #[test]
+    fn accelerator_policy_keeps_tokenizer_parallelism_small() {
+        let policy = semantic_quiet_policy(
+            SemanticSystemResources {
+                total_memory_bytes: Some(16 * 1024 * 1024 * 1024),
+                available_memory_bytes: Some(8 * 1024 * 1024 * 1024),
+                available_parallelism: 12,
+            },
+            SemanticComputeClass::Accelerator,
+        );
+        assert_eq!(policy.threads, 1);
+        assert_eq!(policy.batch_size, 64);
+        assert_eq!(policy.memory_budget_bytes, 1_717_986_918);
+        assert_eq!(policy.active_percent, 50);
+    }
+
+    #[test]
+    fn batch_rest_enforces_target_fraction() {
+        assert_eq!(
+            semantic_batch_rest(StdDuration::from_millis(100), 25),
+            StdDuration::from_millis(300)
+        );
+        assert_eq!(
+            semantic_batch_rest(StdDuration::from_secs(3), 25),
+            StdDuration::from_secs(9)
+        );
+        assert_eq!(
+            semantic_batch_rest(StdDuration::ZERO, 25),
+            StdDuration::ZERO
+        );
+        assert_eq!(
+            semantic_limited_batch_rest(
+                StdDuration::from_secs(3),
+                25,
+                Some(StdDuration::from_secs(2)),
+            ),
+            StdDuration::from_secs(2),
+        );
+        assert_eq!(
+            semantic_limited_batch_rest(
+                StdDuration::from_secs(3),
+                25,
+                Some(StdDuration::ZERO),
+            ),
+            StdDuration::ZERO,
+        );
+    }
+
+    #[test]
+    fn meminfo_parser_is_strict() {
+        assert_eq!(
+            semantic_meminfo_kib("MemTotal: 1024 kB", "MemTotal:"),
+            Some(1024 * 1024)
+        );
+        assert_eq!(semantic_meminfo_kib("MemTotal: 1024 MB", "MemTotal:"), None);
+    }
+
+    #[test]
+    fn cgroup_memory_tightens_host_memory_admission() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        assert_eq!(semantic_parse_cgroup_memory_value("max\n"), None);
+        assert_eq!(semantic_parse_cgroup_memory_value("1234\n"), Some(1234));
+        assert_eq!(
+            semantic_effective_linux_memory(
+                Some(64 * GIB),
+                Some(32 * GIB),
+                Some(3 * GIB),
+                Some(GIB),
+            ),
+            (Some(3 * GIB), Some(GIB))
+        );
+        assert_eq!(
+            semantic_effective_linux_memory(
+                Some(64 * GIB),
+                Some(32 * GIB),
+                Some(4 * GIB),
+                Some(GIB / 2),
+            ),
+            (Some(4 * GIB), Some(GIB / 2))
+        );
+        assert!(semantic_cpu_model_load_deferred(Some(GIB)).is_some());
+    }
+
+    #[test]
+    fn nested_cgroup_uses_tightest_v2_and_v1_limits() -> Result<()> {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        let temp = tempfile::tempdir()?;
+        let root = temp.path();
+        fs::write(root.join("memory.max"), format!("{}\n", 16 * GIB))?;
+        fs::write(root.join("memory.current"), format!("{}\n", 2 * GIB))?;
+        let nested = root.join("user.slice/ctx.scope");
+        fs::create_dir_all(&nested)?;
+        fs::write(nested.join("memory.max"), format!("{}\n", 3 * GIB))?;
+        fs::write(nested.join("memory.current"), format!("{}\n", 2 * GIB))?;
+
+        assert_eq!(
+            semantic_linux_cgroup_memory_at(root, "0::/user.slice/ctx.scope\n"),
+            (Some(3 * GIB), Some(GIB))
+        );
+
+        let v1 = root.join("memory/build.slice");
+        fs::create_dir_all(&v1)?;
+        fs::write(v1.join("memory.limit_in_bytes"), format!("{}\n", 2 * GIB))?;
+        fs::write(v1.join("memory.usage_in_bytes"), format!("{GIB}\n"))?;
+        assert_eq!(
+            semantic_linux_cgroup_memory_at(root, "5:cpu,memory:/build.slice\n"),
+            (Some(2 * GIB), Some(GIB))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cpu_model_load_defers_only_below_known_memory_floor() {
+        let floor = SEMANTIC_CPU_MODEL_LOAD_MIN_AVAILABLE_BYTES;
+        assert!(semantic_cpu_model_load_deferred(Some(floor - 1)).is_some());
+        assert!(semantic_cpu_model_load_deferred(Some(floor)).is_none());
+        assert!(semantic_cpu_model_load_deferred(Some(floor + 1)).is_none());
+        assert!(semantic_cpu_model_load_deferred(None).is_none());
+    }
+
+    #[test]
+    fn accelerator_model_load_uses_larger_measured_memory_floor() {
+        let floor = SEMANTIC_ACCELERATOR_MODEL_LOAD_MIN_AVAILABLE_BYTES;
+        let deferred = semantic_model_load_deferred(
+            Some(floor - 1),
+            SemanticComputeClass::Accelerator,
+        )
+        .expect("accelerator load should defer below its memory floor");
+        assert_eq!(deferred.required_available_memory_bytes, floor);
+        assert!(semantic_model_load_deferred(
+            Some(floor),
+            SemanticComputeClass::Accelerator
+        )
+        .is_none());
+        assert!(semantic_model_load_deferred(None, SemanticComputeClass::Accelerator).is_none());
+    }
+}

--- a/crates/ctx-cli/src/semantic/tests.rs
+++ b/crates/ctx-cli/src/semantic/tests.rs
@@ -178,58 +178,123 @@ mod tests {
         }
     }
 
+    #[test]
+    fn deadline_partial_batch_keeps_only_fully_embedded_events() {
+        let first = Uuid::new_v4();
+        let split = Uuid::new_v4();
+        let last = Uuid::new_v4();
+        let pending = vec![
+            test_chunk_at(first, 1, "first", 0, 1),
+            test_chunk_at(split, 2, "split", 0, 3),
+            test_chunk_at(split, 2, "split", 1, 3),
+            test_chunk_at(split, 2, "split", 2, 3),
+            test_chunk_at(last, 3, "last", 0, 1),
+        ];
+
+        assert_eq!(semantic_complete_embedding_prefix(&pending, 0), 0);
+        assert_eq!(semantic_complete_embedding_prefix(&pending, 1), 1);
+        assert_eq!(semantic_complete_embedding_prefix(&pending, 2), 1);
+        assert_eq!(semantic_complete_embedding_prefix(&pending, 3), 1);
+        assert_eq!(semantic_complete_embedding_prefix(&pending, 4), 4);
+        assert_eq!(semantic_complete_embedding_prefix(&pending, 5), 5);
+        assert_eq!(semantic_complete_embedding_prefix(&pending, 99), 5);
+
+        let considered = vec![first, split, last];
+        assert_eq!(
+            semantic_contiguous_consumed_event_ids(&considered, &[first, last]),
+            vec![first]
+        );
+        assert_eq!(
+            semantic_contiguous_consumed_event_ids(&considered, &[first, split, last]),
+            considered
+        );
+
+        let cursors = vec![(first, (30, 3)), (split, (20, 2)), (last, (10, 1))];
+        assert_eq!(
+            semantic_contiguous_consumed_cursor(&cursors, &[first, last]),
+            Some((30, 3)),
+            "an unchanged event after an unfinished event cannot advance the cursor"
+        );
+        assert_eq!(
+            semantic_contiguous_consumed_cursor(&cursors, &[first, split, last]),
+            Some((10, 1))
+        );
+    }
+
     #[cfg(ctx_semantic_fastembed)]
     fn write_test_semantic_cache(root: &Path) -> Result<()> {
         let snapshot = root
             .join(SEMANTIC_HF_MODEL_CACHE_DIR)
             .join("snapshots")
-            .join("test-snapshot");
+            .join(SEMANTIC_MODEL_REVISION);
         fs::create_dir_all(&snapshot)?;
-        fs::create_dir_all(root.join(SEMANTIC_HF_MODEL_CACHE_DIR).join("refs"))?;
-        fs::write(
-            root.join(SEMANTIC_HF_MODEL_CACHE_DIR)
-                .join("refs")
-                .join("main"),
-            "test-snapshot\n",
-        )?;
         for file in SEMANTIC_REQUIRED_MODEL_FILES {
-            fs::write(snapshot.join(file), b"test")?;
+            let path = snapshot.join(file.path);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::File::create(path)?.set_len(file.size)?;
         }
         Ok(())
     }
 
+    #[test]
+    fn e5_embedding_text_uses_query_and_passage_prefixes_once() {
+        assert_eq!(
+            semantic_e5_query_text_value("find a daemon failure"),
+            "query: find a daemon failure"
+        );
+        assert_eq!(
+            semantic_e5_query_text_value("  query: find a daemon failure"),
+            "query: find a daemon failure"
+        );
+        assert_eq!(
+            semantic_e5_passage_text("daemon failed to restart"),
+            "passage: daemon failed to restart"
+        );
+        assert_eq!(
+            semantic_e5_passage_text("  passage: daemon failed to restart"),
+            "passage: daemon failed to restart"
+        );
+    }
+
     #[cfg(ctx_semantic_fastembed)]
     #[test]
-    fn semantic_adaptive_policy_uses_one_memory_budget_formula() {
-        let gib = 1024 * 1024 * 1024;
-        let large = SemanticMemorySnapshot {
-            total_bytes: Some(64 * gib),
-            available_bytes: Some(32 * gib),
-        };
-        let small = SemanticMemorySnapshot {
-            total_bytes: Some(8 * gib),
-            available_bytes: Some(4 * gib),
-        };
-        let constrained = SemanticMemorySnapshot {
-            total_bytes: Some(64 * gib),
-            available_bytes: Some(3 * gib),
-        };
+    fn fixed_shape_settings_are_strict() {
+        assert_eq!(semantic_fixed_shape_from_values(None, None).unwrap(), None);
+        assert_eq!(
+            semantic_fixed_shape_from_values(Some("16"), Some("512")).unwrap(),
+            Some((16, 512))
+        );
+        for values in [
+            (Some("16"), None),
+            (None, Some("512")),
+            (Some("0"), Some("512")),
+            (Some("wat"), Some("512")),
+            (Some("16"), Some("-1")),
+        ] {
+            assert!(semantic_fixed_shape_from_values(values.0, values.1).is_err());
+        }
+    }
 
-        assert_eq!(
-            semantic_adaptive_memory_budget_bytes(large),
-            SEMANTIC_MEMORY_BUDGET_MAX_BYTES
-        );
-        assert_eq!(semantic_adaptive_embed_policy(large).batch_size, 128);
-        assert_eq!(
-            semantic_adaptive_memory_budget_bytes(small),
-            1_717_986_918
-        );
-        assert_eq!(semantic_adaptive_embed_policy(small).batch_size, 16);
-        assert_eq!(
-            semantic_adaptive_memory_budget_bytes(constrained),
-            1_610_612_736
-        );
-        assert_eq!(semantic_adaptive_embed_policy(constrained).batch_size, 16);
+    #[cfg(ctx_semantic_fastembed)]
+    #[test]
+    fn fixed_batch_padding_preserves_complete_batches() -> Result<()> {
+        let make = |count| {
+            (0..count)
+                .map(|index| format!("passage: {index}"))
+                .collect::<Vec<_>>()
+        };
+        assert!(pad_texts_to_exact_batch(make(0), 4)?.is_empty());
+        assert_eq!(pad_texts_to_exact_batch(make(4), 4)?.len(), 4);
+        let padded = pad_texts_to_exact_batch(make(5), 4)?;
+        assert_eq!(padded.len(), 8);
+        assert_eq!(&padded[..5], make(5));
+        assert!(padded[5..]
+            .iter()
+            .all(|text| text == SEMANTIC_PASSAGE_PREFIX));
+        assert!(pad_texts_to_exact_batch(make(1), 0).is_err());
+        Ok(())
     }
 
     #[test]
@@ -240,7 +305,7 @@ mod tests {
             &json!({
                 "schema_version": 1,
                 "status": "budget_exhausted",
-                "model_key": SEMANTIC_MODEL_KEY,
+                "model_key": semantic_model_key(),
                 "pid": 1234,
                 "searchable_items": 10,
                 "embedded_items": 2,
@@ -311,7 +376,7 @@ mod tests {
             &json!({
                 "schema_version": 1,
                 "status": "completed",
-                "model_key": SEMANTIC_MODEL_KEY,
+                "model_key": semantic_model_key(),
                 "searchable_items": 11,
                 "embedded_items": 10,
                 "embedded_chunks": 20,
@@ -328,7 +393,7 @@ mod tests {
             &json!({
                 "schema_version": 1,
                 "status": "ready",
-                "model_key": SEMANTIC_MODEL_KEY,
+                "model_key": semantic_model_key(),
                 "searchable_items": 10,
                 "embedded_items": 10,
                 "embedded_chunks": 20,
@@ -339,6 +404,66 @@ mod tests {
             temp.path(),
             stats
         ));
+        Ok(())
+    }
+
+    #[test]
+    fn ready_index_requests_daemon_model_load_with_or_without_cache() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let mut report = SemanticWorkerReport::unavailable(temp.path(), "test");
+        report.status = "ready".to_owned();
+        report.searchable_items = 10;
+        report.searchable_items_known = true;
+        report.embedded_items = 10;
+        report.queued_items_estimate = 0;
+        report.model_cache_available = false;
+        report.embedding_runtime = Some(json!({
+            "backend": "cpu",
+            "compute_class": "cpu",
+        }));
+
+        assert!(semantic_daemon_model_load_needed(&report, false));
+        assert!(!semantic_daemon_model_load_needed(&report, true));
+        report.model_cache_available = true;
+        assert!(semantic_daemon_model_load_needed(&report, false));
+        let status = daemon_semantic_job_report(temp.path(), &report, true);
+        assert_eq!(status["embedding_runtime"]["backend"], "cpu");
+        assert_eq!(status["embedding_runtime"]["compute_class"], "cpu");
+        Ok(())
+    }
+
+    #[test]
+    fn daemon_status_reports_retryable_memory_deferral() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        write_semantic_enabled_config(temp.path())?;
+        let mut report = SemanticWorkerReport::unavailable(temp.path(), "test");
+        report.status = "model_load_deferred".to_owned();
+        report.searchable_items = 10;
+        report.searchable_items_known = true;
+        report.queued_items_estimate = 10;
+        write_daemon_job_status(
+            &daemon_semantic_job_path(temp.path()),
+            &compact_json(json!({
+                "schema_version": 1,
+                "model_key": semantic_model_key(),
+                "status": "skipped",
+                "reason": "memory_pressure",
+                "retryable": true,
+                "available_memory_bytes": 1_610_612_736_u64,
+                "required_available_memory_bytes": 2_147_483_648_u64,
+            })),
+        )?;
+
+        let value = daemon_semantic_job_report(temp.path(), &report, true);
+        assert_eq!(value["status"], "skipped");
+        assert_eq!(value["reason"], "memory_pressure");
+        assert_eq!(value["worker_status"], "model_load_deferred");
+        assert_eq!(value["retryable"], true);
+        assert_eq!(value["available_memory_bytes"], 1_610_612_736_u64);
+        assert_eq!(
+            value["required_available_memory_bytes"],
+            2_147_483_648_u64
+        );
         Ok(())
     }
 
@@ -421,8 +546,9 @@ mod tests {
     }
 
     #[test]
-    fn semantic_only_search_fails_fast_while_worker_is_running() -> Result<()> {
+    fn semantic_only_search_does_not_reject_a_running_worker() -> Result<()> {
         let temp = tempfile::tempdir()?;
+        write_test_semantic_cache(&temp.path().join("semantic-model-cache"))?;
         let docs = write_searchable_store(temp.path(), 1)?;
         let doc = docs.first().expect("searchable fixture doc");
         let source_text = semantic_source_text(&doc.text);
@@ -449,8 +575,174 @@ mod tests {
             RefreshArg::Off,
             false,
         )
-        .expect_err("semantic-only search should fail while worker is running");
-        assert!(format!("{err:#}").contains("semantic worker is currently indexing"));
+        .expect_err("fixture has no daemon query service");
+        let message = format!("{err:#}");
+        assert!(message.contains("daemon semantic query service is not available"));
+        assert!(!message.contains("semantic worker is currently indexing"));
+        Ok(())
+    }
+
+    #[test]
+    fn advisory_pid_lock_does_not_expire_or_trust_a_reused_pid() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let lock = DaemonLock::acquire(temp.path())?.expect("daemon lock");
+        let path = daemon_lock_path(temp.path());
+        assert!(pid_lock_file_reports_running(
+            &path,
+            Some(ProcessState::Running),
+            "running"
+        ));
+        assert!(!daemon_lock_is_stale(&path));
+        assert_eq!(
+            observe_pid_advisory_lock(&path),
+            Some(PidAdvisoryLockObservation {
+                held: true,
+                released: false,
+            })
+        );
+        assert!(DaemonLock::acquire(temp.path())?.is_none());
+
+        drop(lock);
+        assert!(!pid_lock_file_reports_running(
+            &path,
+            Some(ProcessState::Running),
+            "running"
+        ));
+        assert!(daemon_lock_is_stale(&path));
+        assert_eq!(
+            observe_pid_advisory_lock(&path),
+            Some(PidAdvisoryLockObservation {
+                held: false,
+                released: true,
+            })
+        );
+        let replacement = DaemonLock::acquire(temp.path())?
+            .expect("released advisory lock should be reusable despite live payload pid");
+        assert!(pid_lock_file_reports_running(
+            &path,
+            Some(ProcessState::Running),
+            "running"
+        ));
+        drop(replacement);
+
+        fs::write(&path, b"{")?;
+        assert!(!daemon_lock_is_stale(&path));
+        Ok(())
+    }
+
+    #[test]
+    fn advisory_pid_lock_allows_only_one_concurrent_reclaimer() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        drop(DaemonLock::acquire(temp.path())?.expect("seed lock"));
+        let root = temp.path().to_path_buf();
+        let contenders = 8;
+        let start = Arc::new(std::sync::Barrier::new(contenders + 1));
+        let finish = Arc::new(std::sync::Barrier::new(contenders + 1));
+        let (send, receive) = std::sync::mpsc::channel();
+        let mut threads = Vec::new();
+        for _ in 0..contenders {
+            let root = root.clone();
+            let start = Arc::clone(&start);
+            let finish = Arc::clone(&finish);
+            let send = send.clone();
+            threads.push(std::thread::spawn(move || -> Result<()> {
+                start.wait();
+                let lock = DaemonLock::acquire(&root)?;
+                send.send(lock.is_some())?;
+                finish.wait();
+                drop(lock);
+                Ok(())
+            }));
+        }
+        drop(send);
+        start.wait();
+        let acquired = (0..contenders)
+            .map(|_| receive.recv())
+            .collect::<std::result::Result<Vec<_>, _>>()?
+            .into_iter()
+            .filter(|acquired| *acquired)
+            .count();
+        finish.wait();
+        for thread in threads {
+            thread.join().expect("lock contender panicked")?;
+        }
+        assert_eq!(acquired, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn advisory_pid_lock_waits_out_a_status_probe() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        drop(DaemonLock::acquire(temp.path())?.expect("seed lock"));
+        let path = daemon_lock_path(temp.path());
+        let probe = private_open_existing_lock_file(&pid_lock_guard_path(&path))?;
+        fs2::FileExt::lock_shared(&probe)?;
+        let root = temp.path().to_path_buf();
+        let contender = std::thread::spawn(move || DaemonLock::acquire(&root));
+        std::thread::sleep(StdDuration::from_millis(5));
+        fs2::FileExt::unlock(&probe)?;
+        let lock = contender
+            .join()
+            .expect("lock contender panicked")?
+            .expect("status probe should not make acquisition give up");
+        drop(lock);
+        Ok(())
+    }
+
+    #[test]
+    fn advisory_guard_survives_metadata_path_replacement() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = daemon_lock_path(temp.path());
+        let lock = DaemonLock::acquire(temp.path())?.expect("daemon lock");
+        fs::remove_file(&path)?;
+        fs::write(&path, serde_json::to_vec(&pid_lock_payload(json!({})))?)?;
+        assert!(DaemonLock::acquire(temp.path())?.is_none());
+        drop(lock);
+        assert!(DaemonLock::acquire(temp.path())?.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn advisory_publication_does_not_overwrite_a_late_legacy_owner() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = daemon_lock_path(temp.path());
+        create_private_dir_all(path.parent().expect("lock parent"))?;
+        fs::write(
+            &path,
+            serde_json::to_vec(&json!({
+                "pid": process::id(),
+                "started_at_ms": utc_now().timestamp_millis(),
+            }))?,
+        )?;
+        assert!(!publish_pid_lock_metadata(
+            &path,
+            &pid_lock_payload(json!({}))
+        )?);
+        assert!(!pid_lock_uses_advisory_protocol(
+            &read_pid_lock_json(&path).expect("legacy metadata")
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn advisory_lock_reclaims_dead_legacy_metadata_for_upgrade_handoff() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = daemon_lock_path(temp.path());
+        create_private_dir_all(path.parent().expect("lock parent"))?;
+        fs::write(
+            &path,
+            serde_json::to_vec(&json!({
+                "pid": u32::MAX,
+                "started_at_ms": 0,
+            }))?,
+        )?;
+        assert!(daemon_lock_is_stale(&path));
+        let lock = DaemonLock::acquire(temp.path())?
+            .expect("dead legacy owner should be reclaimed during upgrade");
+        assert!(pid_lock_uses_advisory_protocol(
+            &read_pid_lock_json(&path).expect("advisory metadata")
+        ));
+        drop(lock);
         Ok(())
     }
 
@@ -833,7 +1125,7 @@ mod tests {
                 (model_key, embedded_items, embedded_chunks, updated_at_ms)
             VALUES (?1, 1, ?2, 1)
             "#,
-            params![SEMANTIC_MODEL_KEY, (chunk_limit + 1) as i64],
+            params![semantic_model_key(), (chunk_limit + 1) as i64],
         )?;
 
         assert!(!semantic_full_corpus_vector_scan_ready(&store)?);
@@ -844,9 +1136,59 @@ mod tests {
             SET embedded_chunks = ?2
             WHERE model_key = ?1
             "#,
-            params![SEMANTIC_MODEL_KEY, chunk_limit as i64],
+            params![semantic_model_key(), chunk_limit as i64],
         )?;
         assert!(semantic_full_corpus_vector_scan_ready(&store)?);
+        Ok(())
+    }
+
+    #[test]
+    fn opening_vector_store_preserves_other_embedding_spaces_and_current_cursor() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let vector_path = temp.path().join("vectors.sqlite");
+        let old_model_key = "fastembed:all-MiniLM-L6-v2:old";
+        {
+            let store = SemanticVectorStore::open(&vector_path)?;
+            store.conn.execute(
+                r#"
+                INSERT INTO embedding_models
+                    (model_key, backend, model_id, dimensions, distance, normalized, created_at_ms)
+                VALUES (?1, 'fastembed', 'sentence-transformers/all-MiniLM-L6-v2', 384, 'cosine', 1, 1)
+                "#,
+                [old_model_key],
+            )?;
+            store.conn.execute(
+                r#"
+                INSERT INTO event_embedding_chunks
+                    (event_id, model_key, event_seq, chunk_index, chunk_count,
+                     source_text_sha256, chunk_text_sha256, start_char, end_char,
+                     dimensions, embedding_f32, embedded_at_ms)
+                VALUES (?1, ?2, 1, 0, 1, 'source', 'chunk', 0, 5, 384, ?3, 1)
+                "#,
+                params![
+                    Uuid::new_v4().to_string(),
+                    old_model_key,
+                    serialize_f32_blob(&test_embedding(1.0, 0.0))
+                ],
+            )?;
+            store.set_backfill_cursor(Some((123, 456)))?;
+        }
+
+        let store = SemanticVectorStore::open(&vector_path)?;
+        let old_rows = store.conn.query_row(
+            "SELECT COUNT(*) FROM event_embedding_chunks WHERE model_key = ?1",
+            [old_model_key],
+            |row| row.get::<_, i64>(0),
+        )?;
+        let old_models = store.conn.query_row(
+            "SELECT COUNT(*) FROM embedding_models WHERE model_key = ?1",
+            [old_model_key],
+            |row| row.get::<_, i64>(0),
+        )?;
+
+        assert_eq!(old_rows, 1);
+        assert_eq!(old_models, 1);
+        assert_eq!(store.backfill_cursor()?, Some((123, 456)));
         Ok(())
     }
 
@@ -995,12 +1337,12 @@ mod tests {
 
         let canonical_rowid = store.conn.query_row(
             "SELECT rowid FROM event_embedding_chunks WHERE event_id = ?1 AND model_key = ?2",
-            params![close_event.to_string(), SEMANTIC_MODEL_KEY],
+            params![close_event.to_string(), semantic_model_key()],
             |row| row.get::<_, i64>(0),
         )?;
         store.conn.execute(
 	            "UPDATE event_embedding_vec0_meta SET rowid = rowid + 1000 WHERE event_id = ?1 AND model_key = ?2",
-	            params![close_event.to_string(), SEMANTIC_MODEL_KEY],
+	            params![close_event.to_string(), semantic_model_key()],
 	        )?;
 
         assert!(!store.sqlite_vec0_ready()?);
@@ -1009,7 +1351,7 @@ mod tests {
 
         let repaired_rowid = store.conn.query_row(
             "SELECT rowid FROM event_embedding_vec0_meta WHERE event_id = ?1 AND model_key = ?2",
-            params![close_event.to_string(), SEMANTIC_MODEL_KEY],
+            params![close_event.to_string(), semantic_model_key()],
             |row| row.get::<_, i64>(0),
         )?;
         assert_eq!(repaired_rowid, canonical_rowid);
@@ -1033,7 +1375,7 @@ mod tests {
 
         let close_rowid = store.conn.query_row(
             "SELECT rowid FROM event_embedding_chunks WHERE event_id = ?1 AND model_key = ?2",
-            params![close_event.to_string(), SEMANTIC_MODEL_KEY],
+            params![close_event.to_string(), semantic_model_key()],
             |row| row.get::<_, i64>(0),
         )?;
         store.conn.execute(
@@ -1107,42 +1449,594 @@ mod tests {
 
 }
 
+#[cfg(all(test, not(ctx_semantic_fastembed)))]
+mod unsupported_platform_tests {
+    use super::*;
+    use ctx_history_core::{
+        new_id, Event, EventRole, EventType, Fidelity, SyncMetadata, SyncState, Visibility,
+    };
+
+    fn test_sync_metadata() -> SyncMetadata {
+        SyncMetadata {
+            visibility: Visibility::LocalOnly,
+            fidelity: Fidelity::Imported,
+            sync_state: SyncState::LocalOnly,
+            sync_version: 0,
+            deleted_at: None,
+            metadata: json!({}),
+        }
+    }
+
+    fn insert_test_event(store: &Store, text: &str) -> Result<()> {
+        store.upsert_event(&Event {
+            id: new_id(),
+            seq: 1,
+            history_record_id: None,
+            session_id: None,
+            run_id: None,
+            event_type: EventType::Message,
+            role: Some(EventRole::User),
+            occurred_at: utc_now(),
+            capture_source_id: None,
+            payload: json!({ "text": text }),
+            payload_blob_id: None,
+            dedupe_key: None,
+            sync: test_sync_metadata(),
+        })?;
+        Ok(())
+    }
+
+    #[test]
+    fn hybrid_search_falls_back_to_lexical_on_unsupported_platform() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::create_dir_all(temp.path())?;
+        let store = Store::open(database_path(temp.path().to_path_buf()))?;
+        insert_test_event(&store, "semantic unsupported platform lexical fallback fixture")?;
+
+        let (packet, retrieval) = search_packet_with_backend(
+            &store,
+            temp.path(),
+            "semantic unsupported platform lexical fallback fixture",
+            &[],
+            &ctx_history_search::PacketOptions::default(),
+            SearchBackendArg::Hybrid,
+            true,
+            0.35,
+            RefreshArg::Off,
+            false,
+        )?;
+
+        assert_eq!(retrieval.effective_mode(), SearchBackendArg::Lexical);
+        assert_eq!(retrieval.to_json()["semantic_status"], "unavailable");
+        assert_eq!(retrieval.to_json()["semantic_fallback_code"], "unsupported_platform");
+        assert_eq!(
+            packet.query,
+            "semantic unsupported platform lexical fallback fixture"
+        );
+
+        let error = search_packet_with_backend(
+            &store,
+            temp.path(),
+            "semantic unsupported platform lexical fallback fixture",
+            &[],
+            &ctx_history_search::PacketOptions::default(),
+            SearchBackendArg::Semantic,
+            true,
+            1.0,
+            RefreshArg::Off,
+            false,
+        )
+        .expect_err("explicit semantic search should fail on unsupported platforms");
+        assert!(format!("{error:#}").contains("local semantic search is not supported"));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod query_service_transport_tests {
+    use super::*;
+
+    #[cfg(any(unix, windows))]
+    const TEST_QUERY_REQUEST_READ_TIMEOUT: StdDuration = StdDuration::from_millis(100);
+
+    #[cfg(any(unix, windows))]
+    fn start_test_query_service(data_root: &Path) -> Result<DaemonQueryService> {
+        start_daemon_query_service_with_request_timeout(
+            data_root,
+            Arc::new(Mutex::new(None)),
+            TEST_QUERY_REQUEST_READ_TIMEOUT,
+        )
+    }
+
+    #[cfg(any(unix, windows))]
+    fn wait_for_active_query(service: &DaemonQueryService) -> Result<()> {
+        let started = Instant::now();
+        while started.elapsed() < StdDuration::from_secs(2) {
+            if service.activity.snapshot().0 == 1 {
+                return Ok(());
+            }
+            std::thread::sleep(StdDuration::from_millis(5));
+        }
+        Err(anyhow!(
+            "daemon query service did not accept the test client"
+        ))
+    }
+
+    #[cfg(unix)]
+    fn connect_stalled_query_client(data_root: &Path) -> Result<UnixStream> {
+        let endpoint = read_daemon_query_endpoint(data_root)?.expect("query endpoint");
+        let DaemonQueryEndpoint::Unix { path, .. } = endpoint;
+        UnixStream::connect(&path)
+            .with_context(|| format!("connect test query socket {}", path.display()))
+    }
+
+    #[cfg(unix)]
+    fn connect_valid_nonreading_query_client(data_root: &Path) -> Result<UnixStream> {
+        let endpoint = read_daemon_query_endpoint(data_root)?.expect("query endpoint");
+        let DaemonQueryEndpoint::Unix { path, token } = endpoint;
+        let mut stream = UnixStream::connect(&path)
+            .with_context(|| format!("connect test query socket {}", path.display()))?;
+        writeln!(
+            stream,
+            "{}",
+            serde_json::to_string(&compact_json(json!({
+                "schema_version": 1,
+                "op": "ping",
+                "token": token,
+            })))?
+        )?;
+        Ok(stream)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configured_unix_query_stream_drains_response_larger_than_socket_buffer() -> Result<()> {
+        use std::io::{Read, Write};
+
+        let (mut server, mut client) = UnixStream::pair()?;
+        server.set_nonblocking(true)?;
+        configure_daemon_query_stream_unix(&server, StdDuration::from_secs(2))?;
+        let response = vec![b'x'; 1024 * 1024];
+        let expected = response.len();
+        let writer = std::thread::spawn(move || -> std::io::Result<()> {
+            server.write_all(&response)?;
+            server.shutdown(Shutdown::Write)
+        });
+        std::thread::sleep(StdDuration::from_millis(25));
+        let mut received = Vec::new();
+        client.read_to_end(&mut received)?;
+        writer.join().expect("query response writer panicked")?;
+        assert_eq!(received.len(), expected);
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    fn connect_stalled_query_client(data_root: &Path) -> Result<WindowsQueryHandle> {
+        let endpoint = read_daemon_query_endpoint(data_root)?.expect("query endpoint");
+        let DaemonQueryEndpoint::WindowsNamedPipe { pipe_name, .. } = endpoint;
+        let deadline = WindowsIoDeadline::new(StdDuration::from_secs(2));
+        open_windows_daemon_query_pipe(&windows_wide_null(&pipe_name), &deadline)
+    }
+
+    #[cfg(windows)]
+    fn connect_valid_nonreading_query_client(data_root: &Path) -> Result<WindowsQueryHandle> {
+        let endpoint = read_daemon_query_endpoint(data_root)?.expect("query endpoint");
+        let DaemonQueryEndpoint::WindowsNamedPipe { pipe_name, token } = endpoint;
+        let deadline = WindowsIoDeadline::new(StdDuration::from_secs(2));
+        let pipe = open_windows_daemon_query_pipe(&windows_wide_null(&pipe_name), &deadline)?;
+        let request = format!(
+            "{}\n",
+            serde_json::to_string(&compact_json(json!({
+                "schema_version": 1,
+                "op": "ping",
+                "token": token,
+            })))?
+        );
+        write_all_windows_daemon_query_pipe(&pipe, request.as_bytes(), &deadline)?;
+        Ok(pipe)
+    }
+
+    #[test]
+    fn daemon_query_activity_prevents_idle_shutdown_during_a_request() {
+        let activity = Arc::new(DaemonQueryActivity::new());
+        let request = activity.begin_request().expect("request accepted");
+        let (active, generation) = activity.snapshot();
+
+        assert_eq!(active, 1);
+        assert!(!activity.try_stop_accepting_if_idle(generation));
+
+        drop(request);
+        let (active, completed_generation) = activity.snapshot();
+        assert_eq!(active, 0);
+        assert_ne!(completed_generation, generation);
+        assert!(activity.try_stop_accepting_if_idle(completed_generation));
+        assert!(activity.begin_request().is_none());
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn stalled_query_client_is_discarded_and_next_query_is_served() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let service = start_test_query_service(temp.path())?;
+        let stalled_client = connect_stalled_query_client(temp.path())?;
+        wait_for_active_query(&service)?;
+
+        let started = Instant::now();
+        let response = daemon_query_request(
+            temp.path(),
+            compact_json(json!({
+                "schema_version": 1,
+                "op": "ping",
+            })),
+            StdDuration::from_secs(2),
+            64 * 1024,
+        )?
+        .expect("query response");
+
+        assert_eq!(response.get("ok").and_then(Value::as_bool), Some(true));
+        assert!(started.elapsed() < StdDuration::from_secs(1));
+        drop(stalled_client);
+        drop(service);
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn query_service_ping_stays_healthy_while_embedder_is_busy() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let embedder = Arc::new(Mutex::new(None));
+        let service = start_daemon_query_service_with_request_timeout(
+            temp.path(),
+            embedder.clone(),
+            TEST_QUERY_REQUEST_READ_TIMEOUT,
+        )?;
+        let _embedder_guard = embedder.lock().expect("test embedder lock");
+
+        let started = Instant::now();
+        let response = daemon_query_request(
+            temp.path(),
+            compact_json(json!({
+                "schema_version": 1,
+                "op": "ping",
+            })),
+            StdDuration::from_secs(1),
+            64 * 1024,
+        )?
+        .expect("query response");
+
+        assert_eq!(response.get("ok").and_then(Value::as_bool), Some(true));
+        assert_eq!(response.get("busy").and_then(Value::as_bool), Some(true));
+        assert!(response["embedding_runtime"].is_null());
+        assert!(started.elapsed() < StdDuration::from_millis(500));
+        drop(service);
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn query_service_shutdown_is_bounded_with_stalled_client() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let service = start_test_query_service(temp.path())?;
+        let stalled_client = connect_stalled_query_client(temp.path())?;
+        wait_for_active_query(&service)?;
+
+        let started = Instant::now();
+        drop(service);
+
+        assert!(started.elapsed() < StdDuration::from_secs(1));
+        drop(stalled_client);
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn valid_nonreading_client_does_not_block_later_queries_or_shutdown() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let service = start_test_query_service(temp.path())?;
+        let nonreader = connect_valid_nonreading_query_client(temp.path())?;
+        std::thread::sleep(StdDuration::from_millis(25));
+
+        let response = daemon_query_request(
+            temp.path(),
+            compact_json(json!({
+                "schema_version": 1,
+                "op": "ping",
+            })),
+            StdDuration::from_secs(2),
+            64 * 1024,
+        )?
+        .expect("query response");
+        assert_eq!(response.get("ok").and_then(Value::as_bool), Some(true));
+
+        let started = Instant::now();
+        drop(service);
+        assert!(started.elapsed() < StdDuration::from_secs(1));
+        drop(nonreader);
+        Ok(())
+    }
+
+    #[test]
+    fn observing_query_activity_resets_an_expired_idle_window() {
+        let activity = Arc::new(DaemonQueryActivity::new());
+        let request = activity.begin_request().expect("request accepted");
+        let mut idle_since = Some(Instant::now() - StdDuration::from_secs(5));
+        let mut observed_generation = 0;
+
+        observe_daemon_query_activity(
+            Some(activity.as_ref()),
+            &mut idle_since,
+            &mut observed_generation,
+        );
+
+        assert!(idle_since.is_none());
+        assert!(!daemon_can_begin_idle_shutdown(
+            Some(activity.as_ref()),
+            observed_generation
+        ));
+        drop(request);
+        observe_daemon_query_activity(
+            Some(activity.as_ref()),
+            &mut idle_since,
+            &mut observed_generation,
+        );
+        assert!(idle_since.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_query_socket_uses_short_private_fallback_for_long_data_root() -> Result<()> {
+        let data_root = PathBuf::from("/tmp").join("x".repeat(160));
+        let (listener, path, runtime_dir) = bind_daemon_query_listener(&data_root)?;
+        assert!(path.as_os_str().as_bytes().len() <= DAEMON_QUERY_SOCKET_PATH_SAFE_BYTES);
+        assert_ne!(path, daemon_query_socket_path(&data_root));
+        let runtime_dir = runtime_dir.expect("long path should use a private runtime dir");
+        assert_eq!(path.parent(), Some(runtime_dir.as_path()));
+
+        drop(listener);
+        fs::remove_file(&path)?;
+        fs::remove_dir(&runtime_dir)?;
+        Ok(())
+    }
+
+    #[test]
+    fn daemon_query_request_reader_stops_at_newline() -> Result<()> {
+        let mut cursor = std::io::Cursor::new(b"{\"op\":\"ping\"}\nignored".to_vec());
+
+        let body = read_daemon_query_request(&mut cursor, 256)?;
+
+        assert_eq!(body, "{\"op\":\"ping\"}");
+        Ok(())
+    }
+
+    #[test]
+    fn daemon_query_request_reader_rejects_oversized_request() {
+        let mut cursor = std::io::Cursor::new(b"abcdef".to_vec());
+
+        let error = read_daemon_query_request(&mut cursor, 3)
+            .expect_err("oversized request should fail");
+
+        assert!(format!("{error:#}").contains("daemon query request is too large"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_query_endpoint_roundtrips_unix_metadata() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let endpoint = DaemonQueryEndpoint::Unix {
+            path: daemon_query_socket_path(temp.path()),
+            token: "0123456789abcdef0123456789abcdef".to_owned(),
+        };
+
+        write_daemon_query_endpoint(temp.path(), &endpoint)?;
+        let loaded = read_daemon_query_endpoint(temp.path())?.expect("endpoint");
+
+        match loaded {
+            DaemonQueryEndpoint::Unix { path, token } => {
+                assert_eq!(path, daemon_query_socket_path(temp.path()));
+                assert_eq!(token, "0123456789abcdef0123456789abcdef");
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn daemon_query_endpoint_roundtrips_windows_named_pipe_metadata() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let pipe_name = daemon_query_pipe_name();
+        assert!(windows_named_pipe_name_is_local(&pipe_name));
+        let endpoint = DaemonQueryEndpoint::WindowsNamedPipe {
+            pipe_name: pipe_name.clone(),
+            token: "0123456789abcdef0123456789abcdef".to_owned(),
+        };
+
+        write_daemon_query_endpoint(temp.path(), &endpoint)?;
+        let loaded = read_daemon_query_endpoint(temp.path())?.expect("endpoint");
+
+        match loaded {
+            DaemonQueryEndpoint::WindowsNamedPipe {
+                pipe_name: loaded_pipe_name,
+                token,
+            } => {
+                assert_eq!(loaded_pipe_name, pipe_name);
+                assert_eq!(token, "0123456789abcdef0123456789abcdef");
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn daemon_query_endpoint_rejects_nonlocal_windows_pipe_name() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        create_private_dir_all(&daemon_root_path(temp.path()))?;
+        let endpoint = compact_json(json!({
+            "schema_version": 1,
+            "transport": "windows_named_pipe",
+            "pipe_name": r"\\server\pipe\ctx-daemon-query-0123456789abcdef0123456789abcdef",
+            "token": "0123456789abcdef0123456789abcdef",
+        }));
+        write_private_json_file(&daemon_query_endpoint_path(temp.path()), &endpoint)?;
+
+        assert!(read_daemon_query_endpoint(temp.path())?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn daemon_query_endpoint_rejects_short_tokens() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        create_private_dir_all(&daemon_root_path(temp.path()))?;
+        let mut endpoint = compact_json(json!({
+                "schema_version": 1,
+                "transport": "unix",
+                "token": "short",
+        }));
+        #[cfg(unix)]
+        {
+            endpoint["path"] = Value::String(
+                daemon_query_socket_path(temp.path())
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+        }
+        #[cfg(windows)]
+        {
+            endpoint["transport"] = Value::String("windows_named_pipe".to_owned());
+            endpoint["pipe_name"] = Value::String(daemon_query_pipe_name());
+        }
+        write_private_json_file(&daemon_query_endpoint_path(temp.path()), &endpoint)?;
+
+        assert!(read_daemon_query_endpoint(temp.path())?.is_none());
+        Ok(())
+    }
+}
+
 #[cfg(all(test, ctx_semantic_fastembed))]
 mod fastembed_policy_tests {
     use super::*;
+
+    #[test]
+    fn cpu_model_file_verification_binds_size_and_sha256() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = temp.path().join("model.bin");
+        fs::write(&path, b"test")?;
+        let expected = SemanticModelFile::new(
+            "model.bin",
+            4,
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+        );
+        verify_semantic_cpu_file(&path, expected)?;
+
+        let size_error = verify_semantic_cpu_file(
+            &path,
+            SemanticModelFile::new("model.bin", 5, expected.sha256),
+        )
+        .unwrap_err();
+        assert!(
+            size_error
+                .downcast_ref::<SemanticCpuModelIntegrityError>()
+                .is_some()
+        );
+        let hash_error = verify_semantic_cpu_file(
+            &path,
+            SemanticModelFile::new(
+                "model.bin",
+                4,
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            ),
+        )
+        .unwrap_err();
+        assert!(semantic_model_acquisition_integrity_error(&hash_error));
+        Ok(())
+    }
+
+    #[test]
+    fn cpu_model_publication_restores_old_root_and_preserves_siblings() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let managed = temp.path().join(SEMANTIC_MANAGED_MODEL_CACHE_DIR);
+        let model_root = managed.join(SEMANTIC_HF_MODEL_CACHE_DIR);
+        let shared = temp.path().join("shared-hf-cache");
+        let partial_download = managed.join("download-cache/partial");
+        fs::create_dir_all(&model_root)?;
+        fs::create_dir_all(&shared)?;
+        fs::create_dir_all(partial_download.parent().expect("partial parent"))?;
+        fs::write(model_root.join("old"), b"old")?;
+        fs::write(shared.join("keep"), b"shared")?;
+        fs::write(&partial_download, b"partial")?;
+
+        let missing_staging = managed.join("missing-staging");
+        assert!(publish_semantic_cpu_model_root(&missing_staging, &model_root).is_err());
+        assert_eq!(fs::read(model_root.join("old"))?, b"old");
+        assert_eq!(fs::read(shared.join("keep"))?, b"shared");
+        assert_eq!(fs::read(&partial_download)?, b"partial");
+
+        let staging = managed.join("staging");
+        fs::create_dir_all(&staging)?;
+        fs::write(staging.join("new"), b"new")?;
+        publish_semantic_cpu_model_root(&staging, &model_root)?;
+        assert_eq!(fs::read(model_root.join("new"))?, b"new");
+        assert!(!model_root.join("old").exists());
+        assert_eq!(fs::read(shared.join("keep"))?, b"shared");
+        assert_eq!(fs::read(&partial_download)?, b"partial");
+        Ok(())
+    }
+
+    #[test]
+    fn cpu_model_acquisition_lock_serializes_publishers() -> Result<()> {
+        use fs2::FileExt;
+
+        let temp = tempfile::tempdir()?;
+        let managed = temp.path().join(SEMANTIC_MANAGED_MODEL_CACHE_DIR);
+        let first = lock_semantic_model_acquisition(&managed)?;
+        let second_path = managed.join("acquisition.lock");
+        let second = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&second_path)?;
+        assert!(second.try_lock_exclusive().is_err());
+        drop(first);
+        second.lock_exclusive()?;
+        FileExt::unlock(&second)?;
+        Ok(())
+    }
+
+    #[test]
+    fn cpu_model_load_defers_before_cache_or_runtime_access() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let policy = semantic_embed_policy_from_env_and_resources(
+            SemanticComputeClass::Cpu,
+            SemanticSystemResources {
+                total_memory_bytes: Some(8 * 1024 * 1024 * 1024),
+                available_memory_bytes: Some(1024),
+                available_parallelism: 8,
+            },
+        );
+        let error = match acquire_cpu_backend(
+            temp.path(),
+            policy,
+            BackendPreference::Cpu,
+            false,
+        ) {
+            Ok(_) => panic!("low-memory acquisition should defer"),
+            Err(error) => error,
+        };
+        assert!(error.downcast_ref::<SemanticModelLoadDeferred>().is_some());
+    }
 
     fn write_test_semantic_cache(root: &Path) -> Result<()> {
         let snapshot = root
             .join(SEMANTIC_HF_MODEL_CACHE_DIR)
             .join("snapshots")
-            .join("test-snapshot");
+            .join(SEMANTIC_MODEL_REVISION);
         fs::create_dir_all(&snapshot)?;
-        fs::create_dir_all(root.join(SEMANTIC_HF_MODEL_CACHE_DIR).join("refs"))?;
-        fs::write(
-            root.join(SEMANTIC_HF_MODEL_CACHE_DIR)
-                .join("refs")
-                .join("main"),
-            "test-snapshot\n",
-        )?;
         for file in SEMANTIC_REQUIRED_MODEL_FILES {
-            fs::write(snapshot.join(file), b"test")?;
+            let path = snapshot.join(file.path);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::File::create(path)?.set_len(file.size)?;
         }
         Ok(())
-    }
-
-    #[test]
-    fn adaptive_policy_formula_runs_without_sqlite_vec() {
-        let gib = 1024 * 1024 * 1024;
-        let snapshot = SemanticMemorySnapshot {
-            total_bytes: Some(64 * gib),
-            available_bytes: Some(32 * gib),
-        };
-
-        let policy = semantic_adaptive_embed_policy(snapshot);
-
-        assert_eq!(policy.memory_budget_bytes, SEMANTIC_MEMORY_BUDGET_MAX_BYTES);
-        assert_eq!(policy.batch_size, SEMANTIC_EMBED_BATCH_ADAPTIVE_MAX);
-        assert_eq!(policy.source, "adaptive");
     }
 
     #[test]

--- a/crates/ctx-cli/src/semantic/vector_store_schema.rs
+++ b/crates/ctx-cli/src/semantic/vector_store_schema.rs
@@ -189,6 +189,20 @@ impl SemanticVectorStore {
                 [],
             )?;
         }
+        let foreign_vec0_rows = if sqlite_table_exists(&self.conn, "event_embedding_vec0_meta")?
+            && sqlite_column_exists(&self.conn, "event_embedding_vec0_meta", "model_key")?
+        {
+            self.conn.query_row(
+                "SELECT COUNT(*) FROM event_embedding_vec0_meta WHERE model_key != ?1",
+                [semantic_model_key()],
+                |row| row.get::<_, i64>(0),
+            )?
+        } else {
+            0
+        };
+        if foreign_vec0_rows > 0 {
+            self.drop_sqlite_vec0_schema()?;
+        }
         let deleted_legacy_embeddings = self.conn.execute("DELETE FROM event_embeddings", [])?;
         let scrubbed_chunk_text = self.conn.execute(
             "UPDATE event_embedding_chunks SET chunk_text = '' WHERE chunk_text != ''",
@@ -201,7 +215,7 @@ impl SemanticVectorStore {
             VALUES (?1, ?2, ?3, ?4, 'cosine', 1, ?5)
             "#,
             params![
-                SEMANTIC_MODEL_KEY,
+                semantic_model_key(),
                 SEMANTIC_BACKEND,
                 SEMANTIC_MODEL_ID,
                 SEMANTIC_DIMENSIONS as i64,
@@ -340,7 +354,7 @@ impl SemanticVectorStore {
 	                     OR m.end_char != c.end_char
 	                  )
 	                "#,
-                params![SEMANTIC_MODEL_KEY, SEMANTIC_DIMENSIONS as i64],
+                params![semantic_model_key(), SEMANTIC_DIMENSIONS as i64],
                 |row| row.get::<_, i64>(0),
             )
             .optional()?
@@ -359,7 +373,7 @@ impl SemanticVectorStore {
 	                WHERE m.model_key = ?1
 	                  AND c.rowid IS NULL
 	                "#,
-                params![SEMANTIC_MODEL_KEY, SEMANTIC_DIMENSIONS as i64],
+                params![semantic_model_key(), SEMANTIC_DIMENSIONS as i64],
                 |row| row.get::<_, i64>(0),
             )
             .optional()?
@@ -380,7 +394,7 @@ impl SemanticVectorStore {
 	                     OR v.embedding != c.embedding_f32
 	                  )
 	                "#,
-                params![SEMANTIC_MODEL_KEY, SEMANTIC_DIMENSIONS as i64],
+                params![semantic_model_key(), SEMANTIC_DIMENSIONS as i64],
                 |row| row.get::<_, i64>(0),
             )
             .optional()?
@@ -412,7 +426,7 @@ impl SemanticVectorStore {
             .conn
             .query_row(
                 "SELECT COUNT(*) FROM event_embedding_chunks WHERE model_key = ?1 AND dimensions = ?2",
-                params![SEMANTIC_MODEL_KEY, SEMANTIC_DIMENSIONS as i64],
+                params![semantic_model_key(), SEMANTIC_DIMENSIONS as i64],
                 |row| row.get::<_, i64>(0),
             )
             .optional()?
@@ -422,7 +436,7 @@ impl SemanticVectorStore {
             .conn
             .query_row(
                 "SELECT COUNT(*) FROM event_embedding_vec0_meta WHERE model_key = ?1",
-                params![SEMANTIC_MODEL_KEY],
+                params![semantic_model_key()],
                 |row| row.get::<_, i64>(0),
             )
             .optional()?
@@ -498,7 +512,7 @@ impl SemanticVectorStore {
             )?;
             let mut vec_stmt =
                 tx.prepare("INSERT INTO event_embedding_vec0(rowid, embedding) VALUES (?1, ?2)")?;
-            let mut rows = rows.query(params![SEMANTIC_MODEL_KEY, SEMANTIC_DIMENSIONS as i64])?;
+            let mut rows = rows.query(params![semantic_model_key(), SEMANTIC_DIMENSIONS as i64])?;
             while let Some(row) = rows.next()? {
                 let rowid: i64 = row.get(0)?;
                 let event_id: String = row.get(1)?;
@@ -513,7 +527,7 @@ impl SemanticVectorStore {
                 meta_stmt.execute(params![
                     rowid,
                     event_id,
-                    SEMANTIC_MODEL_KEY,
+                    semantic_model_key(),
                     history_record_id,
                     session_id,
                     event_seq,

--- a/crates/ctx-cli/src/semantic/vector_store_search.rs
+++ b/crates/ctx-cli/src/semantic/vector_store_search.rs
@@ -46,7 +46,7 @@ impl SemanticVectorStore {
             "#
         .to_owned();
         let mut query_params = vec![
-            SqlValue::from(SEMANTIC_MODEL_KEY.to_owned()),
+            SqlValue::from(semantic_model_key().to_owned()),
             SqlValue::from(SEMANTIC_DIMENSIONS as i64),
         ];
         if let Some(event_ids) = event_ids {
@@ -161,7 +161,7 @@ impl SemanticVectorStore {
 	                ORDER BY v.distance
 	                "#,
             )?;
-            let mut rows = stmt.query(params![&query_blob, k as i64, SEMANTIC_MODEL_KEY])?;
+            let mut rows = stmt.query(params![&query_blob, k as i64, semantic_model_key()])?;
             while let Some(row) = rows.next()? {
                 rows_returned = rows_returned.saturating_add(1);
                 let event_id = Uuid::parse_str(&row.get::<_, String>(0)?)

--- a/crates/ctx-cli/src/semantic/vector_store_state.rs
+++ b/crates/ctx-cli/src/semantic/vector_store_state.rs
@@ -1,4 +1,8 @@
 impl SemanticVectorStore {
+    fn maintenance_state_key(key: &str) -> String {
+        format!("{}:{key}", semantic_model_key())
+    }
+
     fn cached_stats(&self) -> Result<Option<SemanticSidecarStats>> {
         if !sqlite_table_exists(&self.conn, "semantic_index_stats")? {
             return Ok(None);
@@ -11,7 +15,7 @@ impl SemanticVectorStore {
                 FROM semantic_index_stats
                 WHERE model_key = ?1
                 "#,
-                params![SEMANTIC_MODEL_KEY],
+                params![semantic_model_key()],
                 |row| {
                     let embedded_items = row.get::<_, i64>(0)?.max(0) as usize;
                     let embedded_chunks = row.get::<_, i64>(1)?.max(0) as usize;
@@ -33,7 +37,7 @@ impl SemanticVectorStore {
             .conn
             .query_row(
                 "SELECT COUNT(*) FROM event_embedding_chunks WHERE model_key = ?1",
-                params![SEMANTIC_MODEL_KEY],
+                params![semantic_model_key()],
                 |row| row.get::<_, i64>(0),
             )
             .optional()?
@@ -42,7 +46,7 @@ impl SemanticVectorStore {
             .conn
             .query_row(
                 "SELECT COUNT(DISTINCT event_id) FROM event_embedding_chunks WHERE model_key = ?1",
-                params![SEMANTIC_MODEL_KEY],
+                params![semantic_model_key()],
                 |row| row.get::<_, i64>(0),
             )
             .optional()?
@@ -73,7 +77,7 @@ impl SemanticVectorStore {
                 updated_at_ms = excluded.updated_at_ms
             "#,
             params![
-                SEMANTIC_MODEL_KEY,
+                semantic_model_key(),
                 stats.embedded_items as i64,
                 stats.embedded_chunks as i64,
                 utc_now().timestamp_millis()
@@ -86,6 +90,7 @@ impl SemanticVectorStore {
         if !sqlite_table_exists(&self.conn, "semantic_maintenance_state")? {
             return Ok(None);
         }
+        let key = Self::maintenance_state_key(key);
         let value = self
             .conn
             .query_row(
@@ -98,6 +103,7 @@ impl SemanticVectorStore {
     }
 
     fn set_maintenance_state_i64(&self, key: &str, value: i64) -> Result<()> {
+        let key = Self::maintenance_state_key(key);
         self.conn.execute(
             r#"
             INSERT INTO semantic_maintenance_state (key, value, updated_at_ms)
@@ -116,6 +122,7 @@ impl SemanticVectorStore {
             return Ok(());
         }
         for key in keys {
+            let key = Self::maintenance_state_key(key);
             self.conn
                 .execute("DELETE FROM semantic_maintenance_state WHERE key = ?1", [key])?;
         }
@@ -155,7 +162,7 @@ impl SemanticVectorStore {
             .conn
             .query_row(
                 "SELECT COUNT(*) FROM semantic_dirty_events WHERE model_key = ?1",
-                params![SEMANTIC_MODEL_KEY],
+                params![semantic_model_key()],
                 |row| row.get::<_, i64>(0),
             )
             .optional()?
@@ -190,7 +197,7 @@ impl SemanticVectorStore {
             for doc in docs {
                 changed = changed.saturating_add(stmt.execute(params![
                     doc.event_id.to_string(),
-                    SEMANTIC_MODEL_KEY,
+                    semantic_model_key(),
                     queued_at_ms,
                     doc.seq as i64,
                     reason
@@ -214,7 +221,7 @@ impl SemanticVectorStore {
             LIMIT ?2
             "#,
         )?;
-        let mut rows = stmt.query(params![SEMANTIC_MODEL_KEY, limit as i64])?;
+        let mut rows = stmt.query(params![semantic_model_key(), limit as i64])?;
         let mut event_ids = Vec::new();
         while let Some(row) = rows.next()? {
             let event_id_text = row.get::<_, String>(0)?;
@@ -237,7 +244,7 @@ impl SemanticVectorStore {
             )?;
             for event_id in event_ids {
                 deleted = deleted.saturating_add(
-                    stmt.execute(params![SEMANTIC_MODEL_KEY, event_id.to_string()])?,
+                    stmt.execute(params![semantic_model_key(), event_id.to_string()])?,
                 );
             }
         }
@@ -291,7 +298,7 @@ impl SemanticVectorStore {
             GROUP BY event_id, source_text_sha256
             "#
         );
-        let mut query_params = vec![SqlValue::from(SEMANTIC_MODEL_KEY.to_owned())];
+        let mut query_params = vec![SqlValue::from(semantic_model_key().to_owned())];
         query_params.extend(
             event_ids
                 .iter()
@@ -338,8 +345,8 @@ impl SemanticVectorStore {
                 for (doc, _) in items {
                     if deleted_events.insert(doc.event_id) {
                         let event_id = doc.event_id.to_string();
-                        delete_vec_stmt.execute(params![SEMANTIC_MODEL_KEY, &event_id])?;
-                        delete_meta_stmt.execute(params![SEMANTIC_MODEL_KEY, &event_id])?;
+                        delete_vec_stmt.execute(params![semantic_model_key(), &event_id])?;
+                        delete_meta_stmt.execute(params![semantic_model_key(), &event_id])?;
                     }
                 }
             }
@@ -349,7 +356,7 @@ impl SemanticVectorStore {
             let mut deleted_events = std::collections::HashSet::new();
             for (doc, _) in items {
                 if deleted_events.insert(doc.event_id) {
-                    delete_stmt.execute(params![doc.event_id.to_string(), SEMANTIC_MODEL_KEY])?;
+                    delete_stmt.execute(params![doc.event_id.to_string(), semantic_model_key()])?;
                 }
             }
             drop(delete_stmt);
@@ -390,7 +397,7 @@ impl SemanticVectorStore {
                 let blob = serialize_f32_blob(embedding);
                 stmt.execute(params![
                     &event_id,
-                    SEMANTIC_MODEL_KEY,
+                    semantic_model_key(),
                     &history_record_id,
                     &session_id,
                     doc.seq as i64,
@@ -412,7 +419,7 @@ impl SemanticVectorStore {
                     meta_stmt.execute(params![
                         rowid,
                         &event_id,
-                        SEMANTIC_MODEL_KEY,
+                        semantic_model_key(),
                         &history_record_id,
                         &session_id,
                         doc.seq as i64,
@@ -510,7 +517,7 @@ impl SemanticVectorStore {
             "#,
         )?;
         let mut rows = stmt.query(params![
-            SEMANTIC_MODEL_KEY,
+            semantic_model_key(),
             before_event_seq,
             SEMANTIC_PRUNE_EVENTS_PER_PASS as i64
         ])?;
@@ -553,8 +560,8 @@ impl SemanticVectorStore {
                 )?;
                 for event_id in event_ids {
                     let event_id = event_id.to_string();
-                    delete_vec_stmt.execute(params![SEMANTIC_MODEL_KEY, &event_id])?;
-                    delete_meta_stmt.execute(params![SEMANTIC_MODEL_KEY, &event_id])?;
+                    delete_vec_stmt.execute(params![semantic_model_key(), &event_id])?;
+                    delete_meta_stmt.execute(params![semantic_model_key(), &event_id])?;
                 }
             }
             let mut stmt = tx.prepare(
@@ -562,7 +569,7 @@ impl SemanticVectorStore {
             )?;
             for event_id in event_ids {
                 deleted = deleted.saturating_add(
-                    stmt.execute(params![SEMANTIC_MODEL_KEY, event_id.to_string()])?,
+                    stmt.execute(params![semantic_model_key(), event_id.to_string()])?,
                 );
             }
         }

--- a/crates/ctx-cli/src/store_util.rs
+++ b/crates/ctx-cli/src/store_util.rs
@@ -5,31 +5,21 @@ use anyhow::{anyhow, Context, Result};
 use ctx_history_store::{Store, StoreError};
 
 pub(crate) fn open_existing_store_read_only(db_path: &Path, command: &str) -> Result<Store> {
-    open_existing_store_read_only_with(db_path, command, false)
-}
-
-pub(crate) fn open_existing_store_snapshot_read_only(
-    db_path: &Path,
-    command: &str,
-) -> Result<Store> {
-    open_existing_store_read_only_with(db_path, command, true)
-}
-
-fn open_existing_store_read_only_with(
-    db_path: &Path,
-    command: &str,
-    snapshot: bool,
-) -> Result<Store> {
     if !db_path.exists() {
         return Err(anyhow!(
             "ctx store is not initialized at {}; run `ctx setup` or `ctx import` first",
             db_path.display()
         ));
     }
-    let opened = if snapshot {
-        Store::open_read_only_snapshot(db_path)
-    } else {
+    // SQLite immutable mode is side-effect-free but ignores WAL content, so it
+    // is valid only when the store has no live WAL sidecars. A writer creates
+    // those sidecars before committing work; readers must then join the normal
+    // WAL protocol to see a consistent snapshot.
+    let opened = if sqlite_sidecar_exists(db_path, "-wal") || sqlite_sidecar_exists(db_path, "-shm")
+    {
         Store::open_read_only(db_path)
+    } else {
+        Store::open_read_only_snapshot(db_path)
     };
     match opened {
         Ok(store) => Ok(store),
@@ -40,4 +30,10 @@ fn open_existing_store_read_only_with(
             Err(err).with_context(|| format!("open read-only ctx store {}", db_path.display()))
         }
     }
+}
+
+fn sqlite_sidecar_exists(db_path: &Path, suffix: &str) -> bool {
+    let mut path = db_path.as_os_str().to_owned();
+    path.push(suffix);
+    Path::new(&path).exists()
 }

--- a/crates/ctx-cli/src/upgrade/command.rs
+++ b/crates/ctx-cli/src/upgrade/command.rs
@@ -13,7 +13,7 @@ use crate::{analytics, analytics::AnalyticsProperties, config::AppConfig, net};
 
 use super::install::{
     apply_artifact, current_install_path, install_marker_for_plan,
-    read_verified_install_marker_for_current_exe, write_install_marker_after_upgrade, ApplyResult,
+    read_verified_install_marker_for_current_exe, recover_interrupted_install, ApplyResult,
 };
 use super::metadata::{
     metadata_signature_url, metadata_url, parse_release_metadata, validate_artifact_url,
@@ -29,6 +29,7 @@ use super::{env_flag, platform_key, version_gt, UpgradePlan};
 const RELEASE_METADATA_MAX_BYTES: usize = 1024 * 1024;
 const RELEASE_METADATA_SIGNATURE_MAX_BYTES: usize = 64 * 1024;
 const RELEASE_ARTIFACT_MAX_BYTES: usize = 128 * 1024 * 1024;
+const RELEASE_ONNXRUNTIME_ARTIFACT_MAX_BYTES: usize = 1024 * 1024 * 1024;
 
 #[derive(Debug, Args)]
 pub struct UpgradeArgs {
@@ -450,7 +451,8 @@ fn apply_upgrade(
     background: bool,
 ) -> Result<UpgradeOutcome> {
     fs::create_dir_all(data_root)?;
-    let _lock = match UpgradeLock::acquire(data_root) {
+    #[allow(unused_mut)]
+    let mut upgrade_lock = match UpgradeLock::acquire(data_root) {
         Ok(lock) => lock,
         Err(error) if background => {
             append_upgrade_log(data_root, &format!("background upgrade skipped: {error}"));
@@ -467,6 +469,12 @@ fn apply_upgrade(
         }
         Err(error) => return Err(error),
     };
+    if recover_interrupted_install(data_root)? {
+        append_upgrade_log(data_root, "recovered interrupted install transaction");
+        if cfg!(debug_assertions) && env_flag("CTX_UPGRADE_STOP_AFTER_RECOVERY_FOR_TESTS") {
+            return Err(anyhow!("stopped after interrupted install recovery"));
+        }
+    }
     let plan = build_upgrade_plan(config, channel_override, true)?;
     if !plan.update_available {
         write_state_checked(data_root, &plan, "up_to_date")?;
@@ -484,6 +492,12 @@ fn apply_upgrade(
     if !plan.metadata.self_upgrade_allowed {
         return Err(anyhow!(
             "release {} does not allow self-upgrade",
+            plan.latest_version
+        ));
+    }
+    if plan.metadata.onnxruntime.is_none() {
+        return Err(anyhow!(
+            "release {} is newer than this ctx build but has no complete ONNX Runtime sidecar metadata; refusing a downgrade-compatible legacy update",
             plan.latest_version
         ));
     }
@@ -512,10 +526,34 @@ fn apply_upgrade(
     let bytes = net::get_bytes_limited(&plan.artifact_url, RELEASE_ARTIFACT_MAX_BYTES)
         .with_context(|| format!("download {}", plan.artifact_url))?;
     verify_artifact_sha(&bytes, &plan.artifact_sha256)?;
-    let apply_result = apply_artifact(&plan, &bytes)?;
-    let warnings = plan.warnings.clone();
-    if apply_result == ApplyResult::Scheduled {
-        write_state_checked(data_root, &plan, "scheduled")?;
+    let runtime_bytes = match (
+        plan.metadata.onnxruntime.as_ref(),
+        plan.onnxruntime_artifact_url(),
+    ) {
+        (Some(runtime), Some(runtime_url)) => {
+            let bytes =
+                net::get_bytes_limited(&runtime_url, RELEASE_ONNXRUNTIME_ARTIFACT_MAX_BYTES)
+                    .with_context(|| format!("download {runtime_url}"))?;
+            verify_artifact_sha(&bytes, &runtime.sha256)?;
+            Some(bytes)
+        }
+        (None, None) => None,
+        _ => return Err(anyhow!("incomplete ONNX Runtime upgrade plan")),
+    };
+    let apply_result = apply_artifact(
+        &plan,
+        &bytes,
+        runtime_bytes.as_deref(),
+        data_root,
+        upgrade_lock.path(),
+    )?;
+    let mut warnings = plan.warnings.clone();
+    if let ApplyResult::Scheduled { helper_pid } = apply_result {
+        #[cfg(windows)]
+        upgrade_lock.transfer_to(helper_pid)?;
+        #[cfg(not(windows))]
+        let _ = helper_pid;
+        record_post_apply_state(data_root, &plan, "scheduled", &mut warnings);
         return Ok(UpgradeOutcome {
             command: "upgrade",
             status: "scheduled",
@@ -531,8 +569,7 @@ fn apply_upgrade(
             warnings,
         });
     }
-    write_install_marker_after_upgrade(&plan)?;
-    write_state_checked(data_root, &plan, "applied")?;
+    record_post_apply_state(data_root, &plan, "applied", &mut warnings);
     Ok(UpgradeOutcome {
         command: "upgrade",
         status: "applied",
@@ -547,6 +584,19 @@ fn apply_upgrade(
         dry_run: false,
         warnings,
     })
+}
+
+fn record_post_apply_state(
+    data_root: &Path,
+    plan: &UpgradePlan,
+    status: &str,
+    warnings: &mut Vec<String>,
+) {
+    if let Err(error) = write_state_checked(data_root, plan, status) {
+        warnings.push(format!(
+            "upgrade {status}, but local upgrade state could not be written: {error:#}"
+        ));
+    }
 }
 
 fn write_background_skip_state(data_root: &Path, status: &str) -> Result<()> {
@@ -597,6 +647,9 @@ fn build_upgrade_plan(
         metadata.artifact
     );
     validate_artifact_url(&metadata.base_url, &metadata.artifact)?;
+    if let Some(runtime) = &metadata.onnxruntime {
+        validate_artifact_url(&metadata.base_url, &runtime.artifact)?;
+    }
     let update_available = version_gt(&metadata.version, &current_version);
     Ok(UpgradePlan {
         current_version,

--- a/crates/ctx-cli/src/upgrade/install.rs
+++ b/crates/ctx-cli/src/upgrade/install.rs
@@ -4,15 +4,33 @@ use std::{
     path::{Path, PathBuf},
 };
 
+#[cfg(unix)]
+use std::collections::BTreeSet;
+
 use anyhow::{anyhow, Context, Result};
 use ctx_history_core::utc_now;
+#[cfg(unix)]
+use flate2::read::GzDecoder;
+#[cfg(unix)]
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+#[cfg(unix)]
+use super::env_flag;
 use super::path::ctx_binary_version;
 use super::state::{atomic_write_json, now_unix_s, read_json_file};
 use super::{platform_key, sha256_hex, UpgradePlan};
 
 const MAX_INSTALL_ATTEMPT_ID_CHARS: usize = 128;
+const MAX_RUNTIME_EXPANDED_BYTES: u64 = 1024 * 1024 * 1024;
+#[cfg(unix)]
+const INSTALL_TRANSACTION_FILE: &str = "upgrade-install-transaction.json";
+
+#[derive(Debug)]
+struct StagedRuntime {
+    staged_path: PathBuf,
+    target_path: PathBuf,
+}
 
 #[derive(Debug, Clone)]
 pub(super) struct InstallMarker {
@@ -24,12 +42,19 @@ pub(super) struct InstallMarker {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
 pub(super) enum ApplyResult {
     Applied,
-    Scheduled,
+    Scheduled { helper_pid: u32 },
 }
 
-pub(super) fn apply_artifact(plan: &UpgradePlan, bytes: &[u8]) -> Result<ApplyResult> {
+pub(super) fn apply_artifact(
+    plan: &UpgradePlan,
+    bytes: &[u8],
+    runtime_bytes: Option<&[u8]>,
+    data_root: &Path,
+    upgrade_lock_path: &Path,
+) -> Result<ApplyResult> {
     let parent = plan.install_path.parent().ok_or_else(|| {
         anyhow!(
             "install path has no parent: {}",
@@ -39,17 +64,445 @@ pub(super) fn apply_artifact(plan: &UpgradePlan, bytes: &[u8]) -> Result<ApplyRe
     fs::create_dir_all(parent)?;
     let unique = format!("{}.{}", std::process::id(), now_unix_s());
     let staged = parent.join(format!(".ctx-upgrade-{unique}.new"));
-    {
+    let marker_path = install_marker_path(&plan.install_path);
+    let marker_staged = parent.join(format!(".ctx-upgrade-{unique}.install.json.new"));
+    let stage_binary = || -> Result<()> {
         let mut file = fs::File::create(&staged)
             .with_context(|| format!("create staged artifact {}", staged.display()))?;
         file.write_all(bytes)?;
         file.sync_all()?;
+        drop(file);
+        make_executable(&staged, &plan.install_path)?;
+        verify_staged_version(&staged, &plan.latest_version)
+    };
+    if let Err(error) = stage_binary() {
+        let _ = fs::remove_file(&staged);
+        return Err(error);
     }
-    make_executable(&staged, &plan.install_path)?;
-    verify_staged_version(&staged, &plan.latest_version)?;
-    let result = replace_binary(&staged, plan)?;
+    let install_attempt_id = existing_install_attempt_id(&marker_path);
+    if let Err(error) = write_install_marker_to(&marker_staged, plan, install_attempt_id.as_deref())
+    {
+        let _ = fs::remove_file(&staged);
+        let _ = fs::remove_file(&marker_staged);
+        return Err(error);
+    }
+    let staged_runtime = match runtime_bytes {
+        Some(runtime_bytes) => {
+            match stage_runtime_artifact(plan, runtime_bytes, &unique, data_root) {
+                Ok(runtime) => Some(runtime),
+                Err(error) => {
+                    let _ = fs::remove_file(&staged);
+                    let _ = fs::remove_file(&marker_staged);
+                    return Err(error);
+                }
+            }
+        }
+        None => None,
+    };
+    let result = replace_binary(
+        &staged,
+        plan,
+        staged_runtime.as_ref(),
+        &marker_staged,
+        &unique,
+        data_root,
+        upgrade_lock_path,
+    );
+    if result.is_err() {
+        let _ = fs::remove_file(&staged);
+        let _ = fs::remove_file(&marker_staged);
+        if let Some(runtime) = &staged_runtime {
+            let _ = fs::remove_dir_all(&runtime.staged_path);
+        }
+    }
+    let result = result?;
     sync_parent(parent);
     Ok(result)
+}
+
+fn stage_runtime_artifact(
+    plan: &UpgradePlan,
+    bytes: &[u8],
+    unique: &str,
+    data_root: &Path,
+) -> Result<StagedRuntime> {
+    let runtime = plan
+        .metadata
+        .onnxruntime
+        .as_ref()
+        .ok_or_else(|| anyhow!("ONNX Runtime bytes provided without release metadata"))?;
+    let runtime_root = semantic_runtime_root(data_root)?;
+    let runtime_parent = runtime_root.join("onnxruntime").join(&runtime.version);
+    let target_path = runtime_parent.join(&plan.platform);
+    let staged_path = runtime_parent.join(format!(".{}.ctx-upgrade-{unique}.new", plan.platform));
+    let archive_path = runtime_parent.join(format!(".ctx-runtime-{unique}.download"));
+    fs::create_dir_all(&runtime_parent)?;
+    let result = (|| -> Result<()> {
+        let mut archive = fs::File::create(&archive_path)
+            .with_context(|| format!("create staged runtime {}", archive_path.display()))?;
+        archive.write_all(bytes)?;
+        archive.sync_all()?;
+        fs::create_dir(&staged_path)
+            .with_context(|| format!("create staged runtime {}", staged_path.display()))?;
+        extract_runtime_archive(
+            &archive_path,
+            &staged_path,
+            &runtime.artifact,
+            &plan.platform,
+            &runtime.version,
+        )?;
+        write_runtime_manifest(plan, &staged_path)?;
+        #[cfg(unix)]
+        sync_directory(&staged_path)?;
+        Ok(())
+    })();
+    let _ = fs::remove_file(&archive_path);
+    if let Err(error) = result {
+        let _ = fs::remove_dir_all(&staged_path);
+        return Err(error);
+    }
+    sync_parent(&runtime_parent);
+    Ok(StagedRuntime {
+        staged_path,
+        target_path,
+    })
+}
+
+fn semantic_runtime_root(data_root: &Path) -> Result<PathBuf> {
+    let (source, root) = match env::var_os("CTX_RUNTIME_DIR") {
+        Some(value) => ("CTX_RUNTIME_DIR", PathBuf::from(value)),
+        None => ("selected ctx data root", data_root.join("runtime")),
+    };
+    validate_runtime_root(source, &root)?;
+    Ok(root)
+}
+
+fn validate_runtime_root(source: &str, path: &Path) -> Result<()> {
+    if path.as_os_str().is_empty()
+        || path
+            .to_str()
+            .is_some_and(|value| value.trim().is_empty() || value.trim() != value)
+    {
+        return Err(anyhow!("{source} must not be empty or whitespace-padded"));
+    }
+    if !path.is_absolute() {
+        return Err(anyhow!("{source} must be an absolute path"));
+    }
+    Ok(())
+}
+
+fn write_runtime_manifest(plan: &UpgradePlan, staged_path: &Path) -> Result<()> {
+    let runtime = plan
+        .metadata
+        .onnxruntime
+        .as_ref()
+        .ok_or_else(|| anyhow!("release metadata has no ONNX Runtime sidecar"))?;
+    let body = json!({
+        "schema_version": 1,
+        "manager": "ctx-hosted-installer",
+        "metadata_trust": "signed-release-metadata",
+        "runtime": "onnxruntime",
+        "platform": plan.platform,
+        "version": runtime.version,
+        "sha256": runtime.sha256,
+        "artifact_url": plan.onnxruntime_artifact_url(),
+        "installed_at": utc_now(),
+    });
+    let manifest = staged_path.join("ctx-runtime-install.json");
+    let mut file = fs::File::create(&manifest)
+        .with_context(|| format!("create runtime manifest {}", manifest.display()))?;
+    file.write_all(&serde_json::to_vec_pretty(&body)?)?;
+    file.write_all(b"\n")?;
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn extract_runtime_archive(
+    archive_path: &Path,
+    destination: &Path,
+    artifact_name: &str,
+    platform: &str,
+    version: &str,
+) -> Result<()> {
+    if !artifact_name.ends_with(".tar.gz") {
+        return Err(anyhow!(
+            "unsupported ONNX Runtime archive format for {platform}: {artifact_name}"
+        ));
+    }
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let library = if platform.starts_with("macos-") {
+        "libonnxruntime.dylib"
+    } else {
+        "libonnxruntime.so"
+    };
+    let expected_files = BTreeSet::from([
+        "LICENSE".to_owned(),
+        "ThirdPartyNotices.txt".to_owned(),
+        "VERSION_NUMBER".to_owned(),
+        "GIT_COMMIT_ID".to_owned(),
+        format!("lib/{library}"),
+    ]);
+    let mut expected_entries = expected_files.clone();
+    expected_entries.insert("lib".to_owned());
+    let archive_file = fs::File::open(archive_path)
+        .with_context(|| format!("open runtime archive {}", archive_path.display()))?;
+    let decoder = GzDecoder::new(archive_file);
+    let mut archive = tar::Archive::new(decoder);
+    let mut seen = BTreeSet::new();
+    let mut total_size = 0_u64;
+    let lib_dir = destination.join("lib");
+
+    for entry in archive.entries().context("read ONNX Runtime archive")? {
+        let mut entry = entry.context("read ONNX Runtime archive entry")?;
+        let raw = std::str::from_utf8(entry.path_bytes().as_ref())
+            .context("runtime archive path is not UTF-8")?
+            .to_owned();
+        let is_directory_name = raw.ends_with('/');
+        let name = raw.strip_suffix('/').unwrap_or(&raw);
+        if name.is_empty()
+            || raw.contains('\\')
+            || raw.starts_with('/')
+            || name == "."
+            || name == ".."
+            || name.starts_with("../")
+            || name.contains("/./")
+            || name.contains("//")
+            || (is_directory_name && name != "lib")
+        {
+            return Err(anyhow!(
+                "unsafe or non-canonical runtime archive path: {raw:?}"
+            ));
+        }
+        if !expected_entries.contains(name) {
+            return Err(anyhow!("unexpected runtime archive entry: {name}"));
+        }
+        if !seen.insert(name.to_owned()) {
+            return Err(anyhow!("duplicate runtime archive entry: {name}"));
+        }
+        let mode = entry.header().mode().context("read runtime archive mode")?;
+        if mode & 0o7000 != 0 {
+            return Err(anyhow!(
+                "unsafe permission bits on runtime archive entry: {name}"
+            ));
+        }
+        let entry_type = entry.header().entry_type();
+        if name == "lib" {
+            if !is_directory_name || !entry_type.is_dir() {
+                return Err(anyhow!("runtime lib entry is not a directory"));
+            }
+            fs::create_dir_all(&lib_dir)
+                .with_context(|| format!("create runtime directory {}", lib_dir.display()))?;
+            fs::set_permissions(&lib_dir, fs::Permissions::from_mode(0o755))?;
+            continue;
+        }
+        if is_directory_name || !entry_type.is_file() {
+            return Err(anyhow!(
+                "runtime archive entry is not a regular file: {name}"
+            ));
+        }
+        total_size = total_size
+            .checked_add(entry.size())
+            .ok_or_else(|| anyhow!("runtime archive expanded size overflow"))?;
+        if total_size > runtime_expanded_size_limit() {
+            return Err(anyhow!(
+                "runtime archive expands beyond the 1 GiB safety limit"
+            ));
+        }
+        let target = destination.join(name);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create runtime directory {}", parent.display()))?;
+        }
+        let mut output = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&target)
+            .with_context(|| format!("create runtime file {}", target.display()))?;
+        let copied = std::io::copy(&mut entry, &mut output)
+            .with_context(|| format!("extract runtime file {name}"))?;
+        if copied != entry.size() {
+            return Err(anyhow!(
+                "runtime archive entry size mismatch for {name}: expected {}, copied {copied}",
+                entry.size()
+            ));
+        }
+        fs::set_permissions(
+            &target,
+            fs::Permissions::from_mode(if name.starts_with("lib/") {
+                0o755
+            } else {
+                0o644
+            }),
+        )?;
+        output.flush()?;
+        output.sync_all()?;
+    }
+    if seen != expected_entries {
+        let missing = expected_entries
+            .difference(&seen)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(anyhow!(
+            "runtime archive entries do not exactly match the expected layout; missing: {missing}"
+        ));
+    }
+    let actual_version = fs::read(destination.join("VERSION_NUMBER"))?;
+    if actual_version != format!("{version}\n").as_bytes() {
+        return Err(anyhow!("runtime VERSION_NUMBER is not exactly {version}"));
+    }
+    sync_directory(&lib_dir)?;
+    sync_directory(destination)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn extract_runtime_archive(
+    archive_path: &Path,
+    destination: &Path,
+    artifact_name: &str,
+    platform: &str,
+    version: &str,
+) -> Result<()> {
+    if !artifact_name.to_ascii_lowercase().ends_with(".zip") {
+        return Err(anyhow!(
+            "unsupported ONNX Runtime archive format for {platform}: {artifact_name}"
+        ));
+    }
+    const EXTRACT_SCRIPT: &str = r#"
+param(
+  [string]$ArchivePath,
+  [string]$Destination,
+  [string]$ExpectedVersion,
+  [long]$MaxExpandedBytes
+)
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$expectedFiles = [System.Collections.Generic.HashSet[string]]::new(
+  [string[]]@('LICENSE', 'ThirdPartyNotices.txt', 'VERSION_NUMBER', 'GIT_COMMIT_ID', 'lib/onnxruntime.dll'),
+  [System.StringComparer]::Ordinal
+)
+$expectedEntries = [System.Collections.Generic.HashSet[string]]::new($expectedFiles, [System.StringComparer]::Ordinal)
+[void]$expectedEntries.Add('lib')
+$seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$entries = @{}
+[long]$totalLength = 0
+$archive = [System.IO.Compression.ZipFile]::OpenRead($ArchivePath)
+try {
+  foreach ($entry in $archive.Entries) {
+    $rawName = $entry.FullName
+    if (
+      [string]::IsNullOrEmpty($rawName) -or
+      $rawName.Contains('\') -or
+      $rawName.StartsWith('/', [System.StringComparison]::Ordinal) -or
+      $rawName -match '^[A-Za-z]:'
+    ) {
+      throw "unsafe runtime archive entry path: '$rawName'"
+    }
+    $isDirectory = $rawName.EndsWith('/', [System.StringComparison]::Ordinal)
+    $name = if ($isDirectory) { $rawName.Substring(0, $rawName.Length - 1) } else { $rawName }
+    $expectedRawName = if ($name -ceq 'lib') { 'lib/' } else { $name }
+    if (
+      $rawName -cne $expectedRawName -or
+      -not $expectedEntries.Contains($name) -or
+      -not $seen.Add($name)
+    ) {
+      throw "unexpected, duplicate, or non-canonical runtime archive entry: '$rawName'"
+    }
+    $unixMode = ($entry.ExternalAttributes -shr 16) -band 0xFFFF
+    $fileType = $unixMode -band 0xF000
+    if (($unixMode -band 0x0E00) -ne 0) {
+      throw "unsafe permission bits on runtime archive entry: '$rawName'"
+    }
+    if ($name -ceq 'lib') {
+      if (-not $isDirectory -or $fileType -ne 0x4000) {
+        throw 'runtime lib entry is not a directory'
+      }
+    } elseif ($isDirectory -or $fileType -ne 0x8000) {
+      throw "runtime archive entry is not a regular file: '$rawName'"
+    }
+    $totalLength += $entry.Length
+    if ($totalLength -gt $MaxExpandedBytes) {
+      throw 'runtime archive expands beyond the 1 GiB safety limit'
+    }
+    $entries[$name] = $entry
+  }
+  if ($seen.Count -ne $expectedEntries.Count) {
+    $missing = @($expectedEntries | Where-Object { -not $seen.Contains($_) })
+    throw "runtime archive entries do not exactly match the expected layout; missing: $($missing -join ', ')"
+  }
+  $versionStream = $entries['VERSION_NUMBER'].Open()
+  try {
+    $reader = [System.IO.StreamReader]::new($versionStream, [System.Text.UTF8Encoding]::new($false, $true))
+    try {
+      $versionText = $reader.ReadToEnd()
+    } finally {
+      $reader.Dispose()
+    }
+  } finally {
+    $versionStream.Dispose()
+  }
+  if ($versionText -cne ($ExpectedVersion + [char]10)) {
+    throw "runtime VERSION_NUMBER is not exactly $ExpectedVersion"
+  }
+  New-Item -ItemType Directory -Path (Join-Path $Destination 'lib') -Force | Out-Null
+  foreach ($name in $expectedFiles) {
+    $target = Join-Path $Destination ($name.Replace('/', '\'))
+    $sourceStream = $entries[$name].Open()
+    try {
+      $targetStream = [System.IO.File]::Open($target, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+      try {
+        $sourceStream.CopyTo($targetStream)
+        $targetStream.Flush($true)
+      } finally {
+        $targetStream.Dispose()
+      }
+    } finally {
+      $sourceStream.Dispose()
+    }
+  }
+} finally {
+  $archive.Dispose()
+}
+"#;
+    let script_path = archive_path.with_extension("extract.ps1");
+    fs::write(&script_path, EXTRACT_SCRIPT)
+        .with_context(|| format!("write runtime extraction helper {}", script_path.display()))?;
+    let output = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
+        .arg(&script_path)
+        .arg("-ArchivePath")
+        .arg(archive_path)
+        .arg("-Destination")
+        .arg(destination)
+        .arg("-ExpectedVersion")
+        .arg(version)
+        .arg("-MaxExpandedBytes")
+        .arg(runtime_expanded_size_limit().to_string())
+        .output()
+        .context("run Windows ONNX Runtime extraction helper");
+    let _ = fs::remove_file(&script_path);
+    let output = output?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        return Err(anyhow!("extract ONNX Runtime sidecar: {stderr}"));
+    }
+    Ok(())
+}
+
+fn runtime_expanded_size_limit() -> u64 {
+    if cfg!(debug_assertions) {
+        if let Ok(value) = env::var("CTX_UPGRADE_RUNTIME_MAX_EXPANDED_BYTES_FOR_TESTS") {
+            if let Ok(value) = value.parse::<u64>() {
+                if value > 0 {
+                    return value;
+                }
+            }
+        }
+    }
+    MAX_RUNTIME_EXPANDED_BYTES
 }
 
 fn verify_staged_version(staged: &Path, expected_version: &str) -> Result<()> {
@@ -81,27 +534,738 @@ fn make_executable(_staged: &Path, _target: &Path) -> Result<()> {
 }
 
 #[cfg(unix)]
-fn replace_binary(staged: &Path, plan: &UpgradePlan) -> Result<ApplyResult> {
-    let target = &plan.install_path;
-    let backup = backup_path(target);
-    if target.exists() {
-        fs::copy(target, &backup)
-            .with_context(|| format!("backup ctx binary to {}", backup.display()))?;
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum JournalPhase {
+    Publishing,
+    Committed,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum JournalPathKind {
+    File,
+    Directory,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct JournalPath {
+    label: String,
+    staged: PathBuf,
+    target: PathBuf,
+    backup: PathBuf,
+    kind: JournalPathKind,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Deserialize, Serialize)]
+struct InstallTransactionJournal {
+    schema_version: u32,
+    transaction_id: String,
+    phase: JournalPhase,
+    install_path: PathBuf,
+    paths: Vec<JournalPath>,
+}
+
+#[cfg(unix)]
+fn install_transaction_path(data_root: &Path) -> PathBuf {
+    data_root.join(INSTALL_TRANSACTION_FILE)
+}
+
+#[cfg(unix)]
+fn write_install_transaction(data_root: &Path, journal: &InstallTransactionJournal) -> Result<()> {
+    if cfg!(debug_assertions)
+        && journal.phase == JournalPhase::Committed
+        && env_flag("CTX_UPGRADE_FAIL_COMMIT_JOURNAL_WRITE_FOR_TESTS")
+    {
+        return Err(anyhow!("injected committed journal write failure"));
     }
-    fs::rename(staged, target)?;
+    let path = install_transaction_path(data_root);
+    fs::create_dir_all(data_root)?;
+    let temporary = data_root.join(format!(
+        ".{INSTALL_TRANSACTION_FILE}.tmp.{}",
+        std::process::id()
+    ));
+    let result = (|| -> Result<()> {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&temporary)
+            .with_context(|| format!("create install transaction {}", temporary.display()))?;
+        file.write_all(&serde_json::to_vec_pretty(journal)?)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        fs::rename(&temporary, &path).with_context(|| {
+            format!(
+                "publish install transaction {} to {}",
+                temporary.display(),
+                path.display()
+            )
+        })?;
+        sync_directory(data_root)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn remove_install_transaction(data_root: &Path) -> Result<()> {
+    let path = install_transaction_path(data_root);
+    match fs::remove_file(&path) {
+        Ok(()) => sync_directory(data_root),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("remove {}", path.display())),
+    }
+}
+
+#[cfg(unix)]
+pub(super) fn recover_interrupted_install(data_root: &Path) -> Result<bool> {
+    let path = install_transaction_path(data_root);
+    let bytes = match fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error).with_context(|| format!("read {}", path.display())),
+    };
+    let journal: InstallTransactionJournal = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parse interrupted install transaction {}", path.display()))?;
+    validate_install_transaction(&journal, data_root)?;
+    match journal.phase {
+        JournalPhase::Publishing => rollback_journal_paths(&journal.paths)?,
+        JournalPhase::Committed => finish_committed_journal(&journal)?,
+    }
+    remove_install_transaction(data_root)?;
+    Ok(true)
+}
+
+#[cfg(not(unix))]
+pub(super) fn recover_interrupted_install(_data_root: &Path) -> Result<bool> {
+    Ok(false)
+}
+
+#[cfg(unix)]
+fn validate_install_transaction(
+    journal: &InstallTransactionJournal,
+    data_root: &Path,
+) -> Result<()> {
+    if journal.schema_version != 1
+        || journal.transaction_id.is_empty()
+        || journal.transaction_id.len() > 128
+        || !journal
+            .transaction_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'.' || byte == b'-')
+    {
+        return Err(anyhow!("invalid install transaction identity"));
+    }
+    let expected_install_path = current_install_path()?;
+    if journal.install_path != expected_install_path {
+        return Err(anyhow!(
+            "install transaction targets {}, expected current managed install {}",
+            journal.install_path.display(),
+            expected_install_path.display()
+        ));
+    }
+    let binary = journal
+        .paths
+        .iter()
+        .find(|path| path.label == "ctx binary")
+        .ok_or_else(|| anyhow!("install transaction missing ctx binary"))?;
+    let marker = journal
+        .paths
+        .iter()
+        .find(|path| path.label == "ctx install marker")
+        .ok_or_else(|| anyhow!("install transaction missing ctx install marker"))?;
+    if journal.paths.len() != 2 && journal.paths.len() != 3 {
+        return Err(anyhow!("install transaction has an unexpected path count"));
+    }
+    if binary.kind != JournalPathKind::File
+        || binary.target != journal.install_path
+        || binary.staged
+            != journal
+                .install_path
+                .parent()
+                .ok_or_else(|| anyhow!("install transaction install path has no parent"))?
+                .join(format!(".ctx-upgrade-{}.new", journal.transaction_id))
+        || binary.backup
+            != transaction_backup_path(&journal.install_path, &journal.transaction_id, "binary")
+    {
+        return Err(anyhow!("install transaction has invalid binary paths"));
+    }
+    let expected_marker = install_marker_path(&journal.install_path);
+    if marker.kind != JournalPathKind::File
+        || marker.target != expected_marker
+        || marker.staged
+            != journal.install_path.parent().unwrap().join(format!(
+                ".ctx-upgrade-{}.install.json.new",
+                journal.transaction_id
+            ))
+        || marker.backup
+            != transaction_backup_path(&expected_marker, &journal.transaction_id, "marker")
+    {
+        return Err(anyhow!("install transaction has invalid marker paths"));
+    }
+    let runtimes = journal
+        .paths
+        .iter()
+        .filter(|path| path.label == "ONNX Runtime sidecar")
+        .collect::<Vec<_>>();
+    if journal.paths.len() == 3 && runtimes.len() != 1 {
+        return Err(anyhow!("install transaction has invalid runtime paths"));
+    }
+    if let Some(runtime) = runtimes.first() {
+        let name = runtime
+            .target
+            .file_name()
+            .and_then(|value| value.to_str())
+            .ok_or_else(|| anyhow!("install transaction runtime target has no file name"))?;
+        if runtime.kind != JournalPathKind::Directory
+            || runtime.staged
+                != runtime.target.with_file_name(format!(
+                    ".{name}.ctx-upgrade-{}.new",
+                    journal.transaction_id
+                ))
+            || runtime.backup
+                != transaction_backup_path(&runtime.target, &journal.transaction_id, "runtime")
+        {
+            return Err(anyhow!("install transaction has invalid runtime paths"));
+        }
+        let expected_runtime_root = semantic_runtime_root(data_root)?.join("onnxruntime");
+        let relative = runtime
+            .target
+            .strip_prefix(&expected_runtime_root)
+            .map_err(|_| {
+                anyhow!("install transaction runtime is outside the selected runtime root")
+            })?;
+        let components = relative.components().collect::<Vec<_>>();
+        if components.len() != 2
+            || components
+                .iter()
+                .any(|component| !matches!(component, std::path::Component::Normal(_)))
+            || runtime.target.file_name().and_then(|value| value.to_str()) != Some(platform_key()?)
+        {
+            return Err(anyhow!("install transaction has invalid runtime identity"));
+        }
+    }
+    if journal.paths.iter().any(|path| {
+        !matches!(
+            path.label.as_str(),
+            "ONNX Runtime sidecar" | "ctx binary" | "ctx install marker"
+        )
+    }) {
+        return Err(anyhow!("install transaction has an unknown path label"));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn rollback_journal_paths(paths: &[JournalPath]) -> Result<()> {
+    for path in paths.iter().rev() {
+        let staged_exists = path.staged.exists();
+        let backup_exists = path.backup.exists();
+        if backup_exists {
+            if staged_exists {
+                match path.kind {
+                    JournalPathKind::File if path.target.exists() => {
+                        remove_journal_path(&path.backup, path.kind)?;
+                    }
+                    JournalPathKind::Directory if path.target.exists() => {
+                        return Err(anyhow!(
+                            "interrupted {} has both target and staged directories; recoverable backup retained at {}",
+                            path.label,
+                            path.backup.display()
+                        ));
+                    }
+                    _ => {
+                        fs::rename(&path.backup, &path.target).with_context(|| {
+                            format!(
+                                "restore interrupted {} from {}",
+                                path.label,
+                                path.backup.display()
+                            )
+                        })?;
+                    }
+                }
+            } else {
+                if path.target.exists() {
+                    remove_journal_path(&path.target, path.kind)?;
+                }
+                fs::rename(&path.backup, &path.target).with_context(|| {
+                    format!(
+                        "restore interrupted {} from {}",
+                        path.label,
+                        path.backup.display()
+                    )
+                })?;
+            }
+        } else if !staged_exists && path.target.exists() {
+            remove_journal_path(&path.target, path.kind)?;
+        }
+        if path.staged.exists() {
+            remove_journal_path(&path.staged, path.kind)?;
+        }
+        if let Some(parent) = path.target.parent() {
+            sync_directory(parent)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn finish_committed_journal(journal: &InstallTransactionJournal) -> Result<()> {
+    for path in &journal.paths {
+        if !path.target.exists() || path.staged.exists() {
+            return Err(anyhow!(
+                "committed install transaction has incomplete {} publication",
+                path.label
+            ));
+        }
+    }
+    for path in &journal.paths {
+        if !path.backup.exists() {
+            continue;
+        }
+        if path.label == "ctx binary" {
+            retain_journal_binary_backup(path, &backup_path(&journal.install_path))?;
+        } else {
+            remove_journal_path(&path.backup, path.kind)?;
+        }
+        if let Some(parent) = path.target.parent() {
+            sync_directory(parent)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn retain_journal_binary_backup(path: &JournalPath, durable_backup: &Path) -> Result<()> {
+    if durable_backup.exists() {
+        fs::remove_file(durable_backup)
+            .with_context(|| format!("remove old ctx backup {}", durable_backup.display()))?;
+    }
+    fs::rename(&path.backup, durable_backup).with_context(|| {
+        format!(
+            "retain previous ctx binary {} at {}",
+            path.backup.display(),
+            durable_backup.display()
+        )
+    })
+}
+
+#[cfg(unix)]
+fn remove_journal_path(path: &Path, kind: JournalPathKind) -> Result<()> {
+    let result = match kind {
+        JournalPathKind::File => fs::remove_file(path),
+        JournalPathKind::Directory => fs::remove_dir_all(path),
+    };
+    match result {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("remove {}", path.display())),
+    }
+}
+
+#[cfg(unix)]
+fn replace_binary(
+    staged: &Path,
+    plan: &UpgradePlan,
+    staged_runtime: Option<&StagedRuntime>,
+    marker_staged: &Path,
+    unique: &str,
+    data_root: &Path,
+    _upgrade_lock_path: &Path,
+) -> Result<ApplyResult> {
+    let marker_path = install_marker_path(&plan.install_path);
+    let mut runtime = staged_runtime.map(|runtime| {
+        UnixPublishedPath::new(
+            "ONNX Runtime sidecar",
+            runtime.staged_path.clone(),
+            runtime.target_path.clone(),
+            transaction_backup_path(&runtime.target_path, unique, "runtime"),
+            PublishedPathKind::Directory,
+        )
+    });
+    let mut binary = UnixPublishedPath::new(
+        "ctx binary",
+        staged.to_path_buf(),
+        plan.install_path.clone(),
+        transaction_backup_path(&plan.install_path, unique, "binary"),
+        PublishedPathKind::File,
+    );
+    let marker_backup = transaction_backup_path(&marker_path, unique, "marker");
+    let mut marker = UnixPublishedPath::new(
+        "ctx install marker",
+        marker_staged.to_path_buf(),
+        marker_path,
+        marker_backup,
+        PublishedPathKind::File,
+    );
+    let mut journal = InstallTransactionJournal {
+        schema_version: 1,
+        transaction_id: unique.to_owned(),
+        phase: JournalPhase::Publishing,
+        install_path: plan.install_path.clone(),
+        paths: runtime
+            .iter()
+            .map(UnixPublishedPath::journal_path)
+            .chain(std::iter::once(binary.journal_path()))
+            .chain(std::iter::once(marker.journal_path()))
+            .collect(),
+    };
+    write_install_transaction(data_root, &journal)?;
+    let publish_result = (|| -> Result<()> {
+        if let Some(runtime) = runtime.as_mut() {
+            runtime.publish(false)?;
+            abort_after_publish_for_tests("runtime");
+        }
+        binary.publish(false)?;
+        abort_after_publish_for_tests("binary");
+        marker.publish(true)?;
+        abort_after_publish_for_tests("marker");
+        Ok(())
+    })();
+    if let Err(primary) = publish_result {
+        let mut rollback_errors =
+            rollback_unix_publication(&mut marker, &mut binary, runtime.as_mut(), true);
+        if rollback_errors.is_empty() {
+            if let Err(error) = remove_install_transaction(data_root) {
+                rollback_errors.push(format!("remove transaction journal: {error:#}"));
+            } else {
+                return Err(primary);
+            }
+        }
+        return Err(anyhow!(
+            "{primary:#}; rollback failures: {}",
+            rollback_errors.join("; ")
+        ));
+    }
+
+    journal.phase = JournalPhase::Committed;
+    if let Err(primary) = write_install_transaction(data_root, &journal) {
+        let mut rollback_errors =
+            rollback_unix_publication(&mut marker, &mut binary, runtime.as_mut(), false);
+        if rollback_errors.is_empty() {
+            if let Err(error) = remove_install_transaction(data_root) {
+                rollback_errors.push(format!("remove transaction journal: {error:#}"));
+            } else {
+                return Err(primary);
+            }
+        }
+        return Err(anyhow!(
+            "{primary:#}; rollback failures: {}",
+            rollback_errors.join("; ")
+        ));
+    }
+    if cfg!(debug_assertions) && env_flag("CTX_UPGRADE_ABORT_AFTER_COMMIT_FOR_TESTS") {
+        std::process::exit(88);
+    }
+    marker.discard_backup()?;
+    if let Some(runtime) = runtime.as_mut() {
+        runtime.discard_backup()?;
+    }
+    binary.retain_backup_as(&backup_path(&plan.install_path))?;
+    remove_install_transaction(data_root)?;
     Ok(ApplyResult::Applied)
 }
 
+#[cfg(unix)]
+fn rollback_unix_publication(
+    marker: &mut UnixPublishedPath,
+    binary: &mut UnixPublishedPath,
+    runtime: Option<&mut UnixPublishedPath>,
+    inject_runtime_restore_failure: bool,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+    if let Err(error) = marker.rollback(false) {
+        errors.push(format!("{error:#}"));
+    }
+    if let Err(error) = binary.rollback(false) {
+        errors.push(format!("{error:#}"));
+    }
+    if let Some(runtime) = runtime {
+        if let Err(error) = runtime.rollback(inject_runtime_restore_failure) {
+            errors.push(format!("{error:#}"));
+        }
+    }
+    errors
+}
+
+#[cfg(unix)]
+fn abort_after_publish_for_tests(point: &str) {
+    if cfg!(debug_assertions)
+        && env::var("CTX_UPGRADE_ABORT_AFTER_PUBLISH_FOR_TESTS")
+            .ok()
+            .is_some_and(|value| value == point)
+    {
+        std::process::exit(86);
+    }
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy)]
+enum PublishedPathKind {
+    File,
+    Directory,
+}
+
+#[cfg(unix)]
+struct UnixPublishedPath {
+    label: &'static str,
+    staged: PathBuf,
+    target: PathBuf,
+    backup: PathBuf,
+    kind: PublishedPathKind,
+    had_previous: bool,
+    published: bool,
+}
+
+#[cfg(unix)]
+impl UnixPublishedPath {
+    fn new(
+        label: &'static str,
+        staged: PathBuf,
+        target: PathBuf,
+        backup: PathBuf,
+        kind: PublishedPathKind,
+    ) -> Self {
+        Self {
+            label,
+            staged,
+            target,
+            backup,
+            kind,
+            had_previous: false,
+            published: false,
+        }
+    }
+
+    fn journal_path(&self) -> JournalPath {
+        JournalPath {
+            label: self.label.to_owned(),
+            staged: self.staged.clone(),
+            target: self.target.clone(),
+            backup: self.backup.clone(),
+            kind: match self.kind {
+                PublishedPathKind::File => JournalPathKind::File,
+                PublishedPathKind::Directory => JournalPathKind::Directory,
+            },
+        }
+    }
+
+    fn publish(&mut self, inject_marker_failure: bool) -> Result<()> {
+        if self.backup.exists() {
+            return Err(anyhow!(
+                "{} transaction backup already exists at {}",
+                self.label,
+                self.backup.display()
+            ));
+        }
+        if self.target.exists() {
+            match self.kind {
+                PublishedPathKind::File => {
+                    backup_file_for_atomic_replace(&self.target, &self.backup, self.label)?
+                }
+                PublishedPathKind::Directory => {
+                    fs::rename(&self.target, &self.backup).with_context(|| {
+                        format!(
+                            "backup {} {} to {}",
+                            self.label,
+                            self.target.display(),
+                            self.backup.display()
+                        )
+                    })?;
+                }
+            }
+            self.had_previous = true;
+            if let Some(parent) = self.target.parent() {
+                sync_directory(parent)?;
+            }
+            abort_after_backup_for_tests(self.label);
+        }
+        if inject_marker_failure
+            && cfg!(debug_assertions)
+            && env_flag("CTX_UPGRADE_FAIL_MARKER_PUBLISH_FOR_TESTS")
+        {
+            return Err(anyhow!("injected install marker publication failure"));
+        }
+        fs::rename(&self.staged, &self.target).with_context(|| {
+            format!(
+                "publish {} {} to {}",
+                self.label,
+                self.staged.display(),
+                self.target.display()
+            )
+        })?;
+        self.published = true;
+        if let Some(parent) = self.target.parent() {
+            sync_parent(parent);
+        }
+        Ok(())
+    }
+
+    fn rollback(&mut self, inject_runtime_restore_failure: bool) -> Result<()> {
+        if self.published && self.target.exists() {
+            remove_published_path(&self.target, self.kind).with_context(|| {
+                format!(
+                    "remove newly published {} at {}; recoverable backup is {}",
+                    self.label,
+                    self.target.display(),
+                    self.backup.display()
+                )
+            })?;
+            self.published = false;
+        }
+        if self.had_previous {
+            if inject_runtime_restore_failure
+                && cfg!(debug_assertions)
+                && env_flag("CTX_UPGRADE_FAIL_RUNTIME_RESTORE_FOR_TESTS")
+            {
+                return Err(anyhow!(
+                    "injected ONNX Runtime restore failure; recoverable backup retained at {}",
+                    self.backup.display()
+                ));
+            }
+            match self.kind {
+                PublishedPathKind::File => {
+                    fs::rename(&self.backup, &self.target).with_context(|| {
+                        format!(
+                            "restore {} {} from recoverable backup {}",
+                            self.label,
+                            self.target.display(),
+                            self.backup.display()
+                        )
+                    })?;
+                }
+                PublishedPathKind::Directory => {
+                    fs::rename(&self.backup, &self.target).with_context(|| {
+                        format!(
+                            "restore {} {} from recoverable backup {}",
+                            self.label,
+                            self.target.display(),
+                            self.backup.display()
+                        )
+                    })?;
+                }
+            }
+            self.had_previous = false;
+        }
+        if let Some(parent) = self.target.parent() {
+            sync_parent(parent);
+        }
+        Ok(())
+    }
+
+    fn discard_backup(&mut self) -> Result<()> {
+        if self.had_previous {
+            remove_published_path(&self.backup, self.kind).with_context(|| {
+                format!("remove previous {} {}", self.label, self.backup.display())
+            })?;
+            self.had_previous = self.backup.exists();
+        }
+        if let Some(parent) = self.target.parent() {
+            sync_directory(parent)?;
+        }
+        Ok(())
+    }
+
+    fn retain_backup_as(&mut self, durable_backup: &Path) -> Result<()> {
+        if !self.had_previous {
+            return Ok(());
+        }
+        if durable_backup.exists() {
+            fs::remove_file(durable_backup)
+                .with_context(|| format!("remove old ctx backup {}", durable_backup.display()))?;
+        }
+        fs::rename(&self.backup, durable_backup).with_context(|| {
+            format!(
+                "retain previous {} {} at {}",
+                self.label,
+                self.backup.display(),
+                durable_backup.display()
+            )
+        })?;
+        self.had_previous = false;
+        if let Some(parent) = self.target.parent() {
+            sync_directory(parent)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn backup_file_for_atomic_replace(target: &Path, backup: &Path, label: &str) -> Result<()> {
+    if let Err(link_error) = fs::hard_link(target, backup) {
+        fs::copy(target, backup).with_context(|| {
+            format!(
+                "backup {label} {} to {} after hard-link failed: {link_error}",
+                target.display(),
+                backup.display()
+            )
+        })?;
+        fs::File::open(backup)?.sync_all()?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn abort_after_backup_for_tests(label: &str) {
+    let point = match label {
+        "ONNX Runtime sidecar" => "runtime",
+        "ctx binary" => "binary",
+        "ctx install marker" => "marker",
+        _ => return,
+    };
+    if cfg!(debug_assertions)
+        && env::var("CTX_UPGRADE_ABORT_AFTER_BACKUP_FOR_TESTS")
+            .ok()
+            .is_some_and(|value| value == point)
+    {
+        std::process::exit(87);
+    }
+}
+
+#[cfg(unix)]
+fn remove_published_path(path: &Path, kind: PublishedPathKind) -> std::io::Result<()> {
+    match kind {
+        PublishedPathKind::File => fs::remove_file(path),
+        PublishedPathKind::Directory => fs::remove_dir_all(path),
+    }
+}
+
+#[cfg(unix)]
+fn transaction_backup_path(target: &Path, unique: &str, label: &str) -> PathBuf {
+    let name = target
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(label);
+    target.with_file_name(format!(".{name}.ctx-upgrade-{unique}.{label}.previous"))
+}
+
 #[cfg(windows)]
-fn replace_binary(staged: &Path, plan: &UpgradePlan) -> Result<ApplyResult> {
+fn replace_binary(
+    staged: &Path,
+    plan: &UpgradePlan,
+    staged_runtime: Option<&StagedRuntime>,
+    marker_staged: &Path,
+    unique: &str,
+    data_root: &Path,
+    upgrade_lock_path: &Path,
+) -> Result<ApplyResult> {
     let target = &plan.install_path;
     let backup = backup_path(target);
     let script = staged.with_extension("ps1");
-    let marker_tmp = staged.with_extension("install.json.tmp");
     let marker_path = install_marker_path(target);
-    let install_attempt_id = existing_install_attempt_id(&marker_path);
-    write_install_marker_to(&marker_tmp, plan, install_attempt_id.as_deref())?;
+    let marker_backup = marker_path.with_file_name(format!(
+        ".ctx.install.json.ctx-upgrade-{unique}.marker.previous"
+    ));
+    let state_path = data_root.join(super::state::STATE_FILE);
     let parent = std::process::id();
+    let (runtime_variables, runtime_install, runtime_rollback, runtime_finish) =
+        windows_runtime_script(staged_runtime);
     let body = format!(
         r#"$ErrorActionPreference = 'Stop'
 $parent = {parent}
@@ -110,29 +1274,160 @@ $target = {target}
 $backup = {backup}
 $markerTmp = {marker_tmp}
 $markerPath = {marker_path}
-for ($i = 0; $i -lt 80; $i++) {{
-  $p = Get-Process -Id $parent -ErrorAction SilentlyContinue
-  if ($null -eq $p) {{ break }}
+$markerBackup = {marker_backup}
+$lockPath = {lock_path}
+$statePath = {state_path}
+$currentVersion = {current_version}
+$latestVersion = {latest_version}
+$channel = {channel}
+$platform = {platform}
+$metadataUrl = {metadata_url}
+$artifactUrl = {artifact_url}
+$markerHadPrevious = $false
+$markerPublished = $false
+$binaryHadPrevious = Test-Path -LiteralPath $target
+$binaryPublished = $false
+{runtime_variables}
+
+function Test-OwnsUpgradeLock {{
+  if (-not (Test-Path -LiteralPath $lockPath)) {{ return $false }}
+  try {{
+    $fields = ((Get-Content -LiteralPath $lockPath -Raw).Trim() -split '\s+')
+    return $fields.Count -ge 1 -and $fields[0] -eq [string]$PID
+  }} catch {{
+    return $false
+  }}
+}}
+
+function Write-TerminalUpgradeState([string]$status, [string]$errorMessage) {{
+  $state = [ordered]@{{
+    schema_version = 1
+    status = $status
+    checked_at = [DateTime]::UtcNow.ToString('o')
+    last_checked_unix_s = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    current_version = $(if ($status -eq 'applied') {{ $latestVersion }} else {{ $currentVersion }})
+    latest_version = $latestVersion
+    update_available = ($status -ne 'applied')
+    channel = $channel
+    platform = $platform
+    metadata_url = $metadataUrl
+    artifact_url = $artifactUrl
+    install_path = $target
+    managed = $true
+  }}
+  if (-not [string]::IsNullOrEmpty($errorMessage)) {{ $state['error'] = $errorMessage }}
+  $stateTmp = "$statePath.tmp.$PID"
+  $utf8 = [System.Text.UTF8Encoding]::new($false)
+  [System.IO.File]::WriteAllText($stateTmp, (($state | ConvertTo-Json -Depth 4) + [char]10), $utf8)
+  $stateStream = [System.IO.File]::Open($stateTmp, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::Read)
+  try {{ $stateStream.Flush($true) }} finally {{ $stateStream.Dispose() }}
+  if (Test-Path -LiteralPath $statePath) {{
+    [System.IO.File]::Replace($stateTmp, $statePath, $null, $true)
+  }} else {{
+    Move-Item -LiteralPath $stateTmp -Destination $statePath
+  }}
+}}
+
+while ($null -ne (Get-Process -Id $parent -ErrorAction SilentlyContinue)) {{
   Start-Sleep -Milliseconds 250
 }}
+
+$terminalError = $null
+try {{
+if (-not (Test-OwnsUpgradeLock)) {{
+  throw "ctx upgrade helper did not receive the serialization lock"
+}}
+try {{
+{runtime_install}
 if (Test-Path -LiteralPath $target) {{
   [System.IO.File]::Replace($staged, $target, $backup, $true)
 }} else {{
   Move-Item -LiteralPath $staged -Destination $target -Force
 }}
-if (Test-Path -LiteralPath $markerTmp) {{
-  Move-Item -LiteralPath $markerTmp -Destination $markerPath -Force
+$binaryPublished = $true
+if (Test-Path -LiteralPath $markerBackup) {{
+  throw "install marker transaction backup already exists at $markerBackup"
 }}
-Remove-Item -LiteralPath $MyInvocation.MyCommand.Path -Force
+if (Test-Path -LiteralPath $markerPath) {{
+  Move-Item -LiteralPath $markerPath -Destination $markerBackup
+  $markerHadPrevious = $true
+}}
+if (Test-Path -LiteralPath $markerTmp) {{
+  Move-Item -LiteralPath $markerTmp -Destination $markerPath
+  $markerPublished = $true
+}} else {{
+  throw "staged install marker is missing at $markerTmp"
+}}
+}} catch {{
+  $publishError = $_
+  $rollbackErrors = @()
+  try {{
+{runtime_rollback}
+  }} catch {{
+    $rollbackErrors += $_.Exception.Message
+  }}
+  try {{
+    if ($binaryPublished -and (Test-Path -LiteralPath $target)) {{
+      Remove-Item -LiteralPath $target -Force
+    }}
+    if ($binaryHadPrevious -and (Test-Path -LiteralPath $backup)) {{
+      Move-Item -LiteralPath $backup -Destination $target -Force
+    }}
+  }} catch {{
+    $rollbackErrors += $_.Exception.Message
+  }}
+  try {{
+    if ($markerPublished -and (Test-Path -LiteralPath $markerPath)) {{
+      Remove-Item -LiteralPath $markerPath -Force
+    }}
+    if ($markerHadPrevious -and (Test-Path -LiteralPath $markerBackup)) {{
+      Move-Item -LiteralPath $markerBackup -Destination $markerPath -Force
+    }}
+  }} catch {{
+    $rollbackErrors += $_.Exception.Message
+  }}
+  if ($rollbackErrors.Count -gt 0) {{
+    throw "$($publishError.Exception.Message); rollback failures: $($rollbackErrors -join '; ')"
+  }}
+  throw $publishError
+}}
+{runtime_finish}
+if (Test-Path -LiteralPath $markerBackup) {{
+  Remove-Item -LiteralPath $markerBackup -Force -ErrorAction SilentlyContinue
+}}
+Write-TerminalUpgradeState 'applied' $null
+}} catch {{
+  $terminalError = $_.Exception.Message
+  try {{ Write-TerminalUpgradeState 'error' $terminalError }} catch {{}}
+}} finally {{
+  if (Test-OwnsUpgradeLock) {{
+    Remove-Item -LiteralPath $lockPath -Force -ErrorAction SilentlyContinue
+  }}
+  Remove-Item -LiteralPath $MyInvocation.MyCommand.Path -Force -ErrorAction SilentlyContinue
+}}
+if ($null -ne $terminalError) {{ exit 1 }}
 "#,
         staged = ps_single_quote(staged),
         target = ps_single_quote(target),
         backup = ps_single_quote(&backup),
-        marker_tmp = ps_single_quote(&marker_tmp),
+        marker_tmp = ps_single_quote(marker_staged),
         marker_path = ps_single_quote(&marker_path),
+        marker_backup = ps_single_quote(&marker_backup),
+        lock_path = ps_single_quote(upgrade_lock_path),
+        state_path = ps_single_quote(&state_path),
+        current_version = ps_single_quote_value(&plan.current_version),
+        latest_version = ps_single_quote_value(&plan.latest_version),
+        channel = ps_single_quote_value(&plan.channel),
+        platform = ps_single_quote_value(&plan.platform),
+        metadata_url = ps_single_quote_value(&plan.metadata_url),
+        artifact_url = ps_single_quote_value(&plan.artifact_url),
+        runtime_variables = runtime_variables,
+        runtime_install = runtime_install,
+        runtime_rollback = runtime_rollback,
+        runtime_finish = runtime_finish,
     );
     fs::write(&script, body)?;
-    std::process::Command::new("powershell")
+    let child = std::process::Command::new("powershell")
         .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
         .arg(&script)
         .stdin(std::process::Stdio::null())
@@ -140,11 +1435,21 @@ Remove-Item -LiteralPath $MyInvocation.MyCommand.Path -Force
         .stderr(std::process::Stdio::null())
         .spawn()
         .context("spawn Windows ctx replacement helper")?;
-    Ok(ApplyResult::Scheduled)
+    Ok(ApplyResult::Scheduled {
+        helper_pid: child.id(),
+    })
 }
 
 #[cfg(not(any(unix, windows)))]
-fn replace_binary(_staged: &Path, _plan: &UpgradePlan) -> Result<ApplyResult> {
+fn replace_binary(
+    _staged: &Path,
+    _plan: &UpgradePlan,
+    _staged_runtime: Option<&StagedRuntime>,
+    _marker_staged: &Path,
+    _unique: &str,
+    _data_root: &Path,
+    _upgrade_lock_path: &Path,
+) -> Result<ApplyResult> {
     Err(anyhow!(
         "self-upgrade replacement is unsupported on this platform"
     ))
@@ -152,7 +1457,56 @@ fn replace_binary(_staged: &Path, _plan: &UpgradePlan) -> Result<ApplyResult> {
 
 #[cfg(windows)]
 fn ps_single_quote(path: &Path) -> String {
-    format!("'{}'", path.display().to_string().replace('\'', "''"))
+    ps_single_quote_value(&path.display().to_string())
+}
+
+#[cfg(windows)]
+fn ps_single_quote_value(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+#[cfg(windows)]
+fn windows_runtime_script(runtime: Option<&StagedRuntime>) -> (String, String, String, String) {
+    let Some(runtime) = runtime else {
+        return (String::new(), String::new(), String::new(), String::new());
+    };
+    let target_name = runtime
+        .target_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("runtime");
+    let backup = runtime.target_path.with_file_name(format!(
+        ".{target_name}.ctx-upgrade-{}.previous",
+        std::process::id()
+    ));
+    let variables = format!(
+        "$runtimeStaged = {}\n$runtimeTarget = {}\n$runtimeBackup = {}\n$runtimeHadPrevious = $false\n$runtimePublished = $false",
+        ps_single_quote(&runtime.staged_path),
+        ps_single_quote(&runtime.target_path),
+        ps_single_quote(&backup),
+    );
+    let install = r#"  if (Test-Path -LiteralPath $runtimeBackup) {
+    throw "ONNX Runtime transaction backup already exists at $runtimeBackup"
+  }
+  if (Test-Path -LiteralPath $runtimeTarget) {
+    Move-Item -LiteralPath $runtimeTarget -Destination $runtimeBackup
+    $runtimeHadPrevious = $true
+  }
+  Move-Item -LiteralPath $runtimeStaged -Destination $runtimeTarget
+  $runtimePublished = $true"#
+        .to_owned();
+    let rollback = r#"  if ($runtimePublished -and (Test-Path -LiteralPath $runtimeTarget)) {
+    Remove-Item -LiteralPath $runtimeTarget -Recurse -Force
+  }
+  if ($runtimeHadPrevious -and (Test-Path -LiteralPath $runtimeBackup)) {
+    Move-Item -LiteralPath $runtimeBackup -Destination $runtimeTarget
+  }"#
+    .to_owned();
+    let finish = r#"if (Test-Path -LiteralPath $runtimeBackup) {
+  Remove-Item -LiteralPath $runtimeBackup -Recurse -Force -ErrorAction SilentlyContinue
+  }"#
+    .to_owned();
+    (variables, install, rollback, finish)
 }
 
 fn backup_path(target: &Path) -> PathBuf {
@@ -165,11 +1519,18 @@ fn backup_path(target: &Path) -> PathBuf {
 
 #[cfg(unix)]
 fn sync_parent(parent: &Path) {
-    let _ = fs::File::open(parent).and_then(|file| file.sync_all());
+    let _ = sync_directory(parent);
 }
 
 #[cfg(not(unix))]
 fn sync_parent(_parent: &Path) {}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> Result<()> {
+    fs::File::open(path)
+        .and_then(|file| file.sync_all())
+        .with_context(|| format!("sync directory {}", path.display()))
+}
 
 fn read_install_marker_for_current_exe() -> Result<InstallMarker> {
     let path = current_install_path()?;
@@ -264,12 +1625,6 @@ fn verify_install_marker(marker: &InstallMarker, platform: &str) -> Result<()> {
         ));
     }
     Ok(())
-}
-
-pub(super) fn write_install_marker_after_upgrade(plan: &UpgradePlan) -> Result<()> {
-    let marker_path = install_marker_path(&plan.install_path);
-    let install_attempt_id = existing_install_attempt_id(&marker_path);
-    write_install_marker_to(&marker_path, plan, install_attempt_id.as_deref())
 }
 
 fn write_install_marker_to(

--- a/crates/ctx-cli/src/upgrade/metadata.rs
+++ b/crates/ctx-cli/src/upgrade/metadata.rs
@@ -19,6 +19,22 @@ t4JAElZCs8SGTlV70MSlnyZb5/rkKx9kMvb7YjuYbY6vnN5Pp3P7gMhOKehP+62U
 /a+X6TNV/k5fAgMBAAE=
 -----END RSA PUBLIC KEY-----"#;
 const RELEASE_BASE_PREFIX: &str = "https://cli.ctx.rs/storage/v1/object/public/releases/artifacts/";
+const ONNXRUNTIME_METADATA_PREFIX: &str = "CTX_RELEASE_ONNXRUNTIME_";
+const SUPPORTED_PLATFORM_KEYS: [&str; 6] = [
+    "linux_x64",
+    "linux_aarch64",
+    "macos_arm64",
+    "macos_x64",
+    "windows_x64",
+    "freebsd_x64",
+];
+
+#[derive(Debug, Clone)]
+pub(super) struct OnnxRuntimeMetadata {
+    pub(super) version: String,
+    pub(super) artifact: String,
+    pub(super) sha256: String,
+}
 
 #[derive(Debug, Clone)]
 pub(super) struct ReleaseMetadata {
@@ -31,6 +47,7 @@ pub(super) struct ReleaseMetadata {
     pub(super) self_upgrade_allowed: bool,
     pub(super) auto_upgrade_allowed: bool,
     pub(super) store_schema_version: Option<String>,
+    pub(super) onnxruntime: Option<OnnxRuntimeMetadata>,
 }
 
 pub(super) fn metadata_url(config: &AppConfig, channel: &str) -> String {
@@ -81,6 +98,35 @@ pub(super) fn parse_release_metadata(
     let sha256 = value(&format!("CTX_RELEASE_SHA256_{platform_key}"))
         .ok_or_else(|| anyhow!("metadata missing checksum for {platform}"))?;
     validate_sha256(&sha256)?;
+    let onnxruntime = if metadata
+        .keys()
+        .any(|key| key.starts_with(ONNXRUNTIME_METADATA_PREFIX))
+    {
+        let version = value("CTX_RELEASE_ONNXRUNTIME_VERSION")
+            .ok_or_else(|| anyhow!("metadata missing CTX_RELEASE_ONNXRUNTIME_VERSION"))?;
+        validate_onnxruntime_version(&version)?;
+        for key in SUPPORTED_PLATFORM_KEYS {
+            let artifact_key = format!("CTX_RELEASE_ONNXRUNTIME_ARTIFACT_{key}");
+            let checksum_key = format!("CTX_RELEASE_ONNXRUNTIME_SHA256_{key}");
+            let artifact =
+                value(&artifact_key).ok_or_else(|| anyhow!("metadata missing {artifact_key}"))?;
+            let checksum =
+                value(&checksum_key).ok_or_else(|| anyhow!("metadata missing {checksum_key}"))?;
+            validate_artifact_name(&artifact)?;
+            validate_sha256(&checksum)?;
+        }
+        let artifact = value(&format!("CTX_RELEASE_ONNXRUNTIME_ARTIFACT_{platform_key}"))
+            .ok_or_else(|| anyhow!("metadata missing ONNX Runtime artifact for {platform}"))?;
+        let sha256 = value(&format!("CTX_RELEASE_ONNXRUNTIME_SHA256_{platform_key}"))
+            .ok_or_else(|| anyhow!("metadata missing ONNX Runtime checksum for {platform}"))?;
+        Some(OnnxRuntimeMetadata {
+            version,
+            artifact,
+            sha256,
+        })
+    } else {
+        None
+    };
     Ok(ReleaseMetadata {
         version,
         base_url,
@@ -91,23 +137,28 @@ pub(super) fn parse_release_metadata(
         self_upgrade_allowed: metadata_bool(&metadata, "CTX_RELEASE_SELF_UPGRADE_ALLOWED", false)?,
         auto_upgrade_allowed: metadata_bool(&metadata, "CTX_RELEASE_AUTO_UPGRADE_ALLOWED", false)?,
         store_schema_version: value("CTX_RELEASE_STORE_SCHEMA_VERSION"),
+        onnxruntime,
     })
 }
 
 fn parse_metadata_map(text: &str) -> Result<BTreeMap<String, String>> {
     let mut metadata = BTreeMap::new();
-    for line in text.lines() {
-        let line = line.trim();
-        if line.starts_with('#') || line.is_empty() {
+    for raw_line in text.lines() {
+        let line = raw_line.trim_end_matches('\r');
+        if line.trim_start().starts_with('#') || line.trim().is_empty() {
             continue;
         }
         let Some((key, value)) = line.split_once('=') else {
-            continue;
+            return Err(anyhow!("metadata contains malformed line: {line:?}"));
         };
-        if metadata
-            .insert(key.to_owned(), value.trim_end_matches('\r').to_owned())
-            .is_some()
+        if key.is_empty()
+            || !key
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
         {
+            return Err(anyhow!("metadata contains invalid key: {key:?}"));
+        }
+        if metadata.insert(key.to_owned(), value.to_owned()).is_some() {
             return Err(anyhow!("metadata contains duplicate key {key}"));
         }
     }
@@ -171,8 +222,36 @@ pub(super) fn validate_artifact_url(base_url: &str, artifact: &str) -> Result<()
             "metadata base URL must be under {RELEASE_BASE_PREFIX}"
         ));
     }
-    if artifact.contains('/') || artifact.contains('\\') || artifact.contains("..") {
+    validate_artifact_name(artifact)
+}
+
+fn validate_artifact_name(artifact: &str) -> Result<()> {
+    if artifact.is_empty()
+        || artifact.contains('/')
+        || artifact.contains('\\')
+        || artifact.contains("..")
+        || artifact.contains('\n')
+        || artifact.contains('\r')
+    {
         return Err(anyhow!("unsafe artifact name: {artifact}"));
+    }
+    Ok(())
+}
+
+fn validate_onnxruntime_version(version: &str) -> Result<()> {
+    if version.len() > 32
+        || version.trim() != version
+        || version.split('.').count() != 3
+        || version.split('.').any(|part| {
+            part.is_empty()
+                || !part.bytes().all(|byte| byte.is_ascii_digit())
+                || (part.len() > 1 && part.starts_with('0'))
+                || part.parse::<u32>().is_err()
+        })
+    {
+        return Err(anyhow!(
+            "ONNX Runtime version must be a safe MAJOR.MINOR.PATCH identifier"
+        ));
     }
     Ok(())
 }

--- a/crates/ctx-cli/src/upgrade/mod.rs
+++ b/crates/ctx-cli/src/upgrade/mod.rs
@@ -28,6 +28,18 @@ struct UpgradePlan {
     pub(super) metadata: metadata::ReleaseMetadata,
 }
 
+impl UpgradePlan {
+    fn onnxruntime_artifact_url(&self) -> Option<String> {
+        self.metadata.onnxruntime.as_ref().map(|runtime| {
+            format!(
+                "{}/{}",
+                self.metadata.base_url.trim_end_matches('/'),
+                runtime.artifact
+            )
+        })
+    }
+}
+
 fn platform_key() -> Result<&'static str> {
     match (std::env::consts::OS, std::env::consts::ARCH) {
         ("linux", "x86_64") => Ok("linux-x64"),

--- a/crates/ctx-cli/src/upgrade/state.rs
+++ b/crates/ctx-cli/src/upgrade/state.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Context, Result};
 use ctx_history_core::utc_now;
 use serde_json::{json, Value};
 
-use super::UpgradePlan;
+use super::{env_flag, UpgradePlan};
 
 pub(super) const STATE_FILE: &str = "upgrade-state.json";
 const LOCK_FILE: &str = "upgrade.lock";
@@ -21,6 +21,9 @@ pub(super) fn write_state_checked(
     plan: &UpgradePlan,
     status: &str,
 ) -> Result<()> {
+    if cfg!(debug_assertions) && env_flag("CTX_UPGRADE_FAIL_STATE_WRITE_FOR_TESTS") {
+        return Err(anyhow!("injected upgrade state write failure"));
+    }
     let body = json!({
         "schema_version": 1,
         "status": status,
@@ -82,6 +85,7 @@ pub(super) fn atomic_write_json(path: &Path, value: &Value) -> Result<()> {
 
 pub(super) struct UpgradeLock {
     path: PathBuf,
+    remove_on_drop: bool,
 }
 
 impl UpgradeLock {
@@ -96,7 +100,11 @@ impl UpgradeLock {
             {
                 Ok(mut file) => {
                     writeln!(file, "{} {}", std::process::id(), now_unix_s())?;
-                    return Ok(Self { path });
+                    file.sync_all()?;
+                    return Ok(Self {
+                        path,
+                        remove_on_drop: true,
+                    });
                 }
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
                     if stale_upgrade_lock_reason(&path).is_some() {
@@ -132,6 +140,23 @@ impl UpgradeLock {
             "ctx upgrade lock could not be acquired at {}",
             path.display()
         ))
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[cfg(windows)]
+    pub(super) fn transfer_to(&mut self, pid: u32) -> Result<()> {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&self.path)
+            .with_context(|| format!("open ctx upgrade lock {}", self.path.display()))?;
+        writeln!(file, "{} {}", pid, now_unix_s())?;
+        file.sync_all()?;
+        self.remove_on_drop = false;
+        Ok(())
     }
 }
 
@@ -203,7 +228,39 @@ fn process_state(pid: u32) -> ProcessState {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn process_state(pid: u32) -> ProcessState {
+    use windows_sys::Win32::{
+        Foundation::{
+            CloseHandle, GetLastError, ERROR_ACCESS_DENIED, ERROR_INVALID_PARAMETER, STILL_ACTIVE,
+        },
+        System::Threading::{GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION},
+    };
+
+    if pid == 0 {
+        return ProcessState::NotRunning;
+    }
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle.is_null() {
+        return match unsafe { GetLastError() } {
+            ERROR_INVALID_PARAMETER => ProcessState::NotRunning,
+            ERROR_ACCESS_DENIED => ProcessState::Running,
+            _ => ProcessState::Unknown,
+        };
+    }
+    let mut exit_code = 0_u32;
+    let queried = unsafe { GetExitCodeProcess(handle, &mut exit_code) };
+    unsafe { CloseHandle(handle) };
+    if queried == 0 {
+        ProcessState::Unknown
+    } else if exit_code == STILL_ACTIVE as u32 {
+        ProcessState::Running
+    } else {
+        ProcessState::NotRunning
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
 fn process_state(_pid: u32) -> ProcessState {
     ProcessState::Unknown
 }
@@ -234,7 +291,9 @@ fn last_errno() -> Option<i32> {
 
 impl Drop for UpgradeLock {
     fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
+        if self.remove_on_drop {
+            let _ = fs::remove_file(&self.path);
+        }
     }
 }
 

--- a/crates/ctx-cli/tests/index.rs
+++ b/crates/ctx-cli/tests/index.rs
@@ -3,19 +3,21 @@ mod support;
 use support::*;
 
 fn write_fake_semantic_model_cache(cache_root: &Path) {
-    let model_root = cache_root.join("models--Qdrant--all-MiniLM-L6-v2-onnx");
-    let snapshot = model_root.join("snapshots").join("test-snapshot");
-    fs::create_dir_all(model_root.join("refs")).unwrap();
+    let model_root = cache_root.join("models--intfloat--multilingual-e5-small");
+    let snapshot = model_root
+        .join("snapshots")
+        .join("614241f622f53c4eeff9890bdc4f31cfecc418b3");
     fs::create_dir_all(&snapshot).unwrap();
-    fs::write(model_root.join("refs").join("main"), "test-snapshot\n").unwrap();
-    for file in [
-        "model.onnx",
-        "tokenizer.json",
-        "config.json",
-        "special_tokens_map.json",
-        "tokenizer_config.json",
+    for (file, size) in [
+        ("onnx/model.onnx", 470_268_510),
+        ("tokenizer.json", 17_082_730),
+        ("config.json", 655),
+        ("special_tokens_map.json", 167),
+        ("tokenizer_config.json", 443),
     ] {
-        fs::write(snapshot.join(file), "x").unwrap();
+        let path = snapshot.join(file);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::File::create(path).unwrap().set_len(size).unwrap();
     }
 }
 
@@ -76,8 +78,13 @@ fn index_status_reports_stale_daemon_lock_as_recoverable() {
     );
 }
 
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64"),
+    target_env = "gnu"
+))]
 #[test]
-fn index_status_ignores_semantic_model_caches_when_backend_is_unsupported() {
+fn index_status_recognizes_semantic_model_caches_on_supported_linux() {
     let temp = tempdir();
     let workspace = temp.path().join("workspace");
     fs::create_dir_all(&workspace).unwrap();
@@ -87,8 +94,11 @@ fn index_status_ignores_semantic_model_caches_when_backend_is_unsupported() {
     current_dir_command.current_dir(&workspace);
     remove_semantic_cache_env(&mut current_dir_command);
     let status = json_output(current_dir_command.args(["index", "status", "--json"]));
-    assert_eq!(status["semantic"]["model_cache_available"], false);
-    assert_eq!(status["semantic"]["embed_policy"]["source"], "unsupported");
+    assert_eq!(status["semantic"]["model_cache_available"], true);
+    assert_eq!(
+        status["semantic"]["embed_policy"]["source"],
+        "dynamic_quiet"
+    );
 
     let temp = tempdir();
     let hf_home = temp.path().join("hf-home");
@@ -97,8 +107,11 @@ fn index_status_ignores_semantic_model_caches_when_backend_is_unsupported() {
     remove_semantic_cache_env(&mut hf_home_command);
     hf_home_command.env("HF_HOME", &hf_home);
     let status = json_output(hf_home_command.args(["index", "status", "--json"]));
-    assert_eq!(status["semantic"]["model_cache_available"], false);
-    assert_eq!(status["semantic"]["embed_policy"]["source"], "unsupported");
+    assert_eq!(status["semantic"]["model_cache_available"], true);
+    assert_eq!(
+        status["semantic"]["embed_policy"]["source"],
+        "dynamic_quiet"
+    );
 }
 
 #[test]

--- a/crates/ctx-cli/tests/native_providers.rs
+++ b/crates/ctx-cli/tests/native_providers.rs
@@ -599,9 +599,9 @@ fn native_provider_cli_policy_excludes_success_tool_outputs_from_search_and_payl
     }
 
     for (provider, sentinel) in [
-        ("qoder", "native qoder fixture result"),
-        ("openhands", "Edited openhands-cli-native-oracle.txt"),
-        ("continue", "Continue tool output marker"),
+        ("qoder", "qoder-success-tool-output-sentinel"),
+        ("openhands", "openhands-success-tool-output-sentinel"),
+        ("continue", "continue-success-tool-output-sentinel"),
     ] {
         let search = json_output(ctx(&temp).args([
             "search",
@@ -622,21 +622,21 @@ fn native_provider_cli_policy_excludes_success_tool_outputs_from_search_and_payl
     assert_eq!(
         sqlite_count(
             &conn,
-            "SELECT COUNT(*) FROM events WHERE payload_json LIKE '%native qoder fixture result%'",
+            "SELECT COUNT(*) FROM events WHERE payload_json LIKE '%qoder-success-tool-output-sentinel%'",
         ),
         0
     );
     assert_eq!(
         sqlite_count(
             &conn,
-            "SELECT COUNT(*) FROM events WHERE payload_json LIKE '%Edited openhands-cli-native-oracle.txt%'",
+            "SELECT COUNT(*) FROM events WHERE payload_json LIKE '%openhands-success-tool-output-sentinel%'",
         ),
         0
     );
     assert_eq!(
         sqlite_count(
             &conn,
-            "SELECT COUNT(*) FROM events WHERE payload_json LIKE '%Continue tool output marker%'",
+            "SELECT COUNT(*) FROM events WHERE payload_json LIKE '%continue-success-tool-output-sentinel%'",
         ),
         0
     );

--- a/crates/ctx-cli/tests/search_refresh.rs
+++ b/crates/ctx-cli/tests/search_refresh.rs
@@ -485,6 +485,38 @@ sys.exit(23)
 }
 
 #[test]
+fn search_refresh_auto_all_malformed_native_history_fails_instead_of_serving_empty_index() {
+    let temp = tempdir();
+    ctx(&temp).args(["daemon", "disable"]).assert().success();
+    let sessions = temp
+        .path()
+        .join(".codex")
+        .join("sessions")
+        .join("2026/07/12");
+    fs::create_dir_all(&sessions).unwrap();
+    fs::write(sessions.join("rollout-empty-session.jsonl"), "").unwrap();
+
+    let stderr = failure_stderr(ctx(&temp).args([
+        "search",
+        "anything",
+        "--provider",
+        "codex",
+        "--refresh",
+        "background",
+        "--json",
+    ]));
+
+    assert!(
+        stderr.contains("search refresh failed and no existing ctx index is available"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("background refresh imported no content and reported 1 failure(s)"),
+        "{stderr}"
+    );
+}
+
+#[test]
 fn search_refresh_auto_failure_serves_prior_index() {
     let temp = tempdir();
     ctx(&temp).args(["daemon", "disable"]).assert().success();

--- a/crates/ctx-cli/tests/search_show_locate_sql.rs
+++ b/crates/ctx-cli/tests/search_show_locate_sql.rs
@@ -563,7 +563,7 @@ fn fresh_home_search_mvp_flow() {
 }
 
 #[test]
-fn search_backend_defaults_and_unsupported_semantic_config_are_reported() {
+fn search_backend_defaults_and_supported_semantic_config_are_reported() {
     let temp = tempdir();
     let fixture = provider_history_fixture("codex-sessions");
     json_output(ctx(&temp).args([
@@ -631,7 +631,7 @@ fn search_backend_defaults_and_unsupported_semantic_config_are_reported() {
     )
     .unwrap();
 
-    let unsupported_hybrid = failure_stderr(ctx(&temp).args([
+    let supported_hybrid = json_output(ctx(&temp).args([
         "search",
         "onboarding",
         "--backend",
@@ -640,12 +640,14 @@ fn search_backend_defaults_and_unsupported_semantic_config_are_reported() {
         "off",
         "--json",
     ]));
-    assert!(
-        unsupported_hybrid.contains("local semantic search is not supported"),
-        "{unsupported_hybrid}"
+    assert_eq!(supported_hybrid["retrieval"]["requested_mode"], "hybrid");
+    assert_eq!(supported_hybrid["retrieval"]["effective_mode"], "lexical");
+    assert_eq!(
+        supported_hybrid["retrieval"]["semantic_fallback_code"],
+        "semantic_index_missing"
     );
 
-    let unsupported_strict_semantic = ctx(&temp)
+    let missing_index_strict_semantic = ctx(&temp)
         .args([
             "search",
             "onboarding",
@@ -660,10 +662,10 @@ fn search_backend_defaults_and_unsupported_semantic_config_are_reported() {
         .get_output()
         .stderr
         .clone();
-    let unsupported_strict_semantic = String::from_utf8(unsupported_strict_semantic).unwrap();
+    let missing_index_strict_semantic = String::from_utf8(missing_index_strict_semantic).unwrap();
     assert!(
-        unsupported_strict_semantic.contains("local semantic search is not supported"),
-        "{unsupported_strict_semantic}"
+        missing_index_strict_semantic.contains("semantic index is not available yet"),
+        "{missing_index_strict_semantic}"
     );
 
     let explicit_lexical = json_output(ctx(&temp).args([
@@ -679,9 +681,12 @@ fn search_backend_defaults_and_unsupported_semantic_config_are_reported() {
     assert_eq!(explicit_lexical["retrieval"]["effective_mode"], "lexical");
 
     let status = json_output(ctx(&temp).args(["index", "status", "--json"]));
-    assert_eq!(status["semantic"]["status"], "blocked");
-    assert_eq!(status["semantic"]["reason"], "unsupported_platform");
-    assert_eq!(status["semantic"]["embed_policy"]["source"], "unsupported");
+    assert_eq!(status["semantic"]["status"], "pending");
+    assert!(status["semantic"]["reason"].is_null());
+    assert_eq!(
+        status["semantic"]["embed_policy"]["source"],
+        "dynamic_quiet"
+    );
 }
 
 #[test]

--- a/crates/ctx-cli/tests/setup_sources_import.rs
+++ b/crates/ctx-cli/tests/setup_sources_import.rs
@@ -63,6 +63,40 @@ fn setup_does_not_write_default_config_and_preserves_existing_config() {
 }
 
 #[test]
+fn status_reads_committed_wal_content_from_an_active_store() {
+    let temp = tempdir();
+    write_codex_setup_session(&temp);
+    ctx(&temp)
+        .args(["setup", "--wait", "--progress", "none"])
+        .assert()
+        .success();
+
+    let db_path = temp.path().join("work.sqlite");
+    let writer = Connection::open(&db_path).unwrap();
+    writer
+        .execute_batch("PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0;")
+        .unwrap();
+    writer
+        .execute(
+            r#"
+            INSERT INTO sessions
+            (id, provider, external_session_id, agent_type, is_primary, status, fidelity,
+             started_at_ms, created_at_ms, updated_at_ms)
+            VALUES
+            ('00000000-0000-0000-0000-000000000001', 'codex', 'wal-only-session',
+             'primary', 1, 'imported', 'imported', 1, 1, 1)
+            "#,
+            [],
+        )
+        .unwrap();
+    assert!(temp.path().join("work.sqlite-wal").exists());
+
+    let status = json_output(ctx(&temp).args(["status", "--json"]));
+    assert_eq!(status["indexed_sessions"], 2, "{status:#}");
+    drop(writer);
+}
+
+#[test]
 fn malformed_present_config_fails_before_setup_and_analytics_side_effects() {
     let temp = tempdir();
     let state = temp.path().join("state");
@@ -512,6 +546,12 @@ fn setup_partial_import_isolates_empty_codex_session_file() {
         "codex",
         "--json",
     ]));
+    assert_eq!(search["freshness"]["status"], "completed", "{search:#}");
+    assert_eq!(search["freshness"]["totals"]["failed"], 1, "{search:#}");
+    assert_eq!(
+        search["freshness"]["totals"]["failed_sources"], 0,
+        "{search:#}"
+    );
     assert_search_provider_oracle(&search, "codex", "setup should import", 1, "message");
 }
 

--- a/crates/ctx-cli/tests/support/assertions.rs
+++ b/crates/ctx-cli/tests/support/assertions.rs
@@ -128,9 +128,14 @@ pub(crate) fn assert_provider_citations(result: &Value, provider: &str) {
     assert!(!citations.is_empty(), "missing citations in {result:#}");
     for citation in citations {
         assert!(
-            citation["ctx_event_id"].is_string() || citation["ctx_session_id"].is_string(),
-            "citation needs a ctx-owned event or session id in {citation:#}"
+            citation["item_id"].is_string(),
+            "citation needs a ctx-owned item id in {citation:#}"
         );
+        match citation["target_type"].as_str() {
+            Some("event") => assert!(citation["ctx_event_id"].is_string()),
+            Some("session") => assert!(citation["ctx_session_id"].is_string()),
+            _ => {}
+        }
         assert_eq!(citation["provider"], provider, "citation provider failed");
         assert_eq!(
             citation["source_exists"], true,

--- a/crates/ctx-cli/tests/support/native_fixtures/json_tree.rs
+++ b/crates/ctx-cli/tests/support/native_fixtures/json_tree.rs
@@ -567,11 +567,11 @@ pub(crate) fn write_native_qoder_fixture(temp: &TempDir, query: &str) -> String 
                     "content": [{
                         "type": "tool_result",
                         "tool_use_id": "call-qoder-cli-read",
-                        "content": "native qoder fixture result",
+                        "content": "qoder-success-tool-output-sentinel",
                         "is_error": false
                     }]
                 },
-                "toolUseResult": "native qoder fixture result"
+                "toolUseResult": "qoder-success-tool-output-sentinel"
             })
         ),
     )
@@ -646,7 +646,7 @@ pub(crate) fn write_native_openhands_fixture(temp: &TempDir, query: &str) -> Str
             "observation": {
                 "kind": "FileEditorObservation",
                 "command": "str_replace",
-                "output": "Edited openhands-cli-native-oracle.txt",
+                "output": "openhands-success-tool-output-sentinel",
                 "path": "openhands-cli-native-oracle.txt",
                 "prev_exist": true,
                 "old_content": "old",
@@ -1087,7 +1087,7 @@ pub(crate) fn write_native_continue_fixture(temp: &TempDir, query: &str) -> Stri
                                 {
                                     "name": "Result",
                                     "description": "",
-                                    "content": "Continue tool output marker"
+                                    "content": "continue-success-tool-output-sentinel"
                                 }
                             ]
                         }

--- a/crates/ctx-cli/tests/support/upgrade.rs
+++ b/crates/ctx-cli/tests/support/upgrade.rs
@@ -7,9 +7,15 @@ use ring::{
 use serde_json::json;
 use std::{
     fs,
+    io::Cursor,
     path::{Path, PathBuf},
 };
 use tempfile::TempDir;
+
+#[cfg(unix)]
+use flate2::{write::GzEncoder, Compression};
+#[cfg(unix)]
+use tar::{Builder as TarBuilder, EntryType, Header};
 
 use super::file_url;
 
@@ -91,6 +97,15 @@ pub(crate) struct FakeRelease {
 }
 
 #[cfg(unix)]
+#[derive(Debug)]
+pub(crate) struct FakeRuntime {
+    pub(crate) target: PathBuf,
+    pub(crate) artifact: PathBuf,
+    pub(crate) artifact_sha: String,
+    pub(crate) version: String,
+}
+
+#[cfg(unix)]
 pub(crate) fn write_fake_ctx_binary(path: &Path, version: &str) -> Vec<u8> {
     let bytes = format!("#!/bin/sh\nprintf 'ctx {version}\\n'\n").into_bytes();
     fs::write(path, &bytes).unwrap();
@@ -142,6 +157,13 @@ pub(crate) fn install_marker_path(target: &Path) -> PathBuf {
 
 #[cfg(unix)]
 pub(crate) fn fake_release(temp: &TempDir, latest_version: &str) -> FakeRelease {
+    let release = fake_legacy_release(temp, latest_version);
+    let _ = add_fake_release_runtime(temp, &release);
+    release
+}
+
+#[cfg(unix)]
+pub(crate) fn fake_legacy_release(temp: &TempDir, latest_version: &str) -> FakeRelease {
     let bin_dir = temp.path().join("bin");
     let release_dir = temp.path().join("release");
     fs::create_dir_all(&bin_dir).unwrap();
@@ -199,6 +221,195 @@ CTX_RELEASE_AUTO_UPGRADE_ALLOWED=true\n",
         signature,
         artifact_sha,
     }
+}
+
+#[cfg(unix)]
+pub(crate) fn add_fake_release_runtime(temp: &TempDir, release: &FakeRelease) -> FakeRuntime {
+    add_fake_release_runtime_version(temp, release, "1.27.0")
+}
+
+#[cfg(unix)]
+pub(crate) fn add_fake_release_runtime_version(
+    temp: &TempDir,
+    release: &FakeRelease,
+    version: &str,
+) -> FakeRuntime {
+    let release_dir = release.metadata.parent().unwrap();
+    let platform = test_platform_key().replace('_', "-");
+    let artifact_name = format!("ctx-onnxruntime-{platform}.tar.gz");
+    let artifact = release_dir.join(&artifact_name);
+    let library = if platform.starts_with("macos-") {
+        "libonnxruntime.dylib"
+    } else {
+        "libonnxruntime.so"
+    };
+    write_fake_runtime_archive(&artifact, library, version, "valid");
+    let artifact_sha = sha256_hex(&fs::read(&artifact).unwrap());
+    rewrite_fake_release_metadata(release, |metadata| {
+        let mut metadata = metadata
+            .lines()
+            .filter(|line| !line.starts_with("CTX_RELEASE_ONNXRUNTIME_"))
+            .map(|line| format!("{line}\n"))
+            .collect::<String>();
+        metadata.push_str(&format!("CTX_RELEASE_ONNXRUNTIME_VERSION={version}\n"));
+        for key in [
+            "linux_x64",
+            "linux_aarch64",
+            "macos_arm64",
+            "macos_x64",
+            "windows_x64",
+            "freebsd_x64",
+        ] {
+            let platform = key.replace('_', "-");
+            let extension = if key == "windows_x64" {
+                "zip"
+            } else {
+                "tar.gz"
+            };
+            metadata.push_str(&format!(
+                "CTX_RELEASE_ONNXRUNTIME_ARTIFACT_{key}=ctx-onnxruntime-{platform}.{extension}\n\
+CTX_RELEASE_ONNXRUNTIME_SHA256_{key}={artifact_sha}\n"
+            ));
+        }
+        metadata
+    });
+    let target = temp
+        .path()
+        .join("runtime")
+        .join("onnxruntime")
+        .join(version)
+        .join(platform);
+    FakeRuntime {
+        target,
+        artifact,
+        artifact_sha,
+        version: version.to_owned(),
+    }
+}
+
+#[cfg(unix)]
+fn write_fake_runtime_archive(artifact: &Path, library: &str, version: &str, mode: &str) {
+    let archive = fs::File::create(artifact).unwrap();
+    let encoder = GzEncoder::new(archive, Compression::default());
+    let mut bundle = TarBuilder::new(encoder);
+    append_tar_entry(&mut bundle, "lib/", b"", 0o755, EntryType::Directory);
+    let files = [
+        ("LICENSE".to_owned(), b"test license\n".to_vec()),
+        (
+            "ThirdPartyNotices.txt".to_owned(),
+            b"test notices\n".to_vec(),
+        ),
+        (
+            "VERSION_NUMBER".to_owned(),
+            format!("{version}\n").into_bytes(),
+        ),
+        (
+            "GIT_COMMIT_ID".to_owned(),
+            b"test-runtime-commit\n".to_vec(),
+        ),
+        (
+            format!("lib/{library}"),
+            b"fake onnxruntime shared library\n".to_vec(),
+        ),
+    ];
+    for (name, contents) in files {
+        if name.starts_with("lib/") && mode == "symlink" {
+            let mut header = raw_tar_header(&name, 0, 0o755, EntryType::Symlink);
+            header.set_link_name("../LICENSE").unwrap();
+            header.set_cksum();
+            bundle
+                .append(&header, Cursor::new(Vec::<u8>::new()))
+                .unwrap();
+        } else if name.starts_with("lib/") && mode == "special" {
+            append_tar_entry(&mut bundle, &name, b"", 0o755, EntryType::Fifo);
+        } else {
+            let entry_mode = if mode == "unsafe_mode" && name == "LICENSE" {
+                0o4644
+            } else if name.starts_with("lib/") {
+                0o755
+            } else {
+                0o644
+            };
+            append_tar_entry(
+                &mut bundle,
+                &name,
+                &contents,
+                entry_mode,
+                EntryType::Regular,
+            );
+        }
+    }
+    if mode == "traversal" {
+        append_tar_entry(
+            &mut bundle,
+            "../escape",
+            b"escape\n",
+            0o644,
+            EntryType::Regular,
+        );
+    }
+    if mode == "unexpected" {
+        append_tar_entry(&mut bundle, "EXTRA", b"extra\n", 0o644, EntryType::Regular);
+    }
+    if mode == "duplicate" {
+        append_tar_entry(
+            &mut bundle,
+            "LICENSE",
+            b"duplicate\n",
+            0o644,
+            EntryType::Regular,
+        );
+    }
+    bundle.finish().unwrap();
+    bundle.into_inner().unwrap().finish().unwrap();
+}
+
+#[cfg(unix)]
+fn append_tar_entry(
+    bundle: &mut TarBuilder<GzEncoder<fs::File>>,
+    name: &str,
+    contents: &[u8],
+    mode: u32,
+    entry_type: EntryType,
+) {
+    let header = raw_tar_header(name, contents.len() as u64, mode, entry_type);
+    bundle.append(&header, Cursor::new(contents)).unwrap();
+}
+
+#[cfg(unix)]
+fn raw_tar_header(name: &str, size: u64, mode: u32, entry_type: EntryType) -> Header {
+    assert!(name.len() < 100);
+    let mut header = Header::new_gnu();
+    header.set_size(size);
+    header.set_mode(mode);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_entry_type(entry_type);
+    header.as_mut_bytes()[..name.len()].copy_from_slice(name.as_bytes());
+    header.set_cksum();
+    header
+}
+
+#[cfg(unix)]
+pub(crate) fn rewrite_fake_runtime_archive(
+    release: &FakeRelease,
+    runtime: &mut FakeRuntime,
+    mode: &str,
+) {
+    let platform = test_platform_key().replace('_', "-");
+    let library = if platform.starts_with("macos-") {
+        "libonnxruntime.dylib"
+    } else {
+        "libonnxruntime.so"
+    };
+    write_fake_runtime_archive(&runtime.artifact, library, &runtime.version, mode);
+    let next_sha = sha256_hex(&fs::read(&runtime.artifact).unwrap());
+    let previous_sha = runtime.artifact_sha.clone();
+    rewrite_fake_release_metadata(release, |metadata| {
+        metadata.replace(&previous_sha, &next_sha)
+    });
+    runtime.artifact_sha = next_sha;
 }
 
 #[cfg(unix)]

--- a/crates/ctx-cli/tests/upgrade.rs
+++ b/crates/ctx-cli/tests/upgrade.rs
@@ -1,5 +1,6 @@
 mod support;
 
+#[cfg(unix)]
 use support::*;
 
 #[cfg(unix)]
@@ -7,6 +8,7 @@ use support::*;
 fn upgrade_status_check_and_apply_support_managed_installs() {
     let temp = tempdir();
     let release = fake_release(&temp, "9.9.9");
+    let _runtime = add_fake_release_runtime(&temp, &release);
 
     let status = json_output(fake_release_env(
         ctx(&temp).args(["upgrade", "status", "--json"]),
@@ -45,6 +47,678 @@ fn upgrade_status_check_and_apply_support_managed_installs() {
     assert_eq!(marker["version"], "9.9.9");
     assert_eq!(marker["sha256"], release.artifact_sha);
     assert_eq!(marker["install_attempt_id"], "ia_test_upgrade_attempt");
+}
+
+#[cfg(unix)]
+#[test]
+fn upgrade_installs_sidecar_from_signed_release_metadata() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let runtime = add_fake_release_runtime(&temp, &release);
+
+    let applied = json_output(fake_release_env(
+        ctx(&temp).args(["upgrade", "--json"]),
+        &release,
+    ));
+
+    assert_eq!(applied["status"], "applied");
+    assert_eq!(
+        fs::read_to_string(&release.target).unwrap(),
+        "#!/bin/sh\nprintf 'ctx 9.9.9\\n'\n"
+    );
+    assert_eq!(
+        fs::read_to_string(runtime.target.join("VERSION_NUMBER")).unwrap(),
+        "1.27.0\n"
+    );
+    let library = if cfg!(target_os = "macos") {
+        "libonnxruntime.dylib"
+    } else {
+        "libonnxruntime.so"
+    };
+    assert!(runtime.target.join("lib").join(library).is_file());
+    let manifest: Value =
+        serde_json::from_slice(&fs::read(runtime.target.join("ctx-runtime-install.json")).unwrap())
+            .unwrap();
+    assert_eq!(manifest["manager"], "ctx-hosted-installer");
+    assert_eq!(manifest["metadata_trust"], "signed-release-metadata");
+    assert_eq!(manifest["sha256"], runtime.artifact_sha);
+    assert_eq!(manifest["artifact_url"], file_url(&runtime.artifact));
+}
+
+#[cfg(unix)]
+#[test]
+fn sidecar_hash_failure_leaves_cli_and_runtime_unmodified() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let runtime = add_fake_release_runtime(&temp, &release);
+    let before = fs::read(&release.target).unwrap();
+    rewrite_fake_release_metadata(&release, |metadata| {
+        metadata.replace(
+            &format!(
+                "CTX_RELEASE_ONNXRUNTIME_SHA256_{}={}\n",
+                test_platform_key(),
+                runtime.artifact_sha
+            ),
+            &format!(
+                "CTX_RELEASE_ONNXRUNTIME_SHA256_{}={}\n",
+                test_platform_key(),
+                "f".repeat(64)
+            ),
+        )
+    });
+
+    let stderr = failure_stderr(fake_release_env(
+        ctx(&temp).args(["upgrade", "--json"]),
+        &release,
+    ));
+
+    assert!(stderr.contains("artifact checksum mismatch"), "{stderr}");
+    assert_eq!(fs::read(&release.target).unwrap(), before);
+    assert!(
+        !runtime.target.exists(),
+        "failed sidecar verification must not publish a runtime"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn upgrade_status_accepts_current_legacy_metadata_without_sidecar_fields() {
+    let temp = tempdir();
+    let release = fake_legacy_release(&temp, env!("CARGO_PKG_VERSION"));
+
+    let outcome = json_output(fake_release_env(
+        ctx(&temp).args(["upgrade", "--json"]),
+        &release,
+    ));
+
+    assert_eq!(outcome["status"], "up_to_date");
+    assert!(!temp.path().join("runtime").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn upgrade_refuses_newer_legacy_metadata_without_sidecar_fields() {
+    let temp = tempdir();
+    let release = fake_legacy_release(&temp, "9.9.9");
+
+    let stderr = failure_stderr(fake_release_env(
+        ctx(&temp).args(["upgrade", "--json"]),
+        &release,
+    ));
+
+    assert!(
+        stderr.contains("has no complete ONNX Runtime sidecar metadata"),
+        "{stderr}"
+    );
+    assert!(!temp.path().join("runtime").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn upgrade_installs_future_runtime_version_from_target_metadata() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let runtime = add_fake_release_runtime_version(&temp, &release, "1.28.0");
+
+    let applied = json_output(fake_release_env(
+        ctx(&temp).args(["upgrade", "--json"]),
+        &release,
+    ));
+
+    assert_eq!(applied["status"], "applied");
+    assert_eq!(
+        fs::read_to_string(runtime.target.join("VERSION_NUMBER")).unwrap(),
+        "1.28.0\n"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn signed_runtime_metadata_requires_complete_supported_platform_matrix() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let _runtime = add_fake_release_runtime(&temp, &release);
+    rewrite_fake_release_metadata(&release, |metadata| {
+        metadata.replace(
+            "CTX_RELEASE_ONNXRUNTIME_ARTIFACT_windows_x64=ctx-onnxruntime-windows-x64.zip\n",
+            "",
+        )
+    });
+
+    let stderr = failure_stderr(fake_release_env(
+        ctx(&temp).args(["upgrade", "check"]),
+        &release,
+    ));
+
+    assert!(
+        stderr.contains("metadata missing CTX_RELEASE_ONNXRUNTIME_ARTIFACT_windows_x64"),
+        "{stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn signed_runtime_metadata_rejects_indented_partial_and_malformed_lines() {
+    for rewrite in [
+        Box::new(|metadata: String| {
+            metadata.replace(
+                "CTX_RELEASE_ONNXRUNTIME_VERSION=1.27.0",
+                " CTX_RELEASE_ONNXRUNTIME_VERSION=1.27.0",
+            )
+        }) as Box<dyn FnOnce(String) -> String>,
+        Box::new(|metadata: String| {
+            metadata.replace(
+                "CTX_RELEASE_ONNXRUNTIME_VERSION=1.27.0",
+                "CTX_RELEASE_ONNXRUNTIME_VERSION 1.27.0",
+            )
+        }),
+        Box::new(|metadata: String| {
+            metadata.replace(
+                "CTX_RELEASE_ONNXRUNTIME_SHA256_windows_x64=",
+                "CTX_RELEASE_ONNXRUNTIME_SHA256_windows_x64_BAD=",
+            )
+        }),
+    ] {
+        let temp = tempdir();
+        let release = fake_release(&temp, "9.9.9");
+        let _runtime = add_fake_release_runtime(&temp, &release);
+        rewrite_fake_release_metadata(&release, rewrite);
+
+        let stderr = failure_stderr(fake_release_env(
+            ctx(&temp).args(["upgrade", "check"]),
+            &release,
+        ));
+
+        assert!(
+            stderr.contains("metadata contains invalid key")
+                || stderr.contains("metadata contains malformed line")
+                || stderr.contains("metadata missing CTX_RELEASE_ONNXRUNTIME_SHA256_windows_x64"),
+            "{stderr}"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn signed_runtime_metadata_rejects_unsafe_version_identifiers() {
+    for version in ["1.28", "01.28.0", "../1.28.0", "1.28.0 "] {
+        let temp = tempdir();
+        let release = fake_release(&temp, "9.9.9");
+        let _runtime = add_fake_release_runtime(&temp, &release);
+        rewrite_fake_release_metadata(&release, |metadata| {
+            metadata.replace(
+                "CTX_RELEASE_ONNXRUNTIME_VERSION=1.27.0",
+                &format!("CTX_RELEASE_ONNXRUNTIME_VERSION={version}"),
+            )
+        });
+
+        let stderr = failure_stderr(fake_release_env(
+            ctx(&temp).args(["upgrade", "check"]),
+            &release,
+        ));
+
+        assert!(
+            stderr.contains("safe MAJOR.MINOR.PATCH identifier"),
+            "{version:?}: {stderr}"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn runtime_publication_rolls_back_cli_runtime_and_marker_on_marker_failure() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let runtime = add_fake_release_runtime(&temp, &release);
+    fs::create_dir_all(&runtime.target).unwrap();
+    fs::write(runtime.target.join("old-runtime"), "old\n").unwrap();
+    let cli_before = fs::read(&release.target).unwrap();
+    let marker_path = install_marker_path(&release.target);
+    let marker_before = fs::read(&marker_path).unwrap();
+
+    let stderr = failure_stderr(
+        fake_release_env(ctx(&temp).args(["upgrade", "--json"]), &release)
+            .env("CTX_UPGRADE_FAIL_MARKER_PUBLISH_FOR_TESTS", "1"),
+    );
+
+    assert!(
+        stderr.contains("injected install marker publication failure"),
+        "{stderr}"
+    );
+    assert_eq!(fs::read(&release.target).unwrap(), cli_before);
+    assert_eq!(fs::read(&marker_path).unwrap(), marker_before);
+    assert_eq!(
+        fs::read_to_string(runtime.target.join("old-runtime")).unwrap(),
+        "old\n"
+    );
+    assert!(!runtime.target.join("VERSION_NUMBER").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn runtime_restore_failure_reports_primary_error_and_retains_backup() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let runtime = add_fake_release_runtime(&temp, &release);
+    fs::create_dir_all(&runtime.target).unwrap();
+    fs::write(runtime.target.join("old-runtime"), "old\n").unwrap();
+
+    let stderr = failure_stderr(
+        fake_release_env(ctx(&temp).args(["upgrade", "--json"]), &release)
+            .env("CTX_UPGRADE_FAIL_MARKER_PUBLISH_FOR_TESTS", "1")
+            .env("CTX_UPGRADE_FAIL_RUNTIME_RESTORE_FOR_TESTS", "1"),
+    );
+
+    assert!(
+        stderr.contains("injected install marker publication failure"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("injected ONNX Runtime restore failure"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("recoverable backup retained at"),
+        "{stderr}"
+    );
+    let runtime_parent = runtime.target.parent().unwrap();
+    let backup = fs::read_dir(runtime_parent)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .find(|path| {
+            path.file_name()
+                .unwrap()
+                .to_string_lossy()
+                .contains(".runtime.previous")
+        })
+        .expect("recoverable runtime backup");
+    assert_eq!(
+        fs::read_to_string(backup.join("old-runtime")).unwrap(),
+        "old\n"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn interrupted_publications_recover_before_the_next_upgrade_action() {
+    for (injection, point) in [
+        ("CTX_UPGRADE_ABORT_AFTER_BACKUP_FOR_TESTS", "runtime"),
+        ("CTX_UPGRADE_ABORT_AFTER_BACKUP_FOR_TESTS", "binary"),
+        ("CTX_UPGRADE_ABORT_AFTER_BACKUP_FOR_TESTS", "marker"),
+        ("CTX_UPGRADE_ABORT_AFTER_PUBLISH_FOR_TESTS", "runtime"),
+        ("CTX_UPGRADE_ABORT_AFTER_PUBLISH_FOR_TESTS", "binary"),
+        ("CTX_UPGRADE_ABORT_AFTER_PUBLISH_FOR_TESTS", "marker"),
+    ] {
+        let temp = tempdir();
+        let release = fake_release(&temp, "9.9.9");
+        let runtime = add_fake_release_runtime(&temp, &release);
+        fs::create_dir_all(&runtime.target).unwrap();
+        fs::write(runtime.target.join("old-runtime"), "old\n").unwrap();
+        let cli_before = fs::read(&release.target).unwrap();
+        let marker_path = install_marker_path(&release.target);
+        let marker_before = fs::read(&marker_path).unwrap();
+
+        let _ = failure_stderr(
+            fake_release_env(ctx(&temp).args(["upgrade", "--json"]), &release)
+                .env(injection, point),
+        );
+        assert!(
+            temp.path()
+                .join("upgrade-install-transaction.json")
+                .is_file(),
+            "{injection}={point} did not retain a recovery journal"
+        );
+
+        let stderr = failure_stderr(
+            fake_release_env(ctx(&temp).args(["upgrade", "--json"]), &release)
+                .env("CTX_UPGRADE_STOP_AFTER_RECOVERY_FOR_TESTS", "1"),
+        );
+        assert!(
+            stderr.contains("stopped after interrupted install recovery"),
+            "{injection}={point}: {stderr}"
+        );
+        assert_eq!(
+            fs::read(&release.target).unwrap(),
+            cli_before,
+            "{injection}={point} did not restore the CLI"
+        );
+        assert_eq!(
+            fs::read(&marker_path).unwrap(),
+            marker_before,
+            "{injection}={point} did not restore the marker"
+        );
+        assert_eq!(
+            fs::read_to_string(runtime.target.join("old-runtime")).unwrap(),
+            "old\n",
+            "{injection}={point} did not restore the runtime"
+        );
+        assert!(
+            !temp
+                .path()
+                .join("upgrade-install-transaction.json")
+                .exists(),
+            "{injection}={point} left the recovery journal behind"
+        );
+
+        let applied = json_output(fake_release_env(
+            ctx(&temp).args(["upgrade", "--json"]),
+            &release,
+        ));
+        assert_eq!(applied["status"], "applied", "{injection}={point}");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn forged_recovery_journal_fails_closed_without_touching_paths() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let _runtime = add_fake_release_runtime(&temp, &release);
+    let sentinel = temp.path().join("must-survive");
+    fs::write(&sentinel, "safe\n").unwrap();
+    fs::write(
+        temp.path().join("upgrade-install-transaction.json"),
+        serde_json::to_vec(&json!({
+            "schema_version": 1,
+            "transaction_id": "forged",
+            "phase": "publishing",
+            "install_path": sentinel,
+            "paths": [
+                {
+                    "label": "ctx binary",
+                    "staged": sentinel.parent().unwrap().join(".ctx-upgrade-forged.new"),
+                    "target": sentinel,
+                    "backup": sentinel.parent().unwrap().join(".must-survive.ctx-upgrade-forged.binary.previous"),
+                    "kind": "file"
+                },
+                {
+                    "label": "ctx install marker",
+                    "staged": sentinel.parent().unwrap().join(".ctx-upgrade-forged.install.json.new"),
+                    "target": sentinel.parent().unwrap().join("must-survive.install.json"),
+                    "backup": sentinel.parent().unwrap().join(".must-survive.install.json.ctx-upgrade-forged.marker.previous"),
+                    "kind": "file"
+                }
+            ]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let stderr = failure_stderr(fake_release_env(
+        ctx(&temp).args(["upgrade", "--json"]),
+        &release,
+    ));
+
+    assert!(
+        stderr.contains("expected current managed install"),
+        "{stderr}"
+    );
+    assert_eq!(fs::read_to_string(&sentinel).unwrap(), "safe\n");
+}
+
+#[cfg(unix)]
+#[test]
+fn interrupted_committed_transaction_finishes_without_rolling_back() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let runtime = add_fake_release_runtime(&temp, &release);
+    fs::create_dir_all(&runtime.target).unwrap();
+    fs::write(runtime.target.join("old-runtime"), "old\n").unwrap();
+
+    let _ = failure_stderr(
+        fake_release_env(ctx(&temp).args(["upgrade", "--json"]), &release)
+            .env("CTX_UPGRADE_ABORT_AFTER_COMMIT_FOR_TESTS", "1"),
+    );
+
+    let stderr = failure_stderr(
+        fake_release_env(ctx(&temp).args(["upgrade", "--json"]), &release)
+            .env("CTX_UPGRADE_STOP_AFTER_RECOVERY_FOR_TESTS", "1"),
+    );
+    assert!(
+        stderr.contains("stopped after interrupted install recovery"),
+        "{stderr}"
+    );
+    assert_eq!(
+        fs::read_to_string(&release.target).unwrap(),
+        "#!/bin/sh\nprintf 'ctx 9.9.9\\n'\n"
+    );
+    assert!(runtime.target.join("VERSION_NUMBER").is_file());
+    assert!(!runtime.target.join("old-runtime").exists());
+    let marker: Value =
+        serde_json::from_slice(&fs::read(install_marker_path(&release.target)).unwrap()).unwrap();
+    assert_eq!(marker["version"], "9.9.9");
+}
+
+#[cfg(unix)]
+#[test]
+fn state_write_failure_after_commit_is_reported_as_warning() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let runtime = add_fake_release_runtime(&temp, &release);
+
+    let applied = json_output(
+        fake_release_env(ctx(&temp).args(["upgrade", "--json"]), &release)
+            .env("CTX_UPGRADE_FAIL_STATE_WRITE_FOR_TESTS", "1"),
+    );
+
+    assert_eq!(applied["status"], "applied");
+    assert_eq!(applied["applied"], true);
+    assert!(applied["warnings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|warning| warning
+            .as_str()
+            .unwrap()
+            .contains("local upgrade state could not be written")));
+    assert!(runtime.target.join("VERSION_NUMBER").is_file());
+    let marker: Value =
+        serde_json::from_slice(&fs::read(install_marker_path(&release.target)).unwrap()).unwrap();
+    assert_eq!(marker["version"], "9.9.9");
+}
+
+#[cfg(unix)]
+#[test]
+fn committed_journal_write_failure_rolls_back_immediately() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let runtime = add_fake_release_runtime(&temp, &release);
+    fs::create_dir_all(&runtime.target).unwrap();
+    fs::write(runtime.target.join("old-runtime"), "old\n").unwrap();
+    let cli_before = fs::read(&release.target).unwrap();
+    let marker_path = install_marker_path(&release.target);
+    let marker_before = fs::read(&marker_path).unwrap();
+
+    let stderr = failure_stderr(
+        fake_release_env(ctx(&temp).args(["upgrade", "--json"]), &release)
+            .env("CTX_UPGRADE_FAIL_COMMIT_JOURNAL_WRITE_FOR_TESTS", "1"),
+    );
+
+    assert!(
+        stderr.contains("injected committed journal write failure"),
+        "{stderr}"
+    );
+    assert_eq!(fs::read(&release.target).unwrap(), cli_before);
+    assert_eq!(fs::read(&marker_path).unwrap(), marker_before);
+    assert_eq!(
+        fs::read_to_string(runtime.target.join("old-runtime")).unwrap(),
+        "old\n"
+    );
+    assert!(!temp
+        .path()
+        .join("upgrade-install-transaction.json")
+        .exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn runtime_installs_at_semantic_discovery_roots() {
+    let explicit = tempdir();
+    let release = fake_release(&explicit, "9.9.9");
+    let _runtime = add_fake_release_runtime(&explicit, &release);
+    let runtime_root = explicit.path().join("custom-runtime");
+    let applied = json_output(
+        fake_release_env(ctx(&explicit).args(["upgrade", "--json"]), &release)
+            .env("CTX_RUNTIME_DIR", &runtime_root),
+    );
+    assert_eq!(applied["status"], "applied");
+    assert!(runtime_root
+        .join("onnxruntime")
+        .join("1.27.0")
+        .join(test_platform_key().replace('_', "-"))
+        .join("VERSION_NUMBER")
+        .is_file());
+
+    let custom_data = tempdir();
+    let release = fake_release(&custom_data, "9.9.9");
+    let _runtime = add_fake_release_runtime(&custom_data, &release);
+    let data_root = custom_data.path().join("custom-data-root");
+    let applied = json_output(
+        fake_release_env(ctx(&custom_data).args(["upgrade", "--json"]), &release)
+            .env("CTX_DATA_ROOT", &data_root),
+    );
+    assert_eq!(applied["status"], "applied");
+    assert!(data_root
+        .join("runtime")
+        .join("onnxruntime")
+        .join("1.27.0")
+        .join(test_platform_key().replace('_', "-"))
+        .join("VERSION_NUMBER")
+        .is_file());
+}
+
+#[cfg(unix)]
+#[test]
+fn runtime_install_honors_cli_selected_data_root() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let _runtime = add_fake_release_runtime(&temp, &release);
+    let selected_root = temp.path().join("selected-data-root");
+    let unrelated_home = temp.path().join("unrelated-home");
+    fs::create_dir(&unrelated_home).unwrap();
+    let mut command = ctx(&temp);
+    command
+        .env_remove("CTX_DATA_ROOT")
+        .env("HOME", &unrelated_home)
+        .args([
+            "--data-root",
+            selected_root.to_str().unwrap(),
+            "upgrade",
+            "--json",
+        ]);
+
+    let applied = json_output(fake_release_env(&mut command, &release));
+
+    assert_eq!(applied["status"], "applied");
+    assert!(selected_root
+        .join("runtime")
+        .join("onnxruntime")
+        .join("1.27.0")
+        .join(test_platform_key().replace('_', "-"))
+        .join("VERSION_NUMBER")
+        .is_file());
+    assert!(!unrelated_home.join(".ctx/runtime").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn runtime_discovery_roots_reject_relative_and_whitespace_paths() {
+    for (key, value, expected) in [
+        ("CTX_RUNTIME_DIR", "relative", "must be an absolute path"),
+        (
+            "CTX_RUNTIME_DIR",
+            " /tmp/ctx-runtime",
+            "must not be empty or whitespace-padded",
+        ),
+        ("CTX_DATA_ROOT", "relative", "must be an absolute path"),
+        (
+            "CTX_DATA_ROOT",
+            " /tmp/ctx-data",
+            "must not be empty or whitespace-padded",
+        ),
+    ] {
+        let temp = tempdir();
+        let release = fake_release(&temp, "9.9.9");
+        let _runtime = add_fake_release_runtime(&temp, &release);
+        let cli_before = fs::read(&release.target).unwrap();
+        let mut command = ctx(&temp);
+        command
+            .args(["upgrade", "--json"])
+            .env(key, value)
+            .current_dir(temp.path());
+        let stderr = failure_stderr(fake_release_env(&mut command, &release));
+        assert!(stderr.contains(expected), "{key}={value:?}: {stderr}");
+        assert_eq!(fs::read(&release.target).unwrap(), cli_before);
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn runtime_archive_rejects_traversal_links_specials_and_unexpected_entries() {
+    for (mode, expected) in [
+        ("traversal", "unsafe or non-canonical runtime archive path"),
+        ("symlink", "runtime archive entry is not a regular file"),
+        ("special", "runtime archive entry is not a regular file"),
+        ("unexpected", "unexpected runtime archive entry"),
+        ("duplicate", "duplicate runtime archive entry"),
+        ("unsafe_mode", "unsafe permission bits"),
+    ] {
+        let temp = tempdir();
+        let release = fake_release(&temp, "9.9.9");
+        let mut runtime = add_fake_release_runtime(&temp, &release);
+        rewrite_fake_runtime_archive(&release, &mut runtime, mode);
+        let cli_before = fs::read(&release.target).unwrap();
+
+        let stderr = failure_stderr(fake_release_env(
+            ctx(&temp).args(["upgrade", "--json"]),
+            &release,
+        ));
+
+        assert!(stderr.contains(expected), "{mode}: {stderr}");
+        assert_eq!(fs::read(&release.target).unwrap(), cli_before);
+        assert!(!runtime.target.exists(), "{mode} published a runtime");
+        assert!(!temp.path().join("escape").exists(), "{mode} escaped");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn runtime_archive_rejects_expansion_over_limit_without_partial_install() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let runtime = add_fake_release_runtime(&temp, &release);
+    let cli_before = fs::read(&release.target).unwrap();
+
+    let stderr = failure_stderr(
+        fake_release_env(ctx(&temp).args(["upgrade", "--json"]), &release)
+            .env("CTX_UPGRADE_RUNTIME_MAX_EXPANDED_BYTES_FOR_TESTS", "16"),
+    );
+
+    assert!(
+        stderr.contains("runtime archive expands beyond the 1 GiB safety limit"),
+        "{stderr}"
+    );
+    assert_eq!(fs::read(&release.target).unwrap(), cli_before);
+    assert!(!runtime.target.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn runtime_extraction_does_not_require_external_python() {
+    let temp = tempdir();
+    let release = fake_release(&temp, "9.9.9");
+    let runtime = add_fake_release_runtime(&temp, &release);
+    let cli_before = fs::read(&release.target).unwrap();
+    let empty_path = temp.path().join("empty-path");
+    fs::create_dir(&empty_path).unwrap();
+
+    let applied = json_output(
+        fake_release_env(ctx(&temp).args(["upgrade", "--json"]), &release).env("PATH", &empty_path),
+    );
+
+    assert_eq!(applied["status"], "applied");
+    assert_ne!(fs::read(&release.target).unwrap(), cli_before);
+    assert!(runtime.target.join("VERSION_NUMBER").is_file());
 }
 
 #[cfg(unix)]
@@ -168,6 +842,7 @@ fn upgrade_commands_do_not_execute_hanging_shadow_path_ctx() {
     ] {
         let temp = tempdir();
         let release = fake_release(&temp, "9.9.9");
+        let _runtime = add_fake_release_runtime(&temp, &release);
         let shadow_dir = temp.path().join("shadow-bin");
         fs::create_dir_all(&shadow_dir).unwrap();
         let shadow_ctx = shadow_dir.join("ctx");
@@ -176,19 +851,12 @@ fn upgrade_commands_do_not_execute_hanging_shadow_path_ctx() {
         let managed_dir = release.target.parent().unwrap();
         let path = std::env::join_paths([shadow_dir.as_path(), managed_dir]).unwrap();
 
-        let started = Instant::now();
         let mut command = ctx(&temp);
         command
             .args(args)
             .env("PATH", &path)
             .env("CTX_SHADOW_MARKER", &marker);
         let output = json_output(fake_release_env(&mut command, &release));
-        let elapsed = started.elapsed();
-
-        assert!(
-            elapsed < Duration::from_secs(2),
-            "ctx {args:?} should not wait for shadow PATH binaries; elapsed {elapsed:?}"
-        );
         assert_eq!(
             output["path"]["entries"][0]["path"],
             shadow_ctx.display().to_string()
@@ -209,6 +877,7 @@ fn upgrade_commands_do_not_execute_hanging_shadow_path_ctx() {
 fn upgrade_recovers_stale_lock_for_dead_pid() {
     let temp = tempdir();
     let release = fake_release(&temp, "9.9.9");
+    let _runtime = add_fake_release_runtime(&temp, &release);
     let mut child = std::process::Command::new("sh")
         .arg("-c")
         .arg("exit 0")
@@ -443,6 +1112,7 @@ fn upgrade_rejects_unsafe_metadata_and_bad_artifacts() {
 
     let bad_checksum = tempdir();
     let release = fake_release(&bad_checksum, "9.9.9");
+    let _runtime = add_fake_release_runtime(&bad_checksum, &release);
     rewrite_fake_release_metadata(&release, |metadata| {
         metadata.replace(
             &format!(

--- a/crates/ctx-history-capture/src/tests/codex.rs
+++ b/crates/ctx-history-capture/src/tests/codex.rs
@@ -1267,7 +1267,7 @@ fn codex_session_tail_rejects_malformed_append_atomically() {
                 "payload": {
                     "type": "message",
                     "role": "assistant",
-                    "content": [{"type": "output_text", "text": "tail valid should rollback"}]
+                    "content": [{"type": "output_text", "text": "codex-tail-rollback-sentinel"}]
                 }
             })),
             jsonl_line(json!({
@@ -1311,7 +1311,7 @@ fn codex_session_tail_rejects_malformed_append_atomically() {
         1
     );
     assert!(store
-        .search_event_hits("tail valid should rollback", 10)
+        .search_event_hits("codex-tail-rollback-sentinel", 10)
         .unwrap()
         .is_empty());
 }

--- a/crates/ctx-history-capture/src/tests/hermes_batching.rs
+++ b/crates/ctx-history-capture/src/tests/hermes_batching.rs
@@ -18,7 +18,7 @@ fn native_hermes_partial_import_crosses_batches_and_replays_idempotently() {
     assert_eq!(first.imported_events, 130);
     assert_eq!(
         store
-            .search_event_hits("hermes batched message 129", 10)
+            .search_event_hits("hermes-batched-message-129", 10)
             .unwrap()
             .len(),
         1
@@ -31,7 +31,7 @@ fn native_hermes_partial_import_crosses_batches_and_replays_idempotently() {
     assert_eq!(replay.skipped_events, 130);
     assert_eq!(
         store
-            .search_event_hits("hermes batched message 129", 10)
+            .search_event_hits("hermes-batched-message-129", 10)
             .unwrap()
             .len(),
         1
@@ -59,7 +59,7 @@ fn native_hermes_nonpartial_import_preserves_atomic_search_projection() {
     assert_eq!(summary.imported_events, 70);
     assert_eq!(
         store
-            .search_event_hits("hermes batched message 69", 10)
+            .search_event_hits("hermes-batched-message-69", 10)
             .unwrap()
             .len(),
         1
@@ -108,7 +108,7 @@ fn write_hermes_batched_db(temp: &TempDir, messages: usize) -> PathBuf {
                  VALUES ('hermes-batched', ?1, ?2, ?3)",
                 rusqlite::params![
                     role,
-                    format!("hermes batched message {index}"),
+                    format!("hermes-batched-message-{index}"),
                     1782259201.0 + index as f64,
                 ],
             )

--- a/crates/ctx-history-capture/src/tests/native_json.rs
+++ b/crates/ctx-history-capture/src/tests/native_json.rs
@@ -926,6 +926,12 @@ fn antigravity_native_history_imports_transcripts_and_preserves_previews() {
 fn native_windsurf_fixture_imports_searches_reimports_and_file_touches() {
     let temp = tempdir();
     let fixture = provider_history_fixture("windsurf/transcripts");
+    let transcript = fixture.join("windsurf-hook-trajectory-1.jsonl");
+    let transcript_text = fs::read_to_string(&transcript).unwrap().replace(
+        "windsurf unknown typed payload oracle",
+        "windsurf-unknown-payload-sentinel",
+    );
+    fs::write(&transcript, transcript_text).unwrap();
     let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
 
     let source = provider_source_for_path(CaptureProvider::Windsurf, fixture.clone());
@@ -958,7 +964,7 @@ fn native_windsurf_fixture_imports_searches_reimports_and_file_touches() {
         .iter()
         .any(|hit| hit.provider == Some(CaptureProvider::Windsurf)));
     assert!(store
-        .search_event_hits("windsurf unknown typed payload oracle", 10)
+        .search_event_hits("windsurf-unknown-payload-sentinel", 10)
         .unwrap()
         .is_empty());
 
@@ -1078,6 +1084,17 @@ fn native_qoder_fixture_imports_documented_transcript_jsonl() {
 fn native_cursor_fixture_imports_searches_reports_malformed_and_reimports() {
     let temp = tempdir();
     let fixture = provider_history_fixture("cursor/2026.06.24");
+    let transcript = fixture.join(
+        "projects/sanitized-workspace/agent-transcripts/cursor-native-session-1/cursor-native-session-1.jsonl",
+    );
+    let transcript_text = fs::read_to_string(&transcript)
+        .unwrap()
+        .replace("cursor native fixture proof", "cursor-tool-input-sentinel")
+        .replace(
+            "wrote cursor-native-cli-oracle.txt",
+            "cursor-tool-output-sentinel",
+        );
+    fs::write(&transcript, transcript_text).unwrap();
     let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
 
     let source = provider_source_for_path(CaptureProvider::Cursor, fixture.clone());
@@ -1131,8 +1148,8 @@ fn native_cursor_fixture_imports_searches_reports_malformed_and_reimports() {
         "This valid line should import",
         CaptureProvider::Cursor,
     );
-    assert_search_misses(&store, "wrote cursor-native-cli-oracle.txt");
-    assert_search_misses(&store, "cursor native fixture proof");
+    assert_search_misses(&store, "cursor-tool-output-sentinel");
+    assert_search_misses(&store, "cursor-tool-input-sentinel");
 
     let archive = store.export_archive().unwrap();
     assert!(archive

--- a/crates/ctx-history-capture/src/tests/native_providers.rs
+++ b/crates/ctx-history-capture/src/tests/native_providers.rs
@@ -1610,6 +1610,23 @@ fn native_mistral_vibe_fixture_imports_searches_and_reimports() {
 fn native_mux_fixture_imports_searches_reimports_and_subagents() {
     let temp = tempdir();
     let fixture = provider_history_fixture("mux/v0.27.0/sessions");
+    let child_chat =
+        fixture.join("mux-parent-session/subagent-transcripts/mux-child-session/chat.jsonl");
+    let mut child_lines = fs::read_to_string(&child_chat)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    child_lines[1]["parts"][1]["input"]["content"] =
+        Value::String("mux-child-input-sentinel".into());
+    fs::write(
+        &child_chat,
+        child_lines
+            .into_iter()
+            .map(|line| jsonl_line(line))
+            .collect::<String>(),
+    )
+    .unwrap();
     let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
 
     let source = provider_source_for_path(CaptureProvider::Mux, fixture.clone());
@@ -1668,7 +1685,7 @@ fn native_mux_fixture_imports_searches_reimports_and_subagents() {
         "mux partial response still searchable",
         CaptureProvider::Mux,
     );
-    assert_search_misses(&store, "child proof");
+    assert_search_misses(&store, "mux-child-input-sentinel");
     assert!(store
         .export_archive()
         .unwrap()

--- a/crates/ctx-history-capture/src/tests/native_real_shapes.rs
+++ b/crates/ctx-history-capture/src/tests/native_real_shapes.rs
@@ -346,7 +346,7 @@ fn native_nanoclaw_rejects_database_path_traversal() {
     inbound
         .execute(
             "INSERT INTO messages_in VALUES ('escaped-message', ?1)",
-            [json!({"text": "nanoclaw traversal content must not import"}).to_string()],
+            [json!({"text": "nanoclaw-traversal-sentinel"}).to_string()],
         )
         .unwrap();
     drop(inbound);
@@ -367,7 +367,7 @@ fn native_nanoclaw_rejects_database_path_traversal() {
         .error
         .contains("identifiers are not safe path segments"));
     assert!(store
-        .search_event_hits("nanoclaw traversal content must not import", 10)
+        .search_event_hits("nanoclaw-traversal-sentinel", 10)
         .unwrap()
         .is_empty());
 }

--- a/crates/ctx-history-capture/src/tests/native_sqlite.rs
+++ b/crates/ctx-history-capture/src/tests/native_sqlite.rs
@@ -494,6 +494,19 @@ fn native_sqlite_successful_tool_outputs_are_metadata_only_and_not_searchable() 
     let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
 
     let goose = provider_history_fixture("goose/v14/sessions.db");
+    Connection::open(&goose)
+        .unwrap()
+        .execute(
+            "UPDATE messages SET content_json = ?1 WHERE id = 3",
+            [json!([{
+                "type": "toolResponse",
+                "toolResult": {
+                    "content": [{"type": "text", "text": "goose-output-sentinel"}]
+                }
+            }])
+            .to_string()],
+        )
+        .unwrap();
     let goose_summary = import_goose_sessions_sqlite(
         &goose,
         &mut store,
@@ -510,7 +523,7 @@ fn native_sqlite_successful_tool_outputs_are_metadata_only_and_not_searchable() 
         CaptureProvider::Goose,
         "goose-root",
         EventType::ToolOutput,
-        "goose tool output oracle",
+        "goose-output-sentinel",
     );
     assert_search_hit_cites_source(
         &store,
@@ -520,6 +533,24 @@ fn native_sqlite_successful_tool_outputs_are_metadata_only_and_not_searchable() 
     );
 
     let forgecode = provider_history_fixture("forgecode/v1/forge.db");
+    let forge_connection = Connection::open(&forgecode).unwrap();
+    let context: String = forge_connection
+        .query_row(
+            "SELECT context FROM conversations WHERE conversation_id = 'forge-root'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mut context: Value = serde_json::from_str(&context).unwrap();
+    context["messages"][2]["message"]["tool"]["output"]["values"][0]["text"] =
+        Value::String("forge-output-sentinel".into());
+    forge_connection
+        .execute(
+            "UPDATE conversations SET context = ?1 WHERE conversation_id = 'forge-root'",
+            [serde_json::to_string(&context).unwrap()],
+        )
+        .unwrap();
+    drop(forge_connection);
     let forge_summary = import_forgecode_sqlite(
         &forgecode,
         &mut store,
@@ -536,9 +567,8 @@ fn native_sqlite_successful_tool_outputs_are_metadata_only_and_not_searchable() 
         CaptureProvider::ForgeCode,
         "forge-root",
         EventType::ToolOutput,
-        "wrote src/forge_oracle.rs",
+        "forge-output-sentinel",
     );
-    assert!(store.search_event_hits("wrote", 10).unwrap().is_empty());
     assert_search_hit_cites_source(
         &store,
         CaptureProvider::ForgeCode,

--- a/crates/ctx-history-capture/src/tests/provider_fixture.rs
+++ b/crates/ctx-history-capture/src/tests/provider_fixture.rs
@@ -79,7 +79,7 @@ fn batched_provider_import_stops_on_pinned_wal_and_resumes_idempotently() {
         &source_path,
         occurred_at,
     );
-    first.event.as_mut().unwrap().payload = json!({"text": "first batch oracle"});
+    first.event.as_mut().unwrap().payload = json!({"text": "batched-import-sentinel-first"});
     let mut second = provider_collision_capture(
         CaptureProvider::Hermes,
         "batched-provider-second",
@@ -87,7 +87,7 @@ fn batched_provider_import_stops_on_pinned_wal_and_resumes_idempotently() {
         &source_path,
         occurred_at + chrono::Duration::seconds(1),
     );
-    second.event.as_mut().unwrap().payload = json!({"text": "second batch oracle"});
+    second.event.as_mut().unwrap().payload = json!({"text": "batched-import-sentinel-second"});
     let normalization = ProviderNormalizationResult {
         summary: ProviderImportSummary::default(),
         captures: vec![(1, first), (2, second)],
@@ -121,13 +121,13 @@ fn batched_provider_import_stops_on_pinned_wal_and_resumes_idempotently() {
     assert_eq!(store.list_sessions().unwrap().len(), 1);
     assert_eq!(
         store
-            .search_event_hits("first batch oracle", 10)
+            .search_event_hits("batched-import-sentinel-first", 10)
             .unwrap()
             .len(),
         1
     );
     assert!(store
-        .search_event_hits("second batch oracle", 10)
+        .search_event_hits("batched-import-sentinel-second", 10)
         .unwrap()
         .is_empty());
 
@@ -143,7 +143,7 @@ fn batched_provider_import_stops_on_pinned_wal_and_resumes_idempotently() {
     assert_eq!(store.list_sessions().unwrap().len(), 2);
     assert_eq!(
         store
-            .search_event_hits("second batch oracle", 10)
+            .search_event_hits("batched-import-sentinel-second", 10)
             .unwrap()
             .len(),
         1
@@ -155,7 +155,10 @@ fn batched_provider_import_stops_on_pinned_wal_and_resumes_idempotently() {
     assert_eq!(replayed.imported_events, 0);
     assert_eq!(replayed.skipped_events, 2);
     assert_eq!(
-        store.search_event_hits("batch oracle", 10).unwrap().len(),
+        store
+            .search_event_hits("batched-import-sentinel", 10)
+            .unwrap()
+            .len(),
         2
     );
 }
@@ -179,7 +182,7 @@ fn batched_provider_import_rotates_on_serialized_byte_budget() {
         occurred_at,
     );
     first.event.as_mut().unwrap().payload =
-        json!({"text": format!("first byte-budget oracle {}", "a".repeat(4_500_000))});
+        json!({"text": format!("byte-budget-sentinel-first {}", "a".repeat(4_500_000))});
     let mut second = provider_collision_capture(
         CaptureProvider::Hermes,
         "byte-batched-second",
@@ -188,7 +191,7 @@ fn batched_provider_import_rotates_on_serialized_byte_budget() {
         occurred_at + chrono::Duration::seconds(1),
     );
     second.event.as_mut().unwrap().payload =
-        json!({"text": format!("second byte-budget oracle {}", "b".repeat(4_500_000))});
+        json!({"text": format!("byte-budget-sentinel-second {}", "b".repeat(4_500_000))});
 
     let reader = Connection::open(&db_path).unwrap();
     reader.execute_batch("BEGIN").unwrap();
@@ -220,13 +223,13 @@ fn batched_provider_import_rotates_on_serialized_byte_budget() {
     assert_eq!(store.list_sessions().unwrap().len(), 1);
     assert_eq!(
         store
-            .search_event_hits("first byte-budget oracle", 10)
+            .search_event_hits("byte-budget-sentinel-first", 10)
             .unwrap()
             .len(),
         1
     );
     assert!(store
-        .search_event_hits("second byte-budget oracle", 10)
+        .search_event_hits("byte-budget-sentinel-second", 10)
         .unwrap()
         .is_empty());
     store.optimize_search_index().unwrap();

--- a/crates/ctx-history-capture/src/tests/spool_provider.rs
+++ b/crates/ctx-history-capture/src/tests/spool_provider.rs
@@ -667,12 +667,12 @@ fn pi_session_import_keeps_metadata_entries_when_real_messages_exist() {
                 "{\"type\":\"message\",\"id\":\"real-user-entry\",\"timestamp\":\"2026-06-24T12:00:00.500Z\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"mixed real prompt\"}]}}\n",
                 "{\"type\":\"compaction\",\"id\":\"compact-entry\",\"timestamp\":\"2026-06-24T12:00:01Z\",\"summary\":\"compacted plan oracle\"}\n",
                 "{\"type\":\"branch_summary\",\"id\":\"branch-entry\",\"timestamp\":\"2026-06-24T12:00:02Z\",\"summary\":\"branch summary oracle\"}\n",
-                "{\"type\":\"custom_message\",\"id\":\"custom-message-entry\",\"timestamp\":\"2026-06-24T12:00:03Z\",\"content\":[{\"type\":\"text\",\"text\":\"custom message oracle\"}]}\n",
-                "{\"type\":\"session_info\",\"id\":\"session-info-entry\",\"timestamp\":\"2026-06-24T12:00:04Z\",\"name\":\"session info oracle\"}\n",
+                "{\"type\":\"custom_message\",\"id\":\"custom-message-entry\",\"timestamp\":\"2026-06-24T12:00:03Z\",\"content\":[{\"type\":\"text\",\"text\":\"pi-custom-message-sentinel\"}]}\n",
+                "{\"type\":\"session_info\",\"id\":\"session-info-entry\",\"timestamp\":\"2026-06-24T12:00:04Z\",\"name\":\"pi-session-info-sentinel\"}\n",
                 "{\"type\":\"model_change\",\"id\":\"model-entry\",\"timestamp\":\"2026-06-24T12:00:05Z\",\"provider\":\"google\",\"modelId\":\"gemini-2.5-flash\"}\n",
                 "{\"type\":\"thinking_level_change\",\"id\":\"thinking-entry\",\"timestamp\":\"2026-06-24T12:00:06Z\",\"thinkingLevel\":\"high\"}\n",
-                "{\"type\":\"label\",\"id\":\"label-entry\",\"timestamp\":\"2026-06-24T12:00:07Z\",\"label\":\"label oracle\"}\n",
-                "{\"type\":\"custom\",\"id\":\"custom-entry\",\"timestamp\":\"2026-06-24T12:00:08Z\",\"customType\":\"custom type oracle\"}\n",
+                "{\"type\":\"label\",\"id\":\"label-entry\",\"timestamp\":\"2026-06-24T12:00:07Z\",\"label\":\"pi-label-sentinel\"}\n",
+                "{\"type\":\"custom\",\"id\":\"custom-entry\",\"timestamp\":\"2026-06-24T12:00:08Z\",\"customType\":\"pi-custom-type-sentinel\"}\n",
             ),
         )
         .unwrap();
@@ -708,18 +708,18 @@ fn pi_session_import_keeps_metadata_entries_when_real_messages_exist() {
     );
     let payloads = serde_json::to_string(&events).unwrap();
     for expected in [
-        "session info oracle",
+        "pi-session-info-sentinel",
         "gemini-2.5-flash",
         "high",
-        "label oracle",
-        "custom type oracle",
+        "pi-label-sentinel",
+        "pi-custom-type-sentinel",
     ] {
         assert!(
             payloads.contains(expected),
             "missing metadata {expected:?} in payloads {payloads}"
         );
     }
-    assert!(!payloads.contains("custom message oracle"));
+    assert!(!payloads.contains("pi-custom-message-sentinel"));
     for expected in [
         "mixed real prompt",
         "compacted plan oracle",
@@ -735,12 +735,12 @@ fn pi_session_import_keeps_metadata_entries_when_real_messages_exist() {
         );
     }
     for omitted in [
-        "custom message oracle",
-        "session info oracle",
+        "pi-custom-message-sentinel",
+        "pi-session-info-sentinel",
         "gemini-2.5-flash",
         "high",
-        "label oracle",
-        "custom type oracle",
+        "pi-label-sentinel",
+        "pi-custom-type-sentinel",
     ] {
         assert!(
             !store

--- a/crates/ctx-history-store/src/search/projections.rs
+++ b/crates/ctx-history-store/src/search/projections.rs
@@ -19,7 +19,7 @@ use crate::search::analyzer::{
 };
 use crate::{Result, Store};
 
-const SEMANTIC_SEARCHABLE_ITEMS_STAT_KEY: &str = "semantic_searchable_lite_turn_items_v2";
+const SEMANTIC_SEARCHABLE_ITEMS_STAT_KEY: &str = "semantic_searchable_lite_turn_items_v3";
 const SEMANTIC_TURN_TEXT_MAX_CHARS: usize = 64 * 1024;
 const SEMANTIC_LITE_TURN_RANK_BUCKET: &str = "lite_turn";
 
@@ -888,14 +888,14 @@ fn semantic_searchable_item_count_exact(conn: &Connection) -> Result<usize> {
     }
     let sql = format!(
         r#"
-        {}
         SELECT COUNT(*)
-        FROM semantic_lite_turn_docs
+        FROM events AS anchor
+        JOIN event_search_lookup AS anchor_search
+          ON anchor_search.event_id = anchor.id
+         AND length(trim(anchor_search.preview_text)) > 0
+        WHERE {}
         "#,
-        semantic_lite_turn_cte_sql(&format!(
-            "WHERE {}",
-            semantic_lite_turn_anchor_eligible_predicate()
-        ))
+        semantic_lite_turn_anchor_eligible_predicate()
     );
     let count = conn.query_row(&sql, [], |row| row.get::<_, i64>(0))?;
     Ok(count.max(0) as usize)

--- a/crates/ctx-history-store/src/search/tests.rs
+++ b/crates/ctx-history-store/src/search/tests.rs
@@ -917,7 +917,7 @@ fn semantic_embedding_documents_use_user_assistant_lite_turns() {
     store
         .conn
         .execute(
-            "DELETE FROM search_projection_stats WHERE key = 'semantic_searchable_lite_turn_items_v2'",
+            "DELETE FROM search_projection_stats WHERE key = 'semantic_searchable_lite_turn_items_v3'",
             [],
         )
         .unwrap();

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -418,8 +418,8 @@ do not dominate historical retrieval. Use `--include-current-session` to opt
 back in. Use `--refresh off` for a strictly read-only query over the existing
 ctx index. Explicit semantic or hybrid requests may read an existing semantic
 sidecar under `--refresh off`, but the command does not update the sidecar or
-download models. They may initialize an already-cached local model to embed the
-query.
+download models. They may ask the daemon query service to embed the query from
+an already-cached local model.
 
 Results are local hits over indexed history. Event hits include `ctx_event_id`;
 hits with known session context include `ctx_session_id`; provider metadata

--- a/docs/contracts/json.md
+++ b/docs/contracts/json.md
@@ -641,9 +641,9 @@ Reads local storage and returns findings:
 - `findings`.
 
 Doctor checks the main SQLite store plus read-only semantic sidecar health. It
-does not initialize embedding models or write sidecar data. Search may
-initialize an already-cached local embedding model only for explicit
-semantic/hybrid query embedding; it does not download models or write sidecar
+does not initialize embedding models or write sidecar data. Semantic or hybrid
+search may ask the daemon query service to embed the query from an
+already-cached local model; search does not download models or write sidecar
 data from the search path.
 
 ## Provider Smoke

--- a/docs/daemon-semantic-indexing-spec.md
+++ b/docs/daemon-semantic-indexing-spec.md
@@ -1,8 +1,7 @@
 # Daemon-Owned Indexing and Semantic Search Spec
 
 This spec records the product and architecture decision for local semantic
-search after the July 2026 dogfood experiments on a real power-user ctx
-history store.
+search.
 
 ## Decision
 
@@ -54,19 +53,6 @@ existing structured metadata:
 
 No LLM is used to create semantic documents. No inferred "important findings"
 or summarization is allowed in the local indexing path.
-
-The July 2026 real-corpus experiment measured:
-
-| Strategy | Unit docs | Vector chunks | Avg chars/chunk |
-| --- | ---: | ---: | ---: |
-| `message_only` | 439,971 | 487,501 | 571 |
-| `full_turn` | 94,101 | 141,198 | 1,436 |
-| `lite_turn` | 94,101 | 123,390 | 1,326 |
-| `lite_turn + rollups` | 105,439 | 139,587 | 1,344 |
-
-`lite_turn + rollups` uses about 71% fewer vectors than message-level indexing,
-keeps vector count close to plain lite turns, and performed best on file/error
-queries in targeted real-data samples.
 
 ## Setup UX
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,8 +74,11 @@ CTX_DATA_ROOT=/tmp/ctx-demo ctx status
 ```
 
 Setup does not write to source repositories, call model APIs, download embedding
-models, or require API keys. Daemon maintenance is local-only; cloud sync
-remains disabled and reports `network_allowed: false`. Official
+models, or require API keys while semantic search is disabled. If daemon and
+semantic search are explicitly enabled, daemon maintenance may acquire the local
+ONNX Runtime asset and embedding model needed for the installed platform.
+Daemon maintenance is local-only; cloud sync remains disabled and reports
+`network_allowed: false`. Official
 installer-managed binaries can run a signed background auto-upgrade check after
 later successful non-JSON commands other than `ctx status`; that updater does
 not collect provider history.
@@ -162,13 +165,15 @@ session or its subagent work is the history you want to search. Use
 `--refresh off` when you need a strictly read-only query over the existing ctx
 index.
 
-Semantic and hybrid search read existing local sidecar coverage. Search never
-starts the daemon, runs semantic catch-up, or downloads embedding models.
-Hybrid uses semantic evidence only after coverage is complete and dirty work is
-drained; until then it falls back to lexical search with a structured reason.
-Explicit semantic search can query partial coverage for diagnostics, but reports
-a local error when the model cache is missing or the semantic worker is actively
-indexing.
+Semantic and hybrid search read existing local sidecar coverage. With semantic
+enabled and default background refresh, search may start the configured daemon
+so the daemon-owned query service can embed the query; `--refresh off` skips
+that autostart. Search does not run semantic catch-up or download embedding
+models. Hybrid uses semantic evidence only after coverage is complete and dirty
+work is drained; until then it falls back to lexical search with a structured
+reason. Explicit semantic search can query partial coverage for diagnostics,
+but reports a local error when the model cache is missing or the semantic worker
+is actively indexing.
 
 ## 6. Use JSON For Scripts
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -44,9 +44,14 @@ shipped.
   not a claim of semantic understanding.
 - Empty or punctuation-only search is invalid. Broad valid queries can still
   return metadata-driven matches.
-- Semantic embeddings depend on a compatible local ONNX Runtime backend.
-  The current public release artifacts are lexical-only on every platform and
-  report semantic unavailable rather than linking a target-specific backend.
+- Semantic embeddings depend on a compatible local ONNX Runtime backend and
+  the opt-in ctx daemon query service. Release/platform combinations without a
+  validated local runtime remain lexical-safe: `hybrid` falls back to lexical
+  and explicit `semantic` reports a local unavailable/runtime error instead of
+  linking an unsupported backend.
+- The ctx macOS CLI targets macOS 13, but ONNX Runtime 1.27 follows its upstream
+  macOS 14 minimum. On macOS 13, daemon-backed lexical search remains available
+  while semantic search is unavailable.
 
 ## Retrieval Semantics
 

--- a/docs/local-semantic-search-ship-plan.md
+++ b/docs/local-semantic-search-ship-plan.md
@@ -1,7 +1,6 @@
 # Local Semantic Search Ship Plan
 
-This plan captures the dogfood findings from the July 7-8, 2026 local runs on
-a power-user ctx corpus and the implementation path for local semantic search.
+This plan records the implementation and rollout path for local semantic search.
 The local Apache CLI, lexical search, setup, import/export, daemon refresh,
 status, local query service, and local semantic search remain free local
 functionality. Semantic search is implemented as first-class daemon
@@ -55,11 +54,25 @@ and private relevance evals justify flipping the default.
   setup should leave existing data intact, start daemon-owned indexing when
   possible, and let the daemon acquire the local embedding model and build
   missing semantic sidecars.
-- This branch supports the semantic query service on Unix. Non-Unix semantic
-  opt-in is blocked for v1 until there is an equivalent query-service transport.
+- Equal public-platform support uses one embedding model and one runtime family:
+  `intfloat/multilingual-e5-small` through ONNX Runtime. The model produces
+  384-dimensional vectors and requires `query: ` for query inputs and
+  `passage: ` for indexed document chunks. The portable
+  product shape is ctx-managed dynamic runtime assets, not Cargo build-time
+  `ort-sys` downloads. The CLI artifact names remain stable; runtime archives
+  are separate release sidecars acquired by installer metadata or daemon/runtime
+  acquisition.
+- Until a platform has both daemon query transport and a validated local ONNX
+  Runtime asset, that artifact must remain lexical-safe and report semantic
+  unavailable rather than pretending to support embeddings.
 
 ## Current Branch Addendum
 
+- Production semantic embeddings have migrated from
+  `sentence-transformers/all-MiniLM-L6-v2` to
+  `intfloat/multilingual-e5-small`. Query and passage role prefixes are applied
+  exactly once, and the new model key prevents pre-migration vectors from being
+  counted as E5 sidecar coverage.
 - Config now has `[daemon] enabled = true|false` and
   `[search] semantic = true|false`. Both are default unset/off for prerelease
   dogfood, and both have env overrides.
@@ -78,10 +91,11 @@ and private relevance evals justify flipping the default.
   enters `acquiring_model`, downloads/initializes the model through fastembed,
   verifies the cache, and records `model_acquisition_failed` if acquisition
   fails.
-- On Unix, the daemon now exposes a private `0600` Unix socket query service for
-  query embeddings. CLI search no longer initializes or downloads the embedding
-  model in the foreground; semantic/hybrid search asks the daemon query service
-  for the query vector, then performs local vector scan/hydration/ranking.
+- On semantic-capable Unix builds, the daemon now exposes a private `0600` Unix
+  socket query service for query embeddings. CLI search no longer initializes or
+  downloads the embedding model in the foreground; semantic/hybrid search asks
+  the daemon query service for the query vector, then performs local vector
+  scan/hydration/ranking.
 - The query service is intentionally narrow for v1: it embeds query text only.
   Full vector search can move into the daemon later if command startup,
   sqlite-vec scan, or hydration becomes the dominant latency.
@@ -95,248 +109,26 @@ and private relevance evals justify flipping the default.
 - Daemon model acquisition shields fastembed's `HF_HOME` override while filling
   the ctx-selected cache root, preserving ctx cache precedence during download
   as well as during normal model loading.
-
-## Dogfood Baseline
-
-- Fresh `ctx setup` identified 32,384 records / 13.1 GiB in 2.94s, but the
-  daemon autostart path left a stale/non-running daemon before history indexing
-  completed.
-- Manual daemon lexical refresh imported 32,379 sessions / 429,851 events in
-  3m58s, peaking at 665 MB RSS.
-- Default semantic indexing skipped with `model_cache_missing`, even though
-  compatible model caches existed elsewhere on disk.
-- A configured-cache semantic batch embedded 5,000 event chunks in 9m06s,
-  peaking at 1.83 GB RSS and covering only 3,702 of 429,934 searchable events.
-- Incremental lexical refresh for a synthetic Codex session took 4.05s.
-- Incremental semantic refresh with a configured cache made the synthetic marker
-  strict-semantic Hit@1 in 50.73s.
-- Warm lexical event searches were 20-34 ms. Warm semantic/hybrid searches were
-  about 690-735 ms with `sqlite_vec0`, with query embedding about 170-185 ms and
-  vector scan about 20-21 ms.
-
-## Pre-Scheduling-Fix Dogfood Notes
-
-- The lite-turn projection reduced the real local corpus from 430,093 indexed
-  events to 108,252 semantic searchable documents.
-- The semantic index key was bumped for the lite-turn corpus, so old event-level
-  vectors are ignored. After the bump, this machine reports 0 embedded
-  lite-turn items and about 108,000 queued lite-turn documents.
-- Default model cache discovery now succeeds on this machine without setting
-  `CTX_SEMANTIC_CACHE_DIR`.
-- A foreground daemon pass against the real data root did not reach semantic
-  indexing because history refresh consumed the whole bounded dogfood window:
-  - a `--max-chunks 1024` pass was interrupted after 4m18s;
-  - peak RSS was about 203 MB;
-  - history refresh imported 519 new events and semantic vector counts were
-    unchanged.
-- A tighter `--max-chunks 256` pass was interrupted after 2m17s;
-  - peak RSS was about 203 MB;
-  - history refresh imported 38 new events and semantic vector counts were
-    unchanged.
-- This failed the ship bar because large-history refresh work could starve
-  semantic indexing. The scheduling fix below is intended to make semantic
-  bootstrap explicit daemon work rather than something reached only after
-  refresh finishes.
-
-## Scheduling-Fix Dogfood Notes
-
-- After adding semantic-bootstrap scheduling and bounded lite-turn projection
-  queries, real daemon passes on the real local data root now do semantic work
-  before history refresh:
-  - `ctx daemon run --once --max-chunks 64 --json` completed in 22.2s,
-    skipped history refresh with `semantic_bootstrap_in_progress`, indexed
-    64 chunks / 18 items, and peaked at 1.09 GiB RSS.
-  - Warm default-memory shape `--max-chunks 512` completed in 50.7s, indexed
-    512 chunks / 184 additional items, and peaked at 1.17 GiB RSS.
-  - A higher-throughput experiment with `CTX_SEMANTIC_THREADS=4` and
-    `CTX_SEMANTIC_EMBED_BATCH=64` indexed 1,024 chunks in 58.6s but peaked at
-    4.68 GiB RSS, which is not acceptable as a default.
-  - `CTX_SEMANTIC_THREADS=2` with `CTX_SEMANTIC_EMBED_BATCH=64` was worse for
-    this corpus: 1,024 chunks in 1m52.8s and 4.54 GiB RSS.
-- Strict semantic search now works on the partial local index. A representative
-  search scanned 1,600 sqlite-vec chunks in 15ms, with query embedding at
-  239ms and total command wall around 0.86s. Relevance is still not
-  representative because coverage was only about 0.55%.
-- The current implementation is materially better and no longer starves
-  semantic behind refresh, but the safe-memory initial semantic backfill still
-  extrapolates to hours on this corpus, not the sub-60-minute target.
-
-## Adaptive-Default Dogfood Notes
-
-- The default semantic embed policy is now one adaptive rule, not separate
-  background/turbo tiers:
-  `min(20% total RAM, 50% available RAM, 10 GiB)`, floored at `1 GiB`.
-  Threads and embedding batch size derive from that budget, with env vars kept
-  only as operator/debug overrides.
-- On this 64 GB machine, the release binary selected:
-  `threads=8`, `batch_size=128`, `memory_budget_bytes=10 GiB`.
-- Real daemon passes on the real local data root with no semantic tuning env
-  vars:
-  - `--max-chunks 2048` indexed 2,048 chunks in 1m10.7s, used 683% CPU, and
-    peaked at 8.46 GiB RSS.
-  - `--max-chunks 512` indexed 512 chunks in 20.5s, used 590% CPU, and peaked
-    at 8.11 GiB RSS.
-- After removing the public daemon runtime cap, a natural one-pass daemon slice
-  (`ctx daemon run --once --max-chunks 5000 --json`) ran for 62.5s, indexed
-  1,837 chunks / 660 lite-turn items, used 624% CPU, and peaked at 8.49 GiB
-  RSS.
-- A 10-minute foreground daemon-loop soak wrapped in a process-level timeout
-  exercised the real service shape without a CLI runtime cap. It used 589% CPU,
-  peaked at 8.76 GiB RSS, gave history refresh multiple turns, imported fresh
-  events, remained recoverable after external termination, and reached
-  8,253 / 108,589 embedded lite-turn items with 24,665 embedded chunks.
-- A cleanup one-pass command cleared the expected stale lock after the external
-  timeout and moved coverage to 8,254 / 108,589 items, 24,666 chunks, zero dirty
-  items, and a 127 MB sidecar including WAL/SHM.
-- Strict semantic search remains light despite the larger indexing policy:
-  a cold-ish search took 1.75s wall, peaked at 266 MB RSS, scanned 4,672
-  sqlite-vec chunks in 29ms, and spent 180ms in query embedding.
-- At 7.6% coverage, the local basics eval over eight task-shaped queries showed
-  lexical p95 24ms but zero hits for most long natural-language queries, while
-  hybrid/semantic returned results with p95 about 2.1s / 2.0s respectively,
-  query embedding about 175ms, vector scan about 86ms over 24,666 chunks, and
-  hydration about 380ms. A small exact-substring oracle pass scored
-  hybrid/semantic 4/8 versus lexical 2/8; manual inspection showed several
-  misses were oracle/snippet artifacts, but relevance is not proven enough at
-  partial coverage to replace a 30-50 query private manifest at higher coverage.
-- Cache discovery now gives `CTX_SEMANTIC_CACHE_DIR` precedence over generic
-  `HF_HOME`. Daemon semantic bootstrap now gets one semantic-first pass before
-  the next daemon loop must attempt history refresh, preventing semantic
-  backlog from starving fresh lexical import.
-
-## Post-Projection-Fix Dogfood Notes
-
-- Lite-turn construction now reads deterministic preview text from an indexed
-  `event_search_lookup` table instead of joining the FTS table by `event_id` or
-  reparsing raw event JSON in the hot path. The real SQLite plan for recent
-  semantic work now uses `idx_events_role_occurred_seq` plus the lookup primary
-  key, rather than scanning all FTS rows.
-- The lookup table is limited to previewable user/assistant messages. On this
-  corpus it contains 426,974 rows: 108,612 user messages and 318,362 assistant
-  messages.
-- A schema-45 lookup-only repair on the real 435k-event store took 1m47s,
-  peaked at 964 MiB RSS, and avoided the 7m46s full FTS rebuild path observed
-  before the repair was targeted.
-- `ctx daemon status --json` on the incomplete real semantic sidecar is now
-  effectively instant: under 0.01s and about 15 MiB RSS.
-- The pathological one-chunk daemon pass no longer hangs before the worker:
-  `ctx daemon run --once --max-chunks 1 --json` completed in 12.9s, peaked at
-  286 MiB RSS, pruned 1,150 stale chunks, and indexed one chunk. This is still
-  dominated by prune plus single-item embedding overhead, so it is not a
-  throughput estimate.
-- The default daemon worker chunk budget now lets the worker use its existing
-  60s budget. A default `ctx daemon run --once --json` pass on the post-migration
-  stale sidecar completed in 65.6s, indexed 1,407 chunks, used about 5.1 cores,
-  and peaked at 8.18 GiB RSS. This is a conservative throughput slice because
-  the sidecar is still invalidating old pre-lookup vectors while indexing new
-  ones.
-- A cleaner isolated run copied the real schema-45 `work.sqlite` to a fresh
-  data root with no vector sidecar. The copy took 45.8s. Three default daemon
-  passes then indexed 4,720 chunks / 2,418 semantic items in 183.8s total,
-  with zero dirty churn, history refresh skipped for semantic bootstrap, and
-  peak RSS between 8.18 and 8.25 GiB. That sample was useful for throughput
-  shape, but was replaced by the completed v2 dogfood run below.
-- During incomplete bootstrap, eager recent dirty detection is skipped. Recent
-  dirty detection is reserved for the complete/clean incremental path; bootstrap
-  relies on ordered backfill plus bounded prune.
-
-## Final V2 Dogfood Notes
-
-- The v2 semantic corpus excludes deterministic transcript scaffolding
-  (`<environment_context>`, `<turn_aborted>`, `<subagent_notification>`, and
-  unified-exec process-limit warnings) from both semantic anchors and
-  lite-turn boundaries. On the isolated real local corpus this reduced semantic
-  documents from 108,614 v1 lite-turn anchors to 60,715 v2 anchors.
-- A full daemon-owned v2 backfill on the isolated real local corpus completed
-  in 2h02m53s, with max RSS 9,961,304 KiB, average CPU 466%, 60,715 / 60,715
-  embedded items, 157,251 chunks, and a 1.2 GiB sidecar.
-- A final-binary repair pass after review fixes completed in 1m46.5s, peaked at
-  4.66 GiB RSS, repaired 12 stale events / 16 pruned chunks, and ended ready at
-  60,715 / 60,715 items, 157,817 chunks, and zero dirty items.
-- `ctx daemon status --json` on the complete sidecar is read-only/cache-only:
-  under 0.01s and about 15.8 MiB RSS. It no longer exact-counts the work DB or
-  sidecar from the foreground status path, and stale worker/job status files are
-  ignored when their `model_key` does not match the current semantic corpus.
-- The final rough eight-query search gate over the completed sidecar completed
-  24 runs with no command failures. Lexical p95 was 27ms. Semantic p95 was
-  2.17s and hybrid p95 was 2.26s with the safer 1,000-candidate soft-filter
-  overfetch window. Typical diagnostics: query embedding 170-185ms, sqlite-vec
-  scan about 535-575ms over 157,817 chunks / 243 MiB of vectors, and hydration
-  about 170-440ms.
-- The 1,000-candidate soft-filter window is intentionally conservative because
-  current-session/subagent filters are applied after vector retrieval. A lower
-  200-candidate window measured faster, but risks under-filling results without
-  a proper refill loop.
-- Final bounded incremental dogfood:
-  - importing one new lite-turn session took 2.87s and 88 MiB RSS;
-  - status immediately reported 60,717 searchable, 60,716 embedded, and one
-    queued item;
-  - the daemon pass reached ready in 33.85s and 437 MiB RSS;
-  - the worker embedded exactly one chunk in 290ms after 168ms model init;
-  - semantic search found the new marker at Hit@1 in 2.03s.
-- A previous incremental pass before bounding recent repair took 1m34.9s and
-  embedded 1,048 chunks, which showed that complete-index incremental refresh
-  was too eager. The worker now uses a bounded incremental slice when initial
-  queued work is at or below the recent-dirty window, while full bootstrap keeps
-  scanning until its worker budget is exhausted.
-- The sqlite-vec hot path uses cheap count-parity readiness for search. Deep
-  payload drift is repaired by writable daemon maintenance rather than audited
-  before every read-only search; the full audit was measured as a hidden
-  35s-per-search cost and is not acceptable on the hot path.
-- A later bursty incremental dogfood pass exposed two readiness issues:
-  incomplete bootstrap tails needed a persistent backfill cursor, and the
-  cached v2 searchable count could drift because event-level cache adjustment
-  still counted deterministic control-message users. The fixes are:
-  - persist the backfill cursor across daemon passes until the sidecar becomes
-    ready;
-  - make the event-level semantic count predicate match the v2 SQL control
-    filter;
-  - refresh the cached searchable count exactly inside writable daemon/worker
-    maintenance, while keeping foreground status/search cache-only.
-- Post-fix stale-count repair on the isolated real root corrected 60,728 stale
-  searchable items to 60,725 exact searchable items, reached ready with queued
-  zero in 1m16.88s, peaked at 510,476 KiB RSS, and indexed two chunks from live
-  work discovered during the pass.
-- Post-fix clean incremental dogfood imported one fresh marker source in 7.95s
-  and 87,564 KiB RSS, then reported exactly one queued semantic item. A daemon
-  pass skipped history refresh with `semantic_bootstrap_in_progress`, embedded
-  exactly one chunk, reached ready in 49.45s, and peaked at 449,768 KiB RSS.
-  Semantic search found the new marker at Hit@1 in 2.47s over 158,663 chunks;
-  lexical found the same marker in 0.47s because the query shared exact marker
-  tokens.
-
-## Prerelease Opt-In Dogfood Notes
-
-- With semantic disabled by default, the completed dogfood sidecar reports
-  `semantic.status = disabled` and `reason = semantic_disabled`, while retaining
-  coverage counts for diagnostics.
-- After adding `[daemon] enabled = true` and `[search] semantic = true` to the
-  isolated dogfood root, status reported ready with 60,726-60,740 searchable
-  semantic documents and about 158,663-158,688 embedded chunks. The count moved
-  during dogfood because live local work continued to be imported.
-- A manual daemon query-service smoke exposed a private
-  `0600` `daemon/query.sock`. Strict semantic search for
-  `opal maple lantern semantic count drift` found the expected incremental
-  marker at Hit@1 with foreground RSS under 90 MiB.
-- First query through a daemon whose embedder was not warm took about 25s wall
-  because the daemon query service had to initialize the embedding model. Warm
-  query embedding through the daemon dropped to 3ms, but total CLI wall stayed
-  around 8s on the dogfood root because vector scan plus hydration still run in
-  the foreground process over about 158k chunks.
-- Default search with semantic enabled and no manual daemon autostarted the
-  daemon, returned effective `hybrid`, used semantic evidence, and found the
-  same marker at Hit@1 in 8.56s wall with 87 MiB foreground RSS. Diagnostics:
-  query embedding 221ms, sqlite-vec scan 1.087s, hydration 2.656s, 158,688
-  chunks scanned.
-- Strict semantic with `--refresh off` and no running daemon now fails fast with
-  `daemon semantic query service is not available`, as intended.
-- A clean foreground daemon `--once` pass over the isolated dogfood root still
-  spent 2m44s / 469 MiB RSS on no-op history refresh over about 14.2 GiB /
-  32,451 source files. This is acceptable as background daemon work for
-  prerelease, but it remains a candidate for future refresh fingerprinting or
-  source-level no-op avoidance. The idle loop now checks the idle deadline
-  before starting another pass, so a no-op idle daemon does not launch an extra
-  expensive refresh just to discover it should exit.
+- Release plumbing now has a stable ONNX Runtime sidecar naming convention:
+  `ctx-onnxruntime-linux-x64.tar.gz`,
+  `ctx-onnxruntime-linux-aarch64.tar.gz`,
+  `ctx-onnxruntime-macos-arm64.tar.gz`,
+  `ctx-onnxruntime-macos-x64.tar.gz`,
+  `ctx-onnxruntime-windows-x64.zip`, and
+  `ctx-onnxruntime-freebsd-x64.tar.gz`. Runtime producer jobs may use validated
+  `.tar.zst` intermediates, but release metadata and end-user installers only
+  consume the checksum-verified `.tar.gz` transport and do not require zstd.
+- Release metadata can describe those sidecars with
+  `CTX_RELEASE_ONNXRUNTIME_ARTIFACT_<platform_key>`,
+  `CTX_RELEASE_ONNXRUNTIME_SHA256_<platform_key>`, and
+  `CTX_RELEASE_ONNXRUNTIME_VERSION`. The development installers place runtime
+  assets under the selected runtime root at
+  `onnxruntime/<version>/<platform>`.
+- The public Buildkite pipeline has an opt-in runtime smoke matrix gated by
+  `CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX=1`. Each smoke installs and runs the exact
+  CLI artifact and sidecar in an isolated data root, then publishes an
+  exact-binary, exact-runtime proof. Cross-build and translated smoke evidence
+  cannot satisfy a native release gate.
 
 ## Ship Goals
 
@@ -359,17 +151,6 @@ and private relevance evals justify flipping the default.
   only when semantic sidecar coverage is complete and dirty work is drained;
   partial coverage is available through explicit `semantic` for diagnostics and
   dogfood, not default ranking.
-- Local dogfood on this corpus meets:
-  - lexical initial refresh: under 5 minutes;
-  - semantic initial backfill: about 2 hours on this 64 GB power-user
-    corpus, acceptable as daemon work if it is resumable, observable, and lower
-    priority than fresh incremental work;
-  - lexical incremental p95: under 10 seconds;
-  - semantic incremental p95: under 60 seconds after model cache is available;
-  - warm hybrid search p95: target under 2.5 seconds with daemon-owned query
-    embeddings and the conservative soft-filter overfetch window;
-  - semantic worker RSS follows the adaptive memory budget and must remain
-    below that selected budget during default daemon indexing.
 
 ## Readiness Gates
 
@@ -432,7 +213,7 @@ and private relevance evals justify flipping the default.
   recovery, semantic-first bootstrap scheduling, bounded incremental refresh,
   and cached read-only status.
 - Done in prerelease opt-in dogfood: semantic-enabled default search autostarts
-  the daemon query socket, foreground search no longer loads the model, and
+  the daemon query service, foreground search no longer loads the model, and
   strict `--refresh off` fails clearly when no daemon is available.
 - Original implementation checklist:
   - `ctx setup` foreground output distinguishes inventory complete, daemon
@@ -591,6 +372,31 @@ and private relevance evals justify flipping the default.
     startup or per-command sqlite opening becomes the bottleneck;
   - add a refill loop for post-vector filters so candidate count can drop below
     the conservative 1,000 soft-filter window without under-filling results.
+
+### 8. Equal Platform Runtime And Release Plumbing
+
+- Target architecture: one embedding model and ONNX Runtime index format on
+  every public platform. Core ML is an accelerator backend, not a second
+  semantic corpus.
+- Keep CLI artifact names stable. Runtime sidecars are additive assets named
+  `ctx-onnxruntime-<platform>.<archive>` and preserve license and notice files.
+- Release metadata may omit runtime keys entirely, but a published runtime must
+  include artifact name, SHA-256, and version metadata as one complete set.
+- Managed runners produce and natively smoke Linux x64, Linux arm64, and macOS
+  arm64 when the native smoke matrix is enabled.
+- Native Intel macOS x64, Windows x64, and FreeBSD x64 use gated
+  `release-*-native` Buildkite queues. Release staging fails closed until all
+  six canonical sidecars and native proofs are present.
+- Windows native proof uses
+  `scripts/smoke-daemon-semantic-release.ps1 -ProofOutput <path>`. Unix-like
+  native hosts use
+  `scripts/smoke-daemon-semantic-release.sh --proof-output <path>`.
+- Fast-fail review criteria:
+  - no semantic success claim without native exact-artifact smoke;
+  - no fallback to a different embedding model without an index compatibility
+    decision;
+  - no foreground search model downloads;
+  - no default config writes for daemon or semantic opt-in.
 
 ## Parallel Implementation And Review Plan
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -127,20 +127,25 @@ uses local FastEmbed embeddings over v2 semantic documents: a transient metadata
 header plus chunked event semantic text. The header is embedded and hashed but
 not stored as plaintext in the sidecar. `--backend hybrid` blends lexical and
 semantic evidence with reciprocal-rank fusion; `--semantic-weight` controls the
-semantic contribution and defaults to `0.35`. Public reports name the model as
-`sentence-transformers/all-MiniLM-L6-v2`; the required local FastEmbed cache is
-the Qdrant ONNX artifact directory `models--Qdrant--all-MiniLM-L6-v2-onnx`.
-Current builds do not link a local embedding backend on any platform. With the
-semantic preview disabled, `hybrid` reports a lexical fallback and explicit
-`semantic` reports that semantic search is disabled. If semantic is enabled in
-configuration, semantic and hybrid requests fail clearly as unsupported;
-neither downloads a model nor silently returns lexical results.
+semantic contribution and defaults to `0.35`. The production embedding model is
+`intfloat/multilingual-e5-small`, which produces 384-dimensional vectors. Its E5
+input contract prefixes semantic queries with `query: ` and indexed document
+chunks with `passage: `; ctx adds each prefix exactly once. The required local
+FastEmbed cache is the Hugging Face artifact directory
+`models--intfloat--multilingual-e5-small`. The model and prefix contract are part
+of the semantic sidecar model key, so pre-migration `all-MiniLM-L6-v2` vectors
+are not reused as E5 coverage.
+The local embedding backend requires a validated local ONNX Runtime backend for
+the installed platform. Builds without one stay lexical-safe: daemon
+maintenance and lexical search remain available, `hybrid` falls back to
+lexical, and explicit `semantic` reports a local unavailable/runtime/cache
+error instead of linking an unsupported backend.
 Semantic and hybrid searches read the coverage that is already present in the
-semantic sidecar; they do not perform foreground vector catch-up. They also
-require the local embedding model cache to already exist. If the cache is
-missing, hybrid falls back to lexical and explicit semantic search fails with an
-explicit local error instead of initializing or downloading a model during
-search. Explicit `semantic` also fails when filters or repeatable `--term`
+semantic sidecar; they do not perform foreground vector catch-up. If the local
+embedding model is not available to the daemon query service, hybrid falls back
+to lexical and explicit semantic search fails with an explicit local error
+instead of initializing or downloading a model during search. Explicit
+`semantic` also fails when filters or repeatable `--term`
 semantics cannot be honored by vector lookup, or when the installed local vector
 backend cannot safely scan the full sidecar. `hybrid` falls back to lexical in
 those cases and when semantic coverage is incomplete or dirty. Results still return
@@ -179,9 +184,10 @@ discovery and may also be imported with an explicit `--path`.
 
 Use `--refresh off` for a search that does not import providers, execute
 plugins, schedule semantic indexing, or update either the main ctx SQLite store
-or semantic sidecar. Explicit semantic or hybrid requests may still initialize an already-cached local
-embedding model to embed the query and read existing sidecar coverage; they do
-not download a model or write semantic catch-up work during search.
+or semantic sidecar. Explicit semantic or hybrid requests may still ask the
+daemon query service to embed the query from an already-cached local model and
+read existing sidecar coverage; they do not download a model or write semantic
+catch-up work during search.
 
 ## Semantic Freshness
 
@@ -199,8 +205,10 @@ the normal ctx-owned background daemon profile and exits after it becomes idle;
 explicit `ctx daemon run` runs the same coordinator in the foreground.
 
 `ctx search` reads the sidecar coverage that already exists and reports semantic
-coverage and worker state in JSON. Search never starts the daemon, queues vector
-backfill, waits for full semantic coverage, or downloads an embedding model.
+coverage and worker state in JSON. With semantic enabled and default
+`--refresh background`, search may autostart the configured daemon so the
+daemon-owned query service can embed the query. Search does not queue vector
+backfill, wait for full semantic coverage, or download an embedding model.
 `hybrid` uses semantic evidence only after sidecar coverage is complete and the
 dirty queue is empty; otherwise it serves lexical results with a structured
 fallback reason. Explicit `semantic` can query partial sidecar coverage for
@@ -224,11 +232,10 @@ reports disabled with `enabled: false` and `network_allowed: false`.
 `ctx doctor` is the place for semantic and daemon diagnostics when local status
 needs troubleshooting.
 
-Search never starts the daemon or waits for full semantic coverage. Explicit
-semantic queries may read partial sidecar coverage. Default and explicit
-`hybrid` use semantic evidence only when sidecar coverage is complete and dirty
-work is drained, and otherwise serve lexical results with a structured fallback
-reason.
+Search never waits for full semantic coverage. Explicit semantic queries may
+read partial sidecar coverage. Default and explicit `hybrid` use semantic
+evidence only when sidecar coverage is complete and dirty work is drained, and
+otherwise serve lexical results with a structured fallback reason.
 
 ## History Reports
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -11,6 +11,10 @@ Default root:
 ~/.ctx/
   work.sqlite
   config.toml
+  runtime/
+    onnxruntime/
+      <runtime-version>/
+        <platform>/
   upgrade-state.json
   upgrade.lock
   logs/
@@ -30,6 +34,12 @@ binary, for example:
 
 The sidecar is outside the ctx data root because it describes ownership of the
 installed executable, not indexed provider history.
+
+When release metadata includes ctx-managed ONNX Runtime assets, the official
+installer and development installer place those native runtime files under
+`${CTX_RUNTIME_DIR:-$HOME/.ctx/runtime}/onnxruntime/<runtime-version>/<platform>`.
+They are product runtime assets, not provider-history storage, and may be shared
+by multiple ctx data roots on the same machine.
 
 ## What SQLite Stores
 
@@ -89,7 +99,7 @@ analytics marker described under network behavior.
 | `ctx import` | provider transcript files and path metadata, the explicit custom history JSONL file passed with `--format ctx-history-jsonl-v1 --path`, or stdout from an explicit history-source plugin command | data root, SQLite index, and optional daemon lock/status/job files when daemon autostart runs |
 | `ctx show` | SQLite index | selected `--out` path for `show session` when provided |
 | `ctx locate` | SQLite index and raw source path metadata | none |
-| `ctx search` | native provider transcript files, path metadata, enabled auto history-source plugin stdout, SQLite index, and existing semantic sidecar/status metadata | SQLite index for newly discovered native provider or plugin history |
+| `ctx search` | native provider transcript files, path metadata, enabled auto history-source plugin stdout, SQLite index, and existing semantic sidecar/status metadata | SQLite index for newly discovered native provider or plugin history, and optional daemon lock/status/query endpoint files when semantic-enabled background refresh autostarts daemon maintenance |
 | `ctx sql` | existing SQLite index only | none |
 | `ctx docs` | embedded documentation in the binary | selected topic `--out` path for `ctx docs show --out` or selected `--out` directory for `ctx docs man --out` |
 | `ctx upgrade` | signed release metadata and installed binary/sidecar metadata | installed binary for manual upgrade, install sidecar, `upgrade-state.json`, `upgrade.lock`, and `logs/upgrade.log` |
@@ -100,28 +110,30 @@ analytics marker described under network behavior.
 
 Setup, import, and default search do not require source repository writes, model
 APIs, API keys, or remote accounts. Without semantic opt-in they do not download
-models; with semantic enabled, daemon maintenance may acquire the local embedding
-model. Non-JSON setup and native provider imports may opportunistically start
+models or runtime assets; with semantic enabled, installer/runtime acquisition
+and daemon maintenance may acquire the local ONNX Runtime asset and embedding
+model when the installed build supports that path. Non-JSON setup and native provider imports may opportunistically start
 the ctx-owned background daemon maintenance profile when `[daemon].enabled` is true; use
 `ctx setup --no-daemon` or `ctx import --no-daemon` for a one-run opt-out.
 `ctx setup --catalog-only`, `ctx setup --json`, and `ctx import --json` do not
 autostart daemon maintenance.
-`ctx search --refresh off` does not refresh providers, run plugins, start
-semantic workers, schedule semantic indexing, or write the main store or
-semantic sidecar. Default `--backend hybrid --refresh off` uses semantic
-evidence only when sidecar coverage is complete and dirty work is drained, and
-otherwise falls back to lexical. Explicit semantic searches may initialize an
-already-cached local embedding model to embed the query and read partial
-existing sidecar coverage, but they do not download a model or write semantic
-catch-up work during search.
+`ctx search --refresh off` does not refresh providers, run plugins, autostart
+daemon maintenance, start semantic workers, schedule semantic indexing, or write
+the main store or semantic sidecar. Default `--backend hybrid --refresh off`
+uses semantic evidence only when sidecar coverage is complete and dirty work is
+drained, and otherwise falls back to lexical. Explicit semantic searches may ask
+the daemon query service to embed the query from an already-cached local model
+and read partial existing sidecar coverage, but they do not download a model or
+write semantic catch-up work during search.
 Explicit imports may best-effort mark recent semantic-eligible items dirty in
 the semantic sidecar when the sidecar already exists; this does not create the
 sidecar, initialize the model, or embed text.
 Explicit semantic search also refuses to initialize or download the embedding
 model when the required local cache is missing; hybrid falls back to lexical in
 that case. Default `--refresh background` lets daemon maintenance own enabled
-auto history-source plugin refresh when possible; use `--refresh wait` or
-`ctx import` for exhaustive foreground plugin catch-up.
+auto history-source plugin refresh when possible, and may autostart the
+configured daemon query service for semantic/hybrid retrieval; use
+`--refresh wait` or `ctx import` for exhaustive foreground plugin catch-up.
 
 When `ctx daemon run` or setup/import autostart runs the ctx-owned background
 coordinator, it stores private lock/status files under `daemon/` in the ctx data
@@ -129,8 +141,8 @@ root. Setup/import autostart uses the normal background daemon profile and exits
 after it becomes idle; explicit `ctx daemon run` runs the same coordinator in
 the foreground. The current coordinator status surface is local-only: bounded
 native provider-history refresh updates the local SQLite index, semantic
-indexing is bounded by the local model cache, and cloud sync reports `disabled`
-with `enabled: false` and `network_allowed: false`.
+indexing is bounded by the local runtime/model availability, and cloud sync
+reports `disabled` with `enabled: false` and `network_allowed: false`.
 A looping daemon may keep the
 local embedding model resident between passes and uses the sidecar dirty queue
 to prioritize recent/stale events. With semantic enabled and default background

--- a/docs/unmanaged-installs.md
+++ b/docs/unmanaged-installs.md
@@ -32,7 +32,13 @@ Stable releases publish prebuilt binaries on GitHub Releases:
 | Windows x64 | `ctx-windows-x64.exe` |
 | FreeBSD x64 | `ctx-freebsd-x64` |
 
-Each release also publishes `SHA256SUMS` for the binary assets.
+Each release also publishes `SHA256SUMS` for the binary assets. Releases that
+ship ctx-managed dynamic ONNX Runtime assets for the local semantic preview may
+also include sidecar archives named `ctx-onnxruntime-<platform>.tar.gz` on
+Unix-like platforms and `ctx-onnxruntime-windows-x64.zip` on Windows. The
+official installer reads signed release metadata and installs those runtime
+assets automatically when present; direct unmanaged installs should follow the
+release notes for any required runtime sidecar placement.
 
 The hosted installer and managed-upgrade path verify signed ctx release
 metadata. The macOS and Windows binaries are not currently Developer ID

--- a/scripts/bazel-test.sh
+++ b/scripts/bazel-test.sh
@@ -143,6 +143,7 @@ case "${mode}" in
     ;;
   native_candidate_smoke_tests)
     run bash scripts/tests/run-native-candidate-smoke-test.sh
+    run bash scripts/tests/smoke-daemon-semantic-release-test.sh
     if command -v pwsh >/dev/null 2>&1; then
       run pwsh -NoLogo -NoProfile -File scripts/tests/run-native-candidate-smoke-test.ps1
     fi

--- a/scripts/build-onnxruntime-sidecar.sh
+++ b/scripts/build-onnxruntime-sidecar.sh
@@ -1,0 +1,1200 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ONNXRUNTIME_VERSION="1.27.0"
+ONNXRUNTIME_API_VERSION="24"
+ONNXRUNTIME_COMMIT="8f0278c77bf44b0cc83c098c6c722b92a36ac4b5"
+ONNXRUNTIME_RELEASE_BASE_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}"
+ONNXRUNTIME_SOURCE_URL="https://github.com/microsoft/onnxruntime/archive/refs/tags/v${ONNXRUNTIME_VERSION}.tar.gz"
+ONNXRUNTIME_SOURCE_SHA256="b41d09905a3c2f3a25709d1dcce8ef3942a4c2799d1046f74be7b6bbebc45e6a"
+ONNXRUNTIME_LICENSE_URL="https://raw.githubusercontent.com/microsoft/onnxruntime/${ONNXRUNTIME_COMMIT}/LICENSE"
+ONNXRUNTIME_LICENSE_SHA256="2f07c72751aed99790b8a4869cf2311df85a860b22ded05fa22803587a48922c"
+ONNXRUNTIME_NOTICES_URL="https://raw.githubusercontent.com/microsoft/onnxruntime/${ONNXRUNTIME_COMMIT}/ThirdPartyNotices.txt"
+ONNXRUNTIME_NOTICES_SHA256="0e07b95f3a8d6230037707c5c4a2b554d12c4cb67369669ac255635528ffcee2"
+ONNXRUNTIME_MAX_GLIBC="2.39"
+ONNXRUNTIME_DEPS_SHA256="e411468ead299e3386b2e5e9d773e50e1939b5fc0baca599666ca5757eeb3f71"
+FREEBSD_PORTS_COMMIT="7c1f125705820cd2b776056f2c492ed605f3b5e3"
+FREEBSD_PORTS_PATCH_BASE_URL="https://cgit.freebsd.org/ports/plain/misc/onnxruntime/files"
+FREEBSD_SPIN_PAUSE_PATCH="patch-onnxruntime_core_common_spin__pause.cc"
+FREEBSD_SPIN_PAUSE_PATCH_SHA256="37f30419946cc3440859d4ce2bccf05b3a8961dd9b3b2dd9f9663b6a235282c1"
+FREEBSD_POSIX_ENV_PATCH="patch-onnxruntime_core_platform_posix_env.cc"
+FREEBSD_POSIX_ENV_PATCH_SHA256="d730c2fe1341654159f1068beaf224f06cffb5520593718681c96fb47e131033"
+FREEBSD_DISTINFO_SHA256="ef17d849c2707c0db508504f982565238a80af66c33b3261973ec29bc7e72b5e"
+FREEBSD_BUILD_RECIPE="ctx-freebsd-source-v1"
+FREEBSD_ABI_MAJOR="14"
+SOURCE_DATE_EPOCH="1781827200"
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  scripts/build-onnxruntime-sidecar.sh PLATFORM [OUTPUT_DIR]
+  scripts/build-onnxruntime-sidecar.sh --validate PLATFORM ARCHIVE
+
+Builds or validates the ONNX Runtime 1.27.0 CPU sidecar for one public ctx
+platform. Official Microsoft release archives are checksum-pinned. macos-x64
+is built from checksum-pinned source and requires a native Intel macOS host.
+freebsd-x64 is built from that same checksum-pinned source on a native x64
+FreeBSD 14 host. Its two compatibility patches are checksum-pinned to FreeBSD
+ports commit 7c1f125705820cd2b776056f2c492ed605f3b5e3. CMake is forced to fetch
+dependencies from a local mirror verified against that commit's SHA-256
+distinfo instead of using mutable installed packages, and the resulting library
+records its source, recipe, ABI, OS, compiler, and CMake provenance in
+OrtGetBuildInfoString.
+
+Platforms: linux-x64, linux-aarch64, macos-arm64, macos-x64, windows-x64,
+freebsd-x64.
+
+Environment:
+  CTX_ONNXRUNTIME_CACHE_DIR       Download cache (default: target/onnxruntime-sidecar-cache)
+  CTX_ONNXRUNTIME_BUILD_DIR       Source/build directory for source-built platforms
+  CTX_ONNXRUNTIME_BUILD_JOBS      Parallel job count for source-built platforms
+  CTX_ONNXRUNTIME_MAX_GLIBC       Maximum accepted Linux GLIBC symbol version
+
+Native FreeBSD build requirements:
+  FreeBSD 14 x64 userland, CMake >= 3.28, Python 3, clang/clang++, GNU patch
+  (gpatch), make, and network access to the checksum-declared source inputs.
+  The OS/compiler/CMake versions are recorded, not supplied by environment.
+USAGE
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required"
+}
+
+sha256_file() {
+  local path="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${path}" | awk '{ print $1 }'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${path}" | awk '{ print $1 }'
+  else
+    die "sha256sum or shasum is required"
+  fi
+}
+
+verify_sha256() {
+  local path="$1"
+  local expected="$2"
+  local actual
+
+  actual="$(sha256_file "${path}")"
+  if [[ "$(printf '%s' "${actual}" | tr 'A-F' 'a-f')" != "$(printf '%s' "${expected}" | tr 'A-F' 'a-f')" ]]; then
+    die "SHA-256 mismatch for ${path}: expected ${expected}, got ${actual}"
+  fi
+}
+
+verify_size() {
+  local path="$1"
+  local expected="$2"
+  local actual
+
+  actual="$(wc -c < "${path}" | tr -d '[:space:]')"
+  [[ "${actual}" == "${expected}" ]] || \
+    die "size mismatch for ${path}: expected ${expected} bytes, got ${actual}"
+}
+
+download_verified() {
+  local url="$1"
+  local expected_sha256="$2"
+  local destination="$3"
+  local temporary="${destination}.tmp.$$"
+
+  require_command curl
+  mkdir -p "$(dirname "${destination}")"
+  if [[ -f "${destination}" ]]; then
+    if verify_sha256 "${destination}" "${expected_sha256}" 2>/dev/null; then
+      printf 'using cached %s\n' "${destination}"
+      return
+    fi
+    printf 'discarding checksum-mismatched cache entry %s\n' "${destination}" >&2
+    rm -f "${destination}"
+  fi
+
+  rm -f "${temporary}"
+  curl --fail --location --retry 4 --retry-all-errors --silent --show-error \
+    "${url}" --output "${temporary}"
+  verify_sha256 "${temporary}" "${expected_sha256}"
+  mv "${temporary}" "${destination}"
+}
+
+configure_platform() {
+  local requested_platform="$1"
+
+  platform="${requested_platform}"
+  archive_kind="tar.zst"
+  upstream_kind=""
+  upstream_asset=""
+  upstream_sha256=""
+  upstream_root=""
+  upstream_library=""
+  case "${platform}" in
+    linux-x64)
+      asset_name="ctx-onnxruntime-linux-x64.tar.zst"
+      library_name="libonnxruntime.so"
+      upstream_kind="tar.gz"
+      upstream_asset="onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz"
+      upstream_sha256="547e40a48f1fe73e3f812d7c88a948612c23f896b91e4e2ee1e232d7b468246f"
+      upstream_root="onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}"
+      upstream_library="lib/libonnxruntime.so.${ONNXRUNTIME_VERSION}"
+      ;;
+    linux-aarch64)
+      asset_name="ctx-onnxruntime-linux-aarch64.tar.zst"
+      library_name="libonnxruntime.so"
+      upstream_kind="tar.gz"
+      upstream_asset="onnxruntime-linux-aarch64-${ONNXRUNTIME_VERSION}.tgz"
+      upstream_sha256="3e4d83ac06924a32a07b6d7f91ce6f852876153fc0bbdf931bf517a140bfbe48"
+      upstream_root="onnxruntime-linux-aarch64-${ONNXRUNTIME_VERSION}"
+      upstream_library="lib/libonnxruntime.so.${ONNXRUNTIME_VERSION}"
+      ;;
+    macos-arm64)
+      asset_name="ctx-onnxruntime-macos-arm64.tar.zst"
+      library_name="libonnxruntime.dylib"
+      upstream_kind="tar.gz"
+      upstream_asset="onnxruntime-osx-arm64-${ONNXRUNTIME_VERSION}.tgz"
+      upstream_sha256="545e81c58152353acb0d1e8bd6ce4b62f830c0961f5b3acfedc790ffd76e477a"
+      upstream_root="onnxruntime-osx-arm64-${ONNXRUNTIME_VERSION}"
+      upstream_library="lib/libonnxruntime.dylib"
+      ;;
+    macos-x64)
+      asset_name="ctx-onnxruntime-macos-x64.tar.zst"
+      library_name="libonnxruntime.dylib"
+      ;;
+    windows-x64)
+      asset_name="ctx-onnxruntime-windows-x64.zip"
+      library_name="onnxruntime.dll"
+      archive_kind="zip"
+      upstream_kind="zip"
+      upstream_asset="onnxruntime-win-x64-${ONNXRUNTIME_VERSION}.zip"
+      upstream_sha256="c5c81710938e68079ff1a192b04897faabe4b43830d48f39f27ecd4e16138bfc"
+      upstream_root="onnxruntime-win-x64-${ONNXRUNTIME_VERSION}"
+      upstream_library="lib/onnxruntime.dll"
+      ;;
+    freebsd-x64)
+      asset_name="ctx-onnxruntime-freebsd-x64.tar.zst"
+      library_name="libonnxruntime.so"
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+}
+
+extract_official_asset() {
+  local archive="$1"
+  local destination="$2"
+
+  python3 - "${upstream_kind}" "${archive}" "${upstream_root}" \
+    "${upstream_library}" "${library_name}" "${destination}" \
+    "${ONNXRUNTIME_VERSION}" "${ONNXRUNTIME_COMMIT}" <<'PY'
+import os
+import posixpath
+import shutil
+import stat
+import sys
+import tarfile
+import zipfile
+
+kind, archive, expected_root, source_library, library_name, destination, version, commit = sys.argv[1:]
+required = {
+    f"{expected_root}/{source_library}": f"lib/{library_name}",
+    f"{expected_root}/LICENSE": "LICENSE",
+    f"{expected_root}/ThirdPartyNotices.txt": "ThirdPartyNotices.txt",
+    f"{expected_root}/VERSION_NUMBER": "VERSION_NUMBER",
+    f"{expected_root}/GIT_COMMIT_ID": "GIT_COMMIT_ID",
+}
+
+
+def canonical_name(raw):
+    if not raw or "\\" in raw or raw.startswith("/"):
+        raise SystemExit(f"unsafe upstream archive path: {raw!r}")
+    while raw.startswith("./"):
+        raw = raw[2:]
+    normalized = posixpath.normpath(raw.rstrip("/"))
+    if normalized in ("", "."):
+        return ""
+    if normalized == ".." or normalized.startswith("../"):
+        raise SystemExit(f"unsafe upstream archive path: {raw!r}")
+    return normalized
+
+
+def validate_root(name):
+    if name and name != expected_root and not name.startswith(expected_root + "/"):
+        raise SystemExit(
+            f"unexpected upstream archive root: {name!r}; expected {expected_root!r}"
+        )
+
+
+os.makedirs(os.path.join(destination, "lib"), exist_ok=True)
+seen = set()
+if kind == "tar.gz":
+    with tarfile.open(archive, "r:gz") as bundle:
+        members = {}
+        for member in bundle.getmembers():
+            name = canonical_name(member.name)
+            validate_root(name)
+            if not name:
+                continue
+            if name in seen:
+                raise SystemExit(f"duplicate upstream archive entry: {name}")
+            seen.add(name)
+            if member.issym() or member.islnk():
+                target = member.linkname
+                if target.startswith("/"):
+                    raise SystemExit(f"unsafe upstream archive link: {name} -> {target}")
+                resolved = posixpath.normpath(posixpath.join(posixpath.dirname(name), target))
+                validate_root(resolved)
+            elif not (member.isdir() or member.isfile()):
+                raise SystemExit(f"unsupported upstream archive entry type: {name}")
+            members[name] = member
+        for source, target in required.items():
+            member = members.get(source)
+            if member is None or not member.isfile():
+                raise SystemExit(f"required regular file missing from upstream archive: {source}")
+            source_file = bundle.extractfile(member)
+            if source_file is None:
+                raise SystemExit(f"could not read upstream archive member: {source}")
+            target_path = os.path.join(destination, *target.split("/"))
+            with source_file, open(target_path, "wb") as output:
+                shutil.copyfileobj(source_file, output)
+elif kind == "zip":
+    with zipfile.ZipFile(archive) as bundle:
+        members = {}
+        for member in bundle.infolist():
+            name = canonical_name(member.filename)
+            validate_root(name)
+            if not name:
+                continue
+            if name in seen:
+                raise SystemExit(f"duplicate upstream archive entry: {name}")
+            seen.add(name)
+            mode = member.external_attr >> 16
+            if stat.S_ISLNK(mode):
+                raise SystemExit(f"upstream zip contains a symbolic link: {name}")
+            members[name] = member
+        for source, target in required.items():
+            member = members.get(source)
+            if member is None or member.is_dir():
+                raise SystemExit(f"required regular file missing from upstream archive: {source}")
+            target_path = os.path.join(destination, *target.split("/"))
+            with bundle.open(member) as source_file, open(target_path, "wb") as output:
+                shutil.copyfileobj(source_file, output)
+else:
+    raise SystemExit(f"unsupported upstream archive kind: {kind}")
+
+for name in ("LICENSE", "ThirdPartyNotices.txt"):
+    path = os.path.join(destination, name)
+    with open(path, "rb") as handle:
+        content = handle.read().replace(b"\r\n", b"\n")
+    with open(path, "wb") as handle:
+        handle.write(content)
+for name, expected in (("VERSION_NUMBER", version), ("GIT_COMMIT_ID", commit)):
+    path = os.path.join(destination, name)
+    with open(path, "rb") as handle:
+        actual = handle.read().decode("utf-8-sig").strip()
+    if actual != expected:
+        raise SystemExit(f"upstream {name} is {actual!r}, expected {expected!r}")
+    with open(path, "wb") as handle:
+        handle.write((expected + "\n").encode())
+
+os.chmod(os.path.join(destination, "lib", library_name), 0o755)
+for name in ("LICENSE", "ThirdPartyNotices.txt", "VERSION_NUMBER", "GIT_COMMIT_ID"):
+    os.chmod(os.path.join(destination, name), 0o644)
+PY
+}
+
+validate_source_archive_layout() {
+  local archive="$1"
+  local expected_root="onnxruntime-${ONNXRUNTIME_VERSION}"
+
+  python3 - "${archive}" "${expected_root}" <<'PY'
+import posixpath
+import sys
+import tarfile
+
+archive, expected_root = sys.argv[1:]
+seen = set()
+required = {
+    f"{expected_root}/build.sh",
+    f"{expected_root}/LICENSE",
+    f"{expected_root}/ThirdPartyNotices.txt",
+    f"{expected_root}/VERSION_NUMBER",
+}
+with tarfile.open(archive, "r:gz") as bundle:
+    for member in bundle.getmembers():
+        raw = member.name
+        if not raw or "\\" in raw or raw.startswith("/"):
+            raise SystemExit(f"unsafe source archive path: {raw!r}")
+        while raw.startswith("./"):
+            raw = raw[2:]
+        name = posixpath.normpath(raw.rstrip("/"))
+        if name == ".." or name.startswith("../"):
+            raise SystemExit(f"unsafe source archive path: {raw!r}")
+        if name != expected_root and not name.startswith(expected_root + "/"):
+            raise SystemExit(
+                f"unexpected source archive root: {name!r}; expected {expected_root!r}"
+            )
+        if name in seen:
+            raise SystemExit(f"duplicate source archive entry: {name}")
+        seen.add(name)
+        if member.issym() or member.islnk():
+            target = member.linkname
+            if target.startswith("/"):
+                raise SystemExit(f"unsafe source archive link: {name} -> {target}")
+            resolved = posixpath.normpath(posixpath.join(posixpath.dirname(name), target))
+            if resolved != expected_root and not resolved.startswith(expected_root + "/"):
+                raise SystemExit(f"source archive link escapes root: {name} -> {target}")
+        elif not (member.isdir() or member.isfile()):
+            raise SystemExit(f"unsupported source archive entry type: {name}")
+missing = sorted(required - seen)
+if missing:
+    raise SystemExit("source archive is missing required entries: " + ", ".join(missing))
+PY
+}
+
+stage_pinned_documents() {
+  local destination="$1"
+  local cache_dir="$2"
+  local license="${cache_dir}/onnxruntime-${ONNXRUNTIME_COMMIT}-LICENSE"
+  local notices="${cache_dir}/onnxruntime-${ONNXRUNTIME_COMMIT}-ThirdPartyNotices.txt"
+
+  download_verified "${ONNXRUNTIME_LICENSE_URL}" "${ONNXRUNTIME_LICENSE_SHA256}" "${license}"
+  download_verified "${ONNXRUNTIME_NOTICES_URL}" "${ONNXRUNTIME_NOTICES_SHA256}" "${notices}"
+  cp "${license}" "${destination}/LICENSE"
+  cp "${notices}" "${destination}/ThirdPartyNotices.txt"
+  printf '%s\n' "${ONNXRUNTIME_VERSION}" > "${destination}/VERSION_NUMBER"
+  printf '%s\n' "${ONNXRUNTIME_COMMIT}" > "${destination}/GIT_COMMIT_ID"
+  chmod 644 "${destination}/LICENSE" "${destination}/ThirdPartyNotices.txt" \
+    "${destination}/VERSION_NUMBER" "${destination}/GIT_COMMIT_ID"
+}
+
+stage_official_release() {
+  local destination="$1"
+  local cache_dir="$2"
+  local archive="${cache_dir}/${upstream_asset}"
+
+  download_verified "${ONNXRUNTIME_RELEASE_BASE_URL}/${upstream_asset}" \
+    "${upstream_sha256}" "${archive}"
+  extract_official_asset "${archive}" "${destination}"
+}
+
+stage_macos_x64_source_build() {
+  local destination="$1"
+  local cache_dir="$2"
+  local source_archive="${cache_dir}/onnxruntime-${ONNXRUNTIME_VERSION}-source.tar.gz"
+  local build_root="${CTX_ONNXRUNTIME_BUILD_DIR:-${work_dir}/macos-x64-build}"
+  local source_parent="${build_root}/source"
+  local source_dir="${source_parent}/onnxruntime-${ONNXRUNTIME_VERSION}"
+  local cmake_build_dir="${build_root}/build"
+  local built_library="${cmake_build_dir}/Release/libonnxruntime.dylib"
+  local deployment_target="${MACOSX_DEPLOYMENT_TARGET:-14.0}"
+  local jobs="${CTX_ONNXRUNTIME_BUILD_JOBS:-}"
+
+  [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "x86_64" ]] || \
+    die "macos-x64 ONNX Runtime must be built on a native Intel macOS host"
+  require_command python3
+  require_command cmake
+
+  download_verified "${ONNXRUNTIME_SOURCE_URL}" "${ONNXRUNTIME_SOURCE_SHA256}" "${source_archive}"
+  validate_source_archive_layout "${source_archive}"
+  rm -rf "${source_parent}" "${cmake_build_dir}"
+  mkdir -p "${source_parent}" "${cmake_build_dir}"
+  tar -xzf "${source_archive}" -C "${source_parent}"
+
+  build_args=(
+    --config Release
+    --build_dir "${cmake_build_dir}"
+    --build_shared_lib
+    --skip_tests
+    --compile_no_warning_as_error
+  )
+  if [[ -n "${jobs}" ]]; then
+    [[ "${jobs}" =~ ^[1-9][0-9]*$ ]] || die "CTX_ONNXRUNTIME_BUILD_JOBS must be a positive integer"
+    build_args+=(--parallel "${jobs}")
+  else
+    build_args+=(--parallel)
+  fi
+  build_args+=(
+    --cmake_extra_defines
+    "CMAKE_OSX_ARCHITECTURES=x86_64"
+    "CMAKE_OSX_DEPLOYMENT_TARGET=${deployment_target}"
+    "onnxruntime_BUILD_UNIT_TESTS=OFF"
+  )
+  (cd "${source_dir}" && ./build.sh "${build_args[@]}")
+
+  if [[ ! -f "${built_library}" ]]; then
+    alternate_library="${cmake_build_dir}/Release/lib/libonnxruntime.dylib"
+    if [[ -f "${alternate_library}" ]]; then
+      built_library="${alternate_library}"
+    else
+      die "macos-x64 build did not produce ${cmake_build_dir}/Release/libonnxruntime.dylib"
+    fi
+  fi
+
+  cp -L "${built_library}" "${destination}/lib/${library_name}"
+  chmod 755 "${destination}/lib/${library_name}"
+  cp "${source_dir}/LICENSE" "${destination}/LICENSE"
+  cp "${source_dir}/ThirdPartyNotices.txt" "${destination}/ThirdPartyNotices.txt"
+  printf '%s\n' "${ONNXRUNTIME_VERSION}" > "${destination}/VERSION_NUMBER"
+  printf '%s\n' "${ONNXRUNTIME_COMMIT}" > "${destination}/GIT_COMMIT_ID"
+  chmod 644 "${destination}/LICENSE" "${destination}/ThirdPartyNotices.txt" \
+    "${destination}/VERSION_NUMBER" "${destination}/GIT_COMMIT_ID"
+}
+
+prepare_freebsd_dependency_mirror() {
+  local source_dir="$1"
+  local cache_dir="$2"
+  local distinfo="${cache_dir}/freebsd-ports-${FREEBSD_PORTS_COMMIT}-onnxruntime-distinfo"
+  local mirror="${cache_dir}/freebsd-deps-${FREEBSD_PORTS_COMMIT}"
+  local manifest="${work_dir}/freebsd-dependencies.tsv"
+  local url expected_sha256 expected_size relative destination
+
+  download_verified \
+    "https://cgit.freebsd.org/ports/plain/misc/onnxruntime/distinfo?id=${FREEBSD_PORTS_COMMIT}" \
+    "${FREEBSD_DISTINFO_SHA256}" "${distinfo}"
+  python3 - "${source_dir}/cmake/deps.txt" "${distinfo}" "${manifest}" <<'PY'
+import pathlib
+import re
+import sys
+import urllib.parse
+
+deps_path, distinfo_path, manifest_path = map(pathlib.Path, sys.argv[1:])
+sha256 = {}
+sizes = {}
+pattern = re.compile(r"^(SHA256|SIZE) \(onnxruntime/(.+)\) = (.+)$")
+for line in distinfo_path.read_text().splitlines():
+    match = pattern.fullmatch(line)
+    if not match:
+        continue
+    kind, name, value = match.groups()
+    target = sha256 if kind == "SHA256" else sizes
+    if name in target:
+        raise SystemExit(f"duplicate {kind} entry in pinned FreeBSD distinfo: {name}")
+    target[name] = value
+
+rows = []
+seen_basenames = {}
+for line in deps_path.read_text().splitlines():
+    if not line or line.startswith("#"):
+        continue
+    fields = line.split(";")
+    if len(fields) != 3:
+        raise SystemExit(f"invalid ONNX Runtime dependency row: {line!r}")
+    _name, url, _sha1 = fields
+    parsed = urllib.parse.urlsplit(url)
+    if parsed.scheme != "https" or not parsed.netloc or parsed.query or parsed.fragment:
+        raise SystemExit(f"dependency URL is not a plain HTTPS URL: {url}")
+    basename = pathlib.PurePosixPath(parsed.path).name
+    previous = seen_basenames.setdefault(basename, url)
+    if previous != url:
+        raise SystemExit(
+            f"ambiguous dependency basename {basename!r}: {previous!r} and {url!r}"
+        )
+    if basename not in sha256 or basename not in sizes:
+        raise SystemExit(
+            f"pinned FreeBSD distinfo has no SHA256/SIZE for dependency {basename!r}"
+        )
+    relative = f"{parsed.netloc}{parsed.path}"
+    if "\t" in relative or "\n" in relative:
+        raise SystemExit(f"unsafe dependency mirror path: {relative!r}")
+    rows.append((url, sha256[basename], sizes[basename], relative))
+
+if not rows:
+    raise SystemExit("ONNX Runtime dependency manifest is empty")
+manifest_path.write_text(
+    "".join("\t".join(row) + "\n" for row in rows)
+)
+PY
+
+  while IFS=$'\t' read -r url expected_sha256 expected_size relative; do
+    [[ -n "${url}" && -n "${expected_sha256}" && -n "${expected_size}" && -n "${relative}" ]] || \
+      die "invalid row in generated FreeBSD dependency manifest"
+    destination="${mirror}/${relative}"
+    download_verified "${url}" "${expected_sha256}" "${destination}"
+    verify_size "${destination}" "${expected_size}"
+  done < "${manifest}"
+
+  python3 - "${source_dir}/cmake/deps.txt" "${mirror}" <<'PY'
+import pathlib
+import sys
+import urllib.parse
+
+deps_path = pathlib.Path(sys.argv[1])
+mirror = pathlib.Path(sys.argv[2]).resolve()
+rewritten = []
+for line in deps_path.read_text().splitlines(keepends=True):
+    ending = "\n" if line.endswith("\n") else ""
+    body = line[:-1] if ending else line
+    if not body or body.startswith("#"):
+        rewritten.append(line)
+        continue
+    fields = body.split(";")
+    if len(fields) != 3:
+        raise SystemExit(f"invalid ONNX Runtime dependency row: {line!r}")
+    parsed = urllib.parse.urlsplit(fields[1])
+    relative = pathlib.PurePosixPath(parsed.netloc + parsed.path)
+    local_path = mirror.joinpath(*relative.parts)
+    if not local_path.is_file():
+        raise SystemExit(f"verified dependency mirror entry is missing: {local_path}")
+    fields[1] = local_path.as_uri()
+    rewritten.append(";".join(fields) + ending)
+deps_path.write_text("".join(rewritten))
+PY
+}
+
+stage_freebsd_source_build() {
+  local destination="$1"
+  local cache_dir="$2"
+  local source_archive="${cache_dir}/onnxruntime-${ONNXRUNTIME_VERSION}-source.tar.gz"
+  local spin_pause_patch="${cache_dir}/${FREEBSD_SPIN_PAUSE_PATCH}-${FREEBSD_PORTS_COMMIT}"
+  local posix_env_patch="${cache_dir}/${FREEBSD_POSIX_ENV_PATCH}-${FREEBSD_PORTS_COMMIT}"
+  local build_root="${CTX_ONNXRUNTIME_BUILD_DIR:-${work_dir}/freebsd-x64-build}"
+  local source_parent="${build_root}/source"
+  local source_dir="${source_parent}/onnxruntime-${ONNXRUNTIME_VERSION}"
+  local cmake_build_dir="${build_root}/build"
+  local jobs="${CTX_ONNXRUNTIME_BUILD_JOBS:-}"
+  local freebsd_userland cmake_version cc cxx make_program patch_program python_program
+  local reproducible_root common_flags cxx_flags built_library candidate
+  local -a cmake_args build_args library_candidates
+
+  [[ "$(uname -s)" == "FreeBSD" ]] || \
+    die "freebsd-x64 ONNX Runtime must be built on a native FreeBSD host"
+  case "$(uname -m)" in
+    x86_64|amd64) ;;
+    *) die "freebsd-x64 ONNX Runtime requires an x64 FreeBSD host, got $(uname -m)" ;;
+  esac
+  require_command freebsd-version
+  require_command cmake
+  require_command python3
+  require_command clang
+  require_command clang++
+  require_command make
+  require_command gpatch
+
+  freebsd_userland="$(freebsd-version -u)"
+  case "${freebsd_userland}" in
+    "${FREEBSD_ABI_MAJOR}."*) ;;
+    *) die "freebsd-x64 ONNX Runtime requires a FreeBSD ${FREEBSD_ABI_MAJOR} userland, got ${freebsd_userland}" ;;
+  esac
+  [[ "${freebsd_userland}" =~ ^[A-Za-z0-9._+-]+$ ]] || \
+    die "freebsd-version returned an unsafe userland identifier: ${freebsd_userland}"
+  cmake_version="$(cmake --version | awk 'NR == 1 { print $3 }')"
+  python3 - "${cmake_version}" <<'PY'
+import sys
+
+actual = tuple(int(part) for part in sys.argv[1].split("."))
+if actual < (3, 28):
+    raise SystemExit(f"CMake >= 3.28 is required, got {sys.argv[1]}")
+PY
+  if [[ -n "${jobs}" ]]; then
+    [[ "${jobs}" =~ ^[1-9][0-9]*$ ]] || die "CTX_ONNXRUNTIME_BUILD_JOBS must be a positive integer"
+  fi
+
+  download_verified "${ONNXRUNTIME_SOURCE_URL}" "${ONNXRUNTIME_SOURCE_SHA256}" "${source_archive}"
+  download_verified \
+    "${FREEBSD_PORTS_PATCH_BASE_URL}/${FREEBSD_SPIN_PAUSE_PATCH}?id=${FREEBSD_PORTS_COMMIT}" \
+    "${FREEBSD_SPIN_PAUSE_PATCH_SHA256}" "${spin_pause_patch}"
+  download_verified \
+    "${FREEBSD_PORTS_PATCH_BASE_URL}/${FREEBSD_POSIX_ENV_PATCH}?id=${FREEBSD_PORTS_COMMIT}" \
+    "${FREEBSD_POSIX_ENV_PATCH_SHA256}" "${posix_env_patch}"
+  validate_source_archive_layout "${source_archive}"
+  rm -rf "${source_parent}" "${cmake_build_dir}"
+  mkdir -p "${source_parent}" "${cmake_build_dir}"
+  tar -xzf "${source_archive}" -C "${source_parent}"
+  verify_sha256 "${source_dir}/cmake/deps.txt" "${ONNXRUNTIME_DEPS_SHA256}"
+  prepare_freebsd_dependency_mirror "${source_dir}" "${cache_dir}"
+
+  patch_program="$(command -v gpatch)"
+  "${patch_program}" --batch --forward --fuzz=0 -p0 -d "${source_dir}" < "${spin_pause_patch}"
+  "${patch_program}" --batch --forward --fuzz=0 -p0 -d "${source_dir}" < "${posix_env_patch}"
+  python3 - "${source_dir}/cmake/CMakeLists.txt" \
+    "${FREEBSD_BUILD_RECIPE}" "${ONNXRUNTIME_SOURCE_SHA256}" \
+    "${FREEBSD_PORTS_COMMIT}" "${FREEBSD_DISTINFO_SHA256}" \
+    "${FREEBSD_ABI_MAJOR}" "${freebsd_userland}" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+recipe, source_sha256, ports_commit, deps_sha256, abi, freebsd_userland = sys.argv[2:]
+needle = 'string(APPEND ORT_BUILD_INFO "build type=${CMAKE_BUILD_TYPE}")'
+provenance = (
+    'string(APPEND ORT_BUILD_INFO '
+    f'"ctx-recipe={recipe}, ctx-source-sha256={source_sha256}, '
+    f'ctx-freebsd-ports={ports_commit}, ctx-deps-sha256={deps_sha256}, '
+    f'ctx-freebsd-abi={abi}, ctx-freebsd-userland={freebsd_userland}, '
+    'ctx-os=${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_VERSION}, '
+    'ctx-compiler=${CMAKE_CXX_COMPILER_ID}-${CMAKE_CXX_COMPILER_VERSION}, '
+    'ctx-cmake=${CMAKE_VERSION}, ")'
+)
+text = path.read_text()
+if text.count(needle) != 1:
+    raise SystemExit("could not locate the unique ONNX Runtime build-info insertion point")
+path.write_text(text.replace(needle, provenance + "\n" + needle))
+PY
+
+  cc="$(command -v clang)"
+  cxx="$(command -v clang++)"
+  make_program="$(command -v make)"
+  python_program="$(command -v python3)"
+  reproducible_root="/usr/src/ctx-onnxruntime-${ONNXRUNTIME_VERSION}"
+  common_flags="-ffile-prefix-map=${source_dir}=${reproducible_root} -ffile-prefix-map=${cmake_build_dir}=${reproducible_root}/build -fdebug-prefix-map=${source_dir}=${reproducible_root} -fdebug-prefix-map=${cmake_build_dir}=${reproducible_root}/build"
+  cxx_flags="${common_flags} -Wno-array-bounds -Wno-deprecated-declarations -I${source_dir}/include/onnxruntime/core/common/logging -frtti"
+  cmake_args=(
+    --compile-no-warning-as-error
+    -S "${source_dir}/cmake"
+    -B "${cmake_build_dir}"
+    -G "Unix Makefiles"
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_C_COMPILER=${cc}"
+    "-DCMAKE_CXX_COMPILER=${cxx}"
+    "-DCMAKE_MAKE_PROGRAM=${make_program}"
+    "-DPython_EXECUTABLE=${python_program}"
+    "-DPython3_EXECUTABLE=${python_program}"
+    "-DCMAKE_C_FLAGS=${common_flags}"
+    "-DCMAKE_CXX_FLAGS=${cxx_flags}"
+    "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
+    "-DCMAKE_INSTALL_RPATH="
+    "-DCMAKE_SKIP_INSTALL_RPATH=ON"
+    "-DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF"
+    "-DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF"
+    "-DCMAKE_DISABLE_FIND_PACKAGE_Git=TRUE"
+    "-DFETCHCONTENT_TRY_FIND_PACKAGE_MODE=NEVER"
+    "-DFETCHCONTENT_FULLY_DISCONNECTED=OFF"
+    "-DPatch_EXECUTABLE=${patch_program}"
+    "-Donnxruntime_BUILD_SHARED_LIB=ON"
+    "-Donnxruntime_BUILD_UNIT_TESTS=OFF"
+    "-Donnxruntime_BUILD_BENCHMARKS=OFF"
+    "-Donnxruntime_BUILD_FOR_NATIVE_MACHINE=OFF"
+    "-Donnxruntime_ENABLE_CPUINFO=OFF"
+    "-Donnxruntime_ENABLE_PYTHON=OFF"
+    "-Donnxruntime_GENERATE_TEST_REPORTS=OFF"
+    "-Donnxruntime_RUN_ONNX_TESTS=OFF"
+    "-Donnxruntime_USE_AVX=OFF"
+    "-Donnxruntime_USE_AVX2=OFF"
+    "-Donnxruntime_USE_AVX512=OFF"
+    "-Donnxruntime_USE_MIMALLOC=OFF"
+    "-Donnxruntime_USE_XNNPACK=OFF"
+  )
+  env -u CC -u CXX -u CFLAGS -u CXXFLAGS -u CPPFLAGS -u LDFLAGS \
+    -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u LIBRARY_PATH \
+    -u CMAKE_GENERATOR -u CMAKE_GENERATOR_PLATFORM -u CMAKE_GENERATOR_TOOLSET \
+    -u CMAKE_PREFIX_PATH -u CMAKE_TOOLCHAIN_FILE -u MAKEFLAGS -u MFLAGS \
+    SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}" ZERO_AR_DATE=1 TZ=UTC LC_ALL=C LANG=C \
+    cmake "${cmake_args[@]}"
+
+  build_args=(--build "${cmake_build_dir}" --config Release --target onnxruntime)
+  if [[ -n "${jobs}" ]]; then
+    build_args+=(--parallel "${jobs}")
+  else
+    build_args+=(--parallel)
+  fi
+  env -u CC -u CXX -u CFLAGS -u CXXFLAGS -u CPPFLAGS -u LDFLAGS \
+    -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u LIBRARY_PATH \
+    -u MAKEFLAGS -u MFLAGS -u CMAKE_BUILD_PARALLEL_LEVEL \
+    SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}" ZERO_AR_DATE=1 TZ=UTC LC_ALL=C LANG=C \
+    cmake "${build_args[@]}"
+
+  library_candidates=(
+    "${cmake_build_dir}/libonnxruntime.so.${ONNXRUNTIME_VERSION}"
+    "${cmake_build_dir}/libonnxruntime.so"
+    "${cmake_build_dir}/Release/libonnxruntime.so.${ONNXRUNTIME_VERSION}"
+    "${cmake_build_dir}/Release/libonnxruntime.so"
+    "${cmake_build_dir}/Release/lib/libonnxruntime.so.${ONNXRUNTIME_VERSION}"
+    "${cmake_build_dir}/Release/lib/libonnxruntime.so"
+  )
+  built_library=""
+  for candidate in "${library_candidates[@]}"; do
+    if [[ -f "${candidate}" ]]; then
+      built_library="${candidate}"
+      break
+    fi
+  done
+  [[ -n "${built_library}" ]] || \
+    die "freebsd-x64 source build did not produce libonnxruntime.so"
+
+  cp -L "${built_library}" "${destination}/lib/${library_name}"
+  chmod 755 "${destination}/lib/${library_name}"
+  stage_pinned_documents "${destination}" "${cache_dir}"
+}
+
+create_archive() {
+  local source_dir="$1"
+  local output="$2"
+
+  if [[ "${archive_kind}" == "tar.zst" ]]; then
+    require_command zstd
+    python3 - "${source_dir}" "${output}.tar" "${library_name}" <<'PY'
+import os
+import sys
+import tarfile
+
+source, output, library = sys.argv[1:]
+mtime = 1781827200
+with tarfile.open(output, "w", format=tarfile.USTAR_FORMAT) as bundle:
+    directory = tarfile.TarInfo("lib/")
+    directory.type = tarfile.DIRTYPE
+    directory.mode = 0o755
+    directory.uid = directory.gid = 0
+    directory.uname = directory.gname = "root"
+    directory.mtime = mtime
+    bundle.addfile(directory)
+    for name in ("LICENSE", "ThirdPartyNotices.txt", "VERSION_NUMBER", "GIT_COMMIT_ID", f"lib/{library}"):
+        path = os.path.join(source, *name.split("/"))
+        info = tarfile.TarInfo(name)
+        info.size = os.path.getsize(path)
+        info.mode = 0o755 if name.startswith("lib/") else 0o644
+        info.uid = info.gid = 0
+        info.uname = info.gname = "root"
+        info.mtime = mtime
+        with open(path, "rb") as handle:
+            bundle.addfile(info, handle)
+PY
+    zstd -q -19 --threads=0 -f "${output}.tar" -o "${output}"
+    rm -f "${output}.tar"
+  else
+    python3 - "${source_dir}" "${output}" "${library_name}" <<'PY'
+import os
+import sys
+import zipfile
+
+source, output, library = sys.argv[1:]
+timestamp = (2026, 6, 19, 0, 0, 0)
+
+
+def info(name, mode):
+    entry = zipfile.ZipInfo(name, timestamp)
+    entry.create_system = 3
+    entry.compress_type = zipfile.ZIP_DEFLATED
+    entry.external_attr = mode << 16
+    return entry
+
+
+with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9) as bundle:
+    bundle.writestr(info("lib/", 0o40755), b"")
+    for name in ("LICENSE", "ThirdPartyNotices.txt", "VERSION_NUMBER", "GIT_COMMIT_ID", f"lib/{library}"):
+        path = os.path.join(source, *name.split("/"))
+        mode = 0o100755 if name.startswith("lib/") else 0o100644
+        with open(path, "rb") as handle:
+            bundle.writestr(info(name, mode), handle.read())
+PY
+  fi
+}
+
+extract_and_check_archive_layout() {
+  local archive="$1"
+  local destination="$2"
+  local inspection_archive="${archive}"
+
+  if [[ "${archive_kind}" == "tar.zst" ]]; then
+    require_command zstd
+    zstd -q -t "${archive}"
+    inspection_archive="${work_dir}/validated.tar"
+    zstd -q -d -f "${archive}" -o "${inspection_archive}"
+  fi
+
+  python3 - "${archive_kind}" "${inspection_archive}" "${destination}" "${library_name}" <<'PY'
+import os
+import posixpath
+import shutil
+import stat
+import sys
+import tarfile
+import zipfile
+
+kind, archive, destination, library = sys.argv[1:]
+expected_files = {
+    "LICENSE",
+    "ThirdPartyNotices.txt",
+    "VERSION_NUMBER",
+    "GIT_COMMIT_ID",
+    f"lib/{library}",
+}
+expected_entries = expected_files | {"lib"}
+
+
+def canonical_name(raw):
+    if not raw or "\\" in raw or raw.startswith("/"):
+        raise SystemExit(f"unsafe sidecar archive path: {raw!r}")
+    while raw.startswith("./"):
+        raw = raw[2:]
+    name = posixpath.normpath(raw.rstrip("/"))
+    if name in ("", ".", "..") or name.startswith("../"):
+        raise SystemExit(f"unsafe sidecar archive path: {raw!r}")
+    return name
+
+
+os.makedirs(os.path.join(destination, "lib"), exist_ok=True)
+seen = set()
+if kind == "tar.zst":
+    with tarfile.open(archive, "r:") as bundle:
+        members = {}
+        for member in bundle.getmembers():
+            name = canonical_name(member.name)
+            if name in seen:
+                raise SystemExit(f"duplicate sidecar archive entry: {name}")
+            seen.add(name)
+            if name not in expected_entries:
+                raise SystemExit(f"unexpected sidecar archive entry: {name}")
+            if member.mode & 0o7000:
+                raise SystemExit(f"unsafe permission bits on sidecar archive entry: {name}")
+            if name == "lib":
+                if not member.isdir():
+                    raise SystemExit("sidecar lib entry is not a directory")
+            elif not member.isfile():
+                raise SystemExit(f"sidecar entry is not a regular file: {name}")
+            members[name] = member
+        if seen != expected_entries:
+            missing = sorted(expected_entries - seen)
+            raise SystemExit("sidecar archive entries missing: " + ", ".join(missing))
+        for name in expected_files:
+            member = members[name]
+            source_file = bundle.extractfile(member)
+            if source_file is None:
+                raise SystemExit(f"could not read sidecar archive member: {name}")
+            target = os.path.join(destination, *name.split("/"))
+            with source_file, open(target, "wb") as output:
+                shutil.copyfileobj(source_file, output)
+elif kind == "zip":
+    with zipfile.ZipFile(archive) as bundle:
+        members = {}
+        for member in bundle.infolist():
+            name = canonical_name(member.filename)
+            if name in seen:
+                raise SystemExit(f"duplicate sidecar archive entry: {name}")
+            seen.add(name)
+            if name not in expected_entries:
+                raise SystemExit(f"unexpected sidecar archive entry: {name}")
+            if member.flag_bits & 1:
+                raise SystemExit(f"encrypted sidecar archive entry: {name}")
+            mode = member.external_attr >> 16
+            if stat.S_ISLNK(mode):
+                raise SystemExit(f"sidecar zip contains a symbolic link: {name}")
+            if mode & 0o7000:
+                raise SystemExit(f"unsafe permission bits on sidecar archive entry: {name}")
+            if name == "lib":
+                if not member.is_dir():
+                    raise SystemExit("sidecar lib entry is not a directory")
+            elif member.is_dir():
+                raise SystemExit(f"sidecar entry is not a regular file: {name}")
+            members[name] = member
+        if seen != expected_entries:
+            missing = sorted(expected_entries - seen)
+            raise SystemExit("sidecar archive entries missing: " + ", ".join(missing))
+        for name in expected_files:
+            target = os.path.join(destination, *name.split("/"))
+            with bundle.open(members[name]) as source_file, open(target, "wb") as output:
+                shutil.copyfileobj(source_file, output)
+else:
+    raise SystemExit(f"unsupported sidecar archive kind: {kind}")
+PY
+}
+
+check_native_library() {
+  local library="$1"
+  local max_glibc="${CTX_ONNXRUNTIME_MAX_GLIBC:-${ONNXRUNTIME_MAX_GLIBC}}"
+
+  [[ "${max_glibc}" =~ ^[0-9]+\.[0-9]+$ ]] || \
+    die "CTX_ONNXRUNTIME_MAX_GLIBC must be MAJOR.MINOR, got ${max_glibc}"
+  python3 - "${platform}" "${library}" "${ONNXRUNTIME_VERSION}" "${max_glibc}" \
+    "${FREEBSD_BUILD_RECIPE}" "${ONNXRUNTIME_SOURCE_SHA256}" \
+    "${FREEBSD_PORTS_COMMIT}" "${FREEBSD_DISTINFO_SHA256}" \
+    "${FREEBSD_ABI_MAJOR}" <<'PY'
+import re
+import struct
+import sys
+
+(
+    platform,
+    path,
+    version,
+    max_glibc,
+    recipe,
+    source_sha256,
+    ports_commit,
+    deps_sha256,
+    freebsd_abi,
+) = sys.argv[1:]
+with open(path, "rb") as handle:
+    data = handle.read()
+if len(data) < 64:
+    raise SystemExit(f"native runtime library is implausibly small: {len(data)} bytes")
+if version.encode() not in data:
+    raise SystemExit(f"native runtime library does not contain version marker {version}")
+
+if platform.startswith("linux-") or platform == "freebsd-x64":
+    if data[:4] != b"\x7fELF" or data[4] != 2 or data[5] != 1:
+        raise SystemExit("native runtime library is not 64-bit little-endian ELF")
+    elf_type, machine = struct.unpack_from("<HH", data, 16)
+    expected_machine = 183 if platform == "linux-aarch64" else 62
+    if elf_type != 3:
+        raise SystemExit(f"native runtime ELF type is {elf_type}, expected ET_DYN (3)")
+    if machine != expected_machine:
+        raise SystemExit(
+            f"native runtime ELF machine is {machine}, expected {expected_machine} for {platform}"
+        )
+    osabi = data[7]
+    if platform == "freebsd-x64":
+        if osabi != 9:
+            raise SystemExit(f"native runtime ELF OSABI is {osabi}, expected FreeBSD (9)")
+        required_provenance = (
+            f"ctx-recipe={recipe}",
+            f"ctx-source-sha256={source_sha256}",
+            f"ctx-freebsd-ports={ports_commit}",
+            f"ctx-deps-sha256={deps_sha256}",
+            f"ctx-freebsd-abi={freebsd_abi}",
+            f"ctx-freebsd-userland={freebsd_abi}.",
+            "ctx-os=FreeBSD-",
+            "ctx-compiler=Clang-",
+            "ctx-cmake=",
+            "build type=Release",
+        )
+        missing = [marker for marker in required_provenance if marker.encode() not in data]
+        if missing:
+            raise SystemExit(
+                "native FreeBSD runtime is missing pinned build provenance: "
+                + ", ".join(missing)
+            )
+    elif osabi not in (0, 3):
+        raise SystemExit(f"native runtime ELF OSABI is {osabi}, expected System V or GNU/Linux")
+    if platform.startswith("linux-"):
+        versions = {
+            (int(match.group(1)), int(match.group(2)))
+            for match in re.finditer(rb"GLIBC_(\d+)\.(\d+)", data)
+        }
+        if not versions:
+            raise SystemExit("native Linux runtime has no GLIBC symbol versions")
+        allowed = tuple(int(part) for part in max_glibc.split("."))
+        required = max(versions)
+        if required > allowed:
+            raise SystemExit(
+                f"native Linux runtime requires GLIBC_{required[0]}.{required[1]}, "
+                f"newer than allowed GLIBC_{allowed[0]}.{allowed[1]}"
+            )
+elif platform.startswith("macos-"):
+    magic, cpu_type, _cpu_subtype, file_type = struct.unpack_from("<IIII", data, 0)
+    expected_cpu = 0x0100000C if platform == "macos-arm64" else 0x01000007
+    if magic != 0xFEEDFACF:
+        raise SystemExit("native runtime library is not a thin 64-bit little-endian Mach-O")
+    if cpu_type != expected_cpu:
+        raise SystemExit(
+            f"native runtime Mach-O CPU type is 0x{cpu_type:08x}, "
+            f"expected 0x{expected_cpu:08x} for {platform}"
+        )
+    if file_type != 6:
+        raise SystemExit(f"native runtime Mach-O file type is {file_type}, expected MH_DYLIB (6)")
+elif platform == "windows-x64":
+    if data[:2] != b"MZ" or len(data) < 0x40:
+        raise SystemExit("native runtime library is not a PE image")
+    pe_offset = struct.unpack_from("<I", data, 0x3C)[0]
+    if pe_offset + 26 > len(data) or data[pe_offset : pe_offset + 4] != b"PE\0\0":
+        raise SystemExit("native runtime library has an invalid PE header")
+    machine = struct.unpack_from("<H", data, pe_offset + 4)[0]
+    characteristics = struct.unpack_from("<H", data, pe_offset + 22)[0]
+    optional_magic = struct.unpack_from("<H", data, pe_offset + 24)[0]
+    if machine != 0x8664:
+        raise SystemExit(f"native runtime PE machine is 0x{machine:04x}, expected AMD64")
+    if optional_magic != 0x20B:
+        raise SystemExit("native runtime PE image is not PE32+")
+    if not characteristics & 0x2000:
+        raise SystemExit("native runtime PE image is not marked as a DLL")
+else:
+    raise SystemExit(f"unsupported platform: {platform}")
+PY
+}
+
+host_matches_platform() {
+  local system machine
+
+  system="$(uname -s 2>/dev/null || true)"
+  machine="$(uname -m 2>/dev/null || true)"
+  case "${platform}:${system}:${machine}" in
+    linux-x64:Linux:x86_64|linux-x64:Linux:amd64) return 0 ;;
+    linux-aarch64:Linux:aarch64|linux-aarch64:Linux:arm64) return 0 ;;
+    macos-arm64:Darwin:arm64|macos-x64:Darwin:x86_64) return 0 ;;
+    freebsd-x64:FreeBSD:x86_64|freebsd-x64:FreeBSD:amd64) return 0 ;;
+    windows-x64:MINGW*:x86_64|windows-x64:MSYS*:x86_64|windows-x64:CYGWIN*:x86_64) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+check_native_runtime_version() {
+  local library="$1"
+
+  if ! host_matches_platform; then
+    printf 'native ONNX Runtime load check skipped on %s/%s for %s\n' \
+      "$(uname -s 2>/dev/null || printf unknown)" "$(uname -m 2>/dev/null || printf unknown)" "${platform}"
+    return
+  fi
+
+  python3 - "${platform}" "${library}" "${ONNXRUNTIME_VERSION}" \
+    "${ONNXRUNTIME_API_VERSION}" "${FREEBSD_BUILD_RECIPE}" \
+    "${ONNXRUNTIME_SOURCE_SHA256}" "${FREEBSD_PORTS_COMMIT}" \
+    "${FREEBSD_DISTINFO_SHA256}" "${FREEBSD_ABI_MAJOR}" <<'PY'
+import ctypes
+import os
+import sys
+
+(
+    platform,
+    path,
+    expected,
+    api_version,
+    recipe,
+    source_sha256,
+    ports_commit,
+    deps_sha256,
+    freebsd_abi,
+) = sys.argv[1:]
+if os.name == "nt":
+    os.add_dll_directory(os.path.dirname(os.path.abspath(path)))
+runtime = ctypes.CDLL(os.path.abspath(path))
+runtime.OrtGetApiBase.argtypes = []
+runtime.OrtGetApiBase.restype = ctypes.c_void_p
+base = runtime.OrtGetApiBase()
+if not base:
+    raise SystemExit("OrtGetApiBase returned null")
+entries = ctypes.cast(base, ctypes.POINTER(ctypes.c_void_p))
+callback_type = getattr(ctypes, "WINFUNCTYPE", ctypes.CFUNCTYPE) if os.name == "nt" else ctypes.CFUNCTYPE
+get_api = callback_type(ctypes.c_void_p, ctypes.c_uint32)(entries[0])
+api = get_api(int(api_version))
+if not api:
+    raise SystemExit(f"OrtApiBase::GetApi({api_version}) returned null")
+get_version = callback_type(ctypes.c_char_p)(entries[1])
+actual_bytes = get_version()
+actual = actual_bytes.decode("utf-8") if actual_bytes else ""
+if actual != expected:
+    raise SystemExit(f"OrtGetVersionString returned {actual!r}, expected {expected!r}")
+if platform == "freebsd-x64":
+    api_entries = ctypes.cast(api, ctypes.POINTER(ctypes.c_void_p))
+    get_build_info_address = api_entries[254]
+    if not get_build_info_address:
+        raise SystemExit("OrtApi::GetBuildInfoString is null")
+    get_build_info = callback_type(ctypes.c_char_p)(get_build_info_address)
+    build_info_bytes = get_build_info()
+    build_info = build_info_bytes.decode("utf-8") if build_info_bytes else ""
+    required_provenance = (
+        f"ctx-recipe={recipe}",
+        f"ctx-source-sha256={source_sha256}",
+        f"ctx-freebsd-ports={ports_commit}",
+        f"ctx-deps-sha256={deps_sha256}",
+        f"ctx-freebsd-abi={freebsd_abi}",
+        f"ctx-freebsd-userland={freebsd_abi}.",
+        "ctx-os=FreeBSD-",
+        "ctx-compiler=Clang-",
+        "ctx-cmake=",
+        "build type=Release",
+    )
+    missing = [marker for marker in required_provenance if marker not in build_info]
+    if missing:
+        raise SystemExit(
+            "OrtGetBuildInfoString is missing pinned FreeBSD provenance: "
+            + ", ".join(missing)
+        )
+PY
+}
+
+validate_archive() {
+  local archive="$1"
+  local archive_base validation_dir library_path
+
+  [[ -f "${archive}" ]] || die "ONNX Runtime sidecar archive not found: ${archive}"
+  archive_base="$(basename "${archive}")"
+  [[ "${archive_base}" == "${asset_name}" ]] || \
+    die "sidecar archive must be named ${asset_name}, got ${archive_base}"
+
+  validation_dir="${work_dir}/validation"
+  rm -rf "${validation_dir}"
+  mkdir -p "${validation_dir}"
+  extract_and_check_archive_layout "${archive}" "${validation_dir}"
+
+  verify_sha256 "${validation_dir}/LICENSE" "${ONNXRUNTIME_LICENSE_SHA256}"
+  verify_sha256 "${validation_dir}/ThirdPartyNotices.txt" "${ONNXRUNTIME_NOTICES_SHA256}"
+  [[ "$(cat "${validation_dir}/VERSION_NUMBER")" == "${ONNXRUNTIME_VERSION}" ]] || \
+    die "sidecar VERSION_NUMBER is not exactly ${ONNXRUNTIME_VERSION}"
+  [[ "$(wc -c < "${validation_dir}/VERSION_NUMBER" | tr -d '[:space:]')" == "7" ]] || \
+    die "sidecar VERSION_NUMBER has unexpected whitespace or content"
+  [[ "$(cat "${validation_dir}/GIT_COMMIT_ID")" == "${ONNXRUNTIME_COMMIT}" ]] || \
+    die "sidecar GIT_COMMIT_ID is not ${ONNXRUNTIME_COMMIT}"
+  [[ "$(wc -c < "${validation_dir}/GIT_COMMIT_ID" | tr -d '[:space:]')" == "41" ]] || \
+    die "sidecar GIT_COMMIT_ID has unexpected whitespace or content"
+
+  library_path="${validation_dir}/lib/${library_name}"
+  [[ -s "${library_path}" ]] || die "sidecar runtime library is missing or empty: lib/${library_name}"
+  [[ "$(wc -c < "${library_path}" | tr -d '[:space:]')" -ge 1048576 ]] || \
+    die "sidecar runtime library is implausibly small: lib/${library_name}"
+  check_native_library "${library_path}"
+  check_native_runtime_version "${library_path}"
+  printf 'ONNX Runtime sidecar ok: %s version=%s\n' "${platform}" "${ONNXRUNTIME_VERSION}"
+}
+
+mode="build"
+if [[ "${1:-}" == "--validate" ]]; then
+  mode="validate"
+  shift
+fi
+if [[ -z "${1:-}" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  if [[ -z "${1:-}" ]]; then
+    exit 2
+  fi
+  exit 0
+fi
+
+configure_platform "$1"
+shift
+require_command python3
+require_command tar
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/ctx-onnxruntime-sidecar.XXXXXX")"
+trap 'rm -rf "${work_dir}"' EXIT
+
+if [[ "${mode}" == "validate" ]]; then
+  [[ $# -eq 1 ]] || {
+    usage
+    exit 2
+  }
+  validate_archive "$1"
+  exit 0
+fi
+
+[[ $# -le 1 ]] || {
+  usage
+  exit 2
+}
+output_dir="${1:-target/public-cli-artifacts}"
+cache_dir="${CTX_ONNXRUNTIME_CACHE_DIR:-target/onnxruntime-sidecar-cache}"
+stage_dir="${work_dir}/stage"
+package_dir="${work_dir}/package"
+mkdir -p "${stage_dir}/lib" "${package_dir}" "${cache_dir}"
+
+case "${platform}" in
+  linux-x64|linux-aarch64|macos-arm64|windows-x64)
+    stage_official_release "${stage_dir}" "${cache_dir}"
+    ;;
+  macos-x64)
+    stage_macos_x64_source_build "${stage_dir}" "${cache_dir}"
+    ;;
+  freebsd-x64)
+    stage_freebsd_source_build "${stage_dir}" "${cache_dir}"
+    ;;
+esac
+
+package_path="${package_dir}/${asset_name}"
+create_archive "${stage_dir}" "${package_path}"
+validate_archive "${package_path}"
+
+mkdir -p "${output_dir}"
+temporary_output="${output_dir%/}/.${asset_name}.tmp.$$"
+rm -f "${temporary_output}"
+cp "${package_path}" "${temporary_output}"
+chmod 644 "${temporary_output}"
+mv "${temporary_output}" "${output_dir%/}/${asset_name}"
+sha256_file "${output_dir%/}/${asset_name}" > "${output_dir%/}/${asset_name}.sha256.tmp.$$"
+mv "${output_dir%/}/${asset_name}.sha256.tmp.$$" "${output_dir%/}/${asset_name}.sha256"
+printf 'built %s sha256=%s\n' \
+  "${output_dir%/}/${asset_name}" "$(cat "${output_dir%/}/${asset_name}.sha256")"

--- a/scripts/build-public-cli-artifact.sh
+++ b/scripts/build-public-cli-artifact.sh
@@ -670,8 +670,12 @@ if [[ "${platform}" != linux-* ]]; then
   if [[ "$(tr -d '\r' < "${staged}.version" | tail -n 1)" == "ctx ${version}" ]]; then
     local_runtime_status=passed
   fi
+  IFS=$'\t' read -r \
+    host_system host_arch host_native_arch process_translated _native_arch_probe \
+    < <(scripts/public-cli-host-runtime-evidence.sh)
   local_runtime_authority="$(scripts/public-cli-runtime-authority.sh \
-    "${platform}" "$(uname -s)" "$(uname -m)" "${local_runtime_status}")"
+    "${platform}" "${host_system}" "${host_arch}" "${local_runtime_status}" \
+    "${host_native_arch}" "${process_translated}")"
   python3 scripts/write-public-cli-build-info.py \
     --output "${staged}.build-info.json" \
     --artifact "${staged}" \

--- a/scripts/check-buildkite-pipeline.sh
+++ b/scripts/check-buildkite-pipeline.sh
@@ -23,7 +23,7 @@ if command -v ruby >/dev/null 2>&1; then
     data = YAML.load_file(ARGV.fetch(0))
     abort "pipeline must have steps" unless data.is_a?(Hash) && data["steps"].is_a?(Array)
     steps = data["steps"]
-    abort "pipeline should include public smoke and gated artifact matrix" unless steps.length == 8
+    abort "pipeline should include public smoke and gated artifact/native smoke matrices" unless steps.length == 11
     smoke = steps.fetch(0)
     abort "pipeline step must be a mapping" unless smoke.is_a?(Hash)
     abort "pipeline public smoke step must be keyed" unless smoke.key?("key")
@@ -41,11 +41,15 @@ if command -v ruby >/dev/null 2>&1; then
       public-cli-freebsd-x64
       public-cli-macos-arm64
       public-cli-macos-x64
+      public-cli-macos-x64-native-smoke
+      public-cli-windows-x64-native-smoke
+      public-cli-freebsd-x64-native-smoke
     ]
     actual_keys = steps.filter_map { |step| step["key"] if step.is_a?(Hash) }
     required_keys.each { |key| abort "missing gated artifact step #{key}" unless actual_keys.include?(key) }
+    artifact_keys = required_keys.first(6)
     steps.drop(2).each do |step|
-      next unless step.is_a?(Hash)
+      next unless step.is_a?(Hash) && artifact_keys.include?(step["key"])
       abort "artifact step #{step["key"]} must be gated" unless step["if"].to_s.include?("CTX_PUBLIC_CLI_ARTIFACT_MATRIX")
       artifact_paths = Array(step["artifact_paths"]).map(&:to_s)
       abort "artifact step #{step["key"]} must upload build-info evidence" unless artifact_paths.any? { |path| path.end_with?(".build-info.json") }
@@ -53,10 +57,69 @@ if command -v ruby >/dev/null 2>&1; then
     %w[public-cli-macos-arm64 public-cli-macos-x64].each do |key|
       step = steps.find { |candidate| candidate.is_a?(Hash) && candidate["key"] == key }
       abort "missing macOS artifact step #{key}" unless step
-      abort "#{key} must cross-build on release-linux-managed" unless step.dig("agents", "queue") == "release-linux-managed"
-      abort "#{key} must run on linux" unless step.dig("agents", "os") == "linux"
-      abort "#{key} must run on x86_64" unless step.dig("agents", "arch") == "x86_64"
-      abort "#{key} must not serialize on the Mac GUI queue" if step.key?("concurrency_group")
+      abort "#{key} must build on the native mac-shared queue" unless step.dig("agents", "queue") == "mac-shared"
+      abort "#{key} must run on Darwin" unless step.dig("agents", "os") == "darwin"
+      abort "#{key} must run on Apple Silicon" unless step.dig("agents", "arch") == "arm64"
+      abort "#{key} must serialize native Mac construction" unless step["concurrency"] == 1 && step["concurrency_group"] == "ctx-public-cli-macos-native"
+      command = step["command"].to_s
+      abort "#{key} must gate native smoke explicitly" unless command.include?("CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX")
+      abort "#{key} must force the CoreML smoke" unless command.include?("--coreml")
+      abort "#{key} must preserve native smoke evidence" unless command.include?("--keep-root")
+      proof = "target/public-cli-native-smoke/#{key.delete_prefix("public-cli-")}/**/packaged-runtime-proof.txt"
+      abort "#{key} must upload native smoke proof" unless Array(step["artifact_paths"]).include?(proof)
+      diagnostics = "target/public-cli-native-smoke/#{key.delete_prefix("public-cli-")}/**/daemon-smoke.log"
+      abort "#{key} must upload native smoke failure diagnostics" unless Array(step["artifact_paths"]).include?(diagnostics)
+    end
+    macos_arm64 = steps.find { |candidate| candidate.is_a?(Hash) && candidate["key"] == "public-cli-macos-arm64" }
+    abort "macos-arm64 smoke must require authoritative evidence" unless macos_arm64["command"].to_s.include?("runtime_authority=authoritative")
+    macos_x64 = steps.find { |candidate| candidate.is_a?(Hash) && candidate["key"] == "public-cli-macos-x64" }
+    abort "macos-x64 Rosetta smoke must remain explicitly non-authoritative" unless macos_x64["command"].to_s.include?("runtime_authority=non_authoritative")
+    inline_proofs = {
+      "public-cli-linux-x64" => "ctx-linux-x64.native-runtime-proof.txt",
+      "public-cli-linux-aarch64" => "ctx-linux-aarch64.native-runtime-proof.txt",
+      "public-cli-macos-arm64" => "ctx-macos-arm64.native-runtime-proof.txt",
+    }
+    inline_proofs.each do |key, proof_name|
+      step = steps.find { |candidate| candidate.is_a?(Hash) && candidate["key"] == key }
+      command = step["command"].to_s
+      abort "#{key} must gate packaged ONNX smoke" unless command.include?("CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX") && command.include?("--runtime-archive")
+      abort "#{key} must require authoritative proof" unless command.include?("runtime_authority=authoritative")
+      proof_path = "target/public-cli-artifacts/#{proof_name}"
+      abort "#{key} must publish #{proof_name}" unless Array(step["artifact_paths"]).include?(proof_path)
+    end
+    native_steps = {
+      "public-cli-macos-x64-native-smoke" => ["ctx-mac-gui-shared-x64", "ctx-macos-x64.native-runtime-proof.txt"],
+      "public-cli-windows-x64-native-smoke" => ["windows-x64", "ctx-windows-x64.native-runtime-proof.txt"],
+      "public-cli-freebsd-x64-native-smoke" => ["freebsd-x64", "ctx-freebsd-x64.native-runtime-proof.txt"],
+    }
+    native_steps.each do |key, values|
+      queue, proof_name = values
+      step = steps.find { |candidate| candidate.is_a?(Hash) && candidate["key"] == key }
+      abort "missing native semantic smoke step #{key}" unless step
+      condition = step["if"].to_s
+      abort "#{key} must require both artifact and native smoke gates" unless condition.include?("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") && condition.include?("CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX")
+      abort "#{key} must use #{queue}" unless step.dig("agents", "queue") == queue
+      command = step["command"].to_s
+      abort "#{key} must consume or build an ONNX runtime archive" unless command.include?("onnxruntime")
+      abort "#{key} must publish proof directly" unless command.include?("ProofOutput") || command.include?("--proof-output")
+      abort "#{key} must require authoritative execution" unless command.include?("runtime_authority=authoritative") || command.include?("RequireAuthoritative")
+      proof_path = "target/public-cli-artifacts/#{proof_name}"
+      abort "#{key} must publish #{proof_name}" unless Array(step["artifact_paths"]).include?(proof_path)
+    end
+    runtime_builds = {
+      "public-cli-linux-x64" => "linux-x64",
+      "public-cli-linux-aarch64" => "linux-aarch64",
+      "public-cli-windows-x64" => "windows-x64",
+      "public-cli-macos-arm64" => "macos-arm64",
+    }
+    runtime_builds.each do |key, platform|
+      step = steps.find { |candidate| candidate.is_a?(Hash) && candidate["key"] == key }
+      abort "missing runtime-producing artifact step #{key}" unless step
+      command = step["command"].to_s
+      abort "#{key} must build its ONNX Runtime sidecar" unless command.include?("scripts/build-onnxruntime-sidecar.sh #{platform}")
+      archive = platform == "windows-x64" ? "ctx-onnxruntime-windows-x64.zip" : "ctx-onnxruntime-#{platform}.tar.gz"
+      abort "#{key} must upload #{archive}" unless Array(step["artifact_paths"]).include?("target/public-cli-artifacts/#{archive}")
+      abort "#{key} must upload #{archive}.sha256" unless Array(step["artifact_paths"]).include?("target/public-cli-artifacts/#{archive}.sha256")
     end
     linux_aarch64 = steps.find { |candidate| candidate.is_a?(Hash) && candidate["key"] == "public-cli-linux-aarch64" }
     abort "missing linux-aarch64 artifact step" unless linux_aarch64
@@ -73,8 +136,8 @@ else
       END { print count + 0 }
     ' "${pipeline}"
   )"
-  if [[ "${top_level_steps}" != "8" ]]; then
-    printf 'pipeline should include public smoke and gated artifact matrix\n' >&2
+  if [[ "${top_level_steps}" != "11" ]]; then
+    printf 'pipeline should include public smoke and gated artifact/native smoke matrices\n' >&2
     exit 1
   fi
 fi
@@ -183,17 +246,18 @@ fi
 
 for mac_step in public-cli-macos-arm64 public-cli-macos-x64; do
   for required in \
-    'queue: "release-linux-managed"' \
-    'ctx-runner-class: "release-linux-control"' \
-    'os: "linux"' \
-    'arch: "x86_64"'; do
+    'queue: "mac-shared"' \
+    'os: "darwin"' \
+    'arch: "arm64"' \
+    'concurrency: 1' \
+    'concurrency_group: "ctx-public-cli-macos-native"'; do
     if ! awk '
         index($0, "key: \"" step "\"") { in_step = 1 }
         in_step && /^  - label:/ && index($0, step) == 0 { in_step = 0 }
         in_step && index($0, needle) { found = 1 }
         END { exit found ? 0 : 1 }
       ' step="${mac_step}" needle="${required}" "${pipeline}"; then
-      printf '%s artifact step missing required Linux runner snippet: %s\n' "${mac_step}" "${required}" >&2
+      printf '%s artifact step missing required native Mac runner snippet: %s\n' "${mac_step}" "${required}" >&2
       exit 1
     fi
   done

--- a/scripts/check-github-release-assets.sh
+++ b/scripts/check-github-release-assets.sh
@@ -45,6 +45,12 @@ expected_assets=(
   ctx-linux-x64
   ctx-macos-arm64
   ctx-macos-x64
+  ctx-onnxruntime-freebsd-x64.tar.gz
+  ctx-onnxruntime-linux-aarch64.tar.gz
+  ctx-onnxruntime-linux-x64.tar.gz
+  ctx-onnxruntime-macos-arm64.tar.gz
+  ctx-onnxruntime-macos-x64.tar.gz
+  ctx-onnxruntime-windows-x64.zip
   ctx-windows-x64.exe
   SHA256SUMS
 )

--- a/scripts/check-release-binary-compat.sh
+++ b/scripts/check-release-binary-compat.sh
@@ -216,9 +216,20 @@ check_macos() {
   minimum="$(macho_min_version)"
   [[ -n "${minimum}" ]] || fail "missing macOS minimum version load command"
   version_le "${minimum}" 13.0 || fail "minimum macOS ${minimum} is newer than 13.0"
-  assert_exact_lines "Mach-O dylibs" "$(macho_dylibs)" "/usr/lib/libSystem.B.dylib
-/usr/lib/libcharset.1.dylib
-/usr/lib/libiconv.2.dylib"
+  # Core ML support is compiled into both macOS artifacts. Keep the complete
+  # reviewed system-library set exact so an accidental third-party dylib or
+  # new framework dependency still fails release construction.
+  assert_exact_lines "Mach-O dylibs" "$(macho_dylibs)" "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
+/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
+/System/Library/Frameworks/CoreML.framework/Versions/A/CoreML
+/System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
+/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
+/System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
+/System/Library/Frameworks/Metal.framework/Versions/A/Metal
+/usr/lib/libSystem.B.dylib
+/usr/lib/libc++.1.dylib
+/usr/lib/libiconv.2.dylib
+/usr/lib/libobjc.A.dylib"
 }
 
 pe_imports() {

--- a/scripts/convert-e5-coreml.py
+++ b/scripts/convert-e5-coreml.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+import argparse
+import types
+from pathlib import Path
+from typing import Optional, Tuple
+
+import coremltools as ct
+import numpy as np
+import torch
+import torch.nn.functional as functional
+from transformers import AutoModel
+
+
+MODEL_ID = "intfloat/multilingual-e5-small"
+MODEL_REVISION = "614241f622f53c4eeff9890bdc4f31cfecc418b3"
+
+
+def finite_encoder_attention_mask(
+    model: torch.nn.Module,
+    attention_mask: torch.Tensor,
+    input_shape: Tuple[int, ...],
+    device: Optional[torch.device] = None,
+    dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    del input_shape, device
+    if attention_mask.dim() != 2 or model.config.is_decoder:
+        raise ValueError("Core ML E5 conversion expects a two-dimensional encoder mask")
+    dtype = dtype or model.dtype
+    extended = attention_mask[:, None, None, :].to(dtype=dtype)
+    return (1.0 - extended) * -10000.0
+
+
+class E5Embedding(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.model = AutoModel.from_pretrained(MODEL_ID, revision=MODEL_REVISION)
+        self.model.get_extended_attention_mask = types.MethodType(
+            finite_encoder_attention_mask, self.model
+        )
+        self.model.eval()
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        token_type_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            return_dict=False,
+        )[0]
+        mask = attention_mask.unsqueeze(-1).to(hidden.dtype)
+        pooled = (hidden * mask).sum(dim=1) / mask.sum(dim=1).clamp(min=1.0)
+        return functional.normalize(pooled, p=2, dim=1)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert multilingual E5 with pooling to a fixed-shape Core ML program."
+    )
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--batch", type=int, required=True)
+    parser.add_argument("--sequence", type=int, default=512)
+    parser.add_argument(
+        "--precision", choices=("fp16", "fp32", "mixed"), default="fp16"
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.batch <= 0 or not 1 <= args.sequence <= 512:
+        raise SystemExit("--batch must be positive and --sequence must be in 1..=512")
+
+    model = E5Embedding().eval()
+    shape = (args.batch, args.sequence)
+    attention_mask = torch.zeros(shape, dtype=torch.int32)
+    attention_mask[:, : min(32, args.sequence)] = 1
+    example = (
+        torch.zeros(shape, dtype=torch.int32),
+        attention_mask,
+        torch.zeros(shape, dtype=torch.int32),
+    )
+    with torch.inference_mode():
+        traced = torch.jit.trace(model, example, strict=True)
+        expected = model(*example).detach().cpu().numpy()
+
+    inputs = [
+        ct.TensorType(name="input_ids", shape=shape, dtype=np.int32),
+        ct.TensorType(name="attention_mask", shape=shape, dtype=np.int32),
+        ct.TensorType(name="token_type_ids", shape=shape, dtype=np.int32),
+    ]
+    if args.precision == "fp16":
+        precision = ct.precision.FLOAT16
+    elif args.precision == "fp32":
+        precision = ct.precision.FLOAT32
+    else:
+        precision = ct.transform.FP16ComputePrecision(
+            op_selector=lambda operation: operation.op_type in {"linear", "matmul"}
+        )
+    program = ct.convert(
+        traced,
+        convert_to="mlprogram",
+        inputs=inputs,
+        outputs=[ct.TensorType(name="sentence_embeddings", dtype=np.float32)],
+        compute_precision=precision,
+        minimum_deployment_target=ct.target.macOS13,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    program.save(str(args.output))
+
+    inputs = {
+        "input_ids": example[0].numpy(),
+        "attention_mask": example[1].numpy(),
+        "token_type_ids": example[2].numpy(),
+    }
+    minimum_cosine = 1.0
+    for name, compute_units in (
+        ("cpu", ct.ComputeUnit.CPU_ONLY),
+        ("all", ct.ComputeUnit.ALL),
+    ):
+        loaded = ct.models.MLModel(str(args.output), compute_units=compute_units)
+        prediction = loaded.predict(inputs)["sentence_embeddings"]
+        if not np.all(np.isfinite(prediction)):
+            raise SystemExit(f"Core ML conversion produced non-finite {name} output")
+        cosine = np.sum(expected * prediction, axis=1) / (
+            np.linalg.norm(expected, axis=1) * np.linalg.norm(prediction, axis=1)
+        )
+        if not np.all(np.isfinite(cosine)):
+            raise SystemExit(f"Core ML conversion produced non-finite {name} cosine")
+        minimum_cosine = min(minimum_cosine, float(cosine.min()))
+        print(
+            f"verify={name} minimum_cosine={cosine.min():.8f} "
+            f"max_abs={np.max(np.abs(expected - prediction)):.8f}"
+        )
+    print(
+        f"wrote {args.output} batch={args.batch} sequence={args.sequence} "
+        f"precision={args.precision}"
+    )
+    if minimum_cosine < 0.999:
+        raise SystemExit(f"Core ML conversion failed cosine gate: {minimum_cosine:.8f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev-install-from-metadata.sh
+++ b/scripts/dev-install-from-metadata.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+expected_onnxruntime_version="1.27.0"
+
 usage() {
   cat <<'USAGE'
-usage: scripts/dev-install-from-metadata.sh --metadata PATH_OR_URL [--platform PLATFORM] [--bin-dir DIR] [--no-modify-path] [--no-setup] [--no-skill] [--skill-agent AGENT] [--all-skill-agents] [--no-man]
+usage: scripts/dev-install-from-metadata.sh --metadata PATH_OR_URL [--artifact-dir DIR] [--platform PLATFORM] [--bin-dir DIR] [--runtime-dir DIR] [--no-runtime] [--no-modify-path] [--no-setup] [--no-skill] [--skill-agent AGENT] [--all-skill-agents] [--no-man]
 
 Development/CI installer for explicit ctx release metadata.
 
@@ -20,11 +22,17 @@ detached metadata signatures before trusting artifact URLs or checksums.
 
 Options:
   --metadata PATH_OR_URL  Required. Local metadata file or HTTPS URL.
+  --artifact-dir DIR      Read checksum-pinned artifacts from this local
+                         directory instead of downloading them. Development
+                         and native release smoke use only.
   --platform PLATFORM    linux-x64, linux-aarch64, macos-arm64, macos-x64,
                          or freebsd-x64.
                          Defaults to the current host when it can be detected.
   --bin-dir DIR          Install directory. Defaults to
                          ${CTX_BIN_DIR:-$HOME/.local/bin}.
+  --runtime-dir DIR      ONNX Runtime sidecar install directory. Defaults to
+                         ${CTX_RUNTIME_DIR:-$HOME/.ctx/runtime}.
+  --no-runtime           Do not install optional ONNX Runtime sidecar metadata.
   --no-modify-path       Do not update shell startup files when the install
                          directory is not on PATH.
   --no-setup             Install only; do not install the skill or run ctx setup
@@ -99,6 +107,22 @@ download_file() {
   fi
 
   fail "curl or wget is required for HTTPS downloads"
+}
+
+fetch_artifact() {
+  local url="$1"
+  local name="$2"
+  local dest="$3"
+  local source
+
+  if [[ -z "${artifact_dir}" ]]; then
+    download_file "${url}" "${dest}"
+    return
+  fi
+  source="${artifact_dir%/}/${name}"
+  [[ -f "${source}" && ! -L "${source}" ]] || \
+    fail "local artifact is missing or not a regular non-symlink file: ${source}"
+  cp "${source}" "${dest}"
 }
 
 read_metadata_source() {
@@ -183,6 +207,10 @@ json_escape() {
 
 shell_double_quote_escape() {
   printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/`/\\`/g; s/\$/\\$/g'
+}
+
+runtime_manifest_escape() {
+  json_escape "$1"
 }
 
 path_contains_dir() {
@@ -381,7 +409,8 @@ write_install_marker() {
   cat > "${marker_path}.$$" <<EOF
 {
   "schema_version": 1,
-  "manager": "ctx-hosted-installer",
+  "manager": "ctx-explicit-metadata-installer",
+  "metadata_trust": "explicit-unsigned",
   "install_path": "$(json_escape "${install_path}")",
   "platform": "$(json_escape "${platform}")",
   "channel": "$(json_escape "${channel}")",
@@ -397,14 +426,142 @@ EOF
   mv "${marker_path}.$$" "${marker_path}"
 }
 
+extract_runtime_asset() {
+  local archive="$1"
+  local dest="$2"
+  local name="$3"
+  local runtime_platform="$4"
+  local runtime_version="$5"
+
+  [[ "${name}" == *.tar.gz ]] || fail "unsupported ONNX Runtime archive format for ${runtime_platform}: ${name}"
+  command -v python3 >/dev/null 2>&1 || fail "python3 is required to safely install ONNX Runtime"
+  mkdir -p "${dest}"
+  python3 -I - "${archive}" "${dest}" "${runtime_platform}" "${runtime_version}" <<'PY'
+import os
+import posixpath
+import shutil
+import sys
+import tarfile
+
+archive, destination, platform, version = sys.argv[1:]
+library = "libonnxruntime.dylib" if platform.startswith("macos-") else "libonnxruntime.so"
+expected_files = {
+    "LICENSE",
+    "ThirdPartyNotices.txt",
+    "VERSION_NUMBER",
+    "GIT_COMMIT_ID",
+    f"lib/{library}",
+}
+expected_entries = expected_files | {"lib"}
+members = {}
+total_size = 0
+with tarfile.open(archive, "r:gz") as bundle:
+    for member in bundle.getmembers():
+        raw = member.name
+        canonical = posixpath.normpath(raw.rstrip("/"))
+        expected_raw = canonical
+        if (
+            not raw
+            or "\\" in raw
+            or raw.startswith("/")
+            or canonical in ("", ".", "..")
+            or canonical.startswith("../")
+            or raw != expected_raw
+        ):
+            raise SystemExit(f"unsafe or non-canonical runtime archive path: {raw!r}")
+        if canonical in members:
+            raise SystemExit(f"duplicate runtime archive entry: {canonical}")
+        if canonical not in expected_entries:
+            raise SystemExit(f"unexpected runtime archive entry: {canonical}")
+        if member.mode & 0o7000:
+            raise SystemExit(f"unsafe permission bits on runtime archive entry: {canonical}")
+        if canonical == "lib":
+            if not member.isdir():
+                raise SystemExit("runtime lib entry is not a directory")
+        elif not member.isfile():
+            raise SystemExit(f"runtime archive entry is not a regular file: {canonical}")
+        total_size += member.size
+        if total_size > 1024 * 1024 * 1024:
+            raise SystemExit("runtime archive expands beyond the 1 GiB safety limit")
+        members[canonical] = member
+    if set(members) != expected_entries:
+        missing = sorted(expected_entries - set(members))
+        raise SystemExit("runtime archive entries do not exactly match the expected layout; missing: " + ", ".join(missing))
+
+    version_file = bundle.extractfile(members["VERSION_NUMBER"])
+    if version_file is None or version_file.read() != (version + "\n").encode():
+        raise SystemExit(f"runtime VERSION_NUMBER is not exactly {version}")
+
+    os.makedirs(os.path.join(destination, "lib"), mode=0o755, exist_ok=True)
+    for entry_name in sorted(expected_files):
+        source = bundle.extractfile(members[entry_name])
+        if source is None:
+            raise SystemExit(f"could not read runtime archive entry: {entry_name}")
+        target = os.path.join(destination, *entry_name.split("/"))
+        with source, open(target, "wb") as output:
+            shutil.copyfileobj(source, output)
+        os.chmod(target, 0o755 if entry_name.startswith("lib/") else 0o644)
+PY
+}
+
+install_runtime_asset() {
+  local artifact_name="$1"
+  local checksum_value="$2"
+  local runtime_version="$3"
+  local artifact_url runtime_download actual_runtime_checksum runtime_parent runtime_path tmp_runtime_path manifest_path installed_at
+
+  validate_safe_value "ONNX Runtime artifact name" "${artifact_name}"
+  [[ "${checksum_value}" =~ ^[0-9a-fA-F]{64}$ ]] || fail "checksum for ONNX Runtime ${platform} is not a SHA-256 hex digest"
+  [[ "${checksum_value}" != "0000000000000000000000000000000000000000000000000000000000000000" ]] || fail "checksum for ONNX Runtime ${platform} is a placeholder"
+  test -n "${runtime_dir}" || fail "--runtime-dir cannot be empty when ONNX Runtime metadata is present"
+
+  artifact_url="${base_url%/}/${artifact_name}"
+  runtime_download="${tmp_dir}/${artifact_name}"
+  fetch_artifact "${artifact_url}" "${artifact_name}" "${runtime_download}"
+  actual_runtime_checksum="$(sha256_file "${runtime_download}")"
+  if [[ "$(lowercase "${actual_runtime_checksum}")" != "$(lowercase "${checksum_value}")" ]]; then
+    fail "checksum mismatch for ${artifact_name}: expected ${checksum_value}, got ${actual_runtime_checksum}"
+  fi
+
+  runtime_parent="${runtime_dir%/}/onnxruntime/${runtime_version}"
+  runtime_path="${runtime_parent}/${platform}"
+  tmp_runtime_path="${runtime_path}.tmp.$$"
+  rm -rf "${tmp_runtime_path}"
+  mkdir -p "${runtime_parent}"
+  extract_runtime_asset "${runtime_download}" "${tmp_runtime_path}" "${artifact_name}" "${platform}" "${runtime_version}"
+  rm -rf "${runtime_path}"
+  mv "${tmp_runtime_path}" "${runtime_path}"
+
+  manifest_path="${runtime_path}/ctx-runtime-install.json"
+  installed_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  cat > "${manifest_path}.tmp" <<EOF
+{
+  "schema_version": 1,
+  "manager": "ctx-explicit-metadata-installer",
+  "metadata_trust": "explicit-unsigned",
+  "runtime": "onnxruntime",
+  "platform": "$(runtime_manifest_escape "${platform}")",
+  "version": "$(runtime_manifest_escape "${runtime_version}")",
+  "sha256": "$(runtime_manifest_escape "${actual_runtime_checksum}")",
+  "artifact_url": "$(runtime_manifest_escape "${artifact_url}")",
+  "installed_at": "$(runtime_manifest_escape "${installed_at}")"
+}
+EOF
+  mv "${manifest_path}.tmp" "${manifest_path}"
+  printf 'Installed ONNX Runtime sidecar: %s\n' "${runtime_path}"
+}
+
 metadata_source=""
+artifact_dir=""
 platform=""
 bin_dir="${CTX_BIN_DIR:-${HOME:-}/.local/bin}"
+runtime_dir="${CTX_RUNTIME_DIR:-${HOME:-}/.ctx/runtime}"
 man_dir="${CTX_MAN_DIR:-${HOME:-}/.local/share/man/man1}"
 dry_run=0
 modify_path=1
 run_setup=1
 run_skill=1
+install_runtime=1
 no_skill_requested=0
 explicit_skill_request=0
 all_skill_agents=0
@@ -417,6 +574,10 @@ while (($# > 0)); do
       shift
       metadata_source="${1:-}"
       ;;
+    --artifact-dir)
+      shift
+      artifact_dir="${1:-}"
+      ;;
     --platform)
       shift
       platform="${1:-}"
@@ -424,6 +585,13 @@ while (($# > 0)); do
     --bin-dir)
       shift
       bin_dir="${1:-}"
+      ;;
+    --runtime-dir)
+      shift
+      runtime_dir="${1:-}"
+      ;;
+    --no-runtime)
+      install_runtime=0
       ;;
     --no-modify-path)
       modify_path=0
@@ -469,6 +637,10 @@ done
 test -n "${metadata_source}" || fail "--metadata is required"
 test -n "${bin_dir}" || fail "--bin-dir cannot be empty"
 test -n "${man_dir}" || fail "--man-dir cannot be empty"
+if [[ -n "${artifact_dir}" ]]; then
+  [[ -d "${artifact_dir}" ]] || fail "--artifact-dir is not a directory: ${artifact_dir}"
+  artifact_dir="$(cd "${artifact_dir}" && pwd -P)"
+fi
 
 if [[ -z "${platform}" ]]; then
   platform="$(detect_platform)" || fail "cannot detect this host platform; pass --platform"
@@ -493,18 +665,28 @@ base_url="$(metadata_value "${metadata_file}" CTX_RELEASE_BASE_URL)" || fail "me
 platform_key="${platform//-/_}"
 artifact="$(metadata_value "${metadata_file}" "CTX_RELEASE_ARTIFACT_${platform_key}")" || fail "metadata missing artifact for ${platform}"
 checksum="$(metadata_value "${metadata_file}" "CTX_RELEASE_SHA256_${platform_key}")" || fail "metadata missing checksum for ${platform}"
+runtime_artifact="$(metadata_value_optional "${metadata_file}" "CTX_RELEASE_ONNXRUNTIME_ARTIFACT_${platform_key}")"
+runtime_checksum="$(metadata_value_optional "${metadata_file}" "CTX_RELEASE_ONNXRUNTIME_SHA256_${platform_key}")"
+runtime_version="$(metadata_value_optional "${metadata_file}" CTX_RELEASE_ONNXRUNTIME_VERSION)"
 channel="$(metadata_value_optional "${metadata_file}" CTX_RELEASE_CHANNEL)"
 source_commit="$(metadata_value_optional "${metadata_file}" CTX_RELEASE_SOURCE_COMMIT)"
 published_at="$(metadata_value_optional "${metadata_file}" CTX_RELEASE_PUBLISHED_AT)"
 if [[ -z "${channel}" ]]; then
   channel="stable"
 fi
-
 [[ "${schema_version}" == "1" ]] || fail "unsupported metadata schema: ${schema_version}"
 [[ "${base_url}" == https://* ]] || fail "metadata base URL must be HTTPS"
 [[ "${checksum}" =~ ^[0-9a-fA-F]{64}$ ]] || fail "checksum for ${platform} is not a SHA-256 hex digest"
 [[ "${checksum}" != "0000000000000000000000000000000000000000000000000000000000000000" ]] || fail "checksum for ${platform} is a placeholder"
 validate_safe_value "artifact name" "${artifact}"
+if [[ -n "${runtime_artifact}" || -n "${runtime_checksum}" ]]; then
+  [[ -n "${runtime_artifact}" ]] || fail "metadata missing ONNX Runtime artifact for ${platform}"
+  [[ -n "${runtime_checksum}" ]] || fail "metadata missing ONNX Runtime checksum for ${platform}"
+  [[ -n "${runtime_version}" ]] || fail "metadata missing CTX_RELEASE_ONNXRUNTIME_VERSION"
+  [[ "${runtime_version}" == "${expected_onnxruntime_version}" ]] || \
+    fail "unsupported ONNX Runtime version ${runtime_version}; expected ${expected_onnxruntime_version}"
+  validate_safe_value "ONNX Runtime artifact name" "${runtime_artifact}"
+fi
 
 artifact_url="${base_url%/}/${artifact}"
 download_path="${tmp_dir}/${artifact}"
@@ -526,6 +708,10 @@ fi
 
 if [[ "${CTX_INSTALL_NO_SETUP:-0}" == "1" ]]; then
   run_setup=0
+fi
+
+if [[ "${CTX_INSTALL_NO_RUNTIME:-0}" == "1" ]]; then
+  install_runtime=0
 fi
 
 if [[ "${CTX_INSTALL_ALL_SKILL_AGENTS:-0}" == "1" ]]; then
@@ -569,6 +755,13 @@ else
   printf 'Installing ctx %s (%s)\n' "${version}" "${platform}"
 fi
 printf '  binary: %s\n' "${install_path}"
+if ((install_runtime)) && [[ -n "${runtime_artifact}" ]]; then
+  printf '  onnxruntime: %s\n' "${runtime_dir%/}/onnxruntime/${runtime_version}/${platform}"
+elif [[ -n "${runtime_artifact}" ]]; then
+  printf '  onnxruntime: skipped\n'
+else
+  printf '  onnxruntime: not present in metadata\n'
+fi
 if ((run_skill)); then
   if ((all_skill_agents)); then
     printf '  skill: all supported agents\n'
@@ -591,7 +784,7 @@ if ((dry_run)); then
   exit 0
 fi
 
-download_file "${artifact_url}" "${download_path}"
+fetch_artifact "${artifact_url}" "${artifact}" "${download_path}"
 actual_checksum="$(sha256_file "${download_path}")"
 if [[ "$(lowercase "${actual_checksum}")" != "$(lowercase "${checksum}")" ]]; then
   fail "checksum mismatch for ${artifact}: expected ${checksum}, got ${actual_checksum}"
@@ -601,6 +794,10 @@ mkdir -p "${bin_dir}"
 install -m 0755 "${download_path}" "${install_path}"
 
 write_install_marker "${install_path}.install.json" "${metadata_source}" "${source_commit}" "${published_at}"
+
+if ((install_runtime)) && [[ -n "${runtime_artifact}" ]]; then
+  install_runtime_asset "${runtime_artifact}" "${runtime_checksum}" "${runtime_version}"
+fi
 
 if ((install_man)); then
   mkdir -p "${man_dir}"

--- a/scripts/install-path-smoke.sh
+++ b/scripts/install-path-smoke.sh
@@ -125,6 +125,147 @@ metadata="${tmp_dir}/metadata.env"
   printf 'CTX_RELEASE_SHA256_linux_aarch64=%s\n' "${checksum_aarch64}"
 } > "${metadata}"
 
+runtime_stub="${tmp_dir}/ctx-onnxruntime-linux-x64.tar.gz"
+python3 - "${runtime_stub}" "${tmp_dir}" <<'PY'
+import io
+import os
+import tarfile
+import sys
+
+valid_path, root = sys.argv[1:]
+files = {
+    "LICENSE": b"smoke license\n",
+    "ThirdPartyNotices.txt": b"smoke notices\n",
+    "VERSION_NUMBER": b"1.27.0\n",
+    "GIT_COMMIT_ID": b"0123456789abcdef0123456789abcdef01234567\n",
+    "lib/libonnxruntime.so": b"smoke runtime bytes\n",
+}
+
+
+def add_entry(bundle, name, data=None, kind="file"):
+    info = tarfile.TarInfo(name)
+    info.mtime = 0
+    info.uid = info.gid = 0
+    info.uname = info.gname = "root"
+    if kind == "dir":
+        info.type = tarfile.DIRTYPE
+        info.mode = 0o755
+        bundle.addfile(info)
+    elif kind == "symlink":
+        info.type = tarfile.SYMTYPE
+        info.mode = 0o777
+        info.linkname = "/tmp/attacker"
+        bundle.addfile(info)
+    else:
+        info.mode = 0o755 if name.startswith("lib/") else 0o644
+        info.size = len(data)
+        bundle.addfile(info, io.BytesIO(data))
+
+
+def write_archive(path, mutation=None):
+    with tarfile.open(path, "w:gz", format=tarfile.PAX_FORMAT) as bundle:
+        add_entry(bundle, "lib/", kind="dir")
+        for name, data in files.items():
+            if mutation == "symlink" and name == "lib/libonnxruntime.so":
+                add_entry(bundle, name, kind="symlink")
+            else:
+                add_entry(bundle, name, data)
+        if mutation == "extra":
+            add_entry(bundle, "unexpected", b"extra")
+        elif mutation == "traversal":
+            add_entry(bundle, "../escape", b"escape")
+        elif mutation == "duplicate":
+            add_entry(bundle, "LICENSE", b"duplicate")
+
+
+write_archive(valid_path)
+for mutation in ("extra", "traversal", "duplicate", "symlink"):
+    write_archive(os.path.join(root, f"runtime-{mutation}.tar.gz"), mutation)
+PY
+runtime_checksum="$(sha256_file "${runtime_stub}")"
+metadata_runtime_missing_version="${tmp_dir}/metadata-runtime-missing-version.env"
+cp "${metadata}" "${metadata_runtime_missing_version}"
+{
+  printf 'CTX_RELEASE_ONNXRUNTIME_ARTIFACT_linux_x64=ctx-onnxruntime-linux-x64.tar.gz\n'
+  printf 'CTX_RELEASE_ONNXRUNTIME_SHA256_linux_x64=%s\n' "${runtime_checksum}"
+} >> "${metadata_runtime_missing_version}"
+if bash "${repo_root}/scripts/dev-install-from-metadata.sh" \
+  --metadata "${metadata_runtime_missing_version}" --platform linux-x64 --dry-run --no-setup \
+  > "${tmp_dir}/runtime-missing-version.out" 2>&1; then
+  printf 'runtime metadata without a version unexpectedly passed\n' >&2
+  exit 1
+fi
+grep -F 'metadata missing CTX_RELEASE_ONNXRUNTIME_VERSION' "${tmp_dir}/runtime-missing-version.out" >/dev/null
+
+metadata_runtime_wrong_version="${tmp_dir}/metadata-runtime-wrong-version.env"
+cp "${metadata_runtime_missing_version}" "${metadata_runtime_wrong_version}"
+printf 'CTX_RELEASE_ONNXRUNTIME_VERSION=1.26.0\n' >> "${metadata_runtime_wrong_version}"
+if bash "${repo_root}/scripts/dev-install-from-metadata.sh" \
+  --metadata "${metadata_runtime_wrong_version}" --platform linux-x64 --dry-run --no-setup \
+  > "${tmp_dir}/runtime-wrong-version.out" 2>&1; then
+  printf 'unsupported runtime metadata version unexpectedly passed\n' >&2
+  exit 1
+fi
+grep -F 'unsupported ONNX Runtime version 1.26.0; expected 1.27.0' "${tmp_dir}/runtime-wrong-version.out" >/dev/null
+
+metadata_runtime="${tmp_dir}/metadata-runtime.env"
+cp "${metadata_runtime_missing_version}" "${metadata_runtime}"
+printf 'CTX_RELEASE_ONNXRUNTIME_VERSION=1.27.0\n' >> "${metadata_runtime}"
+CURL_CA_BUNDLE="${tmp_dir}/cert.pem" HOME="${tmp_dir}/home-runtime-dry-run" \
+  bash "${repo_root}/scripts/dev-install-from-metadata.sh" \
+  --metadata "${metadata_runtime}" --platform linux-x64 --dry-run --no-setup \
+  > "${tmp_dir}/runtime-dry-run.out"
+grep -F 'onnxruntime: ' "${tmp_dir}/runtime-dry-run.out" | grep -F '/onnxruntime/1.27.0/linux-x64' >/dev/null
+
+runtime_home="${tmp_dir}/home-runtime-install"
+runtime_bin="${tmp_dir}/runtime-install-bin"
+runtime_dir="${tmp_dir}/runtime-install-root"
+mkdir -p "${runtime_home}"
+CURL_CA_BUNDLE="${tmp_dir}/cert.pem" HOME="${runtime_home}" PATH="/usr/bin:/bin" \
+  bash "${repo_root}/scripts/dev-install-from-metadata.sh" \
+    --metadata "${metadata_runtime}" --platform linux-x64 \
+    --bin-dir "${runtime_bin}" --runtime-dir "${runtime_dir}" \
+    --no-setup --no-skill --no-man --no-modify-path \
+    > "${tmp_dir}/runtime-install.out"
+runtime_install_path="${runtime_dir}/onnxruntime/1.27.0/linux-x64"
+test -f "${runtime_install_path}/lib/libonnxruntime.so"
+grep -Fx '1.27.0' "${runtime_install_path}/VERSION_NUMBER" >/dev/null
+grep -F '"manager": "ctx-explicit-metadata-installer"' "${runtime_bin}/ctx.install.json" >/dev/null
+grep -F '"metadata_trust": "explicit-unsigned"' "${runtime_install_path}/ctx-runtime-install.json" >/dev/null
+
+expect_runtime_rejected() {
+  local mutation="$1"
+  local archive="runtime-${mutation}.tar.gz"
+  local bad_metadata="${tmp_dir}/metadata-runtime-${mutation}.env"
+  local bad_checksum
+
+  bad_checksum="$(sha256_file "${tmp_dir}/${archive}")"
+  cp "${metadata}" "${bad_metadata}"
+  {
+    printf 'CTX_RELEASE_ONNXRUNTIME_VERSION=1.27.0\n'
+    printf 'CTX_RELEASE_ONNXRUNTIME_ARTIFACT_linux_x64=%s\n' "${archive}"
+    printf 'CTX_RELEASE_ONNXRUNTIME_SHA256_linux_x64=%s\n' "${bad_checksum}"
+  } >> "${bad_metadata}"
+  if CURL_CA_BUNDLE="${tmp_dir}/cert.pem" HOME="${tmp_dir}/home-bad-${mutation}" PATH="/usr/bin:/bin" \
+    bash "${repo_root}/scripts/dev-install-from-metadata.sh" \
+      --metadata "${bad_metadata}" --platform linux-x64 \
+      --bin-dir "${tmp_dir}/bad-bin-${mutation}" --runtime-dir "${tmp_dir}/bad-runtime-${mutation}" \
+      --no-setup --no-skill --no-man --no-modify-path \
+      > "${tmp_dir}/runtime-${mutation}.out" 2>&1; then
+    printf 'unsafe runtime archive unexpectedly installed: %s\n' "${mutation}" >&2
+    exit 1
+  fi
+}
+
+expect_runtime_rejected extra
+expect_runtime_rejected traversal
+expect_runtime_rejected duplicate
+expect_runtime_rejected symlink
+if grep -F -q 'zstd' "${repo_root}/scripts/dev-install-from-metadata.sh"; then
+  printf 'Unix explicit-metadata installer must not require zstd\n' >&2
+  exit 1
+fi
+
 base_env=(CURL_CA_BUNDLE="${tmp_dir}/cert.pem" CTX_INSTALL_NO_MAN=1)
 installer=(bash "${repo_root}/scripts/dev-install-from-metadata.sh" --metadata "${metadata}" --platform linux-x64)
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,8 +1,11 @@
 param(
     [Parameter(Mandatory = $true)]
     [string]$Metadata,
+    [string]$ArtifactDir = "",
     [string]$Platform = "",
     [string]$BinDir = "",
+    [string]$RuntimeDir = "",
+    [switch]$NoRuntime,
     [switch]$NoModifyPath,
     [switch]$NoSetup,
     [switch]$NoSkill,
@@ -14,6 +17,7 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+$expectedOnnxRuntimeVersion = "1.27.0"
 
 # Local development and explicit-metadata testing helper. The production hosted
 # installer is https://cli.ctx.rs/install.ps1 and verifies detached metadata
@@ -66,6 +70,189 @@ function Assert-SafeArtifactName([string]$Value) {
 
 function Get-Sha256([string]$Path) {
     return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+}
+
+function Get-ReleaseArtifact(
+    [string]$Url,
+    [string]$Name,
+    [string]$Destination
+) {
+    if ([string]::IsNullOrWhiteSpace($ArtifactDir)) {
+        if ($Url -notmatch '^https://') {
+            Fail "refusing non-HTTPS artifact URL: $Url"
+        }
+        Invoke-WebRequest -Uri $Url -OutFile $Destination -UseBasicParsing
+        return
+    }
+
+    $source = Join-Path $ArtifactDir $Name
+    if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+        Fail "local artifact is missing: $source"
+    }
+    $sourceItem = Get-Item -LiteralPath $source -Force
+    if (($sourceItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        Fail "local artifact must not be a symlink or reparse point: $source"
+    }
+    Copy-Item -LiteralPath $source -Destination $Destination -Force
+}
+
+function Expand-WindowsRuntimeArchive(
+    [string]$ArchivePath,
+    [string]$Destination,
+    [string]$ExpectedVersion
+) {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $expectedFiles = [System.Collections.Generic.HashSet[string]]::new(
+        [string[]]@("LICENSE", "ThirdPartyNotices.txt", "VERSION_NUMBER", "GIT_COMMIT_ID", "lib/onnxruntime.dll"),
+        [System.StringComparer]::Ordinal
+    )
+    $expectedEntries = [System.Collections.Generic.HashSet[string]]::new($expectedFiles, [System.StringComparer]::Ordinal)
+    [void]$expectedEntries.Add("lib")
+    $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $entries = @{}
+    [long]$totalLength = 0
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($ArchivePath)
+    try {
+        foreach ($entry in $archive.Entries) {
+            $rawName = $entry.FullName
+            if (
+                [string]::IsNullOrEmpty($rawName) -or
+                $rawName.Contains("\") -or
+                $rawName.StartsWith("/", [System.StringComparison]::Ordinal) -or
+                $rawName -match '^[A-Za-z]:'
+            ) {
+                Fail "unsafe runtime archive entry path: '$rawName'"
+            }
+            $isDirectory = $rawName.EndsWith("/", [System.StringComparison]::Ordinal)
+            $name = if ($isDirectory) { $rawName.Substring(0, $rawName.Length - 1) } else { $rawName }
+            $expectedRawName = if ($name -ceq "lib") { "lib/" } else { $name }
+            if (
+                $rawName -cne $expectedRawName -or
+                -not $expectedEntries.Contains($name) -or
+                -not $seen.Add($name)
+            ) {
+                Fail "unexpected, duplicate, or non-canonical runtime archive entry: '$rawName'"
+            }
+
+            $unixMode = ($entry.ExternalAttributes -shr 16) -band 0xFFFF
+            $fileType = $unixMode -band 0xF000
+            if (($unixMode -band 0x0E00) -ne 0) {
+                Fail "unsafe permission bits on runtime archive entry: '$rawName'"
+            }
+            if ($name -ceq "lib") {
+                if (-not $isDirectory -or $fileType -ne 0x4000) {
+                    Fail "runtime lib entry is not a directory"
+                }
+            } elseif ($isDirectory -or $fileType -ne 0x8000) {
+                Fail "runtime archive entry is not a regular file: '$rawName'"
+            }
+
+            $totalLength += $entry.Length
+            if ($totalLength -gt 1GB) {
+                Fail "runtime archive expands beyond the 1 GiB safety limit"
+            }
+            $entries[$name] = $entry
+        }
+
+        if ($seen.Count -ne $expectedEntries.Count) {
+            $missing = @($expectedEntries | Where-Object { -not $seen.Contains($_) })
+            Fail "runtime archive entries do not exactly match the expected layout; missing: $($missing -join ', ')"
+        }
+
+        $versionStream = $entries["VERSION_NUMBER"].Open()
+        try {
+            $reader = [System.IO.StreamReader]::new($versionStream, [System.Text.UTF8Encoding]::new($false, $true))
+            try {
+                $versionText = $reader.ReadToEnd()
+            } finally {
+                $reader.Dispose()
+            }
+        } finally {
+            $versionStream.Dispose()
+        }
+        if ($versionText -cne ($ExpectedVersion + "`n")) {
+            Fail "runtime VERSION_NUMBER is not exactly $ExpectedVersion"
+        }
+
+        New-Item -ItemType Directory -Path (Join-Path $Destination "lib") -Force | Out-Null
+        foreach ($name in $expectedFiles) {
+            $target = Join-Path $Destination ($name.Replace("/", "\"))
+            $sourceStream = $entries[$name].Open()
+            try {
+                $targetStream = [System.IO.File]::Open($target, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+                try {
+                    $sourceStream.CopyTo($targetStream)
+                } finally {
+                    $targetStream.Dispose()
+                }
+            } finally {
+                $sourceStream.Dispose()
+            }
+        }
+    } finally {
+        $archive.Dispose()
+    }
+}
+
+function Install-RuntimeAsset(
+    [string]$ArtifactName,
+    [string]$Checksum,
+    [string]$RuntimeVersion,
+    [string]$BaseUrl,
+    [string]$TempRoot,
+    [string]$DestinationRoot
+) {
+    Assert-SafeArtifactName $ArtifactName
+    if ($Checksum -notmatch '^[0-9a-fA-F]{64}$') {
+        Fail "checksum for ONNX Runtime $Platform is not a SHA-256 hex digest"
+    }
+    if ($Checksum -eq "0000000000000000000000000000000000000000000000000000000000000000") {
+        Fail "checksum for ONNX Runtime $Platform is a placeholder"
+    }
+    if ([string]::IsNullOrWhiteSpace($DestinationRoot)) {
+        Fail "-RuntimeDir cannot be empty when ONNX Runtime metadata is present"
+    }
+
+    $runtimeUrl = $BaseUrl.TrimEnd("/") + "/" + $ArtifactName
+    $runtimeDownload = Join-Path $TempRoot $ArtifactName
+    Get-ReleaseArtifact -Url $runtimeUrl -Name $ArtifactName -Destination $runtimeDownload
+
+    $actualRuntimeChecksum = Get-Sha256 $runtimeDownload
+    if ($actualRuntimeChecksum -ne $Checksum.ToLowerInvariant()) {
+        Fail "checksum mismatch for $ArtifactName`: expected $Checksum, got $actualRuntimeChecksum"
+    }
+
+    $runtimeParent = Join-Path $DestinationRoot ("onnxruntime\" + $RuntimeVersion)
+    $runtimePath = Join-Path $runtimeParent $Platform
+    $tmpRuntimePath = "$runtimePath.tmp.$PID"
+    Remove-Item -LiteralPath $tmpRuntimePath -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Path $tmpRuntimePath -Force | Out-Null
+
+    if (-not $ArtifactName.EndsWith(".zip", [System.StringComparison]::OrdinalIgnoreCase)) {
+        Fail "unsupported ONNX Runtime archive format for windows-x64: $ArtifactName"
+    }
+    Expand-WindowsRuntimeArchive -ArchivePath $runtimeDownload -Destination $tmpRuntimePath -ExpectedVersion $RuntimeVersion
+
+    Remove-Item -LiteralPath $runtimePath -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Path $runtimeParent -Force | Out-Null
+    Move-Item -LiteralPath $tmpRuntimePath -Destination $runtimePath -Force
+
+    $manifestPath = Join-Path $runtimePath "ctx-runtime-install.json"
+    $marker = [ordered]@{
+        schema_version = 1
+        manager = "ctx-explicit-metadata-installer"
+        metadata_trust = "explicit-unsigned"
+        runtime = "onnxruntime"
+        platform = $Platform
+        version = $RuntimeVersion
+        sha256 = $actualRuntimeChecksum
+        artifact_url = $runtimeUrl
+        installed_at = ([DateTime]::UtcNow.ToString("o"))
+    }
+    $markerJson = $marker | ConvertTo-Json -Depth 4
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText($manifestPath, $markerJson + [Environment]::NewLine, $utf8NoBom)
+    Write-Host "Installed ONNX Runtime sidecar: $runtimePath"
 }
 
 function Normalize-PathEntry([string]$Path) {
@@ -173,6 +360,16 @@ if ([string]::IsNullOrWhiteSpace($BinDir)) {
     $BinDir = Join-Path $HOME ".local\bin"
 }
 
+if ([string]::IsNullOrWhiteSpace($RuntimeDir)) {
+    $RuntimeDir = Join-Path $HOME ".ctx\runtime"
+}
+if (-not [string]::IsNullOrWhiteSpace($ArtifactDir)) {
+    if (-not (Test-Path -LiteralPath $ArtifactDir -PathType Container)) {
+        Fail "-ArtifactDir is not a directory: $ArtifactDir"
+    }
+    $ArtifactDir = (Resolve-Path -LiteralPath $ArtifactDir).Path
+}
+
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("ctx-install-" + [System.Guid]::NewGuid().ToString("n"))
 New-Item -ItemType Directory -Path $tempRoot | Out-Null
 
@@ -190,6 +387,9 @@ try {
     $baseUrl = Get-MetadataValue $metadataValues "CTX_RELEASE_BASE_URL"
     $artifact = Get-MetadataValue $metadataValues "CTX_RELEASE_ARTIFACT_windows_x64"
     $checksum = Get-MetadataValue $metadataValues "CTX_RELEASE_SHA256_windows_x64"
+    $runtimeArtifact = Get-MetadataValueOrDefault $metadataValues "CTX_RELEASE_ONNXRUNTIME_ARTIFACT_windows_x64" ""
+    $runtimeChecksum = Get-MetadataValueOrDefault $metadataValues "CTX_RELEASE_ONNXRUNTIME_SHA256_windows_x64" ""
+    $runtimeVersion = Get-MetadataValueOrDefault $metadataValues "CTX_RELEASE_ONNXRUNTIME_VERSION" ""
     $channel = Get-MetadataValueOrDefault $metadataValues "CTX_RELEASE_CHANNEL" "stable"
     $sourceCommit = Get-MetadataValueOrDefault $metadataValues "CTX_RELEASE_SOURCE_COMMIT" ""
     $publishedAt = Get-MetadataValueOrDefault $metadataValues "CTX_RELEASE_PUBLISHED_AT" ""
@@ -207,6 +407,21 @@ try {
         Fail "checksum for windows-x64 is a placeholder"
     }
     Assert-SafeArtifactName $artifact
+    if (-not [string]::IsNullOrWhiteSpace($runtimeArtifact) -or -not [string]::IsNullOrWhiteSpace($runtimeChecksum)) {
+        if ([string]::IsNullOrWhiteSpace($runtimeArtifact)) {
+            Fail "metadata missing ONNX Runtime artifact for windows-x64"
+        }
+        if ([string]::IsNullOrWhiteSpace($runtimeChecksum)) {
+            Fail "metadata missing ONNX Runtime checksum for windows-x64"
+        }
+        if ([string]::IsNullOrWhiteSpace($runtimeVersion)) {
+            Fail "metadata missing CTX_RELEASE_ONNXRUNTIME_VERSION"
+        }
+        if ($runtimeVersion -ne $expectedOnnxRuntimeVersion) {
+            Fail "unsupported ONNX Runtime version $runtimeVersion; expected $expectedOnnxRuntimeVersion"
+        }
+        Assert-SafeArtifactName $runtimeArtifact
+    }
 
     $artifactUrl = $baseUrl.TrimEnd("/") + "/" + $artifact
     $downloadPath = Join-Path $tempRoot $artifact
@@ -246,6 +461,7 @@ try {
 
     $runSetup = -not $NoSetup -and $env:CTX_INSTALL_NO_SETUP -ne "1"
     $runSkill = -not $noSkillRequested
+    $installRuntime = -not $NoRuntime -and $env:CTX_INSTALL_NO_RUNTIME -ne "1"
     if (-not $runSetup -and -not $explicitSkillRequest) {
         $runSkill = $false
     }
@@ -257,6 +473,13 @@ try {
         Write-Host "Installing ctx $version ($Platform)"
     }
     Write-Host "  binary: $installPath"
+    if ($installRuntime -and -not [string]::IsNullOrWhiteSpace($runtimeArtifact)) {
+        Write-Host "  onnxruntime: $(Join-Path $RuntimeDir ("onnxruntime\" + $runtimeVersion + "\" + $Platform))"
+    } elseif (-not [string]::IsNullOrWhiteSpace($runtimeArtifact)) {
+        Write-Host "  onnxruntime: skipped"
+    } else {
+        Write-Host "  onnxruntime: not present in metadata"
+    }
     if ($runSkill) {
         if ($allSkillAgentsRequested) {
             Write-Host "  skill: all supported agents"
@@ -277,10 +500,7 @@ try {
         exit 0
     }
 
-    if ($artifactUrl -notmatch '^https://') {
-        Fail "refusing non-HTTPS artifact URL: $artifactUrl"
-    }
-    Invoke-WebRequest -Uri $artifactUrl -OutFile $downloadPath -UseBasicParsing
+    Get-ReleaseArtifact -Url $artifactUrl -Name $artifact -Destination $downloadPath
 
     $actualChecksum = Get-Sha256 $downloadPath
     if ($actualChecksum -ne $checksum.ToLowerInvariant()) {
@@ -293,7 +513,8 @@ try {
     $markerPath = "$installPath.install.json"
     $marker = [ordered]@{
         schema_version = 1
-        manager = "ctx-hosted-installer"
+        manager = "ctx-explicit-metadata-installer"
+        metadata_trust = "explicit-unsigned"
         install_path = $installPath
         platform = $Platform
         channel = $channel
@@ -310,6 +531,16 @@ try {
     [System.IO.File]::WriteAllText($markerPath, $markerJson + [Environment]::NewLine, $utf8NoBom)
     Write-Host ""
     Write-Host "Installed ctx binary."
+
+    if ($installRuntime -and -not [string]::IsNullOrWhiteSpace($runtimeArtifact)) {
+        Install-RuntimeAsset `
+            -ArtifactName $runtimeArtifact `
+            -Checksum $runtimeChecksum `
+            -RuntimeVersion $runtimeVersion `
+            -BaseUrl $baseUrl `
+            -TempRoot $tempRoot `
+            -DestinationRoot $RuntimeDir
+    }
 
     if ($runSkill) {
         $skillArgs = @("integrations", "install", "skills")

--- a/scripts/public-cli-host-runtime-evidence.sh
+++ b/scripts/public-cli-host-runtime-evidence.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host_system="$(uname -s)"
+host_arch="$(uname -m)"
+sysctl_bin="/usr/sbin/sysctl"
+
+while (($# > 0)); do
+  case "$1" in
+    --host-system)
+      shift
+      host_system="${1:-}"
+      ;;
+    --host-arch)
+      shift
+      host_arch="${1:-}"
+      ;;
+    --sysctl)
+      shift
+      sysctl_bin="${1:-}"
+      ;;
+    *)
+      echo "unsupported host evidence argument: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+host_native_arch="${host_arch}"
+process_translated=0
+native_arch_probe=uname
+
+if [[ "${host_system}" == "Darwin" ]]; then
+  host_native_arch=unknown
+  process_translated=unknown
+  native_arch_probe=sysctl
+  if [[ -x "${sysctl_bin}" ]]; then
+    translated_probe="$("${sysctl_bin}" -in sysctl.proc_translated 2>/dev/null || true)"
+    arm64_probe="$("${sysctl_bin}" -in hw.optional.arm64 2>/dev/null || true)"
+    case "${host_arch}:${arm64_probe}:${translated_probe}" in
+      arm64:1:|arm64:1:0)
+        host_native_arch=arm64
+        process_translated=0
+        ;;
+      x86_64:1:1)
+        host_native_arch=arm64
+        process_translated=1
+        ;;
+      x86_64:0:|x86_64:0:0)
+        host_native_arch=x86_64
+        process_translated=0
+        ;;
+    esac
+  fi
+fi
+
+printf '%s\t%s\t%s\t%s\t%s\n' \
+  "${host_system}" "${host_arch}" "${host_native_arch}" \
+  "${process_translated}" "${native_arch_probe}"

--- a/scripts/public-cli-runtime-authority.sh
+++ b/scripts/public-cli-runtime-authority.sh
@@ -5,15 +5,40 @@ platform="${1:-}"
 host_system="${2:-}"
 host_arch="${3:-}"
 runtime_status="${4:-}"
+host_native_arch="${5:-unknown}"
+process_translated="${6:-unknown}"
 
 case "${runtime_status}" in
   not_run) printf 'not_run\n' ;;
   passed)
-    if [[ "${platform}:${host_system}:${host_arch}" == "macos-x64:Darwin:arm64" ]]; then
-      printf 'non_authoritative\n'
-    else
-      printf 'authoritative\n'
-    fi
+    case "${process_translated}" in
+      0) ;;
+      1)
+        printf 'non_authoritative\n'
+        exit 0
+        ;;
+      unknown)
+        printf 'non_authoritative\n'
+        exit 0
+        ;;
+      *)
+        echo "process translation status must be 0, 1, or unknown" >&2
+        exit 2
+        ;;
+    esac
+    case "${platform}:${host_system}:${host_arch}:${host_native_arch}" in
+      linux-x64:Linux:x86_64:x86_64|\
+      linux-aarch64:Linux:aarch64:aarch64|\
+      macos-arm64:Darwin:arm64:arm64|\
+      macos-x64:Darwin:x86_64:x86_64|\
+      windows-x64:Windows_NT:AMD64:X64|\
+      freebsd-x64:FreeBSD:amd64:amd64)
+        printf 'authoritative\n'
+        ;;
+      *)
+        printf 'non_authoritative\n'
+        ;;
+    esac
     ;;
   *)
     echo "runtime status must be passed or not_run" >&2

--- a/scripts/search_eval/model_eval/src/main.rs
+++ b/scripts/search_eval/model_eval/src/main.rs
@@ -1,8 +1,7 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    env,
-    fs,
+    env, fs,
     path::{Path, PathBuf},
     time::Instant,
 };
@@ -29,6 +28,9 @@ const DEFAULT_QUERIES: &[&str] = &[
     "semantic payload chunking 1200 200",
     "feature branch dogfood real corpus performance testing",
 ];
+const E5_QUERY_PREFIX: &str = "query: ";
+const E5_PASSAGE_PREFIX: &str = "passage: ";
+const E5_DIMENSIONS: usize = 384;
 
 #[derive(Debug, Parser)]
 struct Args {
@@ -38,7 +40,7 @@ struct Args {
     work_db: Option<PathBuf>,
     #[arg(long)]
     cache_dir: Option<PathBuf>,
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, default_value = "e5-small")]
     model: ModelArg,
     #[arg(long, default_value_t = 2)]
     threads: usize,
@@ -58,8 +60,9 @@ struct Args {
     include_snippets: bool,
 }
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum ModelArg {
+    E5Small,
     MiniLm,
     BgeSmall,
     SnowflakeXs,
@@ -70,6 +73,7 @@ enum ModelArg {
 impl ModelArg {
     fn as_str(self) -> &'static str {
         match self {
+            Self::E5Small => "intfloat/multilingual-e5-small",
             Self::MiniLm => "minilm",
             Self::BgeSmall => "bge-small",
             Self::SnowflakeXs => "snowflake-xs",
@@ -80,12 +84,36 @@ impl ModelArg {
 
     fn embedding_model(self) -> Option<EmbeddingModel> {
         match self {
+            Self::E5Small => Some(EmbeddingModel::MultilingualE5Small),
             Self::MiniLm => Some(EmbeddingModel::AllMiniLML6V2),
             Self::BgeSmall => Some(EmbeddingModel::BGESmallENV15),
             Self::SnowflakeXs => Some(EmbeddingModel::SnowflakeArcticEmbedXS),
             Self::JinaBaseEn => Some(EmbeddingModel::JinaEmbeddingsV2BaseEN),
             Self::BgeReranker => None,
         }
+    }
+
+    fn document_text(self, text: &str) -> String {
+        match self {
+            Self::E5Small => prefixed_text(E5_PASSAGE_PREFIX, text),
+            _ => text.to_owned(),
+        }
+    }
+
+    fn query_text(self, text: &str) -> String {
+        match self {
+            Self::E5Small => prefixed_text(E5_QUERY_PREFIX, text),
+            _ => text.to_owned(),
+        }
+    }
+}
+
+fn prefixed_text(prefix: &str, text: &str) -> String {
+    let text = text.trim_start();
+    if text.starts_with(prefix) {
+        text.to_owned()
+    } else {
+        format!("{prefix}{text}")
     }
 }
 
@@ -217,7 +245,10 @@ fn run_embedding_model(
     .with_context(|| format!("initialize {}", args.model.as_str()))?;
     let model_init_ms = model_started.elapsed().as_millis();
 
-    let doc_texts = docs.iter().map(|doc| doc.text.clone()).collect::<Vec<_>>();
+    let doc_texts = docs
+        .iter()
+        .map(|doc| args.model.document_text(&doc.text))
+        .collect::<Vec<_>>();
     let embed_started = Instant::now();
     eprintln!("embedding {} docs with {}", docs.len(), args.model.as_str());
     let mut doc_embeddings = model
@@ -228,6 +259,14 @@ fn run_embedding_model(
     }
     let embed_docs_ms = embed_started.elapsed().as_millis();
     let dimensions = doc_embeddings.first().map(Vec::len);
+    if args.model == ModelArg::E5Small && dimensions != Some(E5_DIMENSIONS) {
+        return Err(anyhow!(
+            "{} returned {:?} dimensions, expected {}",
+            args.model.as_str(),
+            dimensions,
+            E5_DIMENSIONS
+        ));
+    }
 
     let doc_index = docs
         .iter()
@@ -252,7 +291,7 @@ fn run_embedding_model(
     for (query_index, refs) in query_refs.iter().enumerate() {
         let query_embed_started = Instant::now();
         let mut query_embedding = model
-            .embed(vec![refs.query.clone()], Some(1))
+            .embed(vec![args.model.query_text(&refs.query)], Some(1))
             .with_context(|| format!("embed query with {}", args.model.as_str()))?
             .pop()
             .ok_or_else(|| anyhow!("empty query embedding"))?;
@@ -347,7 +386,12 @@ fn run_reranker(
             .map(|index| docs[*index].text.clone())
             .collect::<Vec<_>>();
         let reranked = reranker
-            .rerank(refs.query.clone(), candidate_docs, false, Some(args.batch_size))
+            .rerank(
+                refs.query.clone(),
+                candidate_docs,
+                false,
+                Some(args.batch_size),
+            )
             .with_context(|| format!("rerank query {}", refs.query))?;
         let top = reranked
             .iter()
@@ -362,7 +406,11 @@ fn run_reranker(
             refs,
             &top,
             docs,
-            &lexical_refs[query_index].iter().copied().take(10).collect::<Vec<_>>(),
+            &lexical_refs[query_index]
+                .iter()
+                .copied()
+                .take(10)
+                .collect::<Vec<_>>(),
             args.include_snippets,
             None,
         ));
@@ -628,8 +676,8 @@ fn candidate_docs(
 
 fn query_tokens(value: &str) -> Vec<String> {
     let stop = [
-        "the", "and", "for", "with", "from", "that", "this", "what", "does", "into", "our",
-        "all", "are", "was", "were", "how", "why",
+        "the", "and", "for", "with", "from", "that", "this", "what", "does", "into", "our", "all",
+        "are", "was", "were", "how", "why",
     ];
     let stop = stop.into_iter().collect::<HashSet<_>>();
     let mut tokens = value
@@ -760,4 +808,40 @@ fn process_peak_rss_kb() -> Option<u64> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn production_e5_model_is_the_eval_default() {
+        let args = Args::try_parse_from(["ctx-model-eval"]).unwrap();
+
+        assert_eq!(args.model, ModelArg::E5Small);
+        assert_eq!(E5_DIMENSIONS, 384);
+    }
+
+    #[test]
+    fn e5_inputs_use_query_and_passage_prefixes_once() {
+        assert_eq!(ModelArg::E5Small.query_text("find it"), "query: find it");
+        assert_eq!(
+            ModelArg::E5Small.query_text("  query: find it"),
+            "query: find it"
+        );
+        assert_eq!(
+            ModelArg::E5Small.document_text("found it"),
+            "passage: found it"
+        );
+        assert_eq!(
+            ModelArg::E5Small.document_text("  passage: found it"),
+            "passage: found it"
+        );
+    }
+
+    #[test]
+    fn comparison_models_keep_unprefixed_inputs() {
+        assert_eq!(ModelArg::MiniLm.query_text("find it"), "find it");
+        assert_eq!(ModelArg::BgeSmall.document_text("found it"), "found it");
+    }
 }

--- a/scripts/search_eval/semantic_backfill_bench.py
+++ b/scripts/search_eval/semantic_backfill_bench.py
@@ -29,6 +29,14 @@ EMBEDDING_MODE_CHUNKED = "chunked"
 SOURCE_MODE_EVENT_SEARCH_PREVIEW = "event_search_preview"
 SOURCE_MODE_SEMANTIC_PAYLOAD = "semantic_payload"
 SOURCE_TEXT_MAX_CHARS = 64 * 1024
+DEFAULT_MODEL = "intfloat/multilingual-e5-small"
+DEFAULT_MODEL_KEY = (
+    "fastembed:intfloat-multilingual-e5-small:"
+    "e5-query-passage:semantic-lite-turn-1200-200-v3"
+)
+DEFAULT_DIMENSIONS = 384
+E5_QUERY_PREFIX = "query: "
+E5_PASSAGE_PREFIX = "passage: "
 
 
 @dataclass(frozen=True)
@@ -53,6 +61,19 @@ class TextChunk:
 
 def sha256_text(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def semantic_prefixed_text(prefix: str, text: str) -> str:
+    text = text.lstrip()
+    return text if text.startswith(prefix) else f"{prefix}{text}"
+
+
+def semantic_query_text(text: str) -> str:
+    return semantic_prefixed_text(E5_QUERY_PREFIX, text)
+
+
+def semantic_passage_text(text: str) -> str:
+    return semantic_prefixed_text(E5_PASSAGE_PREFIX, text)
 
 
 def vector_blob(value) -> bytes:
@@ -589,12 +610,12 @@ def main():
     parser.add_argument("--work-db", required=True)
     parser.add_argument("--sidecar", required=True)
     parser.add_argument("--metrics", required=True)
-    parser.add_argument("--model", default="sentence-transformers/all-MiniLM-L6-v2")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
     parser.add_argument(
         "--model-key",
-        default="fastembed:all-MiniLM-L6-v2:semantic-payload-chunk-1200-200-v2",
+        default=DEFAULT_MODEL_KEY,
     )
-    parser.add_argument("--dimensions", type=int, default=384)
+    parser.add_argument("--dimensions", type=int, default=DEFAULT_DIMENSIONS)
     parser.add_argument("--cache-dir", default="/tmp/fastembed_cache")
     parser.add_argument("--fetch-batch", type=int, default=2048)
     parser.add_argument("--embed-batch", type=int, default=256)
@@ -741,10 +762,10 @@ def main():
                     args.chunk_overlap_chars,
                 )
             ]
-            texts = [chunk.text for chunk in text_units]
+            texts = [semantic_passage_text(chunk.text) for chunk in text_units]
         else:
             text_units = batch
-            texts = [doc.text for doc in batch]
+            texts = [semantic_passage_text(doc.text) for doc in batch]
 
         embed_started = time.perf_counter()
         embeddings = list(model.embed(texts, batch_size=args.embed_batch))

--- a/scripts/search_eval/test_semantic_backfill_bench.py
+++ b/scripts/search_eval/test_semantic_backfill_bench.py
@@ -18,6 +18,25 @@ import semantic_worker_bench as worker_bench
 
 
 class SemanticBackfillBenchTest(unittest.TestCase):
+    def test_e5_defaults_and_role_prefixes_match_production(self):
+        self.assertEqual(bench.DEFAULT_MODEL, "intfloat/multilingual-e5-small")
+        self.assertEqual(
+            bench.DEFAULT_MODEL_KEY,
+            "fastembed:intfloat-multilingual-e5-small:"
+            "e5-query-passage:semantic-lite-turn-1200-200-v3",
+        )
+        self.assertEqual(bench.DEFAULT_DIMENSIONS, 384)
+        self.assertEqual(bench.semantic_query_text("find it"), "query: find it")
+        self.assertEqual(
+            bench.semantic_query_text("  query: find it"), "query: find it"
+        )
+        self.assertEqual(
+            bench.semantic_passage_text("found it"), "passage: found it"
+        )
+        self.assertEqual(
+            bench.semantic_passage_text("  passage: found it"), "passage: found it"
+        )
+
     def test_chunk_document_uses_deterministic_char_ranges(self):
         doc = bench.SourceDocument(
             event_id="event-1",
@@ -80,7 +99,7 @@ class SemanticBackfillBenchTest(unittest.TestCase):
             chunk_metrics = temp_path / "chunk-metrics.json"
             self.create_work_db(work_db)
 
-            self.run_main(
+            event_embedding_texts = self.run_main(
                 [
                     "--work-db",
                     str(work_db),
@@ -100,9 +119,15 @@ class SemanticBackfillBenchTest(unittest.TestCase):
             )
             event_data = json.loads(event_metrics.read_text(encoding="utf-8"))
             self.assertEqual(event_data["embedding_mode"], "event")
+            self.assertEqual(event_data["model"], "intfloat/multilingual-e5-small")
             self.assertEqual(
                 event_data["model_key"],
-                "fastembed:all-MiniLM-L6-v2:semantic-payload-chunk-1200-200-v2",
+                "fastembed:intfloat-multilingual-e5-small:"
+                "e5-query-passage:semantic-lite-turn-1200-200-v3",
+            )
+            self.assertEqual(
+                event_embedding_texts,
+                ["passage: abcdefghijklmnop", "passage: 12345"],
             )
             self.assertEqual(event_data["source_mode"], "event_search_preview")
             self.assertEqual(event_data["events"], 2)
@@ -118,7 +143,7 @@ class SemanticBackfillBenchTest(unittest.TestCase):
                 ).fetchall()
             self.assertEqual(event_rows, [("event_search_preview", 2)])
 
-            self.run_main(
+            chunk_embedding_texts = self.run_main(
                 [
                     "--work-db",
                     str(work_db),
@@ -146,6 +171,14 @@ class SemanticBackfillBenchTest(unittest.TestCase):
             self.assertEqual(chunk_data["events"], 2)
             self.assertEqual(chunk_data["chunks"], 3)
             self.assertEqual(chunk_data["chunk_multiplier"], 1.5)
+            self.assertEqual(
+                chunk_embedding_texts,
+                [
+                    "passage: abcdefghij",
+                    "passage: ijklmnop",
+                    "passage: 12345",
+                ],
+            )
             with sqlite3.connect(chunk_sidecar) as conn:
                 rows = conn.execute(
                     """
@@ -264,11 +297,14 @@ class SemanticBackfillBenchTest(unittest.TestCase):
 
     @staticmethod
     def run_main(argv):
+        embedded_texts = []
+
         class FakeEmbedding:
             def __init__(self, **kwargs):
                 self.kwargs = kwargs
 
             def embed(self, texts, batch_size):
+                embedded_texts.extend(texts)
                 for text in texts:
                     yield [float(len(text)), float(batch_size), 1.0, 0.0]
 
@@ -276,6 +312,7 @@ class SemanticBackfillBenchTest(unittest.TestCase):
             with mock.patch.object(sys, "argv", ["semantic_backfill_bench.py", *argv]):
                 with mock.patch("sys.stdout", new=io.StringIO()):
                     bench.main()
+        return embedded_texts
 
 
 class SemanticWorkerBenchTest(unittest.TestCase):

--- a/scripts/semantic-model-bundle/README.md
+++ b/scripts/semantic-model-bundle/README.md
@@ -1,0 +1,59 @@
+# Semantic Core ML Model Bundle
+
+This directory produces and verifies the public
+`intfloat/multilingual-e5-small` fp16 Core ML bundle. Packaging is offline: it
+accepts already-converted `.mlpackage` directories, a pinned `tokenizer.json`,
+and the upstream model license. It does not read credentials, private evals, or
+machine-specific paths into the bundle.
+
+## Reproducible production
+
+1. On macOS 26.2 with Xcode 26.2 and CPython 3.11.9, create an isolated
+   environment and install `requirements.lock`.
+2. Resolve the model only at revision
+   `614241f622f53c4eeff9890bdc4f31cfecc418b3`; retain its `LICENSE`,
+   `tokenizer.json`, and source weights locally. Convert with the repository's
+   pinned-revision converter and explicit fixed dimensions:
+
+```bash
+python scripts/convert-e5-coreml.py /artifacts/document.mlpackage \
+  --batch 16 --sequence 512 --precision fp16
+python scripts/convert-e5-coreml.py /artifacts/query.mlpackage \
+  --batch 1 --sequence 512 --precision fp16
+```
+
+3. Run the producer with the same fixed tensor dimensions:
+
+```bash
+python scripts/semantic-model-bundle/produce.py \
+  --tokenizer /public-snapshot/tokenizer.json \
+  --document-model /artifacts/document.mlpackage \
+  --query-model /artifacts/query.mlpackage \
+  --model-license /public-snapshot/LICENSE \
+  --bundle-version 1.0.0 \
+  --document-batch-size 16 --query-batch-size 1 --sequence-length 512 \
+  --output-dir /artifacts/ctx-e5-coreml-1.0.0 \
+  --archive /artifacts/ctx-e5-coreml-1.0.0.tar.xz
+```
+
+The document and query packages have distinct fixed contracts: document inputs
+are `[16, 512]` with output `[16, 384]`, while query inputs are `[1, 512]` with
+output `[1, 384]`. The producer validates each package against its role. To
+produce a bundle without a separate query package, omit both `--query-model`
+and `--query-batch-size`; the manifest then omits `query_batch_size`, and the
+runtime uses the document model for queries.
+
+The producer rejects tool-version drift, symlinks, unknown source revisions,
+and existing output paths. Tar member order, modes, owners, and mtimes are
+normalized, so identical inputs produce an identical manifest and archive.
+
+Verify without importing Core ML or loading model weights:
+
+```bash
+python scripts/semantic-model-bundle/verify.py /artifacts/ctx-e5-coreml-1.0.0
+```
+
+The manifest intentionally excludes itself from `files`; every other regular
+file is listed with its complete lowercase SHA-256 and exact byte size. Empty
+directories, symlinks, special files, unlisted payloads, and paths outside the
+small allowlist are rejected.

--- a/scripts/semantic-model-bundle/THIRD_PARTY_NOTICES.md
+++ b/scripts/semantic-model-bundle/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,16 @@
+# Third-Party Notices
+
+The bundle contains derived weights and tokenizer data from
+`intfloat/multilingual-e5-small`, pinned to revision
+`614241f622f53c4eeff9890bdc4f31cfecc418b3`. The model license is shipped as
+`LICENSES/MODEL_LICENSE.txt` in every produced bundle.
+
+The build-only toolchain is pinned in `toolchain.lock.json`. It includes Apple
+coremltools (BSD-3-Clause), Hugging Face transformers, tokenizers,
+huggingface-hub, and safetensors (Apache-2.0), PyTorch (BSD-style), NumPy
+(BSD-3-Clause), and SentencePiece (Apache-2.0). These tools are not included in
+the bundle archive.
+
+Upstream project and license texts are available from their public source
+repositories and installed distributions. This notice does not replace those
+license texts.

--- a/scripts/semantic-model-bundle/bundle_format.py
+++ b/scripts/semantic-model-bundle/bundle_format.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Strict, bounded bundle-format helpers shared by production and verification."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+from pathlib import Path, PurePosixPath
+from typing import Any, BinaryIO
+
+SCHEMA_VERSION = 1
+MODEL_ID = "intfloat/multilingual-e5-small"
+MODEL_REVISION = "614241f622f53c4eeff9890bdc4f31cfecc418b3"
+EMBEDDING_SPACE_ID = "e5-small-v1:mean-pool:l2:query-passage"
+BUNDLE_ID = "ctx.multilingual-e5-small.coreml.fp16"
+MANIFEST_NAME = "manifest.json"
+MAX_MANIFEST_BYTES = 1024 * 1024
+MAX_FILES = 4096
+MAX_DIRECTORIES = 1024
+MAX_FILE_BYTES = 1024 * 1024 * 1024
+MAX_BUNDLE_BYTES = 2 * 1024 * 1024 * 1024
+MAX_TOKENIZER_BYTES = 64 * 1024 * 1024
+MAX_METADATA_FILE_BYTES = 4 * 1024 * 1024
+MAX_PATH_BYTES = 512
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+REVISION_RE = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})\Z")
+SEMVER_RE = re.compile(
+    r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+    r"(?:[-+][0-9A-Za-z.-]+)?\Z"
+)
+
+
+class BundleError(ValueError):
+    pass
+
+
+def canonical_json(value: Any) -> bytes:
+    return (json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True) + "\n").encode()
+
+
+def sha256_file(path: Path, expected_size: int | None = None) -> str:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    digest = hashlib.sha256()
+    count = 0
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise BundleError(f"not a regular file: {path}")
+        if before.st_size > MAX_FILE_BYTES:
+            raise BundleError(f"file exceeds size limit: {path}")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            count = _hash_stream(stream, digest)
+        after = path.lstat()
+        if stat.S_ISLNK(after.st_mode) or (before.st_dev, before.st_ino) != (
+            after.st_dev,
+            after.st_ino,
+        ):
+            raise BundleError(f"file changed during verification: {path}")
+    finally:
+        os.close(descriptor)
+    if expected_size is not None and count != expected_size:
+        raise BundleError(f"file size mismatch: {path}")
+    return digest.hexdigest()
+
+
+def read_bounded_regular_file(path: Path, maximum: int) -> bytes:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_size > maximum:
+            raise BundleError(f"file is not regular or exceeds size limit: {path}")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            body = stream.read(maximum + 1)
+        after = path.lstat()
+        if (
+            len(body) > maximum
+            or stat.S_ISLNK(after.st_mode)
+            or (before.st_dev, before.st_ino) != (after.st_dev, after.st_ino)
+        ):
+            raise BundleError(f"file changed or exceeds size limit: {path}")
+        return body
+    finally:
+        os.close(descriptor)
+
+
+def _hash_stream(stream: BinaryIO, digest: Any) -> int:
+    count = 0
+    while block := stream.read(1024 * 1024):
+        count += len(block)
+        if count > MAX_FILE_BYTES:
+            raise BundleError("file exceeds size limit while hashing")
+        digest.update(block)
+    return count
+
+
+def validate_relative_path(value: str) -> None:
+    if (
+        not value
+        or len(value.encode()) > MAX_PATH_BYTES
+        or "\\" in value
+        or ":" in value
+        or value.startswith("/")
+        or value.endswith("/")
+    ):
+        raise BundleError(f"invalid relative path: {value!r}")
+    parts = PurePosixPath(value).parts
+    if len(parts) > 64 or any(part in {"", ".", ".."} for part in value.split("/")):
+        raise BundleError(f"invalid relative path: {value!r}")
+
+
+def collect_payload_files(root: Path) -> dict[str, Path]:
+    root_metadata = root.lstat()
+    if stat.S_ISLNK(root_metadata.st_mode) or not stat.S_ISDIR(root_metadata.st_mode):
+        raise BundleError(f"bundle root is not a real directory: {root}")
+    files: dict[str, Path] = {}
+    directories = 0
+    for directory, names, filenames in os.walk(
+        root, topdown=True, onerror=_raise_walk_error, followlinks=False
+    ):
+        directories += 1
+        if directories > MAX_DIRECTORIES:
+            raise BundleError("bundle contains too many directories")
+        names.sort()
+        filenames.sort()
+        current = Path(directory)
+        for name in names:
+            path = current / name
+            metadata = path.lstat()
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+                raise BundleError(f"unsupported bundle directory: {path}")
+        if current != root and not names and not filenames:
+            raise BundleError(f"empty bundle directory: {current}")
+        for name in filenames:
+            path = current / name
+            metadata = path.lstat()
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+                raise BundleError(f"unsupported bundle file: {path}")
+            relative = path.relative_to(root).as_posix()
+            validate_relative_path(relative)
+            if relative != MANIFEST_NAME:
+                files[relative] = path
+                if len(files) > MAX_FILES:
+                    raise BundleError("bundle contains too many files")
+    return files
+
+
+def file_records(root: Path) -> list[dict[str, Any]]:
+    total = 0
+    records = []
+    for relative, path in sorted(collect_payload_files(root).items()):
+        size = path.stat().st_size
+        total += size
+        if size > MAX_FILE_BYTES or total > MAX_BUNDLE_BYTES:
+            raise BundleError("bundle exceeds size limits")
+        records.append(
+            {"path": relative, "sha256": sha256_file(path, size), "size_bytes": size}
+        )
+    return records
+
+
+def verify_bundle(root: Path) -> dict[str, Any]:
+    manifest_path = root / MANIFEST_NAME
+    raw = read_bounded_regular_file(manifest_path, MAX_MANIFEST_BYTES)
+    manifest = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
+    validate_manifest(manifest)
+    actual = file_records(root)
+    if actual != manifest["files"]:
+        raise BundleError("payload file set, size, or SHA-256 does not match manifest")
+    return manifest
+
+
+def validate_manifest(manifest: Any) -> None:
+    _keys(
+        manifest,
+        {
+            "schema_version",
+            "bundle_id",
+            "bundle_version",
+            "model",
+            "tensor_contract",
+            "artifacts",
+            "files",
+        },
+        "manifest",
+    )
+    if (
+        type(manifest["schema_version"]) is not int
+        or manifest["schema_version"] != SCHEMA_VERSION
+        or manifest["bundle_id"] != BUNDLE_ID
+    ):
+        raise BundleError("unsupported schema or bundle id")
+    if not isinstance(manifest["bundle_version"], str) or not SEMVER_RE.fullmatch(
+        manifest["bundle_version"]
+    ):
+        raise BundleError("bundle_version is not strict semantic version syntax")
+    _validate_model(manifest["model"])
+    artifacts = manifest["artifacts"]
+    required_artifact_keys = {"tokenizer", "document_model"}
+    allowed_artifact_keys = required_artifact_keys | {"query_model"}
+    _keys(artifacts, allowed_artifact_keys, "artifacts", required_artifact_keys)
+    if artifacts["tokenizer"] != "tokenizer.json" or artifacts["document_model"] != "document.mlpackage":
+        raise BundleError("invalid required artifact paths")
+    if "query_model" in artifacts and artifacts["query_model"] != "query.mlpackage":
+        raise BundleError("invalid query artifact path")
+    has_query = "query_model" in artifacts
+    _validate_contract(manifest["tensor_contract"], has_query)
+    _validate_records(manifest["files"], has_query)
+
+
+def _validate_model(model: Any) -> None:
+    _keys(model, {"id", "source_revision", "embedding_space_id", "precision"}, "model")
+    if model["id"] != MODEL_ID or model["precision"] != "fp16":
+        raise BundleError("unsupported model or precision")
+    if not isinstance(model["source_revision"], str) or not REVISION_RE.fullmatch(
+        model["source_revision"]
+    ):
+        raise BundleError("invalid source revision")
+    if model["embedding_space_id"] != EMBEDDING_SPACE_ID:
+        raise BundleError("unsupported embedding space")
+
+
+def _validate_contract(contract: Any, has_query: bool) -> None:
+    fields = {
+        "inputs",
+        "output",
+        "document_batch_size",
+        "max_sequence_length",
+        "embedding_dimensions",
+        "document_prefix",
+        "query_prefix",
+        "pooling",
+        "normalization",
+    }
+    if has_query:
+        fields.add("query_batch_size")
+    _keys(
+        contract,
+        fields,
+        "tensor_contract",
+    )
+    document_batch = contract["document_batch_size"]
+    sequence = contract["max_sequence_length"]
+    if (
+        type(document_batch) is not int
+        or type(sequence) is not int
+        or document_batch != 16
+        or sequence != 512
+    ):
+        raise BundleError("document contract must use fixed batch 16 and sequence length 512")
+    if has_query and (
+        type(contract["query_batch_size"]) is not int
+        or contract["query_batch_size"] != 1
+    ):
+        raise BundleError("query contract must use fixed batch 1")
+    expected_inputs = (
+        ("input_ids", "int32"),
+        ("attention_mask", "int32"),
+        ("token_type_ids", "int32"),
+    )
+    inputs = contract["inputs"]
+    if not isinstance(inputs, list) or len(inputs) != len(expected_inputs):
+        raise BundleError("invalid input tensor count")
+    for value, (name, dtype) in zip(inputs, expected_inputs, strict=True):
+        _validate_tensor(value, name, dtype, document_batch, sequence)
+    _validate_tensor(
+        contract["output"], "sentence_embeddings", "float32", document_batch, 384
+    )
+    expected = {
+        "embedding_dimensions": 384,
+        "document_prefix": "passage: ",
+        "query_prefix": "query: ",
+        "pooling": "attention_mask_mean",
+        "normalization": "l2",
+    }
+    if any(contract[key] != value for key, value in expected.items()):
+        raise BundleError("incompatible embedding contract")
+
+
+def _validate_tensor(value: Any, name: str, dtype: str, batch: int, width: int) -> None:
+    _keys(value, {"name", "dtype", "shape"}, f"tensor {name}")
+    if value != {"name": name, "dtype": dtype, "shape": [batch, width]}:
+        raise BundleError(f"incompatible tensor {name}")
+
+
+def _validate_records(records: Any, has_query: bool) -> None:
+    if not isinstance(records, list) or not 1 <= len(records) <= MAX_FILES:
+        raise BundleError("invalid file record count")
+    paths: set[str] = set()
+    total = 0
+    for record in records:
+        _keys(record, {"path", "size_bytes", "sha256"}, "file record")
+        path = record["path"]
+        if not isinstance(path, str):
+            raise BundleError("file path must be a string")
+        validate_relative_path(path)
+        allowed = path in {"tokenizer.json", "PROVENANCE.json", "THIRD_PARTY_NOTICES.md"}
+        allowed |= path.startswith("LICENSES/") or path.startswith("document.mlpackage/")
+        allowed |= has_query and path.startswith("query.mlpackage/")
+        if not allowed or path in paths:
+            raise BundleError(f"duplicate or unsupported file path: {path}")
+        paths.add(path)
+        size = record["size_bytes"]
+        if not isinstance(size, int) or isinstance(size, bool) or not 0 <= size <= MAX_FILE_BYTES:
+            raise BundleError(f"invalid file size: {path}")
+        total += size
+        if total > MAX_BUNDLE_BYTES:
+            raise BundleError("bundle exceeds total size limit")
+        if size > _payload_size_limit(path):
+            raise BundleError(f"file exceeds role-specific size limit: {path}")
+        if not isinstance(record["sha256"], str) or not SHA256_RE.fullmatch(record["sha256"]):
+            raise BundleError(f"invalid SHA-256: {path}")
+    required = {"tokenizer.json", "PROVENANCE.json", "THIRD_PARTY_NOTICES.md"}
+    if not required <= paths or not any(path.startswith("LICENSES/") for path in paths):
+        raise BundleError("bundle is missing metadata or license payloads")
+    if not any(path.startswith("document.mlpackage/") for path in paths):
+        raise BundleError("bundle is missing document model files")
+    if has_query != any(path.startswith("query.mlpackage/") for path in paths):
+        raise BundleError("query model declaration and files disagree")
+
+
+def _payload_size_limit(path: str) -> int:
+    if path == "tokenizer.json":
+        return MAX_TOKENIZER_BYTES
+    if path in {"PROVENANCE.json", "THIRD_PARTY_NOTICES.md"} or path.startswith(
+        "LICENSES/"
+    ):
+        return MAX_METADATA_FILE_BYTES
+    return MAX_FILE_BYTES
+
+
+def _keys(
+    value: Any,
+    allowed: set[str],
+    name: str,
+    required: set[str] | None = None,
+) -> None:
+    if not isinstance(value, dict):
+        raise BundleError(f"{name} must be an object")
+    required = allowed if required is None else required
+    if set(value) - allowed or not required <= set(value):
+        raise BundleError(f"{name} has missing or unknown fields")
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise BundleError(f"duplicate JSON field: {key}")
+        value[key] = item
+    return value
+
+
+def _raise_walk_error(error: OSError) -> None:
+    raise error

--- a/scripts/semantic-model-bundle/produce.py
+++ b/scripts/semantic-model-bundle/produce.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Create a deterministic, self-describing Core ML model bundle and archive."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import os
+import platform
+import shutil
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+from bundle_format import (
+    BUNDLE_ID,
+    EMBEDDING_SPACE_ID,
+    MANIFEST_NAME,
+    MODEL_ID,
+    MODEL_REVISION,
+    SCHEMA_VERSION,
+    BundleError,
+    canonical_json,
+    file_records,
+    verify_bundle,
+)
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+TOOLCHAIN_LOCK = SCRIPT_ROOT / "toolchain.lock.json"
+NOTICES = SCRIPT_ROOT / "THIRD_PARTY_NOTICES.md"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tokenizer", type=Path, required=True)
+    parser.add_argument("--document-model", type=Path, required=True)
+    parser.add_argument("--query-model", type=Path)
+    parser.add_argument("--model-license", type=Path, required=True)
+    parser.add_argument("--bundle-version", required=True)
+    parser.add_argument("--document-batch-size", type=int, required=True)
+    parser.add_argument("--query-batch-size", type=int)
+    parser.add_argument("--sequence-length", type=int, default=512)
+    parser.add_argument("--source-revision", default=MODEL_REVISION)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--archive", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.source_revision != MODEL_REVISION:
+        raise SystemExit(f"source revision must equal pinned revision {MODEL_REVISION}")
+    _validate_role_batches(args)
+    if args.output_dir.exists() or args.output_dir.is_symlink():
+        raise SystemExit(f"output directory already exists: {args.output_dir}")
+    _validate_input_file(args.tokenizer, "tokenizer")
+    _validate_input_file(args.model_license, "model license")
+    _validate_mlpackage(args.document_model, "document model")
+    if args.query_model is not None:
+        _validate_mlpackage(args.query_model, "query model")
+    lock = _load_and_check_toolchain()
+    _validate_tokenizer(args.tokenizer)
+    _validate_coreml_contract(
+        args.document_model,
+        args.document_batch_size,
+        args.sequence_length,
+        "document model",
+    )
+    if args.query_model is not None:
+        _validate_coreml_contract(
+            args.query_model,
+            args.query_batch_size,
+            args.sequence_length,
+            "query model",
+        )
+
+    args.output_dir.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{args.output_dir.name}.bundle.", dir=args.output_dir.parent)
+    )
+    try:
+        shutil.copyfile(args.tokenizer, staging / "tokenizer.json", follow_symlinks=False)
+        _copy_tree(args.document_model, staging / "document.mlpackage")
+        artifacts = {
+            "document_model": "document.mlpackage",
+            "tokenizer": "tokenizer.json",
+        }
+        if args.query_model is not None:
+            _copy_tree(args.query_model, staging / "query.mlpackage")
+            artifacts["query_model"] = "query.mlpackage"
+        licenses = staging / "LICENSES"
+        licenses.mkdir(mode=0o755)
+        shutil.copyfile(
+            args.model_license, licenses / "MODEL_LICENSE.txt", follow_symlinks=False
+        )
+        shutil.copyfile(NOTICES, staging / "THIRD_PARTY_NOTICES.md", follow_symlinks=False)
+        provenance = {
+            "bundle_id": BUNDLE_ID,
+            "bundle_version": args.bundle_version,
+            "conversion": {
+                "compute_precision": "fp16",
+                "document_batch_size": args.document_batch_size,
+                "minimum_deployment_target": "macOS13",
+                "sequence_length": args.sequence_length,
+            },
+            "model": {"id": MODEL_ID, "source_revision": MODEL_REVISION},
+            "reproducibility": {
+                "network_required_during_packaging": False,
+                "private_evaluation_data_used": False,
+                "source_date_epoch": 0,
+                "toolchain_lock": lock,
+            },
+        }
+        if args.query_batch_size is not None:
+            provenance["conversion"]["query_batch_size"] = args.query_batch_size
+        (staging / "PROVENANCE.json").write_bytes(canonical_json(provenance))
+        manifest = _manifest(args, artifacts, staging)
+        (staging / MANIFEST_NAME).write_bytes(canonical_json(manifest))
+        verify_bundle(staging)
+        os.rename(staging, args.output_dir)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    try:
+        _write_archive(args.output_dir, args.archive, args.bundle_version)
+    except BaseException:
+        shutil.rmtree(args.output_dir, ignore_errors=True)
+        raise
+    print(f"bundle={args.output_dir}")
+    print(f"archive={args.archive}")
+
+
+def _validate_role_batches(args: argparse.Namespace) -> None:
+    if args.document_batch_size != 16 or args.sequence_length != 512:
+        raise SystemExit("document batch size must be 16 and sequence length must be 512")
+    if args.query_model is None and args.query_batch_size is not None:
+        raise SystemExit("--query-batch-size requires --query-model")
+    if args.query_model is not None and args.query_batch_size is None:
+        raise SystemExit("--query-model requires --query-batch-size")
+    if args.query_batch_size is not None and args.query_batch_size != 1:
+        raise SystemExit("query batch size must be 1")
+
+
+def _manifest(args: argparse.Namespace, artifacts: dict[str, str], root: Path) -> dict:
+    sequence = args.sequence_length
+    inputs = [
+        {
+            "dtype": "int32",
+            "name": name,
+            "shape": [args.document_batch_size, sequence],
+        }
+        for name in ("input_ids", "attention_mask", "token_type_ids")
+    ]
+    tensor_contract = {
+        "document_batch_size": args.document_batch_size,
+        "document_prefix": "passage: ",
+        "embedding_dimensions": 384,
+        "inputs": inputs,
+        "max_sequence_length": sequence,
+        "normalization": "l2",
+        "output": {
+            "dtype": "float32",
+            "name": "sentence_embeddings",
+            "shape": [args.document_batch_size, 384],
+        },
+        "pooling": "attention_mask_mean",
+        "query_prefix": "query: ",
+    }
+    if args.query_batch_size is not None:
+        tensor_contract["query_batch_size"] = args.query_batch_size
+    return {
+        "artifacts": artifacts,
+        "bundle_id": BUNDLE_ID,
+        "bundle_version": args.bundle_version,
+        "files": file_records(root),
+        "model": {
+            "embedding_space_id": EMBEDDING_SPACE_ID,
+            "id": MODEL_ID,
+            "precision": "fp16",
+            "source_revision": MODEL_REVISION,
+        },
+        "schema_version": SCHEMA_VERSION,
+        "tensor_contract": tensor_contract,
+    }
+
+
+def _load_and_check_toolchain() -> dict:
+    lock = json.loads(TOOLCHAIN_LOCK.read_text(encoding="utf-8"))
+    if platform.system() != "Darwin" or platform.mac_ver()[0] != lock["macos"]:
+        raise BundleError("host macOS version does not match toolchain lock")
+    xcode = subprocess.run(
+        ["xcodebuild", "-version"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    if not xcode or xcode[0] != f"Xcode {lock['xcode']}":
+        raise BundleError("Xcode version does not match toolchain lock")
+    expected_python = lock["python"]
+    actual_python = ".".join(map(str, sys.version_info[:3]))
+    if actual_python != expected_python:
+        raise BundleError(f"Python {actual_python} does not match lock {expected_python}")
+    for distribution, expected in lock["python_distributions"].items():
+        actual = importlib.metadata.version(distribution)
+        if actual != expected:
+            raise BundleError(f"{distribution} {actual} does not match lock {expected}")
+    return lock
+
+
+def _validate_tokenizer(path: Path) -> None:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise BundleError("tokenizer.json must contain a JSON object")
+
+
+def _validate_coreml_contract(path: Path, batch: int, sequence: int, name: str) -> None:
+    import coremltools as ct
+    from coremltools.proto.FeatureTypes_pb2 import ArrayFeatureType
+
+    spec = ct.models.MLModel(str(path), skip_model_load=True).get_spec()
+    expected_inputs = [
+        ("input_ids", ArrayFeatureType.INT32, [batch, sequence]),
+        ("attention_mask", ArrayFeatureType.INT32, [batch, sequence]),
+        ("token_type_ids", ArrayFeatureType.INT32, [batch, sequence]),
+    ]
+    actual_inputs = list(spec.description.input)
+    if len(actual_inputs) != len(expected_inputs):
+        raise BundleError(f"{name} has an incompatible input count")
+    for feature, (expected_name, expected_type, expected_shape) in zip(
+        actual_inputs, expected_inputs, strict=True
+    ):
+        if feature.type.WhichOneof("Type") != "multiArrayType":
+            raise BundleError(f"{name} input {expected_name} is not a multi-array")
+        array = feature.type.multiArrayType
+        if (
+            feature.name != expected_name
+            or array.dataType != expected_type
+            or list(array.shape) != expected_shape
+        ):
+            raise BundleError(f"{name} input {expected_name} has an incompatible contract")
+    outputs = list(spec.description.output)
+    if len(outputs) != 1 or outputs[0].type.WhichOneof("Type") != "multiArrayType":
+        raise BundleError(f"{name} must have one multi-array output")
+    output = outputs[0]
+    array = output.type.multiArrayType
+    if (
+        output.name != "sentence_embeddings"
+        or array.dataType != ArrayFeatureType.FLOAT32
+        or list(array.shape) != [batch, 384]
+    ):
+        raise BundleError(f"{name} output has an incompatible contract")
+
+
+def _validate_input_file(path: Path, name: str) -> None:
+    metadata = path.lstat()
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise BundleError(f"{name} must be a regular non-symlink file: {path}")
+
+
+def _validate_mlpackage(path: Path, name: str) -> None:
+    metadata = path.lstat()
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISDIR(metadata.st_mode)
+        or path.suffix != ".mlpackage"
+    ):
+        raise BundleError(f"{name} must be a real .mlpackage directory: {path}")
+    found_file = False
+    for directory, names, filenames in os.walk(
+        path, onerror=_raise_walk_error, followlinks=False
+    ):
+        names.sort()
+        filenames.sort()
+        children = [*(Path(directory) / value for value in names)]
+        children.extend(Path(directory) / value for value in filenames)
+        for child in children:
+            metadata = child.lstat()
+            if stat.S_ISLNK(metadata.st_mode) or not (
+                stat.S_ISDIR(metadata.st_mode) or stat.S_ISREG(metadata.st_mode)
+            ):
+                raise BundleError(f"unsupported mlpackage entry: {child}")
+            found_file |= stat.S_ISREG(metadata.st_mode)
+    if not found_file:
+        raise BundleError(f"{name} contains no files")
+
+
+def _copy_tree(source: Path, destination: Path) -> None:
+    shutil.copytree(
+        source,
+        destination,
+        symlinks=False,
+        copy_function=lambda src, dst: shutil.copyfile(src, dst, follow_symlinks=False),
+    )
+
+
+def _raise_walk_error(error: OSError) -> None:
+    raise error
+
+
+def _write_archive(bundle: Path, archive: Path, version: str) -> None:
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    temporary = archive.with_name(f".{archive.name}.{os.getpid()}.tmp")
+    if temporary.exists() or temporary.is_symlink():
+        raise BundleError(f"archive temporary path already exists: {temporary}")
+    root_name = f"ctx-multilingual-e5-small-coreml-fp16-{version}"
+    try:
+        with tarfile.open(temporary, "w:xz", format=tarfile.PAX_FORMAT, preset=9) as output:
+            _add_tar_entry(output, bundle, root_name)
+            paths = sorted(
+                bundle.rglob("*"), key=lambda item: item.relative_to(bundle).as_posix()
+            )
+            for path in paths:
+                archive_name = f"{root_name}/{path.relative_to(bundle).as_posix()}"
+                _add_tar_entry(output, path, archive_name)
+        with temporary.open("rb") as stream:
+            os.fsync(stream.fileno())
+        os.replace(temporary, archive)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _add_tar_entry(output: tarfile.TarFile, source: Path, archive_name: str) -> None:
+    metadata = source.lstat()
+    if stat.S_ISLNK(metadata.st_mode):
+        raise BundleError(f"refusing to archive symlink: {source}")
+    info = tarfile.TarInfo(archive_name)
+    info.uid = info.gid = 0
+    info.uname = info.gname = ""
+    info.mtime = 0
+    if source.is_dir():
+        info.type = tarfile.DIRTYPE
+        info.mode = 0o755
+        info.size = 0
+        output.addfile(info)
+    elif source.is_file():
+        info.type = tarfile.REGTYPE
+        info.mode = 0o644
+        info.size = metadata.st_size
+        with source.open("rb") as stream:
+            output.addfile(info, stream)
+    else:
+        raise BundleError(f"refusing to archive unsupported entry: {source}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/semantic-model-bundle/requirements.lock
+++ b/scripts/semantic-model-bundle/requirements.lock
@@ -1,0 +1,8 @@
+coremltools==8.3.0
+huggingface-hub==0.29.3
+numpy==1.26.4
+safetensors==0.5.3
+sentencepiece==0.2.0
+tokenizers==0.21.0
+torch==2.5.1
+transformers==4.49.0

--- a/scripts/semantic-model-bundle/test_bundle_contracts.py
+++ b/scripts/semantic-model-bundle/test_bundle_contracts.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Contract and tamper tests for deterministic Core ML model bundles."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import bundle_format
+import produce
+
+
+class BundleContractTest(unittest.TestCase):
+    def test_query_bundle_uses_distinct_role_batches(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest = _write_fixture(root, has_query=True)
+
+            self.assertEqual(bundle_format.verify_bundle(root), manifest)
+            self.assertEqual(
+                manifest["tensor_contract"]["document_batch_size"], 16
+            )
+            self.assertEqual(manifest["tensor_contract"]["query_batch_size"], 1)
+
+    def test_no_query_bundle_omits_query_batch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest = _write_fixture(root, has_query=False)
+
+            self.assertEqual(bundle_format.verify_bundle(root), manifest)
+            self.assertNotIn("query_batch_size", manifest["tensor_contract"])
+
+    def test_rejects_swapped_role_batches_and_wrong_tensor_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest = _write_fixture(root, has_query=True)
+            contract = manifest["tensor_contract"]
+            contract["document_batch_size"] = 1
+            contract["query_batch_size"] = 16
+            for value in contract["inputs"]:
+                value["shape"][0] = 1
+            contract["output"]["shape"][0] = 1
+            _rewrite_manifest(root, manifest)
+
+            with self.assertRaisesRegex(bundle_format.BundleError, "fixed batch 16"):
+                bundle_format.verify_bundle(root)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest = _write_fixture(root, has_query=True)
+            manifest["tensor_contract"]["inputs"][0]["shape"] = [16, 384]
+            _rewrite_manifest(root, manifest)
+
+            with self.assertRaisesRegex(bundle_format.BundleError, "incompatible tensor"):
+                bundle_format.verify_bundle(root)
+
+    def test_rejects_query_declaration_mismatches_and_legacy_batch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest = _write_fixture(root, has_query=True)
+            del manifest["tensor_contract"]["query_batch_size"]
+            _rewrite_manifest(root, manifest)
+
+            with self.assertRaisesRegex(bundle_format.BundleError, "missing or unknown"):
+                bundle_format.verify_bundle(root)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest = _write_fixture(root, has_query=False)
+            manifest["tensor_contract"]["query_batch_size"] = 1
+            _rewrite_manifest(root, manifest)
+
+            with self.assertRaisesRegex(bundle_format.BundleError, "missing or unknown"):
+                bundle_format.verify_bundle(root)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest = _write_fixture(root, has_query=False)
+            contract = manifest["tensor_contract"]
+            contract["batch_size"] = contract.pop("document_batch_size")
+            _rewrite_manifest(root, manifest)
+
+            with self.assertRaisesRegex(bundle_format.BundleError, "missing or unknown"):
+                bundle_format.verify_bundle(root)
+
+    def test_payload_tamper_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            _write_fixture(root, has_query=True)
+            (root / "query.mlpackage" / "Data" / "model.bin").write_bytes(b"tampered")
+
+            with self.assertRaisesRegex(bundle_format.BundleError, "does not match"):
+                bundle_format.verify_bundle(root)
+
+
+class ProducerContractTest(unittest.TestCase):
+    def test_role_batch_arguments_are_conditional_and_exact(self) -> None:
+        produce._validate_role_batches(_role_args(query_model=None, query_batch_size=None))
+        produce._validate_role_batches(
+            _role_args(query_model=Path("query.mlpackage"), query_batch_size=1)
+        )
+
+        for args in (
+            _role_args(document_batch_size=1),
+            _role_args(query_model=Path("query.mlpackage"), query_batch_size=None),
+            _role_args(query_model=None, query_batch_size=1),
+            _role_args(query_model=Path("query.mlpackage"), query_batch_size=16),
+        ):
+            with self.assertRaises(SystemExit):
+                produce._validate_role_batches(args)
+
+    def test_coreml_packages_are_checked_against_their_own_role_shape(self) -> None:
+        document_spec = _coreml_spec(16)
+        query_spec = _coreml_spec(1)
+        modules = _fake_coreml_modules(
+            {"document.mlpackage": document_spec, "query.mlpackage": query_spec}
+        )
+        with mock.patch.dict(sys.modules, modules):
+            produce._validate_coreml_contract(
+                Path("document.mlpackage"), 16, 512, "document model"
+            )
+            produce._validate_coreml_contract(
+                Path("query.mlpackage"), 1, 512, "query model"
+            )
+            with self.assertRaisesRegex(bundle_format.BundleError, "incompatible contract"):
+                produce._validate_coreml_contract(
+                    Path("query.mlpackage"), 16, 512, "document model"
+                )
+
+
+def _write_fixture(root: Path, has_query: bool) -> dict:
+    payloads = {
+        "LICENSES/MODEL_LICENSE.txt": b"license\n",
+        "PROVENANCE.json": b"{}\n",
+        "THIRD_PARTY_NOTICES.md": b"notices\n",
+        "document.mlpackage/Data/model.bin": b"document model",
+        "tokenizer.json": b"{}\n",
+    }
+    if has_query:
+        payloads["query.mlpackage/Data/model.bin"] = b"query model"
+    for relative, body in payloads.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(body)
+
+    artifacts = {
+        "document_model": "document.mlpackage",
+        "tokenizer": "tokenizer.json",
+    }
+    contract = {
+        "document_batch_size": 16,
+        "document_prefix": "passage: ",
+        "embedding_dimensions": 384,
+        "inputs": [
+            {"dtype": "int32", "name": name, "shape": [16, 512]}
+            for name in ("input_ids", "attention_mask", "token_type_ids")
+        ],
+        "max_sequence_length": 512,
+        "normalization": "l2",
+        "output": {
+            "dtype": "float32",
+            "name": "sentence_embeddings",
+            "shape": [16, 384],
+        },
+        "pooling": "attention_mask_mean",
+        "query_prefix": "query: ",
+    }
+    if has_query:
+        artifacts["query_model"] = "query.mlpackage"
+        contract["query_batch_size"] = 1
+    manifest = {
+        "artifacts": artifacts,
+        "bundle_id": bundle_format.BUNDLE_ID,
+        "bundle_version": "1.0.0",
+        "files": bundle_format.file_records(root),
+        "model": {
+            "embedding_space_id": bundle_format.EMBEDDING_SPACE_ID,
+            "id": bundle_format.MODEL_ID,
+            "precision": "fp16",
+            "source_revision": bundle_format.MODEL_REVISION,
+        },
+        "schema_version": bundle_format.SCHEMA_VERSION,
+        "tensor_contract": contract,
+    }
+    _rewrite_manifest(root, manifest)
+    return manifest
+
+
+def _rewrite_manifest(root: Path, manifest: dict) -> None:
+    (root / bundle_format.MANIFEST_NAME).write_bytes(bundle_format.canonical_json(manifest))
+
+
+def _role_args(
+    *,
+    document_batch_size: int = 16,
+    query_model: Path | None = None,
+    query_batch_size: int | None = None,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        document_batch_size=document_batch_size,
+        query_model=query_model,
+        query_batch_size=query_batch_size,
+        sequence_length=512,
+    )
+
+
+def _coreml_spec(batch: int) -> types.SimpleNamespace:
+    def feature(name: str, data_type: int, shape: list[int]) -> types.SimpleNamespace:
+        array = types.SimpleNamespace(dataType=data_type, shape=shape)
+        feature_type = types.SimpleNamespace(
+            WhichOneof=lambda _: "multiArrayType", multiArrayType=array
+        )
+        return types.SimpleNamespace(name=name, type=feature_type)
+
+    inputs = [feature(name, 1, [batch, 512]) for name in (
+        "input_ids",
+        "attention_mask",
+        "token_type_ids",
+    )]
+    outputs = [feature("sentence_embeddings", 2, [batch, 384])]
+    return types.SimpleNamespace(
+        description=types.SimpleNamespace(input=inputs, output=outputs)
+    )
+
+
+def _fake_coreml_modules(specs: dict[str, types.SimpleNamespace]) -> dict[str, object]:
+    coremltools = types.ModuleType("coremltools")
+    coremltools.models = types.SimpleNamespace(
+        MLModel=lambda path, skip_model_load: types.SimpleNamespace(
+            get_spec=lambda: specs[path]
+        )
+    )
+    proto = types.ModuleType("coremltools.proto")
+    feature_types = types.ModuleType("coremltools.proto.FeatureTypes_pb2")
+    feature_types.ArrayFeatureType = types.SimpleNamespace(INT32=1, FLOAT32=2)
+    return {
+        "coremltools": coremltools,
+        "coremltools.proto": proto,
+        "coremltools.proto.FeatureTypes_pb2": feature_types,
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/semantic-model-bundle/toolchain.lock.json
+++ b/scripts/semantic-model-bundle/toolchain.lock.json
@@ -1,0 +1,15 @@
+{
+  "macos": "26.2",
+  "python": "3.11.9",
+  "python_distributions": {
+    "coremltools": "8.3.0",
+    "huggingface-hub": "0.29.3",
+    "numpy": "1.26.4",
+    "safetensors": "0.5.3",
+    "sentencepiece": "0.2.0",
+    "tokenizers": "0.21.0",
+    "torch": "2.5.1",
+    "transformers": "4.49.0"
+  },
+  "xcode": "26.2"
+}

--- a/scripts/semantic-model-bundle/verify.py
+++ b/scripts/semantic-model-bundle/verify.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Verify a semantic Core ML bundle without loading or compiling its models."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+from bundle_format import MANIFEST_NAME, verify_bundle
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle", type=Path)
+    args = parser.parse_args()
+    manifest = verify_bundle(args.bundle)
+    digest = hashlib.sha256((args.bundle / MANIFEST_NAME).read_bytes()).hexdigest()
+    print(f"verified bundle_id={manifest['bundle_id']}")
+    print(f"bundle_version={manifest['bundle_version']}")
+    print(f"manifest_sha256={digest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke-daemon-semantic-release.ps1
+++ b/scripts/smoke-daemon-semantic-release.ps1
@@ -1,0 +1,664 @@
+param(
+    [string]$Ctx = "ctx.exe",
+    [string]$RuntimeArchive = "",
+    [string]$RuntimePlatform = "",
+    [string]$DataRoot = "",
+    [string]$ProofOutput = "",
+    [int]$TimeoutSeconds = 900,
+    [switch]$RequireAuthoritative,
+    [switch]$KeepRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ([System.Environment]::OSVersion.Platform -ne [System.PlatformID]::Win32NT) {
+    throw "This smoke must run on Windows"
+}
+
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class CtxWindowsNativeArchitecture
+{
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool IsWow64Process2(
+        IntPtr process,
+        out ushort processMachine,
+        out ushort nativeMachine);
+
+    [DllImport("kernel32.dll")]
+    private static extern IntPtr GetCurrentProcess();
+
+    public static string Probe()
+    {
+        try
+        {
+            ushort processMachine;
+            ushort nativeMachine;
+            if (!IsWow64Process2(GetCurrentProcess(), out processMachine, out nativeMachine))
+            {
+                return "error";
+            }
+            return processMachine.ToString("X4") + ":" + nativeMachine.ToString("X4");
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return "unavailable";
+        }
+    }
+}
+"@
+
+if ($TimeoutSeconds -lt 30) {
+    throw "TimeoutSeconds must be at least 30"
+}
+if ([string]::IsNullOrWhiteSpace($Ctx)) {
+    throw "Ctx cannot be empty"
+}
+if (-not [string]::IsNullOrEmpty($ProofOutput) -and [string]::IsNullOrWhiteSpace($ProofOutput)) {
+    throw "ProofOutput cannot be whitespace-only"
+}
+if ([string]::IsNullOrWhiteSpace($RuntimeArchive)) {
+    throw "RuntimeArchive is required"
+}
+if ($RuntimePlatform -ne "windows-x64") {
+    throw "RuntimePlatform must be windows-x64"
+}
+
+$runtimeVersion = "1.27.0"
+$expectedRuntimeAsset = "ctx-onnxruntime-windows-x64.zip"
+if ([System.IO.Path]::GetFileName($RuntimeArchive) -ne $expectedRuntimeAsset) {
+    throw "RuntimeArchive for windows-x64 must be named $expectedRuntimeAsset"
+}
+$runtimeArchivePath = (Resolve-Path -LiteralPath $RuntimeArchive).Path
+$runtimeShaPath = "$runtimeArchivePath.sha256"
+if (-not (Test-Path -LiteralPath $runtimeShaPath -PathType Leaf)) {
+    throw "Runtime archive checksum not found: $runtimeShaPath"
+}
+$expectedRuntimeSha = ([System.IO.File]::ReadAllText($runtimeShaPath)).Trim()
+if ($expectedRuntimeSha -notmatch '^[0-9a-fA-F]{64}$') {
+    throw "Runtime archive checksum is not a SHA-256 digest: $runtimeShaPath"
+}
+$actualRuntimeSha = (Get-FileHash -Algorithm SHA256 -LiteralPath $runtimeArchivePath).Hash.ToLowerInvariant()
+if ($actualRuntimeSha -ne $expectedRuntimeSha.ToLowerInvariant()) {
+    throw "Runtime archive checksum mismatch: expected $expectedRuntimeSha, got $actualRuntimeSha"
+}
+
+function Assert-WindowsRuntimeArchive {
+    param(
+        [string]$ArchivePath,
+        [string]$ExpectedVersion
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $expectedFiles = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::Ordinal
+    )
+    @(
+        "LICENSE",
+        "ThirdPartyNotices.txt",
+        "VERSION_NUMBER",
+        "GIT_COMMIT_ID",
+        "lib/onnxruntime.dll"
+    ) | ForEach-Object { [void]$expectedFiles.Add($_) }
+    $seenFiles = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+    $seenDirectories = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+    $versionEntry = $null
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($ArchivePath)
+    try {
+        foreach ($entry in $archive.Entries) {
+            $rawName = $entry.FullName
+            if (
+                [string]::IsNullOrEmpty($rawName) -or
+                $rawName.Contains("\") -or
+                $rawName.StartsWith("/", [System.StringComparison]::Ordinal) -or
+                $rawName -match '^[A-Za-z]:'
+            ) {
+                throw "Unsafe runtime archive entry path: '$rawName'"
+            }
+
+            $isDirectory = $rawName.EndsWith("/", [System.StringComparison]::Ordinal)
+            $canonicalName = if ($isDirectory) {
+                $rawName.Substring(0, $rawName.Length - 1)
+            } else {
+                $rawName
+            }
+            $segments = $canonicalName.Split(
+                [char[]]@('/'),
+                [System.StringSplitOptions]::None
+            )
+            if (
+                [string]::IsNullOrEmpty($canonicalName) -or
+                @($segments | Where-Object { $_ -eq "" -or $_ -eq "." -or $_ -eq ".." }).Count -gt 0
+            ) {
+                throw "Unsafe runtime archive entry path: '$rawName'"
+            }
+
+            $unixMode = ($entry.ExternalAttributes -shr 16) -band 0xFFFF
+            if (($unixMode -band 0xF000) -eq 0xA000) {
+                throw "Runtime archive contains a symbolic link entry: '$rawName'"
+            }
+
+            if ($isDirectory) {
+                if ($canonicalName -cne "lib" -or -not $seenDirectories.Add($canonicalName)) {
+                    throw "Unexpected or duplicate runtime archive directory entry: '$rawName'"
+                }
+                continue
+            }
+            if (-not $expectedFiles.Contains($canonicalName)) {
+                throw "Unexpected runtime archive entry: '$rawName'"
+            }
+            if (-not $seenFiles.Add($canonicalName)) {
+                throw "Duplicate runtime archive entry: '$rawName'"
+            }
+            if ($canonicalName -ceq "VERSION_NUMBER") {
+                $versionEntry = $entry
+            }
+        }
+
+        $missing = @($expectedFiles | Where-Object { -not $seenFiles.Contains($_) })
+        if ($missing.Count -gt 0 -or $seenFiles.Count -ne $expectedFiles.Count) {
+            throw "Runtime archive entries do not match the expected files; missing: $($missing -join ', ')"
+        }
+        if ($null -eq $versionEntry) {
+            throw "Runtime archive is missing VERSION_NUMBER"
+        }
+
+        $versionStream = $versionEntry.Open()
+        try {
+            $memory = [System.IO.MemoryStream]::new()
+            try {
+                $versionStream.CopyTo($memory)
+                $versionText = [System.Text.UTF8Encoding]::new($false, $true).GetString($memory.ToArray())
+            } finally {
+                $memory.Dispose()
+            }
+        } finally {
+            $versionStream.Dispose()
+        }
+        if ($versionText -cne ($ExpectedVersion + "`n")) {
+            throw "Runtime archive VERSION_NUMBER is not exactly $ExpectedVersion"
+        }
+    } finally {
+        $archive.Dispose()
+    }
+}
+
+Assert-WindowsRuntimeArchive -ArchivePath $runtimeArchivePath -ExpectedVersion $runtimeVersion
+
+$ctxCommand = Get-Command -Name $Ctx -CommandType Application -ErrorAction Stop
+$Ctx = $ctxCommand.Source
+
+function New-UniqueRunRoot {
+    param([string]$Parent)
+
+    for ($attempt = 0; $attempt -lt 20; $attempt++) {
+        $candidate = Join-Path $Parent ("ctx-semantic-smoke-" + [System.Guid]::NewGuid().ToString("n"))
+        try {
+            return (New-Item -ItemType Directory -Path $candidate -ErrorAction Stop).FullName
+        } catch {
+            if (Test-Path -LiteralPath $candidate) {
+                continue
+            }
+            throw
+        }
+    }
+    throw "Could not create a unique semantic smoke run root under $Parent"
+}
+
+$environmentVariableNames = @(
+    "USERPROFILE", "HOME", "LOCALAPPDATA", "APPDATA", "XDG_CACHE_HOME", "XDG_CONFIG_HOME",
+    "CTX_DATA_ROOT",
+    "CTX_DAEMON_ENABLED", "CTX_DAEMON_OFF", "CTX_DISABLE_DAEMON",
+    "CTX_DAEMON_AUTOSTART_OFF", "CTX_DAEMON_AUTOSTART_EXE", "CTX_DAEMON_BACKGROUND_CHILD",
+    "CTX_DAEMON_AUTOSTART_IDLE_EXIT_SECONDS", "CTX_DAEMON_AUTOSTART_LOOP_INTERVAL_SECONDS",
+    "CTX_SEARCH_SEMANTIC", "CTX_DISABLE_SEMANTIC_SEARCH", "CTX_SEMANTIC_WORKER_OFF",
+    "CTX_SEMANTIC_WORKER_MAX_CHUNKS", "CTX_SEMANTIC_WORKER_MAX_SECONDS",
+    "CTX_SEMANTIC_THREADS", "CTX_SEMANTIC_EMBED_BATCH",
+    "CTX_ANALYTICS_ENABLED", "CTX_ANALYTICS_OFF", "CTX_DISABLE_ANALYTICS",
+    "CTX_ANALYTICS_ENDPOINT", "CTX_ANALYTICS_DRY_RUN", "CTX_ANALYTICS_DEBUG",
+    "CTX_UPGRADE_OFF", "CTX_DISABLE_AUTO_UPGRADE", "CTX_UPGRADE_AUTO",
+    "CTX_UPGRADE_CHANNEL", "CTX_CHANNEL", "CTX_FUNCTIONS_BASE",
+    "CTX_UPGRADE_INTERVAL_SECONDS", "CTX_UPGRADE_TARGET", "CTX_UPGRADE_BACKGROUND_CHILD",
+    "CTX_SEMANTIC_CACHE_DIR", "FASTEMBED_CACHE_DIR", "HF_HOME", "HF_HUB_CACHE",
+    "HUGGINGFACE_HUB_CACHE", "TRANSFORMERS_CACHE",
+    "CTX_RUNTIME_DIR", "CTX_ONNXRUNTIME_DYLIB", "ORT_DYLIB_PATH",
+    "CTX_ONNXRUNTIME_DIR", "CTX_ONNXRUNTIME_CACHE_DIR",
+    "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH", "LD_PRELOAD", "DYLD_INSERT_LIBRARIES",
+    "DYLD_FORCE_FLAT_NAMESPACE", "DYLD_FALLBACK_LIBRARY_PATH", "PATH"
+) | Select-Object -Unique
+$savedEnvironment = @{}
+foreach ($name in $environmentVariableNames) {
+    $savedEnvironment[$name] = [System.Environment]::GetEnvironmentVariable(
+        $name,
+        [System.EnvironmentVariableTarget]::Process
+    )
+}
+
+function Set-ProcessEnvironmentVariable {
+    param(
+        [string]$Name,
+        [AllowNull()][string]$Value
+    )
+    [System.Environment]::SetEnvironmentVariable(
+        $Name,
+        $Value,
+        [System.EnvironmentVariableTarget]::Process
+    )
+}
+
+$runRoot = ""
+$daemon = $null
+
+function Invoke-Ctx {
+    param([string[]]$Args)
+    & $Ctx --data-root $DataRoot @Args
+}
+
+function Read-OwnedDaemonStatus {
+    param([int]$ExpectedPid)
+
+    $statusLines = @()
+    try {
+        $statusLines = @(Invoke-Ctx -Args @("daemon", "status", "--json") 2>&1)
+        $statusExitCode = $LASTEXITCODE
+    } catch {
+        return [PSCustomObject]@{
+            Ready = $false
+            Text = ($statusLines -join [Environment]::NewLine)
+            Error = $_.Exception.Message
+            Json = $null
+        }
+    }
+    $statusText = $statusLines -join [Environment]::NewLine
+    if ($statusExitCode -ne 0) {
+        return [PSCustomObject]@{
+            Ready = $false
+            Text = $statusText
+            Error = "ctx daemon status exited with $statusExitCode"
+            Json = $null
+        }
+    }
+    try {
+        $statusJson = $statusText | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        throw "ctx daemon status returned invalid JSON: $($_.Exception.Message)"
+    }
+    $daemonProperty = $statusJson.PSObject.Properties["daemon"]
+    if ($null -eq $daemonProperty -or $null -eq $daemonProperty.Value) {
+        throw "ctx daemon status JSON is missing daemon"
+    }
+    $daemonStatus = $daemonProperty.Value
+    $pidProperty = $daemonStatus.PSObject.Properties["pid"]
+    if ($null -ne $pidProperty -and $null -ne $pidProperty.Value) {
+        $reportedPid = [long]$pidProperty.Value
+        if ($reportedPid -ne $ExpectedPid) {
+            throw "ctx daemon status PID mismatch: expected $ExpectedPid, got $reportedPid"
+        }
+    } else {
+        $reportedPid = $null
+    }
+    $statusProperty = $daemonStatus.PSObject.Properties["status"]
+    $runningProperty = $daemonStatus.PSObject.Properties["running"]
+    $ready = (
+        $null -ne $statusProperty -and $statusProperty.Value -ceq "running" -and
+        $null -ne $runningProperty -and $runningProperty.Value -eq $true -and
+        $reportedPid -eq $ExpectedPid
+    )
+    return [PSCustomObject]@{
+        Ready = $ready
+        Text = $statusText
+        Error = ""
+        Json = $statusJson
+    }
+}
+
+try {
+    if ([string]::IsNullOrWhiteSpace($DataRoot)) {
+        $dataRootParent = [System.IO.Path]::GetTempPath()
+    } else {
+        if (Test-Path -LiteralPath $DataRoot -PathType Leaf) {
+            throw "DataRoot parent is a file: $DataRoot"
+        }
+        New-Item -ItemType Directory -Path $DataRoot -Force | Out-Null
+        $dataRootParent = (Resolve-Path -LiteralPath $DataRoot).Path
+    }
+    $runRoot = New-UniqueRunRoot -Parent $dataRootParent
+    $DataRoot = Join-Path $runRoot "data"
+    New-Item -ItemType Directory -Path $DataRoot | Out-Null
+    $DataRoot = [System.IO.Path]::GetFullPath($DataRoot)
+
+    $fixtureDir = Join-Path $DataRoot "smoke-fixture"
+    $fixturePath = Join-Path $fixtureDir "history.jsonl"
+    $smokeHome = Join-Path $DataRoot "home"
+    $smokeCache = Join-Path $DataRoot "cache"
+    $smokeConfig = Join-Path $DataRoot "config-home"
+    $smokeLocalAppData = Join-Path $DataRoot "local-app-data"
+    $smokeAppData = Join-Path $DataRoot "app-data"
+    $semanticCache = Join-Path $DataRoot "semantic-cache"
+    New-Item -ItemType Directory -Path $fixtureDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $smokeHome -Force | Out-Null
+    New-Item -ItemType Directory -Path $smokeCache -Force | Out-Null
+    New-Item -ItemType Directory -Path $smokeConfig -Force | Out-Null
+    New-Item -ItemType Directory -Path $smokeLocalAppData -Force | Out-Null
+    New-Item -ItemType Directory -Path $smokeAppData -Force | Out-Null
+    New-Item -ItemType Directory -Path $semanticCache -Force | Out-Null
+
+    Write-Host "ctx semantic smoke: run_root=$runRoot"
+    Write-Host "ctx semantic smoke: data_root=$DataRoot"
+
+    $runtimeRoot = Join-Path $DataRoot "runtime"
+    $runtimeInstallDir = Join-Path $runtimeRoot ("onnxruntime\" + $runtimeVersion + "\" + $RuntimePlatform)
+    $releaseArtifactDir = Join-Path $runRoot "release-artifacts"
+    $installBinDir = Join-Path $runRoot "installed\bin"
+    $releaseMetadata = Join-Path $runRoot "release-metadata.env"
+    New-Item -ItemType Directory -Path $releaseArtifactDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $installBinDir -Force | Out-Null
+
+    $versionLine = (& $Ctx --version | Select-Object -First 1)
+    if ($LASTEXITCODE -ne 0 -or $versionLine -notmatch '^ctx\s+(\S+)') {
+        throw "Could not determine ctx version from $Ctx"
+    }
+    $ctxVersion = $Matches[1]
+    $releaseBinary = "ctx-windows-x64.exe"
+    Copy-Item -LiteralPath $Ctx -Destination (Join-Path $releaseArtifactDir $releaseBinary) -Force
+    Copy-Item -LiteralPath $runtimeArchivePath -Destination (Join-Path $releaseArtifactDir $expectedRuntimeAsset) -Force
+    Copy-Item -LiteralPath $runtimeShaPath -Destination (Join-Path $releaseArtifactDir "$expectedRuntimeAsset.sha256") -Force
+    $binarySha = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $releaseArtifactDir $releaseBinary)).Hash.ToLowerInvariant()
+    $metadataLines = @(
+        "CTX_RELEASE_SCHEMA_VERSION=1",
+        "CTX_RELEASE_VERSION=$ctxVersion",
+        "CTX_RELEASE_BASE_URL=https://release-smoke.invalid",
+        "CTX_RELEASE_ARTIFACT_windows_x64=$releaseBinary",
+        "CTX_RELEASE_SHA256_windows_x64=$binarySha",
+        "CTX_RELEASE_ONNXRUNTIME_VERSION=$runtimeVersion",
+        "CTX_RELEASE_ONNXRUNTIME_ARTIFACT_windows_x64=$expectedRuntimeAsset",
+        "CTX_RELEASE_ONNXRUNTIME_SHA256_windows_x64=$actualRuntimeSha"
+    )
+    [System.IO.File]::WriteAllLines($releaseMetadata, $metadataLines, [System.Text.UTF8Encoding]::new($false))
+
+    & (Join-Path $PSScriptRoot "install.ps1") `
+        -Metadata $releaseMetadata `
+        -ArtifactDir $releaseArtifactDir `
+        -Platform $RuntimePlatform `
+        -BinDir $installBinDir `
+        -RuntimeDir $runtimeRoot `
+        -NoSetup -NoSkill -NoModifyPath | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Explicit-metadata installer failed with status $LASTEXITCODE"
+    }
+
+    $Ctx = Join-Path $installBinDir "ctx.exe"
+    $runtimeDylib = Join-Path $runtimeInstallDir "lib\onnxruntime.dll"
+    if (
+        -not (Test-Path -LiteralPath $Ctx -PathType Leaf) -or
+        -not (Test-Path -LiteralPath $runtimeDylib -PathType Leaf)
+    ) {
+        throw "Explicit-metadata installer did not create the expected binary/runtime layout"
+    }
+    $runtimeDylib = [System.IO.Path]::GetFullPath($runtimeDylib)
+    $binaryMarker = Get-Content -LiteralPath "$Ctx.install.json" -Raw | ConvertFrom-Json
+    $runtimeMarker = Get-Content -LiteralPath (Join-Path $runtimeInstallDir "ctx-runtime-install.json") -Raw | ConvertFrom-Json
+    if (
+        $binaryMarker.manager -cne "ctx-explicit-metadata-installer" -or
+        $binaryMarker.metadata_trust -cne "explicit-unsigned" -or
+        $runtimeMarker.manager -cne "ctx-explicit-metadata-installer" -or
+        $runtimeMarker.metadata_trust -cne "explicit-unsigned"
+    ) {
+        throw "Explicit-metadata install provenance marker is missing or incorrect"
+    }
+
+    foreach ($name in $environmentVariableNames) {
+        Set-ProcessEnvironmentVariable -Name $name -Value $null
+    }
+    Set-ProcessEnvironmentVariable -Name "USERPROFILE" -Value $smokeHome
+    Set-ProcessEnvironmentVariable -Name "HOME" -Value $smokeHome
+    Set-ProcessEnvironmentVariable -Name "LOCALAPPDATA" -Value $smokeLocalAppData
+    Set-ProcessEnvironmentVariable -Name "APPDATA" -Value $smokeAppData
+    Set-ProcessEnvironmentVariable -Name "XDG_CACHE_HOME" -Value $smokeCache
+    Set-ProcessEnvironmentVariable -Name "XDG_CONFIG_HOME" -Value $smokeConfig
+    Set-ProcessEnvironmentVariable -Name "HF_HOME" -Value $semanticCache
+    Set-ProcessEnvironmentVariable -Name "HF_HUB_CACHE" -Value $semanticCache
+    Set-ProcessEnvironmentVariable -Name "FASTEMBED_CACHE_DIR" -Value $semanticCache
+    Set-ProcessEnvironmentVariable -Name "CTX_SEMANTIC_CACHE_DIR" -Value $semanticCache
+    Set-ProcessEnvironmentVariable -Name "CTX_ANALYTICS_OFF" -Value "1"
+    Set-ProcessEnvironmentVariable -Name "CTX_DISABLE_ANALYTICS" -Value "1"
+    Set-ProcessEnvironmentVariable -Name "CTX_UPGRADE_OFF" -Value "1"
+    Set-ProcessEnvironmentVariable -Name "CTX_DISABLE_AUTO_UPGRADE" -Value "1"
+    Set-ProcessEnvironmentVariable -Name "CTX_UPGRADE_AUTO" -Value "off"
+    Set-ProcessEnvironmentVariable -Name "CTX_DAEMON_ENABLED" -Value "1"
+    Set-ProcessEnvironmentVariable -Name "CTX_SEARCH_SEMANTIC" -Value "1"
+    Set-ProcessEnvironmentVariable -Name "CTX_RUNTIME_DIR" -Value $runtimeRoot
+    Set-ProcessEnvironmentVariable -Name "PATH" -Value $savedEnvironment["PATH"]
+
+    $runtimeProof = Join-Path $DataRoot "packaged-runtime-proof.txt"
+    $hostArch = $env:PROCESSOR_ARCHITECTURE
+    $machineProbe = [CtxWindowsNativeArchitecture]::Probe()
+    $hostNativeArch = if ($machineProbe.EndsWith(":8664", [System.StringComparison]::Ordinal)) {
+        "AMD64"
+    } elseif ($machineProbe.EndsWith(":AA64", [System.StringComparison]::Ordinal)) {
+        "ARM64"
+    } else {
+        "unknown"
+    }
+    $processTranslated = if ($hostArch -ceq "AMD64" -and $machineProbe -ceq "0000:8664") { 0 } else { 1 }
+    $runtimeAuthority = if ($processTranslated -eq 0) { "authoritative" } else { "non_authoritative" }
+    if ($RequireAuthoritative -and $runtimeAuthority -cne "authoritative") {
+        throw "Windows semantic smoke requires native AMD64 execution; probe was $machineProbe"
+    }
+    $runtimeProofLines = @(
+        "runtime=onnxruntime",
+        "version=$runtimeVersion",
+        "platform=$RuntimePlatform",
+        "host_system=Windows_NT",
+        "host_arch=$hostArch",
+        "host_native_arch=$hostNativeArch",
+        "process_translated=$processTranslated",
+        "native_arch_probe=iswow64process2",
+        "runtime_authority=$runtimeAuthority",
+        "artifact=$Ctx",
+        "artifact_sha256=$binarySha",
+        "archive=$runtimeArchivePath",
+        "runtime_archive_sha256=$actualRuntimeSha",
+        "CTX_RUNTIME_DIR=$runtimeRoot",
+        "runtime_dylib=$runtimeDylib",
+        "loader_overrides=unset",
+        "CTX_SEMANTIC_CACHE_DIR=$semanticCache",
+        "installer=explicit-metadata"
+    )
+
+    $marker = "ctx-release-semantic-smoke-" + [System.Guid]::NewGuid().ToString("n")
+    $query = "synthetic release retrieval cobalt willow transit"
+    $embeddingModel = "intfloat/multilingual-e5-small"
+    $lines = @(
+        [PSCustomObject]@{
+            record_type = "manifest"
+            schema_version = "ctx-history-jsonl-v1"
+            metadata = [PSCustomObject]@{ exporter = "ctx-release-smoke" }
+        },
+        [PSCustomObject]@{
+            record_type = "source"
+            source_id = "release-smoke"
+            provider_key = "ctx-smoke"
+            source_format = "release-smoke-jsonl"
+            raw_source_path = $fixturePath
+        },
+        [PSCustomObject]@{
+            record_type = "session"
+            source_id = "release-smoke"
+            session_id = "semantic-daemon-smoke"
+            cwd = "C:\ctx-release-smoke"
+            started_at = "2026-07-10T00:00:00Z"
+            agent_type = "primary"
+            role_hint = "developer"
+            is_primary = $true
+            status = "completed"
+        },
+        [PSCustomObject]@{
+            record_type = "event"
+            source_id = "release-smoke"
+            session_id = "semantic-daemon-smoke"
+            event_index = 0
+            event_type = "message"
+            role = "user"
+            occurred_at = "2026-07-10T00:00:01Z"
+            payload = [PSCustomObject]@{ text = "Please remember the $marker validation task for daemon semantic search." }
+            preview = "Please remember the $marker validation task for daemon semantic search."
+            native_cursor = "line:1"
+        },
+        [PSCustomObject]@{
+            record_type = "event"
+            source_id = "release-smoke"
+            session_id = "semantic-daemon-smoke"
+            event_index = 1
+            event_type = "message"
+            role = "assistant"
+            occurred_at = "2026-07-10T00:00:02Z"
+            payload = [PSCustomObject]@{ text = "Recorded $marker as the release smoke semantic retrieval target." }
+            preview = "Recorded $marker as the release smoke semantic retrieval target."
+            native_cursor = "line:2"
+        }
+    ) | ForEach-Object { $_ | ConvertTo-Json -Depth 8 -Compress }
+    [System.IO.File]::WriteAllLines($fixturePath, $lines, [System.Text.UTF8Encoding]::new($false))
+
+    Write-Host "ctx semantic smoke: isolated_home=$smokeHome"
+    Write-Host "ctx semantic smoke: semantic_cache=$semanticCache"
+    Write-Host "ctx semantic smoke: packaged_runtime=$runtimeDylib"
+    Invoke-Ctx -Args @("import", "--no-daemon", "--format", "ctx-history-jsonl-v1", "--path", $fixturePath) | Out-Null
+
+    $configPath = Join-Path $DataRoot "config.toml"
+    [System.IO.File]::WriteAllText(
+        $configPath,
+        "[analytics]`nenabled = false`n`n[upgrade]`nauto = `"off`"`n`n[daemon]`nenabled = true`n`n[search]`nsemantic = true`n",
+        [System.Text.UTF8Encoding]::new($false)
+    )
+
+    $daemonLog = Join-Path $DataRoot "daemon-smoke.log"
+    $daemonErr = Join-Path $DataRoot "daemon-smoke.err.log"
+    $daemonArgs = @(
+        "--data-root", $DataRoot,
+        "daemon", "run",
+        "--idle-exit-seconds", [string]$TimeoutSeconds,
+        "--loop-interval-seconds", "2",
+        "--json"
+    )
+    $daemon = Start-Process -FilePath $Ctx -ArgumentList $daemonArgs -PassThru -NoNewWindow -RedirectStandardOutput $daemonLog -RedirectStandardError $daemonErr
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    $lastOutput = ""
+    $lastSearchError = ""
+    $lastStatusOutput = ""
+    $lastStatusError = ""
+    while ([DateTime]::UtcNow -lt $deadline) {
+        if ($daemon.HasExited) {
+            $daemonOutput = Get-Content -LiteralPath $daemonLog -Raw -ErrorAction SilentlyContinue
+            $daemonError = Get-Content -LiteralPath $daemonErr -Raw -ErrorAction SilentlyContinue
+            throw "ctx semantic smoke: daemon exited before search succeeded`n$daemonOutput`n$daemonError"
+        }
+
+        $statusReport = Read-OwnedDaemonStatus -ExpectedPid $daemon.Id
+        $lastStatusOutput = $statusReport.Text
+        $lastStatusError = $statusReport.Error
+        if ($statusReport.Ready) {
+            $outputLines = @()
+            $searchOk = $false
+            try {
+                $outputLines = @(Invoke-Ctx -Args @("search", $query, "--backend", "semantic", "--refresh", "off", "--json") 2>&1)
+                $searchOk = $LASTEXITCODE -eq 0
+            } catch {
+                $lastSearchError = $_.Exception.Message
+            }
+            $lastOutput = $outputLines -join [Environment]::NewLine
+            if ($searchOk) {
+                try {
+                    $searchJson = $lastOutput | ConvertFrom-Json -ErrorAction Stop
+                    $retrievalProperty = $searchJson.PSObject.Properties["retrieval"]
+                    $resultsProperty = $searchJson.PSObject.Properties["results"]
+                    $modelMatches = (
+                        $null -ne $retrievalProperty -and
+                        $null -ne $retrievalProperty.Value -and
+                        $null -ne $retrievalProperty.Value.PSObject.Properties["embedding_model"] -and
+                        $retrievalProperty.Value.embedding_model -ceq $embeddingModel
+                    )
+                    $markerMatches = $false
+                    if ($null -ne $resultsProperty -and $null -ne $resultsProperty.Value) {
+                        foreach ($result in @($resultsProperty.Value)) {
+                            $resultJson = $result | ConvertTo-Json -Depth 20 -Compress
+                            if ($resultJson.IndexOf($marker, [System.StringComparison]::Ordinal) -ge 0) {
+                                $markerMatches = $true
+                                break
+                            }
+                        }
+                    }
+                    if ($modelMatches -and $markerMatches) {
+                        $finalStatusReport = Read-OwnedDaemonStatus -ExpectedPid $daemon.Id
+                        $lastStatusOutput = $finalStatusReport.Text
+                        $lastStatusError = $finalStatusReport.Error
+                        if ($finalStatusReport.Ready) {
+                            $runtimeProofLines += @(
+                                "daemon_status=running",
+                                "daemon_pid=$($daemon.Id)",
+                                "embedding_model=$embeddingModel",
+                                "marker=$marker",
+                                "semantic_search=passed"
+                            )
+                            [System.IO.File]::WriteAllLines(
+                                $runtimeProof,
+                                $runtimeProofLines,
+                                [System.Text.UTF8Encoding]::new($false)
+                            )
+                            if (-not [string]::IsNullOrWhiteSpace($ProofOutput)) {
+                                $proofParent = Split-Path -Parent $ProofOutput
+                                if (-not [string]::IsNullOrWhiteSpace($proofParent)) {
+                                    New-Item -ItemType Directory -Path $proofParent -Force | Out-Null
+                                }
+                                Copy-Item -LiteralPath $runtimeProof -Destination $ProofOutput -Force
+                            }
+                            Write-Host "ctx semantic smoke ok: strict semantic search found $marker with $embeddingModel"
+                            exit 0
+                        }
+                    }
+                } catch {
+                    $lastSearchError = $_.Exception.Message
+                }
+            }
+        }
+
+        Start-Sleep -Seconds 5
+    }
+
+    $daemonOutput = Get-Content -LiteralPath $daemonLog -Raw -ErrorAction SilentlyContinue
+    $daemonError = Get-Content -LiteralPath $daemonErr -Raw -ErrorAction SilentlyContinue
+    throw @"
+ctx semantic smoke failed: semantic search did not find fixture before timeout
+Last search output:
+$lastOutput
+Last search error:
+$lastSearchError
+Last daemon status:
+$lastStatusOutput
+Last daemon status error:
+$lastStatusError
+Daemon stdout:
+$daemonOutput
+Daemon stderr:
+$daemonError
+"@
+} finally {
+    if ($null -ne $daemon -and -not $daemon.HasExited) {
+        Stop-Process -InputObject $daemon -Force -ErrorAction SilentlyContinue
+        $daemon.WaitForExit()
+    }
+    if (-not $KeepRoot -and -not [string]::IsNullOrWhiteSpace($runRoot)) {
+        Remove-Item -LiteralPath $runRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    foreach ($name in $environmentVariableNames) {
+        Set-ProcessEnvironmentVariable -Name $name -Value $savedEnvironment[$name]
+    }
+}

--- a/scripts/smoke-daemon-semantic-release.sh
+++ b/scripts/smoke-daemon-semantic-release.sh
@@ -1,0 +1,750 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  scripts/smoke-daemon-semantic-release.sh --runtime-archive PATH --runtime-platform PLATFORM [--ctx PATH] [--data-root DIR] [--proof-output PATH] [--timeout-seconds N] [--keep-root]
+  scripts/smoke-daemon-semantic-release.sh --coreml --runtime-platform macos-arm64|macos-x64 [--ctx PATH] [--data-root DIR] [--proof-output PATH] [--timeout-seconds N] [--keep-root]
+
+Native release smoke for opt-in daemon + semantic search. The smoke creates an
+isolated ctx data root, imports a tiny custom-history fixture, enables daemon
+and semantic search in that root only, runs the daemon, verifies strict semantic
+search can find the fixture, and stops the daemon process it started. The
+default mode installs the packaged ONNX Runtime 1.27.0 sidecar under an isolated
+CTX_RUNTIME_DIR. --coreml instead exercises the production hash-pinned CoreML
+bundle acquisition path using the exact supplied macOS ctx artifact; it cannot
+be combined with --runtime-archive. When --data-root is provided, it is the
+parent for a fresh unique run root; --keep-root preserves that child for
+inspection. --proof-output copies the successful proof to a canonical release
+artifact path before the isolated run root is cleaned up.
+USAGE
+}
+
+ctx_bin="${CTX_BIN:-ctx}"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+data_root_parent=""
+runtime_archive=""
+runtime_platform=""
+proof_output=""
+runtime_version="1.27.0"
+timeout_seconds="${CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS:-900}"
+keep_root=0
+coreml_mode=0
+
+while (($# > 0)); do
+  case "$1" in
+    --ctx)
+      shift
+      ctx_bin="${1:-}"
+      ;;
+    --data-root)
+      shift
+      data_root_parent="${1:-}"
+      ;;
+    --runtime-archive)
+      shift
+      runtime_archive="${1:-}"
+      ;;
+    --runtime-platform)
+      shift
+      runtime_platform="${1:-}"
+      ;;
+    --proof-output)
+      shift
+      proof_output="${1:-}"
+      ;;
+    --coreml)
+      coreml_mode=1
+      ;;
+    --timeout-seconds)
+      shift
+      timeout_seconds="${1:-}"
+      ;;
+    --keep-root)
+      keep_root=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+  shift || true
+done
+
+if [[ -z "${ctx_bin}" ]]; then
+  echo "error: --ctx cannot be empty" >&2
+  exit 2
+fi
+if [[ -z "${runtime_platform}" ]]; then
+  echo "error: --runtime-platform is required" >&2
+  exit 2
+fi
+if [[ "${proof_output}" =~ ^[[:space:]]*$ && -n "${proof_output}" ]]; then
+  echo "error: --proof-output cannot be whitespace-only" >&2
+  exit 2
+fi
+if [[ ! "${timeout_seconds}" =~ ^[0-9]+$ ]] || ((timeout_seconds < 30)); then
+  echo "error: --timeout-seconds must be an integer >= 30" >&2
+  exit 2
+fi
+
+case "${runtime_platform}" in
+  linux-x64|linux-aarch64)
+    runtime_dylib_name="libonnxruntime.so"
+    ;;
+  macos-arm64|macos-x64)
+    runtime_dylib_name="libonnxruntime.dylib"
+    ;;
+  freebsd-x64)
+    runtime_dylib_name="libonnxruntime.so"
+    ;;
+  *)
+    echo "error: unsupported --runtime-platform: ${runtime_platform}" >&2
+    exit 2
+    ;;
+esac
+
+expected_runtime_asset=""
+runtime_sha_path=""
+actual_runtime_sha=""
+if [[ "${coreml_mode}" == "1" ]]; then
+  case "${runtime_platform}" in
+    macos-arm64|macos-x64) ;;
+    *)
+      echo "error: --coreml requires --runtime-platform macos-arm64 or macos-x64" >&2
+      exit 2
+      ;;
+  esac
+  if [[ -n "${runtime_archive}" ]]; then
+    echo "error: --coreml cannot be combined with --runtime-archive" >&2
+    exit 2
+  fi
+else
+  if [[ -z "${runtime_archive}" ]]; then
+    echo "error: --runtime-archive is required unless --coreml is selected" >&2
+    exit 2
+  fi
+  expected_runtime_asset="ctx-onnxruntime-${runtime_platform}.tar.gz"
+  if [[ "$(basename "${runtime_archive}")" != "${expected_runtime_asset}" ]]; then
+    echo "error: runtime archive for ${runtime_platform} must be named ${expected_runtime_asset}" >&2
+    exit 2
+  fi
+  if [[ ! -f "${runtime_archive}" ]]; then
+    echo "error: runtime archive not found: ${runtime_archive}" >&2
+    exit 1
+  fi
+  runtime_archive="$(cd "$(dirname "${runtime_archive}")" && pwd -P)/$(basename "${runtime_archive}")"
+  runtime_sha_path="${runtime_archive}.sha256"
+  if [[ ! -s "${runtime_sha_path}" ]]; then
+    echo "error: runtime archive checksum missing or empty: ${runtime_sha_path}" >&2
+    exit 1
+  fi
+  expected_runtime_sha="$(tr -d '[:space:]' < "${runtime_sha_path}")"
+  if [[ ! "${expected_runtime_sha}" =~ ^[0-9a-fA-F]{64}$ ]]; then
+    echo "error: runtime archive checksum is not a SHA-256 digest: ${runtime_sha_path}" >&2
+    exit 1
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual_runtime_sha="$(sha256sum "${runtime_archive}" | awk '{ print $1 }')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual_runtime_sha="$(shasum -a 256 "${runtime_archive}" | awk '{ print $1 }')"
+  else
+    echo "error: sha256sum or shasum is required to verify the runtime archive" >&2
+    exit 127
+  fi
+  actual_runtime_sha_lower="$(printf '%s' "${actual_runtime_sha}" | tr 'A-F' 'a-f')"
+  expected_runtime_sha_lower="$(printf '%s' "${expected_runtime_sha}" | tr 'A-F' 'a-f')"
+  if [[ "${actual_runtime_sha_lower}" != "${expected_runtime_sha_lower}" ]]; then
+    echo "error: runtime archive checksum mismatch: expected ${expected_runtime_sha}, got ${actual_runtime_sha}" >&2
+    exit 1
+  fi
+fi
+
+unset LD_LIBRARY_PATH DYLD_LIBRARY_PATH LD_PRELOAD DYLD_INSERT_LIBRARIES \
+  DYLD_FORCE_FLAT_NAMESPACE DYLD_FALLBACK_LIBRARY_PATH
+
+run_bounded() {
+  local limit_seconds="$1"
+  shift
+  python3 -I - "${limit_seconds}" "$@" <<'PY'
+import subprocess
+import sys
+
+limit = int(sys.argv[1])
+command = sys.argv[2:]
+try:
+    result = subprocess.run(command, timeout=limit, check=False)
+except subprocess.TimeoutExpired:
+    print(f"error: smoke command exceeded {limit} seconds", file=sys.stderr)
+    raise SystemExit(124)
+raise SystemExit(result.returncode)
+PY
+}
+
+run_root=""
+daemon_pid=""
+cleanup() {
+  local child_pid
+  local daemon_is_running=0
+  local attempt
+
+  if [[ -n "${daemon_pid}" ]]; then
+    while IFS= read -r child_pid; do
+      if [[ "${child_pid}" == "${daemon_pid}" ]]; then
+        daemon_is_running=1
+        break
+      fi
+    done < <(jobs -pr)
+  fi
+  if [[ "${daemon_is_running}" == "1" ]]; then
+    kill "${daemon_pid}" >/dev/null 2>&1 || true
+    for attempt in {1..50}; do
+      if ! kill -0 "${daemon_pid}" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 0.1
+    done
+    if kill -0 "${daemon_pid}" >/dev/null 2>&1; then
+      kill -KILL "${daemon_pid}" >/dev/null 2>&1 || true
+    fi
+    wait "${daemon_pid}" >/dev/null 2>&1 || true
+  fi
+  if [[ "${keep_root}" != "1" && -n "${run_root}" ]]; then
+    rm -rf -- "${run_root}"
+  fi
+}
+trap cleanup EXIT
+
+if [[ -n "${data_root_parent}" ]]; then
+  mkdir -p -- "${data_root_parent}"
+  data_root_parent="$(cd -- "${data_root_parent}" && pwd -P)"
+  run_root="$(mktemp -d "${data_root_parent%/}/ctx-semantic-smoke.XXXXXX")"
+else
+  run_root="$(mktemp -d "${TMPDIR:-/tmp}/ctx-semantic-smoke.XXXXXX")"
+fi
+chmod 700 "${run_root}"
+run_root="$(cd -- "${run_root}" && pwd -P)"
+data_root="${run_root}/data"
+mkdir -p -- "${data_root}"
+data_root="$(cd -- "${data_root}" && pwd -P)"
+
+fixture_dir="${data_root}/smoke-fixture"
+fixture_path="${fixture_dir}/history.jsonl"
+smoke_home="${data_root}/home"
+smoke_cache="${data_root}/cache"
+smoke_config="${data_root}/config-home"
+semantic_cache="${data_root}/semantic-cache"
+mkdir -p \
+  "${fixture_dir}" \
+  "${data_root}" \
+  "${smoke_home}" \
+  "${smoke_cache}" \
+  "${smoke_config}" \
+  "${semantic_cache}"
+
+printf 'ctx semantic smoke: run_root=%s\n' "${run_root}"
+printf 'ctx semantic smoke: data_root=%s\n' "${data_root}"
+
+runtime_root="${data_root}/runtime"
+runtime_install_dir="${runtime_root}/onnxruntime/${runtime_version}/${runtime_platform}"
+release_artifact_dir="${run_root}/release-artifacts"
+install_bin_dir="${run_root}/installed/bin"
+release_metadata="${run_root}/release-metadata.env"
+mkdir -p "${release_artifact_dir}" "${install_bin_dir}"
+IFS=$'\t' read -r \
+  host_system host_arch host_native_arch process_translated native_arch_probe \
+  < <("${script_dir}/public-cli-host-runtime-evidence.sh")
+
+if [[ "${ctx_bin}" == */* ]]; then
+  ctx_source="$(cd "$(dirname "${ctx_bin}")" && pwd -P)/$(basename "${ctx_bin}")"
+else
+  ctx_source="$(command -v "${ctx_bin}")"
+fi
+[[ -x "${ctx_source}" ]] || {
+  echo "error: ctx binary is not executable: ${ctx_source}" >&2
+  exit 1
+}
+ctx_version="$(run_bounded 30 "${ctx_source}" --version | awk 'NR == 1 { print $2 }')"
+[[ -n "${ctx_version}" ]] || {
+  echo "error: could not determine ctx version from ${ctx_source}" >&2
+  exit 1
+}
+release_binary="ctx-${runtime_platform}"
+cp "${ctx_source}" "${release_artifact_dir}/${release_binary}"
+chmod 755 "${release_artifact_dir}/${release_binary}"
+if command -v sha256sum >/dev/null 2>&1; then
+  binary_sha="$(sha256sum "${release_artifact_dir}/${release_binary}" | awk '{ print $1 }')"
+elif command -v shasum >/dev/null 2>&1; then
+  binary_sha="$(shasum -a 256 "${release_artifact_dir}/${release_binary}" | awk '{ print $1 }')"
+else
+  echo "error: sha256sum or shasum is required to verify the ctx artifact" >&2
+  exit 127
+fi
+runtime_authority="$(
+  "${script_dir}/public-cli-runtime-authority.sh" \
+    "${runtime_platform}" "${host_system}" "${host_arch}" passed \
+    "${host_native_arch}" "${process_translated}"
+)"
+if [[ "${coreml_mode}" == "1" ]]; then
+  ctx_bin="${install_bin_dir}/ctx"
+  cp "${release_artifact_dir}/${release_binary}" "${ctx_bin}"
+  chmod 755 "${ctx_bin}"
+  if ! cmp -s "${ctx_source}" "${ctx_bin}"; then
+    echo "error: isolated CoreML smoke artifact differs from the supplied ctx artifact" >&2
+    exit 1
+  fi
+  runtime_dylib=""
+else
+  cp "${runtime_archive}" "${release_artifact_dir}/${expected_runtime_asset}"
+  cp "${runtime_sha_path}" "${release_artifact_dir}/${expected_runtime_asset}.sha256"
+  platform_key="${runtime_platform//-/_}"
+  cat > "${release_metadata}" <<EOF
+CTX_RELEASE_SCHEMA_VERSION=1
+CTX_RELEASE_VERSION=${ctx_version}
+CTX_RELEASE_BASE_URL=https://release-smoke.invalid
+CTX_RELEASE_ARTIFACT_${platform_key}=${release_binary}
+CTX_RELEASE_SHA256_${platform_key}=${binary_sha}
+CTX_RELEASE_ONNXRUNTIME_VERSION=${runtime_version}
+CTX_RELEASE_ONNXRUNTIME_ARTIFACT_${platform_key}=${expected_runtime_asset}
+CTX_RELEASE_ONNXRUNTIME_SHA256_${platform_key}=${actual_runtime_sha}
+EOF
+
+  HOME="${smoke_home}" XDG_CACHE_HOME="${smoke_cache}" XDG_CONFIG_HOME="${smoke_config}" \
+    bash "${script_dir}/dev-install-from-metadata.sh" \
+      --metadata "${release_metadata}" \
+      --artifact-dir "${release_artifact_dir}" \
+      --platform "${runtime_platform}" \
+      --bin-dir "${install_bin_dir}" \
+      --runtime-dir "${runtime_root}" \
+      --no-setup --no-skill --no-man --no-modify-path >/dev/null
+
+  ctx_bin="${install_bin_dir}/ctx"
+  runtime_dylib="${runtime_install_dir}/lib/${runtime_dylib_name}"
+  [[ -x "${ctx_bin}" && -f "${runtime_dylib}" ]] || {
+    echo "error: explicit-metadata installer did not create the expected binary/runtime layout" >&2
+    exit 1
+  }
+  grep -F '"manager": "ctx-explicit-metadata-installer"' "${ctx_bin}.install.json" >/dev/null
+  grep -F '"metadata_trust": "explicit-unsigned"' "${runtime_install_dir}/ctx-runtime-install.json" >/dev/null
+fi
+runtime_proof="${data_root}/packaged-runtime-proof.txt"
+marker="ctx-release-semantic-smoke-$(python3 -I -c 'import uuid; print(uuid.uuid4().hex)')"
+query="synthetic release retrieval cobalt willow transit"
+embedding_model="intfloat/multilingual-e5-small"
+
+python3 -I - "${fixture_path}" "${marker}" <<'PY'
+import json
+import sys
+
+fixture_path, marker = sys.argv[1:]
+records = [
+    {
+        "record_type": "manifest",
+        "schema_version": "ctx-history-jsonl-v1",
+        "metadata": {"exporter": "ctx-release-smoke"},
+    },
+    {
+        "record_type": "source",
+        "source_id": "release-smoke",
+        "provider_key": "ctx-smoke",
+        "source_format": "release-smoke-jsonl",
+        "raw_source_path": fixture_path,
+    },
+    {
+        "record_type": "session",
+        "source_id": "release-smoke",
+        "session_id": "semantic-daemon-smoke",
+        "cwd": "/tmp/ctx-release-smoke",
+        "started_at": "2026-07-10T00:00:00Z",
+        "agent_type": "primary",
+        "role_hint": "developer",
+        "is_primary": True,
+        "status": "completed",
+    },
+]
+for index, role, text in (
+    (0, "user", f"Please remember the {marker} validation task for daemon semantic search."),
+    (1, "assistant", f"Recorded {marker} as the release smoke semantic retrieval target."),
+):
+    records.append(
+        {
+            "record_type": "event",
+            "source_id": "release-smoke",
+            "session_id": "semantic-daemon-smoke",
+            "event_index": index,
+            "event_type": "message",
+            "role": role,
+            "occurred_at": f"2026-07-10T00:00:0{index + 1}Z",
+            "payload": {"text": text},
+            "preview": text,
+            "native_cursor": f"line:{index + 1}",
+        }
+    )
+with open(fixture_path, "w", encoding="utf-8", newline="\n") as output:
+    for record in records:
+        output.write(json.dumps(record, separators=(",", ":")) + "\n")
+PY
+
+isolated_env=(
+  -u CTX_DATA_ROOT
+  -u CTX_DAEMON_OFF
+  -u CTX_DISABLE_DAEMON
+  -u CTX_DAEMON_AUTOSTART_OFF
+  -u CTX_DAEMON_AUTOSTART_EXE
+  -u CTX_DAEMON_BACKGROUND_CHILD
+  -u CTX_DAEMON_AUTOSTART_IDLE_EXIT_SECONDS
+  -u CTX_DAEMON_AUTOSTART_LOOP_INTERVAL_SECONDS
+  -u CTX_DISABLE_SEMANTIC_SEARCH
+  -u CTX_SEMANTIC_WORKER_OFF
+  -u CTX_SEMANTIC_WORKER_MAX_CHUNKS
+  -u CTX_SEMANTIC_WORKER_MAX_SECONDS
+  -u CTX_SEMANTIC_THREADS
+  -u CTX_SEMANTIC_EMBED_BATCH
+  -u CTX_INTERNAL_SEMANTIC_BACKEND
+  -u CTX_SEMANTIC_COREML_NATIVE_COMPUTE
+  -u CTX_ANALYTICS_ENABLED
+  -u CTX_ANALYTICS_ENDPOINT
+  -u CTX_ANALYTICS_DRY_RUN
+  -u CTX_ANALYTICS_DEBUG
+  -u CTX_UPGRADE_AUTO
+  -u CTX_UPGRADE_CHANNEL
+  -u CTX_CHANNEL
+  -u CTX_FUNCTIONS_BASE
+  -u CTX_UPGRADE_INTERVAL_SECONDS
+  -u CTX_UPGRADE_TARGET
+  -u CTX_UPGRADE_BACKGROUND_CHILD
+  -u CTX_SEMANTIC_CACHE_DIR
+  -u FASTEMBED_CACHE_DIR
+  -u HF_HOME
+  -u HF_HUB_CACHE
+  -u HUGGINGFACE_HUB_CACHE
+  -u TRANSFORMERS_CACHE
+  -u CTX_RUNTIME_DIR
+  -u CTX_ONNXRUNTIME_DYLIB
+  -u ORT_DYLIB_PATH
+  -u CTX_ONNXRUNTIME_DIR
+  -u CTX_ONNXRUNTIME_CACHE_DIR
+  -u LD_LIBRARY_PATH
+  -u DYLD_LIBRARY_PATH
+  -u LD_PRELOAD
+  -u DYLD_INSERT_LIBRARIES
+  -u DYLD_FORCE_FLAT_NAMESPACE
+  -u DYLD_FALLBACK_LIBRARY_PATH
+)
+
+ctx_env=(
+  env "${isolated_env[@]}"
+  "HOME=${smoke_home}"
+  "XDG_CACHE_HOME=${smoke_cache}"
+  "XDG_CONFIG_HOME=${smoke_config}"
+  "HF_HOME=${semantic_cache}"
+  "HF_HUB_CACHE=${semantic_cache}"
+  "FASTEMBED_CACHE_DIR=${semantic_cache}"
+  "CTX_SEMANTIC_CACHE_DIR=${semantic_cache}"
+  CTX_ANALYTICS_OFF=1
+  CTX_DISABLE_ANALYTICS=1
+  CTX_UPGRADE_OFF=1
+  CTX_DISABLE_AUTO_UPGRADE=1
+  CTX_UPGRADE_AUTO=off
+  CTX_DAEMON_ENABLED=1
+  CTX_SEARCH_SEMANTIC=1
+  "CTX_RUNTIME_DIR=${runtime_root}"
+)
+if [[ "${coreml_mode}" == "1" ]]; then
+  ctx_env+=(
+    CTX_INTERNAL_SEMANTIC_BACKEND=coreml
+    CTX_SEMANTIC_COREML_NATIVE_COMPUTE=all
+  )
+fi
+
+run_ctx() {
+  run_bounded 30 "${ctx_env[@]}" "${ctx_bin}" --data-root "${data_root}" "$@"
+}
+
+printf 'ctx semantic smoke: isolated_home=%s\n' "${smoke_home}"
+printf 'ctx semantic smoke: semantic_cache=%s\n' "${semantic_cache}"
+if [[ "${coreml_mode}" == "1" ]]; then
+  printf 'ctx semantic smoke: coreml_artifact=%s\n' "${ctx_bin}"
+else
+  printf 'ctx semantic smoke: packaged_runtime=%s\n' "${runtime_dylib}"
+fi
+run_ctx import --no-daemon --format ctx-history-jsonl-v1 --path "${fixture_path}" >/dev/null
+
+cat > "${data_root}/config.toml" <<'EOF'
+[analytics]
+enabled = false
+
+[upgrade]
+auto = "off"
+
+[daemon]
+enabled = true
+
+[search]
+semantic = true
+EOF
+
+daemon_log="${data_root}/daemon-smoke.log"
+"${ctx_env[@]}" "${ctx_bin}" --data-root "${data_root}" \
+  daemon run --idle-exit-seconds "${timeout_seconds}" --loop-interval-seconds 2 --json \
+  > "${daemon_log}" 2>&1 &
+daemon_pid="$!"
+
+deadline=$((SECONDS + timeout_seconds))
+last_output=""
+last_search_error=""
+last_status_output=""
+last_status_error=""
+daemon_status_json="${data_root}/daemon-status.json"
+daemon_status_error="${data_root}/daemon-status.err"
+search_json="${data_root}/semantic-search.json"
+search_error="${data_root}/semantic-search.err"
+
+daemon_status_matches() {
+  python3 -I - "${daemon_status_json}" "${daemon_pid}" "${coreml_mode}" "${embedding_model}" <<'PY'
+import json
+import sys
+
+path, expected_pid_text, coreml_mode, expected_model = sys.argv[1:]
+try:
+    with open(path, encoding="utf-8") as source:
+        payload = json.load(source)
+except (OSError, UnicodeError, json.JSONDecodeError):
+    raise SystemExit(1)
+
+daemon = payload.get("daemon") if isinstance(payload, dict) else None
+if not isinstance(daemon, dict):
+    raise SystemExit(1)
+pid = daemon.get("pid")
+expected_pid = int(expected_pid_text)
+if pid is not None and (isinstance(pid, bool) or not isinstance(pid, int) or pid != expected_pid):
+    print(f"daemon status PID mismatch: expected {expected_pid}, got {pid!r}", file=sys.stderr)
+    raise SystemExit(2)
+if daemon.get("status") != "running" or daemon.get("running") is not True or pid != expected_pid:
+    raise SystemExit(1)
+if coreml_mode != "1":
+    raise SystemExit(0)
+
+jobs = daemon.get("jobs")
+semantic = jobs.get("semantic_index") if isinstance(jobs, dict) else None
+runtime = semantic.get("embedding_runtime") if isinstance(semantic, dict) else None
+if not isinstance(runtime, dict):
+    raise SystemExit(1)
+if runtime.get("backend") != "coreml":
+    print(f"CoreML daemon status reported backend {runtime.get('backend')!r}", file=sys.stderr)
+    raise SystemExit(2)
+if runtime.get("model_id") != expected_model:
+    print(f"CoreML daemon status reported model {runtime.get('model_id')!r}", file=sys.stderr)
+    raise SystemExit(2)
+if runtime.get("compute_mode") != "all":
+    print(f"CoreML daemon status reported compute mode {runtime.get('compute_mode')!r}", file=sys.stderr)
+    raise SystemExit(2)
+if runtime.get("acquisition_source") != "download":
+    print(f"CoreML daemon status reported acquisition source {runtime.get('acquisition_source')!r}", file=sys.stderr)
+    raise SystemExit(2)
+if runtime.get("acquisition_fallback") is not None:
+    print("CoreML daemon status reported an acquisition fallback", file=sys.stderr)
+    raise SystemExit(2)
+PY
+}
+
+search_json_matches() {
+  python3 -I - "${search_json}" "${marker}" "${embedding_model}" "${coreml_mode}" <<'PY'
+import json
+import sys
+
+path, marker, expected_model, coreml_mode = sys.argv[1:]
+try:
+    with open(path, encoding="utf-8") as source:
+        payload = json.load(source)
+except (OSError, UnicodeError, json.JSONDecodeError):
+    raise SystemExit(1)
+
+retrieval = payload.get("retrieval") if isinstance(payload, dict) else None
+results = payload.get("results") if isinstance(payload, dict) else None
+if not isinstance(retrieval, dict) or retrieval.get("embedding_model") != expected_model:
+    raise SystemExit(1)
+if retrieval.get("requested_mode") != "semantic" or retrieval.get("effective_mode") != "semantic":
+    raise SystemExit(1)
+if retrieval.get("semantic_fallback") is not None or retrieval.get("semantic_fallback_code") is not None:
+    raise SystemExit(1)
+if coreml_mode == "1":
+    worker = retrieval.get("worker")
+    runtime = worker.get("embedding_runtime") if isinstance(worker, dict) else None
+    if not isinstance(runtime, dict):
+        print("CoreML search status did not report an embedding runtime", file=sys.stderr)
+        raise SystemExit(2)
+    if runtime.get("backend") != "coreml":
+        print(f"CoreML search status reported backend {runtime.get('backend')!r}", file=sys.stderr)
+        raise SystemExit(2)
+    if runtime.get("model_id") != expected_model:
+        print(f"CoreML search status reported model {runtime.get('model_id')!r}", file=sys.stderr)
+        raise SystemExit(2)
+    if runtime.get("compute_mode") != "all":
+        print(f"CoreML search status reported compute mode {runtime.get('compute_mode')!r}", file=sys.stderr)
+        raise SystemExit(2)
+    if runtime.get("acquisition_source") != "download":
+        print(f"CoreML search status reported acquisition source {runtime.get('acquisition_source')!r}", file=sys.stderr)
+        raise SystemExit(2)
+    if runtime.get("acquisition_fallback") is not None:
+        print("CoreML search status reported an acquisition fallback", file=sys.stderr)
+        raise SystemExit(2)
+if not isinstance(results, list):
+    raise SystemExit(1)
+
+def strings(value):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for child in value.values():
+            yield from strings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from strings(child)
+
+if not any(marker in text for result in results for text in strings(result)):
+    raise SystemExit(1)
+PY
+}
+
+while ((SECONDS < deadline)); do
+  if ! kill -0 "${daemon_pid}" >/dev/null 2>&1; then
+    echo "ctx semantic smoke: daemon exited before search succeeded" >&2
+    cat "${daemon_log}" >&2 || true
+    exit 1
+  fi
+
+  daemon_status_ready=0
+  if run_ctx daemon status --json > "${daemon_status_json}" 2> "${daemon_status_error}"; then
+    last_status_output="$(cat "${daemon_status_json}")"
+    last_status_error="$(cat "${daemon_status_error}")"
+    if daemon_status_matches; then
+      daemon_status_ready=1
+    else
+      status_check=$?
+      if [[ "${status_check}" == "2" ]]; then
+        cat "${daemon_status_json}" >&2 || true
+        exit 1
+      fi
+    fi
+  fi
+
+  if [[ "${daemon_status_ready}" == "1" ]] && \
+    run_ctx search "${query}" --backend semantic --refresh off --json \
+      > "${search_json}" 2> "${search_error}"; then
+    last_output="$(cat "${search_json}")"
+    last_search_error="$(cat "${search_error}")"
+    if search_json_matches; then
+      if run_ctx daemon status --json > "${daemon_status_json}" 2> "${daemon_status_error}" && \
+        daemon_status_matches; then
+        if [[ "${coreml_mode}" == "1" ]]; then
+          runtime_fields="$(python3 -I - "${daemon_status_json}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    payload = json.load(source)
+runtime = payload["daemon"]["jobs"]["semantic_index"]["embedding_runtime"]
+print(
+    "\t".join(
+        (
+            runtime["compute_mode"],
+            runtime["model_id"],
+            runtime.get("acquisition_source", "unknown"),
+        )
+    )
+)
+PY
+)"
+          IFS=$'\t' read -r coreml_compute_mode coreml_model coreml_acquisition_source \
+            <<< "${runtime_fields}"
+          cat > "${runtime_proof}" <<EOF
+runtime=coreml
+platform=${runtime_platform}
+host_system=${host_system}
+host_arch=${host_arch}
+host_native_arch=${host_native_arch}
+process_translated=${process_translated}
+native_arch_probe=${native_arch_probe}
+runtime_authority=${runtime_authority}
+artifact=${ctx_source}
+artifact_sha256=${binary_sha}
+isolated_artifact=${ctx_bin}
+compute_mode=${coreml_compute_mode}
+model=${coreml_model}
+acquisition_source=${coreml_acquisition_source}
+acquisition_fallback=none
+CTX_SEMANTIC_CACHE_DIR=${semantic_cache}
+daemon_status=running
+daemon_pid=${daemon_pid}
+marker=${marker}
+semantic_search=passed
+EOF
+        else
+          cat > "${runtime_proof}" <<EOF
+runtime=onnxruntime
+version=${runtime_version}
+platform=${runtime_platform}
+host_system=${host_system}
+host_arch=${host_arch}
+host_native_arch=${host_native_arch}
+process_translated=${process_translated}
+native_arch_probe=${native_arch_probe}
+runtime_authority=${runtime_authority}
+artifact=${ctx_source}
+artifact_sha256=${binary_sha}
+archive=${runtime_archive}
+runtime_archive_sha256=${actual_runtime_sha}
+CTX_RUNTIME_DIR=${runtime_root}
+runtime_dylib=${runtime_dylib}
+loader_overrides=unset
+CTX_SEMANTIC_CACHE_DIR=${semantic_cache}
+daemon_status=running
+daemon_pid=${daemon_pid}
+embedding_model=${embedding_model}
+marker=${marker}
+semantic_search=passed
+EOF
+        fi
+        if [[ -n "${proof_output}" ]]; then
+          mkdir -p -- "$(dirname -- "${proof_output}")"
+          install -m 0644 "${runtime_proof}" "${proof_output}"
+        fi
+        printf 'ctx semantic smoke ok: strict semantic search found %s with %s\n' \
+          "${marker}" "${embedding_model}"
+        exit 0
+      else
+        status_check=$?
+        if [[ "${status_check}" == "2" ]]; then
+          cat "${daemon_status_json}" >&2 || true
+          exit 1
+        fi
+      fi
+    else
+      search_check=$?
+      if [[ "${search_check}" == "2" ]]; then
+        cat "${search_json}" >&2 || true
+        exit 1
+      fi
+    fi
+  else
+    last_output="$(cat "${search_json}" 2>/dev/null || true)"
+    last_search_error="$(cat "${search_error}" 2>/dev/null || true)"
+  fi
+
+  sleep 5
+done
+
+echo "ctx semantic smoke failed: semantic search did not find fixture before timeout" >&2
+printf '\nLast search output:\n%s\n' "${last_output}" >&2
+printf '\nLast search stderr:\n%s\n' "${last_search_error}" >&2
+printf '\nLast daemon status:\n%s\n' "${last_status_output}" >&2
+printf '\nLast daemon status stderr:\n%s\n' "${last_status_error}" >&2
+printf '\nDaemon log:\n' >&2
+cat "${daemon_log}" >&2 || true
+exit 1

--- a/scripts/stage-github-release-assets.sh
+++ b/scripts/stage-github-release-assets.sh
@@ -4,16 +4,31 @@ set -euo pipefail
 usage() {
   cat >&2 <<'USAGE'
 Usage: scripts/stage-github-release-assets.sh [ARTIFACT_DIR] [OUT_DIR]
+       scripts/stage-github-release-assets.sh --transcode-runtime PLATFORM [ARTIFACT_DIR]
 
 Stages public GitHub Release assets from built public CLI artifacts.
 
 Inputs default to target/public-cli-artifacts.
 Outputs default to target/github-release-assets.
+
+Every ONNX Runtime sidecar is required. Release assembly fails closed when a
+platform runtime is absent.
+
+The transcode mode converts a validated builder-owned Unix .tar.zst sidecar
+to the deterministic .tar.gz transport consumed by release installers.
 USAGE
 }
 
-artifact_dir="${1:-target/public-cli-artifacts}"
-out_dir="${2:-target/github-release-assets}"
+mode="stage"
+if [[ "${1:-}" == "--transcode-runtime" ]]; then
+  mode="transcode"
+  transcode_platform="${2:-}"
+  artifact_dir="${3:-target/public-cli-artifacts}"
+  out_dir=""
+else
+  artifact_dir="${1:-target/public-cli-artifacts}"
+  out_dir="${2:-target/github-release-assets}"
+fi
 
 if [[ "${artifact_dir}" == "-h" || "${artifact_dir}" == "--help" ]]; then
   usage
@@ -40,20 +55,308 @@ sha256_file() {
   exit 127
 }
 
+transcode_runtime_asset() {
+  local platform="$1"
+  local source_name dest_name source_path dest_path
+
+  case "${platform}" in
+    linux-x64|linux-aarch64|macos-arm64|macos-x64|freebsd-x64)
+      source_name="ctx-onnxruntime-${platform}.tar.zst"
+      dest_name="ctx-onnxruntime-${platform}.tar.gz"
+      ;;
+    *)
+      printf 'transcode mode does not support runtime platform: %s\n' "${platform}" >&2
+      exit 2
+      ;;
+  esac
+  source_path="${artifact_dir%/}/${source_name}"
+  dest_path="${artifact_dir%/}/${dest_name}"
+  test -f "${source_path}" || {
+    printf 'runtime source archive missing: %s\n' "${source_path}" >&2
+    exit 1
+  }
+  command -v python3 >/dev/null 2>&1 || {
+    printf 'python3 is required to transcode runtime archives\n' >&2
+    exit 127
+  }
+  command -v zstd >/dev/null 2>&1 || {
+    printf 'zstd is required on runtime producer hosts\n' >&2
+    exit 127
+  }
+
+  bash scripts/build-onnxruntime-sidecar.sh --validate "${platform}" "${source_path}"
+  python3 - "${source_path}" "${dest_path}.tmp" <<'PY'
+import gzip
+import shutil
+import subprocess
+import sys
+
+source, destination = sys.argv[1:]
+with open(destination, "wb") as raw_output:
+    with gzip.GzipFile(filename="", mode="wb", fileobj=raw_output, compresslevel=9, mtime=0) as output:
+        process = subprocess.Popen(["zstd", "-q", "-d", "-c", source], stdout=subprocess.PIPE)
+        assert process.stdout is not None
+        with process.stdout:
+            shutil.copyfileobj(process.stdout, output)
+        status = process.wait()
+        if status != 0:
+            raise SystemExit(f"zstd decompression failed with status {status}")
+PY
+  mv "${dest_path}.tmp" "${dest_path}"
+  sha256_file "${dest_path}" > "${dest_path}.sha256"
+  rm -f "${source_path}" "${source_path}.sha256"
+  printf 'transcoded runtime release asset %s\n' "${dest_path}"
+}
+
+if [[ "${mode}" == "transcode" ]]; then
+  [[ -n "${transcode_platform}" ]] || {
+    usage
+    exit 2
+  }
+  transcode_runtime_asset "${transcode_platform}"
+  exit 0
+fi
+
 stage_asset() {
   local source_name="$1"
   local dest_name="$2"
+  local mode="${3:-0755}"
   local source_path="${artifact_dir%/}/${source_name}"
+  local source_sha_path="${source_path}.sha256"
   local dest_path="${out_dir%/}/${dest_name}"
+  local expected_sha actual_sha
 
   if [[ ! -f "${source_path}" ]]; then
     printf 'missing public CLI artifact: %s\n' "${source_path}" >&2
     exit 1
   fi
+  if [[ ! -s "${source_sha_path}" ]]; then
+    printf 'missing public artifact checksum: %s\n' "${source_sha_path}" >&2
+    exit 1
+  fi
+  expected_sha="$(tr -d '[:space:]' < "${source_sha_path}")"
+  if [[ ! "${expected_sha}" =~ ^[0-9a-fA-F]{64}$ ]]; then
+    printf 'invalid public artifact checksum: %s\n' "${source_sha_path}" >&2
+    exit 1
+  fi
+  actual_sha="$(sha256_file "${source_path}")"
+  if [[ "$(printf '%s' "${actual_sha}" | tr 'A-F' 'a-f')" != "$(printf '%s' "${expected_sha}" | tr 'A-F' 'a-f')" ]]; then
+    printf 'public artifact checksum mismatch for %s: expected %s got %s\n' \
+      "${source_path}" "${expected_sha}" "${actual_sha}" >&2
+    exit 1
+  fi
 
-  install -m 0755 "${source_path}" "${dest_path}"
-  printf '%s  %s\n' "$(sha256_file "${dest_path}")" "${dest_name}" >> "${out_dir%/}/SHA256SUMS"
+  install -m "${mode}" "${source_path}" "${dest_path}"
+  printf '%s  %s\n' "${actual_sha}" "${dest_name}" >> "${out_dir%/}/SHA256SUMS"
 }
+
+stage_runtime_asset() {
+  local platform="$1"
+  local asset_name
+
+  case "${platform}" in
+    linux-x64) asset_name="ctx-onnxruntime-linux-x64.tar.gz" ;;
+    linux-aarch64) asset_name="ctx-onnxruntime-linux-aarch64.tar.gz" ;;
+    macos-arm64) asset_name="ctx-onnxruntime-macos-arm64.tar.gz" ;;
+    macos-x64) asset_name="ctx-onnxruntime-macos-x64.tar.gz" ;;
+    windows-x64) asset_name="ctx-onnxruntime-windows-x64.zip" ;;
+    freebsd-x64) asset_name="ctx-onnxruntime-freebsd-x64.tar.gz" ;;
+    *)
+      printf 'unknown platform for ONNX Runtime staging: %s\n' "${platform}" >&2
+      exit 2
+      ;;
+  esac
+
+  if [[ ! -f "${artifact_dir%/}/${asset_name}" ]]; then
+    printf 'required ONNX Runtime sidecar missing: %s\n' "${artifact_dir%/}/${asset_name}" >&2
+    exit 1
+  fi
+
+  if [[ "${platform}" == "windows-x64" ]]; then
+    bash scripts/build-onnxruntime-sidecar.sh --validate \
+      "${platform}" "${artifact_dir%/}/${asset_name}"
+  else
+    python3 - "${artifact_dir%/}/${asset_name}" "${platform}" <<'PY'
+import posixpath
+import stat
+import sys
+import tarfile
+
+archive, platform = sys.argv[1:]
+library = "libonnxruntime.dylib" if platform.startswith("macos-") else "libonnxruntime.so"
+expected_files = {
+    "LICENSE",
+    "ThirdPartyNotices.txt",
+    "VERSION_NUMBER",
+    "GIT_COMMIT_ID",
+    f"lib/{library}",
+}
+expected = expected_files | {"lib"}
+seen = set()
+with tarfile.open(archive, "r:gz") as bundle:
+    for member in bundle.getmembers():
+        raw = member.name
+        name = posixpath.normpath(raw.rstrip("/"))
+        if (
+            not raw
+            or "\\" in raw
+            or raw.startswith("/")
+            or name in ("", ".", "..")
+            or name.startswith("../")
+            or raw != name
+        ):
+            raise SystemExit(f"unsafe runtime archive path: {raw!r}")
+        if name in seen:
+            raise SystemExit(f"duplicate runtime archive entry: {name}")
+        seen.add(name)
+        if name not in expected:
+            raise SystemExit(f"unexpected runtime archive entry: {name}")
+        if member.mode & 0o7000:
+            raise SystemExit(f"unsafe permission bits on runtime archive entry: {name}")
+        if name == "lib":
+            if not member.isdir():
+                raise SystemExit("runtime lib entry is not a directory")
+        elif not member.isfile():
+            raise SystemExit(f"runtime archive entry is not a regular file: {name}")
+    if seen != expected:
+        raise SystemExit("runtime archive entries do not exactly match the expected layout")
+PY
+  fi
+  stage_asset "${asset_name}" "${asset_name}" 0644
+}
+
+required_runtime_assets=(
+  ctx-onnxruntime-linux-x64.tar.gz
+  ctx-onnxruntime-linux-aarch64.tar.gz
+  ctx-onnxruntime-macos-arm64.tar.gz
+  ctx-onnxruntime-macos-x64.tar.gz
+  ctx-onnxruntime-windows-x64.zip
+  ctx-onnxruntime-freebsd-x64.tar.gz
+)
+for required_runtime_asset in "${required_runtime_assets[@]}"; do
+  if [[ ! -f "${artifact_dir%/}/${required_runtime_asset}" ]]; then
+    printf 'required ONNX Runtime sidecar missing: %s\n' \
+      "${artifact_dir%/}/${required_runtime_asset}" >&2
+    exit 1
+  fi
+done
+
+validate_authoritative_runtime_proof() {
+  local platform="$1"
+  local binary_name="$2"
+  local proof_name="$3"
+  local runtime="$4"
+  local host_system="$5"
+  local host_arch="$6"
+  local host_native_arch="$7"
+  local runtime_asset="${8:-}"
+  local native_arch_probe="$9"
+  local binary_sha_path="${artifact_dir%/}/${binary_name}.sha256"
+  local proof_path="${artifact_dir%/}/${proof_name}"
+  local expected_sha runtime_sha_path runtime_path expected_runtime_sha actual_runtime_sha duplicate_key
+
+  [[ -s "${proof_path}" ]] || {
+    printf 'required authoritative runtime proof missing: %s\n' "${proof_path}" >&2
+    exit 1
+  }
+  [[ -s "${binary_sha_path}" ]] || {
+    printf 'required binary checksum missing for runtime proof: %s\n' "${binary_sha_path}" >&2
+    exit 1
+  }
+  duplicate_key="$(sed -n 's/^\([^=][^=]*\)=.*/\1/p' "${proof_path}" | sort | uniq -d | head -n 1)"
+  [[ -z "${duplicate_key}" ]] || {
+    printf 'runtime proof contains duplicate field %s: %s\n' "${duplicate_key}" "${proof_path}" >&2
+    exit 1
+  }
+  expected_sha="$(tr -d '[:space:]' < "${binary_sha_path}")"
+  [[ "${expected_sha}" =~ ^[0-9a-fA-F]{64}$ ]] || {
+    printf 'invalid binary checksum for runtime proof: %s\n' "${binary_sha_path}" >&2
+    exit 1
+  }
+
+  grep -Fxq "runtime=${runtime}" "${proof_path}" || {
+    printf 'runtime proof has wrong runtime: %s\n' "${proof_path}" >&2
+    exit 1
+  }
+  grep -Fxq "platform=${platform}" "${proof_path}" || {
+    printf 'runtime proof has wrong platform: %s\n' "${proof_path}" >&2
+    exit 1
+  }
+  grep -Fxq "host_system=${host_system}" "${proof_path}" || {
+    printf 'runtime proof has wrong host system: %s\n' "${proof_path}" >&2
+    exit 1
+  }
+  grep -Fxq "host_arch=${host_arch}" "${proof_path}" || {
+    printf 'runtime proof has wrong host architecture: %s\n' "${proof_path}" >&2
+    exit 1
+  }
+  grep -Fxq "host_native_arch=${host_native_arch}" "${proof_path}" || {
+    printf 'runtime proof has wrong native host architecture: %s\n' "${proof_path}" >&2
+    exit 1
+  }
+  grep -Fxq 'process_translated=0' "${proof_path}" || {
+    printf 'runtime proof was produced by a translated process: %s\n' "${proof_path}" >&2
+    exit 1
+  }
+  grep -Fxq "native_arch_probe=${native_arch_probe}" "${proof_path}" || {
+    printf 'runtime proof used the wrong native architecture probe: %s\n' "${proof_path}" >&2
+    exit 1
+  }
+  grep -Fxq 'runtime_authority=authoritative' "${proof_path}" || {
+    printf 'runtime proof is not authoritative: %s\n' "${proof_path}" >&2
+    exit 1
+  }
+  grep -Fxq "artifact_sha256=${expected_sha}" "${proof_path}" || {
+    printf 'runtime proof does not match the exact release binary: %s\n' "${proof_path}" >&2
+    exit 1
+  }
+  if [[ -n "${runtime_asset}" ]]; then
+    runtime_sha_path="${artifact_dir%/}/${runtime_asset}.sha256"
+    runtime_path="${artifact_dir%/}/${runtime_asset}"
+    [[ -s "${runtime_sha_path}" ]] || {
+      printf 'required runtime checksum missing for runtime proof: %s\n' "${runtime_sha_path}" >&2
+      exit 1
+    }
+    expected_runtime_sha="$(tr -d '[:space:]' < "${runtime_sha_path}")"
+    [[ "${expected_runtime_sha}" =~ ^[0-9a-fA-F]{64}$ ]] || {
+      printf 'invalid runtime checksum for runtime proof: %s\n' "${runtime_sha_path}" >&2
+      exit 1
+    }
+    actual_runtime_sha="$(sha256_file "${runtime_path}")"
+    if [[ "$(printf '%s' "${actual_runtime_sha}" | tr 'A-F' 'a-f')" != \
+      "$(printf '%s' "${expected_runtime_sha}" | tr 'A-F' 'a-f')" ]]; then
+      printf 'runtime archive checksum mismatch for proof: %s\n' "${runtime_path}" >&2
+      exit 1
+    fi
+    grep -Fxiq "runtime_archive_sha256=${actual_runtime_sha}" "${proof_path}" || {
+      printf 'runtime proof does not match the exact runtime sidecar: %s\n' "${proof_path}" >&2
+      exit 1
+    }
+  fi
+  grep -Fxq 'semantic_search=passed' "${proof_path}" || {
+    printf 'runtime proof does not record semantic search success: %s\n' "${proof_path}" >&2
+    exit 1
+  }
+}
+
+validate_authoritative_runtime_proof \
+  linux-x64 ctx ctx-linux-x64.native-runtime-proof.txt \
+  onnxruntime Linux x86_64 x86_64 ctx-onnxruntime-linux-x64.tar.gz uname
+validate_authoritative_runtime_proof \
+  linux-aarch64 ctx-linux-aarch64 ctx-linux-aarch64.native-runtime-proof.txt \
+  onnxruntime Linux aarch64 aarch64 ctx-onnxruntime-linux-aarch64.tar.gz uname
+validate_authoritative_runtime_proof \
+  macos-arm64 ctx-macos-arm64 ctx-macos-arm64.native-runtime-proof.txt \
+  onnxruntime Darwin arm64 arm64 ctx-onnxruntime-macos-arm64.tar.gz sysctl
+validate_authoritative_runtime_proof \
+  macos-x64 ctx-macos-x64 ctx-macos-x64.native-runtime-proof.txt \
+  onnxruntime Darwin x86_64 x86_64 ctx-onnxruntime-macos-x64.tar.gz sysctl
+validate_authoritative_runtime_proof \
+  windows-x64 ctx.exe ctx-windows-x64.native-runtime-proof.txt \
+  onnxruntime Windows_NT AMD64 AMD64 ctx-onnxruntime-windows-x64.zip iswow64process2
+validate_authoritative_runtime_proof \
+  freebsd-x64 ctx-freebsd-x64 ctx-freebsd-x64.native-runtime-proof.txt \
+  onnxruntime FreeBSD amd64 amd64 ctx-onnxruntime-freebsd-x64.tar.gz uname
 
 mkdir -p "${out_dir}"
 rm -f \
@@ -63,6 +366,12 @@ rm -f \
   "${out_dir%/}/ctx-macos-x64" \
   "${out_dir%/}/ctx-windows-x64.exe" \
   "${out_dir%/}/ctx-freebsd-x64" \
+  "${out_dir%/}/ctx-onnxruntime-linux-x64.tar.gz" \
+  "${out_dir%/}/ctx-onnxruntime-linux-aarch64.tar.gz" \
+  "${out_dir%/}/ctx-onnxruntime-macos-arm64.tar.gz" \
+  "${out_dir%/}/ctx-onnxruntime-macos-x64.tar.gz" \
+  "${out_dir%/}/ctx-onnxruntime-windows-x64.zip" \
+  "${out_dir%/}/ctx-onnxruntime-freebsd-x64.tar.gz" \
   "${out_dir%/}/SHA256SUMS"
 
 stage_asset ctx ctx-linux-x64
@@ -71,5 +380,11 @@ stage_asset ctx-macos-arm64 ctx-macos-arm64
 stage_asset ctx-macos-x64 ctx-macos-x64
 stage_asset ctx.exe ctx-windows-x64.exe
 stage_asset ctx-freebsd-x64 ctx-freebsd-x64
+stage_runtime_asset linux-x64
+stage_runtime_asset linux-aarch64
+stage_runtime_asset macos-arm64
+stage_runtime_asset macos-x64
+stage_runtime_asset windows-x64
+stage_runtime_asset freebsd-x64
 
 printf 'staged GitHub release assets in %s\n' "${out_dir}"

--- a/scripts/test-linux-release-construction.sh
+++ b/scripts/test-linux-release-construction.sh
@@ -114,13 +114,148 @@ if python3 scripts/write-public-cli-build-info.py \
   exit 1
 fi
 
-test "$(scripts/public-cli-runtime-authority.sh macos-x64 Darwin arm64 passed)" = non_authoritative
-test "$(scripts/public-cli-runtime-authority.sh macos-x64 Darwin x86_64 passed)" = authoritative
+test "$(scripts/public-cli-runtime-authority.sh macos-x64 Darwin arm64 passed arm64 0)" = non_authoritative
+test "$(scripts/public-cli-runtime-authority.sh macos-x64 Darwin x86_64 passed x86_64 0)" = authoritative
+test "$(scripts/public-cli-runtime-authority.sh macos-x64 Darwin x86_64 passed arm64 1)" = non_authoritative
+test "$(scripts/public-cli-runtime-authority.sh macos-x64 Darwin x86_64 passed unknown unknown)" = non_authoritative
+test "$(scripts/public-cli-runtime-authority.sh linux-x64 Linux x86_64 passed x86_64 0)" = authoritative
+test "$(scripts/public-cli-runtime-authority.sh linux-x64 Darwin arm64 passed arm64 0)" = non_authoritative
 test "$(scripts/public-cli-runtime-authority.sh windows-x64 Windows_NT AMD64 not_run)" = not_run
 if scripts/public-cli-runtime-authority.sh macos-x64 Darwin arm64 invalid >/dev/null 2>&1; then
   echo "invalid runtime status unexpectedly produced authority" >&2
   exit 1
 fi
+
+cat > "${tmp_dir}/native-sysctl" <<'EOF'
+#!/usr/bin/env bash
+case "${2:-}" in
+  sysctl.proc_translated) exit 1 ;;
+  hw.optional.arm64) printf '0\n' ;;
+  *) exit 2 ;;
+esac
+EOF
+cat > "${tmp_dir}/rosetta-sysctl" <<'EOF'
+#!/usr/bin/env bash
+case "${2:-}" in
+  sysctl.proc_translated|hw.optional.arm64) printf '1\n' ;;
+  *) exit 2 ;;
+esac
+EOF
+cat > "${tmp_dir}/inconsistent-sysctl" <<'EOF'
+#!/usr/bin/env bash
+case "${2:-}" in
+  sysctl.proc_translated) printf '0\n' ;;
+  hw.optional.arm64) printf '1\n' ;;
+  *) exit 2 ;;
+esac
+EOF
+chmod +x \
+  "${tmp_dir}/native-sysctl" \
+  "${tmp_dir}/rosetta-sysctl" \
+  "${tmp_dir}/inconsistent-sysctl"
+test "$(scripts/public-cli-host-runtime-evidence.sh \
+  --host-system Darwin --host-arch x86_64 --sysctl "${tmp_dir}/native-sysctl")" = \
+  $'Darwin\tx86_64\tx86_64\t0\tsysctl'
+test "$(scripts/public-cli-host-runtime-evidence.sh \
+  --host-system Darwin --host-arch x86_64 --sysctl "${tmp_dir}/rosetta-sysctl")" = \
+  $'Darwin\tx86_64\tarm64\t1\tsysctl'
+test "$(scripts/public-cli-host-runtime-evidence.sh \
+  --host-system Darwin --host-arch x86_64 --sysctl "${tmp_dir}/missing-sysctl")" = \
+  $'Darwin\tx86_64\tunknown\tunknown\tsysctl'
+test "$(scripts/public-cli-host-runtime-evidence.sh \
+  --host-system Darwin --host-arch x86_64 --sysctl "${tmp_dir}/inconsistent-sysctl")" = \
+  $'Darwin\tx86_64\tunknown\tunknown\tsysctl'
+
+partial_runtime_matrix="${tmp_dir}/partial-runtime-matrix"
+mkdir -p "${partial_runtime_matrix}"
+touch \
+  "${partial_runtime_matrix}/ctx-onnxruntime-linux-x64.tar.gz" \
+  "${partial_runtime_matrix}/ctx-onnxruntime-linux-aarch64.tar.gz" \
+  "${partial_runtime_matrix}/ctx-onnxruntime-macos-arm64.tar.gz" \
+  "${partial_runtime_matrix}/ctx-onnxruntime-windows-x64.zip"
+if scripts/stage-github-release-assets.sh \
+  "${partial_runtime_matrix}" "${tmp_dir}/partial-release" \
+  >"${tmp_dir}/partial-runtime.out" 2>"${tmp_dir}/partial-runtime.err"; then
+  echo "release staging accepted an incomplete runtime matrix" >&2
+  exit 1
+fi
+grep -Fq \
+  'required ONNX Runtime sidecar missing:' \
+  "${tmp_dir}/partial-runtime.err"
+grep -Fq \
+  'ctx-onnxruntime-macos-x64.tar.gz' \
+  "${tmp_dir}/partial-runtime.err"
+
+complete_runtime_matrix="${tmp_dir}/complete-runtime-matrix"
+mkdir -p "${complete_runtime_matrix}"
+touch \
+  "${complete_runtime_matrix}/ctx-onnxruntime-linux-x64.tar.gz" \
+  "${complete_runtime_matrix}/ctx-onnxruntime-linux-aarch64.tar.gz" \
+  "${complete_runtime_matrix}/ctx-onnxruntime-macos-arm64.tar.gz" \
+  "${complete_runtime_matrix}/ctx-onnxruntime-macos-x64.tar.gz" \
+  "${complete_runtime_matrix}/ctx-onnxruntime-windows-x64.zip" \
+  "${complete_runtime_matrix}/ctx-onnxruntime-freebsd-x64.tar.gz"
+if scripts/stage-github-release-assets.sh \
+  "${complete_runtime_matrix}" "${tmp_dir}/unproven-release" \
+  >"${tmp_dir}/unproven-runtime.out" 2>"${tmp_dir}/unproven-runtime.err"; then
+  echo "release staging accepted runtimes without native exact-binary proof" >&2
+  exit 1
+fi
+grep -Fq \
+  'required authoritative runtime proof missing:' \
+  "${tmp_dir}/unproven-runtime.err"
+grep -Fq \
+  'ctx-linux-x64.native-runtime-proof.txt' \
+  "${tmp_dir}/unproven-runtime.err"
+
+mismatched_runtime_matrix="${tmp_dir}/mismatched-runtime-matrix"
+cp -R "${complete_runtime_matrix}" "${mismatched_runtime_matrix}"
+for binary in ctx; do
+  printf 'synthetic %s\n' "${binary}" > "${mismatched_runtime_matrix}/${binary}"
+  sha256sum "${mismatched_runtime_matrix}/${binary}" | awk '{ print $1 }' \
+    > "${mismatched_runtime_matrix}/${binary}.sha256"
+done
+linux_binary_sha="$(cat "${mismatched_runtime_matrix}/ctx.sha256")"
+linux_runtime_sha="$(sha256sum \
+  "${mismatched_runtime_matrix}/ctx-onnxruntime-linux-x64.tar.gz" | awk '{ print $1 }')"
+printf '%s\n' "${linux_runtime_sha}" > \
+  "${mismatched_runtime_matrix}/ctx-onnxruntime-linux-x64.tar.gz.sha256"
+cat > "${mismatched_runtime_matrix}/ctx-linux-x64.native-runtime-proof.txt" <<EOF
+runtime=onnxruntime
+platform=linux-x64
+host_system=Linux
+host_arch=x86_64
+host_native_arch=x86_64
+process_translated=0
+native_arch_probe=uname
+runtime_authority=authoritative
+artifact_sha256=${linux_binary_sha}
+runtime_archive_sha256=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+semantic_search=passed
+EOF
+if scripts/stage-github-release-assets.sh \
+  "${mismatched_runtime_matrix}" "${tmp_dir}/mismatched-release" \
+  >"${tmp_dir}/mismatched-runtime.out" 2>"${tmp_dir}/mismatched-runtime.err"; then
+  echo "release staging accepted proof for a different runtime sidecar" >&2
+  exit 1
+fi
+grep -Fq \
+  'runtime proof does not match the exact runtime sidecar:' \
+  "${tmp_dir}/mismatched-runtime.err"
+
+duplicate_proof_matrix="${tmp_dir}/duplicate-proof-matrix"
+cp -R "${mismatched_runtime_matrix}" "${duplicate_proof_matrix}"
+printf 'platform=linux-x64\n' >> \
+  "${duplicate_proof_matrix}/ctx-linux-x64.native-runtime-proof.txt"
+if scripts/stage-github-release-assets.sh \
+  "${duplicate_proof_matrix}" "${tmp_dir}/duplicate-proof-release" \
+  >"${tmp_dir}/duplicate-proof.out" 2>"${tmp_dir}/duplicate-proof.err"; then
+  echo "release staging accepted a proof with duplicate fields" >&2
+  exit 1
+fi
+grep -Fq \
+  'runtime proof contains duplicate field platform:' \
+  "${tmp_dir}/duplicate-proof.err"
 
 multiline_cross_output='cross 0.2.5
 rustup 1.28.2
@@ -167,6 +302,9 @@ grep -F 'LINUX_X64_QEMU_CPU_PROFILE="qemu64"' scripts/build-public-cli-artifact.
 grep -F 'CTX_TEST_ONLY_ALLOW_EMULATED_LINUX_BUILD' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F 'flock -n' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F 'local_runtime_authority' scripts/write-public-cli-build-info.py >/dev/null
+grep -F 'required ONNX Runtime sidecar missing' scripts/stage-github-release-assets.sh >/dev/null
+grep -F 'ctx-onnxruntime-freebsd-x64.tar.gz' scripts/check-github-release-assets.sh >/dev/null
+grep -F 'ctx-onnxruntime-macos-x64.tar.gz' scripts/check-github-release-assets.sh >/dev/null
 grep -F -- '--expected-builder-base "${LINUX_RELEASE_UBUNTU_DIGEST}"' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F -- '--actual-builder-base "${actual_base_digest}"' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F -- '--runtime-image-id "${runtime_image_id}"' scripts/build-public-cli-artifact.sh >/dev/null

--- a/scripts/tests/check-release-binary-compat-test.sh
+++ b/scripts/tests/check-release-binary-compat-test.sh
@@ -107,13 +107,37 @@ Load command 0
     minos 13.0
 Load command 1
       cmd LC_LOAD_DYLIB
-     name /usr/lib/libSystem.B.dylib (offset 24)
+     name /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (offset 24)
 Load command 2
       cmd LC_LOAD_DYLIB
-     name /usr/lib/libiconv.2.dylib (offset 24)
+     name /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics (offset 24)
 Load command 3
       cmd LC_LOAD_DYLIB
-     name /usr/lib/libcharset.1.dylib (offset 24)
+     name /System/Library/Frameworks/CoreML.framework/Versions/A/CoreML (offset 24)
+Load command 4
+      cmd LC_LOAD_DYLIB
+     name /System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo (offset 24)
+Load command 5
+      cmd LC_LOAD_DYLIB
+     name /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (offset 24)
+Load command 6
+      cmd LC_LOAD_DYLIB
+     name /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO (offset 24)
+Load command 7
+      cmd LC_LOAD_DYLIB
+     name /System/Library/Frameworks/Metal.framework/Versions/A/Metal (offset 24)
+Load command 8
+      cmd LC_LOAD_DYLIB
+     name /usr/lib/libSystem.B.dylib (offset 24)
+Load command 9
+      cmd LC_LOAD_DYLIB
+     name /usr/lib/libc++.1.dylib (offset 24)
+Load command 10
+      cmd LC_LOAD_DYLIB
+     name /usr/lib/libiconv.2.dylib (offset 24)
+Load command 11
+      cmd LC_LOAD_DYLIB
+     name /usr/lib/libobjc.A.dylib (offset 24)
 EOF
 
 windows="${tmp}/windows.txt"
@@ -213,7 +237,7 @@ mutate_and_fail linux_avx linux-x64 "${linux_x64}" 's/GNU_PROPERTY_X86_ISA_1_NEE
 mutate_and_fail arm_glibcxx linux-aarch64 "${linux_arm64}" 's/Name: GLIBC_2.35/Name: GLIBC_2.35\nName: GLIBCXX_3.4.30/'
 
 bad_mac_dylib="${tmp}/bad-mac-dylib.txt"
-sed 's#/usr/lib/libcharset.1.dylib#/opt/local/libcharset.dylib#' "${mac_objdump}" > "${bad_mac_dylib}"
+sed 's#/System/Library/Frameworks/CoreML.framework/Versions/A/CoreML#/opt/local/libCoreML.dylib#' "${mac_objdump}" > "${bad_mac_dylib}"
 expect_fail mac_dylib run_check macos-arm64 "${mac_arm_readobj}" "${bad_mac_dylib}"
 bad_mac_version="${tmp}/bad-mac-version.txt"
 sed 's/minos 13.0/minos 14.0/' "${mac_objdump}" > "${bad_mac_version}"

--- a/scripts/tests/smoke-daemon-semantic-release-test.sh
+++ b/scripts/tests/smoke-daemon-semantic-release-test.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+smoke="${repo_root}/scripts/smoke-daemon-semantic-release.sh"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/ctx-semantic-release-smoke-test.XXXXXX")"
+trap 'rm -rf "${tmp}"' EXIT
+
+fake_ctx="${tmp}/ctx-macos-artifact"
+cat > "${fake_ctx}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'ctx 0.25.0\n'
+  exit 0
+fi
+
+data_root=""
+command=""
+while (($# > 0)); do
+  case "$1" in
+    --data-root)
+      data_root="${2:-}"
+      shift 2
+      ;;
+    import|daemon|search)
+      command="$1"
+      shift
+      break
+      ;;
+    *)
+      printf 'unexpected fake ctx prefix argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+[[ -n "${data_root}" && -n "${command}" ]]
+[[ "${CTX_INTERNAL_SEMANTIC_BACKEND:-}" == "coreml" ]]
+[[ "${CTX_SEMANTIC_COREML_NATIVE_COMPUTE:-}" == "all" ]]
+[[ "${CTX_DAEMON_ENABLED:-}" == "1" ]]
+[[ "${CTX_SEARCH_SEMANTIC:-}" == "1" ]]
+[[ "${CTX_SEMANTIC_CACHE_DIR:-}" == "${data_root}/semantic-cache" ]]
+
+case "${command}" in
+  import)
+    fixture=""
+    while (($# > 0)); do
+      if [[ "$1" == "--path" ]]; then
+        fixture="${2:-}"
+        break
+      fi
+      shift
+    done
+    [[ -f "${fixture}" ]]
+    grep -Eo 'ctx-release-semantic-smoke-[0-9a-f]+' "${fixture}" | head -1 \
+      > "${data_root}/fake-marker"
+    ;;
+  daemon)
+    subcommand="${1:-}"
+    shift || true
+    case "${subcommand}" in
+      run)
+        printf '%s\n' "$$" > "${data_root}/fake-daemon-pid"
+        trap 'exit 0' TERM INT
+        while :; do sleep 1; done
+        ;;
+      status)
+        pid="$(cat "${data_root}/fake-daemon-pid")"
+        printf '{"daemon":{"pid":%s,"status":"running","running":true,"jobs":{"semantic_index":{"embedding_runtime":{"backend":"coreml","compute_mode":"all","model_id":"intfloat/multilingual-e5-small","acquisition_source":"download"}}}}}\n' "${pid}"
+        ;;
+      *)
+        printf 'unexpected fake daemon command: %s\n' "${subcommand}" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  search)
+    marker="$(cat "${data_root}/fake-marker")"
+    printf '{"retrieval":{"requested_mode":"semantic","effective_mode":"semantic","semantic_status":"ready","embedding_model":"intfloat/multilingual-e5-small","worker":{"embedding_runtime":{"backend":"coreml","compute_mode":"all","model_id":"intfloat/multilingual-e5-small","acquisition_source":"download"}}},"results":[{"text":"%s"}]}\n' "${marker}"
+    ;;
+esac
+EOF
+chmod 755 "${fake_ctx}"
+fake_ctx="$(cd -- "$(dirname -- "${fake_ctx}")" && pwd -P)/$(basename -- "${fake_ctx}")"
+
+expect_usage_failure() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  if "${smoke}" "$@" > "${tmp}/${name}.out" 2> "${tmp}/${name}.err"; then
+    printf 'expected argument failure: %s\n' "${name}" >&2
+    exit 1
+  fi
+  grep -Fq -- "${expected}" "${tmp}/${name}.err" || {
+    printf 'unexpected argument failure for %s\n' "${name}" >&2
+    cat "${tmp}/${name}.err" >&2
+    exit 1
+  }
+}
+
+"${smoke}" --help > "${tmp}/help.out" 2>&1
+grep -Fq -- '--coreml --runtime-platform macos-arm64|macos-x64' "${tmp}/help.out"
+
+expect_usage_failure coreml_linux \
+  '--coreml requires --runtime-platform macos-arm64 or macos-x64' \
+  --coreml --runtime-platform linux-x64 --ctx "${fake_ctx}"
+expect_usage_failure coreml_archive \
+  '--coreml cannot be combined with --runtime-archive' \
+  --coreml --runtime-platform macos-arm64 --runtime-archive "${tmp}/unused" \
+  --ctx "${fake_ctx}"
+expect_usage_failure archive_required \
+  '--runtime-archive is required unless --coreml is selected' \
+  --runtime-platform macos-arm64 --ctx "${fake_ctx}"
+
+cpu_ctx="${tmp}/ctx-macos-cpu-fallback"
+sed 's/"backend":"coreml"/"backend":"cpu"/g' "${fake_ctx}" > "${cpu_ctx}"
+chmod 755 "${cpu_ctx}"
+started="$(date +%s)"
+if "${smoke}" \
+  --coreml --runtime-platform macos-arm64 --ctx "${cpu_ctx}" \
+  --data-root "${tmp}/cpu-fallback-runs" --timeout-seconds 30 \
+  > "${tmp}/cpu-fallback.out" 2> "${tmp}/cpu-fallback.err"; then
+  printf 'CoreML smoke accepted a CPU runtime\n' >&2
+  exit 1
+fi
+elapsed="$(( $(date +%s) - started ))"
+[[ "${elapsed}" -lt 10 ]] || {
+  printf 'CoreML backend mismatch did not fail fast: %ss\n' "${elapsed}" >&2
+  exit 1
+}
+grep -Fq 'CoreML daemon status reported backend' "${tmp}/cpu-fallback.err"
+
+cpu_mode_ctx="${tmp}/ctx-macos-cpu-mode"
+sed 's/"compute_mode":"all"/"compute_mode":"cpu_only"/g' "${fake_ctx}" > "${cpu_mode_ctx}"
+chmod 755 "${cpu_mode_ctx}"
+if "${smoke}" \
+  --coreml --runtime-platform macos-arm64 --ctx "${cpu_mode_ctx}" \
+  --data-root "${tmp}/cpu-mode-runs" --timeout-seconds 30 \
+  > "${tmp}/cpu-mode.out" 2> "${tmp}/cpu-mode.err"; then
+  printf 'CoreML smoke accepted CPU-only compute mode\n' >&2
+  exit 1
+fi
+grep -Fq "CoreML daemon status reported compute mode 'cpu_only'" "${tmp}/cpu-mode.err"
+
+cached_ctx="${tmp}/ctx-macos-cached-model"
+sed 's/"acquisition_source":"download"/"acquisition_source":"cache"/g' \
+  "${fake_ctx}" > "${cached_ctx}"
+chmod 755 "${cached_ctx}"
+if "${smoke}" \
+  --coreml --runtime-platform macos-arm64 --ctx "${cached_ctx}" \
+  --data-root "${tmp}/cached-runs" --timeout-seconds 30 \
+  > "${tmp}/cached.out" 2> "${tmp}/cached.err"; then
+  printf 'CoreML smoke accepted a cached acquisition\n' >&2
+  exit 1
+fi
+grep -Fq "CoreML daemon status reported acquisition source 'cache'" "${tmp}/cached.err"
+
+run_parent="${tmp}/runs"
+published_proof="${tmp}/published/coreml-proof.txt"
+"${smoke}" \
+  --coreml \
+  --runtime-platform macos-arm64 \
+  --ctx "${fake_ctx}" \
+  --data-root "${run_parent}" \
+  --proof-output "${published_proof}" \
+  --timeout-seconds 30 \
+  --keep-root \
+  > "${tmp}/coreml.out" 2> "${tmp}/coreml.err"
+
+run_root="$(find "${run_parent}" -mindepth 1 -maxdepth 1 -type d -name 'ctx-semantic-smoke.*' -print -quit)"
+[[ -n "${run_root}" ]]
+proof="${run_root}/data/packaged-runtime-proof.txt"
+[[ -s "${proof}" ]]
+cmp -s "${proof}" "${published_proof}"
+grep -Fxq 'runtime=coreml' "${proof}"
+grep -Fxq 'platform=macos-arm64' "${proof}"
+grep -Fxq "host_system=$(uname -s)" "${proof}"
+grep -Fxq "host_arch=$(uname -m)" "${proof}"
+grep -Fxq "host_native_arch=$(uname -m)" "${proof}"
+grep -Fxq 'process_translated=0' "${proof}"
+grep -Fxq 'native_arch_probe=uname' "${proof}"
+grep -Fxq 'runtime_authority=non_authoritative' "${proof}"
+grep -Fxq 'compute_mode=all' "${proof}"
+grep -Fxq 'model=intfloat/multilingual-e5-small' "${proof}"
+grep -Fxq 'acquisition_source=download' "${proof}"
+grep -Fxq 'acquisition_fallback=none' "${proof}"
+grep -Fxq 'semantic_search=passed' "${proof}"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  expected_sha="$(sha256sum "${fake_ctx}" | awk '{ print $1 }')"
+else
+  expected_sha="$(shasum -a 256 "${fake_ctx}" | awk '{ print $1 }')"
+fi
+grep -Fxq "artifact=${fake_ctx}" "${proof}"
+grep -Fxq "artifact_sha256=${expected_sha}" "${proof}"
+isolated_artifact="$(sed -n 's/^isolated_artifact=//p' "${proof}")"
+cmp -s "${fake_ctx}" "${isolated_artifact}"
+[[ ! -e "${run_root}/data/runtime/onnxruntime" ]]
+
+daemon_pid="$(cat "${run_root}/data/fake-daemon-pid")"
+if kill -0 "${daemon_pid}" >/dev/null 2>&1; then
+  printf 'CoreML smoke left daemon process %s running\n' "${daemon_pid}" >&2
+  exit 1
+fi
+
+printf 'daemon semantic release smoke contract tests passed\n'


### PR DESCRIPTION
## Summary

- add the opt-in background daemon query service and deterministic lite-turn semantic index
- use `intfloat/multilingual-e5-small` with quiet adaptive resource policy, Core ML acceleration on supported Macs, and ONNX Runtime sidecars across the public platform matrix
- acquire and verify model/runtime assets in daemon-owned paths; keep foreground search cache-only
- preserve prerelease defaults: daemon and semantic search remain off unless explicitly enabled
- require exact-binary, exact-runtime native smoke proof before release staging
- remove the real-corpus validation summary from the public tree; sanitized provenance is retained privately

Supersedes #113.

## Verification

- `cargo test --workspace --locked` with `CARGO_BUILD_JOBS=2 RUST_TEST_THREADS=2`
- `cargo check --workspace --locked`
- `cargo fmt --check`
- Buildkite pipeline, Linux release-construction, daemon semantic smoke-contract, docs, provider-matrix, and plugin-sync checks
- focused custom-data-root runtime discovery and OR-search regression suites

Platform-native release smokes remain gated release jobs; staging fails closed unless all six canonical proofs are present.