### PR TITLE
fix(history): omit DeepSeek activity from private content

### DIFF
--- a/crates/ctx-deepseek-harness-qualification/tests/deepseek_harness.rs
+++ b/crates/ctx-deepseek-harness-qualification/tests/deepseek_harness.rs
@@ -835,6 +835,7 @@ fn private_reasoning_and_image_only_messages_are_retained_but_not_searchable() {
     assert!(omitted.iter().all(|record| {
         record.core_record.content.normalized_body.is_none()
             && record.core_record.content.structured_content.is_none()
+            && record.core_record.content.activity.is_none()
             && format!("{:?}", record.core_record.content.policy_status).starts_with("Omitted")
     }));
     let encoded = serde_json::to_string(

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/deepseek_harness.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/deepseek_harness.rs
@@ -46,7 +46,7 @@ use ctx_history_jsonl::{JsonlFamilyExecutionIo, JsonlPhysicalEncoding};
 pub(crate) const TREE_SOURCE_FORMAT: &str = "deepseek_harness_session_jsonl_tree";
 pub(crate) const EXPLICIT_SOURCE_FORMAT: &str = "deepseek_harness_session_jsonl";
 
-const PARSER_REVISION: &str = "deepseek-harness-native-jsonl-v2-core-activity";
+const PARSER_REVISION: &str = "deepseek-harness-native-jsonl-v3-selected-core-activity";
 const EVENT_IDENTITY_REVISION: &str = "deepseek-harness-sequence-v1";
 
 #[derive(Debug, Clone, Copy)]
@@ -398,23 +398,6 @@ impl<R: JsonlProviderRuntime> DeepSeekHarnessSemanticExecutor<R> {
             record.parent_session_id =
                 Some(session_identity(&self.source, parent).map_err(contract)?);
         }
-        let mut facts = Vec::new();
-        if let Some(cwd) = &self.binding.cwd {
-            facts.push(ProviderDeclaredFact {
-                kind: LiteralFactKind::SessionCwd,
-                value: cwd.clone(),
-            });
-        }
-        facts.extend(exact_file_references(&event.value).map_err(contract)?);
-        if !facts.is_empty() {
-            record.content.activity = Some(CoreActivity {
-                revision: CORE_ACTIVITY_REVISION,
-                provider_call_id: None,
-                invocation: None,
-                result: None,
-                facts,
-            });
-        }
         if let Some(reason) = event.content_omission_reason {
             record.content.policy_status = CoreContentPolicyStatus::Omitted {
                 reason: reason.to_owned(),
@@ -422,6 +405,23 @@ impl<R: JsonlProviderRuntime> DeepSeekHarnessSemanticExecutor<R> {
             record.content.normalized_body = None;
             record.content.structured_content = None;
         } else {
+            let mut facts = Vec::new();
+            if let Some(cwd) = &self.binding.cwd {
+                facts.push(ProviderDeclaredFact {
+                    kind: LiteralFactKind::SessionCwd,
+                    value: cwd.clone(),
+                });
+            }
+            facts.extend(exact_file_references(&event.value).map_err(contract)?);
+            if !facts.is_empty() {
+                record.content.activity = Some(CoreActivity {
+                    revision: CORE_ACTIVITY_REVISION,
+                    provider_call_id: None,
+                    invocation: None,
+                    result: None,
+                    facts,
+                });
+            }
             record.content.structured_content = Some(event.value);
             record
                 .content


### PR DESCRIPTION
Summary:
- create DeepSeek provider facts and CoreActivity only for selected content
- keep omitted private reasoning and image-only records free of body, structured content, facts, and activity
- bump the DeepSeek parser revision so existing generations are replaced

Validation:
- private/image omission regression
- ordinary raw and Zstd import/search/show/citation/no-op/append/resume
- shared provider, native parser, Core, and search-projection unit tests
- strict Clippy with warnings denied
- cargo fmt and git diff checks
- fresh review: SHIP, P0-P2 none

Known unrelated status:
- automatic_default_and_dsh_home_discovery_keep_parent_and_child_independent remains red with the pre-existing 10-parent/zero-child signature; no scheduler, child, or daemon path is present in this two-file diff.