### PR TITLE
Teach ctx skill advanced event queries

### DIFF
--- a/plugins/ctx-agent-history-search/skills/ctx-agent-history-search/SKILL.md
+++ b/plugins/ctx-agent-history-search/skills/ctx-agent-history-search/SKILL.md
@@ -131,6 +131,14 @@ complete audit from the number of returned hits. If the requested conclusion
 cannot be supported with search, show, and locate evidence, state that limit
 and report the strongest retrieved evidence instead.
 
+For advanced querying or complete deterministic event enumeration, use
+`ctx list events`. Read the full filter, range, cursor, and output documentation
+before use:
+
+```bash
+ctx docs show event-queries
+```
+
 ## History Research Reports
 
 When asked to research a historical topic, stay read-only unless the user also

--- a/skills/ctx-agent-history-search/SKILL.md
+++ b/skills/ctx-agent-history-search/SKILL.md
@@ -131,6 +131,14 @@ complete audit from the number of returned hits. If the requested conclusion
 cannot be supported with search, show, and locate evidence, state that limit
 and report the strongest retrieved evidence instead.
 
+For advanced querying or complete deterministic event enumeration, use
+`ctx list events`. Read the full filter, range, cursor, and output documentation
+before use:
+
+```bash
+ctx docs show event-queries
+```
+
 ## History Research Reports
 
 When asked to research a historical topic, stay read-only unless the user also


### PR DESCRIPTION
## Summary

- direct agents to `ctx list events` for advanced deterministic event querying
- link the embedded `event-queries` documentation instead of duplicating filter and output details
- keep the standalone and plugin skill copies synchronized

## Validation

- `python3 /home/daddy/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/ctx-agent-history-search`
- `python3 /home/daddy/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/ctx-agent-history-search/skills/ctx-agent-history-search`
- `bash scripts/check-docs.sh`