### PR TITLE
fix(managed-pair): restore Windows file identity visibility

### DIFF
--- a/crates/ctx-managed-pair-engine/src/filesystem.rs
+++ b/crates/ctx-managed-pair-engine/src/filesystem.rs
@@ -978,6 +978,8 @@ mod secure_directory;
 
 pub(super) use platform::durable_replace;
 #[cfg(windows)]
+use platform::windows_file_information;
+#[cfg(windows)]
 pub(super) use platform::{current_process_creation_identity, wait_for_parent_exit};
 use platform::{durable_rename, file_information, sync_parent};
 #[cfg(all(test, windows))]

--- a/crates/ctx-managed-pair-engine/src/filesystem/platform.rs
+++ b/crates/ctx-managed-pair-engine/src/filesystem/platform.rs
@@ -22,7 +22,7 @@ pub(super) fn file_information(file: &File, label: &str) -> Result<(u64, u64, u6
 }
 
 #[cfg(windows)]
-fn windows_file_information(file: &File, label: &str) -> Result<(u64, u64, u32)> {
+pub(super) fn windows_file_information(file: &File, label: &str) -> Result<(u64, u64, u32)> {
     use std::{mem::MaybeUninit, os::windows::io::AsRawHandle as _};
     use windows_sys::Win32::{
         Foundation::HANDLE,


### PR DESCRIPTION
The release factory cross-compiles the public CLI for Windows GNU. After the filesystem module split, `windows_file_information` moved into `filesystem::platform` but remained private while its callers stayed in the parent and secure-directory modules. This restores the intended crate-private visibility and parent import.

Validation:
- `scripts/cargo-diagnostic.sh check -p ctx-managed-pair-engine --target x86_64-pc-windows-gnu`
- `scripts/bazelw test //crates/ctx-managed-pair-engine:unit_tests --config=test`
- `scripts/bazelw test //:rustfmt_check --config=test`
- `scripts/bazel-affected.sh origin/main` (63/63)