### PR TITLE
Canonicalize test temp roots on macOS

### DIFF
--- a/crates/ctx-cli/src/commands/import/native_tests.rs
+++ b/crates/ctx-cli/src/commands/import/native_tests.rs
@@ -6,9 +6,18 @@ use ctx_history_core::{
 use ctx_history_store::{SourceImportFile, SourceImportFileIndexUpdate};
 use serde_json::json;
 
+fn tempdir() -> tempfile::TempDir {
+    let temp_root = fs::canonicalize(std::env::temp_dir())
+        .expect("system temporary directory should be canonicalizable");
+    tempfile::Builder::new()
+        .prefix("ctx-native-import-")
+        .tempdir_in(temp_root)
+        .unwrap()
+}
+
 #[test]
 fn codex_preinventory_failures_survive_when_catalog_has_no_pending_sessions() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let source_path = temp.path().join("sessions");
     fs::create_dir_all(&source_path).unwrap();
     let source = explicit_path_source(CaptureProvider::Codex, source_path);
@@ -67,7 +76,7 @@ fn persist_indexed_root(
 
 #[test]
 fn unchanged_root_source_skips_provider_normalization() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let source_path = temp.path().join("state.db");
     let source = explicit_path_source(CaptureProvider::Hermes, source_path.clone());
     let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
@@ -87,7 +96,7 @@ fn unchanged_root_source_skips_provider_normalization() {
 
 #[test]
 fn unchanged_root_source_still_repairs_event_search_backfill() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let db_path = temp.path().join("work.sqlite");
     let source_path = temp.path().join("state.db");
     let source = explicit_path_source(CaptureProvider::Hermes, source_path);
@@ -143,7 +152,7 @@ fn unchanged_root_source_still_repairs_event_search_backfill() {
 
 #[test]
 fn changed_root_source_does_not_skip_provider_normalization() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let source_path = temp.path().join("state.db");
     let source = explicit_path_source(CaptureProvider::Hermes, source_path.clone());
     let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
@@ -178,7 +187,7 @@ fn changed_root_source_does_not_skip_provider_normalization() {
 
 #[test]
 fn full_rescan_does_not_skip_unchanged_root_source() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let source_path = temp.path().join("state.db");
     std::fs::write(&source_path, b"not a sqlite database").unwrap();
     let source = explicit_path_source(CaptureProvider::Hermes, source_path);

--- a/crates/ctx-cli/tests/support/runner.rs
+++ b/crates/ctx-cli/tests/support/runner.rs
@@ -7,7 +7,12 @@ use std::{
 use tempfile::{Builder, TempDir};
 
 pub(crate) fn tempdir() -> TempDir {
-    Builder::new().prefix("ctx-search-mvp-").tempdir().unwrap()
+    let temp_root = fs::canonicalize(std::env::temp_dir())
+        .expect("system temporary directory should be canonicalizable");
+    Builder::new()
+        .prefix("ctx-search-mvp-")
+        .tempdir_in(temp_root)
+        .unwrap()
 }
 
 pub(crate) fn ctx(temp: &TempDir) -> Command {

--- a/crates/ctx-history-capture/src/provider_sources/tests/default_discovery.rs
+++ b/crates/ctx-history-capture/src/provider_sources/tests/default_discovery.rs
@@ -1,11 +1,11 @@
 use ctx_history_core::CaptureProvider;
 
 use super::super::{discover_provider_sources, ProviderImportSupport, ProviderSourceStatus};
-use super::support::assert_source_status;
+use super::support::{assert_source_status, tempdir};
 
 #[test]
 fn gemini_default_source_is_empty_until_chat_transcripts_exist() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let gemini = temp.path().join(".gemini");
     std::fs::create_dir_all(&gemini).unwrap();
 
@@ -35,7 +35,7 @@ fn gemini_default_source_is_empty_until_chat_transcripts_exist() {
 
 #[test]
 fn tabnine_default_source_is_empty_until_chat_transcripts_exist() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let tabnine = temp.path().join(".tabnine/agent");
     std::fs::create_dir_all(&tabnine).unwrap();
 
@@ -69,7 +69,7 @@ fn tabnine_default_source_is_empty_until_chat_transcripts_exist() {
 
 #[test]
 fn codebuddy_default_source_accepts_cli_project_jsonl() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let codebuddy = temp.path().join(".codebuddy");
     std::fs::create_dir_all(&codebuddy).unwrap();
 
@@ -99,7 +99,7 @@ fn codebuddy_default_source_accepts_cli_project_jsonl() {
 
 #[test]
 fn codebuddy_cli_projects_probe_precedes_unrelated_root_entries() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let codebuddy = temp.path().join(".codebuddy");
     let project = codebuddy.join("projects/sanitized-workspace");
     std::fs::create_dir_all(&project).unwrap();
@@ -124,7 +124,7 @@ fn codebuddy_cli_projects_probe_precedes_unrelated_root_entries() {
 
 #[test]
 fn junie_default_source_accepts_unindexed_session_sibling() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let sessions = temp.path().join(".junie/sessions");
     let unindexed = sessions.join("session-260709-212620-18se");
     std::fs::create_dir_all(&unindexed).unwrap();
@@ -149,7 +149,7 @@ fn junie_default_source_accepts_unindexed_session_sibling() {
 
 #[test]
 fn junie_default_source_stops_at_index_entry_budget() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let sessions = temp.path().join(".junie/sessions");
     let target = sessions.join("session-after-budget");
     std::fs::create_dir_all(&target).unwrap();
@@ -172,7 +172,7 @@ fn junie_default_source_stops_at_index_entry_budget() {
 fn junie_default_source_does_not_follow_symlinked_index() {
     use std::os::unix::fs::symlink;
 
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let sessions = temp.path().join(".junie/sessions");
     let target = sessions.join("session-from-linked-index");
     std::fs::create_dir_all(&target).unwrap();
@@ -194,7 +194,7 @@ fn junie_default_source_does_not_follow_symlinked_index() {
 
 #[test]
 fn codex_default_source_is_empty_until_jsonl_sessions_exist() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let sessions = temp.path().join(".codex/sessions");
     std::fs::create_dir_all(&sessions).unwrap();
 
@@ -220,7 +220,7 @@ fn codex_default_source_is_empty_until_jsonl_sessions_exist() {
 
 #[test]
 fn native_provider_default_discovery_uses_importer_specific_file_predicates() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
 
     let pi = temp.path().join(".pi/agent/sessions");
     std::fs::create_dir_all(pi.join("--workspace--")).unwrap();

--- a/crates/ctx-history-capture/src/provider_sources/tests/env_discovery.rs
+++ b/crates/ctx-history-capture/src/provider_sources/tests/env_discovery.rs
@@ -11,16 +11,17 @@ use super::super::{
     specs::TRAE_STATE_VSCDB_SOURCE_FORMAT,
 };
 use super::support::{
-    shared_provider_history_fixture, write_junie_discovery_session, write_kimi_discovery_wire,
-    write_lingma_discovery_db, write_mistral_vibe_discovery_session, write_mux_discovery_session,
-    write_pi_discovery_session, write_qwen_discovery_chat, write_task_json_discovery_task,
-    write_trae_discovery_db, write_trae_non_chat_state_db, CwdGuard, EnvGuard, ENV_LOCK,
+    shared_provider_history_fixture, tempdir, write_junie_discovery_session,
+    write_kimi_discovery_wire, write_lingma_discovery_db, write_mistral_vibe_discovery_session,
+    write_mux_discovery_session, write_pi_discovery_session, write_qwen_discovery_chat,
+    write_task_json_discovery_task, write_trae_discovery_db, write_trae_non_chat_state_db,
+    CwdGuard, EnvGuard, ENV_LOCK,
 };
 
 #[test]
 fn continue_discovery_uses_global_dir_env_sessions_subdir() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let continue_home = temp.path().join("continue-home");
     let sessions = continue_home.join("sessions");
     std::fs::create_dir_all(&sessions).unwrap();
@@ -41,7 +42,7 @@ fn continue_discovery_uses_global_dir_env_sessions_subdir() {
 #[test]
 fn kilo_discovery_uses_xdg_kilo_db_env_override_and_channel_dbs() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let _kilo_db = EnvGuard::remove("KILO_DB");
     let _xdg_data = EnvGuard::remove("XDG_DATA_HOME");
     let _config_dir = EnvGuard::remove("KILO_CONFIG_DIR");
@@ -100,7 +101,7 @@ fn kilo_discovery_uses_xdg_kilo_db_env_override_and_channel_dbs() {
 #[test]
 fn qwen_discovery_uses_runtime_and_home_env_overrides() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let runtime = temp.path().join("qwen-runtime");
     write_qwen_discovery_chat(&runtime.join("projects"));
     let qwen_home = temp.path().join("qwen-home");
@@ -122,7 +123,7 @@ fn qwen_discovery_uses_runtime_and_home_env_overrides() {
 #[test]
 fn kimi_discovery_uses_home_env_override() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let kimi_home = temp.path().join("kimi-home");
     write_kimi_discovery_wire(&kimi_home);
     let _home = EnvGuard::set("KIMI_CODE_HOME", kimi_home.as_os_str());
@@ -157,7 +158,7 @@ fn kimi_discovery_uses_home_env_override() {
 #[test]
 fn codebuddy_discovery_uses_localappdata_override() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let local_app_data = temp.path().join("local-app-data");
     let codebuddy = local_app_data.join("CodeBuddyExtension");
     let session = codebuddy
@@ -188,7 +189,7 @@ fn codebuddy_discovery_uses_localappdata_override() {
 #[test]
 fn firebender_discovery_uses_current_project_chat_history_db() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let project = temp.path().join("project");
     let nested = project.join("src/module");
     let db = project.join(".idea/firebender/chat_history.db");
@@ -220,7 +221,7 @@ fn firebender_discovery_uses_current_project_chat_history_db() {
 #[test]
 fn junie_discovery_uses_default_sessions_and_env_overrides() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let _sessions_dir = EnvGuard::remove("JUNIE_SESSIONS_DIR");
     let _junie_home = EnvGuard::remove("JUNIE_HOME");
 
@@ -268,7 +269,7 @@ fn junie_discovery_uses_default_sessions_and_env_overrides() {
 #[test]
 fn mistral_vibe_discovery_uses_default_and_home_env_sessions() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let _home = EnvGuard::remove("VIBE_HOME");
 
     let default_sessions = temp.path().join(".vibe/logs/session");
@@ -302,7 +303,7 @@ fn mistral_vibe_discovery_uses_default_and_home_env_sessions() {
 #[test]
 fn mux_discovery_uses_default_and_mux_root_sessions() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let _home = EnvGuard::remove("MUX_ROOT");
 
     let default_sessions = temp.path().join(".mux/sessions");
@@ -334,7 +335,7 @@ fn mux_discovery_uses_default_and_mux_root_sessions() {
 
 #[test]
 fn deepagents_discovery_uses_default_sessions_db() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let db = temp.path().join(".deepagents/.state/sessions.db");
     std::fs::create_dir_all(db.parent().unwrap()).unwrap();
 
@@ -370,7 +371,7 @@ fn deepagents_discovery_uses_default_sessions_db() {
 #[test]
 fn crush_discovery_uses_global_config_data_directory() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let config = temp.path().join("crush.json");
     let data_dir = temp.path().join("custom-crush-data");
     std::fs::create_dir_all(&data_dir).unwrap();
@@ -398,7 +399,7 @@ fn crush_discovery_uses_global_config_data_directory() {
 #[test]
 fn goose_discovery_uses_path_root_data_sessions_db() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let root = temp.path().join("goose-root");
     let sessions = root.join("data/sessions");
     std::fs::create_dir_all(&sessions).unwrap();
@@ -418,7 +419,7 @@ fn goose_discovery_uses_path_root_data_sessions_db() {
 #[test]
 fn warp_discovery_uses_documented_state_and_localappdata_paths() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let xdg_state = temp.path().join("xdg-state");
     let local_app_data = temp.path().join("local-app-data");
     let linux_db = xdg_state.join("warp-terminal/warp.sqlite");
@@ -445,7 +446,7 @@ fn warp_discovery_uses_documented_state_and_localappdata_paths() {
 
 #[test]
 fn lingma_discovery_uses_waylog_default_local_db_paths() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let stable = temp
         .path()
         .join(".lingma/vscode/sharedClientCache/cache/db/local.db");
@@ -470,7 +471,7 @@ fn lingma_discovery_uses_waylog_default_local_db_paths() {
 #[test]
 fn trae_discovery_uses_workspace_storage_roots_as_native_sources() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let appdata = temp.path().join("appdata");
     let _appdata = EnvGuard::set("APPDATA", appdata.as_os_str());
 
@@ -522,7 +523,7 @@ fn trae_discovery_uses_workspace_storage_roots_as_native_sources() {
 #[test]
 fn pi_discovery_uses_env_session_dir() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let custom = temp.path().join("pi-env-sessions");
     write_pi_discovery_session(&custom);
     let _session_dir = EnvGuard::set("PI_CODING_AGENT_SESSION_DIR", custom.as_os_str());
@@ -541,8 +542,8 @@ fn pi_discovery_uses_env_session_dir() {
 #[test]
 fn pi_discovery_uses_global_and_project_settings_session_dirs() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
-    let project = tempfile::tempdir().unwrap();
+    let temp = tempdir();
+    let project = tempdir();
     let _session_dir = EnvGuard::remove("PI_CODING_AGENT_SESSION_DIR");
     let _agent_dir = EnvGuard::remove("PI_CODING_AGENT_DIR");
 
@@ -585,7 +586,7 @@ fn pi_discovery_uses_global_and_project_settings_session_dirs() {
 #[test]
 fn cline_discovery_uses_env_data_dirs() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let custom = temp.path().join("custom-cline-data");
     write_task_json_discovery_task(&custom, "cline-env-task", "api_conversation_history.json");
     let _data_dir = EnvGuard::set("CLINE_DATA_DIR", custom.as_os_str());
@@ -606,7 +607,7 @@ fn cline_discovery_uses_env_data_dirs() {
 #[test]
 fn roo_discovery_uses_custom_storage_setting() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let custom = temp.path().join("roo-custom-storage");
     write_task_json_discovery_task(&custom, "roo-custom-task", "history_item.json");
     let settings = temp.path().join(".config/Code/User/settings.json");

--- a/crates/ctx-history-capture/src/provider_sources/tests/probe_status.rs
+++ b/crates/ctx-history-capture/src/provider_sources/tests/probe_status.rs
@@ -4,11 +4,11 @@ use super::super::probes::{default_location_import_probe, BoundedProbe};
 use super::super::{
     discover_provider_sources, ProviderDefaultLocation, ProviderSourceKind, ProviderSourceStatus,
 };
-use super::support::assert_source_status;
+use super::support::{assert_source_status, tempdir};
 
 #[test]
 fn bounded_probe_reports_budget_exhausted_source_as_unknown() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let claude = temp.path().join(".claude/projects");
     std::fs::create_dir_all(&claude).unwrap();
     for index in 0..10_001 {
@@ -24,7 +24,7 @@ fn bounded_probe_reports_budget_exhausted_source_as_unknown() {
 
 #[test]
 fn default_location_probe_does_not_fallback_to_path_existence_for_unhandled_providers() {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let existing = temp.path().join("shell-history");
     std::fs::write(&existing, "{}\n").unwrap();
     let location = ProviderDefaultLocation {
@@ -44,7 +44,7 @@ fn default_location_probe_does_not_fallback_to_path_existence_for_unhandled_prov
 fn default_source_probe_reports_unreadable_directory_as_unknown() {
     use std::os::unix::fs::PermissionsExt;
 
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let sessions = temp.path().join(".codex/sessions");
     std::fs::create_dir_all(&sessions).unwrap();
     let original_permissions = std::fs::metadata(&sessions).unwrap().permissions();
@@ -76,7 +76,7 @@ fn default_source_probe_reports_unreadable_directory_as_unknown() {
 fn default_source_probe_skips_unreadable_child_directory() {
     use std::os::unix::fs::PermissionsExt;
 
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempdir();
     let sessions = temp.path().join(".codex/sessions");
     let readable = sessions.join("readable");
     let unreadable = sessions.join("unreadable");

--- a/crates/ctx-history-capture/src/provider_sources/tests/support.rs
+++ b/crates/ctx-history-capture/src/provider_sources/tests/support.rs
@@ -14,6 +14,15 @@ use super::super::{discover_provider_sources, ProviderSourceStatus};
 
 pub(super) static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+pub(super) fn tempdir() -> tempfile::TempDir {
+    let temp_root = std::fs::canonicalize(std::env::temp_dir())
+        .expect("system temporary directory should be canonicalizable");
+    tempfile::Builder::new()
+        .prefix("ctx-provider-sources-")
+        .tempdir_in(temp_root)
+        .unwrap()
+}
+
 pub(super) struct EnvGuard {
     name: &'static str,
     original: Option<OsString>,

--- a/crates/ctx-history-capture/src/tests/support.rs
+++ b/crates/ctx-history-capture/src/tests/support.rs
@@ -95,10 +95,21 @@ pub(super) use tempfile::TempDir;
 pub(super) use uuid::Uuid;
 
 pub(super) fn tempdir() -> TempDir {
+    let temp_root = fs::canonicalize(std::env::temp_dir())
+        .expect("system temporary directory should be canonicalizable");
     tempfile::Builder::new()
         .prefix("ctx-history-capture-")
-        .tempdir()
+        .tempdir_in(temp_root)
         .unwrap()
+}
+
+#[test]
+fn test_tempdir_has_no_symlinked_parent_components() {
+    let temp = tempdir();
+    crate::common::io::ensure_provider_path_parents_are_not_symlinks(
+        &temp.path().join("provider-transcript.jsonl"),
+    )
+    .unwrap();
 }
 
 pub(super) fn assert_sqlite_source_file_unchanged(

--- a/crates/ctx-history-capture/tests/cursor_native.rs
+++ b/crates/ctx-history-capture/tests/cursor_native.rs
@@ -9,9 +9,11 @@ use rusqlite::Connection;
 use tempfile::TempDir;
 
 fn tempdir() -> TempDir {
+    let temp_root = fs::canonicalize(std::env::temp_dir())
+        .expect("system temporary directory should be canonicalizable");
     tempfile::Builder::new()
         .prefix("cursor-native-import-")
-        .tempdir()
+        .tempdir_in(temp_root)
         .unwrap()
 }
 


### PR DESCRIPTION
## Summary

- canonicalize the system temporary root before creating provider-import test directories
- route provider-source discovery tests through the same canonical test helper
- preserve production symlink rejection unchanged

## Root cause

On macOS, temporary directories are commonly returned under `/var/folders/...`, while `/var` resolves to `/private/var`. Tests either passed the lexical `/var/...` path into production validation or compared it with a canonical `/private/var/...` discovery result.

## Validation

- reproduced the original failure on an Apple M1 running macOS 26.2
- `cargo test -p ctx-history-capture`: 259 passed, 1 ignored
- native-import unit tests: 5 passed
- native provider real-shape tests: 2 passed
- native provider rejection tests: 10 passed
- `cargo fmt --all --check`
- `git diff --check`
- independent implementation review completed with no findings

Closes #161.
