### PR TITLE
fix(history): admit large SQLite snapshots

### DIFF
--- a/crates/ctx-history-capture-composition/src/source_backed/tests/registry.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/tests/registry.rs
@@ -400,6 +400,44 @@ fn cold_second_route_failure_after_output_publishes_first_without_partial_record
 }
 
 #[test]
+fn cold_opencode_capacity_failure_publishes_healthy_peer() {
+    let healthy = fixture_route(CaptureProvider::Gemini, GEMINI_CLI_SOURCE_FORMAT, 41);
+    let failing = fixture_route(CaptureProvider::OpenCode, "opencode_sqlite", 42);
+    let healthy_id = healthy.metadata.route_identity.clone().unwrap();
+    let failing_id = failing.metadata.route_identity.clone().unwrap();
+    let mut registry = SourceBackedProviderRegistry::new();
+    registry.register(healthy);
+    registry.register(fail_route_before_scan(
+        failing,
+        SourceBackedRouteErrorKind::Unavailable,
+    ));
+    let temp = tempdir().unwrap();
+
+    let receipt =
+        refresh_source_backed_generation(temp.path(), &registry, WriterOptions::default()).unwrap();
+
+    assert_eq!(receipt.successful_route_ids, vec![healthy_id.clone()]);
+    assert_eq!(receipt.failed_routes.len(), 1);
+    assert_eq!(receipt.failed_routes[0].route_identity, failing_id.clone());
+    assert_eq!(
+        receipt.failed_routes[0].class,
+        SourceBackedSourceFailureClass::Unavailable
+    );
+    assert!(!receipt.failed_routes[0].carried_forward);
+    assert!(receipt
+        .commit
+        .manifest()
+        .source_route(&healthy_id)
+        .is_some());
+    assert!(receipt
+        .commit
+        .manifest()
+        .source_route(&failing_id)
+        .is_none());
+    assert_eq!(receipt.commit.indexed_documents, 1);
+}
+
+#[test]
 fn warm_success_advances_while_failed_route_is_carried_exactly() {
     let (first_v1, _) = revisioned_receipt_route(1);
     let second = fixture_route(CaptureProvider::Mux, "mux_session_jsonl_tree", 9);

--- a/crates/ctx-history-provider-docproj/src/providers/nanoclaw/native_path/source_backed.rs
+++ b/crates/ctx-history-provider-docproj/src/providers/nanoclaw/native_path/source_backed.rs
@@ -492,6 +492,9 @@ fn nanoclaw_route_error(error: NanoClawSourceBackedError) -> SourceBackedRouteEr
         {
             SourceBackedRouteErrorKind::Unavailable
         }
+        NanoClawSourceBackedError::SqliteStaging(error) if error.is_snapshot_capacity_failure() => {
+            SourceBackedRouteErrorKind::Unavailable
+        }
         NanoClawSourceBackedError::SqliteStaging(error) if error.is_systemic_resource_failure() => {
             SourceBackedRouteErrorKind::ResourceUnavailable
         }

--- a/crates/ctx-history-provider-hermes/src/provider/source_backed/replacement.rs
+++ b/crates/ctx-history-provider-hermes/src/provider/source_backed/replacement.rs
@@ -593,6 +593,9 @@ pub(super) fn hermes_route_error(error: HermesSourceBackedError) -> SourceBacked
         HermesSourceBackedError::SqliteSource(error) if error.is_source_changed() => {
             SourceBackedRouteErrorKind::SourceChanged
         }
+        HermesSourceBackedError::SqliteSource(error) if error.is_snapshot_capacity_failure() => {
+            SourceBackedRouteErrorKind::Unavailable
+        }
         HermesSourceBackedError::SqliteSource(error) if error.is_systemic_resource_failure() => {
             SourceBackedRouteErrorKind::ResourceUnavailable
         }

--- a/crates/ctx-history-providers-sqlite-inventory/src/registration.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/registration.rs
@@ -702,6 +702,8 @@ pub(crate) fn sqlite_source_route_error_kind(
 ) -> SourceBackedRouteErrorKind {
     if error.is_source_changed() {
         SourceBackedRouteErrorKind::SourceChanged
+    } else if error.is_snapshot_capacity_failure() {
+        SourceBackedRouteErrorKind::Unavailable
     } else if error.is_systemic_resource_failure() || error.is_busy_or_locked() {
         SourceBackedRouteErrorKind::ResourceUnavailable
     } else if error.is_ctx_owned_corruption() {

--- a/crates/ctx-history-providers-sqlite-inventory/src/registration/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/registration/tests.rs
@@ -539,6 +539,17 @@ fn shelley_registration_preserves_resource_unavailable_classification() {
 }
 
 #[test]
+fn sqlite_inventory_snapshot_capacity_failure_is_route_local() {
+    let error = shelley_registration_error(SqliteSourceAccessError::InsufficientScratchSpace {
+        path: PathBuf::from("ctx-data"),
+        required: 10 * 1024 * 1024 * 1024,
+        available: 5 * 1024 * 1024 * 1024,
+    });
+
+    assert_eq!(error.kind, SourceBackedRouteErrorKind::Unavailable);
+}
+
+#[test]
 fn sqlite_inventory_watch_targets_include_databases_and_authority_parents() {
     let first = PathBuf::from("/tmp/a/history.sqlite");
     let second = PathBuf::from("/tmp/b/state.db");

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/adapter.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/adapter.rs
@@ -592,6 +592,9 @@ pub(super) fn route_error(error: OpenCodeSourceBackedError) -> SourceBackedRoute
         OpenCodeSourceBackedError::SqliteSource(error) if error.is_ctx_owned_corruption() => {
             SourceBackedRouteErrorKind::Internal
         }
+        OpenCodeSourceBackedError::SqliteSource(error) if error.is_snapshot_capacity_failure() => {
+            SourceBackedRouteErrorKind::Unavailable
+        }
         OpenCodeSourceBackedError::SqliteSource(SqliteSourceAccessError::ResourceUnavailable {
             ..
         }) => SourceBackedRouteErrorKind::ResourceUnavailable,

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/tests/sqlite_diagnostics.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/tests/sqlite_diagnostics.rs
@@ -1,4 +1,56 @@
+use std::path::PathBuf;
+
 use super::*;
+
+#[test]
+fn snapshot_capacity_failure_is_isolated_to_the_opencode_route() {
+    let error = OpenCodeSourceBackedError::SqliteSource(
+        SqliteSourceAccessError::InsufficientScratchSpace {
+            path: PathBuf::from("ctx-data"),
+            required: 10 * 1024 * 1024 * 1024,
+            available: 5 * 1024 * 1024 * 1024,
+        },
+    );
+
+    let route = adapter::route_error(error);
+    assert_eq!(route.kind, SourceBackedRouteErrorKind::Unavailable);
+    assert_eq!(
+        route.kind.source_failure_class(),
+        Some(ctx_history_capture_runtime::SourceBackedSourceFailureClass::Unavailable)
+    );
+}
+
+#[test]
+#[ignore = "explicit multi-gibibyte copy/open resource proof"]
+fn opencode_source_above_two_gibibytes_copies_opens_observes_and_cleans_up() {
+    const ABOVE_TWO_GIB: u64 = 2 * 1024 * 1024 * 1024 + 4096;
+
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("ctx-data");
+    let provider = temp.path().join("provider");
+    fs::create_dir_all(&provider).unwrap();
+    let database = provider.join("opencode.db");
+    drop(write_current_schema(
+        &database,
+        &provider,
+        &json!({"type": "text", "text": "large OpenCode proof"}),
+    ));
+    fs::OpenOptions::new()
+        .write(true)
+        .open(&database)
+        .unwrap()
+        .set_len(ABOVE_TWO_GIB)
+        .unwrap();
+
+    adapter::discover_document_tree_for_test(
+        &data_root,
+        &database,
+        &crate::provider::providers::opencode::OPENCODE_SQLITE_DIALECT,
+    )
+    .unwrap();
+
+    assert_no_opencode_snapshot_leaks(&data_root);
+}
 
 #[test]
 fn schema_and_projection_sqlite_failures_have_distinct_stable_diagnostics() {

--- a/crates/ctx-history-providers-sqlite-selected/src/providers/kiro/source_backed/registration.rs
+++ b/crates/ctx-history-providers-sqlite-selected/src/providers/kiro/source_backed/registration.rs
@@ -432,6 +432,9 @@ pub(crate) fn kiro_scan_error(error: KiroSourceBackedErrorV0) -> SourceBackedRou
         KiroSourceBackedErrorV0::SqliteSource(error) if error.is_source_changed() => {
             SourceBackedRouteErrorKind::SourceChanged
         }
+        KiroSourceBackedErrorV0::SqliteSource(error) if error.is_snapshot_capacity_failure() => {
+            SourceBackedRouteErrorKind::Unavailable
+        }
         KiroSourceBackedErrorV0::SqliteSource(error) if error.is_systemic_resource_failure() => {
             SourceBackedRouteErrorKind::ResourceUnavailable
         }

--- a/crates/ctx-history-source-sqlite/src/sqlite_source.rs
+++ b/crates/ctx-history-source-sqlite/src/sqlite_source.rs
@@ -43,13 +43,15 @@ use ctx_history_source_io::{
 use crate::{SqliteSourceProgress, SqliteSourceProgressStage};
 
 const EVIDENCE_DOMAIN: &[u8] = b"ctx-stock-sqlite-snapshot-v2\0";
-// Admit an approximately 1 GiB provider database together with an active WAL
-// of comparable size while retaining one finite cumulative copy bound.
-const SQLITE_SNAPSHOT_MAX_TOTAL_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 const SQLITE_SNAPSHOT_FREE_HEADROOM_BYTES: u64 = 16 * 1024 * 1024;
+const SQLITE_SNAPSHOT_FREE_HEADROOM_DIVISOR: u64 = 20;
 const SQLITE_COPY_BUFFER_BYTES: usize = 64 * 1024;
 const SQLITE_REVISION_TOKEN_BYTES: usize = 64;
 const SQLITE_SHM_MAX_BYTES: u64 = 8 * 1024 * 1024;
+
+fn sqlite_snapshot_free_headroom_bytes(capacity_bytes: u64) -> u64 {
+    SQLITE_SNAPSHOT_FREE_HEADROOM_BYTES.max(capacity_bytes / SQLITE_SNAPSHOT_FREE_HEADROOM_DIVISOR)
+}
 
 mod diagnostics;
 mod resources;

--- a/crates/ctx-history-source-sqlite/src/sqlite_source/diagnostics.rs
+++ b/crates/ctx-history-source-sqlite/src/sqlite_source/diagnostics.rs
@@ -328,6 +328,20 @@ impl SqliteSourceAccessError {
             || matches!(self, Self::Finalization { primary, cleanup } if primary.is_systemic_resource_failure() || cleanup.is_systemic_resource_failure())
     }
 
+    /// A deterministic admission failure for one SQLite route. Provider
+    /// coordinators can isolate this route and continue publishing healthy
+    /// peers, unlike an I/O failure encountered after scratch writes begin.
+    pub fn is_snapshot_capacity_failure(&self) -> bool {
+        match self {
+            Self::SnapshotTooLarge { .. } | Self::InsufficientScratchSpace { .. } => true,
+            Self::Diagnosed { source, .. } => source.is_snapshot_capacity_failure(),
+            Self::Finalization { primary, cleanup } => {
+                primary.is_snapshot_capacity_failure() && !cleanup.is_systemic_resource_failure()
+            }
+            _ => false,
+        }
+    }
+
     pub fn is_ctx_owned_corruption(&self) -> bool {
         match self {
             Self::ProviderContentCorruption { .. } => false,

--- a/crates/ctx-history-source-sqlite/src/sqlite_source/resources.rs
+++ b/crates/ctx-history-source-sqlite/src/sqlite_source/resources.rs
@@ -230,12 +230,15 @@ struct SqliteRouteScratchState {
 #[derive(Debug)]
 pub(super) struct SqliteRouteScratch {
     context: Arc<SqliteSourceSnapshotContext>,
-    pub(super) maximum_bytes: u64,
+    pub(super) maximum_bytes: Option<u64>,
     state: Mutex<SqliteRouteScratchState>,
 }
 
 impl SqliteRouteScratch {
-    pub(super) fn new(context: &Arc<SqliteSourceSnapshotContext>, maximum_bytes: u64) -> Arc<Self> {
+    pub(super) fn new(
+        context: &Arc<SqliteSourceSnapshotContext>,
+        maximum_bytes: Option<u64>,
+    ) -> Arc<Self> {
         Arc::new(Self {
             context: Arc::clone(context),
             maximum_bytes,
@@ -244,19 +247,19 @@ impl SqliteRouteScratch {
     }
 
     pub(super) fn admit_capacity(&self, capacity_bytes: u64) -> SqliteSourceAccessResult<()> {
-        if capacity_bytes > self.maximum_bytes {
-            return Err(SqliteSourceAccessError::SnapshotTooLarge {
-                path: self.context.data_root.clone(),
-                length: capacity_bytes,
-                maximum: self.maximum_bytes,
-            });
+        if let Some(maximum) = self.maximum_bytes {
+            if capacity_bytes > maximum {
+                return Err(SqliteSourceAccessError::SnapshotTooLarge {
+                    path: self.context.data_root.clone(),
+                    length: capacity_bytes,
+                    maximum,
+                });
+            }
         }
         let required = capacity_bytes
-            .checked_add(SQLITE_SNAPSHOT_FREE_HEADROOM_BYTES)
-            .ok_or_else(|| SqliteSourceAccessError::SnapshotTooLarge {
-                path: self.context.data_root.clone(),
-                length: u64::MAX,
-                maximum: self.maximum_bytes,
+            .checked_add(sqlite_snapshot_free_headroom_bytes(capacity_bytes))
+            .ok_or_else(|| SqliteSourceAccessError::SnapshotUnavailable {
+                reason: "SQLite snapshot capacity admission overflowed".to_owned(),
             })?;
         let available = scratch_available_space(&self.context.data_root)?;
         if available < required {
@@ -273,17 +276,17 @@ impl SqliteRouteScratch {
         let mut state = self.lock();
         let aggregate = retained_bytes
             .checked_add(state.reserved_transient_bytes)
-            .ok_or_else(|| SqliteSourceAccessError::SnapshotTooLarge {
-                path: self.context.data_root.clone(),
-                length: u64::MAX,
-                maximum: self.maximum_bytes,
+            .ok_or_else(|| SqliteSourceAccessError::SnapshotUnavailable {
+                reason: "SQLite retained scratch accounting overflowed".to_owned(),
             })?;
-        if aggregate > self.maximum_bytes {
-            return Err(SqliteSourceAccessError::SnapshotTooLarge {
-                path: self.context.data_root.clone(),
-                length: aggregate,
-                maximum: self.maximum_bytes,
-            });
+        if let Some(maximum) = self.maximum_bytes {
+            if aggregate > maximum {
+                return Err(SqliteSourceAccessError::SnapshotTooLarge {
+                    path: self.context.data_root.clone(),
+                    length: aggregate,
+                    maximum,
+                });
+            }
         }
         state.retained_bytes = retained_bytes;
         state.exact_peak_bytes = state.exact_peak_bytes.max(retained_bytes);
@@ -300,12 +303,12 @@ impl SqliteRouteScratch {
         let used = state
             .retained_bytes
             .checked_add(state.reserved_transient_bytes)
-            .ok_or_else(|| SqliteSourceAccessError::SnapshotTooLarge {
-                path: self.context.data_root.clone(),
-                length: u64::MAX,
-                maximum: self.maximum_bytes,
+            .ok_or_else(|| SqliteSourceAccessError::SnapshotUnavailable {
+                reason: "SQLite transient scratch accounting overflowed".to_owned(),
             })?;
-        let available_capacity = self.maximum_bytes.saturating_sub(used);
+        let available_capacity = self
+            .maximum_bytes
+            .map_or(requested_bytes, |maximum| maximum.saturating_sub(used));
         let reserved_bytes = requested_bytes.min(available_capacity);
         if reserved_bytes == 0 {
             return Err(SqliteSourceAccessError::SnapshotTooLarge {
@@ -321,25 +324,23 @@ impl SqliteRouteScratch {
             state
                 .reserved_transient_bytes
                 .checked_add(reserved_bytes)
-                .ok_or_else(|| SqliteSourceAccessError::SnapshotTooLarge {
-                    path: self.context.data_root.clone(),
-                    length: u64::MAX,
-                    maximum: self.maximum_bytes,
+                .ok_or_else(|| SqliteSourceAccessError::SnapshotUnavailable {
+                    reason: "SQLite transient scratch reservation overflowed".to_owned(),
                 })?;
         let aggregate = state
             .retained_bytes
             .checked_add(reserved_transient_bytes)
-            .ok_or_else(|| SqliteSourceAccessError::SnapshotTooLarge {
-                path: self.context.data_root.clone(),
-                length: u64::MAX,
-                maximum: self.maximum_bytes,
+            .ok_or_else(|| SqliteSourceAccessError::SnapshotUnavailable {
+                reason: "SQLite aggregate scratch reservation overflowed".to_owned(),
             })?;
-        if aggregate > self.maximum_bytes {
-            return Err(SqliteSourceAccessError::SnapshotTooLarge {
-                path: self.context.data_root.clone(),
-                length: aggregate,
-                maximum: self.maximum_bytes,
-            });
+        if let Some(maximum) = self.maximum_bytes {
+            if aggregate > maximum {
+                return Err(SqliteSourceAccessError::SnapshotTooLarge {
+                    path: self.context.data_root.clone(),
+                    length: aggregate,
+                    maximum,
+                });
+            }
         }
         state.reserved_transient_bytes = reserved_transient_bytes;
         Ok(SqliteRouteScratchReservation {
@@ -358,10 +359,8 @@ impl SqliteRouteScratch {
             });
         }
         let aggregate = state.retained_bytes.checked_add(bytes).ok_or_else(|| {
-            SqliteSourceAccessError::SnapshotTooLarge {
-                path: self.context.data_root.clone(),
-                length: u64::MAX,
-                maximum: self.maximum_bytes,
+            SqliteSourceAccessError::SnapshotUnavailable {
+                reason: "SQLite exact scratch accounting overflowed".to_owned(),
             }
         })?;
         state.exact_peak_bytes = state.exact_peak_bytes.max(aggregate);

--- a/crates/ctx-history-source-sqlite/src/sqlite_source/snapshot.rs
+++ b/crates/ctx-history-source-sqlite/src/sqlite_source/snapshot.rs
@@ -38,15 +38,20 @@ fn take_private_directory_cleanup_failure_for_test() -> bool {
 /// file and any SQLite-created transient private artifact for this route.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SqliteSourceSnapshotLimits {
-    maximum_source_bytes: u64,
-    maximum_scratch_bytes: u64,
+    policy: SqliteSnapshotCapacityPolicy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SqliteSnapshotCapacityPolicy {
+    AvailableDisk,
+    FixedAggregate(u64),
+    SourceOnly(u64),
 }
 
 impl SqliteSourceSnapshotLimits {
     pub const fn new(maximum_scratch_bytes: u64) -> Self {
         Self {
-            maximum_source_bytes: maximum_scratch_bytes,
-            maximum_scratch_bytes,
+            policy: SqliteSnapshotCapacityPolicy::FixedAggregate(maximum_scratch_bytes),
         }
     }
 
@@ -54,19 +59,42 @@ impl SqliteSourceSnapshotLimits {
     /// immutable-handle VFS fail closed before creating scratch files.
     pub const fn without_scratch(maximum_source_bytes: u64) -> Self {
         Self {
-            maximum_source_bytes,
-            maximum_scratch_bytes: 0,
+            policy: SqliteSnapshotCapacityPolicy::SourceOnly(maximum_source_bytes),
         }
     }
 
+    /// Returns the explicit aggregate bound, or `u64::MAX` for production's
+    /// available-disk policy. Retained for API compatibility; acquisition uses
+    /// the typed policy rather than treating this value as a production cap.
     pub const fn maximum_scratch_bytes(self) -> u64 {
-        self.maximum_scratch_bytes
+        match self.maximum_scratch_limit() {
+            Some(maximum) => maximum,
+            None => u64::MAX,
+        }
+    }
+
+    const fn maximum_scratch_limit(self) -> Option<u64> {
+        match self.policy {
+            SqliteSnapshotCapacityPolicy::AvailableDisk => None,
+            SqliteSnapshotCapacityPolicy::FixedAggregate(maximum) => Some(maximum),
+            SqliteSnapshotCapacityPolicy::SourceOnly(_) => Some(0),
+        }
+    }
+
+    const fn maximum_source_bytes(self) -> Option<u64> {
+        match self.policy {
+            SqliteSnapshotCapacityPolicy::AvailableDisk => None,
+            SqliteSnapshotCapacityPolicy::FixedAggregate(maximum)
+            | SqliteSnapshotCapacityPolicy::SourceOnly(maximum) => Some(maximum),
+        }
     }
 }
 
 impl Default for SqliteSourceSnapshotLimits {
     fn default() -> Self {
-        Self::new(SQLITE_SNAPSHOT_MAX_TOTAL_BYTES)
+        Self {
+            policy: SqliteSnapshotCapacityPolicy::AvailableDisk,
+        }
     }
 }
 
@@ -277,4 +305,5 @@ pub(super) use test_api::{
     open_root_handle_sqlite_source_snapshot_with_limit_for_test,
     open_root_handle_sqlite_source_stable_snapshot_after_database_copy_for_test,
     open_root_handle_sqlite_source_stable_snapshot_before_revalidation_for_test,
+    planned_snapshot_copy_bytes_for_test,
 };

--- a/crates/ctx-history-source-sqlite/src/sqlite_source/snapshot/acquisition.rs
+++ b/crates/ctx-history-source-sqlite/src/sqlite_source/snapshot/acquisition.rs
@@ -136,8 +136,8 @@ pub(super) fn acquire_sqlite_connection_with_progress<E>(
     after_database_copy: impl FnOnce(),
     report_progress: &mut impl FnMut(SqliteSourceProgress) -> Result<(), E>,
 ) -> Result<AcquiredSqliteConnection, SqliteSourceProgressError<E>> {
-    let source_limit = options.limits.maximum_source_bytes;
-    let scratch_limit = options.limits.maximum_scratch_bytes;
+    let source_limit = options.limits.maximum_source_bytes();
+    let scratch_limit = options.limits.maximum_scratch_limit();
     let scratch = SqliteRouteScratch::new(snapshot_context, scratch_limit);
     if options.policy == SqliteSourceSnapshotPolicy::PinnedReadOnlyWal {
         #[cfg(any(test, feature = "test-support"))]
@@ -192,10 +192,8 @@ pub(super) fn acquire_sqlite_connection_with_progress<E>(
     };
     let admitted_capacity = copied_bytes
         .checked_add(coordination_reserve)
-        .ok_or_else(|| SqliteSourceAccessError::SnapshotTooLarge {
-            path: family.database.path.clone(),
-            length: u64::MAX,
-            maximum: scratch_limit,
+        .ok_or_else(|| SqliteSourceAccessError::SnapshotUnavailable {
+            reason: "SQLite source-copy capacity accounting overflowed".to_owned(),
         })?;
     scratch.admit_capacity(admitted_capacity)?;
     let (snapshot_directory, snapshot_path) = copy_sqlite_family_to_ctx_with_progress(
@@ -390,28 +388,28 @@ pub(super) fn open_immutable_main(
 pub(super) fn enforce_snapshot_copy_bounds_with_limit(
     family: &SqliteSourceFamily,
     evidence: &SqliteFamilyEvidence,
-    scratch_limit: u64,
+    scratch_limit: Option<u64>,
 ) -> SqliteSourceAccessResult<u64> {
     let mut total = evidence.database.length;
     match (family.wal.as_ref(), evidence.wal.as_ref()) {
         (Some(_), Some(state)) => {
             total = total.checked_add(state.length).ok_or_else(|| {
-                SqliteSourceAccessError::SnapshotTooLarge {
-                    path: family.database.path.clone(),
-                    length: u64::MAX,
-                    maximum: scratch_limit,
+                SqliteSourceAccessError::SnapshotUnavailable {
+                    reason: "SQLite source-family length accounting overflowed".to_owned(),
                 }
             })?;
         }
         (None, None) => {}
         _ => return Err(SqliteSourceAccessError::SourceChanged),
     }
-    if total > scratch_limit {
-        return Err(SqliteSourceAccessError::SnapshotTooLarge {
-            path: family.database.path.clone(),
-            length: total,
-            maximum: scratch_limit,
-        });
+    if let Some(maximum) = scratch_limit {
+        if total > maximum {
+            return Err(SqliteSourceAccessError::SnapshotTooLarge {
+                path: family.database.path.clone(),
+                length: total,
+                maximum,
+            });
+        }
     }
     Ok(total)
 }
@@ -420,7 +418,7 @@ pub(super) fn copy_sqlite_family_to_ctx_with_progress<E>(
     data_root: &Path,
     family: &SqliteSourceFamily,
     evidence: &SqliteFamilyEvidence,
-    scratch_limit: u64,
+    scratch_limit: Option<u64>,
     after_database_copy: impl FnOnce(),
     report_progress: &mut impl FnMut(SqliteSourceProgress) -> Result<(), E>,
 ) -> Result<(TempDir, PathBuf), SqliteSourceProgressError<E>> {
@@ -489,7 +487,10 @@ fn injected_storage_full_error() -> std::io::Error {
     std::io::Error::from(std::io::ErrorKind::StorageFull)
 }
 
-fn measure_private_snapshot_bytes(directory: &Path, maximum: u64) -> SqliteSourceAccessResult<u64> {
+fn measure_private_snapshot_bytes(
+    directory: &Path,
+    maximum: Option<u64>,
+) -> SqliteSourceAccessResult<u64> {
     let mut total = 0_u64;
     for name in [
         "source.sqlite",
@@ -516,22 +517,21 @@ fn measure_private_snapshot_bytes(directory: &Path, maximum: u64) -> SqliteSourc
             });
         }
         total = total.checked_add(metadata.len()).ok_or_else(|| {
-            SqliteSourceAccessError::SnapshotTooLarge {
-                path: directory.to_path_buf(),
-                length: u64::MAX,
-                maximum,
+            SqliteSourceAccessError::SnapshotUnavailable {
+                reason: "SQLite private snapshot measurement overflowed".to_owned(),
             }
         })?;
     }
-    if total > maximum {
-        Err(SqliteSourceAccessError::SnapshotTooLarge {
-            path: directory.to_path_buf(),
-            length: total,
-            maximum,
-        })
-    } else {
-        Ok(total)
+    if let Some(maximum) = maximum {
+        if total > maximum {
+            return Err(SqliteSourceAccessError::SnapshotTooLarge {
+                path: directory.to_path_buf(),
+                length: total,
+                maximum,
+            });
+        }
     }
+    Ok(total)
 }
 
 pub(super) fn create_snapshot_directory(

--- a/crates/ctx-history-source-sqlite/src/sqlite_source/snapshot/copy_progress.rs
+++ b/crates/ctx-history-source-sqlite/src/sqlite_source/snapshot/copy_progress.rs
@@ -1,4 +1,5 @@
 use super::*;
+use fs2::FileExt as _;
 
 const SQLITE_SOURCE_FAMILY_COPY_PROGRESS_BYTES: u64 = 8 * 1024 * 1024;
 
@@ -36,6 +37,15 @@ pub(super) fn copy_sqlite_member_with_progress<E>(
             path: destination.to_path_buf(),
             source,
         })?;
+    if expected_length != 0 {
+        destination_file
+            .allocate(expected_length)
+            .map_err(|source| SqliteSourceAccessError::ScratchIoUnavailable {
+                operation: "reserving space for a ctx-owned SQLite snapshot component",
+                path: destination.to_path_buf(),
+                source,
+            })?;
+    }
     let mut remaining = expected_length;
     let mut buffer = [0_u8; SQLITE_COPY_BUFFER_BYTES];
     while remaining > 0 {

--- a/crates/ctx-history-source-sqlite/src/sqlite_source/snapshot/test_api.rs
+++ b/crates/ctx-history-source-sqlite/src/sqlite_source/snapshot/test_api.rs
@@ -73,6 +73,19 @@ pub(in crate::sqlite_source) fn open_root_handle_sqlite_source_snapshot_with_lim
     )
 }
 
+pub(in crate::sqlite_source) fn planned_snapshot_copy_bytes_for_test(
+    authority: &SqliteSourceDirectoryAuthority,
+    database_name: &OsStr,
+) -> SqliteSourceAccessResult<u64> {
+    let family = SqliteSourceFamily::open(authority, database_name, || {})?;
+    let evidence = family.capture_evidence()?;
+    enforce_snapshot_copy_bounds_with_limit(
+        &family,
+        &evidence,
+        SqliteSourceSnapshotLimits::default().maximum_source_bytes(),
+    )
+}
+
 pub(in crate::sqlite_source) fn open_root_handle_sqlite_source_stable_snapshot_after_database_copy_for_test(
     authority: &SqliteSourceDirectoryAuthority,
     database_name: &OsStr,

--- a/crates/ctx-history-source-sqlite/src/sqlite_source/tests.rs
+++ b/crates/ctx-history-source-sqlite/src/sqlite_source/tests.rs
@@ -30,9 +30,8 @@ use super::snapshot::{
     open_root_handle_sqlite_source_snapshot_with_limit_for_test,
     open_root_handle_sqlite_source_stable_snapshot_after_database_copy_for_test,
     open_root_handle_sqlite_source_stable_snapshot_before_revalidation_for_test,
+    planned_snapshot_copy_bytes_for_test,
 };
-#[cfg(target_os = "linux")]
-use super::SQLITE_SNAPSHOT_MAX_TOTAL_BYTES;
 use super::{
     fail_next_private_sqlite_staging_operation_for_test, map_revalidation_error,
     map_revalidation_io_error, open_private_sqlite_staging_file,
@@ -40,7 +39,7 @@ use super::{
     SqliteArtifactKind, SqliteCleanupStatus, SqliteFailurePhase, SqliteSourceAccessError,
     SqliteSourceComponent, SqliteSourceDirectoryAuthority, SqliteSourceFamily,
     SqliteSourceProgressError, SqliteSourceProgressStage, SqliteSourceReadSnapshot,
-    SqliteSourceSnapshotStrategy, SqliteSourceStagingOperationForTest,
+    SqliteSourceSnapshotLimits, SqliteSourceSnapshotStrategy, SqliteSourceStagingOperationForTest,
     SQLITE_SNAPSHOT_FREE_HEADROOM_BYTES,
 };
 
@@ -272,7 +271,6 @@ fn active_wal_retains_one_family_copy_under_one_aggregate_limit() {
     assert_eq!(counters.copied_snapshot_opens(), 1);
     assert_eq!(counters.max_active_snapshots(), 1);
     assert!(counters.max_route_scratch_bytes() >= snapshot.copied_bytes());
-    assert!(counters.max_route_scratch_bytes() <= SQLITE_SNAPSHOT_MAX_TOTAL_BYTES);
     snapshot.finish().unwrap();
 
     assert_eq!(staging_entries(data_root.path()), 0);
@@ -546,8 +544,63 @@ fn near_limit_rejection_happens_before_any_scratch_write() {
     .unwrap_err();
 
     assert!(error.is_systemic_resource_failure());
+    assert!(error.is_snapshot_capacity_failure());
     assert_eq!(staging_entries(data_root.path()), 0);
     assert_eq!(authority.snapshot_counters().source_bytes_copied(), 0);
+}
+
+#[test]
+fn production_snapshot_admission_has_no_fixed_source_size_ceiling() {
+    const TEN_GIB: u64 = 10 * 1024 * 1024 * 1024;
+
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = tempfile::tempdir().unwrap();
+    let database = temp.path().join("provider.sqlite");
+    create_database(&database, "capacity");
+    let authority = retain_parent_in_data_root(data_root.path(), temp.path());
+    let limits = SqliteSourceSnapshotLimits::default();
+    assert_eq!(limits.maximum_scratch_bytes(), u64::MAX);
+
+    super::override_next_scratch_available_space_for_test(
+        TEN_GIB + super::sqlite_snapshot_free_headroom_bytes(TEN_GIB),
+    );
+    let scratch = super::SqliteRouteScratch::new(&authority.snapshot_context, None);
+    scratch.admit_capacity(TEN_GIB).unwrap();
+
+    assert_eq!(authority.snapshot_counters().scratch_admissions(), 1);
+
+    super::override_next_scratch_available_space_for_test(
+        TEN_GIB + super::sqlite_snapshot_free_headroom_bytes(TEN_GIB) - 1,
+    );
+    let error = scratch.admit_capacity(TEN_GIB).unwrap_err();
+    assert!(matches!(
+        error,
+        SqliteSourceAccessError::InsufficientScratchSpace {
+            required,
+            available,
+            ..
+        } if required == TEN_GIB + super::sqlite_snapshot_free_headroom_bytes(TEN_GIB)
+            && available + 1 == required
+    ));
+    assert_eq!(staging_entries(data_root.path()), 0);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn multi_gibibyte_sparse_source_produces_an_available_disk_copy_plan() {
+    const FIVE_GIB: u64 = 5 * 1024 * 1024 * 1024;
+
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = tempfile::tempdir().unwrap();
+    let database = temp.path().join("provider.sqlite");
+    File::create(&database).unwrap().set_len(FIVE_GIB).unwrap();
+    let authority = retain_parent_in_data_root(data_root.path(), temp.path());
+
+    assert_eq!(
+        planned_snapshot_copy_bytes_for_test(&authority, OsStr::new("provider.sqlite")).unwrap(),
+        FIVE_GIB
+    );
+    assert_eq!(staging_entries(data_root.path()), 0);
 }
 
 #[test]
@@ -571,6 +624,7 @@ fn free_space_headroom_rejection_happens_before_any_scratch_write() {
         SqliteSourceAccessError::InsufficientScratchSpace { .. }
             | SqliteSourceAccessError::Diagnosed { .. }
     ));
+    assert!(error.is_snapshot_capacity_failure());
     assert_eq!(staging_entries(data_root.path()), 0);
 }
 

--- a/crates/ctx-history-source-sqlite/src/sqlite_source/tests/diagnostics.rs
+++ b/crates/ctx-history-source-sqlite/src/sqlite_source/tests/diagnostics.rs
@@ -1,5 +1,40 @@
 use super::*;
 
+#[test]
+fn snapshot_capacity_failures_are_distinct_from_runtime_resource_failures() {
+    let capacity = SqliteSourceAccessError::InsufficientScratchSpace {
+        path: PathBuf::from("ctx-data"),
+        required: 10,
+        available: 9,
+    };
+    assert!(capacity.is_snapshot_capacity_failure());
+    assert!(capacity.is_systemic_resource_failure());
+
+    let diagnosed = capacity.with_diagnostic(
+        SqliteFailurePhase::SourceAcquisition,
+        SqliteArtifactKind::PrivateSourceCopy,
+        0,
+        0,
+        SqliteCleanupStatus::NotRequired,
+    );
+    assert!(diagnosed.is_snapshot_capacity_failure());
+
+    let runtime = SqliteSourceAccessError::ScratchIoUnavailable {
+        operation: "writing a private SQLite source-family copy",
+        path: PathBuf::from("ctx-data/source.sqlite"),
+        source: io::Error::from(io::ErrorKind::StorageFull),
+    };
+    assert!(!runtime.is_snapshot_capacity_failure());
+    assert!(runtime.is_systemic_resource_failure());
+
+    let finalization = SqliteSourceAccessError::Finalization {
+        primary: Box::new(diagnosed),
+        cleanup: Box::new(runtime),
+    };
+    assert!(!finalization.is_snapshot_capacity_failure());
+    assert!(finalization.is_systemic_resource_failure());
+}
+
 fn assert_revalidation_resource_unavailable(error: SqliteSourceAccessError) {
     assert!(error.is_systemic_resource_failure());
     assert!(matches!(

--- a/docs/provider-import-policy.md
+++ b/docs/provider-import-policy.md
@@ -257,7 +257,12 @@ contract for that source family:
 - SQLite is observed as one short read-only logical snapshot. WAL size,
   checkpointing, and physical database-file size are not ingestion states.
   Concurrent committed rows belong to a subsequent certified snapshot unless
-  they are visible inside the admitted transaction.
+  they are visible inside the admitted transaction. On platforms and routes
+  that cannot retain a no-write snapshot directly, ctx first preallocates and
+  streams one private DB/WAL copy below its data root. Admission depends on
+  available temporary disk capacity plus safety headroom, not a fixed source
+  size ceiling; copy memory remains bounded and the private family is removed
+  when the route finishes.
 - JSON documents and document trees use unchanged-or-replace semantics. A
   mutation during a scan invalidates that candidate; the retry reads one
   complete replacement.


### PR DESCRIPTION
Closes #646

## Summary

- replace the shared 2 GiB production snapshot ceiling with explicit available-disk admission while keeping finite discovery/test policies
- require DB + WAL + SQLite coordination space plus 5% safety headroom, and preallocate each private component before streaming its bytes with the bounded copy buffer
- isolate deterministic snapshot-capacity failures to the affected SQLite route so healthy providers can still publish
- document the temporary-disk behavior and preserve cleanup, source revalidation, and no-provider-write invariants

## Validation

- `//crates/ctx-history-source-sqlite:unit_tests`
- `//crates/ctx-history-source-discovery:unit_tests`
- all SQLite provider-pack unit suites (logical, inventory, selected, Hermes, and DocProj)
- `//crates/ctx-history-capture-composition:unit_tests`
- `//:docs_check`
- explicit ignored resource proof: full OpenCode discovery, preallocation, streaming copy, SQLite open, logical observation, and cleanup for a 2 GiB + 4 KiB source