### PR TITLE
refactor(cli): extract event renderers

### DIFF
--- a/crates/ctx-cli/src/commands/list/events.rs
+++ b/crates/ctx-cli/src/commands/list/events.rs
@@ -2,13 +2,11 @@ use std::{io::Write, path::Path, path::PathBuf};
 
 use anyhow::Result;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-use chrono::{DateTime, SecondsFormat, Utc};
-use ctx_history_core::{
-    CoreContentPolicyStatus, MAX_CORE_CONTENT_BYTES, MAX_ENCODED_CORE_RECORD_BYTES,
-};
+use chrono::DateTime;
+use ctx_history_core::{MAX_CORE_CONTENT_BYTES, MAX_ENCODED_CORE_RECORD_BYTES};
 use ctx_history_index::{
     CoreEventPageBudget, CoreEventRangeCursor, CoreEventRangeError, CoreEventRangeFilters,
-    CoreEventRangePage, CoreEventRangeSelection, CoreEventRecord, IndexError, VerifiedIndex,
+    CoreEventRangePage, CoreEventRangeSelection, IndexError, VerifiedIndex,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -21,10 +19,13 @@ use crate::{
     ui::Ui,
 };
 
+mod render;
 mod request;
 
 #[cfg(test)]
 use ctx_history_index::{CoreEventRangeDirection, CoreEventRangeScope};
+use render::format_timestamp;
+pub(crate) use render::render_event;
 pub(crate) use request::{
     EventContentProjection, EventQueryFormat, EventQueryWireRequest, ListEventsArgs,
 };
@@ -683,80 +684,6 @@ impl Write for CountingWriter<'_> {
     }
 }
 
-pub(crate) fn render_event(
-    event: &CoreEventRecord,
-    projection: EventContentProjection,
-) -> std::result::Result<Value, EventQueryError> {
-    let record = &event.core_record;
-    let content = &record.content;
-    let (policy_status, policy_reason, complete) = match &content.policy_status {
-        CoreContentPolicyStatus::Selected => ("selected", None, true),
-        CoreContentPolicyStatus::Redacted { reason } => ("redacted", Some(reason.as_str()), false),
-        CoreContentPolicyStatus::Omitted { reason } => ("omitted", Some(reason.as_str()), false),
-    };
-    let text = (projection != EventContentProjection::None)
-        .then_some(content.normalized_body.as_ref())
-        .flatten();
-    let structured_content = (projection == EventContentProjection::Full)
-        .then_some(content.structured_content.as_ref())
-        .flatten();
-    let occurred_at = format_timestamp(event.occurred_at_unix_ms);
-    Ok(json!({
-        "schema_version": EVENT_QUERY_SCHEMA_VERSION,
-        "record_version": record.record_version,
-        "ctx_event_id": event.event_id.as_uuid(),
-        "ctx_source_id": event.source.identity().as_uuid(),
-        "ctx_session_id": event.session_id.as_uuid(),
-        "parent_ctx_session_id": event.parent_session_id.map(|id| id.as_uuid()),
-        "root_ctx_session_id": event.root_session_id.as_uuid(),
-        "occurred_at": occurred_at,
-        "occurred_at_ms": event.occurred_at_unix_ms,
-        "sequence": event.event_sequence,
-        "provider": event.provider,
-        "source_format": event.source_format,
-        "source": event.source,
-        "provider_session_id": event.provider_session_id,
-        "native_event_id": event.native_event_id,
-        "branch": event.branch,
-        "agent_type": event.agent_type,
-        "agent_scope": if event.is_primary { "primary" } else { "subagent" },
-        "is_primary": event.is_primary,
-        "event_type": event.event_type,
-        "role": event.role,
-        "workspace": event.workspace,
-        "cwd": event.cwd,
-        "touched_files": event.touched_files,
-        "parser_revision": record.parser_revision,
-        "normalization_revision": record.normalization_revision,
-        "text": text,
-        "structured_content": structured_content,
-        "content": {
-            "complete": complete,
-            "policy_revision": content.policy_revision,
-            "policy_status": policy_status,
-            "policy_reason": policy_reason,
-        },
-        "citations": [{
-            "target_type": "event",
-            "ctx_event_id": event.event_id.as_uuid(),
-            "ctx_session_id": event.session_id.as_uuid(),
-            "label": event.event_type,
-            "time": occurred_at,
-            "provider": event.provider,
-            "session_id": event.provider_session_id,
-            "event_seq": event.event_sequence,
-        }],
-        "metadata": record.metadata,
-        "repository_candidate_evidence": record.repository_candidate_evidence,
-        "repository_bindings": record.repository_bindings,
-        "repository_abstentions": record.repository_abstentions,
-        "repository_file_invocation_evidence": record.repository_file_invocation_evidence,
-        "repository_file_observations": record.repository_file_observations,
-        "repository_vcs_observations": record.repository_vcs_observations,
-        "content_projection": projection.as_str(),
-    }))
-}
-
 fn event_query_receipt<'a>(
     index: &VerifiedIndex,
     request: &'a EventQueryWireRequest,
@@ -867,12 +794,6 @@ pub(crate) fn parse_uuid(
             })
         })
         .transpose()
-}
-
-fn format_timestamp(value: Option<i64>) -> Option<String> {
-    value
-        .and_then(DateTime::<Utc>::from_timestamp_millis)
-        .map(|value| value.to_rfc3339_opts(SecondsFormat::Millis, true))
 }
 
 pub(crate) fn event_query_error_value(error: &EventQueryError) -> Value {

--- a/crates/ctx-cli/src/commands/list/events/render.rs
+++ b/crates/ctx-cli/src/commands/list/events/render.rs
@@ -1,0 +1,86 @@
+use chrono::{DateTime, SecondsFormat, Utc};
+use ctx_history_core::CoreContentPolicyStatus;
+use ctx_history_index::CoreEventRecord;
+use serde_json::{json, Value};
+
+use super::{EventContentProjection, EventQueryError, EVENT_QUERY_SCHEMA_VERSION};
+
+pub(crate) fn render_event(
+    event: &CoreEventRecord,
+    projection: EventContentProjection,
+) -> std::result::Result<Value, EventQueryError> {
+    let record = &event.core_record;
+    let content = &record.content;
+    let (policy_status, policy_reason, complete) = match &content.policy_status {
+        CoreContentPolicyStatus::Selected => ("selected", None, true),
+        CoreContentPolicyStatus::Redacted { reason } => ("redacted", Some(reason.as_str()), false),
+        CoreContentPolicyStatus::Omitted { reason } => ("omitted", Some(reason.as_str()), false),
+    };
+    let text = (projection != EventContentProjection::None)
+        .then_some(content.normalized_body.as_ref())
+        .flatten();
+    let structured_content = (projection == EventContentProjection::Full)
+        .then_some(content.structured_content.as_ref())
+        .flatten();
+    let occurred_at = format_timestamp(event.occurred_at_unix_ms);
+    Ok(json!({
+        "schema_version": EVENT_QUERY_SCHEMA_VERSION,
+        "record_version": record.record_version,
+        "ctx_event_id": event.event_id.as_uuid(),
+        "ctx_source_id": event.source.identity().as_uuid(),
+        "ctx_session_id": event.session_id.as_uuid(),
+        "parent_ctx_session_id": event.parent_session_id.map(|id| id.as_uuid()),
+        "root_ctx_session_id": event.root_session_id.as_uuid(),
+        "occurred_at": occurred_at,
+        "occurred_at_ms": event.occurred_at_unix_ms,
+        "sequence": event.event_sequence,
+        "provider": event.provider,
+        "source_format": event.source_format,
+        "source": event.source,
+        "provider_session_id": event.provider_session_id,
+        "native_event_id": event.native_event_id,
+        "branch": event.branch,
+        "agent_type": event.agent_type,
+        "agent_scope": if event.is_primary { "primary" } else { "subagent" },
+        "is_primary": event.is_primary,
+        "event_type": event.event_type,
+        "role": event.role,
+        "workspace": event.workspace,
+        "cwd": event.cwd,
+        "touched_files": event.touched_files,
+        "parser_revision": record.parser_revision,
+        "normalization_revision": record.normalization_revision,
+        "text": text,
+        "structured_content": structured_content,
+        "content": {
+            "complete": complete,
+            "policy_revision": content.policy_revision,
+            "policy_status": policy_status,
+            "policy_reason": policy_reason,
+        },
+        "citations": [{
+            "target_type": "event",
+            "ctx_event_id": event.event_id.as_uuid(),
+            "ctx_session_id": event.session_id.as_uuid(),
+            "label": event.event_type,
+            "time": occurred_at,
+            "provider": event.provider,
+            "session_id": event.provider_session_id,
+            "event_seq": event.event_sequence,
+        }],
+        "metadata": record.metadata,
+        "repository_candidate_evidence": record.repository_candidate_evidence,
+        "repository_bindings": record.repository_bindings,
+        "repository_abstentions": record.repository_abstentions,
+        "repository_file_invocation_evidence": record.repository_file_invocation_evidence,
+        "repository_file_observations": record.repository_file_observations,
+        "repository_vcs_observations": record.repository_vcs_observations,
+        "content_projection": projection.as_str(),
+    }))
+}
+
+pub(super) fn format_timestamp(value: Option<i64>) -> Option<String> {
+    value
+        .and_then(DateTime::<Utc>::from_timestamp_millis)
+        .map(|value| value.to_rfc3339_opts(SecondsFormat::Millis, true))
+}

--- a/crates/ctx-cli/src/commands/source_index/show.rs
+++ b/crates/ctx-cli/src/commands/source_index/show.rs
@@ -1,11 +1,11 @@
 mod mcp;
+mod render;
 
 use std::{collections::VecDeque, fmt, io::Write, path::PathBuf};
 
 use anyhow::{anyhow, Result};
 use ctx_history_core::{
-    CaptureProvider, CoreContentPolicyStatus, EventType, MAX_CORE_CONTENT_BYTES,
-    MAX_ENCODED_CORE_RECORD_BYTES,
+    CaptureProvider, EventType, MAX_CORE_CONTENT_BYTES, MAX_ENCODED_CORE_RECORD_BYTES,
 };
 use ctx_history_index::{
     CoreEventPageBudget, CoreEventRecord, SessionEventCursor, SessionRecord, VerifiedIndex,
@@ -18,9 +18,7 @@ use crate::{
     analytics::{count_bucket, ShowTelemetry},
     local_usage::{CliUsage, ResultObservationAction},
     output::{compact_json, OutputFormat},
-    presentation_limit::{
-        enforce_presentation_output_limit, serialized_json_bytes, CLI_PRESENTATION_MAX_OUTPUT_BYTES,
-    },
+    presentation_limit::{enforce_presentation_output_limit, CLI_PRESENTATION_MAX_OUTPUT_BYTES},
     provider_args::ProviderArg,
     transcript::{TranscriptMode, TranscriptOutput},
     ui::{canonical_human_output_bytes, RenderContext, Ui},
@@ -28,7 +26,7 @@ use crate::{
 };
 
 use super::{
-    render::{render_show_document, timestamp_json, write_show_value},
+    render::{render_show_document, write_show_value},
     shared::{
         open_index, render_active_generation_race, resolve_core_event, resolve_lookup_for_output,
         resolve_session, validate_ctx_id, validate_session_selector, ActiveGenerationRaceCommand,
@@ -36,6 +34,10 @@ use super::{
 };
 
 pub(crate) use mcp::{mcp_show_event, mcp_show_session};
+use render::event_window_json;
+#[cfg(test)]
+pub(super) use render::{event_window_value, render_event_values};
+pub(super) use render::{render_event_value, session_transcript_value};
 
 const CORE_PRESENTATION_FETCH_MAX_EVENTS: usize = 200;
 const CLI_SESSION_EVENT_PAGE_ITEMS: usize = CORE_PRESENTATION_FETCH_MAX_EVENTS;
@@ -707,150 +709,6 @@ fn select_show_provider_session(
             matches[1].session_id
         )),
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-pub(super) fn session_transcript_value(
-    session: &SessionRecord,
-    mode: TranscriptMode,
-    format: OutputFormat,
-    rendered: Vec<Value>,
-    truncated: bool,
-    max_events: Option<usize>,
-) -> Value {
-    compact_json(json!({
-        "schema_version": 1,
-        "target": "session",
-        "payload_type": "session_transcript",
-        "ctx_session_id": session.session_id.as_uuid(),
-        "provider": session.provider,
-        "provider_session_id": session.provider_session_id,
-        "mode": mode.as_str(),
-        "format": format.as_str(),
-        "session": {
-            "id": session.session_id.as_uuid(),
-            "item_id": session.session_id.as_uuid(),
-            "record_type": "session",
-            "ctx_session_id": session.session_id.as_uuid(),
-            "provider": session.provider,
-            "provider_session_id": session.provider_session_id,
-            "source_format": session.source_format,
-            "parent_ctx_session_id": session.parent_session_id.map(|id| id.as_uuid()),
-            "root_ctx_session_id": session.root_session_id.as_uuid(),
-            "branch": session.branch,
-            "agent_type": session.agent_type,
-            "is_primary": session.is_primary,
-            "workspace": session.workspace,
-            "cwd": session.cwd,
-        },
-        "events": rendered,
-        "truncated": truncated.then(|| json!({
-            "events": true,
-            "max_events": max_events,
-        })),
-    }))
-}
-
-fn event_window_json(
-    selected: &CoreEventRecord,
-    events: &[CoreEventRecord],
-    format: OutputFormat,
-    output_limit_bytes: usize,
-) -> Result<Value> {
-    let references = events.iter().collect::<Vec<_>>();
-    let rendered = render_event_values(&references, output_limit_bytes)?;
-    event_window_value(selected, format, rendered)
-}
-
-pub(super) fn event_window_value(
-    selected: &CoreEventRecord,
-    format: OutputFormat,
-    rendered: Vec<Value>,
-) -> Result<Value> {
-    let selected_value = rendered
-        .iter()
-        .find(|event| {
-            event["ctx_event_id"].as_str() == Some(&selected.event_id.as_uuid().to_string())
-        })
-        .cloned()
-        .ok_or_else(|| anyhow!("selected event is absent from its pinned Core event window"))?;
-    Ok(compact_json(json!({
-        "schema_version": 1,
-        "target": "event",
-        "payload_type": "event_window",
-        "ctx_event_id": selected.event_id.as_uuid(),
-        "ctx_session_id": selected.session_id.as_uuid(),
-        "format": format.as_str(),
-        "event": selected_value,
-        "events": rendered,
-    })))
-}
-
-pub(super) fn render_event_values(
-    events: &[&CoreEventRecord],
-    output_limit_bytes: usize,
-) -> Result<Vec<Value>> {
-    let mut rendered = Vec::with_capacity(events.len());
-    let mut serialized_event_bytes = 2_usize;
-    for event in events {
-        let content = &event.core_record.content;
-        let content_bytes = serialized_json_bytes(&content.normalized_body)?
-            .saturating_add(serialized_json_bytes(&content.structured_content)?);
-        enforce_presentation_output_limit(
-            serialized_event_bytes.saturating_add(content_bytes),
-            output_limit_bytes,
-            event.event_id.as_uuid(),
-        )?;
-
-        let value = render_event_value(event);
-        serialized_event_bytes = serialized_event_bytes
-            .saturating_add(usize::from(!rendered.is_empty()))
-            .saturating_add(serialized_json_bytes(&value)?);
-        enforce_presentation_output_limit(
-            serialized_event_bytes,
-            output_limit_bytes,
-            event.event_id.as_uuid(),
-        )?;
-        rendered.push(value);
-    }
-    Ok(rendered)
-}
-
-pub(super) fn render_event_value(event: &CoreEventRecord) -> Value {
-    let content = &event.core_record.content;
-    let (policy_status, policy_reason, complete) = match &content.policy_status {
-        CoreContentPolicyStatus::Selected => ("selected", None, true),
-        CoreContentPolicyStatus::Redacted { reason } => ("redacted", Some(reason.as_str()), false),
-        CoreContentPolicyStatus::Omitted { reason } => ("omitted", Some(reason.as_str()), false),
-    };
-    compact_json(json!({
-        "ctx_event_id": event.event_id.as_uuid(),
-        "item_id": event.event_id.as_uuid(),
-        "record_type": "event",
-        "ctx_session_id": event.session_id.as_uuid(),
-        "provider": event.provider,
-        "provider_session_id": event.provider_session_id,
-        "source_format": event.source_format,
-        "parent_ctx_session_id": event.parent_session_id.map(|id| id.as_uuid()),
-        "root_ctx_session_id": event.root_session_id.as_uuid(),
-        "branch": event.branch,
-        "agent_type": event.agent_type,
-        "is_primary": event.is_primary,
-        "sequence": event.event_sequence,
-        "event_type": event.event_type,
-        "role": event.role,
-        "occurred_at": timestamp_json(event.occurred_at_unix_ms),
-        "workspace": event.workspace,
-        "cwd": event.cwd,
-        "touched_files": event.touched_files,
-        "text": content.normalized_body.as_deref(),
-        "structured_content": content.structured_content.as_ref(),
-        "content": {
-            "complete": complete,
-            "policy_status": policy_status,
-            "policy_reason": policy_reason,
-        },
-    }))
 }
 
 pub(super) fn event_window(

--- a/crates/ctx-cli/src/commands/source_index/show/render.rs
+++ b/crates/ctx-cli/src/commands/source_index/show/render.rs
@@ -1,0 +1,156 @@
+use anyhow::{anyhow, Result};
+use ctx_history_core::CoreContentPolicyStatus;
+use ctx_history_index::{CoreEventRecord, SessionRecord};
+use serde_json::{json, Value};
+
+use crate::{
+    output::{compact_json, OutputFormat},
+    presentation_limit::{enforce_presentation_output_limit, serialized_json_bytes},
+    transcript::TranscriptMode,
+};
+
+use super::super::render::timestamp_json;
+
+#[allow(clippy::too_many_arguments)]
+pub(in crate::commands::source_index) fn session_transcript_value(
+    session: &SessionRecord,
+    mode: TranscriptMode,
+    format: OutputFormat,
+    rendered: Vec<Value>,
+    truncated: bool,
+    max_events: Option<usize>,
+) -> Value {
+    compact_json(json!({
+        "schema_version": 1,
+        "target": "session",
+        "payload_type": "session_transcript",
+        "ctx_session_id": session.session_id.as_uuid(),
+        "provider": session.provider,
+        "provider_session_id": session.provider_session_id,
+        "mode": mode.as_str(),
+        "format": format.as_str(),
+        "session": {
+            "id": session.session_id.as_uuid(),
+            "item_id": session.session_id.as_uuid(),
+            "record_type": "session",
+            "ctx_session_id": session.session_id.as_uuid(),
+            "provider": session.provider,
+            "provider_session_id": session.provider_session_id,
+            "source_format": session.source_format,
+            "parent_ctx_session_id": session.parent_session_id.map(|id| id.as_uuid()),
+            "root_ctx_session_id": session.root_session_id.as_uuid(),
+            "branch": session.branch,
+            "agent_type": session.agent_type,
+            "is_primary": session.is_primary,
+            "workspace": session.workspace,
+            "cwd": session.cwd,
+        },
+        "events": rendered,
+        "truncated": truncated.then(|| json!({
+            "events": true,
+            "max_events": max_events,
+        })),
+    }))
+}
+
+pub(super) fn event_window_json(
+    selected: &CoreEventRecord,
+    events: &[CoreEventRecord],
+    format: OutputFormat,
+    output_limit_bytes: usize,
+) -> Result<Value> {
+    let references = events.iter().collect::<Vec<_>>();
+    let rendered = render_event_values(&references, output_limit_bytes)?;
+    event_window_value(selected, format, rendered)
+}
+
+pub(in crate::commands::source_index) fn event_window_value(
+    selected: &CoreEventRecord,
+    format: OutputFormat,
+    rendered: Vec<Value>,
+) -> Result<Value> {
+    let selected_value = rendered
+        .iter()
+        .find(|event| {
+            event["ctx_event_id"].as_str() == Some(&selected.event_id.as_uuid().to_string())
+        })
+        .cloned()
+        .ok_or_else(|| anyhow!("selected event is absent from its pinned Core event window"))?;
+    Ok(compact_json(json!({
+        "schema_version": 1,
+        "target": "event",
+        "payload_type": "event_window",
+        "ctx_event_id": selected.event_id.as_uuid(),
+        "ctx_session_id": selected.session_id.as_uuid(),
+        "format": format.as_str(),
+        "event": selected_value,
+        "events": rendered,
+    })))
+}
+
+pub(in crate::commands::source_index) fn render_event_values(
+    events: &[&CoreEventRecord],
+    output_limit_bytes: usize,
+) -> Result<Vec<Value>> {
+    let mut rendered = Vec::with_capacity(events.len());
+    let mut serialized_event_bytes = 2_usize;
+    for event in events {
+        let content = &event.core_record.content;
+        let content_bytes = serialized_json_bytes(&content.normalized_body)?
+            .saturating_add(serialized_json_bytes(&content.structured_content)?);
+        enforce_presentation_output_limit(
+            serialized_event_bytes.saturating_add(content_bytes),
+            output_limit_bytes,
+            event.event_id.as_uuid(),
+        )?;
+
+        let value = render_event_value(event);
+        serialized_event_bytes = serialized_event_bytes
+            .saturating_add(usize::from(!rendered.is_empty()))
+            .saturating_add(serialized_json_bytes(&value)?);
+        enforce_presentation_output_limit(
+            serialized_event_bytes,
+            output_limit_bytes,
+            event.event_id.as_uuid(),
+        )?;
+        rendered.push(value);
+    }
+    Ok(rendered)
+}
+
+pub(in crate::commands::source_index) fn render_event_value(event: &CoreEventRecord) -> Value {
+    let content = &event.core_record.content;
+    let (policy_status, policy_reason, complete) = match &content.policy_status {
+        CoreContentPolicyStatus::Selected => ("selected", None, true),
+        CoreContentPolicyStatus::Redacted { reason } => ("redacted", Some(reason.as_str()), false),
+        CoreContentPolicyStatus::Omitted { reason } => ("omitted", Some(reason.as_str()), false),
+    };
+    compact_json(json!({
+        "ctx_event_id": event.event_id.as_uuid(),
+        "item_id": event.event_id.as_uuid(),
+        "record_type": "event",
+        "ctx_session_id": event.session_id.as_uuid(),
+        "provider": event.provider,
+        "provider_session_id": event.provider_session_id,
+        "source_format": event.source_format,
+        "parent_ctx_session_id": event.parent_session_id.map(|id| id.as_uuid()),
+        "root_ctx_session_id": event.root_session_id.as_uuid(),
+        "branch": event.branch,
+        "agent_type": event.agent_type,
+        "is_primary": event.is_primary,
+        "sequence": event.event_sequence,
+        "event_type": event.event_type,
+        "role": event.role,
+        "occurred_at": timestamp_json(event.occurred_at_unix_ms),
+        "workspace": event.workspace,
+        "cwd": event.cwd,
+        "touched_files": event.touched_files,
+        "text": content.normalized_body.as_deref(),
+        "structured_content": content.structured_content.as_ref(),
+        "content": {
+            "complete": complete,
+            "policy_status": policy_status,
+            "policy_reason": policy_reason,
+        },
+    }))
+}


### PR DESCRIPTION
## Summary

Extract the existing list-events and show renderers into focused modules as a behavior-neutral prerequisite for adding a shared event annotation.

## Behavior

No CLI schema, field ordering, serialization, selection, or output behavior changes.

## Validation

- 1,435 CLI unit tests and focused list/show tests passed in independent review
- rustfmt, Clippy with warnings denied, LOC, and diff hygiene passed
- every changed line independently reviewed: APPROVE

Part of the implementation follow-up to #206.