### PR TITLE
Bind ONNX release proof to the CPU backend

### DIFF
--- a/scripts/smoke-daemon-semantic-release.ps1
+++ b/scripts/smoke-daemon-semantic-release.ps1
@@ -219,6 +219,7 @@ $environmentVariableNames = @(
     "CTX_DAEMON_AUTOSTART_OFF", "CTX_DAEMON_AUTOSTART_EXE", "CTX_DAEMON_BACKGROUND_CHILD",
     "CTX_DAEMON_AUTOSTART_IDLE_EXIT_SECONDS", "CTX_DAEMON_AUTOSTART_LOOP_INTERVAL_SECONDS",
     "CTX_SEARCH_SEMANTIC", "CTX_DISABLE_SEMANTIC_SEARCH", "CTX_SEMANTIC_WORKER_OFF",
+    "CTX_INTERNAL_SEMANTIC_BACKEND",
     "CTX_SEMANTIC_WORKER_MAX_CHUNKS", "CTX_SEMANTIC_WORKER_MAX_SECONDS",
     "CTX_SEMANTIC_THREADS", "CTX_SEMANTIC_EMBED_BATCH",
     "CTX_ANALYTICS_ENABLED", "CTX_ANALYTICS_OFF", "CTX_DISABLE_ANALYTICS",
@@ -434,6 +435,7 @@ try {
     Set-ProcessEnvironmentVariable -Name "CTX_UPGRADE_AUTO" -Value "off"
     Set-ProcessEnvironmentVariable -Name "CTX_DAEMON_ENABLED" -Value "1"
     Set-ProcessEnvironmentVariable -Name "CTX_SEARCH_SEMANTIC" -Value "1"
+    Set-ProcessEnvironmentVariable -Name "CTX_INTERNAL_SEMANTIC_BACKEND" -Value "cpu"
     Set-ProcessEnvironmentVariable -Name "CTX_RUNTIME_DIR" -Value $runtimeRoot
     Set-ProcessEnvironmentVariable -Name "PATH" -Value $savedEnvironment["PATH"]
 
@@ -455,6 +457,7 @@ try {
     $runtimeProofLines = @(
         "runtime=onnxruntime",
         "version=$runtimeVersion",
+        "embedding_backend=cpu",
         "platform=$RuntimePlatform",
         "host_system=Windows_NT",
         "host_arch=$hostArch",
@@ -608,9 +611,9 @@ try {
                                 "marker=$marker",
                                 "semantic_search=passed"
                             )
-                            [System.IO.File]::WriteAllLines(
+                            [System.IO.File]::WriteAllText(
                                 $runtimeProof,
-                                $runtimeProofLines,
+                                (($runtimeProofLines -join "`n") + "`n"),
                                 [System.Text.UTF8Encoding]::new($false)
                             )
                             if (-not [string]::IsNullOrWhiteSpace($ProofOutput)) {

--- a/scripts/smoke-daemon-semantic-release.sh
+++ b/scripts/smoke-daemon-semantic-release.sh
@@ -460,6 +460,8 @@ if [[ "${coreml_mode}" == "1" ]]; then
     CTX_INTERNAL_SEMANTIC_BACKEND=coreml
     CTX_SEMANTIC_COREML_NATIVE_COMPUTE=all
   )
+else
+  ctx_env+=(CTX_INTERNAL_SEMANTIC_BACKEND=cpu)
 fi
 
 run_ctx() {
@@ -527,14 +529,20 @@ if pid is not None and (isinstance(pid, bool) or not isinstance(pid, int) or pid
     raise SystemExit(2)
 if daemon.get("status") != "running" or daemon.get("running") is not True or pid != expected_pid:
     raise SystemExit(1)
-if coreml_mode != "1":
-    raise SystemExit(0)
-
 jobs = daemon.get("jobs")
 semantic = jobs.get("semantic_index") if isinstance(jobs, dict) else None
 runtime = semantic.get("embedding_runtime") if isinstance(semantic, dict) else None
 if not isinstance(runtime, dict):
     raise SystemExit(1)
+if coreml_mode != "1":
+    if runtime.get("backend") != "cpu" or runtime.get("preference") != "cpu":
+        print(f"ONNX smoke reported runtime {runtime!r}", file=sys.stderr)
+        raise SystemExit(2)
+    if runtime.get("model_id") != expected_model:
+        print(f"ONNX smoke reported model {runtime.get('model_id')!r}", file=sys.stderr)
+        raise SystemExit(2)
+    raise SystemExit(0)
+
 if runtime.get("backend") != "coreml":
     print(f"CoreML daemon status reported backend {runtime.get('backend')!r}", file=sys.stderr)
     raise SystemExit(2)
@@ -689,6 +697,7 @@ EOF
           cat > "${runtime_proof}" <<EOF
 runtime=onnxruntime
 version=${runtime_version}
+embedding_backend=cpu
 platform=${runtime_platform}
 host_system=${host_system}
 host_arch=${host_arch}

--- a/scripts/stage-github-release-assets.sh
+++ b/scripts/stage-github-release-assets.sh
@@ -278,6 +278,12 @@ validate_authoritative_runtime_proof() {
     printf 'runtime proof has wrong runtime: %s\n' "${proof_path}" >&2
     exit 1
   }
+  if [[ "${runtime}" == "onnxruntime" ]]; then
+    grep -Fxq 'embedding_backend=cpu' "${proof_path}" || {
+      printf 'runtime proof did not exercise the ONNX CPU backend: %s\n' "${proof_path}" >&2
+      exit 1
+    }
+  fi
   grep -Fxq "platform=${platform}" "${proof_path}" || {
     printf 'runtime proof has wrong platform: %s\n' "${proof_path}" >&2
     exit 1

--- a/scripts/test-linux-release-construction.sh
+++ b/scripts/test-linux-release-construction.sh
@@ -222,6 +222,7 @@ printf '%s\n' "${linux_runtime_sha}" > \
   "${mismatched_runtime_matrix}/ctx-onnxruntime-linux-x64.tar.gz.sha256"
 cat > "${mismatched_runtime_matrix}/ctx-linux-x64.native-runtime-proof.txt" <<EOF
 runtime=onnxruntime
+embedding_backend=cpu
 platform=linux-x64
 host_system=Linux
 host_arch=x86_64
@@ -323,5 +324,7 @@ grep -F '"${runtime_image_id}"' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F '"${inspector_image_id}"' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F 'timeout --signal=KILL 120s' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F 'x86_64-unknown-freebsd:0.2.5@sha256:' Cross.toml >/dev/null
+grep -F '[System.IO.File]::WriteAllText(' scripts/smoke-daemon-semantic-release.ps1 >/dev/null
+grep -F '($runtimeProofLines -join "`n") + "`n"' scripts/smoke-daemon-semantic-release.ps1 >/dev/null
 
 printf 'Linux release construction self-test passed\n'

--- a/scripts/tests/smoke-daemon-semantic-release-test.sh
+++ b/scripts/tests/smoke-daemon-semantic-release-test.sh
@@ -205,4 +205,46 @@ if kill -0 "${daemon_pid}" >/dev/null 2>&1; then
   exit 1
 fi
 
+cpu_ctx="${tmp}/ctx-linux-cpu"
+sed \
+  -e 's/== "coreml"/== "cpu"/' \
+  -e '/CTX_SEMANTIC_COREML_NATIVE_COMPUTE/d' \
+  -e 's/"backend":"coreml","compute_mode":"all"/"backend":"cpu","preference":"cpu"/g' \
+  "${fake_ctx}" > "${cpu_ctx}"
+chmod 755 "${cpu_ctx}"
+
+runtime_payload="${tmp}/runtime-payload"
+mkdir -p "${runtime_payload}/lib"
+printf 'license\n' > "${runtime_payload}/LICENSE"
+printf 'notices\n' > "${runtime_payload}/ThirdPartyNotices.txt"
+printf '1.27.0\n' > "${runtime_payload}/VERSION_NUMBER"
+printf 'synthetic-commit\n' > "${runtime_payload}/GIT_COMMIT_ID"
+printf 'synthetic runtime\n' > "${runtime_payload}/lib/libonnxruntime.so"
+runtime_archive="${tmp}/ctx-onnxruntime-linux-x64.tar.gz"
+tar --no-recursion -C "${runtime_payload}" -czf "${runtime_archive}" \
+  LICENSE ThirdPartyNotices.txt VERSION_NUMBER GIT_COMMIT_ID lib lib/libonnxruntime.so
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum "${runtime_archive}" | awk '{ print $1 }' > "${runtime_archive}.sha256"
+else
+  shasum -a 256 "${runtime_archive}" | awk '{ print $1 }' > "${runtime_archive}.sha256"
+fi
+
+onnx_proof="${tmp}/published/onnx-proof.txt"
+if ! "${smoke}" \
+  --runtime-archive "${runtime_archive}" \
+  --runtime-platform linux-x64 \
+  --ctx "${cpu_ctx}" \
+  --data-root "${tmp}/onnx-runs" \
+  --proof-output "${onnx_proof}" \
+  --timeout-seconds 30 \
+  > "${tmp}/onnx.out" 2> "${tmp}/onnx.err"; then
+  cat "${tmp}/onnx.out" >&2
+  cat "${tmp}/onnx.err" >&2
+  exit 1
+fi
+grep -Fxq 'runtime=onnxruntime' "${onnx_proof}"
+grep -Fxq 'embedding_backend=cpu' "${onnx_proof}"
+grep -Fxq 'runtime_authority=authoritative' "${onnx_proof}"
+grep -Fxq 'semantic_search=passed' "${onnx_proof}"
+
 printf 'daemon semantic release smoke contract tests passed\n'


### PR DESCRIPTION
## Summary

- force packaged ONNX release smoke to select the CPU/ONNX backend, including Windows
- verify daemon status reports the expected CPU preference and E5 model before publishing proof
- require `embedding_backend=cpu` during release staging
- emit Windows proof files with LF line endings for cross-platform staging
- add an end-to-end synthetic packaged-runtime smoke contract

Follow-up to #132 after final adversarial review.

## Verification

- `scripts/test-linux-release-construction.sh`
- `scripts/tests/smoke-daemon-semantic-release-test.sh`
- `scripts/check-buildkite-pipeline.sh`
- `scripts/check-docs.sh`
- `cargo check --workspace --locked`
- `cargo fmt --check`