### PR TITLE
feat(terminal): compose persistent structured callouts

### DIFF
--- a/crates/ctx-cli/src/core_capability.rs
+++ b/crates/ctx-cli/src/core_capability.rs
@@ -25,10 +25,20 @@ use sha2::{Digest as _, Sha256};
 
 mod failure;
 mod hosted_pair_install;
+mod progress_events;
 mod setup_options;
+mod setup_refresh;
 
 use failure::produce_response;
-use setup_options::{progress_mode_for_notice, setup_notice_lines, setup_progress_mode};
+use progress_events::{CapabilityEventSink, IgnoreEvents, ProtocolEventWriter};
+use setup_options::{
+    progress_mode_for_notice, setup_notice_lines, setup_progress_mode, SetupProgressMode,
+};
+use setup_refresh::core_setup_refresh;
+#[cfg(test)]
+use setup_refresh::{
+    should_propagate_setup_refresh_failure, should_wait_for_fresh_empty_publication,
+};
 
 const INVOCATION: &str = "--ctx-core-capability-v1";
 const HOSTED_PAIR_INSTALL_INVOCATION: &str = "--ctx-core-hosted-pair-install-v1";
@@ -37,10 +47,10 @@ const POST_EXIT_UNINSTALL_INVOCATION: &str = "--ctx-core-managed-pair-uninstall-
 const MAX_FRAME_BYTES: usize = 64 * 1024;
 const MAX_RESPONSE_BYTES: usize = 48 * 1024;
 #[cfg(test)]
-const API_INVENTORY: &str = r#"{"operations":{"CoreDoctor":{"request_keys":[],"response_keys":["facts"]},"CoreSetup":{"request_keys":["catalog_only","defer_fresh_empty_wait","no_daemon","notice_lines","progress","semantic","wait"],"response_keys":["facts","generation_id"]},"CoreStatus":{"request_keys":["usage"],"response_keys":["facts"]},"LocalUsageSummary":{"request_keys":[],"response_keys":["facts"]},"ManagedPairAbort":{"request_keys":["attempt_id"],"response_keys":["aborted"]},"ManagedPairBegin":{"request_keys":[],"response_keys":["attempt_id","candidate_root"]},"ManagedPairStage":{"request_keys":["attempt_id"],"response_keys":["attempt_id","release_name","rollback_generation","status"]},"ManagedPairStatus":{"request_keys":["attempt_id"],"response_keys":["status"]},"ManagedPairUninstall":{"request_keys":[],"response_keys":["attempt_id","cleanup_mode","status"]},"RefreshAndWait":{"request_keys":[],"response_keys":["facts","generation_id"]},"WakeRefresh":{"request_keys":[],"response_keys":["accepted"]}},"protocol":"ctx-core-capability","schema_version":1}"#;
+const API_INVENTORY: &str = r#"{"event_frames":{"Refresh":{"current_source_progress_keys":["logical_certified_bytes","logical_rows_scanned","snapshot_bytes_completed","snapshot_bytes_total","snapshot_pages_completed","snapshot_pages_total","stage"],"frame_keys":["event","operation","protocol_version","refresh","schema_version","sequence","type"],"refresh_keys":["completed_bytes","completed_records","completed_sources","current_source","current_source_progress","elapsed_millis","estimated_remaining_millis","logical_phase","maintenance_wake","phase","physical_attempt_id","physical_attempt_state","processed_bytes","processed_messages","processed_sessions","processed_tool_calls","progress_owner_attempt_state","progress_owner_request_id","providers","request_id","request_state","terminal_state","total_sources","total_sources_known","whole_run_stage"],"terminal_state_details_keys":["affected_routes","blocked_routes","class","physical_attempt_id","published_generation","retained_generation","retry_advice","retryable_routes"],"terminal_state_keys":["details","error_code","retryable"]}},"operations":{"CoreDoctor":{"request_keys":[],"response_keys":["facts"]},"CoreSetup":{"request_keys":["catalog_only","defer_fresh_empty_wait","no_daemon","notice_lines","progress","semantic","wait"],"request_values":{"progress":["auto","events","json","none","plain"]},"response_keys":["facts","generation_id"]},"CoreStatus":{"request_keys":["usage"],"response_keys":["facts"]},"LocalUsageSummary":{"request_keys":[],"response_keys":["facts"]},"ManagedPairAbort":{"request_keys":["attempt_id"],"response_keys":["aborted"]},"ManagedPairBegin":{"request_keys":[],"response_keys":["attempt_id","candidate_root"]},"ManagedPairStage":{"request_keys":["attempt_id"],"response_keys":["attempt_id","release_name","rollback_generation","status"]},"ManagedPairStatus":{"request_keys":["attempt_id"],"response_keys":["status"]},"ManagedPairUninstall":{"request_keys":[],"response_keys":["attempt_id","cleanup_mode","status"]},"RefreshAndWait":{"optional_request_keys":["progress"],"request_keys":[],"request_values":{"progress":["events"]},"response_keys":["facts","generation_id"]},"WakeRefresh":{"request_keys":[],"response_keys":["accepted"]}},"protocol":"ctx-core-capability","schema_version":1,"terminal_failure":{"details_keys":["affected_routes","blocked_routes","class","physical_attempt_id","retained_generation","retry_advice","retryable_routes"],"response_keys":["details","error_code","ok","operation","protocol_version","retryable","schema_version"]}}"#;
 #[cfg(test)]
 pub(crate) const API_FINGERPRINT: &str =
-    "eed67ebb32371c264e6dae66f5499f8bb8baf6c71f5c39eb801fadd25fba9b07";
+    "d03afbac7c95df2df850fcb6b81f49c4051265d70c70a6d7519b18845b9909f2";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Operation {
@@ -139,8 +149,20 @@ fn capability_exit_code(result: Result<()>) -> ExitCode {
 }
 
 fn run() -> Result<()> {
-    let (bytes, terminal_error) = produce_response(read_frame()?, execute)?;
-    write_response_frame(std::io::stdout().lock(), &bytes)?;
+    run_with_protocol_io(std::io::stdin().lock(), std::io::stdout().lock(), execute)
+}
+
+fn run_with_protocol_io(
+    reader: impl std::io::Read,
+    mut writer: impl std::io::Write,
+    execute_request: impl FnOnce(Request, &mut dyn CapabilityEventSink) -> Result<Value>,
+) -> Result<()> {
+    let input = read_frame_from(reader)?;
+    let (bytes, terminal_error) = produce_response(input, |request| {
+        let mut events = ProtocolEventWriter::new(request.operation, &mut writer);
+        execute_request(request, &mut events)
+    })?;
+    write_response_frame(&mut writer, &bytes)?;
     if let Some(error) = terminal_error {
         return Err(error);
     }
@@ -153,12 +175,7 @@ fn run_with_io(
     writer: impl std::io::Write,
     execute_request: impl FnOnce(Request) -> Result<Value>,
 ) -> Result<()> {
-    let (bytes, terminal_error) = produce_response(read_frame_from(reader)?, execute_request)?;
-    write_response_frame(writer, &bytes)?;
-    if let Some(error) = terminal_error {
-        return Err(error);
-    }
-    Ok(())
+    run_with_protocol_io(reader, writer, |request, _events| execute_request(request))
 }
 
 fn write_response_frame(mut writer: impl std::io::Write, bytes: &[u8]) -> Result<()> {
@@ -177,6 +194,7 @@ struct Request {
 enum Options {
     Setup(CoreSetupOptions),
     Status { usage: Option<UsageAction> },
+    Refresh { events: bool },
     PairAttempt { attempt_id: String },
     Empty,
 }
@@ -186,7 +204,7 @@ struct CoreSetupOptions {
     defer_fresh_empty_wait: bool,
     no_daemon: bool,
     notice_lines: Vec<String>,
-    progress: crate::progress::ProgressArg,
+    progress: SetupProgressMode,
     semantic: bool,
     wait: bool,
 }
@@ -252,7 +270,7 @@ fn parse_frame(bytes: Vec<u8>) -> Result<Request> {
     })
 }
 
-fn execute(request: Request) -> Result<Value> {
+fn execute(request: Request, events: &mut dyn CapabilityEventSink) -> Result<Value> {
     if !matches!(
         request.operation,
         Operation::LocalUsageSummary
@@ -266,7 +284,7 @@ fn execute(request: Request) -> Result<Value> {
     }
     let facts = match (request.operation, request.options) {
         (Operation::CoreSetup, Options::Setup(options)) => {
-            core_setup_facts(&request.data_root, options)?
+            core_setup_facts(&request.data_root, options, events)?
         }
         (Operation::CoreStatus, Options::Status { usage }) => {
             core_status_facts(&request.data_root, usage)?
@@ -277,7 +295,12 @@ fn execute(request: Request) -> Result<Value> {
         (Operation::LocalUsageSummary, Options::Empty) => {
             local_usage_summary_facts(&request.data_root)?
         }
-        (Operation::RefreshAndWait, Options::Empty) => refresh_and_facts(&request.data_root)?,
+        (Operation::RefreshAndWait, Options::Refresh { events: true }) => {
+            refresh_and_facts(&request.data_root, events)?
+        }
+        (Operation::RefreshAndWait, Options::Refresh { events: false }) => {
+            refresh_and_facts(&request.data_root, &mut IgnoreEvents)?
+        }
         (Operation::WakeRefresh, Options::Empty) => {
             if let Ok(config) = crate::config::AppConfig::load(&request.data_root) {
                 crate::semantic::maybe_autostart_daemon(
@@ -388,7 +411,11 @@ fn core_status_facts(data_root: &Path, usage: Option<UsageAction>) -> Result<Val
     }))
 }
 
-fn core_setup_facts(data_root: &Path, options: CoreSetupOptions) -> Result<Value> {
+fn core_setup_facts(
+    data_root: &Path,
+    options: CoreSetupOptions,
+    events: &mut dyn CapabilityEventSink,
+) -> Result<Value> {
     let CoreSetupOptions {
         catalog_only,
         defer_fresh_empty_wait,
@@ -429,6 +456,7 @@ fn core_setup_facts(data_root: &Path, options: CoreSetupOptions) -> Result<Value
             defer_fresh_empty_wait,
             &notice_lines,
             progress_mode,
+            events,
         )?
     } else {
         (
@@ -454,142 +482,6 @@ fn core_setup_facts(data_root: &Path, options: CoreSetupOptions) -> Result<Value
     }))
 }
 
-fn core_setup_refresh(
-    data_root: &Path,
-    wait: bool,
-    defer_fresh_empty_wait: bool,
-    notice_lines: &[String],
-    progress_mode: crate::progress::ProgressArg,
-) -> Result<(Option<String>, Value)> {
-    let mut effective_wait = wait;
-    let mut ui = crate::ui::Ui::stdio(ctx_terminal::ui::ColorMode::Auto);
-    let progress_mode = progress_mode_for_notice(
-        progress_mode,
-        ui.stderr_context().content_width(),
-        notice_lines,
-    );
-    let mut reporter =
-        crate::progress::ProgressReporter::new(&mut ui, progress_mode.into(), false, "setup", 0);
-    if !notice_lines.is_empty() {
-        let lines = notice_lines.iter().map(String::as_str).collect::<Vec<_>>();
-        reporter.notice("companion", &lines)?;
-    }
-    let defer_terminal = reporter.is_enabled();
-    let mut terminal_progress = None;
-    let result = {
-        let mut progress = |status: &crate::semantic::RefreshStatus| {
-            if defer_terminal && status.kind()?.request_state().is_terminal() {
-                terminal_progress = Some(status.schema_v1_fields().clone());
-                Ok(())
-            } else {
-                reporter.source_refresh(status).map_err(anyhow::Error::new)
-            }
-        };
-        let mode = if wait {
-            crate::semantic::SourceBackedRefreshMode::Wait
-        } else {
-            crate::semantic::SourceBackedRefreshMode::Background
-        };
-        let mut result = crate::semantic::coordinate_setup_source_backed_refresh_with_progress(
-            data_root,
-            mode,
-            &mut progress,
-        );
-        if result.as_ref().is_err_and(|error| {
-            !defer_fresh_empty_wait && should_wait_for_fresh_empty_publication(wait, error)
-        }) {
-            effective_wait = true;
-            result = crate::semantic::coordinate_setup_source_backed_refresh_with_progress(
-                data_root,
-                crate::semantic::SourceBackedRefreshMode::Wait,
-                &mut progress,
-            );
-        }
-        result
-    };
-    match result {
-        Ok(observation) => {
-            if let Some(terminal) = terminal_progress.take() {
-                let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
-                reporter.source_refresh_with_published_index(
-                    &terminal,
-                    observation.pin.verified_index(),
-                )?;
-            }
-            let generation_id = observation.pin.generation_id().to_owned();
-            let receipt = observation
-                .receipt
-                .as_ref()
-                .map(|receipt| receipt.to_json());
-            Ok((
-                Some(generation_id.clone()),
-                json!({
-                    "daemon_available": observation.daemon_available,
-                    "mode": if effective_wait { "wait" } else { "background" },
-                    "published_generation": generation_id,
-                    "reason": Value::Null,
-                    "receipt": receipt,
-                    "request_id": observation.request_id,
-                    "source_count": observation.source_count,
-                    "status": observation.status,
-                }),
-            ))
-        }
-        Err(error) => {
-            if let Some(terminal) = terminal_progress.take() {
-                let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
-                reporter
-                    .source_refresh(&terminal)
-                    .map_err(anyhow::Error::new)?;
-            }
-            // A caller that explicitly waited asked for a usable generation, not
-            // merely admission. Keep background admission fail-soft, but never
-            // turn a failed waited refresh into a successful setup response.
-            if should_propagate_setup_refresh_failure(effective_wait, &error) {
-                return Err(error);
-            }
-            let pending = (!effective_wait)
-                .then(|| {
-                    error.downcast_ref::<crate::semantic::SourceBackedRefreshPendingPublication>()
-                })
-                .flatten();
-            Ok((
-                None,
-                json!({
-                    "daemon_available": true,
-                    "last_error": format!("{error:#}"),
-                    "mode": if effective_wait { "wait" } else { "background" },
-                    "reason": if pending.is_some() {
-                        "refresh_queued_without_published_generation"
-                    } else {
-                        "refresh_failed"
-                    },
-                    "request_id": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::request_id),
-                    "request_state": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::request_state),
-                    "source_count": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::source_count),
-                    "status": if pending.is_some() { "pending" } else { "unavailable" },
-                }),
-            ))
-        }
-    }
-}
-
-fn should_propagate_setup_refresh_failure(effective_wait: bool, error: &anyhow::Error) -> bool {
-    effective_wait
-        || error.chain().any(|cause| {
-            cause
-                .downcast_ref::<crate::progress::ProgressWriterError>()
-                .is_some()
-        })
-}
-
-fn should_wait_for_fresh_empty_publication(wait: bool, error: &anyhow::Error) -> bool {
-    !wait
-        && error
-            .downcast_ref::<crate::semantic::SourceBackedRefreshPendingPublication>()
-            .is_some_and(|pending| pending.source_count() == 0)
-}
-
 fn setup_generation_id(published: Option<String>, status: &Value) -> Option<String> {
     published.or_else(|| {
         status["lexical"]["generation_id"]
@@ -598,13 +490,35 @@ fn setup_generation_id(published: Option<String>, status: &Value) -> Option<Stri
     })
 }
 
-fn refresh_and_facts(data_root: &Path) -> Result<Value> {
-    let mut progress = |_status: &crate::semantic::RefreshStatus| Ok(());
-    let observation = crate::semantic::coordinate_source_backed_refresh_with_progress(
+fn refresh_and_facts(data_root: &Path, events: &mut dyn CapabilityEventSink) -> Result<Value> {
+    let mut terminal_progress = None;
+    let mut progress = |status: &crate::semantic::RefreshStatus| {
+        if status.kind()?.request_state().is_terminal() {
+            terminal_progress = Some(status.schema_v1_fields().clone());
+            Ok(())
+        } else {
+            events.refresh(status)
+        }
+    };
+    let result = crate::semantic::coordinate_source_backed_refresh_with_progress(
         data_root,
         crate::semantic::SourceBackedRefreshMode::Wait,
         &mut progress,
-    )?;
+    );
+    let observation = match result {
+        Ok(observation) => observation,
+        Err(error) => {
+            if let Some(terminal) = terminal_progress.take() {
+                let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
+                events.refresh(&terminal)?;
+            }
+            return Err(error);
+        }
+    };
+    if let Some(terminal) = terminal_progress.take() {
+        let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
+        events.refresh(&terminal)?;
+    }
     let generation_id = observation.pin.generation_id().to_owned();
     let status = status_facts(data_root)?;
     bounded_value(json!({"generation_id": generation_id, "status": status}))
@@ -614,6 +528,15 @@ fn parse_options(operation: Operation, value: &Value) -> Result<Options> {
     let object = value
         .as_object()
         .ok_or_else(|| anyhow!("options are not an object"))?;
+    if operation == Operation::RefreshAndWait {
+        return match object.len() {
+            0 => Ok(Options::Refresh { events: false }),
+            1 if object.get("progress").and_then(Value::as_str) == Some("events") => {
+                Ok(Options::Refresh { events: true })
+            }
+            _ => Err(anyhow!("refresh progress option is invalid")),
+        };
+    }
     let expected: &[&str] = match operation {
         Operation::CoreSetup => &[
             "catalog_only",
@@ -627,13 +550,13 @@ fn parse_options(operation: Operation, value: &Value) -> Result<Options> {
         Operation::CoreStatus => &["usage"],
         Operation::CoreDoctor
         | Operation::LocalUsageSummary
-        | Operation::RefreshAndWait
         | Operation::WakeRefresh
         | Operation::ManagedPairBegin
         | Operation::ManagedPairUninstall => &[],
         Operation::ManagedPairStage
         | Operation::ManagedPairAbort
         | Operation::ManagedPairStatus => &["attempt_id"],
+        Operation::RefreshAndWait => unreachable!("refresh options returned above"),
     };
     exact_keys(object.keys().map(String::as_str), expected.iter().copied())?;
     match operation {
@@ -838,10 +761,6 @@ fn normalized_absolute_root(value: &str) -> Result<PathBuf> {
         return Err(anyhow!("data root must already be normalized"));
     }
     Ok(path)
-}
-
-fn read_frame() -> Result<Vec<u8>> {
-    read_frame_from(std::io::stdin().lock())
 }
 
 fn read_frame_from(reader: impl std::io::Read) -> Result<Vec<u8>> {

--- a/crates/ctx-cli/src/core_capability/failure.rs
+++ b/crates/ctx-cli/src/core_capability/failure.rs
@@ -23,6 +23,8 @@ pub(super) fn produce_response(
 }
 
 fn terminal_failure_response(operation: Operation, error: &anyhow::Error) -> Option<Value> {
+    use super::progress_events::neutral_dynamic_text;
+
     let terminal = error.chain().find_map(|cause| {
         cause.downcast_ref::<crate::semantic::SourceBackedRefreshTerminalError>()
     })?;
@@ -36,8 +38,8 @@ fn terminal_failure_response(operation: Operation, error: &anyhow::Error) -> Opt
             "affected_routes": &terminal.affected_routes,
             "blocked_routes": &terminal.blocked_routes,
             "class": terminal.class.as_str(),
-            "physical_attempt_id": terminal.physical_attempt_id.as_str(),
-            "retained_generation": terminal.retained_generation.as_deref(),
+            "physical_attempt_id": neutral_dynamic_text(&terminal.physical_attempt_id),
+            "retained_generation": terminal.retained_generation.as_deref().map(neutral_dynamic_text),
             "retry_advice": terminal.retry_advice.as_deref(),
             "retryable_routes": &terminal.retryable_routes,
         },

--- a/crates/ctx-cli/src/core_capability/progress_events.rs
+++ b/crates/ctx-cli/src/core_capability/progress_events.rs
@@ -1,0 +1,245 @@
+use std::io::Write;
+
+use anyhow::Result;
+use ctx_history_refresh::{
+    RefreshLogicalPhase, RefreshRequestState, RefreshStatus, RefreshStatusKind,
+    RefreshTerminalOutcome,
+};
+use serde_json::{json, Value};
+
+use super::{canonical, write_response_frame, Operation, CORE_PRO_PROTOCOL_VERSION};
+
+const MAX_EVENT_FRAME_BYTES: usize = 48 * 1024;
+const MAX_EVENT_STREAM_BYTES: usize = 32 * 1024 * 1024;
+const MAX_EVENT_FRAMES: u64 = 20_000;
+
+pub(super) trait CapabilityEventSink {
+    fn refresh(&mut self, status: &RefreshStatus) -> Result<()>;
+}
+
+pub(super) struct ProtocolEventWriter<'a> {
+    operation: Operation,
+    sequence: u64,
+    stream_bytes: usize,
+    writer: &'a mut dyn Write,
+}
+
+impl<'a> ProtocolEventWriter<'a> {
+    pub(super) fn new(operation: Operation, writer: &'a mut dyn Write) -> Self {
+        Self {
+            operation,
+            sequence: 0,
+            stream_bytes: 0,
+            writer,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn exhaust_byte_budget_for_test(&mut self) {
+        self.stream_bytes = MAX_EVENT_STREAM_BYTES;
+    }
+
+    #[cfg(test)]
+    pub(super) fn exhaust_frame_budget_for_test(&mut self) {
+        self.sequence = MAX_EVENT_FRAMES;
+    }
+}
+
+impl CapabilityEventSink for ProtocolEventWriter<'_> {
+    fn refresh(&mut self, status: &RefreshStatus) -> Result<()> {
+        if self.sequence >= MAX_EVENT_FRAMES {
+            return Err(CapabilityEventWriterError::StreamTooLarge.into());
+        }
+        let frame = refresh_event_frame(self.operation, self.sequence, status)?;
+        let bytes = canonical(&frame)?;
+        if bytes.len() > MAX_EVENT_FRAME_BYTES {
+            return Err(CapabilityEventWriterError::FrameTooLarge.into());
+        }
+        // Canonical JSON escapes C0 values. Reject raw terminal control bytes
+        // as a second boundary check before the frame reaches stdout.
+        if bytes
+            .iter()
+            .any(|byte| matches!(byte, b'\0' | b'\r' | 0x1b))
+        {
+            return Err(CapabilityEventWriterError::ControlByte.into());
+        }
+        let framed_bytes = bytes
+            .len()
+            .checked_add(1)
+            .ok_or(CapabilityEventWriterError::StreamTooLarge)?;
+        self.stream_bytes = self
+            .stream_bytes
+            .checked_add(framed_bytes)
+            .filter(|total| *total <= MAX_EVENT_STREAM_BYTES)
+            .ok_or(CapabilityEventWriterError::StreamTooLarge)?;
+        write_response_frame(&mut self.writer, &bytes)
+            .map_err(|_| CapabilityEventWriterError::Write)?;
+        self.sequence += 1;
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum CapabilityEventWriterError {
+    #[error("Core capability event frame exceeds its bound")]
+    FrameTooLarge,
+    #[error("Core capability event stream exceeds its bound")]
+    StreamTooLarge,
+    #[error("Core capability event frame contains a control byte")]
+    ControlByte,
+    #[error("Core capability event stream write failed")]
+    Write,
+}
+
+fn refresh_event_frame(
+    operation: Operation,
+    sequence: u64,
+    status: &RefreshStatus,
+) -> Result<Value> {
+    let kind = status.kind()?;
+    let progress = status.progress()?;
+    let current_source_progress = progress.current_source_progress.map(|current| {
+        let mut value = json!({
+            "logical_certified_bytes": current.logical_certified_bytes,
+            "logical_rows_scanned": current.logical_rows_scanned,
+            "snapshot_bytes_completed": current.snapshot_bytes_completed,
+            "snapshot_bytes_total": current.snapshot_bytes_total,
+            "snapshot_pages_completed": current.snapshot_pages_completed,
+            "snapshot_pages_total": current.snapshot_pages_total,
+            "stage": current.stage.as_str(),
+        });
+        remove_null_fields(&mut value);
+        value
+    });
+    let mut refresh = json!({
+        "completed_bytes": progress.completed_bytes,
+        "completed_records": progress.completed_records,
+        "completed_sources": u64::try_from(progress.completed_sources)?,
+        "current_source": progress.current_source.as_deref().map(neutral_dynamic_text),
+        "current_source_progress": current_source_progress,
+        "elapsed_millis": progress.elapsed_millis,
+        "estimated_remaining_millis": status.estimated_remaining_millis()?,
+        "phase": neutral_dynamic_text(&progress.phase),
+        "processed_bytes": progress.processed_bytes,
+        "processed_messages": progress.processed_messages,
+        "processed_sessions": progress.processed_sessions,
+        "processed_tool_calls": progress.processed_tool_calls,
+        "providers": progress.providers.iter().map(|provider| neutral_dynamic_text(provider)).collect::<Vec<_>>(),
+        "request_state": request_state_name(kind.request_state()),
+        "total_sources": u64::try_from(progress.total_sources)?,
+        "total_sources_known": status.total_sources_known()?,
+        "whole_run_stage": status.whole_run_stage()?.as_str(),
+    });
+    if let Some(request_id) = status.request_id() {
+        refresh["request_id"] = json!(neutral_dynamic_text(request_id));
+    }
+    append_typed_status(&mut refresh, &kind);
+    Ok(json!({
+        "event": "refresh",
+        "operation": operation.name(),
+        "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+        "refresh": refresh,
+        "schema_version": 1,
+        "sequence": sequence,
+        "type": "ctx_core_capability_event",
+    }))
+}
+
+fn append_typed_status(refresh: &mut Value, kind: &RefreshStatusKind) {
+    match kind {
+        RefreshStatusKind::Legacy { .. } => {}
+        RefreshStatusKind::BackgroundMaintenanceWake(_) => {
+            refresh["logical_phase"] = json!("waiting");
+            refresh["maintenance_wake"] = json!(true);
+        }
+        RefreshStatusKind::Logical(logical) => {
+            refresh["logical_phase"] = json!(logical_phase_name(logical.logical_phase));
+            refresh["physical_attempt_id"] =
+                json!(neutral_dynamic_text(&logical.physical_attempt_id));
+            refresh["physical_attempt_state"] =
+                json!(request_state_name(logical.physical_attempt_state));
+            refresh["progress_owner_request_id"] =
+                json!(neutral_dynamic_text(&logical.progress_owner_request_id));
+            refresh["progress_owner_attempt_state"] =
+                json!(request_state_name(logical.progress_owner_attempt_state));
+            if let Some(outcome) = logical.structured_outcome.as_ref() {
+                refresh["terminal_state"] = terminal_state(outcome);
+            }
+        }
+    }
+}
+
+fn terminal_state(outcome: &RefreshTerminalOutcome) -> Value {
+    let mut details = json!({
+        "affected_routes": outcome.affected_routes.iter().map(|route| route.as_str()).collect::<Vec<_>>(),
+        "blocked_routes": outcome.blocked_routes.iter().map(|route| route.as_str()).collect::<Vec<_>>(),
+        "class": outcome.class.as_str(),
+        "physical_attempt_id": neutral_dynamic_text(&outcome.physical_attempt_id),
+        "published_generation": outcome.published_generation.as_deref().map(neutral_dynamic_text),
+        "retained_generation": outcome.retained_generation.as_deref().map(neutral_dynamic_text),
+        "retry_advice": outcome.retry_advice.map(|advice| advice.as_str()),
+        "retryable_routes": outcome.retryable_routes.iter().map(|route| route.as_str()).collect::<Vec<_>>(),
+    });
+    remove_null_fields(&mut details);
+    json!({
+        "details": details,
+        "error_code": outcome.code.as_str(),
+        "retryable": outcome.retryable,
+    })
+}
+
+fn remove_null_fields(value: &mut Value) {
+    if let Value::Object(fields) = value {
+        fields.retain(|_, value| !value.is_null());
+    }
+}
+
+fn request_state_name(state: RefreshRequestState) -> &'static str {
+    match state {
+        RefreshRequestState::AdmissionPending => "admission_pending",
+        RefreshRequestState::Queued => "queued",
+        RefreshRequestState::Running => "running",
+        RefreshRequestState::Published => "published",
+        RefreshRequestState::Failed => "failed",
+    }
+}
+
+fn logical_phase_name(phase: RefreshLogicalPhase) -> &'static str {
+    match phase {
+        RefreshLogicalPhase::Waiting => "waiting",
+        RefreshLogicalPhase::Attached => "attached",
+        RefreshLogicalPhase::CoverageCheck => "coverage_check",
+        RefreshLogicalPhase::ExactSuccessor => "exact_successor",
+        RefreshLogicalPhase::Direct => "direct",
+        RefreshLogicalPhase::Terminal => "terminal",
+    }
+}
+
+pub(super) fn neutral_dynamic_text(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(|character| {
+            if character.is_control() {
+                format!("\\u{{{:04X}}}", u32::from(character))
+                    .chars()
+                    .collect()
+            } else {
+                vec![character]
+            }
+        })
+        .collect()
+}
+
+pub(super) struct IgnoreEvents;
+
+impl CapabilityEventSink for IgnoreEvents {
+    fn refresh(&mut self, _status: &RefreshStatus) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub(super) fn event_writer_error(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.downcast_ref::<CapabilityEventWriterError>().is_some())
+}

--- a/crates/ctx-cli/src/core_capability/setup_options.rs
+++ b/crates/ctx-cli/src/core_capability/setup_options.rs
@@ -1,6 +1,12 @@
 use anyhow::{anyhow, Result};
 use serde_json::Value;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SetupProgressMode {
+    Legacy(crate::progress::ProgressArg),
+    Events,
+}
+
 pub(super) fn setup_notice_lines(object: &serde_json::Map<String, Value>) -> Result<Vec<String>> {
     const MAX_NOTICE_LINES: usize = 8;
     const MAX_NOTICE_LINE_BYTES: usize = 512;
@@ -50,12 +56,21 @@ pub(super) fn progress_mode_for_notice(
 
 pub(super) fn setup_progress_mode(
     object: &serde_json::Map<String, Value>,
-) -> Result<crate::progress::ProgressArg> {
+) -> Result<SetupProgressMode> {
     match object.get("progress").and_then(Value::as_str) {
-        Some("auto") => Ok(crate::progress::ProgressArg::Auto),
-        Some("plain") => Ok(crate::progress::ProgressArg::Plain),
-        Some("json") => Ok(crate::progress::ProgressArg::Json),
-        Some("none") => Ok(crate::progress::ProgressArg::None),
+        Some("auto") => Ok(SetupProgressMode::Legacy(
+            crate::progress::ProgressArg::Auto,
+        )),
+        Some("plain") => Ok(SetupProgressMode::Legacy(
+            crate::progress::ProgressArg::Plain,
+        )),
+        Some("json") => Ok(SetupProgressMode::Legacy(
+            crate::progress::ProgressArg::Json,
+        )),
+        Some("none") => Ok(SetupProgressMode::Legacy(
+            crate::progress::ProgressArg::None,
+        )),
+        Some("events") => Ok(SetupProgressMode::Events),
         _ => Err(anyhow!("setup progress option is invalid")),
     }
 }

--- a/crates/ctx-cli/src/core_capability/setup_refresh.rs
+++ b/crates/ctx-cli/src/core_capability/setup_refresh.rs
@@ -1,0 +1,257 @@
+use super::*;
+
+pub(super) fn core_setup_refresh(
+    data_root: &Path,
+    wait: bool,
+    defer_fresh_empty_wait: bool,
+    notice_lines: &[String],
+    progress_mode: SetupProgressMode,
+    events: &mut dyn CapabilityEventSink,
+) -> Result<(Option<String>, Value)> {
+    match progress_mode {
+        SetupProgressMode::Legacy(mode) => {
+            core_setup_refresh_legacy(data_root, wait, defer_fresh_empty_wait, notice_lines, mode)
+        }
+        SetupProgressMode::Events => {
+            core_setup_refresh_events(data_root, wait, defer_fresh_empty_wait, events)
+        }
+    }
+}
+
+fn core_setup_refresh_events(
+    data_root: &Path,
+    wait: bool,
+    defer_fresh_empty_wait: bool,
+    events: &mut dyn CapabilityEventSink,
+) -> Result<(Option<String>, Value)> {
+    let mut effective_wait = wait;
+    let mut terminal_progress = None;
+    let result = {
+        let mut progress = |status: &crate::semantic::RefreshStatus| {
+            if status.kind()?.request_state().is_terminal() {
+                terminal_progress = Some(status.schema_v1_fields().clone());
+                Ok(())
+            } else {
+                events.refresh(status)
+            }
+        };
+        let mode = if wait {
+            crate::semantic::SourceBackedRefreshMode::Wait
+        } else {
+            crate::semantic::SourceBackedRefreshMode::Background
+        };
+        let mut result = crate::semantic::coordinate_setup_source_backed_refresh_with_progress(
+            data_root,
+            mode,
+            &mut progress,
+        );
+        if result.as_ref().is_err_and(|error| {
+            !defer_fresh_empty_wait && should_wait_for_fresh_empty_publication(wait, error)
+        }) {
+            effective_wait = true;
+            result = crate::semantic::coordinate_setup_source_backed_refresh_with_progress(
+                data_root,
+                crate::semantic::SourceBackedRefreshMode::Wait,
+                &mut progress,
+            );
+        }
+        result
+    };
+    match result {
+        Ok(observation) => {
+            if let Some(terminal) = terminal_progress.take() {
+                let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
+                events.refresh(&terminal)?;
+            }
+            let generation_id = observation.pin.generation_id().to_owned();
+            let receipt = observation
+                .receipt
+                .as_ref()
+                .map(|receipt| receipt.to_json());
+            Ok((
+                Some(generation_id.clone()),
+                json!({
+                    "daemon_available": observation.daemon_available,
+                    "mode": if effective_wait { "wait" } else { "background" },
+                    "published_generation": generation_id,
+                    "reason": Value::Null,
+                    "receipt": receipt,
+                    "request_id": observation.request_id,
+                    "source_count": observation.source_count,
+                    "status": observation.status,
+                }),
+            ))
+        }
+        Err(error) => {
+            if let Some(terminal) = terminal_progress.take() {
+                let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
+                events.refresh(&terminal)?;
+            }
+            // A caller that explicitly waited asked for a usable generation, not
+            // merely admission. Keep background admission fail-soft, but never
+            // turn a failed waited refresh into a successful setup response.
+            if should_propagate_setup_refresh_failure(effective_wait, &error) {
+                return Err(error);
+            }
+            let pending = (!effective_wait)
+                .then(|| {
+                    error.downcast_ref::<crate::semantic::SourceBackedRefreshPendingPublication>()
+                })
+                .flatten();
+            Ok((
+                None,
+                json!({
+                    "daemon_available": true,
+                    "last_error": format!("{error:#}"),
+                    "mode": if effective_wait { "wait" } else { "background" },
+                    "reason": if pending.is_some() {
+                        "refresh_queued_without_published_generation"
+                    } else {
+                        "refresh_failed"
+                    },
+                    "request_id": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::request_id),
+                    "request_state": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::request_state),
+                    "source_count": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::source_count),
+                    "status": if pending.is_some() { "pending" } else { "unavailable" },
+                }),
+            ))
+        }
+    }
+}
+
+fn core_setup_refresh_legacy(
+    data_root: &Path,
+    wait: bool,
+    defer_fresh_empty_wait: bool,
+    notice_lines: &[String],
+    progress_mode: crate::progress::ProgressArg,
+) -> Result<(Option<String>, Value)> {
+    let mut effective_wait = wait;
+    let mut ui = crate::ui::Ui::stdio(ctx_terminal::ui::ColorMode::Auto);
+    let progress_mode = progress_mode_for_notice(
+        progress_mode,
+        ui.stderr_context().content_width(),
+        notice_lines,
+    );
+    let mut reporter =
+        crate::progress::ProgressReporter::new(&mut ui, progress_mode.into(), false, "setup", 0);
+    if !notice_lines.is_empty() {
+        let lines = notice_lines.iter().map(String::as_str).collect::<Vec<_>>();
+        reporter.notice("companion", &lines)?;
+    }
+    let defer_terminal = reporter.is_enabled();
+    let mut terminal_progress = None;
+    let result = {
+        let mut progress = |status: &crate::semantic::RefreshStatus| {
+            if defer_terminal && status.kind()?.request_state().is_terminal() {
+                terminal_progress = Some(status.schema_v1_fields().clone());
+                Ok(())
+            } else {
+                reporter.source_refresh(status).map_err(anyhow::Error::new)
+            }
+        };
+        let mode = if wait {
+            crate::semantic::SourceBackedRefreshMode::Wait
+        } else {
+            crate::semantic::SourceBackedRefreshMode::Background
+        };
+        let mut result = crate::semantic::coordinate_setup_source_backed_refresh_with_progress(
+            data_root,
+            mode,
+            &mut progress,
+        );
+        if result.as_ref().is_err_and(|error| {
+            !defer_fresh_empty_wait && should_wait_for_fresh_empty_publication(wait, error)
+        }) {
+            effective_wait = true;
+            result = crate::semantic::coordinate_setup_source_backed_refresh_with_progress(
+                data_root,
+                crate::semantic::SourceBackedRefreshMode::Wait,
+                &mut progress,
+            );
+        }
+        result
+    };
+    match result {
+        Ok(observation) => {
+            if let Some(terminal) = terminal_progress.take() {
+                let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
+                reporter.source_refresh_with_published_index(
+                    &terminal,
+                    observation.pin.verified_index(),
+                )?;
+            }
+            let generation_id = observation.pin.generation_id().to_owned();
+            let receipt = observation
+                .receipt
+                .as_ref()
+                .map(|receipt| receipt.to_json());
+            Ok((
+                Some(generation_id.clone()),
+                json!({
+                    "daemon_available": observation.daemon_available,
+                    "mode": if effective_wait { "wait" } else { "background" },
+                    "published_generation": generation_id,
+                    "reason": Value::Null,
+                    "receipt": receipt,
+                    "request_id": observation.request_id,
+                    "source_count": observation.source_count,
+                    "status": observation.status,
+                }),
+            ))
+        }
+        Err(error) => {
+            if let Some(terminal) = terminal_progress.take() {
+                let terminal = crate::semantic::RefreshStatus::parse_schema_v1(terminal)?;
+                reporter
+                    .source_refresh(&terminal)
+                    .map_err(anyhow::Error::new)?;
+            }
+            if should_propagate_setup_refresh_failure(effective_wait, &error) {
+                return Err(error);
+            }
+            let pending = (!effective_wait)
+                .then(|| {
+                    error.downcast_ref::<crate::semantic::SourceBackedRefreshPendingPublication>()
+                })
+                .flatten();
+            Ok((
+                None,
+                json!({
+                    "daemon_available": true,
+                    "last_error": format!("{error:#}"),
+                    "mode": if effective_wait { "wait" } else { "background" },
+                    "reason": if pending.is_some() {
+                        "refresh_queued_without_published_generation"
+                    } else {
+                        "refresh_failed"
+                    },
+                    "request_id": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::request_id),
+                    "request_state": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::request_state),
+                    "source_count": pending.map(crate::semantic::SourceBackedRefreshPendingPublication::source_count),
+                    "status": if pending.is_some() { "pending" } else { "unavailable" },
+                }),
+            ))
+        }
+    }
+}
+
+pub(super) fn should_propagate_setup_refresh_failure(
+    effective_wait: bool,
+    error: &anyhow::Error,
+) -> bool {
+    effective_wait
+        || error.chain().any(|cause| {
+            cause
+                .downcast_ref::<crate::progress::ProgressWriterError>()
+                .is_some()
+        })
+        || progress_events::event_writer_error(error)
+}
+
+pub(super) fn should_wait_for_fresh_empty_publication(wait: bool, error: &anyhow::Error) -> bool {
+    !wait
+        && error
+            .downcast_ref::<crate::semantic::SourceBackedRefreshPendingPublication>()
+            .is_some_and(|pending| pending.source_count() == 0)
+}

--- a/crates/ctx-cli/src/core_capability/tests.rs
+++ b/crates/ctx-cli/src/core_capability/tests.rs
@@ -508,6 +508,8 @@ fn recognized_terminal_failure_writes_one_exact_frame_and_exits_nonzero() {
     input.push(b'\n');
 
     let route = SourceRouteIdentity::from_sha256("ab".repeat(32)).unwrap();
+    let physical_attempt_id = "01234567-89ab-cdef-0123-456789abcdef";
+    let retained_generation = "cd".repeat(32);
     let terminal: anyhow::Error =
         crate::semantic::SourceBackedRefreshTerminalError::from(RefreshTerminalOutcome {
             code: RefreshOutcomeCode::IndexCorruption,
@@ -516,8 +518,8 @@ fn recognized_terminal_failure_writes_one_exact_frame_and_exits_nonzero() {
             affected_routes: BTreeSet::from([route.clone()]),
             retryable_routes: BTreeSet::new(),
             blocked_routes: BTreeSet::from([route]),
-            physical_attempt_id: "attempt\u{009b}[31m".to_owned(),
-            retained_generation: Some(format!("{}\u{001b}[32m", "cd".repeat(32))),
+            physical_attempt_id: physical_attempt_id.to_owned(),
+            retained_generation: Some(retained_generation.clone()),
             published_generation: None,
             retry_advice: Some(RefreshRetryAdvice::RebuildIndex),
             detail: Some("arbitrary source detail must not cross the boundary".to_owned()),
@@ -544,11 +546,11 @@ fn recognized_terminal_failure_writes_one_exact_frame_and_exits_nonzero() {
     assert_eq!(response["retryable"], false);
     assert_eq!(
         response["details"]["physical_attempt_id"],
-        "attempt\\u{009B}[31m"
+        physical_attempt_id
     );
     assert_eq!(
         response["details"]["retained_generation"],
-        format!("{}\\u{{001B}}[32m", "cd".repeat(32))
+        retained_generation
     );
     assert!(!String::from_utf8(output).unwrap().contains('\u{009b}'));
 }
@@ -567,14 +569,15 @@ fn event_terminal_state_and_final_failure_are_ordered_and_typed_the_same() {
     input.push(b'\n');
     let route_text = "ab".repeat(32);
     let retained = "cd".repeat(32);
+    let physical_attempt_id = "01234567-89ab-cdef-0123-456789abcdef";
     let status = crate::semantic::RefreshStatus::parse_schema_v1(json!({
         "request_id": "logical-request",
         "request_state": "failed",
         "logical_request_id": "logical-request",
         "logical_phase": "terminal",
-        "physical_attempt_id": "physical-attempt",
+        "physical_attempt_id": physical_attempt_id,
         "physical_attempt_state": "failed",
-        "progress_owner_request_id": "physical-attempt",
+        "progress_owner_request_id": physical_attempt_id,
         "progress_owner_attempt_state": "failed",
         "progress": {
             "phase": "failed",
@@ -590,7 +593,7 @@ fn event_terminal_state_and_final_failure_are_ordered_and_typed_the_same() {
             "affected_routes": [route_text],
             "retryable_routes": [],
             "blocked_routes": [route_text],
-            "physical_attempt_id": "physical-attempt",
+            "physical_attempt_id": physical_attempt_id,
             "retained_generation": retained,
             "published_generation": null,
             "retry_advice": "rebuild_index"
@@ -606,7 +609,7 @@ fn event_terminal_state_and_final_failure_are_ordered_and_typed_the_same() {
             affected_routes: BTreeSet::from([route.clone()]),
             retryable_routes: BTreeSet::new(),
             blocked_routes: BTreeSet::from([route]),
-            physical_attempt_id: "physical-attempt".to_owned(),
+            physical_attempt_id: physical_attempt_id.to_owned(),
             retained_generation: Some(retained),
             published_generation: None,
             retry_advice: Some(RefreshRetryAdvice::RebuildIndex),

--- a/crates/ctx-cli/src/core_capability/tests.rs
+++ b/crates/ctx-cli/src/core_capability/tests.rs
@@ -2,6 +2,7 @@ use super::hosted_pair_install::{
     acquire_hosted_install_lock, hosted_source_path, replace_hosted_file, stage_hosted_bytes,
     HostedInstallMarker,
 };
+use super::progress_events::{CapabilityEventSink, IgnoreEvents, ProtocolEventWriter};
 use super::*;
 use ctx_history_index::SourceRouteIdentity;
 use ctx_history_refresh::{
@@ -169,6 +170,331 @@ fn run_terminal_failure(
 }
 
 #[test]
+fn refresh_progress_event_is_canonical_bounded_control_free_protocol_json() {
+    let status = crate::semantic::RefreshStatus::parse_schema_v1(json!({
+        "request_id": "logical-request",
+        "request_state": "running",
+        "logical_request_id": "logical-request",
+        "logical_phase": "exact_successor",
+        "physical_attempt_id": "physical-attempt",
+        "physical_attempt_state": "running",
+        "progress_owner_request_id": "physical-attempt",
+        "progress_owner_attempt_state": "running",
+        "progress": {
+            "phase": "copying",
+            "completed_sources": 1,
+            "total_sources": 2,
+            "total_sources_known": true,
+            "current_source": "history\u{001b}[31m\u{009b}red",
+            "completed_records": 8,
+            "completed_bytes": 256,
+            "providers": ["codex"],
+            "processed_sessions": 3,
+            "processed_messages": 5,
+            "processed_tool_calls": 2,
+            "processed_bytes": 1024,
+            "elapsed_millis": 1200,
+            "whole_run_stage": "reading",
+            "estimated_remaining_millis": 3400,
+            "current_source_progress": {
+                "stage": "online_backup",
+                "snapshot_pages_completed": 2,
+                "snapshot_pages_total": 4,
+                "snapshot_bytes_completed": 256,
+                "snapshot_bytes_total": 512
+            }
+        }
+    }))
+    .unwrap();
+    let mut output = Vec::new();
+    let mut events = ProtocolEventWriter::new(Operation::CoreSetup, &mut output);
+
+    events.refresh(&status).unwrap();
+
+    assert_eq!(output.iter().filter(|byte| **byte == b'\n').count(), 1);
+    assert!(!output.contains(&0x1b));
+    assert!(!output.contains(&b'\r'));
+    let frame: Value = serde_json::from_slice(output.strip_suffix(b"\n").unwrap()).unwrap();
+    assert_eq!(canonical(&frame).unwrap(), output[..output.len() - 1]);
+    assert_eq!(frame["type"], "ctx_core_capability_event");
+    assert_eq!(frame["event"], "refresh");
+    assert_eq!(frame["operation"], "CoreSetup");
+    assert_eq!(frame["protocol_version"], CORE_PRO_PROTOCOL_VERSION.get());
+    assert_eq!(frame["schema_version"], 1);
+    assert_eq!(frame["sequence"], 0);
+    assert_eq!(frame["refresh"]["request_id"], "logical-request");
+    assert_eq!(frame["refresh"]["request_state"], "running");
+    assert_eq!(frame["refresh"]["whole_run_stage"], "reading");
+    assert_eq!(frame["refresh"]["providers"], json!(["codex"]));
+    assert_eq!(
+        frame["refresh"]["current_source"],
+        "history\\u{001B}[31m\\u{009B}red"
+    );
+    assert_eq!(
+        frame["refresh"]["current_source_progress"],
+        json!({
+            "stage": "online_backup",
+            "snapshot_pages_completed": 2,
+            "snapshot_pages_total": 4,
+            "snapshot_bytes_completed": 256,
+            "snapshot_bytes_total": 512,
+        })
+    );
+    assert!(frame["refresh"].get("terminal_state").is_none());
+}
+
+#[test]
+fn refresh_terminal_event_preserves_typed_outcome_and_hides_arbitrary_detail() {
+    let route = "ab".repeat(32);
+    let retained = "cd".repeat(32);
+    let status = crate::semantic::RefreshStatus::parse_schema_v1(json!({
+        "request_id": "logical-request",
+        "request_state": "failed",
+        "logical_request_id": "logical-request",
+        "logical_phase": "terminal",
+        "physical_attempt_id": "physical-attempt",
+        "physical_attempt_state": "failed",
+        "progress_owner_request_id": "physical-attempt",
+        "progress_owner_attempt_state": "failed",
+        "progress": {
+            "phase": "failed",
+            "completed_sources": 1,
+            "total_sources": 2,
+            "total_sources_known": true,
+            "providers": ["codex"],
+            "whole_run_stage": "failed"
+        },
+        "structured_outcome": {
+            "code": "index_corruption",
+            "class": "corruption",
+            "retryable": false,
+            "affected_routes": [route],
+            "retryable_routes": [],
+            "blocked_routes": [route],
+            "physical_attempt_id": "physical-attempt",
+            "retained_generation": retained,
+            "published_generation": null,
+            "retry_advice": "rebuild_index",
+            "detail": "raw path, token, and arbitrary diagnostics stay inside Core"
+        }
+    }))
+    .unwrap();
+    let mut output = Vec::new();
+    let mut events = ProtocolEventWriter::new(Operation::RefreshAndWait, &mut output);
+
+    events.refresh(&status).unwrap();
+
+    let frame: Value = serde_json::from_slice(output.strip_suffix(b"\n").unwrap()).unwrap();
+    assert_eq!(frame["event"], "refresh");
+    assert_eq!(frame["refresh"]["request_state"], "failed");
+    assert_eq!(
+        frame["refresh"]["terminal_state"]["error_code"],
+        "index_corruption"
+    );
+    assert_eq!(frame["refresh"]["terminal_state"]["retryable"], false);
+    assert_eq!(
+        frame["refresh"]["terminal_state"]["details"],
+        json!({
+            "affected_routes": [route],
+            "blocked_routes": [route],
+            "class": "corruption",
+            "physical_attempt_id": "physical-attempt",
+            "retained_generation": retained,
+            "retry_advice": "rebuild_index",
+            "retryable_routes": [],
+        })
+    );
+    assert!(!String::from_utf8(output)
+        .unwrap()
+        .contains("arbitrary diagnostics"));
+}
+
+#[test]
+fn protocol_stream_orders_progress_before_the_single_terminal_response() {
+    let root = tempfile::tempdir().unwrap();
+    let request = json!({
+        "data_root": root.path(),
+        "operation": "CoreSetup",
+        "options": {
+            "catalog_only": false,
+            "defer_fresh_empty_wait": false,
+            "no_daemon": false,
+            "notice_lines": [],
+            "progress": "events",
+            "semantic": false,
+            "wait": true
+        },
+        "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+        "schema_version": 1,
+    });
+    let mut input = canonical(&request).unwrap();
+    input.push(b'\n');
+    let status = crate::semantic::RefreshStatus::parse_schema_v1(json!({
+        "request_state": "running",
+        "progress": {
+            "phase": "reading",
+            "completed_sources": 0,
+            "total_sources": 1,
+            "total_sources_known": true,
+            "whole_run_stage": "reading"
+        }
+    }))
+    .unwrap();
+    let mut output = Vec::new();
+
+    run_with_protocol_io(
+        std::io::Cursor::new(input),
+        &mut output,
+        |request, events| {
+            events.refresh(&status)?;
+            Ok(json!({
+                "facts": {"generation_id": null},
+                "ok": true,
+                "operation": request.operation.name(),
+                "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+                "schema_version": 1,
+            }))
+        },
+    )
+    .unwrap();
+
+    let frames = output
+        .split(|byte| *byte == b'\n')
+        .filter(|frame| !frame.is_empty())
+        .map(|frame| serde_json::from_slice::<Value>(frame).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames[0]["event"], "refresh");
+    assert_eq!(frames[0]["sequence"], 0);
+    assert_eq!(frames[1]["ok"], true);
+    assert!(frames[1].get("type").is_none());
+}
+
+#[test]
+fn legacy_refresh_request_still_writes_exactly_one_terminal_response() {
+    let root = tempfile::tempdir().unwrap();
+    let request = json!({
+        "data_root": root.path(),
+        "operation": "RefreshAndWait",
+        "options": {},
+        "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+        "schema_version": 1,
+    });
+    let mut input = canonical(&request).unwrap();
+    input.push(b'\n');
+    let mut output = Vec::new();
+
+    run_with_protocol_io(
+        std::io::Cursor::new(input),
+        &mut output,
+        |request, _events| {
+            assert!(matches!(
+                request.options,
+                Options::Refresh { events: false }
+            ));
+            Ok(json!({
+                "facts": {},
+                "generation_id": null,
+                "ok": true,
+                "operation": request.operation.name(),
+                "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+                "schema_version": 1,
+            }))
+        },
+    )
+    .unwrap();
+
+    assert_eq!(output.iter().filter(|byte| **byte == b'\n').count(), 1);
+    let response: Value = serde_json::from_slice(output.strip_suffix(b"\n").unwrap()).unwrap();
+    assert_eq!(response["ok"], true);
+    assert!(response.get("event").is_none());
+}
+
+#[test]
+fn event_frame_and_cumulative_stream_bounds_fail_before_writing() {
+    let oversized = crate::semantic::RefreshStatus::parse_schema_v1(json!({
+        "request_state": "running",
+        "progress": {
+            "phase": "reading",
+            "completed_sources": 0,
+            "total_sources": 1,
+            "total_sources_known": true,
+            "current_source": "x".repeat(48 * 1024),
+            "whole_run_stage": "reading"
+        }
+    }))
+    .unwrap();
+    let mut oversized_output = Vec::new();
+    let mut oversized_writer =
+        ProtocolEventWriter::new(Operation::CoreSetup, &mut oversized_output);
+    let error = oversized_writer.refresh(&oversized).unwrap_err();
+    assert!(progress_events::event_writer_error(&error));
+    assert!(oversized_output.is_empty());
+
+    let status = crate::semantic::RefreshStatus::parse_schema_v1(json!({
+        "request_state": "running",
+        "progress": {
+            "phase": "reading",
+            "completed_sources": 0,
+            "total_sources": 1,
+            "total_sources_known": true,
+            "whole_run_stage": "reading"
+        }
+    }))
+    .unwrap();
+    let mut byte_output = Vec::new();
+    let mut byte_writer = ProtocolEventWriter::new(Operation::CoreSetup, &mut byte_output);
+    byte_writer.exhaust_byte_budget_for_test();
+    let error = byte_writer.refresh(&status).unwrap_err();
+    assert!(progress_events::event_writer_error(&error));
+    assert!(byte_output.is_empty());
+
+    let mut frame_output = Vec::new();
+    let mut frame_writer = ProtocolEventWriter::new(Operation::CoreSetup, &mut frame_output);
+    frame_writer.exhaust_frame_budget_for_test();
+    let error = frame_writer.refresh(&status).unwrap_err();
+    assert!(progress_events::event_writer_error(&error));
+    assert!(frame_output.is_empty());
+}
+
+#[test]
+fn broken_event_stream_is_a_typed_writer_failure() {
+    struct BrokenWriter;
+
+    impl std::io::Write for BrokenWriter {
+        fn write(&mut self, _buffer: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "injected broken event stream",
+            ))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let status = crate::semantic::RefreshStatus::parse_schema_v1(json!({
+        "request_state": "running",
+        "progress": {
+            "phase": "reading",
+            "completed_sources": 0,
+            "total_sources": 1,
+            "total_sources_known": true,
+            "whole_run_stage": "reading"
+        }
+    }))
+    .unwrap();
+    let mut output = BrokenWriter;
+    let mut events = ProtocolEventWriter::new(Operation::CoreSetup, &mut output);
+
+    let error = events.refresh(&status).unwrap_err();
+
+    assert!(progress_events::event_writer_error(&error));
+    assert!(should_propagate_setup_refresh_failure(false, &error));
+}
+
+#[test]
 fn recognized_terminal_failure_writes_one_exact_frame_and_exits_nonzero() {
     let root = tempfile::tempdir().unwrap();
     let request = json!({
@@ -190,8 +516,8 @@ fn recognized_terminal_failure_writes_one_exact_frame_and_exits_nonzero() {
             affected_routes: BTreeSet::from([route.clone()]),
             retryable_routes: BTreeSet::new(),
             blocked_routes: BTreeSet::from([route]),
-            physical_attempt_id: "00000000-0000-0000-0000-000000000123".to_owned(),
-            retained_generation: Some("cd".repeat(32)),
+            physical_attempt_id: "attempt\u{009b}[31m".to_owned(),
+            retained_generation: Some(format!("{}\u{001b}[32m", "cd".repeat(32))),
             published_generation: None,
             retry_advice: Some(RefreshRetryAdvice::RebuildIndex),
             detail: Some("arbitrary source detail must not cross the boundary".to_owned()),
@@ -210,16 +536,119 @@ fn recognized_terminal_failure_writes_one_exact_frame_and_exits_nonzero() {
     ));
 
     assert_eq!(status, ExitCode::FAILURE);
+    assert_eq!(output.iter().filter(|byte| **byte == b'\n').count(), 1);
+    assert!(!output.contains(&0x1b));
+    let response: Value = serde_json::from_slice(output.strip_suffix(b"\n").unwrap()).unwrap();
+    assert_eq!(canonical(&response).unwrap(), output[..output.len() - 1]);
+    assert_eq!(response["error_code"], "index_corruption");
+    assert_eq!(response["retryable"], false);
     assert_eq!(
-        output,
-        format!(
-            "{{\"details\":{{\"affected_routes\":[\"{}\"],\"blocked_routes\":[\"{}\"],\"class\":\"corruption\",\"physical_attempt_id\":\"00000000-0000-0000-0000-000000000123\",\"retained_generation\":\"{}\",\"retry_advice\":\"rebuild_index\",\"retryable_routes\":[]}},\"error_code\":\"index_corruption\",\"ok\":false,\"operation\":\"RefreshAndWait\",\"protocol_version\":3,\"retryable\":false,\"schema_version\":1}}\n",
-            "ab".repeat(32),
-            "ab".repeat(32),
-            "cd".repeat(32),
-        )
-        .as_bytes()
+        response["details"]["physical_attempt_id"],
+        "attempt\\u{009B}[31m"
     );
+    assert_eq!(
+        response["details"]["retained_generation"],
+        format!("{}\\u{{001B}}[32m", "cd".repeat(32))
+    );
+    assert!(!String::from_utf8(output).unwrap().contains('\u{009b}'));
+}
+
+#[test]
+fn event_terminal_state_and_final_failure_are_ordered_and_typed_the_same() {
+    let root = tempfile::tempdir().unwrap();
+    let request = json!({
+        "data_root": root.path(),
+        "operation": "RefreshAndWait",
+        "options": {"progress": "events"},
+        "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
+        "schema_version": 1,
+    });
+    let mut input = canonical(&request).unwrap();
+    input.push(b'\n');
+    let route_text = "ab".repeat(32);
+    let retained = "cd".repeat(32);
+    let status = crate::semantic::RefreshStatus::parse_schema_v1(json!({
+        "request_id": "logical-request",
+        "request_state": "failed",
+        "logical_request_id": "logical-request",
+        "logical_phase": "terminal",
+        "physical_attempt_id": "physical-attempt",
+        "physical_attempt_state": "failed",
+        "progress_owner_request_id": "physical-attempt",
+        "progress_owner_attempt_state": "failed",
+        "progress": {
+            "phase": "failed",
+            "completed_sources": 0,
+            "total_sources": 1,
+            "total_sources_known": true,
+            "whole_run_stage": "failed"
+        },
+        "structured_outcome": {
+            "code": "index_corruption",
+            "class": "corruption",
+            "retryable": false,
+            "affected_routes": [route_text],
+            "retryable_routes": [],
+            "blocked_routes": [route_text],
+            "physical_attempt_id": "physical-attempt",
+            "retained_generation": retained,
+            "published_generation": null,
+            "retry_advice": "rebuild_index"
+        }
+    }))
+    .unwrap();
+    let route = SourceRouteIdentity::from_sha256(route_text).unwrap();
+    let terminal: anyhow::Error =
+        crate::semantic::SourceBackedRefreshTerminalError::from(RefreshTerminalOutcome {
+            code: RefreshOutcomeCode::IndexCorruption,
+            class: RefreshOutcomeClass::Corruption,
+            retryable: false,
+            affected_routes: BTreeSet::from([route.clone()]),
+            retryable_routes: BTreeSet::new(),
+            blocked_routes: BTreeSet::from([route]),
+            physical_attempt_id: "physical-attempt".to_owned(),
+            retained_generation: Some(retained),
+            published_generation: None,
+            retry_advice: Some(RefreshRetryAdvice::RebuildIndex),
+            detail: Some("private terminal detail".to_owned()),
+        })
+        .into();
+    let mut output = Vec::new();
+
+    let exit = capability_exit_code(run_with_protocol_io(
+        std::io::Cursor::new(input),
+        &mut output,
+        |_request, events| {
+            events.refresh(&status)?;
+            Err(terminal)
+        },
+    ));
+
+    assert_eq!(exit, ExitCode::FAILURE);
+    let frames = output
+        .split(|byte| *byte == b'\n')
+        .filter(|frame| !frame.is_empty())
+        .map(|frame| serde_json::from_slice::<Value>(frame).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames[0]["event"], "refresh");
+    assert_eq!(frames[0]["refresh"]["request_state"], "failed");
+    assert_eq!(frames[1]["ok"], false);
+    assert_eq!(
+        frames[0]["refresh"]["terminal_state"]["error_code"],
+        frames[1]["error_code"]
+    );
+    assert_eq!(
+        frames[0]["refresh"]["terminal_state"]["retryable"],
+        frames[1]["retryable"]
+    );
+    assert_eq!(
+        frames[0]["refresh"]["terminal_state"]["details"],
+        frames[1]["details"]
+    );
+    assert!(!String::from_utf8(output)
+        .unwrap()
+        .contains("private terminal detail"));
 }
 
 #[test]
@@ -409,11 +838,14 @@ fn local_usage_summary_returns_canonical_config_error_without_aborting() {
     )
     .unwrap();
 
-    let response = execute(Request {
-        data_root: root.path().to_path_buf(),
-        operation: Operation::LocalUsageSummary,
-        options: Options::Empty,
-    })
+    let response = execute(
+        Request {
+            data_root: root.path().to_path_buf(),
+            operation: Operation::LocalUsageSummary,
+            options: Options::Empty,
+        },
+        &mut IgnoreEvents,
+    )
     .unwrap();
 
     assert_eq!(response["ok"], true);
@@ -521,7 +953,29 @@ fn managed_setup_presentation_options_are_closed_and_bounded() {
     };
     assert!(defer_fresh_empty_wait);
     assert_eq!(notice_lines[2], "https://companion.example.test/opaque");
-    assert_eq!(progress, crate::progress::ProgressArg::Auto);
+    assert_eq!(
+        progress,
+        SetupProgressMode::Legacy(crate::progress::ProgressArg::Auto)
+    );
+
+    let mut event_options = options.clone();
+    event_options["progress"] = json!("events");
+    let Options::Setup(CoreSetupOptions { progress, .. }) =
+        parse_options(Operation::CoreSetup, &event_options).unwrap()
+    else {
+        panic!("expected setup event options")
+    };
+    assert_eq!(progress, SetupProgressMode::Events);
+
+    assert!(matches!(
+        parse_options(Operation::RefreshAndWait, &json!({})).unwrap(),
+        Options::Refresh { events: false }
+    ));
+    assert!(matches!(
+        parse_options(Operation::RefreshAndWait, &json!({"progress": "events"})).unwrap(),
+        Options::Refresh { events: true }
+    ));
+    assert!(parse_options(Operation::RefreshAndWait, &json!({"progress": "plain"})).is_err());
 
     let mut invalid = options.clone();
     invalid["notice_lines"] = json!(["line\nforgery"]);

--- a/crates/ctx-terminal/src/progress.rs
+++ b/crates/ctx-terminal/src/progress.rs
@@ -9,7 +9,8 @@ use std::{
 use serde_json::json;
 
 use crate::ui::{
-    refresh_progress, Document, Line, LiveOutput, RefreshProgressSnapshot, Span, Token, Ui,
+    refresh_progress, CalloutPresentation, CalloutRow, CalloutStatus, Document, Line, LiveOutput,
+    RefreshProgressSnapshot, Span, Token, Ui,
 };
 
 const MAX_PROGRESS_MESSAGE_BYTES: usize = 512;
@@ -120,6 +121,7 @@ pub struct ProgressReporter<'a> {
     total_bytes: u64,
     started: Instant,
     presentation_agent_histories: Option<Vec<String>>,
+    persistent_callout: Option<CalloutPresentation>,
     output: ProgressOutput<'a>,
 }
 
@@ -152,6 +154,13 @@ impl<'a> ProgressOutput<'a> {
         }
     }
 
+    fn write_live_callout(&mut self, presentation: CalloutPresentation) -> io::Result<()> {
+        match self {
+            Self::Live(output) => output.write_callout(presentation),
+            Self::Direct(_) => Err(io::Error::other("direct renderer has no live worker")),
+        }
+    }
+
     fn write_live_notice(&mut self, document: Document) -> io::Result<()> {
         match self {
             Self::Live(output) => output.write_notice(document),
@@ -168,6 +177,10 @@ enum LiveRenderCommand {
     },
     Refresh {
         snapshot: Box<RefreshProgressSnapshot>,
+        complete: mpsc::Sender<io::Result<()>>,
+    },
+    Callout {
+        presentation: CalloutPresentation,
         complete: mpsc::Sender<io::Result<()>>,
     },
     Notice {
@@ -237,6 +250,20 @@ impl LocalLiveRenderer {
             .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "live renderer stopped"))?
     }
 
+    fn write_callout(&mut self, presentation: CalloutPresentation) -> io::Result<()> {
+        self.check_background_error()?;
+        let (complete, completed) = mpsc::channel();
+        self.commands
+            .send(LiveRenderCommand::Callout {
+                presentation,
+                complete,
+            })
+            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "live renderer stopped"))?;
+        completed
+            .recv()
+            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "live renderer stopped"))?
+    }
+
     fn write_notice(&mut self, document: Document) -> io::Result<()> {
         self.check_background_error()?;
         let (complete, completed) = mpsc::channel();
@@ -274,6 +301,7 @@ fn run_live_renderer(
     background_error: &Mutex<Option<io::Error>>,
 ) {
     let mut active = None;
+    let mut persistent_callout = None;
     let mut persistent_notice = None;
     let mut clock = ActiveElapsedClock::default();
     loop {
@@ -297,7 +325,13 @@ fn run_live_renderer(
                 let rendered =
                     prepare_live_snapshot((*snapshot).clone(), &mut clock, started.elapsed(), true);
                 let result = output.render_frame(terminal, |context| {
-                    render_live_refresh(presentation, context, rendered, persistent_notice.as_ref())
+                    render_live_refresh(
+                        presentation,
+                        context,
+                        rendered,
+                        persistent_notice.as_ref(),
+                        persistent_callout.as_ref(),
+                    )
                 });
                 let failed = result.is_err();
                 let _ = complete.send(result);
@@ -309,27 +343,57 @@ fn run_live_renderer(
                     clock.reset();
                 }
             }
+            Ok(LiveRenderCommand::Callout {
+                presentation: callout,
+                complete,
+            }) => {
+                persistent_callout = Some(callout);
+                let result = if let Some(snapshot) = active.as_ref() {
+                    output.render_frame(false, |context| {
+                        let rendered = prepare_live_snapshot(
+                            snapshot.clone(),
+                            &mut clock,
+                            started.elapsed(),
+                            false,
+                        );
+                        render_live_refresh(
+                            presentation,
+                            context,
+                            rendered,
+                            persistent_notice.as_ref(),
+                            persistent_callout.as_ref(),
+                        )
+                    })
+                } else {
+                    Ok(())
+                };
+                let failed = result.is_err();
+                let _ = complete.send(result);
+                if failed {
+                    break;
+                }
+            }
             Ok(LiveRenderCommand::Notice { document, complete }) => {
                 persistent_notice = Some(document);
-                let result = output.render_frame(false, |context| {
-                    active.as_ref().map_or_else(
-                        || persistent_notice.as_ref().cloned().unwrap_or_default(),
-                        |snapshot| {
-                            let rendered = prepare_live_snapshot(
-                                snapshot.clone(),
-                                &mut clock,
-                                started.elapsed(),
-                                false,
-                            );
-                            render_live_refresh(
-                                presentation,
-                                &context,
-                                rendered,
-                                persistent_notice.as_ref(),
-                            )
-                        },
-                    )
-                });
+                let result = if let Some(snapshot) = active.as_ref() {
+                    output.render_frame(false, |context| {
+                        let rendered = prepare_live_snapshot(
+                            snapshot.clone(),
+                            &mut clock,
+                            started.elapsed(),
+                            false,
+                        );
+                        render_live_refresh(
+                            presentation,
+                            context,
+                            rendered,
+                            persistent_notice.as_ref(),
+                            persistent_callout.as_ref(),
+                        )
+                    })
+                } else {
+                    Ok(())
+                };
                 let failed = result.is_err();
                 let _ = complete.send(result);
                 if failed {
@@ -344,7 +408,13 @@ fn run_live_renderer(
                 let rendered =
                     prepare_live_snapshot(snapshot.clone(), &mut clock, started.elapsed(), false);
                 if let Err(error) = output.render_frame(false, |context| {
-                    render_live_refresh(presentation, context, rendered, persistent_notice.as_ref())
+                    render_live_refresh(
+                        presentation,
+                        context,
+                        rendered,
+                        persistent_notice.as_ref(),
+                        persistent_callout.as_ref(),
+                    )
                 }) {
                     *background_error
                         .lock()
@@ -361,20 +431,17 @@ fn render_live_refresh(
     context: &crate::ui::RenderContext,
     mut snapshot: RefreshProgressSnapshot,
     persistent_notice: Option<&Document>,
+    persistent_callout: Option<&CalloutPresentation>,
 ) -> Document {
-    let terminal = snapshot.is_terminal();
     if presentation == LiveRefreshPresentation::Setup {
         snapshot.use_setup_live_presentation();
     }
     let mut document = refresh_progress(context, &snapshot);
     if let Some(notice) = persistent_notice {
         document.append(notice.clone());
-        if terminal {
-            // Terminal setup frames intentionally omit the no-longer-relevant
-            // ETA row. Keep the live block's height stable through that final
-            // differential repaint without adding space before the notice.
-            document.push_blank();
-        }
+    } else if let Some(callout) = persistent_callout {
+        document.push_blank();
+        document.append(callout.render(context));
     }
     document
 }
@@ -451,6 +518,7 @@ impl<'a> ProgressReporter<'a> {
             total_bytes,
             started,
             presentation_agent_histories: None,
+            persistent_callout: None,
             output,
         }
     }
@@ -479,13 +547,12 @@ impl<'a> ProgressReporter<'a> {
             imported_events: None,
             done: false,
             refresh: None,
+            callout: None,
         })
     }
 
-    /// Emits a trusted, source-authored multi-line notice through the active
-    /// progress transport. Unlike dynamic progress messages, line boundaries
-    /// are preserved so a live or hosted renderer can present the notice while
-    /// another operation continues.
+    /// Compatibility transport for the legacy Core setup progress modes.
+    /// New structured-event consumers should compose a typed callout instead.
     pub fn notice(
         &mut self,
         phase: &'static str,
@@ -532,6 +599,54 @@ impl<'a> ProgressReporter<'a> {
                     imported_events: None,
                     done: false,
                     refresh: None,
+                    callout: None,
+                },
+                elapsed,
+            )
+            .map_err(ProgressWriterError),
+        }
+    }
+
+    /// Installs or replaces one product-neutral callout beneath setup progress.
+    /// Live output re-renders the owned facts at the destination's current
+    /// width; plain output emits the callout only after terminal progress.
+    pub fn callout(
+        &mut self,
+        phase: &'static str,
+        presentation: CalloutPresentation,
+    ) -> Result<(), ProgressWriterError> {
+        if !self.is_enabled() {
+            return Ok(());
+        }
+        self.presentation_agent_histories = None;
+        self.persistent_callout = Some(presentation.clone());
+        let message = bounded_progress_text(
+            &presentation.plain_message(&crate::ui::RenderContext::canonical_human_measurement()),
+            MAX_PROGRESS_MESSAGE_BYTES,
+        );
+        let elapsed = self.started.elapsed();
+        match self.mode {
+            ProgressRenderMode::None => Ok(()),
+            ProgressRenderMode::Live => self
+                .output
+                .write_live_callout(presentation)
+                .map_err(ProgressWriterError),
+            ProgressRenderMode::Plain => Ok(()),
+            ProgressRenderMode::Json => write_progress(
+                &mut self.output,
+                self.mode,
+                self.operation,
+                &ProgressLine {
+                    phase: bounded_progress_text(phase, MAX_PROGRESS_PHASE_BYTES),
+                    message,
+                    completed_bytes: 0,
+                    total_bytes: self.total_bytes,
+                    completed_files: None,
+                    total_files: None,
+                    imported_events: None,
+                    done: false,
+                    refresh: None,
+                    callout: Some(callout_json(&presentation)),
                 },
                 elapsed,
             )
@@ -566,8 +681,19 @@ impl<'a> ProgressReporter<'a> {
             snapshot.set_presentation_agent_histories(self.presentation_agent_histories.clone());
         }
         let line = source_refresh_line(snapshot, self.total_bytes);
+        let terminal = line.done;
         write_progress(&mut self.output, self.mode, self.operation, &line, now)
-            .map_err(ProgressWriterError)
+            .map_err(ProgressWriterError)?;
+        if terminal && self.mode == ProgressRenderMode::Plain {
+            if let Some(callout) = self.persistent_callout.take() {
+                let output = self.output.direct_mut().map_err(ProgressWriterError)?;
+                let document = callout.render(output.context());
+                output
+                    .write_line(document.render_plain().trim_end_matches('\n'))
+                    .map_err(ProgressWriterError)?;
+            }
+        }
+        Ok(())
     }
 
     fn emit_status(&mut self, line: ProgressLine) -> Result<(), ProgressWriterError> {
@@ -587,6 +713,7 @@ struct ProgressLine {
     imported_events: Option<usize>,
     done: bool,
     refresh: Option<RefreshProgressSnapshot>,
+    callout: Option<serde_json::Value>,
 }
 
 fn write_progress(
@@ -668,6 +795,9 @@ fn progress_json(operation: &'static str, line: &ProgressLine, elapsed: StdDurat
             .unwrap_or(serde_json::Value::Null);
         snapshot.append_json_fields(&mut value);
     }
+    if let Some(callout) = line.callout.as_ref() {
+        value["callout"] = callout.clone();
+    }
     value.to_string()
 }
 
@@ -698,7 +828,37 @@ fn source_refresh_line(
         imported_events,
         done,
         refresh: Some(snapshot),
+        callout: None,
     }
+}
+
+fn callout_json(presentation: &CalloutPresentation) -> serde_json::Value {
+    let rows = presentation
+        .rows()
+        .iter()
+        .map(|row| match row {
+            CalloutRow::Blank => json!({"kind": "blank"}),
+            CalloutRow::Text(text) => json!({"kind": "text", "text": text}),
+            CalloutRow::Bullet(text) => json!({"kind": "bullet", "text": text}),
+            CalloutRow::Status { level, text } => json!({
+                "kind": "status",
+                "level": match level {
+                    CalloutStatus::Neutral => "neutral",
+                    CalloutStatus::Success => "success",
+                    CalloutStatus::Warning => "warning",
+                    CalloutStatus::Failure => "failure",
+                },
+                "text": text,
+            }),
+            CalloutRow::Action(text) => json!({"kind": "action", "text": text}),
+            CalloutRow::Reference(text) => json!({"kind": "reference", "text": text}),
+            CalloutRow::Command(text) => json!({"kind": "command", "text": text}),
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "title": presentation.title(),
+        "rows": rows,
+    })
 }
 
 fn progress_percent(completed: u64, total: u64) -> f64 {

--- a/crates/ctx-terminal/src/progress/tests.rs
+++ b/crates/ctx-terminal/src/progress/tests.rs
@@ -429,6 +429,7 @@ fn done_progress_json_forces_complete_bytes_with_incomplete_bytes() {
         imported_events: None,
         done: true,
         refresh: None,
+        callout: None,
     };
 
     let value: serde_json::Value =
@@ -454,6 +455,7 @@ fn progress_json_remains_exact_and_ansi_free() {
         imported_events: Some(7),
         done: false,
         refresh: None,
+        callout: None,
     };
 
     let rendered = progress_json("import", &line, StdDuration::from_secs(2));
@@ -483,6 +485,7 @@ fn plain_and_json_progress_keep_explicit_stream_contracts() {
         imported_events: None,
         done: false,
         refresh: None,
+        callout: None,
     };
 
     let plain = match ProgressRenderMode::Plain {
@@ -539,6 +542,7 @@ fn progress_write_and_flush_failures_remain_errors() {
         imported_events: None,
         done: false,
         refresh: None,
+        callout: None,
     };
     for (failure, expected) in [
         (WriterFailure::Write, "injected progress write failure"),

--- a/crates/ctx-terminal/src/progress/tests/eta_tests.rs
+++ b/crates/ctx-terminal/src/progress/tests/eta_tests.rs
@@ -105,8 +105,8 @@ fn local_live_clock_suppresses_eta_after_backend_snapshot_silence() {
         crate::ui::StreamKind::Stderr,
         80,
     ));
-    let rendered =
-        render_live_refresh(LiveRefreshPresentation::Setup, &context, stale, None).render_plain();
+    let rendered = render_live_refresh(LiveRefreshPresentation::Setup, &context, stale, None, None)
+        .render_plain();
     assert!(
         rendered.contains("Estimated remaining  Estimating"),
         "{rendered}"

--- a/crates/ctx-terminal/src/progress/tests/notice_tests.rs
+++ b/crates/ctx-terminal/src/progress/tests/notice_tests.rs
@@ -1,15 +1,24 @@
 use super::*;
 
-#[test]
-fn trusted_progress_notice_preserves_exact_lines_in_plain_and_json_modes() {
-    let lines = [
-        "first approved line",
-        "second approved line — local",
-        "third approved line",
-        "fourth approved line → https://companion.example.test/opaque-code",
-    ];
-    let expected = lines.join("\n");
+fn presentation() -> CalloutPresentation {
+    CalloutPresentation::new(
+        "A companion",
+        vec![
+            CalloutRow::Bullet("A static local product fact.".to_owned()),
+            CalloutRow::Blank,
+            CalloutRow::Status {
+                level: CalloutStatus::Success,
+                text: "Access is ready.".to_owned(),
+            },
+            CalloutRow::Blank,
+            CalloutRow::Action("Continue here:".to_owned()),
+            CalloutRow::Reference("https://companion.example.test/aB3dE7fGh9Jk".to_owned()),
+        ],
+    )
+}
 
+#[test]
+fn structured_callout_is_ordered_after_plain_progress_and_stays_structured_in_json() {
     let stderr = SharedWriter::default();
     let stderr_capture = stderr.clone();
     let (mut ui, _) = ui_with_stderr(
@@ -18,10 +27,17 @@ fn trusted_progress_notice_preserves_exact_lines_in_plain_and_json_modes() {
             crate::ui::StreamKind::Stderr,
         )),
     );
-    ProgressReporter::new(&mut ui, ProgressMode::Plain, false, "setup", 0)
-        .notice("companion", &lines)
-        .unwrap();
-    assert_eq!(stderr_capture.text(), format!("{expected}\n"));
+    let mut reporter = ProgressReporter::new(&mut ui, ProgressMode::Plain, false, "setup", 0);
+    reporter.callout("companion", presentation()).unwrap();
+    assert!(stderr_capture.text().is_empty());
+    reporter.source_refresh(terminal_status()).unwrap();
+    let plain = stderr_capture.text();
+    assert!(
+        plain.find("History refresh complete").unwrap() < plain.find("A companion").unwrap(),
+        "{plain}"
+    );
+    assert_eq!(plain.matches("A companion").count(), 1, "{plain}");
+    assert_eq!(plain.matches("aB3dE7fGh9Jk").count(), 1, "{plain}");
 
     let stderr = SharedWriter::default();
     let stderr_capture = stderr.clone();
@@ -32,69 +48,91 @@ fn trusted_progress_notice_preserves_exact_lines_in_plain_and_json_modes() {
         )),
     );
     ProgressReporter::new(&mut ui, ProgressMode::Json, false, "setup", 0)
-        .notice("companion", &lines)
+        .callout("companion", presentation())
         .unwrap();
     let event: serde_json::Value = serde_json::from_str(stderr_capture.text().trim()).unwrap();
     assert_eq!(event["phase"], "companion");
-    assert_eq!(event["message"], expected);
+    assert_eq!(event["callout"]["title"], "A companion");
+    assert_eq!(event["callout"]["rows"][2]["kind"], "status");
+    assert_eq!(event["callout"]["rows"][5]["kind"], "reference");
+    assert!(!stderr_capture.text().contains('\u{1b}'));
 }
 
 #[test]
-fn live_notice_is_composed_once_into_every_later_refresh_frame() {
-    let disclosure = [
-        "first trusted companion line",
-        "second trusted companion line",
-        "third trusted companion line",
-        "",
-        "trusted action:",
-        "https://companion.example.test/opaque-code",
-    ];
-    let mut notice = Document::new();
-    notice.push_blank();
-    for line in disclosure {
-        notice.push_line(Line::text(line));
-    }
+fn structured_callout_json_contains_no_raw_c0_c1_or_del_controls() {
+    let stderr = SharedWriter::default();
+    let stderr_capture = stderr.clone();
+    let (mut ui, _) = ui_with_stderr(
+        stderr,
+        crate::ui::RenderContext::for_test(crate::ui::TestContext::pipe(
+            crate::ui::StreamKind::Stderr,
+        )),
+    );
+    let presentation = CalloutPresentation::new(
+        "title\u{1b}\u{009b}",
+        vec![CalloutRow::Status {
+            level: CalloutStatus::Warning,
+            text: "status\0\r\u{007f}\u{0085}".to_owned(),
+        }],
+    );
+
+    ProgressReporter::new(&mut ui, ProgressMode::Json, false, "setup", 0)
+        .callout("companion", presentation)
+        .unwrap();
+
+    let output = stderr_capture.text();
+    assert!(
+        !output.trim_end().chars().any(char::is_control),
+        "{output:?}"
+    );
+    let event: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+    assert_eq!(event["callout"]["title"], "title\\x1b\\u{009b}");
+    assert_eq!(
+        event["callout"]["rows"][0]["text"],
+        "status\\u{0000}\\r\\u{007f}\\u{0085}"
+    );
+}
+
+#[test]
+fn live_callout_is_composed_once_and_terminal_frames_use_natural_height() {
     let context = crate::ui::RenderContext::for_test(crate::ui::TestContext::tty(
         crate::ui::StreamKind::Stderr,
         120,
     ));
-    let mut frame_height = None;
-
+    let callout = presentation();
     let frozen_histories = Some(vec!["Codex".to_owned(), "Claude".to_owned()]);
+    let mut heights = Vec::new();
+
     for mut snapshot in [active_status(), active_transfer_status(), terminal_status()] {
-        let terminal = snapshot.is_terminal();
         snapshot.set_presentation_agent_histories(frozen_histories.clone());
+        let progress_label = if snapshot.is_terminal() {
+            "History refresh complete"
+        } else {
+            "Reading your agent history"
+        };
         let frame = render_live_refresh(
             LiveRefreshPresentation::Setup,
             &context,
             snapshot,
-            Some(&notice),
+            None,
+            Some(&callout),
         );
         let rendered = frame.render_plain();
-        assert_eq!(rendered.matches(disclosure[0]).count(), 1, "{rendered}");
-        assert_eq!(rendered.matches(disclosure[5]).count(), 1, "{rendered}");
-        let notice_end = frame.lines().len() - usize::from(terminal);
-        assert_eq!(
-            &frame.lines()[notice_end - notice.lines().len()..notice_end],
-            notice.lines()
+        assert_eq!(rendered.matches("A companion").count(), 1, "{rendered}");
+        assert_eq!(rendered.matches("aB3dE7fGh9Jk").count(), 1, "{rendered}");
+        assert!(
+            rendered.find(progress_label).unwrap() < rendered.find("A companion").unwrap(),
+            "{rendered}"
         );
-        if let Some(frame_height) = frame_height {
-            assert_eq!(frame.lines().len(), frame_height);
-        } else {
-            frame_height = Some(frame.lines().len());
-        }
+        heights.push(frame.lines().len());
     }
+    assert_eq!(heights[0], heights[1]);
+    assert!(heights[2] < heights[1], "{heights:?}");
 }
 
 #[test]
-fn persistent_notice_survives_ten_hz_whole_run_eta_ticks_at_stable_height() {
-    let mut notice = Document::new();
-    notice.push_blank();
-    notice.push_line(Line::text("persistent Pro disclosure"));
-    let context = crate::ui::RenderContext::for_test(crate::ui::TestContext::tty(
-        crate::ui::StreamKind::Stderr,
-        100,
-    ));
+fn persistent_callout_survives_ten_hz_ticks_and_reflows_from_narrow_to_wide() {
+    let callout = presentation();
     let mut snapshot = active_status();
     snapshot.set_presentation_agent_histories(Some(vec!["Codex".to_owned()]));
     snapshot.progress_mut_for_test().elapsed_millis = Some(10_000);
@@ -112,20 +150,39 @@ fn persistent_notice_survives_ten_hz_whole_run_eta_ticks_at_stable_height() {
             prepared.estimated_remaining_millis(),
             Some(expected_remaining)
         );
+        let context = crate::ui::RenderContext::for_test(crate::ui::TestContext::tty(
+            crate::ui::StreamKind::Stderr,
+            80,
+        ));
         let frame = render_live_refresh(
             LiveRefreshPresentation::Setup,
             &context,
             prepared,
-            Some(&notice),
+            None,
+            Some(&callout),
         );
-        let rendered = frame.render_plain();
-        assert_eq!(rendered.matches("persistent Pro disclosure").count(), 1);
+        assert_eq!(frame.render_plain().matches("A companion").count(), 1);
         if let Some(frame_height) = frame_height {
             assert_eq!(frame.lines().len(), frame_height);
         } else {
             frame_height = Some(frame.lines().len());
         }
     }
+
+    let narrow = callout
+        .render(&crate::ui::RenderContext::for_test(
+            crate::ui::TestContext::tty(crate::ui::StreamKind::Stderr, 32),
+        ))
+        .render_plain();
+    let wide = callout
+        .render(&crate::ui::RenderContext::for_test(
+            crate::ui::TestContext::tty(crate::ui::StreamKind::Stderr, 80),
+        ))
+        .render_plain();
+    assert!(!narrow.contains('│'), "{narrow}");
+    assert!(wide.contains('│'), "{wide}");
+    assert_eq!(narrow.matches("aB3dE7fGh9Jk").count(), 1);
+    assert_eq!(wide.matches("aB3dE7fGh9Jk").count(), 1);
 }
 
 #[test]
@@ -148,19 +205,7 @@ fn hosted_json_live_progress_keeps_stdout_machine_clean() {
             0,
             true,
         );
-        reporter
-            .notice(
-                "companion",
-                &[
-                    "first trusted companion line",
-                    "second trusted companion line",
-                    "third trusted companion line",
-                    "",
-                    "trusted action:",
-                    "https://companion.example.test/opaque-code",
-                ],
-            )
-            .unwrap();
+        reporter.callout("companion", presentation()).unwrap();
         reporter.source_refresh(active_status()).unwrap();
         reporter.source_refresh(active_transfer_status()).unwrap();
     }
@@ -172,12 +217,6 @@ fn hosted_json_live_progress_keeps_stdout_machine_clean() {
     assert_eq!(stdout_capture.text(), "{\"payload_type\":\"setup\"}\n");
     let stderr = stderr_capture.text();
     assert!(stderr.contains("Reading your agent history"), "{stderr:?}");
-    assert!(
-        stderr.contains("second trusted companion line"),
-        "{stderr:?}"
-    );
-    assert!(
-        stderr.contains("https://companion.example.test/opaque-code"),
-        "{stderr:?}"
-    );
+    assert_eq!(stderr.matches("A companion").count(), 1, "{stderr:?}");
+    assert!(stderr.contains("aB3dE7fGh9Jk"), "{stderr:?}");
 }

--- a/crates/ctx-terminal/src/ui/components/callout.rs
+++ b/crates/ctx-terminal/src/ui/components/callout.rs
@@ -1,0 +1,295 @@
+use super::layout::{display_width, is_copyable_atom, line_width, wrap_line};
+use crate::ui::{glyph::Glyph, Document, Line, RenderContext, Span, Token};
+
+const MAX_WIDTH: usize = 80;
+const MIN_BORDERED_WIDTH: usize = 12;
+const BORDER_OVERHEAD: usize = 4;
+
+/// A bounded human-terminal callout with a semantic title and styled body.
+///
+/// Machine-readable formats must bypass terminal components and write their
+/// selected representation directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Callout<'a> {
+    pub title: &'a str,
+    pub body: &'a Document,
+}
+
+pub fn callout(context: &RenderContext, callout: Callout<'_>) -> Document {
+    let title = Line::styled(callout.title, Token::Heading);
+    let available_width = context.content_width().unwrap_or(MAX_WIDTH).min(MAX_WIDTH);
+    let natural_width = std::iter::once(&title)
+        .chain(callout.body.lines())
+        .map(line_width)
+        .max()
+        .unwrap_or_default()
+        .saturating_add(BORDER_OVERHEAD)
+        .max(MIN_BORDERED_WIDTH);
+    let outer_width = natural_width.min(available_width);
+
+    if outer_width < MIN_BORDERED_WIDTH {
+        return borderless(context, &title, callout.body);
+    }
+    let inner_width = outer_width.saturating_sub(BORDER_OVERHEAD);
+    if std::iter::once(&title)
+        .chain(callout.body.lines())
+        .any(|line| has_oversized_copyable_atom(line, inner_width))
+    {
+        return borderless(context, &title, callout.body);
+    }
+
+    let mut document = Document::from_line(horizontal_border(
+        context,
+        Glyph::BoxTopLeft,
+        Glyph::BoxTopRight,
+        outer_width,
+    ));
+    for line in std::iter::once(&title).chain(callout.body.lines()) {
+        for line in wrap_line(line, Some(inner_width)) {
+            document.push_line(content_line(context, line, inner_width));
+        }
+    }
+    document.push_line(horizontal_border(
+        context,
+        Glyph::BoxBottomLeft,
+        Glyph::BoxBottomRight,
+        outer_width,
+    ));
+    document
+}
+
+fn borderless(context: &RenderContext, title: &Line, body: &Document) -> Document {
+    let mut document = Document::new();
+    for line in std::iter::once(title).chain(body.lines()) {
+        for line in wrap_line(line, context.content_width()) {
+            document.push_line(line);
+        }
+    }
+    document
+}
+
+fn horizontal_border(context: &RenderContext, left: Glyph, right: Glyph, width: usize) -> Line {
+    Line::styled(
+        format!(
+            "{}{}{}",
+            left.render(context),
+            Glyph::Rule.render(context).repeat(width.saturating_sub(2)),
+            right.render(context)
+        ),
+        Token::Label,
+    )
+}
+
+fn content_line(context: &RenderContext, content: Line, width: usize) -> Line {
+    let padding = width.saturating_sub(line_width(&content));
+    let mut line = Line::new()
+        .with(Span::new(Glyph::BoxVertical.render(context), Token::Label))
+        .with(Span::text(" "));
+    for span in content.spans() {
+        line.push(span.clone());
+    }
+    line.push(Span::text(" ".repeat(padding.saturating_add(1))));
+    line.push(Span::new(Glyph::BoxVertical.render(context), Token::Label));
+    line
+}
+
+fn has_oversized_copyable_atom(line: &Line, width: usize) -> bool {
+    if line_width(line) > width
+        && line
+            .spans()
+            .iter()
+            .any(|span| matches!(span.token(), Token::Command | Token::Reference))
+    {
+        return true;
+    }
+    let text: String = line.spans().iter().map(Span::content).collect();
+    text.split_whitespace()
+        .any(|word| is_copyable_atom(word) && display_width(word) > width)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::{ColorMode, StreamKind, TestContext};
+
+    fn context(width: usize) -> RenderContext {
+        RenderContext::for_test(TestContext::tty(StreamKind::Stdout, width))
+    }
+
+    fn body() -> Document {
+        Document::from_line(
+            Line::new()
+                .with(Span::text("Local history remains "))
+                .with(Span::new("on this device", Token::Accent))
+                .with(Span::text(
+                    " while ctx prepares the result. Additional neutral details make this body \
+                     wide enough to exercise the component cap without changing its meaning.",
+                )),
+        )
+    }
+
+    #[test]
+    fn wraps_at_standard_widths_and_caps_wide_callouts() {
+        for width in [32, 48, 80, 120] {
+            let context = context(width);
+            let rendered = callout(
+                &context,
+                Callout {
+                    title: "History stays local",
+                    body: &body(),
+                },
+            );
+            let plain = rendered.render_plain();
+            assert!(plain.starts_with('╭'), "width {width}: {plain}");
+            assert!(plain.trim_end().ends_with('╯'), "width {width}: {plain}");
+            assert!(plain.contains("History stays local"), "width {width}");
+            assert!(plain.contains("Local history remains"), "width {width}");
+            for word in ["on", "this", "device"] {
+                assert!(
+                    plain.split_whitespace().any(|candidate| candidate == word),
+                    "width {width}: {plain}"
+                );
+            }
+            assert!(
+                rendered
+                    .lines()
+                    .iter()
+                    .all(|line| line_width(line) <= width.saturating_sub(1).min(MAX_WIDTH)),
+                "width {width}: {plain}"
+            );
+            if width == 120 {
+                assert_eq!(line_width(&rendered.lines()[0]), MAX_WIDTH, "{plain}");
+            }
+        }
+    }
+
+    #[test]
+    fn uses_ascii_fallback_and_dim_semantic_borders() {
+        let context =
+            RenderContext::for_test(TestContext::tty(StreamKind::Stdout, 48).unicode(false));
+        let document = callout(
+            &context,
+            Callout {
+                title: "A note",
+                body: &Document::from_line(Line::text("Complete static text.")),
+            },
+        );
+
+        let plain = document.render_plain();
+        assert!(plain.starts_with('+'), "{plain}");
+        assert!(plain.contains("+\n| A note"), "{plain}");
+        assert!(plain.trim_end().ends_with('+'), "{plain}");
+        assert!(
+            ['╭', '╮', '╰', '╯', '│']
+                .into_iter()
+                .all(|glyph| !plain.contains(glyph)),
+            "{plain}"
+        );
+        assert_eq!(document.lines()[0].spans()[0].token(), Token::Label);
+        assert_eq!(document.lines()[1].spans()[2].token(), Token::Heading);
+    }
+
+    #[test]
+    fn falls_back_without_losing_narrow_or_copyable_content() {
+        let url = "https://example.test/a/long/opaque/copyable/value";
+        let body = Document::from_line(
+            Line::new()
+                .with(Span::text("Open "))
+                .with(Span::new(url, Token::Reference)),
+        );
+        for context in [context(8), context(32)] {
+            let document = callout(
+                &context,
+                Callout {
+                    title: "Next step",
+                    body: &body,
+                },
+            );
+            let plain = document.render_plain();
+            assert!(!plain.contains('│'), "{plain}");
+            assert!(!plain.contains('|'), "{plain}");
+            assert_eq!(plain.matches(url).count(), 1, "{plain}");
+            let url_span = document
+                .lines()
+                .iter()
+                .flat_map(Line::spans)
+                .find(|span| span.content() == url)
+                .expect("URL span");
+            assert_eq!(url_span.token(), Token::Reference);
+        }
+    }
+
+    #[test]
+    fn semantic_commands_and_references_force_a_complete_borderless_fallback() {
+        for token in [Token::Command, Token::Reference] {
+            let atom = match token {
+                Token::Command => "ctx search an intentionally long multi word command",
+                Token::Reference => "0123456789abcdef0123456789abcdef01234567",
+                _ => unreachable!(),
+            };
+            let body = Document::from_line(Line::styled(atom, token));
+            let document = callout(
+                &context(32),
+                Callout {
+                    title: "Copy this value",
+                    body: &body,
+                },
+            );
+            let plain = document.render_plain();
+
+            assert!(!plain.contains('│'), "{plain}");
+            assert_eq!(plain.matches(atom).count(), 1, "{plain}");
+            let span = document
+                .lines()
+                .iter()
+                .flat_map(Line::spans)
+                .find(|span| span.content() == atom)
+                .expect("semantic atom span");
+            assert_eq!(span.token(), token);
+        }
+    }
+
+    #[test]
+    fn dynamic_values_remain_control_safe() {
+        let attack = "\u{1b}[31mowned\u{1b}[0m\rrewrite\u{0000}\u{0085}\u{009b}2J\nnext\tcell";
+        let body = Document::from_line(Line::styled(attack, Token::Accent));
+        let plain = callout(
+            &context(120),
+            Callout {
+                title: attack,
+                body: &body,
+            },
+        )
+        .render_plain();
+
+        for control in ['\u{1b}', '\r', '\u{0000}', '\u{0085}', '\u{009b}'] {
+            assert!(!plain.contains(control), "{plain:?}");
+        }
+        assert_eq!(plain.matches("\\x1b[31mowned\\x1b[0m").count(), 2);
+        assert_eq!(plain.matches("\\u{009b}2J").count(), 2);
+        assert_eq!(plain.matches("\\nnext\\tcell").count(), 2);
+    }
+
+    #[test]
+    fn redirected_and_ansi_output_remain_complete_and_equivalent() {
+        let context =
+            RenderContext::for_test(TestContext::pipe(StreamKind::Stderr).color(ColorMode::Always));
+        let body = body();
+        let document = callout(
+            &context,
+            Callout {
+                title: "History stays local",
+                body: &body,
+            },
+        );
+        let plain = document.render_plain();
+        let styled = document.render(&context);
+
+        assert!(plain.contains("while ctx prepares the result."));
+        assert_eq!(anstream::adapter::strip_str(&styled).to_string(), plain);
+        assert!(document.lines().iter().any(|line| line
+            .spans()
+            .iter()
+            .any(|span| span.token() == Token::Accent)));
+    }
+}

--- a/crates/ctx-terminal/src/ui/components/callout.rs
+++ b/crates/ctx-terminal/src/ui/components/callout.rs
@@ -1,4 +1,5 @@
 use super::layout::{display_width, is_copyable_atom, line_width, wrap_line};
+use crate::ui::document::neutralize_controls;
 use crate::ui::{glyph::Glyph, Document, Line, RenderContext, Span, Token};
 
 const MAX_WIDTH: usize = 80;
@@ -13,6 +14,124 @@ const BORDER_OVERHEAD: usize = 4;
 pub struct Callout<'a> {
     pub title: &'a str,
     pub body: &'a Document,
+}
+
+/// Owned, product-neutral callout facts that can be rendered again when a live
+/// destination changes width.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalloutPresentation {
+    title: String,
+    rows: Vec<CalloutRow>,
+}
+
+impl CalloutPresentation {
+    pub fn new(title: impl Into<String>, rows: Vec<CalloutRow>) -> Self {
+        let title = title.into();
+        Self {
+            title: neutralize_controls(&title),
+            rows: rows.into_iter().map(CalloutRow::neutralized).collect(),
+        }
+    }
+
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    pub fn rows(&self) -> &[CalloutRow] {
+        &self.rows
+    }
+
+    pub fn render(&self, context: &RenderContext) -> Document {
+        let body = self.body(context);
+        callout(
+            context,
+            Callout {
+                title: &self.title,
+                body: &body,
+            },
+        )
+    }
+
+    pub fn plain_message(&self, context: &RenderContext) -> String {
+        let mut document = Document::from_line(Line::text(&self.title));
+        document.append(self.body(context));
+        document.render_plain().trim_end_matches('\n').to_owned()
+    }
+
+    fn body(&self, context: &RenderContext) -> Document {
+        let mut body = Document::new();
+        for row in &self.rows {
+            body.push_line(row.render(context));
+        }
+        body
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CalloutRow {
+    Blank,
+    Text(String),
+    Bullet(String),
+    Status { level: CalloutStatus, text: String },
+    Action(String),
+    Reference(String),
+    Command(String),
+}
+
+impl CalloutRow {
+    fn neutralized(self) -> Self {
+        match self {
+            Self::Blank => Self::Blank,
+            Self::Text(text) => Self::Text(neutralize_controls(&text)),
+            Self::Bullet(text) => Self::Bullet(neutralize_controls(&text)),
+            Self::Status { level, text } => Self::Status {
+                level,
+                text: neutralize_controls(&text),
+            },
+            Self::Action(text) => Self::Action(neutralize_controls(&text)),
+            Self::Reference(text) => Self::Reference(neutralize_controls(&text)),
+            Self::Command(text) => Self::Command(neutralize_controls(&text)),
+        }
+    }
+
+    fn render(&self, context: &RenderContext) -> Line {
+        match self {
+            Self::Blank => Line::new(),
+            Self::Text(text) | Self::Action(text) => Line::text(text),
+            Self::Bullet(text) => prefixed_line(
+                Glyph::Bullet.render(context),
+                Token::Accent,
+                text,
+                Token::Text,
+            ),
+            Self::Status { level, text } => {
+                let (glyph, token) = match level {
+                    CalloutStatus::Neutral => (Glyph::Bullet, Token::Accent),
+                    CalloutStatus::Success => (Glyph::Success, Token::Success),
+                    CalloutStatus::Warning => (Glyph::Warning, Token::Warning),
+                    CalloutStatus::Failure => (Glyph::Failure, Token::Error),
+                };
+                prefixed_line(glyph.render(context), token, text, Token::Text)
+            }
+            Self::Reference(reference) => Line::styled(reference, Token::Reference),
+            Self::Command(command) => Line::styled(command, Token::Command),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CalloutStatus {
+    Neutral,
+    Success,
+    Warning,
+    Failure,
+}
+
+fn prefixed_line(prefix: &str, prefix_token: Token, text: &str, text_token: Token) -> Line {
+    Line::new()
+        .with(Span::new(prefix, prefix_token))
+        .with(Span::text(" "))
+        .with(Span::new(text, text_token))
 }
 
 pub fn callout(context: &RenderContext, callout: Callout<'_>) -> Document {

--- a/crates/ctx-terminal/src/ui/components/layout.rs
+++ b/crates/ctx-terminal/src/ui/components/layout.rs
@@ -1,3 +1,4 @@
+use crate::ui::{Line, Span, Token};
 use unicode_segmentation::UnicodeSegmentation as _;
 use unicode_width::UnicodeWidthStr;
 
@@ -27,6 +28,211 @@ pub(super) fn wrap_text(text: &str, width: Option<usize>) -> Vec<String> {
         wrapped.push(String::new());
     }
     wrapped
+}
+
+pub(super) fn line_width(line: &Line) -> usize {
+    line.spans()
+        .iter()
+        .map(|span| display_width(span.content()))
+        .sum()
+}
+
+pub(super) fn wrap_line(line: &Line, width: Option<usize>) -> Vec<Line> {
+    let Some(width) = width else {
+        return vec![line.clone()];
+    };
+    let width = width.max(1);
+    let chunks = styled_chunks(line);
+    let mut output = Vec::new();
+    let mut current = StyledLine::default();
+    let mut pending_whitespace = None;
+
+    for chunk in chunks {
+        if chunk.whitespace {
+            pending_whitespace = Some(chunk);
+            continue;
+        }
+
+        let separator_width = pending_whitespace
+            .as_ref()
+            .map_or(0, |whitespace| whitespace.width);
+        if current.has_text
+            && current
+                .width
+                .saturating_add(separator_width)
+                .saturating_add(chunk.width)
+                > width
+        {
+            output.push(std::mem::take(&mut current).into_line());
+            if let Some(whitespace) = pending_whitespace.as_mut() {
+                whitespace.consume_wrap_separator();
+            }
+        }
+        if let Some(whitespace) = pending_whitespace.take() {
+            push_wrappable(whitespace.fragments, width, &mut current, &mut output);
+        }
+        if chunk.unbreakable {
+            current.extend(chunk.fragments);
+        } else {
+            push_wrappable(chunk.fragments, width, &mut current, &mut output);
+        }
+    }
+    if let Some(whitespace) = pending_whitespace {
+        push_wrappable(whitespace.fragments, width, &mut current, &mut output);
+    }
+
+    if !current.is_empty() {
+        output.push(current.into_line());
+    }
+    if output.is_empty() {
+        output.push(Line::new());
+    }
+    output
+}
+
+fn push_wrappable(
+    fragments: Vec<StyledFragment>,
+    width: usize,
+    current: &mut StyledLine,
+    output: &mut Vec<Line>,
+) {
+    for fragment in fragments {
+        for grapheme in fragment.text.graphemes(true) {
+            let grapheme_width = display_width(grapheme);
+            if !current.is_empty() && current.width.saturating_add(grapheme_width) > width {
+                output.push(std::mem::take(current).into_line());
+            }
+            current.push(grapheme, fragment.token);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct StyledChunk {
+    fragments: Vec<StyledFragment>,
+    width: usize,
+    whitespace: bool,
+    unbreakable: bool,
+}
+
+impl StyledChunk {
+    fn text(&self) -> String {
+        self.fragments
+            .iter()
+            .map(|fragment| fragment.text.as_str())
+            .collect()
+    }
+
+    fn consume_wrap_separator(&mut self) {
+        let Some(fragment) = self.fragments.first_mut() else {
+            return;
+        };
+        let Some(separator) = fragment.text.graphemes(true).next() else {
+            return;
+        };
+        self.width = self.width.saturating_sub(display_width(separator));
+        fragment.text.drain(..separator.len());
+        if fragment.text.is_empty() {
+            self.fragments.remove(0);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct StyledFragment {
+    text: String,
+    token: Token,
+}
+
+#[derive(Debug, Default)]
+struct StyledLine {
+    fragments: Vec<StyledFragment>,
+    width: usize,
+    has_text: bool,
+}
+
+impl StyledLine {
+    fn is_empty(&self) -> bool {
+        self.fragments.is_empty()
+    }
+
+    fn push(&mut self, text: &str, token: Token) {
+        self.width = self.width.saturating_add(display_width(text));
+        self.has_text |= !text.chars().all(char::is_whitespace);
+        if let Some(fragment) = self.fragments.last_mut().filter(|item| item.token == token) {
+            fragment.text.push_str(text);
+        } else {
+            self.fragments.push(StyledFragment {
+                text: text.to_owned(),
+                token,
+            });
+        }
+    }
+
+    fn extend(&mut self, fragments: Vec<StyledFragment>) {
+        for fragment in fragments {
+            self.push(&fragment.text, fragment.token);
+        }
+    }
+
+    fn into_line(self) -> Line {
+        let mut line = Line::new();
+        for fragment in self.fragments {
+            line.push(Span::new(fragment.text, fragment.token));
+        }
+        line
+    }
+}
+
+fn styled_chunks(line: &Line) -> Vec<StyledChunk> {
+    let mut chunks = Vec::new();
+    let mut atom = StyledLine::default();
+    let mut whitespace = StyledLine::default();
+    for span in line.spans() {
+        if matches!(span.token(), Token::Command | Token::Reference) {
+            flush_chunk(&mut atom, false, &mut chunks);
+            flush_chunk(&mut whitespace, true, &mut chunks);
+            let mut semantic = StyledLine::default();
+            semantic.push(span.content(), span.token());
+            chunks.push(StyledChunk {
+                fragments: semantic.fragments,
+                width: semantic.width,
+                whitespace: false,
+                unbreakable: true,
+            });
+            continue;
+        }
+        for grapheme in span.content().graphemes(true) {
+            if grapheme.chars().all(char::is_whitespace) {
+                flush_chunk(&mut atom, false, &mut chunks);
+                whitespace.push(grapheme, span.token());
+            } else {
+                flush_chunk(&mut whitespace, true, &mut chunks);
+                atom.push(grapheme, span.token());
+            }
+        }
+    }
+    flush_chunk(&mut atom, false, &mut chunks);
+    flush_chunk(&mut whitespace, true, &mut chunks);
+    for chunk in &mut chunks {
+        if !chunk.whitespace {
+            chunk.unbreakable |= is_copyable_atom(&chunk.text());
+        }
+    }
+    chunks
+}
+
+fn flush_chunk(line: &mut StyledLine, whitespace: bool, chunks: &mut Vec<StyledChunk>) {
+    if line.is_empty() {
+        return;
+    }
+    chunks.push(StyledChunk {
+        fragments: std::mem::take(&mut line.fragments),
+        width: std::mem::take(&mut line.width),
+        whitespace,
+        unbreakable: false,
+    });
+    line.has_text = false;
 }
 
 fn wrap_logical_line(line: &str, width: usize, output: &mut Vec<String>) {
@@ -75,7 +281,8 @@ pub fn is_copyable_atom(word: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::wrap_text;
+    use super::{wrap_line, wrap_text};
+    use crate::ui::{Line, Span, Token};
 
     #[test]
     fn wrapping_preserves_graphemes_and_copyable_identifiers() {
@@ -84,5 +291,46 @@ mod tests {
 
         let id = "00000000-0000-0000-0000-000000000001";
         assert_eq!(wrap_text(id, Some(8)), vec![id]);
+    }
+
+    #[test]
+    fn styled_wrapping_preserves_span_tokens_and_authored_whitespace() {
+        let line = Line::new()
+            .with(Span::new("  plain  ", Token::Label))
+            .with(Span::new("styled words  ", Token::Accent));
+
+        let wrapped = wrap_line(&line, Some(80));
+
+        assert_eq!(wrapped, vec![line]);
+        assert_eq!(wrapped[0].spans()[0].token(), Token::Label);
+        assert_eq!(wrapped[0].spans()[1].token(), Token::Accent);
+    }
+
+    #[test]
+    fn semantic_copyable_spans_are_never_split() {
+        for token in [Token::Command, Token::Reference] {
+            let atom = "opaque-copyable-value-without-a-url-shape";
+            let wrapped = wrap_line(&Line::styled(atom, token), Some(8));
+            assert_eq!(wrapped.len(), 1);
+            assert_eq!(wrapped[0].spans()[0].content(), atom);
+            assert_eq!(wrapped[0].spans()[0].token(), token);
+        }
+    }
+
+    #[test]
+    fn wrapping_consumes_one_separator_and_preserves_remaining_space_style() {
+        let line = Line::new()
+            .with(Span::new("  first  ", Token::Label))
+            .with(Span::new("second", Token::Accent));
+
+        let wrapped = wrap_line(&line, Some(8));
+
+        assert_eq!(wrapped.len(), 2);
+        assert_eq!(wrapped[0].spans()[0].content(), "  first");
+        assert_eq!(wrapped[0].spans()[0].token(), Token::Label);
+        assert_eq!(wrapped[1].spans()[0].content(), " ");
+        assert_eq!(wrapped[1].spans()[0].token(), Token::Label);
+        assert_eq!(wrapped[1].spans()[1].content(), "second");
+        assert_eq!(wrapped[1].spans()[1].token(), Token::Accent);
     }
 }

--- a/crates/ctx-terminal/src/ui/components/mod.rs
+++ b/crates/ctx-terminal/src/ui/components/mod.rs
@@ -1,3 +1,4 @@
+mod callout;
 mod diagnostic;
 mod empty_state;
 mod evidence;
@@ -10,6 +11,7 @@ mod refresh_progress;
 mod section;
 mod table;
 
+pub use callout::{callout, Callout};
 pub use diagnostic::{diagnostic, Diagnostic, DiagnosticLevel};
 pub use empty_state::{empty_state, EmptyState};
 pub use evidence::{evidence_list, Evidence};

--- a/crates/ctx-terminal/src/ui/components/mod.rs
+++ b/crates/ctx-terminal/src/ui/components/mod.rs
@@ -11,7 +11,7 @@ mod refresh_progress;
 mod section;
 mod table;
 
-pub use callout::{callout, Callout};
+pub use callout::{callout, Callout, CalloutPresentation, CalloutRow, CalloutStatus};
 pub use diagnostic::{diagnostic, Diagnostic, DiagnosticLevel};
 pub use empty_state::{empty_state, EmptyState};
 pub use evidence::{evidence_list, Evidence};

--- a/crates/ctx-terminal/src/ui/glyph.rs
+++ b/crates/ctx-terminal/src/ui/glyph.rs
@@ -2,6 +2,7 @@ use super::RenderContext;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum Glyph {
+    Bullet,
     Success,
     Failure,
     Warning,
@@ -17,6 +18,8 @@ pub(super) enum Glyph {
 impl Glyph {
     pub(super) const fn render(self, context: &RenderContext) -> &'static str {
         match (self, context.unicode()) {
+            (Self::Bullet, true) => "•",
+            (Self::Bullet, false) => "-",
             (Self::Success, true) => "✓",
             (Self::Success, false) => "OK",
             (Self::Failure, true) => "✗",

--- a/crates/ctx-terminal/src/ui/glyph.rs
+++ b/crates/ctx-terminal/src/ui/glyph.rs
@@ -7,6 +7,11 @@ pub(super) enum Glyph {
     Warning,
     Progress,
     Rule,
+    BoxTopLeft,
+    BoxTopRight,
+    BoxBottomLeft,
+    BoxBottomRight,
+    BoxVertical,
 }
 
 impl Glyph {
@@ -21,6 +26,16 @@ impl Glyph {
             (Self::Progress, false) => "=",
             (Self::Rule, true) => "─",
             (Self::Rule, false) => "-",
+            (Self::BoxTopLeft, true) => "╭",
+            (Self::BoxTopLeft, false) => "+",
+            (Self::BoxTopRight, true) => "╮",
+            (Self::BoxTopRight, false) => "+",
+            (Self::BoxBottomLeft, true) => "╰",
+            (Self::BoxBottomLeft, false) => "+",
+            (Self::BoxBottomRight, true) => "╯",
+            (Self::BoxBottomRight, false) => "+",
+            (Self::BoxVertical, true) => "│",
+            (Self::BoxVertical, false) => "|",
         }
     }
 }

--- a/crates/ctx-terminal/src/ui/mod.rs
+++ b/crates/ctx-terminal/src/ui/mod.rs
@@ -14,12 +14,12 @@ mod writer;
 
 pub use bootstrap::{bootstrap_color_choice, scan_color_mode, scan_machine_output_hint};
 pub use components::{
-    diagnostic, display_width, empty_state, evidence_list, fields, hint, is_copyable_atom, outcome,
-    progress, refresh_progress, section, table, Action, Diagnostic, DiagnosticLevel, EmptyState,
-    Evidence, Field, Hint, Outcome, OutcomeState, Progress, RefreshCurrentSourceProgress,
-    RefreshCurrentSourceProgressStage, RefreshLogicalPhase, RefreshLogicalStatus, RefreshProgress,
-    RefreshProgressSnapshot, RefreshRequestState, RefreshStatusKind, RefreshStructuredOutcome,
-    RefreshWholeRunStage, Table,
+    callout, diagnostic, display_width, empty_state, evidence_list, fields, hint, is_copyable_atom,
+    outcome, progress, refresh_progress, section, table, Action, Callout, Diagnostic,
+    DiagnosticLevel, EmptyState, Evidence, Field, Hint, Outcome, OutcomeState, Progress,
+    RefreshCurrentSourceProgress, RefreshCurrentSourceProgressStage, RefreshLogicalPhase,
+    RefreshLogicalStatus, RefreshProgress, RefreshProgressSnapshot, RefreshRequestState,
+    RefreshStatusKind, RefreshStructuredOutcome, RefreshWholeRunStage, Table,
 };
 pub use context::{ColorMode, RenderContext, StreamKind, TestContext};
 pub use document::{sanitize_untrusted_history_body_for_terminal, Document, Line, Span};

--- a/crates/ctx-terminal/src/ui/mod.rs
+++ b/crates/ctx-terminal/src/ui/mod.rs
@@ -15,11 +15,12 @@ mod writer;
 pub use bootstrap::{bootstrap_color_choice, scan_color_mode, scan_machine_output_hint};
 pub use components::{
     callout, diagnostic, display_width, empty_state, evidence_list, fields, hint, is_copyable_atom,
-    outcome, progress, refresh_progress, section, table, Action, Callout, Diagnostic,
-    DiagnosticLevel, EmptyState, Evidence, Field, Hint, Outcome, OutcomeState, Progress,
-    RefreshCurrentSourceProgress, RefreshCurrentSourceProgressStage, RefreshLogicalPhase,
-    RefreshLogicalStatus, RefreshProgress, RefreshProgressSnapshot, RefreshRequestState,
-    RefreshStatusKind, RefreshStructuredOutcome, RefreshWholeRunStage, Table,
+    outcome, progress, refresh_progress, section, table, Action, Callout, CalloutPresentation,
+    CalloutRow, CalloutStatus, Diagnostic, DiagnosticLevel, EmptyState, Evidence, Field, Hint,
+    Outcome, OutcomeState, Progress, RefreshCurrentSourceProgress,
+    RefreshCurrentSourceProgressStage, RefreshLogicalPhase, RefreshLogicalStatus, RefreshProgress,
+    RefreshProgressSnapshot, RefreshRequestState, RefreshStatusKind, RefreshStructuredOutcome,
+    RefreshWholeRunStage, Table,
 };
 pub use context::{ColorMode, RenderContext, StreamKind, TestContext};
 pub use document::{sanitize_untrusted_history_body_for_terminal, Document, Line, Span};

--- a/crates/ctx-terminal/src/ui/tests.rs
+++ b/crates/ctx-terminal/src/ui/tests.rs
@@ -8,10 +8,11 @@ use unicode_width::UnicodeWidthStr as _;
 
 use super::{
     bootstrap::{scan_color_mode, scan_machine_output_hint},
-    canonical_human_output_bytes, diagnostic, empty_state, evidence_list, fields, hint, outcome,
-    progress, sanitize_untrusted_history_body_for_terminal, section, table, Action, ColorMode,
-    Diagnostic, DiagnosticLevel, Document, EmptyState, Evidence, Field, Hint, Line, Outcome,
-    OutcomeState, Progress, RenderContext, Span, StreamKind, Table, TestContext, Token, Ui,
+    callout, canonical_human_output_bytes, diagnostic, empty_state, evidence_list, fields, hint,
+    outcome, progress, sanitize_untrusted_history_body_for_terminal, section, table, Action,
+    Callout, ColorMode, Diagnostic, DiagnosticLevel, Document, EmptyState, Evidence, Field, Hint,
+    Line, Outcome, OutcomeState, Progress, RenderContext, Span, StreamKind, Table, TestContext,
+    Token, Ui,
 };
 
 fn tty(width: usize) -> RenderContext {
@@ -314,6 +315,28 @@ fn decorative_glyphs_have_only_the_approved_ascii_fallbacks() {
     .render_plain();
     assert!(indeterminate.contains("========"));
     assert!(indeterminate.contains('-'));
+
+    let callout_body = Document::from_line(Line::text("Complete human output."));
+    let unicode_callout = callout(
+        &unicode,
+        Callout {
+            title: "Note",
+            body: &callout_body,
+        },
+    )
+    .render_plain();
+    let ascii_callout = callout(
+        &ascii,
+        Callout {
+            title: "Note",
+            body: &callout_body,
+        },
+    )
+    .render_plain();
+    assert!(unicode_callout.starts_with('╭'));
+    assert!(unicode_callout.trim_end().ends_with('╯'));
+    assert!(ascii_callout.starts_with('+'));
+    assert!(ascii_callout.trim_end().ends_with('+'));
 }
 
 #[test]
@@ -328,7 +351,19 @@ fn every_component_has_byte_identical_ansi_stripped_and_plain_output() {
     let table_value = Table::new(["Provider", "State"])
         .row(["codex", "ready"])
         .row(["claude", "pending"]);
+    let callout_body = Document::from_line(
+        Line::new()
+            .with(Span::text("Local history remains "))
+            .with(Span::new("on this device", Token::Accent)),
+    );
     let documents = vec![
+        callout(
+            &context,
+            Callout {
+                title: "History stays local",
+                body: &callout_body,
+            },
+        ),
         outcome(
             &context,
             Outcome {


### PR DESCRIPTION
## Summary

- add the reviewed reusable semantic callout component from #615
- add the reviewed bounded structured Core progress event stream from #617
- compose one persistent neutral callout through live refresh, resize, plain, and JSON output paths
- preserve typed terminal-failure handling from current main and neutralize control characters before structured serialization

## Validation

- `scripts/bazelw test //crates/ctx-terminal:unit_tests //crates/ctx-cli:unit_tests --config=ci`
- focused Clippy, formatting, repository-policy, guarded disclosure scan, and PTY/resize coverage

This integration PR contains the reviewed work from #615 and #617 on current `main`.