### PR TITLE
fix(build): support macOS system Bash

### DIFF
--- a/scripts/bazelw
+++ b/scripts/bazelw
@@ -38,7 +38,7 @@ case "${command_name}" in
     ;;
   *)
     if (( host_build_governor_active == 0 )); then
-      if [[ -v CTX_HOST_BUILD_GOVERNOR ]]; then
+      if [[ "${CTX_HOST_BUILD_GOVERNOR+x}" == "x" ]]; then
         host_build_governor="${CTX_HOST_BUILD_GOVERNOR}"
       else
         config_home="${XDG_CONFIG_HOME:-${HOME:-}/.config}"
@@ -47,7 +47,7 @@ case "${command_name}" in
           host_build_governor="${governor_hook}"
         fi
       fi
-      if [[ -v CTX_HOST_BUILD_GOVERNOR && -z "${host_build_governor}" ]]; then
+      if [[ "${CTX_HOST_BUILD_GOVERNOR+x}" == "x" && -z "${host_build_governor}" ]]; then
         printf 'configured CTX host build governor must not be empty\n' >&2
         exit 125
       fi

--- a/scripts/tests/bazelw-test.sh
+++ b/scripts/tests/bazelw-test.sh
@@ -33,6 +33,11 @@ export CTX_TOTAL_MEMORY_GB=128
 # thread count forwarded by an outer Bazel test invocation.
 unset RUST_TEST_THREADS
 unset CTX_HOST_BUILD_GOVERNOR CTX_HOST_BUILD_GOVERNOR_ACTIVE
+
+if grep -Eq '\[\[[[:space:]]+-v[[:space:]]' "${wrapper}"; then
+  echo 'bazel wrapper must remain compatible with the Bash 3.2 shipped by macOS' >&2
+  exit 1
+fi
 unset CTX_BUILD_GOVERNOR_LEASE_ID CTX_BUILD_GOVERNOR_LEASE_CLASS XDG_CONFIG_HOME
 export HOME="${test_root}/home"
 export TMPDIR="${test_root}/tmp"


### PR DESCRIPTION
## Summary
- replace Bash 4.2-only variable-presence checks in `scripts/bazelw`
- preserve unset versus explicitly-empty governor semantics
- add a regression guard for the Bash 3.2 compatibility boundary

## Validation
- `//:bazel_wrapper_tests` passes under Bazel 7.7.1
- `bash -n` and `git diff --check` pass
- independent Sol review: APPROVE, no findings
- exact merged-tree macOS native qualification exposed the original parser failure