### PR TITLE
fix(release): complete Windows GNU final linking

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -252,10 +252,12 @@ py_test(
         "$(rootpath MODULE.bazel)",
         "$(rootpath contracts/release-targets-v1.json)",
         "$(rootpath //tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch)",
+        "$(rootpath //tools/bazel/patches:rules-rust-windows-cargo-runfiles.patch)",
     ],
     data = [
         "MODULE.bazel",
         "contracts/release-targets-v1.json",
+        "//tools/bazel/patches:rules-rust-windows-cargo-runfiles.patch",
         "//tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch",
     ],
 )
@@ -269,6 +271,7 @@ py_test(
     data = [
         "MODULE.bazel",
         "contracts/release-targets-v1.json",
+        "//tools/bazel/patches:rules-rust-windows-cargo-runfiles.patch",
         "//tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch",
     ],
     imports = ["tools/bazel"],
@@ -859,7 +862,10 @@ sh_test(
         "scripts/stage-github-release-assets.sh",
         "scripts/stage-semantic-release-handoff.sh",
         "//tools/bazel:release_routes.bzl",
+        "//tools/bazel/mingw:cc_toolchain_config.bzl",
+        "//tools/bazel/mingw:repository.bzl",
         "//tools/bazel/patches:rules-rust-freebsd-host.patch",
+        "//tools/bazel/patches:rules-rust-windows-cargo-runfiles.patch",
         "//tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch",
     ],
     tags = ["release-gate"],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,14 +13,16 @@ bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "platforms", version = "1.1.0")
 
 # rules_rust 0.71.3 publishes the x86_64-unknown-freebsd toolchain, but its
-# host detector omits FreeBSD, and Windows-GNU raw-dylib compilation does not
-# discover the selected C++ toolchain's dlltool. Keep native release
-# construction on the pinned module with the smallest possible upstream fixes.
+# host detector omits FreeBSD, and Windows needs two narrow upstream fixes:
+# GNU raw-dylib compilation must discover the selected C++ toolchain's
+# dlltool, and retained Cargo runfiles must survive both Windows symlink modes.
+# Keep native release construction on the pinned module with those fixes only.
 single_version_override(
     module_name = "rules_rust",
     patch_strip = 1,
     patches = [
         "//tools/bazel/patches:rules-rust-freebsd-host.patch",
+        "//tools/bazel/patches:rules-rust-windows-cargo-runfiles.patch",
         "//tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch",
     ],
     version = "0.71.3",

--- a/scripts/tests/native-bazel-packaging-contract-test.sh
+++ b/scripts/tests/native-bazel-packaging-contract-test.sh
@@ -23,7 +23,10 @@ release_config="${source_root}/.bazelrc"
 module_definition="${source_root}/MODULE.bazel"
 module_lock="${source_root}/MODULE.bazel.lock"
 rules_rust_freebsd_patch="${source_root}/tools/bazel/patches/rules-rust-freebsd-host.patch"
+rules_rust_windows_runfiles_patch="${source_root}/tools/bazel/patches/rules-rust-windows-cargo-runfiles.patch"
 rules_rust_windows_patch="${source_root}/tools/bazel/patches/rules-rust-windows-gnu-dlltool-path.patch"
+mingw_repository="${source_root}/tools/bazel/mingw/repository.bzl"
+mingw_toolchain="${source_root}/tools/bazel/mingw/cc_toolchain_config.bzl"
 
 grep -Fxq 'build:release --lockfile_mode=error' "${release_config}" || {
   echo 'release config must fail closed on incomplete module lock data' >&2
@@ -53,9 +56,18 @@ PY
 
 for required_patch in \
   '//tools/bazel/patches:rules-rust-freebsd-host.patch' \
+  '//tools/bazel/patches:rules-rust-windows-cargo-runfiles.patch' \
   '//tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch'; do
   grep -Fq -- "${required_patch}" "${module_definition}" || {
     printf 'rules_rust must retain release patch: %s\n' "${required_patch}" >&2
+    exit 1
+  }
+done
+for required_patch_line in \
+  '-            if !self' \
+  '+            if self'; do
+  grep -Fq -- "${required_patch_line}" "${rules_rust_windows_runfiles_patch}" || {
+    echo "rules_rust Windows Cargo runfiles patch is missing: ${required_patch_line}" >&2
     exit 1
   }
 done
@@ -68,6 +80,33 @@ for required_patch_line in \
     exit 1
   }
 done
+
+for required in \
+  '"@rules_rust//cargo/settings:cargo_manifest_dir_filename_suffixes_to_retain"' \
+  '[".a"] if attr.target_id == "windows-x64" else []'; do
+  grep -Fq -- "${required}" "${release_routes}" || {
+    printf 'Windows release route does not retain static Cargo archives: %s\n' "${required}" >&2
+    exit 1
+  }
+done
+for required in \
+  'ctx.file("x86_64-w64-mingw32/lib/libgcc.a", "!<arch>\n")' \
+  'ctx.file("x86_64-w64-mingw32/lib/libgcc_eh.a", "!<arch>\n")'; do
+  grep -Fq -- "${required}" "${mingw_repository}" || {
+    printf 'LLVM-MinGW GCC compatibility bridge is not in clang search root: %s\n' "${required}" >&2
+    exit 1
+  }
+done
+grep -Fq 'tool_path(name = "ld", path = "bin/x86_64-w64-mingw32-clang.exe")' \
+  "${mingw_toolchain}" || {
+  echo 'LLVM-MinGW linker route does not use the direct hermetic driver' >&2
+  exit 1
+}
+if grep -Fq 'compat-libgcc' "${mingw_repository}" \
+  || grep -Fq 'ctx-x86_64-w64-mingw32-clang.cmd' "${mingw_repository}" "${mingw_toolchain}"; then
+  echo 'LLVM-MinGW route retains the unused compatibility wrapper path' >&2
+  exit 1
+fi
 for required_patch_line in \
   '+load("@bazel_skylib//lib:paths.bzl", "paths")' \
   '+    if toolchain.target_os == "windows" and toolchain.target_abi == "gnu" and cc_toolchain:' \

--- a/tools/bazel/check_rust_toolchain_pins.py
+++ b/tools/bazel/check_rust_toolchain_pins.py
@@ -13,8 +13,14 @@ VERSION = "1.97.1"
 RULES_RUST_VERSION = "0.71.3"
 RULES_RUST_PATCHES = [
     "//tools/bazel/patches:rules-rust-freebsd-host.patch",
+    "//tools/bazel/patches:rules-rust-windows-cargo-runfiles.patch",
     "//tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch",
 ]
+WINDOWS_CARGO_RUNFILES_PATCH_LINES = (
+    "diff --git a/cargo/private/cargo_build_script_runner/cargo_manifest_dir.rs ",
+    "-            if !self",
+    "+            if self",
+)
 WINDOWS_GNU_DLLTOOL_PATCH_LINES = (
     'diff --git a/rust/private/rustc.bzl b/rust/private/rustc.bzl',
     '+load("@bazel_skylib//lib:paths.bzl", "paths")',
@@ -226,6 +232,14 @@ def validate_windows_gnu_dlltool_patch_text(patch_text: str) -> None:
             )
 
 
+def validate_windows_cargo_runfiles_patch_text(patch_text: str) -> None:
+    for line in WINDOWS_CARGO_RUNFILES_PATCH_LINES:
+        if line not in patch_text:
+            raise PinContractError(
+                "Windows Cargo runfiles retention patch is missing: " + line
+            )
+
+
 def validate_release_matrix_text(matrix_text: str) -> None:
     try:
         matrix = json.loads(matrix_text)
@@ -252,10 +266,11 @@ def validate_release_matrix_text(matrix_text: str) -> None:
 
 
 def main() -> int:
-    if len(sys.argv) != 4:
+    if len(sys.argv) != 5:
         print(
             "usage: check_rust_toolchain_pins.py MODULE.bazel "
-            "release-targets.json rules-rust-windows-gnu-dlltool-path.patch",
+            "release-targets.json rules-rust-windows-gnu-dlltool-path.patch "
+            "rules-rust-windows-cargo-runfiles.patch",
             file=sys.stderr,
         )
         return 2
@@ -264,6 +279,9 @@ def main() -> int:
         validate_release_matrix_text(Path(sys.argv[2]).read_text(encoding="utf-8"))
         validate_windows_gnu_dlltool_patch_text(
             Path(sys.argv[3]).read_text(encoding="utf-8")
+        )
+        validate_windows_cargo_runfiles_patch_text(
+            Path(sys.argv[4]).read_text(encoding="utf-8")
         )
     except (OSError, SyntaxError, PinContractError) as error:
         print(f"Rust toolchain pin contract failed: {error}", file=sys.stderr)

--- a/tools/bazel/check_rust_toolchain_pins_test.py
+++ b/tools/bazel/check_rust_toolchain_pins_test.py
@@ -11,6 +11,7 @@ from check_rust_toolchain_pins import (
     PinContractError,
     validate_module_text,
     validate_release_matrix_text,
+    validate_windows_cargo_runfiles_patch_text,
     validate_windows_gnu_dlltool_patch_text,
 )
 
@@ -26,8 +27,14 @@ FREEBSD_CRATE_UNIVERSE_LINE = '        "x86_64-unknown-freebsd",\n'
 WINDOWS_GNU_PATCH_LINE = (
     '        "//tools/bazel/patches:rules-rust-windows-gnu-dlltool-path.patch",\n'
 )
+WINDOWS_CARGO_RUNFILES_PATCH_LINE = (
+    '        "//tools/bazel/patches:rules-rust-windows-cargo-runfiles.patch",\n'
+)
 WINDOWS_GNU_PATCH = (
     ROOT / "tools/bazel/patches/rules-rust-windows-gnu-dlltool-path.patch"
+).read_text(encoding="utf-8")
+WINDOWS_CARGO_RUNFILES_PATCH = (
+    ROOT / "tools/bazel/patches/rules-rust-windows-cargo-runfiles.patch"
 ).read_text(encoding="utf-8")
 
 
@@ -35,6 +42,7 @@ class RustToolchainPinContractTest(unittest.TestCase):
     def test_repository_contract_is_complete(self) -> None:
         validate_module_text(MODULE_TEXT)
         validate_release_matrix_text(MATRIX_TEXT)
+        validate_windows_cargo_runfiles_patch_text(WINDOWS_CARGO_RUNFILES_PATCH)
         validate_windows_gnu_dlltool_patch_text(WINDOWS_GNU_PATCH)
 
     def test_missing_windows_gnu_override_patch_is_rejected(self) -> None:
@@ -52,6 +60,22 @@ class RustToolchainPinContractTest(unittest.TestCase):
         self.assertNotEqual(mutated, WINDOWS_GNU_PATCH)
         with self.assertRaisesRegex(PinContractError, "dlltool discovery patch is missing"):
             validate_windows_gnu_dlltool_patch_text(mutated)
+
+    def test_missing_windows_cargo_runfiles_patch_is_rejected(self) -> None:
+        mutated = MODULE_TEXT.replace(WINDOWS_CARGO_RUNFILES_PATCH_LINE, "", 1)
+        self.assertNotEqual(mutated, MODULE_TEXT)
+        with self.assertRaisesRegex(PinContractError, "incomplete release patches"):
+            validate_module_text(mutated)
+
+    def test_incomplete_windows_cargo_runfiles_patch_is_rejected(self) -> None:
+        mutated = WINDOWS_CARGO_RUNFILES_PATCH.replace(
+            "+            if self\n",
+            "+            if !self\n",
+            1,
+        )
+        self.assertNotEqual(mutated, WINDOWS_CARGO_RUNFILES_PATCH)
+        with self.assertRaisesRegex(PinContractError, "retention patch is missing"):
+            validate_windows_cargo_runfiles_patch_text(mutated)
 
     def test_missing_arm_checksum_is_rejected(self) -> None:
         line = f'        "{ARM_ARCHIVE}": "{ARM_CHECKSUM}",\n'

--- a/tools/bazel/mingw/cc_toolchain_config.bzl
+++ b/tools/bazel/mingw/cc_toolchain_config.bzl
@@ -18,7 +18,7 @@ def _impl(ctx):
             tool_path(name = "cpp", path = "bin/x86_64-w64-mingw32-clang.exe"),
             tool_path(name = "gcc", path = "bin/x86_64-w64-mingw32-clang.exe"),
             tool_path(name = "gcov", path = "bin/llvm-cov.exe"),
-            tool_path(name = "ld", path = "bin/ctx-x86_64-w64-mingw32-clang.cmd"),
+            tool_path(name = "ld", path = "bin/x86_64-w64-mingw32-clang.exe"),
             tool_path(name = "nm", path = "bin/llvm-nm.exe"),
             tool_path(name = "objcopy", path = "bin/llvm-objcopy.exe"),
             tool_path(name = "objdump", path = "bin/llvm-objdump.exe"),

--- a/tools/bazel/mingw/repository.bzl
+++ b/tools/bazel/mingw/repository.bzl
@@ -11,16 +11,11 @@ def _llvm_mingw_repository_impl(ctx):
     # Rust's windows-gnu standard library asks the compiler driver for these
     # GCC compatibility archives. LLVM-MinGW provides compiler-rt instead; an
     # empty archive is the established compatibility bridge because no libgcc
-    # symbols are referenced by the shipped graph.
-    ctx.file("compat-libgcc/libgcc.a", "!<arch>\n")
-    ctx.file("compat-libgcc/libgcc_eh.a", "!<arch>\n")
-    ctx.file(
-        "bin/ctx-x86_64-w64-mingw32-clang.cmd",
-        """@echo off
-"%~dp0x86_64-w64-mingw32-clang.exe" -L"%~dp0..\\compat-libgcc" %*
-""",
-        executable = True,
-    )
+    # symbols are referenced by the shipped graph. Put the bridge in clang's
+    # target-library directory so every direct compiler-driver link resolves it
+    # without an ambient search path or an unused shell wrapper.
+    ctx.file("x86_64-w64-mingw32/lib/libgcc.a", "!<arch>\n")
+    ctx.file("x86_64-w64-mingw32/lib/libgcc_eh.a", "!<arch>\n")
     ctx.file(
         "BUILD.bazel",
         """

--- a/tools/bazel/patches/BUILD.bazel
+++ b/tools/bazel/patches/BUILD.bazel
@@ -6,6 +6,7 @@ exports_files(
     [
         "ort-freebsd-release-env-order.patch",
         "rules-rust-freebsd-host.patch",
+        "rules-rust-windows-cargo-runfiles.patch",
         "rules-rust-windows-gnu-dlltool-path.patch",
     ],
     visibility = ["//visibility:public"],

--- a/tools/bazel/patches/rules-rust-windows-cargo-runfiles.patch
+++ b/tools/bazel/patches/rules-rust-windows-cargo-runfiles.patch
@@ -1,0 +1,13 @@
+diff --git a/cargo/private/cargo_build_script_runner/cargo_manifest_dir.rs b/cargo/private/cargo_build_script_runner/cargo_manifest_dir.rs
+index a6f54cc..d11e762 100644
+--- a/cargo/private/cargo_build_script_runner/cargo_manifest_dir.rs
++++ b/cargo/private/cargo_build_script_runner/cargo_manifest_dir.rs
+@@ -457,7 +457,7 @@ impl RunfilesMaker {
+-            if !self
++            if self
+                 .filename_suffixes_to_retain
+                 .iter()
+                 .any(|suffix| dest.ends_with(suffix))
+             {
+                 continue;
+             }

--- a/tools/bazel/release_routes.bzl
+++ b/tools/bazel/release_routes.bzl
@@ -15,6 +15,10 @@ ReleaseRouteInfo = provider(
 def _route_transition_impl(_settings, attr):
     route = PUBLIC_RELEASE_ROUTES[attr.target_id]
     return {
+        "@rules_rust//cargo/settings:cargo_manifest_dir_filename_suffixes_to_retain": [
+            ".lib",
+            ".so",
+        ] + ([".a"] if attr.target_id == "windows-x64" else []),
         "//command_line_option:platforms": route[0],
         "//tools/bazel:windows_gnu_release": attr.target_id == "windows-x64",
     }
@@ -23,6 +27,7 @@ _route_transition = transition(
     implementation = _route_transition_impl,
     inputs = [],
     outputs = [
+        "@rules_rust//cargo/settings:cargo_manifest_dir_filename_suffixes_to_retain",
         "//command_line_option:platforms",
         "//tools/bazel:windows_gnu_release",
     ],

--- a/tools/bazel/release_routes_test.bzl
+++ b/tools/bazel/release_routes_test.bzl
@@ -1,5 +1,6 @@
 """Focused analysis tests for public release route transitions."""
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load(
     ":release_routes.bzl",
@@ -28,6 +29,14 @@ def _platform_probe_impl(ctx):
             ctx.attr.windows_abi_value,
             expected_abi,
         ))
+    retained_suffixes = ctx.attr.retained_suffixes[BuildSettingInfo].value
+    expected_suffixes = [".lib", ".so"] + ([".a"] if ctx.attr.expect_windows_gnu else [])
+    if retained_suffixes != expected_suffixes:
+        fail("{} retained Cargo archive suffixes {}, expected {}".format(
+            ctx.label,
+            retained_suffixes,
+            expected_suffixes,
+        ))
     output = ctx.actions.declare_file(ctx.label.name)
     ctx.actions.write(output, "#!/usr/bin/env sh\nexit 0\n", is_executable = True)
     return [DefaultInfo(executable = output)]
@@ -41,6 +50,9 @@ _platform_probe = rule(
             providers = [platform_common.ConstraintValueInfo],
         ),
         "expect_windows_gnu": attr.bool(default = False),
+        "retained_suffixes": attr.label(
+            default = Label("@rules_rust//cargo/settings:cargo_manifest_dir_filename_suffixes_to_retain"),
+        ),
         "windows_gnu_value": attr.string(mandatory = True),
         "windows_abi_value": attr.string(mandatory = True),
     },


### PR DESCRIPTION
Completes the hermetic Windows GNU release link path after native qualification exposed two final-stage gaps. Retains Windows Cargo static archives across both rules_rust runfiles modes and places the LLVM-MinGW libgcc compatibility archives in clang's target library search root.\n\nValidation:\n- full //:ci: 124/124 targets green, 122 test cases\n- focused pin, mutation, route-analysis, and packaging contracts green\n- release lockfile-error contract green\n- independent source review: ship, no findings\n\nThe exact native Windows final-link rerun remains the post-merge empirical qualification gate.