### PR TITLE
feat(core): stream typed refresh protocol events

### DIFF
--- a/crates/ctx-cli/src/core_capability.rs
+++ b/crates/ctx-cli/src/core_capability.rs
@@ -25,10 +25,20 @@ use sha2::{Digest as _, Sha256};
 
 mod failure;
 mod hosted_pair_install;
+mod progress_events;
 mod setup_options;
+mod setup_refresh;
 
 use failure::produce_response;
-use setup_options::{progress_mode_for_notice, setup_notice_lines, setup_progress_mode};
+use progress_events::{CapabilityEventSink, IgnoreEvents, ProtocolEventWriter};
+use setup_options::{
+    progress_mode_for_notice, setup_notice_lines, setup_progress_mode, SetupProgressMode,
+};
+use setup_refresh::core_setup_refresh;
+#[cfg(test)]
+use setup_refresh::{
+    should_propagate_setup_refresh_failure, should_wait_for_fresh_empty_publication,
+};
 
 const INVOCATION: &str = "--ctx-core-capability-v1";
 const HOSTED_PAIR_INSTALL_INVOCATION: &str = "--ctx-core-hosted-pair-install-v1";
@@ -37,10 +47,10 @@ const POST_EXIT_UNINSTALL_INVOCATION: &str = "--ctx-core-managed-pair-uninstall-
 const MAX_FRAME_BYTES: usize = 64 * 1024;
 const MAX_RESPONSE_BYTES: usize = 48 * 1024;
 #[cfg(test)]
-const API_INVENTORY: &str = r#"{"operations":{"CoreDoctor":{"request_keys":[],"response_keys":["facts"]},"CoreSetup":{"request_keys":["catalog_only","defer_fresh_empty_wait","no_daemon","notice_lines","progress","semantic","wait"],"response_keys":["facts","generation_id"]},"CoreStatus":{"request_keys":["usage"],"response_keys":["facts"]},"LocalUsageSummary":{"request_keys":[],"response_keys":["facts"]},"ManagedPairAbort":{"request_keys":["attempt_id"],"response_keys":["aborted"]},"ManagedPairBegin":{"request_keys":[],"response_keys":["attempt_id","candidate_root"]},"ManagedPairStage":{"request_keys":["attempt_id"],"response_keys":["attempt_id","release_name","rollback_generation","status"]},"ManagedPairStatus":{"request_keys":["attempt_id"],"response_keys":["status"]},"ManagedPairUninstall":{"request_keys":[],"response_keys":["attempt_id","cleanup_mode","status"]},"RefreshAndWait":{"request_keys":[],"response_keys":["facts","generation_id"]},"WakeRefresh":{"request_keys":[],"response_keys":["accepted"]}},"protocol":"ctx-core-capability","schema_version":1}"#;
+const API_INVENTORY: &str = r#"{"event_frames":{"Refresh":{"current_source_progress_keys":["logical_certified_bytes","logical_rows_scanned","snapshot_bytes_completed","snapshot_bytes_total","snapshot_pages_completed","snapshot_pages_total","stage"],"frame_keys":["event","operation","protocol_version","refresh","schema_version","sequence","type"],"refresh_keys":["completed_bytes","completed_records","completed_sources","current_source","current_source_progress","elapsed_millis","estimated_remaining_millis","logical_phase","maintenance_wake","phase","physical_attempt_id","physical_attempt_state","processed_bytes","processed_messages","processed_sessions","processed_tool_calls","progress_owner_attempt_state","progress_owner_request_id","providers","request_id","request_state","terminal_state","total_sources","total_sources_known","whole_run_stage"],"terminal_state_details_keys":["affected_routes","blocked_routes","class","physical_attempt_id","published_generation","retained_generation","retry_advice","retryable_routes"],"terminal_state_keys":["details","error_code","retryable"]}},"operations":{"CoreDoctor":{"request_keys":[],"response_keys":["facts"]},"CoreSetup":{"request_keys":["catalog_only","defer_fresh_empty_wait","no_daemon","notice_lines","progress","semantic","wait"],"request_values":{"progress":["auto","events","json","none","plain"]},"response_keys":["facts","generation_id"]},"CoreStatus":{"request_keys":["usage"],"response_keys":["facts"]},"LocalUsageSummary":{"request_keys":[],"response_keys":["facts"]},"ManagedPairAbort":{"request_keys":["attempt_id"],"response_keys":["aborted"]},"ManagedPairBegin":{"request_keys":[],"response_keys":["attempt_id","candidate_root"]},"ManagedPairStage":{"request_keys":["attempt_id"],"response_keys":["attempt_id","release_name","rollback_generation","status"]},"ManagedPairStatus":{"request_keys":["attempt_id"],"response_keys":["status"]},"ManagedPairUninstall":{"request_keys":[],"response_keys":["attempt_id","cleanup_mode","status"]},"RefreshAndWait":{"optional_request_keys":["progress"],"request_keys":[],"request_values":{"progress":["events"]},"response_keys":["facts","generation_id"]},"WakeRefresh":{"request_keys":[],"response_keys":["accepted"]}},"protocol":"ctx-core-capability","schema_version":1,"terminal_failure":{"details_keys":["affected_routes","blocked_routes","class","physical_attempt_id","retained_generation","retry_advice","retryable_routes"],"response_keys":["details","error_code","ok","operation","protocol_version","retryable","schema_version"]}}"#;
 #[cfg(test)]
 pub(crate) const API_FINGERPRINT: &str =
-    "eed67ebb32371c264e6dae66f5499f8bb8baf6c71f5c39eb801fadd25fba9b07";
+    "d03afbac7c95df2df850fcb6b81f49c4051265d70c70a6d7519b18845b9909f2";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Operation {
@@ -139,8 +149,20 @@ fn capability_exit_code(result: Result<()>) -> ExitCode {
 }
 
 fn run() -> Result<()> {
-    let (bytes, terminal_error) = produce_response(read_frame()?, execute)?;
-    write_response_frame(std::io::stdout().lock(), &bytes)?;
+    run_with_protocol_io(std::io::stdin().lock(), std::io::stdout().lock(), execute)
+}
+
+fn run_with_protocol_io(
+    reader: impl std::io::Read,
+    mut writer: impl std::io::Write,
+    execute_request: impl FnOnce(Request, &mut dyn CapabilityEventSink) -> Result<Value>,
+) -> Result<()> {
+    let input = read_frame_from(reader)?;
+    let (bytes, terminal_error) = produce_response(input, |request| {
+        let mut events = ProtocolEventWriter::new(request.operation, &mut writer);
+        execute_request(request, &mut events)
+    })?;
+    write_response_frame(&mut writer, &bytes)?;
     if let Some(error) = terminal_error {
         return Err(error);
     }
@@ -153,12 +175,7 @@ fn run_with_io(
     writer: impl std::io::Write,
     execute_request: impl FnOnce(Request) -> Result<Value>,
 ) -> Result<()> {
-    let (bytes, terminal_error) = produce_response(read_frame_from(reader)?, execute_request)?;
-    write_response_frame(writer, &bytes)?;
-    if let Some(error) = terminal_error {
-        return Err(error);
-    }
-    Ok(())
+    run_with_protocol_io(reader, writer, |request, _events| execute_request(request))
 }
 
 fn write_response_frame(mut writer: impl std::io::Write, bytes: &[u8]) -> Result<()> {
@@ -177,6 +194,7 @@ struct Request {
 enum Options {
     Setup(CoreSetupOptions),
     Status { usage: Option<UsageAction> },
+    Refresh { events: bool },
     PairAttempt { attempt_id: String },
     Empty,
 }
@@ -186,7 +204,7 @@ struct CoreSetupOptions {
     defer_fresh_empty_wait: bool,
     no_daemon: bool,
     notice_lines: Vec<String>,
-    progress: crate::progress::ProgressArg,
+    progress: SetupProgressMode,
     semantic: bool,
     wait: bool,
 }
@@ -252,7 +270,7 @@ fn parse_frame(bytes: Vec<u8>) -> Result<Request> {
     })
 }
 
-fn execute(request: Request) -> Result<Value> {
+fn execute(request: Request, events: &mut dyn CapabilityEventSink) -> Result<Value> {
     if !matches!(
         request.operation,
         Operation::LocalUsageSummary
@@ -266,7 +284,7 @@ fn execute(request: Request) -> Result<Value> {
     }
     let facts = match (request.operation, request.options) {
         (Operation::CoreSetup, Options::Setup(options)) => {
-            core_setup_facts(&request.data_root, options)?
+            core_setup_facts(&request.data_root, options, events)?
         }
         (Operation::CoreStatus, Options::Status { usage }) => {
             core_status_facts(&request.data_root, usage)?
@@ -277,7 +295,12 @@ fn execute(request: Request) -> Result<Value> {
         (Operation::LocalUsageSummary, Options::Empty) => {
             local_usage_summary_facts(&request.data_root)?
         }
-        (Operation::RefreshAndWait, Options::Empty) => refresh_and_facts(&request.data_root)?,
+        (Operation::RefreshAndWait, Options::Refresh { events: true }) => {
+            refresh_and_facts(&request.data_root, events)?
+        }
+        (Operation::RefreshAndWait, Options::Refresh { events: false }) => {
+            refresh_and_facts(&request.data_root, &mut IgnoreEvents)?
+        }
         (Operation::WakeRefresh, Options::Empty) => {
             if let Ok(config) = crate::config::AppConfig::load(&request.data_root) {
                 crate::semantic::maybe_autostart_daemon(
@@ -388,7 +411,11 @@ fn core_status_facts(data_root: &Path, usage: Option<UsageAction>) -> Result<Val
     }))
 }
 
-fn core_setup_facts(data_root: &Path, options: CoreSetupOptions) -> Result<Value> {
+fn core_setup_facts(
+    data_root: &Path,
+    options: CoreSetupOptions,
+    events: &mut dyn CapabilityEventSink,
+) -> Result<Value> {
     let CoreSetupOptions {
         catalog_only,
         defer_fresh_empty_wait,
@@ -429,6 +456,7 @@ fn core_setup_facts(data_root: &Path, options: CoreSetupOptions) -> Result<Value
             defer_fresh_empty_wait,
             &notice_lines,
             progress_mode,
+            events,
         )?
     } else {
         (
@@ -454,142 +482,6 @@ fn core_setup_facts(data_root: &Path, options: CoreSetupOptions) -> Result<Value
     }))
 }
 
-fn core_setup_refresh(
-    data_root: &Path,
-    wait: bool,
-    defer_fresh_empty_wait: bool,
-    notice_lines: &[String],
-    progress_mode: crate::progress::ProgressArg,
-) -> Result<(Option<String>, Value)> {
-    let mut effective_wait = wait;
-    let mut ui = crate::ui::Ui::stdio(ctx_terminal::ui::ColorMode::Auto);
-    let progress_mode = progress_mode_for_notice(
-        progress_mode,
-        ui.stderr_context().content_width(),
-        notice_lines,
-    );
-    let mut reporter =
-        crate::progress::ProgressReporter::new(&mut ui, progress_mode.into(), false, "setup", 0);
-    if !notice_lines.is_empty() {
-        let lines = notice_lines.iter().map(String::as_str).collect::<Vec<_>>();
-        reporter.notice("companion", &lines)?;
-    }
-    let defer_terminal = reporter.is_enabled();
-    let mut terminal_progress = None;
-    let result = {
-        let mut progress = |status: &crate::semantic::RefreshStatus| {
-            if defer_terminal && status.kind()?.request_state().is_terminal() {
-                terminal_progress = Some(status.schema_v1_fields().clone());
-                Ok(())
-            } else {
-                reporter.source_refresh(status).map_err(anyhow::Error::new)
-            }
-        };
-        let mode = if wait {
-            crate::semantic::SourceBackedRefreshMode::Wait
-        } else {
-            crate::semantic::SourceBackedRefreshMode::Background
-        };
-        let mut result = crate::semantic::coordinate_setup_source_backed_refresh_with_progress(
-            data_root,
-            mode,
-            &mut progress,
-        );
-        if result.as_ref().is_err_and(|error| {
-            !defer_fresh_empty_wait && should_wait_for_fresh_empty_publication(wait, error)
-        }) {
-            effective_wait = true;
-            result = crate::semantic::coordinate_setup_source_backed_refresh_with_progress(
-                data_root,
-                crate::semantic::SourceBackedRefreshMode::Wait,
-                &mut progress,
-            );
-        }
-        result
-    };
-    match result {
-        Ok(observation) => {
-            if let Some(terminal) = terminal_progress.take() {
-                let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
-                reporter.source_refresh_with_published_index(
-                    &terminal,
-                    observation.pin.verified_index(),
-                )?;
-            }
-            let generation_id = observation.pin.generation_id().to_owned();
-            let receipt = observation
-                .receipt
-                .as_ref()
-                .map(|receipt| receipt.to_json());
-            Ok((
-                Some(generation_id.clone()),
-                json!({
-                    "daemon_available": observation.daemon_available,
-                    "mode": if effective_wait { "wait" } else { "background" },
-                    "published_generation": generation_id,
-                    "reason": Value::Null,
-                    "receipt": receipt,
-                    "request_id": observation.request_id,
-                    "source_count": observation.source_count,
-                    "status": observation.status,
-                }),
-            ))
-        }
-        Err(error) => {
-            if let Some(terminal) = terminal_progress.take() {
-                let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
-                reporter
-                    .source_refresh(&terminal)
-                    .map_err(anyhow::Error::new)?;
-            }
-            // A caller that explicitly waited asked for a usable generation, not
-            // merely admission. Keep background admission fail-soft, but never
-            // turn a failed waited refresh into a successful setup response.
-            if should_propagate_setup_refresh_failure(effective_wait, &error) {
-                return Err(error);
-            }
-            let pending = (!effective_wait)
-                .then(|| {
-                    error.downcast_ref::<crate::semantic::SourceBackedRefreshPendingPublication>()
-                })
-                .flatten();
-            Ok((
-                None,
-                json!({
-                    "daemon_available": true,
-                    "last_error": format!("{error:#}"),
-                    "mode": if effective_wait { "wait" } else { "background" },
-                    "reason": if pending.is_some() {
-                        "refresh_queued_without_published_generation"
-                    } else {
-                        "refresh_failed"
-                    },
-                    "request_id": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::request_id),
-                    "request_state": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::request_state),
-                    "source_count": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::source_count),
-                    "status": if pending.is_some() { "pending" } else { "unavailable" },
-                }),
-            ))
-        }
-    }
-}
-
-fn should_propagate_setup_refresh_failure(effective_wait: bool, error: &anyhow::Error) -> bool {
-    effective_wait
-        || error.chain().any(|cause| {
-            cause
-                .downcast_ref::<crate::progress::ProgressWriterError>()
-                .is_some()
-        })
-}
-
-fn should_wait_for_fresh_empty_publication(wait: bool, error: &anyhow::Error) -> bool {
-    !wait
-        && error
-            .downcast_ref::<crate::semantic::SourceBackedRefreshPendingPublication>()
-            .is_some_and(|pending| pending.source_count() == 0)
-}
-
 fn setup_generation_id(published: Option<String>, status: &Value) -> Option<String> {
     published.or_else(|| {
         status["lexical"]["generation_id"]
@@ -598,13 +490,35 @@ fn setup_generation_id(published: Option<String>, status: &Value) -> Option<Stri
     })
 }
 
-fn refresh_and_facts(data_root: &Path) -> Result<Value> {
-    let mut progress = |_status: &crate::semantic::RefreshStatus| Ok(());
-    let observation = crate::semantic::coordinate_source_backed_refresh_with_progress(
+fn refresh_and_facts(data_root: &Path, events: &mut dyn CapabilityEventSink) -> Result<Value> {
+    let mut terminal_progress = None;
+    let mut progress = |status: &crate::semantic::RefreshStatus| {
+        if status.kind()?.request_state().is_terminal() {
+            terminal_progress = Some(status.schema_v1_fields().clone());
+            Ok(())
+        } else {
+            events.refresh(status)
+        }
+    };
+    let result = crate::semantic::coordinate_source_backed_refresh_with_progress(
         data_root,
         crate::semantic::SourceBackedRefreshMode::Wait,
         &mut progress,
-    )?;
+    );
+    let observation = match result {
+        Ok(observation) => observation,
+        Err(error) => {
+            if let Some(terminal) = terminal_progress.take() {
+                let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
+                events.refresh(&terminal)?;
+            }
+            return Err(error);
+        }
+    };
+    if let Some(terminal) = terminal_progress.take() {
+        let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
+        events.refresh(&terminal)?;
+    }
     let generation_id = observation.pin.generation_id().to_owned();
     let status = status_facts(data_root)?;
     bounded_value(json!({"generation_id": generation_id, "status": status}))
@@ -614,6 +528,15 @@ fn parse_options(operation: Operation, value: &Value) -> Result<Options> {
     let object = value
         .as_object()
         .ok_or_else(|| anyhow!("options are not an object"))?;
+    if operation == Operation::RefreshAndWait {
+        return match object.len() {
+            0 => Ok(Options::Refresh { events: false }),
+            1 if object.get("progress").and_then(Value::as_str) == Some("events") => {
+                Ok(Options::Refresh { events: true })
+            }
+            _ => Err(anyhow!("refresh progress option is invalid")),
+        };
+    }
     let expected: &[&str] = match operation {
         Operation::CoreSetup => &[
             "catalog_only",
@@ -627,13 +550,13 @@ fn parse_options(operation: Operation, value: &Value) -> Result<Options> {
         Operation::CoreStatus => &["usage"],
         Operation::CoreDoctor
         | Operation::LocalUsageSummary
-        | Operation::RefreshAndWait
         | Operation::WakeRefresh
         | Operation::ManagedPairBegin
         | Operation::ManagedPairUninstall => &[],
         Operation::ManagedPairStage
         | Operation::ManagedPairAbort
         | Operation::ManagedPairStatus => &["attempt_id"],
+        Operation::RefreshAndWait => unreachable!("refresh options returned above"),
     };
     exact_keys(object.keys().map(String::as_str), expected.iter().copied())?;
     match operation {
@@ -838,10 +761,6 @@ fn normalized_absolute_root(value: &str) -> Result<PathBuf> {
         return Err(anyhow!("data root must already be normalized"));
     }
     Ok(path)
-}
-
-fn read_frame() -> Result<Vec<u8>> {
-    read_frame_from(std::io::stdin().lock())
 }
 
 fn read_frame_from(reader: impl std::io::Read) -> Result<Vec<u8>> {

--- a/crates/ctx-cli/src/core_capability.rs
+++ b/crates/ctx-cli/src/core_capability.rs
@@ -23,9 +23,11 @@ use serde_json::{json, Value};
 #[cfg(test)]
 use sha2::{Digest as _, Sha256};
 
+mod failure;
 mod hosted_pair_install;
 mod setup_options;
 
+use failure::produce_response;
 use setup_options::{progress_mode_for_notice, setup_notice_lines, setup_progress_mode};
 
 const INVOCATION: &str = "--ctx-core-capability-v1";
@@ -126,20 +128,36 @@ pub(crate) fn intercept(arguments: &[std::ffi::OsString]) -> Option<ExitCode> {
     if arguments.len() != 2 || arguments.get(1).is_none_or(|value| value != INVOCATION) {
         return None;
     }
-    Some(match run() {
+    Some(capability_exit_code(run()))
+}
+
+fn capability_exit_code(result: Result<()>) -> ExitCode {
+    match result {
         Ok(()) => ExitCode::SUCCESS,
         Err(_) => ExitCode::FAILURE,
-    })
+    }
 }
 
 fn run() -> Result<()> {
-    let request = parse_frame(read_frame()?)?;
-    let response = execute(request)?;
-    let bytes = canonical(&response)?;
-    if bytes.len() > MAX_RESPONSE_BYTES {
-        return Err(anyhow!("response exceeds bound"));
-    }
+    let (bytes, terminal_error) = produce_response(read_frame()?, execute)?;
     write_response_frame(std::io::stdout().lock(), &bytes)?;
+    if let Some(error) = terminal_error {
+        return Err(error);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn run_with_io(
+    reader: impl std::io::Read,
+    writer: impl std::io::Write,
+    execute_request: impl FnOnce(Request) -> Result<Value>,
+) -> Result<()> {
+    let (bytes, terminal_error) = produce_response(read_frame_from(reader)?, execute_request)?;
+    write_response_frame(writer, &bytes)?;
+    if let Some(error) = terminal_error {
+        return Err(error);
+    }
     Ok(())
 }
 
@@ -823,9 +841,12 @@ fn normalized_absolute_root(value: &str) -> Result<PathBuf> {
 }
 
 fn read_frame() -> Result<Vec<u8>> {
+    read_frame_from(std::io::stdin().lock())
+}
+
+fn read_frame_from(reader: impl std::io::Read) -> Result<Vec<u8>> {
     let mut bytes = Vec::new();
-    std::io::stdin()
-        .lock()
+    reader
         .take((MAX_FRAME_BYTES + 2) as u64)
         .read_to_end(&mut bytes)?;
     if bytes.last() == Some(&b'\n') {

--- a/crates/ctx-cli/src/core_capability/failure.rs
+++ b/crates/ctx-cli/src/core_capability/failure.rs
@@ -1,0 +1,46 @@
+use super::*;
+
+pub(super) fn produce_response(
+    input: Vec<u8>,
+    execute_request: impl FnOnce(Request) -> Result<Value>,
+) -> Result<(Vec<u8>, Option<anyhow::Error>)> {
+    let request = parse_frame(input)?;
+    let operation = request.operation;
+    let (response, terminal_error) = match execute_request(request) {
+        Ok(response) => (response, None),
+        Err(error) => match terminal_failure_response(operation, &error) {
+            Some(response) => (response, Some(error)),
+            None => return Err(error),
+        },
+    };
+    let bytes = canonical(&response)?;
+    if bytes.len() > MAX_RESPONSE_BYTES {
+        return Err(anyhow!("response exceeds bound"));
+    }
+    Ok((bytes, terminal_error))
+}
+
+fn terminal_failure_response(operation: Operation, error: &anyhow::Error) -> Option<Value> {
+    let terminal = error.chain().find_map(|cause| {
+        cause.downcast_ref::<crate::semantic::SourceBackedRefreshTerminalError>()
+    })?;
+    // Keep arbitrary display/detail text behind the boundary. Only the
+    // terminal type's validated structured fields enter the failure frame.
+    Some(json!({
+        "details": {
+            "affected_routes": &terminal.affected_routes,
+            "blocked_routes": &terminal.blocked_routes,
+            "class": terminal.class.as_str(),
+            "physical_attempt_id": terminal.physical_attempt_id.as_str(),
+            "retained_generation": terminal.retained_generation.as_deref(),
+            "retry_advice": terminal.retry_advice.as_deref(),
+            "retryable_routes": &terminal.retryable_routes,
+        },
+        "error_code": terminal.code.as_str(),
+        "ok": false,
+        "operation": operation.name(),
+        "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+        "retryable": terminal.retryable,
+        "schema_version": 1,
+    }))
+}

--- a/crates/ctx-cli/src/core_capability/failure.rs
+++ b/crates/ctx-cli/src/core_capability/failure.rs
@@ -21,6 +21,8 @@ pub(super) fn produce_response(
 }
 
 fn terminal_failure_response(operation: Operation, error: &anyhow::Error) -> Option<Value> {
+    use super::progress_events::neutral_dynamic_text;
+
     let terminal = error.chain().find_map(|cause| {
         cause.downcast_ref::<crate::semantic::SourceBackedRefreshTerminalError>()
     })?;
@@ -31,8 +33,8 @@ fn terminal_failure_response(operation: Operation, error: &anyhow::Error) -> Opt
             "affected_routes": &terminal.affected_routes,
             "blocked_routes": &terminal.blocked_routes,
             "class": terminal.class.as_str(),
-            "physical_attempt_id": terminal.physical_attempt_id.as_str(),
-            "retained_generation": terminal.retained_generation.as_deref(),
+            "physical_attempt_id": neutral_dynamic_text(&terminal.physical_attempt_id),
+            "retained_generation": terminal.retained_generation.as_deref().map(neutral_dynamic_text),
             "retry_advice": terminal.retry_advice.as_deref(),
             "retryable_routes": &terminal.retryable_routes,
         },

--- a/crates/ctx-cli/src/core_capability/progress_events.rs
+++ b/crates/ctx-cli/src/core_capability/progress_events.rs
@@ -1,0 +1,245 @@
+use std::io::Write;
+
+use anyhow::Result;
+use ctx_history_refresh::{
+    RefreshLogicalPhase, RefreshRequestState, RefreshStatus, RefreshStatusKind,
+    RefreshTerminalOutcome,
+};
+use serde_json::{json, Value};
+
+use super::{canonical, write_response_frame, Operation, CORE_PRO_PROTOCOL_VERSION};
+
+const MAX_EVENT_FRAME_BYTES: usize = 48 * 1024;
+const MAX_EVENT_STREAM_BYTES: usize = 32 * 1024 * 1024;
+const MAX_EVENT_FRAMES: u64 = 20_000;
+
+pub(super) trait CapabilityEventSink {
+    fn refresh(&mut self, status: &RefreshStatus) -> Result<()>;
+}
+
+pub(super) struct ProtocolEventWriter<'a> {
+    operation: Operation,
+    sequence: u64,
+    stream_bytes: usize,
+    writer: &'a mut dyn Write,
+}
+
+impl<'a> ProtocolEventWriter<'a> {
+    pub(super) fn new(operation: Operation, writer: &'a mut dyn Write) -> Self {
+        Self {
+            operation,
+            sequence: 0,
+            stream_bytes: 0,
+            writer,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn exhaust_byte_budget_for_test(&mut self) {
+        self.stream_bytes = MAX_EVENT_STREAM_BYTES;
+    }
+
+    #[cfg(test)]
+    pub(super) fn exhaust_frame_budget_for_test(&mut self) {
+        self.sequence = MAX_EVENT_FRAMES;
+    }
+}
+
+impl CapabilityEventSink for ProtocolEventWriter<'_> {
+    fn refresh(&mut self, status: &RefreshStatus) -> Result<()> {
+        if self.sequence >= MAX_EVENT_FRAMES {
+            return Err(CapabilityEventWriterError::StreamTooLarge.into());
+        }
+        let frame = refresh_event_frame(self.operation, self.sequence, status)?;
+        let bytes = canonical(&frame)?;
+        if bytes.len() > MAX_EVENT_FRAME_BYTES {
+            return Err(CapabilityEventWriterError::FrameTooLarge.into());
+        }
+        // Canonical JSON escapes C0 values. Reject raw terminal control bytes
+        // as a second boundary check before the frame reaches stdout.
+        if bytes
+            .iter()
+            .any(|byte| matches!(byte, b'\0' | b'\r' | 0x1b))
+        {
+            return Err(CapabilityEventWriterError::ControlByte.into());
+        }
+        let framed_bytes = bytes
+            .len()
+            .checked_add(1)
+            .ok_or(CapabilityEventWriterError::StreamTooLarge)?;
+        self.stream_bytes = self
+            .stream_bytes
+            .checked_add(framed_bytes)
+            .filter(|total| *total <= MAX_EVENT_STREAM_BYTES)
+            .ok_or(CapabilityEventWriterError::StreamTooLarge)?;
+        write_response_frame(&mut self.writer, &bytes)
+            .map_err(|_| CapabilityEventWriterError::Write)?;
+        self.sequence += 1;
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum CapabilityEventWriterError {
+    #[error("Core capability event frame exceeds its bound")]
+    FrameTooLarge,
+    #[error("Core capability event stream exceeds its bound")]
+    StreamTooLarge,
+    #[error("Core capability event frame contains a control byte")]
+    ControlByte,
+    #[error("Core capability event stream write failed")]
+    Write,
+}
+
+fn refresh_event_frame(
+    operation: Operation,
+    sequence: u64,
+    status: &RefreshStatus,
+) -> Result<Value> {
+    let kind = status.kind()?;
+    let progress = status.progress()?;
+    let current_source_progress = progress.current_source_progress.map(|current| {
+        let mut value = json!({
+            "logical_certified_bytes": current.logical_certified_bytes,
+            "logical_rows_scanned": current.logical_rows_scanned,
+            "snapshot_bytes_completed": current.snapshot_bytes_completed,
+            "snapshot_bytes_total": current.snapshot_bytes_total,
+            "snapshot_pages_completed": current.snapshot_pages_completed,
+            "snapshot_pages_total": current.snapshot_pages_total,
+            "stage": current.stage.as_str(),
+        });
+        remove_null_fields(&mut value);
+        value
+    });
+    let mut refresh = json!({
+        "completed_bytes": progress.completed_bytes,
+        "completed_records": progress.completed_records,
+        "completed_sources": u64::try_from(progress.completed_sources)?,
+        "current_source": progress.current_source.as_deref().map(neutral_dynamic_text),
+        "current_source_progress": current_source_progress,
+        "elapsed_millis": progress.elapsed_millis,
+        "estimated_remaining_millis": status.estimated_remaining_millis()?,
+        "phase": neutral_dynamic_text(&progress.phase),
+        "processed_bytes": progress.processed_bytes,
+        "processed_messages": progress.processed_messages,
+        "processed_sessions": progress.processed_sessions,
+        "processed_tool_calls": progress.processed_tool_calls,
+        "providers": progress.providers.iter().map(|provider| neutral_dynamic_text(provider)).collect::<Vec<_>>(),
+        "request_state": request_state_name(kind.request_state()),
+        "total_sources": u64::try_from(progress.total_sources)?,
+        "total_sources_known": status.total_sources_known()?,
+        "whole_run_stage": status.whole_run_stage()?.as_str(),
+    });
+    if let Some(request_id) = status.request_id() {
+        refresh["request_id"] = json!(neutral_dynamic_text(request_id));
+    }
+    append_typed_status(&mut refresh, &kind);
+    Ok(json!({
+        "event": "refresh",
+        "operation": operation.name(),
+        "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+        "refresh": refresh,
+        "schema_version": 1,
+        "sequence": sequence,
+        "type": "ctx_core_capability_event",
+    }))
+}
+
+fn append_typed_status(refresh: &mut Value, kind: &RefreshStatusKind) {
+    match kind {
+        RefreshStatusKind::Legacy { .. } => {}
+        RefreshStatusKind::BackgroundMaintenanceWake(_) => {
+            refresh["logical_phase"] = json!("waiting");
+            refresh["maintenance_wake"] = json!(true);
+        }
+        RefreshStatusKind::Logical(logical) => {
+            refresh["logical_phase"] = json!(logical_phase_name(logical.logical_phase));
+            refresh["physical_attempt_id"] =
+                json!(neutral_dynamic_text(&logical.physical_attempt_id));
+            refresh["physical_attempt_state"] =
+                json!(request_state_name(logical.physical_attempt_state));
+            refresh["progress_owner_request_id"] =
+                json!(neutral_dynamic_text(&logical.progress_owner_request_id));
+            refresh["progress_owner_attempt_state"] =
+                json!(request_state_name(logical.progress_owner_attempt_state));
+            if let Some(outcome) = logical.structured_outcome.as_ref() {
+                refresh["terminal_state"] = terminal_state(outcome);
+            }
+        }
+    }
+}
+
+fn terminal_state(outcome: &RefreshTerminalOutcome) -> Value {
+    let mut details = json!({
+        "affected_routes": outcome.affected_routes.iter().map(|route| route.as_str()).collect::<Vec<_>>(),
+        "blocked_routes": outcome.blocked_routes.iter().map(|route| route.as_str()).collect::<Vec<_>>(),
+        "class": outcome.class.as_str(),
+        "physical_attempt_id": neutral_dynamic_text(&outcome.physical_attempt_id),
+        "published_generation": outcome.published_generation.as_deref().map(neutral_dynamic_text),
+        "retained_generation": outcome.retained_generation.as_deref().map(neutral_dynamic_text),
+        "retry_advice": outcome.retry_advice.map(|advice| advice.as_str()),
+        "retryable_routes": outcome.retryable_routes.iter().map(|route| route.as_str()).collect::<Vec<_>>(),
+    });
+    remove_null_fields(&mut details);
+    json!({
+        "details": details,
+        "error_code": outcome.code.as_str(),
+        "retryable": outcome.retryable,
+    })
+}
+
+fn remove_null_fields(value: &mut Value) {
+    if let Value::Object(fields) = value {
+        fields.retain(|_, value| !value.is_null());
+    }
+}
+
+fn request_state_name(state: RefreshRequestState) -> &'static str {
+    match state {
+        RefreshRequestState::AdmissionPending => "admission_pending",
+        RefreshRequestState::Queued => "queued",
+        RefreshRequestState::Running => "running",
+        RefreshRequestState::Published => "published",
+        RefreshRequestState::Failed => "failed",
+    }
+}
+
+fn logical_phase_name(phase: RefreshLogicalPhase) -> &'static str {
+    match phase {
+        RefreshLogicalPhase::Waiting => "waiting",
+        RefreshLogicalPhase::Attached => "attached",
+        RefreshLogicalPhase::CoverageCheck => "coverage_check",
+        RefreshLogicalPhase::ExactSuccessor => "exact_successor",
+        RefreshLogicalPhase::Direct => "direct",
+        RefreshLogicalPhase::Terminal => "terminal",
+    }
+}
+
+pub(super) fn neutral_dynamic_text(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(|character| {
+            if character.is_control() {
+                format!("\\u{{{:04X}}}", u32::from(character))
+                    .chars()
+                    .collect()
+            } else {
+                vec![character]
+            }
+        })
+        .collect()
+}
+
+pub(super) struct IgnoreEvents;
+
+impl CapabilityEventSink for IgnoreEvents {
+    fn refresh(&mut self, _status: &RefreshStatus) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub(super) fn event_writer_error(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.downcast_ref::<CapabilityEventWriterError>().is_some())
+}

--- a/crates/ctx-cli/src/core_capability/setup_options.rs
+++ b/crates/ctx-cli/src/core_capability/setup_options.rs
@@ -1,6 +1,12 @@
 use anyhow::{anyhow, Result};
 use serde_json::Value;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SetupProgressMode {
+    Legacy(crate::progress::ProgressArg),
+    Events,
+}
+
 pub(super) fn setup_notice_lines(object: &serde_json::Map<String, Value>) -> Result<Vec<String>> {
     const MAX_NOTICE_LINES: usize = 8;
     const MAX_NOTICE_LINE_BYTES: usize = 512;
@@ -50,12 +56,21 @@ pub(super) fn progress_mode_for_notice(
 
 pub(super) fn setup_progress_mode(
     object: &serde_json::Map<String, Value>,
-) -> Result<crate::progress::ProgressArg> {
+) -> Result<SetupProgressMode> {
     match object.get("progress").and_then(Value::as_str) {
-        Some("auto") => Ok(crate::progress::ProgressArg::Auto),
-        Some("plain") => Ok(crate::progress::ProgressArg::Plain),
-        Some("json") => Ok(crate::progress::ProgressArg::Json),
-        Some("none") => Ok(crate::progress::ProgressArg::None),
+        Some("auto") => Ok(SetupProgressMode::Legacy(
+            crate::progress::ProgressArg::Auto,
+        )),
+        Some("plain") => Ok(SetupProgressMode::Legacy(
+            crate::progress::ProgressArg::Plain,
+        )),
+        Some("json") => Ok(SetupProgressMode::Legacy(
+            crate::progress::ProgressArg::Json,
+        )),
+        Some("none") => Ok(SetupProgressMode::Legacy(
+            crate::progress::ProgressArg::None,
+        )),
+        Some("events") => Ok(SetupProgressMode::Events),
         _ => Err(anyhow!("setup progress option is invalid")),
     }
 }

--- a/crates/ctx-cli/src/core_capability/setup_refresh.rs
+++ b/crates/ctx-cli/src/core_capability/setup_refresh.rs
@@ -1,0 +1,257 @@
+use super::*;
+
+pub(super) fn core_setup_refresh(
+    data_root: &Path,
+    wait: bool,
+    defer_fresh_empty_wait: bool,
+    notice_lines: &[String],
+    progress_mode: SetupProgressMode,
+    events: &mut dyn CapabilityEventSink,
+) -> Result<(Option<String>, Value)> {
+    match progress_mode {
+        SetupProgressMode::Legacy(mode) => {
+            core_setup_refresh_legacy(data_root, wait, defer_fresh_empty_wait, notice_lines, mode)
+        }
+        SetupProgressMode::Events => {
+            core_setup_refresh_events(data_root, wait, defer_fresh_empty_wait, events)
+        }
+    }
+}
+
+fn core_setup_refresh_events(
+    data_root: &Path,
+    wait: bool,
+    defer_fresh_empty_wait: bool,
+    events: &mut dyn CapabilityEventSink,
+) -> Result<(Option<String>, Value)> {
+    let mut effective_wait = wait;
+    let mut terminal_progress = None;
+    let result = {
+        let mut progress = |status: &crate::semantic::RefreshStatus| {
+            if status.kind()?.request_state().is_terminal() {
+                terminal_progress = Some(status.schema_v1_fields().clone());
+                Ok(())
+            } else {
+                events.refresh(status)
+            }
+        };
+        let mode = if wait {
+            crate::semantic::SourceBackedRefreshMode::Wait
+        } else {
+            crate::semantic::SourceBackedRefreshMode::Background
+        };
+        let mut result = crate::semantic::coordinate_setup_source_backed_refresh_with_progress(
+            data_root,
+            mode,
+            &mut progress,
+        );
+        if result.as_ref().is_err_and(|error| {
+            !defer_fresh_empty_wait && should_wait_for_fresh_empty_publication(wait, error)
+        }) {
+            effective_wait = true;
+            result = crate::semantic::coordinate_setup_source_backed_refresh_with_progress(
+                data_root,
+                crate::semantic::SourceBackedRefreshMode::Wait,
+                &mut progress,
+            );
+        }
+        result
+    };
+    match result {
+        Ok(observation) => {
+            if let Some(terminal) = terminal_progress.take() {
+                let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
+                events.refresh(&terminal)?;
+            }
+            let generation_id = observation.pin.generation_id().to_owned();
+            let receipt = observation
+                .receipt
+                .as_ref()
+                .map(|receipt| receipt.to_json());
+            Ok((
+                Some(generation_id.clone()),
+                json!({
+                    "daemon_available": observation.daemon_available,
+                    "mode": if effective_wait { "wait" } else { "background" },
+                    "published_generation": generation_id,
+                    "reason": Value::Null,
+                    "receipt": receipt,
+                    "request_id": observation.request_id,
+                    "source_count": observation.source_count,
+                    "status": observation.status,
+                }),
+            ))
+        }
+        Err(error) => {
+            if let Some(terminal) = terminal_progress.take() {
+                let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
+                events.refresh(&terminal)?;
+            }
+            // A caller that explicitly waited asked for a usable generation, not
+            // merely admission. Keep background admission fail-soft, but never
+            // turn a failed waited refresh into a successful setup response.
+            if should_propagate_setup_refresh_failure(effective_wait, &error) {
+                return Err(error);
+            }
+            let pending = (!effective_wait)
+                .then(|| {
+                    error.downcast_ref::<crate::semantic::SourceBackedRefreshPendingPublication>()
+                })
+                .flatten();
+            Ok((
+                None,
+                json!({
+                    "daemon_available": true,
+                    "last_error": format!("{error:#}"),
+                    "mode": if effective_wait { "wait" } else { "background" },
+                    "reason": if pending.is_some() {
+                        "refresh_queued_without_published_generation"
+                    } else {
+                        "refresh_failed"
+                    },
+                    "request_id": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::request_id),
+                    "request_state": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::request_state),
+                    "source_count": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::source_count),
+                    "status": if pending.is_some() { "pending" } else { "unavailable" },
+                }),
+            ))
+        }
+    }
+}
+
+fn core_setup_refresh_legacy(
+    data_root: &Path,
+    wait: bool,
+    defer_fresh_empty_wait: bool,
+    notice_lines: &[String],
+    progress_mode: crate::progress::ProgressArg,
+) -> Result<(Option<String>, Value)> {
+    let mut effective_wait = wait;
+    let mut ui = crate::ui::Ui::stdio(ctx_terminal::ui::ColorMode::Auto);
+    let progress_mode = progress_mode_for_notice(
+        progress_mode,
+        ui.stderr_context().content_width(),
+        notice_lines,
+    );
+    let mut reporter =
+        crate::progress::ProgressReporter::new(&mut ui, progress_mode.into(), false, "setup", 0);
+    if !notice_lines.is_empty() {
+        let lines = notice_lines.iter().map(String::as_str).collect::<Vec<_>>();
+        reporter.notice("companion", &lines)?;
+    }
+    let defer_terminal = reporter.is_enabled();
+    let mut terminal_progress = None;
+    let result = {
+        let mut progress = |status: &crate::semantic::RefreshStatus| {
+            if defer_terminal && status.kind()?.request_state().is_terminal() {
+                terminal_progress = Some(status.schema_v1_fields().clone());
+                Ok(())
+            } else {
+                reporter.source_refresh(status).map_err(anyhow::Error::new)
+            }
+        };
+        let mode = if wait {
+            crate::semantic::SourceBackedRefreshMode::Wait
+        } else {
+            crate::semantic::SourceBackedRefreshMode::Background
+        };
+        let mut result = crate::semantic::coordinate_setup_source_backed_refresh_with_progress(
+            data_root,
+            mode,
+            &mut progress,
+        );
+        if result.as_ref().is_err_and(|error| {
+            !defer_fresh_empty_wait && should_wait_for_fresh_empty_publication(wait, error)
+        }) {
+            effective_wait = true;
+            result = crate::semantic::coordinate_setup_source_backed_refresh_with_progress(
+                data_root,
+                crate::semantic::SourceBackedRefreshMode::Wait,
+                &mut progress,
+            );
+        }
+        result
+    };
+    match result {
+        Ok(observation) => {
+            if let Some(terminal) = terminal_progress.take() {
+                let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
+                reporter.source_refresh_with_published_index(
+                    &terminal,
+                    observation.pin.verified_index(),
+                )?;
+            }
+            let generation_id = observation.pin.generation_id().to_owned();
+            let receipt = observation
+                .receipt
+                .as_ref()
+                .map(|receipt| receipt.to_json());
+            Ok((
+                Some(generation_id.clone()),
+                json!({
+                    "daemon_available": observation.daemon_available,
+                    "mode": if effective_wait { "wait" } else { "background" },
+                    "published_generation": generation_id,
+                    "reason": Value::Null,
+                    "receipt": receipt,
+                    "request_id": observation.request_id,
+                    "source_count": observation.source_count,
+                    "status": observation.status,
+                }),
+            ))
+        }
+        Err(error) => {
+            if let Some(terminal) = terminal_progress.take() {
+                let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
+                reporter
+                    .source_refresh(&terminal)
+                    .map_err(anyhow::Error::new)?;
+            }
+            if should_propagate_setup_refresh_failure(effective_wait, &error) {
+                return Err(error);
+            }
+            let pending = (!effective_wait)
+                .then(|| {
+                    error.downcast_ref::<crate::semantic::SourceBackedRefreshPendingPublication>()
+                })
+                .flatten();
+            Ok((
+                None,
+                json!({
+                    "daemon_available": true,
+                    "last_error": format!("{error:#}"),
+                    "mode": if effective_wait { "wait" } else { "background" },
+                    "reason": if pending.is_some() {
+                        "refresh_queued_without_published_generation"
+                    } else {
+                        "refresh_failed"
+                    },
+                    "request_id": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::request_id),
+                    "request_state": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::request_state),
+                    "source_count": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::source_count),
+                    "status": if pending.is_some() { "pending" } else { "unavailable" },
+                }),
+            ))
+        }
+    }
+}
+
+pub(super) fn should_propagate_setup_refresh_failure(
+    effective_wait: bool,
+    error: &anyhow::Error,
+) -> bool {
+    effective_wait
+        || error.chain().any(|cause| {
+            cause
+                .downcast_ref::<crate::progress::ProgressWriterError>()
+                .is_some()
+        })
+        || progress_events::event_writer_error(error)
+}
+
+pub(super) fn should_wait_for_fresh_empty_publication(wait: bool, error: &anyhow::Error) -> bool {
+    !wait
+        && error
+            .downcast_ref::<crate::semantic::SourceBackedRefreshPendingPublication>()
+            .is_some_and(|pending| pending.source_count() == 0)
+}

--- a/crates/ctx-cli/src/core_capability/tests.rs
+++ b/crates/ctx-cli/src/core_capability/tests.rs
@@ -2,6 +2,7 @@ use super::hosted_pair_install::{
     acquire_hosted_install_lock, hosted_source_path, replace_hosted_file, stage_hosted_bytes,
     HostedInstallMarker,
 };
+use super::progress_events::{CapabilityEventSink, IgnoreEvents, ProtocolEventWriter};
 use super::*;
 use ctx_history_index::SourceRouteIdentity;
 use ctx_history_refresh::{
@@ -92,6 +93,331 @@ fn capability_response_is_one_exact_flushed_json_frame() {
 }
 
 #[test]
+fn refresh_progress_event_is_canonical_bounded_control_free_protocol_json() {
+    let status = crate::semantic::RefreshStatus::parse_schema_v1(json!({
+        "request_id": "logical-request",
+        "request_state": "running",
+        "logical_request_id": "logical-request",
+        "logical_phase": "exact_successor",
+        "physical_attempt_id": "physical-attempt",
+        "physical_attempt_state": "running",
+        "progress_owner_request_id": "physical-attempt",
+        "progress_owner_attempt_state": "running",
+        "progress": {
+            "phase": "copying",
+            "completed_sources": 1,
+            "total_sources": 2,
+            "total_sources_known": true,
+            "current_source": "history\u{001b}[31m\u{009b}red",
+            "completed_records": 8,
+            "completed_bytes": 256,
+            "providers": ["codex"],
+            "processed_sessions": 3,
+            "processed_messages": 5,
+            "processed_tool_calls": 2,
+            "processed_bytes": 1024,
+            "elapsed_millis": 1200,
+            "whole_run_stage": "reading",
+            "estimated_remaining_millis": 3400,
+            "current_source_progress": {
+                "stage": "online_backup",
+                "snapshot_pages_completed": 2,
+                "snapshot_pages_total": 4,
+                "snapshot_bytes_completed": 256,
+                "snapshot_bytes_total": 512
+            }
+        }
+    }))
+    .unwrap();
+    let mut output = Vec::new();
+    let mut events = ProtocolEventWriter::new(Operation::CoreSetup, &mut output);
+
+    events.refresh(&status).unwrap();
+
+    assert_eq!(output.iter().filter(|byte| **byte == b'\n').count(), 1);
+    assert!(!output.contains(&0x1b));
+    assert!(!output.contains(&b'\r'));
+    let frame: Value = serde_json::from_slice(output.strip_suffix(b"\n").unwrap()).unwrap();
+    assert_eq!(canonical(&frame).unwrap(), output[..output.len() - 1]);
+    assert_eq!(frame["type"], "ctx_core_capability_event");
+    assert_eq!(frame["event"], "refresh");
+    assert_eq!(frame["operation"], "CoreSetup");
+    assert_eq!(frame["protocol_version"], CORE_PRO_PROTOCOL_VERSION.get());
+    assert_eq!(frame["schema_version"], 1);
+    assert_eq!(frame["sequence"], 0);
+    assert_eq!(frame["refresh"]["request_id"], "logical-request");
+    assert_eq!(frame["refresh"]["request_state"], "running");
+    assert_eq!(frame["refresh"]["whole_run_stage"], "reading");
+    assert_eq!(frame["refresh"]["providers"], json!(["codex"]));
+    assert_eq!(
+        frame["refresh"]["current_source"],
+        "history\\u{001B}[31m\\u{009B}red"
+    );
+    assert_eq!(
+        frame["refresh"]["current_source_progress"],
+        json!({
+            "stage": "online_backup",
+            "snapshot_pages_completed": 2,
+            "snapshot_pages_total": 4,
+            "snapshot_bytes_completed": 256,
+            "snapshot_bytes_total": 512,
+        })
+    );
+    assert!(frame["refresh"].get("terminal_state").is_none());
+}
+
+#[test]
+fn refresh_terminal_event_preserves_typed_outcome_and_hides_arbitrary_detail() {
+    let route = "ab".repeat(32);
+    let retained = "cd".repeat(32);
+    let status = crate::semantic::RefreshStatus::parse_schema_v1(json!({
+        "request_id": "logical-request",
+        "request_state": "failed",
+        "logical_request_id": "logical-request",
+        "logical_phase": "terminal",
+        "physical_attempt_id": "physical-attempt",
+        "physical_attempt_state": "failed",
+        "progress_owner_request_id": "physical-attempt",
+        "progress_owner_attempt_state": "failed",
+        "progress": {
+            "phase": "failed",
+            "completed_sources": 1,
+            "total_sources": 2,
+            "total_sources_known": true,
+            "providers": ["codex"],
+            "whole_run_stage": "failed"
+        },
+        "structured_outcome": {
+            "code": "index_corruption",
+            "class": "corruption",
+            "retryable": false,
+            "affected_routes": [route],
+            "retryable_routes": [],
+            "blocked_routes": [route],
+            "physical_attempt_id": "physical-attempt",
+            "retained_generation": retained,
+            "published_generation": null,
+            "retry_advice": "rebuild_index",
+            "detail": "raw path, token, and arbitrary diagnostics stay inside Core"
+        }
+    }))
+    .unwrap();
+    let mut output = Vec::new();
+    let mut events = ProtocolEventWriter::new(Operation::RefreshAndWait, &mut output);
+
+    events.refresh(&status).unwrap();
+
+    let frame: Value = serde_json::from_slice(output.strip_suffix(b"\n").unwrap()).unwrap();
+    assert_eq!(frame["event"], "refresh");
+    assert_eq!(frame["refresh"]["request_state"], "failed");
+    assert_eq!(
+        frame["refresh"]["terminal_state"]["error_code"],
+        "index_corruption"
+    );
+    assert_eq!(frame["refresh"]["terminal_state"]["retryable"], false);
+    assert_eq!(
+        frame["refresh"]["terminal_state"]["details"],
+        json!({
+            "affected_routes": [route],
+            "blocked_routes": [route],
+            "class": "corruption",
+            "physical_attempt_id": "physical-attempt",
+            "retained_generation": retained,
+            "retry_advice": "rebuild_index",
+            "retryable_routes": [],
+        })
+    );
+    assert!(!String::from_utf8(output)
+        .unwrap()
+        .contains("arbitrary diagnostics"));
+}
+
+#[test]
+fn protocol_stream_orders_progress_before_the_single_terminal_response() {
+    let root = tempfile::tempdir().unwrap();
+    let request = json!({
+        "data_root": root.path(),
+        "operation": "CoreSetup",
+        "options": {
+            "catalog_only": false,
+            "defer_fresh_empty_wait": false,
+            "no_daemon": false,
+            "notice_lines": [],
+            "progress": "events",
+            "semantic": false,
+            "wait": true
+        },
+        "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+        "schema_version": 1,
+    });
+    let mut input = canonical(&request).unwrap();
+    input.push(b'\n');
+    let status = crate::semantic::RefreshStatus::parse_schema_v1(json!({
+        "request_state": "running",
+        "progress": {
+            "phase": "reading",
+            "completed_sources": 0,
+            "total_sources": 1,
+            "total_sources_known": true,
+            "whole_run_stage": "reading"
+        }
+    }))
+    .unwrap();
+    let mut output = Vec::new();
+
+    run_with_protocol_io(
+        std::io::Cursor::new(input),
+        &mut output,
+        |request, events| {
+            events.refresh(&status)?;
+            Ok(json!({
+                "facts": {"generation_id": null},
+                "ok": true,
+                "operation": request.operation.name(),
+                "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+                "schema_version": 1,
+            }))
+        },
+    )
+    .unwrap();
+
+    let frames = output
+        .split(|byte| *byte == b'\n')
+        .filter(|frame| !frame.is_empty())
+        .map(|frame| serde_json::from_slice::<Value>(frame).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames[0]["event"], "refresh");
+    assert_eq!(frames[0]["sequence"], 0);
+    assert_eq!(frames[1]["ok"], true);
+    assert!(frames[1].get("type").is_none());
+}
+
+#[test]
+fn legacy_refresh_request_still_writes_exactly_one_terminal_response() {
+    let root = tempfile::tempdir().unwrap();
+    let request = json!({
+        "data_root": root.path(),
+        "operation": "RefreshAndWait",
+        "options": {},
+        "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+        "schema_version": 1,
+    });
+    let mut input = canonical(&request).unwrap();
+    input.push(b'\n');
+    let mut output = Vec::new();
+
+    run_with_protocol_io(
+        std::io::Cursor::new(input),
+        &mut output,
+        |request, _events| {
+            assert!(matches!(
+                request.options,
+                Options::Refresh { events: false }
+            ));
+            Ok(json!({
+                "facts": {},
+                "generation_id": null,
+                "ok": true,
+                "operation": request.operation.name(),
+                "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+                "schema_version": 1,
+            }))
+        },
+    )
+    .unwrap();
+
+    assert_eq!(output.iter().filter(|byte| **byte == b'\n').count(), 1);
+    let response: Value = serde_json::from_slice(output.strip_suffix(b"\n").unwrap()).unwrap();
+    assert_eq!(response["ok"], true);
+    assert!(response.get("event").is_none());
+}
+
+#[test]
+fn event_frame_and_cumulative_stream_bounds_fail_before_writing() {
+    let oversized = crate::semantic::RefreshStatus::parse_schema_v1(json!({
+        "request_state": "running",
+        "progress": {
+            "phase": "reading",
+            "completed_sources": 0,
+            "total_sources": 1,
+            "total_sources_known": true,
+            "current_source": "x".repeat(48 * 1024),
+            "whole_run_stage": "reading"
+        }
+    }))
+    .unwrap();
+    let mut oversized_output = Vec::new();
+    let mut oversized_writer =
+        ProtocolEventWriter::new(Operation::CoreSetup, &mut oversized_output);
+    let error = oversized_writer.refresh(&oversized).unwrap_err();
+    assert!(progress_events::event_writer_error(&error));
+    assert!(oversized_output.is_empty());
+
+    let status = crate::semantic::RefreshStatus::parse_schema_v1(json!({
+        "request_state": "running",
+        "progress": {
+            "phase": "reading",
+            "completed_sources": 0,
+            "total_sources": 1,
+            "total_sources_known": true,
+            "whole_run_stage": "reading"
+        }
+    }))
+    .unwrap();
+    let mut byte_output = Vec::new();
+    let mut byte_writer = ProtocolEventWriter::new(Operation::CoreSetup, &mut byte_output);
+    byte_writer.exhaust_byte_budget_for_test();
+    let error = byte_writer.refresh(&status).unwrap_err();
+    assert!(progress_events::event_writer_error(&error));
+    assert!(byte_output.is_empty());
+
+    let mut frame_output = Vec::new();
+    let mut frame_writer = ProtocolEventWriter::new(Operation::CoreSetup, &mut frame_output);
+    frame_writer.exhaust_frame_budget_for_test();
+    let error = frame_writer.refresh(&status).unwrap_err();
+    assert!(progress_events::event_writer_error(&error));
+    assert!(frame_output.is_empty());
+}
+
+#[test]
+fn broken_event_stream_is_a_typed_writer_failure() {
+    struct BrokenWriter;
+
+    impl std::io::Write for BrokenWriter {
+        fn write(&mut self, _buffer: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "injected broken event stream",
+            ))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let status = crate::semantic::RefreshStatus::parse_schema_v1(json!({
+        "request_state": "running",
+        "progress": {
+            "phase": "reading",
+            "completed_sources": 0,
+            "total_sources": 1,
+            "total_sources_known": true,
+            "whole_run_stage": "reading"
+        }
+    }))
+    .unwrap();
+    let mut output = BrokenWriter;
+    let mut events = ProtocolEventWriter::new(Operation::CoreSetup, &mut output);
+
+    let error = events.refresh(&status).unwrap_err();
+
+    assert!(progress_events::event_writer_error(&error));
+    assert!(should_propagate_setup_refresh_failure(false, &error));
+}
+
+#[test]
 fn recognized_terminal_failure_writes_one_exact_frame_and_exits_nonzero() {
     let root = tempfile::tempdir().unwrap();
     let request = json!({
@@ -113,8 +439,8 @@ fn recognized_terminal_failure_writes_one_exact_frame_and_exits_nonzero() {
             affected_routes: BTreeSet::from([route.clone()]),
             retryable_routes: BTreeSet::new(),
             blocked_routes: BTreeSet::from([route]),
-            physical_attempt_id: "00000000-0000-0000-0000-000000000123".to_owned(),
-            retained_generation: Some("cd".repeat(32)),
+            physical_attempt_id: "attempt\u{009b}[31m".to_owned(),
+            retained_generation: Some(format!("{}\u{001b}[32m", "cd".repeat(32))),
             published_generation: None,
             retry_advice: Some(RefreshRetryAdvice::RebuildIndex),
             detail: Some("arbitrary source detail must not cross the boundary".to_owned()),
@@ -133,16 +459,119 @@ fn recognized_terminal_failure_writes_one_exact_frame_and_exits_nonzero() {
     ));
 
     assert_eq!(status, ExitCode::FAILURE);
+    assert_eq!(output.iter().filter(|byte| **byte == b'\n').count(), 1);
+    assert!(!output.contains(&0x1b));
+    let response: Value = serde_json::from_slice(output.strip_suffix(b"\n").unwrap()).unwrap();
+    assert_eq!(canonical(&response).unwrap(), output[..output.len() - 1]);
+    assert_eq!(response["error_code"], "index_corruption");
+    assert_eq!(response["retryable"], false);
     assert_eq!(
-        output,
-        format!(
-            "{{\"details\":{{\"affected_routes\":[\"{}\"],\"blocked_routes\":[\"{}\"],\"class\":\"corruption\",\"physical_attempt_id\":\"00000000-0000-0000-0000-000000000123\",\"retained_generation\":\"{}\",\"retry_advice\":\"rebuild_index\",\"retryable_routes\":[]}},\"error_code\":\"index_corruption\",\"ok\":false,\"operation\":\"RefreshAndWait\",\"protocol_version\":3,\"retryable\":false,\"schema_version\":1}}\n",
-            "ab".repeat(32),
-            "ab".repeat(32),
-            "cd".repeat(32),
-        )
-        .as_bytes()
+        response["details"]["physical_attempt_id"],
+        "attempt\\u{009B}[31m"
     );
+    assert_eq!(
+        response["details"]["retained_generation"],
+        format!("{}\\u{{001B}}[32m", "cd".repeat(32))
+    );
+    assert!(!String::from_utf8(output).unwrap().contains('\u{009b}'));
+}
+
+#[test]
+fn event_terminal_state_and_final_failure_are_ordered_and_typed_the_same() {
+    let root = tempfile::tempdir().unwrap();
+    let request = json!({
+        "data_root": root.path(),
+        "operation": "RefreshAndWait",
+        "options": {"progress": "events"},
+        "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+        "schema_version": 1,
+    });
+    let mut input = canonical(&request).unwrap();
+    input.push(b'\n');
+    let route_text = "ab".repeat(32);
+    let retained = "cd".repeat(32);
+    let status = crate::semantic::RefreshStatus::parse_schema_v1(json!({
+        "request_id": "logical-request",
+        "request_state": "failed",
+        "logical_request_id": "logical-request",
+        "logical_phase": "terminal",
+        "physical_attempt_id": "physical-attempt",
+        "physical_attempt_state": "failed",
+        "progress_owner_request_id": "physical-attempt",
+        "progress_owner_attempt_state": "failed",
+        "progress": {
+            "phase": "failed",
+            "completed_sources": 0,
+            "total_sources": 1,
+            "total_sources_known": true,
+            "whole_run_stage": "failed"
+        },
+        "structured_outcome": {
+            "code": "index_corruption",
+            "class": "corruption",
+            "retryable": false,
+            "affected_routes": [route_text],
+            "retryable_routes": [],
+            "blocked_routes": [route_text],
+            "physical_attempt_id": "physical-attempt",
+            "retained_generation": retained,
+            "published_generation": null,
+            "retry_advice": "rebuild_index"
+        }
+    }))
+    .unwrap();
+    let route = SourceRouteIdentity::from_sha256(route_text).unwrap();
+    let terminal: anyhow::Error =
+        crate::semantic::SourceBackedRefreshTerminalError::from(RefreshTerminalOutcome {
+            code: RefreshOutcomeCode::IndexCorruption,
+            class: RefreshOutcomeClass::Corruption,
+            retryable: false,
+            affected_routes: BTreeSet::from([route.clone()]),
+            retryable_routes: BTreeSet::new(),
+            blocked_routes: BTreeSet::from([route]),
+            physical_attempt_id: "physical-attempt".to_owned(),
+            retained_generation: Some(retained),
+            published_generation: None,
+            retry_advice: Some(RefreshRetryAdvice::RebuildIndex),
+            detail: Some("private terminal detail".to_owned()),
+        })
+        .into();
+    let mut output = Vec::new();
+
+    let exit = capability_exit_code(run_with_protocol_io(
+        std::io::Cursor::new(input),
+        &mut output,
+        |_request, events| {
+            events.refresh(&status)?;
+            Err(terminal)
+        },
+    ));
+
+    assert_eq!(exit, ExitCode::FAILURE);
+    let frames = output
+        .split(|byte| *byte == b'\n')
+        .filter(|frame| !frame.is_empty())
+        .map(|frame| serde_json::from_slice::<Value>(frame).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames[0]["event"], "refresh");
+    assert_eq!(frames[0]["refresh"]["request_state"], "failed");
+    assert_eq!(frames[1]["ok"], false);
+    assert_eq!(
+        frames[0]["refresh"]["terminal_state"]["error_code"],
+        frames[1]["error_code"]
+    );
+    assert_eq!(
+        frames[0]["refresh"]["terminal_state"]["retryable"],
+        frames[1]["retryable"]
+    );
+    assert_eq!(
+        frames[0]["refresh"]["terminal_state"]["details"],
+        frames[1]["details"]
+    );
+    assert!(!String::from_utf8(output)
+        .unwrap()
+        .contains("private terminal detail"));
 }
 
 #[test]
@@ -185,11 +614,14 @@ fn local_usage_summary_returns_canonical_config_error_without_aborting() {
     )
     .unwrap();
 
-    let response = execute(Request {
-        data_root: root.path().to_path_buf(),
-        operation: Operation::LocalUsageSummary,
-        options: Options::Empty,
-    })
+    let response = execute(
+        Request {
+            data_root: root.path().to_path_buf(),
+            operation: Operation::LocalUsageSummary,
+            options: Options::Empty,
+        },
+        &mut IgnoreEvents,
+    )
     .unwrap();
 
     assert_eq!(response["ok"], true);
@@ -297,7 +729,29 @@ fn managed_setup_presentation_options_are_closed_and_bounded() {
     };
     assert!(defer_fresh_empty_wait);
     assert_eq!(notice_lines[2], "https://companion.example.test/opaque");
-    assert_eq!(progress, crate::progress::ProgressArg::Auto);
+    assert_eq!(
+        progress,
+        SetupProgressMode::Legacy(crate::progress::ProgressArg::Auto)
+    );
+
+    let mut event_options = options.clone();
+    event_options["progress"] = json!("events");
+    let Options::Setup(CoreSetupOptions { progress, .. }) =
+        parse_options(Operation::CoreSetup, &event_options).unwrap()
+    else {
+        panic!("expected setup event options")
+    };
+    assert_eq!(progress, SetupProgressMode::Events);
+
+    assert!(matches!(
+        parse_options(Operation::RefreshAndWait, &json!({})).unwrap(),
+        Options::Refresh { events: false }
+    ));
+    assert!(matches!(
+        parse_options(Operation::RefreshAndWait, &json!({"progress": "events"})).unwrap(),
+        Options::Refresh { events: true }
+    ));
+    assert!(parse_options(Operation::RefreshAndWait, &json!({"progress": "plain"})).is_err());
 
     let mut invalid = options.clone();
     invalid["notice_lines"] = json!(["line\nforgery"]);

--- a/crates/ctx-cli/src/core_capability/tests.rs
+++ b/crates/ctx-cli/src/core_capability/tests.rs
@@ -3,6 +3,10 @@ use super::hosted_pair_install::{
     HostedInstallMarker,
 };
 use super::*;
+use ctx_history_index::SourceRouteIdentity;
+use ctx_history_refresh::{
+    RefreshOutcomeClass, RefreshOutcomeCode, RefreshRetryAdvice, RefreshTerminalOutcome,
+};
 
 #[test]
 fn fingerprint_is_the_sha256_of_the_canonical_inventory() {
@@ -85,6 +89,91 @@ fn capability_response_is_one_exact_flushed_json_frame() {
     let mut output = Vec::new();
     write_response_frame(&mut output, br#"{"ok":true}"#).unwrap();
     assert_eq!(output, b"{\"ok\":true}\n");
+}
+
+#[test]
+fn recognized_terminal_failure_writes_one_exact_frame_and_exits_nonzero() {
+    let root = tempfile::tempdir().unwrap();
+    let request = json!({
+        "data_root": root.path(),
+        "operation": "RefreshAndWait",
+        "options": {},
+        "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+        "schema_version": 1,
+    });
+    let mut input = canonical(&request).unwrap();
+    input.push(b'\n');
+
+    let route = SourceRouteIdentity::from_sha256("ab".repeat(32)).unwrap();
+    let terminal: anyhow::Error =
+        crate::semantic::SourceBackedRefreshTerminalError::from(RefreshTerminalOutcome {
+            code: RefreshOutcomeCode::IndexCorruption,
+            class: RefreshOutcomeClass::Corruption,
+            retryable: false,
+            affected_routes: BTreeSet::from([route.clone()]),
+            retryable_routes: BTreeSet::new(),
+            blocked_routes: BTreeSet::from([route]),
+            physical_attempt_id: "00000000-0000-0000-0000-000000000123".to_owned(),
+            retained_generation: Some("cd".repeat(32)),
+            published_generation: None,
+            retry_advice: Some(RefreshRetryAdvice::RebuildIndex),
+            detail: Some("arbitrary source detail must not cross the boundary".to_owned()),
+        })
+        .into();
+    let terminal = terminal.context("arbitrary internal context must not cross the boundary");
+    let mut output = Vec::new();
+
+    let status = capability_exit_code(run_with_io(
+        std::io::Cursor::new(input),
+        &mut output,
+        |request| {
+            assert_eq!(request.operation, Operation::RefreshAndWait);
+            Err(terminal)
+        },
+    ));
+
+    assert_eq!(status, ExitCode::FAILURE);
+    assert_eq!(
+        output,
+        format!(
+            "{{\"details\":{{\"affected_routes\":[\"{}\"],\"blocked_routes\":[\"{}\"],\"class\":\"corruption\",\"physical_attempt_id\":\"00000000-0000-0000-0000-000000000123\",\"retained_generation\":\"{}\",\"retry_advice\":\"rebuild_index\",\"retryable_routes\":[]}},\"error_code\":\"index_corruption\",\"ok\":false,\"operation\":\"RefreshAndWait\",\"protocol_version\":3,\"retryable\":false,\"schema_version\":1}}\n",
+            "ab".repeat(32),
+            "ab".repeat(32),
+            "cd".repeat(32),
+        )
+        .as_bytes()
+    );
+}
+
+#[test]
+fn malformed_and_unknown_failures_remain_silent_and_nonzero() {
+    let mut malformed_output = Vec::new();
+    let malformed_status = capability_exit_code(run_with_io(
+        std::io::Cursor::new(b"not-json\n"),
+        &mut malformed_output,
+        |_| -> Result<Value> { panic!("malformed input must not execute") },
+    ));
+    assert_eq!(malformed_status, ExitCode::FAILURE);
+    assert!(malformed_output.is_empty());
+
+    let root = tempfile::tempdir().unwrap();
+    let request = json!({
+        "data_root": root.path(),
+        "operation": "RefreshAndWait",
+        "options": {},
+        "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+        "schema_version": 1,
+    });
+    let mut input = canonical(&request).unwrap();
+    input.push(b'\n');
+    let mut internal_output = Vec::new();
+    let internal_status = capability_exit_code(run_with_io(
+        std::io::Cursor::new(input),
+        &mut internal_output,
+        |_| Err(anyhow!("unrecognized internal failure")),
+    ));
+    assert_eq!(internal_status, ExitCode::FAILURE);
+    assert!(internal_output.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Summary:
- add opt-in semantic refresh event frames for CoreSetup and RefreshAndWait while preserving legacy single-frame behavior
- emit typed terminal refresh states and stable typed final failures with bounded, canonical, control-safe NDJSON
- bind nested event and failure shapes in the capability fingerprint and add compatibility/boundary coverage

Validation:
- bazel test //crates/ctx-cli:unit_tests --config=ci
- bazel test //:repository_policy_check --config=ci
- cargo fmt --all -- --check
- git diff --check origin/main...HEAD
- source-built hidden capability smoke: exit 0, one stdout frame, zero stderr bytes
- fresh independent Sol review: approved with no findings

Known baseline issue:
- //crates/ctx-terminal:unit_tests currently fails Clippy at crates/ctx-terminal/src/progress.rs:326 for needless_borrow in origin/main commit 00849ddcb; this branch has no diff in that file.

Dependency:
- includes the reviewed typed terminal failure foundation because its sibling branch/PR was not published at publication time.