### PR TITLE
release: restore Core-only factory validator

### DIFF
--- a/docs/linux-release-factory.md
+++ b/docs/linux-release-factory.md
@@ -69,11 +69,13 @@ scripts/validate-public-cli-factory-artifact.sh \
   PLATFORM target/public-cli-artifacts target/public-cli-native-smoke/PLATFORM
 ```
 
-The validator checks the factory checksum, executes the native candidate, and
-checks that validation did not mutate it. macOS additionally performs strict
-native codesign verification. Windows requires `Get-AuthenticodeSignature` to
-accept the exact factory bytes and match the factory certificate evidence.
-Semantic runtime smokes use the same CLI bytes.
+This is an exact three-argument, Core-only interface. Companion binaries and
+managed-pair envelopes are not inputs to the public factory validator or its
+five native lanes. The validator checks the factory checksum, executes the
+native candidate, and checks that validation did not mutate it. macOS
+additionally performs strict native codesign verification. Windows requires
+`Get-AuthenticodeSignature` to accept the exact factory bytes and match the
+factory certificate evidence. Semantic runtime smokes use the same CLI bytes.
 Only after all five jobs pass does the staging job assemble GitHub assets.
 
 Bazel remains available for hermetic development and qualification checks. It

--- a/scripts/check-buildkite-pipeline.sh
+++ b/scripts/check-buildkite-pipeline.sh
@@ -166,6 +166,24 @@ native = {
         "windows-x64", "windows-x64", "windows", "x86_64"
     ),
 }
+
+
+def require_core_validator_call(key: str, platform: str, command: str) -> None:
+    logical_command = re.sub(r"\\\n[ \t]*", " ", command)
+    calls = []
+    for line in logical_command.splitlines():
+        normalized = " ".join(line.split())
+        if "validate-public-cli-factory-artifact.sh" in normalized:
+            calls.append(normalized)
+    expected = (
+        "scripts/validate-public-cli-factory-artifact.sh "
+        f"{platform} target/public-cli-artifacts "
+        f"target/public-cli-native-smoke/{platform}"
+    )
+    if calls != [expected]:
+        fail(f"{key} must use the exact three-argument Core-only validator call")
+
+
 for key, (platform, queue, os_name, arch) in native.items():
     step = keyed[key]
     if key == "public-cli-macos-arm64-native-smoke":
@@ -189,10 +207,26 @@ for key, (platform, queue, os_name, arch) in native.items():
     command = step.get("command", "")
     if "download-linux-factory-artifacts.sh" not in command:
         fail(f"{key} must download factory artifacts")
-    if "validate-public-cli-factory-artifact.sh" not in command or platform not in command:
-        fail(f"{key} must run exact-byte native validation")
+    require_core_validator_call(key, platform, command)
     if re.search(r"cargo (?:build|zigbuild)|bazelw run //:ctx_release", command):
         fail(f"{key} must never rebuild the candidate")
+
+for key, (platform, _queue, _os_name, _arch) in native.items():
+    command = keyed[key].get("command", "")
+    output = f"target/public-cli-native-smoke/{platform}"
+    mutated = command.replace(
+        output,
+        f"{output} companion-artifact managed-pair-envelope",
+        1,
+    )
+    if mutated == command:
+        fail(f"{key} validator arity mutation could not be constructed")
+    try:
+        require_core_validator_call(key, platform, mutated)
+    except SystemExit:
+        pass
+    else:
+        fail(f"{key} accepted a companion/pair-envelope validator mutation")
 
 coreml_archive = (
     "target/public-cli-artifacts/"
@@ -275,8 +309,8 @@ for step in steps:
         fail(f"{step.get('key')} exposes {match.group(0)} to Buildkite interpolation")
 
 print(
-    "Buildkite release pipeline: one Linux factory, five exact-byte native "
-    "validators, strict staging"
+    "Buildkite release pipeline: one Linux factory, five exact-byte "
+    "three-argument Core validators, strict staging"
 )
 PY
 

--- a/scripts/tests/linux-release-factory-test.py
+++ b/scripts/tests/linux-release-factory-test.py
@@ -505,6 +505,27 @@ class LinuxReleaseFactoryTest(unittest.TestCase):
         self.assertIn('--candidate-manifest "${artifact}.candidate.json"', source)
         self.assertIn('--version-file "${artifact}.version"', source)
 
+    def test_native_validator_is_exactly_three_argument_and_core_only(self) -> None:
+        source = (
+            ROOT / "scripts" / "validate-public-cli-factory-artifact.sh"
+        ).read_text()
+        self.assertIn(
+            "Usage: scripts/validate-public-cli-factory-artifact.sh "
+            "PLATFORM ARTIFACT_DIR OUTPUT_DIR\n",
+            source,
+        )
+        self.assertIn('[[ $# -eq 3 ]]', source)
+        for paired_artifact_surface in (
+            "COMPANION",
+            "PAIR_ENVELOPE",
+            '"${companion}"',
+            '"${pair_envelope}"',
+            "-Companion",
+            "-PairEnvelope",
+            "install-managed-pair.py",
+        ):
+            self.assertNotIn(paired_artifact_surface, source)
+
     def test_candidate_version_binds_artifact_build_info_and_sidecar(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/scripts/tests/validate-public-cli-factory-artifact-test.sh
+++ b/scripts/tests/validate-public-cli-factory-artifact-test.sh
@@ -46,11 +46,6 @@ artifact="${artifact_dir}/ctx"
 printf '#!/bin/sh\nexit 1\n' >"${artifact}"
 chmod 600 "${artifact}"
 sha256_file "${artifact}" >"${artifact}.sha256"
-companion="${artifact_dir}/ctx-pro-linux-x64"
-printf '#!/bin/sh\nexit 1\n' >"${companion}"
-chmod 600 "${companion}"
-pair_envelope="${artifact_dir}/ctx-managed-pair-linux-x64.json"
-printf '{}\n' >"${pair_envelope}"
 
 ARTIFACT="${artifact}" REPO_ROOT="${repo_root}" python3 - <<'PY'
 import hashlib
@@ -205,7 +200,6 @@ PATH="${command_dir}:/usr/bin:/bin" \
   CTX_TEST_CHMOD_LOG="${chmod_log}" \
   CTX_TEST_CARGO_MARKER="${cargo_marker}" \
   bash "${validator}" linux-x64 -artifacts "${output_dir}" \
-    "${companion}" "${pair_envelope}" \
   >"${test_root}/stdout" 2>"${test_root}/stderr"
 status=$?
 set -e
@@ -215,7 +209,6 @@ if grep -Fq "factory artifact directory is unavailable" "${test_root}/stderr"; t
   fail "validator parsed a leading-dash artifact directory as an option"
 fi
 [[ -x "${artifact}" ]] || fail "validator did not restore owner execute permission"
-[[ -x "${companion}" ]] || fail "validator did not restore companion execute permission"
 [[ -f "${chmod_log}" ]] || fail "BSD-compatible chmod shim was not invoked"
 [[ ! -e "${cargo_marker}" ]] || fail "validator invoked Cargo"
 [[ "$(cat "${artifact}.sha256")" == "$(sha256_file "${artifact}")" ]] || \
@@ -225,15 +218,24 @@ fi
 expected_artifact="$(cd "${artifact_dir}" && pwd -P)/ctx"
 [[ "$(sed -n '2p' "${chmod_log}")" == "${expected_artifact}" ]] || \
   fail "validator did not pass the canonical artifact path to chmod"
-[[ "$(sed -n '3p' "${chmod_log}")" == u+x ]] || \
-  fail "validator passed a non-portable companion chmod mode"
-[[ "$(sed -n '4p' "${chmod_log}")" == "${companion}" ]] || \
-  fail "validator did not pass the exact companion path to chmod"
-[[ "$(wc -l <"${chmod_log}" | tr -d '[:space:]')" == 4 ]] || \
-  fail "validator passed an unexpected chmod operand"
+[[ "$(wc -l <"${chmod_log}" | tr -d '[:space:]')" == 2 ]] || \
+  fail "validator passed an extra chmod operand"
 if grep -Fq "could not establish factory artifact executable mode" \
   "${test_root}/stderr"; then
   fail "validator rejected the BSD-compatible chmod path"
 fi
 
-printf 'PASS: immutable factory identity and BSD/GNU mode restoration\n'
+set +e
+bash "${validator}" linux-x64 -artifacts "${output_dir}" \
+  companion-artifact managed-pair-envelope \
+  >"${test_root}/pair-mutation-stdout" 2>"${test_root}/pair-mutation-stderr"
+pair_mutation_status=$?
+set -e
+[[ ${pair_mutation_status} -eq 2 ]] || \
+  fail "validator did not reject a companion/pair-envelope arity mutation"
+grep -Fxq \
+  'Usage: scripts/validate-public-cli-factory-artifact.sh PLATFORM ARTIFACT_DIR OUTPUT_DIR' \
+  "${test_root}/pair-mutation-stderr" || \
+  fail "validator did not preserve the exact Core-only three-argument usage"
+
+printf 'PASS: immutable Core factory identity, exact arity, and BSD/GNU mode restoration\n'

--- a/scripts/validate-public-cli-factory-artifact.sh
+++ b/scripts/validate-public-cli-factory-artifact.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<'USAGE'
-Usage: scripts/validate-public-cli-factory-artifact.sh PLATFORM ARTIFACT_DIR OUTPUT_DIR COMPANION PAIR_ENVELOPE
+Usage: scripts/validate-public-cli-factory-artifact.sh PLATFORM ARTIFACT_DIR OUTPUT_DIR
 
-Validates one exact signed Core/companion pair on its native platform. This
-command never compiles or replaces the candidate bytes.
+Validates one exact Core artifact downloaded from the Linux release factory on
+its native platform. This command never compiles or replaces the candidate bytes.
 USAGE
 }
 
@@ -23,12 +23,10 @@ sha256_file() {
   fi
 }
 
-[[ $# -eq 5 ]] || { usage; exit 2; }
+[[ $# -eq 3 ]] || { usage; exit 2; }
 platform="$1"
 artifact_dir="$2"
 output_dir="$3"
-companion="$4"
-pair_envelope="$5"
 case "${platform}" in
   linux-x64) binary="ctx" ;;
   linux-aarch64) binary="ctx-linux-aarch64" ;;
@@ -49,12 +47,8 @@ artifact_dir="$(CDPATH= cd "${artifact_dir_operand}" 2>/dev/null && pwd -P)" || 
   die "factory artifact directory is unavailable"
 artifact="${artifact_dir}/${binary}"
 [[ -f "${artifact}" && ! -L "${artifact}" ]] || die "factory artifact is missing"
-[[ -f "${companion}" && ! -L "${companion}" ]] || die "signed companion artifact is missing"
-[[ -f "${pair_envelope}" && ! -L "${pair_envelope}" ]] || die "signed pair envelope is missing"
 [[ -s "${artifact}.sha256" ]] || die "factory checksum is missing"
 before="$(sha256_file "${artifact}")"
-companion_before="$(sha256_file "${companion}")"
-envelope_before="$(sha256_file "${pair_envelope}")"
 expected_sha256="$(tr -d '[:space:]' <"${artifact}.sha256")"
 [[ "${expected_sha256}" =~ ^[0-9a-f]{64}$ ]] || die "factory checksum is malformed"
 [[ "${before}" == "${expected_sha256}" ]] || \
@@ -79,7 +73,6 @@ if [[ "${platform}" != windows-x64 ]]; then
   # BSD chmod rejects the GNU-only extra option terminator. The canonical
   # absolute path above cannot be mistaken for an option.
   chmod u+x "${artifact}" || die "could not establish factory artifact executable mode"
-  chmod u+x "${companion}" || die "could not establish companion artifact executable mode"
   [[ -f "${artifact}" && ! -L "${artifact}" && -x "${artifact}" ]] || \
     die "factory artifact is not an executable regular file"
 fi
@@ -107,8 +100,7 @@ case "${platform}" in
     scripts/check-macos-release-signing.sh "${platform}" cli "${artifact}"
     mkdir -p "${output_dir%/}"
     scripts/run-native-candidate-smoke.sh \
-      "${artifact}" "${companion}" "${pair_envelope}" \
-      tests/fixtures/custom-history-jsonl/basic.jsonl "${version}" \
+      "${artifact}" tests/fixtures/custom-history-jsonl/basic.jsonl "${version}" \
       "${output_dir%/}/candidate-smoke.json"
     ;;
   windows-x64)
@@ -122,8 +114,6 @@ case "${platform}" in
     powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass \
       -File scripts/run-native-candidate-smoke.ps1 \
       -Binary "${artifact}" \
-      -Companion "${companion}" \
-      -PairEnvelope "${pair_envelope}" \
       -Fixture tests/fixtures/custom-history-jsonl/basic.jsonl \
       -ExpectedVersion "${version}" \
       -ResultPath "${output_dir%/}/candidate-smoke.json"
@@ -131,18 +121,13 @@ case "${platform}" in
   *)
     mkdir -p "${output_dir}"
     scripts/run-native-candidate-smoke.sh \
-      "${artifact}" "${companion}" "${pair_envelope}" \
-      tests/fixtures/custom-history-jsonl/basic.jsonl "${version}" \
+      "${artifact}" tests/fixtures/custom-history-jsonl/basic.jsonl "${version}" \
       "${output_dir%/}/candidate-smoke.json"
     ;;
 esac
 
 after="$(sha256_file "${artifact}")"
 [[ "${after}" == "${before}" ]] || die "native validation mutated candidate bytes"
-[[ "$(sha256_file "${companion}")" == "${companion_before}" ]] || \
-  die "native validation mutated companion bytes"
-[[ "$(sha256_file "${pair_envelope}")" == "${envelope_before}" ]] || \
-  die "native validation mutated signed pair metadata"
 python3 -I scripts/native-execution-proof.py create \
   --platform "${platform}" \
   --artifact "${artifact}" \


### PR DESCRIPTION
Summary:
- restore the public factory validator to its exact three-argument Core-only contract
- enforce exact validator calls and reject companion/pair-envelope arity mutations across all five native Buildkite lanes
- align factory, native, signing, staging documentation and contract tests

Validation:
- affected six-target Bazel closure: 6/6 passed
- uncached deterministic rerun: 6/6 passed
- Bash/Python syntax, git diff check, stable patch/tree/status no-drift: passed

No candidate trigger, release, tag, publish, or deploy.