### PR TITLE
Expose the public Pro protocol authority

### DIFF
--- a/crates/ctx-history-core/src/core_record/repository.rs
+++ b/crates/ctx-history-core/src/core_record/repository.rs
@@ -98,7 +98,8 @@ impl RepositoryBinding {
         Ok(())
     }
 
-    pub(crate) fn accepts_pull_request(
+    #[must_use]
+    pub fn accepts_pull_request(
         &self,
         pull_request: &RepositoryPullRequestIdentity,
     ) -> bool {

--- a/crates/ctx-pro-host-protocol/BUILD.bazel
+++ b/crates/ctx-pro-host-protocol/BUILD.bazel
@@ -21,6 +21,11 @@ RUST_SRCS = glob(["src/**/*.rs"])
 
 CONFORMANCE_DATA = glob(["testdata/**/*.json"])
 
+PROTOCOL_AUTHORITY_DATA = [
+    "testdata/entitlement/v1/golden.json",
+    "testdata/v1/inventory.json",
+]
+
 filegroup(
     name = "entitlement_golden_vectors",
     srcs = glob(["testdata/entitlement/**/*.json"]),
@@ -40,6 +45,7 @@ rust_library(
     srcs = PROD_SRCS,
     crate_name = "ctx_pro_host_protocol",
     crate_root = "src/lib.rs",
+    compile_data = PROTOCOL_AUTHORITY_DATA,
     edition = crate_edition(),
     aliases = aliases(),
     deps = all_crate_deps(normal = True) + CTX_PRO_HOST_PROTOCOL_DEPS,

--- a/crates/ctx-pro-host-protocol/src/core_materialization.rs
+++ b/crates/ctx-pro-host-protocol/src/core_materialization.rs
@@ -631,7 +631,9 @@ impl CoreEventDelta {
         }
     }
 
-    fn record(&self) -> Option<&CoreRecord> {
+    /// Returns the immutable Core record carried by an add or replacement.
+    #[must_use]
+    pub fn record(&self) -> Option<&CoreRecord> {
         match self {
             Self::Added(record) => Some(record),
             Self::Replaced(replacement) => Some(&replacement.record),

--- a/crates/ctx-pro-host-protocol/src/core_materialization/event_delta_pages.rs
+++ b/crates/ctx-pro-host-protocol/src/core_materialization/event_delta_pages.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use super::{
-    core_source_delta_exact_eq, invalid_contract, validate_encoded_bound, validate_sha256,
+    core_source_delta_exact_eq, encoded_len, invalid_contract, validate_encoded_bound,
+    validate_sha256,
     CoreEventDelta, CoreEventDeltaPage, CoreEventDeltaPageApplied, ErrorClass, ProtocolError,
     SourceKey, MAX_CORE_CONTROL_WIRE_BYTES,
 };
@@ -21,7 +22,7 @@ pub struct ApplyCoreEventDeltaPagesRequest {
 
 impl ApplyCoreEventDeltaPagesRequest {
     pub fn validate(&self) -> Result<(), ProtocolError> {
-        self.validate_sequence(true)?;
+        validate_event_delta_page_envelope(self.pages.iter(), CoreEventDeltaPage::validate)?;
         validate_encoded_bound(
             self,
             MAX_CORE_EVENT_DELTA_PAGES_REQUEST_WIRE_BYTES,
@@ -29,75 +30,36 @@ impl ApplyCoreEventDeltaPagesRequest {
         )
     }
 
-    fn validate_sequence(&self, validate_pages: bool) -> Result<(), ProtocolError> {
-        if self.pages.is_empty() || self.pages.len() > MAX_CORE_EVENT_DELTA_PAGES {
+    /// Validates an ordered envelope of prepared pages using the complete
+    /// public page contract, including each page's compact JSON wire bound.
+    pub fn validate_prepared_envelope<'a>(
+        pages: impl ExactSizeIterator<Item = &'a CoreEventDeltaPage>,
+    ) -> Result<(), ProtocolError> {
+        let pages = pages.collect::<Vec<_>>();
+        validate_event_delta_page_envelope(
+            pages.iter().copied(),
+            CoreEventDeltaPage::validate,
+        )?;
+        let encoded_request_bytes = pages.iter().enumerate().try_fold(
+            b"{\"pages\":[]}".len(),
+            |total, (index, page)| -> Result<usize, ProtocolError> {
+                let page_bytes = encoded_len(*page)?;
+                total
+                    .checked_add(usize::from(index != 0))
+                    .and_then(|total| total.checked_add(page_bytes))
+                    .ok_or_else(|| {
+                        ProtocolError::new(
+                            ErrorClass::Bounds,
+                            "Core event delta page batch length overflowed",
+                        )
+                    })
+            },
+        )?;
+        if encoded_request_bytes > MAX_CORE_EVENT_DELTA_PAGES_REQUEST_WIRE_BYTES {
             return Err(ProtocolError::new(
                 ErrorClass::Bounds,
-                "Core event delta page batch has an invalid page count",
+                "Core event delta page batch exceeds its aggregate wire bound",
             ));
-        }
-
-        let first = &self.pages[0];
-        let mut prior_page_index = None;
-        let mut prior_event_id = None;
-        let mut prior_terminal = false;
-        let mut prior_source = None;
-        let mut prior_materialize_index = None;
-        let mut seen_sources = Vec::with_capacity(self.pages.len());
-        for (position, page) in self.pages.iter().enumerate() {
-            if validate_pages {
-                page.validate()?;
-            }
-            if page.materialization_id != first.materialization_id
-                || page.core_generation_id != first.core_generation_id
-            {
-                return Err(batch_sequence_error());
-            }
-            let source = page.reconciliation.delta.source().identity().digest();
-            let same_source = prior_source == Some(source);
-            if !same_source {
-                if seen_sources.contains(&source) {
-                    return Err(batch_sequence_error());
-                }
-                seen_sources.push(source);
-            }
-            if position != 0 {
-                if same_source {
-                    if prior_terminal
-                        || prior_page_index
-                            .is_some_and(|index: u32| index.checked_add(1) != Some(page.page_index))
-                        || prior_materialize_index != Some(page.reconciliation.materialize_index)
-                        || !core_source_delta_exact_eq(
-                            &page.reconciliation.delta,
-                            &self.pages[position - 1].reconciliation.delta,
-                        )
-                    {
-                        return Err(batch_sequence_error());
-                    }
-                } else {
-                    if !prior_terminal
-                        || page.page_index != 0
-                        || prior_materialize_index
-                            .is_some_and(|prior| prior >= page.reconciliation.materialize_index)
-                    {
-                        return Err(batch_sequence_error());
-                    }
-                    prior_event_id = None;
-                }
-            }
-            if let Some(first_delta) = page.deltas.first() {
-                let current = first_delta.event_id().digest();
-                if prior_event_id.is_some_and(|prior| prior >= current) {
-                    return Err(batch_sequence_error());
-                }
-            }
-            if let Some(last_delta) = page.deltas.last() {
-                prior_event_id = Some(last_delta.event_id().digest());
-            }
-            prior_page_index = Some(page.page_index);
-            prior_terminal = page.terminal;
-            prior_source = Some(source);
-            prior_materialize_index = Some(page.reconciliation.materialize_index);
         }
         Ok(())
     }
@@ -132,7 +94,13 @@ impl ApplyCoreEventDeltaPagesRequest {
         &self,
         encoded_request_bytes: usize,
     ) -> Result<CoreEventDeltaPagesAcknowledgementIdentity, ProtocolError> {
-        self.validate_sequence(false)?;
+        self.validate()?;
+        if encoded_request_bytes != encoded_len(self)? {
+            return Err(ProtocolError::new(
+                ErrorClass::InvalidRequest,
+                "prepared Core event delta page batch length does not match canonical JSON",
+            ));
+        }
         if encoded_request_bytes > MAX_CORE_EVENT_DELTA_PAGES_REQUEST_WIRE_BYTES {
             return Err(ProtocolError::new(
                 ErrorClass::Bounds,
@@ -151,6 +119,78 @@ impl ApplyCoreEventDeltaPagesRequest {
             pages,
         })
     }
+}
+
+fn validate_event_delta_page_envelope<'a>(
+    mut pages: impl ExactSizeIterator<Item = &'a CoreEventDeltaPage>,
+    validate_page: fn(&CoreEventDeltaPage) -> Result<(), ProtocolError>,
+) -> Result<(), ProtocolError> {
+    if pages.len() == 0 || pages.len() > MAX_CORE_EVENT_DELTA_PAGES {
+        return Err(ProtocolError::new(
+            ErrorClass::Bounds,
+            "Core event delta page batch has an invalid page count",
+        ));
+    }
+
+    let first = pages
+        .next()
+        .expect("non-empty Core event envelope was checked above");
+    validate_page(first)?;
+    let mut prior_page_index = first.page_index;
+    let mut prior_event_id = first.deltas.last().map(|delta| delta.event_id().digest());
+    let mut prior_terminal = first.terminal;
+    let mut prior_source = first.reconciliation.delta.source().identity().digest();
+    let mut prior_materialize_index = first.reconciliation.materialize_index;
+    let mut prior_reconciliation = &first.reconciliation.delta;
+    let mut seen_sources = vec![prior_source];
+    for page in pages {
+        validate_page(page)?;
+        if page.materialization_id != first.materialization_id
+            || page.core_generation_id != first.core_generation_id
+        {
+            return Err(batch_sequence_error());
+        }
+        let source = page.reconciliation.delta.source().identity().digest();
+        let same_source = prior_source == source;
+        if same_source {
+            if prior_terminal
+                || prior_page_index.checked_add(1) != Some(page.page_index)
+                || prior_materialize_index != page.reconciliation.materialize_index
+                || !core_source_delta_exact_eq(
+                    &page.reconciliation.delta,
+                    prior_reconciliation,
+                )
+            {
+                return Err(batch_sequence_error());
+            }
+        } else {
+            if seen_sources.contains(&source)
+                || !prior_terminal
+                || page.page_index != 0
+                || prior_materialize_index >= page.reconciliation.materialize_index
+            {
+                return Err(batch_sequence_error());
+            }
+            seen_sources.push(source);
+            prior_event_id = None;
+        }
+        if let Some(first_delta) = page.deltas.first() {
+            let current = first_delta.event_id().digest();
+            if prior_event_id.is_some_and(|prior| prior >= current) {
+                return Err(batch_sequence_error());
+            }
+        }
+        if let Some(last_delta) = page.deltas.last() {
+            prior_event_id = Some(last_delta.event_id().digest());
+        }
+        prior_page_index = page.page_index;
+        prior_terminal = page.terminal;
+        prior_source = source;
+        prior_materialize_index = page.reconciliation.materialize_index;
+        prior_reconciliation = &page.reconciliation.delta;
+    }
+
+    Ok(())
 }
 
 fn batch_sequence_error() -> ProtocolError {

--- a/crates/ctx-pro-host-protocol/src/core_materialization/tests.rs
+++ b/crates/ctx-pro-host-protocol/src/core_materialization/tests.rs
@@ -782,6 +782,32 @@ fn event_delta_page_batch_enforces_exact_aggregate_encoded_request_bound() {
 }
 
 #[test]
+fn prepared_event_delta_page_batch_checks_complete_pages_and_exact_length() {
+    let request = event_delta_pages_request(2, true);
+    let encoded_request_bytes = serde_json::to_vec(&request).unwrap().len();
+    ApplyCoreEventDeltaPagesRequest::validate_prepared_envelope(request.pages.iter()).unwrap();
+    request
+        .acknowledgement_identity_for_prepared_request(encoded_request_bytes)
+        .unwrap();
+    assert_eq!(
+        request
+            .acknowledgement_identity_for_prepared_request(encoded_request_bytes - 1)
+            .unwrap_err()
+            .class,
+        ErrorClass::InvalidRequest
+    );
+
+    let mut invalid = request;
+    invalid.pages[0].materialization_id = "not-a-digest".to_owned();
+    assert_eq!(
+        ApplyCoreEventDeltaPagesRequest::validate_prepared_envelope(invalid.pages.iter())
+            .unwrap_err()
+            .class,
+        ErrorClass::InvalidRequest
+    );
+}
+
+#[test]
 fn encoded_bound_counting_writer_matches_compact_json_bytes_and_errors() {
     let values = [
         serde_json::json!(null),

--- a/crates/ctx-pro-host-protocol/src/lib.rs
+++ b/crates/ctx-pro-host-protocol/src/lib.rs
@@ -1,7 +1,7 @@
 //! Exact, bounded Protocol V1 between the OSS `ctx` host and a local Pro helper.
 //!
-//! The public crate is the only wire authority. Private implementations mirror its
-//! generated inventory and fingerprint; they do not define a compatible range.
+//! The public crate is the only wire authority. Private products consume this
+//! crate and its generated inventory at one exact source revision.
 
 use serde::{Deserialize, Serialize};
 
@@ -18,6 +18,11 @@ pub const MAX_BLAME_EVIDENCE: usize = 3_200;
 pub const MAX_BLAME_ATTRIBUTIONS_PER_MATCH: usize = 100;
 pub const MAX_CITATIONS_PER_FACT: usize = 32;
 pub const MAX_BLAME_TARGET_BYTES: usize = 8 * 1024;
+/// Canonical generated Protocol V1 inventory shipped by this exact crate revision.
+pub const PROTOCOL_INVENTORY_JSON: &str = include_str!("../testdata/v1/inventory.json");
+/// Canonical entitlement vectors shipped by this exact crate revision.
+pub const ENTITLEMENT_GOLDEN_JSON: &str =
+    include_str!("../testdata/entitlement/v1/golden.json");
 
 mod entitlement;
 pub use entitlement::{
@@ -62,7 +67,8 @@ pub use message::{
 };
 mod query;
 pub use query::{
-    AgentAttribution, BlameContinuation, BlameMatch, BlameRequest, BlameResult, BlameTarget,
+    canonical_logical_repository_id, AgentAttribution, BlameContinuation, BlameMatch, BlameRequest,
+    BlameResult, BlameTarget,
     CommitBlameMatch, CommitFactType, CommitPredicate, ContinuationReason, FactConfidence,
     FactState, FileBlameMatch, GitSnapshot, LineRange, NumberedEvidence, ProductionRelationship,
     PullRequestAction, PullRequestActivity, PullRequestBlameMatch, PullRequestBlameRelationship,

--- a/crates/ctx-pro-host-protocol/src/query.rs
+++ b/crates/ctx-pro-host-protocol/src/query.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::{borrow::Cow, collections::BTreeSet};
 
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -949,24 +949,27 @@ fn commit_selector_matches(requested: &str, resolved: &str) -> bool {
 
 fn repository_selector_matches(requested: Option<&str>, resolved: &ResourceRef) -> bool {
     requested.is_none_or(|requested| {
-        normalized_repository_selector(requested)
-            == normalized_repository_selector(&resolved.display)
+        canonical_logical_repository_id(requested)
+            == canonical_logical_repository_id(&resolved.display)
     })
 }
 
-fn normalized_repository_selector(value: &str) -> String {
-    let value = value
+/// Canonicalizes only the ASCII case of the forge host in a logical
+/// repository identity. Every other byte remains identity-bearing.
+#[must_use]
+pub fn canonical_logical_repository_id(value: &str) -> Cow<'_, str> {
+    let Some((host, opaque_tail)) = value
         .strip_prefix("forge:")
-        .or_else(|| value.strip_prefix("https://"))
-        .unwrap_or(value)
-        .trim_end_matches('/');
-    let Some((host, path)) = value.split_once('/') else {
-        return value.to_owned();
+        .and_then(|identity| identity.split_once('/'))
+    else {
+        return Cow::Borrowed(value);
     };
-    if !host.contains('.') {
-        return value.to_owned();
+    let canonical_host = host.to_ascii_lowercase();
+    if canonical_host == host {
+        Cow::Borrowed(value)
+    } else {
+        Cow::Owned(format!("forge:{canonical_host}/{opaque_tail}"))
     }
-    format!("forge:{}/{path}", host.to_ascii_lowercase())
 }
 
 #[cfg(test)]

--- a/crates/ctx-pro-host-protocol/src/query/tests.rs
+++ b/crates/ctx-pro-host-protocol/src/query/tests.rs
@@ -36,3 +36,41 @@ fn repository_scope_distinguishes_omitted_empty_and_exact_identity() {
         } if repository == identity
     ));
 }
+
+#[test]
+fn logical_repository_canonicalization_only_lowercases_the_forge_host() {
+    assert_eq!(
+        canonical_logical_repository_id("forge:GitHub.COM/ctxrs/ctx?view=1#readme"),
+        "forge:github.com/ctxrs/ctx?view=1#readme"
+    );
+    for identity in [
+        "https://GitHub.COM/ctxrs/ctx",
+        "forge:github.com/ctxrs/ctx/",
+        "forge:github.com/ctxrs/ctx?view=1",
+        "forge:github.com/ctxrs/ctx#readme",
+        "workspace:CaseSensitiveRepo",
+    ] {
+        assert_eq!(canonical_logical_repository_id(identity), identity);
+    }
+}
+
+#[test]
+fn repository_scope_preserves_scheme_trailing_slash_query_and_fragment() {
+    let resolved = ResourceRef {
+        id: "repository:1".to_owned(),
+        kind: ResourceKind::Repository,
+        display: "forge:github.com/ctxrs/ctx".to_owned(),
+    };
+    assert!(repository_selector_matches(
+        Some("forge:GitHub.COM/ctxrs/ctx"),
+        &resolved
+    ));
+    for distinct in [
+        "https://github.com/ctxrs/ctx",
+        "forge:github.com/ctxrs/ctx/",
+        "forge:github.com/ctxrs/ctx?view=1",
+        "forge:github.com/ctxrs/ctx#readme",
+    ] {
+        assert!(!repository_selector_matches(Some(distinct), &resolved));
+    }
+}


### PR DESCRIPTION
## Summary

- expose the shared Core materialization/query helpers required by private consumers
- canonicalize repository bindings according to the public protocol contract
- validate exact encoded page and wire bounds at the public authority
- keep the generated public inventory and protocol fingerprint unchanged

This is the public prerequisite for deleting the private protocol mirror. The private repository will pin the exact public main commit after this lands.

## Validation

- ctx-history-core unit tests
- ctx-pro-host-protocol unit tests
- protocol inventory regeneration test
- independent semantic/wire review: clean, no P0-P2 findings
- independent release-chain review: public prerequisite clean; private-only follow-up findings are being fixed separately
- git diff --check