### PR TITLE
Fix scoped Clippy warnings

### DIFF
--- a/crates/ctx-cli/tests/stats.rs
+++ b/crates/ctx-cli/tests/stats.rs
@@ -31,12 +31,9 @@ fn insert_row(
     operation: &str,
     value_class: &str,
     context_coverage: &str,
-    calls: i64,
-    results: i64,
-    output_bytes: i64,
-    context_bytes: i64,
-    matched_bytes: i64,
+    metrics: [i64; 5],
 ) {
+    let [calls, results, output_bytes, context_bytes, matched_bytes] = metrics;
     connection
         .execute(
             "INSERT INTO daily_usage (
@@ -148,11 +145,7 @@ fn definition_two_math_uses_only_complete_search_context_and_spec_coefficients()
         "search",
         "result_bearing",
         "complete",
-        1,
-        2,
-        60,
-        19,
-        59,
+        [1, 2, 60, 19, 59],
     );
     insert_row(
         &connection,
@@ -161,11 +154,7 @@ fn definition_two_math_uses_only_complete_search_context_and_spec_coefficients()
         "search",
         "result_bearing",
         "unavailable",
-        1,
-        1,
-        700,
-        0,
-        0,
+        [1, 1, 700, 0, 0],
     );
     drop(connection);
 
@@ -255,11 +244,7 @@ fn definitions_are_reported_separately_and_definition_one_never_drives_estimates
         "search",
         "result_bearing",
         "not_applicable",
-        3,
-        6,
-        1_500,
-        0,
-        0,
+        [3, 6, 1_500, 0, 0],
     );
     insert_row(
         &connection,
@@ -268,11 +253,7 @@ fn definitions_are_reported_separately_and_definition_one_never_drives_estimates
         "doctor",
         "not_applicable",
         "not_applicable",
-        1,
-        0,
-        0,
-        0,
-        0,
+        [1, 0, 0, 0, 0],
     );
     insert_row(
         &connection,
@@ -281,11 +262,7 @@ fn definitions_are_reported_separately_and_definition_one_never_drives_estimates
         "doctor",
         "not_applicable",
         "not_applicable",
-        1,
-        0,
-        1,
-        0,
-        0,
+        [1, 0, 1, 0, 0],
     );
     drop(connection);
 
@@ -323,11 +300,7 @@ fn human_stats_label_measured_and_estimated_sections_without_time_claims() {
         "search",
         "result_bearing",
         "complete",
-        1,
-        1,
-        20,
-        20,
-        100,
+        [1, 1, 20, 20, 100],
     );
     drop(connection);
 

--- a/crates/ctx-companion-bridge/src/tests.rs
+++ b/crates/ctx-companion-bridge/src/tests.rs
@@ -552,15 +552,19 @@ fn control_input_and_output_bounds_fail_closed() {
 
 #[test]
 fn admission_and_captured_lifetime_bounds_are_independent() {
-    let mut limits = LimitConfiguration::default();
-    limits.admission_wait = Duration::ZERO;
+    let limits = LimitConfiguration {
+        admission_wait: Duration::ZERO,
+        ..LimitConfiguration::default()
+    };
     assert!(matches!(
         BridgeLimits::new(limits),
         Err(BridgeError::Limit("admission wait"))
     ));
 
-    let mut limits = LimitConfiguration::default();
-    limits.captured_wall_time = Duration::ZERO;
+    let limits = LimitConfiguration {
+        captured_wall_time: Duration::ZERO,
+        ..LimitConfiguration::default()
+    };
     assert!(matches!(
         BridgeLimits::new(limits),
         Err(BridgeError::Limit("captured wall time"))

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path.rs
@@ -17,8 +17,6 @@ use super::{
     source::session_columns,
 };
 
-const CRUSH_NATIVE_MAX_EVENT_TOUCHES: usize = 3_000;
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct CrushNativeFrontier {
     after_rowid: Option<i64>,

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path/query.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path/query.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use super::super::{
     capture::CRUSH_SQLITE_VALUE_OVERHEAD_BYTES,
-    projection::{decode_message_child, decode_session_at, optional_text},
+    projection::{decode_message_child, decode_session_at},
     source::{
         message_projection, message_session_join, optional_session_column, retained_length_expr,
         session_projection,
@@ -179,38 +179,6 @@ pub(super) fn load_message_batch(
         loaded.insert(rowid, decoded);
     }
     Ok(loaded)
-}
-
-pub(super) fn load_session_parents(
-    connection: &Connection,
-    columns: &std::collections::BTreeSet<String>,
-) -> Result<HashMap<String, Option<String>>> {
-    const PAGE: usize = 256;
-    let parent = optional_session_column(columns, "parent_session_id");
-    let mut after = 0_i64;
-    let mut parents = HashMap::new();
-    loop {
-        let mut statement = connection.prepare(&format!(
-            "select s.rowid, s.id, {parent} from sessions s \
-             where s.rowid > ?1 order by s.rowid limit {PAGE}"
-        ))?;
-        let page = statement
-            .query_map([after], |row| {
-                Ok((row.get::<_, i64>(0)?, raw_sqlite_values_offset(row, 1, 2)?))
-            })?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
-        if page.is_empty() {
-            break;
-        }
-        for (rowid, values) in page {
-            after = rowid;
-            let NativeSqliteValue::Text(id) = &values[0] else {
-                continue;
-            };
-            parents.insert(id.clone(), optional_text(&values, 1)?);
-        }
-    }
-    Ok(parents)
 }
 
 fn raw_sqlite_values_offset(

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path/source_backed.rs
@@ -5,7 +5,7 @@
 //! and bounded complete-record projection.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     ffi::OsString,
     path::{Path, PathBuf},
     sync::Arc,

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/projection.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/projection.rs
@@ -55,10 +55,8 @@ pub(super) struct CrushMessageProjection {
 
 pub(super) struct CrushOutputProjection {
     pub(super) status: Option<String>,
-    pub(super) exit_code: Option<i32>,
     pub(super) duration_ms: Option<u64>,
     pub(super) call_id: Option<String>,
-    pub(super) tool_name: Option<String>,
 }
 
 pub(super) struct CrushChildMessageRow {
@@ -257,13 +255,9 @@ fn crush_output_projection(parts: &Value) -> CrushOutputProjection {
         status: (!aggregate.status_ambiguous)
             .then_some(aggregate.status)
             .flatten(),
-        exit_code: aggregate.exit_code,
         duration_ms: aggregate.duration_ms,
         call_id: (!aggregate.linkage_ambiguous)
             .then_some(aggregate.call_id)
-            .flatten(),
-        tool_name: (!aggregate.linkage_ambiguous)
-            .then_some(aggregate.tool_name)
             .flatten(),
     }
 }
@@ -272,7 +266,6 @@ fn crush_output_projection(parts: &Value) -> CrushOutputProjection {
 struct CrushResultAggregate {
     status: Option<String>,
     status_ambiguous: bool,
-    exit_code: Option<i32>,
     duration_ms: Option<u64>,
     call_id: Option<String>,
     tool_name: Option<String>,
@@ -329,14 +322,6 @@ fn crush_collect_result_literals(value: &Value, aggregate: &mut CrushResultAggre
     let Some(object) = value.as_object() else {
         return;
     };
-    if let Some(code) = object
-        .get("exit_code")
-        .or_else(|| object.get("exitCode"))
-        .and_then(Value::as_i64)
-        .and_then(|code| i32::try_from(code).ok())
-    {
-        aggregate.exit_code = Some(code);
-    }
     if aggregate.duration_ms.is_none() {
         aggregate.duration_ms = ["duration_ms", "durationMs"]
             .iter()

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/tests.rs
@@ -47,8 +47,21 @@ fn projection_keeps_complete_results_and_exact_statuses() -> Result<()> {
         assert_eq!(projection.complete_text.as_deref(), Some(body.as_str()));
         assert_eq!(output.status.as_deref(), status);
         assert_eq!(output.call_id.as_deref(), Some("call-1"));
-        assert_eq!(output.tool_name.as_deref(), Some("shell"));
     }
+
+    let ambiguous_tool_name = crush_message(json!([
+        {"type": "tool_result", "data": {
+            "content": "first body", "tool_call_id": "call-1", "name": "shell"
+        }},
+        {"type": "tool_result", "data": {
+            "content": "second body", "tool_call_id": "call-1", "name": "editor"
+        }}
+    ]));
+    let projection = match project_message(&ambiguous_tool_name, Some(&crush_session()))? {
+        CrushRecordProjection::Message(projection) => projection,
+        CrushRecordProjection::Rejection => panic!("complete tool results were rejected"),
+    };
+    assert!(projection.output.unwrap().call_id.is_none());
 
     let status_only = crush_message(json!([{
         "type": "tool_result",

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/shelley/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/shelley/native_path/source_backed.rs
@@ -64,7 +64,6 @@ const SHELLEY_NATIVE_SESSION_NAMESPACE: &str = "shelley.conversation";
 const SHELLEY_LOGICAL_EVENT_KIND: &str = "shelley-message";
 const SHELLEY_NATIVE_MESSAGE_NAMESPACE: &str = "shelley.message";
 const SHELLEY_CERTIFIED_STREAM_DOMAIN: &[u8] = b"ctx-shelley-source-backed-stream-v1\0";
-const SHELLEY_LINEAGE_LABEL_MAX_CHARS: usize = 256;
 const SQLITE_SOURCE_INVALID_REASON: &str =
     "Shelley SQLite source must have an authorized parent and database leaf";
 
@@ -87,8 +86,6 @@ pub(crate) enum ShelleySourceBackedError {
     CountOverflow,
     #[error("Shelley source-backed projection produced no bounded lexical body")]
     MissingLexicalBody,
-    #[error("Shelley source-backed conversation lineage is invalid: {0}")]
-    InvalidLineage(String),
     #[error("Shelley source-backed result shape is invalid: {0}")]
     InvalidResultShape(String),
 }
@@ -404,7 +401,6 @@ impl ShelleySourceBackedScan {
                         Err(
                             error @ (ShelleySourceBackedError::Projection(_)
                             | ShelleySourceBackedError::MissingLexicalBody
-                            | ShelleySourceBackedError::InvalidLineage(_)
                             | ShelleySourceBackedError::InvalidResultShape(_)),
                         ) => {
                             self.hash_record(
@@ -623,13 +619,6 @@ fn open_root_authorized_snapshot_with_hook(
         .busy_timeout(std::time::Duration::from_secs(5))
         .map_err(CaptureError::from)?;
     Ok((source_root, sqlite_snapshot))
-}
-
-fn shelley_lineage_label(provider_session_id: &str) -> String {
-    provider_session_id
-        .chars()
-        .take(SHELLEY_LINEAGE_LABEL_MAX_CHARS)
-        .collect()
 }
 
 fn build_record(


### PR DESCRIPTION
Summary:
- initialize companion limit fixtures directly
- group CLI stats fixture metrics without changing values or API behavior
- remove stale private SQLite inventory projection residue

Validation:
- unsuppressed Clippy with -D warnings for companion and SQLite packages and the CLI stats target
- owning Cargo tests: companion 24 passed / 1 terminal-only ignored; SQLite 61 passed; CLI stats 5 passed
- owning Bazel tests: all 3 passed
- cargo fmt check and git diff check
- fresh review: SHIP, no P0-P2 findings

No release or candidate work.