### PR TITLE
cli: improve diagnostics for missing SQL input files

### DIFF
--- a/crates/ctx-cli/src/commands/sql.rs
+++ b/crates/ctx-cli/src/commands/sql.rs
@@ -73,6 +73,12 @@ pub(crate) fn read_sql_input(args: &SqlArgs) -> Result<String> {
         }
         (Some(sql), None) => Ok(sql.clone()),
         (None, Some(path)) => {
+            if !path
+                .try_exists()
+                .with_context(|| format!("check SQL file {}", path.display()))?
+            {
+                return Err(anyhow!("SQL file does not exist: {}", path.display()));
+            }
             let file = fs::File::open(path)
                 .with_context(|| format!("read SQL from {}", path.display()))?;
             read_sql_limited(file, max_sql_bytes, &path.display().to_string())

--- a/crates/ctx-cli/src/commands/sql.rs
+++ b/crates/ctx-cli/src/commands/sql.rs
@@ -73,14 +73,15 @@ pub(crate) fn read_sql_input(args: &SqlArgs) -> Result<String> {
         }
         (Some(sql), None) => Ok(sql.clone()),
         (None, Some(path)) => {
-            if !path
-                .try_exists()
-                .with_context(|| format!("check SQL file {}", path.display()))?
-            {
-                return Err(anyhow!("SQL file does not exist: {}", path.display()));
-            }
-            let file = fs::File::open(path)
-                .with_context(|| format!("read SQL from {}", path.display()))?;
+            let file = match fs::File::open(path) {
+                Ok(file) => file,
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    return Err(anyhow!("SQL file does not exist: {}", path.display()));
+                }
+                Err(err) => {
+                    return Err(err).with_context(|| format!("read SQL from {}", path.display()));
+                }
+            };
             read_sql_limited(file, max_sql_bytes, &path.display().to_string())
         }
         (None, None) => Err(anyhow!(

--- a/crates/ctx-cli/tests/search_show_locate_sql.rs
+++ b/crates/ctx-cli/tests/search_show_locate_sql.rs
@@ -165,6 +165,20 @@ fn sql_reads_existing_store_and_supports_formats_and_input_sources() {
 }
 
 #[test]
+fn sql_rejects_nonexistent_file_path() {
+    let temp = tempdir();
+    let path = temp.path().join("does-not-exist.sql");
+    let stderr = failure_stderr(
+        ctx(&temp)
+            .arg("sql")
+            .arg("--file")
+            .arg(&path),
+    );
+    assert!(stderr.contains("SQL file does not exist"), "{stderr}");
+    assert!(stderr.contains(path.to_str().unwrap()), "{stderr}");
+}
+
+#[test]
 fn sql_is_read_only_and_does_not_initialize_store() {
     let temp = tempdir();
     let stderr = failure_stderr(ctx(&temp).args(["sql", "SELECT 1"]));

--- a/crates/ctx-cli/tests/search_show_locate_sql.rs
+++ b/crates/ctx-cli/tests/search_show_locate_sql.rs
@@ -168,12 +168,7 @@ fn sql_reads_existing_store_and_supports_formats_and_input_sources() {
 fn sql_rejects_nonexistent_file_path() {
     let temp = tempdir();
     let path = temp.path().join("does-not-exist.sql");
-    let stderr = failure_stderr(
-        ctx(&temp)
-            .arg("sql")
-            .arg("--file")
-            .arg(&path),
-    );
+    let stderr = failure_stderr(ctx(&temp).arg("sql").arg("--file").arg(&path));
     assert!(stderr.contains("SQL file does not exist"), "{stderr}");
     assert!(stderr.contains(path.to_str().unwrap()), "{stderr}");
 }


### PR DESCRIPTION
## Summary

Improves the error shown when `ctx sql --file` is given a path that doesn't exist.

Other parts of the CLI already check for missing paths before attempting to open them and return a clear, command-specific error. This applies the same pattern to the SQL command, so users get a more direct message instead of an OS-level `NotFound` error.

## Changes

- Check that the SQL file exists before opening it.
- Return a clear error when the file is missing (`SQL file does not exist: <path>`).
- Add a regression test covering the missing-file case.

## Testing

- `cargo fmt --check`
- `search_show_locate_sql` (29/29 passing)
- `cli_public_help_docs` (15/15 passing)