### PR TITLE
Bound Linux release build parallelism

### DIFF
--- a/scripts/build-public-cli-artifact.sh
+++ b/scripts/build-public-cli-artifact.sh
@@ -404,6 +404,7 @@ run_linux_container_build() {
     -e CTX_PUBLIC_CLI_ARTIFACT_DIR=/artifacts \
     -e CTX_PUBLIC_CLI_PREPARED_DIR=/prepared \
     -e CARGO_TARGET_DIR=/release-target \
+    -e "CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-2}" \
     -e HOME=/tmp/home \
     -v "${root_dir}:/work:ro" \
     -v "${root_dir}/${prepared_dir}:/prepared:ro" \

--- a/scripts/test-linux-release-construction.sh
+++ b/scripts/test-linux-release-construction.sh
@@ -294,6 +294,7 @@ grep -F 'RUSTUP_VERSION="1.28.2"' scripts/docker/linux-release.Dockerfile >/dev/
 grep -F 'RUST_TOOLCHAIN_VERSION="1.88.0"' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F 'rustup target add --toolchain "${RUST_TOOLCHAIN_VERSION}"' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F 'cargo "+${RUST_TOOLCHAIN_VERSION}"' scripts/build-public-cli-artifact.sh >/dev/null
+grep -F -- '-e "CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-2}"' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F 'public release construction requires a clean checkout' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F 'source commit changed during public release construction' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F 'linux-*' scripts/build-public-cli-artifact.sh >/dev/null


### PR DESCRIPTION
## Summary

- forward the pipeline's `CARGO_BUILD_JOBS` cap into the offline Linux release container
- default direct local release construction to two Cargo jobs
- lock the propagation into the Linux release construction contract test

## Why

The 0.25 release build showed that the outer pipeline set `CARGO_BUILD_JOBS=2`, but the final network-isolated Docker phase did not receive it and used host-wide Cargo parallelism. This keeps release construction responsive on shared workers and developer machines.

## Validation

- Linux release construction self-test passed
- Buildkite pipeline contract passed
- exact checked-in Buildkite public-smoke set: 12/12 passed
- live release build was stopped before this fix; the final candidate will be rebuilt from the merged commit with the in-container cap observed