### PR TITLE
Fix stable Clippy compatibility

### DIFF
--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl.rs
@@ -56,14 +56,11 @@ pub(crate) fn normalize_jsonl_tree(
 
     let mut merged = ProviderNormalizationResult::default();
     for path in paths {
-        match normalize_native_jsonl_session_file(&path, context, provider, source_format) {
-            Ok(mut result) => {
-                merged.summary.merge(result.summary);
-                merged.captures.append(&mut result.captures);
-                merged.files_touched.append(&mut result.files_touched);
-            }
-            Err(err) => return Err(err),
-        }
+        let mut result =
+            normalize_native_jsonl_session_file(&path, context, provider, source_format)?;
+        merged.summary.merge(result.summary);
+        merged.captures.append(&mut result.captures);
+        merged.files_touched.append(&mut result.files_touched);
     }
     Ok(merged)
 }

--- a/crates/ctx-history-capture/src/tests/native_providers.rs
+++ b/crates/ctx-history-capture/src/tests/native_providers.rs
@@ -1621,10 +1621,7 @@ fn native_mux_fixture_imports_searches_reimports_and_subagents() {
         Value::String("mux-child-input-sentinel".into());
     fs::write(
         &child_chat,
-        child_lines
-            .into_iter()
-            .map(|line| jsonl_line(line))
-            .collect::<String>(),
+        child_lines.into_iter().map(jsonl_line).collect::<String>(),
     )
     .unwrap();
     let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();


### PR DESCRIPTION
## Summary

- replace an error-forwarding `match` with `?`
- remove a redundant closure in the native-provider test fixture

## Why

Rust 1.97 added/strengthened Clippy diagnostics that fail the repository release gate under `-D warnings`. Both changes are mechanical and behavior-preserving.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p ctx-history-capture --locked`