### PR TITLE
fix(release): allow FreeBSD base liblzma

### DIFF
--- a/scripts/check-release-binary-compat.sh
+++ b/scripts/check-release-binary-compat.sh
@@ -470,6 +470,7 @@ check_freebsd() {
     || fail "expected FreeBSD ELF ABI"
   assert_exact_lines "DT_NEEDED libraries" "$(elf_needed_libraries)" "libc.so.7
 libgcc_s.so.1
+liblzma.so.5
 libm.so.5
 libthr.so.3"
   check_no_elf_search_path

--- a/scripts/tests/check-release-binary-compat-test.sh
+++ b/scripts/tests/check-release-binary-compat-test.sh
@@ -372,6 +372,7 @@ DynamicSection [
 NeededLibraries [
   libc.so.7
   libgcc_s.so.1
+  liblzma.so.5
   libm.so.5
   libthr.so.3
 ]
@@ -570,6 +571,10 @@ mutate_and_fail freebsd_missing_bind_now freebsd-x64 "${freebsd}" \
   '/FLAGS[[:space:]]*BIND_NOW/d' 'missing BIND_NOW dynamic flag'
 mutate_and_fail freebsd_missing_pie freebsd-x64 "${freebsd}" \
   's/FLAGS_1      NOW PIE/FLAGS_1      NOW/' 'missing PIE dynamic flag'
+mutate_and_fail freebsd_missing_liblzma freebsd-x64 "${freebsd}" \
+  '/liblzma.so.5/d' 'unexpected DT_NEEDED libraries'
+mutate_and_fail freebsd_liblzma_major freebsd-x64 "${freebsd}" \
+  's/liblzma.so.5/liblzma.so.6/' 'unexpected DT_NEEDED libraries'
 mutate_and_fail freebsd_needed freebsd-x64 "${freebsd}" 's/libthr.so.3/libutil.so.9/'
 mutate_and_fail freebsd_rpath freebsd-x64 "${freebsd}" 's/NeededLibraries \[/RUNPATH: \/tmp\nNeededLibraries [/'
 


### PR DESCRIPTION
The native FreeBSD 14.4 release candidate correctly links the base-system liblzma.so.5 through xz2/lzma-sys. Add that exact SONAME to the public CLI DT_NEEDED contract and prove missing/wrong-major rejection.\n\nValidation:\n- scripts/bazelw test //:release_binary_compat_tests --config=ci\n- scripts/bazelw test //... --config=ci (133/133)\n- independent exact-diff review: SHIP, no findings\n\nThe private ctx-pro ELF contract is intentionally unchanged.