### PR TITLE
fix(build): drop removed release audit fixture

### DIFF
--- a/tools/bazel/release_surface_tests.bzl
+++ b/tools/bazel/release_surface_tests.bzl
@@ -24,7 +24,6 @@ def release_surface_tests():
         srcs = ["scripts/tests/audit-release-binary-strings-test.sh"],
         data = [
             "scripts/check-release-binary-strings.sh",
-            "scripts/tests/fixtures/release-binary-strings/protocol-v1-local-runtime.txt",
             "scripts/tests/fixtures/release-binary-strings/removed-cloud-history.txt",
         ],
         tags = ["non-rust-action"],


### PR DESCRIPTION
## Summary

- remove an obsolete Bazel runfiles entry for a fixture deleted with its former positive assertion
- keep the active release binary denylist audit unchanged

## Validation

- `//:release_binary_string_audit_tests`
- forbidden-signature and neutral-vocabulary mutation contract
- `//:release_binary_compat_tests //:release_binary_string_audit_tests //:release_source_surface_audit_tests //:test_tier_inventory_check`
- `git diff --check`