### PR TITLE
fix(import): preserve typed admission failures

### DIFF
--- a/crates/ctx-cli-contract-tests/tests/contracts/native_provider_rejections.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/native_provider_rejections.rs
@@ -214,10 +214,8 @@ fn mixed_source_replay_remains_stable_after_malformed_file_is_skipped() {
         "antigravity_cli_transcript_jsonl_tree",
         0,
     );
-    let generation = first_source["published_generation"]
-        .as_str()
-        .unwrap()
-        .to_owned();
+    let route_identity = first_source["route_identity"].clone();
+    let complete_records = first_source["current_complete_records"].clone();
 
     let replay = json_output(ctx(&temp).args([
         "import",
@@ -239,7 +237,15 @@ fn mixed_source_replay_remains_stable_after_malformed_file_is_skipped() {
     assert_eq!(replay_source["change"], "no_op", "{replay:#}");
     assert_eq!(replay_source["generation_changed"], false, "{replay:#}");
     assert_eq!(
-        replay_source["published_generation"], generation,
+        replay_source["published_generation"], replay_source["previous_generation"],
+        "{replay:#}"
+    );
+    assert_eq!(
+        replay_source["route_identity"], route_identity,
+        "{replay:#}"
+    );
+    assert_eq!(
+        replay_source["current_complete_records"], complete_records,
         "{replay:#}"
     );
 }

--- a/crates/ctx-cli-contract-tests/tests/contracts/native_providers.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/native_providers.rs
@@ -60,22 +60,26 @@ fn qwen_kimi_mistral_mux_and_qoder_default_sources_import_search_and_reimport() 
         assert_eq!(source["importable"], true);
     }
 
-    for (cli_provider, stored_provider, query, minimum_events) in [
-        ("qwen-code", "qwen_code", "qwen jsonl oracle prompt", 2),
+    // Qwen owns the fixture's one malformed record. Each import receipt is
+    // provider-scoped even though the current-generation total remains one.
+    for (cli_provider, stored_provider, query, minimum_events, rejected_records) in [
+        ("qwen-code", "qwen_code", "qwen jsonl oracle prompt", 2, 1),
         (
             "kimi-code-cli",
             "kimi_code_cli",
             "kimi jsonl oracle prompt",
             5,
+            0,
         ),
         (
             "mistral-vibe",
             "mistral_vibe",
             "mistral vibe oracle prompt",
             3,
+            0,
         ),
-        ("mux", "mux", "mux jsonl oracle prompt", 4),
-        ("qoder", "qoder", "qoder jsonl oracle prompt", 6),
+        ("mux", "mux", "mux jsonl oracle prompt", 4, 0),
+        ("qoder", "qoder", "qoder jsonl oracle prompt", 6, 0),
     ] {
         let first = json_output(ctx(&temp).args([
             "import",
@@ -86,7 +90,7 @@ fn qwen_kimi_mistral_mux_and_qoder_default_sources_import_search_and_reimport() 
             "--progress",
             "none",
         ]));
-        assert_authoritative_provider_publication_with_rejections(&first, 1);
+        assert_authoritative_provider_publication_with_rejections(&first, rejected_records);
         wait_for_imported_core(&temp, &first);
         assert_eq!(first["totals"]["current_rejected_records"], 1, "{first:#}");
         let (session_count, event_count) = provider_core_counts(&data_root(&temp), stored_provider);
@@ -123,7 +127,7 @@ fn qwen_kimi_mistral_mux_and_qoder_default_sources_import_search_and_reimport() 
             "--progress",
             "none",
         ]));
-        assert_authoritative_provider_publication_with_rejections(&second, 1);
+        assert_authoritative_provider_publication_with_rejections(&second, rejected_records);
         assert_eq!(
             second["totals"]["current_rejected_records"], 1,
             "{second:#}"

--- a/crates/ctx-cli-contract-tests/tests/contracts/native_providers/additional.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/native_providers/additional.rs
@@ -259,6 +259,12 @@ fn personal_agent_sqlite_imports_report_corrupt_databases() {
         "--format=json",
     ]));
     assert!(stderr.contains("not a database"), "{stderr}");
+    assert!(stderr.contains("route registration failed"), "{stderr}");
+    assert!(
+        !stderr.contains("discovery produced no executable source routes"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("Core-record emission failed"), "{stderr}");
 
     let temp = tempdir();
     let root = temp.path().join("corrupt-nanoclaw");

--- a/crates/ctx-daemon-service/src/query_service_transport_tests/admission_lifecycle.rs
+++ b/crates/ctx-daemon-service/src/query_service_transport_tests/admission_lifecycle.rs
@@ -333,6 +333,94 @@ fn source_refresh_finisher_releases_barrier_before_signaling_scheduler() -> Resu
     Ok(())
 }
 
+#[cfg(any(unix, windows))]
+#[test]
+fn typed_admission_failure_is_durable_and_visible_over_the_status_transport() -> Result<()> {
+    let (_temp, data_root) = private_data_root()?;
+    let route = ctx_history_index::SourceRouteIdentity::from_sha256("ab".repeat(32))?;
+    let failed_route = route.clone();
+    let coordinator = Arc::new(CoreRefreshEngine::with_admission_fence_for_test(Arc::new(
+        move |_data_root, _catalog| {
+            Err(
+                ctx_history_capture::SourceBackedCoordinatorError::NoUsableSourceRoutes {
+                    failed_routes: ctx_history_capture::SourceBackedSourceFailures::from_failures(
+                        [ctx_history_capture::SourceBackedFailedRoute::new(
+                            failed_route.clone(),
+                            "cd".repeat(32),
+                            ctx_history_core::CaptureProvider::Shelley,
+                            ctx_history_capture::SourceBackedSourceFailureClass::Unreadable,
+                            false,
+                            "shelley.db",
+                            "file is not a database",
+                        )],
+                    ),
+                }
+                .into(),
+            )
+        },
+    )));
+    let wakeup = Arc::new(DaemonWakeup::default());
+    let handler = ctx_authenticated_request_handler(
+        &data_root,
+        SharedSemanticRuntime::default(),
+        Arc::clone(&coordinator),
+        wakeup,
+        &crate::test_support::CONFIG,
+    );
+    let service = start_daemon_source_refresh_service_with_request_timeout(
+        &data_root,
+        handler,
+        TEST_QUERY_REQUEST_READ_TIMEOUT,
+    )?;
+    let request_id = "019fcaaa-0000-7000-8000-000000000296";
+
+    let acknowledged = source_refresh_roundtrip(&data_root, refresh_request(request_id))?;
+    assert_eq!(acknowledged["request_state"], "admission_pending");
+    assert!(coordinator.prepare_next_pending_admission(&data_root)?);
+    let terminal = source_refresh_roundtrip(
+        &data_root,
+        compact_json(json!({
+            "schema_version": 1,
+            "op": "source_refresh_status",
+            "request_id": request_id,
+        })),
+    )?;
+
+    assert_eq!(terminal["request_state"], "failed", "{terminal:#}");
+    assert_eq!(terminal["failure_type"], "malformed_source", "{terminal:#}");
+    assert_eq!(terminal["error_code"], "malformed_source", "{terminal:#}");
+    assert_eq!(terminal["reason"], "unreadable", "{terminal:#}");
+    assert_eq!(
+        terminal["structured_outcome"]["affected_routes"],
+        json!([route.as_str()]),
+        "{terminal:#}"
+    );
+    assert_eq!(
+        terminal["structured_outcome"]["blocked_routes"],
+        json!([route.as_str()]),
+        "{terminal:#}"
+    );
+    assert_eq!(terminal["structured_outcome"]["retryable"], false);
+    assert_eq!(
+        terminal["structured_outcome"]["retry_advice"],
+        "inspect_sources"
+    );
+    let durable = read_daemon_job_status(&daemon_source_backed_refresh_job_path(&data_root))
+        .expect("typed terminal admission failure");
+    assert_eq!(durable["request_id"], terminal["request_id"]);
+    assert_eq!(durable["request_state"], terminal["request_state"]);
+    assert_eq!(durable["failure_type"], terminal["failure_type"]);
+    assert_eq!(durable["error_code"], terminal["error_code"]);
+    assert_eq!(durable["reason"], terminal["reason"]);
+    assert_eq!(
+        durable["structured_outcome"],
+        terminal["structured_outcome"]
+    );
+    assert_eq!(coordinator.pending_scheduler_retry_root_for_test(), None);
+    drop(service);
+    Ok(())
+}
+
 #[test]
 fn disconnected_client_does_not_cancel_a_durably_admitted_request() -> Result<()> {
     let (_temp, data_root) = private_data_root()?;

--- a/crates/ctx-history-capture-composition/src/source_backed/discovery.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/discovery.rs
@@ -51,10 +51,19 @@ fn exact_source_catalog_lineage_preserves_released_v1_identity() {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SourceBackedAutomaticUnavailableReason {
     SourceStatus(ProviderSourceStatus),
-    UnsafeRootOverlap { detail: String },
-    UnsupportedFormat { detail: &'static str },
-    SelectorAuthorityUnavailable { detail: &'static str },
-    RegistrationRejected { detail: String },
+    UnsafeRootOverlap {
+        detail: String,
+    },
+    UnsupportedFormat {
+        detail: &'static str,
+    },
+    SelectorAuthorityUnavailable {
+        detail: &'static str,
+    },
+    RegistrationRejected {
+        kind: SourceBackedRouteErrorKind,
+        detail: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -235,9 +244,7 @@ fn build_automatic_source_backed_registry_from_parts_with_probes(
             ) {
                 Ok(route) => registry.register(route),
                 Err(error) => {
-                    let reason = SourceBackedAutomaticUnavailableReason::RegistrationRejected {
-                        detail: error.to_string(),
-                    };
+                    let reason = automatic_registration_rejected(error);
                     registry.register(SourceBackedRoute::unsupported(
                         source.clone(),
                         automatic_unavailable_detail(&reason),
@@ -323,9 +330,7 @@ fn build_automatic_source_backed_registry_from_parts_with_probes(
             SourceBackedRouteSelection::Automatic,
         );
         if let (Some(source), Err(error)) = (source, registration) {
-            let reason = SourceBackedAutomaticUnavailableReason::RegistrationRejected {
-                detail: error.to_string(),
-            };
+            let reason = automatic_registration_rejected(error);
             registry.register(SourceBackedRoute::unsupported(
                 source.clone(),
                 automatic_unavailable_detail(&reason),
@@ -384,7 +389,9 @@ fn automatic_unavailable_detail(reason: &SourceBackedAutomaticUnavailableReason)
             format!("provider source status is {}", status.as_str())
         }
         SourceBackedAutomaticUnavailableReason::UnsafeRootOverlap { detail }
-        | SourceBackedAutomaticUnavailableReason::RegistrationRejected { detail } => detail.clone(),
+        | SourceBackedAutomaticUnavailableReason::RegistrationRejected { detail, .. } => {
+            detail.clone()
+        }
         SourceBackedAutomaticUnavailableReason::UnsupportedFormat { detail }
         | SourceBackedAutomaticUnavailableReason::SelectorAuthorityUnavailable { detail } => {
             (*detail).to_owned()
@@ -459,7 +466,10 @@ fn register_discovered_automatic_route(
                         SourceBackedAutomaticUnavailableReason::SelectorAuthorityUnavailable { detail }
                     }
                     ctx_history_providers_sqlite_inventory::registration::LingmaRegistrationError::RegistrationRejected(detail) => {
-                        SourceBackedAutomaticUnavailableReason::RegistrationRejected { detail }
+                        SourceBackedAutomaticUnavailableReason::RegistrationRejected {
+                            kind: SourceBackedRouteErrorKind::Unsupported,
+                            detail,
+                        }
                     }
                 })?;
             crate::provider::source_backed::family::document::install_sqlite_inventory_registration(
@@ -512,11 +522,30 @@ fn register_discovered_automatic_route(
             "the landed route constructor does not match its provider registration callback",
         )),
     };
-    result.map_err(
-        |error| SourceBackedAutomaticUnavailableReason::RegistrationRejected {
-            detail: error.to_string(),
-        },
-    )
+    result.map_err(automatic_registration_rejected)
+}
+
+fn automatic_registration_rejected(
+    error: SourceBackedCoordinatorError,
+) -> SourceBackedAutomaticUnavailableReason {
+    let kind = match &error {
+        SourceBackedCoordinatorError::RouteScan { source, .. }
+        | SourceBackedCoordinatorError::RouteRegistration { source, .. }
+        | SourceBackedCoordinatorError::Progress(source)
+        | SourceBackedCoordinatorError::CoreEmission(source) => source.kind,
+        SourceBackedCoordinatorError::UnavailableRoute { .. } => {
+            SourceBackedRouteErrorKind::Unavailable
+        }
+        SourceBackedCoordinatorError::InvalidRoute { .. }
+        | SourceBackedCoordinatorError::InvalidRefreshScope { .. } => {
+            SourceBackedRouteErrorKind::Unsupported
+        }
+        _ => SourceBackedRouteErrorKind::Internal,
+    };
+    SourceBackedAutomaticUnavailableReason::RegistrationRejected {
+        kind,
+        detail: error.to_string(),
+    }
 }
 
 fn goose_platform_root(discovery: &DiscoveryContext, database: &Path) -> Option<PathBuf> {
@@ -625,6 +654,7 @@ fn discovered_crush_inventory_source(
     }
     crush_adapter_inventory(opening).map_err(|error| {
         SourceBackedAutomaticUnavailableReason::RegistrationRejected {
+            kind: SourceBackedRouteErrorKind::Unsupported,
             detail: error.to_string(),
         }
     })?;

--- a/crates/ctx-history-capture-composition/src/source_backed/registration/families/sqlite_inventory.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/registration/families/sqlite_inventory.rs
@@ -76,6 +76,6 @@ pub fn register_shelley_source_backed_route(
     let registration = shelley_registration::<CaptureDocumentLifecycle, CaptureDocumentSpool>(
         source, data_root, exact_cwd,
     )
-    .map_err(|error| invalid_route(provider, error.to_string()))?;
+    .map_err(|source| SourceBackedCoordinatorError::RouteRegistration { provider, source })?;
     install_sqlite_inventory_registration(registry, registration)
 }

--- a/crates/ctx-history-capture-runtime/src/source_backed/driver.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/driver.rs
@@ -177,6 +177,12 @@ where
         #[source]
         source: SourceBackedRouteError,
     },
+    #[error("source-backed route registration failed for {provider}: {source}")]
+    RouteRegistration {
+        provider: CaptureProvider,
+        #[source]
+        source: SourceBackedRouteError,
+    },
     #[error("source-backed refresh has an unknown or unavailable route for {provider}: {detail}")]
     UnavailableRoute {
         provider: CaptureProvider,

--- a/crates/ctx-history-providers-sqlite-inventory/src/registration.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/registration.rs
@@ -272,7 +272,7 @@ pub fn shelley_registration<L, S>(
     source: ProviderSource,
     data_root: &Path,
     exact_cwd: impl Into<PathBuf>,
-) -> Result<
+) -> SourceBackedRouteResult<
     SqliteInventoryRegistration<
         impl ReplacementDocumentTree<
             Lifecycle = L,
@@ -287,14 +287,16 @@ where
 {
     let exact_cwd = exact_cwd.into();
     let adapter = discover_shelley_source_backed_exact_cwd(data_root, &exact_cwd)
-        .map_err(|error| CaptureError::InvalidPayload(error.to_string()))?
+        .map_err(shelley_inventory_route_error)?
         .ok_or_else(|| {
-            CaptureError::InvalidPayload(
+            SourceBackedRouteError::new(
+                SourceBackedRouteErrorKind::SourceChanged,
                 "the exact Shelley CWD no longer contains an admitted database".to_owned(),
             )
         })?;
     if adapter.database_path() != source.path {
-        return Err(CaptureError::InvalidPayload(
+        return Err(SourceBackedRouteError::new(
+            SourceBackedRouteErrorKind::InvalidSource,
             "the Shelley source path does not belong to the supplied exact CWD".to_owned(),
         ));
     }

--- a/crates/ctx-history-providers-sqlite-inventory/src/registration/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/registration/tests.rs
@@ -16,6 +16,7 @@ use rusqlite::Connection;
 use uuid::Uuid;
 
 use super::*;
+use crate::provider_sources::SqliteSourceAccessError;
 
 #[derive(Clone, Default)]
 pub(crate) struct NoopLookup;
@@ -453,6 +454,86 @@ fn fixture_provider_source(
         status: crate::ProviderSourceStatus::Available,
         unsupported_reason: None,
     }
+}
+
+fn shelley_registration_error(error: SqliteSourceAccessError) -> SourceBackedRouteError {
+    shelley_inventory_route_error(
+        crate::provider::providers::shelley::native_path::source_backed::ShelleySourceBackedError::SqliteSource(
+            error,
+        ),
+    )
+}
+
+#[test]
+fn shelley_registration_preserves_corrupt_source_classification() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let exact_cwd = temp.path().join("workspace");
+    let database = exact_cwd.join("shelley.db");
+    std::fs::create_dir_all(&exact_cwd).unwrap();
+    std::fs::write(&database, b"not a sqlite database").unwrap();
+    let source = fixture_provider_source(
+        CaptureProvider::Shelley,
+        database,
+        crate::SHELLEY_SQLITE_SOURCE_FORMAT,
+    );
+
+    let error = shelley_registration::<NoopLifecycle, NoopSpool>(
+        source,
+        crate::test_provider_sqlite_data_root(),
+        exact_cwd,
+    )
+    .err()
+    .expect("corrupt Shelley source must be rejected");
+
+    assert_eq!(error.kind, SourceBackedRouteErrorKind::InvalidSource);
+    assert!(error.detail.contains("not a database"));
+}
+
+#[test]
+fn shelley_registration_preserves_source_change_classification() {
+    let error = shelley_registration_error(SqliteSourceAccessError::SourceChanged);
+
+    assert_eq!(error.kind, SourceBackedRouteErrorKind::SourceChanged);
+}
+
+#[test]
+fn shelley_registration_treats_disappearance_after_discovery_as_source_change() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let exact_cwd = temp.path().join("workspace");
+    let database = exact_cwd.join("shelley.db");
+    std::fs::create_dir_all(&exact_cwd).unwrap();
+    Connection::open(&database)
+        .unwrap()
+        .execute_batch("create table admitted_before_registration(value text);")
+        .unwrap();
+    let source = fixture_provider_source(
+        CaptureProvider::Shelley,
+        database.clone(),
+        crate::SHELLEY_SQLITE_SOURCE_FORMAT,
+    );
+    std::fs::remove_file(database).unwrap();
+
+    let error = shelley_registration::<NoopLifecycle, NoopSpool>(
+        source,
+        crate::test_provider_sqlite_data_root(),
+        exact_cwd,
+    )
+    .err()
+    .expect("disappeared Shelley source must be retried");
+
+    assert_eq!(error.kind, SourceBackedRouteErrorKind::SourceChanged);
+    assert!(error.detail.contains("no longer contains"));
+}
+
+#[test]
+fn shelley_registration_preserves_resource_unavailable_classification() {
+    let error = shelley_registration_error(SqliteSourceAccessError::ResourceUnavailable {
+        operation: "test Shelley admission",
+        path: PathBuf::from("shelley.db"),
+        source: std::io::Error::from(std::io::ErrorKind::OutOfMemory),
+    });
+
+    assert_eq!(error.kind, SourceBackedRouteErrorKind::ResourceUnavailable);
 }
 
 #[test]

--- a/crates/ctx-history-read-application/tests/support/search_show/pi_flow.rs
+++ b/crates/ctx-history-read-application/tests/support/search_show/pi_flow.rs
@@ -75,11 +75,26 @@ fn publish_pi_v6_predecessor(data_root: &Path) -> String {
     assert!(legacy.publication_metadata().is_none());
     assert_eq!(pi_parser_revision(data_root), PI_V6_PARSER_REVISION);
 
-    let job_path = data_root.join("daemon/jobs/core-refresh.json");
-    let mut job: Value = serde_json::from_slice(&fs::read(&job_path).unwrap()).unwrap();
-    job["previous_generation"] = Value::Null;
-    job["published_generation"] = json!(legacy_generation.clone());
-    fs::write(job_path, serde_json::to_vec(&job).unwrap()).unwrap();
+    let job = json!({
+        "schema_version": 1,
+        "owner": "daemon",
+        "request_id": "legacy-pi-v6-publication",
+        "request_state": "published",
+        "status": "completed",
+        "operation": "refresh",
+        "previous_generation": null,
+        "published_generation": legacy_generation.clone(),
+        "refresh_scope": { "kind": "all" },
+        "daemon_mode": "full",
+        "trigger": "periodic",
+        "trigger_provenance": "daemon_scheduler",
+    });
+    assert!(job.get("queued_successors").is_none());
+    fs::write(
+        data_root.join("daemon/jobs/core-refresh.json"),
+        serde_json::to_vec(&job).unwrap(),
+    )
+    .unwrap();
     legacy_generation
 }
 

--- a/crates/ctx-history-refresh-execution/src/execution.rs
+++ b/crates/ctx-history-refresh-execution/src/execution.rs
@@ -14,14 +14,13 @@ use publication::{
 };
 pub(super) use registry_merge::build_merged_source_backed_registry;
 use registry_merge::build_merged_source_backed_registry_with_automatic_routes;
-
 pub(super) struct MergedSourceBackedRegistry {
     pub(super) build: ctx_history_capture::SourceBackedAutomaticRegistryBuild,
     reactivated_automatic_routes: BTreeSet<SourceRouteIdentity>,
     previous_explicit_source_catalog: Option<ExplicitSourceCatalogAuthority>,
     previous_catalog_route_bindings: Vec<ExplicitSourceCatalogRouteBinding>,
     requested_explicit_source_catalog: Option<ExplicitSourceCatalogAuthority>,
-    retained_generation: Option<VerifiedIndex>,
+    pub(super) retained_generation: Option<VerifiedIndex>,
     pub(super) requested_catalog_route_bindings: Vec<ExplicitSourceCatalogRouteBinding>,
     previous_route_controls: BTreeMap<SourceRouteIdentity, Vec<u8>>,
 }
@@ -493,6 +492,17 @@ fn refresh_all_provider_sources_route_local_with_reconciliation(
             &previous_catalog_route_bindings,
             &previous_route_controls,
         )?;
+    }
+    let registration_failure_policy = match &scope {
+        SourceBackedRefreshScope::All => AutomaticRegistryAdmissionFailurePolicy::SystemicOnly,
+        SourceBackedRefreshScope::Exact(routes) => {
+            AutomaticRegistryAdmissionFailurePolicy::ExactRoutes(routes)
+        }
+    };
+    if let Some(registration_failures) =
+        automatic_registry_admission_failures(&build.issues, registration_failure_policy)?
+    {
+        return Err(registration_failures.into());
     }
     let registry_failures = if matches!(scope, SourceBackedRefreshScope::All) {
         reject_blocking_automatic_registry_issues(&build.issues)?;

--- a/crates/ctx-history-refresh-execution/src/lib.rs
+++ b/crates/ctx-history-refresh-execution/src/lib.rs
@@ -51,7 +51,8 @@ use serde_json::{json, Value};
 use catalog_witness::reconcile_published_catalog_witness;
 use observation::{admitted_route_observations, run_after_capture_scan_before_metadata_hook};
 use registry_issues::{
-    automatic_registry_route_less_blockers, selected_registry_route_count,
+    automatic_registry_admission_failures, automatic_registry_route_less_blockers,
+    selected_registry_route_count, AutomaticRegistryAdmissionFailurePolicy,
     RouteLessRegistryBlockers,
 };
 type SourceBackedRefreshOperation = RefreshOperation;
@@ -134,6 +135,109 @@ impl fmt::Display for ZeroSourcePublicationBlocked {
 }
 
 impl std::error::Error for ZeroSourcePublicationBlocked {}
+
+#[derive(Debug, Clone)]
+pub struct SourceBackedAdmissionRouteFailure {
+    route_identity: SourceRouteIdentity,
+    kind: SourceBackedRouteErrorKind,
+    detail: String,
+}
+
+impl SourceBackedAdmissionRouteFailure {
+    #[doc(hidden)]
+    pub fn new(
+        route_identity: SourceRouteIdentity,
+        kind: SourceBackedRouteErrorKind,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            route_identity,
+            kind,
+            detail: detail.into(),
+        }
+    }
+
+    pub fn route_identity(&self) -> &SourceRouteIdentity {
+        &self.route_identity
+    }
+
+    pub fn kind(&self) -> SourceBackedRouteErrorKind {
+        self.kind
+    }
+
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+}
+
+#[derive(Debug)]
+pub struct SourceBackedAdmissionRouteFailures {
+    failures: Vec<SourceBackedAdmissionRouteFailure>,
+}
+
+impl SourceBackedAdmissionRouteFailures {
+    #[doc(hidden)]
+    pub fn try_from_failures(
+        failures: impl IntoIterator<Item = SourceBackedAdmissionRouteFailure>,
+    ) -> Result<Self> {
+        let failures = failures
+            .into_iter()
+            .map(|failure| (failure.route_identity.clone(), failure))
+            .collect::<BTreeMap<_, _>>()
+            .into_values()
+            .collect::<Vec<_>>();
+        if failures.is_empty() {
+            bail!("source-backed admission route failures cannot be empty");
+        }
+        if failures.len() > SOURCE_REFRESH_TERMINAL_ROUTE_LIMIT {
+            bail!(
+                "source-backed admission route failures exceed the terminal route limit: {} > {SOURCE_REFRESH_TERMINAL_ROUTE_LIMIT}",
+                failures.len()
+            );
+        }
+        Ok(Self { failures })
+    }
+
+    pub fn failures(&self) -> &[SourceBackedAdmissionRouteFailure] {
+        &self.failures
+    }
+}
+
+impl fmt::Display for SourceBackedAdmissionRouteFailures {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "source-backed admission has {} route registration failure(s): ",
+            self.failures.len()
+        )?;
+        for (index, failure) in self
+            .failures
+            .iter()
+            .take(SOURCE_REFRESH_BUILD_ISSUE_LIMIT)
+            .enumerate()
+        {
+            if index != 0 {
+                formatter.write_str("; ")?;
+            }
+            write!(
+                formatter,
+                "{}: {}",
+                failure.route_identity.as_str(),
+                failure.detail
+            )?;
+        }
+        let omitted = self
+            .failures
+            .len()
+            .saturating_sub(SOURCE_REFRESH_BUILD_ISSUE_LIMIT);
+        if omitted != 0 {
+            write!(formatter, "; {omitted} additional failure(s) omitted")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for SourceBackedAdmissionRouteFailures {}
 
 pub fn source_backed_index_root(data_root: &Path) -> PathBuf {
     data_root.join(SEARCH_DIRECTORY).join(LEXICAL_DIRECTORY)
@@ -311,6 +415,28 @@ pub fn source_backed_admitted_discovery_from_report(
             .cloned()
             .collect()
     };
+    if let Some(registration_failures) = automatic_registry_admission_failures(
+        &merged.build.issues,
+        AutomaticRegistryAdmissionFailurePolicy::ScopedSelection,
+    )? {
+        return Err(registration_failures.into());
+    }
+    if selected_routes.is_empty() {
+        let registry_failures = automatic_registry_route_failures(
+            &merged.build.issues,
+            merged.retained_generation.as_ref(),
+        )?;
+        if !registry_failures.is_empty() {
+            return Err(SourceBackedCoordinatorError::NoUsableSourceRoutes {
+                failed_routes: SourceBackedSourceFailures::from_failures(registry_failures),
+            }
+            .into());
+        }
+        let route_less_blockers = automatic_registry_route_less_blockers(&merged.build.issues, &[]);
+        if route_less_blockers.total != 0 {
+            return Err(route_less_blockers.publication_error().into());
+        }
+    }
     let admitted_report = match explicit_admitted_report {
         Some(report) => report,
         None if selected_routes.is_empty() => DiscoveryReport {

--- a/crates/ctx-history-refresh-execution/src/registry_issues.rs
+++ b/crates/ctx-history-refresh-execution/src/registry_issues.rs
@@ -107,6 +107,68 @@ pub fn automatic_registry_route_failures(
     Ok(failures.into_values().collect())
 }
 
+#[derive(Clone, Copy)]
+pub(super) enum AutomaticRegistryAdmissionFailurePolicy<'a> {
+    SystemicOnly,
+    ScopedSelection,
+    ExactRoutes(&'a BTreeSet<SourceRouteIdentity>),
+}
+
+pub(super) fn automatic_registry_admission_failures(
+    issues: &[SourceBackedAutomaticRegistryIssue],
+    policy: AutomaticRegistryAdmissionFailurePolicy<'_>,
+) -> Result<Option<SourceBackedAdmissionRouteFailures>> {
+    let failures = issues
+        .iter()
+        .filter_map(|issue| {
+            let SourceBackedAutomaticRegistryIssue::Unavailable { source, reason } = issue else {
+                return None;
+            };
+            let SourceBackedAutomaticUnavailableReason::RegistrationRejected { kind, detail } =
+                reason
+            else {
+                return None;
+            };
+            if !source.exists {
+                return None;
+            }
+            if matches!(
+                policy,
+                AutomaticRegistryAdmissionFailurePolicy::SystemicOnly
+            ) && !matches!(
+                kind,
+                SourceBackedRouteErrorKind::ResourceUnavailable
+                    | SourceBackedRouteErrorKind::Internal
+            ) {
+                return None;
+            }
+            Some((source, *kind, detail))
+        })
+        .filter_map(|(source, kind, detail)| {
+            let route_identity = match automatic_registry_issue_route_identity(source) {
+                Ok(route_identity) => route_identity,
+                Err(error) => return Some(Err(error)),
+            };
+            if matches!(
+                policy,
+                AutomaticRegistryAdmissionFailurePolicy::ExactRoutes(selected)
+                    if !selected.contains(&route_identity)
+            ) {
+                return None;
+            }
+            Some(Ok(SourceBackedAdmissionRouteFailure::new(
+                route_identity,
+                kind,
+                detail.clone(),
+            )))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if failures.is_empty() {
+        return Ok(None);
+    }
+    SourceBackedAdmissionRouteFailures::try_from_failures(failures).map(Some)
+}
+
 pub(super) fn automatic_registry_route_less_blockers(
     issues: &[SourceBackedAutomaticRegistryIssue],
     route_failures: &[ctx_history_capture::SourceBackedFailedRoute],
@@ -175,9 +237,13 @@ fn automatic_registry_issue_failure_class(
         SourceBackedAutomaticUnavailableReason::SourceStatus(_) if source.exists => {
             Some(SourceBackedSourceFailureClass::Unavailable)
         }
+        SourceBackedAutomaticUnavailableReason::RegistrationRejected { kind, .. }
+            if source.exists =>
+        {
+            kind.source_failure_class()
+        }
         SourceBackedAutomaticUnavailableReason::UnsupportedFormat { .. }
         | SourceBackedAutomaticUnavailableReason::SelectorAuthorityUnavailable { .. }
-        | SourceBackedAutomaticUnavailableReason::RegistrationRejected { .. }
             if source.exists =>
         {
             Some(SourceBackedSourceFailureClass::Incompatible)
@@ -220,7 +286,9 @@ fn automatic_registry_issue_reason(reason: &SourceBackedAutomaticUnavailableReas
             format!("source status is {}", status.as_str())
         }
         SourceBackedAutomaticUnavailableReason::UnsafeRootOverlap { detail }
-        | SourceBackedAutomaticUnavailableReason::RegistrationRejected { detail } => detail.clone(),
+        | SourceBackedAutomaticUnavailableReason::RegistrationRejected { detail, .. } => {
+            detail.clone()
+        }
         SourceBackedAutomaticUnavailableReason::UnsupportedFormat { detail }
         | SourceBackedAutomaticUnavailableReason::SelectorAuthorityUnavailable { detail } => {
             (*detail).to_owned()

--- a/crates/ctx-history-refresh-execution/src/tests/registry_policy.rs
+++ b/crates/ctx-history-refresh-execution/src/tests/registry_policy.rs
@@ -168,6 +168,79 @@ fn only_unscopable_registry_safety_issues_block_globally() {
 }
 
 #[test]
+fn systemic_registration_failures_keep_exact_admission_route_authority() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = temp.path().join("shelley.db");
+    std::fs::write(&database, b"fixture").unwrap();
+    for kind in [
+        SourceBackedRouteErrorKind::ResourceUnavailable,
+        SourceBackedRouteErrorKind::Internal,
+    ] {
+        let source = provider_source_for_path(CaptureProvider::Shelley, database.clone());
+        let expected_route = automatic_source_backed_route_identity(&source).unwrap();
+        let issue = SourceBackedAutomaticRegistryIssue::Unavailable {
+            source,
+            reason: SourceBackedAutomaticUnavailableReason::RegistrationRejected {
+                kind,
+                detail: "injected Shelley registration systemic failure".to_owned(),
+            },
+        };
+
+        assert!(
+            automatic_registry_route_failures(std::slice::from_ref(&issue), None)
+                .unwrap()
+                .is_empty()
+        );
+        let failures = automatic_registry_admission_failures(
+            std::slice::from_ref(&issue),
+            AutomaticRegistryAdmissionFailurePolicy::SystemicOnly,
+        )
+        .unwrap()
+        .expect("systemic admission failure");
+
+        assert_eq!(failures.failures().len(), 1);
+        assert_eq!(failures.failures()[0].route_identity(), &expected_route);
+        assert_eq!(failures.failures()[0].kind(), kind);
+        assert!(failures.failures()[0]
+            .detail()
+            .contains("registration systemic failure"));
+        assert!(automatic_registry_admission_failures(
+            std::slice::from_ref(&issue),
+            AutomaticRegistryAdmissionFailurePolicy::ExactRoutes(&BTreeSet::from([
+                expected_route.clone(),
+            ])),
+        )
+        .unwrap()
+        .is_some());
+        let unrelated = SourceRouteIdentity::from_sha256("11".repeat(32)).unwrap();
+        assert!(automatic_registry_admission_failures(
+            std::slice::from_ref(&issue),
+            AutomaticRegistryAdmissionFailurePolicy::ExactRoutes(&BTreeSet::from([unrelated])),
+        )
+        .unwrap()
+        .is_none());
+    }
+}
+
+#[test]
+fn admission_registration_failures_enforce_the_durable_route_bound() {
+    let failures = (0..=SOURCE_REFRESH_TERMINAL_ROUTE_LIMIT).map(|index| {
+        SourceBackedAdmissionRouteFailure::new(
+            SourceRouteIdentity::from_sha256(format!("{index:064x}")).unwrap(),
+            SourceBackedRouteErrorKind::ResourceUnavailable,
+            "bounded resource failure",
+        )
+    });
+
+    let error = SourceBackedAdmissionRouteFailures::try_from_failures(failures).unwrap_err();
+
+    assert!(
+        format!("{error:#}").contains("exceed the terminal route limit"),
+        "{error:#}"
+    );
+}
+
+#[test]
 fn registry_failure_identity_uses_the_canonical_certified_format() {
     let path = PathBuf::from("/detected/codex-sessions");
     let source = registry_policy_source(
@@ -247,6 +320,7 @@ fn distinct_nanoclaw_registry_failures_match_retained_automatic_routes() {
     let issues = sources.map(|source| SourceBackedAutomaticRegistryIssue::Unavailable {
         source,
         reason: SourceBackedAutomaticUnavailableReason::RegistrationRejected {
+            kind: SourceBackedRouteErrorKind::Unsupported,
             detail: "injected NanoClaw registration failure".to_owned(),
         },
     });
@@ -313,6 +387,62 @@ fn mixed_codex_and_unsupported_warp_routes_continue_with_typed_evidence() {
     );
     assert!(is_sha256_identity(&failure.route_identity));
     assert!(is_sha256_identity(&failure.source_identity));
+    let verified = VerifiedIndex::open(&index_root).unwrap();
+    assert_eq!(verified.manifest().sources.len(), 1);
+    assert_eq!(
+        verified
+            .search_event_candidates("registrypolicyvalidmarker", 10)
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn all_route_execution_preserves_a_healthy_peer_during_source_local_registration_failure() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    let index_root = source_backed_index_root(&data_root);
+    ctx_history_platform::platform_security::establish_private_data_root(&data_root).unwrap();
+    let (_, cwd, discovery) = discovery_fixture(temp.path());
+    let codex_root = temp.path().join("codex-sessions");
+    let malformed_shelley = cwd.join("shelley.db");
+    write_registry_policy_codex_rollout(&codex_root);
+    std::fs::write(&malformed_shelley, b"not sqlite").unwrap();
+
+    let publication = run_report(
+        &discovery,
+        DiscoveryReport {
+            sources: vec![
+                provider_source_for_path(CaptureProvider::Codex, codex_root),
+                provider_source_for_path(CaptureProvider::Shelley, malformed_shelley),
+            ],
+            issues: Vec::new(),
+        },
+        &data_root,
+        &index_root,
+    )
+    .unwrap();
+
+    assert_eq!(publication.route_results.len(), 2);
+    assert_eq!(publication.certified_source_count, 1);
+    assert_eq!(
+        publication
+            .route_results
+            .iter()
+            .filter(|result| result.outcome.is_success())
+            .count(),
+        1
+    );
+    let failures = publication
+        .route_results
+        .iter()
+        .flat_map(|result| result.source_failures.iter())
+        .collect::<Vec<_>>();
+    assert_eq!(failures.len(), 1);
+    assert_eq!(failures[0].provider, "shelley");
+    assert_eq!(failures[0].class, "unreadable");
+    assert!(failures[0].detail.contains("not a database"));
     let verified = VerifiedIndex::open(&index_root).unwrap();
     assert_eq!(verified.manifest().sources.len(), 1);
     assert_eq!(
@@ -440,6 +570,47 @@ fn registry_issue_only_cold_refresh_retains_the_all_fail_guard() {
         SourceBackedSourceFailureClass::Incompatible
     );
     assert!(!index_root.exists());
+}
+
+#[test]
+fn scoped_admission_preserves_typed_registration_failure_details() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    ctx_history_platform::platform_security::establish_private_data_root(&data_root).unwrap();
+    let (_, cwd, discovery) = discovery_fixture(temp.path());
+    let database = cwd.join("shelley.db");
+    std::fs::write(&database, b"not sqlite").unwrap();
+    let source = provider_source_for_path(CaptureProvider::Shelley, database);
+
+    let error = source_backed_admitted_discovery_from_report(
+        &discovery,
+        DiscoveryReport {
+            sources: vec![source],
+            issues: Vec::new(),
+        },
+        StdDuration::ZERO,
+        &data_root,
+        None,
+        &TestPublishedState,
+    )
+    .unwrap_err();
+    let registration_failures = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<SourceBackedAdmissionRouteFailures>())
+        .expect("typed scoped registration error");
+    assert_eq!(registration_failures.failures().len(), 1);
+    let failure = &registration_failures.failures()[0];
+    assert_eq!(failure.kind(), SourceBackedRouteErrorKind::InvalidSource);
+    assert!(
+        failure.detail().contains("not a database"),
+        "unexpected Shelley failure detail: {failure:?}"
+    );
+    assert!(
+        failure
+            .detail()
+            .contains("source-backed route registration failed for shelley"),
+        "unexpected Shelley failure phase: {failure:?}"
+    );
 }
 
 fn write_registry_policy_codex_rollout(root: &Path) {

--- a/crates/ctx-history-refresh/src/engine/admission.rs
+++ b/crates/ctx-history-refresh/src/engine/admission.rs
@@ -718,13 +718,31 @@ impl CoreRefreshEngine {
     ) -> Result<Option<SourceBackedRefreshRun>> {
         let snapshot = AdmissionResolutionSnapshot::capture(state);
         state.manual_all_continuations.remove(request_id);
-        let failure_outcome = SourceBackedRefreshFailureOutcome::new(
-            "source_refresh_admission_failed",
-            "control_plane",
-            true,
-            BTreeSet::new(),
-            Some("retry_admission"),
-        );
+        let attempted_routes = find_attempt(state, request_id)
+            .and_then(|attempt| match &attempt.refresh_scope {
+                SourceBackedRefreshScope::All => None,
+                SourceBackedRefreshScope::Exact(routes) => Some(routes.clone()),
+            })
+            .unwrap_or_default();
+        let failure_type = source_backed_refresh_failure_type(&error);
+        let classified_outcome = source_backed_refresh_failure_outcome(&error, &attempted_routes);
+        let failure_outcome = if classified_outcome.code == "source_refresh_failed"
+            && classified_outcome.class == "internal"
+        {
+            SourceBackedRefreshFailureOutcome::new(
+                "source_refresh_admission_failed",
+                "control_plane",
+                true,
+                BTreeSet::new(),
+                Some("retry_admission"),
+            )
+        } else {
+            classified_outcome
+        };
+        let retry_admission = failure_outcome.code == "source_refresh_admission_failed"
+            && failure_outcome.retry_advice == Some("retry_admission");
+        let retryable_routes = failure_outcome.retryable_routes.clone();
+        let blocked_routes = failure_outcome.blocked_routes.clone();
         let (scope, last_error) = {
             let attempt = find_attempt_mut(state, request_id)
                 .ok_or_else(|| anyhow!("source refresh request `{request_id}` is unknown"))?;
@@ -732,6 +750,7 @@ impl CoreRefreshEngine {
             attempt.state = SourceBackedRefreshState::Failed;
             attempt.finished_at_ms = Some(utc_now().timestamp_millis());
             attempt.progress.phase = "failed".to_owned();
+            attempt.failure_type = failure_type;
             attempt.failure_outcome = Some(failure_outcome);
             attempt.last_error = Some(last_error.clone());
             (attempt.refresh_scope.clone(), last_error)
@@ -742,7 +761,10 @@ impl CoreRefreshEngine {
             snapshot.restore(state);
             return Err(persist_error.context("persist terminal source refresh admission failure"));
         }
-        state.pending_scheduler_retry_root_id = Some(request_id.to_owned());
+        Self::restore_route_dispositions_locked(state, &retryable_routes, &blocked_routes);
+        if retry_admission {
+            state.pending_scheduler_retry_root_id = Some(request_id.to_owned());
+        }
         let observed_generation = state.current_published_generation.clone();
         advance_after_terminal_attempt(state, request_id, observed_generation);
         trim_terminal_attempt_history(state);

--- a/crates/ctx-history-refresh/src/engine/admission_tests.rs
+++ b/crates/ctx-history-refresh/src/engine/admission_tests.rs
@@ -63,6 +63,225 @@ fn provider_submission(request_id: &str, provider: CaptureProvider) -> RefreshSu
     .with_selector(SourceBackedRefreshSelector::AutomaticProvider(provider))
 }
 
+fn assert_unreadable_admission_failure(retain_generation: bool, request_id: &str) {
+    let (_temp, data_root) = private_data_root();
+    let retained_generation = retain_generation.then(|| {
+        ctx_history_index::GenerationWriter::open(
+            source_backed_index_root(&data_root),
+            ctx_history_index::WriterOptions::default(),
+        )
+        .unwrap()
+        .into_writer()
+        .unwrap()
+        .commit(|_| true)
+        .unwrap()
+        .generation_id
+    });
+    let route = SourceRouteIdentity::from_sha256("ab".repeat(32)).unwrap();
+    let failed_route = route.clone();
+    let coordinator = CoreRefreshEngine::with_admission_fence_for_test(
+        Arc::new(TestRefreshJournal::default()),
+        test_refresh_runtime(),
+        Arc::new(move |_, _, _, _| {
+            Err(SourceBackedCoordinatorError::NoUsableSourceRoutes {
+                failed_routes: SourceBackedSourceFailures::from_failures([
+                    SourceBackedFailedRoute::new(
+                        failed_route.clone(),
+                        "cd".repeat(32),
+                        CaptureProvider::Shelley,
+                        SourceBackedSourceFailureClass::Unreadable,
+                        false,
+                        "shelley.db",
+                        "file is not a database",
+                    ),
+                ]),
+            }
+            .into())
+        }),
+    );
+    let admission = coordinator
+        .submit(&data_root, test_refresh_submission(request_id))
+        .unwrap();
+    release_pending_admission(&coordinator, admission);
+
+    let run = coordinator
+        .run_next(&data_root)
+        .expect("terminal admission failure");
+    assert!(run.failed, "{:#}", run.job);
+    assert_eq!(run.job["request_state"], "failed");
+    assert_eq!(run.job["failure_type"], "malformed_source");
+    assert_eq!(run.job["error_code"], "malformed_source");
+    assert_eq!(run.job["reason"], "unreadable");
+    assert_eq!(run.job["structured_outcome"]["code"], "malformed_source");
+    assert_eq!(run.job["structured_outcome"]["class"], "unreadable");
+    assert_eq!(run.job["structured_outcome"]["retryable"], false);
+    assert_eq!(
+        run.job["structured_outcome"]["affected_routes"],
+        json!([route.as_str()])
+    );
+    assert_eq!(
+        run.job["structured_outcome"]["blocked_routes"],
+        json!([route.as_str()])
+    );
+    assert_eq!(run.job["structured_outcome"]["retryable_routes"], json!([]));
+    assert_eq!(
+        run.job["structured_outcome"]["retry_advice"],
+        "inspect_sources"
+    );
+    assert_eq!(
+        run.job["structured_outcome"]["retained_generation"],
+        json!(retained_generation)
+    );
+    assert_eq!(run.job["published_generation"], json!(retained_generation));
+    assert_eq!(coordinator.pending_scheduler_retry_root_for_test(), None);
+    assert_eq!(
+        coordinator.dirty_route_ids_for_test(),
+        BTreeSet::from([route.clone()])
+    );
+    assert!(coordinator.route_is_permanently_blocked_for_test(&route));
+}
+
+#[test]
+fn cold_admission_preserves_typed_unreadable_route_failure() {
+    assert_unreadable_admission_failure(false, "019fcaaa-0000-7000-8000-000000000508");
+}
+
+#[test]
+fn warm_admission_preserves_typed_unreadable_route_failure_and_retained_generation() {
+    assert_unreadable_admission_failure(true, "019fcaaa-0000-7000-8000-000000000509");
+}
+
+#[test]
+fn retryable_admission_failure_schedules_exact_route_without_restart() {
+    let (_temp, data_root) = private_data_root();
+    let route = SourceRouteIdentity::from_sha256("de".repeat(32)).unwrap();
+    let failed_route = route.clone();
+    let retry_route = route.clone();
+    let executor: Arc<dyn SourceBackedRefreshExecutor> = Arc::new(
+        move |_: ctx_history_refresh_execution::SourceBackedRefreshExecution<'_>| {
+            Err(SourceBackedAdmissionRouteFailures::try_from_failures([
+                ctx_history_refresh_execution::SourceBackedAdmissionRouteFailure::new(
+                    retry_route.clone(),
+                    SourceBackedRouteErrorKind::ResourceUnavailable,
+                    "Shelley registration resource remains unavailable",
+                ),
+            ])
+            .unwrap()
+            .into())
+        },
+    );
+    let coordinator = CoreRefreshEngine::with_runtime_for_test(
+        Arc::new(TestRefreshJournal::default()),
+        test_refresh_runtime(),
+        executor,
+        Arc::new(move |_, _, _, _| {
+            Err(SourceBackedAdmissionRouteFailures::try_from_failures([
+                ctx_history_refresh_execution::SourceBackedAdmissionRouteFailure::new(
+                    failed_route.clone(),
+                    SourceBackedRouteErrorKind::ResourceUnavailable,
+                    "Shelley registration exhausted a bounded resource",
+                ),
+            ])
+            .unwrap()
+            .into())
+        }),
+    );
+    let request_id = "019fcaaa-0000-7000-8000-000000000510";
+    let admission = coordinator
+        .submit(&data_root, test_refresh_submission(request_id))
+        .unwrap();
+    release_pending_admission(&coordinator, admission);
+
+    let run = coordinator.run_next(&data_root).expect("admission failure");
+
+    assert!(run.failed, "{:#}", run.job);
+    assert_eq!(run.job["error_code"], "resource_unavailable");
+    assert_eq!(run.job["reason"], "resource_unavailable");
+    assert_eq!(run.job["structured_outcome"]["retryable"], true);
+    assert_eq!(
+        run.job["structured_outcome"]["retryable_routes"],
+        json!([route.as_str()])
+    );
+    assert_eq!(run.job["structured_outcome"]["blocked_routes"], json!([]));
+    assert_eq!(
+        coordinator.dirty_route_ids_for_test(),
+        BTreeSet::from([route.clone()])
+    );
+    assert!(!coordinator.route_is_permanently_blocked_for_test(&route));
+    coordinator.reconcile_watch_routes(
+        BTreeSet::from([route.clone()]),
+        EventWatermark::new(2, 0),
+        source_route_ledger_now_ms().saturating_sub(1_000),
+    );
+    assert!(coordinator
+        .enqueue_next_dirty_route(&data_root, source_route_ledger_now_ms())
+        .expect("schedule retryable admission route"));
+    let retry = coordinator.run_next(&data_root).expect("exact route retry");
+    assert!(retry.failed, "{:#}", retry.job);
+    assert_eq!(
+        retry.scope,
+        SourceBackedRefreshScope::Exact(BTreeSet::from([route.clone()]))
+    );
+    assert_eq!(
+        retry.job["error_code"], "resource_unavailable",
+        "{:#}",
+        retry.job
+    );
+    assert_eq!(
+        retry.job["structured_outcome"]["retryable_routes"],
+        json!([route.as_str()])
+    );
+    assert_eq!(
+        coordinator.dirty_route_ids_for_test(),
+        BTreeSet::from([route.clone()])
+    );
+    assert!(!coordinator.route_is_permanently_blocked_for_test(&route));
+}
+
+#[test]
+fn internal_registration_failure_uses_admission_retry_handoff() {
+    let (_temp, data_root) = private_data_root();
+    let route = SourceRouteIdentity::from_sha256("fa".repeat(32)).unwrap();
+    let failed_route = route.clone();
+    let coordinator = CoreRefreshEngine::with_admission_fence_for_test(
+        Arc::new(TestRefreshJournal::default()),
+        test_refresh_runtime(),
+        Arc::new(move |_, _, _, _| {
+            Err(SourceBackedAdmissionRouteFailures::try_from_failures([
+                ctx_history_refresh_execution::SourceBackedAdmissionRouteFailure::new(
+                    failed_route.clone(),
+                    SourceBackedRouteErrorKind::Internal,
+                    "injected registration invariant failure",
+                ),
+            ])
+            .unwrap()
+            .into())
+        }),
+    );
+    let request_id = "019fcaaa-0000-7000-8000-000000000511";
+    let admission = coordinator
+        .submit(&data_root, test_refresh_submission(request_id))
+        .unwrap();
+    release_pending_admission(&coordinator, admission);
+
+    let run = coordinator.run_next(&data_root).expect("admission failure");
+
+    assert!(run.failed, "{:#}", run.job);
+    assert_eq!(run.job["error_code"], "source_refresh_admission_failed");
+    assert_eq!(run.job["reason"], "control_plane");
+    assert_eq!(run.job["structured_outcome"]["retryable"], true);
+    assert_eq!(
+        run.job["structured_outcome"]["retry_advice"],
+        "retry_admission"
+    );
+    assert_eq!(run.job["structured_outcome"]["affected_routes"], json!([]));
+    assert_eq!(
+        coordinator.pending_scheduler_retry_root_for_test(),
+        Some(request_id.to_owned())
+    );
+    assert!(!coordinator.route_is_permanently_blocked_for_test(&route));
+}
+
 #[test]
 fn automatic_provider_admission_is_exact_on_a_fresh_root_without_global_discovery() {
     let (temp, data_root) = private_data_root();
@@ -148,6 +367,13 @@ fn unavailable_provider_admission_fails_without_widening() {
         "{status:#}"
     );
     assert_eq!(status["refresh_scope"], json!({ "kind": "all" }));
+    assert_eq!(status["error_code"], "source_refresh_admission_failed");
+    assert_eq!(status["reason"], "control_plane");
+    assert_eq!(status["structured_outcome"]["retryable"], true);
+    assert_eq!(
+        status["structured_outcome"]["retry_advice"],
+        "retry_admission"
+    );
 }
 
 #[test]

--- a/crates/ctx-history-refresh/src/engine/attempt_helpers.rs
+++ b/crates/ctx-history-refresh/src/engine/attempt_helpers.rs
@@ -65,6 +65,77 @@ pub(super) fn source_backed_refresh_failure_outcome(
     error: &anyhow::Error,
     attempted_routes: &BTreeSet<SourceRouteIdentity>,
 ) -> SourceBackedRefreshFailureOutcome {
+    if let Some(registration_failures) = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<SourceBackedAdmissionRouteFailures>())
+    {
+        let failures = registration_failures.failures();
+        let affected_routes = failures
+            .iter()
+            .map(|failure| failure.route_identity().clone())
+            .collect::<BTreeSet<_>>();
+        if failures
+            .iter()
+            .any(|failure| failure.kind() == SourceBackedRouteErrorKind::Internal)
+        {
+            return SourceBackedRefreshFailureOutcome::new(
+                "source_refresh_failed",
+                "internal",
+                true,
+                affected_routes,
+                Some("retry_request"),
+            );
+        }
+        let (retryable_routes, blocked_routes): (BTreeSet<_>, BTreeSet<_>) = failures
+            .iter()
+            .map(|failure| failure.route_identity().clone())
+            .partition(|route| {
+                failures.iter().any(|failure| {
+                    failure.route_identity() == route
+                        && matches!(
+                            failure.kind(),
+                            SourceBackedRouteErrorKind::Unavailable
+                                | SourceBackedRouteErrorKind::SourceChanged
+                                | SourceBackedRouteErrorKind::ResourceUnavailable
+                        )
+                })
+            });
+        let resource_unavailable = failures
+            .iter()
+            .any(|failure| failure.kind() == SourceBackedRouteErrorKind::ResourceUnavailable);
+        let first_kind = failures[0].kind();
+        let homogeneous = failures.iter().all(|failure| failure.kind() == first_kind);
+        let (code, class) = if resource_unavailable {
+            ("resource_unavailable", "resource_unavailable")
+        } else if homogeneous {
+            match first_kind {
+                SourceBackedRouteErrorKind::Unavailable => ("source_unavailable", "unavailable"),
+                SourceBackedRouteErrorKind::SourceChanged => ("source_changed", "source_changed"),
+                SourceBackedRouteErrorKind::InvalidSource => ("malformed_source", "unreadable"),
+                SourceBackedRouteErrorKind::Unsupported => ("unsupported_schema", "incompatible"),
+                SourceBackedRouteErrorKind::ResourceUnavailable
+                | SourceBackedRouteErrorKind::Internal => unreachable!(),
+            }
+        } else {
+            ("source_failures", "mixed")
+        };
+        let retryable = !retryable_routes.is_empty();
+        let retry_advice = if retryable {
+            "retry_affected_routes"
+        } else if homogeneous && first_kind == SourceBackedRouteErrorKind::Unsupported {
+            "upgrade_or_reconfigure"
+        } else {
+            "inspect_sources"
+        };
+        return SourceBackedRefreshFailureOutcome::with_route_dispositions(
+            code,
+            class,
+            retryable,
+            retryable_routes,
+            blocked_routes,
+            Some(retry_advice),
+        );
+    }
     if error.chain().any(|cause| {
         cause
             .downcast_ref::<ZeroSourcePublicationBlocked>()

--- a/crates/ctx-history-refresh/src/lib.rs
+++ b/crates/ctx-history-refresh/src/lib.rs
@@ -47,7 +47,8 @@ use ctx_history_refresh_execution::{
     required_route_results, source_backed_requested_route_observations,
     source_backed_route_retry_disposition, verify_generation_query_readiness,
     GenerationQueryReadiness, PublishedSourceBackedState, PublishedSourceBackedStatePort,
-    SourceBackedExactScanProgress, SourceBackedRefreshCoveredPublication,
+    SourceBackedAdmissionRouteFailures, SourceBackedExactScanProgress,
+    SourceBackedRefreshCoveredPublication,
     SourceBackedRefreshProgressUpdate as PhysicalRefreshProgressUpdate,
 };
 use serde_json::{json, Value};


### PR DESCRIPTION
## Summary

- preserve typed provider registration failures through selected admission and exact-route retries
- distinguish selected-import failures from systemic automatic-maintenance failures so healthy peer routes still publish
- keep retryable route state durable, bound admission aggregates to the terminal-status limit, and retain precise Shelley diagnostics
- keep request-scoped rejection receipts separate from retained generation totals and harden replay/legacy recovery fixtures

Follow-up correctness work for #599 and #600.

## Validation

- post-rebase CI-mode tests for refresh execution, refresh engine, capture composition/runtime, SQLite inventory, daemon service, and both native-provider contract suites
- 90-target affected validation with timing-sensitive CLI targets rerun successfully in isolation
- cargo fmt check
- repository policy check
- git diff check
- two independent final code reviews: ship