### PR TITLE
fix(history-index): normalize Unix stat metadata on macOS

### DIFF
--- a/crates/ctx-history-index/src/publication/republish/clone.rs
+++ b/crates/ctx-history-index/src/publication/republish/clone.rs
@@ -168,25 +168,26 @@ mod unix {
 
         fn from_stat(stat: &libc::stat) -> Self {
             Self {
-                device: stat.st_dev,
+                device: u64::try_from(stat.st_dev).unwrap_or(u64::MAX),
                 inode: stat.st_ino,
                 bytes: u64::try_from(stat.st_size).unwrap_or(u64::MAX),
-                mode: stat.st_mode,
+                mode: u32::from(stat.st_mode),
             }
         }
 
         fn is_regular(self) -> bool {
-            self.mode & libc::S_IFMT == libc::S_IFREG
+            self.mode & u32::from(libc::S_IFMT) == u32::from(libc::S_IFREG)
         }
 
         fn is_directory(self) -> bool {
-            self.mode & libc::S_IFMT == libc::S_IFDIR
+            self.mode & u32::from(libc::S_IFMT) == u32::from(libc::S_IFDIR)
         }
 
         fn is_same_object(self, other: Self) -> bool {
             self.device == other.device
                 && self.inode == other.inode
-                && (self.mode & libc::S_IFMT) == (other.mode & libc::S_IFMT)
+                && (self.mode & u32::from(libc::S_IFMT))
+                    == (other.mode & u32::from(libc::S_IFMT))
         }
     }
 

--- a/crates/ctx-history-index/src/publication/republish/clone.rs
+++ b/crates/ctx-history-index/src/publication/republish/clone.rs
@@ -156,6 +156,16 @@ mod unix {
         mode: u32,
     }
 
+    #[cfg(target_os = "linux")]
+    const fn normalized_stat_device(device: libc::dev_t) -> u64 {
+        device
+    }
+
+    #[cfg(target_os = "macos")]
+    const fn normalized_stat_device(device: libc::dev_t) -> u64 {
+        device as u64
+    }
+
     impl FileIdentity {
         fn from_metadata(metadata: &fs::Metadata) -> Self {
             Self {
@@ -168,7 +178,7 @@ mod unix {
 
         fn from_stat(stat: &libc::stat) -> Self {
             Self {
-                device: u64::try_from(stat.st_dev).unwrap_or(u64::MAX),
+                device: normalized_stat_device(stat.st_dev),
                 inode: stat.st_ino,
                 bytes: u64::try_from(stat.st_size).unwrap_or(u64::MAX),
                 mode: u32::from(stat.st_mode),
@@ -186,9 +196,14 @@ mod unix {
         fn is_same_object(self, other: Self) -> bool {
             self.device == other.device
                 && self.inode == other.inode
-                && (self.mode & u32::from(libc::S_IFMT))
-                    == (other.mode & u32::from(libc::S_IFMT))
+                && (self.mode & u32::from(libc::S_IFMT)) == (other.mode & u32::from(libc::S_IFMT))
         }
+    }
+
+    #[cfg(all(test, target_os = "macos"))]
+    #[test]
+    fn signed_darwin_device_id_normalization_preserves_distinct_values() {
+        assert_ne!(normalized_stat_device(-1), normalized_stat_device(-2));
     }
 
     #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

Normalize `libc::stat` device and mode fields at the history-index clone identity boundary so current main compiles on macOS ARM64.

macOS exposes `st_dev`, `st_mode`, and `S_IF*` with narrower integer types than Linux. `FileIdentity` intentionally stores normalized `u64`/`u32` values, so this performs explicit checked/widening conversions at capture and comparison sites without changing identity semantics.

## Validation

- Unpatched `//crates/ctx-history-refresh:unit_tests`: compile failure with 14 type mismatches in this file.
- Patched exact base `6153be7816bdab7da7b5e650750b87ee55065634`:
  - Core CLI builds as Mach-O arm64.
  - `//crates/ctx-history-refresh:unit_tests`: compiles, 152/154 pass.
  - `//crates/ctx-history-index:unit_tests`: compiles, 338/340 pass.
  - `//crates/ctx-cli:search_refresh_tests`: 20/21 pass.
  - `git diff --check`: pass.

The residual failures are current-main macOS filesystem, route-authority, and passive-watcher assertions; this PR does not weaken or suppress them.
