### PR TITLE
fix(history): keep terminal route outcomes disjoint

### DIFF
--- a/crates/ctx-history-refresh-execution/src/execution.rs
+++ b/crates/ctx-history-refresh-execution/src/execution.rs
@@ -498,14 +498,16 @@ fn refresh_all_provider_sources_route_local_with_reconciliation(
     {
         return Err(registration_failures.into());
     }
-    let registry_failures = if matches!(scope, SourceBackedRefreshScope::All) {
+    let registry_route_failures = if matches!(scope, SourceBackedRefreshScope::All) {
         reject_blocking_automatic_registry_issues(&build.issues)?;
         automatic_registry_route_failures(&build.issues, retained_generation.as_ref())?
     } else {
         Vec::new()
     };
     let route_less_blockers =
-        automatic_registry_route_less_blockers(&build.issues, &registry_failures);
+        automatic_registry_route_less_blockers(&build.issues, &registry_route_failures);
+    let registry_failures =
+        terminal_registry_route_failures(registry_route_failures, &build.registry, &physical_scope);
     let previous_nonempty_routes = retained_generation
         .as_ref()
         .map(|generation| {

--- a/crates/ctx-history-refresh-execution/src/lib.rs
+++ b/crates/ctx-history-refresh-execution/src/lib.rs
@@ -52,8 +52,8 @@ use catalog_witness::reconcile_published_catalog_witness;
 use observation::{admitted_route_observations, run_after_capture_scan_before_metadata_hook};
 use registry_issues::{
     automatic_registry_admission_failures, automatic_registry_route_less_blockers,
-    selected_registry_route_count, AutomaticRegistryAdmissionFailurePolicy,
-    RouteLessRegistryBlockers,
+    selected_registry_route_count, terminal_registry_route_failures,
+    AutomaticRegistryAdmissionFailurePolicy, RouteLessRegistryBlockers,
 };
 type SourceBackedRefreshOperation = RefreshOperation;
 

--- a/crates/ctx-history-refresh-execution/src/registry_issues.rs
+++ b/crates/ctx-history-refresh-execution/src/registry_issues.rs
@@ -107,6 +107,32 @@ pub fn automatic_registry_route_failures(
     Ok(failures.into_values().collect())
 }
 
+pub(super) fn terminal_registry_route_failures(
+    failures: Vec<ctx_history_capture::SourceBackedFailedRoute>,
+    registry: &SourceBackedProviderRegistry,
+    scope: &SourceBackedRefreshScope,
+) -> Vec<ctx_history_capture::SourceBackedFailedRoute> {
+    // Discovered-winner identities deliberately coalesce alternate physical
+    // candidates. If any selected candidate registered executable or
+    // certified-missing capture authority, capture owns the route's one
+    // terminal outcome. A registry issue for a losing candidate must not
+    // fabricate a second, overlapping route-level failure.
+    let capture_owned_routes = registry
+        .routes()
+        .filter(|route| route.selection.is_some())
+        .filter_map(|route| route.route_identity.as_ref())
+        .filter(|route| match scope {
+            SourceBackedRefreshScope::All => true,
+            SourceBackedRefreshScope::Exact(selected) => selected.contains(*route),
+        })
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    failures
+        .into_iter()
+        .filter(|failure| !capture_owned_routes.contains(&failure.route_identity))
+        .collect()
+}
+
 #[derive(Clone, Copy)]
 pub(super) enum AutomaticRegistryAdmissionFailurePolicy<'a> {
     SystemicOnly,

--- a/crates/ctx-history-refresh-execution/src/tests/registry_policy.rs
+++ b/crates/ctx-history-refresh-execution/src/tests/registry_policy.rs
@@ -39,6 +39,18 @@ fn registry_policy_unsupported_warp_source(path: PathBuf) -> ProviderSource {
     source
 }
 
+fn registry_policy_unsupported_codex_source(path: PathBuf) -> ProviderSource {
+    let mut source = registry_policy_source(
+        CaptureProvider::Codex,
+        path,
+        "codex_session_jsonl_tree",
+        true,
+    );
+    source.status = ProviderSourceStatus::Unsupported;
+    source.unsupported_reason = Some("fixture alternate Codex root is intentionally unsupported");
+    source
+}
+
 fn registry_policy_nanoclaw_source(path: PathBuf) -> ProviderSource {
     registry_policy_source(CaptureProvider::NanoClaw, path, "nanoclaw_project", true)
 }
@@ -396,6 +408,44 @@ fn mixed_codex_and_unsupported_warp_routes_continue_with_typed_evidence() {
             .len(),
         1
     );
+}
+
+#[test]
+fn successful_discovered_winner_owns_a_colliding_unusable_candidate_outcome() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    let index_root = source_backed_index_root(&data_root);
+    ctx_history_platform::platform_security::establish_private_data_root(&data_root).unwrap();
+    let (_, _, discovery) = discovery_fixture(temp.path());
+    let codex_root = temp.path().join("codex-sessions");
+    let unsupported_codex_root = temp.path().join("unsupported-codex-sessions");
+    write_registry_policy_codex_rollout(&codex_root);
+    std::fs::create_dir_all(&unsupported_codex_root).unwrap();
+    let codex_source = provider_source_for_path(CaptureProvider::Codex, codex_root);
+    let unsupported_codex_source = registry_policy_unsupported_codex_source(unsupported_codex_root);
+    assert_eq!(
+        automatic_source_backed_route_identity(&codex_source).unwrap(),
+        automatic_source_backed_route_identity(&unsupported_codex_source).unwrap(),
+    );
+
+    let publication = run_report(
+        &discovery,
+        DiscoveryReport {
+            sources: vec![codex_source, unsupported_codex_source],
+            issues: Vec::new(),
+        },
+        &data_root,
+        &index_root,
+    )
+    .unwrap();
+
+    assert_eq!(publication.route_results.len(), 1);
+    assert!(publication.route_results[0].outcome.is_success());
+    assert!(publication.route_results[0].source_failures.is_empty());
+    // The losing candidate remains counted as unsupported inventory without
+    // becoming a second terminal outcome for the successful logical route.
+    assert_eq!(publication.unsupported_routes, 1);
+    assert_eq!(publication.certified_source_count, 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- keep capture-owned discovered-winner routes as the sole owners of their terminal outcomes
- filter registry failures from losing path candidates that collide with the same path-independent logical route
- preserve unsupported inventory accounting and strict fail-closed publication partitioning

## Regression

A healthy Codex sessions root and an unusable archived-sessions candidate can intentionally resolve to one logical route ID. Previously, capture reported success for that route while registry issue handling also fabricated a failure for it, so publication rejected the duplicate terminal outcomes. The regression test exercises that exact topology and requires one successful route, no source failure, and retained unsupported inventory telemetry.

## Validation

- red-before/green-after end-to-end registry policy regression
- `scripts/bazel-affected.sh origin/main` (64/64 passing)
- public push guard passed