### PR TITLE
Preserve validated Pro channel across daemon handoff

### DIFF
--- a/crates/ctx-cli/src/semantic/daemon_autostart/autostart.rs
+++ b/crates/ctx-cli/src/semantic/daemon_autostart/autostart.rs
@@ -636,6 +636,7 @@ const DAEMON_CHILD_ENV_ALLOWLIST: &[&str] = &[
     "CTX_HISTORY_PLUGIN_PATH",
     "CTX_LOCAL_USAGE_ENABLED",
     "CTX_MACHINE_ID",
+    "CTX_PRO_CHANNEL",
     "CTX_PRO_HELPER",
     "CTX_RUNTIME_DIR",
     "CTX_SEARCH_SEMANTIC",
@@ -684,6 +685,7 @@ const DAEMON_CHILD_ENV_ALLOWLIST: &[&str] = &[
     "http_proxy",
     "no_proxy",
 ];
+const DAEMON_PRO_CHANNEL_ENV: &str = "CTX_PRO_CHANNEL";
 
 pub(super) fn configure_narrow_daemon_environment(command: &mut Command) {
     let inherited = DAEMON_CHILD_ENV_ALLOWLIST
@@ -695,8 +697,25 @@ pub(super) fn configure_narrow_daemon_environment(command: &mut Command) {
 }
 
 pub(super) fn spawn_daemon_child(command: &mut Command) -> io::Result<Child> {
+    validate_daemon_pro_channel_environment(command)?;
     crate::process_environment::sanitize_release_authority_env(command);
     command.spawn()
+}
+
+fn validate_daemon_pro_channel_environment(command: &Command) -> io::Result<()> {
+    let channel = command
+        .get_envs()
+        .find(|(name, _)| *name == std::ffi::OsStr::new(DAEMON_PRO_CHANNEL_ENV))
+        .and_then(|(_, value)| value);
+    if channel.is_none_or(|value| {
+        value == std::ffi::OsStr::new("stable") || value == std::ffi::OsStr::new("staging")
+    }) {
+        return Ok(());
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("{DAEMON_PRO_CHANNEL_ENV} must be stable or staging"),
+    ))
 }
 
 pub(super) fn configured_daemon_autostart_command(

--- a/crates/ctx-cli/src/semantic/daemon_autostart/tests.rs
+++ b/crates/ctx-cli/src/semantic/daemon_autostart/tests.rs
@@ -5,22 +5,37 @@ use ctx_history_core::database_path;
 use std::sync::{Arc, Barrier};
 
 const DAEMON_ENV_PROBE_STAGE: &str = "CTX_DAEMON_ENV_PROBE_STAGE";
+const DAEMON_ENV_PROBE_EXPECTED_CHANNEL: &str = "CTX_DAEMON_ENV_PROBE_EXPECTED_CHANNEL";
+const DAEMON_ENV_PRO_CHANNEL: &str = "CTX_PRO_CHANNEL";
 const DAEMON_ENV_PROBE_TEST: &str =
-    "semantic::daemon_autostart::tests::daemon_child_environment_is_narrow_and_release_sanitized";
+    "semantic::daemon_autostart::telemetry_tests::daemon_child_environment_preserves_supported_pro_channel_and_strips_authority";
 const DAEMON_ENV_HOSTILE: &str = "CTX_UNTRUSTED_DAEMON_AMBIENT_SECRET";
 const DAEMON_ENV_ALLOWED_SENTINEL: &str = "/ctx-daemon-allowed-home";
 
 #[test]
-fn daemon_child_environment_is_narrow_and_release_sanitized() -> Result<()> {
+fn daemon_child_environment_preserves_supported_pro_channel_and_strips_authority() -> Result<()> {
     match env::var(DAEMON_ENV_PROBE_STAGE).as_deref() {
         Ok("final") => {
+            let expected_channel = env::var(DAEMON_ENV_PROBE_EXPECTED_CHANNEL)?;
             assert_eq!(env::var("HOME").as_deref(), Ok(DAEMON_ENV_ALLOWED_SENTINEL));
+            if expected_channel == "default" {
+                assert!(env::var_os(DAEMON_ENV_PRO_CHANNEL).is_none());
+            } else {
+                assert_eq!(
+                    env::var(DAEMON_ENV_PRO_CHANNEL).as_deref(),
+                    Ok(expected_channel.as_str())
+                );
+            }
             assert!(env::var_os(DAEMON_ENV_HOSTILE).is_none());
             assert!(env::var_os("CTX_RELEASE_INHERITED_AUTHORITY").is_none());
             assert!(env::var_os("CTX_RELEASE_CONFIGURED_AUTHORITY").is_none());
+            assert!(env::var_os("CTX_PRO_STAGING_ACCESS_CLIENT_SECRET").is_none());
+            assert!(env::var_os("CTX_PRO_QUALIFICATION_HELPER_PATH").is_none());
+            assert!(env::var_os("CTX_PRO_API_URL").is_none());
             return Ok(());
         }
         Ok("inherited") => {
+            let expected_channel = env::var(DAEMON_ENV_PROBE_EXPECTED_CHANNEL)?;
             assert_eq!(env::var(DAEMON_ENV_HOSTILE).as_deref(), Ok("attacker"));
             assert_eq!(
                 env::var("CTX_RELEASE_INHERITED_AUTHORITY").as_deref(),
@@ -31,21 +46,44 @@ fn daemon_child_environment_is_narrow_and_release_sanitized() -> Result<()> {
             descendant
                 .args(["--exact", DAEMON_ENV_PROBE_TEST, "--nocapture"])
                 .env(DAEMON_ENV_PROBE_STAGE, "final")
+                .env(DAEMON_ENV_PROBE_EXPECTED_CHANNEL, &expected_channel)
                 .env("CTX_RELEASE_CONFIGURED_AUTHORITY", "attacker");
-            assert!(spawn_daemon_child(&mut descendant)?.wait()?.success());
+            if expected_channel == "invalid" {
+                let error = spawn_daemon_child(&mut descendant)
+                    .expect_err("unsupported Pro channel must fail before child launch");
+                assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+                assert!(error.to_string().contains("must be stable or staging"));
+            } else {
+                assert!(spawn_daemon_child(&mut descendant)?.wait()?.success());
+            }
             return Ok(());
         }
         _ => {}
     }
 
-    let mut inherited = Command::new(env::current_exe()?);
-    inherited
-        .args(["--exact", DAEMON_ENV_PROBE_TEST, "--nocapture"])
-        .env(DAEMON_ENV_PROBE_STAGE, "inherited")
-        .env(DAEMON_ENV_HOSTILE, "attacker")
-        .env("CTX_RELEASE_INHERITED_AUTHORITY", "attacker")
-        .env("HOME", DAEMON_ENV_ALLOWED_SENTINEL);
-    assert!(inherited.status()?.success());
+    for (expected_channel, channel) in [
+        ("default", None),
+        ("stable", Some("stable")),
+        ("staging", Some("staging")),
+        ("invalid", Some("preview")),
+    ] {
+        let mut inherited = Command::new(env::current_exe()?);
+        inherited
+            .args(["--exact", DAEMON_ENV_PROBE_TEST, "--nocapture"])
+            .env(DAEMON_ENV_PROBE_STAGE, "inherited")
+            .env(DAEMON_ENV_PROBE_EXPECTED_CHANNEL, expected_channel)
+            .env(DAEMON_ENV_HOSTILE, "attacker")
+            .env("CTX_RELEASE_INHERITED_AUTHORITY", "attacker")
+            .env("CTX_PRO_STAGING_ACCESS_CLIENT_SECRET", "attacker")
+            .env("CTX_PRO_QUALIFICATION_HELPER_PATH", "/attacker/helper")
+            .env("CTX_PRO_API_URL", "https://attacker.invalid")
+            .env("HOME", DAEMON_ENV_ALLOWED_SENTINEL)
+            .env_remove(DAEMON_ENV_PRO_CHANNEL);
+        if let Some(channel) = channel {
+            inherited.env(DAEMON_ENV_PRO_CHANNEL, channel);
+        }
+        assert!(inherited.status()?.success());
+    }
     Ok(())
 }
 

--- a/crates/ctx-cli/src/semantic/daemon_supervisor/environment.rs
+++ b/crates/ctx-cli/src/semantic/daemon_supervisor/environment.rs
@@ -16,6 +16,7 @@ const SUPERVISOR_DAEMON_POLICY_ENV_ALLOWLIST: &[&str] = &[
     "CTX_DAEMON_ENABLED",
     "CTX_DAEMON_MODE",
     "CTX_LOCAL_USAGE_ENABLED",
+    "CTX_PRO_CHANNEL",
     "CTX_SEARCH_SEMANTIC",
     "CTX_UPGRADE_AUTO",
     "CTX_UPGRADE_CHANNEL",
@@ -47,6 +48,7 @@ const SUPERVISOR_DAEMON_POLICY_ENV_ALLOWLIST: &[&str] = &[
     "http_proxy",
     "no_proxy",
 ];
+const PRO_CHANNEL_ENV: &str = "CTX_PRO_CHANNEL";
 const SUPERVISOR_DAEMON_FIXED_PATH: &str = if cfg!(windows) {
     r"C:\Windows\System32;C:\Windows"
 } else {
@@ -84,6 +86,9 @@ pub(super) fn supervisor_environment_snapshot() -> Result<SupervisorEnvironmentS
         .iter()
         .chain(SUPERVISOR_DAEMON_POLICY_ENV_ALLOWLIST)
     {
+        if *name == PRO_CHANNEL_ENV {
+            continue;
+        }
         let Some(value) = env::var_os(name) else {
             continue;
         };
@@ -91,6 +96,9 @@ pub(super) fn supervisor_environment_snapshot() -> Result<SupervisorEnvironmentS
             (*name).to_owned(),
             validated_supervisor_environment_value(name, value)?,
         );
+    }
+    if let Some(channel) = validated_supervisor_pro_channel(env::var_os(PRO_CHANNEL_ENV))? {
+        values.insert(PRO_CHANNEL_ENV.to_owned(), channel);
     }
     values.insert("PATH".to_owned(), SUPERVISOR_DAEMON_FIXED_PATH.to_owned());
     #[cfg(unix)]
@@ -218,6 +226,19 @@ fn validated_supervisor_environment_value(name: &str, value: OsString) -> Result
     Ok(value)
 }
 
+fn validated_supervisor_pro_channel(value: Option<OsString>) -> Result<Option<String>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = validated_supervisor_environment_value(PRO_CHANNEL_ENV, value)?;
+    if matches!(value.as_str(), "stable" | "staging") {
+        return Ok(Some(value));
+    }
+    Err(anyhow!(
+        "supervisor environment variable {PRO_CHANNEL_ENV} must be stable or staging"
+    ))
+}
+
 #[cfg(unix)]
 fn validated_supervisor_fallback_home(home: PathBuf) -> Result<String> {
     validated_supervisor_environment_value("HOME", home.into_os_string())
@@ -268,6 +289,7 @@ mod tests {
             "XDG_CONFIG_HOME",
             "CTX_LOCAL_USAGE_ENABLED",
             "CTX_ANALYTICS_ENABLED",
+            "CTX_PRO_CHANNEL",
             "CTX_UPGRADE_AUTO",
             "CTX_UPGRADE_CHANNEL",
             "CTX_UPGRADE_INTERVAL_SECONDS",
@@ -294,6 +316,11 @@ mod tests {
             "CTX_RELEASE_SIGNATURE",
             "CTX_RELEASE_SELF_UPGRADE_ALLOWED",
             "CTX_RELEASE_VERSION",
+            "CTX_PRO_STAGING_ACCESS_CLIENT_ID",
+            "CTX_PRO_STAGING_ACCESS_CLIENT_SECRET",
+            "CTX_PRO_QUALIFICATION_HELPER_PATH",
+            "CTX_PRO_QUALIFICATION_HELPER_SHA256",
+            "CTX_PRO_QUALIFICATION_HELPER_CHANNEL",
             "AWS_SECRET_ACCESS_KEY",
             "GITHUB_TOKEN",
         ] {
@@ -314,5 +341,20 @@ mod tests {
         }
         #[cfg(unix)]
         assert!(validated_supervisor_fallback_home(PathBuf::from("/tmp/home\ninjected")).is_err());
+
+        assert_eq!(validated_supervisor_pro_channel(None).unwrap(), None);
+        for channel in ["stable", "staging"] {
+            assert_eq!(
+                validated_supervisor_pro_channel(Some(channel.into())).unwrap(),
+                Some(channel.to_owned())
+            );
+        }
+        for invalid in ["", "production", "STAGING", "staging "] {
+            let error = validated_supervisor_pro_channel(Some(invalid.into())).unwrap_err();
+            assert!(
+                error.to_string().contains("must be stable or staging"),
+                "{error:#}"
+            );
+        }
     }
 }

--- a/crates/ctx-cli/src/semantic/daemon_supervisor/tests.rs
+++ b/crates/ctx-cli/src/semantic/daemon_supervisor/tests.rs
@@ -519,6 +519,12 @@ fn windows_task_xml_registers_with_task_scheduler() -> Result<()> {
 fn native_supervisor_artifacts_exclude_authority_and_fail_closed_on_controls() -> Result<()> {
     let forbidden = [
         "CTX_PRO_HELPER",
+        "CTX_PRO_STAGING_ACCESS_CLIENT_ID",
+        "CTX_PRO_STAGING_ACCESS_CLIENT_SECRET",
+        "CTX_PRO_QUALIFICATION_HELPER_PATH",
+        "CTX_PRO_QUALIFICATION_HELPER_SHA256",
+        "CTX_PRO_QUALIFICATION_HELPER_CHANNEL",
+        "CTX_PRO_API_URL",
         "CTX_SEMANTIC_MODEL_ONNX",
         "CTX_RELEASE_CONFIGURED_AUTHORITY",
         "CTX_RELEASE_METADATA_URL",
@@ -533,7 +539,8 @@ fn native_supervisor_artifacts_exclude_authority_and_fail_closed_on_controls() -
         let mut child = Command::new(env::current_exe()?);
         child
             .args(["--exact", SUPERVISOR_ENV_ARTIFACT_PROBE_TEST, "--nocapture"])
-            .env(SUPERVISOR_ENV_ARTIFACT_PROBE_STAGE, "final");
+            .env(SUPERVISOR_ENV_ARTIFACT_PROBE_STAGE, "final")
+            .env("CTX_PRO_CHANNEL", "staging");
         for name in forbidden {
             child.env(name, format!("secret-value-for-{name}"));
         }
@@ -546,6 +553,13 @@ fn native_supervisor_artifacts_exclude_authority_and_fail_closed_on_controls() -
     let systemd = linux_systemd_unit(executable, data_root)?;
     let launchd = launch_agent_plist(executable, data_root)?;
     let windows = windows_sanitized_daemon_script(executable, data_root)?;
+    for artifact in [&systemd, &launchd, &windows] {
+        assert!(
+            artifact.contains("CTX_PRO_CHANNEL=staging")
+                || artifact.contains("['CTX_PRO_CHANNEL']='staging'"),
+            "staging Pro channel missing from {artifact}"
+        );
+    }
     for name in forbidden {
         let value = format!("secret-value-for-{name}");
         for artifact in [&systemd, &launchd, &windows] {


### PR DESCRIPTION
## Summary

- preserve the validated stable/staging Pro channel when starting the persistent daemon
- propagate the channel through native supervisor artifacts
- continue stripping staging credentials, helper overrides, and release-authority environment variables
- reject unsupported channel values before daemon launch

## Validation

- focused daemon child environment test under `-D warnings`
- native supervisor artifact test under `-D warnings`
- formatting and diff checks
- README remains byte-identical to v0.25.0