### PR TITLE
Fix Rust 1.97 lint blockers

### DIFF
--- a/crates/ctx-cli/src/pro/client/operations.rs
+++ b/crates/ctx-cli/src/pro/client/operations.rs
@@ -141,7 +141,7 @@ fn blame_once(
     let request_context = request.clone();
     let result = match client.exchange(HostMessage::Blame(request), BLAME_TIMEOUT)? {
         HelperMessage::Blame(result) => {
-            validate_blame_response(&request_context, &result).map(|()| result)
+            validate_blame_response(&request_context, &result).map(|()| *result)
         }
         HelperMessage::Error(error) => Err(protocol_blame_error(error, &request_context.target)),
         _ => Err(anyhow!(

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/scanner.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/scanner.rs
@@ -17,21 +17,6 @@ fn result_terminal_authority_is_ambiguous(record: &[u8]) -> bool {
     !crate::common::json::raw_object_keys_are_unique(record)
 }
 
-#[cfg(test)]
-mod terminal_authority_tests {
-    use super::result_terminal_authority_is_ambiguous;
-
-    #[test]
-    fn duplicate_selector_cannot_hide_terminal_authority() {
-        assert!(result_terminal_authority_is_ambiguous(
-            br#"{"type":"response_item","payload":{"type":"function_call_output","call_id":"call","output":"hidden"},"payload":{"type":"message","role":"user","content":[]}}"#,
-        ));
-        assert!(!result_terminal_authority_is_ambiguous(
-            br#"{"type":"response_item","payload":{"type":"message","role":"user","content":[]}}"#,
-        ));
-    }
-}
-
 fn observe_result_terminal_call_id(
     authority: &mut CodexMcpTerminalAuthority,
     record: &[u8],
@@ -514,5 +499,20 @@ impl CodexNativeScanner {
                 ))?;
             page.physical_records = page.physical_records.saturating_add(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod terminal_authority_tests {
+    use super::result_terminal_authority_is_ambiguous;
+
+    #[test]
+    fn duplicate_selector_cannot_hide_terminal_authority() {
+        assert!(result_terminal_authority_is_ambiguous(
+            br#"{"type":"response_item","payload":{"type":"function_call_output","call_id":"call","output":"hidden"},"payload":{"type":"message","role":"user","content":[]}}"#,
+        ));
+        assert!(!result_terminal_authority_is_ambiguous(
+            br#"{"type":"response_item","payload":{"type":"message","role":"user","content":[]}}"#,
+        ));
     }
 }

--- a/crates/ctx-history-capture/src/repository_attribution/engine.rs
+++ b/crates/ctx-history-capture/src/repository_attribution/engine.rs
@@ -548,7 +548,7 @@ fn resolve_deferred_commit_observations(
     for observation in observations {
         let deferred = match observation {
             UnscopedOutcomeObservation::Exact(outcome) => {
-                exact.push(outcome);
+                exact.push(*outcome);
                 continue;
             }
             UnscopedOutcomeObservation::DeferredCommitOperation(deferred) => {

--- a/crates/ctx-history-capture/src/repository_attribution/outcome.rs
+++ b/crates/ctx-history-capture/src/repository_attribution/outcome.rs
@@ -28,7 +28,7 @@ const MAX_EXACT_OUTCOME_OUTPUT_BYTES: usize = 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub(crate) enum UnscopedOutcomeObservation {
-    Exact(RepositoryOutcomeObservation),
+    Exact(Box<RepositoryOutcomeObservation>),
     DeferredCommit(DeferredCommitObservation),
     DeferredCommitOperation(DeferredCommitOperationObservation),
     DeferredCherryPick(DeferredCherryPickObservation),
@@ -36,7 +36,7 @@ pub(crate) enum UnscopedOutcomeObservation {
 
 impl From<RepositoryOutcomeObservation> for UnscopedOutcomeObservation {
     fn from(value: RepositoryOutcomeObservation) -> Self {
-        Self::Exact(value)
+        Self::Exact(Box::new(value))
     }
 }
 
@@ -228,7 +228,7 @@ pub(crate) fn linked_outcome_evidence(
                 provider_native_repository_aliases: aliases,
                 outcome_operation_repository_path: operation_path,
                 outcome_output_repository_path: output_path,
-                outcomes: vec![(*outcome).into()],
+                outcomes: vec![UnscopedOutcomeObservation::Exact(outcome)],
                 pull_request_associations: Vec::new(),
                 abstentions: operation_unlinked
                     .then_some((

--- a/crates/ctx-history-capture/src/repository_attribution/tests/outcome_parser.rs
+++ b/crates/ctx-history-capture/src/repository_attribution/tests/outcome_parser.rs
@@ -56,6 +56,10 @@ fn exact_result_and_structured_oid_precedence_are_fail_closed() {
         exact_outcome(&exact.outcomes[0]).produced_object_ids[0].hex,
         oid
     );
+    assert_eq!(
+        serde_json::to_value(&exact.outcomes[0]).unwrap(),
+        serde_json::json!({"Exact": exact_outcome(&exact.outcomes[0])})
+    );
 
     let mut short = input("git commit -m exact", &output);
     short.structured_commit_oid = Some("0123456");

--- a/crates/ctx-history-core/src/core_record/repository.rs
+++ b/crates/ctx-history-core/src/core_record/repository.rs
@@ -764,7 +764,7 @@ impl RepositoryCommitOperationEvent {
             unlinked_results: Vec::new(),
             mapping_completeness: RepositoryCommitMappingCompleteness::Complete,
             state: RepositoryCommitOperationState::Asserted,
-            proof: RepositoryCommitOperationProof::RepositoryVerifiedYield(proof),
+            proof: RepositoryCommitOperationProof::RepositoryVerifiedYield(Box::new(proof)),
         };
         event.validate_contract(linkage)?;
         Ok(event)
@@ -1028,7 +1028,7 @@ pub enum RepositoryCommitOperationState {
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum RepositoryCommitOperationProof {
     RecordExact,
-    RepositoryVerifiedYield(RepositoryVerifiedYieldProof),
+    RepositoryVerifiedYield(Box<RepositoryVerifiedYieldProof>),
 }
 
 impl RepositoryCommitOperationProof {

--- a/crates/ctx-history-core/src/core_record/tests.rs
+++ b/crates/ctx-history-core/src/core_record/tests.rs
@@ -1841,6 +1841,7 @@ fn operation_event_and_pull_request_shapes_are_explicit() {
         result: oid('a'),
     }];
     let linkage = commit.linkage.clone();
+    let repository_geometry_sha256 = [8; 32];
     commit.produced_object_ids.clear();
     commit.commit_operation = Some(RepositoryCommitOperationEvent {
         event_id: repository_commit_operation_event_id(
@@ -1860,21 +1861,42 @@ fn operation_event_and_pull_request_shapes_are_explicit() {
         unlinked_results: Vec::new(),
         mapping_completeness: RepositoryCommitMappingCompleteness::Complete,
         state: RepositoryCommitOperationState::Asserted,
-        proof: RepositoryCommitOperationProof::RepositoryVerifiedYield(
+        proof: RepositoryCommitOperationProof::RepositoryVerifiedYield(Box::new(
             RepositoryVerifiedYieldProof {
                 command_pre_head: Some(oid('b')),
                 sequencer_pre_head: None,
                 exact_source_oids: vec![oid('b')],
                 command_post_head: oid('a'),
-                repository_geometry_before_sha256: [8; 32],
-                repository_geometry_after_sha256: [8; 32],
+                repository_geometry_before_sha256: repository_geometry_sha256,
+                repository_geometry_after_sha256: repository_geometry_sha256,
                 exact_result_map_sha256: repository_result_map_sha256(&mappings),
                 drift_excluded: true,
                 mutation_excluded: true,
             },
-        ),
+        )),
     });
     commit.validate_contract().unwrap();
+    let proof = &commit.commit_operation.as_ref().unwrap().proof;
+    let proof_wire = serde_json::to_value(proof).unwrap();
+    assert_eq!(
+        proof_wire,
+        serde_json::json!({
+            "kind": "repository_verified_yield",
+            "command_pre_head": oid('b'),
+            "sequencer_pre_head": null,
+            "exact_source_oids": [oid('b')],
+            "command_post_head": oid('a'),
+            "repository_geometry_before_sha256": repository_geometry_sha256,
+            "repository_geometry_after_sha256": repository_geometry_sha256,
+            "exact_result_map_sha256": repository_result_map_sha256(&mappings),
+            "drift_excluded": true,
+            "mutation_excluded": true,
+        })
+    );
+    assert_eq!(
+        &serde_json::from_value::<RepositoryCommitOperationProof>(proof_wire).unwrap(),
+        proof
+    );
     assert_eq!(
         commit
             .commit_operation

--- a/crates/ctx-pro-host-protocol/examples/generate_protocol_inventory/messages.rs
+++ b/crates/ctx-pro-host-protocol/examples/generate_protocol_inventory/messages.rs
@@ -231,7 +231,7 @@ fn helper_messages(fingerprint: &str) -> Vec<(&'static str, HelperMessage)> {
                 replayed: false,
             }),
         ),
-        ("blame", HelperMessage::Blame(blame_result())),
+        ("blame", HelperMessage::Blame(Box::new(blame_result()))),
         (
             "error",
             HelperMessage::Error(ProtocolError::new(

--- a/crates/ctx-pro-host-protocol/src/fake.rs
+++ b/crates/ctx-pro-host-protocol/src/fake.rs
@@ -326,7 +326,7 @@ impl FakeHelper {
             ResolvedBlameTarget::Commit { .. } => BlameCoverageUnit::CommitFact,
             ResolvedBlameTarget::PullRequest { .. } => BlameCoverageUnit::PullRequestRelationship,
         };
-        HelperMessage::Blame(BlameResult {
+        HelperMessage::Blame(Box::new(BlameResult {
             snapshot: request.expected_snapshot,
             target,
             git_snapshot,
@@ -345,6 +345,6 @@ impl FakeHelper {
             evidence: Vec::new(),
             next: None,
             lineage: None,
-        })
+        }))
     }
 }

--- a/crates/ctx-pro-host-protocol/src/message.rs
+++ b/crates/ctx-pro-host-protocol/src/message.rs
@@ -211,7 +211,7 @@ pub enum HelperMessage {
     CoreEventStatePage(CoreEventStatePage),
     CoreEventDeltaPageApplied(CoreEventDeltaPageApplied),
     CoreMaterializationFinished(CoreMaterializationFinished),
-    Blame(BlameResult),
+    Blame(Box<BlameResult>),
     Error(ProtocolError),
     CoreEventDeltaPagesApplied(CoreEventDeltaPagesApplied),
 }


### PR DESCRIPTION
Boxes the large enum payloads identified by the pinned Rust 1.97 Clippy toolchain while preserving serde wire and persisted shapes, and mechanically moves one test module after production items.

Validation:
- `scripts/check.sh --mode ci`
- 219-target repository lint build passed
- 124 Bazel test targets passed (122 test cases)
- focused core, capture, protocol, conformance, inventory, golden-byte, rustfmt, and diff checks passed
- fresh review: ship, no findings