### PR TITLE
refactor(capture): split shared parser revisions

### DIFF
--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/antigravity.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/antigravity.rs
@@ -2,10 +2,13 @@ use ctx_history_core::CaptureProvider;
 
 use crate::ANTIGRAVITY_CLI_SOURCE_FORMAT;
 
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v4";
+
 pub(crate) const fn antigravity_source_backed_adapter() -> super::DirectJsonlFamilyAdapter {
     super::DirectJsonlFamilyAdapter::new(
         CaptureProvider::Antigravity,
         ANTIGRAVITY_CLI_SOURCE_FORMAT,
         "antigravity-direct-native-jsonl-v1",
+        PARSER_REVISION,
     )
 }

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/copilot.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/copilot.rs
@@ -3,11 +3,14 @@ use serde_json::Value;
 
 use crate::COPILOT_CLI_SOURCE_FORMAT;
 
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v4";
+
 pub(crate) const fn copilot_source_backed_adapter() -> super::DirectJsonlFamilyAdapter {
     super::DirectJsonlFamilyAdapter::new(
         CaptureProvider::CopilotCli,
         COPILOT_CLI_SOURCE_FORMAT,
         "copilot-cli-direct-native-jsonl-v1",
+        PARSER_REVISION,
     )
 }
 

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/factory_ai_droid.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/factory_ai_droid.rs
@@ -14,11 +14,14 @@ use super::super::result_content::{
     extract_direct_result_content, NativeJsonlResultExtractionError, NativeJsonlResultSubrecord,
 };
 
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v4";
+
 pub(crate) const fn factory_droid_source_backed_adapter() -> super::DirectJsonlFamilyAdapter {
     super::DirectJsonlFamilyAdapter::new(
         CaptureProvider::FactoryAiDroid,
         FACTORY_DROID_SOURCE_FORMAT,
         "factory-droid-direct-native-jsonl-v1",
+        PARSER_REVISION,
     )
 }
 

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/mod.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/mod.rs
@@ -23,7 +23,7 @@ pub(super) use factory_ai_droid::{
 };
 pub(crate) use model::{
     DirectJsonlEvent, DirectJsonlRejection, DirectJsonlRetryDiscriminator, DirectJsonlSession,
-    DirectJsonlSourceRecord, DirectJsonlTouch, DIRECT_JSONL_NATIVEPATH_PARSER_REVISION,
+    DirectJsonlSourceRecord, DirectJsonlTouch,
 };
 pub(crate) use qoder::qoder_source_backed_adapter;
 pub(crate) use qwen_code::{qwen_code_file_is_selected, qwen_code_source_backed_adapter};

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/model.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/model.rs
@@ -3,8 +3,6 @@ use ctx_history_core::{AgentType, EventRole, EventType, FileChangeKind, SessionS
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-pub(crate) const DIRECT_JSONL_NATIVEPATH_PARSER_REVISION: &str = "direct-native-jsonl-parser-v4";
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct DirectJsonlSession {
     pub(crate) native_session_id: String,

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/qoder.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/qoder.rs
@@ -2,10 +2,13 @@ use ctx_history_core::CaptureProvider;
 
 use crate::QODER_SOURCE_FORMAT;
 
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v4";
+
 pub(crate) const fn qoder_source_backed_adapter() -> super::DirectJsonlFamilyAdapter {
     super::DirectJsonlFamilyAdapter::new(
         CaptureProvider::Qoder,
         QODER_SOURCE_FORMAT,
         "qoder-direct-native-jsonl-v1",
+        PARSER_REVISION,
     )
 }

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/qwen_code.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/qwen_code.rs
@@ -14,11 +14,14 @@ use super::super::result_content::{
     extract_direct_result_content, NativeJsonlResultExtractionError, NativeJsonlResultSubrecord,
 };
 
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v4";
+
 pub(crate) const fn qwen_code_source_backed_adapter() -> super::DirectJsonlFamilyAdapter {
     super::DirectJsonlFamilyAdapter::new(
         CaptureProvider::QwenCode,
         QWEN_CODE_SOURCE_FORMAT,
         "qwen-code-direct-native-jsonl-v1",
+        PARSER_REVISION,
     )
 }
 

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 
 use super::{
     reader::DirectJsonlProjector, DirectJsonlEvent, DirectJsonlRejection,
-    DirectJsonlRetryDiscriminator, DirectJsonlSession, DIRECT_JSONL_NATIVEPATH_PARSER_REVISION,
+    DirectJsonlRetryDiscriminator, DirectJsonlSession,
 };
 use crate::{
     common::io::{
@@ -77,6 +77,7 @@ pub(crate) struct DirectJsonlFamilyAdapter {
     provider: CaptureProvider,
     source_format: &'static str,
     schema_variant: &'static str,
+    parser_revision: &'static str,
 }
 
 impl DirectJsonlFamilyAdapter {
@@ -84,11 +85,13 @@ impl DirectJsonlFamilyAdapter {
         provider: CaptureProvider,
         source_format: &'static str,
         schema_variant: &'static str,
+        parser_revision: &'static str,
     ) -> Self {
         Self {
             provider,
             source_format,
             schema_variant,
+            parser_revision,
         }
     }
 
@@ -212,7 +215,7 @@ impl JsonlFamilyAdapter for DirectJsonlFamilyAdapter {
     }
 
     fn parser_revision(&self) -> &'static str {
-        DIRECT_JSONL_NATIVEPATH_PARSER_REVISION
+        self.parser_revision
     }
 
     fn append_mode(&self) -> JsonlFamilyAppendMode {
@@ -680,7 +683,7 @@ fn project_event(
         event.event_type.as_str(),
         session.agent_type.as_str(),
         session.is_primary,
-        DIRECT_JSONL_NATIVEPATH_PARSER_REVISION,
+        adapter.parser_revision,
         body,
     )?;
     record.parent_session_id = parent_session_id;

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed_result_tests.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed_result_tests.rs
@@ -2,8 +2,8 @@ use std::{collections::BTreeMap, path::Path};
 
 use chrono::{DateTime, Utc};
 use ctx_history_core::{
-    AgentType, CaptureProvider, CoreRecord, EventType, SessionStatus, TypedKey,
-    MAX_ENCODED_CORE_RECORD_BYTES,
+    core_record_leaf_sha256, AgentType, CaptureProvider, CoreRecord, EventType, SessionStatus,
+    TypedKey, MAX_ENCODED_CORE_RECORD_BYTES,
 };
 use serde_json::{json, Value};
 
@@ -91,13 +91,18 @@ fn native_subrecord_index(record: &CoreRecord) -> u64 {
 fn project_all(provider: CaptureProvider, values: &[Value]) -> (Vec<CoreRecord>, u64) {
     let adapter = adapter(provider);
     let session = session(provider);
+    let source_path = if provider == CaptureProvider::Windsurf {
+        format!("{}.jsonl", session.native_session_id)
+    } else {
+        "direct-jsonl-identity-contract.jsonl".to_owned()
+    };
     let (source, session_id) = adapter
         .session_identity(&session.native_session_id)
         .unwrap();
     let direct = DirectJsonlProjector::new(
         provider,
         adapter.source_format,
-        Path::new("direct-jsonl-identity-contract.jsonl"),
+        Path::new(&source_path),
         None,
         DateTime::<Utc>::UNIX_EPOCH,
         Some(session.clone()),
@@ -137,6 +142,66 @@ fn event_ids_by_body(records: &[CoreRecord]) -> BTreeMap<String, String> {
             )
         })
         .collect()
+}
+
+#[test]
+fn copilot_and_windsurf_replay_preserve_current_revision_ids_and_records() {
+    let cases = [
+        (
+            CaptureProvider::Windsurf,
+            json!({
+                "id": "windsurf-replay-event",
+                "type": "user_input",
+                "timestamp": "2026-08-03T12:34:56Z",
+                "user_input": {"user_response": "windsurf replay body"}
+            }),
+            "ac4f77cb-6658-8c1d-89fe-6d23fbf96fd0",
+            "6c78de65-0cee-8b0c-841f-56d0004e2af8",
+            "cb5a35bb-fb49-8701-8739-101eb01c524f",
+            "6e71cb85307368ff844c578c96c7744157b51de8dd8b1104475e350938fa4d6e",
+        ),
+        (
+            CaptureProvider::CopilotCli,
+            json!({
+                "id": "copilot-replay-event",
+                "type": "user.message",
+                "timestamp": "2026-08-03T12:34:56Z",
+                "data": {"content": "copilot replay body"}
+            }),
+            "c1ebd99c-7338-859b-891d-1c7e04d9ae9d",
+            "5ff93a01-4aa3-82f8-8d9e-784490016567",
+            "8d4627ce-c12c-8d64-af2d-d85ac722121f",
+            "3f32e8390eceecf11dbd66d8b6bd7cd522e3fdbbe9a2a001ba69ac65e0c561c7",
+        ),
+    ];
+
+    for (provider, value, event_id, session_id, source_id, record_leaf) in cases {
+        let adapter = adapter(provider);
+        assert_eq!(
+            JsonlFamilyAdapter::parser_revision(&adapter),
+            "direct-native-jsonl-parser-v4"
+        );
+        let (initial, rejected) = project_all(provider, std::slice::from_ref(&value));
+        assert_eq!(rejected, 0);
+        assert_eq!(initial.len(), 1);
+        let (replay, replay_rejected) = project_all(provider, std::slice::from_ref(&value));
+        assert_eq!(replay_rejected, 0);
+        assert_eq!(replay, initial);
+        let record = &initial[0];
+        assert_eq!(record.parser_revision, "direct-native-jsonl-parser-v4");
+        assert_eq!(record.event_id.to_string(), event_id, "{provider:?}");
+        assert_eq!(record.session_id.to_string(), session_id, "{provider:?}");
+        assert_eq!(
+            record.source.identity().to_string(),
+            source_id,
+            "{provider:?}"
+        );
+        assert_eq!(
+            core_record_leaf_sha256(record).unwrap(),
+            record_leaf,
+            "{provider:?}"
+        );
+    }
 }
 
 fn factory_result(id: &str, parent_id: Option<&str>, call_id: &str, body: &str) -> Value {

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/tabnine.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/tabnine.rs
@@ -3,11 +3,14 @@ use serde_json::Value;
 
 use crate::TABNINE_CLI_SOURCE_FORMAT;
 
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v4";
+
 pub(crate) const fn tabnine_source_backed_adapter() -> super::DirectJsonlFamilyAdapter {
     super::DirectJsonlFamilyAdapter::new(
         CaptureProvider::Tabnine,
         TABNINE_CLI_SOURCE_FORMAT,
         "tabnine-direct-native-jsonl-v1",
+        PARSER_REVISION,
     )
 }
 

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/windsurf.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/windsurf.rs
@@ -7,6 +7,8 @@ use crate::{
     provider::file_touches::normalized_key, WINDSURF_CASCADE_HOOK_TRANSCRIPT_SOURCE_FORMAT,
 };
 
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v4";
+
 pub(crate) fn windsurf_event_type(value: &Value) -> EventType {
     match value.get("type").and_then(Value::as_str) {
         Some("user_input" | "planner_response") => EventType::Message,
@@ -159,5 +161,6 @@ pub(crate) const fn windsurf_source_backed_adapter() -> super::DirectJsonlFamily
         CaptureProvider::Windsurf,
         WINDSURF_CASCADE_HOOK_TRANSCRIPT_SOURCE_FORMAT,
         "windsurf-direct-native-jsonl-v1",
+        PARSER_REVISION,
     )
 }

--- a/crates/ctx-history-capture/src/provider/providers/task_json/cline_nativepath/source.rs
+++ b/crates/ctx-history-capture/src/provider/providers/task_json/cline_nativepath/source.rs
@@ -36,6 +36,7 @@ pub(crate) struct TaskJsonNativeDialect {
     pub(crate) provider: CaptureProvider,
     pub(crate) source_format: &'static str,
     pub(crate) display_name: &'static str,
+    pub(crate) parser_revision: &'static str,
     metadata_files: &'static [(&'static str, ClineComponent)],
     message_files: &'static [(&'static str, ClineComponent)],
     root_index_file: Option<&'static str>,
@@ -46,6 +47,7 @@ impl TaskJsonNativeDialect {
         provider: CaptureProvider::Cline,
         source_format: CLINE_TASK_JSON_SOURCE_FORMAT,
         display_name: "Cline",
+        parser_revision: "task-json-source-backed-v3",
         metadata_files: &[(METADATA_FILE, ClineComponent::TaskMetadata)],
         message_files: &[
             (API_FILE, ClineComponent::ApiHistory),
@@ -58,6 +60,7 @@ impl TaskJsonNativeDialect {
         provider: CaptureProvider::RooCode,
         source_format: ROO_TASK_JSON_SOURCE_FORMAT,
         display_name: "Roo Code",
+        parser_revision: "task-json-source-backed-v3",
         // Roo's history item is the strongest identity/workspace authority.
         // `_index.json` fills metadata when the history item is absent.
         metadata_files: &[

--- a/crates/ctx-history-capture/src/provider/providers/task_json/cline_nativepath/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/providers/task_json/cline_nativepath/source_backed.rs
@@ -47,7 +47,6 @@ use support::*;
 const SOURCE_ANCHOR_NAMESPACE: &str = "task-directory-id";
 const SOURCE_SCHEMA_VARIANT: &str = "task-directory-v1";
 const SOURCE_REVISION_KIND: &str = "task-directory-compound-v1";
-const PARSER_REVISION: &str = "task-json-source-backed-v3";
 const LOGICAL_SESSION_KIND: &str = "task-json-thread";
 const LOGICAL_EVENT_KIND: &str = "task-json-event";
 const NATIVE_SESSION_NAMESPACE: &str = "task-json-task-id";
@@ -181,7 +180,7 @@ impl ReplacementDocumentTree for TaskJsonDocumentTreeAdapter {
     type TreeAuthority = TaskJsonTreeAuthority;
 
     fn parser_revision(&self) -> &'static str {
-        PARSER_REVISION
+        self.dialect.parser_revision
     }
 
     fn owns_source(&self, source: &SourceKey) -> bool {
@@ -617,7 +616,7 @@ fn project_event(
         event_kind(event.kind),
         AgentType::Primary.as_str(),
         true,
-        PARSER_REVISION,
+        dialect.parser_revision,
         lexical_event_body(&event),
     )?;
     record.provider_session_id = Some(provider_session_id.to_owned());
@@ -687,7 +686,7 @@ fn task_terminal(
         source: task.source,
         opening: task.observation.clone(),
         closing: task.observation,
-        parser_revision: PARSER_REVISION,
+        parser_revision: dialect.parser_revision,
         content_digest: task.content_digest.finalize().into(),
         counts: task.counts,
     })
@@ -718,4 +717,105 @@ fn task_route_error(error: TaskJsonSourceBackedError) -> SourceBackedRouteError 
         _ => SourceBackedRouteErrorKind::InvalidSource,
     };
     SourceBackedRouteError::new(kind, error.to_string())
+}
+
+#[cfg(test)]
+mod replay_tests {
+    use super::*;
+    use ctx_history_core::core_record_leaf_sha256;
+
+    use super::super::normalize::{
+        ClineEventComponent, ClineEventContext, ClineNativeItemKey, ClineSourceRecordEvidence,
+        ClineTaskIdentity,
+    };
+
+    fn project_replay_record(dialect: TaskJsonNativeDialect) -> CoreRecord {
+        let source = SourceKey::derive(
+            dialect.provider.as_str(),
+            dialect.source_format,
+            SOURCE_SCHEMA_VARIANT,
+            1,
+            SourceAnchor::provider_native(
+                SOURCE_ANCHOR_NAMESPACE,
+                TypedKey::utf8("task-json-replay-task").unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let task = ClineTaskIdentity::new("task-json-replay-task");
+        let item = ClineNativeItemKey::NativeId {
+            native_id: "task-json-replay-event".into(),
+            occurrence: 0,
+        };
+        let mut event = ClineEventRow::message(
+            ClineEventContext {
+                task: &task,
+                component: ClineEventComponent::ApiHistory,
+                item: &item,
+                item_index: 3,
+                role: ClineEventRole::Assistant,
+                occurred_at_millis: Some(1_754_227_696_000),
+            },
+            0,
+            ClineEventKind::Message,
+            "task-json replay body".to_owned(),
+        );
+        event.source_record = Some(ClineSourceRecordEvidence {
+            native_index: 3,
+            byte_start: 128,
+            byte_length: 64,
+            record_digest: [0x3c; 32],
+        });
+        let session_id = derive_task_session_id(&source, task.as_str()).unwrap();
+        project_event(
+            dialect,
+            &source,
+            [0xa5; 32],
+            session_id,
+            task.as_str(),
+            Some("/workspace/replay"),
+            event,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn cline_and_roo_replay_preserve_current_revision_ids_and_records() {
+        let cases = [
+            (
+                TaskJsonNativeDialect::CLINE,
+                "f29a3a4b-8b02-8b15-ad30-22b8d3e245e5",
+                "985dcf50-7cf6-85de-87cb-79a03269ff1e",
+                "13ba5b2e-3b34-8fbd-97c7-6647718d8504",
+                "516c346633985902b1066ea05d5e402ca500a2ab9802aa64356e263c3b70f9d3",
+            ),
+            (
+                TaskJsonNativeDialect::ROO,
+                "095b0fe0-c153-8364-b970-22637e99ce3e",
+                "15349de7-8b56-8e85-b075-3a9d9e01d7a1",
+                "7e7f3701-2c21-83b6-b6df-d9e4a7a4d805",
+                "7c9736643bb87876f755c9095ef3935610e7705e8729c0f9dbdc1727eb6d5d42",
+            ),
+        ];
+        for (dialect, event_id, session_id, source_id, record_leaf) in cases {
+            let adapter = TaskJsonDocumentTreeAdapter::new(dialect, &[]);
+            assert_eq!(
+                ReplacementDocumentTree::parser_revision(&adapter),
+                "task-json-source-backed-v3"
+            );
+            let initial = project_replay_record(dialect);
+            let replay = project_replay_record(dialect);
+            assert_eq!(replay, initial);
+            assert_eq!(initial.parser_revision, "task-json-source-backed-v3");
+            assert_eq!(initial.event_id.to_string(), event_id);
+            assert_eq!(initial.session_id.to_string(), session_id);
+            assert_eq!(initial.source.identity().to_string(), source_id);
+            assert_eq!(
+                core_record_leaf_sha256(&initial).unwrap(),
+                record_leaf,
+                "{:?}",
+                dialect.provider
+            );
+        }
+    }
 }

--- a/crates/ctx-history-capture/src/provider/providers/task_json/cline_nativepath/source_backed_tests.rs
+++ b/crates/ctx-history-capture/src/provider/providers/task_json/cline_nativepath/source_backed_tests.rs
@@ -4,7 +4,7 @@ fn direct_core_projection_is_complete_and_self_contained() {
     let production = sources.join("\n");
     assert!(production.contains("CoreRecord::new_selected"));
     assert!(production.contains("native_event_id = Some"));
-    assert!(production.contains("PARSER_REVISION"));
+    assert!(production.contains("dialect.parser_revision"));
     assert!(production.contains("validate_contract"));
     assert!(production.contains("lexical_event_body(&event)"));
     for removed_api in [


### PR DESCRIPTION
## Summary

Give each shared direct-native and task-JSON provider route independent parser-revision ownership before any provider-specific MCP attribution changes.

## Behavior

This is intentionally behavior-neutral: existing revision strings, event/session IDs, and complete Core-record digests are unchanged. It adds no MCP extraction or support claim.

## Validation

- 983 uncached capture tests passed
- replay locks cover revision, IDs, equality, and Core leaf digests
- rustfmt, Clippy with warnings denied, LOC, and diff hygiene passed
- independently reviewed: APPROVE

Part of the implementation follow-up to #206.