### PR TITLE
Publish Codex scan progress sooner

### DIFF
--- a/crates/ctx-history-provider-codex/src/codex/nativepath/reader.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/reader.rs
@@ -30,7 +30,10 @@ use crate::{
     },
     CaptureError, Result,
 };
-const MAX_CODEX_PAGE_UNITS: usize = 64;
+// Pages are also the exact progress-publication boundary. Keep them small
+// enough that a worker cannot make the visible counters appear stalled while
+// projecting a dense rollout.
+const MAX_CODEX_PAGE_UNITS: usize = 16;
 const MAX_CODEX_SOURCE_BACKED_PAGE_RECORDS: u64 = 4 * 1024;
 const MAX_CODEX_SOURCE_BACKED_PAGE_PROGRESS_BYTES: u64 = 32 * 1024 * 1024;
 const PAGE_FIXED_WIRE_BYTES: usize = 4 * 1024;


### PR DESCRIPTION
Reduces the Codex native scan page from 64 to 16 logical units so exact session/message/tool-call/byte counters publish more frequently during cold ingest.

Real-corpus validation (33.9 GB, 9,203 sessions, 5.69M events):
- terminal counts and index generation exactly matched main
- counter-gap p99 improved from 1.51s to 0.49s
- cold wall time improved from 517.39s to 487.92s
- peak RSS remained flat
- focused Codex tests, rustfmt, and 69 other affected targets passed

The affected suite also exposes a pre-existing main failure: Cargo is 1.0.1 while plugin manifests remain 1.0.0. This branch does not touch those files.