### PR TITLE
fix(pro): reject empty repository selectors

### DIFF
--- a/crates/ctx-cli/tests/cli_public_help_docs.rs
+++ b/crates/ctx-cli/tests/cli_public_help_docs.rs
@@ -289,6 +289,19 @@ fn cli_rejects_invalid_blame_selectors_before_local_pro_access() {
     assert!(stderr.contains("END >= START"));
     let stderr = failure_stderr(ctx(&temp).args(["blame", "pr", "0", "--repository", "ctxrs/ctx"]));
     assert!(stderr.contains("positive decimal number"));
+    for repository in ["", "   "] {
+        let stderr = failure_stderr(ctx(&temp).args([
+            "blame",
+            "commit",
+            "abc123",
+            "--repository",
+            repository,
+            "--format=json",
+        ]));
+        assert!(stderr.contains("invalid_request"), "{stderr}");
+        assert!(stderr.contains("repository selector"), "{stderr}");
+        assert!(!stderr.contains("pro_not_installed"), "{stderr}");
+    }
 }
 
 #[test]

--- a/crates/ctx-cli/tests/mcp/input_validation.rs
+++ b/crates/ctx-cli/tests/mcp/input_validation.rs
@@ -165,6 +165,18 @@ fn mcp_tool_input_validation_returns_stable_invalid_request_and_server_recovers(
             "pull request selector must be a positive decimal number",
         ),
         (
+            "empty-pro-repository",
+            "blame",
+            json!({"target": {"kind": "commit", "oid": "abc123", "repository": ""}}),
+            "target.repository cannot be empty",
+        ),
+        (
+            "whitespace-pro-repository",
+            "blame",
+            json!({"target": {"kind": "commit", "oid": "abc123", "repository": "   "}}),
+            "target.repository cannot be empty",
+        ),
+        (
             "bad-pro-lines",
             "blame",
             json!({"target": {"kind": "file", "path": "src/lib.rs", "lines": {"start": 4, "end": 2}}}),

--- a/crates/ctx-pro-host-protocol/src/query.rs
+++ b/crates/ctx-pro-host-protocol/src/query.rs
@@ -106,7 +106,7 @@ impl BlameTarget {
         };
         validate_bounded_text(value, "blame target")?;
         if let Some(repository) = repository {
-            validate_bounded_text(repository, "repository selector")?;
+            validate_repository_selector(repository)?;
         }
         Ok(())
     }
@@ -875,6 +875,16 @@ fn validate_bounded_text(value: &str, name: &str) -> Result<(), ProtocolError> {
     Ok(())
 }
 
+fn validate_repository_selector(value: &str) -> Result<(), ProtocolError> {
+    if value.trim().is_empty() {
+        return Err(ProtocolError::new(
+            ErrorClass::InvalidRequest,
+            "repository selector cannot be empty or whitespace",
+        ));
+    }
+    validate_bounded_text(value, "repository selector")
+}
+
 fn validate_resource_kind(
     resource: &ResourceRef,
     expected: ResourceKind,
@@ -926,4 +936,47 @@ fn normalized_repository_selector(value: &str) -> String {
         return value.to_owned();
     }
     format!("forge:{}/{path}", host.to_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repository_scope_distinguishes_omitted_empty_and_exact_identity() {
+        let omitted: BlameTarget =
+            serde_json::from_str(r#"{"kind":"commit","oid":"abc123"}"#).unwrap();
+        assert!(matches!(
+            &omitted,
+            BlameTarget::Commit {
+                repository: None,
+                ..
+            }
+        ));
+        omitted.validate().unwrap();
+
+        for repository in ["", "   ", "\t"] {
+            let error = BlameTarget::Commit {
+                oid: "abc123".to_owned(),
+                repository: Some(repository.to_owned()),
+            }
+            .validate()
+            .unwrap_err();
+            assert_eq!(error.class, ErrorClass::InvalidRequest);
+        }
+
+        let identity = "workspace:CaseSensitiveRepo";
+        let exact = BlameTarget::Commit {
+            oid: "abc123".to_owned(),
+            repository: Some(identity.to_owned()),
+        };
+        exact.validate().unwrap();
+        assert!(matches!(
+            exact,
+            BlameTarget::Commit {
+                repository: Some(repository),
+                ..
+            } if repository == identity
+        ));
+    }
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -482,9 +482,11 @@ and is bounded from 1 through 100.
 
 Query `--repository` is an optional logical repository identity, such as
 `forge:github.com/ctxrs/ctx`, recorded in the graph. It is never a local
-checkout path or a raw credential-bearing remote URL. It is required for a
-numeric PR selector and optional with a canonical GitHub, GitLab (including
-canonical self-hosted `/-/merge_requests/<positive>`), or Codeberg URL.
+checkout path or a raw credential-bearing remote URL. Omitting it leaves the
+query unscoped; an explicitly empty or whitespace-only identity is an invalid
+request. It is required for a numeric PR selector and optional with a canonical
+GitHub, GitLab (including canonical self-hosted
+`/-/merge_requests/<positive>`), or Codeberg URL.
 
 `--lines` is a positive 1-based committed line or inclusive `start:end` range
 and exists only for file blame. File blame binds the result to a Git HEAD


### PR DESCRIPTION
Reject explicitly empty or whitespace repository selectors as typed invalid requests while preserving omitted repository as unscoped. Focused public protocol, CLI JSON, and MCP tests pass.