### PR TITLE
fix(ingest): tolerate verified Codex appends

### DIFF
--- a/crates/ctx-cli/tests/setup_sources_import/import_orchestration.rs
+++ b/crates/ctx-cli/tests/setup_sources_import/import_orchestration.rs
@@ -851,9 +851,28 @@ fn failed_import_attempt_does_not_count_as_indexed_history() {
         ));
 
     let status = json_output(ctx(&temp).args(["status", "--format=json"]));
-    assert_eq!(status["lexical"]["status"], "unavailable", "{status:#}");
-    assert_eq!(
-        status["history_epoch"]["status"], "unavailable",
+    assert!(
+        matches!(
+            status["lexical"]["status"].as_str(),
+            Some("unavailable" | "pending")
+        ),
+        "{status:#}"
+    );
+    assert!(
+        matches!(
+            status["history_epoch"]["status"].as_str(),
+            Some("unavailable" | "pending")
+        ),
+        "{status:#}"
+    );
+    assert_ne!(status["lexical"]["status"], "ready", "{status:#}");
+    assert_ne!(status["history_epoch"]["status"], "ready", "{status:#}");
+    assert_eq!(status["initialized"], false, "{status:#}");
+    assert!(
+        status
+            .get("indexed_events")
+            .and_then(serde_json::Value::as_u64)
+            .is_none_or(|count| count == 0),
         "{status:#}"
     );
 }

--- a/crates/ctx-history-capture/src/common/io/root_handle.rs
+++ b/crates/ctx-history-capture/src/common/io/root_handle.rs
@@ -407,6 +407,37 @@ impl OpenedProviderSourceFile {
         Ok(bytes)
     }
 
+    /// Reads an exact range from an append-friendly source and permits only a
+    /// same-object metadata change while the range is read. Callers must bind
+    /// the returned bytes to their own digest and frozen-prefix evidence.
+    pub(crate) fn read_exact_range_allow_append(
+        &self,
+        offset: u64,
+        length: usize,
+        maximum_bytes: usize,
+    ) -> Result<Vec<u8>> {
+        if length > maximum_bytes {
+            return Err(CaptureError::InvalidPayload(format!(
+                "provider source range exceeds {maximum_bytes} bytes"
+            )));
+        }
+        let length_u64 = u64::try_from(length)
+            .map_err(|_| CaptureError::SystemInvariant("range length exceeds u64"))?;
+        let end = offset.checked_add(length_u64).ok_or_else(|| {
+            CaptureError::InvalidPayload("provider source range overflows".into())
+        })?;
+        let current_len = self.file.metadata()?.len();
+        if end > current_len {
+            return Err(CaptureError::InvalidPayload(
+                "provider source range exceeds the opened file".into(),
+            ));
+        }
+        let mut bytes = vec![0_u8; length];
+        platform::read_exact_at(&self.file, &mut bytes, offset)?;
+        self.revalidate_same_object()?;
+        Ok(bytes)
+    }
+
     /// Confirms the open handle did not change while read and its route beneath
     /// the retained authority still names the same object.
     ///
@@ -440,6 +471,53 @@ impl OpenedProviderSourceFile {
         let named = platform::object_stamp(&file, &metadata)?;
         if named != self.opened {
             return Err(changed_path(self.display_path()));
+        }
+        Ok(())
+    }
+
+    /// Confirms the route still names the same ordinary file while allowing
+    /// append-only metadata changes on that object.
+    pub(crate) fn revalidate_same_object_leaf(&self) -> Result<()> {
+        let current_metadata = self.file.metadata()?;
+        let current = platform::object_stamp(&self.file, &current_metadata)?;
+        if !platform::same_object(&current, &self.opened) {
+            return Err(changed_path(self.display_path()));
+        }
+        let reopened = match &self.route {
+            ProviderSourceFileRoute::Absolute(path) => platform::open_absolute(path)
+                .map_err(|error| map_changed_open_error(path, error))?,
+            ProviderSourceFileRoute::Relative {
+                root,
+                relative_path,
+            } => {
+                let reopened = root.open_path(relative_path)?;
+                return match reopened {
+                    OpenedProviderSourcePath::File(reopened)
+                        if platform::same_object(&reopened.opened, &self.opened) =>
+                    {
+                        Ok(())
+                    }
+                    _ => Err(changed_path(self.display_path())),
+                };
+            }
+        };
+        let platform::OpenedPath::File { file, metadata, .. } = reopened else {
+            return Err(changed_path(self.display_path()));
+        };
+        let named = platform::object_stamp(&file, &metadata)?;
+        if !platform::same_object(&named, &self.opened) {
+            return Err(changed_path(self.display_path()));
+        }
+        Ok(())
+    }
+
+    /// Confirms same-object leaf identity and the retained root route. This is
+    /// used only by append-friendly providers that separately freeze and hash
+    /// the admitted byte prefix.
+    pub(crate) fn revalidate_same_object(&self) -> Result<()> {
+        self.revalidate_same_object_leaf()?;
+        if let ProviderSourceFileRoute::Relative { root, .. } = &self.route {
+            root.revalidate()?;
         }
         Ok(())
     }
@@ -675,6 +753,36 @@ mod tests {
         assert_eq!(bytes, b"0123456789");
         assert!(source.revalidate_leaf().is_err());
         assert!(source.revalidate().is_err());
+    }
+
+    #[test]
+    fn append_friendly_range_permits_same_object_growth_but_rejects_replacement() {
+        use std::io::Write;
+
+        let temp = crate::test_support_paths::tempdir().unwrap();
+        let path = temp.path().join("source.jsonl");
+        let moved = temp.path().join("moved.jsonl");
+        fs::write(&path, b"first\n").unwrap();
+        let root = ProviderSourceRoot::open(temp.path()).unwrap();
+        let source = root.open_file(Path::new("source.jsonl")).unwrap();
+
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"second\n")
+            .unwrap();
+        assert_eq!(
+            source.read_exact_range_allow_append(0, 6, 6).unwrap(),
+            b"first\n"
+        );
+        assert!(source.revalidate_same_object().is_ok());
+        assert!(source.revalidate().is_err());
+
+        fs::rename(&path, &moved).unwrap();
+        fs::write(&path, b"replacement\n").unwrap();
+        assert!(source.revalidate_same_object_leaf().is_err());
+        assert!(source.read_exact_range_allow_append(0, 6, 6).is_err());
     }
 
     #[test]

--- a/crates/ctx-history-capture/src/common/io/root_handle/unix.rs
+++ b/crates/ctx-history-capture/src/common/io/root_handle/unix.rs
@@ -212,6 +212,10 @@ pub(super) fn object_fingerprint(stamp: &ObjectStamp) -> [u8; 32] {
     digest.finalize().into()
 }
 
+pub(super) fn same_object(left: &ObjectStamp, right: &ObjectStamp) -> bool {
+    left.device == right.device && left.inode == right.inode && left.mode == right.mode
+}
+
 pub(super) fn object_change_token(stamp: &ObjectStamp) -> [u8; 32] {
     let mut digest = Sha256::new();
     digest.update(super::ORDINARY_FILE_TOKEN_DOMAIN);

--- a/crates/ctx-history-capture/src/common/io/root_handle/unsupported.rs
+++ b/crates/ctx-history-capture/src/common/io/root_handle/unsupported.rs
@@ -66,6 +66,10 @@ pub(super) fn object_fingerprint(_stamp: &ObjectStamp) -> [u8; 32] {
     [0; 32]
 }
 
+pub(super) fn same_object(_left: &ObjectStamp, _right: &ObjectStamp) -> bool {
+    false
+}
+
 pub(super) fn object_change_token(_stamp: &ObjectStamp) -> [u8; 32] {
     [0; 32]
 }

--- a/crates/ctx-history-capture/src/common/io/root_handle/windows.rs
+++ b/crates/ctx-history-capture/src/common/io/root_handle/windows.rs
@@ -242,6 +242,12 @@ pub(super) fn object_fingerprint(stamp: &ObjectStamp) -> [u8; 32] {
     digest.finalize().into()
 }
 
+pub(super) fn same_object(left: &ObjectStamp, right: &ObjectStamp) -> bool {
+    left.volume_serial_number == right.volume_serial_number
+        && left.file_id == right.file_id
+        && left.creation_time == right.creation_time
+}
+
 pub(super) fn object_change_token(stamp: &ObjectStamp) -> [u8; 32] {
     let mut digest = Sha256::new();
     digest.update(super::ORDINARY_FILE_TOKEN_DOMAIN);

--- a/crates/ctx-history-capture/src/provider/codex/catalog.rs
+++ b/crates/ctx-history-capture/src/provider/codex/catalog.rs
@@ -520,6 +520,7 @@ fn catalog_codex_session_opened(
         cataloged_at_ms,
         metadata: json!({
             "inventory_file_change_token_v1": hex_digest(&observation.change_token),
+            "inventory_file_stable_token_v1": observation.stable_token.as_ref().map(hex_digest),
             "normalization_capture_revision": CODEX_CAPTURE_REVISION,
             "normalization_policy_revision": CODEX_POLICY_REVISION,
             "originator": payload.and_then(|payload| payload.get("originator")).and_then(Value::as_str),

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/checkpoint.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/checkpoint.rs
@@ -6,7 +6,7 @@ use sha2::{Digest, Sha256};
 use super::rows::CodexSessionRow;
 use super::source::CodexFileObservation;
 
-const CODEX_NATIVE_CHECKPOINT_VERSION: u8 = 4;
+const CODEX_NATIVE_CHECKPOINT_VERSION: u8 = 5;
 const CODEX_PENDING_CALL_ID_DOMAIN: &[u8] = b"ctx/codex-nativepath/pending-call-id/v1\0";
 const MAX_CODEX_PENDING_TOOL_RECORD_BYTES: u64 = 16 * 1024 * 1024 + 1;
 pub(super) const MAX_CODEX_TOOL_CONTEXTS: usize = 24;

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/mod.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/mod.rs
@@ -35,6 +35,7 @@ pub(crate) use source_backed::{
     observe_codex_explicit_session_source_backed_v0,
     source_observation as codex_source_observation,
     writer_base_sources as codex_writer_base_sources, CodexExplicitSessionSourceBackedInputV0,
+    CodexTerminalSourceEvidenceV0,
 };
 pub use source_backed::{
     hydrate_codex_locator, ingest_codex_source_backed_v0, CodexHydratedRecordV0,

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader.rs
@@ -208,6 +208,7 @@ pub(crate) struct CodexNativeScanner {
     source: CodexCatalogSource,
     opened: Arc<OpenedProviderSourceFile>,
     before: CodexFileObservation,
+    frozen_len: u64,
     reader: BufReader<File>,
     disposition: CodexParseDisposition,
     offset: u64,

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/checkpoint.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/checkpoint.rs
@@ -15,7 +15,11 @@ pub(super) fn read_bounded_record(
     storage: &mut Vec<u8>,
     full_hasher: &mut Sha256,
     complete_hasher: &mut Sha256,
+    maximum_bytes: u64,
 ) -> Result<Option<BoundedRecordRead>> {
+    if maximum_bytes == 0 {
+        return Ok(None);
+    }
     storage.clear();
     let complete_before_record = complete_hasher.clone();
     let mut record_hasher = Sha256::new();
@@ -28,7 +32,7 @@ pub(super) fn read_bounded_record(
             let available = reader.fill_buf()?;
             if available.is_empty() {
                 if byte_len == 0 {
-                    return Ok(None);
+                    return Err(source_changed_during_scan());
                 }
                 if all_nul {
                     return Ok(Some(BoundedRecordRead {
@@ -51,8 +55,11 @@ pub(super) fn read_bounded_record(
                 }));
             }
 
-            let newline = available.iter().position(|byte| *byte == b'\n');
-            let consumed = newline.map_or(available.len(), |index| index + 1);
+            let remaining = maximum_bytes.saturating_sub(byte_len);
+            let bounded = usize::try_from(remaining.min(available.len() as u64))
+                .map_err(|_| CaptureError::SystemInvariant("Codex record bound exceeds usize"))?;
+            let newline = available[..bounded].iter().position(|byte| *byte == b'\n');
+            let consumed = newline.map_or(bounded, |index| index + 1);
             let chunk = &available[..consumed];
             full_hasher.update(chunk);
             complete_hasher.update(chunk);
@@ -77,6 +84,27 @@ pub(super) fn read_bounded_record(
             storage.extend_from_slice(&chunk[..copied]);
             if copied != content_len {
                 oversized = true;
+            }
+            if newline.is_none() && byte_len == maximum_bytes {
+                if all_nul {
+                    return Ok(Some(BoundedRecordRead {
+                        complete: true,
+                        terminal_nul_padding: true,
+                        oversized,
+                        stored_len: storage.len(),
+                        byte_len,
+                        sha256: [0; 32],
+                    }));
+                }
+                *complete_hasher = complete_before_record;
+                return Ok(Some(BoundedRecordRead {
+                    complete: false,
+                    terminal_nul_padding: false,
+                    oversized,
+                    stored_len: storage.len(),
+                    byte_len,
+                    sha256: record_hasher.finalize().into(),
+                }));
             }
             (consumed, newline.is_some())
         };
@@ -336,23 +364,47 @@ pub(super) fn observed_opened_file(
     source: &CodexCatalogSource,
     opened: &OpenedProviderSourceFile,
 ) -> Result<CodexFileObservation> {
-    let observed = opened_file_observation(&source.source_path, opened.file())?;
-    opened.revalidate()?;
-    if observed != source.catalog_observation {
+    let current = opened_file_observation(&source.source_path, opened.file())?;
+    opened.revalidate_same_object()?;
+    if !source
+        .catalog_observation
+        .admits_append_only_growth(&current)
+    {
         return Err(CaptureError::InvalidPayload(
             "Codex catalog observation changed before NativePath admission".to_owned(),
         ));
     }
-    Ok(observed)
+    Ok(current)
 }
 
 pub(crate) fn revalidate_codex_source_observation(
     source: &CodexCatalogSource,
     certified: &CodexFileObservation,
+    certified_len: u64,
+    certified_sha256: [u8; 32],
 ) -> Result<()> {
     let opened = open_codex_source_capability(source)?;
-    let observed = observed_opened_file(source, &opened)?;
-    if &observed != certified {
+    let current = opened_file_observation(&source.source_path, opened.file())?;
+    opened.revalidate_same_object()?;
+    if !certified.admits_append_only_growth(&current) {
+        return Err(source_changed_during_scan());
+    }
+    if current != *certified {
+        revalidate_opened_prefix(opened.file(), certified_len, certified_sha256)?;
+        opened.revalidate_same_object()?;
+    }
+    Ok(())
+}
+
+pub(super) fn revalidate_opened_prefix(
+    file: &File,
+    len: u64,
+    expected_sha256: [u8; 32],
+) -> Result<()> {
+    let mut hasher = Sha256::new();
+    let mut reader = file.try_clone()?;
+    hash_opened_file_range(&mut reader, 0, len, &mut hasher)?;
+    if <[u8; 32]>::from(hasher.finalize()) != expected_sha256 {
         return Err(source_changed_during_scan());
     }
     Ok(())
@@ -384,14 +436,14 @@ pub(crate) fn opened_file_observation(path: &Path, file: &File) -> Result<CodexF
     if !metadata.file_type().is_file() {
         return Err(source_changed_during_scan());
     }
-    let platform_before = opened_file_platform_token(path, file, &metadata)?;
+    let platform_before = opened_file_platform_tokens(path, file, &metadata)?;
     let content_fingerprint = if platform_before.is_some() {
         None
     } else {
         Some(opened_file_content_fingerprint(file, &metadata)?)
     };
     let current = file.metadata()?;
-    let platform_after = opened_file_platform_token(path, file, &current)?;
+    let platform_after = opened_file_platform_tokens(path, file, &current)?;
     if current.len() != metadata.len()
         || current.modified().ok() != metadata.modified().ok()
         || platform_after != platform_before
@@ -401,34 +453,53 @@ pub(crate) fn opened_file_observation(path: &Path, file: &File) -> Result<CodexF
     Ok(CodexFileObservation::from_parts(
         metadata.len(),
         metadata.modified().unwrap_or(std::time::UNIX_EPOCH),
-        combine_opened_file_token(platform_before, content_fingerprint),
+        platform_before.map(|tokens| tokens.stable),
+        combine_opened_file_token(
+            platform_before.map(|tokens| tokens.change),
+            content_fingerprint,
+        ),
     ))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OpenedFilePlatformTokens {
+    stable: [u8; 32],
+    change: [u8; 32],
+}
+
 #[cfg(unix)]
-fn opened_file_platform_token(
+fn opened_file_platform_tokens(
     _path: &Path,
     _file: &File,
     metadata: &std::fs::Metadata,
-) -> Result<Option<[u8; 32]>> {
+) -> Result<Option<OpenedFilePlatformTokens>> {
     use std::os::unix::fs::MetadataExt;
 
-    let mut hasher = Sha256::new();
-    hasher.update(ORDINARY_FILE_TOKEN_DOMAIN);
-    hasher.update(b"unix\0");
-    hasher.update(metadata.dev().to_le_bytes());
-    hasher.update(metadata.ino().to_le_bytes());
-    hasher.update(metadata.ctime().to_le_bytes());
-    hasher.update(metadata.ctime_nsec().to_le_bytes());
-    Ok(Some(hasher.finalize().into()))
+    let mut stable = Sha256::new();
+    stable.update(ORDINARY_FILE_TOKEN_DOMAIN);
+    stable.update(b"unix-stable\0");
+    stable.update(metadata.dev().to_le_bytes());
+    stable.update(metadata.ino().to_le_bytes());
+    stable.update(metadata.mode().to_le_bytes());
+    let mut change = Sha256::new();
+    change.update(ORDINARY_FILE_TOKEN_DOMAIN);
+    change.update(b"unix-change\0");
+    change.update(metadata.dev().to_le_bytes());
+    change.update(metadata.ino().to_le_bytes());
+    change.update(metadata.ctime().to_le_bytes());
+    change.update(metadata.ctime_nsec().to_le_bytes());
+    Ok(Some(OpenedFilePlatformTokens {
+        stable: stable.finalize().into(),
+        change: change.finalize().into(),
+    }))
 }
 
 #[cfg(target_os = "windows")]
-fn opened_file_platform_token(
+fn opened_file_platform_tokens(
     path: &Path,
     file: &File,
     metadata: &std::fs::Metadata,
-) -> Result<Option<[u8; 32]>> {
+) -> Result<Option<OpenedFilePlatformTokens>> {
     use std::{mem::size_of, os::windows::io::AsRawHandle};
     use windows_sys::Win32::Storage::FileSystem::{
         FileBasicInfo, FileIdInfo, GetFileInformationByHandleEx, FILE_ATTRIBUTE_REPARSE_POINT,
@@ -468,23 +539,32 @@ fn opened_file_platform_token(
         return Err(std::io::Error::last_os_error().into());
     }
 
-    let mut hasher = Sha256::new();
-    hasher.update(ORDINARY_FILE_TOKEN_DOMAIN);
-    hasher.update(b"windows\0");
-    hasher.update(id_info.VolumeSerialNumber.to_le_bytes());
-    hasher.update(id_info.FileId.Identifier);
-    hasher.update(basic_info.ChangeTime.to_le_bytes());
-    hasher.update(basic_info.LastWriteTime.to_le_bytes());
-    hasher.update(metadata.len().to_le_bytes());
-    Ok(Some(hasher.finalize().into()))
+    let mut stable = Sha256::new();
+    stable.update(ORDINARY_FILE_TOKEN_DOMAIN);
+    stable.update(b"windows-stable\0");
+    stable.update(id_info.VolumeSerialNumber.to_le_bytes());
+    stable.update(id_info.FileId.Identifier);
+    stable.update(basic_info.CreationTime.to_le_bytes());
+    let mut change = Sha256::new();
+    change.update(ORDINARY_FILE_TOKEN_DOMAIN);
+    change.update(b"windows-change\0");
+    change.update(id_info.VolumeSerialNumber.to_le_bytes());
+    change.update(id_info.FileId.Identifier);
+    change.update(basic_info.ChangeTime.to_le_bytes());
+    change.update(basic_info.LastWriteTime.to_le_bytes());
+    change.update(metadata.len().to_le_bytes());
+    Ok(Some(OpenedFilePlatformTokens {
+        stable: stable.finalize().into(),
+        change: change.finalize().into(),
+    }))
 }
 
 #[cfg(not(any(unix, target_os = "windows")))]
-fn opened_file_platform_token(
+fn opened_file_platform_tokens(
     _path: &Path,
     _file: &File,
     _metadata: &std::fs::Metadata,
-) -> Result<Option<[u8; 32]>> {
+) -> Result<Option<OpenedFilePlatformTokens>> {
     Ok(None)
 }
 

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/page_builder.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/page_builder.rs
@@ -58,19 +58,25 @@ impl CodexNativeScanner {
             ));
         }
         if let Some(mut replay) = self.replay.take() {
-            let after = observed_opened_file(&replay.source, &self.opened)?;
-            if after != replay.before_observation {
-                return Err(source_changed_during_scan());
+            let current = observed_opened_file(&replay.source, &self.opened)?;
+            if current != replay.before_observation {
+                revalidate_opened_prefix(
+                    self.opened.file(),
+                    replay.before_observation.len,
+                    replay.full_revision_sha256,
+                )?;
+                self.opened.revalidate_same_object()?;
             }
-            replay.after_observation = after;
+            replay.after_observation = replay.before_observation.clone();
             return Ok(replay);
         }
 
-        let full_revision_sha256 = self.full_hasher.finalize().into();
+        let full_revision_sha256: [u8; 32] = self.full_hasher.finalize().into();
         let complete_prefix_sha256 = self.complete_hasher.finalize().into();
-        let after = observed_opened_file(&self.source, &self.opened)?;
-        if after != self.before {
-            return Err(source_changed_during_scan());
+        let current = observed_opened_file(&self.source, &self.opened)?;
+        if current != self.before {
+            revalidate_opened_prefix(self.opened.file(), self.before.len, full_revision_sha256)?;
+            self.opened.revalidate_same_object()?;
         }
         if let Some(owner) = self.owner.as_ref() {
             validate_catalog_owner(
@@ -81,8 +87,8 @@ impl CodexNativeScanner {
 
         Ok(CodexSourceScan {
             source: self.source,
-            before_observation: self.before,
-            after_observation: after,
+            before_observation: self.before.clone(),
+            after_observation: self.before,
             disposition: self.disposition,
             full_revision_sha256,
             complete_prefix_sha256,

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/scanner.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/scanner.rs
@@ -20,6 +20,7 @@ impl CodexNativeScanner {
         }
 
         let before = observed_opened_file(&source, &opened)?;
+        source.catalog_observation = before.clone();
         let file = opened.file().try_clone()?;
         let mut reader = BufReader::new(file);
         let validated = if let Some(proof) = proof {
@@ -78,6 +79,7 @@ impl CodexNativeScanner {
             return Ok(Self {
                 source,
                 opened,
+                frozen_len: before.len,
                 before,
                 reader,
                 disposition: CodexParseDisposition::ObservationReplay,
@@ -161,6 +163,7 @@ impl CodexNativeScanner {
         Ok(Self {
             source,
             opened,
+            frozen_len: before.len,
             before,
             reader,
             disposition,
@@ -217,7 +220,13 @@ impl CodexNativeScanner {
                 let record_buffer = &mut self.record_buffer;
                 let full_hasher = &mut self.full_hasher;
                 let complete_hasher = &mut self.complete_hasher;
-                read_bounded_record(reader, record_buffer, full_hasher, complete_hasher)?
+                read_bounded_record(
+                    reader,
+                    record_buffer,
+                    full_hasher,
+                    complete_hasher,
+                    self.frozen_len.saturating_sub(self.offset),
+                )?
             };
             let Some(record_read) = record_read else {
                 self.exhausted = true;

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source.rs
@@ -17,22 +17,40 @@ use crate::{
 };
 
 const CATALOG_CHANGE_TOKEN_KEY: &str = "inventory_file_change_token_v1";
+const CATALOG_STABLE_TOKEN_KEY: &str = "inventory_file_stable_token_v1";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct CodexFileObservation {
     pub(crate) len: u64,
     pub(crate) modified_at_ms: i64,
+    #[serde(default)]
+    pub(crate) stable_token: Option<[u8; 32]>,
     pub(crate) change_token: [u8; 32],
 }
 
 impl CodexFileObservation {
-    pub(crate) fn from_parts(len: u64, modified_at: SystemTime, change_token: [u8; 32]) -> Self {
+    pub(crate) fn from_parts(
+        len: u64,
+        modified_at: SystemTime,
+        stable_token: Option<[u8; 32]>,
+        change_token: [u8; 32],
+    ) -> Self {
         Self {
             len,
             modified_at_ms: system_time_ms(modified_at),
+            stable_token,
             change_token,
         }
+    }
+
+    /// Returns true when `current` is either the exact observation or a
+    /// strictly longer observation of the same retained ordinary file.
+    pub(crate) fn admits_append_only_growth(&self, current: &Self) -> bool {
+        self == current
+            || (current.len > self.len
+                && self.stable_token.is_some()
+                && self.stable_token == current.stable_token)
     }
 }
 
@@ -120,12 +138,18 @@ fn catalog_source(session: &CatalogSession) -> Result<CodexCatalogSource, &'stat
     if session.source_path.trim().is_empty() {
         return Err("Codex catalog source path is empty");
     }
-    let token = session
+    let change_token = session
         .metadata
         .get(CATALOG_CHANGE_TOKEN_KEY)
         .and_then(serde_json::Value::as_str)
         .ok_or("Codex catalog change token is missing")
         .and_then(decode_change_token)?;
+    let stable_token = session
+        .metadata
+        .get(CATALOG_STABLE_TOKEN_KEY)
+        .and_then(serde_json::Value::as_str)
+        .map(decode_change_token)
+        .transpose()?;
     Ok(CodexCatalogSource {
         source_root: session.source_root.clone(),
         source_path: PathBuf::from(&session.source_path),
@@ -133,7 +157,8 @@ fn catalog_source(session: &CatalogSession) -> Result<CodexCatalogSource, &'stat
         catalog_observation: CodexFileObservation {
             len: session.file_size_bytes,
             modified_at_ms: session.file_modified_at_ms,
-            change_token: token,
+            stable_token,
+            change_token,
         },
         catalog_native_session_id: session.external_session_id.clone(),
         catalog_parent_native_session_id: session.parent_external_session_id.clone(),

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed.rs
@@ -64,12 +64,12 @@ const CODEX_NATIVE_EVENT_POSITION_KIND: &str = "codex.jsonl.raw-ordinal";
 const CODEX_LOGICAL_SESSION_KIND: &str = "codex-session";
 const CODEX_LOGICAL_EVENT_KIND: &str = "codex-event";
 const CODEX_SOURCE_SCHEMA_VARIANT: &str = "codex-nativepath-jsonl-v0";
-const CODEX_SOURCE_REVISION_KIND: &str = "codex-ordinary-file-observation-v0";
-const CODEX_FRONTIER_KIND: &str = "codex-nativepath-checkpoint-v4";
-const CODEX_PARSER_REVISION: &str = "codex-nativepath-source-backed-v1";
+const CODEX_SOURCE_REVISION_KIND: &str = "codex-ordinary-file-observation-v1";
+const CODEX_FRONTIER_KIND: &str = "codex-nativepath-checkpoint-v5";
+const CODEX_PARSER_REVISION: &str = "codex-nativepath-source-backed-v2";
 const CODEX_INVENTORY_AUTHORITY_NAMESPACE: &str = "codex.sessions-root";
-const CODEX_INVENTORY_REVISION_KIND: &str = "codex-session-tree-inventory-v0";
-const CODEX_DISCOVERY_REVISION: &str = "codex-session-catalog-v0";
+const CODEX_INVENTORY_REVISION_KIND: &str = "codex-session-tree-inventory-v1";
+const CODEX_DISCOVERY_REVISION: &str = "codex-session-catalog-v1";
 const CODEX_EXPLICIT_INVENTORY_AUTHORITY_NAMESPACE: &str = "codex.explicit-session-file";
 const CODEX_EXPLICIT_INVENTORY_REVISION_KIND: &str = "codex-explicit-session-inventory-v0";
 const CODEX_EXPLICIT_DISCOVERY_REVISION: &str = "codex-explicit-session-file-v0";
@@ -155,6 +155,26 @@ pub enum CodexSourceBackedErrorV0 {
     ExplicitSourceIdentityChanged,
     #[error("explicit Codex session inventory changed while it was being certified")]
     ExplicitInventoryChanged,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CodexTerminalSourceEvidenceV0 {
+    pub(crate) source: CodexCatalogSource,
+    pub(crate) observation: CodexFileObservation,
+    pub(crate) certified_len: u64,
+    pub(crate) full_revision_sha256: [u8; 32],
+}
+
+impl CodexTerminalSourceEvidenceV0 {
+    pub(crate) fn revalidate(&self) -> bool {
+        revalidate_codex_source_observation(
+            &self.source,
+            &self.observation,
+            self.certified_len,
+            self.full_revision_sha256,
+        )
+        .is_ok()
+    }
 }
 
 pub type CodexSourceBackedResultV0<T> = Result<T, CodexSourceBackedErrorV0>;

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/catalog.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/catalog.rs
@@ -189,10 +189,7 @@ fn codex_explicit_inventory_observation_v0(
     revision.update(CODEX_EXPLICIT_INVENTORY_DIGEST_DOMAIN);
     revision.update(input.source.exact_descriptor_digest());
     match state {
-        CodexExplicitSessionInventoryStateV0::Present { plan } => {
-            revision.update(b"present\0");
-            revision.update(serde_json::to_vec(&plan.0.catalog_observation)?);
-        }
+        CodexExplicitSessionInventoryStateV0::Present { .. } => revision.update(b"present\0"),
         CodexExplicitSessionInventoryStateV0::Missing => revision.update(b"missing\0"),
     }
     Ok(SourceInventoryObservation::new(
@@ -325,7 +322,7 @@ fn codex_inventory_observation_v0(
     ordered.sort_by_key(|(_, source_key, _)| source_key.identity().digest());
 
     let mut revision = Sha256::new();
-    revision.update(b"ctx.codex-session-tree-inventory-v0\0");
+    revision.update(b"ctx.codex-session-tree-inventory-v1\0");
     revision.update(root_revision);
     hash_inventory_field(&mut revision, root_identity.as_bytes());
     revision.update((ordered.len() as u64).to_be_bytes());
@@ -336,10 +333,6 @@ fn codex_inventory_observation_v0(
         let path_identity = crate::provider::provider_path_identity(&source.source_path)?;
         hash_inventory_field(&mut revision, path_identity.as_bytes());
         hash_inventory_field(&mut revision, native_session_id.as_bytes());
-        hash_inventory_field(
-            &mut revision,
-            &serde_json::to_vec(&source.catalog_observation)?,
-        );
     }
     Ok(SourceInventoryObservation::new(
         CaptureProvider::Codex.as_str(),

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/cold.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/cold.rs
@@ -98,7 +98,7 @@ pub(super) fn cold_scanner_worker_count(
 pub(super) fn ingest_codex_cold_parallel_v0(
     sources: Vec<(CodexCatalogSource, SourceKey, String)>,
     writer: &mut GenerationWriter,
-    revalidation: &mut HashMap<SourceKey, (CodexCatalogSource, CodexFileObservation)>,
+    revalidation: &mut HashMap<SourceKey, CodexTerminalSourceEvidenceV0>,
     timings: &mut CodexSourceBackedPhaseTimingsV0,
     counters: &mut CodexSourceBackedCountersV0,
     worker_count: usize,
@@ -345,7 +345,7 @@ fn consume_cold_lanes_v0(
     lane_states: &mut [ColdLaneStateV0],
     plans: &[ColdSourcePlanV0],
     writer: &mut GenerationWriter,
-    revalidation: &mut HashMap<SourceKey, (CodexCatalogSource, CodexFileObservation)>,
+    revalidation: &mut HashMap<SourceKey, CodexTerminalSourceEvidenceV0>,
     timings: &mut CodexSourceBackedPhaseTimingsV0,
     counters: &mut CodexSourceBackedCountersV0,
 ) -> CodexSourceBackedResultV0<()> {
@@ -472,11 +472,13 @@ fn consume_cold_lanes_v0(
                     .checked_add(complete.staged_documents)
                     .ok_or(CodexSourceBackedErrorV0::CountOverflow)?;
                 counters.cold_sources = counters.cold_sources.saturating_add(1);
-                let after_observation = complete.scan.after_observation.clone();
-                revalidation.insert(
-                    plan.source_key.clone(),
-                    (complete.scan.source, after_observation),
-                );
+                let evidence = CodexTerminalSourceEvidenceV0 {
+                    source: complete.scan.source,
+                    observation: complete.scan.after_observation,
+                    certified_len: complete.scan.before_observation.len,
+                    full_revision_sha256: complete.scan.full_revision_sha256,
+                };
+                revalidation.insert(plan.source_key.clone(), evidence);
                 lane_state.complete_source();
                 completed_sources = completed_sources
                     .checked_add(1)

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/hydration.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/hydration.rs
@@ -161,9 +161,12 @@ impl CodexLocatorResolverV0 {
         let opening_observation =
             opened_codex_file_observation(&source.source_path, opened.file())?;
         opened
-            .revalidate()
+            .revalidate_same_object()
             .map_err(normalize_codex_hydration_capture_error)?;
-        if opening_observation != source.catalog_observation {
+        if !source
+            .catalog_observation
+            .admits_append_only_growth(&opening_observation)
+        {
             return Err(CodexSourceBackedErrorV0::Capture(
                 CaptureError::SourceChangedDuringCapture,
             ));
@@ -193,7 +196,7 @@ impl CodexLocatorResolverV0 {
             });
         }
         opened
-            .revalidate()
+            .revalidate_same_object()
             .map_err(normalize_codex_hydration_capture_error)?;
         let records = ordered
             .into_iter()
@@ -250,13 +253,13 @@ fn hydrate_codex_source_record(
         usize::try_from(byte_length).map_err(|_| CodexSourceBackedErrorV0::LocatorRangeTooLarge)?;
     let opened = open_codex_hydration_source(source)?;
     if byte_offset != 0 {
-        let boundary = opened.read_exact_range(byte_offset.saturating_sub(1), 1, 1)?;
+        let boundary = opened.read_exact_range_allow_append(byte_offset.saturating_sub(1), 1, 1)?;
         if boundary != *b"\n" {
             return Err(CodexSourceBackedErrorV0::LocatorRecordBoundaryMismatch);
         }
     }
     let provider_bytes = opened
-        .read_exact_range(
+        .read_exact_range_allow_append(
             byte_offset,
             byte_length,
             MAX_HYDRATED_CODEX_RECORD_BYTES as usize,

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/ingestion.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/ingestion.rs
@@ -46,7 +46,7 @@ pub(super) fn ingest_codex_source_backed_inner_v0(
     if use_parallel_cold {
         sources.sort_by_key(|(_, source_key, _)| source_key.identity().digest());
     }
-    let mut revalidation = HashMap::<SourceKey, (CodexCatalogSource, CodexFileObservation)>::new();
+    let mut revalidation = HashMap::<SourceKey, CodexTerminalSourceEvidenceV0>::new();
 
     if use_parallel_cold {
         let worker_count = cold_scanner_worker_count(
@@ -123,10 +123,10 @@ pub(super) fn ingest_codex_source_backed_inner_v0(
         match target {
             RevalidationTarget::Source(certificate) => revalidation
                 .get_key_value(certificate.observation().source())
-                .is_some_and(|(source_key, (source, observation))| {
+                .is_some_and(|(source_key, evidence)| {
                     closing.contains(source_key)
                         && source_key.exact_descriptor_eq(certificate.observation().source())
-                        && revalidate_codex_source_observation(source, observation).is_ok()
+                        && evidence.revalidate()
                 }),
             RevalidationTarget::Deletion(deletion) => deletion.verifies(closing),
         }
@@ -144,7 +144,7 @@ pub(crate) fn ingest_codex_sources_serial_v0(
     sources: Vec<(CodexCatalogSource, SourceKey, String)>,
     base_sources: &HashMap<SourceKey, CertifiedSource>,
     writer: &mut GenerationWriter,
-    revalidation: &mut HashMap<SourceKey, (CodexCatalogSource, CodexFileObservation)>,
+    revalidation: &mut HashMap<SourceKey, CodexTerminalSourceEvidenceV0>,
     timings: &mut CodexSourceBackedPhaseTimingsV0,
     counters: &mut CodexSourceBackedCountersV0,
 ) -> CodexSourceBackedResultV0<()> {
@@ -187,7 +187,15 @@ pub(crate) fn ingest_codex_sources_serial_v0(
                 writer.certify_source_append(append)?;
                 timings.certification += certification_started.elapsed();
                 counters.replayed_sources = counters.replayed_sources.saturating_add(1);
-                revalidation.insert(source_key, (source, proof.checkpoint.observation.clone()));
+                revalidation.insert(
+                    source_key,
+                    CodexTerminalSourceEvidenceV0 {
+                        source,
+                        observation: proof.checkpoint.observation.clone(),
+                        certified_len: proof.checkpoint.observation.len,
+                        full_revision_sha256: proof.checkpoint.full_revision_sha256,
+                    },
+                );
                 continue;
             }
         }
@@ -309,7 +317,15 @@ pub(crate) fn ingest_codex_sources_serial_v0(
             }
         }
         timings.certification += certification_started.elapsed();
-        revalidation.insert(source_key, (source, scan.after_observation.clone()));
+        revalidation.insert(
+            source_key,
+            CodexTerminalSourceEvidenceV0 {
+                source,
+                observation: scan.after_observation.clone(),
+                certified_len: scan.before_observation.len,
+                full_revision_sha256: scan.full_revision_sha256,
+            },
+        );
     }
     Ok(())
 }

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/lifecycle.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/lifecycle.rs
@@ -705,3 +705,56 @@ fn source_backed_final_inventory_revalidation_blocks_partial_publication() {
     );
     assert!(search_event_ids(&after, "lateinventorymarker").is_empty());
 }
+
+#[test]
+fn source_backed_commit_accepts_a_post_scan_append_as_next_generation_work() {
+    fn append_after_scan(session_root: &Path) {
+        let path = fs::read_dir(session_root)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .find(|path| path.extension().and_then(|value| value.to_str()) == Some("jsonl"))
+            .unwrap();
+        OpenOptions::new()
+            .append(true)
+            .open(path)
+            .unwrap()
+            .write_all(format!("{}\n", message("assistant", "postcommitappendmarker")).as_bytes())
+            .unwrap();
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let sessions = temp.path().join("sessions");
+    let index = temp.path().join("global-index");
+    fs::create_dir_all(&sessions).unwrap();
+    let native_session_id = "019fa000-0000-7000-8000-000000000047";
+    write_session(
+        &sessions,
+        native_session_id,
+        &[message("user", "frozen generation sentinel")],
+    );
+
+    let frozen = ingest_codex_source_backed_inner_v0(
+        &sessions,
+        &index,
+        ColdParallelOptionsV0 {
+            before_commit_revalidation: Some(append_after_scan),
+            ..ColdParallelOptionsV0::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(frozen.commit.indexed_documents, 1);
+    let verified = VerifiedIndex::open(&index).unwrap();
+    assert_eq!(
+        search_event_ids(&verified, "frozen generation sentinel").len(),
+        1
+    );
+    assert!(search_event_ids(&verified, "postcommitappendmarker").is_empty());
+
+    let appended = ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+    assert_eq!(appended.counters.appended_sources, 1);
+    let verified = VerifiedIndex::open(&index).unwrap();
+    assert_eq!(
+        search_event_ids(&verified, "postcommitappendmarker").len(),
+        1
+    );
+}

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/tests.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/tests.rs
@@ -2,6 +2,7 @@ use std::{
     collections::BTreeSet,
     fs,
     hint::black_box,
+    io::Write,
     path::{Path, PathBuf},
     time::Instant,
 };
@@ -14,7 +15,7 @@ use tempfile::TempDir;
 
 use super::rows::CodexSourceBackedRowV0;
 use super::*;
-use crate::{observe_ordinary_file, CODEX_SESSION_SOURCE_FORMAT};
+use crate::{common::io::open_provider_source_file, CODEX_SESSION_SOURCE_FORMAT};
 
 fn jsonl(value: Value) -> String {
     let mut line = serde_json::to_string(&value).unwrap();
@@ -112,12 +113,8 @@ fn reasoning(text: &str) -> String {
 }
 
 fn catalog_session(path: &Path, native_session_id: &str) -> CatalogSession {
-    let observation = observe_ordinary_file(path).unwrap();
-    let modified_at_ms = observation
-        .modified_at()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| i64::try_from(duration.as_millis()).unwrap())
-        .unwrap_or_default();
+    let opened = open_provider_source_file(path).unwrap();
+    let observation = opened_codex_file_observation(path, opened.file()).unwrap();
     CatalogSession {
         provider: CaptureProvider::Codex,
         source_format: CODEX_SESSION_SOURCE_FORMAT.to_owned(),
@@ -130,13 +127,18 @@ fn catalog_session(path: &Path, native_session_id: &str) -> CatalogSession {
         external_agent_id: None,
         cwd: Some("/workspace".to_owned()),
         session_started_at_ms: Some(0),
-        file_size_bytes: observation.len(),
-        file_modified_at_ms: modified_at_ms,
+        file_size_bytes: observation.len,
+        file_modified_at_ms: observation.modified_at_ms,
         cataloged_at_ms: 1,
         metadata: json!({
-            "inventory_file_change_token_v1": observation.token_hex(),
+            "inventory_file_change_token_v1": hex_token(&observation.change_token),
+            "inventory_file_stable_token_v1": observation.stable_token.as_ref().map(hex_token),
         }),
     }
+}
+
+fn hex_token(token: &[u8; 32]) -> String {
+    token.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 pub(super) fn discover_one(path: &Path, native_session_id: &str) -> CodexCatalogSource {

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/tests/lifecycle.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/tests/lifecycle.rs
@@ -154,6 +154,87 @@ fn append_resumes_at_complete_prefix_and_preserves_suffix_ordinal() {
 }
 
 #[test]
+fn append_after_catalog_is_admitted_at_one_current_frozen_eof() {
+    let initial = [
+        session_meta("moving-catalog-owner"),
+        message("user", "captured prefix"),
+    ]
+    .concat();
+    let appended = message("assistant", "deferred append");
+    let (_temp, path) = write_source(&initial);
+    let catalog_source = discover_one(&path, "moving-catalog-owner");
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap()
+        .write_all(appended.as_bytes())
+        .unwrap();
+
+    let (frozen, frozen_rows) = scan_collect(catalog_source, None);
+    assert_eq!(
+        frozen.before_observation.len,
+        (initial.len() + appended.len()) as u64
+    );
+    assert_eq!(frozen.after_observation, frozen.before_observation);
+    assert_eq!(
+        frozen.complete_prefix_end,
+        (initial.len() + appended.len()) as u64
+    );
+    assert_eq!(frozen_rows.rows.len(), 2);
+    assert_eq!(frozen_rows.rows[0].lexical_body, "captured prefix");
+    assert_eq!(frozen_rows.rows[1].lexical_body, "deferred append");
+
+    let proof = frozen
+        .bind_checkpoint("moving-catalog-source", CodexCheckpointGeneration::new(91))
+        .unwrap()
+        .unwrap();
+    let (replay, replay_rows) =
+        scan_collect(discover_one(&path, "moving-catalog-owner"), Some(&proof));
+    assert_eq!(replay.disposition, CodexParseDisposition::ObservationReplay);
+    assert!(replay_rows.rows.is_empty());
+}
+
+#[test]
+fn rewrite_or_truncate_after_catalog_still_fails_admission() {
+    let initial = [
+        session_meta("moving-rewrite-owner"),
+        message("user", "original body"),
+    ]
+    .concat();
+    let (_temp, path) = write_source(&initial);
+    let rewrite_source = discover_one(&path, "moving-rewrite-owner");
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    let mut rewritten = initial.clone().into_bytes();
+    let marker = b"original body";
+    let start = rewritten
+        .windows(marker.len())
+        .position(|window| window == marker)
+        .unwrap();
+    rewritten[start..start + marker.len()].copy_from_slice(b"rewritten bod");
+    fs::write(&path, rewritten).unwrap();
+    let rewrite_error = CodexNativeScanner::new_source_backed_v0(rewrite_source, None).unwrap_err();
+    assert!(
+        format!("{rewrite_error}").contains("changed before NativePath admission"),
+        "{rewrite_error}"
+    );
+
+    let truncate_source = discover_one(&path, "moving-rewrite-owner");
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    fs::OpenOptions::new()
+        .write(true)
+        .open(&path)
+        .unwrap()
+        .set_len((initial.len() / 2) as u64)
+        .unwrap();
+    let truncate_error =
+        CodexNativeScanner::new_source_backed_v0(truncate_source, None).unwrap_err();
+    assert!(
+        format!("{truncate_error}").contains("changed before NativePath admission"),
+        "{truncate_error}"
+    );
+}
+
+#[test]
 fn append_restarts_at_an_incomplete_records_original_ordinal() {
     let complete_prefix = [
         session_meta("partial-append-owner"),
@@ -247,7 +328,7 @@ fn checkpoint_round_trip_contains_control_state_but_no_event_body() {
     assert!(!wire.contains("command"));
     assert!(!wire.contains("arguments_preview"));
     let decoded_wire = serde_json::from_str::<Value>(&wire).unwrap();
-    assert_eq!(decoded_wire["version"], 4);
+    assert_eq!(decoded_wire["version"], 5);
     assert_eq!(
         decoded_wire["pending_tool_authorities"]
             .as_array()

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/tests/paging.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/tests/paging.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[test]
-fn terminal_authority_rejects_mutation_and_retry_keeps_the_safe_prefix_identity() {
+fn terminal_authority_defers_a_verified_append_and_retry_advances_the_prefix() {
     let initial = [
         session_meta("mutation-owner"),
         message("user", "before mutation"),
@@ -22,16 +22,10 @@ fn terminal_authority_rejects_mutation_and_retry_keeps_the_safe_prefix_identity(
 
     let appended = message("assistant", "after mutation");
     fs::write(&path, format!("{initial}{appended}")).unwrap();
-    let error = scanner.finish().unwrap_err();
-    assert!(
-        matches!(
-            error,
-            crate::CaptureError::SourceChangedDuringCapture
-                | crate::CaptureError::InvalidPayload(_)
-                | crate::CaptureError::InvalidProviderTranscriptPath { .. }
-        ),
-        "{error:?}"
-    );
+    let frozen = scanner.finish().unwrap();
+    assert_eq!(frozen.complete_prefix_end, initial.len() as u64);
+    assert_eq!(frozen.next_raw_ordinal, 3);
+    assert_eq!(frozen.before_observation, frozen.after_observation);
 
     let (retry_scan, retry) = scan_collect(discover_one(&path, "mutation-owner"), None);
     assert_eq!(

--- a/crates/ctx-history-capture/src/provider/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/source_backed.rs
@@ -35,6 +35,7 @@ use super::codex::nativepath::{
     CodexHydratedRecordV0, CodexLocatorResolverV0, CodexPromptHistorySourceBackedDispositionV0,
     CodexPromptHistorySourceBackedInputV0, CodexPromptHistorySourceBackedResolverV0,
     CodexSourceBackedCountersV0, CodexSourceBackedErrorV0, CodexSourceBackedPhaseTimingsV0,
+    CodexTerminalSourceEvidenceV0,
 };
 use super::custom_history_jsonl::{
     observe_custom_history_source_backed_explicit, revalidate_custom_history_source_backed,

--- a/crates/ctx-history-capture/src/provider/source_backed/registration/families/jsonl/codex.rs
+++ b/crates/ctx-history-capture/src/provider/source_backed/registration/families/jsonl/codex.rs
@@ -1,6 +1,12 @@
 use super::*;
 use std::sync::Mutex;
 
+#[derive(Clone)]
+struct CodexSessionTreeTerminalEvidence {
+    inventory: CertifiedSourceInventory,
+    sources: HashMap<SourceKey, CodexTerminalSourceEvidenceV0>,
+}
+
 pub(super) fn register_codex_session_tree_route(
     registry: &mut SourceBackedProviderRegistry,
     source: ProviderSource,
@@ -8,11 +14,20 @@ pub(super) fn register_codex_session_tree_route(
 ) -> SourceBackedCoordinatorResult<()> {
     let root = source.path.clone();
     let capture_root = root.clone();
-    let revalidation_root = root.clone();
     let complete_inventory_revalidation_root = root.clone();
     let hydration_root = root;
+    let terminal_evidence = Arc::new(Mutex::new(None::<CodexSessionTreeTerminalEvidence>));
+    let capture_terminal_evidence = Arc::clone(&terminal_evidence);
+    let source_terminal_evidence = Arc::clone(&terminal_evidence);
+    let inventory_terminal_evidence = terminal_evidence;
     let driver = SourceBackedRouteDriver::new(
         move |sink| {
+            *capture_terminal_evidence.lock().map_err(|_| {
+                SourceBackedRouteError::new(
+                    SourceBackedRouteErrorKind::Internal,
+                    "Codex terminal evidence lock was poisoned",
+                )
+            })? = None;
             let opening = discover_codex_root_inventory_v0(&capture_root).map_err(route_error)?;
             sink.certify_complete_inventory(opening.certificate.clone())
                 .map_err(route_coordinator_error)?;
@@ -48,26 +63,40 @@ pub(super) fn register_codex_session_tree_route(
                     .map_err(route_coordinator_error)?;
                 }
             }
+            *capture_terminal_evidence.lock().map_err(|_| {
+                SourceBackedRouteError::new(
+                    SourceBackedRouteErrorKind::Internal,
+                    "Codex terminal evidence lock was poisoned",
+                )
+            })? = Some(CodexSessionTreeTerminalEvidence {
+                inventory: opening.certificate,
+                sources: revalidation,
+            });
             Ok(())
         },
         provider_format_scope(CaptureProvider::Codex, "codex_session_jsonl"),
         move |target| {
-            let Ok(inventory) = discover_codex_root_inventory_v0(&revalidation_root) else {
+            let Ok(evidence) = source_terminal_evidence.lock() else {
+                return false;
+            };
+            let Some(evidence) = evidence.as_ref() else {
                 return false;
             };
             match target {
-                SourceBackedRevalidationTarget::Source(expected) => inventory
+                SourceBackedRevalidationTarget::Source(expected) => evidence
                     .sources
-                    .iter()
-                    .find(|(_, source_key, _)| {
-                        source_key.exact_descriptor_eq(expected.observation().source())
-                    })
-                    .and_then(|(source, source_key, _)| {
-                        codex_source_observation(source_key, &source.catalog_observation).ok()
+                    .get(expected.observation().source())
+                    .and_then(|evidence| {
+                        codex_source_observation(
+                            expected.observation().source(),
+                            &evidence.observation,
+                        )
+                        .ok()
                     })
                     .is_some_and(|observation| observation == *expected.observation()),
                 SourceBackedRevalidationTarget::Deletion(deletion) => {
-                    deletion.verifies(&inventory.certificate)
+                    deletion.verifies(&evidence.inventory)
+                        && !evidence.sources.contains_key(deletion.source())
                 }
             }
         },
@@ -82,8 +111,30 @@ pub(super) fn register_codex_session_tree_route(
         },
     )
     .with_complete_inventory_revalidation(move |expected| {
-        discover_codex_root_inventory_v0(&complete_inventory_revalidation_root)
-            .is_ok_and(|current| current.certificate == *expected)
+        let terminal = inventory_terminal_evidence
+            .lock()
+            .ok()
+            .and_then(|evidence| evidence.clone());
+        let Some(terminal) = terminal else {
+            return false;
+        };
+        if terminal.inventory != *expected {
+            return false;
+        }
+        let Ok(current) = discover_codex_root_inventory_v0(&complete_inventory_revalidation_root)
+        else {
+            return false;
+        };
+        current.certificate == *expected
+            && current.sources.len() == terminal.sources.len()
+            && current.sources.iter().all(|(source, source_key, _)| {
+                terminal.sources.get(source_key).is_some_and(|certified| {
+                    certified
+                        .observation
+                        .admits_append_only_growth(&source.catalog_observation)
+                        && certified.revalidate()
+                })
+            })
     });
     registry.register(executable_route(
         source,


### PR DESCRIPTION
## Summary
- freeze each admitted Codex JSONL source at one EOF while allowing same-object growth
- bind any concurrent append to the exact SHA-256 of the certified prefix before publication
- defer appended bytes to the next generation while keeping rewrite, truncate, and replacement fail-closed
- avoid repeated terminal tree discovery and permit exact source hydration after benign append
- accept the truthful pending self-heal state in the failed-import regression

## Validation
- public release suite: 105/105 targets pass on 99228305bae75afecab6c72b6a2c9e3d9bec41d4
- focused Codex/nativepath: 64 passed, 2 ignored
- source-backed Codex routes: 3/3
- warning-as-error cargo check and strict Clippy pass
- README is byte-identical to v0.25.0 (SHA-256 b21a1f1e782a837c5bbdc16f5324fe924e371bf8797c9eff63ba54cd75e574a0)