### PR TITLE
fix(history): preserve Codex source root across imports

### DIFF
--- a/crates/ctx-history-capture/src/provider/codex/session.rs
+++ b/crates/ctx-history-capture/src/provider/codex/session.rs
@@ -413,16 +413,12 @@ pub fn import_codex_session_jsonl(
     if options.fast_event_inserts {
         return import_codex_session_paths_fast(vec![path.to_path_buf()], store, options, 0);
     }
-    let source_path = options
-        .source_path
-        .clone()
-        .unwrap_or_else(|| path.to_path_buf());
     let normalization = CodexSessionJsonlAdapter.normalize_path(
         path,
         &ProviderAdapterContext {
             machine_id: options.machine_id,
-            source_path: Some(source_path),
-            source_root: None,
+            source_path: Some(path.to_path_buf()),
+            source_root: options.source_path,
             imported_at: options.imported_at,
         },
     )?;
@@ -480,7 +476,7 @@ fn import_codex_session_jsonl_tail_bounded(
     let context = ProviderAdapterContext {
         machine_id: options.machine_id.clone(),
         source_path: Some(path.to_path_buf()),
-        source_root: None,
+        source_root: options.source_path.clone(),
         imported_at: options.imported_at,
     };
     let import_options = NormalizedProviderImportOptions {

--- a/crates/ctx-history-capture/src/tests/codex.rs
+++ b/crates/ctx-history-capture/src/tests/codex.rs
@@ -1325,6 +1325,82 @@ fn codex_session_tail_keeps_valid_append_when_another_row_is_rejected() {
 }
 
 #[test]
+fn codex_session_tail_preserves_configured_source_root() {
+    for fast_event_inserts in [true, false] {
+        let temp = tempdir();
+        let source_root = temp.path().join("sessions");
+        let path = source_root.join("2026/07/20/session.jsonl");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let session_id = format!("codex-tail-source-root-{fast_event_inserts}");
+        let initial = [
+            jsonl_line(json!({
+                "timestamp": "2026-07-20T12:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": session_id,
+                    "timestamp": "2026-07-20T12:00:00Z",
+                    "cwd": "/workspace",
+                    "originator": "codex-cli"
+                }
+            })),
+            jsonl_line(json!({
+                "timestamp": "2026-07-20T12:00:01Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "initial event"}]
+                }
+            })),
+        ]
+        .concat();
+        fs::write(&path, &initial).unwrap();
+        let tail_start = initial.len() as u64;
+
+        let mut store = Store::open(temp.path().join("work.sqlite")).unwrap();
+        let options = CodexSessionImportOptions {
+            source_path: Some(source_root.clone()),
+            imported_at: "2026-07-20T12:30:00Z".parse().unwrap(),
+            fast_event_inserts,
+            ..CodexSessionImportOptions::default()
+        };
+        import_codex_session_jsonl(&path, &mut store, options.clone()).unwrap();
+
+        fs::write(
+            &path,
+            [
+                initial,
+                jsonl_line(json!({
+                    "timestamp": "2026-07-20T12:00:02Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "appended event"}]
+                    }
+                })),
+            ]
+            .concat(),
+        )
+        .unwrap();
+        import_codex_session_jsonl_tail(&path, tail_start, &mut store, options).unwrap();
+
+        let source = store
+            .capture_source_by_external_session(CaptureProvider::Codex, &session_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            source.descriptor.raw_source_path.as_deref(),
+            Some(path.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            source.descriptor.source_root.as_deref(),
+            Some(source_root.to_string_lossy().as_ref())
+        );
+    }
+}
+
+#[test]
 fn codex_session_tail_skips_oversized_required_header_without_failure() {
     let temp = tempdir();
     let path = temp.path().join("tail-oversized-header-codex.jsonl");


### PR DESCRIPTION
## Problem

Incremental Codex tail imports dropped the configured sessions root and could rewrite source provenance to the individual JSONL file. Full and incremental imports could therefore describe the same source differently, leaving catalog/source state inconsistent.

## Change

- preserve the configured `source_root` during tail imports
- make the non-fast full-import path use the same provenance semantics as the fast path
- keep `raw_source_path` anchored to the actual JSONL file
- cover both fast and non-fast full import followed by a tail import

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p ctx-history-capture --all-targets -- -D warnings`
- `cargo test -p ctx-history-capture --lib` (262 passed, 1 ignored)
- `cargo test -p ctx-history-capture --test cursor_native` (5 passed)
- `cargo test -p ctx` (full package test suite)
- adversarial review with DeepSeek V4 Pro and GLM 5.2; no blocking correctness findings
