### PR TITLE
Clarify provider retention helper names

### DIFF
--- a/crates/ctx-history-capture/src/provider/codex/events.rs
+++ b/crates/ctx-history-capture/src/provider/codex/events.rs
@@ -18,7 +18,8 @@ use crate::common::time::{parse_optional_rfc3339_field, parse_rfc3339_utc};
 use crate::provider::file_touches::event_type_supports_structured_file_touches;
 use crate::provider::importer::provider_cursor_stream;
 use crate::provider::native::{
-    capped_text, provider_output_event_is_failure, provider_sanitized_output_preview_value,
+    capped_text, provider_output_event_is_failure,
+    provider_output_preview_omitting_nested_patch_diff,
 };
 use crate::{
     CaptureError, ProviderAdapterContext, ProviderFileTouchedEnvelope, Result,
@@ -483,9 +484,9 @@ pub(crate) fn codex_tool_output_event(
     } else {
         EventType::ToolOutput
     };
-    let sanitized_output_text =
-        output_text_ref.map(|text| provider_sanitized_output_preview_value(payload, text));
-    let (output_preview, output_truncated) = sanitized_output_text
+    let retained_output_text = output_text_ref
+        .map(|text| provider_output_preview_omitting_nested_patch_diff(payload, text));
+    let (output_preview, output_truncated) = retained_output_text
         .as_deref()
         .map(|text| codex_local_preview(text, PROVIDER_MAX_PREVIEW_CHARS))
         .unwrap_or_else(|| (String::new(), false));

--- a/crates/ctx-history-capture/src/provider/native.rs
+++ b/crates/ctx-history-capture/src/provider/native.rs
@@ -447,7 +447,7 @@ pub(crate) fn provider_policy_event_text(
     let retention = native_event_retention(event_type, body);
     let text = match retention {
         NativeEventRetention::FailedOutputPreview => {
-            provider_sanitized_output_preview_value(body, text)
+            provider_output_preview_omitting_nested_patch_diff(body, text)
         }
         _ => text.to_owned(),
     };
@@ -467,25 +467,29 @@ pub(crate) fn provider_policy_event_text(
 }
 
 pub(crate) fn provider_policy_body(event_type: EventType, body: &Value) -> Value {
-    let mut sanitized = provider_sanitize_body_value(event_type, body, None);
-    if let Value::Object(object) = &mut sanitized {
+    let mut retained = provider_filter_body_by_retention_policy(event_type, body, None);
+    if let Value::Object(object) = &mut retained {
         object.insert(
             "content_retention".to_owned(),
             Value::String(native_event_retention(event_type, body).as_str().to_owned()),
         );
     }
-    sanitized
+    retained
 }
 
-fn provider_sanitize_body_value(event_type: EventType, value: &Value, key: Option<&str>) -> Value {
-    if key.is_some_and(|key| provider_policy_redact_key(event_type, key, value)) {
-        return provider_redacted_body_value(value);
+fn provider_filter_body_by_retention_policy(
+    event_type: EventType,
+    value: &Value,
+    key: Option<&str>,
+) -> Value {
+    if key.is_some_and(|key| provider_should_omit_body_field(event_type, key, value)) {
+        return provider_omitted_body_field(value);
     }
     match value {
         Value::Array(items) => Value::Array(
             items
                 .iter()
-                .map(|item| provider_sanitize_body_value(event_type, item, key))
+                .map(|item| provider_filter_body_by_retention_policy(event_type, item, key))
                 .collect(),
         ),
         Value::Object(object) => Value::Object(
@@ -494,7 +498,7 @@ fn provider_sanitize_body_value(event_type: EventType, value: &Value, key: Optio
                 .map(|(key, value)| {
                     (
                         key.clone(),
-                        provider_sanitize_body_value(event_type, value, Some(key)),
+                        provider_filter_body_by_retention_policy(event_type, value, Some(key)),
                     )
                 })
                 .collect(),
@@ -503,7 +507,7 @@ fn provider_sanitize_body_value(event_type: EventType, value: &Value, key: Optio
     }
 }
 
-fn provider_policy_redact_key(event_type: EventType, key: &str, value: &Value) -> bool {
+fn provider_should_omit_body_field(event_type: EventType, key: &str, value: &Value) -> bool {
     let key = provider_normalized_key(key);
     if matches!(
         event_type,
@@ -550,7 +554,7 @@ fn provider_policy_redact_key(event_type: EventType, key: &str, value: &Value) -
         && provider_value_contains_patch_or_diff(value))
 }
 
-fn provider_redacted_body_value(value: &Value) -> Value {
+fn provider_omitted_body_field(value: &Value) -> Value {
     json!({
         "content_retention": "metadata_only",
         "omitted_bytes": provider_value_approx_bytes(value),
@@ -594,18 +598,21 @@ fn provider_text_contains_patch_or_diff(text: &str) -> bool {
         || text.contains("\n--- ")
 }
 
-pub(crate) fn provider_sanitized_output_preview_value(value: &Value, text: &str) -> String {
+pub(crate) fn provider_output_preview_omitting_nested_patch_diff(
+    value: &Value,
+    text: &str,
+) -> String {
     if provider_value_contains_patch_or_diff(value) {
         format!(
             "[output omitted: contains patch or diff content; bytes={}]",
             provider_value_approx_bytes(value)
         )
     } else {
-        provider_sanitized_output_preview(text)
+        provider_output_preview_omitting_patch_diff(text)
     }
 }
 
-pub(crate) fn provider_sanitized_output_preview(text: &str) -> String {
+pub(crate) fn provider_output_preview_omitting_patch_diff(text: &str) -> String {
     if provider_text_contains_patch_or_diff(text) {
         format!(
             "[output omitted: contains patch or diff content; bytes={}]",
@@ -1022,7 +1029,7 @@ mod tests {
     }
 
     #[test]
-    fn native_event_retains_real_text_and_redacts_noisy_body_fields() {
+    fn native_event_retains_real_text_and_omits_noisy_body_fields() {
         let event = test_native_event(
             EventType::Message,
             "real conversation oracle",
@@ -1126,7 +1133,7 @@ mod tests {
     }
 
     #[test]
-    fn native_event_redacts_patch_arguments_from_tool_metadata_body() {
+    fn native_event_omits_patch_arguments_from_tool_metadata_body() {
         let event = test_native_event(
             EventType::ToolCall,
             "apply_patch file touches: modified:src/main.rs",


### PR DESCRIPTION
## Summary

- replace internal `sanitize`/`redact` helper names with retention and omission terminology
- update the native provider implementation and Codex call site
- rename directly corresponding locals and tests

## Why

The existing names implied broad privacy or secret sanitization, while the code only applies the provider body-retention policy and omits patch/diff output. This is a behavior-neutral internal naming cleanup.

## Compatibility

No serialized values, JSON keys, omission markers, limits, or control flow changed.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- focused native provider tests: 3 passed
- `cargo test -p ctx-history-capture`: 259 passed, 1 ignored
- independent grandchild code review: no findings, merge-ready
