### PR TITLE
Bound FTS merge recovery steps on large indexes

### DIFF
--- a/crates/ctx-cli/src/commands/import/native.rs
+++ b/crates/ctx-cli/src/commands/import/native.rs
@@ -72,6 +72,19 @@ pub(crate) fn import_one_source_inner(
     let record = import_record_for_source(source);
     let record_id = record.id;
     store.upsert_record(&record)?;
+    // Non-manifest SQLite/tree sources still have a persisted root inventory.
+    // Do not normalize an unchanged, already-indexed source just because a
+    // background search discovered it again; those adapters may read the
+    // entire provider database before deduplication can occur.
+    if !full_rescan
+        && !source_uses_import_file_manifest(source)
+        && preinventory.source_root_file().is_some()
+        && store
+            .list_pending_source_import_files(source.provider, &source.path.display().to_string())?
+            .is_empty()
+    {
+        return Ok(ProviderImportSummary::default());
+    }
     let summary = if !full_rescan && source_uses_import_file_manifest(source) {
         import_manifested_source(
             store,
@@ -855,4 +868,60 @@ pub(crate) fn merge_provider_import_summary(
     summary.imported_edges += other.imported_edges;
     summary.skipped_edges += other.skipped_edges;
     summary.failures.extend(other.failures);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider_sources::explicit_path_source;
+    use ctx_history_store::{SourceImportFile, SourceImportFileIndexUpdate};
+    use serde_json::json;
+
+    #[test]
+    fn unchanged_root_source_skips_provider_normalization() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_path = temp.path().join("state.db");
+        let source = explicit_path_source(CaptureProvider::Hermes, source_path.clone());
+        let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+        let source_root = source_path.display().to_string();
+        let file = SourceImportFile {
+            provider: source.provider,
+            source_format: source.source_format.to_owned(),
+            source_root: source_root.clone(),
+            source_path: source_root.clone(),
+            file_size_bytes: 0,
+            file_modified_at_ms: 0,
+            observed_at_ms: 0,
+            metadata: json!({}),
+        };
+        store
+            .upsert_source_import_files(std::slice::from_ref(&file))
+            .unwrap();
+        store
+            .mark_source_import_file_indexed(
+                source.provider,
+                SourceImportFileIndexUpdate {
+                    source_root: &source_root,
+                    source_path: &source_root,
+                    file_size_bytes: file.file_size_bytes,
+                    file_modified_at_ms: file.file_modified_at_ms,
+                    indexed_at_ms: 1,
+                },
+            )
+            .unwrap();
+
+        let summary = import_one_source_inner(
+            &mut store,
+            &source,
+            None,
+            false,
+            false,
+            true,
+            &SourcePreinventory::SourceRoot(file),
+        )
+        .unwrap();
+
+        assert_eq!(summary.imported_events, 0);
+        assert_eq!(summary.failed, 0);
+    }
 }

--- a/crates/ctx-history-store/src/bulk_search.rs
+++ b/crates/ctx-history-store/src/bulk_search.rs
@@ -30,7 +30,11 @@ const BULK_MODE_MERGE_STARTED_KEY_PREFIX: &str = "event_search_bulk_mode_v1:merg
 const FTS_AUTOMERGE_DEFAULT: i64 = 4;
 const FTS_CRISISMERGE_DEFAULT: i64 = 16;
 const FTS_BULK_CRISISMERGE: i64 = 1_000_000;
-const FTS_MERGE_PAGE_BUDGET: i64 = 1024;
+// FTS5's merge page budget is not a hard upper bound on WAL pages: merging a
+// large segment can rewrite substantially more data inside one statement.
+// Keep each step deliberately small so checkpoints remain safe on large real
+// indexes, not only on compact synthetic fixtures.
+const FTS_MERGE_PAGE_BUDGET: i64 = 16;
 const BULK_LOCK_SUFFIX: &str = ".event-search-bulk.lock.sqlite";
 
 /// Owns the cross-process lock for one event-search bulk operation.

--- a/crates/ctx-history-store/src/search/projections.rs
+++ b/crates/ctx-history-store/src/search/projections.rs
@@ -141,6 +141,15 @@ impl Store {
             return Ok(Vec::new());
         }
 
+        if scriptgram_clauses.is_empty() {
+            return self.search_event_hits_page_lexical(
+                match_clauses,
+                limit,
+                offset,
+                prefer_conversation,
+            );
+        }
+
         let mut selects = Vec::new();
         let mut values = Vec::<Value>::new();
         for (term_index, clause) in match_clauses.into_iter().enumerate() {
@@ -189,6 +198,62 @@ impl Store {
                 "ranked JOIN event_search ON event_search.event_id = ranked.event_id",
                 &event_search_score("ranked.score", prefer_conversation),
                 "ORDER BY ranked.matched_terms DESC, search_score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
+            )
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(values), event_search_hit_from_row)?;
+        collect_rows(rows)
+    }
+
+    fn search_event_hits_page_lexical(
+        &self,
+        match_clauses: Vec<String>,
+        limit: usize,
+        offset: usize,
+        prefer_conversation: bool,
+    ) -> Result<Vec<EventSearchHit>> {
+        let mut values = Vec::<Value>::new();
+        let selects = match_clauses
+            .into_iter()
+            .enumerate()
+            .map(|(term_index, clause)| {
+                values.push(Value::Text(clause));
+                format!(
+                    r#"SELECT event_search.event_id,
+                              event_search.history_record_id,
+                              event_search.session_id,
+                              event_search.role,
+                              event_search.preview_text,
+                              {term_index},
+                              bm25(event_search)
+                       FROM event_search
+                       WHERE event_search MATCH ?{}"#,
+                    values.len()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" UNION ALL ");
+        values.push(Value::Integer(limit.max(1) as i64));
+        let limit_parameter = values.len();
+        values.push(Value::Integer(offset as i64));
+        let offset_parameter = values.len();
+        let sql = format!(
+            r#"
+            WITH matches(event_id, history_record_id, session_id, role, preview_text, term_index, score) AS MATERIALIZED (
+                {selects}
+            ),
+            ranked(event_id, history_record_id, session_id, role, preview_text, matched_terms, score) AS (
+                SELECT event_id, history_record_id, session_id, role, preview_text, COUNT(*), SUM(score)
+                FROM matches
+                GROUP BY event_id, history_record_id, session_id, role, preview_text
+            )
+            {}
+            LIMIT ?{limit_parameter} OFFSET ?{offset_parameter}
+            "#,
+            event_search_hit_sql(
+                "ranked AS event_search",
+                &event_search_score("event_search.score", prefer_conversation),
+                "ORDER BY event_search.matched_terms DESC, search_score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
             )
         );
         let mut stmt = self.conn.prepare(&sql)?;


### PR DESCRIPTION
## What changed

Reduce the explicit FTS5 merge page budget from 1,024 to 16 pages per committed/checkpointed step.

## Why

The FTS5 merge page parameter is a work budget, not a hard bound on physical WAL pages. On a real 2.3 GiB ctx database populated from a 206 MiB Hermes source, one 1,024-page recovery step grew the WAL to 7.0 GiB before the process was stopped for disk safety. This also made ordinary `ctx search` appear hung because writable store open synchronously resumes the recovery marker.

The smaller step keeps the existing crash-safe marker, serialization, merge semantics, and strict checkpoint loop unchanged while reducing the amount of FTS work that can occur inside one statement.

## Real-corpus validation

Reused the exact interrupted database and `event_search_bulk_mode_v1` marker that reproduced the failure:

- before: 1,024-page step, WAL reached 7.0 GiB and did not finish safely
- after: 16-page step, recovery completed in 1m52s
- measured peak WAL: 14,959,752 bytes (~14.3 MiB)
- final WAL: 0 bytes
- recovery marker: cleared
- `ctx search Hermes --limit 3`: returned results, including a Hermes event
- exit status: 0

## Checks

- `cargo fmt --all -- --check`
- `cargo test -p ctx-history-store connection_tests -- --nocapture` (7 passed)
- `cargo clippy -p ctx-history-store -p ctx --tests -- -D warnings`
- `cargo build -p ctx --release`

## Search latency follow-up

The same recovery marker also made ordinary search look hung because lexical event ranking re-joined the FTS5 virtual table after materializing its matches. This branch now keeps the match rows in a materialized CTE and ranks them without that second FTS scan. Scriptgram queries retain the existing path.

Live validation on the existing 2.3 GiB database after installing the release binary:

- `ctx search Hermes --refresh off`: 0.70–1.03s over repeated runs
- `ctx search Hermes --provider hermes --refresh off`: 0.69–0.72s
- WAL remained absent/0 bytes and no recovery marker remained

Additional checks: `cargo fmt --check`, `cargo test -p ctx-history-store search -- --nocapture` (38 passed), clippy, and release build.

## Idempotent refresh follow-up

Background search was also re-normalizing unchanged non-manifest native roots after inventory had already marked them indexed. This was especially expensive for live SQLite sources: Hermes (about 216 MiB), OpenCode (about 675 MiB), and OpenClaw (about 350 MiB). The import path now checks the persisted root inventory and skips provider normalization when the source metadata is unchanged and there is no pending import file. Full rescans and changed/pending sources still run normally.

Validation:

- regression test: `unchanged_root_source_skips_provider_normalization`
- unchanged Hermes source: plain `ctx search Hermes --provider hermes --limit 1` returned in 1.11s
- generic plain search completed in 20.95s while reporting six pre-existing malformed Codex records; it did not hang and final WAL was absent
- release binary installed locally from commit `31a4dfdf`