### PR TITLE
Stabilize Factory Droid retry identities

### DIFF
--- a/crates/ctx-cli/BUILD.bazel
+++ b/crates/ctx-cli/BUILD.bazel
@@ -457,6 +457,7 @@ ctx_cli_integration_test(
     name = "native_providers_tests",
     src = "tests/native_providers.rs",
     extra_srcs = [
+        "tests/native_providers/factory_retry.rs",
         "tests/support/native_providers/daemon.rs",
         "tests/support/native_providers/sqlite_sources.rs",
         "tests/support/native_providers/workspace_sources.rs",

--- a/crates/ctx-cli/tests/native_providers.rs
+++ b/crates/ctx-cli/tests/native_providers.rs
@@ -2,6 +2,8 @@ mod support;
 
 use support::{daemon_test_root as tempdir, *};
 
+#[path = "native_providers/factory_retry.rs"]
+mod factory_retry;
 #[path = "support/native_providers/daemon.rs"]
 mod provider_daemon;
 #[path = "support/native_providers/sqlite_sources.rs"]

--- a/crates/ctx-cli/tests/native_providers/factory_retry.rs
+++ b/crates/ctx-cli/tests/native_providers/factory_retry.rs
@@ -1,0 +1,371 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    io::Write as _,
+};
+
+use super::*;
+
+fn factory_header(session_id: &str) -> Value {
+    json!({
+        "type": "session_start",
+        "id": session_id,
+        "timestamp": "2026-07-14T09:30:00Z",
+        "cwd": "/workspace",
+        "model": "factory/droid"
+    })
+}
+
+fn factory_result(message_id: &str, parent_id: Option<&str>, results: &[(&str, &str)]) -> Value {
+    let content = results
+        .iter()
+        .map(|(tool_use_id, content)| {
+            json!({
+                "type": "tool_result",
+                "tool_use_id": tool_use_id,
+                "is_error": content.contains("cancelled"),
+                "content": content
+            })
+        })
+        .collect::<Vec<_>>();
+    let mut value = json!({
+        "type": "message",
+        "id": message_id,
+        "timestamp": "2026-07-14T09:30:13Z",
+        "message": {"role": "user", "content": content}
+    });
+    if let Some(parent_id) = parent_id {
+        value["parentId"] = json!(parent_id);
+        value["message"]["visibility"] = json!("user_only");
+    }
+    value
+}
+
+fn write_jsonl(path: &Path, records: &[Value]) {
+    let encoded = records
+        .iter()
+        .map(|record| format!("{record}\n"))
+        .collect::<String>();
+    fs::write(path, encoded).unwrap();
+}
+
+fn import_factory(temp: &TempDir, path: &str) -> Value {
+    let imported = json_output(ctx(temp).args([
+        "import",
+        "--provider",
+        "factory-ai-droid",
+        "--path",
+        path,
+        "--no-daemon",
+        "--format=json",
+        "--progress",
+        "none",
+    ]));
+    assert_explicit_source_publication(
+        &imported,
+        "factory_ai_droid",
+        "factory_ai_droid_sessions_jsonl",
+    );
+    wait_for_imported_core(temp, &imported);
+    imported
+}
+
+fn factory_event_ids(temp: &TempDir) -> BTreeMap<String, String> {
+    provider_core_records(&data_root(temp), "factory_ai_droid")
+        .into_iter()
+        .map(|record| {
+            (
+                record.content.normalized_body.unwrap(),
+                record.event_id.to_string(),
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn factory_droid_retry_lifecycle_keeps_native_ids_stable() {
+    let temp = tempdir();
+    let root = temp.path().join("native-droid-retry/sessions/project");
+    fs::create_dir_all(&root).unwrap();
+    let session_file = root.join("droid-retry.jsonl");
+    let path = root.parent().unwrap().display().to_string();
+    let header = factory_header("demo");
+    let anchor = factory_result("dup", None, &[("Execute_1", "first")]);
+    let retry = factory_result(
+        "dup",
+        Some("dup"),
+        &[("Execute_2", "Error: Tool execution cancelled by user")],
+    );
+    write_jsonl(
+        &session_file,
+        &[header.clone(), anchor.clone(), retry.clone()],
+    );
+    let _daemon = start_isolated_provider_daemon(&temp);
+
+    let cold = import_factory(&temp, &path);
+    assert_eq!(
+        provider_core_records(&data_root(&temp), "factory_ai_droid").len(),
+        3,
+        "{cold:#}"
+    );
+    let cold_ids = factory_event_ids(&temp);
+    let anchor_id = cold_ids["first"].clone();
+    let retry_id = cold_ids["Error: Tool execution cancelled by user"].clone();
+    assert_ne!(anchor_id, retry_id);
+
+    let no_op = import_factory(&temp, &path);
+    assert_noop_publication(&no_op);
+    assert_eq!(factory_event_ids(&temp), cold_ids);
+
+    let appended = factory_result("dup", Some("dup"), &[("Execute_3", "recovered")]);
+    let mut file = fs::OpenOptions::new()
+        .append(true)
+        .open(&session_file)
+        .unwrap();
+    writeln!(file, "{appended}").unwrap();
+    drop(file);
+    import_factory(&temp, &path);
+    let after_append = factory_event_ids(&temp);
+    assert_eq!(after_append["first"], anchor_id);
+    assert_eq!(
+        after_append["Error: Tool execution cancelled by user"],
+        retry_id
+    );
+    let appended_id = after_append["recovered"].clone();
+
+    let multi = factory_result(
+        "dup",
+        Some("dup"),
+        &[("Execute_A", "multi a"), ("Execute_B", "multi b")],
+    );
+    write_jsonl(
+        &session_file,
+        &[
+            header.clone(),
+            multi,
+            appended.clone(),
+            anchor.clone(),
+            retry.clone(),
+        ],
+    );
+    import_factory(&temp, &path);
+    let after_insert = factory_event_ids(&temp);
+    assert_eq!(after_insert["first"], anchor_id);
+    assert_eq!(
+        after_insert["Error: Tool execution cancelled by user"],
+        retry_id
+    );
+    assert_eq!(after_insert["recovered"], appended_id);
+    let multi_a_id = after_insert["multi a"].clone();
+    let multi_b_id = after_insert["multi b"].clone();
+
+    let rewritten_retry = factory_result(
+        "dup",
+        Some("dup"),
+        &[("Execute_2", "cancelled retry rewritten")],
+    );
+    let reordered_multi = factory_result(
+        "dup",
+        Some("dup"),
+        &[("Execute_B", "multi b"), ("Execute_A", "multi a")],
+    );
+    write_jsonl(
+        &session_file,
+        &[
+            header.clone(),
+            appended.clone(),
+            rewritten_retry.clone(),
+            reordered_multi.clone(),
+            anchor.clone(),
+        ],
+    );
+    import_factory(&temp, &path);
+    let after_rewrite_and_reorder = factory_event_ids(&temp);
+    assert_eq!(after_rewrite_and_reorder["first"], anchor_id);
+    assert_eq!(
+        after_rewrite_and_reorder["cancelled retry rewritten"],
+        retry_id
+    );
+    assert_eq!(after_rewrite_and_reorder["recovered"], appended_id);
+    assert_eq!(after_rewrite_and_reorder["multi a"], multi_a_id);
+    assert_eq!(after_rewrite_and_reorder["multi b"], multi_b_id);
+
+    write_jsonl(
+        &session_file,
+        &[header, appended, rewritten_retry, reordered_multi],
+    );
+    import_factory(&temp, &path);
+    let after_anchor_delete = factory_event_ids(&temp);
+    assert_eq!(after_anchor_delete["cancelled retry rewritten"], retry_id);
+    assert_eq!(after_anchor_delete["recovered"], appended_id);
+    assert_eq!(after_anchor_delete["multi a"], multi_a_id);
+    assert_eq!(after_anchor_delete["multi b"], multi_b_id);
+    assert!(!after_anchor_delete.values().any(|id| id == &anchor_id));
+    let stderr = failure_stderr(ctx(&temp).args(["show", "event", &anchor_id, "--format=json"]));
+    assert!(stderr.contains("not found"), "{stderr}");
+}
+
+#[test]
+fn factory_droid_retry_ambiguity_and_invalid_evidence_fail_closed() {
+    for (name, records) in [
+        (
+            "exact duplicate",
+            vec![
+                factory_header("duplicate"),
+                factory_result("dup", None, &[("Execute_1", "anchor")]),
+                factory_result("dup", Some("dup"), &[("Execute_2", "retry")]),
+                factory_result("dup", Some("dup"), &[("Execute_2", "duplicate retry")]),
+            ],
+        ),
+        (
+            "missing parent evidence",
+            vec![
+                factory_header("missing-parent"),
+                factory_result("dup", None, &[("Execute_1", "anchor")]),
+                factory_result("dup", None, &[("Execute_2", "ambiguous retry")]),
+            ],
+        ),
+        (
+            "contradictory parent evidence",
+            vec![
+                factory_header("wrong-parent"),
+                factory_result("dup", None, &[("Execute_1", "anchor")]),
+                factory_result(
+                    "dup",
+                    Some("different-message"),
+                    &[("Execute_2", "ambiguous retry")],
+                ),
+            ],
+        ),
+    ] {
+        let temp = tempdir();
+        let root = temp.path().join("sessions/project");
+        fs::create_dir_all(&root).unwrap();
+        write_jsonl(&root.join("failure.jsonl"), &records);
+        let path = root.parent().unwrap().display().to_string();
+        let _daemon = start_isolated_provider_daemon(&temp);
+        let stderr = failure_stderr(ctx(&temp).args([
+            "import",
+            "--provider",
+            "factory-ai-droid",
+            "--path",
+            &path,
+            "--no-daemon",
+            "--format=json",
+            "--progress",
+            "none",
+        ]));
+        assert!(
+            stderr.contains("duplicate event identity"),
+            "{name}: {stderr}"
+        );
+    }
+
+    let temp = tempdir();
+    let root = temp.path().join("sessions/project");
+    fs::create_dir_all(&root).unwrap();
+    let missing_linkage = json!({
+        "type": "message",
+        "id": "dup",
+        "parentId": "dup",
+        "timestamp": "2026-07-14T09:30:23Z",
+        "message": {
+            "role": "user",
+            "content": [{"type": "tool_result", "content": "missing tool_use_id"}]
+        }
+    });
+    write_jsonl(
+        &root.join("missing-linkage.jsonl"),
+        &[
+            factory_header("missing-linkage"),
+            factory_result("dup", None, &[("Execute_1", "anchor")]),
+            missing_linkage,
+        ],
+    );
+    let path = root.parent().unwrap().display().to_string();
+    let _daemon = start_isolated_provider_daemon(&temp);
+    let imported = import_factory(&temp, &path);
+    assert_eq!(imported["totals"]["current_rejected_records"], 1);
+    assert_eq!(factory_event_ids(&temp).len(), 2);
+}
+
+#[test]
+fn factory_retry_identity_is_source_scoped() {
+    let temp = tempdir();
+    let root = temp.path().join("sessions/project");
+    fs::create_dir_all(&root).unwrap();
+    for session_id in ["one", "two"] {
+        write_jsonl(
+            &root.join(format!("{session_id}.jsonl")),
+            &[
+                factory_header(session_id),
+                factory_result("dup", None, &[("Execute_1", "cross-source anchor")]),
+                factory_result("dup", Some("dup"), &[("Execute_2", "cross-source retry")]),
+            ],
+        );
+    }
+    let path = root.parent().unwrap().display().to_string();
+    let _daemon = start_isolated_provider_daemon(&temp);
+    import_factory(&temp, &path);
+    let records = provider_core_records(&data_root(&temp), "factory_ai_droid");
+    assert_eq!(records.len(), 6);
+    assert_eq!(
+        records
+            .iter()
+            .map(|record| record.event_id.to_string())
+            .collect::<BTreeSet<_>>()
+            .len(),
+        6
+    );
+    assert_eq!(
+        records
+            .iter()
+            .map(|record| record.source.clone())
+            .collect::<BTreeSet<_>>()
+            .len(),
+        2
+    );
+}
+
+#[test]
+fn non_factory_native_jsonl_duplicates_still_fail() {
+    let temp = tempdir();
+    let root = temp.path().join("projects/workspace/transcript");
+    fs::create_dir_all(&root).unwrap();
+    let qoder = |body: &str| {
+        json!({
+            "type": "user",
+            "sessionId": "qoder-duplicate-session",
+            "uuid": "qoder-duplicate-event",
+            "timestamp": "2026-07-14T09:30:13Z",
+            "message": {"role": "user", "content": body}
+        })
+    };
+    write_jsonl(
+        &root.join("duplicate.jsonl"),
+        &[
+            json!({
+                "type": "session_meta",
+                "sessionId": "qoder-duplicate-session",
+                "uuid": "qoder-meta",
+                "timestamp": "2026-07-14T09:30:00Z",
+                "data": {"meta_type": "session_info"}
+            }),
+            qoder("first"),
+            qoder("second"),
+        ],
+    );
+    let path = temp.path().join("projects").display().to_string();
+    let _daemon = start_isolated_provider_daemon(&temp);
+    let stderr = failure_stderr(ctx(&temp).args([
+        "import",
+        "--provider",
+        "qoder",
+        "--path",
+        &path,
+        "--no-daemon",
+        "--format=json",
+        "--progress",
+        "none",
+    ]));
+    assert!(stderr.contains("duplicate event identity"), "{stderr}");
+}

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/factory_ai_droid.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/factory_ai_droid.rs
@@ -27,6 +27,6 @@ mod records;
 pub(in crate::provider::providers::native_jsonl) use records::{
     enumerate_factory_droid_results, factory_droid_event_identity, factory_droid_event_text,
     factory_droid_event_type, factory_droid_file_is_selected, factory_droid_header_cwd,
-    factory_droid_header_session_id, factory_droid_model, factory_droid_role,
-    factory_droid_session_relationships,
+    factory_droid_header_session_id, factory_droid_model, factory_droid_retry_discriminator,
+    factory_droid_role, factory_droid_session_relationships,
 };

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/factory_ai_droid_records.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/factory_ai_droid_records.rs
@@ -114,10 +114,60 @@ pub(in crate::provider::providers::native_jsonl) fn enumerate_factory_droid_resu
     let content = value
         .get("content")
         .or_else(|| value.pointer("/message/content"));
-    if reject_redacted(value).is_err() {
-        return placeholder_results(content);
+    let results = if reject_redacted(value).is_err() {
+        placeholder_results(content)?
+    } else {
+        enumerate_content_results(content, value)?
+    };
+    for result in &results {
+        factory_droid_retry_discriminator(value, result.subrecord_index)?;
     }
-    enumerate_content_results(content, value)
+    Ok(results)
+}
+
+pub(in crate::provider::providers::native_jsonl) fn factory_droid_retry_discriminator(
+    value: &Value,
+    subrecord_index: u32,
+) -> std::result::Result<
+    Option<super::super::DirectJsonlRetryDiscriminator>,
+    NativeJsonlResultExtractionError,
+> {
+    let Some(message_id) = value
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+    else {
+        return Ok(None);
+    };
+    let Some(parent_id) = value
+        .get("parentId")
+        .and_then(Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+    else {
+        return Ok(None);
+    };
+    if parent_id != message_id {
+        return Ok(None);
+    }
+    let index = usize::try_from(subrecord_index)
+        .map_err(|_| NativeJsonlResultExtractionError::InvalidShape)?;
+    let result = value
+        .get("content")
+        .or_else(|| value.pointer("/message/content"))
+        .and_then(Value::as_array)
+        .and_then(|content| content.get(index))
+        .filter(|result| result.get("type").and_then(Value::as_str) == Some("tool_result"))
+        .ok_or(NativeJsonlResultExtractionError::InvalidShape)?;
+    let tool_use_id = result
+        .get("tool_use_id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+        .ok_or(NativeJsonlResultExtractionError::InvalidShape)?;
+    Ok(Some(
+        super::super::DirectJsonlRetryDiscriminator::FactoryDroidToolResult {
+            tool_use_id: tool_use_id.to_owned(),
+        },
+    ))
 }
 
 fn factory_droid_content_has(value: &Value, expected: &str) -> bool {

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/mod.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/mod.rs
@@ -18,12 +18,12 @@ pub(crate) use factory_ai_droid::factory_droid_source_backed_adapter;
 pub(super) use factory_ai_droid::{
     enumerate_factory_droid_results, factory_droid_event_identity, factory_droid_event_text,
     factory_droid_event_type, factory_droid_file_is_selected, factory_droid_header_cwd,
-    factory_droid_header_session_id, factory_droid_model, factory_droid_role,
-    factory_droid_session_relationships,
+    factory_droid_header_session_id, factory_droid_model, factory_droid_retry_discriminator,
+    factory_droid_role, factory_droid_session_relationships,
 };
 pub(crate) use model::{
-    DirectJsonlEvent, DirectJsonlRejection, DirectJsonlSession, DirectJsonlSourceRecord,
-    DirectJsonlTouch, DIRECT_JSONL_NATIVEPATH_PARSER_REVISION,
+    DirectJsonlEvent, DirectJsonlRejection, DirectJsonlRetryDiscriminator, DirectJsonlSession,
+    DirectJsonlSourceRecord, DirectJsonlTouch, DIRECT_JSONL_NATIVEPATH_PARSER_REVISION,
 };
 pub(crate) use qoder::qoder_source_backed_adapter;
 pub(crate) use qwen_code::{qwen_code_file_is_selected, qwen_code_source_backed_adapter};

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/model.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/model.rs
@@ -34,6 +34,7 @@ pub(crate) struct DirectJsonlEvent {
     pub(crate) raw_ordinal: u64,
     pub(crate) sub_ordinal: u32,
     pub(crate) native_record_id: Option<String>,
+    pub(crate) stable_retry_discriminator: Option<DirectJsonlRetryDiscriminator>,
     pub(crate) provider_event_sequence_index: u64,
     pub(crate) provider_event_hash: String,
     pub(crate) event_type: EventType,
@@ -45,6 +46,11 @@ pub(crate) struct DirectJsonlEvent {
     pub(crate) touches: Vec<DirectJsonlTouch>,
     #[serde(skip, default)]
     pub(crate) source_record: DirectJsonlSourceRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum DirectJsonlRetryDiscriminator {
+    FactoryDroidToolResult { tool_use_id: String },
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/reader.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/reader.rs
@@ -29,9 +29,10 @@ use super::super::{
 };
 use super::{
     copilot, enumerate_factory_droid_results, factory_droid_event_identity,
-    factory_droid_event_text, factory_droid_event_type, factory_droid_model, factory_droid_role,
-    qoder_parser, qwen_code, tabnine, windsurf, DirectJsonlEvent, DirectJsonlRejection,
-    DirectJsonlSession, DirectJsonlSourceRecord, DirectJsonlTouch,
+    factory_droid_event_text, factory_droid_event_type, factory_droid_model,
+    factory_droid_retry_discriminator, factory_droid_role, qoder_parser, qwen_code, tabnine,
+    windsurf, DirectJsonlEvent, DirectJsonlRejection, DirectJsonlSession, DirectJsonlSourceRecord,
+    DirectJsonlTouch,
 };
 
 #[path = "reader_projection.rs"]

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/reader_projection.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/reader_projection.rs
@@ -404,11 +404,22 @@ fn direct_event(
 
     let positional_event_index = direct_jsonl_event_sequence(raw_ordinal, sub_ordinal)?;
     let native_record_id = direct_jsonl_native_event_identity(provider, value);
+    let stable_retry_discriminator = match provider {
+        CaptureProvider::FactoryAiDroid if result.is_some() => {
+            factory_droid_retry_discriminator(value, sub_ordinal).map_err(|_| {
+                CaptureError::SystemInvariant(
+                    "validated Factory Droid retry result lost its native discriminator",
+                )
+            })?
+        }
+        _ => None,
+    };
     let provider_event_sequence_index = positional_event_index;
     let provider_event_hash = crate::compute_payload_hash(&json!({
         "event_type": event_type.as_str(),
         "role": role.as_str(),
         "native_record_id": native_record_id,
+        "stable_retry_discriminator": stable_retry_discriminator,
         "sub_ordinal": sub_ordinal,
         "lexical_text": lexical_text,
         "tool_result": tool_result.clone(),
@@ -418,6 +429,7 @@ fn direct_event(
         raw_ordinal,
         sub_ordinal,
         native_record_id,
+        stable_retry_discriminator,
         provider_event_sequence_index,
         provider_event_hash,
         event_type,

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::{
-    reader::DirectJsonlProjector, DirectJsonlEvent, DirectJsonlRejection, DirectJsonlSession,
-    DIRECT_JSONL_NATIVEPATH_PARSER_REVISION,
+    reader::DirectJsonlProjector, DirectJsonlEvent, DirectJsonlRejection,
+    DirectJsonlRetryDiscriminator, DirectJsonlSession, DIRECT_JSONL_NATIVEPATH_PARSER_REVISION,
 };
 use crate::{
     common::io::{
@@ -586,15 +586,20 @@ fn project_event(
             PositionStability::AppendStable,
         )?
     };
-    let subrecord_selector = (event.sub_ordinal != 0)
-        .then(|| {
-            SubrecordSelector::certified_position(
-                "direct-jsonl-subrecord",
-                TypedKey::U64(u64::from(event.sub_ordinal)),
-                PositionStability::StableSlot,
-            )
-        })
-        .transpose()?;
+    let subrecord_selector = match &event.stable_retry_discriminator {
+        Some(DirectJsonlRetryDiscriminator::FactoryDroidToolResult { tool_use_id }) => {
+            Some(SubrecordSelector::native_id(
+                "factory-ai-droid.retry-tool-result",
+                TypedKey::utf8(tool_use_id)?,
+            )?)
+        }
+        None if event.sub_ordinal != 0 => Some(SubrecordSelector::certified_position(
+            "direct-jsonl-subrecord",
+            TypedKey::U64(u64::from(event.sub_ordinal)),
+            PositionStability::StableSlot,
+        )?),
+        None => None,
+    };
     let event_id = derive_event_id(EventIdentityInput {
         source,
         session_id,
@@ -602,15 +607,22 @@ fn project_event(
         native_item_key: &native_item_key,
         subrecord_selector: subrecord_selector.as_ref(),
     })?;
-    let native_event_key = TypedKey::composite(vec![
-        event
-            .native_record_id
-            .as_deref()
-            .map(TypedKey::utf8)
-            .transpose()?
-            .unwrap_or(TypedKey::U64(event.raw_ordinal)),
-        TypedKey::U64(u64::from(event.sub_ordinal)),
-    ])?;
+    let native_record_key = event
+        .native_record_id
+        .as_deref()
+        .map(TypedKey::utf8)
+        .transpose()?
+        .unwrap_or(TypedKey::U64(event.raw_ordinal));
+    let native_subrecord_key = match &event.stable_retry_discriminator {
+        Some(DirectJsonlRetryDiscriminator::FactoryDroidToolResult { tool_use_id }) => {
+            TypedKey::composite(vec![
+                TypedKey::utf8("factory-ai-droid.retry-tool-result")?,
+                TypedKey::utf8(tool_use_id)?,
+            ])?
+        }
+        None => TypedKey::U64(u64::from(event.sub_ordinal)),
+    };
+    let native_event_key = TypedKey::composite(vec![native_record_key, native_subrecord_key])?;
     let parent_session_id = session
         .parent_provider_session_id
         .as_deref()

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed_result_tests.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed_result_tests.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{collections::BTreeMap, path::Path};
 
 use chrono::{DateTime, Utc};
 use ctx_history_core::{
@@ -86,6 +86,261 @@ fn native_subrecord_index(record: &CoreRecord) -> u64 {
         panic!("direct JSONL result identity has no subrecord index");
     };
     *index
+}
+
+fn project_all(provider: CaptureProvider, values: &[Value]) -> (Vec<CoreRecord>, u64) {
+    let adapter = adapter(provider);
+    let session = session(provider);
+    let (source, session_id) = adapter
+        .session_identity(&session.native_session_id)
+        .unwrap();
+    let direct = DirectJsonlProjector::new(
+        provider,
+        adapter.source_format,
+        Path::new("direct-jsonl-identity-contract.jsonl"),
+        None,
+        DateTime::<Utc>::UNIX_EPOCH,
+        Some(session.clone()),
+    )
+    .unwrap();
+    let mut projector = DirectJsonlFamilyProjector {
+        adapter,
+        source,
+        bound_session: session,
+        session_id,
+        projector: direct,
+        rejected_records: 0,
+    };
+    let mut records = Vec::new();
+    for (ordinal, value) in values.iter().enumerate() {
+        let encoded = serde_json::to_vec(value).unwrap();
+        JsonlFamilyProjector::project(
+            &mut projector,
+            JsonlRecordRef::for_test(&encoded, ordinal as u64),
+            &mut |record| {
+                records.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+    }
+    (records, projector.rejected_records())
+}
+
+fn event_ids_by_body(records: &[CoreRecord]) -> BTreeMap<String, String> {
+    records
+        .iter()
+        .map(|record| {
+            (
+                record.content.normalized_body.clone().unwrap(),
+                record.event_id.to_string(),
+            )
+        })
+        .collect()
+}
+
+fn factory_result(id: &str, parent_id: Option<&str>, call_id: &str, body: &str) -> Value {
+    let mut value = json!({
+        "type": "message",
+        "id": id,
+        "timestamp": "2026-07-14T09:30:13Z",
+        "message": {
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": call_id,
+                "content": body,
+                "is_error": false
+            }]
+        }
+    });
+    if let Some(parent_id) = parent_id {
+        value["parentId"] = json!(parent_id);
+    }
+    value
+}
+
+#[test]
+fn factory_retry_identities_use_stable_native_evidence_not_order_or_content() {
+    let anchor = factory_result("shared", None, "Execute_anchor", "anchor");
+    let retry_one = factory_result("shared", Some("shared"), "Execute_retry_1", "retry one");
+    let retry_two = factory_result("shared", Some("shared"), "Execute_retry_2", "retry two");
+
+    let (anchor_only, rejected) = project_all(
+        CaptureProvider::FactoryAiDroid,
+        std::slice::from_ref(&anchor),
+    );
+    assert_eq!(rejected, 0);
+    let (initial, rejected) = project_all(
+        CaptureProvider::FactoryAiDroid,
+        &[anchor.clone(), retry_one.clone(), retry_two.clone()],
+    );
+    assert_eq!(rejected, 0);
+    assert_eq!(initial.len(), 3);
+    assert_eq!(anchor_only[0].event_id, initial[0].event_id);
+    assert_eq!(
+        initial[0].native_event_id,
+        Some(TypedKey::Composite(vec![
+            TypedKey::Utf8("shared".to_owned()),
+            TypedKey::U64(0),
+        ]))
+    );
+    assert_eq!(
+        initial[1].native_event_id,
+        Some(TypedKey::Composite(vec![
+            TypedKey::Utf8("shared".to_owned()),
+            TypedKey::Composite(vec![
+                TypedKey::Utf8("factory-ai-droid.retry-tool-result".to_owned()),
+                TypedKey::Utf8("Execute_retry_1".to_owned()),
+            ]),
+        ]))
+    );
+
+    let baseline = event_ids_by_body(&initial);
+    let (reordered, rejected) = project_all(
+        CaptureProvider::FactoryAiDroid,
+        &[retry_two.clone(), anchor.clone(), retry_one.clone()],
+    );
+    assert_eq!(rejected, 0);
+    assert_eq!(event_ids_by_body(&reordered), baseline);
+
+    let inserted = factory_result(
+        "shared",
+        Some("shared"),
+        "Execute_inserted",
+        "inserted retry",
+    );
+    let (with_insert, rejected) = project_all(
+        CaptureProvider::FactoryAiDroid,
+        &[
+            retry_two.clone(),
+            inserted,
+            anchor.clone(),
+            retry_one.clone(),
+        ],
+    );
+    assert_eq!(rejected, 0);
+    let with_insert = event_ids_by_body(&with_insert);
+    for (body, event_id) in &baseline {
+        assert_eq!(with_insert.get(body), Some(event_id));
+    }
+
+    let (after_delete, rejected) = project_all(
+        CaptureProvider::FactoryAiDroid,
+        &[retry_two.clone(), anchor.clone()],
+    );
+    assert_eq!(rejected, 0);
+    let after_delete = event_ids_by_body(&after_delete);
+    assert_eq!(after_delete.get("anchor"), baseline.get("anchor"));
+    assert_eq!(after_delete.get("retry two"), baseline.get("retry two"));
+    assert!(!after_delete.values().any(|id| id == &baseline["retry one"]));
+
+    let rewritten = factory_result(
+        "shared",
+        Some("shared"),
+        "Execute_retry_1",
+        "rewritten retry one",
+    );
+    let (rewritten, rejected) = project_all(
+        CaptureProvider::FactoryAiDroid,
+        &[anchor, rewritten, retry_two],
+    );
+    assert_eq!(rejected, 0);
+    assert_eq!(
+        event_ids_by_body(&rewritten)["rewritten retry one"],
+        baseline["retry one"]
+    );
+}
+
+#[test]
+fn factory_retry_multi_subrecords_keep_ids_when_content_blocks_reorder() {
+    let record = |content: Vec<Value>| {
+        json!({
+            "type": "message",
+            "id": "shared",
+            "parentId": "shared",
+            "timestamp": "2026-07-14T09:30:23Z",
+            "message": {"role": "user", "content": content}
+        })
+    };
+    let first = json!({
+        "type": "tool_result",
+        "tool_use_id": "Execute_A",
+        "content": "result a"
+    });
+    let second = json!({
+        "type": "tool_result",
+        "tool_use_id": "Execute_B",
+        "content": "result b"
+    });
+    let text = json!({"type": "text", "text": "interleaved"});
+    let (original, rejected) = project_all(
+        CaptureProvider::FactoryAiDroid,
+        &[record(vec![first.clone(), text.clone(), second.clone()])],
+    );
+    assert_eq!(rejected, 0);
+    let (reordered, rejected) = project_all(
+        CaptureProvider::FactoryAiDroid,
+        &[record(vec![second, first, text])],
+    );
+    assert_eq!(rejected, 0);
+    assert_eq!(event_ids_by_body(&original), event_ids_by_body(&reordered));
+}
+
+#[test]
+fn factory_retry_ambiguity_and_missing_evidence_fail_closed() {
+    let duplicate = factory_result("shared", Some("shared"), "Execute_same", "duplicate");
+    let (records, rejected) = project_all(
+        CaptureProvider::FactoryAiDroid,
+        &[duplicate.clone(), duplicate],
+    );
+    assert_eq!(rejected, 0);
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].event_id, records[1].event_id);
+
+    let missing_tool_use_id = json!({
+        "type": "message",
+        "id": "shared",
+        "parentId": "shared",
+        "timestamp": "2026-07-14T09:30:23Z",
+        "message": {
+            "role": "user",
+            "content": [{"type": "tool_result", "content": "missing linkage"}]
+        }
+    });
+    let (records, rejected) = project_all(CaptureProvider::FactoryAiDroid, &[missing_tool_use_id]);
+    assert!(records.is_empty());
+    assert_eq!(rejected, 1);
+
+    for parent_id in [None, Some("contradictory-parent")] {
+        let anchor = factory_result("shared", None, "Execute_anchor", "anchor");
+        let ambiguous = factory_result("shared", parent_id, "Execute_other", "ambiguous");
+        let (records, rejected) =
+            project_all(CaptureProvider::FactoryAiDroid, &[anchor, ambiguous]);
+        assert_eq!(rejected, 0);
+        assert_eq!(records[0].event_id, records[1].event_id);
+    }
+
+    let qoder = |call_id: &str, body: &str| {
+        json!({
+            "type": "user",
+            "uuid": "shared-qoder-id",
+            "message": {
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": call_id,
+                    "content": body
+                }]
+            }
+        })
+    };
+    let (records, rejected) = project_all(
+        CaptureProvider::Qoder,
+        &[qoder("call-a", "qoder a"), qoder("call-b", "qoder b")],
+    );
+    assert_eq!(rejected, 0);
+    assert_eq!(records[0].event_id, records[1].event_id);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- accept repeated Factory Droid message IDs only when exact native retry evidence is present
- derive a Factory-only typed retry selector from validated parent linkage and `tool_use_id`
- preserve existing event IDs across insert, reorder, deletion, rewrite, append, and checkpoint resume
- keep ambiguous duplicates and every other native-JSONL provider fail-closed

Closes #261.

## Validation
- full capture and native-provider Bazel targets
- 34/34 native-provider CLI tests
- cold, no-op, append/resume, rewrite, insert/reorder/delete, and multi-subrecord reorder regressions
- missing/contradictory/duplicate evidence, cross-source isolation, and non-Factory strict rejection
- strict affected-package clippy, formatting, diff, architecture, and LOC gates
- independent exact-SHA review: PASS with no findings