### PR TITLE
test: harden local fixture paths

### DIFF
--- a/crates/ctx-history-capture/src/provider/providers/mistral_vibe/native_path/source_backed/publication_tests.rs
+++ b/crates/ctx-history-capture/src/provider/providers/mistral_vibe/native_path/source_backed/publication_tests.rs
@@ -131,10 +131,11 @@ fn url_and_stdio_transport_metadata_publish_terminal_content_without_mcp_identit
     .join("\n")
         + "\n";
     let temp = crate::test_support_paths::tempdir().unwrap();
-    write_session(temp.path(), &messages);
+    let source_root = temp.path().join("source");
+    write_session(&source_root, &messages);
 
-    let first = publish(temp.path(), &temp.path().join("index-a"));
-    let second = publish(temp.path(), &temp.path().join("index-b"));
+    let first = publish(&source_root, &temp.path().join("index-a"));
+    let second = publish(&source_root, &temp.path().join("index-b"));
     assert_eq!(first.len(), 4);
     assert_eq!(
         first
@@ -225,10 +226,11 @@ fn reused_tool_result_ids_keep_existing_native_and_collision_identities() {
     .join("\n")
         + "\n";
     let temp = crate::test_support_paths::tempdir().unwrap();
-    write_session(temp.path(), &messages);
+    let source_root = temp.path().join("source");
+    write_session(&source_root, &messages);
 
-    let first = publish(temp.path(), &temp.path().join("index-a"));
-    let second = publish(temp.path(), &temp.path().join("index-b"));
+    let first = publish(&source_root, &temp.path().join("index-a"));
+    let second = publish(&source_root, &temp.path().join("index-b"));
     assert_eq!(first.len(), 3);
     assert_eq!(
         first

--- a/scripts/tests/linux-bazel-release-controller-test.sh
+++ b/scripts/tests/linux-bazel-release-controller-test.sh
@@ -10,16 +10,20 @@ fi
 grep -Fq '{{printf "%s\t%s\t%s" .Architecture .ServerVersion .ID}}' \
   "${source_root}/scripts/release/run-linux-bazel-release-controller.sh"
 
-tmp_dir="$(mktemp -d)"
+tmp_dir=""
+socket_dir=""
 socket_pid=""
 cleanup() {
   if [[ -n "${socket_pid}" ]]; then
     kill "${socket_pid}" >/dev/null 2>&1 || true
     wait "${socket_pid}" >/dev/null 2>&1 || true
   fi
-  rm -rf "${tmp_dir}"
+  [[ -z "${tmp_dir}" ]] || rm -rf "${tmp_dir}"
+  [[ -z "${socket_dir}" ]] || rm -rf "${socket_dir}"
 }
 trap cleanup EXIT
+tmp_dir="$(mktemp -d)"
+socket_dir="$(mktemp -d /tmp/ctx-lbrc.XXXXXX)"
 
 fixture="${tmp_dir}/source"
 mkdir -p \
@@ -60,7 +64,7 @@ printf 'scanner\n' >"${tmp_dir}/advisory/osv-scanner"
 chmod 0755 "${tmp_dir}/advisory/osv-scanner"
 printf '{}\n' >"${tmp_dir}/advisory/database-metadata.json"
 
-socket_path="${tmp_dir}/docker.sock"
+socket_path="${socket_dir}/docker.sock"
 python3 - "${socket_path}" <<'PY' &
 import socket
 import sys


### PR DESCRIPTION
## Summary
- keep the fake Docker AF_UNIX socket under a short, unique `/tmp` path
- keep Mistral publication indexes outside the watched source fixture
- install cleanup before temporary-directory allocation

## Validation
- `bazel test //:linux_bazel_release_controller_tests //crates/ctx-history-capture:unit_tests`
- `bash -n scripts/tests/linux-bazel-release-controller-test.sh`
- `git diff --check`

A read-only subagent review found one temporary-directory cleanup edge case; it was fixed and the Linux target was rerun successfully.