### PR TITLE
Add generation-bound Core event export

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ ctx show event <ctx-event-id> --window 3
 
 # Or print a compact transcript of the original session
 ctx show session <ctx-session-id>
+
+# Export one complete UTC day from a stable Core generation
+ctx export events --since 2026-08-01T00:00:00Z --until 2026-08-02T00:00:00Z --format jsonl
 ```
 
 Those IDs let your current agent recover as much context from previous sessions as it needs.

--- a/contracts/telemetry-v1/source-provenance.json
+++ b/contracts/telemetry-v1/source-provenance.json
@@ -5,7 +5,7 @@
   "provenance_kind": "content_addressed_candidate",
   "scope": "selected_typed_telemetry_contract_inventory",
   "files": {
-    "crates/ctx-cli/src/analytics/operation.rs": "68daa2a0af895fccdb81b272e207729f7eef7f525096c24c7e3909797915d560",
+    "crates/ctx-cli/src/analytics/operation.rs": "6d179a3984b25942113e09db82819080637c9a13cde0f037d9f25d6a2038784a",
     "crates/ctx-cli/src/analytics/daemon.rs": "6eb120f37ed78927bdda09688f6ff824af3d850114c1fdbe92e3b1c93aa1e9a9",
     "crates/ctx-cli/src/analytics/mcp.rs": "a00c1dbbcda7b9c48f58e995406a8f78d035048debcfd6a0654c0b8860b1bd78",
     "crates/ctx-cli/src/analytics/runtime.rs": "b2ab7fb8655d1eafc34e997472f2fdb0a4afa33029a8b92b47f9f752e4d951a6",

--- a/crates/ctx-cli/BUILD.bazel
+++ b/crates/ctx-cli/BUILD.bazel
@@ -376,6 +376,17 @@ ctx_cli_integration_test(
 )
 
 ctx_cli_integration_test(
+    name = "export_events_tests",
+    src = "tests/export_events.rs",
+    extra_deps = ["//crates/ctx-history-core:lib"],
+    tags = ["cli-contract"],
+    test_support = [
+        "base",
+        "fixtures",
+    ],
+)
+
+ctx_cli_integration_test(
     name = "history_source_plugins_tests",
     src = "tests/history_source_plugins.rs",
 )

--- a/crates/ctx-cli/src/analytics/operation.rs
+++ b/crates/ctx-cli/src/analytics/operation.rs
@@ -261,6 +261,7 @@ impl ClientOperationDraft {
             }),
             CommandRoot::Doctor(_) => ClientOperationV1::Doctor(DoctorTelemetry::default()),
             CommandRoot::Pro(_)
+            | CommandRoot::Export(_)
             | CommandRoot::Referral(_)
             | CommandRoot::Blame(_)
             | CommandRoot::Stats(_)

--- a/crates/ctx-cli/src/cli.rs
+++ b/crates/ctx-cli/src/cli.rs
@@ -101,6 +101,8 @@ pub(crate) enum CommandRoot {
     Locate(LocateArgs),
     #[command(about = "Search indexed agent history")]
     Search(SearchArgs),
+    #[command(about = "Export bounded data from one immutable Core generation")]
+    Export(commands::export::ExportArgs),
     #[command(
         about = "Set up, resume, repair, manage, or remove local ctx Pro",
         long_about = "Set up, resume, repair, manage, or remove local ctx Pro. Bare `ctx pro` runs the idempotent setup path; `ctx pro setup` is an explicit synonym. `ctx status` does not mutate canonical history or graph data; entitlement authorization may advance nonsecret anti-clock-rollback metadata.",

--- a/crates/ctx-cli/src/commands/export.rs
+++ b/crates/ctx-cli/src/commands/export.rs
@@ -1,0 +1,425 @@
+use std::{io::Write, path::PathBuf};
+
+use anyhow::Result;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use chrono::DateTime;
+use clap::{Args, Subcommand, ValueEnum};
+use ctx_history_core::CoreContentPolicyStatus;
+use ctx_history_index::{
+    CoreEventRangeCursor, CoreEventRangeError, CoreEventRangeSelection, IndexError, VerifiedIndex,
+    MAX_CORE_EVENT_RANGE_PAGE_ITEMS,
+};
+use serde_json::{json, Value};
+
+use crate::{output::compact_json, provider_args::ProviderArg, ui::Ui};
+
+const EXPORT_SCHEMA_VERSION: u8 = 1;
+const DEFAULT_EXPORT_ITEMS: u64 = 100;
+const DEFAULT_EXPORT_BYTES: u64 = 1024 * 1024;
+const MIN_EXPORT_BYTES: u64 = 512;
+const MAX_EXPORT_BYTES: u64 = 8 * 1024 * 1024;
+const MAX_CURSOR_CHARS: usize = 512;
+
+#[derive(Debug, Args)]
+pub(crate) struct ExportArgs {
+    #[command(subcommand)]
+    target: ExportTarget,
+}
+
+#[derive(Debug, Subcommand)]
+enum ExportTarget {
+    #[command(about = "Export complete timestamped Core events in deterministic order")]
+    Events(ExportEventsArgs),
+}
+
+#[derive(Debug, Args)]
+struct ExportEventsArgs {
+    #[arg(long, help = "Inclusive absolute RFC3339 lower bound")]
+    since: String,
+    #[arg(long, help = "Exclusive absolute RFC3339 upper bound")]
+    until: String,
+    #[arg(
+        long,
+        value_enum,
+        help = "Filter by provider; repeat to select more than one"
+    )]
+    provider: Vec<ProviderArg>,
+    #[arg(long, help = "Resume from an opaque cursor returned by JSON output")]
+    cursor: Option<String>,
+    #[arg(
+        long,
+        default_value_t = DEFAULT_EXPORT_ITEMS,
+        value_parser = clap::value_parser!(u64).range(1..=MAX_CORE_EVENT_RANGE_PAGE_ITEMS as u64),
+        help = "Maximum events per internal page"
+    )]
+    max_items: u64,
+    #[arg(
+        long,
+        default_value_t = DEFAULT_EXPORT_BYTES,
+        value_parser = clap::value_parser!(u64).range(MIN_EXPORT_BYTES..=MAX_EXPORT_BYTES),
+        help = "Maximum serialized bytes per page"
+    )]
+    max_bytes: u64,
+    #[arg(long, value_enum, default_value_t = EventExportFormat::Json)]
+    format: EventExportFormat,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum EventExportFormat {
+    Json,
+    Jsonl,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ExportEventsError {
+    #[error(transparent)]
+    Range(#[from] CoreEventRangeError),
+    #[error("{field} must be an absolute RFC3339 timestamp: {value:?}")]
+    InvalidTimestamp { field: &'static str, value: String },
+    #[error("event export cursor is {actual} characters, maximum {maximum}")]
+    CursorTooLarge { actual: usize, maximum: usize },
+    #[error("event export cursor is not canonical base64url")]
+    InvalidCursorEncoding,
+    #[error(
+        "event {event_id} requires {required_bytes} serialized bytes, maximum {maximum_bytes}"
+    )]
+    WireRecordTooLarge {
+        event_id: uuid::Uuid,
+        required_bytes: usize,
+        maximum_bytes: usize,
+        cursor: Option<String>,
+    },
+    #[error(
+        "the empty event export page requires {required_bytes} bytes, maximum {maximum_bytes}"
+    )]
+    WireEnvelopeTooLarge {
+        required_bytes: usize,
+        maximum_bytes: usize,
+    },
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+pub(crate) fn run_export(args: ExportArgs, data_root: PathBuf, ui: &mut Ui) -> Result<()> {
+    let result = match args.target {
+        ExportTarget::Events(args) => execute_events(args, data_root, ui.stdout_writer()),
+    };
+    match result {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            writeln!(
+                ui.stderr_writer(),
+                "{}",
+                serde_json::to_string(&export_error_value(&error))?
+            )?;
+            Err(crate::dispatch::rendered_cli_error())
+        }
+    }
+}
+
+fn execute_events(
+    args: ExportEventsArgs,
+    data_root: PathBuf,
+    writer: &mut dyn Write,
+) -> std::result::Result<(), ExportEventsError> {
+    let since = parse_rfc3339("since", &args.since)?;
+    let until = parse_rfc3339("until", &args.until)?;
+    let providers = args
+        .provider
+        .into_iter()
+        .map(|provider| provider.capture_provider().as_str().to_owned());
+    let selection = CoreEventRangeSelection::new(since, until, providers)?;
+    let cursor = args.cursor.as_deref().map(decode_cursor).transpose()?;
+    if let Some(cursor) = &cursor {
+        cursor.validate_selection(&selection)?;
+    }
+    let root = data_root.join("search/lexical");
+    let index = match &cursor {
+        Some(cursor) => VerifiedIndex::open_pinned_generation(&root, cursor.generation_id()),
+        None => VerifiedIndex::open_pinned(&root),
+    }
+    .map_err(CoreEventRangeError::from)?;
+    let max_items = args.max_items as usize;
+    let max_bytes = args.max_bytes as usize;
+
+    match args.format {
+        EventExportFormat::Json => write_json_page(
+            &index,
+            &selection,
+            cursor.as_ref(),
+            args.cursor.as_deref(),
+            max_items,
+            max_bytes,
+            writer,
+        ),
+        EventExportFormat::Jsonl => write_jsonl_pages(
+            &index,
+            &selection,
+            cursor,
+            args.cursor,
+            max_items,
+            max_bytes,
+            writer,
+            || {},
+        ),
+    }
+}
+
+fn write_json_page(
+    index: &VerifiedIndex,
+    selection: &CoreEventRangeSelection,
+    cursor: Option<&CoreEventRangeCursor>,
+    cursor_text: Option<&str>,
+    max_items: usize,
+    max_bytes: usize,
+    writer: &mut dyn Write,
+) -> std::result::Result<(), ExportEventsError> {
+    let page = index.core_event_range_page(selection, cursor, max_items)?;
+    let rendered = page
+        .items
+        .iter()
+        .map(render_export_event)
+        .collect::<Vec<_>>();
+    let full_cursor = page.next_cursor.as_ref().map(encode_cursor);
+    let full = encode_page(
+        &page.generation_id,
+        &rendered,
+        full_cursor.as_deref(),
+        page.terminal,
+    )?;
+    if full.len() <= max_bytes {
+        writer.write_all(&full)?;
+        return Ok(());
+    }
+    if rendered.is_empty() {
+        return Err(ExportEventsError::WireEnvelopeTooLarge {
+            required_bytes: full.len(),
+            maximum_bytes: max_bytes,
+        });
+    }
+
+    let mut low = 1_usize;
+    let mut high = rendered.len().saturating_sub(1);
+    let mut accepted = None;
+    while low <= high {
+        let middle = low + (high - low) / 2;
+        let cursor = selection.cursor_for(&page.generation_id, &page.items[middle - 1])?;
+        let cursor = encode_cursor(&cursor);
+        let encoded = encode_page(
+            &page.generation_id,
+            &rendered[..middle],
+            Some(&cursor),
+            false,
+        )?;
+        if encoded.len() <= max_bytes {
+            accepted = Some(encoded);
+            low = middle + 1;
+        } else {
+            high = middle - 1;
+        }
+    }
+    if let Some(encoded) = accepted {
+        writer.write_all(&encoded)?;
+        return Ok(());
+    }
+    let terminal = page.terminal && rendered.len() == 1;
+    let singleton_cursor = (!terminal)
+        .then(|| selection.cursor_for(&page.generation_id, &page.items[0]))
+        .transpose()?
+        .as_ref()
+        .map(encode_cursor);
+    let singleton = encode_page(
+        &page.generation_id,
+        &rendered[..1],
+        singleton_cursor.as_deref(),
+        terminal,
+    )?;
+    Err(ExportEventsError::WireRecordTooLarge {
+        event_id: page.items[0].event_id.as_uuid(),
+        required_bytes: singleton.len(),
+        maximum_bytes: max_bytes,
+        cursor: cursor_text.map(ToOwned::to_owned),
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_jsonl_pages<F>(
+    index: &VerifiedIndex,
+    selection: &CoreEventRangeSelection,
+    mut cursor: Option<CoreEventRangeCursor>,
+    mut cursor_text: Option<String>,
+    max_items: usize,
+    max_bytes: usize,
+    writer: &mut dyn Write,
+    mut after_page: F,
+) -> std::result::Result<(), ExportEventsError>
+where
+    F: FnMut(),
+{
+    loop {
+        let page = index.core_event_range_page(selection, cursor.as_ref(), max_items)?;
+        if page.items.is_empty() {
+            return Ok(());
+        }
+        let mut buffer = Vec::new();
+        let mut accepted = 0_usize;
+        for event in &page.items {
+            let mut line = serde_json::to_vec(&render_export_event(event))?;
+            line.push(b'\n');
+            if buffer.len().saturating_add(line.len()) > max_bytes {
+                if accepted == 0 {
+                    return Err(ExportEventsError::WireRecordTooLarge {
+                        event_id: event.event_id.as_uuid(),
+                        required_bytes: line.len(),
+                        maximum_bytes: max_bytes,
+                        cursor: cursor_text,
+                    });
+                }
+                break;
+            }
+            buffer.extend_from_slice(&line);
+            accepted += 1;
+        }
+        writer.write_all(&buffer)?;
+        after_page();
+        if accepted == page.items.len() && page.terminal {
+            return Ok(());
+        }
+        let next = selection.cursor_for(&page.generation_id, &page.items[accepted - 1])?;
+        cursor_text = Some(encode_cursor(&next));
+        cursor = Some(next);
+    }
+}
+
+fn render_export_event(event: &ctx_history_index::CoreEventRecord) -> Value {
+    let content = &event.core_record.content;
+    let (policy_status, policy_reason, complete) = match &content.policy_status {
+        CoreContentPolicyStatus::Selected => ("selected", None, true),
+        CoreContentPolicyStatus::Redacted { reason } => ("redacted", Some(reason.as_str()), false),
+        CoreContentPolicyStatus::Omitted { reason } => ("omitted", Some(reason.as_str()), false),
+    };
+    compact_json(json!({
+        "schema_version": EXPORT_SCHEMA_VERSION,
+        "ctx_event_id": event.event_id.as_uuid(),
+        "ctx_source_id": event.source.identity().as_uuid(),
+        "ctx_session_id": event.session_id.as_uuid(),
+        "parent_ctx_session_id": event.parent_session_id.map(|id| id.as_uuid()),
+        "root_ctx_session_id": event.root_session_id.as_uuid(),
+        "provider": event.provider,
+        "source_format": event.source_format,
+        "provider_session_id": event.provider_session_id,
+        "native_event_id": event.native_event_id,
+        "branch": event.branch,
+        "agent_type": event.agent_type,
+        "is_primary": event.is_primary,
+        "event_sequence": event.event_sequence,
+        "occurred_at_unix_ms": event.occurred_at_unix_ms,
+        "event_type": event.event_type,
+        "role": event.role,
+        "workspace": event.workspace,
+        "cwd": event.cwd,
+        "touched_files": event.touched_files,
+        "text": content.normalized_body.as_deref(),
+        "structured_content": content.structured_content.as_ref(),
+        "content": {
+            "complete": complete,
+            "policy_status": policy_status,
+            "policy_reason": policy_reason,
+        },
+    }))
+}
+
+fn encode_page(
+    generation_id: &str,
+    events: &[Value],
+    next_cursor: Option<&str>,
+    terminal: bool,
+) -> std::result::Result<Vec<u8>, ExportEventsError> {
+    let mut exact_bytes = 0_usize;
+    loop {
+        let mut encoded = serde_json::to_vec(&json!({
+            "schema_version": EXPORT_SCHEMA_VERSION,
+            "generation_id": generation_id,
+            "events": events,
+            "next_cursor": next_cursor,
+            "terminal": terminal,
+            "usage": {"items": events.len(), "bytes": exact_bytes},
+        }))?;
+        let observed = encoded.len().saturating_add(1);
+        if observed == exact_bytes {
+            encoded.push(b'\n');
+            return Ok(encoded);
+        }
+        exact_bytes = observed;
+    }
+}
+
+fn decode_cursor(encoded: &str) -> std::result::Result<CoreEventRangeCursor, ExportEventsError> {
+    if encoded.len() > MAX_CURSOR_CHARS {
+        return Err(ExportEventsError::CursorTooLarge {
+            actual: encoded.len(),
+            maximum: MAX_CURSOR_CHARS,
+        });
+    }
+    let bytes = URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|_| ExportEventsError::InvalidCursorEncoding)?;
+    if URL_SAFE_NO_PAD.encode(&bytes) != encoded {
+        return Err(ExportEventsError::InvalidCursorEncoding);
+    }
+    Ok(CoreEventRangeCursor::decode(&bytes)?)
+}
+
+fn encode_cursor(cursor: &CoreEventRangeCursor) -> String {
+    URL_SAFE_NO_PAD.encode(cursor.encode())
+}
+
+fn parse_rfc3339(field: &'static str, value: &str) -> std::result::Result<i64, ExportEventsError> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|timestamp| timestamp.timestamp_millis())
+        .map_err(|_| ExportEventsError::InvalidTimestamp {
+            field,
+            value: value.to_owned(),
+        })
+}
+
+fn export_error_value(error: &ExportEventsError) -> Value {
+    let code = match error {
+        ExportEventsError::Range(CoreEventRangeError::Index(
+            IndexError::PinnedGenerationNotRetained { .. },
+        )) => "generation_not_retained",
+        ExportEventsError::Range(CoreEventRangeError::CursorSelectionMismatch) => {
+            "cursor_request_mismatch"
+        }
+        ExportEventsError::Range(CoreEventRangeError::CursorGenerationMismatch { .. }) => {
+            "cursor_generation_mismatch"
+        }
+        ExportEventsError::Range(CoreEventRangeError::InvalidCursor)
+        | ExportEventsError::InvalidCursorEncoding
+        | ExportEventsError::CursorTooLarge { .. } => "invalid_cursor",
+        ExportEventsError::Range(CoreEventRangeError::InvalidCursorCoordinate) => {
+            "invalid_cursor_coordinate"
+        }
+        ExportEventsError::Range(CoreEventRangeError::InvalidRange { .. })
+        | ExportEventsError::InvalidTimestamp { .. } => "invalid_range",
+        ExportEventsError::WireRecordTooLarge { .. } => "event_too_large",
+        ExportEventsError::WireEnvelopeTooLarge { .. } => "page_too_large",
+        _ => "event_export_failed",
+    };
+    let cursor = match error {
+        ExportEventsError::WireRecordTooLarge { cursor, .. } => cursor.as_deref(),
+        _ => None,
+    };
+    json!({
+        "schema_version": EXPORT_SCHEMA_VERSION,
+        "error_code": code,
+        "detail": error.to_string(),
+        "cursor": cursor,
+    })
+}
+
+#[cfg(test)]
+#[path = "export/tests.rs"]
+mod tests;

--- a/crates/ctx-cli/src/commands/export/tests.rs
+++ b/crates/ctx-cli/src/commands/export/tests.rs
@@ -1,0 +1,196 @@
+use super::*;
+
+use std::path::Path;
+
+use ctx_history_core::{
+    derive_event_id, derive_session_id, CertifiedSource, CertifiedSourceAppend, CoreRecord,
+    EventIdentityInput, NativeItemKey, NativeSessionKey, ScannedSourceCounts, SessionIdentityInput,
+    SourceAnchor, SourceFrontier, SourceKey, SourceObservation, TypedKey,
+};
+use ctx_history_index::{GenerationWriter, WriterOptions};
+
+fn source() -> SourceKey {
+    SourceKey::derive(
+        "codex",
+        "codex_session_test",
+        "session",
+        1,
+        SourceAnchor::provider_native("session-file", TypedKey::utf8("jsonl-pin").unwrap())
+            .unwrap(),
+    )
+    .unwrap()
+}
+
+fn record(source: &SourceKey, nonce: u64, body: &str) -> CoreRecord {
+    let session_key =
+        NativeSessionKey::native_id("session", TypedKey::utf8("session").unwrap()).unwrap();
+    let session_id = derive_session_id(SessionIdentityInput {
+        source,
+        logical_session_kind: "thread",
+        native_session_key: &session_key,
+    })
+    .unwrap();
+    let item_key = NativeItemKey::native_id("message", TypedKey::U64(nonce)).unwrap();
+    let event_id = derive_event_id(EventIdentityInput {
+        source,
+        session_id,
+        logical_item_kind: "message",
+        native_item_key: &item_key,
+        subrecord_selector: None,
+    })
+    .unwrap();
+    let mut record = CoreRecord::new_selected(
+        event_id,
+        session_id,
+        session_id,
+        source.clone(),
+        nonce,
+        "message",
+        "primary",
+        true,
+        "event-export-test-v1",
+        body,
+    )
+    .unwrap();
+    record.occurred_at_unix_ms = Some(1_000 + nonce as i64);
+    record
+}
+
+fn publish(root: &Path, revision: u8, source: &SourceKey, records: &[CoreRecord]) {
+    let certificate = certificate(source, revision, records.len());
+    let mut writer = GenerationWriter::open(root, WriterOptions::default()).unwrap();
+    writer.begin_source(source.clone()).unwrap();
+    for record in records {
+        writer.add_core_record(record.clone()).unwrap();
+    }
+    writer.certify_source(certificate).unwrap();
+    writer.commit(|_| true).unwrap();
+}
+
+fn certificate(source: &SourceKey, revision: u8, records: usize) -> CertifiedSource {
+    let observation =
+        SourceObservation::new(source.clone(), "regular-file-v1", vec![revision]).unwrap();
+    CertifiedSource::certify_with_frontier(
+        observation.clone(),
+        observation,
+        "event-export-test-v1",
+        [revision; 32],
+        ScannedSourceCounts {
+            complete_records: records as u64,
+            retained_records: records as u64,
+            indexed_documents: records as u64,
+            certified_bytes: records as u64 * 10,
+            ..ScannedSourceCounts::default()
+        },
+        Some(
+            SourceFrontier::new(
+                "jsonl-byte-offset",
+                TypedKey::U64(records as u64 * 10),
+                records as u64 * 10,
+                [revision; 32],
+            )
+            .unwrap(),
+        ),
+    )
+    .unwrap()
+}
+
+fn append(root: &Path, revision: u8, source: &SourceKey, prior: usize, record: CoreRecord) {
+    let mut writer = GenerationWriter::open(root, WriterOptions::default()).unwrap();
+    let base = writer.begin_source_append(source.clone()).unwrap().clone();
+    writer.add_core_record(record).unwrap();
+    let frontier = base.frontier().unwrap();
+    let proof = CertifiedSourceAppend::certify(
+        &base,
+        certificate(source, revision, prior + 1),
+        frontier.certified_prefix_bytes(),
+        *frontier.certified_prefix_digest(),
+    )
+    .unwrap();
+    writer.certify_source_append(proof).unwrap();
+    writer.commit(|_| true).unwrap();
+}
+
+#[test]
+fn exact_page_usage_counts_the_final_newline() {
+    let encoded = encode_page(
+        &"a".repeat(64),
+        &[serde_json::json!({"ctx_event_id": "event"})],
+        None,
+        true,
+    )
+    .unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
+    assert_eq!(value["usage"]["items"], 1);
+    assert_eq!(value["usage"]["bytes"], encoded.len());
+    assert_eq!(encoded.last(), Some(&b'\n'));
+}
+
+#[test]
+fn exact_page_usage_converges_across_digit_boundaries() {
+    for count in [0, 1, 9, 10, 99, 100] {
+        let events = (0..count)
+            .map(|index| serde_json::json!({"ctx_event_id": index, "text": "雪"}))
+            .collect::<Vec<_>>();
+        let encoded = encode_page(&"b".repeat(64), &events, Some("cursor"), false).unwrap();
+        let value: Value = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(value["usage"]["items"], count);
+        assert_eq!(value["usage"]["bytes"], encoded.len());
+    }
+}
+
+#[test]
+fn jsonl_holds_one_pin_across_append_rewrite_and_delete_publications() {
+    let temp = tempfile::tempdir().unwrap();
+    let index_root = temp.path().join("search/lexical");
+    let source = source();
+    let original = (0..5)
+        .map(|nonce| record(&source, nonce, &format!("old-{nonce}")))
+        .collect::<Vec<_>>();
+    publish(&index_root, 1, &source, &original);
+    let held = VerifiedIndex::open(&index_root).unwrap();
+    let selection = CoreEventRangeSelection::new(1_000, 2_000, Vec::<String>::new()).unwrap();
+    let replacement = (10..13)
+        .map(|nonce| record(&source, nonce, &format!("new-{nonce}")))
+        .collect::<Vec<_>>();
+    let mut publications = 0;
+    let mut output = Vec::new();
+    write_jsonl_pages(
+        &held,
+        &selection,
+        None,
+        None,
+        1,
+        64 * 1024,
+        &mut output,
+        || {
+            if publications == 0 {
+                append(
+                    &index_root,
+                    2,
+                    &source,
+                    original.len(),
+                    record(&source, 99, "appended"),
+                );
+                publish(&index_root, 3, &source, &replacement);
+                publish(&index_root, 4, &source, &[]);
+            }
+            publications += 1;
+        },
+    )
+    .unwrap();
+    let ids = output
+        .split(|byte| *byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            let value: Value = serde_json::from_slice(line).unwrap();
+            value["ctx_event_id"].as_str().unwrap().to_owned()
+        })
+        .collect::<Vec<_>>();
+    let expected = original
+        .iter()
+        .map(|record| record.event_id.as_uuid().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, expected);
+    assert!(publications >= original.len());
+}

--- a/crates/ctx-cli/src/commands/mod.rs
+++ b/crates/ctx-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod blame;
 pub(crate) mod doctor;
+pub(crate) mod export;
 pub(crate) mod import;
 pub(crate) mod index;
 mod index_dashboard;

--- a/crates/ctx-cli/src/dispatch.rs
+++ b/crates/ctx-cli/src/dispatch.rs
@@ -8,6 +8,7 @@ use crate::{
     cli::{CommandRoot, DaemonCommand, DaemonTriggerCommandArg, ImportArgs, ShowArgs, ShowTarget},
     commands::{
         doctor::run_doctor,
+        export::run_export,
         import::{run_import, ProviderRefreshCollector},
         index::run_index,
         locate::run_locate,
@@ -339,6 +340,7 @@ pub(crate) fn run_cli() -> Result<()> {
             &mut local_usage_draft,
             &mut ui,
         ),
+        CommandRoot::Export(args) => run_export(args, data_root.clone(), &mut ui),
         CommandRoot::Pro(args) => {
             let validation = args.validate_invocation();
             if validation.is_err() && !data_root.exists() {
@@ -553,6 +555,7 @@ fn command_json_output(command: &CommandRoot) -> bool {
             crate::LocateTarget::Event(args) => args.format.is_json(),
         },
         CommandRoot::Search(args) => args.format.is_json(),
+        CommandRoot::Export(_) => true,
         CommandRoot::Pro(args) => args.json_output(),
         CommandRoot::Referral(args) => args.json_output(),
         CommandRoot::Blame(args) => args.json_output(),

--- a/crates/ctx-cli/src/local_usage/mod.rs
+++ b/crates/ctx-cli/src/local_usage/mod.rs
@@ -335,7 +335,7 @@ impl CliUsage {
                 Some(args.local_usage_operation()),
                 TargetType::NotApplicable,
             ),
-            CommandRoot::Referral(_) => (None, TargetType::NotApplicable),
+            CommandRoot::Referral(_) | CommandRoot::Export(_) => (None, TargetType::NotApplicable),
             CommandRoot::Blame(_) => (Some("blame"), TargetType::NotApplicable),
             CommandRoot::Docs(_) => (Some("docs"), TargetType::NotApplicable),
             CommandRoot::Integrations(_) => (Some("integrations"), TargetType::NotApplicable),

--- a/crates/ctx-cli/tests/cli_public_help_docs.rs
+++ b/crates/ctx-cli/tests/cli_public_help_docs.rs
@@ -129,6 +129,7 @@ fn help_exposes_session_retrieval_commands() {
         "show",
         "locate",
         "search",
+        "export",
         "docs",
         "mcp",
         "integrations",
@@ -150,7 +151,6 @@ fn help_exposes_session_retrieval_commands() {
         "record",
         "research",
         "list",
-        "export",
         "validate",
         "report",
         "schema",
@@ -647,6 +647,14 @@ fn public_subcommand_help_is_golden_enough_for_session_retrieval() {
         ),
         ("show", vec!["Usage: ctx show", "session", "event"]),
         (
+            "export",
+            vec![
+                "Usage: ctx export",
+                "events",
+                "Export bounded data from one immutable Core generation",
+            ],
+        ),
+        (
             "docs",
             vec![
                 "Usage: ctx docs",
@@ -759,6 +767,7 @@ fn machine_readable_output_uses_format_without_a_json_alias() {
         &["import", "--help"],
         &["show", "session", "--help"],
         &["show", "event", "--help"],
+        &["export", "events", "--help"],
         &["search", "--help"],
         &["pro", "--help"],
         &["pro", "setup", "--help"],
@@ -1213,7 +1222,6 @@ fn removed_public_commands_are_rejected() {
     for removed in [
         "context",
         "list",
-        "export",
         "validate",
         "materialize",
         "related",

--- a/crates/ctx-cli/tests/export_events.rs
+++ b/crates/ctx-cli/tests/export_events.rs
@@ -1,0 +1,533 @@
+mod support;
+
+use std::{fs, path::Path};
+
+use ctx_history_core::{
+    derive_event_id, derive_session_id, CertifiedSource, CoreContentPolicyStatus, CoreRecord,
+    EventIdentityInput, NativeItemKey, NativeSessionKey, ScannedSourceCounts, SessionIdentityInput,
+    SourceAnchor, SourceKey, SourceObservation, TypedKey,
+};
+use ctx_history_index::{GenerationWriter, WriterOptions};
+use serde_json::Value;
+
+use support::{ctx, data_root, tempdir, TempDir};
+
+fn source(provider: &str, source_path: &Path) -> SourceKey {
+    SourceKey::derive(
+        provider,
+        format!("{provider}_session_jsonl"),
+        "session",
+        1,
+        SourceAnchor::provider_native(
+            "session-file",
+            TypedKey::utf8(source_path.display().to_string()).unwrap(),
+        )
+        .unwrap(),
+    )
+    .unwrap()
+}
+
+fn record(source: &SourceKey, nonce: u64, occurred_at_unix_ms: i64, body: &str) -> CoreRecord {
+    let session_key = NativeSessionKey::native_id(
+        "session",
+        TypedKey::utf8(format!("session-{nonce}")).unwrap(),
+    )
+    .unwrap();
+    let session_id = derive_session_id(SessionIdentityInput {
+        source,
+        logical_session_kind: "thread",
+        native_session_key: &session_key,
+    })
+    .unwrap();
+    let item_key = NativeItemKey::native_id("message", TypedKey::U64(nonce)).unwrap();
+    let event_id = derive_event_id(EventIdentityInput {
+        source,
+        session_id,
+        logical_item_kind: "message",
+        native_item_key: &item_key,
+        subrecord_selector: None,
+    })
+    .unwrap();
+    let mut record = CoreRecord::new_selected(
+        event_id,
+        session_id,
+        session_id,
+        source.clone(),
+        nonce % 2,
+        "message",
+        "primary",
+        true,
+        "event-export-integration-v1",
+        body,
+    )
+    .unwrap();
+    record.occurred_at_unix_ms = Some(occurred_at_unix_ms);
+    record.provider_session_id = Some(format!("provider-session-{nonce}"));
+    record.native_event_id = Some(TypedKey::U64(nonce));
+    record.role = Some("user".to_owned());
+    record.workspace = Some("工作区/ctx".to_owned());
+    record.cwd = Some("/workspace/ctx".to_owned());
+    record
+}
+
+fn publish(data_root: &Path, revision: u8, sources: &[(SourceKey, Vec<CoreRecord>)]) -> String {
+    let index_root = data_root.join("search/lexical");
+    let mut writer = GenerationWriter::open(&index_root, WriterOptions::default()).unwrap();
+    for (source, records) in sources {
+        writer.begin_source(source.clone()).unwrap();
+        for record in records {
+            writer.add_core_record(record.clone()).unwrap();
+        }
+        let observation =
+            SourceObservation::new(source.clone(), "regular-file-v1", vec![revision]).unwrap();
+        writer
+            .certify_source(
+                CertifiedSource::certify(
+                    observation.clone(),
+                    observation,
+                    "event-export-integration-v1",
+                    [revision; 32],
+                    ScannedSourceCounts {
+                        complete_records: records.len() as u64,
+                        retained_records: records.len() as u64,
+                        indexed_documents: records.len() as u64,
+                        certified_bytes: records.len() as u64 * 10,
+                        ..ScannedSourceCounts::default()
+                    },
+                )
+                .unwrap(),
+            )
+            .unwrap();
+    }
+    writer.commit(|_| true).unwrap().generation_id
+}
+
+fn fixture() -> (TempDir, Vec<CoreRecord>) {
+    let temp = tempdir();
+    let codex_path = temp.path().join("deleted-codex-source.jsonl");
+    let claude_path = temp.path().join("deleted-claude-source.jsonl");
+    fs::write(&codex_path, b"original source").unwrap();
+    fs::write(&claude_path, b"original source").unwrap();
+    let codex = source("codex", &codex_path);
+    let claude = source("claude", &claude_path);
+    let mut records = vec![
+        record(&codex, 1, 1_700_000_000_000, "héllo 🦀"),
+        record(&claude, 2, 1_700_000_000_000, "structured"),
+        record(&codex, 3, 1_700_000_000_001, "[redacted]"),
+        record(&claude, 4, 1_700_000_000_002, "omitted"),
+        record(&codex, 5, 1_700_000_000_003, &"large雪".repeat(700)),
+    ];
+    records[1].content.structured_content =
+        Some(serde_json::json!({"nested": [1, true, {"emoji": "🧭"}]}));
+    records[2].content.policy_status = CoreContentPolicyStatus::Redacted {
+        reason: "provider_secret".to_owned(),
+    };
+    records[3].content.policy_status = CoreContentPolicyStatus::Omitted {
+        reason: "unsupported_binary".to_owned(),
+    };
+    records[3].content.normalized_body = None;
+    records[3].agent_type = "subagent".to_owned();
+    records[3].is_primary = false;
+    let codex_records = records
+        .iter()
+        .filter(|record| record.source.provider() == "codex")
+        .cloned()
+        .collect::<Vec<_>>();
+    let claude_records = records
+        .iter()
+        .filter(|record| record.source.provider() == "claude")
+        .cloned()
+        .collect::<Vec<_>>();
+    publish(
+        &data_root(&temp),
+        1,
+        &[(codex, codex_records), (claude, claude_records)],
+    );
+    fs::remove_file(codex_path).unwrap();
+    fs::remove_file(claude_path).unwrap();
+    (temp, records)
+}
+
+fn base_args() -> Vec<&'static str> {
+    vec![
+        "export",
+        "events",
+        "--since",
+        "2023-11-14T22:13:20Z",
+        "--until",
+        "2023-11-14T22:13:21Z",
+    ]
+}
+
+fn json_ids(value: &Value) -> Vec<String> {
+    value["events"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|event| event["ctx_event_id"].as_str().unwrap().to_owned())
+        .collect()
+}
+
+#[test]
+fn json_and_jsonl_export_identical_complete_core_ids_without_source_io() {
+    let (temp, records) = fixture();
+    let mut json_args = base_args();
+    json_args.extend(["--max-items", "100", "--format", "json"]);
+    let json_output = ctx(&temp).args(&json_args).output().unwrap();
+    assert!(
+        json_output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&json_output.stderr)
+    );
+    assert!(json_output.stderr.is_empty());
+    let page: Value = serde_json::from_slice(&json_output.stdout).unwrap();
+    assert!(page["terminal"].as_bool().unwrap());
+    assert!(page["next_cursor"].is_null());
+    assert_eq!(page["usage"]["items"], records.len());
+    assert_eq!(page["usage"]["bytes"], json_output.stdout.len());
+    assert!(page["events"].as_array().unwrap().iter().all(|event| {
+        event["schema_version"] == 1
+            && event.get("item_id").is_none()
+            && event.get("sequence").is_none()
+    }));
+    let representative = &page["events"][0];
+    for field in [
+        "ctx_event_id",
+        "ctx_source_id",
+        "ctx_session_id",
+        "root_ctx_session_id",
+        "provider",
+        "source_format",
+        "provider_session_id",
+        "native_event_id",
+        "event_sequence",
+        "occurred_at_unix_ms",
+        "event_type",
+        "role",
+        "workspace",
+        "cwd",
+        "content",
+    ] {
+        assert!(representative.get(field).is_some(), "missing {field}");
+    }
+    assert!(page["events"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|event| { event["agent_type"] == "subagent" && event["is_primary"] == false }));
+    assert!(page["events"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|event| { event["structured_content"]["nested"][2]["emoji"] == "🧭" }));
+    assert!(page["events"].as_array().unwrap().iter().any(|event| {
+        event["content"]["policy_status"] == "redacted" && event["content"]["complete"] == false
+    }));
+    assert!(page["events"].as_array().unwrap().iter().any(|event| {
+        event["content"]["policy_status"] == "omitted" && event.get("text").is_none()
+    }));
+
+    let mut jsonl_args = base_args();
+    jsonl_args.extend(["--max-items", "1", "--format", "jsonl"]);
+    let jsonl_output = ctx(&temp).args(&jsonl_args).output().unwrap();
+    assert!(
+        jsonl_output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&jsonl_output.stderr)
+    );
+    assert!(jsonl_output.stderr.is_empty());
+    let jsonl_ids = String::from_utf8(jsonl_output.stdout)
+        .unwrap()
+        .lines()
+        .map(|line| {
+            let event: Value = serde_json::from_str(line).unwrap();
+            event["ctx_event_id"].as_str().unwrap().to_owned()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(json_ids(&page), jsonl_ids);
+
+    let mut provider_args = base_args();
+    provider_args.extend([
+        "--provider",
+        "codex",
+        "--provider",
+        "codex",
+        "--max-items",
+        "100",
+    ]);
+    let provider_output = ctx(&temp).args(&provider_args).output().unwrap();
+    assert!(provider_output.status.success());
+    assert!(provider_output.stderr.is_empty());
+    let provider_page: Value = serde_json::from_slice(&provider_output.stdout).unwrap();
+    assert!(provider_page["events"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|event| event["provider"] == "codex"));
+    assert!(!data_root(&temp).join("usage.sqlite").exists());
+}
+
+#[test]
+fn json_pages_resume_exactly_and_enforce_final_wire_boundaries() {
+    let (temp, _) = fixture();
+    let mut one_page_args = base_args();
+    one_page_args.extend(["--max-items", "100"]);
+    let full = ctx(&temp).args(&one_page_args).output().unwrap();
+    assert!(full.status.success());
+    let expected: Value = serde_json::from_slice(&full.stdout).unwrap();
+
+    let exact_limit = full.stdout.len().to_string();
+    let mut exact_args = base_args();
+    exact_args.extend(["--max-items", "100", "--max-bytes", &exact_limit]);
+    let exact = ctx(&temp).args(&exact_args).output().unwrap();
+    assert!(exact.status.success());
+    assert_eq!(exact.stdout.len(), full.stdout.len());
+
+    let mut cursor: Option<String> = None;
+    let mut ids = Vec::new();
+    loop {
+        let mut owned = base_args()
+            .into_iter()
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        owned.extend(["--max-items".to_owned(), "2".to_owned()]);
+        if let Some(cursor) = &cursor {
+            owned.extend(["--cursor".to_owned(), cursor.clone()]);
+        }
+        let output = ctx(&temp).args(&owned).output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(output.stderr.is_empty());
+        let page: Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(page["usage"]["bytes"], output.stdout.len());
+        ids.extend(json_ids(&page));
+        if page["terminal"].as_bool().unwrap() {
+            break;
+        }
+        cursor = Some(page["next_cursor"].as_str().unwrap().to_owned());
+    }
+    assert_eq!(ids, json_ids(&expected));
+
+    let smaller_limit = (full.stdout.len() - 1).to_string();
+    let mut smaller_args = base_args();
+    smaller_args.extend(["--max-items", "100", "--max-bytes", &smaller_limit]);
+    let smaller = ctx(&temp).args(&smaller_args).output().unwrap();
+    assert!(smaller.status.success());
+    assert!(smaller.stdout.len() < full.stdout.len());
+    let page: Value = serde_json::from_slice(&smaller.stdout).unwrap();
+    assert!(!page["terminal"].as_bool().unwrap());
+    assert!(page["next_cursor"].is_string());
+}
+
+#[test]
+fn cursor_tamper_mismatch_eviction_and_oversized_singleton_are_typed() {
+    let (temp, records) = fixture();
+    for args in [
+        [
+            "export",
+            "events",
+            "--since",
+            "2023-11-14T22:13:20Z",
+            "--until",
+            "2023-11-14T22:13:20Z",
+        ],
+        [
+            "export",
+            "events",
+            "--since",
+            "2023-11-14T22:13:20",
+            "--until",
+            "2023-11-14T22:13:21Z",
+        ],
+    ] {
+        let output = ctx(&temp).args(args).output().unwrap();
+        assert!(!output.status.success());
+        assert!(output.stdout.is_empty());
+        let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+        assert_eq!(error["error_code"], "invalid_range");
+    }
+    let mut first_args = base_args();
+    first_args.extend(["--max-items", "1"]);
+    let first = ctx(&temp).args(&first_args).output().unwrap();
+    let first_page: Value = serde_json::from_slice(&first.stdout).unwrap();
+    let cursor = first_page["next_cursor"].as_str().unwrap();
+
+    let mut tampered = cursor.to_owned();
+    let replacement = if tampered.ends_with('A') { 'B' } else { 'A' };
+    tampered.pop();
+    tampered.push(replacement);
+    let mut tamper_args = base_args();
+    tamper_args.extend(["--cursor", &tampered]);
+    let tamper = ctx(&temp).args(&tamper_args).output().unwrap();
+    assert!(!tamper.status.success());
+    assert!(tamper.stdout.is_empty());
+    let error: Value = serde_json::from_slice(&tamper.stderr).unwrap();
+    assert_eq!(error["error_code"], "invalid_cursor");
+
+    let mismatch = ctx(&temp)
+        .args([
+            "export",
+            "events",
+            "--since",
+            "2023-11-14T22:13:20Z",
+            "--until",
+            "2023-11-14T22:13:22Z",
+            "--cursor",
+            cursor,
+        ])
+        .output()
+        .unwrap();
+    assert!(!mismatch.status.success());
+    assert!(mismatch.stdout.is_empty());
+    let error: Value = serde_json::from_slice(&mismatch.stderr).unwrap();
+    assert_eq!(error["error_code"], "cursor_request_mismatch");
+
+    let before_large = ctx(&temp)
+        .args([
+            "export",
+            "events",
+            "--since",
+            "2023-11-14T22:13:20.002Z",
+            "--until",
+            "2023-11-14T22:13:20.004Z",
+            "--max-items",
+            "1",
+        ])
+        .output()
+        .unwrap();
+    let before_large: Value = serde_json::from_slice(&before_large.stdout).unwrap();
+    let before_large_cursor = before_large["next_cursor"].as_str().unwrap();
+    let oversized_continuation = ctx(&temp)
+        .args([
+            "export",
+            "events",
+            "--since",
+            "2023-11-14T22:13:20.002Z",
+            "--until",
+            "2023-11-14T22:13:20.004Z",
+            "--cursor",
+            before_large_cursor,
+            "--max-bytes",
+            "512",
+        ])
+        .output()
+        .unwrap();
+    assert!(!oversized_continuation.status.success());
+    assert!(oversized_continuation.stdout.is_empty());
+    let error: Value = serde_json::from_slice(&oversized_continuation.stderr).unwrap();
+    assert_eq!(error["error_code"], "event_too_large");
+    assert_eq!(error["cursor"], before_large_cursor);
+
+    let jsonl_partial = ctx(&temp)
+        .args([
+            "export",
+            "events",
+            "--since",
+            "2023-11-14T22:13:20.002Z",
+            "--until",
+            "2023-11-14T22:13:20.004Z",
+            "--format",
+            "jsonl",
+            "--max-bytes",
+            "1024",
+        ])
+        .output()
+        .unwrap();
+    assert!(!jsonl_partial.status.success());
+    assert!(jsonl_partial.stdout.len() <= 1024);
+    let emitted: Value = serde_json::from_slice(&jsonl_partial.stdout).unwrap();
+    assert_eq!(
+        emitted["ctx_event_id"],
+        records[3].event_id.as_uuid().to_string()
+    );
+    let error: Value = serde_json::from_slice(&jsonl_partial.stderr).unwrap();
+    assert_eq!(error["error_code"], "event_too_large");
+    let restart_cursor = error["cursor"].as_str().unwrap();
+    let resumed = ctx(&temp)
+        .args([
+            "export",
+            "events",
+            "--since",
+            "2023-11-14T22:13:20.002Z",
+            "--until",
+            "2023-11-14T22:13:20.004Z",
+            "--format",
+            "jsonl",
+            "--cursor",
+            restart_cursor,
+            "--max-bytes",
+            "8192",
+        ])
+        .output()
+        .unwrap();
+    assert!(resumed.status.success());
+    assert!(resumed.stderr.is_empty());
+    let resumed: Value = serde_json::from_slice(&resumed.stdout).unwrap();
+    assert_eq!(
+        resumed["ctx_event_id"],
+        records[4].event_id.as_uuid().to_string()
+    );
+
+    let codex = records[0].source.clone();
+    let claude = records[1].source.clone();
+    let codex_records = records
+        .iter()
+        .filter(|record| record.source.provider() == "codex")
+        .cloned()
+        .collect::<Vec<_>>();
+    let claude_records = records
+        .iter()
+        .filter(|record| record.source.provider() == "claude")
+        .cloned()
+        .collect::<Vec<_>>();
+    publish(
+        &data_root(&temp),
+        2,
+        &[
+            (codex.clone(), codex_records.clone()),
+            (claude.clone(), claude_records.clone()),
+        ],
+    );
+    let mut retained_args = base_args();
+    retained_args.extend(["--cursor", cursor]);
+    let retained = ctx(&temp).args(&retained_args).output().unwrap();
+    assert!(retained.status.success());
+    assert!(retained.stderr.is_empty());
+    let retained: Value = serde_json::from_slice(&retained.stdout).unwrap();
+    assert_eq!(retained["generation_id"], first_page["generation_id"]);
+
+    publish(
+        &data_root(&temp),
+        3,
+        &[(codex, codex_records), (claude, claude_records)],
+    );
+    let mut evicted_args = base_args();
+    evicted_args.extend(["--cursor", cursor]);
+    let evicted = ctx(&temp).args(&evicted_args).output().unwrap();
+    assert!(!evicted.status.success());
+    assert!(evicted.stdout.is_empty());
+    let error: Value = serde_json::from_slice(&evicted.stderr).unwrap();
+    assert_eq!(error["error_code"], "generation_not_retained");
+
+    let oversized = ctx(&temp)
+        .args([
+            "export",
+            "events",
+            "--since",
+            "2023-11-14T22:13:20.003Z",
+            "--until",
+            "2023-11-14T22:13:20.004Z",
+            "--max-bytes",
+            "512",
+        ])
+        .output()
+        .unwrap();
+    assert!(!oversized.status.success());
+    assert!(oversized.stdout.is_empty());
+    let error: Value = serde_json::from_slice(&oversized.stderr).unwrap();
+    assert_eq!(error["error_code"], "event_too_large");
+    assert!(error["cursor"].is_null());
+}

--- a/crates/ctx-history-index/src/lib.rs
+++ b/crates/ctx-history-index/src/lib.rs
@@ -64,14 +64,16 @@ pub(crate) use publication::{
     INDEX_GENERATIONS_DIRECTORY,
 };
 pub use query::{
-    AgentScope, CoreEventBatch, CoreEventPageBudget, CoreEventRecord, CoreSemanticEventPage,
+    AgentScope, CoreEventBatch, CoreEventPageBudget, CoreEventRangeCursor, CoreEventRangeError,
+    CoreEventRangePage, CoreEventRangeSelection, CoreEventRecord, CoreSemanticEventPage,
     CoreSessionEventPage, CoreSourceEventPage, EventRecord, EventSearchCandidate,
     EventSearchFilters, ExcludedSessionTree, LexicalQueryLimits, SemanticEligibility,
     SemanticEventCursor, SemanticEventPage, SessionEventCoordinate, SessionEventCursor,
     SessionRecord, SourceEventCursor, SourceEventPage, DEFAULT_CORE_EVENT_PAGE_BUDGET,
-    LEXICAL_QUERY_LIMITS, MAX_LEXICAL_QUERY_RESULTS, MAX_SEMANTIC_EVENT_PAGE_ITEMS,
-    MAX_SESSION_EVENT_COORDINATE_PREFIX_ITEMS, MAX_SESSION_EVENT_COORDINATE_WINDOW_ITEMS,
-    MAX_SESSION_EVENT_PAGE_ITEMS, MAX_SOURCE_EVENT_PAGE_ITEMS,
+    LEXICAL_QUERY_LIMITS, MAX_CORE_EVENT_RANGE_PAGE_ITEMS, MAX_LEXICAL_QUERY_RESULTS,
+    MAX_SEMANTIC_EVENT_PAGE_ITEMS, MAX_SESSION_EVENT_COORDINATE_PREFIX_ITEMS,
+    MAX_SESSION_EVENT_COORDINATE_WINDOW_ITEMS, MAX_SESSION_EVENT_PAGE_ITEMS,
+    MAX_SOURCE_EVENT_PAGE_ITEMS,
 };
 pub use reader::VerifiedIndex;
 #[cfg(test)]

--- a/crates/ctx-history-index/src/query.rs
+++ b/crates/ctx-history-index/src/query.rs
@@ -1,10 +1,12 @@
 mod contract;
+mod event_range;
 mod execution;
 mod filtering;
 mod records;
 mod verification;
 
 pub use contract::*;
+pub use event_range::*;
 use filtering::*;
 pub(crate) use records::stored_event_record;
 use records::{

--- a/crates/ctx-history-index/src/query/event_range.rs
+++ b/crates/ctx-history-index/src/query/event_range.rs
@@ -1,0 +1,518 @@
+use super::*;
+
+use sha2::{Digest, Sha256};
+
+use crate::is_generation_id;
+
+const EVENT_RANGE_CURSOR_VERSION: u8 = 1;
+const EVENT_RANGE_CURSOR_BYTES: usize = 161;
+pub const MAX_CORE_EVENT_RANGE_PAGE_ITEMS: usize = 4_096;
+const MAX_EVENT_RANGE_PROVIDERS: usize = 64;
+
+const MAX_PROVIDER_FILTER_BYTES: usize = 256;
+const CURSOR_PAYLOAD_BYTES: usize = EVENT_RANGE_CURSOR_BYTES - 32;
+const CURSOR_DOMAIN: &[u8] = b"ctx-core-event-range-cursor-v1\0";
+const SELECTION_DOMAIN: &[u8] = b"ctx-core-event-range-selection-v1\0";
+
+type EventRangeSortKey = (i64, u64, u64, u64);
+
+#[derive(Debug, thiserror::Error)]
+pub enum CoreEventRangeError {
+    #[error(transparent)]
+    Index(#[from] IndexError),
+    #[error(
+        "event range must be nonempty and half-open: since {since_unix_ms}, until {until_unix_ms}"
+    )]
+    InvalidRange {
+        since_unix_ms: i64,
+        until_unix_ms: i64,
+    },
+    #[error("invalid event range provider selection")]
+    InvalidProviderSelection,
+    #[error("event range page size {requested} is outside 1..={maximum}")]
+    InvalidPageSize { requested: usize, maximum: usize },
+    #[error("invalid event range cursor encoding or integrity")]
+    InvalidCursor,
+    #[error("event range cursor selection does not match this request")]
+    CursorSelectionMismatch,
+    #[error("event range cursor generation {cursor_generation} does not match pinned generation {pinned_generation}")]
+    CursorGenerationMismatch {
+        cursor_generation: String,
+        pinned_generation: String,
+    },
+    #[error("invalid event range cursor coordinate")]
+    InvalidCursorCoordinate,
+}
+
+type CoreEventRangeResult<T> = std::result::Result<T, CoreEventRangeError>;
+
+/// Canonical half-open event selection shared by first and continuation pages.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoreEventRangeSelection {
+    since_unix_ms: i64,
+    until_unix_ms: i64,
+    providers: Vec<String>,
+    digest: [u8; 32],
+}
+
+impl CoreEventRangeSelection {
+    pub fn new<I, S>(
+        since_unix_ms: i64,
+        until_unix_ms: i64,
+        providers: I,
+    ) -> CoreEventRangeResult<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        if since_unix_ms >= until_unix_ms {
+            return Err(CoreEventRangeError::InvalidRange {
+                since_unix_ms,
+                until_unix_ms,
+            });
+        }
+        let mut providers = providers
+            .into_iter()
+            .map(Into::into)
+            .map(|provider: String| provider.trim().to_owned())
+            .collect::<Vec<_>>();
+        if providers.iter().any(String::is_empty) {
+            return Err(CoreEventRangeError::InvalidProviderSelection);
+        }
+        if providers
+            .iter()
+            .any(|provider| provider.len() > MAX_PROVIDER_FILTER_BYTES)
+        {
+            return Err(CoreEventRangeError::InvalidProviderSelection);
+        }
+        providers.sort_unstable();
+        providers.dedup();
+        if providers.len() > MAX_EVENT_RANGE_PROVIDERS {
+            return Err(CoreEventRangeError::InvalidProviderSelection);
+        }
+        let digest = selection_digest(since_unix_ms, until_unix_ms, &providers);
+        Ok(Self {
+            since_unix_ms,
+            until_unix_ms,
+            providers,
+            digest,
+        })
+    }
+
+    fn accepts_provider(&self, provider: &str) -> bool {
+        self.providers.is_empty()
+            || self
+                .providers
+                .binary_search_by(|candidate| candidate.as_str().cmp(provider))
+                .is_ok()
+    }
+
+    pub fn cursor_for(
+        &self,
+        generation_id: &str,
+        event: &CoreEventRecord,
+    ) -> CoreEventRangeResult<CoreEventRangeCursor> {
+        let coordinate = CoreEventRangeCoordinate::from_event(event)?;
+        if !self.accepts_coordinate(coordinate) || !self.accepts_provider(&event.provider) {
+            return Err(CoreEventRangeError::InvalidCursorCoordinate);
+        }
+        CoreEventRangeCursor::new(generation_id, self.digest, coordinate)
+    }
+
+    fn accepts_coordinate(&self, coordinate: CoreEventRangeCoordinate) -> bool {
+        (self.since_unix_ms..self.until_unix_ms).contains(&coordinate.occurred_at_unix_ms)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct CoreEventRangeCoordinate {
+    occurred_at_unix_ms: i64,
+    event_sequence: u64,
+    event_id: Uuid,
+}
+
+impl CoreEventRangeCoordinate {
+    fn from_event(event: &CoreEventRecord) -> CoreEventRangeResult<Self> {
+        let occurred_at_unix_ms = event
+            .occurred_at_unix_ms
+            .ok_or(CoreEventRangeError::InvalidCursorCoordinate)?;
+        Ok(Self {
+            occurred_at_unix_ms,
+            event_sequence: event.event_sequence,
+            event_id: event.event_id.as_uuid(),
+        })
+    }
+
+    fn from_sort_key(key: EventRangeSortKey) -> Self {
+        Self {
+            occurred_at_unix_ms: key.0,
+            event_sequence: key.1,
+            event_id: Uuid::from_u128((u128::from(key.2) << 64) | u128::from(key.3)),
+        }
+    }
+}
+
+/// Fixed-size, versioned, tamper-evident cursor for one immutable generation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoreEventRangeCursor {
+    generation_id: String,
+    selection_digest: [u8; 32],
+    after: CoreEventRangeCoordinate,
+}
+
+impl CoreEventRangeCursor {
+    fn new(
+        generation_id: &str,
+        selection_digest: [u8; 32],
+        after: CoreEventRangeCoordinate,
+    ) -> CoreEventRangeResult<Self> {
+        if !is_generation_id(generation_id) {
+            return Err(CoreEventRangeError::InvalidCursor);
+        }
+        Ok(Self {
+            generation_id: generation_id.to_owned(),
+            selection_digest,
+            after,
+        })
+    }
+
+    pub fn generation_id(&self) -> &str {
+        &self.generation_id
+    }
+
+    pub fn validate_selection(
+        &self,
+        selection: &CoreEventRangeSelection,
+    ) -> CoreEventRangeResult<()> {
+        if self.selection_digest != selection.digest {
+            return Err(CoreEventRangeError::CursorSelectionMismatch);
+        }
+        if !selection.accepts_coordinate(self.after) {
+            return Err(CoreEventRangeError::InvalidCursorCoordinate);
+        }
+        Ok(())
+    }
+
+    pub fn encode(&self) -> [u8; EVENT_RANGE_CURSOR_BYTES] {
+        let mut encoded = [0_u8; EVENT_RANGE_CURSOR_BYTES];
+        encoded[0] = EVENT_RANGE_CURSOR_VERSION;
+        encoded[1..65].copy_from_slice(self.generation_id.as_bytes());
+        encoded[65..97].copy_from_slice(&self.selection_digest);
+        encoded[97..105].copy_from_slice(&self.after.occurred_at_unix_ms.to_be_bytes());
+        encoded[105..113].copy_from_slice(&self.after.event_sequence.to_be_bytes());
+        encoded[113..129].copy_from_slice(self.after.event_id.as_bytes());
+        let checksum = cursor_checksum(&encoded[..CURSOR_PAYLOAD_BYTES]);
+        encoded[CURSOR_PAYLOAD_BYTES..].copy_from_slice(&checksum);
+        encoded
+    }
+
+    pub fn decode(encoded: &[u8]) -> CoreEventRangeResult<Self> {
+        if encoded.len() != EVENT_RANGE_CURSOR_BYTES {
+            return Err(CoreEventRangeError::InvalidCursor);
+        }
+        if encoded[0] != EVENT_RANGE_CURSOR_VERSION {
+            return Err(CoreEventRangeError::InvalidCursor);
+        }
+        if cursor_checksum(&encoded[..CURSOR_PAYLOAD_BYTES]) != encoded[CURSOR_PAYLOAD_BYTES..] {
+            return Err(CoreEventRangeError::InvalidCursor);
+        }
+        let generation_id =
+            std::str::from_utf8(&encoded[1..65]).map_err(|_| CoreEventRangeError::InvalidCursor)?;
+        let selection_digest = fixed_cursor_bytes(&encoded[65..97])?;
+        let occurred_at_unix_ms = i64::from_be_bytes(fixed_cursor_bytes(&encoded[97..105])?);
+        let event_sequence = u64::from_be_bytes(fixed_cursor_bytes(&encoded[105..113])?);
+        let event_id = Uuid::from_bytes(fixed_cursor_bytes(&encoded[113..129])?);
+        Self::new(
+            generation_id,
+            selection_digest,
+            CoreEventRangeCoordinate {
+                occurred_at_unix_ms,
+                event_sequence,
+                event_id,
+            },
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoreEventRangePage {
+    pub generation_id: String,
+    pub items: Vec<CoreEventRecord>,
+    pub next_cursor: Option<CoreEventRangeCursor>,
+    pub terminal: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EventRangeAddressCandidate {
+    coordinate: CoreEventRangeCoordinate,
+    address: DocAddress,
+}
+
+impl VerifiedIndex {
+    pub fn core_event_range_page(
+        &self,
+        selection: &CoreEventRangeSelection,
+        cursor: Option<&CoreEventRangeCursor>,
+        limit: usize,
+    ) -> CoreEventRangeResult<CoreEventRangePage> {
+        if !(1..=MAX_CORE_EVENT_RANGE_PAGE_ITEMS).contains(&limit) {
+            return Err(CoreEventRangeError::InvalidPageSize {
+                requested: limit,
+                maximum: MAX_CORE_EVENT_RANGE_PAGE_ITEMS,
+            });
+        }
+        if let Some(cursor) = cursor {
+            if cursor.generation_id != self.generation_id {
+                return Err(CoreEventRangeError::CursorGenerationMismatch {
+                    cursor_generation: cursor.generation_id.clone(),
+                    pinned_generation: self.generation_id.clone(),
+                });
+            }
+            cursor.validate_selection(selection)?;
+            self.validate_event_range_cursor(selection, cursor)?;
+        }
+
+        let fields = fields_from_schema(self.searcher.schema())?;
+        let candidates = self.event_range_candidates(
+            selection,
+            cursor.map(|cursor| cursor.after),
+            limit.saturating_add(1),
+            fields,
+        )?;
+        let candidate_count = candidates.len();
+        let mut items = Vec::with_capacity(limit.min(candidate_count));
+        let mut encoded_core_bytes = 0_usize;
+        let mut content_bytes = 0_usize;
+
+        for candidate in candidates.iter().copied().take(limit) {
+            let (preflight_id, candidate_encoded_bytes, candidate_content_bytes) =
+                core_event_fast_preflight(&self.searcher, candidate.address)?;
+            if preflight_id != candidate.coordinate.event_id {
+                return Err(CoreEventRangeError::InvalidCursorCoordinate);
+            }
+            if !items.is_empty()
+                && (!budget_admits(
+                    encoded_core_bytes,
+                    candidate_encoded_bytes,
+                    DEFAULT_CORE_EVENT_PAGE_BUDGET.maximum_encoded_core_bytes,
+                ) || !budget_admits(
+                    content_bytes,
+                    candidate_content_bytes,
+                    DEFAULT_CORE_EVENT_PAGE_BUDGET.maximum_content_bytes,
+                ))
+            {
+                break;
+            }
+            let (record, actual_encoded_bytes) =
+                stored_core_event_record_with_size(&self.searcher, candidate.address, fields)?;
+            let actual_content_bytes = core_content_bytes(&record.core_record.content)?;
+            if actual_encoded_bytes != candidate_encoded_bytes
+                || actual_content_bytes != candidate_content_bytes
+                || CoreEventRangeCoordinate::from_event(&record)? != candidate.coordinate
+                || !selection.accepts_provider(&record.provider)
+            {
+                return Err(CoreEventRangeError::InvalidCursorCoordinate);
+            }
+            encoded_core_bytes = encoded_core_bytes
+                .checked_add(actual_encoded_bytes)
+                .ok_or(IndexError::CountOverflow)?;
+            content_bytes = content_bytes
+                .checked_add(actual_content_bytes)
+                .ok_or(IndexError::CountOverflow)?;
+            items.push(record);
+        }
+
+        let terminal = items.len() == candidate_count;
+        let next_cursor = if terminal {
+            None
+        } else {
+            items
+                .last()
+                .map(|event| selection.cursor_for(&self.generation_id, event))
+                .transpose()?
+        };
+        if !terminal && next_cursor.is_none() {
+            return Err(CoreEventRangeError::InvalidCursorCoordinate);
+        }
+        Ok(CoreEventRangePage {
+            generation_id: self.generation_id.clone(),
+            items,
+            next_cursor,
+            terminal,
+        })
+    }
+
+    fn validate_event_range_cursor(
+        &self,
+        selection: &CoreEventRangeSelection,
+        cursor: &CoreEventRangeCursor,
+    ) -> CoreEventRangeResult<()> {
+        let Some(event) = self.core_event_by_id(cursor.after.event_id)? else {
+            return Err(CoreEventRangeError::InvalidCursorCoordinate);
+        };
+        if CoreEventRangeCoordinate::from_event(&event)? != cursor.after
+            || !selection.accepts_provider(&event.provider)
+        {
+            return Err(CoreEventRangeError::InvalidCursorCoordinate);
+        }
+        Ok(())
+    }
+
+    fn event_range_candidates(
+        &self,
+        selection: &CoreEventRangeSelection,
+        after: Option<CoreEventRangeCoordinate>,
+        limit: usize,
+        fields: Fields,
+    ) -> CoreEventRangeResult<Vec<EventRangeAddressCandidate>> {
+        validate_session_event_coordinate_fast_fields(&self.searcher)?;
+        let query = event_range_query(selection, after, fields);
+        let collector = TopDocs::with_limit(limit).tweak_score(event_range_score);
+        type EventRangeHit = (Reverse<EventRangeSortKey>, DocAddress);
+        let hits: Vec<EventRangeHit> = self
+            .searcher
+            .search(query.as_ref(), &collector)
+            .map_err(IndexError::from)?;
+        let mut candidates = hits
+            .into_iter()
+            .map(|(Reverse(key), address)| EventRangeAddressCandidate {
+                coordinate: CoreEventRangeCoordinate::from_sort_key(key),
+                address,
+            })
+            .collect::<Vec<_>>();
+        candidates.sort_by_key(|candidate| candidate.coordinate);
+        if candidates
+            .windows(2)
+            .any(|pair| pair[0].coordinate >= pair[1].coordinate)
+        {
+            return Err(CoreEventRangeError::InvalidCursorCoordinate);
+        }
+        Ok(candidates)
+    }
+}
+
+fn event_range_query(
+    selection: &CoreEventRangeSelection,
+    after: Option<CoreEventRangeCoordinate>,
+    fields: Fields,
+) -> Box<dyn Query> {
+    let mut clauses: Vec<(Occur, Box<dyn Query>)> = vec![(
+        Occur::Must,
+        Box::new(RangeQuery::new(
+            Bound::Included(Term::from_field_i64(
+                fields.occurred_at_unix_ms,
+                selection.since_unix_ms,
+            )),
+            Bound::Excluded(Term::from_field_i64(
+                fields.occurred_at_unix_ms,
+                selection.until_unix_ms,
+            )),
+        )),
+    )];
+    if !selection.providers.is_empty() {
+        clauses.push((
+            Occur::Must,
+            Box::new(TermSetQuery::new(
+                selection
+                    .providers
+                    .iter()
+                    .map(|provider| Term::from_field_text(fields.provider, provider))
+                    .collect::<Vec<_>>(),
+            )),
+        ));
+    }
+    if let Some(after) = after {
+        let occurred = Term::from_field_i64(fields.occurred_at_unix_ms, after.occurred_at_unix_ms);
+        let sequence = Term::from_field_u64(fields.event_sequence, after.event_sequence);
+        let event_id = Term::from_field_text(fields.event_id, &after.event_id.to_string());
+        clauses.push((
+            Occur::Must,
+            Box::new(BooleanQuery::union(vec![
+                strict_after(occurred.clone(), []),
+                strict_after(sequence.clone(), [occurred.clone()]),
+                strict_after(event_id, [occurred, sequence]),
+            ])),
+        ));
+    }
+    Box::new(BooleanQuery::new(clauses))
+}
+
+fn strict_after<const N: usize>(term: Term, equal: [Term; N]) -> Box<dyn Query> {
+    let mut clauses = equal
+        .into_iter()
+        .map(|term| Box::new(TermQuery::new(term, IndexRecordOption::Basic)) as Box<dyn Query>)
+        .collect::<Vec<_>>();
+    clauses.push(Box::new(RangeQuery::new(
+        Bound::Excluded(term),
+        Bound::Unbounded,
+    )));
+    Box::new(BooleanQuery::intersection(clauses))
+}
+
+fn event_range_score(
+    segment: &SegmentReader,
+) -> impl Fn(DocId, Score) -> Reverse<EventRangeSortKey> {
+    let occurred_at = segment.fast_fields().i64(OCCURRED_AT_UNIX_MS_FIELD).ok();
+    let sequence = segment
+        .fast_fields()
+        .u64(EVENT_SEQUENCE_FIELD)
+        .ok()
+        .map(|column| column.first_or_default_col(0));
+    let high = segment
+        .fast_fields()
+        .u64(EVENT_ID_HIGH_FIELD)
+        .ok()
+        .map(|column| column.first_or_default_col(0));
+    let low = segment
+        .fast_fields()
+        .u64(EVENT_ID_LOW_FIELD)
+        .ok()
+        .map(|column| column.first_or_default_col(0));
+    move |doc, _score| {
+        Reverse((
+            occurred_at
+                .as_ref()
+                .and_then(|column| column.first(doc))
+                .unwrap_or(i64::MIN),
+            sequence.as_ref().map_or(0, |column| column.get_val(doc)),
+            high.as_ref().map_or(0, |column| column.get_val(doc)),
+            low.as_ref().map_or(0, |column| column.get_val(doc)),
+        ))
+    }
+}
+
+fn budget_admits(retained: usize, candidate: usize, maximum: usize) -> bool {
+    retained
+        .checked_add(candidate)
+        .is_some_and(|total| total <= maximum)
+}
+
+fn selection_digest(since: i64, until: i64, providers: &[String]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update(SELECTION_DOMAIN);
+    digest.update(since.to_be_bytes());
+    digest.update(until.to_be_bytes());
+    digest.update((providers.len() as u64).to_be_bytes());
+    for provider in providers {
+        digest.update((provider.len() as u64).to_be_bytes());
+        digest.update(provider.as_bytes());
+    }
+    digest.finalize().into()
+}
+
+fn cursor_checksum(payload: &[u8]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update(CURSOR_DOMAIN);
+    digest.update(payload);
+    digest.finalize().into()
+}
+
+fn fixed_cursor_bytes<const N: usize>(bytes: &[u8]) -> CoreEventRangeResult<[u8; N]> {
+    bytes
+        .try_into()
+        .map_err(|_| CoreEventRangeError::InvalidCursor)
+}
+
+#[cfg(test)]
+#[path = "event_range/tests.rs"]
+mod tests;

--- a/crates/ctx-history-index/src/query/event_range/tests.rs
+++ b/crates/ctx-history-index/src/query/event_range/tests.rs
@@ -1,0 +1,408 @@
+use std::{collections::BTreeSet, path::Path};
+
+use ctx_history_core::{
+    derive_event_id, derive_session_id, CertifiedSource, CoreContentPolicyStatus, CoreRecord,
+    EventIdentityInput, NativeItemKey, NativeSessionKey, ScannedSourceCounts, SessionIdentityInput,
+    SourceAnchor, SourceKey, SourceObservation, TypedKey,
+};
+use tempfile::tempdir;
+
+use super::*;
+use crate::{GenerationWriter, WriterOptions};
+
+fn test_source(provider: &str, name: &str) -> SourceKey {
+    SourceKey::derive(
+        provider,
+        format!("{provider}_session_test"),
+        "session",
+        1,
+        SourceAnchor::provider_native("session-file", TypedKey::utf8(name).unwrap()).unwrap(),
+    )
+    .unwrap()
+}
+
+fn record(
+    source: &SourceKey,
+    nonce: u64,
+    sequence: u64,
+    occurred_at_unix_ms: Option<i64>,
+    body: &str,
+) -> CoreRecord {
+    let native_session_key =
+        NativeSessionKey::native_id("session", TypedKey::utf8("session").unwrap()).unwrap();
+    let session_id = derive_session_id(SessionIdentityInput {
+        source,
+        logical_session_kind: "thread",
+        native_session_key: &native_session_key,
+    })
+    .unwrap();
+    let native_item_key = NativeItemKey::native_id("message", TypedKey::U64(nonce)).unwrap();
+    let event_id = derive_event_id(EventIdentityInput {
+        source,
+        session_id,
+        logical_item_kind: "message",
+        native_item_key: &native_item_key,
+        subrecord_selector: None,
+    })
+    .unwrap();
+    let mut record = CoreRecord::new_selected(
+        event_id,
+        session_id,
+        session_id,
+        source.clone(),
+        sequence,
+        "message",
+        "primary",
+        true,
+        "event-range-test-v1",
+        body,
+    )
+    .unwrap();
+    record.occurred_at_unix_ms = occurred_at_unix_ms;
+    record.provider_session_id = Some(format!("provider-session-{nonce}"));
+    record.native_event_id = Some(TypedKey::U64(nonce));
+    record.role = Some("user".to_owned());
+    record.workspace = Some("工作区/ctx".to_owned());
+    record.cwd = Some("/work/ctx".to_owned());
+    record
+}
+
+fn certificate(source: &SourceKey, revision: u8, documents: usize) -> CertifiedSource {
+    let observation =
+        SourceObservation::new(source.clone(), "regular-file-v1", vec![revision]).unwrap();
+    CertifiedSource::certify(
+        observation.clone(),
+        observation,
+        "event-range-test-parser-v1",
+        [revision; 32],
+        ScannedSourceCounts {
+            complete_records: documents as u64,
+            retained_records: documents as u64,
+            indexed_documents: documents as u64,
+            certified_bytes: documents as u64 * 10,
+            ..ScannedSourceCounts::default()
+        },
+    )
+    .unwrap()
+}
+
+fn publish(root: &Path, revision: u8, sources: &[(SourceKey, Vec<CoreRecord>)]) -> String {
+    let mut writer = GenerationWriter::open(root, WriterOptions::default()).unwrap();
+    for (source, records) in sources {
+        writer.begin_source(source.clone()).unwrap();
+        for record in records {
+            writer.add_core_record(record.clone()).unwrap();
+        }
+        writer
+            .certify_source(certificate(source, revision, records.len()))
+            .unwrap();
+    }
+    writer.commit(|_| true).unwrap().generation_id
+}
+
+fn sorted_ids(records: &[CoreRecord]) -> Vec<uuid::Uuid> {
+    let mut coordinates = records
+        .iter()
+        .filter_map(|record| {
+            record
+                .occurred_at_unix_ms
+                .map(|occurred| (occurred, record.event_sequence, record.event_id.as_uuid()))
+        })
+        .collect::<Vec<_>>();
+    coordinates.sort_unstable();
+    coordinates
+        .into_iter()
+        .map(|coordinate| coordinate.2)
+        .collect()
+}
+
+fn traverse(
+    index: &VerifiedIndex,
+    selection: &CoreEventRangeSelection,
+    limit: usize,
+) -> Vec<uuid::Uuid> {
+    let mut cursor = None;
+    let mut ids = Vec::new();
+    loop {
+        let page = index
+            .core_event_range_page(selection, cursor.as_ref(), limit)
+            .unwrap();
+        ids.extend(page.items.iter().map(|event| event.event_id.as_uuid()));
+        if page.terminal {
+            assert!(page.next_cursor.is_none());
+            return ids;
+        }
+        cursor = page.next_cursor;
+    }
+}
+
+#[test]
+fn range_is_half_open_timestamped_provider_neutral_and_tie_ordered() {
+    let temp = tempdir().unwrap();
+    let codex = test_source("codex", "codex");
+    let claude = test_source("claude", "claude");
+    let since = 1_700_000_000_000_i64;
+    let until = since + 10;
+    let mut records = [
+        record(&codex, 1, 9, None, "timestamp-less"),
+        record(&codex, 2, 1, Some(since - 1), "before"),
+        record(&codex, 3, 7, Some(since), "codex tie"),
+        record(&claude, 4, 7, Some(since), "claude tie"),
+        record(&codex, 5, 2, Some(until - 1), "inside"),
+        record(&claude, 6, 1, Some(until), "exclusive"),
+    ];
+    records[4].agent_type = "subagent".to_owned();
+    records[4].is_primary = false;
+    let codex_records = records
+        .iter()
+        .filter(|record| record.source.provider() == "codex")
+        .cloned()
+        .collect::<Vec<_>>();
+    let claude_records = records
+        .iter()
+        .filter(|record| record.source.provider() == "claude")
+        .cloned()
+        .collect::<Vec<_>>();
+    publish(
+        temp.path(),
+        1,
+        &[(codex, codex_records), (claude, claude_records)],
+    );
+    let index = VerifiedIndex::open(temp.path()).unwrap();
+    let selection = CoreEventRangeSelection::new(since, until, Vec::<String>::new()).unwrap();
+    let expected = sorted_ids(
+        &records
+            .iter()
+            .filter(|record| {
+                record
+                    .occurred_at_unix_ms
+                    .is_some_and(|timestamp| (since..until).contains(&timestamp))
+            })
+            .cloned()
+            .collect::<Vec<_>>(),
+    );
+    for limit in 1..=expected.len() {
+        assert_eq!(traverse(&index, &selection, limit), expected);
+    }
+
+    let codex_only = CoreEventRangeSelection::new(since, until, ["codex"]).unwrap();
+    let codex_ids = traverse(&index, &codex_only, 1);
+    assert_eq!(codex_ids.len(), 2);
+    assert!(codex_ids.contains(&records[4].event_id.as_uuid()));
+}
+
+#[test]
+fn randomized_oracle_has_no_gaps_or_duplicates_at_every_boundary() {
+    let temp = tempdir().unwrap();
+    let source = test_source("codex", "randomized");
+    let mut state = 0x7f4a_7c15_d3e2_91ab_u64;
+    let mut records = Vec::new();
+    for nonce in 0..96_u64 {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        let timestamp = 10_000 + i64::try_from((state >> 17) % 9).unwrap();
+        let sequence = (state >> 29) % 7;
+        records.push(record(
+            &source,
+            nonce,
+            sequence,
+            Some(timestamp),
+            &format!("event-{nonce}"),
+        ));
+    }
+    publish(temp.path(), 1, &[(source, records.clone())]);
+    let index = VerifiedIndex::open(temp.path()).unwrap();
+    let selection = CoreEventRangeSelection::new(10_000, 10_009, Vec::<String>::new()).unwrap();
+    let expected = sorted_ids(&records);
+    assert_eq!(
+        expected.iter().collect::<BTreeSet<_>>().len(),
+        expected.len()
+    );
+    for limit in 1..=expected.len() {
+        assert_eq!(
+            traverse(&index, &selection, limit),
+            expected,
+            "limit {limit}"
+        );
+    }
+}
+
+#[test]
+fn cursor_binds_version_generation_selection_coordinate_and_checksum() {
+    let temp = tempdir().unwrap();
+    let source = test_source("codex", "cursor");
+    let records = (0..3)
+        .map(|nonce| record(&source, nonce, nonce, Some(100 + nonce as i64), "body"))
+        .collect::<Vec<_>>();
+    let first_generation = publish(temp.path(), 1, &[(source.clone(), records.clone())]);
+    let first = VerifiedIndex::open(temp.path()).unwrap();
+    let selection = CoreEventRangeSelection::new(100, 200, ["codex", "codex"]).unwrap();
+    let page = first.core_event_range_page(&selection, None, 1).unwrap();
+    let cursor = page.next_cursor.unwrap();
+    let encoded = cursor.encode();
+    assert_eq!(CoreEventRangeCursor::decode(&encoded).unwrap(), cursor);
+
+    let mut tampered = encoded;
+    tampered[110] ^= 1;
+    assert!(matches!(
+        CoreEventRangeCursor::decode(&tampered),
+        Err(CoreEventRangeError::InvalidCursor)
+    ));
+    assert!(matches!(
+        CoreEventRangeCursor::decode(&encoded[..encoded.len() - 1]),
+        Err(CoreEventRangeError::InvalidCursor)
+    ));
+    let other_selection = CoreEventRangeSelection::new(100, 201, ["codex"]).unwrap();
+    assert!(matches!(
+        cursor.validate_selection(&other_selection),
+        Err(CoreEventRangeError::CursorSelectionMismatch)
+    ));
+
+    let mut invalid_coordinate = cursor.clone();
+    invalid_coordinate.after.event_id = uuid::Uuid::nil();
+    assert!(matches!(
+        first.core_event_range_page(&selection, Some(&invalid_coordinate), 1),
+        Err(CoreEventRangeError::InvalidCursorCoordinate)
+    ));
+
+    let second_generation = publish(temp.path(), 2, &[(source.clone(), records.clone())]);
+    let active = VerifiedIndex::open(temp.path()).unwrap();
+    assert_ne!(first_generation, second_generation);
+    assert!(matches!(
+        active.core_event_range_page(&selection, Some(&cursor), 1),
+        Err(CoreEventRangeError::CursorGenerationMismatch { .. })
+    ));
+    let retained = VerifiedIndex::open_pinned_generation(temp.path(), &first_generation).unwrap();
+    assert_eq!(
+        retained
+            .core_event_range_page(&selection, Some(&cursor), 8)
+            .unwrap()
+            .items
+            .len(),
+        2
+    );
+
+    publish(temp.path(), 3, &[(source, records)]);
+    assert!(matches!(
+        VerifiedIndex::open_pinned_generation(temp.path(), &first_generation),
+        Err(IndexError::PinnedGenerationNotRetained { .. })
+    ));
+}
+
+#[test]
+fn held_pin_traverses_one_generation_while_rewrites_and_deletes_publish() {
+    let temp = tempdir().unwrap();
+    let source = test_source("codex", "immutable");
+    let original = (0..12)
+        .map(|nonce| {
+            record(
+                &source,
+                nonce,
+                nonce % 4,
+                Some(1_000 + (nonce % 3) as i64),
+                &format!("old-{nonce}"),
+            )
+        })
+        .collect::<Vec<_>>();
+    publish(temp.path(), 1, &[(source.clone(), original.clone())]);
+    let held = VerifiedIndex::open(temp.path()).unwrap();
+    let selection = CoreEventRangeSelection::new(1_000, 2_000, Vec::<String>::new()).unwrap();
+    let first = held.core_event_range_page(&selection, None, 3).unwrap();
+    let mut ids = first
+        .items
+        .iter()
+        .map(|event| event.event_id.as_uuid())
+        .collect::<Vec<_>>();
+    let mut cursor = first.next_cursor;
+
+    let rewritten = (6..18)
+        .map(|nonce| {
+            record(
+                &source,
+                nonce,
+                nonce,
+                Some(5_000 + nonce as i64),
+                &format!("new-{nonce}"),
+            )
+        })
+        .collect::<Vec<_>>();
+    publish(temp.path(), 2, &[(source.clone(), rewritten)]);
+    publish(temp.path(), 3, &[(source, Vec::new())]);
+
+    while let Some(current) = cursor {
+        let page = held
+            .core_event_range_page(&selection, Some(&current), 3)
+            .unwrap();
+        ids.extend(page.items.iter().map(|event| event.event_id.as_uuid()));
+        cursor = page.next_cursor;
+    }
+    assert_eq!(ids, sorted_ids(&original));
+}
+
+#[test]
+fn complete_unicode_structured_and_policy_content_stays_generation_owned() {
+    let temp = tempdir().unwrap();
+    let source = test_source("codex", "content");
+    let mut selected = record(&source, 1, 1, Some(10), "héllo 🦀");
+    selected.content.structured_content = Some(serde_json::json!({
+        "valid": "雪",
+        "nested": [1, true, {"emoji": "🧭"}]
+    }));
+    let mut redacted = record(&source, 2, 2, Some(11), "[redacted]");
+    redacted.content.policy_status = CoreContentPolicyStatus::Redacted {
+        reason: "provider_secret".to_owned(),
+    };
+    let mut omitted = record(&source, 3, 3, Some(12), "remove me");
+    omitted.content.policy_status = CoreContentPolicyStatus::Omitted {
+        reason: "unsupported_binary".to_owned(),
+    };
+    omitted.content.normalized_body = None;
+    let records = vec![selected.clone(), redacted.clone(), omitted.clone()];
+    publish(temp.path(), 1, &[(source, records)]);
+    let index = VerifiedIndex::open(temp.path()).unwrap();
+    let selection = CoreEventRangeSelection::new(10, 13, Vec::<String>::new()).unwrap();
+    let page = index.core_event_range_page(&selection, None, 8).unwrap();
+    assert!(page.terminal);
+    assert_eq!(page.items[0].core_record.content, selected.content);
+    assert_eq!(page.items[1].core_record.content, redacted.content);
+    assert_eq!(page.items[2].core_record.content, omitted.content);
+}
+
+#[test]
+fn invalid_ranges_filters_and_limits_fail_before_querying() {
+    assert!(matches!(
+        CoreEventRangeSelection::new(10, 10, Vec::<String>::new()),
+        Err(CoreEventRangeError::InvalidRange { .. })
+    ));
+    assert!(matches!(
+        CoreEventRangeSelection::new(11, 10, Vec::<String>::new()),
+        Err(CoreEventRangeError::InvalidRange { .. })
+    ));
+    assert!(matches!(
+        CoreEventRangeSelection::new(0, 1, [" "]),
+        Err(CoreEventRangeError::InvalidProviderSelection)
+    ));
+    assert!(matches!(
+        CoreEventRangeSelection::new(
+            0,
+            1,
+            (0..=MAX_EVENT_RANGE_PROVIDERS).map(|index| format!("provider-{index}")),
+        ),
+        Err(CoreEventRangeError::InvalidProviderSelection)
+    ));
+
+    let temp = tempdir().unwrap();
+    let source = test_source("codex", "limits");
+    publish(
+        temp.path(),
+        1,
+        &[(source.clone(), vec![record(&source, 1, 1, Some(0), "one")])],
+    );
+    let index = VerifiedIndex::open(temp.path()).unwrap();
+    let selection = CoreEventRangeSelection::new(0, 1, Vec::<String>::new()).unwrap();
+    assert!(matches!(
+        index.core_event_range_page(&selection, None, 0),
+        Err(CoreEventRangeError::InvalidPageSize { .. })
+    ));
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -652,6 +652,46 @@ JSON and JSONL, MCP, noninteractive output, empty or failed results, install and
 setup, Core commands, and later blame results. Showing the copy makes no network
 request and is not reported remotely.
 
+## Export events
+
+```bash
+ctx export events --since 2026-08-01T00:00:00Z --until 2026-08-02T00:00:00Z
+ctx export events --since 2026-08-01T00:00:00Z --until 2026-08-02T00:00:00Z --provider codex --provider claude --format json
+ctx export events --since 2026-08-01T00:00:00Z --until 2026-08-02T00:00:00Z --format jsonl
+```
+
+`export events` reads complete timestamped events from one immutable verified
+Core generation in ascending `(occurred_at_unix_ms, event_sequence,
+ctx_event_id)` order. `--since` is inclusive, `--until` is exclusive, and both
+must be absolute RFC3339 timestamps. Events without a timestamp are outside
+this range contract. With no `--provider`, every provider and both primary and
+subagent sessions are included. Repeat `--provider` to select more than one
+provider.
+
+`--format json` writes one compact resumable page. The versioned object contains
+`generation_id`, `events`, `next_cursor`, `terminal`, and `usage`; `usage.bytes`
+is the exact stdout byte count including the final newline. Continue with the
+same range, provider selection, and returned `--cursor`. A cursor binds its
+version, generation, selection, and last coordinate. Continuation reads that
+named active or retained previous generation and returns a typed
+`generation_not_retained` error after eviction.
+
+`--format jsonl` follows internal pages to completion while holding the same
+generation pin for the whole process. Each line is one event object, in the
+same order and shape as the JSON page's `events`; each standalone event carries
+its own `schema_version`. `--max-items` and
+`--max-bytes` bound each internal page. The final serialized page or JSONL
+batch never exceeds `--max-bytes`; an event that cannot fit alone returns a
+typed `event_too_large` error with a cursor that resumes immediately before
+that event.
+
+Every event includes its Core event, session, root-session, parent-session, and
+source IDs when applicable; provider/runtime format, provider-native IDs,
+workspace, cwd, type, role, timestamp, sequence, normalized text, structured
+content, and content policy completeness. All fields come from the same Core
+generation. Export never opens provider sources, refreshes history, or writes
+state. Machine data goes to stdout and one compact typed error goes to stderr.
+
 ## Show
 
 ```bash

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -48,6 +48,11 @@ uploads transcript or repository content, or requires a hosted research agent.
   They do not reopen provider history at query time.
   `ctx show session --out` writes transcript artifacts. Search/show expose the
   provider-owned session ID when known; for Codex, it is the resume UUID.
+- `ctx export events` enumerates complete timestamped Core events for one
+  half-open RFC3339 range in deterministic timestamp/sequence/event-ID order.
+  JSON returns one bounded resumable page; JSONL traverses one immutable
+  generation to completion. Export includes subagents by default, performs no
+  provider lookup or refresh, and writes no state.
 - `ctx pro` starts or resumes an anonymous 14-day trial without an account,
   authentication, or payment method, installs or repairs the signed
   target-specific helper, and catches the encrypted graph up. The official

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -172,10 +172,12 @@ never checkpoint or write provider data.
 - `usage.sqlite` contains only the bounded content-free aggregates documented
   above. It is product state, not history or search authority.
 
-Search, show, locate, and MCP retrieval read the active verified Core/Tantivy
-generation. Show presents complete policy-selected normalized records stored in
-Core, while locate returns bounded Core source identity metadata; neither
-reopens provider history at query time. Provider changes become visible after
+Search, show, locate, export, and MCP retrieval read verified Core/Tantivy
+generations. Export continuations may reopen the named active or retained
+previous generation; JSONL holds one generation pin for its whole traversal.
+Show and export present complete policy-selected normalized records stored in
+Core, while locate returns bounded Core source identity metadata. None of these
+read paths reopens provider history. Provider changes become visible after
 import or daemon refresh publishes a new Core generation.
 
 Lexical publication keeps the active generation and one previous generation
@@ -348,6 +350,7 @@ local upsert as described above.
 | `ctx sources` | bounded provider path metadata, allowlisted persistent selector files, and local history-source plugin manifests | none |
 | `ctx import` | provider transcript files and path metadata, the explicit custom history JSONL file passed with `--input-format ctx-history-jsonl-v1 --path`, or a durable provider-owned custom history JSONL file declared by an explicit history-source plugin manifest | immutable candidate Core/Tantivy generation and atomic publication, catalog/epoch metadata, and optional daemon files; Pro and semantic work is daemon-owned and does not delay foreground completion |
 | `ctx show session` / `ctx show event` | complete policy-selected records in the active verified Core/Tantivy generation | selected `--out` path for `show session` when provided |
+| `ctx export events` | complete timestamped records in one active or retained immutable Core/Tantivy generation | none; export does not refresh providers, publish a generation, or record usage/telemetry |
 | `ctx search` | active verified Core/Tantivy generation and existing semantic generation; depending on refresh mode, bounded provider discovery/path metadata | candidate Core generation publication only when refresh runs; background mode may write daemon state, and semantic-enabled search may create query endpoint files |
 | `ctx pro` / `ctx pro setup` | selected credential store, commercial account state, signed release metadata/artifact, pinned Core materialization feed, and an optional first-challenge codename only for `ctx pro --referral <codename>` | selected credential store, signed helper installation, encrypted derived graph, and an optional opaque referral claim after accepted activation; the raw codename is not retained, and the explicit `setup` form is a synonym without referral attribution |
 | `ctx pro manage` | selected credential store and commercial account state | may refresh the WorkOS session in the selected credential store and open a hosted billing-portal URL |

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -75,7 +75,7 @@ scan_docs() {
   fi
 }
 
-unsupported_surface_pattern='dashboard|shim|shims|pull request|pull-request|pr evidence|pr-evidence|ctx pr([^[:alnum:]_]|$)|ctx publish|ctx evidence|ctx skill (install|status)([^[:alnum:]_]|$)|ctx update|ctx uninstall|\bADE\b|automatic summar|\bMVP\b|recover prior decisions|ctx remembers everything|privacy-first|ctx context|ctx list|ctx export|ctx validate|--until|normalized-only|normalized only|normalized_import_only|normalized provider JSONL|CTX_PROVIDER_NORMALIZED_IMPORT_DEV|[W]ork Recorder|[w]ork recorder|\bwork-[r]ecord\b'
+unsupported_surface_pattern='dashboard|shim|shims|pull request|pull-request|pr evidence|pr-evidence|ctx pr([^[:alnum:]_]|$)|ctx publish|ctx evidence|ctx skill (install|status)([^[:alnum:]_]|$)|ctx update|ctx uninstall|\bADE\b|automatic summar|\bMVP\b|recover prior decisions|ctx remembers everything|privacy-first|ctx context|ctx list|ctx validate|normalized-only|normalized only|normalized_import_only|normalized provider JSONL|CTX_PROVIDER_NORMALIZED_IMPORT_DEV|[W]ork Recorder|[w]ork recorder|\bwork-[r]ecord\b'
 private_path_pattern='/home/[d]addy|/home/[^[:space:]]+/(code|Documents|Desktop)|/Users/[^[:space:]]+/(code|Documents|Desktop)|ctx-[p]rivate|ctx-multi-repo-workspace|\.ctx/worktrees'
 
 if scan_docs "${unsupported_surface_pattern}" "${public_docs[@]}"; then


### PR DESCRIPTION
## Summary

- add a schema-neutral Core range reader for complete timestamped events in a half-open interval
- expose `ctx export events` as one resumable JSON page or a full JSONL traversal
- bind cursors to the exact retained Core generation, selection, and deterministic event key
- enforce item and final-wire byte budgets without truncating or silently skipping events
- keep Core as the sole authority with no provider refresh, source lookup, SQLite, Pro, MCP, or SDK path

## Validation

- randomized range oracle and no-gap/no-duplicate pagination tests
- cursor tamper, request mismatch, retained-generation, and typed-expiry tests
- concurrent publication with a held immutable generation
- CLI JSON/JSONL, Unicode, structured content, source deletion, and stdout/stderr tests
- focused Cargo/Bazel, Clippy, formatting, docs, telemetry, and diff checks
- two independent final reviews approved the exact commit

Closes #241