### PR TITLE
Align native semantic platform gates

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -98,8 +98,7 @@ steps:
           target/public-cli-artifacts/ctx-linux-aarch64.native-runtime-proof.txt
       fi
     agents:
-      queue: "release-linux-managed"
-      ctx-runner-class: "release-linux-control"
+      queue: "linux-arm64"
       os: "linux"
       arch: "arm64"
     timeout_in_minutes: 60
@@ -316,44 +315,3 @@ steps:
       - "target/public-cli-artifacts/ctx-windows-x64.native-runtime-proof.txt"
       - "target/public-cli-native-smoke/windows-x64/**/packaged-runtime-proof.txt"
       - "target/public-cli-native-smoke/windows-x64/**/daemon-smoke.log"
-
-  - label: ":test_tube: public CLI freebsd-x64 native semantic"
-    key: "public-cli-freebsd-x64-native-smoke"
-    depends_on: "public-cli-freebsd-x64"
-    if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1" && build.env("CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX") == "1"
-    command: |
-      buildkite-agent artifact download \
-        "target/public-cli-artifacts/ctx-freebsd-x64*" . \
-        --step public-cli-freebsd-x64
-      scripts/build-onnxruntime-sidecar.sh freebsd-x64
-      scripts/stage-github-release-assets.sh --transcode-runtime freebsd-x64
-      smoke_root="target/public-cli-native-smoke/freebsd-x64"
-      mkdir -p "${smoke_root}"
-      if ! scripts/smoke-daemon-semantic-release.sh \
-        --runtime-archive target/public-cli-artifacts/ctx-onnxruntime-freebsd-x64.tar.gz \
-        --runtime-platform freebsd-x64 \
-        --ctx target/public-cli-artifacts/ctx-freebsd-x64 \
-        --data-root "${smoke_root}" \
-        --proof-output target/public-cli-artifacts/ctx-freebsd-x64.native-runtime-proof.txt \
-        --keep-root >"${smoke_root}/smoke.log" 2>&1; then
-        cat "${smoke_root}/smoke.log"
-        exit 1
-      fi
-      cat "${smoke_root}/smoke.log"
-      grep -Fxq 'runtime_authority=authoritative' \
-        target/public-cli-artifacts/ctx-freebsd-x64.native-runtime-proof.txt
-    agents:
-      queue: "freebsd-x64"
-      os: "freebsd"
-      arch: "x86_64"
-    concurrency: 1
-    concurrency_group: "ctx-public-cli-freebsd-native"
-    timeout_in_minutes: 240
-    artifact_paths:
-      - "target/public-cli-artifacts/ctx-onnxruntime-freebsd-x64.tar.gz"
-      - "target/public-cli-artifacts/ctx-onnxruntime-freebsd-x64.tar.gz.sha256"
-      - "target/public-cli-artifacts/ctx-freebsd-x64.native-runtime-proof.txt"
-      - "target/public-cli-native-smoke/freebsd-x64/smoke.log"
-      - "target/public-cli-native-smoke/freebsd-x64/**/daemon-smoke.log"
-      - "target/public-cli-native-smoke/freebsd-x64/**/daemon-status.*"
-      - "target/public-cli-native-smoke/freebsd-x64/**/semantic-search.*"

--- a/docs/local-semantic-search-ship-plan.md
+++ b/docs/local-semantic-search-ship-plan.md
@@ -109,26 +109,6 @@ and private relevance evals justify flipping the default.
 - Daemon model acquisition shields fastembed's `HF_HOME` override while filling
   the ctx-selected cache root, preserving ctx cache precedence during download
   as well as during normal model loading.
-- Release plumbing now has a stable ONNX Runtime sidecar naming convention:
-  `ctx-onnxruntime-linux-x64.tar.gz`,
-  `ctx-onnxruntime-linux-aarch64.tar.gz`,
-  `ctx-onnxruntime-macos-arm64.tar.gz`,
-  `ctx-onnxruntime-macos-x64.tar.gz`,
-  `ctx-onnxruntime-windows-x64.zip`, and
-  `ctx-onnxruntime-freebsd-x64.tar.gz`. Runtime producer jobs may use validated
-  `.tar.zst` intermediates, but release metadata and end-user installers only
-  consume the checksum-verified `.tar.gz` transport and do not require zstd.
-- Release metadata can describe those sidecars with
-  `CTX_RELEASE_ONNXRUNTIME_ARTIFACT_<platform_key>`,
-  `CTX_RELEASE_ONNXRUNTIME_SHA256_<platform_key>`, and
-  `CTX_RELEASE_ONNXRUNTIME_VERSION`. The development installers place runtime
-  assets under the selected runtime root at
-  `onnxruntime/<version>/<platform>`.
-- The public Buildkite pipeline has an opt-in runtime smoke matrix gated by
-  `CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX=1`. Each smoke installs and runs the exact
-  CLI artifact and sidecar in an isolated data root, then publishes an
-  exact-binary, exact-runtime proof. Cross-build and translated smoke evidence
-  cannot satisfy a native release gate.
 
 ## Ship Goals
 
@@ -372,31 +352,6 @@ and private relevance evals justify flipping the default.
     startup or per-command sqlite opening becomes the bottleneck;
   - add a refill loop for post-vector filters so candidate count can drop below
     the conservative 1,000 soft-filter window without under-filling results.
-
-### 8. Equal Platform Runtime And Release Plumbing
-
-- Target architecture: one embedding model and ONNX Runtime index format on
-  every public platform. Core ML is an accelerator backend, not a second
-  semantic corpus.
-- Keep CLI artifact names stable. Runtime sidecars are additive assets named
-  `ctx-onnxruntime-<platform>.<archive>` and preserve license and notice files.
-- Release metadata may omit runtime keys entirely, but a published runtime must
-  include artifact name, SHA-256, and version metadata as one complete set.
-- Managed runners produce and natively smoke Linux x64, Linux arm64, and macOS
-  arm64 when the native smoke matrix is enabled.
-- Native Intel macOS x64, Windows x64, and FreeBSD x64 use gated
-  `release-*-native` Buildkite queues. Release staging fails closed until all
-  six canonical sidecars and native proofs are present.
-- Windows native proof uses
-  `scripts/smoke-daemon-semantic-release.ps1 -ProofOutput <path>`. Unix-like
-  native hosts use
-  `scripts/smoke-daemon-semantic-release.sh --proof-output <path>`.
-- Fast-fail review criteria:
-  - no semantic success claim without native exact-artifact smoke;
-  - no fallback to a different embedding model without an index compatibility
-    decision;
-  - no foreground search model downloads;
-  - no default config writes for daemon or semantic opt-in.
 
 ## Parallel Implementation And Review Plan
 

--- a/scripts/check-buildkite-pipeline.sh
+++ b/scripts/check-buildkite-pipeline.sh
@@ -23,7 +23,7 @@ if command -v ruby >/dev/null 2>&1; then
     data = YAML.load_file(ARGV.fetch(0))
     abort "pipeline must have steps" unless data.is_a?(Hash) && data["steps"].is_a?(Array)
     steps = data["steps"]
-    abort "pipeline should include public smoke and gated artifact/native smoke matrices" unless steps.length == 11
+    abort "pipeline should include public smoke and gated artifact/native smoke matrices" unless steps.length == 10
     smoke = steps.fetch(0)
     abort "pipeline step must be a mapping" unless smoke.is_a?(Hash)
     abort "pipeline public smoke step must be keyed" unless smoke.key?("key")
@@ -43,7 +43,6 @@ if command -v ruby >/dev/null 2>&1; then
       public-cli-macos-x64
       public-cli-macos-x64-native-smoke
       public-cli-windows-x64-native-smoke
-      public-cli-freebsd-x64-native-smoke
     ]
     actual_keys = steps.filter_map { |step| step["key"] if step.is_a?(Hash) }
     required_keys.each { |key| abort "missing gated artifact step #{key}" unless actual_keys.include?(key) }
@@ -90,7 +89,6 @@ if command -v ruby >/dev/null 2>&1; then
     native_steps = {
       "public-cli-macos-x64-native-smoke" => ["ctx-mac-gui-shared-x64", "ctx-macos-x64.native-runtime-proof.txt"],
       "public-cli-windows-x64-native-smoke" => ["windows-x64", "ctx-windows-x64.native-runtime-proof.txt"],
-      "public-cli-freebsd-x64-native-smoke" => ["freebsd-x64", "ctx-freebsd-x64.native-runtime-proof.txt"],
     }
     native_steps.each do |key, values|
       queue, proof_name = values
@@ -123,7 +121,7 @@ if command -v ruby >/dev/null 2>&1; then
     end
     linux_aarch64 = steps.find { |candidate| candidate.is_a?(Hash) && candidate["key"] == "public-cli-linux-aarch64" }
     abort "missing linux-aarch64 artifact step" unless linux_aarch64
-    abort "linux-aarch64 must build on release-linux-managed" unless linux_aarch64.dig("agents", "queue") == "release-linux-managed"
+    abort "linux-aarch64 must build on linux-arm64" unless linux_aarch64.dig("agents", "queue") == "linux-arm64"
     abort "linux-aarch64 must run on linux" unless linux_aarch64.dig("agents", "os") == "linux"
     abort "linux-aarch64 must run on arm64" unless linux_aarch64.dig("agents", "arch") == "arm64"
   ' "${pipeline}"
@@ -136,7 +134,7 @@ else
       END { print count + 0 }
     ' "${pipeline}"
   )"
-  if [[ "${top_level_steps}" != "11" ]]; then
+  if [[ "${top_level_steps}" != "10" ]]; then
     printf 'pipeline should include public smoke and gated artifact/native smoke matrices\n' >&2
     exit 1
   fi
@@ -224,8 +222,7 @@ if awk '
 fi
 
 for required in \
-  'queue: "release-linux-managed"' \
-  'ctx-runner-class: "release-linux-control"' \
+  'queue: "linux-arm64"' \
   'os: "linux"' \
   'arch: "arm64"'; do
   if ! awk '


### PR DESCRIPTION
## What changed

- run the Linux ARM64 release job on the registered native ARM queue
- remove the unusable public FreeBSD native-smoke job because no public FreeBSD runner is registered
- keep release staging fail-closed on the externally supplied FreeBSD native proof
- remove internal release-planning prose from the public ship-plan document

## Why

The original platform matrix described queues that are not available in the public Buildkite inventory. This makes the executable CI configuration match the runners we actually operate without weakening the release proof requirement.

## Validation

- full locked Rust workspace test suite
- Buildkite pipeline contract check
- Linux release-construction self-test
- daemon semantic release smoke contract tests
- docs, formatting, workspace compile, and diff checks