### PR TITLE
Enforce LF release-input checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Adds a repository-wide text=auto/eol=lf policy so Git for Windows cannot rewrite hashed Bazel and Cargo release inputs to CRLF. Binary classification remains automatic.\n\nValidation:\n- renormalization changes no existing tracked blob\n- forced core.autocrlf=true fresh clone preserves Cargo.lock, MODULE.bazel.lock, shell, and PowerShell bytes as LF\n- independent review: APPROVE, no P0-P3 findings