### PR TITLE
fix(daemon): recover legacy publications without source-refresh metadata

### DIFF
--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/request_lifecycle.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/request_lifecycle.rs
@@ -189,6 +189,32 @@ impl CoreRefreshEngine {
             let verified = verified.ok_or_else(|| {
                 anyhow!("interrupted source refresh advanced Core without a verified generation")
             })?;
+            if verified.publication_metadata().is_none() {
+                // Publications written before the refresh control plane carry
+                // no source-refresh receipt, so there is nothing exact to
+                // recover. Accept the verified generation as terminal-complete
+                // and install any queued successors; the next scheduled
+                // refresh publishes with metadata again. Publications with
+                // present-but-malformed metadata keep failing closed below.
+                if !queued_successors.is_empty() {
+                    let durable_request_id = {
+                        let mut state = self.lock_state();
+                        install_recovered_successors(&mut state, queued_successors)?;
+                        state.current_published_generation = Some(active_generation);
+                        state
+                            .active_request_id
+                            .as_deref()
+                            .ok_or_else(|| {
+                                anyhow!("recovered source refresh successor is unavailable")
+                            })?
+                            .to_owned()
+                    };
+                    self.persist_job_status(data_root, &durable_request_id)?;
+                    return Ok(true);
+                }
+                self.lock_state().current_published_generation = Some(active_generation);
+                return Ok(false);
+            }
             let metadata = SourceBackedPublicationMetadata::decode(&verified)
                 .context("recover exact terminal refresh receipt from Core publication metadata")?;
             let job_request_id = job

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/restart_recovery_tests.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/restart_recovery_tests.rs
@@ -149,6 +149,47 @@ fn pre_overlay_periodic_job_does_not_block_restart_on_legacy_catalog_commitment(
     assert!(recovered.get("requested_explicit_source_catalog").is_none());
 }
 
+#[test]
+fn legacy_publication_without_source_refresh_metadata_does_not_block_restart() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root).unwrap();
+    let authority = load_explicit_source_catalog_authority(&data_root).unwrap();
+
+    // A generation published by a pre-control-plane binary carries no
+    // source-refresh publication metadata.
+    let writer = ctx_history_index::GenerationWriter::open(
+        source_backed_index_root(&data_root),
+        WriterOptions::default(),
+    )
+    .unwrap();
+    let commit = writer.commit(|_| true).unwrap();
+
+    write_daemon_job_status(
+        &daemon_source_backed_refresh_job_path(&data_root),
+        &json!({
+            "schema_version": 1,
+            "owner": "daemon",
+            "request_id": "legacy-published",
+            "request_state": "published",
+            "operation": "refresh",
+            "previous_generation": null,
+            "published_generation": commit.generation_id,
+            "refresh_scope": {"kind": "all"},
+            "requested_explicit_source_catalog": authority.to_json(),
+            "daemon_mode": "full",
+            "trigger": "periodic",
+            "trigger_provenance": "daemon_scheduler",
+        }),
+    )
+    .unwrap();
+
+    let coordinator = CoreRefreshEngine::new();
+    assert!(!coordinator
+        .recover_interrupted_publication(&data_root)
+        .unwrap());
+}
+
 #[cfg(any(unix, windows))]
 #[test]
 fn old_wait_request_keeps_exact_identity_across_restart_and_returns_exact_generation() {


### PR DESCRIPTION
## Summary

- `recover_interrupted_publication` aborted daemon startup when the active Core generation was published by a binary from before the refresh routing control plane (3ae9c766, d17953a5): those publications carry no source-refresh metadata, and the pointer-advanced branch decoded it with `?`.
- When the verified publication has no source-refresh metadata at all, recovery now accepts the verified generation as terminal-complete and installs any queued successors instead of propagating the decode error.
- Publications with present-but-malformed or mismatched metadata keep failing closed; the next scheduled refresh publishes with metadata, so exact receipt recovery resumes from there.

## Validation

- New regression test `legacy_publication_without_source_refresh_metadata_does_not_block_restart`: a bare committed generation (no metadata) plus a `published` job with an advanced pointer recovers with `Ok(false)`; verified it fails with the #275 startup abort when the fix is reverted.
- `cargo test -p ctx --bins source_backed_refresh_coordinator`: 88 passed, 0 failed (macOS note: the suite needs a symlink-free `TMPDIR`, e.g. `TMPDIR=/private/tmp`, because the private-directory walk opens each component with `O_NOFOLLOW`).
- `cargo clippy -p ctx --bins`: no new warnings; `cargo fmt --all -- --check`: clean.
- Real-data acceptance on macOS: a data root published by a pre-control-plane build aborted `ctx daemon enable` exactly as in #275; with this fix the same root starts the daemon and serves its endpoint (the root's remaining refresh error is unrelated same-machine generation skew).

Fixes #275.
