### PR TITLE
cli: add help text for existing --json flags

### DIFF
--- a/crates/ctx-cli/src/commands/index.rs
+++ b/crates/ctx-cli/src/commands/index.rs
@@ -46,13 +46,13 @@ enum IndexCommand {
 
 #[derive(Debug, Args)]
 struct IndexStatusArgs {
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     json: bool,
 }
 
 #[derive(Debug, Args)]
 struct IndexWatchArgs {
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     json: bool,
     #[arg(long, default_value_t = 2, value_parser = parse_positive_seconds)]
     interval_seconds: u64,
@@ -60,7 +60,7 @@ struct IndexWatchArgs {
 
 #[derive(Debug, Args)]
 struct IndexWaitArgs {
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     json: bool,
     #[arg(long, help = "Wait for lexical SQLite indexing")]
     lexical: bool,

--- a/crates/ctx-cli/src/docs.rs
+++ b/crates/ctx-cli/src/docs.rs
@@ -26,7 +26,7 @@ pub enum DocsCommand {
 
 #[derive(Debug, Args)]
 pub struct DocsListArgs {
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     pub json: bool,
 }
 
@@ -35,7 +35,7 @@ pub struct DocsSearchArgs {
     pub query: String,
     #[arg(long, default_value_t = 10)]
     pub limit: usize,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     pub json: bool,
 }
 
@@ -44,7 +44,7 @@ pub struct DocsShowArgs {
     pub id: String,
     #[arg(long, value_enum, default_value_t = DocsFormat::Markdown)]
     pub format: DocsFormat,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     pub json: bool,
     #[arg(long)]
     pub out: Option<PathBuf>,

--- a/crates/ctx-cli/src/integrations/mcp.rs
+++ b/crates/ctx-cli/src/integrations/mcp.rs
@@ -34,7 +34,7 @@ pub(crate) struct McpInstallArgs {
         help = "Install into the current project's MCP config when supported"
     )]
     pub(crate) project: bool,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     pub(crate) json: bool,
     #[arg(
         long,
@@ -57,7 +57,7 @@ pub(crate) struct McpStatusArgs {
     pub(crate) all_agents: bool,
     #[arg(long, help = "Inspect the current project's MCP config when supported")]
     pub(crate) project: bool,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     pub(crate) json: bool,
 }
 

--- a/crates/ctx-cli/src/integrations/slash_commands.rs
+++ b/crates/ctx-cli/src/integrations/slash_commands.rs
@@ -50,7 +50,7 @@ pub(crate) struct SlashCommandInstallArgs {
         help = "Install into the current project instead of global agent dirs"
     )]
     project: bool,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     pub(crate) json: bool,
     #[arg(long, help = "Overwrite locally modified ctx-managed command files")]
     force: bool,

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -137,7 +137,7 @@ struct SetupArgs {
     no_daemon: bool,
     #[arg(long, help = "Wait for foreground lexical indexing before returning")]
     wait: bool,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     json: bool,
     #[arg(long, value_enum, default_value_t = ProgressArg::Auto)]
     progress: ProgressArg,
@@ -145,13 +145,13 @@ struct SetupArgs {
 
 #[derive(Debug, Args, Clone)]
 struct JsonArgs {
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     json: bool,
 }
 
 #[derive(Debug, Args, Clone)]
 struct SourcesArgs {
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     json: bool,
     #[arg(
         long,
@@ -168,7 +168,7 @@ struct SourcesArgs {
 
 #[derive(Debug, Args, Clone)]
 struct DoctorArgs {
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     json: bool,
     #[arg(long, value_enum, default_value_t = ProgressArg::Auto)]
     progress: ProgressArg,
@@ -210,7 +210,7 @@ struct ImportArgs {
     resume: bool,
     #[arg(long, help = "Do not start daemon maintenance after import")]
     no_daemon: bool,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     json: bool,
     #[arg(long, value_enum, default_value_t = ProgressArg::Auto)]
     progress: ProgressArg,
@@ -252,7 +252,7 @@ struct ShowSessionArgs {
     mode: TranscriptMode,
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
     format: OutputFormat,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     json: bool,
     #[arg(long)]
     out: Option<PathBuf>,
@@ -270,7 +270,7 @@ struct ShowEventArgs {
     window: Option<usize>,
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
     format: OutputFormat,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     json: bool,
 }
 
@@ -299,7 +299,7 @@ struct LocateSessionArgs {
     provider_session: Option<String>,
     #[arg(long, value_enum, default_value_t = LocateFormat::Text)]
     format: LocateFormat,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     json: bool,
 }
 
@@ -309,7 +309,7 @@ struct LocateEventArgs {
     id: String,
     #[arg(long, value_enum, default_value_t = LocateFormat::Text)]
     format: LocateFormat,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     json: bool,
 }
 

--- a/crates/ctx-cli/src/skill.rs
+++ b/crates/ctx-cli/src/skill.rs
@@ -46,7 +46,7 @@ pub(crate) struct SkillInstallArgs {
         help = "Install into the current project instead of global agent dirs"
     )]
     project: bool,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     json: bool,
     #[arg(long, help = "Overwrite locally modified bundled skill files")]
     force: bool,
@@ -63,7 +63,7 @@ pub(crate) struct SkillStatusArgs {
         help = "Check the current project's skill dirs instead of global dirs"
     )]
     project: bool,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     json: bool,
 }
 

--- a/crates/ctx-cli/src/upgrade/command.rs
+++ b/crates/ctx-cli/src/upgrade/command.rs
@@ -39,7 +39,7 @@ pub struct UpgradeArgs {
     pub channel: Option<String>,
     #[arg(long)]
     pub dry_run: bool,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     pub json: bool,
     #[arg(long, hide = true)]
     pub background: bool,
@@ -61,13 +61,13 @@ pub enum UpgradeCommand {
 pub struct UpgradeCheckArgs {
     #[arg(long)]
     pub channel: Option<String>,
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     pub json: bool,
 }
 
 #[derive(Debug, Args)]
 pub struct UpgradeStatusArgs {
-    #[arg(long)]
+    #[arg(long, help = "Print machine-readable JSON")]
     pub json: bool,
 }
 


### PR DESCRIPTION
## Summary

Adds missing help text to existing `--json` flags across the CLI.

Several commands already describe `--json` as:

> Print machine-readable JSON

while many other commands expose the same flag without any description. This change reuses the existing wording to make the help output consistent across commands.

## Changes

- Added `help = "Print machine-readable JSON"` to existing `--json` flags that were missing it.
- Left the SQL-specific `--json` help text (`Alias for --format json`) unchanged.
- No functional changes.

## Testing

- `cargo fmt`
- Relevant test suite passes (15/15)