### PR TITLE
Sync plugin manifests to ctx 1.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "displayName": "ctx",
       "source": "./plugins/ctx",
       "description": "Fast local search and 'git blame' for agent sessions.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "ctx engineering inc"
       },

--- a/plugins/ctx/.claude-plugin/plugin.json
+++ b/plugins/ctx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ctx",
   "displayName": "ctx",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Fast local search and 'git blame' for agent sessions.",
   "author": {
     "name": "ctx engineering inc",

--- a/plugins/ctx/.codex-plugin/plugin.json
+++ b/plugins/ctx/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ctx",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Fast local search and 'git blame' for agent sessions.",
   "author": {
     "name": "ctx engineering inc",

--- a/plugins/ctx/.cursor-plugin/plugin.json
+++ b/plugins/ctx/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ctx",
   "displayName": "ctx",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Fast local search and 'git blame' for agent sessions.",
   "author": {
     "name": "ctx engineering inc",

--- a/plugins/ctx/plugin.json
+++ b/plugins/ctx/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "ctx",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Fast local search and 'git blame' for agent sessions.",
   "author": {
     "name": "ctx engineering inc",


### PR DESCRIPTION
Fixes the version mismatch introduced by the 1.0.1 release merge. All four plugin manifests and the sole version-bearing marketplace entry now match the Cargo workspace version.

Validation:
- plugin validator passed
- full docs check passed
- git diff check passed
- independent final review: ship