### PR TITLE
test: repair current-main deterministic gates

### DIFF
--- a/crates/ctx-history-core/src/platform_security/unix_private_directory.rs
+++ b/crates/ctx-history-core/src/platform_security/unix_private_directory.rs
@@ -317,6 +317,7 @@ mod tests {
         use std::os::unix::fs::symlink;
 
         let temp = tempfile::tempdir().unwrap();
+        fs::set_permissions(temp.path(), fs::Permissions::from_mode(0o700)).unwrap();
         let target = temp.path().join("target");
         let link = temp.path().join("link");
         let temp_metadata = fs::metadata(temp.path()).unwrap();

--- a/crates/ctx-history-index/src/policy.rs
+++ b/crates/ctx-history-index/src/policy.rs
@@ -286,7 +286,7 @@ mod tests {
         assert_eq!(first.lexical.schema_revision, 17);
         assert_eq!(
             first.canonical_sha256().unwrap(),
-            "922a3606cae33c5efd426c7351356ae67ba0fca40de716d034757e5b234f9b68"
+            "45eef26c4539432ccf99e3cc9cfe996339fe934aa4e18e67810ccab9f2188f87"
         );
     }
 


### PR DESCRIPTION
## Summary

- establish the documented 0700 precondition in the symlink-prefix test
- update the exact source-generation policy hash after the current contract change

## Validation

- `scripts/bazelw test //crates/ctx-history-core:unit_tests //crates/ctx-history-index:unit_tests --config=test`
- `scripts/bazelw test //:rustfmt_check --config=test`

This is a behavior-neutral prerequisite discovered while baselining the MCP attribution work.