### PR TITLE
fix(pro): refresh auth while Checkout polls

### DIFF
--- a/crates/ctx-cli/src/pro/commercial_lifecycle.rs
+++ b/crates/ctx-cli/src/pro/commercial_lifecycle.rs
@@ -164,6 +164,33 @@ impl CommercialLifecycleService {
         self.persist_tokens(self.workos.refresh(refresh_token)?)
     }
 
+    fn refresh_rejected_access_token_noninteractive(
+        &self,
+        rejected_access_token: &str,
+    ) -> Result<String> {
+        let session = match self.vault.load(CredentialRecordKind::WorkOsSession) {
+            Ok(CredentialRecord::WorkOsSession(session)) => session,
+            Ok(_) => bail!("key_store_unavailable: WorkOS session record mismatch"),
+            Err(CredentialVaultError::NotFound) => {
+                bail!("authentication_required: run `ctx pro`")
+            }
+            Err(error) => return Err(vault_error(error)),
+        };
+        if session.access_token() != rejected_access_token
+            && session.access_expires_at_unix() > unix_time()?
+            && self
+                .workos
+                .validate_access_token(session.access_token())
+                .is_ok()
+        {
+            return Ok(session.access_token().to_owned());
+        }
+        let refresh_token = session
+            .refresh_token()
+            .ok_or_else(|| anyhow!("authentication_required: run `ctx pro`"))?;
+        self.persist_tokens(self.workos.refresh(refresh_token)?)
+    }
+
     fn device_sign_in(&self) -> Result<String> {
         let authorization = self.workos.begin()?;
         eprintln!("Sign in to ctx Pro at:");
@@ -205,19 +232,22 @@ impl CommercialLifecycleService {
 
     fn active_state(
         &self,
-        access_token: &str,
+        access_token: &mut String,
         referral_claim_token: Option<&str>,
     ) -> Result<CommercialState> {
         resolve_active_state(
-            || self.api.account(access_token),
-            || self.api.checkout(access_token, referral_claim_token),
-            |state, checkout| self.await_checkout_access(access_token, state, checkout),
+            access_token,
+            |access_token| self.api.account(access_token),
+            |access_token| self.api.checkout(access_token, referral_claim_token),
+            |access_token, state, checkout| {
+                self.await_checkout_access(access_token, state, checkout)
+            },
         )
     }
 
     fn await_checkout_access(
         &self,
-        access_token: &str,
+        access_token: &mut String,
         initial_state: &CommercialState,
         checkout: CheckoutResult,
     ) -> Result<CommercialState> {
@@ -240,21 +270,15 @@ impl CommercialLifecycleService {
             unix_time,
             || poll_started.elapsed(),
             thread::sleep,
-            || match self.api.account(access_token) {
-                Ok(state)
-                    if state.subject != initial_state.subject
-                        || state.account_id != initial_state.account_id =>
-                {
-                    CheckoutPoll::Fatal(anyhow!(
-                        "invalid_response: commercial account changed during Checkout"
-                    ))
-                }
-                Ok(state) if state.grants_access() => CheckoutPoll::Granted(state),
-                Ok(_) => CheckoutPoll::Pending,
-                Err(error) if is_retryable_checkout_failure(&error) => {
-                    CheckoutPoll::Retryable(checkout_retry_after(&error))
-                }
-                Err(error) => CheckoutPoll::Fatal(error),
+            || {
+                poll_checkout_account(
+                    access_token,
+                    initial_state,
+                    |access_token| self.api.account(access_token),
+                    |rejected_access_token| {
+                        self.refresh_rejected_access_token_noninteractive(rejected_access_token)
+                    },
+                )
             },
             |elapsed_seconds| {
                 eprintln!(
@@ -484,7 +508,7 @@ impl CommercialLifecycleService {
         let mut access_token = self.access_token()?;
         let mut referral_claim_token = self.checkout_referral_claim_token()?;
         let result = (|| {
-            let state = self.active_state(&access_token, referral_claim_token.as_deref())?;
+            let state = self.active_state(&mut access_token, referral_claim_token.as_deref())?;
             let public_key = self.installation_public_key()?;
             let entitlement = self
                 .api
@@ -570,16 +594,17 @@ impl CommercialLifecycleService {
     }
 }
 
-fn resolve_active_state(
-    mut account: impl FnMut() -> Result<CommercialState>,
-    mut checkout: impl FnMut() -> Result<CheckoutResult>,
-    mut await_checkout: impl FnMut(&CommercialState, CheckoutResult) -> Result<CommercialState>,
+fn resolve_active_state<C>(
+    context: &mut C,
+    mut account: impl FnMut(&C) -> Result<CommercialState>,
+    mut checkout: impl FnMut(&C) -> Result<CheckoutResult>,
+    mut await_checkout: impl FnMut(&mut C, &CommercialState, CheckoutResult) -> Result<CommercialState>,
 ) -> Result<CommercialState> {
-    let state = account()?;
+    let state = account(context)?;
     if state.grants_access() {
         return Ok(state);
     }
-    let checkout = checkout()?;
+    let checkout = checkout(context)?;
     match checkout.kind.as_str() {
         "already_subscribed" => {
             let state = checkout.state.ok_or_else(|| {
@@ -589,10 +614,68 @@ fn resolve_active_state(
                 return Ok(state);
             }
         }
-        "checkout_created" | "checkout_pending" => return await_checkout(&state, checkout),
+        "checkout_created" | "checkout_pending" => {
+            return await_checkout(context, &state, checkout)
+        }
         _ => bail!("invalid_response: commercial API returned an invalid Checkout result"),
     }
     bail!("commercial_access_locked: an active trial or subscription is required")
+}
+
+fn poll_checkout_account(
+    access_token: &mut String,
+    initial_state: &CommercialState,
+    mut account: impl FnMut(&str) -> Result<CommercialState>,
+    mut refresh: impl FnMut(&str) -> Result<String>,
+) -> CheckoutPoll<CommercialState> {
+    match account(access_token) {
+        Ok(state) => classify_checkout_account_state(initial_state, state),
+        Err(error) if is_checkout_authentication_failure(&error) => {
+            let refreshed_access_token = match refresh(access_token) {
+                Ok(access_token) => access_token,
+                Err(error) if is_retryable_checkout_failure(&error) => {
+                    return CheckoutPoll::Retryable(checkout_retry_after(&error))
+                }
+                Err(error) => return CheckoutPoll::Fatal(error),
+            };
+            replace_access_token(access_token, refreshed_access_token);
+            match account(access_token) {
+                Ok(state) => classify_checkout_account_state(initial_state, state),
+                Err(error) if is_retryable_checkout_failure(&error) => {
+                    CheckoutPoll::Retryable(checkout_retry_after(&error))
+                }
+                Err(error) => CheckoutPoll::Fatal(error),
+            }
+        }
+        Err(error) if is_retryable_checkout_failure(&error) => {
+            CheckoutPoll::Retryable(checkout_retry_after(&error))
+        }
+        Err(error) => CheckoutPoll::Fatal(error),
+    }
+}
+
+fn classify_checkout_account_state(
+    initial_state: &CommercialState,
+    state: CommercialState,
+) -> CheckoutPoll<CommercialState> {
+    if state.subject != initial_state.subject || state.account_id != initial_state.account_id {
+        CheckoutPoll::Fatal(anyhow!(
+            "invalid_response: commercial account changed during Checkout"
+        ))
+    } else if state.grants_access() {
+        CheckoutPoll::Granted(state)
+    } else {
+        CheckoutPoll::Pending
+    }
+}
+
+fn is_checkout_authentication_failure(error: &anyhow::Error) -> bool {
+    error.to_string().starts_with("authentication_required:")
+}
+
+fn replace_access_token(access_token: &mut String, refreshed_access_token: String) {
+    let mut rejected_access_token = std::mem::replace(access_token, refreshed_access_token);
+    rejected_access_token.zeroize();
 }
 
 enum CheckoutPoll<T> {

--- a/crates/ctx-cli/src/pro/commercial_lifecycle/tests.rs
+++ b/crates/ctx-cli/src/pro/commercial_lifecycle/tests.rs
@@ -80,16 +80,18 @@ fn already_subscribed_uses_embedded_state_without_a_second_account_request() {
     let await_calls = Cell::new(0_u32);
     let initial = commercial_state("none", None);
     let subscribed = commercial_state("active", Some(2_000));
+    let mut context = ();
 
     let state = resolve_active_state(
-        || {
+        &mut context,
+        |_| {
             account_calls.set(account_calls.get() + 1);
             if account_calls.get() > 1 {
                 bail!("unexpected second account request");
             }
             Ok(initial.clone())
         },
-        || {
+        |_| {
             checkout_calls.set(checkout_calls.get() + 1);
             Ok(CheckoutResult {
                 kind: "already_subscribed".to_owned(),
@@ -98,7 +100,7 @@ fn already_subscribed_uses_embedded_state_without_a_second_account_request() {
                 state: Some(subscribed.clone()),
             })
         },
-        |_, _| {
+        |_, _, _| {
             await_calls.set(await_calls.get() + 1);
             bail!("Checkout polling must not run for an existing subscription")
         },
@@ -116,10 +118,12 @@ fn url_less_pending_checkout_uses_the_polling_path() {
     let await_calls = Cell::new(0_u32);
     let initial = commercial_state("none", None);
     let active = commercial_state("active", Some(2_000));
+    let mut context = ();
 
     let state = resolve_active_state(
-        || Ok(initial.clone()),
-        || {
+        &mut context,
+        |_| Ok(initial.clone()),
+        |_| {
             Ok(CheckoutResult {
                 kind: "checkout_pending".to_owned(),
                 url: None,
@@ -127,7 +131,7 @@ fn url_less_pending_checkout_uses_the_polling_path() {
                 state: None,
             })
         },
-        |observed, checkout| {
+        |_, observed, checkout| {
             await_calls.set(await_calls.get() + 1);
             assert_eq!(observed.access_state, "none");
             assert_eq!(checkout.kind, "checkout_pending");
@@ -140,6 +144,175 @@ fn url_less_pending_checkout_uses_the_polling_path() {
 
     assert_eq!(state.access_state, "active");
     assert_eq!(await_calls.get(), 1);
+}
+
+#[test]
+fn checkout_poll_refreshes_an_expired_token_during_a_long_poll() {
+    let clock = Cell::new(1_000_i64);
+    let account_calls = Cell::new(0_u32);
+    let refresh_calls = Cell::new(0_u32);
+    let initial = commercial_state("none", None);
+    let active = commercial_state("active", Some(2_000));
+    let mut access_token = "original-access-token".to_owned();
+
+    let state = poll_checkout_access(
+        2_000,
+        || Ok(clock.get()),
+        || elapsed_since(&clock, 1_000),
+        |duration| {
+            clock.set(clock.get() + i64::try_from(duration.as_secs()).unwrap());
+        },
+        || {
+            poll_checkout_account(
+                &mut access_token,
+                &initial,
+                |observed_access_token| {
+                    account_calls.set(account_calls.get() + 1);
+                    if observed_access_token == "original-access-token" {
+                        if clock.get() < 1_360 {
+                            Ok(initial.clone())
+                        } else {
+                            bail!("authentication_required: access token expired")
+                        }
+                    } else if observed_access_token == "refreshed-access-token" {
+                        Ok(active.clone())
+                    } else {
+                        bail!("invalid_response: unexpected access token")
+                    }
+                },
+                |rejected_access_token| {
+                    refresh_calls.set(refresh_calls.get() + 1);
+                    assert_eq!(rejected_access_token, "original-access-token");
+                    Ok("refreshed-access-token".to_owned())
+                },
+            )
+        },
+        |_| {},
+    )
+    .unwrap();
+
+    assert_eq!(state.access_state, "active");
+    assert!(clock.get() >= 1_360);
+    assert_eq!(refresh_calls.get(), 1);
+    assert_eq!(access_token, "refreshed-access-token");
+    assert!(account_calls.get() > 2);
+}
+
+#[test]
+fn checkout_poll_retries_transient_refresh_failures() {
+    let clock = Cell::new(1_000_i64);
+    let refresh_calls = Cell::new(0_u32);
+    let initial = commercial_state("none", None);
+    let active = commercial_state("active", Some(2_000));
+    let mut access_token = "expired-access-token".to_owned();
+
+    let state = poll_checkout_access(
+        2_000,
+        || Ok(clock.get()),
+        || elapsed_since(&clock, 1_000),
+        |duration| {
+            clock.set(clock.get() + i64::try_from(duration.as_secs()).unwrap());
+        },
+        || {
+            poll_checkout_account(
+                &mut access_token,
+                &initial,
+                |observed_access_token| {
+                    if observed_access_token == "fresh-access-token" {
+                        Ok(active.clone())
+                    } else {
+                        bail!("authentication_required: access token expired")
+                    }
+                },
+                |_| {
+                    refresh_calls.set(refresh_calls.get() + 1);
+                    if refresh_calls.get() == 1 {
+                        bail!("service_unavailable: WorkOS token refresh failed")
+                    }
+                    Ok("fresh-access-token".to_owned())
+                },
+            )
+        },
+        |_| {},
+    )
+    .unwrap();
+
+    assert_eq!(state.access_state, "active");
+    assert_eq!(refresh_calls.get(), 2);
+    assert_eq!(access_token, "fresh-access-token");
+}
+
+#[test]
+fn checkout_poll_stops_after_one_fatal_refresh_failure() {
+    let clock = Cell::new(1_000_i64);
+    let account_calls = Cell::new(0_u32);
+    let refresh_calls = Cell::new(0_u32);
+    let initial = commercial_state("none", None);
+    let mut access_token = "expired-access-token".to_owned();
+
+    let error = poll_checkout_access::<CommercialState>(
+        2_000,
+        || Ok(clock.get()),
+        || elapsed_since(&clock, 1_000),
+        |duration| {
+            clock.set(clock.get() + i64::try_from(duration.as_secs()).unwrap());
+        },
+        || {
+            poll_checkout_account(
+                &mut access_token,
+                &initial,
+                |_| {
+                    account_calls.set(account_calls.get() + 1);
+                    bail!("authentication_required: access token expired")
+                },
+                |_| {
+                    refresh_calls.set(refresh_calls.get() + 1);
+                    bail!("authentication_failed: WorkOS refresh token was rejected")
+                },
+            )
+        },
+        |_| {},
+    )
+    .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "authentication_failed: WorkOS refresh token was rejected"
+    );
+    assert_eq!(clock.get(), 1_000);
+    assert_eq!(account_calls.get(), 1);
+    assert_eq!(refresh_calls.get(), 1);
+    assert_eq!(access_token, "expired-access-token");
+}
+
+#[test]
+fn checkout_poll_rejects_identity_changes_after_token_refresh() {
+    let initial = commercial_state("none", None);
+    let mut changed = commercial_state("active", Some(2_000));
+    changed.subject = "user_456".to_owned();
+    let mut access_token = "expired-access-token".to_owned();
+
+    let outcome = poll_checkout_account(
+        &mut access_token,
+        &initial,
+        |observed_access_token| {
+            if observed_access_token == "fresh-access-token" {
+                Ok(changed.clone())
+            } else {
+                bail!("authentication_required: access token expired")
+            }
+        },
+        |_| Ok("fresh-access-token".to_owned()),
+    );
+
+    let CheckoutPoll::Fatal(error) = outcome else {
+        panic!("identity changes must fail closed");
+    };
+    assert_eq!(
+        error.to_string(),
+        "invalid_response: commercial account changed during Checkout"
+    );
+    assert_eq!(access_token, "fresh-access-token");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- refresh a rejected WorkOS access token noninteractively during long Checkout polling
- keep account and subject identity pinned across refresh
- zeroize superseded access tokens and reuse the refreshed credential for entitlement issuance
- bound transient and fatal refresh behavior with regression coverage

## Production finding
A real unreleased-CLI Checkout dogfood remained open beyond the short WorkOS token lifetime and failed at approximately six minutes with HTTP 401. This patch keeps the supported 30-minute Checkout wait viable.

## Validation
- `bazel test //crates/ctx-cli:unit_tests --config=ci`
- focused Checkout polling tests
- `git diff --check`
