### PR TITLE
fix(import): isolate optional provider metadata failures

### DIFF
--- a/crates/ctx-cli-contract-tests/tests/contracts/native_provider_rejections.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/native_provider_rejections.rs
@@ -251,7 +251,7 @@ fn mixed_source_replay_remains_stable_after_malformed_file_is_skipped() {
 }
 
 #[test]
-fn firebender_replay_preserves_mixed_and_all_invalid_outcomes() {
+fn firebender_replay_preserves_mixed_rejections_and_distinguishes_all_invalid_from_empty() {
     let mixed_temp = daemon_test_root();
     let mixed_project =
         write_native_firebender_fixture(&mixed_temp, "firebender mixed rejection replay oracle");
@@ -328,54 +328,211 @@ fn firebender_replay_preserves_mixed_and_all_invalid_outcomes() {
         }
     }
 
-    let invalid_temp = daemon_test_root();
-    let invalid_project =
-        write_native_firebender_fixture(&invalid_temp, "unused all-invalid oracle");
-    let invalid_database = Path::new(&invalid_project)
+    let warm_temp = daemon_test_root();
+    let marker = "firebender warm all-invalid carry-forward oracle";
+    let warm_project = write_native_firebender_fixture(&warm_temp, marker);
+    let warm_database = Path::new(&warm_project)
         .join(".idea")
         .join("firebender")
         .join("chat_history.db");
-    let conn = Connection::open(&invalid_database).unwrap();
-    conn.execute("update chat_sessions set messages_json = '{'", [])
-        .unwrap();
+
+    let valid = json_output(ctx(&warm_temp).args([
+        "import",
+        "--provider",
+        "firebender",
+        "--path",
+        &warm_project,
+        "--format=json",
+        "--progress",
+        "none",
+    ]));
+    let valid_source =
+        assert_source_backed_publication(&valid, "firebender", "firebender_chat_history_sqlite", 0);
+    assert_eq!(valid_source["current_source_count"], 1, "{valid:#}");
+    assert_eq!(valid_source["current_indexed_documents"], 3, "{valid:#}");
+    let valid_generation = valid_source["published_generation"]
+        .as_str()
+        .expect("published valid Firebender generation")
+        .to_owned();
+    let valid_search = json_output(ctx(&warm_temp).args([
+        "search",
+        marker,
+        "--provider",
+        "firebender",
+        "--refresh",
+        "off",
+        "--format=json",
+    ]));
+    assert_search_provider_oracle(&valid_search, "firebender", marker, 1, "message");
+
+    let conn = Connection::open(&warm_database).unwrap();
+    conn.execute(
+        "update chat_sessions
+         set messages_json = '{', updated_at = updated_at + 100",
+        [],
+    )
+    .unwrap();
     drop(conn);
 
-    for resume in [false, true] {
-        let mut command = ctx(&invalid_temp);
-        command.args([
-            "import",
-            "--provider",
-            "firebender",
-            "--path",
-            &invalid_project,
-            "--format=json",
-            "--progress",
-            "none",
-        ]);
-        if resume {
-            command.arg("--resume");
-        }
-        let report = failure_json_output(&mut command);
-        let source = assert_unusable_source_backed_failure(
-            &report,
-            "firebender",
-            "firebender_chat_history_sqlite",
-            1,
-        );
-        assert_eq!(source["current_source_count"], 1, "{report:#}");
-        assert_eq!(source["current_indexed_documents"], 0, "{report:#}");
-        assert_eq!(source["current_retained_records"], 0, "{report:#}");
-    }
+    let all_rejected = json_output(ctx(&warm_temp).args([
+        "import",
+        "--provider",
+        "firebender",
+        "--path",
+        &warm_project,
+        "--format=json",
+        "--progress",
+        "none",
+    ]));
+    assert_eq!(
+        all_rejected["outcome"], "completed_with_source_failures",
+        "{all_rejected:#}"
+    );
+    assert_eq!(all_rejected["failure_scope"], "source", "{all_rejected:#}");
+    assert_eq!(
+        all_rejected["failure_type"], "source_failure",
+        "{all_rejected:#}"
+    );
+    assert_eq!(
+        all_rejected["totals"]["failed_sources"], 1,
+        "{all_rejected:#}"
+    );
+    assert_eq!(
+        all_rejected["totals"]["current_indexed_documents"], 3,
+        "{all_rejected:#}"
+    );
+    let rejected_source = &all_rejected["sources"][0];
+    assert_eq!(
+        rejected_source["provider"], "firebender",
+        "{all_rejected:#}"
+    );
+    assert_eq!(
+        rejected_source["source_format"], "firebender_chat_history_sqlite",
+        "{all_rejected:#}"
+    );
+    assert_eq!(rejected_source["status"], "failure", "{all_rejected:#}");
+    assert_eq!(
+        rejected_source["failure_scope"], "source",
+        "{all_rejected:#}"
+    );
+    assert_eq!(rejected_source["failure_type"], "other", "{all_rejected:#}");
+    assert_eq!(
+        rejected_source["source_failure_class"], "unreadable",
+        "{all_rejected:#}"
+    );
+    assert_eq!(rejected_source["carried_forward"], true, "{all_rejected:#}");
+    assert_eq!(
+        rejected_source["source_failure_total"], 1,
+        "{all_rejected:#}"
+    );
+    assert_eq!(
+        rejected_source["route_source_failure_total"], 1,
+        "{all_rejected:#}"
+    );
+    assert_eq!(rejected_source["successful_routes"], 0, "{all_rejected:#}");
+    assert_eq!(rejected_source["change"], "no_op", "{all_rejected:#}");
+    assert_eq!(
+        rejected_source["generation_changed"], false,
+        "{all_rejected:#}"
+    );
+    assert_eq!(
+        rejected_source["previous_generation"], valid_generation,
+        "{all_rejected:#}"
+    );
+    assert_eq!(
+        rejected_source["published_generation"], valid_generation,
+        "{all_rejected:#}"
+    );
+    assert_eq!(
+        rejected_source["current_source_count"], 1,
+        "{all_rejected:#}"
+    );
+    assert_eq!(
+        rejected_source["current_indexed_documents"], 3,
+        "{all_rejected:#}"
+    );
+    assert_eq!(
+        rejected_source["current_retained_records"], 3,
+        "{all_rejected:#}"
+    );
+    assert_eq!(
+        rejected_source["rejected_record_total"], 0,
+        "{all_rejected:#}"
+    );
+    assert!(rejected_source["rejection_diagnostics"]
+        .as_array()
+        .is_some_and(Vec::is_empty));
+
+    let retained_search = json_output(ctx(&warm_temp).args([
+        "search",
+        marker,
+        "--provider",
+        "firebender",
+        "--refresh",
+        "off",
+        "--format=json",
+    ]));
+    assert_search_provider_oracle(&retained_search, "firebender", marker, 1, "message");
+    assert_eq!(
+        retained_search["retrieval"]["generation_id"], valid_generation,
+        "{retained_search:#}"
+    );
+
+    let conn = Connection::open(&warm_database).unwrap();
+    conn.execute("delete from chat_sessions", []).unwrap();
+    drop(conn);
+
+    let empty = json_output(ctx(&warm_temp).args([
+        "import",
+        "--provider",
+        "firebender",
+        "--path",
+        &warm_project,
+        "--format=json",
+        "--progress",
+        "none",
+    ]));
+    let empty_source =
+        assert_source_backed_publication(&empty, "firebender", "firebender_chat_history_sqlite", 0);
+    assert_eq!(empty_source["current_source_count"], 1, "{empty:#}");
+    assert_eq!(empty_source["current_indexed_documents"], 0, "{empty:#}");
+    assert_eq!(empty_source["current_complete_records"], 0, "{empty:#}");
+    assert_eq!(empty_source["current_retained_records"], 0, "{empty:#}");
+    assert_eq!(empty_source["current_rejected_records"], 0, "{empty:#}");
+    assert_ne!(
+        empty_source["published_generation"], valid_generation,
+        "{empty:#}"
+    );
+
+    let removed_search = json_output(ctx(&warm_temp).args([
+        "search",
+        marker,
+        "--provider",
+        "firebender",
+        "--refresh",
+        "off",
+        "--format=json",
+    ]));
+    assert!(
+        removed_search["results"]
+            .as_array()
+            .is_some_and(Vec::is_empty),
+        "{removed_search:#}"
+    );
+    assert_eq!(
+        removed_search["retrieval"]["generation_id"], empty_source["published_generation"],
+        "{removed_search:#}"
+    );
 
     assert!(
-        !invalid_temp.path().join("work.sqlite").exists(),
-        "an all-invalid provider source must not create the previous-epoch Store"
+        !warm_temp.path().join("work.sqlite").exists(),
+        "Firebender refreshes must not create the previous-epoch Store"
     );
     assert!(
-        provider_core_records(&data_root(&invalid_temp), "firebender").is_empty(),
-        "an all-invalid source must publish no Core records"
+        provider_core_records(&data_root(&warm_temp), "firebender").is_empty(),
+        "a successful empty Firebender replacement must clear prior Core records"
     );
-    assert!(!data_root(&invalid_temp).join("relational.sqlite").exists());
+    assert!(!data_root(&warm_temp).join("relational.sqlite").exists());
 }
 
 #[test]
@@ -791,9 +948,34 @@ fn all_invalid_source_reports_daemon_owned_failure_and_exits_nonzero() {
 }
 
 #[test]
-fn complete_oversize_only_codex_session_reports_source_backed_rejection() {
+fn complete_oversize_only_codex_refresh_preserves_last_good_generation() {
     let temp = daemon_test_root();
     let session = temp.path().join("codex-all-rejected.jsonl");
+    let marker = "codex JSONL all-rejected carry-forward oracle";
+    let valid = concat!(
+        r#"{"timestamp":"2026-07-13T12:00:00Z","type":"session_meta","payload":{"id":"codex-all-rejected","timestamp":"2026-07-13T12:00:00Z","cwd":"/repo","originator":"codex-cli"}}"#,
+        "\n",
+        r#"{"timestamp":"2026-07-13T12:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"__MARKER__"}]}}"#,
+        "\n"
+    )
+    .replace("__MARKER__", marker);
+    fs::write(&session, valid).unwrap();
+    let first = json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "codex",
+        "--path",
+        session.to_str().unwrap(),
+        "--format=json",
+        "--progress",
+        "none",
+    ]));
+    let first_source = assert_source_backed_publication(&first, "codex", "codex_session_jsonl", 0);
+    let first_generation = first_source["published_generation"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+
     let mut source = concat!(
         r#"{"timestamp":"2026-07-13T12:00:00Z","type":"session_meta","payload":{"id":"codex-all-rejected","timestamp":"2026-07-13T12:00:00Z","cwd":"/repo","originator":"codex-cli"}}"#,
         "\n",
@@ -819,21 +1001,47 @@ fn complete_oversize_only_codex_session_reports_source_backed_rejection() {
         if resume {
             command.arg("--resume");
         }
-        let report = failure_json_output(&mut command);
-        let source =
-            assert_unusable_source_backed_failure(&report, "codex", "codex_session_jsonl", 1);
-        assert_eq!(source["current_indexed_documents"], 0, "{report:#}");
-        assert_eq!(source["current_retained_records"], 0, "{report:#}");
-        assert_eq!(source["current_sources_with_rejections"], 1, "{report:#}");
+        let report = json_output(&mut command);
+        assert_eq!(
+            report["outcome"], "completed_with_source_failures",
+            "{report:#}"
+        );
+        assert_eq!(report["failure_scope"], "source", "{report:#}");
+        let failed_source = &report["sources"][0];
+        assert_eq!(failed_source["provider"], "codex", "{report:#}");
+        assert_eq!(
+            failed_source["source_format"], "codex_session_jsonl",
+            "{report:#}"
+        );
+        assert_eq!(failed_source["status"], "partial", "{report:#}");
+        assert_eq!(failed_source["carried_forward"], true, "{report:#}");
+        assert_eq!(failed_source["change"], "no_op", "{report:#}");
+        assert_eq!(
+            failed_source["published_generation"], first_generation,
+            "{report:#}"
+        );
+        assert_eq!(failed_source["current_indexed_documents"], 1, "{report:#}");
+        assert_eq!(failed_source["current_retained_records"], 1, "{report:#}");
+        assert_eq!(failed_source["rejected_record_total"], 0, "{report:#}");
     }
 
     assert!(
         !temp.path().join("work.sqlite").exists(),
-        "an all-rejected provider source must not create the previous-epoch Store"
+        "Codex refreshes must not create the previous-epoch Store"
     );
-    assert!(
-        provider_core_records(&data_root(&temp), "codex").is_empty(),
-        "an all-rejected source must publish no Core records"
+    let retained = json_output(ctx(&temp).args([
+        "search",
+        marker,
+        "--provider",
+        "codex",
+        "--refresh",
+        "off",
+        "--format=json",
+    ]));
+    assert_search_provider_oracle(&retained, "codex", marker, 1, "message");
+    assert_eq!(
+        retained["retrieval"]["generation_id"], first_generation,
+        "{retained:#}"
     );
     assert!(!data_root(&temp).join("relational.sqlite").exists());
 }

--- a/crates/ctx-history-capture-composition/src/source_backed/tests/jsonl_shared_publication.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/tests/jsonl_shared_publication.rs
@@ -563,6 +563,43 @@ fn openclaw_preflight_preserves_unique_append_and_carries_cross_boundary_duplica
 }
 
 #[test]
+fn openclaw_cross_record_duplicate_calls_fail_closed_across_append_boundary() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let root = temp.path().join("openclaw");
+    let transcript = openclaw_lifecycle_transcript(&root);
+    let first_call = serde_json::json!({
+        "type": "message",
+        "id": "first-call-record",
+        "timestamp": "2026-08-06T12:00:00Z",
+        "message": {"role": "assistant", "content": [{"type": "toolCall", "id": "duplicate-call", "name": "exec", "arguments": {"command": "ctx search first"}}]}
+    });
+    let duplicate_call = serde_json::json!({
+        "type": "message",
+        "id": "second-call-record",
+        "timestamp": "2026-08-06T12:00:01Z",
+        "message": {"role": "assistant", "content": [{"type": "toolCall", "id": "duplicate-call", "name": "exec", "arguments": {"command": "ctx search second"}}]}
+    });
+    write_openclaw_lifecycle_transcript(&transcript, &[first_call]);
+    let registry = openclaw_registry(&root);
+    let index = temp.path().join("index");
+
+    let initial = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
+    assert!(initial.failed_routes.is_empty());
+    let initial_records = all_indexed_records(&index);
+    assert_eq!(initial_records.len(), 1);
+
+    append_openclaw_lifecycle_transcript(&transcript, &duplicate_call);
+    let duplicate = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
+    assert_eq!(duplicate.failed_routes.len(), 1);
+    assert_eq!(
+        duplicate.failed_routes[0].class,
+        SourceBackedSourceFailureClass::Unreadable
+    );
+    assert!(duplicate.failed_routes[0].carried_forward);
+    assert_eq!(all_indexed_records(&index), initial_records);
+}
+
+#[test]
 fn openclaw_projector_preflight_rejects_same_length_interpass_rewrite() {
     let temp = crate::test_support_paths::tempdir().unwrap();
     let root = temp.path().join("openclaw");

--- a/crates/ctx-history-capture-composition/src/source_backed/tests/mistral_vibe_publication.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/tests/mistral_vibe_publication.rs
@@ -27,7 +27,7 @@ const NATIVE_EVENT_REUSED_TOOL_CALL_POSITION_KIND: &str =
     "mistral-vibe-duplicate-tool-call-id-ordinal";
 const LOGICAL_SESSION_KIND: &str = "mistral-vibe-session";
 const LOGICAL_EVENT_KIND: &str = "mistral-vibe-event";
-const PARSER_REVISION: &str = "mistral-vibe-source-backed-v13-core-activity-agent-scope";
+const PARSER_REVISION: &str = "mistral-vibe-source-backed-v14-optional-admission";
 const PRE_AGENT_SCOPE_PARSER_REVISION: &str = "mistral-vibe-source-backed-v12-core-activity";
 
 fn source_key(native_session_id: &str) -> SourceKey {

--- a/crates/ctx-history-capture-runtime/src/source_backed/document.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/document.rs
@@ -292,7 +292,7 @@ pub struct DocumentSourceTerminal {
 
 impl DocumentSourceTerminal {
     fn certify(
-        self,
+        &self,
         replay_fingerprint: Option<DocumentLeafFingerprint>,
     ) -> SourceBackedRouteResult<CertifiedSource> {
         let frontier = replay_fingerprint
@@ -302,18 +302,18 @@ impl DocumentSourceTerminal {
                     self.counts.certified_bytes,
                     self.content_digest,
                 )
-                .map_err(document_contract_error)
+                .map_err(|error| document_changed(error.to_string()))
             })
             .transpose()?;
         CertifiedSource::certify_with_frontier(
-            self.opening,
-            self.closing,
+            self.opening.clone(),
+            self.closing.clone(),
             self.parser_revision,
             self.content_digest,
             self.counts,
             frontier,
         )
-        .map_err(document_contract_error)
+        .map_err(|error| document_changed(error.to_string()))
     }
 }
 
@@ -753,13 +753,21 @@ where
                     "complete document tree produced a duplicate logical source",
                 ));
             }
-            changed.finish(
+            let replay_fingerprint = observed
+                .replay_from_frontier
+                .then_some(observed.fingerprint);
+            let terminal = match changed.preflight_terminal(
                 terminal,
-                observed
-                    .replay_from_frontier
-                    .then_some(observed.fingerprint),
-                append_base,
-            )?
+                replay_fingerprint,
+                append_base.as_ref(),
+            ) {
+                Ok(terminal) => terminal,
+                Err(error) => {
+                    changed.preserve_record_rejections_on_failure();
+                    return Err(error);
+                }
+            };
+            changed.finish(terminal, append_base)?
         };
         let source = certificate.observation().source().clone();
         validate_current_document_source(adapter, &mut current_sources, source)?;
@@ -887,4 +895,15 @@ fn document_internal(detail: impl Into<String>) -> SourceBackedRouteError {
 
 fn document_contract_error(error: impl std::fmt::Display) -> SourceBackedRouteError {
     SourceBackedRouteError::new(SourceBackedRouteErrorKind::InvalidSource, error.to_string())
+}
+
+fn reject_all_rejected_document_source(
+    terminal: &DocumentSourceTerminal,
+) -> SourceBackedRouteResult<()> {
+    let counts = terminal.counts;
+    if counts.complete_records > 0 && counts.retained_records == 0 && counts.rejected_records > 0 {
+        Err(document_contract_error("document source is unreadable"))
+    } else {
+        Ok(())
+    }
 }

--- a/crates/ctx-history-capture-runtime/src/source_backed/document/independent.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/document/independent.rs
@@ -200,16 +200,16 @@ where
                     "independent document leaf derived a different exact source",
                 ));
             }
+            let replay_fingerprint = observed
+                .replay_from_frontier
+                .then_some(observed.fingerprint);
+            let append_base = adapter.append_base(authority, &observed.provider_leaf);
+            let terminal =
+                active.preflight_terminal(terminal, replay_fingerprint, append_base.as_ref())?;
             changed
                 .take()
                 .ok_or_else(|| document_internal("document leaf sink was consumed early"))?
-                .finish(
-                    terminal,
-                    observed
-                        .replay_from_frontier
-                        .then_some(observed.fingerprint),
-                    adapter.append_base(authority, &observed.provider_leaf),
-                )
+                .finish(terminal, append_base)
         })();
         let record_rejections = changed
             .as_mut()

--- a/crates/ctx-history-capture-runtime/src/source_backed/document/sink.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/document/sink.rs
@@ -39,6 +39,13 @@ enum ChangedDocumentTarget<'sink, 'writer, L: CaptureLifecycleSink> {
     ),
 }
 
+pub(super) struct ValidatedDocumentTerminal {
+    terminal: DocumentSourceTerminal,
+    certificate: CertifiedSource,
+    append: Option<CertifiedSourceAppend>,
+    replay_fingerprint: Option<DocumentLeafFingerprint>,
+}
+
 impl<'sink, 'writer, L, S> ChangedDocumentSink<'sink, 'writer, L, S>
 where
     L: CaptureLifecycleSink,
@@ -147,6 +154,13 @@ where
         std::mem::take(&mut self.record_rejections)
     }
 
+    pub(super) fn preserve_record_rejections_on_failure(&mut self) {
+        let rejections = std::mem::take(&mut self.record_rejections);
+        if let ChangedDocumentTarget::Generation(sink) = &mut self.target {
+            sink.record_rejections(rejections);
+        }
+    }
+
     pub fn report_completed_bytes(&mut self, bytes: u64) -> SourceBackedRouteResult<()> {
         match &mut self.target {
             ChangedDocumentTarget::Generation(sink) => sink
@@ -178,12 +192,12 @@ where
             .ok_or_else(|| document_internal("document adapter did not begin its source"))
     }
 
-    pub(super) fn finish(
-        mut self,
+    pub(super) fn preflight_terminal(
+        &self,
         terminal: DocumentSourceTerminal,
         replay_fingerprint: Option<DocumentLeafFingerprint>,
-        append_base: Option<DocumentAppendBase<L>>,
-    ) -> SourceBackedRouteResult<CertifiedSource> {
+        append_base: Option<&DocumentAppendBase<L>>,
+    ) -> SourceBackedRouteResult<ValidatedDocumentTerminal> {
         let source = self.source()?.clone();
         if !terminal.source.exact_descriptor_eq(&source)
             || !terminal.opening.source().exact_descriptor_eq(&source)
@@ -194,19 +208,42 @@ where
             ));
         }
         let expected_emitted =
-            append_base
-                .as_ref()
-                .map_or(Some(terminal.counts.indexed_documents), |base| {
-                    terminal
-                        .counts
-                        .indexed_documents
-                        .checked_sub(base.certificate().counts().indexed_documents)
-                });
+            append_base.map_or(Some(terminal.counts.indexed_documents), |base| {
+                terminal
+                    .counts
+                    .indexed_documents
+                    .checked_sub(base.certificate().counts().indexed_documents)
+            });
         if expected_emitted != Some(self.emitted_core_records) {
             return Err(document_changed(
                 "document terminal indexed count did not match forwarded Core records",
             ));
         }
+        let certificate = terminal.certify(replay_fingerprint)?;
+        let append = append_base
+            .map(|base| certify_document_append(base.certificate(), certificate.clone()))
+            .transpose()?;
+        reject_all_rejected_document_source(&terminal)?;
+        Ok(ValidatedDocumentTerminal {
+            terminal,
+            certificate,
+            append,
+            replay_fingerprint,
+        })
+    }
+
+    pub(super) fn finish(
+        mut self,
+        validated: ValidatedDocumentTerminal,
+        append_base: Option<DocumentAppendBase<L>>,
+    ) -> SourceBackedRouteResult<CertifiedSource> {
+        let ValidatedDocumentTerminal {
+            terminal,
+            certificate,
+            append,
+            replay_fingerprint,
+        } = validated;
+        let source = terminal.source.clone();
         let logical_base = self.deferred.as_ref().and_then(|_| {
             append_base
                 .as_ref()
@@ -226,20 +263,12 @@ where
                         document_frontier_fingerprint(base) == Some(fingerprint)
                     })
             });
-        let certificate = terminal.certify(replay_fingerprint)?;
         if let Some(deferred) = self.deferred.take() {
             if let Some(base) = append_base {
                 let certificate_base = base.certificate().clone();
-                let frontier = certificate_base.frontier().ok_or_else(|| {
-                    document_changed("document append base has no certified frontier")
+                let append = append.ok_or_else(|| {
+                    document_internal("preflighted document append proof disappeared")
                 })?;
-                let append = CertifiedSourceAppend::certify(
-                    &certificate_base,
-                    certificate.clone(),
-                    frontier.certified_prefix_bytes(),
-                    *frontier.certified_prefix_digest(),
-                )
-                .map_err(document_contract_error)?;
                 match &mut self.target {
                     ChangedDocumentTarget::Generation(sink) => {
                         match base {
@@ -367,6 +396,22 @@ where
         }
         Ok(certificate)
     }
+}
+
+fn certify_document_append(
+    base: &CertifiedSource,
+    current: CertifiedSource,
+) -> SourceBackedRouteResult<CertifiedSourceAppend> {
+    let frontier = base
+        .frontier()
+        .ok_or_else(|| document_changed("document append base has no certified frontier"))?;
+    CertifiedSourceAppend::certify(
+        base,
+        current,
+        frontier.certified_prefix_bytes(),
+        *frontier.certified_prefix_digest(),
+    )
+    .map_err(|error| document_changed(error.to_string()))
 }
 
 fn route_coordinator_error<L: CaptureLifecycleSink>(

--- a/crates/ctx-history-capture-runtime/src/source_backed/parallel.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/parallel.rs
@@ -186,11 +186,8 @@ impl<L: CaptureLifecycleSink> SourceBackedGenerationSink<'_, L> {
             ) -> Result<(), ParallelLeafScanWorkerError<E>>
             + Sync,
     {
-        self.run_parallel_leaf_scans_inner(
+        self.run_parallel_leaf_scans_with_worker_states_and_source_outcomes(
             jobs,
-            worker_states.len(),
-            |job| Some(job.source().clone()),
-            ParallelLeafScanJob::worker_affinity,
             worker_states,
             scan,
         )?
@@ -202,6 +199,36 @@ impl<L: CaptureLifecycleSink> SourceBackedGenerationSink<'_, L> {
             )),
         })
         .collect()
+    }
+
+    /// Runs source-bound scans with persistent worker state while preserving
+    /// logical source failures as typed per-source outcomes.
+    pub fn run_parallel_leaf_scans_with_worker_states_and_source_outcomes<J, R, E, W, F>(
+        &mut self,
+        jobs: Vec<ParallelLeafScanJob<J>>,
+        worker_states: &mut [W],
+        scan: F,
+    ) -> Result<Vec<SourceBackedSourceOutcome<R>>, ParallelLeafScanError<E, L::Error>>
+    where
+        J: Send,
+        R: Send,
+        E: StdError + Send + 'static,
+        W: Send,
+        F: Fn(
+                &mut W,
+                &ParallelLeafScanJob<J>,
+                &mut ParallelLeafScanEmitter<'_, R, E, L::Preparation>,
+            ) -> Result<(), ParallelLeafScanWorkerError<E>>
+            + Sync,
+    {
+        self.run_parallel_leaf_scans_inner(
+            jobs,
+            worker_states.len(),
+            |job| Some(job.source().clone()),
+            ParallelLeafScanJob::worker_affinity,
+            worker_states,
+            scan,
+        )
     }
 
     pub fn run_parallel_leaf_scans_with_source_outcomes<J, R, E, F>(

--- a/crates/ctx-history-capture-runtime/src/source_backed/parallel/tests/document_lifecycle.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/parallel/tests/document_lifecycle.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::DocumentAppendBase;
 
 const PARSER_V1: &str = "no-io-document-v1";
 const PARSER_V2: &str = "no-io-document-v2";
@@ -36,9 +37,23 @@ impl LifecycleLeaf {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+enum LifecycleProjection {
+    #[default]
+    Retained,
+    AllRejected,
+    RejectedAndIgnored,
+    MalformedAllRejected,
+    Empty,
+    IgnoredOnly,
+    Mixed,
+    AppendCountRegression,
+}
+
 #[derive(Default)]
 struct LifecycleState {
     leaves: Vec<LifecycleLeaf>,
+    projection: LifecycleProjection,
     durable_replay: bool,
     bind_exact_descriptor: bool,
     parser_v2: bool,
@@ -51,6 +66,7 @@ struct LifecycleState {
     mutate_before_scan: Option<u8>,
     mutate_on_revalidate: bool,
     unavailable_leaf: Option<u8>,
+    append_base: Option<CertifiedSource>,
 }
 
 #[derive(Clone)]
@@ -153,6 +169,14 @@ impl LifecycleAdapter {
         self.state.lock().unwrap().independent_workers = Some(workers);
     }
 
+    fn project(&self, projection: LifecycleProjection) {
+        self.state.lock().unwrap().projection = projection;
+    }
+
+    fn append_from(&self, base: CertifiedSource) {
+        self.state.lock().unwrap().append_base = Some(base);
+    }
+
     fn install_barrier(&self, workers: usize) {
         self.state.lock().unwrap().scan_barrier = Some(Arc::new(Barrier::new(workers)));
     }
@@ -240,7 +264,7 @@ impl ReplacementDocumentTree for LifecycleAdapter {
         if let Some(barrier) = barrier {
             barrier.wait();
         }
-        let (live, schema_v2, parser_revision) = {
+        let (live, schema_v2, parser_revision, projection) = {
             let mut state = self.state.lock().unwrap();
             if state.mutate_before_scan == Some(leaf.physical_id) {
                 let live = state
@@ -283,11 +307,81 @@ impl ReplacementDocumentTree for LifecycleAdapter {
                 } else {
                     PARSER_V1
                 },
+                state.projection,
             )
         };
         let source = live.source(schema_v2);
         sink.begin_source(source.clone())?;
-        sink.emit_core_record(test_core_record(&source, 0, live.revision))?;
+        let counts = match projection {
+            LifecycleProjection::Retained => {
+                sink.emit_core_record(test_core_record(&source, 0, live.revision))?;
+                ScannedSourceCounts {
+                    complete_records: 1,
+                    retained_records: 1,
+                    indexed_documents: 1,
+                    certified_bytes: 1,
+                    ..ScannedSourceCounts::default()
+                }
+            }
+            LifecycleProjection::AllRejected => {
+                sink.record_rejections(rejection_drafts(&source, live.physical_id));
+                ScannedSourceCounts {
+                    complete_records: 1,
+                    rejected_records: 1,
+                    certified_bytes: 1,
+                    ..ScannedSourceCounts::default()
+                }
+            }
+            LifecycleProjection::RejectedAndIgnored => {
+                sink.record_rejections(rejection_drafts(&source, live.physical_id));
+                ScannedSourceCounts {
+                    complete_records: 2,
+                    rejected_records: 1,
+                    ignored_records: 1,
+                    certified_bytes: 1,
+                    ..ScannedSourceCounts::default()
+                }
+            }
+            LifecycleProjection::MalformedAllRejected => {
+                sink.record_rejections(rejection_drafts(&source, live.physical_id));
+                ScannedSourceCounts {
+                    complete_records: 1,
+                    rejected_records: 1,
+                    indexed_documents: 1,
+                    certified_bytes: 1,
+                    ..ScannedSourceCounts::default()
+                }
+            }
+            LifecycleProjection::Empty => ScannedSourceCounts {
+                certified_bytes: 1,
+                ..ScannedSourceCounts::default()
+            },
+            LifecycleProjection::IgnoredOnly => ScannedSourceCounts {
+                complete_records: 1,
+                ignored_records: 1,
+                certified_bytes: 1,
+                ..ScannedSourceCounts::default()
+            },
+            LifecycleProjection::Mixed => {
+                sink.emit_core_record(test_core_record(&source, 0, live.revision))?;
+                sink.record_rejections(rejection_drafts(&source, live.physical_id));
+                ScannedSourceCounts {
+                    complete_records: 2,
+                    retained_records: 1,
+                    rejected_records: 1,
+                    indexed_documents: 1,
+                    certified_bytes: 1,
+                    ..ScannedSourceCounts::default()
+                }
+            }
+            LifecycleProjection::AppendCountRegression => ScannedSourceCounts {
+                complete_records: 1,
+                retained_records: 1,
+                indexed_documents: 1,
+                certified_bytes: 1,
+                ..ScannedSourceCounts::default()
+            },
+        };
         let observation_revision = if self.state.lock().unwrap().durable_replay {
             vec![live.revision]
         } else {
@@ -305,14 +399,21 @@ impl ReplacementDocumentTree for LifecycleAdapter {
             closing: observation,
             parser_revision,
             content_digest: live.logical_fingerprint(),
-            counts: ScannedSourceCounts {
-                complete_records: 1,
-                retained_records: 1,
-                indexed_documents: 1,
-                certified_bytes: 1,
-                ..ScannedSourceCounts::default()
-            },
+            counts,
         })
+    }
+
+    fn append_base(
+        &self,
+        _authority: &Self::TreeAuthority,
+        _leaf: &Self::Leaf,
+    ) -> Option<DocumentAppendBase<Self::Lifecycle>> {
+        self.state
+            .lock()
+            .unwrap()
+            .append_base
+            .clone()
+            .map(|base| DocumentAppendBase::Certificate(Box::new(base)))
     }
 
     fn revalidate_complete(
@@ -334,6 +435,20 @@ impl ReplacementDocumentTree for LifecycleAdapter {
             ))
         }
     }
+}
+
+fn rejection_drafts(source: &SourceKey, physical_id: u8) -> SourceBackedRecordRejectionDrafts {
+    let mut rejections = SourceBackedRecordRejectionDrafts::default();
+    rejections.record(SourceBackedRecordRejectionDraft {
+        source: source.clone(),
+        provider: CaptureProvider::Codex,
+        source_selector: format!("document-{physical_id}"),
+        line_number: u64::from(physical_id),
+        payload_type: Some("lifecycle-fixture".to_owned()),
+        class: SourceBackedRecordRejectionClass::MalformedRecord,
+        detail: "injected rejected document record".to_owned(),
+    });
+    rejections
 }
 
 fn document_source(logical_id: u8, schema: &str) -> SourceKey {
@@ -587,6 +702,219 @@ fn active_source_family_contract_document_add_change_delete_failure_carry_forwar
         .observation()
         .source()
         .exact_descriptor_eq(&document_source(2, SCHEMA_V1))));
+}
+
+#[test]
+fn active_source_family_contract_document_cold_all_rejected_is_a_source_failure() {
+    let adapter = LifecycleAdapter::new(vec![leaf(1)]);
+    adapter.use_parallel(1);
+    adapter.project(LifecycleProjection::AllRejected);
+
+    let failed = run(&adapter, &[], 1);
+
+    assert!(sources(&failed).is_empty());
+    assert!(failed.writer.records.is_empty());
+    assert_eq!(failed.logical_source_failures.total(), 1);
+    let failure = &failed.logical_source_failures.failures()[0];
+    assert_eq!(failure.class.as_str(), "unreadable");
+    assert!(!failure.carried_forward);
+    assert_eq!(failed.record_rejections.total(), 1);
+    assert_eq!(failed.record_rejections.rejections()[0].line_number, 1);
+}
+
+#[test]
+fn active_source_family_contract_document_serial_all_rejected_fails_before_publication() {
+    let adapter = LifecycleAdapter::new(vec![leaf(1)]);
+    adapter.project(LifecycleProjection::AllRejected);
+
+    let (failure, failed) = run_error(&adapter, &[], 1);
+
+    assert_eq!(failure.kind, SourceBackedRouteErrorKind::InvalidSource);
+    assert!(failed.writer.certified_sources.is_empty());
+    assert!(failed.writer.records.is_empty());
+    assert_eq!(failed.record_rejections.total(), 1);
+}
+
+#[test]
+fn active_source_family_contract_document_rejected_plus_ignored_preserves_last_good_source() {
+    let adapter = LifecycleAdapter::new(vec![leaf(1)]);
+    adapter.use_parallel(1);
+    let cold = run(&adapter, &[], 1);
+    let base = sources(&cold);
+
+    adapter.touch(1, 2);
+    adapter.project(LifecycleProjection::RejectedAndIgnored);
+    let failed = run(&adapter, &base, 1);
+
+    assert_eq!(sources(&failed), base);
+    assert_eq!(failed.logical_source_failures.total(), 1);
+    assert!(failed.logical_source_failures.failures()[0].carried_forward);
+}
+
+#[test]
+fn active_source_family_contract_document_structural_failure_precedes_all_rejected_policy() {
+    let adapter = LifecycleAdapter::new(vec![leaf(1)]);
+    adapter.use_parallel(1);
+    adapter.project(LifecycleProjection::MalformedAllRejected);
+
+    let (failure, failed) = run_error(&adapter, &[], 1);
+
+    assert_eq!(failure.kind, SourceBackedRouteErrorKind::SourceChanged);
+    assert!(failed.writer.certified_sources.is_empty());
+    assert_eq!(failed.logical_source_failures.total(), 0);
+}
+
+#[test]
+fn active_source_family_contract_document_warm_all_rejected_carries_last_good_source() {
+    let adapter = LifecycleAdapter::new(vec![leaf(2)]);
+    adapter.use_parallel(1);
+    let cold = run(&adapter, &[], 1);
+    let base = sources(&cold);
+
+    adapter.touch(2, 2);
+    adapter.project(LifecycleProjection::AllRejected);
+    let failed = run(&adapter, &base, 1);
+
+    assert_eq!(sources(&failed), base);
+    assert!(failed.writer.records.is_empty());
+    assert_eq!(failed.logical_source_failures.total(), 1);
+    let failure = &failed.logical_source_failures.failures()[0];
+    assert_eq!(failure.class.as_str(), "unreadable");
+    assert!(failure.carried_forward);
+    assert_eq!(failed.record_rejections.total(), 1);
+}
+
+#[test]
+fn active_source_family_contract_document_all_rejected_does_not_mask_unsafe_transition() {
+    let adapter = LifecycleAdapter::new(vec![leaf(2)]);
+    adapter.use_parallel(1);
+    let cold = run(&adapter, &[], 1);
+
+    adapter.touch(2, 2);
+    {
+        let mut state = adapter.state.lock().unwrap();
+        state.schema_v2 = true;
+        state.projection = LifecycleProjection::AllRejected;
+    }
+    let (failure, failed) = run_error(&adapter, &sources(&cold), 1);
+
+    assert_eq!(failure.kind, SourceBackedRouteErrorKind::SourceChanged);
+    assert!(failed.writer.certified_sources.is_empty());
+}
+
+#[test]
+fn active_source_family_contract_document_append_invariant_failures_remain_route_fatal() {
+    let parser = LifecycleAdapter::new(vec![leaf(1)]);
+    parser.use_parallel(1);
+    let parser_cold = run(&parser, &[], 1);
+    let parser_base = sources(&parser_cold);
+    parser.touch(1, 2);
+    parser.append_from(parser_base[0].clone());
+    parser.state.lock().unwrap().parser_v2 = true;
+    let (parser_failure, parser_failed) = run_error(&parser, &parser_base, 1);
+    assert_eq!(
+        parser_failure.kind,
+        SourceBackedRouteErrorKind::SourceChanged
+    );
+    assert_eq!(parser_failed.logical_source_failures.total(), 0);
+
+    let descriptor = LifecycleAdapter::new(vec![leaf(2)]);
+    descriptor.use_parallel(1);
+    let descriptor_cold = run(&descriptor, &[], 1);
+    let descriptor_base = sources(&descriptor_cold);
+    descriptor.touch(2, 2);
+    descriptor.append_from(descriptor_base[0].clone());
+    descriptor.state.lock().unwrap().schema_v2 = true;
+    let (descriptor_failure, descriptor_failed) = run_error(&descriptor, &descriptor_base, 1);
+    assert_eq!(
+        descriptor_failure.kind,
+        SourceBackedRouteErrorKind::SourceChanged
+    );
+    assert_eq!(descriptor_failed.logical_source_failures.total(), 0);
+
+    let counts = LifecycleAdapter::new(vec![leaf(3)]);
+    counts.use_parallel(1);
+    counts.project(LifecycleProjection::Mixed);
+    let counts_cold = run(&counts, &[], 1);
+    let counts_base = sources(&counts_cold);
+    counts.touch(3, 2);
+    counts.append_from(counts_base[0].clone());
+    counts.project(LifecycleProjection::AppendCountRegression);
+    let (counts_failure, counts_failed) = run_error(&counts, &counts_base, 1);
+    assert_eq!(
+        counts_failure.kind,
+        SourceBackedRouteErrorKind::SourceChanged
+    );
+    assert_eq!(counts_failed.logical_source_failures.total(), 0);
+
+    let masked = LifecycleAdapter::new(vec![leaf(4)]);
+    masked.use_parallel(1);
+    masked.project(LifecycleProjection::IgnoredOnly);
+    let masked_cold = run(&masked, &[], 1);
+    let masked_base = sources(&masked_cold);
+    masked.touch(4, 2);
+    masked.append_from(masked_base[0].clone());
+    masked.project(LifecycleProjection::AllRejected);
+    let (masked_failure, masked_failed) = run_error(&masked, &masked_base, 1);
+    assert_eq!(
+        masked_failure.kind,
+        SourceBackedRouteErrorKind::SourceChanged
+    );
+    assert_eq!(masked_failed.logical_source_failures.total(), 0);
+}
+
+#[test]
+fn active_source_family_contract_document_all_zero_replacement_and_ignored_only_source_are_valid() {
+    let empty = LifecycleAdapter::new(vec![leaf(3)]);
+    empty.use_parallel(1);
+    let cold = run(&empty, &[], 1);
+    let base = sources(&cold);
+    empty.touch(3, 2);
+    empty.project(LifecycleProjection::Empty);
+
+    let replaced = run(&empty, &base, 1);
+    let replaced_sources = sources(&replaced);
+    let replacement = &replaced_sources[0];
+    assert_ne!(replacement, &base[0]);
+    assert_eq!(replacement.counts().complete_records, 0);
+    assert_eq!(replacement.counts().retained_records, 0);
+    assert_eq!(replacement.counts().rejected_records, 0);
+    assert!(replaced.writer.records.is_empty());
+    assert_eq!(replaced.logical_source_failures.total(), 0);
+
+    let ignored = LifecycleAdapter::new(vec![leaf(4)]);
+    ignored.use_parallel(1);
+    ignored.project(LifecycleProjection::IgnoredOnly);
+    let published = run(&ignored, &[], 1);
+    let published_sources = sources(&published);
+    let certificate = &published_sources[0];
+    assert_eq!(certificate.counts().complete_records, 1);
+    assert_eq!(certificate.counts().ignored_records, 1);
+    assert_eq!(certificate.counts().retained_records, 0);
+    assert_eq!(certificate.counts().rejected_records, 0);
+    assert!(published.writer.records.is_empty());
+    assert_eq!(published.logical_source_failures.total(), 0);
+}
+
+#[test]
+fn active_source_family_contract_document_mixed_retained_and_rejected_records_publish() {
+    let adapter = LifecycleAdapter::new(vec![leaf(5)]);
+    adapter.use_parallel(1);
+    adapter.project(LifecycleProjection::Mixed);
+
+    let published = run(&adapter, &[], 1);
+    let published_sources = sources(&published);
+    let certificate = &published_sources[0];
+    assert_eq!(certificate.counts().complete_records, 2);
+    assert_eq!(certificate.counts().retained_records, 1);
+    assert_eq!(certificate.counts().rejected_records, 1);
+    assert_eq!(published.writer.records.len(), 1);
+    assert_eq!(published.logical_source_failures.total(), 0);
+    assert_eq!(published.record_rejections.total(), 1);
+    assert_eq!(
+        published.record_rejections.rejections()[0].class,
+        SourceBackedRecordRejectionClass::MalformedRecord
+    );
 }
 
 #[test]

--- a/crates/ctx-history-core/src/core_record.rs
+++ b/crates/ctx-history-core/src/core_record.rs
@@ -10,6 +10,7 @@ mod activity;
 mod validation;
 
 pub use activity::{
+    admit_optional_metadata_text, admit_optional_provider_call_id, admit_provider_declared_fact,
     ActivityInvocation, ActivityJsonCapture, ActivityResult, ActivityTextCapture, CoreActivity,
     LiteralFactKind, ProviderDeclaredFact, CORE_ACTIVITY_REVISION, MAX_PROVIDER_DECLARED_FACTS,
 };
@@ -481,6 +482,35 @@ impl CoreContent {
 
     pub fn encoded_content_bytes(&self) -> CoreRecordResult<usize> {
         Ok(self.encoded_content_byte_counts()?.total)
+    }
+
+    /// Omits trailing provider-declared facts when optional activity metadata
+    /// alone would exceed the selected-content budget.
+    pub fn omit_provider_declared_facts_if_aggregate_exceeds_limit(
+        &mut self,
+    ) -> CoreRecordResult<usize> {
+        let mut excess = self
+            .encoded_content_byte_counts()?
+            .total
+            .saturating_sub(MAX_CORE_CONTENT_BYTES);
+        let mut omitted = 0;
+        while excess > 0 {
+            let Some(fact) = self
+                .activity
+                .as_mut()
+                .and_then(|activity| activity.facts.pop())
+            else {
+                break;
+            };
+            excess = excess.saturating_sub(count_encoded_json_bytes(&fact)?);
+            omitted += 1;
+        }
+        if self.activity.as_ref().is_some_and(|activity| {
+            activity.invocation.is_none() && activity.result.is_none() && activity.facts.is_empty()
+        }) {
+            self.activity = None;
+        }
+        Ok(omitted)
     }
 
     /// Omits a projector-declared redundant structured representation when it

--- a/crates/ctx-history-core/src/core_record/activity.rs
+++ b/crates/ctx-history-core/src/core_record/activity.rs
@@ -13,6 +13,37 @@ pub const CORE_ACTIVITY_REVISION: u32 = 1;
 /// Maximum literal provider-declared facts retained on one event.
 pub const MAX_PROVIDER_DECLARED_FACTS: usize = 4_096;
 
+/// Admits exact optional Core metadata text within the metadata byte bound.
+///
+/// Empty and oversized values are omitted. Admitted text is not trimmed or
+/// otherwise altered.
+pub fn admit_optional_metadata_text(value: Option<String>) -> Option<String> {
+    value.filter(|value| !value.is_empty() && value.len() <= MAX_TEXT_METADATA_BYTES)
+}
+
+/// Admits an exact optional provider call ID as a UTF-8 typed key.
+pub fn admit_optional_provider_call_id(value: Option<String>) -> Option<TypedKey> {
+    value.and_then(|value| {
+        let key = TypedKey::utf8(value).ok()?;
+        key.validate_contract().ok().map(|()| key)
+    })
+}
+
+/// Admits one exact provider-declared fact within the value and count bounds.
+pub fn admit_provider_declared_fact(
+    kind: LiteralFactKind,
+    value: String,
+    current_fact_count: usize,
+) -> Option<ProviderDeclaredFact> {
+    if current_fact_count >= MAX_PROVIDER_DECLARED_FACTS
+        || value.is_empty()
+        || value.len() > MAX_TEXT_METADATA_BYTES
+    {
+        return None;
+    }
+    Some(ProviderDeclaredFact { kind, value })
+}
+
 /// One event-local provider activity envelope.
 ///
 /// Providers retain native event granularity. Separate invocation and result

--- a/crates/ctx-history-core/src/core_record/tests.rs
+++ b/crates/ctx-history-core/src/core_record/tests.rs
@@ -409,6 +409,132 @@ fn activity_metadata_accepts_exact_boundaries_and_rejects_max_plus_one() {
 }
 
 #[test]
+fn optional_metadata_text_admission_omits_only_invalid_values() {
+    assert_eq!(admit_optional_metadata_text(None), None);
+    assert_eq!(admit_optional_metadata_text(Some(String::new())), None);
+    assert_eq!(
+        admit_optional_metadata_text(Some(" \t".to_owned())),
+        Some(" \t".to_owned())
+    );
+
+    let exact = "x".repeat(MAX_TEXT_METADATA_BYTES);
+    assert_eq!(
+        admit_optional_metadata_text(Some(exact.clone())),
+        Some(exact)
+    );
+    assert_eq!(
+        admit_optional_metadata_text(Some("x".repeat(MAX_TEXT_METADATA_BYTES + 1))),
+        None
+    );
+}
+
+#[test]
+fn optional_provider_call_id_admission_uses_typed_key_boundaries() {
+    assert_eq!(admit_optional_provider_call_id(None), None);
+    assert_eq!(admit_optional_provider_call_id(Some(String::new())), None);
+    assert_eq!(
+        admit_optional_provider_call_id(Some(" \t".to_owned())),
+        Some(TypedKey::Utf8(" \t".to_owned()))
+    );
+
+    // UTF-8 typed keys add a one-byte tag and an eight-byte length prefix.
+    let exact = "x".repeat(MAX_TEXT_METADATA_BYTES - 9);
+    assert_eq!(
+        admit_optional_provider_call_id(Some(exact.clone())),
+        Some(TypedKey::Utf8(exact.clone()))
+    );
+    assert!(TypedKey::Utf8(exact).validate_contract().is_ok());
+    assert_eq!(
+        admit_optional_provider_call_id(Some("x".repeat(MAX_TEXT_METADATA_BYTES - 8))),
+        None
+    );
+}
+
+#[test]
+fn provider_declared_fact_admission_enforces_value_and_count_boundaries() {
+    assert_eq!(
+        admit_provider_declared_fact(LiteralFactKind::Command, String::new(), 0),
+        None
+    );
+    assert_eq!(
+        admit_provider_declared_fact(LiteralFactKind::Command, " \t".to_owned(), 0),
+        Some(ProviderDeclaredFact {
+            kind: LiteralFactKind::Command,
+            value: " \t".to_owned(),
+        })
+    );
+
+    let exact = "x".repeat(MAX_TEXT_METADATA_BYTES);
+    assert_eq!(
+        admit_provider_declared_fact(LiteralFactKind::Command, exact.clone(), 0),
+        Some(ProviderDeclaredFact {
+            kind: LiteralFactKind::Command,
+            value: exact.clone(),
+        })
+    );
+    let mut complete = record();
+    complete.content.activity = Some(CoreActivity {
+        revision: CORE_ACTIVITY_REVISION,
+        provider_call_id: None,
+        invocation: None,
+        result: None,
+        facts: vec![ProviderDeclaredFact {
+            kind: LiteralFactKind::Command,
+            value: exact,
+        }],
+    });
+    complete.validate_contract().unwrap();
+    assert_eq!(
+        admit_provider_declared_fact(
+            LiteralFactKind::Command,
+            "x".repeat(MAX_TEXT_METADATA_BYTES + 1),
+            0,
+        ),
+        None
+    );
+    assert!(admit_provider_declared_fact(
+        LiteralFactKind::Command,
+        "command".to_owned(),
+        MAX_PROVIDER_DECLARED_FACTS - 1,
+    )
+    .is_some());
+    assert_eq!(
+        admit_provider_declared_fact(
+            LiteralFactKind::Command,
+            "command".to_owned(),
+            MAX_PROVIDER_DECLARED_FACTS,
+        ),
+        None
+    );
+}
+
+#[test]
+fn optional_facts_are_omitted_against_the_complete_selected_content_budget() {
+    let mut record = record();
+    record.content.normalized_body = Some("b".repeat(MAX_CORE_CONTENT_BYTES - 32));
+    record.content.activity = Some(CoreActivity {
+        revision: CORE_ACTIVITY_REVISION,
+        provider_call_id: None,
+        invocation: None,
+        result: None,
+        facts: vec![ProviderDeclaredFact {
+            kind: LiteralFactKind::Command,
+            value: "optional command".to_owned(),
+        }],
+    });
+
+    assert_eq!(
+        record
+            .content
+            .omit_provider_declared_facts_if_aggregate_exceeds_limit()
+            .unwrap(),
+        1
+    );
+    assert!(record.content.activity.is_none());
+    record.validate_contract().unwrap();
+}
+
+#[test]
 fn activity_linkage_and_content_policy_fail_closed() {
     let mut record = record();
     let mut unlinked = activity();

--- a/crates/ctx-history-core/src/lib.rs
+++ b/crates/ctx-history-core/src/lib.rs
@@ -115,6 +115,7 @@ pub mod provider;
 pub mod source;
 
 pub use core_record::{
+    admit_optional_metadata_text, admit_optional_provider_call_id, admit_provider_declared_fact,
     core_record_accumulator_leaf_digest, core_record_contract_fingerprint, core_record_leaf_digest,
     core_record_leaf_sha256, ActivityInvocation, ActivityJsonCapture, ActivityResult,
     ActivityTextCapture, AgentScope, CoreActivity, CoreContent, CoreContentPolicyStatus,

--- a/crates/ctx-history-jsonl/src/family/route/capture.rs
+++ b/crates/ctx-history-jsonl/src/family/route/capture.rs
@@ -229,6 +229,7 @@ pub(super) fn capture<R: JsonlFamilyRuntime>(
             leaf.source().exact_descriptor_digest(),
             TerminalSourceEvidence {
                 certificate: base.clone(),
+                terminal_certificate: None,
                 terminal_proof,
                 emitted_bytes: 0,
                 exact_scan_bytes: leaf

--- a/crates/ctx-history-jsonl/src/family/route/leaf.rs
+++ b/crates/ctx-history-jsonl/src/family/route/leaf.rs
@@ -1,10 +1,10 @@
 use std::{
     collections::{BTreeMap, HashMap},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use chrono::{DateTime, Utc};
-use ctx_history_core::{CertifiedSource, CertifiedSourceAppend, CoreRecord};
+use ctx_history_core::{CertifiedSource, CertifiedSourceAppend};
 
 use super::super::{
     JsonlFamilyError, JsonlFamilyRuntime, JsonlProbe, JsonlReader, JsonlResult, JsonlRuntimeError,
@@ -22,6 +22,8 @@ use super::{
     JsonlFamilyWorkerContext,
 };
 mod checkpoint;
+mod evidence;
+mod output;
 mod prepare;
 mod semantic;
 #[cfg(test)]
@@ -37,6 +39,12 @@ use ctx_history_capture_runtime::{
     ParallelLeafScanComplete, ParallelLeafScanJob, ParallelLeafScanWorkerError,
     SourceBackedGenerationSink, SourceBackedRecordRejectionDrafts, SourceBackedRouteResult,
 };
+pub(super) use evidence::TerminalSourceEvidence;
+use evidence::{
+    candidate_would_replace_retained_records_with_only_rejections,
+    reconcile_parallel_source_outcomes, terminal_byte_remainder,
+};
+pub(super) use output::{JsonlLeafOutput, JsonlLeafOutputEvent};
 pub(super) use prepare::prepare_leaf;
 use semantic::{prepare_semantic_leaf, SemanticLeafExecution, SemanticLeafPlan};
 
@@ -45,27 +53,6 @@ pub(super) struct PreparedLeaf<E: JsonlFamilyError> {
     pub(super) append: Option<CertifiedSourceAppend>,
     pub(super) terminal_proof: JsonlFamilyTerminalProof<E>,
     pub(super) record_rejections: SourceBackedRecordRejectionDrafts,
-}
-
-#[derive(Debug)]
-pub(super) struct TerminalSourceEvidence<E: JsonlFamilyError> {
-    pub(super) certificate: CertifiedSource,
-    pub(super) terminal_proof: JsonlFamilyTerminalProof<E>,
-    pub(super) emitted_bytes: u64,
-    pub(super) exact_scan_bytes: Option<u64>,
-    pub(super) record_rejections: SourceBackedRecordRejectionDrafts,
-}
-
-impl<E: JsonlFamilyError> Clone for TerminalSourceEvidence<E> {
-    fn clone(&self) -> Self {
-        Self {
-            certificate: self.certificate.clone(),
-            terminal_proof: self.terminal_proof.clone(),
-            emitted_bytes: self.emitted_bytes,
-            exact_scan_bytes: self.exact_scan_bytes,
-            record_rejections: self.record_rejections.clone(),
-        }
-    }
 }
 
 struct JsonlLeafJob<E: JsonlFamilyError> {
@@ -104,55 +91,6 @@ impl<R: JsonlFamilyRuntime> JsonlFamilyWorkerContexts<R> {
     }
 }
 
-// The large variant deliberately carries CoreRecord by value: boxing every
-// projected record would add one allocation to the generic JSONL hot path.
-#[allow(clippy::large_enum_variant)]
-pub(super) enum JsonlLeafOutputEvent {
-    Page {
-        append: bool,
-        completed_bytes: u64,
-        records: Vec<CoreRecord>,
-    },
-    Record {
-        append: bool,
-        record: CoreRecord,
-    },
-    Flush,
-}
-
-pub(super) struct JsonlLeafOutput<'emit, E: JsonlFamilyError> {
-    emit: &'emit mut dyn FnMut(JsonlLeafOutputEvent) -> JsonlResult<(), E>,
-}
-
-impl<'emit, E: JsonlFamilyError> JsonlLeafOutput<'emit, E> {
-    pub(super) fn new(
-        emit: &'emit mut dyn FnMut(JsonlLeafOutputEvent) -> JsonlResult<(), E>,
-    ) -> Self {
-        Self { emit }
-    }
-
-    fn emit_page(
-        &mut self,
-        append: bool,
-        completed_bytes: u64,
-        records: Vec<CoreRecord>,
-    ) -> JsonlResult<(), E> {
-        (self.emit)(JsonlLeafOutputEvent::Page {
-            append,
-            completed_bytes,
-            records,
-        })
-    }
-
-    fn emit_record(&mut self, append: bool, record: CoreRecord) -> JsonlResult<(), E> {
-        (self.emit)(JsonlLeafOutputEvent::Record { append, record })
-    }
-
-    fn flush(&mut self) -> JsonlResult<(), E> {
-        (self.emit)(JsonlLeafOutputEvent::Flush)
-    }
-}
-
 fn scan_leaf_serial<R: JsonlFamilyRuntime>(
     adapter: &dyn JsonlFamilyAdapter<Runtime = R>,
     leaf: &JsonlFamilyLeaf<JsonlRuntimeError<R>>,
@@ -167,6 +105,12 @@ fn scan_leaf_serial<R: JsonlFamilyRuntime>(
     let mut sink_failure = None;
     let mut emitted_bytes = 0_u64;
     let mut emit = |event| {
+        if matches!(
+            &event,
+            JsonlLeafOutputEvent::Page { records, .. } if records.is_empty()
+        ) {
+            return Ok(());
+        }
         let append = match &event {
             JsonlLeafOutputEvent::Page { append, .. }
             | JsonlLeafOutputEvent::Record { append, .. } => *append,
@@ -239,6 +183,36 @@ fn scan_leaf_serial<R: JsonlFamilyRuntime>(
         terminal_proof,
         record_rejections,
     } = prepared;
+    if candidate_would_replace_retained_records_with_only_rejections(&certificate, base) {
+        let retained = base.cloned();
+        let publication_certificate = retained.clone().unwrap_or_else(|| certificate.clone());
+        if let Some(base) = retained.as_ref() {
+            sink.retain_source(base.clone()).map_err(route_internal)?;
+        }
+        sink.record_logical_source_failure(
+            leaf.source().clone(),
+            route_invalid("JSONL source is unreadable"),
+            retained.is_some(),
+        )
+        .map_err(route_internal)?;
+        sink.record_rejections(record_rejections);
+        sink.report_completed_bytes_with_exact(
+            certificate.counts().certified_bytes,
+            leaf.frozen_scan_observation()
+                .map(|observation| observation.length()),
+        )
+        .map_err(route_internal)?;
+        return Ok(TerminalSourceEvidence {
+            certificate: publication_certificate,
+            terminal_certificate: Some(certificate),
+            terminal_proof,
+            emitted_bytes: 0,
+            exact_scan_bytes: leaf
+                .frozen_scan_observation()
+                .map(|observation| observation.length()),
+            record_rejections: SourceBackedRecordRejectionDrafts::default(),
+        });
+    }
     sink.record_rejections(record_rejections);
     match append {
         Some(append) => {
@@ -264,6 +238,7 @@ fn scan_leaf_serial<R: JsonlFamilyRuntime>(
             .map_err(route_internal)?;
             Ok(TerminalSourceEvidence {
                 certificate,
+                terminal_certificate: None,
                 terminal_proof,
                 emitted_bytes,
                 exact_scan_bytes: leaf
@@ -292,6 +267,7 @@ fn scan_leaf_serial<R: JsonlFamilyRuntime>(
             .map_err(route_internal)?;
             Ok(TerminalSourceEvidence {
                 certificate,
+                terminal_certificate: None,
                 terminal_proof,
                 emitted_bytes,
                 exact_scan_bytes: leaf
@@ -312,7 +288,8 @@ fn run_parallel_leaf_job_batch<R: JsonlFamilyRuntime>(
     append_only_trust_allowed: bool,
     #[cfg(test)] scanner_probe: Option<&JsonlFamilyScannerProbe>,
 ) -> SourceBackedRouteResult<Vec<TerminalSourceEvidence<JsonlRuntimeError<R>>>> {
-    let result = sink.run_parallel_leaf_scans_with_worker_states(
+    let failed_evidences = Mutex::new(Vec::new());
+    let result = sink.run_parallel_leaf_scans_with_worker_states_and_source_outcomes(
         jobs,
         worker_states,
         |contexts, job, emitter| {
@@ -328,6 +305,12 @@ fn run_parallel_leaf_job_batch<R: JsonlFamilyRuntime>(
             >::default();
             let mut emitted_bytes = 0_u64;
             let mut emit = |event| {
+                if matches!(
+                    &event,
+                    JsonlLeafOutputEvent::Page { records, .. } if records.is_empty()
+                ) {
+                    return Ok(());
+                }
                 let flush = matches!(
                     &event,
                     JsonlLeafOutputEvent::Page { .. } | JsonlLeafOutputEvent::Flush
@@ -440,6 +423,45 @@ fn run_parallel_leaf_job_batch<R: JsonlFamilyRuntime>(
                 terminal_proof,
                 record_rejections,
             } = prepared;
+            if candidate_would_replace_retained_records_with_only_rejections(
+                &certificate,
+                job.leaf().base.as_ref(),
+            ) {
+                if staging_started || append.is_some() {
+                    return Err(ParallelLeafScanWorkerError::provider(route_internal(
+                        "all-rejected JSONL leaf entered publication staging",
+                    )));
+                }
+                let retained = job.leaf().base.clone();
+                let publication_certificate =
+                    retained.clone().unwrap_or_else(|| certificate.clone());
+                failed_evidences
+                    .lock()
+                    .map_err(|_| {
+                        ParallelLeafScanWorkerError::provider(route_internal(
+                            "JSONL failed-evidence lock was poisoned",
+                        ))
+                    })?
+                    .push(TerminalSourceEvidence {
+                        certificate: publication_certificate,
+                        terminal_certificate: Some(certificate),
+                        terminal_proof,
+                        emitted_bytes: 0,
+                        exact_scan_bytes: leaf
+                            .frozen_scan_observation()
+                            .map(|observation| observation.length()),
+                        record_rejections: SourceBackedRecordRejectionDrafts::default(),
+                    });
+                emitter
+                    .complete(ParallelLeafScanComplete::source_failure_with_rejections(
+                        leaf.source().clone(),
+                        retained,
+                        route_invalid("JSONL source is unreadable"),
+                        record_rejections,
+                    ))
+                    .map_err(ParallelLeafScanWorkerError::from)?;
+                return Ok(());
+            }
             match append {
                 Some(append) => {
                     if staging_started && !append_staging {
@@ -460,6 +482,7 @@ fn run_parallel_leaf_job_batch<R: JsonlFamilyRuntime>(
                             append,
                             TerminalSourceEvidence {
                                 certificate,
+                                terminal_certificate: None,
                                 terminal_proof,
                                 emitted_bytes,
                                 exact_scan_bytes: leaf
@@ -483,6 +506,7 @@ fn run_parallel_leaf_job_batch<R: JsonlFamilyRuntime>(
                     }
                     let evidence = TerminalSourceEvidence {
                         certificate: certificate.clone(),
+                        terminal_certificate: None,
                         terminal_proof,
                         emitted_bytes,
                         exact_scan_bytes: leaf
@@ -498,11 +522,15 @@ fn run_parallel_leaf_job_batch<R: JsonlFamilyRuntime>(
             Ok(())
         },
     );
-    let evidences = result.map_err(map_parallel_leaf_error)?;
+    let outcomes = result.map_err(map_parallel_leaf_error)?;
+    let failed_evidences = failed_evidences
+        .into_inner()
+        .map_err(|_| route_internal("JSONL failed-evidence lock was poisoned"))?;
+    let evidences = reconcile_parallel_source_outcomes(outcomes, failed_evidences)?;
     for evidence in &evidences {
         sink.record_rejections(evidence.record_rejections.clone());
         sink.report_completed_bytes_with_exact(
-            terminal_byte_remainder(&evidence.certificate, evidence.emitted_bytes)?,
+            terminal_byte_remainder(evidence.observed_certificate(), evidence.emitted_bytes)?,
             evidence
                 .exact_scan_bytes
                 .and_then(|total| total.checked_sub(evidence.emitted_bytes)),
@@ -510,19 +538,6 @@ fn run_parallel_leaf_job_batch<R: JsonlFamilyRuntime>(
         .map_err(route_internal)?;
     }
     Ok(evidences)
-}
-
-fn terminal_byte_remainder(
-    certificate: &CertifiedSource,
-    emitted_bytes: u64,
-) -> SourceBackedRouteResult<u64> {
-    certificate
-        .counts()
-        .certified_bytes
-        .checked_sub(emitted_bytes)
-        .ok_or_else(|| {
-            route_invalid("JSONL page byte progress exceeded terminal certified source bytes")
-        })
 }
 
 pub(super) fn scan_leaves<R: JsonlFamilyRuntime>(

--- a/crates/ctx-history-jsonl/src/family/route/leaf/evidence.rs
+++ b/crates/ctx-history-jsonl/src/family/route/leaf/evidence.rs
@@ -1,0 +1,116 @@
+use super::*;
+use ctx_history_capture_runtime::SourceBackedSourceOutcome;
+
+#[derive(Debug)]
+pub(crate) struct TerminalSourceEvidence<E: JsonlFamilyError> {
+    pub(crate) certificate: CertifiedSource,
+    pub(crate) terminal_certificate: Option<CertifiedSource>,
+    pub(crate) terminal_proof: JsonlFamilyTerminalProof<E>,
+    pub(crate) emitted_bytes: u64,
+    pub(crate) exact_scan_bytes: Option<u64>,
+    pub(crate) record_rejections: SourceBackedRecordRejectionDrafts,
+}
+
+impl<E: JsonlFamilyError> Clone for TerminalSourceEvidence<E> {
+    fn clone(&self) -> Self {
+        Self {
+            certificate: self.certificate.clone(),
+            terminal_certificate: self.terminal_certificate.clone(),
+            terminal_proof: self.terminal_proof.clone(),
+            emitted_bytes: self.emitted_bytes,
+            exact_scan_bytes: self.exact_scan_bytes,
+            record_rejections: self.record_rejections.clone(),
+        }
+    }
+}
+
+impl<E: JsonlFamilyError> TerminalSourceEvidence<E> {
+    pub(crate) fn observed_certificate(&self) -> &CertifiedSource {
+        self.terminal_certificate
+            .as_ref()
+            .unwrap_or(&self.certificate)
+    }
+}
+
+pub(super) fn candidate_would_replace_retained_records_with_only_rejections(
+    certificate: &CertifiedSource,
+    base: Option<&CertifiedSource>,
+) -> bool {
+    let counts = certificate.counts();
+    let retained_base_records = base
+        .map(CertifiedSource::counts)
+        .map_or(0, |counts| counts.retained_records);
+    retained_base_records > 0
+        && counts.complete_records > 0
+        && counts.retained_records == 0
+        && counts.rejected_records > 0
+}
+
+pub(super) fn reconcile_parallel_source_outcomes<E: JsonlFamilyError>(
+    outcomes: Vec<SourceBackedSourceOutcome<TerminalSourceEvidence<E>>>,
+    failed_evidences: Vec<TerminalSourceEvidence<E>>,
+) -> SourceBackedRouteResult<Vec<TerminalSourceEvidence<E>>> {
+    let mut failed_evidences = failed_evidences
+        .into_iter()
+        .map(|evidence| {
+            (
+                evidence
+                    .observed_certificate()
+                    .observation()
+                    .source()
+                    .exact_descriptor_digest(),
+                evidence,
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    let mut evidences = Vec::with_capacity(outcomes.len());
+    for outcome in outcomes {
+        match outcome {
+            SourceBackedSourceOutcome::Success(evidence) => evidences.push(evidence),
+            SourceBackedSourceOutcome::Failed(mut failure) => {
+                if !failure.failure.kind.is_logical_source_failure() {
+                    return Err(route_internal(
+                        "parallel JSONL source failure was not logical",
+                    ));
+                }
+                let mut evidence = failed_evidences
+                    .remove(&failure.source.exact_descriptor_digest())
+                    .ok_or_else(|| {
+                        route_internal("parallel JSONL source failure lost terminal evidence")
+                    })?;
+                if !evidence
+                    .observed_certificate()
+                    .observation()
+                    .source()
+                    .exact_descriptor_eq(&failure.source)
+                    || failure.retained.as_ref() != Some(&evidence.certificate)
+                {
+                    return Err(route_internal(
+                        "parallel JSONL source failure evidence changed identity",
+                    ));
+                }
+                evidence.record_rejections = std::mem::take(&mut failure.record_rejections);
+                evidences.push(evidence);
+            }
+        }
+    }
+    if !failed_evidences.is_empty() {
+        return Err(route_internal(
+            "parallel JSONL terminal evidence has no source failure outcome",
+        ));
+    }
+    Ok(evidences)
+}
+
+pub(super) fn terminal_byte_remainder(
+    certificate: &CertifiedSource,
+    emitted_bytes: u64,
+) -> SourceBackedRouteResult<u64> {
+    certificate
+        .counts()
+        .certified_bytes
+        .checked_sub(emitted_bytes)
+        .ok_or_else(|| {
+            route_invalid("JSONL page byte progress exceeded terminal certified source bytes")
+        })
+}

--- a/crates/ctx-history-jsonl/src/family/route/leaf/output.rs
+++ b/crates/ctx-history-jsonl/src/family/route/leaf/output.rs
@@ -1,0 +1,52 @@
+use ctx_history_core::CoreRecord;
+
+use super::*;
+
+// The large variant deliberately carries CoreRecord by value: boxing every
+// projected record would add one allocation to the generic JSONL hot path.
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum JsonlLeafOutputEvent {
+    Page {
+        append: bool,
+        completed_bytes: u64,
+        records: Vec<CoreRecord>,
+    },
+    Record {
+        append: bool,
+        record: CoreRecord,
+    },
+    Flush,
+}
+
+pub(crate) struct JsonlLeafOutput<'emit, E: JsonlFamilyError> {
+    emit: &'emit mut dyn FnMut(JsonlLeafOutputEvent) -> JsonlResult<(), E>,
+}
+
+impl<'emit, E: JsonlFamilyError> JsonlLeafOutput<'emit, E> {
+    pub(crate) fn new(
+        emit: &'emit mut dyn FnMut(JsonlLeafOutputEvent) -> JsonlResult<(), E>,
+    ) -> Self {
+        Self { emit }
+    }
+
+    pub(crate) fn emit_page(
+        &mut self,
+        append: bool,
+        completed_bytes: u64,
+        records: Vec<CoreRecord>,
+    ) -> JsonlResult<(), E> {
+        (self.emit)(JsonlLeafOutputEvent::Page {
+            append,
+            completed_bytes,
+            records,
+        })
+    }
+
+    pub(crate) fn emit_record(&mut self, append: bool, record: CoreRecord) -> JsonlResult<(), E> {
+        (self.emit)(JsonlLeafOutputEvent::Record { append, record })
+    }
+
+    pub(crate) fn flush(&mut self) -> JsonlResult<(), E> {
+        (self.emit)(JsonlLeafOutputEvent::Flush)
+    }
+}

--- a/crates/ctx-history-jsonl/src/family/route/revalidation.rs
+++ b/crates/ctx-history-jsonl/src/family/route/revalidation.rs
@@ -146,7 +146,7 @@ pub(super) fn revalidate_complete_inventory<R: JsonlFamilyRuntime>(
     for evidence in expected_sources.values() {
         evidence
             .terminal_proof
-            .revalidate_for(&evidence.certificate)?;
+            .revalidate_for(evidence.observed_certificate())?;
     }
     for dependency in &opening_inventory.exact_dependencies {
         dependency.revalidate_dependency()?;

--- a/crates/ctx-history-jsonl/src/family/route/tests/behavior/scheduler.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/behavior/scheduler.rs
@@ -59,6 +59,51 @@ fn production_jsonl_scheduler_projects_multiple_sources_concurrently() {
 }
 
 #[test]
+fn parallel_all_rejected_candidates_preserve_cold_and_warm_source_semantics() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let root = temp.path().join("sessions");
+    fs::create_dir_all(&root).unwrap();
+    for index in 0..2 {
+        fs::write(
+            root.join(format!("{index}.jsonl")),
+            b"{\"message\":\"valid\"}\n",
+        )
+        .unwrap();
+    }
+    let reject = Arc::new(AtomicBool::new(false));
+    let adapter = AllRejectedParallelTestAdapter {
+        reject: Arc::clone(&reject),
+    };
+    let index = temp.path().join("index");
+
+    let cold = capture_parallel_test_generation(&adapter, &root, &index, 2).0;
+    assert_eq!(cold.manifest.sources.len(), 2);
+    assert_eq!(cold.manifest.records.len(), 2);
+
+    reject.store(true, Ordering::SeqCst);
+    for leaf in 0..2 {
+        fs::write(
+            root.join(format!("{leaf}.jsonl")),
+            format!("{{\"message\":\"rejected-{leaf}\"}}\n"),
+        )
+        .unwrap();
+    }
+    let carried = capture_parallel_test_generation(&adapter, &root, &index, 2).0;
+    assert_eq!(carried.manifest, cold.manifest);
+    assert_eq!(carried.generation_id, cold.generation_id);
+
+    let cold_rejected_index = temp.path().join("cold-rejected-index");
+    let cold_rejected =
+        capture_parallel_test_generation(&adapter, &root, &cold_rejected_index, 2).0;
+    assert!(cold_rejected.manifest.records.is_empty());
+    assert_eq!(cold_rejected.manifest.sources.len(), 2);
+    assert!(cold_rejected.manifest.sources.iter().all(|source| {
+        let counts = source.counts();
+        counts.complete_records == 1 && counts.retained_records == 0 && counts.rejected_records == 1
+    }));
+}
+
+#[test]
 fn dependency_phases_bar_later_jsonl_scans_without_serializing_each_phase() {
     let temp = crate::test_support_paths::tempdir().unwrap();
     let root = temp.path().join("sessions");

--- a/crates/ctx-history-jsonl/src/family/route/tests/scheduler_support.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/scheduler_support.rs
@@ -33,6 +33,58 @@ impl_standard_jsonl_test_adapter!(
     |_adapter, _leaf, _source_file, _imported_at| { Ok(Box::new(ParallelTestProjector)) }
 );
 
+pub(super) struct AllRejectedParallelTestAdapter {
+    pub(super) reject: Arc<AtomicBool>,
+}
+
+pub(super) struct AllRejectedParallelTestProjector {
+    pub(super) source: SourceKey,
+    pub(super) reject: Arc<AtomicBool>,
+    pub(super) rejected_records: u64,
+}
+
+impl JsonlFamilyProjector for AllRejectedParallelTestProjector {
+    type Runtime = TestJsonlRuntime;
+
+    fn project(
+        &mut self,
+        record: JsonlRecordRef<'_>,
+        _worker: &mut JsonlFamilyWorkerContext,
+        emit: &mut dyn FnMut(CoreRecord) -> Result<()>,
+    ) -> Result<()> {
+        if self.reject.load(Ordering::SeqCst) {
+            self.rejected_records =
+                self.rejected_records
+                    .checked_add(1)
+                    .ok_or(CaptureError::SystemInvariant(
+                        "all-rejected test count overflowed",
+                    ))?;
+            return Ok(());
+        }
+        emit(emission_test_record(
+            &self.source,
+            record.evidence().physical_ordinal(),
+        )?)
+    }
+
+    fn rejected_records(&self) -> u64 {
+        self.rejected_records
+    }
+}
+
+impl_standard_jsonl_test_adapter!(
+    AllRejectedParallelTestAdapter,
+    "all-rejected-parallel-test-parser-v1",
+    JsonlFamilyAppendMode::Replacement,
+    |adapter, leaf, _source_file, _imported_at| {
+        Ok(Box::new(AllRejectedParallelTestProjector {
+            source: leaf.source().clone(),
+            reject: Arc::clone(&adapter.reject),
+            rejected_records: 0,
+        }))
+    }
+);
+
 pub(super) struct PhasedTestAdapter {
     pub(super) completed_first_phase: Arc<AtomicUsize>,
     pub(super) second_phase_started_early: Arc<AtomicBool>,

--- a/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
@@ -243,6 +243,7 @@ pub(super) fn expected_state(
                 leaf.source().exact_descriptor_digest(),
                 TerminalSourceEvidence {
                     certificate,
+                    terminal_certificate: None,
                     terminal_proof,
                     emitted_bytes: 0,
                     exact_scan_bytes: None,

--- a/crates/ctx-history-provider-hermes/src/provider/source_backed.rs
+++ b/crates/ctx-history-provider-hermes/src/provider/source_backed.rs
@@ -12,12 +12,13 @@ use std::{
 };
 
 use ctx_history_core::{
+    admit_optional_metadata_text, admit_optional_provider_call_id, admit_provider_declared_fact,
     derive_event_id, derive_session_id, ActivityInvocation, ActivityJsonCapture, ActivityResult,
     ActivityTextCapture, AgentScope, CaptureProvider, CertifiedSource, CoreActivity, CoreRecord,
     CoreRecordError, EventIdentityInput, LiteralFactKind, NativeItemKey, NativeSessionKey,
-    ProjectionContractError, ProviderDeclaredFact, ProviderNativeSessionRelationship,
-    ScannedSourceCounts, SessionIdentityInput, SourceAnchor, SourceKey, SourceObservation,
-    StableEntityId, TypedKey, CORE_ACTIVITY_REVISION,
+    ProjectionContractError, ProviderNativeSessionRelationship, ScannedSourceCounts,
+    SessionIdentityInput, SourceAnchor, SourceKey, SourceObservation, StableEntityId, TypedKey,
+    CORE_ACTIVITY_REVISION,
 };
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -64,7 +65,7 @@ const HERMES_PROFILE_SOURCE_SCHEMA_VARIANT: &str = "hermes-state-db-v1";
 const HERMES_SESSION_SOURCE_SCHEMA_VARIANT: &str = "hermes-state-session-v1";
 const SQLITE_SOURCE_INVALID_REASON: &str =
     "Hermes SQLite source must have an authorized parent and database leaf";
-const HERMES_SOURCE_PARSER_REVISION: &str = "hermes-source-backed-v4-neutral-core";
+const HERMES_SOURCE_PARSER_REVISION: &str = "hermes-source-backed-v5-optional-admission";
 const HERMES_SOURCE_DIGEST_DOMAIN: &[u8] = b"ctx-hermes-session-content-v1\0";
 const HERMES_TREE_FINGERPRINT_DOMAIN: &[u8] = b"ctx-hermes-source-inventory-v1\0";
 const HERMES_LEAF_FINGERPRINT_DOMAIN: &[u8] = b"ctx-hermes-session-leaf-v1\0";

--- a/crates/ctx-history-provider-hermes/src/provider/source_backed/projection.rs
+++ b/crates/ctx-history-provider-hermes/src/provider/source_backed/projection.rs
@@ -179,7 +179,7 @@ pub(super) fn project_message(
 ) -> HermesSourceBackedResult<CoreRecord> {
     let native = hermes_native_event(&row, ordinal)?;
     let _provider_owned_evidence = (&native.cursor, &native.payload, &native.metadata);
-    let activity = hermes_activity(&row, &native)?;
+    let activity = hermes_activity(&row, &native);
     let body = native.complete_text;
     let native_item_key = NativeItemKey::composite(
         HERMES_MESSAGE_NAMESPACE,
@@ -218,6 +218,9 @@ pub(super) fn project_message(
     record.content.activity = merge_hermes_facts(activity, session);
     record
         .content
+        .omit_provider_declared_facts_if_aggregate_exceeds_limit()?;
+    record
+        .content
         .omit_structured_content_if_aggregate_exceeds_limit()?;
     record.validate_contract()?;
     Ok(record)
@@ -226,19 +229,15 @@ pub(super) fn project_message(
 pub(super) fn hermes_activity(
     row: &HermesMessageRow,
     native: &HermesNativeEvent,
-) -> HermesSourceBackedResult<Option<CoreActivity>> {
-    let provider_call_id = row
-        .tool_call_id
-        .as_deref()
-        .map(TypedKey::utf8)
-        .transpose()?;
+) -> Option<CoreActivity> {
+    let provider_call_id = admit_optional_provider_call_id(row.tool_call_id.clone());
     let invocation = if native.event_type == ctx_history_core::EventType::ToolCall
         && provider_call_id.is_some()
     {
-        row.tool_name.as_ref().map(|tool| ActivityInvocation {
+        admit_optional_metadata_text(row.tool_name.clone()).map(|tool| ActivityInvocation {
             protocol: None,
             server: None,
-            tool: tool.clone(),
+            tool,
             arguments: row
                 .tool_calls
                 .as_deref()
@@ -253,7 +252,7 @@ pub(super) fn hermes_activity(
     let result = (native.event_type == ctx_history_core::EventType::ToolOutput
         && provider_call_id.is_some())
     .then(|| ActivityResult {
-        status: row.finish_reason.clone(),
+        status: admit_optional_metadata_text(row.finish_reason.clone()),
         completed_at_unix_ms: Some(native.occurred_at.timestamp_millis()),
         duration_ns: None,
         text: ActivityTextCapture::NormalizedBody,
@@ -262,15 +261,15 @@ pub(super) fn hermes_activity(
         },
     });
     if invocation.is_none() && result.is_none() {
-        return Ok(None);
+        return None;
     }
-    Ok(Some(CoreActivity {
+    Some(CoreActivity {
         revision: CORE_ACTIVITY_REVISION,
         provider_call_id,
         invocation,
         result,
         facts: Vec::new(),
-    }))
+    })
 }
 
 pub(super) fn merge_hermes_facts(
@@ -278,23 +277,16 @@ pub(super) fn merge_hermes_facts(
     session: &HermesSessionContext,
 ) -> Option<CoreActivity> {
     let mut facts = Vec::new();
-    if let Some(branch) = session.branch.clone() {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::Branch,
-            value: branch,
-        });
-    }
-    if let Some(workspace) = session.workspace.clone() {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::Workspace,
-            value: workspace,
-        });
-    }
-    if let Some(cwd) = session.cwd.clone() {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::SessionCwd,
-            value: cwd,
-        });
+    for (kind, value) in [
+        (LiteralFactKind::Branch, session.branch.clone()),
+        (LiteralFactKind::Workspace, session.workspace.clone()),
+        (LiteralFactKind::SessionCwd, session.cwd.clone()),
+    ] {
+        if let Some(fact) =
+            value.and_then(|value| admit_provider_declared_fact(kind, value, facts.len()))
+        {
+            facts.push(fact);
+        }
     }
     match (activity, facts.is_empty()) {
         (Some(mut activity), _) => {

--- a/crates/ctx-history-provider-hermes/src/provider/source_backed/tests.rs
+++ b/crates/ctx-history-provider-hermes/src/provider/source_backed/tests.rs
@@ -32,6 +32,10 @@ fn direct_core_projection_is_complete_and_has_no_recursive_ancestry_sql() {
     assert!(!production.to_ascii_lowercase().contains("with recursive"));
     assert!(!production.contains("body.truncate"));
     assert!(!production.contains("body.chars().take"));
+    assert_eq!(
+        HERMES_SOURCE_PARSER_REVISION,
+        "hermes-source-backed-v5-optional-admission"
+    );
 }
 
 #[test]
@@ -104,6 +108,167 @@ fn candidate(data_root: &Path, database: &Path) -> HermesSourceCandidate {
 
 fn session_source(candidate: &HermesSourceCandidate, session: &str) -> SourceKey {
     hermes_session_source_key(&candidate.source, session).unwrap()
+}
+
+fn projection_context(source: &SourceKey) -> HermesSessionContext {
+    let native_session_key =
+        NativeSessionKey::native_id(HERMES_SESSION_NAMESPACE, TypedKey::utf8(PARENT).unwrap())
+            .unwrap();
+    let session_id = derive_session_id(SessionIdentityInput {
+        source,
+        logical_session_kind: HERMES_LOGICAL_SESSION_KIND,
+        native_session_key: &native_session_key,
+    })
+    .unwrap();
+    HermesSessionContext {
+        session_id,
+        parent_session_id: None,
+        agent_scope: AgentScope::Primary,
+        branch: None,
+        workspace: None,
+        cwd: None,
+    }
+}
+
+fn projection_message_row(id: i64, role: &str) -> HermesMessageRow {
+    HermesMessageRow {
+        id,
+        session_id: PARENT.to_owned(),
+        role: role.to_owned(),
+        content: Some("complete provider content".to_owned()),
+        tool_call_id: None,
+        tool_calls: None,
+        tool_name: None,
+        timestamp: 1_782_259_202.0,
+        token_count: None,
+        finish_reason: None,
+        reasoning: None,
+        reasoning_content: None,
+        reasoning_details: None,
+        codex_reasoning_items: None,
+        codex_message_items: None,
+        platform_message_id: None,
+        observed: 0,
+        active: 1,
+        compacted: 0,
+    }
+}
+
+fn oversized_optional_metadata() -> String {
+    "x".repeat(64 * 1024 + 1)
+}
+
+#[test]
+fn optional_activity_values_are_omitted_without_losing_raw_content_or_emitting_empty_activity() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let database = temp.path().join("source/state.db");
+    create_fixture(&database);
+    let candidate = candidate(&temp.path().join("data-root"), &database);
+    let source = session_source(&candidate, PARENT);
+    let context = projection_context(&source);
+
+    for (offset, invalid_call_id) in [String::new(), oversized_optional_metadata()]
+        .into_iter()
+        .enumerate()
+    {
+        let mut row = projection_message_row(100 + offset as i64, "assistant");
+        row.tool_call_id = Some(invalid_call_id.clone());
+        row.tool_calls = Some("{}".to_owned());
+        row.tool_name = Some("run".to_owned());
+
+        let record = project_message(&source, offset as u64, row, &context).unwrap();
+        assert_eq!(
+            record.content.structured_content.as_ref().unwrap()["tool_call_id"].as_str(),
+            Some(invalid_call_id.as_str())
+        );
+        assert_eq!(record.content.activity, None);
+
+        let mut row = projection_message_row(102 + offset as i64, "tool");
+        row.tool_call_id = Some(invalid_call_id.clone());
+        let record = project_message(&source, 2 + offset as u64, row, &context).unwrap();
+        assert_eq!(
+            record.content.structured_content.as_ref().unwrap()["tool_call_id"].as_str(),
+            Some(invalid_call_id.as_str())
+        );
+        assert_eq!(record.content.activity, None);
+    }
+
+    for (offset, invalid_tool_name) in [String::new(), oversized_optional_metadata()]
+        .into_iter()
+        .enumerate()
+    {
+        let mut row = projection_message_row(110 + offset as i64, "assistant");
+        row.tool_call_id = Some("call-110".to_owned());
+        row.tool_calls = Some("{}".to_owned());
+        row.tool_name = Some(invalid_tool_name.clone());
+
+        let record = project_message(&source, 10 + offset as u64, row, &context).unwrap();
+        assert_eq!(
+            record.content.structured_content.as_ref().unwrap()["tool_name"].as_str(),
+            Some(invalid_tool_name.as_str())
+        );
+        assert_eq!(record.content.activity, None);
+    }
+
+    for (offset, invalid_status) in [String::new(), oversized_optional_metadata()]
+        .into_iter()
+        .enumerate()
+    {
+        let mut row = projection_message_row(120 + offset as i64, "tool");
+        row.tool_call_id = Some("call-120".to_owned());
+        row.finish_reason = Some(invalid_status.clone());
+
+        let record = project_message(&source, 20 + offset as u64, row, &context).unwrap();
+        assert_eq!(
+            record.content.structured_content.as_ref().unwrap()["status"].as_str(),
+            Some(invalid_status.as_str())
+        );
+        let activity = record.content.activity.unwrap();
+        assert!(activity.provider_call_id.is_some());
+        assert_eq!(activity.result.unwrap().status, None);
+    }
+}
+
+#[test]
+fn optional_facts_omit_empty_and_oversized_values_while_preserving_order_and_exact_text() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let database = temp.path().join("source/state.db");
+    create_fixture(&database);
+    let candidate = candidate(&temp.path().join("data-root"), &database);
+    let source = session_source(&candidate, PARENT);
+    let mut context = projection_context(&source);
+    context.branch = Some(String::new());
+    context.workspace = Some("x".repeat(ctx_history_core::MAX_CORE_CONTENT_BYTES + 1));
+
+    let record = project_message(
+        &source,
+        0,
+        projection_message_row(130, "assistant"),
+        &context,
+    )
+    .unwrap();
+    assert_eq!(record.content.activity, None);
+
+    context.branch = Some(" feature ".to_owned());
+    context.cwd = Some(" /repo/worktree ".to_owned());
+    let record = project_message(
+        &source,
+        1,
+        projection_message_row(131, "assistant"),
+        &context,
+    )
+    .unwrap();
+    let facts = record.content.activity.unwrap().facts;
+    assert_eq!(
+        facts
+            .iter()
+            .map(|fact| (fact.kind, fact.value.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (LiteralFactKind::Branch, " feature "),
+            (LiteralFactKind::SessionCwd, " /repo/worktree "),
+        ]
+    );
 }
 
 fn automatic_candidate(data_root: &Path, database: &Path) -> HermesSourceCandidate {

--- a/crates/ctx-history-provider-mistral-mux/src/mistral_vibe/native_path.rs
+++ b/crates/ctx-history-provider-mistral-mux/src/mistral_vibe/native_path.rs
@@ -6,7 +6,7 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use ctx_history_capture_model::file_references::visit_literal_file_reference_drafts;
-use ctx_history_core::{ProviderDeclaredFact, MAX_PROVIDER_DECLARED_FACTS};
+use ctx_history_core::{admit_provider_declared_fact, ProviderDeclaredFact};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -160,18 +160,11 @@ fn valid_mistral_vibe_record_role(value: &Value) -> std::result::Result<&str, &'
     Ok(role)
 }
 
-fn collect_file_facts(value: &Value) -> Vec<ProviderDeclaredFact> {
-    let mut facts = Vec::new();
+fn collect_file_facts(value: &Value, facts: &mut Vec<ProviderDeclaredFact>) {
     let _ = visit_literal_file_reference_drafts(value, |draft| {
-        facts.push(ProviderDeclaredFact {
-            kind: draft.kind,
-            value: draft.value,
-        });
+        if let Some(fact) = admit_provider_declared_fact(draft.kind, draft.value, facts.len()) {
+            facts.push(fact);
+        }
         Ok::<(), std::convert::Infallible>(())
     });
-    if facts.len() > MAX_PROVIDER_DECLARED_FACTS {
-        Vec::new()
-    } else {
-        facts
-    }
 }

--- a/crates/ctx-history-provider-mistral-mux/src/mistral_vibe/native_path/source_backed.rs
+++ b/crates/ctx-history-provider-mistral-mux/src/mistral_vibe/native_path/source_backed.rs
@@ -10,6 +10,7 @@ use chrono::{DateTime, Utc};
 use ctx_history_capture_model::normalization::provider_explicit_result_value_text;
 use ctx_history_capture_runtime::BaseEventLookup;
 use ctx_history_core::{
+    admit_optional_metadata_text, admit_optional_provider_call_id, admit_provider_declared_fact,
     derive_event_id, derive_native_session_id, ActivityInvocation, ActivityJsonCapture,
     ActivityResult, ActivityTextCapture, AgentScope, CaptureProvider, CoreActivity, CoreRecord,
     EventIdentityInput, EventType, LiteralFactKind, NativeItemKey, PositionStability,
@@ -32,6 +33,9 @@ use ctx_history_provider_runtime::{
 };
 use ctx_history_source_io::MAX_PROVIDER_JSONL_LINE_BYTES;
 
+mod activity;
+use activity::mistral_vibe_activity;
+
 const SOURCE_SCHEMA_VARIANT: &str = "meta-json-messages-jsonl-v1";
 const SOURCE_ANCHOR_NAMESPACE: &str = "mistral-vibe-session-id";
 const NATIVE_SESSION_NAMESPACE: &str = "mistral-vibe-session";
@@ -40,7 +44,7 @@ const NATIVE_EVENT_REUSED_TOOL_CALL_POSITION_KIND: &str =
     "mistral-vibe-duplicate-tool-call-id-ordinal";
 const LOGICAL_SESSION_KIND: &str = "mistral-vibe-session";
 const LOGICAL_EVENT_KIND: &str = "mistral-vibe-event";
-const PARSER_REVISION: &str = "mistral-vibe-source-backed-v13-core-activity-agent-scope";
+const PARSER_REVISION: &str = "mistral-vibe-source-backed-v14-optional-admission";
 const EVENT_IDENTITY_REVISION: &str = "mistral-vibe-content-occurrence-v1";
 const FALLBACK_FINGERPRINT_DOMAIN: &[u8] = b"ctx.mistral-vibe.fallback-event-fingerprint.v1\0";
 const SOURCE_REVISION_DIGEST_DOMAIN: &[u8] = b"ctx.mistral-vibe.source-revision.v1\0";
@@ -366,19 +370,21 @@ where
     let role = ctx_history_capture_model::normalization::provider_role(Some(role));
     let mut facts = Vec::new();
     if let Some(cwd) = &binding.cwd {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::SessionCwd,
-            value: cwd.clone(),
-        });
+        if let Some(fact) =
+            admit_provider_declared_fact(LiteralFactKind::SessionCwd, cwd.clone(), facts.len())
+        {
+            facts.push(fact);
+        }
     }
     if let Some(branch) = &binding.branch {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::Branch,
-            value: branch.clone(),
-        });
+        if let Some(fact) =
+            admit_provider_declared_fact(LiteralFactKind::Branch, branch.clone(), facts.len())
+        {
+            facts.push(fact);
+        }
     }
-    facts.extend(collect_file_facts(&value));
-    let activity = mistral_vibe_activity(&value, event_type, &body, facts)?;
+    collect_file_facts(&value, &mut facts);
+    let activity = mistral_vibe_activity(&value, event_type, &body, facts);
     let mut record = CoreRecord::new_selected(
         event_id,
         binding.session_id,
@@ -416,6 +422,10 @@ where
         JsonlActivityObservedBytes::infer_from_present(),
         MAX_CORE_CONTENT_BYTES,
     );
+    record
+        .content
+        .omit_provider_declared_facts_if_aggregate_exceeds_limit()
+        .map_err(contract)?;
     record
         .content
         .omit_structured_content_if_aggregate_exceeds_limit()
@@ -671,72 +681,6 @@ fn mistral_vibe_output_text(value: &Value) -> Result<Option<String>> {
         }
     };
     Ok(provider_explicit_result_value_text(selected).filter(|text| !text.trim().is_empty()))
-}
-
-fn mistral_vibe_activity(
-    value: &Value,
-    event_type: EventType,
-    body: &str,
-    facts: Vec<ProviderDeclaredFact>,
-) -> Result<Option<CoreActivity>> {
-    let provider_call_id = value
-        .get("tool_call_id")
-        .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
-        .map(TypedKey::utf8)
-        .transpose()
-        .map_err(contract)?;
-    let invocation = if event_type == EventType::ToolCall {
-        value
-            .get("name")
-            .or_else(|| value.get("tool_name"))
-            .and_then(Value::as_str)
-            .filter(|value| !value.is_empty())
-            .map(|tool| ActivityInvocation {
-                protocol: None,
-                server: None,
-                tool: tool.to_owned(),
-                arguments: exact_json_capture(value, &["arguments", "input"]),
-                started_at_unix_ms: None,
-            })
-    } else {
-        None
-    };
-    let result = (event_type == EventType::ToolOutput).then(|| ActivityResult {
-        status: None,
-        completed_at_unix_ms: None,
-        duration_ns: None,
-        text: ActivityTextCapture::Present {
-            value: body.to_owned(),
-        },
-        structured_content: ActivityJsonCapture::Present {
-            value: value.clone(),
-        },
-    });
-    if provider_call_id.is_none() && invocation.is_none() && result.is_none() && facts.is_empty() {
-        return Ok(None);
-    }
-    Ok(Some(CoreActivity {
-        revision: CORE_ACTIVITY_REVISION,
-        provider_call_id,
-        invocation,
-        result,
-        facts,
-    }))
-}
-
-fn exact_json_capture(value: &Value, fields: &[&str]) -> ActivityJsonCapture {
-    let candidates = fields
-        .iter()
-        .filter_map(|field| value.get(*field))
-        .collect::<Vec<_>>();
-    match candidates.as_slice() {
-        [] => ActivityJsonCapture::Absent,
-        [candidate] => ActivityJsonCapture::Present {
-            value: (*candidate).clone(),
-        },
-        _ => ActivityJsonCapture::Unavailable,
-    }
 }
 
 fn provider_native_event_id(value: &Value) -> Option<String> {

--- a/crates/ctx-history-provider-mistral-mux/src/mistral_vibe/native_path/source_backed/activity.rs
+++ b/crates/ctx-history-provider-mistral-mux/src/mistral_vibe/native_path/source_backed/activity.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+pub(super) fn mistral_vibe_activity(
+    value: &Value,
+    event_type: EventType,
+    body: &str,
+    facts: Vec<ProviderDeclaredFact>,
+) -> Option<CoreActivity> {
+    let provider_call_id = admit_optional_provider_call_id(
+        value
+            .get("tool_call_id")
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+    );
+    let invocation = if event_type == EventType::ToolCall && provider_call_id.is_some() {
+        admit_optional_metadata_text(
+            value
+                .get("name")
+                .or_else(|| value.get("tool_name"))
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+        )
+        .map(|tool| ActivityInvocation {
+            protocol: None,
+            server: None,
+            tool,
+            arguments: exact_json_capture(value, &["arguments", "input"]),
+            started_at_unix_ms: None,
+        })
+    } else {
+        None
+    };
+    let result = (event_type == EventType::ToolOutput && provider_call_id.is_some()).then(|| {
+        ActivityResult {
+            status: None,
+            completed_at_unix_ms: None,
+            duration_ns: None,
+            text: ActivityTextCapture::Present {
+                value: body.to_owned(),
+            },
+            structured_content: ActivityJsonCapture::Present {
+                value: value.clone(),
+            },
+        }
+    });
+    (invocation.is_some() || result.is_some() || !facts.is_empty()).then_some(CoreActivity {
+        revision: CORE_ACTIVITY_REVISION,
+        provider_call_id,
+        invocation,
+        result,
+        facts,
+    })
+}
+
+fn exact_json_capture(value: &Value, fields: &[&str]) -> ActivityJsonCapture {
+    let candidates = fields
+        .iter()
+        .filter_map(|field| value.get(*field))
+        .collect::<Vec<_>>();
+    match candidates.as_slice() {
+        [] => ActivityJsonCapture::Absent,
+        [candidate] => ActivityJsonCapture::Present {
+            value: (*candidate).clone(),
+        },
+        _ => ActivityJsonCapture::Unavailable,
+    }
+}

--- a/crates/ctx-history-provider-mistral-mux/src/mux/native_path/source_backed.rs
+++ b/crates/ctx-history-provider-mistral-mux/src/mux/native_path/source_backed.rs
@@ -41,7 +41,7 @@ const LOGICAL_SESSION_KIND: &str = "mux-session";
 const LOGICAL_EVENT_KIND: &str = "mux-event";
 const SOURCE_SCHEMA_VARIANT: &str = "mux-session-tree-source-backed-v2";
 const PARSER_REVISION: &str =
-    "mux-source-backed-v10-core-activity-agent-scope-raw-lineage-fail-closed";
+    "mux-source-backed-v11-core-activity-agent-scope-raw-lineage-fail-closed-optional-admission";
 const EVENT_IDENTITY_REVISION: &str = "mux-content-occurrence-v1";
 const COMPOUND_REVISION_DOMAIN: &[u8] = b"ctx.mux.compound-source.v3\0";
 const PARTIAL_EVENT_SEQUENCE_BASE: u64 = 1_u64 << 62;

--- a/crates/ctx-history-provider-mistral-mux/src/mux/native_path/source_backed/projection.rs
+++ b/crates/ctx-history-provider-mistral-mux/src/mux/native_path/source_backed/projection.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 use ctx_history_capture_model::normalization::provider_value_text;
 use ctx_history_capture_runtime::BaseEventLookup;
 use ctx_history_core::{
+    admit_optional_metadata_text, admit_optional_provider_call_id, admit_provider_declared_fact,
     derive_event_id, ActivityInvocation, ActivityJsonCapture, ActivityResult, ActivityTextCapture,
     AgentScope, CoreActivity, CoreContentPolicyStatus, CoreRecord, EventIdentityInput,
     LiteralFactKind, NativeItemKey, ProviderDeclaredFact, ProviderNativeSessionRelationship,
@@ -165,12 +166,13 @@ where
         }
         let mut facts = Vec::new();
         if let Some(cwd) = &self.binding.metadata.cwd {
-            facts.push(ProviderDeclaredFact {
-                kind: LiteralFactKind::SessionCwd,
-                value: cwd.clone(),
-            });
+            if let Some(fact) =
+                admit_provider_declared_fact(LiteralFactKind::SessionCwd, cwd.clone(), facts.len())
+            {
+                facts.push(fact);
+            }
         }
-        let activity = mux_activity(&row.value, facts).map_err(contract)?;
+        let activity = mux_activity(&row.value, facts);
         let mut record = CoreRecord::new_selected(
             event_id,
             self.binding.session_id,
@@ -223,6 +225,10 @@ where
             );
             record
                 .content
+                .omit_provider_declared_facts_if_aggregate_exceeds_limit()
+                .map_err(contract)?;
+            record
+                .content
                 .omit_structured_content_if_aggregate_exceeds_limit()
                 .map_err(contract)?;
         }
@@ -231,7 +237,7 @@ where
     }
 }
 
-fn mux_activity(value: &Value, facts: Vec<ProviderDeclaredFact>) -> Result<Option<CoreActivity>> {
+fn mux_activity(value: &Value, facts: Vec<ProviderDeclaredFact>) -> Option<CoreActivity> {
     let dynamic_parts = value
         .get("parts")
         .and_then(Value::as_array)
@@ -240,13 +246,13 @@ fn mux_activity(value: &Value, facts: Vec<ProviderDeclaredFact>) -> Result<Optio
         .filter(|part| part.get("type").and_then(Value::as_str) == Some("dynamic-tool"))
         .collect::<Vec<_>>();
     let [part] = dynamic_parts.as_slice() else {
-        return Ok((!facts.is_empty()).then_some(CoreActivity {
+        return (!facts.is_empty()).then_some(CoreActivity {
             revision: CORE_ACTIVITY_REVISION,
             provider_call_id: None,
             invocation: None,
             result: None,
             facts,
-        }));
+        });
     };
     let call_ids = [
         "toolCallId",
@@ -260,19 +266,23 @@ fn mux_activity(value: &Value, facts: Vec<ProviderDeclaredFact>) -> Result<Optio
     .into_iter()
     .filter_map(|field| part.get(field).and_then(Value::as_str))
     .collect::<Vec<_>>();
-    let provider_call_id = match call_ids.as_slice() {
-        [id] if !id.is_empty() => Some(TypedKey::utf8(*id).map_err(contract)?),
+    let provider_call_id = admit_optional_provider_call_id(match call_ids.as_slice() {
+        [id] => Some((*id).to_owned()),
         _ => None,
-    };
+    });
     let tool = ["toolName", "tool_name", "name"]
         .into_iter()
         .filter_map(|field| part.get(field).and_then(Value::as_str))
         .collect::<Vec<_>>();
-    let invocation = match tool.as_slice() {
-        [tool] if !tool.is_empty() => Some(ActivityInvocation {
+    let tool = admit_optional_metadata_text(match tool.as_slice() {
+        [tool] => Some((*tool).to_owned()),
+        _ => None,
+    });
+    let invocation = if provider_call_id.is_some() {
+        tool.map(|tool| ActivityInvocation {
             protocol: None,
             server: None,
-            tool: (*tool).to_owned(),
+            tool,
             arguments: part
                 .get("input")
                 .map_or(ActivityJsonCapture::Absent, |value| {
@@ -281,11 +291,14 @@ fn mux_activity(value: &Value, facts: Vec<ProviderDeclaredFact>) -> Result<Optio
                     }
                 }),
             started_at_unix_ms: None,
-        }),
-        _ => None,
+        })
+    } else {
+        None
     };
     let output_redacted = part.get("state").and_then(Value::as_str) == Some("output-redacted");
-    let result = if output_redacted {
+    let result = if provider_call_id.is_none() {
+        None
+    } else if output_redacted {
         Some(ActivityResult {
             status: None,
             completed_at_unix_ms: None,
@@ -310,13 +323,16 @@ fn mux_activity(value: &Value, facts: Vec<ProviderDeclaredFact>) -> Result<Optio
             },
         })
     };
-    Ok(Some(CoreActivity {
+    if invocation.is_none() && result.is_none() && facts.is_empty() {
+        return None;
+    }
+    Some(CoreActivity {
         revision: CORE_ACTIVITY_REVISION,
         provider_call_id,
         invocation,
         result,
         facts,
-    }))
+    })
 }
 
 pub(super) struct MuxJsonlProjector<B: ProviderRuntimeBinding> {
@@ -651,6 +667,37 @@ mod tests {
             .unwrap();
         assert_eq!(emitted.len(), 1);
         emitted.pop().unwrap()
+    }
+
+    #[test]
+    fn optional_dynamic_tool_metadata_abstains_without_losing_valid_result_content() {
+        let oversized = "x".repeat(64 * 1024 + 1);
+        let invalid_id = serde_json::json!({
+            "parts": [{
+                "type": "dynamic-tool",
+                "toolCallId": oversized,
+                "toolName": "shell",
+                "output": {"exact": true},
+            }]
+        });
+        assert_eq!(mux_activity(&invalid_id, Vec::new()), None);
+
+        let invalid_tool = serde_json::json!({
+            "parts": [{
+                "type": "dynamic-tool",
+                "toolCallId": "call-1",
+                "toolName": "x".repeat(64 * 1024 + 1),
+                "output": {"exact": true},
+            }]
+        });
+        let activity = mux_activity(&invalid_tool, Vec::new()).unwrap();
+        assert!(activity.invocation.is_none());
+        assert_eq!(
+            activity.result.unwrap().structured_content,
+            ActivityJsonCapture::Present {
+                value: serde_json::json!({"exact": true}),
+            }
+        );
     }
 
     #[test]

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/antigravity.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/antigravity.rs
@@ -2,7 +2,7 @@ use ctx_history_core::CaptureProvider;
 
 use crate::{NativeJsonlRuntime, ANTIGRAVITY_CLI_SOURCE_FORMAT};
 
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v5-core-activity";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v6-optional-activity-admission";
 
 pub const fn antigravity_source_backed_adapter<R: NativeJsonlRuntime>(
 ) -> super::DirectJsonlFamilyAdapter<R> {

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/copilot.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/copilot.rs
@@ -10,12 +10,12 @@ use serde_json::{value::RawValue, Map, Number, Value};
 use crate::{NativeJsonlRuntime, COPILOT_CLI_SOURCE_FORMAT};
 
 pub(super) const COPILOT_DIRECT_NATIVE_JSONL_PARSER_REVISION: &str =
-    "copilot-cli-direct-native-jsonl-v7-core-activity";
+    "copilot-cli-direct-native-jsonl-v8-optional-activity-admission";
 
 const COPILOT_EVENT_TYPE_MAX_BYTES: usize = 64;
 const COPILOT_CALL_ID_MAX_BYTES: usize = 64 * 1024;
 const COPILOT_ACTIVITY_COMPONENT_MAX_BYTES: usize = 64 * 1024;
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v5-core-activity";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v6-optional-activity-admission";
 
 pub const fn copilot_source_backed_adapter<R: NativeJsonlRuntime>(
 ) -> super::DirectJsonlFamilyAdapter<R> {

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/factory_ai_droid.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/factory_ai_droid.rs
@@ -13,7 +13,7 @@ use super::super::result_content::{
     extract_direct_result_content, NativeJsonlResultExtractionError, NativeJsonlResultSubrecord,
 };
 
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v5-core-activity";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v6-optional-activity-admission";
 
 pub const fn factory_droid_source_backed_adapter<R: NativeJsonlRuntime>(
 ) -> super::DirectJsonlFamilyAdapter<R> {

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/grok_build.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/grok_build.rs
@@ -9,7 +9,7 @@ use crate::NativeJsonlRuntime;
 
 pub const GROK_BUILD_SOURCE_FORMAT: &str = "grok_build_session_updates_jsonl";
 
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v7-grok-closed-content";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v8-grok-closed-content-admission";
 
 pub const fn grok_build_source_backed_adapter<R: NativeJsonlRuntime>(
 ) -> super::DirectJsonlFamilyAdapter<R> {

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/qoder.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/qoder.rs
@@ -2,7 +2,7 @@ use ctx_history_core::CaptureProvider;
 
 use crate::{NativeJsonlRuntime, QODER_SOURCE_FORMAT};
 
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v5-core-activity";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v6-optional-activity-admission";
 
 pub const fn qoder_source_backed_adapter<R: NativeJsonlRuntime>(
 ) -> super::DirectJsonlFamilyAdapter<R> {

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/qwen_code.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/qwen_code.rs
@@ -11,7 +11,7 @@ use super::super::result_content::{
     extract_direct_result_content, NativeJsonlResultExtractionError, NativeJsonlResultSubrecord,
 };
 
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v5-core-activity";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v6-optional-activity-admission";
 
 pub const fn qwen_code_source_backed_adapter<R: NativeJsonlRuntime>(
 ) -> super::DirectJsonlFamilyAdapter<R> {

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/reader.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/reader.rs
@@ -2,8 +2,9 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use ctx_history_core::{
-    ActivityJsonCapture, ActivityResult, ActivityTextCapture, CaptureProvider, CoreActivity,
-    EventType, TypedKey, CORE_ACTIVITY_REVISION,
+    admit_optional_provider_call_id, admit_provider_declared_fact, ActivityJsonCapture,
+    ActivityResult, ActivityTextCapture, CaptureProvider, CoreActivity, EventType,
+    CORE_ACTIVITY_REVISION,
 };
 use serde_json::{json, Value};
 

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/reader_projection.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/reader_projection.rs
@@ -299,11 +299,11 @@ fn native_result_activity(
     subrecord: &NativeJsonlResultSubrecord<'_>,
     native_value: &Value,
 ) -> Result<Option<CoreActivity>> {
-    let provider_call_id = subrecord
-        .call_id
-        .map(TypedKey::utf8)
-        .transpose()
-        .map_err(|error| CaptureError::InvalidPayload(error.to_string()))?;
+    let Some(provider_call_id) =
+        admit_optional_provider_call_id(subrecord.call_id.map(str::to_owned))
+    else {
+        return Ok(None);
+    };
     let text = if subrecord.content.is_some() {
         ActivityTextCapture::NormalizedBody
     } else {
@@ -311,7 +311,7 @@ fn native_result_activity(
     };
     Ok(Some(CoreActivity {
         revision: CORE_ACTIVITY_REVISION,
-        provider_call_id,
+        provider_call_id: Some(provider_call_id),
         invocation: None,
         result: Some(ActivityResult {
             status: None,
@@ -583,10 +583,9 @@ fn direct_jsonl_event_sequence(raw_ordinal: u64, sub_ordinal: u32) -> Result<u64
 fn direct_jsonl_facts(value: &Value) -> Vec<ctx_history_core::ProviderDeclaredFact> {
     let mut facts = Vec::new();
     visit_literal_file_reference_drafts(value, |draft| {
-        facts.push(ctx_history_core::ProviderDeclaredFact {
-            kind: draft.kind,
-            value: draft.value,
-        });
+        if let Some(fact) = admit_provider_declared_fact(draft.kind, draft.value, facts.len()) {
+            facts.push(fact);
+        }
         Ok::<_, std::convert::Infallible>(())
     })
     .expect("direct JSONL file-reference collection is infallible");

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/source_backed.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/source_backed.rs
@@ -6,10 +6,10 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use ctx_history_core::{
-    derive_event_id, derive_native_session_id, CaptureProvider, CoreActivity, CoreRecord,
-    CoreRecordError, EventIdentityInput, LiteralFactKind, NativeItemKey, PositionStability,
-    ProjectionContractError, ProviderDeclaredFact, SourceKey, StableEntityId, SubrecordSelector,
-    TypedKey, CORE_ACTIVITY_REVISION, MAX_CORE_CONTENT_BYTES,
+    admit_provider_declared_fact, derive_event_id, derive_native_session_id, CaptureProvider,
+    CoreActivity, CoreRecord, CoreRecordError, EventIdentityInput, LiteralFactKind, NativeItemKey,
+    PositionStability, ProjectionContractError, ProviderDeclaredFact, SourceKey, StableEntityId,
+    SubrecordSelector, TypedKey, CORE_ACTIVITY_REVISION, MAX_CORE_CONTENT_BYTES,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -762,15 +762,16 @@ fn project_event<R: NativeJsonlRuntime>(
     let mut activity = event.activity;
     let mut facts = Vec::new();
     if let Some(cwd) = &session.cwd {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::SessionCwd,
-            value: cwd.clone(),
-        });
+        push_admitted_fact(&mut facts, LiteralFactKind::SessionCwd, cwd.clone());
     }
     if let Some(activity) = activity.as_mut() {
-        facts.append(&mut activity.facts);
+        for fact in std::mem::take(&mut activity.facts) {
+            push_admitted_fact(&mut facts, fact.kind, fact.value);
+        }
     }
-    facts.extend(event.facts);
+    for fact in event.facts {
+        push_admitted_fact(&mut facts, fact.kind, fact.value);
+    }
     if !facts.is_empty() {
         activity
             .get_or_insert_with(|| CoreActivity {
@@ -782,6 +783,11 @@ fn project_event<R: NativeJsonlRuntime>(
             })
             .facts = facts;
     }
+    if activity.as_ref().is_some_and(|activity| {
+        activity.invocation.is_none() && activity.result.is_none() && activity.facts.is_empty()
+    }) {
+        activity = None;
+    }
     record.content.activity = activity;
     if event.lexical_text.trim().is_empty() {
         record.content.normalized_body = None;
@@ -789,9 +795,18 @@ fn project_event<R: NativeJsonlRuntime>(
     fit_activity_to_content_budget(&mut record)?;
     record
         .content
+        .omit_provider_declared_facts_if_aggregate_exceeds_limit()?;
+    record
+        .content
         .omit_structured_content_if_aggregate_exceeds_limit()?;
     record.validate_contract()?;
     Ok(record)
+}
+
+fn push_admitted_fact(facts: &mut Vec<ProviderDeclaredFact>, kind: LiteralFactKind, value: String) {
+    if let Some(fact) = admit_provider_declared_fact(kind, value, facts.len()) {
+        facts.push(fact);
+    }
 }
 
 fn fit_activity_to_content_budget(record: &mut CoreRecord) -> DirectJsonlAdapterResult<()> {

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/source_backed_result_tests.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/source_backed_result_tests.rs
@@ -279,7 +279,7 @@ fn direct_provider_revision_matrix_matches_the_neutral_projection_and_identity_i
     let parser_cases = [
         (
             CaptureProvider::Antigravity,
-            "direct-native-jsonl-parser-v5-core-activity",
+            "direct-native-jsonl-parser-v6-optional-activity-admission",
         ),
         (
             CaptureProvider::CopilotCli,
@@ -287,27 +287,27 @@ fn direct_provider_revision_matrix_matches_the_neutral_projection_and_identity_i
         ),
         (
             CaptureProvider::FactoryAiDroid,
-            "direct-native-jsonl-parser-v5-core-activity",
+            "direct-native-jsonl-parser-v6-optional-activity-admission",
         ),
         (
             CaptureProvider::GrokBuild,
-            "direct-native-jsonl-parser-v7-grok-closed-content",
+            "direct-native-jsonl-parser-v8-grok-closed-content-admission",
         ),
         (
             CaptureProvider::Qoder,
-            "direct-native-jsonl-parser-v5-core-activity",
+            "direct-native-jsonl-parser-v6-optional-activity-admission",
         ),
         (
             CaptureProvider::QwenCode,
-            "direct-native-jsonl-parser-v5-core-activity",
+            "direct-native-jsonl-parser-v6-optional-activity-admission",
         ),
         (
             CaptureProvider::Tabnine,
-            "direct-native-jsonl-parser-v5-core-activity",
+            "direct-native-jsonl-parser-v6-optional-activity-admission",
         ),
         (
             CaptureProvider::Windsurf,
-            "direct-native-jsonl-parser-v5-core-activity",
+            "direct-native-jsonl-parser-v6-optional-activity-admission",
         ),
     ];
     for (provider, parser_revision) in parser_cases {
@@ -448,7 +448,7 @@ fn copilot_and_windsurf_replay_preserve_current_revision_ids_and_records() {
             "ac4f77cb-6658-8c1d-89fe-6d23fbf96fd0",
             "6c78de65-0cee-8b0c-841f-56d0004e2af8",
             "cb5a35bb-fb49-8701-8739-101eb01c524f",
-            "c03a0ec6949bdfdc9d618552aaedfe4aa750f7b8e66e4e1747bae007fa52defe",
+            "3f61ed135293b4d64d3682911a0e84457c1a5a8633fd9ff24a13ec41a0aa875b",
         ),
         (
             CaptureProvider::CopilotCli,
@@ -461,7 +461,7 @@ fn copilot_and_windsurf_replay_preserve_current_revision_ids_and_records() {
             "c1ebd99c-7338-859b-891d-1c7e04d9ae9d",
             "5ff93a01-4aa3-82f8-8d9e-784490016567",
             "8d4627ce-c12c-8d64-af2d-d85ac722121f",
-            "631b3e2b8f8fc5bac93918763764653e77f0737e29fd3bc9bd0486aa00ffab7e",
+            "242c534cc04212dd8babe58be9810c1c91b3bced3be22056c3bc1ff66e3e9739",
         ),
     ];
 
@@ -471,8 +471,10 @@ fn copilot_and_windsurf_replay_preserve_current_revision_ids_and_records() {
             CaptureProvider::CopilotCli => {
                 super::copilot::COPILOT_DIRECT_NATIVE_JSONL_PARSER_REVISION
             }
-            CaptureProvider::GrokBuild => "direct-native-jsonl-parser-v7-grok-closed-content",
-            _ => "direct-native-jsonl-parser-v5-core-activity",
+            CaptureProvider::GrokBuild => {
+                "direct-native-jsonl-parser-v8-grok-closed-content-admission"
+            }
+            _ => "direct-native-jsonl-parser-v6-optional-activity-admission",
         };
         assert_eq!(
             JsonlFamilyAdapter::parser_revision(&adapter),
@@ -816,6 +818,31 @@ fn supported_family_members_retain_complete_result_bodies_in_core() {
             "{provider:?}"
         );
     }
+}
+
+#[test]
+fn unlinked_native_result_preserves_exact_record_without_empty_activity() {
+    let value = json!({
+        "type": "tool_result",
+        "message": {
+            "role": "tool",
+            "content": [{
+                "type": "tool_result",
+                "name": "shell",
+                "content": "unlinked complete result"
+            }]
+        }
+    });
+
+    let (records, rejected) = project(CaptureProvider::QwenCode, &value);
+
+    assert_eq!(rejected, 0);
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        records[0].content.normalized_body.as_deref(),
+        Some("unlinked complete result")
+    );
+    assert!(records[0].content.activity.is_none());
 }
 
 #[test]

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/tabnine.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/tabnine.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 
 use crate::{NativeJsonlRuntime, TABNINE_CLI_SOURCE_FORMAT};
 
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v5-core-activity";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v6-optional-activity-admission";
 
 pub const fn tabnine_source_backed_adapter<R: NativeJsonlRuntime>(
 ) -> super::DirectJsonlFamilyAdapter<R> {

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/windsurf.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/windsurf.rs
@@ -4,7 +4,7 @@ use ctx_history_core::CaptureProvider;
 
 use crate::{NativeJsonlRuntime, WINDSURF_CASCADE_HOOK_TRANSCRIPT_SOURCE_FORMAT};
 
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v5-core-activity";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v6-optional-activity-admission";
 
 pub(crate) use ctx_history_native_jsonl_parsers::windsurf::{
     event_role as windsurf_event_role, event_text as windsurf_event_text,

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/junie/nativepath/source_backed.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/junie/nativepath/source_backed.rs
@@ -9,6 +9,7 @@ use std::{
 use crate::{provider::source_backed::IndexBaseEventLookup, JsonlProviderRuntime};
 use chrono::{DateTime, Utc};
 use ctx_history_core::{
+    admit_optional_metadata_text, admit_optional_provider_call_id, admit_provider_declared_fact,
     derive_event_id, derive_native_session_id, ActivityInvocation, ActivityJsonCapture,
     ActivityResult, ActivityTextCapture, AgentScope, CaptureProvider, CoreActivity, CoreRecord,
     EventIdentityInput, EventType, LiteralFactKind, NativeItemKey, ProviderDeclaredFact, SourceKey,
@@ -41,7 +42,7 @@ const NATIVE_SESSION_NAMESPACE: &str = "junie.session";
 const LOGICAL_SESSION_KIND: &str = "junie-session";
 const LOGICAL_EVENT_KIND: &str = "junie-event";
 const SOURCE_SCHEMA_VARIANT: &str = "junie-session-events-v2";
-const PARSER_REVISION: &str = "junie-source-backed-v6-core-activity";
+const PARSER_REVISION: &str = "junie-source-backed-v7-optional-activity-admission";
 const EVENT_IDENTITY_REVISION: &str = "junie-content-occurrence-v2";
 const FALLBACK_FINGERPRINT_DOMAIN: &[u8] = b"ctx.junie.fallback-event-fingerprint.v1\0";
 
@@ -310,28 +311,15 @@ fn core_record(
     }
     let mut facts = Vec::new();
     if let Some(workspace) = workspace {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::Workspace,
-            value: workspace.to_owned(),
-        });
+        push_fact(&mut facts, LiteralFactKind::Workspace, workspace.to_owned());
     }
     if let Some(cwd) = cwd {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::SessionCwd,
-            value: cwd.to_owned(),
-        });
+        push_fact(&mut facts, LiteralFactKind::SessionCwd, cwd.to_owned());
     }
     if let Some(change) = &row.file_change {
-        facts.extend(
-            change
-                .paths
-                .iter()
-                .cloned()
-                .map(|value| ProviderDeclaredFact {
-                    kind: LiteralFactKind::File,
-                    value,
-                }),
-        );
+        for path in &change.paths {
+            push_fact(&mut facts, LiteralFactKind::File, path.clone());
+        }
     }
     let activity = junie_activity(&row, facts)?;
     let mut record = CoreRecord::new_selected(
@@ -358,6 +346,10 @@ fn core_record(
         ctx_history_jsonl::JsonlActivityObservedBytes::infer_from_present(),
         MAX_CORE_CONTENT_BYTES,
     );
+    record
+        .content
+        .omit_provider_declared_facts_if_aggregate_exceeds_limit()
+        .map_err(contract)?;
     record
         .content
         .omit_structured_content_if_aggregate_exceeds_limit()
@@ -387,36 +379,37 @@ fn junie_activity(
     row: &EventDraft,
     facts: Vec<ProviderDeclaredFact>,
 ) -> Result<Option<CoreActivity>> {
-    let provider_call_id = row
-        .body
-        .pointer("/provider_native_tool_result/call_id")
-        .or_else(|| row.body.get("provider_step_id"))
-        .and_then(serde_json::Value::as_str)
-        .filter(|value| !value.is_empty())
-        .map(TypedKey::utf8)
-        .transpose()
-        .map_err(contract)?;
-    let invocation = (row.event_type == EventType::ToolCall)
-        .then(|| {
+    let provider_call_id = admit_optional_provider_call_id(
+        row.body
+            .pointer("/provider_native_tool_result/call_id")
+            .or_else(|| row.body.get("provider_step_id"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned),
+    );
+    let invocation = if provider_call_id.is_some() && row.event_type == EventType::ToolCall {
+        admit_optional_metadata_text(
             row.body
                 .get("tool_name")
                 .and_then(serde_json::Value::as_str)
-        })
-        .flatten()
-        .filter(|tool| !tool.is_empty())
+                .map(str::to_owned),
+        )
         .map(|tool| ActivityInvocation {
             protocol: None,
             server: None,
-            tool: tool.to_owned(),
+            tool,
             arguments: ActivityJsonCapture::Present {
                 value: row.body.clone(),
             },
             started_at_unix_ms: None,
-        });
-    let result = matches!(
-        row.event_type,
-        EventType::ToolOutput | EventType::CommandOutput
-    )
+        })
+    } else {
+        None
+    };
+    let result = (provider_call_id.is_some()
+        && matches!(
+            row.event_type,
+            EventType::ToolOutput | EventType::CommandOutput
+        ))
     .then(|| ActivityResult {
         status: None,
         completed_at_unix_ms: None,
@@ -426,7 +419,7 @@ fn junie_activity(
             value: row.body.clone(),
         },
     });
-    if provider_call_id.is_none() && invocation.is_none() && result.is_none() && facts.is_empty() {
+    if invocation.is_none() && result.is_none() && facts.is_empty() {
         return Ok(None);
     }
     Ok(Some(CoreActivity {
@@ -436,6 +429,54 @@ fn junie_activity(
         result,
         facts,
     }))
+}
+
+fn push_fact(facts: &mut Vec<ProviderDeclaredFact>, kind: LiteralFactKind, value: String) {
+    if let Some(fact) = admit_provider_declared_fact(kind, value, facts.len()) {
+        facts.push(fact);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(event_type: EventType, body: serde_json::Value) -> EventDraft {
+        EventDraft {
+            event_index: 0,
+            event_type,
+            role: None,
+            occurred_at: DateTime::<Utc>::UNIX_EPOCH,
+            text: "body".to_owned(),
+            body,
+            file_change: None,
+        }
+    }
+
+    #[test]
+    fn unadmitted_call_id_withholds_linkage_and_empty_activity() {
+        let oversized = "x".repeat(64 * 1024 + 1);
+        let call = row(
+            EventType::ToolCall,
+            serde_json::json!({"provider_step_id": oversized, "tool_name": "Bash"}),
+        );
+        assert_eq!(junie_activity(&call, Vec::new()).unwrap(), None);
+
+        let output = row(
+            EventType::CommandOutput,
+            serde_json::json!({
+                "provider_native_tool_result": {"call_id": oversized},
+            }),
+        );
+        let facts = vec![ProviderDeclaredFact {
+            kind: LiteralFactKind::Command,
+            value: "true".to_owned(),
+        }];
+        let activity = junie_activity(&output, facts.clone()).unwrap().unwrap();
+        assert!(activity.provider_call_id.is_none());
+        assert!(activity.result.is_none());
+        assert_eq!(activity.facts, facts);
+    }
 }
 
 fn decode_binding(leaf: &JsonlFamilyLeaf) -> Result<JunieBinding> {

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/kimi/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/kimi/native_path/source_backed.rs
@@ -19,6 +19,7 @@ use ctx_history_capture_model::file_references::{
     visit_provider_file_reference_drafts_with_limit, MAX_PROVIDER_FILE_REFERENCES_PER_EVENT,
 };
 use ctx_history_core::{
+    admit_optional_metadata_text, admit_optional_provider_call_id, admit_provider_declared_fact,
     derive_event_id, derive_native_session_id, ActivityInvocation, ActivityJsonCapture,
     ActivityResult, ActivityTextCapture, CaptureProvider, CoreActivity, CoreRecord,
     CoreRecordError, EventIdentityInput, EventType, LiteralFactKind, ProjectionContractError,
@@ -60,8 +61,9 @@ const KIMI_SOURCE_ANCHOR_NAMESPACE: &str = "kimi-code-cli-wire-lineage-v1";
 const KIMI_NATIVE_SESSION_NAMESPACE: &str = "kimi-code-cli-session-v1";
 const KIMI_LOGICAL_SESSION_KIND: &str = "agent-session";
 const KIMI_LOGICAL_EVENT_KIND: &str = "wire-event";
-// v5 withholds invocation/result activity when Kimi did not emit an exact call ID.
-const KIMI_SOURCE_PARSER_REVISION: &str = "kimi-code-cli-source-backed-v5-exact-activity-linkage";
+// v6 omits optional activity fields that do not satisfy the Core admission bounds.
+const KIMI_SOURCE_PARSER_REVISION: &str =
+    "kimi-code-cli-source-backed-v6-optional-activity-admission";
 const KIMI_EVENT_IDENTITY_REVISION: &str = "kimi-code-cli-content-occurrence-v1";
 const KIMI_FALLBACK_FINGERPRINT_DOMAIN: &[u8] =
     b"ctx.kimi-code-cli.fallback-event-fingerprint.v1\0";

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/kimi/native_path/source_backed/records.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/kimi/native_path/source_backed/records.rs
@@ -29,7 +29,19 @@ pub(super) fn core_record<R: crate::JsonlProviderRuntime>(
         native_item_key: assignment.native_item_key(),
         subrecord_selector: None,
     })?;
-    let mut facts = kimi_literal_facts(value)?;
+    let mut facts = Vec::new();
+    if let Some(cwd) = &compound.native.session.cwd {
+        if let Some(fact) =
+            admit_provider_declared_fact(LiteralFactKind::SessionCwd, cwd.clone(), facts.len())
+        {
+            facts.push(fact);
+        }
+    }
+    for fact in kimi_literal_facts(value)? {
+        if let Some(fact) = admit_provider_declared_fact(fact.kind, fact.value, facts.len()) {
+            facts.push(fact);
+        }
+    }
     let parent_session_id = compound
         .native
         .session
@@ -44,15 +56,6 @@ pub(super) fn core_record<R: crate::JsonlProviderRuntime>(
         .as_deref()
         .map(lineage_session_identity)
         .transpose()?;
-    if let Some(cwd) = &compound.native.session.cwd {
-        facts.insert(
-            0,
-            ProviderDeclaredFact {
-                kind: LiteralFactKind::SessionCwd,
-                value: cwd.clone(),
-            },
-        );
-    }
     let event = value.get("event").unwrap_or(value);
     let activity = kimi_activity(event, event_type, &body, facts)?;
     let mut record = CoreRecord::new_selected(
@@ -87,6 +90,9 @@ pub(super) fn core_record<R: crate::JsonlProviderRuntime>(
     );
     record
         .content
+        .omit_provider_declared_facts_if_aggregate_exceeds_limit()?;
+    record
+        .content
         .omit_structured_content_if_aggregate_exceeds_limit()?;
     record.validate_contract()?;
     Ok(Some(record))
@@ -103,7 +109,7 @@ fn kimi_activity(
         .filter_map(|field| event.get(field).and_then(Value::as_str))
         .collect::<Vec<_>>();
     let provider_call_id = match call_ids.as_slice() {
-        [id] if !id.is_empty() => Some(TypedKey::utf8(*id)?),
+        [id] => admit_optional_provider_call_id(Some((*id).to_owned())),
         _ => None,
     };
     let tools = ["toolName", "tool_name", "name"]
@@ -112,17 +118,19 @@ fn kimi_activity(
         .collect::<Vec<_>>();
     let invocation = if provider_call_id.is_some() && event_type == EventType::ToolCall {
         match tools.as_slice() {
-            [tool] if !tool.is_empty() => Some(ActivityInvocation {
-                protocol: None,
-                server: None,
-                tool: (*tool).to_owned(),
-                arguments: event.get("args").or_else(|| event.get("arguments")).map_or(
-                    ActivityJsonCapture::Absent,
-                    |value| ActivityJsonCapture::Present {
-                        value: value.clone(),
-                    },
-                ),
-                started_at_unix_ms: None,
+            [tool] => admit_optional_metadata_text(Some((*tool).to_owned())).map(|tool| {
+                ActivityInvocation {
+                    protocol: None,
+                    server: None,
+                    tool,
+                    arguments: event.get("args").or_else(|| event.get("arguments")).map_or(
+                        ActivityJsonCapture::Absent,
+                        |value| ActivityJsonCapture::Present {
+                            value: value.clone(),
+                        },
+                    ),
+                    started_at_unix_ms: None,
+                }
             }),
             _ => None,
         }
@@ -181,10 +189,11 @@ fn kimi_literal_facts(value: &Value) -> KimiSourceBackedResult<Vec<ProviderDecla
         value,
         MAX_PROVIDER_FILE_REFERENCES_PER_EVENT,
         |(_, reference)| {
-            facts.push(ProviderDeclaredFact {
-                kind: reference.kind,
-                value: reference.value,
-            });
+            if let Some(fact) =
+                admit_provider_declared_fact(reference.kind, reference.value, facts.len())
+            {
+                facts.push(fact);
+            }
             Ok::<(), CaptureError>(())
         },
     )?;
@@ -344,6 +353,25 @@ mod tests {
 
         assert_eq!(
             kimi_activity(&event, EventType::ToolCall, "body", Vec::new()).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn unadmitted_optional_linkage_does_not_emit_empty_activity() {
+        let oversized = "x".repeat(64 * 1024 + 1);
+        let output = serde_json::json!({"toolCallId": oversized});
+        assert_eq!(
+            kimi_activity(&output, EventType::ToolOutput, "output", Vec::new()).unwrap(),
+            None
+        );
+
+        let call = serde_json::json!({
+            "toolCallId": "kimi-call-1",
+            "toolName": oversized,
+        });
+        assert_eq!(
+            kimi_activity(&call, EventType::ToolCall, "call", Vec::new()).unwrap(),
             None
         );
     }

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/openclaw/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/openclaw/native_path/source_backed.rs
@@ -50,8 +50,10 @@ const FALLBACK_EVENT_ID_DOMAIN: &[u8] = b"ctx-openclaw-fallback-event-id-v1\0";
 const LOGICAL_SESSION_KIND: &str = "openclaw-legacy-session";
 const LOGICAL_EVENT_KIND: &str = "openclaw-legacy-event";
 const SOURCE_SCHEMA_VARIANT: &str = "openclaw-legacy-jsonl-v2";
-const PARSER_REVISION: &str = "openclaw-source-backed-v15-core-activity-agent-scope-raw-lineage";
+const PARSER_REVISION: &str =
+    "openclaw-source-backed-v17-source-wide-call-id-admission-agent-scope-raw-lineage";
 const MAX_TERMINAL_CALL_IDS: usize = 4096;
+const MAX_TERMINAL_LINKAGE_IDS: usize = MAX_TERMINAL_CALL_IDS * 2;
 const MAX_SELECTOR_CALL_ID_BYTES: usize = 16 * 1024;
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/openclaw/native_path/source_backed/native.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/openclaw/native_path/source_backed/native.rs
@@ -4,6 +4,7 @@ use serde::de::{DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
 use std::fmt;
 
 pub(super) const TERMINAL_CALL_ID_DOMAIN: &[u8] = b"ctx/openclaw/terminal-call-id/v1\0";
+pub(super) const TERMINAL_INVOCATION_ID_DOMAIN: &[u8] = b"ctx/openclaw/terminal-invocation-id/v1\0";
 
 pub(super) type OpenClawTerminalAuthority = JsonlTerminalAuthority;
 
@@ -17,7 +18,7 @@ fn observe_terminal(
             TERMINAL_CALL_ID_DOMAIN,
             call_id,
             region,
-            MAX_TERMINAL_CALL_IDS,
+            MAX_TERMINAL_LINKAGE_IDS,
         );
     }
 }
@@ -33,6 +34,18 @@ pub(super) fn observe_terminal_record(
     let Ok(value) = serde_json::from_slice::<Value>(record) else {
         return;
     };
+    for call in native_tool_calls(&value) {
+        if let Some(call_id) = call.call_id {
+            if !authority.exhausted() && !call_id.is_empty() {
+                authority.observe(
+                    TERMINAL_INVOCATION_ID_DOMAIN,
+                    call_id,
+                    region,
+                    MAX_TERMINAL_LINKAGE_IDS,
+                );
+            }
+        }
+    }
     if let Some(result) = native_tool_result(&value) {
         if result.ambiguous_linkage {
             authority.observe_ambiguous_terminal();

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/openclaw/native_path/source_backed/projection.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/openclaw/native_path/source_backed/projection.rs
@@ -1,5 +1,6 @@
 use super::*;
 use ctx_history_core::{
+    admit_optional_metadata_text, admit_optional_provider_call_id, admit_provider_declared_fact,
     ActivityInvocation, ActivityJsonCapture, ActivityResult, ActivityTextCapture, CoreActivity,
     LiteralFactKind, ProviderDeclaredFact, SubrecordSelector, CORE_ACTIVITY_REVISION,
     MAX_CORE_CONTENT_BYTES,
@@ -69,7 +70,7 @@ impl<R: crate::JsonlProviderRuntime> OpenClawProjector<R> {
             ))?;
         let mut facts = session_facts(&self.session);
         let activity = if let Some(call) = tool_call {
-            facts.extend(call_facts(call));
+            extend_call_facts(&mut facts, call);
             call_activity(call, tool_call_id_is_unique, facts)?
         } else if let Some(result) = tool_result {
             result_activity(
@@ -110,6 +111,10 @@ impl<R: crate::JsonlProviderRuntime> OpenClawProjector<R> {
         );
         record
             .content
+            .omit_provider_declared_facts_if_aggregate_exceeds_limit()
+            .map_err(contract)?;
+        record
+            .content
             .omit_structured_content_if_aggregate_exceeds_limit()
             .map_err(contract)?;
         record.validate_contract().map_err(contract)?;
@@ -120,44 +125,30 @@ impl<R: crate::JsonlProviderRuntime> OpenClawProjector<R> {
 fn session_facts(session: &SessionState) -> Vec<ProviderDeclaredFact> {
     let mut facts = Vec::new();
     if let Some(cwd) = &session.cwd {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::SessionCwd,
-            value: cwd.clone(),
-        });
+        push_fact(&mut facts, LiteralFactKind::SessionCwd, cwd.clone());
     }
     if let Some(branch) = &session.branch {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::Branch,
-            value: branch.clone(),
-        });
+        push_fact(&mut facts, LiteralFactKind::Branch, branch.clone());
     }
     facts
 }
 
-fn call_facts(call: &NativeToolCall<'_>) -> Vec<ProviderDeclaredFact> {
-    let mut facts = Vec::new();
+fn extend_call_facts(facts: &mut Vec<ProviderDeclaredFact>, call: &NativeToolCall<'_>) {
     if let Some(command) = &call.command {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::Command,
-            value: command.clone(),
-        });
+        push_fact(facts, LiteralFactKind::Command, command.clone());
     }
     if let Some(workdir) = &call.declared_workdir {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::ToolWorkdir,
-            value: workdir.clone(),
-        });
+        push_fact(facts, LiteralFactKind::ToolWorkdir, workdir.clone());
     }
-    facts.extend(
-        call.file_references
-            .iter()
-            .cloned()
-            .map(|value| ProviderDeclaredFact {
-                kind: LiteralFactKind::File,
-                value,
-            }),
-    );
-    facts
+    for path in &call.file_references {
+        push_fact(facts, LiteralFactKind::File, path.clone());
+    }
+}
+
+fn push_fact(facts: &mut Vec<ProviderDeclaredFact>, kind: LiteralFactKind, value: String) {
+    if let Some(fact) = admit_provider_declared_fact(kind, value, facts.len()) {
+        facts.push(fact);
+    }
 }
 
 fn call_activity(
@@ -165,19 +156,22 @@ fn call_activity(
     call_id_is_unique: bool,
     facts: Vec<ProviderDeclaredFact>,
 ) -> Result<Option<CoreActivity>> {
-    let provider_call_id = call
-        .call_id
-        .filter(|id| call_id_is_unique && !id.is_empty())
-        .map(TypedKey::utf8)
-        .transpose()
-        .map_err(contract)?;
-    let invocation =
-        call.tool_name
-            .filter(|tool| !tool.is_empty())
-            .map(|tool| ActivityInvocation {
+    if call.call_id.is_some_and(|call_id| !call_id.is_empty()) && !call_id_is_unique {
+        return Err(CaptureError::InvalidPayload(
+            "OpenClaw tool call ID is ambiguous within the source".to_owned(),
+        ));
+    }
+    let provider_call_id = admit_optional_provider_call_id(
+        call.call_id
+            .filter(|_| call_id_is_unique)
+            .map(str::to_owned),
+    );
+    let invocation = provider_call_id.as_ref().and_then(|_| {
+        admit_optional_metadata_text(call.tool_name.map(str::to_owned)).map(|tool| {
+            ActivityInvocation {
                 protocol: None,
                 server: None,
-                tool: tool.to_owned(),
+                tool,
                 arguments: call.block.get("arguments").map_or(
                     ActivityJsonCapture::Absent,
                     |value| ActivityJsonCapture::Present {
@@ -185,14 +179,10 @@ fn call_activity(
                     },
                 ),
                 started_at_unix_ms: None,
-            });
-    Ok(Some(CoreActivity {
-        revision: CORE_ACTIVITY_REVISION,
-        provider_call_id,
-        invocation,
-        result: None,
-        facts,
-    }))
+            }
+        })
+    });
+    Ok(admitted_activity(provider_call_id, invocation, None, facts))
 }
 
 fn result_activity(
@@ -200,35 +190,51 @@ fn result_activity(
     call_id_is_unique: bool,
     facts: Vec<ProviderDeclaredFact>,
 ) -> Result<Option<CoreActivity>> {
-    let provider_call_id = result
-        .call_id
-        .filter(|id| call_id_is_unique && !result.ambiguous_linkage && !id.is_empty())
-        .map(TypedKey::utf8)
-        .transpose()
-        .map_err(contract)?;
-    Ok(Some(CoreActivity {
-        revision: CORE_ACTIVITY_REVISION,
+    if result.call_id.is_some_and(|call_id| !call_id.is_empty())
+        && (!call_id_is_unique || result.ambiguous_linkage)
+    {
+        return Err(CaptureError::InvalidPayload(
+            "OpenClaw tool result call ID is ambiguous within the source".to_owned(),
+        ));
+    }
+    let provider_call_id = admit_optional_provider_call_id(
+        result
+            .call_id
+            .filter(|_| call_id_is_unique && !result.ambiguous_linkage)
+            .map(str::to_owned),
+    );
+    let activity_result = provider_call_id.as_ref().map(|_| ActivityResult {
+        status: None,
+        completed_at_unix_ms: None,
+        duration_ns: None,
+        text: ActivityTextCapture::NormalizedBody,
+        structured_content: ActivityJsonCapture::Present {
+            value: result.output.clone(),
+        },
+    });
+    Ok(admitted_activity(
         provider_call_id,
-        invocation: None,
-        result: Some(ActivityResult {
-            status: None,
-            completed_at_unix_ms: None,
-            duration_ns: None,
-            text: ActivityTextCapture::NormalizedBody,
-            structured_content: ActivityJsonCapture::Present {
-                value: result.output.clone(),
-            },
-        }),
+        None,
+        activity_result,
         facts,
-    }))
+    ))
 }
 
 fn facts_activity(facts: Vec<ProviderDeclaredFact>) -> Option<CoreActivity> {
-    (!facts.is_empty()).then_some(CoreActivity {
+    admitted_activity(None, None, None, facts)
+}
+
+fn admitted_activity(
+    provider_call_id: Option<TypedKey>,
+    invocation: Option<ActivityInvocation>,
+    result: Option<ActivityResult>,
+    facts: Vec<ProviderDeclaredFact>,
+) -> Option<CoreActivity> {
+    (invocation.is_some() || result.is_some() || !facts.is_empty()).then_some(CoreActivity {
         revision: CORE_ACTIVITY_REVISION,
-        provider_call_id: None,
-        invocation: None,
-        result: None,
+        provider_call_id,
+        invocation,
+        result,
         facts,
     })
 }
@@ -321,14 +327,11 @@ impl<R: crate::JsonlProviderRuntime> JsonlFamilyProjector for OpenClawProjector<
         );
         let tool_calls = native_tool_calls(&value);
         if !tool_calls.is_empty() {
-            let mut call_id_counts = HashMap::<&str, usize>::new();
-            for call_id in tool_calls.iter().filter_map(|call| call.call_id) {
-                *call_id_counts.entry(call_id).or_default() += 1;
-            }
             for call in &tool_calls {
-                let unique_call_id = call
-                    .call_id
-                    .is_some_and(|call_id| call_id_counts.get(call_id) == Some(&1));
+                let unique_call_id = call.call_id.is_some_and(|call_id| {
+                    self.terminal_authority
+                        .is_unique(TERMINAL_INVOCATION_ID_DOMAIN, call_id)
+                });
                 let subrecord =
                     tool_call_subrecord(call, unique_call_id, evidence.record_digest())?;
                 self.project_event(
@@ -375,11 +378,11 @@ fn tool_call_subrecord(
     let subordinal = u64::try_from(call.block_index).map_err(|_| {
         CaptureError::SystemInvariant("OpenClaw tool-call block index exceeds platform limits")
     })?;
-    if let Some(call_id) = call
-        .call_id
-        .filter(|call_id| unique_call_id && call_id.len() <= MAX_SELECTOR_CALL_ID_BYTES)
-    {
-        let call_key = TypedKey::utf8(call_id).map_err(contract)?;
+    if let Some(call_key) = admit_optional_provider_call_id(
+        call.call_id
+            .filter(|call_id| unique_call_id && call_id.len() <= MAX_SELECTOR_CALL_ID_BYTES)
+            .map(str::to_owned),
+    ) {
         return Ok((
             SubrecordSelector::native_id(TOOL_CALL_SELECTOR_NAMESPACE, call_key.clone())
                 .map_err(contract)?,

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/pi/nativepath/source_backed.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/pi/nativepath/source_backed.rs
@@ -11,6 +11,7 @@ use std::{
 use crate::{provider::source_backed::IndexBaseEventLookup, JsonlProviderRuntime};
 use chrono::{DateTime, Utc};
 use ctx_history_core::{
+    admit_optional_metadata_text, admit_optional_provider_call_id, admit_provider_declared_fact,
     derive_event_id, derive_native_session_id, ActivityInvocation, ActivityJsonCapture,
     ActivityResult, ActivityTextCapture, AgentScope, CaptureProvider, CoreActivity, CoreRecord,
     EventIdentityInput, EventType, LiteralFactKind, NativeItemKey, ProviderDeclaredFact, SourceKey,
@@ -51,7 +52,7 @@ const NATIVE_EVENT_NAMESPACE: &str = "pi.entry";
 const LOGICAL_SESSION_KIND: &str = "pi-session";
 const LOGICAL_EVENT_KIND: &str = "pi-event";
 const SOURCE_SCHEMA_VARIANT: &str = "pi-nativepath-jsonl-v1";
-const PARSER_REVISION: &str = "pi-shared-jsonl-v7-provider-native-outputs";
+const PARSER_REVISION: &str = "pi-shared-jsonl-v8-optional-activity-admission";
 const EVENT_IDENTITY_REVISION: &str = "pi-content-occurrence-v1";
 const FALLBACK_FINGERPRINT_DOMAIN: &[u8] = b"ctx.pi.fallback-event-fingerprint.v1\0";
 const MAX_TOUCHES_PER_RECORD: usize = 63;
@@ -433,13 +434,11 @@ impl<R: JsonlProviderRuntime> JsonlFamilyProjector for PiProjector<R> {
         .map_err(contract)?;
         let message = value.get("message").unwrap_or(&value);
         if let Some(cwd) = &self.binding.cwd {
-            facts.insert(
-                0,
-                ProviderDeclaredFact {
-                    kind: LiteralFactKind::SessionCwd,
-                    value: cwd.clone(),
-                },
-            );
+            if let Some(fact) =
+                admit_provider_declared_fact(LiteralFactKind::SessionCwd, cwd.clone(), facts.len())
+            {
+                facts.insert(0, fact);
+            }
         }
         let activity = pi_activity(message, event_type, &body, facts)?;
         let mut core = CoreRecord::new_selected(
@@ -478,6 +477,9 @@ impl<R: JsonlProviderRuntime> JsonlFamilyProjector for PiProjector<R> {
             ctx_history_jsonl::JsonlActivityObservedBytes::infer_from_present(),
             MAX_CORE_CONTENT_BYTES,
         );
+        core.content
+            .omit_provider_declared_facts_if_aggregate_exceeds_limit()
+            .map_err(contract)?;
         core.content
             .omit_structured_content_if_aggregate_exceeds_limit()
             .map_err(contract)?;
@@ -614,10 +616,11 @@ fn literal_facts(value: &Value) -> Result<Vec<ProviderDeclaredFact>> {
         value,
         MAX_TOUCHES_PER_RECORD,
         |(_, reference)| {
-            facts.push(ProviderDeclaredFact {
-                kind: reference.kind,
-                value: reference.value,
-            });
+            if let Some(fact) =
+                admit_provider_declared_fact(reference.kind, reference.value, facts.len())
+            {
+                facts.push(fact);
+            }
             Ok::<(), CaptureError>(())
         },
     )?;
@@ -639,7 +642,7 @@ fn pi_activity(
         .filter_map(|field| message.get(field).and_then(Value::as_str))
         .collect::<Vec<_>>();
     let provider_call_id = match call_ids.as_slice() {
-        [id] if !id.is_empty() => Some(TypedKey::utf8(*id).map_err(contract)?),
+        [id] => admit_optional_provider_call_id(Some((*id).to_owned())),
         _ => None,
     };
     let tools = ["toolName", "tool_name", "name"]
@@ -648,18 +651,19 @@ fn pi_activity(
         .collect::<Vec<_>>();
     let invocation = if provider_call_id.is_some() && event_type == EventType::ToolCall {
         match tools.as_slice() {
-            [tool] if !tool.is_empty() => Some(ActivityInvocation {
-                protocol: None,
-                server: None,
-                tool: (*tool).to_owned(),
-                arguments: message
-                    .get("arguments")
-                    .map_or(ActivityJsonCapture::Absent, |value| {
-                        ActivityJsonCapture::Present {
+            [tool] => admit_optional_metadata_text(Some((*tool).to_owned())).map(|tool| {
+                ActivityInvocation {
+                    protocol: None,
+                    server: None,
+                    tool,
+                    arguments: message.get("arguments").map_or(
+                        ActivityJsonCapture::Absent,
+                        |value| ActivityJsonCapture::Present {
                             value: value.clone(),
-                        }
-                    }),
-                started_at_unix_ms: None,
+                        },
+                    ),
+                    started_at_unix_ms: None,
+                }
             }),
             _ => None,
         }
@@ -679,7 +683,7 @@ fn pi_activity(
             value: message.clone(),
         },
     });
-    if provider_call_id.is_none() && invocation.is_none() && result.is_none() && facts.is_empty() {
+    if invocation.is_none() && result.is_none() && facts.is_empty() {
         return Ok(None);
     }
     Ok(Some(CoreActivity {
@@ -815,6 +819,25 @@ mod tests {
         );
         assert!(activity.invocation.is_none());
         assert!(activity.result.is_some());
+    }
+
+    #[test]
+    fn unadmitted_optional_linkage_does_not_emit_empty_activity() {
+        let oversized = "x".repeat(64 * 1024 + 1);
+        let output = serde_json::json!({"toolCallId": oversized});
+        assert_eq!(
+            pi_activity(&output, EventType::ToolOutput, "output", Vec::new()).unwrap(),
+            None
+        );
+
+        let call = serde_json::json!({
+            "toolCallId": "pi-call-1",
+            "toolName": oversized,
+        });
+        assert_eq!(
+            pi_activity(&call, EventType::ToolCall, "call", Vec::new()).unwrap(),
+            None
+        );
     }
 
     #[test]

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/deepagents/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/deepagents/native_path/source_backed.rs
@@ -15,11 +15,12 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use ctx_history_core::{
-    derive_event_id, derive_session_id, ActivityJsonCapture, ActivityResult, ActivityTextCapture,
-    AgentScope, CaptureProvider, CertifiedSource, CoreActivity, CoreRecord, CoreRecordError,
-    EventIdentityInput, LiteralFactKind, NativeItemKey, NativeSessionKey, PositionStability,
-    ProjectionContractError, ProviderDeclaredFact, ScannedSourceCounts, SessionIdentityInput,
-    SourceAnchor, SourceKey, StableEntityId, SubrecordSelector, TypedKey, CORE_ACTIVITY_REVISION,
+    admit_provider_declared_fact, derive_event_id, derive_session_id, ActivityJsonCapture,
+    ActivityResult, ActivityTextCapture, AgentScope, CaptureProvider, CertifiedSource,
+    CoreActivity, CoreRecord, CoreRecordError, EventIdentityInput, LiteralFactKind, NativeItemKey,
+    NativeSessionKey, PositionStability, ProjectionContractError, ScannedSourceCounts,
+    SessionIdentityInput, SourceAnchor, SourceKey, StableEntityId, SubrecordSelector, TypedKey,
+    CORE_ACTIVITY_REVISION,
 };
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -51,7 +52,7 @@ const DEEPAGENTS_SOURCE_ANCHOR_NAMESPACE: &str = "deepagents.sessions";
 const DEEPAGENTS_SOURCE_ANCHOR_KEY: &str = "selected-sessions-db";
 const DEEPAGENTS_SOURCE_SCHEMA_VARIANT: &str = "deepagents-sqlite-write-messages-v0";
 const DEEPAGENTS_SOURCE_PARSER_REVISION: &str =
-    "deepagents-source-backed-v3-neutral-core-agent-scope";
+    "deepagents-source-backed-v4-neutral-core-agent-scope-optional-fact-admission";
 const DEEPAGENTS_NATIVE_SESSION_NAMESPACE: &str = "deepagents.thread";
 const DEEPAGENTS_NATIVE_MESSAGE_NAMESPACE: &str = "deepagents.message";
 const DEEPAGENTS_NATIVE_WRITE_NAMESPACE: &str = "deepagents.write";
@@ -644,16 +645,18 @@ fn deepagents_core_record(
     }));
     let mut facts = Vec::new();
     if let Some(branch) = branch {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::Branch,
-            value: branch.to_owned(),
-        });
+        if let Some(fact) =
+            admit_provider_declared_fact(LiteralFactKind::Branch, branch.to_owned(), facts.len())
+        {
+            facts.push(fact);
+        }
     }
     if let Some(cwd) = cwd {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::SessionCwd,
-            value: cwd.to_owned(),
-        });
+        if let Some(fact) =
+            admit_provider_declared_fact(LiteralFactKind::SessionCwd, cwd.to_owned(), facts.len())
+        {
+            facts.push(fact);
+        }
     }
     let call_id = bounded_linkage(message.tool_call_id.as_deref());
     let result =
@@ -706,6 +709,9 @@ fn deepagents_core_record(
             };
         }
     }
+    record
+        .content
+        .omit_provider_declared_facts_if_aggregate_exceeds_limit()?;
     record
         .content
         .omit_structured_content_if_aggregate_exceeds_limit()?;

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/deepagents/native_path/source_backed/tests.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/deepagents/native_path/source_backed/tests.rs
@@ -102,3 +102,48 @@ fn core_projection_keeps_complete_success_failure_unknown_and_large_results_once
         assert!(structured.to_string().contains(&body));
     }
 }
+
+#[test]
+fn empty_optional_session_facts_do_not_reject_or_create_an_empty_activity() {
+    use chrono::{TimeZone, Utc};
+    use ctx_history_core::EventRole;
+
+    let source = super::deepagents_source_key().unwrap();
+    let key = super::DeepAgentsWriteKey {
+        thread_id: "thread-empty-facts".to_owned(),
+        checkpoint_id: "checkpoint".to_owned(),
+        task_id: "task".to_owned(),
+        idx: 0,
+    };
+    let session_id = super::deepagents_session_id(&source, &key.thread_id).unwrap();
+    let message = super::DeepAgentsMessage {
+        role: EventRole::User,
+        message_type: "human".to_owned(),
+        message_class: Some("HumanMessage".to_owned()),
+        message_id: Some("message-empty-facts".to_owned()),
+        tool_call_id: None,
+        status: None,
+        exit_code: None,
+        duration_ms: None,
+        timed_out: false,
+        is_error: None,
+        success: None,
+        text: "exact DeepAgents body".to_owned(),
+    };
+    let record = super::deepagents_core_record(
+        &source,
+        &key,
+        session_id,
+        1,
+        0,
+        Utc.timestamp_millis_opt(1).unwrap(),
+        Some(""),
+        Some(""),
+        &message,
+    )
+    .unwrap();
+
+    assert_eq!(record.content.meaningful_text(), "exact DeepAgents body");
+    assert!(record.content.activity.is_none());
+    record.validate_contract().unwrap();
+}

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/forgecode/nativepath/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/forgecode/nativepath/source_backed.rs
@@ -12,12 +12,12 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use ctx_history_core::{
+    admit_optional_metadata_text, admit_optional_provider_call_id, admit_provider_declared_fact,
     derive_event_id, derive_session_id, ActivityInvocation, ActivityJsonCapture, ActivityResult,
     ActivityTextCapture, AgentScope, CaptureProvider, CertifiedSource, CoreActivity, CoreRecord,
     CoreRecordError, EventIdentityInput, LiteralFactKind, NativeItemKey, NativeSessionKey,
-    PositionStability, ProjectionContractError, ProviderDeclaredFact, ScannedSourceCounts,
-    SessionIdentityInput, SourceAnchor, SourceKey, StableEntityId, TypedKey,
-    CORE_ACTIVITY_REVISION,
+    PositionStability, ProjectionContractError, ScannedSourceCounts, SessionIdentityInput,
+    SourceAnchor, SourceKey, StableEntityId, TypedKey, CORE_ACTIVITY_REVISION,
 };
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -51,7 +51,7 @@ const FORGECODE_LOGICAL_EVENT_KIND: &str = "forgecode-message";
 const FORGECODE_NATIVE_EVENT_POSITION_KIND: &str = "forgecode-message-index-v1";
 const FORGECODE_RECORD_DIGEST_DOMAIN: &[u8] = b"ctx.forgecode.source-backed-scan-v0\0";
 const FORGECODE_SOURCE_BACKED_PARSER_REVISION: &str =
-    "forgecode-nativepath-source-backed-v2-neutral-core-agent-scope:parser=2;policy=7";
+    "forgecode-nativepath-source-backed-v3-neutral-core-agent-scope-optional-admission:parser=2;policy=7";
 
 #[derive(Debug, Error)]
 pub(crate) enum ForgeCodeSourceBackedErrorV0 {
@@ -268,10 +268,14 @@ fn core_record(
     record.occurred_at_unix_ms = Some(retained.event.occurred_at.timestamp_millis());
     record.role = retained.event.role.map(|role| role.as_str().to_owned());
     record.content.structured_content = structured_content;
-    let facts = vec![ProviderDeclaredFact {
-        kind: LiteralFactKind::Workspace,
-        value: row.workspace_id.to_string(),
-    }];
+    let mut facts = Vec::new();
+    if let Some(fact) = admit_provider_declared_fact(
+        LiteralFactKind::Workspace,
+        row.workspace_id.to_string(),
+        facts.len(),
+    ) {
+        facts.push(fact);
+    }
     let native_entry = record
         .content
         .structured_content
@@ -296,6 +300,9 @@ fn core_record(
             facts,
         });
     }
+    record
+        .content
+        .omit_provider_declared_facts_if_aggregate_exceeds_limit()?;
     record
         .content
         .omit_structured_content_if_aggregate_exceeds_limit()?;
@@ -325,9 +332,17 @@ fn forgecode_activity(
         let [call] = calls.as_slice() else {
             return Ok((None, None, None));
         };
-        let call_id = call.get("call_id").and_then(serde_json::Value::as_str);
-        let tool = call.get("name").and_then(serde_json::Value::as_str);
-        let (Some(call_id), Some(tool)) = (call_id, tool) else {
+        let provider_call_id = admit_optional_provider_call_id(
+            call.get("call_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned),
+        );
+        let tool = admit_optional_metadata_text(
+            call.get("name")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned),
+        );
+        let (Some(provider_call_id), Some(tool)) = (provider_call_id, tool) else {
             return Ok((None, None, None));
         };
         let arguments = call
@@ -336,11 +351,11 @@ fn forgecode_activity(
             .map(|value| ActivityJsonCapture::Present { value })
             .unwrap_or(ActivityJsonCapture::Absent);
         return Ok((
-            Some(TypedKey::utf8(call_id)?),
+            Some(provider_call_id),
             Some(ActivityInvocation {
                 protocol: None,
                 server: None,
-                tool: tool.to_owned(),
+                tool,
                 arguments,
                 started_at_unix_ms: Some(occurred_at_unix_ms),
             }),
@@ -350,22 +365,27 @@ fn forgecode_activity(
     if event_type != ctx_history_core::EventType::ToolOutput {
         return Ok((None, None, None));
     }
-    let call_id = parts
-        .body
-        .get("call_id")
-        .and_then(serde_json::Value::as_str);
-    let Some(call_id) = call_id else {
+    let provider_call_id = admit_optional_provider_call_id(
+        parts
+            .body
+            .get("call_id")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned),
+    );
+    let Some(provider_call_id) = provider_call_id else {
         return Ok((None, None, None));
     };
     Ok((
-        Some(TypedKey::utf8(call_id)?),
+        Some(provider_call_id),
         None,
         Some(ActivityResult {
-            status: parts
-                .body
-                .get("status")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_owned),
+            status: admit_optional_metadata_text(
+                parts
+                    .body
+                    .get("status")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned),
+            ),
             completed_at_unix_ms: Some(occurred_at_unix_ms),
             duration_ns: None,
             text: ActivityTextCapture::NormalizedBody,

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/forgecode/nativepath/source_backed/tests.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/forgecode/nativepath/source_backed/tests.rs
@@ -84,3 +84,46 @@ fn supported_conversations_are_primary_with_exact_native_content() {
     assert_eq!(facts[0].kind, ctx_history_core::LiteralFactKind::Workspace);
     assert_eq!(facts[0].value, "7");
 }
+
+#[test]
+fn optional_activity_metadata_abstains_without_altering_exact_result_content() {
+    let oversized = "x".repeat(64 * 1024 + 1);
+    let invalid_call = serde_json::json!({
+        "text": {"tool_calls": [{"call_id": oversized, "name": "shell"}]},
+    });
+    assert_eq!(
+        super::forgecode_activity(&invalid_call, ctx_history_core::EventType::ToolCall, 0).unwrap(),
+        (None, None, None)
+    );
+
+    let invalid_tool = serde_json::json!({
+        "text": {"tool_calls": [{
+            "call_id": "call-1",
+            "name": "x".repeat(64 * 1024 + 1),
+        }]},
+    });
+    assert_eq!(
+        super::forgecode_activity(&invalid_tool, ctx_history_core::EventType::ToolCall, 0).unwrap(),
+        (None, None, None)
+    );
+
+    let exact_body = serde_json::json!({
+        "call_id": "call-1",
+        "status": "x".repeat(64 * 1024 + 1),
+        "output": {"exact": true},
+    });
+    let output = serde_json::json!({"tool": exact_body.clone()});
+    let (call_id, invocation, result) =
+        super::forgecode_activity(&output, ctx_history_core::EventType::ToolOutput, 1).unwrap();
+    assert_eq!(
+        call_id,
+        Some(ctx_history_core::TypedKey::Utf8("call-1".to_owned()))
+    );
+    assert!(invocation.is_none());
+    let result = result.unwrap();
+    assert_eq!(result.status, None);
+    assert_eq!(
+        result.structured_content,
+        ctx_history_core::ActivityJsonCapture::Present { value: exact_body }
+    );
+}

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed.rs
@@ -43,7 +43,7 @@ use crate::{
 
 const SOURCE_ANCHOR_KEY: &str = "active-database";
 const SOURCE_IDENTITY_VERSION: u32 = 1;
-const PARSER_REVISION: &str = "opencode-family-source-backed-v10-neutral-core";
+const PARSER_REVISION: &str = "opencode-family-source-backed-v11-optional-metadata-admission";
 const LOGICAL_SESSION_KIND: &str = "opencode-family-session";
 const LOGICAL_EVENT_KIND: &str = "opencode-family-event";
 const NATIVE_SESSION_NAMESPACE: &str = "opencode-family.session-id";
@@ -463,10 +463,7 @@ fn stream_logical_rows(
             let disposition = projection_disposition(&event.projection);
             let retained = retained_projection(&event.projection);
             match disposition {
-                ProjectionDisposition::Retained => {
-                    counts.retained_records = checked_add(counts.retained_records, 1)?;
-                    counts.indexed_documents = checked_add(counts.indexed_documents, 1)?;
-                }
+                ProjectionDisposition::Retained => {}
                 ProjectionDisposition::Rejected => {
                     counts.rejected_records = checked_add(counts.rejected_records, 1)?;
                 }
@@ -501,7 +498,7 @@ fn stream_logical_rows(
             let session = current_session.as_ref().ok_or_else(|| {
                 OpenCodeSourceBackedError::MissingSession(event.session_identity.clone())
             })?;
-            let document = core_record(
+            let document = match core_record(
                 source,
                 schema.family,
                 path,
@@ -509,7 +506,19 @@ fn stream_logical_rows(
                 event,
                 retained,
                 &mut next_session_sequence,
-            )?;
+            ) {
+                Ok(document) => document,
+                Err(OpenCodeSourceBackedError::CoreRecord(error)) => {
+                    if !record_local_core_projection_failure(&error) {
+                        return Err(OpenCodeSourceBackedError::CoreRecord(error));
+                    }
+                    counts.rejected_records = checked_add(counts.rejected_records, 1)?;
+                    return Ok(());
+                }
+                Err(error) => return Err(error),
+            };
+            counts.retained_records = checked_add(counts.retained_records, 1)?;
+            counts.indexed_documents = checked_add(counts.indexed_documents, 1)?;
             emit(OpenCodeScanOutput::Document(document))
         };
         stream_fallback_ordered_events(
@@ -548,6 +557,16 @@ fn stream_logical_rows(
             max_buffered_payload_bytes: fallback_stats.max_hydration_batch_bytes,
         },
     })
+}
+
+fn record_local_core_projection_failure(error: &CoreRecordError) -> bool {
+    matches!(
+        error,
+        CoreRecordError::FieldTooLarge {
+            field: "normalized_body" | "structured_content" | "selected_content",
+            ..
+        }
+    )
 }
 
 fn scan_session_evidence(

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/pack_tests.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/pack_tests.rs
@@ -31,6 +31,8 @@ mod temp_authority;
 
 use current_schema::create_current_fixture;
 
+const OVER_LIMIT_OPTIONAL_METADATA_BYTES: usize = 64 * 1024 + 1;
+
 fn write_current_schema(
     path: &Path,
     directory: &Path,
@@ -299,6 +301,169 @@ fn empty_command_fact_does_not_reject_the_opencode_source() {
         .facts
         .iter()
         .any(|fact| fact.kind == LiteralFactKind::Command));
+    record.validate_contract().unwrap();
+}
+
+#[test]
+fn empty_and_oversized_call_ids_omit_dependent_activity_without_losing_content() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let oversized = "c".repeat(OVER_LIMIT_OPTIONAL_METADATA_BYTES);
+    let cases = [
+        (
+            "empty-invocation",
+            json!({
+                "type": "tool",
+                "call_id": "",
+                "tool": "read_file",
+                "state": {"input": {}}
+            }),
+        ),
+        (
+            "oversized-invocation",
+            json!({
+                "type": "tool",
+                "call_id": oversized,
+                "tool": "read_file",
+                "state": {"input": {}}
+            }),
+        ),
+        (
+            "empty-result",
+            json!({
+                "type": "tool_result",
+                "call_id": "",
+                "status": "completed",
+                "output": "exact result"
+            }),
+        ),
+        (
+            "oversized-result",
+            json!({
+                "type": "tool_result",
+                "call_id": "c".repeat(OVER_LIMIT_OPTIONAL_METADATA_BYTES),
+                "status": "completed",
+                "output": "exact result"
+            }),
+        ),
+    ];
+
+    for (label, body) in cases {
+        let database = temp.path().join(format!("{label}-opencode.db"));
+        drop(write_current_schema(&database, temp.path(), &body));
+
+        let (_, _, records) = scan_current_schema(&database);
+        let [record] = records.as_slice() else {
+            panic!("expected {label} to remain a Core record");
+        };
+        assert_eq!(record.content.structured_content.as_ref(), Some(&body));
+        let activity = record.content.activity.as_ref().unwrap();
+        assert!(activity.provider_call_id.is_none());
+        assert!(activity.invocation.is_none());
+        assert!(activity.result.is_none());
+        assert!(!activity.facts.is_empty());
+        record.validate_contract().unwrap();
+    }
+}
+
+#[test]
+fn invalid_call_id_never_publishes_a_summary_after_raw_content_no_longer_fits() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let database = temp.path().join("oversized-invalid-call-opencode.db");
+    let mut body = json!({
+        "type": "tool",
+        "call_id": "",
+        "tool": "read_file",
+        "state": {"input": {"payload": ""}}
+    });
+    let fixed_bytes = body.to_string().len();
+    body["state"]["input"]["payload"] = serde_json::Value::String(
+        "x".repeat(ctx_history_core::MAX_CORE_CONTENT_BYTES - fixed_bytes - 8),
+    );
+    assert_eq!(
+        body.to_string().len(),
+        ctx_history_core::MAX_CORE_CONTENT_BYTES - 8
+    );
+    drop(write_current_schema(&database, temp.path(), &body));
+
+    let (_, scan, records) = scan_current_schema(&database);
+
+    assert!(records.is_empty());
+    let counts = scan.certificate.counts();
+    assert_eq!(counts.complete_records, 1);
+    assert_eq!(counts.retained_records, 0);
+    assert_eq!(counts.rejected_records, 1);
+}
+
+#[test]
+fn empty_and_oversized_activity_metadata_are_omitted_without_losing_content() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let oversized = "m".repeat(OVER_LIMIT_OPTIONAL_METADATA_BYTES);
+
+    for (label, tool) in [
+        ("empty-tool", String::new()),
+        ("oversized-tool", oversized.clone()),
+    ] {
+        let body = json!({
+            "type": "tool",
+            "call_id": format!("call-{label}"),
+            "tool": tool,
+            "state": {"input": {}}
+        });
+        let database = temp.path().join(format!("{label}-opencode.db"));
+        drop(write_current_schema(&database, temp.path(), &body));
+
+        let (_, _, records) = scan_current_schema(&database);
+        let [record] = records.as_slice() else {
+            panic!("expected {label} to remain a Core record");
+        };
+        assert_eq!(record.content.structured_content.as_ref(), Some(&body));
+        let activity = record.content.activity.as_ref().unwrap();
+        assert!(activity.provider_call_id.is_none());
+        assert!(activity.invocation.is_none());
+        assert!(activity.result.is_none());
+        assert!(!activity.facts.is_empty());
+        record.validate_contract().unwrap();
+    }
+
+    for (label, status) in [
+        ("empty-status", String::new()),
+        ("oversized-status", oversized.clone()),
+    ] {
+        let body = json!({
+            "type": "tool_result",
+            "call_id": format!("call-{label}"),
+            "status": status,
+            "output": "exact result"
+        });
+        let database = temp.path().join(format!("{label}-opencode.db"));
+        drop(write_current_schema(&database, temp.path(), &body));
+
+        let (_, _, records) = scan_current_schema(&database);
+        let [record] = records.as_slice() else {
+            panic!("expected {label} to remain a Core record");
+        };
+        assert_eq!(record.content.structured_content.as_ref(), Some(&body));
+        let activity = record.content.activity.as_ref().unwrap();
+        assert!(activity.result.as_ref().unwrap().status.is_none());
+        record.validate_contract().unwrap();
+    }
+
+    let body = json!({
+        "type": "tool_result",
+        "role": oversized,
+        "call_id": "call-oversized-role",
+        "status": "completed",
+        "output": "exact result"
+    });
+    let database = temp.path().join("oversized-role-opencode.db");
+    drop(write_current_schema(&database, temp.path(), &body));
+
+    let (_, _, records) = scan_current_schema(&database);
+    let [record] = records.as_slice() else {
+        panic!("expected oversized role to remain a Core record");
+    };
+    assert_eq!(record.content.structured_content.as_ref(), Some(&body));
+    assert!(record.role.is_none());
     record.validate_contract().unwrap();
 }
 
@@ -1275,4 +1440,24 @@ fn exact_provider_strings_are_not_trimmed_by_helpers() {
         Some("  /literal/path  ")
     );
     assert_eq!(nonempty(String::new()), None);
+}
+
+#[test]
+fn only_payload_content_size_failures_are_record_local() {
+    assert!(record_local_core_projection_failure(
+        &CoreRecordError::FieldTooLarge {
+            field: "selected_content",
+            actual: ctx_history_core::MAX_CORE_CONTENT_BYTES + 1,
+            maximum: ctx_history_core::MAX_CORE_CONTENT_BYTES,
+        }
+    ));
+    assert!(!record_local_core_projection_failure(
+        &CoreRecordError::InvalidIdentityRelationship
+    ));
+    assert!(!record_local_core_projection_failure(
+        &CoreRecordError::InvalidSessionRelationship
+    ));
+    assert!(!record_local_core_projection_failure(
+        &CoreRecordError::InvalidActivity
+    ));
 }

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/projection.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/projection.rs
@@ -1,5 +1,6 @@
 use super::*;
 use ctx_history_core::{
+    admit_optional_metadata_text, admit_optional_provider_call_id, admit_provider_declared_fact,
     ActivityInvocation, ActivityJsonCapture, ActivityResult, ActivityTextCapture, AgentScope,
     CoreActivity, LiteralFactKind, ProviderDeclaredFact, ProviderNativeSessionRelationship,
     CORE_ACTIVITY_REVISION,
@@ -375,7 +376,6 @@ pub(super) fn core_record(
         searchable
     };
     let event_sequence = *next_sequence;
-    *next_sequence = checked_add(*next_sequence, 1)?;
     let mut record = CoreRecord::new_selected(
         event_id,
         session.session_id,
@@ -395,24 +395,27 @@ pub(super) fn core_record(
     record.provider_session_id = Some(session.native_identity.clone());
     record.native_event_id = Some(native_event_id);
     record.occurred_at_unix_ms = Some(normalized_time);
-    record.role = Some(retained.role.clone());
+    record.role = admit_optional_metadata_text(Some(retained.role.clone()));
     record.content.structured_content = Some(retained.body.clone());
     let mut facts = Vec::new();
     if let Some(directory) = session.directory.clone() {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::SessionCwd,
-            value: directory,
-        });
+        if let Some(fact) =
+            admit_provider_declared_fact(LiteralFactKind::SessionCwd, directory, facts.len())
+        {
+            facts.push(fact);
+        }
     }
     if let Some(branch) = session.branch.clone() {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::Branch,
-            value: branch,
-        });
+        if let Some(fact) =
+            admit_provider_declared_fact(LiteralFactKind::Branch, branch, facts.len())
+        {
+            facts.push(fact);
+        }
     }
     collect_opencode_facts(&retained.body, &mut facts);
     let (provider_call_id, invocation, result) =
-        opencode_activity(kind, &retained.body, normalized_time)?;
+        opencode_activity(kind, &retained.body, normalized_time);
+    let retained_linked_activity = invocation.is_some() || result.is_some();
     if invocation.is_some() || result.is_some() || !facts.is_empty() {
         record.content.activity = Some(CoreActivity {
             revision: CORE_ACTIVITY_REVISION,
@@ -424,8 +427,18 @@ pub(super) fn core_record(
     }
     record
         .content
-        .omit_structured_content_if_aggregate_exceeds_limit()?;
+        .omit_provider_declared_facts_if_aggregate_exceeds_limit()?;
+    if !matches!(
+        kind,
+        OpenCodeNativeEventKind::ToolCall | OpenCodeNativeEventKind::ToolOutput
+    ) || retained_linked_activity
+    {
+        record
+            .content
+            .omit_structured_content_if_aggregate_exceeds_limit()?;
+    }
     record.validate_contract()?;
+    *next_sequence = checked_add(*next_sequence, 1)?;
     Ok(record)
 }
 
@@ -494,11 +507,10 @@ fn collect_opencode_fact_values(
         return;
     }
     match value {
-        serde_json::Value::String(value) if !value.is_empty() => {
-            facts.push(ProviderDeclaredFact {
-                kind,
-                value: value.clone(),
-            });
+        serde_json::Value::String(value) => {
+            if let Some(fact) = admit_provider_declared_fact(kind, value.clone(), facts.len()) {
+                facts.push(fact);
+            }
         }
         serde_json::Value::Array(values) => {
             for value in values {
@@ -513,12 +525,12 @@ fn opencode_activity(
     kind: OpenCodeNativeEventKind,
     body: &serde_json::Value,
     occurred_at_unix_ms: i64,
-) -> OpenCodeSourceBackedResult<(
+) -> (
     Option<TypedKey>,
     Option<ActivityInvocation>,
     Option<ActivityResult>,
-)> {
-    let call_id = unique_opencode_string(
+) {
+    let provider_call_id = admit_optional_provider_call_id(unique_opencode_string(
         body,
         &[
             "/call_id",
@@ -530,20 +542,22 @@ fn opencode_activity(
             "/state/callId",
             "/id",
         ],
-    );
-    let Some(call_id) = call_id else {
-        return Ok((None, None, None));
+    ));
+    let Some(provider_call_id) = provider_call_id else {
+        return (None, None, None);
     };
-    let provider_call_id = Some(TypedKey::utf8(&call_id)?);
     if kind == OpenCodeNativeEventKind::ToolCall {
-        let tool = unique_opencode_string(body, &["/tool", "/tool_name", "/toolName", "/name"]);
+        let tool = admit_optional_metadata_text(unique_opencode_string(
+            body,
+            &["/tool", "/tool_name", "/toolName", "/name"],
+        ));
         let Some(tool) = tool else {
-            return Ok((None, None, None));
+            return (None, None, None);
         };
         let arguments =
             opencode_json_alias_capture(body, &["/state/input", "/input", "/arguments"]);
-        return Ok((
-            provider_call_id,
+        return (
+            Some(provider_call_id),
             Some(ActivityInvocation {
                 protocol: None,
                 server: None,
@@ -552,19 +566,19 @@ fn opencode_activity(
                 started_at_unix_ms: Some(occurred_at_unix_ms),
             }),
             None,
-        ));
+        );
     }
     if kind != OpenCodeNativeEventKind::ToolOutput {
-        return Ok((None, None, None));
+        return (None, None, None);
     }
-    Ok((
-        provider_call_id,
+    (
+        Some(provider_call_id),
         None,
         Some(ActivityResult {
-            status: unique_opencode_string(
+            status: admit_optional_metadata_text(unique_opencode_string(
                 body,
                 &["/state/status", "/status", "/state/outcome", "/outcome"],
-            ),
+            )),
             completed_at_unix_ms: Some(occurred_at_unix_ms),
             duration_ns: None,
             text: ActivityTextCapture::NormalizedBody,
@@ -572,7 +586,7 @@ fn opencode_activity(
                 value: body.clone(),
             },
         }),
-    ))
+    )
 }
 
 fn unique_opencode_string(body: &serde_json::Value, pointers: &[&str]) -> Option<String> {
@@ -622,6 +636,41 @@ mod tests {
             Some("call-valid".to_owned())
         );
         assert_eq!(unique_opencode_string(&body, &["/callID"]), None);
+    }
+
+    #[test]
+    fn fact_admission_uses_value_bounds_and_current_fact_count() {
+        let values = serde_json::json!([
+            "",
+            "first",
+            "x".repeat(ctx_history_core::MAX_CORE_CONTENT_BYTES + 1),
+            "second"
+        ]);
+        let mut facts = Vec::new();
+        collect_opencode_fact_values(LiteralFactKind::File, &values, &mut facts, usize::MAX);
+        assert_eq!(
+            facts
+                .iter()
+                .map(|fact| fact.value.as_str())
+                .collect::<Vec<_>>(),
+            ["first", "second"]
+        );
+
+        facts.resize(
+            ctx_history_core::MAX_PROVIDER_DECLARED_FACTS,
+            ProviderDeclaredFact {
+                kind: LiteralFactKind::File,
+                value: "retained".to_owned(),
+            },
+        );
+        let count = facts.len();
+        collect_opencode_fact_values(
+            LiteralFactKind::File,
+            &serde_json::json!("withheld"),
+            &mut facts,
+            count + 1,
+        );
+        assert_eq!(facts.len(), count);
     }
 
     #[test]

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/zed/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/zed/native_path/source_backed.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeSet, path::Path};
 
 use ctx_history_core::{
+    admit_optional_metadata_text, admit_optional_provider_call_id, admit_provider_declared_fact,
     derive_event_id, derive_session_id, ActivityInvocation, ActivityJsonCapture, ActivityResult,
     ActivityTextCapture, AgentScope, CaptureProvider, CoreActivity, CoreRecord, CoreRecordError,
     EventIdentityInput, LiteralFactKind, NativeItemKey, NativeSessionKey, PositionStability,
@@ -34,7 +35,7 @@ const ZED_LOGICAL_EVENT_KIND: &str = "zed-thread-event";
 const ZED_SOURCE_SCHEMA_VARIANT: &str = "zed-nativepath-sqlite-v0";
 const ZED_SOURCE_REVISION_KIND: &str = "zed-logical-rows-v1";
 pub(crate) const ZED_PARSER_REVISION: &str =
-    "zed-nativepath-source-backed-v4-neutral-core-agent-scope";
+    "zed-nativepath-source-backed-v5-neutral-core-agent-scope-optional-admission";
 
 #[derive(Debug, Error)]
 pub(crate) enum ZedSourceBackedErrorV0 {
@@ -276,16 +277,20 @@ fn zed_core_record(
     record.content.structured_content = Some(structured_content);
     let mut facts = Vec::new();
     if let Some(cwd) = session.cwd.clone() {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::SessionCwd,
-            value: cwd,
-        });
+        if let Some(fact) =
+            admit_provider_declared_fact(LiteralFactKind::SessionCwd, cwd, facts.len())
+        {
+            facts.push(fact);
+        }
     }
     for folder_path in &session.folder_paths {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::Workspace,
-            value: folder_path.clone(),
-        });
+        if let Some(fact) = admit_provider_declared_fact(
+            LiteralFactKind::Workspace,
+            folder_path.clone(),
+            facts.len(),
+        ) {
+            facts.push(fact);
+        }
     }
     collect_zed_facts(&event.native_content, &mut facts);
     let (provider_call_id, invocation, result) =
@@ -299,6 +304,9 @@ fn zed_core_record(
             facts,
         });
     }
+    record
+        .content
+        .omit_provider_declared_facts_if_aggregate_exceeds_limit()?;
     record
         .content
         .omit_structured_content_if_aggregate_exceeds_limit()?;
@@ -353,10 +361,11 @@ fn collect_zed_fact_values(
         return;
     }
     match value {
-        serde_json::Value::String(value) => facts.push(ProviderDeclaredFact {
-            kind,
-            value: value.clone(),
-        }),
+        serde_json::Value::String(value) => {
+            if let Some(fact) = admit_provider_declared_fact(kind, value.clone(), facts.len()) {
+                facts.push(fact);
+            }
+        }
         serde_json::Value::Array(values) => {
             for value in values {
                 collect_zed_fact_values(kind, value, facts, maximum);
@@ -384,7 +393,10 @@ fn zed_activity(
     {
         return Ok((None, None, None));
     }
-    let provider_call_id = Some(TypedKey::utf8(first_call_id)?);
+    let Some(provider_call_id) = admit_optional_provider_call_id(Some(first_call_id.clone()))
+    else {
+        return Ok((None, None, None));
+    };
     let invocation = event
         .native_content
         .get("content")
@@ -399,10 +411,12 @@ fn zed_activity(
             matching.next().is_none().then_some(selected)
         })
         .and_then(|tool_use| {
-            let tool = tool_use.get("name")?.as_str()?.to_owned();
-            if tool.is_empty() {
-                return None;
-            }
+            let tool = admit_optional_metadata_text(
+                tool_use
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned),
+            )?;
             let arguments = match (tool_use.get("input"), tool_use.get("raw_input")) {
                 (Some(input), Some(raw_input)) if !input.is_null() && !raw_input.is_null() => {
                     ActivityJsonCapture::Unavailable
@@ -429,7 +443,10 @@ fn zed_activity(
         .and_then(serde_json::Value::as_object)
         .and_then(|results| results.get(first_call_id));
     let result = result_value.map(|value| ActivityResult {
-        status: unique_zed_string(value, &["/status", "/output/status"]),
+        status: admit_optional_metadata_text(unique_zed_string(
+            value,
+            &["/status", "/output/status"],
+        )),
         completed_at_unix_ms: Some(occurred_at_unix_ms),
         duration_ns: None,
         text: value
@@ -446,7 +463,7 @@ fn zed_activity(
     if invocation.is_none() && result.is_none() {
         return Ok((None, None, None));
     }
-    Ok((provider_call_id, invocation, result))
+    Ok((Some(provider_call_id), invocation, result))
 }
 
 fn unique_zed_string(value: &serde_json::Value, pointers: &[&str]) -> Option<String> {

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/zed/native_path/source_backed/semantic_tests.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/zed/native_path/source_backed/semantic_tests.rs
@@ -553,3 +553,86 @@ fn zed_conflicting_input_aliases_abstain_and_metadata_paths_do_not_escape() {
         vec!["src/exact.rs"]
     );
 }
+
+#[test]
+fn zed_optional_activity_fields_and_facts_abstain_independently() {
+    let oversized = "x".repeat(64 * 1024 + 1);
+    let invalid_id_event = ZedNativeEvent::from_draft(
+        1,
+        "thread-activity",
+        super::super::model::ZedDecodedCoreEvent {
+            provider_message_id: None,
+            thread_ordinal: 0,
+            message_ordinal: 0,
+            event_type: EventType::ToolCall,
+            role: EventRole::Assistant,
+            occurred_at: "2026-08-16T00:00:00Z".parse().unwrap(),
+            kind: "agent_tool_call",
+            call_ids: vec![oversized.clone()],
+            native_content: serde_json::json!({
+                "content": [{"type": "tool_use", "id": oversized, "name": "read_file"}],
+            }),
+            body: "tool call: read_file".to_owned(),
+        },
+        RecordDigest::from_text("zed invalid optional call id"),
+    )
+    .unwrap();
+    assert_eq!(
+        zed_activity(&invalid_id_event, 0).unwrap(),
+        (None, None, None)
+    );
+
+    let result_event = ZedNativeEvent::from_draft(
+        2,
+        "thread-activity",
+        super::super::model::ZedDecodedCoreEvent {
+            provider_message_id: None,
+            thread_ordinal: 0,
+            message_ordinal: 1,
+            event_type: EventType::ToolOutput,
+            role: EventRole::Tool,
+            occurred_at: "2026-08-16T00:00:01Z".parse().unwrap(),
+            kind: "agent_tool_result",
+            call_ids: vec!["call-1".to_owned()],
+            native_content: serde_json::json!({
+                "content": [{
+                    "type": "tool_use",
+                    "id": "call-1",
+                    "name": "x".repeat(64 * 1024 + 1),
+                    "input": {"path": "src/lib.rs"},
+                }],
+                "tool_results": {
+                    "call-1": {"status": "x".repeat(64 * 1024 + 1), "content": "exact result"},
+                },
+            }),
+            body: "exact result".to_owned(),
+        },
+        RecordDigest::from_text("zed optional metadata"),
+    )
+    .unwrap();
+    let (call_id, invocation, result) = zed_activity(&result_event, 1).unwrap();
+    assert_eq!(call_id, Some(TypedKey::Utf8("call-1".to_owned())));
+    assert!(invocation.is_none());
+    let result = result.unwrap();
+    assert_eq!(result.status, None);
+    assert_eq!(
+        result.text,
+        ActivityTextCapture::Present {
+            value: "exact result".to_owned(),
+        }
+    );
+
+    let mut facts = Vec::new();
+    collect_zed_facts(
+        &serde_json::json!({
+            "content": [{
+                "type": "tool_use",
+                "input": {"path": "", "command": "cargo check"},
+            }],
+        }),
+        &mut facts,
+    );
+    assert_eq!(facts.len(), 1);
+    assert_eq!(facts[0].kind, LiteralFactKind::Command);
+    assert_eq!(facts[0].value, "cargo check");
+}

--- a/crates/ctx-history-providers-task-docs/src/providers/rovodev/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-task-docs/src/providers/rovodev/native_path/source_backed.rs
@@ -16,11 +16,12 @@ use ctx_history_capture_model::normalization::{
     provider_timestamp_from_fields,
 };
 use ctx_history_core::{
+    admit_optional_metadata_text, admit_optional_provider_call_id, admit_provider_declared_fact,
     derive_event_id, derive_session_id, ActivityInvocation, ActivityJsonCapture, ActivityResult,
     ActivityTextCapture, AgentScope, CaptureProvider, CoreActivity, CoreRecord, CoreRecordError,
     EventIdentityInput, EventRole, EventType, LiteralFactKind, NativeItemKey, NativeSessionKey,
-    ProjectionContractError, ProviderDeclaredFact, ScannedSourceCounts, SessionIdentityInput,
-    SourceAnchor, SourceKey, SourceObservation, StableEntityId, TypedKey, CORE_ACTIVITY_REVISION,
+    ProjectionContractError, ScannedSourceCounts, SessionIdentityInput, SourceAnchor, SourceKey,
+    SourceObservation, StableEntityId, TypedKey, CORE_ACTIVITY_REVISION,
 };
 use serde::de::{DeserializeSeed, MapAccess, SeqAccess, Visitor};
 use sha2::{Digest, Sha256};
@@ -53,7 +54,7 @@ const LOGICAL_SESSION_KIND: &str = "rovodev-session";
 const LOGICAL_EVENT_KIND: &str = "rovodev-event";
 const SOURCE_SCHEMA_VARIANT: &str = "rovodev-session-json-tree-v1";
 const SOURCE_REVISION_KIND: &str = "rovodev-session-tree-revision-v1";
-const PARSER_REVISION: &str = "rovodev-source-backed-v5-neutral-activity";
+const PARSER_REVISION: &str = "rovodev-source-backed-v6-core-admission";
 const RELATIVE_CONTEXT_FILE: &str = "session_context.json";
 const MESSAGE_OBJECT_KIND: &str = "message_history";
 const FILE_HASH_BUFFER_BYTES: usize = 64 * 1024;

--- a/crates/ctx-history-providers-task-docs/src/providers/rovodev/native_path/source_backed/document.rs
+++ b/crates/ctx-history-providers-task-docs/src/providers/rovodev/native_path/source_backed/document.rs
@@ -707,16 +707,18 @@ fn core_record(
     record.content.structured_content = Some(raw_message.clone());
     let mut facts = Vec::new();
     if let Some(branch) = branch {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::Branch,
-            value: branch,
-        });
+        if let Some(fact) =
+            admit_provider_declared_fact(LiteralFactKind::Branch, branch, facts.len())
+        {
+            facts.push(fact);
+        }
     }
     if let Some(cwd) = document.cwd.clone() {
-        facts.push(ProviderDeclaredFact {
-            kind: LiteralFactKind::SessionCwd,
-            value: cwd,
-        });
+        if let Some(fact) =
+            admit_provider_declared_fact(LiteralFactKind::SessionCwd, cwd, facts.len())
+        {
+            facts.push(fact);
+        }
     }
     let projected_output = event.output.as_ref();
     let projected_call_id = projected_output.and_then(|output| output.call_id.clone());
@@ -732,21 +734,23 @@ fn core_record(
         ],
     );
     let call_id = exact_owned_string_alias(projected_call_id, known_call_id);
-    let provider_call_id = call_id.as_deref().map(TypedKey::utf8).transpose()?;
+    let provider_call_id = admit_optional_provider_call_id(call_id);
     let invocation = (provider_call_id.is_some() && event.event_type == EventType::ToolCall)
         .then(|| {
-            known_message_string_field(raw_message, &["tool_name", "toolName", "name", "tool"]).map(
-                |tool| ActivityInvocation {
-                    protocol: None,
-                    server: None,
-                    tool,
-                    arguments: known_message_json_alias_capture(
-                        raw_message,
-                        &["arguments", "args", "input", "parameters"],
-                    ),
-                    started_at_unix_ms: Some(event.occurred_at.timestamp_millis()),
-                },
-            )
+            admit_optional_metadata_text(known_message_string_field(
+                raw_message,
+                &["tool_name", "toolName", "name", "tool"],
+            ))
+            .map(|tool| ActivityInvocation {
+                protocol: None,
+                server: None,
+                tool,
+                arguments: known_message_json_alias_capture(
+                    raw_message,
+                    &["arguments", "args", "input", "parameters"],
+                ),
+                started_at_unix_ms: Some(event.occurred_at.timestamp_millis()),
+            })
         })
         .flatten();
     let result = provider_call_id
@@ -754,7 +758,10 @@ fn core_record(
         .then_some(projected_output)
         .flatten()
         .map(|_| ActivityResult {
-            status: rovodev_string_alias(raw_message, &["status", "state", "outcome"]),
+            status: admit_optional_metadata_text(rovodev_string_alias(
+                raw_message,
+                &["status", "state", "outcome"],
+            )),
             completed_at_unix_ms: Some(event.occurred_at.timestamp_millis()),
             duration_ns: None,
             text: if projected_output.is_some_and(|output| output.capture_unavailable) {
@@ -780,6 +787,9 @@ fn core_record(
             facts,
         });
     }
+    record
+        .content
+        .omit_provider_declared_facts_if_aggregate_exceeds_limit()?;
     record
         .content
         .omit_structured_content_if_aggregate_exceeds_limit()?;

--- a/crates/ctx-history-providers-task-docs/src/providers/rovodev/native_path/source_backed/document/result_tests.rs
+++ b/crates/ctx-history-providers-task-docs/src/providers/rovodev/native_path/source_backed/document/result_tests.rs
@@ -13,6 +13,22 @@ fn document() -> PreparedDocument {
     }
 }
 
+fn projected_record(raw_message: &serde_json::Value, document: &PreparedDocument) -> CoreRecord {
+    let provider_session_id = "session".to_owned();
+    let source_key = rovodev_source_key(&provider_session_id).unwrap();
+    let session_id = rovodev_session_identity(&source_key, &provider_session_id).unwrap();
+    let message_id = explicit_message_id(raw_message).unwrap().to_owned();
+    let bound = RovoDevBoundDocument {
+        source_key,
+        provider_session_id,
+        session_id,
+        parent_session_id: None,
+        unique_message_ids: HashSet::from([message_id]),
+    };
+    let event = project_message(raw_message, 0, document).unwrap().unwrap();
+    core_record(&bound, [9; 32], document, raw_message, 0, event).unwrap()
+}
+
 #[test]
 fn typed_tool_results_keep_exact_status_strings_and_large_bodies() {
     for status in [Some("SUCCESS"), Some("failure"), None] {
@@ -108,6 +124,90 @@ fn rovodev_conflicting_id_name_and_argument_aliases_abstain_without_dropping_rec
         ),
         None
     );
+}
+
+#[test]
+fn rovodev_invalid_optional_facts_abstain_without_changing_identity_or_payload() {
+    let raw_message = serde_json::json!({
+        "id": "message-1",
+        "role": "assistant",
+        "content": "retained exact body",
+    });
+    let mut valid_document = document();
+    valid_document.metadata = serde_json::json!({"branch": "main"});
+    valid_document.cwd = Some("/workspace".to_owned());
+    let valid = projected_record(&raw_message, &valid_document);
+    assert_eq!(valid.content.activity.as_ref().unwrap().facts.len(), 2);
+
+    let mut invalid_document = document();
+    invalid_document.metadata = serde_json::json!({"branch": ""});
+    invalid_document.cwd = Some("x".repeat(ctx_history_core::MAX_CORE_CONTENT_BYTES + 1));
+    let invalid = projected_record(&raw_message, &invalid_document);
+
+    assert_eq!(invalid.event_id, valid.event_id);
+    assert_eq!(invalid.native_event_id, valid.native_event_id);
+    assert_eq!(invalid.event_sequence, valid.event_sequence);
+    assert_eq!(
+        invalid.content.structured_content.as_ref(),
+        Some(&raw_message)
+    );
+    assert!(invalid.content.activity.is_none());
+    invalid.validate_contract().unwrap();
+}
+
+#[test]
+fn rovodev_invalid_optional_tool_metadata_abstains_without_empty_activity() {
+    let oversized_metadata = "x".repeat(1024 * 1024);
+    for raw_message in [
+        serde_json::json!({
+            "id": "message-1",
+            "role": "tool",
+            "tool_use_id": "",
+            "content": "retained exact output",
+        }),
+        serde_json::json!({
+            "id": "message-1",
+            "role": "tool_use",
+            "tool_use_id": oversized_metadata.clone(),
+            "name": "read_file",
+            "content": "retained exact invocation",
+        }),
+        serde_json::json!({
+            "id": "message-1",
+            "role": "tool_use",
+            "tool_use_id": "call-1",
+            "name": oversized_metadata.clone(),
+            "content": "retained exact invocation",
+        }),
+    ] {
+        let record = projected_record(&raw_message, &document());
+        assert_eq!(
+            record.content.structured_content.as_ref(),
+            Some(&raw_message)
+        );
+        assert!(record.content.activity.is_none());
+        record.validate_contract().unwrap();
+    }
+
+    let raw_output = serde_json::json!({
+        "id": "message-1",
+        "role": "tool",
+        "tool_use_id": "call-1",
+        "status": oversized_metadata,
+        "content": "retained exact output",
+    });
+    let record = projected_record(&raw_output, &document());
+    let activity = record.content.activity.as_ref().unwrap();
+    assert_eq!(
+        activity.provider_call_id,
+        Some(TypedKey::Utf8("call-1".to_owned()))
+    );
+    assert_eq!(activity.result.as_ref().unwrap().status, None);
+    assert_eq!(
+        record.content.structured_content.as_ref(),
+        Some(&raw_output)
+    );
+    record.validate_contract().unwrap();
 }
 
 #[test]

--- a/crates/ctx-history-read-application/tests/support/search_show/pi_flow.rs
+++ b/crates/ctx-history-read-application/tests/support/search_show/pi_flow.rs
@@ -1,5 +1,5 @@
 const PI_V6_PARSER_REVISION: &str = "pi-shared-jsonl-v6-linked-core-activity";
-const PI_V7_PARSER_REVISION: &str = "pi-shared-jsonl-v7-provider-native-outputs";
+const PI_V8_PARSER_REVISION: &str = "pi-shared-jsonl-v8-optional-activity-admission";
 
 fn pi_parser_revision(data_root: &Path) -> String {
     let index = ctx_history_index::VerifiedIndex::open(data_root.join("search/lexical")).unwrap();
@@ -23,7 +23,7 @@ fn publish_pi_v6_predecessor(data_root: &Path) -> String {
             .iter()
             .find(|certificate| certificate.observation().source().provider() == "pi")
             .expect("published generation must contain the Pi source");
-        assert_eq!(current.parser_revision(), PI_V7_PARSER_REVISION);
+        assert_eq!(current.parser_revision(), PI_V8_PARSER_REVISION);
         (
             current.observation().source().clone(),
             index.manifest().source_routes().to_vec(),
@@ -154,7 +154,7 @@ fn pi_cli_import_search_flow() {
         second["sources"][0]["published_generation"], legacy_generation,
         "an unchanged Pi source must not reuse a v6 projection: {second:#}"
     );
-    assert_eq!(pi_parser_revision(&data_root(&temp)), PI_V7_PARSER_REVISION);
+    assert_eq!(pi_parser_revision(&data_root(&temp)), PI_V8_PARSER_REVISION);
 
     let records = provider_core_records(&data_root(&temp), "pi");
     assert_eq!(provider_core_counts(&data_root(&temp), "pi"), (1, 6));

--- a/docs/mcp-tool-call-attribution-capabilities.json
+++ b/docs/mcp-tool-call-attribution-capabilities.json
@@ -475,7 +475,7 @@
       "provider_id": "copilot_cli", "route": "native_import", "source_format": "copilot_cli_session_events_jsonl", "source_schema": "copilot-cli-direct-native-jsonl-v1",
       "producer_bound": {"kind": "unversioned", "generation": 1, "unknown_generations": "not-qualified"},
       "implementation_source": "crates/ctx-history-provider-native-jsonl/src/native_path/copilot.rs",
-      "parser_revision": "copilot-cli-direct-native-jsonl-v7-core-activity",
+      "parser_revision": "copilot-cli-direct-native-jsonl-v8-optional-activity-admission",
       "suite_id": "ctx-history-provider-native-jsonl::native_unit",
       "conformance_suite": "mcp_attribution_native_jsonl_provider_units",
       "tests": [

--- a/docs/mcp-tool-call-attribution.md
+++ b/docs/mcp-tool-call-attribution.md
@@ -94,7 +94,7 @@ The exact full tuples are:
   runtime writer-version selectors.
 - Copilot CLI `copilot_cli_session_events_jsonl` /
   `copilot-cli-direct-native-jsonl-v1`, parser
-  `copilot-cli-direct-native-jsonl-v7-core-activity`, for strict unversioned
+  `copilot-cli-direct-native-jsonl-v8-optional-activity-admission`, for strict unversioned
   generation 1. Observed versions and the pinned source commit are evidence,
   not runtime admission selectors.
 

--- a/scripts/check_mcp_tool_call_attribution_capabilities_lib.py
+++ b/scripts/check_mcp_tool_call_attribution_capabilities_lib.py
@@ -871,7 +871,7 @@ def validate_public_docs(
         "48 capability lanes: three `exact`, 44 `not-qualified`, and one `excluded`",
         "`codex-nativepath-core-activity-v6-command-output-retrieval-exclusion`",
         "`warp-source-backed-logical-v7-neutral-activity-agent-scope`",
-        "`copilot-cli-direct-native-jsonl-v7-core-activity`",
+        "`copilot-cli-direct-native-jsonl-v8-optional-activity-admission`",
         "`activity.invocation`",
         "`provider_call_id`",
         "`protocol` equal to `mcp`",

--- a/tools/bazel/check_history_provider_mistral_mux_boundary.py
+++ b/tools/bazel/check_history_provider_mistral_mux_boundary.py
@@ -47,6 +47,7 @@ EXPECTED_SOURCES = {
     "mistral_vibe.rs",
     "mistral_vibe/native_path.rs",
     "mistral_vibe/native_path/source_backed.rs",
+    "mistral_vibe/native_path/source_backed/activity.rs",
     "mistral_vibe/schema.rs",
     "mistral_vibe/source.rs",
     "mux.rs",

--- a/tools/bazel/check_history_provider_mistral_mux_boundary_test.py
+++ b/tools/bazel/check_history_provider_mistral_mux_boundary_test.py
@@ -65,6 +65,7 @@ pub fn mux_jsonl_adapter<B>() -> ProviderJsonlRuntime<B> { todo!() }
     "mistral_vibe.rs": "CaptureProvider::MistralVibe\n",
     "mistral_vibe/native_path.rs": "mistral-vibe-content-occurrence-v1\n",
     "mistral_vibe/native_path/source_backed.rs": "ProviderBaseEventLookup<B>\n",
+    "mistral_vibe/native_path/source_backed/activity.rs": "",
     "mistral_vibe/schema.rs": "",
     "mistral_vibe/source.rs": "",
     "mux.rs": "CaptureProvider::Mux\n",


### PR DESCRIPTION
## Summary

- admit optional provider metadata before strict Core validation across source-backed providers
- reject irreparably oversized event payloads at record scope while retaining valid peer records
- preserve prior retained JSONL/document data when a replacement candidate is rejected-only
- keep source mutation, certification regressions, and ambiguous relationship IDs fail-closed
- add cross-provider boundary, warm refresh, parallel JSONL, and append-invariant coverage

No new user-facing flags, schemas, or diagnostic surfaces are introduced.

## Validation

- uncached 12-target Core/runtime/provider/composition/CLI matrix: pass
- focused review regression suites: pass
- formatting, LOC, repository policy, docs contract, and diff checks: pass
- affected-target run: 111 targets passed; the remaining snapshot-reader test also fails on exact `origin/main` SHA `e9c65af6f`, independently reproduced outside this branch

The Mistral ownership gate found by the affected run was updated and passes.