### PR TITLE
Skip unchanged native search refreshes

### DIFF
--- a/crates/ctx-cli/src/commands/import.rs
+++ b/crates/ctx-cli/src/commands/import.rs
@@ -9,7 +9,6 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use serde_json::{json, Value};
-use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use ctx_history_capture::{
@@ -92,8 +91,10 @@ use explicit::run_explicit_format_import;
 pub(crate) use inventory::{
     inventory_available_sources, inventory_import_sources, ImportInventory,
 };
-pub(crate) use native::import_one_source_without_search_refresh;
 use native::{import_one_source, validate_source_import_supported};
+pub(crate) use native::{
+    import_one_source_for_search_refresh, import_one_source_without_search_refresh,
+};
 use report::{
     custom_format_import_json, history_source_plugin_failure_json,
     history_source_plugin_import_json, import_error_is_systemic, low_disk_space_warning,
@@ -255,6 +256,7 @@ impl SourcePreinventory {
 pub(crate) struct SourceStats {
     pub(crate) files: usize,
     pub(crate) bytes: u64,
+    pub(crate) change_token: Option<[u8; 32]>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/ctx-cli/src/commands/import/catalog.rs
+++ b/crates/ctx-cli/src/commands/import/catalog.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::commands::import::manifest::collect_source_import_paths;
 use crate::commands::import::native::merge_provider_import_summary;
+use sha2::{Digest, Sha256};
 
 pub(crate) fn system_time_ms(time: SystemTime) -> i64 {
     time.duration_since(UNIX_EPOCH)
@@ -346,17 +347,56 @@ pub(crate) fn source_uses_incremental_event_search(source: &SourceInfo) -> bool 
 pub(crate) fn source_stats(path: &Path) -> Result<SourceStats> {
     let metadata = fs::symlink_metadata(path)
         .with_context(|| format!("stat import source {}", path.display()))?;
+    let mut stats = SourceStats::default();
+    let mut change_entries = Vec::new();
     if metadata.file_type().is_file() {
-        return Ok(SourceStats {
-            files: 1,
-            bytes: metadata.len(),
-        });
+        add_source_stat(
+            &mut stats,
+            &mut change_entries,
+            path.parent().unwrap_or(path),
+            path,
+            &metadata,
+            true,
+            true,
+        );
+        // WAL and rollback-journal files can hold committed changes that have
+        // not reached the main database. The shared-memory file is excluded
+        // because read-only SQLite clients may update it.
+        for suffix in ["-wal", "-journal"] {
+            let mut sidecar = path.as_os_str().to_os_string();
+            sidecar.push(suffix);
+            let sidecar = PathBuf::from(sidecar);
+            match fs::symlink_metadata(&sidecar) {
+                Ok(metadata) if metadata.file_type().is_file() => add_source_stat(
+                    &mut stats,
+                    &mut change_entries,
+                    path.parent().unwrap_or(path),
+                    &sidecar,
+                    &metadata,
+                    false,
+                    true,
+                ),
+                Ok(_) => {
+                    return Err(anyhow!(
+                        "import source sidecar is not a regular file: {}",
+                        sidecar.display()
+                    ))
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("stat import source sidecar {}", sidecar.display())
+                    })
+                }
+            }
+        }
+        stats.change_token = Some(source_change_token(change_entries));
+        return Ok(stats);
     }
     if !metadata.file_type().is_dir() {
         return Ok(SourceStats::default());
     }
 
-    let mut stats = SourceStats::default();
     let mut stack = vec![path.to_path_buf()];
     while let Some(dir) = stack.pop() {
         for entry in fs::read_dir(&dir)
@@ -374,12 +414,74 @@ pub(crate) fn source_stats(path: &Path) -> Result<SourceStats> {
                 let metadata = entry
                     .metadata()
                     .with_context(|| format!("stat import source file {}", entry_path.display()))?;
-                stats.files += 1;
-                stats.bytes = stats.bytes.saturating_add(metadata.len());
+                let include_in_token = !entry_path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with("-shm"));
+                add_source_stat(
+                    &mut stats,
+                    &mut change_entries,
+                    path,
+                    &entry_path,
+                    &metadata,
+                    true,
+                    include_in_token,
+                );
             }
         }
     }
+    stats.change_token = Some(source_change_token(change_entries));
     Ok(stats)
+}
+
+struct SourceChangeEntry {
+    path: PathBuf,
+    len: u64,
+    modified_secs: u64,
+    modified_nanos: u32,
+}
+
+fn add_source_stat(
+    stats: &mut SourceStats,
+    change_entries: &mut Vec<SourceChangeEntry>,
+    base: &Path,
+    path: &Path,
+    metadata: &fs::Metadata,
+    include_in_totals: bool,
+    include_in_token: bool,
+) {
+    if include_in_totals {
+        stats.files += 1;
+        stats.bytes = stats.bytes.saturating_add(metadata.len());
+    }
+    if !include_in_token {
+        return;
+    }
+    let modified = metadata
+        .modified()
+        .unwrap_or(UNIX_EPOCH)
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    change_entries.push(SourceChangeEntry {
+        path: path.strip_prefix(base).unwrap_or(path).to_path_buf(),
+        len: metadata.len(),
+        modified_secs: modified.as_secs(),
+        modified_nanos: modified.subsec_nanos(),
+    });
+}
+
+fn source_change_token(mut entries: Vec<SourceChangeEntry>) -> [u8; 32] {
+    entries.sort_by(|left, right| left.path.cmp(&right.path));
+    let mut hasher = Sha256::new();
+    for entry in entries {
+        let path = entry.path.as_os_str().as_encoded_bytes();
+        hasher.update((path.len() as u64).to_le_bytes());
+        hasher.update(path);
+        hasher.update(entry.len.to_le_bytes());
+        hasher.update(entry.modified_secs.to_le_bytes());
+        hasher.update(entry.modified_nanos.to_le_bytes());
+    }
+    hasher.finalize().into()
 }
 
 pub(crate) fn source_import_stats(source: &SourceInfo) -> Result<SourceStats> {

--- a/crates/ctx-cli/src/commands/import/inventory.rs
+++ b/crates/ctx-cli/src/commands/import/inventory.rs
@@ -99,6 +99,7 @@ fn inventory_import_source(
         let stats = SourceStats {
             files: summary.source_files,
             bytes: summary.source_bytes,
+            change_token: None,
         };
         let plan = PlannedImportSource {
             source,
@@ -172,6 +173,7 @@ fn source_stats_from_import_files(files: &[SourceImportFile]) -> SourceStats {
         bytes: files.iter().fold(0_u64, |bytes, file| {
             bytes.saturating_add(file.file_size_bytes)
         }),
+        change_token: None,
     }
 }
 
@@ -189,6 +191,13 @@ fn source_root_import_file(source: &SourceInfo, stats: SourceStats) -> Result<So
         metadata: json!({
             "inventory_unit": "source_root",
             "source_files": stats.files,
+            "change_token_v1": stats
+                .change_token
+                .unwrap_or_default()
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<Vec<_>>()
+                .join(""),
         }),
     })
 }

--- a/crates/ctx-cli/src/commands/import/native.rs
+++ b/crates/ctx-cli/src/commands/import/native.rs
@@ -60,6 +60,35 @@ pub(crate) fn import_one_source_without_search_refresh(
     )
 }
 
+pub(crate) fn import_one_source_for_search_refresh(
+    store: &mut Store,
+    source: &SourceInfo,
+    progress: Option<CodexSessionImportProgressCallback>,
+    allow_partial_failures: bool,
+    preinventory: &SourcePreinventory,
+) -> Result<ProviderImportSummary> {
+    if !source_uses_import_file_manifest(source)
+        && preinventory.source_root_file().is_some()
+        && store
+            .list_pending_source_import_files(source.provider, &source.path.display().to_string())?
+            .is_empty()
+    {
+        store.upsert_record(&import_record_for_source(source))?;
+        if store.event_search_projection_needs_backfill()? {
+            store.refresh_search_index()?;
+        }
+        return Ok(ProviderImportSummary::default());
+    }
+    import_one_source_without_search_refresh(
+        store,
+        source,
+        progress,
+        false,
+        allow_partial_failures,
+        preinventory,
+    )
+}
+
 pub(crate) fn import_one_source_inner(
     store: &mut Store,
     source: &SourceInfo,
@@ -856,3 +885,7 @@ pub(crate) fn merge_provider_import_summary(
     summary.skipped_edges += other.skipped_edges;
     summary.failures.extend(other.failures);
 }
+
+#[cfg(test)]
+#[path = "native_tests.rs"]
+mod tests;

--- a/crates/ctx-cli/src/commands/import/native_tests.rs
+++ b/crates/ctx-cli/src/commands/import/native_tests.rs
@@ -1,0 +1,178 @@
+use super::*;
+use crate::provider_sources::explicit_path_source;
+use ctx_history_core::{
+    new_id, Event, EventRole, EventType, Fidelity, SyncMetadata, SyncState, Visibility,
+};
+use ctx_history_store::{SourceImportFile, SourceImportFileIndexUpdate};
+use serde_json::json;
+
+fn persist_indexed_root(
+    store: &Store,
+    source: &SourceInfo,
+    file_size_bytes: u64,
+    file_modified_at_ms: i64,
+) -> SourceImportFile {
+    let source_root = source.path.display().to_string();
+    let file = SourceImportFile {
+        provider: source.provider,
+        source_format: source.source_format.to_owned(),
+        source_root: source_root.clone(),
+        source_path: source_root.clone(),
+        file_size_bytes,
+        file_modified_at_ms,
+        observed_at_ms: 0,
+        metadata: json!({}),
+    };
+    store
+        .upsert_source_import_files(std::slice::from_ref(&file))
+        .unwrap();
+    store
+        .mark_source_import_file_indexed(
+            source.provider,
+            SourceImportFileIndexUpdate {
+                source_root: &source_root,
+                source_path: &source_root,
+                file_size_bytes,
+                file_modified_at_ms,
+                indexed_at_ms: 1,
+            },
+        )
+        .unwrap();
+    file
+}
+
+#[test]
+fn unchanged_root_source_skips_provider_normalization() {
+    let temp = tempfile::tempdir().unwrap();
+    let source_path = temp.path().join("state.db");
+    let source = explicit_path_source(CaptureProvider::Hermes, source_path.clone());
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let file = persist_indexed_root(&store, &source, 0, 0);
+
+    let summary = import_one_source_for_search_refresh(
+        &mut store,
+        &source,
+        None,
+        true,
+        &SourcePreinventory::SourceRoot(file),
+    )
+    .unwrap();
+
+    assert_eq!(summary.imported_events, 0);
+    assert_eq!(summary.failed, 0);
+}
+
+#[test]
+fn unchanged_root_source_still_repairs_event_search_backfill() {
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("work.sqlite");
+    let source_path = temp.path().join("state.db");
+    let source = explicit_path_source(CaptureProvider::Hermes, source_path);
+    let store = Store::open(&db_path).unwrap();
+    let file = persist_indexed_root(&store, &source, 0, 0);
+    let event = Event {
+        id: new_id(),
+        seq: 1,
+        history_record_id: None,
+        session_id: None,
+        run_id: None,
+        event_type: EventType::Message,
+        role: Some(EventRole::User),
+        occurred_at: utc_now(),
+        capture_source_id: None,
+        payload: json!({"text": "unchanged root backfill oracle"}),
+        payload_blob_id: None,
+        dedupe_key: None,
+        sync: SyncMetadata {
+            visibility: Visibility::LocalOnly,
+            fidelity: Fidelity::Imported,
+            sync_state: SyncState::LocalOnly,
+            sync_version: 0,
+            deleted_at: None,
+            metadata: json!({}),
+        },
+    };
+    store.upsert_event(&event).unwrap();
+    drop(store);
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute("DELETE FROM event_search", []).unwrap();
+    drop(conn);
+    let mut store = Store::open(&db_path).unwrap();
+    assert!(store.event_search_projection_needs_backfill().unwrap());
+
+    import_one_source_for_search_refresh(
+        &mut store,
+        &source,
+        None,
+        true,
+        &SourcePreinventory::SourceRoot(file),
+    )
+    .unwrap();
+
+    assert!(!store.event_search_projection_needs_backfill().unwrap());
+    assert_eq!(
+        store
+            .search_event_hits("unchanged root backfill oracle", 10)
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn changed_root_source_does_not_skip_provider_normalization() {
+    let temp = tempfile::tempdir().unwrap();
+    let source_path = temp.path().join("state.db");
+    let source = explicit_path_source(CaptureProvider::Hermes, source_path.clone());
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    persist_indexed_root(&store, &source, 0, 0);
+    std::fs::write(&source_path, b"not a sqlite database").unwrap();
+    let changed = SourceImportFile {
+        provider: source.provider,
+        source_format: source.source_format.to_owned(),
+        source_root: source_path.display().to_string(),
+        source_path: source_path.display().to_string(),
+        file_size_bytes: 21,
+        file_modified_at_ms: 1,
+        observed_at_ms: 1,
+        metadata: json!({}),
+    };
+    store
+        .upsert_source_import_files(std::slice::from_ref(&changed))
+        .unwrap();
+
+    let result = import_one_source_for_search_refresh(
+        &mut store,
+        &source,
+        None,
+        true,
+        &SourcePreinventory::SourceRoot(changed),
+    );
+
+    assert!(
+        result.is_err(),
+        "changed source must reach the Hermes adapter"
+    );
+}
+
+#[test]
+fn full_rescan_does_not_skip_unchanged_root_source() {
+    let temp = tempfile::tempdir().unwrap();
+    let source_path = temp.path().join("state.db");
+    std::fs::write(&source_path, b"not a sqlite database").unwrap();
+    let source = explicit_path_source(CaptureProvider::Hermes, source_path);
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let file = persist_indexed_root(&store, &source, 21, 1);
+
+    let result = import_one_source_inner(
+        &mut store,
+        &source,
+        None,
+        false,
+        true,
+        true,
+        &SourcePreinventory::SourceRoot(file),
+    );
+
+    assert!(result.is_err(), "full rescan must reach the Hermes adapter");
+}

--- a/crates/ctx-cli/src/commands/import/requests.rs
+++ b/crates/ctx-cli/src/commands/import/requests.rs
@@ -215,6 +215,7 @@ pub(crate) fn import_history_source_plugin(
     let stats = SourceStats {
         files: 1,
         bytes: stdout.len() as u64,
+        change_token: None,
     };
     store.upsert_record(&record)?;
     let summary = import_custom_history_jsonl_v1_reader(

--- a/crates/ctx-cli/src/commands/search.rs
+++ b/crates/ctx-cli/src/commands/search.rs
@@ -18,7 +18,7 @@ use ctx_history_store::Store;
 
 use crate::analytics::AnalyticsProperties;
 use crate::commands::import::{
-    error_summary, import_history_source_plugin, import_one_source_without_search_refresh,
+    error_summary, import_history_source_plugin, import_one_source_for_search_refresh,
     import_totals_json, inventory_import_sources, one_line_error, should_parallelize_import,
     ImportSourceOutcome, ImportTotals, SourceStats,
 };
@@ -568,11 +568,10 @@ pub(crate) fn refresh_sources_for_search(
                 );
                 thread::spawn(move || -> Result<ImportSourceOutcome> {
                     let mut store = Store::open(&db_path)?;
-                    let summary = import_one_source_without_search_refresh(
+                    let summary = import_one_source_for_search_refresh(
                         &mut store,
                         &plan.source,
                         progress_callback,
-                        false,
                         allow_partial_failures,
                         &plan.preinventory,
                     )?;
@@ -621,11 +620,10 @@ pub(crate) fn refresh_sources_for_search(
             let source_progress =
                 progress.codex_import_callback(&plan.source, completed_source_bytes);
             completed_source_bytes = completed_source_bytes.saturating_add(plan.stats.bytes);
-            let import_result = import_one_source_without_search_refresh(
+            let import_result = import_one_source_for_search_refresh(
                 &mut store,
                 &plan.source,
                 source_progress,
-                false,
                 allow_partial_failures,
                 &plan.preinventory,
             );

--- a/crates/ctx-cli/tests/search_refresh.rs
+++ b/crates/ctx-cli/tests/search_refresh.rs
@@ -882,6 +882,79 @@ fn search_refresh_auto_imports_discovered_top_provider_sources() {
 }
 
 #[test]
+fn search_refresh_hermes_root_inventory_skips_unchanged_and_detects_wal_only_append() {
+    let temp = tempdir();
+    let initial = "hermes-root-inventory-initial-oracle";
+    let appended = "hermes-root-inventory-appended-oracle";
+    install_default_hermes_fixture(&temp, initial);
+    let source = temp.path().join(".hermes/state.db");
+    let writer = Connection::open(&source).unwrap();
+    let journal_mode: String = writer
+        .query_row("PRAGMA journal_mode = WAL", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(journal_mode, "wal");
+    writer
+        .execute_batch("PRAGMA wal_autocheckpoint = 0")
+        .unwrap();
+
+    let first = json_output(ctx(&temp).args([
+        "search",
+        initial,
+        "--provider",
+        "hermes",
+        "--refresh",
+        "wait",
+        "--json",
+    ]));
+    assert_search_provider_oracle(&first, "hermes", initial, 1, "message");
+
+    let unchanged = json_output(ctx(&temp).args([
+        "search",
+        initial,
+        "--provider",
+        "hermes",
+        "--refresh",
+        "wait",
+        "--json",
+    ]));
+    assert_eq!(unchanged["freshness"]["totals"]["imported_events"], 0);
+
+    let main_before = fs::metadata(&source).unwrap();
+    writer
+        .execute(
+            "INSERT INTO messages (session_id, role, content, timestamp)
+             VALUES (?1, 'user', ?2, 1782259203.0)",
+            ["hermes-cli-native", appended],
+        )
+        .unwrap();
+    assert!(source.with_extension("db-wal").is_file());
+    let main_after = fs::metadata(&source).unwrap();
+    assert_eq!(main_after.len(), main_before.len());
+    assert_eq!(
+        main_after.modified().unwrap(),
+        main_before.modified().unwrap()
+    );
+
+    let refreshed = json_output(ctx(&temp).args([
+        "search",
+        appended,
+        "--provider",
+        "hermes",
+        "--refresh",
+        "wait",
+        "--json",
+    ]));
+    assert_search_provider_oracle(&refreshed, "hermes", appended, 1, "message");
+    assert!(
+        refreshed["freshness"]["totals"]["imported_events"]
+            .as_u64()
+            .unwrap()
+            >= 1
+    );
+    drop(writer);
+}
+
+#[test]
 fn search_refresh_wait_json_emits_progress_on_stderr() {
     let temp = tempdir();
     let fixture = PathBuf::from(provider_history_fixture("codex-sessions"));

--- a/crates/ctx-history-store/src/catalog.rs
+++ b/crates/ctx-history-store/src/catalog.rs
@@ -530,32 +530,47 @@ impl Store {
                     observed_at_ms = excluded.observed_at_ms,
                     is_stale = 0,
                     indexed_at_ms = CASE
-                        WHEN source_import_files.file_size_bytes = excluded.file_size_bytes
+                        WHEN source_import_files.source_format IS excluded.source_format
+                         AND source_import_files.file_size_bytes = excluded.file_size_bytes
                          AND source_import_files.file_modified_at_ms = excluded.file_modified_at_ms
+                         AND (json_extract(excluded.metadata_json, '$.inventory_unit') IS NOT 'source_root'
+                              OR source_import_files.metadata_json IS excluded.metadata_json)
                         THEN source_import_files.indexed_at_ms
                         ELSE NULL
                     END,
                     indexed_file_size_bytes = CASE
-                        WHEN source_import_files.file_size_bytes = excluded.file_size_bytes
+                        WHEN source_import_files.source_format IS excluded.source_format
+                         AND source_import_files.file_size_bytes = excluded.file_size_bytes
                          AND source_import_files.file_modified_at_ms = excluded.file_modified_at_ms
+                         AND (json_extract(excluded.metadata_json, '$.inventory_unit') IS NOT 'source_root'
+                              OR source_import_files.metadata_json IS excluded.metadata_json)
                         THEN source_import_files.indexed_file_size_bytes
                         ELSE NULL
                     END,
                     indexed_file_modified_at_ms = CASE
-                        WHEN source_import_files.file_size_bytes = excluded.file_size_bytes
+                        WHEN source_import_files.source_format IS excluded.source_format
+                         AND source_import_files.file_size_bytes = excluded.file_size_bytes
                          AND source_import_files.file_modified_at_ms = excluded.file_modified_at_ms
+                         AND (json_extract(excluded.metadata_json, '$.inventory_unit') IS NOT 'source_root'
+                              OR source_import_files.metadata_json IS excluded.metadata_json)
                         THEN source_import_files.indexed_file_modified_at_ms
                         ELSE NULL
                     END,
                     indexed_status = CASE
-                        WHEN source_import_files.file_size_bytes = excluded.file_size_bytes
+                        WHEN source_import_files.source_format IS excluded.source_format
+                         AND source_import_files.file_size_bytes = excluded.file_size_bytes
                          AND source_import_files.file_modified_at_ms = excluded.file_modified_at_ms
+                         AND (json_extract(excluded.metadata_json, '$.inventory_unit') IS NOT 'source_root'
+                              OR source_import_files.metadata_json IS excluded.metadata_json)
                         THEN source_import_files.indexed_status
                         ELSE 'pending'
                     END,
                     indexed_error = CASE
-                        WHEN source_import_files.file_size_bytes = excluded.file_size_bytes
+                        WHEN source_import_files.source_format IS excluded.source_format
+                         AND source_import_files.file_size_bytes = excluded.file_size_bytes
                          AND source_import_files.file_modified_at_ms = excluded.file_modified_at_ms
+                         AND (json_extract(excluded.metadata_json, '$.inventory_unit') IS NOT 'source_root'
+                              OR source_import_files.metadata_json IS excluded.metadata_json)
                         THEN source_import_files.indexed_error
                         ELSE NULL
                     END,

--- a/crates/ctx-history-store/src/catalog/tests.rs
+++ b/crates/ctx-history-store/src/catalog/tests.rs
@@ -782,6 +782,106 @@ fn source_import_manifest_upsert_ignores_observed_at_for_unchanged_files() {
 }
 
 #[test]
+fn source_root_inventory_change_token_marks_same_stat_source_pending() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let observed_at_ms = timestamp_ms(fixed_time());
+    let root = "/home/user/.hermes/state.db";
+    let mut file = SourceImportFile {
+        provider: CaptureProvider::Hermes,
+        source_format: "hermes_state_sqlite".into(),
+        source_root: root.into(),
+        source_path: root.into(),
+        file_size_bytes: 42,
+        file_modified_at_ms: observed_at_ms,
+        observed_at_ms,
+        metadata: serde_json::json!({
+            "inventory_unit": "source_root",
+            "source_files": 1,
+            "change_token_v1": "before",
+        }),
+    };
+    store
+        .upsert_source_import_files(std::slice::from_ref(&file))
+        .unwrap();
+    store
+        .mark_source_import_file_indexed(
+            CaptureProvider::Hermes,
+            SourceImportFileIndexUpdate {
+                source_root: root,
+                source_path: root,
+                file_size_bytes: file.file_size_bytes,
+                file_modified_at_ms: file.file_modified_at_ms,
+                indexed_at_ms: observed_at_ms + 1,
+            },
+        )
+        .unwrap();
+    assert!(store
+        .list_pending_source_import_files(CaptureProvider::Hermes, root)
+        .unwrap()
+        .is_empty());
+
+    file.metadata["change_token_v1"] = serde_json::json!("after");
+    file.observed_at_ms += 1;
+    store
+        .upsert_source_import_files(std::slice::from_ref(&file))
+        .unwrap();
+
+    assert_eq!(
+        store
+            .list_pending_source_import_files(CaptureProvider::Hermes, root)
+            .unwrap(),
+        vec![file]
+    );
+}
+
+#[test]
+fn source_import_format_change_marks_same_stat_source_pending() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let observed_at_ms = timestamp_ms(fixed_time());
+    let root = "/home/user/agent/state.db";
+    let mut file = SourceImportFile {
+        provider: CaptureProvider::Custom,
+        source_format: "old_format".into(),
+        source_root: root.into(),
+        source_path: root.into(),
+        file_size_bytes: 42,
+        file_modified_at_ms: observed_at_ms,
+        observed_at_ms,
+        metadata: serde_json::json!({}),
+    };
+    store
+        .upsert_source_import_files(std::slice::from_ref(&file))
+        .unwrap();
+    store
+        .mark_source_import_file_indexed(
+            CaptureProvider::Custom,
+            SourceImportFileIndexUpdate {
+                source_root: root,
+                source_path: root,
+                file_size_bytes: file.file_size_bytes,
+                file_modified_at_ms: file.file_modified_at_ms,
+                indexed_at_ms: observed_at_ms + 1,
+            },
+        )
+        .unwrap();
+
+    file.source_format = "new_format".into();
+    file.observed_at_ms += 1;
+    store
+        .upsert_source_import_files(std::slice::from_ref(&file))
+        .unwrap();
+
+    assert_eq!(
+        store
+            .list_pending_source_import_files(CaptureProvider::Custom, root)
+            .unwrap(),
+        vec![file]
+    );
+}
+
+#[test]
 fn source_import_file_counts_track_pending_indexed_failed_and_stale() {
     let temp = tempdir();
     let store = Store::open(temp.path().join("work.sqlite")).unwrap();


### PR DESCRIPTION
## What changed

- skip provider normalization during automatic search refresh when a non-manifest native root is already indexed and unchanged
- keep explicit imports, full rescans, and their existing summaries/semantics unchanged
- compute root statistics and a deterministic freshness token in one filesystem traversal
- include SQLite WAL and rollback-journal metadata while excluding reader-mutated shared memory
- invalidate indexed inventory when the root token or source format changes
- preserve event-search backfill even when provider normalization is skipped

## Why

Automatic search refresh was repeatedly normalizing unchanged native roots after inventory had already marked them indexed. For large live sources such as Hermes, OpenCode, and OpenClaw, that meant rereading hundreds of MiB before event deduplication could prove there was no work.

The contributor's initial root size/mtime fast path was too broad: full CLI testing showed that it changed explicit-import summary behavior and could miss rapid same-size SQLite updates. The final design limits the optimization to search refresh and uses a nanosecond-resolution metadata token over tree entries plus SQLite WAL/journal sidecars. Existing inventory rows perform one conservative reimport to acquire the new token.

## Impact

Unchanged search refreshes avoid provider parsing and return immediately after cheap inventory work. Changed roots, WAL-only commits, pending/failed inventory, source-format changes, explicit imports, and full rescans still run the adapter normally. Search projection repair remains automatic.

On the contributor's live host, the earlier fast path reduced repeated plain Hermes search to 1.11s with no WAL. This hardened version preserves that architecture while closing the stale-index and product-semantics gaps found in review.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ctx-history-store --no-fail-fast` (103 passed)
- `cargo test -p ctx --no-fail-fast` (all unit and integration targets passed)
- `cargo test -p ctx-history-capture --no-fail-fast` (242 passed, 1 manual perf test ignored; 5 integration tests passed)
- `cargo clippy -p ctx-history-store -p ctx --tests -- -D warnings`
- `cargo build -p ctx --release`
- `scripts/check-loc.sh`
- `git diff --check`
- WAL-only Hermes regression proves the main DB size/mtime remain unchanged while refresh detects the committed event
- two independent code-review passes; final pass found no blockers and high merge confidence
