### PR TITLE
De-overload provider retention metadata

### DIFF
--- a/crates/ctx-history-capture/src/provider/codex/events.rs
+++ b/crates/ctx-history-capture/src/provider/codex/events.rs
@@ -725,9 +725,9 @@ pub(crate) fn codex_tool_arguments_preview(value: &Value) -> (String, bool, bool
     if !file_touches.is_empty() {
         return codex_file_touch_arguments_preview(&file_touches);
     }
-    let (sanitized, redacted) = codex_sanitized_tool_argument_value(&parsed, None);
-    let (preview, truncated) = codex_value_preview(&sanitized, PROVIDER_MAX_PREVIEW_CHARS);
-    (preview, truncated, !redacted)
+    let (retained, fields_omitted) = codex_tool_argument_value_with_omissions(&parsed, None);
+    let (preview, truncated) = codex_value_preview(&retained, PROVIDER_MAX_PREVIEW_CHARS);
+    (preview, truncated, !fields_omitted)
 }
 pub(crate) fn codex_file_touch_arguments_preview(
     file_touches: &[crate::provider::file_touches::FileTouchDraft],
@@ -749,43 +749,43 @@ pub(crate) fn codex_file_touch_arguments_preview(
     };
     (format!("file touches: {paths}{suffix}"), omitted > 0, false)
 }
-pub(crate) fn codex_sanitized_tool_argument_value(
+pub(crate) fn codex_tool_argument_value_with_omissions(
     value: &Value,
     key: Option<&str>,
 ) -> (Value, bool) {
-    if key.is_some_and(|key| codex_tool_argument_key_should_redact(key, value)) {
-        return (codex_redacted_argument_value(value), true);
+    if key.is_some_and(|key| codex_tool_argument_key_should_omit(key, value)) {
+        return (codex_omitted_argument_value(value), true);
     }
     match value {
         Value::Array(items) => {
-            let mut redacted = false;
+            let mut fields_omitted = false;
             let items = items
                 .iter()
                 .map(|item| {
-                    let (item, item_redacted) = codex_sanitized_tool_argument_value(item, key);
-                    redacted |= item_redacted;
+                    let (item, item_omitted) = codex_tool_argument_value_with_omissions(item, key);
+                    fields_omitted |= item_omitted;
                     item
                 })
                 .collect();
-            (Value::Array(items), redacted)
+            (Value::Array(items), fields_omitted)
         }
         Value::Object(object) => {
-            let mut redacted = false;
+            let mut fields_omitted = false;
             let object = object
                 .iter()
                 .map(|(key, value)| {
-                    let (value, value_redacted) =
-                        codex_sanitized_tool_argument_value(value, Some(key));
-                    redacted |= value_redacted;
+                    let (value, value_omitted) =
+                        codex_tool_argument_value_with_omissions(value, Some(key));
+                    fields_omitted |= value_omitted;
                     (key.clone(), value)
                 })
                 .collect();
-            (Value::Object(object), redacted)
+            (Value::Object(object), fields_omitted)
         }
         _ => (value.clone(), false),
     }
 }
-pub(crate) fn codex_tool_argument_key_should_redact(key: &str, value: &Value) -> bool {
+pub(crate) fn codex_tool_argument_key_should_omit(key: &str, value: &Value) -> bool {
     let key = codex_normalized_key(key);
     matches!(
         key.as_str(),
@@ -810,11 +810,13 @@ pub(crate) fn codex_tool_argument_key_should_redact(key: &str, value: &Value) ->
     ) || (matches!(key.as_str(), "input" | "arguments" | "args" | "params")
         && codex_value_contains_patch_or_diff(value))
 }
-pub(crate) fn codex_redacted_argument_value(value: &Value) -> Value {
+pub(crate) fn codex_omitted_argument_value(value: &Value) -> Value {
     json!({
-        "content_retention": "metadata_only",
-        "omitted_bytes": codex_value_approx_bytes(value),
-        "contains_patch_or_diff": codex_value_contains_patch_or_diff(value),
+        "field_retention": {
+            "mode": "omitted",
+            "original_bytes": codex_value_approx_bytes(value),
+            "contained_patch_or_diff": codex_value_contains_patch_or_diff(value),
+        },
     })
 }
 pub(crate) fn codex_normalized_key(key: &str) -> String {

--- a/crates/ctx-history-capture/src/provider/importer.rs
+++ b/crates/ctx-history-capture/src/provider/importer.rs
@@ -9,6 +9,7 @@ use ctx_history_core::{
     EventRole, EventType, Fidelity, FileTouched, ProviderCaptureEnvelope, ProviderCursorCheckpoint,
     ProviderCursorRange, ProviderEventEnvelope, ProviderSessionEnvelope, ProviderSourceEnvelope,
     ProviderSourceTrust, Session, SessionEdge, SessionEdgeType,
+    PROVIDER_CAPTURE_ENVELOPE_MIN_SUPPORTED_SCHEMA_VERSION,
     PROVIDER_CAPTURE_ENVELOPE_SCHEMA_VERSION,
 };
 use ctx_history_store::{Store, StoreError};
@@ -506,7 +507,10 @@ pub(crate) fn import_provider_capture_line(
     line_number: usize,
     caches: &mut ProviderImportCaches,
 ) -> Result<ProviderImportSummary> {
-    if capture.schema_version != PROVIDER_CAPTURE_ENVELOPE_SCHEMA_VERSION {
+    if !(PROVIDER_CAPTURE_ENVELOPE_MIN_SUPPORTED_SCHEMA_VERSION
+        ..=PROVIDER_CAPTURE_ENVELOPE_SCHEMA_VERSION)
+        .contains(&capture.schema_version)
+    {
         return Err(CaptureError::InvalidPayload(format!(
             "unsupported provider capture envelope schema version {} on line {line_number}",
             capture.schema_version

--- a/crates/ctx-history-capture/src/provider/native.rs
+++ b/crates/ctx-history-capture/src/provider/native.rs
@@ -372,8 +372,7 @@ pub(crate) struct NativeEventDraft {
 }
 
 pub(crate) fn native_event(draft: NativeEventDraft) -> ProviderEventEnvelope {
-    let (text, truncated, retention) =
-        provider_policy_event_text(draft.event_type, &draft.text, &draft.body);
+    let retained_text = provider_policy_event_text(draft.event_type, &draft.text, &draft.body);
     let body = provider_policy_body(draft.event_type, &draft.body);
     ProviderEventEnvelope {
         provider_event_index: draft.provider_event_index,
@@ -391,50 +390,100 @@ pub(crate) fn native_event(draft: NativeEventDraft) -> ProviderEventEnvelope {
         )),
         artifacts: Vec::new(),
         payload: json!({
-            "text": text,
-            "truncated": truncated,
+            "text": retained_text.text,
+            "text_retention": retained_text.retention.as_json(),
             "source_format": draft.source_format,
             "body": provider_capped_json(&body, PROVIDER_MAX_PREVIEW_CHARS),
-            "content_retention": retention.as_str(),
         }),
         metadata: draft.metadata,
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum NativeEventRetention {
-    FullText,
-    Metadata,
-    MetadataOnly,
-    FailedOutputPreview,
+enum NativeTextOmissionPolicy {
+    None,
+    PatchOrDiff,
 }
 
-impl NativeEventRetention {
-    pub(crate) fn as_str(self) -> &'static str {
+impl NativeTextOmissionPolicy {
+    fn as_str(self) -> &'static str {
         match self {
-            Self::FullText => "full_text",
-            Self::Metadata => "metadata",
-            Self::MetadataOnly => "metadata_only",
-            Self::FailedOutputPreview => "failed_output_preview",
+            Self::None => "none",
+            Self::PatchOrDiff => "patch_or_diff",
         }
     }
 }
 
-pub(crate) fn native_event_retention(event_type: EventType, body: &Value) -> NativeEventRetention {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NativeTextRetentionPolicy {
+    limit_chars: Option<usize>,
+    omission_policy: NativeTextOmissionPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProviderPolicyText {
+    pub(crate) text: String,
+    pub(crate) retention: ProviderTextRetention,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProviderTextRetention {
+    limit_chars: Option<usize>,
+    truncated: bool,
+    omission_policy: NativeTextOmissionPolicy,
+    omission_applied: bool,
+}
+
+impl ProviderTextRetention {
+    pub(crate) fn as_json(self) -> Value {
+        let mode = if self.limit_chars.is_some() {
+            "bounded"
+        } else {
+            "none"
+        };
+        json!({
+            "mode": mode,
+            "limit_chars": self.limit_chars,
+            "truncated": self.truncated,
+            "omission_policy": self.omission_policy.as_str(),
+            "omission_applied": self.omission_applied,
+        })
+    }
+}
+
+fn native_event_text_retention_policy(
+    event_type: EventType,
+    body: &Value,
+) -> NativeTextRetentionPolicy {
     match event_type {
-        EventType::Message | EventType::Summary => NativeEventRetention::FullText,
+        EventType::Message | EventType::Summary => NativeTextRetentionPolicy {
+            limit_chars: Some(PROVIDER_MAX_TEXT_CHARS),
+            omission_policy: NativeTextOmissionPolicy::None,
+        },
         EventType::ToolCall | EventType::CommandStarted | EventType::CommandFinished => {
-            NativeEventRetention::Metadata
+            NativeTextRetentionPolicy {
+                limit_chars: Some(PROVIDER_MAX_PREVIEW_CHARS),
+                omission_policy: NativeTextOmissionPolicy::None,
+            }
         }
         EventType::ToolOutput | EventType::CommandOutput => {
             if provider_output_event_is_failure(body) {
-                NativeEventRetention::FailedOutputPreview
+                NativeTextRetentionPolicy {
+                    limit_chars: Some(PROVIDER_MAX_PREVIEW_CHARS),
+                    omission_policy: NativeTextOmissionPolicy::PatchOrDiff,
+                }
             } else {
-                NativeEventRetention::MetadataOnly
+                NativeTextRetentionPolicy {
+                    limit_chars: None,
+                    omission_policy: NativeTextOmissionPolicy::None,
+                }
             }
         }
         EventType::FileTouched | EventType::VcsChange | EventType::Artifact | EventType::Notice => {
-            NativeEventRetention::MetadataOnly
+            NativeTextRetentionPolicy {
+                limit_chars: None,
+                omission_policy: NativeTextOmissionPolicy::None,
+            }
         }
     }
 }
@@ -443,38 +492,34 @@ pub(crate) fn provider_policy_event_text(
     event_type: EventType,
     text: &str,
     body: &Value,
-) -> (String, bool, NativeEventRetention) {
-    let retention = native_event_retention(event_type, body);
-    let text = match retention {
-        NativeEventRetention::FailedOutputPreview => {
-            provider_output_preview_omitting_nested_patch_diff(body, text)
-        }
-        _ => text.to_owned(),
-    };
-    let text_limit = match retention {
-        NativeEventRetention::FullText => PROVIDER_MAX_TEXT_CHARS,
-        NativeEventRetention::Metadata | NativeEventRetention::FailedOutputPreview => {
-            PROVIDER_MAX_PREVIEW_CHARS
-        }
-        NativeEventRetention::MetadataOnly => 0,
-    };
-    let (text, truncated) = if text_limit == 0 {
-        (String::new(), false)
+) -> ProviderPolicyText {
+    let policy = native_event_text_retention_policy(event_type, body);
+    let omission_applied = policy.omission_policy == NativeTextOmissionPolicy::PatchOrDiff
+        && (provider_value_contains_patch_or_diff(body)
+            || provider_text_contains_patch_or_diff(text));
+    let text = if omission_applied {
+        provider_output_preview_omitting_nested_patch_diff(body, text)
     } else {
-        provider_local_preview(&text, text_limit)
+        text.to_owned()
     };
-    (text, truncated, retention)
+    let (text, truncated) = if let Some(limit_chars) = policy.limit_chars {
+        provider_local_preview(&text, limit_chars)
+    } else {
+        (String::new(), false)
+    };
+    ProviderPolicyText {
+        text,
+        retention: ProviderTextRetention {
+            limit_chars: policy.limit_chars,
+            truncated,
+            omission_policy: policy.omission_policy,
+            omission_applied,
+        },
+    }
 }
 
 pub(crate) fn provider_policy_body(event_type: EventType, body: &Value) -> Value {
-    let mut retained = provider_filter_body_by_retention_policy(event_type, body, None);
-    if let Value::Object(object) = &mut retained {
-        object.insert(
-            "content_retention".to_owned(),
-            Value::String(native_event_retention(event_type, body).as_str().to_owned()),
-        );
-    }
-    retained
+    provider_filter_body_by_retention_policy(event_type, body, None)
 }
 
 fn provider_filter_body_by_retention_policy(
@@ -556,9 +601,11 @@ fn provider_should_omit_body_field(event_type: EventType, key: &str, value: &Val
 
 fn provider_omitted_body_field(value: &Value) -> Value {
     json!({
-        "content_retention": "metadata_only",
-        "omitted_bytes": provider_value_approx_bytes(value),
-        "contains_patch_or_diff": provider_value_contains_patch_or_diff(value),
+        "field_retention": {
+            "mode": "omitted",
+            "original_bytes": provider_value_approx_bytes(value),
+            "contained_patch_or_diff": provider_value_contains_patch_or_diff(value),
+        },
     })
 }
 
@@ -1044,7 +1091,9 @@ mod tests {
         let rendered = event.payload.to_string();
 
         assert!(rendered.contains("real conversation oracle"));
-        assert!(rendered.contains("metadata_only"));
+        assert!(rendered.contains("field_retention"));
+        assert!(rendered.contains("original_bytes"));
+        assert!(rendered.contains("contained_patch_or_diff"));
         assert!(!rendered.contains("successful-output-oracle"));
         assert!(!rendered.contains("*** Begin Patch"));
         assert!(!rendered.contains("secret old"));
@@ -1105,26 +1154,51 @@ mod tests {
             }),
         );
 
+        assert_eq!(
+            success.payload["text_retention"],
+            json!({
+                "mode": "none",
+                "limit_chars": null,
+                "truncated": false,
+                "omission_policy": "none",
+                "omission_applied": false,
+            })
+        );
         let success_payload = success.payload.to_string();
-        assert!(success_payload.contains("metadata_only"));
         assert!(!success_payload.contains("successful-output-oracle"));
 
+        assert_eq!(
+            failed.payload["text_retention"],
+            json!({
+                "mode": "bounded",
+                "limit_chars": PROVIDER_MAX_PREVIEW_CHARS,
+                "truncated": false,
+                "omission_policy": "patch_or_diff",
+                "omission_applied": false,
+            })
+        );
         let failed_payload = failed.payload.to_string();
-        assert!(failed_payload.contains("failed_output_preview"));
         assert!(failed_payload.contains("failed-output-oracle"));
 
         let nested_failed_payload = nested_failed.payload.to_string();
-        assert!(nested_failed_payload.contains("failed_output_preview"));
         assert!(nested_failed_payload.contains("nested-failed-output-oracle"));
 
         let http_success_payload = http_success.payload.to_string();
-        assert!(http_success_payload.contains("metadata_only"));
         assert!(!http_success_payload.contains("http-success-output-oracle"));
 
         let http_failed_payload = http_failed.payload.to_string();
-        assert!(http_failed_payload.contains("failed_output_preview"));
         assert!(http_failed_payload.contains("http-failed-output-oracle"));
 
+        assert_eq!(
+            failed_diff.payload["text_retention"],
+            json!({
+                "mode": "bounded",
+                "limit_chars": PROVIDER_MAX_PREVIEW_CHARS,
+                "truncated": false,
+                "omission_policy": "patch_or_diff",
+                "omission_applied": true,
+            })
+        );
         let failed_diff_payload = failed_diff.payload.to_string();
         assert!(failed_diff_payload.contains("output omitted"));
         assert!(!failed_diff_payload.contains("diff --git"));
@@ -1145,9 +1219,54 @@ mod tests {
         let rendered = event.payload.to_string();
 
         assert!(rendered.contains("apply_patch file touches: modified:src/main.rs"));
-        assert!(rendered.contains("metadata_only"));
+        assert!(rendered.contains("field_retention"));
+        assert!(rendered.contains("original_bytes"));
+        assert!(rendered.contains("contained_patch_or_diff"));
         assert!(!rendered.contains("*** Begin Patch"));
         assert!(!rendered.contains("-old"));
         assert!(!rendered.contains("+new"));
+    }
+
+    #[test]
+    fn native_event_reports_bounded_text_limit_separately_from_truncation() {
+        let text = "x".repeat(PROVIDER_MAX_TEXT_CHARS + 1);
+        let event = test_native_event(EventType::Message, &text, json!({"content": text}));
+
+        assert_eq!(
+            event.payload["text"].as_str().unwrap().chars().count(),
+            PROVIDER_MAX_TEXT_CHARS
+        );
+        assert_eq!(
+            event.payload["text_retention"],
+            json!({
+                "mode": "bounded",
+                "limit_chars": PROVIDER_MAX_TEXT_CHARS,
+                "truncated": true,
+                "omission_policy": "none",
+                "omission_applied": false,
+            })
+        );
+        assert!(event.payload.get("content_retention").is_none());
+        assert!(event.payload.get("truncated").is_none());
+    }
+
+    #[test]
+    fn native_event_reports_preview_limit_without_claiming_full_text() {
+        let event = test_native_event(
+            EventType::ToolCall,
+            "read_file src/lib.rs",
+            json!({"tool_name": "read_file", "path": "src/lib.rs"}),
+        );
+
+        assert_eq!(
+            event.payload["text_retention"],
+            json!({
+                "mode": "bounded",
+                "limit_chars": PROVIDER_MAX_PREVIEW_CHARS,
+                "truncated": false,
+                "omission_policy": "none",
+                "omission_applied": false,
+            })
+        );
     }
 }

--- a/crates/ctx-history-capture/src/provider/providers/claude.rs
+++ b/crates/ctx-history-capture/src/provider/providers/claude.rs
@@ -249,7 +249,7 @@ pub(crate) fn claude_event(
             String::new()
         }
     });
-    let (text, truncated, retention) = provider_policy_event_text(event_type, &text, content);
+    let retained_text = provider_policy_event_text(event_type, &text, content);
 
     Some(ProviderEventEnvelope {
         provider_event_index: (line_number - 1) as u64,
@@ -271,10 +271,9 @@ pub(crate) fn claude_event(
             "message_id": message.get("id").and_then(Value::as_str),
             "request_id": value.get("requestId").and_then(Value::as_str),
             "role": message_role,
-            "text": text,
-            "truncated": truncated,
+            "text": retained_text.text,
+            "text_retention": retained_text.retention.as_json(),
             "content_preview": provider_capped_json(&provider_policy_body(event_type, content), PROVIDER_MAX_PREVIEW_CHARS),
-            "content_retention": retention.as_str(),
         }),
         metadata: json!({
             "source": "claude_projects_jsonl",

--- a/crates/ctx-history-capture/src/provider/providers/codebuddy.rs
+++ b/crates/ctx-history-capture/src/provider/providers/codebuddy.rs
@@ -934,8 +934,7 @@ pub(crate) fn codebuddy_event(
     event: &CodeBuddyEventInput,
 ) -> ProviderEventEnvelope {
     let event_type = EventType::Message;
-    let (text, truncated, retention) =
-        provider_policy_event_text(event_type, &event.text, &event.raw_message);
+    let retained_text = provider_policy_event_text(event_type, &event.text, &event.raw_message);
     let event_id = format!("{provider_session_id}:{}", event.native_message_id);
     let role = provider_role(event.role.as_deref());
     ProviderEventEnvelope {
@@ -955,11 +954,10 @@ pub(crate) fn codebuddy_event(
             "event_id": event_id,
             "native_project_hash": project_hash,
             "native_message_id": event.native_message_id,
-            "text": text,
-            "truncated": truncated,
+            "text": retained_text.text,
+            "text_retention": retained_text.retention.as_json(),
             "body": provider_capped_json(&provider_policy_body(event_type, &event.raw_message), PROVIDER_MAX_PREVIEW_CHARS),
             "decoded_body": provider_capped_json(&provider_policy_body(event_type, &event.decoded_message), PROVIDER_MAX_PREVIEW_CHARS),
-            "content_retention": retention.as_str(),
         }),
         metadata: json!({
             "source": shape.event_source(),

--- a/crates/ctx-history-capture/src/provider/providers/lingma.rs
+++ b/crates/ctx-history-capture/src/provider/providers/lingma.rs
@@ -207,8 +207,7 @@ pub(crate) fn lingma_event(
         "gmt_create": row.gmt_create,
         "extra": row.extra.as_deref().map(provider_json_text),
     });
-    let (text, truncated, retention) =
-        provider_policy_event_text(draft.event_type, &draft.text, &body);
+    let retained_text = provider_policy_event_text(draft.event_type, &draft.text, &body);
     ProviderEventEnvelope {
         provider_event_index: draft.provider_event_index,
         provider_event_hash: Some(format!(
@@ -232,11 +231,10 @@ pub(crate) fn lingma_event(
         )),
         artifacts: Vec::new(),
         payload: json!({
-            "text": text,
-            "truncated": truncated,
+            "text": retained_text.text,
+            "text_retention": retained_text.retention.as_json(),
             "source_format": LINGMA_SQLITE_SOURCE_FORMAT,
             "body": provider_capped_json(&provider_policy_body(draft.event_type, &body), PROVIDER_MAX_PREVIEW_CHARS),
-            "content_retention": retention.as_str(),
         }),
         metadata: json!({
             "source": "lingma_chat_record",

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl.rs
@@ -559,7 +559,7 @@ pub(crate) fn native_jsonl_event(
     } else {
         value.clone()
     };
-    let (text, truncated, retention) = provider_policy_event_text(event_type, &text, &body_value);
+    let retained_text = provider_policy_event_text(event_type, &text, &body_value);
     let event_id = native_jsonl_event_id(provider, value, line_number);
     let tool_calls = if provider == CaptureProvider::Antigravity {
         value.get("tool_calls").map(|calls| {
@@ -593,11 +593,10 @@ pub(crate) fn native_jsonl_event(
             "entry_type": entry_type,
             "event_id": event_id,
             "native_step_index": value.get("step_index").and_then(Value::as_u64),
-            "text": text,
-            "truncated": truncated,
+            "text": retained_text.text,
+            "text_retention": retained_text.retention.as_json(),
             "tool_calls": tool_calls,
             "body": body,
-            "content_retention": retention.as_str(),
         }),
         metadata: json!({
             "source": source_format,

--- a/crates/ctx-history-capture/src/provider/providers/opencode.rs
+++ b/crates/ctx-history-capture/src/provider/providers/opencode.rs
@@ -1253,7 +1253,7 @@ pub(crate) fn opencode_event(
     } else {
         data.clone()
     };
-    let (text, truncated, retention) = provider_policy_event_text(event_type, &text, &body);
+    let retained_text = provider_policy_event_text(event_type, &text, &body);
     let payload = if is_message_part {
         json!({
             "entry_type": row.entry_type,
@@ -1264,20 +1264,18 @@ pub(crate) fn opencode_event(
             "part_id": data.get("part_id").cloned(),
             "part_type": data.get("part_type").cloned(),
             "session_message_seq": row.seq,
-            "text": text,
-            "truncated": truncated,
+            "text": retained_text.text,
+            "text_retention": retained_text.retention.as_json(),
             "body": provider_capped_json(&provider_policy_body(event_type, &body), PROVIDER_MAX_PREVIEW_CHARS),
-            "content_retention": retention.as_str(),
         })
     } else {
         json!({
             "entry_type": row.entry_type,
             "message_id": row.id,
             "session_message_seq": row.seq,
-            "text": text,
-            "truncated": truncated,
+            "text": retained_text.text,
+            "text_retention": retained_text.retention.as_json(),
             "body": provider_capped_json(&provider_policy_body(event_type, &body), PROVIDER_MAX_PREVIEW_CHARS),
-            "content_retention": retention.as_str(),
         })
     };
     let metadata = if is_message_part {

--- a/crates/ctx-history-capture/src/provider/providers/pi.rs
+++ b/crates/ctx-history-capture/src/provider/providers/pi.rs
@@ -315,7 +315,7 @@ pub(crate) fn pi_session_event(
     let event_type = pi_event_type(entry_type, message);
     let role = message_role.map(pi_event_role);
     let text = pi_entry_text(entry, message).unwrap_or_default();
-    let (text, truncated, retention) = provider_policy_event_text(event_type, &text, entry);
+    let retained_text = provider_policy_event_text(event_type, &text, entry);
     let provider_event_index = (line_number - 1) as u64;
     let provider_event_identity_index =
         pi_provider_event_identity_index(header, entry).unwrap_or(provider_event_index);
@@ -336,10 +336,9 @@ pub(crate) fn pi_session_event(
             "entry_id": entry.get("id").and_then(Value::as_str),
             "parent_id": entry.get("parentId").and_then(Value::as_str),
             "message_role": message_role,
-            "text": text,
-            "truncated": truncated,
+            "text": retained_text.text,
+            "text_retention": retained_text.retention.as_json(),
             "body": provider_capped_json(&provider_policy_body(event_type, entry), PROVIDER_MAX_PREVIEW_CHARS),
-            "content_retention": retention.as_str(),
         }),
         metadata: json!({
             "source": "pi_session",

--- a/crates/ctx-history-capture/src/provider/providers/task_json.rs
+++ b/crates/ctx-history-capture/src/provider/providers/task_json.rs
@@ -731,7 +731,7 @@ pub(crate) fn task_json_event(
     let event_type = task_json_event_type(&input.raw, input.source);
     let role = Some(task_json_event_role(&input.raw, input.source));
     let text = task_json_event_text(&input.raw, input.source, event_type);
-    let (text, truncated, retention) = provider_policy_event_text(event_type, &text, &input.raw);
+    let retained_text = provider_policy_event_text(event_type, &text, &input.raw);
     let native_id = task_json_string_field(&input.raw, &["id", "uuid", "messageId"])
         .unwrap_or_else(|| format!("{}-{}", input.source, input.native_index));
     let event_id = format!("{task_id}:{}:{native_id}", input.source);
@@ -754,10 +754,9 @@ pub(crate) fn task_json_event(
             "entry_type": task_json_entry_type(&input.raw, input.source),
             "event_id": event_id,
             "native_index": input.native_index,
-            "text": text,
-            "truncated": truncated,
+            "text": retained_text.text,
+            "text_retention": retained_text.retention.as_json(),
             "body": provider_capped_json(&provider_policy_body(event_type, &input.raw), PROVIDER_MAX_PREVIEW_CHARS),
-            "content_retention": retention.as_str(),
         }),
         metadata: json!({
             "source": input.source,

--- a/crates/ctx-history-capture/src/provider/providers/trae.rs
+++ b/crates/ctx-history-capture/src/provider/providers/trae.rs
@@ -587,8 +587,7 @@ pub(crate) fn trae_event(
     event: &TraeEventInput,
 ) -> ProviderEventEnvelope {
     let event_type = EventType::Message;
-    let (text, truncated, retention) =
-        provider_policy_event_text(event_type, &event.text, &event.raw_message);
+    let retained_text = provider_policy_event_text(event_type, &event.text, &event.raw_message);
     let event_id = format!("{provider_session_id}:{}", event.native_message_id);
     ProviderEventEnvelope {
         provider_event_index: event.provider_event_index,
@@ -606,10 +605,9 @@ pub(crate) fn trae_event(
             "event_id": event_id,
             "native_workspace_id": workspace_id,
             "native_message_id": event.native_message_id,
-            "text": text,
-            "truncated": truncated,
+            "text": retained_text.text,
+            "text_retention": retained_text.retention.as_json(),
             "body": provider_capped_json(&provider_policy_body(event_type, &event.raw_message), PROVIDER_MAX_PREVIEW_CHARS),
-            "content_retention": retention.as_str(),
         }),
         metadata: json!({
             "source": "trae_state_vscdb_itemtable",

--- a/crates/ctx-history-capture/src/provider/providers/warp.rs
+++ b/crates/ctx-history-capture/src/provider/providers/warp.rs
@@ -397,8 +397,7 @@ pub(crate) fn warp_message_event(
         "text": message.text,
         "message_index": message_index,
     });
-    let (text, truncated, retention) =
-        provider_policy_event_text(message.event_type, &message.text, &body);
+    let retained_text = provider_policy_event_text(message.event_type, &message.text, &body);
     let message_id = if message.id.is_empty() {
         format!("{task_id}:{message_index}")
     } else {
@@ -421,10 +420,9 @@ pub(crate) fn warp_message_event(
             "message_id": message_id,
             "task_id": task_id,
             "request_id": if message.request_id.is_empty() { Value::Null } else { json!(message.request_id) },
-            "text": text,
-            "truncated": truncated,
+            "text": retained_text.text,
+            "text_retention": retained_text.retention.as_json(),
             "body": provider_policy_body(message.event_type, &body),
-            "content_retention": retention.as_str(),
         }),
         metadata: json!({
             "source": WARP_SQLITE_SOURCE_FORMAT,

--- a/crates/ctx-history-capture/src/tests/codex.rs
+++ b/crates/ctx-history-capture/src/tests/codex.rs
@@ -1820,7 +1820,7 @@ fn codex_default_policy_persists_file_touches_without_raw_patch_text() {
 }
 
 #[test]
-fn codex_default_policy_redacts_non_patch_edit_tool_arguments() {
+fn codex_default_policy_omits_non_patch_edit_tool_arguments() {
     let temp = tempdir();
     let root = temp.path().join("codex-sessions/2026/06/24");
     fs::create_dir_all(&root).unwrap();

--- a/crates/ctx-history-capture/src/tests/native_json.rs
+++ b/crates/ctx-history-capture/src/tests/native_json.rs
@@ -1,4 +1,5 @@
 use super::support::*;
+use crate::PROVIDER_MAX_PREVIEW_CHARS;
 
 #[test]
 
@@ -565,8 +566,14 @@ fn continue_cli_tool_call_redacts_raw_outputs_and_reimports_file_touches() {
         .find(|event| event.event_type == EventType::ToolCall)
         .expect("tool call metadata event imported");
     assert_eq!(
-        tool.payload["body"]["content_retention"].as_str(),
-        Some("metadata")
+        tool.payload["body"]["text_retention"],
+        json!({
+            "mode": "bounded",
+            "limit_chars": PROVIDER_MAX_PREVIEW_CHARS,
+            "truncated": false,
+            "omission_policy": "none",
+            "omission_applied": false,
+        })
     );
     let rendered_tool = serde_json::to_string(tool).unwrap();
     assert!(rendered_tool.contains("apply_patch"));
@@ -751,6 +758,62 @@ fn native_claude_projects_imports_jsonl_tree() {
     assert!(events
         .iter()
         .any(|event| event.event_type == EventType::ToolOutput));
+}
+
+#[test]
+fn native_claude_reports_text_limit_and_truncation_independently() {
+    let temp = tempdir();
+    let root = temp.path().join("claude/projects/-workspace");
+    fs::create_dir_all(&root).unwrap();
+    let text = "x".repeat(20_000);
+    fs::write(
+        root.join("bounded-text.jsonl"),
+        jsonl_line(json!({
+            "sessionId": "claude-bounded-text",
+            "timestamp": "2026-07-04T14:00:00Z",
+            "cwd": "/workspace",
+            "version": "test",
+            "type": "user",
+            "message": {"role": "user", "content": text},
+            "uuid": "claude-bounded-text-message"
+        })),
+    )
+    .unwrap();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+
+    let summary = import_claude_projects_jsonl_tree(
+        temp.path().join("claude/projects"),
+        &mut store,
+        ClaudeProjectsImportOptions {
+            source_path: Some(temp.path().join("claude/projects")),
+            imported_at: "2026-07-04T14:30:00Z".parse().unwrap(),
+            ..ClaudeProjectsImportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    let session_id =
+        stored_provider_session_id(&store, CaptureProvider::Claude, "claude-bounded-text");
+    let events = store.events_for_session(session_id).unwrap();
+    assert_eq!(events.len(), 1);
+    let payload = &events[0].payload["body"];
+    assert_eq!(
+        payload["text"].as_str().unwrap().chars().count(),
+        PROVIDER_MAX_TEXT_CHARS
+    );
+    assert_eq!(
+        payload["text_retention"],
+        json!({
+            "mode": "bounded",
+            "limit_chars": PROVIDER_MAX_TEXT_CHARS,
+            "truncated": true,
+            "omission_policy": "none",
+            "omission_applied": false,
+        })
+    );
+    assert!(payload.get("content_retention").is_none());
+    assert!(payload.get("truncated").is_none());
 }
 
 #[test]
@@ -1752,12 +1815,21 @@ fn native_openhands_file_events_redact_outputs_cite_source_and_leave_tree_readon
         .iter()
         .find(|event| event.event_type == EventType::CommandOutput)
         .expect("successful command output metadata imported");
+    let retention = output
+        .payload
+        .get("text_retention")
+        .or_else(|| output.payload["body"].get("text_retention"))
+        .or_else(|| output.payload["body"]["body"].get("text_retention"))
+        .expect("command output text retention metadata");
     assert_eq!(
-        output.payload["content_retention"]
-            .as_str()
-            .or_else(|| output.payload["body"]["content_retention"].as_str())
-            .or_else(|| output.payload["body"]["body"]["content_retention"].as_str()),
-        Some("metadata_only")
+        retention,
+        &json!({
+            "mode": "none",
+            "limit_chars": null,
+            "truncated": false,
+            "omission_policy": "none",
+            "omission_applied": false,
+        })
     );
     let rendered_output = serde_json::to_string(output).unwrap();
     assert!(!rendered_output.contains(raw_output));

--- a/crates/ctx-history-capture/src/tests/native_sqlite.rs
+++ b/crates/ctx-history-capture/src/tests/native_sqlite.rs
@@ -585,8 +585,14 @@ fn assert_successful_output_metadata_only(
         .unwrap_or_else(|| panic!("missing {provider:?} {event_type:?} event"));
     assert_eq!(event.payload["body"]["text"].as_str(), Some(""));
     assert_eq!(
-        event.payload["body"]["content_retention"].as_str(),
-        Some("metadata_only")
+        event.payload["body"]["text_retention"],
+        json!({
+            "mode": "none",
+            "limit_chars": null,
+            "truncated": false,
+            "omission_policy": "none",
+            "omission_applied": false,
+        })
     );
     let rendered = serde_json::to_string(event).unwrap();
     assert!(
@@ -1040,8 +1046,14 @@ fn assert_message_part_import(
         .expect("tool part metadata-only output event imported");
     assert_eq!(tool_output.payload["body"]["text"].as_str(), Some(""));
     assert_eq!(
-        tool_output.payload["body"]["content_retention"].as_str(),
-        Some("metadata_only")
+        tool_output.payload["body"]["text_retention"],
+        json!({
+            "mode": "none",
+            "limit_chars": null,
+            "truncated": false,
+            "omission_policy": "none",
+            "omission_applied": false,
+        })
     );
     let rendered_tool = serde_json::to_string(tool_output).unwrap();
     assert!(rendered_tool.contains("write_file"));
@@ -1599,7 +1611,14 @@ fn native_shelley_handles_duplicate_sequences_and_nonchat_rows() {
         .iter()
         .find(|event| event.sync.metadata["metadata"]["message_id"].as_str() == Some("msg-large"))
         .expect("large Shelley event imported");
-    assert_eq!(large.payload["body"]["truncated"].as_bool(), Some(true));
+    assert_eq!(
+        large.payload["body"]["text_retention"]["truncated"].as_bool(),
+        Some(true)
+    );
+    assert_eq!(
+        large.payload["body"]["text_retention"]["limit_chars"].as_u64(),
+        Some(PROVIDER_MAX_TEXT_CHARS as u64)
+    );
     assert!(
         large.payload["body"]["text"]
             .as_str()

--- a/crates/ctx-history-capture/src/tests/provider_fixture.rs
+++ b/crates/ctx-history-capture/src/tests/provider_fixture.rs
@@ -1,6 +1,73 @@
 use super::support::*;
 
 #[test]
+fn normalized_provider_import_accepts_v1_during_bounded_v2_transition() {
+    let temp = tempdir();
+    let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+    let occurred_at = DateTime::parse_from_rfc3339("2026-07-13T12:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let mut capture = provider_collision_capture(
+        CaptureProvider::Hermes,
+        "v1-compatible-session",
+        "hermes_state_sqlite",
+        "/tmp/v1-compatible-session.db",
+        occurred_at,
+    );
+    capture.schema_version = 1;
+
+    let summary = import_normalized_provider_captures(
+        &mut store,
+        ProviderNormalizationResult {
+            summary: ProviderImportSummary::default(),
+            captures: vec![(1, capture)],
+            files_touched: Vec::new(),
+        },
+        NormalizedProviderImportOptions::default(),
+    )
+    .unwrap();
+
+    assert_eq!(summary.failed, 0, "{:?}", summary.failures);
+    assert_eq!(summary.imported_events, 1);
+}
+
+#[test]
+fn normalized_provider_import_rejects_versions_outside_v1_v2_window() {
+    for schema_version in [0, 3] {
+        let temp = tempdir();
+        let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+        let occurred_at = DateTime::parse_from_rfc3339("2026-07-13T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let mut capture = provider_collision_capture(
+            CaptureProvider::Hermes,
+            &format!("unsupported-v{schema_version}-session"),
+            "hermes_state_sqlite",
+            &format!("/tmp/unsupported-v{schema_version}-session.db"),
+            occurred_at,
+        );
+        capture.schema_version = schema_version;
+
+        let summary = import_normalized_provider_captures(
+            &mut store,
+            ProviderNormalizationResult {
+                summary: ProviderImportSummary::default(),
+                captures: vec![(1, capture)],
+                files_touched: Vec::new(),
+            },
+            NormalizedProviderImportOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(summary.failed, 1, "schema v{schema_version}");
+        assert!(summary.failures[0]
+            .error
+            .contains("unsupported provider capture envelope schema version"));
+        assert!(store.list_sessions().unwrap().is_empty());
+    }
+}
+
+#[test]
 fn batched_provider_import_rejects_unwrapped_and_zero_sized_modes() {
     let temp = tempdir();
     let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();

--- a/crates/ctx-history-core/src/lib.rs
+++ b/crates/ctx-history-core/src/lib.rs
@@ -127,8 +127,8 @@ pub use provider::{
     ProviderCursorRange, ProviderEventEnvelope, ProviderFidelityClaims, ProviderId,
     ProviderPathKind, ProviderSessionEnvelope, ProviderSourceEnvelope, ProviderSourceTrust,
     ProviderSupportEntry, ProviderSupportMatrixDocument, ProviderSupportPath,
-    ProviderSupportStatus, PROVIDER_CAPTURE_ENVELOPE_SCHEMA_VERSION,
-    PROVIDER_SUPPORT_MATRIX_SCHEMA_VERSION,
+    ProviderSupportStatus, PROVIDER_CAPTURE_ENVELOPE_MIN_SUPPORTED_SCHEMA_VERSION,
+    PROVIDER_CAPTURE_ENVELOPE_SCHEMA_VERSION, PROVIDER_SUPPORT_MATRIX_SCHEMA_VERSION,
 };
 pub use source::{CaptureProvider, CaptureSource, CaptureSourceDescriptor, CaptureSourceKind};
 pub use sync::{

--- a/crates/ctx-history-core/src/provider.rs
+++ b/crates/ctx-history-core/src/provider.rs
@@ -6,7 +6,8 @@ use crate::{
     AgentType, ArtifactKind, CaptureProvider, EventRole, EventType, Fidelity, SessionStatus,
 };
 
-pub const PROVIDER_CAPTURE_ENVELOPE_SCHEMA_VERSION: u32 = 1;
+pub const PROVIDER_CAPTURE_ENVELOPE_SCHEMA_VERSION: u32 = 2;
+pub const PROVIDER_CAPTURE_ENVELOPE_MIN_SUPPORTED_SCHEMA_VERSION: u32 = 1;
 pub const PROVIDER_SUPPORT_MATRIX_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -322,7 +323,7 @@ pub struct ProviderEventEnvelope {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProviderCaptureEnvelope {
-    #[serde(default = "provider_capture_envelope_schema_version")]
+    #[serde(default = "provider_capture_envelope_min_supported_schema_version")]
     pub schema_version: u32,
     pub provider: CaptureProvider,
     pub source: ProviderSourceEnvelope,
@@ -387,6 +388,10 @@ pub const fn provider_capture_envelope_schema_version() -> u32 {
     PROVIDER_CAPTURE_ENVELOPE_SCHEMA_VERSION
 }
 
+const fn provider_capture_envelope_min_supported_schema_version() -> u32 {
+    PROVIDER_CAPTURE_ENVELOPE_MIN_SUPPORTED_SCHEMA_VERSION
+}
+
 pub const fn provider_support_matrix_schema_version() -> u32 {
     PROVIDER_SUPPORT_MATRIX_SCHEMA_VERSION
 }
@@ -397,6 +402,7 @@ mod tests {
 
     use super::{
         ProviderCaptureEnvelope, ProviderId, ProviderSupportMatrixDocument, ProviderSupportStatus,
+        PROVIDER_CAPTURE_ENVELOPE_MIN_SUPPORTED_SCHEMA_VERSION,
     };
 
     fn workspace_file(path: &str) -> PathBuf {
@@ -556,6 +562,13 @@ mod tests {
         let parsed: ProviderCaptureEnvelope =
             serde_json::from_str(sample).expect("envelope should parse");
         assert_eq!(parsed.schema_version, 1);
+        let legacy_without_version = sample.replacen(r#""schema_version": 1,"#, "", 1);
+        let parsed_legacy: ProviderCaptureEnvelope = serde_json::from_str(&legacy_without_version)
+            .expect("legacy envelope without a schema version should parse as v1");
+        assert_eq!(
+            parsed_legacy.schema_version,
+            PROVIDER_CAPTURE_ENVELOPE_MIN_SUPPORTED_SCHEMA_VERSION
+        );
         assert_eq!(
             parsed
                 .source

--- a/crates/ctx-history-store/src/search/projections.rs
+++ b/crates/ctx-history-store/src/search/projections.rs
@@ -1755,6 +1755,13 @@ fn event_output_fields_indicate_failure(payload: &serde_json::Value) -> bool {
             .and_then(serde_json::Value::as_str)
             == Some("failed_preview")
         || payload
+            .get("text_retention")
+            .and_then(|retention| retention.get("omission_policy"))
+            .and_then(serde_json::Value::as_str)
+            == Some("patch_or_diff")
+        // Provider capture envelope v1 compatibility. V2 emits
+        // `text_retention.omission_policy` instead.
+        || payload
             .get("content_retention")
             .and_then(serde_json::Value::as_str)
             == Some("failed_output_preview")

--- a/crates/ctx-history-store/src/search/tests.rs
+++ b/crates/ctx-history-store/src/search/tests.rs
@@ -768,12 +768,46 @@ fn event_search_indexes_policy_allowed_agent_content_only() {
         ),
         policy_event(
             9,
+            EventType::CommandOutput,
+            Some(EventRole::Tool),
+            serde_json::json!({
+                "body": {
+                    "text_retention": {
+                        "mode": "none",
+                        "limit_chars": null,
+                        "truncated": false,
+                        "omission_policy": "none",
+                        "omission_applied": false
+                    },
+                    "text": "success-v2-native-output-oracle"
+                }
+            }),
+        ),
+        policy_event(
+            10,
+            EventType::CommandOutput,
+            Some(EventRole::Tool),
+            serde_json::json!({
+                "body": {
+                    "text_retention": {
+                        "mode": "bounded",
+                        "limit_chars": 4000,
+                        "truncated": false,
+                        "omission_policy": "patch_or_diff",
+                        "omission_applied": false
+                    },
+                    "output_preview": "failed-v2-native-output-oracle"
+                }
+            }),
+        ),
+        policy_event(
+            11,
             EventType::Notice,
             Some(EventRole::System),
             serde_json::json!({ "text": "notice-oracle" }),
         ),
         policy_event(
-            10,
+            12,
             EventType::Message,
             Some(EventRole::Assistant),
             serde_json::json!({ "unexpected_field": "json-fallback-oracle" }),
@@ -819,12 +853,23 @@ fn event_search_indexes_policy_allowed_agent_content_only() {
             .len(),
         1
     );
+    assert_eq!(
+        store
+            .search_event_hits("failed-v2-native-output-oracle", 10)
+            .unwrap()
+            .len(),
+        1
+    );
     assert!(store
         .search_event_hits("success-output-oracle", 10)
         .unwrap()
         .is_empty());
     assert!(store
         .search_event_hits("success-native-output-oracle", 10)
+        .unwrap()
+        .is_empty());
+    assert!(store
+        .search_event_hits("success-v2-native-output-oracle", 10)
         .unwrap()
         .is_empty());
     assert!(store

--- a/docs/provider-import-policy.md
+++ b/docs/provider-import-policy.md
@@ -83,6 +83,53 @@ and low-signal, so it should not be indexed by default. Failed or timed-out
 commands may keep a bounded diagnostic preview because error text is often the
 thing users need to recover a session.
 
+## Native Retention Metadata
+
+Provider capture envelope schema version 2 reports the shared native text
+policy and its outcome independently. Payloads governed by that policy contain
+this object:
+
+```json
+{
+  "text_retention": {
+    "mode": "bounded",
+    "limit_chars": 16000,
+    "truncated": true,
+    "omission_policy": "none",
+    "omission_applied": false
+  }
+}
+```
+
+- `mode` is `bounded` when ctx keeps at most `limit_chars`, or `none` when the
+  policy keeps no event text.
+- `limit_chars` is a character count for `bounded` and `null` for `none`.
+- `truncated` reports whether the character limit shortened this value; it is
+  not encoded in `mode`.
+- `omission_policy` is `none` or `patch_or_diff`. The latter is used for
+  retained failure diagnostics that must not copy patch or diff content.
+- `omission_applied` is true only when that policy actually found and replaced
+  patch or diff content.
+
+When a field is removed from a retained provider body, its replacement records
+the facts about that field without describing the whole event:
+
+```json
+{
+  "field_retention": {
+    "mode": "omitted",
+    "original_bytes": 1234,
+    "contained_patch_or_diff": true
+  }
+}
+```
+
+Version 2 replaces the version 1 `content_retention` strings and their
+overloaded values (`full_text`, `metadata`, `metadata_only`, and
+`failed_output_preview`). New captures emit version 2 only. Import accepts
+versions 1 and 2 during the bounded compatibility window, and stored version 1
+failure previews remain searchable; versions outside that window are rejected.
+
 ## Oversized Provider Rows
 
 Provider-controlled text and blob fields must be bounded. One oversized value


### PR DESCRIPTION
## Summary

- replace overloaded `content_retention` strings with structured `text_retention` policy and outcome metadata
- report bounded limits, truncation, and patch/diff omission independently across all native provider emitters
- replace nested metadata-only placeholders with precise `field_retention` omission records
- bump provider capture envelopes to v2 while accepting v1 imports and retaining v1 search compatibility
- document the v2 contract and add the synthetic Claude >16K regression

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p ctx-history-core -p ctx-history-store -p ctx-history-capture`
  - capture: 259 passed, 1 ignored; 5 integration passed
  - core: 11 passed
  - store: 104 passed
  - doc tests: passed
- independent grandchild code review: clean, no actionable findings

Closes #158.
