### PR TITLE
fix(cursor): skip non-regular source entries without failing discovery

### DIFF
--- a/crates/ctx-history-capture/src/common/io.rs
+++ b/crates/ctx-history-capture/src/common/io.rs
@@ -14,8 +14,8 @@ mod root_handle;
     reason = "provider adapters migrate to these capability types in follow-up slices"
 )]
 pub(crate) use root_handle::{
-    open_provider_source_file, open_provider_source_path, OpenedProviderSourceFile,
-    OpenedProviderSourcePath, ProviderSourceDirectory, ProviderSourceRoot,
+    is_non_regular_source_rejection, open_provider_source_file, open_provider_source_path,
+    OpenedProviderSourceFile, OpenedProviderSourcePath, ProviderSourceDirectory, ProviderSourceRoot,
 };
 
 /// Maximum directories admitted by one provider JSONL inventory.

--- a/crates/ctx-history-capture/src/common/io/root_handle.rs
+++ b/crates/ctx-history-capture/src/common/io/root_handle.rs
@@ -692,6 +692,24 @@ fn map_changed_open_error(path: &Path, error: AuthorityOpenError) -> CaptureErro
     }
 }
 
+/// Reason recorded when a provider source path component is neither a regular
+/// file nor a directory (for example a Unix-domain socket, FIFO, or device
+/// node). Traversal callers can skip such entries safely without treating the
+/// enclosing provider source as unreadable.
+pub(crate) const NON_REGULAR_PROVIDER_SOURCE_REASON: &str =
+    "provider source paths must be regular files or directories";
+
+/// True when `error` is the safe rejection of a non-regular special-file entry
+/// (see [`NON_REGULAR_PROVIDER_SOURCE_REASON`]), as opposed to a symlink
+/// rejection or a genuine IO failure that must fail the enclosing traversal.
+pub(crate) fn is_non_regular_source_rejection(error: &CaptureError) -> bool {
+    matches!(
+        error,
+        CaptureError::InvalidProviderTranscriptPath { reason, .. }
+            if *reason == NON_REGULAR_PROVIDER_SOURCE_REASON
+    )
+}
+
 fn invalid_path(path: &Path, reason: &'static str) -> CaptureError {
     CaptureError::InvalidProviderTranscriptPath {
         path: path.to_path_buf(),

--- a/crates/ctx-history-capture/src/common/io/root_handle/unix.rs
+++ b/crates/ctx-history-capture/src/common/io/root_handle/unix.rs
@@ -303,9 +303,7 @@ fn classify_open_component_error(
             AuthorityOpenError::Rejected("symlinked provider source path components are rejected")
         }
         Some(libc::ENXIO) | Some(libc::ENODEV) | Some(libc::EOPNOTSUPP) => {
-            AuthorityOpenError::Rejected(
-                "provider source paths must be regular files or directories",
-            )
+            AuthorityOpenError::Rejected(super::NON_REGULAR_PROVIDER_SOURCE_REASON)
         }
         _ => AuthorityOpenError::Io(cause),
     }
@@ -349,7 +347,7 @@ fn classify_opened(file: File) -> Result<OpenedPath, AuthorityOpenError> {
         })
     } else {
         Err(AuthorityOpenError::Rejected(
-            "provider source paths must be regular files or directories",
+            super::NON_REGULAR_PROVIDER_SOURCE_REASON,
         ))
     }
 }

--- a/crates/ctx-history-capture/src/provider/providers/cursor/layout.rs
+++ b/crates/ctx-history-capture/src/provider/providers/cursor/layout.rs
@@ -109,6 +109,7 @@ pub(crate) enum CursorDiscoveryIssueKind {
     InvalidLayout,
     NotFound,
     Symlink,
+    SpecialFile,
     LimitExceeded,
 }
 
@@ -394,12 +395,28 @@ fn visit_directories(
                         false,
                     );
                 }
-                Err(error) => inventory.reject(
-                    path,
-                    CursorDiscoveryIssueKind::Symlink,
-                    error.to_string(),
-                    true,
-                ),
+                Err(error) => {
+                    // A non-regular entry (Unix-domain socket, FIFO, device
+                    // node) is safely refused by the authority walk. Skip it
+                    // without invalidating completion: its mere presence beside
+                    // valid transcripts must not mark the whole Cursor source
+                    // unreadable, which would otherwise fail the full refresh.
+                    if crate::common::io::is_non_regular_source_rejection(&error) {
+                        inventory.reject(
+                            path,
+                            CursorDiscoveryIssueKind::SpecialFile,
+                            error.to_string(),
+                            false,
+                        );
+                    } else {
+                        inventory.reject(
+                            path,
+                            CursorDiscoveryIssueKind::Symlink,
+                            error.to_string(),
+                            true,
+                        );
+                    }
+                }
             }
         }
         if let Err(error) = directory.revalidate() {
@@ -578,4 +595,63 @@ fn cursor_catalog_token(
         reopened.revalidate_leaf()?;
     }
     Ok(token)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    // Creates a non-regular special file (FIFO) at `path`. A FIFO shares the
+    // exact authority-walk rejection path as the reported Cursor `worker.sock`
+    // Unix-domain socket (both classify as NON_REGULAR_PROVIDER_SOURCE_REASON),
+    // and unlike a bound socket it is not constrained by the platform sun_path
+    // length limit under a deep temp directory. The socket-specific errno
+    // mapping is covered separately in the root_handle unix tests.
+    fn make_special_file(path: &Path) {
+        let raw = CString::new(path.as_os_str().as_bytes()).unwrap();
+        let result = unsafe { libc::mkfifo(raw.as_ptr(), 0o600) };
+        assert_eq!(result, 0, "mkfifo {}", path.display());
+    }
+
+    #[test]
+    fn cursor_special_file_beside_transcript_is_skipped_without_failing_discovery() {
+        // Regression: a live special file (for example Cursor's `worker.sock`)
+        // sitting beside valid transcripts must be safely skipped, not treated
+        // as an unreadable source. Previously it invalidated completion, marked
+        // the whole Cursor provider `unknown`, and failed the full refresh so
+        // no lexical index was published for any provider.
+        let temp = crate::test_support_paths::tempdir().unwrap();
+        let root = temp.path();
+        let session_directory = root
+            .join("projects")
+            .join("acme")
+            .join(AGENT_TRANSCRIPTS)
+            .join("session-a");
+        std::fs::create_dir_all(&session_directory).unwrap();
+        std::fs::write(session_directory.join("session-a.jsonl"), b"{}\n").unwrap();
+        make_special_file(&session_directory.join("worker.sock"));
+
+        let inventory = discover_cursor_transcripts(root);
+
+        assert!(
+            inventory.completed,
+            "special-file entry must not invalidate completion: {:?}",
+            inventory.issues
+        );
+        assert_eq!(
+            inventory.transcripts.len(),
+            1,
+            "the valid transcript is still discovered alongside the special file"
+        );
+        assert!(
+            inventory
+                .issues
+                .iter()
+                .any(|issue| issue.kind == CursorDiscoveryIssueKind::SpecialFile),
+            "the skipped special file is recorded as a non-fatal issue: {:?}",
+            inventory.issues
+        );
+    }
 }


### PR DESCRIPTION
## Summary

A live Cursor `worker.sock` Unix-domain socket sitting beside valid transcripts made `ctx setup --wait` publish no history or lexical index, so `ctx search` was unavailable for every provider even though Codex, Claude, OpenCode, Zed, Copilot CLI, and Auggie sources were present.

The Cursor authority walk opens each child with `open_child`. A non-regular entry (socket, FIFO, device node) is correctly refused with a `Rejected` error, but `visit_directories` treated every `open_child` error as a fatal symlink rejection. That invalidated inventory completion, classified the whole Cursor source as `unknown`, and made the daemon report a terminal coverage failure for the entire multi-provider refresh.

The refusal already carries a stable reason string. This change adds a shared `is_non_regular_source_rejection` classifier and skips those entries as a non-fatal `SpecialFile` issue, while keeping genuine symlink and IO errors fatal. Valid transcripts beside a special file now complete discovery, the provider reports available, and the full refresh publishes the lexical generation for all providers.

The safe rejection behavior is unchanged: the socket is still never opened or read, it is only no longer treated as coverage failure.

This is the higher-level counterpart to #230 (merged), which corrected the low-level socket errno classification on macOS but left the refresh still blocked by any single `unknown` optional-provider source.

## Validation

`cargo test -p ctx-history-capture --lib cursor_special_file_beside_transcript_is_skipped_without_failing_discovery` passes. The new regression test discovers a valid transcript alongside a non-regular special file and asserts completion is preserved, the transcript is still found, and the skipped entry is recorded as a non-fatal issue. It uses a FIFO to exercise the identical `NON_REGULAR_PROVIDER_SOURCE_REASON` rejection path without the platform `sun_path` length limit; the socket-specific errno mapping is covered by the existing `root_handle` unix tests.

`cargo clippy -p ctx-history-capture --all-targets` is clean for the changed surface.

Fixes #248.
