### PR TITLE
cli: surface search pagination status

### DIFF
--- a/crates/ctx-cli/src/commands/search.rs
+++ b/crates/ctx-cli/src/commands/search.rs
@@ -39,7 +39,10 @@ use crate::search_filters::{
     search_has_intent, search_no_results_target, SearchFilterInput, SearchIntentInput,
     SourceIdentityFilterArgs, SourceIdentityFilters,
 };
-use crate::search_render::{print_search_result_compact, print_search_result_verbose, SearchDto};
+use crate::search_render::{
+    print_search_pagination_footer, print_search_result_compact, print_search_result_verbose,
+    SearchDto,
+};
 use crate::semantic::search_packet_with_backend;
 use crate::store_util::open_existing_store_read_only;
 use crate::transcript::shell_quote_arg;
@@ -359,6 +362,7 @@ pub(crate) fn run_search(
                 print_search_result_compact(index + 1, result);
             }
         }
+        print_search_pagination_footer(&packet);
     }
     analytics::insert_duration(
         analytics_properties,

--- a/crates/ctx-cli/src/search_render.rs
+++ b/crates/ctx-cli/src/search_render.rs
@@ -200,6 +200,13 @@ pub(crate) fn result_type_for_id(store: &Store, item_id: Uuid) -> String {
     "indexed_item".to_owned()
 }
 
+pub(crate) fn print_search_pagination_footer(packet: &ctx_history_search::SearchPacket) {
+    if packet.pagination.has_more {
+        println!();
+        println!("More results available.");
+    }
+}
+
 pub(crate) fn print_search_result_compact(
     index: usize,
     result: &ctx_history_search::SearchPacketResult,

--- a/crates/ctx-cli/tests/search_show_locate_sql.rs
+++ b/crates/ctx-cli/tests/search_show_locate_sql.rs
@@ -560,6 +560,33 @@ fn fresh_home_search_mvp_flow() {
     let doctor_progress = String::from_utf8(doctor_progress).unwrap();
     assert!(doctor_progress.contains(r#""operation":"doctor""#));
     assert!(doctor_progress.contains(r#""phase":"checking""#));
+
+    // Verify pagination footer appears when results exceed the limit.
+    // Importing a second session gives us two FTS5 matches for "history";
+    // requesting only 1 result triggers has_more=true.
+    let pi_fixture = provider_history_fixture("pi-session.jsonl");
+    json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "pi",
+        "--path",
+        &pi_fixture,
+        "--json",
+        "--progress",
+        "none",
+    ]));
+    let paginated = ctx(&temp)
+        .args(["search", "history", "--limit", "1", "--refresh", "off"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let paginated = String::from_utf8(paginated).unwrap();
+    assert!(
+        paginated.contains("More results available."),
+        "expected pagination footer in: {paginated}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Improves the terminal search experience by indicating when additional results are available.

The search backend already reports whether more results exist, but the human-readable output stopped after the last displayed result with no indication that the search was incomplete.

## Changes

- Display `More results available.` when additional search results exist.
- Keep JSON output unchanged.
- Add an integration test covering the terminal output.

## After

```text
$ ctx search "history" --limit 1

1. ...

More results available.
```

## Testing

- `cargo fmt --check`
- Relevant test suite passes