### PR TITLE
Update Windows release DLL contract

### DIFF
--- a/scripts/check-release-binary-compat.sh
+++ b/scripts/check-release-binary-compat.sh
@@ -278,10 +278,10 @@ check_windows() {
 api-ms-win-core-synch-l1-2-0.dll
 bcrypt.dll
 bcryptprimitives.dll
+combase.dll
 kernel32.dll
 msvcrt.dll
 ntdll.dll
-ole32.dll
 shell32.dll
 userenv.dll
 ws2_32.dll"

--- a/scripts/tests/check-release-binary-compat-test.sh
+++ b/scripts/tests/check-release-binary-compat-test.sh
@@ -165,6 +165,9 @@ Import {
   Name: bcryptprimitives.dll
 }
 Import {
+  Name: combase.dll
+}
+Import {
   Name: KERNEL32.dll
 }
 Import {
@@ -172,9 +175,6 @@ Import {
 }
 Import {
   Name: ntdll.dll
-}
-Import {
-  Name: ole32.dll
 }
 Import {
   Name: shell32.dll


### PR DESCRIPTION
## Summary

- update the exact Windows system DLL allowlist from `ole32.dll` to `combase.dll`
- keep the fixture contract synchronized with the real 0.25 release artifact

## Why

The 0.25 Windows x64 artifact links the Windows 11 system `combase.dll` instead of `ole32.dll`. The candidate runs successfully on the pinned native Windows 11 VM; the release gate was rejecting a healthy artifact because its exact import contract was stale.

## Validation

- real 0.25 Windows x64 artifact passes `check-release-binary-compat.sh`
- artifact reports `ctx 0.25.0` on the pinned Windows 11 VM
- exact 12-target public Buildkite-equivalent gate passes