### PR TITLE
Make daemon refresh admission durable

### DIFF
--- a/crates/ctx-cli/src/cli.rs
+++ b/crates/ctx-cli/src/cli.rs
@@ -272,7 +272,10 @@ pub(crate) struct ImportArgs {
     pub(crate) resume: bool,
     #[arg(long, hide = true)]
     pub(crate) partial: bool,
-    #[arg(long, help = "Do not start daemon maintenance after import")]
+    #[arg(
+        long,
+        help = "Do not start or restart the daemon; require an already-running daemon"
+    )]
     pub(crate) no_daemon: bool,
     #[arg(long, value_enum, default_value_t = JsonOutputFormat::Text)]
     pub(crate) format: JsonOutputFormat,

--- a/crates/ctx-cli/src/commands/import/automatic_source_refresh.rs
+++ b/crates/ctx-cli/src/commands/import/automatic_source_refresh.rs
@@ -23,6 +23,10 @@ use super::{
 
 const MAX_REPORTED_SOURCE_FAILURES: usize = 3;
 
+fn published_request_scanned_routes(scanned_routes: Option<usize>) -> Result<usize> {
+    scanned_routes.context("published daemon source refresh omitted its scanned route count")
+}
+
 pub(super) struct AutomaticSourceRefreshImportContext<'a> {
     pub(super) args: &'a ImportArgs,
     pub(super) data_root: PathBuf,
@@ -71,6 +75,7 @@ pub(super) fn run_automatic_source_refresh_import(
         .context("daemon source refresh published without an authoritative terminal receipt")?;
     let request_previous_generation = refresh.request_previous_generation.clone();
     let request_generation_changed = refresh.request_generation_changed;
+    let scanned_routes = published_request_scanned_routes(refresh.scanned_routes)?;
     let request_id = refresh.request_id.clone();
     let index = refresh.pin.into_index();
     let manifest = index.manifest();
@@ -164,7 +169,7 @@ pub(super) fn run_automatic_source_refresh_import(
         "previous_generation": request_previous_generation,
         "published_generation": receipt.published_generation,
         "generation_changed": request_generation_changed,
-        "scanned_routes": receipt.selected_route_total(),
+        "scanned_routes": scanned_routes,
         "successful_routes": receipt.successful_route_total(),
         "source_failure_total": receipt.source_failure_total(),
         "source_failures_omitted": receipt.source_failures_omitted()
@@ -360,5 +365,11 @@ mod tests {
             assert!(row.get(unsupported).is_none(), "{row:#}");
         }
         assert_eq!(MAX_REPORTED_SOURCE_FAILURES, 3);
+    }
+
+    #[test]
+    fn logical_publication_reports_zero_scans_without_receipt_count_fallback() {
+        assert_eq!(published_request_scanned_routes(Some(0)).unwrap(), 0);
+        assert!(published_request_scanned_routes(None).is_err());
     }
 }

--- a/crates/ctx-cli/src/commands/import/explicit.rs
+++ b/crates/ctx-cli/src/commands/import/explicit.rs
@@ -265,7 +265,9 @@ pub(crate) fn run_explicit_source_catalog_import(
         "previous_generation": request_previous_generation,
         "published_generation": published_generation,
         "generation_changed": request_generation_changed,
-        "scanned_routes": receipt.selected_route_total(),
+        "scanned_routes": refresh
+            .scanned_routes
+            .context("published daemon source refresh omitted its scanned route count")?,
         "successful_routes": receipt.successful_route_total(),
         "source_failure_total": receipt.source_failure_total(),
         "route_source_failure_total": requested_outcome.source_failure_total,

--- a/crates/ctx-cli/src/commands/index.rs
+++ b/crates/ctx-cli/src/commands/index.rs
@@ -511,7 +511,10 @@ fn selected_pending_work(status: &Value, selection: IndexSelection) -> bool {
 }
 
 fn pending_state(state: &str) -> bool {
-    matches!(state, "pending" | "queued" | "running")
+    matches!(
+        state,
+        "admission_pending" | "pending" | "queued" | "running"
+    )
 }
 
 fn forward_index_terminal_error(message: String, human_output_rendered: bool) -> anyhow::Error {

--- a/crates/ctx-cli/src/commands/index_tests.rs
+++ b/crates/ctx-cli/src/commands/index_tests.rs
@@ -103,7 +103,8 @@ fn wait_selection(lexical: bool, semantic: bool, all: bool) -> IndexSelection {
 
 #[test]
 fn first_publication_pending_is_not_collapsed_to_missing() {
-    let status = first_publication_pending();
+    let mut status = first_publication_pending();
+    status["refresh"]["request_state"] = json!("admission_pending");
     let selection = IndexSelection::default_for(&status);
     assert!(!index_ready(&status, selection));
     assert!(
@@ -138,10 +139,16 @@ fn machine_snapshot_contains_only_authoritative_readiness_units() {
 
 #[test]
 fn explicit_lexical_wait_accepts_a_verified_generation_during_refresh() {
-    let pending = readiness("pending", 4, true);
+    let mut pending = readiness("pending", 4, true);
     let selection = wait_selection(true, false, false);
-    assert!(index_ready(&pending, selection));
-    assert!(index_terminal_error(&pending, selection).is_none());
+    for request_state in ["admission_pending", "queued", "running"] {
+        pending["refresh"]["request_state"] = json!(request_state);
+        assert!(index_ready(&pending, selection), "{request_state}");
+        assert!(
+            index_terminal_error(&pending, selection).is_none(),
+            "{request_state}"
+        );
+    }
 
     let mut failed = pending;
     failed["refresh"] = json!({
@@ -329,8 +336,8 @@ fn stopped_refresh_is_terminal_without_fabricated_failure_counts() {
 }
 
 #[test]
-fn stopped_queued_or_running_refresh_is_terminal_despite_stale_daemon_status() {
-    for request_state in ["queued", "running"] {
+fn stopped_active_refresh_is_terminal_despite_stale_daemon_status() {
+    for request_state in ["admission_pending", "queued", "running"] {
         let mut status = readiness("pending", 4, false);
         status["refresh"]["request_state"] = json!(request_state);
         status["daemon"]["status"] = json!("running");

--- a/crates/ctx-cli/src/commands/source_index/tests.rs
+++ b/crates/ctx-cli/src/commands/source_index/tests.rs
@@ -799,6 +799,7 @@ mod tests {
                     source_count: 0,
                     request_previous_generation: None,
                     request_generation_changed: false,
+                    scanned_routes: None,
                     receipt: None,
                     pin: PinnedSourceBackedGeneration::from_index(open_index(data_root)?),
                 })

--- a/crates/ctx-cli/src/semantic/daemon.rs
+++ b/crates/ctx-cli/src/semantic/daemon.rs
@@ -125,6 +125,7 @@ impl DaemonIteration {
 #[derive(Default)]
 pub(super) struct DaemonRuntime {
     pub(super) semantic_runtime: SharedSemanticRuntime,
+    pub(super) source_refresh_coordinator: Option<Arc<CoreRefreshEngine>>,
     pub(super) history_retry: DaemonRetryBackoff,
     pub(super) pro_retry: DaemonRetryBackoff,
     pub(super) semantic_retry: DaemonRetryBackoff,
@@ -337,6 +338,10 @@ pub(super) fn run_daemon_inner(
             restore_daemon_source_refresh_retry(&mut runtime, data_root);
             restore_daemon_consumer_retries(&mut runtime, data_root);
         }
+        // Recover the durable queue into the exact coordinator that will own
+        // IPC before publishing the source-refresh endpoint. Otherwise a
+        // restart-time admission could overwrite the unrecovered queue root.
+        recover_source_refresh_coordinator_before_ipc(&mut runtime, data_root)?;
         let stop_disabled = reload_daemon_runtime_config(
             data_root,
             &args,
@@ -372,13 +377,6 @@ pub(super) fn run_daemon_inner(
         if !runtime.config.daemon.mode.runs_only_source_refresh() {
             resume_completed_installation_daemons(data_root)?;
         }
-        recover_source_refresh_before_background_cadence(
-            &mut runtime,
-            data_root,
-            refresh_service
-                .as_ref()
-                .map(|service| service.source_refresh.as_ref()),
-        )?;
         write_daemon_lifecycle_status_with_runtime(
             data_root,
             &args,
@@ -809,7 +807,21 @@ fn recover_source_refresh_before_background_cadence(
     Ok(())
 }
 
-fn daemon_wait_duration(
+fn recover_source_refresh_coordinator_before_ipc(
+    runtime: &mut DaemonRuntime,
+    data_root: &Path,
+) -> Result<Arc<CoreRefreshEngine>> {
+    let source_refresh = Arc::new(CoreRefreshEngine::new());
+    recover_source_refresh_before_background_cadence(
+        runtime,
+        data_root,
+        Some(source_refresh.as_ref()),
+    )?;
+    runtime.source_refresh_coordinator = Some(Arc::clone(&source_refresh));
+    Ok(source_refresh)
+}
+
+pub(super) fn daemon_wait_duration(
     runtime: &DaemonRuntime,
     source_refresh: Option<&CoreRefreshEngine>,
     next_safety_reconcile: Instant,
@@ -817,6 +829,11 @@ fn daemon_wait_duration(
     idle_exit: Option<StdDuration>,
     now: Instant,
 ) -> StdDuration {
+    if runtime.history_retry.ready()
+        && source_refresh.is_some_and(CoreRefreshEngine::has_pending_request)
+    {
+        return StdDuration::ZERO;
+    }
     let mut wait_for = next_safety_reconcile.saturating_duration_since(now);
     if let Some(remaining) = runtime.consumer_retry_deferral.remaining(now) {
         wait_for = wait_for.min(remaining);

--- a/crates/ctx-cli/src/semantic/daemon/config_reload.rs
+++ b/crates/ctx-cli/src/semantic/daemon/config_reload.rs
@@ -14,7 +14,8 @@ use super::{
         paths_status::lower_semantic_worker_priority,
         query_service::{
             daemon_query_service_transport_supported, semantic_query_service_supported,
-            start_daemon_query_service, start_daemon_source_refresh_service, DaemonQueryService,
+            start_daemon_query_service, start_daemon_source_refresh_service,
+            start_daemon_source_refresh_service_with_coordinator, DaemonQueryService,
         },
     },
     DaemonRuntime,
@@ -137,11 +138,25 @@ pub(super) fn reload_daemon_runtime_config(
         semantic_query_service_supported() && daemon_query_service_transport_supported(),
     );
     if daemon_query_service_transport_supported() && refresh_service.is_none() {
-        match start_daemon_source_refresh_service(
-            data_root,
-            runtime.semantic_runtime.clone(),
-            Arc::clone(wakeup),
-        ) {
+        let source_refresh = runtime.source_refresh_coordinator.as_ref().cloned();
+        let started = source_refresh.map_or_else(
+            || {
+                start_daemon_source_refresh_service(
+                    data_root,
+                    runtime.semantic_runtime.clone(),
+                    Arc::clone(wakeup),
+                )
+            },
+            |source_refresh| {
+                start_daemon_source_refresh_service_with_coordinator(
+                    data_root,
+                    runtime.semantic_runtime.clone(),
+                    Arc::clone(wakeup),
+                    source_refresh,
+                )
+            },
+        );
+        match started {
             Ok(service) => *refresh_service = Some(service),
             Err(error) => {
                 reload.activation_failed(error);

--- a/crates/ctx-cli/src/semantic/daemon/tests.rs
+++ b/crates/ctx-cli/src/semantic/daemon/tests.rs
@@ -1,4 +1,6 @@
 mod recovery_cadence;
+#[path = "tests/startup_recovery.rs"]
+mod startup_recovery;
 
 use std::{
     cell::Cell,
@@ -965,6 +967,32 @@ fn due_dirty_route_wait_is_classified_as_scheduled_refresh_instead_of_spinning()
         now + super::super::daemon_scheduler::DAEMON_BACKGROUND_REFRESH_MIN_REST,
         1_000,
     ));
+}
+
+#[test]
+fn pending_source_refresh_wait_respects_retry_backoff() {
+    let coordinator =
+        CoreRefreshEngine::with_executor(Arc::new(|_: SourceBackedRefreshExecution<'_>| {
+            anyhow::bail!("executor must remain backed off")
+        }));
+    coordinator.enqueue_for_test(None);
+    let now = Instant::now();
+    let mut runtime = DaemonRuntime::default();
+    runtime.history_retry.consecutive_failures = 1;
+    runtime.history_retry.retry_not_before = Some(now + StdDuration::from_secs(5));
+    runtime.history_retry.retry_not_before_at_ms = Some(utc_now().timestamp_millis() + 5_000);
+
+    let wait_for = daemon_wait_duration(
+        &runtime,
+        Some(&coordinator),
+        now + StdDuration::from_secs(30),
+        None,
+        None,
+        now,
+    );
+
+    assert!(wait_for > StdDuration::from_secs(4));
+    assert!(wait_for <= StdDuration::from_secs(5));
 }
 
 #[test]

--- a/crates/ctx-cli/src/semantic/daemon/tests/startup_recovery.rs
+++ b/crates/ctx-cli/src/semantic/daemon/tests/startup_recovery.rs
@@ -1,0 +1,93 @@
+use super::*;
+
+#[cfg(any(unix, windows))]
+#[test]
+fn interrupted_queue_is_recovered_before_endpoint_accepts_a_new_admission() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root)?;
+
+    let interrupted = CoreRefreshEngine::new();
+    let predecessor = interrupted.enqueue_periodic(&data_root)?;
+    let predecessor_id = predecessor["request_id"]
+        .as_str()
+        .expect("interrupted request ID")
+        .to_owned();
+    interrupted.persist_job_status_for_test(&data_root, &predecessor_id)?;
+    drop(interrupted);
+    assert!(!daemon_service_endpoint_path(&data_root, DaemonIpcService::SourceRefresh).exists());
+
+    let config = AppConfig::default();
+    let mut runtime = DaemonRuntime {
+        config: config.clone(),
+        ..DaemonRuntime::default()
+    };
+    let startup_source_refresh =
+        recover_source_refresh_coordinator_before_ipc(&mut runtime, &data_root)?;
+    assert_eq!(
+        startup_source_refresh
+            .status_for_test(&predecessor_id)
+            .unwrap()["request_state"],
+        "queued"
+    );
+    assert!(!daemon_service_endpoint_path(&data_root, DaemonIpcService::SourceRefresh).exists());
+
+    let args = DaemonRunArgs {
+        foreground: false,
+        idle_exit_seconds: None,
+        loop_interval_seconds: None,
+        max_chunks: None,
+        max_seconds: None,
+        force: false,
+        start_mode: Some(DaemonStartModeArg::Auto),
+        trigger_command: Some(DaemonTriggerCommandArg::Search),
+        format: crate::output::JsonOutputFormat::Json,
+    };
+    let wakeup = Arc::new(DaemonWakeup::default());
+    let mut query_service = None;
+    let mut refresh_service = None;
+    let mut reload = DaemonConfigReloadState::pending(&config);
+    assert_eq!(
+        reload_daemon_runtime_config(
+            &data_root,
+            &args,
+            &mut runtime,
+            &mut query_service,
+            &mut refresh_service,
+            &mut reload,
+            &wakeup,
+        ),
+        DaemonConfigReloadOutcome::Continue
+    );
+    let service = refresh_service.as_ref().expect("source refresh service");
+    assert!(Arc::ptr_eq(
+        &service.source_refresh,
+        &startup_source_refresh
+    ));
+    assert!(daemon_service_endpoint_path(&data_root, DaemonIpcService::SourceRefresh).exists());
+
+    let successor_id = "019fcaaa-0000-7000-8000-000000000308";
+    let acknowledgement = daemon_source_refresh_request(
+        &data_root,
+        compact_json(json!({
+            "schema_version": 1,
+            "op": "source_refresh_request",
+            "request_id": successor_id,
+            "mode": "wait",
+            "operation": "refresh",
+            "fresh_after_admitted_snapshot": true,
+        })),
+        StdDuration::from_secs(1),
+        64 * 1024,
+    )?
+    .expect("new admission after recovery");
+    assert_eq!(acknowledgement["coalesced_into_request_id"], predecessor_id);
+
+    let durable = read_daemon_job_status(&daemon_core_refresh_job_path(&data_root))
+        .expect("recovered root plus new admission");
+    assert_eq!(durable["request_id"], predecessor_id);
+    assert_eq!(durable["queued_successors"][0]["request_id"], successor_id);
+    drop(query_service);
+    drop(refresh_service);
+    Ok(())
+}

--- a/crates/ctx-cli/src/semantic/daemon_scheduler.rs
+++ b/crates/ctx-cli/src/semantic/daemon_scheduler.rs
@@ -67,6 +67,9 @@ pub(super) fn run_daemon_scheduler_cycle_with_activity(
         if let Some(activity) = query_activity {
             activity.cancel_idle_wakeup();
         }
+        if source_refresh_requested && !runtime.history_retry.ready() {
+            return Ok(deferred_pending_core_refresh(data_root, runtime));
+        }
         if let Some(iteration) = run_pending_core_refresh(data_root, runtime, source_refresh)? {
             return Ok(iteration);
         }
@@ -77,6 +80,9 @@ pub(super) fn run_daemon_scheduler_cycle_with_activity(
         runtime.consumer_retry_deferral.reset();
         if let Some(activity) = query_activity {
             activity.cancel_idle_wakeup();
+        }
+        if !runtime.history_retry.ready() {
+            return Ok(deferred_pending_core_refresh(data_root, runtime));
         }
         return run_core_refresh(data_root, runtime, source_refresh, false);
     }
@@ -146,6 +152,11 @@ pub(super) fn run_daemon_scheduler_cycle_with_activity(
         return run_core_refresh(data_root, runtime, source_refresh, true);
     }
     run_dirty_core_refresh(data_root, runtime, source_refresh)
+}
+
+fn deferred_pending_core_refresh(data_root: &Path, runtime: &DaemonRuntime) -> DaemonIteration {
+    let job = core_refresh_retry_backoff_job(data_root, &runtime.history_retry);
+    DaemonIteration::new(false, false, daemon_core_cycle_state(&job))
 }
 
 fn run_pending_core_semantic_catch_up(
@@ -305,8 +316,13 @@ fn run_pending_core_refresh(
     let Some(run) = coordinator.run_next(data_root) else {
         return Ok(None);
     };
-    let job =
-        record_source_refresh_retry(data_root, &mut runtime.history_retry, coordinator, run.job)?;
+    let job = record_source_refresh_retry(
+        data_root,
+        &mut runtime.history_retry,
+        coordinator,
+        run.job,
+        run.terminal_persistence_pending,
+    )?;
     Ok(Some(DaemonIteration::new(
         run.did_work,
         run.failed || run.terminal_persistence_pending,
@@ -370,6 +386,7 @@ fn run_dirty_core_refresh(
         &mut runtime.history_retry,
         source_refresh,
         run.job,
+        terminal_persistence_pending,
     )?;
     let published_generation = (!run.failed
         && !terminal_persistence_pending
@@ -443,8 +460,13 @@ fn run_core_refresh(
         );
     };
     let terminal_persistence_pending = run.terminal_persistence_pending;
-    let job =
-        record_source_refresh_retry(data_root, &mut runtime.history_retry, coordinator, run.job)?;
+    let job = record_source_refresh_retry(
+        data_root,
+        &mut runtime.history_retry,
+        coordinator,
+        run.job,
+        terminal_persistence_pending,
+    )?;
     let failed = run.failed || terminal_persistence_pending;
     let state = daemon_core_cycle_state(&job);
     if !failed && job.get("status").and_then(Value::as_str) == Some("completed") {
@@ -825,11 +847,15 @@ fn record_source_refresh_retry(
     data_root: &Path,
     backoff: &mut DaemonRetryBackoff,
     coordinator: &CoreRefreshEngine,
-    job: Value,
+    mut job: Value,
+    status_persistence_pending: bool,
 ) -> Result<Value> {
+    if status_persistence_pending {
+        job["retryable"] = Value::Bool(true);
+    }
     let persist_retry = daemon_job_should_backoff(&job);
     let job = record_daemon_job_retry(backoff, job);
-    if persist_retry {
+    if persist_retry && !status_persistence_pending {
         return coordinator.persist_retry_status(data_root, job);
     }
     Ok(job)

--- a/crates/ctx-cli/src/semantic/daemon_scheduler_tests.rs
+++ b/crates/ctx-cli/src/semantic/daemon_scheduler_tests.rs
@@ -26,7 +26,7 @@ use crate::{
     config::{AppConfig, DaemonMode},
     output::JsonOutputFormat,
     semantic::{
-        daemon::{install_daemon_test_job_hooks, DaemonTestJobHooks},
+        daemon::{daemon_wait_duration, install_daemon_test_job_hooks, DaemonTestJobHooks},
         dirty_source_routes::EventWatermark,
         source_backed_refresh_coordinator::{
             coordinate_source_backed_refresh, source_backed_index_root, CoreRefreshEngine,
@@ -571,6 +571,19 @@ fn startup_seeded_manual_all_continuation_scans_each_route_once() {
         (request_id, runtime)
     });
 
+    let wait_started = std::time::Instant::now();
+    assert_eq!(
+        daemon_wait_duration(
+            &runtime,
+            Some(&coordinator),
+            wait_started + std::time::Duration::from_secs(30),
+            None,
+            None,
+            wait_started,
+        ),
+        std::time::Duration::ZERO,
+        "a successor exposed after the watcher-drain yield must remain immediately runnable"
+    );
     let successor = run_daemon_scheduler_cycle_with_activity(
         &daemon_args(),
         &data_root,

--- a/crates/ctx-cli/src/semantic/daemon_scheduler_tests/refresh_retry.rs
+++ b/crates/ctx-cli/src/semantic/daemon_scheduler_tests/refresh_retry.rs
@@ -15,6 +15,173 @@ fn enqueue_synthetic_refresh_successor(
         .expect("synthetic refresh successor")
 }
 
+fn make_history_retry_due(runtime: &mut DaemonRuntime) {
+    runtime.history_retry.retry_not_before = Some(std::time::Instant::now());
+    runtime.history_retry.retry_not_before_at_ms =
+        Some(ctx_history_core::utc_now().timestamp_millis());
+}
+
+#[test]
+fn persistent_admission_status_failure_uses_scheduler_backoff() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root).unwrap();
+    let fence_calls = Arc::new(AtomicUsize::new(0));
+    let observed_fence_calls = Arc::clone(&fence_calls);
+    let queued_writes = Arc::new(AtomicUsize::new(0));
+    let observed_queued_writes = Arc::clone(&queued_writes);
+    let coordinator = CoreRefreshEngine::with_runtime_for_test(
+        Arc::new(|_execution: SourceBackedRefreshExecution<'_>| {
+            panic!("admission persistence failure must stop before execution")
+        }),
+        Arc::new(move |_data_root, _catalog| {
+            observed_fence_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(BTreeMap::new())
+        }),
+        Arc::new(move |path, job| {
+            if job.get("request_state").and_then(Value::as_str) == Some("queued") {
+                observed_queued_writes.fetch_add(1, Ordering::SeqCst);
+                anyhow::bail!("injected persistent admission status failure");
+            }
+            write_daemon_job_status(path, job)
+        }),
+    );
+    let request_id = "019fcaaa-0000-7000-8000-0000000002b0";
+    coordinator
+        .handle_listener_ipc_request(
+            &data_root,
+            &json!({
+                "schema_version": 1,
+                "op": "source_refresh_request",
+                "request_id": request_id,
+                "mode": "wait",
+                "operation": "refresh",
+                "fresh_after_admitted_snapshot": true,
+            }),
+        )
+        .unwrap()
+        .expect("durable pending admission");
+    coordinator.finish_listener_admission_response(request_id);
+    let mut runtime = DaemonRuntime::default();
+    runtime.config.daemon.mode = DaemonMode::SourceRefreshOnly;
+
+    let first = run_daemon_scheduler_cycle_with_activity(
+        &daemon_args(),
+        &data_root,
+        &mut runtime,
+        None,
+        false,
+        None,
+        Some(&coordinator),
+    )
+    .unwrap();
+    assert!(first.failed);
+    assert_eq!(runtime.history_retry.consecutive_failures, 1);
+    assert_eq!(fence_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(queued_writes.load(Ordering::SeqCst), 1);
+
+    let deferred = run_daemon_scheduler_cycle_with_activity(
+        &daemon_args(),
+        &data_root,
+        &mut runtime,
+        None,
+        false,
+        None,
+        Some(&coordinator),
+    )
+    .unwrap();
+    assert!(!deferred.did_work);
+    assert_eq!(fence_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(queued_writes.load(Ordering::SeqCst), 1);
+
+    make_history_retry_due(&mut runtime);
+    let retry = run_daemon_scheduler_cycle_with_activity(
+        &daemon_args(),
+        &data_root,
+        &mut runtime,
+        None,
+        false,
+        None,
+        Some(&coordinator),
+    )
+    .unwrap();
+    assert!(retry.failed);
+    assert_eq!(runtime.history_retry.consecutive_failures, 2);
+    assert_eq!(fence_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(queued_writes.load(Ordering::SeqCst), 2);
+}
+
+#[test]
+fn persistent_terminal_status_failure_retries_without_reexecution_or_hot_spin() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root).unwrap();
+    let executions = Arc::new(AtomicUsize::new(0));
+    let observed_executions = Arc::clone(&executions);
+    let executor = Arc::new(move |execution: SourceBackedRefreshExecution<'_>| {
+        observed_executions.fetch_add(1, Ordering::SeqCst);
+        Ok(publish_empty_authoritative_generation(execution.index_root))
+    });
+    let terminal_writes = Arc::new(AtomicUsize::new(0));
+    let observed_terminal_writes = Arc::clone(&terminal_writes);
+    let writer = Arc::new(move |path: &Path, job: &Value| {
+        if job.get("request_state").and_then(Value::as_str) == Some("published") {
+            observed_terminal_writes.fetch_add(1, Ordering::SeqCst);
+            anyhow::bail!("injected persistent terminal status failure");
+        }
+        write_daemon_job_status(path, job)
+    });
+    let coordinator = CoreRefreshEngine::with_status_writer_for_test(executor, writer);
+    coordinator.enqueue_periodic(&data_root).unwrap();
+    let mut runtime = DaemonRuntime::default();
+    runtime.config.daemon.mode = DaemonMode::SourceRefreshOnly;
+
+    let first = run_daemon_scheduler_cycle_with_activity(
+        &daemon_args(),
+        &data_root,
+        &mut runtime,
+        None,
+        false,
+        None,
+        Some(&coordinator),
+    )
+    .unwrap();
+    assert!(first.failed);
+    assert_eq!(runtime.history_retry.consecutive_failures, 1);
+    assert_eq!(executions.load(Ordering::SeqCst), 1);
+    assert_eq!(terminal_writes.load(Ordering::SeqCst), 1);
+
+    let deferred = run_daemon_scheduler_cycle_with_activity(
+        &daemon_args(),
+        &data_root,
+        &mut runtime,
+        None,
+        false,
+        None,
+        Some(&coordinator),
+    )
+    .unwrap();
+    assert!(!deferred.did_work);
+    assert_eq!(executions.load(Ordering::SeqCst), 1);
+    assert_eq!(terminal_writes.load(Ordering::SeqCst), 1);
+
+    make_history_retry_due(&mut runtime);
+    let retry = run_daemon_scheduler_cycle_with_activity(
+        &daemon_args(),
+        &data_root,
+        &mut runtime,
+        None,
+        false,
+        None,
+        Some(&coordinator),
+    )
+    .unwrap();
+    assert!(retry.failed);
+    assert_eq!(runtime.history_retry.consecutive_failures, 2);
+    assert_eq!(executions.load(Ordering::SeqCst), 1);
+    assert_eq!(terminal_writes.load(Ordering::SeqCst), 2);
+}
+
 #[test]
 fn scheduler_retries_terminal_status_without_republishing_core() {
     let temp = tempfile::tempdir().unwrap();
@@ -119,6 +286,7 @@ fn scheduler_failed_terminal_retry_preserves_successor_across_restart() {
         &mut runtime.history_retry,
         &coordinator,
         retry.job,
+        false,
     )
     .unwrap();
     assert_eq!(recorded["queued_successors"].as_array().unwrap().len(), 2);
@@ -258,7 +426,8 @@ fn blocked_retry_writer_serializes_concurrent_admission_and_restart() {
     });
     let mut backoff = DaemonRetryBackoff::default();
     let recorded =
-        record_source_refresh_retry(&data_root, &mut backoff, &coordinator, retry.job).unwrap();
+        record_source_refresh_retry(&data_root, &mut backoff, &coordinator, retry.job, false)
+            .unwrap();
     assert_eq!(recorded["queued_successors"].as_array().unwrap().len(), 2);
     assert_eq!(executions.load(Ordering::SeqCst), 1);
     let before_restart = read_daemon_job_status(&daemon_core_refresh_job_path(&data_root)).unwrap();
@@ -361,6 +530,7 @@ fn failed_terminal_root_keeps_capacity_through_successful_retry_and_restart() {
         &mut runtime.history_retry,
         &coordinator,
         retry.job,
+        false,
     )
     .unwrap();
     assert_eq!(

--- a/crates/ctx-cli/src/semantic/paths_status.rs
+++ b/crates/ctx-cli/src/semantic/paths_status.rs
@@ -336,7 +336,26 @@ pub(super) fn lower_semantic_worker_priority() {
 #[cfg(not(unix))]
 pub(super) fn lower_semantic_worker_priority() {}
 
+#[derive(Debug, thiserror::Error)]
+#[error("private status replacement is visible or indeterminate")]
+pub(super) struct PrivateJsonReplacementError;
+
 pub(super) fn write_private_json_file(path: &Path, value: &Value) -> Result<()> {
+    write_private_json_file_with_permissions(path, value, secure_private_file_permissions)
+}
+
+#[cfg(test)]
+pub(super) fn write_private_json_with_chmod_fault(path: &Path, value: &Value) -> Result<()> {
+    write_private_json_file_with_permissions(path, value, |_| {
+        anyhow::bail!("injected chmod failure")
+    })
+}
+
+fn write_private_json_file_with_permissions(
+    path: &Path,
+    value: &Value,
+    secure: impl FnOnce(&Path) -> Result<()>,
+) -> Result<()> {
     if let Some(parent) = path.parent() {
         create_private_dir_all(parent)?;
     }
@@ -372,7 +391,27 @@ pub(super) fn write_private_json_file(path: &Path, value: &Value) -> Result<()> 
         let _ = fs::remove_file(&tmp_path);
         return Err(error);
     }
-    secure_private_file_permissions(path)?;
+    secure(path).map_err(|error| {
+        error
+            .context(format!("secure private status file {}", path.display()))
+            .context(PrivateJsonReplacementError)
+    })?;
+    Ok(())
+}
+
+#[cfg(not(windows))]
+pub(super) fn sync_private_file_parent(path: &Path) -> Result<()> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    fs::File::open(parent)
+        .with_context(|| format!("open private status directory {}", parent.display()))?
+        .sync_all()
+        .with_context(|| format!("sync private status directory {}", parent.display()))
+}
+
+#[cfg(windows)]
+pub(super) fn sync_private_file_parent(_path: &Path) -> Result<()> {
     Ok(())
 }
 

--- a/crates/ctx-cli/src/semantic/query_service.rs
+++ b/crates/ctx-cli/src/semantic/query_service.rs
@@ -37,7 +37,8 @@ pub(in crate::semantic) use server::*;
 #[cfg(not(test))]
 pub(in crate::semantic) use server::{
     daemon_can_begin_idle_shutdown, observe_daemon_query_activity, start_daemon_query_service,
-    start_daemon_source_refresh_service, DaemonQueryActivity, DaemonQueryService,
+    start_daemon_source_refresh_service, start_daemon_source_refresh_service_with_coordinator,
+    DaemonQueryActivity, DaemonQueryService,
 };
 
 const MAX_SEMANTIC_CORE_BATCH_BYTES: usize = 64 * 1024 * 1024;

--- a/crates/ctx-cli/src/semantic/query_service/server/dispatch.rs
+++ b/crates/ctx-cli/src/semantic/query_service/server/dispatch.rs
@@ -84,8 +84,19 @@ pub(in crate::semantic) fn handle_daemon_query_stream_inner<S: std::io::Write>(
     }
     let op = request.get("op").and_then(Value::as_str).unwrap_or("");
     if service == DaemonIpcService::SourceRefresh {
-        if let Some(response) = source_refresh.handle_ipc_request(data_root, &request)? {
-            writeln!(stream, "{}", serde_json::to_string(&response)?)?;
+        if let Some(response) = source_refresh.handle_listener_ipc_request(data_root, &request)? {
+            let response_request_id = response
+                .get("request_id")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            let response_write = (|| -> Result<()> {
+                writeln!(stream, "{}", serde_json::to_string(&response)?)?;
+                Ok(())
+            })();
+            if let Some(request_id) = response_request_id.as_deref() {
+                source_refresh.finish_listener_admission_response(request_id);
+            }
+            response_write?;
             return Ok(());
         }
         if op == "ping" {

--- a/crates/ctx-cli/src/semantic/query_service/server/transport.rs
+++ b/crates/ctx-cli/src/semantic/query_service/server/transport.rs
@@ -46,8 +46,24 @@ use super::{
 fn source_refresh_coordinator(
     _data_root: &Path,
     _service: DaemonIpcService,
+    coordinator: Option<Arc<CoreRefreshEngine>>,
 ) -> Result<Arc<CoreRefreshEngine>> {
-    Ok(Arc::new(CoreRefreshEngine::new()))
+    Ok(coordinator.unwrap_or_else(|| Arc::new(CoreRefreshEngine::new())))
+}
+
+fn wake_source_refresh_lifecycle(
+    service: DaemonIpcService,
+    source_refresh: &CoreRefreshEngine,
+    daemon_wakeup: Option<&DaemonWakeup>,
+) {
+    if service != DaemonIpcService::SourceRefresh {
+        return;
+    }
+    if source_refresh.has_pending_request() {
+        if let Some(daemon_wakeup) = daemon_wakeup {
+            daemon_wakeup.signal_ipc();
+        }
+    }
 }
 
 struct DaemonServiceThreadExit {
@@ -158,6 +174,7 @@ pub(in crate::semantic) fn start_daemon_query_service(
         DAEMON_QUERY_REQUEST_READ_TIMEOUT,
         DaemonIpcService::SemanticQuery,
         Some(wakeup),
+        None,
     )
 }
 
@@ -174,6 +191,7 @@ pub(in crate::semantic) fn start_daemon_query_service_with_request_timeout(
         request_read_timeout,
         DaemonIpcService::SemanticQuery,
         Some(Arc::new(DaemonWakeup::default())),
+        None,
     )
 }
 
@@ -189,6 +207,24 @@ pub(in crate::semantic) fn start_daemon_source_refresh_service(
         DAEMON_QUERY_REQUEST_READ_TIMEOUT,
         DaemonIpcService::SourceRefresh,
         Some(wakeup),
+        None,
+    )
+}
+
+#[cfg(unix)]
+pub(in crate::semantic) fn start_daemon_source_refresh_service_with_coordinator(
+    data_root: &Path,
+    runtime: SharedSemanticRuntime,
+    wakeup: Arc<DaemonWakeup>,
+    source_refresh: Arc<CoreRefreshEngine>,
+) -> Result<DaemonQueryService> {
+    start_daemon_service_with_request_timeout(
+        data_root,
+        runtime,
+        DAEMON_QUERY_REQUEST_READ_TIMEOUT,
+        DaemonIpcService::SourceRefresh,
+        Some(wakeup),
+        Some(source_refresh),
     )
 }
 
@@ -205,6 +241,24 @@ pub(in crate::semantic) fn start_daemon_source_refresh_service_with_request_time
         request_read_timeout,
         DaemonIpcService::SourceRefresh,
         Some(Arc::new(DaemonWakeup::default())),
+        None,
+    )
+}
+
+#[cfg(all(test, unix))]
+pub(in crate::semantic) fn start_daemon_source_refresh_service_with_coordinator_for_test(
+    data_root: &Path,
+    runtime: SharedSemanticRuntime,
+    request_read_timeout: StdDuration,
+    source_refresh: Arc<CoreRefreshEngine>,
+) -> Result<DaemonQueryService> {
+    start_daemon_service_with_request_timeout(
+        data_root,
+        runtime,
+        request_read_timeout,
+        DaemonIpcService::SourceRefresh,
+        Some(Arc::new(DaemonWakeup::default())),
+        Some(source_refresh),
     )
 }
 
@@ -215,6 +269,7 @@ fn start_daemon_service_with_request_timeout(
     request_read_timeout: StdDuration,
     service: DaemonIpcService,
     wakeup: Option<Arc<DaemonWakeup>>,
+    source_refresh_override: Option<Arc<CoreRefreshEngine>>,
 ) -> Result<DaemonQueryService> {
     let root = daemon_root_path(data_root);
     create_private_dir_all(&root)?;
@@ -249,7 +304,7 @@ fn start_daemon_service_with_request_timeout(
         DaemonQueryActivity::new()
     });
     let thread_activity = activity.clone();
-    let source_refresh = source_refresh_coordinator(data_root, service)?;
+    let source_refresh = source_refresh_coordinator(data_root, service, source_refresh_override)?;
     let thread_source_refresh = source_refresh.clone();
     let thread_wakeup = wakeup;
     let spawn_result = std::thread::Builder::new()
@@ -295,13 +350,11 @@ fn start_daemon_service_with_request_timeout(
                             request,
                             thread_wakeup.as_deref(),
                         );
-                        if service == DaemonIpcService::SourceRefresh
-                            && thread_source_refresh.has_pending_request()
-                        {
-                            if let Some(wakeup) = thread_wakeup.as_ref() {
-                                wakeup.signal_ipc();
-                            }
-                        }
+                        wake_source_refresh_lifecycle(
+                            service,
+                            &thread_source_refresh,
+                            thread_wakeup.as_deref(),
+                        );
                     }
                     Err(_) => break,
                 }
@@ -391,6 +444,7 @@ pub(in crate::semantic) fn start_daemon_query_service(
         DAEMON_QUERY_REQUEST_READ_TIMEOUT,
         DaemonIpcService::SemanticQuery,
         Some(wakeup),
+        None,
     )
 }
 
@@ -407,6 +461,7 @@ pub(in crate::semantic) fn start_daemon_query_service_with_request_timeout(
         request_read_timeout,
         DaemonIpcService::SemanticQuery,
         Some(Arc::new(DaemonWakeup::default())),
+        None,
     )
 }
 
@@ -422,6 +477,24 @@ pub(in crate::semantic) fn start_daemon_source_refresh_service(
         DAEMON_QUERY_REQUEST_READ_TIMEOUT,
         DaemonIpcService::SourceRefresh,
         Some(wakeup),
+        None,
+    )
+}
+
+#[cfg(windows)]
+pub(in crate::semantic) fn start_daemon_source_refresh_service_with_coordinator(
+    data_root: &Path,
+    runtime: SharedSemanticRuntime,
+    wakeup: Arc<DaemonWakeup>,
+    source_refresh: Arc<CoreRefreshEngine>,
+) -> Result<DaemonQueryService> {
+    start_daemon_service_with_request_timeout(
+        data_root,
+        runtime,
+        DAEMON_QUERY_REQUEST_READ_TIMEOUT,
+        DaemonIpcService::SourceRefresh,
+        Some(wakeup),
+        Some(source_refresh),
     )
 }
 
@@ -438,6 +511,24 @@ pub(in crate::semantic) fn start_daemon_source_refresh_service_with_request_time
         request_read_timeout,
         DaemonIpcService::SourceRefresh,
         Some(Arc::new(DaemonWakeup::default())),
+        None,
+    )
+}
+
+#[cfg(all(test, windows))]
+pub(in crate::semantic) fn start_daemon_source_refresh_service_with_coordinator_for_test(
+    data_root: &Path,
+    runtime: SharedSemanticRuntime,
+    request_read_timeout: StdDuration,
+    source_refresh: Arc<CoreRefreshEngine>,
+) -> Result<DaemonQueryService> {
+    start_daemon_service_with_request_timeout(
+        data_root,
+        runtime,
+        request_read_timeout,
+        DaemonIpcService::SourceRefresh,
+        Some(Arc::new(DaemonWakeup::default())),
+        Some(source_refresh),
     )
 }
 
@@ -448,6 +539,7 @@ fn start_daemon_service_with_request_timeout(
     request_read_timeout: StdDuration,
     service: DaemonIpcService,
     wakeup: Option<Arc<DaemonWakeup>>,
+    source_refresh_override: Option<Arc<CoreRefreshEngine>>,
 ) -> Result<DaemonQueryService> {
     let root = daemon_root_path(data_root);
     create_private_dir_all(&root)?;
@@ -475,7 +567,7 @@ fn start_daemon_service_with_request_timeout(
         DaemonQueryActivity::new()
     });
     let thread_activity = activity.clone();
-    let source_refresh = source_refresh_coordinator(data_root, service)?;
+    let source_refresh = source_refresh_coordinator(data_root, service, source_refresh_override)?;
     let thread_source_refresh = source_refresh.clone();
     let thread_wakeup = wakeup;
     let thread_pipe_name = pipe_name.clone();
@@ -519,13 +611,11 @@ fn start_daemon_service_with_request_timeout(
                     request,
                     thread_wakeup.as_deref(),
                 );
-                if service == DaemonIpcService::SourceRefresh
-                    && thread_source_refresh.has_pending_request()
-                {
-                    if let Some(wakeup) = thread_wakeup.as_ref() {
-                        wakeup.signal_ipc();
-                    }
-                }
+                wake_source_refresh_lifecycle(
+                    service,
+                    &thread_source_refresh,
+                    thread_wakeup.as_deref(),
+                );
             }
         });
     let thread = match spawn_result {
@@ -808,6 +898,18 @@ pub(in crate::semantic) fn start_daemon_source_refresh_service(
     _data_root: &Path,
     _runtime: SharedSemanticRuntime,
     _wakeup: Arc<DaemonWakeup>,
+) -> Result<DaemonQueryService> {
+    Err(anyhow!(
+        "daemon source refresh service is not supported on this platform"
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+pub(in crate::semantic) fn start_daemon_source_refresh_service_with_coordinator(
+    _data_root: &Path,
+    _runtime: SharedSemanticRuntime,
+    _wakeup: Arc<DaemonWakeup>,
+    _source_refresh: Arc<CoreRefreshEngine>,
 ) -> Result<DaemonQueryService> {
     Err(anyhow!(
         "daemon source refresh service is not supported on this platform"

--- a/crates/ctx-cli/src/semantic/query_service/transport.rs
+++ b/crates/ctx-cli/src/semantic/query_service/transport.rs
@@ -9,8 +9,12 @@ pub(in crate::semantic) enum DaemonQueryEndpoint {
     Unsupported,
 }
 
+mod submission;
 #[cfg(unix)]
 mod unix_response;
+#[cfg(windows)]
+use submission::mark_windows_pending_submission;
+use submission::{mark_request_may_have_been_submitted, request_may_have_been_submitted};
 #[cfg(unix)]
 pub(in crate::semantic) use unix_response::daemon_query_roundtrip_unix;
 #[cfg(all(test, unix))]
@@ -67,6 +71,12 @@ impl fmt::Display for DaemonSourceRefreshServiceUnavailable {
 }
 
 impl std::error::Error for DaemonSourceRefreshServiceUnavailable {}
+
+impl DaemonSourceRefreshServiceUnavailable {
+    pub(in crate::semantic) fn request_may_have_been_submitted(error: &anyhow::Error) -> bool {
+        request_may_have_been_submitted(error)
+    }
+}
 
 #[derive(Debug)]
 pub(in crate::semantic) struct DaemonQueryResponseTooLarge {
@@ -357,7 +367,9 @@ pub(in crate::semantic) fn daemon_service_request(
             }
             Err(error) => return Err(error),
         };
-    let response: Value = serde_json::from_str(&body).context("parse daemon query response")?;
+    let response: Value = serde_json::from_str(&body)
+        .context("parse daemon query response")
+        .map_err(mark_request_may_have_been_submitted)?;
     Ok(Some(response))
 }
 
@@ -374,7 +386,9 @@ pub(in crate::semantic) fn daemon_query_roundtrip(
                 return Err(DaemonQueryResponseTooLarge::new(0).into());
             }
             let body = daemon_query_roundtrip_unix(path, request, timeout, max_response_bytes)?;
-            String::from_utf8(body).context("daemon query response is not UTF-8")
+            String::from_utf8(body)
+                .context("daemon query response is not UTF-8")
+                .map_err(mark_request_may_have_been_submitted)
         }
         #[cfg(windows)]
         DaemonQueryEndpoint::WindowsNamedPipe { pipe_name, .. } => {
@@ -391,17 +405,23 @@ pub(in crate::semantic) fn daemon_query_roundtrip_error_is_unavailable(
     endpoint: &DaemonQueryEndpoint,
     error: &anyhow::Error,
 ) -> bool {
+    if request_may_have_been_submitted(error) {
+        return false;
+    }
     let Some(io_error) = error.downcast_ref::<std::io::Error>() else {
         return false;
     };
     match endpoint {
         #[cfg(unix)]
         DaemonQueryEndpoint::Unix { .. } => {
-            daemon_query_unix_io_error_is_unavailable(io_error.kind())
+            daemon_query_unix_io_error_is_pre_submission_unavailable(io_error.kind())
         }
         #[cfg(windows)]
         DaemonQueryEndpoint::WindowsNamedPipe { .. } => {
-            daemon_query_windows_io_error_is_unavailable(io_error.kind(), io_error.raw_os_error())
+            daemon_query_windows_io_error_is_pre_submission_unavailable(
+                io_error.kind(),
+                io_error.raw_os_error(),
+            )
         }
         #[cfg(not(any(unix, windows)))]
         DaemonQueryEndpoint::Unsupported => false,
@@ -409,7 +429,7 @@ pub(in crate::semantic) fn daemon_query_roundtrip_error_is_unavailable(
 }
 
 #[cfg(any(unix, test))]
-pub(in crate::semantic) fn daemon_query_unix_io_error_is_unavailable(
+pub(in crate::semantic) fn daemon_query_unix_io_error_is_pre_submission_unavailable(
     kind: std::io::ErrorKind,
 ) -> bool {
     matches!(
@@ -424,7 +444,7 @@ pub(in crate::semantic) fn daemon_query_unix_io_error_is_unavailable(
 }
 
 #[cfg(any(windows, test))]
-pub(in crate::semantic) fn daemon_query_windows_io_error_is_unavailable(
+pub(in crate::semantic) fn daemon_query_windows_io_error_is_pre_submission_unavailable(
     kind: std::io::ErrorKind,
     raw_os_error: Option<i32>,
 ) -> bool {
@@ -565,9 +585,24 @@ pub(in crate::semantic) fn daemon_query_roundtrip_windows(
     let deadline = WindowsIoDeadline::new(timeout);
     let pipe_name = windows_wide_null(pipe_name);
     let pipe = open_windows_daemon_query_pipe(&pipe_name, &deadline)?;
-    write_all_windows_daemon_query_pipe(&pipe, request, &deadline)?;
-    let response = read_windows_daemon_query_pipe(&pipe, response_limit, &deadline)?;
-    String::from_utf8(response).context("daemon query response is not UTF-8")
+    let mut request_may_have_been_submitted = false;
+    if let Err(error) = write_all_windows_daemon_query_pipe_with_submission(
+        &pipe,
+        request,
+        &deadline,
+        &mut request_may_have_been_submitted,
+    ) {
+        return Err(if request_may_have_been_submitted {
+            mark_request_may_have_been_submitted(error)
+        } else {
+            error
+        });
+    }
+    let response = read_windows_daemon_query_pipe(&pipe, response_limit, &deadline)
+        .map_err(mark_request_may_have_been_submitted)?;
+    String::from_utf8(response)
+        .context("daemon query response is not UTF-8")
+        .map_err(mark_request_may_have_been_submitted)
 }
 
 #[cfg(windows)]
@@ -669,18 +704,39 @@ pub(in crate::semantic) fn open_windows_daemon_query_pipe(
 #[cfg(windows)]
 pub(in crate::semantic) fn write_all_windows_daemon_query_pipe(
     pipe: &WindowsQueryHandle,
+    request: &[u8],
+    deadline: &WindowsIoDeadline,
+) -> Result<()> {
+    let mut request_may_have_been_submitted = false;
+    write_all_windows_daemon_query_pipe_with_submission(
+        pipe,
+        request,
+        deadline,
+        &mut request_may_have_been_submitted,
+    )
+}
+
+#[cfg(windows)]
+fn write_all_windows_daemon_query_pipe_with_submission(
+    pipe: &WindowsQueryHandle,
     mut request: &[u8],
     deadline: &WindowsIoDeadline,
+    request_may_have_been_submitted: &mut bool,
 ) -> Result<()> {
     use windows_sys::Win32::Storage::FileSystem::WriteFile;
 
     while !request.is_empty() {
         let write_len = request.len().min(u32::MAX as usize) as u32;
-        let written =
-            windows_overlapped_io(pipe, deadline, "write", |transferred, overlapped| unsafe {
+        let written = windows_overlapped_io(
+            pipe,
+            deadline,
+            "write",
+            Some(request_may_have_been_submitted),
+            |transferred, overlapped| unsafe {
                 WriteFile(pipe.0, request.as_ptr(), write_len, transferred, overlapped)
-            })
-            .context("write daemon query named pipe")?;
+            },
+        )
+        .context("write daemon query named pipe")?;
         if written == 0 {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::WriteZero,
@@ -688,6 +744,7 @@ pub(in crate::semantic) fn write_all_windows_daemon_query_pipe(
             ))
             .context("write daemon query named pipe");
         }
+        *request_may_have_been_submitted = true;
         request = &request[written as usize..];
     }
     Ok(())
@@ -711,8 +768,12 @@ pub(in crate::semantic) fn read_windows_daemon_query_pipe(
         let read_limit = (response_limit - response.len())
             .saturating_add(1)
             .min(chunk.len());
-        let read =
-            windows_overlapped_io(pipe, deadline, "read", |transferred, overlapped| unsafe {
+        let read = windows_overlapped_io(
+            pipe,
+            deadline,
+            "read",
+            None,
+            |transferred, overlapped| unsafe {
                 ReadFile(
                     pipe.0,
                     chunk.as_mut_ptr(),
@@ -720,7 +781,8 @@ pub(in crate::semantic) fn read_windows_daemon_query_pipe(
                     transferred,
                     overlapped,
                 )
-            });
+            },
+        );
         let read = match read {
             Ok(read) => read as usize,
             Err(error)
@@ -749,6 +811,7 @@ pub(in crate::semantic) fn windows_overlapped_io<F>(
     pipe: &WindowsQueryHandle,
     deadline: &WindowsIoDeadline,
     operation: &str,
+    pending_submission: Option<&mut bool>,
     start: F,
 ) -> std::io::Result<u32>
 where
@@ -778,6 +841,7 @@ where
     if error != ERROR_IO_PENDING {
         return Err(std::io::Error::from_raw_os_error(error as i32));
     }
+    mark_windows_pending_submission(pending_submission);
 
     let wait_ms = match deadline.remaining_ms(operation) {
         Ok(wait_ms) => wait_ms,
@@ -893,6 +957,7 @@ mod windows_query_transport_tests {
             1024,
         )
         .expect_err("stalled response must time out");
+        assert!(request_may_have_been_submitted(&error));
         assert!(format!("{error:#}").contains("timed out"));
         assert!(started.elapsed() < StdDuration::from_millis(450));
         server_thread.join().expect("server thread");

--- a/crates/ctx-cli/src/semantic/query_service/transport/submission.rs
+++ b/crates/ctx-cli/src/semantic/query_service/transport/submission.rs
@@ -1,0 +1,39 @@
+use std::fmt;
+
+use anyhow::Error;
+
+#[derive(Debug)]
+pub(super) struct DaemonQueryRequestMayHaveBeenSubmitted;
+
+impl fmt::Display for DaemonQueryRequestMayHaveBeenSubmitted {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("daemon query request may have been submitted")
+    }
+}
+
+impl std::error::Error for DaemonQueryRequestMayHaveBeenSubmitted {}
+
+pub(super) fn mark_request_may_have_been_submitted(error: Error) -> Error {
+    error.context(DaemonQueryRequestMayHaveBeenSubmitted)
+}
+
+pub(super) fn request_may_have_been_submitted(error: &Error) -> bool {
+    error
+        .downcast_ref::<DaemonQueryRequestMayHaveBeenSubmitted>()
+        .is_some()
+}
+
+#[cfg(windows)]
+pub(super) fn mark_windows_pending_submission(pending_submission: Option<&mut bool>) {
+    if let Some(pending_submission) = pending_submission {
+        *pending_submission = true;
+    }
+}
+
+#[cfg(test)]
+#[path = "submission_tests.rs"]
+mod tests;
+
+#[cfg(all(test, windows))]
+#[path = "windows_submission_tests.rs"]
+mod windows_tests;

--- a/crates/ctx-cli/src/semantic/query_service/transport/submission_tests.rs
+++ b/crates/ctx-cli/src/semantic/query_service/transport/submission_tests.rs
@@ -1,0 +1,45 @@
+use super::*;
+
+#[test]
+fn submission_marker_survives_context_and_preserves_the_transport_source() {
+    let error = std::io::Error::new(
+        std::io::ErrorKind::ConnectionReset,
+        "response connection reset",
+    );
+    let error = mark_request_may_have_been_submitted(error.into());
+
+    assert!(request_may_have_been_submitted(&error));
+    assert_eq!(
+        error
+            .downcast_ref::<std::io::Error>()
+            .map(std::io::Error::kind),
+        Some(std::io::ErrorKind::ConnectionReset)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn identical_disconnect_kind_is_unavailable_only_before_submission() {
+    use super::super::{daemon_query_roundtrip_error_is_unavailable, DaemonQueryEndpoint};
+
+    let endpoint = DaemonQueryEndpoint::Unix {
+        path: "/tmp/ctx-pre-submit-classification.sock".into(),
+        token: "0123456789abcdef0123456789abcdef".to_owned(),
+    };
+    let pre_submission = anyhow::Error::new(std::io::Error::new(
+        std::io::ErrorKind::ConnectionReset,
+        "connect reset",
+    ));
+    let post_submission = mark_request_may_have_been_submitted(anyhow::Error::new(
+        std::io::Error::new(std::io::ErrorKind::ConnectionReset, "response reset"),
+    ));
+
+    assert!(daemon_query_roundtrip_error_is_unavailable(
+        &endpoint,
+        &pre_submission
+    ));
+    assert!(!daemon_query_roundtrip_error_is_unavailable(
+        &endpoint,
+        &post_submission
+    ));
+}

--- a/crates/ctx-cli/src/semantic/query_service/transport/unix_response.rs
+++ b/crates/ctx-cli/src/semantic/query_service/transport/unix_response.rs
@@ -10,7 +10,7 @@ use std::{
 
 use anyhow::{Context, Result};
 
-use super::DaemonQueryResponseTooLarge;
+use super::{mark_request_may_have_been_submitted, DaemonQueryResponseTooLarge};
 
 const CONNECT_RETRY_BACKOFF: Duration = Duration::from_millis(2);
 
@@ -277,6 +277,7 @@ fn write_daemon_query_request_unix(
     stream: &mut UnixStream,
     request: &[u8],
     deadline: &UnixIoDeadline,
+    request_may_have_been_submitted: &mut bool,
 ) -> std::io::Result<()> {
     let mut written = 0;
     while written < request.len() {
@@ -288,7 +289,10 @@ fn write_daemon_query_request_unix(
                     "daemon query request socket stopped accepting bytes",
                 ));
             }
-            Ok(count) => written = written.saturating_add(count),
+            Ok(count) => {
+                *request_may_have_been_submitted = true;
+                written = written.saturating_add(count);
+            }
             Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
                 let _ = wait_for_fd(stream.as_raw_fd(), libc::POLLOUT, deadline, "request write")?;
@@ -345,11 +349,24 @@ pub(in crate::semantic) fn daemon_query_roundtrip_unix(
     let deadline = UnixIoDeadline::new(timeout);
     let mut stream = connect_daemon_query_unix(path, &deadline)
         .with_context(|| format!("connect daemon query socket {}", path.display()))?;
-    write_daemon_query_request_unix(&mut stream, request, &deadline)
-        .context("write daemon query request")?;
+    let mut request_may_have_been_submitted = false;
+    if let Err(error) = write_daemon_query_request_unix(
+        &mut stream,
+        request,
+        &deadline,
+        &mut request_may_have_been_submitted,
+    ) {
+        let error = anyhow::Error::from(error).context("write daemon query request");
+        return Err(if request_may_have_been_submitted {
+            mark_request_may_have_been_submitted(error)
+        } else {
+            error
+        });
+    }
     let _ = stream.shutdown(std::net::Shutdown::Write);
     read_daemon_query_response_unix_with_deadline(&mut stream, max_response_bytes, &deadline)
         .context("read daemon query response")
+        .map_err(mark_request_may_have_been_submitted)
 }
 
 #[cfg(test)]

--- a/crates/ctx-cli/src/semantic/query_service/transport/windows_submission_tests.rs
+++ b/crates/ctx-cli/src/semantic/query_service/transport/windows_submission_tests.rs
@@ -1,0 +1,23 @@
+use super::*;
+
+use super::super::daemon_query_roundtrip_windows;
+
+#[test]
+fn missing_named_pipe_is_definitely_pre_submission() {
+    let error = daemon_query_roundtrip_windows(
+        r"\\.\pipe\ctx-daemon-query-00000000000000000000000000000294",
+        b"{\"op\":\"ping\"}\n",
+        std::time::Duration::from_millis(100),
+        1024,
+    )
+    .expect_err("an uncreated named pipe must be unavailable before submission");
+
+    assert!(!request_may_have_been_submitted(&error));
+}
+
+#[test]
+fn pending_overlapped_write_is_ambiguous_before_cancellation() {
+    let mut may_have_been_submitted = false;
+    super::mark_windows_pending_submission(Some(&mut may_have_been_submitted));
+    assert!(may_have_been_submitted);
+}

--- a/crates/ctx-cli/src/semantic/query_service_transport_tests.rs
+++ b/crates/ctx-cli/src/semantic/query_service_transport_tests.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[path = "query_service_transport_tests/admission_lifecycle.rs"]
+mod admission_lifecycle;
+
 #[cfg(unix)]
 use std::io::Read as _;
 
@@ -761,7 +764,7 @@ fn unavailable_cleanup_waits_for_replacement_daemon_ownership() -> Result<()> {
 
 #[cfg(unix)]
 #[test]
-fn unix_disconnect_kinds_are_classified_as_unavailable() {
+fn unix_pre_submission_disconnect_kinds_are_classified_as_unavailable() {
     for kind in [
         std::io::ErrorKind::NotFound,
         std::io::ErrorKind::ConnectionRefused,
@@ -770,25 +773,29 @@ fn unix_disconnect_kinds_are_classified_as_unavailable() {
         std::io::ErrorKind::BrokenPipe,
         std::io::ErrorKind::NotConnected,
     ] {
-        assert!(daemon_query_unix_io_error_is_unavailable(kind));
+        assert!(daemon_query_unix_io_error_is_pre_submission_unavailable(
+            kind
+        ));
     }
-    assert!(!daemon_query_unix_io_error_is_unavailable(
+    assert!(!daemon_query_unix_io_error_is_pre_submission_unavailable(
         std::io::ErrorKind::TimedOut
     ));
 }
 
 #[test]
-fn windows_disconnect_codes_are_classified_without_native_io() {
+fn windows_pre_submission_disconnect_codes_are_classified_without_native_io() {
     for raw_os_error in [2, 3, 109, 230, 232, 233] {
-        assert!(daemon_query_windows_io_error_is_unavailable(
+        assert!(daemon_query_windows_io_error_is_pre_submission_unavailable(
             std::io::ErrorKind::Other,
             Some(raw_os_error),
         ));
     }
-    assert!(!daemon_query_windows_io_error_is_unavailable(
-        std::io::ErrorKind::TimedOut,
-        None,
-    ));
+    assert!(
+        !daemon_query_windows_io_error_is_pre_submission_unavailable(
+            std::io::ErrorKind::TimedOut,
+            None,
+        )
+    );
 }
 
 #[test]

--- a/crates/ctx-cli/src/semantic/query_service_transport_tests/admission_lifecycle.rs
+++ b/crates/ctx-cli/src/semantic/query_service_transport_tests/admission_lifecycle.rs
@@ -1,0 +1,259 @@
+use super::*;
+
+use std::{
+    collections::BTreeMap,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Barrier,
+    },
+};
+
+use anyhow::Context as _;
+
+use crate::semantic::{
+    daemon_wakeup::DaemonWakeup, source_backed_refresh_coordinator::CoreRefreshEngine,
+};
+
+fn private_data_root() -> Result<(tempfile::TempDir, PathBuf)> {
+    let temp = tempfile::tempdir()?;
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root)?;
+    Ok((temp, data_root))
+}
+
+fn successful_publication(generation_id: &str) -> SourceBackedRefreshPublication {
+    SourceBackedRefreshPublication {
+        generation_id: generation_id.to_owned(),
+        published_explicit_source_catalog: None,
+        unsupported_routes: 0,
+        certified_source_count: 0,
+        certified_source_bytes: 0,
+        current: Default::default(),
+        timings: Default::default(),
+        route_results: Vec::new(),
+        catalog_route_bindings: Vec::new(),
+        verified_index: None,
+    }
+}
+
+fn refresh_request(request_id: &str) -> Value {
+    compact_json(json!({
+        "schema_version": 1,
+        "op": "source_refresh_request",
+        "request_id": request_id,
+        "mode": "wait",
+        "operation": "refresh",
+        "fresh_after_admitted_snapshot": true,
+    }))
+}
+
+fn source_refresh_roundtrip(data_root: &Path, request: Value) -> Result<Value> {
+    daemon_source_refresh_request(data_root, request, StdDuration::from_secs(1), 64 * 1024)?
+        .ok_or_else(|| anyhow!("source refresh endpoint unavailable"))
+}
+
+#[cfg(any(unix, windows))]
+#[test]
+fn running_cold_periodic_all_and_manual_all_share_one_physical_executor() -> Result<()> {
+    let (_temp, data_root) = private_data_root()?;
+    let admission_entered = Arc::new(Barrier::new(2));
+    let admission_release = Arc::new(Barrier::new(2));
+    let fence_entered = Arc::clone(&admission_entered);
+    let fence_release = Arc::clone(&admission_release);
+    let coordinator = Arc::new(CoreRefreshEngine::with_admission_fence_for_test(Arc::new(
+        move |_data_root, _catalog| {
+            fence_entered.wait();
+            fence_release.wait();
+            Ok(BTreeMap::new())
+        },
+    )));
+    let periodic = coordinator.enqueue_periodic(&data_root)?;
+    let periodic_id = periodic["request_id"]
+        .as_str()
+        .expect("periodic request ID")
+        .to_owned();
+
+    let execution_entered = Arc::new(Barrier::new(2));
+    let execution_release = Arc::new(Barrier::new(2));
+    let runner_entered = Arc::clone(&execution_entered);
+    let runner_release = Arc::clone(&execution_release);
+    let execution_count = Arc::new(AtomicUsize::new(0));
+    let observed_executions = Arc::clone(&execution_count);
+    let runner_coordinator = Arc::clone(&coordinator);
+    let runner = std::thread::spawn(move || {
+        runner_coordinator.run_next_with(
+            move |_request_id, _coordinator| {
+                observed_executions.fetch_add(1, Ordering::SeqCst);
+                runner_entered.wait();
+                runner_release.wait();
+                Ok(successful_publication("cold-periodic-generation"))
+            },
+            || Ok(Some("cold-periodic-generation".to_owned())),
+            |_job| Ok(()),
+            |_error| Ok(()),
+        )
+    });
+    execution_entered.wait();
+
+    let service = start_daemon_source_refresh_service_with_coordinator_for_test(
+        &data_root,
+        SharedSemanticRuntime::default(),
+        TEST_QUERY_REQUEST_READ_TIMEOUT,
+        Arc::clone(&coordinator),
+    )?;
+    let planner_coordinator = Arc::clone(&coordinator);
+    let planner_data_root = data_root.clone();
+    let planner = std::thread::spawn(move || -> Result<()> {
+        let deadline = Instant::now() + StdDuration::from_secs(2);
+        loop {
+            if planner_coordinator.prepare_next_pending_admission(&planner_data_root)? {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(anyhow!(
+                    "admission planner was not released after acknowledgement"
+                ));
+            }
+            std::thread::sleep(StdDuration::from_millis(5));
+        }
+    });
+    let manual_id = "019fcaaa-0000-7000-8000-000000000294";
+    let acknowledged_at = Instant::now();
+    let acknowledgement = source_refresh_roundtrip(&data_root, refresh_request(manual_id))?;
+    let acknowledgement_elapsed = acknowledged_at.elapsed();
+
+    assert!(
+        acknowledgement_elapsed < StdDuration::from_millis(750),
+        "durable acknowledgement took {acknowledgement_elapsed:?}"
+    );
+    assert_eq!(acknowledgement["request_id"], manual_id);
+    assert_eq!(acknowledgement["request_state"], "admission_pending");
+    assert_eq!(
+        acknowledgement["disconnect_policy"],
+        "retain_after_durable_admission"
+    );
+    assert_eq!(acknowledgement["coalesced_into_request_id"], periodic_id);
+
+    admission_entered.wait();
+    let ping_started = Instant::now();
+    let ping = source_refresh_roundtrip(
+        &data_root,
+        compact_json(json!({"schema_version": 1, "op": "ping"})),
+    )?;
+    assert_eq!(ping["ok"], true);
+    assert!(ping_started.elapsed() < StdDuration::from_millis(500));
+    let status_started = Instant::now();
+    let planning_status = source_refresh_roundtrip(
+        &data_root,
+        compact_json(json!({
+            "schema_version": 1,
+            "op": "source_refresh_status",
+            "request_id": manual_id,
+        })),
+    )?;
+    assert_eq!(planning_status["request_state"], "admission_pending");
+    assert!(status_started.elapsed() < StdDuration::from_millis(500));
+
+    admission_release.wait();
+    planner
+        .join()
+        .expect("admission planner panicked")
+        .context("plan admitted manual demand")?;
+    let resolved_at = Instant::now();
+    while coordinator
+        .status_for_test(manual_id)
+        .is_some_and(|status| {
+            status["request_state"] == "admission_pending"
+                && resolved_at.elapsed() < StdDuration::from_secs(2)
+        })
+    {
+        std::thread::sleep(StdDuration::from_millis(5));
+    }
+    assert_eq!(
+        coordinator.status_for_test(manual_id).unwrap()["request_state"],
+        "queued"
+    );
+
+    execution_release.wait();
+    let periodic_run = runner
+        .join()
+        .expect("periodic runner panicked")
+        .expect("periodic physical run");
+    assert_eq!(periodic_run.job["request_id"], periodic_id);
+    assert_eq!(periodic_run.job["request_state"], "published");
+    assert_eq!(execution_count.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        coordinator.status_for_test(&periodic_id).unwrap()["coalesced_logical_demands"],
+        1
+    );
+
+    let logical = coordinator
+        .resolve_fully_covered_continuation_for_test(&data_root, |_catalog| Ok(BTreeMap::new()))
+        .expect("covered logical demand terminal result");
+    assert_eq!(logical.job["request_id"], manual_id);
+    assert_eq!(logical.job["request_state"], "published");
+    assert_eq!(logical.job["scanned_routes"], 0);
+    assert_eq!(execution_count.load(Ordering::SeqCst), 1);
+
+    drop(service);
+    Ok(())
+}
+
+struct BrokenResponseWriter;
+
+impl std::io::Write for BrokenResponseWriter {
+    fn write(&mut self, _bytes: &[u8]) -> std::io::Result<usize> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::BrokenPipe,
+            "client disconnected before acknowledgement",
+        ))
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn disconnected_client_does_not_cancel_a_durably_admitted_request() -> Result<()> {
+    let (_temp, data_root) = private_data_root()?;
+    let coordinator =
+        CoreRefreshEngine::with_admission_fence_for_test(Arc::new(|_data_root, _catalog| {
+            Ok(BTreeMap::new())
+        }));
+    let request_id = "019fcaaa-0000-7000-8000-000000000295";
+    let token = "0123456789abcdef0123456789abcdef";
+    let mut request = refresh_request(request_id);
+    request["token"] = Value::String(token.to_owned());
+
+    handle_daemon_query_stream(
+        &data_root,
+        &SharedSemanticRuntime::default(),
+        &coordinator,
+        DaemonIpcService::SourceRefresh,
+        token,
+        BrokenResponseWriter,
+        Ok(serde_json::to_string(&request)?),
+        Some(&DaemonWakeup::default()),
+    );
+
+    let admitted = coordinator
+        .status_for_test(request_id)
+        .expect("retained admission");
+    assert_eq!(admitted["request_state"], "admission_pending");
+    assert_eq!(
+        admitted["disconnect_policy"],
+        "retain_after_durable_admission"
+    );
+    assert!(coordinator.prepare_next_pending_admission(&data_root)?);
+    assert_eq!(
+        coordinator.status_for_test(request_id).unwrap()["request_state"],
+        "queued"
+    );
+    let durable = read_daemon_job_status(&daemon_source_backed_refresh_job_path(&data_root))
+        .expect("retained durable request");
+    assert_eq!(durable["request_id"], request_id);
+    assert_eq!(durable["request_state"], "queued");
+    Ok(())
+}

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/client.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/client.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+#[path = "client_observation_recovery.rs"]
+mod observation_recovery;
+use observation_recovery::{
+    request_bound_status_with_recovery, retained_request_unobservable, DISCONNECT_POLICY,
+};
+
 type SourceBackedRefreshProgressReporter<'a> =
     &'a mut dyn FnMut(&SourceBackedRefreshProgress) -> Result<()>;
 
@@ -37,24 +43,52 @@ pub(crate) struct SourceBackedRefreshObservation {
     pub(crate) source_count: usize,
     pub(crate) request_previous_generation: Option<String>,
     pub(crate) request_generation_changed: bool,
+    pub(crate) scanned_routes: Option<usize>,
     pub(crate) receipt: Option<SourceBackedRefreshReceipt>,
     pub(crate) pin: PinnedSourceBackedGeneration,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum SourceRefreshProtocolState {
+    AdmissionPending,
     Queued,
     Running,
     Published,
     Failed,
 }
 
+const AMBIGUOUS_ADMISSION_RECOVERY_ATTEMPT_LIMIT: usize = 3;
 const TYPED_UNKNOWN_RECOVERY_ATTEMPT_LIMIT: usize = 3;
+
+#[derive(Debug)]
+struct SourceRefreshAdmissionRecoveryFailed {
+    request_id: String,
+    recovery_attempts: usize,
+}
+
+impl fmt::Display for SourceRefreshAdmissionRecoveryFailed {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "daemon source refresh admission acknowledgement for {} remains unresolved after {} same-request recovery attempts; the request may be durably admitted and disconnect does not cancel it",
+            self.request_id, self.recovery_attempts
+        )
+    }
+}
+
+impl std::error::Error for SourceRefreshAdmissionRecoveryFailed {}
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(super) enum SourceRefreshRequestRecoveryFailureReason {
     AttemptsExhausted,
     RequestIdChanged,
+    ReenqueueFailed,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(super) enum SourceRefreshRequestRetention {
+    NotRetained,
+    MayBeRetained,
 }
 
 #[derive(Debug)]
@@ -62,6 +96,9 @@ pub(super) struct SourceRefreshRequestRecoveryFailed {
     pub(super) request_id: String,
     pub(super) recovery_attempts: usize,
     pub(super) reason: SourceRefreshRequestRecoveryFailureReason,
+    pub(super) retention: SourceRefreshRequestRetention,
+    pub(super) disconnect_policy: Option<&'static str>,
+    pub(super) detail: Option<String>,
 }
 
 impl fmt::Display for SourceRefreshRequestRecoveryFailed {
@@ -73,12 +110,31 @@ impl fmt::Display for SourceRefreshRequestRecoveryFailed {
             SourceRefreshRequestRecoveryFailureReason::RequestIdChanged => {
                 "typed unknown-request recovery returned a different logical request ID"
             }
+            SourceRefreshRequestRecoveryFailureReason::ReenqueueFailed => {
+                "same-ID recovery could not durably re-admit the logical request"
+            }
         };
         write!(
             formatter,
-            "daemon source refresh request {} was lost after {} recovery attempts: {reason}",
+            "daemon source refresh request {} could not be conclusively recovered after {} recovery attempts: {reason}",
             self.request_id, self.recovery_attempts
-        )
+        )?;
+        match self.retention {
+            SourceRefreshRequestRetention::NotRetained => {
+                formatter.write_str("; request_retained=false")?;
+            }
+            SourceRefreshRequestRetention::MayBeRetained => {
+                write!(
+                    formatter,
+                    "; request_retained=unknown; disconnect_policy={}",
+                    self.disconnect_policy.unwrap_or(DISCONNECT_POLICY)
+                )?;
+            }
+        }
+        if let Some(detail) = self.detail.as_deref() {
+            write!(formatter, ": {detail}")?;
+        }
+        Ok(())
     }
 }
 
@@ -100,6 +156,9 @@ impl TypedUnknownRequestRecovery {
                 request_id: request_id.to_owned(),
                 recovery_attempts: self.attempts,
                 reason: SourceRefreshRequestRecoveryFailureReason::AttemptsExhausted,
+                retention: SourceRefreshRequestRetention::NotRetained,
+                disconnect_policy: None,
+                detail: None,
             }
             .into());
         }
@@ -119,9 +178,14 @@ impl TypedUnknownRequestRecovery {
     ) -> Result<String> {
         if recovered_request_id != previous_request_id {
             return Err(SourceRefreshRequestRecoveryFailed {
-                request_id: recovered_request_id,
+                request_id: previous_request_id.to_owned(),
                 recovery_attempts: self.attempts,
                 reason: SourceRefreshRequestRecoveryFailureReason::RequestIdChanged,
+                retention: SourceRefreshRequestRetention::NotRetained,
+                disconnect_policy: None,
+                detail: Some(format!(
+                    "recovery response named logical request {recovered_request_id}"
+                )),
             }
             .into());
         }
@@ -141,8 +205,68 @@ where
 {
     let backoff = recovery.begin_attempt(request_id)?;
     sleep(backoff);
-    let recovered_request_id = reenqueue()?;
+    let recovered_request_id = reenqueue().map_err(|error| {
+        let retention = if error
+            .downcast_ref::<SourceRefreshAdmissionRecoveryFailed>()
+            .is_some()
+        {
+            SourceRefreshRequestRetention::MayBeRetained
+        } else {
+            SourceRefreshRequestRetention::NotRetained
+        };
+        SourceRefreshRequestRecoveryFailed {
+            request_id: request_id.to_owned(),
+            recovery_attempts: recovery.attempts,
+            reason: SourceRefreshRequestRecoveryFailureReason::ReenqueueFailed,
+            retention,
+            disconnect_policy: (retention == SourceRefreshRequestRetention::MayBeRetained)
+                .then_some(DISCONNECT_POLICY),
+            detail: Some(format!("{error:#}")),
+        }
+    })?;
     recovery.accept_recovered_request_id(request_id, recovered_request_id)
+}
+
+fn request_admission_with_recovery<S, R>(
+    request_id: &str,
+    mut sleep: S,
+    mut roundtrip: R,
+) -> Result<Option<Value>>
+where
+    S: FnMut(StdDuration),
+    R: FnMut() -> Result<Option<Value>>,
+{
+    match roundtrip() {
+        Ok(response) => return Ok(response),
+        Err(error)
+            if error
+                .downcast_ref::<DaemonSourceRefreshServiceUnavailable>()
+                .is_some() =>
+        {
+            return Err(error)
+        }
+        Err(error)
+            if DaemonSourceRefreshServiceUnavailable::request_may_have_been_submitted(&error) => {}
+        Err(error) => return Err(error),
+    }
+
+    for recovery_attempt in 0..AMBIGUOUS_ADMISSION_RECOVERY_ATTEMPT_LIMIT {
+        let backoff = match recovery_attempt {
+            0 => StdDuration::from_millis(25),
+            1 => StdDuration::from_millis(50),
+            _ => StdDuration::from_millis(100),
+        };
+        sleep(backoff);
+        if let Ok(Some(response)) = roundtrip() {
+            return Ok(Some(response));
+        }
+    }
+
+    Err(SourceRefreshAdmissionRecoveryFailed {
+        request_id: request_id.to_owned(),
+        recovery_attempts: AMBIGUOUS_ADMISSION_RECOVERY_ATTEMPT_LIMIT,
+    }
+    .into())
 }
 
 /// Coordinates source-backed refresh without ever falling back to a foreground
@@ -224,6 +348,7 @@ fn coordinate_source_backed_refresh_with_catalog(
             source_count: 0,
             request_previous_generation: None,
             request_generation_changed: false,
+            scanned_routes: None,
             receipt: None,
             pin,
         });
@@ -241,28 +366,43 @@ fn coordinate_source_backed_refresh_with_catalog(
     }
 
     let logical_request_id = Uuid::now_v7().to_string();
-    let response = match send_wait_authority_request(
+    let admission_request = wait_authority_request_json(
         data_root,
         &logical_request_id,
         mode,
         operation,
         explicit_source_catalog,
         fresh_after_admitted_snapshot,
-    ) {
-        Ok(Some(response)) => response,
-        Ok(None) => return daemon_unavailable_fallback(data_root, mode, None),
-        Err(error)
-            if error
-                .downcast_ref::<DaemonSourceRefreshServiceUnavailable>()
-                .is_some() =>
-        {
-            return daemon_unavailable_fallback(data_root, mode, Some(error))
-        }
-        Err(error) => return Err(error.context("request daemon-owned source-backed refresh")),
-    };
+    )?;
+    let response =
+        match request_admission_with_recovery(&logical_request_id, std::thread::sleep, || {
+            daemon_source_refresh_request(
+                data_root,
+                admission_request.clone(),
+                SOURCE_REFRESH_IPC_TIMEOUT,
+                SOURCE_REFRESH_RESPONSE_MAX_BYTES,
+            )
+        }) {
+            Ok(Some(response)) => response,
+            Ok(None) => return daemon_unavailable_fallback(data_root, mode, None),
+            Err(error)
+                if error
+                    .downcast_ref::<DaemonSourceRefreshServiceUnavailable>()
+                    .is_some() =>
+            {
+                return daemon_unavailable_fallback(data_root, mode, Some(error))
+            }
+            Err(error) => return Err(error),
+        };
     validate_daemon_refresh_response(&response)?;
-    let request_id = response_request_id(&response, "daemon source refresh response")?;
-    validate_source_refresh_status_response_authority(&response, &request_id)?;
+    let accepted_request_id = response_request_id(&response, "daemon source refresh response")?;
+    let request_id = if fresh_after_admitted_snapshot {
+        validate_source_refresh_status_response_authority(&response, &logical_request_id)?;
+        logical_request_id
+    } else {
+        validate_source_refresh_status_response_authority(&response, &accepted_request_id)?;
+        accepted_request_id
+    };
     source_refresh_protocol_state(&response)?;
 
     if mode == SourceBackedRefreshMode::Background {
@@ -283,6 +423,7 @@ fn coordinate_source_backed_refresh_with_catalog(
             source_count: response_source_count(&response),
             request_previous_generation: None,
             request_generation_changed: false,
+            scanned_routes: None,
             receipt: None,
             pin,
         });
@@ -351,18 +492,28 @@ fn wait_for_published_generation_inner(
     let mut last_reported_progress = None;
     let mut last_reported_at = None;
     loop {
-        let response = match daemon_source_refresh_request(
-            data_root,
-            compact_json(json!({
-                "schema_version": 1,
-                "op": SOURCE_REFRESH_STATUS_OP,
-                "request_id": request_id,
-            })),
-            SOURCE_REFRESH_IPC_TIMEOUT,
-            SOURCE_REFRESH_RESPONSE_MAX_BYTES,
+        let status_request = compact_json(json!({
+            "schema_version": 1,
+            "op": SOURCE_REFRESH_STATUS_OP,
+            "request_id": request_id,
+        }));
+        let response = match request_bound_status_with_recovery(
+            &request_id,
+            std::thread::sleep,
+            || {
+                daemon_source_refresh_request(
+                    data_root,
+                    status_request.clone(),
+                    SOURCE_REFRESH_IPC_TIMEOUT,
+                    SOURCE_REFRESH_RESPONSE_MAX_BYTES,
+                )
+            },
         ) {
             Ok(Some(response)) => response,
             Ok(None) => {
+                if !allow_daemon_autostart {
+                    return Err(retained_request_unobservable(&request_id, 0));
+                }
                 request_id = recover_wait_refresh_request(
                     data_root,
                     &request_id,
@@ -381,6 +532,9 @@ fn wait_for_published_generation_inner(
                     .downcast_ref::<DaemonSourceRefreshServiceUnavailable>()
                     .is_some() =>
             {
+                if !allow_daemon_autostart {
+                    return Err(retained_request_unobservable(&request_id, 0));
+                }
                 request_id = recover_wait_refresh_request(
                     data_root,
                     &request_id,
@@ -479,6 +633,13 @@ fn wait_for_published_generation_inner(
                     })?;
                 let request_previous_generation =
                     optional_generation(response.get("previous_generation"))?;
+                let scanned_routes = response
+                    .get("scanned_routes")
+                    .and_then(Value::as_u64)
+                    .and_then(|value| usize::try_from(value).ok())
+                    .ok_or_else(|| {
+                        anyhow!("published daemon source refresh has no scanned route count")
+                    })?;
                 return Ok(SourceBackedRefreshObservation {
                     mode,
                     status: "published".to_owned(),
@@ -487,6 +648,7 @@ fn wait_for_published_generation_inner(
                     source_count: response_source_count(&response),
                     request_previous_generation,
                     request_generation_changed,
+                    scanned_routes: Some(scanned_routes),
                     receipt: Some(receipt),
                     pin,
                 });
@@ -494,7 +656,9 @@ fn wait_for_published_generation_inner(
             SourceRefreshProtocolState::Failed => {
                 return failed_refresh_response(&response);
             }
-            SourceRefreshProtocolState::Queued | SourceRefreshProtocolState::Running => {
+            SourceRefreshProtocolState::AdmissionPending
+            | SourceRefreshProtocolState::Queued
+            | SourceRefreshProtocolState::Running => {
                 std::thread::sleep(SOURCE_REFRESH_POLL_INTERVAL);
             }
         }
@@ -587,32 +751,33 @@ fn recover_wait_refresh_request(
     allow_daemon_autostart: bool,
 ) -> Result<String> {
     if !allow_daemon_autostart {
-        return Err(SourceBackedRefreshDaemonUnavailable::new(Some(
-            "the explicit source import disabled daemon autostart".to_owned(),
-        ))
-        .into());
+        return Err(retained_request_unobservable(request_id, 0));
     }
-    let config =
-        AppConfig::load(data_root).context("load daemon configuration for refresh recovery")?;
-    if !config.daemon.enabled {
-        return Err(SourceBackedRefreshDaemonUnavailable::new(Some(
-            "daemon was disabled while waiting for source refresh".to_owned(),
+    let recovery = (|| {
+        let config =
+            AppConfig::load(data_root).context("load daemon configuration for refresh recovery")?;
+        if !config.daemon.enabled {
+            bail!("daemon was disabled while waiting for source refresh");
+        }
+        super::super::daemon_autostart::autostart_daemon_and_wait(
+            data_root,
+            &config,
+            crate::DaemonTriggerCommandArg::Search,
+        )
+        .context("restart daemon-owned source refresh service")?;
+        enqueue_equivalent_wait_refresh_request(
+            data_root,
+            request_id,
+            operation,
+            explicit_source_catalog,
+            fresh_after_admitted_snapshot,
+        )
+    })();
+    recovery.map_err(|error| {
+        retained_request_unobservable(request_id, 0).context(format!(
+            "recover daemon observation for durably admitted request {request_id}: {error:#}"
         ))
-        .into());
-    }
-    super::super::daemon_autostart::autostart_daemon_and_wait(
-        data_root,
-        &config,
-        crate::DaemonTriggerCommandArg::Search,
-    )
-    .context("restart daemon-owned source refresh service")?;
-    enqueue_equivalent_wait_refresh_request(
-        data_root,
-        request_id,
-        operation,
-        explicit_source_catalog,
-        fresh_after_admitted_snapshot,
-    )
+    })
 }
 
 fn enqueue_equivalent_wait_refresh_request(
@@ -622,48 +787,45 @@ fn enqueue_equivalent_wait_refresh_request(
     explicit_source_catalog: Option<&ExplicitSourceCatalogAuthority>,
     fresh_after_admitted_snapshot: bool,
 ) -> Result<String> {
-    let response = send_wait_authority_request(
+    let request = wait_authority_request_json(
         data_root,
         request_id,
         SourceBackedRefreshMode::Wait,
         operation,
         explicit_source_catalog,
         fresh_after_admitted_snapshot,
-    )?
-    .ok_or_else(|| {
-        SourceBackedRefreshDaemonUnavailable::new(Some(
-            "daemon did not publish a source refresh endpoint".to_owned(),
-        ))
-    })?;
+    )?;
+    let response = request_admission_with_recovery(request_id, std::thread::sleep, || {
+        daemon_source_refresh_request(
+            data_root,
+            request.clone(),
+            SOURCE_REFRESH_IPC_TIMEOUT,
+            SOURCE_REFRESH_RESPONSE_MAX_BYTES,
+        )
+    })?
+    .ok_or_else(|| retained_request_unobservable(request_id, 0))?;
     validate_daemon_refresh_response(&response)?;
-    let request_id = response_request_id(&response, "recovered daemon source refresh response")?;
-    validate_source_refresh_status_response_authority(&response, &request_id)?;
+    validate_source_refresh_status_response_authority(&response, request_id)?;
     source_refresh_protocol_state(&response)?;
-    Ok(request_id)
+    Ok(request_id.to_owned())
 }
 
-fn send_wait_authority_request(
+fn wait_authority_request_json(
     data_root: &Path,
     request_id: &str,
     mode: SourceBackedRefreshMode,
     operation: SourceBackedRefreshOperation,
     explicit_source_catalog: Option<&ExplicitSourceCatalogAuthority>,
     fresh_after_admitted_snapshot: bool,
-) -> Result<Option<Value>> {
-    let request = SourceBackedRefreshRequest::new(
+) -> Result<Value> {
+    SourceBackedRefreshRequest::new(
         mode,
         operation,
         explicit_source_catalog,
         fresh_after_admitted_snapshot,
     )
     .with_request_id(request_id)
-    .to_json(data_root)?;
-    daemon_source_refresh_request(
-        data_root,
-        request,
-        SOURCE_REFRESH_IPC_TIMEOUT,
-        SOURCE_REFRESH_RESPONSE_MAX_BYTES,
-    )
+    .to_json(data_root)
 }
 
 fn response_request_id(response: &Value, label: &str) -> Result<String> {
@@ -677,6 +839,7 @@ fn response_request_id(response: &Value, label: &str) -> Result<String> {
 
 fn source_refresh_protocol_state(response: &Value) -> Result<SourceRefreshProtocolState> {
     match response.get("request_state").and_then(Value::as_str) {
+        Some("admission_pending") => Ok(SourceRefreshProtocolState::AdmissionPending),
         Some("queued") => Ok(SourceRefreshProtocolState::Queued),
         Some("running") => Ok(SourceRefreshProtocolState::Running),
         Some("published") => Ok(SourceRefreshProtocolState::Published),
@@ -760,6 +923,7 @@ fn daemon_unavailable_fallback(
                 source_count: 0,
                 request_previous_generation: None,
                 request_generation_changed: false,
+                scanned_routes: None,
                 receipt: None,
                 pin,
             });
@@ -822,3 +986,11 @@ mod progress_poll_tests {
         ));
     }
 }
+
+#[cfg(test)]
+#[path = "client_admission_recovery_tests.rs"]
+mod admission_recovery_tests;
+
+#[cfg(all(test, unix))]
+#[path = "client_transport_recovery_tests.rs"]
+mod transport_recovery_tests;

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/client_admission_recovery_tests.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/client_admission_recovery_tests.rs
@@ -1,0 +1,190 @@
+use super::*;
+
+fn admitted_response(request_id: &str, request_state: &str) -> Value {
+    compact_json(json!({
+        "ok": true,
+        "schema_version": 1,
+        "owner": "daemon",
+        "request_id": request_id,
+        "request_state": request_state,
+    }))
+}
+
+#[test]
+fn definite_pre_submission_error_is_preserved_without_retry() {
+    let request_id = "019fcaaa-0000-7000-8000-000000000294";
+    let mut observed_backoffs = Vec::new();
+    let mut observed_request_ids = Vec::new();
+
+    let error = request_admission_with_recovery(
+        request_id,
+        |backoff| observed_backoffs.push(backoff),
+        || {
+            observed_request_ids.push(request_id);
+            Err(anyhow!("parse daemon source refresh endpoint"))
+        },
+    )
+    .unwrap_err();
+
+    assert!(observed_backoffs.is_empty());
+    assert_eq!(observed_request_ids, [request_id]);
+    assert_eq!(error.to_string(), "parse daemon source refresh endpoint");
+    assert!(error
+        .downcast_ref::<SourceRefreshAdmissionRecoveryFailed>()
+        .is_none());
+}
+
+#[test]
+fn admission_pending_is_a_non_terminal_protocol_state() {
+    let request_id = "019fcaaa-0000-7000-8000-000000000295";
+    let response = admitted_response(request_id, "admission_pending");
+
+    validate_source_refresh_status_response_authority(&response, request_id).unwrap();
+    assert_eq!(
+        source_refresh_protocol_state(&response).unwrap(),
+        SourceRefreshProtocolState::AdmissionPending
+    );
+}
+
+#[test]
+fn missing_endpoint_before_any_roundtrip_remains_genuinely_unavailable() {
+    let request_id = "019fcaaa-0000-7000-8000-000000000297";
+    let mut roundtrips = 0;
+    let response = request_admission_with_recovery(
+        request_id,
+        |_| panic!("genuine unavailability must not enter ambiguous recovery"),
+        || {
+            roundtrips += 1;
+            Ok(None)
+        },
+    )
+    .unwrap();
+
+    assert!(response.is_none());
+    assert_eq!(roundtrips, 1);
+    let Err(error) = daemon_unavailable_fallback(
+        Path::new("unused-for-wait-mode"),
+        SourceBackedRefreshMode::Wait,
+        None,
+    ) else {
+        panic!("wait mode must reject a genuinely missing daemon endpoint");
+    };
+    assert!(error
+        .downcast_ref::<SourceBackedRefreshDaemonUnavailable>()
+        .is_some());
+}
+
+#[test]
+fn no_daemon_post_ack_recovery_is_typed_retained_and_unobservable() {
+    let request_id = "019fcaaa-0000-7000-8000-000000000296";
+    let error = recover_wait_refresh_request(
+        Path::new("unused-after-durable-ack"),
+        request_id,
+        SourceBackedRefreshOperation::Refresh,
+        None,
+        false,
+        false,
+    )
+    .unwrap_err();
+
+    let retained = error
+        .downcast_ref::<observation_recovery::SourceRefreshObservationRecoveryFailed>()
+        .expect("post-ack endpoint loss must retain request identity");
+    assert_eq!(retained.request_id, request_id);
+    assert_eq!(retained.recovery_attempts, 0);
+    assert_eq!(
+        retained.disconnect_policy,
+        observation_recovery::DISCONNECT_POLICY
+    );
+    assert!(error
+        .downcast_ref::<SourceBackedRefreshDaemonUnavailable>()
+        .is_none());
+    assert!(!error
+        .to_string()
+        .contains("no foreground writer was started"));
+}
+
+#[test]
+fn disabled_daemon_post_ack_recovery_preserves_stable_request_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root).unwrap();
+    std::fs::write(
+        data_root.join(crate::config::CONFIG_FILE),
+        "[daemon]\nenabled = false\n",
+    )
+    .unwrap();
+    let request_id = "019fcaaa-0000-7000-8000-0000000002b1";
+
+    let error = recover_wait_refresh_request(
+        &data_root,
+        request_id,
+        SourceBackedRefreshOperation::Refresh,
+        None,
+        false,
+        true,
+    )
+    .unwrap_err();
+
+    let retained = error
+        .downcast_ref::<observation_recovery::SourceRefreshObservationRecoveryFailed>()
+        .expect("disabled post-ack recovery remains request-bound");
+    assert_eq!(retained.request_id, request_id);
+    assert_eq!(
+        retained.disconnect_policy,
+        observation_recovery::DISCONNECT_POLICY
+    );
+    assert!(format!("{error:#}").contains("daemon was disabled"));
+    assert!(error
+        .downcast_ref::<SourceBackedRefreshDaemonUnavailable>()
+        .is_none());
+}
+
+#[test]
+fn malformed_config_post_ack_recovery_preserves_stable_request_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root).unwrap();
+    std::fs::write(data_root.join(crate::config::CONFIG_FILE), "[daemon\n").unwrap();
+    let request_id = "019fcaaa-0000-7000-8000-0000000002b2";
+
+    let error = recover_wait_refresh_request(
+        &data_root,
+        request_id,
+        SourceBackedRefreshOperation::Refresh,
+        None,
+        false,
+        true,
+    )
+    .unwrap_err();
+
+    let retained = error
+        .downcast_ref::<observation_recovery::SourceRefreshObservationRecoveryFailed>()
+        .expect("configuration failure remains request-bound after acknowledgement");
+    assert_eq!(retained.request_id, request_id);
+    assert_eq!(
+        retained.disconnect_policy,
+        observation_recovery::DISCONNECT_POLICY
+    );
+    assert!(format!("{error:#}").contains("load daemon configuration"));
+}
+
+#[test]
+fn typed_initial_service_unavailability_preserves_existing_fallback() {
+    let request_id = "019fcaaa-0000-7000-8000-000000000298";
+    let mut roundtrips = 0;
+    let error = request_admission_with_recovery(
+        request_id,
+        |_| panic!("typed initial unavailability must not enter ambiguous recovery"),
+        || {
+            roundtrips += 1;
+            Err(DaemonSourceRefreshServiceUnavailable.into())
+        },
+    )
+    .unwrap_err();
+
+    assert_eq!(roundtrips, 1);
+    assert!(error
+        .downcast_ref::<DaemonSourceRefreshServiceUnavailable>()
+        .is_some());
+}

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/client_observation_recovery.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/client_observation_recovery.rs
@@ -1,0 +1,86 @@
+use super::*;
+
+const REQUEST_BOUND_STATUS_RECOVERY_ATTEMPT_LIMIT: usize = 3;
+pub(super) const DISCONNECT_POLICY: &str = "retain_after_durable_admission";
+
+#[derive(Debug)]
+pub(super) struct SourceRefreshObservationRecoveryFailed {
+    pub(super) request_id: String,
+    pub(super) recovery_attempts: usize,
+    pub(super) disconnect_policy: &'static str,
+}
+
+impl fmt::Display for SourceRefreshObservationRecoveryFailed {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "daemon source refresh status for durably admitted request {} remains temporarily unobservable after {} recovery attempts; disconnect_policy={} and the request continues under daemon ownership",
+            self.request_id, self.recovery_attempts, self.disconnect_policy
+        )
+    }
+}
+
+impl std::error::Error for SourceRefreshObservationRecoveryFailed {}
+
+pub(super) fn retained_request_unobservable(
+    request_id: &str,
+    recovery_attempts: usize,
+) -> anyhow::Error {
+    SourceRefreshObservationRecoveryFailed {
+        request_id: request_id.to_owned(),
+        recovery_attempts,
+        disconnect_policy: DISCONNECT_POLICY,
+    }
+    .into()
+}
+
+pub(super) fn request_bound_status_with_recovery<S, R>(
+    request_id: &str,
+    mut sleep: S,
+    mut roundtrip: R,
+) -> Result<Option<Value>>
+where
+    S: FnMut(StdDuration),
+    R: FnMut() -> Result<Option<Value>>,
+{
+    match roundtrip() {
+        Ok(response) => return Ok(response),
+        Err(error)
+            if error
+                .downcast_ref::<DaemonSourceRefreshServiceUnavailable>()
+                .is_some() =>
+        {
+            return Err(error);
+        }
+        Err(_) => {}
+    }
+
+    for recovery_attempt in 0..REQUEST_BOUND_STATUS_RECOVERY_ATTEMPT_LIMIT {
+        let backoff = match recovery_attempt {
+            0 => StdDuration::from_millis(25),
+            1 => StdDuration::from_millis(50),
+            _ => StdDuration::from_millis(100),
+        };
+        sleep(backoff);
+        match roundtrip() {
+            Ok(response) => return Ok(response),
+            Err(error)
+                if error
+                    .downcast_ref::<DaemonSourceRefreshServiceUnavailable>()
+                    .is_some() =>
+            {
+                return Err(error);
+            }
+            Err(_) => {}
+        }
+    }
+
+    Err(retained_request_unobservable(
+        request_id,
+        REQUEST_BOUND_STATUS_RECOVERY_ATTEMPT_LIMIT,
+    ))
+}
+
+#[cfg(test)]
+#[path = "client_observation_recovery_tests.rs"]
+mod tests;

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/client_observation_recovery_tests.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/client_observation_recovery_tests.rs
@@ -1,0 +1,85 @@
+use super::*;
+use std::collections::VecDeque;
+
+fn running_status(request_id: &str) -> Value {
+    compact_json(json!({
+        "ok": true,
+        "schema_version": 1,
+        "owner": "daemon",
+        "request_id": request_id,
+        "request_state": "running",
+    }))
+}
+
+#[test]
+fn transient_status_timeout_recovers_the_same_durable_request() {
+    let request_id = "019fcaaa-0000-7000-8000-000000000301";
+    let expected = running_status(request_id);
+    let mut responses = VecDeque::from([
+        Err(anyhow!("daemon query response read timed out")),
+        Ok(Some(expected.clone())),
+    ]);
+    let mut observed_backoffs = Vec::new();
+    let mut observed_request_ids = Vec::new();
+
+    let recovered = request_bound_status_with_recovery(
+        request_id,
+        |backoff| observed_backoffs.push(backoff),
+        || {
+            observed_request_ids.push(request_id);
+            responses.pop_front().expect("bounded status recovery")
+        },
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(observed_backoffs, [StdDuration::from_millis(25)]);
+    assert_eq!(observed_request_ids, [request_id, request_id]);
+    assert_eq!(recovered, expected);
+}
+
+#[test]
+fn exhausted_status_recovery_reports_retained_request_not_transport_failure() {
+    let request_id = "019fcaaa-0000-7000-8000-000000000302";
+    let error = request_bound_status_with_recovery(
+        request_id,
+        |_| {},
+        || Err(anyhow!("daemon query response read timed out")),
+    )
+    .unwrap_err();
+
+    let recovery = error
+        .downcast_ref::<SourceRefreshObservationRecoveryFailed>()
+        .expect("typed request-bound observation outcome");
+    assert_eq!(recovery.request_id, request_id);
+    assert_eq!(
+        recovery.recovery_attempts,
+        REQUEST_BOUND_STATUS_RECOVERY_ATTEMPT_LIMIT
+    );
+    assert_eq!(recovery.disconnect_policy, DISCONNECT_POLICY);
+    assert!(error.to_string().contains("durably admitted request"));
+    assert!(error
+        .to_string()
+        .contains("continues under daemon ownership"));
+    assert!(!error.to_string().contains("timed out"));
+}
+
+#[test]
+fn typed_service_unavailability_still_enters_daemon_recovery_immediately() {
+    let request_id = "019fcaaa-0000-7000-8000-000000000303";
+    let mut roundtrips = 0;
+    let error = request_bound_status_with_recovery(
+        request_id,
+        |_| panic!("typed unavailability must not use transport retry backoff"),
+        || {
+            roundtrips += 1;
+            Err(DaemonSourceRefreshServiceUnavailable.into())
+        },
+    )
+    .unwrap_err();
+
+    assert_eq!(roundtrips, 1);
+    assert!(error
+        .downcast_ref::<DaemonSourceRefreshServiceUnavailable>()
+        .is_some());
+}

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/client_transport_recovery_tests.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/client_transport_recovery_tests.rs
@@ -1,0 +1,226 @@
+use super::*;
+
+use std::{
+    io::{Read as _, Write as _},
+    os::unix::net::UnixListener,
+};
+
+use crate::semantic::query_service::{
+    write_daemon_service_endpoint, DaemonIpcService, DaemonQueryEndpoint,
+};
+
+const TEST_ENDPOINT_TOKEN: &str = "0123456789abcdef0123456789abcdef";
+
+fn short_socket_root() -> Result<tempfile::TempDir> {
+    tempfile::Builder::new()
+        .prefix("ctx-294-sock-")
+        .tempdir_in("/tmp")
+        .map_err(Into::into)
+}
+
+fn source_refresh_endpoint(socket_path: &Path) -> DaemonQueryEndpoint {
+    DaemonQueryEndpoint::Unix {
+        path: socket_path.to_owned(),
+        token: TEST_ENDPOINT_TOKEN.to_owned(),
+    }
+}
+
+#[test]
+fn pre_submission_connection_refusal_remains_typed_unavailable() -> Result<()> {
+    let data_root = tempfile::tempdir()?;
+    let socket_root = short_socket_root()?;
+    let socket_path = socket_root.path().join("refused.sock");
+    let listener = UnixListener::bind(&socket_path)?;
+    drop(listener);
+    write_daemon_service_endpoint(
+        data_root.path(),
+        DaemonIpcService::SourceRefresh,
+        &source_refresh_endpoint(&socket_path),
+    )?;
+
+    let error = daemon_source_refresh_request(
+        data_root.path(),
+        compact_json(json!({
+            "schema_version": 1,
+            "op": SOURCE_REFRESH_REQUEST_OP,
+            "request_id": "019fcaaa-0000-7000-8000-000000000299",
+        })),
+        StdDuration::from_millis(100),
+        SOURCE_REFRESH_RESPONSE_MAX_BYTES,
+    )
+    .expect_err("a closed pre-submission endpoint must be unavailable");
+
+    assert!(error
+        .downcast_ref::<DaemonSourceRefreshServiceUnavailable>()
+        .is_some());
+    Ok(())
+}
+
+#[test]
+fn same_id_reenqueue_replays_the_exact_payload_after_a_lost_ack() -> Result<()> {
+    let data_root = tempfile::tempdir()?;
+    let socket_root = short_socket_root()?;
+    let socket_path = socket_root.path().join("lost-ack.sock");
+    let listener = UnixListener::bind(&socket_path)?;
+    write_daemon_service_endpoint(
+        data_root.path(),
+        DaemonIpcService::SourceRefresh,
+        &source_refresh_endpoint(&socket_path),
+    )?;
+    let request_id = "019fcaaa-0000-7000-8000-000000000300";
+    let server = std::thread::spawn(move || -> Result<[Vec<u8>; 2]> {
+        let mut requests = Vec::with_capacity(2);
+        for attempt in 0..2 {
+            let (mut stream, _) = listener.accept()?;
+            let mut received = Vec::new();
+            stream.read_to_end(&mut received)?;
+            requests.push(received);
+            if attempt == 0 {
+                continue;
+            }
+            stream.write_all(
+                format!(
+                    "{{\"ok\":true,\"owner\":\"daemon\",\"request_id\":\"{request_id}\",\"request_state\":\"admission_pending\",\"schema_version\":1}}\n"
+                )
+                .as_bytes(),
+            )?;
+        }
+        requests
+            .try_into()
+            .map_err(|_| anyhow!("test server did not observe exactly two requests"))
+    });
+
+    let recovered = enqueue_equivalent_wait_refresh_request(
+        data_root.path(),
+        request_id,
+        SourceBackedRefreshOperation::Refresh,
+        None,
+        false,
+    )?;
+    let requests = server.join().expect("lost-ack test server panicked")?;
+
+    assert_eq!(recovered, request_id);
+    assert_eq!(requests[0], requests[1]);
+    for request in requests {
+        let request: Value = serde_json::from_slice(&request)?;
+        assert_eq!(request["request_id"], request_id);
+    }
+    Ok(())
+}
+
+#[test]
+fn exhausted_post_submission_disconnects_return_typed_ambiguous_admission() -> Result<()> {
+    let data_root = tempfile::tempdir()?;
+    let socket_root = short_socket_root()?;
+    let socket_path = socket_root.path().join("lost-all-acks.sock");
+    let listener = UnixListener::bind(&socket_path)?;
+    write_daemon_service_endpoint(
+        data_root.path(),
+        DaemonIpcService::SourceRefresh,
+        &source_refresh_endpoint(&socket_path),
+    )?;
+    let request_id = "019fcaaa-0000-7000-8000-000000000304";
+
+    let server = std::thread::spawn(move || -> Result<Vec<Vec<u8>>> {
+        let mut requests = Vec::new();
+        for _ in 0..=AMBIGUOUS_ADMISSION_RECOVERY_ATTEMPT_LIMIT {
+            let (mut stream, _) = listener.accept()?;
+            let mut received = Vec::new();
+            stream.read_to_end(&mut received)?;
+            requests.push(received);
+        }
+        Ok(requests)
+    });
+
+    let error = enqueue_equivalent_wait_refresh_request(
+        data_root.path(),
+        request_id,
+        SourceBackedRefreshOperation::Refresh,
+        None,
+        false,
+    )
+    .unwrap_err();
+    let requests = server.join().expect("lost-ack test server panicked")?;
+
+    let recovery = error
+        .downcast_ref::<SourceRefreshAdmissionRecoveryFailed>()
+        .expect("post-submission disconnect must use typed admission recovery");
+    assert_eq!(recovery.request_id, request_id);
+    assert_eq!(
+        recovery.recovery_attempts,
+        AMBIGUOUS_ADMISSION_RECOVERY_ATTEMPT_LIMIT
+    );
+    assert_eq!(
+        requests.len(),
+        1 + AMBIGUOUS_ADMISSION_RECOVERY_ATTEMPT_LIMIT
+    );
+    assert!(requests.windows(2).all(|pair| pair[0] == pair[1]));
+    assert!(!error.to_string().contains("timed out"));
+    Ok(())
+}
+
+#[test]
+fn typed_unknown_readmission_preserves_lost_ack_retention_uncertainty() -> Result<()> {
+    let data_root = tempfile::tempdir()?;
+    let socket_root = short_socket_root()?;
+    let socket_path = socket_root.path().join("typed-unknown-lost-acks.sock");
+    let listener = UnixListener::bind(&socket_path)?;
+    write_daemon_service_endpoint(
+        data_root.path(),
+        DaemonIpcService::SourceRefresh,
+        &source_refresh_endpoint(&socket_path),
+    )?;
+    let request_id = "019fcaaa-0000-7000-8000-000000000307";
+    let server = std::thread::spawn(move || -> Result<Vec<Vec<u8>>> {
+        let mut requests = Vec::new();
+        for _ in 0..=AMBIGUOUS_ADMISSION_RECOVERY_ATTEMPT_LIMIT {
+            let (mut stream, _) = listener.accept()?;
+            let mut received = Vec::new();
+            stream.read_to_end(&mut received)?;
+            requests.push(received);
+        }
+        Ok(requests)
+    });
+
+    let mut recovery = TypedUnknownRequestRecovery::new(request_id);
+    let error = recover_typed_unknown_request_with(
+        &mut recovery,
+        request_id,
+        |_| {},
+        || {
+            enqueue_equivalent_wait_refresh_request(
+                data_root.path(),
+                request_id,
+                SourceBackedRefreshOperation::Refresh,
+                None,
+                false,
+            )
+        },
+    )
+    .unwrap_err();
+    let requests = server.join().expect("lost-ack test server panicked")?;
+
+    let typed = error
+        .downcast_ref::<SourceRefreshRequestRecoveryFailed>()
+        .expect("typed unknown re-admission keeps its request-bound failure");
+    assert_eq!(typed.request_id, request_id);
+    assert_eq!(typed.recovery_attempts, 1);
+    assert_eq!(
+        typed.reason,
+        SourceRefreshRequestRecoveryFailureReason::ReenqueueFailed
+    );
+    assert_eq!(
+        typed.retention,
+        SourceRefreshRequestRetention::MayBeRetained
+    );
+    assert_eq!(typed.disconnect_policy, Some(DISCONNECT_POLICY));
+    assert!(error
+        .to_string()
+        .contains("disconnect_policy=retain_after_durable_admission"));
+    assert_eq!(
+        requests.len(),
+        1 + AMBIGUOUS_ADMISSION_RECOVERY_ATTEMPT_LIMIT
+    );
+    assert!(requests.windows(2).all(|pair| pair[0] == pair[1]));
+    Ok(())
+}

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state.rs
@@ -3,6 +3,9 @@ use crate::semantic::dirty_source_routes::{
     DirtySourceRouteAdmission, DirtySourceRoutes, EventWatermark,
 };
 
+mod admission;
+#[cfg(test)]
+mod admission_tests;
 mod attempt_helpers;
 mod coverage_contract;
 mod durable_queue;
@@ -173,6 +176,8 @@ pub(super) struct CoreRefreshEngineState {
     manual_all_continuations: BTreeMap<String, ManualAllContinuation>,
     pending_terminal_persistence: Option<PendingTerminalPersistence>,
     pending_scheduler_retry_root_id: Option<String>,
+    unacknowledged_admissions: BTreeMap<String, usize>,
+    admission_resolutions_in_flight: BTreeSet<String>,
     watch_routes_initialized: bool,
 }
 
@@ -215,16 +220,28 @@ impl fmt::Debug for PendingTerminalPersistence {
 }
 
 type SourceRefreshStatusWriter = dyn Fn(&Path, &Value) -> Result<()> + Send + Sync;
+type SourceRefreshAdmissionFence = dyn Fn(
+        &Path,
+        Option<&ExplicitSourceCatalogAuthority>,
+    ) -> Result<BTreeMap<SourceRouteIdentity, Option<String>>>
+    + Send
+    + Sync;
 
 pub(in crate::semantic) struct CoreRefreshEngine {
     state: Mutex<CoreRefreshEngineState>,
     pub(super) executor: Arc<dyn SourceBackedRefreshExecutor>,
+    admission_fence: Arc<SourceRefreshAdmissionFence>,
     status_writer: Arc<SourceRefreshStatusWriter>,
 }
 
 #[derive(Debug)]
 struct SourceBackedRefreshQueueFull {
     active_pending_requests: usize,
+}
+
+#[derive(Debug)]
+struct SourceBackedRefreshIdempotencyConflict {
+    request_id: String,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -239,6 +256,8 @@ struct SourceRefreshLogicalDemand {
     admission: SourceRefreshAdmissionRequirement,
     route_observations: BTreeMap<SourceRouteIdentity, Option<String>>,
     request_id: Option<String>,
+    request_fingerprint: Option<String>,
+    admission_pending: bool,
 }
 
 impl SourceRefreshAdmissionRequirement {
@@ -264,6 +283,22 @@ impl SourceBackedRefreshQueueFull {
     }
 }
 
+impl SourceBackedRefreshIdempotencyConflict {
+    fn to_json(&self) -> Value {
+        compact_json(json!({
+            "ok": false,
+            "schema_version": 1,
+            "owner": "daemon",
+            "request_id": self.request_id,
+            "request_state": "request_conflict",
+            "error_code": "request_id_conflict",
+            "reason": "request_id_payload_mismatch",
+            "retryable": false,
+            "error": self.to_string(),
+        }))
+    }
+}
+
 impl fmt::Display for SourceBackedRefreshQueueFull {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -276,6 +311,18 @@ impl fmt::Display for SourceBackedRefreshQueueFull {
 }
 
 impl std::error::Error for SourceBackedRefreshQueueFull {}
+
+impl fmt::Display for SourceBackedRefreshIdempotencyConflict {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "daemon source refresh request ID {} was already admitted for a different request payload",
+            self.request_id
+        )
+    }
+}
+
+impl std::error::Error for SourceBackedRefreshIdempotencyConflict {}
 
 impl CoreRefreshEngine {
     pub(in crate::semantic) fn new() -> Self {
@@ -290,6 +337,18 @@ impl CoreRefreshEngine {
 
     fn with_executor_and_status_writer(
         executor: Arc<dyn SourceBackedRefreshExecutor>,
+        status_writer: Arc<SourceRefreshStatusWriter>,
+    ) -> Self {
+        Self::with_runtime(
+            executor,
+            Arc::new(source_backed_route_admission_fence),
+            status_writer,
+        )
+    }
+
+    fn with_runtime(
+        executor: Arc<dyn SourceBackedRefreshExecutor>,
+        admission_fence: Arc<SourceRefreshAdmissionFence>,
         status_writer: Arc<SourceRefreshStatusWriter>,
     ) -> Self {
         Self {
@@ -307,9 +366,12 @@ impl CoreRefreshEngine {
                 manual_all_continuations: BTreeMap::new(),
                 pending_terminal_persistence: None,
                 pending_scheduler_retry_root_id: None,
+                unacknowledged_admissions: BTreeMap::new(),
+                admission_resolutions_in_flight: BTreeSet::new(),
                 watch_routes_initialized: false,
             }),
             executor,
+            admission_fence,
             status_writer,
         }
     }
@@ -320,6 +382,26 @@ impl CoreRefreshEngine {
         status_writer: Arc<SourceRefreshStatusWriter>,
     ) -> Self {
         Self::with_executor_and_status_writer(executor, status_writer)
+    }
+
+    #[cfg(test)]
+    pub(in crate::semantic) fn with_runtime_for_test(
+        executor: Arc<dyn SourceBackedRefreshExecutor>,
+        admission_fence: Arc<SourceRefreshAdmissionFence>,
+        status_writer: Arc<SourceRefreshStatusWriter>,
+    ) -> Self {
+        Self::with_runtime(executor, admission_fence, status_writer)
+    }
+
+    #[cfg(test)]
+    pub(in crate::semantic) fn with_admission_fence_for_test(
+        admission_fence: Arc<SourceRefreshAdmissionFence>,
+    ) -> Self {
+        Self::with_runtime(
+            Arc::new(CaptureOwnedSourceBackedRefreshExecutor),
+            admission_fence,
+            Arc::new(write_daemon_job_status),
+        )
     }
 
     pub(in crate::semantic) fn has_pending_request(&self) -> bool {
@@ -623,156 +705,27 @@ impl CoreRefreshEngine {
         Ok(true)
     }
 
+    #[cfg(test)]
     pub(in crate::semantic) fn handle_ipc_request(
         &self,
         data_root: &Path,
         request: &Value,
     ) -> Result<Option<Value>> {
-        self.handle_ipc_request_with_admission_fence(
-            data_root,
-            request,
-            source_backed_route_admission_fence,
-        )
+        admission::handle_ipc_request(self, data_root, request)
     }
 
-    fn handle_ipc_request_with_admission_fence<F>(
+    fn background_maintenance_wake_response(
         &self,
         data_root: &Path,
-        request: &Value,
-        admission_fence: F,
-    ) -> Result<Option<Value>>
-    where
-        F: Fn(
-            &Path,
-            Option<&ExplicitSourceCatalogAuthority>,
-        ) -> Result<BTreeMap<SourceRouteIdentity, Option<String>>>,
-    {
-        match request.get("op").and_then(Value::as_str) {
-            Some(SOURCE_REFRESH_REQUEST_OP) => {
-                let mode = request.get("mode").and_then(Value::as_str).unwrap_or("");
-                if !matches!(mode, "background" | "wait") {
-                    return Err(anyhow!("invalid daemon source refresh mode `{mode}`"));
-                }
-                let operation = SourceBackedRefreshOperation::from_request_json(request)?;
-                let explicit_catalog = request.get("explicit_source_catalog");
-                match (operation, mode, explicit_catalog) {
-                    (SourceBackedRefreshOperation::Refresh, _, Some(_)) => {
-                        return Err(anyhow!(
-                            "refresh operation cannot carry explicit source catalog authority"
-                        ))
-                    }
-                    (SourceBackedRefreshOperation::Import, "background", _) => {
-                        return Err(anyhow!(
-                            "import operation requires daemon refresh mode `wait`"
-                        ))
-                    }
-                    (SourceBackedRefreshOperation::Import, _, None) => {
-                        return Err(anyhow!(
-                            "import operation requires explicit source catalog authority"
-                        ))
-                    }
-                    _ => {}
-                }
-                if operation == SourceBackedRefreshOperation::Refresh && mode == "background" {
-                    return Ok(Some(self.background_maintenance_wake_response(data_root)?));
-                }
-                let requested_catalog = explicit_catalog
-                    .map(ExplicitSourceCatalogAuthority::from_json)
-                    .transpose()?;
-                let logical_request_id = match request.get("request_id") {
-                    Some(Value::String(request_id)) if !request_id.is_empty() => {
-                        Uuid::parse_str(request_id)
-                            .context("daemon source refresh logical request ID must be a UUID")?;
-                        Some(request_id.clone())
-                    }
-                    None => None,
-                    Some(_) => {
-                        return Err(anyhow!(
-                            "daemon source refresh logical request ID is invalid"
-                        ))
-                    }
-                };
-                let admission = match request.get("fresh_after_admitted_snapshot") {
-                    None | Some(Value::Bool(false)) => {
-                        SourceRefreshAdmissionRequirement::AttachEquivalent
-                    }
-                    Some(Value::Bool(true)) => {
-                        SourceRefreshAdmissionRequirement::FreshAfterAdmittedSnapshot
-                    }
-                    Some(_) => {
-                        return Err(anyhow!(
-                            "daemon source refresh fresh-after-admitted-snapshot requirement must be boolean"
-                        ))
-                    }
-                };
-                let previous_generation = self.observed_published_generation(data_root)?;
-                let admission_route_observations =
-                    if admission == SourceRefreshAdmissionRequirement::FreshAfterAdmittedSnapshot {
-                        admission_fence(data_root, requested_catalog.as_ref())?
-                    } else {
-                        BTreeMap::new()
-                    };
-                let metadata = match operation {
-                    SourceBackedRefreshOperation::Import => {
-                        source_catalog_refresh_runtime_metadata(data_root)
-                    }
-                    SourceBackedRefreshOperation::Refresh => {
-                        source_refresh_runtime_metadata(data_root)
-                    }
-                };
-                let response = match self.enqueue_with_catalog_metadata(
-                    previous_generation,
-                    metadata,
-                    requested_catalog,
-                    SourceBackedRefreshScope::All,
-                    SourceRefreshLogicalDemand {
-                        // Wait controls how the client observes the attempt; it is
-                        // not itself a fresh-after-admission barrier.
-                        admission,
-                        route_observations: admission_route_observations,
-                        request_id: logical_request_id,
-                    },
-                ) {
-                    Ok(response) => response,
-                    Err(error) => {
-                        if let Some(queue_full) =
-                            error.downcast_ref::<SourceBackedRefreshQueueFull>()
-                        {
-                            return Ok(Some(queue_full.to_json()));
-                        }
-                        return Err(error);
-                    }
-                };
-                let request_id = response
-                    .get("request_id")
-                    .and_then(Value::as_str)
-                    .ok_or_else(|| anyhow!("queued source refresh has no request ID"))?;
-                self.persist_job_status(data_root, request_id)?;
-                Ok(Some(response))
-            }
-            Some(SOURCE_REFRESH_STATUS_OP) => {
-                let request_id = request
-                    .get("request_id")
-                    .and_then(Value::as_str)
-                    .filter(|request_id| !request_id.is_empty())
-                    .ok_or_else(|| anyhow!("daemon source refresh request ID is missing"))?;
-                let status = self
-                    .status(request_id)
-                    .unwrap_or_else(|| unknown_refresh_request_response(request_id));
-                Ok(Some(status))
-            }
-            _ => Ok(None),
-        }
-    }
-
-    fn background_maintenance_wake_response(&self, data_root: &Path) -> Result<Value> {
+        request_id: String,
+    ) -> Result<Value> {
         let published_generation = self.observed_published_generation(data_root)?;
         let metadata = source_refresh_runtime_metadata(data_root);
         Ok(compact_json(json!({
             "ok": true,
             "schema_version": 1,
             "owner": "daemon",
-            "request_id": Uuid::now_v7().to_string(),
+            "request_id": request_id,
             "request_state": "queued",
             "previous_generation": published_generation.clone(),
             "published_generation": published_generation,
@@ -800,10 +753,18 @@ impl CoreRefreshEngine {
             .route_admissions
             .remove(request_id)
             .unwrap_or_default();
-        let predecessor_event_watermarks = state
-            .route_admission_watermarks
-            .remove(request_id)
-            .unwrap_or_default();
+        let retained_predecessor_event_watermarks =
+            state.route_admission_watermarks.remove(request_id);
+        if let Some(predecessor_event_watermarks) = retained_predecessor_event_watermarks.as_ref() {
+            for continuation in state.manual_all_continuations.values_mut() {
+                if continuation.predecessor_request_id == request_id {
+                    continuation.predecessor_event_watermarks =
+                        predecessor_event_watermarks.clone();
+                }
+            }
+        }
+        let predecessor_event_watermarks =
+            retained_predecessor_event_watermarks.unwrap_or_default();
         let current_event_watermarks = state.route_event_watermarks.clone();
         let attempt = find_attempt(&state, request_id).cloned();
         let route_results = attempt
@@ -933,6 +894,16 @@ impl CoreRefreshEngine {
             } else {
                 for (route, result) in &covered_route_results {
                     if continuation.invalidated_routes.contains(route) {
+                        continue;
+                    }
+                    if attempt
+                        .as_ref()
+                        .is_some_and(|attempt| attempt.route_observations.contains_key(route))
+                    {
+                        // A predecessor with a provider-certified observation
+                        // cannot be covered by a later indeterminate sample.
+                        // The ledger path is only for route kinds that were
+                        // indeterminate throughout the same successful pass.
                         continue;
                     }
                     if continuation

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/admission.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/admission.rs
@@ -1,0 +1,746 @@
+use super::durable_queue::DurableAdmissionPersistence;
+use super::*;
+use sha2::{Digest as _, Sha256};
+
+#[cfg(test)]
+pub(super) fn handle_ipc_request(
+    coordinator: &CoreRefreshEngine,
+    data_root: &Path,
+    request: &Value,
+) -> Result<Option<Value>> {
+    handle_ipc_request_inner(coordinator, data_root, request, false)
+}
+
+pub(super) fn handle_listener_ipc_request(
+    coordinator: &CoreRefreshEngine,
+    data_root: &Path,
+    request: &Value,
+) -> Result<Option<Value>> {
+    handle_ipc_request_inner(coordinator, data_root, request, true)
+}
+
+fn handle_ipc_request_inner(
+    coordinator: &CoreRefreshEngine,
+    data_root: &Path,
+    request: &Value,
+    defer_admission_until_response: bool,
+) -> Result<Option<Value>> {
+    match request.get("op").and_then(Value::as_str) {
+        Some(SOURCE_REFRESH_REQUEST_OP) => handle_refresh_request(
+            coordinator,
+            data_root,
+            request,
+            defer_admission_until_response,
+        )
+        .map(Some),
+        Some(SOURCE_REFRESH_STATUS_OP) => {
+            let request_id = request
+                .get("request_id")
+                .and_then(Value::as_str)
+                .filter(|request_id| !request_id.is_empty())
+                .ok_or_else(|| anyhow!("daemon source refresh request ID is missing"))?;
+            Ok(Some(coordinator.status(request_id).unwrap_or_else(|| {
+                unknown_refresh_request_response(request_id)
+            })))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn handle_refresh_request(
+    coordinator: &CoreRefreshEngine,
+    data_root: &Path,
+    request: &Value,
+    defer_admission_until_response: bool,
+) -> Result<Value> {
+    let mode = request.get("mode").and_then(Value::as_str).unwrap_or("");
+    if !matches!(mode, "background" | "wait") {
+        return Err(anyhow!("invalid daemon source refresh mode `{mode}`"));
+    }
+    let operation = SourceBackedRefreshOperation::from_request_json(request)?;
+    let explicit_catalog = request.get("explicit_source_catalog");
+    match (operation, mode, explicit_catalog) {
+        (SourceBackedRefreshOperation::Refresh, _, Some(_)) => {
+            bail!("refresh operation cannot carry explicit source catalog authority")
+        }
+        (SourceBackedRefreshOperation::Import, "background", _) => {
+            bail!("import operation requires daemon refresh mode `wait`")
+        }
+        (SourceBackedRefreshOperation::Import, _, None) => {
+            bail!("import operation requires explicit source catalog authority")
+        }
+        _ => {}
+    }
+    let request_id = match request.get("request_id") {
+        Some(Value::String(request_id)) if !request_id.is_empty() => {
+            Uuid::parse_str(request_id)
+                .context("daemon source refresh logical request ID must be a UUID")?;
+            request_id.clone()
+        }
+        None => Uuid::now_v7().to_string(),
+        Some(_) => bail!("daemon source refresh logical request ID is invalid"),
+    };
+    let admission = match request.get("fresh_after_admitted_snapshot") {
+        None | Some(Value::Bool(false)) => SourceRefreshAdmissionRequirement::AttachEquivalent,
+        Some(Value::Bool(true)) => SourceRefreshAdmissionRequirement::FreshAfterAdmittedSnapshot,
+        Some(_) => {
+            bail!("daemon source refresh fresh-after-admitted-snapshot requirement must be boolean")
+        }
+    };
+    if operation == SourceBackedRefreshOperation::Refresh && mode == "background" {
+        if admission == SourceRefreshAdmissionRequirement::FreshAfterAdmittedSnapshot {
+            bail!("background source refresh cannot require a fresh admission snapshot");
+        }
+        return coordinator.background_maintenance_wake_response(data_root, request_id);
+    }
+
+    let requested_catalog = explicit_catalog
+        .map(ExplicitSourceCatalogAuthority::from_json)
+        .transpose()?;
+    let refresh_scope = request
+        .get("refresh_scope")
+        .filter(|value| !value.is_null())
+        .map(|value| refresh_scope_from_json(Some(value)))
+        .transpose()?
+        .unwrap_or(SourceBackedRefreshScope::All);
+    let fingerprint = request_fingerprint(
+        operation,
+        requested_catalog.as_ref(),
+        &refresh_scope,
+        admission,
+    )?;
+    let previous_generation = coordinator.observed_published_generation(data_root)?;
+    let metadata = match operation {
+        SourceBackedRefreshOperation::Import => source_catalog_refresh_runtime_metadata(data_root),
+        SourceBackedRefreshOperation::Refresh => source_refresh_runtime_metadata(data_root),
+    };
+    let response = coordinator.reserve_ipc_request(SourceRefreshAdmissionReservation {
+        data_root,
+        previous_generation,
+        metadata,
+        requested_catalog,
+        refresh_scope,
+        logical_demand: SourceRefreshLogicalDemand {
+            admission,
+            route_observations: BTreeMap::new(),
+            request_id: Some(request_id),
+            request_fingerprint: Some(fingerprint),
+            admission_pending: admission
+                == SourceRefreshAdmissionRequirement::FreshAfterAdmittedSnapshot,
+        },
+        defer_admission_until_response,
+    });
+    match response {
+        Ok(response) => Ok(response),
+        Err(error) => {
+            if let Some(queue_full) = error.downcast_ref::<SourceBackedRefreshQueueFull>() {
+                return Ok(queue_full.to_json());
+            }
+            if let Some(conflict) = error.downcast_ref::<SourceBackedRefreshIdempotencyConflict>() {
+                return Ok(conflict.to_json());
+            }
+            Err(error)
+        }
+    }
+}
+
+fn request_fingerprint(
+    operation: SourceBackedRefreshOperation,
+    requested_catalog: Option<&ExplicitSourceCatalogAuthority>,
+    refresh_scope: &SourceBackedRefreshScope,
+    admission: SourceRefreshAdmissionRequirement,
+) -> Result<String> {
+    let authority = compact_json(json!({
+        "operation": operation.as_str(),
+        "explicit_source_catalog": requested_catalog
+            .map(ExplicitSourceCatalogAuthority::to_json),
+        "fresh_after_admitted_snapshot": admission
+            == SourceRefreshAdmissionRequirement::FreshAfterAdmittedSnapshot,
+        "refresh_scope": refresh_scope_json(refresh_scope),
+    }));
+    Ok(format!(
+        "{:x}",
+        Sha256::digest(serde_json::to_vec(&authority)?)
+    ))
+}
+
+struct SourceRefreshAdmissionReservation<'a> {
+    data_root: &'a Path,
+    previous_generation: Option<String>,
+    metadata: SourceRefreshRuntimeMetadata,
+    requested_catalog: Option<ExplicitSourceCatalogAuthority>,
+    refresh_scope: SourceBackedRefreshScope,
+    logical_demand: SourceRefreshLogicalDemand,
+    defer_admission_until_response: bool,
+}
+
+impl CoreRefreshEngine {
+    fn reserve_ipc_request(
+        &self,
+        reservation: SourceRefreshAdmissionReservation<'_>,
+    ) -> Result<Value> {
+        let SourceRefreshAdmissionReservation {
+            data_root,
+            previous_generation,
+            metadata,
+            requested_catalog,
+            refresh_scope,
+            logical_demand,
+            defer_admission_until_response,
+        } = reservation;
+        let logical_request_id = logical_demand
+            .request_id
+            .as_deref()
+            .ok_or_else(|| anyhow!("daemon source refresh logical request ID is missing"))?;
+        let request_fingerprint = logical_demand.request_fingerprint.as_ref();
+        let mut state = self.lock_state();
+        if let Some(existing) = find_attempt(&state, logical_request_id) {
+            if existing.request_fingerprint.as_ref() != request_fingerprint {
+                return Err(SourceBackedRefreshIdempotencyConflict {
+                    request_id: logical_request_id.to_owned(),
+                }
+                .into());
+            }
+            if existing.admission_durability_indeterminate {
+                self.reconfirm_retained_admission_locked(data_root, &mut state, logical_request_id);
+            }
+            let existing = find_attempt(&state, logical_request_id).ok_or_else(|| {
+                anyhow!("source refresh request `{logical_request_id}` disappeared during replay")
+            })?;
+            let response = existing.to_json();
+            if defer_admission_until_response
+                && existing.state == SourceBackedRefreshState::AdmissionPending
+            {
+                increment_response_barrier(&mut state, logical_request_id);
+            }
+            return Ok(response);
+        }
+
+        let snapshot = AdmissionReservationSnapshot::capture(&state);
+        let response = match Self::enqueue_with_catalog_metadata_locked(
+            &mut state,
+            previous_generation,
+            metadata,
+            requested_catalog,
+            refresh_scope,
+            logical_demand,
+        ) {
+            Ok(response) => response,
+            Err(error) => {
+                snapshot.restore(&mut state);
+                return Err(error);
+            }
+        };
+        let request_id = response
+            .get("request_id")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("queued source refresh has no request ID"))?
+            .to_owned();
+        if defer_admission_until_response
+            && find_attempt(&state, &request_id)
+                .is_some_and(|attempt| attempt.state == SourceBackedRefreshState::AdmissionPending)
+        {
+            increment_response_barrier(&mut state, &request_id);
+        }
+        let attempt = find_attempt_mut(&mut state, &request_id)
+            .ok_or_else(|| anyhow!("source refresh request `{request_id}` is unknown"))?;
+        // Persist the conservative marker in the first replace. If durability
+        // confirmation fails after replacement, a crash must recover both the
+        // admitted request and the fact that its acknowledgement was uncertain.
+        attempt.admission_durability_indeterminate = true;
+        let durable_root_id = durable_request_id(&state, &request_id);
+        let job = durable_job_json(&state, durable_root_id)
+            .ok_or_else(|| anyhow!("source refresh request `{durable_root_id}` is unknown"))?;
+        let retained_error = match self.write_durable_admission_status(data_root, &job) {
+            DurableAdmissionPersistence::Confirmed => None,
+            DurableAdmissionPersistence::Retained(error) => Some(error),
+            DurableAdmissionPersistence::Failed(error) => {
+                snapshot.restore(&mut state);
+                return Err(error
+                    .context("persist durable source refresh admission before acknowledgement"));
+            }
+        };
+        if retained_error.is_some() {
+            let attempt = find_attempt(&state, &request_id).ok_or_else(|| {
+                anyhow!("retained source refresh request `{request_id}` is unknown")
+            })?;
+            let response = attempt.to_json();
+            trim_terminal_attempt_history(&mut state);
+            return Ok(response);
+        }
+        let attempt = find_attempt_mut(&mut state, &request_id)
+            .ok_or_else(|| anyhow!("confirmed source refresh request `{request_id}` is unknown"))?;
+        attempt.admission_durability_indeterminate = false;
+        let durable_request_id = durable_request_id(&state, &request_id);
+        if let Some(confirmed_job) = durable_job_json(&state, durable_request_id) {
+            // The marker-bearing image already proved the request durable. A
+            // failed cleanup leaves that conservative image recoverable.
+            let _ = self.write_durable_admission_status(data_root, &confirmed_job);
+        }
+        trim_terminal_attempt_history(&mut state);
+        Ok(find_attempt(&state, &request_id)
+            .map(SourceBackedRefreshAttempt::to_json)
+            .unwrap_or(response))
+    }
+
+    fn reconfirm_retained_admission_locked(
+        &self,
+        data_root: &Path,
+        state: &mut CoreRefreshEngineState,
+        request_id: &str,
+    ) {
+        let durable_id = durable_request_id(state, request_id);
+        let Some(retained_job) = durable_job_json(state, durable_id) else {
+            return;
+        };
+        if !matches!(
+            self.write_durable_admission_status(data_root, &retained_job),
+            DurableAdmissionPersistence::Confirmed
+        ) {
+            return;
+        }
+        let Some(attempt) = find_attempt_mut(state, request_id) else {
+            return;
+        };
+        attempt.admission_durability_indeterminate = false;
+        let durable_request_id = durable_request_id(state, request_id);
+        let Some(confirmed_job) = durable_job_json(state, durable_request_id) else {
+            return;
+        };
+        // The marker-bearing image was confirmed above, so a cleanup failure
+        // may leave the conservative marker on disk but cannot lose admission.
+        let _ = self.write_durable_admission_status(data_root, &confirmed_job);
+    }
+
+    pub(in crate::semantic) fn handle_listener_ipc_request(
+        &self,
+        data_root: &Path,
+        request: &Value,
+    ) -> Result<Option<Value>> {
+        handle_listener_ipc_request(self, data_root, request)
+    }
+
+    pub(in crate::semantic) fn finish_listener_admission_response(&self, request_id: &str) {
+        let mut state = self.lock_state();
+        let Some(remaining) = state.unacknowledged_admissions.get_mut(request_id) else {
+            return;
+        };
+        *remaining = remaining.saturating_sub(1);
+        if *remaining == 0 {
+            state.unacknowledged_admissions.remove(request_id);
+        }
+    }
+
+    #[cfg(test)]
+    pub(in crate::semantic) fn has_pending_admission(&self) -> bool {
+        self.lock_state()
+            .attempts
+            .iter()
+            .any(|attempt| attempt.state == SourceBackedRefreshState::AdmissionPending)
+    }
+
+    #[cfg(test)]
+    pub(in crate::semantic) fn prepare_next_pending_admission(
+        &self,
+        data_root: &Path,
+    ) -> Result<bool> {
+        let Some((request_id, requested_catalog)) = self.claim_next_pending_admission() else {
+            return Ok(false);
+        };
+        // Corpus-scale discovery must run without a coordinator or admission
+        // lock so status, ping, and additional bounded admissions stay live.
+        let observations = (self.admission_fence)(data_root, requested_catalog.as_ref());
+        self.complete_claimed_pending_admission(data_root, &request_id, observations)?;
+        Ok(true)
+    }
+
+    pub(super) fn resolve_active_pending_admission(
+        &self,
+        data_root: &Path,
+    ) -> Result<Option<SourceBackedRefreshRun>> {
+        let Some((request_id, requested_catalog)) = self.claim_active_pending_admission() else {
+            return Ok(None);
+        };
+        // Corpus-scale discovery must run without a coordinator or admission
+        // lock so status, ping, and additional bounded admissions stay live.
+        let observations = (self.admission_fence)(data_root, requested_catalog.as_ref());
+        self.complete_claimed_pending_admission(data_root, &request_id, observations)
+    }
+
+    pub(super) fn active_request_admission_pending(&self) -> bool {
+        let state = self.lock_state();
+        state
+            .active_request_id
+            .as_deref()
+            .and_then(|request_id| find_attempt(&state, request_id))
+            .is_some_and(|attempt| attempt.state == SourceBackedRefreshState::AdmissionPending)
+    }
+
+    pub(super) fn admission_persistence_retry_run(
+        &self,
+        error: anyhow::Error,
+    ) -> Option<SourceBackedRefreshRun> {
+        let mut state = self.lock_state();
+        let request_id = state.active_request_id.clone()?;
+        let attempt = find_attempt_mut(&mut state, &request_id)?;
+        if attempt.state != SourceBackedRefreshState::AdmissionPending {
+            return None;
+        }
+        attempt.last_error = Some(format!("persist source refresh admission: {error:#}"));
+        let scope = attempt.refresh_scope.clone();
+        let durable_request_id = durable_request_id(&state, &request_id);
+        let mut job = durable_job_json(&state, durable_request_id)?;
+        job["retryable"] = Value::Bool(true);
+        Some(SourceBackedRefreshRun {
+            job,
+            did_work: false,
+            failed: false,
+            terminal_persistence_pending: true,
+            scope,
+            coverage_certificate: None,
+        })
+    }
+
+    fn claim_active_pending_admission(
+        &self,
+    ) -> Option<(String, Option<ExplicitSourceCatalogAuthority>)> {
+        let mut state = self.lock_state();
+        let request_id = state.active_request_id.clone()?;
+        let attempt = find_attempt(&state, &request_id)?;
+        if attempt.state != SourceBackedRefreshState::AdmissionPending
+            || state.unacknowledged_admissions.contains_key(&request_id)
+            || state.admission_resolutions_in_flight.contains(&request_id)
+        {
+            return None;
+        }
+        let requested_catalog = attempt.requested_explicit_source_catalog.clone();
+        state
+            .admission_resolutions_in_flight
+            .insert(request_id.clone());
+        Some((request_id, requested_catalog))
+    }
+
+    #[cfg(test)]
+    fn claim_next_pending_admission(
+        &self,
+    ) -> Option<(String, Option<ExplicitSourceCatalogAuthority>)> {
+        let mut state = self.lock_state();
+        let request_id = state
+            .attempts
+            .iter()
+            .find(|attempt| {
+                attempt.state == SourceBackedRefreshState::AdmissionPending
+                    && !state
+                        .unacknowledged_admissions
+                        .contains_key(&attempt.request_id)
+                    && !state
+                        .admission_resolutions_in_flight
+                        .contains(&attempt.request_id)
+            })?
+            .request_id
+            .clone();
+        let requested_catalog = find_attempt(&state, &request_id)
+            .and_then(|attempt| attempt.requested_explicit_source_catalog.clone());
+        state
+            .admission_resolutions_in_flight
+            .insert(request_id.clone());
+        Some((request_id, requested_catalog))
+    }
+
+    fn complete_claimed_pending_admission(
+        &self,
+        data_root: &Path,
+        request_id: &str,
+        observations: Result<BTreeMap<SourceRouteIdentity, Option<String>>>,
+    ) -> Result<Option<SourceBackedRefreshRun>> {
+        let mut state = self.lock_state();
+        state.admission_resolutions_in_flight.remove(request_id);
+        if find_attempt(&state, request_id)
+            .is_none_or(|attempt| attempt.state != SourceBackedRefreshState::AdmissionPending)
+        {
+            return Ok(None);
+        }
+        match observations.and_then(validate_admission_observations) {
+            Ok(observations) => {
+                self.persist_resolved_admission(data_root, &mut state, request_id, observations)?;
+                Ok(None)
+            }
+            Err(error) => self.persist_failed_admission(data_root, &mut state, request_id, error),
+        }
+    }
+
+    fn persist_resolved_admission(
+        &self,
+        data_root: &Path,
+        state: &mut CoreRefreshEngineState,
+        request_id: &str,
+        mut observations: BTreeMap<SourceRouteIdentity, Option<String>>,
+    ) -> Result<()> {
+        let snapshot = AdmissionResolutionSnapshot::capture(state);
+        if state.manual_all_continuations.contains_key(request_id) {
+            let known_route_ids = state.known_route_ids.clone();
+            if observations.len().saturating_add(known_route_ids.len())
+                > SOURCE_REFRESH_TERMINAL_ROUTE_LIMIT.saturating_mul(2)
+            {
+                bail!("source refresh admission fence exceeds its bounded route capacity");
+            }
+            let ledger_eligible_routes = known_route_ids
+                .iter()
+                .filter(|route| observations.get(*route).is_none_or(Option::is_none))
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            for route in &known_route_ids {
+                observations.entry(route.clone()).or_insert(None);
+            }
+            if observations.len() > SOURCE_REFRESH_TERMINAL_ROUTE_LIMIT {
+                bail!("source refresh admission fence exceeds its bounded route capacity");
+            }
+            let admission_event_watermarks = observations
+                .keys()
+                .filter_map(|route| {
+                    state
+                        .route_event_watermarks
+                        .get(route)
+                        .copied()
+                        .map(|watermark| (route.clone(), watermark))
+                })
+                .collect::<BTreeMap<_, _>>();
+            let predecessor_request_id = state
+                .manual_all_continuations
+                .get(request_id)
+                .map(|continuation| continuation.predecessor_request_id.clone())
+                .ok_or_else(|| {
+                    anyhow!("source refresh request `{request_id}` lost its predecessor")
+                })?;
+            let predecessor_event_watermarks = state
+                .route_admission_watermarks
+                .get(&predecessor_request_id)
+                .cloned()
+                .or_else(|| {
+                    state
+                        .manual_all_continuations
+                        .get(request_id)
+                        .map(|continuation| continuation.predecessor_event_watermarks.clone())
+                })
+                .unwrap_or_default();
+            let continuation = state
+                .manual_all_continuations
+                .get_mut(request_id)
+                .ok_or_else(|| {
+                    anyhow!("source refresh request `{request_id}` lost its continuation")
+                })?;
+            continuation.admission_pending = false;
+            continuation.admission_route_observations = observations;
+            continuation.ledger_eligible_routes = ledger_eligible_routes;
+            continuation.admission_event_watermarks = admission_event_watermarks;
+            continuation.predecessor_event_watermarks = predecessor_event_watermarks;
+        }
+        let attempt = find_attempt_mut(state, request_id)
+            .ok_or_else(|| anyhow!("source refresh request `{request_id}` is unknown"))?;
+        attempt.state = SourceBackedRefreshState::Queued;
+        attempt.progress.phase = "queued".to_owned();
+        attempt.last_error = None;
+        apply_finished_predecessor_coverage(state, request_id);
+        let durable_request_id = durable_request_id(state, request_id);
+        let job = durable_job_json(state, durable_request_id)
+            .ok_or_else(|| anyhow!("source refresh request `{durable_request_id}` is unknown"))?;
+        if let Err(error) = self.write_status(data_root, &job) {
+            snapshot.restore(state);
+            return Err(error.context("persist resolved source refresh admission before execution"));
+        }
+        Ok(())
+    }
+
+    fn persist_failed_admission(
+        &self,
+        data_root: &Path,
+        state: &mut CoreRefreshEngineState,
+        request_id: &str,
+        error: anyhow::Error,
+    ) -> Result<Option<SourceBackedRefreshRun>> {
+        let snapshot = AdmissionResolutionSnapshot::capture(state);
+        state.manual_all_continuations.remove(request_id);
+        let (scope, last_error) = {
+            let attempt = find_attempt_mut(state, request_id)
+                .ok_or_else(|| anyhow!("source refresh request `{request_id}` is unknown"))?;
+            let last_error = format!("source refresh admission fence failed: {error:#}");
+            attempt.state = SourceBackedRefreshState::Failed;
+            attempt.finished_at_ms = Some(utc_now().timestamp_millis());
+            attempt.progress.phase = "failed".to_owned();
+            attempt.last_error = Some(last_error.clone());
+            (attempt.refresh_scope.clone(), last_error)
+        };
+        let job = durable_job_json(state, request_id)
+            .ok_or_else(|| anyhow!("source refresh request `{request_id}` is unknown"))?;
+        if let Err(persist_error) = self.write_status(data_root, &job) {
+            snapshot.restore(state);
+            return Err(persist_error.context("persist terminal source refresh admission failure"));
+        }
+        state.pending_scheduler_retry_root_id = Some(request_id.to_owned());
+        let observed_generation = state.current_published_generation.clone();
+        advance_after_terminal_attempt(state, request_id, observed_generation);
+        trim_terminal_attempt_history(state);
+        debug_assert_eq!(job["last_error"], last_error);
+        Ok(Some(SourceBackedRefreshRun {
+            job,
+            did_work: false,
+            failed: true,
+            terminal_persistence_pending: false,
+            scope,
+            coverage_certificate: None,
+        }))
+    }
+
+    #[cfg(test)]
+    pub(in crate::semantic) fn complete_pending_admission_for_test(
+        &self,
+        data_root: &Path,
+        request_id: &str,
+        observations: BTreeMap<SourceRouteIdentity, Option<String>>,
+    ) -> Result<()> {
+        let mut state = self.lock_state();
+        if find_attempt(&state, request_id)
+            .is_none_or(|attempt| attempt.state != SourceBackedRefreshState::AdmissionPending)
+        {
+            return Ok(());
+        }
+        self.persist_resolved_admission(
+            data_root,
+            &mut state,
+            request_id,
+            validate_admission_observations(observations)?,
+        )
+    }
+}
+
+fn validate_admission_observations(
+    observations: BTreeMap<SourceRouteIdentity, Option<String>>,
+) -> Result<BTreeMap<SourceRouteIdentity, Option<String>>> {
+    if observations.len() > SOURCE_REFRESH_TERMINAL_ROUTE_LIMIT {
+        bail!("source refresh admission fence exceeds its bounded route capacity");
+    }
+    if observations
+        .values()
+        .flatten()
+        .any(|observation| !is_sha256_identity(observation))
+    {
+        bail!("source refresh admission fence returned an invalid route observation");
+    }
+    Ok(observations)
+}
+
+fn increment_response_barrier(state: &mut CoreRefreshEngineState, request_id: &str) {
+    state
+        .unacknowledged_admissions
+        .entry(request_id.to_owned())
+        .and_modify(|count| *count = count.saturating_add(1))
+        .or_insert(1);
+}
+
+fn durable_request_id<'a>(state: &'a CoreRefreshEngineState, request_id: &'a str) -> &'a str {
+    if find_attempt(state, request_id).is_some_and(|attempt| !attempt.state.is_active()) {
+        return request_id;
+    }
+    state
+        .pending_scheduler_retry_root_id
+        .as_deref()
+        .or_else(|| {
+            state
+                .pending_terminal_persistence
+                .as_ref()
+                .map(|pending| pending.request_id.as_str())
+        })
+        .or(state.active_request_id.as_deref())
+        .unwrap_or(request_id)
+}
+
+fn apply_finished_predecessor_coverage(state: &mut CoreRefreshEngineState, request_id: &str) {
+    let Some(continuation) = state.manual_all_continuations.get(request_id).cloned() else {
+        return;
+    };
+    if !continuation.predecessor_finished || continuation.admission_pending {
+        return;
+    }
+    let Some(predecessor) = find_attempt(state, &continuation.predecessor_request_id).cloned()
+    else {
+        return;
+    };
+    let Some(receipt) = predecessor.receipt.as_ref() else {
+        return;
+    };
+    let continuation = state
+        .manual_all_continuations
+        .get_mut(request_id)
+        .expect("logical demand continuation");
+    for (route, admission_observation) in &continuation.admission_route_observations {
+        let covered = !continuation.invalidated_routes.contains(route)
+            && continuation.admission_event_watermarks.get(route)
+                == continuation.predecessor_event_watermarks.get(route)
+            && admission_observation.as_ref().is_some_and(|admitted| {
+                predecessor.route_observations.get(route) == Some(admitted)
+                    && receipt.route_results.iter().any(|result| {
+                        result.route_identity == route.as_str() && result.outcome.is_success()
+                    })
+            });
+        if covered {
+            if let Some(result) = receipt
+                .route_results
+                .iter()
+                .find(|result| result.route_identity == route.as_str())
+            {
+                continuation
+                    .covered_route_results
+                    .insert(route.clone(), result.clone());
+            }
+        }
+    }
+    continuation.covered_removed_source_count = receipt.current.removed_source_count;
+    continuation.covered_timings = predecessor.timings.unwrap_or_default();
+}
+
+struct AdmissionReservationSnapshot {
+    active_request_id: Option<String>,
+    pending_request_ids: VecDeque<String>,
+    attempts: VecDeque<SourceBackedRefreshAttempt>,
+    continuations: BTreeMap<String, ManualAllContinuation>,
+    response_barriers: BTreeMap<String, usize>,
+}
+
+impl AdmissionReservationSnapshot {
+    fn capture(state: &CoreRefreshEngineState) -> Self {
+        Self {
+            active_request_id: state.active_request_id.clone(),
+            pending_request_ids: state.pending_request_ids.clone(),
+            attempts: state.attempts.clone(),
+            continuations: state.manual_all_continuations.clone(),
+            response_barriers: state.unacknowledged_admissions.clone(),
+        }
+    }
+
+    fn restore(self, state: &mut CoreRefreshEngineState) {
+        state.active_request_id = self.active_request_id;
+        state.pending_request_ids = self.pending_request_ids;
+        state.attempts = self.attempts;
+        state.manual_all_continuations = self.continuations;
+        state.unacknowledged_admissions = self.response_barriers;
+    }
+}
+
+struct AdmissionResolutionSnapshot {
+    attempts: VecDeque<SourceBackedRefreshAttempt>,
+    continuations: BTreeMap<String, ManualAllContinuation>,
+}
+
+impl AdmissionResolutionSnapshot {
+    fn capture(state: &CoreRefreshEngineState) -> Self {
+        Self {
+            attempts: state.attempts.clone(),
+            continuations: state.manual_all_continuations.clone(),
+        }
+    }
+
+    fn restore(self, state: &mut CoreRefreshEngineState) {
+        state.attempts = self.attempts;
+        state.manual_all_continuations = self.continuations;
+    }
+}

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/admission_tests.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/admission_tests.rs
@@ -1,0 +1,340 @@
+use super::*;
+
+fn private_data_root() -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::tempdir().expect("temporary data root");
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root)
+        .expect("private data root");
+    (temp, data_root)
+}
+
+fn fresh_request(request_id: &str) -> Value {
+    compact_json(json!({
+        "schema_version": 1,
+        "op": SOURCE_REFRESH_REQUEST_OP,
+        "request_id": request_id,
+        "mode": "wait",
+        "operation": "refresh",
+        "fresh_after_admitted_snapshot": true,
+    }))
+}
+
+fn assert_retained_acknowledgement(response: &Value, request_id: &str) {
+    assert_eq!(response["ok"], true);
+    assert_eq!(response["request_id"], request_id);
+    assert_eq!(response["request_state"], "admission_pending");
+    assert_eq!(
+        response["disconnect_policy"],
+        "retain_after_durable_admission"
+    );
+    assert_retained_durability_fields(response);
+}
+
+fn assert_retained_durability_fields(response: &Value) {
+    assert_eq!(
+        response["admission_acknowledgement"],
+        "retained_after_durability_error"
+    );
+    assert_eq!(
+        response["admission_durability"],
+        "replacement_visible_or_indeterminate"
+    );
+}
+
+fn assert_reconfirmed_acknowledgement(response: &Value, request_id: &str) {
+    assert_eq!(response["ok"], true);
+    assert_eq!(response["request_id"], request_id);
+    assert!(response.get("admission_acknowledgement").is_none());
+    assert!(response.get("admission_durability").is_none());
+}
+
+#[test]
+fn listener_ack_is_durable_before_admission_discovery_can_start() {
+    let (_temp, data_root) = private_data_root();
+    let fence_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let observed_calls = Arc::clone(&fence_calls);
+    let coordinator =
+        CoreRefreshEngine::with_admission_fence_for_test(Arc::new(move |_data_root, _catalog| {
+            observed_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(BTreeMap::new())
+        }));
+    let request_id = "019fcaaa-0000-7000-8000-000000000294";
+
+    let response = coordinator
+        .handle_listener_ipc_request(&data_root, &fresh_request(request_id))
+        .unwrap()
+        .expect("admission response");
+
+    assert_eq!(response["request_id"], request_id);
+    assert_eq!(response["request_state"], "admission_pending");
+    assert_eq!(
+        response["disconnect_policy"],
+        "retain_after_durable_admission"
+    );
+    assert_eq!(fence_calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+    let durable = read_daemon_job_status(&daemon_source_backed_refresh_job_path(&data_root))
+        .expect("durable admission before acknowledgement");
+    assert_eq!(durable["request_id"], request_id);
+    assert_eq!(durable["request_state"], "admission_pending");
+
+    assert!(!coordinator
+        .prepare_next_pending_admission(&data_root)
+        .unwrap());
+    assert_eq!(fence_calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+    coordinator.finish_listener_admission_response(request_id);
+    assert!(coordinator
+        .prepare_next_pending_admission(&data_root)
+        .unwrap());
+    assert_eq!(fence_calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert_eq!(
+        coordinator.status(request_id).unwrap()["request_state"],
+        "queued"
+    );
+}
+
+#[test]
+fn failed_durable_admission_rolls_back_the_reserved_request() {
+    let (_temp, data_root) = private_data_root();
+    let coordinator = CoreRefreshEngine::with_status_writer_for_test(
+        Arc::new(CaptureOwnedSourceBackedRefreshExecutor),
+        Arc::new(|_path, _job| bail!("injected durable admission failure")),
+    );
+    let request_id = "019fcaaa-0000-7000-8000-000000000295";
+
+    let error = coordinator
+        .handle_listener_ipc_request(&data_root, &fresh_request(request_id))
+        .unwrap_err();
+
+    assert!(format!("{error:#}").contains("persist durable source refresh admission"));
+    assert!(coordinator.status(request_id).is_none());
+    assert!(!coordinator.has_pending_request());
+    assert!(!coordinator.has_pending_admission());
+}
+
+#[test]
+fn post_replacement_chmod_error_retains_and_acknowledges_the_request() {
+    let (_temp, data_root) = private_data_root();
+    let fail_once = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let injected = Arc::clone(&fail_once);
+    let coordinator = CoreRefreshEngine::with_runtime(
+        Arc::new(CaptureOwnedSourceBackedRefreshExecutor),
+        Arc::new(|_data_root, _catalog| Ok(BTreeMap::new())),
+        Arc::new(move |path, job| {
+            if injected.swap(false, std::sync::atomic::Ordering::SeqCst) {
+                return crate::semantic::paths_status::write_private_json_with_chmod_fault(
+                    path, job,
+                );
+            }
+            write_daemon_job_status(path, job)
+        }),
+    );
+    let request_id = "019fcaaa-0000-7000-8000-000000000298";
+
+    let response = coordinator
+        .handle_listener_ipc_request(&data_root, &fresh_request(request_id))
+        .unwrap()
+        .expect("retained admission acknowledgement");
+
+    assert_retained_acknowledgement(&response, request_id);
+    assert!(coordinator.has_pending_admission());
+    let retained = read_daemon_job_status(&daemon_source_backed_refresh_job_path(&data_root))
+        .expect("replacement-visible admission retains its durability marker");
+    assert_eq!(retained["request_id"], request_id);
+    assert_retained_durability_fields(&retained);
+    let replay = coordinator
+        .handle_listener_ipc_request(&data_root, &fresh_request(request_id))
+        .unwrap()
+        .expect("same-ID replay reconfirms admission durability");
+    assert_reconfirmed_acknowledgement(&replay, request_id);
+    coordinator.finish_listener_admission_response(request_id);
+    coordinator.finish_listener_admission_response(request_id);
+    assert!(coordinator
+        .prepare_next_pending_admission(&data_root)
+        .unwrap());
+    assert_eq!(
+        coordinator.status(request_id).unwrap()["request_state"],
+        "queued"
+    );
+}
+
+#[test]
+fn post_replacement_parent_sync_error_retains_and_acknowledges_the_request() {
+    let (_temp, data_root) = private_data_root();
+    let coordinator =
+        CoreRefreshEngine::with_admission_fence_for_test(Arc::new(|_data_root, _catalog| {
+            Ok(BTreeMap::new())
+        }));
+    let request_id = "019fcaaa-0000-7000-8000-000000000299";
+    super::durable_queue::fail_next_admission_parent_sync_for_test();
+
+    let response = coordinator
+        .handle_listener_ipc_request(&data_root, &fresh_request(request_id))
+        .unwrap()
+        .expect("retained admission acknowledgement");
+
+    assert_retained_acknowledgement(&response, request_id);
+    assert!(coordinator.has_pending_admission());
+    let retained = read_daemon_job_status(&daemon_source_backed_refresh_job_path(&data_root))
+        .expect("parent-sync failure retains its durability marker");
+    assert_eq!(retained["request_id"], request_id);
+    assert_retained_durability_fields(&retained);
+    let replay = coordinator
+        .handle_listener_ipc_request(&data_root, &fresh_request(request_id))
+        .unwrap()
+        .expect("same-ID replay reconfirms admission durability");
+    assert_reconfirmed_acknowledgement(&replay, request_id);
+    coordinator.finish_listener_admission_response(request_id);
+    coordinator.finish_listener_admission_response(request_id);
+    assert!(coordinator
+        .prepare_next_pending_admission(&data_root)
+        .unwrap());
+    assert_eq!(
+        coordinator.status(request_id).unwrap()["request_state"],
+        "queued"
+    );
+}
+
+#[test]
+fn same_id_replay_preserves_persistently_indeterminate_admission_durability() {
+    let (_temp, data_root) = private_data_root();
+    let coordinator = CoreRefreshEngine::with_status_writer_for_test(
+        Arc::new(CaptureOwnedSourceBackedRefreshExecutor),
+        Arc::new(crate::semantic::paths_status::write_private_json_with_chmod_fault),
+    );
+    let request_id = "019fcaaa-0000-7000-8000-0000000002a2";
+    let request = fresh_request(request_id);
+
+    let first = coordinator
+        .handle_listener_ipc_request(&data_root, &request)
+        .unwrap()
+        .expect("retained first admission acknowledgement");
+    let replay = coordinator
+        .handle_listener_ipc_request(&data_root, &request)
+        .unwrap()
+        .expect("retained same-ID replay acknowledgement");
+
+    assert_retained_acknowledgement(&first, request_id);
+    assert_retained_acknowledgement(&replay, request_id);
+    let durable = read_daemon_job_status(&daemon_source_backed_refresh_job_path(&data_root))
+        .expect("replacement-visible durable admission");
+    assert_eq!(durable["request_id"], request_id);
+    assert_eq!(
+        durable["admission_acknowledgement"],
+        "retained_after_durability_error"
+    );
+    assert_eq!(
+        durable["admission_durability"],
+        "replacement_visible_or_indeterminate"
+    );
+}
+
+#[test]
+fn stable_request_id_replay_requires_the_exact_same_payload() {
+    let (_temp, data_root) = private_data_root();
+    let coordinator = CoreRefreshEngine::new();
+    let request_id = "019fcaaa-0000-7000-8000-000000000296";
+    let request = fresh_request(request_id);
+
+    let first = coordinator
+        .handle_ipc_request(&data_root, &request)
+        .unwrap()
+        .expect("first response");
+    let replay = coordinator
+        .handle_ipc_request(&data_root, &request)
+        .unwrap()
+        .expect("idempotent replay");
+    assert_eq!(replay, first);
+
+    let mut changed = request;
+    changed["fresh_after_admitted_snapshot"] = Value::Bool(false);
+    let conflict = coordinator
+        .handle_ipc_request(&data_root, &changed)
+        .unwrap()
+        .expect("typed request conflict");
+    assert_eq!(conflict["ok"], false);
+    assert_eq!(conflict["request_id"], request_id);
+    assert_eq!(conflict["request_state"], "request_conflict");
+    assert_eq!(conflict["error_code"], "request_id_conflict");
+    assert_eq!(conflict["retryable"], false);
+}
+
+#[test]
+fn restart_recovers_and_resumes_a_durable_pending_admission() {
+    let (_temp, data_root) = private_data_root();
+    let request_id = "019fcaaa-0000-7000-8000-000000000297";
+    let first = CoreRefreshEngine::new();
+    let response = first
+        .handle_listener_ipc_request(&data_root, &fresh_request(request_id))
+        .unwrap()
+        .expect("durable admission response");
+    assert_eq!(response["request_state"], "admission_pending");
+    drop(first);
+
+    let recovered =
+        CoreRefreshEngine::with_admission_fence_for_test(Arc::new(|_data_root, _catalog| {
+            Ok(BTreeMap::new())
+        }));
+    assert!(recovered
+        .recover_interrupted_publication(&data_root)
+        .unwrap());
+    assert_eq!(
+        recovered.status(request_id).unwrap()["request_state"],
+        "admission_pending"
+    );
+    assert!(recovered
+        .prepare_next_pending_admission(&data_root)
+        .unwrap());
+    assert_eq!(
+        recovered.status(request_id).unwrap()["request_state"],
+        "queued"
+    );
+}
+
+#[test]
+fn crash_restart_preserves_a_logical_successors_non_null_generation_baseline() {
+    let generation_zero = "10".repeat(32);
+    let generation_one = "21".repeat(32);
+    let mut predecessor = new_refresh_attempt(
+        Some(generation_zero.clone()),
+        SourceRefreshRuntimeMetadata::periodic(),
+        None,
+        SourceBackedRefreshScope::All,
+    );
+    predecessor.request_id = "019fcaaa-0000-7000-8000-0000000002a0".to_owned();
+    predecessor.state = SourceBackedRefreshState::Published;
+    predecessor.published_generation = Some(generation_one.clone());
+    let mut successor = new_refresh_attempt(
+        Some(generation_zero.clone()),
+        SourceRefreshRuntimeMetadata::default(),
+        None,
+        SourceBackedRefreshScope::All,
+    );
+    successor.request_id = "019fcaaa-0000-7000-8000-0000000002a1".to_owned();
+    successor.fresh_after_admitted_snapshot = true;
+    let mut interrupted = predecessor.job_json();
+    interrupted["queued_successors"] = Value::Array(vec![successor.job_json()]);
+
+    let mut recovered = recover_queued_successors(&interrupted)
+        .expect("recover successor after predecessor pointer publication")
+        .pop()
+        .expect("persisted logical successor");
+    recovered.state = SourceBackedRefreshState::Published;
+    recovered.published_generation = Some(generation_one.clone());
+    recovered.receipt = Some(SourceBackedRefreshReceipt {
+        previous_generation: recovered.previous_generation.clone(),
+        published_generation: generation_one,
+        generation_changed: true,
+        published_explicit_source_catalog: None,
+        current: SourceBackedRefreshCurrent::default(),
+        route_results: Vec::new(),
+        catalog_route_bindings: Vec::new(),
+    });
+
+    let terminal = recovered.to_json();
+    assert_eq!(terminal["previous_generation"], generation_zero);
+    assert_eq!(terminal["generation_changed"], true);
+    assert_eq!(
+        terminal["receipt"]["previous_generation"],
+        terminal["previous_generation"]
+    );
+}

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/attempt_helpers.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/attempt_helpers.rs
@@ -104,6 +104,11 @@ pub(super) fn new_refresh_attempt(
         refresh_scope,
         operation: metadata.operation,
         requested_explicit_source_catalog: requested_catalog,
+        fresh_after_admitted_snapshot: false,
+        request_fingerprint: None,
+        admission_durability_indeterminate: false,
+        coalesced_into_request_id: None,
+        coalesced_logical_demands: 0,
         coalesced_requests: 0,
         progress: SourceBackedRefreshProgress::default(),
         scanned_routes: None,
@@ -120,6 +125,19 @@ pub(super) fn new_refresh_attempt(
         trigger_provenance: metadata.trigger_provenance,
         failure_type: None,
         last_error: None,
+    }
+}
+
+pub(super) fn recover_admission_durability(job: &Value, context: &str) -> Result<bool> {
+    match (
+        job.get("admission_acknowledgement").and_then(Value::as_str),
+        job.get("admission_durability").and_then(Value::as_str),
+    ) {
+        (None, None) => Ok(false),
+        (Some("retained_after_durability_error"), Some("replacement_visible_or_indeterminate")) => {
+            Ok(true)
+        }
+        _ => bail!("{context} has invalid admission durability state"),
     }
 }
 

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/coverage_contract.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/coverage_contract.rs
@@ -4,6 +4,7 @@ use super::*;
 pub(super) struct ManualAllContinuation {
     pub(super) predecessor_request_id: String,
     pub(super) predecessor_finished: bool,
+    pub(super) admission_pending: bool,
     pub(super) admission_route_observations: BTreeMap<SourceRouteIdentity, Option<String>>,
     pub(super) ledger_eligible_routes: BTreeSet<SourceRouteIdentity>,
     pub(super) admission_event_watermarks: BTreeMap<SourceRouteIdentity, EventWatermark>,
@@ -25,6 +26,7 @@ impl ManualAllContinuation {
         Self {
             predecessor_request_id,
             predecessor_finished: false,
+            admission_pending: false,
             admission_route_observations,
             ledger_eligible_routes,
             admission_event_watermarks,
@@ -34,6 +36,18 @@ impl ManualAllContinuation {
             covered_removed_source_count: 0,
             covered_timings: SourceBackedRefreshTimings::default(),
         }
+    }
+
+    pub(super) fn pending(predecessor_request_id: String) -> Self {
+        let mut continuation = Self::new(
+            predecessor_request_id,
+            BTreeMap::new(),
+            BTreeSet::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        );
+        continuation.admission_pending = true;
+        continuation
     }
 
     pub(super) fn invalidate_route(&mut self, route: &SourceRouteIdentity) {
@@ -57,7 +71,8 @@ impl ManualAllContinuation {
     }
 
     pub(super) fn is_fully_covered(&self) -> bool {
-        self.invalidated_routes.is_empty()
+        !self.admission_pending
+            && self.invalidated_routes.is_empty()
             && self
                 .admission_route_observations
                 .keys()
@@ -85,6 +100,7 @@ impl ManualAllContinuation {
         compact_json(json!({
             "predecessor_request_id": self.predecessor_request_id,
             "predecessor_finished": self.predecessor_finished,
+            "admission_pending": self.admission_pending,
             "admission_route_observations": admission_route_observations,
             "ledger_eligible_routes": self.ledger_eligible_routes
                 .iter()
@@ -113,6 +129,15 @@ impl ManualAllContinuation {
             .get("predecessor_finished")
             .and_then(Value::as_bool)
             .ok_or_else(|| anyhow!("logical refresh demand has no predecessor terminal state"))?;
+        let admission_pending = value
+            .get("admission_pending")
+            .map(|value| {
+                value
+                    .as_bool()
+                    .ok_or_else(|| anyhow!("logical refresh demand admission state is invalid"))
+            })
+            .transpose()?
+            .unwrap_or(false);
         let admission = value
             .get("admission_route_observations")
             .and_then(Value::as_object)
@@ -248,6 +273,7 @@ impl ManualAllContinuation {
         Ok(Self {
             predecessor_request_id,
             predecessor_finished,
+            admission_pending,
             admission_route_observations,
             ledger_eligible_routes,
             admission_event_watermarks,

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/durable_queue.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/durable_queue.rs
@@ -9,6 +9,30 @@ const DAEMON_RETRY_FIELDS: [&str; 4] = [
     "retry_not_before_at_ms",
 ];
 
+pub(super) enum DurableAdmissionPersistence {
+    Confirmed,
+    Retained(anyhow::Error),
+    Failed(anyhow::Error),
+}
+
+#[cfg(test)]
+thread_local! {
+    static FAIL_NEXT_ADMISSION_PARENT_SYNC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(test)]
+pub(super) fn fail_next_admission_parent_sync_for_test() {
+    FAIL_NEXT_ADMISSION_PARENT_SYNC.with(|fail| fail.set(true));
+}
+
+fn sync_durable_admission_parent(path: &Path) -> Result<()> {
+    #[cfg(test)]
+    if FAIL_NEXT_ADMISSION_PARENT_SYNC.with(std::cell::Cell::take) {
+        bail!("injected durable admission parent sync failure");
+    }
+    crate::semantic::paths_status::sync_private_file_parent(path)
+}
+
 impl CoreRefreshEngine {
     pub(super) fn persist_job_status(&self, data_root: &Path, request_id: &str) -> Result<()> {
         let state = self.lock_state();
@@ -38,7 +62,7 @@ impl CoreRefreshEngine {
     }
 
     #[cfg(test)]
-    pub(in super::super) fn persist_job_status_for_test(
+    pub(in crate::semantic) fn persist_job_status_for_test(
         &self,
         data_root: &Path,
         request_id: &str,
@@ -48,6 +72,29 @@ impl CoreRefreshEngine {
 
     pub(super) fn write_status(&self, data_root: &Path, job: &Value) -> Result<()> {
         (self.status_writer)(&daemon_source_backed_refresh_job_path(data_root), job)
+    }
+
+    pub(super) fn write_durable_admission_status(
+        &self,
+        data_root: &Path,
+        job: &Value,
+    ) -> DurableAdmissionPersistence {
+        let path = daemon_source_backed_refresh_job_path(data_root);
+        if let Err(error) = (self.status_writer)(&path, job) {
+            return if error
+                .downcast_ref::<crate::semantic::paths_status::PrivateJsonReplacementError>()
+                .is_some()
+                || read_daemon_job_status(&path).as_ref() == Some(job)
+            {
+                DurableAdmissionPersistence::Retained(error)
+            } else {
+                DurableAdmissionPersistence::Failed(error)
+            };
+        }
+        match sync_durable_admission_parent(&path) {
+            Ok(()) => DurableAdmissionPersistence::Confirmed,
+            Err(error) => DurableAdmissionPersistence::Retained(error),
+        }
     }
 
     pub(in super::super) fn persist_progress(
@@ -183,9 +230,12 @@ pub(super) fn job_with_queued_successors(state: &CoreRefreshEngineState, mut job
         .as_deref()
         .filter(|request_id| Some(*request_id) != root_request_id)
     {
-        if let Some(active) = find_attempt(state, active_request_id)
-            .filter(|attempt| attempt.state == SourceBackedRefreshState::Queued)
-        {
+        if let Some(active) = find_attempt(state, active_request_id).filter(|attempt| {
+            matches!(
+                attempt.state,
+                SourceBackedRefreshState::AdmissionPending | SourceBackedRefreshState::Queued
+            )
+        }) {
             successors.push(job_with_logical_demand(state, active.job_json()));
         }
     }
@@ -194,7 +244,12 @@ pub(super) fn job_with_queued_successors(state: &CoreRefreshEngineState, mut job
             .pending_request_ids
             .iter()
             .filter_map(|request_id| find_attempt(state, request_id))
-            .filter(|attempt| attempt.state == SourceBackedRefreshState::Queued)
+            .filter(|attempt| {
+                matches!(
+                    attempt.state,
+                    SourceBackedRefreshState::AdmissionPending | SourceBackedRefreshState::Queued
+                )
+            })
             .map(SourceBackedRefreshAttempt::job_json)
             .map(|job| job_with_logical_demand(state, job)),
     );
@@ -265,10 +320,7 @@ pub(super) fn recover_logical_demand_continuations(
     Ok(recovered)
 }
 
-pub(super) fn recover_queued_successors(
-    job: &Value,
-    previous_generation: Option<String>,
-) -> Result<Vec<SourceBackedRefreshAttempt>> {
+pub(super) fn recover_queued_successors(job: &Value) -> Result<Vec<SourceBackedRefreshAttempt>> {
     let Some(successors) = job.get(QUEUED_SUCCESSORS_FIELD) else {
         return Ok(Vec::new());
     };
@@ -280,7 +332,7 @@ pub(super) fn recover_queued_successors(
         .and_then(Value::as_str)
         .ok_or_else(|| anyhow!("durable source refresh job has no request state"))?;
     match root_state {
-        "queued" | "running" | "failed" | "published" => {}
+        "admission_pending" | "queued" | "running" | "failed" | "published" => {}
         _ => bail!("durable source refresh job has an invalid request state"),
     }
     if successors.len().saturating_add(1) > SOURCE_REFRESH_ACTIVE_PENDING_LIMIT {
@@ -297,8 +349,12 @@ pub(super) fn recover_queued_successors(
         if successor.get(QUEUED_SUCCESSORS_FIELD).is_some() {
             bail!("durable source refresh successor queue must not be nested");
         }
-        let attempt =
-            recover_pending_attempt(successor, previous_generation.clone(), "successor", false)?;
+        let attempt = recover_pending_attempt(
+            successor,
+            optional_generation(successor.get("previous_generation"))?,
+            "successor",
+            false,
+        )?;
         if !request_ids.insert(attempt.request_id.clone()) {
             bail!("durable source refresh successor request ID is duplicated");
         }
@@ -321,7 +377,9 @@ fn recover_pending_attempt(
     is_root: bool,
 ) -> Result<SourceBackedRefreshAttempt> {
     let request_state = job.get("request_state").and_then(Value::as_str);
-    if request_state != Some("queued") && !(is_root && request_state == Some("running")) {
+    if !matches!(request_state, Some("admission_pending" | "queued"))
+        && !(is_root && request_state == Some("running"))
+    {
         bail!("durable source refresh {role} is not queued");
     }
     let request_id = job
@@ -385,6 +443,31 @@ fn recover_pending_attempt(
         refresh_scope,
     );
     attempt.request_id = request_id.to_owned();
+    attempt.state = if request_state == Some("admission_pending") {
+        SourceBackedRefreshState::AdmissionPending
+    } else {
+        SourceBackedRefreshState::Queued
+    };
+    attempt.fresh_after_admitted_snapshot = match job.get("fresh_after_admitted_snapshot") {
+        None => false,
+        Some(value) => value.as_bool().ok_or_else(|| {
+            anyhow!("durable source refresh {role} has invalid freshness requirement")
+        })?,
+    };
+    attempt.request_fingerprint = optional_sha256(job, "request_fingerprint")?;
+    attempt.admission_durability_indeterminate =
+        recover_admission_durability(job, &format!("durable source refresh {role}"))?;
+    attempt.coalesced_into_request_id = job
+        .get("coalesced_into_request_id")
+        .filter(|value| !value.is_null())
+        .map(|value| {
+            value
+                .as_str()
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .ok_or_else(|| anyhow!("durable source refresh {role} has invalid predecessor ID"))
+        })
+        .transpose()?;
     if let Some(requested_at_ms) = job
         .get("requested_at_ms")
         .or_else(|| job.get("last_run_at_ms"))
@@ -398,7 +481,31 @@ fn recover_pending_attempt(
             anyhow!("durable source refresh {role} has invalid coalesced request count")
         })?;
     }
+    if let Some(coalesced_logical_demands) = job.get("coalesced_logical_demands") {
+        attempt.coalesced_logical_demands =
+            coalesced_logical_demands.as_u64().ok_or_else(|| {
+                anyhow!("durable source refresh {role} has invalid logical demand count")
+            })?;
+    }
+    if attempt.state == SourceBackedRefreshState::AdmissionPending
+        && !attempt.fresh_after_admitted_snapshot
+    {
+        bail!("durable admission-pending source refresh has no freshness requirement");
+    }
     Ok(attempt)
+}
+
+fn optional_sha256(job: &Value, field: &str) -> Result<Option<String>> {
+    job.get(field)
+        .filter(|value| !value.is_null())
+        .map(|value| {
+            value
+                .as_str()
+                .filter(|value| is_sha256_identity(value))
+                .map(str::to_owned)
+                .ok_or_else(|| anyhow!("durable source refresh has invalid `{field}`"))
+        })
+        .transpose()
 }
 
 fn recover_static_job_field(

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/progress_model.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/progress_model.rs
@@ -19,6 +19,7 @@ impl SourceBackedRefreshTimings {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(super) enum SourceBackedRefreshState {
+    AdmissionPending,
     Queued,
     Running,
     Published,
@@ -28,6 +29,7 @@ pub(super) enum SourceBackedRefreshState {
 impl SourceBackedRefreshState {
     pub(super) fn as_str(self) -> &'static str {
         match self {
+            Self::AdmissionPending => "admission_pending",
             Self::Queued => "queued",
             Self::Running => "running",
             Self::Published => "published",
@@ -36,7 +38,7 @@ impl SourceBackedRefreshState {
     }
 
     pub(super) fn is_active(self) -> bool {
-        matches!(self, Self::Queued | Self::Running)
+        matches!(self, Self::AdmissionPending | Self::Queued | Self::Running)
     }
 }
 

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/read_model.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/read_model.rs
@@ -654,6 +654,11 @@ pub(super) struct SourceBackedRefreshAttempt {
     pub(super) refresh_scope: SourceBackedRefreshScope,
     pub(super) operation: SourceBackedRefreshOperation,
     pub(super) requested_explicit_source_catalog: Option<ExplicitSourceCatalogAuthority>,
+    pub(super) fresh_after_admitted_snapshot: bool,
+    pub(super) request_fingerprint: Option<String>,
+    pub(super) admission_durability_indeterminate: bool,
+    pub(super) coalesced_into_request_id: Option<String>,
+    pub(super) coalesced_logical_demands: u64,
     pub(super) coalesced_requests: u64,
     pub(super) progress: SourceBackedRefreshProgress,
     pub(super) scanned_routes: Option<usize>,
@@ -722,6 +727,15 @@ impl SourceBackedRefreshAttempt {
                     .as_ref()
                     .map(ExplicitSourceCatalogAuthority::to_json)
             }).flatten(),
+            "fresh_after_admitted_snapshot": self.fresh_after_admitted_snapshot,
+            "request_fingerprint": self.request_fingerprint,
+            "admission_acknowledgement": self.admission_durability_indeterminate
+                .then_some("retained_after_durability_error"),
+            "admission_durability": self.admission_durability_indeterminate
+                .then_some("replacement_visible_or_indeterminate"),
+            "disconnect_policy": "retain_after_durable_admission",
+            "coalesced_into_request_id": self.coalesced_into_request_id,
+            "coalesced_logical_demands": self.coalesced_logical_demands,
             "generation_changed": self.request_generation_changed(),
             "receipt": publication_receipt.map(SourceBackedRefreshReceipt::to_json),
             "request_outcome": self.request_outcome_receipt()
@@ -748,7 +762,9 @@ impl SourceBackedRefreshAttempt {
         let status = match self.state {
             SourceBackedRefreshState::Published => "completed",
             SourceBackedRefreshState::Failed => "failed",
-            SourceBackedRefreshState::Queued | SourceBackedRefreshState::Running => "running",
+            SourceBackedRefreshState::AdmissionPending
+            | SourceBackedRefreshState::Queued
+            | SourceBackedRefreshState::Running => "running",
         };
         let publication_receipt = self.publication_receipt.as_ref().or(self.receipt.as_ref());
         compact_json(json!({
@@ -772,6 +788,15 @@ impl SourceBackedRefreshAttempt {
                     .as_ref()
                     .map(ExplicitSourceCatalogAuthority::to_json)
             }).flatten(),
+            "fresh_after_admitted_snapshot": self.fresh_after_admitted_snapshot,
+            "request_fingerprint": self.request_fingerprint,
+            "admission_acknowledgement": self.admission_durability_indeterminate
+                .then_some("retained_after_durability_error"),
+            "admission_durability": self.admission_durability_indeterminate
+                .then_some("replacement_visible_or_indeterminate"),
+            "disconnect_policy": "retain_after_durable_admission",
+            "coalesced_into_request_id": self.coalesced_into_request_id,
+            "coalesced_logical_demands": self.coalesced_logical_demands,
             "generation_changed": self.request_generation_changed(),
             "receipt": publication_receipt.map(SourceBackedRefreshReceipt::to_json),
             "request_outcome": self.request_outcome_receipt()

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/request_lifecycle.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/request_lifecycle.rs
@@ -14,6 +14,8 @@ impl CoreRefreshEngine {
                 admission: SourceRefreshAdmissionRequirement::AttachEquivalent,
                 route_observations: BTreeMap::new(),
                 request_id: None,
+                request_fingerprint: None,
+                admission_pending: false,
             },
         )
     }
@@ -47,6 +49,8 @@ impl CoreRefreshEngine {
                 admission: SourceRefreshAdmissionRequirement::FreshAfterAdmittedSnapshot,
                 route_observations: admission_route_observations,
                 request_id: Some(request_id),
+                request_fingerprint: None,
+                admission_pending: false,
             },
         )
     }
@@ -73,6 +77,8 @@ impl CoreRefreshEngine {
                 admission: SourceRefreshAdmissionRequirement::FreshAfterAdmittedSnapshot,
                 route_observations: BTreeMap::new(),
                 request_id: Some(request_id),
+                request_fingerprint: None,
+                admission_pending: false,
             },
         ) {
             Ok(response) => response,
@@ -106,6 +112,8 @@ impl CoreRefreshEngine {
                 admission: SourceRefreshAdmissionRequirement::AttachEquivalent,
                 route_observations: BTreeMap::new(),
                 request_id: None,
+                request_fingerprint: None,
+                admission_pending: false,
             },
         )
         .expect("requests without catalog authority always coalesce")
@@ -119,16 +127,44 @@ impl CoreRefreshEngine {
         refresh_scope: SourceBackedRefreshScope,
         logical_demand: SourceRefreshLogicalDemand,
     ) -> Result<Value> {
+        let mut state = self.lock_state();
+        let response = Self::enqueue_with_catalog_metadata_locked(
+            &mut state,
+            observed_generation,
+            metadata,
+            requested_catalog,
+            refresh_scope,
+            logical_demand,
+        )?;
+        trim_terminal_attempt_history(&mut state);
+        Ok(response)
+    }
+
+    pub(super) fn enqueue_with_catalog_metadata_locked(
+        state: &mut CoreRefreshEngineState,
+        observed_generation: Option<String>,
+        metadata: SourceRefreshRuntimeMetadata,
+        requested_catalog: Option<ExplicitSourceCatalogAuthority>,
+        refresh_scope: SourceBackedRefreshScope,
+        logical_demand: SourceRefreshLogicalDemand,
+    ) -> Result<Value> {
         let SourceRefreshLogicalDemand {
             admission,
             route_observations: mut admission_route_observations,
             request_id: logical_request_id,
+            request_fingerprint,
+            admission_pending,
         } = logical_demand;
-        let mut state = self.lock_state();
         if let Some(existing) = logical_request_id
             .as_deref()
-            .and_then(|request_id| find_attempt(&state, request_id))
+            .and_then(|request_id| find_attempt(state, request_id))
         {
+            if existing.request_fingerprint.as_ref() != request_fingerprint.as_ref() {
+                return Err(SourceBackedRefreshIdempotencyConflict {
+                    request_id: existing.request_id.clone(),
+                }
+                .into());
+            }
             return Ok(existing.to_json());
         }
         let is_manual_all = admission
@@ -136,12 +172,26 @@ impl CoreRefreshEngine {
             && refresh_scope == SourceBackedRefreshScope::All;
         let mut continuation_predecessor = None;
         if let Some(active_request_id) = state.active_request_id.clone() {
-            if let Some(active) = find_attempt_mut(&mut state, &active_request_id) {
+            if let Some(active) = find_attempt_mut(state, &active_request_id) {
                 if active.state.is_active() {
-                    if is_manual_all && active.state == SourceBackedRefreshState::Running {
+                    if is_manual_all {
                         continuation_predecessor = Some(active.request_id.clone());
-                    }
-                    if admission.requires_successor(active.state) {
+                        if active.state == SourceBackedRefreshState::Queued {
+                            if let Some(requested_catalog) = requested_catalog.as_ref() {
+                                if active.requested_explicit_source_catalog.is_none() {
+                                    active.requested_explicit_source_catalog =
+                                        Some(requested_catalog.clone());
+                                }
+                            }
+                            active.refresh_scope = SourceBackedRefreshScope::All;
+                            let _ = coalesce_attempt(active, metadata);
+                            active.coalesced_logical_demands =
+                                active.coalesced_logical_demands.saturating_add(1);
+                        } else {
+                            active.coalesced_logical_demands =
+                                active.coalesced_logical_demands.saturating_add(1);
+                        }
+                    } else if admission.requires_successor(active.state) {
                         // A logical freshness demand attaches to the immutable
                         // physical attempt, then proves coverage after its
                         // publication instead of eagerly repeating the pass.
@@ -182,7 +232,7 @@ impl CoreRefreshEngine {
             && requested_catalog.is_some()
         {
             let coalesced_request_id = state.pending_request_ids.iter().find_map(|request_id| {
-                find_attempt(&state, request_id)
+                find_attempt(state, request_id)
                     .filter(|attempt| {
                         attempt.state.is_active()
                             && attempt.requested_explicit_source_catalog.as_ref()
@@ -192,13 +242,13 @@ impl CoreRefreshEngine {
                     .map(|attempt| attempt.request_id.clone())
             });
             if let Some(coalesced_request_id) = coalesced_request_id {
-                let attempt = find_attempt_mut(&mut state, &coalesced_request_id)
+                let attempt = find_attempt_mut(state, &coalesced_request_id)
                     .expect("pending source refresh attempt");
                 return Ok(coalesce_attempt(attempt, metadata));
             }
         }
 
-        let active_pending_requests = durable_queue_entry_count(&state);
+        let active_pending_requests = durable_queue_entry_count(state);
         if active_pending_requests >= SOURCE_REFRESH_ACTIVE_PENDING_LIMIT {
             return Err(SourceBackedRefreshQueueFull {
                 active_pending_requests,
@@ -215,13 +265,15 @@ impl CoreRefreshEngine {
         if let Some(logical_request_id) = logical_request_id {
             attempt.request_id = logical_request_id;
         }
-        let response = attempt.to_json();
+        attempt.request_fingerprint = request_fingerprint;
+        attempt.fresh_after_admitted_snapshot =
+            admission == SourceRefreshAdmissionRequirement::FreshAfterAdmittedSnapshot;
         let request_id = attempt.request_id.clone();
         let terminal_persistence_owns_root = state.pending_terminal_persistence.is_some();
         let active_attempt_owns_root = state
             .active_request_id
             .as_deref()
-            .and_then(|request_id| find_attempt(&state, request_id))
+            .and_then(|request_id| find_attempt(state, request_id))
             .is_some_and(|attempt| attempt.state.is_active());
         if terminal_persistence_owns_root || active_attempt_owns_root {
             state.pending_request_ids.push_back(request_id.clone());
@@ -229,46 +281,60 @@ impl CoreRefreshEngine {
             state.active_request_id = Some(request_id.clone());
         }
         if let Some(predecessor_request_id) = continuation_predecessor {
-            let ledger_eligible_routes = state
-                .known_route_ids
-                .iter()
-                .filter(|route| !admission_route_observations.contains_key(*route))
-                .cloned()
-                .collect();
-            for route in &state.known_route_ids {
-                admission_route_observations
-                    .entry(route.clone())
-                    .or_insert(None);
-            }
-            let admission_event_watermarks = admission_route_observations
-                .keys()
-                .filter_map(|route| {
-                    state
-                        .route_event_watermarks
-                        .get(route)
-                        .copied()
-                        .map(|watermark| (route.clone(), watermark))
-                })
-                .collect();
-            let predecessor_event_watermarks = state
-                .route_admission_watermarks
-                .get(&predecessor_request_id)
-                .cloned()
-                .unwrap_or_default();
-            state.manual_all_continuations.insert(
-                request_id,
+            attempt.coalesced_into_request_id = Some(predecessor_request_id.clone());
+            let continuation = if admission_pending {
+                ManualAllContinuation::pending(predecessor_request_id)
+            } else {
+                let ledger_eligible_routes = state
+                    .known_route_ids
+                    .iter()
+                    .filter(|route| {
+                        admission_route_observations
+                            .get(*route)
+                            .is_none_or(Option::is_none)
+                    })
+                    .cloned()
+                    .collect();
+                for route in &state.known_route_ids {
+                    admission_route_observations
+                        .entry(route.clone())
+                        .or_insert(None);
+                }
+                let admission_event_watermarks = admission_route_observations
+                    .keys()
+                    .filter_map(|route| {
+                        state
+                            .route_event_watermarks
+                            .get(route)
+                            .copied()
+                            .map(|watermark| (route.clone(), watermark))
+                    })
+                    .collect();
+                let predecessor_event_watermarks = state
+                    .route_admission_watermarks
+                    .get(&predecessor_request_id)
+                    .cloned()
+                    .unwrap_or_default();
                 ManualAllContinuation::new(
                     predecessor_request_id,
                     admission_route_observations,
                     ledger_eligible_routes,
                     admission_event_watermarks,
                     predecessor_event_watermarks,
-                ),
-            );
+                )
+            };
+            state
+                .manual_all_continuations
+                .insert(request_id.clone(), continuation);
+        }
+        if admission_pending {
+            attempt.state = SourceBackedRefreshState::AdmissionPending;
+            attempt.progress.phase = "admission_pending".to_owned();
         }
         state.attempts.push_back(attempt);
-        trim_terminal_attempt_history(&mut state);
-        Ok(response)
+        Ok(find_attempt(state, &request_id)
+            .expect("new source refresh request")
+            .to_json())
     }
 
     pub(in super::super) fn status(&self, request_id: &str) -> Option<Value> {
@@ -771,7 +837,7 @@ impl CoreRefreshEngine {
     }
 
     #[cfg(test)]
-    pub(in super::super) fn run_next_with<Execute, Probe, Published, Failed>(
+    pub(in crate::semantic) fn run_next_with<Execute, Probe, Published, Failed>(
         &self,
         execute: Execute,
         probe: Probe,

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/request_lifecycle/recovery.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/request_lifecycle/recovery.rs
@@ -15,7 +15,7 @@ impl CoreRefreshEngine {
         let active_generation = verified
             .as_ref()
             .map(|verified| verified.generation_id().to_owned());
-        let queued_successors = recover_queued_successors(&job, active_generation.clone())?;
+        let queued_successors = recover_queued_successors(&job)?;
         let recovered_continuations = recover_logical_demand_continuations(&job)?;
         let request_state = job
             .get("request_state")
@@ -146,7 +146,7 @@ impl CoreRefreshEngine {
             return Ok(has_successors);
         }
 
-        if !matches!(request_state, "queued" | "running") {
+        if !matches!(request_state, "admission_pending" | "queued" | "running") {
             if let Some(verified) = verified {
                 self.lock_state().current_published_generation =
                     Some(verified.generation_id().to_owned());
@@ -369,6 +369,23 @@ fn recover_terminal_attempt(
     attempt.started_at_ms = optional_i64(job, "started_at_ms")?;
     attempt.finished_at_ms = optional_i64(job, "finished_at_ms")?;
     attempt.published_generation = optional_generation(job.get("published_generation"))?;
+    attempt.fresh_after_admitted_snapshot = job
+        .get("fresh_after_admitted_snapshot")
+        .and_then(Value::as_bool)
+        .unwrap_or_default();
+    attempt.request_fingerprint = optional_string(job, "request_fingerprint")?;
+    if attempt
+        .request_fingerprint
+        .as_deref()
+        .is_some_and(|fingerprint| !is_sha256_identity(fingerprint))
+    {
+        bail!("durable terminal source refresh request fingerprint is invalid");
+    }
+    attempt.admission_durability_indeterminate =
+        recover_admission_durability(job, "durable terminal source refresh")?;
+    attempt.coalesced_into_request_id = optional_string(job, "coalesced_into_request_id")?;
+    attempt.coalesced_logical_demands =
+        optional_u64(job, "coalesced_logical_demands")?.unwrap_or_default();
     attempt.coalesced_requests = optional_u64(job, "coalesced_requests")?.unwrap_or_default();
     attempt.progress = SourceBackedRefreshProgress::from_status_json(job)?;
     attempt.scanned_routes = optional_usize(job, "scanned_routes")?;

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/request_lifecycle/resolution.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/request_lifecycle/resolution.rs
@@ -2,6 +2,14 @@ use super::*;
 
 impl CoreRefreshEngine {
     pub(in crate::semantic) fn run_next(&self, data_root: &Path) -> Option<SourceBackedRefreshRun> {
+        match self.resolve_active_pending_admission(data_root) {
+            Ok(Some(run)) => return Some(run),
+            Ok(None) => {}
+            Err(error) => return self.admission_persistence_retry_run(error),
+        }
+        if self.active_request_admission_pending() {
+            return None;
+        }
         if let Some(run) =
             self.resolve_fully_covered_continuation_with(data_root, |catalog, routes| {
                 source_backed_requested_route_observation_fence(data_root, catalog, routes)
@@ -15,7 +23,7 @@ impl CoreRefreshEngine {
     }
 
     #[cfg(test)]
-    pub(in super::super::super) fn run_next_with_post_publication_sampler_for_test<Sample>(
+    pub(in crate::semantic) fn run_next_with_post_publication_sampler_for_test<Sample>(
         &self,
         data_root: &Path,
         sample: Sample,
@@ -33,6 +41,20 @@ impl CoreRefreshEngine {
         self.run_next_with_verified_index_opener(data_root, |index_root| {
             Ok(Arc::new(open_verified_index(index_root)?))
         })
+    }
+
+    #[cfg(test)]
+    pub(in crate::semantic) fn resolve_fully_covered_continuation_for_test<Sample>(
+        &self,
+        data_root: &Path,
+        sample: Sample,
+    ) -> Option<SourceBackedRefreshRun>
+    where
+        Sample: FnOnce(
+            Option<&ExplicitSourceCatalogAuthority>,
+        ) -> Result<BTreeMap<SourceRouteIdentity, Option<String>>>,
+    {
+        self.resolve_fully_covered_continuation_with(data_root, |catalog, _routes| sample(catalog))
     }
 
     fn resolve_fully_covered_continuation_with<Sample>(
@@ -61,7 +83,12 @@ impl CoreRefreshEngine {
             if publication_receipt.published_generation.is_empty() {
                 return None;
             }
-            let routes = continuation.covered_route_results.keys().cloned().collect();
+            let routes = continuation
+                .covered_route_results
+                .keys()
+                .filter(|route| !continuation.ledger_eligible_routes.contains(*route))
+                .cloned()
+                .collect();
             (request_id, routes)
         };
         let post_publication_fence = self.post_publication_route_coverage_fence_with(
@@ -97,6 +124,10 @@ impl CoreRefreshEngine {
             .covered_route_results
             .keys()
             .filter(|route| {
+                if continuation.ledger_eligible_routes.contains(*route) {
+                    return continuation.admission_event_watermarks.get(*route)
+                        != state.route_event_watermarks.get(*route);
+                }
                 let admitted_observation = continuation
                     .admission_route_observations
                     .get(*route)
@@ -185,8 +216,30 @@ impl CoreRefreshEngine {
             attempt.last_error = None;
             receipt
         };
+        // A fresh logical demand can be admitted while the provider sample
+        // above runs without the state lock. Its exact predecessor is this
+        // logical request, so release that durable fence with this terminal
+        // image. Coverage is intentionally not inherited transitively here:
+        // the later snapshot executes unless it establishes its own proof.
+        let successor_fence_snapshots = state
+            .manual_all_continuations
+            .iter_mut()
+            .filter_map(|(successor_id, successor)| {
+                (successor.predecessor_request_id == request_id && !successor.predecessor_finished)
+                    .then(|| {
+                        let snapshot = successor.clone();
+                        successor.predecessor_finished = true;
+                        (successor_id.clone(), snapshot)
+                    })
+            })
+            .collect::<BTreeMap<_, _>>();
         let terminal_job = durable_job_json(&state, &request_id)?;
         if let Err(error) = self.write_status(data_root, &terminal_job) {
+            for (successor_id, snapshot) in successor_fence_snapshots {
+                state
+                    .manual_all_continuations
+                    .insert(successor_id, snapshot);
+            }
             let attempt = find_attempt_mut(&mut state, &request_id)?;
             attempt.state = SourceBackedRefreshState::Queued;
             attempt.progress.phase = "persisting_terminal".to_owned();
@@ -456,6 +509,9 @@ impl CoreRefreshEngine {
             &BTreeSet<SourceRouteIdentity>,
         ) -> Result<BTreeMap<SourceRouteIdentity, Option<String>>>,
     {
+        if routes.is_empty() {
+            return PostPublicationRouteCoverageFence::fail_closed();
+        }
         // Snapshot the exact seen-event boundary before touching provider
         // targets. Events delivered after this lock is released are outside
         // the certificate even if their content-free observation is equal.

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/test_support.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/coordinator_state/test_support.rs
@@ -1,14 +1,42 @@
 use super::*;
 
 impl CoreRefreshEngine {
+    pub(in crate::semantic) fn status_for_test(&self, request_id: &str) -> Option<Value> {
+        self.status(request_id)
+    }
+
+    pub(in crate::semantic) fn logical_continuation_is_fully_covered_for_test(
+        &self,
+        request_id: &str,
+    ) -> bool {
+        self.lock_state()
+            .manual_all_continuations
+            .get(request_id)
+            .is_some_and(ManualAllContinuation::is_fully_covered)
+    }
+
     pub(in crate::semantic) fn handle_ipc_request_with_admission_fence_for_test(
         &self,
         data_root: &Path,
         request: &Value,
         observations: BTreeMap<SourceRouteIdentity, Option<String>>,
     ) -> Result<Option<Value>> {
-        self.handle_ipc_request_with_admission_fence(data_root, request, move |_, _| {
-            Ok(observations.clone())
-        })
+        let response = self.handle_ipc_request(data_root, request)?;
+        let Some(request_id) = response
+            .as_ref()
+            .and_then(|response| response.get("request_id"))
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+        else {
+            return Ok(response);
+        };
+        if self
+            .status(&request_id)
+            .is_some_and(|status| status["request_state"] == "admission_pending")
+        {
+            self.complete_pending_admission_for_test(data_root, &request_id, observations)?;
+            return Ok(self.status(&request_id));
+        }
+        Ok(response)
     }
 }

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/restart_recovery_tests.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/restart_recovery_tests.rs
@@ -2,7 +2,7 @@ use super::client::{
     recover_typed_unknown_request_with, source_refresh_request_is_unknown,
     validate_source_refresh_status_response_authority, wait_for_published_generation,
     SourceRefreshRequestRecoveryFailed, SourceRefreshRequestRecoveryFailureReason,
-    TypedUnknownRequestRecovery,
+    SourceRefreshRequestRetention, TypedUnknownRequestRecovery,
 };
 use super::*;
 
@@ -82,6 +82,7 @@ fn persistent_typed_unknown_loss_is_bounded_with_backoff_and_typed_failure() {
         .expect("persistent loss returns a typed recovery failure");
     assert_eq!(typed.request_id, "lost-0");
     assert_eq!(typed.recovery_attempts, 3);
+    assert_eq!(typed.retention, SourceRefreshRequestRetention::NotRetained);
     assert_eq!(
         typed.reason,
         SourceRefreshRequestRecoveryFailureReason::AttemptsExhausted
@@ -94,6 +95,65 @@ fn persistent_typed_unknown_loss_is_bounded_with_backoff_and_typed_failure() {
             StdDuration::from_millis(100),
         ]
     );
+}
+
+#[test]
+fn typed_unknown_then_prewrite_unavailable_is_typed_lost_after_acknowledgement() {
+    let request_id = "019fcaaa-0000-7000-8000-000000000305";
+    let mut recovery = TypedUnknownRequestRecovery::new(request_id);
+    let error = recover_typed_unknown_request_with(
+        &mut recovery,
+        request_id,
+        |_| {},
+        || Err(DaemonSourceRefreshServiceUnavailable.into()),
+    )
+    .unwrap_err();
+
+    let typed = error
+        .downcast_ref::<SourceRefreshRequestRecoveryFailed>()
+        .expect("post-ack recovery failure stays request-bound");
+    assert_eq!(typed.request_id, request_id);
+    assert_eq!(typed.recovery_attempts, 1);
+    assert_eq!(
+        typed.reason,
+        SourceRefreshRequestRecoveryFailureReason::ReenqueueFailed
+    );
+    assert_eq!(typed.retention, SourceRefreshRequestRetention::NotRetained);
+    assert!(typed
+        .detail
+        .as_deref()
+        .is_some_and(|detail| detail.contains("daemon source refresh service is unavailable")));
+    assert!(error
+        .downcast_ref::<DaemonSourceRefreshServiceUnavailable>()
+        .is_none());
+}
+
+#[test]
+fn typed_unknown_then_queue_full_is_typed_lost_after_acknowledgement() {
+    let request_id = "019fcaaa-0000-7000-8000-000000000306";
+    let mut recovery = TypedUnknownRequestRecovery::new(request_id);
+    let error = recover_typed_unknown_request_with(
+        &mut recovery,
+        request_id,
+        |_| {},
+        || bail!("source_refresh_queue_full: bounded daemon queue is full"),
+    )
+    .unwrap_err();
+
+    let typed = error
+        .downcast_ref::<SourceRefreshRequestRecoveryFailed>()
+        .expect("post-ack queue pressure stays request-bound");
+    assert_eq!(typed.request_id, request_id);
+    assert_eq!(typed.recovery_attempts, 1);
+    assert_eq!(
+        typed.reason,
+        SourceRefreshRequestRecoveryFailureReason::ReenqueueFailed
+    );
+    assert_eq!(typed.retention, SourceRefreshRequestRetention::NotRetained);
+    assert!(typed
+        .detail
+        .as_deref()
+        .is_some_and(|detail| detail.contains("source_refresh_queue_full")));
 }
 
 #[cfg(any(unix, windows))]

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/source_backed_refresh_coordinator_tests.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/source_backed_refresh_coordinator_tests.rs
@@ -30,6 +30,12 @@ mod observation_fence;
 #[path = "source_backed_refresh_coordinator_tests/logical_demand.rs"]
 mod logical_demand;
 
+#[path = "source_backed_refresh_coordinator_tests/logical_completion_race.rs"]
+mod logical_completion_race;
+
+#[path = "source_backed_refresh_coordinator_tests/delayed_admission.rs"]
+mod delayed_admission;
+
 struct TestExecutor {
     calls: Arc<AtomicUsize>,
     generation_id: String,
@@ -489,9 +495,14 @@ fn queued_startup_exact_is_upgraded_to_one_manual_all_scan() {
             .expect("queued startup exact request ID");
     let authority = load_explicit_source_catalog_authority(&data_root).unwrap();
     let manual = manual_all_request(&coordinator, &data_root, &authority);
+    let manual_request_id = request_id(&manual);
 
-    assert_eq!(request_id(&manual), automatic_request_id);
-    assert_eq!(manual["trigger"], "import");
+    assert_ne!(manual_request_id, automatic_request_id);
+    assert_eq!(manual["coalesced_into_request_id"], automatic_request_id);
+    assert_eq!(manual["request_state"], "queued");
+    let upgraded = coordinator.status(&automatic_request_id).unwrap();
+    assert_eq!(upgraded["trigger"], "import");
+    assert_eq!(upgraded["coalesced_logical_demands"], 1);
     let run = coordinator.run_next(&data_root).expect("upgraded all run");
     assert!(!run.failed);
     assert_eq!(run.scope, SourceBackedRefreshScope::All);
@@ -502,6 +513,10 @@ fn queued_startup_exact_is_upgraded_to_one_manual_all_scan() {
             .cloned()
             .map(|route| (route, 1))
             .collect::<BTreeMap<_, _>>()
+    );
+    assert_eq!(
+        coordinator.status(&manual_request_id).unwrap()["request_state"],
+        "queued"
     );
     assert!(!coordinator.has_scheduled_route_work());
 }

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/source_backed_refresh_coordinator_tests/delayed_admission.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/source_backed_refresh_coordinator_tests/delayed_admission.rs
@@ -1,0 +1,110 @@
+use super::logical_demand::verified_publication_with_successful_routes;
+use super::*;
+
+#[test]
+fn delayed_real_route_fence_after_predecessor_publication_stays_logical() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root).unwrap();
+    let route = route_identity(0x62);
+    let directory_route = route_identity(0x63);
+    let routes = BTreeSet::from([route.clone(), directory_route.clone()]);
+    let route_observation = format!("{:02x}", 0xa2).repeat(32);
+    let publication_observations = BTreeMap::from([(route.clone(), route_observation.clone())]);
+    let executor_observations = publication_observations.clone();
+    let executor_routes = routes.clone();
+    let execution_entered = Arc::new(Barrier::new(2));
+    let execution_release = Arc::new(Barrier::new(2));
+    let executor_entered = Arc::clone(&execution_entered);
+    let executor_release = Arc::clone(&execution_release);
+    let executions = Arc::new(AtomicUsize::new(0));
+    let observed_executions = Arc::clone(&executions);
+    let executor = Arc::new(move |execution: SourceBackedRefreshExecution<'_>| {
+        assert_eq!(observed_executions.fetch_add(1, Ordering::SeqCst), 0);
+        executor_entered.wait();
+        executor_release.wait();
+        verified_publication_with_successful_routes(
+            &execution,
+            &executor_observations,
+            &executor_routes,
+        )
+    });
+    let fence_entered = Arc::new(Barrier::new(2));
+    let fence_release = Arc::new(Barrier::new(2));
+    let admission_entered = Arc::clone(&fence_entered);
+    let admission_release = Arc::clone(&fence_release);
+    let fence_route = route.clone();
+    let fence_observation = route_observation.clone();
+    let admission_fence = Arc::new(
+        move |_data_root: &Path, _catalog: Option<&ExplicitSourceCatalogAuthority>| {
+            admission_entered.wait();
+            admission_release.wait();
+            Ok(BTreeMap::from([
+                (fence_route.clone(), Some(fence_observation.clone())),
+                (directory_route.clone(), None),
+            ]))
+        },
+    );
+    let coordinator = Arc::new(CoreRefreshEngine::with_runtime_for_test(
+        executor,
+        admission_fence,
+        Arc::new(crate::semantic::paths_status::write_daemon_job_status),
+    ));
+    coordinator.initialize_watch_route_authority(routes.clone());
+    coordinator.schedule_startup_route_reconciliation(
+        routes,
+        EventWatermark::new(0, 1),
+        ledger_now_ms(),
+    );
+    let periodic = coordinator.enqueue_periodic(&data_root).unwrap();
+    let periodic_id = request_id(&periodic);
+    let manual_id = Uuid::from_u128(0x29403).to_string();
+    let manual_request = json!({
+        "schema_version": 1,
+        "op": SOURCE_REFRESH_REQUEST_OP,
+        "request_id": manual_id,
+        "mode": "wait",
+        "operation": "refresh",
+        "fresh_after_admitted_snapshot": true,
+    });
+
+    std::thread::scope(|scope| {
+        let running = Arc::clone(&coordinator);
+        let running_root = data_root.clone();
+        let predecessor = scope.spawn(move || running.run_next(&running_root));
+        execution_entered.wait();
+        let admitted = coordinator
+            .handle_listener_ipc_request(&data_root, &manual_request)
+            .unwrap()
+            .expect("manual All admission acknowledgement");
+        assert_eq!(admitted["request_state"], "admission_pending");
+        assert_eq!(admitted["coalesced_into_request_id"], periodic_id);
+        coordinator.finish_listener_admission_response(&manual_id);
+
+        let planning = Arc::clone(&coordinator);
+        let planning_root = data_root.clone();
+        let planner = scope.spawn(move || planning.prepare_next_pending_admission(&planning_root));
+        fence_entered.wait();
+        execution_release.wait();
+        let predecessor = predecessor
+            .join()
+            .unwrap()
+            .expect("verified periodic predecessor");
+        assert!(!predecessor.failed, "{:#}", predecessor.job);
+        fence_release.wait();
+        assert!(planner.join().unwrap().unwrap());
+    });
+
+    assert!(coordinator.logical_continuation_is_fully_covered_for_test(&manual_id));
+    let sampled_route = route;
+    let sampled_observation = route_observation;
+    let logical = coordinator
+        .run_next_with_post_publication_sampler_for_test(&data_root, move |_| {
+            Ok(BTreeMap::from([(sampled_route, Some(sampled_observation))]))
+        })
+        .expect("covered logical demand resolution");
+    assert_eq!(request_id(&logical.job), manual_id);
+    assert_eq!(logical.job["scanned_routes"], 0);
+    assert_eq!(executions.load(Ordering::SeqCst), 1);
+    assert!(!coordinator.has_pending_request());
+}

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/source_backed_refresh_coordinator_tests/logical_completion_race.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/source_backed_refresh_coordinator_tests/logical_completion_race.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+use super::logical_demand::complete_verified_fully_covered_demand;
+
+fn observation(byte: u8) -> String {
+    format!("{byte:02x}").repeat(32)
+}
+
+#[test]
+fn successor_admitted_during_logical_sampling_is_durably_unfenced() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root).unwrap();
+    let route = route_identity(0x7a);
+    let route_observation = observation(0xba);
+    let first_demand_id = Uuid::from_u128(0x28120).to_string();
+    let second_demand_id = Uuid::from_u128(0x28121).to_string();
+    let (coordinator, selected_deltas) = complete_verified_fully_covered_demand(
+        &data_root,
+        &route,
+        &route_observation,
+        &first_demand_id,
+        None,
+        false,
+    );
+
+    let admitting_coordinator = Arc::clone(&coordinator);
+    let admitted_route = route.clone();
+    let admitted_observation = route_observation.clone();
+    let admitted_request_id = second_demand_id.clone();
+    let sampled_route = route.clone();
+    let sampled_observation = route_observation.clone();
+    let first_resolution = coordinator
+        .run_next_with_post_publication_sampler_for_test(&data_root, move |_| {
+            admitting_coordinator.enqueue_fresh_demand_for_test(
+                None,
+                admitted_request_id,
+                BTreeMap::from([(admitted_route, Some(admitted_observation))]),
+            )?;
+            Ok(BTreeMap::from([(sampled_route, Some(sampled_observation))]))
+        })
+        .expect("first logical demand resolution");
+    assert_eq!(request_id(&first_resolution.job), first_demand_id);
+
+    let durable = read_daemon_job_status(&daemon_source_backed_refresh_job_path(&data_root))
+        .expect("durable terminal root with queued successor");
+    assert_eq!(
+        durable["queued_successors"][0]["logical_demand"]["predecessor_finished"],
+        true
+    );
+
+    let second_resolution = coordinator
+        .run_next(&data_root)
+        .expect("successor must not remain predecessor-fenced");
+    assert_eq!(request_id(&second_resolution.job), second_demand_id);
+    assert!(second_resolution.did_work);
+    assert!(!second_resolution.failed, "{:#}", second_resolution.job);
+    assert_eq!(
+        selected_deltas.lock().unwrap().as_slice(),
+        &[BTreeSet::from([route])]
+    );
+    assert!(!coordinator.has_pending_request());
+}

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/source_backed_refresh_coordinator_tests/logical_demand.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/source_backed_refresh_coordinator_tests/logical_demand.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-type SelectedRouteDeltas = Arc<Mutex<Vec<BTreeSet<SourceRouteIdentity>>>>;
+pub(super) type SelectedRouteDeltas = Arc<Mutex<Vec<BTreeSet<SourceRouteIdentity>>>>;
 
 fn observation(byte: u8) -> String {
     format!("{byte:02x}").repeat(32)
@@ -18,9 +18,21 @@ fn publication_for_routes(
     publication
 }
 
-fn verified_publication_for_observations(
+pub(super) fn verified_publication_for_observations(
     execution: &SourceBackedRefreshExecution<'_>,
     observations: &BTreeMap<SourceRouteIdentity, String>,
+) -> Result<SourceBackedRefreshPublication> {
+    verified_publication_with_successful_routes(
+        execution,
+        observations,
+        &observations.keys().cloned().collect(),
+    )
+}
+
+pub(super) fn verified_publication_with_successful_routes(
+    execution: &SourceBackedRefreshExecution<'_>,
+    observations: &BTreeMap<SourceRouteIdentity, String>,
+    successful_routes: &BTreeSet<SourceRouteIdentity>,
 ) -> Result<SourceBackedRefreshPublication> {
     let previous_generation = open_verified_index(execution.index_root)
         .ok()
@@ -29,8 +41,8 @@ fn verified_publication_for_observations(
     let operation = execution.operation;
     let scope = execution.scope.clone();
     let metadata_observations = observations.clone();
-    let route_results = observations
-        .keys()
+    let route_results = successful_routes
+        .iter()
         .map(|route| SourceBackedRefreshRouteResult::succeeded(route.as_str().to_owned(), true))
         .collect::<Vec<_>>();
     let covered_publication = execution.covered_publication.clone();
@@ -62,8 +74,8 @@ fn verified_publication_for_observations(
                 },
             )?;
     let mut publication = empty_test_publication(published.receipt().generation_id.clone());
-    publication.route_results = observations
-        .keys()
+    publication.route_results = successful_routes
+        .iter()
         .map(|route| SourceBackedRefreshRouteResult::succeeded(route.as_str().to_owned(), true))
         .collect();
     execution
@@ -72,7 +84,7 @@ fn verified_publication_for_observations(
     Ok(publication)
 }
 
-fn complete_verified_fully_covered_demand(
+pub(super) fn complete_verified_fully_covered_demand(
     data_root: &Path,
     route: &SourceRouteIdentity,
     route_observation: &str,
@@ -663,6 +675,71 @@ fn indeterminate_admission_observation_is_not_covered() {
         coordinator.status(&demand_id).unwrap()["request_state"],
         "published"
     );
+}
+
+#[test]
+fn watcher_event_invalidates_indeterminate_ledger_coverage() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    ctx_history_core::platform_security::establish_private_data_root(&data_root).unwrap();
+    let route = route_identity(0x6b);
+    let routes = BTreeSet::from([route.clone()]);
+    let demand_id = Uuid::from_u128(0x2810d).to_string();
+    let coordinator = CoreRefreshEngine::new();
+    coordinator.initialize_watch_route_authority(routes.clone());
+    coordinator.schedule_startup_route_reconciliation(
+        routes.clone(),
+        EventWatermark::new(0, 1),
+        ledger_now_ms(),
+    );
+    coordinator.enqueue_periodic(&data_root).unwrap();
+    let predecessor = coordinator
+        .run_next_with(
+            |running_request_id, running| {
+                running.admit_refresh_scope_for_test(
+                    running_request_id,
+                    &SourceBackedRefreshScope::All,
+                )?;
+                running.enqueue_fresh_demand_for_test(
+                    None,
+                    demand_id.clone(),
+                    BTreeMap::from([(route.clone(), None)]),
+                )?;
+                Ok(publication_for_routes("ledger-covered-generation", &routes))
+            },
+            || Ok(Some("ledger-covered-generation".to_owned())),
+            |_| Ok(()),
+            |_| Ok(()),
+        )
+        .expect("predecessor publication with exact watcher-ledger coverage");
+    assert!(!predecessor.failed, "{:#}", predecessor.job);
+    assert!(coordinator.logical_continuation_is_fully_covered_for_test(&demand_id));
+
+    coordinator.record_watch_routes(
+        [(route.clone(), EventWatermark::new(0, 2))],
+        ledger_now_ms(),
+    );
+    assert!(!coordinator.logical_continuation_is_fully_covered_for_test(&demand_id));
+
+    let mut covered_routes = None;
+    let delta = coordinator
+        .run_next_with(
+            |request_id, running| {
+                covered_routes = Some(
+                    running
+                        .admit_refresh_scope_for_test(request_id, &SourceBackedRefreshScope::All)?,
+                );
+                Ok(publication_for_routes("event-delta-generation", &routes))
+            },
+            || Ok(Some("event-delta-generation".to_owned())),
+            |_| Ok(()),
+            |_| Ok(()),
+        )
+        .expect("post-admission watcher event executes the exact delta");
+
+    assert!(delta.did_work);
+    assert_eq!(request_id(&delta.job), demand_id);
+    assert_eq!(covered_routes, Some(BTreeSet::new()));
 }
 
 #[test]

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/source_backed_refresh_coordinator_tests_request_coalescing.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/source_backed_refresh_coordinator_tests_request_coalescing.rs
@@ -35,7 +35,9 @@ fn exact_import_overlay_upgrades_queued_route_work_without_rescan() {
     let data_root = temp.path().join("data");
     ctx_history_core::platform_security::establish_private_data_root(&data_root).unwrap();
     let coordinator = CoreRefreshEngine::new();
-    coordinator.reconcile_watch_routes([route_identity(0xa1)], EventWatermark::new(1, 0), 0);
+    let route = route_identity(0xa1);
+    let observation = format!("{:02x}", 0xa3).repeat(32);
+    coordinator.reconcile_watch_routes([route.clone()], EventWatermark::new(1, 0), 0);
     assert!(coordinator
         .enqueue_next_dirty_route(&data_root, u64::MAX)
         .unwrap());
@@ -58,28 +60,58 @@ fn exact_import_overlay_upgrades_queued_route_work_without_rescan() {
     assert_eq!(request["fresh_after_admitted_snapshot"], true);
 
     let upgraded = coordinator
-        .handle_ipc_request_with_admission_fence_for_test(&data_root, &request, BTreeMap::new())
+        .handle_ipc_request_with_admission_fence_for_test(
+            &data_root,
+            &request,
+            BTreeMap::from([(route.clone(), Some(observation.clone()))]),
+        )
         .unwrap()
         .expect("exact-overlay import response");
     let attached = coordinator
-        .handle_ipc_request_with_admission_fence_for_test(&data_root, &request, BTreeMap::new())
+        .handle_ipc_request_with_admission_fence_for_test(
+            &data_root,
+            &request,
+            BTreeMap::from([(route.clone(), Some(observation.clone()))]),
+        )
         .unwrap()
         .expect("equivalent import response");
 
-    assert_eq!(request_id(&upgraded), scheduled_request_id);
-    assert_eq!(request_id(&attached), scheduled_request_id);
-    assert_eq!(attached["coalesced_requests"], 2);
-    assert_eq!(attached["operation"], "import");
-    assert_eq!(attached["trigger"], "import");
-    assert_eq!(attached["trigger_provenance"], "explicit_source_catalog");
+    let logical_request_id = request_id(&upgraded);
+    assert_eq!(logical_request_id, request["request_id"]);
+    assert_eq!(request_id(&attached), logical_request_id);
+    assert_eq!(attached["coalesced_requests"], 0);
+    assert_eq!(attached["coalesced_into_request_id"], scheduled_request_id);
+    let upgraded_physical = coordinator
+        .status_for_test(&scheduled_request_id)
+        .expect("upgraded physical request");
+    assert_eq!(upgraded_physical["operation"], "import");
+    assert_eq!(upgraded_physical["trigger"], "import");
+    assert_eq!(
+        upgraded_physical["trigger_provenance"],
+        "explicit_source_catalog"
+    );
+    assert_eq!(upgraded_physical["coalesced_logical_demands"], 1);
 
     let writer_launches = AtomicUsize::new(0);
     let run = coordinator
         .run_next_with(
-            |_, _| {
+            |request_id, coordinator| {
                 writer_launches.fetch_add(1, Ordering::SeqCst);
+                coordinator
+                    .admit_refresh_scope_for_test(request_id, &SourceBackedRefreshScope::All)
+                    .unwrap();
                 let mut publication = test_publication("implicit-import-generation");
                 publication.published_explicit_source_catalog = Some(authority);
+                publication
+                    .route_results
+                    .push(SourceBackedRefreshRouteResult::succeeded(
+                        route.as_str().to_owned(),
+                        true,
+                    ));
+                coordinator.set_route_observations_for_test(
+                    request_id,
+                    BTreeMap::from([(route.clone(), observation.clone())]),
+                );
                 Ok(publication)
             },
             || Ok(Some("implicit-import-generation".to_owned())),
@@ -89,7 +121,9 @@ fn exact_import_overlay_upgrades_queued_route_work_without_rescan() {
         .expect("upgraded all-route refresh");
     assert_eq!(run.scope, SourceBackedRefreshScope::All);
     assert_eq!(writer_launches.load(Ordering::SeqCst), 1);
-    assert!(!coordinator.has_pending_request());
+    assert!(coordinator.logical_continuation_is_fully_covered_for_test(&logical_request_id));
+    assert_eq!(writer_launches.load(Ordering::SeqCst), 1);
+    assert!(coordinator.has_pending_request());
 }
 
 #[test]

--- a/crates/ctx-cli/src/semantic/source_status.rs
+++ b/crates/ctx-cli/src/semantic/source_status.rs
@@ -188,7 +188,9 @@ fn refresh_report(job: Option<&Value>, generation_id: Option<&str>, daemon: &Val
             )
         }
         Some("published") if generation_matches => ("ready", None),
-        Some("queued" | "running") => ("pending", Some("core_refresh_pending")),
+        Some("admission_pending" | "queued" | "running") => {
+            ("pending", Some("core_refresh_pending"))
+        }
         Some("failed") => ("unavailable", Some("core_refresh_failed")),
         Some("published") => ("stale", Some("published_generation_mismatch")),
         Some(_) => ("unavailable", Some("refresh_state_unrecognized")),
@@ -288,7 +290,9 @@ fn lexical_report(
         }
         Err(ctx_history_index::IndexError::MissingActiveGenerationPointer) => {
             let (status, reason) = match request_state {
-                Some("queued" | "running") => ("pending", "generation_not_published"),
+                Some("admission_pending" | "queued" | "running") => {
+                    ("pending", "generation_not_published")
+                }
                 Some("failed") => ("unavailable", "core_refresh_failed"),
                 Some("published") => ("unavailable", "published_generation_missing"),
                 _ => ("unavailable", "generation_not_published"),

--- a/crates/ctx-cli/src/semantic/source_status_tests.rs
+++ b/crates/ctx-cli/src/semantic/source_status_tests.rs
@@ -298,11 +298,14 @@ fn lexical_state_depends_only_on_verified_generation_policy_identity() {
 #[test]
 fn refresh_report_uses_typed_pending_ready_stale_and_unavailable_states() {
     let daemon = json!({"running": true});
-    let pending = refresh_report(
-        Some(&json!({"request_state": "running"})),
-        Some("generation-1"),
-        &daemon,
-    );
+    for request_state in ["admission_pending", "queued", "running"] {
+        let pending = refresh_report(
+            Some(&json!({"request_state": request_state})),
+            Some("generation-1"),
+            &daemon,
+        );
+        assert_eq!(pending["status"], "pending", "{request_state}");
+    }
     let ready = refresh_report(
         Some(&json!({
             "request_state": "published",
@@ -324,7 +327,6 @@ fn refresh_report_uses_typed_pending_ready_stale_and_unavailable_states() {
     );
     let unavailable = refresh_report(None, None, &json!({"running": false}));
 
-    assert_eq!(pending["status"], "pending");
     assert_eq!(ready["status"], "ready");
     assert_eq!(stale["status"], "stale");
     assert_eq!(stale["certified_source_count"], 2);
@@ -332,6 +334,48 @@ fn refresh_report_uses_typed_pending_ready_stale_and_unavailable_states() {
     assert_eq!(stale["timings_us"]["commit"], 33);
     assert_eq!(unavailable["status"], "unavailable");
     assert_eq!(unavailable["reason"], "daemon_unavailable");
+}
+
+#[test]
+fn admission_pending_is_active_with_existing_and_empty_generations() {
+    let (_temp, data_root, generation_id) = core_publication_fixture();
+    super::super::paths_status::write_daemon_job_status(
+        &daemon_core_refresh_job_path(&data_root),
+        &json!({
+            "status": "running",
+            "request_id": "admission-existing",
+            "request_state": "admission_pending",
+            "published_generation": generation_id,
+        }),
+    )
+    .unwrap();
+
+    let existing = source_epoch_status_report(&data_root, &AppConfig::default()).unwrap();
+    assert_eq!(existing.report["refresh"]["status"], "pending");
+    assert_eq!(existing.report["lexical"]["status"], "ready");
+    assert_eq!(
+        existing.report["lexical"]["request_state"],
+        "admission_pending"
+    );
+
+    let empty = tempfile::tempdir().unwrap();
+    let empty_root = empty.path().join("data");
+    super::super::paths_status::write_daemon_job_status(
+        &daemon_core_refresh_job_path(&empty_root),
+        &json!({
+            "status": "running",
+            "request_id": "admission-empty",
+            "request_state": "admission_pending",
+        }),
+    )
+    .unwrap();
+    let empty = source_epoch_status_report(&empty_root, &AppConfig::default()).unwrap();
+    assert_eq!(empty.report["refresh"]["status"], "pending");
+    assert_eq!(empty.report["lexical"]["status"], "pending");
+    assert_eq!(
+        empty.report["lexical"]["reason"],
+        "generation_not_published"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- durably admit and identify refresh requests before acknowledgement, without holding admission on discovery or scan work
- coalesce equivalent manual All demand into the running periodic physical executor and preserve request-bound terminal observation
- define retained disconnect and ambiguous transport recovery semantics with stable request IDs, bounded admission, truthful receipts, and restart-safe queue ownership
- recover the durable coordinator before publishing the daemon refresh endpoint

## Behavior

Acknowledgement now means the request ID and AdmissionPending state are durable. A disconnected client does not cancel already-admitted work: the receipt reports the retained policy and the stable ID so the caller can replay or observe it. Definite pre-admission failures remain typed as not retained. Equivalent All requests share one physical executor; non-equivalent work stays in the bounded successor queue.

## Validation

- exact-candidate concurrency/lifecycle/cancellation review: PASS, zero P0-P2
- exact-candidate product/API/receipts/regression review: PASS, zero P0-P2
- real isolated daemon reproduction: periodic cold All plus manual All acknowledged in 12.7 ms, one physical executor, one coalesced logical demand, responsive status endpoint, request-bound completion, and explicit retained disconnect receipt
- Bazel source_diff_check: PASS
- Bazel ctx-cli unit_tests: PASS
- Bazel search_refresh_tests: PASS, 20 tests
- Bazel setup_sources_import_tests serial: PASS, 72 tests
- strict candidate Clippy: PASS with only the unchanged parent let-and-return lint allowed
- Windows production cargo check: PASS
- changed-file rustfmt and git diff checks: PASS
- repository LOC check remains red only on existing main excesses; this change creates no new over-limit file

Fixes #294.