### PR TITLE
Refresh release LOC baselines

### DIFF
--- a/scripts/check-loc-exceptions.tsv
+++ b/scripts/check-loc-exceptions.tsv
@@ -1,17 +1,23 @@
 path	max_lines	kind	reason	review_after
-crates/ctx-history-capture/src/tests/native_json.rs	2796	test	native JSON import regression matrix with shared fixtures; split after provider fixture consolidation lands	2026-10-01
-crates/ctx-history-capture/src/tests/native_providers.rs	2430	test	native provider parser matrix with cross-provider fixture setup; split after provider fixture consolidation lands	2026-10-01
-crates/ctx-cli/src/integrations/mcp.rs	1638	source	MCP config writer matrix spans many agent formats; split after the initial integrations installer surface stabilizes	2026-10-01
+crates/ctx-history-capture/src/tests/native_json.rs	2814	test	native JSON import regression matrix with shared fixtures; split after provider fixture consolidation lands	2026-10-01
+crates/ctx-history-capture/src/tests/native_providers.rs	2435	test	native provider parser matrix with cross-provider fixture setup; split after provider fixture consolidation lands	2026-10-01
+crates/ctx-cli/src/integrations/mcp.rs	1623	source	MCP config writer matrix spans many agent formats; split after the initial integrations installer surface stabilizes	2026-10-01
 crates/ctx-history-capture/src/tests/support.rs	2074	test	shared capture test fixture support plus hermetic fixture roots; splitting now would add indirection without narrowing callers	2026-10-01
-crates/ctx-history-capture/src/provider/providers/opencode.rs	1500	source	OpenCode/Kilo provider import compatibility spans legacy and message-part transcript formats; split after provider parser boundaries settle	2026-10-01
+crates/ctx-history-capture/src/provider/providers/opencode.rs	1446	source	OpenCode/Kilo provider import compatibility spans legacy and message-part transcript formats; split after provider parser boundaries settle	2026-10-01
 crates/ctx-history-capture/src/tests/codex.rs	1844	test	Codex parser regression matrix covers oversized JSONL and session semantics; split after fixture helpers are shared	2026-10-01
-crates/ctx-history-capture/src/tests/native_sqlite.rs	1730	test	native SQLite provider regression matrix shares setup across formats; split after fixture helpers are shared	2026-10-01
+crates/ctx-history-capture/src/tests/native_sqlite.rs	1754	test	native SQLite provider regression matrix shares setup across formats; split after fixture helpers are shared	2026-10-01
 crates/ctx-history-capture/src/provider/native.rs	1146	source	native provider discovery dispatcher remains centralized until provider registry extraction lands	2026-10-01
-crates/ctx-history-capture/src/provider/importer.rs	1127	source	native provider import orchestration remains centralized until importer phase extraction lands	2026-10-01
-crates/ctx-cli/tests/native_providers.rs	1900	test	native provider public CLI scenario matrix; fixtures are already modular and splitting would scatter end-to-end coverage	2026-10-01
-crates/ctx-history-store/src/schema/migrations.rs	1040	source	schema migration history is append-only; split only after migration module boundaries are consolidated	2026-10-01
-crates/ctx-history-store/src/schema/tests.rs	1510	test	schema migration regression matrix shares catalog and version fixtures; split after schema test helpers consolidate	2026-10-01
+crates/ctx-history-capture/src/provider/importer.rs	1062	source	native provider import orchestration remains centralized until importer phase extraction lands	2026-10-01
+crates/ctx-cli/tests/native_providers.rs	1895	test	native provider public CLI scenario matrix; fixtures are already modular and splitting would scatter end-to-end coverage	2026-10-01
+crates/ctx-history-store/src/schema/migrations.rs	1031	source	schema migration history is append-only; split only after migration module boundaries are consolidated	2026-10-01
+crates/ctx-history-store/src/schema/tests.rs	1506	test	schema migration regression matrix shares catalog and version fixtures; split after schema test helpers consolidate	2026-10-01
 crates/ctx-history-capture/src/provider/codex/session.rs	1008	source	Codex session parser recently grew oversized-record semantics; keep bounded while follow-up parser split is scoped	2026-10-01
-crates/ctx-history-store/src/search/projections.rs	2021	source	search projection eligibility and embedding document helpers are temporarily over cap after semantic projection integration; split with next search-store cleanup	2026-10-01
-crates/ctx-cli/src/main.rs	1150	source	public CLI argument and dispatch surface is temporarily over cap after daemon/status/semantic flags; split command args with next CLI modularization	2026-10-01
-crates/ctx-cli/src/semantic/daemon.rs	1446	source	daemon lifecycle, query service, and semantic scheduler are integrated for prerelease; split after daemon service boundaries settle	2026-10-01
+crates/ctx-history-store/src/search/projections.rs	2024	source	search projection eligibility and embedding document helpers are temporarily over cap after semantic projection integration; split with next search-store cleanup	2026-10-01
+crates/ctx-cli/src/main.rs	1112	source	public CLI argument and dispatch surface is temporarily over cap after daemon/status/semantic flags; split command args with next CLI modularization	2026-10-01
+crates/ctx-cli/src/semantic/daemon.rs	2315	source	daemon lifecycle, query service, and semantic scheduler are integrated for prerelease; split after daemon service boundaries settle	2026-10-01
+crates/ctx-cli/src/semantic/embedding_backend.rs	1361	source	unified ONNX and Core ML embedding execution remains together while the cross-platform backend contract settles	2026-10-01
+crates/ctx-cli/src/semantic/model_acquisition.rs	1424	source	model download, cache validation, and atomic installation remain together while distribution paths settle	2026-10-01
+crates/ctx-cli/src/semantic/model_bundle.rs	1445	source	model bundle manifests, validation, cache markers, and atomic publication remain together while the bundle format settles	2026-10-01
+crates/ctx-cli/src/semantic/tests.rs	2058	test	semantic readiness, indexing, and query tests share fixtures while the prerelease module boundaries settle	2026-10-01
+crates/ctx-cli/src/upgrade/install.rs	1706	source	managed upgrade installation includes transactional CLI and runtime sidecar handling; split after the runtime install boundary settles	2026-10-01
+scripts/build-onnxruntime-sidecar.sh	1200	source	pinned cross-platform ONNX Runtime construction, packaging, and validation remain one release helper while platform lanes settle	2026-10-01


### PR DESCRIPTION
## Summary

- record exact current LOC baselines for the cross-platform semantic and runtime release modules
- refresh small existing provider/search exceptions after recent fixes
- retain dated review notes for each temporary exception

## Why

The semantic/runtime merge expanded or introduced these files without updating the executable LOC gate, leaving current `main` unable to pass the release suite. This records the present baseline without raising the repository-wide source or test limits; future growth above these exact counts still fails closed.

## Validation

- `scripts/check-loc.sh`
- `cargo fmt --check`
- `cargo check --workspace --locked`
- `scripts/check-docs.sh`