### PR TITLE
Bound FTS merge WAL on populated indexes

### DIFF
--- a/crates/ctx-cli/tests/setup_sources_import.rs
+++ b/crates/ctx-cli/tests/setup_sources_import.rs
@@ -1,5 +1,12 @@
 mod support;
 
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc, Barrier,
+    },
+    thread,
+};
 use support::*;
 
 fn write_codex_setup_session(temp: &TempDir) {
@@ -640,6 +647,196 @@ fn setup_inventories_whole_source_sqlite_providers() {
     assert_eq!(status["source_import_files"], 1);
     assert_eq!(status["indexed_source_import_files"], 1);
     assert_eq!(status["pending_inventory_units"], 0);
+}
+
+#[test]
+fn clean_multisource_setup_with_hermes_bounds_wal_through_final_optimization() {
+    let temp = tempdir();
+    write_large_codex_setup_sessions(&temp, 40, 4, 4 * 1024);
+    write_large_hermes_setup_db(&temp, 130, 8 * 1024);
+    let db_path = temp.path().join("work.sqlite");
+    let wal_path = temp.path().join("work.sqlite-wal");
+
+    let running = Arc::new(AtomicBool::new(true));
+    let peak_wal_bytes = Arc::new(AtomicU64::new(0));
+    let sampler_ready = Arc::new(Barrier::new(2));
+    let sampler = {
+        let running = Arc::clone(&running);
+        let peak_wal_bytes = Arc::clone(&peak_wal_bytes);
+        let sampler_ready = Arc::clone(&sampler_ready);
+        thread::spawn(move || {
+            sampler_ready.wait();
+            loop {
+                if let Ok(metadata) = fs::metadata(&wal_path) {
+                    peak_wal_bytes.fetch_max(metadata.len(), Ordering::AcqRel);
+                }
+                if !running.load(Ordering::Acquire) {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(1));
+            }
+        })
+    };
+    sampler_ready.wait();
+    let mut setup_command = ctx(&temp);
+    setup_command.args(["setup", "--wait", "--json", "--progress", "none"]);
+    let setup_output = setup_command.output().unwrap();
+    running.store(false, Ordering::Release);
+    sampler.join().unwrap();
+
+    assert!(
+        setup_output.status.success(),
+        "setup failed: {}",
+        String::from_utf8_lossy(&setup_output.stderr)
+    );
+    let setup: Value = serde_json::from_slice(&setup_output.stdout).unwrap();
+    assert_eq!(setup["import"]["totals"]["failed_sources"], 0);
+    assert!(
+        peak_wal_bytes.load(Ordering::Acquire) <= 32 * 1024 * 1024,
+        "clean multi-source setup grew WAL to {} bytes",
+        peak_wal_bytes.load(Ordering::Acquire)
+    );
+    assert!(
+        fs::metadata(temp.path().join("work.sqlite-wal"))
+            .map(|metadata| metadata.len())
+            .unwrap_or(0)
+            <= 4 * 1024 * 1024,
+        "setup left a large final WAL"
+    );
+
+    let conn = Connection::open(&db_path).unwrap();
+    assert_eq!(
+        conn.query_row("PRAGMA integrity_check", [], |row| row.get::<_, String>(0))
+            .unwrap(),
+        "ok"
+    );
+    assert_eq!(
+        sqlite_count(
+            &conn,
+            "SELECT COUNT(*) FROM search_projection_stats WHERE key LIKE 'event_search_bulk_mode_v1%'"
+        ),
+        0
+    );
+    assert!(
+        sqlite_count(
+            &conn,
+            "SELECT COUNT(*) FROM event_search WHERE event_search MATCH 'codex AND setup AND history'"
+        ) > 0
+    );
+    assert!(
+        sqlite_count(
+            &conn,
+            "SELECT COUNT(*) FROM event_search WHERE event_search MATCH 'hermes AND setup AND current'"
+        ) > 0
+    );
+    let event_count = sqlite_count(&conn, "SELECT COUNT(*) FROM events");
+    drop(conn);
+
+    let replay = json_output(ctx(&temp).args(["setup", "--wait", "--json", "--progress", "none"]));
+    assert_eq!(replay["import"]["totals"]["failed_sources"], 0);
+    let conn = Connection::open(&db_path).unwrap();
+    assert_eq!(
+        sqlite_count(&conn, "SELECT COUNT(*) FROM events"),
+        event_count
+    );
+}
+
+fn write_large_codex_setup_sessions(
+    temp: &TempDir,
+    sessions: usize,
+    messages_per_session: usize,
+    payload_bytes: usize,
+) {
+    let sessions_dir = temp.path().join(".codex/sessions/2026/07/12");
+    fs::create_dir_all(&sessions_dir).unwrap();
+    let payload = "database migration checkpoint bounded wal search index ".repeat(
+        payload_bytes / "database migration checkpoint bounded wal search index ".len() + 1,
+    );
+    for session_index in 0..sessions {
+        let session_id = format!("codex-setup-history-{session_index}");
+        let path = sessions_dir.join(format!("rollout-{session_id}.jsonl"));
+        let mut file = fs::File::create(path).unwrap();
+        writeln!(
+            file,
+            "{}",
+            json!({
+                "timestamp": "2026-07-12T10:00:00.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": session_id,
+                    "timestamp": "2026-07-12T10:00:00.000Z",
+                    "cwd": "/repo/setup",
+                    "originator": "codex-cli",
+                    "cli_version": "0.200.0",
+                    "source": "cli",
+                    "model_provider": "openai"
+                }
+            })
+        )
+        .unwrap();
+        for message_index in 0..messages_per_session {
+            writeln!(
+                file,
+                "{}",
+                json!({
+                    "timestamp": "2026-07-12T10:00:01.000Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{
+                            "type": "input_text",
+                            "text": format!(
+                                "codex-setup-history session {session_index} message {message_index} {payload}"
+                            )
+                        }]
+                    }
+                })
+            )
+            .unwrap();
+        }
+    }
+}
+
+fn write_large_hermes_setup_db(temp: &TempDir, messages: usize, payload_bytes: usize) {
+    let hermes_dir = temp.path().join(".hermes");
+    fs::create_dir_all(&hermes_dir).unwrap();
+    let mut conn = Connection::open(hermes_dir.join("state.db")).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            started_at REAL NOT NULL
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            timestamp REAL NOT NULL,
+            active INTEGER NOT NULL DEFAULT 1,
+            compacted INTEGER NOT NULL DEFAULT 0
+        );
+        INSERT INTO sessions VALUES ('hermes-setup-current', 'acp', 1782259200.0);",
+    )
+    .unwrap();
+    let payload = "provider import fts merge recovery bounded checkpoint "
+        .repeat(payload_bytes / "provider import fts merge recovery bounded checkpoint ".len() + 1);
+    let transaction = conn.transaction().unwrap();
+    for index in 0..messages {
+        transaction
+            .execute(
+                "INSERT INTO messages (session_id, role, content, timestamp)
+                 VALUES ('hermes-setup-current', ?1, ?2, ?3)",
+                params![
+                    if index % 2 == 0 { "user" } else { "assistant" },
+                    format!("hermes-setup-current message {index} {payload}"),
+                    1782259201.0 + index as f64,
+                ],
+            )
+            .unwrap();
+    }
+    transaction.commit().unwrap();
 }
 
 #[test]

--- a/crates/ctx-history-capture/src/tests/hermes_batching.rs
+++ b/crates/ctx-history-capture/src/tests/hermes_batching.rs
@@ -1,4 +1,12 @@
 use super::support::*;
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc, Barrier,
+    },
+    thread,
+    time::Duration,
+};
 
 #[test]
 fn native_hermes_partial_import_crosses_batches_and_replays_idempotently() {
@@ -67,6 +75,91 @@ fn native_hermes_nonpartial_import_preserves_atomic_search_projection() {
     assert_bounded_wal(&db_path);
 }
 
+#[test]
+fn native_hermes_partial_import_preserves_preexisting_search_segment_and_bounds_peak_wal() {
+    let temp = tempdir();
+    let historic = write_hermes_batched_db_named(&temp, "historic", 256, 8 * 1024);
+    let current = write_hermes_batched_db_named(&temp, "current", 130, 8 * 1024);
+    let db_path = temp.path().join("work.sqlite");
+    let mut store = Store::open(&db_path).unwrap();
+
+    let historic_summary = import_hermes_sqlite(
+        &historic,
+        &mut store,
+        HermesSqliteImportOptions {
+            source_path: Some(historic.clone()),
+            allow_partial_failures: true,
+            ..HermesSqliteImportOptions::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        historic_summary.failed, 0,
+        "{:?}",
+        historic_summary.failures
+    );
+    assert_eq!(historic_summary.imported_events, 256);
+    assert_eq!(event_search_segment_count(&db_path), 1);
+
+    let running = Arc::new(AtomicBool::new(true));
+    let peak_wal_bytes = Arc::new(AtomicU64::new(0));
+    let sampler_ready = Arc::new(Barrier::new(2));
+    let sampler = {
+        let running = Arc::clone(&running);
+        let peak_wal_bytes = Arc::clone(&peak_wal_bytes);
+        let sampler_ready = Arc::clone(&sampler_ready);
+        let wal_path = PathBuf::from(format!("{}-wal", db_path.display()));
+        thread::spawn(move || {
+            sampler_ready.wait();
+            loop {
+                if let Ok(metadata) = fs::metadata(&wal_path) {
+                    peak_wal_bytes.fetch_max(metadata.len(), Ordering::AcqRel);
+                }
+                if !running.load(Ordering::Acquire) {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(1));
+            }
+        })
+    };
+    sampler_ready.wait();
+    let current_options = HermesSqliteImportOptions {
+        source_path: Some(current.clone()),
+        allow_partial_failures: true,
+        ..HermesSqliteImportOptions::default()
+    };
+    let current_summary = import_hermes_sqlite(&current, &mut store, current_options.clone());
+    running.store(false, Ordering::Release);
+    sampler.join().unwrap();
+    let current_summary = current_summary.unwrap();
+
+    assert_eq!(current_summary.failed, 0, "{:?}", current_summary.failures);
+    assert_eq!(current_summary.imported_events, 130);
+    assert!(
+        peak_wal_bytes.load(Ordering::Acquire) <= 32 * 1024 * 1024,
+        "pre-populated Hermes import grew WAL to {} bytes",
+        peak_wal_bytes.load(Ordering::Acquire)
+    );
+    assert!(
+        event_search_segment_count(&db_path) > 1,
+        "finishing Hermes must not re-optimize the pre-existing search segment"
+    );
+    assert_eq!(bulk_search_marker_count(&db_path), 0);
+    assert_eq!(integrity_check(&db_path), "ok");
+    assert_eq!(
+        store
+            .search_event_hits("current-message-129", 10)
+            .unwrap()
+            .len(),
+        1
+    );
+
+    let replay = import_hermes_sqlite(&current, &mut store, current_options).unwrap();
+    assert_eq!(replay.failed, 0, "{:?}", replay.failures);
+    assert_eq!(replay.imported_events, 0);
+    assert_eq!(replay.skipped_events, 130);
+}
+
 fn assert_bounded_wal(db_path: &Path) {
     let wal_path = PathBuf::from(format!("{}-wal", db_path.display()));
     let wal_bytes = fs::metadata(&wal_path)
@@ -79,7 +172,16 @@ fn assert_bounded_wal(db_path: &Path) {
 }
 
 fn write_hermes_batched_db(temp: &TempDir, messages: usize) -> PathBuf {
-    let path = temp.path().join("hermes-batched.db");
+    write_hermes_batched_db_named(temp, "hermes-batched", messages, 0)
+}
+
+fn write_hermes_batched_db_named(
+    temp: &TempDir,
+    name: &str,
+    messages: usize,
+    payload_bytes: usize,
+) -> PathBuf {
+    let path = temp.path().join(format!("{name}.db"));
     let mut conn = Connection::open(&path).unwrap();
     conn.execute_batch(
         "CREATE TABLE sessions (
@@ -95,8 +197,12 @@ fn write_hermes_batched_db(temp: &TempDir, messages: usize) -> PathBuf {
             timestamp REAL NOT NULL,
             active INTEGER NOT NULL DEFAULT 1,
             compacted INTEGER NOT NULL DEFAULT 0
-        );
-        INSERT INTO sessions VALUES ('hermes-batched', 'acp', 1782259200.0);",
+        );",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO sessions VALUES (?1, 'acp', 1782259200.0)",
+        [name],
     )
     .unwrap();
     let transaction = conn.transaction().unwrap();
@@ -105,10 +211,11 @@ fn write_hermes_batched_db(temp: &TempDir, messages: usize) -> PathBuf {
         transaction
             .execute(
                 "INSERT INTO messages (session_id, role, content, timestamp)
-                 VALUES ('hermes-batched', ?1, ?2, ?3)",
+                 VALUES (?1, ?2, ?3, ?4)",
                 rusqlite::params![
+                    name,
                     role,
-                    format!("hermes-batched-message-{index}"),
+                    format!("{name}-message-{index} {}", "x".repeat(payload_bytes)),
                     1782259201.0 + index as f64,
                 ],
             )
@@ -116,4 +223,33 @@ fn write_hermes_batched_db(temp: &TempDir, messages: usize) -> PathBuf {
     }
     transaction.commit().unwrap();
     path
+}
+
+fn event_search_segment_count(db_path: &Path) -> i64 {
+    Connection::open(db_path)
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(DISTINCT segid) FROM event_search_idx",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
+fn bulk_search_marker_count(db_path: &Path) -> i64 {
+    Connection::open(db_path)
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM search_projection_stats WHERE key LIKE 'event_search_bulk_mode_v1%'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
+fn integrity_check(db_path: &Path) -> String {
+    Connection::open(db_path)
+        .unwrap()
+        .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+        .unwrap()
 }

--- a/crates/ctx-history-store/src/bulk_search.rs
+++ b/crates/ctx-history-store/src/bulk_search.rs
@@ -26,7 +26,6 @@ const ALL_FTS_TABLES: [&str; 5] = [
 const BULK_MODE_MARKER_KEY: &str = "event_search_bulk_mode_v1";
 const BULK_MODE_AUTOMERGE_KEY_PREFIX: &str = "event_search_bulk_mode_v1:automerge:";
 const BULK_MODE_CRISISMERGE_KEY_PREFIX: &str = "event_search_bulk_mode_v1:crisismerge:";
-const BULK_MODE_MERGE_STARTED_KEY_PREFIX: &str = "event_search_bulk_mode_v1:merge_started:";
 const FTS_AUTOMERGE_DEFAULT: i64 = 4;
 const FTS_CRISISMERGE_DEFAULT: i64 = 16;
 const FTS_BULK_CRISISMERGE: i64 = 1_000_000;
@@ -88,20 +87,19 @@ impl Store {
         Ok(guard)
     }
 
-    /// Compact all bulk segments in bounded steps, then restore saved settings.
+    /// Compact pending bulk segments in bounded steps, then restore saved settings.
+    ///
+    /// Bulk finalization deliberately uses positive FTS5 merge commands. Starting
+    /// a full merge with a negative command would assign every pre-existing
+    /// segment to the same level and rewrite the entire shared event index. That
+    /// is appropriate for an explicit optimize, but not for finishing one
+    /// provider import in an already-populated multi-source index.
     pub fn finish_event_search_bulk_mode(&self, guard: &EventSearchBulkGuard) -> Result<()> {
         if guard.store_path != self.path {
             return Err(StoreError::InvalidBulkSearchGuard);
         }
         if !bulk_mode_pending(self)? {
             return Ok(());
-        }
-        for table in EVENT_SEARCH_FTS_TABLES {
-            let progress_key = format!("{BULK_MODE_MERGE_STARTED_KEY_PREFIX}{table}");
-            let start_full_merge = bulk_mode_config(self, &progress_key)?.is_none();
-            if start_full_merge && table_exists(&self.conn, table)? {
-                self.merge_fts_table_step(table, -FTS_MERGE_PAGE_BUDGET, Some(&progress_key))?;
-            }
         }
         loop {
             if self.finish_event_search_bulk_mode_step()? {
@@ -154,7 +152,7 @@ impl Store {
             self.finish_event_search_bulk_mode(&guard)?;
         }
         for table in ALL_FTS_TABLES {
-            self.merge_fts_table_bounded(table, true, None)?;
+            self.merge_fts_table_bounded(table, true)?;
         }
         Ok(())
     }
@@ -163,7 +161,6 @@ impl Store {
         &self,
         table: &'static str,
         mut start_full_merge: bool,
-        progress_key: Option<&str>,
     ) -> Result<()> {
         if !table_exists(&self.conn, table)? {
             return Ok(());
@@ -174,11 +171,7 @@ impl Store {
             } else {
                 FTS_MERGE_PAGE_BUDGET
             };
-            let changed = self.merge_fts_table_step(
-                table,
-                page_budget,
-                start_full_merge.then_some(progress_key).flatten(),
-            )?;
+            let changed = self.merge_fts_table_step(table, page_budget)?;
             start_full_merge = false;
             if !changed {
                 return Ok(());
@@ -186,20 +179,9 @@ impl Store {
         }
     }
 
-    fn merge_fts_table_step(
-        &self,
-        table: &'static str,
-        page_budget: i64,
-        progress_key: Option<&str>,
-    ) -> Result<bool> {
+    fn merge_fts_table_step(&self, table: &'static str, page_budget: i64) -> Result<bool> {
         self.begin_immediate_batch()?;
-        let result = (|| {
-            let changed = merge_fts_table_in_transaction(self, table, page_budget)?;
-            if let Some(progress_key) = progress_key {
-                save_bulk_mode_config(self, progress_key, 1)?;
-            }
-            Ok(changed)
-        })();
+        let result = merge_fts_table_in_transaction(self, table, page_budget);
         let changed = match result {
             Ok(changed) => changed,
             Err(err) => {

--- a/crates/ctx-history-store/src/bulk_search.rs
+++ b/crates/ctx-history-store/src/bulk_search.rs
@@ -29,7 +29,11 @@ const BULK_MODE_CRISISMERGE_KEY_PREFIX: &str = "event_search_bulk_mode_v1:crisis
 const FTS_AUTOMERGE_DEFAULT: i64 = 4;
 const FTS_CRISISMERGE_DEFAULT: i64 = 16;
 const FTS_BULK_CRISISMERGE: i64 = 1_000_000;
-const FTS_MERGE_PAGE_BUDGET: i64 = 1024;
+// FTS5's merge page budget is not a hard upper bound on WAL pages: merging a
+// large segment can rewrite substantially more data inside one statement.
+// Keep each step deliberately small so checkpoints remain safe on large real
+// indexes, not only on compact synthetic fixtures.
+const FTS_MERGE_PAGE_BUDGET: i64 = 16;
 const BULK_LOCK_SUFFIX: &str = ".event-search-bulk.lock.sqlite";
 
 /// Owns the cross-process lock for one event-search bulk operation.

--- a/crates/ctx-history-store/src/connection_tests.rs
+++ b/crates/ctx-history-store/src/connection_tests.rs
@@ -238,6 +238,127 @@ fn bulk_search_mode_crosses_crisis_threshold_without_automatic_merge() {
 }
 
 #[test]
+fn bulk_search_finish_preserves_preexisting_optimized_segment() {
+    let temp = tempdir();
+    let db_path = temp.path().join("work.sqlite");
+    let store = Store::open(&db_path).unwrap();
+
+    let first_guard = store.begin_event_search_bulk_mode().unwrap();
+    insert_bulk_search_events(&store, "historic", 80, 512);
+    store.finish_event_search_bulk_mode(&first_guard).unwrap();
+    drop(first_guard);
+    assert_eq!(event_search_segment_count(&store), 1);
+
+    let second_guard = store.begin_event_search_bulk_mode().unwrap();
+    insert_bulk_search_events(&store, "new", 20, 128);
+    assert_eq!(event_search_segment_count(&store), 21);
+    store.finish_event_search_bulk_mode(&second_guard).unwrap();
+
+    assert_eq!(
+        event_search_segment_count(&store),
+        2,
+        "finishing one provider import must not re-optimize the historical index"
+    );
+    assert_eq!(
+        store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM event_search WHERE event_search MATCH 'historic OR new'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        100
+    );
+}
+
+#[test]
+fn bulk_search_recovery_resumes_legacy_in_progress_full_merge() {
+    let temp = tempdir();
+    let db_path = temp.path().join("work.sqlite");
+    let store = Store::open(&db_path).unwrap();
+    let guard = store.begin_event_search_bulk_mode().unwrap();
+    insert_bulk_search_events(&store, "legacy-recovery", 40, 512);
+    store
+        .conn
+        .execute(
+            "INSERT INTO event_search(event_search, rank) VALUES ('merge', -1)",
+            [],
+        )
+        .unwrap();
+    store
+        .conn
+        .execute(
+            r#"
+            INSERT INTO search_projection_stats (key, value, updated_at_ms)
+            VALUES ('event_search_bulk_mode_v1:merge_started:event_search', 1, 0)
+            "#,
+            [],
+        )
+        .unwrap();
+    drop(store);
+    drop(guard);
+
+    let reopened = Store::open(&db_path).unwrap();
+    assert_eq!(bulk_mode_marker(&reopened), None);
+    assert_eq!(
+        reopened
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM search_projection_stats WHERE key LIKE 'event_search_bulk_mode_v1:%'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        reopened
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM event_search WHERE event_search MATCH 'legacy'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        40
+    );
+}
+
+fn insert_bulk_search_events(store: &Store, prefix: &str, count: usize, payload_words: usize) {
+    for index in 0..count {
+        store
+            .conn
+            .execute(
+                r#"
+                INSERT INTO event_search
+                (event_id, history_record_id, session_id, role, preview_text, rank_bucket)
+                VALUES (?1, NULL, NULL, 'user', ?2, 'message')
+                "#,
+                params![
+                    format!("{prefix}-event-{index}"),
+                    format!(
+                        "{prefix} token {index} {}",
+                        "payload ".repeat(payload_words)
+                    )
+                ],
+            )
+            .unwrap();
+    }
+}
+
+fn event_search_segment_count(store: &Store) -> i64 {
+    store
+        .conn
+        .query_row(
+            "SELECT COUNT(DISTINCT segid) FROM event_search_idx",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
+#[test]
 fn interrupted_bounded_merge_resumes_after_reopen() {
     let temp = tempdir();
     let db_path = temp.path().join("work.sqlite");


### PR DESCRIPTION
## What changed

- reduce each FTS5 merge step from 1,024 pages to 16 so physical WAL amplification remains safe on large indexes
- finish provider bulk-search mode with bounded positive merges instead of initiating an unnecessary full negative merge over historical segments
- preserve explicit full optimization behavior, now using the safer 16-page steps
- cover pre-populated Hermes imports, full clean multi-source setup through final optimization, legacy interrupted merge recovery, WAL bounds, integrity, searchability, and replay

## Root cause

Two behaviors combined in the failing setup path. Hermes bulk finalization initiated a full FTS5 merge over the shared historical event index, and the logical page budget was not a hard physical WAL bound. On the contributor exact interrupted 2.3 GiB database, a 1,024-page step reached a 7.0 GiB WAL. The 16-page step recovered the same database with a measured 14.3 MiB peak and zero final WAL.

## Impact

New provider finalization no longer re-optimizes historical search segments. Legacy in-progress full merges and explicit final optimization use smaller checkpointed steps. Source atomicity, crash markers, serialization, and strict checkpoint handling remain unchanged.

## Verification

- independent review: approved with no remaining P0, P1, or P2 findings after three passes, including the combined fix
- exact interrupted database: recovered in 1m52s with about 14.3 MiB peak WAL and zero final WAL
- cargo test -p ctx-history-store: 98 passed
- cargo test -p ctx-history-capture: 247 passed, one existing manual benchmark ignored
- cargo test -p ctx --test setup_sources_import: 38 passed
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- bash scripts/check-loc.sh