### PR TITLE
release: restore complete GitHub asset assembly

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -217,7 +217,7 @@ steps:
       - "target/public-cli-native-smoke/windows-x64/candidate-smoke.json"
       - "target/public-cli-native-smoke/windows-x64/ctx-windows-x64.native-execution.json"
 
-  - label: ":package: stage native-qualified GitHub release candidate"
+  - label: ":package: stage native-qualified Core release candidate"
     key: "github-release-candidate"
     depends_on:
       - "public-release"
@@ -240,7 +240,7 @@ steps:
       CTX_PUBLIC_RELEASE_SOURCE_COMMIT="$${source_commit}" \
         scripts/stage-github-release-assets.sh \
           target/public-cli-artifacts \
-          target/github-release-assets \
+          target/github-core-release-assets \
           target/github-release-authority \
           target/public-cli-native-smoke
     agents:
@@ -252,7 +252,7 @@ steps:
       arch: "x86_64"
     timeout_in_minutes: 30
     artifact_paths:
-      - "target/github-release-assets/*"
+      - "target/github-core-release-assets/*"
       - "target/github-release-authority/*"
 
   - label: ":package: Semantic ONNX models"
@@ -342,6 +342,7 @@ steps:
     key: "semantic-runtime-windows-ml"
     if: build.env("CTX_PUBLIC_SEMANTIC_ASSET_MATRIX") == "1" && build.branch == "main" && build.pull_request.id == null
     command: |
+      bash scripts/build-onnxruntime-sidecar.sh windows-x64
       bash scripts/build-onnxruntime-sidecar.sh windows-x64-windowsml
       powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/test-windows-semantic-smoke-contract.ps1
     agents:
@@ -352,6 +353,8 @@ steps:
     concurrency_group: "ctx-public-semantic-windows-native"
     timeout_in_minutes: 90
     artifact_paths:
+      - "target/public-cli-artifacts/ctx-onnxruntime-windows-x64.zip"
+      - "target/public-cli-artifacts/ctx-onnxruntime-windows-x64.zip.sha256"
       - "target/public-cli-artifacts/ctx-windowsml-windows-x64.zip"
       - "target/public-cli-artifacts/ctx-windowsml-windows-x64.zip.sha256"
       - "target/public-cli-artifacts/ctx-windowsml-windows-x64.zip.asset.json"
@@ -382,6 +385,49 @@ steps:
       - "target/public-cli-artifacts/ctx-onnxruntime-linux-x64*"
       - "target/public-cli-artifacts/ctx-onnxruntime-linux-aarch64*"
       - "target/public-cli-artifacts/ctx-onnxruntime-macos-arm64*"
+
+  - label: ":package: assemble complete GitHub release assets"
+    key: "github-release-assets"
+    depends_on:
+      - "github-release-candidate"
+      - "semantic-runtime-portable"
+      - "public-cli-macos-x64-runtime-producer"
+      - "semantic-runtime-windows-ml"
+    if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1" && build.env("CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX") == "1" && build.env("CTX_PUBLIC_SEMANTIC_ASSET_MATRIX") == "1" && build.branch == "main" && build.pull_request.id == null
+    command: |
+      mkdir -p target/public-cli-artifacts
+      buildkite-agent artifact download \
+        "target/github-core-release-assets/*" . \
+        --step github-release-candidate
+      buildkite-agent artifact download \
+        "target/public-cli-artifacts/ctx-onnxruntime-linux-x64.tar.gz*" . \
+        --step semantic-runtime-portable
+      buildkite-agent artifact download \
+        "target/public-cli-artifacts/ctx-onnxruntime-linux-aarch64.tar.gz*" . \
+        --step semantic-runtime-portable
+      buildkite-agent artifact download \
+        "target/public-cli-artifacts/ctx-onnxruntime-macos-arm64.tar.gz*" . \
+        --step semantic-runtime-portable
+      buildkite-agent artifact download \
+        "target/public-cli-artifacts/ctx-onnxruntime-macos-x64.tar.gz*" . \
+        --step public-cli-macos-x64-runtime-producer
+      buildkite-agent artifact download \
+        "*ctx-onnxruntime-windows-x64.zip*" . \
+        --step semantic-runtime-windows-ml
+      scripts/assemble-github-release-assets.sh \
+        target/github-core-release-assets \
+        target/public-cli-artifacts \
+        target/github-release-assets
+    agents:
+      queue: "release-linux-managed"
+      ctx-runner-class: "release-linux-control"
+      ctx-release-os: "ubuntu-24.04"
+      ctx-release-nested-docker: "true"
+      os: "linux"
+      arch: "x86_64"
+    timeout_in_minutes: 30
+    artifact_paths:
+      - "target/github-release-assets/*"
 
   - label: ":package: gather unsigned Semantic release handoff"
     key: "semantic-release-handoff"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -609,6 +609,16 @@ sh_test(
     tags = ["release-gate"],
 )
 
+sh_test(
+    name = "assemble_github_release_assets_tests",
+    srcs = ["scripts/tests/assemble-github-release-assets-test.sh"],
+    data = [
+        "scripts/assemble-github-release-assets.sh",
+        "scripts/release/release_bundle.py",
+    ],
+    tags = ["release-gate"],
+)
+
 py_test(
     name = "native_execution_proof_tests",
     srcs = [

--- a/docs/bazel-development.md
+++ b/docs/bazel-development.md
@@ -259,9 +259,22 @@ to the five fan-out jobs.
 With no mode flag, the staging helper validates and stages the five CLI
 binaries plus their SBOMs and notices. Semantic models and runtime transports
 are constructed and handed off by the separate Semantic release graph; they
-are not accepted by the Core factory or GitHub staging command. Core staging
-requires its aggregate Core completion marker, not per-platform Linux runtime
+are not accepted by the Core factory or Core staging command. Core staging
+requires its aggregate Core completion marker, not per-platform runtime
 completion identities.
+
+The final GitHub assembly step is the only convergence point. It consumes the
+independently staged 15-asset Core set and the five qualified ONNX Runtime
+transports, verifies both checksum sets, and atomically publishes the complete
+20-asset set plus `SHA256SUMS`. It does not rebuild, modify, or make either
+input graph authoritative for the other:
+
+```bash
+scripts/assemble-github-release-assets.sh \
+  target/github-core-release-assets \
+  target/public-cli-artifacts \
+  target/github-release-assets
+```
 
 Aggregate staging also writes a separate release-authority handoff directory;
 it does not add those files to the GitHub Release asset set or `SHA256SUMS`.
@@ -304,7 +317,7 @@ Pass an explicit third directory when staging for a release build:
 ```bash
 scripts/stage-github-release-assets.sh \
   target/public-cli-artifacts \
-  target/github-release-assets \
+  target/github-core-release-assets \
   target/github-release-authority
 ```
 

--- a/docs/unmanaged-installs.md
+++ b/docs/unmanaged-installs.md
@@ -80,13 +80,12 @@ Stable releases publish prebuilt binaries on GitHub Releases:
 | macOS Intel | `ctx-macos-x64` |
 | Windows x64 | `ctx-windows-x64.exe` |
 
-Each release also publishes `SHA256SUMS` for the binary assets. Releases that
-ship ctx-managed dynamic ONNX Runtime assets for the local semantic preview may
-also include sidecar archives named `ctx-onnxruntime-<platform>.tar.gz` on
-Unix-like platforms and `ctx-onnxruntime-windows-x64.zip` on Windows. The
-official installer reads signed release metadata and installs those runtime
-assets automatically when present; direct unmanaged installs should follow the
-release notes for any required runtime sidecar placement.
+Each stable release also publishes `SHA256SUMS` and the dynamic ONNX Runtime
+dependency used by local semantic search: `ctx-onnxruntime-<platform>.tar.gz`
+on Unix-like platforms and `ctx-onnxruntime-windows-x64.zip` on Windows. The
+official installer reads signed release metadata and installs the matching
+runtime automatically; direct unmanaged installs should follow the release
+notes for runtime sidecar placement.
 
 The hosted installer and managed-upgrade path verify signed ctx release
 metadata. Beginning with ctx 0.25.0, official macOS CLI binaries and the

--- a/scripts/assemble-github-release-assets.sh
+++ b/scripts/assemble-github-release-assets.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/assemble-github-release-assets.sh CORE_DIR RUNTIME_DIR [OUT_DIR]
+
+Combines an independently staged Core GitHub handoff with the five qualified
+ONNX Runtime transports. OUT_DIR defaults to target/github-release-assets.
+The input directories are never modified and the output is published once.
+USAGE
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ $# -ge 2 && $# -le 3 ]] || {
+  usage
+  exit 2
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+bundle_tool="${repo_root}/scripts/release/release_bundle.py"
+core_dir="$1"
+runtime_dir="$2"
+out_dir="${3:-target/github-release-assets}"
+for variable in core_dir runtime_dir out_dir; do
+  value="${!variable}"
+  [[ "${value}" != -* ]] || die "release directory cannot start with '-': ${value}"
+  if [[ "${value}" != /* ]]; then
+    printf -v "${variable}" '%s/%s' "${repo_root}" "${value}"
+  fi
+done
+
+python3 -I "${bundle_tool}" require-directory --directory "${core_dir}"
+python3 -I "${bundle_tool}" require-directory --directory "${runtime_dir}"
+python3 -I "${bundle_tool}" preflight-publication \
+  --input-dir "${core_dir}" --output-dir "${out_dir}"
+python3 -I "${bundle_tool}" preflight-publication \
+  --input-dir "${runtime_dir}" --output-dir "${out_dir}"
+
+core_assets=(
+  ctx-linux-x64
+  ctx-linux-x64.cdx.json
+  ctx-linux-x64.third-party-notices.txt
+  ctx-linux-aarch64
+  ctx-linux-aarch64.cdx.json
+  ctx-linux-aarch64.third-party-notices.txt
+  ctx-macos-arm64
+  ctx-macos-arm64.cdx.json
+  ctx-macos-arm64.third-party-notices.txt
+  ctx-macos-x64
+  ctx-macos-x64.cdx.json
+  ctx-macos-x64.third-party-notices.txt
+  ctx-windows-x64.exe
+  ctx-windows-x64.exe.cdx.json
+  ctx-windows-x64.exe.third-party-notices.txt
+)
+runtime_assets=(
+  ctx-onnxruntime-linux-x64.tar.gz
+  ctx-onnxruntime-linux-aarch64.tar.gz
+  ctx-onnxruntime-macos-arm64.tar.gz
+  ctx-onnxruntime-macos-x64.tar.gz
+  ctx-onnxruntime-windows-x64.zip
+)
+release_assets=(
+  ctx-linux-aarch64
+  ctx-linux-aarch64.cdx.json
+  ctx-linux-aarch64.third-party-notices.txt
+  ctx-linux-x64
+  ctx-linux-x64.cdx.json
+  ctx-linux-x64.third-party-notices.txt
+  ctx-macos-arm64
+  ctx-macos-arm64.cdx.json
+  ctx-macos-arm64.third-party-notices.txt
+  ctx-macos-x64
+  ctx-macos-x64.cdx.json
+  ctx-macos-x64.third-party-notices.txt
+  ctx-onnxruntime-linux-aarch64.tar.gz
+  ctx-onnxruntime-linux-x64.tar.gz
+  ctx-onnxruntime-macos-arm64.tar.gz
+  ctx-onnxruntime-macos-x64.tar.gz
+  ctx-onnxruntime-windows-x64.zip
+  ctx-windows-x64.exe
+  ctx-windows-x64.exe.cdx.json
+  ctx-windows-x64.exe.third-party-notices.txt
+)
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{ print $1 }'
+  else
+    die "sha256sum or shasum is required"
+  fi
+}
+
+require_regular() {
+  [[ -f "$1" && ! -L "$1" ]] || die "$2 must be a regular non-symlink file: $1"
+}
+
+declare -A core_digests=()
+core_names=()
+core_sums="${core_dir%/}/SHA256SUMS"
+require_regular "${core_sums}" "Core checksum manifest"
+while IFS= read -r line; do
+  [[ "${line}" =~ ^([0-9a-f]{64})\ \ ([A-Za-z0-9][A-Za-z0-9._-]{0,127})$ ]] \
+    || die "Core SHA256SUMS is malformed"
+  digest="${BASH_REMATCH[1]}"
+  name="${BASH_REMATCH[2]}"
+  [[ ! -v "core_digests[${name}]" ]] || die "Core SHA256SUMS repeats ${name}"
+  core_digests["${name}"]="${digest}"
+  core_names+=("${name}")
+done < "${core_sums}"
+[[ "${#core_names[@]}" -eq "${#core_assets[@]}" ]] \
+  || die "Core SHA256SUMS must contain exactly 15 assets"
+for asset in "${core_assets[@]}"; do
+  source_path="${core_dir%/}/${asset}"
+  require_regular "${source_path}" "Core release asset"
+  [[ -v "core_digests[${asset}]" ]] || die "Core SHA256SUMS is missing ${asset}"
+  actual="$(sha256_file "${source_path}")"
+  [[ "${actual}" == "${core_digests[${asset}]}" ]] \
+    || die "Core checksum mismatch for ${asset}"
+done
+
+declare -A runtime_digests=()
+for asset in "${runtime_assets[@]}"; do
+  source_path="${runtime_dir%/}/${asset}"
+  checksum_path="${source_path}.sha256"
+  require_regular "${source_path}" "runtime release asset"
+  require_regular "${checksum_path}" "runtime checksum"
+  IFS= read -r expected < "${checksum_path}" || true
+  [[ "${expected}" =~ ^[0-9a-f]{64}$ ]] \
+    || die "runtime checksum is malformed for ${asset}"
+  [[ "$(wc -l < "${checksum_path}" | tr -d '[:space:]')" == "1" ]] \
+    || die "runtime checksum must contain one line for ${asset}"
+  actual="$(sha256_file "${source_path}")"
+  [[ "${actual}" == "${expected}" ]] || die "runtime checksum mismatch for ${asset}"
+  runtime_digests["${asset}"]="${actual}"
+done
+
+staged="$(mktemp -d "$(dirname "${out_dir}")/.github-release-final.XXXXXX")"
+cleanup() {
+  if [[ -n "${staged:-}" && -d "${staged}" && ! -L "${staged}" ]]; then
+    rm -rf -- "${staged}"
+  fi
+}
+trap cleanup EXIT
+
+for asset in "${core_assets[@]}"; do
+  mode=0644
+  case "${asset}" in
+    ctx-linux-x64|ctx-linux-aarch64|ctx-macos-arm64|ctx-macos-x64)
+      mode=0755
+      ;;
+  esac
+  install -m "${mode}" "${core_dir%/}/${asset}" "${staged}/${asset}"
+  [[ "$(sha256_file "${staged}/${asset}")" == "${core_digests[${asset}]}" ]] \
+    || die "Core asset changed while staged: ${asset}"
+done
+for asset in "${runtime_assets[@]}"; do
+  install -m 0644 "${runtime_dir%/}/${asset}" "${staged}/${asset}"
+  [[ "$(sha256_file "${staged}/${asset}")" == "${runtime_digests[${asset}]}" ]] \
+    || die "runtime asset changed while staged: ${asset}"
+done
+
+for asset in "${release_assets[@]}"; do
+  printf '%s  %s\n' "$(sha256_file "${staged}/${asset}")" "${asset}" \
+    >> "${staged}/SHA256SUMS"
+done
+[[ "$(find "${staged}" -maxdepth 1 -type f | wc -l)" == "21" ]] \
+  || die "final GitHub release inventory is not exactly 21 files"
+
+python3 -I "${bundle_tool}" commit-directory \
+  --stage-dir "${staged}" --output-dir "${out_dir}"
+trap - EXIT
+printf 'assembled GitHub release assets in %s\n' "${out_dir}"

--- a/scripts/check-buildkite-pipeline.sh
+++ b/scripts/check-buildkite-pipeline.sh
@@ -9,6 +9,7 @@ for required in \
   scripts/release/build-public-candidate-on-linux.sh \
   scripts/validate-public-cli-factory-artifact.sh \
   scripts/stage-github-release-assets.sh \
+  scripts/assemble-github-release-assets.sh \
   scripts/stage-semantic-release-handoff.sh \
   scripts/build-onnxruntime-sidecar.sh \
   scripts/check-sdks.sh; do
@@ -68,6 +69,7 @@ required = {
     "public-cli-macos-x64-native-smoke",
     "public-cli-windows-x64-native-smoke",
     "github-release-candidate",
+    "github-release-assets",
     "semantic-model-archives",
     "semantic-coreml-archive",
     "semantic-runtime-linux-cuda12",
@@ -101,6 +103,12 @@ core_native_condition = (
     'build.branch == "main" && build.pull_request.id == null'
 )
 semantic_condition = (
+    'build.env("CTX_PUBLIC_SEMANTIC_ASSET_MATRIX") == "1" && '
+    'build.branch == "main" && build.pull_request.id == null'
+)
+github_release_condition = (
+    'build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1" && '
+    'build.env("CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX") == "1" && '
     'build.env("CTX_PUBLIC_SEMANTIC_ASSET_MATRIX") == "1" && '
     'build.branch == "main" && build.pull_request.id == null'
 )
@@ -160,6 +168,7 @@ linux_x64_keys = {
     "public-cli-linux-factory",
     "public-cli-linux-x64-native-smoke",
     "github-release-candidate",
+    "github-release-assets",
     "semantic-model-archives",
     "semantic-runtime-linux-cuda12",
     "semantic-runtime-portable",
@@ -319,6 +328,8 @@ if (
         "Core candidate staging must keep the sealed factory immutable, "
         "consume separate native proofs, and bind HEAD"
     )
+if "target/github-core-release-assets" not in candidate_command:
+    fail("Core candidate staging must publish a Core-only handoff")
 for marker in ("onnxruntime", "coreml", "semantic", "sdk-swift-required"):
     if marker in candidate_command.lower():
         fail(f"Core candidate staging must not consume {marker}")
@@ -362,6 +373,21 @@ if portable.get("artifact_paths") != [
 ]:
     fail("portable Semantic runtime construction must upload only Unix CPU runtimes")
 
+windows_runtime = keyed["semantic-runtime-windows-ml"]
+windows_runtime_command = windows_runtime.get("command", "")
+if (
+    windows_runtime_command.count("build-onnxruntime-sidecar.sh") != 2
+    or "build-onnxruntime-sidecar.sh windows-x64\n" not in windows_runtime_command
+    or "build-onnxruntime-sidecar.sh windows-x64-windowsml" not in windows_runtime_command
+):
+    fail("Windows Semantic producer must qualify both CPU ONNX Runtime and Windows ML")
+for expected_path in (
+    "target/public-cli-artifacts/ctx-onnxruntime-windows-x64.zip",
+    "target/public-cli-artifacts/ctx-onnxruntime-windows-x64.zip.sha256",
+):
+    if expected_path not in windows_runtime.get("artifact_paths", []):
+        fail(f"Windows Semantic producer does not upload {expected_path}")
+
 macos_x64_runtime = keyed["public-cli-macos-x64-runtime-producer"]
 if (
     "build-onnxruntime-sidecar.sh macos-x64" not in macos_x64_runtime.get("command", "")
@@ -372,6 +398,36 @@ if (
     fail("macos-x64 Semantic runtime producer must remain independent")
 if "download-linux-factory-artifacts.sh" in macos_x64_runtime.get("command", ""):
     fail("macos-x64 Semantic runtime producer must not consume Core artifacts")
+
+github_release = keyed["github-release-assets"]
+expected_github_dependencies = [
+    "github-release-candidate",
+    "semantic-runtime-portable",
+    "public-cli-macos-x64-runtime-producer",
+    "semantic-runtime-windows-ml",
+]
+if github_release.get("depends_on") != expected_github_dependencies:
+    fail("final GitHub assembly has the wrong independent producer set")
+if github_release.get("if") != github_release_condition:
+    fail("final GitHub assembly has the wrong release condition")
+if github_release.get("allow_dependency_failure") or github_release.get("soft_fail"):
+    fail("final GitHub assembly must fail closed")
+github_release_command = github_release.get("command", "")
+if (
+    github_release_command.count("assemble-github-release-assets.sh") != 1
+    or github_release_command.count("--step semantic-runtime-portable") != 3
+    or github_release_command.count("--step public-cli-macos-x64-runtime-producer") != 1
+    or github_release_command.count("--step semantic-runtime-windows-ml") != 1
+    or github_release_command.count("--step github-release-candidate") != 1
+    or "target/github-core-release-assets" not in github_release_command
+    or "target/github-release-assets" not in github_release_command
+):
+    fail("final GitHub assembly must join the exact Core and five-runtime handoffs")
+for forbidden in ("multilingual-e5", "cuda12", "windowsml"):
+    if forbidden in github_release_command.lower():
+        fail(f"final GitHub assembly unexpectedly consumes {forbidden}")
+if github_release.get("artifact_paths") != ["target/github-release-assets/*"]:
+    fail("final GitHub assembly must upload only the complete public asset set")
 
 handoff = keyed["semantic-release-handoff"]
 expected_semantic_dependencies = [

--- a/scripts/stage-github-release-assets.sh
+++ b/scripts/stage-github-release-assets.sh
@@ -10,7 +10,7 @@ Stages the five public Core GitHub Release assets and their existing
 SBOM/notices evidence from one sealed factory candidate.
 
 Inputs default to target/public-cli-artifacts.
-Outputs default to target/github-release-assets.
+Core outputs default to target/github-core-release-assets.
 
 The transcode mode converts a validated builder-owned Unix .tar.zst sidecar
 to the deterministic .tar.gz transport consumed by release installers. It is
@@ -47,7 +47,7 @@ case "${1:-}" in
       exit 2
     }
     artifact_dir="${1:-target/public-cli-artifacts}"
-    out_dir="${2:-target/github-release-assets}"
+    out_dir="${2:-target/github-core-release-assets}"
     authority_dir="${3:-${out_dir}.authority}"
     native_proof_dir="${4:-${CTX_PUBLIC_NATIVE_PROOF_DIR:-target/public-cli-native-smoke}}"
     ;;

--- a/scripts/tests/assemble-github-release-assets-test.sh
+++ b/scripts/tests/assemble-github-release-assets-test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${TEST_SRCDIR:-}" && -n "${TEST_WORKSPACE:-}" ]]; then
+  source_root="${TEST_SRCDIR}/${TEST_WORKSPACE}"
+else
+  source_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+assembler="${source_root}/scripts/assemble-github-release-assets.sh"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/ctx-assemble-github-assets.XXXXXX")"
+trap 'rm -rf "${tmp}"' EXIT
+core="${tmp}/core"
+runtime="${tmp}/runtime"
+mkdir -p "${core}" "${runtime}"
+
+core_assets=(
+  ctx-linux-x64
+  ctx-linux-x64.cdx.json
+  ctx-linux-x64.third-party-notices.txt
+  ctx-linux-aarch64
+  ctx-linux-aarch64.cdx.json
+  ctx-linux-aarch64.third-party-notices.txt
+  ctx-macos-arm64
+  ctx-macos-arm64.cdx.json
+  ctx-macos-arm64.third-party-notices.txt
+  ctx-macos-x64
+  ctx-macos-x64.cdx.json
+  ctx-macos-x64.third-party-notices.txt
+  ctx-windows-x64.exe
+  ctx-windows-x64.exe.cdx.json
+  ctx-windows-x64.exe.third-party-notices.txt
+)
+runtime_assets=(
+  ctx-onnxruntime-linux-x64.tar.gz
+  ctx-onnxruntime-linux-aarch64.tar.gz
+  ctx-onnxruntime-macos-arm64.tar.gz
+  ctx-onnxruntime-macos-x64.tar.gz
+  ctx-onnxruntime-windows-x64.zip
+)
+
+for asset in "${core_assets[@]}"; do
+  printf 'qualified Core fixture: %s\n' "${asset}" > "${core}/${asset}"
+  printf '%s  %s\n' "$(sha256sum "${core}/${asset}" | awk '{print $1}')" "${asset}" \
+    >> "${core}/SHA256SUMS"
+done
+for asset in "${runtime_assets[@]}"; do
+  printf 'qualified runtime fixture: %s\n' "${asset}" > "${runtime}/${asset}"
+  sha256sum "${runtime}/${asset}" | awk '{print $1}' > "${runtime}/${asset}.sha256"
+done
+
+output="${tmp}/release"
+bash "${assembler}" "${core}" "${runtime}" "${output}"
+test "$(find "${output}" -maxdepth 1 -type f | wc -l)" -eq 21
+test "$(wc -l < "${output}/SHA256SUMS")" -eq 20
+(
+  cd "${output}"
+  sha256sum -c SHA256SUMS >/dev/null
+)
+test -x "${output}/ctx-linux-x64"
+test ! -x "${output}/ctx-onnxruntime-linux-x64.tar.gz"
+
+if bash "${assembler}" "${core}" "${runtime}" "${output}" \
+  > "${tmp}/existing.out" 2> "${tmp}/existing.err"; then
+  printf 'assembler replaced an existing release directory\n' >&2
+  exit 1
+fi
+grep -Fq 'release publication destination already exists' "${tmp}/existing.err"
+
+bad_runtime="${tmp}/bad-runtime"
+cp -a "${runtime}" "${bad_runtime}"
+printf 'corrupt\n' >> "${bad_runtime}/ctx-onnxruntime-linux-x64.tar.gz"
+if bash "${assembler}" "${core}" "${bad_runtime}" "${tmp}/bad-runtime-output" \
+  > "${tmp}/bad-runtime.out" 2> "${tmp}/bad-runtime.err"; then
+  printf 'assembler accepted a runtime checksum mismatch\n' >&2
+  exit 1
+fi
+grep -Fq 'runtime checksum mismatch for ctx-onnxruntime-linux-x64.tar.gz' \
+  "${tmp}/bad-runtime.err"
+test ! -e "${tmp}/bad-runtime-output"
+
+bad_core="${tmp}/bad-core"
+cp -a "${core}" "${bad_core}"
+printf '%064d  unexpected\n' 0 >> "${bad_core}/SHA256SUMS"
+if bash "${assembler}" "${bad_core}" "${runtime}" "${tmp}/bad-core-output" \
+  > "${tmp}/bad-core.out" 2> "${tmp}/bad-core.err"; then
+  printf 'assembler accepted an expanded Core inventory\n' >&2
+  exit 1
+fi
+grep -Fq 'Core SHA256SUMS must contain exactly 15 assets' "${tmp}/bad-core.err"
+test ! -e "${tmp}/bad-core-output"
+
+symlink_runtime="${tmp}/symlink-runtime"
+cp -a "${runtime}" "${symlink_runtime}"
+rm "${symlink_runtime}/ctx-onnxruntime-windows-x64.zip"
+ln -s "${runtime}/ctx-onnxruntime-windows-x64.zip" \
+  "${symlink_runtime}/ctx-onnxruntime-windows-x64.zip"
+if bash "${assembler}" "${core}" "${symlink_runtime}" "${tmp}/symlink-output" \
+  > "${tmp}/symlink.out" 2> "${tmp}/symlink.err"; then
+  printf 'assembler accepted a symlink runtime\n' >&2
+  exit 1
+fi
+grep -Fq 'runtime release asset must be a regular non-symlink file' \
+  "${tmp}/symlink.err"
+test ! -e "${tmp}/symlink-output"
+
+printf 'GitHub release final assembly tests passed\n'

--- a/scripts/tests/buildkite-windowsml-artifact-path-test.py
+++ b/scripts/tests/buildkite-windowsml-artifact-path-test.py
@@ -12,15 +12,27 @@ import sys
 import unittest
 
 
-ASSET = "ctx-windowsml-windows-x64.zip"
-UPLOADS = (
-    f"target/public-cli-artifacts/{ASSET}",
-    f"target/public-cli-artifacts/{ASSET}.sha256",
-    f"target/public-cli-artifacts/{ASSET}.asset.json",
+WINDOWS_ML_ASSET = "ctx-windowsml-windows-x64.zip"
+WINDOWS_ONNX_ASSET = "ctx-onnxruntime-windows-x64.zip"
+WINDOWS_ML_UPLOADS = (
+    f"target/public-cli-artifacts/{WINDOWS_ML_ASSET}",
+    f"target/public-cli-artifacts/{WINDOWS_ML_ASSET}.sha256",
+    f"target/public-cli-artifacts/{WINDOWS_ML_ASSET}.asset.json",
 )
-WINDOWS_UPLOADS = tuple(path.replace("/", "\\") for path in UPLOADS)
-PORTABLE_SELECTOR = f"*{ASSET}*"
-LINUX_ONLY_SELECTOR = f"target/public-cli-artifacts/{ASSET}*"
+WINDOWS_ONNX_UPLOADS = (
+    f"target/public-cli-artifacts/{WINDOWS_ONNX_ASSET}",
+    f"target/public-cli-artifacts/{WINDOWS_ONNX_ASSET}.sha256",
+)
+UPLOADS = WINDOWS_ONNX_UPLOADS + WINDOWS_ML_UPLOADS
+WINDOWS_ML_UPLOADS_RENDERED = tuple(
+    path.replace("/", "\\") for path in WINDOWS_ML_UPLOADS
+)
+WINDOWS_ONNX_UPLOADS_RENDERED = tuple(
+    path.replace("/", "\\") for path in WINDOWS_ONNX_UPLOADS
+)
+WINDOWS_ML_SELECTOR = f"*{WINDOWS_ML_ASSET}*"
+WINDOWS_ONNX_SELECTOR = f"*{WINDOWS_ONNX_ASSET}*"
+LINUX_ONLY_SELECTOR = f"target/public-cli-artifacts/{WINDOWS_ML_ASSET}*"
 
 
 class ContractError(ValueError):
@@ -62,15 +74,15 @@ def buildkite_path_matches(pattern: str, path: str) -> bool:
     return re.fullmatch(expression, path) is not None
 
 
-def windows_ml_selector(command: str) -> str:
+def artifact_selector(command: str, step_key: str, label: str) -> str:
     downloads = re.findall(
         r"buildkite-agent artifact download\s+\\\s+"
         r'"([^"]+)"\s+\.\s+\\\s+--step\s+([^\s]+)',
         command,
     )
-    selectors = [query for query, step in downloads if step == "semantic-runtime-windows-ml"]
+    selectors = [query for query, step in downloads if step == step_key]
     if len(selectors) != 1:
-        raise ContractError("handoff must have one Windows ML artifact download")
+        raise ContractError(f"{label} must have one Windows artifact download")
     return selectors[0]
 
 
@@ -79,6 +91,7 @@ def validate_pipeline(value: dict[str, object]) -> None:
     try:
         producer = keyed["semantic-runtime-windows-ml"]
         handoff = keyed["semantic-release-handoff"]
+        github_release = keyed["github-release-assets"]
     except KeyError as error:
         raise ContractError(f"missing Buildkite step: {error.args[0]}") from error
 
@@ -86,7 +99,7 @@ def validate_pipeline(value: dict[str, object]) -> None:
     if not isinstance(producer_agents, dict) or producer_agents.get("os") != "windows":
         raise ContractError("Windows ML artifacts must originate on Windows")
     if producer.get("artifact_paths") != list(UPLOADS):
-        raise ContractError("Windows ML producer must upload the exact three slash-declared paths")
+        raise ContractError("Windows runtime producer must upload the exact five slash-declared paths")
 
     handoff_agents = handoff.get("agents")
     if not isinstance(handoff_agents, dict) or handoff_agents.get("os") != "linux":
@@ -94,15 +107,37 @@ def validate_pipeline(value: dict[str, object]) -> None:
     command = handoff.get("command")
     if not isinstance(command, str):
         raise ContractError("Semantic handoff command is missing")
-    selector = windows_ml_selector(command)
-    if selector != PORTABLE_SELECTOR:
+    selector = artifact_selector(
+        command, "semantic-runtime-windows-ml", "Semantic handoff"
+    )
+    if selector != WINDOWS_ML_SELECTOR:
         raise ContractError("Windows ML handoff must use the portable whole-path selector")
-    if not all(buildkite_path_matches(selector, path) for path in WINDOWS_UPLOADS):
+    if not all(
+        buildkite_path_matches(selector, path)
+        for path in WINDOWS_ML_UPLOADS_RENDERED
+    ):
         raise ContractError("Windows ML selector does not match Windows-rendered upload paths")
 
-    linux_paths = tuple(path.replace("\\", "/") for path in WINDOWS_UPLOADS)
-    if linux_paths != UPLOADS:
+    linux_paths = tuple(path.replace("\\", "/") for path in WINDOWS_ML_UPLOADS_RENDERED)
+    if linux_paths != WINDOWS_ML_UPLOADS:
         raise ContractError("Linux download normalization must reconstruct the staging paths")
+
+    github_agents = github_release.get("agents")
+    if not isinstance(github_agents, dict) or github_agents.get("os") != "linux":
+        raise ContractError("GitHub release assembly must gather on Linux")
+    github_command = github_release.get("command")
+    if not isinstance(github_command, str):
+        raise ContractError("GitHub release assembly command is missing")
+    onnx_selector = artifact_selector(
+        github_command, "semantic-runtime-windows-ml", "GitHub release assembly"
+    )
+    if onnx_selector != WINDOWS_ONNX_SELECTOR:
+        raise ContractError("Windows ONNX handoff must use the portable whole-path selector")
+    if not all(
+        buildkite_path_matches(onnx_selector, path)
+        for path in WINDOWS_ONNX_UPLOADS_RENDERED
+    ):
+        raise ContractError("Windows ONNX selector does not match Windows-rendered upload paths")
 
 
 class WindowsMlArtifactPathTest(unittest.TestCase):
@@ -117,14 +152,14 @@ class WindowsMlArtifactPathTest(unittest.TestCase):
         self.assertFalse(
             any(
                 buildkite_path_matches(LINUX_ONLY_SELECTOR, path)
-                for path in WINDOWS_UPLOADS
+                for path in WINDOWS_ML_UPLOADS_RENDERED
             )
         )
         mutated = copy.deepcopy(self.pipeline)
         handoff = keyed_steps(mutated)["semantic-release-handoff"]
         command = handoff["command"]
         self.assertIsInstance(command, str)
-        handoff["command"] = command.replace(PORTABLE_SELECTOR, LINUX_ONLY_SELECTOR)
+        handoff["command"] = command.replace(WINDOWS_ML_SELECTOR, LINUX_ONLY_SELECTOR)
         with self.assertRaisesRegex(ContractError, "portable whole-path selector"):
             validate_pipeline(mutated)
 
@@ -132,7 +167,7 @@ class WindowsMlArtifactPathTest(unittest.TestCase):
         mutated = copy.deepcopy(self.pipeline)
         producer = keyed_steps(mutated)["semantic-runtime-windows-ml"]
         producer["artifact_paths"] = list(UPLOADS[1:])
-        with self.assertRaisesRegex(ContractError, "exact three slash-declared paths"):
+        with self.assertRaisesRegex(ContractError, "exact five slash-declared paths"):
             validate_pipeline(mutated)
 
 

--- a/scripts/tests/stage-github-release-assets-test.sh
+++ b/scripts/tests/stage-github-release-assets-test.sh
@@ -453,6 +453,17 @@ grep -Fq -- "--sbom ${tmp_dir}/.github-release-assets." \
 ! grep -Fq -- "--artifact ${matrix}/" "${default_build_info_log}"
 ! grep -Fq -- "--artifact ${matrix}/" "${default_sbom_log}"
 
+named_default_output="${repo_root}/target/github-core-release-assets"
+CTX_FAKE_SBOM_LOG="${tmp_dir}/named-default-sbom.log" \
+  CTX_FAKE_BUILD_INFO_LOG="${tmp_dir}/named-default-build-info.log" \
+  CTX_PUBLIC_RELEASE_SOURCE_COMMIT="${source_commit}" \
+  CTX_REAL_PYTHON3="${real_python3}" \
+  PATH="${fake_bin}:${PATH}" \
+  /bin/bash "${stage}" "${matrix}"
+assert_exact_assets "${named_default_output}" 15 "${default_assets[@]}"
+test -d "${named_default_output}.authority"
+test ! -e "${repo_root}/target/github-release-assets"
+
 runtime_claim_candidate="${tmp_dir}/runtime-claim-candidate"
 cp -a "${matrix}" "${runtime_claim_candidate}"
 rm "${runtime_claim_candidate}/ctx-core.release-complete.json"


### PR DESCRIPTION
Summary:
- add an atomic final assembler that joins independently qualified Core and ONNX Runtime handoffs
- publish the exact 21-file GitHub release shape while keeping runtime production outside the Core factory
- qualify the Windows CPU runtime in the Semantic producer and make Core-only output naming unambiguous
- document ONNX Runtime assets as part of every stable GitHub release

Validation:
- focused Bazel release-gate tests pass
- Buildkite pipeline, docs, and repository-policy checks pass
- the final assembler reproduced the live v1.0.2 21-file release byte-for-byte

The broad CI build was attempted locally but the shared Bazel volume hit its storage quota before source validation completed; no source or test failure was reported.