### PR TITLE
fix(import): scope selected source refreshes

### DIFF
--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration.rs
@@ -121,6 +121,23 @@ fn wait_for_core_generation(temp: &TempDir, generation: &str) -> Value {
     }
 }
 
+fn wait_for_initial_source_refresh(temp: &TempDir) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let status = json_output(ctx(temp).args(["status", "--format=json"]));
+        if status["refresh"]["status"] == "ready"
+            && status["refresh"]["published_generation"].is_string()
+        {
+            return status;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for the daemon's initial source refresh: {status:#}"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
 fn published_generation(report: &Value) -> String {
     report["sources"][0]["published_generation"]
         .as_str()
@@ -1141,10 +1158,11 @@ fn write_valid_explicit_custom_source(path: &Path, text: &str) {
 }
 
 #[test]
-fn explicit_import_reports_requested_route_failure_when_another_cold_route_publishes() {
+fn explicit_import_failure_does_not_refresh_an_unrelated_cold_route() {
     let temp = tempdir();
-    write_codex_setup_session(&temp);
     let _daemon = start_full_source_refresh_daemon(&temp);
+    wait_for_initial_source_refresh(&temp);
+    write_codex_setup_session(&temp);
     let fixture = temp.path().join("cold-explicit-failure.jsonl");
     fs::write(&fixture, b"").unwrap();
 
@@ -1161,41 +1179,11 @@ fn explicit_import_reports_requested_route_failure_when_another_cold_route_publi
             "json",
         ])
         .assert()
-        .success()
+        .failure()
         .get_output()
         .clone();
-    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(
-        report["outcome"], "completed_with_source_failures",
-        "{report:#}"
-    );
-    assert_eq!(report["failure_scope"], "source", "{report:#}");
-    assert_eq!(report["failure_type"], "source_failure", "{report:#}");
-    assert!(
-        report["totals"].get("imported_sources").is_none(),
-        "{report:#}"
-    );
-    assert_eq!(report["totals"]["failed_sources"], 1, "{report:#}");
-    assert!(report["totals"]["current_indexed_documents"]
-        .as_u64()
-        .is_some_and(|count| count >= 1));
-
-    let source = &report["sources"][0];
-    assert_eq!(source["status"], "failure", "{source:#}");
-    assert_eq!(source["failure_scope"], "source", "{source:#}");
-    assert_eq!(source["failure_type"], "other", "{source:#}");
-    assert_eq!(source["source_failure_class"], "unreadable", "{source:#}");
-    assert_eq!(source["carried_forward"], false, "{source:#}");
-    assert_eq!(
-        source["daemon_request_metadata"]["operation"], "import",
-        "{source:#}"
-    );
-    assert_eq!(source["source_failure_total"], 1, "{source:#}");
-    assert!(source["successful_routes"]
-        .as_u64()
-        .is_some_and(|routes| routes >= 1));
-    assert!(source["source_identity"].is_string(), "{source:#}");
-    assert_eq!(source["detail"], source["error"], "{source:#}");
+    assert!(output.stdout.is_empty());
+    assert_eq!(provider_core_counts(&data_root(&temp), "codex"), (0, 0));
 
     let stderr = String::from_utf8(output.stderr).unwrap();
     let terminal_progress = stderr
@@ -1204,11 +1192,12 @@ fn explicit_import_reports_requested_route_failure_when_another_cold_route_publi
         .find(|event| event["done"] == true)
         .expect("terminal explicit-import progress event");
     assert_eq!(terminal_progress["operation"], "import", "{stderr}");
-    assert_eq!(terminal_progress["phase"], "published", "{stderr}");
+    assert_eq!(terminal_progress["phase"], "failed", "{stderr}");
     assert_eq!(
-        terminal_progress["structured_outcome"]["code"], "completed_with_source_failures",
+        terminal_progress["structured_outcome"]["code"], "malformed_source",
         "{stderr}"
     );
+    assert!(stderr.contains(fixture.to_str().unwrap()), "{stderr}");
 }
 
 #[path = "import_orchestration/additional.rs"]

--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration/additional.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration/additional.rs
@@ -20,6 +20,7 @@ fn explicit_import_reports_warm_carried_route_failure() {
     ]));
     assert_eq!(first["outcome"], "success", "{first:#}");
     assert_eq!(provider_core_counts(&data_root(&temp), "custom"), (1, 1));
+    let first_generation = published_generation(&first);
 
     fs::write(&fixture, b"").unwrap();
     let carried = json_output(ctx(&temp).args([
@@ -54,12 +55,8 @@ fn explicit_import_reports_warm_carried_route_failure() {
     assert_eq!(source["source_failure_total"], 1, "{source:#}");
     assert_eq!(source["source_failure_class"], "unreadable", "{source:#}");
     assert_eq!(source["carried_forward"], true, "{source:#}");
-    assert!(
-        source["successful_routes"]
-            .as_u64()
-            .is_some_and(|routes| routes > 0),
-        "{source:#}"
-    );
+    assert_eq!(source["successful_routes"], 0, "{source:#}");
+    assert_eq!(published_generation(&carried), first_generation);
     assert!(source["source_identity"].is_string(), "{source:#}");
     assert_eq!(provider_core_counts(&data_root(&temp), "custom"), (1, 1));
 }
@@ -89,13 +86,14 @@ fn all_invalid_custom_source_fails_with_unrelated_history_then_refreshes_after_f
         "none",
     ]));
     assert_eq!(retained["outcome"], "success", "{retained:#}");
+    let retained_generation = published_generation(&retained);
     let retained_documents = retained["totals"]["current_indexed_documents"]
         .as_u64()
         .filter(|count| *count > 0)
         .expect("retained Codex fixture documents");
     fs::write(&fixture, records(r#""invalid""#)).unwrap();
 
-    let empty = failure_json_output(ctx(&temp).args([
+    let failure = failure_stderr(ctx(&temp).args([
         "import",
         "--input-format",
         "ctx-history-jsonl-v1",
@@ -106,25 +104,13 @@ fn all_invalid_custom_source_fails_with_unrelated_history_then_refreshes_after_f
         "--progress",
         "none",
     ]));
-    assert_eq!(empty["outcome"], "failure", "{empty:#}");
-    assert_eq!(empty["failure_scope"], "record", "{empty:#}");
-    assert_eq!(empty["failure_type"], "record_rejection", "{empty:#}");
-    assert_eq!(empty["sources"][0]["status"], "partial", "{empty:#}");
-    assert_eq!(
-        empty["sources"][0]["current_indexed_documents"], retained_documents,
-        "{empty:#}"
-    );
     assert!(
-        empty["sources"][0]["current_retained_records"]
-            .as_u64()
-            .is_some_and(|records| records > 0),
-        "generation-wide retained history must not mask this failed request: {empty:#}"
+        failure.contains("No usable history was imported"),
+        "{failure}"
     );
-    let empty_generation = published_generation(&empty);
-    let empty_status = wait_for_core_generation(&temp, &empty_generation);
     assert_eq!(
-        empty_status["lexical"]["indexed_documents"], retained_documents,
-        "{empty_status:#}"
+        provider_core_counts(&data_root(&temp), "codex").1,
+        retained_documents as usize
     );
     assert_eq!(provider_core_counts(&data_root(&temp), "custom"), (0, 0));
 
@@ -142,7 +128,7 @@ fn all_invalid_custom_source_fails_with_unrelated_history_then_refreshes_after_f
     ]));
     assert_eq!(retry["outcome"], "success", "{retry:#}");
     let generation = published_generation(&retry);
-    assert_ne!(generation, empty_generation);
+    assert_ne!(generation, retained_generation);
     let status = wait_for_core_generation(&temp, &generation);
     assert_eq!(
         status["lexical"]["indexed_documents"],
@@ -227,6 +213,68 @@ fn import_all_discovers_and_imports_providers_together() {
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains(r#""type":"ctx_progress""#), "{stderr}");
     assert!(stderr.contains(r#""phase":"published""#), "{stderr}");
+}
+
+#[test]
+fn selected_provider_and_exact_path_ignore_unrelated_discoverable_sources() {
+    for exact_path in [false, true] {
+        let temp = tempdir();
+        let daemon = start_full_source_refresh_daemon(&temp);
+        wait_for_initial_source_refresh(&temp);
+        write_codex_setup_session(&temp);
+        install_default_pi_fixture(&temp, "unselected pi import scope oracle");
+        let opencode_dir = temp.path().join(".local/share/opencode");
+        fs::create_dir_all(&opencode_dir).unwrap();
+        fs::write(opencode_dir.join("opencode.db"), b"not sqlite").unwrap();
+        let codex_path = temp.path().join(".codex/sessions");
+        let discovered = json_output(ctx(&temp).args(["sources", "--format=json"]));
+        for provider in ["codex", "pi", "opencode"] {
+            let source = discovered["sources"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|source| source["provider"] == provider)
+                .unwrap_or_else(|| {
+                    panic!("missing discoverable {provider} source: {discovered:#}")
+                });
+            assert_eq!(source["status"], "available", "{provider}: {discovered:#}");
+            assert_eq!(source["importable"], true, "{provider}: {discovered:#}");
+        }
+        for provider in ["codex", "pi", "opencode"] {
+            assert_eq!(
+                provider_core_counts(&data_root(&temp), provider),
+                (0, 0),
+                "the daemon's initial generation must predate the selected-import fixtures"
+            );
+        }
+
+        let mut command = ctx(&temp);
+        command.args(["import", "--provider", "codex"]);
+        if exact_path {
+            command.args(["--path", codex_path.to_str().unwrap()]);
+        }
+        let imported = json_output(command.args(["--format=json", "--progress", "none"]));
+        let source = if exact_path {
+            let source =
+                assert_explicit_source_publication(&imported, "codex", "codex_session_jsonl_tree");
+            assert_eq!(source["path"], codex_path.to_str().unwrap(), "{imported:#}");
+            assert!(source["route_identity"].is_string(), "{imported:#}");
+            source
+        } else {
+            assert_authoritative_provider_publication(&imported)
+        };
+
+        assert_eq!(source["scanned_routes"], 1, "{imported:#}");
+        assert_eq!(source["successful_routes"], 1, "{imported:#}");
+        assert_eq!(source["source_failure_total"], 0, "{imported:#}");
+        assert_eq!(
+            imported["totals"]["current_sources_with_rejections"], 0,
+            "{imported:#}"
+        );
+
+        assert!(!published_generation(&imported).is_empty(), "{imported:#}");
+        drop(daemon);
+    }
 }
 
 #[test]

--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration/relocation.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration/relocation.rs
@@ -126,14 +126,9 @@ fn failed_explicit_replacement_preserves_retained_relocation_witness() {
         failed["outcome"], "completed_with_source_failures",
         "{failed:#}"
     );
-    assert!(
-        failed["sources"][0]["successful_routes"]
-            .as_u64()
-            .is_some_and(|routes| routes > 0),
-        "{failed:#}"
-    );
+    assert_eq!(failed["sources"][0]["successful_routes"], 0, "{failed:#}");
     assert_eq!(failed["sources"][0]["carried_forward"], false, "{failed:#}");
-    assert_ne!(published_generation(&failed), first_generation);
+    assert_eq!(published_generation(&failed), first_generation);
 
     let retained =
         ctx_history_index::VerifiedIndex::open(data_root(&temp).join("search").join("lexical"))

--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle/additional.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle/additional.rs
@@ -528,6 +528,20 @@ fn foreground_import_returns_at_ready_core_generation() {
         .success();
 
     let core_daemon = start_core_only_source_refresh_daemon(&temp);
+    let initial_refresh_deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let status = json_output(ctx_from_binary(&temp, &binary).args(["status", "--format=json"]));
+        if status["refresh"]["status"] == "ready"
+            && status["refresh"]["published_generation"].is_string()
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < initial_refresh_deadline,
+            "timed out waiting for the daemon's initial Core refresh: {status:#}"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
     let import = json_output(
         ctx_from_binary(&temp, &binary)
             .args([

--- a/crates/ctx-cli/src/commands/import/application_adapter.rs
+++ b/crates/ctx-cli/src/commands/import/application_adapter.rs
@@ -3,9 +3,11 @@ use std::path::Path;
 use anyhow::Result;
 use ctx_history_capture::{source_backed_source_failure_identity, ProviderSource};
 use ctx_history_core::CaptureProvider;
-use ctx_history_ingest_application::{HistorySourcePluginSource, IngestPublication};
+use ctx_history_ingest_application::{
+    HistorySourcePluginSource, IngestPublication, IngestRefreshSelection,
+};
 use ctx_history_platform::platform_security::establish_private_data_root;
-use ctx_history_refresh::{ExplicitSourceCatalogAuthority, ExplicitSourceCatalogUpsert};
+use ctx_history_refresh::ExplicitSourceCatalogUpsert;
 
 use crate::{
     history_source_plugins::prepare_source_backed_history_source, progress::ProgressReporter,
@@ -77,25 +79,32 @@ impl ctx_history_cli::ImportApplicationPort for CliImportHost {
         &mut self,
         data_root: &Path,
         _config: ctx_history_cli::HistoryCliConfig,
-        admission: Option<&ExplicitSourceCatalogAuthority>,
+        selection: IngestRefreshSelection<'_>,
         no_daemon: bool,
         progress: &mut ProgressReporter<'_>,
     ) -> Result<IngestPublication> {
-        let request = admission.map_or(ImportCoreRefreshRequest::Automatic, |authority| {
-            ImportCoreRefreshRequest::ExplicitCatalog(authority)
-        });
+        let request = match selection {
+            IngestRefreshSelection::AllAutomatic => ImportCoreRefreshRequest::Automatic,
+            IngestRefreshSelection::AutomaticProvider(provider) => {
+                ImportCoreRefreshRequest::AutomaticProvider(provider)
+            }
+            IngestRefreshSelection::ExplicitCatalog(authority) => {
+                ImportCoreRefreshRequest::ExplicitCatalog(authority)
+            }
+        };
         let refresh = wait_for_import_core_refresh(data_root, no_daemon, request, progress)?;
         let pinned_generation = refresh.pin.generation_id().to_owned();
-        let policy_schema_hash = admission.is_none().then(|| {
-            refresh
-                .pin
-                .verified_index()
-                .manifest()
-                .policy_schema_hash
-                .clone()
-        });
-        let catalog_content = match (admission, refresh.receipt.as_ref()) {
-            (Some(authority), Some(receipt)) => authority
+        let policy_schema_hash = (!matches!(selection, IngestRefreshSelection::ExplicitCatalog(_)))
+            .then(|| {
+                refresh
+                    .pin
+                    .verified_index()
+                    .manifest()
+                    .policy_schema_hash
+                    .clone()
+            });
+        let catalog_content = match (selection, refresh.receipt.as_ref()) {
+            (IngestRefreshSelection::ExplicitCatalog(authority), Some(receipt)) => authority
                 .route_lineages()
                 .into_iter()
                 .map(|lineage| {

--- a/crates/ctx-cli/src/commands/import/core_refresh.rs
+++ b/crates/ctx-cli/src/commands/import/core_refresh.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
+use ctx_history_core::CaptureProvider;
+use ctx_history_refresh::SourceBackedRefreshSelector;
 
 use crate::{
     progress::ProgressReporter,
@@ -14,6 +16,7 @@ use super::ExplicitSourceCatalogAuthority;
 
 pub(super) enum ImportCoreRefreshRequest<'a> {
     Automatic,
+    AutomaticProvider(CaptureProvider),
     ExplicitCatalog(&'a ExplicitSourceCatalogAuthority),
 }
 
@@ -29,26 +32,25 @@ pub(super) fn wait_for_import_core_refresh(
     let mut report_progress = |update: &crate::semantic::RefreshStatus| {
         progress.source_refresh(update).map_err(anyhow::Error::new)
     };
-    let refresh = match request {
-        ImportCoreRefreshRequest::Automatic => {
-            coordinate_import_source_backed_refresh_with_progress(
-                data_root,
-                SourceBackedRefreshMode::Wait,
-                None,
-                !no_daemon,
-                &mut report_progress,
-            )
-        }
-        ImportCoreRefreshRequest::ExplicitCatalog(authority) => {
-            coordinate_import_source_backed_refresh_with_progress(
-                data_root,
-                SourceBackedRefreshMode::Wait,
-                Some(authority),
-                !no_daemon,
-                &mut report_progress,
-            )
-        }
-    }
+    let (selector, explicit_source_catalog) = match request {
+        ImportCoreRefreshRequest::Automatic => (SourceBackedRefreshSelector::AllAutomatic, None),
+        ImportCoreRefreshRequest::AutomaticProvider(provider) => (
+            SourceBackedRefreshSelector::AutomaticProvider(provider),
+            None,
+        ),
+        ImportCoreRefreshRequest::ExplicitCatalog(authority) => (
+            SourceBackedRefreshSelector::ExplicitCatalog,
+            Some(authority),
+        ),
+    };
+    let refresh = coordinate_import_source_backed_refresh_with_progress(
+        data_root,
+        SourceBackedRefreshMode::Wait,
+        selector,
+        explicit_source_catalog,
+        !no_daemon,
+        &mut report_progress,
+    )
     .context("publish provider inputs through the Core refresh engine")?;
 
     let receipt = refresh

--- a/crates/ctx-daemon-cli/src/source_backed_refresh_coordinator.rs
+++ b/crates/ctx-daemon-cli/src/source_backed_refresh_coordinator.rs
@@ -9,7 +9,7 @@ pub use ctx_daemon_service::{
     pin_active_verified_generation, published_explicit_source_relocation_authority,
     PinnedSourceBackedGeneration, RefreshStatus, SourceBackedRefreshDaemonUnavailable,
     SourceBackedRefreshMode, SourceBackedRefreshObservation, SourceBackedRefreshPendingPublication,
-    SourceBackedRefreshTerminalError,
+    SourceBackedRefreshSelector, SourceBackedRefreshTerminalError,
 };
 pub use ctx_history_refresh::{open_verified_index, verified_generation_is_query_ready};
 
@@ -49,6 +49,7 @@ pub fn coordinate_setup_source_backed_refresh_with_progress(
 pub fn coordinate_import_source_backed_refresh_with_progress(
     data_root: &Path,
     mode: SourceBackedRefreshMode,
+    selector: SourceBackedRefreshSelector,
     explicit_source_catalog: Option<&ExplicitSourceCatalogAuthority>,
     allow_daemon_autostart: bool,
     report_progress: &mut dyn FnMut(&RefreshStatus) -> Result<()>,
@@ -57,6 +58,7 @@ pub fn coordinate_import_source_backed_refresh_with_progress(
         &AVAILABILITY,
         data_root,
         mode,
+        selector,
         explicit_source_catalog,
         allow_daemon_autostart,
         report_progress,

--- a/crates/ctx-daemon-service/src/lib.rs
+++ b/crates/ctx-daemon-service/src/lib.rs
@@ -86,7 +86,7 @@ pub use source_backed_refresh_coordinator::{
     published_explicit_source_relocation_authority, PinnedSourceBackedGeneration, RefreshStatus,
     SourceBackedCurrentSourceProgress, SourceBackedRefreshDaemonUnavailable,
     SourceBackedRefreshMode, SourceBackedRefreshObservation, SourceBackedRefreshPendingPublication,
-    SourceBackedRefreshTerminalError,
+    SourceBackedRefreshSelector, SourceBackedRefreshTerminalError,
 };
 
 #[cfg(feature = "test-support")]

--- a/crates/ctx-daemon-service/src/source_backed_refresh_adapter/wire.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_adapter/wire.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use ctx_history_index::SourceRouteIdentity;
 use ctx_history_refresh::{
     AdmissionResponseBarrier, ExplicitSourceCatalogAuthority, RefreshEngine, RefreshOperation,
-    RefreshScope, RefreshStatus, RefreshSubmission,
+    RefreshScope, RefreshStatus, RefreshSubmission, SourceBackedRefreshSelector,
 };
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -143,17 +143,41 @@ fn refresh_submission(request: &Value) -> Result<RefreshSubmission> {
         bail!("daemon source refresh trigger does not match its operation");
     }
     let explicit_catalog = request.get("explicit_source_catalog");
-    match (operation, mode, explicit_catalog) {
-        (RefreshOperation::Refresh, _, Some(_)) => {
-            bail!("refresh operation cannot carry explicit source catalog authority")
+    let has_typed_selector = request.get("refresh_selector").is_some();
+    let selector = match request.get("refresh_selector") {
+        Some(value) => SourceBackedRefreshSelector::from_json(value)
+            .context("parse daemon source refresh selector")?,
+        None => match (operation, explicit_catalog.is_some()) {
+            (RefreshOperation::Refresh, false) => SourceBackedRefreshSelector::AllAutomatic,
+            // Legacy explicit catalogs were all-route import overlays, not
+            // exact-path selectors. Only the typed selector opts into scoped
+            // admission.
+            (RefreshOperation::Import, true) => SourceBackedRefreshSelector::AllAutomatic,
+            _ => bail!("daemon source refresh selector is missing"),
+        },
+    };
+    if operation == RefreshOperation::Import && mode == "background" {
+        bail!("import operation requires daemon refresh mode `wait`");
+    }
+    if operation == RefreshOperation::Refresh
+        && selector != SourceBackedRefreshSelector::AllAutomatic
+    {
+        bail!("refresh operation requires the all-automatic source selector");
+    }
+    match (selector, explicit_catalog.is_some()) {
+        (SourceBackedRefreshSelector::AllAutomatic, true) if !has_typed_selector => {}
+        (SourceBackedRefreshSelector::AllAutomatic, false)
+        | (SourceBackedRefreshSelector::AutomaticProvider(_), false)
+        | (SourceBackedRefreshSelector::ExplicitCatalog, true) => {}
+        (SourceBackedRefreshSelector::ExplicitCatalog, false) => {
+            bail!("explicit-catalog source refresh selector has no catalog authority")
         }
-        (RefreshOperation::Import, "background", _) => {
-            bail!("import operation requires daemon refresh mode `wait`")
+        (SourceBackedRefreshSelector::AutomaticProvider(_), true) => {
+            bail!("automatic provider source refresh selector carries explicit catalog authority")
         }
-        (RefreshOperation::Import, _, None) => {
-            bail!("import operation requires explicit source catalog authority")
+        (SourceBackedRefreshSelector::AllAutomatic, true) => {
+            bail!("all-automatic source refresh selector carries explicit catalog authority")
         }
-        _ => {}
     }
     let request_id = match request.get("request_id") {
         Some(Value::String(request_id)) if !request_id.is_empty() => {
@@ -177,12 +201,19 @@ fn refresh_submission(request: &Value) -> Result<RefreshSubmission> {
     {
         bail!("background source refresh cannot require a fresh admission snapshot");
     }
+    if has_typed_selector && selector.is_scoped() && !fresh_after_admitted_snapshot {
+        bail!("scoped source refresh selector requires a fresh admission snapshot");
+    }
     let requested_catalog = explicit_catalog
         .map(ExplicitSourceCatalogAuthority::from_json)
         .transpose()?;
-    let refresh_scope = request
+    let requested_refresh_scope = request
         .get("refresh_scope")
-        .filter(|value| !value.is_null())
+        .filter(|value| !value.is_null());
+    if selector.is_scoped() && requested_refresh_scope.is_some() {
+        bail!("scoped source refresh selector cannot carry a physical refresh scope");
+    }
+    let refresh_scope = requested_refresh_scope
         .map(refresh_scope_from_json)
         .transpose()?
         .unwrap_or(RefreshScope::All);
@@ -194,7 +225,8 @@ fn refresh_submission(request: &Value) -> Result<RefreshSubmission> {
         fresh_after_admitted_snapshot,
         operation == RefreshOperation::Refresh && mode == "background",
     )
-    .with_trigger(trigger))
+    .with_trigger(trigger)
+    .with_selector(selector))
 }
 
 fn refresh_scope_from_json(value: &Value) -> Result<RefreshScope> {
@@ -247,6 +279,18 @@ fn unknown_refresh_request_response(request_id: &str) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn admitted_job(request: Value) -> Value {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = super::super::refresh_engine(&crate::test_support::SOURCE_REFRESH_CONFIG);
+        handle_ipc_request(&engine, temp.path(), &request)
+            .unwrap()
+            .expect("source refresh response");
+        crate::paths_status::read_daemon_job_status(
+            &crate::paths_status::daemon_source_backed_refresh_job_path(temp.path()),
+        )
+        .expect("persisted source refresh job")
+    }
 
     #[test]
     fn refresh_request_requires_a_typed_operation() {
@@ -342,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    fn automatic_import_keeps_import_trigger_on_refresh_operation() {
+    fn legacy_automatic_import_keeps_import_trigger_on_refresh_operation() {
         let temp = tempfile::tempdir().unwrap();
         let engine = super::super::refresh_engine(&crate::test_support::SOURCE_REFRESH_CONFIG);
 
@@ -363,5 +407,190 @@ mod tests {
         assert_eq!(response.value["operation"], "refresh");
         assert_eq!(response.value["trigger"], "import");
         assert_eq!(response.value["trigger_provenance"], "import_command");
+    }
+
+    #[test]
+    fn typed_import_selectors_remain_distinct_after_wire_admission() {
+        let all = admitted_job(json!({
+            "op": SOURCE_REFRESH_REQUEST_OP,
+            "mode": "wait",
+            "operation": "refresh",
+            "trigger": "import",
+            "refresh_selector": {"kind": "all_automatic"},
+            "fresh_after_admitted_snapshot": true,
+        }));
+        let provider = admitted_job(json!({
+            "op": SOURCE_REFRESH_REQUEST_OP,
+            "mode": "wait",
+            "operation": "import",
+            "trigger": "import",
+            "refresh_selector": {
+                "kind": "automatic_provider",
+                "provider": "codex",
+            },
+            "fresh_after_admitted_snapshot": true,
+        }));
+        let authority = ctx_history_refresh::explicit_source_catalog_authority_for_test(0);
+        let catalog = admitted_job(json!({
+            "op": SOURCE_REFRESH_REQUEST_OP,
+            "mode": "wait",
+            "operation": "import",
+            "trigger": "import",
+            "refresh_selector": {"kind": "explicit_catalog"},
+            "explicit_source_catalog": authority.to_json(),
+            "fresh_after_admitted_snapshot": true,
+        }));
+
+        assert_eq!(all["refresh_selector"], json!({"kind": "all_automatic"}));
+        assert_eq!(
+            provider["refresh_selector"],
+            json!({"kind": "automatic_provider", "provider": "codex"})
+        );
+        assert_ne!(provider["refresh_selector"], all["refresh_selector"]);
+        assert_eq!(
+            catalog["refresh_selector"],
+            json!({"kind": "explicit_catalog"})
+        );
+    }
+
+    #[test]
+    fn selector_wire_validation_fails_closed() {
+        let authority = ctx_history_refresh::explicit_source_catalog_authority_for_test(0);
+        let invalid = [
+            json!({
+                "op": SOURCE_REFRESH_REQUEST_OP,
+                "mode": "wait",
+                "operation": "import",
+                "trigger": "import",
+                "refresh_selector": {"kind": "provider"},
+            }),
+            json!({
+                "op": SOURCE_REFRESH_REQUEST_OP,
+                "mode": "wait",
+                "operation": "import",
+                "trigger": "import",
+                "refresh_selector": {"kind": "automatic_provider"},
+            }),
+            json!({
+                "op": SOURCE_REFRESH_REQUEST_OP,
+                "mode": "wait",
+                "operation": "import",
+                "trigger": "import",
+                "refresh_selector": {
+                    "kind": "automatic_provider",
+                    "provider": "unknown",
+                },
+            }),
+            json!({
+                "op": SOURCE_REFRESH_REQUEST_OP,
+                "mode": "wait",
+                "operation": "refresh",
+                "trigger": "search",
+                "refresh_selector": {
+                    "kind": "automatic_provider",
+                    "provider": "codex",
+                },
+            }),
+            json!({
+                "op": SOURCE_REFRESH_REQUEST_OP,
+                "mode": "background",
+                "operation": "import",
+                "trigger": "import",
+                "refresh_selector": {
+                    "kind": "automatic_provider",
+                    "provider": "codex",
+                },
+            }),
+            json!({
+                "op": SOURCE_REFRESH_REQUEST_OP,
+                "mode": "wait",
+                "operation": "import",
+                "trigger": "import",
+                "refresh_selector": {"kind": "all_automatic"},
+                "explicit_source_catalog": authority.to_json(),
+            }),
+            json!({
+                "op": SOURCE_REFRESH_REQUEST_OP,
+                "mode": "wait",
+                "operation": "import",
+                "trigger": "import",
+                "refresh_selector": {"kind": "explicit_catalog"},
+            }),
+            json!({
+                "op": SOURCE_REFRESH_REQUEST_OP,
+                "mode": "wait",
+                "operation": "import",
+                "trigger": "import",
+                "refresh_selector": {
+                    "kind": "automatic_provider",
+                    "provider": "codex",
+                },
+            }),
+            json!({
+                "op": SOURCE_REFRESH_REQUEST_OP,
+                "mode": "wait",
+                "operation": "import",
+                "trigger": "import",
+                "refresh_selector": {"kind": "explicit_catalog"},
+                "explicit_source_catalog": authority.to_json(),
+                "fresh_after_admitted_snapshot": false,
+            }),
+            json!({
+                "op": SOURCE_REFRESH_REQUEST_OP,
+                "mode": "wait",
+                "operation": "import",
+                "trigger": "import",
+                "refresh_selector": {
+                    "kind": "automatic_provider",
+                    "provider": "codex",
+                },
+                "refresh_scope": {"kind": "all"},
+            }),
+            json!({
+                "op": SOURCE_REFRESH_REQUEST_OP,
+                "mode": "wait",
+                "operation": "import",
+                "trigger": "import",
+            }),
+        ];
+
+        for (index, request) in invalid.into_iter().enumerate() {
+            let temp = tempfile::tempdir().unwrap();
+            let engine = super::super::refresh_engine(&crate::test_support::SOURCE_REFRESH_CONFIG);
+            assert!(
+                handle_ipc_request(&engine, temp.path(), &request).is_err(),
+                "invalid selector request {index} was accepted"
+            );
+            assert!(!engine.has_pending_request());
+        }
+    }
+
+    #[test]
+    fn omitted_selector_is_accepted_only_for_legacy_request_shapes() {
+        let legacy_all = admitted_job(json!({
+            "op": SOURCE_REFRESH_REQUEST_OP,
+            "mode": "wait",
+            "operation": "refresh",
+            "trigger": "import",
+            "fresh_after_admitted_snapshot": true,
+        }));
+        let authority = ctx_history_refresh::explicit_source_catalog_authority_for_test(0);
+        let legacy_catalog = admitted_job(json!({
+            "op": SOURCE_REFRESH_REQUEST_OP,
+            "mode": "wait",
+            "operation": "import",
+            "trigger": "import",
+            "explicit_source_catalog": authority.to_json(),
+            "fresh_after_admitted_snapshot": true,
+        }));
+
+        assert_eq!(
+            legacy_all["refresh_selector"],
+            json!({"kind": "all_automatic"})
+        );
+        assert_eq!(
+            legacy_catalog["refresh_selector"],
+            json!({"kind": "all_automatic"})
+        );
     }
 }

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator.rs
@@ -49,7 +49,7 @@ pub use ctx_history_refresh::{
     explicit_catalog_request_is_accounted_for, optional_generation,
     published_refresh_receipt_for_index, RefreshOutcomeClass, RefreshRequestState, RefreshStatus,
     RefreshStatusKind, RefreshTerminalOutcome, SourceBackedCurrentSourceProgress,
-    SourceBackedPublicationMetadata, SourceBackedRefreshReceipt,
+    SourceBackedPublicationMetadata, SourceBackedRefreshReceipt, SourceBackedRefreshSelector,
 };
 
 #[cfg(test)]

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client.rs
@@ -219,6 +219,7 @@ pub fn coordinate_import_source_backed_refresh_with_progress(
     availability: &dyn crate::DaemonAvailabilityPort,
     data_root: &Path,
     mode: SourceBackedRefreshMode,
+    selector: SourceBackedRefreshSelector,
     explicit_source_catalog: Option<&ExplicitSourceCatalogAuthority>,
     allow_daemon_autostart: bool,
     report_progress: &mut dyn FnMut(&RefreshStatus) -> Result<()>,
@@ -227,6 +228,7 @@ pub fn coordinate_import_source_backed_refresh_with_progress(
         availability,
         data_root,
         mode,
+        selector,
         explicit_source_catalog,
         allow_daemon_autostart,
         Some(report_progress),
@@ -237,6 +239,7 @@ fn coordinate_import_source_backed_refresh_inner(
     availability: &dyn crate::DaemonAvailabilityPort,
     data_root: &Path,
     mode: SourceBackedRefreshMode,
+    selector: SourceBackedRefreshSelector,
     explicit_source_catalog: Option<&ExplicitSourceCatalogAuthority>,
     allow_daemon_autostart: bool,
     report_progress: Option<SourceBackedRefreshProgressReporter<'_>>,
@@ -245,7 +248,11 @@ fn coordinate_import_source_backed_refresh_inner(
         availability,
         data_root,
         mode,
-        SourceBackedRefreshRequestPolicy::import(explicit_source_catalog, allow_daemon_autostart),
+        SourceBackedRefreshRequestPolicy::import(
+            selector,
+            explicit_source_catalog,
+            allow_daemon_autostart,
+        ),
         report_progress,
     )
 }
@@ -260,6 +267,7 @@ fn coordinate_source_backed_refresh_with_catalog(
     let SourceBackedRefreshRequestPolicy {
         operation,
         trigger,
+        selector,
         explicit_source_catalog,
         fresh_after_admitted_snapshot,
         allow_daemon_autostart,
@@ -309,11 +317,11 @@ fn coordinate_source_backed_refresh_with_catalog(
 
     let logical_request_id = Uuid::now_v7().to_string();
     let admission_request = wait_authority_request_json(
-        data_root,
         &logical_request_id,
         mode,
         operation,
         trigger,
+        selector,
         explicit_source_catalog,
         fresh_after_admitted_snapshot,
     )?;
@@ -434,6 +442,7 @@ fn coordinate_source_backed_refresh_with_catalog(
             mode,
             operation,
             trigger,
+            selector,
             expected_catalog: explicit_source_catalog,
             fresh_after_admitted_snapshot,
             allow_daemon_autostart,
@@ -462,6 +471,11 @@ pub(super) fn wait_for_published_generation(
                 SourceBackedRefreshOperation::Refresh => SourceBackedRefreshTrigger::Search,
                 SourceBackedRefreshOperation::Import => SourceBackedRefreshTrigger::Import,
             },
+            selector: if expected_catalog.is_some() {
+                SourceBackedRefreshSelector::ExplicitCatalog
+            } else {
+                SourceBackedRefreshSelector::AllAutomatic
+            },
             expected_catalog,
             fresh_after_admitted_snapshot: false,
             allow_daemon_autostart,
@@ -474,6 +488,7 @@ struct PublishedGenerationWait<'catalog, 'progress> {
     mode: SourceBackedRefreshMode,
     operation: SourceBackedRefreshOperation,
     trigger: SourceBackedRefreshTrigger,
+    selector: SourceBackedRefreshSelector,
     expected_catalog: Option<&'catalog ExplicitSourceCatalogAuthority>,
     fresh_after_admitted_snapshot: bool,
     allow_daemon_autostart: bool,
@@ -490,6 +505,7 @@ fn wait_for_published_generation_inner(
         mode,
         operation,
         trigger,
+        selector,
         expected_catalog,
         fresh_after_admitted_snapshot,
         allow_daemon_autostart,
@@ -567,6 +583,7 @@ fn wait_for_published_generation_inner(
                     &lost_request_id,
                     operation,
                     trigger,
+                    selector,
                     expected_catalog,
                     fresh_after_admitted_snapshot,
                 )
@@ -789,15 +806,16 @@ fn enqueue_equivalent_wait_refresh_request(
     request_id: &str,
     operation: SourceBackedRefreshOperation,
     trigger: SourceBackedRefreshTrigger,
+    selector: SourceBackedRefreshSelector,
     explicit_source_catalog: Option<&ExplicitSourceCatalogAuthority>,
     fresh_after_admitted_snapshot: bool,
 ) -> Result<String> {
     let request = wait_authority_request_json(
-        data_root,
         request_id,
         SourceBackedRefreshMode::Wait,
         operation,
         trigger,
+        selector,
         explicit_source_catalog,
         fresh_after_admitted_snapshot,
     )?;
@@ -824,23 +842,24 @@ fn enqueue_equivalent_wait_refresh_request(
 }
 
 fn wait_authority_request_json(
-    data_root: &Path,
     request_id: &str,
     mode: SourceBackedRefreshMode,
     operation: SourceBackedRefreshOperation,
     trigger: SourceBackedRefreshTrigger,
+    selector: SourceBackedRefreshSelector,
     explicit_source_catalog: Option<&ExplicitSourceCatalogAuthority>,
     fresh_after_admitted_snapshot: bool,
 ) -> Result<Value> {
     SourceBackedRefreshRequest::new(
         mode,
         operation,
+        selector,
         explicit_source_catalog,
         fresh_after_admitted_snapshot,
     )
     .with_trigger(trigger)
     .with_request_id(request_id)
-    .to_json(data_root)
+    .to_json()
 }
 
 fn response_request_id(response: &Value, label: &str) -> Result<String> {

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client_request_policy.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client_request_policy.rs
@@ -3,6 +3,7 @@ use super::*;
 pub(super) struct SourceBackedRefreshRequestPolicy<'catalog> {
     pub(super) operation: SourceBackedRefreshOperation,
     pub(super) trigger: SourceBackedRefreshTrigger,
+    pub(super) selector: SourceBackedRefreshSelector,
     pub(super) explicit_source_catalog: Option<&'catalog ExplicitSourceCatalogAuthority>,
     pub(super) fresh_after_admitted_snapshot: bool,
     pub(super) allow_daemon_autostart: bool,
@@ -13,6 +14,7 @@ impl<'catalog> SourceBackedRefreshRequestPolicy<'catalog> {
         Self {
             operation: SourceBackedRefreshOperation::Refresh,
             trigger,
+            selector: SourceBackedRefreshSelector::AllAutomatic,
             explicit_source_catalog: None,
             fresh_after_admitted_snapshot: false,
             allow_daemon_autostart: true,
@@ -20,16 +22,20 @@ impl<'catalog> SourceBackedRefreshRequestPolicy<'catalog> {
     }
 
     pub(super) fn import(
+        selector: SourceBackedRefreshSelector,
         explicit_source_catalog: Option<&'catalog ExplicitSourceCatalogAuthority>,
         allow_daemon_autostart: bool,
     ) -> Self {
         Self {
-            operation: if explicit_source_catalog.is_some() {
-                SourceBackedRefreshOperation::Import
-            } else {
-                SourceBackedRefreshOperation::Refresh
+            operation: match selector {
+                SourceBackedRefreshSelector::AllAutomatic => SourceBackedRefreshOperation::Refresh,
+                SourceBackedRefreshSelector::AutomaticProvider(_)
+                | SourceBackedRefreshSelector::ExplicitCatalog => {
+                    SourceBackedRefreshOperation::Import
+                }
             },
             trigger: SourceBackedRefreshTrigger::Import,
+            selector,
             explicit_source_catalog,
             fresh_after_admitted_snapshot: true,
             allow_daemon_autostart,

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client_transport_recovery_tests.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client_transport_recovery_tests.rs
@@ -5,6 +5,8 @@ use std::{
     os::unix::net::UnixListener,
 };
 
+use ctx_history_core::CaptureProvider;
+
 use crate::query_service::{
     ctx_authenticated_request_handler, start_daemon_source_refresh_service_with_request_timeout,
     write_daemon_service_endpoint, DaemonIpcService, DaemonQueryEndpoint,
@@ -60,6 +62,7 @@ fn background_maintenance_wake_is_accepted_through_client_and_coordinator() -> R
         SourceBackedRefreshRequestPolicy {
             operation: SourceBackedRefreshOperation::Refresh,
             trigger: SourceBackedRefreshTrigger::Search,
+            selector: SourceBackedRefreshSelector::AllAutomatic,
             explicit_source_catalog: None,
             fresh_after_admitted_snapshot: false,
             allow_daemon_autostart: false,
@@ -143,10 +146,11 @@ fn same_id_reenqueue_replays_the_exact_payload_after_a_lost_ack() -> Result<()> 
     let recovered = enqueue_equivalent_wait_refresh_request(
         data_root.path(),
         request_id,
-        SourceBackedRefreshOperation::Refresh,
-        SourceBackedRefreshTrigger::Search,
+        SourceBackedRefreshOperation::Import,
+        SourceBackedRefreshTrigger::Import,
+        SourceBackedRefreshSelector::AutomaticProvider(CaptureProvider::Codex),
         None,
-        false,
+        true,
     )?;
     let requests = server.join().expect("lost-ack test server panicked")?;
 
@@ -155,37 +159,67 @@ fn same_id_reenqueue_replays_the_exact_payload_after_a_lost_ack() -> Result<()> 
     for request in requests {
         let request: Value = serde_json::from_slice(&request)?;
         assert_eq!(request["request_id"], request_id);
+        assert_eq!(request["operation"], "import");
+        assert_eq!(request["trigger"], "import");
+        assert_eq!(
+            request["refresh_selector"],
+            json!({"kind": "automatic_provider", "provider": "codex"})
+        );
     }
     Ok(())
 }
 
 #[test]
-fn automatic_import_recovery_payload_keeps_import_trigger() -> Result<()> {
-    let data_root = short_data_root()?;
+fn provider_import_recovery_payload_keeps_selector_and_import_identity() -> Result<()> {
     let request = wait_authority_request_json(
-        data_root.path(),
         "019fcaaa-0000-7000-8000-000000000414",
         SourceBackedRefreshMode::Wait,
-        SourceBackedRefreshOperation::Refresh,
+        SourceBackedRefreshOperation::Import,
         SourceBackedRefreshTrigger::Import,
+        SourceBackedRefreshSelector::AutomaticProvider(CaptureProvider::Codex),
         None,
         true,
     )?;
 
-    assert_eq!(request["operation"], "refresh");
+    assert_eq!(request["operation"], "import");
     assert_eq!(request["trigger"], "import");
+    assert_eq!(
+        request["refresh_selector"],
+        json!({"kind": "automatic_provider", "provider": "codex"})
+    );
     assert!(request.get("explicit_source_catalog").is_none());
     Ok(())
 }
 
 #[test]
-fn automatic_import_policy_is_refresh_work_with_import_trigger() {
-    let policy = SourceBackedRefreshRequestPolicy::import(None, true);
+fn automatic_provider_import_policy_keeps_selector_and_import_identity() {
+    let policy = SourceBackedRefreshRequestPolicy::import(
+        SourceBackedRefreshSelector::AutomaticProvider(CaptureProvider::Codex),
+        None,
+        true,
+    );
+
+    assert_eq!(policy.operation, SourceBackedRefreshOperation::Import);
+    assert_eq!(policy.trigger, SourceBackedRefreshTrigger::Import);
+    assert_eq!(
+        policy.selector,
+        SourceBackedRefreshSelector::AutomaticProvider(CaptureProvider::Codex)
+    );
+    assert!(policy.explicit_source_catalog.is_none());
+    assert!(policy.fresh_after_admitted_snapshot);
+}
+
+#[test]
+fn all_automatic_import_policy_preserves_legacy_refresh_operation() {
+    let policy = SourceBackedRefreshRequestPolicy::import(
+        SourceBackedRefreshSelector::AllAutomatic,
+        None,
+        true,
+    );
 
     assert_eq!(policy.operation, SourceBackedRefreshOperation::Refresh);
     assert_eq!(policy.trigger, SourceBackedRefreshTrigger::Import);
-    assert!(policy.explicit_source_catalog.is_none());
-    assert!(policy.fresh_after_admitted_snapshot);
+    assert_eq!(policy.selector, SourceBackedRefreshSelector::AllAutomatic);
 }
 
 #[test]
@@ -232,6 +266,7 @@ fn background_lost_ack_terminal_replay_is_not_reported_as_pending() -> Result<()
         SourceBackedRefreshRequestPolicy {
             operation: SourceBackedRefreshOperation::Refresh,
             trigger: SourceBackedRefreshTrigger::Search,
+            selector: SourceBackedRefreshSelector::AllAutomatic,
             explicit_source_catalog: None,
             fresh_after_admitted_snapshot: false,
             allow_daemon_autostart: false,
@@ -279,6 +314,7 @@ fn exhausted_post_submission_disconnects_return_typed_ambiguous_admission() -> R
         request_id,
         SourceBackedRefreshOperation::Refresh,
         SourceBackedRefreshTrigger::Search,
+        SourceBackedRefreshSelector::AllAutomatic,
         None,
         false,
     )
@@ -335,6 +371,7 @@ fn typed_unknown_readmission_preserves_lost_ack_retention_uncertainty() -> Resul
                 request_id,
                 SourceBackedRefreshOperation::Refresh,
                 SourceBackedRefreshTrigger::Search,
+                SourceBackedRefreshSelector::AllAutomatic,
                 None,
                 false,
             )

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/request.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/request.rs
@@ -48,6 +48,7 @@ pub(super) struct SourceBackedRefreshRequest<'a> {
     request_id: String,
     mode: SourceBackedRefreshMode,
     operation: SourceBackedRefreshOperation,
+    selector: SourceBackedRefreshSelector,
     explicit_source_catalog: Option<&'a ExplicitSourceCatalogAuthority>,
     fresh_after_admitted_snapshot: bool,
     trigger: SourceBackedRefreshTrigger,
@@ -57,6 +58,7 @@ impl<'a> SourceBackedRefreshRequest<'a> {
     pub(super) fn new(
         mode: SourceBackedRefreshMode,
         operation: SourceBackedRefreshOperation,
+        selector: SourceBackedRefreshSelector,
         explicit_source_catalog: Option<&'a ExplicitSourceCatalogAuthority>,
         fresh_after_admitted_snapshot: bool,
     ) -> Self {
@@ -64,6 +66,7 @@ impl<'a> SourceBackedRefreshRequest<'a> {
             request_id: Uuid::now_v7().to_string(),
             mode,
             operation,
+            selector,
             explicit_source_catalog,
             fresh_after_admitted_snapshot,
             trigger: match operation {
@@ -83,7 +86,7 @@ impl<'a> SourceBackedRefreshRequest<'a> {
         self
     }
 
-    pub(super) fn to_json(&self, _data_root: &Path) -> Result<Value> {
+    pub(super) fn to_json(&self) -> Result<Value> {
         Ok(compact_json(json!({
             "schema_version": 1,
             "op": SOURCE_REFRESH_REQUEST_OP,
@@ -91,6 +94,7 @@ impl<'a> SourceBackedRefreshRequest<'a> {
             "mode": self.mode.as_str(),
             "operation": self.operation.as_str(),
             "trigger": self.trigger.as_str(),
+            "refresh_selector": self.selector.to_json(),
             "explicit_source_catalog": self.explicit_source_catalog
                 .map(ExplicitSourceCatalogAuthority::to_json),
             "fresh_after_admitted_snapshot": self.fresh_after_admitted_snapshot,

--- a/crates/ctx-history-cli/src/import_application.rs
+++ b/crates/ctx-history-cli/src/import_application.rs
@@ -5,7 +5,8 @@ use ctx_history_capture::{DiscoveryReport, ProviderSource};
 use ctx_history_core::CaptureProvider;
 use ctx_history_ingest_application::{
     CaptureAdmissionPort, HistorySourcePluginSource, IngestProgressPort, IngestPublication,
-    IngestRefreshPort, IngestReport, IngestRequest, SourceDiscoveryPort, SourceStats,
+    IngestRefreshPort, IngestRefreshSelection, IngestReport, IngestRequest, SourceDiscoveryPort,
+    SourceStats,
 };
 use ctx_history_refresh::ExplicitSourceCatalogUpsert;
 use ctx_terminal::Ui;
@@ -48,7 +49,7 @@ pub trait ImportApplicationPort {
         &mut self,
         data_root: &Path,
         config: HistoryCliConfig,
-        admission: Option<&ctx_history_refresh::ExplicitSourceCatalogAuthority>,
+        selection: IngestRefreshSelection<'_>,
         no_daemon: bool,
         progress: &mut ProgressReporter<'_>,
     ) -> Result<IngestPublication>;
@@ -210,7 +211,7 @@ impl<P: ImportApplicationPort> IngestRefreshPort for HistoryImportHost<'_, P> {
     fn refresh(
         &mut self,
         data_root: &Path,
-        admission: Option<&ctx_history_refresh::ExplicitSourceCatalogAuthority>,
+        selection: IngestRefreshSelection<'_>,
         no_daemon: bool,
     ) -> Result<IngestPublication> {
         let progress = self
@@ -218,7 +219,7 @@ impl<P: ImportApplicationPort> IngestRefreshPort for HistoryImportHost<'_, P> {
             .as_mut()
             .context("ingest refresh requested before progress initialization")?;
         self.port
-            .refresh(data_root, self.config, admission, no_daemon, progress)
+            .refresh(data_root, self.config, selection, no_daemon, progress)
     }
 }
 

--- a/crates/ctx-history-ingest-application/src/lib.rs
+++ b/crates/ctx-history-ingest-application/src/lib.rs
@@ -35,7 +35,7 @@ pub use plugins::{
 };
 pub use routing::{
     automatic_source_preflight, validate_ingest_request, AutomaticSourcePreflight,
-    CaptureAdmissionPort, IngestProgressPort, IngestRefreshPort, IngestRequest, IngestRoute,
-    ProviderSelectionGuidance, SourceDiscoveryPort,
+    CaptureAdmissionPort, IngestProgressPort, IngestRefreshPort, IngestRefreshSelection,
+    IngestRequest, IngestRoute, ProviderSelectionGuidance, SourceDiscoveryPort,
 };
 pub use totals::{ImportFailureScope, ImportFailureType, ImportOutcome, ImportTotals};

--- a/crates/ctx-history-ingest-application/src/lifecycle.rs
+++ b/crates/ctx-history-ingest-application/src/lifecycle.rs
@@ -16,10 +16,10 @@ use crate::{
     validate_ingest_request, AutomaticPublicationOutcome, CaptureAdmissionPort,
     CorePublicationFacts, ExactPublicationOutcome, HistorySourcePluginSource, ImportTotals,
     IngestChange, IngestFailureScope, IngestFailureType, IngestProgressPort, IngestPublication,
-    IngestRefreshPort, IngestReport, IngestRequest, IngestRoute, IngestSourceOutcome, IngestStatus,
-    IngestTelemetryFacts, IngestTerminalOutcome, PluginPublicationOutcome, ProviderRefreshFacts,
-    ProviderRefreshModeFact, RecordRejectionOutcome, SourceDiscoveryPort, SourceFailureOutcome,
-    SourceStats,
+    IngestRefreshPort, IngestRefreshSelection, IngestReport, IngestRequest, IngestRoute,
+    IngestSourceOutcome, IngestStatus, IngestTelemetryFacts, IngestTerminalOutcome,
+    PluginPublicationOutcome, ProviderRefreshFacts, ProviderRefreshModeFact,
+    RecordRejectionOutcome, SourceDiscoveryPort, SourceFailureOutcome, SourceStats,
 };
 
 const MAX_REPORTED_SOURCE_FAILURES: usize = 3;
@@ -43,16 +43,25 @@ fn run_automatic<H>(request: &IngestRequest, data_root: &Path, host: &mut H) -> 
 where
     H: SourceDiscoveryPort + CaptureAdmissionPort + IngestRefreshPort + IngestProgressPort,
 {
-    if let Some(provider) = request.provider {
-        validate_selected_provider(host, provider)?;
-    }
     host.begin(0)?;
-    automatic_source_preflight(host, data_root)
+    let selection = if let Some(provider) = request.provider {
+        let report = host.discover_provider(provider)?;
+        validate_selected_provider(host, provider, &report)?;
+        ctx_history_source_discovery::validate_provider_source_roots_outside_data_root(
+            data_root,
+            report.sources.iter(),
+        )
         .context("validate provider roots before initializing ctx state")?;
+        IngestRefreshSelection::AutomaticProvider(provider)
+    } else {
+        automatic_source_preflight(host, data_root)
+            .context("validate provider roots before initializing ctx state")?;
+        IngestRefreshSelection::AllAutomatic
+    };
 
     host.protect_data_root(data_root)
         .context("protect ctx data root before provider refresh")?;
-    let publication = host.refresh(data_root, None, request.no_daemon)?;
+    let publication = host.refresh(data_root, selection, request.no_daemon)?;
     let (publication, receipt) = verified_publication(
         publication,
         "daemon source refresh published without an authoritative terminal receipt",
@@ -171,7 +180,11 @@ where
 
     let started = Instant::now();
     let upsert = host.admit_exact(data_root, &source, request.relocate_from.as_deref())?;
-    let publication = host.refresh(data_root, Some(&upsert.authority), request.no_daemon)?;
+    let publication = host.refresh(
+        data_root,
+        IngestRefreshSelection::ExplicitCatalog(&upsert.authority),
+        request.no_daemon,
+    )?;
     let duration = started.elapsed();
     let (publication, receipt) = verified_publication(
         publication,
@@ -339,7 +352,11 @@ where
         )
     })?;
     let upsert = host.admit_exact(data_root, &route_source, None)?;
-    let publication = host.refresh(data_root, Some(&upsert.authority), request.no_daemon)?;
+    let publication = host.refresh(
+        data_root,
+        IngestRefreshSelection::ExplicitCatalog(&upsert.authority),
+        request.no_daemon,
+    )?;
     let duration = started.elapsed();
     let (publication, receipt) = verified_publication(
         publication,

--- a/crates/ctx-history-ingest-application/src/lifecycle_tests.rs
+++ b/crates/ctx-history-ingest-application/src/lifecycle_tests.rs
@@ -11,20 +11,27 @@ use ctx_history_capture_model::{
 };
 use ctx_history_core::CaptureProvider;
 use ctx_history_refresh::{
-    explicit_source_catalog_authority_for_test, ExplicitSourceCatalogAuthority,
-    ExplicitSourceCatalogRouteBinding, ExplicitSourceCatalogUpsert, SourceBackedRefreshCurrent,
-    SourceBackedRefreshReceipt, SourceBackedRefreshRecordRejection, SourceBackedRefreshRouteResult,
+    explicit_source_catalog_authority_for_test, ExplicitSourceCatalogRouteBinding,
+    ExplicitSourceCatalogUpsert, SourceBackedRefreshCurrent, SourceBackedRefreshReceipt,
+    SourceBackedRefreshRecordRejection, SourceBackedRefreshRouteResult,
     SourceBackedRefreshSourceFailure,
 };
 
 use crate::{
     run_ingest, CaptureAdmissionPort, HistorySourcePluginSource, IngestProgressPort,
-    IngestPublication, IngestRefreshPort, IngestRequest, IngestSourceOutcome,
-    ProviderSelectionGuidance, SourceDiscoveryPort, SourceStats,
+    IngestPublication, IngestRefreshPort, IngestRefreshSelection, IngestRequest,
+    IngestSourceOutcome, ProviderSelectionGuidance, SourceDiscoveryPort, SourceStats,
 };
 
 const ROUTE: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const SOURCE_ID: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RecordedRefreshSelection {
+    AllAutomatic,
+    AutomaticProvider(CaptureProvider),
+    ExplicitCatalog(String),
+}
 
 struct FakeHost {
     events: RefCell<Vec<String>>,
@@ -42,6 +49,7 @@ struct FakeHost {
     provider_discovery_calls: Cell<usize>,
     source_identity_calls: Cell<usize>,
     relocate_from: RefCell<Option<PathBuf>>,
+    refresh_selections: RefCell<Vec<RecordedRefreshSelection>>,
 }
 
 impl FakeHost {
@@ -62,6 +70,7 @@ impl FakeHost {
             provider_discovery_calls: Cell::new(0),
             source_identity_calls: Cell::new(0),
             relocate_from: RefCell::new(None),
+            refresh_selections: RefCell::new(Vec::new()),
         }
     }
 
@@ -181,14 +190,25 @@ impl IngestRefreshPort for FakeHost {
     fn refresh(
         &mut self,
         _: &Path,
-        admission: Option<&ExplicitSourceCatalogAuthority>,
+        selection: IngestRefreshSelection<'_>,
         _: bool,
     ) -> Result<IngestPublication> {
-        self.push(if admission.is_some() {
-            "refresh:exact"
-        } else {
-            "refresh:automatic"
-        });
+        let (event, recorded) = match selection {
+            IngestRefreshSelection::AllAutomatic => (
+                "refresh:all_automatic",
+                RecordedRefreshSelection::AllAutomatic,
+            ),
+            IngestRefreshSelection::AutomaticProvider(provider) => (
+                "refresh:automatic_provider",
+                RecordedRefreshSelection::AutomaticProvider(provider),
+            ),
+            IngestRefreshSelection::ExplicitCatalog(authority) => (
+                "refresh:explicit_catalog",
+                RecordedRefreshSelection::ExplicitCatalog(authority.integrity_hex()),
+            ),
+        };
+        self.push(event);
+        self.refresh_selections.borrow_mut().push(recorded);
         self.refresh_calls.set(self.refresh_calls.get() + 1);
         if let Some(error) = self.refresh_error {
             return Err(anyhow!(error));
@@ -329,8 +349,12 @@ fn automatic_safety_snapshot_precedes_root_admission_and_one_refresh() {
             "begin:0",
             "discover_all",
             "protect_data_root",
-            "refresh:automatic"
+            "refresh:all_automatic"
         ]
+    );
+    assert_eq!(
+        host.refresh_selections.borrow().as_slice(),
+        [RecordedRefreshSelection::AllAutomatic]
     );
 }
 
@@ -388,8 +412,14 @@ fn exact_route_admits_and_refreshes_exactly_once() {
             "begin:8",
             "catalog_exact",
             "admit_exact",
-            "refresh:exact"
+            "refresh:explicit_catalog"
         ]
+    );
+    assert_eq!(
+        host.refresh_selections.borrow().as_slice(),
+        [RecordedRefreshSelection::ExplicitCatalog(
+            explicit_source_catalog_authority_for_test(1).integrity_hex()
+        )]
     );
 }
 
@@ -701,7 +731,7 @@ fn admission_and_progress_errors_propagate_without_publication() {
 }
 
 #[test]
-fn selected_automatic_provider_uses_one_provider_snapshot_and_one_safety_snapshot() {
+fn selected_automatic_provider_uses_only_its_provider_snapshot_and_forwards_selection() {
     let temp = tempfile::tempdir().unwrap();
     let source_path = write_source(&temp);
     let source = provider_source(source_path.clone(), ProviderSourceStatus::Available);
@@ -712,8 +742,7 @@ fn selected_automatic_provider_uses_one_provider_snapshot_and_one_safety_snapsho
             SourceBackedRefreshRouteResult::succeeded(ROUTE.into(), true),
         )),
     );
-    host.provider_discovery.sources = vec![source.clone()];
-    host.all_discovery.sources = vec![source];
+    host.provider_discovery.sources = vec![source];
     let request = IngestRequest {
         provider: Some(CaptureProvider::Codex),
         ..IngestRequest::default()
@@ -722,8 +751,14 @@ fn selected_automatic_provider_uses_one_provider_snapshot_and_one_safety_snapsho
     run_ingest(&request, &temp.path().join("ctx"), &mut host).unwrap();
 
     assert_eq!(host.provider_discovery_calls.get(), 1);
-    assert_eq!(host.all_discovery_calls.get(), 1);
+    assert_eq!(host.all_discovery_calls.get(), 0);
     assert_eq!(host.refresh_calls.get(), 1);
+    assert_eq!(
+        host.refresh_selections.borrow().as_slice(),
+        [RecordedRefreshSelection::AutomaticProvider(
+            CaptureProvider::Codex
+        )]
+    );
 }
 
 #[test]

--- a/crates/ctx-history-ingest-application/src/routing.rs
+++ b/crates/ctx-history-ingest-application/src/routing.rs
@@ -55,9 +55,18 @@ pub trait IngestRefreshPort {
     fn refresh(
         &mut self,
         data_root: &Path,
-        admission: Option<&ExplicitSourceCatalogAuthority>,
+        selection: IngestRefreshSelection<'_>,
         no_daemon: bool,
     ) -> Result<IngestPublication>;
+}
+
+/// Logical source selection for one import request. This is intentionally
+/// independent from the daemon's later physical route scope.
+#[derive(Debug, Clone, Copy)]
+pub enum IngestRefreshSelection<'a> {
+    AllAutomatic,
+    AutomaticProvider(CaptureProvider),
+    ExplicitCatalog(&'a ExplicitSourceCatalogAuthority),
 }
 
 /// Bounded operation-level progress boundary; no source record is permitted to
@@ -133,8 +142,8 @@ pub fn validate_ingest_request(request: &IngestRequest) -> Result<IngestRoute> {
 pub(crate) fn validate_selected_provider(
     discovery: &dyn SourceDiscoveryPort,
     provider: CaptureProvider,
+    report: &DiscoveryReport,
 ) -> Result<()> {
-    let report = discovery.discover_provider(provider)?;
     if report.sources.iter().any(|source| {
         source.status == ProviderSourceStatus::Available && source.import_support.is_importable()
     }) {

--- a/crates/ctx-history-refresh-execution/src/execution.rs
+++ b/crates/ctx-history-refresh-execution/src/execution.rs
@@ -2,9 +2,11 @@ use super::*;
 
 #[cfg(test)]
 mod catalog_refresh_admission_tests;
+mod family_fallback;
 mod publication;
 mod registry_merge;
 
+use family_fallback::{exact_member_family_fallback_required, ExactMemberFallbackRequired};
 pub use publication::exclusive_scan_stage_duration;
 use publication::{
     encode_publication_metadata, provider_route_results, publication_from_verified_metadata,
@@ -20,7 +22,7 @@ pub(super) struct MergedSourceBackedRegistry {
     previous_catalog_route_bindings: Vec<ExplicitSourceCatalogRouteBinding>,
     requested_explicit_source_catalog: Option<ExplicitSourceCatalogAuthority>,
     retained_generation: Option<VerifiedIndex>,
-    requested_catalog_route_bindings: Vec<ExplicitSourceCatalogRouteBinding>,
+    pub(super) requested_catalog_route_bindings: Vec<ExplicitSourceCatalogRouteBinding>,
     previous_route_controls: BTreeMap<SourceRouteIdentity, Vec<u8>>,
 }
 
@@ -30,20 +32,10 @@ enum SourceBackedInventoryDisposition {
     UnsupportedOrUnavailable(ZeroSourcePublicationBlocked),
 }
 
-#[derive(Debug)]
-struct ExactMemberFallbackRequired;
-
-impl std::fmt::Display for ExactMemberFallbackRequired {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("exact member requires registered-route family reconciliation")
-    }
-}
-
-impl std::error::Error for ExactMemberFallbackRequired {}
-
 #[derive(Clone)]
 struct CatalogRefreshAdmission {
     report: DiscoveryReport,
+    discovery_duration: StdDuration,
     exact_members: bool,
 }
 
@@ -62,6 +54,11 @@ impl PublishedSourceBackedStatePort for PreopenedPublishedState {
 pub(super) fn execute_capture_owned_refresh(
     execution: SourceBackedRefreshExecution<'_>,
 ) -> Result<SourceBackedRefreshPublication> {
+    if execution.admitted_discovery.is_some()
+        && !matches!(execution.scope, SourceBackedRefreshScope::Exact(_))
+    {
+        bail!("admitted scoped discovery requires an exact source refresh scope");
+    }
     let catalog_admission = catalog_refresh_admission(&execution);
     let mut family_fallback = execution.clone();
     match execute_capture_owned_refresh_once(execution, catalog_admission.clone()) {
@@ -106,7 +103,7 @@ fn execute_capture_owned_refresh_once(
         discovery_context,
         catalog_admission
             .as_ref()
-            .map(|admission| admission.report.clone()),
+            .map(|admission| (admission.report.clone(), admission.discovery_duration)),
         move |discovery,
               report,
               discovery_duration,
@@ -148,7 +145,7 @@ fn execute_capture_owned_refresh_once(
 pub fn execute_capture_owned_refresh_with<Refresh>(
     execution: SourceBackedRefreshExecution<'_>,
     discovery: &DiscoveryContext,
-    catalog_report: Option<DiscoveryReport>,
+    admitted_report: Option<(DiscoveryReport, StdDuration)>,
     refresh_all: Refresh,
 ) -> Result<SourceBackedRefreshPublication>
 where
@@ -176,13 +173,21 @@ where
         .published_state
         .open_published_state(execution.data_root)?;
     let published_state = PreopenedPublishedState(Mutex::new(Some(published_state)));
-    let work_budget =
-        source_backed_refresh_work_budget(source_backed_refresh_writer_options().indexer_threads);
-    let discovery_started = StdInstant::now();
-    let report = catalog_report.unwrap_or_else(|| {
-        discover_provider_sources_with_context_and_work_budget(&discovery, work_budget)
-    });
-    let discovery_duration = discovery_started.elapsed();
+    let (report, discovery_duration) = match admitted_report {
+        Some(admitted) => admitted,
+        None if execution.requires_admitted_discovery => {
+            bail!("selected source refresh has no admitted discovery authority")
+        }
+        None => {
+            let work_budget = source_backed_refresh_work_budget(
+                source_backed_refresh_writer_options().indexer_threads,
+            );
+            let discovery_started = StdInstant::now();
+            let report =
+                discover_provider_sources_with_context_and_work_budget(&discovery, work_budget);
+            (report, discovery_started.elapsed())
+        }
+    };
     validate_provider_source_roots_outside_data_root(execution.data_root, report.sources.iter())
         .context("validate provider roots before source-refresh state writes")?;
     if let Some(authority) = execution.explicit_source_catalog {
@@ -275,6 +280,38 @@ fn establish_source_backed_index_privacy(data_root: &Path, index_root: &Path) ->
 fn catalog_refresh_admission(
     execution: &SourceBackedRefreshExecution<'_>,
 ) -> Option<CatalogRefreshAdmission> {
+    if let Some(admitted) = execution.admitted_discovery.as_ref() {
+        let SourceBackedRefreshScope::Exact(routes) = &execution.scope else {
+            return None;
+        };
+        let exact_member_report = (execution.reconciliation_demand
+            == SourceBackedReconciliationDemand::Incremental)
+            .then(|| {
+                execution
+                    .route_worksets
+                    .iter()
+                    .map(|(route, workset)| match workset {
+                        SourceBackedRefreshWorkset::Members(members) => {
+                            Some((route.clone(), members.clone()))
+                        }
+                        SourceBackedRefreshWorkset::Exhaustive => None,
+                    })
+                    .collect::<Option<BTreeMap<_, _>>>()
+                    .and_then(|worksets| {
+                        admitted
+                            .watch_catalog()
+                            .exact_member_discovery_report(routes, &worksets)
+                    })
+            })
+            .flatten();
+        return Some(CatalogRefreshAdmission {
+            report: exact_member_report
+                .clone()
+                .unwrap_or_else(|| admitted.report().clone()),
+            discovery_duration: admitted.discovery_duration(),
+            exact_members: exact_member_report.is_some(),
+        });
+    }
     if execution.operation != RefreshOperation::Refresh
         || execution.explicit_source_catalog.is_some()
     {
@@ -303,11 +340,13 @@ fn catalog_refresh_admission(
     if let Some(report) = exact_member_report {
         return Some(CatalogRefreshAdmission {
             report,
+            discovery_duration: StdDuration::ZERO,
             exact_members: true,
         });
     }
     Some(CatalogRefreshAdmission {
         report: catalog.route_discovery_report(routes)?,
+        discovery_duration: StdDuration::ZERO,
         exact_members: false,
     })
 }
@@ -814,25 +853,6 @@ fn refresh_all_provider_sources_route_local_with_reconciliation(
         publication.verified_index = Some(recertified);
     }
     Ok(publication)
-}
-
-fn exact_member_family_fallback_required(
-    route_worksets: &BTreeMap<SourceRouteIdentity, BTreeSet<PathBuf>>,
-    complete_inventory_routes: &BTreeSet<SourceRouteIdentity>,
-    successful_routes: &[SourceBackedSuccessfulRouteOutcome],
-    failed_routes: &[SourceBackedFailedRouteOutcome],
-) -> bool {
-    let exact_routes = route_worksets.keys().collect::<BTreeSet<_>>();
-    complete_inventory_routes
-        .iter()
-        .any(|route| exact_routes.contains(route))
-        || successful_routes.iter().any(|outcome| {
-            exact_routes.contains(&outcome.route_identity)
-                && outcome.logical_source_failure_total != 0
-        })
-        || failed_routes
-            .iter()
-            .any(|outcome| exact_routes.contains(&outcome.route_identity))
 }
 
 fn register_automatic_hermes_profile_rename_retirements(

--- a/crates/ctx-history-refresh-execution/src/execution/family_fallback.rs
+++ b/crates/ctx-history-refresh-execution/src/execution/family_fallback.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+#[derive(Debug)]
+pub(super) struct ExactMemberFallbackRequired;
+
+impl std::fmt::Display for ExactMemberFallbackRequired {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("exact member requires registered-route family reconciliation")
+    }
+}
+
+impl std::error::Error for ExactMemberFallbackRequired {}
+
+pub(super) fn exact_member_family_fallback_required(
+    route_worksets: &BTreeMap<SourceRouteIdentity, BTreeSet<PathBuf>>,
+    complete_inventory_routes: &BTreeSet<SourceRouteIdentity>,
+    successful_routes: &[SourceBackedSuccessfulRouteOutcome],
+    failed_routes: &[SourceBackedFailedRouteOutcome],
+) -> bool {
+    let exact_routes = route_worksets.keys().collect::<BTreeSet<_>>();
+    complete_inventory_routes
+        .iter()
+        .any(|route| exact_routes.contains(route))
+        || successful_routes.iter().any(|outcome| {
+            exact_routes.contains(&outcome.route_identity)
+                && outcome.logical_source_failure_total != 0
+        })
+        || failed_routes
+            .iter()
+            .any(|outcome| exact_routes.contains(&outcome.route_identity))
+}

--- a/crates/ctx-history-refresh-execution/src/explicit_source_catalog.rs
+++ b/crates/ctx-history-refresh-execution/src/explicit_source_catalog.rs
@@ -73,6 +73,22 @@ impl ExplicitSourceCatalogAuthority {
         validate_explicit_source_catalog_snapshot_roots(data_root, &snapshot)
     }
 
+    /// Derives only the provider inputs named by this request authority.
+    /// No provider-wide discovery is performed here.
+    #[doc(hidden)]
+    pub fn admission_discovery_report(&self) -> Result<DiscoveryReport> {
+        let sources = self
+            .entries
+            .iter()
+            .filter(|entry| entry.enabled)
+            .map(|entry| source_from_catalog_entry(entry, true))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(DiscoveryReport {
+            sources,
+            issues: Vec::new(),
+        })
+    }
+
     pub fn route_lineages(&self) -> BTreeSet<String> {
         self.entries
             .iter()

--- a/crates/ctx-history-refresh-execution/src/lib.rs
+++ b/crates/ctx-history-refresh-execution/src/lib.rs
@@ -98,11 +98,12 @@ pub use route_result::{
 };
 pub use types::{
     nonzero_duration_micros, PublishedSourceBackedState, PublishedSourceBackedStatePort,
-    RefreshOperation, SourceBackedCurrentSourceProgress, SourceBackedCurrentSourceProgressStage,
-    SourceBackedExactScanProgress, SourceBackedRefreshCoveredPublication,
-    SourceBackedRefreshExecution, SourceBackedRefreshProgressUpdate,
-    SourceBackedRefreshPublication, SourceBackedRefreshTimings, SourceBackedRefreshWorkset,
-    SourceBackedZeroSourceAuthority, SourceBackedZeroSourceAuthorityKind,
+    RefreshOperation, SourceBackedAdmittedDiscovery, SourceBackedCurrentSourceProgress,
+    SourceBackedCurrentSourceProgressStage, SourceBackedExactScanProgress,
+    SourceBackedRefreshCoveredPublication, SourceBackedRefreshExecution,
+    SourceBackedRefreshProgressUpdate, SourceBackedRefreshPublication, SourceBackedRefreshTimings,
+    SourceBackedRefreshWorkset, SourceBackedZeroSourceAuthority,
+    SourceBackedZeroSourceAuthorityKind,
 };
 
 const SEARCH_DIRECTORY: &str = "search";
@@ -263,4 +264,67 @@ pub fn source_backed_watch_catalog_from_report(
         published_state,
     )?;
     Ok(merged.build.registry.watch_catalog())
+}
+
+/// Builds exact, provider-neutral execution authority from one already-bounded
+/// discovery report. The returned routes are derived from that same report;
+/// this helper performs no discovery of its own.
+#[doc(hidden)]
+pub fn source_backed_admitted_discovery_from_report(
+    discovery: &DiscoveryContext,
+    report: DiscoveryReport,
+    discovery_duration: StdDuration,
+    data_root: &Path,
+    explicit_source_catalog: Option<&ExplicitSourceCatalogAuthority>,
+    published_state: &dyn PublishedSourceBackedStatePort,
+) -> Result<(SourceBackedAdmittedDiscovery, BTreeSet<SourceRouteIdentity>)> {
+    // Explicit-catalog discovery is already reconstructed from the catalog
+    // authority itself. Unlike automatic routes, explicit routes deliberately
+    // do not expose replayable registration sources through the watch catalog.
+    let explicit_admitted_report = explicit_source_catalog.is_some().then(|| report.clone());
+    let merged = execution::build_merged_source_backed_registry(
+        discovery,
+        report,
+        discovery_duration,
+        data_root,
+        explicit_source_catalog,
+        published_state,
+    )?;
+    reject_blocking_automatic_registry_issues(&merged.build.issues)?;
+    let watch_catalog = merged.build.registry.watch_catalog();
+    let selected_routes = if explicit_source_catalog.is_some() {
+        merged
+            .requested_catalog_route_bindings
+            .iter()
+            .map(|binding| {
+                SourceRouteIdentity::from_sha256(binding.route_identity.clone()).map_err(Into::into)
+            })
+            .collect::<Result<BTreeSet<_>>>()?
+    } else {
+        watch_catalog
+            .route_ids()
+            .filter(|route| {
+                watch_catalog
+                    .route_discovery_report(&BTreeSet::from([(*route).clone()]))
+                    .is_some()
+            })
+            .cloned()
+            .collect()
+    };
+    let admitted_report = match explicit_admitted_report {
+        Some(report) => report,
+        None if selected_routes.is_empty() => DiscoveryReport {
+            sources: Vec::new(),
+            issues: Vec::new(),
+        },
+        None => watch_catalog
+            .route_discovery_report(&selected_routes)
+            .ok_or_else(|| {
+                anyhow!("selected source routes have no provider-neutral discovery report")
+            })?,
+    };
+    Ok((
+        SourceBackedAdmittedDiscovery::new(admitted_report, discovery_duration, watch_catalog),
+        selected_routes,
+    ))
 }

--- a/crates/ctx-history-refresh-execution/src/tests/execution_path.rs
+++ b/crates/ctx-history-refresh-execution/src/tests/execution_path.rs
@@ -248,3 +248,179 @@ fn provider_wide_execution_discovers_once_and_preserves_progress_order() {
         ]
     );
 }
+
+#[test]
+fn exact_execution_without_admitted_authority_cannot_fall_back_to_global_discovery() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    let index_root = source_backed_index_root(&data_root);
+    ctx_history_platform::platform_security::establish_private_data_root(&data_root).unwrap();
+    let (home, cwd, discovery) = discovery_fixture(temp.path());
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cwd).unwrap();
+    let route = SourceRouteIdentity::from_sha256("ac".repeat(32)).unwrap();
+    let progress = |_: SourceBackedRefreshProgressUpdate| Ok(());
+    let execution = SourceBackedRefreshExecution::new(
+        &data_root,
+        &index_root,
+        "missing-scoped-authority",
+        RefreshOperation::Refresh,
+        None,
+        SourceBackedRefreshScope::exact([route]),
+        BTreeSet::new(),
+        SourceBackedRefreshCoveredPublication::default(),
+        &discovery,
+        &TestPublishedState,
+        &progress,
+    )
+    .with_admitted_discovery_requirement(true);
+
+    let error = execute_capture_owned_refresh_with(
+        execution,
+        &discovery,
+        None,
+        |_, _, _, _, _, _, _, _, _, _, _, _, _| {
+            panic!("exact execution reached refresh after global fallback")
+        },
+    )
+    .unwrap_err();
+    assert!(format!("{error:#}")
+        .contains("selected source refresh has no admitted discovery authority"));
+}
+
+#[test]
+fn warm_exact_carries_unselected_routes_while_receipt_stays_selected() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    let index_root = source_backed_index_root(&data_root);
+    ctx_history_platform::platform_security::establish_private_data_root(&data_root).unwrap();
+    let (_, _, discovery) = discovery_fixture(temp.path());
+
+    let codex_root = temp.path().join("codex-sessions");
+    fs::create_dir_all(&codex_root).unwrap();
+    let codex_session = codex_root.join("rollout.jsonl");
+    fs::write(
+        &codex_session,
+        format!(
+            "{}\n{}\n",
+            json!({
+                "timestamp": "2026-08-17T00:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "019fb700-0000-7000-8000-000000000701",
+                    "timestamp": "2026-08-17T00:00:00Z",
+                    "cwd": "/repo/exact-carry",
+                    "originator": "codex_cli_rs",
+                    "cli_version": "1.0.0",
+                    "source": "cli",
+                    "model_provider": "openai"
+                }
+            }),
+            json!({
+                "timestamp": "2026-08-17T00:00:01Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "codex warm"}]
+                }
+            })
+        ),
+    )
+    .unwrap();
+    let claude_root = temp.path().join("claude-projects");
+    let claude_session = claude_root.join("project/session.jsonl");
+    fs::create_dir_all(claude_session.parent().unwrap()).unwrap();
+    fs::write(
+        &claude_session,
+        format!(
+            "{}\n",
+            json!({
+                "type": "user",
+                "uuid": "literal-claude-warm",
+                "sessionId": "019fb700-0000-7000-8000-000000000702",
+                "message": {"role": "user", "content": "claude warm"}
+            })
+        ),
+    )
+    .unwrap();
+    let codex_source = provider_source_for_path(CaptureProvider::Codex, codex_root);
+    let claude_source = provider_source_for_path(CaptureProvider::Claude, claude_root);
+    let codex_route = automatic_source_backed_route_identity(&codex_source).unwrap();
+    let claude_route = automatic_source_backed_route_identity(&claude_source).unwrap();
+    let report = DiscoveryReport {
+        sources: vec![codex_source.clone(), claude_source],
+        issues: Vec::new(),
+    };
+    let mut progress = |_: CaptureSourceBackedDetailedRefreshProgress| Ok(());
+    let cold = refresh_all_provider_sources(
+        &discovery,
+        report,
+        StdDuration::ZERO,
+        &data_root,
+        &index_root,
+        None,
+        SourceBackedRefreshScope::All,
+        &BTreeSet::new(),
+        &mut progress,
+    )
+    .unwrap();
+    assert_eq!(cold.route_results.len(), 2);
+
+    fs::write(
+        &codex_session,
+        format!(
+            "{}\n{}\n",
+            json!({
+                "timestamp": "2026-08-17T00:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "019fb700-0000-7000-8000-000000000701",
+                    "timestamp": "2026-08-17T00:00:00Z",
+                    "cwd": "/repo/exact-carry",
+                    "originator": "codex_cli_rs",
+                    "cli_version": "1.0.0",
+                    "source": "cli",
+                    "model_provider": "openai"
+                }
+            }),
+            json!({
+                "timestamp": "2026-08-17T00:00:02Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "codex exact"}]
+                }
+            })
+        ),
+    )
+    .unwrap();
+    let exact_routes = BTreeSet::from([codex_route.clone()]);
+    let mut exact_progress = |_: CaptureSourceBackedDetailedRefreshProgress| Ok(());
+    let exact = refresh_all_provider_sources_route_local(
+        &discovery,
+        DiscoveryReport {
+            sources: vec![codex_source],
+            issues: Vec::new(),
+        },
+        StdDuration::ZERO,
+        "warm-exact-carry",
+        RefreshOperation::Refresh,
+        &data_root,
+        &index_root,
+        None,
+        SourceBackedRefreshScope::Exact(exact_routes.clone()),
+        &BTreeSet::new(),
+        &SourceBackedRefreshCoveredPublication::default(),
+        &TestPublishedState,
+        &mut exact_progress,
+    )
+    .unwrap();
+
+    assert_eq!(exact.route_results.len(), 1);
+    assert_eq!(exact.route_results[0].route_identity, codex_route.as_str());
+    let published = VerifiedIndex::open(&index_root).unwrap();
+    assert!(published.manifest().source_route(&codex_route).is_some());
+    assert!(published.manifest().source_route(&claude_route).is_some());
+}

--- a/crates/ctx-history-refresh-execution/src/types.rs
+++ b/crates/ctx-history-refresh-execution/src/types.rs
@@ -386,6 +386,11 @@ pub struct SourceBackedRefreshExecution<'a> {
     /// Immutable authenticated watch-catalog snapshot admitted with this
     /// request. It is absent for manual and uncertainty fallbacks.
     pub watch_catalog: Option<SourceBackedWatchCatalog>,
+    /// Provider-neutral discovery authority resolved before exact execution.
+    /// Logical provider selection is deliberately absent from this boundary.
+    pub admitted_discovery: Option<SourceBackedAdmittedDiscovery>,
+    /// Whether this request is forbidden from using provider-wide discovery.
+    pub requires_admitted_discovery: bool,
     pub covered_route_ids: BTreeSet<SourceRouteIdentity>,
     pub covered_publication: SourceBackedRefreshCoveredPublication,
     pub discovery_context: &'a DiscoveryContext,
@@ -424,6 +429,8 @@ impl<'a> SourceBackedRefreshExecution<'a> {
             scope,
             route_worksets: BTreeMap::new(),
             watch_catalog: None,
+            admitted_discovery: None,
+            requires_admitted_discovery: false,
             covered_route_ids,
             covered_publication,
             discovery_context,
@@ -447,6 +454,21 @@ impl<'a> SourceBackedRefreshExecution<'a> {
 
     pub fn with_watch_catalog_opt(mut self, catalog: Option<SourceBackedWatchCatalog>) -> Self {
         self.watch_catalog = catalog;
+        self
+    }
+
+    #[doc(hidden)]
+    pub fn with_admitted_discovery_opt(
+        mut self,
+        admitted: Option<SourceBackedAdmittedDiscovery>,
+    ) -> Self {
+        self.admitted_discovery = admitted;
+        self
+    }
+
+    #[doc(hidden)]
+    pub fn with_admitted_discovery_requirement(mut self, required: bool) -> Self {
+        self.requires_admitted_discovery = required;
         self
     }
 
@@ -560,6 +582,45 @@ impl<'a> SourceBackedRefreshExecution<'a> {
             completed_bytes,
             None,
         )
+    }
+}
+
+/// Provider-neutral, request-local discovery authority for exact execution.
+///
+/// This value is intentionally transient. Durable jobs retain the logical
+/// selector and exact physical scope, then recovery reconstructs and verifies
+/// this authority before execution resumes.
+#[doc(hidden)]
+#[derive(Debug, Clone)]
+pub struct SourceBackedAdmittedDiscovery {
+    report: DiscoveryReport,
+    discovery_duration: StdDuration,
+    watch_catalog: SourceBackedWatchCatalog,
+}
+
+impl SourceBackedAdmittedDiscovery {
+    pub fn new(
+        report: DiscoveryReport,
+        discovery_duration: StdDuration,
+        watch_catalog: SourceBackedWatchCatalog,
+    ) -> Self {
+        Self {
+            report,
+            discovery_duration,
+            watch_catalog,
+        }
+    }
+
+    pub fn report(&self) -> &DiscoveryReport {
+        &self.report
+    }
+
+    pub fn discovery_duration(&self) -> StdDuration {
+        self.discovery_duration
+    }
+
+    pub fn watch_catalog(&self) -> &SourceBackedWatchCatalog {
+        &self.watch_catalog
     }
 }
 

--- a/crates/ctx-history-refresh/src/engine/admission.rs
+++ b/crates/ctx-history-refresh/src/engine/admission.rs
@@ -1,15 +1,29 @@
 use super::*;
 use sha2::{Digest as _, Sha256};
 
+#[derive(Clone)]
+struct PendingAdmissionClaim {
+    request_id: String,
+    selector: SourceBackedRefreshSelector,
+    requested_catalog: Option<ExplicitSourceCatalogAuthority>,
+    persisted_scope: SourceBackedRefreshScope,
+}
+
+enum PendingAdmissionResolution {
+    Unscoped(BTreeMap<SourceRouteIdentity, Option<String>>),
+    Scoped(read_model::AdmittedSourceBackedRefreshAuthority),
+}
+
 fn request_fingerprint(
     operation: SourceBackedRefreshOperation,
     trigger: RefreshRequestTrigger,
     reconciliation_demand: SourceBackedReconciliationDemand,
+    selector: SourceBackedRefreshSelector,
     requested_catalog: Option<&ExplicitSourceCatalogAuthority>,
     refresh_scope: &SourceBackedRefreshScope,
     admission: SourceRefreshAdmissionRequirement,
 ) -> Result<String> {
-    let authority = compact_json(json!({
+    let mut authority = compact_json(json!({
         "operation": operation.as_str(),
         "trigger": trigger.as_str(),
         "reconciliation_demand": reconciliation_demand.as_str(),
@@ -19,6 +33,12 @@ fn request_fingerprint(
             == SourceRefreshAdmissionRequirement::FreshAfterAdmittedSnapshot,
         "refresh_scope": refresh_scope_json(refresh_scope),
     }));
+    // Legacy all-automatic payloads predate the selector field. Scoped
+    // selectors are new request semantics and must participate in stable-ID
+    // identity so exact-catalog work cannot replay as an all-route overlay.
+    if selector.is_scoped() {
+        authority["refresh_selector"] = selector.to_json();
+    }
     Ok(format!(
         "{:x}",
         Sha256::digest(serde_json::to_vec(&authority)?)
@@ -30,6 +50,7 @@ struct SourceRefreshAdmissionReservation<'a> {
     previous_generation: Option<String>,
     metadata: SourceRefreshRuntimeMetadata,
     requested_catalog: Option<ExplicitSourceCatalogAuthority>,
+    selector: SourceBackedRefreshSelector,
     refresh_scope: SourceBackedRefreshScope,
     logical_demand: SourceRefreshLogicalDemand,
     defer_admission_until_response: bool,
@@ -58,10 +79,25 @@ impl CoreRefreshEngine {
             SourceBackedRefreshOperation::Refresh => RefreshRequestTrigger::Search,
             SourceBackedRefreshOperation::Import => RefreshRequestTrigger::Import,
         });
+        match (
+            submission.selector,
+            submission.explicit_source_catalog.is_some(),
+        ) {
+            (SourceBackedRefreshSelector::AllAutomatic, _)
+            | (SourceBackedRefreshSelector::AutomaticProvider(_), false)
+            | (SourceBackedRefreshSelector::ExplicitCatalog, true) => {}
+            (SourceBackedRefreshSelector::ExplicitCatalog, false) => {
+                bail!("explicit-catalog source refresh selector has no catalog authority")
+            }
+            (SourceBackedRefreshSelector::AutomaticProvider(_), true) => bail!(
+                "automatic provider source refresh selector carries explicit catalog authority"
+            ),
+        }
         let fingerprint = request_fingerprint(
             submission.operation,
             trigger,
             submission.reconciliation_demand,
+            submission.selector,
             submission.explicit_source_catalog.as_ref(),
             &submission.refresh_scope,
             admission,
@@ -83,6 +119,7 @@ impl CoreRefreshEngine {
             previous_generation,
             metadata,
             requested_catalog: submission.explicit_source_catalog,
+            selector: submission.selector,
             refresh_scope: submission.refresh_scope,
             logical_demand: SourceRefreshLogicalDemand {
                 admission,
@@ -91,7 +128,11 @@ impl CoreRefreshEngine {
                 request_id: Some(submission.request_id),
                 request_fingerprint: Some(fingerprint),
                 admission_pending: admission
-                    == SourceRefreshAdmissionRequirement::FreshAfterAdmittedSnapshot,
+                    == SourceRefreshAdmissionRequirement::FreshAfterAdmittedSnapshot
+                    || matches!(
+                        submission.selector,
+                        SourceBackedRefreshSelector::AutomaticProvider(_)
+                    ),
             },
             defer_admission_until_response: true,
         });
@@ -136,6 +177,7 @@ impl CoreRefreshEngine {
             previous_generation,
             metadata,
             requested_catalog,
+            selector,
             refresh_scope,
             logical_demand,
             defer_admission_until_response,
@@ -177,6 +219,7 @@ impl CoreRefreshEngine {
             requested_catalog,
             refresh_scope,
             logical_demand,
+            selector,
         ) {
             Ok(response) => response,
             Err(error) => {
@@ -292,19 +335,13 @@ impl CoreRefreshEngine {
 
     #[cfg(any(test, feature = "test-support"))]
     pub fn prepare_next_pending_admission(&self, data_root: &Path) -> Result<bool> {
-        let Some((request_id, requested_catalog)) = self.claim_next_pending_admission() else {
+        let Some(claim) = self.claim_next_pending_admission() else {
             return Ok(false);
         };
         // Corpus-scale discovery must run without a coordinator or admission
         // lock so status, ping, and additional bounded admissions stay live.
-        let discovery = self.runtime.discovery_context(data_root)?;
-        let observations = (self.admission_fence)(
-            &discovery,
-            self.journal.as_ref(),
-            data_root,
-            requested_catalog.as_ref(),
-        );
-        self.complete_claimed_pending_admission(data_root, &request_id, observations)?;
+        let resolution = self.resolve_pending_admission_claim(data_root, &claim);
+        self.complete_claimed_pending_admission(data_root, &claim.request_id, resolution)?;
         Ok(true)
     }
 
@@ -312,19 +349,149 @@ impl CoreRefreshEngine {
         &self,
         data_root: &Path,
     ) -> Result<Option<SourceBackedRefreshRun>> {
-        let Some((request_id, requested_catalog)) = self.claim_active_pending_admission() else {
+        let Some(claim) = self.claim_active_pending_admission() else {
             return Ok(None);
         };
         // Corpus-scale discovery must run without a coordinator or admission
         // lock so status, ping, and additional bounded admissions stay live.
-        let discovery = self.runtime.discovery_context(data_root)?;
-        let observations = (self.admission_fence)(
-            &discovery,
-            self.journal.as_ref(),
-            data_root,
-            requested_catalog.as_ref(),
+        let resolution = self.resolve_pending_admission_claim(data_root, &claim);
+        self.complete_claimed_pending_admission(data_root, &claim.request_id, resolution)
+    }
+
+    fn resolve_pending_admission_claim(
+        &self,
+        data_root: &Path,
+        claim: &PendingAdmissionClaim,
+    ) -> Result<PendingAdmissionResolution> {
+        let discovery = self
+            .runtime
+            .discovery_context(data_root)?
+            .with_data_root(data_root);
+        match claim.selector {
+            SourceBackedRefreshSelector::AllAutomatic => (self.admission_fence)(
+                &discovery,
+                self.journal.as_ref(),
+                data_root,
+                claim.requested_catalog.as_ref(),
+            )
+            .map(PendingAdmissionResolution::Unscoped),
+            SourceBackedRefreshSelector::AutomaticProvider(provider) => {
+                let started = StdInstant::now();
+                let report =
+                    ctx_history_capture::discover_provider_sources_for_provider_with_context(
+                        &discovery, provider,
+                    );
+                let duration = started.elapsed();
+                self.resolve_scoped_admission_report(data_root, claim, &discovery, report, duration)
+                    .with_context(|| {
+                        format!(
+                            "resolve automatic provider `{}` source refresh admission",
+                            provider.as_str()
+                        )
+                    })
+            }
+            SourceBackedRefreshSelector::ExplicitCatalog => {
+                let authority = claim.requested_catalog.as_ref().ok_or_else(|| {
+                    anyhow!("explicit-catalog source refresh admission has no authority")
+                })?;
+                authority
+                    .validate_source_roots(data_root)
+                    .context("validate explicit source roots before scoped admission")?;
+                let started = StdInstant::now();
+                let report = authority.admission_discovery_report()?;
+                let duration = started.elapsed();
+                self.resolve_scoped_admission_report(data_root, claim, &discovery, report, duration)
+                    .context("resolve explicit-catalog source refresh admission")
+            }
+        }
+    }
+
+    fn resolve_scoped_admission_report(
+        &self,
+        data_root: &Path,
+        claim: &PendingAdmissionClaim,
+        discovery: &DiscoveryContext,
+        report: ctx_history_capture::DiscoveryReport,
+        discovery_duration: StdDuration,
+    ) -> Result<PendingAdmissionResolution> {
+        if report.sources.is_empty() && report.issues.is_empty() {
+            match claim.selector {
+                SourceBackedRefreshSelector::AutomaticProvider(provider) => bail!(
+                    "automatic provider `{}` discovery produced no executable source routes",
+                    provider.as_str()
+                ),
+                SourceBackedRefreshSelector::ExplicitCatalog => {
+                    bail!("explicit source catalog produced no executable source routes")
+                }
+                SourceBackedRefreshSelector::AllAutomatic => {
+                    bail!("all-automatic admission unexpectedly resolved as scoped")
+                }
+            }
+        }
+        validate_provider_source_roots_outside_data_root(data_root, report.sources.iter())
+            .context("validate provider roots before scoped source refresh admission")?;
+        prepare_generation_control_state(data_root)?;
+        let published_state = crate::orchestration::RetainedPublishedState {
+            journal: self.journal.as_ref(),
+        };
+        let (admitted_discovery, routes) =
+            ctx_history_refresh_execution::source_backed_admitted_discovery_from_report(
+                discovery,
+                report,
+                discovery_duration,
+                data_root,
+                claim.requested_catalog.as_ref(),
+                &published_state,
+            )?;
+        if routes.is_empty() {
+            match claim.selector {
+                SourceBackedRefreshSelector::AutomaticProvider(provider) => bail!(
+                    "automatic provider `{}` discovery produced no executable source routes",
+                    provider.as_str()
+                ),
+                SourceBackedRefreshSelector::ExplicitCatalog => {
+                    bail!("explicit source catalog produced no executable source routes")
+                }
+                SourceBackedRefreshSelector::AllAutomatic => {
+                    bail!("all-automatic admission unexpectedly resolved as scoped")
+                }
+            }
+        }
+        let selected_routes = match &claim.persisted_scope {
+            SourceBackedRefreshScope::All => routes,
+            SourceBackedRefreshScope::Exact(persisted) => {
+                let missing = persisted
+                    .difference(&routes)
+                    .cloned()
+                    .collect::<BTreeSet<_>>();
+                if !missing.is_empty() {
+                    bail!(
+                        "recovered scoped source refresh discovery is missing persisted exact routes: {missing:?}"
+                    );
+                }
+                // Provider discovery may legitimately grow while an
+                // acknowledged request is interrupted. Resume only the
+                // persisted exact selection; newly discovered routes belong
+                // to later maintenance.
+                persisted.clone()
+            }
+        };
+        if selected_routes.len() > SOURCE_REFRESH_TERMINAL_ROUTE_LIMIT {
+            bail!("scoped source refresh admission exceeds its bounded route capacity");
+        }
+        let scope = SourceBackedRefreshScope::Exact(selected_routes.clone());
+        let route_observations = source_backed_requested_route_observations(
+            admitted_discovery.watch_catalog(),
+            &selected_routes,
         );
-        self.complete_claimed_pending_admission(data_root, &request_id, observations)
+        validate_admission_observations(route_observations.clone())?;
+        Ok(PendingAdmissionResolution::Scoped(
+            read_model::AdmittedSourceBackedRefreshAuthority {
+                scope,
+                route_observations,
+                discovery: admitted_discovery,
+            },
+        ))
     }
 
     pub(super) fn active_request_admission_pending(&self) -> bool {
@@ -361,9 +528,7 @@ impl CoreRefreshEngine {
         })
     }
 
-    fn claim_active_pending_admission(
-        &self,
-    ) -> Option<(String, Option<ExplicitSourceCatalogAuthority>)> {
+    fn claim_active_pending_admission(&self) -> Option<PendingAdmissionClaim> {
         let mut state = self.lock_state();
         let request_id = state.active_request_id.clone()?;
         let attempt = find_attempt(&state, &request_id)?;
@@ -373,17 +538,20 @@ impl CoreRefreshEngine {
         {
             return None;
         }
-        let requested_catalog = attempt.requested_explicit_source_catalog.clone();
+        let claim = PendingAdmissionClaim {
+            request_id: request_id.clone(),
+            selector: attempt.selector,
+            requested_catalog: attempt.requested_explicit_source_catalog.clone(),
+            persisted_scope: attempt.refresh_scope.clone(),
+        };
         state
             .admission_resolutions_in_flight
             .insert(request_id.clone());
-        Some((request_id, requested_catalog))
+        Some(claim)
     }
 
     #[cfg(any(test, feature = "test-support"))]
-    fn claim_next_pending_admission(
-        &self,
-    ) -> Option<(String, Option<ExplicitSourceCatalogAuthority>)> {
+    fn claim_next_pending_admission(&self) -> Option<PendingAdmissionClaim> {
         let mut state = self.lock_state();
         let request_id = state
             .attempts
@@ -399,19 +567,24 @@ impl CoreRefreshEngine {
             })?
             .request_id
             .clone();
-        let requested_catalog = find_attempt(&state, &request_id)
-            .and_then(|attempt| attempt.requested_explicit_source_catalog.clone());
+        let attempt = find_attempt(&state, &request_id)?;
+        let claim = PendingAdmissionClaim {
+            request_id: request_id.clone(),
+            selector: attempt.selector,
+            requested_catalog: attempt.requested_explicit_source_catalog.clone(),
+            persisted_scope: attempt.refresh_scope.clone(),
+        };
         state
             .admission_resolutions_in_flight
             .insert(request_id.clone());
-        Some((request_id, requested_catalog))
+        Some(claim)
     }
 
     fn complete_claimed_pending_admission(
         &self,
         data_root: &Path,
         request_id: &str,
-        observations: Result<BTreeMap<SourceRouteIdentity, Option<String>>>,
+        resolution: Result<PendingAdmissionResolution>,
     ) -> Result<Option<SourceBackedRefreshRun>> {
         let mut state = self.lock_state();
         state.admission_resolutions_in_flight.remove(request_id);
@@ -420,9 +593,15 @@ impl CoreRefreshEngine {
         {
             return Ok(None);
         }
-        match observations.and_then(validate_admission_observations) {
-            Ok(observations) => {
-                self.persist_resolved_admission(data_root, &mut state, request_id, observations)?;
+        match resolution.and_then(|resolution| match resolution {
+            PendingAdmissionResolution::Unscoped(observations) => {
+                validate_admission_observations(observations)
+                    .map(PendingAdmissionResolution::Unscoped)
+            }
+            scoped @ PendingAdmissionResolution::Scoped(_) => Ok(scoped),
+        }) {
+            Ok(resolution) => {
+                self.persist_resolved_admission(data_root, &mut state, request_id, resolution)?;
                 Ok(None)
             }
             Err(error) => self.persist_failed_admission(data_root, &mut state, request_id, error),
@@ -434,9 +613,28 @@ impl CoreRefreshEngine {
         data_root: &Path,
         state: &mut CoreRefreshEngineState,
         request_id: &str,
-        mut observations: BTreeMap<SourceRouteIdentity, Option<String>>,
+        resolution: PendingAdmissionResolution,
     ) -> Result<()> {
         let snapshot = AdmissionResolutionSnapshot::capture(state);
+        let mut observations = match resolution {
+            PendingAdmissionResolution::Unscoped(observations) => observations,
+            PendingAdmissionResolution::Scoped(authority) => {
+                let observations = authority.route_observations.clone();
+                let attempt = find_attempt_mut(state, request_id)
+                    .ok_or_else(|| anyhow!("source refresh request `{request_id}` is unknown"))?;
+                if matches!(attempt.selector, SourceBackedRefreshSelector::AllAutomatic) {
+                    bail!("all-automatic source refresh received scoped admission authority");
+                }
+                if matches!(&attempt.refresh_scope, SourceBackedRefreshScope::Exact(_))
+                    && attempt.refresh_scope != authority.scope
+                {
+                    bail!("scoped source refresh admission would widen its persisted exact scope");
+                }
+                attempt.refresh_scope = authority.scope.clone();
+                attempt.admitted_authority = Some(authority);
+                observations
+            }
+        };
         if state.manual_all_continuations.contains_key(request_id) {
             let known_route_ids = state.known_route_ids.clone();
             if observations.len().saturating_add(known_route_ids.len())
@@ -576,7 +774,7 @@ impl CoreRefreshEngine {
             data_root,
             &mut state,
             request_id,
-            validate_admission_observations(observations)?,
+            PendingAdmissionResolution::Unscoped(validate_admission_observations(observations)?),
         )
     }
 }

--- a/crates/ctx-history-refresh/src/engine/admission_tests.rs
+++ b/crates/ctx-history-refresh/src/engine/admission_tests.rs
@@ -8,6 +8,353 @@ fn private_data_root() -> (tempfile::TempDir, PathBuf) {
     (temp, data_root)
 }
 
+#[derive(Debug, Clone)]
+struct ScopedAdmissionRuntime {
+    home: PathBuf,
+    cwd: PathBuf,
+}
+
+impl RefreshRuntime for ScopedAdmissionRuntime {
+    fn metadata(&self, _data_root: &Path, operation: RefreshOperation) -> RefreshRuntimeMetadata {
+        RefreshRuntimeMetadata {
+            operation,
+            ..RefreshRuntimeMetadata::default()
+        }
+    }
+
+    fn discovery_context(&self, _data_root: &Path) -> Result<DiscoveryContext> {
+        Ok(DiscoveryContext::new(
+            &self.home,
+            &self.cwd,
+            ctx_history_capture::DiscoveryPlatform::Linux,
+            ctx_history_capture::DiscoveryPlatformDirs::default(),
+        ))
+    }
+}
+
+fn scoped_runtime(root: &Path) -> Arc<dyn RefreshRuntime> {
+    let home = root.join("home");
+    let cwd = root.join("cwd");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cwd).unwrap();
+    Arc::new(ScopedAdmissionRuntime { home, cwd })
+}
+
+fn release_pending_admission(
+    coordinator: &CoreRefreshEngine,
+    admission: RefreshAdmission,
+) -> Value {
+    let (status, barrier) = admission.into_parts();
+    barrier
+        .expect("scoped request should retain a pending-admission barrier")
+        .release(coordinator);
+    status.schema_v1_fields().clone()
+}
+
+fn provider_submission(request_id: &str, provider: CaptureProvider) -> RefreshSubmission {
+    RefreshSubmission::new(
+        request_id.to_owned(),
+        RefreshOperation::Refresh,
+        None,
+        SourceBackedRefreshScope::All,
+        false,
+        false,
+    )
+    .with_selector(SourceBackedRefreshSelector::AutomaticProvider(provider))
+}
+
+#[test]
+fn automatic_provider_admission_is_exact_on_a_fresh_root_without_global_discovery() {
+    let (temp, data_root) = private_data_root();
+    let runtime = scoped_runtime(temp.path());
+    let sessions = temp.path().join("home/.codex/sessions");
+    fs::create_dir_all(&sessions).unwrap();
+    fs::write(sessions.join("session.jsonl"), "{}\n").unwrap();
+    let unrelated = temp.path().join("home/.claude/projects/unrelated");
+    fs::create_dir_all(&unrelated).unwrap();
+    fs::write(unrelated.join("broken.jsonl"), "not-json\n").unwrap();
+    // If provider selection widens to the all-provider fence, this test fails.
+    let coordinator = CoreRefreshEngine::with_admission_fence_for_test(
+        Arc::new(TestRefreshJournal::default()),
+        runtime,
+        Arc::new(|_, _, _, _| panic!("provider selection invoked global discovery")),
+    );
+    let request_id = "019fcaaa-0000-7000-8000-000000000501";
+    let admission = coordinator
+        .submit(
+            &data_root,
+            provider_submission(request_id, CaptureProvider::Codex),
+        )
+        .unwrap();
+    assert_eq!(
+        release_pending_admission(&coordinator, admission)["request_state"],
+        "admission_pending"
+    );
+
+    assert!(coordinator
+        .prepare_next_pending_admission(&data_root)
+        .unwrap());
+    let status = status_value(&coordinator, request_id);
+    assert_eq!(status["request_state"], "queued");
+    let scope = refresh_scope_from_json(status.get("refresh_scope")).unwrap();
+    let SourceBackedRefreshScope::Exact(routes) = scope else {
+        panic!("provider selection did not resolve to an exact scope");
+    };
+    assert!(!routes.is_empty());
+    // Fresh-root exact execution is seeded from request-local authority, not
+    // from global known routes or a previously installed watch catalog.
+    let run = coordinator
+        .run_next(&data_root)
+        .expect("admitted provider request should execute");
+    assert!(!run.failed, "{}", run.job);
+    assert_eq!(run.scope, SourceBackedRefreshScope::Exact(routes.clone()));
+    let receipt_routes = run.job["receipt"]["route_results"]
+        .as_object()
+        .expect("scoped publication receipt routes");
+    assert_eq!(receipt_routes.len(), routes.len());
+    assert!(routes
+        .iter()
+        .all(|route| receipt_routes.contains_key(route.as_str())));
+}
+
+#[test]
+fn unavailable_provider_admission_fails_without_widening() {
+    let (temp, data_root) = private_data_root();
+    let runtime = scoped_runtime(temp.path());
+    let coordinator = CoreRefreshEngine::with_admission_fence_for_test(
+        Arc::new(TestRefreshJournal::default()),
+        runtime,
+        Arc::new(|_, _, _, _| panic!("empty provider selection invoked global discovery")),
+    );
+    let request_id = "019fcaaa-0000-7000-8000-000000000502";
+    let admission = coordinator
+        .submit(
+            &data_root,
+            provider_submission(request_id, CaptureProvider::Claude),
+        )
+        .unwrap();
+    release_pending_admission(&coordinator, admission);
+
+    assert!(coordinator
+        .prepare_next_pending_admission(&data_root)
+        .unwrap());
+    let status = status_value(&coordinator, request_id);
+    assert_eq!(status["request_state"], "failed");
+    assert!(
+        status["last_error"]
+            .as_str()
+            .is_some_and(|error| error.contains("automatic provider `claude`")
+                && error.contains("no executable source routes")),
+        "{status:#}"
+    );
+    assert_eq!(status["refresh_scope"], json!({ "kind": "all" }));
+}
+
+#[test]
+fn explicit_catalog_admission_uses_only_its_exact_path_authority() {
+    let (temp, data_root) = private_data_root();
+    let runtime = scoped_runtime(temp.path());
+    let source_path = temp.path().join("requested-history.jsonl");
+    fs::write(&source_path, "{}\n").unwrap();
+    let source = crate::explicit_source_for_path(&source_path, None, true).unwrap();
+    let authority = crate::upsert_explicit_source(&data_root, &source)
+        .unwrap()
+        .authority;
+    let coordinator = CoreRefreshEngine::with_admission_fence_for_test(
+        Arc::new(TestRefreshJournal::default()),
+        runtime,
+        Arc::new(|_, _, _, _| panic!("explicit path invoked all-provider discovery")),
+    );
+    let request_id = "019fcaaa-0000-7000-8000-000000000503";
+    let admission = coordinator
+        .submit(
+            &data_root,
+            RefreshSubmission::new(
+                request_id.to_owned(),
+                RefreshOperation::Import,
+                Some(authority),
+                SourceBackedRefreshScope::All,
+                true,
+                false,
+            )
+            .with_selector(SourceBackedRefreshSelector::ExplicitCatalog),
+        )
+        .unwrap();
+    release_pending_admission(&coordinator, admission);
+
+    assert!(coordinator
+        .prepare_next_pending_admission(&data_root)
+        .unwrap());
+    let status = status_value(&coordinator, request_id);
+    assert_eq!(status["request_state"], "queued");
+    let scope = refresh_scope_from_json(status.get("refresh_scope")).unwrap();
+    assert!(matches!(scope, SourceBackedRefreshScope::Exact(ref routes) if routes.len() == 1));
+}
+
+#[test]
+fn explicit_catalog_admission_does_not_inherit_running_all_route_work() {
+    let (temp, data_root) = private_data_root();
+    let runtime = scoped_runtime(temp.path());
+    let source_path = temp.path().join("requested-history.jsonl");
+    fs::write(&source_path, "{}\n").unwrap();
+    let source = crate::explicit_source_for_path(&source_path, None, true).unwrap();
+    let authority = crate::upsert_explicit_source(&data_root, &source)
+        .unwrap()
+        .authority;
+    let coordinator = CoreRefreshEngine::with_admission_fence_for_test(
+        Arc::new(TestRefreshJournal::default()),
+        runtime,
+        Arc::new(|_, _, _, _| panic!("explicit path invoked all-provider discovery")),
+    );
+    let predecessor = coordinator.enqueue_periodic(&data_root).unwrap();
+    let predecessor_id = predecessor["request_id"].as_str().unwrap().to_owned();
+    {
+        let mut state = coordinator.lock_state();
+        let predecessor = find_attempt_mut(&mut state, &predecessor_id).unwrap();
+        predecessor.state = SourceBackedRefreshState::Running;
+        predecessor.started_at_ms = Some(utc_now().timestamp_millis());
+        predecessor.progress.phase = "refreshing".to_owned();
+    }
+    let request_id = "019fcaaa-0000-7000-8000-000000000505";
+    let admission = coordinator
+        .submit(
+            &data_root,
+            RefreshSubmission::new(
+                request_id.to_owned(),
+                RefreshOperation::Import,
+                Some(authority),
+                SourceBackedRefreshScope::All,
+                true,
+                false,
+            )
+            .with_selector(SourceBackedRefreshSelector::ExplicitCatalog),
+        )
+        .unwrap();
+    release_pending_admission(&coordinator, admission);
+
+    let state = coordinator.lock_state();
+    assert!(!state.manual_all_continuations.contains_key(request_id));
+    drop(state);
+    let pending = status_value(&coordinator, request_id);
+    assert_eq!(pending["request_state"], "admission_pending");
+    assert_eq!(pending["physical_attempt_id"], request_id);
+    assert!(pending["coalesced_into_request_id"].is_null());
+}
+
+#[test]
+fn recovered_provider_scope_is_rehydrated_and_cannot_widen() {
+    let (temp, data_root) = private_data_root();
+    let runtime = scoped_runtime(temp.path());
+    let sessions = temp.path().join("home/.codex/sessions");
+    fs::create_dir_all(&sessions).unwrap();
+    fs::write(sessions.join("session.jsonl"), "{}\n").unwrap();
+    let journal = Arc::new(TestRefreshJournal::default());
+    let request_id = "019fcaaa-0000-7000-8000-000000000504";
+    let first = CoreRefreshEngine::with_admission_fence_for_test(
+        Arc::clone(&journal) as Arc<dyn RefreshJournal>,
+        Arc::clone(&runtime),
+        Arc::new(|_, _, _, _| panic!("provider selection invoked global discovery")),
+    );
+    let admission = first
+        .submit(
+            &data_root,
+            provider_submission(request_id, CaptureProvider::Codex),
+        )
+        .unwrap();
+    release_pending_admission(&first, admission);
+    assert!(first.prepare_next_pending_admission(&data_root).unwrap());
+    let admitted_scope = status_value(&first, request_id)["refresh_scope"].clone();
+    let persisted_scope = refresh_scope_from_json(Some(&admitted_scope)).unwrap();
+    assert_eq!(admitted_scope["kind"], "exact");
+    drop(first);
+
+    // A newly available route for the same provider must not widen the exact
+    // request that was already persisted before the restart.
+    fs::write(
+        temp.path().join("home/.codex/history.jsonl"),
+        r#"{"session_id":"new-route","ts":1,"text":"later"}"#,
+    )
+    .unwrap();
+    let recovered = CoreRefreshEngine::with_admission_fence_for_test(
+        journal as Arc<dyn RefreshJournal>,
+        runtime,
+        Arc::new(|_, _, _, _| panic!("recovery invoked global discovery")),
+    );
+    assert!(recovered
+        .recover_interrupted_publication(&data_root)
+        .unwrap());
+    let pending = status_value(&recovered, request_id);
+    assert_eq!(pending["request_state"], "admission_pending");
+    assert_eq!(pending["refresh_scope"], admitted_scope);
+    assert!(recovered
+        .prepare_next_pending_admission(&data_root)
+        .unwrap());
+    let admitted = status_value(&recovered, request_id);
+    assert_eq!(admitted["request_state"], "queued");
+    assert_eq!(admitted["refresh_scope"], admitted_scope);
+    let run = recovered
+        .run_next(&data_root)
+        .expect("recovered exact provider request should execute");
+    assert!(!run.failed, "{}", run.job);
+    assert_eq!(run.scope, persisted_scope);
+    assert_eq!(run.job["request_state"], "published");
+}
+
+#[test]
+fn recovered_provider_scope_fails_when_a_persisted_route_disappears() {
+    let (temp, data_root) = private_data_root();
+    let runtime = scoped_runtime(temp.path());
+    let sessions = temp.path().join("home/.codex/sessions");
+    fs::create_dir_all(&sessions).unwrap();
+    fs::write(sessions.join("session.jsonl"), "{}\n").unwrap();
+    let journal = Arc::new(TestRefreshJournal::default());
+    let request_id = "019fcaaa-0000-7000-8000-000000000507";
+    let first = CoreRefreshEngine::with_admission_fence_for_test(
+        Arc::clone(&journal) as Arc<dyn RefreshJournal>,
+        Arc::clone(&runtime),
+        Arc::new(|_, _, _, _| panic!("provider selection invoked global discovery")),
+    );
+    let admission = first
+        .submit(
+            &data_root,
+            provider_submission(request_id, CaptureProvider::Codex),
+        )
+        .unwrap();
+    release_pending_admission(&first, admission);
+    assert!(first.prepare_next_pending_admission(&data_root).unwrap());
+    let admitted_scope = status_value(&first, request_id)["refresh_scope"].clone();
+    assert_eq!(admitted_scope["kind"], "exact");
+    drop(first);
+
+    // Keep the provider available under a different route so recovery must
+    // compare exact authority, rather than merely fail because it found no
+    // executable provider routes.
+    fs::remove_dir_all(&sessions).unwrap();
+    fs::write(
+        temp.path().join("home/.codex/history.jsonl"),
+        r#"{"session_id":"replacement-route","ts":1,"text":"later"}"#,
+    )
+    .unwrap();
+    let recovered = CoreRefreshEngine::with_admission_fence_for_test(
+        journal as Arc<dyn RefreshJournal>,
+        runtime,
+        Arc::new(|_, _, _, _| panic!("recovery invoked global discovery")),
+    );
+    assert!(recovered
+        .recover_interrupted_publication(&data_root)
+        .unwrap());
+    assert!(recovered
+        .prepare_next_pending_admission(&data_root)
+        .unwrap());
+    let failed = status_value(&recovered, request_id);
+    assert_eq!(failed["request_state"], "failed");
+    assert_eq!(failed["refresh_scope"], admitted_scope);
+    assert!(failed["last_error"]
+        .as_str()
+        .is_some_and(|error| error.contains("missing persisted exact routes")));
+    assert!(recovered.run_next(&data_root).is_none());
+}
+
 fn assert_retained_acknowledgement(response: &Value, request_id: &str) {
     assert_eq!(response["ok"], true);
     assert_eq!(response["request_id"], request_id);
@@ -309,6 +656,191 @@ fn stable_request_id_replay_requires_the_exact_same_payload() {
     assert_eq!(conflict["request_state"], "request_conflict");
     assert_eq!(conflict["error_code"], "request_id_conflict");
     assert_eq!(conflict["retryable"], false);
+}
+
+#[test]
+fn stable_request_id_distinguishes_exact_catalog_from_legacy_all_overlay() {
+    let (_temp, data_root) = private_data_root();
+    let coordinator = test_refresh_engine();
+    let request_id = "019fcaaa-0000-7000-8000-000000000506";
+    let authority = crate::explicit_source_catalog_authority_for_test(1);
+    let submission = |selector| {
+        RefreshSubmission::new(
+            request_id.to_owned(),
+            RefreshOperation::Import,
+            Some(authority.clone()),
+            SourceBackedRefreshScope::All,
+            true,
+            false,
+        )
+        .with_selector(selector)
+    };
+
+    let legacy = coordinator
+        .submit(
+            &data_root,
+            submission(SourceBackedRefreshSelector::AllAutomatic),
+        )
+        .unwrap();
+    release_pending_admission(&coordinator, legacy);
+    let conflict = coordinator
+        .submit(
+            &data_root,
+            submission(SourceBackedRefreshSelector::ExplicitCatalog),
+        )
+        .unwrap();
+    let conflict = conflict.status().schema_v1_fields();
+    assert_eq!(conflict["request_state"], "request_conflict");
+    assert_eq!(conflict["error_code"], "request_id_conflict");
+}
+
+#[test]
+fn stable_request_id_replays_the_same_provider_and_conflicts_on_provider_change() {
+    let (_temp, data_root) = private_data_root();
+    let coordinator = test_refresh_engine();
+    let request_id = "019fcaaa-0000-7000-8000-000000000414";
+    let submission = |provider| {
+        RefreshSubmission::new(
+            request_id.to_owned(),
+            RefreshOperation::Refresh,
+            None,
+            SourceBackedRefreshScope::All,
+            false,
+            false,
+        )
+        .with_selector(SourceBackedRefreshSelector::AutomaticProvider(provider))
+    };
+
+    let first = coordinator
+        .submit(&data_root, submission(CaptureProvider::Codex))
+        .unwrap();
+    let replay = coordinator
+        .submit(&data_root, submission(CaptureProvider::Codex))
+        .unwrap();
+    assert_eq!(replay.status(), first.status());
+
+    let conflict = coordinator
+        .submit(&data_root, submission(CaptureProvider::Claude))
+        .unwrap();
+    let conflict = conflict.status().schema_v1_fields();
+    assert_eq!(conflict["request_state"], "request_conflict");
+    assert_eq!(conflict["error_code"], "request_id_conflict");
+}
+
+#[test]
+fn provider_selection_does_not_coalesce_with_all_automatic() {
+    let (_temp, data_root) = private_data_root();
+    let coordinator = test_refresh_engine();
+    let all_request_id = "019fcaaa-0000-7000-8000-000000000415";
+    let provider_request_id = "019fcaaa-0000-7000-8000-000000000416";
+    let submission = |request_id: &str| {
+        RefreshSubmission::new(
+            request_id.to_owned(),
+            RefreshOperation::Refresh,
+            None,
+            SourceBackedRefreshScope::All,
+            false,
+            false,
+        )
+    };
+
+    let all = coordinator
+        .submit(&data_root, submission(all_request_id))
+        .unwrap();
+    let provider = coordinator
+        .submit(
+            &data_root,
+            submission(provider_request_id).with_selector(
+                SourceBackedRefreshSelector::AutomaticProvider(CaptureProvider::Codex),
+            ),
+        )
+        .unwrap();
+
+    assert_eq!(all.status()["request_id"], all_request_id);
+    assert_eq!(provider.status()["request_id"], provider_request_id);
+    assert_eq!(
+        status_value(&coordinator, all_request_id)["refresh_selector"],
+        json!({ "kind": "all_automatic" })
+    );
+    assert_eq!(
+        status_value(&coordinator, provider_request_id)["refresh_selector"],
+        json!({ "kind": "automatic_provider", "provider": "codex" })
+    );
+}
+
+#[test]
+fn durable_recovery_preserves_selector_separately_from_physical_scope() {
+    let routes = BTreeSet::from([
+        SourceRouteIdentity::from_sha256("41".repeat(32)).unwrap(),
+        SourceRouteIdentity::from_sha256("42".repeat(32)).unwrap(),
+    ]);
+    let scope = SourceBackedRefreshScope::Exact(routes);
+    let mut attempt = new_refresh_attempt(
+        None,
+        SourceRefreshRuntimeMetadata::default(),
+        None,
+        scope.clone(),
+    );
+    attempt.selector = SourceBackedRefreshSelector::AutomaticProvider(CaptureProvider::Codex);
+    let job = attempt.job_json();
+
+    assert_eq!(
+        job["refresh_selector"],
+        json!({ "kind": "automatic_provider", "provider": "codex" })
+    );
+    let recovered = recover_queued_root(&job, None).unwrap();
+    assert_eq!(recovered.selector, attempt.selector);
+    assert_eq!(recovered.refresh_scope, scope);
+
+    let mut legacy = job.clone();
+    legacy.as_object_mut().unwrap().remove("refresh_selector");
+    let recovered_legacy = recover_queued_root(&legacy, None).unwrap();
+    assert_eq!(
+        recovered_legacy.selector,
+        SourceBackedRefreshSelector::AllAutomatic
+    );
+    assert_eq!(recovered_legacy.refresh_scope, attempt.refresh_scope);
+
+    let mut legacy_explicit = new_refresh_attempt(
+        None,
+        SourceRefreshRuntimeMetadata {
+            operation: SourceBackedRefreshOperation::Import,
+            daemon_mode: "full".to_owned(),
+            trigger: "import",
+            trigger_provenance: "explicit_source_catalog",
+        },
+        Some(crate::explicit_source_catalog_authority_for_test(1)),
+        SourceBackedRefreshScope::All,
+    )
+    .job_json();
+    legacy_explicit
+        .as_object_mut()
+        .unwrap()
+        .remove("refresh_selector");
+    let recovered_explicit = recover_queued_root(&legacy_explicit, None).unwrap();
+    assert_eq!(
+        recovered_explicit.selector,
+        SourceBackedRefreshSelector::AllAutomatic
+    );
+
+    let mut malformed = job.clone();
+    malformed["refresh_selector"] = json!({
+        "kind": "automatic_provider",
+        "provider": "codex",
+        "unexpected": true,
+    });
+    assert!(recover_queued_root(&malformed, None).is_err());
+
+    let mut unknown_provider = job.clone();
+    unknown_provider["refresh_selector"] = json!({
+        "kind": "automatic_provider",
+        "provider": "unknown",
+    });
+    assert!(recover_queued_root(&unknown_provider, None).is_err());
+
+    let mut missing_authority = job;
+    missing_authority["refresh_selector"] = json!({ "kind": "explicit_catalog" });
+    assert!(recover_queued_root(&missing_authority, None).is_err());
 }
 
 #[test]

--- a/crates/ctx-history-refresh/src/engine/attempt_helpers.rs
+++ b/crates/ctx-history-refresh/src/engine/attempt_helpers.rs
@@ -462,7 +462,11 @@ pub(super) fn new_refresh_attempt(
             SourceBackedRefreshOperation::Refresh => SourceBackedReconciliationDemand::Incremental,
             SourceBackedRefreshOperation::Import => SourceBackedReconciliationDemand::Exhaustive,
         },
+        // Callers that own a typed scoped request replace this legacy
+        // all-route default after construction.
+        selector: SourceBackedRefreshSelector::AllAutomatic,
         requested_explicit_source_catalog: requested_catalog,
+        admitted_authority: None,
         fresh_after_admitted_snapshot: false,
         request_fingerprint: None,
         admission_durability_indeterminate: false,
@@ -504,6 +508,45 @@ pub(super) fn recover_reconciliation_demand(
             SourceBackedRefreshOperation::Refresh => SourceBackedReconciliationDemand::Incremental,
             SourceBackedRefreshOperation::Import => SourceBackedReconciliationDemand::Exhaustive,
         }),
+    }
+}
+
+pub(super) fn recover_refresh_selector(
+    job: &Value,
+    operation: SourceBackedRefreshOperation,
+    has_explicit_catalog: bool,
+    allow_legacy_terminal_catalog_omission: bool,
+) -> Result<SourceBackedRefreshSelector> {
+    let legacy = job.get("refresh_selector").is_none();
+    let selector = match job.get("refresh_selector") {
+        Some(value) => SourceBackedRefreshSelector::from_json(value)?,
+        None => SourceBackedRefreshSelector::AllAutomatic,
+    };
+    if legacy {
+        match (
+            operation,
+            has_explicit_catalog,
+            allow_legacy_terminal_catalog_omission,
+        ) {
+            (SourceBackedRefreshOperation::Import, false, false) => {
+                bail!("durable import source refresh has no explicit source authority")
+            }
+            (SourceBackedRefreshOperation::Refresh, true, _) => {
+                bail!("durable refresh carries legacy explicit source authority")
+            }
+            _ => {}
+        }
+    }
+    match (selector, has_explicit_catalog) {
+        (SourceBackedRefreshSelector::AllAutomatic, _)
+        | (SourceBackedRefreshSelector::AutomaticProvider(_), false)
+        | (SourceBackedRefreshSelector::ExplicitCatalog, true) => Ok(selector),
+        (SourceBackedRefreshSelector::ExplicitCatalog, false) => {
+            bail!("durable explicit-catalog source refresh has no catalog authority")
+        }
+        (SourceBackedRefreshSelector::AutomaticProvider(_), true) => {
+            bail!("durable automatic provider source refresh carries explicit catalog authority")
+        }
     }
 }
 

--- a/crates/ctx-history-refresh/src/engine/durable_queue.rs
+++ b/crates/ctx-history-refresh/src/engine/durable_queue.rs
@@ -480,7 +480,10 @@ fn recover_pending_attempt(
     // Pre-overlay periodic roots can carry obsolete catalog-shaped data. It
     // was never request authority for refresh operations, so retain that
     // compatibility without weakening import or successor validation.
-    let requested_catalog = if is_root && operation == SourceBackedRefreshOperation::Refresh {
+    let requested_catalog = if is_root
+        && operation == SourceBackedRefreshOperation::Refresh
+        && job.get("refresh_selector").is_none()
+    {
         None
     } else {
         job.get("requested_explicit_source_catalog")
@@ -489,15 +492,8 @@ fn recover_pending_attempt(
             .transpose()
             .with_context(|| format!("recover durable source refresh {role} explicit authority"))?
     };
-    match (operation, requested_catalog.is_some()) {
-        (SourceBackedRefreshOperation::Import, false) => {
-            bail!("durable import {role} has no explicit source authority")
-        }
-        (SourceBackedRefreshOperation::Refresh, true) => {
-            bail!("durable refresh {role} carries explicit source authority")
-        }
-        _ => {}
-    }
+    let selector = recover_refresh_selector(job, operation, requested_catalog.is_some(), false)
+        .with_context(|| format!("recover durable source refresh {role} selector"))?;
     let daemon_mode = job
         .get("daemon_mode")
         .and_then(Value::as_str)
@@ -537,6 +533,7 @@ fn recover_pending_attempt(
         refresh_scope,
     );
     attempt.request_id = request_id.to_owned();
+    attempt.selector = selector;
     attempt.reconciliation_demand = recover_reconciliation_demand(job, operation)?;
     attempt.physical_attempt_id = optional_pending_string(job, "physical_attempt_id")?;
     attempt.state = if request_state == Some("admission_pending") {
@@ -593,6 +590,7 @@ fn recover_pending_attempt(
     }
     if attempt.state == SourceBackedRefreshState::AdmissionPending
         && !attempt.fresh_after_admitted_snapshot
+        && matches!(attempt.selector, SourceBackedRefreshSelector::AllAutomatic)
     {
         bail!("durable admission-pending source refresh has no freshness requirement");
     }

--- a/crates/ctx-history-refresh/src/engine/read_model.rs
+++ b/crates/ctx-history-refresh/src/engine/read_model.rs
@@ -95,7 +95,12 @@ pub(super) struct SourceBackedRefreshAttempt {
     pub(super) refresh_scope: SourceBackedRefreshScope,
     pub(super) operation: SourceBackedRefreshOperation,
     pub(super) reconciliation_demand: SourceBackedReconciliationDemand,
+    pub(super) selector: SourceBackedRefreshSelector,
     pub(super) requested_explicit_source_catalog: Option<ExplicitSourceCatalogAuthority>,
+    /// Attempt-local authority resolved from the logical selector. Durable
+    /// state persists only the selector and exact scope; recovery rehydrates
+    /// and verifies this provider-neutral input before execution.
+    pub(super) admitted_authority: Option<AdmittedSourceBackedRefreshAuthority>,
     pub(super) fresh_after_admitted_snapshot: bool,
     pub(super) request_fingerprint: Option<String>,
     pub(super) admission_durability_indeterminate: bool,
@@ -125,6 +130,13 @@ pub(super) struct SourceBackedRefreshAttempt {
     pub(super) failure_type: Option<&'static str>,
     pub(super) failure_outcome: Option<SourceBackedRefreshFailureOutcome>,
     pub(super) last_error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct AdmittedSourceBackedRefreshAuthority {
+    pub(super) scope: SourceBackedRefreshScope,
+    pub(super) route_observations: BTreeMap<SourceRouteIdentity, Option<String>>,
+    pub(super) discovery: ctx_history_refresh_execution::SourceBackedAdmittedDiscovery,
 }
 
 impl SourceBackedRefreshAttempt {
@@ -258,6 +270,7 @@ impl SourceBackedRefreshAttempt {
             "reconciliation_demand".to_owned(),
             json!(self.reconciliation_demand.as_str()),
         );
+        fields.insert("refresh_selector".to_owned(), self.selector.to_json());
         if let Some(outcome) = self.structured_outcome_json() {
             fields.insert("structured_outcome".to_owned(), outcome);
         }
@@ -279,11 +292,9 @@ impl SourceBackedRefreshAttempt {
             "previous_generation": self.previous_generation,
             "published_generation": self.published_generation,
             "refresh_scope": refresh_scope_json(&self.refresh_scope),
-            "requested_explicit_source_catalog": self.receipt.is_none().then(|| {
-                self.requested_explicit_source_catalog
-                    .as_ref()
-                    .map(ExplicitSourceCatalogAuthority::to_json)
-            }).flatten(),
+            "requested_explicit_source_catalog": self.requested_explicit_source_catalog
+                .as_ref()
+                .map(ExplicitSourceCatalogAuthority::to_json),
             "fresh_after_admitted_snapshot": self.fresh_after_admitted_snapshot,
             "request_fingerprint": self.request_fingerprint,
             "admission_acknowledgement": self.admission_durability_indeterminate
@@ -343,11 +354,9 @@ impl SourceBackedRefreshAttempt {
             "previous_generation": self.previous_generation,
             "published_generation": self.published_generation,
             "refresh_scope": refresh_scope_json(&self.refresh_scope),
-            "requested_explicit_source_catalog": self.receipt.is_none().then(|| {
-                self.requested_explicit_source_catalog
-                    .as_ref()
-                    .map(ExplicitSourceCatalogAuthority::to_json)
-            }).flatten(),
+            "requested_explicit_source_catalog": self.requested_explicit_source_catalog
+                .as_ref()
+                .map(ExplicitSourceCatalogAuthority::to_json),
             "fresh_after_admitted_snapshot": self.fresh_after_admitted_snapshot,
             "request_fingerprint": self.request_fingerprint,
             "admission_acknowledgement": self.admission_durability_indeterminate

--- a/crates/ctx-history-refresh/src/engine/request_lifecycle.rs
+++ b/crates/ctx-history-refresh/src/engine/request_lifecycle.rs
@@ -8,6 +8,8 @@ struct AdmittedRefreshScope {
     covered_publication: SourceBackedRefreshCoveredPublication,
     route_worksets: BTreeMap<SourceRouteIdentity, SourceBackedRefreshWorkset>,
     watch_catalog: Option<SourceBackedWatchCatalog>,
+    admitted_discovery: Option<ctx_history_refresh_execution::SourceBackedAdmittedDiscovery>,
+    requires_admitted_discovery: bool,
 }
 
 impl CoreRefreshEngine {
@@ -136,6 +138,9 @@ impl CoreRefreshEngine {
         refresh_scope: SourceBackedRefreshScope,
         logical_demand: SourceRefreshLogicalDemand,
     ) -> Result<Value> {
+        // This compatibility entry point predates typed selectors. Its
+        // explicit catalog is an all-route overlay.
+        let selector = SourceBackedRefreshSelector::AllAutomatic;
         let mut state = self.lock_state();
         let response = Self::enqueue_with_catalog_metadata_locked(
             &mut state,
@@ -144,6 +149,7 @@ impl CoreRefreshEngine {
             requested_catalog,
             refresh_scope,
             logical_demand,
+            selector,
         )?;
         trim_terminal_attempt_history(&mut state);
         Ok(response)
@@ -156,6 +162,7 @@ impl CoreRefreshEngine {
         requested_catalog: Option<ExplicitSourceCatalogAuthority>,
         refresh_scope: SourceBackedRefreshScope,
         logical_demand: SourceRefreshLogicalDemand,
+        selector: SourceBackedRefreshSelector,
     ) -> Result<Value> {
         let SourceRefreshLogicalDemand {
             admission,
@@ -178,9 +185,14 @@ impl CoreRefreshEngine {
             return projected_status_json(state, &existing.request_id)
                 .ok_or_else(|| anyhow!("existing source refresh request disappeared"));
         }
+        // Only a genuinely all-automatic request may enter the all-route
+        // continuation path. Typed provider and explicit-catalog selections
+        // begin at the legacy wire scope of All, but scoped admission must
+        // resolve them to Exact without inheriting unrelated predecessor work.
         let is_manual_all = admission
             == SourceRefreshAdmissionRequirement::FreshAfterAdmittedSnapshot
-            && refresh_scope == SourceBackedRefreshScope::All;
+            && refresh_scope == SourceBackedRefreshScope::All
+            && matches!(selector, SourceBackedRefreshSelector::AllAutomatic);
         // A later manual exhaustive demand is a logical waiter on the one
         // already-queued exhaustive successor. It receives its own durable
         // request identity but cannot manufacture another physical scan.
@@ -190,6 +202,10 @@ impl CoreRefreshEngine {
                     find_attempt(state, request_id)
                         .filter(|attempt| {
                             attempt.state == SourceBackedRefreshState::Queued
+                                && !matches!(
+                                    attempt.selector,
+                                    SourceBackedRefreshSelector::AutomaticProvider(_)
+                                )
                                 && attempt.refresh_scope == SourceBackedRefreshScope::All
                                 && attempt.reconciliation_demand >= reconciliation_demand
                         })
@@ -201,7 +217,12 @@ impl CoreRefreshEngine {
         if let Some(active_request_id) = state.active_request_id.clone() {
             if let Some(active) = find_attempt_mut(state, &active_request_id) {
                 if active.state.is_active() {
-                    if is_manual_all {
+                    if is_manual_all
+                        && !matches!(
+                            active.selector,
+                            SourceBackedRefreshSelector::AutomaticProvider(_)
+                        )
+                    {
                         // Command ownership applies to the work a command is
                         // waiting on even when a running attempt remains
                         // physically immutable and needs a logical successor.
@@ -237,13 +258,15 @@ impl CoreRefreshEngine {
                         // publication instead of eagerly repeating the pass.
                         merge_trigger_ownership(active, &metadata);
                     } else {
-                        if let Some(requested_catalog) = requested_catalog.as_ref() {
-                            let upgrades_queued_automatic =
-                                active.requested_explicit_source_catalog.is_none()
-                                    && active.state == SourceBackedRefreshState::Queued;
-                            if upgrades_queued_automatic {
-                                active.requested_explicit_source_catalog =
-                                    Some(requested_catalog.clone());
+                        if active.selector == selector {
+                            if let Some(requested_catalog) = requested_catalog.as_ref() {
+                                let upgrades_queued_automatic =
+                                    active.requested_explicit_source_catalog.is_none()
+                                        && active.state == SourceBackedRefreshState::Queued;
+                                if upgrades_queued_automatic {
+                                    active.requested_explicit_source_catalog =
+                                        Some(requested_catalog.clone());
+                                }
                             }
                         }
                         let automatic_exact = active.trigger == "periodic"
@@ -261,6 +284,7 @@ impl CoreRefreshEngine {
                             && reconciliation_demand > active.reconciliation_demand;
                         if active.requested_explicit_source_catalog.as_ref()
                             == requested_catalog.as_ref()
+                            && active.selector == selector
                             && active.refresh_scope == refresh_scope
                             && !stronger_running_demand
                         {
@@ -284,6 +308,7 @@ impl CoreRefreshEngine {
                         attempt.state.is_active()
                             && attempt.requested_explicit_source_catalog.as_ref()
                                 == requested_catalog.as_ref()
+                            && attempt.selector == selector
                             && attempt.refresh_scope == refresh_scope
                             && attempt.reconciliation_demand >= reconciliation_demand
                     })
@@ -315,6 +340,7 @@ impl CoreRefreshEngine {
             attempt.physical_attempt_id = Some(attempt.request_id.clone());
         }
         attempt.request_fingerprint = request_fingerprint;
+        attempt.selector = selector;
         attempt.fresh_after_admitted_snapshot =
             admission == SourceRefreshAdmissionRequirement::FreshAfterAdmittedSnapshot;
         attempt.reconciliation_demand = reconciliation_demand;
@@ -606,22 +632,25 @@ impl CoreRefreshEngine {
         };
         let verified = match verified {
             Ok((observed, publication)) => {
-                let exact_scope_matches = match &refresh_scope {
-                    SourceBackedRefreshScope::All => true,
+                let exact_scope_mismatch = match &refresh_scope {
+                    SourceBackedRefreshScope::All => None,
                     SourceBackedRefreshScope::Exact(routes) => {
-                        publication
+                        let actual = publication
                             .route_results
                             .iter()
                             .filter_map(|result| {
                                 SourceRouteIdentity::from_sha256(result.route_identity.clone()).ok()
                             })
-                            .collect::<BTreeSet<_>>()
-                            == *routes
-                            && publication.route_results.len() == routes.len()
+                            .collect::<BTreeSet<_>>();
+                        (actual != *routes || publication.route_results.len() != routes.len())
+                            .then_some((routes, actual))
                     }
                 };
-                if !exact_scope_matches {
-                    Err("validate terminal Core publication: exact refresh omitted or added a selected route outcome".to_owned())
+                if let Some((expected, actual)) = exact_scope_mismatch {
+                    Err(format!(
+                        "validate terminal Core publication: exact refresh omitted or added a selected route outcome (expected={expected:?}, actual={actual:?}, result_count={})",
+                        publication.route_results.len()
+                    ))
                 } else {
                     SourceBackedRefreshReceipt::from_verified_publication(
                         previous_generation.clone(),

--- a/crates/ctx-history-refresh/src/engine/request_lifecycle/admission_scope.rs
+++ b/crates/ctx-history-refresh/src/engine/request_lifecycle/admission_scope.rs
@@ -53,6 +53,20 @@ impl CoreRefreshEngine {
         if state.route_admissions.contains_key(request_id) {
             bail!("source refresh request `{request_id}` already has retained route admissions");
         }
+        let (admitted_authority, requires_admitted_discovery) = find_attempt(&state, request_id)
+            .map(|attempt| {
+                (
+                    attempt.admitted_authority.clone(),
+                    attempt.selector.is_scoped()
+                        && matches!(scope, SourceBackedRefreshScope::Exact(_)),
+                )
+            })
+            .unwrap_or((None, false));
+        if let Some(authority) = admitted_authority.as_ref() {
+            if &authority.scope != scope {
+                bail!("scoped source refresh execution does not match its admitted exact scope");
+            }
+        }
         let known_route_ids = state.known_route_ids.clone();
         let mut covered_route_ids = if let Some(continuation) =
             state.manual_all_continuations.get_mut(request_id)
@@ -118,6 +132,23 @@ impl CoreRefreshEngine {
                         "daemon exact source refresh must admit between one and {SOURCE_REFRESH_TERMINAL_ROUTE_LIMIT} routes"
                     );
                 }
+                if admitted_authority.is_some() {
+                    let watermark = state.dirty_routes.seed_watermark();
+                    for route in routes {
+                        state
+                            .route_event_watermarks
+                            .entry(route.clone())
+                            .and_modify(|current| *current = (*current).max(watermark))
+                            .or_insert(watermark);
+                    }
+                    state.dirty_routes.seed_exact_routes(
+                        routes.iter().cloned(),
+                        watermark,
+                        // A logical request is explicit admission, so its
+                        // first exact attempt bypasses watcher debounce.
+                        now_ms.saturating_sub(1_000),
+                    );
+                }
                 state
                     .dirty_routes
                     .admit_exact_routes(routes, now_ms)
@@ -178,7 +209,12 @@ impl CoreRefreshEngine {
             covered_route_ids,
             covered_publication,
             route_worksets,
-            watch_catalog: state.watch_catalog.clone(),
+            watch_catalog: admitted_authority
+                .as_ref()
+                .map(|authority| authority.discovery.watch_catalog().clone())
+                .or_else(|| state.watch_catalog.clone()),
+            admitted_discovery: admitted_authority.map(|authority| authority.discovery),
+            requires_admitted_discovery,
         })
     }
 

--- a/crates/ctx-history-refresh/src/engine/request_lifecycle/recovery.rs
+++ b/crates/ctx-history-refresh/src/engine/request_lifecycle/recovery.rs
@@ -22,7 +22,10 @@ impl CoreRefreshEngine {
         let active_generation = verified
             .as_ref()
             .map(|verified| verified.generation_id().to_owned());
-        let queued_successors = recover_queued_successors(&job)?;
+        let mut queued_successors = recover_queued_successors(&job)?;
+        for successor in &mut queued_successors {
+            require_scoped_rehydration(successor)?;
+        }
         let recovered_continuations = recover_logical_demand_continuations(&job)?;
         let request_state = job
             .get("request_state")
@@ -243,7 +246,8 @@ impl CoreRefreshEngine {
         } else {
             active_generation.clone()
         };
-        let root = recover_queued_root(&job, recovered_previous_generation)?;
+        let mut root = recover_queued_root(&job, recovered_previous_generation)?;
+        require_scoped_rehydration(&mut root)?;
         let request_id = root.request_id.clone();
         {
             let mut state = self.lock_state();
@@ -323,7 +327,8 @@ impl CoreRefreshEngine {
             object.remove(field);
         }
 
-        let root = recover_queued_root(&rebuild_job, None)?;
+        let mut root = recover_queued_root(&rebuild_job, None)?;
+        require_scoped_rehydration(&mut root)?;
         let request_id = root.request_id.clone();
         let mut state = self.lock_state();
         if state.active_request_id.is_some() || !state.pending_request_ids.is_empty() {
@@ -376,6 +381,21 @@ impl CoreRefreshEngine {
         self.persist_job_status(data_root, &durable_request_id)?;
         Ok(true)
     }
+}
+
+fn require_scoped_rehydration(attempt: &mut SourceBackedRefreshAttempt) -> Result<()> {
+    if matches!(attempt.selector, SourceBackedRefreshSelector::AllAutomatic) {
+        return Ok(());
+    }
+    if attempt.state == SourceBackedRefreshState::Queued
+        && !matches!(attempt.refresh_scope, SourceBackedRefreshScope::Exact(_))
+    {
+        bail!("durable resolved scoped source refresh has no exact physical scope");
+    }
+    attempt.admitted_authority = None;
+    attempt.state = SourceBackedRefreshState::AdmissionPending;
+    attempt.progress.phase = "admission_pending".to_owned();
+    Ok(())
 }
 
 fn recover_exact_published_attempt(
@@ -499,6 +519,8 @@ fn recover_terminal_attempt(
         .filter(|value| !value.is_null())
         .map(ExplicitSourceCatalogAuthority::from_json)
         .transpose()?;
+    let selector = recover_refresh_selector(job, operation, requested_catalog.is_some(), true)
+        .context("recover durable terminal source refresh selector")?;
     let previous_generation = optional_generation(job.get("previous_generation"))?;
     let mut attempt = new_refresh_attempt(
         previous_generation,
@@ -513,6 +535,7 @@ fn recover_terminal_attempt(
     );
     attempt.request_id =
         required_nonempty_string(job, "request_id", "terminal source refresh")?.to_owned();
+    attempt.selector = selector;
     attempt.physical_attempt_id = optional_string(job, "physical_attempt_id")?;
     attempt.reconciliation_demand = recover_reconciliation_demand(job, operation)?;
     attempt.state = state;

--- a/crates/ctx-history-refresh/src/engine/request_lifecycle/resolution.rs
+++ b/crates/ctx-history-refresh/src/engine/request_lifecycle/resolution.rs
@@ -75,7 +75,7 @@ impl CoreRefreshEngine {
             &BTreeSet<SourceRouteIdentity>,
         ) -> Result<BTreeMap<SourceRouteIdentity, Option<String>>>,
     {
-        let (sample_request_id, sample_routes) = {
+        let (sample_request_id, sample_routes, scoped_catalog) = {
             let state = self.lock_state();
             let request_id = state.active_request_id.clone()?;
             let continuation = state.manual_all_continuations.get(&request_id)?;
@@ -100,13 +100,26 @@ impl CoreRefreshEngine {
                 .filter(|route| !continuation.ledger_eligible_routes.contains(*route))
                 .cloned()
                 .collect();
-            (request_id, routes)
+            let scoped_catalog = requested
+                .admitted_authority
+                .as_ref()
+                .map(|authority| authority.discovery.watch_catalog().clone());
+            (request_id, routes, scoped_catalog)
         };
-        let post_publication_fence = self.post_publication_route_coverage_fence_with(
-            &sample_request_id,
-            sample_routes,
-            sample,
-        );
+        let post_publication_fence = match scoped_catalog {
+            Some(catalog) => self.post_publication_route_coverage_fence_with(
+                &sample_request_id,
+                sample_routes,
+                move |_authority, routes| {
+                    Ok(source_backed_requested_route_observations(&catalog, routes))
+                },
+            ),
+            None => self.post_publication_route_coverage_fence_with(
+                &sample_request_id,
+                sample_routes,
+                sample,
+            ),
+        };
 
         let mut state = self.lock_state();
         let request_id = state.active_request_id.clone()?;
@@ -384,6 +397,8 @@ impl CoreRefreshEngine {
                         scope: refresh_scope.clone(),
                         route_worksets: admitted.route_worksets,
                         watch_catalog: admitted.watch_catalog,
+                        admitted_discovery: admitted.admitted_discovery,
+                        requires_admitted_discovery: admitted.requires_admitted_discovery,
                         covered_route_ids: admitted.covered_route_ids,
                         covered_publication: admitted.covered_publication,
                     },
@@ -494,6 +509,20 @@ impl CoreRefreshEngine {
         data_root: &Path,
         request_id: &str,
     ) -> PostPublicationRouteCoverageFence {
+        let scoped_catalog = {
+            let state = self.lock_state();
+            find_attempt(&state, request_id)
+                .and_then(|attempt| attempt.admitted_authority.as_ref())
+                .map(|authority| authority.discovery.watch_catalog().clone())
+        };
+        if let Some(catalog) = scoped_catalog {
+            return self.regular_post_publication_route_coverage_fence_with(
+                request_id,
+                move |_authority, routes| {
+                    Ok(source_backed_requested_route_observations(&catalog, routes))
+                },
+            );
+        }
         self.regular_post_publication_route_coverage_fence_with(request_id, |catalog, routes| {
             let discovery = self.runtime.discovery_context(data_root)?;
             source_backed_requested_route_observation_fence(

--- a/crates/ctx-history-refresh/src/lib.rs
+++ b/crates/ctx-history-refresh/src/lib.rs
@@ -34,9 +34,7 @@ use ctx_history_capture::{
 };
 #[cfg(test)]
 use ctx_history_capture_model::{DiscoveryReport, ProviderSourceStatus};
-use ctx_history_core::utc_now;
-#[cfg(test)]
-use ctx_history_core::CaptureProvider;
+use ctx_history_core::{utc_now, CaptureProvider};
 #[cfg(test)]
 use ctx_history_index::WriterOptions;
 use ctx_history_index::{
@@ -101,7 +99,7 @@ pub use request::{
     RefreshMaintenanceWakeStatus, RefreshOperation, RefreshOutcomeClass, RefreshOutcomeCode,
     RefreshRequestState, RefreshRequestTrigger, RefreshRetryAdvice, RefreshStatus,
     RefreshStatusKind, RefreshSubmission, RefreshTerminalFailureScope, RefreshTerminalFailureType,
-    RefreshTerminalOutcome,
+    RefreshTerminalOutcome, SourceBackedRefreshSelector,
 };
 pub use route_ledger::EventWatermark;
 

--- a/crates/ctx-history-refresh/src/orchestration.rs
+++ b/crates/ctx-history-refresh/src/orchestration.rs
@@ -10,6 +10,9 @@ pub(super) struct SourceBackedRefreshPlan<'a> {
     pub(super) scope: SourceBackedRefreshScope,
     pub(super) route_worksets: BTreeMap<SourceRouteIdentity, SourceBackedRefreshWorkset>,
     pub(super) watch_catalog: Option<SourceBackedWatchCatalog>,
+    pub(super) admitted_discovery:
+        Option<ctx_history_refresh_execution::SourceBackedAdmittedDiscovery>,
+    pub(super) requires_admitted_discovery: bool,
     pub(super) covered_route_ids: BTreeSet<SourceRouteIdentity>,
     pub(super) covered_publication: SourceBackedRefreshCoveredPublication,
 }
@@ -88,7 +91,9 @@ pub(super) fn execute_source_backed_refresh(
         )
         .with_reconciliation_demand(plan.reconciliation_demand)
         .with_route_worksets(plan.route_worksets)
-        .with_watch_catalog_opt(plan.watch_catalog),
+        .with_watch_catalog_opt(plan.watch_catalog)
+        .with_admitted_discovery_opt(plan.admitted_discovery)
+        .with_admitted_discovery_requirement(plan.requires_admitted_discovery),
     )
 }
 

--- a/crates/ctx-history-refresh/src/request.rs
+++ b/crates/ctx-history-refresh/src/request.rs
@@ -293,6 +293,137 @@ impl std::str::FromStr for RefreshRequestTrigger {
     }
 }
 
+/// Logical source selection owned by one refresh request.
+///
+/// This remains distinct from [`SourceBackedRefreshScope`]: provider and
+/// explicit-catalog selections are resolved by daemon admission into an exact
+/// physical route set before capture execution begins.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum SourceBackedRefreshSelector {
+    AllAutomatic,
+    AutomaticProvider(CaptureProvider),
+    ExplicitCatalog,
+}
+
+impl SourceBackedRefreshSelector {
+    #[doc(hidden)]
+    pub fn to_json(self) -> Value {
+        match self {
+            Self::AllAutomatic => json!({ "kind": "all_automatic" }),
+            Self::AutomaticProvider(provider) => json!({
+                "kind": "automatic_provider",
+                "provider": provider.as_str(),
+            }),
+            Self::ExplicitCatalog => json!({ "kind": "explicit_catalog" }),
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn from_json(value: &Value) -> Result<Self> {
+        let fields = value
+            .as_object()
+            .ok_or_else(|| anyhow!("source refresh selector is not an object"))?;
+        match fields.get("kind").and_then(Value::as_str) {
+            Some("all_automatic") if fields.len() == 1 => Ok(Self::AllAutomatic),
+            Some("automatic_provider") if fields.len() == 2 => {
+                let provider = fields
+                    .get("provider")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("automatic provider selector has no provider"))?
+                    .parse()
+                    .context("parse automatic provider selector")?;
+                if provider == CaptureProvider::Unknown {
+                    bail!("automatic provider selector has an unknown provider");
+                }
+                Ok(Self::AutomaticProvider(provider))
+            }
+            Some("explicit_catalog") if fields.len() == 1 => Ok(Self::ExplicitCatalog),
+            Some(kind) => bail!("source refresh selector `{kind}` is malformed"),
+            None => bail!("source refresh selector kind is missing"),
+        }
+    }
+
+    pub const fn is_scoped(self) -> bool {
+        !matches!(self, Self::AllAutomatic)
+    }
+}
+
+#[cfg(test)]
+mod source_backed_refresh_selector_tests {
+    use super::*;
+
+    #[test]
+    fn selector_json_round_trips_and_rejects_malformed_scoped_values() {
+        for selector in [
+            SourceBackedRefreshSelector::AllAutomatic,
+            SourceBackedRefreshSelector::AutomaticProvider(CaptureProvider::Codex),
+            SourceBackedRefreshSelector::ExplicitCatalog,
+        ] {
+            assert_eq!(
+                SourceBackedRefreshSelector::from_json(&selector.to_json()).unwrap(),
+                selector
+            );
+        }
+
+        for malformed in [
+            json!({ "kind": "automatic_provider" }),
+            json!({ "kind": "automatic_provider", "provider": 7 }),
+            json!({ "kind": "automatic_provider", "provider": "unknown" }),
+            json!({
+                "kind": "automatic_provider",
+                "provider": "codex",
+                "unexpected": true,
+            }),
+            json!({ "kind": "explicit_catalog", "provider": "codex" }),
+        ] {
+            assert!(SourceBackedRefreshSelector::from_json(&malformed).is_err());
+        }
+    }
+
+    #[test]
+    fn submission_constructor_defaults_to_legacy_all_and_allows_typed_override() {
+        let automatic = RefreshSubmission::new(
+            "automatic".to_owned(),
+            RefreshOperation::Refresh,
+            None,
+            SourceBackedRefreshScope::All,
+            false,
+            false,
+        );
+        assert_eq!(
+            automatic.selector(),
+            SourceBackedRefreshSelector::AllAutomatic
+        );
+        assert_eq!(
+            automatic
+                .with_selector(SourceBackedRefreshSelector::AutomaticProvider(
+                    CaptureProvider::Codex,
+                ))
+                .selector(),
+            SourceBackedRefreshSelector::AutomaticProvider(CaptureProvider::Codex)
+        );
+
+        let explicit = RefreshSubmission::new(
+            "explicit".to_owned(),
+            RefreshOperation::Import,
+            Some(crate::explicit_source_catalog_authority_for_test(1)),
+            SourceBackedRefreshScope::All,
+            true,
+            false,
+        );
+        assert_eq!(
+            explicit.selector(),
+            SourceBackedRefreshSelector::AllAutomatic
+        );
+        assert_eq!(
+            explicit
+                .with_selector(SourceBackedRefreshSelector::ExplicitCatalog)
+                .selector(),
+            SourceBackedRefreshSelector::ExplicitCatalog
+        );
+    }
+}
+
 /// Process-neutral facts required to submit one logical refresh request.
 #[derive(Debug, Clone)]
 pub struct RefreshSubmission {
@@ -300,6 +431,7 @@ pub struct RefreshSubmission {
     pub(crate) operation: RefreshOperation,
     pub(crate) reconciliation_demand: SourceBackedReconciliationDemand,
     pub(crate) explicit_source_catalog: Option<ExplicitSourceCatalogAuthority>,
+    pub(crate) selector: SourceBackedRefreshSelector,
     pub(crate) refresh_scope: SourceBackedRefreshScope,
     pub(crate) fresh_after_admitted_snapshot: bool,
     pub(crate) maintenance_wake: bool,
@@ -324,6 +456,10 @@ impl RefreshSubmission {
             operation,
             reconciliation_demand,
             explicit_source_catalog,
+            // The constructor preserves the pre-selector meaning of an
+            // explicit catalog: an overlay on an all-route import. New typed
+            // scoped callers opt in with `with_selector`.
+            selector: SourceBackedRefreshSelector::AllAutomatic,
             refresh_scope,
             fresh_after_admitted_snapshot,
             maintenance_wake,
@@ -339,6 +475,15 @@ impl RefreshSubmission {
     pub fn with_trigger(mut self, trigger: RefreshRequestTrigger) -> Self {
         self.trigger = Some(trigger);
         self
+    }
+
+    pub fn with_selector(mut self, selector: SourceBackedRefreshSelector) -> Self {
+        self.selector = selector;
+        self
+    }
+
+    pub fn selector(&self) -> SourceBackedRefreshSelector {
+        self.selector
     }
 
     pub fn request_id(&self) -> &str {


### PR DESCRIPTION
Closes #599.

## Summary

- carry a typed logical source selector from the import command through daemon IPC and durable refresh admission
- discover and execute only the selected provider or exact catalog while preserving legacy all-provider behavior
- persist exact admitted scope across restart, accepting benign provider growth without widening and failing closed when selected routes disappear
- keep global watcher state intact while using request-local discovery authority for scoped work

## Validation

- `//crates/ctx-history-refresh:unit_tests`
- `//crates/ctx-history-refresh-execution:unit_tests`
- `//crates/ctx-history-ingest-application:unit_tests`
- `//crates/ctx-daemon-service:unit_tests`
- `//crates/ctx-cli:unit_tests`
- `//crates/ctx-cli-contract-tests:setup_sources_import_tests` (83 cases)
- `cargo fmt --all -- --check`
- `scripts/check-repository-policy.sh`
- `git diff --check origin/main`