### PR TITLE
release: bind candidate manifest authority

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -527,7 +527,9 @@ steps:
         --step public-cli-windows-x64
       CTX_PUBLIC_RELEASE_SOURCE_COMMIT="${source_commit}" \
         scripts/stage-github-release-assets.sh \
-          target/public-cli-artifacts target/github-release-assets
+          target/public-cli-artifacts \
+          target/github-release-assets \
+          target/github-release-authority
     agents:
       queue: "release-linux-managed"
       ctx-runner-class: "release-linux-control"
@@ -536,6 +538,7 @@ steps:
     timeout_in_minutes: 30
     artifact_paths:
       - "target/github-release-assets/*"
+      - "target/github-release-authority/*"
 
   - label: ":package: Semantic ONNX models"
     key: "semantic-model-archives"

--- a/contracts/release-candidate-manifest-v1.schema.json
+++ b/contracts/release-candidate-manifest-v1.schema.json
@@ -53,6 +53,36 @@
       }
     },
     "artifact": { "$ref": "#/$defs/artifact" },
+    "release_sums": {
+      "allOf": [
+        { "$ref": "#/$defs/artifact" },
+        {
+          "properties": {
+            "file": { "const": "SHA256SUMS" }
+          }
+        }
+      ]
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["file", "sha256", "size_bytes", "dll"],
+      "properties": {
+        "file": { "const": "ctx-onnxruntime-windows-x64.zip" },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "size_bytes": { "type": "integer", "minimum": 1 },
+        "dll": {
+          "allOf": [
+            { "$ref": "#/$defs/artifact" },
+            {
+              "properties": {
+                "file": { "const": "lib/onnxruntime.dll" }
+              }
+            }
+          ]
+        }
+      }
+    },
     "evidence": {
       "type": "object",
       "required": [
@@ -136,6 +166,30 @@
       }
     }
   },
+  "dependentRequired": {
+    "release_sums": ["runtime"],
+    "runtime": ["release_sums"]
+  },
+  "allOf": [
+    {
+      "if": { "required": ["release_sums"] },
+      "then": {
+        "properties": {
+          "target": {
+            "properties": {
+              "id": { "const": "windows-x64" },
+              "platform": { "const": "windows-x64" }
+            }
+          },
+          "artifact": {
+            "properties": {
+              "file": { "const": "ctx.exe" }
+            }
+          }
+        }
+      }
+    }
+  ],
   "$defs": {
     "artifact": {
       "type": "object",

--- a/docs/bazel-development.md
+++ b/docs/bazel-development.md
@@ -229,9 +229,49 @@ those pairs and adds the ten exact Semantic assets. Linux inputs must carry
 their sealed per-platform completion identities; Semantic assets are instead
 validated directly through their manifests, checksums, and canonical catalog.
 
-Linux must also pass `--build-info PATH` from the pinned Ubuntu 22.04 builder;
-the tracked builder above owns that producer and passes its output to the
-generic packager. Set
+Aggregate staging also writes a separate release-authority handoff directory;
+it does not add those files to the GitHub Release asset set or `SHA256SUMS`.
+The handoff retains all six canonical per-target candidate manifests and their
+digest sidecars. It also retains the Windows executable and candidate evidence
+under their exact construction names (`ctx.exe`, `ctx.exe.build-info.json`,
+`ctx.exe.cdx.json`, `ctx.exe.size.json`, and
+`ctx.exe.third-party-notices.txt`), plus exact copies of `SHA256SUMS` and the
+Windows runtime archive. `release_bundle.py` publishes this fresh, exact
+19-file directory atomically without replacement.
+
+After the final `SHA256SUMS` exists, the Windows manifest is finalized to bind
+the literal `SHA256SUMS` and
+`ctx-onnxruntime-windows-x64.zip` names, their exact bytes and SHA-256 values,
+and the exact `lib/onnxruntime.dll` name, size, and SHA-256 value. Its digest
+sidecar is convenience input and is not authority. The production verifier
+accepts only the complete handoff and an independently obtained expected
+manifest digest:
+
+```bash
+python3 -I scripts/release-sbom.py verify-release \
+  --handoff-dir target/github-release-authority \
+  --expected-manifest-sha256 HEX_DIGEST
+```
+
+The command requires the exact handoff inventory, verifies the release-bound
+manifest and every Windows input it names, and prints the verified digest. It
+does not sign, attest, authenticate, or select the expected digest. The
+authority integrating this interface must supply that digest independently of
+the handoff and its sidecars.
+
+Pass an explicit third directory when staging for a release build:
+
+```bash
+scripts/stage-github-release-assets.sh \
+  target/public-cli-artifacts \
+  target/github-release-assets \
+  target/github-release-authority
+```
+
+Linux must also pass `--build-info PATH` from the pinned Ubuntu 22.04 builder.
+For Linux x64 staging dogfood, the tracked builder above owns that producer and
+passes its output to the generic packager. Other Linux release lanes must
+provide equivalently validated builder-authored evidence. Set
 `CTX_MACOS_RELEASE_SIGNING=required` on trusted macOS release workers; signing
 remains optional for unsigned local qualification candidates.
 

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -41,6 +41,11 @@ the local retrieval product.
   public key, and artifact-origin prefix are binary constants; ambient config
   and environment cannot replace them, and release-related child processes
   remove inherited release-authority variables before execution.
+- Public release construction emits one atomic authority handoff. Its aggregate
+  Windows candidate manifest binds the exact construction executable, release
+  checksum file, runtime archive, and runtime DLL. The public verifier accepts
+  that exact handoff plus an independently supplied expected manifest digest;
+  it does not sign, attest, or treat a matching handoff sidecar as authority.
 - Automatic upgrade defaults on for managed installs, but the enabled daemon is
   its only scheduler. A disabled daemon performs no automatic check, download,
   or apply. Signed policy and explicit opt-outs remain mandatory, and upgrade

--- a/scripts/check-buildkite-pipeline.sh
+++ b/scripts/check-buildkite-pipeline.sh
@@ -576,9 +576,10 @@ if command -v ruby >/dev/null 2>&1; then
     ].each do |producer|
       abort "release candidate staging does not bind artifacts from #{producer}" unless candidate_command.include?("--step #{producer}")
     end
-    abort "release candidate staging must run exact-byte public assembly" unless candidate_command.include?("scripts/stage-github-release-assets.sh") && candidate_command.include?("target/github-release-assets")
+    abort "release candidate staging must run exact-byte public assembly" unless candidate_command.include?("scripts/stage-github-release-assets.sh") && candidate_command.include?("target/github-release-assets") && candidate_command.include?("target/github-release-authority")
     abort "GitHub staging must bind the public source commit to checkout HEAD" unless candidate_command.include?("CTX_PUBLIC_RELEASE_SOURCE_COMMIT") && candidate_command.include?("git rev-parse --verify HEAD^{commit}")
     abort "release candidate staging must upload the immutable manifest" unless Array(candidate["artifact_paths"]).include?("target/github-release-assets/*")
+    abort "release candidate staging must upload the manifest-authority handoff" unless Array(candidate["artifact_paths"]).include?("target/github-release-authority/*")
     semantic_assets = %w[
       ctx-multilingual-e5-small-onnx-fp32-1.0.0.tar.xz
       ctx-multilingual-e5-small-onnx-o4-fp16-1.0.0.tar.xz
@@ -683,6 +684,7 @@ for required in \
   'scripts/build-onnxruntime-sidecar.sh linux-x64-cuda12' \
   'key: "github-release-candidate"' \
   'target/github-release-assets/*' \
+  'target/github-release-authority/*' \
   'scripts/stage-semantic-release-handoff.sh' \
   'target/semantic-release-handoff/*' \
   'CTX_MACOS_RELEASE_SIGNING=required' \

--- a/scripts/release-sbom.py
+++ b/scripts/release-sbom.py
@@ -4,11 +4,16 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import io
 import json
 import os
 from pathlib import Path
+import re
+import stat
 import sys
 from typing import Any
+import zipfile
 
 _SCRIPT_DIRECTORY = os.fspath(Path(__file__).resolve().parent)
 sys.path.insert(0, _SCRIPT_DIRECTORY)
@@ -40,6 +45,221 @@ try:
 finally:
     del sys.path[0]
 del _SCRIPT_DIRECTORY
+
+
+WINDOWS_TARGET_ID = "windows-x64"
+WINDOWS_CONSTRUCTION_ARTIFACT = "ctx.exe"
+WINDOWS_RELEASE_ARTIFACT = "ctx-windows-x64.exe"
+RELEASE_SUMS = "SHA256SUMS"
+WINDOWS_RUNTIME_ARCHIVE = "ctx-onnxruntime-windows-x64.zip"
+WINDOWS_RUNTIME_DLL = "lib/onnxruntime.dll"
+SUM_LINE = re.compile(r"([0-9a-f]{64})  ([A-Za-z0-9][A-Za-z0-9._-]{0,127})")
+MAX_RELEASE_SUMS_BYTES = 64 * 1024
+MAX_RUNTIME_ARCHIVE_BYTES = 256 * 1024 * 1024
+MAX_RUNTIME_DLL_BYTES = 512 * 1024 * 1024
+MAX_RUNTIME_EXPANDED_BYTES = 1024 * 1024 * 1024
+LEGACY_RELEASE_ASSETS = (
+    "ctx-linux-x64",
+    "ctx-linux-x64.cdx.json",
+    "ctx-linux-x64.third-party-notices.txt",
+    "ctx-linux-aarch64",
+    "ctx-linux-aarch64.cdx.json",
+    "ctx-linux-aarch64.third-party-notices.txt",
+    "ctx-macos-arm64",
+    "ctx-macos-arm64.cdx.json",
+    "ctx-macos-arm64.third-party-notices.txt",
+    "ctx-macos-x64",
+    "ctx-macos-x64.cdx.json",
+    "ctx-macos-x64.third-party-notices.txt",
+    WINDOWS_RELEASE_ARTIFACT,
+    f"{WINDOWS_RELEASE_ARTIFACT}.cdx.json",
+    f"{WINDOWS_RELEASE_ARTIFACT}.third-party-notices.txt",
+    "ctx-freebsd-x64",
+    "ctx-freebsd-x64.cdx.json",
+    "ctx-freebsd-x64.third-party-notices.txt",
+    "ctx-onnxruntime-linux-x64.tar.gz",
+    "ctx-onnxruntime-linux-aarch64.tar.gz",
+    "ctx-onnxruntime-macos-arm64.tar.gz",
+    "ctx-onnxruntime-macos-x64.tar.gz",
+    WINDOWS_RUNTIME_ARCHIVE,
+    "ctx-onnxruntime-freebsd-x64.tar.gz",
+)
+SEMANTIC_RELEASE_ASSETS = (
+    "ctx-multilingual-e5-small-onnx-fp32-1.0.0.tar.xz",
+    "ctx-multilingual-e5-small-onnx-o4-fp16-1.0.0.tar.xz",
+    "ctx-multilingual-e5-small-coreml-fp16-1.0.0.tar.xz",
+    "ctx-onnxruntime-linux-x64.tar.zst",
+    "ctx-onnxruntime-linux-aarch64.tar.zst",
+    "ctx-onnxruntime-macos-arm64.tar.zst",
+    "ctx-onnxruntime-macos-x64.tar.zst",
+    "ctx-windowsml-windows-x64.zip",
+    "ctx-onnxruntime-freebsd-x64.tar.zst",
+    "ctx-onnxruntime-linux-x64-cuda12.tar.zst",
+)
+WINDOWS_RUNTIME_FILES = {
+    "LICENSE",
+    "ThirdPartyNotices.txt",
+    "VERSION_NUMBER",
+    "GIT_COMMIT_ID",
+    "MICROSOFT_VC_RUNTIME_LICENSE.rtf",
+    WINDOWS_RUNTIME_DLL,
+    "lib/msvcp140.dll",
+    "lib/msvcp140_1.dll",
+    "lib/vcruntime140.dll",
+    "lib/vcruntime140_1.dll",
+}
+WINDOWS_RUNTIME_ENTRIES = WINDOWS_RUNTIME_FILES | {"lib"}
+RELEASE_AUTHORITY_CANDIDATES = (
+    "ctx.candidate.json",
+    "ctx-linux-aarch64.candidate.json",
+    "ctx-macos-arm64.candidate.json",
+    "ctx-macos-x64.candidate.json",
+    "ctx.exe.candidate.json",
+    "ctx-freebsd-x64.candidate.json",
+)
+WINDOWS_RELEASE_HANDOFF_INPUTS = (
+    WINDOWS_CONSTRUCTION_ARTIFACT,
+    f"{WINDOWS_CONSTRUCTION_ARTIFACT}.build-info.json",
+    f"{WINDOWS_CONSTRUCTION_ARTIFACT}.cdx.json",
+    f"{WINDOWS_CONSTRUCTION_ARTIFACT}.size.json",
+    f"{WINDOWS_CONSTRUCTION_ARTIFACT}.third-party-notices.txt",
+    RELEASE_SUMS,
+    WINDOWS_RUNTIME_ARCHIVE,
+)
+RELEASE_AUTHORITY_HANDOFF_LEAVES = tuple(
+    sorted(
+        WINDOWS_RELEASE_HANDOFF_INPUTS
+        + RELEASE_AUTHORITY_CANDIDATES
+        + tuple(f"{name}.sha256" for name in RELEASE_AUTHORITY_CANDIDATES)
+    )
+)
+
+
+def release_sums_record(path: Path) -> tuple[dict[str, str], dict[str, object]]:
+    if path.name != RELEASE_SUMS:
+        raise ValueError(f"release checksum manifest must be named {RELEASE_SUMS}")
+    payload = regular_bytes(path, "release SHA256SUMS", MAX_RELEASE_SUMS_BYTES)
+    if not payload.endswith(b"\n") or b"\r" in payload or b"\x00" in payload:
+        raise ValueError("release SHA256SUMS is not canonical lowercase SHA-256 text")
+    try:
+        lines = payload.decode("ascii").splitlines()
+    except UnicodeDecodeError as error:
+        raise ValueError("release SHA256SUMS is not ASCII") from error
+    entries: dict[str, str] = {}
+    for index, line in enumerate(lines, 1):
+        match = SUM_LINE.fullmatch(line)
+        if match is None:
+            raise ValueError(f"release SHA256SUMS line {index} is malformed")
+        digest, name = match.groups()
+        if name in entries:
+            raise ValueError(f"release SHA256SUMS repeats {name}")
+        entries[name] = digest
+    names = tuple(entries)
+    if names not in (
+        LEGACY_RELEASE_ASSETS,
+        LEGACY_RELEASE_ASSETS + SEMANTIC_RELEASE_ASSETS,
+    ):
+        raise ValueError(
+            "release SHA256SUMS does not have the exact canonical 24- or "
+            "34-entry release inventory and order"
+        )
+    return entries, {
+        "file": RELEASE_SUMS,
+        "sha256": sha256_bytes(payload),
+        "size_bytes": len(payload),
+    }
+
+
+def safe_zip_name(name: str) -> str:
+    parts = name.rstrip("/").split("/")
+    if (
+        not name
+        or "\\" in name
+        or name.startswith("/")
+        or re.match(r"^[A-Za-z]:", name)
+        or any(part in ("", ".", "..") for part in parts)
+    ):
+        raise ValueError(f"Windows runtime archive has unsafe path {name!r}")
+    return "/".join(parts)
+
+
+def windows_runtime_record(path: Path) -> dict[str, object]:
+    if path.name != WINDOWS_RUNTIME_ARCHIVE:
+        raise ValueError(
+            f"Windows runtime archive must be named {WINDOWS_RUNTIME_ARCHIVE}"
+        )
+    archive_bytes = regular_bytes(
+        path, "Windows runtime archive", MAX_RUNTIME_ARCHIVE_BYTES
+    )
+    archive_sha256 = sha256_bytes(archive_bytes)
+    archive_size = len(archive_bytes)
+    try:
+        with zipfile.ZipFile(io.BytesIO(archive_bytes)) as archive:
+            entries: dict[str, zipfile.ZipInfo] = {}
+            expanded_size = 0
+            for record in archive.infolist():
+                name = safe_zip_name(record.filename)
+                if name in entries:
+                    raise ValueError(f"Windows runtime archive repeats {name}")
+                mode = record.external_attr >> 16
+                if record.flag_bits & 1 or stat.S_ISLNK(mode) or mode & 0o7000:
+                    raise ValueError(
+                        f"Windows runtime archive has unsafe entry {name}"
+                    )
+                if name not in WINDOWS_RUNTIME_ENTRIES:
+                    raise ValueError(
+                        f"Windows runtime archive has unexpected entry {name}"
+                    )
+                if name == "lib":
+                    if not record.is_dir():
+                        raise ValueError(
+                            "Windows runtime archive lib entry is not a directory"
+                        )
+                elif record.is_dir() or record.file_size <= 0:
+                    raise ValueError(
+                        f"Windows runtime archive entry is not a non-empty file: {name}"
+                    )
+                expanded_size += record.file_size
+                if expanded_size > MAX_RUNTIME_EXPANDED_BYTES:
+                    raise ValueError(
+                        "Windows runtime archive exceeds its expanded size limit"
+                    )
+                entries[name] = record
+            if set(entries) != WINDOWS_RUNTIME_ENTRIES:
+                missing = sorted(WINDOWS_RUNTIME_ENTRIES - set(entries))
+                raise ValueError(
+                    "Windows runtime archive entries do not exactly match the "
+                    f"legacy sidecar layout; missing: {missing}"
+                )
+            dll = entries.get(WINDOWS_RUNTIME_DLL)
+            if dll is None or dll.is_dir():
+                raise ValueError(
+                    f"Windows runtime archive does not contain {WINDOWS_RUNTIME_DLL}"
+                )
+            if dll.file_size <= 0 or dll.file_size > MAX_RUNTIME_DLL_BYTES:
+                raise ValueError("Windows runtime DLL has an invalid size")
+            digest = hashlib.sha256()
+            observed = 0
+            with archive.open(dll) as source:
+                for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                    observed += len(chunk)
+                    if observed > MAX_RUNTIME_DLL_BYTES:
+                        raise ValueError("Windows runtime DLL exceeds its size limit")
+                    digest.update(chunk)
+            if observed != dll.file_size:
+                raise ValueError("Windows runtime DLL ended before its declared size")
+    except (OSError, KeyError, zipfile.BadZipFile) as error:
+        raise ValueError("Windows runtime archive is not a valid ZIP") from error
+    return {
+        "file": WINDOWS_RUNTIME_ARCHIVE,
+        "sha256": archive_sha256,
+        "size_bytes": archive_size,
+        "dll": {
+            "file": WINDOWS_RUNTIME_DLL,
+            "sha256": digest.hexdigest(),
+            "size_bytes": observed,
+        },
+    }
 
 def load_core_build_info(
     build_info_bytes: bytes,
@@ -487,6 +707,68 @@ def atomic_write(path: Path, payload: bytes) -> None:
         temporary.unlink(missing_ok=True)
 
 
+def exclusive_write(path: Path, payload: bytes) -> None:
+    descriptor = os.open(
+        path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+        0o600,
+    )
+    try:
+        with os.fdopen(descriptor, "wb", closefd=False) as destination:
+            destination.write(payload)
+            destination.flush()
+            os.fsync(destination.fileno())
+    finally:
+        os.close(descriptor)
+
+
+def canonical_path(path: Path) -> Path:
+    return Path(os.path.abspath(path)).resolve(strict=False)
+
+
+def release_handoff_binding(path: Path) -> tuple[int, int, int, int, int, tuple[str, ...]]:
+    try:
+        metadata = path.lstat()
+        names = tuple(sorted(entry.name for entry in path.iterdir()))
+    except OSError as error:
+        raise ValueError(f"release authority handoff is unavailable: {path}") from error
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError(f"release authority handoff is not a directory: {path}")
+    if names != RELEASE_AUTHORITY_HANDOFF_LEAVES:
+        raise ValueError(
+            "release authority handoff does not have the exact production inventory"
+        )
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        names,
+    )
+
+
+def verify_release_handoff(args: argparse.Namespace) -> str:
+    handoff = args.handoff_dir
+    before = release_handoff_binding(handoff)
+    args.artifact = handoff / WINDOWS_CONSTRUCTION_ARTIFACT
+    args.build_info = handoff / f"{WINDOWS_CONSTRUCTION_ARTIFACT}.build-info.json"
+    args.sbom = handoff / f"{WINDOWS_CONSTRUCTION_ARTIFACT}.cdx.json"
+    args.notices = handoff / f"{WINDOWS_CONSTRUCTION_ARTIFACT}.third-party-notices.txt"
+    args.size_report = handoff / f"{WINDOWS_CONSTRUCTION_ARTIFACT}.size.json"
+    args.candidate_manifest = handoff / f"{WINDOWS_CONSTRUCTION_ARTIFACT}.candidate.json"
+    args.release_sums = handoff / RELEASE_SUMS
+    args.runtime_archive = handoff / WINDOWS_RUNTIME_ARCHIVE
+    digest = verify_bundle_only(
+        args,
+        release_bound=True,
+        expected_manifest_sha256=args.expected_manifest_sha256,
+    )
+    if release_handoff_binding(handoff) != before:
+        raise ValueError("release authority handoff changed while verified")
+    return digest
+
+
 def read_canonical_json(path: Path, label: str, maximum: int) -> tuple[dict[str, Any], bytes]:
     payload = regular_bytes(path, label, maximum)
     try:
@@ -498,7 +780,12 @@ def read_canonical_json(path: Path, label: str, maximum: int) -> tuple[dict[str,
     return value, payload
 
 
-def verify_bundle_only(args: argparse.Namespace) -> str:
+def verify_bundle_only(
+    args: argparse.Namespace,
+    *,
+    release_bound: bool = False,
+    expected_manifest_sha256: str | None = None,
+) -> str:
     artifact_sha256 = sha256_file(
         args.artifact, "Core artifact", 256 * 1024 * 1024
     )
@@ -506,6 +793,18 @@ def verify_bundle_only(args: argparse.Namespace) -> str:
     candidate, candidate_bytes = read_canonical_json(
         args.candidate_manifest, "candidate manifest", 16 * 1024 * 1024
     )
+    candidate_sha256 = sha256_bytes(candidate_bytes)
+    if expected_manifest_sha256 is not None:
+        if (
+            HEX_64.fullmatch(expected_manifest_sha256) is None
+            or expected_manifest_sha256 == "0" * 64
+        ):
+            raise ValueError("expected candidate manifest digest is invalid")
+        if candidate_sha256 != expected_manifest_sha256:
+            raise ValueError(
+                "candidate manifest digest does not match the independently "
+                "supplied expected digest"
+            )
     expected_top = {
         "schema_version",
         "kind",
@@ -518,6 +817,8 @@ def verify_bundle_only(args: argparse.Namespace) -> str:
         "evidence",
         "tantivy",
     }
+    if release_bound:
+        expected_top.update(("release_sums", "runtime"))
     if (
         set(candidate) != expected_top
         or candidate.get("schema_version") != 1
@@ -677,7 +978,69 @@ def verify_bundle_only(args: argparse.Namespace) -> str:
         or any(name == "rust-stemmers" for name, _, _ in closure_identities)
     ):
         raise ValueError("candidate manifest Tantivy contract is malformed")
-    return sha256_bytes(candidate_bytes)
+    if release_bound:
+        if (
+            target["id"] != WINDOWS_TARGET_ID
+            or candidate["artifact"]["file"] != WINDOWS_CONSTRUCTION_ARTIFACT
+        ):
+            raise ValueError(
+                "release-bound candidate manifest is not the Windows construction candidate"
+            )
+        sums, sums_record = release_sums_record(args.release_sums)
+        runtime_record = windows_runtime_record(args.runtime_archive)
+        if candidate.get("release_sums") != sums_record:
+            raise ValueError("candidate manifest does not bind exact release SHA256SUMS")
+        if candidate.get("runtime") != runtime_record:
+            raise ValueError("candidate manifest does not bind exact Windows runtime and DLL")
+        if sums[WINDOWS_RELEASE_ARTIFACT] != artifact_sha256:
+            raise ValueError(
+                f"release SHA256SUMS does not bind {WINDOWS_RELEASE_ARTIFACT} "
+                "to the candidate artifact"
+            )
+        if sums[WINDOWS_RUNTIME_ARCHIVE] != runtime_record["sha256"]:
+            raise ValueError(
+                f"release SHA256SUMS does not bind {WINDOWS_RUNTIME_ARCHIVE} "
+                "to the candidate runtime"
+            )
+    return candidate_sha256
+
+
+def bind_release_candidate(args: argparse.Namespace) -> tuple[bytes, bytes]:
+    verified_candidate_sha256 = verify_bundle_only(args)
+    candidate, candidate_bytes = read_canonical_json(
+        args.candidate_manifest, "candidate manifest", 16 * 1024 * 1024
+    )
+    if sha256_bytes(candidate_bytes) != verified_candidate_sha256:
+        raise ValueError("candidate manifest changed while release binding was verified")
+    target = candidate.get("target")
+    artifact = candidate.get("artifact")
+    if (
+        not isinstance(target, dict)
+        or target.get("id") != WINDOWS_TARGET_ID
+        or target.get("platform") != WINDOWS_TARGET_ID
+        or not isinstance(artifact, dict)
+        or artifact.get("file") != WINDOWS_CONSTRUCTION_ARTIFACT
+    ):
+        raise ValueError(
+            "release binding requires the exact Windows Bazel construction candidate"
+        )
+    sums, sums_record = release_sums_record(args.release_sums)
+    runtime_record = windows_runtime_record(args.runtime_archive)
+    if sums[WINDOWS_RELEASE_ARTIFACT] != artifact["sha256"]:
+        raise ValueError(
+            f"release SHA256SUMS does not bind {WINDOWS_RELEASE_ARTIFACT} "
+            "to the candidate artifact"
+        )
+    if sums[WINDOWS_RUNTIME_ARCHIVE] != runtime_record["sha256"]:
+        raise ValueError(
+            f"release SHA256SUMS does not bind {WINDOWS_RUNTIME_ARCHIVE} "
+            "to the candidate runtime"
+        )
+    candidate["release_sums"] = sums_record
+    candidate["runtime"] = runtime_record
+    payload = canonical(candidate)
+    digest = sha256_bytes(payload)
+    return payload, f"{digest}\n".encode("ascii")
 
 
 def require_full_arguments(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
@@ -721,7 +1084,16 @@ def require_full_arguments(parser: argparse.ArgumentParser, args: argparse.Names
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("mode", choices=("generate", "verify", "verify-bundle"))
+    parser.add_argument(
+        "mode",
+        choices=(
+            "generate",
+            "verify",
+            "verify-bundle",
+            "bind-release",
+            "verify-release",
+        ),
+    )
     parser.add_argument("--product", choices=("core",))
     parser.add_argument("--version")
     parser.add_argument("--target-id")
@@ -745,9 +1117,41 @@ def main() -> int:
     parser.add_argument("--sbom", type=Path)
     parser.add_argument("--notices", type=Path)
     parser.add_argument("--size-report", type=Path)
+    parser.add_argument("--release-sums", type=Path)
+    parser.add_argument("--runtime-archive", type=Path)
+    parser.add_argument("--output-manifest", type=Path)
+    parser.add_argument("--manifest-sha256-output", type=Path)
+    parser.add_argument("--expected-manifest-sha256")
+    parser.add_argument("--handoff-dir", type=Path)
     args = parser.parse_args()
     try:
-        if args.mode == "verify-bundle":
+        if args.mode == "verify-release":
+            required = ("handoff_dir", "expected_manifest_sha256")
+            missing = [
+                "--" + name.replace("_", "-")
+                for name in required
+                if getattr(args, name) is None
+            ]
+            if missing:
+                parser.error(f"verify-release requires " + ", ".join(missing))
+            explicit_inputs = (
+                "artifact",
+                "build_info",
+                "candidate_manifest",
+                "notices",
+                "release_sums",
+                "runtime_archive",
+                "sbom",
+                "size_report",
+            )
+            if any(getattr(args, name) is not None for name in explicit_inputs):
+                parser.error(
+                    "verify-release accepts release inputs only through --handoff-dir"
+                )
+            print(verify_release_handoff(args))
+            return 0
+
+        if args.mode in ("verify-bundle", "bind-release"):
             required = (
                 "artifact",
                 "build_info",
@@ -756,14 +1160,41 @@ def main() -> int:
                 "sbom",
                 "size_report",
             )
+            if args.mode == "bind-release":
+                required += ("release_sums", "runtime_archive")
+                required += ("output_manifest", "manifest_sha256_output")
             missing = [
                 "--" + name.replace("_", "-")
                 for name in required
                 if getattr(args, name) is None
             ]
             if missing:
-                parser.error("verify-bundle requires " + ", ".join(missing))
-            print(verify_bundle_only(args))
+                parser.error(f"{args.mode} requires " + ", ".join(missing))
+            if args.mode == "verify-bundle":
+                print(verify_bundle_only(args))
+            elif args.mode == "bind-release":
+                outputs = (args.output_manifest, args.manifest_sha256_output)
+                inputs = (
+                    args.artifact,
+                    args.build_info,
+                    args.candidate_manifest,
+                    args.notices,
+                    args.release_sums,
+                    args.runtime_archive,
+                    args.sbom,
+                    args.size_report,
+                )
+                canonical_outputs = tuple(canonical_path(path) for path in outputs)
+                canonical_inputs = {canonical_path(path) for path in inputs}
+                if (
+                    len(set(canonical_outputs)) != len(canonical_outputs)
+                    or canonical_inputs.intersection(canonical_outputs)
+                ):
+                    parser.error("bind-release inputs and outputs must be distinct")
+                manifest, digest = bind_release_candidate(args)
+                exclusive_write(args.output_manifest, manifest)
+                exclusive_write(args.manifest_sha256_output, digest)
+                print(digest.decode("ascii").strip())
             return 0
 
         require_full_arguments(parser, args)

--- a/scripts/release/release_bundle.py
+++ b/scripts/release/release_bundle.py
@@ -581,6 +581,45 @@ def preflight_destinations(
     return output, symbols
 
 
+def preflight_publication_directories(
+    input_directory: Path, output_directories: list[Path]
+) -> None:
+    source = _absolute(input_directory)
+    source_descriptor = _open_bound_directory(
+        source, "release publication input"
+    )
+    try:
+        _require_bound_directory_identity(
+            source_descriptor, source, "release publication input"
+        )
+    finally:
+        os.close(source_descriptor)
+    outputs = [_absolute(path) for path in output_directories]
+    paths = [source, *outputs]
+    if len(outputs) < 1 or len(set(paths)) != len(paths) or Path("/") in paths:
+        raise BundleError("release publication directories are invalid")
+    for index, path in enumerate(paths):
+        for other in paths[index + 1 :]:
+            if path in other.parents or other in path.parents:
+                raise BundleError(
+                    "release publication directories must not be nested"
+                )
+    for output in outputs:
+        _ensure_parent(output.parent)
+        parent = _open_bound_directory(
+            output.parent, "release publication destination parent"
+        )
+        try:
+            if _entry_binding(
+                parent, _valid_leaf_name(output.name, "release publication output")
+            ) is not None:
+                raise BundleError(
+                    f"release publication destination already exists: {output}"
+                )
+        finally:
+            os.close(parent)
+
+
 def commit_directory(stage: Path, output: Path) -> None:
     stage = _absolute(stage)
     output = _absolute(output)
@@ -737,6 +776,11 @@ def main() -> int:
     preflight.add_argument("--repo-root", type=Path, required=True)
     preflight.add_argument("--output-dir", required=True)
     preflight.add_argument("--private-symbols-dir")
+    publication = commands.add_parser("preflight-publication")
+    publication.add_argument("--input-dir", type=Path, required=True)
+    publication.add_argument(
+        "--output-dir", type=Path, action="append", required=True
+    )
     seal = commands.add_parser("seal")
     seal.add_argument("--candidate-dir", type=Path, required=True)
     seal.add_argument("--platform", required=True)
@@ -772,6 +816,8 @@ def main() -> int:
                 "CTX_LINUX_RELEASE_PRIVATE_SYMBOLS_DIR="
                 f"{shlex.quote(str(symbols))}"
             )
+        elif args.command == "preflight-publication":
+            preflight_publication_directories(args.input_dir, args.output_dir)
         elif args.command == "seal":
             print(seal_bundle(args.candidate_dir, args.platform, args.source_commit))
         elif args.command == "verify":

--- a/scripts/stage-github-release-assets.sh
+++ b/scripts/stage-github-release-assets.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<'USAGE'
-Usage: scripts/stage-github-release-assets.sh [ARTIFACT_DIR] [OUT_DIR]
-       scripts/stage-github-release-assets.sh --with-semantic [ARTIFACT_DIR] [OUT_DIR]
+Usage: scripts/stage-github-release-assets.sh [ARTIFACT_DIR] [OUT_DIR] [AUTHORITY_DIR]
+       scripts/stage-github-release-assets.sh --with-semantic [ARTIFACT_DIR] [OUT_DIR] [AUTHORITY_DIR]
        scripts/stage-github-release-assets.sh --transcode-runtime PLATFORM [ARTIFACT_DIR]
 
 Stages public GitHub Release assets from built public CLI artifacts.
@@ -36,15 +36,17 @@ case "${1:-}" in
     transcode_platform="${2:-}"
     artifact_dir="${3:-target/public-cli-artifacts}"
     out_dir=""
+    authority_dir=""
     ;;
   --with-semantic)
-    [[ "$#" -le 3 ]] || {
+    [[ "$#" -le 4 ]] || {
       usage
       exit 2
     }
     include_semantic="1"
     artifact_dir="${2:-target/public-cli-artifacts}"
     out_dir="${3:-target/github-release-assets}"
+    authority_dir="${4:-${out_dir}.authority}"
     ;;
   -h|--help)
     usage
@@ -56,16 +58,17 @@ case "${1:-}" in
     exit 2
     ;;
   *)
-    [[ "$#" -le 2 ]] || {
+    [[ "$#" -le 3 ]] || {
       usage
       exit 2
     }
     artifact_dir="${1:-target/public-cli-artifacts}"
     out_dir="${2:-target/github-release-assets}"
+    authority_dir="${3:-${out_dir}.authority}"
     ;;
 esac
 
-if [[ "${artifact_dir}" == -* || "${out_dir}" == -* ]]; then
+if [[ "${artifact_dir}" == -* || "${out_dir}" == -* || "${authority_dir}" == -* ]]; then
   printf 'staging modes cannot be combined\n' >&2
   usage
   exit 2
@@ -309,22 +312,34 @@ validate_staged_cli_evidence() {
   local source_name="$1"
   local dest_name="$2"
   local platform="$3"
+  local candidate_manifest="$4"
+  local verification_name="${5:-${dest_name}}"
+  local verification_dir="${6:-${out_dir}}"
   local source_path="${artifact_dir%/}/${source_name}"
-  local staged_path="${out_dir%/}/${dest_name}"
+  local staged_path="${verification_dir%/}/${verification_name}"
+  local build_info_path="${source_path}.build-info.json"
+  local sbom_path="${verification_dir%/}/${verification_name}.cdx.json"
+  local notices_path="${verification_dir%/}/${verification_name}.third-party-notices.txt"
+  local size_report_path="${source_path}.size.json"
+
+  if [[ "${verification_dir}" == "${authority_dir}" ]]; then
+    build_info_path="${verification_dir%/}/${verification_name}.build-info.json"
+    size_report_path="${verification_dir%/}/${verification_name}.size.json"
+  fi
 
   python3 -I scripts/check-public-cli-build-info.py \
     --artifact "${staged_path}" \
-    --build-info "${source_path}.build-info.json" \
+    --build-info "${build_info_path}" \
     --matrix contracts/release-targets-v1.json \
     --platform "${platform}" \
     --source-commit "${source_commit}" >/dev/null
   python3 -I scripts/release-sbom.py verify-bundle \
     --artifact "${staged_path}" \
-    --build-info "${source_path}.build-info.json" \
-    --sbom "${staged_path}.cdx.json" \
-    --notices "${staged_path}.third-party-notices.txt" \
-    --size-report "${source_path}.size.json" \
-    --candidate-manifest "${source_path}.candidate.json"
+    --build-info "${build_info_path}" \
+    --sbom "${sbom_path}" \
+    --notices "${notices_path}" \
+    --size-report "${size_report_path}" \
+    --candidate-manifest "${candidate_manifest}"
 }
 
 runtime_asset_name() {
@@ -421,14 +436,34 @@ local out_dir="$2"
 local include_semantic="$3"
 local source_commit="$4"
 local repo_root="$5"
-local required_runtime_asset cli_dest semantic_fields semantic_asset
-local required_runtime_assets semantic_assets
+local authority_dir="$6"
+local authority_candidate required_runtime_asset cli_dest semantic_fields semantic_asset
+local authority_candidates required_runtime_assets semantic_assets
 
 [[ "${source_commit}" =~ ^[0-9a-f]{40}$ ]] || {
   printf 'completed GitHub staging source commit is invalid\n' >&2
   exit 1
 }
 cd "${repo_root}"
+
+stage_authority_leaf() {
+  local source_path="$1"
+  local destination_name="$2"
+  local destination_path="${authority_dir%/}/${destination_name}"
+  local before staged after
+
+  require_regular_input "${source_path}" "candidate authority input"
+  before="$(sha256_file "${source_path}")"
+  install -m 0644 "${source_path}" "${destination_path}"
+  staged="$(sha256_file "${destination_path}")"
+  after="$(sha256_file "${source_path}")"
+  if [[ "${before}" != "${staged}" || "${before}" != "${after}" ]]; then
+    printf 'candidate authority input changed while staged: %s\n' \
+      "${source_path}" >&2
+    exit 1
+  fi
+}
+
 required_runtime_assets=(
   ctx-onnxruntime-linux-x64.tar.gz
   ctx-onnxruntime-linux-aarch64.tar.gz
@@ -629,12 +664,60 @@ if [[ "${include_semantic}" == "1" ]]; then
   rm -f "${semantic_fields}"
 fi
 
-validate_staged_cli_evidence ctx ctx-linux-x64 linux-x64
-validate_staged_cli_evidence ctx-linux-aarch64 ctx-linux-aarch64 linux-aarch64
-validate_staged_cli_evidence ctx-macos-arm64 ctx-macos-arm64 macos-arm64
-validate_staged_cli_evidence ctx-macos-x64 ctx-macos-x64 macos-x64
-validate_staged_cli_evidence ctx.exe ctx-windows-x64.exe windows-x64
-validate_staged_cli_evidence ctx-freebsd-x64 ctx-freebsd-x64 freebsd-x64
+authority_candidates=(
+  ctx.candidate.json
+  ctx-linux-aarch64.candidate.json
+  ctx-macos-arm64.candidate.json
+  ctx-macos-x64.candidate.json
+  ctx.exe.candidate.json
+  ctx-freebsd-x64.candidate.json
+)
+for authority_candidate in "${authority_candidates[@]}"; do
+  authority_source="${artifact_dir%/}/${authority_candidate}"
+  authority_destination="${authority_dir%/}/${authority_candidate}"
+  if [[ "${authority_candidate}" == "ctx.exe.candidate.json" ]]; then
+    authority_destination="${authority_dir%/}/.ctx.exe.candidate.base.json"
+  fi
+  stage_authority_leaf "${authority_source}" "$(basename "${authority_destination}")"
+done
+
+# The authority handoff retains the exact Windows construction names. The
+# public release executable remains ctx-windows-x64.exe in SHA256SUMS; equality
+# of its bytes with handoff/ctx.exe is checked by bind-release below.
+stage_authority_leaf "${out_dir%/}/ctx-windows-x64.exe" ctx.exe
+stage_authority_leaf \
+  "${artifact_dir%/}/ctx.exe.build-info.json" ctx.exe.build-info.json
+stage_authority_leaf \
+  "${out_dir%/}/ctx-windows-x64.exe.cdx.json" ctx.exe.cdx.json
+stage_authority_leaf \
+  "${artifact_dir%/}/ctx.exe.size.json" ctx.exe.size.json
+stage_authority_leaf \
+  "${out_dir%/}/ctx-windows-x64.exe.third-party-notices.txt" \
+  ctx.exe.third-party-notices.txt
+stage_authority_leaf "${out_dir%/}/SHA256SUMS" SHA256SUMS
+stage_authority_leaf \
+  "${out_dir%/}/ctx-onnxruntime-windows-x64.zip" \
+  ctx-onnxruntime-windows-x64.zip
+
+validate_staged_cli_evidence \
+  ctx ctx-linux-x64 linux-x64 \
+  "${authority_dir%/}/ctx.candidate.json"
+validate_staged_cli_evidence \
+  ctx-linux-aarch64 ctx-linux-aarch64 linux-aarch64 \
+  "${authority_dir%/}/ctx-linux-aarch64.candidate.json"
+validate_staged_cli_evidence \
+  ctx-macos-arm64 ctx-macos-arm64 macos-arm64 \
+  "${authority_dir%/}/ctx-macos-arm64.candidate.json"
+validate_staged_cli_evidence \
+  ctx-macos-x64 ctx-macos-x64 macos-x64 \
+  "${authority_dir%/}/ctx-macos-x64.candidate.json"
+validate_staged_cli_evidence \
+  ctx.exe ctx-windows-x64.exe windows-x64 \
+  "${authority_dir%/}/.ctx.exe.candidate.base.json" \
+  ctx.exe "${authority_dir}"
+validate_staged_cli_evidence \
+  ctx-freebsd-x64 ctx-freebsd-x64 freebsd-x64 \
+  "${authority_dir%/}/ctx-freebsd-x64.candidate.json"
 validate_staged_runtime_asset linux-x64
 validate_staged_runtime_asset linux-aarch64
 validate_staged_runtime_asset macos-arm64
@@ -644,6 +727,49 @@ validate_staged_runtime_asset freebsd-x64
 validate_macos_signing_evidence macos-arm64
 validate_macos_signing_evidence macos-x64
 
+python3 -I scripts/release-sbom.py bind-release \
+  --artifact "${authority_dir%/}/ctx.exe" \
+  --build-info "${authority_dir%/}/ctx.exe.build-info.json" \
+  --sbom "${authority_dir%/}/ctx.exe.cdx.json" \
+  --notices "${authority_dir%/}/ctx.exe.third-party-notices.txt" \
+  --size-report "${authority_dir%/}/ctx.exe.size.json" \
+  --candidate-manifest \
+    "${authority_dir%/}/.ctx.exe.candidate.base.json" \
+  --release-sums "${authority_dir%/}/SHA256SUMS" \
+  --runtime-archive \
+    "${authority_dir%/}/ctx-onnxruntime-windows-x64.zip" \
+  --output-manifest "${authority_dir%/}/ctx.exe.candidate.json" \
+  --manifest-sha256-output \
+    "${authority_dir%/}/ctx.exe.candidate.json.sha256" >/dev/null
+rm "${authority_dir%/}/.ctx.exe.candidate.base.json"
+
+for authority_candidate in "${authority_candidates[@]}"; do
+  if [[ "${authority_candidate}" != "ctx.exe.candidate.json" ]]; then
+    printf '%s\n' \
+      "$(sha256_file "${authority_dir%/}/${authority_candidate}")" \
+      >"${authority_dir%/}/${authority_candidate}.sha256"
+  fi
+done
+authority_expected="$({
+  for authority_candidate in "${authority_candidates[@]}"; do
+    printf '%s\n%s.sha256\n' \
+      "${authority_candidate}" "${authority_candidate}"
+  done
+  printf '%s\n' \
+    SHA256SUMS \
+    ctx.exe \
+    ctx.exe.build-info.json \
+    ctx.exe.cdx.json \
+    ctx.exe.size.json \
+    ctx.exe.third-party-notices.txt \
+    ctx-onnxruntime-windows-x64.zip
+} | LC_ALL=C sort)"
+authority_actual="$(find "${authority_dir}" -mindepth 1 -maxdepth 1 \
+  -printf '%f\n' | LC_ALL=C sort)"
+if [[ "${authority_actual}" != "${authority_expected}" ]]; then
+  printf 'candidate authority handoff inventory is not exact\n' >&2
+  exit 1
+fi
 }
 
 python3 -I "${bundle_tool}" verify \
@@ -660,19 +786,27 @@ python3 -I "${bundle_tool}" verify \
 if [[ "${out_dir}" != /* ]]; then
   out_dir="${repo_root}/${out_dir}"
 fi
-[[ ! -e "${out_dir}" && ! -L "${out_dir}" ]] || {
-  printf 'refusing to replace existing GitHub release staging: %s\n' "${out_dir}" >&2
-  exit 1
-}
-mkdir -p "$(dirname "${out_dir}")"
+if [[ "${authority_dir}" != /* ]]; then
+  authority_dir="${repo_root}/${authority_dir}"
+fi
+python3 -I "${bundle_tool}" preflight-publication \
+  --input-dir "${requested_artifact_dir}" \
+  --output-dir "${out_dir}" \
+  --output-dir "${authority_dir}"
 staged_out="$(mktemp -d "$(dirname "${out_dir}")/.github-release-assets.XXXXXX")"
-trap 'rm -rf -- "${staged_out}"' EXIT
+staged_authority="$(mktemp -d \
+  "$(dirname "${authority_dir}")/.github-release-authority.XXXXXX")"
+trap 'rm -rf -- "${staged_out}" "${staged_authority}"' EXIT
 artifact_dir="${requested_artifact_dir}"
 stage_complete_candidate \
   "${artifact_dir}" "${staged_out}" "${include_semantic}" \
-  "${source_commit}" "${repo_root}"
+  "${source_commit}" "${repo_root}" "${staged_authority}"
 python3 -I "${bundle_tool}" commit-directory \
   --stage-dir "${staged_out}" \
   --output-dir "${out_dir}"
+python3 -I "${bundle_tool}" commit-directory \
+  --stage-dir "${staged_authority}" \
+  --output-dir "${authority_dir}"
 trap - EXIT
-printf 'staged GitHub release assets in %s\n' "${out_dir}"
+printf 'staged GitHub release assets in %s; candidate authority handoff in %s\n' \
+  "${out_dir}" "${authority_dir}"

--- a/scripts/test-linux-release-construction.sh
+++ b/scripts/test-linux-release-construction.sh
@@ -441,7 +441,7 @@ grep -F 'require_authoritative=1' \
   scripts/smoke-daemon-semantic-release.sh >/dev/null
 grep -F -- '--source-commit "${source_commit}"' \
   scripts/stage-github-release-assets.sh >/dev/null
-grep -F 'validate_staged_cli_evidence ctx-freebsd-x64 ctx-freebsd-x64 freebsd-x64' \
+grep -F 'ctx-freebsd-x64 ctx-freebsd-x64 freebsd-x64' \
   scripts/stage-github-release-assets.sh >/dev/null
 grep -F 'required ONNX Runtime sidecar' \
   scripts/stage-github-release-assets.sh >/dev/null

--- a/scripts/tests/release-bundle-test.py
+++ b/scripts/tests/release-bundle-test.py
@@ -134,6 +134,28 @@ class ReleaseBundleTests(unittest.TestCase):
             [str(self.repo / output), str(symbols)],
         )
 
+    def test_publication_preflight_requires_fresh_distinct_non_nested_outputs(
+        self,
+    ) -> None:
+        assets = self.root / "publication/assets"
+        authority = self.root / "publication/authority"
+        BUNDLE.preflight_publication_directories(
+            self.stage, [assets, authority]
+        )
+        authority.mkdir()
+        with self.assertRaisesRegex(BUNDLE.BundleError, "already exists"):
+            BUNDLE.preflight_publication_directories(
+                self.stage, [assets, authority]
+            )
+        with self.assertRaisesRegex(BUNDLE.BundleError, "invalid"):
+            BUNDLE.preflight_publication_directories(
+                self.stage, [assets, assets]
+            )
+        with self.assertRaisesRegex(BUNDLE.BundleError, "must not be nested"):
+            BUNDLE.preflight_publication_directories(
+                self.stage, [assets, assets / "authority"]
+            )
+
     def test_verifier_rejects_missing_extra_link_and_changed_bytes(self) -> None:
         cases = []
         missing = self.root / "missing"

--- a/scripts/tests/release-sbom-test.py
+++ b/scripts/tests/release-sbom-test.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 import tempfile
 import unittest
+import zipfile
 
 
 SCRIPT = Path(__file__).resolve().parents[1] / "release-sbom.py"
@@ -38,6 +40,52 @@ EXTERNAL_PACKAGES = (
     ("tempfile", "3.0.0"),
     ("zstd", "0.13.0"),
 )
+LEGACY_RELEASE_ASSETS = (
+    "ctx-linux-x64",
+    "ctx-linux-x64.cdx.json",
+    "ctx-linux-x64.third-party-notices.txt",
+    "ctx-linux-aarch64",
+    "ctx-linux-aarch64.cdx.json",
+    "ctx-linux-aarch64.third-party-notices.txt",
+    "ctx-macos-arm64",
+    "ctx-macos-arm64.cdx.json",
+    "ctx-macos-arm64.third-party-notices.txt",
+    "ctx-macos-x64",
+    "ctx-macos-x64.cdx.json",
+    "ctx-macos-x64.third-party-notices.txt",
+    "ctx-windows-x64.exe",
+    "ctx-windows-x64.exe.cdx.json",
+    "ctx-windows-x64.exe.third-party-notices.txt",
+    "ctx-freebsd-x64",
+    "ctx-freebsd-x64.cdx.json",
+    "ctx-freebsd-x64.third-party-notices.txt",
+    "ctx-onnxruntime-linux-x64.tar.gz",
+    "ctx-onnxruntime-linux-aarch64.tar.gz",
+    "ctx-onnxruntime-macos-arm64.tar.gz",
+    "ctx-onnxruntime-macos-x64.tar.gz",
+    "ctx-onnxruntime-windows-x64.zip",
+    "ctx-onnxruntime-freebsd-x64.tar.gz",
+)
+WINDOWS_RUNTIME_FILES = (
+    "LICENSE",
+    "ThirdPartyNotices.txt",
+    "VERSION_NUMBER",
+    "GIT_COMMIT_ID",
+    "MICROSOFT_VC_RUNTIME_LICENSE.rtf",
+    "lib/onnxruntime.dll",
+    "lib/msvcp140.dll",
+    "lib/msvcp140_1.dll",
+    "lib/vcruntime140.dll",
+    "lib/vcruntime140_1.dll",
+)
+RELEASE_AUTHORITY_CANDIDATES = (
+    "ctx.candidate.json",
+    "ctx-linux-aarch64.candidate.json",
+    "ctx-macos-arm64.candidate.json",
+    "ctx-macos-x64.candidate.json",
+    "ctx.exe.candidate.json",
+    "ctx-freebsd-x64.candidate.json",
+)
 
 
 class ReleaseSbomTest(unittest.TestCase):
@@ -47,6 +95,8 @@ class ReleaseSbomTest(unittest.TestCase):
         self.runfiles = self.root / "runfiles"
         self.main_runfiles = self.runfiles / "_main"
         self.main_runfiles.mkdir(parents=True)
+        self.target_id = "linux-x64"
+        self.platform = "linux-x64"
 
         self.artifact = self.root / "ctx"
         self.artifact.write_bytes(b"exact release artifact\n")
@@ -189,6 +239,12 @@ repository = "https://example.invalid/{name}"
         self.notices = self.root / "ctx.third-party-notices.txt"
         self.size_report = self.root / "ctx.size.json"
         self.candidate = self.root / "ctx.candidate.json"
+        self.release_sums = self.root / "SHA256SUMS"
+        self.runtime = self.root / "ctx-onnxruntime-windows-x64.zip"
+        self.bound_candidate = self.root / "ctx.release-candidate.json"
+        self.bound_digest = self.root / "ctx.release-candidate.json.sha256"
+        self.handoff = self.root / "release-authority-handoff"
+        self.expected_digest: str | None = None
 
     def tearDown(self) -> None:
         self.temporary.cleanup()
@@ -250,7 +306,11 @@ repository = "https://example.invalid/{name}"
         ]
         return "version = 4\n\n" + "\n\n".join(packages) + "\n"
 
-    def write_build_info(self) -> None:
+    def write_build_info(
+        self,
+        platform: str = "linux-x64",
+        target: str = "x86_64-unknown-linux-gnu",
+    ) -> None:
         self.build_info.write_text(
             json.dumps(
                 {
@@ -261,8 +321,8 @@ repository = "https://example.invalid/{name}"
                     "cargo_lock_sha256": hashlib.sha256(
                         self.cargo_lock.read_bytes()
                     ).hexdigest(),
-                    "platform": "linux-x64",
-                    "target": "x86_64-unknown-linux-gnu",
+                    "platform": platform,
+                    "target": target,
                     "source": {"commit": COMMIT, "clean": True},
                     "rust_version": "rustc 1.97.1 (test 2026-07-14)",
                     "builder": {
@@ -278,7 +338,130 @@ repository = "https://example.invalid/{name}"
             encoding="utf-8",
         )
 
+    def configure_windows_release(self) -> None:
+        self.target_id = "windows-x64"
+        self.platform = "windows-x64"
+        windows_artifact = self.root / "ctx.exe"
+        self.artifact.rename(windows_artifact)
+        self.artifact = windows_artifact
+        self.build_info = self.root / "ctx.exe.build-info.json"
+        self.sbom = self.root / "ctx.exe.cdx.json"
+        self.notices = self.root / "ctx.exe.third-party-notices.txt"
+        self.size_report = self.root / "ctx.exe.size.json"
+        self.candidate = self.root / "ctx.exe.candidate.json"
+        self.target_matrix.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "targets": [
+                        {
+                            "id": "windows-x64",
+                            "public_rust_target": "x86_64-pc-windows-gnu",
+                            "public_construction_authority": "bazel-release-route-v1",
+                            "public_construction_label": "//:ctx_release_windows_x64",
+                        }
+                    ],
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        self.write_build_info("windows-x64", "x86_64-pc-windows-gnu")
+        self.write_runtime()
+        self.write_release_sums()
+
+    def write_release_handoff(self) -> None:
+        self.handoff.mkdir()
+        copies = {
+            "ctx.exe": self.artifact,
+            "ctx.exe.build-info.json": self.build_info,
+            "ctx.exe.cdx.json": self.sbom,
+            "ctx.exe.size.json": self.size_report,
+            "ctx.exe.third-party-notices.txt": self.notices,
+            "SHA256SUMS": self.release_sums,
+            "ctx-onnxruntime-windows-x64.zip": self.runtime,
+            "ctx.exe.candidate.json": self.bound_candidate,
+            "ctx.exe.candidate.json.sha256": self.bound_digest,
+        }
+        for name, source in copies.items():
+            shutil.copyfile(source, self.handoff / name)
+        for name in RELEASE_AUTHORITY_CANDIDATES:
+            if name == "ctx.exe.candidate.json":
+                continue
+            payload = b"{}\n"
+            (self.handoff / name).write_bytes(payload)
+            (self.handoff / f"{name}.sha256").write_text(
+                hashlib.sha256(payload).hexdigest() + "\n", encoding="ascii"
+            )
+
+    def write_runtime(
+        self,
+        dll: bytes = b"exact Windows runtime DLL\n",
+        dll_name: str = "lib/onnxruntime.dll",
+        omit: str | None = None,
+        extra: str | None = None,
+    ) -> None:
+        with zipfile.ZipFile(
+            self.runtime, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9
+        ) as archive:
+            directory = zipfile.ZipInfo(
+                "lib/", date_time=(1980, 1, 1, 0, 0, 0)
+            )
+            directory.compress_type = zipfile.ZIP_DEFLATED
+            directory.external_attr = 0o40755 << 16
+            archive.writestr(directory, b"")
+            for name in WINDOWS_RUNTIME_FILES:
+                emitted_name = dll_name if name == "lib/onnxruntime.dll" else name
+                if emitted_name == omit:
+                    continue
+                record = zipfile.ZipInfo(
+                    emitted_name, date_time=(1980, 1, 1, 0, 0, 0)
+                )
+                record.compress_type = zipfile.ZIP_DEFLATED
+                record.external_attr = 0o100644 << 16
+                payload = dll if name == "lib/onnxruntime.dll" else f"{name}\n".encode()
+                archive.writestr(record, payload)
+            if extra is not None:
+                record = zipfile.ZipInfo(
+                    extra, date_time=(1980, 1, 1, 0, 0, 0)
+                )
+                record.compress_type = zipfile.ZIP_DEFLATED
+                record.external_attr = 0o100644 << 16
+                archive.writestr(record, b"unexpected\n")
+
+    def write_release_sums(self) -> None:
+        values = {
+            name: hashlib.sha256(f"synthetic {name}\n".encode()).hexdigest()
+            for name in LEGACY_RELEASE_ASSETS
+        }
+        values["ctx-windows-x64.exe"] = hashlib.sha256(
+            self.artifact.read_bytes()
+        ).hexdigest()
+        values["ctx-onnxruntime-windows-x64.zip"] = hashlib.sha256(
+            self.runtime.read_bytes()
+        ).hexdigest()
+        self.release_sums.write_text(
+            "".join(f"{values[name]}  {name}\n" for name in LEGACY_RELEASE_ASSETS),
+            encoding="ascii",
+        )
+
     def command(self, mode: str) -> list[str]:
+        if mode == "verify-release":
+            expected = self.expected_digest or self.bound_digest.read_text(
+                encoding="ascii"
+            ).strip()
+            return [
+                sys.executable,
+                "-I",
+                str(SCRIPT),
+                mode,
+                "--handoff-dir",
+                str(self.handoff),
+                "--expected-manifest-sha256",
+                expected,
+            ]
         command = [
             sys.executable,
             "-I",
@@ -289,17 +472,39 @@ repository = "https://example.invalid/{name}"
             "--build-info",
             str(self.build_info),
         ]
-        if mode == "verify-bundle":
-            return command + [
-                "--sbom",
-                str(self.sbom),
-                "--notices",
-                str(self.notices),
-                "--size-report",
-                str(self.size_report),
-                "--candidate-manifest",
-                str(self.candidate),
-            ]
+        if mode in ("verify-bundle", "bind-release"):
+            candidate = self.candidate
+            command.extend(
+                [
+                    "--sbom",
+                    str(self.sbom),
+                    "--notices",
+                    str(self.notices),
+                    "--size-report",
+                    str(self.size_report),
+                    "--candidate-manifest",
+                    str(candidate),
+                ]
+            )
+            if mode == "bind-release":
+                command.extend(
+                    [
+                        "--release-sums",
+                        str(self.release_sums),
+                        "--runtime-archive",
+                        str(self.runtime),
+                    ]
+                )
+            if mode == "bind-release":
+                command.extend(
+                    [
+                        "--output-manifest",
+                        str(self.bound_candidate),
+                        "--manifest-sha256-output",
+                        str(self.bound_digest),
+                    ]
+                )
+            return command
         command.extend(
             [
                 "--product",
@@ -307,9 +512,9 @@ repository = "https://example.invalid/{name}"
                 "--version",
                 "0.26.0",
                 "--target-id",
-                "linux-x64",
+                self.target_id,
                 "--platform",
-                "linux-x64",
+                self.platform,
                 "--cargo-lock",
                 str(self.cargo_lock),
                 "--module-lock",
@@ -519,6 +724,161 @@ repository = "https://example.invalid/{name}"
         rejected = self.run_command("verify-bundle", check=False)
         self.assertNotEqual(rejected.returncode, 0)
         self.assertIn("does not bind third_party_notices", rejected.stderr)
+
+    def test_windows_release_manifest_binds_sums_runtime_dll_and_authority(
+        self,
+    ) -> None:
+        self.configure_windows_release()
+        self.generate()
+        authority = self.run_command("bind-release").stdout.strip()
+        self.write_release_handoff()
+        self.assertEqual(authority, self.bound_digest.read_text().strip())
+        self.assertEqual(self.run_command("verify-release").stdout.strip(), authority)
+
+        candidate = json.loads(self.bound_candidate.read_bytes())
+        self.assertEqual(
+            candidate["release_sums"],
+            {
+                "file": "SHA256SUMS",
+                "sha256": hashlib.sha256(self.release_sums.read_bytes()).hexdigest(),
+                "size_bytes": self.release_sums.stat().st_size,
+            },
+        )
+        with zipfile.ZipFile(self.runtime) as archive:
+            dll = archive.read("lib/onnxruntime.dll")
+        self.assertEqual(
+            candidate["runtime"],
+            {
+                "file": "ctx-onnxruntime-windows-x64.zip",
+                "sha256": hashlib.sha256(self.runtime.read_bytes()).hexdigest(),
+                "size_bytes": self.runtime.stat().st_size,
+                "dll": {
+                    "file": "lib/onnxruntime.dll",
+                    "sha256": hashlib.sha256(dll).hexdigest(),
+                    "size_bytes": len(dll),
+                },
+            },
+        )
+
+        handoff_sums = self.handoff / "SHA256SUMS"
+        original_sums = handoff_sums.read_bytes()
+        lines = original_sums.decode("ascii").splitlines()
+        replacement = "0" if lines[0][0] != "0" else "1"
+        lines[0] = replacement + lines[0][1:]
+        handoff_sums.write_text("\n".join(lines) + "\n", encoding="ascii")
+        rejected = self.run_command("verify-release", check=False)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("does not bind exact release SHA256SUMS", rejected.stderr)
+        handoff_sums.write_bytes(original_sums)
+
+        self.write_runtime(b"X" * len(dll))
+        shutil.copyfile(
+            self.runtime, self.handoff / "ctx-onnxruntime-windows-x64.zip"
+        )
+        rejected = self.run_command("verify-release", check=False)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("does not bind exact Windows runtime and DLL", rejected.stderr)
+
+        # A complete caller-coordinated replacement remains unauthorized: even
+        # canonical regenerated manifest/sums/archive/DLL records cannot change
+        # the digest already committed by signed or attested release metadata.
+        original_authority = authority
+        self.write_release_sums()
+        self.bound_candidate.unlink()
+        self.bound_digest.unlink()
+        self.run_command("bind-release")
+        shutil.rmtree(self.handoff)
+        self.write_release_handoff()
+        self.expected_digest = original_authority
+        rejected = self.run_command("verify-release", check=False)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("independently supplied expected digest", rejected.stderr)
+
+    def test_verify_release_handoff_requires_exact_construction_names(self) -> None:
+        self.configure_windows_release()
+        self.generate()
+        authority = self.run_command("bind-release").stdout.strip()
+        self.write_release_handoff()
+
+        self.assertTrue((self.handoff / "ctx.exe").is_file())
+        self.assertFalse((self.handoff / "ctx-windows-x64.exe").exists())
+        self.assertIn(
+            "  ctx-windows-x64.exe\n",
+            (self.handoff / "SHA256SUMS").read_text(encoding="ascii"),
+        )
+        self.assertEqual(self.run_command("verify-release").stdout.strip(), authority)
+
+        (self.handoff / "ctx.exe").rename(
+            self.handoff / "ctx-windows-x64.exe"
+        )
+        rejected = self.run_command("verify-release", check=False)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("exact production inventory", rejected.stderr)
+
+    def test_verify_release_accepts_only_the_handoff_interface(self) -> None:
+        self.configure_windows_release()
+        self.generate()
+        self.run_command("bind-release")
+        self.write_release_handoff()
+        command = self.command("verify-release")
+        command.extend(("--artifact", str(self.artifact)))
+        rejected = subprocess.run(command, capture_output=True, text=True, check=False)
+        self.assertEqual(rejected.returncode, 2)
+        self.assertIn("only through --handoff-dir", rejected.stderr)
+
+    def test_windows_release_binding_requires_literal_outer_and_dll_names(self) -> None:
+        self.configure_windows_release()
+        self.generate()
+
+        renamed_sums = self.root / "OTHER_SUMS"
+        renamed_sums.write_bytes(self.release_sums.read_bytes())
+        command = self.command("bind-release")
+        command[command.index(str(self.release_sums))] = str(renamed_sums)
+        rejected = subprocess.run(command, capture_output=True, text=True, check=False)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("must be named SHA256SUMS", rejected.stderr)
+
+        renamed_runtime = self.root / "other-runtime.zip"
+        renamed_runtime.write_bytes(self.runtime.read_bytes())
+        command = self.command("bind-release")
+        command[command.index(str(self.runtime))] = str(renamed_runtime)
+        rejected = subprocess.run(command, capture_output=True, text=True, check=False)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("must be named ctx-onnxruntime-windows-x64.zip", rejected.stderr)
+
+        self.write_runtime(dll_name="lib/other.dll")
+        self.write_release_sums()
+        rejected = self.run_command("bind-release", check=False)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("unexpected entry lib/other.dll", rejected.stderr)
+
+    def test_windows_release_binding_requires_exact_runtime_and_sums_inventories(
+        self,
+    ) -> None:
+        self.configure_windows_release()
+        self.generate()
+
+        self.write_runtime(omit="lib/vcruntime140_1.dll")
+        self.write_release_sums()
+        rejected = self.run_command("bind-release", check=False)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("do not exactly match the legacy sidecar layout", rejected.stderr)
+
+        self.write_runtime(extra="lib/extra.dll")
+        self.write_release_sums()
+        rejected = self.run_command("bind-release", check=False)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("unexpected entry lib/extra.dll", rejected.stderr)
+
+        self.write_runtime()
+        self.write_release_sums()
+        lines = self.release_sums.read_text(encoding="ascii").splitlines()
+        self.release_sums.write_text(
+            "\n".join(reversed(lines)) + "\n", encoding="ascii"
+        )
+        rejected = self.run_command("bind-release", check=False)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("exact canonical 24- or 34-entry", rejected.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/stage-github-release-assets-test.sh
+++ b/scripts/tests/stage-github-release-assets-test.sh
@@ -81,6 +81,70 @@ case "$*" in
       exit 1
     fi
     ;;
+  *release-sbom.py\ bind-release*)
+    output_manifest=""
+    digest_output=""
+    artifact=""
+    build_info=""
+    sbom=""
+    notices=""
+    size_report=""
+    candidate_manifest=""
+    release_sums=""
+    runtime_archive=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --artifact|--build-info|--sbom|--notices|--size-report|--candidate-manifest|--release-sums|--runtime-archive)
+          option="$1"
+          shift
+          case "$option" in
+            --artifact) artifact="$1" ;;
+            --build-info) build_info="$1" ;;
+            --sbom) sbom="$1" ;;
+            --notices) notices="$1" ;;
+            --size-report) size_report="$1" ;;
+            --candidate-manifest) candidate_manifest="$1" ;;
+            --release-sums) release_sums="$1" ;;
+            --runtime-archive) runtime_archive="$1" ;;
+          esac
+          ;;
+        --output-manifest)
+          shift
+          output_manifest="$1"
+          ;;
+        --manifest-sha256-output)
+          shift
+          digest_output="$1"
+          ;;
+      esac
+      shift
+    done
+    [ -n "$output_manifest" ] && [ -n "$digest_output" ]
+    authority_root="$(dirname "${artifact:?}")"
+    case "$authority_root" in
+      */.github-release-authority.*) ;;
+      *)
+        printf 'release binder did not use the fresh authority handoff\n' >&2
+        exit 1
+        ;;
+    esac
+    [ "$(basename "$artifact")" = ctx.exe ]
+    [ "$(basename "$build_info")" = ctx.exe.build-info.json ]
+    [ "$(basename "$sbom")" = ctx.exe.cdx.json ]
+    [ "$(basename "$notices")" = ctx.exe.third-party-notices.txt ]
+    [ "$(basename "$size_report")" = ctx.exe.size.json ]
+    [ "$(basename "$candidate_manifest")" = .ctx.exe.candidate.base.json ]
+    [ "$(basename "$release_sums")" = SHA256SUMS ]
+    [ "$(basename "$runtime_archive")" = ctx-onnxruntime-windows-x64.zip ]
+    for handoff_input in \
+      "$build_info" "$sbom" "$notices" "$size_report" \
+      "$candidate_manifest" "$release_sums" "$runtime_archive"; do
+      [ "$(dirname "$handoff_input")" = "$authority_root" ]
+    done
+    printf '{"kind":"ctx-public-cli-candidate","release_sums":{},"runtime":{}}\n' \
+      >"$output_manifest"
+    sha256sum "$output_manifest" | awk '{print $1}' >"$digest_output"
+    ;;
   *release-sbom.py\ verify-bundle*)
     printf '%s\n' "$*" >> "${CTX_FAKE_SBOM_LOG:?}"
     ;;
@@ -341,12 +405,47 @@ CTX_FAKE_SBOM_LOG="${default_sbom_log}" \
   PATH="${fake_bin}:${PATH}" \
   /bin/bash "${stage}" "${matrix}" "${default_output}"
 assert_exact_assets "${default_output}" 24 "${default_assets[@]}"
+default_authority="${default_output}.authority"
+test "$(find "${default_authority}" -maxdepth 1 -type f | wc -l)" -eq 19
+for candidate in \
+  ctx.candidate.json \
+  ctx-linux-aarch64.candidate.json \
+  ctx-macos-arm64.candidate.json \
+  ctx-macos-x64.candidate.json \
+  ctx.exe.candidate.json \
+  ctx-freebsd-x64.candidate.json; do
+  test -s "${default_authority}/${candidate}"
+  test -s "${default_authority}/${candidate}.sha256"
+  test "$(sha256sum "${default_authority}/${candidate}" | awk '{print $1}')" = \
+    "$(cat "${default_authority}/${candidate}.sha256")"
+done
+grep -Fq '"release_sums"' "${default_authority}/ctx.exe.candidate.json"
+grep -Fq '"runtime"' "${default_authority}/ctx.exe.candidate.json"
+for handoff_input in \
+  ctx.exe \
+  ctx.exe.build-info.json \
+  ctx.exe.cdx.json \
+  ctx.exe.size.json \
+  ctx.exe.third-party-notices.txt \
+  SHA256SUMS \
+  ctx-onnxruntime-windows-x64.zip; do
+  test -s "${default_authority}/${handoff_input}"
+done
+test ! -e "${default_authority}/ctx-windows-x64.exe"
+cmp "${default_authority}/ctx.exe" "${default_output}/ctx-windows-x64.exe"
+cmp "${default_authority}/SHA256SUMS" "${default_output}/SHA256SUMS"
+cmp "${default_authority}/ctx-onnxruntime-windows-x64.zip" \
+  "${default_output}/ctx-onnxruntime-windows-x64.zip"
 test "$(wc -l < "${default_sbom_log}")" -eq 6
 test "$(wc -l < "${default_build_info_log}")" -eq 6
 test "$(grep -Fc -- "--source-commit ${source_commit}" "${default_build_info_log}")" -eq 6
 grep -Fq -- "--artifact ${tmp_dir}/.github-release-assets." \
   "${default_build_info_log}"
 grep -Fq -- "--artifact ${tmp_dir}/.github-release-assets." \
+  "${default_sbom_log}"
+grep -Fq -- "--artifact ${tmp_dir}/.github-release-authority." \
+  "${default_sbom_log}"
+grep -Fq -- "/ctx.exe --build-info ${tmp_dir}/.github-release-authority." \
   "${default_sbom_log}"
 grep -Fq -- "--sbom ${tmp_dir}/.github-release-assets." \
   "${default_sbom_log}"
@@ -361,6 +460,33 @@ CTX_FAKE_SBOM_LOG="${tmp_dir}/semantic-sbom.log" \
   /bin/bash "${stage}" \
   --with-semantic "${matrix}" "${semantic_output}"
 assert_exact_assets "${semantic_output}" 34 "${semantic_assets[@]}"
+test "$(find "${semantic_output}.authority" -maxdepth 1 -type f | wc -l)" -eq 19
+
+stale_authority="${tmp_dir}/stale-authority"
+mkdir "${stale_authority}"
+printf 'stale\n' >"${stale_authority}/unexpected"
+if CTX_REAL_PYTHON3="${real_python3}" PATH="${fake_bin}:${PATH}" \
+  /bin/bash "${stage}" "${matrix}" "${tmp_dir}/stale-output" \
+  "${stale_authority}" \
+  >"${tmp_dir}/stale.out" 2>"${tmp_dir}/stale.err"; then
+  printf 'GitHub stager reused a stale candidate authority directory\n' >&2
+  exit 1
+fi
+grep -Fq 'release publication destination already exists' \
+  "${tmp_dir}/stale.err"
+test ! -e "${tmp_dir}/stale-output"
+grep -Fqx stale "${stale_authority}/unexpected"
+
+if CTX_REAL_PYTHON3="${real_python3}" PATH="${fake_bin}:${PATH}" \
+  /bin/bash "${stage}" "${matrix}" "${tmp_dir}/aliased-output" \
+  "${tmp_dir}/aliased-output" \
+  >"${tmp_dir}/aliased.out" 2>"${tmp_dir}/aliased.err"; then
+  printf 'GitHub stager aliased release assets and candidate authority\n' >&2
+  exit 1
+fi
+grep -Fq 'release publication directories are invalid' \
+  "${tmp_dir}/aliased.err"
+test ! -e "${tmp_dir}/aliased-output"
 
 late_copy="${tmp_dir}/late-copy"
 cp -a "${matrix}" "${late_copy}"


### PR DESCRIPTION
Binds Windows release manifests, checksums, runtime archive, and DLL through the existing sealed-bundle authority. Adds an exact construction-named handoff and production verifier interface for independently authenticated manifest digests; sidecars remain non-authoritative.\n\nValidation: focused release/staging/construction/docs targets passed; independent security review approved. No parallel signer or proof layer.