### PR TITLE
fix(history): reuse writerless identical refreshes

### DIFF
--- a/crates/ctx-history-index/src/staging.rs
+++ b/crates/ctx-history-index/src/staging.rs
@@ -243,14 +243,14 @@ pub(super) fn manifest_source_replacements(
     Ok(replacements)
 }
 
-/// Discards a completed one-pass staging run when it reproduced the full
-/// verified base manifest exactly.
+/// Finishes a completed one-pass run when it reproduced the full verified
+/// base manifest exactly.
 ///
 /// Requiring every retained base source to have a pending certificate prevents
 /// an incomplete route scan from turning a carried source into a false no-op.
-/// The already-created Tantivy writer is rolled back, so physical churn that
-/// leaves the logical corpus unchanged does not publish `meta.json`, advance
-/// the opstamp, or create a generation.
+/// An already-created Tantivy writer is rolled back; a writerless run is reused
+/// directly. Physical work that leaves the logical corpus unchanged therefore
+/// does not publish `meta.json`, advance the opstamp, or create a generation.
 pub(super) fn finish_identical_staging<F, I>(
     generation: &mut GenerationWriter,
     manifest: &GenerationManifest,
@@ -302,11 +302,10 @@ where
         .ok_or(IndexError::WriterInvariant(
             "staged no-op is missing its verified base manifest",
         ))?;
-    let mut writer = generation.writer.take().ok_or(IndexError::WriterInvariant(
-        "staged no-op is missing its Tantivy writer",
-    ))?;
-    writer.rollback()?;
-    writer.wait_merging_threads()?;
+    if let Some(mut writer) = generation.writer.take() {
+        writer.rollback()?;
+        writer.wait_merging_threads()?;
+    }
     Ok(true)
 }
 
@@ -314,7 +313,14 @@ fn staged_manifest_matches_base(
     generation: &GenerationWriter,
     manifest: &GenerationManifest,
 ) -> Result<bool> {
-    if generation.writer.is_none() {
+    if generation.writer.is_none()
+        && generation.complete_inventories.is_empty()
+        && generation.source_route_plan.is_none()
+    {
+        // A writerless candidate still needs current inventory authority. An
+        // exact route plan plus the manifest equality and source coverage
+        // checks below supplies it; otherwise preserve the ordinary path so
+        // its terminal witness can reject races.
         return Ok(false);
     }
     let Some(base) = generation

--- a/crates/ctx-history-index/src/tests/writer/routes.rs
+++ b/crates/ctx-history-index/src/tests/writer/routes.rs
@@ -502,6 +502,86 @@ fn failed_route_rollback_restores_its_carried_retirement() {
 }
 
 #[test]
+fn writerless_failed_route_reuses_identical_publication_metadata() {
+    let temp = tempdir().unwrap();
+    let old_source = source("writerless-failed-route.jsonl");
+    let old_route = SourceRouteIdentity::from_sha256("5c".repeat(32)).unwrap();
+    let failed_route = SourceRouteIdentity::from_sha256("6d".repeat(32)).unwrap();
+
+    let mut initial = GenerationWriter::open(temp.path(), WriterOptions::default())
+        .unwrap()
+        .into_writer()
+        .unwrap();
+    initial.begin_source(old_source.clone()).unwrap();
+    initial
+        .add_core_record(document(&old_source, 1, "writerless retained body"))
+        .unwrap();
+    initial
+        .certify_source(appendable_certificate(&old_source, 1, 1, 10))
+        .unwrap();
+    initial
+        .set_present_source_routes(vec![SourceRouteSnapshot::present(
+            old_route.clone(),
+            vec![old_source.clone()],
+        )
+        .unwrap()])
+        .unwrap();
+    let initial = initial
+        .commit_with_publication_metadata(|_| true, |_| Ok(b"initial metadata".to_vec()))
+        .unwrap();
+    let meta_path = active_generation_path(temp.path()).join("meta.json");
+    let meta_before = fs::read(&meta_path).unwrap();
+
+    let mut failed = GenerationWriter::open(temp.path(), WriterOptions::default())
+        .unwrap()
+        .into_writer()
+        .unwrap();
+    failed
+        .set_source_route_plan(
+            BTreeSet::from([old_route.clone(), failed_route.clone()]),
+            BTreeSet::new(),
+        )
+        .unwrap();
+    failed.begin_source_route_stage(old_route.clone()).unwrap();
+    let replayed = stage_exact_replay(&mut failed, &old_source);
+    failed.finish_source_route_stage(&old_route).unwrap();
+    assert!(!failed
+        .carry_failed_source_route_from_base(&failed_route)
+        .unwrap());
+    failed
+        .set_present_source_routes(vec![SourceRouteSnapshot::present(
+            old_route.clone(),
+            vec![old_source],
+        )
+        .unwrap()])
+        .unwrap();
+    assert!(
+        failed.writer.is_none(),
+        "carrying the verified base must not construct a Tantivy writer"
+    );
+
+    let replay = failed
+        .commit_with_publication_metadata(
+            |target| matches!(target, RevalidationTarget::Source(current) if current == &replayed),
+            |_| -> Result<Vec<u8>> {
+                panic!("writerless identical staging must skip the metadata factory")
+            },
+        )
+        .unwrap();
+
+    assert_eq!(replay.disposition(), PublicationDisposition::Reused);
+    assert_eq!(
+        replay.receipt().generation_id,
+        initial.receipt().generation_id
+    );
+    assert_eq!(fs::read(&meta_path).unwrap(), meta_before);
+    assert_eq!(
+        replay.receipt().manifest().source_route(&old_route),
+        initial.receipt().manifest().source_route(&old_route)
+    );
+}
+
+#[test]
 fn unpublished_route_checkpoint_is_reclaimed_after_reopen() {
     let temp = tempdir().unwrap();
     let source_a = source("checkpoint-crash-a.jsonl");


### PR DESCRIPTION
Summary:
- reuse writerless refresh runs when an exact route plan and the staged manifest prove the active generation is unchanged
- preserve the ordinary terminal-witness path when no current inventory authority exists
- add regression coverage proving publication metadata is not rebuilt and meta.json remains byte-identical

Validation:
- //crates/ctx-history-index:unit_tests (227 tests)
- scripts/check-repository-policy.sh
- 1.15 GiB Codex corpus: immutable no-op 0.75s, one append ~0.9s
- 32 valid-history burst: 32 distinct events published; refresh work 0.57s