### PR TITLE
fix(release): make routes native Windows runnable

### DIFF
--- a/scripts/tests/native-bazel-packaging-contract-test.sh
+++ b/scripts/tests/native-bazel-packaging-contract-test.sh
@@ -89,6 +89,17 @@ for required in \
     exit 1
   }
 done
+for required in \
+  'load("@rules_shell//shell:sh_binary.bzl", "sh_binary")' \
+  'payload_name = name + "_payload"' \
+  'srcs = [":" + payload_name]' \
+  'use_bash_launcher = True'; do
+  grep -Fq -- "${required}" "${release_routes}" || {
+    printf 'Public release route lacks the native shell launcher contract: %s\n' \
+      "${required}" >&2
+    exit 1
+  }
+done
 python3 - "${mingw_repository}" <<'PY'
 from pathlib import Path
 import re

--- a/tools/bazel/release_routes.bzl
+++ b/tools/bazel/release_routes.bzl
@@ -1,5 +1,6 @@
 """Target-configured public CLI release packaging routes."""
 
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load(":release_inventory.bzl", "PUBLIC_RELEASE_ROUTES")
 
 ReleaseRouteInfo = provider(
@@ -98,9 +99,9 @@ exec "${{packager}}" \
         target_id = target_id,
     )
 
-def _release_route_impl(ctx):
+def _release_route_payload_impl(ctx):
     route = PUBLIC_RELEASE_ROUTES[ctx.attr.target_id]
-    launcher = ctx.actions.declare_file(ctx.label.name)
+    launcher = ctx.actions.declare_file(ctx.label.name + ".sh")
     ctx.actions.write(
         output = launcher,
         content = _launcher_content(ctx.attr.target_id),
@@ -148,7 +149,7 @@ def _release_route_impl(ctx):
     )
     runfiles = runfiles.merge(ctx.attr.sbom_tool[DefaultInfo].default_runfiles)
     return [
-        DefaultInfo(executable = launcher, runfiles = runfiles),
+        DefaultInfo(files = depset([launcher]), runfiles = runfiles),
         ReleaseRouteInfo(
             available = True,
             platform = route[0],
@@ -157,9 +158,8 @@ def _release_route_impl(ctx):
         ),
     ]
 
-_release_route = rule(
-    implementation = _release_route_impl,
-    executable = True,
+_release_route_payload = rule(
+    implementation = _release_route_payload_impl,
     attrs = {
         "advisory_gate": attr.label(
             cfg = "exec",
@@ -226,8 +226,10 @@ def public_cli_release_route(
     llvm_readobj = None
     if target_id == "windows-x64":
         llvm_readobj = "@ctx_llvm_mingw//:bin/llvm-readobj.exe"
-    _release_route(
-        name = name,
+    payload_name = name + "_payload"
+    route_tags = ["manual", "release-gate", "release-tool"]
+    _release_route_payload(
+        name = payload_name,
         advisory_gate = advisory_gate,
         artifact = artifact,
         cargo_lock = "//:release_cargo_lock",
@@ -240,7 +242,14 @@ def public_cli_release_route(
         sbom_tool = sbom_tool,
         target_id = target_id,
         target_matrix = "//:release_target_matrix",
-        tags = ["manual", "release-gate", "release-tool"],
+        tags = route_tags,
+    )
+    sh_binary(
+        name = name,
+        srcs = [":" + payload_name],
+        data = [":" + payload_name],
+        tags = route_tags,
+        use_bash_launcher = True,
     )
 
 def _advisory_launcher_content(target_id):

--- a/tools/bazel/release_routes_test.bzl
+++ b/tools/bazel/release_routes_test.bzl
@@ -213,7 +213,7 @@ def release_route_analysis_test_suite(name):
         )
         _route_analysis_test(
             name = test_name,
-            route = route_name,
+            route = route_name + "_payload",
             tags = ["release-gate"],
             target_id = spec.id,
             target_triple = spec.triple,


### PR DESCRIPTION
The release route payload is a Bash controller. Native Windows Bazel cannot execute the previous extensionless custom-rule output and fails with error 193 after a successful 1,301-action build.\n\nPublish each existing payload through pinned rules_shell sh_binary. That gives Windows a native .exe Bash launcher while preserving the transitioned artifact graph, runfiles, packager, POSIX behavior, and release_bundle.py authority.\n\nValidation:\n- focused release route/packaging contracts: 9/9\n- scripts/bazelw test //... --config=ci: 133/133\n- independent exact-diff review: SHIP, no findings\n\nNative Windows exact qualification follows on the merged SHA.