### PR TITLE
Support Python 3.9 in sidecar archive tool

### DIFF
--- a/scripts/onnxruntime-sidecar/archive_tool.py
+++ b/scripts/onnxruntime-sidecar/archive_tool.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Create and safely extract the fixed ONNX Runtime sidecar archive shape."""
 
+from __future__ import annotations
+
 import argparse
 import datetime
 import posixpath

--- a/scripts/tests/onnxruntime-sidecar-tools-test.py
+++ b/scripts/tests/onnxruntime-sidecar-tools-test.py
@@ -316,6 +316,10 @@ class ManifestTests(unittest.TestCase):
             self.assertNotIn("macos-release-signing-evidence.py", text, path.name)
             self.assertNotIn("temporary_output", text, path.name)
 
+    def test_archive_tool_defers_annotations_for_macos_python(self) -> None:
+        source = (TOOLS / "archive_tool.py").read_text().splitlines()
+        self.assertIn("from __future__ import annotations", source[:6])
+
 
 class ArchiveTests(unittest.TestCase):
     def test_cuda_archive_shape_is_exactly_eighteen_files(self) -> None:


### PR DESCRIPTION
Defers type-annotation evaluation so the ONNX Runtime sidecar archive tool runs on the macOS system Python 3.9.6. Archive behavior is unchanged.\n\nValidation:\n- //:onnxruntime_sidecar_tools_tests uncached\n- direct import with native M1 Python 3.9.6\n- independent review: APPROVE, no P0-P3 findings