### PR TITLE
fix(copilot-cli): skip link-like session files entries without failing the source

### DIFF
--- a/crates/ctx-cli/tests/native_providers.rs
+++ b/crates/ctx-cli/tests/native_providers.rs
@@ -356,6 +356,148 @@ fn windsurf_default_discovery_is_native_and_search_refresh_imports() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn copilot_cli_import_skips_symlinked_session_files_checkout() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir();
+    let query = "copilot-cli-symlinked-files-oracle";
+    let path = write_native_copilot_fixture(&temp, query);
+    // Copilot CLI stores the session working copy under
+    // `<session>/files/`, and checked-out repositories legitimately contain
+    // symlinks (for example `CLAUDE.md -> AGENTS.md`). The link can never
+    // hold an `events.jsonl` transcript, so it must be skipped without
+    // failing the whole copilot_cli source.
+    let checkout = Path::new(&path).join("copilot-cli-native/files/checkout");
+    fs::create_dir_all(&checkout).unwrap();
+    fs::write(checkout.join("AGENTS.md"), b"agents\n").unwrap();
+    symlink("AGENTS.md", checkout.join("CLAUDE.md")).unwrap();
+    let _daemon = start_isolated_provider_daemon(&temp);
+
+    let first = json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "copilot-cli",
+        "--path",
+        &path,
+        "--no-daemon",
+        "--format=json",
+    ]));
+    assert_explicit_source_publication(&first, "copilot_cli", "copilot_cli_session_events_jsonl");
+    wait_for_imported_core(&temp, &first);
+    assert_eq!(first["totals"]["current_rejected_records"], 0, "{first:#}");
+    let (session_count, event_count) = provider_core_counts(&data_root(&temp), "copilot_cli");
+    assert!(session_count >= 1);
+    assert!(event_count >= 1);
+
+    let search = json_output(ctx(&temp).args([
+        "search",
+        query,
+        "--provider",
+        "copilot-cli",
+        "--refresh",
+        "off",
+        "--format=json",
+    ]));
+    assert_search_provider_oracle(&search, "copilot_cli", query, 1, "message");
+
+    // A second import exercises the membership fence walk against the same
+    // symlinked checkout and must republish cleanly.
+    let second = json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "copilot-cli",
+        "--path",
+        &path,
+        "--no-daemon",
+        "--format=json",
+    ]));
+    assert_explicit_source_publication(&second, "copilot_cli", "copilot_cli_session_events_jsonl");
+    assert_eq!(
+        second["totals"]["current_rejected_records"], 0,
+        "{second:#}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn copilot_cli_reimport_fails_when_transcript_turns_into_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir();
+    let query = "copilot-cli-transcript-to-symlink-oracle";
+    let path = write_native_copilot_fixture(&temp, query);
+    let _daemon = start_isolated_provider_daemon(&temp);
+
+    let first = json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "copilot-cli",
+        "--path",
+        &path,
+        "--no-daemon",
+        "--format=json",
+    ]));
+    assert_explicit_source_publication(&first, "copilot_cli", "copilot_cli_session_events_jsonl");
+    wait_for_imported_core(&temp, &first);
+
+    // A transcript route that turns into a link after admission drops out of
+    // the observed membership route set, so the re-import must fail closed
+    // instead of silently keeping stale content.
+    let session = Path::new(&path).join("copilot-cli-native");
+    let real_transcript = session.join("events.real.jsonl");
+    fs::rename(session.join("events.jsonl"), &real_transcript).unwrap();
+    symlink("events.real.jsonl", session.join("events.jsonl")).unwrap();
+
+    let second = json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "copilot-cli",
+        "--path",
+        &path,
+        "--no-daemon",
+        "--format=json",
+    ]));
+    assert_eq!(second["failure_type"], "source_failure", "{second:#}");
+    assert_eq!(
+        second["outcome"], "completed_with_source_failures",
+        "{second:#}"
+    );
+    assert_eq!(second["sources"][0]["carried_forward"], true, "{second:#}");
+}
+
+#[cfg(unix)]
+#[test]
+fn copilot_cli_import_still_rejects_symlinked_transcript() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir();
+    let query = "copilot-cli-symlinked-transcript-oracle";
+    let path = write_native_copilot_fixture(&temp, query);
+    // A symlink where the transcript itself should be stays fail-closed:
+    // skipping is only safe for entries that can never hold a transcript.
+    let session = Path::new(&path).join("copilot-cli-native");
+    let real_transcript = session.join("events.real.jsonl");
+    fs::rename(session.join("events.jsonl"), &real_transcript).unwrap();
+    symlink("events.real.jsonl", session.join("events.jsonl")).unwrap();
+    let _daemon = start_isolated_provider_daemon(&temp);
+
+    let stderr = failure_stderr(ctx(&temp).args([
+        "import",
+        "--provider",
+        "copilot-cli",
+        "--path",
+        &path,
+        "--no-daemon",
+        "--format=json",
+    ]));
+    assert!(
+        stderr.contains("symlinked provider source path components are rejected"),
+        "{stderr}"
+    );
+}
+
 #[test]
 fn unknown_native_providers_are_rejected_by_public_cli() {
     let temp = tempdir();

--- a/crates/ctx-history-capture/src/common/io.rs
+++ b/crates/ctx-history-capture/src/common/io.rs
@@ -14,9 +14,9 @@ mod root_handle;
     reason = "provider adapters migrate to these capability types in follow-up slices"
 )]
 pub(crate) use root_handle::{
-    is_non_regular_source_rejection, open_provider_source_file, open_provider_source_path,
-    OpenedProviderSourceFile, OpenedProviderSourcePath, ProviderSourceDirectory,
-    ProviderSourceRoot,
+    is_non_regular_source_rejection, is_symlink_source_rejection, open_provider_source_file,
+    open_provider_source_path, OpenedProviderSourceFile, OpenedProviderSourcePath,
+    ProviderSourceDirectory, ProviderSourceRoot,
 };
 
 /// Maximum directories admitted by one provider JSONL inventory.
@@ -193,7 +193,9 @@ fn ensure_inventory_path_bound(path: &Path) -> Result<()> {
 ///
 /// The result is lexically sorted and contains only admitted regular `.jsonl`
 /// files. Every encountered child, including non-JSONL and non-regular
-/// entries, consumes the metadata-entry budget. Links are never followed.
+/// entries, consumes the metadata-entry budget. Links are never followed:
+/// link-like and non-regular entries are skipped rather than failing the
+/// inventory.
 pub fn inventory_provider_jsonl_paths(
     root: &Path,
     limits: ProviderJsonlInventoryLimits,
@@ -251,7 +253,20 @@ fn inventory_provider_paths(
             let relative_path = pending.relative_path.join(&name);
             let path = root.join(&relative_path);
             ensure_inventory_path_bound(&path)?;
-            match directory.open_child(&name)? {
+            let opened = match directory.open_child(&name) {
+                Ok(opened) => opened,
+                // Link-like and non-regular entries (sockets, FIFOs, device
+                // nodes) are never followed and hold no provider content, so
+                // they are skipped instead of failing the whole inventory.
+                Err(error)
+                    if is_symlink_source_rejection(&error)
+                        || is_non_regular_source_rejection(&error) =>
+                {
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            match opened {
                 OpenedProviderSourcePath::Directory(_) => {
                     state.admit_directory(child_depth)?;
                     child_directories.push(PendingJsonlDirectory {

--- a/crates/ctx-history-capture/src/common/io/root_handle.rs
+++ b/crates/ctx-history-capture/src/common/io/root_handle.rs
@@ -761,6 +761,32 @@ pub(crate) fn is_non_regular_source_rejection(error: &CaptureError) -> bool {
     )
 }
 
+/// Reason recorded when a provider source path component is a symlink (Unix)
+/// or a reparse, offline, or cloud-placeholder entry (Windows). Provider
+/// layouts that store non-transcript working files beside transcripts (for
+/// example Copilot CLI `session-state/<id>/files/` checkouts containing
+/// `CLAUDE.md -> AGENTS.md` links) can skip such entries safely: the link is
+/// never followed, so the no-follow security boundary is preserved.
+pub(crate) const SYMLINK_PROVIDER_SOURCE_REASON: &str =
+    "symlinked provider source path components are rejected";
+
+/// Windows counterpart of [`SYMLINK_PROVIDER_SOURCE_REASON`].
+pub(crate) const REPARSE_PROVIDER_SOURCE_REASON: &str =
+    "reparse, offline, and cloud-placeholder provider sources are rejected";
+
+/// True when `error` is the safe rejection of a link-like entry that a
+/// traversal can skip without following it. The entry itself is never opened,
+/// so skipping it does not weaken the symlink boundary; transcript-shaped
+/// selections must still treat this rejection as fatal.
+pub(crate) fn is_symlink_source_rejection(error: &CaptureError) -> bool {
+    matches!(
+        error,
+        CaptureError::InvalidProviderTranscriptPath { reason, .. }
+            if *reason == SYMLINK_PROVIDER_SOURCE_REASON
+                || *reason == REPARSE_PROVIDER_SOURCE_REASON
+    )
+}
+
 fn invalid_path(path: &Path, reason: &'static str) -> CaptureError {
     CaptureError::InvalidProviderTranscriptPath {
         path: path.to_path_buf(),

--- a/crates/ctx-history-capture/src/common/io/root_handle/unix.rs
+++ b/crates/ctx-history-capture/src/common/io/root_handle/unix.rs
@@ -292,15 +292,13 @@ fn classify_open_component_error(
     cause: io::Error,
 ) -> AuthorityOpenError {
     match cause.raw_os_error() {
-        Some(libc::ELOOP) => {
-            AuthorityOpenError::Rejected("symlinked provider source path components are rejected")
-        }
+        Some(libc::ELOOP) => AuthorityOpenError::Rejected(super::SYMLINK_PROVIDER_SOURCE_REASON),
         // BSD kernels also use ENOTDIR for O_NOFOLLOW | O_DIRECTORY against a
         // symlink. Reclassify only when no-follow metadata confirms that case.
         Some(libc::ENOTDIR)
             if expected == Some(ExpectedType::Directory) && component_is_symlink(parent, name) =>
         {
-            AuthorityOpenError::Rejected("symlinked provider source path components are rejected")
+            AuthorityOpenError::Rejected(super::SYMLINK_PROVIDER_SOURCE_REASON)
         }
         Some(libc::ENXIO) | Some(libc::ENODEV) | Some(libc::EOPNOTSUPP) => {
             AuthorityOpenError::Rejected(super::NON_REGULAR_PROVIDER_SOURCE_REASON)

--- a/crates/ctx-history-capture/src/common/io/root_handle/windows.rs
+++ b/crates/ctx-history-capture/src/common/io/root_handle/windows.rs
@@ -521,7 +521,7 @@ fn ensure_handle_is_ordinary(
         != 0
     {
         return Err(AuthorityOpenError::Rejected(
-            "reparse, offline, and cloud-placeholder provider sources are rejected",
+            super::REPARSE_PROVIDER_SOURCE_REASON,
         ));
     }
     Ok(())

--- a/crates/ctx-history-capture/src/common/io_tests.rs
+++ b/crates/ctx-history-capture/src/common/io_tests.rs
@@ -231,34 +231,32 @@ fn regular_provider_inventory_applies_file_and_metadata_limits_to_non_jsonl_sour
 
 #[cfg(unix)]
 #[test]
-fn provider_inventory_rejects_symlinked_tree_entries_without_following_them() {
+fn provider_inventory_skips_symlinked_tree_entries_without_following_them() {
     use std::os::unix::fs::symlink;
 
     let temp = crate::test_support_paths::tempdir().unwrap();
     let outside = crate::test_support_paths::tempdir().unwrap();
     fs::write(outside.path().join("session.jsonl"), b"{}\n").unwrap();
     symlink(outside.path(), temp.path().join("linked")).unwrap();
+    fs::write(temp.path().join("local.jsonl"), b"{}\n").unwrap();
 
-    let error =
+    // The symlinked directory is skipped, never followed: the outside
+    // `session.jsonl` must not leak into the inventory, while the regular
+    // sibling is still admitted.
+    let inventory =
         inventory_provider_jsonl_paths(temp.path(), ProviderJsonlInventoryLimits::default())
-            .unwrap_err();
-    assert!(matches!(
-        error,
-        CaptureError::InvalidProviderTranscriptPath { .. }
-    ));
+            .unwrap();
+    assert_eq!(inventory.paths(), &[temp.path().join("local.jsonl")]);
 
-    let error =
+    let inventory =
         inventory_provider_regular_paths(temp.path(), ProviderJsonlInventoryLimits::default())
-            .unwrap_err();
-    assert!(matches!(
-        error,
-        CaptureError::InvalidProviderTranscriptPath { .. }
-    ));
+            .unwrap();
+    assert_eq!(inventory.paths(), &[temp.path().join("local.jsonl")]);
 }
 
 #[cfg(unix)]
 #[test]
-fn provider_inventory_rejects_nonregular_jsonl_entries() {
+fn provider_inventory_skips_nonregular_jsonl_entries() {
     use std::os::unix::net::UnixListener;
 
     let temp = tempfile::Builder::new()
@@ -267,14 +265,12 @@ fn provider_inventory_rejects_nonregular_jsonl_entries() {
         .unwrap();
     let root = fs::canonicalize(temp.path()).unwrap();
     let _listener = UnixListener::bind(root.join("socket.jsonl")).unwrap();
+    fs::write(root.join("session.jsonl"), b"{}\n").unwrap();
 
-    let error =
-        inventory_provider_jsonl_paths(&root, ProviderJsonlInventoryLimits::default()).unwrap_err();
+    let inventory =
+        inventory_provider_jsonl_paths(&root, ProviderJsonlInventoryLimits::default()).unwrap();
 
-    assert!(matches!(
-        error,
-        CaptureError::InvalidProviderTranscriptPath { .. }
-    ));
+    assert_eq!(inventory.paths(), &[root.join("session.jsonl")]);
 }
 
 #[test]

--- a/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed.rs
+++ b/crates/ctx-history-capture/src/provider/providers/native_jsonl/native_path/source_backed.rs
@@ -370,6 +370,20 @@ impl DirectJsonlDirectoryTraversal<'_> {
                 Err(error) if selected && self.adapter.provider == CaptureProvider::Tabnine => {
                     return Err(tabnine_unavailable_source(&child_path, error));
                 }
+                // A link-like or non-regular entry that can never hold a
+                // transcript (for example a `CLAUDE.md -> AGENTS.md` symlink
+                // inside a Copilot CLI `files/` checkout, or a socket beside
+                // transcripts) must not mark the whole source unreadable. The
+                // entry is never followed, so skipping it preserves the
+                // no-follow boundary; a selected transcript path stays
+                // fail-closed below.
+                Err(error)
+                    if !selected
+                        && (crate::common::io::is_symlink_source_rejection(&error)
+                            || crate::common::io::is_non_regular_source_rejection(&error)) =>
+                {
+                    continue;
+                }
                 Err(error) => return Err(error),
             };
             match opened {

--- a/crates/ctx-history-capture/src/provider/source_backed/family/jsonl/route.rs
+++ b/crates/ctx-history-capture/src/provider/source_backed/family/jsonl/route.rs
@@ -10,8 +10,9 @@ use super::{
 };
 use crate::{
     common::io::{
-        open_provider_source_path, OpenedProviderSourceFile, OpenedProviderSourcePath,
-        ProviderSourceDirectory, ProviderSourceRoot,
+        is_non_regular_source_rejection, is_symlink_source_rejection, open_provider_source_path,
+        OpenedProviderSourceFile, OpenedProviderSourcePath, ProviderSourceDirectory,
+        ProviderSourceRoot,
     },
     provider::source_backed::{
         source_backed_base_sources, SourceBackedGenerationSink, SourceBackedRevalidationTarget,
@@ -502,7 +503,23 @@ fn observe_membership_directory(
         let authority = directory.authority_root();
         let source_path = authority.named_path().join(&authority_path);
         check_membership_path(&source_path)?;
-        match directory.open_child(&name)? {
+        let opened = match directory.open_child(&name) {
+            Ok(opened) => opened,
+            // Admission never admits a link-like or non-regular route (a
+            // selected transcript that is a link fails admission), so
+            // skipping here only ever drops non-route entries or a route that
+            // changed into a link after admission; that change drops out of
+            // the observed route set and fails the membership comparison as a
+            // source change.
+            Err(error)
+                if is_symlink_source_rejection(&error)
+                    || is_non_regular_source_rejection(&error) =>
+            {
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
+        match opened {
             OpenedProviderSourcePath::Directory(child) => {
                 observe_membership_directory(&child, depth.saturating_add(1), state)?;
             }


### PR DESCRIPTION

Fixes 362.

## Summary

- A Copilot CLI `session-state/<id>/files/` checkout containing a symlink (for example `CLAUDE.md -> AGENTS.md`) made the whole `copilot_cli` source unreadable, so no Copilot history imported or was searchable.
- Adds `is_symlink_source_rejection` (plus the shared `SYMLINK_PROVIDER_SOURCE_REASON` and Windows `REPARSE_PROVIDER_SOURCE_REASON` constants) next to the `is_non_regular_source_rejection` helper from #249.
- The direct-JSONL discovery traversal now skips link-like and non-regular rejections for entries the provider selector can never select; a selected transcript path (a symlinked `events.jsonl`) stays fail-closed.
- The JSONL membership fence walk skips the same entries, keeping opening and closing observations consistent; a transcript route that turns into a link after admission still drops out of the observed route set and fails the membership comparison as a source change.
- The format-neutral source inventory (`inventory_provider_jsonl_paths` / `inventory_provider_regular_paths`) skips link-like and non-regular entries instead of erroring, matching its documented "links are never followed" contract; its unit tests now assert the outside target of a symlink never leaks into the inventory.
- The shared walks also harden the other direct-JSONL family providers (Windsurf, Qwen Code, Qoder, Tabnine, Antigravity, Factory AI Droid) against the same layout.

## Validation

- `cargo fmt --all -- --check` clean.
- `cargo test -p ctx --test native_providers copilot_cli_import` green: `copilot_cli_import_skips_symlinked_session_files_checkout` imports and searches a session-state tree whose `files/` checkout contains a symlink, including a second import that exercises the membership fence; `copilot_cli_import_still_rejects_symlinked_transcript` proves a symlinked `events.jsonl` still aborts.
- `cargo test -p ctx-history-capture --lib common::io` and the `source_backed::family::jsonl` / `native_jsonl` unit tests green.
- `cargo clippy -p ctx-history-capture -p ctx --all-targets -- -D warnings` reports no findings in the files this PR touches; the workspace currently carries pre-existing clippy 1.96 findings in unrelated crates (for example `ctx-protocol`, `ctx-history-index`, `ctx-cli/src/upgrade`) that reproduce on unmodified `main` with this toolchain.
- Real-data check: with this patch applied on top of 49932564, `ctx import --all` against live history including a `~/.copilot/session-state` with symlinked `files/` checkouts completes cleanly and `ctx search --provider copilot-cli` returns Copilot sessions. Note: current `main` cannot complete any refresh on this machine's real history due to an unrelated regression ("session relationship graph is invalid: session chain disagrees on root identity", reproduced with a pristine d462376b binary on a fresh data root), so the real-data check was run on the last-known-good base; the patch itself is base-independent.
