### PR TITLE
fix(workspace): make cargo clippy --workspace --all-targets -D warnings pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,6 +836,8 @@ dependencies = [
  "assert_cmd",
  "base64 0.22.1",
  "chrono",
+ "ctx-history-core",
+ "ctx-history-index",
  "flate2",
  "libc",
  "predicates",

--- a/contracts/telemetry-v1/source-provenance.json
+++ b/contracts/telemetry-v1/source-provenance.json
@@ -16,6 +16,6 @@
     "crates/ctx-cli/src/upgrade/command.rs": "0e0929c0cc854bf3d79637b293159dde3a6bd09fe06d5067e6506d2e036a5e10",
     "crates/ctx-cli/src/upgrade/ports.rs": "08e16fd1d1ad294cad261d0355d0a63ae24c0c9420b127d9739505fbb5696650",
     "crates/ctx-upgrade-engine/src/upgrade/command/daemon.rs": "294ee5c5b425747ecdc01648476c1686fabc1e221d927b640b56e8f5eaea2386",
-    "crates/ctx-upgrade-engine/src/upgrade/state.rs": "c1d3569ab954d05a46618a0f1671627dcd5b204cf6683e2936a17134b16f9fb2"
+    "crates/ctx-upgrade-engine/src/upgrade/state.rs": "167700076b8b64909ace80abf30c15e3e115efda216b098ca90f49c7f15baa02"
   }
 }

--- a/crates/ctx-cli-contract-tests/Cargo.toml
+++ b/crates/ctx-cli-contract-tests/Cargo.toml
@@ -36,6 +36,8 @@ path = "tests/contracts/setup_sources_import.rs"
 assert_cmd.workspace = true
 base64.workspace = true
 chrono.workspace = true
+ctx-history-core = { path = "../ctx-history-core" }
+ctx-history-index = { path = "../ctx-history-index" }
 flate2 = "1"
 libc.workspace = true
 predicates.workspace = true
@@ -50,3 +52,13 @@ uuid.workspace = true
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }
+
+[lints.rust]
+# Bazel passes these cfgs for its owned test wiring (binary binding, fixture
+# selection, upgrade fixtures); plain cargo builds never set them, so declare
+# them for check-cfg.
+unexpected_cfgs = { level = "allow", check-cfg = [
+    'cfg(ctx_cli_bazel_test)',
+    'cfg(ctx_cli_test_support_fixtures)',
+    'cfg(ctx_cli_test_support_upgrade)',
+] }

--- a/crates/ctx-cli/src/core_capability/failure.rs
+++ b/crates/ctx-cli/src/core_capability/failure.rs
@@ -167,7 +167,7 @@ fn valid_terminal_failure(terminal: &crate::semantic::SourceBackedRefreshTermina
             &terminal.blocked_routes,
         )
         || (!terminal.affected_routes.is_empty()
-            && terminal.retryable != !terminal.retryable_routes.is_empty())
+            && terminal.retryable == terminal.retryable_routes.is_empty())
     {
         return false;
     }

--- a/crates/ctx-daemon-application/src/supervisor/environment.rs
+++ b/crates/ctx-daemon-application/src/supervisor/environment.rs
@@ -259,7 +259,10 @@ pub(super) fn linux_systemd_unit_with_environment(
     )?)
 }
 
+// Called from supervisor tests on every host and from the daemon only on
+// macOS; plain cargo test on this host sees no caller, so allow dead_code.
 #[cfg(any(test, target_os = "macos"))]
+#[allow(dead_code)]
 pub(super) fn launch_agent_plist_with_environment(
     executable: &Path,
     data_root: &Path,

--- a/crates/ctx-daemon-runtime/Cargo.toml
+++ b/crates/ctx-daemon-runtime/Cargo.toml
@@ -39,3 +39,8 @@ windows-sys = { version = "0.61", features = [
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints.rust]
+# Bazel passes --cfg ctx_release_qualification for the release-qualification
+# build; plain cargo builds never set it, so declare it for check-cfg.
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(ctx_release_qualification)'] }

--- a/crates/ctx-daemon-runtime/src/handoff/installation.rs
+++ b/crates/ctx-daemon-runtime/src/handoff/installation.rs
@@ -204,10 +204,10 @@ fn validate_installation_registration(value: &Value, path: &Path) -> Result<()> 
         .map(Path::new)
         .is_some_and(Path::is_absolute);
     if value.get("schema_version").and_then(Value::as_u64) != Some(1)
-        || !value
+        || value
             .get("registration_id")
             .and_then(Value::as_str)
-            .is_some_and(|id| !id.is_empty())
+            .is_none_or(|id| id.is_empty())
         || !valid_status
         || !valid_root
     {

--- a/crates/ctx-daemon-service/src/daemon/tests.rs
+++ b/crates/ctx-daemon-service/src/daemon/tests.rs
@@ -6,7 +6,7 @@ use std::{
     fs,
     path::PathBuf,
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicUsize, Ordering},
         Arc,
     },
 };
@@ -138,6 +138,9 @@ struct ProviderObservationFixture {
     catalog: SourceBackedWatchCatalog,
     route: ctx_history_index::SourceRouteIdentity,
     executor: Arc<dyn SourceBackedRefreshExecutor>,
+    // Read only by linux-gated watcher tests; the fixture builds it on every
+    // platform so the constructor stays platform-neutral.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     writer_launches: Arc<AtomicUsize>,
 }
 

--- a/crates/ctx-daemon-service/src/daemon_wakeup.rs
+++ b/crates/ctx-daemon-service/src/daemon_wakeup.rs
@@ -23,7 +23,7 @@ use event_routing::record_and_observe_watch_event;
 use event_routing::{ignored_watch_event, record_ignored_watch_event, record_watch_event};
 
 #[cfg(test)]
-use ctx_daemon_runtime::{WATCH_DEBOUNCE_QUIET, WATCH_EVENT_QUEUE_CAPACITY};
+use ctx_daemon_runtime::WATCH_EVENT_QUEUE_CAPACITY;
 const WATCH_RECEIPT_FILE: &str = "wakeup.json";
 
 #[derive(Debug, Clone, Default)]
@@ -401,7 +401,7 @@ impl DaemonFileWatcher {
         EventWatermark::new(watermark.epoch, watermark.sequence)
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, target_os = "linux"))]
     pub(super) fn install_rearm_overlap_hook(&mut self, hook: impl FnMut(&Path) + 'static) {
         self.runtime.install_rearm_overlap_hook(hook);
     }

--- a/crates/ctx-daemon-service/src/daemon_wakeup/tests.rs
+++ b/crates/ctx-daemon-service/src/daemon_wakeup/tests.rs
@@ -9,13 +9,7 @@ use ctx_history_capture_model::{
     ProviderSourceStatus,
 };
 use ctx_history_core::CaptureProvider;
-use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Barrier,
-    },
-    thread,
-};
+use std::{sync::Barrier, thread};
 
 fn catalog_route(
     provider: CaptureProvider,

--- a/crates/ctx-history-index-query/src/filtering.rs
+++ b/crates/ctx-history-index-query/src/filtering.rs
@@ -202,10 +202,10 @@ pub(super) fn source_identity_values_match(
     {
         return false;
     }
-    !filters
+    filters
         .source_id
         .as_deref()
-        .is_some_and(|expected| expected.trim() != source_id)
+        .is_none_or(|expected| expected.trim() == source_id)
 }
 
 pub(super) fn add_optional_text_filter(

--- a/crates/ctx-history-index/src/tests/integrity_certification.rs
+++ b/crates/ctx-history-index/src/tests/integrity_certification.rs
@@ -101,6 +101,7 @@ fn mismatched_same_size_managed_bytes(path: &Path) -> Vec<u8> {
     bytes
 }
 
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 fn mismatched_same_size_bytes(path: &Path) -> Vec<u8> {
     let mut bytes = fs::read(path).unwrap();
     bytes[0] ^= 0x5a;

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/rows.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/rows.rs
@@ -629,10 +629,10 @@ fn is_encrypted_reasoning_without_plaintext(payload: &Value) -> bool {
         return false;
     };
     if object.get("type").and_then(Value::as_str) != Some("reasoning")
-        || !object
+        || object
             .get("encrypted_content")
             .and_then(Value::as_str)
-            .is_some_and(|content| !content.is_empty())
+            .is_none_or(|content| content.is_empty())
     {
         return false;
     }

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path/source_backed/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path/source_backed/tests.rs
@@ -78,6 +78,7 @@ fn query_time_corrupt_and_notadb_keep_provider_content_provenance() {
             ctx_history_source_sqlite::SqliteSourceSnapshotStrategy::CopiedFamily => {
                 crate::provider_sources::SqliteArtifactKind::PrivateSourceCopy
             }
+            #[cfg(target_os = "linux")]
             ctx_history_source_sqlite::SqliteSourceSnapshotStrategy::PinnedReadOnlyWal => {
                 crate::provider_sources::SqliteArtifactKind::ProviderDatabase
             }

--- a/crates/ctx-history-refresh/src/engine/durable_queue.rs
+++ b/crates/ctx-history-refresh/src/engine/durable_queue.rs
@@ -414,8 +414,8 @@ fn recover_pending_attempt(
     is_root: bool,
 ) -> Result<SourceBackedRefreshAttempt> {
     let request_state = job.get("request_state").and_then(Value::as_str);
-    if !matches!(request_state, Some("admission_pending" | "queued"))
-        && !(is_root && request_state == Some("running"))
+    if !(matches!(request_state, Some("admission_pending" | "queued"))
+        || is_root && request_state == Some("running"))
     {
         bail!("durable source refresh {role} is not queued");
     }

--- a/crates/ctx-history-refresh/src/engine/request_lifecycle/recovery.rs
+++ b/crates/ctx-history-refresh/src/engine/request_lifecycle/recovery.rs
@@ -609,7 +609,7 @@ fn recover_failure_outcome(
                 || retryable_routes
                     .union(&blocked_routes)
                     .ne(affected_routes.iter())
-                || (!affected_routes.is_empty() && retryable != !retryable_routes.is_empty())
+                || (!affected_routes.is_empty() && retryable == retryable_routes.is_empty())
             {
                 bail!("durable terminal source refresh outcome has inconsistent route disposition");
             }

--- a/crates/ctx-history-refresh/src/request.rs
+++ b/crates/ctx-history-refresh/src/request.rs
@@ -694,7 +694,7 @@ fn parse_terminal_outcome(value: &Value) -> Result<RefreshTerminalOutcome> {
     if !retryable_routes.is_disjoint(&blocked_routes)
         || !retryable_routes.is_subset(&affected_routes)
         || !blocked_routes.is_subset(&affected_routes)
-        || (!affected_routes.is_empty() && retryable != !retryable_routes.is_empty())
+        || (!affected_routes.is_empty() && retryable == retryable_routes.is_empty())
     {
         bail!("source refresh structured outcome has inconsistent route dispositions");
     }

--- a/crates/ctx-protocol/src/lib.rs
+++ b/crates/ctx-protocol/src/lib.rs
@@ -673,7 +673,7 @@ impl AgentHistoryEvent {
             .as_ref()
             .and_then(|exchange| exchange.response.as_ref())
             .is_some_and(|response| response.text == McpTextCapture::NormalizedBody);
-        if has_normalized_body && !self.text.as_deref().is_some_and(|text| !text.is_empty()) {
+        if has_normalized_body && self.text.as_deref().is_none_or(|text| text.is_empty()) {
             return Err("normalized MCP response body requires nonempty event text".to_owned());
         }
         Ok(())

--- a/crates/ctx-sdk/src/tests.rs
+++ b/crates/ctx-sdk/src/tests.rs
@@ -6,7 +6,7 @@ use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
 use std::process::Child;
 #[cfg(unix)]
-use std::{thread, time::Instant};
+use std::thread;
 
 #[cfg(unix)]
 fn spawn_json_shell(body: &str) -> Child {

--- a/crates/ctx-semantic-model/src/model_runtime/onnx.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/onnx.rs
@@ -540,7 +540,6 @@ pub(super) fn semantic_onnxruntime_platform_dir() -> &'static str {
 #[cfg(test)]
 #[cfg(ctx_semantic_fastembed)]
 mod ort_runtime_tests {
-    use std::env;
 
     use super::*;
 

--- a/crates/ctx-upgrade-engine/src/upgrade/state.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/state.rs
@@ -469,9 +469,9 @@ fn auto_check_due(state: &UpgradeState, interval: Duration, now: u64) -> bool {
     if interval.is_zero() {
         return true;
     }
-    !state
+    state
         .next_check_unix_s
-        .is_some_and(|deadline| now < deadline)
+        .is_none_or(|deadline| now >= deadline)
 }
 
 fn failure_backoff(consecutive_failures: u64) -> Duration {


### PR DESCRIPTION
## Summary

- Declare the four Bazel-owned cfgs (`ctx_release_qualification`, `ctx_cli_bazel_test`, `ctx_cli_test_support_fixtures`, `ctx_cli_test_support_upgrade`) in the owning crate manifests so check-cfg stops flagging them.
- Apply current clippy 1.96 suggestions: `nonminimal_bool` simplifications (7 sites, e.g. `is_none_or`), two unused-import removals.
- Align cfg gates with call sites for platform-gated test helpers: `install_rearm_overlap_hook` is only called from linux tests, `mismatched_same_size_bytes` only from linux/windows tests, `ProviderObservationFixture::writer_launches` is only read on linux (kept platform-neutral with an annotated allow), `launch_agent_plist_with_environment` is called from tests on every host but only from the daemon on macOS.
- Gate the `PinnedReadOnlyWal` match arm in the crush source_backed tests, fixing a real compile error on non-linux hosts.
- Refresh the `crates/ctx-upgrade-engine/src/upgrade/state.rs` hash in `contracts/telemetry-v1/source-provenance.json`, required by the content-addressed provenance contract test.

No behavior change; lint and cfg-declaration fixes only.

Fixes #633.

## Validation

- `cargo clippy --workspace --all-targets -- -D warnings`: clean on macOS (previously 15+ errors across 9 crates).
- `cargo fmt --all -- --check`: clean.
- `cargo test --workspace` on macOS with `TMPDIR=/private/tmp`: identical results to a pristine v1.0.2 baseline (the `hosted_uninstall_fence` target fails 3 of 4 on both trees; pre-existing hosted-installer environment behavior, untouched by this PR).

## Notes

- Stacked on #634 (the `ctx-cli-contract-tests` targets reference `ctx_history_index`/`ctx_history_core` and only compile with those dev-dependencies declared). Merge order: #634 first.
- Contract tests spawn `target/debug/ctx` via `Command::cargo_bin`; run `cargo build -p ctx` before `cargo test -p ctx-cli-contract-tests` or stale-binary failures appear.
