### PR TITLE
fix(codex): mark unique repository result origins

### DIFF
--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed.rs
@@ -73,8 +73,7 @@ const CODEX_LOGICAL_EVENT_KIND: &str = "codex-event";
 const CODEX_SOURCE_SCHEMA_VARIANT: &str = "codex-nativepath-jsonl-v0";
 const CODEX_SOURCE_REVISION_KIND: &str = "codex-ordinary-file-observation-v1";
 const CODEX_FRONTIER_KIND: &str = "codex-nativepath-checkpoint-v10";
-const CODEX_PARSER_REVISION: &str =
-    "codex-nativepath-core-record-v21-transitive-root-normalization";
+const CODEX_PARSER_REVISION: &str = "codex-nativepath-core-record-v22-typed-unique-result-origin";
 const CODEX_GENERATION_LINEAGE_COMPONENTS_PER_WAVE: usize = 4;
 #[cfg(test)]
 const CODEX_INVENTORY_AUTHORITY_NAMESPACE: &str = "codex.sessions-root";

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/identity.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/identity.rs
@@ -296,6 +296,9 @@ pub(super) fn codex_core_record(
         repository_result.as_ref(),
         provider_event_identity.as_ref(),
     ) {
+        (Some(CodexOutcomeOriginV0::UniqueToSession), Some(_), _) => {
+            Some(ctx_history_core::EventOrigin::UniqueToSession)
+        }
         (
             Some(CodexOutcomeOriginV0::CopiedFromAncestor {
                 ancestor_native_session_id,

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/projection.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/projection.rs
@@ -720,7 +720,10 @@ fn codex_forked_history_attributes_one_canonical_execution_origin() {
     };
     assert_eq!(outcome.produced_object_ids[0].hex, child_oid);
     assert_eq!(outcome.linkage.origin_call_id, "call-child-execution");
-    assert_eq!(unique_child_result.event_origin, EventOrigin::Unknown);
+    assert_eq!(
+        unique_child_result.event_origin,
+        EventOrigin::UniqueToSession
+    );
 
     let copied_child_call = outcome_for_sequence(&verified, child_session, 1);
     assert_eq!(copied_child_call.event_origin, EventOrigin::Unknown);

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/projection/repository_outcome_regressions.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/projection/repository_outcome_regressions.rs
@@ -208,7 +208,7 @@ fn codex_lineage_evidence_authority_retains_certified_unique_repository_outcome(
     let child_source = codex_source_key(child).unwrap();
     let child_session = codex_session_identity(&child_source, child).unwrap();
     let result = outcome_for_sequence(&verified, child_session, 2);
-    assert_eq!(result.event_origin, EventOrigin::Unknown);
+    assert_eq!(result.event_origin, EventOrigin::UniqueToSession);
     assert!(result
         .repository_vcs_observations
         .iter()

--- a/crates/ctx-history-capture/tests/codex_direct_result.rs
+++ b/crates/ctx-history-capture/tests/codex_direct_result.rs
@@ -742,7 +742,7 @@ fn invalid_attribution_preserves_terminal_content_and_all_stable_identities() {
     );
     assert_eq!(
         exact.parser_revision,
-        "codex-nativepath-core-record-v21-transitive-root-normalization"
+        "codex-nativepath-core-record-v22-typed-unique-result-origin"
     );
     assert_eq!(exact.parser_revision, invalid.parser_revision);
     assert_eq!(

--- a/docs/mcp-tool-call-attribution-capabilities.json
+++ b/docs/mcp-tool-call-attribution-capabilities.json
@@ -435,7 +435,7 @@
       "provider_id": "codex", "route": "native_import", "source_format": "codex_session_jsonl_tree", "source_schema": "codex-nativepath-jsonl-v0",
       "producer_bound": {"kind": "unversioned", "generation": 1, "unknown_generations": "not-qualified"},
       "implementation_source": "crates/ctx-history-capture/src/provider/codex/nativepath/source_backed.rs",
-      "parser_revision": "codex-nativepath-core-record-v21-transitive-root-normalization",
+      "parser_revision": "codex-nativepath-core-record-v22-typed-unique-result-origin",
       "suite_id": "ctx-history-capture::test:codex_direct_result",
       "conformance_suite": "codex_direct_result",
       "tests": [

--- a/docs/mcp-tool-call-attribution.md
+++ b/docs/mcp-tool-call-attribution.md
@@ -66,7 +66,7 @@ Deep Agents hosted trace. Capability revision 3 exact providers are
 Codex, Warp, and Copilot CLI. The exact full tuples are:
 
 - Codex `codex_session_jsonl_tree` / `codex-nativepath-jsonl-v0`, parser
-  `codex-nativepath-core-record-v21-transitive-root-normalization`, for unversioned producer generation 1
+  `codex-nativepath-core-record-v22-typed-unique-result-origin`, for unversioned producer generation 1
   only. Codex producer versions 0.200.0, 0.201.0, and 0.202.0 are separate
   explicit `not-qualified` lanes and never inherit that exact status.
 - Warp `warp_sqlite` / `warp-agent-task-protobuf-v1`, parser


### PR DESCRIPTION
## Summary
- preserve typed `UniqueToSession` origin on exact Codex repository command-result events
- rotate the Codex parser revision so existing source-backed generations are rebuilt
- keep ambiguous or copied result origins fail-closed

## Validation
- full `ctx-history-capture` binary suite: 1,338 passed
- `codex_direct_result`: 11 passed
- focused repository-origin projection regressions
- public docs, format, and diff checks

This changes capture metadata only; it does not alter the public wire shape.