### PR TITLE
perf(index): reduce cold-ingest merge stalls

### DIFF
--- a/crates/ctx-history-index-format/src/contracts.rs
+++ b/crates/ctx-history-index-format/src/contracts.rs
@@ -33,7 +33,7 @@ pub const MAX_DOCUMENT_METADATA_BYTES: usize = 64 * 1024;
 /// active segments, bounding merge publications amortized over tiny appends
 /// while avoiding a full-index rewrite for each append. Delete-heavy segments
 /// use the independent reclamation threshold in the lexical merge policy.
-pub const LEXICAL_SEGMENT_MERGE_FAN_IN: usize = 8;
+pub const LEXICAL_SEGMENT_MERGE_FAN_IN: usize = 16;
 
 /// Published active segments may contain at most 1/4 deleted documents.
 ///

--- a/crates/ctx-history-index/src/merge_policy.rs
+++ b/crates/ctx-history-index/src/merge_policy.rs
@@ -139,7 +139,7 @@ mod tests {
     }
 
     #[test]
-    fn append_tiering_waits_for_eight_one_doc_deltas_before_merging() {
+    fn append_tiering_waits_for_fan_in_one_doc_deltas_before_merging() {
         let index = Index::create_in_ram(Schema::builder().build());
         let base = segment(&index, 1_024, 0);
         let one_doc_deltas = (0..(LEXICAL_SEGMENT_MERGE_FAN_IN - 1))
@@ -150,7 +150,7 @@ mod tests {
             .compute_merge_candidates(&[vec![base], one_doc_deltas].concat());
         assert!(
             candidates.is_empty(),
-            "seven one-doc deltas must stay below the merge threshold even when a larger packed base exists"
+            "fan-in minus one one-doc deltas must stay below the merge threshold even when a larger packed base exists"
         );
     }
 }

--- a/crates/ctx-history-index/src/tests/writer/complexity_contract.rs
+++ b/crates/ctx-history-index/src/tests/writer/complexity_contract.rs
@@ -108,8 +108,12 @@ fn measure_exact_noop(retained_documents: u64) -> PublicationWork {
     )
 }
 
-fn measure_one_record_append(retained_documents: u64) -> PublicationWork {
+fn measure_one_record_append(retained_documents: u64) -> (PublicationWork, usize) {
     let fixture = retained_fixture(retained_documents);
+    let base_segment_count = {
+        let (searcher, _) = open_unverified_generation(fixture.root.path());
+        searcher.segment_readers().len()
+    };
     let mut writer = GenerationWriter::open(fixture.root.path(), WriterOptions::default())
         .unwrap()
         .into_writer()
@@ -146,9 +150,12 @@ fn measure_one_record_append(retained_documents: u64) -> PublicationWork {
 
     crate::publication::reset_verification_activity();
     writer.commit(|_| true).unwrap();
-    PublicationWork::capture(
-        constructions.load(Ordering::SeqCst),
-        crate::prior_session_identity_lookup_work(),
+    (
+        PublicationWork::capture(
+            constructions.load(Ordering::SeqCst),
+            crate::prior_session_identity_lookup_work(),
+        ),
+        base_segment_count,
     )
 }
 
@@ -270,8 +277,8 @@ fn exact_noop_work_is_zero_for_n_and_2n_retained_documents() {
 
 #[test]
 fn one_record_append_verification_work_is_independent_of_retained_corpus_size() {
-    let n = measure_one_record_append(RETAINED_N);
-    let two_n = measure_one_record_append(RETAINED_2N);
+    let (n, n_base_segments) = measure_one_record_append(RETAINED_N);
+    let (two_n, two_n_base_segments) = measure_one_record_append(RETAINED_2N);
 
     assert_eq!(
         n.logical_passes, 0,
@@ -287,7 +294,15 @@ fn one_record_append_verification_work_is_independent_of_retained_corpus_size() 
     assert_eq!(n.lineage_spills, 0);
     assert_eq!(n.complete_session_id_traversals, 0);
     assert_eq!(n.writer_constructions, 1);
-    assert_eq!(n.authority_lookup.segment_range_probes, 1);
+    assert_eq!(
+        n.authority_lookup.segment_range_probes, n_base_segments,
+        "the append must probe each live base segment exactly once"
+    );
+    assert_eq!(
+        two_n.authority_lookup.segment_range_probes, two_n_base_segments,
+        "the append must probe each live base segment exactly once"
+    );
+    assert!(n.authority_lookup.segment_range_probes <= MAX_SESSION_WITNESS_SEGMENT_PROBES);
     assert_eq!(n.authority_lookup.dictionary_terms, 1);
     assert_eq!(two_n.identity_terms, n.identity_terms);
     assert_eq!(two_n.identity_documents, n.identity_documents);
@@ -323,8 +338,11 @@ fn same_session_append_charges_each_live_segment_and_not_each_session_event() {
 #[test]
 #[ignore = "high-cardinality authority dictionary contract; tier-nightly"]
 fn high_cardinality_same_session_append_reads_only_the_live_witness() {
-    let work = measure_one_record_append(4_096);
-    assert_eq!(work.authority_lookup.segment_range_probes, 1);
+    let (work, base_segment_count) = measure_one_record_append(4_096);
+    assert_eq!(
+        work.authority_lookup.segment_range_probes,
+        base_segment_count
+    );
     assert_eq!(work.authority_lookup.dictionary_terms, 1);
     assert_eq!(work.authority_lookup.postings, 1);
     assert_eq!(work.authority_lookup.core_decodes, 1);

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -224,7 +224,7 @@ invocation terms become searchable.
 
 Lexical publication keeps the active generation and one previous generation
 for recovery and pinned readers; their manifests and integrity receipts use the
-same two-generation bound. Append-only segments merge after eight comparable
+same two-generation bound. Append-only segments merge after sixteen comparable
 segments accumulate. A refresh that rewrites, replaces, or deletes indexed
 records marks the superseded documents deleted in their Tantivy segments. This
 incremental behavior is independent of the removed `relational.sqlite` path.


### PR DESCRIPTION
## Summary
- raise lexical comparable-segment fan-in from 8 to 16
- keep incremental authority work explicitly bounded by live segment topology
- update storage documentation and topology-coupled tests

## Real-corpus evidence
- exact same 9,203 sessions, 453,178 messages, 2,097,929 tool calls, 33,874,315,420 scanned bytes, 5,693,291 documents, and logical generation
- exact-main control: 689s total, 94s merge, 137s frozen final tail
- candidate: 505s deterministic finite-worker cold publication and 571s persistent-daemon run; about 32s merge and 72-74s frozen final tail
- warm query p95: 1.32s candidate versus 2.17s control
- five-run tiny append: 0.373-0.376s candidate versus 0.316-0.317s control, both well below the 3s target

## Validation
- ctx-history-index unit tests
- ctx-history-index-format unit tests
- writer integration tests
- performance sanity tests
- ignored 4,096-record high-cardinality authority contract
- independent final review approved the bounded tradeoff