### PR TITLE
fix(opencode): ignore empty derived strings

### DIFF
--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/json.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/json.rs
@@ -193,6 +193,21 @@ mod tests {
         };
         assert_eq!(diagnostic.body["exit_code"], 7);
         assert_eq!(diagnostic.body["command"], "false");
+
+        let (empty_role, _) = project(
+            r#"{"type":"tool_result","role":"","output":"ok"}"#,
+            "result",
+            None,
+            OpenCodeNativeSchemaFamily::SessionMessageSeq,
+        );
+        let OpenCodeJsonProjection::Output(OpenCodeOutputJson {
+            diagnostic: Some(diagnostic),
+        }) = empty_role
+        else {
+            panic!("empty output role did not retain a diagnostic");
+        };
+        assert_eq!(diagnostic.role, "tool");
+        assert_eq!(diagnostic.body["role"], "");
     }
 
     #[test]

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/json/output.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/json/output.rs
@@ -12,6 +12,7 @@ pub(super) fn project_output(body: &Value, effective_type: &str) -> OpenCodeJson
             role: body
                 .get("role")
                 .and_then(Value::as_str)
+                .filter(|role| !role.is_empty())
                 .unwrap_or("tool")
                 .to_owned(),
             body: body.clone(),

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed.rs
@@ -43,7 +43,7 @@ use crate::{
 
 const SOURCE_ANCHOR_KEY: &str = "active-database";
 const SOURCE_IDENTITY_VERSION: u32 = 1;
-const PARSER_REVISION: &str = "opencode-family-source-backed-v9-neutral-core";
+const PARSER_REVISION: &str = "opencode-family-source-backed-v10-neutral-core";
 const LOGICAL_SESSION_KIND: &str = "opencode-family-session";
 const LOGICAL_EVENT_KIND: &str = "opencode-family-event";
 const NATIVE_SESSION_NAMESPACE: &str = "opencode-family.session-id";

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/pack_tests.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/pack_tests.rs
@@ -255,6 +255,54 @@ fn strict_native_tool_call_preserves_exact_target_range_and_lexical_prefix() {
 }
 
 #[test]
+fn empty_command_fact_does_not_reject_the_opencode_source() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let database = temp.path().join("empty-command-opencode.db");
+    let body = json!({
+        "type": "tool",
+        "callID": "call-empty-command",
+        "tool": "bash",
+        "state": {
+            "status": "error",
+            "input": {
+                "command": "",
+                "path": "src/noop.rs",
+                "description": "noop"
+            }
+        }
+    });
+    drop(write_current_schema(&database, temp.path(), &body));
+
+    let (_, _, records) = scan_current_schema(&database);
+    let [record] = records.as_slice() else {
+        panic!("expected the empty-command call to remain a Core record");
+    };
+    let activity = record.content.activity.as_ref().unwrap();
+    let invocation = activity.invocation.as_ref().unwrap();
+    assert_eq!(invocation.tool, "bash");
+    assert_eq!(
+        invocation.arguments,
+        ActivityJsonCapture::Present {
+            value: json!({
+                "command": "",
+                "path": "src/noop.rs",
+                "description": "noop"
+            })
+        }
+    );
+    assert!(activity.facts.iter().all(|fact| !fact.value.is_empty()));
+    assert!(activity
+        .facts
+        .iter()
+        .any(|fact| fact.kind == LiteralFactKind::File && fact.value == "src/noop.rs"));
+    assert!(!activity
+        .facts
+        .iter()
+        .any(|fact| fact.kind == LiteralFactKind::Command));
+    record.validate_contract().unwrap();
+}
+
+#[test]
 fn strict_native_tool_call_ambiguity_and_overflow_abstain_without_cross_call_inference() {
     let temp = crate::test_support_paths::tempdir().unwrap();
     let database = temp.path().join("ambiguous-tool-opencode.db");

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/projection.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/projection.rs
@@ -494,10 +494,12 @@ fn collect_opencode_fact_values(
         return;
     }
     match value {
-        serde_json::Value::String(value) => facts.push(ProviderDeclaredFact {
-            kind,
-            value: value.clone(),
-        }),
+        serde_json::Value::String(value) if !value.is_empty() => {
+            facts.push(ProviderDeclaredFact {
+                kind,
+                value: value.clone(),
+            });
+        }
         serde_json::Value::Array(values) => {
             for value in values {
                 collect_opencode_fact_values(kind, value, facts, maximum);
@@ -579,6 +581,9 @@ fn unique_opencode_string(body: &serde_json::Value, pointers: &[&str]) -> Option
         let Some(value) = body.pointer(pointer).and_then(serde_json::Value::as_str) else {
             continue;
         };
+        if value.is_empty() {
+            continue;
+        }
         if selected.is_some_and(|selected| selected != value) {
             return None;
         }
@@ -608,6 +613,16 @@ fn opencode_json_alias_capture(body: &serde_json::Value, pointers: &[&str]) -> A
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unique_string_treats_empty_aliases_as_absent() {
+        let body = serde_json::json!({"callID": "", "call_id": "call-valid"});
+        assert_eq!(
+            unique_opencode_string(&body, &["/callID", "/call_id"]),
+            Some("call-valid".to_owned())
+        );
+        assert_eq!(unique_opencode_string(&body, &["/callID"]), None);
+    }
 
     #[test]
     fn relationship_rejection_precedes_payload_and_timestamp_rejections() {


### PR DESCRIPTION
## Problem

A valid OpenCode SQLite source can contain empty derived metadata, for example a failed
tool call whose `state.input.command` is `""`. The OpenCode projection emitted that value
as a `ProviderDeclaredFact`, Core validation rejected the empty field, and the error escaped
the record projection. The result was that the complete OpenCode source was reported as
unreadable and none of its otherwise valid history became searchable.

## Change

- Skip exactly empty OpenCode fact values while preserving whitespace-only values, matching
  Core's existing `is_empty()` contract.
- Treat empty call-id, tool, status, and output-role strings as absent derived metadata.
- Preserve the complete structured source body and invocation arguments, including an empty
  command; only the invalid derived field is omitted.
- Bump the OpenCode parser revision to v10 so existing indexes are reprojected consistently.

## Validation

- Targeted Rust checks passed in the Microsoft Rust DevContainer.
- A release build imported an unchanged 1.5 GB OpenCode SQLite source into a fresh data root:
  168,782 searchable events across 1,504 sessions, with zero source failures.
- `ctx doctor` returned clean and provider-scoped lexical search returned OpenCode results.
- A production `import --all` then completed with Codex, Claude, OpenCode, Gemini, and Hermes
  present: 1,251,793 searchable events across 5,797 sources.
- The final diff received GO verdicts from two independent reviewers and a separate premium
  adversarial review.
