### PR TITLE
fix(release): expect Pro protocol v2 in native smoke

### DIFF
--- a/scripts/run-native-candidate-smoke.sh
+++ b/scripts/run-native-candidate-smoke.sh
@@ -221,7 +221,7 @@ pro_status_reports_absent_local_runtime() {
     '"ready"[[:space:]]*:[[:space:]]*false' \
     '"materialized"[[:space:]]*:[[:space:]]*false' \
     '"helper_version"[[:space:]]*:[[:space:]]*null' \
-    '"protocol_version"[[:space:]]*:[[:space:]]*1' \
+    '"protocol_version"[[:space:]]*:[[:space:]]*2' \
     '"capabilities"[[:space:]]*:[[:space:]]*\[[[:space:]]*\]' \
     '"command"[[:space:]]*:[[:space:]]*"ctx pro"' \
     '"reason"[[:space:]]*:[[:space:]]*"helper_missing"'

--- a/scripts/tests/fixtures/native-candidate-pro-status/absent-helper-locked.json
+++ b/scripts/tests/fixtures/native-candidate-pro-status/absent-helper-locked.json
@@ -6,7 +6,7 @@
   "ready": false,
   "materialized": false,
   "helper_version": null,
-  "protocol_version": 1,
+  "protocol_version": 2,
   "capabilities": [],
   "error_code": "entitlement_expired",
   "access_state": "locked",

--- a/scripts/tests/fixtures/native-candidate-pro-status/absent-helper-trial.json
+++ b/scripts/tests/fixtures/native-candidate-pro-status/absent-helper-trial.json
@@ -6,7 +6,7 @@
   "ready": false,
   "materialized": false,
   "helper_version": null,
-  "protocol_version": 1,
+  "protocol_version": 2,
   "capabilities": [],
   "error_code": "pro_not_installed",
   "access_state": "trial",

--- a/scripts/tests/fixtures/native-candidate-pro-status/absent-helper-unavailable.json
+++ b/scripts/tests/fixtures/native-candidate-pro-status/absent-helper-unavailable.json
@@ -6,7 +6,7 @@
   "ready": false,
   "materialized": false,
   "helper_version": null,
-  "protocol_version": 1,
+  "protocol_version": 2,
   "capabilities": [],
   "error_code": "commercial_unavailable",
   "access_state": null,


### PR DESCRIPTION
## Summary\n- align the native release smoke with the authoritative Pro protocol version 2\n- update all absent-helper fixtures used by the owning smoke test\n\n## Root cause\nThe exact sealed Linux candidate correctly emitted protocol_version 2, but the release harness and its fixtures still asserted protocol_version 1. This made artifact construction fail after the binary itself had built successfully.\n\n## Validation\n- scripts/tests/run-native-candidate-smoke-test.sh\n- scripts/bazelw test //:native_candidate_smoke_tests //:release_binary_compat_tests //:native_bazel_packaging_contract_tests --config=ci --test_output=errors\n- git diff --check\n- independent Sol review: no findings; change judged correct, minimal, and release-safe\n\nNo product behavior, wire contract, or persisted format changes.