### PR TITLE
Recover exact legacy daemon publications safely

### DIFF
--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/request_lifecycle.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/request_lifecycle.rs
@@ -189,6 +189,32 @@ impl CoreRefreshEngine {
             let verified = verified.ok_or_else(|| {
                 anyhow!("interrupted source refresh advanced Core without a verified generation")
             })?;
+            if verified.publication_metadata().is_none() {
+                // Publications written before the refresh control plane carry
+                // no source-refresh receipt, so there is nothing exact to
+                // recover. Accept the verified generation as terminal-complete
+                // and install any queued successors; the next scheduled
+                // refresh publishes with metadata again. Publications with
+                // present-but-malformed metadata keep failing closed below.
+                if !queued_successors.is_empty() {
+                    let durable_request_id = {
+                        let mut state = self.lock_state();
+                        install_recovered_successors(&mut state, queued_successors)?;
+                        state.current_published_generation = Some(active_generation);
+                        state
+                            .active_request_id
+                            .as_deref()
+                            .ok_or_else(|| {
+                                anyhow!("recovered source refresh successor is unavailable")
+                            })?
+                            .to_owned()
+                    };
+                    self.persist_job_status(data_root, &durable_request_id)?;
+                    return Ok(true);
+                }
+                self.lock_state().current_published_generation = Some(active_generation);
+                return Ok(false);
+            }
             let metadata = SourceBackedPublicationMetadata::decode(&verified)
                 .context("recover exact terminal refresh receipt from Core publication metadata")?;
             let job_request_id = job

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/request_lifecycle.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/request_lifecycle.rs
@@ -182,20 +182,33 @@ impl CoreRefreshEngine {
             .unwrap_or("unknown");
         let previous_generation = job.get("previous_generation").and_then(Value::as_str);
         let pointer_advanced = active_generation.as_deref() != previous_generation;
-        if pointer_advanced {
+        // A terminal job must always recover or reject its exact publication,
+        // even when the persisted previous-generation pointer already equals
+        // the active generation. Otherwise malformed terminal authority can
+        // be ignored and queued successors can be lost on restart.
+        if pointer_advanced || request_state == "published" {
             let active_generation = active_generation.ok_or_else(|| {
                 anyhow!("interrupted source refresh advanced Core without an active generation")
             })?;
             let verified = verified.ok_or_else(|| {
                 anyhow!("interrupted source refresh advanced Core without a verified generation")
             })?;
-            if verified.publication_metadata().is_none() {
+            if verified.publication_metadata().is_none() && request_state == "published" {
                 // Publications written before the refresh control plane carry
                 // no source-refresh receipt, so there is nothing exact to
                 // recover. Accept the verified generation as terminal-complete
-                // and install any queued successors; the next scheduled
-                // refresh publishes with metadata again. Publications with
-                // present-but-malformed metadata keep failing closed below.
+                // only when the legacy job names that exact publication, then
+                // install any queued successors; the next scheduled refresh
+                // publishes with metadata again. Non-terminal jobs, mismatched
+                // generations, and present-but-malformed metadata keep failing
+                // closed below.
+                let job_generation = required_generation(
+                    job.get("published_generation"),
+                    "legacy published refresh generation",
+                )?;
+                if job_generation != active_generation {
+                    bail!("legacy Core refresh job names a different published generation");
+                }
                 if !queued_successors.is_empty() {
                     let durable_request_id = {
                         let mut state = self.lock_state();

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/restart_recovery_tests.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/restart_recovery_tests.rs
@@ -190,6 +190,132 @@ fn legacy_publication_without_source_refresh_metadata_does_not_block_restart() {
         .unwrap());
 }
 
+#[test]
+fn legacy_terminal_publication_recovers_successor_without_pointer_change() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root).unwrap();
+    let authority = load_explicit_source_catalog_authority(&data_root).unwrap();
+    let writer = ctx_history_index::GenerationWriter::open(
+        source_backed_index_root(&data_root),
+        WriterOptions::default(),
+    )
+    .unwrap();
+    let commit = writer.commit(|_| true).unwrap();
+    let successor = CoreRefreshEngine::new().enqueue(Some(commit.generation_id.clone()));
+    let successor_id = successor["request_id"].as_str().unwrap().to_owned();
+
+    write_daemon_job_status(
+        &daemon_source_backed_refresh_job_path(&data_root),
+        &json!({
+            "schema_version": 1,
+            "owner": "daemon",
+            "request_id": "legacy-published-with-successor",
+            "request_state": "published",
+            "operation": "refresh",
+            "previous_generation": commit.generation_id.clone(),
+            "published_generation": commit.generation_id,
+            "refresh_scope": {"kind": "all"},
+            "requested_explicit_source_catalog": authority.to_json(),
+            "daemon_mode": "full",
+            "trigger": "periodic",
+            "trigger_provenance": "daemon_scheduler",
+            "queued_successors": [successor],
+        }),
+    )
+    .unwrap();
+
+    let coordinator = CoreRefreshEngine::new();
+    assert!(coordinator
+        .recover_interrupted_publication(&data_root)
+        .unwrap());
+    assert_eq!(
+        coordinator.status(&successor_id).unwrap()["request_state"],
+        "queued"
+    );
+    assert!(coordinator.has_pending_request());
+}
+
+#[test]
+fn metadata_free_publication_does_not_discard_a_running_refresh() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root).unwrap();
+    let authority = load_explicit_source_catalog_authority(&data_root).unwrap();
+    let writer = ctx_history_index::GenerationWriter::open(
+        source_backed_index_root(&data_root),
+        WriterOptions::default(),
+    )
+    .unwrap();
+    let commit = writer.commit(|_| true).unwrap();
+
+    write_daemon_job_status(
+        &daemon_source_backed_refresh_job_path(&data_root),
+        &json!({
+            "schema_version": 1,
+            "owner": "daemon",
+            "request_id": "still-running",
+            "request_state": "running",
+            "operation": "refresh",
+            "previous_generation": null,
+            "published_generation": commit.generation_id,
+            "refresh_scope": {"kind": "all"},
+            "requested_explicit_source_catalog": authority.to_json(),
+            "daemon_mode": "full",
+            "trigger": "periodic",
+            "trigger_provenance": "daemon_scheduler",
+        }),
+    )
+    .unwrap();
+
+    let error = CoreRefreshEngine::new()
+        .recover_interrupted_publication(&data_root)
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("recover exact terminal refresh receipt"));
+}
+
+#[test]
+fn metadata_free_publication_requires_the_exact_legacy_generation() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root).unwrap();
+    let authority = load_explicit_source_catalog_authority(&data_root).unwrap();
+    let writer = ctx_history_index::GenerationWriter::open(
+        source_backed_index_root(&data_root),
+        WriterOptions::default(),
+    )
+    .unwrap();
+    let commit = writer.commit(|_| true).unwrap();
+
+    write_daemon_job_status(
+        &daemon_source_backed_refresh_job_path(&data_root),
+        &json!({
+            "schema_version": 1,
+            "owner": "daemon",
+            "request_id": "mismatched-published",
+            "request_state": "published",
+            "operation": "refresh",
+            "previous_generation": commit.generation_id,
+            "published_generation": "different-generation",
+            "refresh_scope": {"kind": "all"},
+            "requested_explicit_source_catalog": authority.to_json(),
+            "daemon_mode": "full",
+            "trigger": "periodic",
+            "trigger_provenance": "daemon_scheduler",
+        }),
+    )
+    .unwrap();
+
+    let error = CoreRefreshEngine::new()
+        .recover_interrupted_publication(&data_root)
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("legacy Core refresh job names a different published generation"));
+}
+
 #[cfg(any(unix, windows))]
 #[test]
 fn old_wait_request_keeps_exact_identity_across_restart_and_returns_exact_generation() {

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/restart_recovery_tests.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/restart_recovery_tests.rs
@@ -149,6 +149,47 @@ fn pre_overlay_periodic_job_does_not_block_restart_on_legacy_catalog_commitment(
     assert!(recovered.get("requested_explicit_source_catalog").is_none());
 }
 
+#[test]
+fn legacy_publication_without_source_refresh_metadata_does_not_block_restart() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root).unwrap();
+    let authority = load_explicit_source_catalog_authority(&data_root).unwrap();
+
+    // A generation published by a pre-control-plane binary carries no
+    // source-refresh publication metadata.
+    let writer = ctx_history_index::GenerationWriter::open(
+        source_backed_index_root(&data_root),
+        WriterOptions::default(),
+    )
+    .unwrap();
+    let commit = writer.commit(|_| true).unwrap();
+
+    write_daemon_job_status(
+        &daemon_source_backed_refresh_job_path(&data_root),
+        &json!({
+            "schema_version": 1,
+            "owner": "daemon",
+            "request_id": "legacy-published",
+            "request_state": "published",
+            "operation": "refresh",
+            "previous_generation": null,
+            "published_generation": commit.generation_id,
+            "refresh_scope": {"kind": "all"},
+            "requested_explicit_source_catalog": authority.to_json(),
+            "daemon_mode": "full",
+            "trigger": "periodic",
+            "trigger_provenance": "daemon_scheduler",
+        }),
+    )
+    .unwrap();
+
+    let coordinator = CoreRefreshEngine::new();
+    assert!(!coordinator
+        .recover_interrupted_publication(&data_root)
+        .unwrap());
+}
+
 #[cfg(any(unix, windows))]
 #[test]
 fn old_wait_request_keeps_exact_identity_across_restart_and_returns_exact_generation() {


### PR DESCRIPTION
Fixes #275.

Builds on the external contribution in #276 and preserves its commit attribution. Publications from before the source-refresh control plane can now restart the daemon when the durable job is terminal and names the exact active generation.

The fallback remains fail-closed for running or queued requests, mismatched generations, and present-but-invalid publication metadata. Terminal recovery also preserves queued successors when the generation pointer did not change.

Validation:
- restart recovery tests: 10 passed
- full ctx-cli Bazel unit target focused to the regression: passed
- cargo fmt and git diff checks: passed
- two independent exact-head reviews: passed