### PR TITLE
fix(contract-tests): declare ctx-history dev-dependencies for cargo builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,6 +836,8 @@ dependencies = [
  "assert_cmd",
  "base64 0.22.1",
  "chrono",
+ "ctx-history-core",
+ "ctx-history-index",
  "flate2",
  "libc",
  "predicates",

--- a/crates/ctx-cli-contract-tests/Cargo.toml
+++ b/crates/ctx-cli-contract-tests/Cargo.toml
@@ -36,6 +36,8 @@ path = "tests/contracts/setup_sources_import.rs"
 assert_cmd.workspace = true
 base64.workspace = true
 chrono.workspace = true
+ctx-history-core = { path = "../ctx-history-core" }
+ctx-history-index = { path = "../ctx-history-index" }
 flate2 = "1"
 libc.workspace = true
 predicates.workspace = true
@@ -50,3 +52,13 @@ uuid.workspace = true
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }
+
+[lints.rust]
+# Bazel passes these cfgs for its owned test wiring (binary binding, fixture
+# selection, upgrade fixtures); plain cargo builds never set them, so declare
+# them for check-cfg.
+unexpected_cfgs = { level = "allow", check-cfg = [
+    'cfg(ctx_cli_bazel_test)',
+    'cfg(ctx_cli_test_support_fixtures)',
+    'cfg(ctx_cli_test_support_upgrade)',
+] }


### PR DESCRIPTION
## Summary

- Declare `ctx-history-core` and `ctx-history-index` as path dev-dependencies of `ctx-cli-contract-tests` so its Bazel-owned cargo targets compile standalone again.
- The manifest comment already promises cargo all-target compilation for these contracts; this restores it.

Fixes #632.

## Validation

- `cargo test -p ctx-cli-contract-tests --no-run`: all 5 targets compile (previously 5 unresolved-crate errors).
- `cargo test -p ctx-cli-contract-tests`: green on macOS (the 4 sqlite-source failures seen during development reproduce only when `target/debug/ctx` predates the checkout; these tests spawn the debug binary via `Command::cargo_bin`, so they need `cargo build -p ctx` first).
