### PR TITLE
fix(release): map Windows GNU runtimes

### DIFF
--- a/scripts/tests/native-bazel-packaging-contract-test.sh
+++ b/scripts/tests/native-bazel-packaging-contract-test.sh
@@ -89,14 +89,39 @@ for required in \
     exit 1
   }
 done
-for required in \
-  'ctx.file("x86_64-w64-mingw32/lib/libgcc.a", "!<arch>\n")' \
-  'ctx.file("x86_64-w64-mingw32/lib/libgcc_eh.a", "!<arch>\n")'; do
-  grep -Fq -- "${required}" "${mingw_repository}" || {
-    printf 'LLVM-MinGW GCC compatibility bridge is not in clang search root: %s\n' "${required}" >&2
-    exit 1
-  }
-done
+python3 - "${mingw_repository}" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+aliases = (
+    (
+        "x86_64-w64-mingw32/lib/libunwind.a",
+        "x86_64-w64-mingw32/lib/libgcc_eh.a",
+    ),
+    (
+        "lib/clang/22/lib/windows/libclang_rt.builtins-x86_64.a",
+        "x86_64-w64-mingw32/lib/libgcc.a",
+    ),
+)
+for source, destination in aliases:
+    pattern = re.compile(
+        r'ctx\.symlink\(\s*"'
+        + re.escape(source)
+        + r'",\s*"'
+        + re.escape(destination)
+        + r'",\s*\)',
+        re.MULTILINE,
+    )
+    if pattern.search(text) is None:
+        raise SystemExit(
+            "LLVM-MinGW GCC runtime alias is missing: "
+            f"{source} -> {destination}"
+        )
+if "!<arch>" in text:
+    raise SystemExit("LLVM-MinGW GCC runtime aliases must not be empty archives")
+PY
 grep -Fq 'tool_path(name = "ld", path = "bin/x86_64-w64-mingw32-clang.exe")' \
   "${mingw_toolchain}" || {
   echo 'LLVM-MinGW linker route does not use the direct hermetic driver' >&2

--- a/tools/bazel/mingw/repository.bzl
+++ b/tools/bazel/mingw/repository.bzl
@@ -8,14 +8,19 @@ def _llvm_mingw_repository_impl(ctx):
         url = ctx.attr.urls,
     )
 
-    # Rust's windows-gnu standard library asks the compiler driver for these
-    # GCC compatibility archives. LLVM-MinGW provides compiler-rt instead; an
-    # empty archive is the established compatibility bridge because no libgcc
-    # symbols are referenced by the shipped graph. Put the bridge in clang's
-    # target-library directory so every direct compiler-driver link resolves it
-    # without an ambient search path or an unused shell wrapper.
-    ctx.file("x86_64-w64-mingw32/lib/libgcc.a", "!<arch>\n")
-    ctx.file("x86_64-w64-mingw32/lib/libgcc_eh.a", "!<arch>\n")
+    # Rust's windows-gnu standard library passes -nodefaultlibs and requests
+    # GCC-compatible runtime names explicitly. Preserve that link order while
+    # mapping the names to LLVM-MinGW's equivalent static runtimes. Bazel uses
+    # native symlinks where available and copies file targets on Windows hosts
+    # without symlink support.
+    ctx.symlink(
+        "x86_64-w64-mingw32/lib/libunwind.a",
+        "x86_64-w64-mingw32/lib/libgcc_eh.a",
+    )
+    ctx.symlink(
+        "lib/clang/22/lib/windows/libclang_rt.builtins-x86_64.a",
+        "x86_64-w64-mingw32/lib/libgcc.a",
+    )
     ctx.file(
         "BUILD.bazel",
         """


### PR DESCRIPTION
Maps Rust's explicit Windows-GNU compatibility archive names to LLVM-MinGW's pinned static runtimes: libgcc_eh to libunwind and libgcc to compiler-rt builtins. This preserves the existing target, ABI, nodefaultlibs behavior, and link order while removing the empty-archive bridge disproven by native qualification. Bazel copy-emulates these aliases on Windows hosts without symlink support.\n\nValidation:\n- full //:ci: 124/124 targets and 122/122 test cases green\n- focused native packaging contract green\n- materialized alias hashes exactly match both source archives\n- llvm-nm confirms every native failure symbol in libgcc_eh\n- independent source review: ship, no findings\n\nExact native Windows link/runtime qualification remains the post-merge empirical gate.