### PR TITLE
fix(semantic): account for intentional projection filters

### DIFF
--- a/crates/ctx-cli-presentation/src/commands/index_dashboard.rs
+++ b/crates/ctx-cli-presentation/src/commands/index_dashboard.rs
@@ -209,6 +209,7 @@ fn render_semantic(readiness: &Value, context: &RenderContext) -> Document {
 
     let semantic_status = string_at(readiness, &["semantic", "status"], "unknown");
     let embedded = u64_at(readiness, &["semantic", "coverage", "embedded_items"]).unwrap_or(0);
+    let candidates = u64_at(readiness, &["semantic", "coverage", "candidate_items"]);
     let searchable = u64_at(readiness, &["semantic", "coverage", "searchable_items"]);
     if semantic_status == "ready" {
         return fields(context, &[Field::new("Semantic search", "On")]);
@@ -230,7 +231,8 @@ fn render_semantic(readiness: &Value, context: &RenderContext) -> Document {
         return document;
     }
 
-    let total = searchable
+    let total = candidates
+        .or(searchable)
         .filter(|total| *total > 0)
         .map(|total| total.max(embedded));
     let mut document = progress(

--- a/crates/ctx-cli/src/commands/index.rs
+++ b/crates/ctx-cli/src/commands/index.rs
@@ -148,11 +148,7 @@ fn index_readiness_snapshot(data_root: &Path) -> Result<Value> {
             "status": source_semantic.get("status"),
             "reason": source_semantic.get("reason"),
             "enabled": source_semantic.get("enabled"),
-            "coverage": {
-                "searchable_items": semantic_flat.get("semantic_documents"),
-                "embedded_items": semantic_flat.get("active_events"),
-                "embedded_chunks": semantic_flat.get("active_chunks"),
-            },
+            "coverage": semantic_coverage(semantic_flat),
         },
         "daemon": {
             "status": source_daemon.get("status"),
@@ -166,6 +162,16 @@ fn index_readiness_snapshot(data_root: &Path) -> Result<Value> {
     })))
 }
 
+fn semantic_coverage(flat: &Value) -> Value {
+    compact_json(json!({
+        "candidate_items": flat.get("semantic_documents"),
+        "searchable_items": flat.get("projected_documents"),
+        "embedded_items": flat.get("projected_documents"),
+        "filtered_items": flat.get("filtered_documents"),
+        "embedded_chunks": flat.get("active_chunks"),
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -173,6 +179,22 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn semantic_coverage_distinguishes_candidates_from_intentional_filters() {
+        let coverage = semantic_coverage(&json!({
+            "semantic_documents": 4,
+            "projected_documents": 1,
+            "filtered_documents": 3,
+            "active_chunks": 2,
+        }));
+
+        assert_eq!(coverage["candidate_items"], 4);
+        assert_eq!(coverage["searchable_items"], 1);
+        assert_eq!(coverage["embedded_items"], 1);
+        assert_eq!(coverage["filtered_items"], 3);
+        assert_eq!(coverage["embedded_chunks"], 2);
+    }
 
     #[test]
     fn readiness_port_preserves_exact_engine_logical_and_physical_status() {

--- a/crates/ctx-cli/src/commands/index/dashboard_fixture.rs
+++ b/crates/ctx-cli/src/commands/index/dashboard_fixture.rs
@@ -295,8 +295,10 @@ impl DashboardStatus {
                 reason: Some("semantic_disabled"),
                 enabled: false,
                 coverage: SemanticCoverage {
+                    candidate_items: INDEXED_ITEMS,
                     embedded_items: 0,
-                    searchable_items: INDEXED_ITEMS,
+                    searchable_items: 0,
+                    filtered_items: 0,
                 },
             },
             daemon: DaemonStatus {
@@ -344,6 +346,7 @@ impl DashboardStatus {
         self.semantic.reason = reason;
         self.semantic.enabled = true;
         self.semantic.coverage.embedded_items = embedded_items;
+        self.semantic.coverage.searchable_items = embedded_items;
         self.daemon.jobs.semantic_index.status = state;
         self.daemon.jobs.semantic_index.reason = reason;
     }
@@ -411,8 +414,10 @@ struct SemanticStatus {
 
 #[derive(Debug, Serialize)]
 struct SemanticCoverage {
+    candidate_items: u64,
     embedded_items: u64,
     searchable_items: u64,
+    filtered_items: u64,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/ctx-cli/src/commands/index/dashboard_fixture/tests.rs
+++ b/crates/ctx-cli/src/commands/index/dashboard_fixture/tests.rs
@@ -115,7 +115,9 @@ fn typed_cases_construct_the_expected_production_status_shapes() {
         assert!(status["lexical"]["status"].is_string());
         assert!(status["lexical"]["indexed_items"].is_u64());
         assert!(status["semantic"]["enabled"].is_boolean());
+        assert!(status["semantic"]["coverage"]["candidate_items"].is_u64());
         assert!(status["semantic"]["coverage"]["embedded_items"].is_u64());
+        assert!(status["semantic"]["coverage"]["filtered_items"].is_u64());
         assert!(status["daemon"]["running"].is_boolean());
         assert!(status["daemon"]["jobs"]["semantic_index"]["status"].is_string());
     }

--- a/crates/ctx-daemon-cli/src/query_adapter/tests.rs
+++ b/crates/ctx-daemon-cli/src/query_adapter/tests.rs
@@ -337,7 +337,7 @@ fn adapter_preserves_daemon_query_service_unavailable_contract() -> Result<()> {
 }
 
 #[test]
-fn adapter_preserves_typed_not_ready_from_engine_search() -> Result<()> {
+fn adapter_scores_only_the_active_flat_core_intersection() -> Result<()> {
     let temp = tempfile::tempdir()?;
     let (index, _) = semantic_index(temp.path())?;
     let mut adapter = ready_adapter(
@@ -347,20 +347,14 @@ fn adapter_preserves_typed_not_ready_from_engine_search() -> Result<()> {
         &temp.path().join("vectors"),
     )?;
 
-    let error = adapter
-        .search_with("query", &EventSearchFilters::default(), 1, |_, _| {
+    let (candidates, diagnostics) =
+        adapter.search_with("query", &EventSearchFilters::default(), 1, |_, _| {
             Ok(Some((embedding(), 1)))
-        })
-        .expect_err("a vector generation that does not map to Core must fail closed");
+        })?;
 
-    assert!(matches!(
-        error,
-        SemanticQueryError::NotReady {
-            code: "semantic_projection_event_mismatch",
-            detail,
-            retryable: true,
-        } if detail.contains("metadata-eligible events")
-    ));
+    assert!(candidates.is_empty());
+    assert_eq!(diagnostics["events_scored"], 0);
+    assert_eq!(diagnostics["filtered_candidates"], 1);
     Ok(())
 }
 

--- a/crates/ctx-daemon-cli/src/source_status.rs
+++ b/crates/ctx-daemon-cli/src/source_status.rs
@@ -19,6 +19,43 @@ use super::source_backed_refresh_coordinator::verified_generation_is_query_ready
 
 const SEARCH_DIRECTORY: &str = "search";
 const LEXICAL_DIRECTORY: &str = "lexical";
+const MAX_SAFE_PUBLIC_JSON_COUNTER: u64 = (1_u64 << 53) - 1;
+
+#[derive(Clone, Copy)]
+struct PublicSemanticDocumentCounts {
+    semantic_documents: u64,
+    projected_documents: u64,
+    filtered_documents: u64,
+}
+
+impl PublicSemanticDocumentCounts {
+    fn new(semantic_documents: u64, projected_documents: u64) -> Result<Self> {
+        let semantic_documents =
+            validate_public_semantic_counter("semantic_documents", semantic_documents)?;
+        let projected_documents =
+            validate_public_semantic_counter("projected_documents", projected_documents)?;
+        let filtered_documents = semantic_documents
+            .checked_sub(projected_documents)
+            .ok_or_else(|| anyhow::anyhow!("projected_documents exceeds semantic_documents"))?;
+        let filtered_documents =
+            validate_public_semantic_counter("filtered_documents", filtered_documents)?;
+        Ok(Self {
+            semantic_documents,
+            projected_documents,
+            filtered_documents,
+        })
+    }
+}
+
+fn validate_public_semantic_counter(field: &'static str, value: u64) -> Result<u64> {
+    if value > MAX_SAFE_PUBLIC_JSON_COUNTER {
+        return Err(anyhow::anyhow!(
+            "{field} exceeds maximum {MAX_SAFE_PUBLIC_JSON_COUNTER}"
+        ));
+    }
+    Ok(value)
+}
+
 pub struct SourceEpochStatus {
     pub initialized: bool,
     pub indexed_items: Option<u64>,
@@ -391,42 +428,82 @@ fn semantic_report(
 
     let flat_f32 = match SemanticVectorStore::open_read_only(&path) {
         Ok(Some(store)) => match index.semantic_eligible_event_count() {
-            Ok(semantic_documents) => match store
-                .source_backed_generation_pin_exact(index.generation_id(), semantic_documents)
-            {
-                Ok(SourceBackedGenerationPin::Ready(pin)) => compact_json(json!({
-                    "status": "ready",
-                    "reason": Value::Null,
-                    "path": path,
-                    "core_generation_id": index.generation_id(),
-                    "semantic_documents": semantic_documents,
-                    "flat_generation": pin.generation(),
-                    "flat_generation_hash": pin.generation_hash(),
-                    "active_events": pin.active_event_count(),
-                    "active_chunks": pin.active_chunk_count(),
-                    "active_vector_bytes": pin.active_vector_bytes(),
-                })),
-                Ok(SourceBackedGenerationPin::ReadyEmpty) => compact_json(json!({
-                    "status": "ready",
-                    "reason": Value::Null,
-                    "path": path,
-                    "core_generation_id": index.generation_id(),
-                    "semantic_documents": semantic_documents,
-                    "flat_generation": Value::Null,
-                    "flat_generation_hash": Value::Null,
-                    "active_events": 0,
-                    "active_chunks": 0,
-                    "active_vector_bytes": 0,
-                })),
-                Ok(SourceBackedGenerationPin::NotReady) => compact_json(json!({
-                    "status": "pending",
-                    "reason": "generation_not_acknowledged",
-                    "path": path,
-                    "core_generation_id": index.generation_id(),
-                    "semantic_documents": semantic_documents,
-                })),
-                Err(error) => typed_unavailable_with_error("flat_f32_status_failed", path, error),
-            },
+            Ok(semantic_documents) => {
+                match validate_public_semantic_counter("semantic_documents", semantic_documents) {
+                    Ok(semantic_documents) => match store.source_backed_generation_pin_exact(
+                        index.generation_id(),
+                        semantic_documents,
+                    ) {
+                        Ok(SourceBackedGenerationPin::Ready(pin)) => {
+                            let counts = u64::try_from(pin.active_event_count())
+                                .map_err(anyhow::Error::from)
+                                .and_then(|projected_documents| {
+                                    PublicSemanticDocumentCounts::new(
+                                        semantic_documents,
+                                        projected_documents,
+                                    )
+                                });
+                            match counts {
+                                Ok(counts) => compact_json(json!({
+                                    "status": "ready",
+                                    "reason": Value::Null,
+                                    "path": path,
+                                    "core_generation_id": index.generation_id(),
+                                    "semantic_documents": counts.semantic_documents,
+                                    "projected_documents": counts.projected_documents,
+                                    "filtered_documents": counts.filtered_documents,
+                                    "flat_generation": pin.generation(),
+                                    "flat_generation_hash": pin.generation_hash(),
+                                    "active_events": counts.projected_documents,
+                                    "active_chunks": pin.active_chunk_count(),
+                                    "active_vector_bytes": pin.active_vector_bytes(),
+                                })),
+                                Err(error) => typed_unavailable_with_error(
+                                    "semantic_count_out_of_range",
+                                    path,
+                                    error,
+                                ),
+                            }
+                        }
+                        Ok(SourceBackedGenerationPin::ReadyEmpty) => {
+                            match PublicSemanticDocumentCounts::new(semantic_documents, 0) {
+                                Ok(counts) => compact_json(json!({
+                                    "status": "ready",
+                                    "reason": Value::Null,
+                                    "path": path,
+                                    "core_generation_id": index.generation_id(),
+                                    "semantic_documents": counts.semantic_documents,
+                                    "projected_documents": counts.projected_documents,
+                                    "filtered_documents": counts.filtered_documents,
+                                    "flat_generation": Value::Null,
+                                    "flat_generation_hash": Value::Null,
+                                    "active_events": counts.projected_documents,
+                                    "active_chunks": 0,
+                                    "active_vector_bytes": 0,
+                                })),
+                                Err(error) => typed_unavailable_with_error(
+                                    "semantic_count_out_of_range",
+                                    path,
+                                    error,
+                                ),
+                            }
+                        }
+                        Ok(SourceBackedGenerationPin::NotReady) => compact_json(json!({
+                            "status": "pending",
+                            "reason": "generation_not_acknowledged",
+                            "path": path,
+                            "core_generation_id": index.generation_id(),
+                            "semantic_documents": semantic_documents,
+                        })),
+                        Err(error) => {
+                            typed_unavailable_with_error("flat_f32_status_failed", path, error)
+                        }
+                    },
+                    Err(error) => {
+                        typed_unavailable_with_error("semantic_count_out_of_range", path, error)
+                    }
+                }
+            }
             Err(error) => typed_unavailable_with_error("semantic_count_failed", path, error.into()),
         },
         Ok(None) => compact_json(json!({

--- a/crates/ctx-daemon-cli/src/source_status_tests.rs
+++ b/crates/ctx-daemon-cli/src/source_status_tests.rs
@@ -1,7 +1,17 @@
 use super::*;
 use std::fs;
 
-use ctx_history_index::{GenerationWriter, WriterOptions};
+use ctx_history_core::{
+    derive_event_id, derive_session_id, CaptureProvider, CertifiedSource, CoreRecord,
+    EventIdentityInput, EventRole, EventType, NativeItemKey, NativeSessionKey, ScannedSourceCounts,
+    SessionIdentityInput, SourceAnchor, SourceKey, SourceObservation, TypedKey,
+};
+use ctx_history_index::{CoreEventRecord, GenerationWriter, WriterOptions};
+use ctx_semantic_index::{
+    SemanticBatchEmbedder, SemanticChunkDocument, SemanticDocumentBuilder, SemanticEventDocument,
+    SemanticVectorStore,
+};
+use ctx_semantic_model::SEMANTIC_DIMENSIONS;
 
 fn core_publication_fixture() -> (tempfile::TempDir, std::path::PathBuf, String) {
     let temp = tempfile::tempdir().unwrap();
@@ -103,6 +113,207 @@ fn core_publication_fixture() -> (tempfile::TempDir, std::path::PathBuf, String)
     )
     .unwrap();
     (temp, data_root, generation_id)
+}
+
+struct StatusSemanticBuilder;
+
+const EMPTY_DOCUMENT_TOKEN: &str = "semantic-empty-status-document-fixture";
+
+impl SemanticDocumentBuilder for StatusSemanticBuilder {
+    fn build_document(
+        &mut self,
+        record: &CoreEventRecord,
+    ) -> anyhow::Result<Option<SemanticEventDocument>> {
+        let text = record.core_record.content.meaningful_text();
+        if text.trim().is_empty() || text.contains(EMPTY_DOCUMENT_TOKEN) {
+            return Ok(None);
+        }
+        Ok(Some(SemanticEventDocument::new(
+            record.event_id.as_uuid(),
+            Some(record.session_id.as_uuid()),
+            record.event_sequence,
+            record.occurred_at_unix_ms.unwrap_or_default(),
+            EventType::Message,
+            Some(EventRole::User),
+            "status_test".to_owned(),
+            Some(CaptureProvider::Codex),
+            Some(record.source_format.clone()),
+            record.core_record.agent_scope,
+            Vec::new(),
+            format!("user:\n{text}"),
+        )))
+    }
+}
+
+struct StatusSemanticEmbedder;
+
+impl SemanticBatchEmbedder for StatusSemanticEmbedder {
+    fn embed_chunks(&mut self, chunks: &[SemanticChunkDocument]) -> anyhow::Result<Vec<Vec<f32>>> {
+        Ok(chunks
+            .iter()
+            .map(|_| {
+                let mut vector = vec![0.0; SEMANTIC_DIMENSIONS];
+                vector[0] = 1.0;
+                vector
+            })
+            .collect())
+    }
+}
+
+#[test]
+fn public_semantic_counters_accept_the_exact_json_integer_maximum() {
+    for field in [
+        "semantic_documents",
+        "projected_documents",
+        "filtered_documents",
+    ] {
+        assert_eq!(
+            validate_public_semantic_counter(field, MAX_SAFE_PUBLIC_JSON_COUNTER).unwrap(),
+            MAX_SAFE_PUBLIC_JSON_COUNTER
+        );
+    }
+    let projected = PublicSemanticDocumentCounts::new(
+        MAX_SAFE_PUBLIC_JSON_COUNTER,
+        MAX_SAFE_PUBLIC_JSON_COUNTER,
+    )
+    .unwrap();
+    assert_eq!(projected.projected_documents, MAX_SAFE_PUBLIC_JSON_COUNTER);
+    assert_eq!(projected.filtered_documents, 0);
+    let filtered = PublicSemanticDocumentCounts::new(MAX_SAFE_PUBLIC_JSON_COUNTER, 0).unwrap();
+    assert_eq!(filtered.projected_documents, 0);
+    assert_eq!(filtered.filtered_documents, MAX_SAFE_PUBLIC_JSON_COUNTER);
+}
+
+#[test]
+fn public_semantic_counters_reject_exact_json_integer_maximum_plus_one() {
+    let rejected = MAX_SAFE_PUBLIC_JSON_COUNTER + 1;
+    for field in [
+        "semantic_documents",
+        "projected_documents",
+        "filtered_documents",
+    ] {
+        let error = validate_public_semantic_counter(field, rejected).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!("{field} exceeds maximum {MAX_SAFE_PUBLIC_JSON_COUNTER}")
+        );
+    }
+    assert!(PublicSemanticDocumentCounts::new(rejected, rejected).is_err());
+}
+
+#[test]
+fn semantic_status_reports_ready_only_with_exact_projected_and_filtered_counts() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    fs::create_dir_all(&data_root).unwrap();
+    fs::write(
+        data_root.join(crate::config::CONFIG_FILE),
+        "[search]\nsemantic = true\n",
+    )
+    .unwrap();
+    let source = SourceKey::derive(
+        "codex",
+        "codex_session_jsonl",
+        "session",
+        1,
+        SourceAnchor::provider_native(
+            "session-file",
+            TypedKey::utf8("semantic-status.jsonl").unwrap(),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let native_session_key =
+        NativeSessionKey::native_id("session", TypedKey::utf8("semantic-status").unwrap()).unwrap();
+    let session_id = derive_session_id(SessionIdentityInput {
+        source: &source,
+        logical_session_kind: "thread",
+        native_session_key: &native_session_key,
+    })
+    .unwrap();
+    let mut writer =
+        GenerationWriter::open(data_root.join("search/lexical"), WriterOptions::default())
+            .unwrap()
+            .into_writer()
+            .unwrap();
+    writer.begin_source(source.clone()).unwrap();
+    for (sequence, body) in [
+        (1_u64, "ordinary semantic question"),
+        (
+            2,
+            "<environment_context>status control</environment_context>",
+        ),
+        (3, EMPTY_DOCUMENT_TOKEN),
+    ] {
+        let event_id = derive_event_id(EventIdentityInput {
+            source: &source,
+            session_id,
+            logical_item_kind: "message",
+            native_item_key: &NativeItemKey::native_id("message", TypedKey::U64(sequence)).unwrap(),
+            subrecord_selector: None,
+        })
+        .unwrap();
+        let mut record = CoreRecord::new_selected(
+            event_id,
+            session_id,
+            source.clone(),
+            sequence,
+            "message",
+            "semantic-status-v1",
+            body,
+        )
+        .unwrap();
+        record.provider_session_id = Some("semantic-status".to_owned());
+        record.native_event_id = Some(TypedKey::U64(sequence));
+        record.role = Some("user".to_owned());
+        record.validate_contract().unwrap();
+        writer.add_core_record(record).unwrap();
+    }
+    let observation =
+        SourceObservation::new(source.clone(), "regular-file-v1", vec![1_u8]).unwrap();
+    writer
+        .certify_source(
+            CertifiedSource::certify(
+                observation.clone(),
+                observation,
+                "semantic-status-parser-v1",
+                [1; 32],
+                ScannedSourceCounts {
+                    complete_records: 3,
+                    retained_records: 3,
+                    indexed_documents: 3,
+                    certified_bytes: 3,
+                    ..ScannedSourceCounts::default()
+                },
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    writer.commit(|_| true).unwrap();
+    let index = VerifiedIndex::open(data_root.join("search/lexical")).unwrap();
+    let mut store =
+        SemanticVectorStore::open(&source_backed_semantic_vector_path(&data_root)).unwrap();
+    for _ in 0..16 {
+        let outcome = store
+            .reconcile_source_backed_index(
+                &index,
+                &mut StatusSemanticBuilder,
+                &mut StatusSemanticEmbedder,
+            )
+            .unwrap();
+        if outcome.ready() {
+            break;
+        }
+    }
+
+    let config = AppConfig::load(&data_root).unwrap();
+    let status = source_epoch_status_report(&data_root, &config).unwrap();
+    let semantic = &status.report["semantic"];
+    assert_eq!(semantic["status"], "ready");
+    assert_eq!(semantic["flat_f32"]["semantic_documents"], 3);
+    assert_eq!(semantic["flat_f32"]["projected_documents"], 1);
+    assert_eq!(semantic["flat_f32"]["filtered_documents"], 2);
+    assert_eq!(semantic["flat_f32"]["active_events"], 1);
 }
 
 #[test]

--- a/crates/ctx-daemon-service/src/daemon_scheduler.rs
+++ b/crates/ctx-daemon-service/src/daemon_scheduler.rs
@@ -757,6 +757,9 @@ fn run_daemon_semantic_job_with_retry(
 }
 
 fn bind_semantic_generation(mut job: Value, core_generation_id: Option<&str>) -> Value {
+    if let Ok(fingerprint) = ctx_semantic_index::source_backed_semantic_contract_fingerprint() {
+        job["source_contract_fingerprint"] = Value::String(fingerprint);
+    }
     if let Some(core_generation_id) = core_generation_id {
         job["core_generation_id"] = Value::String(core_generation_id.to_owned());
     }
@@ -764,11 +767,20 @@ fn bind_semantic_generation(mut job: Value, core_generation_id: Option<&str>) ->
 }
 
 fn semantic_generation_needs_catch_up(data_root: &Path, core_generation_id: &str) -> bool {
+    let Ok(contract_fingerprint) =
+        ctx_semantic_index::source_backed_semantic_contract_fingerprint()
+    else {
+        return true;
+    };
     let Some(job) = read_daemon_job_status(&daemon_semantic_job_path(data_root)) else {
         return true;
     };
     job.get("core_generation_id").and_then(Value::as_str) != Some(core_generation_id)
         || job.get("status").and_then(Value::as_str) != Some("ready")
+        || job
+            .get("source_contract_fingerprint")
+            .and_then(Value::as_str)
+            != Some(contract_fingerprint.as_str())
 }
 
 fn semantic_page_continuation_pending(data_root: &Path, core_generation_id: &str) -> bool {

--- a/crates/ctx-daemon-service/src/daemon_scheduler_tests.rs
+++ b/crates/ctx-daemon-service/src/daemon_scheduler_tests.rs
@@ -32,6 +32,10 @@ use crate::{
         SourceBackedRefreshRouteResult, SourceBackedRefreshSourceFailure,
         SourceBackedRefreshTimings,
     },
+    test_support::{
+        current_semantic_vector_schema_version, seed_filter_unaware_semantic_state,
+        semantic_contract_fingerprint, semantic_generation_is_ready_empty, semantic_vector_path,
+    },
     CoreGenerationPublished, CoreGenerationPublishedPort, DaemonRunArgs,
 };
 
@@ -676,6 +680,93 @@ fn one_core_cycle_then_scheduler_drains_semantic_consumer() {
     )
     .unwrap();
     assert!(!drained.continue_immediately);
+}
+
+#[test]
+fn automatic_scheduler_restart_migrates_legacy_semantic_state_despite_ready_job() {
+    let temp = tempfile::tempdir().unwrap();
+    let generation = publish_empty_core_generation(temp.path());
+    let vector_path = semantic_vector_path(temp.path());
+    let contract_fingerprint = semantic_contract_fingerprint().unwrap();
+
+    let mut initial_runtime = DaemonRuntime::default();
+    let initial = run_daemon_scheduler_cycle_with_activity(
+        &daemon_args(),
+        temp.path(),
+        &mut initial_runtime,
+        None,
+        true,
+        None,
+        None,
+    )
+    .unwrap();
+    assert!(initial.continue_immediately);
+    let initial_job = read_daemon_job_status(&daemon_semantic_job_path(temp.path())).unwrap();
+    assert_eq!(initial_job["status"], "ready");
+    assert_eq!(initial_job["core_generation_id"], generation);
+    assert_eq!(
+        initial_job["source_contract_fingerprint"],
+        contract_fingerprint
+    );
+
+    seed_filter_unaware_semantic_state(&vector_path).unwrap();
+    let control = rusqlite::Connection::open(vector_path.join("state.sqlite")).unwrap();
+    let seeded_version = control
+        .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+        .unwrap();
+    assert_eq!(seeded_version, 5);
+    drop(control);
+    write_daemon_job_status(
+        &daemon_semantic_job_path(temp.path()),
+        &json!({
+            "schema_version": 1,
+            "status": "ready",
+            "core_generation_id": generation,
+            "source_generation_ready": true,
+            "source_work_remaining": false,
+        }),
+    )
+    .unwrap();
+
+    let mut restarted_runtime = DaemonRuntime::default();
+    assert!(super::semantic_generation_needs_catch_up(
+        temp.path(),
+        &generation
+    ));
+    for _ in 0..8 {
+        run_daemon_scheduler_cycle_with_activity(
+            &daemon_args(),
+            temp.path(),
+            &mut restarted_runtime,
+            None,
+            true,
+            None,
+            None,
+        )
+        .unwrap();
+        if !super::semantic_generation_needs_catch_up(temp.path(), &generation) {
+            break;
+        }
+    }
+
+    assert!(!super::semantic_generation_needs_catch_up(
+        temp.path(),
+        &generation
+    ));
+    let migrated_job = read_daemon_job_status(&daemon_semantic_job_path(temp.path())).unwrap();
+    assert_eq!(migrated_job["status"], "ready");
+    assert_eq!(migrated_job["core_generation_id"], generation);
+    assert_eq!(
+        migrated_job["source_contract_fingerprint"],
+        contract_fingerprint
+    );
+    let control = rusqlite::Connection::open(vector_path.join("state.sqlite")).unwrap();
+    let migrated_version = control
+        .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+        .unwrap();
+    assert_eq!(migrated_version, current_semantic_vector_schema_version());
+    drop(control);
+    assert!(semantic_generation_is_ready_empty(&vector_path, &generation).unwrap());
 }
 
 #[test]

--- a/crates/ctx-daemon-service/src/test_support.rs
+++ b/crates/ctx-daemon-service/src/test_support.rs
@@ -5,6 +5,7 @@ use ctx_client_observability::analytics::{
     Outcome, ProviderRefreshCompletedV1, PublicEventV1, Surface,
 };
 use ctx_history_capture::DiscoveryContext;
+use ctx_semantic_index::{SemanticVectorStore, SourceBackedGenerationPin};
 use ctx_semantic_model::{
     ArtifactFetchRequest, ArtifactFetcher, SemanticModelConfig, SemanticModelPaths,
     SemanticOnnxRuntimePaths,
@@ -23,6 +24,32 @@ pub(crate) static AVAILABILITY: TestAvailability = TestAvailability;
 pub(crate) static GENERATION_PUBLISHED: TestCoreGenerationPublished = TestCoreGenerationPublished;
 pub(crate) static ARTIFACT: TestArtifact = TestArtifact;
 pub(crate) static OBSERVATION: TestObservation = TestObservation;
+
+pub(crate) fn semantic_contract_fingerprint() -> Result<String> {
+    ctx_semantic_index::source_backed_semantic_contract_fingerprint()
+}
+
+pub(crate) fn semantic_vector_path(data_root: &Path) -> std::path::PathBuf {
+    ctx_semantic_index::source_backed_semantic_vector_path(data_root)
+}
+
+pub(crate) fn seed_filter_unaware_semantic_state(path: &Path) -> Result<()> {
+    ctx_semantic_index::test_support::seed_filter_unaware_derived_state(path)
+}
+
+pub(crate) fn current_semantic_vector_schema_version() -> i64 {
+    ctx_semantic_index::test_support::semantic_vector_schema_version()
+}
+
+pub(crate) fn semantic_generation_is_ready_empty(path: &Path, generation: &str) -> Result<bool> {
+    let Some(store) = SemanticVectorStore::open_read_only(path)? else {
+        return Ok(false);
+    };
+    Ok(matches!(
+        store.source_backed_generation_pin_exact(generation, 0)?,
+        SourceBackedGenerationPin::ReadyEmpty
+    ))
+}
 
 pub(crate) struct TestConfig;
 pub(crate) struct SourceRefreshConfig;

--- a/crates/ctx-semantic-index/src/lib.rs
+++ b/crates/ctx-semantic-index/src/lib.rs
@@ -17,9 +17,10 @@ mod vector_store_state;
 pub use document::SemanticEventDocument;
 pub use query_index::{SemanticNotReady, SemanticQueryPin};
 pub use vector_store::{
-    semantic_core_content_is_control, source_backed_semantic_vector_path, PinnedFlatGeneration,
-    SemanticBatchEmbedder, SemanticChunkDocument, SemanticDocumentBuilder, SemanticVectorStore,
-    SourceBackedGenerationPin, SourceBackedSemanticOutcome,
+    semantic_core_content_is_control, source_backed_semantic_contract_fingerprint,
+    source_backed_semantic_vector_path, PinnedFlatGeneration, SemanticBatchEmbedder,
+    SemanticChunkDocument, SemanticDocumentBuilder, SemanticVectorStore, SourceBackedGenerationPin,
+    SourceBackedSemanticOutcome,
 };
 pub use vector_store_schema::{semantic_vector_failure_kind, SemanticVectorFailureKind};
 
@@ -95,6 +96,10 @@ pub mod test_support {
 
     pub fn semantic_vector_schema_version() -> i64 {
         super::vector_store_schema::SEMANTIC_VECTOR_SCHEMA_VERSION
+    }
+
+    pub fn seed_filter_unaware_derived_state(root: &std::path::Path) -> Result<()> {
+        super::vector_store::seed_filter_unaware_derived_state(root)
     }
 }
 

--- a/crates/ctx-semantic-index/src/query_index.rs
+++ b/crates/ctx-semantic-index/src/query_index.rs
@@ -197,17 +197,8 @@ fn semantic_candidates_with_embedding(
         ));
     }
     let active_events = pinned.stats().active_events;
-    let eligible_events = projection.len();
-    if eligible_events > active_events {
-        return Err(semantic_not_ready(
-            "semantic_projection_event_mismatch",
-            format!(
-                "Core generation {} selected {eligible_events} semantic events but the flat-F32 generation contains only {active_events}",
-                index.generation_id()
-            ),
-        ));
-    }
-    let requested_k = candidate_limit.min(eligible_events.max(1));
+    let metadata_matches = projection.len();
+    let requested_k = candidate_limit.min(metadata_matches.max(1));
     let event_is_eligible = |event_id| projection.contains(event_id);
     let search = scan_exact_generation(
         pinned,
@@ -217,16 +208,6 @@ fn semantic_candidates_with_embedding(
         Instant::now(),
     )?;
     let stats = search.stats.clone();
-    if stats.events_scored != eligible_events {
-        return Err(semantic_not_ready(
-            "semantic_projection_event_mismatch",
-            format!(
-                "flat-F32 generation scored {} of {eligible_events} metadata-eligible events from Core generation {}",
-                stats.events_scored,
-                index.generation_id()
-            ),
-        ));
-    }
     let raw_candidates = search.hits.len();
     let mut non_positive = 0_usize;
     let mut positive_hits = Vec::with_capacity(raw_candidates);
@@ -287,9 +268,9 @@ fn semantic_candidates_with_embedding(
         1,
         raw_candidates,
         candidates.len(),
-        active_events.saturating_sub(eligible_events),
+        active_events.saturating_sub(stats.events_scored),
         non_positive,
-        eligible_events,
+        stats.events_scored,
         query_embed_ms,
     );
     Ok((candidates, diagnostics))

--- a/crates/ctx-semantic-index/src/query_index/tests.rs
+++ b/crates/ctx-semantic-index/src/query_index/tests.rs
@@ -214,6 +214,147 @@ fn semantic_filter_is_applied_before_top_k_across_more_than_4096_candidates() ->
     Ok(())
 }
 
+#[test]
+fn semantic_query_scores_only_active_flat_events_that_match_core_metadata() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let source = SourceKey::derive(
+        "codex",
+        "codex_session_jsonl",
+        "session",
+        1,
+        SourceAnchor::provider_native(
+            "session-file",
+            TypedKey::utf8("semantic-active-intersection.jsonl")?,
+        )?,
+    )?;
+    let native_session_key =
+        NativeSessionKey::native_id("session", TypedKey::utf8("active-intersection")?)?;
+    let session_id = derive_session_id(SessionIdentityInput {
+        source: &source,
+        logical_session_kind: "thread",
+        native_session_key: &native_session_key,
+    })?;
+    let index_root = temp.path().join("index");
+    let mut writer = GenerationWriter::open(&index_root, WriterOptions::default())?
+        .into_writer()
+        .map_err(crate::committed_generation_recovery_error)?;
+    writer.begin_source(source.clone())?;
+    let mut active_event_id = None;
+    let mut vector_items = Vec::new();
+    for (sequence, workspace, has_vector) in [
+        (1_u64, "shared", true),
+        (2, "shared", false),
+        (3, "filtered-only", false),
+    ] {
+        let native_item_key = NativeItemKey::native_id("message", TypedKey::U64(sequence))?;
+        let event_id = derive_event_id(EventIdentityInput {
+            source: &source,
+            session_id,
+            logical_item_kind: "message",
+            native_item_key: &native_item_key,
+            subrecord_selector: None,
+        })?;
+        let mut record = CoreRecord::new_selected(
+            event_id,
+            session_id,
+            source.clone(),
+            sequence,
+            "message",
+            "semantic-active-intersection-v1",
+            format!("event {sequence}"),
+        )?;
+        record.provider_session_id = Some("active-intersection".to_owned());
+        record.native_event_id = Some(TypedKey::U64(sequence));
+        record.role = Some("user".to_owned());
+        record.content.activity = Some(CoreActivity {
+            revision: CORE_ACTIVITY_REVISION,
+            provider_call_id: None,
+            invocation: None,
+            result: None,
+            facts: vec![ProviderDeclaredFact {
+                kind: LiteralFactKind::Workspace,
+                value: workspace.to_owned(),
+            }],
+        });
+        record.validate_contract()?;
+        writer.add_core_record(record)?;
+        if has_vector {
+            active_event_id = Some(event_id.as_uuid());
+            vector_items.push((
+                super::super::vector_store::SemanticChunkDocument {
+                    event_id: event_id.as_uuid(),
+                    seq: sequence,
+                    chunk_index: 0,
+                    source_text_hash: format!("{sequence:064x}"),
+                    text: String::new(),
+                    start_char: 0,
+                    end_char: 1,
+                },
+                normalized_test_embedding(1.0, 0.0),
+            ));
+        }
+    }
+    let observation = SourceObservation::new(source.clone(), "regular-file-v1", vec![1_u8])?;
+    writer.certify_source(CertifiedSource::certify(
+        observation.clone(),
+        observation,
+        "active-intersection-parser-v1",
+        [1; 32],
+        ScannedSourceCounts {
+            complete_records: 3,
+            retained_records: 3,
+            indexed_documents: 3,
+            certified_bytes: 3,
+            ..ScannedSourceCounts::default()
+        },
+    )?)?;
+    writer.commit(|_| true)?;
+    let index = VerifiedIndex::open_pinned(&index_root)?;
+
+    let mut store = SemanticVectorStore::open(&temp.path().join("vectors"))?;
+    store.publish_chunk_replacements(&vector_items, &[])?;
+    let pinned = store
+        .flat_pin_generation()?
+        .expect("the active intersection vector must publish");
+    let mut pin = semantic_query_pin_from_readiness(
+        index.generation_id(),
+        SourceBackedGenerationPin::Ready(pinned),
+    )?;
+
+    let shared = EventSearchFilters {
+        workspace: Some("shared".to_owned()),
+        ..EventSearchFilters::default()
+    };
+    let (candidates, diagnostics) = pin.search(
+        &index,
+        &shared,
+        &normalized_test_embedding(1.0, 0.0),
+        3,
+        None,
+    )?;
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(
+        candidates[0].event.event_id.as_uuid(),
+        active_event_id.expect("active event ID")
+    );
+    assert_eq!(diagnostics["events_scored"], 1);
+
+    let filtered_only = EventSearchFilters {
+        workspace: Some("filtered-only".to_owned()),
+        ..EventSearchFilters::default()
+    };
+    let (candidates, diagnostics) = pin.search(
+        &index,
+        &filtered_only,
+        &normalized_test_embedding(1.0, 0.0),
+        3,
+        None,
+    )?;
+    assert!(candidates.is_empty());
+    assert_eq!(diagnostics["events_scored"], 0);
+    Ok(())
+}
+
 fn normalized_test_embedding(first: f32, second: f32) -> Vec<f32> {
     let mut embedding = vec![0.0; SEMANTIC_DIMENSIONS];
     let norm = first.mul_add(first, second * second).sqrt();

--- a/crates/ctx-semantic-index/src/vector_store.rs
+++ b/crates/ctx-semantic-index/src/vector_store.rs
@@ -52,9 +52,24 @@ use uuid::Uuid;
 mod source_projection;
 pub use flat_segments::PinnedFlatGeneration;
 pub use source_projection::{
-    semantic_core_content_is_control, source_backed_semantic_vector_path, SemanticBatchEmbedder,
-    SemanticDocumentBuilder, SourceBackedGenerationPin, SourceBackedSemanticOutcome,
+    semantic_core_content_is_control, source_backed_semantic_contract_fingerprint,
+    source_backed_semantic_vector_path, SemanticBatchEmbedder, SemanticDocumentBuilder,
+    SourceBackedGenerationPin, SourceBackedSemanticOutcome,
 };
 pub(super) mod control;
 pub(super) mod flat_scan;
 pub(super) mod flat_segments;
+
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) fn seed_filter_unaware_derived_state(path: &std::path::Path) -> anyhow::Result<()> {
+    const FILTER_UNAWARE_CONTROL_SCHEMA_VERSION: i64 = 5;
+
+    let connection = Connection::open(path.join(control::CONTROL_FILE))?;
+    connection.pragma_update(None, "user_version", FILTER_UNAWARE_CONTROL_SCHEMA_VERSION)?;
+    drop(connection);
+    flat_segments::seed_filter_unaware_manifest(
+        path,
+        crate::vector_store_schema::active_model_contract(),
+    )
+    .map_err(anyhow::Error::new)
+}

--- a/crates/ctx-semantic-index/src/vector_store/control.rs
+++ b/crates/ctx-semantic-index/src/vector_store/control.rs
@@ -17,7 +17,7 @@ use crate::{
 pub(super) const CONTROL_FILE: &str = "state.sqlite";
 const SEMANTIC_VECTOR_BUSY_TIMEOUT_MS: u64 = 30_000;
 const CONTROL_APPLICATION_ID: i64 = 0x4354_584D; // "CTXM"
-const CONTROL_SCHEMA_VERSION: i64 = 5;
+const CONTROL_SCHEMA_VERSION: i64 = 6;
 pub(super) const FULL_REBUILD_STATE: &str = "projection_full_rebuild_v1";
 
 pub(crate) fn open_writable(root: &Path) -> Result<Connection> {
@@ -249,7 +249,7 @@ fn user_table_count(connection: &Connection) -> Result<usize> {
 mod tests {
     use super::*;
 
-    const V5_TABLES: [&str; 3] = [
+    const V6_TABLES: [&str; 3] = [
         "semantic_dirty_events",
         "semantic_index_stats",
         "semantic_maintenance_state",
@@ -315,7 +315,7 @@ mod tests {
     fn fresh_control_database_has_no_obsolete_source_receipts_table() -> Result<()> {
         let temporary = tempfile::tempdir()?;
         let connection = open_writable(temporary.path())?;
-        assert_eq!(user_tables(&connection)?, V5_TABLES);
+        assert_eq!(user_tables(&connection)?, V6_TABLES);
         assert_eq!(
             connection.query_row(
                 "SELECT COUNT(*) FROM semantic_maintenance_state
@@ -335,9 +335,62 @@ mod tests {
         create_v4_fixture(temporary.path())?;
 
         let connection = open_writable(temporary.path())?;
-        assert_eq!(pragma_i64(&connection, "user_version")?, 5);
-        assert_eq!(user_tables(&connection)?, V5_TABLES);
-        assert_eq!(user_table_count(&connection)?, V5_TABLES.len());
+        assert_eq!(pragma_i64(&connection, "user_version")?, 6);
+        assert_eq!(user_tables(&connection)?, V6_TABLES);
+        assert_eq!(user_table_count(&connection)?, V6_TABLES.len());
+        assert_eq!(
+            connection.query_row(
+                "SELECT value FROM semantic_maintenance_state WHERE key = ?1",
+                [FULL_REBUILD_STATE],
+                |row| row.get::<_, String>(0),
+            )?,
+            "true"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn v5_filter_unaware_acknowledgement_is_discarded_for_rebuild() -> Result<()> {
+        let temporary = tempfile::tempdir()?;
+        let connection = Connection::open(control_path(temporary.path()))?;
+        connection.execute_batch(
+            r#"
+            CREATE TABLE semantic_index_stats (
+                id INTEGER PRIMARY KEY CHECK(id = 1),
+                dirty_items INTEGER NOT NULL CHECK(dirty_items >= 0)
+            );
+            INSERT INTO semantic_index_stats(id, dirty_items) VALUES (1, 0);
+            CREATE TABLE semantic_dirty_events (
+                event_id TEXT PRIMARY KEY,
+                queued_at_ms INTEGER NOT NULL,
+                priority_seq INTEGER,
+                reason TEXT NOT NULL,
+                attempts INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE semantic_maintenance_state (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            INSERT INTO semantic_maintenance_state(key, value)
+                VALUES ('core_semantic_acknowledgement_v1',
+                        '{"semantic_documents":2,"projected_documents":1}');
+            "#,
+        )?;
+        connection.pragma_update(None, "application_id", CONTROL_APPLICATION_ID)?;
+        connection.pragma_update(None, "user_version", 5)?;
+        drop(connection);
+
+        let connection = open_writable(temporary.path())?;
+        assert_eq!(pragma_i64(&connection, "user_version")?, 6);
+        assert_eq!(user_tables(&connection)?, V6_TABLES);
+        assert_eq!(
+            connection.query_row(
+                "SELECT COUNT(*) FROM semantic_maintenance_state WHERE key = ?1",
+                ["core_semantic_acknowledgement_v1"],
+                |row| row.get::<_, u64>(0),
+            )?,
+            0
+        );
         assert_eq!(
             connection.query_row(
                 "SELECT value FROM semantic_maintenance_state WHERE key = ?1",

--- a/crates/ctx-semantic-index/src/vector_store/flat_segments.rs
+++ b/crates/ctx-semantic-index/src/vector_store/flat_segments.rs
@@ -19,6 +19,8 @@ use uuid::Uuid;
 
 mod artifacts;
 mod catalog;
+#[cfg(any(test, feature = "test-support"))]
+mod legacy_fixture;
 mod manifest;
 mod pinned;
 mod recovery;
@@ -27,6 +29,8 @@ mod source_reconciliation;
 mod source_stage_log;
 mod source_staging;
 mod validation;
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) use legacy_fixture::seed_filter_unaware_manifest;
 
 use artifacts::*;
 use catalog::*;
@@ -142,6 +146,8 @@ pub(crate) struct FlatSourceReceipt {
     pub(crate) contract_fingerprint: String,
     pub(crate) semantic_policy_fingerprint: String,
     pub(crate) owned_event_count: u64,
+    #[serde(default)]
+    pub(crate) filtered_event_count: u64,
     pub(crate) owned_event_ids_hash: String,
 }
 
@@ -154,6 +160,7 @@ pub(crate) struct FlatSourceReceiptInput {
     pub(crate) core_record_accumulator: String,
     pub(crate) contract_fingerprint: String,
     pub(crate) semantic_policy_fingerprint: String,
+    pub(crate) filtered_event_count: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ctx-semantic-index/src/vector_store/flat_segments/legacy_fixture.rs
+++ b/crates/ctx-semantic-index/src/vector_store/flat_segments/legacy_fixture.rs
@@ -1,0 +1,27 @@
+use super::*;
+
+pub(crate) fn seed_filter_unaware_manifest(
+    root: &Path,
+    contract: FlatModelContract,
+) -> FlatResult<()> {
+    const FILTER_UNAWARE_FLAT_SCHEMA_VERSION: u32 = 3;
+
+    let selected = match select_manifest_any(root)? {
+        Some(selected) => selected,
+        None => {
+            let store = FlatSegmentStore::open(root, contract)?;
+            store.publish_replacement_event_chunks(&[], &[Uuid::from_u128(1)])?;
+            drop(store);
+            select_manifest_any(root)?.ok_or_else(|| {
+                FlatStoreError::Corrupt("legacy test manifest publication is missing".to_owned())
+            })?
+        }
+    };
+    let mut legacy = selected.envelope;
+    legacy.manifest.schema_version = FILTER_UNAWARE_FLAT_SCHEMA_VERSION;
+    fs::write(
+        &selected.path,
+        serde_json::to_vec(&legacy).map_err(FlatStoreError::Serialize)?,
+    )
+    .map_err(|source| io_error("write legacy test manifest", &selected.path, source))
+}

--- a/crates/ctx-semantic-index/src/vector_store/flat_segments/manifest.rs
+++ b/crates/ctx-semantic-index/src/vector_store/flat_segments/manifest.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(super) const STORE_FORMAT: &str = "ctx-flat-f32";
 pub(super) const MANIFEST_ENVELOPE_VERSION: u32 = 1;
-pub(super) const MANIFEST_SCHEMA_VERSION: u32 = 3;
+pub(super) const MANIFEST_SCHEMA_VERSION: u32 = 4;
 pub(super) const SEGMENT_FORMAT_VERSION: u32 = 2;
 pub(super) const HEADER_BYTES: usize = 4_096;
 pub(super) const HEADER_BYTES_U64: u64 = HEADER_BYTES as u64;

--- a/crates/ctx-semantic-index/src/vector_store/flat_segments/source_compaction.rs
+++ b/crates/ctx-semantic-index/src/vector_store/flat_segments/source_compaction.rs
@@ -108,10 +108,11 @@ fn build_streamed_receipt(
             )));
         }
     }
+    let accounted_events = owned_event_count.checked_add(input.filtered_event_count);
     if input.source_identity_digest != source.source_identity_digest
         || input.source_reconciliation_id != source.source_reconciliation_id
         || input.source_reconciliation_id.is_empty()
-        || owned_event_count > input.semantic_eligible_documents
+        || accounted_events != Some(input.semantic_eligible_documents)
     {
         return Err(FlatStoreError::InvalidInput(
             "source receipt does not match its staged Core aggregate".to_owned(),
@@ -126,6 +127,7 @@ fn build_streamed_receipt(
         contract_fingerprint: input.contract_fingerprint.clone(),
         semantic_policy_fingerprint: input.semantic_policy_fingerprint.clone(),
         owned_event_count,
+        filtered_event_count: input.filtered_event_count,
         owned_event_ids_hash: encode_hex(&digest.finalize()),
     })
 }

--- a/crates/ctx-semantic-index/src/vector_store/flat_segments/tests.rs
+++ b/crates/ctx-semantic-index/src/vector_store/flat_segments/tests.rs
@@ -58,6 +58,41 @@ fn visible_chunks(pinned: &PinnedFlatGeneration) -> Vec<(Uuid, u64, u32, Vec<f32
 }
 
 #[test]
+fn filter_unaware_manifest_schema_is_rebuilt_as_empty_derived_state() -> FlatResult<()> {
+    let temporary = tempfile::tempdir()
+        .map_err(|source| io_error("create test directory", Path::new("."), source))?;
+    let store = FlatSegmentStore::open(temporary.path(), contract())?;
+    store.publish_replacement_event_chunks(
+        &[replacement(
+            Uuid::from_u128(1),
+            1,
+            1,
+            vec![chunk(0, [1.0, 0.0, 0.0, 0.0])],
+        )],
+        &[],
+    )?;
+    let selected = select_manifest_any(temporary.path())?
+        .ok_or_else(|| FlatStoreError::Corrupt("test manifest is missing".to_owned()))?;
+    let mut legacy = selected.envelope;
+    legacy.manifest.schema_version = 3;
+    fs::write(
+        &selected.path,
+        serde_json::to_vec(&legacy).map_err(FlatStoreError::Serialize)?,
+    )
+    .map_err(|source| io_error("write legacy test manifest", &selected.path, source))?;
+    drop(store);
+
+    let rebuilt = FlatSegmentStore::open(temporary.path(), contract())?;
+    assert!(rebuilt.recovery_report().model_contract_reset);
+    let pin = rebuilt
+        .pin_generation()?
+        .ok_or_else(|| FlatStoreError::Corrupt("rebuilt empty manifest is missing".to_owned()))?;
+    assert_eq!(pin.stats().active_events, 0);
+    assert_eq!(pin.stats().active_chunks, 0);
+    Ok(())
+}
+
+#[test]
 fn replacement_tombstone_and_read_only_enumeration_are_exact() -> FlatResult<()> {
     let temporary = tempfile::tempdir()
         .map_err(|source| io_error("create test directory", Path::new("."), source))?;

--- a/crates/ctx-semantic-index/src/vector_store/flat_segments/validation.rs
+++ b/crates/ctx-semantic-index/src/vector_store/flat_segments/validation.rs
@@ -336,9 +336,12 @@ pub(super) fn validate_manifest(
             ));
         }
         if let Some(receipt) = &snapshot.receipt {
+            let accounted_events = receipt
+                .owned_event_count
+                .checked_add(receipt.filtered_event_count);
             if receipt.source_identity_digest != snapshot.source_identity_digest
                 || receipt.source_reconciliation_id.is_empty()
-                || receipt.owned_event_count > receipt.semantic_eligible_documents
+                || accounted_events != Some(receipt.semantic_eligible_documents)
                 || decode_sha256(&receipt.core_record_accumulator).is_none()
                 || decode_sha256(&receipt.contract_fingerprint).is_none()
                 || decode_sha256(&receipt.semantic_policy_fingerprint).is_none()

--- a/crates/ctx-semantic-index/src/vector_store/source_projection.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection.rs
@@ -33,8 +33,8 @@ mod state;
 #[cfg(test)]
 use manifest::SOURCE_CONTRACT_VERSION;
 use manifest::{
-    source_contract_fingerprint_with_authority, validate_generation, validate_page,
-    validate_resolved_document, SourceProjectionFrontier, SourceTraversalPhase,
+    source_contract_fingerprint, source_contract_fingerprint_with_authority, validate_generation,
+    validate_page, validate_resolved_document, SourceProjectionFrontier, SourceTraversalPhase,
     SOURCE_INPUT_LEXICAL_SCHEMA_VERSION,
 };
 use state::{
@@ -47,6 +47,10 @@ const SEMANTIC_DIRECTORY: &str = "semantic";
 
 pub fn source_backed_semantic_vector_path(data_root: &Path) -> PathBuf {
     data_root.join(SEARCH_DIRECTORY).join(SEMANTIC_DIRECTORY)
+}
+
+pub fn source_backed_semantic_contract_fingerprint() -> Result<String> {
+    source_contract_fingerprint()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -614,6 +618,7 @@ impl SemanticVectorStore {
         if resume == FlatSourceStageResume::Restarted {
             frontier.processed_source_documents = 0;
             frontier.processed_source_semantic_documents = 0;
+            frontier.processed_source_filtered_documents = 0;
             frontier.after_identity = None;
             frontier.source_scan_complete = false;
             frontier.flat_staging = None;
@@ -647,6 +652,7 @@ impl SemanticVectorStore {
             ..SourceBackedSemanticOutcome::default()
         };
         let mut semantic_records = 0_u64;
+        let mut filtered_records = 0_u64;
         let mut replacements = Vec::new();
         let mut resolved = Vec::new();
         let mut retire = Vec::new();
@@ -677,6 +683,11 @@ impl SemanticVectorStore {
 
             let Some(document) = builder.build_document(record)? else {
                 retire.push(record.event_id.as_uuid());
+                filtered_records = filtered_records.checked_add(1).ok_or_else(|| {
+                    SemanticVectorStoreError::reset_required(
+                        "source-backed semantic filtered count overflowed",
+                    )
+                })?;
                 outcome.records_filtered = outcome.records_filtered.saturating_add(1);
                 continue;
             };
@@ -684,6 +695,11 @@ impl SemanticVectorStore {
             let source_text = semantic_source_text(&document.text);
             if semantic_core_content_is_control(&source_text) {
                 retire.push(record.event_id.as_uuid());
+                filtered_records = filtered_records.checked_add(1).ok_or_else(|| {
+                    SemanticVectorStoreError::reset_required(
+                        "source-backed semantic filtered count overflowed",
+                    )
+                })?;
                 outcome.records_filtered = outcome.records_filtered.saturating_add(1);
                 continue;
             }
@@ -737,6 +753,14 @@ impl SemanticVectorStore {
                     "source-backed semantic source candidate count overflowed",
                 )
             })?;
+        let processed_filtered_documents = frontier
+            .processed_source_filtered_documents
+            .checked_add(filtered_records)
+            .ok_or_else(|| {
+                SemanticVectorStoreError::reset_required(
+                    "source-backed semantic filtered count overflowed",
+                )
+            })?;
         let metadata_updates = resolved
             .iter()
             .map(|document| {
@@ -769,6 +793,7 @@ impl SemanticVectorStore {
             self.publish_source_page(&replacements, &metadata_updates, &retire, &existing_lookup)?;
         frontier.processed_source_documents = processed_documents;
         frontier.processed_source_semantic_documents = processed_semantic_documents;
+        frontier.processed_source_filtered_documents = processed_filtered_documents;
         if let Some(last) = page.records.last() {
             frontier.after_identity = Some(last.event_id.encode_canonical()?.to_vec());
         }
@@ -816,6 +841,7 @@ impl SemanticVectorStore {
         if resume == FlatSourceStageResume::Restarted {
             frontier.processed_source_documents = 0;
             frontier.processed_source_semantic_documents = 0;
+            frontier.processed_source_filtered_documents = 0;
             frontier.after_identity = None;
             frontier.source_scan_complete = false;
             frontier.flat_staging = None;
@@ -836,6 +862,7 @@ impl SemanticVectorStore {
                 core_record_accumulator: source.aggregate.core_record_accumulator().to_owned(),
                 contract_fingerprint: frontier.contract_fingerprint.clone(),
                 semantic_policy_fingerprint: frontier.semantic_policy_fingerprint.clone(),
+                filtered_event_count: frontier.processed_source_filtered_documents,
             }))
             .map_err(anyhow::Error::new)?;
         #[cfg(test)]

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/manifest.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/manifest.rs
@@ -15,7 +15,7 @@ use crate::{
 
 pub(super) const SOURCE_FRONTIER_STATE: &str = "core_semantic_frontier_v1";
 pub(super) const SOURCE_ACKNOWLEDGEMENT_STATE: &str = "core_semantic_acknowledgement_v1";
-pub(super) const SOURCE_CONTRACT_VERSION: u16 = 12;
+pub(super) const SOURCE_CONTRACT_VERSION: u16 = 13;
 const SOURCE_CONTRACT_DOMAIN: &[u8] = b"ctx-source-backed-semantic-contract-v1\0";
 const SOURCE_BUILD_DOMAIN: &[u8] = b"ctx-source-backed-semantic-build-v1\0";
 pub(super) const SOURCE_INPUT_LEXICAL_SCHEMA_VERSION: u32 = 22;
@@ -35,6 +35,7 @@ pub(super) struct SourceProjectionFrontier {
     pub(super) active_source_indexed_documents: u64,
     pub(super) processed_source_documents: u64,
     pub(super) processed_source_semantic_documents: u64,
+    pub(super) processed_source_filtered_documents: u64,
     pub(super) after_identity: Option<Vec<u8>>,
     pub(super) source_scan_complete: bool,
     pub(super) removing_source: bool,
@@ -64,6 +65,7 @@ pub(super) struct SourceProjectionAcknowledgement {
     pub(super) consumer_build_id: String,
     pub(super) semantic_documents: u64,
     pub(super) projected_documents: u64,
+    pub(super) filtered_documents: u64,
     pub(super) source_receipt_count: u64,
     pub(super) source_receipts_hash: String,
     #[serde(default)]

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/state.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/state.rs
@@ -48,7 +48,10 @@ pub(super) fn source_receipt_matches(
         && receipt.core_record_accumulator == source.aggregate.core_record_accumulator()
         && receipt.contract_fingerprint == contract_fingerprint
         && receipt.semantic_policy_fingerprint == policy_fingerprint
-        && receipt.owned_event_count <= receipt.semantic_eligible_documents
+        && receipt
+            .owned_event_count
+            .checked_add(receipt.filtered_event_count)
+            == Some(receipt.semantic_eligible_documents)
 }
 
 impl SemanticVectorStore {
@@ -175,11 +178,12 @@ impl SemanticVectorStore {
     pub(super) fn source_receipts_summary(
         &self,
         states: &SourceProjectionStates,
-    ) -> Result<(u64, String, u64, u64)> {
+    ) -> Result<(u64, String, u64, u64, u64)> {
         let mut digest = Sha256::new();
         digest.update(RECEIPT_SET_DOMAIN);
         let mut projected_documents = 0_u64;
         let mut semantic_documents = 0_u64;
+        let mut filtered_documents = 0_u64;
         let mut receipt_count = 0_u64;
         for receipt in states.values() {
             let receipt = receipt.as_ref().ok_or_else(|| {
@@ -206,12 +210,20 @@ impl SemanticVectorStore {
                         "semantic source candidate count overflowed",
                     )
                 })?;
+            filtered_documents = filtered_documents
+                .checked_add(receipt.filtered_event_count)
+                .ok_or_else(|| {
+                    SemanticVectorStoreError::reset_required(
+                        "semantic filtered receipt count overflowed",
+                    )
+                })?;
         }
         Ok((
             receipt_count,
             hex(&digest.finalize()),
             semantic_documents,
             projected_documents,
+            filtered_documents,
         ))
     }
 
@@ -224,13 +236,23 @@ impl SemanticVectorStore {
         if states.values().any(Option::is_none) {
             return Ok(false);
         }
-        let (receipt_count, receipt_hash, semantic_documents, projected_documents) =
-            self.source_receipts_summary(&states)?;
+        let (
+            receipt_count,
+            receipt_hash,
+            semantic_documents,
+            projected_documents,
+            filtered_documents,
+        ) = self.source_receipts_summary(&states)?;
         let stats = self.flat.active_stats().map_err(anyhow::Error::new)?;
         Ok(acknowledgement.source_receipt_count == receipt_count
             && acknowledgement.source_receipts_hash == receipt_hash
             && acknowledgement.semantic_documents == semantic_documents
             && acknowledgement.projected_documents == projected_documents
+            && acknowledgement.filtered_documents == filtered_documents
+            && acknowledgement
+                .projected_documents
+                .checked_add(acknowledgement.filtered_documents)
+                == Some(acknowledgement.semantic_documents)
             && acknowledgement.flat_active_events == stats.active_events as u64
             && acknowledgement.flat_active_chunks == stats.active_chunks as u64
             && self
@@ -267,11 +289,16 @@ impl SemanticVectorStore {
             .into());
         }
 
-        let (source_receipt_count, source_receipts_hash, semantic_documents, receipt_documents) =
-            self.source_receipts_summary(states)?;
-        if receipt_documents > semantic_documents {
+        let (
+            source_receipt_count,
+            source_receipts_hash,
+            semantic_documents,
+            receipt_documents,
+            filtered_documents,
+        ) = self.source_receipts_summary(states)?;
+        if receipt_documents.checked_add(filtered_documents) != Some(semantic_documents) {
             return Err(SemanticVectorStoreError::reset_required(
-                "semantic source receipts exceed metadata-eligible Core records",
+                "semantic source receipts do not account for every pre-filter Core candidate",
             )
             .into());
         }
@@ -293,6 +320,7 @@ impl SemanticVectorStore {
             consumer_build_id: frontier.consumer_build_id.clone(),
             semantic_documents,
             projected_documents: receipt_documents,
+            filtered_documents,
             source_receipt_count,
             source_receipts_hash,
             flat_generation: stats.generation,
@@ -405,13 +433,22 @@ impl SemanticVectorStore {
         if states.values().any(Option::is_none) {
             return Ok(None);
         }
-        let (receipt_count, receipt_hash, semantic_documents, projected_documents) =
-            self.source_receipts_summary(&states)?;
+        let (
+            receipt_count,
+            receipt_hash,
+            semantic_documents,
+            projected_documents,
+            filtered_documents,
+        ) = self.source_receipts_summary(&states)?;
         if acknowledgement.source_receipt_count != receipt_count
             || acknowledgement.source_receipts_hash != receipt_hash
             || acknowledgement.semantic_documents != semantic_documents
             || acknowledgement.projected_documents != projected_documents
-            || acknowledgement.projected_documents > acknowledgement.semantic_documents
+            || acknowledgement.filtered_documents != filtered_documents
+            || acknowledgement
+                .projected_documents
+                .checked_add(acknowledgement.filtered_documents)
+                != Some(acknowledgement.semantic_documents)
         {
             return Ok(None);
         }
@@ -489,6 +526,7 @@ impl SemanticVectorStore {
             active_source_indexed_documents: 0,
             processed_source_documents: 0,
             processed_source_semantic_documents: 0,
+            processed_source_filtered_documents: 0,
             after_identity: None,
             source_scan_complete: false,
             removing_source: false,
@@ -527,6 +565,7 @@ impl SemanticVectorStore {
         frontier.active_source_indexed_documents = source.aggregate.indexed_documents();
         frontier.processed_source_documents = 0;
         frontier.processed_source_semantic_documents = 0;
+        frontier.processed_source_filtered_documents = 0;
         frontier.after_identity = None;
         frontier.source_scan_complete = false;
         frontier.removing_source = false;
@@ -546,6 +585,7 @@ impl SemanticVectorStore {
         frontier.active_source_indexed_documents = 0;
         frontier.processed_source_documents = 0;
         frontier.processed_source_semantic_documents = 0;
+        frontier.processed_source_filtered_documents = 0;
         frontier.after_identity = None;
         frontier.source_scan_complete = true;
         frontier.removing_source = true;
@@ -610,6 +650,7 @@ fn frontier_from_acknowledgement(
         active_source_indexed_documents: 0,
         processed_source_documents: 0,
         processed_source_semantic_documents: 0,
+        processed_source_filtered_documents: 0,
         after_identity: None,
         source_scan_complete: false,
         removing_source: false,
@@ -638,6 +679,7 @@ pub(super) fn clear_active_source(frontier: &mut SourceProjectionFrontier) {
     frontier.active_source_indexed_documents = 0;
     frontier.processed_source_documents = 0;
     frontier.processed_source_semantic_documents = 0;
+    frontier.processed_source_filtered_documents = 0;
     frontier.after_identity = None;
     frontier.source_scan_complete = false;
     frontier.removing_source = false;

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests.rs
@@ -18,11 +18,13 @@ use super::*;
 use crate::vector_store_search::scan_exact_generation;
 
 mod content;
+mod filter_accounting;
 mod policy_rebuild;
 mod proportionality;
 mod recovery;
 
 const TAIL_TOKEN: &str = "semantic-tail-token-7f0d";
+const EMPTY_DOCUMENT_TOKEN: &str = "semantic-empty-document-fixture-7f0d";
 
 #[derive(Default)]
 struct CoreBuilder {
@@ -46,7 +48,7 @@ impl SemanticDocumentBuilder for CoreBuilder {
         }
         let text = ctx_history_index::project_body_search(record.core_record.content.clone())?
             .unwrap_or_default();
-        if text.is_empty() {
+        if text.is_empty() || text.contains(EMPTY_DOCUMENT_TOKEN) {
             return Ok(None);
         }
         Ok(Some(SemanticEventDocument {
@@ -481,7 +483,7 @@ fn semantic_generation_uses_exact_per_source_core_aggregates_without_candidate_t
         &[(0, bodies("stable", 3)), (1, bodies("changed", 2))],
     )?;
     let generation = SourceBackedSemanticGeneration::from_verified_index(&index)?;
-    assert_eq!(SOURCE_CONTRACT_VERSION, 12);
+    assert_eq!(SOURCE_CONTRACT_VERSION, 13);
     assert_eq!(SOURCE_INPUT_LEXICAL_SCHEMA_VERSION, 22);
     assert_eq!(index.semantic_eligible_event_count()?, 5);
     assert_eq!(generation.core_generation_id, index.generation_id());

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/filter_accounting.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/filter_accounting.rs
@@ -1,0 +1,267 @@
+use super::*;
+
+#[test]
+fn mixed_controls_and_empty_content_publish_exact_filter_accounting() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let index = fixture.publish(
+        "mixed-content-filters",
+        &[(
+            0,
+            vec![
+                "ordinary semantic question".to_owned(),
+                "<environment_context>private control</environment_context>".to_owned(),
+                "Warning: The maximum number of unified exec processes was reached".to_owned(),
+                EMPTY_DOCUMENT_TOKEN.to_owned(),
+            ],
+        )],
+    )?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let outcome = reconcile_all(
+        &mut store,
+        &index,
+        &mut CoreBuilder::default(),
+        &mut MarkerEmbedder::default(),
+    )?;
+
+    assert_eq!(index.semantic_eligible_event_count()?, 4);
+    assert_eq!(outcome.records_embedded, 1);
+    assert_eq!(outcome.records_filtered, 3);
+    let acknowledgement = store
+        .source_acknowledgement()?
+        .ok_or_else(|| anyhow!("mixed filter projection was not acknowledged"))?;
+    assert_eq!(acknowledgement.semantic_documents, 4);
+    assert_eq!(acknowledgement.projected_documents, 1);
+    assert_eq!(acknowledgement.filtered_documents, 3);
+    assert_eq!(
+        acknowledgement
+            .projected_documents
+            .checked_add(acknowledgement.filtered_documents),
+        Some(acknowledgement.semantic_documents)
+    );
+    let receipt = store
+        .flat
+        .source_states()
+        .map_err(anyhow::Error::new)?
+        .into_iter()
+        .next()
+        .and_then(|state| state.receipt)
+        .ok_or_else(|| anyhow!("mixed filter source receipt is missing"))?;
+    assert_eq!(receipt.semantic_eligible_documents, 4);
+    assert_eq!(receipt.owned_event_count, 1);
+    assert_eq!(receipt.filtered_event_count, 3);
+    assert!(matches!(
+        store.source_backed_generation_pin_exact(index.generation_id(), 4)?,
+        SourceBackedGenerationPin::Ready(_)
+    ));
+
+    let flat_generation = store
+        .flat_pin_generation()?
+        .ok_or_else(|| anyhow!("mixed filter Flat generation is missing"))?
+        .generation();
+    let unchanged = fixture.publish(
+        "mixed-content-filters-noop",
+        &[(
+            0,
+            vec![
+                "ordinary semantic question".to_owned(),
+                "<environment_context>private control</environment_context>".to_owned(),
+                "Warning: The maximum number of unified exec processes was reached".to_owned(),
+                EMPTY_DOCUMENT_TOKEN.to_owned(),
+            ],
+        )],
+    )?;
+    let no_op = reconcile_all(
+        &mut store,
+        &unchanged,
+        &mut CoreBuilder::default(),
+        &mut MarkerEmbedder::default(),
+    )?;
+    assert_eq!(no_op.records_decoded, 0);
+    assert_eq!(
+        store
+            .flat_pin_generation()?
+            .ok_or_else(|| anyhow!("no-op lost the Flat generation"))?
+            .generation(),
+        flat_generation
+    );
+    let acknowledgement = store
+        .source_acknowledgement()?
+        .ok_or_else(|| anyhow!("no-op acknowledgement is missing"))?;
+    assert_eq!(acknowledgement.semantic_documents, 4);
+    assert_eq!(acknowledgement.projected_documents, 1);
+    assert_eq!(acknowledgement.filtered_documents, 3);
+    Ok(())
+}
+
+#[test]
+fn all_filtered_generation_is_ready_empty_with_exact_accounting() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let index = fixture.publish(
+        "all-filtered",
+        &[(
+            0,
+            vec![
+                "<environment_context>control</environment_context>".to_owned(),
+                "<turn_aborted>control</turn_aborted>".to_owned(),
+                EMPTY_DOCUMENT_TOKEN.to_owned(),
+            ],
+        )],
+    )?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let outcome = reconcile_all(
+        &mut store,
+        &index,
+        &mut CoreBuilder::default(),
+        &mut MarkerEmbedder::default(),
+    )?;
+
+    assert_eq!(outcome.records_embedded, 0);
+    assert_eq!(outcome.records_filtered, 3);
+    assert_eq!(active_events(&store)?, 0);
+    let acknowledgement = store
+        .source_acknowledgement()?
+        .ok_or_else(|| anyhow!("all-filtered projection was not acknowledged"))?;
+    assert_eq!(acknowledgement.semantic_documents, 3);
+    assert_eq!(acknowledgement.projected_documents, 0);
+    assert_eq!(acknowledgement.filtered_documents, 3);
+    assert!(matches!(
+        store.source_backed_generation_pin_exact(index.generation_id(), 3)?,
+        SourceBackedGenerationPin::ReadyEmpty
+    ));
+    Ok(())
+}
+
+#[test]
+fn unaccounted_source_drop_cannot_publish_a_receipt() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let index = fixture.publish(
+        "unaccounted-drop",
+        &[(
+            0,
+            vec![
+                "ordinary semantic question".to_owned(),
+                "<subagent_notification>control</subagent_notification>".to_owned(),
+            ],
+        )],
+    )?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    store.flat.fail_after_source_frontier_commit_once();
+    let error = store
+        .reconcile_source_backed_index(
+            &index,
+            &mut CoreBuilder::default(),
+            &mut MarkerEmbedder::default(),
+        )
+        .expect_err("fault must stop before the source receipt is published");
+    assert!(error
+        .to_string()
+        .contains("injected failure after semantic source frontier commit"));
+    let mut frontier = store
+        .source_frontier()?
+        .ok_or_else(|| anyhow!("faulted source lost its durable frontier"))?;
+    assert_eq!(frontier.processed_source_semantic_documents, 2);
+    assert_eq!(frontier.processed_source_filtered_documents, 1);
+    frontier.processed_source_filtered_documents = 0;
+    store.store_source_frontier(&frontier)?;
+
+    let error = store
+        .reconcile_source_backed_index(
+            &index,
+            &mut CoreBuilder::default(),
+            &mut MarkerEmbedder::default(),
+        )
+        .expect_err("an unaccounted candidate must fail source finalization");
+    assert!(error
+        .to_string()
+        .contains("source receipt does not match its staged Core aggregate"));
+    assert!(store.source_acknowledgement()?.is_none());
+    Ok(())
+}
+
+#[test]
+fn corrupted_filter_acknowledgement_is_not_query_ready() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let index = fixture.publish(
+        "corrupt-filter-ack",
+        &[(
+            0,
+            vec![
+                "ordinary semantic question".to_owned(),
+                "<environment_context>control</environment_context>".to_owned(),
+            ],
+        )],
+    )?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    reconcile_all(
+        &mut store,
+        &index,
+        &mut CoreBuilder::default(),
+        &mut MarkerEmbedder::default(),
+    )?;
+    let mut acknowledgement = store
+        .source_acknowledgement()?
+        .ok_or_else(|| anyhow!("projection acknowledgement is missing"))?;
+    acknowledgement.filtered_documents = 0;
+    store.conn.execute(
+        "UPDATE semantic_maintenance_state SET value = ?1 WHERE key = ?2",
+        rusqlite::params![
+            serde_json::to_string(&acknowledgement)?,
+            super::super::manifest::SOURCE_ACKNOWLEDGEMENT_STATE
+        ],
+    )?;
+
+    assert!(matches!(
+        store.source_backed_generation_pin_exact(index.generation_id(), 2)?,
+        SourceBackedGenerationPin::NotReady
+    ));
+    Ok(())
+}
+
+#[test]
+fn vector_reuse_preserves_intentional_filter_accounting() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let records = vec![
+        (1, "same semantic body".to_owned()),
+        (
+            2,
+            "<environment_context>same control body</environment_context>".to_owned(),
+        ),
+    ];
+    let resequenced = vec![
+        (91, "same semantic body".to_owned()),
+        (
+            92,
+            "<environment_context>same control body</environment_context>".to_owned(),
+        ),
+    ];
+    let initial = fixture.publish_with_event_sequences("reuse-filter-a", &[(0, records)])?;
+    let target = fixture.publish_with_event_sequences("reuse-filter-b", &[(0, resequenced)])?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    reconcile_all(
+        &mut store,
+        &initial,
+        &mut CoreBuilder::default(),
+        &mut MarkerEmbedder::default(),
+    )?;
+
+    let outcome = reconcile_all(
+        &mut store,
+        &target,
+        &mut CoreBuilder::default(),
+        &mut MarkerEmbedder::default(),
+    )?;
+    assert_eq!(outcome.records_reused, 1);
+    assert_eq!(outcome.records_embedded, 0);
+    assert_eq!(outcome.records_filtered, 1);
+    let acknowledgement = store
+        .source_acknowledgement()?
+        .ok_or_else(|| anyhow!("reuse projection acknowledgement is missing"))?;
+    assert_eq!(acknowledgement.semantic_documents, 2);
+    assert_eq!(acknowledgement.projected_documents, 1);
+    assert_eq!(acknowledgement.filtered_documents, 1);
+    assert!(matches!(
+        store.source_backed_generation_pin_exact(target.generation_id(), 2)?,
+        SourceBackedGenerationPin::Ready(_)
+    ));
+    Ok(())
+}

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/generation_recovery.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/generation_recovery.rs
@@ -103,7 +103,23 @@ fn full_compaction_preserves_receipts_and_readiness_exactly() -> Result<()> {
     let fixture = Fixture::new(2)?;
     let index = fixture.publish(
         "full-compaction",
-        &[(0, bodies("first", 3)), (1, bodies("second", 2))],
+        &[
+            (
+                0,
+                vec![
+                    "first projected".to_owned(),
+                    "<turn_aborted>first filtered</turn_aborted>".to_owned(),
+                    "first projected again".to_owned(),
+                ],
+            ),
+            (
+                1,
+                vec![
+                    "second projected".to_owned(),
+                    EMPTY_DOCUMENT_TOKEN.to_owned(),
+                ],
+            ),
+        ],
     )?;
     let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
     reconcile_all(
@@ -112,10 +128,22 @@ fn full_compaction_preserves_receipts_and_readiness_exactly() -> Result<()> {
         &mut CoreBuilder::default(),
         &mut MarkerEmbedder::default(),
     )?;
+    let acknowledgement = store
+        .source_acknowledgement()?
+        .ok_or_else(|| anyhow!("pre-compaction acknowledgement is missing"))?;
+    assert_eq!(acknowledgement.semantic_documents, 5);
+    assert_eq!(acknowledgement.projected_documents, 3);
+    assert_eq!(acknowledgement.filtered_documents, 2);
     let before = projection_snapshot(&store)?;
     let compacted = store.flat.compact().map_err(anyhow::Error::new)?;
     assert!(compacted.published);
     assert_eq!(projection_snapshot(&store)?, before);
+    assert_eq!(
+        store
+            .source_acknowledgement()?
+            .ok_or_else(|| anyhow!("post-compaction acknowledgement is missing"))?,
+        acknowledgement
+    );
     assert!(matches!(
         store.source_backed_generation_pin_exact(index.generation_id(), 5)?,
         SourceBackedGenerationPin::Ready(_)

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/policy_rebuild.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/policy_rebuild.rs
@@ -120,7 +120,7 @@ fn control_reset_retires_unowned_flat_vectors_before_rebuild() -> Result<()> {
 
     drop(store);
     let control = rusqlite::Connection::open(fixture.semantic_path.join("state.sqlite"))?;
-    control.pragma_update(None, "user_version", 2)?;
+    control.pragma_update(None, "user_version", 5)?;
     drop(control);
     let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
     builder.calls.clear();

--- a/crates/ctx-semantic-index/src/vector_store_schema.rs
+++ b/crates/ctx-semantic-index/src/vector_store_schema.rs
@@ -12,7 +12,7 @@ use super::vector_store::{
     SemanticVectorStore,
 };
 
-pub(super) const SEMANTIC_VECTOR_SCHEMA_VERSION: i64 = 5;
+pub(super) const SEMANTIC_VECTOR_SCHEMA_VERSION: i64 = 6;
 pub(super) const SEMANTIC_VECTOR_BACKEND_FLAT_F32: &str = "flat-f32";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/docs/contracts/json.md
+++ b/docs/contracts/json.md
@@ -153,7 +153,7 @@ Wait returns one object with `schema_version`, `status` (`ready`, `blocked`, or
 including daemon and supervisor diagnostics.
 
 Index snapshots expose the reduced
-`semantic.{status,reason,enabled,coverage.{searchable_items,embedded_items,embedded_chunks}}`
+`semantic.{status,reason,enabled,coverage.{candidate_items,searchable_items,embedded_items,filtered_items,embedded_chunks}}`
 shape and `daemon.{status,running,jobs.semantic_index}`. The complete semantic
 and daemon fields below describe `ctx status --format json`, not index
 snapshots.
@@ -161,9 +161,17 @@ snapshots.
 `semantic.status` is `disabled`, `pending`, `ready`, or `unavailable`.
 `semantic.flat_f32` reports the source-backed projection and can include its
 `status`, `reason`, `path`, Core and flat generation identity, semantic document
-count, active event/chunk/vector-byte counts, and `last_error`. Optional
-`semantic.catch_up` retains the latest semantic-index job receipt. Live worker
-state and coverage are reported under `daemon.jobs.semantic_index` below.
+count, projected and intentionally filtered document counts, active
+event/chunk/vector-byte counts, and `last_error`. For a ready generation,
+`semantic_documents = projected_documents + filtered_documents` and
+`projected_documents = active_events`. These document counters, and the index
+snapshot candidate/searchable/embedded/filtered counters derived from them,
+are integers in the exact inclusive range `0..9007199254740991`; a larger
+internal count makes semantic status unavailable instead of emitting an unsafe
+JSON number. Optional `semantic.catch_up` retains the latest semantic-index job
+receipt, including its `source_contract_fingerprint` when produced by current
+daemon maintenance. Live worker state and coverage are reported under
+`daemon.jobs.semantic_index` below.
 
 `daemon` reports the ctx-owned background coordinator state. Fields listed as
 nullable may be omitted when unavailable:
@@ -842,6 +850,13 @@ Semantic-only unavailability is a typed command error, not a successful
 `searchable_items`, `indexed_now`, and `dirty_items` when known. Coverage counts
 are numbers when present; null count fields are pruned from public SDK fixtures
 and typed SDK shapes.
+
+Index readiness coverage uses `candidate_items` for the pre-content-filter Core
+population, `filtered_items` for intentional semantic content filtering, and
+`searchable_items`/`embedded_items` for acknowledged active flat-F32 events.
+Ready coverage therefore satisfies
+`candidate_items = searchable_items + filtered_items` and
+`searchable_items = embedded_items`.
 
 The SDK `agent-history-v1` contract keeps schema version 1 and normalizes the
 resolved filter as `search.filters.contentScope`, with the same exact four

--- a/docs/search.md
+++ b/docs/search.md
@@ -184,7 +184,11 @@ events.
 `search/semantic`. Semantic projection enumerates eligible imported Core
 records, filters control messages, then chunks and embeds them. The semantic
 generation stores vectors, hashes, offsets, and generation binding rather than
-plaintext transcript chunks.
+plaintext transcript chunks. Readiness accounts for all pre-content-filter Core
+candidates: each candidate is either an acknowledged active flat-F32 event or
+an intentionally filtered event. Metadata filters are then applied to the
+acknowledged active flat-F32 events; a query does not require intentionally
+filtered Core matches to have vectors.
 
 `--backend hybrid` blends lexical and semantic evidence with reciprocal-rank
 fusion. `--semantic-weight` controls the semantic contribution and defaults to

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -340,6 +340,17 @@ drained, and otherwise falls back to lexical. Explicit semantic searches may ask
 the daemon query service to embed the query from an already-cached local model
 and read partial existing semantic generation coverage, but they do not
 download a model or write semantic catch-up work during search.
+Semantic coverage is exact across the content-filter boundary. Persisted
+flat-F32 source receipts account for every pre-filter Core candidate as either
+an active projected event or an intentionally filtered event. Query metadata
+filters score only the intersection with active projected events. Derived
+semantic state from an older filter-unaware receipt contract is discarded and
+rebuilt from the current committed Core generation; provider history is not
+needed for that rebuild. In automatic indexing mode, the persistent scheduler
+binds ready semantic jobs to the current source-projection contract fingerprint.
+A missing or stale fingerprint forces writable maintenance even when the Core
+generation is unchanged, so opening the derived store performs the reset and
+rebuild. Manual indexing remains passive and performs no scheduled migration.
 Explicit imports may best-effort mark recent semantic-eligible items dirty in
 the semantic generation when it already exists; this does not create semantic
 storage, initialize the model, or embed text.


### PR DESCRIPTION
Summary
- persist intentional source-projection filter counts and enforce selected = projected + filtered
- intersect semantic queries with the current Core match set
- rebuild stale ready state and expose bounded truthful readiness counters

Validation
- affected test selection: 63 passed; one unrelated concurrency failure passed on immediate isolated rerun
- independent final review: merge-ready, no findings

Fixes #645