### PR TITLE
Prepare ctx 0.25.0 release candidate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "ctx"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-capture"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-core"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "chrono",
  "directories",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-search"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "chrono",
  "ctx-history-core",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "ctx-history-store"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "chrono",
  "ctx-history-core",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1608,16 +1608,16 @@
         "usagesDigest": "trZT1wMYy/tgV92a1ogDlCDavOm0R9plXCfxm6DTWdw=",
         "recordedFileInputs": {
           "@@//crates/ctx-sdk/Cargo.toml": "36d7b44b8415faf5a6b81989f92d421ad145f43a8bf822a08599ebf5c56b2b2c",
-          "@@//crates/ctx-cli/Cargo.toml": "0bcb9ca9f60165ffd2c015465848baad1ea2b2dfe9c59ca8380fc331a7efa5d0",
-          "@@//crates/ctx-history-core/Cargo.toml": "b96429c1c01bc372c165697d51c62c814f1d9f5b3f78df538f8eca42239b105a",
+          "@@//crates/ctx-cli/Cargo.toml": "6e7b9f55b350908f34bdf0141e62a901de90903b9315bec459981f289107b29b",
+          "@@//crates/ctx-history-core/Cargo.toml": "703e44fa36843a0a0633425af4602a60a258baf983a553774c4f891cefc5a9e7",
           "@@//Cargo.toml": "7a3a1444da31713b8c336c96f5150248704bb412b3adc47154097c7976af9d76",
-          "@@//Cargo.lock": "70454baa619853acffbf961db28d8c07628a90150c8d2084c88051f9db39e159",
+          "@@//Cargo.lock": "0aafa94ab10f0747c5ebcce645a9bb81daacbecaaacfd668bec13eaf3cb8f9b2",
           "@@//crates/ctx-protocol/Cargo.toml": "e9e75a7c7ca116f86e58ee0e09d174612607c8c45cce0213e66825e403046bce",
-          "@@//crates/ctx-history-store/Cargo.toml": "082c0a34d1ac15f957d43b582c80b868be113a80bf648475b3172b40699b82e1",
+          "@@//crates/ctx-history-store/Cargo.toml": "ef7d57054308ada6f83bb9dd19bfc4245c3ad9e8e6e2e2c34c42183eb0d67bd1",
           "@@//MODULE.bazel": "21385b2234d0b74abc07e1c465d9cb4c9abed0ec4605fabe212a2148583bb295",
           "@@rules_rust~~rust_host_tools~rust_host_tools//rust_host_tools": "ENOENT",
-          "@@//crates/ctx-history-search/Cargo.toml": "0453edbe6568f321cbe47d7eaabdacb619df575bcb832fbd3b3224f58554cf53",
-          "@@//crates/ctx-history-capture/Cargo.toml": "3812ff4f4e7f257c8856ecbd5f719059c164bcf53e73da551898fccf5226efec"
+          "@@//crates/ctx-history-search/Cargo.toml": "b2015a95487147b52f60361594a53a26b497188912355e901ff298e96bd835c3",
+          "@@//crates/ctx-history-capture/Cargo.toml": "e47247aa8032e96ae8916d10d61e82ac3df09aba52715ae3b3526244ec329266"
         },
         "recordedDirentsInputs": {},
         "envVariables": {

--- a/crates/ctx-cli/Cargo.toml
+++ b/crates/ctx-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx"
-version = "0.24.0"
+version = "0.25.0"
 description = "Local CLI for indexing and searching agent session history"
 edition.workspace = true
 autobins = false

--- a/crates/ctx-history-capture/Cargo.toml
+++ b/crates/ctx-history-capture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-capture"
-version = "0.24.0"
+version = "0.25.0"
 description = "Internal provider import adapters for ctx local agent history"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-core/Cargo.toml
+++ b/crates/ctx-history-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-core"
-version = "0.24.0"
+version = "0.25.0"
 description = "Internal core types for ctx local agent history indexing"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-search/Cargo.toml
+++ b/crates/ctx-history-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-search"
-version = "0.24.0"
+version = "0.25.0"
 description = "Internal search projection and ranking helpers for ctx"
 edition.workspace = true
 license.workspace = true

--- a/crates/ctx-history-store/Cargo.toml
+++ b/crates/ctx-history-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctx-history-store"
-version = "0.24.0"
+version = "0.25.0"
 description = "Internal SQLite storage layer for ctx local agent history"
 edition.workspace = true
 license.workspace = true

--- a/docs/unmanaged-installs.md
+++ b/docs/unmanaged-installs.md
@@ -73,8 +73,8 @@ https://github.com/ctxrs/ctx/releases/download/vVERSION/ASSET
 For example:
 
 ```text
-https://github.com/ctxrs/ctx/releases/download/v0.24.0/ctx-linux-x64
-https://github.com/ctxrs/ctx/releases/download/v0.24.0/SHA256SUMS
+https://github.com/ctxrs/ctx/releases/download/v0.25.0/ctx-linux-x64
+https://github.com/ctxrs/ctx/releases/download/v0.25.0/SHA256SUMS
 ```
 
 ## Direct GitHub Download
@@ -116,7 +116,7 @@ mise use -g 'github:ctxrs/ctx[bin=ctx]@latest'
 For a pinned install, replace `latest` with a release version:
 
 ```bash
-mise use -g 'github:ctxrs/ctx[bin=ctx]@0.24.0'
+mise use -g 'github:ctxrs/ctx[bin=ctx]@0.25.0'
 ```
 
 mise owns upgrades for this install. Re-run `ctx integrations install skills` after upgrading

--- a/scripts/real-harness-codex-skill-e2e.sh
+++ b/scripts/real-harness-codex-skill-e2e.sh
@@ -136,12 +136,12 @@ main() {
 
   require_contains "${stdout_file}" 'fixture-ctx-skill-ok'
   require_contains "${stderr_file}" "/bin/bash -lc 'ctx --version'"
-  require_contains "${stderr_file}" 'ctx 0.24.0'
+  require_contains "${stderr_file}" 'ctx 0.25.0'
   require_contains "${log_file}" '"has_ctx_skill":true'
   require_contains "${log_file}" '"has_ctx_skill_description":true'
   require_contains "${log_file}" '"has_ctx_skill_path":true'
   require_contains "${log_file}" '"call_id":"call_ctx_version"'
-  require_contains "${log_file}" 'ctx 0.24.0'
+  require_contains "${log_file}" 'ctx 0.25.0'
 
   printf 'real Codex skill harness E2E passed: %s\n' "${run_root}"
 }


### PR DESCRIPTION
## Summary

- bump the public CLI and runtime crate set from 0.24.0 to 0.25.0
- refresh Cargo and Bazel dependency metadata for the new manifest versions
- update unmanaged-install examples and the pinned Codex skill harness expectation

## Validation

- `cargo metadata --no-deps --format-version 1 --locked`
- `bazel mod tidy`
- exact checked-in Buildkite public-smoke set: 12/12 passed
- release signing tests, native candidate smoke, installer smoke, release compatibility, docs, formatting, package audit, and source-diff checks all passed

This PR prepares the immutable source commit for the six-platform release build. No release or stable-channel metadata has been published.