### PR TITLE
Allow reviewed macOS x64 preview proof for v0.25

### DIFF
--- a/scripts/public-cli-host-runtime-evidence.sh
+++ b/scripts/public-cli-host-runtime-evidence.sh
@@ -47,7 +47,11 @@ if [[ "${host_system}" == "Darwin" ]]; then
         host_native_arch=arm64
         process_translated=1
         ;;
-      x86_64:0:|x86_64:0:0)
+      x86_64:1:|x86_64:1:0)
+        host_native_arch=arm64
+        process_translated=unknown
+        ;;
+      x86_64::|x86_64::0|x86_64:0:|x86_64:0:0)
         host_native_arch=x86_64
         process_translated=0
         ;;

--- a/scripts/smoke-daemon-semantic-release.sh
+++ b/scripts/smoke-daemon-semantic-release.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 usage() {
   cat >&2 <<'USAGE'
 Usage:
-  scripts/smoke-daemon-semantic-release.sh --runtime-archive PATH --runtime-platform PLATFORM [--ctx PATH] [--data-root DIR] [--proof-output PATH] [--timeout-seconds N] [--keep-root]
+  scripts/smoke-daemon-semantic-release.sh --runtime-archive PATH --runtime-platform PLATFORM [--ctx PATH] [--data-root DIR] [--proof-output PATH] [--timeout-seconds N] [--non-authoritative-runtime-proof] [--keep-root]
   scripts/smoke-daemon-semantic-release.sh --coreml --runtime-platform macos-arm64|macos-x64 [--ctx PATH] [--data-root DIR] [--proof-output PATH] [--timeout-seconds N] [--keep-root]
 
 Native release smoke for opt-in daemon + semantic search. The smoke creates an
@@ -18,6 +18,8 @@ be combined with --runtime-archive. When --data-root is provided, it is the
 parent for a fresh unique run root; --keep-root preserves that child for
 inspection. --proof-output copies the successful proof to a canonical release
 artifact path before the isolated run root is cleaned up.
+--non-authoritative-runtime-proof may only downgrade macos-x64 diagnostic proof;
+it cannot elevate unknown or translated execution to authoritative evidence.
 USAGE
 }
 
@@ -31,6 +33,7 @@ runtime_version="1.27.0"
 timeout_seconds="${CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS:-900}"
 keep_root=0
 coreml_mode=0
+downgrade_runtime_authority=0
 
 while (($# > 0)); do
   case "$1" in
@@ -56,6 +59,9 @@ while (($# > 0)); do
       ;;
     --coreml)
       coreml_mode=1
+      ;;
+    --non-authoritative-runtime-proof)
+      downgrade_runtime_authority=1
       ;;
     --timeout-seconds)
       shift
@@ -108,6 +114,10 @@ case "${runtime_platform}" in
     exit 2
     ;;
 esac
+if [[ "${downgrade_runtime_authority}" == "1" && "${runtime_platform}" != "macos-x64" ]]; then
+  echo "error: --non-authoritative-runtime-proof is restricted to macos-x64" >&2
+  exit 2
+fi
 
 expected_runtime_asset=""
 runtime_sha_path=""
@@ -290,6 +300,9 @@ runtime_authority="$(
     "${runtime_platform}" "${host_system}" "${host_arch}" passed \
     "${host_native_arch}" "${process_translated}"
 )"
+if [[ "${downgrade_runtime_authority}" == "1" ]]; then
+  runtime_authority=non_authoritative
+fi
 if [[ "${coreml_mode}" == "1" ]]; then
   ctx_bin="${install_bin_dir}/ctx"
   cp "${release_artifact_dir}/${release_binary}" "${ctx_bin}"

--- a/scripts/stage-github-release-assets.sh
+++ b/scripts/stage-github-release-assets.sh
@@ -282,7 +282,7 @@ for required_runtime_asset in "${required_runtime_assets[@]}"; do
   fi
 done
 
-validate_authoritative_runtime_proof() {
+validate_runtime_proof() {
   local platform="$1"
   local binary_name="$2"
   local proof_name="$3"
@@ -292,6 +292,8 @@ validate_authoritative_runtime_proof() {
   local host_native_arch="$7"
   local runtime_asset="${8:-}"
   local native_arch_probe="$9"
+  local expected_process_translated="${10:-0}"
+  local expected_runtime_authority="${11:-authoritative}"
   local binary_sha_path="${artifact_dir%/}/${binary_name}.sha256"
   local proof_path="${artifact_dir%/}/${proof_name}"
   local expected_sha runtime_sha_path runtime_path expected_runtime_sha actual_runtime_sha duplicate_key
@@ -341,16 +343,16 @@ validate_authoritative_runtime_proof() {
     printf 'runtime proof has wrong native host architecture: %s\n' "${proof_path}" >&2
     exit 1
   }
-  grep -Fxq 'process_translated=0' "${proof_path}" || {
-    printf 'runtime proof was produced by a translated process: %s\n' "${proof_path}" >&2
+  grep -Fxq "process_translated=${expected_process_translated}" "${proof_path}" || {
+    printf 'runtime proof has the wrong process translation status: %s\n' "${proof_path}" >&2
     exit 1
   }
   grep -Fxq "native_arch_probe=${native_arch_probe}" "${proof_path}" || {
     printf 'runtime proof used the wrong native architecture probe: %s\n' "${proof_path}" >&2
     exit 1
   }
-  grep -Fxq 'runtime_authority=authoritative' "${proof_path}" || {
-    printf 'runtime proof is not authoritative: %s\n' "${proof_path}" >&2
+  grep -Fxq "runtime_authority=${expected_runtime_authority}" "${proof_path}" || {
+    printf 'runtime proof has the wrong authority classification: %s\n' "${proof_path}" >&2
     exit 1
   }
   grep -Fxq "artifact_sha256=${expected_sha}" "${proof_path}" || {
@@ -413,6 +415,41 @@ validate_authoritative_runtime_proof() {
     printf 'runtime proof does not record semantic search success: %s\n' "${proof_path}" >&2
     exit 1
   }
+}
+
+validate_macos_x64_preview_candidate() {
+  local version_path="${artifact_dir%/}/ctx-macos-x64.version"
+  local build_info_path="${artifact_dir%/}/ctx-macos-x64.build-info.json"
+  local binary_sha_path="${artifact_dir%/}/ctx-macos-x64.sha256"
+  local expected_source_commit="228e05fa0fd058822be7a362acd65cacdad24356"
+  local expected_binary_sha
+
+  grep -Fxq 'ctx 0.25.0' "${version_path}" || {
+    printf 'macOS x64 preview proof exception is restricted to ctx 0.25.0\n' >&2
+    exit 1
+  }
+  [[ -s "${build_info_path}" ]] || {
+    printf 'macOS x64 preview proof requires candidate build info: %s\n' "${build_info_path}" >&2
+    exit 1
+  }
+  expected_binary_sha="$(tr -d '[:space:]' < "${binary_sha_path}")"
+  python3 - "${build_info_path}" "${expected_binary_sha}" "${expected_source_commit}" <<'PY'
+import json
+import sys
+
+path, expected_sha, expected_commit = sys.argv[1:]
+with open(path, encoding="utf-8") as source:
+    payload = json.load(source)
+if payload.get("schema_version") != 1:
+    raise SystemExit("macOS x64 preview candidate has unsupported build-info schema")
+if payload.get("platform") != "macos-x64" or payload.get("target") != "x86_64-apple-darwin":
+    raise SystemExit("macOS x64 preview candidate has wrong build-info platform")
+if payload.get("artifact_sha256") != expected_sha:
+    raise SystemExit("macOS x64 preview candidate build info does not bind the release binary")
+source = payload.get("source", {})
+if source.get("commit") != expected_commit or source.get("clean") is not True:
+    raise SystemExit("macOS x64 preview exception is restricted to the reviewed 0.25.0 source commit")
+PY
 }
 
 validate_macos_signing_evidence() (
@@ -483,22 +520,37 @@ PY
     "${release_attestation}" "${release_attestation_cms}"
 )
 
-validate_authoritative_runtime_proof \
+validate_runtime_proof \
   linux-x64 ctx ctx-linux-x64.native-runtime-proof.txt \
   onnxruntime Linux x86_64 x86_64 ctx-onnxruntime-linux-x64.tar.gz uname
-validate_authoritative_runtime_proof \
+validate_runtime_proof \
   linux-aarch64 ctx-linux-aarch64 ctx-linux-aarch64.native-runtime-proof.txt \
   onnxruntime Linux aarch64 aarch64 ctx-onnxruntime-linux-aarch64.tar.gz uname
-validate_authoritative_runtime_proof \
+validate_runtime_proof \
   macos-arm64 ctx-macos-arm64 ctx-macos-arm64.native-runtime-proof.txt \
   onnxruntime Darwin arm64 arm64 ctx-onnxruntime-macos-arm64.tar.gz sysctl
-validate_authoritative_runtime_proof \
-  macos-x64 ctx-macos-x64 ctx-macos-x64.native-runtime-proof.txt \
-  onnxruntime Darwin x86_64 x86_64 ctx-onnxruntime-macos-x64.tar.gz sysctl
-validate_authoritative_runtime_proof \
+case "${CTX_RELEASE_ALLOW_MACOS_X64_PREVIEW_PROOF:-0}" in
+  0)
+    validate_runtime_proof \
+      macos-x64 ctx-macos-x64 ctx-macos-x64.native-runtime-proof.txt \
+      onnxruntime Darwin x86_64 x86_64 ctx-onnxruntime-macos-x64.tar.gz sysctl
+    ;;
+  1)
+    validate_macos_x64_preview_candidate
+    validate_runtime_proof \
+      macos-x64 ctx-macos-x64 ctx-macos-x64.native-runtime-proof.txt \
+      onnxruntime Darwin x86_64 x86_64 ctx-onnxruntime-macos-x64.tar.gz sysctl \
+      0 non_authoritative
+    ;;
+  *)
+    printf 'CTX_RELEASE_ALLOW_MACOS_X64_PREVIEW_PROOF must be 0 or 1\n' >&2
+    exit 2
+    ;;
+esac
+validate_runtime_proof \
   windows-x64 ctx.exe ctx-windows-x64.native-runtime-proof.txt \
   onnxruntime Windows_NT AMD64 AMD64 ctx-onnxruntime-windows-x64.zip iswow64process2
-validate_authoritative_runtime_proof \
+validate_runtime_proof \
   freebsd-x64 ctx-freebsd-x64 ctx-freebsd-x64.native-runtime-proof.txt \
   onnxruntime FreeBSD amd64 amd64 ctx-onnxruntime-freebsd-x64.tar.gz uname
 validate_macos_signing_evidence macos-arm64

--- a/scripts/test-linux-release-construction.sh
+++ b/scripts/test-linux-release-construction.sh
@@ -149,10 +149,15 @@ case "${2:-}" in
   *) exit 2 ;;
 esac
 EOF
+cat > "${tmp_dir}/blank-sysctl" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
 chmod +x \
   "${tmp_dir}/native-sysctl" \
   "${tmp_dir}/rosetta-sysctl" \
-  "${tmp_dir}/inconsistent-sysctl"
+  "${tmp_dir}/inconsistent-sysctl" \
+  "${tmp_dir}/blank-sysctl"
 test "$(scripts/public-cli-host-runtime-evidence.sh \
   --host-system Darwin --host-arch x86_64 --sysctl "${tmp_dir}/native-sysctl")" = \
   $'Darwin\tx86_64\tx86_64\t0\tsysctl'
@@ -163,8 +168,11 @@ test "$(scripts/public-cli-host-runtime-evidence.sh \
   --host-system Darwin --host-arch x86_64 --sysctl "${tmp_dir}/missing-sysctl")" = \
   $'Darwin\tx86_64\tunknown\tunknown\tsysctl'
 test "$(scripts/public-cli-host-runtime-evidence.sh \
+  --host-system Darwin --host-arch x86_64 --sysctl "${tmp_dir}/blank-sysctl")" = \
+  $'Darwin\tx86_64\tx86_64\t0\tsysctl'
+test "$(scripts/public-cli-host-runtime-evidence.sh \
   --host-system Darwin --host-arch x86_64 --sysctl "${tmp_dir}/inconsistent-sysctl")" = \
-  $'Darwin\tx86_64\tunknown\tunknown\tsysctl'
+  $'Darwin\tx86_64\tarm64\tunknown\tsysctl'
 
 partial_runtime_matrix="${tmp_dir}/partial-runtime-matrix"
 mkdir -p "${partial_runtime_matrix}"
@@ -307,6 +315,85 @@ write_synthetic_runtime_proof \
 write_synthetic_runtime_proof \
   windows-x64 ctx.exe ctx-windows-x64.native-runtime-proof.txt \
   Windows_NT AMD64 ctx-onnxruntime-windows-x64.zip iswow64process2
+
+preview_macos_matrix="${tmp_dir}/preview-macos-matrix"
+cp -R "${missing_windows_dependency_matrix}" "${preview_macos_matrix}"
+sed -i \
+  -e 's/^runtime_authority=authoritative$/runtime_authority=non_authoritative/' \
+  "${preview_macos_matrix}/ctx-macos-x64.native-runtime-proof.txt"
+printf 'ctx 0.25.0\n' > "${preview_macos_matrix}/ctx-macos-x64.version"
+preview_macos_sha="$(cat "${preview_macos_matrix}/ctx-macos-x64.sha256")"
+cat > "${preview_macos_matrix}/ctx-macos-x64.build-info.json" <<EOF
+{"schema_version":1,"artifact_sha256":"${preview_macos_sha}","platform":"macos-x64","target":"x86_64-apple-darwin","source":{"commit":"228e05fa0fd058822be7a362acd65cacdad24356","clean":true}}
+EOF
+if scripts/stage-github-release-assets.sh \
+  "${preview_macos_matrix}" "${tmp_dir}/preview-macos-default-release" \
+  >"${tmp_dir}/preview-macos-default.out" 2>"${tmp_dir}/preview-macos-default.err"; then
+  echo "release staging accepted macOS x64 preview proof without explicit opt-in" >&2
+  exit 1
+fi
+grep -Fq \
+  'runtime proof has the wrong authority classification:' \
+  "${tmp_dir}/preview-macos-default.err"
+
+printf 'ctx 0.25.1\n' > "${preview_macos_matrix}/ctx-macos-x64.version"
+if CTX_RELEASE_ALLOW_MACOS_X64_PREVIEW_PROOF=1 \
+  scripts/stage-github-release-assets.sh \
+    "${preview_macos_matrix}" "${tmp_dir}/preview-macos-wrong-version-release" \
+    >"${tmp_dir}/preview-macos-wrong-version.out" \
+    2>"${tmp_dir}/preview-macos-wrong-version.err"; then
+  echo "release staging accepted the macOS x64 preview exception for another version" >&2
+  exit 1
+fi
+grep -Fq \
+  'macOS x64 preview proof exception is restricted to ctx 0.25.0' \
+  "${tmp_dir}/preview-macos-wrong-version.err"
+
+printf 'ctx 0.25.0\n' > "${preview_macos_matrix}/ctx-macos-x64.version"
+sed -i \
+  's/228e05fa0fd058822be7a362acd65cacdad24356/0000000000000000000000000000000000000000/' \
+  "${preview_macos_matrix}/ctx-macos-x64.build-info.json"
+if CTX_RELEASE_ALLOW_MACOS_X64_PREVIEW_PROOF=1 \
+  scripts/stage-github-release-assets.sh \
+    "${preview_macos_matrix}" "${tmp_dir}/preview-macos-wrong-source-release" \
+    >"${tmp_dir}/preview-macos-wrong-source.out" \
+    2>"${tmp_dir}/preview-macos-wrong-source.err"; then
+  echo "release staging accepted preview proof for another source commit" >&2
+  exit 1
+fi
+grep -Fq \
+  'macOS x64 preview exception is restricted to the reviewed 0.25.0 source commit' \
+  "${tmp_dir}/preview-macos-wrong-source.err"
+sed -i \
+  's/0000000000000000000000000000000000000000/228e05fa0fd058822be7a362acd65cacdad24356/' \
+  "${preview_macos_matrix}/ctx-macos-x64.build-info.json"
+
+if CTX_RELEASE_ALLOW_MACOS_X64_PREVIEW_PROOF=1 \
+  scripts/stage-github-release-assets.sh \
+    "${preview_macos_matrix}" "${tmp_dir}/preview-macos-release" \
+    >"${tmp_dir}/preview-macos.out" 2>"${tmp_dir}/preview-macos.err"; then
+  echo "release staging unexpectedly passed an incomplete synthetic matrix" >&2
+  exit 1
+fi
+grep -Fq \
+  'Windows runtime proof is missing runtime_dylib:' \
+  "${tmp_dir}/preview-macos.err"
+
+sed -i \
+  -e 's/^host_native_arch=x86_64$/host_native_arch=arm64/' \
+  -e 's/^process_translated=0$/process_translated=1/' \
+  "${preview_macos_matrix}/ctx-macos-x64.native-runtime-proof.txt"
+if CTX_RELEASE_ALLOW_MACOS_X64_PREVIEW_PROOF=1 \
+  scripts/stage-github-release-assets.sh \
+    "${preview_macos_matrix}" "${tmp_dir}/preview-macos-rosetta-release" \
+    >"${tmp_dir}/preview-macos-rosetta.out" 2>"${tmp_dir}/preview-macos-rosetta.err"; then
+  echo "release staging accepted Rosetta-shaped proof as preview evidence" >&2
+  exit 1
+fi
+grep -Fq \
+  'runtime proof has wrong native host architecture:' \
+  "${tmp_dir}/preview-macos-rosetta.err"
+
 cat >> \
   "${missing_windows_dependency_matrix}/ctx-windows-x64.native-runtime-proof.txt" <<'EOF'
 runtime_dylib=C:\ctx-runtime\onnxruntime\1.27.0\windows-x64\lib\onnxruntime.dll

--- a/scripts/tests/smoke-daemon-semantic-release-test.sh
+++ b/scripts/tests/smoke-daemon-semantic-release-test.sh
@@ -102,6 +102,7 @@ expect_usage_failure() {
 
 "${smoke}" --help > "${tmp}/help.out" 2>&1
 grep -Fq -- '--coreml --runtime-platform macos-arm64|macos-x64' "${tmp}/help.out"
+grep -Fq -- '--non-authoritative-runtime-proof' "${tmp}/help.out"
 
 expect_usage_failure coreml_linux \
   '--coreml requires --runtime-platform macos-arm64 or macos-x64' \
@@ -113,6 +114,9 @@ expect_usage_failure coreml_archive \
 expect_usage_failure archive_required \
   '--runtime-archive is required unless --coreml is selected' \
   --runtime-platform macos-arm64 --ctx "${fake_ctx}"
+expect_usage_failure preview_proof_linux \
+  '--non-authoritative-runtime-proof is restricted to macos-x64' \
+  --runtime-platform linux-x64 --non-authoritative-runtime-proof --ctx "${fake_ctx}"
 
 cpu_ctx="${tmp}/ctx-macos-cpu-fallback"
 sed 's/"backend":"coreml"/"backend":"cpu"/g' "${fake_ctx}" > "${cpu_ctx}"


### PR DESCRIPTION
## Summary

- add a one-release, explicit macOS x64 preview-proof exception for the exact reviewed v0.25 candidate
- distinguish native x86 guest execution from Rosetta and downgrade virtualized proof to non-authoritative
- keep authoritative physical-hardware proof as the default and reject the exception for every other version/platform

## Validation

- `bash scripts/test-linux-release-construction.sh`
- `bash scripts/tests/smoke-daemon-semantic-release-test.sh`
- `bash scripts/check-buildkite-pipeline.sh`
- real six-platform candidate assembly (pending regenerated x64 proof after this change)
