### PR TITLE
fix(factory-ai-droid): restore automatic ~/.factory/sessions discovery

### DIFF
--- a/crates/ctx-cli/tests/custom_root_discovery.rs
+++ b/crates/ctx-cli/tests/custom_root_discovery.rs
@@ -58,19 +58,15 @@ fn sources_json_keeps_the_v1_top_level_and_source_fields() {
         ])
     );
 
-    let no_path_report = json_output(ctx(&temp).args([
-        "sources",
-        "--provider",
-        "factory-ai-droid",
-        "--format=json",
-    ]));
+    let no_path_report =
+        json_output(ctx(&temp).args(["sources", "--provider", "firebender", "--format=json"]));
     assert_eq!(object_keys(&no_path_report), object_keys(&packet));
     assert!(no_path_report["sources"].as_array().unwrap().is_empty());
     assert_eq!(no_path_report["issues_truncated"], false);
     let issues = no_path_report["issues"].as_array().unwrap();
     assert_eq!(issues.len(), 1);
-    assert_eq!(issues[0]["provider"], "factory_ai_droid");
-    assert!(issues[0]["path"].is_string());
+    assert_eq!(issues[0]["provider"], "firebender");
+    assert!(issues[0]["path"].is_null());
     assert_eq!(issues[0]["code"], "insufficient_official_evidence");
     assert_eq!(issues[0]["message_truncated"], false);
 }
@@ -127,14 +123,13 @@ fn provider_filtered_human_sources_and_import_errors_are_actionable() {
     assert!(!stderr.contains("relative-provider-root"), "{stderr}");
 
     let unestablished = tempdir();
-    let stdout =
-        success_stdout(ctx(&unestablished).args(["sources", "--provider", "factory-ai-droid"]));
+    let stdout = success_stdout(ctx(&unestablished).args(["sources", "--provider", "firebender"]));
     assert!(
         stdout.contains("has no established automatic history location"),
         "{stdout}"
     );
     assert!(
-        stdout.contains("ctx import --provider factory-ai-droid --path <path>"),
+        stdout.contains("ctx import --provider firebender --path <path>"),
         "{stdout}"
     );
     assert!(
@@ -144,16 +139,16 @@ fn provider_filtered_human_sources_and_import_errors_are_actionable() {
     let stderr = failure_stderr(ctx(&unestablished).args([
         "import",
         "--provider",
-        "factory-ai-droid",
+        "firebender",
         "--format=json",
     ]));
     assert!(
         stderr.contains("has no official automatic history location established")
-            || stderr.contains("no official automatic Factory history location is established"),
+            || stderr.contains("no official automatic Firebender history location is established"),
         "{stderr}"
     );
     assert!(
-        stderr.contains("ctx import --provider factory-ai-droid --path <path>"),
+        stderr.contains("ctx import --provider firebender --path <path>"),
         "{stderr}"
     );
 }

--- a/crates/ctx-cli/tests/native_providers/factory_retry.rs
+++ b/crates/ctx-cli/tests/native_providers/factory_retry.rs
@@ -86,6 +86,82 @@ fn factory_event_ids(temp: &TempDir) -> BTreeMap<String, String> {
         .collect()
 }
 
+fn factory_record_ids(temp: &TempDir) -> BTreeSet<(String, String)> {
+    provider_core_records(&data_root(temp), "factory_ai_droid")
+        .into_iter()
+        .map(|record| (record.session_id.to_string(), record.event_id.to_string()))
+        .collect()
+}
+
+#[test]
+fn factory_droid_default_source_imports_searches_and_reimports_without_identity_drift() {
+    let temp = tempdir();
+    let query = "factory-default-discovery-oracle";
+    let generated = PathBuf::from(write_native_factory_droid_fixture(&temp, query));
+    let default_root = temp.path().join(".factory/sessions");
+    copy_dir_all(&generated, &default_root);
+    let _daemon = start_isolated_provider_daemon(&temp);
+
+    let sources = json_output(ctx(&temp).args([
+        "sources",
+        "--provider",
+        "factory-ai-droid",
+        "--format=json",
+    ]));
+    let source = source_by_path(&sources, "factory_ai_droid", &default_root);
+    assert_eq!(source["status"], "available");
+    assert_eq!(source["source_format"], "factory_ai_droid_sessions_jsonl");
+    assert_eq!(source["import_support"], "native");
+    assert_eq!(source["native_import"], true);
+    assert_eq!(source["importable"], true);
+
+    let first = json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "factory-ai-droid",
+        "--no-daemon",
+        "--progress",
+        "none",
+        "--format=json",
+    ]));
+    assert_authoritative_provider_publication(&first);
+    assert_eq!(first["totals"]["current_rejected_records"], 0);
+    wait_for_imported_core(&temp, &first);
+    assert_eq!(
+        provider_core_counts(&data_root(&temp), "factory_ai_droid"),
+        (1, 2)
+    );
+    let first_ids = factory_record_ids(&temp);
+
+    let search = json_output(ctx(&temp).args([
+        "search",
+        query,
+        "--provider",
+        "factory-ai-droid",
+        "--refresh",
+        "off",
+        "--format=json",
+    ]));
+    assert_search_provider_oracle(&search, "factory_ai_droid", query, 1, "message");
+
+    let second = json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "factory-ai-droid",
+        "--no-daemon",
+        "--progress",
+        "none",
+        "--format=json",
+    ]));
+    assert_authoritative_provider_publication(&second);
+    assert_noop_publication(&second);
+    assert_eq!(
+        provider_core_counts(&data_root(&temp), "factory_ai_droid"),
+        (1, 2)
+    );
+    assert_eq!(factory_record_ids(&temp), first_ids);
+}
+
 #[test]
 fn factory_droid_retry_lifecycle_keeps_native_ids_stable() {
     let temp = tempdir();

--- a/crates/ctx-history-capture/src/provider_sources/resolvers/manual_unsupported.rs
+++ b/crates/ctx-history-capture/src/provider_sources/resolvers/manual_unsupported.rs
@@ -32,7 +32,6 @@ const UNSAFE_SELECTED_PATH_REASON: &str =
 pub(super) fn resolve(context: &DiscoveryContext, spec: &ProviderSourceSpec) -> DiscoveryReport {
     match spec.provider {
         CaptureProvider::Qoder => resolve_qoder(context, spec),
-        CaptureProvider::FactoryAiDroid => resolve_factory(context, spec),
         CaptureProvider::Firebender => resolve_firebender(spec),
         CaptureProvider::Auggie => resolve_auggie(context, spec),
         CaptureProvider::DeepAgents => resolve_deepagents(context, spec),
@@ -220,18 +219,6 @@ fn inspect_qoder_projects(projects: &Path) -> (ProbeState, bool) {
         },
         direct,
     )
-}
-
-fn resolve_factory(context: &DiscoveryContext, spec: &ProviderSourceSpec) -> DiscoveryReport {
-    DiscoveryReport {
-        sources: Vec::new(),
-        issues: vec![issue(
-            spec.provider,
-            bounded_issue_path(context.home().join(".factory").join("sessions")),
-            DiscoveryIssueKind::InsufficientOfficialEvidence,
-            "no official automatic Factory history location is established; use an exact user-authorized --path",
-        )],
-    }
 }
 
 fn resolve_firebender(spec: &ProviderSourceSpec) -> DiscoveryReport {

--- a/crates/ctx-history-capture/src/provider_sources/resolvers/manual_unsupported_tests.rs
+++ b/crates/ctx-history-capture/src/provider_sources/resolvers/manual_unsupported_tests.rs
@@ -100,11 +100,9 @@ fn qoder_probe_is_shallow_bounded_and_deterministic() {
 }
 
 #[test]
-fn factory_and_firebender_emit_only_insufficient_evidence_issues() {
+fn firebender_emits_only_insufficient_evidence_issues() {
     let temp = tempdir();
     let context = context(temp.path(), DiscoveryPlatform::Linux);
-    let factory_path = context.home().join(".factory/sessions");
-    write(&factory_path.join("session.jsonl"), b"{}\n");
     write(
         &context
             .cwd()
@@ -112,24 +110,13 @@ fn factory_and_firebender_emit_only_insufficient_evidence_issues() {
             .join(".idea/firebender/chat_history.db"),
         b"not consulted",
     );
-    for provider in [CaptureProvider::FactoryAiDroid, CaptureProvider::Firebender] {
-        let report = resolve(&context, spec(provider));
-        assert!(report.sources.is_empty());
-        assert_eq!(
-            (report.issues.len(), report.issues[0].kind),
-            (1, DiscoveryIssueKind::InsufficientOfficialEvidence)
-        );
-    }
+    let report = resolve(&context, spec(CaptureProvider::Firebender));
+    assert!(report.sources.is_empty());
     assert_eq!(
-        resolve(&context, spec(CaptureProvider::FactoryAiDroid)).issues[0]
-            .path
-            .as_deref(),
-        Some(factory_path.as_path())
+        (report.issues.len(), report.issues[0].kind),
+        (1, DiscoveryIssueKind::InsufficientOfficialEvidence)
     );
-    assert_eq!(
-        resolve(&context, spec(CaptureProvider::Firebender)).issues[0].path,
-        None
-    );
+    assert_eq!(report.issues[0].path, None);
 }
 
 #[test]

--- a/crates/ctx-history-capture/src/provider_sources/resolvers/mod.rs
+++ b/crates/ctx-history-capture/src/provider_sources/resolvers/mod.rs
@@ -104,6 +104,7 @@ pub(super) fn resolver_group(provider: CaptureProvider) -> Option<ResolverGroup>
         | CaptureProvider::Cursor
         | CaptureProvider::KimiCodeCli
         | CaptureProvider::Junie
+        | CaptureProvider::FactoryAiDroid
         | CaptureProvider::ForgeCode => Some(ResolverGroup::Simple),
         CaptureProvider::KiroCli
         | CaptureProvider::Warp
@@ -127,7 +128,6 @@ pub(super) fn resolver_group(provider: CaptureProvider) -> Option<ResolverGroup>
         | CaptureProvider::Shelley
         | CaptureProvider::OpenHands => Some(ResolverGroup::ProfileProject),
         CaptureProvider::Qoder
-        | CaptureProvider::FactoryAiDroid
         | CaptureProvider::Firebender
         | CaptureProvider::Auggie
         | CaptureProvider::DeepAgents
@@ -481,11 +481,11 @@ mod tests {
             .iter()
             .all(|spec| resolver_group(spec.provider).is_some()));
         for (group, expected) in [
-            (ResolverGroup::Simple, 13),
+            (ResolverGroup::Simple, 14),
             (ResolverGroup::Platform, 9),
             (ResolverGroup::ConfigProject, 6),
             (ResolverGroup::ProfileProject, 6),
-            (ResolverGroup::ManualUnsupported, 7),
+            (ResolverGroup::ManualUnsupported, 6),
         ] {
             assert_eq!(
                 specs

--- a/crates/ctx-history-capture/src/provider_sources/resolvers/simple.rs
+++ b/crates/ctx-history-capture/src/provider_sources/resolvers/simple.rs
@@ -50,6 +50,7 @@ pub(super) fn resolve(context: &DiscoveryContext, spec: &ProviderSourceSpec) -> 
         CaptureProvider::Cursor => resolve_cursor(context, spec),
         CaptureProvider::KimiCodeCli => resolve_kimi(context, spec),
         CaptureProvider::Junie => resolve_junie(context, spec),
+        CaptureProvider::FactoryAiDroid => resolve_factory(context, spec),
         CaptureProvider::ForgeCode => resolve_forgecode(context, spec),
         _ => DiscoveryReport::default(),
     }
@@ -373,6 +374,17 @@ fn resolve_junie(context: &DiscoveryContext, spec: &ProviderSourceSpec) -> Disco
         spec,
         home.join("sessions"),
         "junie_session_events_jsonl_tree",
+    )
+}
+
+fn resolve_factory(context: &DiscoveryContext, spec: &ProviderSourceSpec) -> DiscoveryReport {
+    if let Err(report) = supported_default(context, spec) {
+        return report;
+    }
+    one_source(
+        spec,
+        context.home().join(".factory").join("sessions"),
+        "factory_ai_droid_sessions_jsonl",
     )
 }
 

--- a/crates/ctx-history-capture/src/provider_sources/resolvers/simple.rs
+++ b/crates/ctx-history-capture/src/provider_sources/resolvers/simple.rs
@@ -34,7 +34,7 @@ const CODEX_COMPRESSION_SCAN_REASON: &str =
     "bounded Codex compressed-history detection could not complete; use an exact --path for compressed rollouts";
 const MAX_CODEX_COMPRESSION_ENTRIES: usize = 10_000;
 
-/// Official winner-only custom-root policy for the thirteen scalar/fixed-root
+/// Winner-only custom-root policy for the fourteen scalar/fixed-root
 /// providers owned by the simple resolver lane.
 pub(super) fn resolve(context: &DiscoveryContext, spec: &ProviderSourceSpec) -> DiscoveryReport {
     match spec.provider {

--- a/crates/ctx-history-capture/src/provider_sources/resolvers/simple_tests.rs
+++ b/crates/ctx-history-capture/src/provider_sources/resolvers/simple_tests.rs
@@ -460,19 +460,25 @@ fn junie_official_root_uses_junie_home_and_ignores_retired_sessions_override() {
 }
 
 #[test]
-fn factory_official_root_is_the_fixed_sessions_directory_on_supported_platforms() {
+fn factory_supported_default_is_the_sessions_directory_on_supported_platforms() {
     let temp = tempdir();
     let base = context(&temp, DiscoveryPlatform::Linux);
     let sessions = base.home().join(".factory/sessions");
 
-    let missing = resolve_provider(&base, CaptureProvider::FactoryAiDroid);
-    assert_eq!(paths(&missing), std::slice::from_ref(&sessions));
-    assert_eq!(missing.sources[0].status, ProviderSourceStatus::Missing);
-    assert_eq!(
-        missing.sources[0].source_format,
-        "factory_ai_droid_sessions_jsonl"
-    );
-    assert!(missing.issues.is_empty());
+    for platform in [
+        DiscoveryPlatform::Linux,
+        DiscoveryPlatform::MacOS,
+        DiscoveryPlatform::Windows,
+    ] {
+        let missing = resolve_provider(&context(&temp, platform), CaptureProvider::FactoryAiDroid);
+        assert_eq!(paths(&missing), std::slice::from_ref(&sessions));
+        assert_eq!(missing.sources[0].status, ProviderSourceStatus::Missing);
+        assert_eq!(
+            missing.sources[0].source_format,
+            "factory_ai_droid_sessions_jsonl"
+        );
+        assert!(missing.issues.is_empty());
+    }
 
     fs::create_dir_all(sessions.join("-Users-example-project")).unwrap();
     fs::write(
@@ -525,7 +531,7 @@ fn forgecode_official_root_preserves_raw_cwd_semantics_and_exists_winner() {
 }
 
 #[test]
-fn simple_lane_has_thirteen_reviewed_winner_only_policies() {
+fn simple_lane_has_fourteen_reviewed_winner_only_policies() {
     let temp = tempdir();
     let context = context(&temp, DiscoveryPlatform::Linux);
     let providers = [
@@ -541,9 +547,10 @@ fn simple_lane_has_thirteen_reviewed_winner_only_policies() {
         CaptureProvider::Cursor,
         CaptureProvider::KimiCodeCli,
         CaptureProvider::Junie,
+        CaptureProvider::FactoryAiDroid,
         CaptureProvider::ForgeCode,
     ];
-    assert_eq!(providers.len(), 13);
+    assert_eq!(providers.len(), 14);
     for provider in providers {
         let report = resolve_provider(&context, provider);
         let expected = if provider == CaptureProvider::Codex {

--- a/crates/ctx-history-capture/src/provider_sources/resolvers/simple_tests.rs
+++ b/crates/ctx-history-capture/src/provider_sources/resolvers/simple_tests.rs
@@ -460,6 +460,46 @@ fn junie_official_root_uses_junie_home_and_ignores_retired_sessions_override() {
 }
 
 #[test]
+fn factory_official_root_is_the_fixed_sessions_directory_on_supported_platforms() {
+    let temp = tempdir();
+    let base = context(&temp, DiscoveryPlatform::Linux);
+    let sessions = base.home().join(".factory/sessions");
+
+    let missing = resolve_provider(&base, CaptureProvider::FactoryAiDroid);
+    assert_eq!(paths(&missing), std::slice::from_ref(&sessions));
+    assert_eq!(missing.sources[0].status, ProviderSourceStatus::Missing);
+    assert_eq!(
+        missing.sources[0].source_format,
+        "factory_ai_droid_sessions_jsonl"
+    );
+    assert!(missing.issues.is_empty());
+
+    fs::create_dir_all(sessions.join("-Users-example-project")).unwrap();
+    fs::write(
+        sessions.join("-Users-example-project/session.jsonl"),
+        "{}\n",
+    )
+    .unwrap();
+    let available = resolve_provider(&base, CaptureProvider::FactoryAiDroid);
+    assert_eq!(paths(&available), std::slice::from_ref(&sessions));
+    assert_eq!(available.sources[0].status, ProviderSourceStatus::Available);
+
+    fs::remove_file(sessions.join("-Users-example-project/session.jsonl")).unwrap();
+    let empty = resolve_provider(&base, CaptureProvider::FactoryAiDroid);
+    assert_eq!(empty.sources[0].status, ProviderSourceStatus::Empty);
+
+    let unsupported = resolve_provider(
+        &context(&temp, DiscoveryPlatform::OtherUnix),
+        CaptureProvider::FactoryAiDroid,
+    );
+    assert!(unsupported.sources.is_empty());
+    assert_eq!(
+        unsupported.issues[0].kind,
+        DiscoveryIssueKind::SelectorUnreconstructible
+    );
+}
+
+#[test]
 fn forgecode_official_root_preserves_raw_cwd_semantics_and_exists_winner() {
     let temp = tempdir();
     let base = context(&temp, DiscoveryPlatform::Linux);

--- a/crates/ctx-history-capture/src/provider_sources/specs.rs
+++ b/crates/ctx-history-capture/src/provider_sources/specs.rs
@@ -172,7 +172,11 @@ const COPILOT_DEFAULTS: &[ProviderDefaultLocation] = &[ProviderDefaultLocation {
     source_kind: ProviderSourceKind::NativeHistory,
 }];
 
-const FACTORY_DROID_DEFAULTS: &[ProviderDefaultLocation] = &[];
+const FACTORY_DROID_DEFAULTS: &[ProviderDefaultLocation] = &[ProviderDefaultLocation {
+    path_components: &[".factory", "sessions"],
+    source_format: "factory_ai_droid_sessions_jsonl",
+    source_kind: ProviderSourceKind::NativeHistory,
+}];
 
 const QWEN_CODE_DEFAULTS: &[ProviderDefaultLocation] = &[ProviderDefaultLocation {
     path_components: &[".qwen", "projects"],

--- a/crates/ctx-history-capture/src/provider_sources/tests/default_discovery.rs
+++ b/crates/ctx-history-capture/src/provider_sources/tests/default_discovery.rs
@@ -567,12 +567,15 @@ fn legacy_vector_apis_are_exact_report_source_projections() {
         discover_provider_sources_for_provider(temp.path(), CaptureProvider::Codex),
         provider_report.sources
     );
-    for provider in [CaptureProvider::FactoryAiDroid, CaptureProvider::Firebender] {
-        assert!(all_report.issues.iter().any(|issue| {
-            issue.provider == provider
-                && issue.kind == DiscoveryIssueKind::InsufficientOfficialEvidence
-        }));
-    }
+    assert!(all_report.issues.iter().any(|issue| {
+        issue.provider == CaptureProvider::Firebender
+            && issue.kind == DiscoveryIssueKind::InsufficientOfficialEvidence
+    }));
+    assert!(all_report.sources.iter().any(|source| {
+        source.provider == CaptureProvider::FactoryAiDroid
+            && source.path == temp.path().join(".factory/sessions")
+            && source.status == ProviderSourceStatus::Missing
+    }));
     assert!(provider_report.issues.is_empty());
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -286,7 +286,7 @@ ctx import --provider cursor
 ctx import --provider zed
 ctx import --provider kiro-cli
 ctx import --provider copilot-cli
-ctx import --provider factory-ai-droid --path /path/to/factory/sessions
+ctx import --provider factory-ai-droid
 ctx import --provider qwen-code
 ctx import --provider kimi-code-cli
 ctx import --provider windsurf

--- a/docs/provider-support-matrix.json
+++ b/docs/provider-support-matrix.json
@@ -1177,11 +1177,13 @@
           "source_format": "factory_ai_droid_sessions_jsonl",
           "fidelity": "imported",
           "notes": [
-            "Reads Factory AI Droid session JSONL supplied by exact explicit path, including worker session linkage when present; no official automatic root is established."
+            "Reads Factory AI Droid session JSONL under ~/.factory/sessions or an explicit session directory, including worker session linkage when present."
           ]
         }
       ],
-      "history_locations": [],
+      "history_locations": [
+        "Fixed: `~/.factory/sessions/<project>/<session-id>.jsonl`."
+      ],
       "imports_existing_history": true,
       "captures_new_runs_passively": false,
       "child_sessions_supported": true,
@@ -1199,7 +1201,7 @@
         "parent_child_session_edges": true
       },
       "limitations": [
-        "No automatic official Factory root; former `~/.factory/sessions` probe is removed. User-owned supported JSONL remains available by exact `--path`."
+        "Unsupported Unix platforms require an exact `--path`."
       ],
       "public_docs": "docs/provider-support.md"
     },

--- a/docs/provider-support-matrix.json
+++ b/docs/provider-support-matrix.json
@@ -1182,7 +1182,7 @@
         }
       ],
       "history_locations": [
-        "Fixed: `~/.factory/sessions/<project>/<session-id>.jsonl`."
+        "Supported default: `~/.factory/sessions/<project>/<session-id>.jsonl`."
       ],
       "imports_existing_history": true,
       "captures_new_runs_passively": false,

--- a/docs/provider-support.md
+++ b/docs/provider-support.md
@@ -64,8 +64,8 @@ support matrix is:
 | Cline | Supported | `cline_task_directory_json` |
 | Roo Code | Supported | `roo_task_directory_json` |
 
-Factory AI Droid has no automatic history location. Its imports always require
-an exact path, for example
+Factory AI Droid history is discovered automatically at `~/.factory/sessions`.
+An exact path remains available, for example
 `ctx import --provider factory-ai-droid --path /path/to/factory/sessions`.
 
 `ctx sources --format json` reports each known provider source with `import_support`


### PR DESCRIPTION
Replaces #262 after its contributor branch was rewritten and GitHub would no longer reopen the original PR.

Fixes #260.

## Summary

- Restores automatic Factory AI Droid discovery at `~/.factory/sessions`.
- Routes Factory through the supported fixed-root resolver lane while retaining exact `--path` imports.
- Updates public provider documentation and support metadata.
- Preserves the contributor change as a separate commit authored by rNoz; the maintainer follow-up is isolated in a second commit.

## Maintainer hardening

- Adds a hermetic default-source CLI regression covering sources, bare import, search, unchanged reimport, stable session/event IDs, and stable counts.
- Covers Linux, macOS, Windows, and unsupported Unix resolver behavior.
- Updates the simple resolver lane invariant from 13 providers to 14.
- Describes the path as a supported default rather than an official vendor contract.

## Validation

- `cargo test -p ctx-history-capture` — 963 passed, 1 ignored.
- `cargo test -p ctx --test custom_root_discovery` — 5 passed.
- `cargo test -p ctx --test native_providers factory_droid` — 3 passed.
- `cargo test -p ctx --test native_providers factory_retry_identity_is_source_scoped` — passed.
- `cargo clippy -p ctx-history-capture --lib --tests` — passed.
- `cargo clippy -p ctx --test native_providers` — passed.
- `cargo fmt --all --check` — passed.
- `python3 scripts/check-provider-support-matrix.py` — passed.
- `git diff --check` — passed.