### PR TITLE
test(release): use portable sed ranges

### DIFF
--- a/scripts/tests/check-release-binary-compat-test.sh
+++ b/scripts/tests/check-release-binary-compat-test.sh
@@ -452,7 +452,7 @@ mutate_and_fail linux_type linux-x64 "${linux_x64}" 's/Type: SharedObject/Type: 
 mutate_and_fail linux_missing_relro linux-x64 "${linux_x64}" \
   '/Type: PT_GNU_RELRO/d' 'expected exactly one GNU_RELRO program header'
 mutate_and_fail linux_exec_stack linux-x64 "${linux_x64}" \
-  '0,/PF_W (0x2)/s//PF_W (0x2)\
+  '1,/PF_W (0x2)/s/PF_W (0x2)/PF_W (0x2)\
       PF_X (0x1)/' 'GNU_STACK is executable'
 mutate_and_fail linux_missing_bind_now linux-x64 "${linux_x64}" \
   '/FLAGS[[:space:]]*BIND_NOW/d' 'missing BIND_NOW dynamic flag'
@@ -565,7 +565,7 @@ mutate_and_fail freebsd_type freebsd-x64 "${freebsd}" 's/Type: SharedObject/Type
 mutate_and_fail freebsd_missing_relro freebsd-x64 "${freebsd}" \
   '/Type: PT_GNU_RELRO/d' 'expected exactly one GNU_RELRO program header'
 mutate_and_fail freebsd_exec_stack freebsd-x64 "${freebsd}" \
-  '0,/PF_W (0x2)/s//PF_W (0x2)\
+  '1,/PF_W (0x2)/s/PF_W (0x2)/PF_W (0x2)\
       PF_X (0x1)/' 'GNU_STACK is executable'
 mutate_and_fail freebsd_missing_bind_now freebsd-x64 "${freebsd}" \
   '/FLAGS[[:space:]]*BIND_NOW/d' 'missing BIND_NOW dynamic flag'


### PR DESCRIPTION
FreeBSD native qualification exposed two GNU-only sed first-match ranges in release compatibility negative fixtures. Replace the GNU 0,/regex/ form and implicit empty substitution regex with POSIX-compatible 1,/regex/ plus an explicit substitution pattern.\n\nValidation:\n- release_binary_compat_tests: pass\n- scripts/bazelw test //... --config=ci: 133/133\n- independent exact-diff review: SHIP, no findings\n\nNo release/product behavior changes.