### PR TITLE
build: add governed Bazel remote execution profile

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,6 +11,17 @@ build --java_runtime_version=remotejdk_21
 test --cache_test_results=auto
 test --test_output=errors
 
+# Optional REAPI execution keeps every eligible spawn action remote-only.
+build:ctx-reapi --spawn_strategy=remote
+build:ctx-reapi --genrule_strategy=remote
+build:ctx-reapi --remote_local_fallback=false
+build:ctx-reapi --incompatible_legacy_local_fallback=false
+build:ctx-reapi --remote_download_outputs=toplevel
+build:ctx-reapi --remote_timeout=60s
+build:ctx-reapi --remote_retries=2
+test:ctx-reapi --test_strategy=remote
+test:ctx-reapi --test_output=errors
+
 # Fast local Linux iteration: stable fastbuild key, no Rust debug info, and the
 # content-pinned mold input declared in MODULE.bazel.
 build:dev-linux --compilation_mode=fastbuild

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -342,10 +342,12 @@ sh_test(
     name = "bazel_wrapper_tests",
     srcs = ["scripts/tests/bazelw-test.sh"],
     data = [
+        ".bazelrc",
         ".bazelversion",
         "scripts/bazelw",
         "scripts/ci-common.sh",
         "scripts/tests/fixtures/fake-bazel.sh",
+        "scripts/tests/fixtures/fake-build-governor.sh",
         "scripts/tests/fixtures/fake-df.sh",
     ],
 )

--- a/docs/bazel-development.md
+++ b/docs/bazel-development.md
@@ -108,6 +108,34 @@ CTX_TEST_THREADS=2 \
 The values above are an example, not required machine defaults. Prefer the
 wrapper defaults unless the host or concurrent workload needs an override.
 
+Hosts may opt into a generic external build governor by placing an executable
+at `${XDG_CONFIG_HOME:-$HOME/.config}/ctx/build-governor` or setting the
+absolute `CTX_HOST_BUILD_GOVERNOR` path. Build-capable and other non-light
+commands are invoked as `<governor> bazel <command> -- <exact Bazel argv>`;
+query, informational, and shutdown commands bypass admission. The wrapper
+fails with status 125 when a configured governor is not executable. The
+governor sets `CTX_HOST_BUILD_GOVERNOR_ACTIVE=1` for the managed command so
+nested wrapper calls do not reacquire a lease. The wrapper accepts that marker
+only when its lease ID matches the current systemd lease cgroup; a forged marker
+or an explicitly empty governor path fails with status 125. A governed host
+defaults Bazel jobs and local CPU resources to 16 while preserving explicit
+resource overrides.
+
+## Optional remote execution
+
+The repository defines one opt-in REAPI profile: `--config=ctx-reapi`. It sends
+every remotely eligible spawn action to the configured executor and disables
+local fallback. Connection and authentication settings remain external to the
+repository and must be supplied by the Bazel invocation or machine
+configuration.
+
+After those external settings are available, use the profile with an ordinary
+wrapper command:
+
+```bash
+scripts/bazelw test //crates/ctx-cli:unit_tests --config=ctx-reapi
+```
+
 ## Focused, affected, and complete checks
 
 ```bash

--- a/scripts/bazelw
+++ b/scripts/bazelw
@@ -14,6 +14,63 @@ else
   repo_root="${script_repo_root}"
 fi
 export CTX_REPO_ROOT="${repo_root}"
+
+if (( "$#" == 0 )); then
+  set -- help
+fi
+command_name="$1"
+
+host_build_governor=""
+host_build_governed=0
+host_build_governor_active=0
+if [[ "${CTX_HOST_BUILD_GOVERNOR_ACTIVE:-0}" == "1" ]]; then
+  lease_id="${CTX_BUILD_GOVERNOR_LEASE_ID:-}"
+  lease_class="${CTX_BUILD_GOVERNOR_LEASE_CLASS:-}"
+  if [[ ! "$lease_id" =~ ^[0-9a-f]{32}$ || ! "$lease_class" =~ ^(heavy|light|remote)$ ]] ||
+    ! grep -Fq -- "/ctx-build-lease-${lease_id}.service" /proc/self/cgroup; then
+    printf 'CTX host build governor active marker is not backed by the current lease cgroup\n' >&2
+    exit 125
+  fi
+  host_build_governor_active=1
+fi
+case "${command_name}" in
+  analyze-profile|aquery|canonicalize-flags|cquery|dump|help|info|license|query|shutdown|version)
+    ;;
+  *)
+    if (( host_build_governor_active == 0 )); then
+      if [[ -v CTX_HOST_BUILD_GOVERNOR ]]; then
+        host_build_governor="${CTX_HOST_BUILD_GOVERNOR}"
+      else
+        config_home="${XDG_CONFIG_HOME:-${HOME:-}/.config}"
+        governor_hook="${config_home}/ctx/build-governor"
+        if [[ -e "${governor_hook}" || -L "${governor_hook}" ]]; then
+          host_build_governor="${governor_hook}"
+        fi
+      fi
+      if [[ -v CTX_HOST_BUILD_GOVERNOR && -z "${host_build_governor}" ]]; then
+        printf 'configured CTX host build governor must not be empty\n' >&2
+        exit 125
+      fi
+      if [[ -n "${host_build_governor}" ]]; then
+        if [[ "${host_build_governor}" != /* || ! -x "${host_build_governor}" ]]; then
+          printf 'configured CTX host build governor must be an absolute executable: %s\n' \
+            "${host_build_governor}" >&2
+          exit 125
+        fi
+        host_build_governed=1
+        if [[ -z "${BAZEL_JOBS:-}" && -z "${CTX_BAZEL_JOBS:-}" ]]; then
+          export CTX_BAZEL_JOBS=16
+        fi
+        if [[ -z "${BAZEL_LOCAL_CPU_RESOURCES:-}" && -z "${CTX_BAZEL_LOCAL_CPU_RESOURCES:-}" ]]; then
+          export CTX_BAZEL_LOCAL_CPU_RESOURCES=16
+        fi
+        if [[ -z "${BAZEL_LOCAL_RAM_RESOURCES:-}" && -z "${CTX_BAZEL_LOCAL_RAM_RESOURCES:-}" ]]; then
+          export CTX_BAZEL_LOCAL_RAM_RESOURCES=49152
+        fi
+      fi
+    fi
+    ;;
+esac
 # shellcheck source=scripts/ci-common.sh
 source "${script_repo_root}/scripts/ci-common.sh"
 
@@ -71,12 +128,14 @@ if [[ "${version_output}" != "bazel ${bazel_version}" ]]; then
   exit 64
 fi
 
-if (( "$#" == 0 )); then
-  set -- help
-fi
-
-command_name="$1"
 shift
+
+run_bazel() {
+  if (( host_build_governed == 1 )); then
+    exec "${host_build_governor}" bazel "${command_name}" -- "$@"
+  fi
+  exec "$@"
+}
 
 printf 'ctx bazel: jobs=%s cpu=%s ram_mb=%s test_jobs=%s rust_threads=%s cache=%s\n' \
   "${BAZEL_JOBS}" \
@@ -99,7 +158,7 @@ case "${command_name}" in
     fi
     ;;
   analyze-profile|canonicalize-flags|clean|dump|help|info|license|version)
-    exec "${bazel_bin}" \
+    run_bazel "${bazel_bin}" \
       --output_user_root="${output_root}" \
       --max_idle_secs="${CTX_BAZEL_MAX_IDLE_SECS:-600}" \
       "${command_name}" "$@"
@@ -129,7 +188,7 @@ case "${command_name}" in
         )
         ;;
     esac
-    exec "${bazel_bin}" \
+    run_bazel "${bazel_bin}" \
       --output_user_root="${output_root}" \
       --max_idle_secs="${CTX_BAZEL_MAX_IDLE_SECS:-600}" \
       "${command_name}" "${shared_args[@]}" "$@"

--- a/scripts/tests/bazelw-test.sh
+++ b/scripts/tests/bazelw-test.sh
@@ -9,6 +9,7 @@ fi
 wrapper="${repo_root}/scripts/bazelw"
 fake_bazel="${repo_root}/scripts/tests/fixtures/fake-bazel.sh"
 fake_df="${repo_root}/scripts/tests/fixtures/fake-df.sh"
+fake_governor="${repo_root}/scripts/tests/fixtures/fake-build-governor.sh"
 test_root="$(mktemp -d "${TEST_TMPDIR:-${TMPDIR:-/tmp}}/ctx-bazelw-test.XXXXXXXX")"
 trap 'rm -rf -- "${test_root}"' EXIT
 
@@ -31,6 +32,8 @@ export CTX_TOTAL_MEMORY_GB=128
 # Exercise the wrapper's default derivation independently from the bounded
 # thread count forwarded by an outer Bazel test invocation.
 unset RUST_TEST_THREADS
+unset CTX_HOST_BUILD_GOVERNOR CTX_HOST_BUILD_GOVERNOR_ACTIVE
+unset CTX_BUILD_GOVERNOR_LEASE_ID CTX_BUILD_GOVERNOR_LEASE_CLASS XDG_CONFIG_HOME
 export HOME="${test_root}/home"
 export TMPDIR="${test_root}/tmp"
 mkdir -p "${HOME}" "${TMPDIR}"
@@ -125,5 +128,113 @@ export XDG_CACHE_HOME="${test_root}/xdg-low-inode"
 selected_cache="$(ctx_bazel_cache_root)"
 [[ "${selected_cache}" == "${XDG_CACHE_HOME}/ctx/bazel" ]] \
   || fail 'low-inode spacious root did not fall back before invoking Bazel'
+
+grep -Fqx 'build:ctx-reapi --spawn_strategy=remote' "${repo_root}/.bazelrc" \
+  || fail 'ctx-reapi must force eligible spawn actions to remote execution'
+grep -Fqx 'build:ctx-reapi --remote_local_fallback=false' "${repo_root}/.bazelrc" \
+  || fail 'ctx-reapi must disable local fallback'
+grep -Fqx 'test:ctx-reapi --test_strategy=remote' "${repo_root}/.bazelrc" \
+  || fail 'ctx-reapi must force test actions to remote execution'
+[[ "$(grep -cE '^[^#[:space:]][^:[:space:]]*:ctx-reapi[[:space:]]' "${repo_root}/.bazelrc")" == "9" ]] \
+  || fail 'ctx-reapi repository policy has an unexpected directive count'
+
+# An explicitly activated generic host governor wraps build-capable commands,
+# raises healthy single-build defaults, and leaves query/read commands light.
+export XDG_CONFIG_HOME="${test_root}/governor-config"
+export CTX_FAKE_GOVERNOR_LOG="${test_root}/fake-governor.log"
+mkdir -p "${XDG_CONFIG_HOME}/ctx"
+ln -s "${fake_governor}" "${XDG_CONFIG_HOME}/ctx/build-governor"
+unset BAZEL_JOBS BAZEL_LOCAL_CPU_RESOURCES BAZEL_LOCAL_RAM_RESOURCES
+unset CTX_BAZEL_JOBS CTX_BAZEL_LOCAL_CPU_RESOURCES CTX_BAZEL_LOCAL_RAM_RESOURCES
+: >"${CTX_FAKE_GOVERNOR_LOG}"
+: >"${CTX_FAKE_BAZEL_LOG}"
+"${wrapper}" test //:governed --config=test 2>"${test_root}/governed-config.log"
+grep -Fqx 'mode=bazel' "${CTX_FAKE_GOVERNOR_LOG}" || fail 'heavy command did not use governor'
+grep -Fqx 'command=test' "${CTX_FAKE_GOVERNOR_LOG}" || fail 'governor command classification missing'
+grep -Fqx 'jobs=16' "${CTX_FAKE_GOVERNOR_LOG}" || fail 'governed jobs default is not 16'
+grep -Fqx 'cpu=16' "${CTX_FAKE_GOVERNOR_LOG}" || fail 'governed CPU default is not 16'
+grep -Fqx 'ram=49152' "${CTX_FAKE_GOVERNOR_LOG}" || fail 'governed memory default is not bounded'
+assert_log_line 'arg=--jobs=16'
+assert_log_line 'arg=--local_resources=cpu=16'
+
+mapfile -t governed_argv < <(sed -n 's/^argv=//p' "${CTX_FAKE_GOVERNOR_LOG}")
+mapfile -t executed_argv < <(sed -n 's/^arg=//p' "${CTX_FAKE_BAZEL_LOG}")
+[[ "${governed_argv[0]:-}" == "${fake_bazel}" ]] \
+  || fail 'governor did not receive the Bazel executable first'
+[[ "${governed_argv[1]:-}" == --output_user_root=* ]] \
+  || fail 'governor did not receive output_user_root as a startup option'
+[[ "${governed_argv[2]:-}" == '--max_idle_secs=600' ]] \
+  || fail 'governor did not receive max_idle_secs before the command'
+[[ "${governed_argv[3]:-}" == 'test' ]] \
+  || fail 'governor did not receive startup options before the Bazel command'
+[[ "${#governed_argv[@]}" == "$(( ${#executed_argv[@]} + 1 ))" ]] \
+  || fail 'governor did not receive the complete Bazel argv'
+for (( index = 0; index < ${#executed_argv[@]}; index++ )); do
+  [[ "${governed_argv[index + 1]}" == "${executed_argv[index]}" ]] \
+    || fail "governor changed Bazel argument $index"
+done
+
+for governed_command in build coverage run clean; do
+  : >"${CTX_FAKE_GOVERNOR_LOG}"
+  : >"${CTX_FAKE_BAZEL_LOG}"
+  "${wrapper}" "${governed_command}" //:governed \
+    2>"${test_root}/${governed_command}-governed-config.log"
+  grep -Fqx 'mode=bazel' "${CTX_FAKE_GOVERNOR_LOG}" \
+    || fail "${governed_command} did not use governor"
+  grep -Fqx "command=${governed_command}" "${CTX_FAKE_GOVERNOR_LOG}" \
+    || fail "${governed_command} classification was not forwarded"
+done
+
+: >"${CTX_FAKE_GOVERNOR_LOG}"
+: >"${CTX_FAKE_BAZEL_LOG}"
+BAZEL_JOBS=5 \
+BAZEL_LOCAL_CPU_RESOURCES=3 \
+BAZEL_LOCAL_RAM_RESOURCES=4096 \
+  "${wrapper}" build //:governed-override 2>"${test_root}/governed-override-config.log"
+grep -Fqx 'jobs=5' "${CTX_FAKE_GOVERNOR_LOG}" || fail 'governor changed explicit jobs override'
+grep -Fqx 'cpu=3' "${CTX_FAKE_GOVERNOR_LOG}" || fail 'governor changed explicit CPU override'
+grep -Fqx 'ram=4096' "${CTX_FAKE_GOVERNOR_LOG}" || fail 'governor changed explicit memory override'
+assert_log_line 'arg=--jobs=5'
+assert_log_line 'arg=--local_resources=cpu=3'
+assert_log_line 'arg=--local_resources=memory=4096'
+
+: >"${CTX_FAKE_GOVERNOR_LOG}"
+"${wrapper}" query //... >/dev/null 2>"${test_root}/query-config.log"
+[[ ! -s "${CTX_FAKE_GOVERNOR_LOG}" ]] || fail 'light query unexpectedly acquired admission'
+
+: >"${CTX_FAKE_GOVERNOR_LOG}"
+"${wrapper}" shutdown 2>"${test_root}/governed-shutdown-config.log"
+[[ ! -s "${CTX_FAKE_GOVERNOR_LOG}" ]] || fail 'shutdown unexpectedly acquired admission'
+
+: >"${CTX_FAKE_GOVERNOR_LOG}"
+set +e
+CTX_HOST_BUILD_GOVERNOR_ACTIVE=1 "${wrapper}" build //:forged-active \
+  >"${test_root}/forged-active.out" 2>"${test_root}/forged-active.err"
+forged_active_status=$?
+set -e
+[[ "${forged_active_status}" == "125" ]] ||
+  fail "forged active marker exited ${forged_active_status}, expected 125"
+grep -Fq 'active marker is not backed by the current lease cgroup' \
+  "${test_root}/forged-active.err" || fail 'forged active marker did not fail closed'
+
+: >"${CTX_FAKE_GOVERNOR_LOG}"
+set +e
+CTX_HOST_BUILD_GOVERNOR= "${wrapper}" build //:empty-governor \
+  >"${test_root}/empty-governor.out" 2>"${test_root}/empty-governor.err"
+empty_governor_status=$?
+set -e
+[[ "${empty_governor_status}" == "125" ]] ||
+  fail "empty governor override exited ${empty_governor_status}, expected 125"
+grep -Fq 'configured CTX host build governor must not be empty' \
+  "${test_root}/empty-governor.err" || fail 'empty governor override did not fail closed'
+
+set +e
+CTX_HOST_BUILD_GOVERNOR="${test_root}/missing-governor" \
+  "${wrapper}" build //:must-not-run >"${test_root}/missing.out" 2>"${test_root}/missing.err"
+missing_status=$?
+set -e
+[[ "${missing_status}" == "125" ]] || fail "invalid governor exited ${missing_status}, expected 125"
+grep -Fq 'configured CTX host build governor must be an absolute executable' \
+  "${test_root}/missing.err" || fail 'missing governor did not fail closed'
 
 printf 'bazelw tests passed\n'

--- a/scripts/tests/fixtures/fake-build-governor.sh
+++ b/scripts/tests/fixtures/fake-build-governor.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-}"
+command_name="${2:-}"
+shift 2
+[[ "${1:-}" == "--" ]] || {
+  echo 'fake governor: missing separator' >&2
+  exit 2
+}
+shift
+{
+  printf 'mode=%s\n' "${mode}"
+  printf 'command=%s\n' "${command_name}"
+  printf 'jobs=%s\n' "${BAZEL_JOBS:-}"
+  printf 'cpu=%s\n' "${BAZEL_LOCAL_CPU_RESOURCES:-}"
+  printf 'ram=%s\n' "${BAZEL_LOCAL_RAM_RESOURCES:-}"
+  for argument in "$@"; do
+    printf 'argv=%s\n' "${argument}"
+  done
+} >>"${CTX_FAKE_GOVERNOR_LOG:?}"
+exec "$@"


### PR DESCRIPTION
## Summary

- add an optional external governor hook to the public Bazel wrapper
- add an endpoint-neutral, opt-in ctx-reapi profile with no local fallback
- preserve ordinary local builds when no governor or REAPI configuration is present
- cover wrapper behavior with focused tests and public documentation

## Validation

- scripts/bazelw test //:bazel_wrapper_tests --config=ci
- git diff --check origin/main...HEAD

The installed host policy remains local; this PR does not activate remote execution.