### PR TITLE
Bound partial provider imports and avoid OpenClaw full FTS rebuild

### DIFF
--- a/crates/ctx-cli/src/commands/import/catalog.rs
+++ b/crates/ctx-cli/src/commands/import/catalog.rs
@@ -306,56 +306,10 @@ pub(crate) fn mark_catalog_sessions_failed(
 }
 
 pub(crate) fn source_uses_incremental_event_search(source: &SourceInfo) -> bool {
-    matches!(
-        source.provider,
-        CaptureProvider::Codex
-            | CaptureProvider::Claude
-            | CaptureProvider::Pi
-            | CaptureProvider::Cursor
-            | CaptureProvider::OpenCode
-            | CaptureProvider::Kilo
-            | CaptureProvider::KiroCli
-            | CaptureProvider::Crush
-            | CaptureProvider::Goose
-            | CaptureProvider::Warp
-            | CaptureProvider::Antigravity
-            | CaptureProvider::Gemini
-            | CaptureProvider::Tabnine
-            | CaptureProvider::Windsurf
-            | CaptureProvider::Qoder
-            | CaptureProvider::CopilotCli
-            | CaptureProvider::FactoryAiDroid
-            | CaptureProvider::Continue
-            | CaptureProvider::QwenCode
-            | CaptureProvider::KimiCodeCli
-            | CaptureProvider::Auggie
-            | CaptureProvider::Junie
-            | CaptureProvider::Firebender
-            | CaptureProvider::ForgeCode
-            | CaptureProvider::DeepAgents
-            | CaptureProvider::Hermes
-            | CaptureProvider::OpenClaw
-            | CaptureProvider::MistralVibe
-            | CaptureProvider::Mux
-            | CaptureProvider::RovoDev
-            | CaptureProvider::Cline
-            | CaptureProvider::RooCode
-            | CaptureProvider::CodeBuddy
-            | CaptureProvider::Trae
-    )
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::provider_sources::explicit_path_source;
-
-    #[test]
-    fn openclaw_uses_incremental_event_search() {
-        let source = explicit_path_source(CaptureProvider::OpenClaw, PathBuf::from("openclaw"));
-
-        assert!(source_uses_incremental_event_search(&source));
-    }
+    // Every importable provider persists events through Store APIs that update
+    // the event-search projection transactionally. Unsupported sources have no
+    // importer and therefore cannot make that guarantee.
+    source.import_support.is_importable()
 }
 
 pub(crate) fn source_stats(path: &Path) -> Result<SourceStats> {
@@ -583,4 +537,36 @@ pub(crate) fn import_record_for_history_source_plugin(
     );
     record.id = stable_capture_uuid(&key, "record");
     record
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider_sources::explicit_path_source;
+    use ctx_history_capture::provider_source_specs;
+
+    #[test]
+    fn every_importable_provider_uses_incremental_event_search() {
+        for spec in provider_source_specs() {
+            let source = explicit_path_source(
+                spec.provider,
+                PathBuf::from(format!("{}-history", spec.provider.as_str())),
+            );
+
+            assert_eq!(source.import_support, spec.import_support);
+            assert!(
+                source_uses_incremental_event_search(&source),
+                "{} import must maintain event search incrementally",
+                spec.provider
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_source_does_not_claim_incremental_event_search() {
+        let source = explicit_path_source(CaptureProvider::Shell, PathBuf::from("shell-history"));
+
+        assert!(!source.import_support.is_importable());
+        assert!(!source_uses_incremental_event_search(&source));
+    }
 }

--- a/crates/ctx-cli/src/commands/import/catalog.rs
+++ b/crates/ctx-cli/src/commands/import/catalog.rs
@@ -334,6 +334,7 @@ pub(crate) fn source_uses_incremental_event_search(source: &SourceInfo) -> bool 
             | CaptureProvider::ForgeCode
             | CaptureProvider::DeepAgents
             | CaptureProvider::Hermes
+            | CaptureProvider::OpenClaw
             | CaptureProvider::MistralVibe
             | CaptureProvider::Mux
             | CaptureProvider::RovoDev
@@ -342,6 +343,19 @@ pub(crate) fn source_uses_incremental_event_search(source: &SourceInfo) -> bool 
             | CaptureProvider::CodeBuddy
             | CaptureProvider::Trae
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider_sources::explicit_path_source;
+
+    #[test]
+    fn openclaw_uses_incremental_event_search() {
+        let source = explicit_path_source(CaptureProvider::OpenClaw, PathBuf::from("openclaw"));
+
+        assert!(source_uses_incremental_event_search(&source));
+    }
 }
 
 pub(crate) fn source_stats(path: &Path) -> Result<SourceStats> {

--- a/crates/ctx-history-capture/src/provider/api/json_sources.rs
+++ b/crates/ctx-history-capture/src/provider/api/json_sources.rs
@@ -9,7 +9,8 @@ use crate::provider::adapter::{
     ProviderCaptureAdapter, RooTaskJsonAdapter,
 };
 use crate::provider::importer::{
-    import_native_jsonl_tree, import_normalized_provider_captures, NativeJsonlTreeImport,
+    import_native_jsonl_tree, import_normalized_provider_captures,
+    import_normalized_provider_captures_with_bulk_search, NativeJsonlTreeImport,
 };
 use crate::provider::providers::trae::normalize_trae_history;
 use crate::{
@@ -330,7 +331,11 @@ pub fn import_hermes_sqlite(
         wrap_transaction: true,
         fast_event_inserts: true,
     };
-    import_normalized_provider_captures(store, normalization, import_options)
+    if options.allow_partial_failures {
+        import_normalized_provider_captures(store, normalization, import_options)
+    } else {
+        import_normalized_provider_captures_with_bulk_search(store, normalization, import_options)
+    }
 }
 
 pub fn import_auggie_history(

--- a/crates/ctx-history-capture/src/provider/api/json_sources.rs
+++ b/crates/ctx-history-capture/src/provider/api/json_sources.rs
@@ -9,9 +9,7 @@ use crate::provider::adapter::{
     ProviderCaptureAdapter, RooTaskJsonAdapter,
 };
 use crate::provider::importer::{
-    import_native_jsonl_tree, import_normalized_provider_captures,
-    import_normalized_provider_captures_in_batches,
-    import_normalized_provider_captures_with_bulk_search, NativeJsonlTreeImport,
+    import_native_jsonl_tree, import_normalized_provider_captures, NativeJsonlTreeImport,
 };
 use crate::provider::providers::trae::normalize_trae_history;
 use crate::{
@@ -325,25 +323,14 @@ pub fn import_hermes_sqlite(
             imported_at: options.imported_at,
         },
     )?;
-    const HERMES_TRANSACTION_BATCH_MESSAGES: usize = 64;
-    let allow_partial_failures = options.allow_partial_failures;
     let import_options = NormalizedProviderImportOptions {
         history_record_id: options.history_record_id,
-        allow_partial_failures,
+        allow_partial_failures: options.allow_partial_failures,
         persist_cursors: true,
         wrap_transaction: true,
         fast_event_inserts: true,
     };
-    if allow_partial_failures {
-        import_normalized_provider_captures_in_batches(
-            store,
-            normalization,
-            import_options,
-            HERMES_TRANSACTION_BATCH_MESSAGES,
-        )
-    } else {
-        import_normalized_provider_captures_with_bulk_search(store, normalization, import_options)
-    }
+    import_normalized_provider_captures(store, normalization, import_options)
 }
 
 pub fn import_auggie_history(

--- a/crates/ctx-history-capture/src/provider/importer.rs
+++ b/crates/ctx-history-capture/src/provider/importer.rs
@@ -105,14 +105,7 @@ pub fn import_normalized_provider_captures(
     batches::import_normalized_provider_captures(store, normalization, options, false)
 }
 
-pub(crate) fn import_normalized_provider_captures_with_bulk_search(
-    store: &mut Store,
-    normalization: ProviderNormalizationResult,
-    options: NormalizedProviderImportOptions,
-) -> Result<ProviderImportSummary> {
-    batches::import_normalized_provider_captures(store, normalization, options, true)
-}
-
+#[cfg(test)]
 pub(crate) fn import_normalized_provider_captures_in_batches(
     store: &mut Store,
     normalization: ProviderNormalizationResult,

--- a/crates/ctx-history-capture/src/provider/importer.rs
+++ b/crates/ctx-history-capture/src/provider/importer.rs
@@ -102,7 +102,23 @@ pub fn import_normalized_provider_captures(
     normalization: ProviderNormalizationResult,
     options: NormalizedProviderImportOptions,
 ) -> Result<ProviderImportSummary> {
-    batches::import_normalized_provider_captures(store, normalization, options, false)
+    // Partial imports commit and checkpoint in bounded batches. Suppress FTS
+    // automatic merges for the same path so a merge cannot undo that bound.
+    let suppress_search_merges = options.allow_partial_failures;
+    batches::import_normalized_provider_captures(
+        store,
+        normalization,
+        options,
+        suppress_search_merges,
+    )
+}
+
+pub(crate) fn import_normalized_provider_captures_with_bulk_search(
+    store: &mut Store,
+    normalization: ProviderNormalizationResult,
+    options: NormalizedProviderImportOptions,
+) -> Result<ProviderImportSummary> {
+    batches::import_normalized_provider_captures(store, normalization, options, true)
 }
 
 #[cfg(test)]

--- a/crates/ctx-history-capture/src/provider/importer.rs
+++ b/crates/ctx-history-capture/src/provider/importer.rs
@@ -30,6 +30,8 @@ mod cursors;
 mod identity;
 mod ids;
 
+#[cfg(test)]
+pub(crate) use batches::import_normalized_provider_captures_in_batches;
 pub(crate) use commands::{provider_command_run_from_event, ProviderCommandRunInput};
 #[cfg(test)]
 pub(crate) use cursors::provider_source_cursor_stream;
@@ -102,15 +104,7 @@ pub fn import_normalized_provider_captures(
     normalization: ProviderNormalizationResult,
     options: NormalizedProviderImportOptions,
 ) -> Result<ProviderImportSummary> {
-    // Partial imports commit and checkpoint in bounded batches. Suppress FTS
-    // automatic merges for the same path so a merge cannot undo that bound.
-    let suppress_search_merges = options.allow_partial_failures;
-    batches::import_normalized_provider_captures(
-        store,
-        normalization,
-        options,
-        suppress_search_merges,
-    )
+    batches::import_normalized_provider_captures(store, normalization, options, false)
 }
 
 pub(crate) fn import_normalized_provider_captures_with_bulk_search(
@@ -119,21 +113,6 @@ pub(crate) fn import_normalized_provider_captures_with_bulk_search(
     options: NormalizedProviderImportOptions,
 ) -> Result<ProviderImportSummary> {
     batches::import_normalized_provider_captures(store, normalization, options, true)
-}
-
-#[cfg(test)]
-pub(crate) fn import_normalized_provider_captures_in_batches(
-    store: &mut Store,
-    normalization: ProviderNormalizationResult,
-    options: NormalizedProviderImportOptions,
-    transaction_batch_size: usize,
-) -> Result<ProviderImportSummary> {
-    batches::import_normalized_provider_captures_in_batches(
-        store,
-        normalization,
-        options,
-        transaction_batch_size,
-    )
 }
 
 pub(crate) fn import_provider_capture_lines(

--- a/crates/ctx-history-capture/src/provider/importer/batches.rs
+++ b/crates/ctx-history-capture/src/provider/importer/batches.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use super::*;
 
 const PROVIDER_IMPORT_TRANSACTION_BATCH_BYTES: usize = 8 * 1024 * 1024;
+const PARTIAL_PROVIDER_IMPORT_TRANSACTION_BATCH_UNITS: usize = 64;
 
 pub(super) fn import_normalized_provider_captures(
     store: &mut Store,
@@ -12,6 +13,7 @@ pub(super) fn import_normalized_provider_captures(
     options: NormalizedProviderImportOptions,
     suppress_search_merges: bool,
 ) -> Result<ProviderImportSummary> {
+    let transaction_batch_size = partial_transaction_batch_size(options.allow_partial_failures);
     let ProviderNormalizationResult {
         summary,
         captures,
@@ -23,11 +25,12 @@ pub(super) fn import_normalized_provider_captures(
         summary,
         captures,
         files_touched,
-        None,
+        transaction_batch_size,
         suppress_search_merges,
     )
 }
 
+#[cfg(test)]
 pub(super) fn import_normalized_provider_captures_in_batches(
     store: &mut Store,
     normalization: ProviderNormalizationResult,
@@ -81,6 +84,12 @@ pub(super) fn import_provider_capture_lines(
         None,
         false,
     )
+}
+
+fn partial_transaction_batch_size(allow_partial_failures: bool) -> Option<NonZeroUsize> {
+    allow_partial_failures
+        .then(|| NonZeroUsize::new(PARTIAL_PROVIDER_IMPORT_TRANSACTION_BATCH_UNITS))
+        .flatten()
 }
 
 fn import_provider_capture_lines_with_batch_size(

--- a/crates/ctx-history-capture/src/provider/importer/batches.rs
+++ b/crates/ctx-history-capture/src/provider/importer/batches.rs
@@ -11,9 +11,10 @@ pub(super) fn import_normalized_provider_captures(
     store: &mut Store,
     normalization: ProviderNormalizationResult,
     options: NormalizedProviderImportOptions,
-    suppress_search_merges: bool,
+    force_bulk_search_mode: bool,
 ) -> Result<ProviderImportSummary> {
     let transaction_batch_size = partial_transaction_batch_size(options.allow_partial_failures);
+    let suppress_search_merges = force_bulk_search_mode || options.allow_partial_failures;
     let ProviderNormalizationResult {
         summary,
         captures,
@@ -31,7 +32,7 @@ pub(super) fn import_normalized_provider_captures(
 }
 
 #[cfg(test)]
-pub(super) fn import_normalized_provider_captures_in_batches(
+pub(crate) fn import_normalized_provider_captures_in_batches(
     store: &mut Store,
     normalization: ProviderNormalizationResult,
     options: NormalizedProviderImportOptions,

--- a/crates/ctx-history-capture/src/tests/provider_fixture.rs
+++ b/crates/ctx-history-capture/src/tests/provider_fixture.rs
@@ -164,6 +164,68 @@ fn batched_provider_import_stops_on_pinned_wal_and_resumes_idempotently() {
 }
 
 #[test]
+fn partial_provider_import_uses_shared_bounded_batches() {
+    let temp = tempdir();
+    let db_path = temp.path().join("work.sqlite");
+    let mut store =
+        Store::open_with_busy_timeout(&db_path, std::time::Duration::from_millis(10)).unwrap();
+    let occurred_at = DateTime::parse_from_rfc3339("2026-07-11T12:15:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let source_path = temp.path().join("shared-bounded-provider.jsonl");
+    let source_path = source_path.display().to_string();
+    let captures = (0..64)
+        .map(|index| {
+            let mut capture = provider_collision_capture(
+                CaptureProvider::Hermes,
+                &format!("shared-bounded-{index}"),
+                "hermes_state_sqlite",
+                &source_path,
+                occurred_at + chrono::Duration::seconds(index),
+            );
+            capture.event.as_mut().unwrap().payload =
+                json!({"text": format!("shared-bounded-sentinel-{index}")});
+            (index as usize + 1, capture)
+        })
+        .collect();
+    let reader = Connection::open(&db_path).unwrap();
+    reader.execute_batch("BEGIN").unwrap();
+    assert_eq!(
+        reader
+            .query_row("SELECT COUNT(*) FROM events", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        0
+    );
+
+    let error = import_normalized_provider_captures(
+        &mut store,
+        ProviderNormalizationResult {
+            summary: ProviderImportSummary::default(),
+            captures,
+            files_touched: Vec::new(),
+        },
+        NormalizedProviderImportOptions {
+            allow_partial_failures: true,
+            fast_event_inserts: true,
+            ..NormalizedProviderImportOptions::default()
+        },
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("ctx index is busy"), "{error}");
+    reader.execute_batch("ROLLBACK").unwrap();
+
+    assert_eq!(store.list_sessions().unwrap().len(), 64);
+    assert_eq!(
+        store
+            .search_event_hits("shared-bounded-sentinel", 100)
+            .unwrap()
+            .len(),
+        64
+    );
+}
+
+#[test]
 fn batched_provider_import_rotates_on_serialized_byte_budget() {
     let temp = tempdir();
     let db_path = temp.path().join("work.sqlite");

--- a/crates/ctx-history-capture/src/tests/provider_fixture.rs
+++ b/crates/ctx-history-capture/src/tests/provider_fixture.rs
@@ -226,6 +226,48 @@ fn partial_provider_import_uses_shared_bounded_batches() {
 }
 
 #[test]
+fn partial_provider_import_uses_shared_bulk_search_guard() {
+    let temp = tempdir();
+    let db_path = temp.path().join("work.sqlite");
+    let mut store =
+        Store::open_with_busy_timeout(&db_path, std::time::Duration::from_millis(10)).unwrap();
+    let occurred_at = DateTime::parse_from_rfc3339("2026-07-11T12:20:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let source_path = temp.path().join("shared-bulk-provider.jsonl");
+    let source_path = source_path.display().to_string();
+    let guard = store.begin_event_search_bulk_mode().unwrap();
+
+    let error = import_normalized_provider_captures(
+        &mut store,
+        ProviderNormalizationResult {
+            summary: ProviderImportSummary::default(),
+            captures: vec![(
+                1,
+                provider_collision_capture(
+                    CaptureProvider::Claude,
+                    "shared-bulk",
+                    "claude_projects_jsonl",
+                    &source_path,
+                    occurred_at,
+                ),
+            )],
+            files_touched: Vec::new(),
+        },
+        NormalizedProviderImportOptions {
+            allow_partial_failures: true,
+            ..NormalizedProviderImportOptions::default()
+        },
+    )
+    .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains("another bulk search import is active"));
+    store.finish_event_search_bulk_mode(&guard).unwrap();
+}
+
+#[test]
 fn batched_provider_import_rotates_on_serialized_byte_budget() {
     let temp = tempdir();
     let db_path = temp.path().join("work.sqlite");


### PR DESCRIPTION
## Summary

- Use the existing bounded batch transaction path for all normalized provider imports when `--partial` is selected.
- Keep FTS merge bounds during those batches.
- Treat OpenClaw as incrementally searchable, so its import does not run an unnecessary full post-import FTS rebuild.
- Leave public flags and the default atomic import semantics unchanged.

## Validation

Live all-harness validation details are in the comment below.