### PR TITLE
feat(pro): prepare production commercial channels

### DIFF
--- a/crates/ctx-cli/BUILD.bazel
+++ b/crates/ctx-cli/BUILD.bazel
@@ -119,9 +119,31 @@ ctx_rust_binary(
     stamp = -1,
 )
 
-# Optimized Pro protocol tests need the developer helper authority that ordinary
-# release binaries intentionally compile out. This test-only host keeps release
-# optimization while making `debug_assertions` the compile-time authority.
+# This target is the only non-test host allowed to select an unpublished local
+# Pro helper. It remains testonly so no release graph can depend on it.
+ctx_rust_binary(
+    name = "ctx_pro_qualification",
+    testonly = True,
+    srcs = PROD_SRCS,
+    crate_name = "ctx_pro_qualification",
+    crate_root = "src/main.rs",
+    edition = crate_edition(),
+    aliases = aliases(),
+    compile_data = CTX_CLI_COMPILE_DATA,
+    deps = all_crate_deps(normal = True) + CTX_CLI_DEPS,
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    rustc_env = RELEASE_BUILD_RUSTC_ENV,
+    rustc_env_files = [
+        ":cargo_toml_env_vars",
+        "release-stamp.env",
+    ],
+    rustc_flags = CTX_CLI_RUSTC_FLAGS + ["--cfg=ctx_pro_qualification"],
+    stamp = -1,
+    tags = ["manual", "qualification"],
+)
+
+# Optimized Pro protocol tests need a local helper authority that ordinary
+# binaries intentionally compile out. Keep it in this test-only host.
 ctx_rust_binary(
     name = "ctx_pro_test_host",
     testonly = True,
@@ -138,7 +160,7 @@ ctx_rust_binary(
         ":cargo_toml_env_vars",
         "release-stamp.env",
     ],
-    rustc_flags = CTX_CLI_RUSTC_FLAGS + ["-Cdebug-assertions=yes"],
+    rustc_flags = CTX_CLI_RUSTC_FLAGS + ["--cfg=ctx_pro_test_helper"],
     stamp = -1,
 )
 
@@ -353,6 +375,13 @@ ctx_cli_integration_test(
     src = "tests/pro_mcp.rs",
     binary = ":ctx_pro_test_host",
     tags = ["protocol"],
+)
+
+ctx_cli_integration_test(
+    name = "pro_qualification_tests",
+    src = "tests/pro_qualification.rs",
+    binary = ":ctx_pro_qualification",
+    tags = ["qualification", "security"],
 )
 
 ctx_cli_integration_test(

--- a/crates/ctx-cli/src/pro/anonymous_trial.rs
+++ b/crates/ctx-cli/src/pro/anonymous_trial.rs
@@ -11,7 +11,7 @@ use ctx_pro_host_protocol::base64url;
 use zeroize::Zeroizing;
 
 use super::{
-    artifact_delivery::{fetch_latest, ArtifactDeliveryConfig},
+    artifact_delivery::{acquire_latest, ArtifactDeliveryConfig},
     authorization::InstallationChallengeSigner,
     commercial_api::TrialChallengeRequest,
     commercial_lifecycle::{vault_error, CommercialLifecycleService},
@@ -107,13 +107,10 @@ pub(super) fn setup(
             std::mem::take(&mut refresh.trial_access_token),
             std::mem::take(&mut refresh.referral_claim_token),
         )?;
-        let artifact = fetch_latest(
+        let artifact = acquire_latest(
             data_root,
             installed_version,
-            ArtifactDeliveryConfig {
-                release_origin: service.api.origin(),
-                release_trust: service.config.release_trust,
-            },
+            ArtifactDeliveryConfig::new(service.api.config(), service.config.release_trust),
         )?;
         service.store_anonymous_state(
             refresh.entitlement.clone(),
@@ -139,17 +136,14 @@ pub(super) fn setup(
         referral_codename,
     })?;
     let activation_token = Zeroizing::new(std::mem::take(&mut challenge.trial_activation_token));
-    let artifact = fetch_latest(
+    let artifact = acquire_latest(
         data_root,
         installed_version,
-        ArtifactDeliveryConfig {
-            release_origin: service.api.origin(),
-            release_trust: service.config.release_trust,
-        },
+        ArtifactDeliveryConfig::new(service.api.config(), service.config.release_trust),
     )?;
     let evidence = collect_device_evidence(
         data_root,
-        &artifact.artifact,
+        artifact.verified_helper_path()?,
         &challenge.challenge_base64url,
         &encoded_public_key,
     )?;

--- a/crates/ctx-cli/src/pro/artifact_delivery.rs
+++ b/crates/ctx-cli/src/pro/artifact_delivery.rs
@@ -16,18 +16,30 @@ use sha2::{Digest, Sha256};
 use url::Url;
 use uuid::Uuid;
 
+use super::commercial_api::CommercialApiConfig;
 use super::lifecycle::lifecycle_manifest::{
     parse_release_version, platform_target, verified_manifest_for_trust, ProManifest, ReleaseTrust,
     MAX_ARTIFACT_BYTES, MAX_MANIFEST_BYTES, MAX_SIGNATURE_BYTES,
 };
 use super::lifecycle::ProInstallArgs;
+#[cfg(any(test, ctx_pro_qualification))]
+use super::qualification_helper::QualificationHelperBundle;
 
 const RELEASE_ACCEPT: &str = "application/json, application/problem+json";
 const MAX_RELEASE_RESPONSE_BYTES: u64 = 96 * 1024;
 
-pub(crate) struct ArtifactDeliveryConfig<'a> {
-    pub(crate) release_origin: &'a str,
-    pub(crate) release_trust: ReleaseTrust,
+pub(super) struct ArtifactDeliveryConfig<'a> {
+    release_api: &'a CommercialApiConfig,
+    release_trust: ReleaseTrust,
+}
+
+impl<'a> ArtifactDeliveryConfig<'a> {
+    pub(super) fn new(release_api: &'a CommercialApiConfig, release_trust: ReleaseTrust) -> Self {
+        Self {
+            release_api,
+            release_trust,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -36,6 +48,24 @@ pub(crate) struct VerifiedArtifactBundle {
     pub(crate) artifact: PathBuf,
     pub(crate) manifest: PathBuf,
     pub(crate) signature: PathBuf,
+}
+
+#[derive(Debug)]
+#[cfg_attr(test, allow(dead_code))]
+pub(crate) enum SetupArtifactBundle {
+    Release(VerifiedArtifactBundle),
+    #[cfg(any(test, ctx_pro_qualification))]
+    Qualification(QualificationHelperBundle),
+}
+
+impl SetupArtifactBundle {
+    pub(crate) fn verified_helper_path(&self) -> Result<&Path> {
+        match self {
+            Self::Release(bundle) => Ok(&bundle.artifact),
+            #[cfg(any(test, ctx_pro_qualification))]
+            Self::Qualification(bundle) => bundle.verified_path(),
+        }
+    }
 }
 
 impl Drop for VerifiedArtifactBundle {
@@ -91,7 +121,7 @@ enum ReleaseReadFailure {
     },
 }
 
-pub(crate) fn fetch_latest(
+pub(super) fn fetch_latest(
     data_root: &Path,
     installed_version: Option<&str>,
     config: ArtifactDeliveryConfig<'_>,
@@ -104,18 +134,21 @@ pub(crate) fn fetch_latest(
         .build();
     let target = platform_target();
     let manifest_url = manifest_url(
-        config.release_origin,
+        config.release_api.origin().as_str(),
         config.release_trust.channel.wire_name(),
         &target,
     )?;
-    let envelope_bytes = get_manifest_bounded(&agent, &manifest_url)?;
+    let envelope_bytes = get_manifest_bounded(&agent, &manifest_url, config.release_api)?;
     let envelope: ApiSuccess<ManifestEnvelope> = serde_json::from_slice(&envelope_bytes)
         .context("invalid_response: parse artifact manifest response")?;
     validate_success_envelope(&envelope)?;
     let (manifest, manifest_bytes, signature_bytes) =
         verify_envelope(envelope.data, config.release_trust)?;
     reject_release_rollback(installed_version, &manifest.version)?;
-    let artifact_url = artifact_url(config.release_origin, &manifest.artifact_object)?;
+    let artifact_url = artifact_url(
+        config.release_api.origin().as_str(),
+        &manifest.artifact_object,
+    )?;
 
     let stage_dir = create_stage_directory(data_root)?;
     match download_and_stage(
@@ -125,6 +158,7 @@ pub(crate) fn fetch_latest(
         &manifest,
         &manifest_bytes,
         &signature_bytes,
+        config.release_api,
     ) {
         Ok(bundle) => Ok(bundle),
         Err(error) => {
@@ -132,6 +166,21 @@ pub(crate) fn fetch_latest(
             Err(error)
         }
     }
+}
+
+pub(super) fn acquire_latest(
+    data_root: &Path,
+    installed_version: Option<&str>,
+    config: ArtifactDeliveryConfig<'_>,
+) -> Result<SetupArtifactBundle> {
+    #[cfg(ctx_pro_qualification)]
+    if let Some(bundle) =
+        QualificationHelperBundle::from_process_environment(config.release_trust.channel)?
+    {
+        return Ok(SetupArtifactBundle::Qualification(bundle));
+    }
+
+    fetch_latest(data_root, installed_version, config).map(SetupArtifactBundle::Release)
 }
 
 fn reject_release_rollback(installed_version: Option<&str>, release_version: &str) -> Result<()> {
@@ -205,8 +254,14 @@ fn artifact_url(base: &str, artifact_object: &str) -> Result<Url> {
     Ok(url)
 }
 
-fn get_manifest_bounded(agent: &ureq::Agent, url: &Url) -> Result<Vec<u8>> {
-    let response = agent.get(url.as_str()).set("accept", RELEASE_ACCEPT).call();
+fn get_manifest_bounded(
+    agent: &ureq::Agent,
+    url: &Url,
+    api: &CommercialApiConfig,
+) -> Result<Vec<u8>> {
+    let request = api
+        .apply_transport_credentials(agent.get(url.as_str()).set("accept", RELEASE_ACCEPT), url)?;
+    let response = request.call();
     let response =
         response.map_err(|error| anonymous_release_read_error(error, "manifest read"))?;
     let response = require_success_status(response, "manifest read")?;
@@ -335,9 +390,11 @@ fn download_and_stage(
     manifest: &ProManifest,
     manifest_bytes: &[u8],
     signature_bytes: &[u8],
+    api: &CommercialApiConfig,
 ) -> Result<VerifiedArtifactBundle> {
-    let response = agent
-        .get(artifact_url.as_str())
+    let request =
+        api.apply_transport_credentials(agent.get(artifact_url.as_str()), artifact_url)?;
+    let response = request
         .call()
         .map_err(|error| anonymous_release_read_error(error, "artifact read"))?;
     let response = require_success_status(response, "artifact read")?;
@@ -737,13 +794,21 @@ mod tests {
             .build();
 
         assert_eq!(
-            get_manifest_bounded(&agent, &manifest_url).unwrap(),
+            get_manifest_bounded(
+                &agent,
+                &manifest_url,
+                &CommercialApiConfig::new(Url::parse(&format!("{origin}/")).unwrap(), None)
+                    .unwrap(),
+            )
+            .unwrap(),
             br#"{"manifest":"transport-only"}"#
         );
 
         let root = tempfile::tempdir().unwrap();
         let stage = create_stage_directory(root.path()).unwrap();
         let manifest = transport_test_manifest(artifact_object, artifact);
+        let api =
+            CommercialApiConfig::new(Url::parse(&format!("{origin}/")).unwrap(), None).unwrap();
         let bundle = download_and_stage(
             &agent,
             &stage,
@@ -751,11 +816,12 @@ mod tests {
             &manifest,
             b"{}",
             b"signature",
+            &api,
         )
         .unwrap();
         assert_eq!(fs::read(&bundle.artifact).unwrap(), artifact);
 
-        let error = get_manifest_bounded(&agent, &manifest_url).unwrap_err();
+        let error = get_manifest_bounded(&agent, &manifest_url, &api).unwrap_err();
         assert_eq!(
             error.to_string(),
             "invalid_response: anonymous release manifest read returned HTTP 302"

--- a/crates/ctx-cli/src/pro/authorization.rs
+++ b/crates/ctx-cli/src/pro/authorization.rs
@@ -208,7 +208,7 @@ mod tests {
         SignedEntitlement {
             grant: EntitlementGrant {
                 schema_version: ENTITLEMENT_SCHEMA_VERSION,
-                issuer: "https://commercial.staging.ctx.rs".to_owned(),
+                issuer: "https://pro-staging.ctx.rs".to_owned(),
                 key_id: "staging-2026-07-v1".to_owned(),
                 grant_id: "grant-1".to_owned(),
                 subject: "user-1".to_owned(),

--- a/crates/ctx-cli/src/pro/client.rs
+++ b/crates/ctx-cli/src/pro/client.rs
@@ -65,6 +65,8 @@ pub(crate) use output::ProOutputImport;
 mod client_status;
 #[cfg(all(test, unix))]
 use client_status::smoke_helper_at_path_with_authorization;
+#[cfg(ctx_pro_qualification)]
+pub(crate) use client_status::smoke_qualification_helper;
 #[cfg(test)]
 use client_status::status_outcome;
 #[cfg(test)]

--- a/crates/ctx-cli/src/pro/client/transport.rs
+++ b/crates/ctx-cli/src/pro/client/transport.rs
@@ -10,6 +10,7 @@ pub(crate) struct ProClient {
     pub(super) helper_version: String,
     pub(super) authorization_state: Option<EntitlementAccessState>,
     pub(super) entitlement_schedule: Option<EntitlementSchedule>,
+    pub(super) _execution_guard: Option<VerifiedHelperExecutable>,
 }
 
 impl ProClient {
@@ -80,14 +81,12 @@ impl ProClient {
         }
         #[cfg(unix)]
         command.process_group(0);
-        #[cfg(windows)]
         if let Some(executable) = execution_guard.as_ref() {
             executable.verify_execution_identity()?;
         }
         let mut child = command
             .spawn()
             .with_context(|| format!("helper_crashed: start Pro helper {}", path.display()))?;
-        drop(execution_guard);
         let stdin = child
             .stdin
             .take()
@@ -110,6 +109,7 @@ impl ProClient {
             helper_version: String::new(),
             authorization_state: None,
             entitlement_schedule: None,
+            _execution_guard: execution_guard,
         };
         let offered = BTreeSet::from([
             Capability::EntitlementAuthorization,

--- a/crates/ctx-cli/src/pro/client/transport.rs
+++ b/crates/ctx-cli/src/pro/client/transport.rs
@@ -57,12 +57,23 @@ impl ProClient {
         // staged setup smoke, status, journal, and deletion operations.
         let query_only = required.len() == 1 && required.contains(&Capability::Query);
         let git_executable = (!query_only).then(git_executable).transpose()?;
-        let mut command = helper_command::new(path, data_root, git_executable.as_deref())?;
+        let prepared_execution = execution_guard
+            .as_ref()
+            .map(VerifiedHelperExecutable::prepare_execution)
+            .transpose()?;
+        let program = prepared_execution
+            .as_ref()
+            .map(|execution| execution.program())
+            .unwrap_or(path);
+        let mut command = helper_command::new(program, data_root, git_executable.as_deref())?;
         command
             .arg("serve-stdio")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        if let Some(execution) = &prepared_execution {
+            execution.configure_command(&mut command);
+        }
         #[cfg(target_os = "linux")]
         {
             let expected_parent = unsafe { libc::getpid() };
@@ -81,12 +92,10 @@ impl ProClient {
         }
         #[cfg(unix)]
         command.process_group(0);
-        if let Some(executable) = execution_guard.as_ref() {
-            executable.verify_execution_identity()?;
-        }
         let mut child = command
             .spawn()
             .with_context(|| format!("helper_crashed: start Pro helper {}", path.display()))?;
+        drop(prepared_execution);
         let stdin = child
             .stdin
             .take()

--- a/crates/ctx-cli/src/pro/client_status.rs
+++ b/crates/ctx-cli/src/pro/client_status.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 
 use super::{
     default_helper_path, helper_status, protocol_error, support, AuthorizationProvider, ProClient,
-    HANDSHAKE_TIMEOUT,
+    VerifiedHelperExecutable, HANDSHAKE_TIMEOUT,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,12 +60,34 @@ pub(super) fn smoke_helper_at_path_with_authorization(
     path: &Path,
     authorization: Option<&dyn AuthorizationProvider>,
 ) -> Result<HelperSmoke> {
-    smoke_helper_at_path_with_authorization_observing_status(data_root, path, authorization, drop)
+    smoke_helper_at_path_with_authorization_observing_status(
+        data_root,
+        path,
+        None,
+        authorization,
+        drop,
+    )
+}
+
+#[cfg(ctx_pro_qualification)]
+pub(crate) fn smoke_qualification_helper(
+    data_root: &Path,
+    executable: VerifiedHelperExecutable,
+) -> Result<HelperSmoke> {
+    let path = executable.path().to_path_buf();
+    smoke_helper_at_path_with_authorization_observing_status(
+        data_root,
+        &path,
+        Some(executable),
+        None,
+        drop,
+    )
 }
 
 fn smoke_helper_at_path_with_authorization_observing_status(
     data_root: &Path,
     path: &Path,
+    execution_guard: Option<VerifiedHelperExecutable>,
     authorization: Option<&dyn AuthorizationProvider>,
     observe_status: impl FnOnce(StatusResult),
 ) -> Result<HelperSmoke> {
@@ -73,7 +95,7 @@ fn smoke_helper_at_path_with_authorization_observing_status(
     let mut client = ProClient::connect_to_path_with_authorization_mode(
         data_root,
         path,
-        None,
+        execution_guard,
         &required,
         authorization,
         true,
@@ -99,6 +121,7 @@ pub(super) fn smoke_helper_at_path_with_authorization_and_status(
     let smoke = smoke_helper_at_path_with_authorization_observing_status(
         data_root,
         path,
+        None,
         authorization,
         |status| observed_status = Some(status),
     )?;

--- a/crates/ctx-cli/src/pro/client_support.rs
+++ b/crates/ctx-cli/src/pro/client_support.rs
@@ -78,7 +78,7 @@ pub(super) fn helper_path(data_root: &Path) -> Result<PathBuf> {
             crate::pro::commercial_config::selected_channel()?,
         )?
     {
-        return Ok(bundle.verified_path()?.to_path_buf());
+        return Ok(bundle.source_path().to_path_buf());
     }
 
     #[cfg(any(test, ctx_pro_test_helper))]
@@ -100,8 +100,7 @@ pub(super) fn helper_executable(data_root: &Path) -> Result<VerifiedHelperExecut
             crate::pro::commercial_config::selected_channel()?,
         )?
     {
-        let path = bundle.verified_path()?;
-        return VerifiedHelperExecutable::open_qualification(path);
+        return VerifiedHelperExecutable::open_qualification(bundle);
     }
 
     #[cfg(any(test, ctx_pro_test_helper))]

--- a/crates/ctx-cli/src/pro/client_support.rs
+++ b/crates/ctx-cli/src/pro/client_support.rs
@@ -72,7 +72,16 @@ pub(crate) fn default_helper_path(data_root: &Path) -> PathBuf {
 }
 
 pub(super) fn helper_path(data_root: &Path) -> Result<PathBuf> {
-    #[cfg(any(debug_assertions, test))]
+    #[cfg(ctx_pro_qualification)]
+    if let Some(bundle) =
+        crate::pro::qualification_helper::QualificationHelperBundle::from_process_environment(
+            crate::pro::commercial_config::selected_channel()?,
+        )?
+    {
+        return Ok(bundle.verified_path()?.to_path_buf());
+    }
+
+    #[cfg(any(test, ctx_pro_test_helper))]
     if let Some(value) = env::var_os("CTX_PRO_HELPER") {
         let path = PathBuf::from(value);
         if !path.is_absolute() {
@@ -85,7 +94,17 @@ pub(super) fn helper_path(data_root: &Path) -> Result<PathBuf> {
 }
 
 pub(super) fn helper_executable(data_root: &Path) -> Result<VerifiedHelperExecutable> {
-    #[cfg(any(debug_assertions, test))]
+    #[cfg(ctx_pro_qualification)]
+    if let Some(bundle) =
+        crate::pro::qualification_helper::QualificationHelperBundle::from_process_environment(
+            crate::pro::commercial_config::selected_channel()?,
+        )?
+    {
+        let path = bundle.verified_path()?;
+        return VerifiedHelperExecutable::open_qualification(path);
+    }
+
+    #[cfg(any(test, ctx_pro_test_helper))]
     if let Some(value) = env::var_os("CTX_PRO_HELPER") {
         let path = PathBuf::from(value);
         if !path.is_absolute() {
@@ -144,7 +163,7 @@ fn git_executable_names() -> &'static [&'static str] {
     &["git"]
 }
 
-#[cfg(any(debug_assertions, test))]
+#[cfg(any(test, ctx_pro_test_helper))]
 fn regular_helper_path(path: PathBuf) -> Result<PathBuf> {
     let metadata = fs::symlink_metadata(&path)
         .with_context(|| format!("pro_not_installed: no Pro helper at {}", path.display()))?;

--- a/crates/ctx-cli/src/pro/client_tests.rs
+++ b/crates/ctx-cli/src/pro/client_tests.rs
@@ -1312,8 +1312,8 @@ fn dual_namespace_graph_key_deletion_uses_each_exact_vault_authorization() {
     fs::set_permissions(&backend_marker, fs::Permissions::from_mode(0o600))
         .expect("protect backend marker");
 
-    let production_issuer = "https://commercial.ctx.rs";
-    let staging_issuer = "https://commercial.staging.ctx.rs";
+    let production_issuer = "https://pro.ctx.rs";
+    let staging_issuer = "https://pro-staging.ctx.rs";
     let (production_thumbprint, production_public_key) = store_namespace(
         root.path(),
         CredentialVaultNamespace::Production,

--- a/crates/ctx-cli/src/pro/client_tests.rs
+++ b/crates/ctx-cli/src/pro/client_tests.rs
@@ -1326,7 +1326,7 @@ fn dual_namespace_graph_key_deletion_uses_each_exact_vault_authorization() {
         CredentialVaultNamespace::Staging,
         32,
         staging_issuer,
-        "staging-2026-07-v2",
+        "staging-2026-07-v3",
     );
 
     let mismatch = StoredAuthorizationProvider::load_for_graph_key_deletion(

--- a/crates/ctx-cli/src/pro/commercial_api.rs
+++ b/crates/ctx-cli/src/pro/commercial_api.rs
@@ -26,10 +26,104 @@ const MAX_CHECKOUT_LIFETIME_SECONDS: i64 = 7 * 24 * 60 * 60;
 const MAX_RETRY_AFTER_SECONDS: u64 = 30 * 60;
 const MAX_TRIAL_CHALLENGE_LIFETIME_SECONDS: i64 = 10 * 60;
 pub(super) const COMMERCIAL_ACCEPT: &str = "application/json, application/problem+json";
+const STAGING_ACCESS_ORIGIN: &str = "https://pro-staging.ctx.rs/";
+const MAX_ACCESS_HEADER_BYTES: usize = 4096;
+const CLOUDFLARE_ACCESS_CLIENT_ID_HEADER: &str = "CF-Access-Client-Id";
+const CLOUDFLARE_ACCESS_CLIENT_SECRET_HEADER: &str = "CF-Access-Client-Secret";
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+pub(super) struct CloudflareAccessCredentials {
+    client_id: Zeroizing<String>,
+    client_secret: Zeroizing<String>,
+}
+
+impl CloudflareAccessCredentials {
+    pub(super) fn new(client_id: String, client_secret: String) -> Result<Self> {
+        validate_access_header_value(&client_id)?;
+        validate_access_header_value(&client_secret)?;
+        Ok(Self {
+            client_id: Zeroizing::new(client_id),
+            client_secret: Zeroizing::new(client_secret),
+        })
+    }
+}
+
+impl fmt::Debug for CloudflareAccessCredentials {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CloudflareAccessCredentials")
+            .field("client_id", &"[REDACTED]")
+            .field("client_secret", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[derive(Clone)]
 pub(super) struct CommercialApiConfig {
-    pub(super) origin: Url,
+    origin: Url,
+    staging_access: Option<CloudflareAccessCredentials>,
+}
+
+impl fmt::Debug for CommercialApiConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CommercialApiConfig")
+            .field("origin", &self.origin)
+            .field(
+                "staging_access",
+                &self.staging_access.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
+    }
+}
+
+impl CommercialApiConfig {
+    pub(super) fn new(
+        origin: Url,
+        staging_access: Option<CloudflareAccessCredentials>,
+    ) -> Result<Self> {
+        validate_origin(&origin)?;
+        if staging_access.is_some() && origin.as_str() != STAGING_ACCESS_ORIGIN {
+            bail!(
+                "invalid_request: staging Cloudflare Access credentials require the fixed staging origin"
+            );
+        }
+        Ok(Self {
+            origin,
+            staging_access,
+        })
+    }
+
+    pub(super) fn origin(&self) -> &Url {
+        &self.origin
+    }
+
+    pub(super) fn apply_transport_credentials(
+        &self,
+        request: ureq::Request,
+        url: &Url,
+    ) -> Result<ureq::Request> {
+        if url.origin() != self.origin.origin() {
+            bail!("invalid_request: commercial request escaped its fixed origin");
+        }
+        let Some(access) = &self.staging_access else {
+            return Ok(request);
+        };
+        if self.origin.as_str() != STAGING_ACCESS_ORIGIN {
+            bail!(
+                "invalid_request: staging Cloudflare Access credentials require the fixed staging origin"
+            );
+        }
+        Ok(request
+            .set(
+                CLOUDFLARE_ACCESS_CLIENT_ID_HEADER,
+                access.client_id.as_str(),
+            )
+            .set(
+                CLOUDFLARE_ACCESS_CLIENT_SECRET_HEADER,
+                access.client_secret.as_str(),
+            ))
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -147,6 +241,12 @@ pub(super) struct CheckoutResult {
 pub(super) struct PortalResult {
     pub(super) kind: String,
     pub(super) url: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WorkOsBootstrapResult {
+    organization_id: String,
 }
 
 #[derive(Deserialize, ZeroizeOnDrop)]
@@ -319,6 +419,11 @@ pub(super) struct CommercialApiClient {
 impl CommercialApiClient {
     pub(super) fn new(config: CommercialApiConfig) -> Result<Self> {
         validate_origin(&config.origin)?;
+        if config.staging_access.is_some() && config.origin.as_str() != STAGING_ACCESS_ORIGIN {
+            bail!(
+                "invalid_request: staging Cloudflare Access credentials require the fixed staging origin"
+            );
+        }
         Ok(Self {
             config,
             agent: ureq::AgentBuilder::new()
@@ -361,6 +466,16 @@ impl CommercialApiClient {
         }
         urls::validate_portal_url(&result.url)?;
         Ok(result)
+    }
+
+    pub(super) fn bootstrap_workos_personal_organization(
+        &self,
+        access_token: &str,
+    ) -> Result<String> {
+        let result: WorkOsBootstrapResult =
+            self.post("/v1/identity/bootstrap", access_token, &EmptyRequest {})?;
+        validate_identifier(&result.organization_id, "organization")?;
+        Ok(result.organization_id)
     }
 
     pub(super) fn entitlement(
@@ -442,19 +557,22 @@ impl CommercialApiClient {
         Ok(refresh)
     }
 
-    pub(super) fn origin(&self) -> &str {
-        self.config.origin.as_str()
+    pub(super) fn config(&self) -> &CommercialApiConfig {
+        &self.config
     }
 
     fn get<T: DeserializeOwned>(&self, path: &str, access_token: &str) -> Result<T> {
         let url = self.endpoint(path)?;
         let response = {
             let authorization = bearer_authorization(access_token)?;
-            self.agent
-                .get(url.as_str())
-                .set("accept", COMMERCIAL_ACCEPT)
-                .set("authorization", authorization.as_str())
-                .call()
+            let request = self.config.apply_transport_credentials(
+                self.agent
+                    .get(url.as_str())
+                    .set("accept", COMMERCIAL_ACCEPT)
+                    .set("authorization", authorization.as_str()),
+                &url,
+            )?;
+            request.call()
         };
         self.finish(response, "commercial API request")
     }
@@ -482,12 +600,14 @@ impl CommercialApiClient {
             body.zeroize();
             bail!("invalid_request: commercial request is too large");
         }
-        let mut request = self
-            .agent
-            .post(url.as_str())
-            .set("accept", COMMERCIAL_ACCEPT)
-            .set("content-type", "application/json")
-            .set("idempotency-key", &new_idempotency_key("cli")?);
+        let mut request = self.config.apply_transport_credentials(
+            self.agent
+                .post(url.as_str())
+                .set("accept", COMMERCIAL_ACCEPT)
+                .set("content-type", "application/json")
+                .set("idempotency-key", &new_idempotency_key("cli")?),
+            &url,
+        )?;
         if let Some(authorization) = authorization.as_deref() {
             validate_authorization_header(authorization)?;
             request = request.set("authorization", authorization);
@@ -658,6 +778,16 @@ fn validate_origin(origin: &Url) -> Result<()> {
         || origin.password().is_some()
     {
         bail!("invalid_request: commercial API must be an HTTPS origin");
+    }
+    Ok(())
+}
+
+fn validate_access_header_value(value: &str) -> Result<()> {
+    if value.is_empty()
+        || value.len() > MAX_ACCESS_HEADER_BYTES
+        || !value.bytes().all(|byte| byte.is_ascii_graphic())
+    {
+        bail!("invalid_request: staging Cloudflare Access credential is invalid");
     }
     Ok(())
 }

--- a/crates/ctx-cli/src/pro/commercial_api_tests.rs
+++ b/crates/ctx-cli/src/pro/commercial_api_tests.rs
@@ -7,10 +7,116 @@ use super::*;
 use ctx_pro_host_protocol::{EntitlementAccessKind, EntitlementGrant, ENTITLEMENT_SCHEMA_VERSION};
 
 fn test_client() -> CommercialApiClient {
-    CommercialApiClient::new(CommercialApiConfig {
-        origin: Url::parse("https://pro.ctx.test/").unwrap(),
-    })
+    CommercialApiClient::new(
+        CommercialApiConfig::new(Url::parse("https://pro.ctx.test/").unwrap(), None).unwrap(),
+    )
     .unwrap()
+}
+
+#[test]
+fn staging_access_pair_is_attached_only_to_the_exact_fixed_staging_origin() {
+    let client_id = "access-client-id-123";
+    let client_secret = "access-client-secret-456";
+    let credentials =
+        CloudflareAccessCredentials::new(client_id.to_owned(), client_secret.to_owned()).unwrap();
+    let config = CommercialApiConfig::new(
+        Url::parse(STAGING_ACCESS_ORIGIN).unwrap(),
+        Some(credentials.clone()),
+    )
+    .unwrap();
+    let url = Url::parse("https://pro-staging.ctx.rs/v1/account").unwrap();
+    let request = config
+        .apply_transport_credentials(ureq::get(url.as_str()), &url)
+        .unwrap();
+    assert_eq!(
+        request.header(CLOUDFLARE_ACCESS_CLIENT_ID_HEADER),
+        Some(client_id)
+    );
+    assert_eq!(
+        request.header(CLOUDFLARE_ACCESS_CLIENT_SECRET_HEADER),
+        Some(client_secret)
+    );
+
+    let stable =
+        CommercialApiConfig::new(Url::parse("https://pro.ctx.rs/").unwrap(), None).unwrap();
+    let stable_url = Url::parse("https://pro.ctx.rs/v1/account").unwrap();
+    let stable_request = stable
+        .apply_transport_credentials(ureq::get(stable_url.as_str()), &stable_url)
+        .unwrap();
+    assert!(stable_request
+        .header(CLOUDFLARE_ACCESS_CLIENT_ID_HEADER)
+        .is_none());
+    assert!(stable_request
+        .header(CLOUDFLARE_ACCESS_CLIENT_SECRET_HEADER)
+        .is_none());
+
+    assert!(CommercialApiConfig::new(
+        Url::parse("https://pro.ctx.rs/").unwrap(),
+        Some(credentials)
+    )
+    .is_err());
+    assert!(config
+        .apply_transport_credentials(
+            ureq::get("https://example.test/v1/account"),
+            &Url::parse("https://example.test/v1/account").unwrap(),
+        )
+        .is_err());
+}
+
+#[test]
+fn staging_access_credentials_are_bounded_and_redacted() {
+    let client_id = "do-not-log-client-id";
+    let client_secret = "do-not-log-client-secret";
+    let credentials =
+        CloudflareAccessCredentials::new(client_id.to_owned(), client_secret.to_owned()).unwrap();
+    let config = CommercialApiConfig::new(
+        Url::parse(STAGING_ACCESS_ORIGIN).unwrap(),
+        Some(credentials.clone()),
+    )
+    .unwrap();
+    for debug in [format!("{credentials:?}"), format!("{config:?}")] {
+        assert!(!debug.contains(client_id));
+        assert!(!debug.contains(client_secret));
+        assert!(debug.contains("[REDACTED]"));
+    }
+    for invalid in [
+        "",
+        "line\nbreak",
+        "tab\tvalue",
+        "space value",
+        "non-ascii-é",
+    ] {
+        assert!(
+            CloudflareAccessCredentials::new(invalid.to_owned(), "valid-secret".to_owned())
+                .is_err()
+        );
+        assert!(
+            CloudflareAccessCredentials::new("valid-id".to_owned(), invalid.to_owned()).is_err()
+        );
+    }
+}
+
+#[test]
+fn workos_bootstrap_response_contains_only_a_bounded_organization_id() {
+    let result: WorkOsBootstrapResult = serde_json::from_value(serde_json::json!({
+        "organization_id": "org_personal_123"
+    }))
+    .unwrap();
+    validate_identifier(&result.organization_id, "organization").unwrap();
+
+    assert!(
+        serde_json::from_value::<WorkOsBootstrapResult>(serde_json::json!({
+            "organization_id": "org_personal_123",
+            "user_id": "user_caller_controlled"
+        }))
+        .is_err()
+    );
+    let too_long = "x".repeat(129);
+    for invalid in ["", "org with spaces", too_long.as_str()] {
+        let parsed: WorkOsBootstrapResult =
+            serde_json::from_value(serde_json::json!({ "organization_id": invalid })).unwrap();
+        assert!(validate_identifier(&parsed.organization_id, "organization").is_err());
+    }
 }
 
 fn test_response(

--- a/crates/ctx-cli/src/pro/commercial_config.rs
+++ b/crates/ctx-cli/src/pro/commercial_config.rs
@@ -1,25 +1,34 @@
 use anyhow::{bail, Context, Result};
+use std::ffi::OsString;
 use url::Url;
 
 use super::{
-    commercial_api::CommercialApiConfig,
+    commercial_api::{CloudflareAccessCredentials, CommercialApiConfig},
+    commercial_production_record,
     credential_vault::CredentialVaultNamespace,
     lifecycle::lifecycle_manifest::{release_trust, ReleaseChannel, ReleaseTrust},
     workos_device::WorkOsConfig,
 };
 
-const WORKOS_CLIENT_ID: &str = "client_01KQE1NZAXDDBNTV5HVB4N5CVC";
+const STAGING_WORKOS_CLIENT_ID: &str = "client_01KQE1NZAXDDBNTV5HVB4N5CVC";
 const WORKOS_API_ORIGIN: &str = "https://api.workos.com/";
-const STAGING_COMMERCIAL_API_ORIGIN: &str =
-    "https://ctx-local-pro-commercial-staging.fancy-sea-92df.workers.dev/";
-const PRODUCTION_COMMERCIAL_API_ORIGIN: Option<&str> = None;
+const STAGING_COMMERCIAL_API_ORIGIN: &str = "https://pro-staging.ctx.rs/";
+const PRODUCTION_COMMERCIAL_API_ORIGIN: &str = "https://pro.ctx.rs/";
 const CHANNEL_ENV: &str = "CTX_PRO_CHANNEL";
-const STAGING_REFERRALS_AVAILABLE: bool = false;
-const PRODUCTION_REFERRALS_AVAILABLE: bool = false;
-const STAGING_ENTITLEMENT_ISSUER: &str = "https://commercial.staging.ctx.rs";
+const STAGING_ACCESS_CLIENT_ID_ENV: &str = "CTX_PRO_STAGING_ACCESS_CLIENT_ID";
+const STAGING_ACCESS_CLIENT_SECRET_ENV: &str = "CTX_PRO_STAGING_ACCESS_CLIENT_SECRET";
+const STAGING_ENTITLEMENT_ISSUER: &str = "https://pro-staging.ctx.rs";
 const STAGING_ENTITLEMENT_KEY_IDS: &[&str] = &["staging-2026-07-v1", "staging-2026-07-v2"];
-const PRODUCTION_ENTITLEMENT_ISSUER: Option<&str> = None;
-const PRODUCTION_ENTITLEMENT_KEY_IDS: &[&str] = &[];
+const PRODUCTION_ENTITLEMENT_ISSUER: &str = "https://pro.ctx.rs";
+
+#[derive(Debug, Clone, Copy)]
+struct CommercialChannelRecord {
+    api_origin: &'static str,
+    workos_client_id: &'static str,
+    entitlement_issuer: &'static str,
+    entitlement_key_ids: &'static [&'static str],
+    vault_namespace: CredentialVaultNamespace,
+}
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct EntitlementTrust {
@@ -50,88 +59,93 @@ impl CommercialConfig {
         Self::for_channel(selected_channel()?)
     }
 
-    pub(super) fn ensure_referrals_available() -> Result<()> {
-        if !referrals_available_for_channel(selected_channel()?) {
-            bail!(
-                "referral_unavailable: ctx referrals are disabled until the reviewed commercial and payout rollout is qualified"
-            );
-        }
-        Ok(())
-    }
-
-    pub(super) fn referrals_available() -> bool {
-        Self::ensure_referrals_available().is_ok()
-    }
-
     fn for_channel(channel: ReleaseChannel) -> Result<Self> {
-        match channel {
-            ReleaseChannel::Stable => {
-                let (Some(api_origin), Some(entitlement_issuer)) = (
-                    PRODUCTION_COMMERCIAL_API_ORIGIN,
-                    PRODUCTION_ENTITLEMENT_ISSUER,
-                ) else {
-                    bail!(
-                        "commercial_unavailable: ctx Pro stable channel is not configured; production API, release key, and entitlement key are unavailable"
-                    );
-                };
-                if PRODUCTION_ENTITLEMENT_KEY_IDS.is_empty() {
-                    bail!(
-                        "commercial_unavailable: ctx Pro stable channel is not configured; production API, release key, and entitlement key are unavailable"
-                    );
-                }
-                Ok(Self {
-                    workos: WorkOsConfig {
-                        api_origin: parse_origin(WORKOS_API_ORIGIN, "WorkOS")?,
-                        client_id: WORKOS_CLIENT_ID.to_owned(),
-                    },
-                    api: CommercialApiConfig {
-                        origin: parse_origin(api_origin, "commercial API")?,
-                    },
-                    release_trust: release_trust(channel)?,
-                    entitlement_trust: EntitlementTrust {
-                        issuer: entitlement_issuer,
-                        key_ids: PRODUCTION_ENTITLEMENT_KEY_IDS,
-                    },
-                    vault_namespace: CredentialVaultNamespace::Production,
-                })
-            }
-            ReleaseChannel::Staging => Ok(Self {
-                workos: WorkOsConfig {
-                    api_origin: parse_origin(WORKOS_API_ORIGIN, "WorkOS")?,
-                    client_id: WORKOS_CLIENT_ID.to_owned(),
-                },
-                api: CommercialApiConfig {
-                    origin: parse_origin(STAGING_COMMERCIAL_API_ORIGIN, "commercial API")?,
-                },
-                release_trust: release_trust(channel)?,
-                entitlement_trust: EntitlementTrust {
-                    issuer: STAGING_ENTITLEMENT_ISSUER,
-                    key_ids: STAGING_ENTITLEMENT_KEY_IDS,
-                },
-                vault_namespace: CredentialVaultNamespace::Staging,
-            }),
+        let record = channel_record(channel);
+        if record.entitlement_key_ids.is_empty() {
+            bail!("commercial_unavailable: the selected ctx Pro channel has no entitlement trust");
         }
+        let access = match channel {
+            ReleaseChannel::Stable => None,
+            ReleaseChannel::Staging => staging_access_credentials()?,
+        };
+        Ok(Self {
+            workos: WorkOsConfig {
+                api_origin: parse_origin(WORKOS_API_ORIGIN, "WorkOS")?,
+                client_id: record.workos_client_id.to_owned(),
+            },
+            api: CommercialApiConfig::new(
+                parse_origin(record.api_origin, "commercial API")?,
+                access,
+            )?,
+            release_trust: release_trust(channel)?,
+            entitlement_trust: EntitlementTrust {
+                issuer: record.entitlement_issuer,
+                key_ids: record.entitlement_key_ids,
+            },
+            vault_namespace: record.vault_namespace,
+        })
     }
 }
 
-fn referrals_available_for_channel(channel: ReleaseChannel) -> bool {
+fn channel_record(channel: ReleaseChannel) -> CommercialChannelRecord {
     match channel {
-        ReleaseChannel::Stable => PRODUCTION_REFERRALS_AVAILABLE,
-        ReleaseChannel::Staging => STAGING_REFERRALS_AVAILABLE,
+        ReleaseChannel::Stable => CommercialChannelRecord {
+            api_origin: PRODUCTION_COMMERCIAL_API_ORIGIN,
+            workos_client_id: commercial_production_record::WORKOS_CLIENT_ID,
+            entitlement_issuer: PRODUCTION_ENTITLEMENT_ISSUER,
+            entitlement_key_ids: commercial_production_record::ENTITLEMENT_KEY_IDS,
+            vault_namespace: CredentialVaultNamespace::Production,
+        },
+        ReleaseChannel::Staging => CommercialChannelRecord {
+            api_origin: STAGING_COMMERCIAL_API_ORIGIN,
+            workos_client_id: STAGING_WORKOS_CLIENT_ID,
+            entitlement_issuer: STAGING_ENTITLEMENT_ISSUER,
+            entitlement_key_ids: STAGING_ENTITLEMENT_KEY_IDS,
+            vault_namespace: CredentialVaultNamespace::Staging,
+        },
     }
 }
 
-fn selected_channel() -> Result<ReleaseChannel> {
-    let channel = match std::env::var(CHANNEL_ENV) {
-        Ok(value) if value == "staging" => ReleaseChannel::Staging,
-        Ok(value) if value == "stable" => ReleaseChannel::Stable,
-        Ok(_) => bail!("invalid_request: {CHANNEL_ENV} must be stable or staging"),
-        Err(std::env::VarError::NotPresent) => ReleaseChannel::Stable,
-        Err(std::env::VarError::NotUnicode(_)) => {
-            bail!("invalid_request: {CHANNEL_ENV} must be valid UTF-8")
+pub(super) fn selected_channel() -> Result<ReleaseChannel> {
+    selected_channel_from_value(std::env::var_os(CHANNEL_ENV))
+}
+
+fn selected_channel_from_value(value: Option<OsString>) -> Result<ReleaseChannel> {
+    match value {
+        Some(value) if value == "staging" => Ok(ReleaseChannel::Staging),
+        Some(value) if value == "stable" => Ok(ReleaseChannel::Stable),
+        Some(value) if value.to_str().is_some() => {
+            bail!("invalid_request: {CHANNEL_ENV} must be stable or staging")
         }
-    };
-    Ok(channel)
+        Some(_) => bail!("invalid_request: {CHANNEL_ENV} must be valid UTF-8"),
+        None => Ok(ReleaseChannel::Stable),
+    }
+}
+
+fn staging_access_credentials() -> Result<Option<CloudflareAccessCredentials>> {
+    staging_access_credentials_from_values(
+        std::env::var(STAGING_ACCESS_CLIENT_ID_ENV),
+        std::env::var(STAGING_ACCESS_CLIENT_SECRET_ENV),
+    )
+}
+
+fn staging_access_credentials_from_values(
+    client_id: std::result::Result<String, std::env::VarError>,
+    client_secret: std::result::Result<String, std::env::VarError>,
+) -> Result<Option<CloudflareAccessCredentials>> {
+    match (client_id, client_secret) {
+        (Err(std::env::VarError::NotPresent), Err(std::env::VarError::NotPresent)) => Ok(None),
+        (Ok(client_id), Ok(client_secret)) => {
+            CloudflareAccessCredentials::new(client_id, client_secret).map(Some)
+        }
+        (Err(std::env::VarError::NotUnicode(_)), _)
+        | (_, Err(std::env::VarError::NotUnicode(_))) => bail!(
+            "invalid_request: staging Cloudflare Access credentials must be valid UTF-8"
+        ),
+        _ => bail!(
+            "invalid_request: {STAGING_ACCESS_CLIENT_ID_ENV} and {STAGING_ACCESS_CLIENT_SECRET_ENV} must be set together"
+        ),
+    }
 }
 
 fn parse_origin(value: &str, label: &str) -> Result<Url> {
@@ -143,29 +157,70 @@ mod tests {
     use super::*;
 
     #[test]
-    fn constants_are_https_origins() {
-        for value in [WORKOS_API_ORIGIN, STAGING_COMMERCIAL_API_ORIGIN] {
+    fn fixed_channel_records_have_separate_https_origins_and_issuers() {
+        let stable = channel_record(ReleaseChannel::Stable);
+        let staging = channel_record(ReleaseChannel::Staging);
+        for value in [
+            WORKOS_API_ORIGIN,
+            stable.api_origin,
+            staging.api_origin,
+            stable.entitlement_issuer,
+            staging.entitlement_issuer,
+        ] {
             let origin = Url::parse(value).unwrap();
             assert_eq!(origin.scheme(), "https");
-            assert_eq!(origin.path(), "/");
             assert!(origin.host_str().is_some());
         }
-        assert!(WORKOS_CLIENT_ID.starts_with("client_"));
+        assert_eq!(stable.api_origin, "https://pro.ctx.rs/");
+        assert_eq!(stable.entitlement_issuer, "https://pro.ctx.rs");
+        assert_eq!(staging.api_origin, "https://pro-staging.ctx.rs/");
+        assert_eq!(staging.entitlement_issuer, "https://pro-staging.ctx.rs");
+        assert_ne!(stable.api_origin, staging.api_origin);
+        assert_ne!(stable.entitlement_issuer, staging.entitlement_issuer);
+        assert!(STAGING_WORKOS_CLIENT_ID.starts_with("client_"));
+        assert_ne!(stable.workos_client_id, staging.workos_client_id);
     }
 
     #[test]
-    fn stable_fails_closed_until_production_trust_is_configured() {
-        let error = CommercialConfig::for_channel(ReleaseChannel::Stable).unwrap_err();
+    fn unset_channel_defaults_stable_and_explicit_staging_is_supported() {
         assert_eq!(
-            error.to_string(),
-            "commercial_unavailable: ctx Pro stable channel is not configured; production API, release key, and entitlement key are unavailable"
+            selected_channel_from_value(None).unwrap(),
+            ReleaseChannel::Stable
         );
+        assert_eq!(
+            selected_channel_from_value(Some(OsString::from("stable"))).unwrap(),
+            ReleaseChannel::Stable
+        );
+        assert_eq!(
+            selected_channel_from_value(Some(OsString::from("staging"))).unwrap(),
+            ReleaseChannel::Staging
+        );
+        assert!(selected_channel_from_value(Some(OsString::from("production"))).is_err());
+    }
+
+    #[test]
+    fn stable_registry_binds_production_api_workos_release_and_entitlement_identities() {
+        let config = CommercialConfig::for_channel(ReleaseChannel::Stable).unwrap();
+        assert_eq!(
+            config.api.origin().as_str(),
+            PRODUCTION_COMMERCIAL_API_ORIGIN
+        );
+        assert_eq!(config.workos.client_id, "client_01KQE1P04WPEN66E12QCBWHQ8V");
+        assert_eq!(config.release_trust.channel, ReleaseChannel::Stable);
+        config
+            .entitlement_trust
+            .validate_identity(PRODUCTION_ENTITLEMENT_ISSUER, "production-2026-07-v1")
+            .unwrap();
+        assert!(config
+            .entitlement_trust
+            .validate_identity(STAGING_ENTITLEMENT_ISSUER, "staging-2026-07-v2")
+            .is_err());
     }
 
     #[test]
     fn staging_registry_binds_api_release_and_entitlement_identities() {
         let config = CommercialConfig::for_channel(ReleaseChannel::Staging).unwrap();
-        assert_eq!(config.api.origin.as_str(), STAGING_COMMERCIAL_API_ORIGIN);
+        assert_eq!(config.api.origin().as_str(), STAGING_COMMERCIAL_API_ORIGIN);
         assert_eq!(config.release_trust.channel, ReleaseChannel::Staging);
         config
             .entitlement_trust
@@ -173,18 +228,61 @@ mod tests {
             .unwrap();
         assert!(config
             .entitlement_trust
-            .validate_identity("https://commercial.ctx.rs", "production-2026-07-v1")
+            .validate_identity(PRODUCTION_ENTITLEMENT_ISSUER, "production-2026-07-v1")
             .is_err());
     }
 
     #[test]
-    fn referrals_are_reviewed_and_default_disabled_on_every_channel() {
-        assert!(!referrals_available_for_channel(ReleaseChannel::Staging));
-        assert!(!referrals_available_for_channel(ReleaseChannel::Stable));
-        assert!(!CommercialConfig::referrals_available());
-        assert!(CommercialConfig::ensure_referrals_available()
-            .unwrap_err()
-            .to_string()
-            .starts_with("referral_unavailable:"));
+    fn entitlement_identity_is_bound_in_both_channel_directions() {
+        let production_fixture = EntitlementTrust {
+            issuer: PRODUCTION_ENTITLEMENT_ISSUER,
+            key_ids: &["production-fixture-v1"],
+        };
+        let staging = EntitlementTrust {
+            issuer: STAGING_ENTITLEMENT_ISSUER,
+            key_ids: STAGING_ENTITLEMENT_KEY_IDS,
+        };
+        assert!(production_fixture
+            .validate_identity(STAGING_ENTITLEMENT_ISSUER, STAGING_ENTITLEMENT_KEY_IDS[0])
+            .is_err());
+        assert!(staging
+            .validate_identity(PRODUCTION_ENTITLEMENT_ISSUER, "production-fixture-v1")
+            .is_err());
+    }
+
+    #[test]
+    fn staging_access_credentials_are_an_optional_complete_pair() {
+        assert!(staging_access_credentials_from_values(
+            Err(std::env::VarError::NotPresent),
+            Err(std::env::VarError::NotPresent)
+        )
+        .unwrap()
+        .is_none());
+
+        let pair = staging_access_credentials_from_values(
+            Ok("access-client-id".to_owned()),
+            Ok("access-client-secret".to_owned()),
+        )
+        .unwrap()
+        .unwrap();
+        let debug = format!("{pair:?}");
+        assert!(!debug.contains("access-client-id"));
+        assert!(!debug.contains("access-client-secret"));
+
+        for partial in [
+            staging_access_credentials_from_values(
+                Ok("access-client-id".to_owned()),
+                Err(std::env::VarError::NotPresent),
+            ),
+            staging_access_credentials_from_values(
+                Err(std::env::VarError::NotPresent),
+                Ok("access-client-secret".to_owned()),
+            ),
+        ] {
+            assert!(partial
+                .unwrap_err()
+                .to_string()
+                .contains("must be set together"));
+        }
     }
 }

--- a/crates/ctx-cli/src/pro/commercial_config.rs
+++ b/crates/ctx-cli/src/pro/commercial_config.rs
@@ -18,7 +18,7 @@ const CHANNEL_ENV: &str = "CTX_PRO_CHANNEL";
 const STAGING_ACCESS_CLIENT_ID_ENV: &str = "CTX_PRO_STAGING_ACCESS_CLIENT_ID";
 const STAGING_ACCESS_CLIENT_SECRET_ENV: &str = "CTX_PRO_STAGING_ACCESS_CLIENT_SECRET";
 const STAGING_ENTITLEMENT_ISSUER: &str = "https://pro-staging.ctx.rs";
-const STAGING_ENTITLEMENT_KEY_IDS: &[&str] = &["staging-2026-07-v1", "staging-2026-07-v2"];
+const STAGING_ENTITLEMENT_KEY_IDS: &[&str] = &["staging-2026-07-v3"];
 const PRODUCTION_ENTITLEMENT_ISSUER: &str = "https://pro.ctx.rs";
 
 #[derive(Debug, Clone, Copy)]
@@ -213,7 +213,7 @@ mod tests {
             .unwrap();
         assert!(config
             .entitlement_trust
-            .validate_identity(STAGING_ENTITLEMENT_ISSUER, "staging-2026-07-v2")
+            .validate_identity(STAGING_ENTITLEMENT_ISSUER, "staging-2026-07-v3")
             .is_err());
     }
 
@@ -224,7 +224,7 @@ mod tests {
         assert_eq!(config.release_trust.channel, ReleaseChannel::Staging);
         config
             .entitlement_trust
-            .validate_identity(STAGING_ENTITLEMENT_ISSUER, "staging-2026-07-v2")
+            .validate_identity(STAGING_ENTITLEMENT_ISSUER, "staging-2026-07-v3")
             .unwrap();
         assert!(config
             .entitlement_trust

--- a/crates/ctx-cli/src/pro/commercial_lifecycle.rs
+++ b/crates/ctx-cli/src/pro/commercial_lifecycle.rs
@@ -14,7 +14,7 @@ use zeroize::Zeroize as _;
 
 use super::{
     anonymous_trial,
-    artifact_delivery::{fetch_latest, ArtifactDeliveryConfig},
+    artifact_delivery::{acquire_latest, ArtifactDeliveryConfig},
     authorization::InstallationChallengeSigner,
     commercial_api::{
         checkout_retry_after, is_retryable_checkout_failure, validate_https_url, CheckoutResult,
@@ -172,7 +172,20 @@ impl CommercialLifecycleService {
         if open_browser(&authorization.verification_uri_complete).is_err() {
             eprintln!("A browser could not be opened; use the URL and code above.");
         }
-        self.persist_tokens(self.workos.poll(&authorization)?)
+        self.complete_device_sign_in(self.workos.poll(&authorization)?)
+    }
+
+    fn complete_device_sign_in(&self, tokens: WorkOsTokens) -> Result<String> {
+        if !self.workos.bootstrap_pending(&tokens)? {
+            return self.persist_tokens(tokens);
+        }
+        let organization_id = self
+            .api
+            .bootstrap_workos_personal_organization(&tokens.access_token)?;
+        let refreshed = self
+            .workos
+            .refresh_for_organization(&tokens.refresh_token, &organization_id)?;
+        self.persist_tokens(refreshed)
     }
 
     fn persist_tokens(&self, tokens: WorkOsTokens) -> Result<String> {
@@ -482,13 +495,10 @@ impl CommercialLifecycleService {
                 bail!("invalid_response: entitlement identity does not match commercial account");
             }
             self.store_entitlement(entitlement, &public_key)?;
-            let artifact = fetch_latest(
+            let artifact = acquire_latest(
                 data_root,
                 installed_version,
-                ArtifactDeliveryConfig {
-                    release_origin: self.api.origin(),
-                    release_trust: self.config.release_trust,
-                },
+                ArtifactDeliveryConfig::new(self.api.config(), self.config.release_trust),
             )?;
             Ok(ProSetupPlan {
                 artifact: Some(artifact),

--- a/crates/ctx-cli/src/pro/commercial_production_record.rs
+++ b/crates/ctx-cli/src/pro/commercial_production_record.rs
@@ -1,0 +1,6 @@
+// This file is the checked-in public half of the production commercial trust
+// record. Update these values only from generated production records created by
+// the private release/control-plane ceremony. None of these values are secrets.
+
+pub(super) const WORKOS_CLIENT_ID: &str = "client_01KQE1P04WPEN66E12QCBWHQ8V";
+pub(super) const ENTITLEMENT_KEY_IDS: &[&str] = &["production-2026-07-v1"];

--- a/crates/ctx-cli/src/pro/credential_vault/anonymous_trial.rs
+++ b/crates/ctx-cli/src/pro/credential_vault/anonymous_trial.rs
@@ -256,7 +256,7 @@ mod tests {
         BoundedSignedEntitlement::new(SignedEntitlement {
             grant: EntitlementGrant {
                 schema_version: ENTITLEMENT_SCHEMA_VERSION,
-                issuer: "https://commercial.ctx.rs".to_owned(),
+                issuer: "https://pro.ctx.rs".to_owned(),
                 key_id: "key-1".to_owned(),
                 grant_id: "grant-1".to_owned(),
                 subject: "subject-1".to_owned(),

--- a/crates/ctx-cli/src/pro/credential_vault/linux_tests.rs
+++ b/crates/ctx-cli/src/pro/credential_vault/linux_tests.rs
@@ -173,7 +173,7 @@ fn fixture_entitlement() -> SignedEntitlement {
     SignedEntitlement {
         grant: EntitlementGrant {
             schema_version: ENTITLEMENT_SCHEMA_VERSION,
-            issuer: "https://commercial.ctx.rs".to_owned(),
+            issuer: "https://pro.ctx.rs".to_owned(),
             key_id: "key-1".to_owned(),
             grant_id: "grant-1".to_owned(),
             subject: "subject-1".to_owned(),

--- a/crates/ctx-cli/src/pro/credential_vault/secret_service.rs
+++ b/crates/ctx-cli/src/pro/credential_vault/secret_service.rs
@@ -506,7 +506,7 @@ mod tests {
         SignedEntitlement {
             grant: EntitlementGrant {
                 schema_version: ENTITLEMENT_SCHEMA_VERSION,
-                issuer: "https://commercial.ctx.rs".to_owned(),
+                issuer: "https://pro.ctx.rs".to_owned(),
                 key_id: "key-1".to_owned(),
                 grant_id: "grant-1".to_owned(),
                 subject: "subject-1".to_owned(),

--- a/crates/ctx-cli/src/pro/lifecycle.rs
+++ b/crates/ctx-cli/src/pro/lifecycle.rs
@@ -251,6 +251,13 @@ pub(super) fn validated_installed_helper_path(data_root: &Path) -> Result<PathBu
     validated_installed_helper(data_root).map(|helper| helper.path().to_path_buf())
 }
 
+pub(super) fn acquire_commercial_lifecycle_lock(
+    data_root: &Path,
+    create_pro_root: bool,
+) -> Result<Option<impl Drop>> {
+    LifecycleLock::acquire(&default_helper_path(data_root), create_pro_root)
+}
+
 pub(super) fn validated_installed_helper(data_root: &Path) -> Result<VerifiedHelperExecutable> {
     let target = default_helper_path(data_root);
     if !installation_artifacts_present(data_root) {

--- a/crates/ctx-cli/src/pro/lifecycle_commands.rs
+++ b/crates/ctx-cli/src/pro/lifecycle_commands.rs
@@ -23,6 +23,8 @@ use super::{
     SetupInstallation,
 };
 use crate::pro::artifact_delivery::SetupArtifactBundle;
+#[cfg(ctx_pro_qualification)]
+use crate::pro::client::smoke_qualification_helper;
 #[cfg(test)]
 use crate::pro::client::HelperSmoke;
 use crate::pro::client::{
@@ -424,21 +426,13 @@ fn run_setup(
     telemetry.access_state = ProAccessStateV1::from_safe_name(&plan.account_state);
     let artifact = setup_artifact(&installation, plan.artifact)?;
     let helper_updated = if let Some(bundle) = artifact {
-        let helper_path = bundle.verified_helper_path()?.to_path_buf();
-        let smoke = match smoke_helper_at_path(data_root, &helper_path) {
-            Ok(smoke) => {
-                telemetry.helper_connection = ProHelperConnectionOutcomeV1::Connected;
-                smoke
-            }
-            Err(error) => {
-                telemetry.helper_connection =
-                    crate::analytics::pro_helper_connection_outcome(stable_error_code(&error));
-                return Err(error);
-            }
-        };
-        validate_staged_helper(&smoke)?;
         match bundle {
             SetupArtifactBundle::Release(bundle) => {
+                let smoke = record_helper_smoke(
+                    smoke_helper_at_path(data_root, &bundle.artifact),
+                    telemetry,
+                )?;
+                validate_staged_helper(&smoke)?;
                 install_verified_bundle(&bundle, data_root, trust)?;
                 telemetry.reconcile = if replacing_existing {
                     ProReconcileOutcomeV1::Updated
@@ -447,8 +441,28 @@ fn run_setup(
                 };
                 true
             }
-            #[cfg(any(test, ctx_pro_qualification))]
-            SetupArtifactBundle::Qualification(_) => false,
+            #[cfg(ctx_pro_qualification)]
+            SetupArtifactBundle::Qualification(bundle) => {
+                let executable =
+                    crate::pro::verified_executable::VerifiedHelperExecutable::open_qualification(
+                        bundle,
+                    )?;
+                let smoke = record_helper_smoke(
+                    smoke_qualification_helper(data_root, executable),
+                    telemetry,
+                )?;
+                validate_staged_helper(&smoke)?;
+                false
+            }
+            #[cfg(all(test, not(ctx_pro_qualification)))]
+            SetupArtifactBundle::Qualification(bundle) => {
+                let smoke = record_helper_smoke(
+                    smoke_helper_at_path(data_root, bundle.verified_path()?),
+                    telemetry,
+                )?;
+                validate_staged_helper(&smoke)?;
+                false
+            }
         }
     } else {
         false
@@ -485,6 +499,23 @@ fn run_setup(
         println!("materialized observations: {}", report.observations);
     }
     Ok(())
+}
+
+fn record_helper_smoke(
+    smoke: Result<crate::pro::client::HelperSmoke>,
+    telemetry: &mut ProLifecycleTelemetryV1,
+) -> Result<crate::pro::client::HelperSmoke> {
+    match smoke {
+        Ok(smoke) => {
+            telemetry.helper_connection = ProHelperConnectionOutcomeV1::Connected;
+            Ok(smoke)
+        }
+        Err(error) => {
+            telemetry.helper_connection =
+                crate::analytics::pro_helper_connection_outcome(stable_error_code(&error));
+            Err(error)
+        }
+    }
 }
 
 fn run_manage(

--- a/crates/ctx-cli/src/pro/lifecycle_commands.rs
+++ b/crates/ctx-cli/src/pro/lifecycle_commands.rs
@@ -22,13 +22,12 @@ use super::{
     transaction_journal_next_path, transaction_journal_path, transaction_marker_path, Persistence,
     SetupInstallation,
 };
-use crate::pro::artifact_delivery::VerifiedArtifactBundle;
+use crate::pro::artifact_delivery::SetupArtifactBundle;
 #[cfg(test)]
 use crate::pro::client::HelperSmoke;
 use crate::pro::client::{
     materialize, smoke_helper_at_path, status, ProSetupRepairability, ProStatus,
 };
-use crate::pro::commercial_config::CommercialConfig;
 use crate::pro::commercial_lifecycle::CommercialLifecycleService;
 use crate::pro::lifecycle::lifecycle_manifest::ReleaseTrust;
 use crate::pro::local_deletion::{
@@ -163,7 +162,7 @@ impl ProArgs {
 
 #[derive(Debug)]
 pub(crate) struct ProSetupPlan {
-    pub(crate) artifact: Option<VerifiedArtifactBundle>,
+    pub(crate) artifact: Option<SetupArtifactBundle>,
     pub(crate) account_state: String,
 }
 
@@ -224,9 +223,6 @@ fn run_lifecycle_inner(
     telemetry: &mut ProLifecycleTelemetryV1,
 ) -> Result<()> {
     args.validate_invocation()?;
-    if args.referral.is_some() {
-        CommercialConfig::ensure_referrals_available()?;
-    }
     let json_output = args.json_output();
     let defer_materialization = matches!(
         &args.command,
@@ -428,7 +424,8 @@ fn run_setup(
     telemetry.access_state = ProAccessStateV1::from_safe_name(&plan.account_state);
     let artifact = setup_artifact(&installation, plan.artifact)?;
     let helper_updated = if let Some(bundle) = artifact {
-        let smoke = match smoke_helper_at_path(data_root, &bundle.artifact) {
+        let helper_path = bundle.verified_helper_path()?.to_path_buf();
+        let smoke = match smoke_helper_at_path(data_root, &helper_path) {
             Ok(smoke) => {
                 telemetry.helper_connection = ProHelperConnectionOutcomeV1::Connected;
                 smoke
@@ -440,13 +437,19 @@ fn run_setup(
             }
         };
         validate_staged_helper(&smoke)?;
-        install_verified_bundle(&bundle, data_root, trust)?;
-        telemetry.reconcile = if replacing_existing {
-            ProReconcileOutcomeV1::Updated
-        } else {
-            ProReconcileOutcomeV1::Installed
-        };
-        true
+        match bundle {
+            SetupArtifactBundle::Release(bundle) => {
+                install_verified_bundle(&bundle, data_root, trust)?;
+                telemetry.reconcile = if replacing_existing {
+                    ProReconcileOutcomeV1::Updated
+                } else {
+                    ProReconcileOutcomeV1::Installed
+                };
+                true
+            }
+            #[cfg(any(test, ctx_pro_qualification))]
+            SetupArtifactBundle::Qualification(_) => false,
+        }
     } else {
         false
     };

--- a/crates/ctx-cli/src/pro/lifecycle_manifest.rs
+++ b/crates/ctx-cli/src/pro/lifecycle_manifest.rs
@@ -8,6 +8,18 @@ pub(crate) const MAX_MANIFEST_BYTES: u64 = 64 * 1024;
 pub(crate) const MAX_SIGNATURE_BYTES: u64 = 16 * 1024;
 pub(crate) const MAX_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
 pub(super) const MAX_INSTALL_MARKER_BYTES: u64 = 128 * 1024;
+pub(super) const PRO_RELEASE_STABLE_KEY_ID: &str = "ctx-pro-release-stable-2026-07-27";
+pub(super) const PRO_RELEASE_STABLE_PUBLIC_KEY_PEM: &str = r#"-----BEGIN RSA PUBLIC KEY-----
+MIIBigKCAYEAq2vmUvoGcm0bAJhCdjzqzLF9SAALDA33KQOHWI3JeKFjxHTLs3hP
+88b3WfUfWgd/Bj6pVWpAI/S6MnrT5IQ8VMxPMe9VMM97F4TMN+ZMwo9y4sxefGwJ
++GI/7SJP3hnRLMV2xme9RRMERuaAEL1ComPdqKwcAMzvZSpAHnDrWnjLrhBFyahl
+2n8JoxvNr4sNHGJBdK0voDBgHmgoJvL23zrRDoo+yA7M7F0gQJc0hwxXUeku7rxb
+hlPU7WPZGwDbaNEzoVJBinlXoLuFT3cR7ImwnfPOARSa7q7KZaIoaeljqM3d6lTa
+abVHhCI+EJy1XX4ydQxFbqccMzhsz5g6Wim8q7pKliKT97uwV3r80f3DpjBUiG3e
++6QpMkxZqVaIgK85Za1stYKPfy9wOZyKkXthHeRbhKjozuogyK8cp03TjY6K6pw2
+VNd6soFZl6R0F8V4tNR5CXwlMjgFogl6t2sKIGHUhHC7y1U01lYlRJNqmvCClD2N
+uvdK7q5ndg1XAgMBAAE=
+-----END RSA PUBLIC KEY-----"#;
 pub(super) const PRO_RELEASE_STAGING_KEY_ID: &str = "ctx-pro-release-staging-2026-07-21";
 pub(super) const PRO_RELEASE_STAGING_PUBLIC_KEY_PEM: &str = r#"-----BEGIN RSA PUBLIC KEY-----
 MIIBigKCAYEAzhEEzfwq/hJtK8l0G+K722eEUy9vNyTFvRLK2rIOkTBDwZQs1tgp
@@ -50,9 +62,11 @@ pub(crate) fn release_trust(channel: ReleaseChannel) -> Result<ReleaseTrust> {
             key_id: PRO_RELEASE_STAGING_KEY_ID,
             public_key_pem: PRO_RELEASE_STAGING_PUBLIC_KEY_PEM,
         }),
-        ReleaseChannel::Stable => {
-            bail!("commercial_unavailable: ctx Pro stable release trust is not configured")
-        }
+        ReleaseChannel::Stable => Ok(ReleaseTrust {
+            channel,
+            key_id: PRO_RELEASE_STABLE_KEY_ID,
+            public_key_pem: PRO_RELEASE_STABLE_PUBLIC_KEY_PEM,
+        }),
     }
 }
 #[derive(Debug, Clone, Deserialize)]
@@ -354,12 +368,46 @@ mod release_tests {
     }
 
     #[test]
-    fn stable_release_registry_is_unavailable_without_production_key() {
-        let error = release_trust(ReleaseChannel::Stable).unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            "commercial_unavailable: ctx Pro stable release trust is not configured"
-        );
+    fn release_registry_has_distinct_channel_bound_public_keys() {
+        let stable = release_trust(ReleaseChannel::Stable).unwrap();
+        let staging = release_trust(ReleaseChannel::Staging).unwrap();
+        assert_eq!(stable.channel, ReleaseChannel::Stable);
+        assert_eq!(stable.key_id, "ctx-pro-release-stable-2026-07-27");
+        assert_eq!(staging.channel, ReleaseChannel::Staging);
+        assert_ne!(stable.key_id, staging.key_id);
+        assert_ne!(stable.public_key_pem, staging.public_key_pem);
+    }
+
+    #[test]
+    fn release_selector_rejects_cross_channel_material_before_signature_validation() {
+        let stable_selector = serde_json::json!({
+            "schema_version": 1,
+            "channel": "stable",
+            "release_key_id": PRO_RELEASE_STABLE_KEY_ID,
+        });
+        let staging_selector = serde_json::json!({
+            "schema_version": 1,
+            "channel": "staging",
+            "release_key_id": PRO_RELEASE_STAGING_KEY_ID,
+        });
+        for (selector, trust) in [
+            (
+                serde_json::to_vec(&stable_selector).unwrap(),
+                release_trust(ReleaseChannel::Staging).unwrap(),
+            ),
+            (
+                serde_json::to_vec(&staging_selector).unwrap(),
+                release_trust(ReleaseChannel::Stable).unwrap(),
+            ),
+        ] {
+            let error = verified_manifest_for_trust(&selector, b"not-a-signature", trust)
+                .unwrap_err()
+                .to_string();
+            assert_eq!(
+                error,
+                "invalid_response: signed manifest does not match the selected release channel"
+            );
+        }
     }
 
     #[test]

--- a/crates/ctx-cli/src/pro/local_deletion/tests.rs
+++ b/crates/ctx-cli/src/pro/local_deletion/tests.rs
@@ -143,7 +143,7 @@ impl CredentialRecordReader for MismatchedKeyAndEntitlementReader {
                     grant: EntitlementGrant {
                         schema_version: ENTITLEMENT_SCHEMA_VERSION,
                         issuer: "https://pro-staging.ctx.rs".to_owned(),
-                        key_id: "staging-2026-07-v2".to_owned(),
+                        key_id: "staging-2026-07-v3".to_owned(),
                         grant_id: "grant-mismatch".to_owned(),
                         subject: "subject".to_owned(),
                         account_id: "account".to_owned(),

--- a/crates/ctx-cli/src/pro/local_deletion/tests.rs
+++ b/crates/ctx-cli/src/pro/local_deletion/tests.rs
@@ -142,7 +142,7 @@ impl CredentialRecordReader for MismatchedKeyAndEntitlementReader {
                 let entitlement = SignedEntitlement {
                     grant: EntitlementGrant {
                         schema_version: ENTITLEMENT_SCHEMA_VERSION,
-                        issuer: "https://commercial.staging.ctx.rs".to_owned(),
+                        issuer: "https://pro-staging.ctx.rs".to_owned(),
                         key_id: "staging-2026-07-v2".to_owned(),
                         grant_id: "grant-mismatch".to_owned(),
                         subject: "subject".to_owned(),

--- a/crates/ctx-cli/src/pro/mod.rs
+++ b/crates/ctx-cli/src/pro/mod.rs
@@ -6,12 +6,15 @@ mod commercial_api;
 mod commercial_config;
 mod commercial_deletion;
 mod commercial_lifecycle;
+mod commercial_production_record;
 mod credential_vault;
 mod graph_key_deletion;
 mod helper_command;
 mod lifecycle;
 mod local_deletion;
 mod pending_materialization;
+#[cfg(any(test, ctx_pro_qualification))]
+mod qualification_helper;
 mod referral;
 mod render;
 mod request_identity;

--- a/crates/ctx-cli/src/pro/qualification_helper.rs
+++ b/crates/ctx-cli/src/pro/qualification_helper.rs
@@ -1,12 +1,18 @@
 use std::{
     ffi::OsString,
-    fs::{self, File},
-    io::Read as _,
+    fs::{self, File, OpenOptions},
+    io::{Read as _, Write as _},
     path::{Path, PathBuf},
 };
 
 use anyhow::{bail, Context, Result};
+#[cfg(windows)]
+use ctx_history_core::platform_security::restrict_private_executable;
+use ctx_history_core::platform_security::{
+    restrict_private_directory, verify_private_directory as verify_platform_private_directory,
+};
 use sha2::{Digest, Sha256};
+use uuid::Uuid;
 
 use super::lifecycle::lifecycle_manifest::{ReleaseChannel, MAX_ARTIFACT_BYTES};
 
@@ -19,8 +25,26 @@ const HELPER_CHANNEL_ENV: &str = "CTX_PRO_QUALIFICATION_HELPER_CHANNEL";
 
 #[derive(Debug)]
 pub(crate) struct QualificationHelperBundle {
+    stage: QualificationStage,
+    #[cfg(ctx_pro_qualification)]
+    source_path: PathBuf,
     path: PathBuf,
     sha256: String,
+}
+
+#[derive(Debug)]
+struct QualificationStage {
+    directory: PathBuf,
+    helper: PathBuf,
+    helper_handle: Option<File>,
+}
+
+impl Drop for QualificationStage {
+    fn drop(&mut self) {
+        drop(self.helper_handle.take());
+        let _ = fs::remove_file(&self.helper);
+        let _ = fs::remove_dir(&self.directory);
+    }
 }
 
 impl QualificationHelperBundle {
@@ -74,10 +98,16 @@ impl QualificationHelperBundle {
                 "invalid_request: qualification helper channel does not match the selected commercial channel"
             );
         }
-        let path = path
-            .canonicalize()
-            .context("invalid_request: resolve qualification helper path")?;
-        let bundle = Self { path, sha256 };
+        let source = open_verified_source(&path)?;
+        let stage = stage_verified_helper(source, &sha256)?;
+        let staged_path = stage.helper.clone();
+        let bundle = Self {
+            stage,
+            #[cfg(ctx_pro_qualification)]
+            source_path: path,
+            path: staged_path,
+            sha256,
+        };
         bundle.verify()?;
         Ok(Some(bundle))
     }
@@ -87,36 +117,239 @@ impl QualificationHelperBundle {
         Ok(&self.path)
     }
 
+    #[cfg(ctx_pro_qualification)]
+    pub(crate) fn source_path(&self) -> &Path {
+        &self.source_path
+    }
+
     fn verify(&self) -> Result<()> {
-        let metadata = fs::symlink_metadata(&self.path)
-            .context("invalid_request: inspect qualification helper")?;
-        if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
-            bail!("invalid_request: qualification helper must be a regular non-symlink file");
-        }
-        verify_private_executable(&self.path, &metadata)?;
-        if metadata.len() == 0 || metadata.len() > MAX_ARTIFACT_BYTES {
-            bail!("invalid_request: qualification helper size is outside allowed bounds");
-        }
-        let file = open_without_following_symlinks(&self.path)
-            .context("invalid_request: open qualification helper")?;
-        let opened = file
+        let parent = self
+            .path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("invalid_request: qualification stage is invalid"))?;
+        verify_platform_private_directory(parent)
+            .context("invalid_request: qualification stage permissions are unsafe")?;
+        let retained = self
+            .stage
+            .helper_handle
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("invalid_request: qualification stage is unavailable"))?
             .metadata()
-            .context("invalid_request: inspect opened qualification helper")?;
-        if !same_file_identity(&metadata, &opened) {
+            .context("invalid_request: inspect retained qualification helper")?;
+        let mut named = open_verified_helper(&self.path)?;
+        let opened = named
+            .metadata()
+            .context("invalid_request: inspect staged qualification helper")?;
+        if !same_file_identity(&retained, &opened) {
             bail!("invalid_request: qualification helper changed during validation");
         }
-        let mut bytes = Vec::with_capacity(usize::try_from(opened.len()).unwrap_or(0));
-        file.take(MAX_ARTIFACT_BYTES.saturating_add(1))
-            .read_to_end(&mut bytes)
-            .context("invalid_request: hash qualification helper")?;
-        if bytes.len() as u64 != opened.len() || bytes.len() as u64 > MAX_ARTIFACT_BYTES {
-            bail!("invalid_request: qualification helper changed during validation");
-        }
-        if format!("{:x}", Sha256::digest(&bytes)) != self.sha256 {
-            bail!("invalid_request: qualification helper SHA-256 does not match");
-        }
+        verify_reader_digest(&mut named, opened.len(), &self.sha256)?;
         Ok(())
     }
+}
+
+struct VerifiedSource {
+    file: File,
+    size: u64,
+}
+
+fn open_verified_source(path: &Path) -> Result<VerifiedSource> {
+    let metadata =
+        fs::symlink_metadata(path).context("invalid_request: inspect qualification helper")?;
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        bail!("invalid_request: qualification helper must be a regular non-symlink file");
+    }
+    verify_private_executable(path, &metadata)?;
+    if metadata.len() == 0 || metadata.len() > MAX_ARTIFACT_BYTES {
+        bail!("invalid_request: qualification helper size is outside allowed bounds");
+    }
+    let file = open_without_following_symlinks(path)
+        .context("invalid_request: open qualification helper")?;
+    let opened = file
+        .metadata()
+        .context("invalid_request: inspect opened qualification helper")?;
+    if !same_file_identity(&metadata, &opened) {
+        bail!("invalid_request: qualification helper changed during validation");
+    }
+    Ok(VerifiedSource {
+        file,
+        size: opened.len(),
+    })
+}
+
+fn stage_verified_helper(mut source: VerifiedSource, sha256: &str) -> Result<QualificationStage> {
+    let directory = create_stage_directory()?;
+    let path = directory.join(if cfg!(windows) {
+        "ctx-pro-qualification.exe"
+    } else {
+        "ctx-pro-qualification"
+    });
+    let mut stage = QualificationStage {
+        directory,
+        helper: path.clone(),
+        helper_handle: None,
+    };
+    restrict_private_directory(&stage.directory)
+        .context("invalid_request: secure qualification helper stage")?;
+    verify_platform_private_directory(&stage.directory)
+        .context("invalid_request: qualification stage permissions are unsafe")?;
+
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(&path)
+        .context("invalid_request: create staged qualification helper")?;
+    let mut digest = Sha256::new();
+    let mut copied = 0_u64;
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = source
+            .file
+            .read(&mut buffer)
+            .context("invalid_request: read qualification helper")?;
+        if read == 0 {
+            break;
+        }
+        copied = copied
+            .checked_add(read as u64)
+            .filter(|copied| *copied <= MAX_ARTIFACT_BYTES)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "invalid_request: qualification helper size is outside allowed bounds"
+                )
+            })?;
+        digest.update(&buffer[..read]);
+        file.write_all(&buffer[..read])
+            .context("invalid_request: write staged qualification helper")?;
+    }
+    if copied != source.size {
+        bail!("invalid_request: qualification helper changed during validation");
+    }
+    if format!("{:x}", digest.finalize()) != sha256 {
+        bail!("invalid_request: qualification helper SHA-256 does not match");
+    }
+    file.flush()
+        .context("invalid_request: flush staged qualification helper")?;
+    file.sync_all()
+        .context("invalid_request: sync staged qualification helper")?;
+    drop(file);
+
+    make_staged_helper_read_only(&path)?;
+    let mut helper_handle = open_verified_helper(&path)?;
+    let staged_metadata = helper_handle
+        .metadata()
+        .context("invalid_request: inspect staged qualification helper")?;
+    verify_reader_digest(&mut helper_handle, staged_metadata.len(), sha256)?;
+    sync_directory(&stage.directory)?;
+    stage.helper_handle = Some(helper_handle);
+    Ok(stage)
+}
+
+#[cfg(unix)]
+fn make_staged_helper_read_only(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o500))
+        .context("invalid_request: make staged qualification helper read-only")
+}
+
+#[cfg(windows)]
+fn make_staged_helper_read_only(path: &Path) -> Result<()> {
+    restrict_private_executable(path).context("invalid_request: secure staged qualification helper")
+}
+
+#[cfg(not(any(unix, windows)))]
+fn make_staged_helper_read_only(_path: &Path) -> Result<()> {
+    bail!("invalid_request: qualification helpers are unsupported on this platform")
+}
+
+fn open_verified_helper(path: &Path) -> Result<File> {
+    let metadata =
+        fs::symlink_metadata(path).context("invalid_request: inspect qualification helper")?;
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        bail!("invalid_request: qualification helper must be a regular non-symlink file");
+    }
+    verify_private_executable(path, &metadata)?;
+    if metadata.len() == 0 || metadata.len() > MAX_ARTIFACT_BYTES {
+        bail!("invalid_request: qualification helper size is outside allowed bounds");
+    }
+    let file = open_without_following_symlinks(path)
+        .context("invalid_request: open qualification helper")?;
+    let opened = file
+        .metadata()
+        .context("invalid_request: inspect opened qualification helper")?;
+    if !same_file_identity(&metadata, &opened) {
+        bail!("invalid_request: qualification helper changed during validation");
+    }
+    Ok(file)
+}
+
+fn verify_reader_digest(reader: &mut File, expected_size: u64, sha256: &str) -> Result<()> {
+    let mut digest = Sha256::new();
+    let mut size = 0_u64;
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .context("invalid_request: hash qualification helper")?;
+        if read == 0 {
+            break;
+        }
+        size = size
+            .checked_add(read as u64)
+            .filter(|size| *size <= MAX_ARTIFACT_BYTES)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "invalid_request: qualification helper size is outside allowed bounds"
+                )
+            })?;
+        digest.update(&buffer[..read]);
+    }
+    if size != expected_size {
+        bail!("invalid_request: qualification helper changed during validation");
+    }
+    if format!("{:x}", digest.finalize()) != sha256 {
+        bail!("invalid_request: qualification helper SHA-256 does not match");
+    }
+    Ok(())
+}
+
+fn create_stage_directory() -> Result<PathBuf> {
+    for _ in 0..16 {
+        let path =
+            std::env::temp_dir().join(format!("ctx-pro-qualification-{}", Uuid::new_v4().simple()));
+        let mut builder = fs::DirBuilder::new();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt as _;
+            builder.mode(0o700);
+        }
+        match builder.create(&path) {
+            Ok(()) => return Ok(path),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error).context("invalid_request: create qualification helper stage")
+            }
+        }
+    }
+    bail!("invalid_request: create unique qualification helper stage")
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> Result<()> {
+    File::open(path)
+        .and_then(|directory| directory.sync_all())
+        .context("invalid_request: sync qualification helper stage")
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> Result<()> {
+    Ok(())
 }
 
 fn open_without_following_symlinks(path: &Path) -> std::io::Result<File> {
@@ -126,6 +359,17 @@ fn open_without_following_symlinks(path: &Path) -> std::io::Result<File> {
     {
         use std::os::unix::fs::OpenOptionsExt as _;
         options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt as _;
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ,
+        };
+
+        options
+            .share_mode(FILE_SHARE_READ)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
     }
     options.open(path)
 }
@@ -189,7 +433,7 @@ mod tests {
     fn helper() -> (tempfile::TempDir, PathBuf, String) {
         let root = tempfile::tempdir().unwrap();
         let path = root.path().join("ctx-pro");
-        fs::write(&path, b"qualification helper").unwrap();
+        fs::write(&path, b"#!/bin/sh\nprintf 'verified helper\\n'\n").unwrap();
         fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
         let digest = format!("{:x}", Sha256::digest(fs::read(&path).unwrap()));
         (root, path, digest)
@@ -218,7 +462,39 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn exact_private_helper_is_accepted_but_tampering_is_rejected() {
+    fn source_path_replacement_cannot_change_the_staged_helper() {
+        let (_root, path, digest) = helper();
+        let bundle = QualificationHelperBundle::from_values(
+            Some(path.clone().into_os_string()),
+            value(&digest),
+            value("stable"),
+            ReleaseChannel::Stable,
+        )
+        .unwrap()
+        .unwrap();
+        let staged = bundle.verified_path().unwrap().to_path_buf();
+        assert_ne!(staged, path);
+        assert_eq!(
+            fs::metadata(&staged).unwrap().permissions().mode() & 0o777,
+            0o500
+        );
+
+        let original = path.with_extension("original");
+        fs::rename(&path, &original).unwrap();
+        fs::write(&path, b"#!/bin/sh\nprintf 'attacker replacement\\n'\n").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+
+        let output = std::process::Command::new(bundle.verified_path().unwrap())
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"verified helper\n");
+        assert!(!String::from_utf8_lossy(&output.stdout).contains("attacker"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn staged_helper_tampering_is_rejected() {
         let (_root, path, digest) = helper();
         let bundle = QualificationHelperBundle::from_values(
             Some(path.into_os_string()),
@@ -228,13 +504,76 @@ mod tests {
         )
         .unwrap()
         .unwrap();
-        bundle.verified_path().unwrap();
-        fs::write(bundle.verified_path().unwrap(), b"tampered helper").unwrap();
+        let staged = bundle.verified_path().unwrap().to_path_buf();
+        fs::set_permissions(&staged, fs::Permissions::from_mode(0o700)).unwrap();
+        fs::write(&staged, b"tampered helper").unwrap();
         assert!(bundle
             .verified_path()
             .unwrap_err()
             .to_string()
             .contains("SHA-256 does not match"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn staged_path_replacement_is_rejected_against_the_retained_inode() {
+        let (root, path, digest) = helper();
+        let bundle = QualificationHelperBundle::from_values(
+            Some(path.into_os_string()),
+            value(&digest),
+            value("stable"),
+            ReleaseChannel::Stable,
+        )
+        .unwrap()
+        .unwrap();
+        let staged = bundle.verified_path().unwrap().to_path_buf();
+        let displaced = root.path().join("displaced-staged-helper");
+        fs::rename(&staged, &displaced).unwrap();
+        fs::write(&staged, b"#!/bin/sh\nprintf 'replacement\\n'\n").unwrap();
+        fs::set_permissions(&staged, fs::Permissions::from_mode(0o500)).unwrap();
+
+        assert!(bundle
+            .verified_path()
+            .unwrap_err()
+            .to_string()
+            .contains("changed during validation"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_stage_is_removed_when_the_bundle_is_dropped() {
+        let (_root, path, digest) = helper();
+        let staged;
+        {
+            let bundle = QualificationHelperBundle::from_values(
+                Some(path.into_os_string()),
+                value(&digest),
+                value("stable"),
+                ReleaseChannel::Stable,
+            )
+            .unwrap()
+            .unwrap();
+            staged = bundle.verified_path().unwrap().to_path_buf();
+            assert!(staged.exists());
+        }
+        assert!(!staged.exists());
+        assert!(!staged.parent().unwrap().exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_source_is_rejected() {
+        let (_root, path, digest) = helper();
+        let link = path.with_extension("link");
+        std::os::unix::fs::symlink(&path, &link).unwrap();
+        let error = QualificationHelperBundle::from_values(
+            Some(link.into_os_string()),
+            value(&digest),
+            value("stable"),
+            ReleaseChannel::Stable,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("regular non-symlink file"));
     }
 
     #[cfg(unix)]

--- a/crates/ctx-cli/src/pro/qualification_helper.rs
+++ b/crates/ctx-cli/src/pro/qualification_helper.rs
@@ -1,0 +1,253 @@
+use std::{
+    ffi::OsString,
+    fs::{self, File},
+    io::Read as _,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{bail, Context, Result};
+use sha2::{Digest, Sha256};
+
+use super::lifecycle::lifecycle_manifest::{ReleaseChannel, MAX_ARTIFACT_BYTES};
+
+#[cfg(ctx_pro_qualification)]
+const HELPER_PATH_ENV: &str = "CTX_PRO_QUALIFICATION_HELPER_PATH";
+#[cfg(ctx_pro_qualification)]
+const HELPER_SHA256_ENV: &str = "CTX_PRO_QUALIFICATION_HELPER_SHA256";
+#[cfg(ctx_pro_qualification)]
+const HELPER_CHANNEL_ENV: &str = "CTX_PRO_QUALIFICATION_HELPER_CHANNEL";
+
+#[derive(Debug)]
+pub(crate) struct QualificationHelperBundle {
+    path: PathBuf,
+    sha256: String,
+}
+
+impl QualificationHelperBundle {
+    #[cfg(ctx_pro_qualification)]
+    pub(crate) fn from_process_environment(
+        selected_channel: ReleaseChannel,
+    ) -> Result<Option<Self>> {
+        Self::from_values(
+            std::env::var_os(HELPER_PATH_ENV),
+            std::env::var_os(HELPER_SHA256_ENV),
+            std::env::var_os(HELPER_CHANNEL_ENV),
+            selected_channel,
+        )
+    }
+
+    fn from_values(
+        path: Option<OsString>,
+        sha256: Option<OsString>,
+        channel: Option<OsString>,
+        selected_channel: ReleaseChannel,
+    ) -> Result<Option<Self>> {
+        if path.is_none() && sha256.is_none() && channel.is_none() {
+            return Ok(None);
+        }
+        let (Some(path), Some(sha256), Some(channel)) = (path, sha256, channel) else {
+            bail!(
+                "invalid_request: qualification helper path, SHA-256, and channel must be configured together"
+            );
+        };
+        let path = PathBuf::from(path);
+        if !path.is_absolute() {
+            bail!("invalid_request: qualification helper path must be absolute");
+        }
+        let sha256 = sha256.into_string().map_err(|_| {
+            anyhow::anyhow!("invalid_request: qualification helper SHA-256 must be valid UTF-8")
+        })?;
+        if sha256.len() != 64
+            || !sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            bail!(
+                "invalid_request: qualification helper SHA-256 must be 64 lowercase hex characters"
+            );
+        }
+        let channel = channel.into_string().map_err(|_| {
+            anyhow::anyhow!("invalid_request: qualification helper channel must be valid UTF-8")
+        })?;
+        if channel != selected_channel.wire_name() {
+            bail!(
+                "invalid_request: qualification helper channel does not match the selected commercial channel"
+            );
+        }
+        let path = path
+            .canonicalize()
+            .context("invalid_request: resolve qualification helper path")?;
+        let bundle = Self { path, sha256 };
+        bundle.verify()?;
+        Ok(Some(bundle))
+    }
+
+    pub(crate) fn verified_path(&self) -> Result<&Path> {
+        self.verify()?;
+        Ok(&self.path)
+    }
+
+    fn verify(&self) -> Result<()> {
+        let metadata = fs::symlink_metadata(&self.path)
+            .context("invalid_request: inspect qualification helper")?;
+        if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+            bail!("invalid_request: qualification helper must be a regular non-symlink file");
+        }
+        verify_private_executable(&self.path, &metadata)?;
+        if metadata.len() == 0 || metadata.len() > MAX_ARTIFACT_BYTES {
+            bail!("invalid_request: qualification helper size is outside allowed bounds");
+        }
+        let file = open_without_following_symlinks(&self.path)
+            .context("invalid_request: open qualification helper")?;
+        let opened = file
+            .metadata()
+            .context("invalid_request: inspect opened qualification helper")?;
+        if !same_file_identity(&metadata, &opened) {
+            bail!("invalid_request: qualification helper changed during validation");
+        }
+        let mut bytes = Vec::with_capacity(usize::try_from(opened.len()).unwrap_or(0));
+        file.take(MAX_ARTIFACT_BYTES.saturating_add(1))
+            .read_to_end(&mut bytes)
+            .context("invalid_request: hash qualification helper")?;
+        if bytes.len() as u64 != opened.len() || bytes.len() as u64 > MAX_ARTIFACT_BYTES {
+            bail!("invalid_request: qualification helper changed during validation");
+        }
+        if format!("{:x}", Sha256::digest(&bytes)) != self.sha256 {
+            bail!("invalid_request: qualification helper SHA-256 does not match");
+        }
+        Ok(())
+    }
+}
+
+fn open_without_following_symlinks(path: &Path) -> std::io::Result<File> {
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    }
+    options.open(path)
+}
+
+#[cfg(unix)]
+fn verify_private_executable(_path: &Path, metadata: &fs::Metadata) -> Result<()> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let mode = metadata.permissions().mode();
+    if metadata.uid() != unsafe { libc::geteuid() } || mode & 0o077 != 0 || mode & 0o100 == 0 {
+        bail!("invalid_request: qualification helper must be an owner-only executable");
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn verify_private_executable(path: &Path, metadata: &fs::Metadata) -> Result<()> {
+    let _ = metadata;
+    ctx_history_core::platform_security::verify_private_executable(path)
+        .context("invalid_request: qualification helper ACL is unsafe")
+}
+
+#[cfg(not(any(unix, windows)))]
+fn verify_private_executable(_path: &Path, metadata: &fs::Metadata) -> Result<()> {
+    let _ = metadata;
+    bail!("invalid_request: qualification helpers are unsupported on this platform")
+}
+
+#[cfg(unix)]
+fn same_file_identity(left: &fs::Metadata, right: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt as _;
+
+    left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+#[cfg(windows)]
+fn same_file_identity(left: &fs::Metadata, right: &fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt as _;
+
+    left.volume_serial_number() == right.volume_serial_number()
+        && left.file_index() == right.file_index()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn same_file_identity(_left: &fs::Metadata, _right: &fs::Metadata) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+
+    fn value(value: &str) -> Option<OsString> {
+        Some(OsString::from(value))
+    }
+
+    #[cfg(unix)]
+    fn helper() -> (tempfile::TempDir, PathBuf, String) {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("ctx-pro");
+        fs::write(&path, b"qualification helper").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+        let digest = format!("{:x}", Sha256::digest(fs::read(&path).unwrap()));
+        (root, path, digest)
+    }
+
+    #[test]
+    fn absent_configuration_preserves_normal_delivery() {
+        assert!(
+            QualificationHelperBundle::from_values(None, None, None, ReleaseChannel::Stable)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn partial_configuration_fails_closed() {
+        let error = QualificationHelperBundle::from_values(
+            value("/tmp/ctx-pro"),
+            None,
+            value("stable"),
+            ReleaseChannel::Stable,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("configured together"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exact_private_helper_is_accepted_but_tampering_is_rejected() {
+        let (_root, path, digest) = helper();
+        let bundle = QualificationHelperBundle::from_values(
+            Some(path.into_os_string()),
+            value(&digest),
+            value("stable"),
+            ReleaseChannel::Stable,
+        )
+        .unwrap()
+        .unwrap();
+        bundle.verified_path().unwrap();
+        fs::write(bundle.verified_path().unwrap(), b"tampered helper").unwrap();
+        assert!(bundle
+            .verified_path()
+            .unwrap_err()
+            .to_string()
+            .contains("SHA-256 does not match"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn selected_channel_mismatch_is_rejected() {
+        let (_root, path, digest) = helper();
+        let error = QualificationHelperBundle::from_values(
+            Some(path.into_os_string()),
+            value(&digest),
+            value("staging"),
+            ReleaseChannel::Stable,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("does not match"));
+    }
+}

--- a/crates/ctx-cli/src/pro/qualification_helper.rs
+++ b/crates/ctx-cli/src/pro/qualification_helper.rs
@@ -117,6 +117,22 @@ impl QualificationHelperBundle {
         Ok(&self.path)
     }
 
+    #[cfg(unix)]
+    pub(crate) fn prepare_descriptor_execution(&self) -> Result<QualificationDescriptorExecution> {
+        self.verify()?;
+        let retained = self.stage.helper_handle.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("invalid_request: qualification stage is unavailable")
+        })?;
+        let descriptor = retained
+            .try_clone()
+            .context("invalid_request: duplicate qualification helper descriptor")?;
+        let program = descriptor_execution_path(&descriptor)?;
+        Ok(QualificationDescriptorExecution {
+            program,
+            descriptor,
+        })
+    }
+
     #[cfg(ctx_pro_qualification)]
     pub(crate) fn source_path(&self) -> &Path {
         &self.source_path
@@ -146,6 +162,51 @@ impl QualificationHelperBundle {
         verify_reader_digest(&mut named, opened.len(), &self.sha256)?;
         Ok(())
     }
+}
+
+#[cfg(unix)]
+pub(crate) struct QualificationDescriptorExecution {
+    program: PathBuf,
+    descriptor: File,
+}
+
+#[cfg(unix)]
+impl QualificationDescriptorExecution {
+    pub(crate) fn program(&self) -> &Path {
+        &self.program
+    }
+
+    pub(crate) fn configure_command(&self, command: &mut std::process::Command) {
+        use std::{os::fd::AsRawFd as _, os::unix::process::CommandExt as _};
+
+        let descriptor = self.descriptor.as_raw_fd();
+        unsafe {
+            command.pre_exec(move || {
+                let flags = libc::fcntl(descriptor, libc::F_GETFD);
+                if flags == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::fcntl(descriptor, libc::F_SETFD, flags & !libc::FD_CLOEXEC) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+}
+
+#[cfg(unix)]
+fn descriptor_execution_path(file: &File) -> Result<PathBuf> {
+    use std::os::fd::AsRawFd as _;
+
+    #[cfg(target_os = "linux")]
+    let root = Path::new("/proc/self/fd");
+    #[cfg(not(target_os = "linux"))]
+    let root = Path::new("/dev/fd");
+    if !root.is_dir() {
+        bail!("invalid_request: descriptor-bound qualification execution is unavailable");
+    }
+    Ok(root.join(file.as_raw_fd().to_string()))
 }
 
 struct VerifiedSource {
@@ -537,6 +598,37 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("changed during validation"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn descriptor_execution_survives_post_verification_pre_spawn_replacement() {
+        let (root, path, digest) = helper();
+        let bundle = QualificationHelperBundle::from_values(
+            Some(path.into_os_string()),
+            value(&digest),
+            value("stable"),
+            ReleaseChannel::Stable,
+        )
+        .unwrap()
+        .unwrap();
+        let staged = bundle.verified_path().unwrap().to_path_buf();
+        let execution = bundle.prepare_descriptor_execution().unwrap();
+
+        let displaced = root.path().join("verified-staged-helper");
+        fs::rename(&staged, &displaced).unwrap();
+        fs::write(&staged, b"#!/bin/sh\nprintf 'attacker replacement\\n'\n").unwrap();
+        fs::set_permissions(&staged, fs::Permissions::from_mode(0o500)).unwrap();
+
+        let mut command = std::process::Command::new(execution.program());
+        execution.configure_command(&mut command);
+        let output = command.output().unwrap();
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"verified helper\n");
+        assert_eq!(
+            fs::read_to_string(&staged).unwrap(),
+            "#!/bin/sh\nprintf 'attacker replacement\\n'\n"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/ctx-cli/src/pro/referral.rs
+++ b/crates/ctx-cli/src/pro/referral.rs
@@ -12,8 +12,9 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use super::{
     commercial_api::{ReferralCreateResult, ReferralPayoutResult, ReferralStatusResult},
-    commercial_config::CommercialConfig,
+    commercial_config::selected_channel,
     commercial_lifecycle::{open_browser, CommercialLifecycleService},
+    lifecycle::lifecycle_manifest::ReleaseChannel,
 };
 use crate::output::JsonOutputFormat;
 
@@ -21,7 +22,7 @@ const REFERRAL_TAGLINE: &str = "Refer a developer. Earn $10/month toward your ag
 const REFERRAL_SECONDARY: &str = "Up to $120 per friend.";
 const REFERRAL_CODENAME_MIN_BYTES: usize = 3;
 const REFERRAL_CODENAME_MAX_BYTES: usize = 32;
-const REFERRAL_CTA_MARKER: &str = ".referral-cta-v1.shown";
+const REFERRAL_CTA_MARKER_PREFIX: &str = ".referral-cta-v1";
 pub(crate) const REFERRAL_CTA: &str = "Refer a developer. Earn $10/month toward your agent bill.\n\
 Up to $120 per friend.\n\
 ctx referral create <codename>";
@@ -245,50 +246,66 @@ impl ReferralService for CommercialLifecycleService {
 
 pub(crate) fn run(args: ReferralArgs, data_root: PathBuf) -> Result<()> {
     args.validate_invocation()?;
-    CommercialConfig::ensure_referrals_available()?;
     let json_output = args.json_output();
     prepare_referral_identity(&data_root, json_output)?;
+    let _lifecycle_lock =
+        super::lifecycle::acquire_commercial_lifecycle_lock(&data_root, !json_output)?.ok_or_else(
+            || {
+                anyhow::anyhow!(
+                    "authentication_required: rerun the referral command without --json to sign in"
+                )
+            },
+        )?;
     let mut service = CommercialLifecycleService::production(&data_root)?;
     run_with_service(args, &mut service, &mut io::stdout().lock(), &open_browser)
 }
 
 pub(crate) fn show_cta_once(data_root: &Path, eligible: bool, output: &mut impl io::Write) -> bool {
-    show_cta_once_when_available(
-        data_root,
-        eligible,
-        CommercialConfig::referrals_available(),
-        output,
-    )
+    let Ok(channel) = selected_channel() else {
+        return false;
+    };
+    show_cta_once_for_channel(data_root, eligible, channel, output)
 }
 
-fn show_cta_once_when_available(
+fn show_cta_once_for_channel(
     data_root: &Path,
     eligible: bool,
-    available: bool,
+    channel: ReleaseChannel,
     output: &mut impl io::Write,
 ) -> bool {
-    if !available || !eligible || !claim_cta_marker(data_root) {
+    if !eligible || !claim_cta_marker(data_root, channel) {
         return false;
     }
     let rendered = format!("\n{REFERRAL_CTA}\n");
     if output.write_all(rendered.as_bytes()).is_ok() {
         true
     } else {
-        rollback_cta_marker(data_root);
+        rollback_cta_marker(data_root, channel);
         false
     }
 }
 
-fn claim_cta_marker(data_root: &Path) -> bool {
+fn cta_marker(data_root: &Path, channel: ReleaseChannel) -> PathBuf {
+    data_root.join(format!(
+        "{REFERRAL_CTA_MARKER_PREFIX}.{}.shown",
+        channel.wire_name()
+    ))
+}
+
+fn claim_cta_marker(data_root: &Path, channel: ReleaseChannel) -> bool {
     use ctx_history_core::platform_security::{
         restrict_private_file, verify_private_directory, verify_private_file,
     };
 
-    let marker = data_root.join(REFERRAL_CTA_MARKER);
+    let marker = cta_marker(data_root, channel);
     if verify_private_directory(data_root).is_err() {
         return false;
     }
-    let temporary = data_root.join(format!(".referral-cta-v1.{}.tmp", Uuid::new_v4().simple()));
+    let temporary = data_root.join(format!(
+        "{REFERRAL_CTA_MARKER_PREFIX}.{}.{}.tmp",
+        channel.wire_name(),
+        Uuid::new_v4().simple()
+    ));
     let result = (|| -> std::io::Result<bool> {
         crate::identity::create_private_file(&temporary, b"shown\n")?;
         restrict_private_file(&temporary).map_err(std::io::Error::other)?;
@@ -308,8 +325,8 @@ fn claim_cta_marker(data_root: &Path) -> bool {
     result.unwrap_or(false)
 }
 
-fn rollback_cta_marker(data_root: &Path) {
-    let marker = data_root.join(REFERRAL_CTA_MARKER);
+fn rollback_cta_marker(data_root: &Path, channel: ReleaseChannel) {
+    let marker = cta_marker(data_root, channel);
     if fs::remove_file(marker).is_ok() {
         #[cfg(unix)]
         let _ = fs::File::open(data_root).and_then(|directory| directory.sync_all());
@@ -872,5 +889,20 @@ mod tests {
         let debug = format!("{value:?}");
         assert!(debug.contains("[REDACTED]"));
         assert!(!debug.contains("secret-agent"));
+    }
+
+    #[test]
+    fn interactive_referral_prepares_the_private_pro_lifecycle_root() {
+        let root = tempfile::tempdir().unwrap();
+        prepare_referral_identity(root.path(), false).unwrap();
+
+        let _lock = super::super::lifecycle::acquire_commercial_lifecycle_lock(root.path(), true)
+            .unwrap()
+            .expect("interactive referrals create the Pro lifecycle root");
+
+        ctx_history_core::platform_security::verify_private_directory(
+            &ctx_pro_host_protocol::ProFilesystemLayout::new(root.path()).pro_root(),
+        )
+        .unwrap();
     }
 }

--- a/crates/ctx-cli/src/pro/referral.rs
+++ b/crates/ctx-cli/src/pro/referral.rs
@@ -252,7 +252,7 @@ pub(crate) fn run(args: ReferralArgs, data_root: PathBuf) -> Result<()> {
         super::lifecycle::acquire_commercial_lifecycle_lock(&data_root, !json_output)?.ok_or_else(
             || {
                 anyhow::anyhow!(
-                    "authentication_required: rerun the referral command without --json to sign in"
+                    "authentication_required: rerun the referral command without --format=json to sign in"
                 )
             },
         )?;

--- a/crates/ctx-cli/src/pro/referral/cta_tests.rs
+++ b/crates/ctx-cli/src/pro/referral/cta_tests.rs
@@ -3,7 +3,8 @@ use std::{
     sync::{Arc, Barrier},
 };
 
-use super::{show_cta_once, show_cta_once_when_available, REFERRAL_CTA, REFERRAL_CTA_MARKER};
+use super::{cta_marker, show_cta_once_for_channel, REFERRAL_CTA};
+use crate::pro::lifecycle::lifecycle_manifest::ReleaseChannel;
 
 #[test]
 fn cta_marker_is_private_atomic_and_shown_once() {
@@ -11,16 +12,16 @@ fn cta_marker_is_private_atomic_and_shown_once() {
     ctx_history_core::platform_security::restrict_private_directory(root.path()).unwrap();
     let mut first = Vec::new();
     let mut second = Vec::new();
-    assert!(show_cta_once_when_available(
+    assert!(show_cta_once_for_channel(
         root.path(),
         true,
-        true,
+        ReleaseChannel::Stable,
         &mut first
     ));
-    assert!(!show_cta_once_when_available(
+    assert!(!show_cta_once_for_channel(
         root.path(),
         true,
-        true,
+        ReleaseChannel::Stable,
         &mut second
     ));
     assert_eq!(
@@ -28,7 +29,7 @@ fn cta_marker_is_private_atomic_and_shown_once() {
         format!("\n{REFERRAL_CTA}\n")
     );
     assert!(second.is_empty());
-    let marker = root.path().join(REFERRAL_CTA_MARKER);
+    let marker = cta_marker(root.path(), ReleaseChannel::Stable);
     assert_eq!(fs::read(&marker).unwrap(), b"shown\n");
     ctx_history_core::platform_security::verify_private_file(&marker).unwrap();
     assert!(fs::read_dir(root.path()).unwrap().all(|entry| !entry
@@ -58,19 +59,19 @@ fn cta_output_failure_rolls_back_the_marker_for_a_later_retry() {
     let root = tempfile::tempdir().unwrap();
     ctx_history_core::platform_security::restrict_private_directory(root.path()).unwrap();
 
-    assert!(!show_cta_once_when_available(
+    assert!(!show_cta_once_for_channel(
         root.path(),
         true,
-        true,
+        ReleaseChannel::Stable,
         &mut FailingWriter
     ));
-    assert!(!root.path().join(REFERRAL_CTA_MARKER).exists());
+    assert!(!cta_marker(root.path(), ReleaseChannel::Stable).exists());
 
     let mut retry = Vec::new();
-    assert!(show_cta_once_when_available(
+    assert!(show_cta_once_for_channel(
         root.path(),
         true,
-        true,
+        ReleaseChannel::Stable,
         &mut retry
     ));
     assert_eq!(
@@ -93,7 +94,8 @@ fn concurrent_cta_attempts_publish_exactly_once() {
         workers.push(std::thread::spawn(move || {
             let mut output = Vec::new();
             barrier.wait();
-            let shown = show_cta_once_when_available(root.path(), true, true, &mut output);
+            let shown =
+                show_cta_once_for_channel(root.path(), true, ReleaseChannel::Stable, &mut output);
             (shown, output)
         }));
     }
@@ -120,22 +122,39 @@ fn ineligible_cta_does_not_write_or_create_state() {
     let root = tempfile::tempdir().unwrap();
     ctx_history_core::platform_security::restrict_private_directory(root.path()).unwrap();
     let mut output = Vec::new();
-    assert!(!show_cta_once_when_available(
+    assert!(!show_cta_once_for_channel(
         root.path(),
         false,
-        true,
+        ReleaseChannel::Stable,
         &mut output
     ));
     assert!(output.is_empty());
-    assert!(!root.path().join(REFERRAL_CTA_MARKER).exists());
+    assert!(!cta_marker(root.path(), ReleaseChannel::Stable).exists());
 }
 
 #[test]
-fn disabled_cta_does_not_write_or_consume_the_marker() {
+fn cta_marker_is_namespaced_by_commercial_channel() {
     let root = tempfile::tempdir().unwrap();
     ctx_history_core::platform_security::restrict_private_directory(root.path()).unwrap();
-    let mut output = Vec::new();
-    assert!(!show_cta_once(root.path(), true, &mut output));
-    assert!(output.is_empty());
-    assert!(!root.path().join(REFERRAL_CTA_MARKER).exists());
+    let mut stable = Vec::new();
+    let mut staging = Vec::new();
+    assert!(show_cta_once_for_channel(
+        root.path(),
+        true,
+        ReleaseChannel::Stable,
+        &mut stable
+    ));
+    assert!(show_cta_once_for_channel(
+        root.path(),
+        true,
+        ReleaseChannel::Staging,
+        &mut staging
+    ));
+    assert_eq!(stable, staging);
+    assert!(cta_marker(root.path(), ReleaseChannel::Stable).is_file());
+    assert!(cta_marker(root.path(), ReleaseChannel::Staging).is_file());
+    assert_ne!(
+        cta_marker(root.path(), ReleaseChannel::Stable),
+        cta_marker(root.path(), ReleaseChannel::Staging)
+    );
 }

--- a/crates/ctx-cli/src/pro/setup_validation.rs
+++ b/crates/ctx-cli/src/pro/setup_validation.rs
@@ -2,13 +2,13 @@ use anyhow::{bail, Result};
 use ctx_pro_host_protocol::{Capability, PROTOCOL_FINGERPRINT, PROTOCOL_VERSION};
 
 use super::{
-    artifact_delivery::VerifiedArtifactBundle, client::HelperSmoke, lifecycle::SetupInstallation,
+    artifact_delivery::SetupArtifactBundle, client::HelperSmoke, lifecycle::SetupInstallation,
 };
 
 pub(super) fn setup_artifact(
     installation: &SetupInstallation,
-    artifact: Option<VerifiedArtifactBundle>,
-) -> Result<Option<VerifiedArtifactBundle>> {
+    artifact: Option<SetupArtifactBundle>,
+) -> Result<Option<SetupArtifactBundle>> {
     if artifact.is_none() && !matches!(installation, SetupInstallation::Current(_)) {
         bail!("invalid_response: Pro setup returned no helper artifact for an install or repair");
     }

--- a/crates/ctx-cli/src/pro/verified_executable.rs
+++ b/crates/ctx-cli/src/pro/verified_executable.rs
@@ -17,6 +17,28 @@ use ctx_history_core::platform_security::{
 };
 use ctx_pro_host_protocol::ProFilesystemLayout;
 
+pub(super) struct PreparedHelperExecution {
+    program: PathBuf,
+    #[cfg(all(unix, ctx_pro_qualification))]
+    _qualification_descriptor:
+        Option<crate::pro::qualification_helper::QualificationDescriptorExecution>,
+}
+
+impl PreparedHelperExecution {
+    pub(super) fn program(&self) -> &Path {
+        &self.program
+    }
+
+    pub(super) fn configure_command(&self, command: &mut std::process::Command) {
+        #[cfg(all(unix, ctx_pro_qualification))]
+        if let Some(descriptor) = &self._qualification_descriptor {
+            descriptor.configure_command(command);
+        }
+        #[cfg(not(all(unix, ctx_pro_qualification)))]
+        let _ = command;
+    }
+}
+
 /// Holds the exact installed helper and its controlled directory chain for the
 /// complete helper process lifetime.
 pub(super) struct VerifiedHelperExecutable {
@@ -151,6 +173,24 @@ impl VerifiedHelperExecutable {
 
     pub(super) fn path(&self) -> &Path {
         &self.path
+    }
+
+    pub(super) fn prepare_execution(&self) -> Result<PreparedHelperExecution> {
+        #[cfg(all(unix, ctx_pro_qualification))]
+        if let Some(bundle) = &self.qualification_bundle {
+            let descriptor = bundle.prepare_descriptor_execution()?;
+            return Ok(PreparedHelperExecution {
+                program: descriptor.program().to_path_buf(),
+                _qualification_descriptor: Some(descriptor),
+            });
+        }
+
+        self.verify_execution_identity()?;
+        Ok(PreparedHelperExecution {
+            program: self.path.clone(),
+            #[cfg(all(unix, ctx_pro_qualification))]
+            _qualification_descriptor: None,
+        })
     }
 
     /// Reopens the execution pathname immediately before spawn and confirms it

--- a/crates/ctx-cli/src/pro/verified_executable.rs
+++ b/crates/ctx-cli/src/pro/verified_executable.rs
@@ -17,8 +17,8 @@ use ctx_history_core::platform_security::{
 };
 use ctx_pro_host_protocol::ProFilesystemLayout;
 
-/// Holds the exact installed helper and its controlled directory chain open
-/// until `CreateProcess` has consumed the executable path.
+/// Holds the exact installed helper and its controlled directory chain for the
+/// complete helper process lifetime.
 pub(super) struct VerifiedHelperExecutable {
     path: PathBuf,
     #[cfg(windows)]
@@ -27,6 +27,10 @@ pub(super) struct VerifiedHelperExecutable {
     helper: fs::File,
     #[cfg(windows)]
     marker: fs::File,
+    // Keep this last so Windows execution handles close before its exact-path
+    // cleanup runs.
+    #[cfg(ctx_pro_qualification)]
+    qualification_bundle: Option<crate::pro::qualification_helper::QualificationHelperBundle>,
 }
 
 impl VerifiedHelperExecutable {
@@ -45,6 +49,8 @@ impl VerifiedHelperExecutable {
                 .context("pro_not_installed: clone developer Pro helper handle")?;
             Ok(Self {
                 path: path.to_path_buf(),
+                #[cfg(ctx_pro_qualification)]
+                qualification_bundle: None,
                 _directories: Vec::new(),
                 helper,
                 marker,
@@ -53,24 +59,30 @@ impl VerifiedHelperExecutable {
         #[cfg(not(windows))]
         Ok(Self {
             path: path.to_path_buf(),
+            #[cfg(ctx_pro_qualification)]
+            qualification_bundle: None,
         })
     }
 
     #[cfg(ctx_pro_qualification)]
-    pub(super) fn open_qualification(path: &Path) -> Result<Self> {
-        let metadata = fs::symlink_metadata(path)
+    pub(super) fn open_qualification(
+        bundle: crate::pro::qualification_helper::QualificationHelperBundle,
+    ) -> Result<Self> {
+        let path = bundle.verified_path()?.to_path_buf();
+        let metadata = fs::symlink_metadata(&path)
             .context("pro_not_installed: inspect qualification Pro helper")?;
         if !metadata.is_file() || metadata.file_type().is_symlink() {
             bail!("pro_not_installed: qualification Pro helper is not a regular file");
         }
         #[cfg(windows)]
         {
-            let helper = open_locked_file(path)?;
+            let helper = open_locked_file(&path)?;
             let marker = helper
                 .try_clone()
                 .context("pro_not_installed: clone qualification Pro helper handle")?;
             Ok(Self {
-                path: path.to_path_buf(),
+                path,
+                qualification_bundle: Some(bundle),
                 _directories: Vec::new(),
                 helper,
                 marker,
@@ -78,7 +90,8 @@ impl VerifiedHelperExecutable {
         }
         #[cfg(not(windows))]
         Ok(Self {
-            path: path.to_path_buf(),
+            path,
+            qualification_bundle: Some(bundle),
         })
     }
 
@@ -109,6 +122,8 @@ impl VerifiedHelperExecutable {
                 .context("invalid_response: installed Pro marker ACL is unsafe")?;
             Ok(Self {
                 path: path.to_path_buf(),
+                #[cfg(ctx_pro_qualification)]
+                qualification_bundle: None,
                 _directories: locked,
                 helper,
                 marker: marker_file,
@@ -128,6 +143,8 @@ impl VerifiedHelperExecutable {
                 .context("invalid_response: installed Pro marker permissions are unsafe")?;
             Ok(Self {
                 path: path.to_path_buf(),
+                #[cfg(ctx_pro_qualification)]
+                qualification_bundle: None,
             })
         }
     }
@@ -136,12 +153,19 @@ impl VerifiedHelperExecutable {
         &self.path
     }
 
-    /// Reopens the execution pathname and confirms it still resolves to the
-    /// exact helper handle retained since signature and ACL validation.
-    #[cfg(windows)]
+    /// Reopens the execution pathname immediately before spawn and confirms it
+    /// still resolves to the exact retained qualification or installed handle.
     pub(super) fn verify_execution_identity(&self) -> Result<()> {
-        let named = open_file_handle(&self.path)?;
-        verify_open_identity(&self.helper, &named, false)
+        #[cfg(ctx_pro_qualification)]
+        if let Some(bundle) = &self.qualification_bundle {
+            bundle.verified_path()?;
+        }
+        #[cfg(windows)]
+        {
+            let named = open_file_handle(&self.path)?;
+            verify_open_identity(&self.helper, &named, false)?;
+        }
+        Ok(())
     }
 
     pub(super) fn read_helper(&self, maximum: u64) -> Result<Vec<u8>> {

--- a/crates/ctx-cli/src/pro/verified_executable.rs
+++ b/crates/ctx-cli/src/pro/verified_executable.rs
@@ -30,7 +30,7 @@ pub(super) struct VerifiedHelperExecutable {
 }
 
 impl VerifiedHelperExecutable {
-    #[cfg(any(debug_assertions, test))]
+    #[cfg(any(test, ctx_pro_test_helper))]
     pub(super) fn open_developer(path: &Path) -> Result<Self> {
         let metadata = fs::symlink_metadata(path)
             .context("pro_not_installed: inspect developer Pro helper")?;
@@ -43,6 +43,32 @@ impl VerifiedHelperExecutable {
             let marker = helper
                 .try_clone()
                 .context("pro_not_installed: clone developer Pro helper handle")?;
+            Ok(Self {
+                path: path.to_path_buf(),
+                _directories: Vec::new(),
+                helper,
+                marker,
+            })
+        }
+        #[cfg(not(windows))]
+        Ok(Self {
+            path: path.to_path_buf(),
+        })
+    }
+
+    #[cfg(ctx_pro_qualification)]
+    pub(super) fn open_qualification(path: &Path) -> Result<Self> {
+        let metadata = fs::symlink_metadata(path)
+            .context("pro_not_installed: inspect qualification Pro helper")?;
+        if !metadata.is_file() || metadata.file_type().is_symlink() {
+            bail!("pro_not_installed: qualification Pro helper is not a regular file");
+        }
+        #[cfg(windows)]
+        {
+            let helper = open_locked_file(path)?;
+            let marker = helper
+                .try_clone()
+                .context("pro_not_installed: clone qualification Pro helper handle")?;
             Ok(Self {
                 path: path.to_path_buf(),
                 _directories: Vec::new(),

--- a/crates/ctx-cli/src/pro/workos_device.rs
+++ b/crates/ctx-cli/src/pro/workos_device.rs
@@ -470,7 +470,7 @@ fn validate_claim_time_and_audience(claims: &AccessClaims, client_id: &str) -> R
         || claims
         .aud
         .as_ref()
-        .is_some_and(|aud| !audience_contains(aud, client_id))
+        .is_some_and(|aud| !audience_matches(aud, client_id))
     {
         bail!("authentication_invalid: WorkOS access token audience does not match ctx");
     }
@@ -514,13 +514,8 @@ fn valid_scope(value: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || b"._:-/".contains(&byte))
 }
 
-fn audience_contains(value: &Value, expected: &str) -> bool {
+fn audience_matches(value: &Value, expected: &str) -> bool {
     value.as_str() == Some(expected)
-        || value.as_array().is_some_and(|items| {
-            items.len() <= 16
-                && items.iter().all(Value::is_string)
-                && items.iter().any(|item| item.as_str() == Some(expected))
-        })
 }
 
 fn deserialize_optional_present_string<'de, D>(
@@ -879,6 +874,7 @@ mod tests {
         for claims in [
             serde_json::json!({"sub":"user_123","sid":"session_123","org_id":"org_123","client_id":"other_123","iat":now,"exp":now+300,"permissions":[REQUIRED_PERMISSION]}),
             serde_json::json!({"sub":"user_123","sid":"session_123","org_id":"org_123","client_id":"client_123456","iat":now,"exp":now+300,"aud":"other_123","permissions":[REQUIRED_PERMISSION]}),
+            serde_json::json!({"sub":"user_123","sid":"session_123","org_id":"org_123","client_id":"client_123456","iat":now,"exp":now+300,"aud":["client_123456","other_123"],"permissions":[REQUIRED_PERMISSION]}),
             serde_json::json!({"sub":"user_123","sid":"session_123","org_id":"org_123","client_id":"client_123456","iat":now,"exp":now+300,"aud":"client_123456","scope":{"bad":true},"permissions":[REQUIRED_PERMISSION]}),
         ] {
             assert!(client.validate_access_token(&jwt(claims)).is_err());

--- a/crates/ctx-cli/src/pro/workos_device.rs
+++ b/crates/ctx-cli/src/pro/workos_device.rs
@@ -99,6 +99,7 @@ struct OAuthError {
 struct AccessClaims {
     sub: String,
     sid: String,
+    client_id: String,
     #[serde(default, deserialize_with = "deserialize_optional_present_string")]
     org_id: Option<String>,
     exp: i64,
@@ -462,11 +463,11 @@ fn validate_claim_time_and_audience(claims: &AccessClaims, client_id: &str) -> R
     {
         bail!("authentication_expired: WorkOS access token is expired or not active");
     }
-    // WorkOS does not currently guarantee an `aud` claim for AuthKit access
-    // tokens. The token comes directly from the selected client flow and the
-    // commercial Worker verifies the client-specific issuer and JWKS. When
-    // WorkOS emits `aud`, still require it to bind to that selected client.
-    if claims
+    // AuthKit access tokens bind the application with `client_id`; `aud` is
+    // optional. Require the documented client binding and, when present, a
+    // matching audience as defense in depth.
+    if claims.client_id != client_id
+        || claims
         .aud
         .as_ref()
         .is_some_and(|aud| !audience_contains(aud, client_id))
@@ -740,6 +741,7 @@ mod tests {
         let now = unix_time().unwrap();
         let token = jwt(serde_json::json!({
             "sub":"user_123", "sid":"session_123", "org_id":"org_123",
+            "client_id":"client_123456",
             "iat":now, "exp":now+300, "aud":"client_123456", "scope":"openid profile",
             "permissions":[REQUIRED_PERMISSION]
         }));
@@ -761,6 +763,7 @@ mod tests {
             .remove("organization_id");
         pending_response["access_token"] = Value::String(jwt(serde_json::json!({
             "sub":"user_123", "sid":"session_123",
+            "client_id":"client_123456",
             "iat":now, "exp":now+300, "aud":"client_123456"
         })));
         let pending: WorkOsTokens = serde_json::from_value(pending_response).unwrap();
@@ -769,6 +772,7 @@ mod tests {
         let mut bound_response = token_response();
         bound_response["access_token"] = Value::String(jwt(serde_json::json!({
             "sub":"user_123", "sid":"session_123", "org_id":"org_123",
+            "client_id":"client_123456",
             "iat":now, "exp":now+300, "aud":"client_123456",
             "permissions":[REQUIRED_PERMISSION]
         })));
@@ -792,6 +796,7 @@ mod tests {
             response.as_object_mut().unwrap().remove("organization_id");
             response["access_token"] = Value::String(jwt(serde_json::json!({
                 "sub":"user_123", "sid":"session_123",
+                "client_id":"client_123456",
                 "iat":now, "exp":now+300, "aud":"client_123456",
                 "permissions":permissions
             })));
@@ -802,6 +807,7 @@ mod tests {
         let mut response = token_response();
         response["access_token"] = Value::String(jwt(serde_json::json!({
             "sub":"user_123", "sid":"session_123", "org_id":"org_123",
+            "client_id":"client_123456",
             "iat":now, "exp":now+300, "aud":"client_123456",
             "permissions":[]
         })));
@@ -842,6 +848,7 @@ mod tests {
         let mut response = token_response();
         response["access_token"] = Value::String(jwt(serde_json::json!({
             "sub":"user_123", "sid":"session_123", "org_id":"org_123",
+            "client_id":"client_123456",
             "iat":now, "exp":now+300, "aud":"client_123456",
             "permissions":[REQUIRED_PERMISSION]
         })));
@@ -865,12 +872,14 @@ mod tests {
         client
             .validate_access_token(&jwt(serde_json::json!({
                 "sub":"user_123","sid":"session_123","org_id":"org_123",
+                "client_id":"client_123456",
                 "iat":now,"exp":now+300,"permissions":[REQUIRED_PERMISSION]
             })))
             .unwrap();
         for claims in [
-            serde_json::json!({"sub":"user_123","sid":"session_123","org_id":"org_123","iat":now,"exp":now+300,"aud":"other_123","permissions":[REQUIRED_PERMISSION]}),
-            serde_json::json!({"sub":"user_123","sid":"session_123","org_id":"org_123","iat":now,"exp":now+300,"aud":"client_123456","scope":{"bad":true},"permissions":[REQUIRED_PERMISSION]}),
+            serde_json::json!({"sub":"user_123","sid":"session_123","org_id":"org_123","client_id":"other_123","iat":now,"exp":now+300,"permissions":[REQUIRED_PERMISSION]}),
+            serde_json::json!({"sub":"user_123","sid":"session_123","org_id":"org_123","client_id":"client_123456","iat":now,"exp":now+300,"aud":"other_123","permissions":[REQUIRED_PERMISSION]}),
+            serde_json::json!({"sub":"user_123","sid":"session_123","org_id":"org_123","client_id":"client_123456","iat":now,"exp":now+300,"aud":"client_123456","scope":{"bad":true},"permissions":[REQUIRED_PERMISSION]}),
         ] {
             assert!(client.validate_access_token(&jwt(claims)).is_err());
         }

--- a/crates/ctx-cli/src/pro/workos_device.rs
+++ b/crates/ctx-cli/src/pro/workos_device.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-use serde::Deserialize;
+use serde::{de::Deserializer, Deserialize};
 use serde_json::Value;
 use url::Url;
 use zeroize::Zeroize as _;
@@ -23,6 +23,7 @@ const MAX_USER_PROFILE_DEPTH: usize = 8;
 const MAX_USER_PROFILE_NODES: usize = 256;
 const MAX_USER_PROFILE_STRING_BYTES: usize = 16 * 1024;
 const MAX_USER_PROFILE_KEY_BYTES: usize = 256;
+const REQUIRED_PERMISSION: &str = "ctx-pro:access";
 
 #[derive(Debug, Clone)]
 pub(super) struct WorkOsConfig {
@@ -46,7 +47,8 @@ pub(super) struct DeviceAuthorization {
 pub(super) struct WorkOsTokens {
     pub(super) access_token: String,
     pub(super) refresh_token: String,
-    pub(super) organization_id: String,
+    #[serde(default, deserialize_with = "deserialize_optional_present_string")]
+    pub(super) organization_id: Option<String>,
     #[serde(default)]
     authentication_method: Option<String>,
     user: WorkOsUser,
@@ -58,7 +60,7 @@ impl std::fmt::Debug for WorkOsTokens {
             .debug_struct("WorkOsTokens")
             .field("access_token", &"[REDACTED]")
             .field("refresh_token", &"[REDACTED]")
-            .field("organization_id", &self.organization_id)
+            .field("organization_id", &self.organization_id.as_deref())
             .finish_non_exhaustive()
     }
 }
@@ -97,7 +99,8 @@ struct OAuthError {
 struct AccessClaims {
     sub: String,
     sid: String,
-    org_id: String,
+    #[serde(default, deserialize_with = "deserialize_optional_present_string")]
+    org_id: Option<String>,
     exp: i64,
     iat: i64,
     #[serde(default)]
@@ -106,6 +109,14 @@ struct AccessClaims {
     aud: Option<Value>,
     #[serde(default)]
     scope: Option<Value>,
+    #[serde(default, deserialize_with = "deserialize_optional_permissions")]
+    permissions: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkOsTokenDisposition {
+    BootstrapPending,
+    OrganizationBound,
 }
 
 pub(super) struct WorkOsDeviceClient {
@@ -191,21 +202,57 @@ impl WorkOsDeviceClient {
     }
 
     pub(super) fn refresh(&self, refresh_token: &str) -> Result<WorkOsTokens> {
+        let tokens = self.refresh_inner(refresh_token, None)?;
+        if self.validate_tokens(&tokens)? != WorkOsTokenDisposition::OrganizationBound {
+            bail!("authentication_invalid: WorkOS token refresh has no organization");
+        }
+        Ok(tokens)
+    }
+
+    pub(super) fn refresh_for_organization(
+        &self,
+        refresh_token: &str,
+        organization_id: &str,
+    ) -> Result<WorkOsTokens> {
+        validate_identifier(organization_id, "organization")?;
+        let tokens = self.refresh_inner(refresh_token, Some(organization_id))?;
+        self.validate_refreshed_organization(&tokens, organization_id)?;
+        Ok(tokens)
+    }
+
+    fn validate_refreshed_organization(
+        &self,
+        tokens: &WorkOsTokens,
+        organization_id: &str,
+    ) -> Result<()> {
+        if self.validate_tokens(&tokens)? != WorkOsTokenDisposition::OrganizationBound
+            || tokens.organization_id.as_deref() != Some(organization_id)
+        {
+            bail!("authentication_invalid: WorkOS token refresh selected another organization");
+        }
+        Ok(())
+    }
+
+    fn refresh_inner(
+        &self,
+        refresh_token: &str,
+        organization_id: Option<&str>,
+    ) -> Result<WorkOsTokens> {
         validate_secret(refresh_token, "refresh token")?;
         let url = self.endpoint("/user_management/authenticate")?;
+        let form = refresh_form(
+            refresh_token,
+            self.config.client_id.as_str(),
+            organization_id,
+        );
         let response = self
             .agent
             .post(url.as_str())
             .set("content-type", "application/x-www-form-urlencoded")
-            .send_form(&[
-                ("grant_type", "refresh_token"),
-                ("refresh_token", refresh_token),
-                ("client_id", self.config.client_id.as_str()),
-            ])
+            .send_form(&form)
             .map_err(|error| safe_http_error(error, "WorkOS token refresh"))?;
         require_json(&response, "WorkOS token refresh")?;
         let tokens: WorkOsTokens = read_json(response, "WorkOS token refresh")?;
-        self.validate_tokens(&tokens)?;
         Ok(tokens)
     }
 
@@ -213,22 +260,16 @@ impl WorkOsDeviceClient {
         let claims = claims(access_token)?;
         validate_identifier(&claims.sub, "subject")?;
         validate_identifier(&claims.sid, "session")?;
-        validate_identifier(&claims.org_id, "organization")?;
-        let now = unix_time()?;
-        if claims.exp <= now - 60
-            || claims.iat > now + 60
-            || claims.nbf.is_some_and(|nbf| nbf > now + 60)
-        {
-            bail!("authentication_expired: WorkOS access token is expired or not active");
-        }
-        if claims
-            .aud
-            .as_ref()
-            .is_some_and(|aud| !audience_contains(aud, &self.config.client_id))
-        {
-            bail!("authentication_invalid: WorkOS access token audience does not match ctx");
-        }
-        validate_scope(claims.scope.as_ref())
+        validate_identifier(
+            claims
+                .org_id
+                .as_deref()
+                .ok_or_else(|| anyhow!("authentication_invalid: WorkOS organization is missing"))?,
+            "organization",
+        )?;
+        validate_claim_time_and_audience(&claims, &self.config.client_id)?;
+        validate_scope(claims.scope.as_ref())?;
+        validate_permissions(claims.permissions.as_deref(), true)
     }
 
     pub(super) fn access_token_expiration(&self, access_token: &str) -> Result<i64> {
@@ -236,10 +277,16 @@ impl WorkOsDeviceClient {
         Ok(claims(access_token)?.exp)
     }
 
-    fn validate_tokens(&self, tokens: &WorkOsTokens) -> Result<()> {
+    pub(super) fn bootstrap_pending(&self, tokens: &WorkOsTokens) -> Result<bool> {
+        Ok(self.validate_tokens(tokens)? == WorkOsTokenDisposition::BootstrapPending)
+    }
+
+    fn validate_tokens(&self, tokens: &WorkOsTokens) -> Result<WorkOsTokenDisposition> {
         validate_secret(&tokens.access_token, "access token")?;
         validate_secret(&tokens.refresh_token, "refresh token")?;
-        validate_identifier(&tokens.organization_id, "organization")?;
+        if let Some(organization_id) = tokens.organization_id.as_deref() {
+            validate_identifier(organization_id, "organization")?;
+        }
         validate_identifier(&tokens.user.id, "user")?;
         if !tokens.user_profile_is_bounded() {
             bail!("authentication_invalid: WorkOS user profile is outside allowed bounds");
@@ -252,11 +299,24 @@ impl WorkOsDeviceClient {
             bail!("authentication_invalid: WorkOS authentication method is invalid");
         }
         let claims = claims(&tokens.access_token)?;
-        self.validate_access_token(&tokens.access_token)?;
-        if claims.org_id != tokens.organization_id || claims.sub != tokens.user.id {
+        validate_identifier(&claims.sub, "subject")?;
+        validate_identifier(&claims.sid, "session")?;
+        validate_claim_time_and_audience(&claims, &self.config.client_id)?;
+        validate_scope(claims.scope.as_ref())?;
+        if claims.sub != tokens.user.id || claims.org_id != tokens.organization_id {
             bail!("authentication_invalid: WorkOS token identity is inconsistent");
         }
-        Ok(())
+        match tokens.organization_id.as_deref() {
+            Some(organization_id) => {
+                validate_identifier(organization_id, "organization")?;
+                validate_permissions(claims.permissions.as_deref(), true)?;
+                Ok(WorkOsTokenDisposition::OrganizationBound)
+            }
+            None => {
+                validate_permissions(claims.permissions.as_deref(), false)?;
+                Ok(WorkOsTokenDisposition::BootstrapPending)
+            }
+        }
     }
 
     fn endpoint(&self, path: &str) -> Result<Url> {
@@ -265,6 +325,22 @@ impl WorkOsDeviceClient {
             .join(path)
             .context("invalid_request: invalid WorkOS route")
     }
+}
+
+fn refresh_form<'a>(
+    refresh_token: &'a str,
+    client_id: &'a str,
+    organization_id: Option<&'a str>,
+) -> Vec<(&'a str, &'a str)> {
+    let mut form = vec![
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh_token),
+        ("client_id", client_id),
+    ];
+    if let Some(organization_id) = organization_id {
+        form.push(("organization_id", organization_id));
+    }
+    form
 }
 
 impl WorkOsTokens {
@@ -378,6 +454,57 @@ fn validate_scope(scope: Option<&Value>) -> Result<()> {
     Ok(())
 }
 
+fn validate_claim_time_and_audience(claims: &AccessClaims, client_id: &str) -> Result<()> {
+    let now = unix_time()?;
+    if claims.exp <= now - 60
+        || claims.iat > now + 60
+        || claims.nbf.is_some_and(|nbf| nbf > now + 60)
+    {
+        bail!("authentication_expired: WorkOS access token is expired or not active");
+    }
+    // WorkOS does not currently guarantee an `aud` claim for AuthKit access
+    // tokens. The token comes directly from the selected client flow and the
+    // commercial Worker verifies the client-specific issuer and JWKS. When
+    // WorkOS emits `aud`, still require it to bind to that selected client.
+    if claims
+        .aud
+        .as_ref()
+        .is_some_and(|aud| !audience_contains(aud, client_id))
+    {
+        bail!("authentication_invalid: WorkOS access token audience does not match ctx");
+    }
+    Ok(())
+}
+
+fn validate_permissions(permissions: Option<&[String]>, organization_bound: bool) -> Result<()> {
+    let permissions = permissions.unwrap_or_default();
+    if permissions.len() > 128
+        || permissions.iter().any(|permission| {
+            permission.len() < 3
+                || permission.len() > 128
+                || !permission
+                    .as_bytes()
+                    .first()
+                    .is_some_and(u8::is_ascii_lowercase)
+                || !permission.bytes().all(|byte| {
+                    byte.is_ascii_lowercase()
+                        || byte.is_ascii_digit()
+                        || matches!(byte, b'_' | b'.' | b':' | b'-')
+                })
+        })
+        || permissions
+            .iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len()
+            != permissions.len()
+        || (organization_bound && !permissions.iter().any(|value| value == REQUIRED_PERMISSION))
+        || (!organization_bound && !permissions.is_empty())
+    {
+        bail!("authentication_invalid: WorkOS access token permissions are invalid");
+    }
+    Ok(())
+}
+
 fn valid_scope(value: &str) -> bool {
     !value.is_empty()
         && value.len() <= 128
@@ -393,6 +520,24 @@ fn audience_contains(value: &Value, expected: &str) -> bool {
                 && items.iter().all(Value::is_string)
                 && items.iter().any(|item| item.as_str() == Some(expected))
         })
+}
+
+fn deserialize_optional_present_string<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer).map(Some)
+}
+
+fn deserialize_optional_permissions<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Vec::<String>::deserialize(deserializer).map(Some)
 }
 
 fn validate_identifier(value: &str, label: &str) -> Result<()> {
@@ -499,9 +644,24 @@ mod tests {
     fn parses_documented_token_response() {
         let tokens: WorkOsTokens = serde_json::from_value(token_response()).unwrap();
 
-        assert_eq!(tokens.organization_id, "org_123");
+        assert_eq!(tokens.organization_id.as_deref(), Some("org_123"));
         assert_eq!(tokens.user.id, "user_123");
         assert_eq!(tokens.ignored_fields(), 11);
+    }
+
+    #[test]
+    fn parses_a_bounded_zero_organization_bootstrap_response() {
+        let mut response = token_response();
+        response.as_object_mut().unwrap().remove("organization_id");
+        let tokens: WorkOsTokens = serde_json::from_value(response).unwrap();
+        assert!(tokens.organization_id.is_none());
+    }
+
+    #[test]
+    fn rejects_null_organization_instead_of_treating_it_as_bootstrap_pending() {
+        let mut response = token_response();
+        response["organization_id"] = Value::Null;
+        assert!(serde_json::from_value::<WorkOsTokens>(response).is_err());
     }
 
     #[test]
@@ -580,22 +740,137 @@ mod tests {
         let now = unix_time().unwrap();
         let token = jwt(serde_json::json!({
             "sub":"user_123", "sid":"session_123", "org_id":"org_123",
-            "iat":now, "exp":now+300, "aud":"client_123456", "scope":"openid profile"
+            "iat":now, "exp":now+300, "aud":"client_123456", "scope":"openid profile",
+            "permissions":[REQUIRED_PERMISSION]
         }));
         client.validate_access_token(&token).unwrap();
     }
 
     #[test]
-    fn rejects_wrong_audience_and_malformed_scope() {
+    fn distinguishes_bootstrap_pending_from_organization_bound_tokens() {
         let client = WorkOsDeviceClient::new(WorkOsConfig {
             api_origin: Url::parse("https://api.workos.com/").unwrap(),
             client_id: "client_123456".to_owned(),
         })
         .unwrap();
         let now = unix_time().unwrap();
+        let mut pending_response = token_response();
+        pending_response
+            .as_object_mut()
+            .unwrap()
+            .remove("organization_id");
+        pending_response["access_token"] = Value::String(jwt(serde_json::json!({
+            "sub":"user_123", "sid":"session_123",
+            "iat":now, "exp":now+300, "aud":"client_123456"
+        })));
+        let pending: WorkOsTokens = serde_json::from_value(pending_response).unwrap();
+        assert!(client.bootstrap_pending(&pending).unwrap());
+
+        let mut bound_response = token_response();
+        bound_response["access_token"] = Value::String(jwt(serde_json::json!({
+            "sub":"user_123", "sid":"session_123", "org_id":"org_123",
+            "iat":now, "exp":now+300, "aud":"client_123456",
+            "permissions":[REQUIRED_PERMISSION]
+        })));
+        let bound: WorkOsTokens = serde_json::from_value(bound_response).unwrap();
+        assert!(!client.bootstrap_pending(&bound).unwrap());
+    }
+
+    #[test]
+    fn bootstrap_pending_rejects_org_permissions_and_bound_tokens_require_access() {
+        let client = WorkOsDeviceClient::new(WorkOsConfig {
+            api_origin: Url::parse("https://api.workos.com/").unwrap(),
+            client_id: "client_123456".to_owned(),
+        })
+        .unwrap();
+        let now = unix_time().unwrap();
+        for permissions in [
+            serde_json::json!([REQUIRED_PERMISSION]),
+            serde_json::json!(["ctx-pro:other"]),
+        ] {
+            let mut response = token_response();
+            response.as_object_mut().unwrap().remove("organization_id");
+            response["access_token"] = Value::String(jwt(serde_json::json!({
+                "sub":"user_123", "sid":"session_123",
+                "iat":now, "exp":now+300, "aud":"client_123456",
+                "permissions":permissions
+            })));
+            let tokens: WorkOsTokens = serde_json::from_value(response).unwrap();
+            assert!(client.bootstrap_pending(&tokens).is_err());
+        }
+
+        let mut response = token_response();
+        response["access_token"] = Value::String(jwt(serde_json::json!({
+            "sub":"user_123", "sid":"session_123", "org_id":"org_123",
+            "iat":now, "exp":now+300, "aud":"client_123456",
+            "permissions":[]
+        })));
+        let tokens: WorkOsTokens = serde_json::from_value(response).unwrap();
+        assert!(client.bootstrap_pending(&tokens).is_err());
+    }
+
+    #[test]
+    fn organization_bootstrap_refresh_selects_the_server_returned_organization() {
+        assert_eq!(
+            refresh_form(
+                "refresh-secret",
+                "client_123456",
+                Some("org_server_selected")
+            ),
+            [
+                ("grant_type", "refresh_token"),
+                ("refresh_token", "refresh-secret"),
+                ("client_id", "client_123456"),
+                ("organization_id", "org_server_selected"),
+            ]
+        );
+        assert_eq!(
+            refresh_form("refresh-secret", "client_123456", None),
+            [
+                ("grant_type", "refresh_token"),
+                ("refresh_token", "refresh-secret"),
+                ("client_id", "client_123456"),
+            ]
+        );
+
+        let client = WorkOsDeviceClient::new(WorkOsConfig {
+            api_origin: Url::parse("https://api.workos.com/").unwrap(),
+            client_id: "client_123456".to_owned(),
+        })
+        .unwrap();
+        let now = unix_time().unwrap();
+        let mut response = token_response();
+        response["access_token"] = Value::String(jwt(serde_json::json!({
+            "sub":"user_123", "sid":"session_123", "org_id":"org_123",
+            "iat":now, "exp":now+300, "aud":"client_123456",
+            "permissions":[REQUIRED_PERMISSION]
+        })));
+        let tokens: WorkOsTokens = serde_json::from_value(response).unwrap();
+        client
+            .validate_refreshed_organization(&tokens, "org_123")
+            .unwrap();
+        assert!(client
+            .validate_refreshed_organization(&tokens, "org_other")
+            .is_err());
+    }
+
+    #[test]
+    fn accepts_undocumented_missing_audience_but_rejects_wrong_audience_and_malformed_scope() {
+        let client = WorkOsDeviceClient::new(WorkOsConfig {
+            api_origin: Url::parse("https://api.workos.com/").unwrap(),
+            client_id: "client_123456".to_owned(),
+        })
+        .unwrap();
+        let now = unix_time().unwrap();
+        client
+            .validate_access_token(&jwt(serde_json::json!({
+                "sub":"user_123","sid":"session_123","org_id":"org_123",
+                "iat":now,"exp":now+300,"permissions":[REQUIRED_PERMISSION]
+            })))
+            .unwrap();
         for claims in [
-            serde_json::json!({"sub":"user_123","sid":"session_123","org_id":"org_123","iat":now,"exp":now+300,"aud":"other_123"}),
-            serde_json::json!({"sub":"user_123","sid":"session_123","org_id":"org_123","iat":now,"exp":now+300,"scope":{"bad":true}}),
+            serde_json::json!({"sub":"user_123","sid":"session_123","org_id":"org_123","iat":now,"exp":now+300,"aud":"other_123","permissions":[REQUIRED_PERMISSION]}),
+            serde_json::json!({"sub":"user_123","sid":"session_123","org_id":"org_123","iat":now,"exp":now+300,"aud":"client_123456","scope":{"bad":true},"permissions":[REQUIRED_PERMISSION]}),
         ] {
             assert!(client.validate_access_token(&jwt(claims)).is_err());
         }

--- a/crates/ctx-cli/test_targets.bzl
+++ b/crates/ctx-cli/test_targets.bzl
@@ -4,6 +4,8 @@ load("@crates//:defs.bzl", "aliases", "all_crate_deps", "crate_edition")
 load("//tools/bazel:ctx_rust.bzl", "ctx_rust_test")
 
 CTX_CLI_RUSTC_FLAGS = [
+    "--check-cfg=cfg(ctx_pro_qualification)",
+    "--check-cfg=cfg(ctx_pro_test_helper)",
     "--check-cfg=cfg(ctx_semantic_fastembed)",
     "--check-cfg=cfg(ctx_sqlite_vec)",
     "--check-cfg=cfg(test)",

--- a/crates/ctx-cli/tests/pro_lifecycle.rs
+++ b/crates/ctx-cli/tests/pro_lifecycle.rs
@@ -48,7 +48,7 @@ fn ctx_status_has_one_actionable_pro_machine_contract() {
 }
 
 #[test]
-fn commercial_channel_selection_is_exact_and_stable_fails_closed() {
+fn commercial_channel_selection_rejects_every_non_registry_value() {
     let root = tempdir().unwrap();
     for arguments in [
         vec!["pro", "--format=json"],
@@ -67,23 +67,6 @@ fn commercial_channel_selection_is_exact_and_stable_fails_closed() {
                     "CTX_PRO_CHANNEL must be stable or staging",
                 ));
         }
-    }
-
-    for arguments in [
-        vec!["pro", "--format=json"],
-        vec!["pro", "setup", "--format=json"],
-    ] {
-        Command::cargo_bin("ctx")
-            .unwrap()
-            .env_remove("CTX_PRO_CHANNEL")
-            .arg("--data-root")
-            .arg(root.path())
-            .args(arguments)
-            .assert()
-            .failure()
-            .stderr(predicate::str::contains(
-                "ctx Pro stable channel is not configured",
-            ));
     }
 }
 
@@ -323,35 +306,42 @@ fn obsolete_and_manual_repository_lifecycle_flags_are_rejected() {
 }
 
 #[test]
-fn default_disabled_referrals_fail_before_identity_auth_or_browser_side_effects() {
-    for arguments in [
-        vec!["referral", "create", "agent-smith", "--format=json"],
-        vec!["referral", "status", "--format=json"],
-        vec!["referral", "payout", "--format=json"],
-        vec!["pro", "--referral", "agent-smith", "--format=json"],
-    ] {
-        let parent = tempdir().unwrap();
-        let data_root = parent.path().join("missing-data-root");
-        let output = Command::cargo_bin("ctx")
-            .unwrap()
-            .env("CTX_PRO_CHANNEL", "staging")
-            .arg("--data-root")
-            .arg(&data_root)
-            .args(arguments)
-            .output()
-            .unwrap();
-        assert!(!output.status.success());
-        assert!(output.stdout.is_empty());
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(stderr.contains("referral_unavailable:"));
-        assert!(!stderr.contains("authentication_required:"));
-        assert!(!stderr.contains("Sign in to ctx Pro"));
-        assert!(!stderr.contains("http://"));
-        assert!(!stderr.contains("https://"));
-        assert!(
-            !data_root.join("pro").exists(),
-            "unavailable referrals must not initialize Pro credentials"
-        );
+fn referral_commands_are_available_on_both_channels_before_cached_authentication() {
+    for channel in ["stable", "staging"] {
+        for arguments in [
+            vec!["referral", "create", "agent-smith", "--format=json"],
+            vec!["referral", "status", "--format=json"],
+            vec!["referral", "payout", "--format=json"],
+        ] {
+            let parent = tempdir().unwrap();
+            let data_root = parent.path().join("missing-data-root");
+            let output = Command::cargo_bin("ctx")
+                .unwrap()
+                .env("CTX_PRO_CHANNEL", channel)
+                .arg("--data-root")
+                .arg(&data_root)
+                .args(arguments)
+                .output()
+                .unwrap();
+            assert!(!output.status.success());
+            assert!(output.stdout.is_empty());
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(
+                stderr.contains("authentication_required:"),
+                "{channel}: {stderr}"
+            );
+            assert!(
+                !stderr.contains("referral_unavailable:"),
+                "{channel}: {stderr}"
+            );
+            assert!(!stderr.contains("Sign in to ctx Pro"));
+            assert!(!stderr.contains("http://"));
+            assert!(!stderr.contains("https://"));
+            assert!(
+                !data_root.join("pro").exists(),
+                "noninteractive referrals must not initialize Pro credentials"
+            );
+        }
     }
 }
 

--- a/crates/ctx-cli/tests/pro_qualification.rs
+++ b/crates/ctx-cli/tests/pro_qualification.rs
@@ -1,0 +1,105 @@
+#![cfg(unix)]
+
+use std::fs;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use sha2::{Digest, Sha256};
+use tempfile::tempdir;
+
+mod support;
+use support::{initialize_current_query_store, write_blame_helper};
+
+const PATH_ENV: &str = "CTX_PRO_QUALIFICATION_HELPER_PATH";
+const SHA256_ENV: &str = "CTX_PRO_QUALIFICATION_HELPER_SHA256";
+const CHANNEL_ENV: &str = "CTX_PRO_QUALIFICATION_HELPER_CHANNEL";
+
+fn digest(path: &std::path::Path) -> String {
+    format!("{:x}", Sha256::digest(fs::read(path).unwrap()))
+}
+
+fn qualification_command(
+    root: &std::path::Path,
+    helper: &std::path::Path,
+    helper_digest: &str,
+    helper_channel: &str,
+) -> Command {
+    let mut command = Command::cargo_bin("ctx").unwrap();
+    command
+        .env("CTX_ANALYTICS_ENABLED", "false")
+        .env("CTX_PRO_CHANNEL", "stable")
+        .env(PATH_ENV, helper)
+        .env(SHA256_ENV, helper_digest)
+        .env(CHANNEL_ENV, helper_channel)
+        .args([
+            "--data-root",
+            root.to_str().unwrap(),
+            "blame",
+            "commit",
+            "0123456789abcdef",
+            "--json",
+        ]);
+    command
+}
+
+#[test]
+fn exact_local_helper_is_selected_by_the_qualification_binary() {
+    let root = tempdir().unwrap();
+    initialize_current_query_store(root.path());
+    let helper = root.path().join("ctx-pro-qualification");
+    write_blame_helper(&helper);
+
+    qualification_command(root.path(), &helper, &digest(&helper), "stable")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"kind\": \"commit\""));
+}
+
+#[test]
+fn qualification_configuration_is_atomic_and_channel_bound() {
+    let root = tempdir().unwrap();
+    initialize_current_query_store(root.path());
+    let helper = root.path().join("ctx-pro-qualification");
+    write_blame_helper(&helper);
+    let helper_digest = digest(&helper);
+
+    qualification_command(root.path(), &helper, &helper_digest, "staging")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "qualification helper channel does not match",
+        ));
+
+    let mut partial = Command::cargo_bin("ctx").unwrap();
+    partial
+        .env("CTX_ANALYTICS_ENABLED", "false")
+        .env("CTX_PRO_CHANNEL", "stable")
+        .env(PATH_ENV, &helper)
+        .env(CHANNEL_ENV, "stable")
+        .args([
+            "--data-root",
+            root.path().to_str().unwrap(),
+            "blame",
+            "commit",
+            "0123456789abcdef",
+            "--json",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("must be configured together"));
+}
+
+#[test]
+fn helper_tampering_is_rejected_before_execution() {
+    let root = tempdir().unwrap();
+    initialize_current_query_store(root.path());
+    let helper = root.path().join("ctx-pro-qualification");
+    write_blame_helper(&helper);
+    let expected_digest = digest(&helper);
+    fs::write(&helper, b"#!/bin/sh\nexit 91\n").unwrap();
+
+    qualification_command(root.path(), &helper, &expected_digest, "stable")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("SHA-256 does not match"));
+}

--- a/crates/ctx-cli/tests/pro_qualification.rs
+++ b/crates/ctx-cli/tests/pro_qualification.rs
@@ -37,7 +37,7 @@ fn qualification_command(
             "blame",
             "commit",
             "0123456789abcdef",
-            "--json",
+            "--format=json",
         ]);
     command
 }
@@ -82,7 +82,7 @@ fn qualification_configuration_is_atomic_and_channel_bound() {
             "blame",
             "commit",
             "0123456789abcdef",
-            "--json",
+            "--format=json",
         ])
         .assert()
         .failure()

--- a/crates/ctx-cli/tests/pro_release_helper.rs
+++ b/crates/ctx-cli/tests/pro_release_helper.rs
@@ -1,4 +1,4 @@
-#![cfg(all(unix, not(debug_assertions)))]
+#![cfg(unix)]
 
 use std::{fs, os::unix::fs::PermissionsExt};
 
@@ -7,7 +7,7 @@ use ctx_pro_host_protocol::ProFilesystemLayout;
 use tempfile::tempdir;
 
 #[test]
-fn release_binary_ignores_untrusted_helper_override() {
+fn release_binary_ignores_all_untrusted_helper_overrides() {
     let root = tempdir().unwrap();
     let helper = root.path().join("untrusted-ctx-pro");
     let executed = root.path().join("executed");
@@ -22,6 +22,12 @@ fn release_binary_ignores_untrusted_helper_override() {
         .unwrap()
         .env("CTX_PRO_CHANNEL", "staging")
         .env("CTX_PRO_HELPER", &helper)
+        .env("CTX_PRO_QUALIFICATION_HELPER_PATH", &helper)
+        .env(
+            "CTX_PRO_QUALIFICATION_HELPER_SHA256",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        .env("CTX_PRO_QUALIFICATION_HELPER_CHANNEL", "staging")
         .args([
             "--data-root",
             root.path().to_str().unwrap(),


### PR DESCRIPTION
Prepares ctx 0.26 Local Pro for fixed staging and production commercial channels.

- pins pro.ctx.rs and pro-staging.ctx.rs trust records
- enables referral commands on configured commercial channels
- adds WorkOS first-sign-in personal-organization bootstrap
- adds Access service-token support for staging
- adds a compile-time qualification-only local helper target for unreleased end-to-end testing
- keeps ordinary release binaries on signed manifest/R2 helper delivery

Validation: ctx-cli unit, Pro lifecycle, and qualification suites pass. Final 0.26 artifacts, stable pointer advancement, and release publication remain intentionally deferred.