### PR TITLE
Repair legacy upgrade state permissions

### DIFF
--- a/contracts/telemetry-v1/source-provenance.json
+++ b/contracts/telemetry-v1/source-provenance.json
@@ -17,6 +17,6 @@
     "crates/ctx-cli/src/upgrade/command.rs": "0e0929c0cc854bf3d79637b293159dde3a6bd09fe06d5067e6506d2e036a5e10",
     "crates/ctx-cli/src/upgrade/ports.rs": "08e16fd1d1ad294cad261d0355d0a63ae24c0c9420b127d9739505fbb5696650",
     "crates/ctx-upgrade-engine/src/upgrade/command/daemon.rs": "294ee5c5b425747ecdc01648476c1686fabc1e221d927b640b56e8f5eaea2386",
-    "crates/ctx-upgrade-engine/src/upgrade/state.rs": "167700076b8b64909ace80abf30c15e3e115efda216b098ca90f49c7f15baa02"
+    "crates/ctx-upgrade-engine/src/upgrade/state.rs": "77657769f52ab3dbefa7a66c2f714bf4bc8309bada5792a6ca2c473647a29dd8"
   }
 }

--- a/crates/ctx-cli/src/upgrade/config.rs
+++ b/crates/ctx-cli/src/upgrade/config.rs
@@ -6,8 +6,8 @@ use std::{
 
 use anyhow::{Context, Result};
 use ctx_history_platform::platform_security::{
-    establish_private_data_root, restrict_private_file_handle, verify_private_directory,
-    verify_private_file_handle,
+    ensure_private_file_handle, establish_private_data_root, restrict_private_file_handle,
+    verify_private_directory, verify_private_file_handle,
 };
 use uuid::Uuid;
 
@@ -30,16 +30,20 @@ fn read_upgrade_config(path: &Path) -> Result<String> {
     {
         use std::os::unix::fs::OpenOptionsExt as _;
 
-        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
     }
     #[cfg(windows)]
     {
         use std::os::windows::fs::OpenOptionsExt as _;
-        use windows_sys::Win32::Storage::FileSystem::{
-            FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ,
+        use windows_sys::Win32::{
+            Foundation::GENERIC_READ,
+            Storage::FileSystem::{
+                FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ, READ_CONTROL, WRITE_DAC,
+            },
         };
 
         options
+            .access_mode(GENERIC_READ | READ_CONTROL | WRITE_DAC)
             .share_mode(FILE_SHARE_READ)
             .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
     }
@@ -48,8 +52,8 @@ fn read_upgrade_config(path: &Path) -> Result<String> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(String::new()),
         Err(error) => return Err(error).with_context(|| format!("open {}", path.display())),
     };
-    verify_private_file_handle(&file)
-        .with_context(|| format!("verify private upgrade config {}", path.display()))?;
+    ensure_private_file_handle(&file)
+        .with_context(|| format!("protect private upgrade config {}", path.display()))?;
     let mut existing = String::new();
     file.read_to_string(&mut existing)
         .with_context(|| format!("read {}", path.display()))?;

--- a/crates/ctx-history-platform/src/platform_security.rs
+++ b/crates/ctx-history-platform/src/platform_security.rs
@@ -156,9 +156,49 @@ pub fn restrict_private_file(path: &Path) -> io::Result<()> {
 /// the current user owns it. Symlinks, reparse points, unsafe ownership, and
 /// non-regular files fail closed.
 pub fn ensure_private_file(path: &Path) -> io::Result<()> {
-    match verify_private_file(path) {
-        Ok(()) => Ok(()),
-        Err(_) => restrict_private_file(path),
+    #[cfg(unix)]
+    {
+        let file = open_regular_file_nofollow(path)?;
+        ensure_private_file_handle(&file)
+    }
+    #[cfg(windows)]
+    {
+        windows_acl::ensure_private_file(path)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = path;
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "private file establishment is unavailable on this platform",
+        ))
+    }
+}
+
+/// Verifies an already-open regular file and repairs its owner-only policy
+/// through that same handle when the current user owns it.
+///
+/// Callers opening by pathname must use platform no-follow semantics. Unsafe
+/// ownership and non-regular handles fail closed, as do unsuccessful repairs.
+pub fn ensure_private_file_handle(handle: &std::fs::File) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        match verify_private_file_handle(handle) {
+            Ok(()) => Ok(()),
+            Err(_) => restrict_private_file_handle(handle),
+        }
+    }
+    #[cfg(windows)]
+    {
+        windows_acl::ensure_private_file_handle(handle)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = handle;
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "private file establishment is unavailable on this platform",
+        ))
     }
 }
 
@@ -386,6 +426,48 @@ mod unix_tests {
         ensure_private_directory(&target)?;
 
         assert_eq!(fs::metadata(target)?.permissions().mode() & 0o777, 0o500);
+        Ok(())
+    }
+
+    #[test]
+    fn ensure_private_file_handle_repairs_legacy_owner_owned_modes() -> io::Result<()> {
+        let parent = tempfile::tempdir()?;
+        for (mode, expected) in [
+            (0o400, 0o400),
+            (0o444, 0o600),
+            (0o644, 0o600),
+            (0o664, 0o600),
+        ] {
+            let target = parent.path().join(format!("private-state-{mode:o}"));
+            fs::write(&target, b"state")?;
+            fs::set_permissions(&target, fs::Permissions::from_mode(mode))?;
+            let file = fs::OpenOptions::new().read(true).open(&target)?;
+
+            ensure_private_file_handle(&file)?;
+
+            assert_eq!(file.metadata()?.permissions().mode() & 0o777, expected);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn ensure_private_file_rejects_links_and_non_regular_files() -> io::Result<()> {
+        use std::os::unix::fs::symlink;
+
+        let parent = tempfile::tempdir()?;
+        let target = parent.path().join("target");
+        let link = parent.path().join("link");
+        fs::write(&target, b"state")?;
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644))?;
+        symlink(&target, &link)?;
+
+        assert!(ensure_private_file(&link).is_err());
+        assert_eq!(fs::metadata(&target)?.permissions().mode() & 0o777, 0o644);
+
+        let directory = parent.path().join("directory");
+        fs::create_dir(&directory)?;
+        let handle = fs::File::open(directory)?;
+        assert!(ensure_private_file_handle(&handle).is_err());
         Ok(())
     }
 

--- a/crates/ctx-history-platform/src/platform_security/windows_acl.rs
+++ b/crates/ctx-history-platform/src/platform_security/windows_acl.rs
@@ -28,8 +28,8 @@ use windows_sys::Win32::{
         GetTokenInformation, InitializeAcl, InitializeSecurityDescriptor, IsValidSid,
         SetSecurityDescriptorControl, SetSecurityDescriptorDacl, TokenUser, WinLocalSystemSid,
         ACCESS_ALLOWED_ACE, ACL, ACL_REVISION, DACL_SECURITY_INFORMATION,
-        PROTECTED_DACL_SECURITY_INFORMATION, PSID, SECURITY_ATTRIBUTES, SECURITY_DESCRIPTOR,
-        SE_DACL_PROTECTED, TOKEN_QUERY, TOKEN_USER,
+        OWNER_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION, PSID, SECURITY_ATTRIBUTES,
+        SECURITY_DESCRIPTOR, SE_DACL_PROTECTED, TOKEN_QUERY, TOKEN_USER,
     },
     Storage::FileSystem::{
         CreateDirectoryW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
@@ -159,6 +159,21 @@ pub(super) fn restrict_private_file_handle(handle: &File) -> io::Result<()> {
     restrict_handle(handle, ObjectKind::File)
 }
 
+pub(super) fn ensure_private_file(path: &Path) -> io::Result<()> {
+    let object = OpenedPrivateObject::open(path, ObjectKind::File, true)?;
+    ensure_private_file_handle(object.file())
+}
+
+pub(super) fn ensure_private_file_handle(handle: &File) -> io::Result<()> {
+    let identities = PrivateIdentities::current()?;
+    validate_handle_type(handle, ObjectKind::File)?;
+    verify_handle_owner(handle, identities.user_sid())?;
+    match verify_handle_with_identities(handle, ObjectKind::File, &identities) {
+        Ok(()) => Ok(()),
+        Err(_) => restrict_handle_with_identities(handle, ObjectKind::File, &identities),
+    }
+}
+
 pub(super) fn verify_private_directory(path: &Path) -> io::Result<()> {
     verify(path, ObjectKind::Directory)
 }
@@ -198,7 +213,15 @@ fn restrict(path: &Path, kind: ObjectKind) -> io::Result<()> {
 fn restrict_handle(handle: &File, kind: ObjectKind) -> io::Result<()> {
     validate_handle_type(handle, kind)?;
     let identities = PrivateIdentities::current()?;
-    let mut acl = private_acl(&identities, kind)?;
+    restrict_handle_with_identities(handle, kind, &identities)
+}
+
+fn restrict_handle_with_identities(
+    handle: &File,
+    kind: ObjectKind,
+    identities: &PrivateIdentities,
+) -> io::Result<()> {
+    let mut acl = private_acl(identities, kind)?;
     // SAFETY: the file owns a live handle with WRITE_DAC and the ACL remains
     // live for this synchronous call.
     let result = unsafe {
@@ -215,7 +238,37 @@ fn restrict_handle(handle: &File, kind: ObjectKind) -> io::Result<()> {
     if result != ERROR_SUCCESS {
         return Err(win32_error(result));
     }
-    verify_handle_with_identities(handle, kind, &identities)
+    verify_handle_with_identities(handle, kind, identities)
+}
+
+fn verify_handle_owner(handle: &File, expected_owner: PSID) -> io::Result<()> {
+    let mut owner = null_mut();
+    let mut descriptor = null_mut();
+    // SAFETY: all out pointers are valid and the returned descriptor is guarded.
+    let result = unsafe {
+        GetSecurityInfo(
+            handle.as_raw_handle().cast(),
+            SE_FILE_OBJECT,
+            OWNER_SECURITY_INFORMATION,
+            &raw mut owner,
+            null_mut(),
+            null_mut(),
+            null_mut(),
+            &raw mut descriptor,
+        )
+    };
+    if result != ERROR_SUCCESS {
+        return Err(win32_error(result));
+    }
+    let _descriptor = LocalAllocation(descriptor);
+    if owner.is_null() || unsafe { EqualSid(owner, expected_owner) } == 0 {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "private state path is not owned by the current user",
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 fn verify(path: &Path, kind: ObjectKind) -> io::Result<()> {
@@ -609,6 +662,106 @@ fn win32_error(code: u32) -> io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn set_permissive_null_dacl(handle: &File) -> io::Result<()> {
+        // SAFETY: the file owns a live handle with WRITE_DAC. A null DACL is an
+        // intentionally permissive fixture that ensure_private_file_handle
+        // must replace before the file is used as private state.
+        let result = unsafe {
+            SetSecurityInfo(
+                handle.as_raw_handle().cast(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                null_mut(),
+                null_mut(),
+                null_mut(),
+                null_mut(),
+            )
+        };
+        if result == ERROR_SUCCESS {
+            Ok(())
+        } else {
+            Err(win32_error(result))
+        }
+    }
+
+    fn world_sid() -> io::Result<AlignedBuffer> {
+        use windows_sys::Win32::Security::WinWorldSid;
+
+        let mut sid = AlignedBuffer::new(SECURITY_MAX_SID_SIZE)?;
+        let mut size = u32::try_from(sid.byte_len()).map_err(|_| invalid_acl())?;
+        // SAFETY: sid is aligned and has SECURITY_MAX_SID_SIZE capacity.
+        if unsafe {
+            CreateWellKnownSid(
+                WinWorldSid,
+                null_mut(),
+                sid.as_mut_ptr().cast(),
+                &raw mut size,
+            )
+        } == 0
+        {
+            Err(last_error())
+        } else {
+            Ok(sid)
+        }
+    }
+
+    #[test]
+    fn permissive_file_dacl_is_repaired_on_the_open_handle(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let parent = tempfile::tempdir()?;
+        let path = parent.path().join("legacy-config.toml");
+        fs::write(&path, b"legacy")?;
+        let object = OpenedPrivateObject::open(&path, ObjectKind::File, true)?;
+        set_permissive_null_dacl(object.file())?;
+        assert!(verify_handle(object.file(), ObjectKind::File).is_err());
+
+        ensure_private_file_handle(object.file())?;
+
+        verify_handle(object.file(), ObjectKind::File)?;
+        Ok(())
+    }
+
+    #[test]
+    fn wrong_owner_is_rejected_before_acl_repair() -> Result<(), Box<dyn std::error::Error>> {
+        let parent = tempfile::tempdir()?;
+        let path = parent.path().join("wrong-owner.toml");
+        fs::write(&path, b"legacy")?;
+        let object = OpenedPrivateObject::open(&path, ObjectKind::File, true)?;
+        set_permissive_null_dacl(object.file())?;
+        let world = world_sid()?;
+
+        let error =
+            verify_handle_owner(object.file(), world.as_ptr().cast_mut().cast()).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(error.to_string().contains("not owned by the current user"));
+        assert!(verify_handle(object.file(), ObjectKind::File).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn reparse_handle_is_rejected_before_acl_repair() -> Result<(), Box<dyn std::error::Error>> {
+        let parent = tempfile::tempdir()?;
+        let target = parent.path().join("target");
+        let junction = parent.path().join("junction");
+        fs::create_dir(&target)?;
+        let status = std::process::Command::new("cmd.exe")
+            .args(["/D", "/C", "mklink", "/J"])
+            .arg(&junction)
+            .arg(&target)
+            .status()?;
+        if !status.success() {
+            return Err("failed to create junction fixture".into());
+        }
+        let handle = open_handle(&junction, ObjectKind::Directory, READ_CONTROL | WRITE_DAC)?;
+
+        let error = ensure_private_file_handle(&handle).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("reparse point"));
+        Ok(())
+    }
 
     #[test]
     fn pathname_swap_cannot_redirect_handle_bound_acl_steps(

--- a/crates/ctx-upgrade-engine/src/upgrade/state.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/state.rs
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use ctx_history_core::utc_now;
+use ctx_history_platform::platform_security::restrict_private_file_handle;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use uuid::Uuid;
@@ -528,11 +529,36 @@ pub(super) fn atomic_write_json(path: &Path, value: &Value) -> Result<()> {
     let tmp = path.with_extension(format!("tmp.{}", Uuid::new_v4().simple()));
     let body = serde_json::to_vec_pretty(value)?;
     let result = (|| -> Result<()> {
-        let mut file = fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
+        let mut options = fs::OpenOptions::new();
+        options.read(true).write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+
+            options
+                .mode(0o600)
+                .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt as _;
+            use windows_sys::Win32::{
+                Foundation::{GENERIC_READ, GENERIC_WRITE},
+                Storage::FileSystem::{
+                    FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ, READ_CONTROL, WRITE_DAC,
+                },
+            };
+
+            options
+                .access_mode(GENERIC_READ | GENERIC_WRITE | READ_CONTROL | WRITE_DAC)
+                .share_mode(FILE_SHARE_READ)
+                .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+        }
+        let mut file = options
             .open(&tmp)
             .with_context(|| format!("create {}", tmp.display()))?;
+        restrict_private_file_handle(&file)
+            .with_context(|| format!("protect {}", tmp.display()))?;
         file.write_all(&body)
             .with_context(|| format!("write {}", tmp.display()))?;
         file.sync_all()

--- a/crates/ctx-upgrade-engine/src/upgrade/state/tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/state/tests.rs
@@ -217,5 +217,11 @@ fn atomic_json_write_replaces_without_partial_content() -> Result<()> {
         Some("applied")
     );
     assert_eq!(fs::read_dir(temp.path())?.count(), 1);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        assert_eq!(fs::metadata(&path)?.permissions().mode() & 0o777, 0o600);
+    }
     Ok(())
 }

--- a/crates/ctx-upgrade-engine/tests/contracts/upgrade.rs
+++ b/crates/ctx-upgrade-engine/tests/contracts/upgrade.rs
@@ -271,32 +271,68 @@ fn upgrade_enable_and_disable_persist_private_config_with_analytics_disabled() {
 
 #[cfg(unix)]
 #[test]
-fn upgrade_enable_and_disable_reject_insecure_config_without_repair() {
+fn upgrade_enable_and_disable_repair_legacy_config_permissions() {
     use std::os::unix::fs::PermissionsExt as _;
+
+    for (command_name, expected_mode) in [("enable", "apply"), ("disable", "off")] {
+        for legacy_permissions in [0o400, 0o444, 0o644, 0o664] {
+            let temp = tempdir();
+            let data_root = temp
+                .path()
+                .join(format!("{command_name}-{legacy_permissions:o}-state"));
+            let config = data_root.join("config.toml");
+            fs::create_dir(&data_root).unwrap();
+            fs::set_permissions(&data_root, fs::Permissions::from_mode(0o700)).unwrap();
+            fs::write(&config, "[search]\nsemantic = true\n").unwrap();
+            fs::set_permissions(&config, fs::Permissions::from_mode(legacy_permissions)).unwrap();
+
+            ctx(&temp)
+                .args(["upgrade", command_name])
+                .env("CTX_DATA_ROOT", &data_root)
+                .env("CTX_ANALYTICS_ENABLED", "false")
+                .assert()
+                .success();
+
+            assert_eq!(
+                fs::read_to_string(&config).unwrap(),
+                format!("[search]\nsemantic = true\n\n[upgrade]\nauto = \"{expected_mode}\"\n"),
+                "{command_name} legacy mode {legacy_permissions:o}"
+            );
+            assert_mode(&config, 0o600);
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn upgrade_enable_and_disable_reject_symlinked_config_without_changing_target() {
+    use std::os::unix::fs::{symlink, PermissionsExt as _};
 
     for command_name in ["enable", "disable"] {
         let temp = tempdir();
         let data_root = temp.path().join(format!("{command_name}-state"));
+        let target = temp.path().join(format!("{command_name}-outside.toml"));
         let config = data_root.join("config.toml");
         let original = b"[search]\nsemantic = true\n";
         fs::create_dir(&data_root).unwrap();
         fs::set_permissions(&data_root, fs::Permissions::from_mode(0o700)).unwrap();
-        fs::write(&config, original).unwrap();
-        fs::set_permissions(&config, fs::Permissions::from_mode(0o666)).unwrap();
+        fs::write(&target, original).unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
+        symlink(&target, &config).unwrap();
 
-        let stderr = failure_stderr(
-            ctx(&temp)
-                .args(["upgrade", command_name])
-                .env("CTX_DATA_ROOT", &data_root)
-                .env("CTX_ANALYTICS_ENABLED", "false"),
-        );
+        ctx(&temp)
+            .args(["upgrade", command_name])
+            .env("CTX_DATA_ROOT", &data_root)
+            .env("CTX_ANALYTICS_ENABLED", "false")
+            .assert()
+            .failure();
 
-        assert!(
-            stderr.contains("private state path is not owner-only"),
-            "{command_name}: {stderr}"
-        );
-        assert_eq!(fs::read(&config).unwrap(), original, "{command_name}");
-        assert_mode(&config, 0o666);
+        assert_eq!(fs::read(&target).unwrap(), original, "{command_name}");
+        assert_mode(&target, 0o644);
+        assert!(fs::symlink_metadata(&config)
+            .unwrap()
+            .file_type()
+            .is_symlink());
     }
 }
 


### PR DESCRIPTION
## Summary

- repair owner-owned legacy upgrade config permissions through the already-open, no-follow handle before reading
- preserve fail-closed behavior for wrong ownership, symlinks, reparse points, and non-regular files on Unix and Windows
- create upgrade scheduler state with private permissions before its first write

Fixes #647

## Validation

- focused platform and upgrade unit/contract tests
- affected-target suite: 106/108 passed in the broad run; both remaining targets passed on isolated rerun after updating the required source-provenance digest
- Windows MSVC test code cross-compile
- independent read-only code review: ship