### PR TITLE
Bound FTS optimization merge steps

### DIFF
--- a/crates/ctx-cli/src/commands/import.rs
+++ b/crates/ctx-cli/src/commands/import.rs
@@ -673,11 +673,6 @@ pub(crate) fn run_import_internal(
         }
     }
 
-    if totals.imported_sessions > 0 || totals.imported_events > 0 || totals.imported_edges > 0 {
-        progress.message("finalizing", "Optimizing search index...");
-        Store::open(&db_path)?.optimize_search_index()?;
-    }
-
     progress.message("finalizing", "Checkpointing search database...");
     Store::open(&db_path)?.checkpoint_wal_truncate_if_larger_than(WAL_TRUNCATE_MIN_BYTES)?;
 

--- a/crates/ctx-cli/src/commands/import/explicit.rs
+++ b/crates/ctx-cli/src/commands/import/explicit.rs
@@ -85,10 +85,6 @@ pub(crate) fn run_explicit_format_import(
 
     let mut totals = ImportTotals::default();
     totals.add(&summary, &stats);
-    if totals.imported_sessions > 0 || totals.imported_events > 0 || totals.imported_edges > 0 {
-        progress.message("finalizing", "optimizing search index");
-        Store::open(&db_path)?.optimize_search_index()?;
-    }
     progress.message("finalizing", "checkpointing search database");
     Store::open(&db_path)?.checkpoint_wal_truncate_if_larger_than(WAL_TRUNCATE_MIN_BYTES)?;
     if options.print_human {

--- a/crates/ctx-history-capture/src/provider/importer.rs
+++ b/crates/ctx-history-capture/src/provider/importer.rs
@@ -102,7 +102,11 @@ pub fn import_normalized_provider_captures(
     normalization: ProviderNormalizationResult,
     options: NormalizedProviderImportOptions,
 ) -> Result<ProviderImportSummary> {
-    batches::import_normalized_provider_captures(store, normalization, options, false)
+    // Every normalized provider import writes into the shared event FTS tables.
+    // Keep FTS automatic/crisis merges suppressed until the importer can finish
+    // them in bounded, checkpointed steps. This applies equally to atomic and
+    // partial imports, so no provider needs its own WAL safety policy.
+    batches::import_normalized_provider_captures(store, normalization, options, true)
 }
 
 pub(crate) fn import_normalized_provider_captures_with_bulk_search(

--- a/crates/ctx-history-capture/src/provider/importer/batches.rs
+++ b/crates/ctx-history-capture/src/provider/importer/batches.rs
@@ -79,7 +79,7 @@ pub(super) fn import_provider_capture_lines(
         captures,
         files_touched,
         None,
-        false,
+        true,
     )
 }
 

--- a/crates/ctx-history-store/src/bulk_search.rs
+++ b/crates/ctx-history-store/src/bulk_search.rs
@@ -156,27 +156,23 @@ impl Store {
             self.finish_event_search_bulk_mode(&guard)?;
         }
         for table in ALL_FTS_TABLES {
-            self.merge_fts_table_bounded(table, true)?;
+            self.merge_fts_table_bounded(table)?;
         }
         Ok(())
     }
 
-    fn merge_fts_table_bounded(
-        &self,
-        table: &'static str,
-        mut start_full_merge: bool,
-    ) -> Result<()> {
+    /// Compact one FTS table using only positive merge budgets.
+    ///
+    /// A negative FTS5 merge budget starts a full merge. Even a small absolute
+    /// budget can then rewrite a large existing segment in one transaction,
+    /// before this layer gets a chance to checkpoint the WAL. Normal imports
+    /// must therefore make progress through positive bounded steps only.
+    fn merge_fts_table_bounded(&self, table: &'static str) -> Result<()> {
         if !table_exists(&self.conn, table)? {
             return Ok(());
         }
         loop {
-            let page_budget = if start_full_merge {
-                -FTS_MERGE_PAGE_BUDGET
-            } else {
-                FTS_MERGE_PAGE_BUDGET
-            };
-            let changed = self.merge_fts_table_step(table, page_budget)?;
-            start_full_merge = false;
+            let changed = self.merge_fts_table_step(table, FTS_MERGE_PAGE_BUDGET)?;
             if !changed {
                 return Ok(());
             }

--- a/crates/ctx-history-store/src/bulk_search.rs
+++ b/crates/ctx-history-store/src/bulk_search.rs
@@ -1,10 +1,10 @@
-//! Crash-safe FTS5 merge suppression and bounded compaction for bulk imports.
+//! Crash-safe FTS5 merge suppression for bulk imports.
 //!
 //! FTS5 may perform an automatic or crisis merge inside a single row insert,
 //! producing a WAL far larger than the imported data. Bulk mode persists a
 //! recovery marker before disabling those merges. Event rows and their search
 //! projections still commit together; interrupted work remains searchable.
-//! Bounded merge steps run before the saved settings and marker are cleared.
+//! Saved settings are restored only after the import WAL has been checkpointed.
 
 use ctx_history_core::utc_now;
 use std::{ffi::OsString, path::PathBuf, time::Duration};
@@ -91,13 +91,13 @@ impl Store {
         Ok(guard)
     }
 
-    /// Compact pending bulk segments in bounded steps, then restore saved settings.
+    /// Checkpoint the import and restore saved FTS settings.
     ///
-    /// Bulk finalization deliberately uses positive FTS5 merge commands. Starting
-    /// a full merge with a negative command would assign every pre-existing
-    /// segment to the same level and rewrite the entire shared event index. That
-    /// is appropriate for an explicit optimize, but not for finishing one
-    /// provider import in an already-populated multi-source index.
+    /// Import finalization must not compact the shared historical index. Even
+    /// positive FTS5 merge commands may select an existing large segment and
+    /// turn a small source import into prolonged write amplification. Search is
+    /// correct with multiple segments; routine FTS maintenance can happen on
+    /// later ordinary writes or through an explicit maintenance operation.
     pub fn finish_event_search_bulk_mode(&self, guard: &EventSearchBulkGuard) -> Result<()> {
         if guard.store_path != self.path {
             return Err(StoreError::InvalidBulkSearchGuard);
@@ -105,11 +105,11 @@ impl Store {
         if !bulk_mode_pending(self)? {
             return Ok(());
         }
-        loop {
-            if self.finish_event_search_bulk_mode_step()? {
-                return Ok(());
-            }
-        }
+        // Keep the recovery marker until the potentially large import WAL has
+        // been truncated. A pinned reader must leave the safe-mode settings in
+        // place so a later open can retry the checkpoint.
+        self.checkpoint_wal_truncate_required()?;
+        self.restore_event_search_bulk_mode()
     }
 
     pub(crate) fn recover_event_search_bulk_mode(&self) -> Result<()> {
@@ -197,64 +197,28 @@ impl Store {
         Ok(changed)
     }
 
-    /// Perform one bounded merge on both tables from the same writer snapshot.
-    /// A quiescent pass is checkpointed before a second locked pass may restore
-    /// settings, so a failed large-WAL checkpoint always leaves recovery marked.
-    fn finish_event_search_bulk_mode_step(&self) -> Result<bool> {
+    fn restore_event_search_bulk_mode(&self) -> Result<()> {
         self.begin_immediate_batch()?;
         let result = (|| {
             if !bulk_mode_pending(self)? {
-                return Ok(true);
+                return Ok(());
             }
-            Ok(!merge_event_search_tables_in_transaction(self)?)
+            restore_event_search_merge_config(self)?;
+            clear_bulk_mode_state(self)
         })();
-        let quiescent = match result {
-            Ok(quiescent) => quiescent,
+        match result {
+            Ok(()) => {}
             Err(err) => {
                 let _ = self.rollback_batch();
                 return Err(err);
             }
-        };
+        }
         if let Err(err) = self.commit_batch() {
             let _ = self.rollback_batch();
             return Err(err);
         }
         self.checkpoint_wal_truncate_required()?;
-        if !quiescent {
-            return Ok(false);
-        }
-        self.restore_event_search_bulk_mode_if_quiescent()
-    }
-
-    /// Recheck both tables and restore settings while holding one writer lock.
-    /// If the final config-only checkpoint is pinned, the preceding potentially
-    /// large merge WAL has already been truncated successfully.
-    fn restore_event_search_bulk_mode_if_quiescent(&self) -> Result<bool> {
-        self.begin_immediate_batch()?;
-        let result = (|| {
-            if !bulk_mode_pending(self)? {
-                return Ok(true);
-            }
-            let changed = merge_event_search_tables_in_transaction(self)?;
-            if !changed {
-                restore_event_search_merge_config(self)?;
-                clear_bulk_mode_state(self)?;
-            }
-            Ok(!changed)
-        })();
-        let finished = match result {
-            Ok(finished) => finished,
-            Err(err) => {
-                let _ = self.rollback_batch();
-                return Err(err);
-            }
-        };
-        if let Err(err) = self.commit_batch() {
-            let _ = self.rollback_batch();
-            return Err(err);
-        }
-        self.checkpoint_wal_truncate_required()?;
-        Ok(finished)
+        Ok(())
     }
 
     fn acquire_event_search_bulk_lock(
@@ -290,16 +254,6 @@ fn merge_fts_table_in_transaction(
     let sql = format!("INSERT INTO {table}({table}, rank) VALUES ('merge', ?1)");
     store.conn.execute(&sql, params![page_budget])?;
     Ok(store.conn.total_changes().saturating_sub(before) >= 2)
-}
-
-fn merge_event_search_tables_in_transaction(store: &Store) -> Result<bool> {
-    let mut changed = false;
-    for table in EVENT_SEARCH_FTS_TABLES {
-        if table_exists(&store.conn, table)? {
-            changed |= merge_fts_table_in_transaction(store, table, FTS_MERGE_PAGE_BUDGET)?;
-        }
-    }
-    Ok(changed)
 }
 
 fn event_search_bulk_lock_path(store_path: &std::path::Path) -> PathBuf {

--- a/crates/ctx-history-store/src/connection_tests.rs
+++ b/crates/ctx-history-store/src/connection_tests.rs
@@ -215,7 +215,7 @@ fn bulk_search_mode_crosses_crisis_threshold_without_automatic_merge() {
 
     store.finish_event_search_bulk_mode(&guard).unwrap();
     assert_eq!(bulk_mode_marker(&store), None);
-    let compacted_segments = store
+    let deferred_segments = store
         .conn
         .query_row(
             "SELECT COUNT(DISTINCT segid) FROM event_search_idx",
@@ -223,7 +223,7 @@ fn bulk_search_mode_crosses_crisis_threshold_without_automatic_merge() {
             |row| row.get::<_, i64>(0),
         )
         .unwrap();
-    assert_eq!(compacted_segments, 1);
+    assert!(deferred_segments >= 20);
     assert_eq!(
         store
             .conn
@@ -238,7 +238,7 @@ fn bulk_search_mode_crosses_crisis_threshold_without_automatic_merge() {
 }
 
 #[test]
-fn bulk_search_finish_preserves_preexisting_optimized_segment() {
+fn bulk_search_finish_preserves_deferred_segments_for_later_maintenance() {
     let temp = tempdir();
     let db_path = temp.path().join("work.sqlite");
     let store = Store::open(&db_path).unwrap();
@@ -247,18 +247,14 @@ fn bulk_search_finish_preserves_preexisting_optimized_segment() {
     insert_bulk_search_events(&store, "historic", 80, 512);
     store.finish_event_search_bulk_mode(&first_guard).unwrap();
     drop(first_guard);
-    assert_eq!(event_search_segment_count(&store), 1);
+    assert_eq!(event_search_segment_count(&store), 80);
 
     let second_guard = store.begin_event_search_bulk_mode().unwrap();
     insert_bulk_search_events(&store, "new", 20, 128);
-    assert_eq!(event_search_segment_count(&store), 21);
+    assert_eq!(event_search_segment_count(&store), 100);
     store.finish_event_search_bulk_mode(&second_guard).unwrap();
 
-    assert_eq!(
-        event_search_segment_count(&store),
-        2,
-        "finishing one provider import must not re-optimize the historical index"
-    );
+    assert_eq!(event_search_segment_count(&store), 100);
     assert_eq!(
         store
             .conn
@@ -434,7 +430,7 @@ fn interrupted_bounded_merge_resumes_after_reopen() {
             |row| row.get::<_, i64>(0),
         )
         .unwrap();
-    assert_eq!(segments, 1);
+    assert_eq!(segments, 20);
     assert_eq!(
         reopened
             .conn

--- a/crates/ctx-history-store/src/connection_tests.rs
+++ b/crates/ctx-history-store/src/connection_tests.rs
@@ -273,6 +273,32 @@ fn bulk_search_finish_preserves_preexisting_optimized_segment() {
 }
 
 #[test]
+fn optimize_search_index_compacts_deferred_segments_in_bounded_steps() {
+    let temp = tempdir();
+    let store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let guard = store.begin_event_search_bulk_mode().unwrap();
+    insert_bulk_search_events(&store, "optimize", 40, 512);
+    drop(guard);
+
+    assert_eq!(event_search_segment_count(&store), 40);
+
+    store.optimize_search_index().unwrap();
+
+    assert_eq!(event_search_segment_count(&store), 1);
+    assert_eq!(
+        store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM event_search WHERE event_search MATCH 'optimize'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        40
+    );
+}
+
+#[test]
 fn bulk_search_recovery_resumes_legacy_in_progress_full_merge() {
     let temp = tempdir();
     let db_path = temp.path().join("work.sqlite");


### PR DESCRIPTION
## Draft: shared WAL-safety work in progress

This PR is deliberately still a draft. It generalizes FTS merge suppression across normalized provider imports and removes automatic full-index compaction after imports.

Live validation exposed a remaining common issue: normal imports still wrap an entire provider source in one SQLite transaction, so a large source can grow the WAL even with FTS merges suppressed. The next revision will make the existing bounded import transaction behavior the normal shared path (not a Hermes-/partial-only exception), while preserving crash-safe resume semantics.

Do not review or merge yet; I will update this description and tests after that final shared change is validated.