### PR TITLE
fix(codex): bound descendant lineage authority

### DIFF
--- a/crates/ctx-history-capture/src/provider/codex/nativepath/checkpoint.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/checkpoint.rs
@@ -6,7 +6,7 @@ use sha2::{Digest, Sha256};
 use super::rows::CodexSessionRow;
 use super::source::CodexFileObservation;
 
-const CODEX_NATIVE_CHECKPOINT_VERSION: u8 = 10;
+const CODEX_NATIVE_CHECKPOINT_VERSION: u8 = 11;
 pub(crate) const MAX_CODEX_CERTIFIED_LINEAGE_FACTS: usize = 16;
 const CODEX_PENDING_CALL_ID_DOMAIN: &[u8] = b"ctx/codex-nativepath/pending-call-id/v1\0";
 const MAX_CODEX_PENDING_TOOL_RECORD_BYTES: u64 = 16 * 1024 * 1024 + 1;
@@ -20,6 +20,7 @@ pub(crate) enum CodexCertifiedLineageFactKindV0 {
     Call,
     Result,
     Ambiguous,
+    DescendantStarted,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -27,6 +28,7 @@ pub(crate) enum CodexCertifiedLineageFactKindV0 {
 pub(crate) struct CodexCertifiedLineageFactV0 {
     pub(crate) call_id_sha256: [u8; 32],
     pub(crate) kind: CodexCertifiedLineageFactKindV0,
+    pub(crate) raw_ordinal: u64,
 }
 
 /// Small exact lineage authority carried by an authenticated source frontier.
@@ -39,12 +41,29 @@ pub(crate) struct CodexCertifiedLineageFactV0 {
 pub(crate) struct CodexCertifiedLineageFactsV0 {
     pub(crate) facts: Vec<CodexCertifiedLineageFactV0>,
     pub(crate) has_unattributed_ambiguity: bool,
+    pub(crate) earliest_unattributed_ambiguity_raw_ordinal: Option<u64>,
 }
 
 impl CodexCertifiedLineageFactsV0 {
-    fn validate_wire_state(&self) -> serde_json::Result<()> {
+    fn validate_wire_state(
+        &self,
+        complete_record_count: u64,
+        has_incomplete_tail: bool,
+    ) -> serde_json::Result<()> {
         if self.facts.len() > MAX_CODEX_CERTIFIED_LINEAGE_FACTS
             || self.facts.windows(2).any(|pair| pair[0] >= pair[1])
+            || self
+                .facts
+                .iter()
+                .any(|fact| fact.raw_ordinal >= complete_record_count)
+            || self.has_unattributed_ambiguity
+                != self.earliest_unattributed_ambiguity_raw_ordinal.is_some()
+            || self
+                .earliest_unattributed_ambiguity_raw_ordinal
+                .is_some_and(|ordinal| {
+                    ordinal > complete_record_count
+                        || (ordinal == complete_record_count && !has_incomplete_tail)
+                })
         {
             return Err(serde::de::Error::custom(
                 "Codex certified lineage fact authority is invalid",
@@ -350,7 +369,10 @@ impl CodexNativeCheckpoint {
             ));
         }
         if let Some(facts) = self.certified_lineage_facts.as_ref() {
-            facts.validate_wire_state()?;
+            facts.validate_wire_state(
+                self.complete_record_count,
+                self.incomplete_tail().is_some(),
+            )?;
         }
         Ok(())
     }

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader.rs
@@ -20,10 +20,10 @@ use super::{
     },
     record::{
         classify_codex_record, classify_mcp_terminal_after_selector_ambiguity,
-        codex_lineage_record_evidence, malformed_record_may_contain_lineage, parse_decoded_record,
-        parse_session_meta, parse_turn_context_cwd, prefilter_codex_record,
-        CodexLineageRecordEvidence, CodexRecordAdmission, CodexRecordClass, CodexRecordProbe,
-        CodexResultKind, CodexSkipProjection,
+        codex_lineage_record_evidence, malformed_codex_lineage_record_evidence,
+        parse_decoded_record, parse_session_meta, parse_turn_context_cwd, prefilter_codex_record,
+        CodexLineageRecordEvidence, CodexMalformedLineageRecordEvidence, CodexRecordAdmission,
+        CodexRecordClass, CodexRecordProbe, CodexResultKind, CodexSkipProjection,
     },
     rows::{
         build_source_backed_event_row, build_source_backed_sparse_output_row, encoded_json_len,

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/checkpoint.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/checkpoint.rs
@@ -582,11 +582,10 @@ fn record_checkpoint_lineage(
     let record = trim_jsonl_terminator(record);
     match classify_codex_record(record) {
         Ok(probe) => facts.record_at(codex_lineage_record_evidence(&probe), raw_ordinal),
-        Err(_) if malformed_record_may_contain_lineage(record) => facts.record_at(
-            CodexLineageRecordEvidence::UnattributedAmbiguity,
-            raw_ordinal,
-        ),
-        Err(_) => Ok(()),
+        Err(_) => {
+            let evidence = malformed_codex_lineage_record_evidence(record);
+            facts.record_at(evidence.as_record_evidence(), raw_ordinal)
+        }
     }
 }
 

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/checkpoint.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/checkpoint.rs
@@ -401,7 +401,12 @@ pub(super) fn validate_checkpoint_source(
                     }
                 }
                 if let Some(facts) = lineage_facts.as_deref_mut() {
-                    record_checkpoint_lineage(facts, &lineage_record, lineage_record_oversized)?;
+                    record_checkpoint_lineage(
+                        facts,
+                        &lineage_record,
+                        lineage_record_oversized,
+                        complete_records,
+                    )?;
                     lineage_record.clear();
                     lineage_record_oversized = false;
                 }
@@ -465,7 +470,10 @@ pub(super) fn validate_checkpoint_source(
             // a complete JSONL record. Append replay resumes at that boundary,
             // so the primary scanner derives replacement evidence from the
             // tail's now-current bytes instead of retaining this old fact.
-            facts.record(CodexLineageRecordEvidence::UnattributedAmbiguity)?;
+            facts.record_at(
+                CodexLineageRecordEvidence::UnattributedAmbiguity,
+                complete_records,
+            )?;
         }
     }
 
@@ -557,6 +565,7 @@ fn record_checkpoint_lineage(
     facts: &mut CodexLineageFactsV0,
     record: &[u8],
     oversized: bool,
+    raw_ordinal: u64,
 ) -> Result<()> {
     if record
         .iter()
@@ -565,14 +574,18 @@ fn record_checkpoint_lineage(
         return Ok(());
     }
     if oversized {
-        return facts.record(CodexLineageRecordEvidence::UnattributedAmbiguity);
+        return facts.record_at(
+            CodexLineageRecordEvidence::UnattributedAmbiguity,
+            raw_ordinal,
+        );
     }
     let record = trim_jsonl_terminator(record);
     match classify_codex_record(record) {
-        Ok(probe) => facts.record(codex_lineage_record_evidence(&probe)),
-        Err(_) if malformed_record_may_contain_lineage(record) => {
-            facts.record(CodexLineageRecordEvidence::UnattributedAmbiguity)
-        }
+        Ok(probe) => facts.record_at(codex_lineage_record_evidence(&probe), raw_ordinal),
+        Err(_) if malformed_record_may_contain_lineage(record) => facts.record_at(
+            CodexLineageRecordEvidence::UnattributedAmbiguity,
+            raw_ordinal,
+        ),
         Err(_) => Ok(()),
     }
 }

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/lineage.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/lineage.rs
@@ -28,6 +28,15 @@ const MAX_LINEAGE_FACTS_PER_COMPONENT: usize =
 const LINEAGE_FACT_GROWTH: usize = 64;
 const LINEAGE_CONTAINER_CHARGE: usize = 128;
 const LINEAGE_SPILL_DOMAIN: &[u8] = b"ctx/codex-lineage-facts-spill/v1\0";
+const DESCENDANT_SESSION_DOMAIN: &[u8] = b"ctx/codex-lineage-descendant-session/v1\0";
+
+fn codex_lineage_descendant_session_digest(native_session_id: &str) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(DESCENDANT_SESSION_DOMAIN);
+    hasher.update((native_session_id.len() as u64).to_le_bytes());
+    hasher.update(native_session_id.as_bytes());
+    hasher.finalize().into()
+}
 
 #[derive(Debug)]
 pub(crate) struct CodexLineageFactBudgetV0 {
@@ -117,12 +126,23 @@ enum CodexLineageFactKindV0 {
     Call,
     Result,
     Ambiguous,
+    DescendantStarted,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 struct CodexLineageFactV0 {
     call_id_sha256: [u8; 32],
     kind: CodexLineageFactKindV0,
+    raw_ordinal: u64,
+}
+
+fn retain_two_earliest(ordinals: &mut [u64; 2], candidate: u64) {
+    if candidate < ordinals[0] {
+        ordinals[1] = ordinals[0];
+        ordinals[0] = candidate;
+    } else if candidate < ordinals[1] {
+        ordinals[1] = candidate;
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -136,6 +156,7 @@ pub(crate) struct CodexLineageFactsSpillRecordV0 {
 pub(crate) struct CodexLineageFactsV0 {
     facts: Vec<CodexLineageFactV0>,
     has_unattributed_ambiguity: bool,
+    earliest_unattributed_ambiguity_raw_ordinal: Option<u64>,
     sealed: bool,
     conservative: bool,
     charged: usize,
@@ -147,6 +168,7 @@ pub(crate) struct CodexLineageFactsV0 {
 pub(super) struct CodexLineageFactMarkV0 {
     len: usize,
     has_unattributed_ambiguity: bool,
+    earliest_unattributed_ambiguity_raw_ordinal: Option<u64>,
 }
 
 impl CodexLineageFactsV0 {
@@ -159,6 +181,7 @@ impl CodexLineageFactsV0 {
         Ok(Self {
             facts: Vec::new(),
             has_unattributed_ambiguity: false,
+            earliest_unattributed_ambiguity_raw_ordinal: None,
             sealed: conservative,
             conservative,
             charged,
@@ -167,28 +190,44 @@ impl CodexLineageFactsV0 {
         })
     }
 
+    #[cfg(test)]
     pub(super) fn record(&mut self, evidence: CodexLineageRecordEvidence<'_>) -> Result<()> {
+        self.record_at(evidence, 0)
+    }
+
+    pub(super) fn record_at(
+        &mut self,
+        evidence: CodexLineageRecordEvidence<'_>,
+        raw_ordinal: u64,
+    ) -> Result<()> {
         if self.conservative {
             return Ok(());
         }
         match evidence {
             CodexLineageRecordEvidence::None => {}
             CodexLineageRecordEvidence::UnattributedAmbiguity => {
-                self.has_unattributed_ambiguity = true;
+                self.note_unattributed_ambiguity(raw_ordinal);
             }
             CodexLineageRecordEvidence::Call(call_id) => {
-                self.push(CodexLineageFactKindV0::Call, call_id)?;
+                self.push(CodexLineageFactKindV0::Call, call_id, raw_ordinal)?;
             }
             CodexLineageRecordEvidence::Result(call_id) => {
-                self.push(CodexLineageFactKindV0::Result, call_id)?;
+                self.push(CodexLineageFactKindV0::Result, call_id, raw_ordinal)?;
             }
             CodexLineageRecordEvidence::Ambiguous(call_id) => {
-                self.push(CodexLineageFactKindV0::Ambiguous, call_id)?;
+                self.push(CodexLineageFactKindV0::Ambiguous, call_id, raw_ordinal)?;
             }
             CodexLineageRecordEvidence::AmbiguousDigests(digests) => {
                 for digest in digests {
-                    self.push_digest(CodexLineageFactKindV0::Ambiguous, *digest)?;
+                    self.push_digest(CodexLineageFactKindV0::Ambiguous, *digest, raw_ordinal)?;
                 }
+            }
+            CodexLineageRecordEvidence::DescendantStarted(native_session_id) => {
+                self.push_digest(
+                    CodexLineageFactKindV0::DescendantStarted,
+                    codex_lineage_descendant_session_digest(native_session_id),
+                    raw_ordinal,
+                )?;
             }
         }
         Ok(())
@@ -212,24 +251,44 @@ impl CodexLineageFactsV0 {
         let mut write = 0_usize;
         while read < self.facts.len() {
             let digest = self.facts[read].call_id_sha256;
-            let mut call_count = 0_usize;
-            let mut result_count = 0_usize;
             let mut ambiguous = false;
+            let mut call_ordinals = [u64::MAX; 2];
+            let mut result_ordinals = [u64::MAX; 2];
+            let mut ambiguous_ordinal = u64::MAX;
+            let mut descendant_started_ordinal = u64::MAX;
             while read < self.facts.len() && self.facts[read].call_id_sha256 == digest {
                 match self.facts[read].kind {
-                    CodexLineageFactKindV0::Call => call_count = call_count.saturating_add(1),
-                    CodexLineageFactKindV0::Result => result_count = result_count.saturating_add(1),
-                    CodexLineageFactKindV0::Ambiguous => ambiguous = true,
+                    CodexLineageFactKindV0::Call => {
+                        retain_two_earliest(&mut call_ordinals, self.facts[read].raw_ordinal);
+                    }
+                    CodexLineageFactKindV0::Result => {
+                        retain_two_earliest(&mut result_ordinals, self.facts[read].raw_ordinal);
+                    }
+                    CodexLineageFactKindV0::Ambiguous => {
+                        ambiguous = true;
+                        ambiguous_ordinal = ambiguous_ordinal.min(self.facts[read].raw_ordinal);
+                    }
+                    CodexLineageFactKindV0::DescendantStarted => {
+                        descendant_started_ordinal =
+                            descendant_started_ordinal.min(self.facts[read].raw_ordinal);
+                    }
                 }
                 read = read.saturating_add(1);
             }
-            if call_count > 1 || result_count > 1 {
-                ambiguous = true;
-            }
-            for kind in [
-                (call_count != 0).then_some(CodexLineageFactKindV0::Call),
-                (result_count != 0).then_some(CodexLineageFactKindV0::Result),
-                ambiguous.then_some(CodexLineageFactKindV0::Ambiguous),
+            for (kind, raw_ordinal) in [
+                (call_ordinals[0] != u64::MAX)
+                    .then_some((CodexLineageFactKindV0::Call, call_ordinals[0])),
+                (call_ordinals[1] != u64::MAX)
+                    .then_some((CodexLineageFactKindV0::Call, call_ordinals[1])),
+                (result_ordinals[0] != u64::MAX)
+                    .then_some((CodexLineageFactKindV0::Result, result_ordinals[0])),
+                (result_ordinals[1] != u64::MAX)
+                    .then_some((CodexLineageFactKindV0::Result, result_ordinals[1])),
+                ambiguous.then_some((CodexLineageFactKindV0::Ambiguous, ambiguous_ordinal)),
+                (descendant_started_ordinal != u64::MAX).then_some((
+                    CodexLineageFactKindV0::DescendantStarted,
+                    descendant_started_ordinal,
+                )),
             ]
             .into_iter()
             .flatten()
@@ -237,6 +296,7 @@ impl CodexLineageFactsV0 {
                 self.facts[write] = CodexLineageFactV0 {
                     call_id_sha256: digest,
                     kind,
+                    raw_ordinal,
                 };
                 write = write.saturating_add(1);
             }
@@ -255,6 +315,8 @@ impl CodexLineageFactsV0 {
         CodexLineageFactMarkV0 {
             len: self.facts.len(),
             has_unattributed_ambiguity: self.has_unattributed_ambiguity,
+            earliest_unattributed_ambiguity_raw_ordinal: self
+                .earliest_unattributed_ambiguity_raw_ordinal,
         }
     }
 
@@ -267,12 +329,24 @@ impl CodexLineageFactsV0 {
             .expect("Codex lineage logical-fact accounting is balanced");
         self.budget.release_facts(released_facts);
         self.has_unattributed_ambiguity = mark.has_unattributed_ambiguity;
+        self.earliest_unattributed_ambiguity_raw_ordinal =
+            mark.earliest_unattributed_ambiguity_raw_ordinal;
     }
 
+    #[cfg(test)]
     pub(crate) fn presence(
         &self,
         origin_call_id: &str,
         result_call_id: &str,
+    ) -> CodexLineageFactPresenceV0 {
+        self.presence_before(origin_call_id, result_call_id, None)
+    }
+
+    pub(crate) fn presence_before(
+        &self,
+        origin_call_id: &str,
+        result_call_id: &str,
+        descendant_native_session_id: Option<&str>,
     ) -> CodexLineageFactPresenceV0 {
         if self.conservative {
             return CodexLineageFactPresenceV0::Unproven;
@@ -282,11 +356,29 @@ impl CodexLineageFactsV0 {
         }
         let origin = codex_lineage_call_id_digest(origin_call_id);
         let result = codex_lineage_call_id_digest(result_call_id);
-        let has_call = self.contains(origin, CodexLineageFactKindV0::Call);
-        let has_result = self.contains(result, CodexLineageFactKindV0::Result);
-        let ambiguous = self.has_unattributed_ambiguity
-            || self.contains(origin, CodexLineageFactKindV0::Ambiguous)
-            || self.contains(result, CodexLineageFactKindV0::Ambiguous);
+        let inherited_prefix_end = match descendant_native_session_id {
+            Some(descendant) => self.raw_ordinal(
+                codex_lineage_descendant_session_digest(descendant),
+                CodexLineageFactKindV0::DescendantStarted,
+            ),
+            None => None,
+        };
+        let inherited_count =
+            |digest, kind| self.occurrence_count_before(digest, kind, inherited_prefix_end);
+        let call_count = inherited_count(origin, CodexLineageFactKindV0::Call);
+        let result_count = inherited_count(result, CodexLineageFactKindV0::Result);
+        let has_call = call_count != 0;
+        let has_result = result_count != 0;
+        let unattributed_ambiguity_applies = self.has_unattributed_ambiguity
+            && inherited_prefix_end.is_none_or(|prefix_end| {
+                self.earliest_unattributed_ambiguity_raw_ordinal
+                    .is_none_or(|ambiguity| ambiguity <= prefix_end)
+            });
+        let ambiguous = unattributed_ambiguity_applies
+            || call_count > 1
+            || result_count > 1
+            || inherited_count(origin, CodexLineageFactKindV0::Ambiguous) != 0
+            || inherited_count(result, CodexLineageFactKindV0::Ambiguous) != 0;
         if has_call && has_result && !ambiguous {
             CodexLineageFactPresenceV0::Present
         } else if ambiguous || has_call || has_result {
@@ -313,10 +405,16 @@ impl CodexLineageFactsV0 {
                         CodexLineageFactKindV0::Ambiguous => {
                             CodexCertifiedLineageFactKindV0::Ambiguous
                         }
+                        CodexLineageFactKindV0::DescendantStarted => {
+                            CodexCertifiedLineageFactKindV0::DescendantStarted
+                        }
                     },
+                    raw_ordinal: fact.raw_ordinal,
                 })
                 .collect(),
             has_unattributed_ambiguity: self.has_unattributed_ambiguity,
+            earliest_unattributed_ambiguity_raw_ordinal: self
+                .earliest_unattributed_ambiguity_raw_ordinal,
         })
     }
 
@@ -331,11 +429,17 @@ impl CodexLineageFactsV0 {
                     CodexCertifiedLineageFactKindV0::Call => CodexLineageFactKindV0::Call,
                     CodexCertifiedLineageFactKindV0::Result => CodexLineageFactKindV0::Result,
                     CodexCertifiedLineageFactKindV0::Ambiguous => CodexLineageFactKindV0::Ambiguous,
+                    CodexCertifiedLineageFactKindV0::DescendantStarted => {
+                        CodexLineageFactKindV0::DescendantStarted
+                    }
                 },
                 fact.call_id_sha256,
+                fact.raw_ordinal,
             )?;
         }
         facts.has_unattributed_ambiguity = authority.has_unattributed_ambiguity;
+        facts.earliest_unattributed_ambiguity_raw_ordinal =
+            authority.earliest_unattributed_ambiguity_raw_ordinal;
         facts.seal();
         Ok(facts)
     }
@@ -350,9 +454,15 @@ impl CodexLineageFactsV0 {
             hasher.update(bytes);
             Ok(())
         };
-        write(&[1])?;
+        write(&[3])?;
         let flags = u8::from(self.has_unattributed_ambiguity) | (u8::from(self.conservative) << 1);
         write(&[flags])?;
+        write(
+            &self
+                .earliest_unattributed_ambiguity_raw_ordinal
+                .unwrap_or(u64::MAX)
+                .to_le_bytes(),
+        )?;
         let count = u64::try_from(self.facts.len()).map_err(|_| lineage_accounting_invariant())?;
         write(&count.to_le_bytes())?;
         for fact in &self.facts {
@@ -360,9 +470,11 @@ impl CodexLineageFactsV0 {
                 CodexLineageFactKindV0::Call => 0,
                 CodexLineageFactKindV0::Result => 1,
                 CodexLineageFactKindV0::Ambiguous => 2,
+                CodexLineageFactKindV0::DescendantStarted => 3,
             };
             write(&[kind])?;
             write(&fact.call_id_sha256)?;
+            write(&fact.raw_ordinal.to_le_bytes())?;
         }
         let end = file.stream_position()?;
         Ok(CodexLineageFactsSpillRecordV0 {
@@ -389,7 +501,7 @@ impl CodexLineageFactsV0 {
         };
         let mut version = [0_u8; 1];
         read(&mut version)?;
-        if version != [1] {
+        if version != [3] {
             return Err(lineage_spill_invalid());
         }
         let mut flags = [0_u8; 1];
@@ -397,13 +509,19 @@ impl CodexLineageFactsV0 {
         if flags[0] & !0b11 != 0 {
             return Err(lineage_spill_invalid());
         }
+        let mut earliest_ambiguity = [0_u8; 8];
+        read(&mut earliest_ambiguity)?;
+        let earliest_ambiguity = match u64::from_le_bytes(earliest_ambiguity) {
+            u64::MAX => None,
+            value => Some(value),
+        };
         let mut count = [0_u8; 8];
         read(&mut count)?;
         let count = u64::from_le_bytes(count);
-        let expected_length = 10_u64
+        let expected_length = 18_u64
             .checked_add(
                 count
-                    .checked_mul(33)
+                    .checked_mul(41)
                     .ok_or_else(lineage_accounting_invariant)?,
             )
             .ok_or_else(lineage_accounting_invariant)?;
@@ -425,13 +543,22 @@ impl CodexLineageFactsV0 {
                 0 => CodexLineageFactKindV0::Call,
                 1 => CodexLineageFactKindV0::Result,
                 2 => CodexLineageFactKindV0::Ambiguous,
+                3 => CodexLineageFactKindV0::DescendantStarted,
                 _ => return Err(lineage_spill_invalid()),
             };
             let mut digest = [0_u8; 32];
             read(&mut digest)?;
-            facts.push_digest(kind, digest)?;
+            let mut raw_ordinal = [0_u8; 8];
+            read(&mut raw_ordinal)?;
+            facts.push_digest(kind, digest, u64::from_le_bytes(raw_ordinal))?;
         }
         facts.has_unattributed_ambiguity = flags[0] & 0b1 != 0;
+        facts.earliest_unattributed_ambiguity_raw_ordinal = earliest_ambiguity;
+        if (facts.has_unattributed_ambiguity != earliest_ambiguity.is_some())
+            || (conservative && earliest_ambiguity.is_some())
+        {
+            return Err(lineage_spill_invalid());
+        }
         facts.seal();
         if (!conservative && facts.conservative)
             || (!conservative && facts.facts.len() != usize::try_from(count).unwrap_or(usize::MAX))
@@ -442,20 +569,30 @@ impl CodexLineageFactsV0 {
         Ok(facts)
     }
 
-    fn push(&mut self, kind: CodexLineageFactKindV0, call_id: &str) -> Result<()> {
+    fn push(
+        &mut self,
+        kind: CodexLineageFactKindV0,
+        call_id: &str,
+        raw_ordinal: u64,
+    ) -> Result<()> {
         if call_id.is_empty() || self.sealed {
-            self.has_unattributed_ambiguity = true;
+            self.note_unattributed_ambiguity(raw_ordinal);
             return Ok(());
         }
-        self.push_digest(kind, codex_lineage_call_id_digest(call_id))
+        self.push_digest(kind, codex_lineage_call_id_digest(call_id), raw_ordinal)
     }
 
-    fn push_digest(&mut self, kind: CodexLineageFactKindV0, digest: [u8; 32]) -> Result<()> {
+    fn push_digest(
+        &mut self,
+        kind: CodexLineageFactKindV0,
+        digest: [u8; 32],
+        raw_ordinal: u64,
+    ) -> Result<()> {
         if self.conservative {
             return Ok(());
         }
         if self.sealed {
-            self.has_unattributed_ambiguity = true;
+            self.note_unattributed_ambiguity(raw_ordinal);
             return Ok(());
         }
         if self.facts.len() == self.facts.capacity() && !self.reserve_more(LINEAGE_FACT_GROWTH)? {
@@ -476,6 +613,7 @@ impl CodexLineageFactsV0 {
         self.facts.push(CodexLineageFactV0 {
             call_id_sha256: digest,
             kind,
+            raw_ordinal,
         });
         Ok(())
     }
@@ -536,19 +674,45 @@ impl CodexLineageFactsV0 {
         self.budget.release(self.charged);
         self.budget.release_facts(self.charged_facts);
         self.has_unattributed_ambiguity = false;
+        self.earliest_unattributed_ambiguity_raw_ordinal = None;
         self.sealed = true;
         self.conservative = true;
         self.charged = 0;
         self.charged_facts = 0;
     }
 
-    fn contains(&self, digest: [u8; 32], kind: CodexLineageFactKindV0) -> bool {
+    fn raw_ordinal(&self, digest: [u8; 32], kind: CodexLineageFactKindV0) -> Option<u64> {
+        let index = self
+            .facts
+            .partition_point(|fact| (fact.call_id_sha256, fact.kind) < (digest, kind));
         self.facts
-            .binary_search(&CodexLineageFactV0 {
-                call_id_sha256: digest,
-                kind,
-            })
-            .is_ok()
+            .get(index)
+            .filter(|fact| (fact.call_id_sha256, fact.kind) == (digest, kind))
+            .map(|fact| fact.raw_ordinal)
+    }
+
+    fn occurrence_count_before(
+        &self,
+        digest: [u8; 32],
+        kind: CodexLineageFactKindV0,
+        inclusive_end: Option<u64>,
+    ) -> usize {
+        let start = self
+            .facts
+            .partition_point(|fact| (fact.call_id_sha256, fact.kind) < (digest, kind));
+        self.facts[start..]
+            .iter()
+            .take_while(|fact| (fact.call_id_sha256, fact.kind) == (digest, kind))
+            .filter(|fact| inclusive_end.is_none_or(|end| fact.raw_ordinal <= end))
+            .count()
+    }
+
+    fn note_unattributed_ambiguity(&mut self, raw_ordinal: u64) {
+        self.earliest_unattributed_ambiguity_raw_ordinal = Some(
+            self.earliest_unattributed_ambiguity_raw_ordinal
+                .map_or(raw_ordinal, |current| current.min(raw_ordinal)),
+        );
+        self.has_unattributed_ambiguity = true;
     }
 }
 
@@ -715,6 +879,46 @@ mod tests {
         facts.seal();
         assert_eq!(
             facts.presence("duplicate", "duplicate"),
+            CodexLineageFactPresenceV0::Unproven
+        );
+    }
+
+    #[test]
+    fn typed_descendant_boundary_excludes_only_later_ambiguity() {
+        let budget = Arc::new(CodexLineageFactBudgetV0::default());
+        let mut later = CodexLineageFactsV0::new(Arc::clone(&budget)).unwrap();
+        later
+            .record_at(CodexLineageRecordEvidence::DescendantStarted("child"), 100)
+            .unwrap();
+        later
+            .record_at(CodexLineageRecordEvidence::UnattributedAmbiguity, 200)
+            .unwrap();
+        later.seal();
+        assert_eq!(
+            later.presence_before("child-call", "child-call", Some("child")),
+            CodexLineageFactPresenceV0::Absent
+        );
+
+        let mut earlier = CodexLineageFactsV0::new(Arc::clone(&budget)).unwrap();
+        earlier
+            .record_at(CodexLineageRecordEvidence::UnattributedAmbiguity, 50)
+            .unwrap();
+        earlier
+            .record_at(CodexLineageRecordEvidence::DescendantStarted("child"), 100)
+            .unwrap();
+        earlier.seal();
+        assert_eq!(
+            earlier.presence_before("child-call", "child-call", Some("child")),
+            CodexLineageFactPresenceV0::Unproven
+        );
+
+        let mut unbounded = CodexLineageFactsV0::new(budget).unwrap();
+        unbounded
+            .record(CodexLineageRecordEvidence::UnattributedAmbiguity)
+            .unwrap();
+        unbounded.seal();
+        assert_eq!(
+            unbounded.presence_before("child-call", "child-call", Some("child")),
             CodexLineageFactPresenceV0::Unproven
         );
     }
@@ -963,6 +1167,89 @@ mod tests {
         let facts = replay.lineage_facts.unwrap();
         assert_eq!(
             facts.presence("checkpoint-call", "checkpoint-call"),
+            CodexLineageFactPresenceV0::Present
+        );
+    }
+
+    #[test]
+    fn typed_descendant_boundary_excludes_later_exact_facts_and_is_mandatory() {
+        let child = "019fa000-0000-7000-8000-000000000301";
+        let budget = Arc::new(CodexLineageFactBudgetV0::default());
+        let mut facts = CodexLineageFactsV0::new(budget).unwrap();
+        facts
+            .record_at(CodexLineageRecordEvidence::Call("inherited"), 1)
+            .unwrap();
+        facts
+            .record_at(CodexLineageRecordEvidence::Result("inherited"), 2)
+            .unwrap();
+        facts
+            .record_at(CodexLineageRecordEvidence::DescendantStarted(child), 3)
+            .unwrap();
+        facts
+            .record_at(CodexLineageRecordEvidence::Call("later"), 4)
+            .unwrap();
+        facts
+            .record_at(CodexLineageRecordEvidence::Result("later"), 5)
+            .unwrap();
+        facts.seal();
+
+        assert_eq!(
+            facts.presence_before("inherited", "inherited", Some(child)),
+            CodexLineageFactPresenceV0::Present
+        );
+        assert_eq!(
+            facts.presence_before("later", "later", Some(child)),
+            CodexLineageFactPresenceV0::Absent
+        );
+
+        let mut duplicate_after =
+            CodexLineageFactsV0::new(Arc::new(CodexLineageFactBudgetV0::default())).unwrap();
+        duplicate_after
+            .record_at(CodexLineageRecordEvidence::Call("shared"), 1)
+            .unwrap();
+        duplicate_after
+            .record_at(CodexLineageRecordEvidence::Result("shared"), 2)
+            .unwrap();
+        duplicate_after
+            .record_at(CodexLineageRecordEvidence::DescendantStarted(child), 3)
+            .unwrap();
+        duplicate_after
+            .record_at(CodexLineageRecordEvidence::Call("shared"), 4)
+            .unwrap();
+        duplicate_after.seal();
+        assert_eq!(
+            duplicate_after.presence_before("shared", "shared", Some(child)),
+            CodexLineageFactPresenceV0::Present
+        );
+
+        let mut duplicate_before =
+            CodexLineageFactsV0::new(Arc::new(CodexLineageFactBudgetV0::default())).unwrap();
+        duplicate_before
+            .record_at(CodexLineageRecordEvidence::Call("shared"), 1)
+            .unwrap();
+        duplicate_before
+            .record_at(CodexLineageRecordEvidence::Call("shared"), 2)
+            .unwrap();
+        duplicate_before
+            .record_at(CodexLineageRecordEvidence::Result("shared"), 3)
+            .unwrap();
+        duplicate_before
+            .record_at(CodexLineageRecordEvidence::DescendantStarted(child), 4)
+            .unwrap();
+        duplicate_before.seal();
+        assert_eq!(
+            duplicate_before.presence_before("shared", "shared", Some(child)),
+            CodexLineageFactPresenceV0::Unproven
+        );
+        // Without a typed boundary, exact call/result identifiers retain the
+        // existing globally unique match semantics. Only unattributed
+        // ambiguity remains conservatively unbounded.
+        assert_eq!(
+            facts.presence_before(
+                "inherited",
+                "inherited",
+                Some("019fa000-0000-7000-8000-000000000302")
+            ),
             CodexLineageFactPresenceV0::Present
         );
     }

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/project.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/project.rs
@@ -36,7 +36,8 @@ impl CodexNativeScanner {
             Ok(probe) if !probe.lineage_malformed() => (probe, false),
             Ok(probe) => {
                 if let Some(lineage_facts) = self.lineage_facts.as_mut() {
-                    lineage_facts.record(codex_lineage_record_evidence(&probe))?;
+                    lineage_facts
+                        .record_at(codex_lineage_record_evidence(&probe), self.raw_ordinal)?;
                 }
                 let Some(recovered) = classify_mcp_terminal_after_selector_ambiguity(record) else {
                     self.reject(false);
@@ -48,7 +49,10 @@ impl CodexNativeScanner {
                 let mut lineage_recorded = false;
                 if malformed_record_may_contain_lineage(record) {
                     if let Some(lineage_facts) = self.lineage_facts.as_mut() {
-                        lineage_facts.record(CodexLineageRecordEvidence::UnattributedAmbiguity)?;
+                        lineage_facts.record_at(
+                            CodexLineageRecordEvidence::UnattributedAmbiguity,
+                            self.raw_ordinal,
+                        )?;
                     }
                     lineage_recorded = true;
                 }
@@ -62,7 +66,7 @@ impl CodexNativeScanner {
         if !lineage_already_recorded {
             let lineage_evidence = codex_lineage_record_evidence(&probe);
             if let Some(lineage_facts) = self.lineage_facts.as_mut() {
-                lineage_facts.record(lineage_evidence)?;
+                lineage_facts.record_at(lineage_evidence, self.raw_ordinal)?;
             }
         }
         if probe.lineage_malformed() {
@@ -70,6 +74,10 @@ impl CodexNativeScanner {
             return Ok(CodexRecordProjection::default());
         }
         match probe.class {
+            CodexRecordClass::DescendantActivity | CodexRecordClass::DescendantStarted => {
+                self.counters.ignored_records = self.counters.ignored_records.saturating_add(1);
+                Ok(CodexRecordProjection::default())
+            }
             CodexRecordClass::SessionMeta => {
                 self.counters.typed_json_parses = self.counters.typed_json_parses.saturating_add(1);
                 match parse_session_meta(record) {

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/project.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/project.rs
@@ -46,15 +46,14 @@ impl CodexNativeScanner {
                 (recovered, true)
             }
             Err(_) => {
-                let mut lineage_recorded = false;
-                if malformed_record_may_contain_lineage(record) {
-                    if let Some(lineage_facts) = self.lineage_facts.as_mut() {
-                        lineage_facts.record_at(
-                            CodexLineageRecordEvidence::UnattributedAmbiguity,
-                            self.raw_ordinal,
-                        )?;
-                    }
-                    lineage_recorded = true;
+                let malformed_evidence = malformed_codex_lineage_record_evidence(record);
+                let lineage_recorded = !matches!(
+                    malformed_evidence,
+                    CodexMalformedLineageRecordEvidence::None
+                );
+                if let Some(lineage_facts) = self.lineage_facts.as_mut() {
+                    lineage_facts
+                        .record_at(malformed_evidence.as_record_evidence(), self.raw_ordinal)?;
                 }
                 let Some(recovered) = classify_mcp_terminal_after_selector_ambiguity(record) else {
                     self.reject(false);

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/reader/scanner.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/reader/scanner.rs
@@ -425,7 +425,10 @@ impl CodexNativeScanner {
                         self.counters.oversized_records.saturating_add(1);
                 }
                 if let Some(lineage_facts) = self.lineage_facts.as_mut() {
-                    lineage_facts.record(CodexLineageRecordEvidence::UnattributedAmbiguity)?;
+                    lineage_facts.record_at(
+                        CodexLineageRecordEvidence::UnattributedAmbiguity,
+                        self.raw_ordinal,
+                    )?;
                 }
                 self.exhausted = true;
                 self.queue_end_pages(false)?;
@@ -440,7 +443,10 @@ impl CodexNativeScanner {
             } else if record_read.oversized {
                 self.reject(true);
                 if let Some(lineage_facts) = self.lineage_facts.as_mut() {
-                    lineage_facts.record(CodexLineageRecordEvidence::UnattributedAmbiguity)?;
+                    lineage_facts.record_at(
+                        CodexLineageRecordEvidence::UnattributedAmbiguity,
+                        self.raw_ordinal,
+                    )?;
                 }
                 CodexRecordProjection::default()
             } else {

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/record.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/record.rs
@@ -26,7 +26,7 @@ pub(super) fn codex_lineage_call_id_digest(call_id: &str) -> [u8; 32] {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
-struct CodexLineageCallIds {
+pub(super) struct CodexLineageCallIds {
     digests: [[u8; 32]; MAX_CODEX_LINEAGE_CALL_IDS_PER_RECORD],
     len: usize,
     overflowed: bool,
@@ -366,6 +366,8 @@ struct CodexPayloadProbe<'a> {
     lineage_call_ids: CodexLineageCallIds,
     relationship_escaped: bool,
     lineage_malformed: bool,
+    activity_relationship_escaped: bool,
+    activity_lineage_malformed: bool,
 }
 
 fn empty_codex_payload_probe<'a>() -> CodexPayloadProbe<'a> {
@@ -377,6 +379,8 @@ fn empty_codex_payload_probe<'a>() -> CodexPayloadProbe<'a> {
         lineage_call_ids: CodexLineageCallIds::default(),
         relationship_escaped: false,
         lineage_malformed: false,
+        activity_relationship_escaped: false,
+        activity_lineage_malformed: false,
     }
 }
 
@@ -413,6 +417,8 @@ impl<'de> Visitor<'de> for CodexPayloadProbeVisitor {
         let mut lineage_call_ids = CodexLineageCallIds::default();
         let mut relationship_escaped = false;
         let mut lineage_malformed = false;
+        let mut activity_relationship_escaped = false;
+        let mut activity_lineage_malformed = false;
         while let Some(key) = map.next_key::<CodexText<'de>>()? {
             let key_escaped = key.escaped;
             match key.as_str() {
@@ -445,9 +451,9 @@ impl<'de> Visitor<'de> for CodexPayloadProbeVisitor {
                     let duplicate = saw_agent_thread_id;
                     saw_agent_thread_id = true;
                     let value = map.next_value::<CodexLineageText<'de>>()?;
-                    relationship_escaped |=
+                    activity_relationship_escaped |=
                         key_escaped || value.value.as_ref().is_some_and(|value| value.escaped);
-                    lineage_malformed |= duplicate || value.malformed;
+                    activity_lineage_malformed |= duplicate || value.malformed;
                     if !duplicate {
                         agent_thread_id = value.value;
                     }
@@ -456,9 +462,9 @@ impl<'de> Visitor<'de> for CodexPayloadProbeVisitor {
                     let duplicate = saw_activity_kind;
                     saw_activity_kind = true;
                     let value = map.next_value::<CodexLineageText<'de>>()?;
-                    relationship_escaped |=
+                    activity_relationship_escaped |=
                         key_escaped || value.value.as_ref().is_some_and(|value| value.escaped);
-                    lineage_malformed |= duplicate || value.malformed;
+                    activity_lineage_malformed |= duplicate || value.malformed;
                     if !duplicate {
                         activity_kind = value.value;
                     }
@@ -476,6 +482,8 @@ impl<'de> Visitor<'de> for CodexPayloadProbeVisitor {
             lineage_call_ids,
             relationship_escaped,
             lineage_malformed,
+            activity_relationship_escaped,
+            activity_lineage_malformed,
         })
     }
 
@@ -553,6 +561,25 @@ pub(super) enum CodexLineageRecordEvidence<'a> {
     DescendantStarted(&'a str),
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(super) enum CodexMalformedLineageRecordEvidence {
+    None,
+    AmbiguousDigests(CodexLineageCallIds),
+    UnattributedAmbiguity,
+}
+
+impl CodexMalformedLineageRecordEvidence {
+    pub(super) fn as_record_evidence(&self) -> CodexLineageRecordEvidence<'_> {
+        match self {
+            Self::None => CodexLineageRecordEvidence::None,
+            Self::AmbiguousDigests(call_ids) => {
+                CodexLineageRecordEvidence::AmbiguousDigests(call_ids.as_slice())
+            }
+            Self::UnattributedAmbiguity => CodexLineageRecordEvidence::UnattributedAmbiguity,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct CodexStructuralOutput {
     pub(super) outcome: OutputOutcomeMetadata,
@@ -562,11 +589,6 @@ pub(super) struct CodexStructuralOutput {
 
 pub(super) fn classify_codex_record(line: &[u8]) -> serde_json::Result<CodexRecordProbe<'_>> {
     let envelope = serde_json::from_slice::<CodexEnvelopeProbe<'_>>(line)?;
-    let lineage_malformed = envelope.lineage_malformed
-        || envelope
-            .payload
-            .as_ref()
-            .is_some_and(|payload| payload.lineage_malformed);
     let item_type = envelope
         .payload
         .as_ref()
@@ -575,16 +597,21 @@ pub(super) fn classify_codex_record(line: &[u8]) -> serde_json::Result<CodexReco
         envelope.record_type.as_ref().map_or("", CodexText::as_str),
         item_type,
     );
+    let activity_record = base_class == CodexRecordClass::DescendantActivity;
+    let lineage_malformed = envelope.lineage_malformed
+        || envelope.payload.as_ref().is_some_and(|payload| {
+            payload.lineage_malformed || (activity_record && payload.activity_lineage_malformed)
+        });
     let output = match (lineage_malformed, base_class) {
         (true, _) => None,
         (false, CodexRecordClass::ExcludedResult(_)) => Some(probe_structural_output(line)?),
         (false, _) => None,
     };
     let relationship_escaped = envelope.relationship_escaped
-        || envelope
-            .payload
-            .as_ref()
-            .is_some_and(|payload| payload.relationship_escaped);
+        || envelope.payload.as_ref().is_some_and(|payload| {
+            payload.relationship_escaped
+                || (activity_record && payload.activity_relationship_escaped)
+        });
     let descendant_started_native_session_id = envelope.payload.as_ref().and_then(|payload| {
         (base_class == CodexRecordClass::DescendantActivity
             && payload.activity_kind.as_ref().map(CodexText::as_str) == Some("started")
@@ -661,9 +688,199 @@ pub(super) fn malformed_record_may_contain_lineage(record: &[u8]) -> bool {
         br#""custom_tool_call""#.as_slice(),
         br#""function_call_output""#.as_slice(),
         br#""custom_tool_call_output""#.as_slice(),
+        br#""sub_agent_activity""#.as_slice(),
+        br#""agent_thread_id""#.as_slice(),
     ]
     .into_iter()
     .any(|needle| record.windows(needle.len()).any(|window| window == needle))
+}
+
+/// Recovers exact ambiguity scope when one physical JSONL row is a sequence of
+/// otherwise valid Codex envelopes.
+///
+/// Real Codex interruption races have concatenated two complete JSON objects
+/// without a newline. The row is still rejected, but treating that corruption
+/// as ambiguity for every call in the entire session discards unrelated exact
+/// producer evidence. A complete serde stream proves the full malformed row is
+/// composed only of the envelopes inspected here; any parse error, overflow,
+/// or selector whose call identity cannot be recovered retains the existing
+/// fail-closed global ambiguity.
+pub(super) fn malformed_codex_lineage_record_evidence(
+    record: &[u8],
+) -> CodexMalformedLineageRecordEvidence {
+    if !malformed_record_may_contain_lineage(record) {
+        return CodexMalformedLineageRecordEvidence::None;
+    }
+
+    let mut stream =
+        serde_json::Deserializer::from_slice(record).into_iter::<CodexEnvelopeProbe<'_>>();
+    let mut call_ids = CodexLineageCallIds::default();
+    let mut envelopes = 0_usize;
+    while let Some(next) = stream.next() {
+        let Ok(envelope) = next else {
+            return literal_malformed_call_id_evidence(record);
+        };
+        envelopes = envelopes.saturating_add(1);
+
+        let item_type = envelope
+            .payload
+            .as_ref()
+            .and_then(|payload| payload.item_type.as_ref().map(CodexText::as_str));
+        let class = codex_record_class(
+            envelope.record_type.as_ref().map_or("", CodexText::as_str),
+            item_type,
+        );
+        if class == CodexRecordClass::DescendantActivity {
+            // A malformed physical row can never grant a trusted child-start
+            // boundary. Preserve source-wide abstention instead of silently
+            // treating a concatenated activity as ordinary ignored telemetry.
+            return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+        }
+        let lineage_malformed = envelope.lineage_malformed
+            || envelope
+                .payload
+                .as_ref()
+                .is_some_and(|payload| payload.lineage_malformed);
+
+        if lineage_malformed {
+            if envelope.lineage_call_ids.overflowed
+                || envelope.lineage_call_ids.as_slice().is_empty()
+            {
+                return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+            }
+            call_ids.merge(envelope.lineage_call_ids);
+        } else if matches!(
+            class,
+            CodexRecordClass::Retained(CodexRetainedKind::ToolCall)
+                | CodexRecordClass::ExcludedResult(_)
+        ) {
+            let Some(call_id) = envelope
+                .payload
+                .as_ref()
+                .and_then(|payload| payload.call_id.as_ref())
+                .map(CodexText::as_str)
+            else {
+                return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+            };
+            if call_id.is_empty() || call_id.len() > super::checkpoint::MAX_CODEX_TOOL_CALL_ID_BYTES
+            {
+                return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+            }
+            call_ids.remember(call_id);
+        }
+
+        if call_ids.overflowed {
+            return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+        }
+    }
+
+    if envelopes == 0
+        || !record[stream.byte_offset()..]
+            .iter()
+            .all(u8::is_ascii_whitespace)
+    {
+        return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+    }
+    if call_ids.as_slice().is_empty() {
+        CodexMalformedLineageRecordEvidence::None
+    } else {
+        CodexMalformedLineageRecordEvidence::AmbiguousDigests(call_ids)
+    }
+}
+
+fn literal_malformed_call_id_evidence(record: &[u8]) -> CodexMalformedLineageRecordEvidence {
+    let Some(call_ids) = recover_literal_malformed_call_ids(record) else {
+        return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+    };
+    CodexMalformedLineageRecordEvidence::AmbiguousDigests(call_ids)
+}
+
+/// Returns a conservative superset of every literal `call_id` in a corrupted
+/// row, or declines to scope the ambiguity.
+///
+/// A malformed outer string can contain either ordinary JSON fields or an
+/// escaped serialized JSON fragment. Both forms are admitted only when every
+/// `call_id` substring has the exact key/colon/plain-string shape and every
+/// value is bounded. Any Unicode escape could encode a hidden key, while any
+/// unrecognized occurrence could be a key whose value this scanner failed to
+/// recover, so either condition preserves global ambiguity.
+fn recover_literal_malformed_call_ids(record: &[u8]) -> Option<CodexLineageCallIds> {
+    if record.windows(2).any(|window| window == br#"\u"#) {
+        return None;
+    }
+
+    let needle = b"call_id";
+    let mut search_from = 0_usize;
+    let mut call_ids = CodexLineageCallIds::default();
+    let mut occurrences = 0_usize;
+    while let Some(relative) = record
+        .get(search_from..)?
+        .windows(needle.len())
+        .position(|window| window == needle)
+    {
+        let start = search_from.checked_add(relative)?;
+        occurrences = occurrences.checked_add(1)?;
+        let mut cursor = start.checked_add(needle.len())?;
+
+        let escaped_key = match (
+            record.get(start.checked_sub(2)?..start),
+            record.get(start.checked_sub(1)?),
+        ) {
+            (Some(br#"\""#), _) => true,
+            (_, Some(b'"')) => false,
+            _ => return None,
+        };
+        if escaped_key {
+            (record.get(cursor..cursor.checked_add(2)?)? == br#"\""#).then_some(())?;
+            cursor = cursor.checked_add(2)?;
+        } else {
+            (record.get(cursor) == Some(&b'"')).then_some(())?;
+            cursor = cursor.checked_add(1)?;
+        }
+        while record
+            .get(cursor)
+            .is_some_and(|byte| byte.is_ascii_whitespace())
+        {
+            cursor = cursor.checked_add(1)?;
+        }
+        (record.get(cursor) == Some(&b':')).then_some(())?;
+        cursor = cursor.checked_add(1)?;
+        while record
+            .get(cursor)
+            .is_some_and(|byte| byte.is_ascii_whitespace())
+        {
+            cursor = cursor.checked_add(1)?;
+        }
+
+        let escaped_value = record.get(cursor..cursor.checked_add(2)?)? == br#"\""#;
+        if escaped_value {
+            cursor = cursor.checked_add(2)?;
+        } else {
+            (record.get(cursor) == Some(&b'"')).then_some(())?;
+            cursor = cursor.checked_add(1)?;
+        }
+        let value_start = cursor;
+        let value_end = loop {
+            if escaped_value {
+                if record.get(cursor..cursor.checked_add(2)?)? == br#"\""# {
+                    break cursor;
+                }
+            } else if record.get(cursor) == Some(&b'"') {
+                break cursor;
+            }
+            // Call IDs are provider identifiers. Escapes make the exact value
+            // non-literal and therefore retain global ambiguity.
+            (record.get(cursor) != Some(&b'\\')).then_some(())?;
+            cursor = cursor.checked_add(1)?;
+        };
+        let value = std::str::from_utf8(record.get(value_start..value_end)?).ok()?;
+        (!value.is_empty() && value.len() <= super::checkpoint::MAX_CODEX_TOOL_CALL_ID_BYTES)
+            .then_some(())?;
+        call_ids.remember(value);
+        (!call_ids.overflowed).then_some(())?;
+        search_from = start.checked_add(needle.len())?;
+    }
+    (occurrences > 0 && !call_ids.as_slice().is_empty()).then_some(call_ids)
 }
 
 /// Recovers only the canonical MCP terminal shape when the strict selector
@@ -1028,6 +1245,81 @@ mod lineage_tests {
             codex_lineage_record_evidence(&probe),
             CodexLineageRecordEvidence::UnattributedAmbiguity
         );
+    }
+
+    #[test]
+    fn concatenated_valid_envelopes_recover_exact_ambiguity_scope() {
+        let record = br#"{"type":"response_item","payload":{"type":"function_call","call_id":"first","name":"exec"}}{"type":"response_item","payload":{"type":"function_call_output","call_id":"second","output":"ok"}}"#;
+        assert!(classify_codex_record(record).is_err());
+        let evidence = malformed_codex_lineage_record_evidence(record);
+        assert_ambiguous_call_ids(evidence.as_record_evidence(), &["first", "second"]);
+    }
+
+    #[test]
+    fn corrupted_outer_call_recovers_its_exact_trailing_call_id() {
+        let record = br#"{"type":"response_item","payload":{"type":"function_call","arguments":"prefix {"type":"response_item","payload":{"type":"function_call"}","call_id":"outer-call","name":"exec"}}"#;
+        assert!(classify_codex_record(record).is_err());
+        let evidence = malformed_codex_lineage_record_evidence(record);
+        assert!(
+            matches!(
+                evidence,
+                CodexMalformedLineageRecordEvidence::AmbiguousDigests(_)
+            ),
+            "outer corruption was not scoped: {evidence:?}"
+        );
+        assert_ambiguous_call_ids(evidence.as_record_evidence(), &["outer-call"]);
+    }
+
+    #[test]
+    fn malformed_unicode_or_unstructured_call_id_retains_global_ambiguity() {
+        for record in [
+            br#"{"type":"response_item","payload":{"type":"function_call","call_\u0069d":"hidden""#
+                .as_slice(),
+            br#"{"type":"response_item","payload":{"type":"function_call","text":"call_id without exact field""#
+                .as_slice(),
+        ] {
+            let evidence = malformed_codex_lineage_record_evidence(record);
+            assert!(matches!(
+                evidence,
+                CodexMalformedLineageRecordEvidence::UnattributedAmbiguity
+            ), "unexpected scoped evidence: {evidence:?}");
+        }
+    }
+
+    #[test]
+    fn malformed_rows_scope_all_exact_ids_but_not_descendant_authority() {
+        let exact_ids = br#"{"type":"response_item","payload":{"type":"function_call","call_id":"first"}}{"type":"response_item","payload":{"type":"function_call","call_id":"hidden""#;
+        let evidence = malformed_codex_lineage_record_evidence(exact_ids);
+        assert_ambiguous_call_ids(evidence.as_record_evidence(), &["first", "hidden"]);
+
+        let descendant = br#"{"type":"event_msg","payload":{"type":"sub_agent_activity","kind":"started","agent_thread_id":"019f8d80-ba23-73f3-a02a-9400f9e7b9ec"}} trailing"#;
+        assert!(matches!(
+            malformed_codex_lineage_record_evidence(descendant),
+            CodexMalformedLineageRecordEvidence::UnattributedAmbiguity
+        ));
+    }
+
+    #[test]
+    fn malformed_non_lineage_record_adds_no_lineage_ambiguity() {
+        let record = br#"{"type":"event_msg","payload":{"type":"token_count","value":1}} trailing"#;
+        assert!(matches!(
+            malformed_codex_lineage_record_evidence(record),
+            CodexMalformedLineageRecordEvidence::None
+        ));
+    }
+
+    #[test]
+    fn too_many_concatenated_call_ids_retain_global_ambiguity() {
+        let mut record = String::new();
+        for index in 0..=MAX_CODEX_LINEAGE_CALL_IDS_PER_RECORD {
+            record.push_str(&format!(
+                r#"{{"type":"response_item","payload":{{"type":"function_call","call_id":"call-{index}"}}}}"#
+            ));
+        }
+        assert!(matches!(
+            malformed_codex_lineage_record_evidence(record.as_bytes()),
+            CodexMalformedLineageRecordEvidence::UnattributedAmbiguity
+        ));
     }
 }
 

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/record.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/record.rs
@@ -100,6 +100,8 @@ impl CodexResultKind {
 pub(super) enum CodexRecordClass {
     SessionMeta,
     TurnContext,
+    DescendantActivity,
+    DescendantStarted,
     Retained(CodexRetainedKind),
     ExcludedResult(CodexResultKind),
     Ignored,
@@ -359,6 +361,8 @@ impl<'de> Visitor<'de> for CodexEnvelopeProbeVisitor {
 struct CodexPayloadProbe<'a> {
     item_type: Option<CodexText<'a>>,
     call_id: Option<CodexText<'a>>,
+    agent_thread_id: Option<CodexText<'a>>,
+    activity_kind: Option<CodexText<'a>>,
     lineage_call_ids: CodexLineageCallIds,
     relationship_escaped: bool,
     lineage_malformed: bool,
@@ -368,6 +372,8 @@ fn empty_codex_payload_probe<'a>() -> CodexPayloadProbe<'a> {
     CodexPayloadProbe {
         item_type: None,
         call_id: None,
+        agent_thread_id: None,
+        activity_kind: None,
         lineage_call_ids: CodexLineageCallIds::default(),
         relationship_escaped: false,
         lineage_malformed: false,
@@ -398,8 +404,12 @@ impl<'de> Visitor<'de> for CodexPayloadProbeVisitor {
     {
         let mut item_type = None;
         let mut call_id = None;
+        let mut agent_thread_id = None;
+        let mut activity_kind = None;
         let mut saw_item_type = false;
         let mut saw_call_id = false;
+        let mut saw_agent_thread_id = false;
+        let mut saw_activity_kind = false;
         let mut lineage_call_ids = CodexLineageCallIds::default();
         let mut relationship_escaped = false;
         let mut lineage_malformed = false;
@@ -431,6 +441,28 @@ impl<'de> Visitor<'de> for CodexPayloadProbeVisitor {
                         }
                     }
                 }
+                "agent_thread_id" => {
+                    let duplicate = saw_agent_thread_id;
+                    saw_agent_thread_id = true;
+                    let value = map.next_value::<CodexLineageText<'de>>()?;
+                    relationship_escaped |=
+                        key_escaped || value.value.as_ref().is_some_and(|value| value.escaped);
+                    lineage_malformed |= duplicate || value.malformed;
+                    if !duplicate {
+                        agent_thread_id = value.value;
+                    }
+                }
+                "kind" => {
+                    let duplicate = saw_activity_kind;
+                    saw_activity_kind = true;
+                    let value = map.next_value::<CodexLineageText<'de>>()?;
+                    relationship_escaped |=
+                        key_escaped || value.value.as_ref().is_some_and(|value| value.escaped);
+                    lineage_malformed |= duplicate || value.malformed;
+                    if !duplicate {
+                        activity_kind = value.value;
+                    }
+                }
                 _ => {
                     map.next_value::<IgnoredAny>()?;
                 }
@@ -439,6 +471,8 @@ impl<'de> Visitor<'de> for CodexPayloadProbeVisitor {
         Ok(CodexPayloadProbe {
             item_type,
             call_id,
+            agent_thread_id,
+            activity_kind,
             lineage_call_ids,
             relationship_escaped,
             lineage_malformed,
@@ -496,6 +530,7 @@ pub(super) struct CodexRecordProbe<'a> {
     pub(super) timestamp: Option<Cow<'a, str>>,
     pub(super) call_id: Option<Cow<'a, str>>,
     pub(super) output: Option<CodexStructuralOutput>,
+    descendant_started_native_session_id: Option<Cow<'a, str>>,
     relationship_escaped: bool,
     lineage_malformed: bool,
     lineage_call_ids: CodexLineageCallIds,
@@ -515,6 +550,7 @@ pub(super) enum CodexLineageRecordEvidence<'a> {
     Ambiguous(&'a str),
     AmbiguousDigests(&'a [[u8; 32]]),
     UnattributedAmbiguity,
+    DescendantStarted(&'a str),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -535,11 +571,11 @@ pub(super) fn classify_codex_record(line: &[u8]) -> serde_json::Result<CodexReco
         .payload
         .as_ref()
         .and_then(|payload| payload.item_type.as_ref().map(CodexText::as_str));
-    let class = codex_record_class(
+    let base_class = codex_record_class(
         envelope.record_type.as_ref().map_or("", CodexText::as_str),
         item_type,
     );
-    let output = match (lineage_malformed, class) {
+    let output = match (lineage_malformed, base_class) {
         (true, _) => None,
         (false, CodexRecordClass::ExcludedResult(_)) => Some(probe_structural_output(line)?),
         (false, _) => None,
@@ -549,6 +585,25 @@ pub(super) fn classify_codex_record(line: &[u8]) -> serde_json::Result<CodexReco
             .payload
             .as_ref()
             .is_some_and(|payload| payload.relationship_escaped);
+    let descendant_started_native_session_id = envelope.payload.as_ref().and_then(|payload| {
+        (base_class == CodexRecordClass::DescendantActivity
+            && payload.activity_kind.as_ref().map(CodexText::as_str) == Some("started")
+            && !lineage_malformed
+            && !relationship_escaped)
+            .then(|| {
+                payload
+                    .agent_thread_id
+                    .as_ref()
+                    .map(|value| value.value.clone())
+            })
+            .flatten()
+            .filter(|value| uuid::Uuid::parse_str(value.as_ref()).is_ok())
+    });
+    let class = if descendant_started_native_session_id.is_some() {
+        CodexRecordClass::DescendantStarted
+    } else {
+        base_class
+    };
     Ok(CodexRecordProbe {
         class,
         timestamp: envelope.timestamp,
@@ -556,6 +611,7 @@ pub(super) fn classify_codex_record(line: &[u8]) -> serde_json::Result<CodexReco
             .payload
             .and_then(|payload| payload.call_id.map(|call_id| call_id.value)),
         output,
+        descendant_started_native_session_id,
         relationship_escaped,
         lineage_malformed,
         lineage_call_ids: envelope.lineage_call_ids,
@@ -570,6 +626,9 @@ pub(super) fn codex_lineage_record_evidence<'a>(
             return CodexLineageRecordEvidence::AmbiguousDigests(probe.lineage_call_ids.as_slice());
         }
         return CodexLineageRecordEvidence::UnattributedAmbiguity;
+    }
+    if let Some(descendant) = probe.descendant_started_native_session_id.as_deref() {
+        return CodexLineageRecordEvidence::DescendantStarted(descendant);
     }
     let is_call = matches!(
         probe.class,
@@ -638,6 +697,7 @@ pub(super) fn classify_mcp_terminal_after_selector_ambiguity(
         timestamp,
         call_id,
         output: Some(probe_structural_output(line).ok()?),
+        descendant_started_native_session_id: None,
         relationship_escaped: true,
         lineage_malformed: false,
         lineage_call_ids: CodexLineageCallIds::default(),
@@ -686,6 +746,7 @@ fn classify_response_item(item_type: Option<&str>) -> CodexRecordClass {
 
 fn classify_event_message(item_type: Option<&str>) -> CodexRecordClass {
     match item_type {
+        Some("sub_agent_activity") => CodexRecordClass::DescendantActivity,
         Some(
             "patch_apply_end" | "web_search_end" | "exec_command_end" | "command_complete"
             | "tool_complete" | "mcp_tool_call_end",
@@ -821,6 +882,43 @@ mod lineage_tests {
             write!(escaped, "\\u{byte:04x}").unwrap();
         }
         escaped
+    }
+
+    #[test]
+    fn descendant_start_requires_exact_typed_unescaped_uuid_authority() {
+        let child = "019f8d80-ba23-73f3-a02a-9400f9e7b9ec";
+        let exact = format!(
+            r#"{{"type":"event_msg","payload":{{"type":"sub_agent_activity","kind":"started","agent_thread_id":"{child}"}}}}"#
+        );
+        let probe = classify_codex_record(exact.as_bytes()).unwrap();
+        assert_eq!(probe.class, CodexRecordClass::DescendantStarted);
+        assert_eq!(
+            codex_lineage_record_evidence(&probe),
+            CodexLineageRecordEvidence::DescendantStarted(child)
+        );
+
+        for untrusted in [
+            format!(
+                r#"{{"type":"event_msg","payload":{{"type":"sub_agent_activity","kind":"completed","agent_thread_id":"{child}"}}}}"#
+            ),
+            r#"{"type":"event_msg","payload":{"type":"sub_agent_activity","kind":"started","agent_thread_id":"not-a-uuid"}}"#.to_owned(),
+            format!(
+                r#"{{"type":"event_msg","payload":{{"type":"sub_agent_activity","kind":"st\u0061rted","agent_thread_id":"{child}"}}}}"#
+            ),
+            format!(
+                r#"{{"type":"event_msg","payload":{{"type":"sub_agent_activity","kind":"started","agent_thread_id":"{child}","agent_thread_id":"{child}"}}}}"#
+            ),
+        ] {
+            let probe = classify_codex_record(untrusted.as_bytes()).unwrap();
+            assert_ne!(probe.class, CodexRecordClass::DescendantStarted, "{untrusted}");
+            assert!(
+                !matches!(
+                    codex_lineage_record_evidence(&probe),
+                    CodexLineageRecordEvidence::DescendantStarted(_)
+                ),
+                "{untrusted}"
+            );
+        }
     }
 
     #[test]

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/record.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/record.rs
@@ -718,7 +718,10 @@ pub(super) fn malformed_codex_lineage_record_evidence(
     let mut envelopes = 0_usize;
     while let Some(next) = stream.next() {
         let Ok(envelope) = next else {
-            return literal_malformed_call_id_evidence(record);
+            if envelopes != 0 {
+                return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+            }
+            return interrupted_duplicate_call_evidence(record);
         };
         envelopes = envelopes.saturating_add(1);
 
@@ -788,99 +791,136 @@ pub(super) fn malformed_codex_lineage_record_evidence(
     }
 }
 
-fn literal_malformed_call_id_evidence(record: &[u8]) -> CodexMalformedLineageRecordEvidence {
-    let Some(call_ids) = recover_literal_malformed_call_ids(record) else {
+/// Recovers the one malformed-row shape observed from interrupted Codex file
+/// writes: a truncated function-call envelope immediately followed by a full
+/// retry of the same provider response item. The provider response `id` must
+/// occur exactly once in each fragment and match byte-for-byte; the complete
+/// retry must independently classify as one exact tool call. Everything else
+/// retains source-wide ambiguity because a truncated producer might have no
+/// recoverable `call_id` at all.
+fn interrupted_duplicate_call_evidence(record: &[u8]) -> CodexMalformedLineageRecordEvidence {
+    const ENVELOPE_START: &[u8] = br#"{"timestamp""#;
+    let mut starts = record
+        .windows(ENVELOPE_START.len())
+        .enumerate()
+        .filter(|(_, window)| *window == ENVELOPE_START)
+        .map(|(start, _)| start);
+    if starts.next() != Some(0) {
+        return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+    }
+    let Some(retry_start) = starts.next() else {
         return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
     };
+    if starts.next().is_some() {
+        return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+    }
+
+    let Some(prefix) = record.get(..retry_start) else {
+        return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+    };
+    let Some(suffix) = record.get(retry_start..) else {
+        return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+    };
+    let Some((prefix_item_id, interrupted_arguments)) = canonical_function_call_prefix(prefix)
+    else {
+        return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+    };
+    if !is_unterminated_json_string_fragment(interrupted_arguments) {
+        return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+    }
+    let Some((suffix_item_id, _)) = canonical_function_call_prefix(suffix) else {
+        return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+    };
+    if prefix_item_id != suffix_item_id
+        || count_bytes(suffix, br#""id""#) != 1
+        || suffix.windows(2).any(|window| window == br#"\u"#)
+    {
+        return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+    }
+    let Ok(probe) = classify_codex_record(suffix) else {
+        return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+    };
+    if probe.lineage_malformed
+        || probe.relationship_escaped
+        || !matches!(
+            probe.class,
+            CodexRecordClass::Retained(CodexRetainedKind::ToolCall)
+        )
+    {
+        return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+    }
+    let Some(call_id) = probe.call_id.as_deref() else {
+        return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+    };
+    if call_id.is_empty() || call_id.len() > super::checkpoint::MAX_CODEX_TOOL_CALL_ID_BYTES {
+        return CodexMalformedLineageRecordEvidence::UnattributedAmbiguity;
+    }
+    let mut call_ids = CodexLineageCallIds::default();
+    call_ids.remember(call_id);
     CodexMalformedLineageRecordEvidence::AmbiguousDigests(call_ids)
 }
 
-/// Returns a conservative superset of every literal `call_id` in a corrupted
-/// row, or declines to scope the ambiguity.
-///
-/// A malformed outer string can contain either ordinary JSON fields or an
-/// escaped serialized JSON fragment. Both forms are admitted only when every
-/// `call_id` substring has the exact key/colon/plain-string shape and every
-/// value is bounded. Any Unicode escape could encode a hidden key, while any
-/// unrecognized occurrence could be a key whose value this scanner failed to
-/// recover, so either condition preserves global ambiguity.
-fn recover_literal_malformed_call_ids(record: &[u8]) -> Option<CodexLineageCallIds> {
-    if record.windows(2).any(|window| window == br#"\u"#) {
-        return None;
-    }
+fn canonical_function_call_prefix(record: &[u8]) -> Option<(&str, &[u8])> {
+    let mut remaining = record.strip_prefix(br#"{"timestamp":""#)?;
+    let (_, after_timestamp) = plain_json_string_prefix(remaining)?;
+    remaining = after_timestamp
+        .strip_prefix(br#","type":"response_item","payload":{"type":"function_call","id":""#)?;
+    let (item_id, after_item_id) = plain_json_string_prefix(remaining)?;
+    remaining = after_item_id.strip_prefix(br#","name":""#)?;
+    let (_, after_name) = plain_json_string_prefix(remaining)?;
+    let arguments = after_name.strip_prefix(br#","arguments":""#)?;
+    Some((item_id, arguments))
+}
 
-    let needle = b"call_id";
-    let mut search_from = 0_usize;
-    let mut call_ids = CodexLineageCallIds::default();
-    let mut occurrences = 0_usize;
-    while let Some(relative) = record
-        .get(search_from..)?
-        .windows(needle.len())
-        .position(|window| window == needle)
-    {
-        let start = search_from.checked_add(relative)?;
-        occurrences = occurrences.checked_add(1)?;
-        let mut cursor = start.checked_add(needle.len())?;
+fn plain_json_string_prefix(record: &[u8]) -> Option<(&str, &[u8])> {
+    let end = record
+        .iter()
+        .position(|byte| *byte == b'"' || *byte == b'\\')?;
+    (record.get(end) == Some(&b'"')).then_some(())?;
+    let value = std::str::from_utf8(record.get(..end)?).ok()?;
+    (!value.is_empty() && value.bytes().all(|byte| byte >= 0x20)).then_some(())?;
+    Some((value, record.get(end.checked_add(1)?..)?))
+}
 
-        let escaped_key = match (
-            record.get(start.checked_sub(2)?..start),
-            record.get(start.checked_sub(1)?),
-        ) {
-            (Some(br#"\""#), _) => true,
-            (_, Some(b'"')) => false,
-            _ => return None,
+fn is_unterminated_json_string_fragment(fragment: &[u8]) -> bool {
+    let mut cursor = 0_usize;
+    while let Some(byte) = fragment.get(cursor).copied() {
+        if byte == b'"' || byte < 0x20 {
+            return false;
+        }
+        if byte != b'\\' {
+            cursor = cursor.saturating_add(1);
+            continue;
+        }
+        cursor = cursor.saturating_add(1);
+        let Some(escape) = fragment.get(cursor).copied() else {
+            return false;
         };
-        if escaped_key {
-            (record.get(cursor..cursor.checked_add(2)?)? == br#"\""#).then_some(())?;
-            cursor = cursor.checked_add(2)?;
-        } else {
-            (record.get(cursor) == Some(&b'"')).then_some(())?;
-            cursor = cursor.checked_add(1)?;
-        }
-        while record
-            .get(cursor)
-            .is_some_and(|byte| byte.is_ascii_whitespace())
-        {
-            cursor = cursor.checked_add(1)?;
-        }
-        (record.get(cursor) == Some(&b':')).then_some(())?;
-        cursor = cursor.checked_add(1)?;
-        while record
-            .get(cursor)
-            .is_some_and(|byte| byte.is_ascii_whitespace())
-        {
-            cursor = cursor.checked_add(1)?;
-        }
-
-        let escaped_value = record.get(cursor..cursor.checked_add(2)?)? == br#"\""#;
-        if escaped_value {
-            cursor = cursor.checked_add(2)?;
-        } else {
-            (record.get(cursor) == Some(&b'"')).then_some(())?;
-            cursor = cursor.checked_add(1)?;
-        }
-        let value_start = cursor;
-        let value_end = loop {
-            if escaped_value {
-                if record.get(cursor..cursor.checked_add(2)?)? == br#"\""# {
-                    break cursor;
-                }
-            } else if record.get(cursor) == Some(&b'"') {
-                break cursor;
+        match escape {
+            b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't' => {
+                cursor = cursor.saturating_add(1);
             }
-            // Call IDs are provider identifiers. Escapes make the exact value
-            // non-literal and therefore retain global ambiguity.
-            (record.get(cursor) != Some(&b'\\')).then_some(())?;
-            cursor = cursor.checked_add(1)?;
-        };
-        let value = std::str::from_utf8(record.get(value_start..value_end)?).ok()?;
-        (!value.is_empty() && value.len() <= super::checkpoint::MAX_CODEX_TOOL_CALL_ID_BYTES)
-            .then_some(())?;
-        call_ids.remember(value);
-        (!call_ids.overflowed).then_some(())?;
-        search_from = start.checked_add(needle.len())?;
+            b'u' => {
+                let Some(hex) = fragment.get(cursor.saturating_add(1)..cursor.saturating_add(5))
+                else {
+                    return false;
+                };
+                if !hex.iter().all(u8::is_ascii_hexdigit) {
+                    return false;
+                }
+                cursor = cursor.saturating_add(5);
+            }
+            _ => return false,
+        }
     }
-    (occurrences > 0 && !call_ids.as_slice().is_empty()).then_some(call_ids)
+    std::str::from_utf8(fragment).is_ok()
+}
+
+fn count_bytes(haystack: &[u8], needle: &[u8]) -> usize {
+    haystack
+        .windows(needle.len())
+        .filter(|window| *window == needle)
+        .count()
 }
 
 /// Recovers only the canonical MCP terminal shape when the strict selector
@@ -1256,8 +1296,8 @@ mod lineage_tests {
     }
 
     #[test]
-    fn corrupted_outer_call_recovers_its_exact_trailing_call_id() {
-        let record = br#"{"type":"response_item","payload":{"type":"function_call","arguments":"prefix {"type":"response_item","payload":{"type":"function_call"}","call_id":"outer-call","name":"exec"}}"#;
+    fn interrupted_duplicate_call_recovers_its_exact_retry_call_id() {
+        let record = br#"{"timestamp":"2026-07-23T21:34:01Z","type":"response_item","payload":{"type":"function_call","id":"fc_same","name":"exec_command","arguments":"prefix {"timestamp":"2026-07-23T21:34:22Z","type":"response_item","payload":{"type":"function_call","id":"fc_same","name":"exec_command","arguments":"{}","call_id":"outer-call"}}"#;
         assert!(classify_codex_record(record).is_err());
         let evidence = malformed_codex_lineage_record_evidence(record);
         assert!(
@@ -1268,6 +1308,30 @@ mod lineage_tests {
             "outer corruption was not scoped: {evidence:?}"
         );
         assert_ambiguous_call_ids(evidence.as_record_evidence(), &["outer-call"]);
+    }
+
+    #[test]
+    fn interrupted_duplicate_recovery_rejects_noncanonical_or_ambiguous_fragments() {
+        let decoy_then_unidentified = br#"{"timestamp":"2026-07-23T21:34:00Z","type":"response_item","payload":{"type":"function_call_output","call_id":"decoy"}}{"type":"response_item","payload":{"type":"function_call"{"timestamp":"2026-07-23T21:34:22Z","type":"response_item","payload":{"type":"function_call","id":"fc_same","name":"exec_command","arguments":"{}","call_id":"target"}}"#;
+        let mismatched_retry = br#"{"timestamp":"2026-07-23T21:34:01Z","type":"response_item","payload":{"type":"function_call","id":"fc_first","name":"exec_command","arguments":"prefix {"timestamp":"2026-07-23T21:34:22Z","type":"response_item","payload":{"type":"function_call","id":"fc_second","name":"exec_command","arguments":"{}","call_id":"target"}}"#;
+        let escaped_duplicate_id = br#"{"timestamp":"2026-07-23T21:34:01Z","type":"response_item","payload":{"type":"function_call","id":"fc_same","name":"exec_command","arguments":"prefix {"timestamp":"2026-07-23T21:34:22Z","type":"response_item","payload":{"type":"function_call","id":"fc_same","\u0069\u0064":"fc_same","name":"exec_command","arguments":"{}","call_id":"target"}}"#;
+        let extra_fragment = br#"{"timestamp":"2026-07-23T21:34:01Z","type":"response_item","payload":{"type":"function_call","id":"fc_same","name":"exec_command","arguments":"prefix {"timestamp":"2026-07-23T21:34:10Z","type":"event_msg","payload":{"type":"sub_agent_activity"}}{"timestamp":"2026-07-23T21:34:22Z","type":"response_item","payload":{"type":"function_call","id":"fc_same","name":"exec_command","arguments":"{}","call_id":"target"}}"#;
+        let escaped_call_id = br#"{"timestamp":"2026-07-23T21:34:01Z","type":"response_item","payload":{"type":"function_call","id":"fc_same","name":"exec_command","arguments":"prefix {"timestamp":"2026-07-23T21:34:22Z","type":"response_item","payload":{"type":"function_call","id":"fc_same","name":"exec_command","arguments":"{}","call_id":"call\/id"}}"#;
+        let control_in_prefix = b"{\"timestamp\":\"2026-07-23\x01\",\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"id\":\"fc_same\",\"name\":\"exec_command\",\"arguments\":\"prefix {\"timestamp\":\"2026-07-23T21:34:22Z\",\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"id\":\"fc_same\",\"name\":\"exec_command\",\"arguments\":\"{}\",\"call_id\":\"target\"}}";
+
+        for record in [
+            decoy_then_unidentified.as_slice(),
+            mismatched_retry.as_slice(),
+            escaped_duplicate_id.as_slice(),
+            extra_fragment.as_slice(),
+            escaped_call_id.as_slice(),
+            control_in_prefix.as_slice(),
+        ] {
+            assert!(matches!(
+                malformed_codex_lineage_record_evidence(record),
+                CodexMalformedLineageRecordEvidence::UnattributedAmbiguity
+            ));
+        }
     }
 
     #[test]
@@ -1287,10 +1351,18 @@ mod lineage_tests {
     }
 
     #[test]
-    fn malformed_rows_scope_all_exact_ids_but_not_descendant_authority() {
+    fn truncated_rows_retain_global_ambiguity_even_when_literal_ids_are_visible() {
         let exact_ids = br#"{"type":"response_item","payload":{"type":"function_call","call_id":"first"}}{"type":"response_item","payload":{"type":"function_call","call_id":"hidden""#;
-        let evidence = malformed_codex_lineage_record_evidence(exact_ids);
-        assert_ambiguous_call_ids(evidence.as_record_evidence(), &["first", "hidden"]);
+        assert!(matches!(
+            malformed_codex_lineage_record_evidence(exact_ids),
+            CodexMalformedLineageRecordEvidence::UnattributedAmbiguity
+        ));
+
+        let unidentified_producer = br#"{"type":"response_item","payload":{"type":"function_call_output","call_id":"decoy"}}{"type":"response_item","payload":{"type":"function_call"#;
+        assert!(matches!(
+            malformed_codex_lineage_record_evidence(unidentified_producer),
+            CodexMalformedLineageRecordEvidence::UnattributedAmbiguity
+        ));
 
         let descendant = br#"{"type":"event_msg","payload":{"type":"sub_agent_activity","kind":"started","agent_thread_id":"019f8d80-ba23-73f3-a02a-9400f9e7b9ec"}} trailing"#;
         assert!(matches!(

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/record/prefilter.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/record/prefilter.rs
@@ -62,13 +62,31 @@ pub(in super::super) enum CodexSkipProjection {
 ///
 /// The record must already be trimmed of its JSONL terminator.
 pub(in super::super) fn prefilter_codex_record(record: &[u8]) -> CodexRecordAdmission {
-    match Prefilter::new(record)
-        .envelope()
-        .and_then(codex_skip_projection)
-    {
+    let projection = Prefilter::new(record).envelope().and_then(|class| {
+        if class == CodexRecordClass::DescendantActivity {
+            if record_may_describe_descendant_start(record) {
+                None
+            } else {
+                Some(CodexSkipProjection::Ignored)
+            }
+        } else {
+            codex_skip_projection(class)
+        }
+    });
+    match projection {
         Some(projection) => CodexRecordAdmission::NoProjection(projection),
         None => CodexRecordAdmission::Probe,
     }
+}
+
+/// A fully validated `sub_agent_activity` record needs the structural probe
+/// only when it may be the typed boundary that started a descendant. Escaped
+/// member names already make the prefilter abandon its proof and probe, while
+/// false positives here merely take the conservative parsed path.
+fn record_may_describe_descendant_start(record: &[u8]) -> bool {
+    [br#""agent_thread_id""#.as_slice(), br#""kind""#.as_slice()]
+        .into_iter()
+        .all(|needle| record.windows(needle.len()).any(|window| window == needle))
 }
 
 /// The reader's skip set, expressed against the class the reader projects.
@@ -81,8 +99,11 @@ pub(in super::super) fn codex_skip_projection(
     class: CodexRecordClass,
 ) -> Option<CodexSkipProjection> {
     match class {
-        CodexRecordClass::Ignored => Some(CodexSkipProjection::Ignored),
-        CodexRecordClass::ExcludedResult(_)
+        CodexRecordClass::Ignored | CodexRecordClass::DescendantActivity => {
+            Some(CodexSkipProjection::Ignored)
+        }
+        CodexRecordClass::DescendantStarted
+        | CodexRecordClass::ExcludedResult(_)
         | CodexRecordClass::SessionMeta
         | CodexRecordClass::TurnContext
         | CodexRecordClass::Retained(_) => None,

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/record/prefilter.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/record/prefilter.rs
@@ -62,31 +62,20 @@ pub(in super::super) enum CodexSkipProjection {
 ///
 /// The record must already be trimmed of its JSONL terminator.
 pub(in super::super) fn prefilter_codex_record(record: &[u8]) -> CodexRecordAdmission {
-    let projection = Prefilter::new(record).envelope().and_then(|class| {
-        if class == CodexRecordClass::DescendantActivity {
-            if record_may_describe_descendant_start(record) {
-                None
-            } else {
-                Some(CodexSkipProjection::Ignored)
-            }
-        } else {
-            codex_skip_projection(class)
-        }
-    });
+    let projection = Prefilter::new(record)
+        .envelope()
+        .and_then(codex_skip_projection);
     match projection {
         Some(projection) => CodexRecordAdmission::NoProjection(projection),
         None => CodexRecordAdmission::Probe,
     }
 }
 
-/// A fully validated `sub_agent_activity` record needs the structural probe
-/// only when it may be the typed boundary that started a descendant. Escaped
-/// member names already make the prefilter abandon its proof and probe, while
-/// false positives here merely take the conservative parsed path.
-fn record_may_describe_descendant_start(record: &[u8]) -> bool {
-    [br#""agent_thread_id""#.as_slice(), br#""kind""#.as_slice()]
-        .into_iter()
-        .all(|needle| record.windows(needle.len()).any(|window| window == needle))
+#[derive(Clone, Copy, Default)]
+struct PrefilterPayload<'a> {
+    item_type: Option<&'a str>,
+    activity_kind: Option<&'a str>,
+    has_agent_thread_id: bool,
 }
 
 /// The reader's skip set, expressed against the class the reader projects.
@@ -127,7 +116,7 @@ impl<'a> Prefilter<'a> {
         self.take(b'{')?;
         self.whitespace();
         let mut record_type = None;
-        let mut item_type = None;
+        let mut payload = PrefilterPayload::default();
         let mut saw_record_type = false;
         let mut saw_timestamp = false;
         let mut saw_payload = false;
@@ -151,7 +140,7 @@ impl<'a> Prefilter<'a> {
                     // Stop as soon as the discriminators rule a skip out. A
                     // record that has to be probed anyway must not pay for a
                     // second full walk of its body.
-                    decided_skip(value, item_type)?;
+                    decided_skip(value, payload.item_type)?;
                     record_type = Some(value);
                 }
                 "timestamp" => {
@@ -170,7 +159,7 @@ impl<'a> Prefilter<'a> {
                         return None;
                     }
                     saw_payload = true;
-                    item_type = self.payload(1, record_type)?;
+                    payload = self.payload(1, record_type)?;
                 }
                 _ => self.value(1)?,
             }
@@ -189,29 +178,41 @@ impl<'a> Prefilter<'a> {
         }
         self.whitespace();
         (self.offset == self.bytes.len()).then_some(())?;
-        Some(codex_record_class(record_type?, item_type))
+        let class = codex_record_class(record_type?, payload.item_type);
+        if class == CodexRecordClass::DescendantActivity
+            && payload.activity_kind == Some("started")
+            && payload.has_agent_thread_id
+        {
+            // Only a provider-authored started activity with an exact thread
+            // field can become a typed boundary. Everything else in this
+            // high-volume class is a proved ignored record.
+            return None;
+        }
+        Some(class)
     }
 
     /// Validates a `payload` member and reports its discriminator.
     ///
     /// The structural probe accepts any JSON here: a non-object payload simply
     /// has no item type.
-    fn payload(&mut self, depth: usize, record_type: Option<&str>) -> Option<Option<&'a str>> {
+    fn payload(&mut self, depth: usize, record_type: Option<&str>) -> Option<PrefilterPayload<'a>> {
         if self.peek()? != b'{' {
             decided_skip_with(record_type, None)?;
             self.value(depth)?;
-            return Some(None);
+            return Some(PrefilterPayload::default());
         }
         self.offset += 1;
         self.whitespace();
         if self.peek()? == b'}' {
             decided_skip_with(record_type, None)?;
             self.offset += 1;
-            return Some(None);
+            return Some(PrefilterPayload::default());
         }
-        let mut item_type = None;
+        let mut payload = PrefilterPayload::default();
         let mut saw_item_type = false;
         let mut saw_call_id = false;
+        let mut saw_activity_kind = false;
+        let mut saw_agent_thread_id = false;
         loop {
             let key = self.simple_string(MAX_PREFILTER_TYPE_BYTES)?;
             self.whitespace();
@@ -229,7 +230,7 @@ impl<'a> Prefilter<'a> {
                     } else {
                         let value = self.simple_string(MAX_PREFILTER_TYPE_BYTES)?;
                         decided_skip_with(record_type, Some(value))?;
-                        item_type = Some(value);
+                        payload.item_type = Some(value);
                     }
                 }
                 "call_id" => {
@@ -242,6 +243,21 @@ impl<'a> Prefilter<'a> {
                     } else {
                         self.simple_string(MAX_PREFILTER_TYPE_BYTES)?;
                     }
+                }
+                "kind" => {
+                    if saw_activity_kind {
+                        return None;
+                    }
+                    saw_activity_kind = true;
+                    payload.activity_kind = Some(self.simple_string(MAX_PREFILTER_TYPE_BYTES)?);
+                }
+                "agent_thread_id" => {
+                    if saw_agent_thread_id {
+                        return None;
+                    }
+                    saw_agent_thread_id = true;
+                    self.simple_string(MAX_PREFILTER_TYPE_BYTES)?;
+                    payload.has_agent_thread_id = true;
                 }
                 _ => self.value(depth + 1)?,
             }
@@ -258,7 +274,7 @@ impl<'a> Prefilter<'a> {
                 _ => return None,
             }
         }
-        Some(item_type)
+        Some(payload)
     }
 
     fn value(&mut self, depth: usize) -> Option<()> {

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/record/prefilter_tests.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/record/prefilter_tests.rs
@@ -97,11 +97,45 @@ fn prefilter_probes_only_candidate_descendant_start_activity() {
         CodexRecordAdmission::Probe
     );
 
-    let unrelated = r#"{"type":"event_msg","payload":{"type":"sub_agent_activity","kind":"completed","message":"done"}}"#;
-    assert_eq!(
-        prefilter_codex_record(unrelated.as_bytes()),
-        CodexRecordAdmission::NoProjection(CodexSkipProjection::Ignored)
-    );
+    for unrelated in [
+        r#"{"type":"event_msg","payload":{"type":"sub_agent_activity","kind":"completed","message":"done"}}"#,
+        r#"{"type":"event_msg","payload":{"type":"sub_agent_activity","kind":"completed","agent_thread_id":"019f8d80-ba23-73f3-a02a-9400f9e7b9ec"}}"#,
+        r#"{"type":"event_msg","payload":{"type":"sub_agent_activity","kind":"started","message":"missing child"}}"#,
+    ] {
+        assert_eq!(
+            prefilter_codex_record(unrelated.as_bytes()),
+            CodexRecordAdmission::NoProjection(CodexSkipProjection::Ignored),
+            "ordinary activity should retain the ignored fast path: {unrelated}"
+        );
+    }
+
+    for malformed in [
+        r#"{"type":"event_msg","payload":{"type":"sub_agent_activity","kind":{}}}"#,
+        r#"{"type":"event_msg","payload":{"type":"sub_agent_activity","kind":"completed","agent_thread_id":7}}"#,
+        r#"{"type":"event_msg","payload":{"type":"sub_agent_activity","kind":"completed","kind":"started"}}"#,
+    ] {
+        assert_eq!(
+            prefilter_codex_record(malformed.as_bytes()),
+            CodexRecordAdmission::Probe,
+            "malformed activity authority must reach the shared structural probe: {malformed}"
+        );
+    }
+}
+
+#[test]
+fn unrelated_payload_kind_does_not_become_lineage_authority() {
+    for raw in [
+        r#"{"type":"response_item","payload":{"type":"message","kind":{},"role":"user","content":[]}}"#,
+        r#"{"type":"response_item","payload":{"type":"message","kind":"a","kind":"b","role":"user","content":[]}}"#,
+        r#"{"type":"response_item","payload":{"type":"message","k\u0069nd":"escaped","role":"user","content":[]}}"#,
+    ] {
+        let probe = classify_codex_record(raw.as_bytes())
+            .unwrap_or_else(|error| panic!("unrelated kind must remain valid: {error}"));
+        assert!(
+            !probe.lineage_malformed(),
+            "unrelated kind poisoned lineage"
+        );
+    }
 }
 
 /// Envelopes with no payload discriminator must classify exactly like the

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/record/prefilter_tests.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/record/prefilter_tests.rs
@@ -86,6 +86,24 @@ fn prefilter_skip_set_matches_what_the_reader_materializes() {
     }
 }
 
+#[test]
+fn prefilter_probes_only_candidate_descendant_start_activity() {
+    let child = "019f8d80-ba23-73f3-a02a-9400f9e7b9ec";
+    let started = format!(
+        r#"{{"type":"event_msg","payload":{{"type":"sub_agent_activity","kind":"started","agent_thread_id":"{child}"}}}}"#
+    );
+    assert_eq!(
+        prefilter_codex_record(started.as_bytes()),
+        CodexRecordAdmission::Probe
+    );
+
+    let unrelated = r#"{"type":"event_msg","payload":{"type":"sub_agent_activity","kind":"completed","message":"done"}}"#;
+    assert_eq!(
+        prefilter_codex_record(unrelated.as_bytes()),
+        CodexRecordAdmission::NoProjection(CodexSkipProjection::Ignored)
+    );
+}
+
 /// Envelopes with no payload discriminator must classify exactly like the
 /// structural probe's `None` item type.
 #[test]

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/rows.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/rows.rs
@@ -569,7 +569,9 @@ pub(super) fn source_backed_display_text(
                 }
             }
         }
-        CodexRecordClass::SessionMeta
+        CodexRecordClass::DescendantActivity
+        | CodexRecordClass::DescendantStarted
+        | CodexRecordClass::SessionMeta
         | CodexRecordClass::TurnContext
         | CodexRecordClass::Ignored => {
             CodexSourceBackedDocumentEligibility::IntentionallyNonDisplay

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed.rs
@@ -74,7 +74,7 @@ const CODEX_SOURCE_SCHEMA_VARIANT: &str = "codex-nativepath-jsonl-v0";
 const CODEX_SOURCE_REVISION_KIND: &str = "codex-ordinary-file-observation-v1";
 const CODEX_FRONTIER_KIND: &str = "codex-nativepath-checkpoint-v11";
 const CODEX_PARSER_REVISION: &str =
-    "codex-nativepath-core-record-v23-typed-descendant-prefix-authority";
+    "codex-nativepath-core-record-v24-scoped-malformed-descendant-authority";
 const CODEX_GENERATION_LINEAGE_COMPONENTS_PER_WAVE: usize = 4;
 #[cfg(test)]
 const CODEX_INVENTORY_AUTHORITY_NAMESPACE: &str = "codex.sessions-root";

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed.rs
@@ -72,8 +72,9 @@ const CODEX_LOGICAL_SESSION_KIND: &str = "codex-session";
 const CODEX_LOGICAL_EVENT_KIND: &str = "codex-event";
 const CODEX_SOURCE_SCHEMA_VARIANT: &str = "codex-nativepath-jsonl-v0";
 const CODEX_SOURCE_REVISION_KIND: &str = "codex-ordinary-file-observation-v1";
-const CODEX_FRONTIER_KIND: &str = "codex-nativepath-checkpoint-v10";
-const CODEX_PARSER_REVISION: &str = "codex-nativepath-core-record-v22-typed-unique-result-origin";
+const CODEX_FRONTIER_KIND: &str = "codex-nativepath-checkpoint-v11";
+const CODEX_PARSER_REVISION: &str =
+    "codex-nativepath-core-record-v23-typed-descendant-prefix-authority";
 const CODEX_GENERATION_LINEAGE_COMPONENTS_PER_WAVE: usize = 4;
 #[cfg(test)]
 const CODEX_INVENTORY_AUTHORITY_NAMESPACE: &str = "codex.sessions-root";

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/lineage.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/lineage.rs
@@ -979,9 +979,12 @@ impl CodexOutcomeLineageAuthorityV0 {
         else {
             return Ok(CodexOutcomeOriginV0::Unproven);
         };
-        // Codex event timestamps are not lineage authority: copied native rows
-        // may be reordered or restamped. Only an exhaustive walk of certified
-        // ancestor call/result facts can prove copied presence or unique absence.
+        // Timestamps are not lineage authority: provider clocks may move or
+        // copied rows may be restamped. A parent's typed `sub_agent_activity`
+        // `started` record is an exact append-order boundary for that direct
+        // child. Ambiguity after that raw ordinal could not have been inherited;
+        // without the typed boundary the edge remains conservatively unbounded.
+        let mut direct_child_native_session_id = current.native_session_id.as_str();
         let mut parent = match &current.parent {
             ParentLinkV0::Root => return Ok(CodexOutcomeOriginV0::UniqueToSession),
             ParentLinkV0::Source(index) => ParentLinkV0::Source(*index),
@@ -1013,7 +1016,11 @@ impl CodexOutcomeLineageAuthorityV0 {
                     return Err(CodexSourceBackedErrorV0::LineageWorkingSetUnavailable)
                 }
             };
-            match parent_facts.presence(origin_call_id, result_call_id) {
+            match parent_facts.presence_before(
+                origin_call_id,
+                result_call_id,
+                Some(direct_child_native_session_id),
+            ) {
                 CodexLineageFactPresenceV0::Present => {
                     return Ok(CodexOutcomeOriginV0::CopiedFromAncestor {
                         ancestor_native_session_id: parent_node.native_session_id.clone(),
@@ -1022,6 +1029,7 @@ impl CodexOutcomeLineageAuthorityV0 {
                 CodexLineageFactPresenceV0::Unproven => return Ok(CodexOutcomeOriginV0::Unproven),
                 CodexLineageFactPresenceV0::Absent => {}
             }
+            direct_child_native_session_id = parent_node.native_session_id.as_str();
             parent = parent_node.parent.clone();
         }
         Ok(CodexOutcomeOriginV0::Unproven)

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests.rs
@@ -133,6 +133,19 @@ fn message(role: &str, text: &str) -> String {
     .to_string()
 }
 
+fn descendant_started(native_session_id: &str) -> String {
+    serde_json::json!({
+        "timestamp": "2026-07-28T12:00:01Z",
+        "type": "event_msg",
+        "payload": {
+            "type": "sub_agent_activity",
+            "agent_thread_id": native_session_id,
+            "kind": "started"
+        }
+    })
+    .to_string()
+}
+
 fn tool_call_with_patch(call_id: &str) -> String {
     serde_json::json!({
             "timestamp": "2026-07-28T12:00:02Z",

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/lineage_regressions.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/lineage_regressions.rs
@@ -455,6 +455,107 @@ fn attributed_malformed_call_does_not_suppress_an_unrelated_unique_call() {
 }
 
 #[test]
+fn concatenated_ancestor_calls_only_suppress_their_exact_identifiers_on_replay() {
+    use ctx_history_core::EventOrigin;
+
+    let temp = tempfile::tempdir().unwrap();
+    let sessions = temp.path().join("sessions");
+    let index = temp.path().join("global-index");
+    let repository = temp.path().join("repo");
+    fs::create_dir_all(&sessions).unwrap();
+    initialize_repository(&repository);
+    let parent = "019fa000-0000-7000-8000-000000000230";
+    let child = "019fa000-0000-7000-8000-000000000231";
+    let target = "unique-after-concatenated-row";
+    let concatenated = concat!(
+        r#"{"type":"response_item","payload":{"type":"function_call","call_id":"unrelated-a","name":"exec"}}"#,
+        r#"{"type":"response_item","payload":{"type":"function_call_output","call_id":"unrelated-b","output":"ok"}}"#
+    );
+    write_session(
+        &sessions,
+        parent,
+        &[
+            message("user", "parent session anchor"),
+            concatenated.to_owned(),
+            descendant_started(child),
+        ],
+    );
+    ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+
+    write_forked_session(
+        &sessions,
+        child,
+        parent,
+        &[
+            exec_call(
+                target,
+                "git commit -m child && git rev-parse --verify HEAD",
+                &repository,
+            ),
+            successful_result(
+                target,
+                Value::String(
+                    "[main 7777777] child\n7777777777777777777777777777777777777777\n".to_owned(),
+                ),
+            ),
+        ],
+    );
+    let refresh = ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+    assert_eq!(refresh.counters.replayed_sources, 1);
+    let child_source = codex_source_key(child).unwrap();
+    let child_session = codex_session_identity(&child_source, child).unwrap();
+    let result = outcome_for_sequence(&VerifiedIndex::open(&index).unwrap(), child_session, 2);
+    assert_eq!(result.event_origin, EventOrigin::UniqueToSession);
+    assert_eq!(result.repository_vcs_observations.len(), 1);
+}
+
+#[test]
+fn concatenated_ancestor_call_with_same_identifier_still_fails_closed() {
+    let temp = tempfile::tempdir().unwrap();
+    let sessions = temp.path().join("sessions");
+    let index = temp.path().join("global-index");
+    let repository = temp.path().join("repo");
+    fs::create_dir_all(&sessions).unwrap();
+    initialize_repository(&repository);
+    let parent = "019fa000-0000-7000-8000-000000000232";
+    let child = "019fa000-0000-7000-8000-000000000233";
+    let target = "copied-from-concatenated-row";
+    let concatenated = format!(
+        r#"{{"type":"response_item","payload":{{"type":"function_call","call_id":"{target}","name":"exec"}}}}{{"type":"event_msg","payload":{{"type":"token_count"}}}}"#
+    );
+    write_session(
+        &sessions,
+        parent,
+        &[
+            message("user", "parent session anchor"),
+            concatenated,
+            descendant_started(child),
+        ],
+    );
+    write_forked_session(
+        &sessions,
+        child,
+        parent,
+        &[
+            exec_call(
+                target,
+                "git commit -m child && git rev-parse --verify HEAD",
+                &repository,
+            ),
+            successful_result(
+                target,
+                Value::String(
+                    "[main 8888888] child\n8888888888888888888888888888888888888888\n".to_owned(),
+                ),
+            ),
+        ],
+    );
+
+    ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+    assert_child_outcome_is_unproven(&VerifiedIndex::open(&index).unwrap(), child);
+}
+
+#[test]
 fn fully_escaped_duplicate_call_id_after_non_string_cannot_publish_a_unique_child_outcome() {
     let temp = tempfile::tempdir().unwrap();
     let sessions = temp.path().join("sessions");

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/lineage_regressions.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/lineage_regressions.rs
@@ -6,6 +6,15 @@ use super::projection::{
     exec_call, initialize_repository, outcome_for_sequence, successful_result,
 };
 
+fn uuid_v7_at_unix_ms(unix_ms: u64, suffix: u64) -> String {
+    format!(
+        "{:08x}-{:04x}-7000-8000-{:012x}",
+        unix_ms >> 16,
+        unix_ms & 0xffff,
+        suffix
+    )
+}
+
 fn assert_child_outcome_is_unproven(index: &VerifiedIndex, child_native_session_id: &str) {
     assert_child_outcome_at_sequence_is_unproven(index, child_native_session_id, 2);
 }
@@ -23,6 +32,121 @@ fn assert_child_outcome_at_sequence_is_unproven(
         abstention.reason == RepositoryAbstentionReason::ProviderOutputUnjoined
             && abstention.detail.as_deref() == Some("provider_execution_origin_lineage_unproven")
     }));
+}
+
+#[test]
+fn post_fork_ancestor_corruption_does_not_poison_a_transitive_child_outcome() {
+    use ctx_history_core::EventOrigin;
+
+    let temp = tempfile::tempdir().unwrap();
+    let sessions = temp.path().join("sessions");
+    let index = temp.path().join("global-index");
+    let repository = temp.path().join("repo");
+    fs::create_dir_all(&sessions).unwrap();
+    initialize_repository(&repository);
+    let root = uuid_v7_at_unix_ms(1_785_240_000_000, 1);
+    let fork = uuid_v7_at_unix_ms(1_785_241_800_000, 2);
+    let child = uuid_v7_at_unix_ms(1_785_242_700_000, 3);
+    write_session(
+        &sessions,
+        &root,
+        &[
+            message("user", "root before fork"),
+            descendant_started(&fork),
+            r#"{"timestamp":"2026-07-28T13:00:00Z","type":"response_item","payload":{"type":"function_call","arguments":"#.to_owned(),
+        ],
+    );
+    write_forked_session_at(
+        &sessions,
+        &fork,
+        &root,
+        "2026-07-28T12:30:00Z",
+        &[
+            message("user", "fork before delegated child"),
+            descendant_started(&child),
+        ],
+    );
+    write_forked_session_at(
+        &sessions,
+        &child,
+        &fork,
+        "2026-07-28T12:45:00Z",
+        &[
+            exec_call(
+                "transitive-child-call",
+                "git commit -m child && git rev-parse --verify HEAD",
+                &repository,
+            ),
+            successful_result(
+                "transitive-child-call",
+                Value::String(
+                    "[main 5555555] child\n5555555555555555555555555555555555555555\n".to_owned(),
+                ),
+            ),
+        ],
+    );
+
+    ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+    let child_source = codex_source_key(&child).unwrap();
+    let child_session = codex_session_identity(&child_source, &child).unwrap();
+    let verified = VerifiedIndex::open(&index).unwrap();
+    let result = outcome_for_sequence(&verified, child_session, 2);
+    assert_eq!(result.event_origin, EventOrigin::UniqueToSession);
+    assert_eq!(result.repository_vcs_observations.len(), 1);
+}
+
+#[test]
+fn pre_fork_ancestor_corruption_still_fails_closed_transitively() {
+    let temp = tempfile::tempdir().unwrap();
+    let sessions = temp.path().join("sessions");
+    let index = temp.path().join("global-index");
+    let repository = temp.path().join("repo");
+    fs::create_dir_all(&sessions).unwrap();
+    initialize_repository(&repository);
+    let root = uuid_v7_at_unix_ms(1_785_240_000_000, 4);
+    let fork = uuid_v7_at_unix_ms(1_785_241_800_000, 5);
+    let child = uuid_v7_at_unix_ms(1_785_242_700_000, 6);
+    write_session(
+        &sessions,
+        &root,
+        &[
+            message("user", "root before fork"),
+            r#"{"timestamp":"2026-07-28T12:15:00Z","type":"response_item","payload":{"type":"function_call","arguments":"#.to_owned(),
+            descendant_started(&fork),
+        ],
+    );
+    write_forked_session_at(
+        &sessions,
+        &fork,
+        &root,
+        "2026-07-28T12:30:00Z",
+        &[
+            message("user", "fork before delegated child"),
+            descendant_started(&child),
+        ],
+    );
+    write_forked_session_at(
+        &sessions,
+        &child,
+        &fork,
+        "2026-07-28T12:45:00Z",
+        &[
+            exec_call(
+                "transitive-unproven-call",
+                "git commit -m child && git rev-parse --verify HEAD",
+                &repository,
+            ),
+            successful_result(
+                "transitive-unproven-call",
+                Value::String(
+                    "[main 6666666] child\n6666666666666666666666666666666666666666\n".to_owned(),
+                ),
+            ),
+        ],
+    );
+
+    ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+    assert_child_outcome_is_unproven(&VerifiedIndex::open(&index).unwrap(), &child);
 }
 
 #[test]
@@ -70,6 +194,60 @@ fn checkpoint_replay_preserves_incomplete_tail_lineage_ambiguity() {
     let refresh = ingest_codex_source_backed_v0(&sessions, &index).unwrap();
     assert_eq!(refresh.counters.replayed_sources, 1);
     assert_child_outcome_is_unproven(&VerifiedIndex::open(&index).unwrap(), child);
+}
+
+#[test]
+fn checkpoint_replay_bounds_incomplete_tail_after_typed_descendant_start() {
+    use ctx_history_core::EventOrigin;
+
+    let temp = tempfile::tempdir().unwrap();
+    let sessions = temp.path().join("sessions");
+    let index = temp.path().join("global-index");
+    let repository = temp.path().join("repo");
+    fs::create_dir_all(&sessions).unwrap();
+    initialize_repository(&repository);
+    let parent = "019fa000-0000-7000-8000-000000000220";
+    let child = "019fa000-0000-7000-8000-000000000221";
+    let incomplete =
+        r#"{"type":"response_item","payload":{"type":"function_call","call_id":"unterminated"#;
+    fs::write(
+        session_path(&sessions, parent),
+        format!(
+            "{}\n{}\n{}\n{incomplete}",
+            session_meta(parent),
+            message("user", "parent session anchor"),
+            descendant_started(child)
+        ),
+    )
+    .unwrap();
+
+    ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+    write_forked_session(
+        &sessions,
+        child,
+        parent,
+        &[
+            exec_call(
+                "child-after-bounded-tail",
+                "git commit -m child && git rev-parse --verify HEAD",
+                &repository,
+            ),
+            successful_result(
+                "child-after-bounded-tail",
+                Value::String(
+                    "[main ababab1] child\nababab1ababab1ababab1ababab1ababab1ababa\n".to_owned(),
+                ),
+            ),
+        ],
+    );
+
+    let refresh = ingest_codex_source_backed_v0(&sessions, &index).unwrap();
+    assert_eq!(refresh.counters.replayed_sources, 1);
+    let child_source = codex_source_key(child).unwrap();
+    let child_session = codex_session_identity(&child_source, child).unwrap();
+    let result = outcome_for_sequence(&VerifiedIndex::open(&index).unwrap(), child_session, 2);
+    assert_eq!(result.event_origin, EventOrigin::UniqueToSession);
+    assert_eq!(result.repository_vcs_observations.len(), 1);
 }
 
 #[test]

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/migration.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/source_backed/tests/migration.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[test]
-fn v9_frontier_and_v20_parser_generation_is_rebuilt_to_current_authority() {
+fn v9_frontier_and_v20_parser_generation_rebuilds_to_v11_authority() {
     let temp = tempfile::tempdir().unwrap();
     let sessions = temp.path().join("sessions");
     let index = temp.path().join("global-index");
@@ -74,7 +74,7 @@ fn v9_frontier_and_v20_parser_generation_is_rebuilt_to_current_authority() {
         panic!("rebuilt Codex checkpoint must be byte keyed");
     };
     let checkpoint = serde_json::from_slice::<serde_json::Value>(bytes).unwrap();
-    assert_eq!(checkpoint["version"], 10);
+    assert_eq!(checkpoint["version"], 11);
 }
 
 #[test]

--- a/crates/ctx-history-capture/src/provider/codex/nativepath/tests/lifecycle.rs
+++ b/crates/ctx-history-capture/src/provider/codex/nativepath/tests/lifecycle.rs
@@ -325,7 +325,7 @@ fn checkpoint_round_trip_contains_control_state_but_no_event_body() {
     assert!(!wire.contains("command"));
     assert!(!wire.contains("arguments_preview"));
     let decoded_wire = serde_json::from_str::<Value>(&wire).unwrap();
-    assert_eq!(decoded_wire["version"], 10);
+    assert_eq!(decoded_wire["version"], 11);
     assert_eq!(
         decoded_wire["lineage_dependency_sha256"],
         json!(vec![0; 32])

--- a/crates/ctx-history-capture/src/provider/source_backed/tests/codex.rs
+++ b/crates/ctx-history-capture/src/provider/source_backed/tests/codex.rs
@@ -178,6 +178,18 @@ fn codex_dense_lineage_events(component: usize, pairs: usize) -> Vec<serde_json:
         .collect()
 }
 
+fn codex_descendant_started(native_session_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "timestamp": "2026-08-06T12:00:00Z",
+        "type": "event_msg",
+        "payload": {
+            "type": "sub_agent_activity",
+            "kind": "started",
+            "agent_thread_id": native_session_id,
+        }
+    })
+}
+
 fn register_codex_route(
     registry: &mut SourceBackedProviderRegistry,
     path: &Path,
@@ -1203,7 +1215,9 @@ fn codex_exact_leaf_uses_three_level_carried_authority_and_missing_parent_fails(
 fn codex_generation_spills_more_than_sixteen_near_budget_components_four_at_a_time() {
     const COMPONENTS: usize = 17;
     const FACT_PAIRS: usize = 20;
-    const BYTE_LIMIT: usize = 2_300;
+    // Typed raw-record ordinals make each in-memory fact 48 bytes; one 64-fact
+    // reservation plus the fixed container remains the deterministic peak.
+    const BYTE_LIMIT: usize = 3_300;
     const FACT_LIMIT: usize = 44;
 
     let temp = tempdir().unwrap();
@@ -1214,6 +1228,8 @@ fn codex_generation_spills_more_than_sixteen_near_budget_components_four_at_a_ti
         let root = format!("019fa100-0000-7000-8000-{component:012x}");
         let child = format!("019fa101-0000-7000-8000-{component:012x}");
         let events = codex_dense_lineage_events(component, FACT_PAIRS);
+        let mut root_events = events.clone();
+        root_events.push(codex_descendant_started(&child));
         fs::write(
             sessions.join(format!("rollout-{root}.jsonl")),
             codex_lineage_rollout_with_events(
@@ -1221,7 +1237,7 @@ fn codex_generation_spills_more_than_sixteen_near_budget_components_four_at_a_ti
                 None,
                 SessionRelationshipKind::Root,
                 None,
-                &events,
+                &root_events,
             ),
         )
         .unwrap();
@@ -1270,7 +1286,7 @@ fn codex_generation_spills_more_than_sixteen_near_budget_components_four_at_a_ti
     assert_eq!(peak, 4);
     assert_eq!(current_bytes, 0);
     assert!(
-        (2_200..=BYTE_LIMIT).contains(&peak_bytes),
+        (3_100..=BYTE_LIMIT).contains(&peak_bytes),
         "lineage component peak was {peak_bytes} bytes"
     );
     assert_eq!(component_loads, COMPONENTS);

--- a/crates/ctx-history-capture/tests/codex_direct_result.rs
+++ b/crates/ctx-history-capture/tests/codex_direct_result.rs
@@ -742,7 +742,7 @@ fn invalid_attribution_preserves_terminal_content_and_all_stable_identities() {
     );
     assert_eq!(
         exact.parser_revision,
-        "codex-nativepath-core-record-v22-typed-unique-result-origin"
+        "codex-nativepath-core-record-v23-typed-descendant-prefix-authority"
     );
     assert_eq!(exact.parser_revision, invalid.parser_revision);
     assert_eq!(

--- a/crates/ctx-history-capture/tests/codex_direct_result.rs
+++ b/crates/ctx-history-capture/tests/codex_direct_result.rs
@@ -742,7 +742,7 @@ fn invalid_attribution_preserves_terminal_content_and_all_stable_identities() {
     );
     assert_eq!(
         exact.parser_revision,
-        "codex-nativepath-core-record-v23-typed-descendant-prefix-authority"
+        "codex-nativepath-core-record-v24-scoped-malformed-descendant-authority"
     );
     assert_eq!(exact.parser_revision, invalid.parser_revision);
     assert_eq!(

--- a/docs/mcp-tool-call-attribution-capabilities.json
+++ b/docs/mcp-tool-call-attribution-capabilities.json
@@ -435,7 +435,7 @@
       "provider_id": "codex", "route": "native_import", "source_format": "codex_session_jsonl_tree", "source_schema": "codex-nativepath-jsonl-v0",
       "producer_bound": {"kind": "unversioned", "generation": 1, "unknown_generations": "not-qualified"},
       "implementation_source": "crates/ctx-history-capture/src/provider/codex/nativepath/source_backed.rs",
-      "parser_revision": "codex-nativepath-core-record-v23-typed-descendant-prefix-authority",
+      "parser_revision": "codex-nativepath-core-record-v24-scoped-malformed-descendant-authority",
       "suite_id": "ctx-history-capture::test:codex_direct_result",
       "conformance_suite": "codex_direct_result",
       "tests": [

--- a/docs/mcp-tool-call-attribution-capabilities.json
+++ b/docs/mcp-tool-call-attribution-capabilities.json
@@ -435,7 +435,7 @@
       "provider_id": "codex", "route": "native_import", "source_format": "codex_session_jsonl_tree", "source_schema": "codex-nativepath-jsonl-v0",
       "producer_bound": {"kind": "unversioned", "generation": 1, "unknown_generations": "not-qualified"},
       "implementation_source": "crates/ctx-history-capture/src/provider/codex/nativepath/source_backed.rs",
-      "parser_revision": "codex-nativepath-core-record-v22-typed-unique-result-origin",
+      "parser_revision": "codex-nativepath-core-record-v23-typed-descendant-prefix-authority",
       "suite_id": "ctx-history-capture::test:codex_direct_result",
       "conformance_suite": "codex_direct_result",
       "tests": [

--- a/docs/mcp-tool-call-attribution.md
+++ b/docs/mcp-tool-call-attribution.md
@@ -66,7 +66,7 @@ Deep Agents hosted trace. Capability revision 3 exact providers are
 Codex, Warp, and Copilot CLI. The exact full tuples are:
 
 - Codex `codex_session_jsonl_tree` / `codex-nativepath-jsonl-v0`, parser
-  `codex-nativepath-core-record-v23-typed-descendant-prefix-authority`, for unversioned producer generation 1
+  `codex-nativepath-core-record-v24-scoped-malformed-descendant-authority`, for unversioned producer generation 1
   only. Codex producer versions 0.200.0, 0.201.0, and 0.202.0 are separate
   explicit `not-qualified` lanes and never inherit that exact status.
 - Warp `warp_sqlite` / `warp-agent-task-protobuf-v1`, parser

--- a/docs/mcp-tool-call-attribution.md
+++ b/docs/mcp-tool-call-attribution.md
@@ -66,7 +66,7 @@ Deep Agents hosted trace. Capability revision 3 exact providers are
 Codex, Warp, and Copilot CLI. The exact full tuples are:
 
 - Codex `codex_session_jsonl_tree` / `codex-nativepath-jsonl-v0`, parser
-  `codex-nativepath-core-record-v22-typed-unique-result-origin`, for unversioned producer generation 1
+  `codex-nativepath-core-record-v23-typed-descendant-prefix-authority`, for unversioned producer generation 1
   only. Codex producer versions 0.200.0, 0.201.0, and 0.202.0 are separate
   explicit `not-qualified` lanes and never inherit that exact status.
 - Warp `warp_sqlite` / `warp-agent-task-protobuf-v1`, parser


### PR DESCRIPTION
## Summary

- use provider-authored sub_agent_activity(kind=started, agent_thread_id=...) records as exact inherited-prefix boundaries
- keep post-boundary parent calls/results out of child provenance without weakening conservative behavior when the boundary is unavailable
- scope two real malformed Codex outer-call rows to their exact bounded call_id values so unrelated producer evidence is not globally poisoned
- keep malformed descendant activity fail-closed and preserve identical fresh/checkpoint evidence

## Validation

- owning Bazel release graph: 5/5 targets green
- warnings-as-errors cargo check for ctx-history-capture all targets
- Bazel LOC gate, docs, format, and diff checks green
- immutable seven-file real canary: 233,092,337 bytes; 55,562 documents; zero source failures; both formerly poisoned H02 producer events now unique_to_session
- daemon disabled and no task-root process remained

No public wire shape changes. Parser/checkpoint revisions rotate because the certified lineage authority gained raw ordinals and descendant-start facts.
