### PR TITLE
fix(capture): restore macOS symlink/socket rejection after data_root threading

### DIFF
--- a/crates/ctx-history-capture/src/common/io/root_handle.rs
+++ b/crates/ctx-history-capture/src/common/io/root_handle.rs
@@ -758,6 +758,42 @@ mod tests {
             .is_err());
     }
 
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+    #[test]
+    fn symlinked_ancestor_is_classified_as_a_rejected_provider_path() {
+        use std::os::unix::fs::symlink;
+
+        let temp = crate::test_support_paths::tempdir().unwrap();
+        let target = temp.path().join("target");
+        let linked = temp.path().join("linked");
+        fs::create_dir(&target).unwrap();
+        fs::write(target.join("source.jsonl"), b"inside\n").unwrap();
+        symlink(&target, &linked).unwrap();
+
+        let error = open_provider_source_file(&linked.join("source.jsonl")).unwrap_err();
+
+        assert!(matches!(
+            error,
+            CaptureError::InvalidProviderTranscriptPath { reason, .. }
+                if reason.contains("symlinked provider source path components")
+        ));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+    #[test]
+    fn plain_file_ancestor_preserves_the_raw_not_a_directory_io_error() {
+        let temp = crate::test_support_paths::tempdir().unwrap();
+        let plain_file = temp.path().join("plain-file");
+        fs::write(&plain_file, b"ordinary").unwrap();
+
+        let error = open_provider_source_file(&plain_file.join("source.jsonl")).unwrap_err();
+
+        assert!(matches!(
+            error,
+            CaptureError::Io(error) if error.raw_os_error() == Some(libc::ENOTDIR)
+        ));
+    }
+
     #[test]
     fn descendants_reject_absolute_and_parent_escape() {
         let temp = crate::test_support_paths::tempdir().unwrap();

--- a/crates/ctx-history-capture/src/common/io/root_handle/unix.rs
+++ b/crates/ctx-history-capture/src/common/io/root_handle/unix.rs
@@ -272,9 +272,31 @@ fn open_component(
             Some(libc::ELOOP) => Err(AuthorityOpenError::Rejected(
                 "symlinked provider source path components are rejected",
             )),
-            Some(libc::ENXIO | libc::ENODEV) => Err(AuthorityOpenError::Rejected(
-                "provider source paths must be regular files or directories",
-            )),
+            // `open(2)`'s ENXIO/ENODEV cover most non-regular special files
+            // (FIFOs, device nodes) portably, but a bound Unix-domain socket
+            // is rejected with EOPNOTSUPP on macOS/BSD kernels instead.
+            Some(libc::ENXIO | libc::ENODEV | libc::EOPNOTSUPP) => {
+                Err(AuthorityOpenError::Rejected(
+                    "provider source paths must be regular files or directories",
+                ))
+            }
+            // BSD-derived kernels (observed on macOS) report ENOTDIR rather
+            // than ELOOP for `openat(..., O_NOFOLLOW | O_DIRECTORY)` against a
+            // symlink component. Without this arm, a symlinked ancestor
+            // silently degraded to a bare `std::io::Error` on macOS instead
+            // of the intended rejection that every other platform already
+            // gets via ELOOP. A non-symlink component still legitimately
+            // returns ENOTDIR here too (e.g. a plain regular file standing
+            // in for a directory ancestor), so only reclassify when an
+            // `lstat` confirms the component is actually a symlink.
+            Some(libc::ENOTDIR)
+                if expected == Some(ExpectedType::Directory)
+                    && component_is_symlink(parent, &name) =>
+            {
+                Err(AuthorityOpenError::Rejected(
+                    "symlinked provider source path components are rejected",
+                ))
+            }
             _ => Err(cause.into()),
         };
     }
@@ -286,6 +308,27 @@ fn open_component(
         ));
     }
     Ok(file)
+}
+
+/// Best-effort, TOCTOU-tolerant check for whether `name` under `parent` is
+/// currently a symlink. Used only to select the diagnostic reason on an
+/// `ENOTDIR` failure that already aborted the open; it never grants access
+/// and a failed/ambiguous `lstat` here simply keeps the raw IO error.
+fn component_is_symlink(parent: libc::c_int, name: &CStr) -> bool {
+    let mut stat_buffer: MaybeUninit<libc::stat> = MaybeUninit::uninit();
+    let result = unsafe {
+        libc::fstatat(
+            parent,
+            name.as_ptr(),
+            stat_buffer.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if result != 0 {
+        return false;
+    }
+    let stat = unsafe { stat_buffer.assume_init() };
+    stat.st_mode & libc::S_IFMT == libc::S_IFLNK
 }
 
 fn classify_opened(file: File) -> Result<OpenedPath, AuthorityOpenError> {

--- a/crates/ctx-history-capture/src/common/io/root_handle/unix.rs
+++ b/crates/ctx-history-capture/src/common/io/root_handle/unix.rs
@@ -268,37 +268,12 @@ fn open_component(
     let descriptor = unsafe { libc::openat(parent, name.as_ptr(), flags) };
     if descriptor < 0 {
         let cause = io::Error::last_os_error();
-        return match cause.raw_os_error() {
-            Some(libc::ELOOP) => Err(AuthorityOpenError::Rejected(
-                "symlinked provider source path components are rejected",
-            )),
-            // `open(2)`'s ENXIO/ENODEV cover most non-regular special files
-            // (FIFOs, device nodes) portably, but a bound Unix-domain socket
-            // is rejected with EOPNOTSUPP on macOS/BSD kernels instead.
-            Some(libc::ENXIO | libc::ENODEV | libc::EOPNOTSUPP) => {
-                Err(AuthorityOpenError::Rejected(
-                    "provider source paths must be regular files or directories",
-                ))
-            }
-            // BSD-derived kernels (observed on macOS) report ENOTDIR rather
-            // than ELOOP for `openat(..., O_NOFOLLOW | O_DIRECTORY)` against a
-            // symlink component. Without this arm, a symlinked ancestor
-            // silently degraded to a bare `std::io::Error` on macOS instead
-            // of the intended rejection that every other platform already
-            // gets via ELOOP. A non-symlink component still legitimately
-            // returns ENOTDIR here too (e.g. a plain regular file standing
-            // in for a directory ancestor), so only reclassify when an
-            // `lstat` confirms the component is actually a symlink.
-            Some(libc::ENOTDIR)
-                if expected == Some(ExpectedType::Directory)
-                    && component_is_symlink(parent, &name) =>
-            {
-                Err(AuthorityOpenError::Rejected(
-                    "symlinked provider source path components are rejected",
-                ))
-            }
-            _ => Err(cause.into()),
-        };
+        return Err(classify_open_component_error(
+            parent,
+            name.as_c_str(),
+            expected,
+            cause,
+        ));
     }
     let file = unsafe { File::from_raw_fd(descriptor) };
     let metadata = file.metadata()?;
@@ -308,6 +283,32 @@ fn open_component(
         ));
     }
     Ok(file)
+}
+
+fn classify_open_component_error(
+    parent: libc::c_int,
+    name: &CStr,
+    expected: Option<ExpectedType>,
+    cause: io::Error,
+) -> AuthorityOpenError {
+    match cause.raw_os_error() {
+        Some(libc::ELOOP) => {
+            AuthorityOpenError::Rejected("symlinked provider source path components are rejected")
+        }
+        // BSD kernels also use ENOTDIR for O_NOFOLLOW | O_DIRECTORY against a
+        // symlink. Reclassify only when no-follow metadata confirms that case.
+        Some(libc::ENOTDIR)
+            if expected == Some(ExpectedType::Directory) && component_is_symlink(parent, name) =>
+        {
+            AuthorityOpenError::Rejected("symlinked provider source path components are rejected")
+        }
+        Some(libc::ENXIO) | Some(libc::ENODEV) | Some(libc::EOPNOTSUPP) => {
+            AuthorityOpenError::Rejected(
+                "provider source paths must be regular files or directories",
+            )
+        }
+        _ => AuthorityOpenError::Io(cause),
+    }
 }
 
 /// Best-effort, TOCTOU-tolerant check for whether `name` under `parent` is
@@ -476,8 +477,26 @@ fn current_errno() -> libc::c_int {
     unsafe { *errno_location() }
 }
 
-#[cfg(all(test, target_os = "linux"))]
+#[cfg(test)]
 mod tests {
+    #[test]
+    fn eopnotsupp_is_classified_as_a_special_file_rejection() {
+        let error = super::classify_open_component_error(
+            libc::AT_FDCWD,
+            c"unused",
+            None,
+            std::io::Error::from_raw_os_error(libc::EOPNOTSUPP),
+        );
+
+        assert!(matches!(
+            error,
+            super::AuthorityOpenError::Rejected(
+                "provider source paths must be regular files or directories"
+            )
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
     #[test]
     fn filesystem_policy_rejects_network_fuse_and_virtual_roots() {
         const NFS_SUPER_MAGIC: i64 = 0x6969;

--- a/crates/ctx-history-capture/src/provider_sources/resolvers/mod.rs
+++ b/crates/ctx-history-capture/src/provider_sources/resolvers/mod.rs
@@ -364,10 +364,16 @@ mod tests {
         let dangling = temp.path().join("dangling");
         symlink(temp.path().join("absent-target"), &dangling).unwrap();
         assert_eq!(path_presence(&dangling), PathPresence::Unsupported);
-        assert!(matches!(
+        // A path routed through a symlinked ancestor is rejected the same
+        // way regardless of what lies beyond it: both `dangling` itself and
+        // `dangling/child` resolve to `Unsupported`. `suppresses_fallback`
+        // treats this identically to `Unknown(_)` (anything but `Missing`
+        // suppresses the legacy fallback), so this assertion only pins the
+        // more accurate diagnostic classification, not a behavior change.
+        assert_eq!(
             path_presence(&dangling.join("child")),
-            PathPresence::Unknown(ErrorKind::NotADirectory)
-        ));
+            PathPresence::Unsupported
+        );
 
         let loop_link = temp.path().join("loop");
         symlink(&loop_link, &loop_link).unwrap();


### PR DESCRIPTION
## Summary

Fixes #230.

- fix two macOS-only tests in `nanoclaw_snapshot.rs` that were left on the stale 1-arg signature of `open_provider_sqlite_readonly` after it gained a `data_root` parameter in `4f7ec06c`, which broke `cargo test` compilation whenever those `#[cfg(target_os = "macos")]` tests are included in the build
- passing the missing argument uncovered a real regression from the same commit's descriptor-walk changes: on macOS/BSD, `openat(..., O_NOFOLLOW | O_DIRECTORY)` against a symlinked ancestor fails with `ENOTDIR` rather than Linux's `ELOOP`, and a bound Unix-domain socket fails with `EOPNOTSUPP` rather than `ENXIO`/`ENODEV`; neither errno was handled, so both cases fell through to a raw `std::io::Error` instead of the intended `AuthorityOpenError::Rejected`
- disambiguate the `ENOTDIR` case with an `fstatat(AT_SYMLINK_NOFOLLOW)` probe before reclassifying, since the same errno is also returned for a legitimate non-symlink component (e.g. a plain file standing in for a directory ancestor) that must keep surfacing as a raw IO error for existing resolver callers
- update one resolver test whose expected diagnostic (`Unknown(NotADirectory)` for a path through a dangling symlink) is superseded by the more accurate `Unsupported` classification; the prior and new variants were already treated identically by `suppresses_fallback()`, so this is not a behavior change

## Validation

- `cargo test -p ctx-history-capture --lib common::io::` (23 passed)
- `cargo test -p ctx-history-capture --lib provider_sources::resolvers` (115 passed)
- `cargo test -p ctx-history-capture --lib nanoclaw` (21 passed, including the macOS-only symlink-ancestor regression test)
- `cargo fmt -p ctx-history-capture -- --check`
- `cargo check -p ctx-history-capture --lib`

Note: `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test -p ctx-history-capture --lib` (full crate) currently fail on a clean checkout of `main` for reasons unrelated to this change (a `clippy::nonminimal_bool` lint on unrelated code, and ~46 pre-existing macOS test failures around non-UTF-8 symlink handling and Gemini/Hermes/Zed fixtures). Verified these reproduce identically on bare `main`.
