### PR TITLE
feat(search): index policy-selected MCP invocations

### DIFF
--- a/crates/ctx-cli/src/commands/source_index/search/hydration.rs
+++ b/crates/ctx-cli/src/commands/source_index/search/hydration.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeSet, fmt};
 
 use anyhow::{anyhow, Result};
 use ctx_history_core::{MAX_CORE_CONTENT_BYTES, MAX_ENCODED_CORE_RECORD_BYTES};
-use ctx_history_index::{CoreEventPageBudget, CoreEventRecord, VerifiedIndex};
+use ctx_history_index::{project_body_search, CoreEventPageBudget, CoreEventRecord, VerifiedIndex};
 use uuid::Uuid;
 
 use crate::MAX_SEARCH_LIMIT;
@@ -150,10 +150,7 @@ fn search_presentation_projection<'event>(
     expected_event: &'event SearchEventMetadata,
     query_texts: &[&str],
 ) -> Result<(SearchPresentation<'event>, usize)> {
-    let CoreEventRecord {
-        event,
-        mut core_record,
-    } = record;
+    let CoreEventRecord { event, core_record } = record;
     if event.event_id != core_record.event_id
         || event.session_id != core_record.session_id
         || SearchEventMetadata::from(&event) != *expected_event
@@ -163,25 +160,19 @@ fn search_presentation_projection<'event>(
             expected_event.event_id
         ));
     }
-    let body = core_record
-        .content
-        .normalized_body
-        .take()
-        .filter(|body| !body.is_empty())
-        .ok_or_else(|| {
-            anyhow!(
-                "Core search event {} has no normalized body",
-                event.event_id
-            )
-        })?;
+    let body = project_body_search(core_record.content)?.ok_or_else(|| {
+        anyhow!(
+            "Core search event {} has no searchable body projection",
+            event.event_id
+        )
+    })?;
     let (snippet, snippet_truncated) = search_snippet_fragment(&body, query_texts);
     let retained_snippet_bytes = snippet.len();
 
-    // Neither the complete body nor the remainder of Core crosses the search
-    // presentation boundary.
+    // Neither the complete searchable projection nor the remainder of Core
+    // crosses the search presentation boundary.
     drop(body);
     drop(event);
-    drop(core_record);
     Ok((
         SearchPresentation {
             event: expected_event,

--- a/crates/ctx-cli/src/commands/source_index/tests/mcp_exchange.rs
+++ b/crates/ctx-cli/src/commands/source_index/tests/mcp_exchange.rs
@@ -6,6 +6,10 @@ use ctx_history_core::{
 use super::*;
 use crate::commands::source_index::mcp_show_event;
 
+const ARGUMENT_SEARCH_CANARY: &str = "zzargumentcanary8h63";
+const CALL_ID_SEARCH_CANARY: &str = "zzcallidcanary7g52";
+const RESPONSE_SEARCH_CANARY: &str = "zzresponsecanary9j74";
+
 fn complete_exchange(payload: Value) -> McpExchangeContent {
     McpExchangeContent {
         provider_call_id: "native-call-呼び出し-🦀".to_owned(),
@@ -119,4 +123,99 @@ fn full_show_surfaces_mcp_exchange_losslessly_and_accounts_for_its_output_bytes(
         "no exchange",
     );
     assert!(render_event_value(&absent).get("mcp_exchange").is_none());
+}
+
+#[test]
+fn search_snippets_use_mcp_invocation_arguments_but_exclude_response_and_call_id() {
+    let temp = tempdir().unwrap();
+    let event = fixture_event(CaptureProvider::Codex, "codex_session_jsonl", 96, 1);
+    let exchange = McpExchangeContent {
+        provider_call_id: CALL_ID_SEARCH_CANARY.to_owned(),
+        invocation: Some(McpInvocationContent {
+            server: "mcp-検索サーバー".to_owned(),
+            tool: "nested_lookup_tool".to_owned(),
+            arguments: McpJsonCapture::Present {
+                value: json!({
+                    "outer": {
+                        "雪": ["東京", {"argument_only": ARGUMENT_SEARCH_CANARY}],
+                    },
+                }),
+            },
+        }),
+        response: Some(McpTerminalResponseContent {
+            status: McpTerminalStatus::Succeeded,
+            failure_kind: None,
+            duration_ns: Some(42),
+            text: McpTextCapture::NormalizedBody,
+            payload: McpJsonCapture::Present {
+                value: json!({"response_only": RESPONSE_SEARCH_CANARY}),
+            },
+        }),
+    };
+    let exact_exchange = serde_json::to_value(&exchange).unwrap();
+    let mut stored = fixture_core_event(&event, "ordinary stored response body");
+    stored.core_record.mcp_tool_call = Some(McpToolCallAttribution {
+        server: "mcp-検索サーバー".to_owned(),
+        tool: "nested_lookup_tool".to_owned(),
+    });
+    stored.core_record.content.mcp_exchange = Some(exchange);
+    stored.core_record.validate_contract().unwrap();
+    append_fixture_session(temp.path(), std::slice::from_ref(&stored), 96);
+
+    let mut argument_request = request(RefreshArg::Off);
+    argument_request.query = ARGUMENT_SEARCH_CANARY.to_owned();
+    argument_request.events = true;
+    argument_request.limit = 1;
+    let (value, collection, _) = search_existing_generation(
+        &argument_request,
+        open_index(temp.path()).unwrap(),
+        temp.path(),
+        argument_request.semantic_weight,
+        "existing_generation",
+        1,
+    )
+    .unwrap();
+
+    assert_eq!(collection.result_window.hits.len(), 1);
+    assert_eq!(
+        value["results"][0]["ctx_event_id"],
+        json!(event.event_id.as_uuid())
+    );
+    let snippet = value["results"][0]["snippet"].as_str().unwrap();
+    assert!(snippet.contains(ARGUMENT_SEARCH_CANARY));
+    assert!(snippet.contains("東京"));
+    assert!(!snippet.contains(CALL_ID_SEARCH_CANARY));
+    assert!(!snippet.contains(RESPONSE_SEARCH_CANARY));
+
+    let (mcp_value, _) = mcp_search(argument_request, temp.path()).unwrap();
+    assert_eq!(mcp_value["results"][0]["snippet"], snippet);
+
+    let shown = mcp_show_event(
+        temp.path(),
+        &stored.event_id.as_uuid().to_string(),
+        0,
+        0,
+        None,
+        crate::presentation_limit::MCP_PRESENTATION_MAX_OUTPUT_BYTES,
+    )
+    .unwrap();
+    assert_eq!(shown["event"]["text"], "ordinary stored response body");
+    assert_eq!(shown["event"]["mcp_exchange"], exact_exchange);
+
+    for excluded in [CALL_ID_SEARCH_CANARY, RESPONSE_SEARCH_CANARY] {
+        let mut excluded_request = request(RefreshArg::Off);
+        excluded_request.query = excluded.to_owned();
+        excluded_request.events = true;
+        let (value, collection, _) = search_existing_generation(
+            &excluded_request,
+            open_index(temp.path()).unwrap(),
+            temp.path(),
+            excluded_request.semantic_weight,
+            "existing_generation",
+            1,
+        )
+        .unwrap();
+        assert!(collection.result_window.hits.is_empty());
+        assert!(value["results"].as_array().unwrap().is_empty());
+    }
 }

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/copilot.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/copilot.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 pub(super) const COPILOT_DIRECT_NATIVE_JSONL_PARSER_REVISION: &str =
-    "copilot-cli-direct-native-jsonl-v5-mcp-exchange";
+    "copilot-cli-direct-native-jsonl-v6-mcp-start-generic-body";
 
 const COPILOT_LINKAGE_SCAN_CHUNK_BYTES: usize = 1024 * 1024;
 // The selector reads in fixed-size chunks, but must retain any complete line
@@ -246,6 +246,44 @@ pub(super) fn copilot_event_identity(value: &Value) -> Option<&str> {
         .get("id")
         .and_then(Value::as_str)
         .filter(|event_id| !event_id.trim().is_empty())
+}
+
+pub(super) fn copilot_start_requires_generic_body(bytes: &[u8]) -> bool {
+    let mut deserializer = serde_json::Deserializer::from_slice(bytes);
+    let Ok(envelope) = CopilotRawEnvelope::deserialize(&mut deserializer) else {
+        return true;
+    };
+    if deserializer.end().is_err()
+        || envelope.event_type.duplicate
+        || envelope.data.duplicate
+        || envelope.explicitly_redacted
+    {
+        return true;
+    }
+    if !matches!(
+        exact_bounded_string(
+            envelope.event_type.value,
+            COPILOT_LINKAGE_MAX_EVENT_TYPE_BYTES
+        ),
+        ExactBoundedString::Exact(event_type) if event_type == "tool.execution_start"
+    ) {
+        return true;
+    }
+    let Some(raw_data) = envelope.data.value else {
+        return false;
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(raw_data.get());
+    let Ok(data) = CopilotRawData::deserialize(&mut deserializer) else {
+        return true;
+    };
+    if deserializer.end().is_err() {
+        return true;
+    }
+    data.explicitly_redacted
+        || data.mcp_server_name.value.is_some()
+        || data.mcp_server_name.duplicate
+        || data.mcp_tool_name.value.is_some()
+        || data.mcp_tool_name.duplicate
 }
 
 /// Captures only the exact MCP side represented by this Copilot event.

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/reader_projection.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/reader_projection.rs
@@ -128,6 +128,23 @@ impl DirectJsonlProjector {
         }
 
         let touches = direct_jsonl_touches(&value, event_type, false);
+        let generic_tool_call_body = self.provider == CaptureProvider::CopilotCli
+            && event_type == EventType::ToolCall
+            && super::copilot::copilot_start_requires_generic_body(bytes);
+        let mcp_exchange = (self.provider == CaptureProvider::CopilotCli)
+            .then(|| super::copilot::copilot_mcp_exchange(bytes, None))
+            .flatten();
+        let fallback_identity_discriminator = mcp_exchange
+            .as_ref()
+            .filter(|exchange| exchange.invocation.is_some())
+            .map(|exchange| {
+                crate::compute_payload_hash(&json!({
+                    "domain": "ctx.copilot-mcp-invocation-fallback-v1",
+                    "provider_call_id": exchange.provider_call_id,
+                    "invocation": exchange.invocation,
+                }))
+            })
+            .transpose()?;
         let mut event = direct_event(
             self.provider,
             &self.source_format,
@@ -138,10 +155,10 @@ impl DirectJsonlProjector {
             occurred_at,
             None,
             touches,
+            generic_tool_call_body,
+            fallback_identity_discriminator.as_deref(),
         )?;
-        if self.provider == CaptureProvider::CopilotCli {
-            event.mcp_exchange = super::copilot::copilot_mcp_exchange(bytes, None);
-        }
+        event.mcp_exchange = mcp_exchange;
         event.source_record = DirectJsonlSourceRecord {
             byte_start,
             byte_end_exclusive,
@@ -245,6 +262,8 @@ impl DirectJsonlProjector {
                 occurred_at,
                 Some(&subrecord),
                 touches,
+                false,
+                None,
             )?;
             if self.provider == CaptureProvider::CopilotCli {
                 event.mcp_tool_call = self
@@ -394,11 +413,13 @@ fn direct_event(
     occurred_at: DateTime<Utc>,
     result: Option<&super::result_content::NativeJsonlResultSubrecord<'_>>,
     touches: Vec<DirectJsonlTouch>,
+    generic_tool_call_body: bool,
+    fallback_identity_discriminator: Option<&str>,
 ) -> Result<DirectJsonlEvent> {
     let event_type = direct_jsonl_event_type(provider, value);
     let entry_type = native_jsonl_entry_type(provider, value);
     let role = direct_jsonl_role(provider, value);
-    let text = if event_type == EventType::ToolOutput {
+    let text = if generic_tool_call_body || event_type == EventType::ToolOutput {
         String::new()
     } else {
         direct_jsonl_event_text(provider, value, event_type, &entry_type)
@@ -436,7 +457,7 @@ fn direct_event(
         _ => None,
     };
     let provider_event_sequence_index = positional_event_index;
-    let provider_event_hash = crate::compute_payload_hash(&json!({
+    let mut provider_event_hash_input = json!({
         "event_type": event_type.as_str(),
         "role": role.as_str(),
         "native_record_id": native_record_id,
@@ -445,7 +466,21 @@ fn direct_event(
         "lexical_text": lexical_text,
         "tool_result": tool_result.clone(),
         "touches": touches,
-    }))?;
+    });
+    if native_record_id.is_none() {
+        if let Some(discriminator) = fallback_identity_discriminator {
+            provider_event_hash_input
+                .as_object_mut()
+                .ok_or(CaptureError::SystemInvariant(
+                    "direct JSONL fallback hash input is not an object",
+                ))?
+                .insert(
+                    "fallback_identity_discriminator".to_owned(),
+                    Value::String(discriminator.to_owned()),
+                );
+        }
+    }
+    let provider_event_hash = crate::compute_payload_hash(&provider_event_hash_input)?;
     Ok(DirectJsonlEvent {
         raw_ordinal,
         sub_ordinal,

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed_copilot_tests.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed_copilot_tests.rs
@@ -555,6 +555,152 @@ fn copilot_captures_exact_invocations_and_linked_terminal_responses() {
 }
 
 #[test]
+fn copilot_mcp_start_uses_generic_body_and_typed_exchange_is_canonical() {
+    let arguments = json!({"needle": "ordinary-arguments-canary"});
+    let events = vec![json!({
+        "type": "tool.execution_start",
+        "id": "ordinary-mcp-start",
+        "timestamp": "2026-08-03T12:00:01Z",
+        "data": {
+            "toolCallId": "ordinary-call-id-canary",
+            "mcpServerName": "ordinary-server-canary",
+            "mcpToolName": "ordinary-tool-canary",
+            "arguments": arguments.clone()
+        }
+    })
+    .to_string()];
+
+    let records = project_events(&events);
+    let record = record_by_native_id(&records, "ordinary-mcp-start");
+    let body = record.content.normalized_body.as_deref().unwrap();
+    assert_eq!(body, "tool_call");
+    for canary in [
+        "ordinary-call-id-canary",
+        "ordinary-server-canary",
+        "ordinary-tool-canary",
+        "ordinary-arguments-canary",
+    ] {
+        assert!(!body.contains(canary), "normalized body leaked {canary}");
+    }
+
+    assert_eq!(record.mcp_tool_call, None);
+    let exchange = record.content.mcp_exchange.as_ref().unwrap();
+    assert_eq!(exchange.provider_call_id, "ordinary-call-id-canary");
+    assert_eq!(exchange.response, None);
+    let invocation = exchange.invocation.as_ref().unwrap();
+    assert_eq!(invocation.server, "ordinary-server-canary");
+    assert_eq!(invocation.tool, "ordinary-tool-canary");
+    assert_eq!(
+        invocation.arguments,
+        McpJsonCapture::Present { value: arguments }
+    );
+}
+
+#[test]
+fn copilot_no_id_mcp_starts_keep_distinct_fallback_ids_across_reordering() {
+    fn start_without_id(call_id: &str) -> String {
+        json!({
+            "type": "tool.execution_start",
+            "timestamp": "2026-08-03T12:00:01Z",
+            "data": {
+                "toolCallId": call_id,
+                "mcpServerName": "fallback-server",
+                "mcpToolName": "identical-fallback-tool",
+                "arguments": {"query": "identical-fallback-argument"}
+            }
+        })
+        .to_string()
+    }
+
+    fn ids_by_call(records: Vec<CoreRecord>) -> BTreeMap<String, StableEntityId> {
+        records
+            .into_iter()
+            .filter_map(|record| {
+                let exchange = record.content.mcp_exchange?;
+                exchange.invocation?;
+                Some((exchange.provider_call_id, record.event_id))
+            })
+            .collect()
+    }
+
+    let first = start_without_id("fallback-call-one");
+    let second = start_without_id("fallback-call-two");
+    let original = ids_by_call(project_events(&[first.clone(), second.clone()]));
+    let reordered = ids_by_call(project_events(&[second, first]));
+
+    assert_eq!(original, reordered);
+    assert_eq!(original.len(), 2);
+    assert_ne!(original["fallback-call-one"], original["fallback-call-two"]);
+}
+
+#[test]
+fn copilot_non_mcp_tool_start_retains_native_data_body() {
+    let data = json!({
+        "toolCallId": "ordinary-non-mcp-call",
+        "toolName": "shell",
+        "redacted": false,
+        "arguments": {"command": "printf retained-non-mcp-canary"}
+    });
+    let events = vec![json!({
+        "type": "tool.execution_start",
+        "id": "ordinary-non-mcp-start",
+        "timestamp": "2026-08-03T12:00:01Z",
+        "redacted": false,
+        "data": data.clone()
+    })
+    .to_string()];
+
+    let records = project_events(&events);
+    let record = record_by_native_id(&records, "ordinary-non-mcp-start");
+    assert_eq!(
+        record.content.normalized_body.as_deref(),
+        Some(data.to_string().as_str())
+    );
+    assert!(record
+        .content
+        .normalized_body
+        .as_deref()
+        .unwrap()
+        .contains("retained-non-mcp-canary"));
+    assert_eq!(record.content.mcp_exchange, None);
+}
+
+#[test]
+fn copilot_duplicate_sensitive_start_keys_force_generic_body_before_hashing() {
+    let events = vec![
+        r#"{"type":"tool.execution_start","id":"duplicate-envelope-redaction","timestamp":"2026-08-03T12:00:01Z","redacted":true,"redacted":false,"data":{"toolCallId":"duplicate-envelope-call-canary","arguments":{"needle":"duplicate-envelope-arguments-canary"}}}"#.to_owned(),
+        r#"{"type":"tool.execution_start","id":"duplicate-data-redaction","timestamp":"2026-08-03T12:00:02Z","data":{"redacted":true,"r\u0065dacted":false,"toolCallId":"duplicate-data-call-canary","arguments":{"needle":"duplicate-data-arguments-canary"}}}"#.to_owned(),
+        r#"{"type":"tool.execution_start","id":"duplicate-mcp-key","timestamp":"2026-08-03T12:00:03Z","data":{"toolCallId":"duplicate-mcp-call-canary","mcpServerName":"duplicate-mcp-server-first-canary","mcpSer\u0076erName":"duplicate-mcp-server-second-canary","mcpToolName":"duplicate-mcp-tool-canary","arguments":{"needle":"duplicate-mcp-arguments-canary"}}}"#.to_owned(),
+    ];
+
+    let records = project_events(&events);
+    for native_id in [
+        "duplicate-envelope-redaction",
+        "duplicate-data-redaction",
+        "duplicate-mcp-key",
+    ] {
+        let record = record_by_native_id(&records, native_id);
+        assert_eq!(record.mcp_tool_call, None);
+        assert_eq!(record.content.mcp_exchange, None);
+        let body = record.content.normalized_body.as_deref().unwrap();
+        assert_eq!(body, "tool_call");
+        for canary in [
+            "duplicate-envelope-call-canary",
+            "duplicate-envelope-arguments-canary",
+            "duplicate-data-call-canary",
+            "duplicate-data-arguments-canary",
+            "duplicate-mcp-call-canary",
+            "duplicate-mcp-server-first-canary",
+            "duplicate-mcp-server-second-canary",
+            "duplicate-mcp-tool-canary",
+            "duplicate-mcp-arguments-canary",
+        ] {
+            assert!(!body.contains(canary), "normalized body leaked {canary}");
+        }
+    }
+}
+
+#[test]
 fn copilot_argument_capture_distinguishes_exact_absent_and_unavailable() {
     let events = vec![
         json!({
@@ -822,19 +968,39 @@ fn copilot_tool_owned_redaction_like_keys_preserve_body_and_exchange() {
 #[test]
 fn copilot_provider_redacted_starts_do_not_leak_linkage_or_exchange() {
     let events = vec![
-        r#"{"type":"tool.execution_start","id":"redacted-envelope","timestamp":"2026-08-03T12:00:01Z","redacted":true,"data":{"toolCallId":"redacted-envelope-call","mcpServerName":"secret-server","mcpToolName":"secret-tool","arguments":{}}}"#.to_owned(),
+        r#"{"type":"tool.execution_start","id":"redacted-envelope","timestamp":"2026-08-03T12:00:01Z","redacted":true,"data":{"toolCallId":"redacted-envelope-call-canary","mcpServerName":"redacted-envelope-server-canary","mcpToolName":"redacted-envelope-tool-canary","arguments":{"needle":"redacted-envelope-arguments-canary"}}}"#.to_owned(),
         r#"{"type":"tool.execution_complete","id":"redacted-envelope-complete","timestamp":"2026-08-03T12:00:02Z","data":{"toolCallId":"redacted-envelope-call","success":true,"result":{"content":"ordinary envelope completion"}}}"#.to_owned(),
-        r#"{"type":"tool.execution_start","id":"redacted-data","timestamp":"2026-08-03T12:00:03Z","data":{"redacted":true,"toolCallId":"redacted-data-call","mcpServerName":"secret-server","mcpToolName":"secret-tool","arguments":{}}}"#.to_owned(),
+        r#"{"type":"tool.execution_start","id":"redacted-data","timestamp":"2026-08-03T12:00:03Z","data":{"redacted":true,"toolCallId":"redacted-data-call-canary","mcpServerName":"redacted-data-server-canary","mcpToolName":"redacted-data-tool-canary","arguments":{"needle":"redacted-data-arguments-canary"}}}"#.to_owned(),
         r#"{"type":"tool.execution_complete","id":"redacted-data-complete","timestamp":"2026-08-03T12:00:04Z","data":{"toolCallId":"redacted-data-call","success":false,"error":{"message":"ordinary data completion"}}}"#.to_owned(),
+        r#"{"type":"tool.execution_start","id":"redacted-envelope-bool-without-names","timestamp":"2026-08-03T12:00:05Z","isRedacted":true,"data":{"toolCallId":"envelope-bool-call-canary","arguments":{"needle":"envelope-bool-arguments-canary"}}}"#.to_owned(),
+        r#"{"type":"tool.execution_start","id":"redacted-envelope-status-without-names","timestamp":"2026-08-03T12:00:06Z","status":"redacted","data":{"toolCallId":"envelope-status-call-canary","arguments":{"needle":"envelope-status-arguments-canary"}}}"#.to_owned(),
+        r#"{"type":"tool.execution_start","id":"redacted-data-bool-without-names","timestamp":"2026-08-03T12:00:07Z","data":{"is_redacted":true,"toolCallId":"data-bool-call-canary","arguments":{"needle":"data-bool-arguments-canary"}}}"#.to_owned(),
+        r#"{"type":"tool.execution_start","id":"redacted-data-state-without-names","timestamp":"2026-08-03T12:00:08Z","data":{"state":"output-redacted","toolCallId":"data-state-call-canary","arguments":{"needle":"data-state-arguments-canary"}}}"#.to_owned(),
     ];
     assert!(linkage_plan(&events, super::copilot::CopilotLinkageLimits::DEFAULT).is_empty());
     let records = project_events(&events);
 
-    for native_id in ["redacted-envelope", "redacted-data"] {
+    for native_id in [
+        "redacted-envelope",
+        "redacted-data",
+        "redacted-envelope-bool-without-names",
+        "redacted-envelope-status-without-names",
+        "redacted-data-bool-without-names",
+        "redacted-data-state-without-names",
+    ] {
         let record = record_by_native_id(&records, native_id);
         assert_eq!(record.mcp_tool_call, None);
         assert_eq!(record.content.mcp_exchange, None);
-        assert!(record.content.normalized_body.is_some());
+        assert_eq!(record.content.normalized_body.as_deref(), Some("tool_call"));
+        let body = record.content.normalized_body.as_deref().unwrap();
+        for canary in [
+            "call-canary",
+            "server-canary",
+            "tool-canary",
+            "arguments-canary",
+        ] {
+            assert!(!body.contains(canary), "normalized body leaked {canary}");
+        }
     }
     for (native_id, expected_body) in [
         ("redacted-envelope-complete", "ordinary envelope completion"),
@@ -954,17 +1120,37 @@ fn copilot_budget_fitting_omits_one_capture_at_a_time() {
 
 #[test]
 fn copilot_oversized_native_arguments_become_explicit_omission_without_losing_the_event() {
+    let empty_arguments = json!({"blob": ""});
+    let empty_event = json!({
+        "type": "tool.execution_start",
+        "id": "oversized-arguments-start",
+        "timestamp": "2026-08-03T12:00:01Z",
+        "data": {
+            "toolCallId": "oversized-call-id-canary",
+            "mcpServerName": "oversized-server-canary",
+            "mcpToolName": "oversized-tool-canary",
+            "arguments": empty_arguments
+        }
+    })
+    .to_string();
+    let padding_bytes = crate::MAX_PROVIDER_JSONL_LINE_BYTES
+        .checked_sub(empty_event.len())
+        .and_then(|remaining| remaining.checked_sub(32))
+        .unwrap();
+    let arguments_canary = "oversized-arguments-canary";
     let arguments = json!({
-        "blob": "x".repeat(MAX_CORE_CONTENT_BYTES / 2 + 64 * 1024)
+        "blob": format!(
+            "{}{arguments_canary}",
+            "x".repeat(padding_bytes - arguments_canary.len())
+        )
     });
     let observed_encoded_bytes = u64::try_from(serde_json::to_vec(&arguments).unwrap().len()).ok();
     let data = json!({
-        "toolCallId": "oversized-arguments-call",
-        "mcpServerName": "oversized-server",
-        "mcpToolName": "oversized-tool",
+        "toolCallId": "oversized-call-id-canary",
+        "mcpServerName": "oversized-server-canary",
+        "mcpToolName": "oversized-tool-canary",
         "arguments": arguments
     });
-    let expected_normalized_body = data.to_string();
     let event = json!({
         "type": "tool.execution_start",
         "id": "oversized-arguments-start",
@@ -972,15 +1158,22 @@ fn copilot_oversized_native_arguments_become_explicit_omission_without_losing_th
         "data": data
     })
     .to_string();
+    assert_eq!(event.len(), crate::MAX_PROVIDER_JSONL_LINE_BYTES - 32);
     assert!(event.len() <= crate::MAX_PROVIDER_JSONL_LINE_BYTES);
 
     let records = project_events(&[event]);
     let record = record_by_native_id(&records, "oversized-arguments-start");
     assert_eq!(record.mcp_tool_call, None);
-    assert_eq!(
-        record.content.normalized_body.as_deref(),
-        Some(expected_normalized_body.as_str())
-    );
+    let body = record.content.normalized_body.as_deref().unwrap();
+    assert_eq!(body, "tool_call");
+    for canary in [
+        "oversized-call-id-canary",
+        "oversized-server-canary",
+        "oversized-tool-canary",
+        arguments_canary,
+    ] {
+        assert!(!body.contains(canary), "normalized body leaked {canary}");
+    }
     assert_eq!(
         record
             .content
@@ -1421,6 +1614,10 @@ fn copilot_attribution_does_not_change_stable_event_ids() {
 #[test]
 fn only_copilot_bumps_the_shared_direct_jsonl_parser_revision() {
     let copilot = super::super::copilot_source_backed_adapter();
+    assert_eq!(
+        super::copilot::COPILOT_DIRECT_NATIVE_JSONL_PARSER_REVISION,
+        "copilot-cli-direct-native-jsonl-v6-mcp-start-generic-body"
+    );
     assert_eq!(
         JsonlFamilyAdapter::parser_revision(&copilot),
         super::copilot::COPILOT_DIRECT_NATIVE_JSONL_PARSER_REVISION

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed_result_tests.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed_result_tests.rs
@@ -233,7 +233,7 @@ fn copilot_and_windsurf_replay_preserve_current_revision_ids_and_records() {
             "c1ebd99c-7338-859b-891d-1c7e04d9ae9d",
             "5ff93a01-4aa3-82f8-8d9e-784490016567",
             "8d4627ce-c12c-8d64-af2d-d85ac722121f",
-            "e4ff824c4d7ee3d0013103491db678391e7558a0795decc86ec7ff62c88ab505",
+            "80dad7726d3955a9d853a053fa886ce204b45f41abfd5025f8b478da943ff0e4",
         ),
     ];
 

--- a/crates/ctx-history-index/src/core_contract.rs
+++ b/crates/ctx-history-index/src/core_contract.rs
@@ -250,7 +250,7 @@ mod tests {
                 .unwrap(),
             SAME_EPOCH_PREDECESSOR_SOURCE_GENERATION_POLICY_HASH
         );
-        assert_eq!(
+        assert_ne!(
             current_source_generation_policy_hash().unwrap(),
             SAME_EPOCH_PREDECESSOR_SOURCE_GENERATION_POLICY_HASH
         );

--- a/crates/ctx-history-index/src/index_document.rs
+++ b/crates/ctx-history-index/src/index_document.rs
@@ -687,7 +687,7 @@ impl IndexDocument {
         if let Some(role) = record.role {
             target.add_text(fields.role, role);
         }
-        if let Some(body) = record.content.normalized_body {
+        if let Some(body) = crate::project_body_search(record.content)? {
             target.add_text(fields.body_search, body);
         }
         for observation in record.repository_vcs_observations {

--- a/crates/ctx-history-index/src/lib.rs
+++ b/crates/ctx-history-index/src/lib.rs
@@ -17,6 +17,7 @@ mod publication;
 mod query;
 mod reader;
 mod schema;
+mod search_projection;
 mod staging;
 mod writer_deletion;
 mod writer_publication;
@@ -102,6 +103,7 @@ pub use reader::VerifiedIndex;
 #[cfg(test)]
 pub(crate) use schema::required_field;
 pub(crate) use schema::{fields_from_schema, lexical_schema, validate_schema, Fields};
+pub use search_projection::project_body_search;
 pub use writer_support::BaseEventIdentityLookup;
 
 use std::{

--- a/crates/ctx-history-index/src/policy.rs
+++ b/crates/ctx-history-index/src/policy.rs
@@ -13,7 +13,7 @@ pub const SOURCE_ROUTE_SNAPSHOT_REVISION: u32 = 1;
 pub const AUTOMATIC_ROUTE_DELETION_GRACE_OBSERVATIONS: u32 = 3;
 pub const LEXICAL_SCHEMA_REVISION: u32 = 17;
 pub const LEXICAL_TOKENIZER_REVISION: u32 = 2;
-pub const SOURCE_EVENT_PROJECTOR_REVISION: u32 = 3;
+pub const SOURCE_EVENT_PROJECTOR_REVISION: u32 = 4;
 pub const LEXICAL_INDEXED_BODY_LIMIT: LexicalIndexedBodyLimit =
     LexicalIndexedBodyLimit::ProviderValidatedFullText;
 pub const SEMANTIC_ELIGIBILITY_REVISION: u32 = 2;
@@ -283,10 +283,13 @@ mod tests {
             .as_object()
             .unwrap()
             .contains_key("core_repository_association_policy_revision"));
+        assert_eq!(first.policy_version, 10);
+        assert_eq!(first.lexical.event_projector_revision, 4);
         assert_eq!(first.lexical.schema_revision, 17);
+        assert_eq!(first.lexical.tokenizer_revision, 2);
         assert_eq!(
             first.canonical_sha256().unwrap(),
-            "e728b5d7b76d04248e9dccc91fc11d915fcbcd714b445090725ba0604b8e8b37"
+            "f9204898f2c6783d94954d1aad4e374bd507f538b547fb0d66c8b8174c6838a3"
         );
     }
 

--- a/crates/ctx-history-index/src/publication/certification.rs
+++ b/crates/ctx-history-index/src/publication/certification.rs
@@ -22,6 +22,7 @@ const CERTIFICATION_VERSION: u32 = 1;
 const CERTIFICATION_SUFFIX: &str = ".physical-certification.json";
 const CERTIFICATION_DIRECTORY: &str = "integrity-certifications";
 const TANTIVY_META_FILE: &str = "meta.json";
+const ARTIFACT_STABLE_SNAPSHOT_ATTEMPTS: usize = 4;
 pub(crate) const MAX_CERTIFICATION_BYTES: usize = 1024 * 1024;
 pub(crate) const MAX_CERTIFIED_ARTIFACTS: usize = 1024;
 
@@ -86,6 +87,21 @@ where
 pub(super) struct ArtifactIdentity {
     pub(super) path: String,
     pub(super) identity: FileIdentity,
+}
+
+impl ArtifactIdentity {
+    /// Returns whether both observations still bind the same native file and
+    /// immutable-content metadata, but some stronger identity metadata changed.
+    ///
+    /// This is a fail-closed concurrency classification, not proof that a hard
+    /// link operation was the cause: ctime is excluded because managed
+    /// link/unlink operations change it, and a same-size mutation with restored
+    /// mtime must likewise force the caller to retry rather than accept bytes.
+    pub(super) fn same_payload_identity_changed(&self, other: &Self) -> bool {
+        self.path == other.path
+            && self.identity != other.identity
+            && self.identity.same_payload_identity(&other.identity)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -156,6 +172,33 @@ impl FileIdentity {
         #[cfg(not(any(unix, windows)))]
         {
             let _ = other;
+            false
+        }
+    }
+
+    /// Identity fields that cannot be changed by creating or removing a hard
+    /// link to the same immutable payload. Link operations may change ctime
+    /// and link count, so those fields are deliberately excluded here.
+    fn same_payload_identity(&self, other: &Self) -> bool {
+        if !self.same_native_file(other) {
+            return false;
+        }
+        #[cfg(unix)]
+        {
+            self.length == other.length
+                && self.mode == other.mode
+                && self.modified_seconds == other.modified_seconds
+                && self.modified_nanoseconds == other.modified_nanoseconds
+        }
+        #[cfg(windows)]
+        {
+            self.length == other.length
+                && self.creation_time == other.creation_time
+                && self.last_write_time == other.last_write_time
+                && self.attributes == other.attributes
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
             false
         }
     }
@@ -256,17 +299,35 @@ fn install_certification(
     ensure_real_directory(&root.join(INDEX_GENERATIONS_DIRECTORY))?;
     ensure_real_directory(&generation_path)?;
 
-    let pointer_identity = capture_single_link_control(&root.join("active-generation.json"))?;
-    let manifest_identity =
-        capture_single_link_control(&manifest_path(root, slot.generation_id()))?;
+    let pointer_identity = capture_pointer_bound_single_link_control(
+        root,
+        pointer,
+        &root.join("active-generation.json"),
+    )?;
+    let manifest_identity = capture_pointer_bound_single_link_control(
+        root,
+        pointer,
+        &manifest_path(root, slot.generation_id()),
+    )?;
     let mut artifacts = Vec::with_capacity(audit.artifacts().len());
     for prior in audit.artifacts() {
-        let current = capture_artifact(root, &generation_path, Path::new(&prior.path))?;
-        if current.identity != prior.identity
-            && !(allow_link_reclamation
-                && current.identity.follows_link_reclamation(&prior.identity))
-        {
-            return Err(IndexError::ChecksumMismatch);
+        let current = capture_artifact(
+            root,
+            &generation_path,
+            Path::new(&prior.path),
+            Some(pointer),
+        )?;
+        if current.identity != prior.identity {
+            if allow_link_reclamation && current.identity.follows_link_reclamation(&prior.identity)
+            {
+                artifacts.push(current);
+                continue;
+            }
+            return if prior.same_payload_identity_changed(&current) {
+                Err(IndexError::ConcurrentGenerationChange)
+            } else {
+                Err(IndexError::ChecksumMismatch)
+            };
         }
         artifacts.push(current);
     }
@@ -336,10 +397,16 @@ fn certification_matches(
     ensure_real_directory(&root.join(INDEX_GENERATIONS_DIRECTORY))?;
     let generation_path = super::slot_path(root, slot);
     ensure_real_directory(&generation_path)?;
-    if capture_single_link_control(&root.join("active-generation.json"))?
-        != certification.pointer_identity
-        || capture_single_link_control(&manifest_path(root, slot.generation_id()))?
-            != certification.manifest_identity
+    if capture_pointer_bound_single_link_control(
+        root,
+        pointer,
+        &root.join("active-generation.json"),
+    )? != certification.pointer_identity
+        || capture_pointer_bound_single_link_control(
+            root,
+            pointer,
+            &manifest_path(root, slot.generation_id()),
+        )? != certification.manifest_identity
     {
         return Ok(false);
     }
@@ -355,10 +422,18 @@ fn certification_matches(
         return Ok(false);
     }
     for expected in &certification.artifacts {
-        let current = capture_artifact(root, &generation_path, Path::new(&expected.path))?;
+        let current = capture_artifact(
+            root,
+            &generation_path,
+            Path::new(&expected.path),
+            Some(pointer),
+        )?;
         if &current != expected {
             return Ok(false);
         }
+    }
+    if load_current_pointer(root)? != *pointer {
+        return Err(IndexError::ConcurrentGenerationChange);
     }
     Ok(true)
 }
@@ -404,6 +479,7 @@ pub(super) fn open_artifact(
     root: &Path,
     generation_path: &Path,
     relative_path: &Path,
+    pointer: Option<&ActiveGenerationPointer>,
 ) -> Result<(File, ArtifactIdentity)> {
     if relative_path.components().count() != 1 {
         return Err(IndexError::ChecksumMismatch);
@@ -412,25 +488,150 @@ pub(super) fn open_artifact(
         .to_str()
         .ok_or(IndexError::ChecksumMismatch)?
         .to_owned();
-    let (file, identity) = open_regular_file(&generation_path.join(relative_path))?;
-    validate_artifact_link_count(root, relative_path, &identity)?;
-    Ok((file, ArtifactIdentity { path, identity }))
+    let artifact_path = generation_path.join(relative_path);
+    let mut unaccounted_observation: Option<(FileIdentity, u64)> = None;
+    let mut stable_unaccounted_attempts = 0_usize;
+    for _ in 0..ARTIFACT_STABLE_SNAPSHOT_ATTEMPTS {
+        let Some((file, identity)) = open_artifact_file_snapshot(&artifact_path)? else {
+            unaccounted_observation = None;
+            stable_unaccounted_attempts = 0;
+            std::thread::yield_now();
+            continue;
+        };
+        match stable_artifact_link_snapshot(
+            root,
+            &artifact_path,
+            relative_path,
+            &file,
+            &identity,
+            pointer,
+        )? {
+            ArtifactLinkSnapshot::Stable(identity) => {
+                return Ok((file, ArtifactIdentity { path, identity }));
+            }
+            ArtifactLinkSnapshot::Retry => {
+                unaccounted_observation = None;
+                stable_unaccounted_attempts = 0;
+            }
+            ArtifactLinkSnapshot::Unaccounted { identity, aliases } => {
+                let observation = (identity, aliases);
+                if unaccounted_observation.as_ref() == Some(&observation) {
+                    stable_unaccounted_attempts = stable_unaccounted_attempts
+                        .checked_add(1)
+                        .ok_or(IndexError::CountOverflow)?;
+                } else {
+                    unaccounted_observation = Some(observation);
+                    stable_unaccounted_attempts = 1;
+                }
+                if stable_unaccounted_attempts == ARTIFACT_STABLE_SNAPSHOT_ATTEMPTS {
+                    return Err(IndexError::ChecksumMismatch);
+                }
+            }
+        }
+        std::thread::yield_now();
+    }
+    Err(IndexError::ConcurrentGenerationChange)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ArtifactLinkSnapshot {
+    Stable(FileIdentity),
+    Retry,
+    Unaccounted {
+        identity: FileIdentity,
+        aliases: u64,
+    },
+}
+
+/// Opens a named artifact while distinguishing hard-link topology churn from
+/// replacement or payload mutation. `None` asks the bounded caller to retry a
+/// snapshot changed only by a link/unlink operation.
+fn open_artifact_file_snapshot(path: &Path) -> Result<Option<(File, FileIdentity)>> {
+    validate_named_regular_file(path)?;
+    let file = open_nofollow(path).map_err(|_| IndexError::ChecksumMismatch)?;
+    let opened = file_identity(&file).map_err(|_| IndexError::ChecksumMismatch)?;
+    validate_named_regular_file(path)?;
+    let named = open_nofollow(path).map_err(|_| IndexError::ChecksumMismatch)?;
+    let named_identity = file_identity(&named).map_err(|_| IndexError::ChecksumMismatch)?;
+    drop(named);
+    let held = file_identity(&file).map_err(|_| IndexError::ChecksumMismatch)?;
+    if opened == named_identity && named_identity == held {
+        return Ok(Some((file, held)));
+    }
+    if opened.same_payload_identity(&named_identity) && named_identity.same_payload_identity(&held)
+    {
+        return Ok(None);
+    }
+    Err(IndexError::ChecksumMismatch)
+}
+
+/// Proves one stable managed-alias snapshot for an already-bound artifact.
+/// Stable unaccounted hardlinks remain corruption; only an observation that
+/// changed during the bounded snapshot is retryable.
+fn stable_artifact_link_snapshot(
+    root: &Path,
+    artifact_path: &Path,
+    relative_path: &Path,
+    file: &File,
+    identity: &FileIdentity,
+    pointer: Option<&ActiveGenerationPointer>,
+) -> Result<ArtifactLinkSnapshot> {
+    let before = file_identity(file).map_err(|_| IndexError::ChecksumMismatch)?;
+    if before != *identity {
+        return if before.same_payload_identity(identity) {
+            Ok(ArtifactLinkSnapshot::Retry)
+        } else {
+            Err(IndexError::ChecksumMismatch)
+        };
+    }
+    let Some(alias_snapshot) = managed_artifact_alias_count(root, relative_path, &before, pointer)?
+    else {
+        return Ok(ArtifactLinkSnapshot::Retry);
+    };
+    let after_scan = file_identity(file).map_err(|_| IndexError::ChecksumMismatch)?;
+    validate_named_regular_file(artifact_path)?;
+    let named = open_nofollow(artifact_path).map_err(|_| IndexError::ChecksumMismatch)?;
+    let named_identity = file_identity(&named).map_err(|_| IndexError::ChecksumMismatch)?;
+    drop(named);
+    let final_identity = file_identity(file).map_err(|_| IndexError::ChecksumMismatch)?;
+
+    if before == after_scan && after_scan == named_identity && named_identity == final_identity {
+        if alias_snapshot.aliases == 0 || alias_snapshot.aliases != final_identity.link_count() {
+            if alias_snapshot.saw_unpublished_generation {
+                return Ok(ArtifactLinkSnapshot::Retry);
+            }
+            return Ok(ArtifactLinkSnapshot::Unaccounted {
+                identity: final_identity,
+                aliases: alias_snapshot.aliases,
+            });
+        }
+        return Ok(ArtifactLinkSnapshot::Stable(final_identity));
+    }
+    if before.same_payload_identity(&after_scan)
+        && after_scan.same_payload_identity(&named_identity)
+        && named_identity.same_payload_identity(&final_identity)
+    {
+        return Ok(ArtifactLinkSnapshot::Retry);
+    }
+    Err(IndexError::ChecksumMismatch)
 }
 
 pub(super) fn recapture_artifact(
     root: &Path,
     generation_path: &Path,
     relative_path: &Path,
+    pointer: Option<&ActiveGenerationPointer>,
 ) -> Result<ArtifactIdentity> {
-    capture_artifact(root, generation_path, relative_path)
+    capture_artifact(root, generation_path, relative_path, pointer)
 }
 
 fn capture_artifact(
     root: &Path,
     generation_path: &Path,
     relative_path: &Path,
+    pointer: Option<&ActiveGenerationPointer>,
 ) -> Result<ArtifactIdentity> {
-    let (file, artifact) = open_artifact(root, generation_path, relative_path)?;
+    let (file, artifact) = open_artifact(root, generation_path, relative_path, pointer)?;
     drop(file);
     Ok(artifact)
 }
@@ -444,10 +645,39 @@ fn capture_single_link_control(path: &Path) -> Result<FileIdentity> {
     Ok(identity)
 }
 
+fn capture_pointer_bound_single_link_control(
+    root: &Path,
+    pointer: &ActiveGenerationPointer,
+    path: &Path,
+) -> Result<FileIdentity> {
+    for attempt in 0..ARTIFACT_STABLE_SNAPSHOT_ATTEMPTS {
+        match capture_single_link_control(path) {
+            Ok(identity) => {
+                if load_current_pointer(root)? != *pointer {
+                    return Err(IndexError::ConcurrentGenerationChange);
+                }
+                return Ok(identity);
+            }
+            Err(error) => {
+                if load_current_pointer(root)? != *pointer {
+                    return Err(IndexError::ConcurrentGenerationChange);
+                }
+                if attempt + 1 == ARTIFACT_STABLE_SNAPSHOT_ATTEMPTS {
+                    return Err(error);
+                }
+                std::thread::yield_now();
+            }
+        }
+    }
+    Err(IndexError::ConcurrentGenerationChange)
+}
+
 fn open_regular_file(path: &Path) -> Result<(File, FileIdentity)> {
     validate_named_regular_file(path)?;
     let file = open_nofollow(path).map_err(|_| IndexError::ChecksumMismatch)?;
     let identity = file_identity(&file).map_err(|_| IndexError::ChecksumMismatch)?;
+    #[cfg(test)]
+    run_regular_file_identity_test_hook(path);
     validate_named_regular_file(path)?;
     let named = open_nofollow(path).map_err(|_| IndexError::ChecksumMismatch)?;
     let named_identity = file_identity(&named).map_err(|_| IndexError::ChecksumMismatch)?;
@@ -455,6 +685,40 @@ fn open_regular_file(path: &Path) -> Result<(File, FileIdentity)> {
         return Err(IndexError::ChecksumMismatch);
     }
     Ok((file, identity))
+}
+
+#[cfg(test)]
+thread_local! {
+    static REGULAR_FILE_IDENTITY_TEST_HOOK: std::cell::RefCell<Option<Box<dyn FnMut(&Path)>>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(test)]
+struct RegularFileIdentityTestHookGuard(Option<Box<dyn FnMut(&Path)>>);
+
+#[cfg(test)]
+impl RegularFileIdentityTestHookGuard {
+    fn install(hook: impl FnMut(&Path) + 'static) -> Self {
+        let previous =
+            REGULAR_FILE_IDENTITY_TEST_HOOK.with(|active| active.replace(Some(Box::new(hook))));
+        Self(previous)
+    }
+}
+
+#[cfg(test)]
+impl Drop for RegularFileIdentityTestHookGuard {
+    fn drop(&mut self) {
+        REGULAR_FILE_IDENTITY_TEST_HOOK.with(|active| active.replace(self.0.take()));
+    }
+}
+
+#[cfg(test)]
+fn run_regular_file_identity_test_hook(path: &Path) {
+    REGULAR_FILE_IDENTITY_TEST_HOOK.with(|active| {
+        if let Some(hook) = active.borrow_mut().as_mut() {
+            hook(path);
+        }
+    });
 }
 
 fn open_nofollow(path: &Path) -> std::io::Result<File> {
@@ -596,37 +860,109 @@ fn metadata_is_reparse_point(_metadata: &Metadata) -> bool {
     false
 }
 
-fn validate_artifact_link_count(
+fn managed_artifact_alias_count(
     root: &Path,
     relative_path: &Path,
     identity: &FileIdentity,
-) -> Result<()> {
+    pointer: Option<&ActiveGenerationPointer>,
+) -> Result<Option<ManagedAliasSnapshot>> {
     let generations = root.join(INDEX_GENERATIONS_DIRECTORY);
     let mut aliases = 0_u64;
+    let mut saw_unpublished_generation = false;
     for entry in fs::read_dir(generations).map_err(|_| IndexError::ChecksumMismatch)? {
-        let entry = entry.map_err(|_| IndexError::ChecksumMismatch)?;
-        let file_type = entry
-            .file_type()
-            .map_err(|_| IndexError::ChecksumMismatch)?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) if retryable_alias_snapshot_error(&error) => return Ok(None),
+            Err(_) => return Err(IndexError::ChecksumMismatch),
+        };
+        #[cfg(test)]
+        run_alias_entry_test_hook(&entry.path());
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) if retryable_alias_snapshot_error(&error) => return Ok(None),
+            Err(_) => return Err(IndexError::ChecksumMismatch),
+        };
         let Some(directory_name) = entry.file_name().to_str().map(str::to_owned) else {
             continue;
         };
         if !file_type.is_dir() || !is_generation_directory_name(&directory_name) {
             continue;
         }
+        if pointer.is_some_and(|pointer| {
+            pointer.active().directory() != directory_name
+                && pointer
+                    .previous()
+                    .is_none_or(|slot| slot.directory() != directory_name)
+        }) {
+            saw_unpublished_generation = true;
+        }
         let candidate = entry.path().join(relative_path);
-        let Ok((file, candidate_identity)) = open_regular_file(&candidate) else {
-            continue;
+        let (file, candidate_identity) = match open_regular_file(&candidate) {
+            Ok(opened) => opened,
+            Err(_) => continue,
         };
         drop(file);
         if candidate_identity.same_native_file(identity) {
             aliases = aliases.checked_add(1).ok_or(IndexError::CountOverflow)?;
         }
     }
-    if aliases == 0 || aliases != identity.link_count() {
-        return Err(IndexError::ChecksumMismatch);
+    Ok(Some(ManagedAliasSnapshot {
+        aliases,
+        saw_unpublished_generation,
+    }))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ManagedAliasSnapshot {
+    aliases: u64,
+    saw_unpublished_generation: bool,
+}
+
+fn retryable_alias_snapshot_error(error: &std::io::Error) -> bool {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        return true;
     }
-    Ok(())
+    #[cfg(unix)]
+    {
+        error.raw_os_error() == Some(libc::ESTALE)
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
+#[cfg(test)]
+thread_local! {
+    static ALIAS_ENTRY_TEST_HOOK: std::cell::RefCell<Option<Box<dyn FnMut(&Path)>>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(test)]
+struct AliasEntryTestHookGuard(Option<Box<dyn FnMut(&Path)>>);
+
+#[cfg(test)]
+impl AliasEntryTestHookGuard {
+    fn install(hook: impl FnMut(&Path) + 'static) -> Self {
+        let previous = ALIAS_ENTRY_TEST_HOOK.with(|active| active.replace(Some(Box::new(hook))));
+        Self(previous)
+    }
+}
+
+#[cfg(test)]
+impl Drop for AliasEntryTestHookGuard {
+    fn drop(&mut self) {
+        ALIAS_ENTRY_TEST_HOOK.with(|active| active.replace(self.0.take()));
+    }
+}
+
+#[cfg(test)]
+fn run_alias_entry_test_hook(path: &Path) {
+    ALIAS_ENTRY_TEST_HOOK.with(|active| {
+        if let Some(hook) = active.borrow_mut().as_mut() {
+            hook(path);
+        }
+    });
 }
 
 fn is_generation_directory_name(name: &str) -> bool {
@@ -684,4 +1020,185 @@ pub(crate) fn reclaim_unreferenced_certifications(
 pub(crate) fn certification_file_for_active(root: &Path) -> Result<PathBuf> {
     let pointer = load_current_pointer(root)?;
     Ok(certification_path(root, pointer.active()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn generation(root: &Path, digit: char) -> PathBuf {
+        root.join(INDEX_GENERATIONS_DIRECTORY)
+            .join(format!("generation-{}", digit.to_string().repeat(32)))
+    }
+
+    fn pointer(digit: char) -> ActiveGenerationPointer {
+        let digit = digit.to_string();
+        ActiveGenerationPointer::new(
+            GenerationSlot::new(
+                digit.repeat(64),
+                format!("generation-{}", digit.repeat(32)),
+                digit.repeat(64),
+            )
+            .unwrap(),
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn managed_link_creation_and_cleanup_are_retryable_stable_snapshots() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let active = generation(root, '1');
+        let candidate = generation(root, '2');
+        fs::create_dir_all(&active).unwrap();
+        fs::create_dir_all(&candidate).unwrap();
+        let relative = Path::new("payload.bin");
+        let active_path = active.join(relative);
+        let candidate_path = candidate.join(relative);
+        fs::write(&active_path, b"immutable payload").unwrap();
+
+        let (file, before_link) = open_artifact_file_snapshot(&active_path).unwrap().unwrap();
+        fs::hard_link(&active_path, &candidate_path).unwrap();
+        assert!(matches!(
+            stable_artifact_link_snapshot(root, &active_path, relative, &file, &before_link, None,)
+                .unwrap(),
+            ArtifactLinkSnapshot::Retry
+        ));
+        drop(file);
+
+        let (_, linked) = open_artifact(root, &active, relative, None).unwrap();
+        assert_eq!(linked.identity.link_count(), 2);
+        let (file, before_unlink) = open_artifact_file_snapshot(&active_path).unwrap().unwrap();
+        fs::remove_file(&candidate_path).unwrap();
+        assert!(matches!(
+            stable_artifact_link_snapshot(
+                root,
+                &active_path,
+                relative,
+                &file,
+                &before_unlink,
+                None,
+            )
+            .unwrap(),
+            ArtifactLinkSnapshot::Retry
+        ));
+        drop(file);
+
+        let (_, unlinked) = open_artifact(root, &active, relative, None).unwrap();
+        assert_eq!(unlinked.identity.link_count(), 1);
+        assert!(linked.same_payload_identity_changed(&unlinked));
+    }
+
+    #[test]
+    fn generation_disappearing_during_alias_scan_is_retryable() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let active = generation(root, '1');
+        let candidate = generation(root, '2');
+        fs::create_dir_all(&active).unwrap();
+        fs::create_dir_all(&candidate).unwrap();
+        let relative = Path::new("payload.bin");
+        let active_path = active.join(relative);
+        let candidate_path = candidate.join(relative);
+        fs::write(&active_path, b"immutable payload").unwrap();
+        fs::hard_link(&active_path, &candidate_path).unwrap();
+        let (file, linked) = open_artifact_file_snapshot(&active_path).unwrap().unwrap();
+
+        let candidate_for_hook = candidate.clone();
+        let candidate_path_for_hook = candidate_path.clone();
+        let _hook = AliasEntryTestHookGuard::install(move |entry_path| {
+            if entry_path == candidate_for_hook {
+                fs::remove_file(&candidate_path_for_hook).unwrap();
+                fs::remove_dir(&candidate_for_hook).unwrap();
+            }
+        });
+
+        assert!(matches!(
+            stable_artifact_link_snapshot(root, &active_path, relative, &file, &linked, None,)
+                .unwrap(),
+            ArtifactLinkSnapshot::Retry
+        ));
+    }
+
+    #[test]
+    fn stale_directory_entry_errors_are_retryable_but_io_errors_are_not() {
+        assert!(retryable_alias_snapshot_error(&std::io::Error::from(
+            std::io::ErrorKind::NotFound,
+        )));
+        assert!(!retryable_alias_snapshot_error(&std::io::Error::from(
+            std::io::ErrorKind::PermissionDenied,
+        )));
+        #[cfg(unix)]
+        assert!(retryable_alias_snapshot_error(
+            &std::io::Error::from_raw_os_error(libc::ESTALE)
+        ));
+    }
+
+    #[test]
+    fn pointer_replacement_during_control_capture_is_concurrent_not_corruption() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let first = pointer('1');
+        let second = pointer('2');
+        let target = root.join("active-generation.json");
+        fs::write(&target, serde_json::to_vec(&first).unwrap()).unwrap();
+        let directory = DurableMmapDirectory::open(root).unwrap();
+        let target_for_hook = target.clone();
+        let second_bytes = serde_json::to_vec(&second).unwrap();
+        let mut replaced = false;
+        let hook = RegularFileIdentityTestHookGuard::install(move |path| {
+            if path == target_for_hook && !replaced {
+                directory
+                    .atomic_write(Path::new("active-generation.json"), &second_bytes)
+                    .unwrap();
+                replaced = true;
+            }
+        });
+
+        assert!(matches!(
+            capture_pointer_bound_single_link_control(root, &first, &target),
+            Err(IndexError::ConcurrentGenerationChange)
+        ));
+        drop(hook);
+        assert_eq!(load_current_pointer(root).unwrap(), second);
+
+        let directory = DurableMmapDirectory::open(root).unwrap();
+        let target_for_hook = target.clone();
+        let second_bytes = serde_json::to_vec(&second).unwrap();
+        let mut rewritten = false;
+        let hook = RegularFileIdentityTestHookGuard::install(move |path| {
+            if path == target_for_hook && !rewritten {
+                directory
+                    .atomic_write(Path::new("active-generation.json"), &second_bytes)
+                    .unwrap();
+                rewritten = true;
+            }
+        });
+        assert!(capture_pointer_bound_single_link_control(root, &second, &target).is_ok());
+        drop(hook);
+
+        fs::hard_link(&target, root.join("unmanaged-pointer-hardlink")).unwrap();
+        assert!(matches!(
+            capture_pointer_bound_single_link_control(root, &second, &target),
+            Err(IndexError::ChecksumMismatch)
+        ));
+    }
+
+    #[test]
+    fn stable_unmanaged_hardlink_remains_checksum_mismatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let active = generation(root, '1');
+        fs::create_dir_all(&active).unwrap();
+        let relative = Path::new("payload.bin");
+        let active_path = active.join(relative);
+        fs::write(&active_path, b"immutable payload").unwrap();
+        fs::hard_link(&active_path, root.join("unmanaged-hardlink")).unwrap();
+
+        assert!(matches!(
+            open_artifact(root, &active, relative, None),
+            Err(IndexError::ChecksumMismatch)
+        ));
+    }
 }

--- a/crates/ctx-history-index/src/publication/verification.rs
+++ b/crates/ctx-history-index/src/publication/verification.rs
@@ -227,6 +227,7 @@ pub(crate) fn physical_integrity_audit(
         })
         .and_then(Path::parent)
         .ok_or(IndexError::ChecksumMismatch)?;
+    let pointer = super::load_active_generation_pointer(root)?;
     let mut paths = active_index_files(index)?;
     paths.insert(PathBuf::from(TANTIVY_META_FILE));
     let entries = paths
@@ -238,6 +239,7 @@ pub(crate) fn physical_integrity_audit(
                 generation_path,
                 &path,
                 path != Path::new(TANTIVY_META_FILE),
+                pointer.as_ref(),
             )
         })
         .collect::<Result<Vec<_>>>()?;
@@ -273,8 +275,9 @@ fn hash_physical_file(
     generation_path: &Path,
     relative_path: &Path,
     validate_tantivy_footer: bool,
+    pointer: Option<&super::ActiveGenerationPointer>,
 ) -> Result<PhysicalFileDigest> {
-    let (mut file, artifact) = open_artifact(root, generation_path, relative_path)?;
+    let (mut file, artifact) = open_artifact(root, generation_path, relative_path, pointer)?;
     let length = artifact.identity.length();
     let footer_contract = if validate_tantivy_footer {
         let slice = directory
@@ -324,8 +327,13 @@ fn hash_physical_file(
             return Err(IndexError::ChecksumMismatch);
         }
     }
-    if recapture_artifact(root, generation_path, relative_path)? != artifact {
-        return Err(IndexError::ChecksumMismatch);
+    let recaptured = recapture_artifact(root, generation_path, relative_path, pointer)?;
+    if recaptured != artifact {
+        return if artifact.same_payload_identity_changed(&recaptured) {
+            Err(IndexError::ConcurrentGenerationChange)
+        } else {
+            Err(IndexError::ChecksumMismatch)
+        };
     }
     Ok(PhysicalFileDigest {
         artifact,

--- a/crates/ctx-history-index/src/publication/verification/logical.rs
+++ b/crates/ctx-history-index/src/publication/verification/logical.rs
@@ -129,9 +129,7 @@ fn verify_searcher_with_options(
             index: total_documents,
         });
     }
-    if live_body_token_count(searcher, fields.body_search)? != expected_body_tokens {
-        return Err(IndexError::InvalidStoredDocumentField("body_search"));
-    }
+    verify_live_body_token_count(searcher, fields.body_search, expected_body_tokens)?;
     let mut projection_deltas = verification_spill.load_projection_deltas()?;
     metrics.verification_tracked_heap_bytes = metrics
         .verification_tracked_heap_bytes
@@ -210,15 +208,6 @@ fn verify_segment(
             )
             .ok_or(IndexError::CountOverflow)?;
         verify_query_fast_fields(segment, doc_id, &record)?;
-        body_tokens = body_tokens
-            .checked_add(verify_body_projection(
-                &body_search,
-                &mut body_analyzer,
-                fields.body_search,
-                record.body.as_deref(),
-                doc_id,
-            )?)
-            .ok_or(IndexError::CountOverflow)?;
         let projection_delta = expected_query_projection_delta(fields, &record)?;
         let source_ordinal = *source_ordinals
             .get(&record.source_owner)
@@ -233,6 +222,16 @@ fn verify_segment(
         accumulate_core_record(&mut source.accumulator, &accumulator_leaf);
         parent_session_documents = parent_session_documents
             .checked_add(u64::from(record.identities.parent_session.is_some()))
+            .ok_or(IndexError::CountOverflow)?;
+        let body_projection = crate::project_body_search(record.core_record.content)?;
+        body_tokens = body_tokens
+            .checked_add(verify_body_projection(
+                &body_search,
+                &mut body_analyzer,
+                fields.body_search,
+                body_projection.as_deref(),
+                doc_id,
+            )?)
             .ok_or(IndexError::CountOverflow)?;
         identity_writer.write_record(
             doc_id,
@@ -713,6 +712,13 @@ fn live_body_token_count(searcher: &Searcher, field: Field) -> Result<u64> {
     Ok(total)
 }
 
+fn verify_live_body_token_count(searcher: &Searcher, field: Field, expected: u64) -> Result<()> {
+    if live_body_token_count(searcher, field)? != expected {
+        return Err(IndexError::InvalidStoredDocumentField("body_search"));
+    }
+    Ok(())
+}
+
 fn merge_source_aggregates(
     target: &mut BTreeMap<String, SourceAggregate>,
     source: BTreeMap<String, SourceAggregate>,
@@ -925,4 +931,85 @@ fn canonical_uuid_term(term: &[u8], field: &'static str) -> Result<Uuid> {
         return Err(IndexError::InvalidStoredDocumentField(field));
     }
     Ok(uuid)
+}
+
+#[cfg(test)]
+mod body_projection_tests {
+    use ctx_history_core::{
+        CoreContent, CoreContentPolicyStatus, McpExchangeContent, McpInvocationContent,
+        McpJsonCapture,
+    };
+    use tantivy::TantivyDocument;
+
+    use super::*;
+
+    fn expected_invocation_projection() -> String {
+        crate::project_body_search(CoreContent {
+            policy_revision: 1,
+            policy_status: CoreContentPolicyStatus::Selected,
+            normalized_body: Some("normalized body".to_owned()),
+            structured_content: None,
+            mcp_exchange: Some(McpExchangeContent {
+                provider_call_id: "excluded-call-id".to_owned(),
+                invocation: Some(McpInvocationContent {
+                    server: "verificationservercanary".to_owned(),
+                    tool: "verificationtoolcanary".to_owned(),
+                    arguments: McpJsonCapture::Present {
+                        value: serde_json::json!({
+                            "verificationargumentkey": "verificationargumentvalue"
+                        }),
+                    },
+                }),
+                response: None,
+            }),
+        })
+        .unwrap()
+        .unwrap()
+    }
+
+    fn searcher_with_body(body: &str) -> (Searcher, Field) {
+        let schema = crate::lexical_schema();
+        let fields = crate::fields_from_schema(&schema).unwrap();
+        let index = tantivy::Index::create_in_ram(schema);
+        crate::analyzer::register_body_analyzer(&index);
+        let mut writer = index.writer(20_000_000).unwrap();
+        let mut document = TantivyDocument::default();
+        document.add_text(fields.body_search, body);
+        writer.add_document(document).unwrap();
+        writer.commit().unwrap();
+        writer.wait_merging_threads().unwrap();
+        let reader = index.reader().unwrap();
+        (reader.searcher(), fields.body_search)
+    }
+
+    #[test]
+    fn body_verification_rejects_missing_and_extra_invocation_terms() {
+        let expected = expected_invocation_projection();
+        let mut analyzer = crate::analyzer::body_analyzer();
+
+        let (missing_searcher, field) =
+            searcher_with_body("normalized body\nverificationservercanary\nverificationtoolcanary");
+        let missing_inverted = missing_searcher
+            .segment_reader(0)
+            .inverted_index(field)
+            .unwrap();
+        assert!(matches!(
+            verify_body_projection(&missing_inverted, &mut analyzer, field, Some(&expected), 0,),
+            Err(IndexError::InvalidStoredDocumentField("body_search"))
+        ));
+
+        let (extra_searcher, field) =
+            searcher_with_body(&format!("{expected}\nextrainvocationterm"));
+        let extra_inverted = extra_searcher
+            .segment_reader(0)
+            .inverted_index(field)
+            .unwrap();
+        let expected_token_count =
+            verify_body_projection(&extra_inverted, &mut analyzer, field, Some(&expected), 0)
+                .unwrap();
+        assert!(matches!(
+            verify_live_body_token_count(&extra_searcher, field, expected_token_count),
+            Err(IndexError::InvalidStoredDocumentField("body_search"))
+        ));
+    }
 }

--- a/crates/ctx-history-index/src/query/verification.rs
+++ b/crates/ctx-history-index/src/query/verification.rs
@@ -23,7 +23,6 @@ pub(crate) struct VerificationRecord {
     pub(crate) session_event_order: [u8; SESSION_EVENT_ORDER_KEY_LEN],
     pub(crate) semantic_event_order: [u8; SEMANTIC_EVENT_ORDER_KEY_LEN],
     pub(crate) event_range_order: [u8; EVENT_RANGE_ORDER_KEY_LEN],
-    pub(crate) body: Option<String>,
     pub(crate) identities: CompactVerificationIdentities,
     pub(crate) stored_core_bytes: usize,
 }
@@ -104,7 +103,6 @@ pub(crate) fn stored_verification_record(
         core_content_bytes(&core.content)?,
     )?
     .into_bytes();
-    let body = core.content.normalized_body.clone();
     let identities = CompactVerificationIdentities {
         event: core.event_id.into(),
         session: core.session_id.into(),
@@ -120,7 +118,6 @@ pub(crate) fn stored_verification_record(
         session_event_order,
         semantic_event_order,
         event_range_order,
-        body,
         identities,
         stored_core_bytes,
     })

--- a/crates/ctx-history-index/src/search_projection.rs
+++ b/crates/ctx-history-index/src/search_projection.rs
@@ -1,0 +1,206 @@
+use ctx_history_core::{CoreContent, CoreContentPolicyStatus, McpJsonCapture};
+
+use crate::{IndexError, Result};
+
+/// Derives the complete analyzed text stored in the lexical `body_search` field.
+///
+/// Callers must pass decoded, contract-validated Core content. The content is
+/// consumed so its normalized-body allocation can become the projection and be
+/// extended in place instead of cloning complete body text. Components appear in
+/// order as normalized body, server, tool, and compact present argument JSON. No
+/// response, capture-state, structured-content, or attribution-only data enters
+/// this projection.
+pub fn project_body_search(mut content: CoreContent) -> Result<Option<String>> {
+    if !matches!(content.policy_status, CoreContentPolicyStatus::Selected) {
+        return Ok(None);
+    }
+
+    let normalized_body = content
+        .normalized_body
+        .take()
+        .filter(|body| !body.is_empty());
+    let invocation = content
+        .mcp_exchange
+        .take()
+        .and_then(|exchange| exchange.invocation);
+    let (server, tool, argument_json) = match invocation {
+        Some(invocation) => {
+            let argument_json = match invocation.arguments {
+                McpJsonCapture::Present { value } => Some(serde_json::to_string(&value)?),
+                McpJsonCapture::Absent
+                | McpJsonCapture::Unavailable
+                | McpJsonCapture::Omitted { .. } => None,
+            };
+            (
+                (!invocation.server.is_empty()).then_some(invocation.server),
+                (!invocation.tool.is_empty()).then_some(invocation.tool),
+                argument_json.filter(|arguments| !arguments.is_empty()),
+            )
+        }
+        None => (None, None, None),
+    };
+    let components = [normalized_body, server, tool, argument_json];
+    let component_count = components.iter().flatten().count();
+    if component_count == 0 {
+        return Ok(None);
+    }
+    let component_bytes = components
+        .iter()
+        .flatten()
+        .try_fold(0_usize, |total, value| {
+            total
+                .checked_add(value.len())
+                .ok_or(IndexError::CountOverflow)
+        })?;
+    let capacity = component_bytes
+        .checked_add(component_count - 1)
+        .ok_or(IndexError::CountOverflow)?;
+    let mut components = components.into_iter().flatten();
+    let mut projection = components.next().ok_or(IndexError::WriterInvariant(
+        "body search projection component count drift",
+    ))?;
+    projection.reserve(capacity - projection.len());
+    for component in components {
+        projection.push('\n');
+        projection.push_str(&component);
+    }
+    debug_assert_eq!(projection.len(), capacity);
+    Ok(Some(projection))
+}
+
+#[cfg(test)]
+mod tests {
+    use ctx_history_core::{
+        CoreContentPolicyStatus, McpExchangeContent, McpInvocationContent, McpPayloadOmissionReason,
+    };
+
+    use super::*;
+
+    fn selected_content(
+        normalized_body: Option<&str>,
+        arguments: Option<McpJsonCapture>,
+    ) -> CoreContent {
+        CoreContent {
+            policy_revision: 1,
+            policy_status: CoreContentPolicyStatus::Selected,
+            normalized_body: normalized_body.map(str::to_owned),
+            structured_content: None,
+            mcp_exchange: arguments.map(|arguments| McpExchangeContent {
+                provider_call_id: "excluded-call-id".to_owned(),
+                invocation: Some(McpInvocationContent {
+                    server: "服务器".to_owned(),
+                    tool: "lookup_tool".to_owned(),
+                    arguments,
+                }),
+                response: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn ordinary_body_projection_moves_and_reuses_the_body_allocation() {
+        let content = selected_content(Some("ordinary normalized body"), None);
+        let body_pointer = content.normalized_body.as_ref().unwrap().as_ptr();
+        let projection = project_body_search(content).unwrap().unwrap();
+
+        assert_eq!(projection.as_ptr(), body_pointer);
+        assert_eq!(projection, "ordinary normalized body");
+    }
+
+    #[test]
+    fn invocation_projection_appends_into_spare_body_capacity() {
+        let mut body = String::with_capacity(256);
+        body.push_str("normalized body");
+        let body_pointer = body.as_ptr();
+        let mut content = selected_content(
+            None,
+            Some(McpJsonCapture::Present {
+                value: serde_json::json!({}),
+            }),
+        );
+        content.normalized_body = Some(body);
+
+        let projection = project_body_search(content).unwrap().unwrap();
+
+        assert_eq!(projection.as_ptr(), body_pointer);
+        assert_eq!(projection, "normalized body\n服务器\nlookup_tool\n{}");
+    }
+
+    #[test]
+    fn invocation_projection_is_ordered_compact_and_deterministic() {
+        let mut first = serde_json::Map::new();
+        first.insert("zeta".to_owned(), serde_json::json!("München"));
+        first.insert("empty".to_owned(), serde_json::json!({}));
+        first.insert(
+            "alpha".to_owned(),
+            serde_json::json!(["東京", {"control": "line\nbreak\t\"quote\"\\slash"}, [3, 1, 2]]),
+        );
+        let mut second = serde_json::Map::new();
+        second.insert(
+            "alpha".to_owned(),
+            serde_json::json!(["東京", {"control": "line\nbreak\t\"quote\"\\slash"}, [3, 1, 2]]),
+        );
+        second.insert("empty".to_owned(), serde_json::json!({}));
+        second.insert("zeta".to_owned(), serde_json::json!("München"));
+
+        let first = selected_content(
+            Some("normalized body"),
+            Some(McpJsonCapture::Present {
+                value: serde_json::Value::Object(first),
+            }),
+        );
+        let second = selected_content(
+            Some("normalized body"),
+            Some(McpJsonCapture::Present {
+                value: serde_json::Value::Object(second),
+            }),
+        );
+        let first = project_body_search(first).unwrap().unwrap();
+        let second = project_body_search(second).unwrap().unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(
+            first,
+            "normalized body\n服务器\nlookup_tool\n{\"alpha\":[\"東京\",{\"control\":\"line\\nbreak\\t\\\"quote\\\"\\\\slash\"},[3,1,2]],\"empty\":{},\"zeta\":\"München\"}"
+        );
+        assert!(!first.ends_with('\n'));
+    }
+
+    #[test]
+    fn non_present_argument_states_add_no_projection_component() {
+        let captures = [
+            McpJsonCapture::Absent,
+            McpJsonCapture::Unavailable,
+            McpJsonCapture::Omitted {
+                reason: McpPayloadOmissionReason::SizeLimit,
+                observed_encoded_bytes: Some(998_877),
+            },
+        ];
+
+        for capture in captures {
+            let content = selected_content(Some("body"), Some(capture));
+            assert_eq!(
+                project_body_search(content).unwrap().as_deref(),
+                Some("body\n服务器\nlookup_tool")
+            );
+        }
+    }
+
+    #[test]
+    fn empty_object_is_serialized_but_excluded_content_is_ignored() {
+        let mut content = selected_content(
+            None,
+            Some(McpJsonCapture::Present {
+                value: serde_json::json!({}),
+            }),
+        );
+        content.structured_content = Some(serde_json::json!({
+            "structured_only_canary": "must_not_leak"
+        }));
+
+        assert_eq!(
+            project_body_search(content).unwrap().as_deref(),
+            Some("服务器\nlookup_tool\n{}")
+        );
+    }
+}

--- a/crates/ctx-history-index/src/tests/migration_qualification.rs
+++ b/crates/ctx-history-index/src/tests/migration_qualification.rs
@@ -534,50 +534,20 @@ fn deterministic_body(bytes: usize, sequence: u64) -> String {
     body
 }
 
-fn build_generated_predecessor(root: &Path, corpus: CorpusSpec) {
-    let _predecessor = TestCoreFingerprintOverride::set(SAME_EPOCH_PREDECESSOR_CORE_FINGERPRINT);
-    let source = source("migration-qualification.jsonl");
-    let options = WriterOptions {
-        indexer_threads: 1,
-        memory_bytes: INDEX_MEMORY_MIN_PER_THREAD,
-    };
-    let mut writer = GenerationWriter::open(root, options)
-        .unwrap()
-        .into_writer()
-        .unwrap();
-    writer.begin_source(source.clone()).unwrap();
-    for sequence in 1..=corpus.documents {
-        let body = deterministic_body(corpus.body_bytes, sequence);
-        writer
-            .add_core_record(document(&source, sequence, &body))
-            .unwrap();
-    }
-    writer
-        .certify_source(certificate(&source, 1, corpus.documents))
-        .unwrap();
-    writer.commit(|_| true).unwrap();
-    let verified = VerifiedIndex::open(root).unwrap();
-    assert_eq!(verified.document_count(), corpus.documents);
-    assert_eq!(
-        verified.manifest().core_record_contract_fingerprint,
-        SAME_EPOCH_PREDECESSOR_CORE_FINGERPRINT
-    );
-}
-
-fn relabel_as_current(root: &Path) {
-    let _successor = TestCoreFingerprintOverride::set(SUCCESSOR_CORE_FINGERPRINT);
+fn relabel_active_manifest(root: &Path, mutate: impl FnOnce(&mut GenerationManifest)) {
     let pointer = load_active_generation_pointer(root).unwrap().unwrap();
     let index = open_slot_index(root, pointer.active()).unwrap();
     let metas = index.load_metas().unwrap();
     let publication = load_publication_for_metas(root, &metas).unwrap();
-    let predecessor_generation_id = publication.generation_id;
-    let mut current_manifest = publication.manifest;
-    current_manifest.core_record_contract_fingerprint = SUCCESSOR_CORE_FINGERPRINT.to_owned();
-    current_manifest.validate_contract().unwrap();
-    let current_generation_id = current_manifest.generation_id().unwrap();
-    write_manifest(root, &current_generation_id, &current_manifest).unwrap();
+    let prior_generation_id = publication.generation_id;
+    let mut manifest = publication.manifest;
+    mutate(&mut manifest);
+    manifest.validate_contract().unwrap();
+    let generation_id = manifest.generation_id().unwrap();
+    assert_ne!(generation_id, prior_generation_id);
+    write_manifest(root, &generation_id, &manifest).unwrap();
     let payload =
-        canonical_commit_payload(&current_generation_id, publication.metadata.as_deref()).unwrap();
+        canonical_commit_payload(&generation_id, publication.metadata.as_deref()).unwrap();
     let mut writer = index
         .writer_with_num_threads::<TantivyDocument>(1, INDEX_MEMORY_MIN_PER_THREAD)
         .unwrap();
@@ -589,20 +559,64 @@ fn relabel_as_current(root: &Path) {
     let generation_path = active_generation_path(root);
     sync_generation(&generation_path).unwrap();
     let slot = GenerationSlot::new(
-        current_generation_id,
+        generation_id,
         pointer.active().directory().to_owned(),
         physical_integrity_digest(&index, &generation_path).unwrap(),
     )
     .unwrap();
     publish_active_generation_pointer(root, &ActiveGenerationPointer::new(slot, None).unwrap())
         .unwrap();
-    fs::remove_file(manifest_path(root, &predecessor_generation_id)).unwrap();
-    sync_directory(
-        manifest_path(root, &predecessor_generation_id)
-            .parent()
-            .unwrap(),
-    )
-    .unwrap();
+    fs::remove_file(manifest_path(root, &prior_generation_id)).unwrap();
+    sync_directory(manifest_path(root, &prior_generation_id).parent().unwrap()).unwrap();
+}
+
+fn build_generated_predecessor(root: &Path, corpus: CorpusSpec) {
+    {
+        // Produce equivalent records through the current writer, then bind the
+        // generation to the exact deployed pre-projector-4 Core/policy pair.
+        let _successor = TestCoreFingerprintOverride::set(SUCCESSOR_CORE_FINGERPRINT);
+        let source = source("migration-qualification.jsonl");
+        let options = WriterOptions {
+            indexer_threads: 1,
+            memory_bytes: INDEX_MEMORY_MIN_PER_THREAD,
+        };
+        let mut writer = GenerationWriter::open(root, options)
+            .unwrap()
+            .into_writer()
+            .unwrap();
+        writer.begin_source(source.clone()).unwrap();
+        for sequence in 1..=corpus.documents {
+            let body = deterministic_body(corpus.body_bytes, sequence);
+            writer
+                .add_core_record(document(&source, sequence, &body))
+                .unwrap();
+        }
+        writer
+            .certify_source(certificate(&source, 1, corpus.documents))
+            .unwrap();
+        writer.commit(|_| true).unwrap();
+        relabel_active_manifest(root, |manifest| {
+            manifest.core_record_contract_fingerprint =
+                SAME_EPOCH_PREDECESSOR_CORE_FINGERPRINT.to_owned();
+            manifest.policy_schema_hash =
+                SAME_EPOCH_PREDECESSOR_SOURCE_GENERATION_POLICY_HASH.to_owned();
+        });
+    }
+
+    let verified = VerifiedIndex::open(root).unwrap();
+    assert_eq!(verified.document_count(), corpus.documents);
+    assert_eq!(
+        verified.manifest().core_record_contract_fingerprint,
+        SAME_EPOCH_PREDECESSOR_CORE_FINGERPRINT
+    );
+}
+
+fn relabel_as_current(root: &Path) {
+    let _successor = TestCoreFingerprintOverride::set(SUCCESSOR_CORE_FINGERPRINT);
+    relabel_active_manifest(root, |manifest| {
+        manifest.core_record_contract_fingerprint = SUCCESSOR_CORE_FINGERPRINT.to_owned();
+        manifest.policy_schema_hash = current_source_generation_policy_hash().unwrap();
+    });
     assert!(!VerifiedIndex::open(root)
         .unwrap()
         .uses_allowlisted_predecessor_contract());

--- a/crates/ctx-history-index/tests/mcp_attribution_search.rs
+++ b/crates/ctx-history-index/tests/mcp_attribution_search.rs
@@ -1,35 +1,51 @@
 use ctx_history_core::{
     derive_event_id, derive_session_id, CertifiedSource, CoreRecord, EventIdentityInput,
-    McpExchangeContent, McpInvocationContent, McpJsonCapture, McpTerminalResponseContent,
-    McpTerminalStatus, McpTextCapture, McpToolCallAttribution, NativeItemKey, NativeSessionKey,
-    ScannedSourceCounts, SessionIdentityInput, SourceAnchor, SourceKey, SourceObservation,
-    TypedKey,
+    McpExchangeContent, McpFailureKind, McpInvocationContent, McpJsonCapture,
+    McpPayloadOmissionReason, McpTerminalResponseContent, McpTerminalStatus, McpTextCapture,
+    McpToolCallAttribution, NativeItemKey, NativeSessionKey, ScannedSourceCounts,
+    SessionIdentityInput, SourceAnchor, SourceKey, SourceObservation, StableEntityId, TypedKey,
 };
-use ctx_history_index::{GenerationWriter, VerifiedIndex, WriterOptions};
+use ctx_history_index::{
+    EventSearchFilters, GenerationWriter, SearchContentScope, VerifiedIndex, WriterOptions,
+};
 
+const BODY_ORACLE: &str = "provider neutral attribution ranking oracle";
 const SERVER_CANARY: &str = "zzsrvcoresearchcanary4c18vjqx";
 const TOOL_CANARY: &str = "zztoolcoresearchcanary6d29wknp";
+const ARGUMENT_KEY_CANARY: &str = "zzargumentkeycanary8h63tlmq";
+const ARGUMENT_VALUE_CANARY: &str = "zzargumentvaluecanary5g42rknp";
+const CONTROL_VALUE_CANARY: &str = "zzcontrolvaluecanary2f31qjmo";
 const CALL_ID_CANARY: &str = "zzcallidcoresearchcanary7g52skmp";
-const ARGUMENT_CANARY: &str = "zzargumentcoresearchcanary8h63tlmq";
-const RESPONSE_CANARY: &str = "zzresponsecoresearchcanary9j74vmnr";
-const BODY_ORACLE: &str = "provider neutral attribution ranking oracle";
+const SECOND_CALL_ID_CANARY: &str = "zzcallidcoresearchcanary3b14plqx";
+const RESPONSE_KEY_CANARY: &str = "zzresponsekeycanary1a03okpw";
+const RESPONSE_VALUE_CANARY: &str = "zzresponsevaluecanary9j74vmnr";
+const ATTRIBUTION_SERVER_CANARY: &str = "zzattributionservercanary6d18vlrx";
+const ATTRIBUTION_TOOL_CANARY: &str = "zzattributiontoolcanary7e29wmsy";
+const STRUCTURED_CANARY: &str = "zzstructuredcontentcanary8f30xntz";
+const OMITTED_ARGUMENT_BYTES: u64 = 998_877_665_544;
+const RESPONSE_DURATION_NS: u64 = 424_242_424_242;
 
-fn source() -> SourceKey {
+const SCOPE_CANARY: &str = "zzmcpscopecanary4c27vlqy";
+const SCOPE_SERVER: &str = "zzmcpscopeserver5d38wmrz";
+const SCOPE_TOOL: &str = "zzmcpscopetool6e49xnas";
+
+fn source(name: &str) -> SourceKey {
     SourceKey::derive(
         "codex",
         "codex_session_jsonl_tree",
         "session",
         1,
-        SourceAnchor::provider_native(
-            "session-file",
-            TypedKey::utf8("mcp-attribution-search.jsonl").unwrap(),
-        )
-        .unwrap(),
+        SourceAnchor::provider_native("session-file", TypedKey::utf8(name).unwrap()).unwrap(),
     )
     .unwrap()
 }
 
-fn record(source: &SourceKey, sequence: u64) -> CoreRecord {
+fn record(
+    source: &SourceKey,
+    sequence: u64,
+    event_type: &str,
+    normalized_body: &str,
+) -> CoreRecord {
     let native_session_key =
         NativeSessionKey::native_id("session", TypedKey::utf8("mcp-search-session").unwrap())
             .unwrap();
@@ -54,128 +70,363 @@ fn record(source: &SourceKey, sequence: u64) -> CoreRecord {
         session_id,
         source.clone(),
         sequence,
-        "tool_result",
+        event_type,
         "primary",
         true,
-        "mcp-attribution-search-test-v1",
-        BODY_ORACLE,
+        "mcp-attribution-search-test-v2",
+        normalized_body,
     )
     .unwrap();
     record.native_event_id = Some(TypedKey::U64(sequence));
     record
 }
 
-fn certificate(source: &SourceKey) -> CertifiedSource {
+fn invocation(server: &str, tool: &str, arguments: McpJsonCapture) -> McpInvocationContent {
+    McpInvocationContent {
+        server: server.to_owned(),
+        tool: tool.to_owned(),
+        arguments,
+    }
+}
+
+fn certificate(source: &SourceKey, count: u64) -> CertifiedSource {
     let observation = SourceObservation::new(source.clone(), "regular-file-v1", vec![1]).unwrap();
     CertifiedSource::certify(
         observation.clone(),
         observation,
-        "mcp-attribution-search-test-v1",
+        "mcp-attribution-search-test-v2",
         [1; 32],
         ScannedSourceCounts {
-            complete_records: 2,
-            retained_records: 2,
-            indexed_documents: 2,
-            certified_bytes: 2,
+            complete_records: count,
+            retained_records: count,
+            indexed_documents: count,
+            certified_bytes: count,
             ..ScannedSourceCounts::default()
         },
     )
     .unwrap()
 }
 
-#[test]
-fn mcp_attribution_and_exchange_are_stored_but_never_indexed_or_ranked() {
+fn publish(source: &SourceKey, records: Vec<CoreRecord>) -> (tempfile::TempDir, VerifiedIndex) {
+    let count = u64::try_from(records.len()).unwrap();
     let temp = tempfile::tempdir().unwrap();
-    let source = source();
-    let mut attributed = record(&source, 1);
-    attributed.mcp_tool_call = Some(McpToolCallAttribution {
-        server: SERVER_CANARY.to_owned(),
-        tool: TOOL_CANARY.to_owned(),
-    });
-    let exchange = McpExchangeContent {
-        provider_call_id: CALL_ID_CANARY.to_owned(),
-        invocation: Some(McpInvocationContent {
-            server: SERVER_CANARY.to_owned(),
-            tool: TOOL_CANARY.to_owned(),
-            arguments: McpJsonCapture::Present {
-                value: serde_json::json!({"only_in_mcp_exchange": ARGUMENT_CANARY}),
-            },
-        }),
-        response: Some(McpTerminalResponseContent {
-            status: McpTerminalStatus::Succeeded,
-            failure_kind: None,
-            duration_ns: Some(42),
-            text: McpTextCapture::NormalizedBody,
-            payload: McpJsonCapture::Present {
-                value: serde_json::json!({"only_in_mcp_exchange": RESPONSE_CANARY}),
-            },
-        }),
-    };
-    attributed.content.mcp_exchange = Some(exchange.clone());
-    attributed.validate_contract().unwrap();
-    let attributed_id = attributed.event_id;
-    let attributed_content_bytes = attributed.content.encoded_content_bytes().unwrap();
-    let plain = record(&source, 2);
-    let plain_content_bytes = plain.content.encoded_content_bytes().unwrap();
-
     let mut writer = GenerationWriter::open(temp.path(), WriterOptions::default())
         .unwrap()
         .into_writer()
         .unwrap();
     writer.begin_source(source.clone()).unwrap();
-    writer.add_core_record(attributed).unwrap();
-    writer.add_core_record(plain).unwrap();
-    writer.certify_source(certificate(&source)).unwrap();
+    for record in records {
+        writer.add_core_record(record).unwrap();
+    }
+    writer.certify_source(certificate(source, count)).unwrap();
     writer.commit(|_| true).unwrap();
-
     let index = VerifiedIndex::open(temp.path()).unwrap();
-    let body_matches = index.search_event_candidates(BODY_ORACLE, 10).unwrap();
+    (temp, index)
+}
+
+fn matching_ids(index: &VerifiedIndex, query: &str) -> Vec<StableEntityId> {
+    let mut ids = index
+        .search_event_candidates(query, 20)
+        .unwrap()
+        .into_iter()
+        .map(|candidate| candidate.event.event_id)
+        .collect::<Vec<_>>();
+    ids.sort_unstable_by_key(|id| id.as_uuid());
+    ids
+}
+
+fn sorted_ids(ids: impl IntoIterator<Item = StableEntityId>) -> Vec<StableEntityId> {
+    let mut ids = ids.into_iter().collect::<Vec<_>>();
+    ids.sort_unstable_by_key(|id| id.as_uuid());
+    ids
+}
+
+fn score_for(index: &VerifiedIndex, query: &str, event_id: StableEntityId) -> f32 {
+    index
+        .search_event_candidates(query, 20)
+        .unwrap()
+        .into_iter()
+        .find(|candidate| candidate.event.event_id == event_id)
+        .unwrap()
+        .score
+}
+
+#[test]
+fn mcp_invocation_projection_is_searchable_narrow_and_response_neutral() {
+    let source = source("mcp-invocation-projection.jsonl");
+    let arguments = serde_json::json!({
+        ARGUMENT_KEY_CANARY: {
+            "empty": {},
+            "nested": [
+                ARGUMENT_VALUE_CANARY,
+                {"control": format!("line\n{CONTROL_VALUE_CANARY}\t\"quote\"\\slash")},
+                [3, 1, 2]
+            ],
+            "unicode": ["Grüße", "東京"]
+        }
+    });
+
+    let first_exchange = McpExchangeContent {
+        provider_call_id: CALL_ID_CANARY.to_owned(),
+        invocation: Some(invocation(
+            SERVER_CANARY,
+            TOOL_CANARY,
+            McpJsonCapture::Present {
+                value: arguments.clone(),
+            },
+        )),
+        response: Some(McpTerminalResponseContent {
+            status: McpTerminalStatus::Failed,
+            failure_kind: Some(McpFailureKind::ToolReported),
+            duration_ns: Some(RESPONSE_DURATION_NS),
+            text: McpTextCapture::NormalizedBody,
+            payload: McpJsonCapture::Present {
+                value: serde_json::json!({RESPONSE_KEY_CANARY: RESPONSE_VALUE_CANARY}),
+            },
+        }),
+    };
+    let mut first = record(&source, 1, "tool_output", BODY_ORACLE);
+    first.content.structured_content = Some(serde_json::json!({
+        "structured_only": STRUCTURED_CANARY
+    }));
+    first.content.mcp_exchange = Some(first_exchange.clone());
+    first.validate_contract().unwrap();
+    let first_id = first.event_id;
+
+    let mut second = record(&source, 2, "tool_output", BODY_ORACLE);
+    second.content.mcp_exchange = Some(McpExchangeContent {
+        provider_call_id: SECOND_CALL_ID_CANARY.to_owned(),
+        invocation: Some(invocation(
+            SERVER_CANARY,
+            TOOL_CANARY,
+            McpJsonCapture::Present { value: arguments },
+        )),
+        response: Some(McpTerminalResponseContent {
+            status: McpTerminalStatus::Succeeded,
+            failure_kind: None,
+            duration_ns: None,
+            text: McpTextCapture::Absent,
+            payload: McpJsonCapture::Absent,
+        }),
+    });
+    second.validate_contract().unwrap();
+    let second_id = second.event_id;
+
+    let captures = [
+        McpJsonCapture::Absent,
+        McpJsonCapture::Unavailable,
+        McpJsonCapture::Omitted {
+            reason: McpPayloadOmissionReason::SizeLimit,
+            observed_encoded_bytes: Some(OMITTED_ARGUMENT_BYTES),
+        },
+    ];
+    let mut records = vec![first, second];
+    for (offset, arguments) in captures.into_iter().enumerate() {
+        let sequence = u64::try_from(offset).unwrap() + 3;
+        let mut state = record(
+            &source,
+            sequence,
+            "tool_call",
+            &format!("zzargumentstatebodyoracle{sequence}"),
+        );
+        state.content.mcp_exchange = Some(McpExchangeContent {
+            provider_call_id: format!("zzstatecallidcanary{sequence}"),
+            invocation: Some(invocation(
+                "zzargumentstateservercanary",
+                "zzargumentstatetoolcanary",
+                arguments,
+            )),
+            response: None,
+        });
+        state.validate_contract().unwrap();
+        records.push(state);
+    }
+    let mut empty_object = record(&source, 6, "tool_call", "zzemptyobjectbodyoracle");
+    empty_object.content.mcp_exchange = Some(McpExchangeContent {
+        provider_call_id: "zzemptyobjectcallidcanary".to_owned(),
+        invocation: Some(invocation(
+            "zzemptyobjectservercanary",
+            "zzemptyobjecttoolcanary",
+            McpJsonCapture::Present {
+                value: serde_json::json!({}),
+            },
+        )),
+        response: None,
+    });
+    empty_object.validate_contract().unwrap();
+    records.push(empty_object);
+    let mut attribution_only = record(&source, 7, "tool_call", "zzattributiononlybodyoracle");
+    attribution_only.mcp_tool_call = Some(McpToolCallAttribution {
+        server: ATTRIBUTION_SERVER_CANARY.to_owned(),
+        tool: ATTRIBUTION_TOOL_CANARY.to_owned(),
+    });
+    attribution_only.validate_contract().unwrap();
+    let attribution_only_id = attribution_only.event_id;
+    records.push(attribution_only);
+
+    let (_temp, index) = publish(&source, records);
+    let expected_invocation_ids = sorted_ids([first_id, second_id]);
+    for query in [
+        SERVER_CANARY,
+        TOOL_CANARY,
+        ARGUMENT_KEY_CANARY,
+        ARGUMENT_VALUE_CANARY,
+        "quote",
+        "Grüße",
+        "東京",
+    ] {
+        assert_eq!(
+            matching_ids(&index, query),
+            expected_invocation_ids,
+            "missing searchable invocation component: {query}"
+        );
+    }
+
+    let body_matches = index.search_event_candidates(BODY_ORACLE, 20).unwrap();
     assert_eq!(body_matches.len(), 2);
-    assert_eq!(body_matches[0].score, body_matches[1].score);
+    assert_eq!(
+        score_for(&index, BODY_ORACLE, first_id),
+        score_for(&index, BODY_ORACLE, second_id),
+        "NormalizedBody response disposition duplicated the normalized body"
+    );
 
     let stored = index
-        .core_record_by_id(attributed_id.as_uuid())
+        .core_record_by_id(first_id.as_uuid())
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.content.mcp_exchange, Some(first_exchange));
+    let stored_attribution = index
+        .core_record_by_id(attribution_only_id.as_uuid())
         .unwrap()
         .unwrap();
     assert_eq!(
-        stored.mcp_tool_call,
+        stored_attribution.mcp_tool_call,
         Some(McpToolCallAttribution {
-            server: SERVER_CANARY.to_owned(),
-            tool: TOOL_CANARY.to_owned(),
+            server: ATTRIBUTION_SERVER_CANARY.to_owned(),
+            tool: ATTRIBUTION_TOOL_CANARY.to_owned(),
         })
     );
-    assert_eq!(stored.content.mcp_exchange, Some(exchange.clone()));
 
-    let page = index.core_source_event_page(&source, None, 10).unwrap();
-    assert_eq!(page.items.len(), 2);
-    assert_eq!(
-        page.content_bytes,
-        attributed_content_bytes + plain_content_bytes
-    );
-    assert_eq!(
-        page.items
-            .iter()
-            .find(|item| item.core_record.event_id == attributed_id)
-            .unwrap()
-            .core_record
-            .content
-            .mcp_exchange,
-        Some(exchange)
-    );
-
-    for canary in [
-        SERVER_CANARY,
-        TOOL_CANARY,
+    for excluded in [
         CALL_ID_CANARY,
-        ARGUMENT_CANARY,
-        RESPONSE_CANARY,
+        SECOND_CALL_ID_CANARY,
+        RESPONSE_KEY_CANARY,
+        RESPONSE_VALUE_CANARY,
+        ATTRIBUTION_SERVER_CANARY,
+        ATTRIBUTION_TOOL_CANARY,
+        STRUCTURED_CANARY,
+        "failed",
+        "succeeded",
+        "tool_reported",
+        "duration_ns",
+        "normalized_body",
+        "payload",
+        "capture_status",
+        "present",
+        "absent",
+        "unavailable",
+        "omitted",
+        "size_limit",
+        "observed_encoded_bytes",
+        "424242424242",
+        "998877665544",
     ] {
         assert!(
-            index
-                .search_event_candidates(canary, 10)
-                .unwrap()
-                .is_empty(),
-            "provider-neutral MCP data became searchable: {canary}"
+            matching_ids(&index, excluded).is_empty(),
+            "excluded MCP data became searchable: {excluded}"
         );
     }
+}
+
+#[test]
+fn separate_calls_and_mixed_outputs_keep_their_existing_scope_and_weight() {
+    let source = source("mcp-invocation-scope.jsonl");
+    let scope_arguments = McpJsonCapture::Present {
+        value: serde_json::json!({"scope_argument": SCOPE_CANARY}),
+    };
+    let mut call = record(&source, 1, "tool_call", "zzmcpscopebodyoracle");
+    call.content.mcp_exchange = Some(McpExchangeContent {
+        provider_call_id: "zzscopecallidone".to_owned(),
+        invocation: Some(invocation(
+            SCOPE_SERVER,
+            SCOPE_TOOL,
+            scope_arguments.clone(),
+        )),
+        response: None,
+    });
+    call.validate_contract().unwrap();
+    let call_id = call.event_id;
+
+    let mut mixed = record(&source, 2, "tool_output", "zzmcpscopebodyoracle");
+    mixed.content.mcp_exchange = Some(McpExchangeContent {
+        provider_call_id: "zzscopecallidtwo".to_owned(),
+        invocation: Some(invocation(SCOPE_SERVER, SCOPE_TOOL, scope_arguments)),
+        response: Some(McpTerminalResponseContent {
+            status: McpTerminalStatus::Succeeded,
+            failure_kind: None,
+            duration_ns: Some(17),
+            text: McpTextCapture::NormalizedBody,
+            payload: McpJsonCapture::Absent,
+        }),
+    });
+    mixed.validate_contract().unwrap();
+    let mixed_id = mixed.event_id;
+
+    let (_temp, index) = publish(&source, vec![call, mixed]);
+    let all = index.search_event_candidates(SCOPE_CANARY, 20).unwrap();
+    let explicit_all = index
+        .search_event_candidates_with_filters(
+            SCOPE_CANARY,
+            &EventSearchFilters {
+                content_scope: SearchContentScope::All,
+                ..EventSearchFilters::default()
+            },
+            20,
+        )
+        .unwrap();
+    assert_eq!(all, explicit_all);
+    assert_eq!(
+        matching_ids(&index, SCOPE_CANARY),
+        sorted_ids([call_id, mixed_id])
+    );
+
+    let calls = index
+        .search_event_candidates_with_filters(
+            SCOPE_CANARY,
+            &EventSearchFilters {
+                content_scope: SearchContentScope::Calls,
+                ..EventSearchFilters::default()
+            },
+            20,
+        )
+        .unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].event.event_id, call_id);
+
+    let outputs = index
+        .search_event_candidates_with_filters(
+            SCOPE_CANARY,
+            &EventSearchFilters {
+                content_scope: SearchContentScope::Outputs,
+                ..EventSearchFilters::default()
+            },
+            20,
+        )
+        .unwrap();
+    assert_eq!(outputs.len(), 1);
+    assert_eq!(outputs[0].event.event_id, mixed_id);
+
+    let all_call_score = all
+        .iter()
+        .find(|candidate| candidate.event.event_id == call_id)
+        .unwrap()
+        .score;
+    let all_output_score = all
+        .iter()
+        .find(|candidate| candidate.event.event_id == mixed_id)
+        .unwrap()
+        .score;
+    assert!((all_call_score / calls[0].score - 0.8).abs() < 0.000_01);
+    assert!((all_output_score / outputs[0].score - 0.6).abs() < 0.000_01);
+    assert!(all_call_score > all_output_score);
 }

--- a/docs/mcp-exchange-capture.md
+++ b/docs/mcp-exchange-capture.md
@@ -129,13 +129,19 @@ into one synthetic event.
 
 | Provider route | Event shape | Parser revision |
 | --- | --- | --- |
-| Codex session JSONL, including versioned lanes | The combined terminal record can carry invocation and response together. | `codex-nativepath-core-record-v15` |
+| Codex session JSONL, including versioned lanes | The combined terminal record can carry invocation and response together. | `codex-nativepath-core-record-v16-aggregate-content-admission` |
 | Warp SQLite | Separate call and result records carry invocation and response respectively, linked by the native call ID. | `warp-source-backed-logical-v5` |
-| Copilot CLI JSONL | Separate start and completion records carry invocation and response respectively, linked by the native call ID. | `copilot-cli-direct-native-jsonl-v5-mcp-exchange` |
+| Copilot CLI JSONL | Separate start and completion records carry invocation and response respectively, linked by the native call ID. | `copilot-cli-direct-native-jsonl-v6-mcp-start-generic-body` |
 
 No other provider route currently publishes this typed capture. This provider
 coverage does not change exact top-level attribution qualification or general
 provider import support.
+
+Search class follows the event type of the record that owns the capture.
+Separate Warp and Copilot CLI invocation records are calls. The combined Codex
+terminal record is one `tool_output`, so its normalized response text and any
+projected invocation terms are found under `outputs`, not `calls`. ctx does not
+duplicate or dual-classify that event.
 
 ## Content policy, projection, and limits
 
@@ -169,18 +175,34 @@ Core contract migration, existing rows keep `mcp_exchange` absent; migration
 does not reopen provider sources. A later ordinary provider refresh or
 reimport can populate the field when the source is still available.
 
-Capture does not change indexing. `mcp_exchange`, provider call IDs, arguments,
-response status/timing, and response payloads are not Tantivy fields or tokens,
-selectors, semantic text, ranking signals, snippets, SQL columns, or Local Pro
-facts. The existing normalized body keeps its pre-existing lexical and semantic
-eligibility; the `normalized_body` text disposition creates no new text.
+Lexical search derives a narrow body projection from policy-selected invocation
+content. `invocation.server`, `invocation.tool`, and the compact JSON value of
+`present` arguments contribute ordinary body-search terms without synthetic
+server/tool labels. `absent`, `unavailable`, and `omitted` arguments contribute
+no terms.
+
+The provider call ID, response status, failure kind, timing, and structured
+response payload remain stored and retrievable but unsearchable. Response text
+with the `normalized_body` disposition retains the event's existing body-search
+behavior exactly once; capture does not append a duplicate. The projection adds
+no semantic text, selector, filter, search result field, SQL column, Local Pro
+fact, or hidden network request.
+
+Full show/list/MCP/SDK output remains exact stored-content retrieval. Search
+snippets instead come from the Core-backed searchable projection and can
+therefore contain projected invocation content. Because the lexical projector
+revision participates in generation identity, an older generation must be
+rebuilt or pass the documented narrow same-epoch preservation migration before
+these terms become searchable. Historical Core rows that have no captured
+exchange remain unchanged.
 
 ## Privacy and network behavior
 
 MCP arguments and responses can contain credentials, personal data, private
-repository details, absolute paths, or proprietary output. Exact machine
-output is private local content and is not share-safe without review. MCP hosts
-may log or forward returned results.
+repository details, absolute paths, or proprietary output. Present invocation
+arguments become searchable in the local lexical index. Exact machine output
+and local search results are private content and are not share-safe without
+review. MCP hosts may log or forward returned results.
 
 Import, storage, and local retrieval of the exchange add no hidden network
 request. ctx does not send the captured invocation or response anywhere by

--- a/docs/mcp-tool-call-attribution-capabilities.json
+++ b/docs/mcp-tool-call-attribution-capabilities.json
@@ -461,7 +461,7 @@
       "provider_id": "copilot_cli", "route": "native_import", "source_format": "copilot_cli_session_events_jsonl", "source_schema": "copilot-cli-direct-native-jsonl-v1",
       "producer_bound": {"kind": "unversioned", "generation": 1, "unknown_generations": "not-qualified"},
       "implementation_source": "crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/copilot.rs",
-      "parser_revision": "copilot-cli-direct-native-jsonl-v5-mcp-exchange",
+      "parser_revision": "copilot-cli-direct-native-jsonl-v6-mcp-start-generic-body",
       "suite_id": "ctx-history-capture::native_unit",
       "conformance_suite": "mcp_attribution_provider_units",
       "tests": [

--- a/docs/mcp-tool-call-attribution.md
+++ b/docs/mcp-tool-call-attribution.md
@@ -11,6 +11,11 @@ synthesize or qualify the other. See
 [`mcp-exchange-capture.md`](mcp-exchange-capture.md) for arguments, response
 payloads, call IDs, status, timing, and capture-state semantics.
 
+The top-level `mcp_tool_call` object remains unsearchable attribution metadata.
+A policy-selected `mcp_exchange.invocation` on the same record is a separate
+content source whose server, tool, and `present` arguments can contribute to
+ordinary lexical body search.
+
 ## Wire contract
 
 Attributed CLI/Core event rows add one optional snake_case object:
@@ -61,7 +66,7 @@ Deep Agents hosted trace. Capability revision 3 exact providers are
 Codex, Warp, and Copilot CLI. The exact full tuples are:
 
 - Codex `codex_session_jsonl_tree` / `codex-nativepath-jsonl-v0`, parser
-  `codex-nativepath-core-record-v15`, for unversioned producer generation 1
+  `codex-nativepath-core-record-v16-aggregate-content-admission`, for unversioned producer generation 1
   only. Codex producer versions 0.200.0, 0.201.0, and 0.202.0 are separate
   explicit `not-qualified` lanes and never inherit that exact status.
 - Warp `warp_sqlite` / `warp-agent-task-protobuf-v1`, parser
@@ -70,7 +75,7 @@ Codex, Warp, and Copilot CLI. The exact full tuples are:
   runtime-observable writer-version selectors.
 - Copilot CLI `copilot_cli_session_events_jsonl` /
   `copilot-cli-direct-native-jsonl-v1`, parser
-  `copilot-cli-direct-native-jsonl-v5-mcp-exchange`, for
+  `copilot-cli-direct-native-jsonl-v6-mcp-start-generic-body`, for
   strict unversioned format generation 1. Versions 0.0.393 and 1.0.77 and the
   pinned source commit are observed evidence, not runtime admission selectors.
 
@@ -119,11 +124,15 @@ ctx list events --provider codex --content none --format jsonl |
     {ctx_event_id, ctx_session_id, mcp_tool_call}'
 ```
 
-This is client-side filtering after ctx emits each JSONL row. There is no
-server/tool filter, no search, no query selector, and no SQL access for this
-metadata. In particular, there is no `--mcp-server` or `--mcp-tool` selector;
-the names are not a search input, search result field, ranking signal, snippet
-source, or SQL column.
+This is client-side filtering after ctx emits each JSONL row. For the top-level
+attribution metadata, there is no server/tool filter, no search, no query
+selector, and no SQL access. In particular, there is no `--mcp-server` or
+`--mcp-tool` selector. Here, "no search" means the top-level pair is not itself
+a search input, search result field, ranking signal, snippet source, or SQL
+column. A text query can match the same values only when they are separately
+retained in a policy-selected `mcp_exchange.invocation` and projected as
+ordinary lexical body content; that does not turn search results into exact
+attribution records.
 
 Full-content JSON/JSONL can additionally expose `mcp_exchange`. The
 `--content text` and `--content none` projections omit that content field while
@@ -159,9 +168,13 @@ graph. Reimport recomputes the field from provider history; query paths never
 reparse provider-specific structured content or consult current MCP config.
 
 The separate optional `mcp_exchange` is stored as content on selected Core
-events. Its call ID, arguments, status/timing, and response payload are not
-lexical or semantic fields, SQL columns, usage aggregates, or Local Pro facts.
-Existing normalized-body indexing behavior is unchanged.
+events. Its invocation server, tool, and compact `present` argument JSON are
+projected into ordinary lexical body search under the record's existing event
+type. Other argument capture states add no terms. Its provider call ID and
+response status/failure/timing/payload remain unsearchable, and response text
+with a `normalized_body` disposition retains existing body search exactly once.
+The exchange adds no semantic text, selector, filter, search result field, SQL
+column, usage aggregate, or Local Pro fact.
 
 During the one allowlisted transition from the immediately preceding
 self-contained Core contract, ctx republishes verified records with

--- a/docs/search.md
+++ b/docs/search.md
@@ -126,6 +126,12 @@ over the downweighting used to mix that class into `all`. Class-aware search
 does not infer diagnostic importance and does not automatically collapse
 events with duplicate text.
 
+MCP invocation terms keep the class of the record that carries them. Separate
+Warp and Copilot CLI invocation records are calls. A combined Codex terminal
+`tool_output` remains an output, including when its searchable body projection
+contains the invocation server, tool, or arguments. The record is never
+dual-classified as both a call and an output.
+
 Changing content scope does not alter retained or indexed bodies, Core schema,
 or index generations, and it does not require an index rebuild. Search still
 uses semantic evidence only for transcript messages: `all` and `transcript`
@@ -209,26 +215,44 @@ generation binding and coverage, daemon work, and typed fallback reasons.
 
 ## Core-backed presentation
 
-Search snippets and `ctx show` presentation come from complete policy-selected
-records in the active verified Core/Tantivy generation. Query-time reads do not
-reopen provider history. Provider changes become searchable and visible to show
-after explicit import or daemon refresh publishes a new Core generation.
-`ctx show session` preserves provider event order.
+Search snippets come from the Core-backed searchable projection for complete
+policy-selected records in the active verified Core/Tantivy generation. Full
+show/list/MCP event output retrieves the exact stored Core content; it does not
+rewrite the normalized body to include projected invocation text. Query-time
+reads do not reopen provider history. Provider changes become searchable and
+visible to show after explicit import or daemon refresh publishes a new Core
+generation. `ctx show session` preserves provider event order.
 
-Exact `mcp_tool_call` server/tool metadata is not indexed and is not added to
-search inputs, filters, results, matching, ranking, snippets, or
-`why_matched`. Use log-mode `ctx show session`, `ctx show event`, or
-`ctx list events` and filter JSON/JSONL rows client-side when that metadata is
-needed.
+The top-level exact `mcp_tool_call: {server, tool}` attribution object remains
+metadata. That object is not indexed and adds no search input, filter, result
+field, selector, match, ranking signal, snippet, `why_matched` value, SQL column,
+or Local Pro fact. Use log-mode `ctx show session`, `ctx show event`, or
+`ctx list events` and filter JSON/JSONL rows client-side when exact attribution
+metadata is needed.
 
-Typed `mcp_exchange` content does not change that policy. The field itself,
-provider call IDs, arguments, response status/timing, and response payloads are
-not new Tantivy fields or tokens, semantic text, selectors, search result
-fields, ranking signals, snippets, SQL columns, or Local Pro facts. The event's
-existing normalized body keeps its pre-existing lexical and semantic
-eligibility; a response text disposition of `normalized_body` adds no second
-text copy. Retrieve the exchange with full-content show/list/MCP event output,
-not search. See [`mcp-exchange-capture.md`](mcp-exchange-capture.md).
+The separately stored, content-governed `mcp_exchange.invocation` has a narrow
+lexical body projection. On a policy-selected record, ctx projects the
+invocation server value, tool value, and the compact JSON representation of
+arguments whose capture state is `present`. It adds no synthetic server/tool
+labels. `absent`, `unavailable`, and `omitted` arguments contribute no terms.
+These values use ordinary lexical body matching and ranking under the record's
+existing event type; they are not new fields or selectors.
+
+`mcp_exchange.provider_call_id` remains unsearchable metadata and adds no
+filter, selector, result field, ranking signal, or snippet. Response status,
+failure, timing, and structured payload capture are stored and retrievable in
+full-content event output but add no search terms. Response text represented by
+the `normalized_body` disposition retains the event's existing normalized-body
+search behavior exactly once; the exchange does not duplicate it.
+
+This projection adds no semantic text, filter, search result field, SQL column,
+Local Pro fact, or hidden network request. Sensitive invocation arguments can
+therefore become searchable in the local lexical index, but ctx does not send
+them over the network. The lexical projector revision participates in
+generation identity, so an older generation must be rebuilt or pass the narrow
+same-epoch preservation migration before the new terms are searchable; stored
+historical rows with no captured exchange remain unchanged. See
+[`mcp-exchange-capture.md`](mcp-exchange-capture.md).
 
 ## History reports
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -175,11 +175,11 @@ never checkpoint or write provider data.
 
 A qualifying normalized event may carry
 `mcp_tool_call: {server, tool}` as event-local Core metadata. The pair is stored
-only with that Core event. It is not copied into lexical terms, semantic text,
-`usage.sqlite`, or the Local Pro graph, and query paths do not reconstruct it
-from provider-specific content or current MCP configuration. Presentation
-`--content none` retains already-stored metadata; Core `Redacted` or `Omitted`
-policy omits the sensitive pair by default.
+only with that Core event. The top-level pair is not copied into lexical terms,
+semantic text, `usage.sqlite`, or the Local Pro graph, and query paths do not
+reconstruct it from provider-specific content or current MCP configuration.
+Presentation `--content none` retains already-stored metadata; Core `Redacted`
+or `Omitted` policy omits the sensitive pair by default.
 
 A selected Core event may separately carry content-governed `mcp_exchange`
 with a provider call ID and invocation and/or terminal response. Present
@@ -189,20 +189,32 @@ exchange share the 16 MiB Core encoded-content budget. Oversized JSON channels
 become explicit `omitted` capture states without truncation; if the compact
 exchange cannot fit, the ordinary event remains stored without it.
 
-The exchange is retrievable from full-content event output but is not copied
-into Tantivy fields or tokens, semantic text, `usage.sqlite`, SQL columns, or
-the Local Pro graph. Provider call IDs, arguments, status/timing, and response
-payloads add no selectors, snippets, or ranking signals. Existing normalized
-body indexing behavior is unchanged. See
+The exchange is retrievable from full-content event output. Lexical publication
+projects the invocation server, tool, and compact JSON value of `present`
+arguments into ordinary body search for a policy-selected record. Other
+argument capture states add no terms. The projection follows the record's
+existing event type: separate invocation records are calls, while a combined
+Codex terminal `tool_output` remains an output and is not also classified as a
+call.
+
+The provider call ID, response status/failure/timing, and structured response
+payload are not copied into search terms. Response text with a
+`normalized_body` disposition retains its existing body-search behavior exactly
+once. The exchange adds no semantic text, selector, filter, search result field,
+`usage.sqlite` value, SQL column, or Local Pro fact. See
 [`mcp-exchange-capture.md`](mcp-exchange-capture.md).
 
 Search, show, list, locate, and MCP retrieval read verified Core/Tantivy
 generations. List continuations remain bound to the named active or retained
 generation, and JSONL holds one generation pin for its whole traversal. Show
-and list present complete policy-selected normalized records stored in Core,
-while locate returns bounded Core source identity metadata. None of these read
+and list present the exact, complete policy-selected normalized records stored
+in Core, while search snippets come from the Core-backed searchable projection
+and locate returns bounded Core source identity metadata. None of these read
 paths reopens provider history. Provider changes become visible after import or
-daemon refresh publishes a new Core generation.
+daemon refresh publishes a new Core generation. Search projection changes are
+part of lexical generation identity, so an older active generation is rebuilt
+or passes the narrow same-epoch preservation migration before newly projected
+invocation terms become searchable.
 
 Lexical publication keeps the active generation and one previous generation
 for recovery and pinned readers; their manifests and integrity receipts use the


### PR DESCRIPTION
## Summary
- project policy-selected MCP server, tool, and Present invocation arguments into the existing lexical body field
- preserve class-aware call/output scope and weights, with combined Codex exchanges intentionally classified as tool output
- keep call IDs, structured response payloads, timing, status, failure, and attribution-only metadata out of search
- fix a discovered verified-reader race during managed generation hard-link topology changes without weakening fail-closed corruption checks

## Validation
- docs, CLI, capture, index, MCP search, migration fault, and migration disk suites: 7/7 passed
- continuous predecessor/successor reader race: 300/300 passed after rebase (1000/1000 before rebase)
- isolated performance sanity: passed
- three independent review lanes: search semantics, provider/privacy identity, and generation-race correctness; no blockers

## Known non-blocking edge
An abandoned validly named unpublished generation can conservatively classify unrelated external-hardlink corruption as retryable concurrency until cleanup. It never admits bytes; stronger candidate authentication is a follow-up if read-only availability requires it.