### PR TITLE
Format the Cursor special-file import

### DIFF
--- a/crates/ctx-history-capture/src/common/io.rs
+++ b/crates/ctx-history-capture/src/common/io.rs
@@ -15,7 +15,8 @@ mod root_handle;
 )]
 pub(crate) use root_handle::{
     is_non_regular_source_rejection, open_provider_source_file, open_provider_source_path,
-    OpenedProviderSourceFile, OpenedProviderSourcePath, ProviderSourceDirectory, ProviderSourceRoot,
+    OpenedProviderSourceFile, OpenedProviderSourcePath, ProviderSourceDirectory,
+    ProviderSourceRoot,
 };
 
 /// Maximum directories admitted by one provider JSONL inventory.


### PR DESCRIPTION
## Summary

- apply the repository rustfmt layout to the import added by PR #249
- restore a clean workspace-wide  result
- make no behavioral change

## Validation

- 
- 