### PR TITLE
perf(index): parallelize exhaustive generation verification

### DIFF
--- a/crates/ctx-history-index/src/publication/verification.rs
+++ b/crates/ctx-history-index/src/publication/verification.rs
@@ -30,7 +30,7 @@ use crate::{
     fields_from_schema, hex,
     query::{self, CompactIdentity, IdentityFieldRole},
     staging::{accumulate_core_record, core_record_accumulator_leaf},
-    GenerationManifest, IndexError, Result, WriterOptions,
+    GenerationManifest, IndexError, Result,
 };
 
 mod spill;
@@ -53,6 +53,13 @@ struct SegmentVerification {
     body_tokens: u64,
     source_aggregates: BTreeMap<String, SourceAggregate>,
     parent_session_documents: u64,
+}
+
+#[derive(Clone, Copy)]
+struct SegmentVerificationTask {
+    segment_ord: usize,
+    start_doc_id: u32,
+    end_doc_id: u32,
 }
 
 #[derive(Default)]
@@ -99,7 +106,7 @@ struct VerificationRunMetrics {
     stored_core_bytes: u64,
     body_tokens: u64,
     verification_spill_bytes: u64,
-    verification_heap_payload_bound_bytes: usize,
+    verification_tracked_heap_bytes: usize,
 }
 
 #[cfg(test)]
@@ -123,13 +130,14 @@ pub(crate) fn verify_searcher_structure(
 }
 
 pub(crate) fn verify_searcher(searcher: &Searcher, manifest: &GenerationManifest) -> Result<()> {
-    let worker_budget = verification_worker_budget(searcher.segment_readers().len());
+    let worker_budget = verification_worker_budget(searcher.num_docs());
     verify_searcher_with_options(searcher, manifest, worker_budget, false, false).map(|_| ())
 }
 
 const PHYSICAL_INTEGRITY_DOMAIN: &[u8] = b"ctx-tantivy-physical-integrity-v1\0";
 const PHYSICAL_HASH_BUFFER_BYTES: usize = 64 * 1024;
 const TANTIVY_META_FILE: &str = "meta.json";
+const MAX_VERIFICATION_WORKERS: usize = 24;
 
 #[derive(Debug)]
 struct PhysicalFileDigest {
@@ -371,14 +379,35 @@ pub(crate) fn verify_complete_searcher(
     verify_searcher(searcher, manifest)
 }
 
-fn verification_worker_budget(segment_count: usize) -> usize {
+fn verification_worker_budget(document_count: u64) -> usize {
     let available = std::thread::available_parallelism()
         .map(usize::from)
         .unwrap_or(1);
-    segment_count
+    usize::try_from(document_count)
+        .unwrap_or(usize::MAX)
         .max(1)
         .min(available)
-        .min(WriterOptions::default().indexer_threads.max(1))
+        .min(MAX_VERIFICATION_WORKERS)
+}
+
+#[cfg(test)]
+#[test]
+fn verification_tasks_split_large_segments_into_contiguous_bounded_ranges() {
+    let max_docs = [1_052_077, 976_361, 131_836, 3_341];
+    let tasks = segment_verification_tasks_for_max_docs(&max_docs, 24).unwrap();
+    assert!(tasks.len() > 24);
+
+    for (segment_ord, max_doc) in max_docs.into_iter().enumerate() {
+        let segment_tasks = tasks
+            .iter()
+            .filter(|task| task.segment_ord == segment_ord)
+            .collect::<Vec<_>>();
+        assert_eq!(segment_tasks.first().unwrap().start_doc_id, 0);
+        assert_eq!(segment_tasks.last().unwrap().end_doc_id, max_doc);
+        assert!(segment_tasks
+            .windows(2)
+            .all(|pair| pair[0].end_doc_id == pair[1].start_doc_id));
+    }
 }
 
 include!("verification/logical.rs");
@@ -397,7 +426,7 @@ pub(crate) struct VerificationMetrics {
     pub(crate) stored_core_bytes: u64,
     pub(crate) body_tokens: u64,
     pub(crate) verification_spill_bytes: u64,
-    pub(crate) verification_heap_payload_bound_bytes: usize,
+    pub(crate) verification_tracked_heap_bytes: usize,
 }
 
 #[cfg(test)]
@@ -426,7 +455,7 @@ pub(crate) fn verify_searcher_with_metrics(
         stored_core_bytes: metrics.stored_core_bytes,
         body_tokens: metrics.body_tokens,
         verification_spill_bytes: metrics.verification_spill_bytes,
-        verification_heap_payload_bound_bytes: metrics.verification_heap_payload_bound_bytes,
+        verification_tracked_heap_bytes: metrics.verification_tracked_heap_bytes,
     })
 }
 

--- a/crates/ctx-history-index/src/publication/verification/logical.rs
+++ b/crates/ctx-history-index/src/publication/verification/logical.rs
@@ -10,15 +10,21 @@ fn verify_searcher_with_options(
     verify_searcher_structure(searcher, manifest)?;
     let fields = fields_from_schema(searcher.schema())?;
     query::validate_verification_projection(fields)?;
-    let segment_count = searcher.segment_readers().len();
-    let worker_budget = requested_worker_budget.max(1).min(segment_count.max(1));
+    let verification_spill = VerificationSpill::create(
+        searcher
+            .segment_readers()
+            .iter()
+            .map(tantivy::SegmentReader::max_doc),
+    )?;
+    let tasks = segment_verification_tasks(searcher, requested_worker_budget.max(1))?;
+    let worker_budget = requested_worker_budget.max(1).min(tasks.len().max(1));
     let executor = if worker_budget == 1 {
         Executor::single_thread()
     } else {
         Executor::multi_thread(worker_budget, "ctx-generation-verify-")?
     };
     let counters = instrument.then(VerificationCounters::default);
-    let first_wave_size = worker_budget.min(segment_count);
+    let first_wave_size = worker_budget.min(tasks.len());
     let rendezvous =
         (synchronize_first_wave && first_wave_size > 1).then(|| Barrier::new(first_wave_size));
     let mut metrics = VerificationRunMetrics {
@@ -41,37 +47,44 @@ fn verify_searcher_with_options(
             ))
         })
         .collect::<Result<HashMap<_, _>>>()?;
-    let verification_spill = VerificationSpill::create(
-        searcher
-            .segment_readers()
-            .iter()
-            .map(tantivy::SegmentReader::max_doc),
-    )?;
     metrics.verification_spill_bytes = verification_spill.logical_bytes();
-    metrics.verification_heap_payload_bound_bytes = verification_spill
+    metrics.verification_tracked_heap_bytes = verification_spill
         .segment_offsets_heap_bytes()?
         .checked_add(
             worker_budget
-                .checked_mul(VERIFICATION_SPILL_BUFFER_BYTES + VERIFICATION_SPILL_RECORD_BYTES)
+                .checked_mul(
+                    VERIFICATION_SPILL_BUFFER_BYTES
+                        .checked_mul(2)
+                        .and_then(|bytes| bytes.checked_add(VERIFICATION_SPILL_RECORD_BYTES))
+                        .ok_or(IndexError::CountOverflow)?,
+                )
                 .ok_or(IndexError::CountOverflow)?,
         )
+        .and_then(|bytes| {
+            tasks
+                .capacity()
+                .checked_mul(std::mem::size_of::<SegmentVerificationTask>())
+                .and_then(|task_bytes| bytes.checked_add(task_bytes))
+        })
         .ok_or(IndexError::CountOverflow)?;
 
-    for wave_start in (0..segment_count).step_by(worker_budget) {
-        let wave_end = (wave_start + worker_budget).min(segment_count);
+    for wave_start in (0..tasks.len()).step_by(worker_budget) {
+        let wave_end = (wave_start + worker_budget).min(tasks.len());
+        let wave = &tasks[wave_start..wave_end];
         let wave_rendezvous = (wave_start == 0).then_some(rendezvous.as_ref()).flatten();
         let segments = executor.map(
-            |segment_ord| {
+            |task_index| {
+                let task = wave[task_index];
                 Ok(verify_segment(
                     searcher,
-                    segment_ord,
+                    task,
                     wave_rendezvous,
                     counters.as_ref(),
                     &verification_spill,
                     &source_ordinals,
                 ))
             },
-            wave_start..wave_end,
+            0..wave.len(),
         )?;
         metrics.max_buffered_segments = metrics.max_buffered_segments.max(segments.len());
         for segment in segments {
@@ -120,8 +133,8 @@ fn verify_searcher_with_options(
         return Err(IndexError::InvalidStoredDocumentField("body_search"));
     }
     let mut projection_deltas = verification_spill.load_projection_deltas()?;
-    metrics.verification_heap_payload_bound_bytes = metrics
-        .verification_heap_payload_bound_bytes
+    metrics.verification_tracked_heap_bytes = metrics
+        .verification_tracked_heap_bytes
         .checked_add(projection_deltas.heap_bytes())
         .ok_or(IndexError::CountOverflow)?;
     verify_event_identities(
@@ -151,7 +164,7 @@ fn verify_searcher_with_options(
 
 fn verify_segment(
     searcher: &Searcher,
-    segment_ord: usize,
+    task: SegmentVerificationTask,
     rendezvous: Option<&Barrier>,
     counters: Option<&VerificationCounters>,
     verification_spill: &VerificationSpill,
@@ -161,7 +174,7 @@ fn verify_segment(
     if let Some(rendezvous) = rendezvous {
         rendezvous.wait();
     }
-    let segment = searcher.segment_reader(segment_ord as u32);
+    let segment = searcher.segment_reader(task.segment_ord as u32);
     let fields = fields_from_schema(searcher.schema())?;
     let body_search = segment.inverted_index(fields.body_search)?;
     let mut body_analyzer = crate::analyzer::body_analyzer();
@@ -170,16 +183,25 @@ fn verify_segment(
     let mut stored_core_bytes = 0_u64;
     let mut body_tokens = 0_u64;
     let mut parent_session_documents = 0_u64;
-    let mut identity_writer = verification_spill.segment_writer(segment_ord, segment.max_doc())?;
-    for doc_id in 0..segment.max_doc() {
+    let mut identity_writer = verification_spill.segment_range_writer(
+        task.segment_ord,
+        task.start_doc_id,
+        task.end_doc_id,
+        segment.max_doc(),
+    )?;
+    let mut document_count = 0_u64;
+    for doc_id in task.start_doc_id..task.end_doc_id {
         if segment.is_deleted(doc_id) {
             identity_writer.write_deleted(doc_id)?;
             continue;
         }
+        document_count = document_count
+            .checked_add(1)
+            .ok_or(IndexError::CountOverflow)?;
         document_decodes += 1;
         let record = query::stored_verification_record(
             searcher,
-            DocAddress::new(segment_ord as u32, doc_id),
+            DocAddress::new(task.segment_ord as u32, doc_id),
             fields,
         )?;
         stored_core_bytes = stored_core_bytes
@@ -225,13 +247,119 @@ fn verify_segment(
     }
     identity_writer.finish()?;
     Ok(SegmentVerification {
-        document_count: u64::from(segment.num_docs()),
+        document_count,
         document_decodes,
         stored_core_bytes,
         body_tokens,
         source_aggregates,
         parent_session_documents,
     })
+}
+
+fn segment_verification_tasks(
+    searcher: &Searcher,
+    worker_budget: usize,
+) -> Result<Vec<SegmentVerificationTask>> {
+    const MAX_VERIFICATION_TASK_HEAP_BYTES: usize = 16 * 1024 * 1024;
+    let total_max_docs = searcher
+        .segment_readers()
+        .iter()
+        .map(tantivy::SegmentReader::max_doc)
+        .try_fold(0_u64, |total, max_doc| {
+            total
+                .checked_add(u64::from(max_doc))
+                .ok_or(IndexError::CountOverflow)
+        })?;
+    let documents_per_task = verification_documents_per_task(total_max_docs, worker_budget)?;
+    let task_count = searcher
+        .segment_readers()
+        .iter()
+        .map(tantivy::SegmentReader::max_doc)
+        .try_fold(0_usize, |count, max_doc| {
+            let segment_tasks = usize::try_from(max_doc.div_ceil(documents_per_task))
+                .map_err(|_| IndexError::CountOverflow)?;
+            count
+                .checked_add(segment_tasks)
+                .ok_or(IndexError::CountOverflow)
+        })?;
+    let task_heap_bytes = task_count
+        .checked_mul(std::mem::size_of::<SegmentVerificationTask>())
+        .ok_or(IndexError::CountOverflow)?;
+    if task_heap_bytes > MAX_VERIFICATION_TASK_HEAP_BYTES {
+        return Err(IndexError::VerificationScratchLimitExceeded {
+            required_bytes: u64::try_from(task_heap_bytes)
+                .map_err(|_| IndexError::CountOverflow)?,
+            maximum_bytes: MAX_VERIFICATION_TASK_HEAP_BYTES as u64,
+        });
+    }
+    let mut tasks = Vec::with_capacity(task_count);
+    append_segment_verification_tasks(
+        &mut tasks,
+        searcher
+            .segment_readers()
+            .iter()
+            .map(tantivy::SegmentReader::max_doc),
+        documents_per_task,
+    );
+    Ok(tasks)
+}
+
+#[cfg(test)]
+fn segment_verification_tasks_for_max_docs(
+    segment_max_docs: &[u32],
+    worker_budget: usize,
+) -> Result<Vec<SegmentVerificationTask>> {
+    let total_max_docs = segment_max_docs.iter().try_fold(0_u64, |total, max_doc| {
+        total
+            .checked_add(u64::from(*max_doc))
+            .ok_or(IndexError::CountOverflow)
+    })?;
+    let documents_per_task = verification_documents_per_task(total_max_docs, worker_budget)?;
+    let mut tasks = Vec::new();
+    append_segment_verification_tasks(
+        &mut tasks,
+        segment_max_docs.iter().copied(),
+        documents_per_task,
+    );
+    Ok(tasks)
+}
+
+fn verification_documents_per_task(total_max_docs: u64, worker_budget: usize) -> Result<u32> {
+    const MIN_DOCUMENTS_PER_TASK: u64 = 16 * 1024;
+    const TASKS_PER_WORKER: u64 = 4;
+
+    let target_tasks = u64::try_from(worker_budget)
+        .map_err(|_| IndexError::CountOverflow)?
+        .checked_mul(TASKS_PER_WORKER)
+        .ok_or(IndexError::CountOverflow)?
+        .max(1);
+    let documents_per_task = total_max_docs
+        .div_ceil(target_tasks)
+        .max(MIN_DOCUMENTS_PER_TASK);
+    let documents_per_task = u32::try_from(documents_per_task.min(u64::from(u32::MAX)))
+        .map_err(|_| IndexError::CountOverflow)?;
+    Ok(documents_per_task)
+}
+
+fn append_segment_verification_tasks(
+    tasks: &mut Vec<SegmentVerificationTask>,
+    segment_max_docs: impl Iterator<Item = u32>,
+    documents_per_task: u32,
+) {
+    for (segment_ord, max_doc) in segment_max_docs.enumerate() {
+        let mut start_doc_id = 0_u32;
+        while start_doc_id < max_doc {
+            let end_doc_id = start_doc_id
+                .saturating_add(documents_per_task)
+                .min(max_doc);
+            tasks.push(SegmentVerificationTask {
+                segment_ord,
+                start_doc_id,
+                end_doc_id,
+            });
+            start_doc_id = end_doc_id;
+        }
+    }
 }
 
 fn expected_query_projection_delta(

--- a/crates/ctx-history-index/src/publication/verification/spill.rs
+++ b/crates/ctx-history-index/src/publication/verification/spill.rs
@@ -15,6 +15,7 @@ const QUERY_PROJECTION_ACCUMULATOR_BYTES: usize = 32;
 pub(super) const VERIFICATION_SPILL_RECORD_BYTES: usize =
     IDENTITY_SPILL_RECORD_BYTES + QUERY_PROJECTION_ACCUMULATOR_BYTES;
 pub(super) const MAX_VERIFICATION_SPILL_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_VERIFICATION_LAYOUT_HEAP_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub(super) struct ProjectionAccumulator([u8; QUERY_PROJECTION_ACCUMULATOR_BYTES]);
@@ -67,7 +68,7 @@ pub(super) struct SegmentVerificationWriter<'a> {
     identity_writer: BufWriter<SpillAtWriter<'a>>,
     projection_writer: BufWriter<SpillAtWriter<'a>>,
     next_doc_id: u32,
-    max_doc: u32,
+    end_doc_id: u32,
 }
 
 pub(super) struct ProjectionDeltas {
@@ -81,29 +82,35 @@ struct SpillAtWriter<'a> {
 }
 
 impl VerificationSpill {
-    pub(super) fn create(segment_max_docs: impl Iterator<Item = u32>) -> Result<Self> {
+    pub(super) fn create<I>(segment_max_docs: I) -> Result<Self>
+    where
+        I: Iterator<Item = u32> + Clone,
+    {
         Self::create_with_limit(segment_max_docs, MAX_VERIFICATION_SPILL_BYTES)
     }
 
-    fn create_with_limit(
-        segment_max_docs: impl Iterator<Item = u32>,
-        maximum_bytes: u64,
-    ) -> Result<Self> {
+    fn create_with_limit<I>(segment_max_docs: I, maximum_bytes: u64) -> Result<Self>
+    where
+        I: Iterator<Item = u32> + Clone,
+    {
         Self::create_with_limit_and_witness(segment_max_docs, maximum_bytes, None)
     }
 
-    fn create_with_limit_and_witness(
-        max_docs: impl Iterator<Item = u32>,
+    fn create_with_limit_and_witness<I>(
+        max_docs: I,
         maximum_bytes: u64,
         cleanup_witness: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
-    ) -> Result<Self> {
-        let (minimum, maximum) = max_docs.size_hint();
-        let mut segment_offsets = Vec::with_capacity(
-            maximum
-                .filter(|maximum| *maximum == minimum)
-                .unwrap_or(minimum),
-        );
-        let mut segment_max_docs = Vec::with_capacity(segment_offsets.capacity());
+    ) -> Result<Self>
+    where
+        I: Iterator<Item = u32> + Clone,
+    {
+        let (segment_count, expected_logical_bytes) = preflight_spill_layout(
+            max_docs.clone(),
+            maximum_bytes,
+            MAX_VERIFICATION_LAYOUT_HEAP_BYTES,
+        )?;
+        let mut segment_offsets = Vec::with_capacity(segment_count);
+        let mut segment_max_docs = Vec::with_capacity(segment_count);
         let mut logical_bytes = 0_u64;
         for max_doc in max_docs {
             segment_offsets.push(logical_bytes);
@@ -112,12 +119,7 @@ impl VerificationSpill {
                 .checked_add(segment_spill_bytes(max_doc)?)
                 .ok_or(IndexError::CountOverflow)?;
         }
-        if logical_bytes > maximum_bytes {
-            return Err(IndexError::VerificationScratchLimitExceeded {
-                required_bytes: logical_bytes,
-                maximum_bytes,
-            });
-        }
+        debug_assert_eq!(logical_bytes, expected_logical_bytes);
         let file = tempfile::tempfile()?;
         Ok(Self {
             file,
@@ -145,15 +147,32 @@ impl VerificationSpill {
             .ok_or(IndexError::CountOverflow)
     }
 
+    #[cfg(test)]
     pub(super) fn segment_writer(
         &self,
         segment_ord: usize,
+        max_doc: u32,
+    ) -> Result<SegmentVerificationWriter<'_>> {
+        self.segment_range_writer(segment_ord, 0, max_doc, max_doc)
+    }
+
+    pub(super) fn segment_range_writer(
+        &self,
+        segment_ord: usize,
+        start_doc_id: u32,
+        end_doc_id: u32,
         max_doc: u32,
     ) -> Result<SegmentVerificationWriter<'_>> {
         let offset = *self
             .segment_offsets
             .get(segment_ord)
             .ok_or(IndexError::InvalidStoredDocumentField("core_record"))?;
+        if self.segment_max_docs.get(segment_ord).copied() != Some(max_doc)
+            || start_doc_id > end_doc_id
+            || end_doc_id > max_doc
+        {
+            return Err(IndexError::InvalidStoredDocumentField("core_record"));
+        }
         let end = offset
             .checked_add(segment_spill_bytes(max_doc)?)
             .ok_or(IndexError::CountOverflow)?;
@@ -162,13 +181,22 @@ impl VerificationSpill {
         }
         let projection_offset = offset
             .checked_add(identity_segment_bytes(max_doc)?)
+            .and_then(|offset| {
+                u64::from(start_doc_id)
+                    .checked_mul(QUERY_PROJECTION_ACCUMULATOR_BYTES as u64)
+                    .and_then(|start| offset.checked_add(start))
+            })
+            .ok_or(IndexError::CountOverflow)?;
+        let identity_offset = u64::from(start_doc_id)
+            .checked_mul(IDENTITY_SPILL_RECORD_BYTES as u64)
+            .and_then(|start| offset.checked_add(start))
             .ok_or(IndexError::CountOverflow)?;
         Ok(SegmentVerificationWriter {
             identity_writer: BufWriter::with_capacity(
                 VERIFICATION_SPILL_BUFFER_BYTES,
                 SpillAtWriter {
                     file: &self.file,
-                    offset,
+                    offset: identity_offset,
                 },
             ),
             projection_writer: BufWriter::with_capacity(
@@ -178,8 +206,8 @@ impl VerificationSpill {
                     offset: projection_offset,
                 },
             ),
-            next_doc_id: 0,
-            max_doc,
+            next_doc_id: start_doc_id,
+            end_doc_id,
         })
     }
 
@@ -223,6 +251,41 @@ impl VerificationSpill {
             heap_bytes,
         })
     }
+}
+
+fn preflight_spill_layout(
+    max_docs: impl Iterator<Item = u32>,
+    maximum_bytes: u64,
+    maximum_layout_heap_bytes: usize,
+) -> Result<(usize, u64)> {
+    let mut segment_count = 0_usize;
+    let mut logical_bytes = 0_u64;
+    for max_doc in max_docs {
+        segment_count = segment_count
+            .checked_add(1)
+            .ok_or(IndexError::CountOverflow)?;
+        logical_bytes = logical_bytes
+            .checked_add(segment_spill_bytes(max_doc)?)
+            .ok_or(IndexError::CountOverflow)?;
+        if logical_bytes > maximum_bytes {
+            return Err(IndexError::VerificationScratchLimitExceeded {
+                required_bytes: logical_bytes,
+                maximum_bytes,
+            });
+        }
+        let layout_heap_bytes = segment_count
+            .checked_mul(std::mem::size_of::<u64>() + std::mem::size_of::<u32>())
+            .ok_or(IndexError::CountOverflow)?;
+        if layout_heap_bytes > maximum_layout_heap_bytes {
+            return Err(IndexError::VerificationScratchLimitExceeded {
+                required_bytes: u64::try_from(layout_heap_bytes)
+                    .map_err(|_| IndexError::CountOverflow)?,
+                maximum_bytes: u64::try_from(maximum_layout_heap_bytes)
+                    .map_err(|_| IndexError::CountOverflow)?,
+            });
+        }
+    }
+    Ok((segment_count, logical_bytes))
 }
 
 impl ProjectionDeltas {
@@ -305,7 +368,7 @@ impl SegmentVerificationWriter<'_> {
     }
 
     pub(super) fn finish(mut self) -> Result<()> {
-        if self.next_doc_id != self.max_doc {
+        if self.next_doc_id != self.end_doc_id {
             return Err(IndexError::InvalidStoredDocumentField("core_record"));
         }
         self.identity_writer.flush()?;
@@ -314,7 +377,7 @@ impl SegmentVerificationWriter<'_> {
     }
 
     fn check_doc_id(&self, doc_id: u32) -> Result<()> {
-        if doc_id != self.next_doc_id || doc_id >= self.max_doc {
+        if doc_id != self.next_doc_id || doc_id >= self.end_doc_id {
             return Err(IndexError::InvalidStoredDocumentField("core_record"));
         }
         Ok(())
@@ -501,6 +564,25 @@ mod tests {
     }
 
     #[test]
+    fn layout_limit_rejects_segment_metadata_before_allocation() {
+        let one_segment_bytes = std::mem::size_of::<u64>() + std::mem::size_of::<u32>();
+        let error = preflight_spill_layout(
+            [0, 0].into_iter(),
+            MAX_VERIFICATION_SPILL_BYTES,
+            one_segment_bytes,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            IndexError::VerificationScratchLimitExceeded {
+                required_bytes,
+                maximum_bytes,
+            } if required_bytes == (one_segment_bytes * 2) as u64
+                && maximum_bytes == one_segment_bytes as u64
+        ));
+    }
+
+    #[test]
     fn projection_accumulator_preserves_multiset_addition_modulo_256_bits() {
         let first = [0xff; QUERY_PROJECTION_ACCUMULATOR_BYTES];
         let second = [1; QUERY_PROJECTION_ACCUMULATOR_BYTES];
@@ -530,6 +612,48 @@ mod tests {
             .accumulate(DocAddress::new(0, 0), &digest)
             .unwrap();
         assert!(projections.is_complete(DocAddress::new(0, 0)).unwrap());
+    }
+
+    #[test]
+    fn disjoint_segment_ranges_write_exact_positional_records() {
+        let spill = VerificationSpill::create([4].into_iter()).unwrap();
+        std::thread::scope(|scope| {
+            let first = scope.spawn(|| {
+                let mut writer = spill.segment_range_writer(0, 0, 2, 4).unwrap();
+                writer
+                    .write_record(0, identities(), ProjectionAccumulator::default())
+                    .unwrap();
+                writer.write_deleted(1).unwrap();
+                writer.finish().unwrap();
+            });
+            let second = scope.spawn(|| {
+                let mut writer = spill.segment_range_writer(0, 2, 4, 4).unwrap();
+                writer.write_deleted(2).unwrap();
+                writer
+                    .write_record(3, identities(), ProjectionAccumulator::default())
+                    .unwrap();
+                writer.finish().unwrap();
+            });
+            first.join().unwrap();
+            second.join().unwrap();
+        });
+
+        assert_eq!(
+            spill
+                .record(DocAddress::new(0, 0), "test")
+                .unwrap()
+                .session
+                .digest,
+            [1; 32]
+        );
+        assert_eq!(
+            spill
+                .record(DocAddress::new(0, 3), "test")
+                .unwrap()
+                .root_session
+                .digest,
+            [3; 32]
+        );
     }
 }
 

--- a/crates/ctx-history-index/src/tests/recovery/verifier.rs
+++ b/crates/ctx-history-index/src/tests/recovery/verifier.rs
@@ -26,7 +26,104 @@ fn complete_verifier_decodes_once_with_bounded_parallel_segment_state() {
         metrics.verification_spill_bytes,
         expected_documents as u64 * 133
     );
-    assert!(metrics.verification_heap_payload_bound_bytes < 32 * 1024);
+    assert!(metrics.verification_tracked_heap_bytes < 64 * 1024);
+}
+
+#[test]
+fn complete_verifier_splits_one_large_segment_across_workers() {
+    const DOCUMENTS_PER_RANGE: u64 = 16 * 1024;
+    const DOCUMENTS: u64 = DOCUMENTS_PER_RANGE + 2;
+
+    let temp = tempdir().unwrap();
+    let source = source("split-segment-verifier.jsonl");
+    let mut writer = GenerationWriter::open(
+        temp.path(),
+        WriterOptions {
+            indexer_threads: 1,
+            memory_bytes: 128 * 1024 * 1024,
+        },
+    )
+    .unwrap();
+    writer.begin_source(source.clone()).unwrap();
+    for sequence in 1..=DOCUMENTS {
+        writer
+            .add_core_record(document(&source, sequence, "split range verifier"))
+            .unwrap();
+    }
+    writer
+        .certify_source(certificate(&source, 1, DOCUMENTS))
+        .unwrap();
+    writer.commit(|_| true).unwrap();
+
+    let (initial_searcher, manifest) = open_unverified_generation(temp.path());
+    assert_eq!(initial_searcher.segment_readers().len(), 1);
+    assert_eq!(
+        u64::from(initial_searcher.segment_readers()[0].max_doc()),
+        DOCUMENTS
+    );
+    assert_eq!(initial_searcher.segment_readers()[0].num_deleted_docs(), 0);
+
+    // Replace the final record exactly so the manifest aggregate stays stable
+    // while the large segment retains a deleted slot in its nonzero range.
+    let replacement = document(&source, DOCUMENTS, "split range verifier");
+    let replacement_event_id = replacement.event_id;
+    let event_id = required_field(initial_searcher.schema(), "event_id").unwrap();
+    let original_addresses = initial_searcher
+        .search(
+            &tantivy::query::TermQuery::new(
+                Term::from_field_text(event_id, &replacement_event_id.to_string()),
+                tantivy::schema::IndexRecordOption::Basic,
+            ),
+            &DocSetCollector,
+        )
+        .unwrap();
+    assert_eq!(original_addresses.len(), 1);
+    assert!(
+        u64::from(original_addresses.iter().next().unwrap().doc_id) >= DOCUMENTS_PER_RANGE,
+        "replacement must exercise a nonzero document-range offset"
+    );
+
+    let index = initial_searcher.index().clone();
+    drop(initial_searcher);
+    let mut index_writer = index
+        .writer_with_num_threads::<TantivyDocument>(1, INDEX_MEMORY_MIN_PER_THREAD)
+        .unwrap();
+    index_writer.set_merge_policy(Box::<NoMergePolicy>::default());
+    index_writer.delete_term(Term::from_field_text(
+        event_id,
+        &replacement_event_id.to_string(),
+    ));
+    index_writer
+        .add_document(indexed_document(replacement))
+        .unwrap();
+    index_writer.commit().unwrap();
+    index_writer.wait_merging_threads().unwrap();
+
+    let reader = index
+        .reader_builder()
+        .reload_policy(ReloadPolicy::Manual)
+        .try_into()
+        .unwrap();
+    let searcher = reader.searcher();
+    let mut segment_stats = searcher
+        .segment_readers()
+        .iter()
+        .map(|segment| (segment.max_doc(), segment.num_deleted_docs()))
+        .collect::<Vec<_>>();
+    segment_stats.sort_unstable();
+    assert_eq!(segment_stats, vec![(1, 0), (DOCUMENTS as u32, 1)]);
+
+    let metrics =
+        crate::publication::verify_searcher_with_metrics(&searcher, &manifest, 2, true).unwrap();
+    assert_eq!(metrics.worker_budget, 2);
+    assert_eq!(metrics.segment_tasks, 3);
+    assert_eq!(metrics.max_active_workers, 2);
+    assert_eq!(metrics.max_buffered_segments, 2);
+    assert_eq!(metrics.document_decodes, DOCUMENTS as usize);
+    assert_eq!(metrics.source_terms, 3);
+    assert!(metrics.body_tokens >= DOCUMENTS);
+    assert_eq!(metrics.verification_spill_bytes, (DOCUMENTS + 1) * 133);
+    assert!(metrics.verification_tracked_heap_bytes < 1024 * 1024);
 }
 
 #[test]


### PR DESCRIPTION
## Outcome

Splits oversized immutable Tantivy segments into deterministic document-range verification tasks, allowing the exhaustive stored-Core/projection audit to use the host CPU budget without changing publication, checksum, or audit semantics.

The implementation remains a committed-Core sequential path. It adds no candidate-overlap protocol or persisted product state. Scratch/layout/task admission is bounded before allocation; workers use disjoint positional writes and deterministic ordered reduction.

## Real corpus evidence

Full 20.8GB Codex corpus, sequential Core then Pro, on a loaded 32-logical-CPU Linux host:

| Product timing | Before | After | Change |
| --- | ---: | ---: | ---: |
| Core ingestion | 21m49.8s | 15m04.5s | -30.9% |
| Core commit/verification | 9m29.9s | 2m18.4s | -75.7% |
| Pro materialization | 6m11.8s | 6m12.8s | +0.3% |
| End-to-end | 28m33.2s | 21m47.4s | -23.7% |

After-run resource receipt: 12.73GB sampled peak product RSS, 34.35GB sampled physical-write lower bound, and 15.7% normalized average utilization of 32 logical CPUs. The output passed all harness checks. Identity differs from the earlier baseline because public-main schema/event-query behavior advanced between builds; no cross-schema byte-parity claim is made.

Same immutable 2,638,373-document / 9.9GB generation microbenchmark:

- 8 workers: 231.61s complete logical audit; 200.52s segment audit
- 16 workers: 141.85s complete; 109.74s segment audit
- 24 workers: 115.92s complete; 85.50s segment audit
- physical SHA/CRC pass remained 6-10s

The prior segment-per-worker implementation was still inside the segment audit after 497s in the same loaded-host experiment because two segments owned 2.03M/2.64M documents.

## Validation

- `bazelisk test -c opt //crates/ctx-history-index:unit_tests //crates/ctx-history-index:source_backed_recovery_tests --test_output=errors --jobs=4`
- `cargo test -p ctx-history-index --lib complete_verifier_splits_one_large_segment_across_workers -- --nocapture`
- `cargo clippy -p ctx-history-index --lib -- -D warnings`
- `cargo fmt --all -- --check`
- Windows GNU cross-compile: `cargo check -p ctx-history-index --lib --target x86_64-pc-windows-gnu`
- Independent simplicity/correctness re-review: all findings resolved; merge recommended

The split-path end-to-end test covers multiple workers over one large segment, nonzero range offsets, projection/identity verification, stable aggregates, and a deleted slot. Repository-wide check-loc still reports pre-existing files outside this PR; all four touched files remain below their limits.
