### PR TITLE
fix(kimi): re-project corrected wire semantics

### DIFF
--- a/crates/ctx-history-capture/src/provider/providers/kimi/native_path/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/providers/kimi/native_path/source_backed.rs
@@ -57,7 +57,8 @@ const KIMI_NATIVE_SESSION_NAMESPACE: &str = "kimi-code-cli-session-v1";
 const KIMI_NATIVE_EVENT_POSITION_KIND: &str = "kimi-code-cli-wire-ordinal-v1";
 const KIMI_LOGICAL_SESSION_KIND: &str = "agent-session";
 const KIMI_LOGICAL_EVENT_KIND: &str = "wire-event";
-const KIMI_SOURCE_PARSER_REVISION: &str = "kimi-code-cli-source-backed-v2";
+// v3 reclassifies content parts; the bump re-projects transcripts indexed by v2.
+const KIMI_SOURCE_PARSER_REVISION: &str = "kimi-code-cli-source-backed-v3";
 const KIMI_DISCOVERY_MAX_DEPTH: usize = 16;
 const KIMI_DISCOVERY_MAX_ENTRIES: usize = 65_536;
 

--- a/crates/ctx-history-capture/src/provider/providers/kimi/native_path/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/providers/kimi/native_path/source_backed.rs
@@ -57,7 +57,7 @@ const KIMI_NATIVE_SESSION_NAMESPACE: &str = "kimi-code-cli-session-v1";
 const KIMI_NATIVE_EVENT_POSITION_KIND: &str = "kimi-code-cli-wire-ordinal-v1";
 const KIMI_LOGICAL_SESSION_KIND: &str = "agent-session";
 const KIMI_LOGICAL_EVENT_KIND: &str = "wire-event";
-// v3 reclassifies content parts; the bump re-projects transcripts indexed by v2.
+// v3 reclassifies content parts and normalizes toolCallId; the bump re-projects v2.
 const KIMI_SOURCE_PARSER_REVISION: &str = "kimi-code-cli-source-backed-v3";
 const KIMI_DISCOVERY_MAX_DEPTH: usize = 16;
 const KIMI_DISCOVERY_MAX_ENTRIES: usize = 65_536;

--- a/crates/ctx-history-capture/src/provider/providers/kimi/native_path/source_backed/records.rs
+++ b/crates/ctx-history-capture/src/provider/providers/kimi/native_path/source_backed/records.rs
@@ -67,33 +67,7 @@ pub(super) fn core_record(
         AgentType::Subagent
     };
     let event = value.get("event").unwrap_or(value);
-    let tool_name = event
-        .get("toolName")
-        .or_else(|| event.get("tool_name"))
-        .or_else(|| event.get("name"))
-        .cloned();
-    let call_id = event
-        .get("callId")
-        .or_else(|| event.get("call_id"))
-        .or_else(|| event.get("id"))
-        .cloned();
-    let provider_tool_content = matches!(
-        event_type,
-        EventType::ToolCall | EventType::ToolOutput | EventType::CommandOutput
-    )
-    .then(|| event.clone());
-    let structured_content = (!touched_files.is_empty()
-        || tool_name.is_some()
-        || call_id.is_some()
-        || provider_tool_content.is_some())
-    .then(|| {
-        serde_json::json!({
-            "tool_name": tool_name,
-            "call_id": call_id,
-            "file_touches": touched_files,
-            "provider_tool_content": provider_tool_content,
-        })
-    });
+    let structured_content = kimi_structured_content(event, event_type, touched_files);
     let mut record = CoreRecord::new_selected(
         event_id,
         session_id,
@@ -116,6 +90,41 @@ pub(super) fn core_record(
     record.content.structured_content = structured_content;
     record.validate_contract()?;
     Ok(Some(record))
+}
+
+fn kimi_structured_content(
+    event: &Value,
+    event_type: EventType,
+    touched_files: Vec<String>,
+) -> Option<Value> {
+    let tool_name = event
+        .get("toolName")
+        .or_else(|| event.get("tool_name"))
+        .or_else(|| event.get("name"))
+        .cloned();
+    let call_id = event
+        .get("toolCallId")
+        .or_else(|| event.get("callId"))
+        .or_else(|| event.get("call_id"))
+        .or_else(|| event.get("id"))
+        .cloned();
+    let provider_tool_content = matches!(
+        event_type,
+        EventType::ToolCall | EventType::ToolOutput | EventType::CommandOutput
+    )
+    .then(|| event.clone());
+    (!touched_files.is_empty()
+        || tool_name.is_some()
+        || call_id.is_some()
+        || provider_tool_content.is_some())
+    .then(|| {
+        serde_json::json!({
+            "tool_name": tool_name,
+            "call_id": call_id,
+            "file_touches": touched_files,
+            "provider_tool_content": provider_tool_content,
+        })
+    })
 }
 
 pub(super) fn kimi_lexical_body(
@@ -190,6 +199,33 @@ fn kimi_output_classification(value: &Value) -> KimiOutputClassification {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn official_tool_call_id_is_published_for_call_and_result() {
+        let call = serde_json::json!({
+            "type": "tool.call",
+            "toolCallId": "call_1",
+            "name": "Read",
+            "args": {"path": "/tmp/splines.txt"}
+        });
+        let result = serde_json::json!({
+            "type": "tool.result",
+            "toolCallId": "call_1",
+            "result": {"output": "spline data", "isError": false}
+        });
+
+        for (event, event_type) in [
+            (&call, EventType::ToolCall),
+            (&result, EventType::ToolOutput),
+        ] {
+            let structured = kimi_structured_content(event, event_type, Vec::new()).unwrap();
+            assert_eq!(
+                structured.get("call_id").and_then(Value::as_str),
+                Some("call_1"),
+                "{structured:#}"
+            );
+        }
+    }
 
     #[test]
     fn successful_textual_result_over_16k_is_complete() {


### PR DESCRIPTION
Follow-up to #267. That change corrected `content.part` classification but left `KIMI_SOURCE_PARSER_REVISION` at `v2`, so unchanged transcripts already indexed by the previous parser are never re-read.

This PR now uses one v3 projection boundary for both corrected Kimi wire semantics:

- bumps the revision to `kimi-code-cli-source-backed-v3`, forcing v2 transcripts to re-project cold
- normalizes the official Kimi `toolCallId` field into canonical `call_id` for both tool calls and results while retaining existing aliases
- keeps event identity stable because IDs derive from source, session, and ordinal rather than parser revision
- adds regression coverage proving both sides of a tool exchange publish `call_id: call_1`

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy -p ctx-history-capture --lib -- -D warnings`
- `cargo test -p ctx-history-capture kimi -- --nocapture`
- `cargo test -p ctx --test native_provider_real_shapes kimi_code_cli_wire_indexes_streamed_assistant_output_through_public_cli -- --exact --nocapture`