### PR TITLE
Fail open on ambiguous retrieval records

### DIFF
--- a/crates/ctx-history-capture/src/common/json.rs
+++ b/crates/ctx-history-capture/src/common/json.rs
@@ -1,5 +1,126 @@
+use std::{collections::BTreeSet, fmt};
+
+use serde::{
+    de::{MapAccess, SeqAccess, Visitor},
+    Deserialize, Deserializer,
+};
 use serde_json::{json, Value};
+
+/// Returns true only when `input` is one complete JSON value whose object keys
+/// are unique at every depth. The visitor retains no payload, so callers can
+/// establish structural authority without allocating a second value tree.
+pub(crate) fn raw_object_keys_are_unique(input: &[u8]) -> bool {
+    let mut deserializer = serde_json::Deserializer::from_slice(input);
+    if UniqueJsonShape::deserialize(&mut deserializer).is_err() {
+        return false;
+    }
+    deserializer.end().is_ok()
+}
+
+/// Parses one exact JSON value after the shared duplicate-key preflight.
+pub(crate) fn exact_value(input: &str) -> Option<Value> {
+    raw_object_keys_are_unique(input.as_bytes())
+        .then(|| serde_json::from_str(input).ok())
+        .flatten()
+}
+
+struct UniqueJsonShape;
+
+impl<'de> Deserialize<'de> for UniqueJsonShape {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(UniqueJsonShapeVisitor)
+    }
+}
+
+struct UniqueJsonShapeVisitor;
+
+impl<'de> Visitor<'de> for UniqueJsonShapeVisitor {
+    type Value = UniqueJsonShape;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("JSON without duplicate object keys")
+    }
+
+    fn visit_bool<E>(self, _value: bool) -> Result<Self::Value, E> {
+        Ok(UniqueJsonShape)
+    }
+
+    fn visit_i64<E>(self, _value: i64) -> Result<Self::Value, E> {
+        Ok(UniqueJsonShape)
+    }
+
+    fn visit_u64<E>(self, _value: u64) -> Result<Self::Value, E> {
+        Ok(UniqueJsonShape)
+    }
+
+    fn visit_f64<E>(self, _value: f64) -> Result<Self::Value, E> {
+        Ok(UniqueJsonShape)
+    }
+
+    fn visit_str<E>(self, _value: &str) -> Result<Self::Value, E> {
+        Ok(UniqueJsonShape)
+    }
+
+    fn visit_string<E>(self, _value: String) -> Result<Self::Value, E> {
+        Ok(UniqueJsonShape)
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(UniqueJsonShape)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(UniqueJsonShape)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        while sequence.next_element::<UniqueJsonShape>()?.is_some() {}
+        Ok(UniqueJsonShape)
+    }
+
+    fn visit_map<A>(self, mut object: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut keys = BTreeSet::new();
+        while let Some(key) = object.next_key::<String>()? {
+            if !keys.insert(key) {
+                return Err(serde::de::Error::custom("duplicate JSON object key"));
+            }
+            object.next_value::<UniqueJsonShape>()?;
+        }
+        Ok(UniqueJsonShape)
+    }
+}
 
 pub(crate) fn default_metadata() -> Value {
     json!({})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{exact_value, raw_object_keys_are_unique};
+
+    #[test]
+    fn exact_json_authority_rejects_duplicate_escaped_and_incomplete_values() {
+        let exact = br#"{"command":"ctx search exact","nested":{"key":1},"items":[null,true]}"#;
+        assert!(raw_object_keys_are_unique(exact));
+        assert!(exact_value(std::str::from_utf8(exact).unwrap()).is_some());
+        assert!(!raw_object_keys_are_unique(
+            br#"{"command":"ordinary","command":"ctx search secret"}"#,
+        ));
+        assert!(!raw_object_keys_are_unique(
+            br#"{"input":{"command":"ordinary","comm\u0061nd":"ctx search secret"}}"#,
+        ));
+        assert!(!raw_object_keys_are_unique(br#"{"command":}"#));
+        assert!(!raw_object_keys_are_unique(
+            br#"{"command":"ctx search exact"} trailing"#,
+        ));
+    }
 }

--- a/crates/ctx-history-capture/src/common/json.rs
+++ b/crates/ctx-history-capture/src/common/json.rs
@@ -1,17 +1,31 @@
 use std::{collections::BTreeSet, fmt};
 
 use serde::{
-    de::{MapAccess, SeqAccess, Visitor},
-    Deserialize, Deserializer,
+    de::{DeserializeSeed, MapAccess, SeqAccess, Visitor},
+    Deserializer,
 };
 use serde_json::{json, Value};
+
+/// Provider envelopes and tool payloads are far smaller than 65,536 object
+/// members. Keeping this limit high avoids excluding legitimate shapes while
+/// bounding the decoded keys retained by the structural-authority pass across
+/// every nested object in one record.
+const MAX_TOTAL_OBJECT_MEMBERS: usize = 65_536;
 
 /// Returns true only when `input` is one complete JSON value whose object keys
 /// are unique at every depth. The visitor retains no payload, so callers can
 /// establish structural authority without allocating a second value tree.
+/// Member-budget exhaustion returns false, leaving callers to ordinary
+/// discovery instead of rejecting the provider record.
 pub(crate) fn raw_object_keys_are_unique(input: &[u8]) -> bool {
     let mut deserializer = serde_json::Deserializer::from_slice(input);
-    if UniqueJsonShape::deserialize(&mut deserializer).is_err() {
+    let mut remaining_object_members = MAX_TOTAL_OBJECT_MEMBERS;
+    if (UniqueJsonShapeSeed {
+        remaining_object_members: &mut remaining_object_members,
+    })
+    .deserialize(&mut deserializer)
+    .is_err()
+    {
         return false;
     }
     deserializer.end().is_ok()
@@ -26,18 +40,28 @@ pub(crate) fn exact_value(input: &str) -> Option<Value> {
 
 struct UniqueJsonShape;
 
-impl<'de> Deserialize<'de> for UniqueJsonShape {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+struct UniqueJsonShapeSeed<'a> {
+    remaining_object_members: &'a mut usize,
+}
+
+impl<'de> DeserializeSeed<'de> for UniqueJsonShapeSeed<'_> {
+    type Value = UniqueJsonShape;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_any(UniqueJsonShapeVisitor)
+        deserializer.deserialize_any(UniqueJsonShapeVisitor {
+            remaining_object_members: self.remaining_object_members,
+        })
     }
 }
 
-struct UniqueJsonShapeVisitor;
+struct UniqueJsonShapeVisitor<'a> {
+    remaining_object_members: &'a mut usize,
+}
 
-impl<'de> Visitor<'de> for UniqueJsonShapeVisitor {
+impl<'de> Visitor<'de> for UniqueJsonShapeVisitor<'_> {
     type Value = UniqueJsonShape;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -80,7 +104,12 @@ impl<'de> Visitor<'de> for UniqueJsonShapeVisitor {
     where
         A: SeqAccess<'de>,
     {
-        while sequence.next_element::<UniqueJsonShape>()?.is_some() {}
+        while sequence
+            .next_element_seed(UniqueJsonShapeSeed {
+                remaining_object_members: &mut *self.remaining_object_members,
+            })?
+            .is_some()
+        {}
         Ok(UniqueJsonShape)
     }
 
@@ -90,10 +119,19 @@ impl<'de> Visitor<'de> for UniqueJsonShapeVisitor {
     {
         let mut keys = BTreeSet::new();
         while let Some(key) = object.next_key::<String>()? {
+            let Some(remaining_object_members) = self.remaining_object_members.checked_sub(1)
+            else {
+                return Err(serde::de::Error::custom(
+                    "JSON object member limit exceeded",
+                ));
+            };
+            *self.remaining_object_members = remaining_object_members;
             if !keys.insert(key) {
                 return Err(serde::de::Error::custom("duplicate JSON object key"));
             }
-            object.next_value::<UniqueJsonShape>()?;
+            object.next_value_seed(UniqueJsonShapeSeed {
+                remaining_object_members: &mut *self.remaining_object_members,
+            })?;
         }
         Ok(UniqueJsonShape)
     }
@@ -105,7 +143,38 @@ pub(crate) fn default_metadata() -> Value {
 
 #[cfg(test)]
 mod tests {
-    use super::{exact_value, raw_object_keys_are_unique};
+    use std::fmt::Write as _;
+
+    use super::{exact_value, raw_object_keys_are_unique, MAX_TOTAL_OBJECT_MEMBERS};
+
+    fn nested_objects_with_total_members(total_member_count: usize) -> String {
+        const MEMBERS_PER_NESTED_OBJECT: usize = 256;
+
+        assert!(total_member_count >= 1);
+        let nested_member_count = total_member_count - 1;
+        let mut input =
+            String::with_capacity(total_member_count.saturating_mul(14).saturating_add(16));
+        input.push_str("{\"groups\":[");
+        let mut written_members = 0;
+        while written_members < nested_member_count {
+            if written_members != 0 {
+                input.push(',');
+            }
+            input.push('{');
+            let members_in_object =
+                (nested_member_count - written_members).min(MEMBERS_PER_NESTED_OBJECT);
+            for member in 0..members_in_object {
+                if member != 0 {
+                    input.push(',');
+                }
+                write!(input, "\"key{member}\":null").unwrap();
+            }
+            input.push('}');
+            written_members += members_in_object;
+        }
+        input.push_str("]}");
+        input
+    }
 
     #[test]
     fn exact_json_authority_rejects_duplicate_escaped_and_incomplete_values() {
@@ -122,5 +191,18 @@ mod tests {
         assert!(!raw_object_keys_are_unique(
             br#"{"command":"ctx search exact"} trailing"#,
         ));
+    }
+
+    #[test]
+    fn exact_json_authority_accepts_the_nested_total_object_member_limit() {
+        let input = nested_objects_with_total_members(MAX_TOTAL_OBJECT_MEMBERS);
+        assert!(raw_object_keys_are_unique(input.as_bytes()));
+    }
+
+    #[test]
+    fn exact_json_authority_abstains_when_nested_maps_exceed_the_total_member_limit() {
+        let input = nested_objects_with_total_members(MAX_TOTAL_OBJECT_MEMBERS + 1);
+        assert!(!raw_object_keys_are_unique(input.as_bytes()));
+        assert!(exact_value(&input).is_none());
     }
 }

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/project.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/project.rs
@@ -110,7 +110,8 @@ impl CodexNativeScanner {
                     return Ok(CodexRecordProjection::default());
                 };
                 let mut built =
-                    match build_source_backed_event_row(self.raw_ordinal, kind, &retained)? {
+                    match build_source_backed_event_row(self.raw_ordinal, kind, &retained, record)?
+                    {
                         Ok(built) => built,
                         Err(CodexRetainedNonMaterialized::ValidUnmaterializable) => {
                             self.counters.ignored_records =

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/project/mcp.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/project/mcp.rs
@@ -98,6 +98,11 @@ impl CodexMcpTerminalAuthority {
         state.after_certified_prefix |= !in_certified_prefix;
     }
 
+    pub(in super::super) fn observe_ambiguous_result_terminal(&mut self) {
+        self.result_call_ids.clear();
+        self.result_exhausted = true;
+    }
+
     pub(super) fn is_unique(&self, call_id: &str) -> bool {
         !self.mcp_exhausted
             && self

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/project/mcp_exchange.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/project/mcp_exchange.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashSet, fmt};
+use std::{borrow::Cow, fmt};
 
 use serde::{
     de::{MapAccess, SeqAccess, Visitor},
@@ -8,6 +8,7 @@ use serde_json::{value::RawValue, Map, Value};
 
 use super::mcp::BoundedStringProbe;
 use super::*;
+use crate::common::json::exact_value as exact_json_value;
 
 pub(super) struct ProjectedMcpExchange {
     content: ctx_history_core::McpExchangeContent,
@@ -1124,100 +1125,6 @@ impl<'de> Visitor<'de> for BoolProbeVisitor {
             .is_some()
         {}
         Ok(BoolProbe(None))
-    }
-}
-
-/// Parses one JSON value and rejects duplicate keys at every object depth.
-fn exact_json_value(input: &str) -> Option<Value> {
-    let mut deserializer = serde_json::Deserializer::from_str(input);
-    let value = NoDuplicateJson::deserialize(&mut deserializer).ok()?.0;
-    deserializer.end().ok()?;
-    Some(value)
-}
-
-struct NoDuplicateJson(Value);
-
-impl<'de> Deserialize<'de> for NoDuplicateJson {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_any(NoDuplicateJsonVisitor)
-    }
-}
-
-struct NoDuplicateJsonVisitor;
-
-impl<'de> Visitor<'de> for NoDuplicateJsonVisitor {
-    type Value = NoDuplicateJson;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("JSON without duplicate object keys")
-    }
-
-    fn visit_bool<E>(self, value: bool) -> std::result::Result<Self::Value, E> {
-        Ok(NoDuplicateJson(Value::Bool(value)))
-    }
-
-    fn visit_i64<E>(self, value: i64) -> std::result::Result<Self::Value, E> {
-        Ok(NoDuplicateJson(Value::Number(value.into())))
-    }
-
-    fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E> {
-        Ok(NoDuplicateJson(Value::Number(value.into())))
-    }
-
-    fn visit_f64<E>(self, value: f64) -> std::result::Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        serde_json::Number::from_f64(value)
-            .map(Value::Number)
-            .map(NoDuplicateJson)
-            .ok_or_else(|| E::custom("non-finite JSON number"))
-    }
-
-    fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E> {
-        Ok(NoDuplicateJson(Value::String(value.to_owned())))
-    }
-
-    fn visit_string<E>(self, value: String) -> std::result::Result<Self::Value, E> {
-        Ok(NoDuplicateJson(Value::String(value)))
-    }
-
-    fn visit_none<E>(self) -> std::result::Result<Self::Value, E> {
-        Ok(NoDuplicateJson(Value::Null))
-    }
-
-    fn visit_unit<E>(self) -> std::result::Result<Self::Value, E> {
-        Ok(NoDuplicateJson(Value::Null))
-    }
-
-    fn visit_seq<A>(self, mut sequence: A) -> std::result::Result<Self::Value, A::Error>
-    where
-        A: SeqAccess<'de>,
-    {
-        let mut values = Vec::new();
-        while let Some(value) = sequence.next_element::<NoDuplicateJson>()? {
-            values.push(value.0);
-        }
-        Ok(NoDuplicateJson(Value::Array(values)))
-    }
-
-    fn visit_map<A>(self, mut object: A) -> std::result::Result<Self::Value, A::Error>
-    where
-        A: MapAccess<'de>,
-    {
-        let mut keys = HashSet::new();
-        let mut values = Map::new();
-        while let Some(key) = object.next_key::<String>()? {
-            if !keys.insert(key.clone()) {
-                return Err(serde::de::Error::custom("duplicate JSON object key"));
-            }
-            let value = object.next_value::<NoDuplicateJson>()?;
-            values.insert(key, value.0);
-        }
-        Ok(NoDuplicateJson(Value::Object(values)))
     }
 }
 

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/scanner.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/scanner.rs
@@ -14,23 +14,22 @@ fn result_terminal_authority_is_ambiguous(record: &[u8]) -> bool {
     if record.first() == Some(&0) {
         return false;
     }
-    if crate::common::json::raw_object_keys_are_unique(record) {
-        return false;
+    !crate::common::json::raw_object_keys_are_unique(record)
+}
+
+#[cfg(test)]
+mod terminal_authority_tests {
+    use super::result_terminal_authority_is_ambiguous;
+
+    #[test]
+    fn duplicate_selector_cannot_hide_terminal_authority() {
+        assert!(result_terminal_authority_is_ambiguous(
+            br#"{"type":"response_item","payload":{"type":"function_call_output","call_id":"call","output":"hidden"},"payload":{"type":"message","role":"user","content":[]}}"#,
+        ));
+        assert!(!result_terminal_authority_is_ambiguous(
+            br#"{"type":"response_item","payload":{"type":"message","role":"user","content":[]}}"#,
+        ));
     }
-    let Ok(envelope) = serde_json::from_slice::<Value>(record) else {
-        return true;
-    };
-    let Some(record_type) = envelope.get("type").and_then(Value::as_str) else {
-        return false;
-    };
-    let item_type = envelope
-        .get("payload")
-        .and_then(|payload| payload.get("type"))
-        .and_then(Value::as_str);
-    matches!(
-        codex_record_class(record_type, item_type),
-        CodexRecordClass::ExcludedResult(_)
-    )
 }
 
 fn observe_result_terminal_call_id(

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/scanner.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/scanner.rs
@@ -8,6 +8,31 @@ struct McpTerminalAuthorityPreflight {
     peak_record_bytes: usize,
 }
 
+fn result_terminal_authority_is_ambiguous(record: &[u8]) -> bool {
+    // Codex treats a NUL-prefixed suffix as framing corruption, not a JSON
+    // record candidate. Preserve that dedicated append-boundary diagnosis.
+    if record.first() == Some(&0) {
+        return false;
+    }
+    if crate::common::json::raw_object_keys_are_unique(record) {
+        return false;
+    }
+    let Ok(envelope) = serde_json::from_slice::<Value>(record) else {
+        return true;
+    };
+    let Some(record_type) = envelope.get("type").and_then(Value::as_str) else {
+        return false;
+    };
+    let item_type = envelope
+        .get("payload")
+        .and_then(|payload| payload.get("type"))
+        .and_then(Value::as_str);
+    matches!(
+        codex_record_class(record_type, item_type),
+        CodexRecordClass::ExcludedResult(_)
+    )
+}
+
 fn observe_result_terminal_call_id(
     authority: &mut CodexMcpTerminalAuthority,
     record: &[u8],
@@ -94,6 +119,9 @@ fn preflight_mcp_terminal_authority(
         let record = trim_jsonl_terminator(&record_buffer[..record_read.stored_len]);
         let in_certified_prefix =
             certified_prefix_end.is_some_and(|prefix_end| offset <= prefix_end);
+        if result_terminal_authority_is_ambiguous(record) {
+            authority.observe_ambiguous_result_terminal();
+        }
         if let Some(evidence) = mcp_terminal_candidate_evidence(record) {
             authority.observe(&evidence, in_certified_prefix);
         }

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/scanner.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/scanner.rs
@@ -112,7 +112,11 @@ fn preflight_mcp_terminal_authority(
         if !record_read.complete {
             break;
         }
-        if record_read.oversized || record_read.terminal_nul_padding {
+        if record_read.terminal_nul_padding {
+            continue;
+        }
+        if record_read.oversized {
+            authority.observe_ambiguous_result_terminal();
             continue;
         }
         let record = trim_jsonl_terminator(&record_buffer[..record_read.stored_len]);

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/rows.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/rows.rs
@@ -315,10 +315,12 @@ pub(super) fn build_source_backed_event_row(
     raw_ordinal: u64,
     kind: CodexRetainedKind,
     retained: &CodexDecodedRecord,
+    raw_record: &[u8],
 ) -> CaptureResult<std::result::Result<CodexSourceBackedBuiltRowV0, CodexRetainedNonMaterialized>> {
     let discovery_exclusion = (kind == CodexRetainedKind::ToolCall)
         .then(|| codex_tool_call_discovery_exclusion(&retained.payload))
-        .flatten();
+        .flatten()
+        .filter(|_| crate::common::json::raw_object_keys_are_unique(raw_record));
     let semantic = match source_backed_semantic_projection(kind, &retained.payload) {
         SourceBackedSemanticProjection::Materialized(semantic) => *semantic,
         SourceBackedSemanticProjection::ValidUnmaterializable => {

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed.rs
@@ -70,7 +70,7 @@ const CODEX_SOURCE_SCHEMA_VARIANT: &str = "codex-nativepath-jsonl-v0";
 const CODEX_SOURCE_REVISION_KIND: &str = "codex-ordinary-file-observation-v1";
 const CODEX_FRONTIER_KIND: &str = "codex-nativepath-checkpoint-v9";
 const CODEX_PARSER_REVISION: &str =
-    "codex-nativepath-core-record-v19-lineage-evidence-source-unique-result-exclusion";
+    "codex-nativepath-core-record-v20-exact-retrieval-json-authority";
 #[cfg(test)]
 const CODEX_INVENTORY_AUTHORITY_NAMESPACE: &str = "codex.sessions-root";
 #[cfg(test)]

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/migration.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/migration.rs
@@ -78,7 +78,7 @@ fn v8_frontier_and_v11_parser_generation_is_rebuilt_to_current_authority() {
 }
 
 #[test]
-fn retrieval_exclusion_rebuilds_current_main_v18_parser_generation() {
+fn exact_retrieval_json_authority_rebuilds_v19_parser_generation() {
     let temp = tempfile::tempdir().unwrap();
     let sessions = temp.path().join("sessions");
     let index = temp.path().join("global-index");
@@ -97,7 +97,7 @@ fn retrieval_exclusion_rebuilds_current_main_v18_parser_generation() {
     let old_certificate = CertifiedSource::certify_with_frontier(
         current_certificate.observation().clone(),
         current_certificate.observation().clone(),
-        "codex-nativepath-core-record-v18-lineage-evidence-authority",
+        "codex-nativepath-core-record-v19-lineage-evidence-source-unique-result-exclusion",
         *current_certificate.content_digest(),
         current_certificate.counts(),
         current_certificate.frontier().cloned(),
@@ -120,7 +120,7 @@ fn retrieval_exclusion_rebuilds_current_main_v18_parser_generation() {
     let certificate = &old.manifest().sources[0];
     assert_eq!(
         certificate.parser_revision(),
-        "codex-nativepath-core-record-v18-lineage-evidence-authority"
+        "codex-nativepath-core-record-v19-lineage-evidence-source-unique-result-exclusion"
     );
     assert_eq!(
         certificate.frontier().unwrap().checkpoint_kind(),

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/projection.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/projection.rs
@@ -293,6 +293,147 @@ fn appended_duplicate_ctx_result_retracts_prior_exclusion_and_preserves_identiti
 }
 
 #[test]
+fn trailing_malformed_terminal_makes_an_earlier_ctx_result_searchable() {
+    let temp = tempfile::tempdir().unwrap();
+    let sessions = temp.path().join("sessions");
+    let index = temp.path().join("global-index");
+    fs::create_dir_all(&sessions).unwrap();
+    let native_session_id = "019fa000-0000-7000-8000-000000000099";
+    let call_id = "ctx-retrieval-trailing-terminal";
+    let output = concat!(
+        "Chunk ID: 9abc03\n",
+        "Wall time: 0.125 seconds\n",
+        "Process exited with code 0\n",
+        "Final output:\n",
+        "prior authoritative payload"
+    );
+    let result = serde_json::json!({
+        "timestamp": "2025-03-07T16:00:01Z",
+        "type": "response_item",
+        "payload": {
+            "type": "function_call_output",
+            "call_id": call_id,
+            "output": output,
+        },
+    })
+    .to_string();
+    let trailing = format!("{result} trailing terminal bytes");
+    write_session(
+        &sessions,
+        native_session_id,
+        &[
+            exec_call(call_id, "ctx search trailing-terminal", temp.path()),
+            result,
+            trailing,
+        ],
+    );
+
+    ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+    let source = codex_source_key(native_session_id).unwrap();
+    let session_id = codex_session_identity(&source, native_session_id).unwrap();
+    let verified = VerifiedIndex::open(&index).unwrap();
+    let invocation = outcome_for_sequence(&verified, session_id, 1);
+    let retained_result = outcome_for_sequence(&verified, session_id, 2);
+
+    assert_eq!(
+        invocation.content.discovery_exclusion,
+        Some(ctx_history_core::CoreDiscoveryExclusion::CtxRetrievalDerived)
+    );
+    assert_eq!(retained_result.content.discovery_exclusion, None);
+    assert_eq!(
+        retained_result.content.normalized_body.as_deref(),
+        Some(output)
+    );
+}
+
+#[test]
+fn appended_duplicate_member_terminal_retracts_prior_ctx_result_exclusion() {
+    let temp = tempfile::tempdir().unwrap();
+    let sessions = temp.path().join("sessions");
+    let index = temp.path().join("global-index");
+    fs::create_dir_all(&sessions).unwrap();
+    let native_session_id = "019fa000-0000-7000-8000-00000000009a";
+    let call_id = "ctx-retrieval-ambiguous-terminal";
+    let first_output = concat!(
+        "Chunk ID: 9abc04\n",
+        "Wall time: 0.125 seconds\n",
+        "Process exited with code 0\n",
+        "Final output:\n",
+        "first authoritative payload"
+    );
+    let second_output = concat!(
+        "Chunk ID: 9abc05\n",
+        "Wall time: 0.250 seconds\n",
+        "Process exited with code 0\n",
+        "Final output:\n",
+        "ambiguous duplicate-member payload"
+    );
+    let first_result = serde_json::json!({
+        "timestamp": "2025-03-07T16:00:01Z",
+        "type": "response_item",
+        "payload": {
+            "type": "function_call_output",
+            "call_id": call_id,
+            "output": first_output,
+        },
+    })
+    .to_string();
+    write_session(
+        &sessions,
+        native_session_id,
+        &[
+            exec_call(call_id, "ctx search ambiguous-terminal", temp.path()),
+            first_result,
+        ],
+    );
+
+    ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+    let source = codex_source_key(native_session_id).unwrap();
+    let session_id = codex_session_identity(&source, native_session_id).unwrap();
+    let initial = VerifiedIndex::open(&index).unwrap();
+    let initial_invocation_id = outcome_for_sequence(&initial, session_id, 1).event_id;
+    let initial_result = outcome_for_sequence(&initial, session_id, 2);
+    assert_eq!(
+        initial_result.content.discovery_exclusion,
+        Some(ctx_history_core::CoreDiscoveryExclusion::CtxRetrievalDerived)
+    );
+    let initial_result_id = initial_result.event_id;
+    drop(initial);
+
+    let ambiguous_result = format!(
+        r#"{{"timestamp":"2025-03-07T16:00:02Z","type":"response_item","payload":{{"type":"function_call_output","call_id":"{call_id}","output":"discarded duplicate member","output":{}}}}}"#,
+        serde_json::to_string(second_output).unwrap(),
+    );
+    let mut file = OpenOptions::new()
+        .append(true)
+        .open(session_path(&sessions, native_session_id))
+        .unwrap();
+    writeln!(file, "{ambiguous_result}").unwrap();
+    drop(file);
+
+    let receipt = ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+    assert_eq!(receipt.counters.appended_sources, 0);
+    assert_eq!(receipt.counters.replaced_sources, 1);
+    let verified = VerifiedIndex::open(&index).unwrap();
+    let invocation = outcome_for_sequence(&verified, session_id, 1);
+    let first = outcome_for_sequence(&verified, session_id, 2);
+    let ambiguous = outcome_for_sequence(&verified, session_id, 3);
+    assert_eq!(invocation.event_id, initial_invocation_id);
+    assert_eq!(first.event_id, initial_result_id);
+    assert_eq!(
+        invocation.content.discovery_exclusion,
+        Some(ctx_history_core::CoreDiscoveryExclusion::CtxRetrievalDerived)
+    );
+    assert_eq!(first.content.discovery_exclusion, None);
+    assert_eq!(ambiguous.content.discovery_exclusion, None);
+    assert_eq!(first.content.normalized_body.as_deref(), Some(first_output));
+    assert_eq!(
+        ambiguous.content.normalized_body.as_deref(),
+        Some(second_output)
+    );
+}
+
+#[test]
 fn codex_exact_commit_result_publishes_scoped_outcome_and_complete_raw_output() {
     use ctx_history_core::{RepositoryOutcomeKind, RepositoryVcsObservationKind};
 

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/projection.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/projection.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::provider::codex::nativepath::tests::discover_one;
+use crate::provider::codex::nativepath::{tests::discover_one, MAX_CODEX_RECORD_BYTES};
 use serde_json::Value;
 
 mod repository_outcome_regressions;
@@ -63,6 +63,28 @@ fn exec_call_at(timestamp: &str, call_id: &str, command: &str, workdir: &Path) -
 
 pub(super) fn successful_result(call_id: &str, output: Value) -> String {
     successful_result_at("2026-07-28T12:00:02Z", call_id, output)
+}
+
+fn oversized_result(call_id: &str) -> String {
+    let mut record = format!(
+        r#"{{"timestamp":"2026-07-28T12:00:03Z","type":"response_item","payload":{{"type":"function_call_output","call_id":"{call_id}","output":""#,
+    );
+    record.push_str(&"x".repeat(MAX_CODEX_RECORD_BYTES));
+    record.push_str("\"}}");
+    record
+}
+
+fn exact_exec_result(call_id: &str, output: &str) -> String {
+    serde_json::json!({
+        "timestamp": "2026-07-28T12:00:02Z",
+        "type": "response_item",
+        "payload": {
+            "type": "function_call_output",
+            "call_id": call_id,
+            "output": output,
+        }
+    })
+    .to_string()
 }
 
 fn successful_result_at(timestamp: &str, call_id: &str, output: Value) -> String {
@@ -289,6 +311,104 @@ fn appended_duplicate_ctx_result_retracts_prior_exclusion_and_preserves_identiti
     assert_eq!(
         second.content.normalized_body.as_deref(),
         Some(second_output)
+    );
+}
+
+#[test]
+fn cold_oversized_terminal_makes_an_earlier_ctx_result_searchable() {
+    let temp = tempfile::tempdir().unwrap();
+    let sessions = temp.path().join("sessions");
+    let index = temp.path().join("global-index");
+    fs::create_dir_all(&sessions).unwrap();
+    let native_session_id = "019fa000-0000-7000-8000-00000000009b";
+    let call_id = "ctx-retrieval-oversized-cold";
+    let output = concat!(
+        "Chunk ID: 9abc0c\n",
+        "Wall time: 0.125 seconds\n",
+        "Process exited with code 0\n",
+        "Final output:\n",
+        "prior cold oversized authority payload"
+    );
+    write_session(
+        &sessions,
+        native_session_id,
+        &[
+            exec_call(call_id, "ctx search oversized-cold", temp.path()),
+            exact_exec_result(call_id, output),
+            oversized_result(call_id),
+        ],
+    );
+
+    ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+    let source = codex_source_key(native_session_id).unwrap();
+    let session_id = codex_session_identity(&source, native_session_id).unwrap();
+    let verified = VerifiedIndex::open(&index).unwrap();
+    let invocation = outcome_for_sequence(&verified, session_id, 1);
+    let retained_result = outcome_for_sequence(&verified, session_id, 2);
+
+    assert_eq!(
+        invocation.content.discovery_exclusion,
+        Some(ctx_history_core::CoreDiscoveryExclusion::CtxRetrievalDerived)
+    );
+    assert_eq!(retained_result.content.discovery_exclusion, None);
+    assert_eq!(
+        retained_result.content.normalized_body.as_deref(),
+        Some(output)
+    );
+}
+
+#[test]
+fn appended_oversized_terminal_retracts_prior_ctx_result_exclusion() {
+    let temp = tempfile::tempdir().unwrap();
+    let sessions = temp.path().join("sessions");
+    let index = temp.path().join("global-index");
+    fs::create_dir_all(&sessions).unwrap();
+    let native_session_id = "019fa000-0000-7000-8000-00000000009c";
+    let call_id = "ctx-retrieval-oversized-append";
+    let output = concat!(
+        "Chunk ID: 9abc0a\n",
+        "Wall time: 0.125 seconds\n",
+        "Process exited with code 0\n",
+        "Final output:\n",
+        "prior append oversized authority payload"
+    );
+    write_session(
+        &sessions,
+        native_session_id,
+        &[
+            exec_call(call_id, "ctx search oversized-append", temp.path()),
+            exact_exec_result(call_id, output),
+        ],
+    );
+
+    ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+    let source = codex_source_key(native_session_id).unwrap();
+    let session_id = codex_session_identity(&source, native_session_id).unwrap();
+    let initial = VerifiedIndex::open(&index).unwrap();
+    assert_eq!(
+        outcome_for_sequence(&initial, session_id, 2)
+            .content
+            .discovery_exclusion,
+        Some(ctx_history_core::CoreDiscoveryExclusion::CtxRetrievalDerived)
+    );
+    drop(initial);
+
+    let mut file = OpenOptions::new()
+        .append(true)
+        .open(session_path(&sessions, native_session_id))
+        .unwrap();
+    writeln!(file, "{}", oversized_result(call_id)).unwrap();
+    drop(file);
+
+    let receipt = ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+    assert_eq!(receipt.counters.appended_sources, 0);
+    assert_eq!(receipt.counters.replaced_sources, 1);
+    let verified = VerifiedIndex::open(&index).unwrap();
+    let retained_result = outcome_for_sequence(&verified, session_id, 2);
+    assert_eq!(retained_result.content.discovery_exclusion, None);
+    assert_eq!(
+        retained_result.content.normalized_body.as_deref(),
+        Some(output)
     );
 }
 

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/projection.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/projection.rs
@@ -175,6 +175,38 @@ fn codex_ctx_retrieval_invocation_and_exact_result_persist_exclusion_with_comple
 }
 
 #[test]
+fn codex_duplicate_raw_tool_members_remain_searchable() {
+    let temp = tempfile::tempdir().unwrap();
+    let sessions = temp.path().join("sessions");
+    let index = temp.path().join("global-index");
+    fs::create_dir_all(&sessions).unwrap();
+    let native_session_id = "019fa000-0000-7000-8000-000000000097";
+    let arguments = serde_json::json!({
+        "cmd": "ctx search ambiguous-duplicate-member",
+        "workdir": temp.path(),
+    })
+    .to_string();
+    let raw_call = format!(
+        r#"{{"timestamp":"2026-08-05T16:00:01Z","type":"response_item","payload":{{"type":"function_call","name":"ordinary","name":"exec_command","call_id":"duplicate-member-call","arguments":{}}}}}"#,
+        serde_json::to_string(&arguments).unwrap(),
+    );
+    write_session(&sessions, native_session_id, &[raw_call]);
+
+    ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+    let source = codex_source_key(native_session_id).unwrap();
+    let session_id = codex_session_identity(&source, native_session_id).unwrap();
+    let verified = VerifiedIndex::open(&index).unwrap();
+    let invocation = outcome_for_sequence(&verified, session_id, 1);
+
+    assert!(invocation
+        .content
+        .normalized_body
+        .as_deref()
+        .is_some_and(|body| body.contains("ctx search ambiguous-duplicate-member")));
+    assert_eq!(invocation.content.discovery_exclusion, None);
+}
+
+#[test]
 fn appended_duplicate_ctx_result_retracts_prior_exclusion_and_preserves_identities() {
     let temp = tempfile::tempdir().unwrap();
     let sessions = temp.path().join("sessions");

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/tests/profiles.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/tests/profiles.rs
@@ -871,8 +871,8 @@ fn synthetic_adversarial_fixture_requires_source_unique_terminal_authority() {
 
     assert_eq!(scan.counters.rejected_complete_records, 0);
     assert_eq!(sink.rows.len(), 14);
-    assert_eq!(scan.counters.peak_mcp_terminal_authority_entries, 20);
-    assert!(scan.counters.peak_mcp_terminal_authority_bytes > 20 * 32);
+    assert_eq!(scan.counters.peak_mcp_terminal_authority_entries, 10);
+    assert!(scan.counters.peak_mcp_terminal_authority_bytes > 10 * 32);
     for marker in [
         "AMBIGUOUS_MCP_RESULT",
         "DUPLICATE_SAME_FIRST",

--- a/crates/ctx-history-capture/src/provider/providers/claude/nativepath/record.rs
+++ b/crates/ctx-history-capture/src/provider/providers/claude/nativepath/record.rs
@@ -230,6 +230,7 @@ impl SafeContent {
                     ),
                     file_touches: safe_file_touches(&block.input, block.name.as_deref()),
                     exact_file_invocations,
+                    retrieval_input_ambiguous: false,
                     input: block.input,
                 });
             }
@@ -572,7 +573,7 @@ fn parse_native_record_inner(
         let metadata: MetadataOnlyRecord = serde_json::from_slice(bytes)?;
         let outputs = output_descriptors(&preflight, bytes, &record_outcome)?;
         let value: Value = serde_json::from_slice(bytes)?;
-        let rows = complete_output_rows(
+        let mut rows = complete_output_rows(
             raw_ordinal,
             locator,
             metadata.uuid.clone(),
@@ -580,6 +581,11 @@ fn parse_native_record_inner(
             &outputs,
             &value,
         );
+        if !crate::common::json::raw_object_keys_are_unique(bytes) {
+            for result in rows.iter_mut().filter_map(|row| row.tool_result.as_mut()) {
+                result.retrieval_input_ambiguous = true;
+            }
+        }
         validate_row_count(&rows)?;
         return Ok(ParsedClaudeRecord {
             session_id: metadata.session_id,
@@ -597,7 +603,14 @@ fn parse_native_record_inner(
     let cwd = record.cwd.clone();
     let version = record.version.clone();
     let git_branch = record.git_branch.clone();
-    let rows = retain_safe_record(record, raw_ordinal, locator);
+    let mut rows = retain_safe_record(record, raw_ordinal, locator);
+    if rows.iter().any(|row| row.tool_call.is_some())
+        && !crate::common::json::raw_object_keys_are_unique(bytes)
+    {
+        for call in rows.iter_mut().filter_map(|row| row.tool_call.as_mut()) {
+            call.retrieval_input_ambiguous = true;
+        }
+    }
     validate_row_count(&rows)?;
     Ok(ParsedClaudeRecord {
         session_id,

--- a/crates/ctx-history-capture/src/provider/providers/claude/nativepath/record/value_decoding.rs
+++ b/crates/ctx-history-capture/src/provider/providers/claude/nativepath/record/value_decoding.rs
@@ -102,6 +102,7 @@ pub(super) fn complete_output_rows(
                     content,
                     tool_use_result: tool_use_result.cloned(),
                     discovery_evidence,
+                    retrieval_input_ambiguous: false,
                 }),
                 locator: locator.clone(),
             }

--- a/crates/ctx-history-capture/src/provider/providers/claude/nativepath/rows.rs
+++ b/crates/ctx-history-capture/src/provider/providers/claude/nativepath/rows.rs
@@ -70,6 +70,11 @@ pub(crate) struct ToolCallRequest {
     // compatibility digest.
     #[serde(skip)]
     pub(crate) exact_file_invocations: ClaudeExactFileInvocations,
+    // Projection-only authority bit. Raw duplicate JSON members are lost when
+    // `input` becomes a `serde_json::Value`, so ambiguous provider records may
+    // be retained but must not suppress themselves from retrieval.
+    #[serde(skip)]
+    pub(crate) retrieval_input_ambiguous: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -103,6 +108,8 @@ pub(crate) struct ClaudeToolResult {
     // provider content continue to depend only on the complete native body.
     #[serde(skip)]
     pub(crate) discovery_evidence: ClaudeDiscoveryResultEvidence,
+    #[serde(skip)]
+    pub(crate) retrieval_input_ambiguous: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ctx-history-capture/src/provider/providers/claude/nativepath/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/providers/claude/nativepath/source_backed.rs
@@ -371,19 +371,14 @@ fn preflight_claude_result_terminals(
             };
             let exact_json_authority =
                 crate::common::json::raw_object_keys_are_unique(record.bytes());
+            if !exact_json_authority {
+                authority.observe_ambiguous_terminal();
+            }
             let parsed =
                 match parse_native_record(record.bytes(), evidence.physical_ordinal(), &locator) {
                     Ok(parsed) => parsed,
-                    Err(_) => {
-                        if !exact_json_authority {
-                            authority.observe_ambiguous_terminal();
-                        }
-                        return Ok(());
-                    }
+                    Err(_) => return Ok(()),
                 };
-            if !exact_json_authority && parsed.rows.iter().any(|row| row.tool_result.is_some()) {
-                authority.observe_ambiguous_terminal();
-            }
             let in_certified_prefix = certified_prefix_end
                 .is_some_and(|prefix_end| evidence.byte_end_exclusive() <= prefix_end);
             for call_id in parsed.rows.iter().filter_map(|row| {

--- a/crates/ctx-history-capture/src/provider/providers/claude/nativepath/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/providers/claude/nativepath/source_backed.rs
@@ -129,6 +129,12 @@ impl ClaudeResultTerminalAuthority {
                 state.in_certified_prefix && state.after_certified_prefix && state.candidates > 1
             })
     }
+
+    fn observe_ambiguous_terminal(&mut self) {
+        self.available = true;
+        self.call_ids.clear();
+        self.exhausted = true;
+    }
 }
 
 fn claude_source_backed_adapter() -> Arc<dyn JsonlFamilyAdapter> {
@@ -363,11 +369,21 @@ fn preflight_claude_result_terminals(
                 line_number: evidence.physical_ordinal().saturating_add(1),
                 record_sha256: evidence.record_digest(),
             };
-            let Ok(parsed) =
-                parse_native_record(record.bytes(), evidence.physical_ordinal(), &locator)
-            else {
-                return Ok(());
-            };
+            let exact_json_authority =
+                crate::common::json::raw_object_keys_are_unique(record.bytes());
+            let parsed =
+                match parse_native_record(record.bytes(), evidence.physical_ordinal(), &locator) {
+                    Ok(parsed) => parsed,
+                    Err(_) => {
+                        if !exact_json_authority {
+                            authority.observe_ambiguous_terminal();
+                        }
+                        return Ok(());
+                    }
+                };
+            if !exact_json_authority && parsed.rows.iter().any(|row| row.tool_result.is_some()) {
+                authority.observe_ambiguous_terminal();
+            }
             let in_certified_prefix = certified_prefix_end
                 .is_some_and(|prefix_end| evidence.byte_end_exclusive() <= prefix_end);
             for call_id in parsed.rows.iter().filter_map(|row| {

--- a/crates/ctx-history-capture/src/provider/providers/claude/nativepath/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/providers/claude/nativepath/source_backed.rs
@@ -58,7 +58,7 @@ const FALLBACK_EVENT_ID_DOMAIN: &[u8] = b"ctx-claude-fallback-event-id-v1\0";
 const LOGICAL_SESSION_KIND: &str = "claude-session";
 const LOGICAL_EVENT_KIND: &str = "claude-event";
 const SOURCE_SCHEMA_VARIANT: &str = "claude-nativepath-jsonl-v6";
-const PARSER_REVISION: &str = "claude-shared-jsonl-v8-source-unique-result-exclusion";
+const PARSER_REVISION: &str = "claude-shared-jsonl-v9-exact-retrieval-json-authority";
 const MAX_PENDING_CALLS: usize = 4096;
 const MAX_RESULT_METADATA_BYTES: usize = 64 * 1024;
 const RESULT_TERMINAL_CALL_ID_DOMAIN: &[u8] = b"ctx/claude-nativepath/result-terminal-call-id/v1\0";
@@ -700,6 +700,9 @@ impl JsonlFamilyProjector for ClaudeProjector {
 }
 
 fn claude_call_contribution(call: &ToolCallRequest) -> ContributionClass {
+    if call.retrieval_input_ambiguous {
+        return ContributionClass::Unknown;
+    }
     let Some(tool_name) = call.tool_name.as_deref() else {
         return ContributionClass::Unknown;
     };
@@ -716,6 +719,9 @@ fn claude_result_contribution(
     result: &super::rows::ClaudeToolResult,
     context: Option<&PendingCall>,
 ) -> ContributionClass {
+    if result.retrieval_input_ambiguous {
+        return ContributionClass::Unknown;
+    }
     let linked_invocation = context
         .filter(|context| context.ctx_retrieval_derived)
         .map(|_| ContributionClass::RetrievalDerived);

--- a/crates/ctx-history-capture/src/provider/providers/claude/nativepath/source_backed/tests.rs
+++ b/crates/ctx-history-capture/src/provider/providers/claude/nativepath/source_backed/tests.rs
@@ -888,6 +888,58 @@ fn claude_ctx_retrieval_cli_mcp_and_success_payloads_are_excluded_without_body_l
 }
 
 #[test]
+fn claude_duplicate_raw_tool_members_remain_searchable() {
+    let record = br#"{"type":"assistant","uuid":"duplicate-command","sessionId":"test-session","message":{"role":"assistant","content":[{"type":"tool_use","id":"duplicate-command-call","name":"Bash","input":{"command":"ordinary command","command":"ctx search ambiguous-duplicate-member"}}]}}"#.to_vec();
+
+    let records = project_claude_records(&mut test_projector(), &[record]);
+
+    assert_eq!(records.len(), 1);
+    assert!(records[0]
+        .content
+        .normalized_body
+        .as_deref()
+        .is_some_and(|body| body.contains("ctx search ambiguous-duplicate-member")));
+    assert_eq!(records[0].content.discovery_exclusion, None);
+}
+
+#[test]
+fn claude_duplicate_raw_result_members_remain_searchable() {
+    let call = claude_ctx_call(
+        "duplicate-result-member",
+        "Bash",
+        serde_json::json!({"command": "ctx search ambiguous-duplicate-result"}),
+    );
+    let result = br#"{"type":"user","uuid":"duplicate-result-member","sessionId":"test-session","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"duplicate-result-member","content":{"result":"ordinary payload","result":"ambiguous duplicate payload"},"is_error":false}]}}"#.to_vec();
+
+    let records = project_claude_records(&mut test_projector(), &[call, result]);
+
+    assert_eq!(
+        records
+            .iter()
+            .filter(|record| {
+                record.content.discovery_exclusion
+                    == Some(CoreDiscoveryExclusion::CtxRetrievalDerived)
+            })
+            .count(),
+        1
+    );
+    let retained_results = records
+        .iter()
+        .filter(|record| {
+            record
+                .content
+                .normalized_body
+                .as_deref()
+                .is_some_and(|body| body.contains("ambiguous duplicate payload"))
+        })
+        .collect::<Vec<_>>();
+    assert!(!retained_results.is_empty());
+    assert!(retained_results
+        .iter()
+        .all(|record| record.content.discovery_exclusion.is_none()));
+}
+
+#[test]
 fn claude_duplicate_result_terminals_fail_open_without_retracting_invocation_exclusion() {
     let call = claude_ctx_call(
         "duplicate-result",

--- a/crates/ctx-history-capture/src/provider/providers/claude/nativepath/source_backed/tests.rs
+++ b/crates/ctx-history-capture/src/provider/providers/claude/nativepath/source_backed/tests.rs
@@ -1065,6 +1065,180 @@ fn claude_late_duplicate_result_forces_replacement_and_retracts_prior_exclusion(
 }
 
 #[test]
+fn claude_trailing_malformed_terminal_makes_an_earlier_result_searchable() {
+    let temp = tempfile::tempdir().unwrap();
+    let projects = temp.path().join("projects");
+    let transcript = projects
+        .join("project")
+        .join("trailing-terminal-session.jsonl");
+    let index = temp.path().join("index");
+    let native_session_id = "trailing-terminal-session";
+    let call_id = "trailing-terminal-result";
+    let call = serde_json::json!({
+        "type": "assistant",
+        "uuid": "trailing-terminal-call",
+        "sessionId": native_session_id,
+        "message": {"role": "assistant", "content": [{
+            "type": "tool_use",
+            "id": call_id,
+            "name": "Bash",
+            "input": {"command": "ctx search trailing-terminal"}
+        }]},
+    });
+    let result = serde_json::json!({
+        "type": "user",
+        "uuid": "trailing-terminal-first",
+        "sessionId": native_session_id,
+        "message": {"role": "user", "content": [{
+            "type": "tool_result",
+            "tool_use_id": call_id,
+            "content": "prior authoritative Claude payload",
+            "is_error": false
+        }]},
+    });
+    write_claude_transcript(&transcript, &[call, result.clone()]);
+    let mut file = OpenOptions::new().append(true).open(&transcript).unwrap();
+    serde_json::to_writer(&mut file, &result).unwrap();
+    file.write_all(b" trailing terminal bytes\n").unwrap();
+    file.sync_all().unwrap();
+
+    let registry = claude_test_registry(&projects);
+    refresh_source_backed_generation(&index, &registry, claude_test_writer_options()).unwrap();
+    let records = indexed_claude_records(&index, native_session_id);
+
+    assert_eq!(records.len(), 2);
+    let invocation = records
+        .iter()
+        .find(|record| {
+            record
+                .content
+                .normalized_body
+                .as_deref()
+                .is_some_and(|body| body.contains("ctx search trailing-terminal"))
+        })
+        .unwrap();
+    let retained_result = records
+        .iter()
+        .find(|record| {
+            record.content.normalized_body.as_deref() == Some("prior authoritative Claude payload")
+        })
+        .unwrap();
+    assert_eq!(
+        invocation.content.discovery_exclusion,
+        Some(CoreDiscoveryExclusion::CtxRetrievalDerived)
+    );
+    assert_eq!(retained_result.content.discovery_exclusion, None);
+}
+
+#[test]
+fn claude_appended_duplicate_member_terminal_retracts_prior_result_exclusion() {
+    let temp = tempfile::tempdir().unwrap();
+    let projects = temp.path().join("projects");
+    let transcript = projects
+        .join("project")
+        .join("ambiguous-terminal-session.jsonl");
+    let index = temp.path().join("index");
+    let native_session_id = "ambiguous-terminal-session";
+    let call_id = "ambiguous-terminal-result";
+    let call = serde_json::json!({
+        "type": "assistant",
+        "uuid": "ambiguous-terminal-call",
+        "sessionId": native_session_id,
+        "message": {"role": "assistant", "content": [{
+            "type": "tool_use",
+            "id": call_id,
+            "name": "Bash",
+            "input": {"command": "ctx search ambiguous-terminal"}
+        }]},
+    });
+    let first_result = serde_json::json!({
+        "type": "user",
+        "uuid": "ambiguous-terminal-first",
+        "sessionId": native_session_id,
+        "message": {"role": "user", "content": [{
+            "type": "tool_result",
+            "tool_use_id": call_id,
+            "content": "first authoritative Claude payload",
+            "is_error": false
+        }]},
+    });
+    write_claude_transcript(&transcript, &[call, first_result]);
+    let registry = claude_test_registry(&projects);
+
+    refresh_source_backed_generation(&index, &registry, claude_test_writer_options()).unwrap();
+    let initial = indexed_claude_records(&index, native_session_id);
+    assert_eq!(initial.len(), 2);
+    assert!(initial.iter().all(|record| {
+        record.content.discovery_exclusion == Some(CoreDiscoveryExclusion::CtxRetrievalDerived)
+    }));
+    let initial_invocation = initial
+        .iter()
+        .find(|record| {
+            record
+                .content
+                .normalized_body
+                .as_deref()
+                .is_some_and(|body| body.contains("ctx search ambiguous-terminal"))
+        })
+        .unwrap();
+    let initial_result = initial
+        .iter()
+        .find(|record| {
+            record.content.normalized_body.as_deref() == Some("first authoritative Claude payload")
+        })
+        .unwrap();
+
+    let ambiguous_result = format!(
+        r#"{{"type":"user","uuid":"ambiguous-terminal-second","sessionId":"{native_session_id}","message":{{"role":"user","content":[{{"type":"tool_result","tool_use_id":"{call_id}","content":{{"result":"discarded duplicate member","result":"ambiguous duplicate-member Claude payload"}},"is_error":false}}]}}}}"#,
+    );
+    let mut file = OpenOptions::new().append(true).open(&transcript).unwrap();
+    file.write_all(ambiguous_result.as_bytes()).unwrap();
+    file.write_all(b"\n").unwrap();
+    file.sync_all().unwrap();
+
+    refresh_source_backed_generation(&index, &registry, claude_test_writer_options()).unwrap();
+    let corrected = indexed_claude_records(&index, native_session_id);
+    assert!(corrected.len() >= 3);
+    let corrected_invocation = corrected
+        .iter()
+        .find(|record| {
+            record
+                .content
+                .normalized_body
+                .as_deref()
+                .is_some_and(|body| body.contains("ctx search ambiguous-terminal"))
+        })
+        .unwrap();
+    let corrected_result = corrected
+        .iter()
+        .find(|record| {
+            record.content.normalized_body.as_deref() == Some("first authoritative Claude payload")
+        })
+        .unwrap();
+    assert_eq!(corrected_invocation.event_id, initial_invocation.event_id);
+    assert_eq!(corrected_result.event_id, initial_result.event_id);
+    assert_eq!(
+        corrected_invocation.content.discovery_exclusion,
+        Some(CoreDiscoveryExclusion::CtxRetrievalDerived)
+    );
+    assert_eq!(corrected_result.content.discovery_exclusion, None);
+    let ambiguous = corrected
+        .iter()
+        .filter(|record| {
+            record
+                .content
+                .normalized_body
+                .as_deref()
+                .is_some_and(|body| body.contains("ambiguous duplicate-member Claude payload"))
+        })
+        .collect::<Vec<_>>();
+    assert!(!ambiguous.is_empty());
+    assert!(ambiguous
+        .iter()
+        .all(|record| record.content.discovery_exclusion.is_none()));
+}
+
+#[test]
 fn claude_ctx_retrieval_results_fail_open_for_every_unproven_or_diagnostic_envelope() {
     let payload = "searchable diagnostic payload";
     let cases = [

--- a/crates/ctx-history-capture/src/provider/providers/gemini/nativepath/parser.rs
+++ b/crates/ctx-history-capture/src/provider/providers/gemini/nativepath/parser.rs
@@ -219,7 +219,11 @@ impl GeminiBorrowedRecordParser {
             byte_length: byte_end_exclusive.saturating_sub(byte_start),
             record_digest,
         };
-        let events = match class {
+        let exact_json_authority = !matches!(
+            class,
+            GeminiRecordClass::ToolCall | GeminiRecordClass::Result
+        ) || crate::common::json::raw_object_keys_are_unique(payload);
+        let mut events = match class {
             GeminiRecordClass::Result => {
                 let decoded = match decode_result_record(payload, raw_ordinal, source_record) {
                     Ok(decoded) => decoded,
@@ -271,6 +275,21 @@ impl GeminiBorrowedRecordParser {
             }
             GeminiRecordClass::Ignored | GeminiRecordClass::Header => Vec::new(),
         };
+        if !exact_json_authority {
+            for event in &mut events {
+                match class {
+                    GeminiRecordClass::ToolCall => event
+                        .extra_body_contributions
+                        .push(ContributionClass::Unknown),
+                    GeminiRecordClass::Result => event.result_atoms.push(ResultAtom::Unknown),
+                    GeminiRecordClass::Header
+                    | GeminiRecordClass::Message
+                    | GeminiRecordClass::StateNotice
+                    | GeminiRecordClass::RewindNotice
+                    | GeminiRecordClass::Ignored => {}
+                }
+            }
+        }
         if let Some(native_event_id) = native_event_id {
             self.page_native_event_ids
                 .commit_at(native_event_id, raw_ordinal);
@@ -290,6 +309,14 @@ impl GeminiBorrowedRecordParser {
             })
         }
     }
+}
+
+pub(crate) fn gemini_result_terminal_authority_is_ambiguous(payload: &[u8]) -> bool {
+    if crate::common::json::raw_object_keys_are_unique(payload) {
+        return false;
+    }
+    serde_json::from_slice::<GeminiRecordProbe>(payload)
+        .map_or(true, |probe| probe.classify() == GeminiRecordClass::Result)
 }
 
 /// Reads only through the first importable header. This is the bounded

--- a/crates/ctx-history-capture/src/provider/providers/gemini/nativepath/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/providers/gemini/nativepath/source_backed.rs
@@ -20,7 +20,10 @@ use thiserror::Error;
 
 use super::dto::{GeminiEventBody, GeminiTranscriptLayout};
 use super::file_invocation::extract_gemini_file_invocations;
-use super::parser::{read_gemini_session_header, GeminiBorrowedRecordParser};
+use super::parser::{
+    gemini_result_terminal_authority_is_ambiguous, read_gemini_session_header,
+    GeminiBorrowedRecordParser,
+};
 use super::{
     discover_gemini_transcripts, GeminiFileObservation, GeminiScanError, GeminiSession,
     GeminiTranscriptSource,
@@ -51,7 +54,7 @@ const GEMINI_LOGICAL_SESSION_KIND: &str = "gemini-session";
 const GEMINI_LOGICAL_EVENT_KIND: &str = "gemini-event";
 const GEMINI_SOURCE_SCHEMA_VARIANT: &str = "gemini-nativepath-jsonl-v0";
 const GEMINI_SOURCE_BACKED_PARSER_REVISION: &str =
-    "gemini-nativepath-source-backed-v2-session-lineage-source-unique-result-exclusion";
+    "gemini-nativepath-source-backed-v3-exact-retrieval-json-authority";
 const MAX_GEMINI_LEXICAL_METADATA_CHARS: usize = 8 * 1024;
 const MAX_GEMINI_REPOSITORY_FIELD_CHARS: usize = 64 * 1024;
 const MAX_GEMINI_TOOL_CONTEXTS: usize = 256;
@@ -155,6 +158,12 @@ impl GeminiResultTerminalAuthority {
                     .call_ids
                     .get(&gemini_result_terminal_call_id_digest(call_id))
                     .is_some_and(|candidates| *candidates == 1))
+    }
+
+    fn observe_ambiguous_terminal(&mut self) {
+        self.available = true;
+        self.call_ids.clear();
+        self.exhausted = true;
     }
 }
 
@@ -334,6 +343,9 @@ fn preflight_gemini_result_terminals(
     while reader
         .visit_page(&mut |record: JsonlRecordRef<'_>| -> crate::Result<()> {
             let evidence = record.evidence();
+            if gemini_result_terminal_authority_is_ambiguous(record.bytes()) {
+                authority.observe_ambiguous_terminal();
+            }
             let events = parser
                 .project(
                     record.bytes(),

--- a/crates/ctx-history-capture/src/provider/providers/gemini/nativepath/tests/retrieval_exclusion.rs
+++ b/crates/ctx-history-capture/src/provider/providers/gemini/nativepath/tests/retrieval_exclusion.rs
@@ -150,6 +150,90 @@ fn duplicate_result_terminals_fail_open_including_the_earlier_result() {
 }
 
 #[test]
+fn malformed_duplicate_result_terminal_invalidates_source_wide_uniqueness() {
+    use crate::provider::source_backed::refresh_source_backed_generation;
+
+    let temp = TempDir::new().unwrap();
+    let root = fixture_root(&temp);
+    let path = transcript_path(&root);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let mut bytes = jsonl(&[
+        header("gemini-malformed-duplicate-terminal", "main"),
+        json!({
+            "id": "call-record",
+            "timestamp": "2026-01-01T00:00:01Z",
+            "type": "gemini",
+            "toolCalls": [{
+                "id": "duplicate-terminal-call",
+                "name": "run_shell_command",
+                "args": {"command": "ctx search malformed-duplicate-terminal"}
+            }]
+        }),
+        json!({
+            "id": "first-result-record",
+            "timestamp": "2026-01-01T00:00:02Z",
+            "type": "gemini",
+            "toolCalls": [{
+                "id": "duplicate-terminal-call",
+                "name": "run_shell_command",
+                "result": {"content": "first authoritative payload", "exitCode": 0}
+            }]
+        }),
+    ]);
+    bytes.extend_from_slice(
+        br#"{"id":"malformed-result-record","timestamp":"2026-01-01T00:00:03Z","type":"gemini","toolCalls":[{"id":"other-call","id":"duplicate-terminal-call","name":"run_shell_command","result":{"content":"ambiguous duplicate terminal payload","exitCode":0}}]}"#,
+    );
+    bytes.push(b'\n');
+    std::fs::write(&path, bytes).unwrap();
+
+    let registry = registry(&root);
+    let index = temp.path().join("index");
+    refresh_source_backed_generation(
+        &index,
+        &registry,
+        ctx_history_index::WriterOptions {
+            indexer_threads: 1,
+            memory_bytes: 15_000_000,
+        },
+    )
+    .unwrap();
+    let records = indexed_records(&index);
+
+    assert_eq!(records.len(), 3);
+    let record_with_body = |needle: &str| {
+        records
+            .iter()
+            .find(|record| {
+                record
+                    .content
+                    .normalized_body
+                    .as_deref()
+                    .is_some_and(|body| body.contains(needle))
+            })
+            .unwrap()
+    };
+    assert!(excluded(record_with_body(
+        "ctx search malformed-duplicate-terminal"
+    )));
+    assert!(!excluded(record_with_body("first authoritative payload")));
+    assert!(!excluded(record_with_body(
+        "ambiguous duplicate terminal payload"
+    )));
+}
+
+#[test]
+fn malformed_terminal_candidates_poison_result_uniqueness_authority() {
+    use super::super::parser::gemini_result_terminal_authority_is_ambiguous;
+
+    assert!(gemini_result_terminal_authority_is_ambiguous(
+        br#"{"type":"gemini","toolCalls":[{"id":"call","result":{"content":"payload"}}]} trailing"#,
+    ));
+    assert!(gemini_result_terminal_authority_is_ambiguous(
+        br#"{"type":"gemini","toolCalls":[],"toolCalls":[{"id":"call","result":{"content":"payload"}}]}"#,
+    ));
+}
+
+#[test]
 fn late_duplicate_result_replacement_corrects_the_earlier_result() {
     use crate::provider::source_backed::refresh_source_backed_generation;
 

--- a/crates/ctx-history-capture/src/provider/providers/openclaw/native_path/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/providers/openclaw/native_path/source_backed.rs
@@ -58,8 +58,7 @@ const FALLBACK_EVENT_ID_DOMAIN: &[u8] = b"ctx-openclaw-fallback-event-id-v1\0";
 const LOGICAL_SESSION_KIND: &str = "openclaw-legacy-session";
 const LOGICAL_EVENT_KIND: &str = "openclaw-legacy-event";
 const SOURCE_SCHEMA_VARIANT: &str = "openclaw-legacy-jsonl-v2";
-const PARSER_REVISION: &str =
-    "openclaw-source-backed-v10-lineage-authority-source-wide-result-authority";
+const PARSER_REVISION: &str = "openclaw-source-backed-v11-exact-retrieval-json-authority";
 const MAX_PENDING_CALLS: usize = 4096;
 const MAX_RUNNING_PROCESSES: usize = 256;
 const MAX_TERMINAL_CALL_IDS: usize = 4096;

--- a/crates/ctx-history-capture/src/provider/providers/openclaw/native_path/source_backed/native.rs
+++ b/crates/ctx-history-capture/src/provider/providers/openclaw/native_path/source_backed/native.rs
@@ -44,6 +44,26 @@ impl OpenClawTerminalAuthority {
         *count = count.saturating_add(1).min(2);
     }
 
+    fn observe_ambiguous_terminal(&mut self) {
+        self.call_ids.clear();
+        self.exhausted = true;
+    }
+
+    fn observe_record(&mut self, record: &[u8]) {
+        let exact_json_authority = crate::common::json::raw_object_keys_are_unique(record);
+        let Ok(value) = serde_json::from_slice::<Value>(record) else {
+            self.observe_ambiguous_terminal();
+            return;
+        };
+        let result = native_tool_result(&value);
+        if !exact_json_authority && result.is_some() {
+            self.observe_ambiguous_terminal();
+        }
+        if let Some(call_id) = result.and_then(|result| result.call_id) {
+            self.observe(call_id);
+        }
+    }
+
     pub(super) fn is_unique(&self, call_id: &str) -> bool {
         if !self.complete {
             return true;
@@ -95,12 +115,7 @@ pub(super) fn terminal_authority_for_source(
     let mut authority = OpenClawTerminalAuthority::for_scan();
     while reader
         .visit_page(&mut |record| -> Result<()> {
-            let Ok(value) = serde_json::from_slice::<Value>(record.bytes()) else {
-                return Ok(());
-            };
-            if let Some(call_id) = native_tool_result(&value).and_then(|result| result.call_id) {
-                authority.observe(call_id);
-            }
+            authority.observe_record(record.bytes());
             Ok(())
         })?
         .is_some()
@@ -122,6 +137,17 @@ pub(super) fn terminal_authority_for_values<'a>(
         if let Some(call_id) = native_tool_result(value).and_then(|result| result.call_id) {
             authority.observe(call_id);
         }
+    }
+    authority
+}
+
+#[cfg(test)]
+pub(super) fn terminal_authority_for_records<'a>(
+    records: impl IntoIterator<Item = &'a [u8]>,
+) -> OpenClawTerminalAuthority {
+    let mut authority = OpenClawTerminalAuthority::for_scan();
+    for record in records {
+        authority.observe_record(record);
     }
     authority
 }

--- a/crates/ctx-history-capture/src/provider/providers/openclaw/native_path/source_backed/native.rs
+++ b/crates/ctx-history-capture/src/provider/providers/openclaw/native_path/source_backed/native.rs
@@ -51,14 +51,13 @@ impl OpenClawTerminalAuthority {
 
     fn observe_record(&mut self, record: &[u8]) {
         let exact_json_authority = crate::common::json::raw_object_keys_are_unique(record);
-        let Ok(value) = serde_json::from_slice::<Value>(record) else {
+        if !exact_json_authority {
             self.observe_ambiguous_terminal();
+        }
+        let Ok(value) = serde_json::from_slice::<Value>(record) else {
             return;
         };
         let result = native_tool_result(&value);
-        if !exact_json_authority && result.is_some() {
-            self.observe_ambiguous_terminal();
-        }
         if let Some(call_id) = result.and_then(|result| result.call_id) {
             self.observe(call_id);
         }

--- a/crates/ctx-history-capture/src/provider/providers/openclaw/native_path/source_backed/projection.rs
+++ b/crates/ctx-history-capture/src/provider/providers/openclaw/native_path/source_backed/projection.rs
@@ -368,8 +368,11 @@ impl OpenClawProjector {
         let linked_invocation = context
             .as_ref()
             .map(|context| ctx_retrieval::ContributionClass::from(context.retrieval_contribution));
-        let result_contribution =
-            classify_openclaw_tool_result(source_value, result, linked_invocation);
+        let result_contribution = if crate::common::json::raw_object_keys_are_unique(source_bytes) {
+            classify_openclaw_tool_result(source_value, result, linked_invocation)
+        } else {
+            ctx_retrieval::ContributionClass::Unknown
+        };
         let Some(mut context) = context else {
             return (None, Some(result_contribution));
         };
@@ -829,7 +832,11 @@ impl JsonlFamilyProjector for OpenClawProjector {
         );
         let tool_calls = native_tool_calls(&value);
         if !tool_calls.is_empty() {
-            let source_contribution = self.tool_call_source_contribution(&value, &tool_calls);
+            let source_contribution = if crate::common::json::raw_object_keys_are_unique(bytes) {
+                self.tool_call_source_contribution(&value, &tool_calls)
+            } else {
+                ctx_retrieval::ContributionClass::Unknown
+            };
             let mut call_id_counts = HashMap::<&str, usize>::new();
             for call_id in tool_calls.iter().filter_map(|call| call.call_id) {
                 *call_id_counts.entry(call_id).or_default() += 1;

--- a/crates/ctx-history-capture/src/provider/providers/openclaw/native_path/source_backed/tests.rs
+++ b/crates/ctx-history-capture/src/provider/providers/openclaw/native_path/source_backed/tests.rs
@@ -384,6 +384,88 @@ fn openclaw_duplicate_raw_result_members_remain_searchable() {
 }
 
 #[test]
+fn openclaw_ambiguous_terminal_exhausts_source_wide_result_uniqueness() {
+    let call = serde_json::json!({
+        "type": "message",
+        "id": "ambiguous-terminal-call-record",
+        "timestamp": "2026-08-05T12:00:00Z",
+        "message": {"role": "assistant", "content": [{
+            "type": "toolCall",
+            "id": "ambiguous-terminal-call",
+            "name": "exec",
+            "arguments": {"command": "ctx search ambiguous-terminal"}
+        }]}
+    });
+    let first_result = serde_json::json!({
+        "type": "message",
+        "id": "ambiguous-terminal-first",
+        "timestamp": "2026-08-05T12:00:01Z",
+        "message": {
+            "role": "toolResult",
+            "toolCallId": "ambiguous-terminal-call",
+            "content": "first authoritative OpenClaw payload",
+            "details": {"status": "completed", "exitCode": 0}
+        }
+    });
+    let ambiguous_result = br#"{"type":"message","id":"ambiguous-terminal-second","timestamp":"2026-08-05T12:00:02Z","message":{"role":"toolResult","toolCallId":"ambiguous-terminal-call","content":"discarded duplicate member","content":"ambiguous duplicate-member OpenClaw payload","details":{"status":"completed","exitCode":0}}}"#;
+    let call_bytes = serde_json::to_vec(&call).unwrap();
+    let first_result_bytes = serde_json::to_vec(&first_result).unwrap();
+    let authority = terminal_authority_for_records([
+        call_bytes.as_slice(),
+        first_result_bytes.as_slice(),
+        ambiguous_result.as_slice(),
+    ]);
+    assert!(!authority.is_unique("ambiguous-terminal-call"));
+
+    let (_temp, mut projector) = test_projector();
+    projector.terminal_authority = authority;
+    let mut worker = JsonlFamilyWorkerContext::default();
+    let mut records = Vec::new();
+    for (ordinal, bytes) in [
+        call_bytes.as_slice(),
+        first_result_bytes.as_slice(),
+        ambiguous_result.as_slice(),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        projector
+            .project(
+                JsonlRecordRef::for_test(bytes, ordinal as u64),
+                &mut worker,
+                &mut |record| {
+                    records.push(record);
+                    Ok(())
+                },
+            )
+            .unwrap();
+    }
+
+    assert_eq!(records.len(), 3);
+    assert!(retrieval_excluded(&records[0]));
+    assert!(!retrieval_excluded(&records[1]));
+    assert!(!retrieval_excluded(&records[2]));
+    assert_eq!(
+        records[1].content.normalized_body.as_deref(),
+        Some("first authoritative OpenClaw payload")
+    );
+    assert_eq!(
+        records[2].content.normalized_body.as_deref(),
+        Some("ambiguous duplicate-member OpenClaw payload")
+    );
+
+    let trailing = [first_result_bytes.as_slice(), b" trailing terminal bytes"].concat();
+    for malformed in [trailing.as_slice(), b"{".as_slice()] {
+        let authority = terminal_authority_for_records([
+            call_bytes.as_slice(),
+            first_result_bytes.as_slice(),
+            malformed,
+        ]);
+        assert!(!authority.is_unique("ambiguous-terminal-call"));
+    }
+}
+
+#[test]
 fn openclaw_mixed_diagnostic_and_unknown_shapes_fail_open() {
     let (_temp, mut projector) = test_projector();
     let records = project_values(
@@ -1610,11 +1692,11 @@ fn terminal_ambiguity_fingerprint_invalidates_only_affected_append() {
     assert!(unique_append.is_unique("call-b"));
 
     let duplicate_append = scan(&[
-        first_call,
-        first_result,
+        first_call.clone(),
+        first_result.clone(),
         second_call,
         second_result,
-        reused_result,
+        reused_result.clone(),
     ]);
     assert_ne!(
         prefix.ambiguity_fingerprint(),
@@ -1622,6 +1704,23 @@ fn terminal_ambiguity_fingerprint_invalidates_only_affected_append() {
     );
     assert!(!duplicate_append.is_unique("call-a"));
     assert!(duplicate_append.is_unique("call-b"));
+
+    let mut malformed_bytes = Vec::new();
+    for value in [first_call, first_result] {
+        serde_json::to_writer(&mut malformed_bytes, &value).unwrap();
+        malformed_bytes.push(b'\n');
+    }
+    serde_json::to_writer(&mut malformed_bytes, &reused_result).unwrap();
+    malformed_bytes.extend_from_slice(b" trailing terminal bytes\n");
+    fs::write(&transcript_path, malformed_bytes).unwrap();
+    let opened = Arc::new(authority.open_file(Path::new("session.jsonl")).unwrap());
+    let malformed_append =
+        terminal_authority_for_source(&source, &transcript_path, opened).unwrap();
+    assert_ne!(
+        prefix.ambiguity_fingerprint(),
+        malformed_append.ambiguity_fingerprint()
+    );
+    assert!(!malformed_append.is_unique("call-a"));
 }
 
 #[test]

--- a/crates/ctx-history-capture/src/provider/providers/openclaw/native_path/source_backed/tests.rs
+++ b/crates/ctx-history-capture/src/provider/providers/openclaw/native_path/source_backed/tests.rs
@@ -463,6 +463,14 @@ fn openclaw_ambiguous_terminal_exhausts_source_wide_result_uniqueness() {
         ]);
         assert!(!authority.is_unique("ambiguous-terminal-call"));
     }
+
+    let hidden_terminal = br#"{"type":"message","id":"hidden-terminal","message":{"role":"toolResult","toolCallId":"ambiguous-terminal-call","content":"hidden result"},"message":{"role":"assistant","content":"last-wins ordinary message"}}"#;
+    let authority = terminal_authority_for_records([
+        call_bytes.as_slice(),
+        first_result_bytes.as_slice(),
+        hidden_terminal.as_slice(),
+    ]);
+    assert!(!authority.is_unique("ambiguous-terminal-call"));
 }
 
 #[test]

--- a/crates/ctx-history-capture/src/provider/providers/openclaw/native_path/source_backed/tests.rs
+++ b/crates/ctx-history-capture/src/provider/providers/openclaw/native_path/source_backed/tests.rs
@@ -316,6 +316,74 @@ fn openclaw_exact_cli_and_success_envelope_are_excluded() {
 }
 
 #[test]
+fn openclaw_duplicate_raw_tool_members_remain_searchable() {
+    let (_temp, mut projector) = test_projector();
+    let bytes = br#"{"type":"message","id":"duplicate-command-record","timestamp":"2026-08-05T12:00:00Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"duplicate-command-call","name":"exec","arguments":{"command":"ordinary command","command":"ctx search ambiguous-duplicate-member"}}]}}"#;
+    let mut worker = JsonlFamilyWorkerContext::default();
+    let mut records = Vec::new();
+    projector
+        .project(
+            JsonlRecordRef::for_test(bytes, 0),
+            &mut worker,
+            &mut |record| {
+                records.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+    assert_eq!(records.len(), 1);
+    assert!(records[0]
+        .content
+        .normalized_body
+        .as_deref()
+        .is_some_and(|body| body.contains("ctx search ambiguous-duplicate-member")));
+    assert!(!retrieval_excluded(&records[0]));
+}
+
+#[test]
+fn openclaw_duplicate_raw_result_members_remain_searchable() {
+    let (_temp, mut projector) = test_projector();
+    let call = serde_json::json!({
+        "type": "message",
+        "id": "duplicate-result-call-record",
+        "timestamp": "2026-08-05T12:00:00Z",
+        "message": {"role": "assistant", "content": [{
+            "type": "toolCall",
+            "id": "duplicate-result-call",
+            "name": "exec",
+            "arguments": {"command": "ctx search ambiguous-duplicate-result"}
+        }]}
+    });
+    let result = br#"{"type":"message","id":"duplicate-result-record","timestamp":"2026-08-05T12:00:01Z","message":{"role":"toolResult","toolCallId":"duplicate-result-call","content":"exact first payload","content":"ambiguous duplicate payload","details":{"status":"completed","exitCode":0}}}"#;
+    let result_value: Value = serde_json::from_slice(result).unwrap();
+    projector.terminal_authority = terminal_authority_for_values([&result_value]);
+    let call_bytes = serde_json::to_vec(&call).unwrap();
+    let mut worker = JsonlFamilyWorkerContext::default();
+    let mut records = Vec::new();
+    for (ordinal, bytes) in [call_bytes.as_slice(), result].into_iter().enumerate() {
+        projector
+            .project(
+                JsonlRecordRef::for_test(bytes, ordinal as u64),
+                &mut worker,
+                &mut |record| {
+                    records.push(record);
+                    Ok(())
+                },
+            )
+            .unwrap();
+    }
+
+    assert_eq!(records.len(), 2);
+    assert!(retrieval_excluded(&records[0]));
+    assert!(!retrieval_excluded(&records[1]));
+    assert_eq!(
+        records[1].content.normalized_body.as_deref(),
+        Some("ambiguous duplicate payload")
+    );
+}
+
+#[test]
 fn openclaw_mixed_diagnostic_and_unknown_shapes_fail_open() {
     let (_temp, mut projector) = test_projector();
     let records = project_values(

--- a/crates/ctx-history-capture/src/provider/source_backed/family/jsonl/route.rs
+++ b/crates/ctx-history-capture/src/provider/source_backed/family/jsonl/route.rs
@@ -1019,15 +1019,13 @@ struct TerminalSourceEvidence {
 }
 
 fn default_base_source_path(
-    adapter: &(impl JsonlFamilyAdapter + ?Sized),
+    _adapter: &(impl JsonlFamilyAdapter + ?Sized),
     certificate: &CertifiedSource,
 ) -> Result<PathBuf> {
     certificate.validate_contract().map_err(contract_error)?;
-    if certificate.parser_revision() != adapter.parser_revision() {
-        return Err(CaptureError::InvalidPayload(
-            "JSONL base parser revision changed".to_owned(),
-        ));
-    }
+    // Parser revisions govern projection semantics, not source ownership. The
+    // family still needs the prior source path so an unchanged source can be
+    // selected and replaced under the current parser rather than rejected.
     let frontier = certificate
         .frontier()
         .ok_or_else(|| CaptureError::InvalidPayload("JSONL base frontier is absent".to_owned()))?;

--- a/crates/ctx-history-capture/src/provider/source_backed/family/jsonl/route/tests.rs
+++ b/crates/ctx-history-capture/src/provider/source_backed/family/jsonl/route/tests.rs
@@ -708,6 +708,7 @@ impl JsonlFamilyAdapter for UnpartitionedSchedulerStateTestAdapter {
 }
 
 struct IdentityRevisionTestAdapter {
+    parser_revision: &'static str,
     revision: &'static str,
     expected_mode: JsonlFamilyProjectionMode,
 }
@@ -726,7 +727,7 @@ impl JsonlFamilyAdapter for IdentityRevisionTestAdapter {
     }
 
     fn parser_revision(&self) -> &'static str {
-        "identity-revision-test-parser-v1"
+        self.parser_revision
     }
 
     fn event_identity_revision(&self) -> &'static str {
@@ -1697,12 +1698,14 @@ fn event_identity_revision_forces_replacement_with_core_base_authority() {
     fs::write(root.join("identity.jsonl"), b"{\"message\":\"stable\"}\n").unwrap();
 
     let cold = IdentityRevisionTestAdapter {
+        parser_revision: "identity-revision-test-parser-v1",
         revision: "content-occurrence-v1",
         expected_mode: JsonlFamilyProjectionMode::Cold,
     };
     let (cold_receipt, _) = capture_parallel_test_generation(&cold, &root, &index, 1);
 
     let upgraded = IdentityRevisionTestAdapter {
+        parser_revision: "identity-revision-test-parser-v1",
         revision: "content-occurrence-v2",
         expected_mode: JsonlFamilyProjectionMode::Replacement,
     };
@@ -1721,6 +1724,35 @@ fn event_identity_revision_forces_replacement_with_core_base_authority() {
             .unwrap()
             .event_identity_revision,
         "content-occurrence-v2"
+    );
+}
+
+#[test]
+fn parser_revision_forces_unchanged_source_replacement() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let root = temp.path().join("sessions");
+    let index = temp.path().join("index");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("parser.jsonl"), b"{\"message\":\"stable\"}\n").unwrap();
+
+    let cold = IdentityRevisionTestAdapter {
+        parser_revision: "identity-revision-test-parser-v1",
+        revision: "content-occurrence-v1",
+        expected_mode: JsonlFamilyProjectionMode::Cold,
+    };
+    let (cold_receipt, _) = capture_parallel_test_generation(&cold, &root, &index, 1);
+
+    let upgraded = IdentityRevisionTestAdapter {
+        parser_revision: "identity-revision-test-parser-v2",
+        revision: "content-occurrence-v1",
+        expected_mode: JsonlFamilyProjectionMode::Replacement,
+    };
+    let (upgraded_receipt, _) = capture_parallel_test_generation(&upgraded, &root, &index, 1);
+
+    assert_ne!(cold_receipt.generation_id, upgraded_receipt.generation_id);
+    assert_eq!(
+        upgraded_receipt.manifest().sources[0].parser_revision(),
+        "identity-revision-test-parser-v2"
     );
 }
 

--- a/crates/ctx-history-capture/src/repository_attribution/association.rs
+++ b/crates/ctx-history-capture/src/repository_attribution/association.rs
@@ -3,12 +3,11 @@ use ctx_history_core::{
     GitObjectFormat, GitObjectId, RepositoryAlias, RepositoryAliasKind, RepositoryOutcomeLinkage,
     RepositoryPullRequestIdentity,
 };
-use serde::de::{Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde_json::Value;
-use std::{collections::HashSet, fmt};
 use url::{Host, Url};
 
 use super::shell::bounded_pull_request_association_query;
+use crate::common::json::exact_value as exact_json_value;
 
 const MAX_ASSOCIATION_OUTPUT_BYTES: usize = 1024 * 1024;
 
@@ -115,102 +114,6 @@ pub(crate) fn exact_pull_request_association(
         merged_as,
         linkage,
     })
-}
-
-/// Parse one JSON value while rejecting duplicate keys at every object depth.
-/// `serde_json::Value` alone retains only the final duplicate and therefore is
-/// not an exact schema authority.
-fn exact_json_value(input: &str) -> Option<Value> {
-    let mut deserializer = serde_json::Deserializer::from_str(input);
-    let value = NoDuplicateJson::deserialize(&mut deserializer).ok()?.0;
-    deserializer.end().ok()?;
-    Some(value)
-}
-
-struct NoDuplicateJson(Value);
-
-impl<'de> Deserialize<'de> for NoDuplicateJson {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_any(NoDuplicateJsonVisitor)
-    }
-}
-
-struct NoDuplicateJsonVisitor;
-
-impl<'de> Visitor<'de> for NoDuplicateJsonVisitor {
-    type Value = NoDuplicateJson;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("JSON without duplicate object keys")
-    }
-
-    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
-        Ok(NoDuplicateJson(Value::Bool(value)))
-    }
-
-    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
-        Ok(NoDuplicateJson(Value::Number(value.into())))
-    }
-
-    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
-        Ok(NoDuplicateJson(Value::Number(value.into())))
-    }
-
-    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        serde_json::Number::from_f64(value)
-            .map(Value::Number)
-            .map(NoDuplicateJson)
-            .ok_or_else(|| E::custom("non-finite JSON number"))
-    }
-
-    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
-        Ok(NoDuplicateJson(Value::String(value.to_owned())))
-    }
-
-    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
-        Ok(NoDuplicateJson(Value::String(value)))
-    }
-
-    fn visit_none<E>(self) -> Result<Self::Value, E> {
-        Ok(NoDuplicateJson(Value::Null))
-    }
-
-    fn visit_unit<E>(self) -> Result<Self::Value, E> {
-        Ok(NoDuplicateJson(Value::Null))
-    }
-
-    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
-    where
-        A: SeqAccess<'de>,
-    {
-        let mut values = Vec::new();
-        while let Some(value) = sequence.next_element::<NoDuplicateJson>()? {
-            values.push(value.0);
-        }
-        Ok(NoDuplicateJson(Value::Array(values)))
-    }
-
-    fn visit_map<A>(self, mut object: A) -> Result<Self::Value, A::Error>
-    where
-        A: MapAccess<'de>,
-    {
-        let mut keys = HashSet::new();
-        let mut values = serde_json::Map::new();
-        while let Some(key) = object.next_key::<String>()? {
-            if !keys.insert(key.clone()) {
-                return Err(serde::de::Error::custom("duplicate JSON object key"));
-            }
-            let value = object.next_value::<NoDuplicateJson>()?;
-            values.insert(key, value.0);
-        }
-        Ok(NoDuplicateJson(Value::Object(values)))
-    }
 }
 
 fn inadmissible_result_line(line: &str) -> bool {


### PR DESCRIPTION
Follow-up hardening for the retrieval self-echo exclusion landed in #319.

- centralizes exact JSON structural authority and rejects duplicate object members at every depth while retaining provider content
- caps the structural pass at 65,536 total nested object members; budget exhaustion fails open to normal discovery
- applies fail-open handling to Codex, Claude, Gemini, and OpenClaw calls and terminal results
- exhausts source-wide result uniqueness when malformed, trailing, duplicate-member, hidden-selector, or complete oversized records make terminal authority ambiguous
- bumps affected parser revisions and proves unchanged JSONL sources are replacement-projected under the new parser
- preserves incomplete-record and terminal-NUL framing behavior
- leaves index, protocol, ranking, identity, and complete-content contracts unchanged

Validation on `14701e38917e4792a4a0ee07679d170df25cc559`:

- full uncached `//crates/ctx-history-capture:unit_tests`: pass (1,307 passed, 1 ignored)
- focused oversized-terminal cold/append/NUL regressions: pass
- focused duplicate-result, hidden-selector, source-wide append replacement, parser-revision replacement, and JSON budget regressions: pass
- `//:loc_check`: pass
- `cargo fmt --all -- --check`: pass
- `git diff --check`: pass

The stack is rebased onto current `main` (`ddbc81a8a42d50fa29bb04a9b6da172b98bc953c`). An independent read-only adversarial review of the exact five-commit diff returned **SHIP** with no P0/P1/P2 findings. This PR is intentionally left unmerged for human review.
