### PR TITLE
Gate semantic Read import on Unix

### DIFF
--- a/crates/ctx-cli/src/semantic/preamble.rs
+++ b/crates/ctx-cli/src/semantic/preamble.rs
@@ -1,13 +1,15 @@
 use std::{
     collections::{HashMap, HashSet},
     env, fmt, fs,
-    io::{Read, Seek, SeekFrom, Write},
+    io::{Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     process::{self, Command, Stdio},
     sync::{Arc, Mutex},
     time::{Duration as StdDuration, Instant, SystemTime},
 };
 
+#[cfg(unix)]
+use std::io::Read;
 #[cfg(unix)]
 use std::net::Shutdown;
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

Gate the parent semantic module's `Read` trait import to Unix, matching the transports that use it.

## Why

The Windows x64 0.25 release build compiled successfully but emitted an unused-import warning because its query transport does not use `Read`. Keeping release output warning-free makes new target regressions visible.

## Validation

- `cargo +1.88.0 check -p ctx --target x86_64-pc-windows-gnu --locked`
- `//:cargo_check`
- `//:cargo_fmt_check`
- `//:source_diff_check`