### PR TITLE
test(history): use Claude projects root fixture

### DIFF
--- a/crates/ctx-history-capture-composition/src/source_backed/tests/claude_cursor.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/tests/claude_cursor.rs
@@ -228,7 +228,7 @@ fn claude_message(kind: &str, uuid: &str, session_id: &str, text: &str) -> Value
 #[test]
 fn claude_route_publishes_cold_append_and_recovers_from_carried_checkpoint() {
     let temp = crate::test_support_paths::tempdir().unwrap();
-    let projects = temp.path().join("claude-projects");
+    let projects = temp.path().join("projects");
     let native_session_id = "neutral-claude-session";
     let transcript = projects
         .join("project")


### PR DESCRIPTION
## Summary
- correct the Claude lifecycle fixture basename from `claude-projects` to the supported `projects` root
- keep the change test-only and preserve the reviewed `fe472a341` patch exactly

## Validation
- exact Claude lifecycle regression: 3/3 uncached passes
- full capture-composition units: 134/134 uncached passes
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Fresh review: SHIP; no P0-P2 findings.