### PR TITLE
Update native smoke for semantic releases

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -131,6 +131,7 @@ steps:
       - "target/public-cli-artifacts/ctx.exe"
       - "target/public-cli-artifacts/ctx.exe.sha256"
       - "target/public-cli-artifacts/ctx.exe.version"
+      - "target/public-cli-artifacts/ctx.exe.expected-version"
       - "target/public-cli-artifacts/ctx.exe.build-info.json"
       - "target/public-cli-artifacts/ctx-onnxruntime-windows-x64.zip"
       - "target/public-cli-artifacts/ctx-onnxruntime-windows-x64.zip.sha256"
@@ -303,6 +304,7 @@ steps:
     command: |
       buildkite-agent artifact download "target/public-cli-artifacts/ctx.exe*" . --step public-cli-windows-x64
       buildkite-agent artifact download "target/public-cli-artifacts/ctx-onnxruntime-windows-x64.zip*" . --step public-cli-windows-x64
+      powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/run-native-candidate-smoke.ps1 -Binary target/public-cli-artifacts/ctx.exe -Fixture tests/fixtures/custom-history-jsonl/basic.jsonl -ExpectedVersionFile target/public-cli-artifacts/ctx.exe.expected-version -ResultPath target/public-cli-native-smoke/windows-x64/candidate-smoke.json
       powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/smoke-daemon-semantic-release.ps1 -Ctx target/public-cli-artifacts/ctx.exe -RuntimeArchive target/public-cli-artifacts/ctx-onnxruntime-windows-x64.zip -RuntimePlatform windows-x64 -DataRoot target/public-cli-native-smoke/windows-x64 -ProofOutput target/public-cli-artifacts/ctx-windows-x64.native-runtime-proof.txt -RequireAuthoritative -KeepRoot
     agents:
       queue: "windows-x64"
@@ -313,5 +315,6 @@ steps:
     timeout_in_minutes: 90
     artifact_paths:
       - "target/public-cli-artifacts/ctx-windows-x64.native-runtime-proof.txt"
+      - "target/public-cli-native-smoke/windows-x64/candidate-smoke.json"
       - "target/public-cli-native-smoke/windows-x64/**/packaged-runtime-proof.txt"
       - "target/public-cli-native-smoke/windows-x64/**/daemon-smoke.log"

--- a/docs/unmanaged-installs.md
+++ b/docs/unmanaged-installs.md
@@ -47,9 +47,9 @@ release metadata, but it is not OS-native application signing.
 
 Official Linux release binaries are checked to require no newer than glibc
 2.35 and are built from pinned Ubuntu 22.04 container inputs rather than the
-runner's host libraries. The public release matrix is currently lexical-only on
-every platform; a future semantic build must not raise the baseline CPU or ABI
-contract without an explicit compatibility decision. The macOS binaries
+runner's host libraries. Local semantic search is opt-in and supported on every
+public release platform through a separately installed ONNX Runtime sidecar, so
+the CLI binary keeps its baseline CPU and ABI contract. The macOS binaries
 currently target macOS 13 or newer.
 
 For pinned installs, GitHub release asset URLs use this pattern:

--- a/scripts/build-public-cli-artifact.sh
+++ b/scripts/build-public-cli-artifact.sh
@@ -316,6 +316,7 @@ run_linux_container_build() {
     "${out_dir}/${binary_name}" \
     "${out_dir}/${binary_name}.sha256" \
     "${out_dir}/${binary_name}.version" \
+    "${out_dir}/${binary_name}.expected-version" \
     "${out_dir}/${binary_name}.build-info.json"
 
   docker pull --platform "${docker_platform}" "${base_image}" >/dev/null
@@ -615,6 +616,9 @@ fi
 staged="${out_dir}/${binary_name}"
 cp "${target_binary}" "${staged}"
 chmod 755 "${staged}"
+if [[ "${platform}" == "windows-x64" ]]; then
+  printf '%s\n' "${version}" > "${staged}.expected-version"
+fi
 
 if command -v file >/dev/null 2>&1; then
   file "${staged}"
@@ -669,6 +673,15 @@ if [[ "${platform}" != linux-* ]]; then
   local_runtime_status=not_run
   if [[ "$(tr -d '\r' < "${staged}.version" | tail -n 1)" == "ctx ${version}" ]]; then
     local_runtime_status=passed
+  fi
+  if [[ "${local_runtime_status}" == passed && "${platform}" == macos-* ]]; then
+    native_smoke_result="$(mktemp "${TMPDIR:-/tmp}/ctx-native-smoke.XXXXXX")"
+    rm -f "${native_smoke_result}"
+    scripts/run-native-candidate-smoke.sh \
+      "${staged}" tests/fixtures/custom-history-jsonl/basic.jsonl \
+      "${version}" "${native_smoke_result}"
+    grep -Fq '"status":"passed"' "${native_smoke_result}"
+    rm -f "${native_smoke_result}"
   fi
   IFS=$'\t' read -r \
     host_system host_arch host_native_arch process_translated _native_arch_probe \

--- a/scripts/check-release-binary-compat.sh
+++ b/scripts/check-release-binary-compat.sh
@@ -126,8 +126,8 @@ check_linux() {
   if [[ "${platform}" == "linux-x64" ]]; then
     expected_machine="EM_X86_64"
     expected_interpreter="/lib64/ld-linux-x86-64.so.2"
-    # The reviewed lexical-only x64 artifact names the loader in DT_NEEDED as
-    # well as PT_INTERP; keep that fact explicit instead of normalizing it away.
+    # The reviewed baseline-compatible x64 artifact names the loader in
+    # DT_NEEDED as well as PT_INTERP; keep that fact explicit.
     expected_needed="ld-linux-x86-64.so.2
 libc.so.6
 libgcc_s.so.1
@@ -162,7 +162,7 @@ libm.so.6"
   check_symbol_ceiling GCC 4.2.0
   if [[ "${platform}" == "linux-x64" ]]; then
     if grep -Eq 'GLIBCXX_[0-9]|CXXABI_[0-9]' <<<"${readobj_output}"; then
-      fail "GLIBCXX and CXXABI requirements are forbidden on lexical-only Linux x64"
+      fail "GLIBCXX and CXXABI requirements are forbidden on Linux x64"
     fi
     if grep -Eqi 'x86-64-v[234]|x86-64-v1[^[:alnum:]].*(x86-64-v[234])|ISA_1_(NEEDED|USED).*(AVX|AVX2|AVX512|SSE3|SSE4)' <<<"${readobj_output}"; then
       fail "advertises an x86 ISA requirement above x86-64-v1"

--- a/scripts/run-native-candidate-smoke.ps1
+++ b/scripts/run-native-candidate-smoke.ps1
@@ -3,8 +3,8 @@ param(
     [string]$Binary,
     [Parameter(Mandatory = $true)]
     [string]$Fixture,
-    [Parameter(Mandatory = $true)]
     [string]$ExpectedVersion,
+    [string]$ExpectedVersionFile,
     [Parameter(Mandatory = $true)]
     [string]$ResultPath
 )
@@ -19,6 +19,18 @@ function Fail([string]$Message) {
 $Binary = [System.IO.Path]::GetFullPath($Binary)
 $Fixture = [System.IO.Path]::GetFullPath($Fixture)
 $ResultPath = [System.IO.Path]::GetFullPath($ResultPath)
+
+if ([string]::IsNullOrWhiteSpace($ExpectedVersion) -eq
+    [string]::IsNullOrWhiteSpace($ExpectedVersionFile)) {
+    Fail "provide exactly one of ExpectedVersion or ExpectedVersionFile"
+}
+if (-not [string]::IsNullOrWhiteSpace($ExpectedVersionFile)) {
+    $ExpectedVersionFile = [System.IO.Path]::GetFullPath($ExpectedVersionFile)
+    if (-not (Test-Path -LiteralPath $ExpectedVersionFile -PathType Leaf)) {
+        Fail "expected-version file is missing: $ExpectedVersionFile"
+    }
+    $ExpectedVersion = (Get-Content -LiteralPath $ExpectedVersionFile -Raw).Trim()
+}
 
 if (-not (Test-Path -LiteralPath $Binary -PathType Leaf)) {
     Fail "binary is missing: $Binary"
@@ -187,17 +199,27 @@ try {
         Fail "lexical search did not return the expected fixture result"
     }
 
-    $status = Invoke-Ctx @("status", "--json")
+    $env:CTX_SEARCH_SEMANTIC = $null
+    $env:CTX_DISABLE_DAEMON = $null
+    try {
+        $status = Invoke-Ctx @("status", "--json")
+    } finally {
+        $env:CTX_SEARCH_SEMANTIC = "0"
+        $env:CTX_DISABLE_DAEMON = "1"
+    }
     if ($status -notmatch '"read_only"\s*:\s*true') {
         Fail "read-only status command returned an unexpected payload"
     }
-    if ($status -notmatch '"source"\s*:\s*"unsupported"') {
-        Fail "native candidate does not report the unsupported semantic capability"
+    if ($status -notmatch '"config_source"\s*:\s*"default"' -or
+        $status -notmatch '"reason"\s*:\s*"semantic_disabled"') {
+        Fail "native candidate does not report semantic search as disabled by default"
+    }
+    if ($status -match '"source"\s*:\s*"unsupported"') {
+        Fail "native candidate unexpectedly reports semantic search as unsupported"
     }
 
-    # Windows intentionally has no semantic backend. An explicit semantic-only
-    # request must fail before any fallback, cache creation, daemon, or network
-    # path can run.
+    # Semantic search is supported but opt-in. Without a provisioned model, an
+    # explicit offline request must fail before fallback, state, or network.
     $env:CTX_SEARCH_SEMANTIC = "1"
     $env:CTX_DAEMON_ENABLED = "1"
     $env:CTX_DISABLE_DAEMON = "0"
@@ -220,7 +242,7 @@ try {
     if ($capabilityExit -eq 0) {
         Fail "semantic-only search unexpectedly succeeded"
     }
-    if ($capabilityText -notmatch 'local semantic search is not supported on this platform yet') {
+    if ($capabilityText -notmatch 'semantic-only search will not initialize or download') {
         Fail "semantic-only search did not report the fail-closed capability contract"
     }
     if ($capabilityText -match '"effective_mode"\s*:\s*"lexical"') {
@@ -256,7 +278,7 @@ try {
             import = "passed"
             search = "passed"
             read_only = "passed"
-            capability = "passed"
+            semantic_offline_fail_closed = "passed"
         }
     }
     $resultJson = $result | ConvertTo-Json -Compress -Depth 3

--- a/scripts/run-native-candidate-smoke.sh
+++ b/scripts/run-native-candidate-smoke.sh
@@ -201,7 +201,8 @@ grep -Eq '"effective_mode"[[:space:]]*:[[:space:]]*"lexical"' "${root}/search.js
 grep -Fq 'Add a parser test.' "${root}/search.json" \
   || { printf 'candidate search did not return the fixture event\n' >&2; exit 1; }
 
-run_bounded "${root}/status.json" "${root}/status.err" ctx status --json || {
+run_bounded "${root}/status.json" "${root}/status.err" \
+  clean_env "${binary}" status --json || {
   cat "${root}/status.err" >&2
   exit 1
 }
@@ -210,13 +211,18 @@ grep -Eq '"read_only"[[:space:]]*:[[:space:]]*true' "${root}/status.json" || {
   exit 1
 }
 
-# Every public release target is intentionally lexical-only. Prove that an
-# explicit semantic-only request fails closed without lexical fallback, model
-# cache, vector index, daemon, or download.
-grep -Eq '"source"[[:space:]]*:[[:space:]]*"unsupported"' "${root}/status.json" || {
-  printf 'native candidate does not report the unsupported semantic capability\n' >&2
+# Semantic search is supported but opt-in on every public release target. Prove
+# that the default remains disabled, then that an explicit offline request with
+# no provisioned model fails closed without fallback, state, or download.
+if ! grep -Eq '"config_source"[[:space:]]*:[[:space:]]*"default"' "${root}/status.json" \
+  || ! grep -Eq '"reason"[[:space:]]*:[[:space:]]*"semantic_disabled"' "${root}/status.json"; then
+  printf 'native candidate does not report semantic search as disabled by default\n' >&2
   exit 1
-}
+fi
+if grep -Eq '"source"[[:space:]]*:[[:space:]]*"unsupported"' "${root}/status.json"; then
+  printf 'native candidate unexpectedly reports semantic search as unsupported\n' >&2
+  exit 1
+fi
 if run_bounded "${root}/semantic.out" "${root}/semantic.err" clean_env \
   CTX_DAEMON_ENABLED=1 \
   CTX_SEARCH_SEMANTIC=1 \
@@ -224,8 +230,7 @@ if run_bounded "${root}/semantic.out" "${root}/semantic.err" clean_env \
   printf 'semantic-only search unexpectedly succeeded\n' >&2
   exit 1
 fi
-if ! grep -Eq \
-  'semantic-only search will not initialize or download|local semantic search is not supported on this platform yet' \
+if ! grep -Fq 'semantic-only search will not initialize or download' \
   "${root}/semantic.err"; then
   printf 'semantic-only search did not report the fail-closed capability contract\n' >&2
   exit 1
@@ -252,7 +257,7 @@ if [ -e "${data_root}/daemon/daemon.lock" ]; then
   exit 1
 fi
 
-printf '%s\n' '{"schema_version":1,"kind":"ctx-native-candidate-smoke","status":"passed","steps":{"version":"passed","setup":"passed","import":"passed","search":"passed","read_only":"passed","capability":"passed"}}' \
+printf '%s\n' '{"schema_version":1,"kind":"ctx-native-candidate-smoke","status":"passed","steps":{"version":"passed","setup":"passed","import":"passed","search":"passed","read_only":"passed","semantic_offline_fail_closed":"passed"}}' \
   > "${result_tmp}"
 mv "${result_tmp}" "${result_path}"
 printf 'native candidate smoke passed: %s %s\n' "$(uname -s)" "$(uname -m)"

--- a/scripts/tests/run-native-candidate-smoke-test.ps1
+++ b/scripts/tests/run-native-candidate-smoke-test.ps1
@@ -18,7 +18,9 @@ if "%USERPROFILE%"=="" exit /b 95
 echo %* | findstr /c:"--backend semantic" >nul
 if not errorlevel 1 (
   if not "%CTX_SEARCH_SEMANTIC%"=="1" exit /b 96
-  1>&2 echo local semantic search is not supported on this platform yet
+  if not "%CTX_DAEMON_ENABLED%"=="1" exit /b 97
+  if not "%CTX_DISABLE_DAEMON%"=="0" exit /b 98
+  1>&2 echo semantic-only search will not initialize or download intfloat/multilingual-e5-small during search
   exit /b 1
 )
 if "%1"=="--version" (
@@ -35,7 +37,9 @@ if "%1"=="search" (
   exit /b 0
 )
 if "%1"=="status" (
-  echo {"read_only":true,"semantic":{"embed_policy":{"source":"unsupported"}}}
+  if not "%CTX_SEARCH_SEMANTIC%"=="" exit /b 89
+  if not "%CTX_DISABLE_DAEMON%"=="" exit /b 90
+  echo {"read_only":true,"semantic":{"config_source":"default","enabled":false,"reason":"semantic_disabled","embed_policy":{"source":"dynamic_quiet"}}}
   exit /b 0
 )
 exit /b 99
@@ -45,8 +49,10 @@ exit /b 99
     '{"record_type":"manifest","schema_version":"ctx-history-jsonl-v1"}' |
         Set-Content -LiteralPath $fixture -Encoding Ascii
     $result = Join-Path $root "result.json"
+    $expectedVersionFile = Join-Path $root "expected-version"
+    "0.25.0`n" | Set-Content -LiteralPath $expectedVersionFile -NoNewline -Encoding Ascii
 
-    & $smoke -Binary $fake -Fixture $fixture -ExpectedVersion 0.25.0 -ResultPath $result | Out-Null
+    & $smoke -Binary $fake -Fixture $fixture -ExpectedVersionFile $expectedVersionFile -ResultPath $result | Out-Null
     $parsed = Get-Content -LiteralPath $result -Raw | ConvertFrom-Json
     if ($parsed.schema_version -ne 1 -or
         $parsed.kind -ne "ctx-native-candidate-smoke" -or
@@ -58,7 +64,7 @@ exit /b 99
         throw "candidate smoke result contains unexpected top-level keys"
     }
     $stepKeys = @($parsed.steps.PSObject.Properties.Name)
-    if (($stepKeys -join ",") -ne "version,setup,import,search,read_only,capability") {
+    if (($stepKeys -join ",") -ne "version,setup,import,search,read_only,semantic_offline_fail_closed") {
         throw "candidate smoke result contains unexpected step keys"
     }
     foreach ($key in $stepKeys) {

--- a/scripts/tests/run-native-candidate-smoke-test.sh
+++ b/scripts/tests/run-native-candidate-smoke-test.sh
@@ -24,8 +24,12 @@ case " $* " in
   *" --backend semantic "*)
     test "${CTX_SEARCH_SEMANTIC:-}" = 1
     test "${CTX_DAEMON_ENABLED:-}" = 1
-    printf '%s\n' 'local semantic search is not supported on this platform yet' >&2
+    printf '%s\n' 'semantic-only search will not initialize or download intfloat/multilingual-e5-small during search' >&2
     exit 1
+    ;;
+  *" status --json "*)
+    test -z "${CTX_SEARCH_SEMANTIC:-}"
+    test -z "${CTX_DISABLE_DAEMON:-}"
     ;;
   *)
     test "${CTX_DISABLE_DAEMON:-}" = 1
@@ -48,7 +52,7 @@ case "${1:-}" in
     printf '%s\n' '{"retrieval":{"requested_mode":"lexical","effective_mode":"lexical"},"results":[{"text":"Add a parser test."}]}'
     ;;
   status)
-    printf '%s\n' '{"read_only":true,"semantic":{"embed_policy":{"source":"unsupported"}}}'
+    printf '%s\n' '{"read_only":true,"semantic":{"config_source":"default","enabled":false,"reason":"semantic_disabled","embed_policy":{"source":"dynamic_quiet"}}}'
     ;;
   *)
     printf 'unexpected fake ctx arguments: %s\n' "$*" >&2
@@ -61,30 +65,12 @@ printf '%s\n' '{"record_type":"manifest","schema_version":"ctx-history-jsonl-v1"
 
 result="${tmp}/result.json"
 "${smoke}" "${fake}" "${tmp}/fixture.jsonl" 0.25.0 "${result}" >/dev/null
-expected='{"schema_version":1,"kind":"ctx-native-candidate-smoke","status":"passed","steps":{"version":"passed","setup":"passed","import":"passed","search":"passed","read_only":"passed","capability":"passed"}}'
+expected='{"schema_version":1,"kind":"ctx-native-candidate-smoke","status":"passed","steps":{"version":"passed","setup":"passed","import":"passed","search":"passed","read_only":"passed","semantic_offline_fail_closed":"passed"}}'
 [[ "$(tr -d '\r\n' < "${result}")" == "${expected}" ]] || {
   printf 'candidate smoke result schema changed\n' >&2
   cat "${result}" >&2
   exit 1
 }
-
-# Exercise the non-FastEmbed policy branch deterministically. The private proof
-# still derives the real guest OS independently; this fake uname exists only in
-# this focused helper test.
-mkdir -p "${tmp}/fake-path"
-cat > "${tmp}/fake-path/uname" <<'EOF'
-#!/bin/sh
-case "${1:-}" in
-  -s) printf 'FreeBSD\n' ;;
-  -m) printf 'amd64\n' ;;
-  *) exec /usr/bin/uname "$@" ;;
-esac
-EOF
-chmod +x "${tmp}/fake-path/uname"
-capability_result="${tmp}/capability-result.json"
-PATH="${tmp}/fake-path:${PATH}" "${smoke}" \
-  "${fake}" "${tmp}/fixture.jsonl" 0.25.0 "${capability_result}" >/dev/null
-[[ "$(tr -d '\r\n' < "${capability_result}")" == "${expected}" ]]
 
 failed_result="${tmp}/failed-result.json"
 cp "${fake}" "${tmp}/ctx-bad-version"


### PR DESCRIPTION
## Summary
- update packaged-candidate smoke to prove semantic search is supported, disabled by default, and fails closed offline without a cached model
- run the contract on native macOS and Windows release paths in addition to Linux
- carry the Windows build version in a generated CI evidence sidecar and refresh semantic release documentation

## Validation
- `bazel test //:native_candidate_smoke_tests //:linux_release_construction_tests //:release_binary_compat_tests //:buildkite_pipeline_check //:docs_check //:loc_check --config=ci --test_output=errors`
- real packaged `ctx 0.25.0` through both shell and PowerShell smoke helpers
- independent adversarial review: no remaining release-blocking findings

## Residual coverage
- FreeBSD remains manually/VM runtime-tested because there is no standing native CI worker
- Linux release smoke is network-isolated; other native smoke paths enforce the product offline contract and assert no semantic/daemon state is created