### PR TITLE
feat(terminal): add reusable callout component

### DIFF
--- a/crates/ctx-terminal/src/ui/components/callout.rs
+++ b/crates/ctx-terminal/src/ui/components/callout.rs
@@ -1,0 +1,295 @@
+use super::layout::{display_width, is_copyable_atom, line_width, wrap_line};
+use crate::ui::{glyph::Glyph, Document, Line, RenderContext, Span, Token};
+
+const MAX_WIDTH: usize = 80;
+const MIN_BORDERED_WIDTH: usize = 12;
+const BORDER_OVERHEAD: usize = 4;
+
+/// A bounded human-terminal callout with a semantic title and styled body.
+///
+/// Machine-readable formats must bypass terminal components and write their
+/// selected representation directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Callout<'a> {
+    pub title: &'a str,
+    pub body: &'a Document,
+}
+
+pub fn callout(context: &RenderContext, callout: Callout<'_>) -> Document {
+    let title = Line::styled(callout.title, Token::Heading);
+    let available_width = context.content_width().unwrap_or(MAX_WIDTH).min(MAX_WIDTH);
+    let natural_width = std::iter::once(&title)
+        .chain(callout.body.lines())
+        .map(line_width)
+        .max()
+        .unwrap_or_default()
+        .saturating_add(BORDER_OVERHEAD)
+        .max(MIN_BORDERED_WIDTH);
+    let outer_width = natural_width.min(available_width);
+
+    if outer_width < MIN_BORDERED_WIDTH {
+        return borderless(context, &title, callout.body);
+    }
+    let inner_width = outer_width.saturating_sub(BORDER_OVERHEAD);
+    if std::iter::once(&title)
+        .chain(callout.body.lines())
+        .any(|line| has_oversized_copyable_atom(line, inner_width))
+    {
+        return borderless(context, &title, callout.body);
+    }
+
+    let mut document = Document::from_line(horizontal_border(
+        context,
+        Glyph::BoxTopLeft,
+        Glyph::BoxTopRight,
+        outer_width,
+    ));
+    for line in std::iter::once(&title).chain(callout.body.lines()) {
+        for line in wrap_line(line, Some(inner_width)) {
+            document.push_line(content_line(context, line, inner_width));
+        }
+    }
+    document.push_line(horizontal_border(
+        context,
+        Glyph::BoxBottomLeft,
+        Glyph::BoxBottomRight,
+        outer_width,
+    ));
+    document
+}
+
+fn borderless(context: &RenderContext, title: &Line, body: &Document) -> Document {
+    let mut document = Document::new();
+    for line in std::iter::once(title).chain(body.lines()) {
+        for line in wrap_line(line, context.content_width()) {
+            document.push_line(line);
+        }
+    }
+    document
+}
+
+fn horizontal_border(context: &RenderContext, left: Glyph, right: Glyph, width: usize) -> Line {
+    Line::styled(
+        format!(
+            "{}{}{}",
+            left.render(context),
+            Glyph::Rule.render(context).repeat(width.saturating_sub(2)),
+            right.render(context)
+        ),
+        Token::Label,
+    )
+}
+
+fn content_line(context: &RenderContext, content: Line, width: usize) -> Line {
+    let padding = width.saturating_sub(line_width(&content));
+    let mut line = Line::new()
+        .with(Span::new(Glyph::BoxVertical.render(context), Token::Label))
+        .with(Span::text(" "));
+    for span in content.spans() {
+        line.push(span.clone());
+    }
+    line.push(Span::text(" ".repeat(padding.saturating_add(1))));
+    line.push(Span::new(Glyph::BoxVertical.render(context), Token::Label));
+    line
+}
+
+fn has_oversized_copyable_atom(line: &Line, width: usize) -> bool {
+    if line_width(line) > width
+        && line
+            .spans()
+            .iter()
+            .any(|span| matches!(span.token(), Token::Command | Token::Reference))
+    {
+        return true;
+    }
+    let text: String = line.spans().iter().map(Span::content).collect();
+    text.split_whitespace()
+        .any(|word| is_copyable_atom(word) && display_width(word) > width)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::{ColorMode, StreamKind, TestContext};
+
+    fn context(width: usize) -> RenderContext {
+        RenderContext::for_test(TestContext::tty(StreamKind::Stdout, width))
+    }
+
+    fn body() -> Document {
+        Document::from_line(
+            Line::new()
+                .with(Span::text("Local history remains "))
+                .with(Span::new("on this device", Token::Accent))
+                .with(Span::text(
+                    " while ctx prepares the result. Additional neutral details make this body \
+                     wide enough to exercise the component cap without changing its meaning.",
+                )),
+        )
+    }
+
+    #[test]
+    fn wraps_at_standard_widths_and_caps_wide_callouts() {
+        for width in [32, 48, 80, 120] {
+            let context = context(width);
+            let rendered = callout(
+                &context,
+                Callout {
+                    title: "History stays local",
+                    body: &body(),
+                },
+            );
+            let plain = rendered.render_plain();
+            assert!(plain.starts_with('╭'), "width {width}: {plain}");
+            assert!(plain.trim_end().ends_with('╯'), "width {width}: {plain}");
+            assert!(plain.contains("History stays local"), "width {width}");
+            assert!(plain.contains("Local history remains"), "width {width}");
+            for word in ["on", "this", "device"] {
+                assert!(
+                    plain.split_whitespace().any(|candidate| candidate == word),
+                    "width {width}: {plain}"
+                );
+            }
+            assert!(
+                rendered
+                    .lines()
+                    .iter()
+                    .all(|line| line_width(line) <= width.saturating_sub(1).min(MAX_WIDTH)),
+                "width {width}: {plain}"
+            );
+            if width == 120 {
+                assert_eq!(line_width(&rendered.lines()[0]), MAX_WIDTH, "{plain}");
+            }
+        }
+    }
+
+    #[test]
+    fn uses_ascii_fallback_and_dim_semantic_borders() {
+        let context =
+            RenderContext::for_test(TestContext::tty(StreamKind::Stdout, 48).unicode(false));
+        let document = callout(
+            &context,
+            Callout {
+                title: "A note",
+                body: &Document::from_line(Line::text("Complete static text.")),
+            },
+        );
+
+        let plain = document.render_plain();
+        assert!(plain.starts_with('+'), "{plain}");
+        assert!(plain.contains("+\n| A note"), "{plain}");
+        assert!(plain.trim_end().ends_with('+'), "{plain}");
+        assert!(
+            ['╭', '╮', '╰', '╯', '│']
+                .into_iter()
+                .all(|glyph| !plain.contains(glyph)),
+            "{plain}"
+        );
+        assert_eq!(document.lines()[0].spans()[0].token(), Token::Label);
+        assert_eq!(document.lines()[1].spans()[2].token(), Token::Heading);
+    }
+
+    #[test]
+    fn falls_back_without_losing_narrow_or_copyable_content() {
+        let url = "https://example.test/a/long/opaque/copyable/value";
+        let body = Document::from_line(
+            Line::new()
+                .with(Span::text("Open "))
+                .with(Span::new(url, Token::Reference)),
+        );
+        for context in [context(8), context(32)] {
+            let document = callout(
+                &context,
+                Callout {
+                    title: "Next step",
+                    body: &body,
+                },
+            );
+            let plain = document.render_plain();
+            assert!(!plain.contains('│'), "{plain}");
+            assert!(!plain.contains('|'), "{plain}");
+            assert_eq!(plain.matches(url).count(), 1, "{plain}");
+            let url_span = document
+                .lines()
+                .iter()
+                .flat_map(Line::spans)
+                .find(|span| span.content() == url)
+                .expect("URL span");
+            assert_eq!(url_span.token(), Token::Reference);
+        }
+    }
+
+    #[test]
+    fn semantic_commands_and_references_force_a_complete_borderless_fallback() {
+        for token in [Token::Command, Token::Reference] {
+            let atom = match token {
+                Token::Command => "ctx search an intentionally long multi word command",
+                Token::Reference => "0123456789abcdef0123456789abcdef01234567",
+                _ => unreachable!(),
+            };
+            let body = Document::from_line(Line::styled(atom, token));
+            let document = callout(
+                &context(32),
+                Callout {
+                    title: "Copy this value",
+                    body: &body,
+                },
+            );
+            let plain = document.render_plain();
+
+            assert!(!plain.contains('│'), "{plain}");
+            assert_eq!(plain.matches(atom).count(), 1, "{plain}");
+            let span = document
+                .lines()
+                .iter()
+                .flat_map(Line::spans)
+                .find(|span| span.content() == atom)
+                .expect("semantic atom span");
+            assert_eq!(span.token(), token);
+        }
+    }
+
+    #[test]
+    fn dynamic_values_remain_control_safe() {
+        let attack = "\u{1b}[31mowned\u{1b}[0m\rrewrite\u{0000}\u{0085}\u{009b}2J\nnext\tcell";
+        let body = Document::from_line(Line::styled(attack, Token::Accent));
+        let plain = callout(
+            &context(120),
+            Callout {
+                title: attack,
+                body: &body,
+            },
+        )
+        .render_plain();
+
+        for control in ['\u{1b}', '\r', '\u{0000}', '\u{0085}', '\u{009b}'] {
+            assert!(!plain.contains(control), "{plain:?}");
+        }
+        assert_eq!(plain.matches("\\x1b[31mowned\\x1b[0m").count(), 2);
+        assert_eq!(plain.matches("\\u{009b}2J").count(), 2);
+        assert_eq!(plain.matches("\\nnext\\tcell").count(), 2);
+    }
+
+    #[test]
+    fn redirected_and_ansi_output_remain_complete_and_equivalent() {
+        let context =
+            RenderContext::for_test(TestContext::pipe(StreamKind::Stderr).color(ColorMode::Always));
+        let body = body();
+        let document = callout(
+            &context,
+            Callout {
+                title: "History stays local",
+                body: &body,
+            },
+        );
+        let plain = document.render_plain();
+        let styled = document.render(&context);
+
+        assert!(plain.contains("while ctx prepares the result."));
+        assert_eq!(anstream::adapter::strip_str(&styled).to_string(), plain);
+        assert!(document.lines().iter().any(|line| line
+            .spans()
+            .iter()
+            .any(|span| span.token() == Token::Accent)));
+    }
+}

--- a/crates/ctx-terminal/src/ui/components/layout.rs
+++ b/crates/ctx-terminal/src/ui/components/layout.rs
@@ -1,3 +1,4 @@
+use crate::ui::{Line, Span, Token};
 use unicode_segmentation::UnicodeSegmentation as _;
 use unicode_width::UnicodeWidthStr;
 
@@ -27,6 +28,211 @@ pub(super) fn wrap_text(text: &str, width: Option<usize>) -> Vec<String> {
         wrapped.push(String::new());
     }
     wrapped
+}
+
+pub(super) fn line_width(line: &Line) -> usize {
+    line.spans()
+        .iter()
+        .map(|span| display_width(span.content()))
+        .sum()
+}
+
+pub(super) fn wrap_line(line: &Line, width: Option<usize>) -> Vec<Line> {
+    let Some(width) = width else {
+        return vec![line.clone()];
+    };
+    let width = width.max(1);
+    let chunks = styled_chunks(line);
+    let mut output = Vec::new();
+    let mut current = StyledLine::default();
+    let mut pending_whitespace = None;
+
+    for chunk in chunks {
+        if chunk.whitespace {
+            pending_whitespace = Some(chunk);
+            continue;
+        }
+
+        let separator_width = pending_whitespace
+            .as_ref()
+            .map_or(0, |whitespace| whitespace.width);
+        if current.has_text
+            && current
+                .width
+                .saturating_add(separator_width)
+                .saturating_add(chunk.width)
+                > width
+        {
+            output.push(std::mem::take(&mut current).into_line());
+            if let Some(whitespace) = pending_whitespace.as_mut() {
+                whitespace.consume_wrap_separator();
+            }
+        }
+        if let Some(whitespace) = pending_whitespace.take() {
+            push_wrappable(whitespace.fragments, width, &mut current, &mut output);
+        }
+        if chunk.unbreakable {
+            current.extend(chunk.fragments);
+        } else {
+            push_wrappable(chunk.fragments, width, &mut current, &mut output);
+        }
+    }
+    if let Some(whitespace) = pending_whitespace {
+        push_wrappable(whitespace.fragments, width, &mut current, &mut output);
+    }
+
+    if !current.is_empty() {
+        output.push(current.into_line());
+    }
+    if output.is_empty() {
+        output.push(Line::new());
+    }
+    output
+}
+
+fn push_wrappable(
+    fragments: Vec<StyledFragment>,
+    width: usize,
+    current: &mut StyledLine,
+    output: &mut Vec<Line>,
+) {
+    for fragment in fragments {
+        for grapheme in fragment.text.graphemes(true) {
+            let grapheme_width = display_width(grapheme);
+            if !current.is_empty() && current.width.saturating_add(grapheme_width) > width {
+                output.push(std::mem::take(current).into_line());
+            }
+            current.push(grapheme, fragment.token);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct StyledChunk {
+    fragments: Vec<StyledFragment>,
+    width: usize,
+    whitespace: bool,
+    unbreakable: bool,
+}
+
+impl StyledChunk {
+    fn text(&self) -> String {
+        self.fragments
+            .iter()
+            .map(|fragment| fragment.text.as_str())
+            .collect()
+    }
+
+    fn consume_wrap_separator(&mut self) {
+        let Some(fragment) = self.fragments.first_mut() else {
+            return;
+        };
+        let Some(separator) = fragment.text.graphemes(true).next() else {
+            return;
+        };
+        self.width = self.width.saturating_sub(display_width(separator));
+        fragment.text.drain(..separator.len());
+        if fragment.text.is_empty() {
+            self.fragments.remove(0);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct StyledFragment {
+    text: String,
+    token: Token,
+}
+
+#[derive(Debug, Default)]
+struct StyledLine {
+    fragments: Vec<StyledFragment>,
+    width: usize,
+    has_text: bool,
+}
+
+impl StyledLine {
+    fn is_empty(&self) -> bool {
+        self.fragments.is_empty()
+    }
+
+    fn push(&mut self, text: &str, token: Token) {
+        self.width = self.width.saturating_add(display_width(text));
+        self.has_text |= !text.chars().all(char::is_whitespace);
+        if let Some(fragment) = self.fragments.last_mut().filter(|item| item.token == token) {
+            fragment.text.push_str(text);
+        } else {
+            self.fragments.push(StyledFragment {
+                text: text.to_owned(),
+                token,
+            });
+        }
+    }
+
+    fn extend(&mut self, fragments: Vec<StyledFragment>) {
+        for fragment in fragments {
+            self.push(&fragment.text, fragment.token);
+        }
+    }
+
+    fn into_line(self) -> Line {
+        let mut line = Line::new();
+        for fragment in self.fragments {
+            line.push(Span::new(fragment.text, fragment.token));
+        }
+        line
+    }
+}
+
+fn styled_chunks(line: &Line) -> Vec<StyledChunk> {
+    let mut chunks = Vec::new();
+    let mut atom = StyledLine::default();
+    let mut whitespace = StyledLine::default();
+    for span in line.spans() {
+        if matches!(span.token(), Token::Command | Token::Reference) {
+            flush_chunk(&mut atom, false, &mut chunks);
+            flush_chunk(&mut whitespace, true, &mut chunks);
+            let mut semantic = StyledLine::default();
+            semantic.push(span.content(), span.token());
+            chunks.push(StyledChunk {
+                fragments: semantic.fragments,
+                width: semantic.width,
+                whitespace: false,
+                unbreakable: true,
+            });
+            continue;
+        }
+        for grapheme in span.content().graphemes(true) {
+            if grapheme.chars().all(char::is_whitespace) {
+                flush_chunk(&mut atom, false, &mut chunks);
+                whitespace.push(grapheme, span.token());
+            } else {
+                flush_chunk(&mut whitespace, true, &mut chunks);
+                atom.push(grapheme, span.token());
+            }
+        }
+    }
+    flush_chunk(&mut atom, false, &mut chunks);
+    flush_chunk(&mut whitespace, true, &mut chunks);
+    for chunk in &mut chunks {
+        if !chunk.whitespace {
+            chunk.unbreakable |= is_copyable_atom(&chunk.text());
+        }
+    }
+    chunks
+}
+
+fn flush_chunk(line: &mut StyledLine, whitespace: bool, chunks: &mut Vec<StyledChunk>) {
+    if line.is_empty() {
+        return;
+    }
+    chunks.push(StyledChunk {
+        fragments: std::mem::take(&mut line.fragments),
+        width: std::mem::take(&mut line.width),
+        whitespace,
+        unbreakable: false,
+    });
+    line.has_text = false;
 }
 
 fn wrap_logical_line(line: &str, width: usize, output: &mut Vec<String>) {
@@ -75,7 +281,8 @@ pub fn is_copyable_atom(word: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::wrap_text;
+    use super::{wrap_line, wrap_text};
+    use crate::ui::{Line, Span, Token};
 
     #[test]
     fn wrapping_preserves_graphemes_and_copyable_identifiers() {
@@ -84,5 +291,46 @@ mod tests {
 
         let id = "00000000-0000-0000-0000-000000000001";
         assert_eq!(wrap_text(id, Some(8)), vec![id]);
+    }
+
+    #[test]
+    fn styled_wrapping_preserves_span_tokens_and_authored_whitespace() {
+        let line = Line::new()
+            .with(Span::new("  plain  ", Token::Label))
+            .with(Span::new("styled words  ", Token::Accent));
+
+        let wrapped = wrap_line(&line, Some(80));
+
+        assert_eq!(wrapped, vec![line]);
+        assert_eq!(wrapped[0].spans()[0].token(), Token::Label);
+        assert_eq!(wrapped[0].spans()[1].token(), Token::Accent);
+    }
+
+    #[test]
+    fn semantic_copyable_spans_are_never_split() {
+        for token in [Token::Command, Token::Reference] {
+            let atom = "opaque-copyable-value-without-a-url-shape";
+            let wrapped = wrap_line(&Line::styled(atom, token), Some(8));
+            assert_eq!(wrapped.len(), 1);
+            assert_eq!(wrapped[0].spans()[0].content(), atom);
+            assert_eq!(wrapped[0].spans()[0].token(), token);
+        }
+    }
+
+    #[test]
+    fn wrapping_consumes_one_separator_and_preserves_remaining_space_style() {
+        let line = Line::new()
+            .with(Span::new("  first  ", Token::Label))
+            .with(Span::new("second", Token::Accent));
+
+        let wrapped = wrap_line(&line, Some(8));
+
+        assert_eq!(wrapped.len(), 2);
+        assert_eq!(wrapped[0].spans()[0].content(), "  first");
+        assert_eq!(wrapped[0].spans()[0].token(), Token::Label);
+        assert_eq!(wrapped[1].spans()[0].content(), " ");
+        assert_eq!(wrapped[1].spans()[0].token(), Token::Label);
+        assert_eq!(wrapped[1].spans()[1].content(), "second");
+        assert_eq!(wrapped[1].spans()[1].token(), Token::Accent);
     }
 }

--- a/crates/ctx-terminal/src/ui/components/mod.rs
+++ b/crates/ctx-terminal/src/ui/components/mod.rs
@@ -1,3 +1,4 @@
+mod callout;
 mod diagnostic;
 mod empty_state;
 mod evidence;
@@ -10,6 +11,7 @@ mod refresh_progress;
 mod section;
 mod table;
 
+pub use callout::{callout, Callout};
 pub use diagnostic::{diagnostic, Diagnostic, DiagnosticLevel};
 pub use empty_state::{empty_state, EmptyState};
 pub use evidence::{evidence_list, Evidence};

--- a/crates/ctx-terminal/src/ui/glyph.rs
+++ b/crates/ctx-terminal/src/ui/glyph.rs
@@ -7,6 +7,11 @@ pub(super) enum Glyph {
     Warning,
     Progress,
     Rule,
+    BoxTopLeft,
+    BoxTopRight,
+    BoxBottomLeft,
+    BoxBottomRight,
+    BoxVertical,
 }
 
 impl Glyph {
@@ -21,6 +26,16 @@ impl Glyph {
             (Self::Progress, false) => "=",
             (Self::Rule, true) => "─",
             (Self::Rule, false) => "-",
+            (Self::BoxTopLeft, true) => "╭",
+            (Self::BoxTopLeft, false) => "+",
+            (Self::BoxTopRight, true) => "╮",
+            (Self::BoxTopRight, false) => "+",
+            (Self::BoxBottomLeft, true) => "╰",
+            (Self::BoxBottomLeft, false) => "+",
+            (Self::BoxBottomRight, true) => "╯",
+            (Self::BoxBottomRight, false) => "+",
+            (Self::BoxVertical, true) => "│",
+            (Self::BoxVertical, false) => "|",
         }
     }
 }

--- a/crates/ctx-terminal/src/ui/mod.rs
+++ b/crates/ctx-terminal/src/ui/mod.rs
@@ -14,12 +14,12 @@ mod writer;
 
 pub use bootstrap::{bootstrap_color_choice, scan_color_mode, scan_machine_output_hint};
 pub use components::{
-    diagnostic, display_width, empty_state, evidence_list, fields, hint, is_copyable_atom, outcome,
-    progress, refresh_progress, section, table, Action, Diagnostic, DiagnosticLevel, EmptyState,
-    Evidence, Field, Hint, Outcome, OutcomeState, Progress, RefreshCurrentSourceProgress,
-    RefreshCurrentSourceProgressStage, RefreshLogicalPhase, RefreshLogicalStatus, RefreshProgress,
-    RefreshProgressSnapshot, RefreshRequestState, RefreshStatusKind, RefreshStructuredOutcome,
-    RefreshWholeRunStage, Table,
+    callout, diagnostic, display_width, empty_state, evidence_list, fields, hint, is_copyable_atom,
+    outcome, progress, refresh_progress, section, table, Action, Callout, Diagnostic,
+    DiagnosticLevel, EmptyState, Evidence, Field, Hint, Outcome, OutcomeState, Progress,
+    RefreshCurrentSourceProgress, RefreshCurrentSourceProgressStage, RefreshLogicalPhase,
+    RefreshLogicalStatus, RefreshProgress, RefreshProgressSnapshot, RefreshRequestState,
+    RefreshStatusKind, RefreshStructuredOutcome, RefreshWholeRunStage, Table,
 };
 pub use context::{ColorMode, RenderContext, StreamKind, TestContext};
 pub use document::{sanitize_untrusted_history_body_for_terminal, Document, Line, Span};

--- a/crates/ctx-terminal/src/ui/tests.rs
+++ b/crates/ctx-terminal/src/ui/tests.rs
@@ -8,10 +8,11 @@ use unicode_width::UnicodeWidthStr as _;
 
 use super::{
     bootstrap::{scan_color_mode, scan_machine_output_hint},
-    canonical_human_output_bytes, diagnostic, empty_state, evidence_list, fields, hint, outcome,
-    progress, sanitize_untrusted_history_body_for_terminal, section, table, Action, ColorMode,
-    Diagnostic, DiagnosticLevel, Document, EmptyState, Evidence, Field, Hint, Line, Outcome,
-    OutcomeState, Progress, RenderContext, Span, StreamKind, Table, TestContext, Token, Ui,
+    callout, canonical_human_output_bytes, diagnostic, empty_state, evidence_list, fields, hint,
+    outcome, progress, sanitize_untrusted_history_body_for_terminal, section, table, Action,
+    Callout, ColorMode, Diagnostic, DiagnosticLevel, Document, EmptyState, Evidence, Field, Hint,
+    Line, Outcome, OutcomeState, Progress, RenderContext, Span, StreamKind, Table, TestContext,
+    Token, Ui,
 };
 
 fn tty(width: usize) -> RenderContext {
@@ -311,6 +312,28 @@ fn decorative_glyphs_have_only_the_approved_ascii_fallbacks() {
     .render_plain();
     assert!(indeterminate.contains("========"));
     assert!(indeterminate.contains('-'));
+
+    let callout_body = Document::from_line(Line::text("Complete human output."));
+    let unicode_callout = callout(
+        &unicode,
+        Callout {
+            title: "Note",
+            body: &callout_body,
+        },
+    )
+    .render_plain();
+    let ascii_callout = callout(
+        &ascii,
+        Callout {
+            title: "Note",
+            body: &callout_body,
+        },
+    )
+    .render_plain();
+    assert!(unicode_callout.starts_with('╭'));
+    assert!(unicode_callout.trim_end().ends_with('╯'));
+    assert!(ascii_callout.starts_with('+'));
+    assert!(ascii_callout.trim_end().ends_with('+'));
 }
 
 #[test]
@@ -325,7 +348,19 @@ fn every_component_has_byte_identical_ansi_stripped_and_plain_output() {
     let table_value = Table::new(["Provider", "State"])
         .row(["codex", "ready"])
         .row(["claude", "pending"]);
+    let callout_body = Document::from_line(
+        Line::new()
+            .with(Span::text("Local history remains "))
+            .with(Span::new("on this device", Token::Accent)),
+    );
     let documents = vec![
+        callout(
+            &context,
+            Callout {
+                title: "History stays local",
+                body: &callout_body,
+            },
+        ),
         outcome(
             &context,
             Outcome {


### PR DESCRIPTION
Summary

- add a semantic human-terminal Callout with dim Unicode borders and an ASCII fallback
- cap responsive layouts at 80 columns and fall back borderlessly when a copyable atom cannot fit safely
- preserve authored span styles, whitespace hierarchy, commands, and references while wrapping

Validation

- `scripts/bazelw test //:rustfmt_check //:repository_policy_check //crates/ctx-terminal:unit_tests //crates/ctx-terminal:raw_output_policy_tests --test_output=errors`
- `scripts/bazelw build --config=lint //crates/ctx-terminal:lib //crates/ctx-terminal:unit_tests`