### PR TITLE
Skip submodule sync for macOS runtime archive

### DIFF
--- a/scripts/build-onnxruntime-sidecar.sh
+++ b/scripts/build-onnxruntime-sidecar.sh
@@ -411,7 +411,7 @@ stage_macos_x64_source_build() {
     --config Release
     --build_dir "${cmake_build_dir}"
     --build_shared_lib
-    --skip_tests
+    --skip_tests --skip_submodule_sync
     --compile_no_warning_as_error
   )
   if [[ -n "${jobs}" ]]; then

--- a/scripts/test-linux-release-construction.sh
+++ b/scripts/test-linux-release-construction.sh
@@ -307,6 +307,8 @@ grep -F 'local_runtime_authority' scripts/write-public-cli-build-info.py >/dev/n
 grep -F 'required ONNX Runtime sidecar missing' scripts/stage-github-release-assets.sh >/dev/null
 grep -F 'ctx-onnxruntime-freebsd-x64.tar.gz' scripts/check-github-release-assets.sh >/dev/null
 grep -F 'ctx-onnxruntime-macos-x64.tar.gz' scripts/check-github-release-assets.sh >/dev/null
+test "$(sed -n '/^stage_macos_x64_source_build()/,/^stage_freebsd_source_build()/p' \
+  scripts/build-onnxruntime-sidecar.sh | grep -Fc -- '--skip_tests --skip_submodule_sync')" = 1
 grep -F -- '--expected-builder-base "${LINUX_RELEASE_UBUNTU_DIGEST}"' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F -- '--actual-builder-base "${actual_base_digest}"' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F -- '--runtime-image-id "${runtime_image_id}"' scripts/build-public-cli-artifact.sh >/dev/null


### PR DESCRIPTION
## Summary

Pass ONNX Runtime's `--skip_submodule_sync` option when building the macOS x64 sidecar from the checksum-pinned source archive, and lock the flag into the release construction contract.

## Root cause

The x64 runtime builder extracts the official source tarball rather than cloning the upstream Git repository. ONNX Runtime's build helper defaults to `git submodule sync --recursive`, which necessarily fails in that archive. All source dependencies are already acquired through the build helper after the archive is verified.

## Validation

- reproduced on the Intel macOS 15.7.7 diagnostic VM with Python 3.12 and CMake 3.31.6
- Linux release construction self-test passes
- exact 12-target public Buildkite-equivalent gate passes