### PR TITLE
release: qualify FreeBSD advisory scanner

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -456,6 +456,7 @@ py_test(
     srcs = ["scripts/check-release-target-matrix.py"],
     main = "scripts/check-release-target-matrix.py",
     data = [
+        ":release_advisory_policy",
         ":release_contracts",
         "//tools/bazel:release_inventory.bzl",
     ],
@@ -469,7 +470,10 @@ py_test(
         "scripts/tests/check-release-target-matrix-test.py",
     ],
     main = "scripts/tests/check-release-target-matrix-test.py",
-    data = [":release_contracts"],
+    data = [
+        ":release_advisory_policy",
+        ":release_contracts",
+    ],
     tags = ["release-gate"],
 )
 

--- a/scripts/check-release-target-matrix.py
+++ b/scripts/check-release-target-matrix.py
@@ -12,6 +12,7 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 MATRIX_PATH = ROOT / "contracts" / "release-targets-v1.json"
+ADVISORY_POLICY_PATH = ROOT / "security" / "release-advisory-policy-v1.json"
 BAZEL_CONSUMER_PATH = ROOT / "tools" / "bazel" / "release_inventory.bzl"
 GENERATED_BEGIN = "# BEGIN GENERATED: contracts/release-targets-v1.json"
 GENERATED_END = "# END GENERATED: contracts/release-targets-v1.json"
@@ -125,6 +126,44 @@ def load_and_validate(path: Path = MATRIX_PATH) -> dict[str, Any]:
     return value
 
 
+def validate_advisory_policy_coverage(
+    value: dict[str, Any], path: Path = ADVISORY_POLICY_PATH
+) -> None:
+    policy = json.loads(path.read_text(encoding="utf-8"))
+    scanner = policy.get("scanner")
+    scanner_hashes = (
+        scanner.get("sha256_by_target") if isinstance(scanner, dict) else None
+    )
+    if not isinstance(scanner_hashes, dict):
+        raise ValueError("release advisory scanner target map is missing")
+    release_targets = {target["id"] for target in value["targets"]}
+    scanner_targets = set(scanner_hashes)
+    if scanner_targets != release_targets:
+        missing = sorted(release_targets - scanner_targets)
+        unexpected = sorted(scanner_targets - release_targets)
+        details = []
+        if missing:
+            details.append("missing: " + ", ".join(missing))
+        if unexpected:
+            details.append("unexpected: " + ", ".join(unexpected))
+        raise ValueError(
+            "release advisory scanner targets do not match release matrix ("
+            + "; ".join(details)
+            + ")"
+        )
+    malformed = sorted(
+        target
+        for target, digest in scanner_hashes.items()
+        if not isinstance(digest, str)
+        or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+    )
+    if malformed:
+        raise ValueError(
+            "release advisory scanner has malformed SHA-256 for: "
+            + ", ".join(malformed)
+        )
+
+
 def generated_bazel_consumer(value: dict[str, Any]) -> str:
     rows = [
         f'    "{target["id"]}": ("{target["bazel_platform"]}", '
@@ -158,6 +197,7 @@ def main() -> int:
         if sys.argv[1:] not in ([], ["--write-bazel-consumer"]):
             raise ValueError("usage: check-release-target-matrix.py [--write-bazel-consumer]")
         value = load_and_validate()
+        validate_advisory_policy_coverage(value)
         if BAZEL_CONSUMER_PATH.is_file():
             if sys.argv[1:]:
                 source = BAZEL_CONSUMER_PATH.read_text(encoding="utf-8")

--- a/scripts/tests/check-release-target-matrix-test.py
+++ b/scripts/tests/check-release-target-matrix-test.py
@@ -20,6 +20,7 @@ SPEC.loader.exec_module(matrix)
 class ReleaseTargetMatrixTest(unittest.TestCase):
     def test_repository_matrix_is_exact(self) -> None:
         value = matrix.load_and_validate()
+        matrix.validate_advisory_policy_coverage(value)
         self.assertEqual(
             [target["id"] for target in value["targets"]],
             list(matrix.SUPPORTED_TARGET_IDS),
@@ -54,6 +55,36 @@ class ReleaseTargetMatrixTest(unittest.TestCase):
             linux["linux_build"]["rust_sysroot"],
             "/opt/rustup/toolchains/1.97.1-x86_64-unknown-linux-gnu",
         )
+
+    def test_advisory_scanner_must_cover_every_release_target(self) -> None:
+        value = matrix.load_and_validate()
+        policy = json.loads(matrix.ADVISORY_POLICY_PATH.read_text(encoding="utf-8"))
+        del policy["scanner"]["sha256_by_target"]["freebsd-x64"]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "release-advisory-policy-v1.json"
+            path.write_text(json.dumps(policy), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "missing: freebsd-x64"):
+                matrix.validate_advisory_policy_coverage(value, path)
+
+    def test_advisory_scanner_rejects_unexpected_targets(self) -> None:
+        value = matrix.load_and_validate()
+        policy = json.loads(matrix.ADVISORY_POLICY_PATH.read_text(encoding="utf-8"))
+        policy["scanner"]["sha256_by_target"]["freebsd-arm64"] = "1" * 64
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "release-advisory-policy-v1.json"
+            path.write_text(json.dumps(policy), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "unexpected: freebsd-arm64"):
+                matrix.validate_advisory_policy_coverage(value, path)
+
+    def test_advisory_scanner_rejects_malformed_digest(self) -> None:
+        value = matrix.load_and_validate()
+        policy = json.loads(matrix.ADVISORY_POLICY_PATH.read_text(encoding="utf-8"))
+        policy["scanner"]["sha256_by_target"]["freebsd-x64"] = None
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "release-advisory-policy-v1.json"
+            path.write_text(json.dumps(policy), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "malformed SHA-256 for: freebsd-x64"):
+                matrix.validate_advisory_policy_coverage(value, path)
 
     def test_diagnostic_runner_cannot_be_authoritative(self) -> None:
         value = matrix.load_and_validate()

--- a/security/release-advisory-policy-v1.json
+++ b/security/release-advisory-policy-v1.json
@@ -4,6 +4,7 @@
     "name": "osv-scanner",
     "version": "2.4.0",
     "sha256_by_target": {
+      "freebsd-x64": "5e9343ae565c37a6d1767e0b2a55fb59158890ffb480797fb602e22fb48b478e",
       "linux-x64": "15314940c10d26af9c6649f150b8a47c1262e8fc7e17b1d1029b0e479e8ed8a0",
       "linux-arm64": "44e580752910f0ff36ec99aff59af20f65df1e859aa31e5605a8f0d055b496e9",
       "macos-arm64": "9ca3185ad63e9ab54f7cb90f46a7362be02d80e37f0123d095a54355ea202f5d",


### PR DESCRIPTION
Adds the native FreeBSD x64 OSV Scanner 2.4.0 binary digest to the sealed advisory policy and makes release-target coverage exact and fail-closed.

Provenance: official signed FreeBSD package osv-scanner-2.4.0_1 (FreeBSD:14:amd64); installed native binary reports upstream 2.4.0 and hashes to 5e9343ae565c37a6d1767e0b2a55fb59158890ffb480797fb602e22fb48b478e.

Validation:
- //:release_target_matrix_check
- //:release_target_matrix_tests
- //:dependency_advisory_gate_tests
- //:public_cli_bazel_release_contract
- independent review PASS after adding malformed/unexpected target regressions