### PR TITLE
feat: add diskless Turso import for shared history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +158,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -199,6 +238,9 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "castaway"
@@ -285,7 +327,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -365,6 +407,22 @@ dependencies = [
  "time",
  "url",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "coreml-native"
@@ -462,6 +520,7 @@ dependencies = [
  "jsonc-parser",
  "libc",
  "libloading",
+ "libsql",
  "ort",
  "predicates",
  "proptest",
@@ -475,6 +534,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokenizers",
+ "tokio",
  "toml_edit",
  "ureq 2.12.1",
  "uuid",
@@ -583,7 +643,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -594,7 +654,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -630,7 +690,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -640,7 +700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -719,7 +779,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -869,12 +929,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -882,6 +958,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -897,7 +984,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -918,6 +1005,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -978,6 +1066,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,7 +1134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
- "http",
+ "http 1.4.2",
  "indicatif",
  "libc",
  "log",
@@ -1042,6 +1149,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
@@ -1052,12 +1170,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -1068,8 +1197,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1078,6 +1207,36 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -1089,8 +1248,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1101,16 +1260,34 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c78f9338483cb7e630c8474b07268983c6bd5acee012e4211f9f7bb21b070"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.22.4",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.2",
+ "hyper 1.10.1",
  "hyper-util",
- "rustls",
+ "rustls 0.23.41",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.8",
 ]
@@ -1125,14 +1302,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -1284,6 +1461,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1351,6 +1537,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsql"
+version = "0.10.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e6206c72726b16e7ec9d68c3661d50ebe70947f8e60e0ebb4388d327e1fc2b"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.21.7",
+ "bitflags",
+ "bytes",
+ "fallible-iterator",
+ "futures",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "hyper-rustls 0.25.0",
+ "libsql-hrana",
+ "libsql-sqlite3-parser",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
+name = "libsql-hrana"
+version = "0.10.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fce77fd40abf780ff5c96e58f251a162a3f51458a6cb67d3319574b9c00d6b1"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "prost",
+ "serde",
+]
+
+[[package]]
+name = "libsql-sqlite3-parser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a90128c708356af8f7d767c9ac2946692c9112b4f74f07b99a01a60680e413"
+dependencies = [
+ "bitflags",
+ "cc",
+ "fallible-iterator",
+ "indexmap",
+ "log",
+ "memchr",
+ "phf",
+ "phf_codegen",
+ "phf_shared",
+ "uncased",
 ]
 
 [[package]]
@@ -1483,7 +1726,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1699,6 +1942,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1981,65 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+ "uncased",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1843,6 +2151,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,8 +2191,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
- "socket2",
+ "rustls 0.23.41",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1881,7 +2212,7 @@ dependencies = [
  "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -1899,7 +2230,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -1924,6 +2255,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "rand"
@@ -1955,6 +2295,12 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -2012,7 +2358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
 ]
 
@@ -2087,27 +2433,27 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.10.1",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -2191,6 +2537,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
@@ -2199,9 +2559,31 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2212,6 +2594,17 @@ checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2263,6 +2656,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,7 +2714,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2354,6 +2779,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2795,16 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -2442,6 +2883,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,7 +2910,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2517,7 +2969,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2528,7 +2980,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2600,7 +3052,7 @@ dependencies = [
  "esaxx-rs",
  "getrandom 0.3.4",
  "indicatif",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -2630,8 +3082,19 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
 ]
 
 [[package]]
@@ -2640,7 +3103,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.41",
  "tokio",
 ]
 
@@ -2683,6 +3146,21 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -2705,10 +3183,10 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "url",
@@ -2732,6 +3210,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -2762,6 +3241,15 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -2824,7 +3312,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.11",
@@ -2841,7 +3329,7 @@ dependencies = [
  "flate2",
  "log",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2858,7 +3346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http",
+ "http 1.4.2",
  "httparse",
  "log",
 ]
@@ -2992,7 +3480,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -3291,7 +3779,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3312,7 +3800,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3332,7 +3820,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3372,7 +3860,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ clap_mangen = "0.2"
 directories = "5.0"
 ed25519-dalek = "2.1"
 libc = "0.2"
+libsql = { version = "0.10.0-pre.4", default-features = false, features = ["remote", "tls"] }
 predicates = "3.1"
 proptest = "1"
 regex = "1.10"
@@ -39,6 +40,7 @@ sha2 = "0.10"
 tempfile = "3.10"
 thiserror = "1.0"
 tar = "0.4"
+tokio = { version = "1", features = ["rt-multi-thread"] }
 url = "2.5"
 uuid = { version = "1.10", features = ["serde", "v4", "v7"] }
 xz2 = "0.1"

--- a/crates/ctx-cli/Cargo.toml
+++ b/crates/ctx-cli/Cargo.toml
@@ -35,6 +35,8 @@ ctx-history-capture = { path = "../ctx-history-capture" }
 ctx-history-core = { path = "../ctx-history-core" }
 ctx-history-search = { path = "../ctx-history-search" }
 ctx-history-store = { path = "../ctx-history-store" }
+libsql.workspace = true
+tokio.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 flate2 = "1"

--- a/crates/ctx-cli/src/commands/import.rs
+++ b/crates/ctx-cli/src/commands/import.rs
@@ -973,6 +973,50 @@ pub(crate) fn run_import_internal(
     })
 }
 
+/// Imports every discovered native provider into a process-memory Store. The
+/// caller owns the Store and must persist its accepted records before dropping
+/// it. This path deliberately has no data root, catalog files, spool, or
+/// SQLite database file.
+pub(crate) fn import_all_providers_in_memory() -> Result<(Store, ImportTotals)> {
+    let args = ImportArgs {
+        provider: None,
+        path: None,
+        history_source: None,
+        history_source_manifest: Vec::new(),
+        reset_cursor: false,
+        format: None,
+        all: true,
+        resume: true,
+        no_daemon: true,
+        json: false,
+        progress: ProgressArg::None,
+    };
+    let requests = import_requests(&args)?;
+    let mut store = Store::open_in_memory()?;
+    let inventory = inventory_import_sources(&store, requests, true)?;
+    let mut totals = ImportTotals::default();
+
+    for failure in inventory.failures {
+        totals.add_source_failure(&failure.stats);
+    }
+    for plan in inventory.sources {
+        match import_one_source_without_search_refresh(
+            &mut store,
+            &plan.source,
+            None,
+            true,
+            &plan.preinventory,
+        ) {
+            Ok(summary) => totals.add(&summary, &plan.stats),
+            Err(error) if import_error_scope(&error) == ImportFailureScope::Source => {
+                totals.add_source_failure(&plan.stats);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok((store, totals))
+}
+
 fn source_provider_label(source: &SourceInfo) -> &'static str {
     provider_source_spec(source.provider)
         .map(|spec| spec.display_name)

--- a/crates/ctx-cli/src/commands/mod.rs
+++ b/crates/ctx-cli/src/commands/mod.rs
@@ -8,3 +8,4 @@ pub(crate) mod show;
 pub(crate) mod sources;
 pub(crate) mod sql;
 pub(crate) mod status;
+pub(crate) mod turso;

--- a/crates/ctx-cli/src/commands/turso.rs
+++ b/crates/ctx-cli/src/commands/turso.rs
@@ -27,6 +27,7 @@ impl TursoArgs {
         match &self.command {
             TursoCommand::Init(args) => args.json,
             TursoCommand::Push(args) => args.json,
+            TursoCommand::Import(args) => args.json,
             TursoCommand::Search(args) => args.json,
             TursoCommand::Status(args) => args.json,
         }
@@ -39,6 +40,10 @@ enum TursoCommand {
     Init(TursoInitArgs),
     #[command(about = "Export an existing local ctx index to Turso")]
     Push(TursoPushArgs),
+    #[command(
+        about = "Import all discovered provider histories directly into Turso without a local SQLite file"
+    )]
+    Import(TursoImportArgs),
     #[command(about = "Search history stored in Turso")]
     Search(TursoSearchArgs),
     #[command(about = "Show Turso ctx projection status")]
@@ -67,6 +72,19 @@ struct TursoPushArgs {
         help = "Also export local-only events; required unless events are marked sync_full"
     )]
     include_local_only: bool,
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+struct TursoImportArgs {
+    #[arg(
+        long,
+        default_value_t = DEFAULT_PUSH_BATCH_SIZE,
+        value_parser = parse_push_batch_size,
+        help = "Number of events per remote transaction (1-250)"
+    )]
+    batch_size: usize,
     #[arg(long)]
     json: bool,
 }
@@ -113,20 +131,64 @@ impl TursoConfig {
     }
 }
 
+#[derive(Debug)]
+struct TursoPushReport {
+    uploaded_events: u64,
+    skipped_events: usize,
+    scanned_events: usize,
+    batches: usize,
+}
+
 pub(crate) fn run_turso(args: TursoArgs, data_root: PathBuf) -> Result<()> {
     match args.command {
         TursoCommand::Init(args) => run_async(init(args.json)),
         TursoCommand::Push(args) => {
             let db_path = database_path(data_root);
             let store = open_existing_store_read_only(&db_path, "ctx turso push")?;
-            run_async(push(store, args))
+            let json_output = args.json;
+            let report = run_async(push(store, args))?;
+            print_push_report(&report, json_output)
         }
+        TursoCommand::Import(args) => run_turso_import(args),
         TursoCommand::Search(args) => run_async(search(args)),
         TursoCommand::Status(args) => run_async(status(args.json)),
     }
 }
 
-fn run_async(operation: impl std::future::Future<Output = Result<()>>) -> Result<()> {
+fn run_turso_import(args: TursoImportArgs) -> Result<()> {
+    let (store, totals) = crate::commands::import::import_all_providers_in_memory()?;
+    let report = run_async(push(
+        store,
+        TursoPushArgs {
+            batch_size: args.batch_size,
+            limit: None,
+            include_local_only: true,
+            json: args.json,
+        },
+    ))?;
+    if args.json {
+        print_json(json!({
+            "ephemeral_store": true,
+            "providers_imported": totals.imported_sources,
+            "events_materialized": totals.imported_events,
+            "source_failures": totals.failed_sources,
+            "uploaded_events": report.uploaded_events,
+            "skipped_events": report.skipped_events,
+            "scanned_events": report.scanned_events,
+            "batches": report.batches,
+            "idempotent": true,
+            "remote_projection": true,
+        }))
+    } else {
+        println!("ephemeral_store: true");
+        println!("providers_imported: {}", totals.imported_sources);
+        println!("events_materialized: {}", totals.imported_events);
+        println!("source_failures: {}", totals.failed_sources);
+        print_push_report(&report, false)
+    }
+}
+
+fn run_async<T>(operation: impl std::future::Future<Output = Result<T>>) -> Result<T> {
     Runtime::new()
         .context("create async runtime for Turso")?
         .block_on(operation)
@@ -191,15 +253,6 @@ async fn ensure_schema(conn: &libsql::Connection) -> Result<()> {
     )
     .await
     .context("create Turso dedupe index")?;
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS ctx_turso_upload_cursors (\
-            device_id TEXT PRIMARY KEY,\
-            last_event_id TEXT NOT NULL\
-        )",
-        (),
-    )
-    .await
-    .context("create Turso upload cursor table")?;
     Ok(())
 }
 
@@ -222,14 +275,21 @@ async fn ensure_dedupe_key_column(conn: &libsql::Connection) -> Result<()> {
     Ok(())
 }
 
-async fn push(store: Store, args: TursoPushArgs) -> Result<()> {
+async fn push(store: Store, args: TursoPushArgs) -> Result<TursoPushReport> {
     let conn = connect().await?;
     ensure_schema(&conn).await?;
-    let device_id = export_device_id(&store)?;
-    let session_providers = store
+    let session_identities = store
         .list_sessions()?
         .into_iter()
-        .map(|session| (session.id, session.provider.as_str().to_owned()))
+        .map(|session| {
+            (
+                session.id,
+                (
+                    session.provider.as_str().to_owned(),
+                    session.external_session_id,
+                ),
+            )
+        })
         .collect::<std::collections::HashMap<_, _>>();
     let capture_source_providers = store
         .list_capture_sources()?
@@ -237,7 +297,7 @@ async fn push(store: Store, args: TursoPushArgs) -> Result<()> {
         .map(|source| (source.id, source.descriptor.provider.as_str().to_owned()))
         .collect::<std::collections::HashMap<_, _>>();
 
-    let mut after_id = upload_cursor(&conn, &device_id).await?;
+    let mut after_id = None;
     let mut uploaded = 0u64;
     let mut skipped = 0usize;
     let mut scanned = 0usize;
@@ -270,7 +330,7 @@ async fn push(store: Store, args: TursoPushArgs) -> Result<()> {
                 serde_json::to_string(&event.payload).context("serialize event payload")?;
             let provider = event
                 .session_id
-                .and_then(|id| session_providers.get(&id))
+                .and_then(|id| session_identities.get(&id).map(|identity| &identity.0))
                 .or_else(|| {
                     event
                         .capture_source_id
@@ -278,6 +338,7 @@ async fn push(store: Store, args: TursoPushArgs) -> Result<()> {
                 })
                 .map(String::as_str)
                 .unwrap_or("unknown");
+            let dedupe_key = remote_dedupe_key(event, &session_identities);
             uploaded += transaction
                 .execute(
                     "INSERT OR IGNORE INTO ctx_turso_events \
@@ -290,7 +351,7 @@ async fn push(store: Store, args: TursoPushArgs) -> Result<()> {
                         event.role.map(|role| role.as_str().to_owned()),
                         event.event_type.as_str(),
                         event.occurred_at.timestamp_millis(),
-                        event.dedupe_key.as_deref(),
+                        dedupe_key.as_deref(),
                         payload_json,
                         "",
                     ],
@@ -298,7 +359,6 @@ async fn push(store: Store, args: TursoPushArgs) -> Result<()> {
                 .await
                 .with_context(|| format!("upload event {}", event.id))?;
         }
-        save_upload_cursor(&transaction, &device_id, last.id).await?;
         transaction
             .commit()
             .await
@@ -306,21 +366,64 @@ async fn push(store: Store, args: TursoPushArgs) -> Result<()> {
         batches += 1;
     }
 
-    if args.json {
+    Ok(TursoPushReport {
+        uploaded_events: uploaded,
+        skipped_events: skipped,
+        scanned_events: scanned,
+        batches,
+    })
+}
+
+fn remote_dedupe_key(
+    event: &ctx_history_core::Event,
+    sessions: &std::collections::HashMap<uuid::Uuid, (String, Option<String>)>,
+) -> Option<String> {
+    let source_dedupe_key = event.dedupe_key.as_deref()?;
+    let session_id = event.session_id?;
+    let (provider, external_session_id) = sessions.get(&session_id)?;
+    canonical_provider_source_dedupe_key(
+        provider,
+        external_session_id.as_deref(),
+        source_dedupe_key,
+    )
+    .or_else(|| Some(source_dedupe_key.to_owned()))
+}
+
+fn canonical_provider_source_dedupe_key(
+    provider: &str,
+    external_session_id: Option<&str>,
+    source_dedupe_key: &str,
+) -> Option<String> {
+    let external_session_id = external_session_id?.trim();
+    if external_session_id.is_empty() {
+        return None;
+    }
+    let source_dedupe_key = source_dedupe_key.strip_prefix("provider-source:")?;
+    let (_, event_identity) = source_dedupe_key.split_once(':')?;
+    let (provider_event_index, payload_hash) = event_identity.split_once(':')?;
+    if provider_event_index.is_empty() || payload_hash.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "provider:{provider}:{external_session_id}:{provider_event_index}:{payload_hash}"
+    ))
+}
+
+fn print_push_report(report: &TursoPushReport, json_output: bool) -> Result<()> {
+    if json_output {
         print_json(json!({
-            "uploaded_events": uploaded,
-            "skipped_events": skipped,
-            "scanned_events": scanned,
-            "batches": batches,
+            "uploaded_events": report.uploaded_events,
+            "skipped_events": report.skipped_events,
+            "scanned_events": report.scanned_events,
+            "batches": report.batches,
             "idempotent": true,
             "remote_projection": true,
-            "device_id": device_id,
         }))?;
     } else {
-        println!("uploaded_events: {uploaded}");
-        println!("skipped_events: {skipped}");
-        println!("scanned_events: {scanned}");
-        println!("batches: {batches}");
+        println!("uploaded_events: {}", report.uploaded_events);
+        println!("skipped_events: {}", report.skipped_events);
+        println!("scanned_events: {}", report.scanned_events);
+        println!("batches: {}", report.batches);
         println!("idempotent: true");
     }
     Ok(())
@@ -459,54 +562,6 @@ async fn require_projection(conn: &libsql::Connection) -> Result<()> {
     Ok(())
 }
 
-fn export_device_id(store: &Store) -> Result<String> {
-    if let Ok(value) = env::var("CTX_TURSO_DEVICE_ID") {
-        if !value.trim().is_empty() {
-            return Ok(value);
-        }
-    }
-    store
-        .local_device()?
-        .map(|device| device.stable_device_id)
-        .ok_or_else(|| {
-            anyhow!(
-                "CTX_TURSO_DEVICE_ID is required when the local ctx store has no device identity"
-            )
-        })
-}
-
-async fn upload_cursor(conn: &libsql::Connection, device_id: &str) -> Result<Option<uuid::Uuid>> {
-    let mut rows = conn
-        .query(
-            "SELECT last_event_id FROM ctx_turso_upload_cursors WHERE device_id = ?1",
-            [device_id],
-        )
-        .await
-        .context("read Turso upload cursor")?;
-    let Some(row) = rows.next().await.context("read Turso upload cursor row")? else {
-        return Ok(None);
-    };
-    row.get::<String>(0)?
-        .parse()
-        .map(Some)
-        .context("parse Turso upload cursor")
-}
-
-async fn save_upload_cursor(
-    conn: &libsql::Connection,
-    device_id: &str,
-    last_event_id: uuid::Uuid,
-) -> Result<()> {
-    conn.execute(
-        "INSERT INTO ctx_turso_upload_cursors (device_id, last_event_id) VALUES (?1, ?2) \
-         ON CONFLICT(device_id) DO UPDATE SET last_event_id = excluded.last_event_id",
-        (device_id, last_event_id.to_string()),
-    )
-    .await
-    .context("save Turso upload cursor")?;
-    Ok(())
-}
-
 fn remote_export_allowed(event: &ctx_history_core::Event, include_local_only: bool) -> bool {
     if matches!(event.sync.visibility, Visibility::Withheld)
         || matches!(event.sync.sync_state, SyncState::Withheld)
@@ -526,6 +581,30 @@ mod tests {
         assert_eq!(parse_push_batch_size("250"), Ok(250));
         assert!(parse_push_batch_size("0").is_err());
         assert!(parse_push_batch_size("251").is_err());
+    }
+
+    #[test]
+    fn canonicalizes_provider_source_dedupe_keys_for_cross_mac_merging() {
+        assert_eq!(
+            canonical_provider_source_dedupe_key(
+                "codex",
+                Some("session-123"),
+                "provider-source:a5dcd0d3-41d1-7bad-90ee-e1ba0b64be32:2:fnv1a64:abc",
+            ),
+            Some("provider:codex:session-123:2:fnv1a64:abc".to_owned())
+        );
+    }
+
+    #[test]
+    fn leaves_source_dedupe_key_unchanged_without_a_stable_session_id() {
+        assert_eq!(
+            canonical_provider_source_dedupe_key(
+                "codex",
+                None,
+                "provider-source:a5dcd0d3-41d1-7bad-90ee-e1ba0b64be32:2:fnv1a64:abc",
+            ),
+            None
+        );
     }
 
     #[test]

--- a/crates/ctx-cli/src/commands/turso.rs
+++ b/crates/ctx-cli/src/commands/turso.rs
@@ -1,0 +1,542 @@
+use std::{env, path::PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+use clap::{Args, Subcommand};
+use ctx_history_core::{database_path, SyncState, Visibility};
+use ctx_history_store::Store;
+use serde_json::json;
+use tokio::runtime::Runtime;
+
+use crate::{output::print_json, store_util::open_existing_store_read_only};
+
+const DATABASE_URL_ENV: &str = "CTX_TURSO_DATABASE_URL";
+const AUTH_TOKEN_ENV: &str = "CTX_TURSO_AUTH_TOKEN";
+const DEFAULT_PUSH_BATCH_SIZE: usize = 100;
+const MAX_PUSH_BATCH_SIZE: usize = 250;
+const DEFAULT_SEARCH_LIMIT: usize = 20;
+const MAX_SEARCH_LIMIT: usize = 200;
+
+#[derive(Debug, Args)]
+pub(crate) struct TursoArgs {
+    #[command(subcommand)]
+    command: TursoCommand,
+}
+
+impl TursoArgs {
+    pub(crate) fn json_output(&self) -> bool {
+        match &self.command {
+            TursoCommand::Init(args) => args.json,
+            TursoCommand::Push(args) => args.json,
+            TursoCommand::Search(args) => args.json,
+            TursoCommand::Status(args) => args.json,
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+enum TursoCommand {
+    #[command(about = "Create the portable remote ctx projection")]
+    Init(TursoInitArgs),
+    #[command(about = "Export an existing local ctx index to Turso")]
+    Push(TursoPushArgs),
+    #[command(about = "Search history stored in Turso")]
+    Search(TursoSearchArgs),
+    #[command(about = "Show Turso ctx projection status")]
+    Status(TursoStatusArgs),
+}
+
+#[derive(Debug, Args)]
+struct TursoInitArgs {
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+struct TursoPushArgs {
+    #[arg(
+        long,
+        default_value_t = DEFAULT_PUSH_BATCH_SIZE,
+        value_parser = parse_push_batch_size,
+        help = "Number of events per remote transaction (1-250)"
+    )]
+    batch_size: usize,
+    #[arg(long, help = "Upload no more than this many events")]
+    limit: Option<usize>,
+    #[arg(
+        long,
+        help = "Also export local-only events; required unless events are marked sync_full"
+    )]
+    include_local_only: bool,
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+struct TursoSearchArgs {
+    #[arg(help = "ASCII case-insensitive substring query")]
+    query: String,
+    #[arg(
+        long,
+        help = "Filter by ctx provider name, for example codex or claude"
+    )]
+    provider: Option<String>,
+    #[arg(long, default_value_t = DEFAULT_SEARCH_LIMIT, value_parser = parse_search_limit)]
+    limit: usize,
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+struct TursoStatusArgs {
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug)]
+struct TursoConfig {
+    database_url: String,
+    auth_token: String,
+}
+
+impl TursoConfig {
+    fn from_env() -> Result<Self> {
+        let database_url = required_env(DATABASE_URL_ENV)?;
+        if !database_url.starts_with("libsql://") && !database_url.starts_with("https://") {
+            return Err(anyhow!(
+                "{DATABASE_URL_ENV} must start with libsql:// or https://"
+            ));
+        }
+        Ok(Self {
+            database_url,
+            auth_token: required_env(AUTH_TOKEN_ENV)?,
+        })
+    }
+}
+
+pub(crate) fn run_turso(args: TursoArgs, data_root: PathBuf) -> Result<()> {
+    match args.command {
+        TursoCommand::Init(args) => run_async(init(args.json)),
+        TursoCommand::Push(args) => {
+            let db_path = database_path(data_root);
+            let store = open_existing_store_read_only(&db_path, "ctx turso push")?;
+            run_async(push(store, args))
+        }
+        TursoCommand::Search(args) => run_async(search(args)),
+        TursoCommand::Status(args) => run_async(status(args.json)),
+    }
+}
+
+fn run_async(operation: impl std::future::Future<Output = Result<()>>) -> Result<()> {
+    Runtime::new()
+        .context("create async runtime for Turso")?
+        .block_on(operation)
+}
+
+async fn connect() -> Result<libsql::Connection> {
+    let config = TursoConfig::from_env()?;
+    let database = libsql::Builder::new_remote(config.database_url, config.auth_token)
+        .build()
+        .await
+        .context("connect to Turso")?;
+    database.connect().context("open Turso connection")
+}
+
+async fn init(json_output: bool) -> Result<()> {
+    let conn = connect().await?;
+    ensure_schema(&conn).await?;
+    if json_output {
+        print_json(json!({"initialized": true, "remote_projection": true}))?;
+    } else {
+        println!("Turso ctx projection is ready.");
+    }
+    Ok(())
+}
+
+async fn ensure_schema(conn: &libsql::Connection) -> Result<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS ctx_turso_events (\
+            event_id TEXT PRIMARY KEY,\
+            session_id TEXT,\
+            provider TEXT NOT NULL,\
+            role TEXT,\
+            event_type TEXT NOT NULL,\
+            occurred_at_ms INTEGER NOT NULL,\
+            dedupe_key TEXT,\
+            payload_json TEXT NOT NULL,\
+            search_text TEXT NOT NULL DEFAULT ''\
+        )",
+        (),
+    )
+    .await
+    .context("create Turso event table")?;
+    ensure_dedupe_key_column(conn).await?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS ctx_turso_events_occurred_at \
+         ON ctx_turso_events(occurred_at_ms DESC)",
+        (),
+    )
+    .await
+    .context("create Turso event time index")?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS ctx_turso_events_provider \
+         ON ctx_turso_events(provider)",
+        (),
+    )
+    .await
+    .context("create Turso provider index")?;
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ctx_turso_events_dedupe_key \
+         ON ctx_turso_events(dedupe_key) WHERE dedupe_key IS NOT NULL",
+        (),
+    )
+    .await
+    .context("create Turso dedupe index")?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS ctx_turso_upload_cursors (\
+            device_id TEXT PRIMARY KEY,\
+            last_event_id TEXT NOT NULL\
+        )",
+        (),
+    )
+    .await
+    .context("create Turso upload cursor table")?;
+    Ok(())
+}
+
+async fn ensure_dedupe_key_column(conn: &libsql::Connection) -> Result<()> {
+    let mut columns = conn
+        .query("PRAGMA table_info(ctx_turso_events)", ())
+        .await
+        .context("inspect Turso event table")?;
+    while let Some(column) = columns.next().await.context("read Turso table column")? {
+        if column.get::<String>(1)? == "dedupe_key" {
+            return Ok(());
+        }
+    }
+    conn.execute(
+        "ALTER TABLE ctx_turso_events ADD COLUMN dedupe_key TEXT",
+        (),
+    )
+    .await
+    .context("add Turso event dedupe key")?;
+    Ok(())
+}
+
+async fn push(store: Store, args: TursoPushArgs) -> Result<()> {
+    let conn = connect().await?;
+    ensure_schema(&conn).await?;
+    let device_id = export_device_id(&store)?;
+    let session_providers = store
+        .list_sessions()?
+        .into_iter()
+        .map(|session| (session.id, session.provider.as_str().to_owned()))
+        .collect::<std::collections::HashMap<_, _>>();
+    let capture_source_providers = store
+        .list_capture_sources()?
+        .into_iter()
+        .map(|source| (source.id, source.descriptor.provider.as_str().to_owned()))
+        .collect::<std::collections::HashMap<_, _>>();
+
+    let mut after_id = upload_cursor(&conn, &device_id).await?;
+    let mut uploaded = 0u64;
+    let mut skipped = 0usize;
+    let mut scanned = 0usize;
+    let mut batches = 0usize;
+    loop {
+        let remaining = args.limit.map(|limit| limit.saturating_sub(scanned));
+        if remaining == Some(0) {
+            break;
+        }
+        let page_size = remaining
+            .map(|limit| limit.min(args.batch_size))
+            .unwrap_or(args.batch_size);
+        let events = store.list_events_page_after(after_id, page_size)?;
+        let Some(last) = events.last() else {
+            break;
+        };
+        scanned += events.len();
+        after_id = Some(last.id);
+
+        let transaction = conn
+            .transaction()
+            .await
+            .context("begin Turso upload transaction")?;
+        for event in &events {
+            if !remote_export_allowed(event, args.include_local_only) {
+                skipped += 1;
+                continue;
+            }
+            let payload_json =
+                serde_json::to_string(&event.payload).context("serialize event payload")?;
+            let provider = event
+                .session_id
+                .and_then(|id| session_providers.get(&id))
+                .or_else(|| {
+                    event
+                        .capture_source_id
+                        .and_then(|id| capture_source_providers.get(&id))
+                })
+                .map(String::as_str)
+                .unwrap_or("unknown");
+            uploaded += transaction
+                .execute(
+                    "INSERT OR IGNORE INTO ctx_turso_events \
+                     (event_id, session_id, provider, role, event_type, occurred_at_ms, dedupe_key, payload_json, search_text) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                    libsql::params![
+                        event.id.to_string(),
+                        event.session_id.map(|id| id.to_string()),
+                        provider,
+                        event.role.map(|role| role.as_str().to_owned()),
+                        event.event_type.as_str(),
+                        event.occurred_at.timestamp_millis(),
+                        event.dedupe_key.as_deref(),
+                        payload_json,
+                        "",
+                    ],
+                )
+                .await
+                .with_context(|| format!("upload event {}", event.id))?;
+        }
+        save_upload_cursor(&transaction, &device_id, last.id).await?;
+        transaction
+            .commit()
+            .await
+            .context("commit Turso upload transaction")?;
+        batches += 1;
+    }
+
+    if args.json {
+        print_json(json!({
+            "uploaded_events": uploaded,
+            "skipped_events": skipped,
+            "scanned_events": scanned,
+            "batches": batches,
+            "idempotent": true,
+            "remote_projection": true,
+            "device_id": device_id,
+        }))?;
+    } else {
+        println!("uploaded_events: {uploaded}");
+        println!("skipped_events: {skipped}");
+        println!("scanned_events: {scanned}");
+        println!("batches: {batches}");
+        println!("idempotent: true");
+    }
+    Ok(())
+}
+
+async fn search(args: TursoSearchArgs) -> Result<()> {
+    let conn = connect().await?;
+    require_projection(&conn).await?;
+    let (sql, params) = if let Some(provider) = args.provider.as_deref() {
+        (
+            "SELECT event_id, session_id, provider, role, event_type, occurred_at_ms, payload_json \
+             FROM ctx_turso_events WHERE provider = ?1 AND payload_json LIKE ?2 ESCAPE '\\' COLLATE NOCASE \
+             ORDER BY occurred_at_ms DESC LIMIT ?3",
+            libsql::params_from_iter(vec![
+                libsql::Value::Text(provider.to_owned()),
+                libsql::Value::Text(substring_pattern(&args.query)),
+                libsql::Value::Integer(args.limit as i64),
+            ]),
+        )
+    } else {
+        (
+            "SELECT event_id, session_id, provider, role, event_type, occurred_at_ms, payload_json \
+             FROM ctx_turso_events WHERE payload_json LIKE ?1 ESCAPE '\\' COLLATE NOCASE \
+             ORDER BY occurred_at_ms DESC LIMIT ?2",
+            libsql::params_from_iter(vec![
+                libsql::Value::Text(substring_pattern(&args.query)),
+                libsql::Value::Integer(args.limit as i64),
+            ]),
+        )
+    };
+    let mut rows = conn
+        .query(sql, params)
+        .await
+        .context("search Turso history")?;
+    let mut results = Vec::new();
+    while let Some(row) = rows.next().await.context("read Turso search result")? {
+        results.push(json!({
+            "event_id": row.get::<String>(0)?,
+            "session_id": row.get::<Option<String>>(1)?,
+            "provider": row.get::<String>(2)?,
+            "role": row.get::<Option<String>>(3)?,
+            "event_type": row.get::<String>(4)?,
+            "occurred_at_ms": row.get::<i64>(5)?,
+            "payload_json": row.get::<String>(6)?,
+        }));
+    }
+    if args.json {
+        print_json(json!({"query": args.query, "results": results}))?;
+    } else {
+        for result in results {
+            println!("{}", serde_json::to_string(&result)?);
+        }
+    }
+    Ok(())
+}
+
+async fn status(json_output: bool) -> Result<()> {
+    let conn = connect().await?;
+    require_projection(&conn).await?;
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*), COUNT(DISTINCT provider), MIN(occurred_at_ms), MAX(occurred_at_ms) \
+             FROM ctx_turso_events",
+            (),
+        )
+        .await
+        .context("read Turso status")?;
+    let row = rows
+        .next()
+        .await
+        .context("read Turso status row")?
+        .ok_or_else(|| anyhow!("Turso status query returned no row"))?;
+    let value = json!({
+        "remote_projection": true,
+        "events": row.get::<i64>(0)?,
+        "providers": row.get::<i64>(1)?,
+        "oldest_event_ms": row.get::<Option<i64>>(2)?,
+        "newest_event_ms": row.get::<Option<i64>>(3)?,
+    });
+    if json_output {
+        print_json(value)?;
+    } else {
+        for (key, value) in value.as_object().expect("status is an object") {
+            println!("{key}: {value}");
+        }
+    }
+    Ok(())
+}
+
+fn required_env(name: &str) -> Result<String> {
+    env::var(name).with_context(|| {
+        format!("{name} is required; set it in your shell, never in a file or CLI argument")
+    })
+}
+
+fn parse_push_batch_size(value: &str) -> std::result::Result<usize, String> {
+    let size = value
+        .parse::<usize>()
+        .map_err(|error| format!("invalid batch size: {error}"))?;
+    if !(1..=MAX_PUSH_BATCH_SIZE).contains(&size) {
+        return Err(format!(
+            "batch size must be between 1 and {MAX_PUSH_BATCH_SIZE}"
+        ));
+    }
+    Ok(size)
+}
+
+fn parse_search_limit(value: &str) -> std::result::Result<usize, String> {
+    let limit = value
+        .parse::<usize>()
+        .map_err(|error| format!("invalid search limit: {error}"))?;
+    if !(1..=MAX_SEARCH_LIMIT).contains(&limit) {
+        return Err(format!(
+            "search limit must be between 1 and {MAX_SEARCH_LIMIT}"
+        ));
+    }
+    Ok(limit)
+}
+
+fn substring_pattern(query: &str) -> String {
+    format!(
+        "%{}%",
+        query
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_")
+    )
+}
+
+async fn require_projection(conn: &libsql::Connection) -> Result<()> {
+    conn.query("SELECT 1 FROM ctx_turso_events LIMIT 1", ())
+        .await
+        .context(
+            "open Turso ctx projection; run `ctx turso init` with a write-capable token first",
+        )?;
+    Ok(())
+}
+
+fn export_device_id(store: &Store) -> Result<String> {
+    if let Ok(value) = env::var("CTX_TURSO_DEVICE_ID") {
+        if !value.trim().is_empty() {
+            return Ok(value);
+        }
+    }
+    store
+        .local_device()?
+        .map(|device| device.stable_device_id)
+        .ok_or_else(|| {
+            anyhow!(
+                "CTX_TURSO_DEVICE_ID is required when the local ctx store has no device identity"
+            )
+        })
+}
+
+async fn upload_cursor(conn: &libsql::Connection, device_id: &str) -> Result<Option<uuid::Uuid>> {
+    let mut rows = conn
+        .query(
+            "SELECT last_event_id FROM ctx_turso_upload_cursors WHERE device_id = ?1",
+            [device_id],
+        )
+        .await
+        .context("read Turso upload cursor")?;
+    let Some(row) = rows.next().await.context("read Turso upload cursor row")? else {
+        return Ok(None);
+    };
+    row.get::<String>(0)?
+        .parse()
+        .map(Some)
+        .context("parse Turso upload cursor")
+}
+
+async fn save_upload_cursor(
+    conn: &libsql::Connection,
+    device_id: &str,
+    last_event_id: uuid::Uuid,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO ctx_turso_upload_cursors (device_id, last_event_id) VALUES (?1, ?2) \
+         ON CONFLICT(device_id) DO UPDATE SET last_event_id = excluded.last_event_id",
+        (device_id, last_event_id.to_string()),
+    )
+    .await
+    .context("save Turso upload cursor")?;
+    Ok(())
+}
+
+fn remote_export_allowed(event: &ctx_history_core::Event, include_local_only: bool) -> bool {
+    if matches!(event.sync.visibility, Visibility::Withheld)
+        || matches!(event.sync.sync_state, SyncState::Withheld)
+    {
+        return false;
+    }
+    matches!(event.sync.visibility, Visibility::SyncFull) || include_local_only
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_bounded_push_batch_size() {
+        assert_eq!(parse_push_batch_size("1"), Ok(1));
+        assert_eq!(parse_push_batch_size("250"), Ok(250));
+        assert!(parse_push_batch_size("0").is_err());
+        assert!(parse_push_batch_size("251").is_err());
+    }
+
+    #[test]
+    fn validates_bounded_search_limit() {
+        assert_eq!(parse_search_limit("200"), Ok(200));
+        assert!(parse_search_limit("0").is_err());
+        assert!(parse_search_limit("201").is_err());
+    }
+
+    #[test]
+    fn escapes_like_wildcards_in_queries() {
+        assert_eq!(substring_pattern("50%_off\\now"), "%50\\%\\_off\\\\now%");
+    }
+}

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -39,7 +39,7 @@ use commands::sql::{parse_sql_timeout, raw_sql_result_json};
 use commands::{
     doctor::run_doctor, import::run_import, index::run_index, locate::run_locate,
     search::run_search, setup::run_setup, show::run_show, sources::run_sources, sql::run_sql,
-    status::run_status,
+    status::run_status, turso::run_turso,
 };
 use config::AppConfig;
 use ctx_history_core::{default_data_root, CaptureProvider};
@@ -111,6 +111,8 @@ enum CommandRoot {
     Search(SearchArgs),
     #[command(about = "Run read-only SQL against the local ctx index")]
     Sql(SqlArgs),
+    #[command(about = "Sync and search ctx history through a remote libSQL database")]
+    Turso(commands::turso::TursoArgs),
     #[command(about = "Read embedded ctx documentation")]
     Docs(docs::DocsArgs),
     #[command(about = "Install or inspect ctx integrations")]
@@ -574,6 +576,7 @@ impl CommandRoot {
             Self::Locate(_) => "locate",
             Self::Search(_) => "search",
             Self::Sql(_) => "sql",
+            Self::Turso(_) => "turso",
             Self::Docs(_) => "docs",
             Self::Integrations(_) => "integrations",
             Self::Mcp(_) => "mcp",
@@ -585,7 +588,9 @@ impl CommandRoot {
 
     fn sends_analytics(&self) -> bool {
         match self {
-            Self::Status(_) | Self::Index(_) | Self::Sql(_) | Self::Mcp(_) => false,
+            Self::Status(_) | Self::Index(_) | Self::Sql(_) | Self::Turso(_) | Self::Mcp(_) => {
+                false
+            }
             Self::Daemon(args) => !matches!(&args.command, DaemonCommand::Status(_)),
             _ => true,
         }
@@ -602,6 +607,7 @@ impl CommandRoot {
             Self::Locate(args) => args.json_output(),
             Self::Search(args) => args.json,
             Self::Sql(args) => args.json_output(),
+            Self::Turso(args) => args.json_output(),
             Self::Docs(args) => args.json_output(),
             Self::Integrations(args) => args.json_output(),
             Self::Mcp(_) => false,
@@ -624,6 +630,7 @@ impl CommandRoot {
                 | Self::Docs(_)
                 | Self::Mcp(_)
                 | Self::Sql(_)
+                | Self::Turso(_)
                 | Self::Upgrade(_)
                 | Self::Daemon(_)
         )
@@ -712,6 +719,7 @@ fn main() -> Result<()> {
             run_search(args, data_root.clone(), &mut analytics_properties, &config)
         }
         CommandRoot::Sql(args) => run_sql(args, data_root.clone()),
+        CommandRoot::Turso(args) => run_turso(args, data_root.clone()),
         CommandRoot::Docs(args) => docs::run(args),
         CommandRoot::Integrations(args) => integrations::run(args, &mut analytics_properties),
         CommandRoot::Mcp(args) => mcp::run(args, data_root.clone()),
@@ -772,6 +780,7 @@ fn command_analytics_properties(command: &CommandRoot) -> AnalyticsProperties {
         | CommandRoot::Index(_)
         | CommandRoot::Sources(_)
         | CommandRoot::Sql(_)
+        | CommandRoot::Turso(_)
         | CommandRoot::Doctor(_) => {}
         CommandRoot::Import(args) => {
             analytics::insert_bool(&mut properties, "resume", args.resume);

--- a/crates/ctx-history-store/src/connection.rs
+++ b/crates/ctx-history-store/src/connection.rs
@@ -18,6 +18,24 @@ use crate::{Result, Store, StoreError, SCHEMA_VERSION};
 pub(crate) const BUSY_TIMEOUT: Duration = Duration::from_millis(30_000);
 
 impl Store {
+    /// Opens an ephemeral Store backed only by process memory. This never
+    /// creates a SQLite file, WAL sidecar, object directory, or spool.
+    pub fn open_in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory()?;
+        configure_connection(&conn, BUSY_TIMEOUT)?;
+        let store = Self {
+            path: PathBuf::from(":memory:"),
+            object_dir: PathBuf::new(),
+            conn,
+            busy_timeout: BUSY_TIMEOUT,
+            event_search_bulk_depth: Default::default(),
+        };
+        store.migrate()?;
+        store.recover_event_search_bulk_mode()?;
+        store.ensure_search_projection_initialized()?;
+        Ok(store)
+    }
+
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         Self::open_with_busy_timeout(path, BUSY_TIMEOUT)
     }

--- a/crates/ctx-history-store/src/connection_tests.rs
+++ b/crates/ctx-history-store/src/connection_tests.rs
@@ -11,6 +11,21 @@ fn tempdir() -> tempfile::TempDir {
         .unwrap()
 }
 
+#[test]
+fn in_memory_store_uses_no_filesystem_database_path() {
+    let store = Store::open_in_memory().unwrap();
+    assert_eq!(store.path().to_string_lossy(), ":memory:");
+    assert_eq!(
+        store
+            .conn
+            .query_row("SELECT COUNT(*) FROM events", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        0
+    );
+    assert!(store.object_dir.as_os_str().is_empty());
+}
+
 fn fts_config(store: &Store, table: &str, key: &str, default: i64) -> i64 {
     let sql = format!("SELECT v FROM {table}_config WHERE k = ?1");
     store

--- a/crates/ctx-history-store/src/events.rs
+++ b/crates/ctx-history-store/src/events.rs
@@ -328,6 +328,26 @@ impl Store {
         collect_rows(rows)
     }
 
+    /// Reads a stable, bounded page for remote export without loading an
+    /// entire history corpus into memory.
+    pub fn list_events_page_after(
+        &self,
+        after_id: Option<Uuid>,
+        limit: usize,
+    ) -> Result<Vec<Event>> {
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let sql = match after_id {
+            Some(_) => event_select_sql("WHERE id > ?1 ORDER BY id LIMIT ?2"),
+            None => event_select_sql("ORDER BY id LIMIT ?1"),
+        };
+        let mut stmt = self.conn.prepare(sql.as_str())?;
+        let rows = match after_id {
+            Some(id) => stmt.query_map(params![id.to_string(), limit], event_from_row)?,
+            None => stmt.query_map(params![limit], event_from_row)?,
+        };
+        collect_rows(rows)
+    }
+
     pub fn max_events_per_history_record(&self) -> Result<i64> {
         let max_events = self.conn.query_row(
             r#"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -20,6 +20,40 @@ top-level `status`. `CTX_QUIET=1` provides the same default for scripts and
 installer wrappers. JSON output, errors, and command results from commands such
 as `search`, `show`, `sources`, and `docs` are not suppressed.
 
+## Remote libSQL / Turso (experimental)
+
+`ctx turso` stores a portable event projection in a remote libSQL-compatible
+database. It is intended for sharing a history projection across machines; it
+does not alter the normal local `ctx` commands.
+
+```bash
+export CTX_TURSO_DATABASE_URL='libsql://your-database.turso.io'
+export CTX_TURSO_AUTH_TOKEN='...'
+
+ctx turso init
+ctx turso push --batch-size 100
+ctx turso search 'deployment' --provider codex
+ctx turso status
+```
+
+- Credentials are read only from `CTX_TURSO_DATABASE_URL` and
+  `CTX_TURSO_AUTH_TOKEN`. Do not put an auth token in a command argument, a
+  config file, or a repository.
+- `push` reads an existing local `work.sqlite` and uploads events in bounded,
+  idempotent batches. It exports only records explicitly marked `sync_full` by
+  default; use `--include-local-only` to make exporting ordinary local history
+  an intentional action. Event UUID and provider dedupe keys make replaying a
+  push and independently uploading matching history from a second Mac safe.
+- Each Mac needs a stable `CTX_TURSO_DEVICE_ID` unless its existing ctx store
+  already has a local device identity. The remote per-device cursor means later
+  pushes only scan new events.
+- `turso search` is a portable, ASCII case-insensitive substring search over
+  the uploaded JSON payload. It is intentionally separate from `ctx search` and
+  does not provide local semantic search, artifact bodies, raw SQL, or MCP.
+- A local ctx index is needed only for the initial import/push path. Direct
+  provider-to-remote capture is not implemented yet, so this is a remote
+  projection/exporter rather than the requested remote-primary backend.
+
 ## Setup And Health
 
 ```bash

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -31,6 +31,10 @@ export CTX_TURSO_DATABASE_URL='libsql://your-database.turso.io'
 export CTX_TURSO_AUTH_TOKEN='...'
 
 ctx turso init
+# Import every discovered native provider without creating ctx/work.sqlite.
+ctx turso import --batch-size 100
+
+# Or migrate an existing local ctx index.
 ctx turso push --batch-size 100
 ctx turso search 'deployment' --provider codex
 ctx turso status
@@ -44,15 +48,26 @@ ctx turso status
   default; use `--include-local-only` to make exporting ordinary local history
   an intentional action. Event UUID and provider dedupe keys make replaying a
   push and independently uploading matching history from a second Mac safe.
-- Each Mac needs a stable `CTX_TURSO_DEVICE_ID` unless its existing ctx store
-  already has a local device identity. The remote per-device cursor means later
-  pushes only scan new events.
+- `import` reads every discovered native provider directly into a process-memory
+  ctx store, then uploads it to Turso. It never creates a persistent ctx
+  `work.sqlite`, WAL, `objects`, or `spool` directory. The transient store is
+  discarded after the upload. Each execution performs a complete idempotent
+  event scan, so a new event can never be skipped because its stable UUID sorts
+  before an earlier event. Provider-owned SQLite sources with live WAL files may
+  still be copied to an OS temporary directory for a consistent read; this is
+  never a ctx index and is removed when the command exits.
+- Imports from Mac 1 and Mac 2 are unioned. When both Macs contain the same
+  provider session with a stable provider-owned session ID, its matching events
+  are deduplicated even when their local source paths differ. Sources without a
+  stable provider session ID are kept as separate events to avoid losing valid
+  independent history.
 - `turso search` is a portable, ASCII case-insensitive substring search over
   the uploaded JSON payload. It is intentionally separate from `ctx search` and
   does not provide local semantic search, artifact bodies, raw SQL, or MCP.
-- A local ctx index is needed only for the initial import/push path. Direct
-  provider-to-remote capture is not implemented yet, so this is a remote
-  projection/exporter rather than the requested remote-primary backend.
+- The remote persistence path currently covers the portable event projection.
+  Normal `ctx search`, `show`, SQL, MCP, semantic retrieval, and artifact-body
+  storage still use the local-store feature set; use the `turso` subcommands
+  when running without a local ctx index.
 
 ## Setup And Health
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,8 @@
 # Limitations
 
-ctx is production-scoped to local history indexing and search retrieval.
+ctx is production-scoped to local history indexing and search retrieval. The
+separate `ctx turso` command is an experimental remote libSQL exporter and
+projection, not a remote-primary backend.
 These limitations are intentional unless another document says a capability has
 shipped.
 
@@ -52,6 +54,22 @@ shipped.
 - The ctx macOS CLI targets macOS 13, but ONNX Runtime 1.27 follows its upstream
   macOS 14 minimum. On macOS 13, daemon-backed lexical search remains available
   while semantic search is unavailable.
+- `ctx turso search` is a remote, ASCII case-insensitive substring search. It does
+  not currently use Turso FTS, semantic retrieval, ctx's local ranking, or
+  artifact bodies; very large remote projections need a dedicated indexed
+  search follow-up before they should replace local lexical-search performance.
+
+## Remote Projection Semantics
+
+- `ctx turso push` uploads existing local events but does not perform a direct
+  remote provider import. A temporary/local ctx index remains necessary to seed
+  the projection.
+- Event UUID plus provider dedupe keys make repeated pushes and most separately
+  captured histories idempotent across Macs. Histories without a provider
+  dedupe key are unioned by event UUID only.
+- Turso/libSQL is the first remote protocol target. Arbitrary hosted SQLite
+  files and providers that do not implement the libSQL remote protocol are not
+  supported.
 
 ## Retrieval Semantics
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,8 +1,8 @@
 # Limitations
 
 ctx is production-scoped to local history indexing and search retrieval. The
-separate `ctx turso` command is an experimental remote libSQL exporter and
-projection, not a remote-primary backend.
+separate `ctx turso` command has an experimental remote-primary persistence path
+for its portable event projection.
 These limitations are intentional unless another document says a capability has
 shipped.
 
@@ -61,12 +61,22 @@ shipped.
 
 ## Remote Projection Semantics
 
-- `ctx turso push` uploads existing local events but does not perform a direct
-  remote provider import. A temporary/local ctx index remains necessary to seed
-  the projection.
+- `ctx turso import` uses an in-process-memory ctx store to read all discovered
+  native providers and uploads the resulting event projection without creating
+  a persistent ctx SQLite index. It is memory-bound for large corpora and scans
+  the complete event set on each execution to guarantee that UUID sort order
+  cannot lose newly imported history. It does not yet stream normalized records
+  directly to libSQL or maintain a remote per-source incremental cursor.
+- `ctx turso push` uploads an existing local index. Neither command makes the
+  ordinary local `ctx search`, `show`, SQL, MCP, semantic retrieval, or
+  artifact-body interfaces remote-capable; use `ctx turso search` for remote
+  projection retrieval.
 - Event UUID plus provider dedupe keys make repeated pushes and most separately
-  captured histories idempotent across Macs. Histories without a provider
-  dedupe key are unioned by event UUID only.
+  captured histories idempotent across Macs. For source-scoped provider keys,
+  Turso derives a canonical key from the provider-owned session ID, event index,
+  and payload hash so the same session copied to different source paths merges.
+  Histories without a stable provider session ID are unioned by their original
+  event UUID only.
 - Turso/libSQL is the first remote protocol target. Arbitrary hosted SQLite
   files and providers that do not implement the libSQL remote protocol are not
   supported.


### PR DESCRIPTION
## Summary

- Add `ctx turso import` to import discovered native provider histories through a process-memory ctx Store, without creating a persistent local ctx SQLite index.
- Make remote ingestion idempotent and safe across Macs by canonicalizing provider session dedupe keys.
- Document the current Turso/libSQL-only event-projection scope and large-history limitations.

## Verification

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test -p ctx -- --test-threads=1`
- `cargo test -p ctx-history-store in_memory_store_uses_no_filesystem_database_path`
- `ctx turso import --help`


