### PR TITLE
fix(kimi): index streamed assistant content parts from wire transcripts

### DIFF
--- a/crates/ctx-cli/tests/native_provider_real_shapes.rs
+++ b/crates/ctx-cli/tests/native_provider_real_shapes.rs
@@ -252,3 +252,54 @@ fn nanoclaw_import_preserves_text_timestamp_millis_and_integer_trigger() {
         "{search:#}"
     );
 }
+
+#[test]
+fn kimi_code_cli_wire_indexes_streamed_assistant_output_through_public_cli() {
+    let temp = finite_daemon_test_root();
+    let query = "streamedassistantwireoracle";
+    let path = write_native_kimi_code_cli_wire_fixture(&temp, query);
+
+    let imported = json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "kimi-code-cli",
+        "--path",
+        &path,
+        "--format=json",
+    ]));
+    let source = assert_explicit_source_publication(
+        &imported,
+        "kimi_code_cli",
+        "kimi_code_cli_wire_jsonl_tree",
+    );
+    assert_eq!(source["current_source_count"], 1, "{imported:#}");
+    assert!(
+        source["current_indexed_documents"]
+            .as_u64()
+            .is_some_and(|count| count >= 1),
+        "{imported:#}"
+    );
+
+    let search = json_output(ctx(&temp).args([
+        "search",
+        query,
+        "--provider",
+        "kimi-code-cli",
+        "--events",
+        "--refresh",
+        "off",
+        "--format=json",
+    ]));
+    assert_event_search_provider_oracle(&search, "kimi_code_cli", query, 1, "message");
+    let assistant_reply = &search["results"][0];
+    assert_eq!(
+        assistant_reply["title"], "kimi_code_cli assistant message",
+        "{search:#}"
+    );
+    assert!(
+        assistant_reply["snippet"]
+            .as_str()
+            .is_some_and(|snippet| snippet.contains(query)),
+        "{search:#}"
+    );
+}

--- a/crates/ctx-cli/tests/support/native_fixtures/json_tree.rs
+++ b/crates/ctx-cli/tests/support/native_fixtures/json_tree.rs
@@ -1110,3 +1110,94 @@ pub(crate) fn write_native_continue_fixture(temp: &TempDir, query: &str) -> Stri
     .unwrap();
     root.to_str().unwrap().to_owned()
 }
+
+/// Writes a Kimi Code CLI wire tree in the shape the CLI actually journals:
+/// the assistant reply exists only as streamed `content.part` loop events.
+pub(crate) fn write_native_kimi_code_cli_wire_fixture(temp: &TempDir, query: &str) -> String {
+    let root = temp.path().join("native-kimi-code-cli/.kimi-code");
+    let session_dir = root.join("sessions/wd_workspace_abc123/session-real-shape");
+    let agent_dir = session_dir.join("agents/main");
+    fs::create_dir_all(&agent_dir).unwrap();
+    fs::write(
+        root.join("session_index.jsonl"),
+        format!(
+            "{}\n",
+            json!({
+                "sessionId": "session-real-shape",
+                "sessionDir": session_dir,
+                "workDir": "/workspace/kimi"
+            })
+        ),
+    )
+    .unwrap();
+    fs::write(
+        session_dir.join("state.json"),
+        json!({
+            "createdAt": "2026-07-17T12:00:00Z",
+            "updatedAt": "2026-07-17T12:00:10Z",
+            "title": "Kimi wire real shape",
+            "agents": {"main": {"type": "main", "parentAgentId": null}},
+            "workDir": "/workspace/kimi"
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let records = [
+        json!({"type": "metadata", "protocol_version": "1.4", "created_at": 1_783_170_000_000_i64}),
+        json!({
+            "type": "turn.prompt",
+            "time": 1_783_170_001_000_i64,
+            "input": [{"type": "text", "text": "kimi wire real shape prompt"}],
+            "origin": {"kind": "user"}
+        }),
+        json!({
+            "type": "context.append_loop_event",
+            "time": 1_783_170_002_000_i64,
+            "event": {"type": "step.begin", "uuid": "step-1", "turnId": "0", "step": 1}
+        }),
+        json!({
+            "type": "context.append_loop_event",
+            "time": 1_783_170_003_000_i64,
+            "event": {
+                "type": "content.part",
+                "uuid": "part-1",
+                "turnId": "0",
+                "step": 1,
+                "stepUuid": "step-1",
+                "part": {"type": "text", "text": query}
+            }
+        }),
+        json!({
+            "type": "context.append_loop_event",
+            "time": 1_783_170_004_000_i64,
+            "event": {
+                "type": "tool.call",
+                "turnId": "0",
+                "step": 1,
+                "stepUuid": "step-1",
+                "toolCallId": "call_1",
+                "name": "Read",
+                "args": {"path": "src/kimi_wire.txt"}
+            }
+        }),
+        json!({
+            "type": "context.append_loop_event",
+            "time": 1_783_170_005_000_i64,
+            "event": {
+                "type": "tool.result",
+                "turnId": "0",
+                "toolCallId": "call_1",
+                "result": {"output": "kimi wire real shape tool output", "isError": false}
+            }
+        }),
+    ];
+    fs::write(
+        agent_dir.join("wire.jsonl"),
+        records
+            .iter()
+            .map(|record| format!("{record}\n"))
+            .collect::<String>(),
+    )
+    .unwrap();
+    root.to_str().unwrap().to_owned()
+}

--- a/crates/ctx-history-capture/src/provider/providers/kimi/event.rs
+++ b/crates/ctx-history-capture/src/provider/providers/kimi/event.rs
@@ -36,7 +36,9 @@ pub(crate) fn kimi_event_type(record_type: &str, value: &Value) -> EventType {
                 Some(kind) if kind.contains("tool.result") || kind.contains("tool.finish") => {
                     EventType::ToolOutput
                 }
-                Some(kind) if kind.contains("message") => EventType::Message,
+                Some(kind) if kind.contains("content.part") || kind.contains("message") => {
+                    EventType::Message
+                }
                 _ if value.pointer("/event/toolName").is_some()
                     || value.pointer("/event/tool_name").is_some() =>
                 {
@@ -68,6 +70,10 @@ pub(crate) fn kimi_event_role(
         {
             EventRole::Tool
         }
+        // Content parts are streamed model output, so they carry no role field.
+        "context.append_loop_event" if kimi_loop_event_is_content_part(value) => {
+            EventRole::Assistant
+        }
         "context.append_loop_event" => provider_role(
             value
                 .pointer("/event/role")
@@ -89,17 +95,22 @@ pub(crate) fn kimi_event_text(record_type: &str, value: &Value, event_type: Even
             .or_else(|| value.get("message"))
             .and_then(provider_value_text)
             .unwrap_or_default(),
-        "context.append_loop_event" => value
-            .pointer("/event/content")
-            .or_else(|| value.pointer("/event/text"))
-            .or_else(|| value.pointer("/event/output"))
-            .or_else(|| value.pointer("/event/result"))
-            .or_else(|| value.pointer("/event/message"))
-            .and_then(provider_value_text)
+        "context.append_loop_event" => kimi_content_part_text(value)
+            .or_else(|| {
+                value
+                    .pointer("/event/content")
+                    .or_else(|| value.pointer("/event/text"))
+                    .or_else(|| value.pointer("/event/output"))
+                    .or_else(|| value.pointer("/event/result/output"))
+                    .or_else(|| value.pointer("/event/result"))
+                    .or_else(|| value.pointer("/event/message"))
+                    .and_then(provider_value_text)
+            })
             .or_else(|| {
                 value
                     .pointer("/event/toolName")
                     .or_else(|| value.pointer("/event/tool_name"))
+                    .or_else(|| value.pointer("/event/name"))
                     .and_then(Value::as_str)
                     .map(|tool| match event_type {
                         EventType::ToolOutput => format!("tool result: {tool}"),
@@ -141,9 +152,33 @@ pub(super) fn kimi_output_content(value: &Value) -> Option<String> {
         .pointer("/event/content")
         .or_else(|| value.pointer("/event/text"))
         .or_else(|| value.pointer("/event/output"))
+        .or_else(|| value.pointer("/event/result/output"))
         .or_else(|| value.pointer("/event/result"))
         .or_else(|| value.pointer("/event/message"))
         .and_then(provider_explicit_result_value_text)
+}
+
+fn kimi_loop_event_is_content_part(value: &Value) -> bool {
+    value
+        .pointer("/event/type")
+        .and_then(Value::as_str)
+        .is_some_and(|kind| kind.contains("content.part"))
+}
+
+/// Extracts assistant output from a Kimi `content.part` loop event. Kimi never
+/// journals assistant messages as `context.append_message`; replies and
+/// reasoning are only persisted as text and think parts.
+fn kimi_content_part_text(value: &Value) -> Option<String> {
+    if !kimi_loop_event_is_content_part(value) {
+        return None;
+    }
+    let part = value.pointer("/event/part")?;
+    part.get("text")
+        .or_else(|| part.get("think"))
+        .or_else(|| part.get("thinking"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| provider_value_text(part))
 }
 
 pub(crate) fn kimi_record_timestamp(
@@ -172,6 +207,97 @@ pub(crate) fn kimi_record_timestamp(
                 .and_then(DateTime::<Utc>::from_timestamp_millis)
         })
         .or(Some(fallback))
+}
+
+#[cfg(test)]
+mod loop_event_tests {
+    use ctx_history_core::{EventRole, EventType};
+    use serde_json::json;
+
+    use super::{kimi_event_role, kimi_event_text, kimi_event_type, kimi_output_content};
+
+    fn classify(value: &serde_json::Value) -> (EventType, EventRole, String) {
+        let record_type = value
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .unwrap();
+        let event_type = kimi_event_type(record_type, value);
+        (
+            event_type,
+            kimi_event_role(record_type, value, event_type),
+            kimi_event_text(record_type, value, event_type),
+        )
+    }
+
+    #[test]
+    fn content_parts_carry_assistant_reply_and_reasoning() {
+        let reply = json!({
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "content.part",
+                "turnId": "0",
+                "step": 1,
+                "stepUuid": "8d666b5f",
+                "part": {"type": "text", "text": "reticulate them counter-clockwise"}
+            }
+        });
+        assert_eq!(
+            classify(&reply),
+            (
+                EventType::Message,
+                EventRole::Assistant,
+                "reticulate them counter-clockwise".to_owned()
+            )
+        );
+
+        let think = json!({
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "content.part",
+                "stepUuid": "8d666b5f",
+                "part": {"type": "think", "think": "Simple probe request."}
+            }
+        });
+        assert_eq!(
+            classify(&think),
+            (
+                EventType::Message,
+                EventRole::Assistant,
+                "Simple probe request.".to_owned()
+            )
+        );
+    }
+
+    #[test]
+    fn wire_tool_exchange_keeps_name_and_output() {
+        let call = json!({
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "tool.call",
+                "toolCallId": "call_1",
+                "name": "Read",
+                "args": {"path": "/tmp/splines.txt"}
+            }
+        });
+        assert_eq!(
+            classify(&call),
+            (
+                EventType::ToolCall,
+                EventRole::Tool,
+                "tool call: Read".to_owned()
+            )
+        );
+
+        let result = json!({
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "tool.result",
+                "toolCallId": "call_1",
+                "result": {"output": "spline data", "isError": false}
+            }
+        });
+        assert_eq!(kimi_output_content(&result).as_deref(), Some("spline data"));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Kimi Code CLI never journals assistant replies as `context.append_message` — it persists them only as streamed `content.part` loop events, so the current classifier drops every model turn while keeping user prompts. This also affects tool events, which use `name` and `result.output` rather than the `toolName`/`output` shapes the importer expects.

- `content.part` now maps to a `Message` event with the `assistant` role, taking text from `part.text` and reasoning from `part.think`
- `/event/name` added to the tool-name fallback so modern `tool.call` records keep a body instead of being rejected as empty
- `/event/result/output` added to the output chain so `tool.result` payloads extract cleanly rather than serializing the wrapper object
- new unit tests pin the real wire-protocol 1.4 shapes for content parts and the tool exchange
- new e2e test in `native_provider_real_shapes.rs` asserts an event-scoped search finds the streamed reply; it returns 0 results before this change and 1 `assistant message` after

Existing fixtures use a schema the CLI does not emit, so session-scoped search masked this: the session still matched while the assistant event was absent from the event index.