### PR TITLE
Strip symbols from release binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,9 @@ ort = { git = "https://github.com/ctxrs/ort.git", rev = "f7994dc91b8f48c78afc506
 # FreeBSD headers. This fork is the stable crate plus the upstream three-typedef
 # removal from asg017/sqlite-vec#219. Drop it once a stable release includes it.
 sqlite-vec = { git = "https://github.com/ctxrs/sqlite-vec.git", rev = "c1762b6065bccdedf1f68a904096d46f91d3a486" }
+
+[profile.release]
+# Distributed binaries must omit local/static symbols and debug symbol data.
+# The artifact compatibility gate enforces the resulting binary contract
+# independently of the implementation language used to build the CLI.
+strip = "symbols"

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1610,7 +1610,7 @@
           "@@//crates/ctx-sdk/Cargo.toml": "36d7b44b8415faf5a6b81989f92d421ad145f43a8bf822a08599ebf5c56b2b2c",
           "@@//crates/ctx-cli/Cargo.toml": "8eff7ff82ce9275cb96ea39e72368d4f12926d2bc9cfff6be3ed8b502cf245c9",
           "@@//crates/ctx-history-core/Cargo.toml": "703e44fa36843a0a0633425af4602a60a258baf983a553774c4f891cefc5a9e7",
-          "@@//Cargo.toml": "7a4b6d65969d2e36d2d4da1aeffea222ec0d236967aed3549b543a5592b4b0c5",
+          "@@//Cargo.toml": "f9e9a5961a6de8e3ffd9e061dad0ca4673ad215c2d7c0bea0ef4950c9f0b8336",
           "@@//Cargo.lock": "9b8898b2b68c1ce9b2dd674af21b3c019e0f0aff5df16c4e5833976bcc0c4de3",
           "@@//crates/ctx-protocol/Cargo.toml": "e9e75a7c7ca116f86e58ee0e09d174612607c8c45cce0213e66825e403046bce",
           "@@//crates/ctx-history-store/Cargo.toml": "ef7d57054308ada6f83bb9dd19bfc4245c3ad9e8e6e2e2c34c42183eb0d67bd1",

--- a/scripts/check-release-binary-compat.sh
+++ b/scripts/check-release-binary-compat.sh
@@ -10,8 +10,8 @@ usage() {
   cat >&2 <<'USAGE'
 Usage: scripts/check-release-binary-compat.sh PLATFORM BINARY
 
-Checks the executable format, architecture, loader, shared-library, ABI, and
-minimum-OS contract for one public ctx release binary.
+Checks the executable format, architecture, loader, shared-library, ABI,
+minimum-OS, and stripped-symbol contract for one public ctx release binary.
 Platforms: linux-x64, linux-aarch64, macos-arm64, macos-x64, windows-x64,
 freebsd-x64.
 USAGE
@@ -110,6 +110,67 @@ elf_needed_libraries() {
 check_no_elf_search_path() {
   if printf '%s\n' "${readobj_output}" | grep -Eq '(^|[^[:alnum:]_])(RPATH|RUNPATH)([^[:alnum:]_]|$)'; then
     fail "RPATH or RUNPATH is forbidden"
+  fi
+}
+
+check_stripped_symbols() {
+  for inventory in Sections Symbols; do
+    if ! awk -v header="${inventory} [" '
+      $0 == header {
+        opened++
+        if (in_inventory) malformed=1
+        in_inventory=1
+        next
+      }
+      in_inventory && ($0 == "Sections [" || $0 == "Symbols [") {
+        malformed=1
+        next
+      }
+      in_inventory && $0 == "]" { closed=1; in_inventory=0 }
+      END {
+        exit(opened == 1 && closed && !in_inventory && !malformed ? 0 : 1)
+      }
+    ' <<<"${readobj_output}"; then
+      fail "${inventory} inspection output is missing or truncated"
+    fi
+  done
+
+  if grep -Eq \
+    '^[[:space:]]*Name:[[:space:]]+(\.symtab|\.debug[^[:space:] (]*|\.zdebug[^[:space:] (]*|__debug[^[:space:] (]*)([[:space:] (]|$)' \
+    <<<"${readobj_output}"; then
+    fail "debug or static symbol section is present"
+  fi
+
+  if [[ "${platform}" == macos-* ]]; then
+    if awk '
+      /^Symbols \[$/ { in_table=1; next }
+      in_table && /^\]$/ {
+        if (in_symbol) malformed=1
+        in_table=0
+        next
+      }
+      in_table && /^[[:space:]]*Symbol[[:space:]]*\{/ {
+        if (in_symbol) malformed=1
+        in_symbol=1
+        external=0
+        next
+      }
+      in_table && in_symbol && /^[[:space:]]*Extern([[:space:]]|$)/ { external=1; next }
+      in_table && in_symbol && /^[[:space:]]*\}[[:space:]]*$/ {
+        if (!external) local_symbol=1
+        in_symbol=0
+      }
+      END { exit(local_symbol || malformed || in_symbol ? 0 : 1) }
+    ' <<<"${readobj_output}"; then
+      fail "local symbol table entry is present"
+    fi
+  elif awk '
+    /^Symbols \[$/ { in_table=1; next }
+    in_table && /^\]$/ { in_table=0; next }
+    in_table && /^[[:space:]]*Symbol[[:space:]]*\{/ { symbol=1 }
+    END { exit(symbol ? 0 : 1) }
+  ' <<<"${readobj_output}"; then
+    fail "static symbol table is present"
   fi
 }
 
@@ -316,17 +377,21 @@ case "${platform}" in
       --version-info \
       --notes \
       --string-dump=.interp \
+      --sections \
+      --symbols \
       "${binary}")" || fail "llvm-readobj could not inspect the binary"
     ;;
   macos-arm64|macos-x64)
-    readobj_output="$("${LLVM_READOBJ}" --file-headers "${binary}")" \
+    readobj_output="$("${LLVM_READOBJ}" --file-headers --sections --symbols "${binary}")" \
       || fail "llvm-readobj could not inspect the binary"
     ;;
   windows-x64)
-    readobj_output="$("${LLVM_READOBJ}" --file-headers --coff-imports "${binary}")" \
+    readobj_output="$("${LLVM_READOBJ}" --file-headers --coff-imports --sections --symbols "${binary}")" \
       || fail "llvm-readobj could not inspect the binary"
     ;;
 esac
+
+check_stripped_symbols
 
 objdump_output=""
 if [[ "${platform}" == macos-* ]]; then

--- a/scripts/test-linux-release-construction.sh
+++ b/scripts/test-linux-release-construction.sh
@@ -443,6 +443,7 @@ grep -F '20260701T000000Z' scripts/docker/linux-release.Dockerfile >/dev/null
 grep -F 'ubuntu:22.04@sha256:' scripts/docker/linux-release.Dockerfile >/dev/null
 grep -F 'RUSTUP_VERSION="1.28.2"' scripts/docker/linux-release.Dockerfile >/dev/null
 grep -F 'RUST_TOOLCHAIN_VERSION="1.88.0"' scripts/build-public-cli-artifact.sh >/dev/null
+grep -A5 -F '[profile.release]' Cargo.toml | grep -F 'strip = "symbols"' >/dev/null
 grep -F 'rustup target add --toolchain "${RUST_TOOLCHAIN_VERSION}"' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F 'cargo "+${RUST_TOOLCHAIN_VERSION}"' scripts/build-public-cli-artifact.sh >/dev/null
 grep -F -- '-e "CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-2}"' scripts/build-public-cli-artifact.sh >/dev/null

--- a/scripts/tests/check-release-binary-compat-test.sh
+++ b/scripts/tests/check-release-binary-compat-test.sh
@@ -6,7 +6,12 @@ checker="${repo_root}/scripts/check-release-binary-compat.sh"
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/ctx-binary-compat-test.XXXXXX")"
 trap 'rm -rf "${tmp}"' EXIT
 
-printf '#!/bin/sh\ncat "$FAKE_READOBJ_OUTPUT"\n' > "${tmp}/llvm-readobj"
+cat > "${tmp}/llvm-readobj" <<'EOF'
+#!/bin/sh
+case " $* " in *' --sections '*) ;; *) exit 64 ;; esac
+case " $* " in *' --symbols '*) ;; *) exit 64 ;; esac
+cat "$FAKE_READOBJ_OUTPUT"
+EOF
 printf '#!/bin/sh\ncat "$FAKE_OBJDUMP_OUTPUT"\n' > "${tmp}/llvm-objdump"
 chmod +x "${tmp}/llvm-readobj" "${tmp}/llvm-objdump"
 printf 'not a real binary\n' > "${tmp}/candidate"
@@ -65,6 +70,13 @@ NeededLibraries [
 Name: GLIBC_2.35
 Name: GCC_4.2.0
 GNU_PROPERTY_X86_ISA_1_NEEDED: x86-64-baseline
+Sections [
+Section {
+  Name: .dynsym (1)
+}
+]
+Symbols [
+]
 EOF
 
 linux_arm64="${tmp}/linux-arm64.txt"
@@ -84,6 +96,10 @@ NeededLibraries [
 ]
 Name: GLIBC_2.35
 Name: GCC_4.2.0
+Sections [
+]
+Symbols [
+]
 EOF
 
 mac_arm_readobj="${tmp}/mac-arm-readobj.txt"
@@ -92,6 +108,15 @@ Format: Mach-O arm64
 Arch: aarch64
 AddressSize: 64bit
 FileType: Executable (0x2)
+Sections [
+]
+Symbols [
+  Symbol {
+    Name: _abort (1)
+    Extern
+    Type: Undef (0x0)
+  }
+]
 EOF
 mac_x64_readobj="${tmp}/mac-x64-readobj.txt"
 cat > "${mac_x64_readobj}" <<'EOF'
@@ -99,6 +124,10 @@ Format: Mach-O 64-bit x86-64
 Arch: x86_64
 AddressSize: 64bit
 FileType: Executable (0x2)
+Sections [
+]
+Symbols [
+]
 EOF
 mac_objdump="${tmp}/mac-objdump.txt"
 cat > "${mac_objdump}" <<'EOF'
@@ -152,6 +181,10 @@ MinorOperatingSystemVersion: 0
 MajorSubsystemVersion: 6
 MinorSubsystemVersion: 2
 Subsystem: IMAGE_SUBSYSTEM_WINDOWS_CUI (0x3)
+Sections [
+]
+Symbols [
+]
 Import {
   Name: ADVAPI32.dll
 }
@@ -202,6 +235,10 @@ NeededLibraries [
   libm.so.5
   libthr.so.3
 ]
+Sections [
+]
+Symbols [
+]
 EOF
 
 expect_pass linux_x64 run_check linux-x64 "${linux_x64}"
@@ -211,6 +248,20 @@ expect_pass mac_x64 run_check macos-x64 "${mac_x64_readobj}" "${mac_objdump}"
 expect_pass windows run_check windows-x64 "${windows}"
 expect_pass freebsd run_check freebsd-x64 "${freebsd}"
 expect_fail malformed run_check linux-x64 "${tmp}/empty"
+
+missing_symbols="${tmp}/missing-symbols.txt"
+sed '/^Symbols \[$/,/^\]$/d' "${linux_x64}" > "${missing_symbols}"
+expect_fail missing_symbols run_check linux-x64 "${missing_symbols}"
+truncated_symbols="${tmp}/truncated-symbols.txt"
+sed '$d' "${linux_x64}" > "${truncated_symbols}"
+expect_fail truncated_symbols run_check linux-x64 "${truncated_symbols}"
+truncated_sections="${tmp}/truncated-sections.txt"
+awk '
+  /^Sections \[$/ { in_sections=1 }
+  in_sections && /^\]$/ { in_sections=0; next }
+  { print }
+' "${linux_x64}" > "${truncated_sections}"
+expect_fail truncated_sections run_check linux-x64 "${truncated_sections}"
 
 mutate_and_fail() {
   local name="$1"
@@ -235,6 +286,8 @@ mutate_and_fail linux_rpath linux-x64 "${linux_x64}" 's/Name: GLIBC_2.35/RUNPATH
 mutate_and_fail linux_isa linux-x64 "${linux_x64}" 's/x86-64-baseline/x86-64-v3/'
 mutate_and_fail linux_avx linux-x64 "${linux_x64}" 's/GNU_PROPERTY_X86_ISA_1_NEEDED: x86-64-baseline/GNU_PROPERTY_X86_ISA_1_NEEDED: x86-64-baseline AVX/'
 mutate_and_fail arm_glibcxx linux-aarch64 "${linux_arm64}" 's/Name: GLIBC_2.35/Name: GLIBC_2.35\nName: GLIBCXX_3.4.30/'
+mutate_and_fail linux_static_symbols linux-x64 "${linux_x64}" 's/Section {/Symbols [\n  Symbol {\n    Name: main (1)\n  }\n]\nSection {/'
+mutate_and_fail linux_debug_section linux-x64 "${linux_x64}" 's/Name: .dynsym/Name: .debug_info/'
 
 bad_mac_dylib="${tmp}/bad-mac-dylib.txt"
 sed 's#/System/Library/Frameworks/CoreML.framework/Versions/A/CoreML#/opt/local/libCoreML.dylib#' "${mac_objdump}" > "${bad_mac_dylib}"
@@ -251,6 +304,16 @@ expect_fail mac_arch run_check macos-arm64 "${bad_mac_arch}" "${mac_objdump}"
 bad_mac_type="${tmp}/bad-mac-type.txt"
 sed 's/FileType: Executable/FileType: Dylib/' "${mac_arm_readobj}" > "${bad_mac_type}"
 expect_fail mac_type run_check macos-arm64 "${bad_mac_type}" "${mac_objdump}"
+bad_mac_local_symbol="${tmp}/bad-mac-local-symbol.txt"
+sed '/^[[:space:]]*Extern$/d' "${mac_arm_readobj}" > "${bad_mac_local_symbol}"
+expect_fail mac_local_symbol run_check macos-arm64 "${bad_mac_local_symbol}" "${mac_objdump}"
+bad_mac_truncated_symbol="${tmp}/bad-mac-truncated-symbol.txt"
+sed '/^  }$/d' "${mac_arm_readobj}" > "${bad_mac_truncated_symbol}"
+expect_fail mac_truncated_symbol run_check macos-arm64 "${bad_mac_truncated_symbol}" "${mac_objdump}"
+bad_mac_debug_section="${tmp}/bad-mac-debug-section.txt"
+sed 's/AddressSize: 64bit/AddressSize: 64bit\nSection {\n  Name: __debug_info (1)\n}/' \
+  "${mac_arm_readobj}" > "${bad_mac_debug_section}"
+expect_fail mac_debug_section run_check macos-arm64 "${bad_mac_debug_section}" "${mac_objdump}"
 
 mutate_and_fail windows_machine windows-x64 "${windows}" 's/IMAGE_FILE_MACHINE_AMD64/IMAGE_FILE_MACHINE_ARM64/'
 mutate_and_fail windows_magic windows-x64 "${windows}" 's/Magic: 0x20B/Magic: 0x10B/'
@@ -259,6 +322,7 @@ mutate_and_fail windows_subsystem windows-x64 "${windows}" 's/IMAGE_SUBSYSTEM_WI
 mutate_and_fail windows_version windows-x64 "${windows}" 's/MajorOperatingSystemVersion: 10/MajorOperatingSystemVersion: 11/'
 mutate_and_fail windows_subsystem_version windows-x64 "${windows}" 's/MajorSubsystemVersion: 6/MajorSubsystemVersion: 11/'
 mutate_and_fail windows_dll windows-x64 "${windows}" 's/ws2_32.dll/winhttp.dll/'
+mutate_and_fail windows_static_symbols windows-x64 "${windows}" 's/Import {/Symbols [\n  Symbol {\n    Name: main (1)\n  }\n]\nImport {/'
 mutate_and_fail freebsd_abi freebsd-x64 "${freebsd}" 's/OS\/ABI: FreeBSD/OS\/ABI: UNIX - System V/'
 mutate_and_fail freebsd_arch freebsd-x64 "${freebsd}" 's/EM_X86_64/EM_AARCH64/'
 mutate_and_fail freebsd_type freebsd-x64 "${freebsd}" 's/Type: SharedObject/Type: Relocatable/'


### PR DESCRIPTION
## Summary

- configure the Cargo release profile to omit local/static symbols and debug symbol data
- make the cross-platform artifact compatibility gate enforce stripped outputs for ELF, Mach-O, and PE binaries
- fail closed when LLVM section or symbol inventories are missing, truncated, or malformed while allowing loader-required Mach-O externals

## Measured impact

On a local Linux x64 release build from the same source and Rust 1.88 toolchain:

- raw binary: 23,669,584 bytes to 20,090,128 bytes (15.1% smaller)
- gzip transport: 9,057,159 bytes to 8,111,665 bytes (10.4% smaller)

The stripped binary still reports ctx 0.25.0 and passes the release artifact symbol contract.

## Validation

- bazel test //:release_binary_compat_tests //:linux_release_construction_tests //:buildkite_pipeline_check
- cargo check, formatting, docs, installer, signing, native-smoke, package-audit, and CLI unit gates through the public smoke command
- cross-format inspection against stripped ELF, Mach-O, PE, and FreeBSD samples
- independent code review completed with no remaining findings