### PR TITLE
fix(release): provision requested OSV ecosystems

### DIFF
--- a/scripts/release/run-with-release-advisory-inputs.py
+++ b/scripts/release/run-with-release-advisory-inputs.py
@@ -25,6 +25,7 @@ SCANNER_ASSETS = {
     "macos-x64": "osv-scanner_darwin_amd64",
     "windows-x64": "osv-scanner_windows_amd64.exe",
 }
+DATABASE_ECOSYSTEMS = ("crates.io", "npm")
 HEX_64 = re.compile(r"[0-9a-f]{64}")
 VERSION = re.compile(r"[0-9]+[.][0-9]+[.][0-9]+")
 
@@ -126,6 +127,7 @@ def prepare_inputs(
     repo_root: Path,
     task_root: Path,
     target_id: str,
+    ecosystems: tuple[str, ...] = ("crates.io",),
 ) -> tuple[Path, Path, Path, str]:
     version, expected_sha256, asset = load_scanner_spec(
         repo_root / "security/release-advisory-policy-v1.json",
@@ -137,18 +139,24 @@ def prepare_inputs(
 
     database = task_root / "database"
     metadata = task_root / "database-metadata.json"
+    selected_ecosystems = tuple(sorted(set(ecosystems)))
+    if not selected_ecosystems or any(
+        ecosystem not in DATABASE_ECOSYSTEMS for ecosystem in selected_ecosystems
+    ):
+        raise InputError("release advisory database ecosystem is invalid")
+    update_command = [
+        sys.executable,
+        "-I",
+        str(repo_root / "scripts/update-release-advisory-db.py"),
+        "--database-root",
+        str(database),
+        "--metadata",
+        str(metadata),
+    ]
+    for ecosystem in selected_ecosystems:
+        update_command.extend(["--ecosystem", ecosystem])
     update = subprocess.run(
-        [
-            sys.executable,
-            "-I",
-            str(repo_root / "scripts/update-release-advisory-db.py"),
-            "--database-root",
-            str(database),
-            "--metadata",
-            str(metadata),
-            "--ecosystem",
-            "crates.io",
-        ],
+        update_command,
         capture_output=True,
         check=False,
         env=acquisition_environment(),
@@ -174,6 +182,12 @@ def prepare_inputs(
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser()
     result.add_argument("--target", choices=sorted(SCANNER_ASSETS), required=True)
+    result.add_argument(
+        "--ecosystem",
+        action="append",
+        choices=DATABASE_ECOSYSTEMS,
+        help="OSV ecosystem snapshot to provision (default: crates.io)",
+    )
     result.add_argument("command", nargs=argparse.REMAINDER)
     return result
 
@@ -195,6 +209,7 @@ def main() -> int:
             ROOT,
             task_root,
             args.target,
+            tuple(args.ecosystem or ("crates.io",)),
         )
         print(
             "release advisory inputs prepared: "

--- a/scripts/tests/run-with-release-advisory-inputs-test.py
+++ b/scripts/tests/run-with-release-advisory-inputs-test.py
@@ -240,6 +240,50 @@ class ReleaseAdvisoryInputsTest(unittest.TestCase):
             "v2.4.0/osv-scanner_linux_arm64",
         )
 
+    def test_prepares_every_requested_database_ecosystem_once(self) -> None:
+        task_root = self.root / "mixed-task"
+        task_root.mkdir()
+        observed_command = []
+
+        def fake_run(argv, **kwargs):
+            observed_command.extend(argv)
+            return self.fake_run(argv, **kwargs)
+
+        with mock.patch.object(
+            MODULE.urllib.request,
+            "urlopen",
+            return_value=Response(self.scanner_bytes),
+        ), mock.patch.object(
+            MODULE.subprocess,
+            "run",
+            side_effect=fake_run,
+        ):
+            MODULE.prepare_inputs(
+                self.root,
+                task_root,
+                "linux-x64",
+                ("npm", "crates.io", "npm"),
+            )
+
+        ecosystem_arguments = [
+            observed_command[index + 1]
+            for index, value in enumerate(observed_command)
+            if value == "--ecosystem"
+        ]
+        self.assertEqual(ecosystem_arguments, ["crates.io", "npm"])
+
+    def test_rejects_an_empty_database_ecosystem_set(self) -> None:
+        task_root = self.root / "empty-task"
+        task_root.mkdir()
+        with mock.patch.object(
+            MODULE.urllib.request,
+            "urlopen",
+            return_value=Response(self.scanner_bytes),
+        ), mock.patch.object(MODULE.subprocess, "run") as run:
+            with self.assertRaisesRegex(MODULE.InputError, "ecosystem is invalid"):
+                MODULE.prepare_inputs(self.root, task_root, "linux-x64", ())
+        run.assert_not_called()
+
     def test_cached_ordinary_endpoint_cannot_certify_latest(self) -> None:
         with mock.patch.object(
             UPDATE_MODULE.urllib.request,


### PR DESCRIPTION
Fixes the paired release factory advisory gate by allowing callers to provision every required OSV ecosystem snapshot. The existing default remains crates.io; the paired private factory will explicitly request npm as well.\n\nValidated with:\n- `scripts/bazelw test //:release_advisory_input_tests --test_output=errors`\n- real pinned OSV scanner plus current crates.io/npm snapshots against the private release union (`status: clean`)\n- `git diff --check`