### PR TITLE
feat(cli): add indexing mode controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Your past coding agent sessions already live on your machine, usually in JSONL f
 
 `ctx setup` discovers those sources and reads them without modifying them. It converts each provider’s format into consistent local records for sessions, messages, tool calls, relationships, and repository activity, then stores and indexes those records locally.
 
-ctx does not require hooks or any code running inside the agent process. After setup, a local background daemon watches the history sources your agents already write and keeps the index current as they change. Each update is completed before it becomes visible, so commands never read a partially built index.
+ctx does not require hooks or any code running inside the agent process. Automatic indexing is on by default and keeps the index current as those history sources change. Each update is completed before it becomes visible, so commands never read a partially built index.
 
 Every session and event receives a stable ctx ID and retains its complete transcript content and source information. `ctx search` finds the relevant history, `ctx show` retrieves the exact event or full transcript, and `ctx locate` identifies where it came from. Semantic search and ctx pro use those same records.
 
@@ -136,6 +136,19 @@ ctx show event <ctx-event-id> --window 3
 ctx show session <ctx-session-id>
 ```
 
+Search uses BM25 lexical matching by default. Give it likely terms—an error, file, command, or decision—and it ranks sessions containing those terms.
+
+### Semantic search
+
+Semantic search helps when related ideas use different wording. ctx computes embeddings locally and searches them directly, without a vector database to run. Enable it with:
+
+```bash
+ctx setup --semantic
+ctx index
+```
+
+Semantic search requires automatic indexing, which is the default. If you use manual indexing, run `ctx index mode auto` first. Lexical search remains available while embeddings build; once they are ready, hybrid search uses lexical and semantic evidence automatically.
+
 ctx does not send your prompts, transcripts, or indexed history to a cloud service, call model APIs, require API keys, or write into your source repositories. Transcript text is preserved rather than automatically redacted, so review copied output before sharing it outside your machine.
 
 For the full pipeline, see [How ctx works](https://ctx.rs/concepts/how-it-works). For a quick first run, see [Quickstart](https://ctx.rs/first-search).
@@ -144,13 +157,11 @@ For the full pipeline, see [How ctx works](https://ctx.rs/concepts/how-it-works)
 
 ctx is written in Rust, but that's not the main reason why it's fast. Instead of ingesting your history into a local relational database like SQLite, ctx scans it with parallel workers and writes searchable records directly to [Tantivy](https://github.com/quickwit-oss/tantivy). That removes an entire database ingest step while still supporting structured filtering and complete record retrieval.
 
-Tantivy builds the index in parallel. It creates a compact map from each term to the records containing it, searches memory-mapped segments without loading your entire history into memory, and ranks the results with BM25. The same index stores the complete record for every result, so `ctx search`, `ctx show`, and `ctx locate` can read it without a second database or reopening and reparsing the original agent logs.
+Tantivy builds the index in parallel. It creates a compact map from each term to the records containing it and searches memory-mapped segments without loading your entire history into memory. The same index stores the complete record for every result, so `ctx search`, `ctx show`, and `ctx locate` can read it without a second database or reopening and reparsing the original agent logs.
 
 In our benchmark, this was 16x faster than ctx's previous optimized SQLite implementation.
 
 <img src="docs/assets/ctx-cold-indexing-chart.png" alt="Cold indexing time: ctx with Tantivy, 9.65 seconds; previous ctx SQLite pipeline, 155.09 seconds. Lower is better." width="100%">
-
-Semantic search takes a similarly direct approach. ctx embeds your history locally with `multilingual-e5-small` and stores the vectors in memory-mapped flat-F32 segments. At the scale of personal agent history, scanning those vectors exactly is fast, so there is no vector database or approximate HNSW graph to build, tune, or maintain.
 
 ## How ctx differs from agent memory and codebase intelligence
 

--- a/contracts/public-control-surface-v1.json
+++ b/contracts/public-control-surface-v1.json
@@ -63,7 +63,7 @@
       "config_key": "indexing.mode",
       "environment_variable": "CTX_DAEMON_ENABLED",
       "released_default": {
-        "value": "automatic",
+        "value": "auto",
         "state": "on",
         "scope": "all_cli_installations"
       },

--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle/additional.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle/additional.rs
@@ -168,10 +168,7 @@ fn setup_autostart_records_spawn_failure_status() {
         .clone();
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("ctx daemon did not start"), "{stderr}");
-    assert!(
-        stderr.contains("ctx daemon status --format json"),
-        "{stderr}"
-    );
+    assert!(stderr.contains("ctx status --format json"), "{stderr}");
     assert!(
         output.stdout.is_empty(),
         "failed quiet setup must not print success or queued output: {}",

--- a/crates/ctx-cli-presentation/src/commands/doctor_presentation.rs
+++ b/crates/ctx-cli-presentation/src/commands/doctor_presentation.rs
@@ -111,7 +111,7 @@ pub fn render_doctor_human(
         },
         Some(Action {
             command: if refresh_failed {
-                "ctx daemon status"
+                "ctx status"
             } else {
                 "ctx doctor"
             },
@@ -279,7 +279,7 @@ mod ui_tests {
                 "History source catalog is still preparing",
                 "History refresh is unavailable",
                 "Check the history refresh service.",
-                "ctx daemon status",
+                "ctx status",
             ] {
                 assert!(
                     flattened.contains(expected),

--- a/crates/ctx-cli-presentation/src/commands/index.rs
+++ b/crates/ctx-cli-presentation/src/commands/index.rs
@@ -11,31 +11,65 @@ use serde_json::{json, Value};
 
 use crate::analytics::{count_bucket, IndexOperation, IndexState, IndexTelemetry, WaitOutcome};
 use crate::output::{compact_json, print_json, JsonOutputFormat};
-use crate::ui::{Document, LiveOutput, Ui};
+use crate::ui::{fields, outcome, Document, Field, LiveOutput, Outcome, OutcomeState, Ui};
 
 use super::index_dashboard::{render_semantic_disabled_wait, IndexDashboard};
 
 #[derive(Debug, Args)]
 pub struct IndexArgs {
+    #[arg(long, value_enum, default_value_t = JsonOutputFormat::Text)]
+    format: JsonOutputFormat,
     #[command(subcommand)]
-    command: IndexCommand,
+    command: Option<IndexCommand>,
 }
 
 impl IndexArgs {
     pub fn json_output(&self) -> bool {
-        match &self.command {
-            IndexCommand::Watch(args) => args.format == IndexWatchFormat::Jsonl,
-            IndexCommand::Wait(args) => args.format.is_json(),
-        }
+        self.format.is_json()
+            || match &self.command {
+                None => false,
+                Some(IndexCommand::Mode(args)) => args.format.is_json(),
+                Some(IndexCommand::Watch(args)) => args.format == IndexWatchFormat::Jsonl,
+                Some(IndexCommand::Wait(args)) => args.format.is_json(),
+            }
     }
 }
 
 #[derive(Debug, Subcommand)]
 enum IndexCommand {
+    #[command(about = "Show or change automatic indexing mode")]
+    Mode(IndexModeArgs),
     #[command(about = "Watch local indexing progress until ready")]
     Watch(IndexWatchArgs),
     #[command(about = "Wait until local indexing reaches a ready state")]
     Wait(IndexWaitArgs),
+}
+
+#[derive(Debug, Args)]
+struct IndexModeArgs {
+    #[arg(value_enum)]
+    mode: Option<IndexModeArg>,
+    #[arg(long, value_enum, default_value_t = JsonOutputFormat::Text)]
+    format: JsonOutputFormat,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum IndexModeArg {
+    Auto,
+    Manual,
+}
+
+impl IndexModeArg {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Manual => "manual",
+        }
+    }
+
+    pub const fn is_auto(self) -> bool {
+        matches!(self, Self::Auto)
+    }
 }
 
 #[derive(Debug, Args)]
@@ -72,24 +106,125 @@ pub trait IndexReadinessPort {
     fn snapshot(&mut self, data_root: &Path) -> Result<Value>;
 }
 
+pub trait IndexModePort {
+    fn current(&mut self, data_root: &Path) -> Result<Value>;
+    fn update(&mut self, data_root: &Path, mode: IndexModeArg) -> Result<Value>;
+}
+
 pub fn run_index(
     args: IndexArgs,
     data_root: PathBuf,
     quiet: bool,
     telemetry: &mut IndexTelemetry,
     readiness: &mut dyn IndexReadinessPort,
+    mode: &mut dyn IndexModePort,
     ui: &mut Ui,
 ) -> Result<()> {
+    let parent_json = args.format.is_json();
     match args.command {
-        IndexCommand::Watch(args) => {
+        None => {
+            telemetry.operation = Some(IndexOperation::Status);
+            let status = readiness.snapshot(&data_root)?;
+            record_index_telemetry(telemetry, &status);
+            if args.format.is_json() {
+                print_json(status)?;
+            } else if !quiet {
+                let mut document = IndexDashboard.render(&status, ui.stdout_context());
+                append_indexing_mode(&mut document, &status, ui);
+                ui.write_stdout(&document)?;
+            }
+            Ok(())
+        }
+        Some(IndexCommand::Mode(args)) => {
+            telemetry.operation = Some(IndexOperation::Mode);
+            let report = match args.mode {
+                Some(requested) => mode.update(&data_root, requested)?,
+                None => mode.current(&data_root)?,
+            };
+            if parent_json || args.format.is_json() {
+                print_json(report)?;
+            } else if !quiet {
+                let document = render_index_mode(&report, args.mode.is_some(), ui);
+                ui.write_stdout(&document)?;
+            }
+            Ok(())
+        }
+        Some(IndexCommand::Watch(mut args)) => {
             telemetry.operation = Some(IndexOperation::Watch);
+            if parent_json {
+                args.format = IndexWatchFormat::Jsonl;
+            }
             run_index_watch(args, &data_root, quiet, telemetry, readiness, ui)
         }
-        IndexCommand::Wait(args) => {
+        Some(IndexCommand::Wait(mut args)) => {
             telemetry.operation = Some(IndexOperation::Wait);
+            if parent_json {
+                args.format = JsonOutputFormat::Json;
+            }
             run_index_wait(args, &data_root, quiet, telemetry, readiness, ui)
         }
     }
+}
+
+fn append_indexing_mode(document: &mut Document, report: &Value, ui: &Ui) {
+    let mode = report
+        .pointer("/indexing/mode")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    if !document.is_empty() {
+        document.push_blank();
+    }
+    document.append(fields(
+        ui.stdout_context(),
+        &[Field::new("Indexing mode", mode)],
+    ));
+}
+
+fn render_index_mode(report: &Value, changed: bool, ui: &Ui) -> Document {
+    let mode = report
+        .pointer("/indexing/mode")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    if !changed {
+        return fields(ui.stdout_context(), &[Field::new("Indexing mode", mode)]);
+    }
+
+    let requested_mode = report
+        .pointer("/indexing/requested_mode")
+        .and_then(Value::as_str)
+        .unwrap_or(mode);
+    let overridden = report
+        .pointer("/indexing/overridden")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if overridden {
+        let title = format!("Indexing mode remains {mode}");
+        let detail = format!(
+            "The requested {requested_mode} mode was saved, but a process-level override keeps {mode} mode active."
+        );
+        return outcome(
+            ui.stdout_context(),
+            Outcome {
+                state: OutcomeState::Warning,
+                title: &title,
+                detail: Some(&detail),
+            },
+        );
+    }
+
+    let detail = match mode {
+        "auto" => "ctx will keep the index current in the background.",
+        "manual" => "Run `ctx import` or use `ctx search --refresh wait` to update the index.",
+        _ => "The indexing mode was updated.",
+    };
+    outcome(
+        ui.stdout_context(),
+        Outcome {
+            state: OutcomeState::Success,
+            title: &format!("Indexing mode set to {mode}"),
+            detail: Some(detail),
+        },
+    )
 }
 
 fn run_index_watch(

--- a/crates/ctx-cli-presentation/src/commands/setup.rs
+++ b/crates/ctx-cli-presentation/src/commands/setup.rs
@@ -130,9 +130,9 @@ pub fn render_setup_human(
     } else if queued {
         "ctx index watch"
     } else if daemon.requested && !daemon.started {
-        "ctx daemon status"
+        "ctx status"
     } else if matches!(daemon.reason, Some("daemon_disabled" | "explicit_opt_out")) {
-        "ctx daemon enable"
+        "ctx index mode auto"
     } else {
         "ctx doctor"
     };
@@ -160,7 +160,7 @@ fn daemon_human_status(daemon: &SetupDaemonState<'_>) -> Option<String> {
         (true, true) => None,
         (true, false) => Some("persistent daemon (automatic restart unavailable)".to_owned()),
         (false, _) if daemon.requested => {
-            Some("startup was not verified; run ctx daemon status".to_owned())
+            Some("startup was not verified; run ctx status".to_owned())
         }
         (false, _) if daemon.reason == Some("explicit_opt_out") => {
             Some("skipped because --no-daemon was used".to_owned())
@@ -362,7 +362,7 @@ mod tests {
             assert!(rendered.starts_with("! History is not ready\n"));
             assert!(rendered.contains("Background  disabled\n"));
             assert!(rendered.contains("Data\nRoot  /tmp/ctx\n"));
-            assert!(rendered.contains("Next\n  ctx daemon enable\n"));
+            assert!(rendered.contains("Next\n  ctx index mode auto\n"));
             assert!(!rendered.contains("ctx index watch"));
             assert_fits(&document, &context);
         }

--- a/crates/ctx-cli-presentation/src/commands/status_presentation.rs
+++ b/crates/ctx-cli-presentation/src/commands/status_presentation.rs
@@ -154,7 +154,13 @@ pub fn render_status_human(
     } else {
         component_display(daemon)
     };
+    let indexing_mode = report
+        .pointer("/indexing/mode")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_owned();
     let mut service_values = vec![
+        ("Indexing mode", indexing_mode),
         ("Daemon", daemon_status),
         (
             "Semantic",
@@ -265,6 +271,7 @@ mod tests {
     fn status_report(initialized: bool, lexical: &str, refresh: &str) -> Value {
         json!({
             "initialized": initialized,
+            "indexing": {"mode": "auto"},
             "history_epoch": {"status": lexical},
             "lexical": {"status": lexical},
             "refresh": {"status": refresh},
@@ -326,6 +333,7 @@ mod tests {
             assert!(normalized.contains("1,000 searchable events"));
             assert!(rendered.contains("\nServices\n"));
             assert!(normalized.contains("Daemon running"));
+            assert!(normalized.contains("Indexing mode auto"));
             assert!(normalized.contains("Semantic disabled"));
             assert!(!rendered.contains("Automatic upgrades"));
             assert!(rendered.contains("Local usage"));
@@ -443,14 +451,14 @@ mod tests {
                     state: "disabled",
                     ..usage_report()
                 },
-                "Local usage  disabled",
+                "Local usage disabled",
             ),
             (
                 local_usage::UsageReport {
                     state: "empty",
                     ..usage_report()
                 },
-                "Local usage  enabled; store missing or empty",
+                "Local usage enabled; store missing or empty",
             ),
         ] {
             let rendered = render_status_human(
@@ -462,7 +470,8 @@ mod tests {
                 &usage,
             )
             .render_plain();
-            assert!(rendered.contains(expected), "{rendered}");
+            let normalized = rendered.split_whitespace().collect::<Vec<_>>().join(" ");
+            assert!(normalized.contains(expected), "{rendered}");
         }
     }
 

--- a/crates/ctx-cli/src/cli.rs
+++ b/crates/ctx-cli/src/cli.rs
@@ -133,7 +133,7 @@ pub(crate) enum CommandRoot {
     Status(StatusArgs),
     #[command(about = "Show local history retrieval and value statistics")]
     Stats(StatsArgs),
-    #[command(about = "Show, watch, or wait for local indexing progress")]
+    #[command(about = "Show or configure local indexing and follow progress")]
     Index(commands::index::IndexArgs),
     #[command(about = "List configured and discovered agent history sources")]
     Sources(SourcesArgs),
@@ -153,7 +153,7 @@ pub(crate) enum CommandRoot {
     Integrations(integrations::IntegrationsArgs),
     #[command(about = "Serve local ctx tools over MCP")]
     Mcp(mcp::McpArgs),
-    #[command(about = "Run or inspect local ctx background maintenance")]
+    #[command(about = "Run local ctx background maintenance")]
     Daemon(DaemonArgs),
     #[command(about = "Check or apply signed ctx CLI upgrades")]
     Upgrade(upgrade::UpgradeArgs),
@@ -235,13 +235,22 @@ pub(crate) struct DaemonArgs {
 
 #[derive(Debug, Subcommand, Clone)]
 pub(crate) enum DaemonCommand {
-    #[command(about = "Run ctx background maintenance in the foreground")]
+    #[command(
+        about = "Run ctx background maintenance in the foreground until stopped",
+        long_about = "Run ctx background maintenance in the foreground until stopped. This command blocks the terminal and does not change the configured indexing mode."
+    )]
     Run(DaemonRunArgs),
-    #[command(about = "Show ctx daemon status")]
+    #[command(about = "Show ctx daemon status", hide = true)]
     Status(FormatArgs),
-    #[command(about = "Use automatic indexing and enable persistent maintenance")]
+    #[command(
+        about = "Use automatic indexing and enable persistent maintenance",
+        hide = true
+    )]
     Enable(FormatArgs),
-    #[command(about = "Use manual indexing and remove persistent maintenance")]
+    #[command(
+        about = "Use manual indexing and remove persistent maintenance",
+        hide = true
+    )]
     Disable(DaemonDisableArgs),
 }
 

--- a/crates/ctx-cli/src/commands/index.rs
+++ b/crates/ctx-cli/src/commands/index.rs
@@ -4,7 +4,10 @@ use anyhow::Result;
 use serde_json::{json, Value};
 
 use crate::{
-    analytics::IndexTelemetry, config, output::compact_json, semantic::source_epoch_status_report,
+    analytics::IndexTelemetry,
+    config::{self, CONFIG_FILE},
+    output::compact_json,
+    semantic::source_epoch_status_report,
     ui::Ui,
 };
 
@@ -15,9 +18,39 @@ pub(crate) use ctx_cli_presentation::commands::index::IndexArgs;
 
 struct CliIndexReadiness;
 
+struct CliIndexMode;
+
 impl ctx_cli_presentation::commands::index::IndexReadinessPort for CliIndexReadiness {
     fn snapshot(&mut self, data_root: &Path) -> Result<Value> {
         index_readiness_snapshot(data_root)
+    }
+}
+
+impl ctx_cli_presentation::commands::index::IndexModePort for CliIndexMode {
+    fn current(&mut self, data_root: &Path) -> Result<Value> {
+        let config = config::AppConfig::load(data_root)?;
+        Ok(index_mode_report(
+            data_root,
+            config.indexing.mode.as_str(),
+            None,
+            None,
+        ))
+    }
+
+    fn update(
+        &mut self,
+        data_root: &Path,
+        mode: ctx_cli_presentation::commands::index::IndexModeArg,
+    ) -> Result<Value> {
+        let config = config::AppConfig::load(data_root)?;
+        let update = crate::semantic::update_indexing_mode(data_root, &config, mode.is_auto())?;
+        let applied_mode = if update.automatic { "auto" } else { "manual" };
+        Ok(index_mode_report(
+            data_root,
+            applied_mode,
+            Some(mode.as_str()),
+            Some(update),
+        ))
     }
 }
 
@@ -34,8 +67,39 @@ pub(crate) fn run_index(
         quiet,
         telemetry,
         &mut CliIndexReadiness,
+        &mut CliIndexMode,
         ui,
     )
+}
+
+fn index_mode_report(
+    data_root: &Path,
+    mode: &str,
+    requested_mode: Option<&str>,
+    update: Option<ctx_daemon_cli::IndexingModeUpdate>,
+) -> Value {
+    let mut report = json!({
+        "schema_version": 1,
+        "indexing": {
+            "mode": mode,
+        },
+        "config_path": data_root.join(CONFIG_FILE),
+        "local_only": true,
+        "read_only": update.is_none(),
+    });
+    if let Some(requested_mode) = requested_mode {
+        report["indexing"]["requested_mode"] = json!(requested_mode);
+        report["indexing"]["overridden"] = json!(requested_mode != mode);
+    }
+    if let Some(update) = update {
+        report["daemon"] = json!({
+            "running": update.running,
+            "pid": update.pid,
+            "persistent": update.persistent,
+            "supervisor": update.supervisor,
+        });
+    }
+    compact_json(report)
 }
 
 fn index_readiness_snapshot(data_root: &Path) -> Result<Value> {
@@ -48,6 +112,9 @@ fn index_readiness_snapshot(data_root: &Path) -> Result<Value> {
     Ok(compact_json(json!({
         "schema_version": 1,
         "initialized": source.initialized,
+        "indexing": {
+            "mode": config.indexing.mode.as_str(),
+        },
         "lexical": {
             "status": source_lexical.get("status"),
             "reason": source_lexical.get("reason"),

--- a/crates/ctx-cli/src/commands/setup.rs
+++ b/crates/ctx-cli/src/commands/setup.rs
@@ -34,7 +34,7 @@ pub(crate) fn run_setup(
     let suppression_reason = daemon_autostart_suppression_reason();
     if args.semantic && (!config.automatic_indexing_enabled() || args.no_daemon) {
         bail!(
-            "`ctx setup --semantic` requires automatic indexing. Set [indexing] mode = \"automatic\" and rerun without --no-daemon"
+            "`ctx setup --semantic` requires automatic indexing. Run `ctx index mode auto` and retry without --no-daemon"
         );
     }
     if args.semantic {
@@ -46,7 +46,7 @@ pub(crate) fn run_setup(
         && (!config.automatic_indexing_enabled() || args.no_daemon)
     {
         bail!(
-            "local semantic search requires automatic indexing. Set [indexing] mode = \"automatic\", remove --no-daemon, or set [search] semantic = false"
+            "local semantic search requires automatic indexing. Run `ctx index mode auto`, remove --no-daemon, or set [search] semantic = false"
         );
     }
 
@@ -377,7 +377,7 @@ fn daemon_autostart_json(
                 "persistent": true,
                 "limitation": Value::Null,
                 "supervisor": supervisor,
-                "status_command": "ctx daemon status",
+                "status_command": "ctx status",
             })
         }
         None => json!({
@@ -387,7 +387,7 @@ fn daemon_autostart_json(
             "persistent": false,
             "limitation": Value::Null,
             "supervisor": supervisor,
-            "status_command": "ctx daemon status",
+            "status_command": "ctx status",
         }),
     }
 }

--- a/crates/ctx-cli/src/commands/status.rs
+++ b/crates/ctx-cli/src/commands/status.rs
@@ -42,6 +42,10 @@ pub(crate) fn status_read_model_authorized(
     let mut report = source.report;
     if let Some(object) = report.as_object_mut() {
         object.remove("catalog");
+        object.insert(
+            "indexing".to_owned(),
+            json!({"mode": config.indexing.mode.as_str()}),
+        );
         object.insert("upgrade".to_owned(), upgrade);
         object.insert(
             "local_usage".to_owned(),
@@ -191,6 +195,7 @@ mod tests {
         let config = config::AppConfig::default();
         let status = status_read_model(&data_root, &config).unwrap();
         assert_eq!(status.report["lexical"]["status"], "ready");
+        assert_eq!(status.report["indexing"]["mode"], "auto");
         assert_eq!(status.report["lexical"]["generation_id"], generation_id);
         assert!(status.report.get("catalog").is_none());
     }

--- a/crates/ctx-cli/src/config.rs
+++ b/crates/ctx-cli/src/config.rs
@@ -31,7 +31,7 @@ pub enum IndexingMode {
 impl IndexingMode {
     pub const fn as_str(self) -> &'static str {
         match self {
-            Self::Automatic => "automatic",
+            Self::Automatic => "auto",
             Self::Manual => "manual",
         }
     }

--- a/crates/ctx-cli/src/config/toml_subset.rs
+++ b/crates/ctx-cli/src/config/toml_subset.rs
@@ -141,10 +141,10 @@ pub(super) fn parse_upgrade_auto_text(key: &str, value: &str) -> Result<AutoUpgr
 pub(super) fn parse_indexing_mode(value: &ConfigValue) -> Result<IndexingMode> {
     let mode = parse_non_empty_string("indexing.mode", value)?;
     match mode.to_ascii_lowercase().as_str() {
-        "automatic" => Ok(IndexingMode::Automatic),
+        "auto" | "automatic" => Ok(IndexingMode::Automatic),
         "manual" => Ok(IndexingMode::Manual),
         _ => bail!(
-            "indexing.mode at line {} must be either \"automatic\" or \"manual\"",
+            "indexing.mode at line {} must be either \"auto\" or \"manual\"",
             value.line
         ),
     }

--- a/crates/ctx-cli/src/config_tests.rs
+++ b/crates/ctx-cli/src/config_tests.rs
@@ -270,6 +270,23 @@ fn canonical_indexing_mode_wins_over_legacy_daemon_enabled() {
 }
 
 #[test]
+fn indexing_mode_accepts_canonical_and_automatic_alias() {
+    for (spelling, expected, canonical) in [
+        ("auto", IndexingMode::Automatic, "auto"),
+        ("automatic", IndexingMode::Automatic, "auto"),
+        ("manual", IndexingMode::Manual, "manual"),
+    ] {
+        let values = parse_toml_subset(&format!("[indexing]\nmode = \"{spelling}\"\n")).unwrap();
+        let mut config = AppConfig::default();
+
+        config.apply_values(&values).unwrap();
+
+        assert_eq!(config.indexing.mode, expected);
+        assert_eq!(config.indexing.mode.as_str(), canonical);
+    }
+}
+
+#[test]
 fn indexing_mode_rejects_unknown_values() {
     let temp = tempfile::tempdir().unwrap();
     fs::write(
@@ -281,8 +298,9 @@ fn indexing_mode_rejects_unknown_values() {
     let error = format!("{:#}", AppConfig::load(temp.path()).unwrap_err());
 
     assert!(error.contains("indexing.mode"), "{error}");
-    assert!(error.contains("automatic"), "{error}");
+    assert!(error.contains("\"auto\""), "{error}");
     assert!(error.contains("manual"), "{error}");
+    assert!(!error.contains("automatic"), "{error}");
 }
 
 #[test]
@@ -704,7 +722,8 @@ fn daemon_enablement_updates_write_canonical_indexing_mode_and_remove_legacy_key
     let enabled = AppConfig::load(temp.path()).unwrap();
     assert_eq!(enabled.indexing.mode, IndexingMode::Automatic);
     let text = fs::read_to_string(temp.path().join(CONFIG_FILE)).unwrap();
-    assert!(text.contains("mode = \"automatic\""));
+    assert!(text.contains("mode = \"auto\""));
+    assert!(!text.contains("automatic"));
     assert!(!text.contains("enabled = true"));
 }
 

--- a/crates/ctx-cli/src/main_tests.rs
+++ b/crates/ctx-cli/src/main_tests.rs
@@ -161,7 +161,7 @@ fn complete_cli_grammar_renders_and_parses_help_recursively() {
     // the public grammar is intentionally smaller than the pre-split tree.
     assert_eq!(
         paths.len(),
-        47,
+        48,
         "unexpected public CLI grammar depth: {paths:?}"
     );
 

--- a/crates/ctx-cli/src/semantic.rs
+++ b/crates/ctx-cli/src/semantic.rs
@@ -145,6 +145,14 @@ pub(crate) fn maybe_autostart_daemon(
     );
 }
 
+pub(crate) fn update_indexing_mode(
+    data_root: &Path,
+    config: &crate::config::AppConfig,
+    automatic: bool,
+) -> Result<ctx_daemon_cli::IndexingModeUpdate> {
+    ctx_daemon_cli::update_indexing_mode(data_root, &daemon_cli_config(config), automatic)
+}
+
 pub(crate) fn begin_current_daemon_upgrade_handoff(
     data_root: &Path,
     attempt_id: &str,

--- a/crates/ctx-cli/tests/cli_public_help_docs.rs
+++ b/crates/ctx-cli/tests/cli_public_help_docs.rs
@@ -431,10 +431,10 @@ fn public_subcommand_help_is_golden_enough_for_session_retrieval() {
             "index",
             vec![
                 "Usage: ctx index",
-                "status",
+                "mode",
                 "watch",
                 "wait",
-                "Show, watch, or wait for local indexing progress",
+                "Show or configure local indexing and follow progress",
             ],
         ),
         ("sources", vec!["Usage: ctx sources", "--format <FORMAT>"]),
@@ -484,10 +484,7 @@ fn public_subcommand_help_is_golden_enough_for_session_retrieval() {
             vec![
                 "Usage: ctx daemon",
                 "run",
-                "status",
-                "enable",
-                "disable",
-                "Run or inspect local ctx background maintenance",
+                "Run local ctx background maintenance",
             ],
         ),
         (
@@ -569,6 +566,8 @@ fn machine_readable_output_uses_format_without_a_json_alias() {
         &["setup", "--help"][..],
         &["status", "--help"],
         &["stats", "--help"],
+        &["index", "--help"],
+        &["index", "mode", "--help"],
         &["index", "watch", "--help"],
         &["index", "wait", "--help"],
         &["sources", "--help"],
@@ -586,9 +585,6 @@ fn machine_readable_output_uses_format_without_a_json_alias() {
         &["integrations", "status", "mcp", "--help"],
         &["integrations", "status", "skills", "--help"],
         &["daemon", "run", "--help"],
-        &["daemon", "status", "--help"],
-        &["daemon", "enable", "--help"],
-        &["daemon", "disable", "--help"],
         &["upgrade", "--help"],
         &["upgrade", "check", "--help"],
         &["upgrade", "status", "--help"],
@@ -622,15 +618,18 @@ fn machine_readable_output_uses_format_without_a_json_alias() {
 }
 
 #[test]
-fn daemon_help_exposes_readable_status_and_run_controls() {
+fn indexing_mode_and_daemon_run_help_expose_the_public_controls() {
     let temp = tempdir();
     for (args, required) in [
         (
-            vec!["daemon", "status", "--help"],
+            vec!["index", "mode", "--help"],
             vec![
-                "Usage: ctx daemon status",
+                "Usage: ctx index mode",
+                "[MODE]",
+                "auto",
+                "manual",
                 "--format <FORMAT>",
-                "Show ctx daemon status",
+                "Show or change automatic indexing mode",
             ],
         ),
         (
@@ -643,22 +642,8 @@ fn daemon_help_exposes_readable_status_and_run_controls() {
                 "Process at most this many semantic chunks per pass",
                 "--force",
                 "--format <FORMAT>",
-            ],
-        ),
-        (
-            vec!["daemon", "enable", "--help"],
-            vec![
-                "Usage: ctx daemon enable",
-                "--format <FORMAT>",
-                "Use automatic indexing and enable persistent maintenance",
-            ],
-        ),
-        (
-            vec!["daemon", "disable", "--help"],
-            vec![
-                "Usage: ctx daemon disable",
-                "--format <FORMAT>",
-                "Use manual indexing and remove persistent maintenance",
+                "foreground until stopped",
+                "does not change the configured indexing mode",
             ],
         ),
     ] {
@@ -685,6 +670,26 @@ fn daemon_help_exposes_readable_status_and_run_controls() {
             !help.contains("--idle-exit-seconds"),
             "{args:?} help:\n{help}"
         );
+    }
+
+    let daemon_help = String::from_utf8(
+        ctx(&temp)
+            .args(["daemon", "--help"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .unwrap();
+    let daemon_commands = daemon_help
+        .split("Commands:")
+        .nth(1)
+        .and_then(|tail| tail.split("Options:").next())
+        .unwrap_or(&daemon_help);
+    assert!(daemon_commands.contains("run"), "{daemon_help}");
+    for hidden in ["status", "enable", "disable"] {
+        assert!(!daemon_commands.contains(hidden), "{daemon_help}");
     }
 
     let stderr = ctx(&temp)

--- a/crates/ctx-cli/tests/hosted_uninstall_fence.rs
+++ b/crates/ctx-cli/tests/hosted_uninstall_fence.rs
@@ -382,7 +382,7 @@ fn prepare_uninstall_waits_for_indexing_control_before_disabling_and_cleanup() {
     );
     let in_flight_config = fs::read_to_string(requested_root.join("config.toml")).unwrap();
     assert!(
-        in_flight_config.contains("mode = \"automatic\""),
+        in_flight_config.contains("mode = \"auto\""),
         "prepare-uninstall changed indexing before acquiring control: {in_flight_config}"
     );
 

--- a/crates/ctx-cli/tests/index.rs
+++ b/crates/ctx-cli/tests/index.rs
@@ -93,17 +93,79 @@ fn assert_single_human_diagnosis(
 }
 
 #[test]
+fn index_status_and_mode_have_one_coherent_public_surface() {
+    let temp = daemon_test_root();
+
+    let status = json_output(ctx(&temp).args(["index", "--format=json"]));
+    assert_eq!(status["indexing"]["mode"], "auto");
+    assert_eq!(status["local_only"], true);
+    assert_eq!(status["read_only"], true);
+
+    let default_mode = json_output(ctx(&temp).args(["index", "--format=json", "mode"]));
+    assert_eq!(default_mode["indexing"]["mode"], "auto");
+    assert_eq!(default_mode["read_only"], true);
+    assert!(!data_root(&temp).join("config.toml").exists());
+
+    let manual = json_output(ctx(&temp).args(["index", "mode", "manual", "--format=json"]));
+    assert_eq!(manual["indexing"]["mode"], "manual");
+    assert_eq!(manual["daemon"]["running"], false);
+    assert_eq!(manual["read_only"], false);
+    let config = fs::read_to_string(data_root(&temp).join("config.toml")).unwrap();
+    assert!(config.contains("mode = \"manual\""), "{config}");
+
+    let current = json_output(ctx(&temp).args(["index", "mode", "--format=json"]));
+    assert_eq!(current["indexing"]["mode"], "manual");
+    assert_eq!(current["read_only"], true);
+}
+
+#[test]
+fn daemon_off_override_is_truthful_when_auto_mode_is_requested() {
+    let temp = daemon_test_root();
+
+    let update = json_output(
+        ctx(&temp)
+            .args(["index", "mode", "auto", "--format=json"])
+            .env("CTX_DAEMON_ENABLED", "false"),
+    );
+
+    assert_eq!(update["indexing"]["mode"], "manual");
+    assert_eq!(update["indexing"]["requested_mode"], "auto");
+    assert_eq!(update["indexing"]["overridden"], true);
+    assert_eq!(update["daemon"]["running"], false);
+    assert_eq!(update["daemon"]["persistent"], false);
+    let config = fs::read_to_string(data_root(&temp).join("config.toml")).unwrap();
+    assert!(config.contains("mode = \"auto\""), "{config}");
+}
+
+#[test]
+fn automatic_index_mode_starts_managed_background_maintenance() {
+    let temp = daemon_test_root();
+    ctx(&temp)
+        .args(["index", "mode", "manual", "--format=json"])
+        .assert()
+        .success();
+
+    let automatic = json_output(ctx(&temp).args(["index", "mode", "auto", "--format=json"]));
+    assert_eq!(automatic["indexing"]["mode"], "auto");
+    assert_eq!(automatic["daemon"]["running"], true);
+    assert_eq!(automatic["daemon"]["persistent"], true);
+    assert_eq!(automatic["read_only"], false);
+    let config = fs::read_to_string(data_root(&temp).join("config.toml")).unwrap();
+    assert!(config.contains("mode = \"auto\""), "{config}");
+    assert!(!config.contains("automatic"), "{config}");
+
+    ctx(&temp)
+        .args(["index", "mode", "manual", "--format=json"])
+        .assert()
+        .success();
+}
+
+#[test]
 fn index_watch_and_wait_are_read_only_for_missing_store() {
     let temp = tempdir();
 
     let watch_machine = ctx(&temp)
-        .args([
-            "index",
-            "watch",
-            "--format=jsonl",
-            "--interval-seconds",
-            "1",
-        ])
+        .args(["index", "--format=json", "watch", "--interval-seconds", "1"])
         .assert()
         .failure()
         .get_output()
@@ -120,7 +182,7 @@ fn index_watch_and_wait_are_read_only_for_missing_store() {
     );
 
     let wait_machine = ctx(&temp)
-        .args(["index", "wait", "--format=json", "--interval-seconds", "1"])
+        .args(["index", "--format=json", "wait", "--interval-seconds", "1"])
         .assert()
         .failure()
         .get_output()
@@ -297,7 +359,7 @@ fn authoritative_status_reports_stale_daemon_lock_as_recoverable() {
 }
 
 #[test]
-fn index_command_has_only_watch_and_wait_subcommands() {
+fn index_command_exposes_mode_watch_and_wait_without_a_status_subcommand() {
     let temp = tempdir();
     let help = String::from_utf8(
         ctx(&temp)
@@ -309,6 +371,7 @@ fn index_command_has_only_watch_and_wait_subcommands() {
             .clone(),
     )
     .unwrap();
+    assert!(help.contains("mode"), "{help}");
     assert!(help.contains("watch"), "{help}");
     assert!(help.contains("wait"), "{help}");
     assert!(!help.contains("\n  status"), "{help}");
@@ -795,6 +858,10 @@ fn human_wait_stops_when_selected_semantic_work_has_no_running_daemon() {
 fn forced_color_on_a_pipe_adds_only_sgr_not_cursor_motion() {
     let temp = daemon_test_root();
     import_ready_history(&temp);
+    ctx(&temp)
+        .args(["index", "mode", "manual", "--format=json"])
+        .assert()
+        .success();
 
     let plain = ctx(&temp)
         .args(["--color=never", "index", "watch", "--interval-seconds", "1"])

--- a/crates/ctx-cli/tests/status_store_cutover.rs
+++ b/crates/ctx-cli/tests/status_store_cutover.rs
@@ -13,6 +13,7 @@ fn pristine_status_doctor_and_mcp_status_create_nothing() {
             .env("CTX_DATA_ROOT", &data_root),
     );
     assert_eq!(status["schema_version"], 2);
+    assert_eq!(status["indexing"]["mode"], "auto");
     assert_eq!(status["initialized"], false);
     assert_eq!(
         status["lexical"]["path"],

--- a/crates/ctx-client-observability/src/analytics/client.rs
+++ b/crates/ctx-client-observability/src/analytics/client.rs
@@ -161,6 +161,8 @@ pub struct StatusTelemetry {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IndexOperation {
+    Status,
+    Mode,
     Watch,
     Wait,
 }
@@ -168,6 +170,8 @@ pub enum IndexOperation {
 impl IndexOperation {
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::Status => "status",
+            Self::Mode => "mode",
             Self::Watch => "watch",
             Self::Wait => "wait",
         }

--- a/crates/ctx-daemon-cli/src/composition.rs
+++ b/crates/ctx-daemon-cli/src/composition.rs
@@ -234,7 +234,7 @@ impl DaemonCliHost for TestHost {
             Self::config_item(&document, "indexing", "mode").and_then(toml_edit::Item::as_str)
         {
             config.daemon.enabled = match mode {
-                "automatic" => true,
+                "auto" | "automatic" => true,
                 "manual" => false,
                 _ => return Err(anyhow!("unknown indexing mode `{mode}`")),
             };
@@ -276,7 +276,7 @@ impl DaemonCliHost for TestHost {
             .ok_or_else(|| anyhow!("indexing configuration must be a table"))?;
         indexing.insert(
             "mode",
-            toml_edit::value(if enabled { "automatic" } else { "manual" }),
+            toml_edit::value(if enabled { "auto" } else { "manual" }),
         );
         if let Some(daemon) = document
             .as_table_mut()

--- a/crates/ctx-daemon-cli/src/daemon.rs
+++ b/crates/ctx-daemon-cli/src/daemon.rs
@@ -23,7 +23,7 @@ use super::{
 pub(crate) mod control;
 #[cfg(test)]
 mod seam_tests;
-pub use control::run_daemon_command;
+pub use control::{run_daemon_command, update_indexing_mode};
 
 fn run_daemon(
     application: &ctx_daemon_application::DaemonApplication<'_>,

--- a/crates/ctx-daemon-cli/src/daemon/control.rs
+++ b/crates/ctx-daemon-cli/src/daemon/control.rs
@@ -70,10 +70,9 @@ pub(super) fn run_daemon_enabled_update(
     enabled: bool,
     ui: &mut Ui,
 ) -> Result<()> {
-    let update = application
-        .update_daemon_enabled(&data_root, enabled)
-        .map_err(daemon_enabled_update_error)?;
-    let supervisor = update.supervisor.into_json();
+    let update = apply_indexing_mode(application, &data_root, enabled)?;
+    let effective_enabled = update.automatic;
+    let supervisor = update.supervisor;
     let persistent = update.persistent;
     let running = update.running;
     let pid = update.pid;
@@ -81,7 +80,7 @@ pub(super) fn run_daemon_enabled_update(
     if args.format.is_json() {
         print_json(json!({
             "schema_version": 1,
-            "daemon_enabled": enabled,
+            "daemon_enabled": effective_enabled,
             "running": running,
             "pid": pid,
             "persistent": persistent,
@@ -89,7 +88,7 @@ pub(super) fn run_daemon_enabled_update(
             "config_path": config_path,
             "local_only": true,
         }))?;
-    } else if enabled {
+    } else if effective_enabled {
         let document = render_daemon_enable_receipt(
             ui.stdout_context(),
             running,
@@ -104,6 +103,33 @@ pub(super) fn run_daemon_enabled_update(
         ui.write_stdout(&document)?;
     }
     Ok(())
+}
+
+pub fn update_indexing_mode(
+    data_root: &Path,
+    config: &AppConfig<'_>,
+    automatic: bool,
+) -> Result<crate::IndexingModeUpdate> {
+    super::super::daemon_supervisor::with_daemon_run_application(config, |application| {
+        apply_indexing_mode(application, data_root, automatic)
+    })
+}
+
+fn apply_indexing_mode(
+    application: &ctx_daemon_application::DaemonApplication<'_>,
+    data_root: &Path,
+    automatic: bool,
+) -> Result<crate::IndexingModeUpdate> {
+    let update = application
+        .update_daemon_enabled(data_root, automatic)
+        .map_err(daemon_enabled_update_error)?;
+    Ok(crate::IndexingModeUpdate {
+        automatic: update.enabled,
+        running: update.running,
+        pid: update.pid,
+        persistent: update.persistent,
+        supervisor: update.supervisor.into_json(),
+    })
 }
 
 fn daemon_enabled_update_error(
@@ -123,10 +149,10 @@ fn daemon_enabled_update_error(
             ),
             ctx_daemon_application::DaemonStartError::BinaryIdentity(error) => error,
             ctx_daemon_application::DaemonStartError::Start(error) => anyhow!(
-                "ctx daemon did not start: {error:#}. Run `ctx daemon status --format json`, then `ctx daemon run` for details"
+                "ctx daemon did not start: {error:#}. Run `ctx status --format json`, then `ctx daemon run` for details"
             ),
             ctx_daemon_application::DaemonStartError::Ready(error) => anyhow!(
-                "ctx daemon did not become ready: {error}. Run `ctx daemon status --format json`, then `ctx daemon run` for details"
+                "ctx daemon did not become ready: {error}. Run `ctx status --format json`, then `ctx daemon run` for details"
             ),
         },
     }

--- a/crates/ctx-daemon-cli/src/daemon_autostart/autostart.rs
+++ b/crates/ctx-daemon-cli/src/daemon_autostart/autostart.rs
@@ -116,10 +116,10 @@ pub fn autostart_daemon_for_setup_and_wait(
                 ),
                 ctx_daemon_application::DaemonStartError::BinaryIdentity(error) => error,
                 ctx_daemon_application::DaemonStartError::Start(error) => anyhow!(
-                    "ctx daemon did not start: {error:#}. Run `ctx daemon status --format json`, then `ctx daemon run` for details"
+                    "ctx daemon did not start: {error:#}. Run `ctx status --format json`, then `ctx daemon run` for details"
                 ),
                 ctx_daemon_application::DaemonStartError::Ready(error) => anyhow!(
-                    "ctx daemon did not become ready: {error}. Run `ctx daemon status --format json`, then `ctx daemon run` for details"
+                    "ctx daemon did not become ready: {error}. Run `ctx status --format json`, then `ctx daemon run` for details"
                 ),
             })?;
         Ok(DaemonSetupHandoff {

--- a/crates/ctx-daemon-cli/src/daemon_status/render.rs
+++ b/crates/ctx-daemon-cli/src/daemon_status/render.rs
@@ -410,7 +410,7 @@ fn render_daemon_enabled_receipt(
                 text: "Check supervisor status.",
             },
             Some(Action {
-                command: "ctx daemon status",
+                command: "ctx status",
             }),
         ));
         return document;
@@ -514,7 +514,7 @@ fn render_daemon_enabled_receipt(
                 text: "Retry startup after resolving the service error.",
             },
             Some(Action {
-                command: "ctx daemon enable",
+                command: "ctx index mode auto",
             }),
         ));
     } else if !enabled && !supervisor_disabled {
@@ -720,8 +720,8 @@ fn recovery_action(
     } = signals;
     if presentation == DaemonPresentation::Disabled {
         return Some((
-            "Enable the daemon to resume automatic history refresh.",
-            "ctx daemon enable",
+            "Use automatic indexing to resume background history refresh.",
+            "ctx index mode auto",
         ));
     }
     if presentation == DaemonPresentation::NotStarted {
@@ -730,7 +730,7 @@ fn recovery_action(
     if recoverable {
         return Some((
             "Restart the daemon and check its health.",
-            "ctx daemon enable",
+            "ctx index mode auto",
         ));
     }
     if history_failed || source_failures > 0 {
@@ -847,7 +847,7 @@ fn supervisor_persistence_issue(supervisor: &Value) -> Option<String> {
         == Some(true)
     {
         return Some(
-            "native supervisor environment changed; run `ctx daemon enable` to install the current nonsecret snapshot and restart"
+            "native supervisor environment changed; run `ctx index mode auto` to install the current nonsecret snapshot and restart"
                 .to_owned(),
         );
     }

--- a/crates/ctx-daemon-cli/src/daemon_status/tests.rs
+++ b/crates/ctx-daemon-cli/src/daemon_status/tests.rs
@@ -200,7 +200,7 @@ fn changed_installed_supervisor_environment_is_a_restart_caveat() {
     assert!(rendered.starts_with("! Daemon is partially healthy\n"));
     assert!(rendered.contains("Persistence  not verified\n"));
     assert!(normalized.contains(
-        "Caveat native supervisor environment changed; run `ctx daemon enable` to install the current nonsecret snapshot and restart"
+        "Caveat native supervisor environment changed; run `ctx index mode auto` to install the current nonsecret snapshot and restart"
     ));
     assert!(!rendered.contains("installed-snapshot"));
     assert!(!rendered.contains("current-snapshot"));
@@ -268,7 +268,7 @@ fn disabled_status_is_clear_and_enable_is_the_only_action() {
     assert!(rendered.contains("Service\nStatus  disabled\n"));
     assert!(rendered.contains("History refresh\nStatus  disabled\n"));
     assert!(rendered.contains("Semantic\nStatus  disabled\n"));
-    assert_eq!(rendered.matches("ctx daemon enable").count(), 1);
+    assert_eq!(rendered.matches("ctx index mode auto").count(), 1);
 }
 
 #[test]
@@ -408,7 +408,7 @@ fn recoverable_failure_surfaces_error_and_one_restart_action() {
     assert!(rendered.contains("Status    failed (recoverable)\n"));
     assert!(rendered.contains("Reason    daemon lock stale\n"));
     assert!(rendered.contains("Error     the previous daemon exited unexpectedly\n"));
-    assert_eq!(rendered.matches("ctx daemon enable").count(), 1);
+    assert_eq!(rendered.matches("ctx index mode auto").count(), 1);
     assert!(!rendered.contains("999"));
     assert!(!rendered.contains("omit-me"));
 }
@@ -751,7 +751,7 @@ fn enable_receipts_distinguish_managed_and_limited_persistence() {
         "Hint: Check supervisor status.\n",
         "\n",
         "Next\n",
-        "  ctx daemon status\n",
+        "  ctx status\n",
     );
     assert_exact_cross_width(
         |context| {
@@ -772,7 +772,7 @@ fn enable_receipts_distinguish_managed_and_limited_persistence() {
                     "Hint: Check supervisor status.\n",
                     "\n",
                     "Next\n",
-                    "  ctx daemon status\n",
+                    "  ctx status\n",
                 ),
             ),
             (48, limited_wide),
@@ -784,7 +784,7 @@ fn enable_receipts_distinguish_managed_and_limited_persistence() {
             "\u{1b}[2mHint\u{1b}[0m: Check supervisor status.\n",
             "\n",
             "\u{1b}[2mNext\u{1b}[0m\n",
-            "  \u{1b}[36mctx daemon status\u{1b}[0m\n",
+            "  \u{1b}[36mctx status\u{1b}[0m\n",
         ),
     );
     let limited_rendered = render_daemon_enable_receipt(

--- a/crates/ctx-daemon-cli/src/lib.rs
+++ b/crates/ctx-daemon-cli/src/lib.rs
@@ -104,6 +104,15 @@ pub struct FormatArgs {
     pub format: ctx_terminal::JsonOutputFormat,
 }
 
+#[derive(Debug)]
+pub struct IndexingModeUpdate {
+    pub automatic: bool,
+    pub running: bool,
+    pub pid: Option<u32>,
+    pub persistent: bool,
+    pub supervisor: serde_json::Value,
+}
+
 #[derive(Debug, Clone)]
 pub struct DaemonDisableArgs {
     pub format: ctx_terminal::JsonOutputFormat,
@@ -149,7 +158,7 @@ mod query_service;
 pub use query_service::wait_for_daemon_query_service;
 mod daemon;
 mod paths_status;
-pub use daemon::run_daemon_command;
+pub use daemon::{run_daemon_command, update_indexing_mode};
 pub mod daemon_service_ports;
 mod daemon_status;
 mod daemon_supervisor;

--- a/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle.rs
@@ -494,7 +494,7 @@ mod native {
         let enabled_config = fs::read_to_string(harness.root().join("config.toml")).unwrap();
         assert!(
             enabled_config.contains("[indexing]")
-                && enabled_config.contains("mode = \"automatic\"")
+                && enabled_config.contains("mode = \"auto\"")
                 && !enabled_config.contains("[daemon]\nenabled"),
             "enable was not durable: {enabled_config}"
         );

--- a/crates/ctx-history-cli/src/source_index/search.rs
+++ b/crates/ctx-history-cli/src/source_index/search.rs
@@ -175,7 +175,7 @@ fn semantic_external_detail(reason: SemanticReason, detail: &str) -> String {
     match reason {
         SemanticReason::PolicyDisabled => "semantic search is disabled. Set [search] semantic = true in ctx config to enable local semantic search".to_owned(),
         SemanticReason::PlatformUnsupported => "local semantic search is not supported on this platform yet. Set [search] semantic = false or use --backend lexical".to_owned(),
-        SemanticReason::ExecutionUnavailable => "local semantic search requires automatic indexing. Set [indexing] mode = \"automatic\", set [search] semantic = false, or use --backend lexical".to_owned(),
+        SemanticReason::ExecutionUnavailable => "local semantic search requires automatic indexing. Run `ctx index mode auto`, set [search] semantic = false, or use --backend lexical".to_owned(),
         SemanticReason::ContentScopeUnsupported => format!("{detail}; use --backend lexical or choose --content-scope all|transcript"),
         SemanticReason::EventTypeUnsupported => format!("{detail}; use --backend lexical or remove --event-type"),
         _ => detail.to_owned(),

--- a/docs/agent-usage.md
+++ b/docs/agent-usage.md
@@ -27,6 +27,11 @@ explicitly enabled. Use `--refresh wait` when the task authorizes an
 authoritative refresh, or `--refresh off` when it must never start or wake a
 process.
 
+Use `ctx index mode` to inspect the mode. `ctx index mode auto` enables
+persistent background indexing; `ctx index mode manual` stops the persistent
+daemon and removes its supervision while leaving explicit `ctx import` and
+`ctx search --refresh wait` available through finite workers.
+
 When one query is not enough, vary the wording, add `--term`, narrow by
 workspace/provider/file/session, or use `--events`. Ordinary search already
 covers primary and subagent work with root-diverse results; use

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -42,11 +42,14 @@ ctx status --usage disable
 ctx status --usage reset
 ctx doctor
 ctx doctor --format json
-ctx daemon status
-ctx daemon status --format json
+ctx index
+ctx index --format json
+ctx index mode
+ctx index mode auto
+ctx index mode manual
+ctx index watch
+ctx index wait
 ctx daemon run
-ctx daemon disable
-ctx daemon enable
 ```
 
 - `setup` creates the data root, discovers known provider history locations,
@@ -64,9 +67,10 @@ ctx daemon enable
   It is deprecated and ignored; setup follows the same refresh lifecycle as
   when the flag is omitted.
 - `status` reports the ctx root, source epoch, lexical and refresh readiness,
-  semantic generation and coverage, daemon state, initialization state,
-  compact local usage health, local-only marker, and read-only marker. It does
-  not initialize or repair Core or semantic state or open old history.
+  semantic generation and coverage, daemon and supervisor health,
+  initialization state, compact local usage health, local-only marker, and
+  read-only marker. It does not initialize or repair Core or semantic state or
+  open old history.
 - `stats` is the read-only, local, offline report for History retrieval, Code
   provenance, Measured delivery, and Estimated savings. Measured facts and
   model-based estimates are separate in JSON; the estimate model and
@@ -88,15 +92,23 @@ ctx daemon enable
   success. Use `status --format json` when scripts need the actual state.
 - `doctor` validates source-epoch storage and reports lexical, semantic, and
   daemon lock/status problems when present.
-- `daemon status` reports the same ctx-owned daemon coordinator state without
-  mutating storage. It separates current requested config from the last config
-  applied by the running daemon, and reports observed semantic query-runtime
-  ownership. `config_reload.status` exposes pending, applied, parse/read failure,
-  or semantic activation failure rather than treating config-file mutation as a
-  successful live reload. This diagnostic remains available when malformed
-  config caused the retained reload failure; ordinary commands still reject the
-  malformed file.
-- `daemon run` runs persistent local maintenance in the foreground. Each pass
+- `index` prints a one-shot indexing status view. It is the focused view of the
+  current indexing mode, lexical publication, refresh progress, semantic
+  coverage, and background process state. Use `--format json` for the
+  readiness snapshot.
+- `index mode` prints the current mode. Its setters persist the requested mode
+  and reconcile supervision to the effective mode. When auto is not overridden,
+  ctx installs or repairs supervision and starts the persistent background
+  daemon. Manual mode stops it and removes supervision. In manual mode,
+  `ctx import` and `ctx search --refresh wait` can still start finite workers
+  for explicit refreshes.
+- `index watch` redraws indexing progress until the default readiness target is
+  met; `--format jsonl` emits one snapshot per line. `index wait` blocks until
+  the selected lexical, semantic, or combined readiness target is met and
+  supports one final `--format json` result.
+- `daemon run` is an advanced command that runs persistent local maintenance in
+  the foreground and blocks until stopped. It does not change the configured
+  indexing mode. In manual mode, pass `--force` to run it explicitly. Each pass
   performs bounded native provider-history refresh followed by semantic
   catch-up when semantic is enabled. The daemon may acquire the local embedding
   model for semantic indexing. A looping daemon keeps the embedding model
@@ -105,10 +117,14 @@ ctx daemon enable
   loops. Enabling
   `[search] semantic = true` and rerunning setup activates the existing daemon;
   no unrelated restart is required.
-- `daemon disable` writes `[indexing] mode = "manual"`; `daemon enable` writes
-  `[indexing] mode = "automatic"`. Automatic is the default. Touching either
-  lifecycle control removes the legacy `[daemon] enabled` key.
-  `daemon run --force` remains available for explicit troubleshooting.
+
+Automatic indexing is the default. Its canonical configuration is
+`[indexing] mode = "auto"`; the other supported value is `"manual"`.
+Enable local semantic search with `ctx setup --semantic`. Semantic indexing
+requires auto mode, so run `ctx index mode auto` first if the current mode is
+manual. Lexical search remains available while embeddings build, and hybrid
+search uses lexical and semantic evidence automatically when semantic coverage
+is ready.
 
 Setup and health checks do not change shell startup files, install repository
 integrations, write into source repositories, call model APIs, or require API
@@ -644,12 +660,13 @@ scope changes neither retained bodies nor the Core/index schema and requires no
 rebuild. Search JSON always reports the resolved selection as
 `filters.content_scope`, including `all` when the option was omitted.
 
-Automatic daemon maintenance owns provider/plugin refresh, immutable candidate
-construction, atomic lexical publication, source discovery state, and semantic
-catch-up. Manual mode retains only explicit finite Core publication. Use
-`ctx daemon run` for explicit foreground maintenance. JSON status exposes
-`history_epoch`, `lexical`, `refresh`, `semantic`, and `daemon`
-objects. `ctx doctor` is the diagnostic surface for those components.
+In auto mode, persistent background maintenance owns provider/plugin refresh,
+immutable candidate construction, atomic lexical publication, source discovery
+state, and semantic catch-up. Manual mode retains explicit finite Core
+publication. `ctx daemon run` is available for advanced foreground maintenance
+and does not change the indexing mode. `ctx status` exposes `history_epoch`,
+`lexical`, `refresh`, `semantic`, and `daemon` objects; `ctx doctor` is the
+diagnostic surface for those components.
 
 ## Docs
 
@@ -801,6 +818,10 @@ Structured output is available for:
 ```text
 ctx setup --format json
 ctx status --format json
+ctx index --format json
+ctx index mode --format json
+ctx index mode auto --format json
+ctx index mode manual --format json
 ctx index watch --format jsonl
 ctx index wait --format json
 ctx sources --format json

--- a/docs/contracts/json.md
+++ b/docs/contracts/json.md
@@ -69,8 +69,8 @@ setup attaches long enough to certify a verified empty Core generation instead
 of returning an uncertified pending state. The deprecated `--catalog-only` flag
 is reported by `deprecated_catalog_only_ignored` and does not change the
 persistent lifecycle.
-Use `ctx daemon status --format json` for the complete process and applied
-configuration state.
+Use `ctx status --format json` for complete process, supervisor, and applied
+configuration health.
 
 ## Status
 
@@ -84,6 +84,7 @@ Reads local storage state and returns:
 - `initialized`;
 - `data_root`;
 - `config_path`;
+- `indexing`, with effective `mode` (`auto` or `manual`);
 - `history_epoch`;
 - `lexical`;
 - `refresh`;
@@ -119,46 +120,56 @@ local diagnostics.
 ## Index Readiness
 
 ```bash
+ctx index --format json
+ctx index mode --format json
+ctx index mode auto --format json
+ctx index mode manual --format json
 ctx index watch --format jsonl
 ctx index wait --format json
 ```
 
-Each watch line is a read-only readiness snapshot containing `schema_version`,
-`initialized`, `lexical`, `refresh`, `semantic`, `daemon`, `local_only`, and
-`read_only`. Lexical counts and certified source bytes describe the currently
-verified generation. Refresh progress contains only values reported by the
-active refresh job; no synthetic work units, failure counts, rates, or remaining
-time are added.
+`ctx index --format json` returns the one-shot readiness snapshot. Each watch
+line uses the same read-only shape: `schema_version`, `initialized`, `indexing`,
+`lexical`, `refresh`, `semantic`, `daemon`, `local_only`, and `read_only`.
+`indexing.mode` is `auto` or `manual`. Lexical counts and certified source bytes
+describe the currently verified generation. Refresh progress contains only
+values reported by the active refresh job; no synthetic work units, failure
+counts, rates, or remaining time are added.
+
+`ctx index mode --format json` returns `schema_version`, `indexing.mode`,
+`config_path`, `local_only`, and `read_only: true`. Supplying `auto` or `manual`
+persists the mode and returns `read_only: false` plus
+`indexing.requested_mode`, `indexing.overridden`, `daemon.running`, optional
+`daemon.pid`, `daemon.persistent`, and `daemon.supervisor`. `overridden` is true
+when a process-level control keeps a different effective mode. Mode changes
+reconcile supervision to that effective mode. When auto remains effective, ctx
+installs or repairs supervision and starts the persistent daemon; manual mode
+stops it and removes persistent supervision. Explicit import and search
+`--refresh wait` can still use finite workers.
 
 Wait returns one object with `schema_version`, `status` (`ready`, `blocked`, or
 `timeout`), `selection`, the final `readiness` snapshot, `local_only`, and
-`read_only`. Use `ctx status --format json` for the complete status contract;
-the index command intentionally has no separate one-shot status surface.
+`read_only`. Use `ctx status --format json` for the complete health contract,
+including daemon and supervisor diagnostics.
 
-`semantic.status` is one of:
+Index snapshots expose the reduced
+`semantic.{status,reason,enabled,coverage.{searchable_items,embedded_items,embedded_chunks}}`
+shape and `daemon.{status,running,jobs.semantic_index}`. The complete semantic
+and daemon fields below describe `ctx status --format json`, not index
+snapshots.
 
-- `unknown`, no initialized ctx store is available for live coverage;
-- `empty`, the store has no semantic-eligible items;
-- `pending`, semantic-eligible items exist but the sidecar is missing, behind,
-  or has dirty/stale items queued for re-embedding;
-- `ready`, sidecar coverage matches the current searchable item count and the
-  dirty queue is empty;
-- `running`, the background worker lock belongs to a live process;
-- `stale_lock`, a worker lock exists but the recorded process is not live;
-- `failed`, the last worker run failed and recorded `last_error`;
-- `unavailable`, the sidecar cannot be opened/read by this ctx build;
-- `budget_exhausted`, the worker indexed a bounded batch and left queued work.
-
-`semantic.coverage` includes `searchable_items`, `embedded_items`,
-`embedded_chunks`, `dirty_items`, `queued_items_estimate`, and
-`coverage_ratio`. `dirty_items` counts already-known events whose semantic
-vectors may be stale after import or daemon startup freshness checks.
+`semantic.status` is `disabled`, `pending`, `ready`, or `unavailable`.
+`semantic.flat_f32` reports the source-backed projection and can include its
+`status`, `reason`, `path`, Core and flat generation identity, semantic document
+count, active event/chunk/vector-byte counts, and `last_error`. Optional
+`semantic.catch_up` retains the latest semantic-index job receipt. Live worker
+state and coverage are reported under `daemon.jobs.semantic_index` below.
 
 `daemon` reports the ctx-owned background coordinator state. Fields listed as
 nullable may be omitted when unavailable:
 
 - `enabled`, retained as a compatibility-shaped boolean and true when indexing
-  mode is automatic;
+  mode is `auto`;
 - `status`, one of `unknown`, `disabled`, `running`, `stopped`, `completed`,
   `failed`, or `stale_lock`; `completed` remains readable for legacy finite-run
   receipts, while current persistent and finite workers use `stopped` after
@@ -187,8 +198,9 @@ configuration acknowledged by the running daemon. A changed config remains
 `pending` with `out_of_sync: true` until the daemon reloads it. Parse/read
 failures retain the last applied runtime and report `failed`; inability to
 establish newly requested semantic runtime ownership reports
-`activation_failed`. `ctx daemon status` remains available while the config is
-malformed so this retained failure can be diagnosed.
+`activation_failed`. `ctx daemon status --format json` remains a hidden
+compatibility diagnostic when malformed configuration caused the retained
+reload failure; ordinary commands reject malformed configuration.
 
 `daemon.jobs.semantic_index` mirrors live semantic coverage and includes
 `status`, `enabled`, `runtime_active`, `semantic_enabled`,
@@ -220,13 +232,6 @@ diagnostics survive later healthy source cycles and daemon restarts, clear when
 that source is observed without rejections, and do not make the daemon fail.
 Source-level failures remain terminal and are reported separately.
 
-`ctx daemon status --format json` returns `schema_version`, `daemon`, `pro`, and
-`local_only`. `ctx daemon enable --format json` and `ctx daemon disable --format json` return
-`schema_version`, `daemon_enabled`, `running`, `pid`, `persistent`, `supervisor`,
-`config_path`, and `local_only`. Here `persistent` means the running process has
-no planned idle exit; automatic restart after process failure is reported
-separately by `supervisor.restart_supported` and the supervisor verification
-fields.
 `ctx daemon run --format json` returns the daemon object directly. The legacy hidden
 `__ctx-daemon` entry point follows the same run output for compatibility.
 
@@ -416,8 +421,7 @@ then require an already-running endpoint. Output format does not change this
 authority. A process started for import reports `start_mode: "auto"` and
 `trigger_command: "import"` through live status surfaces.
 Import result schema version 2 does not embed daemon process state. Use
-`ctx daemon status --format json` to inspect an already-running or explicitly started
-daemon.
+`ctx status --format json` to inspect daemon and supervisor health.
 
 ## Progress
 

--- a/docs/daemon-semantic-indexing-spec.md
+++ b/docs/daemon-semantic-indexing-spec.md
@@ -1,13 +1,27 @@
-# Daemon-Owned Indexing and Semantic Search Spec
+# Indexing and Semantic Search Spec
 
 This spec records the product and architecture decision for local semantic
 search.
 
 ## Decision
 
-ctx makes automatic local daemon-owned indexing the default path and also
-supports manual indexing. Semantic search remains an explicit opt-in; when
-enabled, hybrid retrieval becomes the default.
+ctx makes automatic indexing the default and also supports manual indexing.
+Automatic indexing uses a persistent background daemon; manual indexing starts
+finite workers only for explicit refreshes. Semantic search remains an explicit
+opt-in; when enabled, hybrid retrieval becomes the default.
+
+The public indexing modes are:
+
+| Mode | Meaning |
+| --- | --- |
+| `auto` | Default. Permit persistent background maintenance to keep indexes current. |
+| `manual` | Run no persistent daemon. `ctx import` and `ctx search --refresh wait` can start finite workers for explicit updates. |
+
+`ctx index mode` reads the mode; `ctx index mode auto` and
+`ctx index mode manual` persist changes and immediately reconcile supervision.
+When auto remains effective, ctx installs or repairs supervision and starts the
+daemon; manual mode stops it and removes supervision.
+The canonical config is `[indexing] mode = "auto"|"manual"`.
 
 Search is an interactive read path and never becomes a duplicate importer.
 Automatic background search may start or signal the persistent daemon. Manual
@@ -63,6 +77,11 @@ history, start persistent daemon maintenance in automatic mode, and return
 promptly. Manual setup starts no worker. Setup should not block for full
 semantic completion by default.
 
+`ctx setup --semantic` enables semantic search and requires auto mode. A user in
+manual mode runs `ctx index mode auto` first. Lexical search remains available
+while embeddings build; hybrid retrieval uses both indexes when coverage is
+ready.
+
 Default human output should include a strong foreground signal:
 
 ```text
@@ -107,10 +126,15 @@ semantic job as enabled.
 
 ## Foreground Progress Commands
 
-Add an `index` command group that observes daemon state. It should not become
-the indexing worker.
+The `index` command group shows focused indexing state and controls automatic
+indexing. Its status and readiness commands do not become indexing workers.
 
 ```text
+ctx index
+ctx index --format json
+ctx index mode
+ctx index mode auto
+ctx index mode manual
 ctx index watch
 ctx index watch --format jsonl
 ctx index wait --lexical
@@ -125,6 +149,8 @@ without terminal control sequences. `--format jsonl` writes one JSON object per
 snapshot instead. `ctx index wait` exits zero when the requested readiness is
 reached and non-zero on timeout/error; wait uses `--format json` for one
 structured result. `ctx status` remains the complete one-shot authority.
+It includes daemon and supervisor health; `ctx index` is the smaller one-shot
+indexing status view.
 
 Example watch output:
 
@@ -171,10 +197,18 @@ The setup command owns:
 
 The foreground `index` command owns:
 
+- showing a one-shot indexing status view
+- reading and updating the persisted indexing mode
+- installing or repairing persistent supervision in auto mode
+- stopping and removing persistent supervision in manual mode
 - reading daemon/store/semantic status
 - displaying progress
 - waiting on readiness
 - never doing embedding itself
+
+`ctx daemon run` remains an advanced foreground command. It blocks until stopped
+and does not change the persisted indexing mode. Automatic mode owns ordinary
+background startup; there is no separate public daemon start command.
 
 ## Implementation Principles
 
@@ -218,8 +252,9 @@ The foreground `index` command owns:
    full semantic indexing by default.
 
 5. Add `ctx index`:
-   implement `status`, `watch`, and `wait` by reading existing daemon job and
-   semantic worker status. Reuse `daemon_report` and `semantic_worker_report`.
+   implement the one-shot status view, `mode`, `watch`, and `wait` by reading
+   existing daemon job and semantic worker status. Mode changes reuse the
+   persistent supervision lifecycle.
 
 6. Move semantic corpus toward `lite_turn + rollups`:
    replace raw event chunking in the semantic worker with deterministic

--- a/docs/first-10-minutes.md
+++ b/docs/first-10-minutes.md
@@ -36,6 +36,7 @@ inventories local history sources, imports discovered native provider sources,
 and publishes an immutable Core/Tantivy search generation. Optional semantic
 indexing advances separately. It does not execute history-source plugin
 commands. The default root is `~/.ctx`.
+
 Use a temporary root for trials:
 
 ```bash
@@ -116,11 +117,12 @@ ctx search "build failure" --term checksum --term release --limit 5
 ```
 
 `--limit` is capped at `200`. Search defaults to `--refresh background`, which
-serves the active Core generation while automatic indexing requests persistent
-daemon refresh and semantic catch-up when enabled. Manual indexing serves only
-the last published generation in background mode. Use `--refresh wait` for an
-authoritative Core refresh or `--refresh off` for a query that never starts or
-wakes a process.
+serves the active Core generation while automatic indexing requests background
+refresh and semantic catch-up when enabled. Manual indexing serves only the last
+published generation in background mode. Use `ctx index mode auto` or
+`ctx index mode manual` to change the mode, `--refresh wait` for an authoritative
+Core refresh, or `--refresh off` for a query that never starts or wakes a
+process.
 
 Direct CLI searches automatically exclude the current session tree for Codex,
 DeepSeek Harness, Grok Build, Pi, Claude Code, Goose, Hermes, Shelley, Qwen
@@ -137,6 +139,9 @@ Copy ctx-owned IDs from the result and inspect the hit or transcript:
 ctx show event <ctx-event-id> --window 3
 ctx show session <ctx-session-id>
 ```
+
+Semantic search is optional; see [Retrieval backends](search.md#retrieval-backends)
+for setup and readiness behavior.
 
 Use citations from `ctx search` or `ctx show` when the retrieved material
 affects an answer or implementation. Add `--format json` only when a script or

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,9 +23,8 @@ to manage `PATH` yourself.
 
 The install script installs `ctx`, runs the bundled agent-history skill
 installer, and runs `ctx setup` so discovered local history is inventoried and
-indexing begins. Automatic indexing is the default, so that setup run requests
-the persistent ctx-owned daemon after setup output for native-history
-freshness. Semantic
+indexing begins. Automatic indexing is the default, so ctx keeps native history
+fresh in the background after setup. Semantic
 catch-up remains disabled unless semantic search is explicitly enabled. The
 skill installer opens an agent picker when interactive;
 otherwise it installs the universal `~/.agents/skills` copy plus detected
@@ -69,20 +68,33 @@ ctx status
 ```
 
 Setup creates the configured ctx data root, prepares an immutable Core/Tantivy
-generation with complete policy-selected records and source identities, starts or health-checks the
-enabled persistent daemon, requests a provider-source refresh, and prints next
-steps. It does not write `config.toml`
+generation with complete policy-selected records and source identities,
+requests a provider-source refresh, starts or health-checks automatic background
+indexing, and prints next steps. It does not write `config.toml`
 for implicit defaults and does not execute history-source plugin commands. The
-default data root is `~/.ctx`. Use `ctx daemon disable` to select manual
-indexing or `ctx setup --no-daemon` for a one-run opt-out. Existing
-`[daemon] enabled = false` configurations are accepted as manual mode and are
-migrated to `[indexing] mode = "manual"` when lifecycle controls touch them.
+default data root is `~/.ctx`. Use `ctx index mode manual` to select manual
+indexing or `ctx setup --no-daemon` for a one-run process-start opt-out. Check or
+change the mode with:
+
+```bash
+ctx index mode
+ctx index mode auto
+ctx index mode manual
+```
+
 The equivalent canonical configuration is:
 
 ```toml
 [indexing]
 mode = "manual"
 ```
+
+The other supported value is `"auto"`, which is the default and permits
+persistent background maintenance. Mode setters persist the requested choice
+and reconcile supervision to the effective mode. When auto is not overridden,
+ctx installs or repairs supervision and starts the daemon. Manual mode stops the
+persistent daemon and removes its supervision; explicit `ctx import` and
+`ctx search --refresh wait` can still use finite workers.
 
 Machine-readable setup follows the same lifecycle and reports schema version 2
 with top-level `daemon_autostart` and `refresh_request` objects. The deprecated
@@ -100,6 +112,19 @@ models, or require API keys while semantic search is disabled. If automatic
 indexing and semantic search are explicitly enabled, daemon maintenance may
 acquire the local ONNX Runtime asset and embedding model needed for the
 installed platform.
+
+Enable local semantic search with:
+
+```bash
+ctx setup --semantic
+ctx index
+```
+
+Semantic indexing requires auto mode. If you selected manual indexing, run
+`ctx index mode auto` before `ctx setup --semantic`. Lexical search remains
+available while embeddings build; hybrid search uses lexical and semantic
+evidence automatically when coverage is ready.
+
 ctx has no hosted-history client or `ctx cloud` subcommand. Official
 installer-managed binaries can separately run signed CLI
 upgrade checks; that updater does not collect provider history.
@@ -141,7 +166,7 @@ malformed and report those rejections explicitly. Unreadable or incompatible
 sources still fail without preventing `--all` from importing other sources.
 
 With automatic indexing, `ctx import` can start the persistent ctx-owned daemon.
-With manual indexing, the explicit import instead starts a finite Core worker,
+With manual indexing, the explicit import can instead start a finite Core worker,
 waits for authoritative publication, and lets it exit without watcher,
 semantic, timer, supervisor, or upgrade maintenance. Use
 `ctx import --no-daemon` to forbid starting or restarting either process.
@@ -249,5 +274,5 @@ available for human shell use.
 unmanaged and will not self-upgrade. Automatic upgrade is on by default for a
 managed binary while automatic indexing's persistent daemon is enabled; use
 `ctx upgrade disable` for a persistent upgrade-only opt-out or
-`ctx daemon disable` to select manual indexing, which also disables automatic
+`ctx index mode manual` to select manual indexing, which also disables automatic
 upgrade maintenance.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -40,7 +40,9 @@ shipped.
   `--refresh wait` may start a finite Core worker. Use `ctx setup --no-daemon`
   or `ctx import --no-daemon` for a one-run process-start opt-out. Explicit
   `ctx daemon run --force` runs persistent maintenance in the foreground even
-  when manual mode is configured.
+  when manual mode is configured, blocks until stopped, and does not change the
+  configured indexing mode. The canonical setting is `[indexing] mode = "auto"`
+  or `"manual"`; use `ctx index mode` to read or change it.
 - Finite Core workers use the same daemon refresh engine and endpoint, but do
   not install supervision or run watcher, timer, semantic, reconciliation, or
   upgrade maintenance. They exit only after an admitted request exists, all
@@ -73,6 +75,10 @@ shipped.
   validated local runtime remain lexical-safe: `hybrid` falls back to lexical
   and explicit `semantic` reports a local unavailable/runtime error instead of
   linking an unsupported backend.
+- Semantic indexing requires auto mode. Use `ctx index mode auto` before
+  `ctx setup --semantic` when manual mode is configured. Lexical search remains
+  available while embeddings build, and hybrid uses both backends when coverage
+  is ready.
 - The ctx macOS CLI targets macOS 13, but ONNX Runtime 1.27 follows its upstream
   macOS 14 minimum. On macOS 13, daemon-backed lexical search remains available
   while semantic search is unavailable.

--- a/docs/local-semantic-search-ship-plan.md
+++ b/docs/local-semantic-search-ship-plan.md
@@ -16,16 +16,24 @@ and private relevance evals justify flipping the default.
   compliance, hosted acceleration, and LLM summaries. The free local CLI should
   stay useful enough to create trust.
 - Automatic indexing and persistent daemon maintenance are the default. Users
-  can select manual indexing durably with:
+  can inspect the mode with `ctx index mode` and change it with
+  `ctx index mode auto` or `ctx index mode manual`. The
+  canonical config is:
 
   ```toml
   [indexing]
-  mode = "manual"
+  mode = "auto" # or "manual"
   ```
 
-- Semantic remains disabled by default and requires the daemon. The supported
-  semantic opt-in shape
-  is:
+- Semantic remains disabled by default and requires auto mode. Enable it with:
+
+  ```bash
+  ctx index mode auto
+  ctx setup --semantic
+  ctx index
+  ```
+
+  The equivalent config opt-in is:
 
   ```toml
   [search]
@@ -50,7 +58,7 @@ and private relevance evals justify flipping the default.
 - `ctx setup`, `ctx import`, and `ctx search` should not write `config.toml` for
   implicit defaults. The config file is user-managed override surface.
 - `ctx setup` should be repeatable. If an existing user later enables
-  `[indexing] mode = "automatic"` and `[search] semantic = true` and reruns setup,
+  `[indexing] mode = "auto"` and `[search] semantic = true` and reruns setup,
   setup should leave existing data intact, start daemon-owned indexing when
   possible, and let the daemon acquire the local embedding model and build
   missing semantic sidecars.
@@ -80,10 +88,10 @@ and private relevance evals justify flipping the default.
   `intfloat/multilingual-e5-small`. Query and passage role prefixes are applied
   exactly once, and the new model key prevents pre-migration vectors from being
   counted as E5 sidecar coverage.
-- Config now has `[indexing] mode = "automatic"|"manual"` and
-  `[search] semantic = true|false`. Indexing defaults to automatic, while unset
+- Config now has `[indexing] mode = "auto"|"manual"` and
+  `[search] semantic = true|false`. Indexing defaults to auto, while unset
   semantic search defaults off; both have env overrides. Legacy
-  `[daemon] enabled = true|false` is compatibility input only.
+  `[daemon] enabled = true|false` remains compatibility input only.
 - Default search backend resolution is config-aware: lexical by default while
   semantic is off, hybrid by default while semantic is on, and explicit semantic
   fails fast when disabled.
@@ -117,6 +125,8 @@ and private relevance evals justify flipping the default.
   background refresh and explicit `--refresh off` do not start daemon work;
   strict semantic fails with an actionable daemon-query-service error when the
   daemon is not running.
+- Lexical search remains available during semantic backfill. Hybrid search uses
+  both lexical and semantic evidence automatically when coverage is ready.
 - Daemon query socket startup is required when semantic is enabled. If the
   socket cannot bind during initial startup, daemon startup fails visibly. If a
   running semantic-disabled daemon cannot bind while applying a later opt-in,
@@ -344,7 +354,7 @@ and private relevance evals justify flipping the default.
 
 - Done on this branch:
   - `[search] semantic = true|false`;
-  - `[indexing] mode = "automatic"|"manual"`;
+  - `[indexing] mode = "auto"|"manual"`;
   - compatibility parsing for `[daemon] enabled = true|false`;
   - `CTX_SEARCH_SEMANTIC`;
   - `CTX_DAEMON_ENABLED`;

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -14,9 +14,8 @@ a hosted research agent.
 ## In Scope
 
 - `ctx setup` initializes local storage, publishes discovered supported local
-  transcript formats, and in automatic indexing mode can opportunistically
-  start the default-on persistent ctx-owned daemon. Manual indexing runs no
-  persistent or background daemon.
+  transcript formats, and in automatic indexing mode can start persistent
+  background indexing. Manual indexing runs no persistent or background daemon.
   `ctx setup --no-daemon` is the one-run daemon-autostart opt-out. Output format
   does not change setup autostart behavior. The deprecated `--catalog-only` flag
   is ignored and does not change setup behavior.
@@ -60,14 +59,20 @@ a hosted research agent.
 - `ctx docs` exposes embedded public documentation and generated man pages.
 - `ctx upgrade` checks and applies signed CLI releases for official
   installer-managed binaries.
-- `ctx daemon` is the first-class local coordinator surface for status,
-  automatic/manual indexing config, persistent maintenance in automatic mode,
-  and explicit foreground maintenance runs. The coordinator performs bounded
+- `ctx index` is the focused indexing surface. With no subcommand it shows a
+  one-shot status view; `ctx index mode` reads or changes `auto|manual` mode;
+  `ctx index watch` follows progress; and `ctx index wait` blocks for selected
+  readiness. The canonical config is `[indexing] mode = "auto"|"manual"`, with
+  auto as the default. Auto permits persistent background maintenance; manual
+  disables it while retaining finite explicit refresh workers. The mode-change
+  commands persist the choice and immediately reconcile daemon supervision.
+- `ctx status` and `ctx doctor` report ctx-owned daemon and supervisor health.
+- `ctx daemon run` is an advanced foreground, blocking maintenance command. It
+  does not change the configured indexing mode. The daemon performs bounded
   native provider-history refresh and local semantic indexing/freshness work.
-  Setup/import
-  autostart reports semantic status read-only; explicit `ctx daemon run` is the
-  path that may perform semantic catch-up.
-- `ctx status` and `ctx doctor` report ctx-owned daemon coordinator state.
+- `ctx setup --semantic` enables local semantic search and requires auto mode.
+  Lexical search remains available while embeddings build; hybrid search uses
+  lexical and semantic evidence when semantic coverage is ready.
 - `ctx stats` reports bounded local usage/value aggregates from the separate
   owner-private `usage.sqlite` sidecar. This default-on product state is
   independent of remote event reporting, has no network path or identity, keeps
@@ -120,7 +125,7 @@ Provider-owned IDs are metadata. Positional command arguments are ctx-owned
 IDs unless a command explicitly accepts `--provider ... --provider-session ...`.
 
 Search and show read indexed content and complete policy-selected normalized
-records from the active Core/Tantivy generation. Explicit import and daemon
+records from the active Core/Tantivy generation. Explicit import and background
 refresh publish provider-file changes into a new search generation.
 
 ## Privacy Contract

--- a/docs/search.md
+++ b/docs/search.md
@@ -50,6 +50,7 @@ ctx search "this current task" --include-current-session
 ctx search "mail provider throttled bulk mailbox setup" --backend hybrid
 ctx search "pricing decisions from the launch review" --backend semantic
 ctx status --format json
+ctx index
 ```
 
 A result can include:
@@ -202,6 +203,18 @@ chunking, source projector, and lexical generation policies participate in
 generation identity, so incompatible derived data is rebuilt rather than
 silently reused.
 
+Enable local semantic search with:
+
+```bash
+ctx index mode auto
+ctx setup --semantic
+ctx index
+```
+
+Semantic indexing requires auto mode. Lexical search remains available while
+embeddings build; when semantic coverage is ready, the default hybrid backend
+uses lexical and semantic evidence together automatically.
+
 Search does not download models, initialize semantic storage, or perform
 foreground semantic catch-up. Explicit semantic search reports a typed local
 error when its cached runtime/model or compatible generation is unavailable; it
@@ -210,7 +223,7 @@ remains lexical-safe in those cases.
 
 ## Refresh and freshness
 
-`--refresh background` is the default. In automatic mode, search health-checks
+`--refresh background` is the default. In auto mode, search health-checks
 and, when needed, wakes or recovers the persistent daemon. In manual mode it
 does not contact, start, or wake a process. Both serve the latest committed
 lexical generation without waiting for optional semantic indexing.
@@ -218,14 +231,14 @@ The daemon owns bounded provider discovery, source refresh, immutable
 candidate-generation construction, publication, and opted-in semantic catch-up.
 The query process never becomes a foreground history writer.
 
-On a fresh automatic root, background mode asks the daemon to publish the first
+On a fresh auto-mode root, background mode asks the daemon to publish the first
 lexical generation. In manual mode, search performs no hidden bootstrap or
 fallback import and can query only an already committed generation. Enabled
 auto-refresh history-source plugins run through the same
 daemon-owned, bounded Core refresh route; explicit-only sources still require
 an explicit import.
 
-`--refresh wait` wakes the persistent daemon in automatic mode or starts a
+`--refresh wait` wakes the persistent daemon in auto mode or starts a
 finite Core worker in manual mode, then waits for the requested source frontier
 and lexical-generation receipt. It fails with a typed source, lag, or system
 error when that receipt cannot publish; it does not fall back to a foreground
@@ -242,8 +255,9 @@ Winner-only provider precedence prevents combining a selected replacement with
 stale defaults.
 
 `ctx status` and search JSON report lexical generation, refresh state, semantic
-generation binding and coverage, daemon work, and typed fallback reasons.
-`ctx index watch` and `ctx index wait` expose a smaller readiness-only view.
+generation binding and coverage, daemon work, supervisor health, and typed
+fallback reasons. `ctx index` shows the smaller one-shot indexing status view;
+`ctx index watch` follows it and `ctx index wait` blocks for readiness.
 
 ## Core-backed presentation
 

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -23,7 +23,13 @@ the local retrieval product.
   `ctx show session --out` writes only the explicit path when one is provided.
 - `ctx status` does not mutate canonical history: missing stores stay missing,
   and existing stores are not migrated, repaired, or used to create search
-  generations.
+  generations. It reports daemon and supervisor health without changing either.
+- `ctx index` is read-only, as are `ctx index mode` with no mode argument,
+  `ctx index watch`, and `ctx index wait`. `ctx index mode auto` and
+  `ctx index mode manual` are explicit configuration and process-lifecycle
+  mutations. They persist the requested mode and reconcile supervision to the
+  effective mode; a process-level override can keep manual mode active after an
+  auto request.
 - In local-only security mode, setup/import/default search do not use network
   access or API keys. Explicit semantic use still must not call hosted model
   APIs, and search must not download the local embedding model when the required
@@ -59,7 +65,9 @@ the local retrieval product.
   only bounded native local provider-history refresh and bounded semantic
   catch-up. It must not run history-source plugins.
   Network model acquisition is allowed only for the local embedding model when
-  semantic search is explicitly enabled.
+  semantic search is explicitly enabled with `ctx setup --semantic` in auto
+  mode. `ctx daemon run` blocks in the foreground and does not mutate indexing
+  mode.
 - A finite Core worker may start only for explicit import or search
   `--refresh wait`. It must not install persistent supervision or run watcher,
   timer, semantic, or upgrade maintenance, and it must not exit before admitted

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -29,11 +29,9 @@ The duplicate `upgrade.interval_seconds` config key is also removed. Use
 `upgrade.interval_hours` for persistent configuration or
 `CTX_UPGRADE_INTERVAL_SECONDS` for a process-level override.
 
-The canonical persisted indexing control is `[indexing] mode = "automatic"`
-or `"manual"`. Existing `[daemon] enabled = true|false` files remain accepted
-as compatibility input and map to automatic/manual respectively. If both keys
-are present, the canonical indexing mode wins. A daemon lifecycle enable or
-disable command rewrites the canonical key and removes the legacy key.
+The canonical persisted indexing control is `[indexing] mode = "auto"` or
+`"manual"`. Auto is the default. Use `ctx index mode` to read the effective
+mode and `ctx index mode auto` or `ctx index mode manual` to persist a change.
 
 ctx stores immutable Core/Tantivy search generations, optional semantic data,
 and content-free local usage aggregates locally. Treat the ctx data root like
@@ -292,6 +290,8 @@ local upsert as described above.
 | --- | --- | --- |
 | `ctx setup` | provider transcript files and bounded path metadata for source discovery | data root, source catalog/epoch metadata, `search/lexical`, and optional persistent daemon lock/status/job files in automatic mode; old Store artifacts are neither opened nor deleted |
 | `ctx status` | data root metadata, source epoch, lexical/semantic generation metadata, daemon state, and compact local usage health | none; does not mutate provider history, Core generations, or usage aggregates |
+| `ctx index` / `ctx index watch` / `ctx index wait` | indexing mode, lexical/semantic generation metadata, and daemon state | none |
+| `ctx index mode` | `config.toml` when present | none when reading; `auto` or `manual` writes `config.toml` and establishes or removes persistent supervision |
 | `ctx stats` | owner-private aggregate `usage.sqlite` when present | none; does not create pristine usage state or count itself |
 | `ctx sources` | bounded provider path metadata, allowlisted persistent selector files, and local history-source plugin manifests | none |
 | `ctx import` | provider transcript files and path metadata, the explicit custom history JSONL file passed with `--input-format ctx-history-jsonl-v1 --path`, or a durable provider-owned custom history JSONL file declared by an explicit history-source plugin manifest | immutable candidate Core/Tantivy generation and atomic publication, catalog/epoch metadata, and optional persistent or finite-worker daemon files; finite workers do not run semantic work |
@@ -301,8 +301,6 @@ local upsert as described above.
 | `ctx docs` | embedded documentation in the binary | selected topic `--out` path for `ctx docs show --out` or selected `--out` directory for `ctx docs man --out` |
 | `ctx upgrade` | signed release metadata and installed binary/sidecar metadata | installed binary for manual upgrade, install sidecar, and executable-adjacent `.ctx.upgrade-state.json`, `.ctx.install.lock`, and transaction journal |
 | `ctx doctor` | source epoch, lexical/semantic generation metadata, and ctx-owned daemon lock/status/job metadata | none |
-| `ctx daemon status` | lexical/semantic generation and ctx-owned daemon lock/status/job metadata | none |
-| `ctx daemon enable` / `ctx daemon disable` | `config.toml` | `config.toml` |
 | `ctx daemon run` | provider transcripts, active lexical and semantic generations, model-cache metadata, and daemon state | candidate lexical generation publication, semantic catch-up, and daemon state |
 
 Setup, import, and default search do not require source repository writes, model
@@ -340,13 +338,14 @@ process. Explicit `--refresh wait` may start a finite Core worker, but that
 worker never starts semantic services or catch-up. History-source plugins are
 refreshed only by an explicit selected-plugin import in 1.0.
 
-When automatic setup/import autostart or `ctx daemon run` starts the persistent
-coordinator, it stores private lock/status files under `daemon/` in the ctx data
-root. Explicit `ctx daemon run` runs the same persistent coordinator in the
-foreground; `--force` is required to override manual indexing. The coordinator
-always bounds native provider-history refresh and local semantic indexing by
-its local runtime/model availability. Foreground query activity preempts
-background work.
+When auto mode or `ctx daemon run` starts the persistent coordinator, it stores
+private lock/status files under `daemon/` in the ctx data root. Auto mode owns
+background startup; there is no separate public daemon start command. Explicit
+`ctx daemon run` runs the same coordinator in the foreground and blocks until
+stopped without changing indexing mode; `--force` is required in manual mode.
+The coordinator always bounds native provider-history refresh and local semantic
+indexing by its local runtime/model availability. Foreground query activity
+preempts background work.
 
 Manual explicit import and search `--refresh wait` instead start the same Core
 refresh engine in a finite worker. The finite profile does not install native
@@ -423,11 +422,18 @@ explicit import and search `--refresh wait` may use a finite Core worker.
 `--refresh off` and explicit `--no-daemon` controls never start or wake either
 profile.
 
-`ctx daemon disable` writes `[indexing] mode = "manual"`; `ctx daemon enable`
-writes `"automatic"`. Both remove a legacy `[daemon] enabled` key while
-preserving other daemon settings. Legacy `enabled = true|false` remains accepted
-under `[daemon]` as automatic/manual compatibility input, but the canonical key
-wins if both are present. An explicit manual config continues to win after CLI
+Use the public indexing controls to inspect or change the setting:
+
+```bash
+ctx index mode
+ctx index mode auto
+ctx index mode manual
+```
+
+Mode setters persist the requested canonical value and reconcile supervision to
+the effective mode. When auto is not overridden, ctx installs or repairs
+supervision and starts the persistent background daemon. Manual mode stops it
+and removes supervision. An explicit manual config continues to win after CLI
 upgrades and over `CTX_DAEMON_ENABLED=true`; `CTX_DAEMON_ENABLED=false` remains
 a process-level manual-mode override.
 
@@ -449,16 +455,16 @@ indexing and serving, canonical maintenance, and automatic upgrades do not run.
 Manual finite workers always enforce the Core-only exclusions independently of
 this persistent-daemon setting.
 
-Local semantic search requires daemon maintenance and remains disabled by
-default. Its opt-in is:
+Local semantic search remains disabled by default and requires automatic
+indexing. Its config opt-in is:
 
 ```toml
 [search]
 semantic = true
 ```
 
-If manual indexing was previously selected, run `ctx daemon enable` before
-enabling semantic search.
+See [Retrieval backends](search.md#retrieval-backends) for the setup command and
+readiness behavior.
 
 The persistent daemon in automatic mode is the sole automatic-upgrade authority
 and uses `upgrade.auto = "apply"` by default for official installer-managed

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -48,6 +48,13 @@ daemon to refresh while serving the latest published generation. In manual
 mode, ordinary search and `--refresh background` intentionally use only that
 published generation and do not start or wake a process.
 
+Check the current mode and background health:
+
+```bash
+ctx status
+ctx index mode
+```
+
 Request an authoritative refresh explicitly:
 
 ```bash
@@ -60,7 +67,24 @@ ctx search "the missing phrase" --refresh wait
 Use `ctx import --resume --format json` when you want output to mark the run as an
 idempotent rescan. In manual mode, explicit import and `--refresh wait` may
 start a finite Core worker and wait for it to publish. `--refresh off` never
-starts or wakes one. Run `ctx daemon enable` to return to automatic indexing.
+starts or wakes one. Run `ctx index mode auto` to return to automatic indexing;
+when no process-level override disables it, that command installs or repairs
+supervision and starts persistent background indexing.
+
+## Background Indexing Is Not Running
+
+Run:
+
+```bash
+ctx status
+ctx index mode auto
+```
+
+`ctx status` includes daemon and supervisor health. Reapplying auto mode
+reconciles the lifecycle to the effective mode; if an override still selects
+manual mode, the command reports that instead of starting a daemon.
+For advanced foreground diagnosis, `ctx daemon run` blocks in the current
+terminal and does not change the configured indexing mode.
 
 After upgrading to `0.10.x` or newer, a refresh can take longer once because ctx
 marks older provider import cache rows pending and reimports them to populate
@@ -109,6 +133,19 @@ The automatic scheduler state is stored beside the managed executable in
 `.ctx.upgrade-state.json`; checks should not write to foreground stdout or
 stderr. With `[indexing] mode = "manual"`, no automatic check occurs. Finite
 Core workers do not perform upgrade maintenance.
+
+## Semantic Search Is Not Ready
+
+Semantic indexing requires auto mode. Enable it and inspect current health with:
+
+```bash
+ctx index mode auto
+ctx setup --semantic
+ctx index
+```
+
+Lexical search remains available while embeddings build. Hybrid search begins
+using both lexical and semantic evidence when coverage is ready.
 
 ## Store Problems
 

--- a/docs/unmanaged-installs.md
+++ b/docs/unmanaged-installs.md
@@ -30,7 +30,11 @@ installed executable:
 ctx daemon disable --prepare-uninstall --format=json
 ```
 
-This is an installation-wide handoff, even when `CTX_DATA_ROOT` or
+This hidden compatibility command is reserved for the installation-wide
+uninstall handoff; it is not the public indexing-mode control. Use
+`ctx index mode auto` or `ctx index mode manual` for normal indexing
+configuration. The handoff
+applies even when `CTX_DATA_ROOT` or
 `--data-root` selects a custom root. It disables and quiesces every registered
 daemon root, removes the singleton native supervisor from the canonical root,
 releases owner locks and endpoints, and retains the executable and history
@@ -57,7 +61,7 @@ After an upgrade or reinstall, restore the normal unmanaged installation:
 
 ```bash
 ctx integrations install skills
-ctx daemon enable
+ctx index mode auto
 ctx setup
 ```
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -32,6 +32,11 @@ upgrade process; manual mode's finite Core workers do not either. With
 apply; explicit `ctx upgrade` remains available. Output format does not change
 these rules.
 
+Use `ctx index mode` to inspect the indexing mode. `ctx index mode auto`
+restores automatic indexing and its persistent daemon when no process-level
+override disables it; `ctx index mode manual` stops the daemon and removes its
+supervision.
+
 Use `CTX_UPGRADE_AUTO=off` for a process-level opt-out. For a persistent opt-out,
 run `ctx upgrade disable`; it writes `upgrade.auto = "off"` in `config.toml`.
 Run `ctx upgrade enable` to restore `upgrade.auto = "apply"`. `ctx status` and

--- a/scripts/check-public-control-surface.py
+++ b/scripts/check-public-control-surface.py
@@ -145,7 +145,11 @@ def extract_empty_config_defaults(config_source: str) -> dict[str, object]:
         re.DOTALL,
     )
     if indexing_mode:
-        defaults["indexing.mode"] = indexing_mode.group(1).lower()
+        mode_variant = indexing_mode.group(1)
+        defaults["indexing.mode"] = {
+            "Automatic": "auto",
+            "Manual": "manual",
+        }.get(mode_variant, mode_variant.lower())
     else:
         # Previous stable releases exposed the same control as a boolean.
         # Keep extracting that historical key so the pinned snapshot can be
@@ -163,7 +167,7 @@ def extract_empty_config_defaults(config_source: str) -> dict[str, object]:
 
 
 def default_state(value: object) -> str:
-    return "on" if value is True or value in {"apply", "automatic"} else "off"
+    return "on" if value is True or value in {"apply", "auto", "automatic"} else "off"
 
 
 def previous_stable_defaults(

--- a/scripts/run-native-candidate-smoke.sh
+++ b/scripts/run-native-candidate-smoke.sh
@@ -433,7 +433,7 @@ indexing_default="$(inventory_default_field "indexing mode" "value")"
 semantic_default="$(inventory_default_field "semantic search" "value")"
 if [ "${analytics_default}" != true ] \
   || [ "${upgrade_default}" != apply ] \
-  || [ "${indexing_default}" != automatic ] \
+  || [ "${indexing_default}" != auto ] \
   || [ "${semantic_default}" != false ]; then
   printf 'candidate smoke control inventory has unexpected released defaults\n' >&2
   exit 1


### PR DESCRIPTION
## Summary

- replace user-facing daemon enable/disable controls with `ctx index mode auto|manual` while retaining parse compatibility
- add the coherent `ctx index` command family plus foreground `ctx daemon run`
- report requested/effective indexing mode and document BM25 lexical search versus optional semantic search

## Validation

- affected Bazel selector: 64/64 passed
- strict CI Clippy build: 429 targets passed
- default CI test graph: 206 tests passed
- focused lifecycle, docs/control-surface, and native smoke coverage passed

`bash scripts/check.sh --mode=ci` currently stops in preflight on the existing `ctx-history-refresh` crate-size limit (`20992 > 20000`) on current main; this branch does not modify that crate. The exact build and test phases invoked by the gate pass.