### PR TITLE
perf(history): reuse retained SQLite source handles

### DIFF
--- a/crates/ctx-history-source-sqlite/src/sqlite_source/snapshot/copy_progress.rs
+++ b/crates/ctx-history-source-sqlite/src/sqlite_source/snapshot/copy_progress.rs
@@ -1,6 +1,11 @@
 use super::*;
 use fs2::FileExt as _;
 
+#[cfg(unix)]
+use std::os::unix::fs::FileExt as _;
+#[cfg(windows)]
+use std::os::windows::fs::FileExt as _;
+
 const SQLITE_SOURCE_FAMILY_COPY_PROGRESS_BYTES: u64 = 8 * 1024 * 1024;
 
 pub(super) fn copy_sqlite_member_with_progress<E>(
@@ -12,22 +17,26 @@ pub(super) fn copy_sqlite_member_with_progress<E>(
     total_bytes: u64,
     report_progress: &mut impl FnMut(SqliteSourceProgress) -> Result<(), E>,
 ) -> Result<(), SqliteSourceProgressError<E>> {
-    let mut source_file =
-        member
-            .file()
-            .try_clone()
+    #[cfg(not(any(unix, windows)))]
+    let mut source_file = {
+        let mut source_file =
+            member
+                .file()
+                .try_clone()
+                .map_err(|source| SqliteSourceAccessError::Io {
+                    operation: "retaining a provider SQLite component for snapshot copy",
+                    path: member.path.clone(),
+                    source,
+                })?;
+        source_file
+            .seek(SeekFrom::Start(0))
             .map_err(|source| SqliteSourceAccessError::Io {
-                operation: "retaining a provider SQLite component for snapshot copy",
+                operation: "seeking a provider SQLite component for snapshot copy",
                 path: member.path.clone(),
                 source,
             })?;
-    source_file
-        .seek(SeekFrom::Start(0))
-        .map_err(|source| SqliteSourceAccessError::Io {
-            operation: "seeking a provider SQLite component for snapshot copy",
-            path: member.path.clone(),
-            source,
-        })?;
+        source_file
+    };
     let mut destination_file = OpenOptions::new()
         .write(true)
         .create_new(true)
@@ -49,15 +58,19 @@ pub(super) fn copy_sqlite_member_with_progress<E>(
     let mut remaining = expected_length;
     let mut buffer = [0_u8; SQLITE_COPY_BUFFER_BYTES];
     while remaining > 0 {
+        #[cfg(any(unix, windows))]
+        let source_offset = expected_length - remaining;
         let requested = usize::try_from(remaining.min(buffer.len() as u64))
             .map_err(|_| SqliteSourceAccessError::SourceChanged)?;
-        let read = source_file
-            .read(&mut buffer[..requested])
-            .map_err(|source| SqliteSourceAccessError::Io {
-                operation: "reading a provider SQLite snapshot component",
-                path: member.path.clone(),
-                source,
-            })?;
+        #[cfg(any(unix, windows))]
+        let read = read_source_at(member.file(), &mut buffer[..requested], source_offset);
+        #[cfg(not(any(unix, windows)))]
+        let read = source_file.read(&mut buffer[..requested]);
+        let read = read.map_err(|source| SqliteSourceAccessError::Io {
+            operation: "reading a provider SQLite snapshot component",
+            path: member.path.clone(),
+            source,
+        })?;
         if read == 0 {
             return Err(SqliteSourceAccessError::SourceChanged.into());
         }
@@ -83,14 +96,15 @@ pub(super) fn copy_sqlite_member_with_progress<E>(
         }
     }
     let mut extra = [0_u8; 1];
-    if source_file
-        .read(&mut extra)
-        .map_err(|source| SqliteSourceAccessError::Io {
-            operation: "certifying a provider SQLite snapshot component length",
-            path: member.path.clone(),
-            source,
-        })?
-        != 0
+    #[cfg(any(unix, windows))]
+    let extra_read = read_source_at(member.file(), &mut extra, expected_length);
+    #[cfg(not(any(unix, windows)))]
+    let extra_read = source_file.read(&mut extra);
+    if extra_read.map_err(|source| SqliteSourceAccessError::Io {
+        operation: "certifying a provider SQLite snapshot component length",
+        path: member.path.clone(),
+        source,
+    })? != 0
     {
         return Err(SqliteSourceAccessError::SourceChanged.into());
     }
@@ -104,6 +118,16 @@ pub(super) fn copy_sqlite_member_with_progress<E>(
     Ok(())
 }
 
+#[cfg(unix)]
+fn read_source_at(file: &File, buffer: &mut [u8], offset: u64) -> std::io::Result<usize> {
+    file.read_at(buffer, offset)
+}
+
+#[cfg(windows)]
+fn read_source_at(file: &File, buffer: &mut [u8], offset: u64) -> std::io::Result<usize> {
+    file.seek_read(buffer, offset)
+}
+
 pub(super) fn report_source_family_copy_progress<E>(
     report_progress: &mut impl FnMut(SqliteSourceProgress) -> Result<(), E>,
     completed_bytes: u64,
@@ -113,4 +137,24 @@ pub(super) fn report_source_family_copy_progress<E>(
     progress.snapshot_bytes_completed = Some(completed_bytes);
     progress.snapshot_bytes_total = Some(total_bytes);
     report_progress(progress).map_err(SqliteSourceProgressError::Progress)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn positional_source_read_does_not_change_the_retained_handle_offset() {
+        let directory = tempfile::tempdir().unwrap();
+        let source_path = directory.path().join("source.sqlite");
+        std::fs::write(&source_path, b"0123456789").unwrap();
+        let mut source = File::open(&source_path).unwrap();
+        source.seek(SeekFrom::Start(7)).unwrap();
+        let mut observed = [0_u8; 4];
+
+        assert_eq!(read_source_at(&source, &mut observed, 2).unwrap(), 4);
+
+        assert_eq!(&observed, b"2345");
+        assert_eq!(source.stream_position().unwrap(), 7);
+    }
 }

--- a/docs/provider-import-policy.md
+++ b/docs/provider-import-policy.md
@@ -259,10 +259,12 @@ contract for that source family:
   Concurrent committed rows belong to a subsequent certified snapshot unless
   they are visible inside the admitted transaction. On platforms and routes
   that cannot retain a no-write snapshot directly, ctx first preallocates and
-  streams one private DB/WAL copy below its data root. Admission depends on
-  available temporary disk capacity plus safety headroom, not a fixed source
-  size ceiling; copy memory remains bounded and the private family is removed
-  when the route finishes.
+  streams one private DB/WAL copy below its data root. The stream reuses the
+  retained authority handle instead of allocating duplicate provider handles;
+  Unix reads are positional and leave that handle's mutable offset unchanged.
+  Admission depends on available temporary disk capacity plus safety headroom,
+  not a fixed source size ceiling; copy memory remains bounded and the private
+  family is removed when the route finishes.
 - JSON documents and document trees use unchanged-or-replace semantics. A
   mutation during a scan invalidates that candidate; the retry reads one
   complete replacement.


### PR DESCRIPTION
Follow-up to #646 and #651.

## Summary

- read private SQLite DB/WAL snapshots directly from the already-retained provider handle instead of allocating a duplicate handle for each family member
- use explicit offsets on Unix so snapshot copying no longer mutates the retained handle cursor; preserve the prior absolute-offset behavior on Windows and the prior fallback elsewhere
- retain the existing preallocation, 64 KiB bounded buffer, exact-length certification, DB/WAL revalidation, cleanup, and provider no-write guarantees

## Why this scope

The larger no-full-copy experiments did not clear a monotonic-safety bar:

- copy-on-write clones can make provider checkpoints or overwrites allocate deferred blocks and newly fail with `ENOSPC` while the snapshot is retained
- Linux `sendfile` remained detached but was slower than the current loop in controlled 512 MiB comparisons (106 ms vs 99 ms on XFS; 328 ms vs 256 ms on ext4)
- `copy_file_range` copied 256 MiB in about 1.3 ms, but extent inspection proved that it silently replaced the preallocated destination with shared XFS extents
- direct long-lived reads can pin WAL checkpoints; online backup still needs a portable authority-preserving, no-write SQLite source open and can restart under sustained writes

This change is narrower but monotonic: it removes a fallible OS-handle duplication and, on Unix, shared cursor mutation without changing disk use, memory bounds, copy duration semantics, or provider behavior.

## Validation

- `//crates/ctx-history-source-sqlite:unit_tests`
- all SQLite provider unit suites (logical, inventory, selected, Hermes, and OpenClaw SQLite)
- `//crates/ctx-history-source-discovery:unit_tests`
- `//crates/ctx-history-capture-composition:unit_tests`
- `//:docs_check`
- Windows GNU cross-check of the source crate and tests
- explicit ignored OpenCode resource proof above 2 GiB: copy, open, observe, and cleanup
- independent final review: ship, no findings
