### PR TITLE
Avoid rescanning FTS rows during lexical search

### DIFF
--- a/crates/ctx-history-store/src/search/event_query.rs
+++ b/crates/ctx-history-store/src/search/event_query.rs
@@ -1,0 +1,112 @@
+use rusqlite::types::Value;
+
+pub(super) fn lexical_event_search_query(
+    match_clauses: Vec<String>,
+    limit: usize,
+    offset: usize,
+    prefer_conversation: bool,
+) -> (String, Vec<Value>) {
+    let mut values = Vec::<Value>::new();
+    let selects = match_clauses
+        .into_iter()
+        .enumerate()
+        .map(|(term_index, clause)| {
+            values.push(Value::Text(clause));
+            format!(
+                r#"SELECT event_search.event_id,
+                          event_search.history_record_id,
+                          event_search.session_id,
+                          event_search.role,
+                          event_search.preview_text,
+                          {term_index},
+                          bm25(event_search)
+                   FROM event_search
+                   WHERE event_search MATCH ?{}"#,
+                values.len()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" UNION ALL ");
+    values.push(Value::Integer(limit.max(1) as i64));
+    let limit_parameter = values.len();
+    values.push(Value::Integer(offset as i64));
+    let offset_parameter = values.len();
+    let sql = format!(
+        r#"
+        WITH matches(event_id, history_record_id, session_id, role, preview_text, term_index, score) AS MATERIALIZED (
+            {selects}
+        ),
+        ranked(event_id, history_record_id, session_id, role, preview_text, matched_terms, score) AS (
+            -- Projection maintenance keeps one row per event. Grouping only by the
+            -- canonical event key also collapses legacy duplicate result rows.
+            SELECT event_id,
+                   MIN(history_record_id),
+                   MIN(session_id),
+                   MIN(role),
+                   MIN(preview_text),
+                   COUNT(*),
+                   SUM(score)
+            FROM matches
+            GROUP BY event_id
+        )
+        {}
+        LIMIT ?{limit_parameter} OFFSET ?{offset_parameter}
+        "#,
+        event_search_hit_sql(
+            "ranked AS event_search",
+            &event_search_score("event_search.score", prefer_conversation),
+            "ORDER BY event_search.matched_terms DESC, search_score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
+        )
+    );
+    (sql, values)
+}
+
+pub(super) fn event_search_score(score_sql: &str, prefer_conversation: bool) -> String {
+    if prefer_conversation {
+        format!(
+            "CASE WHEN e.event_type IN ('message', 'summary') THEN ({score_sql}) - (ABS({score_sql}) * 0.15) ELSE ({score_sql}) END"
+        )
+    } else {
+        score_sql.to_owned()
+    }
+}
+
+pub(super) fn event_search_hit_sql(from_sql: &str, score_sql: &str, tail_sql: &str) -> String {
+    format!(
+        r#"
+        SELECT event_search.event_id,
+               COALESCE(e.history_record_id, event_search.history_record_id, s.history_record_id, rs.history_record_id),
+               COALESCE(e.session_id, event_search.session_id, s.id, rs.id),
+               e.run_id,
+               e.seq,
+               e.event_type,
+               e.role,
+               e.occurred_at_ms,
+               event_search.preview_text,
+               {score_sql} AS search_score,
+               COALESCE(s.provider, rs.provider, event_source.provider, session_source.provider, run_source.provider),
+               COALESCE(s.external_session_id, rs.external_session_id),
+               COALESCE(s.parent_session_id, rs.parent_session_id),
+               COALESCE(s.root_session_id, rs.root_session_id),
+               COALESCE(s.agent_type, rs.agent_type),
+               COALESCE(s.is_primary, rs.is_primary),
+               COALESCE(event_source.cwd, session_source.cwd, run_source.cwd),
+               COALESCE(event_source.raw_source_path, session_source.raw_source_path, run_source.raw_source_path),
+               e.payload_json,
+               COALESCE(event_source.metadata_json, session_source.metadata_json, run_source.metadata_json),
+               wr.title,
+               wr.kind,
+               wr.workspace
+        FROM {from_sql}
+        JOIN events e ON e.id = event_search.event_id
+        LEFT JOIN runs r ON r.id = e.run_id
+        LEFT JOIN sessions s ON s.id = COALESCE(e.session_id, event_search.session_id)
+        LEFT JOIN sessions rs ON rs.id = r.session_id
+        LEFT JOIN capture_sources event_source ON event_source.id = e.capture_source_id
+        LEFT JOIN capture_sources session_source ON session_source.id = COALESCE(s.capture_source_id, rs.capture_source_id)
+        LEFT JOIN capture_sources run_source ON run_source.id = r.source_id
+        LEFT JOIN history_records wr ON wr.id = COALESCE(e.history_record_id, event_search.history_record_id, s.history_record_id, rs.history_record_id, r.history_record_id)
+        {tail_sql}
+        "#
+    )
+}

--- a/crates/ctx-history-store/src/search/event_query_tests.rs
+++ b/crates/ctx-history-store/src/search/event_query_tests.rs
@@ -1,0 +1,151 @@
+use ctx_history_core::CaptureProvider;
+use rusqlite::{params, params_from_iter};
+use uuid::Uuid;
+
+use super::super::{event_query::lexical_event_search_query, projections::fts_match_clauses};
+use super::{local_preview_event, record_with_id, tempdir, with_occurred_at};
+use crate::Store;
+
+#[test]
+fn lexical_event_search_groups_projection_rows_by_event_and_preserves_hit_metadata() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let source_id = Uuid::parse_str("018f45d0-0000-7000-8000-000000090001").unwrap();
+    store
+        .conn
+        .execute(
+            r#"
+            INSERT INTO capture_sources
+            (id, kind, provider, machine_id, cwd, raw_source_path, source_format,
+             started_at_ms, fidelity, metadata_json)
+            VALUES (?1, 'provider_import', 'codex', 'test-machine', '/workspace/ctx',
+                    '/history/session.jsonl', 'codex_session_jsonl', 1, 'full', ?2)
+            "#,
+            params![
+                source_id.to_string(),
+                serde_json::json!({
+                    "source_metadata": {
+                        "ctx_history_plugin": {
+                            "plugin_name": "test-plugin",
+                            "plugin_source_id": "source-7",
+                            "history_source": "test-plugin/history"
+                        },
+                        "ctx_history_jsonl_v1": {
+                            "provider_key": "provider-7",
+                            "source_id": "source-7",
+                            "source_format": "test-jsonl"
+                        }
+                    }
+                })
+                .to_string(),
+            ],
+        )
+        .unwrap();
+
+    let record = record_with_id(
+        "018f45d0-0000-7000-8000-000000090002",
+        "Projection metadata title",
+        "Projection metadata body",
+    );
+    store.insert_record(&record).unwrap();
+    let mut event = local_preview_event(1, "projection duplicate oracle");
+    event.history_record_id = Some(record.id);
+    event.capture_source_id = Some(source_id);
+    event.payload = serde_json::json!({
+        "text": "projection duplicate oracle",
+        "cursor": "cursor-7"
+    });
+    store.upsert_event(&event).unwrap();
+
+    store
+        .conn
+        .execute(
+            r#"
+            INSERT INTO event_search
+            (event_id, history_record_id, session_id, role, preview_text, rank_bucket)
+            VALUES (?1, NULL, NULL, 'assistant',
+                    'projection duplicate oracle stale copy', 'message')
+            "#,
+            [event.id.to_string()],
+        )
+        .unwrap();
+
+    let hits = store
+        .search_event_hits("projection duplicate oracle", 10)
+        .unwrap();
+    assert_eq!(hits.len(), 1, "one event must produce one ranked hit");
+    let hit = &hits[0];
+    assert_eq!(hit.event_id, event.id);
+    assert_eq!(hit.history_record_id, Some(record.id));
+    assert_eq!(hit.preview, "projection duplicate oracle");
+    assert_eq!(hit.provider, Some(CaptureProvider::Codex));
+    assert_eq!(hit.history_source.as_deref(), Some("test-plugin/history"));
+    assert_eq!(hit.history_source_plugin.as_deref(), Some("test-plugin"));
+    assert_eq!(hit.provider_key.as_deref(), Some("provider-7"));
+    assert_eq!(hit.source_id.as_deref(), Some("source-7"));
+    assert_eq!(hit.source_format.as_deref(), Some("test-jsonl"));
+    assert_eq!(hit.cwd.as_deref(), Some("/workspace/ctx"));
+    assert_eq!(
+        hit.raw_source_path.as_deref(),
+        Some("/history/session.jsonl")
+    );
+    assert_eq!(hit.cursor.as_deref(), Some("cursor-7"));
+    assert_eq!(
+        hit.record_title.as_deref(),
+        Some("Projection metadata title")
+    );
+    assert_eq!(hit.record_kind.as_deref(), Some("task"));
+    assert_eq!(
+        hit.record_workspace.as_deref(),
+        Some("/workspace/multilingual")
+    );
+}
+
+#[test]
+fn lexical_event_search_pagination_is_a_stable_slice_of_ranked_results() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let events = [
+        with_occurred_at(local_preview_event(1, "paginationoracle"), 0),
+        with_occurred_at(local_preview_event(2, "paginationoracle"), 3),
+        with_occurred_at(local_preview_event(3, "paginationoracle"), 1),
+        with_occurred_at(local_preview_event(4, "paginationoracle"), 2),
+    ];
+    for event in events.iter().rev() {
+        store.upsert_event(event).unwrap();
+    }
+
+    let all = store.search_event_hits("paginationoracle", 10).unwrap();
+    let page = store
+        .search_event_hits_page("paginationoracle", 2, 1)
+        .unwrap();
+    assert_eq!(
+        all.iter().map(|hit| hit.event_id).collect::<Vec<_>>(),
+        vec![events[1].id, events[3].id, events[2].id, events[0].id]
+    );
+    assert_eq!(page, all[1..3]);
+}
+
+#[test]
+fn lexical_event_search_plan_scans_fts_once_per_match_clause() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let clauses = fts_match_clauses("planalpha planbeta");
+    let expected_scans = clauses.len();
+    let (sql, values) = lexical_event_search_query(clauses, 10, 0, false);
+    let mut stmt = store
+        .conn
+        .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+        .unwrap();
+    let details = stmt
+        .query_map(params_from_iter(values), |row| row.get::<_, String>(3))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+    let virtual_table_scans = details
+        .iter()
+        .filter(|detail| detail.contains("event_search VIRTUAL TABLE"))
+        .count();
+
+    assert_eq!(virtual_table_scans, expected_scans, "{details:#?}");
+}

--- a/crates/ctx-history-store/src/search/mod.rs
+++ b/crates/ctx-history-store/src/search/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod analyzer;
+mod event_query;
 pub(crate) mod projections;
 #[cfg(test)]
 mod tests;

--- a/crates/ctx-history-store/src/search/projections.rs
+++ b/crates/ctx-history-store/src/search/projections.rs
@@ -17,6 +17,9 @@ use crate::schema::ddl::{table_exists, table_has_column};
 use crate::search::analyzer::{
     lexical_query_terms, scriptgram_index_text, scriptgram_match_clauses,
 };
+use crate::search::event_query::{
+    event_search_hit_sql, event_search_score, lexical_event_search_query,
+};
 use crate::{Result, Store};
 
 const SEMANTIC_SEARCHABLE_ITEMS_STAT_KEY: &str = "semantic_searchable_lite_turn_items_v3";
@@ -141,6 +144,15 @@ impl Store {
             return Ok(Vec::new());
         }
 
+        if scriptgram_clauses.is_empty() {
+            return self.search_event_hits_page_lexical(
+                match_clauses,
+                limit,
+                offset,
+                prefer_conversation,
+            );
+        }
+
         let mut selects = Vec::new();
         let mut values = Vec::<Value>::new();
         for (term_index, clause) in match_clauses.into_iter().enumerate() {
@@ -191,6 +203,20 @@ impl Store {
                 "ORDER BY ranked.matched_terms DESC, search_score, e.occurred_at_ms DESC, e.seq DESC, event_search.event_id",
             )
         );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(values), event_search_hit_from_row)?;
+        collect_rows(rows)
+    }
+
+    fn search_event_hits_page_lexical(
+        &self,
+        match_clauses: Vec<String>,
+        limit: usize,
+        offset: usize,
+        prefer_conversation: bool,
+    ) -> Result<Vec<EventSearchHit>> {
+        let (sql, values) =
+            lexical_event_search_query(match_clauses, limit, offset, prefer_conversation);
         let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt.query_map(params_from_iter(values), event_search_hit_from_row)?;
         collect_rows(rows)
@@ -514,56 +540,6 @@ impl Store {
             )?;
         Ok(())
     }
-}
-
-fn event_search_score(score_sql: &str, prefer_conversation: bool) -> String {
-    if prefer_conversation {
-        format!(
-            "CASE WHEN e.event_type IN ('message', 'summary') THEN ({score_sql}) - (ABS({score_sql}) * 0.15) ELSE ({score_sql}) END"
-        )
-    } else {
-        score_sql.to_owned()
-    }
-}
-
-fn event_search_hit_sql(from_sql: &str, score_sql: &str, tail_sql: &str) -> String {
-    format!(
-        r#"
-        SELECT event_search.event_id,
-               COALESCE(e.history_record_id, event_search.history_record_id, s.history_record_id, rs.history_record_id),
-               COALESCE(e.session_id, event_search.session_id, s.id, rs.id),
-               e.run_id,
-               e.seq,
-               e.event_type,
-               e.role,
-               e.occurred_at_ms,
-               event_search.preview_text,
-               {score_sql} AS search_score,
-               COALESCE(s.provider, rs.provider, event_source.provider, session_source.provider, run_source.provider),
-               COALESCE(s.external_session_id, rs.external_session_id),
-               COALESCE(s.parent_session_id, rs.parent_session_id),
-               COALESCE(s.root_session_id, rs.root_session_id),
-               COALESCE(s.agent_type, rs.agent_type),
-               COALESCE(s.is_primary, rs.is_primary),
-               COALESCE(event_source.cwd, session_source.cwd, run_source.cwd),
-               COALESCE(event_source.raw_source_path, session_source.raw_source_path, run_source.raw_source_path),
-               e.payload_json,
-               COALESCE(event_source.metadata_json, session_source.metadata_json, run_source.metadata_json),
-               wr.title,
-               wr.kind,
-               wr.workspace
-        FROM {from_sql}
-        JOIN events e ON e.id = event_search.event_id
-        LEFT JOIN runs r ON r.id = e.run_id
-        LEFT JOIN sessions s ON s.id = COALESCE(e.session_id, event_search.session_id)
-        LEFT JOIN sessions rs ON rs.id = r.session_id
-        LEFT JOIN capture_sources event_source ON event_source.id = e.capture_source_id
-        LEFT JOIN capture_sources session_source ON session_source.id = COALESCE(s.capture_source_id, rs.capture_source_id)
-        LEFT JOIN capture_sources run_source ON run_source.id = r.source_id
-        LEFT JOIN history_records wr ON wr.id = COALESCE(e.history_record_id, event_search.history_record_id, s.history_record_id, rs.history_record_id, r.history_record_id)
-        {tail_sql}
-        "#
-    )
 }
 
 fn event_search_hit_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EventSearchHit> {

--- a/crates/ctx-history-store/src/search/tests.rs
+++ b/crates/ctx-history-store/src/search/tests.rs
@@ -11,6 +11,9 @@ use uuid::Uuid;
 
 use crate::Store;
 
+#[path = "event_query_tests.rs"]
+mod event_query_tests;
+
 fn tempdir() -> tempfile::TempDir {
     let root = std::env::var_os("TEST_TMPDIR")
         .map(|path| std::path::PathBuf::from(path).join("test-data"))


### PR DESCRIPTION
## What changed

- materialize lexical FTS matches once and rank that relation without rejoining the FTS5 virtual table
- group ranking strictly by canonical event ID while preserving projected hit metadata
- keep mixed/scriptgram search on its existing path
- extract event search SQL construction into a focused module
- add regressions for query-plan scan count, deterministic pagination, event grouping, and metadata/cursor preservation

## Why

After the bounded FTS recovery work, ordinary lexical search could still appear hung on a populated index. The ranking query materialized matches and then joined them back through `event_search`, causing another expensive FTS5 virtual-table scan. The lexical-only path now carries the projection data through the materialized match relation and never rescans FTS for hydration.

The final query relies on the store's maintained one-row-per-event projection invariant and uses one event-ID aggregation. An independent review rejected a defensive window-function variant after a live benchmark showed roughly 2x regression on a common term.

## Impact

Search semantics, ordering, pagination, hit metadata, cursors, and mixed-script behavior remain unchanged. On the contributor's 2.3 GiB database, the original fast path reduced repeated `ctx search Hermes --refresh off` runs to 0.70–1.03s. Independent review on a 1.26M-row FTS index found the hardened event-ID grouping within about 4% of the contributor query for a common two-clause query and 14% for a pathological single common term.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ctx-history-store --no-fail-fast` (101 passed)
- `cargo clippy -p ctx-history-store -p ctx --tests -- -D warnings`
- `cargo build -p ctx --release`
- `scripts/check-loc.sh`
- `git diff --check`
- independent code review with no blocking findings
