### PR TITLE
build: expose pinned dlltool to Windows Rust actions

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -251,10 +251,12 @@ py_test(
     args = [
         "$(rootpath MODULE.bazel)",
         "$(rootpath contracts/release-targets-v1.json)",
+        "$(rootpath //tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch)",
     ],
     data = [
         "MODULE.bazel",
         "contracts/release-targets-v1.json",
+        "//tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch",
     ],
 )
 
@@ -267,6 +269,7 @@ py_test(
     data = [
         "MODULE.bazel",
         "contracts/release-targets-v1.json",
+        "//tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch",
     ],
     imports = ["tools/bazel"],
     main = "//tools/bazel:check_rust_toolchain_pins_test.py",
@@ -857,6 +860,7 @@ sh_test(
         "scripts/stage-semantic-release-handoff.sh",
         "//tools/bazel:release_routes.bzl",
         "//tools/bazel/patches:rules-rust-freebsd-host.patch",
+        "//tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch",
     ],
     tags = ["release-gate"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,12 +13,16 @@ bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "platforms", version = "1.1.0")
 
 # rules_rust 0.71.3 publishes the x86_64-unknown-freebsd toolchain, but its
-# host detector omits FreeBSD. Keep native FreeBSD release construction on the
-# pinned module with the smallest possible upstream patch.
+# host detector omits FreeBSD, and Windows-GNU raw-dylib compilation does not
+# discover the selected C++ toolchain's dlltool. Keep native release
+# construction on the pinned module with the smallest possible upstream fixes.
 single_version_override(
     module_name = "rules_rust",
     patch_strip = 1,
-    patches = ["//tools/bazel/patches:rules-rust-freebsd-host.patch"],
+    patches = [
+        "//tools/bazel/patches:rules-rust-freebsd-host.patch",
+        "//tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch",
+    ],
     version = "0.71.3",
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -497,7 +497,7 @@
     },
     "@@rules_rust+//crate_universe:extensions.bzl%crate": {
       "general": {
-        "bzlTransitiveDigest": "WhRNsYW7B4LBk+68iRWNiYRwZu9KVbwq01S7mj18jGU=",
+        "bzlTransitiveDigest": "qL3sSlj9UfbrFrXGxVG/YFFPId7vO9RcW1XsCZdKZ0A=",
         "usagesDigest": "smlcd296BSO7bKl00H5EjAeWv6dmGaGYfjx58mde3eE=",
         "recordedInputs": [
           "ENV:CARGO_BAZEL_DEBUG \\0",
@@ -6997,7 +6997,7 @@
     },
     "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
       "general": {
-        "bzlTransitiveDigest": "zKMEz8bCDR8KFgYqm1jrD5t/Lgg0gFwfFyX5yeEVVXc=",
+        "bzlTransitiveDigest": "LjJaGRJvM0xwbywHpeXuhXA8OOTlSogdhKXPiPTWzz8=",
         "usagesDigest": "cXwM8V1dYpvU0qY6LVYuUUf4Ql389ZhymEzwJhYVr2o=",
         "recordedInputs": [
           "REPO_MAPPING:apple_support+,bazel_skylib bazel_skylib+",

--- a/scripts/tests/native-bazel-packaging-contract-test.sh
+++ b/scripts/tests/native-bazel-packaging-contract-test.sh
@@ -22,7 +22,8 @@ release_routes="${source_root}/tools/bazel/release_routes.bzl"
 release_config="${source_root}/.bazelrc"
 module_definition="${source_root}/MODULE.bazel"
 module_lock="${source_root}/MODULE.bazel.lock"
-rules_rust_patch="${source_root}/tools/bazel/patches/rules-rust-freebsd-host.patch"
+rules_rust_freebsd_patch="${source_root}/tools/bazel/patches/rules-rust-freebsd-host.patch"
+rules_rust_windows_patch="${source_root}/tools/bazel/patches/rules-rust-windows-gnu-dlltool-path.patch"
 
 grep -Fxq 'build:release --lockfile_mode=error' "${release_config}" || {
   echo 'release config must fail closed on incomplete module lock data' >&2
@@ -50,17 +51,30 @@ if not facts or not all(isinstance(value, dict) and value for value in facts.val
     )
 PY
 
-grep -Fq 'patches = ["//tools/bazel/patches:rules-rust-freebsd-host.patch"]' \
-  "${module_definition}" || {
-  echo 'rules_rust must retain the pinned FreeBSD host patch' >&2
-  exit 1
-}
+for required_patch in \
+  '//tools/bazel/patches:rules-rust-freebsd-host.patch' \
+  '//tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch'; do
+  grep -Fq -- "${required_patch}" "${module_definition}" || {
+    printf 'rules_rust must retain release patch: %s\n' "${required_patch}" >&2
+    exit 1
+  }
+done
 for required_patch_line in \
   '+        "freebsd": ["x86_64"],' \
   '+    if "freebsd" in repository_ctx.os.name:' \
   '+        return triple("{}-unknown-freebsd".format(arch))'; do
-  grep -Fq -- "${required_patch_line}" "${rules_rust_patch}" || {
+  grep -Fq -- "${required_patch_line}" "${rules_rust_freebsd_patch}" || {
     echo "rules_rust FreeBSD host patch is missing: ${required_patch_line}" >&2
+    exit 1
+  }
+done
+for required_patch_line in \
+  '+load("@bazel_skylib//lib:paths.bzl", "paths")' \
+  '+    if toolchain.target_os == "windows" and toolchain.target_abi == "gnu" and cc_toolchain:' \
+  '+        tool_dir = paths.dirname(linker)' \
+  '+        env["PATH"] = tool_dir + (";" + inherited_path if inherited_path else "")'; do
+  grep -Fq -- "${required_patch_line}" "${rules_rust_windows_patch}" || {
+    echo "rules_rust Windows-GNU dlltool patch is missing: ${required_patch_line}" >&2
     exit 1
   }
 done

--- a/tools/bazel/check_rust_toolchain_pins.py
+++ b/tools/bazel/check_rust_toolchain_pins.py
@@ -10,6 +10,19 @@ import sys
 
 
 VERSION = "1.97.1"
+RULES_RUST_VERSION = "0.71.3"
+RULES_RUST_PATCHES = [
+    "//tools/bazel/patches:rules-rust-freebsd-host.patch",
+    "//tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch",
+]
+WINDOWS_GNU_DLLTOOL_PATCH_LINES = (
+    'diff --git a/rust/private/rustc.bzl b/rust/private/rustc.bzl',
+    '+load("@bazel_skylib//lib:paths.bzl", "paths")',
+    '+    if toolchain.target_os == "windows" and toolchain.target_abi == "gnu" and cc_toolchain:',
+    '+            action_name = CPP_LINK_EXECUTABLE_ACTION_NAME,',
+    '+        tool_dir = paths.dirname(linker)',
+    '+        env["PATH"] = tool_dir + (";" + inherited_path if inherited_path else "")',
+)
 CHANNEL_MANIFEST = (
     "https://static.rust-lang.org/dist/2026-07-16/channel-rust-1.97.1.toml"
 )
@@ -108,6 +121,36 @@ def validate_module_text(module_text: str) -> None:
         and len(node.targets) == 1
         and isinstance(node.targets[0], ast.Name)
     }
+    override_calls = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Name)
+        and node.value.func.id == "single_version_override"
+    ]
+    rules_rust_overrides = []
+    for node in override_calls:
+        keywords = {
+            keyword.arg: keyword.value
+            for keyword in node.value.keywords
+            if keyword.arg
+        }
+        if "module_name" in keywords and _literal(
+            keywords["module_name"], assignments
+        ) == "rules_rust":
+            rules_rust_overrides.append(keywords)
+    if len(rules_rust_overrides) != 1:
+        raise PinContractError("expected exactly one rules_rust version override")
+    rules_rust_override = rules_rust_overrides[0]
+    if (
+        _literal(rules_rust_override.get("version"), assignments)
+        != RULES_RUST_VERSION
+        or _literal(rules_rust_override.get("patch_strip"), assignments) != 1
+        or _literal(rules_rust_override.get("patches"), assignments)
+        != RULES_RUST_PATCHES
+    ):
+        raise PinContractError("rules_rust override has incomplete release patches")
     calls = [
         node
         for node in ast.walk(tree)
@@ -175,6 +218,14 @@ def validate_module_text(module_text: str) -> None:
         )
 
 
+def validate_windows_gnu_dlltool_patch_text(patch_text: str) -> None:
+    for line in WINDOWS_GNU_DLLTOOL_PATCH_LINES:
+        if line not in patch_text:
+            raise PinContractError(
+                "Windows-GNU dlltool discovery patch is missing: " + line
+            )
+
+
 def validate_release_matrix_text(matrix_text: str) -> None:
     try:
         matrix = json.loads(matrix_text)
@@ -201,15 +252,19 @@ def validate_release_matrix_text(matrix_text: str) -> None:
 
 
 def main() -> int:
-    if len(sys.argv) != 3:
+    if len(sys.argv) != 4:
         print(
-            "usage: check_rust_toolchain_pins.py MODULE.bazel release-targets.json",
+            "usage: check_rust_toolchain_pins.py MODULE.bazel "
+            "release-targets.json rules-rust-windows-gnu-dlltool-path.patch",
             file=sys.stderr,
         )
         return 2
     try:
         validate_module_text(Path(sys.argv[1]).read_text(encoding="utf-8"))
         validate_release_matrix_text(Path(sys.argv[2]).read_text(encoding="utf-8"))
+        validate_windows_gnu_dlltool_patch_text(
+            Path(sys.argv[3]).read_text(encoding="utf-8")
+        )
     except (OSError, SyntaxError, PinContractError) as error:
         print(f"Rust toolchain pin contract failed: {error}", file=sys.stderr)
         return 1

--- a/tools/bazel/check_rust_toolchain_pins_test.py
+++ b/tools/bazel/check_rust_toolchain_pins_test.py
@@ -11,6 +11,7 @@ from check_rust_toolchain_pins import (
     PinContractError,
     validate_module_text,
     validate_release_matrix_text,
+    validate_windows_gnu_dlltool_patch_text,
 )
 
 
@@ -22,12 +23,35 @@ MATRIX_TEXT = (ROOT / "contracts/release-targets-v1.json").read_text(
 ARM_ARCHIVE = "rustc-1.97.1-aarch64-unknown-linux-gnu.tar.xz"
 ARM_CHECKSUM = "b344b81f0cd4c2246c7da8b197fe7a339d7dd02bb15cb69b2524115d9c75224c"
 FREEBSD_CRATE_UNIVERSE_LINE = '        "x86_64-unknown-freebsd",\n'
+WINDOWS_GNU_PATCH_LINE = (
+    '        "//tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch",\n'
+)
+WINDOWS_GNU_PATCH = (
+    ROOT / "tools/bazel/patches/rules-rust-windows-gnu-dlltool-path.patch"
+).read_text(encoding="utf-8")
 
 
 class RustToolchainPinContractTest(unittest.TestCase):
     def test_repository_contract_is_complete(self) -> None:
         validate_module_text(MODULE_TEXT)
         validate_release_matrix_text(MATRIX_TEXT)
+        validate_windows_gnu_dlltool_patch_text(WINDOWS_GNU_PATCH)
+
+    def test_missing_windows_gnu_override_patch_is_rejected(self) -> None:
+        mutated = MODULE_TEXT.replace(WINDOWS_GNU_PATCH_LINE, "", 1)
+        self.assertNotEqual(mutated, MODULE_TEXT)
+        with self.assertRaisesRegex(PinContractError, "incomplete release patches"):
+            validate_module_text(mutated)
+
+    def test_incomplete_windows_gnu_patch_is_rejected(self) -> None:
+        mutated = WINDOWS_GNU_PATCH.replace(
+            '+        tool_dir = paths.dirname(linker)\n',
+            "",
+            1,
+        )
+        self.assertNotEqual(mutated, WINDOWS_GNU_PATCH)
+        with self.assertRaisesRegex(PinContractError, "dlltool discovery patch is missing"):
+            validate_windows_gnu_dlltool_patch_text(mutated)
 
     def test_missing_arm_checksum_is_rejected(self) -> None:
         line = f'        "{ARM_ARCHIVE}": "{ARM_CHECKSUM}",\n'

--- a/tools/bazel/patches/BUILD.bazel
+++ b/tools/bazel/patches/BUILD.bazel
@@ -6,6 +6,7 @@ exports_files(
     [
         "ort-freebsd-release-env-order.patch",
         "rules-rust-freebsd-host.patch",
+        "rules-rust-windows-gnu-dlltool-path.patch",
     ],
     visibility = ["//visibility:public"],
 )

--- a/tools/bazel/patches/rules-rust-windows-gnu-dlltool-path.patch
+++ b/tools/bazel/patches/rules-rust-windows-gnu-dlltool-path.patch
@@ -1,0 +1,32 @@
+diff --git a/rust/private/rustc.bzl b/rust/private/rustc.bzl
+index da151a3..d8c0ec8 100644
+--- a/rust/private/rustc.bzl
++++ b/rust/private/rustc.bzl
+@@ -14,6 +14,7 @@
+ 
+ """Functionality for constructing actions that invoke the Rust compiler"""
+ 
++load("@bazel_skylib//lib:paths.bzl", "paths")
+ load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+ load(
+     "@bazel_tools//tools/build_defs/cc:action_names.bzl",
+@@ -1764,6 +1765,19 @@ def rustc_compile_action(
+ 
+     # this is the final list of env vars
+     env.update(env_from_args)
++
++    # Raw-dylib declarations make rustc invoke dlltool while compiling an
++    # rlib, before rules_rust enters its normal linker setup. The selected
++    # Windows-GNU C++ toolchain already contributes its checksum-pinned tools
++    # to compile_inputs; expose that same declared directory for discovery.
++    if toolchain.target_os == "windows" and toolchain.target_abi == "gnu" and cc_toolchain:
++        linker = cc_common.get_tool_for_action(
++            action_name = CPP_LINK_EXECUTABLE_ACTION_NAME,
++            feature_configuration = feature_configuration,
++        )
++        tool_dir = paths.dirname(linker)
++        inherited_path = env.get("PATH", "")
++        env["PATH"] = tool_dir + (";" + inherited_path if inherited_path else "")
+ 
+     if hasattr(attr, "version") and attr.version != "0.0.0":
+         formatted_version = " v{}".format(attr.version)


### PR DESCRIPTION
Fixes the native Windows GNU release build when rustc expands raw-dylib declarations while compiling an rlib. The repo-pinned LLVM-MinGW tools were already declared action inputs, but their bin directory was not discoverable until rules_rust entered its normal linker branch.

This adds a narrow rules_rust 0.71.3 patch that prepends the selected Windows-GNU C++ toolchain directory to Rustc PATH. No runner/global MinGW dependency is introduced; non-Windows and MSVC actions are unchanged.

Validation:
- lockfile regeneration and --lockfile_mode=error
- //:rust_toolchain_pin_check
- //:rust_toolchain_pin_mutation_tests
- //:native_bazel_packaging_contract_tests
- //tools/bazel:release_route_analysis_tests
- independent review PASS

Native Windows exact-head qualification follows after merge.