### PR TITLE
fix(ci): restore release policy checks after legacy takeover

### DIFF
--- a/crates/ctx-daemon-runtime/src/handoff/termination/windows/legacy_image.rs
+++ b/crates/ctx-daemon-runtime/src/handoff/termination/windows/legacy_image.rs
@@ -133,7 +133,7 @@ impl RetainedProcessImage {
         if renamed {
             verify_adjacent_rename(&observed_path, expected_executable)?;
             let current = WindowsProcess::open(process::id(), WindowsProcessAccess::Observe)?
-                .ok_or_else(|| anyhow!("current ctx uninstall candidate is not running"))?;
+                .ok_or_else(|| anyhow!("current ctx candidate is not running"))?;
             verify_exact_process_path(&current, expected_executable)
                 .context("bind installed ctx.exe to the current uninstall candidate")?;
         }
@@ -166,7 +166,7 @@ impl RetainedProcessImage {
         if self.renamed {
             verify_adjacent_rename(&self.observed_path, expected_executable)?;
             let current = WindowsProcess::open(process::id(), WindowsProcessAccess::Observe)?
-                .ok_or_else(|| anyhow!("current ctx uninstall candidate is not running"))?;
+                .ok_or_else(|| anyhow!("current ctx candidate is not running"))?;
             verify_exact_process_path(&current, expected_executable)
                 .context("recheck installed ctx.exe current-self identity")?;
         } else if !same_windows_path(&self.observed_path, expected_executable) {

--- a/scripts/check-public-control-surface.py
+++ b/scripts/check-public-control-surface.py
@@ -509,7 +509,11 @@ def main() -> None:
     }
     for path in tracked_text_files(root, excluded):
         relative = path.relative_to(root)
-        is_test = "tests" in relative.parts or relative.name.endswith("_tests.rs")
+        is_test = (
+            "tests" in relative.parts
+            or relative.name.endswith("_tests.rs")
+            or relative.name.startswith("test-")
+        )
         if is_test:
             continue
         text = path.read_text(encoding="utf-8", errors="replace")

--- a/scripts/tests/check-public-control-surface-test.sh
+++ b/scripts/tests/check-public-control-surface-test.sh
@@ -31,6 +31,7 @@ cp "${repo_root}/crates/ctx-upgrade-engine/tests/contracts/upgrade.rs" \
   "${fixture}/crates/ctx-upgrade-engine/tests/contracts/"
 cp "${repo_root}/scripts/smoke-daemon-semantic-release.ps1" "${fixture}/scripts/"
 cp "${repo_root}/scripts/smoke-daemon-semantic-release.sh" "${fixture}/scripts/"
+cp "${repo_root}/scripts/test-windows-legacy-daemon-takeover.ps1" "${fixture}/scripts/"
 cp "${repo_root}/docs/storage.md" "${fixture}/docs/"
 
 python3 "${checker}" "${fixture}" > "${tmp}/pass.out"


### PR DESCRIPTION
## Summary

- classify repository-root test-* scripts as test-only deprecated-control consumers
- exercise that policy with the Windows v0.25 takeover fixture
- remove retired top-level command wording from internal legacy-image diagnostics

This repairs the two release-policy gates broken by #657 without changing the Windows takeover behavior.

## Validation

- affected Bazel suite: 63/63 passed
- //:public_control_surface_check
- //:package_audit_fast
- //:rustfmt_check
- //:repository_policy_check