### PR TITLE
fix(codex): quarantine conflicting provider roots

### DIFF
--- a/crates/ctx-cli/tests/native_provider_rejections.rs
+++ b/crates/ctx-cli/tests/native_provider_rejections.rs
@@ -54,6 +54,48 @@ fn source_refresh_failure(command: &mut Command) -> String {
     String::from_utf8(output.stderr).unwrap()
 }
 
+fn write_codex_lineage_rollout(
+    root: &Path,
+    native_session_id: &str,
+    parent_native_session_id: Option<&str>,
+    advisory_session_id: Option<&str>,
+    marker: &str,
+) -> PathBuf {
+    fs::create_dir_all(root).unwrap();
+    let mut payload = serde_json::json!({
+        "id": native_session_id,
+        "timestamp": "2026-08-07T12:00:00Z",
+        "cwd": "/private/root-conflict/workspace",
+        "originator": "codex_cli_rs",
+        "cli_version": "1.0.0",
+        "source": "cli",
+        "model_provider": "openai"
+    });
+    if let Some(parent) = parent_native_session_id {
+        payload["forked_from_id"] = serde_json::json!(parent);
+    }
+    if let Some(advisory) = advisory_session_id {
+        payload["session_id"] = serde_json::json!(advisory);
+    }
+    let session_meta = serde_json::json!({
+        "timestamp": "2026-08-07T12:00:00Z",
+        "type": "session_meta",
+        "payload": payload,
+    });
+    let message = serde_json::json!({
+        "timestamp": "2026-08-07T12:00:01Z",
+        "type": "response_item",
+        "payload": {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": marker}]
+        }
+    });
+    let path = root.join(format!("rollout-{native_session_id}.jsonl"));
+    fs::write(&path, format!("{session_meta}\n{message}\n")).unwrap();
+    path
+}
+
 #[test]
 fn antigravity_cli_import_skips_malformed_file_among_valid_files() {
     let temp = finite_daemon_test_root();
@@ -336,6 +378,206 @@ fn codex_mixed_session_replay_preserves_source_backed_rejection_counts() {
         "--format=json",
     ]));
     assert_search_provider_oracle(&search, "codex", "codex mixed replay oracle", 1, "message");
+}
+
+#[test]
+fn codex_root_conflict_cli_reports_path_safe_source_failure_and_publishes_peer() {
+    let temp = finite_daemon_test_root();
+    let sessions = temp.path().join("private-codex-root-conflict-sessions");
+    let root_a = "019fc000-0000-7000-8000-0000000032a0";
+    let child_a = "019fc000-0000-7000-8000-0000000032a1";
+    let root_b = "019fc000-0000-7000-8000-0000000032b0";
+    let private_root_marker = "privaterootaclicanary328";
+    let private_child_marker = "privatechildaclicanary328";
+    let valid_marker = "validrootbclicanary328";
+    write_codex_lineage_rollout(&sessions, root_a, None, None, private_root_marker);
+    write_codex_lineage_rollout(
+        &sessions,
+        child_a,
+        Some(root_a),
+        Some(root_b),
+        private_child_marker,
+    );
+    write_codex_lineage_rollout(&sessions, root_b, None, None, valid_marker);
+
+    let report = json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "codex",
+        "--path",
+        sessions.to_str().unwrap(),
+        "--format=json",
+        "--progress",
+        "none",
+    ]));
+    assert_eq!(
+        report["outcome"], "completed_with_source_failures",
+        "{report:#}"
+    );
+    assert_eq!(report["failure_scope"], "source", "{report:#}");
+    let [source] = report["sources"].as_array().unwrap().as_slice() else {
+        panic!("one explicit Codex receipt expected: {report:#}");
+    };
+    assert_eq!(source["status"], "partial", "{report:#}");
+    assert_eq!(source["failure_scope"], "source", "{report:#}");
+    assert_eq!(source["route_source_failure_total"], 2, "{report:#}");
+    assert_eq!(source["current_source_count"], 1, "{report:#}");
+    assert_eq!(source["current_rejected_records"], 0, "{report:#}");
+    assert!(source["rejection_diagnostics"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+    assert!(source["source_selector"]
+        .as_str()
+        .is_some_and(|selector| selector.starts_with("logical-source:")));
+    let detail = source["detail"].as_str().unwrap();
+    for expected in [
+        format!("computed_root_native_session_id={root_a}"),
+        format!("conflicting_advisory_session_id={root_b}"),
+        format!("evidence_source_record=session_meta:{child_a}"),
+        format!("computed_root_source_record=session_meta:{root_a}"),
+        format!("advisory_source_record=session_meta:{root_b}"),
+    ] {
+        assert!(detail.contains(&expected), "{detail}");
+    }
+    assert!(!detail.contains(sessions.to_str().unwrap()));
+    assert!(!detail.contains(private_root_marker));
+    assert!(!detail.contains(private_child_marker));
+
+    let search = json_output(ctx(&temp).args([
+        "search",
+        valid_marker,
+        "--provider",
+        "codex",
+        "--refresh",
+        "off",
+        "--format=json",
+    ]));
+    assert_search_provider_oracle(&search, "codex", valid_marker, 1, "message");
+}
+
+#[test]
+fn codex_many_root_conflicts_cli_reports_exact_total_and_bounded_omission() {
+    const CONFLICTING_CHILDREN: usize = 65;
+    const REJECTED_SOURCES: usize = CONFLICTING_CHILDREN + 1;
+
+    let temp = finite_daemon_test_root();
+    let sessions = temp.path().join(".codex/sessions/2026/08/07");
+    let root_a = "019fc000-0000-7000-8000-000000003400";
+    let root_b = "019fc000-0000-7000-8000-0000000034b0";
+    let evidence_child = "019fc000-0000-7000-8001-000000000000";
+    let private_marker = "private bounded CLI root conflict content 328";
+    let valid_marker = "bounded CLI root conflict valid peer 328";
+    write_codex_lineage_rollout(&sessions, root_a, None, None, private_marker);
+    for index in 0..CONFLICTING_CHILDREN {
+        let child = format!("019fc000-0000-7000-8001-{index:012x}");
+        let advisory = if index == 0 { root_b } else { root_a };
+        write_codex_lineage_rollout(
+            &sessions,
+            &child,
+            Some(root_a),
+            Some(advisory),
+            private_marker,
+        );
+    }
+    write_codex_lineage_rollout(&sessions, root_b, None, None, valid_marker);
+
+    let report =
+        json_output(ctx(&temp).args(["import", "--all", "--format=json", "--progress", "none"]));
+    assert_eq!(
+        report["outcome"], "completed_with_source_failures",
+        "{report:#}"
+    );
+    assert_eq!(report["failure_scope"], "source", "{report:#}");
+    assert_eq!(report["totals"]["current_source_count"], 1, "{report:#}");
+    assert_eq!(
+        report["totals"]["current_rejected_records"], 0,
+        "{report:#}"
+    );
+    let sources = report["sources"].as_array().unwrap();
+    assert_eq!(sources.len(), 4, "summary plus three bounded diagnostics");
+    let summary = &sources[0];
+    assert_eq!(summary["status"], "partial", "{report:#}");
+    assert_eq!(summary["failure_scope"], "source", "{report:#}");
+    assert_eq!(summary["failure_type"], "source_failure", "{report:#}");
+    assert_eq!(summary["source_failure_total"], REJECTED_SOURCES);
+    assert_eq!(summary["source_failures_omitted"], REJECTED_SOURCES - 3);
+    assert_eq!(summary["rejected_record_total"], 0);
+    assert_eq!(summary["current_rejected_records"], 0);
+    for source in &sources[1..] {
+        assert_eq!(source["failure_scope"], "source", "{source:#}");
+        assert_eq!(source["failure_type"], "other", "{source:#}");
+        assert!(source["source_selector"]
+            .as_str()
+            .is_some_and(|selector| selector.starts_with("logical-source:")));
+        let detail = source["detail"].as_str().unwrap();
+        for expected in [
+            format!("computed_root_native_session_id={root_a}"),
+            format!("conflicting_advisory_session_id={root_b}"),
+            format!("evidence_source_record=session_meta:{evidence_child}"),
+            format!("computed_root_source_record=session_meta:{root_a}"),
+            format!("advisory_source_record=session_meta:{root_b}"),
+        ] {
+            assert!(detail.contains(&expected), "{detail}");
+        }
+        assert!(!detail.contains(sessions.to_str().unwrap()));
+        assert!(!detail.contains(private_marker));
+    }
+
+    let search = json_output(ctx(&temp).args([
+        "search",
+        valid_marker,
+        "--provider",
+        "codex",
+        "--refresh",
+        "off",
+        "--format=json",
+    ]));
+    assert_search_provider_oracle(&search, "codex", valid_marker, 1, "message");
+}
+
+#[test]
+fn codex_all_invalid_root_conflict_cli_failure_includes_typed_proof() {
+    let temp = finite_daemon_test_root();
+    let sessions = temp.path().join("private-codex-root-conflict-sessions");
+    let root = "019fc000-0000-7000-8000-0000000032c0";
+    let child = "019fc000-0000-7000-8000-0000000032c1";
+    let missing_advisory = "019fc000-0000-7000-8000-0000000032ff";
+    let private_marker = "private all-invalid CLI message content";
+    write_codex_lineage_rollout(&sessions, root, None, None, private_marker);
+    write_codex_lineage_rollout(
+        &sessions,
+        child,
+        Some(root),
+        Some(missing_advisory),
+        private_marker,
+    );
+
+    let stderr = source_refresh_failure(ctx(&temp).args([
+        "import",
+        "--provider",
+        "codex",
+        "--path",
+        sessions.to_str().unwrap(),
+        "--format=json",
+        "--progress",
+        "none",
+    ]));
+    for expected in [
+        format!("computed_root_native_session_id={root}"),
+        format!("conflicting_advisory_session_id={missing_advisory}"),
+        format!("evidence_source_record=session_meta:{child}"),
+        format!("computed_root_source_record=session_meta:{root}"),
+        "advisory_source_record=unavailable".to_owned(),
+    ] {
+        assert!(stderr.contains(&expected), "{stderr}");
+    }
+    let diagnostic = stderr
+        .split_once("first rejection diagnostic:")
+        .and_then(|(_, diagnostic)| diagnostic.lines().next())
+        .expect("all-invalid Codex failure must identify its projected diagnostic");
+    assert!(!diagnostic.contains(sessions.to_str().unwrap()), "{stderr}");
+    assert!(!stderr.contains(private_marker), "{stderr}");
 }
 
 #[test]

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/jsonl_family.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/jsonl_family.rs
@@ -27,27 +27,43 @@ const CODEX_LINEAGE_EXHAUSTED_DETAIL: &str =
 const CODEX_LINEAGE_UNAVAILABLE_DETAIL: &str = "Codex lineage working set is unavailable";
 const CODEX_GENERATION_TERMINAL_PARTITION_V0: u64 = u64::MAX;
 
-fn bind_generation_source_capability_v0(
-    source: &mut CodexCatalogSource,
-) -> Result<(Arc<OpenedProviderSourceFile>, JsonlFileObservation)> {
+fn observe_generation_source_capability_v0(
+    source: &CodexCatalogSource,
+) -> Result<JsonlFileObservation> {
     let opened = reopen_codex_source_capability(source)?;
     revalidate_codex_catalog_source_capability(source, &opened)?;
-    let observation = observe_opened_file(&source.source_path, &opened)?;
-    source.opened = Some(Arc::clone(&opened));
-    Ok((opened, observation))
+    observe_opened_file(&source.source_path, &opened)
 }
 
 fn codex_lineage_rejected_leaf_v0(
     rejected: CodexLineageRejectedSourceV0,
     authority_path: PathBuf,
 ) -> Result<JsonlFamilyRejectedLeaf> {
-    let proof = TypedKey::bytes(serde_json::to_vec(&rejected.proof)?)
+    let native_session_id = rejected.source.catalog_native_session_id.as_deref().ok_or(
+        CaptureError::SystemInvariant(
+            "rejected Codex lineage source has no native session identity",
+        ),
+    )?;
+    let source = codex_source_key(native_session_id)
         .map_err(|error| CaptureError::InvalidPayload(error.to_string()))?;
-    Ok(JsonlFamilyRejectedLeaf::bind_observed(
+    let diagnostic = rejected.proof.root_conflict_diagnostic_detail();
+    let proof_bytes = serde_json::to_vec(&rejected.proof)?;
+    let proof = TypedKey::bytes(proof_bytes)
+        .map_err(|error| CaptureError::InvalidPayload(error.to_string()))?;
+    let terminal_source = rejected.source.clone();
+    let opened = reopen_codex_source_capability(&terminal_source)?;
+    revalidate_codex_catalog_source_capability(&terminal_source, &opened)?;
+    Ok(JsonlFamilyRejectedLeaf::bind_observed_with_terminal(
         rejected.source.source_path,
         authority_path,
         proof,
         1,
+        source,
+        move || {
+            let opened = reopen_codex_source_capability(&terminal_source)?;
+            revalidate_codex_catalog_source_capability(&terminal_source, &opened)
+        },
+        diagnostic,
     ))
 }
 
@@ -70,7 +86,7 @@ fn scan_codex_session_jsonl_leaf_v0(
     worker: &mut JsonlFamilyWorkerContext,
     emit_page: &mut dyn FnMut(JsonlFamilyPublication, Vec<CoreRecord>) -> Result<()>,
 ) -> Result<JsonlFamilyOptimizedLeafOutcome> {
-    let (plan, outcome_lineage) = {
+    let (mut plan, outcome_lineage) = {
         let state = state.lock().map_err(|_| codex_family_state_error())?;
         let plan = state.plans.get(leaf.source()).cloned().ok_or_else(|| {
             CaptureError::InvalidPayload(
@@ -87,6 +103,9 @@ fn scan_codex_session_jsonl_leaf_v0(
     if plan.0.source_path != leaf.source_path() {
         return Err(CaptureError::SourceChangedDuringCapture);
     }
+    // Generation preparation retains root authority and route observations,
+    // while each scheduled worker holds only its own exact leaf capability.
+    plan.0.opened = Some(leaf.open_for_optimized_scan()?);
     let mut scan_context = CodexJsonlFamilyLeafContextV0 {
         base_event_lookup,
         outcome_lineage: &outcome_lineage,
@@ -509,7 +528,7 @@ impl CodexSessionTreeJsonlFamilyAdapterV0 {
             ));
         }
         let outcome_lineage = prepared.authority;
-        let mut normalized_sources = prepared.sources;
+        let normalized_sources = prepared.sources;
         let mut rejected_leaves = Vec::with_capacity(prepared.rejections.len());
         for rejected in prepared.rejections {
             let authority_path = rejected.source.authority_relative_path.clone().ok_or(
@@ -526,7 +545,7 @@ impl CodexSessionTreeJsonlFamilyAdapterV0 {
         for index in ordered_sources {
             let (source, source_key, native_session_id) =
                 normalized_sources
-                    .get_mut(index)
+                    .get(index)
                     .ok_or(CaptureError::SystemInvariant(
                         "Codex generation source ordering changed",
                     ))?;
@@ -541,7 +560,7 @@ impl CodexSessionTreeJsonlFamilyAdapterV0 {
                         "Codex catalog source has no authority path",
                     ))?;
             let observation = if self.generation.is_some() {
-                bind_generation_source_capability_v0(source)?.1
+                observe_generation_source_capability_v0(source)?
             } else {
                 let opened = authority.open_file(&authority_path)?;
                 observe_opened_file(&source.source_path, &opened)?
@@ -880,11 +899,11 @@ impl CodexExplicitSessionJsonlFamilyAdapterV0 {
         })?;
         let authority = Arc::new(ProviderSourceRoot::open(parent)?);
         let outcome_lineage = prepared.authority;
-        let mut plans = prepared.sources;
+        let plans = prepared.sources;
         let mut leaves = Vec::with_capacity(plans.len());
-        for plan in &mut plans {
+        for plan in &plans {
             let observation = if self.generation.is_some() {
-                bind_generation_source_capability_v0(&mut plan.0)?.1
+                observe_generation_source_capability_v0(&plan.0)?
             } else {
                 let opened = authority.open_file(&authority_path)?;
                 observe_opened_file(&plan.0.source_path, &opened)?

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/lineage.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/lineage.rs
@@ -32,6 +32,63 @@ pub(super) enum CodexLineageRejectionReasonV0 {
     AdvisoryIrreconcilable { advisory_session_id: String },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CodexLineageSourceRecordKindV0 {
+    SessionMeta,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct CodexLineageSourceRecordV0 {
+    source_native_session_id: String,
+    record_kind: CodexLineageSourceRecordKindV0,
+}
+
+impl CodexLineageSourceRecordV0 {
+    fn session_meta(source_native_session_id: &str) -> Self {
+        Self {
+            source_native_session_id: source_native_session_id.to_owned(),
+            record_kind: CodexLineageSourceRecordKindV0::SessionMeta,
+        }
+    }
+
+    fn diagnostic_identity(&self) -> String {
+        let kind = match self.record_kind {
+            CodexLineageSourceRecordKindV0::SessionMeta => "session_meta",
+        };
+        format!("{kind}:{}", self.source_native_session_id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct CodexLineageRootConflictV0 {
+    computed_root_native_session_id: String,
+    conflicting_advisory_session_id: String,
+    evidence_source_record: CodexLineageSourceRecordV0,
+    computed_root_source_record: CodexLineageSourceRecordV0,
+    advisory_source_record: Option<CodexLineageSourceRecordV0>,
+}
+
+impl CodexLineageRootConflictV0 {
+    fn diagnostic_detail(&self) -> String {
+        let advisory_source_record = self
+            .advisory_source_record
+            .as_ref()
+            .map(CodexLineageSourceRecordV0::diagnostic_identity)
+            .unwrap_or_else(|| "unavailable".to_owned());
+        format!(
+            "codex_lineage_root_conflict_v0 computed_root_native_session_id={} \
+             conflicting_advisory_session_id={} evidence_source_record={} \
+             computed_root_source_record={} advisory_source_record={}",
+            self.computed_root_native_session_id,
+            self.conflicting_advisory_session_id,
+            self.evidence_source_record.diagnostic_identity(),
+            self.computed_root_source_record.diagnostic_identity(),
+            advisory_source_record,
+        )
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(super) struct CodexLineageRejectionProofV0 {
     version: u8,
@@ -39,6 +96,16 @@ pub(super) struct CodexLineageRejectionProofV0 {
     component_native_session_id: String,
     evidence_native_session_id: String,
     reason: CodexLineageRejectionReasonV0,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    root_conflict: Option<CodexLineageRootConflictV0>,
+}
+
+impl CodexLineageRejectionProofV0 {
+    pub(super) fn root_conflict_diagnostic_detail(&self) -> Option<String> {
+        self.root_conflict
+            .as_ref()
+            .map(CodexLineageRootConflictV0::diagnostic_detail)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -57,6 +124,7 @@ pub(super) struct CodexLineageNormalizationV0 {
 struct ComponentIssueV0 {
     evidence_native_session_id: String,
     reason: CodexLineageRejectionReasonV0,
+    root_conflict: Option<CodexLineageRootConflictV0>,
 }
 
 struct DisjointComponentsV0 {
@@ -243,12 +311,16 @@ impl CodexOutcomeLineageAuthorityV0 {
         let mut issues = HashMap::<usize, ComponentIssueV0>::new();
         macro_rules! reject {
             ($index:expr, $reason:expr $(,)?) => {{
+                reject!($index, $reason, None);
+            }};
+            ($index:expr, $reason:expr, $root_conflict:expr $(,)?) => {{
                 let index = $index;
                 issues
                     .entry(component_of[index])
                     .or_insert_with(|| ComponentIssueV0 {
                         evidence_native_session_id: ordered[index].2.clone(),
                         reason: $reason,
+                        root_conflict: $root_conflict,
                     });
             }};
         }
@@ -391,6 +463,17 @@ impl CodexOutcomeLineageAuthorityV0 {
             if advisory == &ordered[root_index].2 || advisory == &ordered[index].2 {
                 continue;
             }
+            let root_conflict = |advisory_index: Option<usize>| CodexLineageRootConflictV0 {
+                computed_root_native_session_id: ordered[root_index].2.clone(),
+                conflicting_advisory_session_id: advisory.clone(),
+                evidence_source_record: CodexLineageSourceRecordV0::session_meta(&ordered[index].2),
+                computed_root_source_record: CodexLineageSourceRecordV0::session_meta(
+                    &ordered[root_index].2,
+                ),
+                advisory_source_record: advisory_index.map(|advisory_index| {
+                    CodexLineageSourceRecordV0::session_meta(&ordered[advisory_index].2)
+                }),
+            };
             let advisory_index = match groups.get(advisory).map(Vec::as_slice) {
                 Some([advisory_index]) => *advisory_index,
                 Some(_) | None => {
@@ -399,6 +482,7 @@ impl CodexOutcomeLineageAuthorityV0 {
                         CodexLineageRejectionReasonV0::AdvisoryIrreconcilable {
                             advisory_session_id: advisory.clone(),
                         },
+                        Some(root_conflict(None)),
                     );
                     continue;
                 }
@@ -409,6 +493,7 @@ impl CodexOutcomeLineageAuthorityV0 {
                     CodexLineageRejectionReasonV0::AdvisoryUnrelatedComponent {
                         advisory_session_id: advisory.clone(),
                     },
+                    Some(root_conflict(Some(advisory_index))),
                 );
                 continue;
             }
@@ -430,6 +515,7 @@ impl CodexOutcomeLineageAuthorityV0 {
                     CodexLineageRejectionReasonV0::AdvisoryIrreconcilable {
                         advisory_session_id: advisory.clone(),
                     },
+                    Some(root_conflict(Some(advisory_index))),
                 );
             }
         }
@@ -460,11 +546,12 @@ impl CodexOutcomeLineageAuthorityV0 {
                 rejections.push(CodexLineageRejectedSourceV0 {
                     source: plan.0,
                     proof: CodexLineageRejectionProofV0 {
-                        version: 1,
+                        version: if issue.root_conflict.is_some() { 2 } else { 1 },
                         native_session_id: plan.2,
                         component_native_session_id,
                         evidence_native_session_id: issue.evidence_native_session_id.clone(),
                         reason: issue.reason.clone(),
+                        root_conflict: issue.root_conflict.clone(),
                     },
                 });
                 continue;

--- a/crates/ctx-history-capture/src/provider/source_backed/family/jsonl.rs
+++ b/crates/ctx-history-capture/src/provider/source_backed/family/jsonl.rs
@@ -38,6 +38,8 @@ pub(crate) use route::{
     JsonlFamilyProjector, JsonlFamilyPublication, JsonlFamilyRejectedLeaf,
     JsonlFamilyRootMissingMode, JsonlFamilyTerminalProof, JsonlFamilyWorkerContext,
 };
+#[cfg(test)]
+pub(crate) use route::{jsonl_family_scanner_max_worker_count, with_family_scanner_workers};
 const PREFIX_HASH_DOMAIN: &[u8] = b"ctx-direct-jsonl-nativepath-prefix-v1\0";
 const PAGE_MAX_RECORDS: usize = 64;
 const PAGE_MAX_BYTES: usize = 8 * 1024 * 1024;

--- a/crates/ctx-history-capture/src/provider/source_backed/family/jsonl/route.rs
+++ b/crates/ctx-history-capture/src/provider/source_backed/family/jsonl/route.rs
@@ -57,9 +57,11 @@ mod scanner;
 #[cfg(test)]
 use scanner::{
     jsonl_family_scanner_activity, jsonl_family_scanner_probe,
-    record_jsonl_family_scanner_activity, with_family_scanner_workers, JsonlFamilyScannerActivity,
-    JsonlFamilyScannerProbe, FAMILY_SCANNER_WORKERS_OVERRIDE,
+    record_jsonl_family_scanner_activity, JsonlFamilyScannerActivity, JsonlFamilyScannerProbe,
+    FAMILY_SCANNER_WORKERS_OVERRIDE,
 };
+#[cfg(test)]
+pub(crate) use scanner::{jsonl_family_scanner_max_worker_count, with_family_scanner_workers};
 pub(crate) use scanner::{
     JsonlFamilyAppendMode, JsonlFamilyOptimizedLeafOutcome, JsonlFamilyProjectionMode,
     JsonlFamilyPublication, JsonlFamilyWorkerContext,
@@ -433,6 +435,7 @@ impl JsonlFamilyMembershipObservation {
         mode: JsonlFamilyInventoryMode,
         expected_sources: &HashMap<[u8; 32], TerminalSourceEvidence>,
         owned_sources: &HashMap<[u8; 32], SourceKey>,
+        rejected_sources: &HashMap<[u8; 32], Vec<JsonlFamilyRejectedTerminal>>,
     ) -> bool {
         if self.root_missing != current.root_missing {
             return false;
@@ -446,6 +449,11 @@ impl JsonlFamilyMembershipObservation {
                         .get(&digest)
                         .is_some_and(|owned| owned.exact_descriptor_eq(source))
                         || expected_sources.contains_key(&digest)
+                        || rejected_sources.get(&digest).is_some_and(|rejected| {
+                            rejected
+                                .iter()
+                                .any(|rejected| rejected.source.exact_descriptor_eq(source))
+                        })
                 })
             }
         }
@@ -728,6 +736,13 @@ impl JsonlFamilyLeaf {
         Ok(Arc::new(opened))
     }
 
+    /// Reopens an optimized leaf through the shared no-follow authority at
+    /// worker admission, bounding retained leaf capabilities by the scheduled
+    /// worker set while preserving the opening observation as the proof fence.
+    pub(crate) fn open_for_optimized_scan(&self) -> Result<Arc<OpenedProviderSourceFile>> {
+        self.open_for_scan().map(|(_, opened)| opened)
+    }
+
     fn open_for_scan(&self) -> Result<(Self, Arc<OpenedProviderSourceFile>)> {
         let opened = self.authority.open_file(&self.authority_path)?;
         let current = observe_opened_file(&self.source_path, &opened)?;
@@ -762,6 +777,31 @@ pub(crate) struct JsonlFamilyRejectedLeaf {
     authority_path: PathBuf,
     proof: TypedKey,
     rejected_records: u64,
+    terminal: Option<JsonlFamilyRejectedTerminal>,
+    logical_source_failure_detail: Option<String>,
+}
+
+type JsonlFamilyRejectedRevalidator = Arc<dyn Fn() -> Result<()> + Send + Sync>;
+
+#[derive(Clone)]
+struct JsonlFamilyRejectedTerminal {
+    source: SourceKey,
+    revalidate: JsonlFamilyRejectedRevalidator,
+}
+
+impl std::fmt::Debug for JsonlFamilyRejectedTerminal {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("JsonlFamilyRejectedTerminal")
+            .field("source", &self.source)
+            .finish_non_exhaustive()
+    }
+}
+
+impl JsonlFamilyRejectedTerminal {
+    fn revalidate(&self) -> Result<()> {
+        (self.revalidate)()
+    }
 }
 
 impl JsonlFamilyRejectedLeaf {
@@ -776,6 +816,30 @@ impl JsonlFamilyRejectedLeaf {
             authority_path,
             proof,
             rejected_records,
+            terminal: None,
+            logical_source_failure_detail: None,
+        }
+    }
+
+    pub(crate) fn bind_observed_with_terminal(
+        source_path: PathBuf,
+        authority_path: PathBuf,
+        proof: TypedKey,
+        rejected_records: u64,
+        source: SourceKey,
+        revalidate: impl Fn() -> Result<()> + Send + Sync + 'static,
+        logical_source_failure_detail: Option<String>,
+    ) -> Self {
+        Self {
+            source_path,
+            authority_path,
+            proof,
+            rejected_records,
+            terminal: Some(JsonlFamilyRejectedTerminal {
+                source,
+                revalidate: Arc::new(revalidate),
+            }),
+            logical_source_failure_detail,
         }
     }
 }
@@ -1062,6 +1126,7 @@ struct FamilyResident {
     ownership_initialized: bool,
     owned_sources: HashMap<[u8; 32], SourceKey>,
     terminal_sources: HashMap<[u8; 32], TerminalSourceEvidence>,
+    terminal_rejected_sources: HashMap<[u8; 32], Vec<JsonlFamilyRejectedTerminal>>,
     absent_sources: Vec<JsonlFamilyAbsentMember>,
     opening_membership: Option<JsonlFamilyMembershipObservation>,
     certified_inventory: Option<CertifiedSourceInventory>,
@@ -1203,12 +1268,18 @@ fn capture(
                         )
                     })
                 })?;
+        let diagnostic = opening
+            .rejected_leaves()
+            .iter()
+            .find_map(|leaf| leaf.logical_source_failure_detail.as_deref())
+            .map(|detail| format!("; first rejection diagnostic: {detail}"))
+            .unwrap_or_default();
         return Err(SourceBackedRouteError::new(
             SourceBackedRouteErrorKind::InvalidSource,
             format!(
                 "direct JSONL route rejected {rejected_records} records across {} sources; \
-                 all provider-native session identity leaves were rejected",
-                opening.rejected_leaves().len()
+                 all provider-native session identity leaves were rejected{diagnostic}",
+                opening.rejected_leaves().len(),
             ),
         ));
     }
@@ -1256,6 +1327,43 @@ fn capture(
     let terminal_sources = terminal_sources?;
     finish_leaf_scans?;
 
+    // Identity-level rejection happens before a rejected leaf can own a
+    // certified source. Project the typed proof solely as a logical-source
+    // failure; no committed record was inspected or rejected.
+    for rejected in opening.rejected_leaves() {
+        let (Some(terminal), Some(detail)) = (
+            rejected.terminal.as_ref(),
+            rejected.logical_source_failure_detail.as_ref(),
+        ) else {
+            continue;
+        };
+        sink.record_logical_source_failure(
+            terminal.source.clone(),
+            SourceBackedRouteError::new(SourceBackedRouteErrorKind::InvalidSource, detail.clone()),
+            false,
+        )
+        .map_err(route_internal)?;
+    }
+
+    let mut terminal_rejected_sources =
+        HashMap::<[u8; 32], Vec<JsonlFamilyRejectedTerminal>>::new();
+    for rejected in opening.rejected_leaves() {
+        let Some(terminal) = rejected.terminal.as_ref() else {
+            continue;
+        };
+        let digest = terminal.source.exact_descriptor_digest();
+        let matching = terminal_rejected_sources.entry(digest).or_default();
+        if matching
+            .first()
+            .is_some_and(|prior| !prior.source.exact_descriptor_eq(&terminal.source))
+        {
+            return Err(route_invalid(
+                "terminally rejected JSONL source descriptor digest collision",
+            ));
+        }
+        matching.push(terminal.clone());
+    }
+
     let selected_sources = selected_leaves
         .iter()
         .map(|leaf| leaf.source().clone())
@@ -1291,6 +1399,7 @@ fn capture(
     resident.ownership_initialized = true;
     resident.owned_sources = owned_sources;
     resident.terminal_sources = terminal_sources;
+    resident.terminal_rejected_sources = terminal_rejected_sources;
     resident.absent_sources = absent_sources;
     resident.opening_membership = Some(opening_membership);
     resident.certified_inventory = Some(inventory);

--- a/crates/ctx-history-capture/src/provider/source_backed/family/jsonl/route/revalidation.rs
+++ b/crates/ctx-history-capture/src/provider/source_backed/family/jsonl/route/revalidation.rs
@@ -5,6 +5,7 @@ pub(super) fn reset_terminal(resident: &Mutex<FamilyResident>) -> SourceBackedRo
         .lock()
         .map_err(|_| route_internal("JSONL resident catalog lock was poisoned"))?;
     resident.terminal_sources.clear();
+    resident.terminal_rejected_sources.clear();
     resident.absent_sources.clear();
     resident.opening_membership = None;
     resident.certified_inventory = None;
@@ -54,6 +55,7 @@ pub(super) fn revalidate_complete_inventory(
         opening_membership,
         certified_inventory,
         opening_inventory,
+        rejected_sources,
     ) = {
         let resident = resident.lock().map_err(|_| {
             CaptureError::InvalidPayload("JSONL resident catalog lock was poisoned".to_owned())
@@ -65,6 +67,7 @@ pub(super) fn revalidate_complete_inventory(
             resident.opening_membership.clone(),
             resident.certified_inventory.clone(),
             resident.opening_inventory.clone(),
+            resident.terminal_rejected_sources.clone(),
         )
     };
     if certified_inventory.as_ref() != Some(expected_inventory) {
@@ -84,6 +87,7 @@ pub(super) fn revalidate_complete_inventory(
         adapter.inventory_mode(),
         &expected_sources,
         &owned_sources,
+        &rejected_sources,
     ) {
         return Ok(false);
     }
@@ -96,6 +100,9 @@ pub(super) fn revalidate_complete_inventory(
         evidence
             .terminal_proof
             .revalidate_for(&evidence.certificate)?;
+    }
+    for rejected in rejected_sources.values().flatten() {
+        rejected.revalidate()?;
     }
     for dependency in &opening_inventory.exact_dependencies {
         dependency.revalidate_dependency()?;

--- a/crates/ctx-history-capture/src/provider/source_backed/family/jsonl/route/scanner.rs
+++ b/crates/ctx-history-capture/src/provider/source_backed/family/jsonl/route/scanner.rs
@@ -80,9 +80,11 @@ impl JsonlFamilyOptimizedLeafOutcome {
 #[cfg(test)]
 pub(super) use activity::{
     jsonl_family_scanner_activity, jsonl_family_scanner_probe,
-    record_jsonl_family_scanner_activity, with_family_scanner_workers, JsonlFamilyScannerActivity,
-    JsonlFamilyScannerProbe, FAMILY_SCANNER_WORKERS_OVERRIDE,
+    record_jsonl_family_scanner_activity, JsonlFamilyScannerActivity, JsonlFamilyScannerProbe,
+    FAMILY_SCANNER_WORKERS_OVERRIDE,
 };
+#[cfg(test)]
+pub(crate) use activity::{jsonl_family_scanner_max_worker_count, with_family_scanner_workers};
 
 #[cfg(test)]
 mod activity {
@@ -112,10 +114,15 @@ mod activity {
                 sources_completed: 0,
                 peak_active_scanners: 0,
             }) };
+        static FAMILY_SCANNER_MAX_WORKER_COUNT: Cell<usize> = const { Cell::new(0) };
     }
 
     pub(crate) fn jsonl_family_scanner_activity() -> JsonlFamilyScannerActivity {
         FAMILY_SCANNER_ACTIVITY.get()
+    }
+
+    pub(crate) fn jsonl_family_scanner_max_worker_count() -> usize {
+        FAMILY_SCANNER_MAX_WORKER_COUNT.get()
     }
 
     pub(in super::super) struct JsonlFamilyScannerProbe {
@@ -188,6 +195,8 @@ mod activity {
         worker_count: usize,
         probe: Option<&JsonlFamilyScannerProbe>,
     ) {
+        FAMILY_SCANNER_MAX_WORKER_COUNT
+            .set(FAMILY_SCANNER_MAX_WORKER_COUNT.get().max(worker_count));
         FAMILY_SCANNER_ACTIVITY.set(
             probe.map_or_else(JsonlFamilyScannerActivity::default, |probe| {
                 probe.snapshot(worker_count)
@@ -195,10 +204,7 @@ mod activity {
         );
     }
 
-    pub(in super::super) fn with_family_scanner_workers<T>(
-        workers: usize,
-        run: impl FnOnce() -> T,
-    ) -> T {
+    pub(crate) fn with_family_scanner_workers<T>(workers: usize, run: impl FnOnce() -> T) -> T {
         struct Restore(Option<usize>);
 
         impl Drop for Restore {
@@ -210,6 +216,7 @@ mod activity {
         let previous = FAMILY_SCANNER_WORKERS_OVERRIDE.replace(Some(workers));
         let _restore = Restore(previous);
         FAMILY_SCANNER_ACTIVITY.set(JsonlFamilyScannerActivity::default());
+        FAMILY_SCANNER_MAX_WORKER_COUNT.set(0);
         run()
     }
 }

--- a/crates/ctx-history-capture/src/provider/source_backed/family/jsonl/route/tests.rs
+++ b/crates/ctx-history-capture/src/provider/source_backed/family/jsonl/route/tests.rs
@@ -168,6 +168,7 @@ fn expected_state(
             ownership_initialized: true,
             owned_sources,
             terminal_sources,
+            terminal_rejected_sources: HashMap::new(),
             absent_sources: Vec::new(),
             opening_membership: Some(opening_membership),
             certified_inventory: Some(inventory.clone()),

--- a/crates/ctx-history-capture/src/provider/source_backed/tests/codex.rs
+++ b/crates/ctx-history-capture/src/provider/source_backed/tests/codex.rs
@@ -1,9 +1,23 @@
 use std::{fs::OpenOptions, io::Write};
 
+#[cfg(target_os = "linux")]
+use std::{
+    process::Command,
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    thread,
+    time::Duration,
+};
+
 use ctx_history_core::{EventOrigin, SessionRelationshipKind};
 
 use super::*;
 use crate::provider::codex::nativepath::install_after_codex_lineage_normalization_hook_v0;
+
+#[cfg(target_os = "linux")]
+const CODEX_FD_BUDGET_CHILD_ENV: &str = "CTX_TEST_CODEX_FD_BUDGET_CHILD";
+#[cfg(target_os = "linux")]
+const CODEX_FD_BUDGET_TEST: &str =
+    "provider::source_backed::tests::codex::codex_generation_bounds_leaf_fds_under_soft_nofile_1024";
 
 fn prompt_line(session_id: &str, ts: i64, text: &str) -> Vec<u8> {
     let mut line = serde_json::to_vec(&serde_json::json!({
@@ -254,6 +268,162 @@ fn register_codex_trees(roots: &[(&Path, ProviderImportSupport)]) -> SourceBacke
     )
     .unwrap();
     registry
+}
+
+#[cfg(target_os = "linux")]
+fn set_soft_nofile_limit(limit: libc::rlim_t) {
+    let mut current = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: this runs only in the isolated child process below, before any
+    // refresh worker starts. The child exits without restoring its soft limit.
+    assert_eq!(
+        unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut current) },
+        0
+    );
+    assert!(
+        current.rlim_max >= limit,
+        "hard RLIMIT_NOFILE {} is below required test limit {limit}",
+        current.rlim_max
+    );
+    current.rlim_cur = limit;
+    assert_eq!(unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &current) }, 0);
+    let mut observed = current;
+    assert_eq!(
+        unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut observed) },
+        0
+    );
+    assert_eq!(observed.rlim_cur, limit);
+}
+
+#[cfg(target_os = "linux")]
+fn open_fd_count() -> usize {
+    fs::read_dir("/proc/self/fd").unwrap().count()
+}
+
+#[cfg(target_os = "linux")]
+fn run_codex_fd_budget_child() {
+    const TREE_SOURCES: usize = 2_048;
+    const EXPLICIT_SOURCES: usize = 16;
+    const SOFT_NOFILE: libc::rlim_t = 1_024;
+    const MAX_OPEN_FDS: usize = 256;
+
+    set_soft_nofile_limit(SOFT_NOFILE);
+    let temp = tempdir().unwrap();
+    let tree = temp.path().join("automatic-tree");
+    let explicit = temp.path().join("explicit-routes");
+    let index = temp.path().join("index");
+    fs::create_dir_all(&tree).unwrap();
+    fs::create_dir_all(&explicit).unwrap();
+    for source in 0..TREE_SOURCES {
+        let native_session_id = format!("019fb000-0000-7000-8000-{source:012x}");
+        fs::write(
+            tree.join(format!("rollout-{native_session_id}.jsonl")),
+            codex_lineage_rollout(
+                &native_session_id,
+                None,
+                SessionRelationshipKind::Root,
+                None,
+                "bounded automatic leaf",
+            ),
+        )
+        .unwrap();
+    }
+    let mut registry = register_codex_tree(&tree);
+    for source in 0..EXPLICIT_SOURCES {
+        let native_session_id = format!("019fb001-0000-7000-8000-{source:012x}");
+        let path = explicit.join(format!("route-{source:02}.jsonl"));
+        fs::write(
+            &path,
+            codex_lineage_rollout(
+                &native_session_id,
+                None,
+                SessionRelationshipKind::Root,
+                None,
+                "bounded explicit leaf",
+            ),
+        )
+        .unwrap();
+        register_codex_route(
+            &mut registry,
+            &path,
+            "codex_session_jsonl",
+            ProviderImportSupport::Explicit,
+            SourceBackedRouteSelection::ExplicitManual,
+        );
+    }
+
+    let baseline = open_fd_count();
+    let sampling = Arc::new(AtomicBool::new(true));
+    let peak = Arc::new(AtomicUsize::new(baseline));
+    let sampling_from_thread = Arc::clone(&sampling);
+    let peak_from_thread = Arc::clone(&peak);
+    let monitor = thread::spawn(move || {
+        while sampling_from_thread.load(Ordering::Acquire) {
+            peak_from_thread.fetch_max(open_fd_count(), Ordering::Relaxed);
+            thread::sleep(Duration::from_millis(1));
+        }
+        peak_from_thread.fetch_max(open_fd_count(), Ordering::Relaxed);
+    });
+    let writer_options = WriterOptions {
+        indexer_threads: 1,
+        ..WriterOptions::default()
+    };
+    let refreshed = super::super::family::jsonl::with_family_scanner_workers(16, || {
+        refresh_source_backed_generation(&index, &registry, writer_options)
+    });
+    let scanner_workers = super::super::family::jsonl::jsonl_family_scanner_max_worker_count();
+    sampling.store(false, Ordering::Release);
+    monitor.join().unwrap();
+
+    let refreshed = refreshed.unwrap();
+    let high_water = peak.load(Ordering::Relaxed);
+    assert!(refreshed.failed_routes.is_empty());
+    assert_eq!(
+        scanner_workers, 16,
+        "FD regression did not exercise 16 workers"
+    );
+    assert_eq!(
+        refreshed.certified_source_count,
+        TREE_SOURCES + EXPLICIT_SOURCES
+    );
+    assert!(
+        high_water <= MAX_OPEN_FDS,
+        "Codex refresh FD high-water {high_water} exceeded bound {MAX_OPEN_FDS} (baseline {baseline})"
+    );
+    eprintln!(
+        "CODEX_FD_BUDGET_RECEIPT soft_nofile={SOFT_NOFILE} sources={} routes={} scanner_workers={scanner_workers} baseline_fds={baseline} peak_fds={high_water} bound={MAX_OPEN_FDS}",
+        TREE_SOURCES + EXPLICIT_SOURCES,
+        EXPLICIT_SOURCES + 1,
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn codex_generation_bounds_leaf_fds_under_soft_nofile_1024() {
+    if std::env::var_os(CODEX_FD_BUDGET_CHILD_ENV).is_some() {
+        run_codex_fd_budget_child();
+        return;
+    }
+    let output = Command::new(std::env::current_exe().unwrap())
+        .args([
+            "--exact",
+            CODEX_FD_BUDGET_TEST,
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env(CODEX_FD_BUDGET_CHILD_ENV, "1")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "soft-NOFILE Codex refresh child failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    eprint!("{}", String::from_utf8_lossy(&output.stdout));
+    eprint!("{}", String::from_utf8_lossy(&output.stderr));
 }
 
 #[test]
@@ -1534,6 +1704,327 @@ fn codex_transitive_root_normalization_quarantines_before_workers() {
 }
 
 #[test]
+fn codex_root_conflict_projects_typed_source_failures_while_valid_peer_publishes() {
+    let temp = tempdir().unwrap();
+    let sessions = temp.path().join("private-codex-sessions");
+    let index = temp.path().join("index");
+    fs::create_dir_all(&sessions).unwrap();
+    let root_a = "019fa000-0000-7000-8000-0000000032a0";
+    let child_a = "019fa000-0000-7000-8000-0000000032a1";
+    let root_b = "019fa000-0000-7000-8000-0000000032b0";
+    let invalid_root_marker = "privaterootacanary328";
+    let invalid_child_marker = "privatechildacanary328";
+    let valid_marker = "validrootbcanary328";
+    for (id, parent, relationship, advisory, marker) in [
+        (
+            root_a,
+            None,
+            SessionRelationshipKind::Root,
+            None,
+            invalid_root_marker,
+        ),
+        (
+            child_a,
+            Some(root_a),
+            SessionRelationshipKind::Delegated,
+            Some(root_b),
+            invalid_child_marker,
+        ),
+        (
+            root_b,
+            None,
+            SessionRelationshipKind::Root,
+            None,
+            valid_marker,
+        ),
+    ] {
+        fs::write(
+            sessions.join(format!("rollout-{id}.jsonl")),
+            codex_lineage_rollout(id, parent, relationship, advisory, marker),
+        )
+        .unwrap();
+    }
+    let registry = register_codex_tree(&sessions);
+
+    let refreshed =
+        refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
+    assert_eq!(refreshed.certified_source_count, 1);
+    assert_eq!(refreshed.commit.indexed_documents, 1);
+    assert_eq!(refreshed.logical_source_failures.total(), 2);
+    assert_eq!(refreshed.successful_route_outcomes.len(), 1);
+    assert_eq!(
+        refreshed.successful_route_outcomes[0].logical_source_failure_total,
+        2
+    );
+    assert_eq!(refreshed.record_rejections.total(), 0);
+    assert_eq!(
+        refreshed.record_completion(),
+        SourceBackedRecordCompletion::Completed
+    );
+    for failure in refreshed.logical_source_failures.failures() {
+        assert_eq!(failure.class, SourceBackedSourceFailureClass::Unreadable);
+        assert!(!failure.carried_forward);
+        for expected in [
+            format!("computed_root_native_session_id={root_a}"),
+            format!("conflicting_advisory_session_id={root_b}"),
+            format!("evidence_source_record=session_meta:{child_a}"),
+            format!("computed_root_source_record=session_meta:{root_a}"),
+            format!("advisory_source_record=session_meta:{root_b}"),
+        ] {
+            assert!(failure.detail.contains(&expected), "{}", failure.detail);
+        }
+        assert!(!failure.detail.contains(sessions.to_str().unwrap()));
+        assert!(!failure.detail.contains(invalid_root_marker));
+        assert!(!failure.detail.contains(invalid_child_marker));
+    }
+    let verified = VerifiedIndex::open(&index).unwrap();
+    assert_eq!(
+        verified
+            .search_event_candidates(valid_marker, 8)
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(verified
+        .search_event_candidates(invalid_root_marker, 8)
+        .unwrap()
+        .is_empty());
+    assert!(verified
+        .search_event_candidates(invalid_child_marker, 8)
+        .unwrap()
+        .is_empty());
+    let generation = verified.generation_id().to_owned();
+
+    let replay =
+        refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
+    assert_eq!(replay.commit.generation_id, generation);
+    assert_eq!(replay.logical_source_failures.total(), 2);
+    assert_eq!(replay.record_rejections.total(), 0);
+}
+
+#[test]
+fn codex_warm_root_conflict_quarantines_owned_component_and_publishes_peer_update() {
+    let temp = tempdir().unwrap();
+    let sessions = temp.path().join("codex-sessions");
+    let index = temp.path().join("index");
+    fs::create_dir_all(&sessions).unwrap();
+    let root_a = "019fa000-0000-7000-8000-0000000033a0";
+    let child_a = "019fa000-0000-7000-8000-0000000033a1";
+    let root_b = "019fa000-0000-7000-8000-0000000033b0";
+    let root_a_marker = "warmrootacanary328";
+    let child_a_marker = "warmchildacanary328";
+    let old_peer_marker = "warmoldpeercanary328";
+    let new_peer_marker = "warmnewpeercanary328";
+    let root_a_path = sessions.join(format!("rollout-{root_a}.jsonl"));
+    let child_a_path = sessions.join(format!("rollout-{child_a}.jsonl"));
+    let root_b_path = sessions.join(format!("rollout-{root_b}.jsonl"));
+    fs::write(
+        &root_a_path,
+        codex_lineage_rollout(
+            root_a,
+            None,
+            SessionRelationshipKind::Root,
+            None,
+            root_a_marker,
+        ),
+    )
+    .unwrap();
+    fs::write(
+        &child_a_path,
+        codex_lineage_rollout(
+            child_a,
+            Some(root_a),
+            SessionRelationshipKind::Delegated,
+            Some(root_a),
+            child_a_marker,
+        ),
+    )
+    .unwrap();
+    fs::write(
+        &root_b_path,
+        codex_lineage_rollout(
+            root_b,
+            None,
+            SessionRelationshipKind::Root,
+            None,
+            old_peer_marker,
+        ),
+    )
+    .unwrap();
+    let registry = register_codex_tree(&sessions);
+
+    let initial =
+        refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
+    assert_eq!(initial.certified_source_count, 3);
+    assert!(initial.logical_source_failures.is_empty());
+    let initial_generation = initial.commit.generation_id;
+
+    fs::write(
+        &child_a_path,
+        codex_lineage_rollout(
+            child_a,
+            Some(root_a),
+            SessionRelationshipKind::Delegated,
+            Some(root_b),
+            child_a_marker,
+        ),
+    )
+    .unwrap();
+    fs::write(
+        &root_b_path,
+        codex_lineage_rollout(
+            root_b,
+            None,
+            SessionRelationshipKind::Root,
+            None,
+            new_peer_marker,
+        ),
+    )
+    .unwrap();
+
+    let refreshed =
+        refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
+    assert_ne!(refreshed.commit.generation_id, initial_generation);
+    assert_eq!(refreshed.certified_source_count, 1);
+    assert_eq!(refreshed.logical_source_failures.total(), 2);
+    assert_eq!(refreshed.logical_source_failures.failures().len(), 2);
+    assert_eq!(refreshed.logical_source_failures.omitted(), 0);
+    assert_eq!(refreshed.record_rejections.total(), 0);
+    assert_eq!(
+        refreshed.record_completion(),
+        SourceBackedRecordCompletion::Completed
+    );
+    assert_eq!(refreshed.successful_route_outcomes.len(), 1);
+    assert_eq!(
+        refreshed.successful_route_outcomes[0].logical_source_failure_total,
+        2
+    );
+    for failure in refreshed.logical_source_failures.failures() {
+        assert!(!failure.carried_forward);
+        for expected in [
+            format!("computed_root_native_session_id={root_a}"),
+            format!("conflicting_advisory_session_id={root_b}"),
+            format!("evidence_source_record=session_meta:{child_a}"),
+            format!("computed_root_source_record=session_meta:{root_a}"),
+            format!("advisory_source_record=session_meta:{root_b}"),
+        ] {
+            assert!(failure.detail.contains(&expected), "{}", failure.detail);
+        }
+        assert!(!failure.detail.contains(sessions.to_str().unwrap()));
+        assert!(!failure.detail.contains(root_a_marker));
+        assert!(!failure.detail.contains(child_a_marker));
+    }
+    let verified = VerifiedIndex::open(&index).unwrap();
+    assert_eq!(
+        verified
+            .search_event_candidates(new_peer_marker, 8)
+            .unwrap()
+            .len(),
+        1
+    );
+    for removed_marker in [root_a_marker, child_a_marker, old_peer_marker] {
+        assert!(
+            verified
+                .search_event_candidates(removed_marker, 8)
+                .unwrap()
+                .is_empty(),
+            "stale marker remained published: {removed_marker}"
+        );
+    }
+}
+
+#[test]
+fn codex_many_root_conflicts_keep_exact_total_and_bounded_capture_diagnostics() {
+    const CONFLICTING_CHILDREN: usize = 65;
+    const REJECTED_SOURCES: usize = CONFLICTING_CHILDREN + 1;
+
+    let temp = tempdir().unwrap();
+    let sessions = temp.path().join("private-bounded-codex-conflicts");
+    let index = temp.path().join("index");
+    fs::create_dir_all(&sessions).unwrap();
+    let root_a = "019fa000-0000-7000-8000-000000003500";
+    let root_b = "019fa000-0000-7000-8000-0000000035b0";
+    let evidence_child = "019fa000-0000-7000-8001-000000000000";
+    let private_marker = "private bounded capture root conflict 328";
+    let valid_marker = "boundedcapturerootconflictvalidpeer328";
+    fs::write(
+        sessions.join(format!("rollout-{root_a}.jsonl")),
+        codex_lineage_rollout(
+            root_a,
+            None,
+            SessionRelationshipKind::Root,
+            None,
+            private_marker,
+        ),
+    )
+    .unwrap();
+    for index in 0..CONFLICTING_CHILDREN {
+        let child = format!("019fa000-0000-7000-8001-{index:012x}");
+        fs::write(
+            sessions.join(format!("rollout-{child}.jsonl")),
+            codex_lineage_rollout(
+                &child,
+                Some(root_a),
+                SessionRelationshipKind::Delegated,
+                Some(if index == 0 { root_b } else { root_a }),
+                private_marker,
+            ),
+        )
+        .unwrap();
+    }
+    fs::write(
+        sessions.join(format!("rollout-{root_b}.jsonl")),
+        codex_lineage_rollout(
+            root_b,
+            None,
+            SessionRelationshipKind::Root,
+            None,
+            valid_marker,
+        ),
+    )
+    .unwrap();
+    let registry = register_codex_tree(&sessions);
+
+    let refreshed =
+        refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
+    assert_eq!(refreshed.certified_source_count, 1);
+    assert_eq!(refreshed.logical_source_failures.total(), REJECTED_SOURCES);
+    assert_eq!(refreshed.logical_source_failures.failures().len(), 64);
+    assert_eq!(refreshed.logical_source_failures.omitted(), 2);
+    assert_eq!(refreshed.successful_route_outcomes.len(), 1);
+    assert_eq!(
+        refreshed.successful_route_outcomes[0].logical_source_failure_total,
+        REJECTED_SOURCES
+    );
+    assert_eq!(refreshed.record_rejections.total(), 0);
+    assert_eq!(
+        refreshed.record_completion(),
+        SourceBackedRecordCompletion::Completed
+    );
+    for failure in refreshed.logical_source_failures.failures() {
+        for expected in [
+            format!("computed_root_native_session_id={root_a}"),
+            format!("conflicting_advisory_session_id={root_b}"),
+            format!("evidence_source_record=session_meta:{evidence_child}"),
+            format!("computed_root_source_record=session_meta:{root_a}"),
+            format!("advisory_source_record=session_meta:{root_b}"),
+        ] {
+            assert!(failure.detail.contains(&expected), "{}", failure.detail);
+        }
+        assert!(!failure.detail.contains(sessions.to_str().unwrap()));
+        assert!(!failure.detail.contains(private_marker));
+    }
+    assert_eq!(
+        VerifiedIndex::open(&index)
+            .unwrap()
+            .search_event_candidates(valid_marker, 8)
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
 fn codex_all_invalid_lineage_fails_without_workers_or_publication() {
     let temp = tempdir().unwrap();
     let sessions = temp.path().join("sessions");
@@ -1580,6 +2071,64 @@ fn codex_all_invalid_lineage_fails_without_workers_or_publication() {
     assert_eq!(observation.rejected_sources, 2);
     assert_eq!(observation.worker_starts_at_normalization, 0);
     assert_eq!(observation.worker_start_latch.starts(), 0);
+    assert!(VerifiedIndex::open(&index).is_err());
+}
+
+#[test]
+fn codex_all_invalid_root_conflict_failure_exposes_path_safe_proof() {
+    let temp = tempdir().unwrap();
+    let sessions = temp.path().join("private-codex-sessions");
+    let index = temp.path().join("index");
+    fs::create_dir_all(&sessions).unwrap();
+    let root = "019fa000-0000-7000-8000-0000000032c0";
+    let child = "019fa000-0000-7000-8000-0000000032c1";
+    let missing_advisory = "019fa000-0000-7000-8000-0000000032ff";
+    let private_marker = "private all-invalid root-conflict message content";
+    fs::write(
+        sessions.join(format!("rollout-{root}.jsonl")),
+        codex_lineage_rollout(
+            root,
+            None,
+            SessionRelationshipKind::Root,
+            None,
+            private_marker,
+        ),
+    )
+    .unwrap();
+    fs::write(
+        sessions.join(format!("rollout-{child}.jsonl")),
+        codex_lineage_rollout(
+            child,
+            Some(root),
+            SessionRelationshipKind::Delegated,
+            Some(missing_advisory),
+            private_marker,
+        ),
+    )
+    .unwrap();
+
+    let error = refresh_source_backed_generation(
+        &index,
+        &register_codex_tree(&sessions),
+        WriterOptions::default(),
+    )
+    .unwrap_err();
+    let SourceBackedCoordinatorError::NoUsableSourceRoutes { failed_routes } = error else {
+        panic!("expected an unusable Codex route, got {error:?}");
+    };
+    assert_eq!(failed_routes.len(), 1);
+    let detail = &failed_routes[0].detail;
+    for expected in [
+        format!("computed_root_native_session_id={root}"),
+        format!("conflicting_advisory_session_id={missing_advisory}"),
+        format!("evidence_source_record=session_meta:{child}"),
+        format!("computed_root_source_record=session_meta:{root}"),
+        "advisory_source_record=unavailable".to_owned(),
+    ] {
+        assert!(detail.contains(&expected), "{detail}");
+    }
+    assert!(!detail.contains(sessions.to_str().unwrap()));
+    assert!(!detail.contains(private_marker));
     assert!(VerifiedIndex::open(&index).is_err());
 }
 

--- a/crates/ctx-history-capture/src/provider/source_backed/tests/codex.rs
+++ b/crates/ctx-history-capture/src/provider/source_backed/tests/codex.rs
@@ -371,7 +371,12 @@ fn run_codex_fd_budget_child() {
         ..WriterOptions::default()
     };
     let refreshed = super::super::family::jsonl::with_family_scanner_workers(16, || {
-        refresh_source_backed_generation(&index, &registry, writer_options)
+        refresh_source_backed_generation_with_work_budget_for_test(
+            &index,
+            &registry,
+            writer_options,
+            16,
+        )
     });
     let scanner_workers = super::super::family::jsonl::jsonl_family_scanner_max_worker_count();
     sampling.store(false, Ordering::Release);

--- a/crates/ctx-history-refresh/src/engine/tests/codex_union.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/codex_union.rs
@@ -113,6 +113,229 @@ fn successful_codex_route_derives_rejected_records_from_committed_core_sources()
 }
 
 #[test]
+fn codex_root_conflict_projects_source_failures_while_valid_peer_publishes() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    let index_root = source_backed_index_root(&data_root);
+    let home = temp.path().join("home");
+    let cwd = temp.path().join("cwd");
+    let root = temp.path().join("private-codex-sessions");
+    let root_a = "019fb600-0000-7000-8000-0000000032a0";
+    let child_a = "019fb600-0000-7000-8000-0000000032a1";
+    let root_b = "019fb600-0000-7000-8000-0000000032b0";
+    let private_root_marker = "privaterootacanary328";
+    let private_child_marker = "privatechildacanary328";
+    let valid_marker = "validrootbpublicationmarker";
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cwd).unwrap();
+    write_codex_rollout(&root, root_a, private_root_marker);
+    write_codex_root_conflict_rollout(&root, child_a, root_a, root_b, private_child_marker);
+    write_codex_rollout(&root, root_b, valid_marker);
+    let report = DiscoveryReport {
+        sources: vec![provider_source_for_path(
+            CaptureProvider::Codex,
+            root.clone(),
+        )],
+        issues: Vec::new(),
+    };
+    let discovery = DiscoveryContext::new(
+        &home,
+        &cwd,
+        DiscoveryPlatform::Linux,
+        DiscoveryPlatformDirs::default(),
+    );
+    let mut progress =
+        |_: CaptureSourceBackedDetailedRefreshProgress| Ok::<(), SourceBackedRouteError>(());
+
+    let publication = refresh_all_provider_sources(
+        &discovery,
+        report,
+        StdDuration::ZERO,
+        &data_root,
+        &index_root,
+        None,
+        SourceBackedRefreshScope::All,
+        &BTreeSet::new(),
+        &mut progress,
+    )
+    .unwrap();
+
+    let [result] = publication.route_results.as_slice() else {
+        panic!("one selected Codex route expected");
+    };
+    assert!(result.outcome.is_success());
+    assert_eq!(result.source_failure_total, 2);
+    assert_eq!(result.source_failures.len(), 2);
+    assert_eq!(result.rejected_record_total, 0);
+    assert!(result.rejection_diagnostics.is_empty());
+    assert_eq!(publication.current.source_count, 1);
+    assert_eq!(publication.current.rejected_records, 0);
+    for failure in &result.source_failures {
+        assert!(failure.source_selector.starts_with("logical-source:"));
+        for expected in [
+            format!("computed_root_native_session_id={root_a}"),
+            format!("conflicting_advisory_session_id={root_b}"),
+            format!("evidence_source_record=session_meta:{child_a}"),
+            format!("computed_root_source_record=session_meta:{root_a}"),
+            format!("advisory_source_record=session_meta:{root_b}"),
+        ] {
+            assert!(failure.detail.contains(&expected), "{}", failure.detail);
+        }
+        assert!(!failure.detail.contains(root.to_str().unwrap()));
+        assert!(!failure.detail.contains(private_root_marker));
+        assert!(!failure.detail.contains(private_child_marker));
+    }
+    let verified = VerifiedIndex::open(&index_root).unwrap();
+    assert_eq!(
+        verified
+            .search_event_candidates(valid_marker, 10)
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(verified
+        .search_event_candidates(private_root_marker, 10)
+        .unwrap()
+        .is_empty());
+    assert!(verified
+        .search_event_candidates(private_child_marker, 10)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn codex_root_conflict_receipt_keeps_exact_total_and_bounded_path_safe_diagnostics() {
+    const CONFLICTING_CHILDREN: usize = 65;
+    const REJECTED_SOURCES: usize = CONFLICTING_CHILDREN + 1;
+
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    let index_root = source_backed_index_root(&data_root);
+    let home = temp.path().join("home");
+    let cwd = temp.path().join("cwd");
+    let root = temp.path().join("private-bounded-codex-conflicts");
+    let root_a = "019fb600-0000-7000-8000-000000003400";
+    let root_b = "019fb600-0000-7000-8000-0000000034b0";
+    let evidence_child = "019fb600-0000-7000-8001-000000000000";
+    let private_marker = "private bounded root conflict content 328";
+    let valid_marker = "bounded root conflict valid peer 328";
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cwd).unwrap();
+    write_codex_rollout(&root, root_a, private_marker);
+    for index in 0..CONFLICTING_CHILDREN {
+        let child = format!("019fb600-0000-7000-8001-{index:012x}");
+        if index == 0 {
+            write_codex_root_conflict_rollout(&root, &child, root_a, root_b, private_marker);
+        } else {
+            write_codex_related_rollout(&root, &child, root_a, private_marker);
+        }
+    }
+    write_codex_rollout(&root, root_b, valid_marker);
+    let report = DiscoveryReport {
+        sources: vec![provider_source_for_path(
+            CaptureProvider::Codex,
+            root.clone(),
+        )],
+        issues: Vec::new(),
+    };
+    let discovery = DiscoveryContext::new(
+        &home,
+        &cwd,
+        DiscoveryPlatform::Linux,
+        DiscoveryPlatformDirs::default(),
+    );
+    let mut progress =
+        |_: CaptureSourceBackedDetailedRefreshProgress| Ok::<(), SourceBackedRouteError>(());
+
+    let publication = refresh_all_provider_sources(
+        &discovery,
+        report,
+        StdDuration::ZERO,
+        &data_root,
+        &index_root,
+        None,
+        SourceBackedRefreshScope::All,
+        &BTreeSet::new(),
+        &mut progress,
+    )
+    .unwrap();
+
+    let [result] = publication.route_results.as_slice() else {
+        panic!("one selected Codex route expected");
+    };
+    assert!(result.outcome.is_success());
+    assert_eq!(result.source_failure_total, REJECTED_SOURCES);
+    let bounded_diagnostics = result.source_failures.len();
+    assert!((1..=64).contains(&bounded_diagnostics));
+    assert!(bounded_diagnostics < REJECTED_SOURCES);
+    assert_eq!(result.rejected_record_total, 0);
+    assert!(result.rejection_diagnostics.is_empty());
+    assert_eq!(publication.current.source_count, 1);
+    assert_eq!(publication.current.rejected_records, 0);
+    for failure in &result.source_failures {
+        assert!(failure.source_selector.starts_with("logical-source:"));
+        for expected in [
+            format!("computed_root_native_session_id={root_a}"),
+            format!("conflicting_advisory_session_id={root_b}"),
+            format!("evidence_source_record=session_meta:{evidence_child}"),
+            format!("computed_root_source_record=session_meta:{root_a}"),
+            format!("advisory_source_record=session_meta:{root_b}"),
+        ] {
+            assert!(failure.detail.contains(&expected), "{}", failure.detail);
+        }
+        assert!(!failure.detail.contains(root.to_str().unwrap()));
+        assert!(!failure.detail.contains(private_marker));
+    }
+
+    let receipt = SourceBackedRefreshReceipt::from_verified_publication(
+        None,
+        publication.generation_id.clone(),
+        &publication,
+    )
+    .unwrap();
+    assert_eq!(receipt.terminal_outcome(), "completed_with_source_failures");
+    assert_eq!(receipt.source_failure_total(), REJECTED_SOURCES);
+    assert_eq!(
+        receipt.source_failure_diagnostic_count(),
+        bounded_diagnostics
+    );
+    assert_eq!(
+        receipt.source_failures_omitted(),
+        REJECTED_SOURCES - bounded_diagnostics
+    );
+    assert_eq!(receipt.rejected_record_total(), 0);
+
+    let envelope = receipt.to_json();
+    assert_eq!(envelope["source_failure_total"], REJECTED_SOURCES);
+    assert_eq!(envelope["rejected_record_total"], 0);
+    let route = envelope["route_results"]
+        .as_object()
+        .and_then(|routes| routes.values().next())
+        .and_then(Value::as_array)
+        .expect("one compact route receipt");
+    let transmitted = route[3]
+        .as_array()
+        .expect("bounded source failure diagnostics")
+        .len();
+    assert!(transmitted <= bounded_diagnostics);
+    assert_eq!(
+        envelope["source_failures_omitted"],
+        REJECTED_SOURCES - transmitted
+    );
+    assert!(
+        serde_json::to_vec(&envelope).unwrap().len() <= SOURCE_REFRESH_RECEIPT_JSON_BUDGET_BYTES
+    );
+    assert_eq!(
+        VerifiedIndex::open(&index_root)
+            .unwrap()
+            .search_event_candidates(valid_marker, 10)
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
 fn registered_codex_parent_and_exact_subdir_share_route_scoped_ownership() {
     let temp = tempfile::tempdir().unwrap();
     let data_root = temp.path().join("data");
@@ -534,10 +757,42 @@ fn write_codex_related_rollout(
     )
 }
 
+fn write_codex_root_conflict_rollout(
+    root: &Path,
+    native_session_id: &str,
+    parent_native_session_id: &str,
+    advisory_session_id: &str,
+    text: &str,
+) -> PathBuf {
+    write_codex_rollout_with_lineage(
+        root,
+        native_session_id,
+        Some(parent_native_session_id),
+        Some(advisory_session_id),
+        text,
+    )
+}
+
 fn write_codex_rollout_with_parent(
     root: &Path,
     native_session_id: &str,
     parent_native_session_id: Option<&str>,
+    text: &str,
+) -> PathBuf {
+    write_codex_rollout_with_lineage(
+        root,
+        native_session_id,
+        parent_native_session_id,
+        parent_native_session_id,
+        text,
+    )
+}
+
+fn write_codex_rollout_with_lineage(
+    root: &Path,
+    native_session_id: &str,
+    parent_native_session_id: Option<&str>,
+    advisory_session_id: Option<&str>,
     text: &str,
 ) -> PathBuf {
     fs::create_dir_all(root).unwrap();
@@ -552,9 +807,11 @@ fn write_codex_rollout_with_parent(
     });
     if let Some(parent) = parent_native_session_id {
         payload["forked_from_id"] = json!(parent);
+    }
+    if let Some(advisory) = advisory_session_id {
         // `payload.session_id` is advisory. The structural parent marker
         // remains authoritative for the native child identity and edge.
-        payload["session_id"] = json!(parent);
+        payload["session_id"] = json!(advisory);
     }
     let session_meta = json!({
         "timestamp": "2026-07-30T12:00:00Z",


### PR DESCRIPTION
Fixes #328.

- quarantine only the conflicted logical source while valid peers publish
- remove stale warm-generation records for newly conflicted roots
- report bounded typed diagnostics with exact omission counts
- preserve PR #349 lineage/capability ownership
- make the 16-worker FD regression deterministic across host CPU counts

Focused capture/refresh/CLI/FD tests, rustfmt, LOC, and diff checks pass. Fresh independent review: SHIP.