### PR TITLE
fix(factory-ai-droid): retain retried records that reuse one native id

### DIFF
--- a/crates/ctx-cli/tests/native_providers.rs
+++ b/crates/ctx-cli/tests/native_providers.rs
@@ -850,6 +850,107 @@ fn personal_agent_provider_imports_are_idempotent_and_incremental() {
 }
 
 #[test]
+fn factory_droid_import_retains_retried_records_that_reuse_one_native_id() {
+    // Factory AI Droid rewrites a message id when a tool execution is
+    // cancelled and retried, so one native record id repeats in a session.
+    let temp = tempdir();
+    let root = temp.path().join("native-droid-retry/sessions/project");
+    fs::create_dir_all(&root).unwrap();
+    let session_file = root.join("droid-retry.jsonl");
+    let shared_id = "droid-retry-shared-message";
+    let header = json!({
+        "type": "session_start",
+        "id": "droid-retry-session",
+        "timestamp": "2026-07-14T09:30:00Z",
+        "cwd": "/workspace",
+        "model": "factory/droid"
+    });
+    let result = |call: &str, is_error: bool, content: &str| {
+        json!({
+            "type": "message",
+            "id": shared_id,
+            "timestamp": "2026-07-14T09:30:13Z",
+            "message": {
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": call,
+                    "is_error": is_error,
+                    "content": content
+                }],
+                "visibility": "user_only"
+            },
+            "parentId": shared_id
+        })
+    };
+    fs::write(
+        &session_file,
+        format!(
+            "{}\n{}\n{}\n",
+            header,
+            result("Execute_117", false, "factory-retry-initial-oracle"),
+            result("Execute_118", true, "factory-retry-cancelled-oracle"),
+        ),
+    )
+    .unwrap();
+    let path = root.parent().unwrap().display().to_string();
+    let _daemon = start_isolated_provider_daemon(&temp);
+
+    let first = json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "factory-ai-droid",
+        "--path",
+        &path,
+        "--no-daemon",
+        "--format=json",
+    ]));
+    assert_explicit_source_publication(
+        &first,
+        "factory_ai_droid",
+        "factory_ai_droid_sessions_jsonl",
+    );
+    wait_for_imported_core(&temp, &first);
+    let initial = provider_core_records(&data_root(&temp), "factory_ai_droid").len();
+    assert_eq!(initial, 3, "{first:#}");
+
+    // A certified-suffix append that reuses the same native id keeps refreshing.
+    use std::io::Write as _;
+    let mut handle = fs::OpenOptions::new()
+        .append(true)
+        .open(&session_file)
+        .unwrap();
+    writeln!(
+        handle,
+        "{}",
+        result("Execute_119", false, "factory-retry-appended-oracle")
+    )
+    .unwrap();
+    drop(handle);
+
+    let second = json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "factory-ai-droid",
+        "--path",
+        &path,
+        "--no-daemon",
+        "--format=json",
+    ]));
+    assert_explicit_source_publication(
+        &second,
+        "factory_ai_droid",
+        "factory_ai_droid_sessions_jsonl",
+    );
+    wait_for_imported_core(&temp, &second);
+    assert_eq!(
+        provider_core_records(&data_root(&temp), "factory_ai_droid").len(),
+        initial + 1,
+        "{second:#}"
+    );
+}
+
+#[test]
 fn openclaw_import_accepts_explicit_session_jsonl_file() {
     let temp = tempdir();
     let query = "openclaw-explicit-file-oracle";

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     ffi::OsStr,
     path::{Path, PathBuf},
     sync::Arc,
@@ -11,6 +12,7 @@ use ctx_history_core::{
     ProjectionContractError, SessionIdentityInput, SourceAnchor, SourceKey, StableEntityId,
     SubrecordSelector, TypedKey,
 };
+use ctx_history_index::BaseEventIdentityLookup;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -250,6 +252,24 @@ impl JsonlFamilyAdapter for DirectJsonlFamilyAdapter {
             .map(|projector| Box::new(projector) as Box<dyn JsonlFamilyProjector>)
             .map_err(capture_error)
     }
+
+    fn projector_with_provider_checkpoint(
+        &self,
+        leaf: &JsonlFamilyLeaf,
+        _source_file: Arc<OpenedProviderSourceFile>,
+        imported_at: DateTime<Utc>,
+        checkpoint: Option<&TypedKey>,
+        base_event_lookup: Option<BaseEventIdentityLookup>,
+    ) -> Result<Box<dyn JsonlFamilyProjector>> {
+        if checkpoint.is_some() {
+            return Err(CaptureError::InvalidPayload(
+                "JSONL adapter does not accept provider checkpoint state".to_owned(),
+            ));
+        }
+        DirectJsonlFamilyProjector::with_base_lookup(*self, leaf, imported_at, base_event_lookup)
+            .map(|projector| Box::new(projector) as Box<dyn JsonlFamilyProjector>)
+            .map_err(capture_error)
+    }
 }
 
 #[derive(Default)]
@@ -474,6 +494,18 @@ struct DirectJsonlFamilyProjector {
     session_id: StableEntityId,
     projector: DirectJsonlProjector,
     rejected_records: u64,
+    event_identities: DirectJsonlEventIdentityState,
+}
+
+/// Occurrence state for provider records that reuse one native record identity
+/// inside a single session (Factory AI Droid rewrites a message id when a tool
+/// execution is cancelled and retried). Occurrence zero keeps the identity
+/// minted before this disambiguation existed, so previously imported events
+/// never move.
+#[derive(Default)]
+struct DirectJsonlEventIdentityState {
+    base_lookup: Option<BaseEventIdentityLookup>,
+    next_occurrences: BTreeMap<(String, u32), u64>,
 }
 
 impl DirectJsonlFamilyProjector {
@@ -481,6 +513,15 @@ impl DirectJsonlFamilyProjector {
         adapter: DirectJsonlFamilyAdapter,
         leaf: &JsonlFamilyLeaf,
         imported_at: DateTime<Utc>,
+    ) -> DirectJsonlAdapterResult<Self> {
+        Self::with_base_lookup(adapter, leaf, imported_at, None)
+    }
+
+    fn with_base_lookup(
+        adapter: DirectJsonlFamilyAdapter,
+        leaf: &JsonlFamilyLeaf,
+        imported_at: DateTime<Utc>,
+        base_lookup: Option<BaseEventIdentityLookup>,
     ) -> DirectJsonlAdapterResult<Self> {
         let binding = decode_binding(leaf)?;
         let (source, session_id) = adapter.session_identity(&binding.session.native_session_id)?;
@@ -500,7 +541,80 @@ impl DirectJsonlFamilyProjector {
             session_id,
             projector,
             rejected_records: 0,
+            event_identities: DirectJsonlEventIdentityState {
+                base_lookup,
+                next_occurrences: BTreeMap::new(),
+            },
         })
+    }
+
+    fn next_event_occurrence(&mut self, event: &DirectJsonlEvent) -> DirectJsonlAdapterResult<u64> {
+        let Some(native_record_id) = event.native_record_id.as_deref() else {
+            return Ok(0);
+        };
+        let key = (native_record_id.to_owned(), event.sub_ordinal);
+        let occurrence = match self.event_identities.next_occurrences.get(&key).copied() {
+            Some(occurrence) => occurrence,
+            None => self.first_unused_base_occurrence(event)?,
+        };
+        let next = occurrence
+            .checked_add(1)
+            .ok_or(DirectJsonlAdapterError::CountMismatch)?;
+        self.event_identities.next_occurrences.insert(key, next);
+        Ok(occurrence)
+    }
+
+    fn first_unused_base_occurrence(
+        &self,
+        event: &DirectJsonlEvent,
+    ) -> DirectJsonlAdapterResult<u64> {
+        let Some(base_lookup) = self.event_identities.base_lookup.as_ref() else {
+            return Ok(0);
+        };
+        if !self.base_occurrence_exists(base_lookup, event, 0)? {
+            return Ok(0);
+        }
+        let mut present = 0_u64;
+        let mut missing = 1_u64;
+        while self.base_occurrence_exists(base_lookup, event, missing)? {
+            present = missing;
+            missing = match missing.checked_mul(2) {
+                Some(next) => next,
+                None if missing != u64::MAX => u64::MAX,
+                None => return Err(DirectJsonlAdapterError::CountMismatch),
+            };
+        }
+        while present.saturating_add(1) < missing {
+            let candidate = present + (missing - present) / 2;
+            if self.base_occurrence_exists(base_lookup, event, candidate)? {
+                present = candidate;
+            } else {
+                missing = candidate;
+            }
+        }
+        Ok(missing)
+    }
+
+    fn base_occurrence_exists(
+        &self,
+        base_lookup: &BaseEventIdentityLookup,
+        event: &DirectJsonlEvent,
+        occurrence: u64,
+    ) -> DirectJsonlAdapterResult<bool> {
+        let candidate = direct_jsonl_event_id(
+            self.adapter,
+            &self.source,
+            self.session_id,
+            event.native_record_id.as_deref(),
+            event.raw_ordinal,
+            event.sub_ordinal,
+            occurrence,
+        )?;
+        // The pinned lookup also rejects duplicate base identities. Propagate
+        // that error so an ambiguous base can never select a new occurrence.
+        Ok(base_lookup
+            .contains(candidate.as_uuid())
+            .map_err(|error| CaptureError::InvalidPayload(error.to_string()))?)
     }
 
     fn validate_session(&self) -> DirectJsonlAdapterResult<&DirectJsonlSession> {
@@ -536,9 +650,17 @@ impl JsonlFamilyProjector for DirectJsonlFamilyProjector {
         }
         let session = self.validate_session().map_err(capture_error)?.clone();
         for event in projected.events {
+            let occurrence = self.next_event_occurrence(&event).map_err(capture_error)?;
             emit(
-                project_event(self.adapter, &self.source, self.session_id, &session, event)
-                    .map_err(capture_error)?,
+                project_event(
+                    self.adapter,
+                    &self.source,
+                    self.session_id,
+                    &session,
+                    event,
+                    occurrence,
+                )
+                .map_err(capture_error)?,
             )?;
         }
         Ok(())
@@ -567,42 +689,88 @@ fn same_session_identity(left: &DirectJsonlSession, right: &DirectJsonlSession) 
         && left.root_provider_session_id == right.root_provider_session_id
 }
 
+fn direct_jsonl_native_item_key(
+    provider: CaptureProvider,
+    native_record_id: Option<&str>,
+    raw_ordinal: u64,
+    occurrence: u64,
+) -> DirectJsonlAdapterResult<NativeItemKey> {
+    let Some(native_record_id) = native_record_id else {
+        return Ok(NativeItemKey::certified_position(
+            format!("{}.direct-jsonl-ordinal", provider.as_str()),
+            TypedKey::U64(raw_ordinal),
+            PositionStability::AppendStable,
+        )?);
+    };
+    let key = if occurrence == 0 {
+        TypedKey::utf8(native_record_id)?
+    } else {
+        TypedKey::composite(vec![
+            TypedKey::utf8(native_record_id)?,
+            TypedKey::U64(occurrence),
+        ])?
+    };
+    Ok(NativeItemKey::native_id(
+        format!("{}.direct-jsonl-event", provider.as_str()),
+        key,
+    )?)
+}
+
+fn direct_jsonl_subrecord_selector(
+    sub_ordinal: u32,
+) -> DirectJsonlAdapterResult<Option<SubrecordSelector>> {
+    (sub_ordinal != 0)
+        .then(|| {
+            SubrecordSelector::certified_position(
+                "direct-jsonl-subrecord",
+                TypedKey::U64(u64::from(sub_ordinal)),
+                PositionStability::StableSlot,
+            )
+        })
+        .transpose()
+        .map_err(Into::into)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn direct_jsonl_event_id(
+    adapter: DirectJsonlFamilyAdapter,
+    source: &SourceKey,
+    session_id: StableEntityId,
+    native_record_id: Option<&str>,
+    raw_ordinal: u64,
+    sub_ordinal: u32,
+    occurrence: u64,
+) -> DirectJsonlAdapterResult<StableEntityId> {
+    let native_item_key =
+        direct_jsonl_native_item_key(adapter.provider, native_record_id, raw_ordinal, occurrence)?;
+    let subrecord_selector = direct_jsonl_subrecord_selector(sub_ordinal)?;
+    Ok(derive_event_id(EventIdentityInput {
+        source,
+        session_id,
+        logical_item_kind: "direct-jsonl-event",
+        native_item_key: &native_item_key,
+        subrecord_selector: subrecord_selector.as_ref(),
+    })?)
+}
+
 fn project_event(
     adapter: DirectJsonlFamilyAdapter,
     source: &SourceKey,
     session_id: StableEntityId,
     session: &DirectJsonlSession,
     event: DirectJsonlEvent,
+    occurrence: u64,
 ) -> DirectJsonlAdapterResult<CoreRecord> {
-    let native_item_key = if let Some(native_record_id) = event.native_record_id.as_deref() {
-        NativeItemKey::native_id(
-            format!("{}.direct-jsonl-event", adapter.provider.as_str()),
-            TypedKey::utf8(native_record_id)?,
-        )?
-    } else {
-        NativeItemKey::certified_position(
-            format!("{}.direct-jsonl-ordinal", adapter.provider.as_str()),
-            TypedKey::U64(event.raw_ordinal),
-            PositionStability::AppendStable,
-        )?
-    };
-    let subrecord_selector = (event.sub_ordinal != 0)
-        .then(|| {
-            SubrecordSelector::certified_position(
-                "direct-jsonl-subrecord",
-                TypedKey::U64(u64::from(event.sub_ordinal)),
-                PositionStability::StableSlot,
-            )
-        })
-        .transpose()?;
-    let event_id = derive_event_id(EventIdentityInput {
+    let event_id = direct_jsonl_event_id(
+        adapter,
         source,
         session_id,
-        logical_item_kind: "direct-jsonl-event",
-        native_item_key: &native_item_key,
-        subrecord_selector: subrecord_selector.as_ref(),
-    })?;
-    let native_event_key = TypedKey::composite(vec![
+        event.native_record_id.as_deref(),
+        event.raw_ordinal,
+        event.sub_ordinal,
+        occurrence,
+    )?;
+    let mut native_event_parts = vec![
         event
             .native_record_id
             .as_deref()
@@ -610,7 +778,11 @@ fn project_event(
             .transpose()?
             .unwrap_or(TypedKey::U64(event.raw_ordinal)),
         TypedKey::U64(u64::from(event.sub_ordinal)),
-    ])?;
+    ];
+    if occurrence != 0 {
+        native_event_parts.push(TypedKey::U64(occurrence));
+    }
+    let native_event_key = TypedKey::composite(native_event_parts)?;
     let parent_session_id = session
         .parent_provider_session_id
         .as_deref()

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed_result_tests.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed_result_tests.rs
@@ -63,6 +63,7 @@ fn project(provider: CaptureProvider, value: &Value) -> (Vec<CoreRecord>, u64) {
         session_id,
         projector: direct,
         rejected_records: 0,
+        event_identities: DirectJsonlEventIdentityState::default(),
     };
     let encoded = serde_json::to_vec(value).unwrap();
     let mut records = Vec::new();
@@ -86,6 +87,118 @@ fn native_subrecord_index(record: &CoreRecord) -> u64 {
         panic!("direct JSONL result identity has no subrecord index");
     };
     *index
+}
+
+fn project_all(provider: CaptureProvider, values: &[Value]) -> Vec<CoreRecord> {
+    let adapter = adapter(provider);
+    let session = session(provider);
+    let (source, session_id) = adapter
+        .session_identity(&session.native_session_id)
+        .unwrap();
+    let direct = DirectJsonlProjector::new(
+        provider,
+        adapter.source_format,
+        Path::new("direct-jsonl-identity-contract.jsonl"),
+        None,
+        DateTime::<Utc>::UNIX_EPOCH,
+        Some(session.clone()),
+    )
+    .unwrap();
+    let mut projector = DirectJsonlFamilyProjector {
+        adapter,
+        source,
+        bound_session: session,
+        session_id,
+        projector: direct,
+        rejected_records: 0,
+        event_identities: DirectJsonlEventIdentityState::default(),
+    };
+    let mut records = Vec::new();
+    for (ordinal, value) in values.iter().enumerate() {
+        let encoded = serde_json::to_vec(value).unwrap();
+        JsonlFamilyProjector::project(
+            &mut projector,
+            JsonlRecordRef::for_test(&encoded, ordinal as u64),
+            &mut |record| {
+                records.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+    }
+    records
+}
+
+#[test]
+fn factory_droid_reused_record_ids_mint_distinct_stable_event_identities() {
+    // Factory AI Droid rewrites a message id when a tool execution is
+    // cancelled and retried, so one native record id can repeat in a session.
+    let shared_id = "199d5bdc-5644-4185-b970-1ede80d0d374";
+    let first = json!({
+        "type": "message",
+        "id": shared_id,
+        "timestamp": "2026-07-14T09:30:13.764Z",
+        "message": {
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "Execute_117",
+                "is_error": false,
+                "content": "first attempt output"
+            }]
+        }
+    });
+    let retried = json!({
+        "type": "message",
+        "id": shared_id,
+        "timestamp": "2026-07-14T09:30:23.825Z",
+        "message": {
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "Execute_118",
+                "is_error": true,
+                "content": "Error: Tool execution cancelled by user"
+            }],
+            "visibility": "user_only"
+        },
+        "parentId": shared_id
+    });
+
+    let records = project_all(
+        CaptureProvider::FactoryAiDroid,
+        &[first.clone(), retried.clone()],
+    );
+    assert_eq!(records.len(), 2);
+    assert_ne!(records[0].event_id, records[1].event_id);
+
+    // The first occurrence keeps the identity minted before disambiguation.
+    let single = project_all(CaptureProvider::FactoryAiDroid, std::slice::from_ref(&first));
+    assert_eq!(single[0].event_id, records[0].event_id);
+
+    // Replays assign the same occurrences in file order.
+    let replayed = project_all(CaptureProvider::FactoryAiDroid, &[first, retried]);
+    assert_eq!(
+        records
+            .iter()
+            .map(|record| record.event_id)
+            .collect::<Vec<_>>(),
+        replayed
+            .iter()
+            .map(|record| record.event_id)
+            .collect::<Vec<_>>()
+    );
+
+    // Only the retried occurrence carries the occurrence marker.
+    let Some(TypedKey::Composite(first_parts)) = records[0].native_event_id.as_ref() else {
+        panic!("first occurrence has no composite native event identity");
+    };
+    let Some(TypedKey::Composite(retried_parts)) = records[1].native_event_id.as_ref() else {
+        panic!("retried occurrence has no composite native event identity");
+    };
+    assert_eq!(first_parts.len(), 2);
+    assert_eq!(retried_parts.len(), 3);
+    assert_eq!(retried_parts[2], TypedKey::U64(1));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #261.

## Summary

- Factory AI Droid reuses a message `id` when a tool execution is cancelled and retried (the retry keeps the `id` and references it through `parentId`). The direct JSONL projector derived each event identity from the native record id alone, so the retry collided with the first occurrence and the whole import failed closed with `DuplicateEventIdentity`.
- Mints an occurrence suffix per (native record id, subrecord) pair, mirroring the disambiguation the Cursor provider already uses. Occurrence zero keeps the exact pre-fix identity, so previously imported events never move.
- Certified-suffix append scans probe the base event identity lookup (exponential then binary search) so appended retries continue the occurrence sequence instead of colliding with the imported prefix.

## Validation

- New unit test `factory_droid_reused_record_ids_mint_distinct_stable_event_identities`: two records sharing one native id mint distinct event ids, the first occurrence keeps the pre-fix identity, and replays are deterministic.
- New CLI end-to-end test `factory_droid_import_retains_retried_records_that_reuse_one_native_id`: importing a session with a reused id retains both records, and a certified-suffix append reusing the same id refreshes incrementally.
- `cargo test -p ctx-history-capture` and `cargo test -p ctx --test native_providers` failure sets are byte-identical to a clean `upstream/main` checkout (pre-existing environment-dependent sqlite and warp failures only).
- `cargo clippy -p ctx-history-capture -p ctx --all-targets` introduces no new warnings.
- Manual acceptance on macOS with a real `~/.factory/sessions` tree containing multiple sessions with reused record ids: `ctx import --provider factory-ai-droid` publishes successfully, cancelled-retry records are searchable, and a repeat import refreshes incrementally without identity errors.
