### PR TITLE
style(cli): apply canonical rustfmt

### DIFF
--- a/crates/ctx-cli/src/cli.rs
+++ b/crates/ctx-cli/src/cli.rs
@@ -13,7 +13,7 @@ use crate::{
     docs, integrations, mcp,
     output::JsonOutputFormat,
     progress::ProgressArg,
-    provider_args::{ImportFormatArg, NativeProviderArg, parse_native_provider_arg},
+    provider_args::{parse_native_provider_arg, ImportFormatArg, NativeProviderArg},
     semantic,
     ui::ColorMode,
     upgrade,
@@ -26,7 +26,7 @@ pub(crate) const MAX_EVENT_WINDOW: usize = 50;
 #[cfg(test)]
 use crate::commands::search::ContentScopeArg;
 #[cfg(test)]
-pub(crate) use crate::commands::search::{MAX_SEARCH_LIMIT, parse_search_limit};
+pub(crate) use crate::commands::search::{parse_search_limit, MAX_SEARCH_LIMIT};
 
 pub(crate) const CLAP_STYLES: clap::builder::styling::Styles =
     clap::builder::styling::Styles::styled()

--- a/crates/ctx-cli/src/commands/import/application_adapter.rs
+++ b/crates/ctx-cli/src/commands/import/application_adapter.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use anyhow::Result;
-use ctx_history_capture::{ProviderSource, source_backed_source_failure_identity};
+use ctx_history_capture::{source_backed_source_failure_identity, ProviderSource};
 use ctx_history_core::CaptureProvider;
 use ctx_history_ingest_application::{HistorySourcePluginSource, IngestPublication};
 use ctx_history_platform::platform_security::establish_private_data_root;
@@ -12,7 +12,7 @@ use crate::{
 };
 
 use super::{
-    core_refresh::{ImportCoreRefreshRequest, wait_for_import_core_refresh},
+    core_refresh::{wait_for_import_core_refresh, ImportCoreRefreshRequest},
     explicit_source_catalog::{
         explicit_source_for_admission, relocate_explicit_source, relocation_authority_for_import,
         upsert_explicit_source,

--- a/crates/ctx-cli/src/commands/import/core_refresh.rs
+++ b/crates/ctx-cli/src/commands/import/core_refresh.rs
@@ -1,15 +1,15 @@
 use std::path::Path;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 
 use crate::{
-    DaemonTriggerCommandArg,
     config::AppConfig,
     progress::ProgressReporter,
     semantic::{
-        SourceBackedRefreshMode, SourceBackedRefreshObservation, autostart_daemon_and_wait,
-        coordinate_import_source_backed_refresh_with_progress,
+        autostart_daemon_and_wait, coordinate_import_source_backed_refresh_with_progress,
+        SourceBackedRefreshMode, SourceBackedRefreshObservation,
     },
+    DaemonTriggerCommandArg,
 };
 
 use super::ExplicitSourceCatalogAuthority;

--- a/crates/ctx-cli/src/commands/import/entry.rs
+++ b/crates/ctx-cli/src/commands/import/entry.rs
@@ -3,13 +3,13 @@ use std::path::PathBuf;
 use anyhow::Result;
 use ctx_history_ingest_application::{IngestReport, ProviderRefreshModeFact};
 
-use crate::ImportArgs;
 use crate::analytics::{
-    ImportFailureScope as AnalyticsImportFailureScope,
+    bytes_bucket, count_bucket, ImportFailureScope as AnalyticsImportFailureScope,
     ImportFailureType as AnalyticsImportFailureType, ImportOutcome as AnalyticsImportOutcome,
-    ImportTelemetry, ProviderRefreshSourceMode, ProviderRefreshTrigger, bytes_bucket, count_bucket,
+    ImportTelemetry, ProviderRefreshSourceMode, ProviderRefreshTrigger,
 };
 use crate::ui::Ui;
+use crate::ImportArgs;
 
 use super::{
     application_adapter::CliImportHost,

--- a/crates/ctx-cli/src/commands/import/explicit_source_catalog.rs
+++ b/crates/ctx-cli/src/commands/import/explicit_source_catalog.rs
@@ -6,8 +6,8 @@ use ctx_history_capture::{ProviderSource, SourceBackedRouteError, SourceBackedRo
 use ctx_history_core::CaptureProvider;
 
 pub(crate) use ctx_history_refresh::{
-    ExplicitSourceCatalogAuthority, ExplicitSourceRelocationAuthority, relocate_explicit_source,
-    upsert_explicit_source,
+    relocate_explicit_source, upsert_explicit_source, ExplicitSourceCatalogAuthority,
+    ExplicitSourceRelocationAuthority,
 };
 
 pub(crate) fn explicit_source_for_admission(

--- a/crates/ctx-cli/src/commands/import/provider_refresh.rs
+++ b/crates/ctx-cli/src/commands/import/provider_refresh.rs
@@ -8,11 +8,11 @@ use ctx_history_refresh::{
 };
 
 use crate::analytics::{
-    DurationBucket, ForegroundProviderRefreshV1, Outcome, ProviderCoreResult,
-    ProviderRefreshChange, ProviderRefreshCompletedV1, ProviderRefreshContentEvidence,
-    ProviderRefreshCountsV1, ProviderRefreshFailureScope, ProviderRefreshFailureType,
-    ProviderRefreshResult, ProviderRefreshSourceMode, ProviderRefreshTrigger,
-    ProviderRefreshWorkKind, PublicEventV1, count_bucket, duration_bucket,
+    count_bucket, duration_bucket, DurationBucket, ForegroundProviderRefreshV1, Outcome,
+    ProviderCoreResult, ProviderRefreshChange, ProviderRefreshCompletedV1,
+    ProviderRefreshContentEvidence, ProviderRefreshCountsV1, ProviderRefreshFailureScope,
+    ProviderRefreshFailureType, ProviderRefreshResult, ProviderRefreshSourceMode,
+    ProviderRefreshTrigger, ProviderRefreshWorkKind, PublicEventV1,
 };
 
 use super::SourceStats;

--- a/crates/ctx-cli/src/commands/import/provider_refresh/tests.rs
+++ b/crates/ctx-cli/src/commands/import/provider_refresh/tests.rs
@@ -278,11 +278,9 @@ fn every_capture_provider_emits_without_usage_suppression() {
 
     assert_eq!(events.len(), providers.len());
     for provider in providers {
-        assert!(
-            events
-                .iter()
-                .any(|event| foreground(event).provider == Some(provider))
-        );
+        assert!(events
+            .iter()
+            .any(|event| foreground(event).provider == Some(provider)));
     }
 }
 

--- a/crates/ctx-cli/src/commands/index.rs
+++ b/crates/ctx-cli/src/commands/index.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 use crate::{
     analytics::IndexTelemetry, config, output::compact_json, semantic::source_epoch_status_report,

--- a/crates/ctx-cli/src/commands/index/dashboard_fixture.rs
+++ b/crates/ctx-cli/src/commands/index/dashboard_fixture.rs
@@ -1,10 +1,10 @@
 use std::process::ExitCode;
 
-use anyhow::{Context as _, Result, bail};
+use anyhow::{bail, Context as _, Result};
 use clap::ValueEnum;
 use ctx_cli_presentation::commands::index::IndexWatchOutput;
 use serde::Serialize;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 use crate::{
     cli::IndexDashboardFixtureArgs,

--- a/crates/ctx-cli/src/commands/index/dashboard_fixture/tests.rs
+++ b/crates/ctx-cli/src/commands/index/dashboard_fixture/tests.rs
@@ -1,4 +1,4 @@
-use clap::{Parser as _, ValueEnum as _, error::ErrorKind};
+use clap::{error::ErrorKind, Parser as _, ValueEnum as _};
 use sha2::{Digest as _, Sha256};
 
 use super::*;
@@ -6,7 +6,7 @@ use crate::{
     cli::CliColorMode,
     ui::{ColorMode, StreamKind, TestContext},
 };
-use ctx_cli_presentation::commands::index::{IndexWatchOutput, render_dashboard_for_fixture};
+use ctx_cli_presentation::commands::index::{render_dashboard_for_fixture, IndexWatchOutput};
 
 fn args(case: FixtureCase, columns: usize) -> IndexDashboardFixtureArgs {
     IndexDashboardFixtureArgs {

--- a/crates/ctx-cli/src/commands/mod.rs
+++ b/crates/ctx-cli/src/commands/mod.rs
@@ -10,10 +10,10 @@ pub(crate) mod show;
 /// execution itself lives in `ctx-history-cli`.
 pub(crate) mod source_index {
     pub(crate) use ctx_history_cli::{
-        McpSearchError, ShowApplicationError, SourceSearchRequest,
         generation_query_authority_error_json, mcp_search_with_compact, mcp_show_event_application,
         mcp_show_session_application, normalize_mcp_search_request,
-        validate_explicit_semantic_scope,
+        validate_explicit_semantic_scope, McpSearchError, ShowApplicationError,
+        SourceSearchRequest,
     };
 }
 pub(crate) mod sources;

--- a/crates/ctx-cli/src/commands/setup.rs
+++ b/crates/ctx-cli/src/commands/setup.rs
@@ -1,21 +1,21 @@
 use std::path::PathBuf;
 
-use anyhow::{Result, bail};
-use serde_json::{Value, json};
+use anyhow::{bail, Result};
+use serde_json::{json, Value};
 
 use crate::analytics::{self, SetupMode, SetupTelemetry};
 use crate::history_config::CliHistoryConfigAdapter;
 use crate::output::print_json;
 use crate::progress::{ProgressReporter, ProgressWriterError};
 use crate::semantic::{
-    DaemonSetupHandoff, SourceBackedRefreshMode, SourceBackedRefreshPendingPublication,
     autostart_daemon_for_setup_and_wait, coordinate_setup_source_backed_refresh_with_progress,
     daemon_autostart_suppression_reason, observe_daemon_for_setup_and_wait,
-    semantic_query_service_supported, source_epoch_status_report,
+    semantic_query_service_supported, source_epoch_status_report, DaemonSetupHandoff,
+    SourceBackedRefreshMode, SourceBackedRefreshPendingPublication,
 };
 use crate::ui::Ui;
-use crate::{SetupArgs, config};
-use ctx_cli_presentation::commands::{SetupDaemonState, render_setup_human};
+use crate::{config, SetupArgs};
+use ctx_cli_presentation::commands::{render_setup_human, SetupDaemonState};
 use ctx_history_cli::HistoryConfigPort;
 
 const HOSTED_INSTALLER_SETUP_ENV: &str = "CTX_HOSTED_INSTALLER_SETUP";
@@ -453,11 +453,9 @@ mod tests {
             0,
         )
         .into();
-        assert!(
-            empty
-                .downcast_ref::<SourceBackedRefreshPendingPublication>()
-                .is_some_and(|pending| pending.source_count() == 0)
-        );
+        assert!(empty
+            .downcast_ref::<SourceBackedRefreshPendingPublication>()
+            .is_some_and(|pending| pending.source_count() == 0));
     }
 
     #[test]
@@ -517,11 +515,9 @@ mod tests {
         assert_eq!(autostart["persistent"], true);
         assert!(autostart["limitation"].is_null());
         assert_eq!(autostart["reason"], "native_supervisor_unavailable");
-        assert!(
-            autostart["supervisor"]["limitation"]
-                .as_str()
-                .is_some_and(|message| message.contains("automatic restart"))
-        );
+        assert!(autostart["supervisor"]["limitation"]
+            .as_str()
+            .is_some_and(|message| message.contains("automatic restart")));
     }
 
     #[test]

--- a/crates/ctx-cli/src/commands/status.rs
+++ b/crates/ctx-cli/src/commands/status.rs
@@ -1,15 +1,15 @@
 use std::path::Path;
 
 use anyhow::Result;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
-use crate::StatusArgs;
-use crate::analytics::{StatusTelemetry, count_bucket};
+use crate::analytics::{count_bucket, StatusTelemetry};
 use crate::config::{self, CONFIG_FILE};
 use crate::local_usage;
 use crate::output::print_json;
 use crate::semantic::source_epoch_status_report;
 use crate::ui::Ui;
+use crate::StatusArgs;
 use ctx_cli_presentation::commands::compact_usage_health_json;
 
 mod usage;

--- a/crates/ctx-cli/src/commands/status/usage.rs
+++ b/crates/ctx-cli/src/commands/status/usage.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
 use anyhow::Result;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
-use crate::{UsageStatusMode, config, local_usage, output::print_json, ui::Ui};
+use crate::{config, local_usage, output::print_json, ui::Ui, UsageStatusMode};
 use ctx_cli_presentation::commands::{
     malformed_status_config_json, removed_cloud_config_json,
     render_malformed_status_config_failure, render_removed_cloud_config_failure,

--- a/crates/ctx-cli/src/config.rs
+++ b/crates/ctx-cli/src/config.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use ctx_history_platform::platform_security::establish_private_data_root;
 
 mod durable_write;

--- a/crates/ctx-cli/src/config/durable_write.rs
+++ b/crates/ctx-cli/src/config/durable_write.rs
@@ -51,7 +51,7 @@ fn replace_config_file(source: &Path, target: &Path) -> io::Result<()> {
 fn replace_config_file(source: &Path, target: &Path) -> io::Result<()> {
     use std::os::windows::ffi::OsStrExt as _;
     use windows_sys::Win32::Storage::FileSystem::{
-        MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
     };
 
     let source = source

--- a/crates/ctx-cli/src/dispatch.rs
+++ b/crates/ctx-cli/src/dispatch.rs
@@ -6,21 +6,21 @@ use ctx_history_platform::default_data_root;
 
 use crate::{
     analytics::{
-        self, ClientOperationDraft, DocsTelemetry, DoctorTelemetry, IndexTelemetry,
+        self, count_bucket, ClientOperationDraft, DocsTelemetry, DoctorTelemetry, IndexTelemetry,
         IntegrationTelemetry, LocateTelemetry, RenderFormat, SearchTelemetry, SetupTelemetry,
         ShowTelemetry, SourcesTelemetry, StatusTelemetry, TargetKind, UpgradeMode,
-        UpgradeOperation, UpgradeTelemetry, count_bucket,
+        UpgradeOperation, UpgradeTelemetry,
     },
     cli::{CommandRoot, DaemonCommand, DaemonTriggerCommandArg, ImportArgs},
     commands::{
         doctor::run_doctor,
-        import::{ProviderRefreshCollector, run_import},
+        import::{run_import, ProviderRefreshCollector},
         index::run_index,
         list::run_list,
         locate::run_locate,
         search::run_search,
         setup::run_setup,
-        show::{ShowArgs, ShowTarget, run_show},
+        show::{run_show, ShowArgs, ShowTarget},
         sources::run_sources,
         stats::{malformed_config_failure as malformed_stats_config_failure, run as run_stats},
         status::{
@@ -35,8 +35,8 @@ use crate::{
     output::{OutputFormat, OutputMeasurement},
     presentation_limit, semantic,
     ui::{
-        ColorMode, Diagnostic, DiagnosticLevel, Outcome, OutcomeState, Ui, diagnostic, outcome,
-        scan_color_mode, scan_machine_output_hint,
+        diagnostic, outcome, scan_color_mode, scan_machine_output_hint, ColorMode, Diagnostic,
+        DiagnosticLevel, Outcome, OutcomeState, Ui,
     },
     upgrade,
 };
@@ -1067,10 +1067,8 @@ mod tests {
 
             let machine_stderr = styled_stderr_copy.bytes();
             assert!(!machine_stderr.contains(&0x1b), "{args:?}");
-            assert!(
-                String::from_utf8_lossy(&machine_stderr)
-                    .starts_with("Error: representative command failure")
-            );
+            assert!(String::from_utf8_lossy(&machine_stderr)
+                .starts_with("Error: representative command failure"));
         }
     }
 

--- a/crates/ctx-cli/src/dispatch/parse.rs
+++ b/crates/ctx-cli/src/dispatch/parse.rs
@@ -2,16 +2,16 @@ use std::{error::Error as _, ffi::OsString};
 
 use anyhow::{Context, Result};
 use clap::{
-    Command, CommandFactory, Parser,
     error::{ContextKind as ClapContextKind, ContextValue as ClapContextValue, ErrorKind},
+    Command, CommandFactory, Parser,
 };
 
 use super::RenderedClapError;
 use crate::{
     cli::Cli,
     ui::{
-        Action, ColorMode, Diagnostic, DiagnosticLevel, Document, Field, Line, RenderContext, Ui,
-        diagnostic, scan_color_mode, scan_machine_output_hint,
+        diagnostic, scan_color_mode, scan_machine_output_hint, Action, ColorMode, Diagnostic,
+        DiagnosticLevel, Document, Field, Line, RenderContext, Ui,
     },
 };
 

--- a/crates/ctx-cli/src/dispatch/parse/tests.rs
+++ b/crates/ctx-cli/src/dispatch/parse/tests.rs
@@ -276,12 +276,10 @@ fn clap_help_has_no_authored_trailing_cells_at_supported_widths() {
     for width in [32, 80, 100, 120] {
         for path in [&[][..], &["search"][..], &["sources"][..]] {
             let (plain, styled) = rendered_help(path, width);
-            assert!(
-                plain
-                    .split_whitespace()
-                    .collect::<String>()
-                    .contains("Usage:ctx")
-            );
+            assert!(plain
+                .split_whitespace()
+                .collect::<String>()
+                .contains("Usage:ctx"));
             assert!(
                 plain
                     .lines()

--- a/crates/ctx-cli/src/identity.rs
+++ b/crates/ctx-cli/src/identity.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use ctx_history_core::utc_now;
 use ctx_history_platform::platform_security::{
     establish_private_data_root, restrict_private_file, verify_private_directory,

--- a/crates/ctx-cli/src/mcp.rs
+++ b/crates/ctx-cli/src/mcp.rs
@@ -3,7 +3,7 @@ use std::{io, path::PathBuf};
 use anyhow::Result;
 use clap::{Args, Subcommand};
 use ctx_agent_application::mcp::{
-    McpTelemetry, McpUsagePort, ProductIdentity, serve_stdio as serve_mcp_stdio,
+    serve_stdio as serve_mcp_stdio, McpTelemetry, McpUsagePort, ProductIdentity,
 };
 use ctx_agent_integrations::{mcp::McpToolKind, tool_backend::ToolUsageFacts};
 use ctx_client_observability::local_usage::{McpInvocation, McpUsageRecorder};
@@ -12,7 +12,7 @@ use serde_json::Value;
 #[cfg(test)]
 use {
     ctx_agent_integrations::mcp::{
-        McpHandled, McpServerIdentity, McpUsage, RequestDescriptor, handle_protocol_message,
+        handle_protocol_message, McpHandled, McpServerIdentity, McpUsage, RequestDescriptor,
     },
     serde_json::json,
     std::path::Path,
@@ -198,8 +198,9 @@ pub(crate) fn render_tool_text_for_test(value: &Value) -> String {
 mod tests {
     use super::{query_events_for_test, render_tool_text_for_test};
     use ctx_history_capture::{
-        SourceBackedProviderRegistry, SourceBackedRouteSelection, provider_source_for_path,
-        refresh_source_backed_generation, register_landed_source_backed_route,
+        provider_source_for_path, refresh_source_backed_generation,
+        register_landed_source_backed_route, SourceBackedProviderRegistry,
+        SourceBackedRouteSelection,
     };
     use ctx_history_core::CaptureProvider;
     use ctx_history_index::WriterOptions;

--- a/crates/ctx-cli/src/net.rs
+++ b/crates/ctx-cli/src/net.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use sha2::{Digest, Sha256};
 use url::{Host, Url};
 
@@ -536,13 +536,11 @@ mod tests {
                 "{endpoint} should be rejected"
             );
         }
-        assert!(
-            validate_artifact_redirect(
-                &Url::parse("https://releases.example.com/file").unwrap(),
-                &Url::parse("http://releases.example.com/file").unwrap(),
-            )
-            .is_err()
-        );
+        assert!(validate_artifact_redirect(
+            &Url::parse("https://releases.example.com/file").unwrap(),
+            &Url::parse("http://releases.example.com/file").unwrap(),
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/ctx-cli/src/parser_prop_tests.rs
+++ b/crates/ctx-cli/src/parser_prop_tests.rs
@@ -1,4 +1,4 @@
-use crate::cli::{MAX_EVENT_WINDOW, MAX_SEARCH_LIMIT, parse_search_limit};
+use crate::cli::{parse_search_limit, MAX_EVENT_WINDOW, MAX_SEARCH_LIMIT};
 use crate::search_filters::parse_since_filter;
 use crate::transcript::normalize_uuid_prefix;
 use crate::value_parsers::parse_event_window_limit;

--- a/crates/ctx-cli/src/process_environment.rs
+++ b/crates/ctx-cli/src/process_environment.rs
@@ -135,12 +135,10 @@ mod tests {
             .env("CTX_UPGRADE_AUTO", "off");
         sanitize_release_authority_env(&mut command);
 
-        assert!(
-            command
-                .status()
-                .expect("run sanitized child process")
-                .success()
-        );
+        assert!(command
+            .status()
+            .expect("run sanitized child process")
+            .success());
         assert_eq!(
             fs::read_to_string(probe).expect("read detached descendant probe"),
             "sanitized:stable:off"
@@ -168,14 +166,12 @@ mod tests {
                 .stdin(Stdio::null())
                 .stdout(Stdio::null())
                 .stderr(Stdio::null());
-            assert!(
-                descendant
-                    .spawn()
-                    .expect("spawn detached descendant")
-                    .wait()
-                    .expect("wait for detached descendant")
-                    .success()
-            );
+            assert!(descendant
+                .spawn()
+                .expect("spawn detached descendant")
+                .wait()
+                .expect("wait for detached descendant")
+                .success());
             return;
         }
 

--- a/crates/ctx-cli/src/upgrade/command.rs
+++ b/crates/ctx-cli/src/upgrade/command.rs
@@ -1,16 +1,16 @@
 use std::path::PathBuf;
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use ctx_cli_presentation::upgrade::{
-    UpgradeArgs, UpgradeCommand, render_auto_mode, render_error, render_outcome,
+    render_auto_mode, render_error, render_outcome, UpgradeArgs, UpgradeCommand,
 };
 use ctx_upgrade_engine::{
-    HostedTransactionArgs, UpgradeOutcome, UpgradePolicy, run_hosted_transaction,
+    run_hosted_transaction, HostedTransactionArgs, UpgradeOutcome, UpgradePolicy,
 };
 
 use crate::{
     analytics::{
-        UpgradeChannel, UpgradeFailureKind, UpgradeStatus, UpgradeTelemetry, count_bucket,
+        count_bucket, UpgradeChannel, UpgradeFailureKind, UpgradeStatus, UpgradeTelemetry,
     },
     config::AppConfig,
     output::JsonOutputFormat,

--- a/crates/ctx-cli/src/upgrade/command/status.rs
+++ b/crates/ctx-cli/src/upgrade/command/status.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 
 use anyhow::Result;
 use ctx_upgrade_engine::{
-    ManagedInstallMarker, STATE_SCHEMA_VERSION, managed_install_marker_for_current_exe,
-    read_state_json,
+    managed_install_marker_for_current_exe, read_state_json, ManagedInstallMarker,
+    STATE_SCHEMA_VERSION,
 };
 use serde_json::json;
 

--- a/crates/ctx-cli/src/upgrade/config.rs
+++ b/crates/ctx-cli/src/upgrade/config.rs
@@ -119,7 +119,7 @@ fn replace_config_file(temporary: &Path, target: &Path) -> Result<()> {
 fn replace_config_file(temporary: &Path, target: &Path) -> Result<()> {
     use std::os::windows::ffi::OsStrExt as _;
     use windows_sys::Win32::Storage::FileSystem::{
-        MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
     };
 
     let temporary_wide = temporary

--- a/crates/ctx-cli/src/upgrade/ports.rs
+++ b/crates/ctx-cli/src/upgrade/ports.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use ctx_upgrade_engine::{
     AutomaticUpgradeObservation, AutomaticUpgradePolicyProvider, DaemonRestart, DaemonUpgradeLease,
     DaemonUpgradePort, ProductBuildIdentity, ReleaseProcessPort, ReleaseTransport,
@@ -15,8 +15,8 @@ use ctx_upgrade_engine::{
 
 use crate::{
     analytics::{
-        OperationCompletedV1, Outcome, PublicEventV1, UpgradeChannel, UpgradeFailureKind,
-        UpgradeMode, UpgradeOperation, UpgradeStatus, UpgradeTelemetry, count_bucket,
+        count_bucket, OperationCompletedV1, Outcome, PublicEventV1, UpgradeChannel,
+        UpgradeFailureKind, UpgradeMode, UpgradeOperation, UpgradeStatus, UpgradeTelemetry,
     },
     config::AppConfig,
 };


### PR DESCRIPTION
## Summary

- apply the repository-pinned Rust 1.97.1 rustfmt output to `ctx-cli`
- preserve donor commit `40b11ad05a518e6b89ed316560d1b25303c31eeb` exactly
- make no documentation, MCP capability, manifest, or unrelated source changes

## Verification

- `scripts/bazelw test //:rustfmt_check --config=ci` passed twice
- `cargo fmt --all -- --check` passed twice
- formatting exact base `14210158a8e5a41e75dec42c8debe6720a168a52` reproduced all 28 changed files and matched donor tree `fc7256b4b2aa7be2a5dc0c09e90876eb8e8fa56a` exactly
- `git diff --check origin/main...HEAD` passed
- worktree clean before push