### PR TITLE
fix(codex): preserve cold imports during live append

### DIFF
--- a/crates/ctx-history-capture-composition/src/source_backed/tests/codex_child_independence.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/tests/codex_child_independence.rs
@@ -1426,6 +1426,8 @@ fn codex_incremental_4097th_terminal_saturates_and_replaces_fail_open() {
 
 #[path = "codex_child_independence/compressed.rs"]
 mod compressed;
+#[path = "codex_child_independence/continuous_append.rs"]
+mod continuous_append;
 #[path = "codex_child_independence/lifecycle.rs"]
 mod lifecycle;
 #[path = "codex_child_independence/repository.rs"]

--- a/crates/ctx-history-capture-composition/src/source_backed/tests/codex_child_independence/continuous_append.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/tests/codex_child_independence/continuous_append.rs
@@ -1,0 +1,105 @@
+use super::*;
+
+#[test]
+fn codex_cold_appends_during_bounded_capture_catch_up_once() {
+    const INVENTORY_APPEND_MARKER: &str = "coldinventoryappendtoken631a";
+    const OBSERVATION_APPEND_MARKER: &str = "coldobservationappendtoken631b";
+    const SEMANTIC_APPEND_MARKER: &str = "coldsemanticappendtoken631c";
+    const TERMINAL_APPEND_MARKER: &str = "coldterminalappendtoken631d";
+    let temp = tempdir().unwrap();
+    let sessions = temp.path().join("sessions-continuous-append");
+    let index_root = temp.path().join("index-continuous-append");
+    fs::create_dir_all(&sessions).unwrap();
+    let native_session_id = "019fb000-0000-7000-8000-000000000063";
+    let path = session_path(&sessions, native_session_id);
+    write_session(
+        &sessions,
+        native_session_id,
+        ProviderNativeSessionRelationship::Root,
+        None,
+        [message("coldprefixuniquetoken631")],
+    );
+    let registry = register_tree(&[&sessions]);
+
+    // Product contract: docs/provider-import-policy.md#active-writer-lifecycle-contract.
+    // Keep this as one end-to-end Codex route test: lower-level frozen-prefix
+    // tests cannot prove that provider inventory and shared preflight compose.
+    let append_path = path.clone();
+    crate::provider::codex::nativepath::source_backed::install_after_codex_metadata_inventory_hook(
+        move || {
+            append_event(&append_path, message(INVENTORY_APPEND_MARKER));
+        },
+    );
+    let append_path = path.clone();
+    crate::provider::source_backed::family::jsonl::set_after_jsonl_append_observation_route_binding_hook(
+        path.clone(),
+        move || append_event(&append_path, message(OBSERVATION_APPEND_MARKER)),
+    );
+    let append_path = path.clone();
+    crate::provider::source_backed::family::jsonl::set_after_jsonl_semantic_preflight_hook(
+        path.clone(),
+        move || append_event(&append_path, message(SEMANTIC_APPEND_MARKER)),
+    );
+    let append_path = path.clone();
+    set_before_jsonl_terminal_physical_revalidation_hook(sessions.clone(), move || {
+        append_event(&append_path, message(TERMINAL_APPEND_MARKER));
+    });
+
+    let cold = refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
+    assert!(
+        cold.failed_routes.is_empty(),
+        "unexpected route failures: {:?}",
+        cold.failed_routes
+    );
+    assert!(cold.logical_source_failures.is_empty());
+
+    let initial = VerifiedIndex::open(&index_root).unwrap();
+    assert!(source_records_contain(
+        &initial,
+        native_session_id,
+        "coldprefixuniquetoken631"
+    ));
+    for marker in [
+        INVENTORY_APPEND_MARKER,
+        OBSERVATION_APPEND_MARKER,
+        SEMANTIC_APPEND_MARKER,
+        TERMINAL_APPEND_MARKER,
+    ] {
+        assert!(
+            !source_records_contain(&initial, native_session_id, marker),
+            "cold publication included deferred suffix {marker}"
+        );
+    }
+    drop(initial);
+
+    let caught_up =
+        refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
+    assert!(caught_up.failed_routes.is_empty());
+    assert!(caught_up.logical_source_failures.is_empty());
+    let current = VerifiedIndex::open(&index_root).unwrap();
+    let caught_up_generation = current.generation_id().to_owned();
+    assert_eq!(records_for(&current, native_session_id).len(), 5);
+    for marker in [
+        INVENTORY_APPEND_MARKER,
+        OBSERVATION_APPEND_MARKER,
+        SEMANTIC_APPEND_MARKER,
+        TERMINAL_APPEND_MARKER,
+    ] {
+        assert!(source_records_contain(&current, native_session_id, marker));
+        assert_eq!(
+            source_snapshot(&current, native_session_id, marker)
+                .search_event_ids
+                .len(),
+            1,
+            "catch-up did not index suffix {marker} exactly once"
+        );
+    }
+    drop(current);
+
+    let no_op = refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
+    assert!(no_op.failed_routes.is_empty());
+    assert!(no_op.logical_source_failures.is_empty());
+    let terminal = VerifiedIndex::open(&index_root).unwrap();
+    assert_eq!(terminal.generation_id(), caught_up_generation);
+    assert_eq!(records_for(&terminal, native_session_id).len(), 5);
+}

--- a/crates/ctx-history-jsonl/src/family/route/capture.rs
+++ b/crates/ctx-history-jsonl/src/family/route/capture.rs
@@ -484,9 +484,10 @@ fn classify_incomplete_first_records<R: JsonlFamilyRuntime>(
                         &leaf.source_path,
                         &leaf.authority,
                         &leaf.authority_path,
-                        Some(&leaf.observation),
+                        &leaf.observation,
                         adapter.physical_encoding(&leaf),
                         adapter.record_framing(),
+                        leaf.frozen_scan_observation().is_some(),
                     )? =>
             {
                 changed = true;
@@ -511,9 +512,10 @@ fn classify_incomplete_first_records<R: JsonlFamilyRuntime>(
                     &leaf.source_path,
                     authority,
                     &leaf.authority_path,
-                    Some(&leaf.observation),
+                    &leaf.observation,
                     leaf.physical_encoding,
                     adapter.record_framing(),
+                    false,
                 )? {
                     changed = true;
                     classified.push(JsonlFamilyInventoryMember::Pending {
@@ -544,15 +546,27 @@ fn first_record_is_incomplete<E: JsonlFamilyError>(
     source_path: &Path,
     authority: &Arc<ProviderSourceRoot<E>>,
     authority_path: &Path,
-    expected: Option<&JsonlFileObservation>,
+    expected: &JsonlFileObservation,
     encoding: JsonlPhysicalEncoding,
     framing: JsonlRecordFraming,
+    freeze_observation_at_scan: bool,
 ) -> JsonlResult<bool, E> {
     let opened = authority.open_file(authority_path)?;
-    let observation = observe_opened_file(source_path, &opened)?;
-    if expected.is_some_and(|expected| expected != &observation) {
+    let current = if freeze_observation_at_scan {
+        observe_opened_file_allow_append(source_path, &opened)?
+    } else {
+        observe_opened_file(source_path, &opened)?
+    };
+    // Frozen-scan leaves already bind publication to the discovery-time
+    // observation. Classify their first record inside that bound while later
+    // scan and terminal proofs authenticate the prefix; newly appended bytes
+    // belong to the next refresh. Exact leaves retain exact preflight behavior.
+    if (freeze_observation_at_scan && !expected.admits_frozen_prefix_in(&current))
+        || (!freeze_observation_at_scan && expected != &current)
+    {
         return Err(E::source_changed());
     }
+    let observation = expected;
     if observation.length() == 0 {
         opened.revalidate_same_object()?;
         return Ok(false);

--- a/docs/provider-import-policy.md
+++ b/docs/provider-import-policy.md
@@ -240,7 +240,13 @@ contract for that source family:
   prefix. Daemon startup and watcher replacement are exhaustive safety
   boundaries as well. Only complete records ending at or before the frozen EOF
   are published; a partial final record is deferred until a later refresh
-  completes it.
+  completes it. Cold bootstrap and exhaustive refresh must not require the
+  provider to become globally quiescent: once a leaf's opening observation is
+  admitted, ordinary append-only growth of that retained object publishes the
+  complete records inside the frozen prefix and defers the newer suffix. The
+  next refresh imports that suffix exactly once, while truncation, path
+  replacement, and mutation inside the authenticated prefix continue to fail
+  closed.
 - Standard-Zstandard Codex rollouts snapshot exactly the frozen compressed
   prefix from the retained source handle, then decode and hash that same private
   snapshot. The compressed snapshot plus decoded spool is bounded to 256 MiB


### PR DESCRIPTION
## Summary

- admit the discovery-time frozen prefix through first-record preflight so active Codex writers do not invalidate cold or exhaustive capture
- specify the active-writer lifecycle contract and add an end-to-end Codex test covering appends at inventory, observation binding, semantic preflight, and terminal revalidation
- verify suffix bytes are deferred, caught up exactly once on the next refresh, and converge to a no-op while truncation, replacement, and authenticated-prefix mutation remain fail-closed

## Validation

- focused documentation, formatting, JSONL, and capture-composition gates: 4/4 passed
- affected-target selection against origin/main: 86/86 passed
- two independent code reviews: ship, no blocking findings

## Scope

Addresses #631.

This does not change the documented partial-success exit-code policy; the separate required-route exit-status concern remains outside this patch.