### PR TITLE
Fix refresh release-validation determinism

### DIFF
--- a/crates/ctx-cli/src/commands/setup.rs
+++ b/crates/ctx-cli/src/commands/setup.rs
@@ -10,6 +10,7 @@ use crate::semantic::{
     autostart_daemon_and_wait, coordinate_source_backed_refresh_with_progress,
     daemon_autostart_suppression_reason, semantic_query_service_supported,
     source_epoch_status_report, DaemonHandoff, SourceBackedRefreshMode,
+    SourceBackedRefreshPendingPublication,
 };
 use crate::ui::{
     fields, outcome, section, Document, Field, Line, Outcome, OutcomeState, RenderContext, Span,
@@ -81,7 +82,11 @@ pub(crate) fn run_setup(
     let lexical_status = source.report["lexical"]["status"]
         .as_str()
         .unwrap_or("unavailable");
-    telemetry.mode = Some(if lexical_status == "ready" {
+    let mode = setup_mode(
+        lexical_status,
+        refresh_request["status"].as_str().unwrap_or("unavailable"),
+    );
+    telemetry.mode = Some(if mode == "ready" {
         SetupMode::Ready
     } else {
         SetupMode::Background
@@ -89,12 +94,6 @@ pub(crate) fn run_setup(
     telemetry.providers_detected = source.indexed_sources.map(analytics::count_bucket);
     telemetry.has_indexed_content = source.indexed_items.map(|count| count > 0);
 
-    let mode = match lexical_status {
-        "ready" => "ready",
-        "pending" => "pending",
-        "stale" => "stale",
-        _ => "unavailable",
-    };
     let mut output = source.report.clone();
     let Some(output_fields) = output.as_object_mut() else {
         bail!("source status report was not an object");
@@ -137,6 +136,16 @@ pub(crate) fn run_setup(
         ui.write_stdout(&document)?;
     }
     Ok(())
+}
+
+fn setup_mode(lexical_status: &str, refresh_status: &str) -> &'static str {
+    match lexical_status {
+        "ready" => "ready",
+        "pending" => "pending",
+        "stale" => "stale",
+        _ if refresh_status == "pending" => "pending",
+        _ => "unavailable",
+    }
 }
 
 fn request_source_refresh(
@@ -191,30 +200,42 @@ fn request_source_refresh(
             {
                 return Err(error);
             }
-            let daemon_unavailable = error
-                .downcast_ref::<crate::semantic::SourceBackedRefreshDaemonUnavailable>()
-                .is_some();
-            Ok(json!({
-                "status": if daemon_unavailable {
-                    "unavailable"
-                } else if !wait {
-                    "pending"
-                } else {
-                    "unavailable"
-                },
-                "reason": if daemon_unavailable {
-                    daemon_unavailable_reason.unwrap_or("daemon_unavailable")
-                } else if !wait {
-                    "refresh_queued_without_published_generation"
-                } else {
-                    "refresh_failed"
-                },
-                "mode": if wait { "wait" } else { "background" },
-                "daemon_available": !daemon_unavailable,
-                "last_error": format!("{error:#}"),
-            }))
+            Ok(refresh_request_failure(
+                &error,
+                wait,
+                daemon_unavailable_reason,
+            ))
         }
     }
+}
+
+fn refresh_request_failure(
+    error: &anyhow::Error,
+    wait: bool,
+    daemon_unavailable_reason: Option<&str>,
+) -> Value {
+    let daemon_unavailable = error
+        .downcast_ref::<crate::semantic::SourceBackedRefreshDaemonUnavailable>()
+        .is_some();
+    let pending = (!wait)
+        .then(|| error.downcast_ref::<SourceBackedRefreshPendingPublication>())
+        .flatten();
+    json!({
+        "status": if pending.is_some() { "pending" } else { "unavailable" },
+        "reason": if daemon_unavailable {
+            daemon_unavailable_reason.unwrap_or("daemon_unavailable")
+        } else if pending.is_some() {
+            "refresh_queued_without_published_generation"
+        } else {
+            "refresh_failed"
+        },
+        "mode": if wait { "wait" } else { "background" },
+        "request_id": pending.map(SourceBackedRefreshPendingPublication::request_id),
+        "request_state": pending.map(SourceBackedRefreshPendingPublication::request_state),
+        "source_count": pending.map(SourceBackedRefreshPendingPublication::source_count),
+        "daemon_available": !daemon_unavailable,
+        "last_error": format!("{error:#}"),
+    })
 }
 
 fn daemon_autostart_json(
@@ -454,6 +475,38 @@ mod tests {
             "registration_verified": true,
             "live_owner_verified": true,
         })
+    }
+
+    #[test]
+    fn admitted_background_refresh_reports_pending_before_first_publication() {
+        assert_eq!(setup_mode("unavailable", "pending"), "pending");
+        assert_eq!(setup_mode("unavailable", "unavailable"), "unavailable");
+        assert_eq!(setup_mode("stale", "pending"), "stale");
+        assert_eq!(setup_mode("ready", "pending"), "ready");
+    }
+
+    #[test]
+    fn only_admitted_background_work_reports_pending() {
+        let admitted: anyhow::Error = SourceBackedRefreshPendingPublication::new(
+            "request-1".to_owned(),
+            "admission_pending".to_owned(),
+            7,
+        )
+        .into();
+        let pending = refresh_request_failure(&admitted, false, None);
+        assert_eq!(pending["status"], "pending");
+        assert_eq!(
+            pending["reason"],
+            "refresh_queued_without_published_generation"
+        );
+        assert_eq!(pending["request_id"], "request-1");
+        assert_eq!(pending["request_state"], "admission_pending");
+        assert_eq!(pending["source_count"], 7);
+
+        let rejected = refresh_request_failure(&anyhow::anyhow!("queue full"), false, None);
+        assert_eq!(rejected["status"], "unavailable");
+        assert_eq!(rejected["reason"], "refresh_failed");
+        assert!(rejected["request_id"].is_null());
     }
 
     fn ready_source() -> Value {

--- a/crates/ctx-cli/src/semantic.rs
+++ b/crates/ctx-cli/src/semantic.rs
@@ -122,7 +122,7 @@ pub(crate) use source_backed_refresh_coordinator::{
     coordinate_source_backed_refresh_with_progress, pin_active_verified_generation,
     published_explicit_source_relocation_authority, PinnedSourceBackedGeneration, RefreshStatus,
     SourceBackedCurrentSourceProgress, SourceBackedRefreshDaemonUnavailable,
-    SourceBackedRefreshMode, SourceBackedRefreshObservation,
+    SourceBackedRefreshMode, SourceBackedRefreshObservation, SourceBackedRefreshPendingPublication,
 };
 mod daemon_scheduler;
 #[cfg(test)]

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator.rs
@@ -261,7 +261,8 @@ impl CoreRefreshEngine {
 pub(crate) use client::{
     coordinate_import_source_backed_refresh_with_progress, coordinate_source_backed_refresh,
     coordinate_source_backed_refresh_with_progress, SourceBackedRefreshDaemonUnavailable,
-    SourceBackedRefreshObservation, SourceBackedRefreshTerminalError,
+    SourceBackedRefreshObservation, SourceBackedRefreshPendingPublication,
+    SourceBackedRefreshTerminalError,
 };
 #[cfg(test)]
 pub(crate) use ctx_history_refresh::count_verified_index_opens;

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/client.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/client.rs
@@ -33,6 +33,45 @@ impl fmt::Display for SourceBackedRefreshDaemonUnavailable {
 
 impl std::error::Error for SourceBackedRefreshDaemonUnavailable {}
 
+#[derive(Debug)]
+pub(crate) struct SourceBackedRefreshPendingPublication {
+    request_id: String,
+    request_state: String,
+    source_count: usize,
+}
+
+impl SourceBackedRefreshPendingPublication {
+    pub(crate) fn new(request_id: String, request_state: String, source_count: usize) -> Self {
+        Self {
+            request_id,
+            request_state,
+            source_count,
+        }
+    }
+
+    pub(crate) fn request_id(&self) -> &str {
+        &self.request_id
+    }
+
+    pub(crate) fn request_state(&self) -> &str {
+        &self.request_state
+    }
+
+    pub(crate) fn source_count(&self) -> usize {
+        self.source_count
+    }
+}
+
+impl fmt::Display for SourceBackedRefreshPendingPublication {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(
+            "daemon source refresh was queued but no published generation exists; retry with --refresh wait",
+        )
+    }
+}
+
+impl std::error::Error for SourceBackedRefreshPendingPublication {}
+
 #[allow(dead_code)] // Request metadata is retained for CLI/status integrations.
 pub(crate) struct SourceBackedRefreshObservation {
     pub(crate) mode: SourceBackedRefreshMode,
@@ -503,28 +542,46 @@ fn coordinate_source_backed_refresh_with_catalog(
         validate_source_refresh_status_response_authority(&response, &accepted_request_id)?;
         accepted_request_id
     };
-    source_refresh_protocol_state(&response)?;
+    let protocol = source_refresh_protocol_status(&response)?;
 
     if mode == SourceBackedRefreshMode::Background {
         if let Some(report_progress) = report_progress {
             let status = source_refresh_progress_status(response.clone())?;
             report_progress(&status).context("render daemon-owned source refresh progress")?;
         }
-        let pin = pin_published_generation(data_root)?.ok_or_else(|| {
-            anyhow!(
-                "daemon source refresh was queued but no published generation exists; retry with --refresh wait"
+        let request_state = protocol.request_state();
+        match request_state {
+            RefreshRequestState::Published => {
+                return published_refresh_observation(
+                    data_root,
+                    &response,
+                    request_id,
+                    mode,
+                    explicit_source_catalog,
+                );
+            }
+            RefreshRequestState::Failed => {
+                return failed_refresh_response(&response, protocol.into_terminal_outcome());
+            }
+            RefreshRequestState::AdmissionPending
+            | RefreshRequestState::Queued
+            | RefreshRequestState::Running => {}
+        }
+        let source_count = response_source_count(&response);
+        let Some(pin) = pin_published_generation(data_root)? else {
+            return Err(SourceBackedRefreshPendingPublication::new(
+                request_id,
+                refresh_request_state_name(request_state).to_owned(),
+                source_count,
             )
-        })?;
+            .into());
+        };
         return Ok(SourceBackedRefreshObservation {
             mode,
-            status: response
-                .get("request_state")
-                .and_then(Value::as_str)
-                .unwrap_or("queued")
-                .to_owned(),
+            status: refresh_request_state_name(request_state).to_owned(),
             request_id: Some(request_id),
             daemon_available: true,
-            source_count: response_source_count(&response),
+            source_count,
             request_previous_generation: None,
             request_generation_changed: false,
             scanned_routes: None,
@@ -701,63 +758,13 @@ fn wait_for_published_generation_inner(
         }
         match protocol_state {
             RefreshRequestState::Published => {
-                let expected = response
-                    .get("published_generation")
-                    .and_then(Value::as_str)
-                    .ok_or_else(|| {
-                        anyhow!("published daemon source refresh has no generation ID")
-                    })?;
-                let pin = pin_retained_generation(data_root, expected).with_context(|| {
-                    format!(
-                        "daemon published Core generation {expected}, but its retained terminal generation cannot be opened"
-                    )
-                })?;
-                let publication_receipt = published_refresh_receipt(&response, &pin)?;
-                validate_status_publication_authority(&publication_receipt, &pin)?;
-                let receipt = published_request_outcome(&response, &pin)?;
-                let source_count =
-                    published_source_count(&response, &receipt, pin.verified_index())?;
-                if let Some(expected_catalog) = expected_catalog {
-                    if !explicit_catalog_request_is_accounted_for(
-                        expected_catalog,
-                        receipt.published_explicit_source_catalog.as_ref(),
-                        &receipt.catalog_route_bindings,
-                        &receipt.route_results,
-                    ) {
-                        bail!(
-                            "daemon published an unexpected explicit source catalog authority: expected {:?}, published {:?}",
-                            expected_catalog,
-                            receipt.published_explicit_source_catalog,
-                        );
-                    }
-                }
-                let request_generation_changed = response
-                    .get("generation_changed")
-                    .and_then(Value::as_bool)
-                    .ok_or_else(|| {
-                        anyhow!("published daemon source refresh has no request generation outcome")
-                    })?;
-                let request_previous_generation =
-                    optional_generation(response.get("previous_generation"))?;
-                let scanned_routes = response
-                    .get("scanned_routes")
-                    .and_then(Value::as_u64)
-                    .and_then(|value| usize::try_from(value).ok())
-                    .ok_or_else(|| {
-                        anyhow!("published daemon source refresh has no scanned route count")
-                    })?;
-                return Ok(SourceBackedRefreshObservation {
+                return published_refresh_observation(
+                    data_root,
+                    &response,
+                    request_id,
                     mode,
-                    status: "published".to_owned(),
-                    request_id: Some(request_id),
-                    daemon_available: true,
-                    source_count,
-                    request_previous_generation,
-                    request_generation_changed,
-                    scanned_routes: Some(scanned_routes),
-                    receipt: Some(receipt),
-                    pin,
-                });
+                    expected_catalog,
+                );
             }
             RefreshRequestState::Failed => {
                 return failed_refresh_response(&response, protocol.into_terminal_outcome());
@@ -769,6 +776,66 @@ fn wait_for_published_generation_inner(
             }
         }
     }
+}
+
+fn published_refresh_observation(
+    data_root: &Path,
+    response: &Value,
+    request_id: String,
+    mode: SourceBackedRefreshMode,
+    expected_catalog: Option<&ExplicitSourceCatalogAuthority>,
+) -> Result<SourceBackedRefreshObservation> {
+    let expected = response
+        .get("published_generation")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("published daemon source refresh has no generation ID"))?;
+    let pin = pin_retained_generation(data_root, expected).with_context(|| {
+        format!(
+            "daemon published Core generation {expected}, but its retained terminal generation cannot be opened"
+        )
+    })?;
+    let publication_receipt = published_refresh_receipt(response, &pin)?;
+    validate_status_publication_authority(&publication_receipt, &pin)?;
+    let receipt = published_request_outcome(response, &pin)?;
+    let source_count = published_source_count(response, &receipt, pin.verified_index())?;
+    if let Some(expected_catalog) = expected_catalog {
+        if !explicit_catalog_request_is_accounted_for(
+            expected_catalog,
+            receipt.published_explicit_source_catalog.as_ref(),
+            &receipt.catalog_route_bindings,
+            &receipt.route_results,
+        ) {
+            bail!(
+                "daemon published an unexpected explicit source catalog authority: expected {:?}, published {:?}",
+                expected_catalog,
+                receipt.published_explicit_source_catalog,
+            );
+        }
+    }
+    let request_generation_changed = response
+        .get("generation_changed")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| {
+            anyhow!("published daemon source refresh has no request generation outcome")
+        })?;
+    let request_previous_generation = optional_generation(response.get("previous_generation"))?;
+    let scanned_routes = response
+        .get("scanned_routes")
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .ok_or_else(|| anyhow!("published daemon source refresh has no scanned route count"))?;
+    Ok(SourceBackedRefreshObservation {
+        mode,
+        status: "published".to_owned(),
+        request_id: Some(request_id),
+        daemon_available: true,
+        source_count,
+        request_previous_generation,
+        request_generation_changed,
+        scanned_routes: Some(scanned_routes),
+        receipt: Some(receipt),
+        pin,
+    })
 }
 
 fn published_request_outcome(
@@ -956,6 +1023,16 @@ fn response_request_id(response: &Value, label: &str) -> Result<String> {
 
 fn source_refresh_protocol_state(response: &Value) -> Result<RefreshRequestState> {
     Ok(source_refresh_protocol_status(response)?.request_state())
+}
+
+fn refresh_request_state_name(state: RefreshRequestState) -> &'static str {
+    match state {
+        RefreshRequestState::AdmissionPending => "admission_pending",
+        RefreshRequestState::Queued => "queued",
+        RefreshRequestState::Running => "running",
+        RefreshRequestState::Published => "published",
+        RefreshRequestState::Failed => "failed",
+    }
 }
 
 fn source_refresh_protocol_status(response: &Value) -> Result<RefreshStatusKind> {

--- a/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/client_transport_recovery_tests.rs
+++ b/crates/ctx-cli/src/semantic/source_backed_refresh_coordinator/client_transport_recovery_tests.rs
@@ -148,6 +148,65 @@ fn same_id_reenqueue_replays_the_exact_payload_after_a_lost_ack() -> Result<()> 
 }
 
 #[test]
+fn background_lost_ack_terminal_replay_is_not_reported_as_pending() -> Result<()> {
+    let data_root = short_data_root()?;
+    ctx_history_core::platform_security::establish_private_data_root(data_root.path())?;
+    let socket_path = data_root.path().join("lost-ack-terminal.sock");
+    let listener = UnixListener::bind(&socket_path)?;
+    write_daemon_service_endpoint(
+        data_root.path(),
+        DaemonIpcService::SourceRefresh,
+        &source_refresh_endpoint(&socket_path),
+    )?;
+    let server = std::thread::spawn(move || -> Result<[Vec<u8>; 2]> {
+        let mut requests = Vec::with_capacity(2);
+        for attempt in 0..2 {
+            let (mut stream, _) = listener.accept()?;
+            let mut received = Vec::new();
+            stream.read_to_end(&mut received)?;
+            let request: Value = serde_json::from_slice(&received)?;
+            requests.push(received);
+            if attempt == 0 {
+                continue;
+            }
+            let request_id = request["request_id"]
+                .as_str()
+                .ok_or_else(|| anyhow!("lost-ack request had no request ID"))?;
+            stream.write_all(
+                format!(
+                    "{{\"ok\":true,\"owner\":\"daemon\",\"request_id\":\"{request_id}\",\"request_state\":\"failed\",\"schema_version\":1,\"last_error\":\"replayed terminal failure\"}}\n"
+                )
+                .as_bytes(),
+            )?;
+        }
+        requests
+            .try_into()
+            .map_err(|_| anyhow!("test server did not observe exactly two requests"))
+    });
+
+    let error = match coordinate_source_backed_refresh_with_catalog(
+        data_root.path(),
+        SourceBackedRefreshMode::Background,
+        SourceBackedRefreshOperation::Refresh,
+        None,
+        false,
+        false,
+        None,
+    ) {
+        Ok(_) => panic!("terminal failed replay must remain a failure"),
+        Err(error) => error,
+    };
+    let requests = server.join().expect("lost-ack test server panicked")?;
+
+    assert_eq!(requests[0], requests[1]);
+    assert!(error
+        .downcast_ref::<SourceBackedRefreshPendingPublication>()
+        .is_none());
+    assert!(format!("{error:#}").contains("replayed terminal failure"));
+    Ok(())
+}
+
+#[test]
 fn exhausted_post_submission_disconnects_return_typed_ambiguous_admission() -> Result<()> {
     let data_root = short_data_root()?;
     let socket_path = data_root.path().join("lost-all-acks.sock");

--- a/crates/ctx-history-capture/src/provider/providers/cursor/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/providers/cursor/source_backed.rs
@@ -22,7 +22,7 @@ use sha2::Digest;
 #[cfg(test)]
 use std::cell::Cell;
 #[cfg(test)]
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::LazyLock;
 
 #[cfg(test)]
 use super::parser::MAX_CURSOR_INPUT_PATHS;
@@ -67,7 +67,8 @@ use checkpoint::*;
 use file_observations::preserve_cursor_ordinary_file_observations;
 
 #[cfg(test)]
-static CURSOR_PROJECTED_RECORDS: AtomicU64 = AtomicU64::new(0);
+static CURSOR_PROJECTED_RECORDS: LazyLock<Mutex<HashMap<StableEntityId, u64>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[cfg(test)]
 thread_local! {
@@ -76,13 +77,32 @@ thread_local! {
 }
 
 #[cfg(test)]
-fn reset_cursor_projected_records() {
-    CURSOR_PROJECTED_RECORDS.store(0, Ordering::SeqCst);
+fn reset_cursor_projected_records(source: &SourceKey) {
+    CURSOR_PROJECTED_RECORDS
+        .lock()
+        .expect("Cursor projection counters must remain available")
+        .insert(source.identity(), 0);
 }
 
 #[cfg(test)]
-fn cursor_projected_records() -> u64 {
-    CURSOR_PROJECTED_RECORDS.load(Ordering::SeqCst)
+fn take_cursor_projected_records(source: &SourceKey) -> u64 {
+    CURSOR_PROJECTED_RECORDS
+        .lock()
+        .expect("Cursor projection counters must remain available")
+        .remove(&source.identity())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+fn observe_cursor_projected_record(source: &SourceKey) {
+    let mut counters = CURSOR_PROJECTED_RECORDS
+        .lock()
+        .expect("Cursor projection counters must remain available");
+    if let Some(counter) = counters.get_mut(&source.identity()) {
+        *counter = counter
+            .checked_add(1)
+            .expect("Cursor projection test counter overflowed");
+    }
 }
 
 #[cfg(test)]
@@ -517,7 +537,7 @@ impl JsonlFamilyProjector for CursorProjector {
         emit: &mut dyn FnMut(CoreRecord) -> Result<()>,
     ) -> Result<()> {
         #[cfg(test)]
-        CURSOR_PROJECTED_RECORDS.fetch_add(1, Ordering::SeqCst);
+        observe_cursor_projected_record(&self.source);
         let evidence = record.evidence();
         let Some(events) = project_cursor_jsonl_record(
             record.bytes(),

--- a/crates/ctx-history-capture/src/provider/providers/cursor/source_backed/tests.rs
+++ b/crates/ctx-history-capture/src/provider/providers/cursor/source_backed/tests.rs
@@ -1341,13 +1341,14 @@ mod fidelity_identity_tests {
         write_transcript(&transcript, &[first]);
         let registry = registry(&root);
         let index = temp.path().join("index");
+        let source = source_key("native-session").unwrap();
 
-        reset_cursor_projected_records();
+        reset_cursor_projected_records(&source);
         reset_cursor_signature_records();
         reset_cursor_base_identity_probes();
         let cold = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
         assert_eq!(cold.commit.indexed_documents, 1);
-        assert_eq!(cursor_projected_records(), 1);
+        assert_eq!(take_cursor_projected_records(&source), 1);
         assert_eq!(cursor_base_identity_probes(), 0);
         assert_eq!(
             cursor_signature_records(),
@@ -1357,14 +1358,14 @@ mod fidelity_identity_tests {
         let cold_ids = indexed_event_ids(&index, "native-session");
 
         append_transcript(&transcript, &second);
-        reset_cursor_projected_records();
+        reset_cursor_projected_records(&source);
         reset_cursor_signature_records();
         reset_cursor_base_identity_probes();
         let appended =
             refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
         assert_eq!(appended.commit.indexed_documents, 2);
         assert_eq!(
-            cursor_projected_records(),
+            take_cursor_projected_records(&source),
             1,
             "Cursor append work must remain bounded to the validated suffix"
         );
@@ -1378,13 +1379,13 @@ mod fidelity_identity_tests {
         assert_ids_preserved(&cold_ids, &appended_ids);
 
         append_transcript(&transcript, &second);
-        reset_cursor_projected_records();
+        reset_cursor_projected_records(&source);
         reset_cursor_signature_records();
         reset_cursor_base_identity_probes();
         let first_duplicate =
             refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
         assert_eq!(first_duplicate.commit.indexed_documents, 3);
-        assert_eq!(cursor_projected_records(), 1);
+        assert_eq!(take_cursor_projected_records(&source), 1);
         assert_eq!(cursor_signature_records(), 0);
         assert_eq!(cursor_base_identity_probes(), 2);
         let first_duplicate_ids = indexed_event_ids(&index, "native-session");
@@ -1392,13 +1393,13 @@ mod fidelity_identity_tests {
         assert_all_ids_distinct(&first_duplicate_ids);
 
         append_transcript(&transcript, &second);
-        reset_cursor_projected_records();
+        reset_cursor_projected_records(&source);
         reset_cursor_signature_records();
         reset_cursor_base_identity_probes();
         let second_duplicate =
             refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
         assert_eq!(second_duplicate.commit.indexed_documents, 4);
-        assert_eq!(cursor_projected_records(), 1);
+        assert_eq!(take_cursor_projected_records(&source), 1);
         assert_eq!(cursor_signature_records(), 0);
         assert_eq!(cursor_base_identity_probes(), 3);
         let second_duplicate_ids = indexed_event_ids(&index, "native-session");


### PR DESCRIPTION
## Summary
- isolate Cursor projection instrumentation by source so parallel tests cannot inflate append-work counts
- report first-generation background refreshes as typed pending work without masking real daemon/protocol failures
- preserve terminal failed/published refresh semantics after lost-ack replay and validate published receipts through the existing authority path

## Validation
- focused release targets: 4/4 passed
- `scripts/bazel-affected.sh origin/main`: 124/124 passed
- independent Sol Advisor review: SHIP, no actionable findings