### PR TITLE
Preserve SQLite revalidation resource failures

### DIFF
--- a/crates/ctx-history-capture/src/provider_sources/sqlite_source.rs
+++ b/crates/ctx-history-capture/src/provider_sources/sqlite_source.rs
@@ -83,6 +83,13 @@ pub(crate) enum SqliteSourceAccessError {
         #[source]
         source: rusqlite::Error,
     },
+    #[error("SQLite source resource is unavailable during {operation} for {path:?}: {source}")]
+    ResourceUnavailable {
+        operation: &'static str,
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
     #[error("private SQLite scratch resource is unavailable during {operation}: {source}")]
     ScratchSqliteUnavailable {
         operation: &'static str,
@@ -141,7 +148,9 @@ impl SqliteSourceAccessError {
     pub(crate) const fn is_retryable_resource_unavailable(&self) -> bool {
         matches!(
             self,
-            Self::ScratchSqliteUnavailable { .. } | Self::ScratchIoUnavailable { .. }
+            Self::ResourceUnavailable { .. }
+                | Self::ScratchSqliteUnavailable { .. }
+                | Self::ScratchIoUnavailable { .. }
         )
     }
 
@@ -602,7 +611,13 @@ impl SqliteSourceDirectoryAuthority {
         let retained = self
             .directory
             .try_clone_authority_handle()
-            .map_err(|_| SqliteSourceAccessError::SourceChanged)
+            .map_err(|source| {
+                map_revalidation_io_error(
+                    source,
+                    "retaining the approved SQLite parent capability during revalidation",
+                    &self.path,
+                )
+            })
             .and_then(|directory| {
                 NativeFileState::read(&directory, &self.path, ExpectedObjectKind::Directory)
                     .map_err(map_revalidation_error)
@@ -610,14 +625,29 @@ impl SqliteSourceDirectoryAuthority {
         if retained.identity != self.identity {
             return Err(SqliteSourceAccessError::SourceChanged);
         }
-        let named_root = ProviderSourceRoot::open(&self.path)
-            .map_err(|_| SqliteSourceAccessError::SourceChanged)?;
-        let named_directory = named_root
-            .directory()
-            .map_err(|_| SqliteSourceAccessError::SourceChanged)?;
+        let named_root = ProviderSourceRoot::open(&self.path).map_err(|error| {
+            map_provider_source_revalidation_error(
+                error,
+                "reopening the approved SQLite parent capability during revalidation",
+                &self.path,
+            )
+        })?;
+        let named_directory = named_root.directory().map_err(|error| {
+            map_provider_source_revalidation_error(
+                error,
+                "retaining the reopened SQLite parent capability during revalidation",
+                &self.path,
+            )
+        })?;
         let named = named_directory
             .try_clone_authority_handle()
-            .map_err(|_| SqliteSourceAccessError::SourceChanged)?;
+            .map_err(|source| {
+                map_revalidation_io_error(
+                    source,
+                    "retaining the reopened SQLite parent capability handle during revalidation",
+                    &self.path,
+                )
+            })?;
         let named_state = NativeFileState::read(&named, &self.path, ExpectedObjectKind::Directory)
             .map_err(map_revalidation_error)?;
         if named_state.identity == self.identity {
@@ -661,29 +691,42 @@ impl SqliteSourceTerminalFence {
     /// Revalidates the exact retained source family without opening SQLite or
     /// acquiring another source snapshot.
     pub(crate) fn revalidate(&self) -> SqliteSourceAccessResult<()> {
-        let root = ProviderSourceRoot::open(&self.inner.approved_parent_path)
-            .map_err(|_| SqliteSourceAccessError::SourceChanged)?;
-        let directory = root
-            .directory()
-            .map_err(|_| SqliteSourceAccessError::SourceChanged)?;
-        let authority_handle = directory
-            .try_clone_authority_handle()
-            .map_err(|_| SqliteSourceAccessError::SourceChanged)?;
+        let root = ProviderSourceRoot::open(&self.inner.approved_parent_path).map_err(|error| {
+            map_provider_source_revalidation_error(
+                error,
+                "reopening the approved SQLite parent for terminal revalidation",
+                &self.inner.approved_parent_path,
+            )
+        })?;
+        let directory = root.directory().map_err(|error| {
+            map_provider_source_revalidation_error(
+                error,
+                "retaining the reopened SQLite parent for terminal revalidation",
+                &self.inner.approved_parent_path,
+            )
+        })?;
+        let authority_handle = directory.try_clone_authority_handle().map_err(|source| {
+            map_revalidation_io_error(
+                source,
+                "retaining the reopened SQLite parent handle for terminal revalidation",
+                &self.inner.approved_parent_path,
+            )
+        })?;
         let authority = SqliteSourceDirectoryAuthority::retain(
             &self.inner.data_root,
             &authority_handle,
             &self.inner.approved_parent_path,
         )
-        .map_err(|_| SqliteSourceAccessError::SourceChanged)?;
+        .map_err(map_revalidation_error)?;
         match self.inner.policy {
             SqliteSourceSnapshotPolicy::StrictPhysicalFamily => {
                 let family = SqliteSourceFamily::open(&authority, &self.inner.database_name, || {})
-                    .map_err(|_| SqliteSourceAccessError::SourceChanged)?;
+                    .map_err(map_revalidation_error)?;
                 family.revalidate(&self.inner.native_evidence)?;
             }
             SqliteSourceSnapshotPolicy::LogicalOnlineBackup => {
                 let family = SqliteSourceFamily::open(&authority, &self.inner.database_name, || {})
-                    .map_err(|_| SqliteSourceAccessError::SourceChanged)?;
+                    .map_err(map_revalidation_error)?;
                 family.revalidate_logical_database_identity(&self.inner.native_evidence)?;
             }
         }
@@ -895,7 +938,8 @@ mod snapshot;
 
 use family::{
     capture_sqlite_evidence, clear_snapshot_authorizer, configure_and_pin_snapshot,
-    map_provider_source_error, map_revalidation_error, sqlite_error, validate_approved_parent_path,
+    map_provider_source_error, map_provider_source_revalidation_error, map_revalidation_error,
+    map_revalidation_io_error, sqlite_error, validate_approved_parent_path,
     verify_connection_read_only, verify_snapshot_active, ExpectedObjectKind, NativeFileIdentity,
     NativeFileState, SqliteConnectionEvidence, SqliteFamilyEvidence, SqliteFamilyMember,
     SqliteSchemaEvidence, SqliteSnapshotEvidence, SqliteSourceFamily,

--- a/crates/ctx-history-capture/src/provider_sources/sqlite_source/family.rs
+++ b/crates/ctx-history-capture/src/provider_sources/sqlite_source/family.rs
@@ -299,7 +299,10 @@ impl SqliteSourceFamily {
             expected.shared_memory_token.as_ref(),
         ) {
             (Some(shared_memory), Some(expected_token))
-                if shared_memory.content_digest()? == *expected_token => {}
+                if shared_memory
+                    .content_digest()
+                    .map_err(map_revalidation_error)?
+                    == *expected_token => {}
             (None, None) => {}
             _ => return Err(SqliteSourceAccessError::SourceChanged),
         }
@@ -327,10 +330,12 @@ impl SqliteSourceFamily {
                     .as_ref()
                     .ok_or(SqliteSourceAccessError::SourceChanged)?;
                 wal.revalidate(&self.authority, expected_state)?;
-                if expected.wal_token.as_ref().is_some_and(|expected_token| {
-                    wal.bounded_token()
-                        .is_ok_and(|token| &token == expected_token)
-                }) {
+                let expected_token = expected
+                    .wal_token
+                    .as_ref()
+                    .ok_or(SqliteSourceAccessError::SourceChanged)?;
+                let token = wal.bounded_token().map_err(map_revalidation_error)?;
+                if &token == expected_token {
                     Ok(())
                 } else {
                     Err(SqliteSourceAccessError::SourceChanged)
@@ -771,9 +776,63 @@ pub(super) fn map_provider_source_error(
     }
 }
 
+pub(super) fn map_provider_source_revalidation_error(
+    error: CaptureError,
+    operation: &'static str,
+    path: &Path,
+) -> SqliteSourceAccessError {
+    map_revalidation_error(map_provider_source_error(error, operation, path))
+}
+
+pub(super) fn map_revalidation_io_error(
+    source: std::io::Error,
+    operation: &'static str,
+    path: &Path,
+) -> SqliteSourceAccessError {
+    map_revalidation_error(SqliteSourceAccessError::Io {
+        operation,
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
 pub(super) fn map_revalidation_error(error: SqliteSourceAccessError) -> SqliteSourceAccessError {
-    let _ = error;
-    SqliteSourceAccessError::SourceChanged
+    match error {
+        SqliteSourceAccessError::Io {
+            operation,
+            path,
+            source,
+        } if resource_exhaustion_io_error(&source) => {
+            SqliteSourceAccessError::ResourceUnavailable {
+                operation,
+                path,
+                source,
+            }
+        }
+        error if error.is_retryable_resource_unavailable() => error,
+        _ => SqliteSourceAccessError::SourceChanged,
+    }
+}
+
+fn resource_exhaustion_io_error(error: &std::io::Error) -> bool {
+    if matches!(
+        error.kind(),
+        std::io::ErrorKind::OutOfMemory
+            | std::io::ErrorKind::StorageFull
+            | std::io::ErrorKind::QuotaExceeded
+    ) {
+        return true;
+    }
+    #[cfg(unix)]
+    if error.raw_os_error().is_some_and(|code| {
+        matches!(
+            code,
+            libc::EMFILE | libc::ENFILE | libc::ENOMEM | libc::ENOSPC | libc::EDQUOT
+        )
+    }) {
+        return true;
+    }
+    false
 }
 
 pub(super) fn configure_and_pin_snapshot(connection: &Connection) -> SqliteSourceAccessResult<()> {

--- a/crates/ctx-history-capture/src/provider_sources/sqlite_source/tests.rs
+++ b/crates/ctx-history-capture/src/provider_sources/sqlite_source/tests.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     ffi::{OsStr, OsString},
     fs::{self, File, OpenOptions},
-    io::{Seek, SeekFrom, Write},
+    io::{self, Seek, SeekFrom, Write},
     path::Path,
     sync::{Arc, Barrier},
     thread,
@@ -19,7 +19,8 @@ use sha2::{Digest, Sha256};
 use crate::provider::source_backed::SourceBackedCurrentSourceProgressStage;
 
 use super::{
-    certify_root_handle_sqlite_source_snapshot_copy_budget_for_test,
+    certify_root_handle_sqlite_source_snapshot_copy_budget_for_test, map_revalidation_error,
+    map_revalidation_io_error,
     open_root_handle_sqlite_source_online_backup_after_database_copy_for_test,
     open_root_handle_sqlite_source_online_backup_before_identity_check_for_test,
     open_root_handle_sqlite_source_online_backup_with_scratch_limit_for_test,
@@ -132,6 +133,85 @@ fn provider_content_bytes(path: &Path) -> BTreeMap<OsString, Vec<u8>> {
             name == OsStr::new("provider.sqlite") || name == OsStr::new("provider.sqlite-wal")
         })
         .collect()
+}
+
+fn assert_revalidation_resource_unavailable(error: SqliteSourceAccessError) {
+    assert!(error.is_retryable_resource_unavailable());
+    assert!(matches!(
+        error,
+        SqliteSourceAccessError::ResourceUnavailable { .. }
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn sqlite_authority_revalidation_preserves_descriptor_exhaustion() {
+    let path = Path::new("/provider/provider.sqlite");
+    for code in [libc::EMFILE, libc::ENFILE] {
+        let error = map_revalidation_io_error(
+            io::Error::from_raw_os_error(code),
+            "retaining SQLite authority in the regression test",
+            path,
+        );
+        match &error {
+            SqliteSourceAccessError::ResourceUnavailable {
+                operation,
+                path: error_path,
+                source,
+            } => {
+                assert_eq!(
+                    *operation,
+                    "retaining SQLite authority in the regression test"
+                );
+                assert_eq!(error_path, path);
+                assert_eq!(source.raw_os_error(), Some(code));
+            }
+            other => panic!("unexpected revalidation error: {other:?}"),
+        }
+        assert_revalidation_resource_unavailable(error);
+    }
+}
+
+#[test]
+fn sqlite_authority_revalidation_preserves_portable_resource_exhaustion() {
+    let path = Path::new("provider.sqlite");
+    for kind in [
+        io::ErrorKind::OutOfMemory,
+        io::ErrorKind::StorageFull,
+        io::ErrorKind::QuotaExceeded,
+    ] {
+        let error = map_revalidation_io_error(
+            io::Error::from(kind),
+            "retaining SQLite authority in the portable regression test",
+            path,
+        );
+        assert!(matches!(
+            &error,
+            SqliteSourceAccessError::ResourceUnavailable { source, .. }
+                if source.kind() == kind
+        ));
+        assert_revalidation_resource_unavailable(error);
+    }
+}
+
+#[test]
+fn sqlite_authority_revalidation_keeps_mutation_as_source_changed() {
+    assert!(matches!(
+        map_revalidation_error(SqliteSourceAccessError::ConnectionIdentityMismatch),
+        SqliteSourceAccessError::SourceChanged
+    ));
+    assert!(matches!(
+        map_revalidation_error(SqliteSourceAccessError::SourceChanged),
+        SqliteSourceAccessError::SourceChanged
+    ));
+    assert!(matches!(
+        map_revalidation_io_error(
+            io::Error::from(io::ErrorKind::NotFound),
+            "reopening mutated SQLite authority in the regression test",
+            Path::new("provider.sqlite"),
+        ),
+        SqliteSourceAccessError::SourceChanged
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- preserve descriptor, memory, and storage exhaustion as typed retryable resource-unavailable errors during SQLite source revalidation
- keep actual identity mutation, disappearance, and non-resource failures classified as source-changed
- cover authority reopen, terminal fences, WAL tokens, and SHM digests without weakening validation or adding fallback scans

## Validation
- 3 deterministic injected classification regressions
- 51 SQLite-source tests
- capture all-target check and strict clippy
- cargo fmt and git diff checks
- independent exact-SHA review: approved with no findings

This follows a targeted audit of a transient full-suite failure: 200 isolated passes and 1,320 SQLite-module passes, plus a deterministic low-descriptor reproduction proving the underlying OS error was `EMFILE`, not source mutation.