### PR TITLE
Fix Bazel 9 release contracts and macOS symbols

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -510,11 +510,14 @@ py_binary(
 
 py_test(
     name = "dependency_advisory_gate_tests",
+    args = ["$(rootpath :dependency_advisory_gate)"],
     srcs = [
         "scripts/dependency-advisory-gate.py",
         "scripts/tests/dependency-advisory-gate-test.py",
     ],
-    data = glob(["scripts/tests/fixtures/dependency-advisory/**"]),
+    data = glob(["scripts/tests/fixtures/dependency-advisory/**"]) + [
+        ":dependency_advisory_gate",
+    ],
     deps = ["@ctx_tomli//:lib"],
     main = "scripts/tests/dependency-advisory-gate-test.py",
     tags = ["release-gate", "security"],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -212,6 +212,8 @@ http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_j
 http_archive(
     name = "ctx_tomli",
     build_file_content = """
+load("@rules_python//python:defs.bzl", "py_library")
+
 package(default_visibility = ["//visibility:public"])
 
 py_library(

--- a/crates/ctx-cli/src/pro/lifecycle_commands.rs
+++ b/crates/ctx-cli/src/pro/lifecycle_commands.rs
@@ -259,22 +259,27 @@ pub(crate) fn run_lifecycle(args: ProArgs, data_root: PathBuf, ui: &mut Ui) -> R
     let human_output = !args.json_output();
     let retry_command = render::human_retry_command(&args);
     let mut telemetry = ProLifecycleTelemetryV1::new(args.telemetry_operation());
-    let result = run_lifecycle_inner(args, &data_root, &mut telemetry, ui);
+    let control_validation = crate::pro::commercial_config::reject_test_control_outside_test_host();
+    let emit_telemetry = control_validation.is_ok();
+    let result =
+        control_validation.and_then(|()| run_lifecycle_inner(args, &data_root, &mut telemetry, ui));
     #[cfg(ctx_pro_test_helper)]
     let result = crate::pro::test_control::finish(result);
     if let Err(error) = &result {
         telemetry.fail(stable_error_code(error));
     }
-    send_pro_operation(
-        &data_root,
-        ProHostOperationV1::Lifecycle(telemetry),
-        if result.is_ok() {
-            Outcome::Success
-        } else {
-            Outcome::Failure
-        },
-        started.elapsed(),
-    );
+    if emit_telemetry {
+        send_pro_operation(
+            &data_root,
+            ProHostOperationV1::Lifecycle(telemetry),
+            if result.is_ok() {
+                Outcome::Success
+            } else {
+                Outcome::Failure
+            },
+            started.elapsed(),
+        );
+    }
     crate::pro::human_result(result, human_output, retry_command, ui)
 }
 
@@ -284,7 +289,6 @@ fn run_lifecycle_inner(
     telemetry: &mut ProLifecycleTelemetryV1,
     ui: &mut Ui,
 ) -> Result<()> {
-    crate::pro::commercial_config::reject_test_control_outside_test_host()?;
     #[cfg(ctx_pro_test_helper)]
     crate::pro::test_control::prepare()?;
     args.validate_invocation()?;

--- a/crates/ctx-cli/src/semantic/daemon/tests.rs
+++ b/crates/ctx-cli/src/semantic/daemon/tests.rs
@@ -1430,6 +1430,33 @@ fn source_refresh_only_status_exposes_runtime_and_certified_refresh_identity() -
 
 #[test]
 fn post_lock_initialization_failure_retains_restart_intent() -> Result<()> {
+    struct RestoreUpgradeTarget(Option<std::ffi::OsString>);
+    impl Drop for RestoreUpgradeTarget {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => std::env::set_var("CTX_UPGRADE_TEST_TARGET", value),
+                None => std::env::remove_var("CTX_UPGRADE_TEST_TARGET"),
+            }
+        }
+    }
+
+    let _env_lock = crate::config::TEST_LOCAL_USAGE_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _restore_upgrade_target = RestoreUpgradeTarget(std::env::var_os("CTX_UPGRADE_TEST_TARGET"));
+    let installation = tempfile::tempdir()?;
+    let installation_executable =
+        installation
+            .path()
+            .join(if cfg!(windows) { "ctx.exe" } else { "ctx" });
+    fs::write(&installation_executable, b"test ctx executable")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        fs::set_permissions(&installation_executable, fs::Permissions::from_mode(0o700))?;
+    }
+    std::env::set_var("CTX_UPGRADE_TEST_TARGET", &installation_executable);
+
     let root = tempfile::tempdir()?;
     super::super::daemon_autostart::write_daemon_restart_request(
         root.path(),
@@ -1456,9 +1483,11 @@ fn post_lock_initialization_failure_retains_restart_intent() -> Result<()> {
     )
     .expect_err("the injected post-lock initialization failure must surface");
 
-    assert!(error
-        .to_string()
-        .contains("injected daemon failure before readiness"));
+    let rendered_error = error.to_string();
+    assert!(
+        rendered_error.contains("injected daemon failure before readiness"),
+        "unexpected daemon initialization error: {rendered_error}"
+    );
     assert!(super::super::daemon_autostart::read_daemon_restart_request(root.path()).is_some());
     Ok(())
 }

--- a/scripts/cli-ux/observe_test.py
+++ b/scripts/cli-ux/observe_test.py
@@ -6,6 +6,7 @@ import errno
 import hashlib
 import json
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -36,6 +37,12 @@ class ObserverTests(unittest.TestCase):
         )
         self.addCleanup(self.temporary.cleanup)
         self.root_parent = Path(self.temporary.name)
+        self.observed_python = self.root_parent / "python"
+        self.observed_python.write_text(
+            f"#!/bin/sh\nexec {shlex.quote(sys.executable)} \"$@\"\n",
+            encoding="utf-8",
+        )
+        self.observed_python.chmod(0o700)
 
     def run_fixture(
         self,
@@ -49,7 +56,7 @@ class ObserverTests(unittest.TestCase):
         stdin: bytes | str = b"",
     ) -> dict[str, object]:
         receipt = observe.observe(
-            [sys.executable, str(FIXTURE), mode, *arguments],
+            [str(self.observed_python), str(FIXTURE), mode, *arguments],
             columns=columns,
             rows=rows,
             timeout_ms=timeout_ms,
@@ -175,6 +182,15 @@ class ObserverTests(unittest.TestCase):
             stdin_receipt["observed"]["plain_projection"]["text"],
             "stdin:'hello\\n'\n",
         )
+
+    def test_group_writable_executable_is_rejected(self) -> None:
+        executable = self.root_parent / "group-writable"
+        executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        executable.chmod(0o720)
+        with self.assertRaisesRegex(
+            observe.ObservationError, "group- or world-writable"
+        ):
+            observe._resolve_executable([str(executable)])
 
     def test_failure_signal_and_timeout_are_distinct(self) -> None:
         failed = self.run_fixture("exit")
@@ -313,7 +329,7 @@ class ObserverTests(unittest.TestCase):
                 "--output",
                 str(output),
                 "--",
-                sys.executable,
+                str(self.observed_python),
                 str(FIXTURE),
                 "environment",
             ],
@@ -347,7 +363,7 @@ class ObserverTests(unittest.TestCase):
                 "--output",
                 str(timeout_output),
                 "--",
-                sys.executable,
+                str(self.observed_python),
                 str(FIXTURE),
                 "timeout",
             ],

--- a/scripts/release/detached-debug-symbols.py
+++ b/scripts/release/detached-debug-symbols.py
@@ -720,7 +720,12 @@ def prepare_macho(
         fail("dsymutil did not produce one nonempty DWARF image")
     if macho_uuid(dwarf_files[0]) != identifier:
         fail("dSYM UUID differs from the release intermediate")
-    run([str(tools["strip"]), "-S", "-x", str(artifact)])
+    # Rust's Mach-O link can leave an N_OPT `radr://...` entry after the
+    # conventional debug/local-symbol strip.  It is an nlist marker rather
+    # than a runtime export, and the shipping CLI does not expose an nlist
+    # interface.  Remove the nlist/string table as well so the detached dSYM
+    # is the only symbol authority carried by the release.
+    run([str(tools["strip"]), "-S", "-x", "-N", str(artifact)])
     if macho_uuid(artifact) != identifier:
         fail("Mach-O UUID changed while detaching symbols")
     return "mach-o-uuid", identifier

--- a/scripts/tests/dependency-advisory-gate-test.py
+++ b/scripts/tests/dependency-advisory-gate-test.py
@@ -14,6 +14,7 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts/dependency-advisory-gate.py"
+GATE = Path(sys.argv.pop(1)).resolve(strict=True)
 FIXTURES = ROOT / "scripts/tests/fixtures/dependency-advisory"
 FAKE_SCANNER = FIXTURES / "fake-osv-scanner.py"
 NOW = "2026-07-29T17:00:00Z"
@@ -122,8 +123,7 @@ class AdvisoryGateTest(unittest.TestCase):
         environment["FAKE_OSV_EXIT"] = str(scanner_exit)
         result = subprocess.run(
             [
-                sys.executable,
-                str(SCRIPT),
+                str(GATE),
                 "--repo-root",
                 str(self.repo),
                 "--policy",

--- a/scripts/tests/detached-debug-symbols-test.py
+++ b/scripts/tests/detached-debug-symbols-test.py
@@ -18,6 +18,7 @@ import tempfile
 import unittest
 import uuid
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -231,6 +232,44 @@ int main(void) { printf("%d\\n", answer()); return 0; }
             + identifier.bytes
         )
         self.assertEqual(SYMBOL_TOOL.macho_uuid(macho), str(identifier))
+
+    def test_macho_prepare_removes_the_nlist_symbol_table(self) -> None:
+        artifact = self.directory / "ctx-macos"
+        artifact.write_bytes(b"shipping binary")
+        symbol_tree = self.directory / "macho-symbols"
+        symbol_tree.mkdir()
+        dsymutil = self.directory / "dsymutil"
+        strip = self.directory / "strip"
+        calls: list[list[str]] = []
+
+        def fake_run(arguments: list[str], **_kwargs: object) -> str:
+            command = [str(argument) for argument in arguments]
+            calls.append(command)
+            if command[0] == str(dsymutil):
+                output = Path(command[command.index("-o") + 1])
+                dwarf = output / "Contents" / "Resources" / "DWARF" / artifact.name
+                dwarf.parent.mkdir(parents=True)
+                dwarf.write_bytes(b"detached symbols")
+            return ""
+
+        identifier = "12345678-1234-5678-9abc-def012345678"
+        with (
+            mock.patch.object(SYMBOL_TOOL, "run", side_effect=fake_run),
+            mock.patch.object(SYMBOL_TOOL, "macho_uuid", return_value=identifier),
+        ):
+            self.assertEqual(
+                SYMBOL_TOOL.prepare_macho(
+                    artifact,
+                    symbol_tree,
+                    {"dsymutil": dsymutil, "strip": strip},
+                ),
+                ("mach-o-uuid", identifier),
+            )
+
+        self.assertIn(
+            [str(strip), "-S", "-x", "-N", str(artifact)],
+            calls,
+        )
 
     def test_ignores_all_hostile_ambient_symbol_tools(self) -> None:
         hostile_bin = self.directory / "hostile-bin"

--- a/scripts/tests/native-bazel-packaging-contract-test.sh
+++ b/scripts/tests/native-bazel-packaging-contract-test.sh
@@ -29,6 +29,12 @@ grep -Fxq 'build:release --lockfile_mode=error' "${release_config}" || {
   exit 1
 }
 
+grep -Fq 'load("@rules_python//python:defs.bzl", "py_library")' \
+  "${module_definition}" || {
+  echo 'Bazel 9 external tomli repository must load py_library explicitly' >&2
+  exit 1
+}
+
 python3 - "${module_lock}" <<'PY'
 import json
 from pathlib import Path

--- a/scripts/tests/package-public-cli-bazel-release-test.sh
+++ b/scripts/tests/package-public-cli-bazel-release-test.sh
@@ -33,6 +33,27 @@ trap cleanup EXIT
 repo="${test_root}/repo"
 runfiles="${test_root}/runfiles"
 route_runfiles="${runfiles}/_main/ctx_release_routes/linux-x64"
+advisory_launcher="${source_root}/dependency_advisory_gate"
+advisory_stage2="${source_root}/_dependency_advisory_gate_stage2_bootstrap.py"
+advisory_venv="${source_root}/_dependency_advisory_gate.venv"
+tomli_repo="+http_archive+ctx_tomli"
+python_runfile="$(sed -n \
+  's/^PYTHON_BINARY_ACTUAL = "\([^"]*\)"$/\1/p' "${advisory_launcher}")"
+python_repo="${python_runfile%%/*}"
+[[ -x "${advisory_launcher}" && -f "${advisory_stage2}" && \
+  -d "${advisory_venv}" ]] || {
+  echo "dependency advisory gate Python launcher runfiles are incomplete" >&2
+  exit 1
+}
+[[ "${python_runfile}" == */* && \
+  -x "${TEST_SRCDIR}/${python_runfile}" ]] || {
+  echo "dependency advisory gate Python interpreter runfile is unavailable" >&2
+  exit 1
+}
+[[ -d "${TEST_SRCDIR}/${tomli_repo}" ]] || {
+  echo "dependency advisory gate tomli runfiles are unavailable" >&2
+  exit 1
+}
 mkdir -p \
   "${repo}/scripts" \
   "${repo}/scripts/release" \
@@ -47,8 +68,12 @@ mkdir -p \
   "${route_runfiles}"
 ln -s "${source_root}/scripts/dependency-advisory-gate.py" \
   "${runfiles}/_main/scripts/dependency-advisory-gate.py"
-ln -s "${TEST_SRCDIR}/_main~_repo_rules~ctx_tomli" \
-  "${runfiles}/_main~_repo_rules~ctx_tomli"
+ln -s "${advisory_stage2}" \
+  "${runfiles}/_main/_dependency_advisory_gate_stage2_bootstrap.py"
+ln -s "${advisory_venv}" \
+  "${runfiles}/_main/_dependency_advisory_gate.venv"
+ln -s "${TEST_SRCDIR}/${python_repo}" "${runfiles}/${python_repo}"
+ln -s "${TEST_SRCDIR}/${tomli_repo}" "${runfiles}/${tomli_repo}"
 ln -s "${TEST_SRCDIR}/bazel_tools" "${runfiles}/bazel_tools"
 ln -s "${pinned_rustc}" "${route_runfiles}/rustc"
 ln -s "${pinned_rust_objcopy}" "${route_runfiles}/rust-objcopy"
@@ -416,8 +441,7 @@ path.write_text(
 )
 PY
 
-test -x "${source_root}/dependency_advisory_gate"
-ln -s "${source_root}/dependency_advisory_gate" \
+ln -s "${advisory_launcher}" \
   "${route_runfiles}/advisory-gate"
 ln -s "${repo}/scripts/release-sbom.py" "${route_runfiles}/sbom-tool"
 ln -s "${artifact}" "${route_runfiles}/artifact"


### PR DESCRIPTION
## Summary
- strip macOS release nlist tables so binary compatibility checks accept native artifacts
- adapt Bazel 9 rules_python runfiles and test launchers
- preserve owner-safe executable validation in tests
- reject forbidden Pro test control before telemetry side effects
- isolate the daemon restart-intent test from shared build output permissions

## Validation
- independent review: APPROVE, no P0-P3 findings
- focused release and CI targets pass uncached
- full //:ci: 123/124 targets passed; sole nested-Bazel inventory target hit a concurrent output race and passed immediately in an uncached isolated rerun
- cargo fmt --check and git diff --check pass
- native Apple M1 package, symbol, smoke, and compatibility proof passed for the macOS strip change before convergence