### PR TITLE
feat(blame): add universal target shorthand

### DIFF
--- a/crates/ctx-cli/src/commands/blame.rs
+++ b/crates/ctx-cli/src/commands/blame.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use ctx_pro_host_protocol::{BlameTarget, LineRange, MAX_BLAME_RESULTS};
 
 use crate::{
@@ -18,19 +18,116 @@ use crate::{
 };
 
 #[derive(Debug, Args)]
+#[command(args_conflicts_with_subcommands = true, subcommand_negates_reqs = true)]
 pub(crate) struct BlameArgs {
     #[command(subcommand)]
-    pub(crate) target: BlameTargetArgs,
+    pub(crate) explicit_target: Option<BlameTargetArgs>,
+    #[arg(
+        value_name = "TARGET",
+        required = true,
+        help = "File path, Git commit ID, or positive PR number/canonical PR URL"
+    )]
+    pub(crate) target: Option<String>,
+    #[arg(
+        long = "type",
+        value_enum,
+        value_name = "TYPE",
+        requires = "target",
+        help = "Interpret TARGET as file, commit, or pr; overrides auto-detection"
+    )]
+    pub(crate) target_type: Option<BlameTargetType>,
+    #[arg(
+        long,
+        value_name = "START[:END]",
+        value_parser = parse_line_range,
+        requires = "target",
+        help = "Positive 1-based committed line or inclusive line range; file targets only"
+    )]
+    pub(crate) lines: Option<LineRange>,
+    #[arg(
+        long,
+        value_name = "REPOSITORY",
+        requires = "target",
+        help = "Optional logical repository identity, such as forge:github.com/ctxrs/ctx; required with a PR number and never a checkout path"
+    )]
+    pub(crate) repository: Option<String>,
+    #[arg(
+        long,
+        default_value_t = DEFAULT_BLAME_LIMIT,
+        value_parser = parse_blame_limit,
+        requires = "target",
+        help = "Maximum complete matches to return, from 1 to 100"
+    )]
+    pub(crate) limit: u32,
+    #[arg(
+        long,
+        requires = "target",
+        help = "Opaque continuation cursor from a previous blame page"
+    )]
+    pub(crate) cursor: Option<String>,
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = JsonOutputFormat::Text,
+        requires = "target"
+    )]
+    pub(crate) format: JsonOutputFormat,
 }
 
 impl BlameArgs {
     pub(crate) const fn json_output(&self) -> bool {
-        match &self.target {
-            BlameTargetArgs::File(args) => args.format.is_json(),
-            BlameTargetArgs::Commit(args) => args.format.is_json(),
-            BlameTargetArgs::PullRequest(args) => args.format.is_json(),
+        match &self.explicit_target {
+            Some(BlameTargetArgs::File(args)) => args.format.is_json(),
+            Some(BlameTargetArgs::Commit(args)) => args.format.is_json(),
+            Some(BlameTargetArgs::PullRequest(args)) => args.format.is_json(),
+            None => self.format.is_json(),
         }
     }
+
+    fn into_query(self) -> Result<(BlameTarget, u32, Option<String>, bool)> {
+        if let Some(target) = self.explicit_target {
+            return Ok(explicit_query(target));
+        }
+        let target = self
+            .target
+            .ok_or_else(|| anyhow!("invalid_request: a blame target is required"))?;
+        let target_type = self
+            .target_type
+            .or_else(|| classify_target(&target))
+            .ok_or_else(|| {
+                anyhow!(
+                    "invalid_request: blame target type is ambiguous; use --type file, --type commit, or --type pr"
+                )
+            })?;
+        if self.lines.is_some() && target_type != BlameTargetType::File {
+            return Err(anyhow!(
+                "invalid_request: --lines is only valid for file blame; use --type file if the target is a path"
+            ));
+        }
+        let target = match target_type {
+            BlameTargetType::File => BlameTarget::File {
+                path: target,
+                repository: self.repository,
+                lines: self.lines,
+            },
+            BlameTargetType::Commit => BlameTarget::Commit {
+                oid: target,
+                repository: self.repository,
+            },
+            BlameTargetType::Pr => BlameTarget::PullRequest {
+                selector: target,
+                repository: self.repository,
+            },
+        };
+        Ok((target, self.limit, self.cursor, self.format.is_json()))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum BlameTargetType {
+    File,
+    Commit,
+    Pr,
 }
 
 #[derive(Debug, Subcommand)]
@@ -128,13 +225,8 @@ pub(crate) struct PullRequestBlameArgs {
     pub(crate) format: JsonOutputFormat,
 }
 
-pub(crate) fn run(
-    args: BlameArgs,
-    data_root: PathBuf,
-    local_usage: &mut crate::local_usage::CliUsage,
-    ui: &mut crate::ui::Ui,
-) -> Result<()> {
-    let (target, limit, cursor, json) = match args.target {
+fn explicit_query(target: BlameTargetArgs) -> (BlameTarget, u32, Option<String>, bool) {
+    match target {
         BlameTargetArgs::File(args) => (
             BlameTarget::File {
                 path: args.path,
@@ -163,7 +255,46 @@ pub(crate) fn run(
             args.cursor,
             args.format.is_json(),
         ),
+    }
+}
+
+fn classify_target(target: &str) -> Option<BlameTargetType> {
+    let pr_candidate = BlameTarget::PullRequest {
+        selector: target.to_owned(),
+        repository: Some("auto-detection".to_owned()),
     };
+    if pr_candidate.validate().is_ok() {
+        return Some(BlameTargetType::Pr);
+    }
+    if (4..=64).contains(&target.len()) && target.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Some(BlameTargetType::Commit);
+    }
+    if looks_like_file_path(target) {
+        return Some(BlameTargetType::File);
+    }
+    None
+}
+
+fn looks_like_file_path(target: &str) -> bool {
+    if target.contains("://") {
+        return false;
+    }
+    if target.contains(['/', '\\']) {
+        return true;
+    }
+    let Some((stem, extension)) = target.rsplit_once('.') else {
+        return false;
+    };
+    (!stem.is_empty() || target.starts_with('.')) && !extension.is_empty()
+}
+
+pub(crate) fn run(
+    args: BlameArgs,
+    data_root: PathBuf,
+    local_usage: &mut crate::local_usage::CliUsage,
+    ui: &mut crate::ui::Ui,
+) -> Result<()> {
+    let (target, limit, cursor, json) = args.into_query()?;
     target
         .validate()
         .map_err(|error| anyhow!("invalid_request: {}", error.message))?;
@@ -468,6 +599,165 @@ mod tests {
         );
         for invalid in ["0", "0:1", "4:3", "1:2:3", "-1", "x"] {
             assert!(parse_line_range(invalid).is_err(), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn shorthand_classifier_is_deterministic_and_conservative() {
+        for target in [
+            "42",
+            "https://github.com/ctxrs/ctx/pull/42",
+            "https://gitlab.example.com/group/project/-/merge_requests/42",
+            "https://codeberg.org/ctxrs/ctx/pulls/42",
+        ] {
+            assert_eq!(
+                classify_target(target),
+                Some(BlameTargetType::Pr),
+                "{target}"
+            );
+        }
+        for target in ["abc1234", "0123456789abcdef0123456789abcdef01234567"] {
+            assert_eq!(
+                classify_target(target),
+                Some(BlameTargetType::Commit),
+                "{target}"
+            );
+        }
+        for target in ["src/lib.rs", r"src\lib.rs", "README.md", ".gitignore"] {
+            assert_eq!(
+                classify_target(target),
+                Some(BlameTargetType::File),
+                "{target}"
+            );
+        }
+        for target in [
+            "main",
+            "README",
+            "abc",
+            "feature",
+            "https://example.com/not-a-pr",
+        ] {
+            assert_eq!(classify_target(target), None, "{target}");
+        }
+    }
+
+    #[test]
+    fn shorthand_parser_builds_the_existing_typed_queries() {
+        let parse = |arguments: &[&str]| {
+            let cli =
+                crate::Cli::try_parse_from(std::iter::once("ctx").chain(arguments.iter().copied()))
+                    .unwrap();
+            let crate::cli::CommandRoot::Blame(args) = cli.command else {
+                panic!("expected blame command");
+            };
+            args.into_query().unwrap().0
+        };
+
+        assert_eq!(
+            parse(&[
+                "blame",
+                "src/lib.rs",
+                "--lines",
+                "4:8",
+                "--repository",
+                "forge:github.com/ctxrs/ctx",
+            ]),
+            BlameTarget::File {
+                path: "src/lib.rs".to_owned(),
+                repository: Some("forge:github.com/ctxrs/ctx".to_owned()),
+                lines: Some(LineRange { start: 4, end: 8 }),
+            }
+        );
+        assert_eq!(
+            parse(&["blame", "0123456789abcdef"]),
+            BlameTarget::Commit {
+                oid: "0123456789abcdef".to_owned(),
+                repository: None,
+            }
+        );
+        assert_eq!(
+            parse(&["blame", "42", "--repository", "forge:github.com/ctxrs/ctx",]),
+            BlameTarget::PullRequest {
+                selector: "42".to_owned(),
+                repository: Some("forge:github.com/ctxrs/ctx".to_owned()),
+            }
+        );
+    }
+
+    #[test]
+    fn explicit_type_is_authoritative_and_invalid_type_fails_in_clap() {
+        let cli =
+            crate::Cli::try_parse_from(["ctx", "blame", "0123456789abcdef", "--type", "file"])
+                .unwrap();
+        let crate::cli::CommandRoot::Blame(args) = cli.command else {
+            panic!("expected blame command");
+        };
+        assert!(matches!(
+            args.into_query().unwrap().0,
+            BlameTarget::File { path, .. } if path == "0123456789abcdef"
+        ));
+
+        let error = crate::Cli::try_parse_from(["ctx", "blame", "src/lib.rs", "--type", "unknown"])
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("invalid value 'unknown'"), "{error}");
+        assert!(error.contains("file, commit, pr"), "{error}");
+    }
+
+    #[test]
+    fn ambiguous_shorthand_and_non_file_lines_are_typed_actionable_errors() {
+        for arguments in [
+            &["ctx", "blame", "main"][..],
+            &["ctx", "blame", "abc1234", "--lines", "4:8"][..],
+        ] {
+            let cli = crate::Cli::try_parse_from(arguments).unwrap();
+            let crate::cli::CommandRoot::Blame(args) = cli.command else {
+                panic!("expected blame command");
+            };
+            let error = args.into_query().unwrap_err().to_string();
+            assert!(error.starts_with("invalid_request:"), "{error}");
+            assert!(error.contains("--type"), "{error}");
+        }
+    }
+
+    #[test]
+    fn explicit_blame_subcommands_keep_their_original_queries() {
+        for (arguments, expected) in [
+            (
+                &["ctx", "blame", "file", "src/lib.rs"][..],
+                BlameTarget::File {
+                    path: "src/lib.rs".to_owned(),
+                    repository: None,
+                    lines: None,
+                },
+            ),
+            (
+                &["ctx", "blame", "commit", "abc1234"][..],
+                BlameTarget::Commit {
+                    oid: "abc1234".to_owned(),
+                    repository: None,
+                },
+            ),
+            (
+                &[
+                    "ctx",
+                    "blame",
+                    "pr",
+                    "42",
+                    "--repository",
+                    "forge:github.com/ctxrs/ctx",
+                ][..],
+                BlameTarget::PullRequest {
+                    selector: "42".to_owned(),
+                    repository: Some("forge:github.com/ctxrs/ctx".to_owned()),
+                },
+            ),
+        ] {
+            let cli = crate::Cli::try_parse_from(arguments).unwrap();
+            let crate::cli::CommandRoot::Blame(args) = cli.command else {
+                panic!("expected blame command");
+            };
+            assert_eq!(args.into_query().unwrap().0, expected, "{arguments:?}");
         }
     }
 

--- a/crates/ctx-cli/tests/cli_public_help_docs.rs
+++ b/crates/ctx-cli/tests/cli_public_help_docs.rs
@@ -238,6 +238,20 @@ fn pro_uninstall_help_uses_local_pro_data_terminology() {
 #[test]
 fn blame_help_explains_launch_targets_and_bounds() {
     let temp = tempdir();
+    let output = ctx(&temp)
+        .args(["blame", "--help"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let help = String::from_utf8(output).unwrap();
+    assert!(help.contains("ctx blame [OPTIONS] <TARGET>"), "{help}");
+    assert!(help.contains("ctx blame <COMMAND>"), "{help}");
+    assert!(help.contains("--type <TYPE>"), "{help}");
+    assert!(help.contains("possible values: file, commit, pr"), "{help}");
+    assert!(help.contains("overrides auto-detection"), "{help}");
+
     for args in [
         vec!["blame", "file", "--help"],
         vec!["blame", "commit", "--help"],
@@ -289,6 +303,12 @@ fn cli_rejects_invalid_blame_selectors_before_local_pro_access() {
     assert!(stderr.contains("END >= START"));
     let stderr = failure_stderr(ctx(&temp).args(["blame", "pr", "0", "--repository", "ctxrs/ctx"]));
     assert!(stderr.contains("positive decimal number"));
+    let stderr = failure_stderr(ctx(&temp).args(["blame", "42"]));
+    assert!(
+        stderr.contains("pull request number requires a repository selector"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("pro_not_installed"), "{stderr}");
     for repository in ["", "   "] {
         let stderr = failure_stderr(ctx(&temp).args([
             "blame",
@@ -302,6 +322,30 @@ fn cli_rejects_invalid_blame_selectors_before_local_pro_access() {
         assert!(stderr.contains("repository selector"), "{stderr}");
         assert!(!stderr.contains("pro_not_installed"), "{stderr}");
     }
+
+    for args in [
+        &["blame", "main"][..],
+        &["blame", "main", "--format=json"][..],
+    ] {
+        let stderr = failure_stderr(ctx(&temp).args(args));
+        assert!(stderr.contains("invalid_request"), "{stderr}");
+        assert!(stderr.contains("target type is ambiguous"), "{stderr}");
+        assert!(stderr.contains("--type file"), "{stderr}");
+        assert!(stderr.contains("--type commit"), "{stderr}");
+        assert!(stderr.contains("--type pr"), "{stderr}");
+        assert!(!stderr.contains("pro_not_installed"), "{stderr}");
+    }
+
+    let stderr = failure_stderr(ctx(&temp).args([
+        "blame",
+        "src/lib.rs",
+        "--type",
+        "unknown",
+        "--format=json",
+    ]));
+    assert!(stderr.contains("invalid value 'unknown'"), "{stderr}");
+    assert!(stderr.contains("file, commit, pr"), "{stderr}");
+    assert!(!stderr.contains("pro_not_installed"), "{stderr}");
 }
 
 #[test]

--- a/crates/ctx-cli/tests/pro_host.rs
+++ b/crates/ctx-cli/tests/pro_host.rs
@@ -266,6 +266,64 @@ fn commit_blame_human_output_preserves_production_grouping() {
 }
 
 #[test]
+fn shorthand_blame_preserves_explicit_human_and_json_output() {
+    let root = tempdir().unwrap();
+    initialize_current_query_store(root.path());
+    let helper = root.path().join("ctx-pro-blame");
+    write_blame_helper(&helper);
+
+    for (explicit, shorthand) in [
+        (
+            vec!["blame", "commit", "0123456789abcdef"],
+            vec!["blame", "0123456789abcdef"],
+        ),
+        (
+            vec!["blame", "pr", "https://github.com/ctxrs/ctx/pull/42"],
+            vec!["blame", "https://github.com/ctxrs/ctx/pull/42"],
+        ),
+    ] {
+        for format in [None, Some("--format=json")] {
+            let run = |args: &[&str]| {
+                let mut command = Command::cargo_bin("ctx").unwrap();
+                command
+                    .env("CTX_PRO_HELPER", &helper)
+                    .arg("--data-root")
+                    .arg(root.path())
+                    .args(args);
+                if let Some(format) = format {
+                    command.arg(format);
+                }
+                command.output().unwrap()
+            };
+            let explicit_output = run(&explicit);
+            let shorthand_output = run(&shorthand);
+            assert!(
+                explicit_output.status.success(),
+                "{}",
+                String::from_utf8_lossy(&explicit_output.stderr)
+            );
+            assert!(
+                shorthand_output.status.success(),
+                "{}",
+                String::from_utf8_lossy(&shorthand_output.stderr)
+            );
+            assert_eq!(shorthand_output.stdout, explicit_output.stdout);
+            assert_eq!(shorthand_output.stderr, explicit_output.stderr);
+            if format.is_some() {
+                let value: serde_json::Value =
+                    serde_json::from_slice(&shorthand_output.stdout).unwrap();
+                assert!(matches!(
+                    value["target"]["kind"].as_str(),
+                    Some("commit" | "pull_request")
+                ));
+            } else {
+                assert!(!shorthand_output.stdout.is_empty());
+            }
+        }
+    }
+}
+
+#[test]
 fn commit_and_pr_blame_do_not_require_git_but_file_blame_does() {
     let root = tempdir().unwrap();
     initialize_current_query_store(root.path());

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -471,10 +471,28 @@ ctx data root preserves that identity and its selected backend; copying
 The public Pro query surface is:
 
 ```bash
+ctx blame <target> [--type file|commit|pr] [--lines <start[:end]>] [--repository <logical-repository>] [--limit N] [--cursor <cursor>] [--format json]
+
+# Explicit compatibility forms
 ctx blame file <path> [--lines <start[:end]>] [--repository <logical-repository>] [--limit N] [--cursor <cursor>] [--format json]
 ctx blame commit <sha> [--repository <logical-repository>] [--limit N] [--cursor <cursor>] [--format json]
 ctx blame pr <positive-number-or-canonical-url> [--repository <logical-repository>] [--limit N] [--cursor <cursor>] [--format json]
 ```
+
+Without `--type`, shorthand classification is deterministic and conservative:
+positive PR numbers and canonical supported PR/MR URLs select PR blame; 4-64
+character hexadecimal Git object IDs select commit blame; and path-shaped
+targets containing `/`, `\`, or a filename extension select file blame. Other
+targets fail with `invalid_request` and direct the caller to `--type`. Explicit
+`--type file|commit|pr` is authoritative. Use it for bare filenames, a
+hexadecimal filename, or any target whose intended kind is otherwise ambiguous.
+The selected value remains subject to that target kind's existing validation
+contract.
+
+The `file`, `commit`, and `pr` subcommands remain supported compatibility forms
+with their existing arguments and output behavior. Those three words therefore
+retain subcommand precedence as the first token; for example, use
+`ctx blame file file` to query a file literally named `file`.
 
 There are no Pro `show`, `timeline`, `facts`, or `related` compatibility
 aliases. OSS `ctx show session|event` remains unchanged. The CLI blame limit defaults to 20
@@ -958,6 +976,7 @@ ctx pro uninstall (--delete-data|--keep-data) --format json
 ctx referral create <codename> --format json
 ctx referral status --format json
 ctx referral payout [--no-open] [--country <CC>] [--entity-type <individual|company>] --format json
+ctx blame <target> [--type file|commit|pr] --format json
 ctx blame file <path> --format json
 ctx blame commit <sha> --format json
 ctx blame pr <number-or-url> [--repository <logical-repository>] --format json

--- a/docs/contracts/json.md
+++ b/docs/contracts/json.md
@@ -923,9 +923,10 @@ deletion and emits no success payload. An interrupted deletion retains
 root-local retry metadata; setup and `--keep-data` fail until a later
 `--delete-data` verifies and completes the same installation-scoped cleanup.
 
-Successful `ctx blame file|commit|pr --format json` and MCP `blame` return the protocol
-`BlameResult` directly, with no payload wrapper, prose summary, or suggested
-claims:
+Successful `ctx blame <target> [--type file|commit|pr] --format json`, the
+explicit `ctx blame file|commit|pr --format json` compatibility forms, and MCP
+`blame` return the protocol `BlameResult` directly, with no payload wrapper,
+prose summary, or suggested claims:
 
 - `target`, a resolved tagged `file`, `commit`, or `pull_request` target;
 - `git_snapshot`, required for file results and null for commit/PR results;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -209,15 +209,17 @@ remain local.
 
 ```bash
 ctx pro
-ctx blame file src/lib.rs --lines 42
-ctx blame commit <sha> --format json
-ctx blame pr 42 --repository forge:github.com/ctxrs/ctx
+ctx blame src/lib.rs --lines 42
+ctx blame <sha> --type commit --format json
+ctx blame 42 --repository forge:github.com/ctxrs/ctx
 ```
 
 Repositories and worktrees are detected from indexed activity; setup does not
 need a repository path. Query `--repository` accepts a logical repository
 identity such as `forge:github.com/ctxrs/ctx`, rather than a filesystem path.
 Numeric PR selectors require it; canonical supported PR/MR URLs do not.
+Use `--type file|commit|pr` when a target is ambiguous. The explicit
+`ctx blame file`, `ctx blame commit`, and `ctx blame pr` forms remain supported.
 
 Setup, daemon freshness, and blame can catch the derived graph up. Canonical
 history is never changed by that work. Blame returns typed file, commit, or PR

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -141,7 +141,10 @@ or requires a hosted research agent.
   daemon freshness, and blame. It consumes a bounded feed from a pinned Core
   generation and does not depend on semantic readiness. Repository roots are inferred from
   canonical activity rather than accepted as setup flags.
-- The only public Pro query is `ctx blame file|commit|pr`. It returns typed,
+- The only public Pro query is `ctx blame <target> [--type file|commit|pr]`.
+  The explicit `ctx blame file|commit|pr` forms remain compatible. Shorthand
+  auto-detection is conservative and ambiguous targets fail with an actionable
+  `invalid_request`; explicit `--type` is authoritative. Blame returns typed,
   bounded matches with complete deduplicated canonical evidence. OSS
   `ctx show session|event` remains available; there are no Pro show, timeline,
   facts, or related aliases. Blame may


### PR DESCRIPTION
Adds ctx blame <target> with conservative auto-detection and an authoritative --type file|commit|pr override. Existing ctx blame file|commit|pr forms and their human/JSON outputs remain unchanged. Ambiguous selectors fail with actionable invalid_request diagnostics.\n\nValidation: 12 blame unit tests; Pro-host shorthand/explicit byte-parity test; full public help/docs target; strict Clippy; rustfmt; diff and LOC gates.