### PR TITLE
Rerender live terminal output after resize

### DIFF
--- a/crates/ctx-cli-presentation/src/commands/index.rs
+++ b/crates/ctx-cli-presentation/src/commands/index.rs
@@ -303,8 +303,8 @@ impl<W: io::Write> IndexWatchOutput<W> {
     }
 
     pub fn print_human(&mut self, status: &Value) -> io::Result<()> {
-        let document = self.dashboard.render(status, self.output.context());
-        self.output.write_frame(&document, false)
+        self.output
+            .render_frame(false, |context| self.dashboard.render(status, context))
     }
 
     #[doc(hidden)]

--- a/crates/ctx-history-cli/src/source_index/tests/additional.rs
+++ b/crates/ctx-history-cli/src/source_index/tests/additional.rs
@@ -917,6 +917,72 @@ fn unbounded_cli_show_streams_valid_json_beyond_4096_events_in_order() {
 }
 
 #[test]
+fn human_cli_show_stream_renders_header_events_empty_and_truncation() {
+    let temp = tempdir().unwrap();
+    write_test_generation(temp.path());
+
+    let events = (1..=2)
+        .map(|sequence| {
+            let event = fixture_event(CaptureProvider::Codex, "codex_session_jsonl", 78, sequence);
+            fixture_core_event(&event, format!("human-event-{sequence}"))
+        })
+        .collect::<Vec<_>>();
+    append_fixture_session(temp.path(), &events, 78);
+    let session = SessionRecord::from(&events[0].event);
+    let (mut ui, stdout) = test_ui();
+
+    let result = stream_cli_session(
+        temp.path(),
+        Some(session.session_id.to_string()),
+        None,
+        None,
+        TranscriptMode::Log,
+        OutputFormat::Text,
+        Some(1),
+        None,
+        &mut ui,
+    )
+    .unwrap();
+    ui.flush().unwrap();
+
+    assert_eq!(result.events_returned, 1);
+    let rendered = String::from_utf8(stdout.bytes()).unwrap();
+    assert!(rendered.contains("Session"));
+    assert!(rendered.contains("human-event-1"));
+    assert!(!rendered.contains("human-event-2"));
+    assert!(rendered.contains("Transcript is truncated."));
+    assert!(rendered.contains("Showing the first 1 events."));
+
+    let mut filtered = fixture_event(CaptureProvider::Codex, "codex_session_jsonl", 79, 1);
+    filtered.event_type = "tool_call".to_owned();
+    filtered.role = None;
+    let filtered = fixture_core_event(&filtered, "filtered-human-event");
+    append_fixture_session(temp.path(), std::slice::from_ref(&filtered), 79);
+    let filtered_session = SessionRecord::from(&filtered.event);
+    let (mut ui, stdout) = test_ui();
+
+    let result = stream_cli_session(
+        temp.path(),
+        Some(filtered_session.session_id.to_string()),
+        None,
+        None,
+        TranscriptMode::Lite,
+        OutputFormat::Text,
+        None,
+        None,
+        &mut ui,
+    )
+    .unwrap();
+    ui.flush().unwrap();
+
+    assert_eq!(result.events_returned, 0);
+    let rendered = String::from_utf8(stdout.bytes()).unwrap();
+    assert!(rendered.contains("Session"));
+    assert!(rendered.contains("No transcript events."));
+    assert!(!rendered.contains("filtered-human-event"));
+}
+
+#[test]
 fn max_events_does_not_claim_truncation_for_only_filtered_raw_events() {
     let temp = tempdir().unwrap();
     write_test_generation(temp.path());

--- a/crates/ctx-terminal/src/progress.rs
+++ b/crates/ctx-terminal/src/progress.rs
@@ -296,14 +296,9 @@ fn run_live_renderer(
                 let terminal = snapshot.is_terminal();
                 let rendered =
                     prepare_live_snapshot((*snapshot).clone(), &mut clock, started.elapsed(), true);
-                let context = *output.context();
-                let document = render_live_refresh(
-                    presentation,
-                    &context,
-                    rendered,
-                    persistent_notice.as_ref(),
-                );
-                let result = output.write_frame(&document, terminal);
+                let result = output.render_frame(terminal, |context| {
+                    render_live_refresh(presentation, context, rendered, persistent_notice.as_ref())
+                });
                 let failed = result.is_err();
                 let _ = complete.send(result);
                 if failed {
@@ -316,25 +311,25 @@ fn run_live_renderer(
             }
             Ok(LiveRenderCommand::Notice { document, complete }) => {
                 persistent_notice = Some(document);
-                let context = *output.context();
-                let document = active.as_ref().map_or_else(
-                    || persistent_notice.as_ref().cloned().unwrap_or_default(),
-                    |snapshot| {
-                        let rendered = prepare_live_snapshot(
-                            snapshot.clone(),
-                            &mut clock,
-                            started.elapsed(),
-                            false,
-                        );
-                        render_live_refresh(
-                            presentation,
-                            &context,
-                            rendered,
-                            persistent_notice.as_ref(),
-                        )
-                    },
-                );
-                let result = output.write_frame(&document, false);
+                let result = output.render_frame(false, |context| {
+                    active.as_ref().map_or_else(
+                        || persistent_notice.as_ref().cloned().unwrap_or_default(),
+                        |snapshot| {
+                            let rendered = prepare_live_snapshot(
+                                snapshot.clone(),
+                                &mut clock,
+                                started.elapsed(),
+                                false,
+                            );
+                            render_live_refresh(
+                                presentation,
+                                &context,
+                                rendered,
+                                persistent_notice.as_ref(),
+                            )
+                        },
+                    )
+                });
                 let failed = result.is_err();
                 let _ = complete.send(result);
                 if failed {
@@ -348,14 +343,9 @@ fn run_live_renderer(
                 };
                 let rendered =
                     prepare_live_snapshot(snapshot.clone(), &mut clock, started.elapsed(), false);
-                let context = *output.context();
-                let document = render_live_refresh(
-                    presentation,
-                    &context,
-                    rendered,
-                    persistent_notice.as_ref(),
-                );
-                if let Err(error) = output.write_frame(&document, false) {
+                if let Err(error) = output.render_frame(false, |context| {
+                    render_live_refresh(presentation, context, rendered, persistent_notice.as_ref())
+                }) {
                     *background_error
                         .lock()
                         .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(error);

--- a/crates/ctx-terminal/src/ui/context.rs
+++ b/crates/ctx-terminal/src/ui/context.rs
@@ -1,4 +1,8 @@
+use std::sync::Arc;
+
 pub const DEFAULT_TERMINAL_WIDTH: usize = 80;
+
+type WidthProbe = Arc<dyn Fn() -> Option<usize> + Send + Sync>;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ColorMode {
@@ -109,9 +113,7 @@ impl RenderContext {
             ColorMode::Never => false,
             ColorMode::Auto => auto_color_enabled,
         };
-        let terminal_width = is_terminal
-            .then_some(terminal_width.unwrap_or(DEFAULT_TERMINAL_WIDTH))
-            .filter(|width| *width > 0);
+        let terminal_width = is_terminal.then(|| resolved_terminal_width(terminal_width));
 
         Self {
             stream,
@@ -149,6 +151,13 @@ impl RenderContext {
         self
     }
 
+    pub(super) fn with_terminal_width(mut self, terminal_width: Option<usize>) -> Self {
+        if self.is_terminal {
+            self.terminal_width = Some(resolved_terminal_width(terminal_width));
+        }
+        self
+    }
+
     pub const fn terminal_width(self) -> Option<usize> {
         self.terminal_width
     }
@@ -162,6 +171,51 @@ impl RenderContext {
 
     pub const fn unicode(self) -> bool {
         self.unicode
+    }
+}
+
+fn resolved_terminal_width(terminal_width: Option<usize>) -> usize {
+    terminal_width
+        .filter(|width| *width > 0)
+        .unwrap_or(DEFAULT_TERMINAL_WIDTH)
+}
+
+/// Capabilities established once for one output destination at the command
+/// root. Live rendering re-queries only the dimension that can change while a
+/// command is running; styling, Unicode, stream identity, and interactivity
+/// remain authoritative for the lifetime of the destination.
+#[derive(Clone)]
+pub(super) struct DestinationRuntime {
+    context: RenderContext,
+    width_probe: WidthProbe,
+}
+
+impl DestinationRuntime {
+    pub(super) fn fixed(context: RenderContext) -> Self {
+        let terminal_width = context.terminal_width();
+        Self::new(context, move || terminal_width)
+    }
+
+    pub(super) fn new(
+        context: RenderContext,
+        width_probe: impl Fn() -> Option<usize> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            context,
+            width_probe: Arc::new(width_probe),
+        }
+    }
+
+    pub(super) const fn context(&self) -> &RenderContext {
+        &self.context
+    }
+
+    pub(super) fn current_live_context(&self) -> RenderContext {
+        if self.context.live_output_capable() {
+            self.context.with_terminal_width((self.width_probe)())
+        } else {
+            self.context
+        }
     }
 }
 

--- a/crates/ctx-terminal/src/ui/tests.rs
+++ b/crates/ctx-terminal/src/ui/tests.rs
@@ -86,6 +86,9 @@ fn render_context_resolves_color_width_and_unicode_explicitly() {
 
     let unknown = RenderContext::for_test(TestContext::tty(StreamKind::Stdout, 32).unknown_width());
     assert_eq!(unknown.terminal_width(), Some(80));
+
+    let zero = RenderContext::for_test(TestContext::tty(StreamKind::Stdout, 0));
+    assert_eq!(zero.terminal_width(), Some(80));
 }
 
 #[test]

--- a/crates/ctx-terminal/src/ui/writer.rs
+++ b/crates/ctx-terminal/src/ui/writer.rs
@@ -5,7 +5,9 @@ use std::{
 
 use crate::output::MeasuredWriter;
 
-use super::{ColorMode, Document, RenderContext, StreamKind};
+use super::{
+    context::DestinationRuntime, display_width, ColorMode, Document, RenderContext, StreamKind,
+};
 
 type BoxedWriter = Box<dyn Write + Send>;
 
@@ -70,8 +72,8 @@ impl Ui {
         );
         let stderr_terminal_controls = stdio_terminal_controls(&stderr, stderr_context);
         Self {
-            stdout: Destination::adapted(stdout_context, stdout, stdout_terminal_controls),
-            stderr: Destination::adapted(stderr_context, stderr, stderr_terminal_controls),
+            stdout: Destination::stdio(stdout_context, stdout, stdout_terminal_controls),
+            stderr: Destination::stdio(stderr_context, stderr, stderr_terminal_controls),
         }
     }
 
@@ -160,18 +162,18 @@ impl Ui {
     }
 
     pub fn stdout_live_output(&mut self) -> LiveOutput<&mut (dyn Write + Send)> {
-        let context = *self.stdout.context();
-        LiveOutput::new(self.stdout.writer(), context)
+        self.stdout.live_output()
     }
 
     pub fn stderr_live_output(&mut self) -> LiveOutput<&mut (dyn Write + Send)> {
-        let context = *self.stderr.context();
-        LiveOutput::new(self.stderr.writer(), context)
+        self.stderr.live_output()
     }
 
     pub(crate) fn stderr_shared_live_output(&self) -> LiveOutput<BoxedWriter> {
-        let context = *self.stderr.context();
-        LiveOutput::new(Box::new(self.stderr.shared_writer()), context)
+        LiveOutput::with_runtime(
+            Box::new(self.stderr.shared_writer()),
+            self.stderr.runtime.clone(),
+        )
     }
 
     pub fn stdout_writer(&mut self) -> &mut (dyn Write + Send) {
@@ -192,10 +194,23 @@ impl Ui {
 /// content is rendered separately and is never part of a control sequence.
 pub struct LiveOutput<W: Write> {
     writer: W,
+    runtime: DestinationRuntime,
     context: RenderContext,
-    rendered_rows: Vec<String>,
+    rendered_rows: Vec<RenderedRow>,
+    rendered_width: Option<usize>,
     repaint_cursor: Option<RepaintCursor>,
     cursor_hidden: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RenderedRow {
+    text: String,
+    display_width: usize,
+}
+
+struct RenderedFrame {
+    text: String,
+    rows: Vec<RenderedRow>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -206,10 +221,17 @@ struct RepaintCursor {
 
 impl<W: Write> LiveOutput<W> {
     pub fn new(writer: W, context: RenderContext) -> Self {
+        Self::with_runtime(writer, DestinationRuntime::fixed(context))
+    }
+
+    fn with_runtime(writer: W, runtime: DestinationRuntime) -> Self {
+        let context = *runtime.context();
         Self {
             writer,
+            runtime,
             context,
             rendered_rows: Vec::new(),
+            rendered_width: None,
             repaint_cursor: None,
             cursor_hidden: false,
         }
@@ -246,30 +268,55 @@ impl<W: Write> LiveOutput<W> {
     }
 
     pub fn write_frame(&mut self, document: &Document, final_frame: bool) -> io::Result<()> {
-        let frame = document.render(&self.context);
+        self.context = self.runtime.current_live_context();
+        self.write_rendered_frame(render_frame(document, &self.context), final_frame)
+    }
+
+    /// Rebuilds and renders one semantic live frame using the destination's
+    /// current terminal dimensions. Other destination capabilities remain the
+    /// values established by the root [`Ui`].
+    pub fn render_frame(
+        &mut self,
+        final_frame: bool,
+        render: impl FnOnce(&RenderContext) -> Document,
+    ) -> io::Result<()> {
+        self.context = self.runtime.current_live_context();
+        let document = render(&self.context);
+        self.write_rendered_frame(render_frame(&document, &self.context), final_frame)
+    }
+
+    fn write_rendered_frame(&mut self, frame: RenderedFrame, final_frame: bool) -> io::Result<()> {
         if !self.context.live_output_capable() {
-            self.writer.write_all(frame.as_bytes())?;
+            self.writer.write_all(frame.text.as_bytes())?;
             self.writer.write_all(b"\n")?;
             return self.writer.flush();
         }
 
-        let rows = frame_rows(&frame);
         if !self.cursor_hidden {
             let write_result = if final_frame {
-                self.writer.write_all(frame.as_bytes())
+                self.writer.write_all(frame.text.as_bytes())
             } else {
                 self.hide_cursor()
-                    .and_then(|()| self.writer.write_all(frame.as_bytes()))
+                    .and_then(|()| self.writer.write_all(frame.text.as_bytes()))
             };
             if !final_frame && write_result.is_ok() {
-                self.rendered_rows = rows.iter().map(|row| (*row).to_owned()).collect();
+                self.rendered_rows = frame.rows;
+                self.rendered_width = self.context.terminal_width();
             }
             return self.finish_frame(final_frame, write_result);
         }
 
-        let repaint_result = self.repaint_changed_rows(&rows);
+        let width_changed = self.rendered_width != self.context.terminal_width();
+        let wrapped_frame = self.frame_has_wrapped_rows(&self.rendered_rows)
+            || self.frame_has_wrapped_rows(&frame.rows);
+        let repaint_result = if width_changed || wrapped_frame {
+            self.repaint_full_frame(&frame.rows)
+        } else {
+            self.repaint_changed_rows(&frame.rows)
+        };
         if repaint_result.is_ok() {
-            self.rendered_rows = rows.iter().map(|row| (*row).to_owned()).collect();
+            self.rendered_rows = frame.rows;
+            self.rendered_width = self.context.terminal_width();
         }
         self.finish_frame(final_frame, repaint_result)
     }
@@ -279,13 +326,8 @@ impl<W: Write> LiveOutput<W> {
         self.writer.write_all(b"\x1b[?25l")
     }
 
-    fn repaint_changed_rows(&mut self, rows: &[&str]) -> io::Result<()> {
-        if self
-            .rendered_rows
-            .iter()
-            .map(String::as_str)
-            .eq(rows.iter().copied())
-        {
+    fn repaint_changed_rows(&mut self, rows: &[RenderedRow]) -> io::Result<()> {
+        if self.rendered_rows == rows {
             return Ok(());
         }
 
@@ -303,7 +345,7 @@ impl<W: Write> LiveOutput<W> {
             Some(&mut cursor.current_row),
         )?;
         for row in 0..height {
-            if self.rendered_rows.get(row).map(String::as_str) == rows.get(row).copied() {
+            if self.rendered_rows.get(row) == rows.get(row) {
                 continue;
             }
             let Some(cursor) = self.repaint_cursor.as_mut() else {
@@ -316,7 +358,7 @@ impl<W: Write> LiveOutput<W> {
             )?;
             self.writer.write_all(b"\r")?;
             if let Some(line) = rows.get(row) {
-                self.writer.write_all(line.as_bytes())?;
+                self.writer.write_all(line.text.as_bytes())?;
             }
             self.writer.write_all(b"\x1b[K")?;
         }
@@ -342,18 +384,67 @@ impl<W: Write> LiveOutput<W> {
         Ok(())
     }
 
+    fn repaint_full_frame(&mut self, rows: &[RenderedRow]) -> io::Result<()> {
+        let old_height = self.physical_height(&self.rendered_rows);
+        let new_height = self.physical_height(rows);
+        self.repaint_cursor = Some(RepaintCursor {
+            current_row: old_height,
+            recovery_row: old_height.max(new_height),
+        });
+        let Some(cursor) = self.repaint_cursor.as_mut() else {
+            return Err(io::Error::other("missing repaint cursor"));
+        };
+        write_cursor_up(&mut self.writer, old_height, Some(&mut cursor.current_row))?;
+        for _ in 0..old_height {
+            self.writer.write_all(b"\r\x1b[K")?;
+            let Some(cursor) = self.repaint_cursor.as_mut() else {
+                return Err(io::Error::other("missing repaint cursor"));
+            };
+            write_cursor_down(&mut self.writer, 1, Some(&mut cursor.current_row))?;
+        }
+        let Some(cursor) = self.repaint_cursor.as_mut() else {
+            return Err(io::Error::other("missing repaint cursor"));
+        };
+        write_cursor_up(&mut self.writer, old_height, Some(&mut cursor.current_row))?;
+        for row in rows {
+            self.writer.write_all(row.text.as_bytes())?;
+            self.writer.write_all(b"\n")?;
+            let row_height = self.row_height(row);
+            if let Some(cursor) = self.repaint_cursor.as_mut() {
+                cursor.current_row = cursor.current_row.saturating_add(row_height);
+            }
+        }
+        self.repaint_cursor = None;
+        Ok(())
+    }
+
+    fn frame_has_wrapped_rows(&self, rows: &[RenderedRow]) -> bool {
+        rows.iter().any(|row| self.row_height(row) > 1)
+    }
+
+    fn physical_height(&self, rows: &[RenderedRow]) -> usize {
+        rows.iter().map(|row| self.row_height(row)).sum()
+    }
+
+    fn row_height(&self, row: &RenderedRow) -> usize {
+        let width = self.context.terminal_width().unwrap_or(usize::MAX).max(1);
+        row.display_width.saturating_sub(1) / width + 1
+    }
+
     fn finish_frame(&mut self, final_frame: bool, result: io::Result<()>) -> io::Result<()> {
         if let Err(error) = result {
             self.restore_repaint_anchor_best_effort();
             let _ = self.writer.write_all(b"\r");
             let _ = self.restore_cursor();
             self.rendered_rows.clear();
+            self.rendered_width = None;
             let _ = self.writer.flush();
             return Err(error);
         }
         if final_frame {
             let restore_result = self.restore_cursor();
             self.rendered_rows.clear();
+            self.rendered_width = None;
             return restore_result.and_then(|()| self.writer.flush());
         }
         self.writer.flush()
@@ -413,6 +504,23 @@ fn frame_rows(frame: &str) -> Vec<&str> {
     }
 }
 
+fn render_frame(document: &Document, context: &RenderContext) -> RenderedFrame {
+    let text = document.render(context);
+    let plain = document.render_plain();
+    let plain_rows = frame_rows(&plain);
+    let styled_rows = frame_rows(&text);
+    debug_assert_eq!(styled_rows.len(), plain_rows.len());
+    let rows = styled_rows
+        .into_iter()
+        .enumerate()
+        .map(|(index, text)| RenderedRow {
+            text: text.to_owned(),
+            display_width: plain_rows.get(index).map_or(0, |row| display_width(row)),
+        })
+        .collect();
+    RenderedFrame { text, rows }
+}
+
 fn write_cursor_up(
     writer: &mut impl Write,
     rows: usize,
@@ -442,14 +550,21 @@ fn write_cursor_down(
 }
 
 struct Destination {
-    context: RenderContext,
+    runtime: DestinationRuntime,
     writer: SharedDestinationWriter,
 }
 
 impl Destination {
     fn new(context: RenderContext, writer: BoxedWriter) -> Self {
         Self {
-            context,
+            runtime: DestinationRuntime::fixed(context),
+            writer: SharedDestinationWriter::new(writer),
+        }
+    }
+
+    fn new_with_runtime(runtime: DestinationRuntime, writer: BoxedWriter) -> Self {
+        Self {
+            runtime,
             writer: SharedDestinationWriter::new(writer),
         }
     }
@@ -486,13 +601,27 @@ impl Destination {
         Self::new(context, measured)
     }
 
+    fn stdio<W>(context: RenderContext, writer: W, terminal_controls: bool) -> Self
+    where
+        W: anstream::stream::RawStream + anstream::stream::AsLockedWrite + Send + 'static,
+    {
+        let context = context.with_terminal_control_support(terminal_controls);
+        let stream = context.stream();
+        let adapted = terminal_adapter(writer, context);
+        let measured: BoxedWriter = Box::new(MeasuredWriter::current(adapted, context.stream()));
+        Self::new_with_runtime(
+            DestinationRuntime::new(context, move || stream_width(stream)),
+            measured,
+        )
+    }
+
     const fn context(&self) -> &RenderContext {
-        &self.context
+        self.runtime.context()
     }
 
     fn write(&mut self, document: &Document) -> io::Result<()> {
         self.writer
-            .write_all(document.render(&self.context).as_bytes())
+            .write_all(document.render(self.context()).as_bytes())
     }
 
     fn writer(&mut self) -> &mut (dyn Write + Send) {
@@ -501,6 +630,11 @@ impl Destination {
 
     fn shared_writer(&self) -> SharedDestinationWriter {
         self.writer.clone()
+    }
+
+    fn live_output(&mut self) -> LiveOutput<&mut (dyn Write + Send)> {
+        let runtime = self.runtime.clone();
+        LiveOutput::with_runtime(self.writer(), runtime)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/crates/ctx-terminal/src/ui/writer/tests.rs
+++ b/crates/ctx-terminal/src/ui/writer/tests.rs
@@ -1,8 +1,18 @@
 use super::*;
-use crate::ui::{Line, Span, TestContext, Token};
+use crate::ui::{context::DEFAULT_TERMINAL_WIDTH, Line, Span, TestContext, Token};
 use std::{
     cell::Cell,
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+};
+
+#[cfg(target_os = "linux")]
+use std::{
+    ffi::{c_char, c_int, c_ulong, c_void},
+    fs::File,
+    os::fd::{AsRawFd as _, FromRawFd as _},
 };
 
 #[derive(Clone, Default)]
@@ -49,7 +59,7 @@ impl FailOnceWriter {
 impl Write for FailOnceWriter {
     fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
         let mut state = self.0.lock().unwrap();
-        if !state.failed && buffer == b"\x1b[K" {
+        if !state.failed && (buffer == b"\x1b[K" || buffer == b"\r\x1b[K") {
             state.failed = true;
             return Err(io::Error::other("injected repaint failure"));
         }
@@ -602,4 +612,289 @@ fn dynamic_text_is_neutralized_before_live_control_bytes() {
         .unwrap();
     let rendered = String::from_utf8(output.into_inner()).unwrap();
     assert_eq!(rendered, "\x1b[?25lsource\\x1b[999A\\rname\n\x1b[?25h");
+}
+
+#[test]
+fn semantic_live_frames_rebuild_at_current_standard_widths() {
+    let width = Arc::new(AtomicUsize::new(80));
+    let width_probe = Arc::clone(&width);
+    let context = RenderContext::for_test(
+        TestContext::tty(StreamKind::Stderr, 80)
+            .color(ColorMode::Never)
+            .unicode(false),
+    );
+    let runtime =
+        DestinationRuntime::new(context, move || Some(width_probe.load(Ordering::Relaxed)));
+    let mut output = LiveOutput::with_runtime(Vec::new(), runtime);
+    let mut observed = Vec::new();
+
+    for terminal_width in [32, 48, 80, 120] {
+        width.store(terminal_width, Ordering::Relaxed);
+        output
+            .render_frame(false, |current| {
+                observed.push((
+                    current.stream(),
+                    current.terminal_width(),
+                    current.color_enabled(),
+                    current.unicode(),
+                    current.live_output_capable(),
+                ));
+                Document::from_line(Line::text(format!(
+                    "destination={:?} width={}",
+                    current.stream(),
+                    current.terminal_width().unwrap_or_default()
+                )))
+            })
+            .unwrap();
+    }
+
+    assert_eq!(
+        observed,
+        [32, 48, 80, 120].map(|width| (StreamKind::Stderr, Some(width), false, false, true))
+    );
+    let rendered = String::from_utf8(output.into_inner()).unwrap();
+    for terminal_width in [32, 48, 80, 120] {
+        assert!(
+            rendered.contains(&format!("destination=Stderr width={terminal_width}")),
+            "{rendered:?}"
+        );
+    }
+}
+
+#[test]
+fn resize_invalidates_wrapped_rows_and_restores_cursor_after_height_change() {
+    let width = Arc::new(AtomicUsize::new(80));
+    let width_probe = Arc::clone(&width);
+    let context = RenderContext::for_test(TestContext::tty(StreamKind::Stdout, 80));
+    let runtime =
+        DestinationRuntime::new(context, move || Some(width_probe.load(Ordering::Relaxed)));
+    let mut output = LiveOutput::with_runtime(Vec::new(), runtime);
+
+    output
+        .render_frame(false, |_| Document::from_line(Line::text("x".repeat(79))))
+        .unwrap();
+    width.store(32, Ordering::Relaxed);
+    output
+        .render_frame(false, |_| {
+            document(&["narrow one", "narrow two", "narrow three", "narrow four"])
+        })
+        .unwrap();
+    width.store(120, Ordering::Relaxed);
+    output.render_frame(true, |_| document(&["done"])).unwrap();
+    output.write_document(&document(&["SENTINEL"])).unwrap();
+
+    let rendered = String::from_utf8(output.into_inner()).unwrap();
+    let shrink_repaint = concat!(
+        "\x1b[A\x1b[A\x1b[A",
+        "\r\x1b[K\x1b[B\r\x1b[K\x1b[B\r\x1b[K\x1b[B",
+        "\x1b[A\x1b[A\x1b[A",
+        "narrow one\nnarrow two\nnarrow three\nnarrow four\n",
+    );
+    assert!(rendered.contains(shrink_repaint), "{rendered:?}");
+    assert!(
+        rendered.ends_with("done\n\x1b[?25hSENTINEL\n"),
+        "{rendered:?}"
+    );
+}
+
+#[test]
+fn frame_height_measurement_ignores_ansi_and_counts_terminal_cells() {
+    let context =
+        RenderContext::for_test(TestContext::tty(StreamKind::Stdout, 32).color(ColorMode::Always));
+    let mut document = Document::new();
+    document.push_line(Line::styled("界".repeat(20), Token::Heading));
+    document.push_line(Line::text("e\u{301}".repeat(32)));
+    document.push_blank();
+    document.push_line(Line::text("x".repeat(65)));
+    let frame = render_frame(&document, &context);
+    assert!(frame.text.contains("\x1b[1m"));
+
+    let output = LiveOutput::new(Vec::new(), context);
+    let row_heights = frame
+        .rows
+        .iter()
+        .map(|row| output.row_height(row))
+        .collect::<Vec<_>>();
+    assert_eq!(row_heights, vec![2, 1, 1, 3]);
+    assert_eq!(output.physical_height(&frame.rows), 7);
+}
+
+#[test]
+fn full_repaint_failure_recovers_below_reflowed_block_and_restores_cursor() {
+    let width = Arc::new(AtomicUsize::new(80));
+    let width_probe = Arc::clone(&width);
+    let context = RenderContext::for_test(TestContext::tty(StreamKind::Stdout, 80));
+    let runtime =
+        DestinationRuntime::new(context, move || Some(width_probe.load(Ordering::Relaxed)));
+    let writer = FailOnceWriter::new();
+    let capture = writer.clone();
+    {
+        let mut output = LiveOutput::with_runtime(writer, runtime);
+        output
+            .render_frame(false, |_| Document::from_line(Line::text("x".repeat(79))))
+            .unwrap();
+        width.store(32, Ordering::Relaxed);
+        let error = output
+            .render_frame(false, |_| document(&["replacement"]))
+            .expect_err("full repaint failure must propagate");
+        assert_eq!(error.to_string(), "injected repaint failure");
+    }
+    let mut sentinel = capture.clone();
+    sentinel.write_all(b"SENTINEL").unwrap();
+
+    let rendered = capture.text();
+    assert!(
+        rendered.ends_with("\x1b[B\x1b[B\x1b[B\r\x1b[?25hSENTINEL"),
+        "{rendered:?}"
+    );
+}
+
+#[test]
+fn zero_or_unknown_live_width_falls_back_to_eighty_columns() {
+    let probed_width = Arc::new(AtomicUsize::new(0));
+    let width_probe = Arc::clone(&probed_width);
+    let context = RenderContext::for_test(TestContext::tty(StreamKind::Stdout, 32));
+    let runtime =
+        DestinationRuntime::new(context, move || Some(width_probe.load(Ordering::Relaxed)));
+    let mut output = LiveOutput::with_runtime(Vec::new(), runtime);
+    output
+        .render_frame(false, |current| {
+            assert_eq!(current.terminal_width(), Some(DEFAULT_TERMINAL_WIDTH));
+            document(&["zero"])
+        })
+        .unwrap();
+
+    let unknown_runtime = DestinationRuntime::new(context, || None);
+    let mut unknown_output = LiveOutput::with_runtime(Vec::new(), unknown_runtime);
+    unknown_output
+        .render_frame(false, |current| {
+            assert_eq!(current.terminal_width(), Some(DEFAULT_TERMINAL_WIDTH));
+            document(&["unknown"])
+        })
+        .unwrap();
+}
+
+#[test]
+fn redirected_and_dumb_destinations_never_probe_resize_or_move_the_cursor() {
+    for context in [
+        RenderContext::for_test(TestContext::pipe(StreamKind::Stdout)),
+        RenderContext::for_test(TestContext::tty(StreamKind::Stderr, 80).term_dumb(true)),
+    ] {
+        let probes = Arc::new(AtomicUsize::new(0));
+        let probe_count = Arc::clone(&probes);
+        let runtime = DestinationRuntime::new(context, move || {
+            probe_count.fetch_add(1, Ordering::Relaxed);
+            Some(32)
+        });
+        let mut output = LiveOutput::with_runtime(Vec::new(), runtime);
+        let expected_width = context.terminal_width();
+        output
+            .render_frame(false, |current| {
+                assert_eq!(current.terminal_width(), expected_width);
+                document(&["stable"])
+            })
+            .unwrap();
+        output
+            .render_frame(false, |current| {
+                assert_eq!(current.terminal_width(), expected_width);
+                document(&["still stable"])
+            })
+            .unwrap();
+
+        assert_eq!(probes.load(Ordering::Relaxed), 0);
+        let rendered = String::from_utf8(output.into_inner()).unwrap();
+        assert_eq!(rendered, "stable\n\nstill stable\n\n");
+        assert!(!rendered.contains('\u{1b}'));
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn live_runtime_observes_pty_resize_between_frames() {
+    #[repr(C)]
+    struct LinuxWinsize {
+        rows: u16,
+        columns: u16,
+        x_pixels: u16,
+        y_pixels: u16,
+    }
+
+    unsafe extern "C" {
+        fn openpty(
+            master: *mut c_int,
+            slave: *mut c_int,
+            name: *mut c_char,
+            termios: *const c_void,
+            winsize: *const LinuxWinsize,
+        ) -> c_int;
+        fn ioctl(file_descriptor: c_int, request: c_ulong, ...) -> c_int;
+    }
+
+    const TIOCSWINSZ: c_ulong = 0x5414;
+
+    fn open_pty(width: u16) -> io::Result<(File, Arc<File>)> {
+        let mut master = -1;
+        let mut slave = -1;
+        let dimensions = LinuxWinsize {
+            rows: 24,
+            columns: width,
+            x_pixels: 0,
+            y_pixels: 0,
+        };
+        let status = unsafe {
+            openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                &dimensions,
+            )
+        };
+        if status != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let master = unsafe { File::from_raw_fd(master) };
+        let slave = Arc::new(unsafe { File::from_raw_fd(slave) });
+        Ok((master, slave))
+    }
+
+    fn resize_pty(master: &File, width: u16) -> io::Result<()> {
+        let dimensions = LinuxWinsize {
+            rows: 24,
+            columns: width,
+            x_pixels: 0,
+            y_pixels: 0,
+        };
+        let status = unsafe { ioctl(master.as_raw_fd(), TIOCSWINSZ, &dimensions) };
+        if status == -1 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    let (master, slave) = open_pty(80).unwrap();
+    let width_handle = Arc::clone(&slave);
+    let context = RenderContext::for_test(TestContext::tty(StreamKind::Stdout, 80));
+    let runtime = DestinationRuntime::new(context, move || {
+        terminal_size::terminal_size_of(&*width_handle)
+            .map(|(terminal_size::Width(width), _)| usize::from(width))
+    });
+    let mut output = LiveOutput::with_runtime(Vec::new(), runtime);
+    let mut observed = Vec::new();
+    output
+        .render_frame(false, |current| {
+            observed.push(current.terminal_width());
+            document(&["wide"])
+        })
+        .unwrap();
+    resize_pty(&master, 32).unwrap();
+    output
+        .render_frame(true, |current| {
+            observed.push(current.terminal_width());
+            document(&["narrow"])
+        })
+        .unwrap();
+
+    assert_eq!(observed, vec![Some(80), Some(32)]);
 }

--- a/crates/ctx-terminal/tests/raw_output_policy.rs
+++ b/crates/ctx-terminal/tests/raw_output_policy.rs
@@ -1047,8 +1047,6 @@ fn primitive_at(
     }
     if text == "render" && tokens.get(index + 1).map(|token| token.text.as_str()) == Some("(") {
         let document_call = previous_is(tokens, index, ".")
-            && tokens.get(index + 2).map(|token| token.text.as_str()) == Some("&")
-            && tokens.get(index + 3).map(|token| token.text.as_str()) != Some("mut")
             && documents.render_receiver_is_document(tokens, functions, index, document_catalog);
         let document_api =
             path == "crates/ctx-terminal/src/ui/document.rs" && previous_is(tokens, index, "fn");

--- a/crates/ctx-terminal/tests/raw_output_policy/allowlist.rs
+++ b/crates/ctx-terminal/tests/raw_output_policy/allowlist.rs
@@ -54,6 +54,11 @@ const LIVE_OUTPUT: TestOwner = TestOwner::behavioral(
     &["crates/ctx-terminal/src/ui/writer.rs"],
     &["LiveOutput", "write_frame", "assert_eq"],
 );
+const LIVE_RESIZE: TestOwner = TestOwner::behavioral(
+    "crates/ctx-terminal/src/ui/writer/tests.rs::resize_invalidates_wrapped_rows_and_restores_cursor_after_height_change",
+    &["crates/ctx-terminal/src/ui/writer.rs"],
+    &["LiveOutput", "render_frame", "shrink_repaint", "SENTINEL"],
+);
 const PLAIN_REFRESH_PROGRESS: TestOwner = TestOwner::behavioral(
     "crates/ctx-terminal/src/progress/tests.rs::plain_refresh_progress_is_the_stable_live_document_without_internal_routes",
     &["crates/ctx-terminal/src/progress.rs"],
@@ -82,6 +87,16 @@ const SOURCE_INDEX_STREAM: TestOwner = TestOwner::behavioral(
     "crates/ctx-history-cli/src/source_index/tests/additional.rs::unbounded_cli_show_streams_valid_json_beyond_4096_events_in_order",
     &["crates/ctx-history-cli/src/source_index/show.rs"],
     &["stream_cli_session", "events_returned", "from_slice"],
+);
+const SOURCE_INDEX_HUMAN_STREAM: TestOwner = TestOwner::behavioral(
+    "crates/ctx-history-cli/src/source_index/tests/additional.rs::human_cli_show_stream_renders_header_events_empty_and_truncation",
+    &["crates/ctx-history-cli/src/source_index/show.rs"],
+    &[
+        "stream_cli_session",
+        "OutputFormat::Text",
+        "Transcript is truncated.",
+        "No transcript events.",
+    ],
 );
 const HISTORY_CLI_TERMINAL_PORT: TestOwner = TestOwner::behavioral(
     "crates/ctx-history-cli/src/ports.rs::terminal_port_preserves_selected_stream_bytes",
@@ -426,6 +441,38 @@ pub(super) const ALLOWLIST: &[AllowEntry] = &[
         Infrastructure,
         SPECIALIZED_STREAM,
         SOURCE_INDEX_STREAM
+    ),
+    allow!(
+        SOURCE_INDEX_SHOW,
+        "emit#1@e00603b31705f733",
+        DocumentRender,
+        JustifiedPlainHuman,
+        "streamed human show events use the shared terminal document renderer",
+        SOURCE_INDEX_HUMAN_STREAM
+    ),
+    allow!(
+        SOURCE_INDEX_SHOW,
+        "finish#1@83de2ef9ce802211",
+        DocumentRender,
+        JustifiedPlainHuman,
+        "streamed empty human show results use the shared terminal document renderer",
+        SOURCE_INDEX_HUMAN_STREAM
+    ),
+    allow!(
+        SOURCE_INDEX_SHOW,
+        "finish#2@bc572009073a0869",
+        DocumentRender,
+        JustifiedPlainHuman,
+        "streamed truncated human show results use the shared terminal document renderer",
+        SOURCE_INDEX_HUMAN_STREAM
+    ),
+    allow!(
+        SOURCE_INDEX_SHOW,
+        "write_header#1@311e92a0e876bc18",
+        DocumentRender,
+        JustifiedPlainHuman,
+        "streamed human show headers use the shared terminal document renderer",
+        SOURCE_INDEX_HUMAN_STREAM
     ),
     allow!(
         SOURCE_INDEX_SHARED,
@@ -845,15 +892,23 @@ pub(super) const ALLOWLIST: &[AllowEntry] = &[
     ),
     allow!(
         UI_WRITER,
-        "write_frame#1@800a077f8a4bc2c0",
+        "render_frame#1@570278e406fabb4a",
         DocumentRender,
         Infrastructure,
         UI_INFRASTRUCTURE,
-        LIVE_OUTPUT
+        LIVE_RESIZE
     ),
     allow!(
         UI_WRITER,
-        "write_frame#1@9e176dd4991e94f2",
+        "render_frame#2@21157661e5d7d8c9",
+        DocumentRender,
+        Infrastructure,
+        UI_INFRASTRUCTURE,
+        LIVE_RESIZE
+    ),
+    allow!(
+        UI_WRITER,
+        "write_rendered_frame#1@c3fea88d95687a11",
         DirectWrite,
         Infrastructure,
         SPECIALIZED_STREAM,
@@ -861,7 +916,7 @@ pub(super) const ALLOWLIST: &[AllowEntry] = &[
     ),
     allow!(
         UI_WRITER,
-        "write_frame#2@26dbdba5809c8356",
+        "write_rendered_frame#2@26dbdba5809c8356",
         DirectWrite,
         Infrastructure,
         SPECIALIZED_STREAM,
@@ -869,7 +924,7 @@ pub(super) const ALLOWLIST: &[AllowEntry] = &[
     ),
     allow!(
         UI_WRITER,
-        "write_frame#3@601d22f56b79cdd3",
+        "write_rendered_frame#3@0ba0fd9d995d5136",
         DirectWrite,
         Infrastructure,
         SPECIALIZED_STREAM,
@@ -877,7 +932,7 @@ pub(super) const ALLOWLIST: &[AllowEntry] = &[
     ),
     allow!(
         UI_WRITER,
-        "write_frame#4@ed3cb2ef0bf6912f",
+        "write_rendered_frame#4@05c759eaddd10788",
         DirectWrite,
         Infrastructure,
         SPECIALIZED_STREAM,
@@ -901,7 +956,7 @@ pub(super) const ALLOWLIST: &[AllowEntry] = &[
     ),
     allow!(
         UI_WRITER,
-        "repaint_changed_rows#2@4f59ef5cdaf825f7",
+        "repaint_changed_rows#2@2aaf68bbaa8f574a",
         DirectWrite,
         Infrastructure,
         SPECIALIZED_STREAM,
@@ -922,6 +977,30 @@ pub(super) const ALLOWLIST: &[AllowEntry] = &[
         Infrastructure,
         SPECIALIZED_STREAM,
         LIVE_OUTPUT
+    ),
+    allow!(
+        UI_WRITER,
+        "repaint_full_frame#1@25d91e214faa3726",
+        DirectWrite,
+        Infrastructure,
+        SPECIALIZED_STREAM,
+        LIVE_RESIZE
+    ),
+    allow!(
+        UI_WRITER,
+        "repaint_full_frame#2@33d04ce985307180",
+        DirectWrite,
+        Infrastructure,
+        SPECIALIZED_STREAM,
+        LIVE_RESIZE
+    ),
+    allow!(
+        UI_WRITER,
+        "repaint_full_frame#3@177ec66628e8b21e",
+        DirectWrite,
+        Infrastructure,
+        SPECIALIZED_STREAM,
+        LIVE_RESIZE
     ),
     allow!(
         UI_WRITER,
@@ -1021,7 +1100,7 @@ pub(super) const ALLOWLIST: &[AllowEntry] = &[
     ),
     allow!(
         UI_WRITER,
-        "write#1@62dfe1a34afb27b0",
+        "write#1@cae68c8b3d8eadff",
         DocumentRender,
         Infrastructure,
         UI_INFRASTRUCTURE,
@@ -1029,7 +1108,7 @@ pub(super) const ALLOWLIST: &[AllowEntry] = &[
     ),
     allow!(
         UI_WRITER,
-        "write#1@62dfe1a34afb27b0",
+        "write#1@cae68c8b3d8eadff",
         DirectWrite,
         Infrastructure,
         UI_INFRASTRUCTURE,

--- a/crates/ctx-terminal/tests/raw_output_policy/self_tests.rs
+++ b/crates/ctx-terminal/tests/raw_output_policy/self_tests.rs
@@ -574,13 +574,20 @@ fn scanner_tracks_raw_writers_through_free_function_parameters() {
 #[test]
 fn scanner_covers_document_render_regardless_of_binding_names() {
     let source = r#"
-        fn emit(page: &Document, palette: RenderContext) {
+        fn emit(page: &Document, palette: RenderContext, borrowed: &RenderContext) {
             let _ = page.render(&palette);
+            let _ = page.render(borrowed);
+            let _ = page.render(context());
         }
     "#;
     let sites = scan_source("src/example.rs", source);
-    assert_eq!(sites.len(), 1, "{sites:#?}");
-    assert_eq!(sites[0].key.primitive, Primitive::DocumentRender);
+    assert_eq!(sites.len(), 3, "{sites:#?}");
+    assert!(
+        sites
+            .iter()
+            .all(|site| site.key.primitive == Primitive::DocumentRender),
+        "{sites:#?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- establish one destination-aware terminal runtime for capabilities, live eligibility, width, and stream selection
- rebuild semantic live documents against current terminal dimensions and safely repaint wrapped/height-changing frames
- preserve deterministic static and machine output, with conservative pipe and TERM=dumb behavior

## Validation
- scripts/bazel-affected.sh origin/main (61/61 targets pass)
- focused terminal width/resize tests at 32/48/80/120 columns
- Linux PTY resize test using TIOCSWINSZ
- raw-output policy and repository-policy checks
- three independent Sol reviews; all findings resolved