### PR TITLE
fix(release): repair final qualification drift

### DIFF
--- a/crates/ctx-cli/tests/mcp/input_validation.rs
+++ b/crates/ctx-cli/tests/mcp/input_validation.rs
@@ -229,11 +229,30 @@ fn mcp_tool_input_validation_returns_stable_invalid_request_and_server_recovers(
 
     let responses = mcp_roundtrip(&temp, &requests);
 
-    for (offset, (id, _, _, detail)) in cases.iter().enumerate() {
+    for (offset, (id, name, _, detail)) in cases.iter().enumerate() {
         let result = &responses[offset + 1]["result"];
         assert_eq!(responses[offset + 1]["id"], *id);
         assert_eq!(result["isError"], true);
         assert_eq!(result["structuredContent"]["error_code"], "invalid_request");
+        if *name == "blame" {
+            assert_eq!(
+                result["structuredContent"],
+                json!({
+                    "error": "invalid_request",
+                    "error_code": "invalid_request",
+                    "reason": "request_invalid",
+                    "message": "The blame request is invalid.",
+                    "retryable": false,
+                }),
+                "{id}: {result:#?}"
+            );
+            assert_eq!(
+                mcp_content_text(result),
+                "The blame request is invalid.",
+                "{id}: {result:#?}"
+            );
+            continue;
+        }
         assert!(
             result["structuredContent"]["error"]
                 .as_str()

--- a/crates/ctx-cli/tests/pro_mcp.rs
+++ b/crates/ctx-cli/tests/pro_mcp.rs
@@ -200,36 +200,30 @@ fn mcp_blame_rejects_non_launch_targets_and_invalid_bounds() {
         (
             "issue",
             json!({"target": {"kind": "issue", "selector": "42"}}),
-            "target.kind must be file, commit, or pull_request",
         ),
         (
             "numeric-pr-without-repository",
             json!({"target": {"kind": "pull_request", "selector": "42"}}),
-            "pull request number requires a repository selector",
         ),
         (
             "zero-pr",
             json!({"target": {"kind": "pull_request", "selector": "0", "repository": "ctxrs/ctx"}}),
-            "pull request selector must be a positive decimal number or canonical supported PR URL",
         ),
         (
             "malformed-pr-url",
             json!({"target": {"kind": "pull_request", "selector": "https://gitlab.example.com/a/b/merge_requests/42"}}),
-            "pull request selector must be a positive decimal number or canonical supported PR URL",
         ),
         (
             "bad-lines",
             json!({"target": {"kind": "file", "path": "src/lib.rs", "lines": {"start": 9, "end": 2}}}),
-            "line range must be positive and inclusive",
         ),
         (
             "limit",
             json!({"target": {"kind": "commit", "oid": "abcd"}, "limit": 9}),
-            "limit must be between 1 and 8",
         ),
     ];
     let mut requests = vec![initialize_request(), initialized_notification()];
-    requests.extend(cases.iter().map(|(id, arguments, _)| {
+    requests.extend(cases.iter().map(|(id, arguments)| {
         json!({
             "jsonrpc": "2.0",
             "id": id,
@@ -238,15 +232,25 @@ fn mcp_blame_rejects_non_launch_targets_and_invalid_bounds() {
         })
     }));
     let responses = mcp_roundtrip_with_env(&temp, &requests, &[]);
-    for (response, (_, _, expected)) in responses[1..].iter().zip(cases) {
+    for (response, _) in responses[1..].iter().zip(cases) {
         let result = &response["result"];
         assert_eq!(result["isError"], true);
-        assert_eq!(result["structuredContent"]["error_code"], "invalid_request");
-        assert!(
-            result["content"][0]["text"]
-                .as_str()
-                .is_some_and(|text| text.contains(expected)),
-            "{result:#?}"
+        assert_eq!(
+            result["structuredContent"],
+            json!({
+                "error": "invalid_request",
+                "error_code": "invalid_request",
+                "reason": "request_invalid",
+                "message": "The blame request is invalid.",
+                "retryable": false,
+            })
+        );
+        assert_eq!(
+            result["content"],
+            json!([{
+                "type": "text",
+                "text": "The blame request is invalid.",
+            }])
         );
     }
 }

--- a/crates/ctx-cli/tests/raw_output_policy/allowlist.rs
+++ b/crates/ctx-cli/tests/raw_output_policy/allowlist.rs
@@ -124,6 +124,11 @@ const PRO_MACHINE_ERROR: TestOwner = TestOwner::behavioral(
     &["src/dispatch.rs"],
     &["write_stable_error_json", "from_slice", "output"],
 );
+const PRO_BLAME_MACHINE_ERROR: TestOwner = TestOwner::behavioral(
+    "src/pro/tests.rs::blame_machine_errors_are_typed_without_expanding_unrelated_pro_errors",
+    &["src/dispatch.rs"],
+    &["write_blame_error_json", "from_slice", "output"],
+);
 const SKILL: TestOwner = TestOwner::behavioral(
     "src/skill/install.rs::human_install_and_status_results_use_the_typed_ui",
     &["src/skill/"],
@@ -444,6 +449,14 @@ pub(super) const ALLOWLIST: &[AllowEntry] = &[
         MachineProtocol,
         JSON_PROTOCOL,
         PRO_MACHINE_ERROR
+    ),
+    allow!(
+        DISPATCH,
+        "render_blame_error_json#1@51617f6288b47ada",
+        OutputRawHelper,
+        MachineProtocol,
+        JSON_PROTOCOL,
+        PRO_BLAME_MACHINE_ERROR
     ),
     allow!(
         DISPATCH,

--- a/crates/ctx-cli/tests/support/pro.rs
+++ b/crates/ctx-cli/tests/support/pro.rs
@@ -332,11 +332,13 @@ fn initialize_provider_neutral_core_projection(data_root: &Path) -> String {
         "uuid": "d863cb84-6bd3-8071-abdb-5326c44c896a",
     });
     let record: ctx_pro_host_protocol::CoreRecord = serde_json::from_value(serde_json::json!({
-        "record_version": 1,
+        "record_version": ctx_history_core::CORE_RECORD_VERSION,
         "event_id": event_id,
         "session_id": session_id,
         "parent_session_id": null,
         "root_session_id": session_id,
+        "session_relationship": "root",
+        "event_origin": {"kind": "unknown"},
         "source": source,
         "provider_session_id": "golden-session",
         "native_event_id": null,
@@ -352,7 +354,7 @@ fn initialize_provider_neutral_core_projection(data_root: &Path) -> String {
         "parser_revision": "golden-parser-v1",
         "normalization_revision": 1,
         "content": {
-            "policy_revision": 2,
+            "policy_revision": ctx_history_core::CORE_CONTENT_POLICY_REVISION,
             "policy_status": "selected",
             "normalized_body": "provider-neutral Pro query fixture",
             "structured_content": null,

--- a/crates/ctx-cli/tests/support/search_show/search_flows.rs
+++ b/crates/ctx-cli/tests/support/search_show/search_flows.rs
@@ -77,13 +77,22 @@ fn fresh_home_search_mvp_flow() {
             "record_id",
             "history_record_id",
             "raw_source_path",
-            "kind",
             "external_session_id",
         ],
+    );
+    assert!(
+        search["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|result| result.get("kind").is_none()),
+        "search results must not regain the obsolete top-level kind field: {search:#}"
     );
     let first_result = &search["results"][0];
     assert_eq!(first_result["result_type"], "session_result");
     assert_eq!(first_result["result_scope"], "session");
+    assert_eq!(first_result["session_relationship"], "root");
+    assert_eq!(first_result["event_origin"]["kind"], "unknown");
     let ctx_event_id = first_result["ctx_event_id"].as_str().unwrap().to_owned();
     let ctx_session_id = first_result["ctx_session_id"].as_str().unwrap().to_owned();
     let provider_session_id = first_result["provider_session_id"]

--- a/crates/ctx-history-capture/tests/mcp_attribution_conformance.py
+++ b/crates/ctx-history-capture/tests/mcp_attribution_conformance.py
@@ -445,9 +445,19 @@ def _validate_provenance(
 def _matrix_inventory(
     provider_matrix: dict[str, Any],
 ) -> tuple[set[str], set[BaseKey]]:
-    _exact_keys(provider_matrix, {"schema_version", "scope", "providers"}, "matrix")
-    if provider_matrix["schema_version"] != 1:
-        raise ConformanceError("provider matrix schema_version must equal 1")
+    _exact_keys(
+        provider_matrix,
+        {
+            "schema_version",
+            "scope",
+            "lineage_capability_values",
+            "custom_history_lineage_support",
+            "providers",
+        },
+        "matrix",
+    )
+    if provider_matrix["schema_version"] != 2:
+        raise ConformanceError("provider matrix schema_version must equal 2")
     provider_ids: set[str] = set()
     base_routes: set[BaseKey] = set()
     for provider_index, raw_provider in enumerate(

--- a/crates/ctx-history-capture/tests/mcp_attribution_conformance_test.py
+++ b/crates/ctx-history-capture/tests/mcp_attribution_conformance_test.py
@@ -130,8 +130,31 @@ def bind_manifest_contract(manifest: dict, contract: RouteSchemaContract) -> Non
 
 def minimal_matrix(provider: str = "fixture", source_format: str = "fixture_jsonl") -> dict:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "scope": "fixture",
+        "lineage_capability_values": {
+            "session_relationship": ["exact_relationship", "unknown"],
+            "event_origin": [
+                "exact_copy",
+                "certified_prefix",
+                "explicit_no_copy",
+                "unknown",
+            ],
+        },
+        "custom_history_lineage_support": {
+            "legacy": {
+                "session_relationship": "unknown",
+                "event_origin": "unknown",
+            },
+            "provider_native_v1": {
+                "session_relationship": "exact_relationship",
+                "event_origin": "exact_copy",
+            },
+            "command_only_plugin": {
+                "session_relationship": "unknown",
+                "event_origin": "unknown",
+            },
+        },
         "providers": [
             {
                 "id": provider,

--- a/tools/bazel/rust-target-inventory.json
+++ b/tools/bazel/rust-target-inventory.json
@@ -57,6 +57,7 @@
       "targets": {
         "lib:ctx_history_capture": "//crates/ctx-history-capture:lib",
         "test:codex_direct_result": "//crates/ctx-history-capture:codex_direct_result_tests",
+        "test:ctx_retrieval_classifier": "//crates/ctx-history-capture:ctx_retrieval_classifier_tests",
         "test:repository_shell_outcomes": "//crates/ctx-history-capture:repository_shell_outcomes_tests",
         "test:self_contained_core_final_locator_removal": "//crates/ctx-history-capture:self_contained_core_final_locator_removal_tests"
       },

--- a/tools/bazel/test_tiers.bzl
+++ b/tools/bazel/test_tiers.bzl
@@ -43,6 +43,7 @@ RUST_FORMAT_TARGETS = [
     "//crates/ctx-cli:upgrade_tests",
     "//crates/ctx-cli:upgrade_analytics_tests",
     "//crates/ctx-history-capture:codex_direct_result_tests",
+    "//crates/ctx-history-capture:ctx_retrieval_classifier_tests",
     "//crates/ctx-history-capture:repository_shell_outcomes_tests",
     "//crates/ctx-history-capture:self_contained_core_final_locator_removal_tests",
     "//crates/ctx-history-capture:unit_tests",
@@ -65,6 +66,7 @@ RUST_FORMAT_TARGETS = [
 # families. The CLI targets prove real-shape admission/rejection, discovery,
 # refresh, and user-facing self-contained Core behavior.
 _CI_PROVIDER_TESTS = [
+    ":provider_support_matrix_tests",
     "//crates/ctx-cli:mcp_attribution_privacy_tests",
     "//crates/ctx-cli:native_provider_real_shapes_tests",
     "//crates/ctx-cli:native_provider_rejections_tests",
@@ -73,6 +75,7 @@ _CI_PROVIDER_TESTS = [
     "//crates/ctx-cli:setup_sources_import_tests",
     "//crates/ctx-cli:self_contained_core_content_tests",
     "//crates/ctx-history-capture:active_source_family_contract_tests",
+    "//crates/ctx-history-capture:ctx_retrieval_classifier_tests",
     "//crates/ctx-history-capture:mcp_attribution_conformance_runner_tests",
     "//crates/ctx-history-capture:mcp_attribution_conformance_tests",
     "//crates/ctx-history-capture:self_contained_core_final_locator_removal_tests",
@@ -118,7 +121,7 @@ _CI_RUST_TESTS = [
     "//crates/ctx-history-capture:codex_direct_result_tests",
     "//crates/ctx-history-capture:repository_shell_outcomes_tests",
     "//crates/ctx-history-core:unit_tests",
-    "//crates/ctx-history-index:migration_fault_tests",
+    "//crates/ctx-history-index:republish_fault_tests",
     "//crates/ctx-history-index:source_backed_recovery_tests",
     "//crates/ctx-history-index:unit_tests",
     "//crates/ctx-history-refresh:unit_tests",
@@ -198,6 +201,6 @@ NIGHTLY_TESTS = [
     ":performance_sanity_tests",
     "//crates/ctx-cli:auto_upgrade_acceptance_tests",
     "//crates/ctx-cli:persistent_daemon_lifecycle_tests",
-    "//crates/ctx-history-index:migration_disk_qualification_tests",
+    "//crates/ctx-history-index:republish_disk_qualification_tests",
     "//scripts/source-backed-recovery:fault_qualification",
 ]


### PR DESCRIPTION
## Summary

- repair release test-tier and Rust target inventories after the retrieval changes
- update strict Protocol V2 and Core V2 test fixtures without weakening production contracts
- align CLI/MCP assertions with the canonical structured invalid-request response and additive event-origin JSON

## Validation

- ctx-cli unit, pro-host, pro-MCP, MCP, and search/show tests
- test-tier inventory, Rust target inventory, raw-output policy, attribution conformance, provider matrix, and rustfmt checks
- independent exact-commit review: APPROVE