### PR TITLE
Bound search presentation without query regressions

### DIFF
--- a/crates/ctx-cli/src/commands/source_index/render.rs
+++ b/crates/ctx-cli/src/commands/source_index/render.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     ops::Range,
     path::{Path, PathBuf},
     time::Duration,
@@ -22,7 +21,9 @@ use crate::{
     transcript::{shell_quote_arg, write_output},
 };
 
-use super::search::{NormalizedSearchQuery, SearchCollection, SearchHit, SourceSearchRequest};
+use super::search::{
+    NormalizedSearchQuery, SearchCollection, SearchHit, SearchPresentation, SourceSearchRequest,
+};
 
 mod human;
 mod search;
@@ -32,12 +33,7 @@ pub(super) use search::{render_search_document, render_search_not_ready_document
 pub(super) use show::render_show_document;
 
 pub(in crate::commands::source_index) const SEARCH_SNIPPET_MAX_CHARS: usize = 320;
-
-#[derive(Debug)]
-pub(in crate::commands::source_index) struct SearchCorePresentation {
-    pub(in crate::commands::source_index) record: ctx_history_index::CoreEventRecord,
-    pub(in crate::commands::source_index) snippet_truncated: bool,
-}
+pub(in crate::commands::source_index) const SEARCH_SNIPPET_MAX_BYTES: usize = 16 * 1024;
 
 pub(super) fn pretty_json_stdout_bytes(value: &Value) -> Result<usize> {
     Ok(serde_json::to_string_pretty(value)?.len().saturating_add(1))
@@ -48,14 +44,14 @@ pub(super) fn stdout_body_bytes(body: &str) -> usize {
         .saturating_add(usize::from(!body.ends_with('\n')))
 }
 
-struct SearchJsonInput<'a> {
-    request: &'a SourceSearchRequest,
-    data_root: &'a Path,
-    index: &'a VerifiedIndex,
-    collection: &'a SearchCollection,
-    filters: &'a EventSearchFilters,
-    core_records: &'a HashMap<Uuid, SearchCorePresentation>,
-    metrics: SearchRenderMetrics<'a>,
+struct SearchJsonInput<'input, 'event> {
+    request: &'input SourceSearchRequest,
+    data_root: &'input Path,
+    index: &'input VerifiedIndex,
+    collection: &'input SearchCollection,
+    filters: &'input EventSearchFilters,
+    presentations: &'input [SearchPresentation<'event>],
+    metrics: SearchRenderMetrics<'input>,
 }
 
 struct SearchRenderMetrics<'a> {
@@ -64,75 +60,68 @@ struct SearchRenderMetrics<'a> {
     query_duration: Duration,
 }
 
-// Keep the orchestration call shape stable while rendering consumes one typed input.
-type SearchJsonCompatibilityFn = fn(
-    &SourceSearchRequest,
-    &Path,
-    &VerifiedIndex,
-    &SearchCollection,
-    &EventSearchFilters,
-    &HashMap<Uuid, SearchCorePresentation>,
-    &str,
-    usize,
-    Duration,
-) -> Result<Value>;
+pub(super) fn search_json<'event>(
+    request: &SourceSearchRequest,
+    data_root: &Path,
+    index: &VerifiedIndex,
+    collection: &SearchCollection,
+    filters: &EventSearchFilters,
+    presentations: &[SearchPresentation<'event>],
+    refresh_status: &str,
+    refresh_source_count: usize,
+    query_duration: Duration,
+) -> Result<Value> {
+    render_search_json(SearchJsonInput {
+        request,
+        data_root,
+        index,
+        collection,
+        filters,
+        presentations,
+        metrics: SearchRenderMetrics {
+            refresh_status,
+            refresh_source_count,
+            query_duration,
+        },
+    })
+}
 
-pub(super) const SEARCH_JSON: SearchJsonCompatibilityFn =
-    |request,
-     data_root,
-     index,
-     collection,
-     filters,
-     core_records,
-     refresh_status,
-     refresh_source_count,
-     query_duration| {
-        render_search_json(SearchJsonInput {
-            request,
-            data_root,
-            index,
-            collection,
-            filters,
-            core_records,
-            metrics: SearchRenderMetrics {
-                refresh_status,
-                refresh_source_count,
-                query_duration,
-            },
-        })
-    };
-pub(super) use self::SEARCH_JSON as search_json;
-
-fn render_search_json(input: SearchJsonInput<'_>) -> Result<Value> {
+fn render_search_json(input: SearchJsonInput<'_, '_>) -> Result<Value> {
     let SearchJsonInput {
         request,
         data_root,
         index,
         collection,
         filters,
-        core_records,
+        presentations,
         metrics,
     } = input;
     let normalized_query = NormalizedSearchQuery::from_request(request);
     let result_scope = if request.events { "event" } else { "session" };
     let command_prefix = follow_up_command_prefix(data_root);
+    if presentations.len() != collection.result_window.hits.len() {
+        return Err(anyhow!(
+            "pinned Core lookup returned {} search presentations for {} hits",
+            presentations.len(),
+            collection.result_window.hits.len()
+        ));
+    }
     let results = collection
         .result_window
         .hits
         .iter()
+        .zip(presentations)
         .enumerate()
-        .map(|(offset, hit)| {
-            let core_record = core_records
-                .get(&hit.event.event_id.as_uuid())
-                .ok_or_else(|| {
-                    anyhow!(
-                        "pinned Core lookup omitted search event {}",
-                        hit.event.event_id
-                    )
-                })?;
+        .map(|(offset, (hit, presentation))| {
+            if presentation.event.event_id != hit.event.event_id {
+                return Err(anyhow!(
+                    "pinned Core lookup returned an out-of-order search presentation for event {}",
+                    hit.event.event_id
+                ));
+            }
             search_result_json(
                 hit,
-                core_record,
+                presentation,
                 result_scope,
                 &normalized_query,
                 offset.saturating_add(1),
@@ -195,16 +184,16 @@ fn render_search_json(input: SearchJsonInput<'_>) -> Result<Value> {
 
 fn search_result_json(
     hit: &SearchHit,
-    core_record: &SearchCorePresentation,
+    presentation: &SearchPresentation<'_>,
     result_scope: &str,
     query: &NormalizedSearchQuery,
     rank: usize,
     command_prefix: &str,
 ) -> Result<Value> {
-    let (snippet, snippet_truncated) = search_snippet(core_record)?;
-    let event = &core_record.record.event;
-    let event_id = event.event_id.as_uuid();
-    let session_id = event.session_id.as_uuid();
+    let (snippet, snippet_truncated) = search_snippet(presentation);
+    let event = &presentation.event;
+    let event_id = event.event_id;
+    let session_id = event.session_id;
     let item_id = if result_scope == "session" {
         session_id
     } else {
@@ -247,8 +236,8 @@ fn search_result_json(
         "provider": event.provider,
         "provider_session_id": event.provider_session_id,
         "source_format": event.source_format,
-        "parent_ctx_session_id": event.parent_session_id.map(|id| id.as_uuid()),
-        "root_ctx_session_id": event.root_session_id.as_uuid(),
+        "parent_ctx_session_id": event.parent_session_id,
+        "root_ctx_session_id": event.root_session_id,
         "branch": event.branch,
         "agent_type": event.agent_type,
         "is_primary": event.is_primary,
@@ -269,21 +258,13 @@ fn search_result_json(
     })))
 }
 
-fn search_snippet(record: &SearchCorePresentation) -> Result<(&str, bool)> {
-    let body = record
-        .record
-        .core_record
-        .content
-        .normalized_body
-        .as_deref()
-        .filter(|body| !body.is_empty())
-        .ok_or_else(|| {
-            anyhow!(
-                "Core search event {} has no normalized body",
-                record.record.event_id
-            )
-        })?;
-    Ok((body, record.snippet_truncated))
+fn search_snippet<'presentation>(
+    presentation: &'presentation SearchPresentation<'_>,
+) -> (&'presentation str, bool) {
+    (
+        presentation.snippet.as_str(),
+        presentation.snippet_truncated,
+    )
 }
 
 pub(in crate::commands::source_index) fn search_snippet_fragment(
@@ -297,7 +278,7 @@ pub(in crate::commands::source_index) fn search_snippet_fragment(
         body.graphemes(true).count()
     };
     if grapheme_count <= SEARCH_SNIPPET_MAX_CHARS {
-        return (body.to_owned(), false);
+        return byte_bounded_search_snippet(body, query_texts, false);
     }
 
     let start = query_match_range(body, query_texts).map_or(0, |matched| {
@@ -313,9 +294,155 @@ pub(in crate::commands::source_index) fn search_snippet_fragment(
     } else {
         grapheme_byte_range(body, start, end)
     };
-    let snippet = body[byte_range].to_owned();
+    let snippet = &body[byte_range];
     let truncated = start > 0 || end < grapheme_count;
-    (snippet, truncated)
+    byte_bounded_search_snippet(snippet, query_texts, truncated)
+}
+
+fn byte_bounded_search_snippet(
+    snippet: &str,
+    query_texts: &[&str],
+    truncated: bool,
+) -> (String, bool) {
+    if snippet.len() <= SEARCH_SNIPPET_MAX_BYTES {
+        return (snippet.to_owned(), truncated);
+    }
+
+    let graphemes = snippet
+        .grapheme_indices(true)
+        .map(|(start, grapheme)| start..start.saturating_add(grapheme.len()))
+        .collect::<Vec<_>>();
+    let matched = query_match_range(snippet, query_texts);
+    let match_containing = matched
+        .as_ref()
+        .and_then(|matched| grapheme_span_covering_match(&graphemes, matched))
+        .filter(|required| grapheme_window_bytes(&graphemes, required) <= SEARCH_SNIPPET_MAX_BYTES)
+        .and_then(|required| {
+            match_containing_grapheme_window(&graphemes, &required, matched.as_ref())
+        });
+    let window =
+        match_containing.or_else(|| fallback_grapheme_window(&graphemes, matched.as_ref()));
+    let Some(window) = window else {
+        // A valid Core body can contain one extended grapheme cluster larger
+        // than the presentation byte cap. Keep the hit and its truncation
+        // signal without retaining or splitting that cluster.
+        return (String::new(), true);
+    };
+    (snippet[window].to_owned(), true)
+}
+
+fn match_containing_grapheme_window(
+    graphemes: &[Range<usize>],
+    required: &Range<usize>,
+    matched: Option<&Range<usize>>,
+) -> Option<Range<usize>> {
+    let required_center = matched.map_or_else(
+        || {
+            graphemes[required.start]
+                .start
+                .saturating_add(graphemes[required.end - 1].end)
+        },
+        |matched| matched.start.saturating_add(matched.end),
+    );
+    // Retain the largest complete-grapheme window containing the required
+    // match span, then prefer the window whose byte midpoint is closest to the
+    // match midpoint. The final start offset makes ties deterministic.
+    let mut best: Option<(Range<usize>, usize, usize)> = None;
+    for start in 0..=required.start {
+        for end in required.end..=graphemes.len() {
+            let bytes = graphemes[end - 1]
+                .end
+                .saturating_sub(graphemes[start].start);
+            if bytes > SEARCH_SNIPPET_MAX_BYTES {
+                break;
+            }
+            let center = graphemes[start]
+                .start
+                .saturating_add(graphemes[end - 1].end);
+            let center_distance = center.abs_diff(required_center);
+            let replace = best
+                .as_ref()
+                .is_none_or(|(best_range, best_bytes, best_distance)| {
+                    bytes > *best_bytes
+                        || (bytes == *best_bytes && center_distance < *best_distance)
+                        || (bytes == *best_bytes
+                            && center_distance == *best_distance
+                            && graphemes[start].start < best_range.start)
+                });
+            if replace {
+                best = Some((
+                    graphemes[start].start..graphemes[end - 1].end,
+                    bytes,
+                    center_distance,
+                ));
+            }
+        }
+    }
+    best.map(|(window, _, _)| window)
+}
+
+fn fallback_grapheme_window(
+    graphemes: &[Range<usize>],
+    matched: Option<&Range<usize>>,
+) -> Option<Range<usize>> {
+    let match_center = matched.map(|matched| matched.start.saturating_add(matched.end));
+    let mut best: Option<(Range<usize>, usize, usize)> = None;
+    for start in 0..graphemes.len() {
+        for end in start.saturating_add(1)..=graphemes.len() {
+            let bytes = graphemes[end - 1]
+                .end
+                .saturating_sub(graphemes[start].start);
+            if bytes > SEARCH_SNIPPET_MAX_BYTES {
+                break;
+            }
+            let window = graphemes[start].start..graphemes[end - 1].end;
+            let match_distance = match_center.map_or(0, |center| {
+                if center < window.start.saturating_mul(2) {
+                    window.start.saturating_mul(2).saturating_sub(center)
+                } else if center > window.end.saturating_mul(2) {
+                    center.saturating_sub(window.end.saturating_mul(2))
+                } else {
+                    0
+                }
+            });
+            let replace = best
+                .as_ref()
+                .is_none_or(|(best_window, best_bytes, best_distance)| {
+                    (matched.is_some() && match_distance < *best_distance)
+                        || (matched.is_some()
+                            && match_distance == *best_distance
+                            && bytes > *best_bytes)
+                        || (matched.is_none() && bytes > *best_bytes)
+                        || (match_distance == *best_distance
+                            && bytes == *best_bytes
+                            && window.start < best_window.start)
+                });
+            if replace {
+                best = Some((window, bytes, match_distance));
+            }
+        }
+    }
+    best.map(|(window, _, _)| window)
+}
+
+fn grapheme_window_bytes(graphemes: &[Range<usize>], window: &Range<usize>) -> usize {
+    graphemes[window.end - 1]
+        .end
+        .saturating_sub(graphemes[window.start].start)
+}
+
+fn grapheme_span_covering_match(
+    graphemes: &[Range<usize>],
+    matched: &Range<usize>,
+) -> Option<Range<usize>> {
+    let start = graphemes
+        .iter()
+        .position(|grapheme| grapheme.end > matched.start)?;
+    let end = graphemes
+        .iter()
+        .rposition(|grapheme| grapheme.start < matched.end)?
+        .saturating_add(1);
+    (start < end).then_some(start..end)
 }
 
 fn centered_snippet_start(body: &str, grapheme_count: usize, matched: Range<usize>) -> usize {

--- a/crates/ctx-cli/src/commands/source_index/render/tests.rs
+++ b/crates/ctx-cli/src/commands/source_index/render/tests.rs
@@ -8,7 +8,7 @@ use unicode_width::UnicodeWidthStr as _;
 
 use super::{
     render_search_document, render_show_document, render_show_jsonl, render_show_markdown,
-    render_show_text, search_snippet_fragment, SEARCH_SNIPPET_MAX_CHARS,
+    render_show_text, search_snippet_fragment, SEARCH_SNIPPET_MAX_BYTES, SEARCH_SNIPPET_MAX_CHARS,
 };
 use crate::{
     cli::Cli,
@@ -63,6 +63,36 @@ fn search_snippet_keeps_combining_and_emoji_graphemes_intact() {
     assert_eq!(graphemes.first().copied(), Some(combining));
     assert_eq!(graphemes.last().copied(), Some(family));
     assert!(snippet.contains("目标"));
+}
+
+#[test]
+fn search_snippet_byte_bounds_pathological_large_grapheme_clusters_around_the_query() {
+    let oversized_cluster = format!("x{}", "\u{301}".repeat(SEARCH_SNIPPET_MAX_BYTES));
+    let body = format!("{oversized_cluster}needle{oversized_cluster}");
+
+    let (snippet, truncated) = search_snippet_fragment(&body, &["needle"]);
+
+    assert!(truncated);
+    assert!(snippet.len() <= SEARCH_SNIPPET_MAX_BYTES);
+    assert!(snippet.contains("needle"));
+    let start = body.find(&snippet).expect("snippet remains a body window");
+    let end = start + snippet.len();
+    assert!(body
+        .grapheme_indices(true)
+        .any(|(offset, _)| offset == start));
+    assert!(end == body.len() || body.grapheme_indices(true).any(|(offset, _)| offset == end));
+    assert_eq!(snippet.graphemes(true).next(), Some("n"));
+    assert_eq!(snippet.graphemes(true).next_back(), Some("e"));
+    assert!(!snippet.starts_with('\u{301}'));
+    assert!(!snippet.ends_with('\u{301}'));
+
+    let first = search_snippet_fragment(&oversized_cluster, &["x"]);
+    let second = search_snippet_fragment(&oversized_cluster, &["x"]);
+    assert_eq!(first, second);
+    assert_eq!(first, (String::new(), true));
+
+    let metadata_only = search_snippet_fragment(&oversized_cluster, &[]);
+    assert_eq!(metadata_only, (String::new(), true));
 }
 
 #[test]

--- a/crates/ctx-cli/src/commands/source_index/search.rs
+++ b/crates/ctx-cli/src/commands/source_index/search.rs
@@ -41,13 +41,13 @@ use super::{
     shared::{index_root, render_active_generation_race, ActiveGenerationRaceCommand},
 };
 
-use hydration::core_records_for_search_hits;
+use hydration::presentations_for_search_hits;
+pub(in crate::commands::source_index) use hydration::SearchPresentation;
 #[cfg(test)]
 pub(super) use hydration::{
-    core_records_for_search_hits_with_budget, SearchCoreHydrationBudget,
-    SearchCoreHydrationBudgetExceeded, SearchCoreHydrationBudgetStage,
-    SEARCH_CORE_BODY_PREFIX_CHARS, SEARCH_CORE_HYDRATION_BUDGET,
-    SEARCH_CORE_MAX_RETAINED_BODY_BYTES,
+    presentations_for_search_hits_with_budget, SearchPresentationHydrationBudget,
+    SearchPresentationRetentionBudgetExceeded, SEARCH_PRESENTATION_HYDRATION_BUDGET,
+    SEARCH_PRESENTATION_MAX_RETAINED_SNIPPET_BYTES,
 };
 pub(crate) use query::SourceSearchRequest;
 pub(super) use query::{index_search_filters, NormalizedSearchQuery};
@@ -91,9 +91,55 @@ pub(super) struct SemanticFallbackDiagnostics {
 
 #[derive(Debug, Clone)]
 pub(super) struct SearchHit {
-    pub(super) event: EventRecord,
+    pub(super) event: SearchEventMetadata,
     pub(super) score: f32,
     pub(super) more_matches_in_session: usize,
+}
+
+/// The exact immutable event fields retained after candidate shaping and used
+/// by search presentation, rendering, and context accounting. Large source,
+/// native-identity, and touched-file metadata stays outside the result window.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::commands::source_index) struct SearchEventMetadata {
+    pub(in crate::commands::source_index) event_id: Uuid,
+    pub(in crate::commands::source_index) session_id: Uuid,
+    pub(in crate::commands::source_index) parent_session_id: Option<Uuid>,
+    pub(in crate::commands::source_index) root_session_id: Uuid,
+    pub(in crate::commands::source_index) provider: String,
+    pub(in crate::commands::source_index) source_format: String,
+    pub(in crate::commands::source_index) provider_session_id: Option<String>,
+    pub(in crate::commands::source_index) branch: Option<String>,
+    pub(in crate::commands::source_index) agent_type: String,
+    pub(in crate::commands::source_index) is_primary: bool,
+    pub(in crate::commands::source_index) event_sequence: u64,
+    pub(in crate::commands::source_index) occurred_at_unix_ms: Option<i64>,
+    pub(in crate::commands::source_index) event_type: String,
+    pub(in crate::commands::source_index) role: Option<String>,
+    pub(in crate::commands::source_index) workspace: Option<String>,
+    pub(in crate::commands::source_index) cwd: Option<String>,
+}
+
+impl From<&EventRecord> for SearchEventMetadata {
+    fn from(event: &EventRecord) -> Self {
+        Self {
+            event_id: event.event_id.as_uuid(),
+            session_id: event.session_id.as_uuid(),
+            parent_session_id: event.parent_session_id.map(|id| id.as_uuid()),
+            root_session_id: event.root_session_id.as_uuid(),
+            provider: event.provider.clone(),
+            source_format: event.source_format.clone(),
+            provider_session_id: event.provider_session_id.clone(),
+            branch: event.branch.clone(),
+            agent_type: event.agent_type.clone(),
+            is_primary: event.is_primary,
+            event_sequence: event.event_sequence,
+            occurred_at_unix_ms: event.occurred_at_unix_ms,
+            event_type: event.event_type.clone(),
+            role: event.role.clone(),
+            workspace: event.workspace.clone(),
+            cwd: event.cwd.clone(),
+        }
+    }
 }
 
 pub(super) struct RefreshOutcome {
@@ -316,7 +362,7 @@ pub(super) fn search_context_observation(
         .result_window
         .hits
         .iter()
-        .map(|hit| hit.event.session_id.as_uuid())
+        .map(|hit| hit.event.session_id)
         .collect::<BTreeSet<_>>();
     let mut matched_normalized_session_bytes = 0_usize;
     for session_id in session_ids {
@@ -417,7 +463,7 @@ pub(super) fn search_existing_generation(
     let collection =
         collect_search_hits_with_backend(request, &index, data_root, semantic_weight, &filters)?;
     let query_duration = query_started.elapsed();
-    let core_records = core_records_for_search_hits(
+    let presentations = presentations_for_search_hits(
         &index,
         &collection.result_window.hits,
         &NormalizedSearchQuery::from_request(request),
@@ -428,7 +474,7 @@ pub(super) fn search_existing_generation(
         &index,
         &collection,
         &filters,
-        &core_records,
+        &presentations,
         refresh_status,
         refresh_source_count,
         query_duration,
@@ -788,7 +834,7 @@ pub(super) fn shape_search_result_window<'a>(
             .into_iter()
             .take(shape_limit)
             .map(|candidate| SearchHit {
-                event: candidate.event.clone(),
+                event: SearchEventMetadata::from(&candidate.event),
                 score: candidate.score,
                 more_matches_in_session: 0,
             })
@@ -809,7 +855,7 @@ pub(super) fn shape_search_result_window<'a>(
             }
             positions.insert(session_id, hits.len());
             hits.push(SearchHit {
-                event: candidate.event.clone(),
+                event: SearchEventMetadata::from(&candidate.event),
                 score: candidate.score,
                 more_matches_in_session: 0,
             });

--- a/crates/ctx-cli/src/commands/source_index/search/hydration.rs
+++ b/crates/ctx-cli/src/commands/source_index/search/hydration.rs
@@ -1,171 +1,168 @@
-use std::{collections::HashMap, fmt};
+use std::{collections::BTreeSet, fmt};
 
 use anyhow::{anyhow, Result};
-use ctx_history_core::{CoreRecord, MAX_CORE_CONTENT_BYTES, MAX_ENCODED_CORE_RECORD_BYTES};
+use ctx_history_core::{MAX_CORE_CONTENT_BYTES, MAX_ENCODED_CORE_RECORD_BYTES};
 use ctx_history_index::{CoreEventPageBudget, CoreEventRecord, VerifiedIndex};
 use uuid::Uuid;
 
 use crate::MAX_SEARCH_LIMIT;
 
-use super::{NormalizedSearchQuery, SearchHit};
-use crate::commands::source_index::render::{
-    search_snippet_fragment, SearchCorePresentation, SEARCH_SNIPPET_MAX_CHARS,
-};
+use super::{NormalizedSearchQuery, SearchEventMetadata, SearchHit};
+use crate::commands::source_index::render::{search_snippet_fragment, SEARCH_SNIPPET_MAX_BYTES};
 
-#[cfg(test)]
-pub(in crate::commands::source_index) const SEARCH_CORE_BODY_PREFIX_CHARS: usize =
-    SEARCH_SNIPPET_MAX_CHARS;
-const MAX_UTF8_CHAR_BYTES: usize = 4;
-pub(in crate::commands::source_index) const SEARCH_CORE_MAX_RETAINED_BODY_BYTES: usize =
-    MAX_SEARCH_LIMIT * SEARCH_SNIPPET_MAX_CHARS * MAX_UTF8_CHAR_BYTES;
-const SEARCH_CORE_MAX_AGGREGATE_ENCODED_BYTES: usize = MAX_ENCODED_CORE_RECORD_BYTES;
-const SEARCH_CORE_MAX_AGGREGATE_CONTENT_BYTES: usize = MAX_CORE_CONTENT_BYTES;
+const SEARCH_CORE_RECORD_BUDGET: CoreEventPageBudget =
+    CoreEventPageBudget::new(MAX_ENCODED_CORE_RECORD_BYTES, MAX_CORE_CONTENT_BYTES);
+pub(in crate::commands::source_index) const SEARCH_PRESENTATION_MAX_RETAINED_SNIPPET_BYTES: usize =
+    MAX_SEARCH_LIMIT * SEARCH_SNIPPET_MAX_BYTES;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::commands::source_index) struct SearchCoreHydrationBudget {
-    pub(in crate::commands::source_index) maximum_encoded_core_bytes: usize,
-    pub(in crate::commands::source_index) maximum_content_bytes: usize,
-    pub(in crate::commands::source_index) maximum_retained_body_bytes: usize,
+/// Compact, non-authoritative search state derived from one complete stored
+/// Core record. Event metadata is borrowed from the already compact result
+/// window; only the snippet is newly retained.
+#[derive(Debug, PartialEq, Eq)]
+pub(in crate::commands::source_index) struct SearchPresentation<'event> {
+    pub(in crate::commands::source_index) event: &'event SearchEventMetadata,
+    pub(in crate::commands::source_index) snippet: String,
+    pub(in crate::commands::source_index) snippet_truncated: bool,
 }
 
-pub(in crate::commands::source_index) const SEARCH_CORE_HYDRATION_BUDGET:
-    SearchCoreHydrationBudget = SearchCoreHydrationBudget {
-    maximum_encoded_core_bytes: SEARCH_CORE_MAX_AGGREGATE_ENCODED_BYTES,
-    maximum_content_bytes: SEARCH_CORE_MAX_AGGREGATE_CONTENT_BYTES,
-    maximum_retained_body_bytes: SEARCH_CORE_MAX_RETAINED_BODY_BYTES,
-};
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::commands::source_index) enum SearchCoreHydrationBudgetStage {
-    Decode,
-    Retention,
+pub(in crate::commands::source_index) struct SearchPresentationHydrationBudget {
+    pub(in crate::commands::source_index) maximum_retained_snippet_bytes: usize,
 }
+
+pub(in crate::commands::source_index) const SEARCH_PRESENTATION_HYDRATION_BUDGET:
+    SearchPresentationHydrationBudget = SearchPresentationHydrationBudget {
+    maximum_retained_snippet_bytes: SEARCH_PRESENTATION_MAX_RETAINED_SNIPPET_BYTES,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(in crate::commands::source_index) struct SearchCoreHydrationBudgetExceeded {
+pub(in crate::commands::source_index) struct SearchPresentationRetentionBudgetExceeded {
     pub(in crate::commands::source_index) event_id: Uuid,
-    pub(in crate::commands::source_index) stage: SearchCoreHydrationBudgetStage,
-    pub(in crate::commands::source_index) admitted_encoded_core_bytes: usize,
-    pub(in crate::commands::source_index) maximum_encoded_core_bytes: usize,
-    pub(in crate::commands::source_index) admitted_content_bytes: usize,
-    pub(in crate::commands::source_index) maximum_content_bytes: usize,
-    pub(in crate::commands::source_index) retained_body_bytes: usize,
-    pub(in crate::commands::source_index) maximum_retained_body_bytes: usize,
+    pub(in crate::commands::source_index) retained_snippet_bytes: usize,
+    pub(in crate::commands::source_index) maximum_retained_snippet_bytes: usize,
 }
 
-impl fmt::Display for SearchCoreHydrationBudgetExceeded {
+impl fmt::Display for SearchPresentationRetentionBudgetExceeded {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             formatter,
-            "Core search event {} cannot fit the aggregate search {:?} budget (encoded Core: {}/{}, decoded content: {}/{}, retained snippet bodies: {}/{})",
+            "Core search event {} cannot fit the bounded search presentation retention budget (retained snippets: {}/{})",
             self.event_id,
-            self.stage,
-            self.admitted_encoded_core_bytes,
-            self.maximum_encoded_core_bytes,
-            self.admitted_content_bytes,
-            self.maximum_content_bytes,
-            self.retained_body_bytes,
-            self.maximum_retained_body_bytes,
+            self.retained_snippet_bytes,
+            self.maximum_retained_snippet_bytes,
         )
     }
 }
 
-impl std::error::Error for SearchCoreHydrationBudgetExceeded {}
+impl std::error::Error for SearchPresentationRetentionBudgetExceeded {}
 
-pub(super) fn core_records_for_search_hits(
+pub(super) fn presentations_for_search_hits<'event>(
     index: &VerifiedIndex,
-    hits: &[SearchHit],
+    hits: &'event [SearchHit],
     query: &NormalizedSearchQuery,
-) -> Result<HashMap<Uuid, SearchCorePresentation>> {
-    core_records_for_search_hits_with_budget(index, hits, query, SEARCH_CORE_HYDRATION_BUDGET)
+) -> Result<Vec<SearchPresentation<'event>>> {
+    presentations_for_search_hits_with_budget(
+        index,
+        hits,
+        query,
+        SEARCH_PRESENTATION_HYDRATION_BUDGET,
+    )
 }
 
-pub(in crate::commands::source_index) fn core_records_for_search_hits_with_budget(
+pub(in crate::commands::source_index) fn presentations_for_search_hits_with_budget<'event>(
     index: &VerifiedIndex,
-    hits: &[SearchHit],
+    hits: &'event [SearchHit],
     query: &NormalizedSearchQuery,
-    budget: SearchCoreHydrationBudget,
-) -> Result<HashMap<Uuid, SearchCorePresentation>> {
-    if budget.maximum_encoded_core_bytes == 0
-        || budget.maximum_content_bytes == 0
-        || budget.maximum_retained_body_bytes == 0
-    {
-        return Err(anyhow!("Core search hydration budgets must be positive"));
+    budget: SearchPresentationHydrationBudget,
+) -> Result<Vec<SearchPresentation<'event>>> {
+    if budget.maximum_retained_snippet_bytes == 0 {
+        return Err(anyhow!(
+            "search presentation hydration budget must be positive"
+        ));
+    }
+
+    let mut requested = BTreeSet::new();
+    for hit in hits {
+        if !requested.insert(hit.event.event_id) {
+            return Err(anyhow!(
+                "search result duplicated Core event {}",
+                hit.event.event_id
+            ));
+        }
     }
 
     let event_ids = hits
         .iter()
-        .map(|hit| hit.event.event_id.as_uuid())
+        .map(|hit| hit.event.event_id)
         .collect::<Vec<_>>();
-    let page_budget = CoreEventPageBudget::new(
-        budget.maximum_encoded_core_bytes,
-        budget.maximum_content_bytes,
-    );
-    // Resolve all selected addresses with one bounded Tantivy query. The
-    // aggregate encoded/content ceilings bound complete decoded records for
-    // this batch. Each record is reduced to its compact query-centered
-    // presentation before it enters the returned map.
-    let batch = index
-        .core_events_by_ids_with_strict_budget(&event_ids, event_ids.len(), page_budget)?
+    // Execute one generation-pinned Tantivy selection. The returned iterator
+    // decodes exactly one complete Core record at a time, allowing each body
+    // to be projected and discarded before the next record is materialized.
+    let mut records = index
+        .stream_core_events_by_ids_with_strict_per_record_budget(
+            &event_ids,
+            hits.len(),
+            SEARCH_CORE_RECORD_BUDGET,
+        )?
         .ok_or_else(|| {
-            search_core_hydration_budget_error(
-                event_ids.first().copied().unwrap_or_else(Uuid::nil),
-                SearchCoreHydrationBudgetStage::Decode,
-                0,
-                0,
-                0,
-                budget,
+            anyhow!(
+                "pinned Core lookup omitted search event {}",
+                event_ids.first().copied().unwrap_or_else(Uuid::nil)
             )
         })?;
-    let admitted_encoded_core_bytes = batch.encoded_core_bytes;
-    let admitted_content_bytes = batch.content_bytes;
-    let mut records = HashMap::with_capacity(hits.len());
-    let mut retained_body_bytes = 0_usize;
     let query_texts = query.texts();
-    for (event_id, record) in event_ids.into_iter().zip(batch.items) {
-        if record.event_id.as_uuid() != event_id {
-            return Err(anyhow!(
-                "pinned Core lookup returned an invalid record for search event {event_id}"
-            ));
-        }
-        let (record, body_bytes) = search_core_presentation_projection(record, &query_texts)?;
-        let next_retained_body_bytes =
-            retained_body_bytes.checked_add(body_bytes).ok_or_else(|| {
-                search_core_hydration_budget_error(
-                    event_id,
-                    SearchCoreHydrationBudgetStage::Retention,
-                    admitted_encoded_core_bytes,
-                    admitted_content_bytes,
-                    retained_body_bytes,
-                    budget,
-                )
+    let mut presentations = Vec::with_capacity(hits.len());
+    let mut retained_snippet_bytes = 0_usize;
+    for hit in hits {
+        let event_id = hit.event.event_id;
+        let record = records
+            .next()
+            .transpose()?
+            .ok_or_else(|| anyhow!("pinned Core lookup omitted search event {event_id}"))?;
+
+        let (presentation, snippet_bytes) =
+            search_presentation_projection(record, &hit.event, &query_texts)?;
+        let next_retained_snippet_bytes = retained_snippet_bytes
+            .checked_add(snippet_bytes)
+            .ok_or_else(|| {
+                search_presentation_retention_budget_error(event_id, retained_snippet_bytes, budget)
             })?;
-        if next_retained_body_bytes > budget.maximum_retained_body_bytes {
-            return Err(search_core_hydration_budget_error(
+        if next_retained_snippet_bytes > budget.maximum_retained_snippet_bytes {
+            return Err(search_presentation_retention_budget_error(
                 event_id,
-                SearchCoreHydrationBudgetStage::Retention,
-                admitted_encoded_core_bytes,
-                admitted_content_bytes,
-                next_retained_body_bytes,
+                next_retained_snippet_bytes,
                 budget,
             ));
         }
-        retained_body_bytes = next_retained_body_bytes;
-        if records.insert(event_id, record).is_some() {
-            return Err(anyhow!("search result duplicated Core event {event_id}"));
-        }
+        retained_snippet_bytes = next_retained_snippet_bytes;
+        presentations.push(presentation);
     }
-    Ok(records)
+    if records.next().transpose()?.is_some() {
+        return Err(anyhow!(
+            "pinned Core lookup returned more search records than requested"
+        ));
+    }
+    Ok(presentations)
 }
 
-fn search_core_presentation_projection(
+fn search_presentation_projection<'event>(
     record: CoreEventRecord,
+    expected_event: &'event SearchEventMetadata,
     query_texts: &[&str],
-) -> Result<(SearchCorePresentation, usize)> {
+) -> Result<(SearchPresentation<'event>, usize)> {
     let CoreEventRecord {
         event,
         mut core_record,
     } = record;
+    if event.event_id != core_record.event_id
+        || event.session_id != core_record.session_id
+        || SearchEventMetadata::from(&event) != *expected_event
+    {
+        return Err(anyhow!(
+            "pinned Core lookup returned misaligned metadata for search event {}",
+            expected_event.event_id
+        ));
+    }
     let body = core_record
         .content
         .normalized_body
@@ -177,46 +174,32 @@ fn search_core_presentation_projection(
                 event.event_id
             )
         })?;
-    let (fragment, snippet_truncated) = search_snippet_fragment(&body, query_texts);
-    let retained_body_bytes = fragment.len();
+    let (snippet, snippet_truncated) = search_snippet_fragment(&body, query_texts);
+    let retained_snippet_bytes = snippet.len();
 
-    let core_record = CoreRecord::new_selected(
-        core_record.event_id,
-        core_record.session_id,
-        core_record.root_session_id,
-        core_record.source,
-        core_record.event_sequence,
-        core_record.event_type,
-        core_record.agent_type,
-        core_record.is_primary,
-        "search-presentation-v2",
-        fragment,
-    )?;
+    // Neither the complete body nor the remainder of Core crosses the search
+    // presentation boundary.
+    drop(body);
+    drop(event);
+    drop(core_record);
     Ok((
-        SearchCorePresentation {
-            record: CoreEventRecord { event, core_record },
+        SearchPresentation {
+            event: expected_event,
+            snippet,
             snippet_truncated,
         },
-        retained_body_bytes,
+        retained_snippet_bytes,
     ))
 }
 
-fn search_core_hydration_budget_error(
+fn search_presentation_retention_budget_error(
     event_id: Uuid,
-    stage: SearchCoreHydrationBudgetStage,
-    admitted_encoded_core_bytes: usize,
-    admitted_content_bytes: usize,
-    retained_body_bytes: usize,
-    budget: SearchCoreHydrationBudget,
+    retained_snippet_bytes: usize,
+    budget: SearchPresentationHydrationBudget,
 ) -> anyhow::Error {
-    anyhow::Error::new(SearchCoreHydrationBudgetExceeded {
+    anyhow::Error::new(SearchPresentationRetentionBudgetExceeded {
         event_id,
-        stage,
-        admitted_encoded_core_bytes,
-        maximum_encoded_core_bytes: budget.maximum_encoded_core_bytes,
-        admitted_content_bytes,
-        maximum_content_bytes: budget.maximum_content_bytes,
-        retained_body_bytes,
-        maximum_retained_body_bytes: budget.maximum_retained_body_bytes,
+        retained_snippet_bytes,
+        maximum_retained_snippet_bytes: budget.maximum_retained_snippet_bytes,
     })
 }

--- a/crates/ctx-cli/src/commands/source_index/tests.rs
+++ b/crates/ctx-cli/src/commands/source_index/tests.rs
@@ -5,7 +5,6 @@ mod tests {
 
     use std::{
         cell::Cell,
-        collections::HashMap,
         fs,
         io::{self, Write},
         sync::{Arc, Mutex},
@@ -18,8 +17,11 @@ mod tests {
     };
     use ctx_history_core::{
         derive_event_id, derive_session_id, CertifiedSource, CoreContentPolicyStatus, CoreRecord,
-        EventIdentityInput, NativeItemKey, NativeSessionKey, ScannedSourceCounts,
+        EventIdentityInput, NativeItemKey, NativeSessionKey, RepositoryBinding,
+        RepositoryEvidence, RepositoryEvidenceConfidence, RepositoryEvidenceKind,
+        RepositoryFileObservation, RepositoryFileObservationKind, ScannedSourceCounts,
         SessionIdentityInput, SourceAnchor, SourceKey, SourceObservation, TypedKey,
+        MAX_CORE_CONTENT_BYTES,
     };
     use ctx_history_index::{
         EventSearchFilters, GenerationWriter, IndexError, SessionRecord, WriterOptions,
@@ -38,13 +40,16 @@ mod tests {
 
     use super::*;
     use super::{
-        render::{render_show_document, search_json, SearchCorePresentation},
+        render::{
+            render_show_document, search_json, SEARCH_SNIPPET_MAX_BYTES, SEARCH_SNIPPET_MAX_CHARS,
+        },
         search::{
-            core_records_for_search_hits_with_budget, NormalizedSearchQuery, SearchCollection,
-            SearchCoreHydrationBudget, SearchCoreHydrationBudgetExceeded,
-            SearchCoreHydrationBudgetStage, SearchHit, SearchResultWindow,
-            SEARCH_CORE_BODY_PREFIX_CHARS, SEARCH_CORE_HYDRATION_BUDGET,
-            SEARCH_CORE_MAX_RETAINED_BODY_BYTES,
+            presentations_for_search_hits_with_budget, NormalizedSearchQuery, SearchCollection,
+            SearchEventMetadata, SearchHit, SearchPresentation,
+            SearchPresentationHydrationBudget, SearchPresentationRetentionBudgetExceeded,
+            SearchResultWindow,
+            SEARCH_PRESENTATION_HYDRATION_BUDGET,
+            SEARCH_PRESENTATION_MAX_RETAINED_SNIPPET_BYTES,
         },
         show::{
             canonical_show_output_bytes, core_events_by_ids_with_presentation_limits, event_window,
@@ -158,7 +163,6 @@ mod tests {
         write_test_generation(temp.path());
         let index = open_index(temp.path()).unwrap();
         let event = fixture_event(CaptureProvider::Codex, "codex_session_jsonl", 31, 1);
-        let event_id = event.event_id.as_uuid();
         let core_event = fixture_core_event(&event, "Core-owned search snippet");
         let mut source_request = request(RefreshArg::Off);
         source_request.query = "  primary query ".to_owned();
@@ -168,7 +172,7 @@ mod tests {
             result_window: SearchResultWindow {
                 limit: 1,
                 hits: vec![SearchHit {
-                    event,
+                    event: SearchEventMetadata::from(&event),
                     score: 1.0,
                     more_matches_in_session: 0,
                 }],
@@ -190,13 +194,11 @@ mod tests {
             &index,
             &collection,
             &EventSearchFilters::default(),
-            &HashMap::from([(
-                event_id,
-                SearchCorePresentation {
-                    record: core_event,
-                    snippet_truncated: false,
-                },
-            )]),
+            &[fixture_search_presentation(
+                &collection.result_window.hits[0].event,
+                core_event,
+                false,
+            )],
             "existing_generation",
             1,
             std::time::Duration::ZERO,
@@ -279,12 +281,12 @@ mod tests {
                 limit: 2,
                 hits: vec![
                     SearchHit {
-                        event: first,
+                        event: SearchEventMetadata::from(&first),
                         score: 0.25,
                         more_matches_in_session: 0,
                     },
                     SearchHit {
-                        event: second,
+                        event: SearchEventMetadata::from(&second),
                         score: 9.5,
                         more_matches_in_session: 0,
                     },
@@ -300,28 +302,25 @@ mod tests {
             semantic_fallback: None,
             semantic_diagnostics: None,
         };
+        let mut presentations = [
+            fixture_search_presentation(
+                &collection.result_window.hits[0].event,
+                first_core,
+                false,
+            ),
+            fixture_search_presentation(
+                &collection.result_window.hits[1].event,
+                second_core,
+                false,
+            ),
+        ];
         let value = search_json(
             &source_request,
             temp.path(),
             &index,
             &collection,
             &EventSearchFilters::default(),
-            &HashMap::from([
-                (
-                    first_id,
-                    SearchCorePresentation {
-                        record: first_core,
-                        snippet_truncated: false,
-                    },
-                ),
-                (
-                    second_id,
-                    SearchCorePresentation {
-                        record: second_core,
-                        snippet_truncated: false,
-                    },
-                ),
-            ]),
+            &presentations,
             "existing_generation",
             1,
             std::time::Duration::ZERO,
@@ -335,6 +334,23 @@ mod tests {
         assert_eq!(results[1]["rank"], 2);
         assert_eq!(results[0]["retrieval_score"], 0.25);
         assert_eq!(results[1]["retrieval_score"], 9.5);
+
+        presentations.swap(0, 1);
+        let error = search_json(
+            &source_request,
+            temp.path(),
+            &index,
+            &collection,
+            &EventSearchFilters::default(),
+            &presentations,
+            "existing_generation",
+            1,
+            std::time::Duration::ZERO,
+        )
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("out-of-order search presentation"));
     }
 
     #[test]
@@ -415,6 +431,15 @@ mod tests {
             })
         );
         assert_eq!(event_value["event"]["provider_session_id"], TEST_SESSION_ID);
+        assert_eq!(
+            event_value["event"]["text"],
+            selected
+                .core_record
+                .content
+                .normalized_body
+                .as_deref()
+                .unwrap()
+        );
         assert!(event_value["event"].get("source").is_none());
         assert!(event_value["event"].get("cursor").is_none());
     }
@@ -544,6 +569,25 @@ mod tests {
     }
 
     #[test]
+    fn result_window_discards_non_render_event_metadata() {
+        let (event_id, expected, window) = {
+            let mut event =
+                fixture_event(CaptureProvider::Codex, "codex_session_jsonl", 90, 1);
+            event.touched_files = vec!["x".repeat(1024 * 1024)];
+            let event_id = event.event_id.as_uuid();
+            let expected = SearchEventMetadata::from(&event);
+            let candidate = EventSearchCandidate { event, score: 1.0 };
+            let window = shape_search_result_window(std::iter::once(&candidate), 1, true);
+            assert_eq!(window.hits[0].event, expected);
+            (event_id, expected, window)
+        };
+
+        assert_eq!(window.hits.len(), 1);
+        assert_eq!(window.hits[0].event, expected);
+        assert_eq!(window.hits[0].event.event_id, event_id);
+    }
+
+    #[test]
     fn show_provider_session_resolution_is_ambiguous_until_provider_qualified() {
         let temp = tempdir().unwrap();
         write_test_generation(temp.path());
@@ -657,10 +701,11 @@ mod tests {
     }
 
     #[test]
-    fn limit_200_search_retains_compact_query_centered_core_projections() {
+    fn limit_200_search_reduces_each_large_core_body_before_retaining_presentations() {
         let temp = tempdir().unwrap();
-        let body = format!("{} {TEST_QUERY}", "🦀".repeat(4_100));
+        let body = format!("{} {TEST_QUERY}", "x".repeat(96 * 1024));
         let body_bytes = body.len();
+        assert!(body_bytes * crate::MAX_SEARCH_LIMIT > MAX_CORE_CONTENT_BYTES);
         let events = (1..=crate::MAX_SEARCH_LIMIT)
             .map(|sequence| {
                 let event = fixture_event(
@@ -691,52 +736,23 @@ mod tests {
         assert!(!collection.result_window.more_available);
         let normalized_query = NormalizedSearchQuery::from_request(&source_request);
 
-        let core_records = core_records_for_search_hits_with_budget(
+        let presentations = presentations_for_search_hits_with_budget(
             &index,
             &collection.result_window.hits,
             &normalized_query,
-            SEARCH_CORE_HYDRATION_BUDGET,
+            SEARCH_PRESENTATION_HYDRATION_BUDGET,
         )
         .unwrap();
-        let retained_body_bytes = core_records
-            .values()
-            .map(|record| {
-                record
-                    .record
-                    .core_record
-                    .content
-                    .normalized_body
-                    .as_ref()
-                    .map_or(0, String::len)
-            })
+        let retained_snippet_bytes = presentations
+            .iter()
+            .map(|presentation| presentation.snippet.len())
             .sum::<usize>();
-        assert!(retained_body_bytes <= SEARCH_CORE_MAX_RETAINED_BODY_BYTES);
-        assert!(core_records.values().all(|record| {
-            let projected = record.record.core_record.content.normalized_body.as_deref();
-            record.snippet_truncated
-                && projected.is_some_and(|projected| {
-                    projected.chars().count() == SEARCH_CORE_BODY_PREFIX_CHARS
-                        && projected.contains(TEST_QUERY)
-                        && projected.len() < body_bytes
-                })
-                && record
-                    .record
-                    .core_record
-                    .content
-                    .structured_content
-                    .is_none()
-                && record.record.core_record.metadata.is_empty()
-                && record.record.core_record.repository_bindings.is_empty()
-                && record
-                    .record
-                    .core_record
-                    .repository_file_observations
-                    .is_empty()
-                && record
-                    .record
-                    .core_record
-                    .repository_vcs_observations
-                    .is_empty()
+        assert!(retained_snippet_bytes <= SEARCH_PRESENTATION_MAX_RETAINED_SNIPPET_BYTES);
+        assert!(presentations.iter().all(|presentation| {
+            presentation.snippet_truncated
+                && presentation.snippet.chars().count() == SEARCH_SNIPPET_MAX_CHARS
+                && presentation.snippet.contains(TEST_QUERY)
+                && presentation.snippet.len() < body_bytes
         }));
 
         let value = search_json(
@@ -745,7 +761,7 @@ mod tests {
             &index,
             &collection,
             &filters,
-            &core_records,
+            &presentations,
             "existing_generation",
             1,
             std::time::Duration::ZERO,
@@ -754,50 +770,165 @@ mod tests {
         let results = value["results"].as_array().unwrap();
         assert_eq!(results.len(), crate::MAX_SEARCH_LIMIT);
         assert!(results.iter().all(|result| {
-            result["snippet"].as_str().unwrap().chars().count() == SEARCH_CORE_BODY_PREFIX_CHARS
+            result["snippet"].as_str().unwrap().chars().count() == SEARCH_SNIPPET_MAX_CHARS
                 && result["snippet"].as_str().unwrap().contains(TEST_QUERY)
                 && result["snippet_truncated"] == true
-                && result["snippet_max_chars"] == SEARCH_CORE_BODY_PREFIX_CHARS
+                && result["snippet_max_chars"] == SEARCH_SNIPPET_MAX_CHARS
         }));
         assert_eq!(value["result_window"]["returned"], crate::MAX_SEARCH_LIMIT);
         assert_eq!(value["result_window"]["more_available"], false);
 
-        let decode_error = core_records_for_search_hits_with_budget(
+        let retention_error = presentations_for_search_hits_with_budget(
             &index,
             &collection.result_window.hits,
             &normalized_query,
-            SearchCoreHydrationBudget {
-                maximum_encoded_core_bytes: SEARCH_CORE_HYDRATION_BUDGET.maximum_encoded_core_bytes,
-                maximum_content_bytes: body_bytes.checked_mul(crate::MAX_SEARCH_LIMIT).unwrap() - 1,
-                maximum_retained_body_bytes: SEARCH_CORE_HYDRATION_BUDGET
-                    .maximum_retained_body_bytes,
-            },
-        )
-        .unwrap_err();
-        let typed = decode_error
-            .downcast_ref::<SearchCoreHydrationBudgetExceeded>()
-            .expect("aggregate decode failure must stay typed");
-        assert_eq!(typed.stage, SearchCoreHydrationBudgetStage::Decode);
-        assert_eq!(
-            typed.maximum_content_bytes,
-            body_bytes * crate::MAX_SEARCH_LIMIT - 1
-        );
-
-        let retention_error = core_records_for_search_hits_with_budget(
-            &index,
-            &collection.result_window.hits,
-            &normalized_query,
-            SearchCoreHydrationBudget {
-                maximum_retained_body_bytes: retained_body_bytes - 1,
-                ..SEARCH_CORE_HYDRATION_BUDGET
+            SearchPresentationHydrationBudget {
+                maximum_retained_snippet_bytes: retained_snippet_bytes - 1,
+                ..SEARCH_PRESENTATION_HYDRATION_BUDGET
             },
         )
         .unwrap_err();
         let typed = retention_error
-            .downcast_ref::<SearchCoreHydrationBudgetExceeded>()
-            .expect("aggregate retention failure must stay typed");
-        assert_eq!(typed.stage, SearchCoreHydrationBudgetStage::Retention);
-        assert_eq!(typed.retained_body_bytes, retained_body_bytes);
+            .downcast_ref::<SearchPresentationRetentionBudgetExceeded>()
+            .expect("snippet retention failure must stay typed");
+        assert_eq!(typed.retained_snippet_bytes, retained_snippet_bytes);
+    }
+
+    #[test]
+    fn file_only_search_keeps_an_oversized_grapheme_body_without_requiring_a_body_match() {
+        let temp = tempdir().unwrap();
+        let event = fixture_event(CaptureProvider::Codex, "codex_session_jsonl", 94, 1);
+        let oversized_cluster = format!("x{}", "\u{301}".repeat(SEARCH_SNIPPET_MAX_BYTES));
+        let mut stored = fixture_core_event(&event, oversized_cluster);
+        stored.core_record.repository_bindings.push(RepositoryBinding {
+            binding_id: "binding-1".to_owned(),
+            logical_repository_id: "repo-1".to_owned(),
+            checkout_id: None,
+            worktree_id: None,
+            aliases: Vec::new(),
+            git_object_format: None,
+            local_root_authorization: None,
+            evidence: vec![RepositoryEvidence {
+                kind: RepositoryEvidenceKind::FileActivity,
+                confidence: RepositoryEvidenceConfidence::Explicit,
+            }],
+            association_policy_revision:
+                ctx_history_core::CORE_REPOSITORY_ASSOCIATION_POLICY_REVISION,
+        });
+        stored.core_record.repository_file_observations = vec![RepositoryFileObservation {
+            repository_binding_id: "binding-1".to_owned(),
+            relative_path: "src/huge.rs".to_owned(),
+            kind: RepositoryFileObservationKind::Modified,
+            prior_relative_path: None,
+        }];
+        stored.core_record.validate_contract().unwrap();
+        append_fixture_session(temp.path(), std::slice::from_ref(&stored), 94);
+
+        let mut source_request = request(RefreshArg::Off);
+        source_request.query.clear();
+        source_request.file = Some(PathBuf::from("src/huge.rs"));
+        source_request.events = true;
+        source_request.limit = 1;
+        let (value, collection, _) = search_existing_generation(
+            &source_request,
+            open_index(temp.path()).unwrap(),
+            temp.path(),
+            source_request.semantic_weight,
+            "existing_generation",
+            1,
+        )
+        .unwrap();
+
+        assert_eq!(collection.result_window.hits.len(), 1);
+        assert_eq!(
+            value["results"][0]["ctx_event_id"],
+            json!(event.event_id.as_uuid())
+        );
+        assert_eq!(value["results"][0]["snippet"], "");
+        assert_eq!(value["results"][0]["snippet_truncated"], true);
+
+        let (mcp, _) = mcp_search(source_request, temp.path()).unwrap();
+        assert_eq!(
+            mcp["results"][0]["ctx_event_id"],
+            json!(event.event_id.as_uuid())
+        );
+        assert_eq!(mcp["results"][0]["snippet"], "");
+        assert_eq!(mcp["results"][0]["snippet_truncated"], true);
+    }
+
+    #[test]
+    fn search_presentation_hydration_rejects_missing_duplicate_and_misaligned_hits() {
+        let temp = tempdir().unwrap();
+        let event = fixture_event(CaptureProvider::Codex, "codex_session_jsonl", 92, 1);
+        let stored = fixture_core_event(&event, format!("stored {TEST_QUERY} body"));
+        append_fixture_session(temp.path(), std::slice::from_ref(&stored), 92);
+        let index = open_index(temp.path()).unwrap();
+        let query = NormalizedSearchQuery::from_request(&request(RefreshArg::Off));
+        let expected_event = SearchEventMetadata::from(&event);
+        let hit = SearchHit {
+            event: expected_event.clone(),
+            score: 1.0,
+            more_matches_in_session: 0,
+        };
+
+        let presentations = presentations_for_search_hits_with_budget(
+            &index,
+            std::slice::from_ref(&hit),
+            &query,
+            SEARCH_PRESENTATION_HYDRATION_BUDGET,
+        )
+        .unwrap();
+        assert_eq!(presentations.len(), 1);
+        assert_eq!(presentations[0].event, &expected_event);
+
+        let duplicate_error = presentations_for_search_hits_with_budget(
+            &index,
+            &[hit.clone(), hit.clone()],
+            &query,
+            SEARCH_PRESENTATION_HYDRATION_BUDGET,
+        )
+        .unwrap_err();
+        assert!(duplicate_error
+            .to_string()
+            .contains("search result duplicated Core event"));
+
+        let missing_event = fixture_event(
+            CaptureProvider::Codex,
+            "codex_session_jsonl",
+            93,
+            1,
+        );
+        let missing_error = presentations_for_search_hits_with_budget(
+            &index,
+            &[SearchHit {
+                event: SearchEventMetadata::from(&missing_event),
+                score: 1.0,
+                more_matches_in_session: 0,
+            }],
+            &query,
+            SEARCH_PRESENTATION_HYDRATION_BUDGET,
+        )
+        .unwrap_err();
+        assert_eq!(
+            missing_error.to_string(),
+            format!(
+                "pinned Core lookup omitted search event {}",
+                missing_event.event_id
+            )
+        );
+
+        let mut misaligned = hit;
+        misaligned.event.event_sequence += 1;
+        let misaligned_error = presentations_for_search_hits_with_budget(
+            &index,
+            &[misaligned],
+            &query,
+            SEARCH_PRESENTATION_HYDRATION_BUDGET,
+        )
+        .unwrap_err();
+        assert!(misaligned_error
+            .to_string()
+            .contains("misaligned metadata"));
     }
 
     #[test]
@@ -820,7 +951,7 @@ mod tests {
             .iter()
             .map(|result| result["snippet"].as_str().unwrap().len())
             .sum::<usize>();
-        let session_id = collection.result_window.hits[0].event.session_id.as_uuid();
+        let session_id = collection.result_window.hits[0].event.session_id;
         let complete_bytes = index
             .core_events_for_session(session_id)
             .unwrap()

--- a/crates/ctx-cli/src/commands/source_index/tests/fixtures.rs
+++ b/crates/ctx-cli/src/commands/source_index/tests/fixtures.rs
@@ -120,6 +120,25 @@ fn fixture_core_event(event: &EventRecord, body: impl Into<String>) -> CoreEvent
     }
 }
 
+fn fixture_search_presentation<'event>(
+    event: &'event SearchEventMetadata,
+    record: CoreEventRecord,
+    snippet_truncated: bool,
+) -> SearchPresentation<'event> {
+    let snippet = record
+        .core_record
+        .content
+        .normalized_body
+        .as_ref()
+        .expect("search fixture needs normalized body")
+        .clone();
+    SearchPresentation {
+        event,
+        snippet,
+        snippet_truncated,
+    }
+}
+
 fn request(refresh: RefreshArg) -> SourceSearchRequest {
     SourceSearchRequest {
         query: TEST_QUERY.to_owned(),

--- a/crates/ctx-cli/tests/mcp.rs
+++ b/crates/ctx-cli/tests/mcp.rs
@@ -658,6 +658,99 @@ fn mcp_search_returns_structured_json_without_refresh() {
 }
 
 #[test]
+fn mcp_search_keeps_a_hit_whose_matching_grapheme_exceeds_the_snippet_cap() {
+    const SNIPPET_MAX_BYTES: usize = 16 * 1024;
+    const SESSION_ID: &str = "019c0000-0000-7000-8000-000000000002";
+
+    let temp = daemon_test_root();
+    let oversized_cluster = format!("x{}", "\u{301}".repeat(SNIPPET_MAX_BYTES));
+    let fixture = write_codex_message_fixture(
+        &temp.path().join("huge-grapheme-mcp-fixture"),
+        SESSION_ID,
+        &oversized_cluster,
+    );
+    let _daemon = start_mcp_source_refresh_daemon(&temp);
+    json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "codex",
+        "--path",
+        fixture.to_str().unwrap(),
+        "--format=json",
+        "--progress=none",
+        "--no-daemon",
+    ]));
+
+    let requests = [
+        json!({
+            "jsonrpc": "2.0",
+            "id": "init",
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "ctx-test", "version": "0" }
+            }
+        }),
+        json!({
+            "jsonrpc": "2.0",
+            "id": "search-1",
+            "method": "tools/call",
+            "params": {
+                "name": "search",
+                "arguments": {
+                    "query": "x",
+                    "provider": "codex",
+                    "events": true,
+                    "include_current_session": true,
+                    "limit": 1,
+                    "backend": "lexical"
+                }
+            }
+        }),
+        json!({
+            "jsonrpc": "2.0",
+            "id": "search-2",
+            "method": "tools/call",
+            "params": {
+                "name": "search",
+                "arguments": {
+                    "query": "x",
+                    "provider": "codex",
+                    "events": true,
+                    "include_current_session": true,
+                    "limit": 1,
+                    "backend": "lexical"
+                }
+            }
+        }),
+    ];
+    let responses = mcp_roundtrip(&temp, &requests);
+    let first = &responses[1]["result"]["structuredContent"];
+    let second = &responses[2]["result"]["structuredContent"];
+    let first_result = &first["results"][0];
+    let second_result = &second["results"][0];
+
+    assert_eq!(
+        first["results"].as_array().map(Vec::len),
+        Some(1),
+        "{first:#}"
+    );
+    assert_eq!(first_result["snippet"], "", "{first:#}");
+    assert_eq!(first_result["snippet_truncated"], true, "{first:#}");
+    assert!(
+        first_result["snippet"].as_str().unwrap().len() <= SNIPPET_MAX_BYTES,
+        "{first:#}"
+    );
+    assert_eq!(first_result["snippet"], second_result["snippet"]);
+    assert_eq!(
+        first_result["snippet_truncated"],
+        second_result["snippet_truncated"]
+    );
+    assert_eq!(first_result["ctx_event_id"], second_result["ctx_event_id"]);
+}
+
+#[test]
 fn mcp_search_applies_source_backed_identity_filters() {
     let temp = tempdir();
     let (_daemon, _) = import_custom_history_fixture_source_backed(&temp, "basic.jsonl");

--- a/crates/ctx-cli/tests/search_show.rs
+++ b/crates/ctx-cli/tests/search_show.rs
@@ -129,6 +129,90 @@ fn assert_source_backed_search(search: &Value, provider: &str, query: &str) {
 }
 
 #[test]
+fn search_keeps_huge_matching_grapheme_hits_in_json_and_human_output() {
+    const SNIPPET_MAX_BYTES: usize = 16 * 1024;
+    const SESSION_ID: &str = "019c0000-0000-7000-8000-000000000001";
+
+    let temp = tempdir();
+    let oversized_cluster = format!("x{}", "\u{301}".repeat(SNIPPET_MAX_BYTES));
+    let fixture = write_codex_message_fixture(
+        &temp.path().join("huge-grapheme-fixture"),
+        SESSION_ID,
+        &oversized_cluster,
+    );
+    let _daemon = start_mcp_source_refresh_daemon(&temp);
+    json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "codex",
+        "--path",
+        fixture.to_str().unwrap(),
+        "--format=json",
+        "--progress=none",
+        "--no-daemon",
+    ]));
+
+    let search_json = || {
+        json_output(ctx(&temp).args([
+            "search",
+            "x",
+            "--provider",
+            "codex",
+            "--events",
+            "--include-current-session",
+            "--refresh=off",
+            "--format=json",
+        ]))
+    };
+    let first = search_json();
+    let second = search_json();
+    let first_result = &first["results"][0];
+    let second_result = &second["results"][0];
+    assert_eq!(
+        first["results"].as_array().map(Vec::len),
+        Some(1),
+        "{first:#}"
+    );
+    assert_eq!(first_result["snippet"], "", "{first:#}");
+    assert_eq!(first_result["snippet_truncated"], true, "{first:#}");
+    assert!(
+        first_result["snippet"].as_str().unwrap().len() <= SNIPPET_MAX_BYTES,
+        "{first:#}"
+    );
+    assert_eq!(first_result["snippet"], second_result["snippet"]);
+    assert_eq!(
+        first_result["snippet_truncated"],
+        second_result["snippet_truncated"]
+    );
+    assert_eq!(first_result["ctx_event_id"], second_result["ctx_event_id"]);
+
+    let render_human = || {
+        let output = ctx(&temp)
+            .args([
+                "search",
+                "x",
+                "--provider",
+                "codex",
+                "--events",
+                "--include-current-session",
+                "--refresh=off",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        String::from_utf8(output).unwrap()
+    };
+    let first_human = render_human();
+    let second_human = render_human();
+    assert_eq!(first_human, second_human);
+    assert!(first_human.contains("1 result"), "{first_human}");
+    assert!(first_human.contains("codex user message"), "{first_human}");
+    assert!(!first_human.contains('\u{301}'), "{first_human}");
+}
+
+#[test]
 fn search_result_window_is_truthful_in_json_and_human_output() {
     let temp = tempdir();
     let fixture = provider_history_fixture("codex-sessions");

--- a/crates/ctx-cli/tests/support/fixtures.rs
+++ b/crates/ctx-cli/tests/support/fixtures.rs
@@ -1,5 +1,6 @@
 use ctx_history_index::{CoreRecord, GenerationWriter, VerifiedIndex, WriterOptions};
 use rusqlite::Connection;
+use serde_json::json;
 use std::{
     collections::BTreeSet,
     fs,
@@ -83,6 +84,44 @@ pub(crate) fn initialize_generation_only_core(data_root: &Path) -> String {
     let verified = VerifiedIndex::open(index_root).unwrap();
     assert_eq!(verified.generation_id(), core_receipt.generation_id);
     core_receipt.generation_id
+}
+
+pub(crate) fn write_codex_message_fixture(root: &Path, session_id: &str, message: &str) -> PathBuf {
+    fs::create_dir_all(root).unwrap();
+    let path = root.join(format!("rollout-{session_id}.jsonl"));
+    let records = [
+        json!({
+            "timestamp": "2026-08-02T12:00:00Z",
+            "type": "session_meta",
+            "payload": {
+                "id": session_id,
+                "timestamp": "2026-08-02T12:00:00Z",
+                "cwd": "/workspace/huge-grapheme",
+                "originator": "codex_cli_rs",
+                "cli_version": "0.1.0",
+                "source": "cli",
+                "model_provider": "openai"
+            }
+        }),
+        json!({
+            "timestamp": "2026-08-02T12:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{
+                    "type": "input_text",
+                    "text": message
+                }]
+            }
+        }),
+    ];
+    let encoded = records
+        .iter()
+        .map(|record| format!("{}\n", serde_json::to_string(record).unwrap()))
+        .collect::<String>();
+    fs::write(&path, encoded).unwrap();
+    path
 }
 
 pub(crate) fn provider_core_records(data_root: &Path, provider: &str) -> Vec<CoreRecord> {

--- a/crates/ctx-history-index/src/query.rs
+++ b/crates/ctx-history-index/src/query.rs
@@ -74,6 +74,7 @@ thread_local! {
     static STORED_EVENT_RECORD_MATERIALIZATIONS: Cell<usize> = const { Cell::new(0) };
     static STORED_CORE_EVENT_RECORD_MATERIALIZATIONS: Cell<usize> = const { Cell::new(0) };
     static CORE_RECORD_DECODES: Cell<usize> = const { Cell::new(0) };
+    static CORE_EVENT_ID_SELECTION_QUERIES: Cell<usize> = const { Cell::new(0) };
     static SOURCE_EVENT_ORDER_TERM_VISITS: Cell<usize> = const { Cell::new(0) };
     static SESSION_EVENT_ORDER_TERM_VISITS: Cell<usize> = const { Cell::new(0) };
     static SEMANTIC_EVENT_ORDER_TERM_VISITS: Cell<usize> = const { Cell::new(0) };
@@ -110,6 +111,16 @@ pub(crate) fn reset_core_record_decodes() {
 #[cfg(test)]
 pub(crate) fn core_record_decodes() -> usize {
     CORE_RECORD_DECODES.get()
+}
+
+#[cfg(test)]
+pub(crate) fn reset_core_event_id_selection_queries() {
+    CORE_EVENT_ID_SELECTION_QUERIES.set(0);
+}
+
+#[cfg(test)]
+pub(crate) fn core_event_id_selection_queries() -> usize {
+    CORE_EVENT_ID_SELECTION_QUERIES.get()
 }
 
 #[cfg(test)]

--- a/crates/ctx-history-index/src/query/execution/lookup.rs
+++ b/crates/ctx-history-index/src/query/execution/lookup.rs
@@ -308,6 +308,101 @@ impl VerifiedIndex {
         )
     }
 
+    /// Selects a complete requested-order Core set with one Tantivy query,
+    /// then decodes records lazily under independent per-record ceilings.
+    ///
+    /// The complete FAST-only candidate set is validated before this returns.
+    /// The iterator retains only addresses and size metadata; each call to
+    /// `next` materializes one complete Core record and validates it against
+    /// the preflight metadata before yielding it.
+    pub fn stream_core_events_by_ids_with_strict_per_record_budget<'index>(
+        &'index self,
+        event_ids: &[Uuid],
+        maximum_events: usize,
+        per_record_budget: CoreEventPageBudget,
+    ) -> Result<Option<impl Iterator<Item = Result<CoreEventRecord>> + 'index>> {
+        validate_core_event_page_budget(per_record_budget)?;
+        if event_ids.len() > maximum_events {
+            return Ok(None);
+        }
+
+        let fields = fields_from_schema(self.searcher.schema())?;
+        let mut requested = BTreeSet::new();
+        for event_id in event_ids {
+            if !requested.insert(*event_id) {
+                return Err(IndexError::DuplicateEventIdentity(event_id.to_string()));
+            }
+        }
+        let query = TermSetQuery::new(
+            requested
+                .iter()
+                .map(|event_id| Term::from_field_text(fields.event_id, &event_id.to_string()))
+                .collect::<Vec<_>>(),
+        );
+        #[cfg(test)]
+        CORE_EVENT_ID_SELECTION_QUERIES
+            .set(CORE_EVENT_ID_SELECTION_QUERIES.get().saturating_add(1));
+        let addresses = self.searcher.search(&query, &DocSetCollector)?;
+        let mut by_event_id = BTreeMap::new();
+        for address in addresses {
+            let (event_id, encoded_core_bytes, content_bytes) =
+                core_event_fast_preflight(&self.searcher, address)?;
+            if !requested.contains(&event_id) {
+                return Err(IndexError::InvalidStoredDocumentField("event_id"));
+            }
+            if encoded_core_bytes > per_record_budget.maximum_encoded_core_bytes
+                || content_bytes > per_record_budget.maximum_content_bytes
+            {
+                return Ok(None);
+            }
+            if by_event_id
+                .insert(event_id, (address, encoded_core_bytes, content_bytes))
+                .is_some()
+            {
+                return Err(IndexError::DuplicateEventIdentity(event_id.to_string()));
+            }
+        }
+        if by_event_id.len() != requested.len() {
+            return Ok(None);
+        }
+
+        let mut ordered = Vec::with_capacity(event_ids.len());
+        for event_id in event_ids {
+            let Some((address, encoded_core_bytes, content_bytes)) = by_event_id.remove(event_id)
+            else {
+                return Ok(None);
+            };
+            ordered.push((address, *event_id, encoded_core_bytes, content_bytes));
+        }
+        let searcher = &self.searcher;
+        Ok(Some(ordered.into_iter().map(
+            move |(
+                address,
+                expected_event_id,
+                expected_encoded_core_bytes,
+                expected_content_bytes,
+            )| {
+                let (record, encoded_core_bytes) =
+                    stored_core_event_record_with_size(searcher, address, fields)?;
+                let content_bytes = core_content_bytes(&record.core_record.content)?;
+                if record.event_id.as_uuid() != expected_event_id {
+                    return Err(IndexError::InvalidStoredDocumentField("event_id"));
+                }
+                if encoded_core_bytes != expected_encoded_core_bytes {
+                    return Err(IndexError::InvalidStoredDocumentField(
+                        CORE_RECORD_ENCODED_BYTES_FIELD,
+                    ));
+                }
+                if content_bytes != expected_content_bytes {
+                    return Err(IndexError::InvalidStoredDocumentField(
+                        CORE_CONTENT_BYTES_FIELD,
+                    ));
+                }
+                Ok(record)
+            },
+        )))
+    }
+
     fn core_event_batch_by_ids(
         &self,
         event_ids: &[Uuid],
@@ -340,6 +435,9 @@ impl VerifiedIndex {
                 .map(|event_id| Term::from_field_text(fields.event_id, &event_id.to_string()))
                 .collect::<Vec<_>>(),
         );
+        #[cfg(test)]
+        CORE_EVENT_ID_SELECTION_QUERIES
+            .set(CORE_EVENT_ID_SELECTION_QUERIES.get().saturating_add(1));
         let addresses = self.searcher.search(&query, &DocSetCollector)?;
         let per_record_budget = budget_mode.per_record_budget();
         let candidates = if budget_mode.preflights_before_decode() {

--- a/crates/ctx-history-index/src/tests/query/lookup.rs
+++ b/crates/ctx-history-index/src/tests/query/lookup.rs
@@ -798,6 +798,78 @@ fn bounded_core_event_batch_is_complete_and_requested_ordered() {
 }
 
 #[test]
+fn strict_core_event_stream_selects_once_and_materializes_in_requested_order() {
+    let temp = tempdir().unwrap();
+    let source = source("strict-streaming-events.jsonl");
+    let first = document(&source, 1, "first complete body");
+    let second = document(&source, 2, "second complete body");
+    let third = document(&source, 3, "third complete body");
+    let mut writer = GenerationWriter::open(temp.path(), WriterOptions::default()).unwrap();
+    writer.begin_source(source.clone()).unwrap();
+    writer.add_core_record(first.clone()).unwrap();
+    writer.add_core_record(second.clone()).unwrap();
+    writer.add_core_record(third.clone()).unwrap();
+    writer.certify_source(certificate(&source, 1, 3)).unwrap();
+    writer.commit(|_| true).unwrap();
+
+    let index = VerifiedIndex::open(temp.path()).unwrap();
+    let requested = [
+        third.event_id.as_uuid(),
+        first.event_id.as_uuid(),
+        second.event_id.as_uuid(),
+    ];
+    crate::query::reset_core_event_id_selection_queries();
+    crate::query::reset_stored_core_event_record_materializations();
+    let mut stream = index
+        .stream_core_events_by_ids_with_strict_per_record_budget(
+            &requested,
+            requested.len(),
+            DEFAULT_CORE_EVENT_PAGE_BUDGET,
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(crate::query::core_event_id_selection_queries(), 1);
+    assert_eq!(crate::query::stored_core_event_record_materializations(), 0);
+
+    for (offset, expected) in [third, first, second].into_iter().enumerate() {
+        let actual = stream.next().unwrap().unwrap();
+        assert_eq!(actual.core_record, expected);
+        assert_eq!(
+            crate::query::stored_core_event_record_materializations(),
+            offset + 1
+        );
+    }
+    assert!(stream.next().is_none());
+    assert_eq!(crate::query::core_event_id_selection_queries(), 1);
+    drop(stream);
+
+    crate::query::reset_core_event_id_selection_queries();
+    let duplicate = index.stream_core_events_by_ids_with_strict_per_record_budget(
+        &[requested[0], requested[0]],
+        2,
+        DEFAULT_CORE_EVENT_PAGE_BUDGET,
+    );
+    assert!(matches!(
+        duplicate,
+        Err(IndexError::DuplicateEventIdentity(_))
+    ));
+    assert_eq!(crate::query::core_event_id_selection_queries(), 0);
+
+    crate::query::reset_core_event_id_selection_queries();
+    crate::query::reset_stored_core_event_record_materializations();
+    assert!(index
+        .stream_core_events_by_ids_with_strict_per_record_budget(
+            &[requested[0], Uuid::nil()],
+            2,
+            DEFAULT_CORE_EVENT_PAGE_BUDGET,
+        )
+        .unwrap()
+        .is_none());
+    assert_eq!(crate::query::core_event_id_selection_queries(), 1);
+    assert_eq!(crate::query::stored_core_event_record_materializations(), 0);
+}
+
+#[test]
 fn strict_core_event_batch_rejects_fast_content_overflow_before_stored_materialization() {
     let temp = tempdir().unwrap();
     let source = source("strict-content-preflight.jsonl");
@@ -821,6 +893,19 @@ fn strict_core_event_batch_rejects_fast_content_overflow_before_stored_materiali
     crate::query::reset_core_record_decodes();
     assert!(index
         .core_events_by_ids_with_strict_budget(
+            &requested,
+            requested.len(),
+            CoreEventPageBudget::new(ctx_history_core::MAX_ENCODED_CORE_RECORD_BYTES, 1),
+        )
+        .unwrap()
+        .is_none());
+    assert_eq!(crate::query::stored_core_event_record_materializations(), 0);
+    assert_eq!(crate::query::core_record_decodes(), 0);
+
+    crate::query::reset_stored_core_event_record_materializations();
+    crate::query::reset_core_record_decodes();
+    assert!(index
+        .stream_core_events_by_ids_with_strict_per_record_budget(
             &requested,
             requested.len(),
             CoreEventPageBudget::new(ctx_history_core::MAX_ENCODED_CORE_RECORD_BYTES, 1),
@@ -1049,6 +1134,24 @@ fn strict_core_event_batch_rejects_forged_fast_content_size_after_decode() {
     );
     assert_eq!(crate::query::stored_core_event_record_materializations(), 1);
     assert_eq!(crate::query::core_record_decodes(), 1);
+
+    crate::query::reset_stored_core_event_record_materializations();
+    crate::query::reset_core_record_decodes();
+    let mut stream = pinned
+        .stream_core_events_by_ids_with_strict_per_record_budget(
+            &[record.event_id.as_uuid()],
+            1,
+            DEFAULT_CORE_EVENT_PAGE_BUDGET,
+        )
+        .unwrap()
+        .unwrap();
+    let streamed = stream.next().unwrap();
+    assert!(matches!(
+        streamed,
+        Err(IndexError::InvalidStoredDocumentField("core_content_bytes"))
+    ));
+    assert_eq!(crate::query::stored_core_event_record_materializations(), 1);
+    assert_eq!(crate::query::core_record_decodes(), 1);
 }
 
 #[test]
@@ -1103,6 +1206,26 @@ fn strict_core_event_batch_rejects_forged_fast_encoded_size_before_decode() {
         ),
         "unexpected strict corruption result: {result:?}"
     );
+    assert_eq!(crate::query::stored_core_event_record_materializations(), 1);
+    assert_eq!(crate::query::core_record_decodes(), 0);
+
+    crate::query::reset_stored_core_event_record_materializations();
+    crate::query::reset_core_record_decodes();
+    let mut stream = pinned
+        .stream_core_events_by_ids_with_strict_per_record_budget(
+            &[record.event_id.as_uuid()],
+            1,
+            DEFAULT_CORE_EVENT_PAGE_BUDGET,
+        )
+        .unwrap()
+        .unwrap();
+    let streamed = stream.next().unwrap();
+    assert!(matches!(
+        streamed,
+        Err(IndexError::InvalidStoredDocumentField(
+            "core_record_encoded_bytes"
+        ))
+    ));
     assert_eq!(crate::query::stored_core_event_record_materializations(), 1);
     assert_eq!(crate::query::core_record_decodes(), 0);
 }


### PR DESCRIPTION
## Summary

- stream matching Core records from one generation-pinned Tantivy selection instead of retaining full result bodies or issuing one lookup per hit
- retain only bounded search presentation snippets, capped at 16 KiB each and 200 results
- clip only at complete extended-grapheme boundaries and preserve valid hits when no match-containing grapheme fits
- preserve ordinary CLI text/JSON, show, and MCP output behavior

## Performance

On the deterministic 200-hit fixture, the final streaming path measured 104.309 ms median versus 103.904 ms for the previous batch path (+0.4%). The rejected singleton design measured 215.131 ms and was not retained.

## Validation

- cargo and Bazel CLI unit suites
- source-index tests, including 200-hit and file-only cases
- search/show integration tests
- MCP search tests
- strict history-index lookup tests
- cargo fmt and git diff checks

Three independent final reviews approved Unicode correctness, public compatibility, and memory/performance behavior.