### PR TITLE
Verify macOS attestations against candidate source

### DIFF
--- a/scripts/stage-github-release-assets.sh
+++ b/scripts/stage-github-release-assets.sh
@@ -465,7 +465,8 @@ validate_macos_signing_evidence() (
   local runtime_attestation_cms="${artifact_dir%/}/ctx-onnxruntime-${platform}.attestation.cms"
   local release_attestation="${artifact_dir%/}/ctx-onnxruntime-${platform}.release-attestation.json"
   local release_attestation_cms="${artifact_dir%/}/ctx-onnxruntime-${platform}.release-attestation.cms"
-  local work nested
+  local build_info="${artifact_dir%/}/ctx-${platform}.build-info.json"
+  local source_commit work nested
 
   # JSON records diagnostics and archive bindings. The Developer ID CMS
   # checks below are the cross-platform authorization for executable bytes.
@@ -477,13 +478,34 @@ validate_macos_signing_evidence() (
     printf 'required macOS runtime signing evidence missing: %s\n' "${runtime_evidence}" >&2
     exit 1
   }
+  source_commit="$(python3 - "${build_info}" "${platform}" <<'PY'
+import json
+import re
+import sys
+
+path, platform = sys.argv[1:]
+with open(path, encoding="utf-8") as source:
+    payload = json.load(source)
+commit = payload.get("source", {}).get("commit", "")
+if (
+    payload.get("schema_version") != 1
+    or payload.get("platform") != platform
+    or payload.get("source", {}).get("clean") is not True
+    or re.fullmatch(r"[0-9a-f]{40}", commit) is None
+    or commit == "0" * 40
+):
+    raise SystemExit("macOS release build info has invalid source provenance")
+print(commit)
+PY
+)"
   python3 scripts/macos-release-signing-evidence.py verify-artifact \
     --evidence "${cli_evidence}" \
     --platform "${platform}" \
     --kind cli \
     --artifact "${binary}" \
     --checksum "${binary}.sha256"
-  scripts/verify-macos-release-attestation.sh \
+  CTX_MACOS_RELEASE_SOURCE_COMMIT="${source_commit}" \
+    scripts/verify-macos-release-attestation.sh \
     "${platform}" cli "${binary}" "${cli_attestation}" "${cli_attestation_cms}"
 
   work="$(mktemp -d "${TMPDIR:-/tmp}/ctx-stage-macos-signing.XXXXXX")"
@@ -512,10 +534,12 @@ PY
     --checksum "${runtime}.sha256" \
     --nested-artifact "${nested}" \
     --role release
-  scripts/verify-macos-release-attestation.sh \
+  CTX_MACOS_RELEASE_SOURCE_COMMIT="${source_commit}" \
+    scripts/verify-macos-release-attestation.sh \
     "${platform}" runtime "${nested}" \
     "${runtime_attestation}" "${runtime_attestation_cms}"
-  scripts/verify-macos-release-attestation.sh --runtime-archive \
+  CTX_MACOS_RELEASE_SOURCE_COMMIT="${source_commit}" \
+    scripts/verify-macos-release-attestation.sh --runtime-archive \
     "${platform}" "${runtime}" "${nested}" \
     "${release_attestation}" "${release_attestation_cms}"
 )

--- a/scripts/tests/macos-release-signing-test.sh
+++ b/scripts/tests/macos-release-signing-test.sh
@@ -943,6 +943,21 @@ PY
     "${decoy_root}/scripts/verify-macos-release-attestation.sh" \
       macos-arm64 cli "${decoy_cli}" "${decoy_cli_statement}" "${decoy_valid_cms}" \
       >/dev/null
+  env PATH=/usr/bin:/bin CTX_MACOS_RELEASE_SOURCE_COMMIT="${decoy_commit}" \
+    "${decoy_root}/scripts/verify-macos-release-attestation.sh" \
+      macos-arm64 cli "${decoy_cli}" "${decoy_cli_statement}" "${decoy_valid_cms}" \
+      >/dev/null
+  expect_failure 'source commit must be a non-placeholder' \
+    "${test_root}/real-decoy-invalid-source-commit.log" \
+    env PATH=/usr/bin:/bin CTX_MACOS_RELEASE_SOURCE_COMMIT=not-a-commit \
+    "${decoy_root}/scripts/verify-macos-release-attestation.sh" \
+      macos-arm64 cli "${decoy_cli}" "${decoy_cli_statement}" "${decoy_valid_cms}"
+  expect_failure 'signed macOS attestation does not bind the exact pinned artifact' \
+    "${test_root}/real-decoy-wrong-source-commit.log" \
+    env PATH=/usr/bin:/bin \
+    CTX_MACOS_RELEASE_SOURCE_COMMIT=1111111111111111111111111111111111111111 \
+    "${decoy_root}/scripts/verify-macos-release-attestation.sh" \
+      macos-arm64 cli "${decoy_cli}" "${decoy_cli_statement}" "${decoy_valid_cms}"
   /usr/bin/openssl cms -sign -binary -in "${decoy_cli_statement}" \
     -signer "${decoy_root}/wrong.pem" -inkey "${decoy_root}/wrong.key" \
     -certfile "${decoy_root}/decoy.pem" -outform DER -out "${decoy_cli_cms}" \

--- a/scripts/verify-macos-release-attestation.sh
+++ b/scripts/verify-macos-release-attestation.sh
@@ -112,7 +112,12 @@ openssl verify -purpose any -partial_chain -no-CApath -no-CAstore -ignore_critic
   -CAfile "${ca_file}" "${signer_cert}" >/dev/null 2>&1 || \
   die "macOS attestation actual signer does not chain exclusively to the pinned Apple G2 CA"
 
-source_commit="$(git -C "${root_dir}" rev-parse --verify HEAD)"
+source_commit="${CTX_MACOS_RELEASE_SOURCE_COMMIT:-}"
+if [[ -z "${source_commit}" ]]; then
+  source_commit="$(git -C "${root_dir}" rev-parse --verify HEAD)"
+fi
+[[ "${source_commit}" =~ ^[0-9a-f]{40}$ && ! "${source_commit}" =~ ^0{40}$ ]] || \
+  die "macOS release source commit must be a non-placeholder 40-character Git commit"
 if [[ "${mode}" == "runtime_archive" ]]; then
   python3 "${root_dir}/scripts/macos-release-signing-evidence.py" \
     verify-runtime-archive-attestation \


### PR DESCRIPTION
## Summary

- verify signed macOS attestations against the candidate source commit recorded in hash-bound build info
- allow release tooling to advance without invalidating unchanged signed and notarized candidate bytes
- retain exact artifact, runtime archive, signer, Team ID, CA, and notarization bindings

## Validation

- `bash scripts/tests/macos-release-signing-test.sh`
- `bash scripts/test-linux-release-construction.sh`
- complete real 12-asset v0.25 staging passed with both macOS architectures
- `git diff --check`
