### PR TITLE
Revert duplicate implementation before integrating PR #232

### DIFF
--- a/crates/ctx-history-capture/src/common/io/root_handle.rs
+++ b/crates/ctx-history-capture/src/common/io/root_handle.rs
@@ -758,42 +758,6 @@ mod tests {
             .is_err());
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
-    #[test]
-    fn symlinked_ancestor_is_classified_as_a_rejected_provider_path() {
-        use std::os::unix::fs::symlink;
-
-        let temp = crate::test_support_paths::tempdir().unwrap();
-        let target = temp.path().join("target");
-        let linked = temp.path().join("linked");
-        fs::create_dir(&target).unwrap();
-        fs::write(target.join("source.jsonl"), b"inside\n").unwrap();
-        symlink(&target, &linked).unwrap();
-
-        let error = open_provider_source_file(&linked.join("source.jsonl")).unwrap_err();
-
-        assert!(matches!(
-            error,
-            CaptureError::InvalidProviderTranscriptPath { reason, .. }
-                if reason.contains("symlinked provider source path components")
-        ));
-    }
-
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
-    #[test]
-    fn plain_file_ancestor_preserves_the_raw_not_a_directory_io_error() {
-        let temp = crate::test_support_paths::tempdir().unwrap();
-        let plain_file = temp.path().join("plain-file");
-        fs::write(&plain_file, b"ordinary").unwrap();
-
-        let error = open_provider_source_file(&plain_file.join("source.jsonl")).unwrap_err();
-
-        assert!(matches!(
-            error,
-            CaptureError::Io(error) if error.raw_os_error() == Some(libc::ENOTDIR)
-        ));
-    }
-
     #[test]
     fn descendants_reject_absolute_and_parent_escape() {
         let temp = crate::test_support_paths::tempdir().unwrap();

--- a/crates/ctx-history-capture/src/common/io/root_handle/unix.rs
+++ b/crates/ctx-history-capture/src/common/io/root_handle/unix.rs
@@ -268,11 +268,15 @@ fn open_component(
     let descriptor = unsafe { libc::openat(parent, name.as_ptr(), flags) };
     if descriptor < 0 {
         let cause = io::Error::last_os_error();
-        return Err(classify_open_component_error(
-            parent,
-            name.as_c_str(),
-            cause,
-        ));
+        return match cause.raw_os_error() {
+            Some(libc::ELOOP) => Err(AuthorityOpenError::Rejected(
+                "symlinked provider source path components are rejected",
+            )),
+            Some(libc::ENXIO | libc::ENODEV) => Err(AuthorityOpenError::Rejected(
+                "provider source paths must be regular files or directories",
+            )),
+            _ => Err(cause.into()),
+        };
     }
     let file = unsafe { File::from_raw_fd(descriptor) };
     let metadata = file.metadata()?;
@@ -282,46 +286,6 @@ fn open_component(
         ));
     }
     Ok(file)
-}
-
-fn classify_open_component_error(
-    parent: libc::c_int,
-    name: &CStr,
-    cause: io::Error,
-) -> AuthorityOpenError {
-    match cause.raw_os_error() {
-        Some(libc::ELOOP) => {
-            AuthorityOpenError::Rejected("symlinked provider source path components are rejected")
-        }
-        // BSD kernels also use ENOTDIR for O_NOFOLLOW | O_DIRECTORY against a
-        // symlink. Reclassify only when no-follow metadata confirms that case.
-        Some(libc::ENOTDIR) if component_is_symlink(parent, name) => {
-            AuthorityOpenError::Rejected("symlinked provider source path components are rejected")
-        }
-        Some(libc::ENXIO) | Some(libc::ENODEV) | Some(libc::EOPNOTSUPP) => {
-            AuthorityOpenError::Rejected(
-                "provider source paths must be regular files or directories",
-            )
-        }
-        _ => AuthorityOpenError::Io(cause),
-    }
-}
-
-fn component_is_symlink(parent: libc::c_int, name: &CStr) -> bool {
-    let mut metadata = MaybeUninit::<libc::stat>::uninit();
-    let result = unsafe {
-        libc::fstatat(
-            parent,
-            name.as_ptr(),
-            metadata.as_mut_ptr(),
-            libc::AT_SYMLINK_NOFOLLOW,
-        )
-    };
-    if result != 0 {
-        return false;
-    }
-    let metadata = unsafe { metadata.assume_init() };
-    metadata.st_mode & libc::S_IFMT == libc::S_IFLNK
 }
 
 fn classify_opened(file: File) -> Result<OpenedPath, AuthorityOpenError> {
@@ -469,25 +433,8 @@ fn current_errno() -> libc::c_int {
     unsafe { *errno_location() }
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
-    #[test]
-    fn eopnotsupp_is_classified_as_a_special_file_rejection() {
-        let error = super::classify_open_component_error(
-            libc::AT_FDCWD,
-            c"unused",
-            std::io::Error::from_raw_os_error(libc::EOPNOTSUPP),
-        );
-
-        assert!(matches!(
-            error,
-            super::AuthorityOpenError::Rejected(
-                "provider source paths must be regular files or directories"
-            )
-        ));
-    }
-
-    #[cfg(target_os = "linux")]
     #[test]
     fn filesystem_policy_rejects_network_fuse_and_virtual_roots() {
         const NFS_SUPER_MAGIC: i64 = 0x6969;

--- a/crates/ctx-history-capture/src/provider_sources/resolvers/mod.rs
+++ b/crates/ctx-history-capture/src/provider_sources/resolvers/mod.rs
@@ -364,10 +364,10 @@ mod tests {
         let dangling = temp.path().join("dangling");
         symlink(temp.path().join("absent-target"), &dangling).unwrap();
         assert_eq!(path_presence(&dangling), PathPresence::Unsupported);
-        assert_eq!(
+        assert!(matches!(
             path_presence(&dangling.join("child")),
-            PathPresence::Unsupported
-        );
+            PathPresence::Unknown(ErrorKind::NotADirectory)
+        ));
 
         let loop_link = temp.path().join("loop");
         symlink(&loop_link, &loop_link).unwrap();


### PR DESCRIPTION
## Summary

This narrowly removes the maintainer-authored implementation that superseded contributor PR #232.

It restores the integration base so #232 can be rebased onto current main, retain the contributor-authored implementation, and receive the additional maintainer tests and cleanup as follow-up commits.

Only the #232-equivalent root-handle classification, resolver expectation, and associated maintainer tests are reverted. The larger bundled correctness commit is not reverted.

## Validation

- 
- 
running 8 tests
test common::io::root_handle::platform::tests::filesystem_policy_rejects_network_fuse_and_virtual_roots ... ok
test common::io::root_handle::tests::descendants_reject_absolute_and_parent_escape ... ok
test common::io::root_handle::tests::exact_range_reads_from_open_handle_and_detects_named_replacement ... ok
test common::io::root_handle::tests::active_source_family_contract_retained_handle_allows_growth_and_rejects_replacement ... ok
test common::io::root_handle::tests::leaf_revalidation_and_one_terminal_root_fence_have_distinct_purposes ... ok
test common::io::root_handle::tests::retained_root_reads_the_original_tree_after_named_root_replacement ... ok
test common::io::root_handle::tests::authority_fingerprints_are_stable_for_the_same_objects_and_change_on_mutation ... ok
test common::io::root_handle::tests::replaced_descendant_symlink_cannot_escape_retained_root ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 766 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s
- 
running 1 test
test provider_sources::resolvers::tests::dangling_links_and_symlink_loops_never_unlock_fallbacks ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 773 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s

Follow-up: #232