### PR TITLE
fix(daemon): query Windows SID from process token

### DIFF
--- a/crates/ctx-daemon-application/src/supervisor/native.rs
+++ b/crates/ctx-daemon-application/src/supervisor/native.rs
@@ -233,9 +233,9 @@ fn native_supervisor_identity(
 #[cfg(windows)]
 fn native_supervisor_identity(
     data_root: &Path,
-    manager_environment: &SupervisorManagerEnvironment,
+    _manager_environment: &SupervisorManagerEnvironment,
 ) -> Result<Option<SupervisorIdentity>> {
-    let sid = ctx_daemon_runtime::current_windows_user_sid(manager_environment)?;
+    let sid = ctx_daemon_runtime::current_windows_user_sid()?;
     environment::windows_supervisor_identity(data_root, &sid).map(Some)
 }
 

--- a/crates/ctx-daemon-application/src/supervisor/tests.rs
+++ b/crates/ctx-daemon-application/src/supervisor/tests.rs
@@ -542,8 +542,7 @@ fn windows_task_xml_registers_with_task_scheduler() -> Result<()> {
         }
     }
 
-    let manager_environment = supervisor_manager_environment(&TestHost)?;
-    let sid = current_windows_user_sid(&manager_environment)?;
+    let sid = current_windows_user_sid()?;
     let task_name = format!(r"\ctx-test-daemon-xml-{}", std::process::id());
     let temp = tempfile::tempdir()?;
     let path = temp.path().join("windows-task.xml");

--- a/crates/ctx-daemon-runtime/src/ipc/server/windows_security.rs
+++ b/crates/ctx-daemon-runtime/src/ipc/server/windows_security.rs
@@ -174,58 +174,16 @@ impl WindowsDaemonQueryPipeSecurity {
 }
 
 struct WindowsDaemonQueryPipeIdentities {
-    _token: TokenHandle,
-    token_user: AlignedBuffer,
+    user: crate::windows_identity::CurrentProcessTokenUser,
     system: AlignedBuffer,
     user_is_system: bool,
 }
 
 impl WindowsDaemonQueryPipeIdentities {
     fn current() -> std::io::Result<Self> {
-        use windows_sys::Win32::{
-            Foundation::ERROR_INSUFFICIENT_BUFFER,
-            Security::{
-                CreateWellKnownSid, EqualSid, GetTokenInformation, TokenUser, WinLocalSystemSid,
-                TOKEN_QUERY,
-            },
-            System::Threading::{GetCurrentProcess, OpenProcessToken},
-        };
+        use windows_sys::Win32::Security::{CreateWellKnownSid, EqualSid, WinLocalSystemSid};
 
-        let mut token = std::ptr::null_mut();
-        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &raw mut token) } == 0 {
-            return Err(last_error());
-        }
-        let token = TokenHandle(token);
-        let mut required = 0;
-        let first = unsafe {
-            GetTokenInformation(
-                token.0,
-                TokenUser,
-                std::ptr::null_mut(),
-                0,
-                &raw mut required,
-            )
-        };
-        if first != 0
-            || unsafe { windows_sys::Win32::Foundation::GetLastError() }
-                != ERROR_INSUFFICIENT_BUFFER
-            || required == 0
-        {
-            return Err(last_error());
-        }
-        let mut token_user = AlignedBuffer::new(required as usize)?;
-        if unsafe {
-            GetTokenInformation(
-                token.0,
-                TokenUser,
-                token_user.as_mut_ptr().cast(),
-                required,
-                &raw mut required,
-            )
-        } == 0
-        {
-            return Err(last_error());
-        }
+        let user = crate::windows_identity::CurrentProcessTokenUser::current()?;
         let mut system = AlignedBuffer::new(68)?;
         let mut system_size = 68;
         if unsafe {
@@ -240,8 +198,7 @@ impl WindowsDaemonQueryPipeIdentities {
             return Err(last_error());
         }
         let mut identities = Self {
-            _token: token,
-            token_user,
+            user,
             system,
             user_is_system: false,
         };
@@ -253,8 +210,7 @@ impl WindowsDaemonQueryPipeIdentities {
     }
 
     fn user_sid(&self) -> windows_sys::Win32::Security::PSID {
-        use windows_sys::Win32::Security::TOKEN_USER;
-        unsafe { (*self.token_user.as_ptr().cast::<TOKEN_USER>()).User.Sid }
+        self.user.sid()
     }
 
     fn system_sid(&self) -> windows_sys::Win32::Security::PSID {
@@ -310,16 +266,6 @@ fn sid_size(sid: windows_sys::Win32::Security::PSID) -> std::io::Result<usize> {
         return Err(invalid_acl());
     }
     Ok(unsafe { GetLengthSid(sid) } as usize)
-}
-
-struct TokenHandle(windows_sys::Win32::Foundation::HANDLE);
-
-impl Drop for TokenHandle {
-    fn drop(&mut self) {
-        unsafe {
-            let _ = windows_sys::Win32::Foundation::CloseHandle(self.0);
-        }
-    }
 }
 
 struct AlignedBuffer {

--- a/crates/ctx-daemon-runtime/src/lib.rs
+++ b/crates/ctx-daemon-runtime/src/lib.rs
@@ -10,6 +10,8 @@ mod process;
 mod supervisor;
 mod wakeup;
 mod watch;
+#[cfg(windows)]
+mod windows_identity;
 
 pub use handoff::*;
 pub use ipc::*;
@@ -23,3 +25,5 @@ pub use process::*;
 pub use supervisor::*;
 pub use wakeup::*;
 pub use watch::*;
+#[cfg(windows)]
+pub use windows_identity::current_windows_user_sid;

--- a/crates/ctx-daemon-runtime/src/supervisor/windows.rs
+++ b/crates/ctx-daemon-runtime/src/supervisor/windows.rs
@@ -65,7 +65,7 @@ pub fn install_windows_supervisor(
     let path = identity.artifact_path();
     let system_root = manager_environment_value(manager_environment, "SystemRoot")
         .ok_or_else(|| anyhow!("Windows SystemRoot is unavailable"))?;
-    let sid = current_windows_user_sid(manager_environment)?;
+    let sid = crate::current_windows_user_sid()?;
     let xml = windows_task_xml(spec, Path::new(system_root), &sid)?;
     write_atomic_supervisor_file(path, &windows_task_xml_bytes(&xml))?;
 
@@ -295,27 +295,6 @@ pub fn windows_command_line_quote(value: &str) -> String {
 }
 
 #[cfg(windows)]
-pub fn current_windows_user_sid(
-    manager_environment: &SupervisorManagerEnvironment,
-) -> Result<String> {
-    let mut command = supervisor_command("whoami", manager_environment);
-    command.args(["/user", "/fo", "csv", "/nh"]);
-    let output = supervisor_output(&mut command).context("query current Windows user SID")?;
-    if !output.status.success() {
-        return Err(anyhow!(
-            "whoami /user failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
-    }
-    String::from_utf8_lossy(&output.stdout)
-        .split(',')
-        .nth(1)
-        .map(|value| value.trim().trim_matches('"').to_owned())
-        .filter(|value| value.starts_with("S-1-"))
-        .ok_or_else(|| anyhow!("whoami returned no current-user SID"))
-}
-
-#[cfg(windows)]
 fn query_windows_task(
     task_name: &str,
     manager_environment: &SupervisorManagerEnvironment,
@@ -332,7 +311,7 @@ pub fn verify_windows_supervisor_registration(
 ) -> Result<()> {
     let system_root = manager_environment_value(manager_environment, "SystemRoot")
         .ok_or_else(|| anyhow!("Windows SystemRoot is unavailable"))?;
-    let sid = current_windows_user_sid(manager_environment)?;
+    let sid = crate::current_windows_user_sid()?;
     let task_name = spec.identity().name();
     let output = query_windows_task(&task_name, manager_environment)?;
     if !output.status.success() {

--- a/crates/ctx-daemon-runtime/src/supervisor/windows/manager_probe_tests.rs
+++ b/crates/ctx-daemon-runtime/src/supervisor/windows/manager_probe_tests.rs
@@ -20,6 +20,25 @@ fn task_scheduler_probe_is_read_only() {
 }
 
 #[test]
+fn current_windows_sid_uses_the_process_token_without_a_path_command() {
+    let supervisor = include_str!("../windows.rs");
+    let identity = include_str!("../../windows_identity.rs");
+    let pipe_security = include_str!("../../ipc/server/windows_security.rs");
+
+    assert!(!supervisor.contains("whoami"));
+    assert!(!identity.contains("Command::new"));
+    assert!(!identity.contains("\"whoami\""));
+    assert!(identity.contains("OpenProcessToken(GetCurrentProcess()"));
+    assert!(identity.contains("GetTokenInformation"));
+    assert!(identity.contains("TokenUser"));
+    assert!(identity.contains("ConvertSidToStringSidW"));
+    assert!(identity.contains("impl Drop for LocalSidString"));
+    assert!(identity.contains("LocalFree"));
+    assert!(pipe_security.contains("CurrentProcessTokenUser::current()"));
+    assert!(!pipe_security.contains("GetTokenInformation"));
+}
+
+#[test]
 fn task_state_query_represents_absence_separately_from_failure() {
     let script = windows_task_state_script(r"\ctx-test-task");
     assert!(script.contains("-ErrorAction Stop"));

--- a/crates/ctx-daemon-runtime/src/windows_identity.rs
+++ b/crates/ctx-daemon-runtime/src/windows_identity.rs
@@ -1,0 +1,257 @@
+use std::{ffi::c_void, io, ptr::null_mut, slice};
+
+use anyhow::{Context, Result};
+use windows_sys::Win32::{
+    Foundation::{CloseHandle, GetLastError, LocalFree, ERROR_INSUFFICIENT_BUFFER, HANDLE},
+    Security::{
+        Authorization::ConvertSidToStringSidW, GetLengthSid, GetTokenInformation, IsValidSid,
+        TokenUser, PSID, TOKEN_QUERY, TOKEN_USER,
+    },
+    System::Threading::{GetCurrentProcess, OpenProcessToken},
+};
+
+pub fn current_windows_user_sid() -> Result<String> {
+    CurrentProcessTokenUser::current()
+        .and_then(|identity| identity.sid_string())
+        .context("query current Windows process-token user SID")
+}
+
+pub(crate) struct CurrentProcessTokenUser {
+    _token: TokenHandle,
+    token_user: AlignedTokenInformation,
+}
+
+impl CurrentProcessTokenUser {
+    pub(crate) fn current() -> io::Result<Self> {
+        // Daemon supervision and named-pipe ownership are both identities of
+        // this process, so deliberately query its primary token rather than a
+        // potentially impersonated thread token.
+        let mut token = null_mut();
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &raw mut token) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let token = TokenHandle(token);
+
+        let mut required = 0;
+        let first =
+            unsafe { GetTokenInformation(token.0, TokenUser, null_mut(), 0, &raw mut required) };
+        let first_error = unsafe { GetLastError() };
+        let required = token_user_information_size(first, first_error, required)?;
+        if required < std::mem::size_of::<TOKEN_USER>() {
+            return Err(invalid_token_user("TokenUser buffer is too small"));
+        }
+        let mut token_user = AlignedTokenInformation::new(required)?;
+        let mut returned = u32::try_from(required)
+            .map_err(|_| invalid_token_user("TokenUser size exceeds the Win32 API limit"))?;
+        if unsafe {
+            GetTokenInformation(
+                token.0,
+                TokenUser,
+                token_user.as_mut_ptr().cast(),
+                returned,
+                &raw mut returned,
+            )
+        } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        let returned = usize::try_from(returned)
+            .map_err(|_| invalid_token_user("returned TokenUser size does not fit in memory"))?;
+        if returned < std::mem::size_of::<TOKEN_USER>() || returned > token_user.byte_len() {
+            return Err(invalid_token_user(
+                "GetTokenInformation returned an invalid TokenUser size",
+            ));
+        }
+        token_user.set_initialized_len(returned);
+
+        let identity = Self {
+            _token: token,
+            token_user,
+        };
+        let _ = identity.sid_size()?;
+        Ok(identity)
+    }
+
+    pub(crate) fn sid(&self) -> PSID {
+        unsafe { (*self.token_user.as_ptr().cast::<TOKEN_USER>()).User.Sid }
+    }
+
+    fn sid_size(&self) -> io::Result<usize> {
+        const SID_HEADER_BYTES: usize = 8;
+
+        let sid = self.sid();
+        if sid.is_null()
+            || !self.token_user.contains_range(sid, SID_HEADER_BYTES)
+            || unsafe { IsValidSid(sid) } == 0
+        {
+            return Err(invalid_token_user("process TokenUser SID is invalid"));
+        }
+        let sid_len = unsafe { GetLengthSid(sid) } as usize;
+        if sid_len == 0 || !self.token_user.contains_range(sid, sid_len) {
+            return Err(invalid_token_user(
+                "process TokenUser SID falls outside its information buffer",
+            ));
+        }
+        Ok(sid_len)
+    }
+
+    fn sid_string(&self) -> io::Result<String> {
+        let _ = self.sid_size()?;
+        let sid_string = LocalSidString::from_sid(self.sid())?;
+        sid_string.to_string()
+    }
+}
+
+fn token_user_information_size(
+    query_result: i32,
+    query_error: u32,
+    required: u32,
+) -> io::Result<usize> {
+    if query_result != 0 {
+        return Err(invalid_token_user(
+            "TokenUser size query unexpectedly succeeded",
+        ));
+    }
+    if query_error != ERROR_INSUFFICIENT_BUFFER {
+        return Err(io::Error::from_raw_os_error(
+            i32::try_from(query_error).unwrap_or(i32::MAX),
+        ));
+    }
+    if required == 0 {
+        return Err(invalid_token_user(
+            "TokenUser size query returned no required length",
+        ));
+    }
+    usize::try_from(required)
+        .map_err(|_| invalid_token_user("TokenUser size does not fit in memory"))
+}
+
+struct TokenHandle(HANDLE);
+
+impl Drop for TokenHandle {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe {
+                let _ = CloseHandle(self.0);
+            }
+        }
+    }
+}
+
+struct AlignedTokenInformation {
+    words: Vec<usize>,
+    initialized_len: usize,
+}
+
+impl AlignedTokenInformation {
+    fn new(byte_len: usize) -> io::Result<Self> {
+        let word = std::mem::size_of::<usize>();
+        let words = byte_len
+            .checked_add(word - 1)
+            .ok_or_else(|| invalid_token_user("TokenUser allocation size overflow"))?
+            / word;
+        Ok(Self {
+            words: vec![0; words],
+            initialized_len: 0,
+        })
+    }
+
+    fn byte_len(&self) -> usize {
+        self.words.len() * std::mem::size_of::<usize>()
+    }
+
+    fn set_initialized_len(&mut self, initialized_len: usize) {
+        self.initialized_len = initialized_len;
+    }
+
+    fn as_ptr(&self) -> *const usize {
+        self.words.as_ptr()
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut usize {
+        self.words.as_mut_ptr()
+    }
+
+    fn contains_range(&self, pointer: *const c_void, len: usize) -> bool {
+        let start = self.as_ptr().addr();
+        let Some(end) = start.checked_add(self.initialized_len) else {
+            return false;
+        };
+        let pointer = pointer.addr();
+        pointer >= start
+            && pointer
+                .checked_add(len)
+                .is_some_and(|pointer_end| pointer_end <= end)
+    }
+}
+
+struct LocalSidString(*mut u16);
+
+impl LocalSidString {
+    fn from_sid(sid: PSID) -> io::Result<Self> {
+        let mut value = null_mut();
+        if unsafe { ConvertSidToStringSidW(sid, &raw mut value) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if value.is_null() {
+            return Err(invalid_token_user(
+                "ConvertSidToStringSidW returned a null string",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    fn to_string(&self) -> io::Result<String> {
+        let mut len = 0;
+        while unsafe { *self.0.add(len) } != 0 {
+            len += 1;
+        }
+        String::from_utf16(unsafe { slice::from_raw_parts(self.0, len) })
+            .map_err(|_| invalid_token_user("converted SID is not valid UTF-16"))
+    }
+}
+
+impl Drop for LocalSidString {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe {
+                let _ = LocalFree(self.0.cast());
+            }
+        }
+    }
+}
+
+fn invalid_token_user(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED;
+
+    #[test]
+    fn token_user_size_query_preserves_unexpected_win32_error_before_zero_length() {
+        let error = token_user_information_size(0, ERROR_ACCESS_DENIED, 0)
+            .expect_err("unexpected Win32 error must be preserved");
+
+        assert_eq!(error.raw_os_error(), Some(ERROR_ACCESS_DENIED as i32));
+    }
+
+    #[test]
+    fn token_user_size_query_rejects_zero_length_after_expected_win32_error() {
+        let error = token_user_information_size(0, ERROR_INSUFFICIENT_BUFFER, 0)
+            .expect_err("zero TokenUser length must be rejected");
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(error.raw_os_error(), None);
+    }
+
+    #[test]
+    fn current_process_token_user_has_a_canonical_sid_string() -> Result<()> {
+        let sid = current_windows_user_sid()?;
+        assert!(sid.starts_with("S-1-"), "{sid}");
+        assert!(sid.bytes().all(|byte| byte.is_ascii_graphic()), "{sid}");
+        Ok(())
+    }
+}

--- a/crates/ctx-daemon-service/src/query_service_transport_tests.rs
+++ b/crates/ctx-daemon-service/src/query_service_transport_tests.rs
@@ -1083,9 +1083,13 @@ fn windows_pre_submission_disconnect_codes_are_classified_without_native_io() {
 
 #[test]
 fn windows_pipe_creation_source_verifies_a_protected_handle_bound_acl() {
+    let identity = include_str!("../../ctx-daemon-runtime/src/windows_identity.rs");
     let security = include_str!("../../ctx-daemon-runtime/src/ipc/server/windows_security.rs");
     let server = include_str!("../../ctx-daemon-runtime/src/ipc/server/transport.rs");
-    assert!(security.contains("GetTokenInformation"));
+    assert!(identity.contains("OpenProcessToken(GetCurrentProcess()"));
+    assert!(identity.contains("GetTokenInformation"));
+    assert!(identity.contains("TokenUser"));
+    assert!(security.contains("CurrentProcessTokenUser::current()"));
     assert!(security.contains("WinLocalSystemSid"));
     assert!(security.contains("SE_DACL_PROTECTED"));
     assert!(security.contains("GetSecurityInfo"));


### PR DESCRIPTION
Summary
- replace PATH- and locale-dependent whoami SID discovery with the current process primary token
- share the validated owned SID primitive with Windows named-pipe ACL construction
- preserve Win32 errors, validate SID bounds, and release token/string allocations with RAII

Validation
- integrated rustfmt, source diff, daemon runtime/application/service suites passed
- native Windows process-token/error-ordering tests and ctx.exe build passed
- Git Bash resolved the incompatible fake whoami first and direct invocation failed as designed
- independent final review: ship, no correctness or security findings
- final supervision invocation was blocked before product execution by Windows test-transport quoting; no product test failed

Fixes #644