### PR TITLE
fix(upgrade): allow retained Windows runtime extraction

### DIFF
--- a/crates/ctx-upgrade-engine/BUILD.bazel
+++ b/crates/ctx-upgrade-engine/BUILD.bazel
@@ -148,6 +148,7 @@ ctx_binary_contract_test(
         "CTX_ORDINARY_RELEASE_BINARY": "$(rootpath //crates/ctx-cli:ctx)",
     },
     extra_compile_data = [
+        "src/upgrade/install/archive.rs",
         "src/upgrade/install.rs",
         "//:upgrade_extractor_contract",
     ],

--- a/crates/ctx-upgrade-engine/src/upgrade/download.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/download.rs
@@ -207,13 +207,19 @@ impl DownloadedArtifact {
     }
 
     fn open_cached(path: &Path, expected_sha256: &str) -> Result<Option<Self>> {
-        let file = match open_private_file(path) {
+        let file = match open_retained_private_file(path) {
             Ok(file) => file,
             Err(error)
                 if error
                     .downcast_ref::<std::io::Error>()
                     .is_some_and(|error| error.kind() == std::io::ErrorKind::NotFound) =>
             {
+                return Ok(None);
+            }
+            Err(error) if cached_artifact_has_active_writer(&error) => {
+                // A concurrent publisher still owns write access. Treat the
+                // cache as unavailable; the separately verified download path
+                // remains authoritative and publication is create-new.
                 return Ok(None);
             }
             Err(error) => {
@@ -466,31 +472,76 @@ fn remove_file_if_identity(path: &Path, expected: &FileIdentity) {
 }
 
 fn open_private_file(path: &Path) -> Result<fs::File> {
-    #[cfg(unix)]
-    use std::os::unix::fs::OpenOptionsExt as _;
-
-    let mut options = fs::OpenOptions::new();
-    options.read(true);
-    #[cfg(unix)]
-    options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
     #[cfg(windows)]
     {
-        use std::os::windows::fs::OpenOptionsExt as _;
-        use windows_sys::Win32::Storage::FileSystem::{
-            FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ, FILE_SHARE_WRITE,
-        };
-        options
-            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
-            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+        use windows_sys::Win32::Storage::FileSystem::{FILE_SHARE_READ, FILE_SHARE_WRITE};
+
+        return open_private_file_windows(path, FILE_SHARE_READ | FILE_SHARE_WRITE);
     }
+
+    #[cfg(not(windows))]
+    {
+        #[cfg(unix)]
+        use std::os::unix::fs::OpenOptionsExt as _;
+
+        let mut options = fs::OpenOptions::new();
+        options.read(true);
+        #[cfg(unix)]
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+        let file = options.open(path)?;
+        verify_private_file(path)?;
+        if !file.metadata()?.is_file() {
+            return Err(anyhow!("private artifact path is not a regular file"));
+        }
+        Ok(file)
+    }
+}
+
+fn open_retained_private_file(path: &Path) -> Result<fs::File> {
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ;
+
+        // Retained cache handles admit concurrent readers but deny writers and
+        // deletion until digest-checked consumption has completed.
+        return open_private_file_windows(path, FILE_SHARE_READ);
+    }
+
+    #[cfg(not(windows))]
+    open_private_file(path)
+}
+
+#[cfg(windows)]
+fn open_private_file_windows(path: &Path, share_mode: u32) -> Result<fs::File> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT;
+
+    let mut options = fs::OpenOptions::new();
+    options
+        .read(true)
+        .share_mode(share_mode)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
     let file = options.open(path)?;
     verify_private_file(path)?;
-    #[cfg(windows)]
     ctx_history_platform::platform_security::verify_private_file_handle(&file)?;
     if !file.metadata()?.is_file() {
         return Err(anyhow!("private artifact path is not a regular file"));
     }
     Ok(file)
+}
+
+#[cfg(windows)]
+fn cached_artifact_has_active_writer(error: &anyhow::Error) -> bool {
+    use windows_sys::Win32::Foundation::ERROR_SHARING_VIOLATION;
+
+    error
+        .downcast_ref::<std::io::Error>()
+        .is_some_and(|error| error.raw_os_error() == Some(ERROR_SHARING_VIOLATION as i32))
+}
+
+#[cfg(not(windows))]
+fn cached_artifact_has_active_writer(_error: &anyhow::Error) -> bool {
+    false
 }
 
 pub(super) fn copy_file_verified(

--- a/crates/ctx-upgrade-engine/src/upgrade/download_tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/download_tests.rs
@@ -1,8 +1,42 @@
 use super::*;
 
+#[cfg(windows)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 struct FileReleaseTransport;
 
 static FILE_RELEASE_TRANSPORT: FileReleaseTransport = FileReleaseTransport;
+
+#[cfg(windows)]
+struct CountingReleaseTransport<'a> {
+    inner: &'a dyn ReleaseTransport,
+    download_calls: AtomicUsize,
+}
+
+#[cfg(windows)]
+impl ReleaseTransport for CountingReleaseTransport<'_> {
+    fn get_bytes_limited(&self, endpoint: &str, max_bytes: usize) -> Result<Vec<u8>> {
+        self.inner.get_bytes_limited(endpoint, max_bytes)
+    }
+
+    fn download_artifact_verified(
+        &self,
+        endpoint: &str,
+        destination: &mut fs::File,
+        max_bytes: u64,
+        expected_sha256: &str,
+        timeout: Duration,
+    ) -> Result<u64> {
+        self.download_calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.download_artifact_verified(
+            endpoint,
+            destination,
+            max_bytes,
+            expected_sha256,
+            timeout,
+        )
+    }
+}
 
 impl ReleaseTransport for FileReleaseTransport {
     fn get_bytes_limited(&self, endpoint: &str, max_bytes: usize) -> Result<Vec<u8>> {
@@ -123,6 +157,137 @@ fn runtime_download_cache_is_rehashed_and_reused_across_releases() {
     let mut copied = Vec::new();
     reused.copy_verified_to(&mut copied).unwrap();
     assert_eq!(copied, bytes);
+}
+
+#[cfg(windows)]
+#[test]
+fn retained_runtime_cache_allows_extractor_readers_but_denies_writers_and_delete() {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    use windows_sys::Win32::{
+        Foundation::ERROR_SHARING_VIOLATION,
+        Storage::FileSystem::{FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE},
+    };
+
+    let root = private_tempdir();
+    let source = root.path().join("runtime.zip");
+    let bytes = b"same signed runtime artifact";
+    fs::write(&source, bytes).unwrap();
+    let endpoint = format!("file://{}", source.display());
+    let expected = digest(bytes);
+
+    let first = DownloadedArtifact::download_or_reuse_verified(
+        &FILE_RELEASE_TRANSPORT,
+        root.path(),
+        &endpoint,
+        &expected,
+        1024,
+        Duration::from_secs(1),
+    )
+    .unwrap();
+    drop(first);
+
+    let retained = DownloadedArtifact::download_or_reuse_verified(
+        &FILE_RELEASE_TRANSPORT,
+        root.path(),
+        &endpoint,
+        &expected,
+        1024,
+        Duration::from_secs(1),
+    )
+    .unwrap();
+    let cache_path = retained.temporary_path().to_path_buf();
+
+    let extractor_reader = fs::OpenOptions::new()
+        .read(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .open(&cache_path)
+        .unwrap();
+    let writer_error = fs::OpenOptions::new()
+        .write(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .open(&cache_path)
+        .unwrap_err();
+    assert_eq!(
+        writer_error.raw_os_error(),
+        Some(ERROR_SHARING_VIOLATION as i32)
+    );
+    let delete_error = fs::remove_file(&cache_path).unwrap_err();
+    assert_eq!(
+        delete_error.raw_os_error(),
+        Some(ERROR_SHARING_VIOLATION as i32)
+    );
+
+    drop(extractor_reader);
+    drop(retained);
+    fs::remove_file(cache_path).unwrap();
+}
+
+#[cfg(windows)]
+#[test]
+fn publisher_held_runtime_cache_falls_back_to_a_separately_verified_download() {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ};
+
+    let root = private_tempdir();
+    let source = root.path().join("runtime.zip");
+    let bytes = b"same signed runtime artifact";
+    fs::write(&source, bytes).unwrap();
+    let endpoint = format!("file://{}", source.display());
+    let expected = digest(bytes);
+
+    let first = DownloadedArtifact::download_or_reuse_verified(
+        &FILE_RELEASE_TRANSPORT,
+        root.path(),
+        &endpoint,
+        &expected,
+        1024,
+        Duration::from_secs(1),
+    )
+    .unwrap();
+    drop(first);
+
+    let cache_path = root
+        .path()
+        .join(DOWNLOAD_DIRECTORY)
+        .join(format!("runtime-{expected}.artifact"));
+    let mut publisher = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .share_mode(FILE_SHARE_READ)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(&cache_path)
+        .unwrap();
+    let transport = CountingReleaseTransport {
+        inner: &FILE_RELEASE_TRANSPORT,
+        download_calls: AtomicUsize::new(0),
+    };
+
+    let mut downloaded = DownloadedArtifact::download_or_reuse_verified(
+        &transport,
+        root.path(),
+        &endpoint,
+        &expected,
+        1024,
+        Duration::from_secs(1),
+    )
+    .unwrap();
+    assert_eq!(transport.download_calls.load(Ordering::SeqCst), 1);
+    assert_ne!(downloaded.temporary_path(), cache_path);
+    let downloaded_path = downloaded.temporary_path().to_path_buf();
+    let mut copied = Vec::new();
+    downloaded.copy_verified_to(&mut copied).unwrap();
+    assert_eq!(copied, bytes);
+
+    publisher.seek(SeekFrom::Start(0)).unwrap();
+    let mut cached = Vec::new();
+    publisher.read_to_end(&mut cached).unwrap();
+    assert_eq!(cached, bytes);
+    drop(downloaded);
+    assert!(!downloaded_path.exists());
+    assert!(cache_path.is_file());
+
+    drop(publisher);
+    fs::remove_file(cache_path).unwrap();
 }
 
 #[test]

--- a/crates/ctx-upgrade-engine/src/upgrade/install.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install.rs
@@ -330,6 +330,7 @@ param(
   [long]$MaxExpandedBytes
 )
 $ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.IO.Compression
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 $expectedFiles = [System.Collections.Generic.HashSet[string]]::new(
   [string[]]@(
@@ -351,8 +352,19 @@ $expectedEntries = [System.Collections.Generic.HashSet[string]]::new($expectedFi
 $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 $entries = @{}
 [long]$totalLength = 0
-$archive = [System.IO.Compression.ZipFile]::OpenRead($ArchivePath)
+$archiveStream = [System.IO.FileStream]::new(
+  $ArchivePath,
+  [System.IO.FileMode]::Open,
+  [System.IO.FileAccess]::Read,
+  [System.IO.FileShare]::ReadWrite
+)
+$archive = $null
 try {
+  $archive = [System.IO.Compression.ZipArchive]::new(
+    $archiveStream,
+    [System.IO.Compression.ZipArchiveMode]::Read,
+    $true
+  )
   foreach ($entry in $archive.Entries) {
     $rawName = $entry.FullName
     if (
@@ -426,7 +438,13 @@ try {
     }
   }
 } finally {
-  $archive.Dispose()
+  try {
+    if ($null -ne $archive) {
+      $archive.Dispose()
+    }
+  } finally {
+    $archiveStream.Dispose()
+  }
 }
 "#;
 

--- a/crates/ctx-upgrade-engine/src/upgrade/install/archive.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/archive.rs
@@ -539,6 +539,7 @@ param(
   [string]$ContractPath
 )
 $ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.IO.Compression
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 $contract = Get-Content -LiteralPath $ContractPath -Raw | ConvertFrom-Json
 $expectedArchive = @{}
@@ -559,8 +560,19 @@ foreach ($file in $contract.files) {
 $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 $seenFiles = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
 [long]$total = 0
-$archive = [System.IO.Compression.ZipFile]::OpenRead($ArchivePath)
+$archiveStream = [System.IO.FileStream]::new(
+  $ArchivePath,
+  [System.IO.FileMode]::Open,
+  [System.IO.FileAccess]::Read,
+  [System.IO.FileShare]::ReadWrite
+)
+$archive = $null
 try {
+  $archive = [System.IO.Compression.ZipArchive]::new(
+    $archiveStream,
+    [System.IO.Compression.ZipArchiveMode]::Read,
+    $true
+  )
   foreach ($entry in $archive.Entries) {
     $raw = $entry.FullName
     if (
@@ -629,7 +641,13 @@ try {
     throw 'Semantic zip file set does not exactly match signed metadata'
   }
 } finally {
-  $archive.Dispose()
+  try {
+    if ($null -ne $archive) {
+      $archive.Dispose()
+    }
+  } finally {
+    $archiveStream.Dispose()
+  }
 }
 "#;
 

--- a/crates/ctx-upgrade-engine/tests/contracts/upgrade.rs
+++ b/crates/ctx-upgrade-engine/tests/contracts/upgrade.rs
@@ -188,28 +188,79 @@ fn assert_mode(path: &Path, expected: u32) {
 }
 
 #[test]
-fn windows_runtime_extractor_keeps_external_source_contract() {
+fn windows_zip_extractors_share_with_the_retained_parent_writer_but_not_deleters() {
+    fn embedded_script<'a>(source: &'a str, declaration: &str) -> &'a str {
+        assert_eq!(
+            source.matches(declaration).count(),
+            1,
+            "expected exactly one embedded extractor declared as {declaration:?}"
+        );
+        source
+            .split_once(declaration)
+            .unwrap()
+            .1
+            .split_once("\n\"#;")
+            .unwrap()
+            .0
+    }
+
+    fn assert_archive_open_contract(extractor: &str) {
+        assert!(extractor.contains("Add-Type -AssemblyName System.IO.Compression\n"));
+        assert!(extractor.contains("Add-Type -AssemblyName System.IO.Compression.FileSystem"));
+        let stream_open = extractor
+            .find("$archiveStream = [System.IO.FileStream]::new(")
+            .unwrap();
+        let file_mode = extractor.find("[System.IO.FileMode]::Open").unwrap();
+        let file_access = extractor.find("[System.IO.FileAccess]::Read").unwrap();
+        let file_share = extractor.find("[System.IO.FileShare]::ReadWrite").unwrap();
+        let zip_archive = extractor
+            .find("$archive = [System.IO.Compression.ZipArchive]::new(")
+            .unwrap();
+        let zip_mode = extractor
+            .find("[System.IO.Compression.ZipArchiveMode]::Read")
+            .unwrap();
+        let archive_dispose = extractor.rfind("$archive.Dispose()").unwrap();
+        let stream_dispose = extractor.rfind("$archiveStream.Dispose()").unwrap();
+        assert!(
+            stream_open < file_mode
+                && file_mode < file_access
+                && file_access < file_share
+                && file_share < zip_archive
+                && zip_archive < zip_mode
+                && zip_mode < archive_dispose
+                && archive_dispose < stream_dispose
+        );
+        assert!(!extractor.contains("[System.IO.Compression.ZipFile]::OpenRead"));
+        assert!(!extractor.contains("[System.IO.FileShare]::Delete"));
+    }
+
     let installer_source = include_str!("../../src/upgrade/install.rs");
     let declaration = "const EXTRACT_SCRIPT: &str = r#\"\n";
-    assert_eq!(
-        installer_source.matches(declaration).count(),
-        1,
-        "the external PowerShell test expects one embedded extractor at upgrade/install.rs"
-    );
-    let extractor = installer_source
-        .split_once(declaration)
-        .unwrap()
-        .1
-        .split_once("\n\"#;")
-        .unwrap()
-        .0;
-    assert!(extractor.contains("[System.IO.Compression.ZipFile]::OpenRead($ArchivePath)"));
-    assert!(extractor.contains("$targetStream.Flush($true)"));
+    let runtime_extractor = embedded_script(installer_source, declaration);
+    assert_archive_open_contract(runtime_extractor);
+    assert!(runtime_extractor.contains("$targetStream.Flush($true)"));
+
+    let archive_source = include_str!("../../src/upgrade/install/archive.rs");
+    let semantic_declaration = "const WINDOWS_SEMANTIC_ZIP_EXTRACT_SCRIPT: &str = r#\"\n";
+    let semantic_extractor = embedded_script(archive_source, semantic_declaration);
+    assert_archive_open_contract(semantic_extractor);
+    assert!(semantic_extractor.contains("$output.Flush($true)"));
 
     let external_contract =
         include_str!("../../../../scripts/test-windows-runtime-upgrade-extractor.ps1");
-    assert!(external_contract.contains(r#"..\crates\ctx-cli\src\upgrade\install.rs"#));
-    assert!(external_contract.contains("const EXTRACT_SCRIPT: &str = r#"));
+    assert!(external_contract.contains(r#"..\crates\ctx-upgrade-engine\src\upgrade\install.rs"#));
+    assert!(external_contract
+        .contains(r#"..\crates\ctx-upgrade-engine\src\upgrade\install\archive.rs"#));
+    assert!(external_contract
+        .contains("$runtimeScript = Get-EmbeddedScript $installerSource \"EXTRACT_SCRIPT\""));
+    assert!(external_contract.contains(
+        "$semanticScript = Get-EmbeddedScript $archiveSource \"WINDOWS_SEMANTIC_ZIP_EXTRACT_SCRIPT\""
+    ));
+    assert!(external_contract.contains("$PSVersionTable.PSVersion.Major -ne 5"));
+    assert!(external_contract.contains("Semantic zip file verification failed"));
+    assert!(external_contract.contains("unexpected or non-regular Semantic zip file"));
+    assert!(external_contract.contains("[System.IO.FileAccess]::ReadWrite"));
+    assert!(external_contract.contains("[System.IO.FileShare]::Read"));
 }
 
 #[test]

--- a/scripts/test-windows-runtime-upgrade-extractor.ps1
+++ b/scripts/test-windows-runtime-upgrade-extractor.ps1
@@ -8,104 +8,368 @@ $ErrorActionPreference = "Stop"
 if ([System.Environment]::OSVersion.Platform -ne [System.PlatformID]::Win32NT) {
     throw "This contract test must run on Windows"
 }
-
-$archivePath = (Resolve-Path -LiteralPath $RuntimeArchive).Path
-$installerSource = Join-Path $PSScriptRoot "..\crates\ctx-cli\src\upgrade\install.rs"
-$source = [System.IO.File]::ReadAllText((Resolve-Path -LiteralPath $installerSource).Path)
-$pattern = 'const EXTRACT_SCRIPT: &str = r#"\r?\n(?<script>.*?)\r?\n"#;'
-$matches = [regex]::Matches(
-    $source,
-    $pattern,
-    [System.Text.RegularExpressions.RegexOptions]::Singleline
-)
-if ($matches.Count -ne 1) {
-    throw "Expected exactly one embedded Windows runtime extraction script"
+if (
+    $PSVersionTable.PSVersion.Major -ne 5 -or
+    $PSVersionTable.PSVersion.Minor -ne 1
+) {
+    throw "This contract test requires Windows PowerShell 5.1"
 }
 
-$root = Join-Path ([System.IO.Path]::GetTempPath()) ("ctx-upgrade-extractor-" + [Guid]::NewGuid().ToString("n"))
-$destination = Join-Path $root "runtime"
-$extractor = Join-Path $root "extract.ps1"
-New-Item -ItemType Directory -Path $destination -Force | Out-Null
-try {
-    [System.IO.File]::WriteAllText(
-        $extractor,
-        $matches[0].Groups["script"].Value,
-        [System.Text.UTF8Encoding]::new($false)
+Add-Type -AssemblyName System.IO.Compression
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+function Get-EmbeddedScript {
+    param(
+        [string]$SourcePath,
+        [string]$ConstantName
     )
+
+    $source = [System.IO.File]::ReadAllText((Resolve-Path -LiteralPath $SourcePath).Path)
+    $pattern = 'const ' + [regex]::Escape($ConstantName) + ': &str = r#"\r?\n(?<script>.*?)\r?\n"#;'
+    $scriptMatches = [regex]::Matches(
+        $source,
+        $pattern,
+        [System.Text.RegularExpressions.RegexOptions]::Singleline
+    )
+    if ($scriptMatches.Count -ne 1) {
+        throw "Expected exactly one embedded $ConstantName script in $SourcePath"
+    }
+    return $scriptMatches[0].Groups["script"].Value
+}
+
+function Invoke-EmbeddedExtractorProcess {
+    param(
+        [string]$PowerShellPath,
+        [string]$ScriptPath,
+        [string[]]$ArgumentList
+    )
+
     $previousErrorActionPreference = $ErrorActionPreference
     try {
         $ErrorActionPreference = "Continue"
         $outputLines = @(
-            & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $extractor `
-                -ArchivePath $archivePath `
-                -Destination $destination `
-                -ExpectedVersion "1.27.0" `
-                -MaxExpandedBytes 1073741824 2>&1
+            & $PowerShellPath -NoProfile -ExecutionPolicy Bypass -File $ScriptPath @ArgumentList 2>&1
         )
         $exitCode = $LASTEXITCODE
     } finally {
         $ErrorActionPreference = $previousErrorActionPreference
     }
-    if ($exitCode -ne 0) {
-        throw "Embedded Windows runtime extractor failed with status $exitCode`n$($outputLines -join [Environment]::NewLine)"
+    return [pscustomobject]@{
+        ExitCode = $exitCode
+        Output = $outputLines -join [Environment]::NewLine
     }
+}
 
-    $expectedFiles = @(
-        "GIT_COMMIT_ID",
-        "LICENSE",
-        "MICROSOFT_VC_RUNTIME_LICENSE.rtf",
-        "ThirdPartyNotices.txt",
-        "VERSION_NUMBER",
-        "lib/msvcp140.dll",
-        "lib/msvcp140_1.dll",
-        "lib/onnxruntime.dll",
-        "lib/vcruntime140.dll",
-        "lib/vcruntime140_1.dll"
-    ) | Sort-Object
+function Assert-EmbeddedExtractorSuccess {
+    param(
+        [string]$PowerShellPath,
+        [string]$ScriptPath,
+        [string[]]$ArgumentList,
+        [string]$Label
+    )
+
+    $result = Invoke-EmbeddedExtractorProcess $PowerShellPath $ScriptPath $ArgumentList
+    if ($result.ExitCode -ne 0) {
+        throw "$Label failed with status $($result.ExitCode)`n$($result.Output)"
+    }
+}
+
+function Assert-EmbeddedExtractorFailure {
+    param(
+        [string]$PowerShellPath,
+        [string]$ScriptPath,
+        [string[]]$ArgumentList,
+        [string]$ExpectedText,
+        [string]$Label
+    )
+
+    $result = Invoke-EmbeddedExtractorProcess $PowerShellPath $ScriptPath $ArgumentList
+    if ($result.ExitCode -eq 0) {
+        throw "$Label unexpectedly succeeded"
+    }
+    if (-not $result.Output.Contains($ExpectedText)) {
+        throw "$Label did not report '$ExpectedText'`n$($result.Output)"
+    }
+}
+
+function Get-SignedArchiveRecords {
+    param(
+        [string]$ArchivePath,
+        [string[]]$ExpectedFiles
+    )
+
+    $archiveStream = [System.IO.FileStream]::new(
+        $ArchivePath,
+        [System.IO.FileMode]::Open,
+        [System.IO.FileAccess]::Read,
+        [System.IO.FileShare]::ReadWrite
+    )
+    $archive = $null
+    $records = [System.Collections.Generic.List[object]]::new()
+    try {
+        $archive = [System.IO.Compression.ZipArchive]::new(
+            $archiveStream,
+            [System.IO.Compression.ZipArchiveMode]::Read,
+            $true
+        )
+        foreach ($relativePath in $ExpectedFiles) {
+            $entry = $archive.GetEntry($relativePath)
+            if ($null -eq $entry) {
+                throw "Runtime archive entry is missing: $relativePath"
+            }
+            $entryStream = $entry.Open()
+            $sha256 = [System.Security.Cryptography.SHA256]::Create()
+            try {
+                $entryHash = [System.BitConverter]::ToString($sha256.ComputeHash($entryStream)).Replace("-", "").ToLowerInvariant()
+            } finally {
+                $sha256.Dispose()
+                $entryStream.Dispose()
+            }
+            $records.Add([pscustomobject][ordered]@{
+                path = $relativePath
+                size = [long]$entry.Length
+                sha256 = $entryHash
+            })
+        }
+    } finally {
+        try {
+            if ($null -ne $archive) {
+                $archive.Dispose()
+            }
+        } finally {
+            $archiveStream.Dispose()
+        }
+    }
+    return $records.ToArray()
+}
+
+function Write-SemanticContract {
+    param(
+        [string]$Path,
+        [object[]]$Records,
+        [long]$MaxExpandedBytes
+    )
+
+    $contract = [ordered]@{
+        prefix = ""
+        max_expanded_bytes = $MaxExpandedBytes
+        files = @($Records)
+    }
+    [System.IO.File]::WriteAllText(
+        $Path,
+        ($contract | ConvertTo-Json -Depth 6 -Compress),
+        [System.Text.UTF8Encoding]::new($false)
+    )
+}
+
+function Assert-SignedTree {
+    param(
+        [string]$Destination,
+        [object[]]$Records,
+        [string]$Label
+    )
+
+    $expectedFiles = @($Records | ForEach-Object { [string]$_.path } | Sort-Object)
     $actualFiles = @(
-        Get-ChildItem -LiteralPath $destination -Recurse -File | ForEach-Object {
-            $_.FullName.Substring($destination.Length + 1).Replace("\", "/")
+        Get-ChildItem -LiteralPath $Destination -Recurse -File | ForEach-Object {
+            $_.FullName.Substring($Destination.Length + 1).Replace("\", "/")
         } | Sort-Object
     )
     if ($actualFiles.Count -ne $expectedFiles.Count) {
-        throw "Embedded extractor produced $($actualFiles.Count) files, expected $($expectedFiles.Count)"
+        throw "$Label produced $($actualFiles.Count) files, expected $($expectedFiles.Count)"
     }
     for ($index = 0; $index -lt $expectedFiles.Count; $index++) {
         if ($actualFiles[$index] -cne $expectedFiles[$index]) {
-            throw "Embedded extractor file $index was '$($actualFiles[$index])', expected '$($expectedFiles[$index])'"
+            throw "$Label file $index was '$($actualFiles[$index])', expected '$($expectedFiles[$index])'"
         }
     }
-
-    Add-Type -AssemblyName System.IO.Compression.FileSystem
-    $archive = [System.IO.Compression.ZipFile]::OpenRead($archivePath)
-    try {
-        $sha256 = [System.Security.Cryptography.SHA256]::Create()
-        try {
-            foreach ($relativePath in $expectedFiles) {
-                $entry = $archive.GetEntry($relativePath)
-                if ($null -eq $entry) {
-                    throw "Runtime archive entry is missing: $relativePath"
-                }
-                $stream = $entry.Open()
-                try {
-                    $archiveHash = [System.BitConverter]::ToString($sha256.ComputeHash($stream)).Replace("-", "")
-                } finally {
-                    $stream.Dispose()
-                }
-                $extractedPath = Join-Path $destination $relativePath.Replace("/", "\")
-                $extractedHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $extractedPath).Hash
-                if ($archiveHash -cne $extractedHash) {
-                    throw "Extracted runtime file does not match its archive entry: $relativePath"
-                }
-            }
-        } finally {
-            $sha256.Dispose()
+    foreach ($record in $Records) {
+        $target = Join-Path $Destination ([string]$record.path).Replace("/", "\")
+        $metadata = Get-Item -LiteralPath $target
+        if ([long]$metadata.Length -ne [long]$record.size) {
+            throw "$Label file size does not match its signed record: $($record.path)"
         }
-    } finally {
-        $archive.Dispose()
+        $actualHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $target).Hash.ToLowerInvariant()
+        if ($actualHash -cne [string]$record.sha256) {
+            throw "$Label file hash does not match its signed record: $($record.path)"
+        }
     }
-} finally {
-    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
 }
 
-Write-Host "Windows runtime upgrade extractor contract passed"
+$runtimeArchivePath = (Resolve-Path -LiteralPath $RuntimeArchive).Path
+$installerSource = Join-Path $PSScriptRoot "..\crates\ctx-upgrade-engine\src\upgrade\install.rs"
+$archiveSource = Join-Path $PSScriptRoot "..\crates\ctx-upgrade-engine\src\upgrade\install\archive.rs"
+$runtimeScript = Get-EmbeddedScript $installerSource "EXTRACT_SCRIPT"
+$semanticScript = Get-EmbeddedScript $archiveSource "WINDOWS_SEMANTIC_ZIP_EXTRACT_SCRIPT"
+$windowsPowerShell = Join-Path $PSHOME "powershell.exe"
+$expectedFiles = @(
+    "GIT_COMMIT_ID",
+    "LICENSE",
+    "MICROSOFT_VC_RUNTIME_LICENSE.rtf",
+    "ThirdPartyNotices.txt",
+    "VERSION_NUMBER",
+    "lib/msvcp140.dll",
+    "lib/msvcp140_1.dll",
+    "lib/onnxruntime.dll",
+    "lib/vcruntime140.dll",
+    "lib/vcruntime140_1.dll"
+) | Sort-Object
+
+$root = Join-Path ([System.IO.Path]::GetTempPath()) ("ctx-upgrade-extractor-" + [Guid]::NewGuid().ToString("n"))
+$archivePath = Join-Path $root "runtime.zip"
+$runtimeDestination = Join-Path $root "runtime"
+$semanticDestination = Join-Path $root "semantic"
+$hashFailureDestination = Join-Path $root "semantic-hash-failure"
+$fileSetFailureDestination = Join-Path $root "semantic-file-set-failure"
+$runtimeExtractor = Join-Path $root "runtime-extract.ps1"
+$semanticExtractor = Join-Path $root "semantic-extract.ps1"
+$semanticContractPath = Join-Path $root "semantic-contract.json"
+$hashFailureContractPath = Join-Path $root "semantic-hash-failure.json"
+$fileSetFailureContractPath = Join-Path $root "semantic-file-set-failure.json"
+$parentArchive = $null
+
+New-Item -ItemType Directory -Path $root -Force | Out-Null
+try {
+    Copy-Item -LiteralPath $runtimeArchivePath -Destination $archivePath
+    [System.IO.File]::WriteAllText(
+        $runtimeExtractor,
+        $runtimeScript,
+        [System.Text.UTF8Encoding]::new($false)
+    )
+    [System.IO.File]::WriteAllText(
+        $semanticExtractor,
+        $semanticScript,
+        [System.Text.UTF8Encoding]::new($false)
+    )
+
+    $signedRecords = @(Get-SignedArchiveRecords $archivePath $expectedFiles)
+    $maxExpandedBytes = [long](($signedRecords | Measure-Object -Property size -Sum).Sum)
+    Write-SemanticContract $semanticContractPath $signedRecords $maxExpandedBytes
+
+    $hashFailureRecords = @()
+    for ($index = 0; $index -lt $signedRecords.Count; $index++) {
+        $record = $signedRecords[$index]
+        $recordHash = if ($index -eq 0) { (("0" * 64) -join "") } else { [string]$record.sha256 }
+        $hashFailureRecords += [pscustomobject][ordered]@{
+            path = [string]$record.path
+            size = [long]$record.size
+            sha256 = $recordHash
+        }
+    }
+    Write-SemanticContract $hashFailureContractPath $hashFailureRecords $maxExpandedBytes
+
+    $fileSetFailureRecords = @($signedRecords | Select-Object -First ($signedRecords.Count - 1))
+    Write-SemanticContract $fileSetFailureContractPath $fileSetFailureRecords $maxExpandedBytes
+
+    foreach ($destination in @(
+        $runtimeDestination,
+        $semanticDestination,
+        $hashFailureDestination,
+        $fileSetFailureDestination
+    )) {
+        New-Item -ItemType Directory -Path $destination -Force | Out-Null
+    }
+
+    # Exercise the publisher/identity-pin sharing contract with read/write
+    # access and read sharing, deliberately excluding write and delete
+    # sharing. Every child extraction below runs while this handle remains live.
+    $parentArchive = [System.IO.FileStream]::new(
+        $archivePath,
+        [System.IO.FileMode]::Open,
+        [System.IO.FileAccess]::ReadWrite,
+        [System.IO.FileShare]::Read
+    )
+    try {
+        Assert-EmbeddedExtractorSuccess `
+            $windowsPowerShell `
+            $runtimeExtractor `
+            @(
+                "-ArchivePath", $archivePath,
+                "-Destination", $runtimeDestination,
+                "-ExpectedVersion", "1.27.0",
+                "-MaxExpandedBytes", "1073741824"
+            ) `
+            "Embedded Windows runtime extractor"
+        Assert-SignedTree $runtimeDestination $signedRecords "Runtime extractor"
+
+        Assert-EmbeddedExtractorSuccess `
+            $windowsPowerShell `
+            $semanticExtractor `
+            @(
+                "-ArchivePath", $archivePath,
+                "-Destination", $semanticDestination,
+                "-ContractPath", $semanticContractPath
+            ) `
+            "Embedded Windows Semantic zip extractor"
+        Assert-SignedTree $semanticDestination $signedRecords "Semantic extractor"
+
+        Assert-EmbeddedExtractorFailure `
+            $windowsPowerShell `
+            $semanticExtractor `
+            @(
+                "-ArchivePath", $archivePath,
+                "-Destination", $hashFailureDestination,
+                "-ContractPath", $hashFailureContractPath
+            ) `
+            "Semantic zip file verification failed" `
+            "Semantic hash contract"
+        Remove-Item -LiteralPath $hashFailureDestination -Recurse -Force -ErrorAction Stop
+
+        Assert-EmbeddedExtractorFailure `
+            $windowsPowerShell `
+            $semanticExtractor `
+            @(
+                "-ArchivePath", $archivePath,
+                "-Destination", $fileSetFailureDestination,
+                "-ContractPath", $fileSetFailureContractPath
+            ) `
+            "unexpected or non-regular Semantic zip file" `
+            "Semantic file-set contract"
+        Remove-Item -LiteralPath $fileSetFailureDestination -Recurse -Force -ErrorAction Stop
+
+        foreach ($temporaryHelper in @(
+            $runtimeExtractor,
+            $semanticExtractor,
+            $semanticContractPath,
+            $hashFailureContractPath,
+            $fileSetFailureContractPath
+        )) {
+            Remove-Item -LiteralPath $temporaryHelper -Force -ErrorAction Stop
+            if (Test-Path -LiteralPath $temporaryHelper) {
+                throw "Temporary extractor input was retained: $temporaryHelper"
+            }
+        }
+    } finally {
+        $parentArchive.Dispose()
+        $parentArchive = $null
+    }
+
+    # No child or verifier may retain the archive once the identity pin closes.
+    $exclusiveArchive = [System.IO.FileStream]::new(
+        $archivePath,
+        [System.IO.FileMode]::Open,
+        [System.IO.FileAccess]::ReadWrite,
+        [System.IO.FileShare]::None
+    )
+    try {
+        $exclusiveArchive.Flush($true)
+    } finally {
+        $exclusiveArchive.Dispose()
+    }
+    Remove-Item -LiteralPath $archivePath -Force -ErrorAction Stop
+    if (Test-Path -LiteralPath $archivePath) {
+        throw "Extractor archive remained after every handle was disposed"
+    }
+} finally {
+    if ($null -ne $parentArchive) {
+        $parentArchive.Dispose()
+    }
+    if (Test-Path -LiteralPath $root) {
+        Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction Stop
+    }
+}
+
+if (Test-Path -LiteralPath $root) {
+    throw "Windows extractor contract retained its temporary root"
+}
+Write-Host "Windows runtime and Semantic upgrade extractor contracts passed under PowerShell 5.1"


### PR DESCRIPTION
Summary
- open both Windows runtime zip extractors with sharing compatible with the parent retained artifact handle
- retain cache write/delete exclusion and fall back to a separately verified download during active publication
- cover PowerShell 5.1 runtime and signed Semantic extraction, negative file/hash cases, and handle cleanup

Validation
- post-rebase rustfmt, source-diff, 104 unit tests, and 44 upgrade tests passed
- native PowerShell 5.1 dual-extractor qualification passed
- independent final review: ship, no product findings
- extra Windows Rust tests were blocked before execution by native toolchain infrastructure; no product test failed

Fixes #642