### PR TITLE
Fix release test readiness and progress invariants

### DIFF
--- a/crates/ctx-cli/tests/persistent_daemon_lifecycle.rs
+++ b/crates/ctx-cli/tests/persistent_daemon_lifecycle.rs
@@ -274,8 +274,10 @@ mod native {
         let quiet_before = wait_for_stable_quiet_snapshot(&harness);
         let wakeup_before: Value = serde_json::from_slice(&quiet_before.wakeup.bytes).unwrap();
         assert_eq!(
-            wakeup_before["wakeup"]["timeout_wakeups"], 0,
-            "{wakeup_before:#}"
+            counter(&wakeup_before, "timeout_wakeups"),
+            counter(&wakeup_before, "scheduled_retry_wakeups")
+                .saturating_add(counter(&wakeup_before, "scheduled_refresh_wakeups")),
+            "startup observed an unclassified timeout wake: {wakeup_before:#}"
         );
         thread::sleep(QUIESCENT_WINDOW);
         assert!(

--- a/crates/ctx-cli/tests/setup_sources_import/import_orchestration.rs
+++ b/crates/ctx-cli/tests/setup_sources_import/import_orchestration.rs
@@ -99,6 +99,7 @@ fn start_full_source_refresh_daemon(temp: &TempDir) -> SourceRefreshDaemon {
             status["daemon"]["running"] == true
                 && status["daemon"]["pid"] == daemon_pid
                 && status["daemon"]["core_refresh_endpoint"]["available"] == true
+                && status["daemon"]["core_refresh_endpoint"]["owner_pid"] == daemon_pid
         }) {
             return daemon;
         }

--- a/scripts/tests/performance_family_runtime_test.py
+++ b/scripts/tests/performance_family_runtime_test.py
@@ -66,14 +66,10 @@ class SourceFamilyColdRefreshPerformanceTest(unittest.TestCase):
         self.assertEqual(job["status"], "completed")
         self.assertEqual(job["request_state"], "published")
         self.assertEqual(job["source_count"], 1)
-        self.assertEqual(
-            job["progress"],
-            {
-                "completed_sources": 1,
-                "phase": "published",
-                "total_sources": 1,
-            },
-        )
+        progress = job["progress"]
+        self.assertEqual(progress["phase"], "published")
+        self.assertEqual(progress["total_sources_known"], True)
+        self.assertEqual(progress["completed_sources"], progress["total_sources"])
         self.assertEqual(job["certified_source_count"], corpus.source_count)
         self.assertEqual(
             job["certified_source_bytes"], corpus.certified_source_bytes

--- a/scripts/tests/performance_sanity_test.py
+++ b/scripts/tests/performance_sanity_test.py
@@ -761,14 +761,10 @@ class TopProviderColdRefreshPerformanceTest(unittest.TestCase):
         self.assertEqual(job["status"], "completed")
         self.assertEqual(job["request_state"], "published")
         self.assertEqual(job["source_count"], TOP_PROVIDER_COUNT)
-        self.assertEqual(
-            job["progress"],
-            {
-                "completed_sources": TOP_PROVIDER_COUNT,
-                "phase": "published",
-                "total_sources": TOP_PROVIDER_COUNT,
-            },
-        )
+        progress = job["progress"]
+        self.assertEqual(progress["phase"], "published")
+        self.assertEqual(progress["total_sources_known"], True)
+        self.assertEqual(progress["completed_sources"], progress["total_sources"])
         self.assertTrue(job["generation_changed"])
         self.assertEqual(job["certified_source_count"], corpus.source_count)
         self.assertEqual(job["certified_source_bytes"], corpus.fixture_bytes)


### PR DESCRIPTION
## Summary

- require daemon endpoint ownership to match the newly spawned daemon before test replay
- accept only classified scheduled timeout wakeups during startup qualification
- assert terminal progress completion without coupling logical route progress to executed scans

## Validation

- //:performance_sanity_tests passed uncached
- //crates/ctx-cli:setup_sources_import_tests passed uncached
- //crates/ctx-cli:persistent_daemon_lifecycle_tests passed uncached
- independent review approved the final diff after one correction
