### PR TITLE
Allow cold Gatekeeper assessment

### DIFF
--- a/scripts/verify-macos-quarantined-cli.sh
+++ b/scripts/verify-macos-quarantined-cli.sh
@@ -34,7 +34,8 @@ fi
 command -v python3 >/dev/null 2>&1 || die "python3 is required"
 command -v xattr >/dev/null 2>&1 || die "xattr is required"
 
-timeout_seconds="${CTX_MACOS_CLI_EXEC_TIMEOUT_SECONDS:-30}"
+# A cold Gatekeeper assessment can spend more than 30 seconds online.
+timeout_seconds="${CTX_MACOS_CLI_EXEC_TIMEOUT_SECONDS:-120}"
 [[ "${timeout_seconds}" =~ ^[1-9][0-9]*$ ]] || \
   die "CTX_MACOS_CLI_EXEC_TIMEOUT_SECONDS must be a positive integer"
 artifact="$(cd "$(dirname "${artifact}")" && pwd)/$(basename "${artifact}")"


### PR DESCRIPTION
## Summary

- increase the quarantined macOS CLI execution ceiling from 30 to 120 seconds
- document why the release check needs the larger cold-start window

## Why

Two independently signed and notarized 0.25 Apple Silicon candidates exceeded 30 seconds on their first Safari-style quarantined execution, then the identical bytes passed in under one second on retry. This is Apple Gatekeeper cold assessment latency, not CLI startup latency.

## Validation

- exact signed candidate passes quarantine execution unchanged
- macOS release-signing contract suite passes
- exact 12-target public Buildkite-equivalent gate passes