### PR TITLE
fix(release): require native macOS ONNX runtime evidence

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -386,6 +386,76 @@ steps:
       - "target/public-cli-artifacts/ctx-onnxruntime-linux-aarch64*"
       - "target/public-cli-artifacts/ctx-onnxruntime-macos-arm64*"
 
+  - label: ":test_tube: macOS arm64 final CLI/runtime semantic execution"
+    key: "github-macos-arm64-semantic-native-smoke"
+    depends_on:
+      - "github-release-candidate"
+      - "semantic-runtime-portable"
+    if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1" && build.env("CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX") == "1" && build.env("CTX_PUBLIC_SEMANTIC_ASSET_MATRIX") == "1" && build.branch == "main" && build.pull_request.id == null
+    command: |
+      mkdir -p target/public-cli-artifacts target/public-cli-semantic-native-smoke/macos-arm64
+      buildkite-agent artifact download \
+        "target/github-core-release-assets/ctx-macos-arm64" . \
+        --step github-release-candidate
+      buildkite-agent artifact download \
+        "target/public-cli-artifacts/ctx-onnxruntime-macos-arm64*" . \
+        --step semantic-runtime-portable
+      scripts/check-macos-release-signing.sh \
+        macos-arm64 runtime \
+        target/public-cli-artifacts/ctx-onnxruntime-macos-arm64.tar.gz
+      scripts/smoke-daemon-semantic-release.sh \
+        --runtime-archive target/public-cli-artifacts/ctx-onnxruntime-macos-arm64.tar.gz \
+        --runtime-platform macos-arm64 \
+        --ctx target/github-core-release-assets/ctx-macos-arm64 \
+        --data-root target/public-cli-semantic-native-smoke/macos-arm64/runs \
+        --require-authoritative \
+        --receipt target/public-cli-semantic-native-smoke/macos-arm64/ctx-macos-arm64.semantic-execution.json
+    agents:
+      queue: "ctx-release-macos-arm64"
+      os: "darwin"
+      arch: "arm64"
+    concurrency: 1
+    concurrency_group: "ctx/github-macos-arm64-semantic-native"
+    timeout_in_minutes: 180
+    artifact_paths:
+      - "target/public-cli-semantic-native-smoke/macos-arm64/ctx-macos-arm64.semantic-execution.json"
+
+  - label: ":test_tube: macOS x64 final CLI/runtime semantic execution"
+    key: "github-macos-x64-semantic-native-smoke"
+    depends_on:
+      - "github-release-candidate"
+      - "public-cli-macos-x64-runtime-producer"
+    if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1" && build.env("CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX") == "1" && build.env("CTX_PUBLIC_SEMANTIC_ASSET_MATRIX") == "1" && build.branch == "main" && build.pull_request.id == null
+    command: |
+      mkdir -p target/public-cli-artifacts target/public-cli-semantic-native-smoke/macos-x64
+      buildkite-agent artifact download \
+        "target/github-core-release-assets/ctx-macos-x64" . \
+        --step github-release-candidate
+      buildkite-agent artifact download \
+        "target/public-cli-artifacts/ctx-onnxruntime-macos-x64*" . \
+        --step public-cli-macos-x64-runtime-producer
+      scripts/check-macos-release-signing.sh \
+        macos-x64 runtime \
+        target/public-cli-artifacts/ctx-onnxruntime-macos-x64.tar.gz
+      scripts/smoke-daemon-semantic-release.sh \
+        --runtime-archive target/public-cli-artifacts/ctx-onnxruntime-macos-x64.tar.gz \
+        --runtime-platform macos-x64 \
+        --ctx target/github-core-release-assets/ctx-macos-x64 \
+        --data-root target/public-cli-semantic-native-smoke/macos-x64/runs \
+        --require-authoritative \
+        --receipt target/public-cli-semantic-native-smoke/macos-x64/ctx-macos-x64.semantic-execution.json
+    agents:
+      queue: "ctx-mac-gui-shared-x64"
+      os: "darwin"
+      arch: "x86_64"
+    env:
+      CTX_RELEASE_MACOS_X64_KVM_RUNNER_ID: "ctx-mac-gui-shared-x64"
+    concurrency: 1
+    concurrency_group: "ctx/github-macos-x64-semantic-native"
+    timeout_in_minutes: 240
+    artifact_paths:
+      - "target/public-cli-semantic-native-smoke/macos-x64/ctx-macos-x64.semantic-execution.json"
+
   - label: ":package: assemble complete GitHub release assets"
     key: "github-release-assets"
     depends_on:
@@ -393,11 +463,16 @@ steps:
       - "semantic-runtime-portable"
       - "public-cli-macos-x64-runtime-producer"
       - "semantic-runtime-windows-ml"
+      - "github-macos-arm64-semantic-native-smoke"
+      - "github-macos-x64-semantic-native-smoke"
     if: build.env("CTX_PUBLIC_CLI_ARTIFACT_MATRIX") == "1" && build.env("CTX_PUBLIC_CLI_NATIVE_SMOKE_MATRIX") == "1" && build.env("CTX_PUBLIC_SEMANTIC_ASSET_MATRIX") == "1" && build.branch == "main" && build.pull_request.id == null
     command: |
-      mkdir -p target/public-cli-artifacts
+      mkdir -p target/public-cli-artifacts target/public-cli-semantic-native-smoke
       buildkite-agent artifact download \
         "target/github-core-release-assets/*" . \
+        --step github-release-candidate
+      buildkite-agent artifact download \
+        "target/github-release-authority/*" . \
         --step github-release-candidate
       buildkite-agent artifact download \
         "target/public-cli-artifacts/ctx-onnxruntime-linux-x64.tar.gz*" . \
@@ -406,17 +481,21 @@ steps:
         "target/public-cli-artifacts/ctx-onnxruntime-linux-aarch64.tar.gz*" . \
         --step semantic-runtime-portable
       buildkite-agent artifact download \
-        "target/public-cli-artifacts/ctx-onnxruntime-macos-arm64.tar.gz*" . \
+        "target/public-cli-artifacts/ctx-onnxruntime-macos-arm64*" . \
         --step semantic-runtime-portable
       buildkite-agent artifact download \
-        "target/public-cli-artifacts/ctx-onnxruntime-macos-x64.tar.gz*" . \
+        "target/public-cli-artifacts/ctx-onnxruntime-macos-x64*" . \
         --step public-cli-macos-x64-runtime-producer
       buildkite-agent artifact download \
         "*ctx-onnxruntime-windows-x64.zip*" . \
         --step semantic-runtime-windows-ml
+      scripts/buildkite/download-authenticated-semantic-receipt.sh macos-arm64
+      scripts/buildkite/download-authenticated-semantic-receipt.sh macos-x64
       scripts/assemble-github-release-assets.sh \
         target/github-core-release-assets \
+        target/github-release-authority \
         target/public-cli-artifacts \
+        target/public-cli-semantic-native-smoke \
         target/github-release-assets
     agents:
       queue: "release-linux-managed"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -613,9 +613,20 @@ sh_test(
     name = "assemble_github_release_assets_tests",
     srcs = ["scripts/tests/assemble-github-release-assets-test.sh"],
     data = [
+        "scripts/apple-developer-id-g2-ca.pem",
         "scripts/assemble-github-release-assets.sh",
+        "scripts/macos-release-publisher-policy.sh",
+        "scripts/macos-release-signing-evidence.py",
         "scripts/release/release_bundle.py",
+        "scripts/verify-macos-release-attestation.sh",
     ],
+    tags = ["release-gate"],
+)
+
+sh_test(
+    name = "authenticated_semantic_receipt_tests",
+    srcs = ["scripts/tests/download-authenticated-semantic-receipt-test.sh"],
+    data = ["scripts/buildkite/download-authenticated-semantic-receipt.sh"],
     tags = ["release-gate"],
 )
 
@@ -660,6 +671,7 @@ sh_test(
         "scripts/semantic_release_assets/common.py",
         "scripts/semantic_release_assets/contracts.py",
         "scripts/smoke-daemon-semantic-release.sh",
+        "scripts/write-semantic-execution-receipt.sh",
     ],
     tags = ["release-gate"],
     target_compatible_with = ["@platforms//os:linux"],

--- a/scripts/assemble-github-release-assets.sh
+++ b/scripts/assemble-github-release-assets.sh
@@ -3,11 +3,15 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<'USAGE'
-Usage: scripts/assemble-github-release-assets.sh CORE_DIR RUNTIME_DIR [OUT_DIR]
+Usage: scripts/assemble-github-release-assets.sh CORE_DIR CORE_AUTHORITY_DIR RUNTIME_DIR SEMANTIC_PROOF_DIR [OUT_DIR]
 
 Combines an independently staged Core GitHub handoff with the five qualified
-ONNX Runtime transports. OUT_DIR defaults to target/github-release-assets.
-The input directories are never modified and the output is published once.
+ONNX Runtime transports. Final assembly requires cryptographic macOS runtime
+signing/attestation evidence plus authoritative native semantic execution
+receipts for macOS arm64 and untranslated x64. OUT_DIR defaults to
+target/github-release-assets. The input directories are never modified and the
+output is published once. Source authority comes from scrubbed checkout HEAD
+plus the exact Core handoff; caller-provided source commits are rejected.
 USAGE
 }
 
@@ -16,17 +20,21 @@ die() {
   exit 1
 }
 
-[[ $# -ge 2 && $# -le 3 ]] || {
+[[ $# -ge 4 && $# -le 5 ]] || {
   usage
   exit 2
 }
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 bundle_tool="${repo_root}/scripts/release/release_bundle.py"
+signing_evidence_tool="${repo_root}/scripts/macos-release-signing-evidence.py"
+attestation_verifier="${repo_root}/scripts/verify-macos-release-attestation.sh"
 core_dir="$1"
-runtime_dir="$2"
-out_dir="${3:-target/github-release-assets}"
-for variable in core_dir runtime_dir out_dir; do
+core_authority_dir="$2"
+runtime_dir="$3"
+semantic_proof_dir="$4"
+out_dir="${5:-target/github-release-assets}"
+for variable in core_dir core_authority_dir runtime_dir semantic_proof_dir out_dir; do
   value="${!variable}"
   [[ "${value}" != -* ]] || die "release directory cannot start with '-': ${value}"
   if [[ "${value}" != /* ]]; then
@@ -35,9 +43,13 @@ for variable in core_dir runtime_dir out_dir; do
 done
 
 python3 -I "${bundle_tool}" require-directory --directory "${core_dir}"
+python3 -I "${bundle_tool}" require-directory --directory "${core_authority_dir}"
 python3 -I "${bundle_tool}" require-directory --directory "${runtime_dir}"
+python3 -I "${bundle_tool}" require-directory --directory "${semantic_proof_dir}"
 python3 -I "${bundle_tool}" preflight-publication \
   --input-dir "${core_dir}" --output-dir "${out_dir}"
+python3 -I "${bundle_tool}" preflight-publication \
+  --input-dir "${core_authority_dir}" --output-dir "${out_dir}"
 python3 -I "${bundle_tool}" preflight-publication \
   --input-dir "${runtime_dir}" --output-dir "${out_dir}"
 
@@ -102,6 +114,174 @@ require_regular() {
   [[ -f "$1" && ! -L "$1" ]] || die "$2 must be a regular non-symlink file: $1"
 }
 
+[[ -z "${CTX_PUBLIC_RELEASE_SOURCE_COMMIT:-}" ]] \
+  || die "caller-provided CTX_PUBLIC_RELEASE_SOURCE_COMMIT is not accepted by final assembly"
+git_environment=(
+  GIT_ALTERNATE_OBJECT_DIRECTORIES
+  GIT_CEILING_DIRECTORIES
+  GIT_COMMON_DIR
+  GIT_CONFIG_COUNT
+  GIT_CONFIG_GLOBAL
+  GIT_CONFIG_NOSYSTEM
+  GIT_CONFIG_PARAMETERS
+  GIT_CONFIG_SYSTEM
+  GIT_DIR
+  GIT_DISCOVERY_ACROSS_FILESYSTEM
+  GIT_EXEC_PATH
+  GIT_GRAFT_FILE
+  GIT_INDEX_FILE
+  GIT_NAMESPACE
+  GIT_OBJECT_DIRECTORY
+  GIT_REPLACE_REF_BASE
+  GIT_SHALLOW_FILE
+  GIT_WORK_TREE
+)
+for git_variable in "${git_environment[@]}"; do
+  [[ -z "${!git_variable+x}" ]] \
+    || die "hostile Git repository override is not accepted: ${git_variable}"
+done
+git_scrub=()
+for git_variable in "${git_environment[@]}"; do
+  git_scrub+=( -u "${git_variable}" )
+done
+source_commit="$(
+  env "${git_scrub[@]}" git -C "${repo_root}" rev-parse --verify HEAD^{commit}
+)" || die "could not resolve scrubbed final assembly checkout HEAD"
+[[ "${source_commit}" =~ ^[0-9a-f]{40}$ && ! "${source_commit}" =~ ^0{40}$ ]] \
+  || die "final assembly checkout source commit is invalid"
+buildkite_build_id="${BUILDKITE_BUILD_ID:-}"
+buildkite_build_number="${BUILDKITE_BUILD_NUMBER:-}"
+[[ "${buildkite_build_id}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ \
+  && "${buildkite_build_number}" =~ ^[1-9][0-9]*$ ]] \
+  || die "final assembly requires immutable Buildkite build identity"
+
+staged=""
+validation_work="$(mktemp -d "${TMPDIR:-/tmp}/ctx-github-release-validation.XXXXXX")"
+cleanup() {
+  if [[ -n "${staged:-}" && -d "${staged}" && ! -L "${staged}" ]]; then
+    rm -rf -- "${staged}"
+  fi
+  if [[ -n "${validation_work:-}" && -d "${validation_work}" \
+    && ! -L "${validation_work}" ]]; then
+    rm -rf -- "${validation_work}"
+  fi
+}
+trap cleanup EXIT
+
+python3 -I - "${core_dir}" "${core_authority_dir}" "${source_commit}" <<'PY'
+import hashlib
+import json
+import stat
+import sys
+from pathlib import Path
+
+core_root = Path(sys.argv[1])
+root = Path(sys.argv[2])
+source_commit = sys.argv[3]
+candidates = (
+    "ctx-linux-aarch64.candidate.json",
+    "ctx.candidate.json",
+    "ctx-macos-arm64.candidate.json",
+    "ctx-macos-x64.candidate.json",
+    "ctx.exe.candidate.json",
+)
+expected = {
+    *(name for candidate in candidates for name in (candidate, f"{candidate}.sha256")),
+    "SHA256SUMS",
+    "ctx-core-github-handoff.json",
+    "ctx-core-github-handoff.json.sha256",
+    "ctx-core.release-complete.json",
+    "ctx.exe",
+    "ctx.exe.build-info.json",
+    "ctx.exe.cdx.json",
+    "ctx.exe.size.json",
+    "ctx.exe.third-party-notices.txt",
+    "ctx-release-factory.json",
+}
+def regular_bytes(path: Path, label: str, maximum: int = 512 * 1024 * 1024) -> bytes:
+    try:
+        metadata = path.lstat()
+    except OSError as error:
+        raise SystemExit(f"{label} is unavailable: {path}") from error
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise SystemExit(f"{label} must be a regular non-symlink file")
+    if metadata.st_size <= 0 or metadata.st_size > maximum:
+        raise SystemExit(f"{label} has an invalid size")
+    return path.read_bytes()
+
+
+actual = {entry.name for entry in root.iterdir()}
+if actual != expected:
+    raise SystemExit("Core authority handoff inventory is not exact")
+for name in expected:
+    regular_bytes(root / name, f"Core authority leaf {name}")
+
+handoff_raw = regular_bytes(root / "ctx-core-github-handoff.json", "Core authority handoff", 64 * 1024)
+handoff_sha = hashlib.sha256(handoff_raw).hexdigest()
+handoff_sum = regular_bytes(
+    root / "ctx-core-github-handoff.json.sha256", "Core authority handoff checksum", 128
+)
+if handoff_sum != f"{handoff_sha}\n".encode("ascii"):
+    raise SystemExit("Core authority handoff checksum mismatch")
+try:
+    handoff = json.loads(handoff_raw)
+except (UnicodeDecodeError, json.JSONDecodeError) as error:
+    raise SystemExit("Core authority handoff is malformed") from error
+if (
+    not isinstance(handoff, dict)
+    or set(handoff) != {
+        "candidate_manifests",
+        "factory_completion",
+        "factory_manifest",
+        "kind",
+        "release_sums",
+        "schema_version",
+        "source_commit",
+    }
+    or handoff.get("kind") != "ctx-public-core-github-handoff"
+    or handoff.get("schema_version") != 1
+    or handoff.get("source_commit") != source_commit
+):
+    raise SystemExit("Core authority handoff does not bind scrubbed checkout HEAD")
+
+
+def verify_record(record: object, name: str, label: str) -> None:
+    payload = regular_bytes(root / name, label)
+    expected_record = {
+        "file": name,
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "size_bytes": len(payload),
+    }
+    if record != expected_record:
+        raise SystemExit(f"Core authority handoff has a mismatched {label} record")
+
+
+records = handoff.get("candidate_manifests")
+if not isinstance(records, list) or len(records) != len(candidates):
+    raise SystemExit("Core authority handoff candidate manifest inventory is invalid")
+for record, name in zip(records, candidates, strict=True):
+    verify_record(record, name, name)
+    payload = regular_bytes(root / name, name)
+    sidecar = regular_bytes(root / f"{name}.sha256", f"{name} checksum", 128)
+    if sidecar != f"{hashlib.sha256(payload).hexdigest()}\n".encode("ascii"):
+        raise SystemExit(f"Core authority candidate checksum mismatch: {name}")
+verify_record(
+    handoff.get("factory_completion"),
+    "ctx-core.release-complete.json",
+    "factory completion",
+)
+verify_record(
+    handoff.get("factory_manifest"),
+    "ctx-release-factory.json",
+    "factory manifest",
+)
+verify_record(handoff.get("release_sums"), "SHA256SUMS", "release checksum manifest")
+authority_sums = regular_bytes(root / "SHA256SUMS", "authority release checksum manifest", 4096)
+core_sums = regular_bytes(core_root / "SHA256SUMS", "Core release checksum manifest", 4096)
+if authority_sums != core_sums:
+    raise SystemExit("Core assets and source-bound authority use different SHA256SUMS")
+PY
+
 declare -A core_digests=()
 core_names=()
 core_sums="${core_dir%/}/SHA256SUMS"
@@ -142,13 +322,333 @@ for asset in "${runtime_assets[@]}"; do
   runtime_digests["${asset}"]="${actual}"
 done
 
-staged="$(mktemp -d "$(dirname "${out_dir}")/.github-release-final.XXXXXX")"
-cleanup() {
-  if [[ -n "${staged:-}" && -d "${staged}" && ! -L "${staged}" ]]; then
-    rm -rf -- "${staged}"
-  fi
+declare -A macos_nested_artifacts=()
+for platform in macos-arm64 macos-x64; do
+  prefix="ctx-onnxruntime-${platform}"
+  archive="${runtime_dir%/}/${prefix}.tar.gz"
+  checksum="${archive}.sha256"
+  signing_evidence="${runtime_dir%/}/${prefix}.signing.json"
+  notary_submit="${runtime_dir%/}/${prefix}.notary-submit.json"
+  artifact_attestation="${runtime_dir%/}/${prefix}.attestation.json"
+  artifact_attestation_cms="${runtime_dir%/}/${prefix}.attestation.cms"
+  release_attestation="${runtime_dir%/}/${prefix}.release-attestation.json"
+  release_attestation_cms="${runtime_dir%/}/${prefix}.release-attestation.cms"
+  for evidence_path in \
+    "${signing_evidence}" \
+    "${notary_submit}" \
+    "${artifact_attestation}" \
+    "${artifact_attestation_cms}" \
+    "${release_attestation}" \
+    "${release_attestation_cms}"; do
+    require_regular "${evidence_path}" "macOS runtime release evidence"
+    [[ -s "${evidence_path}" ]] || die "macOS runtime release evidence is empty: ${evidence_path}"
+  done
+
+  nested_artifact="${validation_work}/${platform}/libonnxruntime.dylib"
+  mkdir -p "$(dirname "${nested_artifact}")"
+  python3 -I - "${archive}" "${nested_artifact}" <<'PY'
+import shutil
+import stat
+import sys
+import tarfile
+from pathlib import PurePosixPath
+
+archive, output = sys.argv[1:]
+expected_files = {
+    "GIT_COMMIT_ID",
+    "LICENSE",
+    "ThirdPartyNotices.txt",
+    "VERSION_NUMBER",
+    "lib/libonnxruntime.dylib",
 }
-trap cleanup EXIT
+expected_entries = expected_files | {"lib"}
+members = {}
+with tarfile.open(archive, "r:gz") as bundle:
+    for member in bundle.getmembers():
+        name = member.name[:-1] if member.name.endswith("/") else member.name
+        path = PurePosixPath(name)
+        if (
+            not name
+            or path.is_absolute()
+            or str(path) != name
+            or any(part in {"", ".", ".."} for part in path.parts)
+            or name in members
+            or name not in expected_entries
+            or member.mode & 0o7000
+        ):
+            raise SystemExit(f"unsafe or unexpected macOS runtime archive entry: {member.name!r}")
+        if name == "lib":
+            if not member.isdir():
+                raise SystemExit("macOS runtime lib entry is not a directory")
+        elif not member.isfile() or stat.S_ISLNK(member.mode):
+            raise SystemExit(f"macOS runtime entry is not a regular file: {name}")
+        members[name] = member
+    if set(members) != expected_entries:
+        raise SystemExit("macOS runtime archive does not have the exact release layout")
+    source = bundle.extractfile(members["lib/libonnxruntime.dylib"])
+    if source is None:
+        raise SystemExit("could not read final lib/libonnxruntime.dylib")
+    with source, open(output, "xb") as destination:
+        shutil.copyfileobj(source, destination)
+PY
+  [[ -s "${nested_artifact}" ]] || die "final macOS runtime dylib is empty"
+  macos_nested_artifacts["${platform}"]="${nested_artifact}"
+
+  python3 -I "${signing_evidence_tool}" verify-archive \
+    --evidence "${signing_evidence}" \
+    --platform "${platform}" \
+    --archive "${archive}" \
+    --checksum "${checksum}" \
+    --nested-artifact "${nested_artifact}" \
+    --role release
+  python3 -I - \
+    "${signing_evidence}" "${notary_submit}" \
+    "${artifact_attestation}" "${release_attestation}" <<'PY'
+import hashlib
+import json
+import sys
+
+signing_path, notary_path, artifact_path, release_path = sys.argv[1:]
+with open(signing_path, encoding="utf-8") as source:
+    signing = json.load(source)
+with open(artifact_path, encoding="utf-8") as source:
+    artifact = json.load(source)
+with open(release_path, encoding="utf-8") as source:
+    release = json.load(source)
+with open(notary_path, "rb") as source:
+    notary_sha256 = hashlib.sha256(source.read()).hexdigest()
+
+codesign = signing.get("codesign") if isinstance(signing, dict) else None
+notarization = signing.get("notarization") if isinstance(signing, dict) else None
+identity = (
+    codesign.get("authority") if isinstance(codesign, dict) else None,
+    codesign.get("team_identifier") if isinstance(codesign, dict) else None,
+)
+if (
+    identity != (artifact.get("codesign_authority"), artifact.get("team_identifier"))
+    or identity != (release.get("codesign_authority"), release.get("team_identifier"))
+):
+    raise SystemExit(
+        "macOS runtime signing evidence identity does not match its cryptographic attestations"
+    )
+if not isinstance(notarization, dict) or notarization.get("submit_sha256") != notary_sha256:
+    raise SystemExit("macOS runtime signing evidence does not bind the notarization response")
+PY
+  CTX_MACOS_RELEASE_SOURCE_COMMIT="${source_commit}" \
+    "${attestation_verifier}" \
+      "${platform}" runtime "${nested_artifact}" \
+      "${artifact_attestation}" "${artifact_attestation_cms}" >/dev/null
+  CTX_MACOS_RELEASE_SOURCE_COMMIT="${source_commit}" \
+    "${attestation_verifier}" --runtime-archive \
+      "${platform}" "${archive}" "${nested_artifact}" \
+      "${release_attestation}" "${release_attestation_cms}" >/dev/null
+done
+
+python3 -I - \
+  "${core_dir}" "${runtime_dir}" "${semantic_proof_dir}" \
+  "${macos_nested_artifacts[macos-arm64]}" \
+  "${macos_nested_artifacts[macos-x64]}" \
+  "${source_commit}" "${buildkite_build_id}" "${buildkite_build_number}" <<'PY'
+import hashlib
+import json
+import re
+import stat
+import sys
+from pathlib import Path
+
+core_root = Path(sys.argv[1])
+runtime_root = Path(sys.argv[2])
+proof_root = Path(sys.argv[3])
+nested = {
+    "macos-arm64": Path(sys.argv[4]),
+    "macos-x64": Path(sys.argv[5]),
+}
+source_commit = sys.argv[6]
+build_id = sys.argv[7]
+build_number = int(sys.argv[8])
+uuid = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+)
+producer_steps = {
+    "macos-arm64": "github-macos-arm64-semantic-native-smoke",
+    "macos-x64": "github-macos-x64-semantic-native-smoke",
+}
+
+
+def digest(path: Path, label: str, maximum: int) -> str:
+    try:
+        metadata = path.lstat()
+    except OSError as error:
+        raise SystemExit(f"{label} is unavailable: {path}") from error
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise SystemExit(f"{label} must be a regular non-symlink file")
+    if metadata.st_size <= 0 or metadata.st_size > maximum:
+        raise SystemExit(f"{label} has an invalid size")
+    value = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            value.update(chunk)
+    return value.hexdigest()
+
+
+def require_exact_host(platform: str, host: object) -> None:
+    if not isinstance(host, dict) or set(host) != {
+        "arch",
+        "emulation",
+        "evidence_complete",
+        "hardware_identity",
+        "hypervisor",
+        "native_arch",
+        "native_arch_probe",
+        "process_translated",
+        "runner_id",
+        "system",
+    }:
+        raise SystemExit(f"native semantic receipt has invalid {platform} host evidence")
+    if (
+        host["system"] != "Darwin"
+        or host["native_arch_probe"] != "sysctl"
+        or host["process_translated"] != 0
+        or host["evidence_complete"] is not True
+    ):
+        raise SystemExit(f"native semantic receipt is not untranslated complete {platform} evidence")
+    if platform == "macos-arm64":
+        valid = (
+            host["arch"] == "arm64"
+            and host["native_arch"] == "arm64"
+            and host["hardware_identity"] == "apple"
+            and host["emulation"] == "none"
+            and host["hypervisor"] == "absent"
+            and host["runner_id"] == ""
+        )
+    else:
+        physical = (
+            host["hardware_identity"] == "apple"
+            and host["emulation"] == "none"
+            and host["hypervisor"] == "absent"
+            and host["runner_id"] == ""
+        )
+        pinned_untranslated = (
+            host["hardware_identity"] == "generic"
+            and host["emulation"] == "qemu-kvm"
+            and host["hypervisor"] == "present"
+            and host["runner_id"] == "ctx-mac-gui-shared-x64"
+        )
+        valid = (
+            host["arch"] == "x86_64"
+            and host["native_arch"] == "x86_64"
+            and (physical or pinned_untranslated)
+        )
+    if not valid:
+        raise SystemExit(f"native semantic receipt has non-authoritative {platform} host evidence")
+
+
+for platform in ("macos-arm64", "macos-x64"):
+    proof = proof_root / platform / f"ctx-{platform}.semantic-execution.json"
+    proof_sha256 = digest(proof, f"{platform} native semantic receipt", 64 * 1024)
+    artifact_path = (
+        f"target/public-cli-semantic-native-smoke/{platform}/"
+        f"ctx-{platform}.semantic-execution.json"
+    )
+    authority_path = proof.with_name(
+        f"ctx-{platform}.semantic-execution.artifact-authority.json"
+    )
+    digest(authority_path, f"{platform} semantic receipt artifact authority", 64 * 1024)
+    try:
+        value = json.loads(proof.read_text(encoding="utf-8"))
+        artifact_authority = json.loads(authority_path.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SystemExit(f"native semantic receipt authority is malformed for {platform}") from error
+    expected_step = producer_steps[platform]
+    if (
+        not isinstance(artifact_authority, dict)
+        or artifact_authority
+        != {
+            "artifact_path": artifact_path,
+            "artifact_sha256": proof_sha256,
+            "attempt_selection": "latest",
+            "build_id": build_id,
+            "build_number": build_number,
+            "kind": "ctx-buildkite-semantic-receipt-artifact-authority",
+            "producer_job_id": artifact_authority.get("producer_job_id"),
+            "producer_step_key": expected_step,
+            "schema_version": 1,
+        }
+        or uuid.fullmatch(str(artifact_authority.get("producer_job_id"))) is None
+    ):
+        raise SystemExit(
+            f"{platform} semantic receipt lacks exact Buildkite artifact authority"
+        )
+    provenance = value.get("provenance") if isinstance(value, dict) else None
+    if (
+        not isinstance(provenance, dict)
+        or set(provenance) != {
+            "build_id",
+            "build_number",
+            "job_id",
+            "retry_count",
+            "source_commit",
+            "step_key",
+        }
+        or provenance.get("build_id") != build_id
+        or provenance.get("build_number") != build_number
+        or provenance.get("source_commit") != source_commit
+        or provenance.get("step_key") != expected_step
+        or provenance.get("job_id") != artifact_authority.get("producer_job_id")
+        or uuid.fullmatch(str(provenance.get("job_id"))) is None
+        or isinstance(provenance.get("retry_count"), bool)
+        or not isinstance(provenance.get("retry_count"), int)
+        or provenance["retry_count"] < 0
+    ):
+        raise SystemExit(
+            f"{platform} semantic receipt provenance is replayed or forged"
+        )
+    cli_name = f"ctx-{platform}"
+    runtime_name = f"ctx-onnxruntime-{platform}.tar.gz"
+    expected_cli = {"name": cli_name, "sha256": digest(core_root / cli_name, "final CLI", 256 * 1024 * 1024)}
+    expected_runtime = {
+        "name": runtime_name,
+        "nested_artifact_name": "lib/libonnxruntime.dylib",
+        "nested_artifact_sha256": digest(nested[platform], "final nested runtime", 256 * 1024 * 1024),
+        "sha256": digest(runtime_root / runtime_name, "final runtime archive", 1024 * 1024 * 1024),
+    }
+    expected_semantic = {
+        "effective_mode": "semantic",
+        "indexed_chunks_minimum": 1,
+        "model_key": "e5-small-v1:mean-pool:l2:query-passage",
+        "requested_mode": "semantic",
+        "status": "ready",
+    }
+    if (
+        not isinstance(value, dict)
+        or set(value) != {
+            "authority",
+            "backend",
+            "cli_artifact",
+            "host_evidence",
+            "kind",
+            "platform",
+            "provenance",
+            "runtime_archive",
+            "schema_version",
+            "semantic",
+            "status",
+        }
+        or value.get("schema_version") != 2
+        or value.get("kind") != "ctx-semantic-native-execution"
+        or value.get("platform") != platform
+        or value.get("status") != "passed"
+        or value.get("authority") != "authoritative"
+        or value.get("backend") != "onnxruntime-cpu"
+        or value.get("cli_artifact") != expected_cli
+        or value.get("runtime_archive") != expected_runtime
+        or value.get("semantic") != expected_semantic
+    ):
+        raise SystemExit(f"native semantic receipt does not bind the exact final {platform} CLI/runtime bytes")
+    require_exact_host(platform, value.get("host_evidence"))
+PY
+
+staged="$(mktemp -d "$(dirname "${out_dir}")/.github-release-final.XXXXXX")"
 
 for asset in "${core_assets[@]}"; do
   mode=0644
@@ -176,5 +676,7 @@ done
 
 python3 -I "${bundle_tool}" commit-directory \
   --stage-dir "${staged}" --output-dir "${out_dir}"
+rm -rf -- "${validation_work}"
+validation_work=""
 trap - EXIT
 printf 'assembled GitHub release assets in %s\n' "${out_dir}"

--- a/scripts/buildkite/download-authenticated-semantic-receipt.sh
+++ b/scripts/buildkite/download-authenticated-semantic-receipt.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/buildkite/download-authenticated-semantic-receipt.sh PLATFORM
+
+Downloads the latest-attempt semantic receipt from its exact producer job in
+the current Buildkite build, verifies the Buildkite API SHA-256, and writes a
+local artifact-authority record for final release assembly.
+USAGE
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ $# -eq 1 ]] || {
+  usage
+  exit 2
+}
+
+platform="$1"
+case "${platform}" in
+  macos-arm64)
+    producer_step="github-macos-arm64-semantic-native-smoke"
+    ;;
+  macos-x64)
+    producer_step="github-macos-x64-semantic-native-smoke"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+proof_root="${repo_root}/target/public-cli-semantic-native-smoke"
+
+build_id="${BUILDKITE_BUILD_ID:-}"
+build_number="${BUILDKITE_BUILD_NUMBER:-}"
+uuid_pattern='^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+[[ "${build_id}" =~ ${uuid_pattern} && "${build_number}" =~ ^[1-9][0-9]*$ ]] \
+  || die "authenticated receipt download requires immutable Buildkite build identity"
+command -v buildkite-agent >/dev/null 2>&1 \
+  || die "buildkite-agent is required for authenticated receipt download"
+
+artifact_path="target/public-cli-semantic-native-smoke/${platform}/ctx-${platform}.semantic-execution.json"
+local_receipt="${proof_root%/}/${platform}/ctx-${platform}.semantic-execution.json"
+authority="${proof_root%/}/${platform}/ctx-${platform}.semantic-execution.artifact-authority.json"
+mkdir -p "$(dirname "${local_receipt}")"
+for output in "${local_receipt}" "${authority}"; do
+  [[ ! -e "${output}" && ! -L "${output}" ]] \
+    || die "authenticated receipt output already exists: ${output}"
+done
+
+mapfile -t matches < <(
+  BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS=false \
+    buildkite-agent artifact search "${artifact_path}" \
+    --step "${producer_step}" \
+    --build "${build_id}" \
+    --format '%j\t%p\t%T\n'
+)
+[[ "${#matches[@]}" == "1" && -n "${matches[0]}" ]] \
+  || die "expected exactly one latest-attempt ${platform} semantic receipt artifact"
+IFS=$'\t' read -r producer_job_id matched_path artifact_sha256 extra <<<"${matches[0]}"
+[[ -z "${extra:-}" \
+  && "${producer_job_id}" =~ ${uuid_pattern} \
+  && "${matched_path}" == "${artifact_path}" \
+  && "${artifact_sha256}" =~ ^[0-9a-f]{64}$ ]] \
+  || die "Buildkite returned malformed semantic receipt artifact authority"
+
+(
+  cd "${repo_root}"
+  BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS=false \
+    buildkite-agent artifact download "${artifact_path}" . \
+    --step "${producer_job_id}" \
+    --build "${build_id}"
+)
+[[ -f "${local_receipt}" && ! -L "${local_receipt}" && -s "${local_receipt}" ]] \
+  || die "authenticated semantic receipt download did not produce a regular file"
+if command -v sha256sum >/dev/null 2>&1; then
+  local_sha256="$(sha256sum "${local_receipt}" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  local_sha256="$(shasum -a 256 "${local_receipt}" | awk '{print $1}')"
+else
+  die "sha256sum or shasum is required"
+fi
+[[ "${local_sha256}" == "${artifact_sha256}" ]] \
+  || die "downloaded semantic receipt does not match Buildkite artifact SHA-256"
+
+python3 -I - \
+  "${authority}" "${artifact_path}" "${artifact_sha256}" \
+  "${build_id}" "${build_number}" "${producer_job_id}" "${producer_step}" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+output_text, artifact_path, artifact_sha256, build_id, build_number, job_id, step_key = sys.argv[1:]
+document = {
+    "artifact_path": artifact_path,
+    "artifact_sha256": artifact_sha256,
+    "attempt_selection": "latest",
+    "build_id": build_id,
+    "build_number": int(build_number),
+    "kind": "ctx-buildkite-semantic-receipt-artifact-authority",
+    "producer_job_id": job_id,
+    "producer_step_key": step_key,
+    "schema_version": 1,
+}
+output = Path(output_text)
+temporary = output.with_name(f".{output.name}.tmp.{os.getpid()}")
+descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+try:
+    with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as stream:
+        json.dump(document, stream, sort_keys=True, separators=(",", ":"))
+        stream.write("\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    if output.exists() or output.is_symlink():
+        raise SystemExit(f"artifact authority already exists: {output}")
+    os.replace(temporary, output)
+finally:
+    temporary.unlink(missing_ok=True)
+PY
+
+printf 'authenticated Buildkite semantic receipt: %s job=%s\n' \
+  "${platform}" "${producer_job_id}"

--- a/scripts/check-buildkite-pipeline.sh
+++ b/scripts/check-buildkite-pipeline.sh
@@ -6,6 +6,7 @@ for required in \
   "${pipeline}" \
   scripts/buildkite-public-ci.sh \
   scripts/buildkite/download-linux-factory-artifacts.sh \
+  scripts/buildkite/download-authenticated-semantic-receipt.sh \
   scripts/release/build-public-candidate-on-linux.sh \
   scripts/validate-public-cli-factory-artifact.sh \
   scripts/stage-github-release-assets.sh \
@@ -69,6 +70,8 @@ required = {
     "public-cli-macos-x64-native-smoke",
     "public-cli-windows-x64-native-smoke",
     "github-release-candidate",
+    "github-macos-arm64-semantic-native-smoke",
+    "github-macos-x64-semantic-native-smoke",
     "github-release-assets",
     "semantic-model-archives",
     "semantic-coreml-archive",
@@ -399,12 +402,85 @@ if (
 if "download-linux-factory-artifacts.sh" in macos_x64_runtime.get("command", ""):
     fail("macos-x64 Semantic runtime producer must not consume Core artifacts")
 
+semantic_native = {
+    "github-macos-arm64-semantic-native-smoke": (
+        "macos-arm64",
+        "ctx-release-macos-arm64",
+        "arm64",
+        "semantic-runtime-portable",
+        "github-release-candidate",
+    ),
+    "github-macos-x64-semantic-native-smoke": (
+        "macos-x64",
+        "ctx-mac-gui-shared-x64",
+        "x86_64",
+        "public-cli-macos-x64-runtime-producer",
+        "github-release-candidate",
+    ),
+}
+for key, (platform, queue, arch, runtime_step, core_step) in semantic_native.items():
+    step = keyed[key]
+    if step.get("depends_on") != [core_step, runtime_step]:
+        fail(f"{key} must join only the exact native Core proof and runtime producer")
+    if step.get("if") != github_release_condition:
+        fail(f"{key} has the wrong complete GitHub release condition")
+    if step.get("allow_dependency_failure") or step.get("soft_fail") or step.get("skip"):
+        fail(f"{key} must fail closed")
+    agents = step.get("agents", {})
+    if (agents.get("queue"), agents.get("os"), agents.get("arch")) != (
+        queue,
+        "darwin",
+        arch,
+    ):
+        fail(f"{key} has the wrong native macOS runner")
+    command = step.get("command", "")
+    logical_command = re.sub(r"\\\n[ \t]*", " ", command)
+    if (
+        command.count("buildkite-agent artifact download") != 2
+        or command.count("--step github-release-candidate") != 1
+        or command.count(f"--step {runtime_step}") != 1
+        or f"target/github-core-release-assets/ctx-{platform}" not in command
+        or f"--ctx target/github-core-release-assets/ctx-{platform}" not in logical_command
+        or f"ctx-onnxruntime-{platform}*" not in command
+        or command.count("check-macos-release-signing.sh") != 1
+        or command.count("smoke-daemon-semantic-release.sh") != 1
+        or f"--runtime-platform {platform}" not in logical_command
+        or "--require-authoritative" not in command
+        or f"ctx-{platform}.semantic-execution.json" not in command
+        or "--receipt" not in command
+        or "download-linux-factory-artifacts.sh" in command
+        or "validate-public-cli-factory-artifact.sh" in command
+    ):
+        fail(f"{key} must execute the exact final signed CLI/runtime and emit one receipt")
+    for forbidden in (
+        "build-onnxruntime-sidecar.sh",
+        "run-macos-release-signing.sh",
+        "stage-github-release-assets.sh --transcode-runtime",
+        "cargo build",
+        "cargo zigbuild",
+    ):
+        if forbidden in command:
+            fail(f"{key} must never rebuild, re-sign, or transcode final bytes ({forbidden})")
+    if step.get("artifact_paths") != [
+        f"target/public-cli-semantic-native-smoke/{platform}/ctx-{platform}.semantic-execution.json"
+    ]:
+        fail(f"{key} must upload only its sanitized exact-byte semantic receipt")
+
+if keyed["github-macos-arm64-semantic-native-smoke"].get("env") is not None:
+    fail("macOS arm64 semantic execution must not claim the pinned x64 runner")
+if keyed["github-macos-x64-semantic-native-smoke"].get("env") != {
+    "CTX_RELEASE_MACOS_X64_KVM_RUNNER_ID": "ctx-mac-gui-shared-x64"
+}:
+    fail("macOS x64 semantic execution must bind the pinned untranslated x64 runner")
+
 github_release = keyed["github-release-assets"]
 expected_github_dependencies = [
     "github-release-candidate",
     "semantic-runtime-portable",
     "public-cli-macos-x64-runtime-producer",
     "semantic-runtime-windows-ml",
+    "github-macos-arm64-semantic-native-smoke",
+    "github-macos-x64-semantic-native-smoke",
 ]
 if github_release.get("depends_on") != expected_github_dependencies:
     fail("final GitHub assembly has the wrong independent producer set")
@@ -415,17 +491,32 @@ if github_release.get("allow_dependency_failure") or github_release.get("soft_fa
 github_release_command = github_release.get("command", "")
 if (
     github_release_command.count("assemble-github-release-assets.sh") != 1
+    or github_release_command.count("download-authenticated-semantic-receipt.sh") != 2
     or github_release_command.count("--step semantic-runtime-portable") != 3
     or github_release_command.count("--step public-cli-macos-x64-runtime-producer") != 1
     or github_release_command.count("--step semantic-runtime-windows-ml") != 1
-    or github_release_command.count("--step github-release-candidate") != 1
+    or github_release_command.count("--step github-release-candidate") != 2
+    or "ctx-onnxruntime-macos-arm64*" not in github_release_command
+    or "ctx-onnxruntime-macos-x64*" not in github_release_command
+    or "target/public-cli-semantic-native-smoke" not in github_release_command
+    or "download-authenticated-semantic-receipt.sh macos-arm64" not in github_release_command
+    or "download-authenticated-semantic-receipt.sh macos-x64" not in github_release_command
     or "target/github-core-release-assets" not in github_release_command
+    or "target/github-release-authority" not in github_release_command
     or "target/github-release-assets" not in github_release_command
 ):
     fail("final GitHub assembly must join the exact Core and five-runtime handoffs")
 for forbidden in ("multilingual-e5", "cuda12", "windowsml"):
     if forbidden in github_release_command.lower():
         fail(f"final GitHub assembly unexpectedly consumes {forbidden}")
+for forbidden in (
+    "CTX_PUBLIC_RELEASE_SOURCE_COMMIT",
+    "git rev-parse",
+    "--step github-macos-arm64-semantic-native-smoke",
+    "--step github-macos-x64-semantic-native-smoke",
+):
+    if forbidden in github_release_command:
+        fail(f"final GitHub assembly bypasses authenticated source/receipt authority ({forbidden})")
 if github_release.get("artifact_paths") != ["target/github-release-assets/*"]:
     fail("final GitHub assembly must upload only the complete public asset set")
 
@@ -469,6 +560,10 @@ for key in semantic_keys:
         dependencies = [dependencies]
     if set(dependencies) & (core_keys | {"sdk-swift-required"}):
         fail(f"{key} crosses from the Semantic graph into Core/SDK work")
+for key, (_, _, _, runtime_step, core_step) in semantic_native.items():
+    dependencies = keyed[key].get("depends_on", [])
+    if dependencies != [core_step, runtime_step]:
+        fail(f"{key} lost its single explicit Core/Semantic join boundary")
 
 for step in steps:
     command = str(step.get("command", ""))
@@ -480,7 +575,8 @@ for step in steps:
 
 print(
     "Buildkite release pipeline: independent Core/SDK/Semantic graphs, "
-    "five exact-byte Core validators"
+    "five exact-byte Core validators, source-bound Core authority, and two "
+    "authenticated final-byte macOS semantic receipts"
 )
 PY
 

--- a/scripts/public-cli-runtime-authority.sh
+++ b/scripts/public-cli-runtime-authority.sh
@@ -72,12 +72,6 @@ case "${runtime_status}" in
     fi
     case "${hardware_identity}:${emulation}:${hypervisor}:${evidence_complete}" in
       apple:none:absent:1|generic:none:absent:1|generic:none:present:1|generic:none:unknown:1) ;;
-      apple:none:present:1)
-        if [[ "${platform}" != "macos-arm64" ]]; then
-          printf 'non_authoritative\n'
-          exit 0
-        fi
-        ;;
       generic:qemu-kvm:present:1)
         if [[ "${platform}" != "macos-x64" || "${runner_id}" != "${pinned_macos_x64_kvm_runner}" ]]; then
           printf 'non_authoritative\n'
@@ -109,10 +103,9 @@ case "${runtime_status}" in
         ;;
     esac
     if [[ "${platform}" == "macos-arm64" ]]; then
-      # Apple Silicon guests execute arm64 natively; a present hypervisor is
-      # authoritative only when the remaining Apple and no-emulation facts agree.
+      # Release-governing arm64 evidence must come from physical Apple hardware.
       case "${hardware_identity}:${emulation}:${hypervisor}" in
-        apple:none:absent|apple:none:present) ;;
+        apple:none:absent) ;;
         *)
           printf 'non_authoritative\n'
           exit 0

--- a/scripts/smoke-daemon-semantic-release.sh
+++ b/scripts/smoke-daemon-semantic-release.sh
@@ -5,7 +5,7 @@ umask 077
 usage() {
   cat >&2 <<'USAGE'
 Usage:
-  scripts/smoke-daemon-semantic-release.sh --runtime-archive PATH --runtime-platform PLATFORM [--ctx PATH] [--data-root DIR] [--timeout-seconds N] [--require-authoritative] [--keep-root]
+  scripts/smoke-daemon-semantic-release.sh --runtime-archive PATH --runtime-platform PLATFORM [--ctx PATH] [--data-root DIR] [--timeout-seconds N] [--require-authoritative] [--receipt PATH] [--keep-root]
   scripts/smoke-daemon-semantic-release.sh --coreml --runtime-platform macos-arm64|macos-x64 [--coreml-archive PATH] [--ctx PATH] [--data-root DIR] [--timeout-seconds N] [--require-authoritative] [--keep-root]
 
 Native release smoke for opt-in daemon + semantic search. The smoke creates an
@@ -21,6 +21,8 @@ production acquisition path without publication. When --data-root is provided,
 it is the parent for a fresh unique run root; --keep-root preserves that child
 for inspection. --require-authoritative fails unless host evidence confirms
 native execution for the requested platform.
+--receipt writes a sanitized exact-byte native ONNX semantic execution receipt;
+it requires --runtime-archive and --require-authoritative.
 USAGE
 }
 
@@ -35,6 +37,7 @@ timeout_seconds="${CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS:-900}"
 keep_root=0
 coreml_mode=0
 require_authoritative=0
+receipt_path=""
 
 while (($# > 0)); do
   case "$1" in
@@ -64,6 +67,10 @@ while (($# > 0)); do
     --require-authoritative)
       require_authoritative=1
       ;;
+    --receipt)
+      shift
+      receipt_path="${1:-}"
+      ;;
     --timeout-seconds)
       shift
       timeout_seconds="${1:-}"
@@ -86,6 +93,84 @@ done
 if [[ -z "${ctx_bin}" ]]; then
   echo "error: --ctx cannot be empty" >&2
   exit 2
+fi
+
+if [[ -n "${receipt_path}" ]]; then
+  if [[ "${coreml_mode}" == "1" ]]; then
+    echo "error: --receipt requires --runtime-archive" >&2
+    exit 2
+  fi
+  if [[ "${require_authoritative}" != "1" ]]; then
+    echo "error: --receipt requires --require-authoritative" >&2
+    exit 2
+  fi
+  receipt_parent="$(dirname "${receipt_path}")"
+  receipt_name="$(basename "${receipt_path}")"
+  if [[ -z "${receipt_name}" || "${receipt_name}" == "." || "${receipt_name}" == ".." ]]; then
+    echo "error: --receipt must name a file" >&2
+    exit 2
+  fi
+  mkdir -p -- "${receipt_parent}"
+  receipt_parent="$(cd -- "${receipt_parent}" && pwd -P)"
+  receipt_path="${receipt_parent%/}/${receipt_name}"
+  if [[ -e "${receipt_path}" || -L "${receipt_path}" ]]; then
+    echo "error: semantic smoke receipt already exists: ${receipt_path}" >&2
+    exit 1
+  fi
+  for buildkite_variable in \
+    BUILDKITE_BUILD_ID \
+    BUILDKITE_BUILD_NUMBER \
+    BUILDKITE_JOB_ID \
+    BUILDKITE_RETRY_COUNT \
+    BUILDKITE_STEP_KEY; do
+    [[ -n "${!buildkite_variable:-}" ]] || {
+      echo "error: --receipt requires ${buildkite_variable}" >&2
+      exit 2
+    }
+  done
+  uuid_pattern='^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+  [[ "${BUILDKITE_BUILD_ID}" =~ ${uuid_pattern} \
+    && "${BUILDKITE_JOB_ID}" =~ ${uuid_pattern} ]] || {
+    echo "error: semantic receipt Buildkite build/job identity is malformed" >&2
+    exit 2
+  }
+  [[ "${BUILDKITE_BUILD_NUMBER}" =~ ^[1-9][0-9]*$ \
+    && "${BUILDKITE_RETRY_COUNT}" =~ ^(0|[1-9][0-9]*)$ \
+    && "${BUILDKITE_STEP_KEY}" =~ ^[A-Za-z0-9][A-Za-z0-9_-]{0,99}$ ]] || {
+    echo "error: semantic receipt Buildkite attempt/step identity is malformed" >&2
+    exit 2
+  }
+  receipt_repo_root="$(cd -- "${script_dir}/.." && pwd -P)"
+  receipt_source_commit="$(
+    env \
+      -u GIT_ALTERNATE_OBJECT_DIRECTORIES \
+      -u GIT_CEILING_DIRECTORIES \
+      -u GIT_COMMON_DIR \
+      -u GIT_CONFIG_COUNT \
+      -u GIT_CONFIG_GLOBAL \
+      -u GIT_CONFIG_NOSYSTEM \
+      -u GIT_CONFIG_PARAMETERS \
+      -u GIT_CONFIG_SYSTEM \
+      -u GIT_DIR \
+      -u GIT_DISCOVERY_ACROSS_FILESYSTEM \
+      -u GIT_EXEC_PATH \
+      -u GIT_GRAFT_FILE \
+      -u GIT_INDEX_FILE \
+      -u GIT_NAMESPACE \
+      -u GIT_OBJECT_DIRECTORY \
+      -u GIT_REPLACE_REF_BASE \
+      -u GIT_SHALLOW_FILE \
+      -u GIT_WORK_TREE \
+      git -C "${receipt_repo_root}" rev-parse --verify HEAD^{commit}
+  )" || {
+    echo "error: semantic receipt could not resolve scrubbed checkout HEAD" >&2
+    exit 1
+  }
+  [[ "${receipt_source_commit}" =~ ^[0-9a-f]{40}$ \
+    && ! "${receipt_source_commit}" =~ ^0{40}$ ]] || {
+    echo "error: semantic receipt checkout source commit is malformed" >&2
+    exit 1
+  }
 fi
 if [[ -z "${runtime_platform}" ]]; then
   echo "error: --runtime-platform is required" >&2
@@ -415,6 +500,17 @@ EOF
   }
   grep -F '"manager": "ctx-explicit-metadata-installer"' "${ctx_bin}.install.json" >/dev/null
   grep -F '"metadata_trust": "explicit-unsigned"' "${runtime_install_dir}/ctx-runtime-install.json" >/dev/null
+  if command -v sha256sum >/dev/null 2>&1; then
+    installed_binary_sha="$(sha256sum "${ctx_bin}" | awk '{ print $1 }')"
+    installed_runtime_sha="$(sha256sum "${runtime_dylib}" | awk '{ print $1 }')"
+  else
+    installed_binary_sha="$(shasum -a 256 "${ctx_bin}" | awk '{ print $1 }')"
+    installed_runtime_sha="$(shasum -a 256 "${runtime_dylib}" | awk '{ print $1 }')"
+  fi
+  if [[ "${installed_binary_sha}" != "${binary_sha}" ]]; then
+    echo "error: installed semantic smoke CLI differs from the supplied final artifact" >&2
+    exit 1
+  fi
 fi
 marker="ctx-release-semantic-smoke-$(python3 -I -c 'import uuid; print(uuid.uuid4().hex)')"
 query="synthetic release retrieval cobalt willow transit"
@@ -721,6 +817,37 @@ if not any(marker in text for result in results for text in strings(result)):
 PY
 }
 
+write_semantic_receipt() {
+  [[ -n "${receipt_path}" ]] || return 0
+  "${script_dir}/write-semantic-execution-receipt.sh" \
+    "${receipt_path}" \
+    "${runtime_platform}" \
+    "${release_binary}" \
+    "${binary_sha}" \
+    "${expected_runtime_asset}" \
+    "${actual_runtime_sha_lower}" \
+    "${runtime_dylib_name}" \
+    "${installed_runtime_sha}" \
+    "${host_system}" \
+    "${host_arch}" \
+    "${host_native_arch}" \
+    "${process_translated}" \
+    "${native_arch_probe}" \
+    "${hardware_identity}" \
+    "${emulation}" \
+    "${hypervisor}" \
+    "${evidence_complete}" \
+    "${CTX_RELEASE_MACOS_X64_KVM_RUNNER_ID:-}" \
+    "${runtime_authority}" \
+    "${semantic_model_key}" \
+    "${receipt_source_commit}" \
+    "${BUILDKITE_BUILD_ID}" \
+    "${BUILDKITE_BUILD_NUMBER}" \
+    "${BUILDKITE_JOB_ID}" \
+    "${BUILDKITE_RETRY_COUNT}" \
+    "${BUILDKITE_STEP_KEY}"
+}
+
 while ((SECONDS < deadline)); do
   if ! kill -0 "${daemon_pid}" >/dev/null 2>&1; then
     echo "ctx semantic smoke: daemon exited before search succeeded" >&2
@@ -755,6 +882,7 @@ while ((SECONDS < deadline)); do
           echo "error: daemon reported a downloaded model without populating the clean cache" >&2
           exit 1
         fi
+        write_semantic_receipt
         printf 'ctx semantic smoke ok: strict semantic search found %s with %s\n' \
           "${marker}" "${semantic_model_key}"
         exit 0

--- a/scripts/tests/assemble-github-release-assets-test.sh
+++ b/scripts/tests/assemble-github-release-assets-test.sh
@@ -6,12 +6,111 @@ if [[ -n "${TEST_SRCDIR:-}" && -n "${TEST_WORKSPACE:-}" ]]; then
 else
   source_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 fi
-assembler="${source_root}/scripts/assemble-github-release-assets.sh"
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/ctx-assemble-github-assets.XXXXXX")"
 trap 'rm -rf "${tmp}"' EXIT
+test_repo="${tmp}/repo"
+mkdir -p "${test_repo}/scripts/release"
+for source in \
+  scripts/apple-developer-id-g2-ca.pem \
+  scripts/assemble-github-release-assets.sh \
+  scripts/macos-release-publisher-policy.sh \
+  scripts/macos-release-signing-evidence.py \
+  scripts/release/release_bundle.py \
+  scripts/verify-macos-release-attestation.sh; do
+  mkdir -p "${test_repo}/$(dirname "${source}")"
+  cp -L "${source_root}/${source}" "${test_repo}/${source}"
+done
+chmod 0755 \
+  "${test_repo}/scripts/assemble-github-release-assets.sh" \
+  "${test_repo}/scripts/macos-release-signing-evidence.py" \
+  "${test_repo}/scripts/verify-macos-release-attestation.sh"
+git -C "${test_repo}" init -q
+git -C "${test_repo}" config user.name 'ctx release assembly test'
+git -C "${test_repo}" config user.email 'ctx-release-assembly@example.invalid'
+git -C "${test_repo}" add .
+git -C "${test_repo}" commit -qm 'seal assembly fixture checkout'
+source_commit="$(git -C "${test_repo}" rev-parse --verify HEAD^{commit})"
+assembler="${test_repo}/scripts/assemble-github-release-assets.sh"
+evidence_tool="${test_repo}/scripts/macos-release-signing-evidence.py"
 core="${tmp}/core"
+core_authority="${tmp}/core-authority"
 runtime="${tmp}/runtime"
-mkdir -p "${core}" "${runtime}"
+proof="${tmp}/semantic-proof"
+fake_bin="${tmp}/fake-bin"
+mkdir -p "${core}" "${core_authority}" "${runtime}" "${proof}" "${fake_bin}"
+buildkite_build_id='11111111-1111-4111-8111-111111111111'
+buildkite_build_number=42
+
+cat > "${fake_bin}/openssl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+command_name="${1:-}"
+shift || true
+case "${command_name}" in
+  version)
+    printf 'OpenSSL 3.3.0 ctx test fixture\n'
+    ;;
+  cms)
+    if [[ "${1:-}" == "-help" ]]; then
+      printf '%s\n' '-no-CApath -no-CAstore -ignore_critical'
+      exit 0
+    fi
+    input=""
+    signer=""
+    while (($# > 0)); do
+      case "$1" in
+        -in) input="$2"; shift 2 ;;
+        -signer) signer="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    [[ -n "${input}" && -n "${signer}" ]]
+    [[ "$(cat "${input}")" == "valid-cms" ]] || exit 1
+    printf '%s\n' \
+      '-----BEGIN CERTIFICATE-----' \
+      'fake signer certificate' \
+      '-----END CERTIFICATE-----' > "${signer}"
+    ;;
+  x509)
+    if [[ " $* " == *' -fingerprint '* ]]; then
+      printf '%s\n' 'sha256 Fingerprint=F1:6C:D3:C5:4C:7F:83:CE:A4:BF:1A:3E:6A:08:19:C8:AA:A8:E4:A1:52:8F:D1:44:71:5F:35:06:43:D2:DF:3A'
+    elif [[ " $* " == *' -subject '* ]]; then
+      team="${CTX_TEST_FAKE_SIGNER_TEAM_ID:-TESTTEAM01}"
+      if [[ "${team}" == "TESTTEAM01" ]]; then
+        name='Fixture Publisher'
+      else
+        name='Other Publisher'
+      fi
+      printf 'subject=OU=%s,CN=Developer ID Application: %s (%s)\n' \
+        "${team}" "${name}" "${team}"
+    elif [[ " $* " == *' -ext extendedKeyUsage '* ]]; then
+      printf '%s\n' 'X509v3 Extended Key Usage:' '    Code Signing'
+    elif [[ " $* " == *' -ext keyUsage '* ]]; then
+      printf '%s\n' 'X509v3 Key Usage: critical' '    Digital Signature'
+    elif [[ " $* " == *' -text '* ]]; then
+      printf '%s\n' '1.2.840.113635.100.6.1.13: critical'
+    else
+      exit 1
+    fi
+    ;;
+  verify)
+    exit 0
+    ;;
+  dgst)
+    team_id="$(cat)"
+    if [[ "${team_id}" == "TESTTEAM01" ]]; then
+      printf '%s *stdin\n' '013a2701d0f3400afe5257f41fce0e2d4276ef37981e443b1d3aeb442a95763c'
+    else
+      printf '%s' "${team_id}" | sha256sum | awk '{print $1 " *stdin"}'
+    fi
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+SH
+chmod 0755 "${fake_bin}/openssl"
+export PATH="${fake_bin}:${PATH}"
 
 core_assets=(
   ctx-linux-x64
@@ -43,13 +142,330 @@ for asset in "${core_assets[@]}"; do
   printf '%s  %s\n' "$(sha256sum "${core}/${asset}" | awk '{print $1}')" "${asset}" \
     >> "${core}/SHA256SUMS"
 done
+cp "${core}/SHA256SUMS" "${core_authority}/SHA256SUMS"
+for candidate in \
+  ctx-linux-aarch64.candidate.json \
+  ctx.candidate.json \
+  ctx-macos-arm64.candidate.json \
+  ctx-macos-x64.candidate.json \
+  ctx.exe.candidate.json; do
+  printf '{"fixture":"%s"}\n' "${candidate}" > "${core_authority}/${candidate}"
+  sha256sum "${core_authority}/${candidate}" | awk '{print $1}' \
+    > "${core_authority}/${candidate}.sha256"
+done
+for authority_leaf in \
+  ctx-core.release-complete.json \
+  ctx.exe \
+  ctx.exe.build-info.json \
+  ctx.exe.cdx.json \
+  ctx.exe.size.json \
+  ctx.exe.third-party-notices.txt \
+  ctx-release-factory.json; do
+  printf 'Core authority fixture: %s\n' "${authority_leaf}" \
+    > "${core_authority}/${authority_leaf}"
+done
+python3 - "${core_authority}" "${source_commit}" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+source_commit = sys.argv[2]
+candidates = (
+    "ctx-linux-aarch64.candidate.json",
+    "ctx.candidate.json",
+    "ctx-macos-arm64.candidate.json",
+    "ctx-macos-x64.candidate.json",
+    "ctx.exe.candidate.json",
+)
+
+
+def record(name):
+    raw = (root / name).read_bytes()
+    return {"file": name, "sha256": hashlib.sha256(raw).hexdigest(), "size_bytes": len(raw)}
+
+
+document = {
+    "candidate_manifests": [record(name) for name in candidates],
+    "factory_completion": record("ctx-core.release-complete.json"),
+    "factory_manifest": record("ctx-release-factory.json"),
+    "kind": "ctx-public-core-github-handoff",
+    "release_sums": record("SHA256SUMS"),
+    "schema_version": 1,
+    "source_commit": source_commit,
+}
+raw = (json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n").encode()
+(root / "ctx-core-github-handoff.json").write_bytes(raw)
+(root / "ctx-core-github-handoff.json.sha256").write_text(
+    hashlib.sha256(raw).hexdigest() + "\n", encoding="ascii"
+)
+PY
 for asset in "${runtime_assets[@]}"; do
+  case "${asset}" in
+    ctx-onnxruntime-macos-*) continue ;;
+  esac
   printf 'qualified runtime fixture: %s\n' "${asset}" > "${runtime}/${asset}"
   sha256sum "${runtime}/${asset}" | awk '{print $1}' > "${runtime}/${asset}.sha256"
 done
 
+authority='Developer ID Application: Fixture Publisher (TESTTEAM01)'
+for platform in macos-arm64 macos-x64; do
+  prefix="ctx-onnxruntime-${platform}"
+  package="${tmp}/package-${platform}"
+  mkdir -p "${package}/lib"
+  printf 'license\n' > "${package}/LICENSE"
+  printf 'notices\n' > "${package}/ThirdPartyNotices.txt"
+  printf '1.27.0\n' > "${package}/VERSION_NUMBER"
+  printf '0123456789abcdef0123456789abcdef01234567\n' > "${package}/GIT_COMMIT_ID"
+  printf 'signed ctx Team runtime fixture: %s\n' "${platform}" \
+    > "${package}/lib/libonnxruntime.dylib"
+  archive="${runtime}/${prefix}.tar.gz"
+  tar --no-recursion -czf "${archive}" -C "${package}" \
+    GIT_COMMIT_ID LICENSE ThirdPartyNotices.txt VERSION_NUMBER lib \
+    lib/libonnxruntime.dylib
+  sha256sum "${archive}" | awk '{print $1}' > "${archive}.sha256"
+  notary="${runtime}/${prefix}.notary-submit.json"
+  printf '{"id":"fixture-%s","status":"Accepted"}\n' "${platform}" > "${notary}"
+  python3 - "${archive}" "${package}/lib/libonnxruntime.dylib" \
+    "${notary}" "${runtime}/${prefix}.signing.json" "${platform}" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+archive, nested, notary, output, platform = map(Path, sys.argv[1:])
+
+
+def sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+value = {
+    "artifact_kind": "runtime",
+    "artifact_name": "libonnxruntime.dylib",
+    "artifact_sha256": sha256(nested),
+    "artifact_verification": {
+        "method": "accepted-notary-strict-codesign-attestation",
+        "status": "passed",
+    },
+    "codesign": {
+        "authority": "Developer ID Application: Fixture Publisher (TESTTEAM01)",
+        "hardened_runtime": True,
+        "identifier": "ctx",
+        "secure_timestamp": True,
+        "team_identifier": "TESTTEAM01",
+        "verified": True,
+    },
+    "notarization": {
+        "status": "Accepted",
+        "submission_id": f"fixture-{platform}",
+        "submit_sha256": sha256(notary),
+    },
+    "packages": [
+        {
+            "archive_name": archive.name,
+            "archive_sha256": sha256(archive),
+            "nested_artifact_sha256": sha256(nested),
+            "role": "release",
+        }
+    ],
+    "platform": str(platform),
+    "schema_version": 2,
+}
+output.write_text(json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n")
+PY
+  python3 "${evidence_tool}" create-attestation \
+    --output "${runtime}/${prefix}.attestation.json" \
+    --platform "${platform}" --kind runtime \
+    --artifact "${package}/lib/libonnxruntime.dylib" \
+    --notary-submit "${notary}" --source-commit "${source_commit}" \
+    --codesign-authority "${authority}"
+  python3 "${evidence_tool}" create-runtime-archive-attestation \
+    --output "${runtime}/${prefix}.release-attestation.json" \
+    --platform "${platform}" --archive "${archive}" \
+    --nested-artifact "${package}/lib/libonnxruntime.dylib" \
+    --notary-submit "${notary}" --source-commit "${source_commit}" \
+    --codesign-authority "${authority}"
+  printf 'valid-cms\n' > "${runtime}/${prefix}.attestation.cms"
+  printf 'valid-cms\n' > "${runtime}/${prefix}.release-attestation.cms"
+
+  mkdir -p "${proof}/${platform}"
+  python3 - "${core}/ctx-${platform}" "${archive}" \
+    "${package}/lib/libonnxruntime.dylib" \
+    "${proof}/${platform}/ctx-${platform}.semantic-execution.json" \
+    "${platform}" "${source_commit}" "${buildkite_build_id}" \
+    "${buildkite_build_number}" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+cli, archive, nested, output, platform = map(Path, sys.argv[1:6])
+source_commit, build_id, build_number = sys.argv[6:]
+
+
+def sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+if str(platform) == "macos-arm64":
+    host = {
+        "arch": "arm64",
+        "emulation": "none",
+        "evidence_complete": True,
+        "hardware_identity": "apple",
+        "hypervisor": "absent",
+        "native_arch": "arm64",
+        "native_arch_probe": "sysctl",
+        "process_translated": 0,
+        "runner_id": "",
+        "system": "Darwin",
+    }
+else:
+    host = {
+        "arch": "x86_64",
+        "emulation": "qemu-kvm",
+        "evidence_complete": True,
+        "hardware_identity": "generic",
+        "hypervisor": "present",
+        "native_arch": "x86_64",
+        "native_arch_probe": "sysctl",
+        "process_translated": 0,
+        "runner_id": "ctx-mac-gui-shared-x64",
+        "system": "Darwin",
+    }
+step_key = f"github-{platform}-semantic-native-smoke"
+job_id = (
+    "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    if str(platform) == "macos-arm64"
+    else "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+)
+value = {
+    "authority": "authoritative",
+    "backend": "onnxruntime-cpu",
+    "cli_artifact": {"name": cli.name, "sha256": sha256(cli)},
+    "host_evidence": host,
+    "kind": "ctx-semantic-native-execution",
+    "platform": str(platform),
+    "provenance": {
+        "build_id": build_id,
+        "build_number": int(build_number),
+        "job_id": job_id,
+        "retry_count": 1,
+        "source_commit": source_commit,
+        "step_key": step_key,
+    },
+    "runtime_archive": {
+        "name": archive.name,
+        "nested_artifact_name": "lib/libonnxruntime.dylib",
+        "nested_artifact_sha256": sha256(nested),
+        "sha256": sha256(archive),
+    },
+    "schema_version": 2,
+    "semantic": {
+        "effective_mode": "semantic",
+        "indexed_chunks_minimum": 1,
+        "model_key": "e5-small-v1:mean-pool:l2:query-passage",
+        "requested_mode": "semantic",
+        "status": "ready",
+    },
+    "status": "passed",
+}
+output.write_text(json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n")
+receipt_sha256 = sha256(output)
+authority_output = output.with_name(
+    f"ctx-{platform}.semantic-execution.artifact-authority.json"
+)
+artifact_authority = {
+    "artifact_path": (
+        f"target/public-cli-semantic-native-smoke/{platform}/"
+        f"ctx-{platform}.semantic-execution.json"
+    ),
+    "artifact_sha256": receipt_sha256,
+    "attempt_selection": "latest",
+    "build_id": build_id,
+    "build_number": int(build_number),
+    "kind": "ctx-buildkite-semantic-receipt-artifact-authority",
+    "producer_job_id": job_id,
+    "producer_step_key": step_key,
+    "schema_version": 1,
+}
+authority_output.write_text(
+    json.dumps(artifact_authority, sort_keys=True, separators=(",", ":")) + "\n"
+)
+PY
+done
+
+expect_failure() {
+  local name="$1"
+  local expected="$2"
+  local core_input="$3"
+  local core_authority_input="$4"
+  local runtime_input="$5"
+  local proof_input="$6"
+  local output="${7:-${tmp}/${name}-output}"
+  if BUILDKITE_BUILD_ID="${buildkite_build_id}" \
+    BUILDKITE_BUILD_NUMBER="${buildkite_build_number}" \
+    bash "${assembler}" \
+      "${core_input}" "${core_authority_input}" \
+      "${runtime_input}" "${proof_input}" "${output}" \
+    > "${tmp}/${name}.out" 2> "${tmp}/${name}.err"; then
+    printf 'assembler accepted invalid input: %s\n' "${name}" >&2
+    exit 1
+  fi
+  grep -Fq "${expected}" "${tmp}/${name}.err" || {
+    printf 'unexpected assembler failure for %s\n' "${name}" >&2
+    cat "${tmp}/${name}.err" >&2
+    exit 1
+  }
+  if [[ "${name}" != "existing" ]]; then
+    test ! -e "${output}"
+  fi
+}
+
+refresh_receipt_authority_sha() {
+  local proof_root="$1"
+  local platform="$2"
+  python3 - \
+    "${proof_root}/${platform}/ctx-${platform}.semantic-execution.json" \
+    "${proof_root}/${platform}/ctx-${platform}.semantic-execution.artifact-authority.json" <<'PY'
+import hashlib
+import json
+import sys
+
+receipt, authority = sys.argv[1:]
+with open(receipt, "rb") as source:
+    digest = hashlib.sha256(source.read()).hexdigest()
+with open(authority, encoding="utf-8") as source:
+    value = json.load(source)
+value["artifact_sha256"] = digest
+with open(authority, "w", encoding="utf-8") as output:
+    json.dump(value, output, sort_keys=True, separators=(",", ":"))
+    output.write("\n")
+PY
+}
+
 output="${tmp}/release"
-bash "${assembler}" "${core}" "${runtime}" "${output}"
+if CTX_PUBLIC_RELEASE_SOURCE_COMMIT="${source_commit}" \
+  BUILDKITE_BUILD_ID="${buildkite_build_id}" \
+  BUILDKITE_BUILD_NUMBER="${buildkite_build_number}" \
+  bash "${assembler}" \
+    "${core}" "${core_authority}" "${runtime}" "${proof}" \
+    "${tmp}/caller-commit-output" \
+  > "${tmp}/caller-commit.out" 2> "${tmp}/caller-commit.err"; then
+  printf 'assembler trusted a caller-provided source commit\n' >&2
+  exit 1
+fi
+grep -Fq \
+  'caller-provided CTX_PUBLIC_RELEASE_SOURCE_COMMIT is not accepted' \
+  "${tmp}/caller-commit.err"
+test ! -e "${tmp}/caller-commit-output"
+
+BUILDKITE_BUILD_ID="${buildkite_build_id}" \
+BUILDKITE_BUILD_NUMBER="${buildkite_build_number}" \
+  bash "${assembler}" \
+    "${core}" "${core_authority}" "${runtime}" "${proof}" "${output}"
 test "$(find "${output}" -maxdepth 1 -type f | wc -l)" -eq 21
 test "$(wc -l < "${output}/SHA256SUMS")" -eq 20
 (
@@ -59,48 +475,221 @@ test "$(wc -l < "${output}/SHA256SUMS")" -eq 20
 test -x "${output}/ctx-linux-x64"
 test ! -x "${output}/ctx-onnxruntime-linux-x64.tar.gz"
 
-if bash "${assembler}" "${core}" "${runtime}" "${output}" \
-  > "${tmp}/existing.out" 2> "${tmp}/existing.err"; then
-  printf 'assembler replaced an existing release directory\n' >&2
+wrong_commit_authority="${tmp}/wrong-commit-authority"
+cp -a "${core_authority}" "${wrong_commit_authority}"
+python3 - \
+  "${wrong_commit_authority}/ctx-core-github-handoff.json" \
+  "${wrong_commit_authority}/ctx-core-github-handoff.json.sha256" <<'PY'
+import hashlib
+import json
+import sys
+
+handoff, sidecar = sys.argv[1:]
+with open(handoff, encoding="utf-8") as source:
+    value = json.load(source)
+value["source_commit"] = "f" * 40
+raw = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+with open(handoff, "wb") as output:
+    output.write(raw)
+with open(sidecar, "w", encoding="ascii") as output:
+    output.write(hashlib.sha256(raw).hexdigest() + "\n")
+PY
+expect_failure wrong-commit \
+  'Core authority handoff does not bind scrubbed checkout HEAD' \
+  "${core}" "${wrong_commit_authority}" "${runtime}" "${proof}"
+
+if GIT_DIR="${tmp}/hostile-git-dir" \
+  BUILDKITE_BUILD_ID="${buildkite_build_id}" \
+  BUILDKITE_BUILD_NUMBER="${buildkite_build_number}" \
+  bash "${assembler}" \
+    "${core}" "${core_authority}" "${runtime}" "${proof}" \
+    "${tmp}/hostile-git-output" \
+  > "${tmp}/hostile-git.out" 2> "${tmp}/hostile-git.err"; then
+  printf 'assembler accepted a hostile Git repository override\n' >&2
   exit 1
 fi
-grep -Fq 'release publication destination already exists' "${tmp}/existing.err"
+grep -Fq 'hostile Git repository override is not accepted: GIT_DIR' \
+  "${tmp}/hostile-git.err"
+test ! -e "${tmp}/hostile-git-output"
+
+expect_failure existing \
+  'release publication destination already exists' \
+  "${core}" "${core_authority}" "${runtime}" "${proof}" "${output}"
 
 bad_runtime="${tmp}/bad-runtime"
 cp -a "${runtime}" "${bad_runtime}"
 printf 'corrupt\n' >> "${bad_runtime}/ctx-onnxruntime-linux-x64.tar.gz"
-if bash "${assembler}" "${core}" "${bad_runtime}" "${tmp}/bad-runtime-output" \
-  > "${tmp}/bad-runtime.out" 2> "${tmp}/bad-runtime.err"; then
-  printf 'assembler accepted a runtime checksum mismatch\n' >&2
-  exit 1
-fi
-grep -Fq 'runtime checksum mismatch for ctx-onnxruntime-linux-x64.tar.gz' \
-  "${tmp}/bad-runtime.err"
-test ! -e "${tmp}/bad-runtime-output"
+expect_failure bad-runtime \
+  'runtime checksum mismatch for ctx-onnxruntime-linux-x64.tar.gz' \
+  "${core}" "${core_authority}" "${bad_runtime}" "${proof}"
 
-bad_core="${tmp}/bad-core"
-cp -a "${core}" "${bad_core}"
-printf '%064d  unexpected\n' 0 >> "${bad_core}/SHA256SUMS"
-if bash "${assembler}" "${bad_core}" "${runtime}" "${tmp}/bad-core-output" \
-  > "${tmp}/bad-core.out" 2> "${tmp}/bad-core.err"; then
-  printf 'assembler accepted an expanded Core inventory\n' >&2
-  exit 1
-fi
-grep -Fq 'Core SHA256SUMS must contain exactly 15 assets' "${tmp}/bad-core.err"
-test ! -e "${tmp}/bad-core-output"
+mixed_core="${tmp}/mixed-core"
+cp -a "${core}" "${mixed_core}"
+printf 'different Core bytes\n' > "${mixed_core}/ctx-linux-x64"
+python3 - "${mixed_core}/SHA256SUMS" "${mixed_core}/ctx-linux-x64" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+
+sums, artifact = map(Path, sys.argv[1:])
+lines = sums.read_text(encoding="ascii").splitlines()
+digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+sums.write_text(
+    "\n".join(
+        f"{digest}  ctx-linux-x64" if line.endswith("  ctx-linux-x64") else line
+        for line in lines
+    )
+    + "\n",
+    encoding="ascii",
+)
+PY
+expect_failure mixed-core \
+  'Core assets and source-bound authority use different SHA256SUMS' \
+  "${mixed_core}" "${core_authority}" "${runtime}" "${proof}"
 
 symlink_runtime="${tmp}/symlink-runtime"
 cp -a "${runtime}" "${symlink_runtime}"
 rm "${symlink_runtime}/ctx-onnxruntime-windows-x64.zip"
 ln -s "${runtime}/ctx-onnxruntime-windows-x64.zip" \
   "${symlink_runtime}/ctx-onnxruntime-windows-x64.zip"
-if bash "${assembler}" "${core}" "${symlink_runtime}" "${tmp}/symlink-output" \
-  > "${tmp}/symlink.out" 2> "${tmp}/symlink.err"; then
-  printf 'assembler accepted a symlink runtime\n' >&2
-  exit 1
-fi
-grep -Fq 'runtime release asset must be a regular non-symlink file' \
-  "${tmp}/symlink.err"
-test ! -e "${tmp}/symlink-output"
+expect_failure symlink-runtime \
+  'runtime release asset must be a regular non-symlink file' \
+  "${core}" "${core_authority}" "${symlink_runtime}" "${proof}"
+
+missing_evidence="${tmp}/missing-evidence"
+cp -a "${runtime}" "${missing_evidence}"
+rm "${missing_evidence}/ctx-onnxruntime-macos-arm64.release-attestation.cms"
+expect_failure missing-evidence \
+  'macOS runtime release evidence must be a regular non-symlink file' \
+  "${core}" "${core_authority}" "${missing_evidence}" "${proof}"
+
+tampered_evidence="${tmp}/tampered-evidence"
+cp -a "${runtime}" "${tampered_evidence}"
+printf 'tampered-cms\n' \
+  > "${tampered_evidence}/ctx-onnxruntime-macos-arm64.release-attestation.cms"
+expect_failure tampered-evidence \
+  'macOS release attestation CMS signature verification failed' \
+  "${core}" "${core_authority}" "${tampered_evidence}" "${proof}"
+
+different_team="${tmp}/different-team"
+cp -a "${runtime}" "${different_team}"
+python3 - \
+  "${different_team}/ctx-onnxruntime-macos-arm64.signing.json" \
+  "${different_team}/ctx-onnxruntime-macos-arm64.attestation.json" \
+  "${different_team}/ctx-onnxruntime-macos-arm64.release-attestation.json" <<'PY'
+import json
+import sys
+
+signing_path, artifact_path, release_path = sys.argv[1:]
+authority = "Developer ID Application: Other Publisher (OTHERTEAM1)"
+with open(signing_path, encoding="utf-8") as source:
+    signing = json.load(source)
+signing["codesign"]["authority"] = authority
+signing["codesign"]["team_identifier"] = "OTHERTEAM1"
+with open(signing_path, "w", encoding="utf-8") as output:
+    json.dump(signing, output, sort_keys=True, separators=(",", ":"))
+    output.write("\n")
+for path in (artifact_path, release_path):
+    with open(path, encoding="utf-8") as source:
+        statement = json.load(source)
+    statement["codesign_authority"] = authority
+    statement["team_identifier"] = "OTHERTEAM1"
+    with open(path, "w", encoding="utf-8") as output:
+        json.dump(statement, output, sort_keys=True, separators=(",", ":"))
+        output.write("\n")
+PY
+CTX_TEST_FAKE_SIGNER_TEAM_ID=OTHERTEAM1 expect_failure different-team \
+  'macOS attestation signer does not match the pinned project release publisher' \
+  "${core}" "${core_authority}" "${different_team}" "${proof}"
+
+missing_receipt="${tmp}/missing-receipt"
+cp -a "${proof}" "${missing_receipt}"
+rm "${missing_receipt}/macos-x64/ctx-macos-x64.semantic-execution.json"
+expect_failure missing-receipt \
+  'macos-x64 native semantic receipt is unavailable' \
+  "${core}" "${core_authority}" "${runtime}" "${missing_receipt}"
+
+mismatched_receipt="${tmp}/mismatched-receipt"
+cp -a "${proof}" "${mismatched_receipt}"
+python3 - "${mismatched_receipt}/macos-arm64/ctx-macos-arm64.semantic-execution.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as source:
+    value = json.load(source)
+value["cli_artifact"]["sha256"] = "0" * 64
+with open(path, "w", encoding="utf-8") as output:
+    json.dump(value, output, sort_keys=True, separators=(",", ":"))
+    output.write("\n")
+PY
+refresh_receipt_authority_sha "${mismatched_receipt}" macos-arm64
+expect_failure mismatched-receipt \
+  'native semantic receipt does not bind the exact final macos-arm64 CLI/runtime bytes' \
+  "${core}" "${core_authority}" "${runtime}" "${mismatched_receipt}"
+
+replayed_receipt="${tmp}/replayed-receipt"
+cp -a "${proof}" "${replayed_receipt}"
+python3 - \
+  "${replayed_receipt}/macos-arm64/ctx-macos-arm64.semantic-execution.json" \
+  "${replayed_receipt}/macos-arm64/ctx-macos-arm64.semantic-execution.artifact-authority.json" <<'PY'
+import json
+import sys
+
+receipt, authority = sys.argv[1:]
+old_build = "33333333-3333-4333-8333-333333333333"
+for path in (receipt, authority):
+    with open(path, encoding="utf-8") as source:
+        value = json.load(source)
+    if path == receipt:
+        value["provenance"]["build_id"] = old_build
+    else:
+        value["build_id"] = old_build
+    with open(path, "w", encoding="utf-8") as output:
+        json.dump(value, output, sort_keys=True, separators=(",", ":"))
+        output.write("\n")
+PY
+refresh_receipt_authority_sha "${replayed_receipt}" macos-arm64
+expect_failure replayed-receipt \
+  'macos-arm64 semantic receipt lacks exact Buildkite artifact authority' \
+  "${core}" "${core_authority}" "${runtime}" "${replayed_receipt}"
+
+forged_receipt="${tmp}/forged-receipt"
+cp -a "${proof}" "${forged_receipt}"
+python3 - "${forged_receipt}/macos-x64/ctx-macos-x64.semantic-execution.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as source:
+    value = json.load(source)
+value["provenance"]["job_id"] = "44444444-4444-4444-8444-444444444444"
+with open(path, "w", encoding="utf-8") as output:
+    json.dump(value, output, sort_keys=True, separators=(",", ":"))
+    output.write("\n")
+PY
+refresh_receipt_authority_sha "${forged_receipt}" macos-x64
+expect_failure forged-receipt \
+  'macos-x64 semantic receipt provenance is replayed or forged' \
+  "${core}" "${core_authority}" "${runtime}" "${forged_receipt}"
+
+virtualized_arm64="${tmp}/virtualized-arm64"
+cp -a "${proof}" "${virtualized_arm64}"
+python3 - "${virtualized_arm64}/macos-arm64/ctx-macos-arm64.semantic-execution.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as source:
+    value = json.load(source)
+value["host_evidence"]["hypervisor"] = "present"
+with open(path, "w", encoding="utf-8") as output:
+    json.dump(value, output, sort_keys=True, separators=(",", ":"))
+    output.write("\n")
+PY
+refresh_receipt_authority_sha "${virtualized_arm64}" macos-arm64
+expect_failure virtualized-arm64 \
+  'native semantic receipt has non-authoritative macos-arm64 host evidence' \
+  "${core}" "${core_authority}" "${runtime}" "${virtualized_arm64}"
 
 printf 'GitHub release final assembly tests passed\n'

--- a/scripts/tests/download-authenticated-semantic-receipt-test.sh
+++ b/scripts/tests/download-authenticated-semantic-receipt-test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${TEST_SRCDIR:-}" && -n "${TEST_WORKSPACE:-}" ]]; then
+  source_root="${TEST_SRCDIR}/${TEST_WORKSPACE}"
+else
+  source_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+fi
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/ctx-authenticated-semantic-receipt.XXXXXX")"
+trap 'rm -rf "${tmp}"' EXIT
+repo="${tmp}/repo"
+mkdir -p "${repo}/scripts/buildkite" "${tmp}/bin"
+cp -L "${source_root}/scripts/buildkite/download-authenticated-semantic-receipt.sh" \
+  "${repo}/scripts/buildkite/download-authenticated-semantic-receipt.sh"
+chmod 0755 "${repo}/scripts/buildkite/download-authenticated-semantic-receipt.sh"
+helper="${repo}/scripts/buildkite/download-authenticated-semantic-receipt.sh"
+build_id='11111111-1111-4111-8111-111111111111'
+job_id='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+artifact_path='target/public-cli-semantic-native-smoke/macos-arm64/ctx-macos-arm64.semantic-execution.json'
+fixture='authenticated semantic receipt fixture'
+fixture_sha="$(printf '%s\n' "${fixture}" | sha256sum | awk '{print $1}')"
+log="${tmp}/buildkite-agent.log"
+
+cat > "${tmp}/bin/buildkite-agent" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%q ' "$@" >> "${CTX_TEST_BUILDKITE_LOG}"
+printf '\n' >> "${CTX_TEST_BUILDKITE_LOG}"
+command="$1"
+subcommand="$2"
+shift 2
+[[ "${command}:${subcommand}" == "artifact:search" \
+  || "${command}:${subcommand}" == "artifact:download" ]]
+query="$1"
+shift
+if [[ "${subcommand}" == "search" ]]; then
+  [[ " $* " == *" --step github-macos-arm64-semantic-native-smoke "* ]]
+  [[ " $* " == *" --build ${BUILDKITE_BUILD_ID} "* ]]
+  [[ " $* " != *" --include-retried-jobs "* ]]
+  if [[ "${CTX_TEST_DUPLICATE_RESULTS:-0}" == "1" ]]; then
+    printf '%s\t%s\t%s\n' "${CTX_TEST_JOB_ID}" "${query}" "${CTX_TEST_ARTIFACT_SHA256}"
+  fi
+  printf '%s\t%s\t%s\n' "${CTX_TEST_JOB_ID}" "${query}" "${CTX_TEST_ARTIFACT_SHA256}"
+else
+  destination="$1"
+  shift
+  [[ "${destination}" == "." ]]
+  [[ " $* " == *" --step ${CTX_TEST_JOB_ID} "* ]]
+  [[ " $* " == *" --build ${BUILDKITE_BUILD_ID} "* ]]
+  mkdir -p "$(dirname "${query}")"
+  printf '%s\n' "${CTX_TEST_RECEIPT_FIXTURE}" > "${query}"
+fi
+SH
+chmod 0755 "${tmp}/bin/buildkite-agent"
+export PATH="${tmp}/bin:${PATH}"
+export CTX_TEST_BUILDKITE_LOG="${log}"
+export CTX_TEST_JOB_ID="${job_id}"
+export CTX_TEST_ARTIFACT_SHA256="${fixture_sha}"
+export CTX_TEST_RECEIPT_FIXTURE="${fixture}"
+
+BUILDKITE_BUILD_ID="${build_id}" BUILDKITE_BUILD_NUMBER=42 \
+  "${helper}" macos-arm64 > "${tmp}/positive.out"
+receipt="${repo}/${artifact_path}"
+authority="${receipt%.json}.artifact-authority.json"
+test "$(cat "${receipt}")" = "${fixture}"
+python3 -I - "${authority}" "${build_id}" "${job_id}" "${fixture_sha}" <<'PY'
+import json
+import sys
+
+path, build_id, job_id, digest = sys.argv[1:]
+with open(path, encoding="utf-8") as source:
+    value = json.load(source)
+expected = {
+    "artifact_path": "target/public-cli-semantic-native-smoke/macos-arm64/ctx-macos-arm64.semantic-execution.json",
+    "artifact_sha256": digest,
+    "attempt_selection": "latest",
+    "build_id": build_id,
+    "build_number": 42,
+    "kind": "ctx-buildkite-semantic-receipt-artifact-authority",
+    "producer_job_id": job_id,
+    "producer_step_key": "github-macos-arm64-semantic-native-smoke",
+    "schema_version": 1,
+}
+if value != expected:
+    raise SystemExit(f"unexpected artifact authority: {value!r}")
+PY
+grep -Fq -- "artifact search ${artifact_path}" "${log}"
+grep -Fq -- "artifact download ${artifact_path} . --step ${job_id}" "${log}"
+
+rm -rf "${repo}/target"
+export CTX_TEST_ARTIFACT_SHA256="$(printf '0%.0s' {1..64})"
+if BUILDKITE_BUILD_ID="${build_id}" BUILDKITE_BUILD_NUMBER=42 \
+  "${helper}" macos-arm64 > "${tmp}/bad-sha.out" 2> "${tmp}/bad-sha.err"; then
+  printf 'authenticated receipt helper accepted an API SHA mismatch\n' >&2
+  exit 1
+fi
+grep -Fq 'does not match Buildkite artifact SHA-256' "${tmp}/bad-sha.err"
+test ! -e "${repo}/target/public-cli-semantic-native-smoke/macos-arm64/ctx-macos-arm64.semantic-execution.artifact-authority.json"
+
+rm -rf "${repo}/target"
+export CTX_TEST_ARTIFACT_SHA256="${fixture_sha}"
+export CTX_TEST_DUPLICATE_RESULTS=1
+if BUILDKITE_BUILD_ID="${build_id}" BUILDKITE_BUILD_NUMBER=42 \
+  "${helper}" macos-arm64 > "${tmp}/duplicate.out" 2> "${tmp}/duplicate.err"; then
+  printf 'authenticated receipt helper accepted multiple producer attempts\n' >&2
+  exit 1
+fi
+grep -Fq 'expected exactly one latest-attempt macos-arm64 semantic receipt artifact' \
+  "${tmp}/duplicate.err"
+test ! -e "${repo}/${artifact_path}"
+test ! -e "${repo}/target/public-cli-semantic-native-smoke/macos-arm64/ctx-macos-arm64.semantic-execution.artifact-authority.json"
+
+printf 'authenticated Buildkite semantic receipt tests passed\n'

--- a/scripts/tests/smoke-daemon-semantic-release-test.sh
+++ b/scripts/tests/smoke-daemon-semantic-release-test.sh
@@ -19,7 +19,8 @@ for release_script in \
   public-cli-host-runtime-evidence.sh \
   public-cli-runtime-authority.sh \
   semantic-release-assets.py \
-  smoke-daemon-semantic-release.sh; do
+  smoke-daemon-semantic-release.sh \
+  write-semantic-execution-receipt.sh; do
   cp -L "${repo_root}/scripts/${release_script}" \
     "${release_root}/scripts/${release_script}"
 done
@@ -147,6 +148,10 @@ if [[ "\${CTX_TEST_RUNTIME_EVIDENCE:-}" == "macos-arm64-native-virtualized" ]]; 
   printf 'Darwin\tarm64\tarm64\t0\tsysctl\tapple\tnone\tpresent\t1\n'
   exit 0
 fi
+if [[ "\${CTX_TEST_RUNTIME_EVIDENCE:-}" == "macos-arm64-physical" ]]; then
+  printf 'Darwin\tarm64\tarm64\t0\tsysctl\tapple\tnone\tabsent\t1\n'
+  exit 0
+fi
 if [[ "\${CTX_TEST_RUNTIME_EVIDENCE:-}" == "macos-arm64-generic-virtualized" ]]; then
   printf 'Darwin\tarm64\tarm64\t0\tsysctl\tgeneric\tnone\tpresent\t1\n'
   exit 0
@@ -172,7 +177,7 @@ expect_runtime_authority() {
 
 expect_runtime_authority macos_arm64_bare_metal authoritative \
   macos-arm64 Darwin arm64 passed arm64 0 apple none absent 1
-expect_runtime_authority macos_arm64_native_virtualized authoritative \
+expect_runtime_authority macos_arm64_native_virtualized non_authoritative \
   macos-arm64 Darwin arm64 passed arm64 0 apple none present 1
 expect_runtime_authority macos_arm64_rosetta non_authoritative \
   macos-arm64 Darwin arm64 passed arm64 1 apple rosetta-2 absent 1
@@ -408,6 +413,7 @@ expect_usage_failure() {
 grep -Fq -- '--coreml --runtime-platform macos-arm64|macos-x64' "${tmp}/help.out"
 grep -Fq -- '[--coreml-archive PATH]' "${tmp}/help.out"
 grep -Fq -- '--require-authoritative' "${tmp}/help.out"
+grep -Fq -- '--receipt PATH' "${tmp}/help.out"
 
 expect_usage_failure coreml_linux \
   '--coreml requires --runtime-platform macos-arm64 or macos-x64' \
@@ -431,6 +437,14 @@ expect_usage_failure retired_proof_output \
   'Usage:' \
   --coreml --runtime-platform macos-arm64 --proof-output "${tmp}/proof" \
   --ctx "${fake_ctx}"
+expect_usage_failure receipt_requires_runtime \
+  '--receipt requires --runtime-archive' \
+  --coreml --runtime-platform macos-arm64 --receipt "${tmp}/coreml-receipt.json" \
+  --ctx "${fake_ctx}" --require-authoritative
+expect_usage_failure receipt_requires_authority \
+  '--receipt requires --require-authoritative' \
+  --runtime-platform macos-arm64 --runtime-archive "${tmp}/unused" \
+  --receipt "${tmp}/non-authoritative-receipt.json" --ctx "${fake_ctx}"
 
 if CTX_TEST_RUNTIME_EVIDENCE=macos-arm64-generic-virtualized "${smoke}" \
   --coreml \
@@ -454,9 +468,24 @@ grep -Fq -- \
   'error: semantic smoke requires authoritative native macos-arm64 execution' \
   "${tmp}/non-authoritative.err"
 
+if CTX_TEST_RUNTIME_EVIDENCE=macos-arm64-native-virtualized "${smoke}" \
+  --coreml \
+  --runtime-platform macos-arm64 \
+  --ctx "${fake_ctx}" \
+  --data-root "${tmp}/virtualized-arm64-runs" \
+  --require-authoritative \
+  --timeout-seconds 30 \
+  > "${tmp}/virtualized-arm64.out" 2> "${tmp}/virtualized-arm64.err"; then
+  printf 'virtualized Apple macOS arm64 smoke unexpectedly passed\n' >&2
+  exit 1
+fi
+grep -Fq -- \
+  'error: semantic smoke requires authoritative native macos-arm64 execution' \
+  "${tmp}/virtualized-arm64.err"
+
 run_parent="${tmp}/runs"
 coreml_bind_log="${tmp}/coreml-bind.log"
-CTX_TEST_RUNTIME_EVIDENCE=macos-arm64-native-virtualized \
+CTX_TEST_RUNTIME_EVIDENCE=macos-arm64-physical \
 CTX_TEST_COREML_BIND_LOG="${coreml_bind_log}" "${smoke}" \
   --coreml \
   --runtime-platform macos-arm64 \
@@ -473,7 +502,7 @@ run_root="$(find "${run_parent}" -mindepth 1 -maxdepth 1 -type d -name 'ctx-sema
 test ! -e "${run_root}/data/packaged-runtime-proof.txt"
 grep -Fq 'ctx semantic smoke ok:' "${tmp}/coreml.out"
 grep -Fq \
-  'hardware_identity=apple emulation=none hypervisor=present evidence_complete=1' \
+  'hardware_identity=apple emulation=none hypervisor=absent evidence_complete=1' \
   "${tmp}/coreml.out"
 grep -Fq 'authority=authoritative' "${tmp}/coreml.out"
 grep -Fxq -- "archive=${coreml_archive}" "${coreml_bind_log}"
@@ -605,12 +634,28 @@ else
   shasum -a 256 "${runtime_archive}" | awk '{ print $1 }' > "${runtime_archive}.sha256"
 fi
 
-if ! "${smoke}" \
+onnx_receipt="${tmp}/onnx-receipt/ctx-linux-x64.semantic-execution.json"
+git -C "${release_root}" init -q
+git -C "${release_root}" config user.name 'ctx semantic receipt test'
+git -C "${release_root}" config user.email 'ctx-semantic-receipt@example.invalid'
+git -C "${release_root}" add .
+git -C "${release_root}" commit -qm 'seal semantic receipt fixture'
+receipt_source_commit="$(git -C "${release_root}" rev-parse --verify HEAD^{commit})"
+buildkite_build_id='11111111-1111-4111-8111-111111111111'
+buildkite_job_id='22222222-2222-4222-8222-222222222222'
+buildkite_step_key='semantic-linux-smoke'
+if ! BUILDKITE_BUILD_ID="${buildkite_build_id}" \
+  BUILDKITE_BUILD_NUMBER=42 \
+  BUILDKITE_JOB_ID="${buildkite_job_id}" \
+  BUILDKITE_RETRY_COUNT=2 \
+  BUILDKITE_STEP_KEY="${buildkite_step_key}" \
+  "${smoke}" \
   --runtime-archive "${runtime_archive}" \
   --runtime-platform linux-x64 \
   --ctx "${cpu_ctx}" \
   --data-root "${tmp}/onnx-runs" \
   --require-authoritative \
+  --receipt "${onnx_receipt}" \
   --timeout-seconds 30 \
   > "${tmp}/onnx.out" 2> "${tmp}/onnx.err"; then
   cat "${tmp}/onnx.out" >&2
@@ -618,6 +663,87 @@ if ! "${smoke}" \
   exit 1
 fi
 grep -Fq 'ctx semantic smoke ok:' "${tmp}/onnx.out"
+python3 -I - "${onnx_receipt}" "${cpu_ctx}" "${runtime_archive}" \
+  "${runtime_payload}/lib/libonnxruntime.so" "${receipt_source_commit}" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+receipt, cli, archive, nested = map(Path, sys.argv[1:5])
+
+
+def sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+value = json.loads(receipt.read_text(encoding="utf-8"))
+if (
+    value.get("schema_version") != 2
+    or value.get("kind") != "ctx-semantic-native-execution"
+    or value.get("platform") != "linux-x64"
+    or value.get("status") != "passed"
+    or value.get("authority") != "authoritative"
+    or value.get("backend") != "onnxruntime-cpu"
+    or value.get("provenance")
+    != {
+        "build_id": "11111111-1111-4111-8111-111111111111",
+        "build_number": 42,
+        "job_id": "22222222-2222-4222-8222-222222222222",
+        "retry_count": 2,
+        "source_commit": sys.argv[5],
+        "step_key": "semantic-linux-smoke",
+    }
+    or value.get("cli_artifact")
+    != {"name": "ctx-linux-x64", "sha256": sha256(cli)}
+    or value.get("runtime_archive")
+    != {
+        "name": archive.name,
+        "nested_artifact_name": "lib/libonnxruntime.so",
+        "nested_artifact_sha256": sha256(nested),
+        "sha256": sha256(archive),
+    }
+    or value.get("semantic")
+    != {
+        "effective_mode": "semantic",
+        "indexed_chunks_minimum": 1,
+        "model_key": "e5-small-v1:mean-pool:l2:query-passage",
+        "requested_mode": "semantic",
+        "status": "ready",
+    }
+):
+    raise SystemExit(f"unexpected native semantic receipt: {value!r}")
+host = value.get("host_evidence")
+if (
+    not isinstance(host, dict)
+    or host.get("system") != "Linux"
+    or host.get("arch") != "x86_64"
+    or host.get("native_arch") != "x86_64"
+    or host.get("process_translated") != 0
+    or host.get("evidence_complete") is not True
+):
+    raise SystemExit(f"receipt lost authoritative host evidence: {host!r}")
+if any("/" in str(value.get(key, "")) for key in ("authority", "platform", "status")):
+    raise SystemExit("receipt exposed a local path")
+PY
+if BUILDKITE_BUILD_ID="${buildkite_build_id}" \
+  BUILDKITE_BUILD_NUMBER=42 \
+  BUILDKITE_JOB_ID="${buildkite_job_id}" \
+  BUILDKITE_RETRY_COUNT=2 \
+  BUILDKITE_STEP_KEY="${buildkite_step_key}" \
+  "${smoke}" \
+  --runtime-archive "${runtime_archive}" \
+  --runtime-platform linux-x64 \
+  --ctx "${cpu_ctx}" \
+  --data-root "${tmp}/duplicate-receipt-runs" \
+  --require-authoritative \
+  --receipt "${onnx_receipt}" \
+  --timeout-seconds 30 \
+  > "${tmp}/duplicate-receipt.out" 2> "${tmp}/duplicate-receipt.err"; then
+  printf 'semantic smoke replaced an existing native receipt\n' >&2
+  exit 1
+fi
+grep -Fq 'semantic smoke receipt already exists' "${tmp}/duplicate-receipt.err"
 if find "${tmp}/onnx-runs" -name packaged-runtime-proof.txt -print -quit | grep -q .; then
   printf 'semantic smoke emitted a retired proof artifact\n' >&2
   exit 1

--- a/scripts/write-semantic-execution-receipt.sh
+++ b/scripts/write-semantic-execution-receipt.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  write-semantic-execution-receipt.sh \
+    OUTPUT PLATFORM \
+    CLI_NAME CLI_SHA256 \
+    ARCHIVE_NAME ARCHIVE_SHA256 \
+    RUNTIME_NAME RUNTIME_SHA256 \
+    HOST_SYSTEM HOST_ARCH HOST_NATIVE_ARCH PROCESS_TRANSLATED \
+    NATIVE_ARCH_PROBE HARDWARE_IDENTITY EMULATION HYPERVISOR \
+    EVIDENCE_COMPLETE RUNNER_ID AUTHORITY MODEL_KEY \
+    SOURCE_COMMIT BUILD_ID BUILD_NUMBER JOB_ID RETRY_COUNT STEP_KEY
+
+Construct an atomic schema-v2 receipt for authoritative native semantic
+execution. Arguments are ordered to mirror the receipt's artifact, host,
+semantic, and Buildkite provenance sections.
+USAGE
+}
+
+if (($# != 26)); then
+  usage
+  exit 2
+fi
+
+python3 -I - "$@" <<'PY'
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+(
+    output_text,
+    platform,
+    cli_name,
+    cli_sha256,
+    archive_name,
+    archive_sha256,
+    runtime_name,
+    runtime_sha256,
+    host_system,
+    host_arch,
+    host_native_arch,
+    process_translated_text,
+    native_arch_probe,
+    hardware_identity,
+    emulation,
+    hypervisor,
+    evidence_complete_text,
+    runner_id,
+    authority,
+    model_key,
+    source_commit,
+    build_id,
+    build_number_text,
+    job_id,
+    retry_count_text,
+    step_key,
+) = sys.argv[1:]
+
+if authority != "authoritative":
+    raise SystemExit("semantic receipt requires authoritative native execution")
+if process_translated_text != "0" or evidence_complete_text != "1":
+    raise SystemExit("semantic receipt host evidence is incomplete or translated")
+for label, value in (
+    ("CLI", cli_sha256),
+    ("runtime archive", archive_sha256),
+    ("nested runtime", runtime_sha256),
+):
+    if re.fullmatch(r"[0-9a-f]{64}", value) is None:
+        raise SystemExit(f"semantic receipt {label} digest is malformed")
+if re.fullmatch(r"[0-9a-f]{40}", source_commit) is None or source_commit == "0" * 40:
+    raise SystemExit("semantic receipt source commit is malformed")
+
+document = {
+    "authority": authority,
+    "backend": "onnxruntime-cpu",
+    "cli_artifact": {"name": cli_name, "sha256": cli_sha256},
+    "host_evidence": {
+        "arch": host_arch,
+        "emulation": emulation,
+        "evidence_complete": True,
+        "hardware_identity": hardware_identity,
+        "hypervisor": hypervisor,
+        "native_arch": host_native_arch,
+        "native_arch_probe": native_arch_probe,
+        "process_translated": 0,
+        "runner_id": runner_id,
+        "system": host_system,
+    },
+    "kind": "ctx-semantic-native-execution",
+    "platform": platform,
+    "provenance": {
+        "build_id": build_id,
+        "build_number": int(build_number_text),
+        "job_id": job_id,
+        "retry_count": int(retry_count_text),
+        "source_commit": source_commit,
+        "step_key": step_key,
+    },
+    "runtime_archive": {
+        "name": archive_name,
+        "nested_artifact_name": f"lib/{runtime_name}",
+        "nested_artifact_sha256": runtime_sha256,
+        "sha256": archive_sha256,
+    },
+    "schema_version": 2,
+    "semantic": {
+        "effective_mode": "semantic",
+        "indexed_chunks_minimum": 1,
+        "model_key": model_key,
+        "requested_mode": "semantic",
+        "status": "ready",
+    },
+    "status": "passed",
+}
+output = Path(output_text)
+temporary = output.with_name(f".{output.name}.tmp.{os.getpid()}")
+try:
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+    with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as stream:
+        json.dump(document, stream, sort_keys=True, separators=(",", ":"))
+        stream.write("\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    if output.exists() or output.is_symlink():
+        raise SystemExit(f"semantic smoke receipt already exists: {output}")
+    os.replace(temporary, output)
+finally:
+    temporary.unlink(missing_ok=True)
+PY


### PR DESCRIPTION
## Root cause

The v1.0.2 final release assembler accepted independently qualified Core and ONNX Runtime handoffs without proving that the exact final CLI/runtime pair could execute together under macOS hardened-runtime library validation. That allowed a current-team ctx binary to be paired with a legacy-team dylib.

## What changes

- run the exact final macOS arm64 and x64 CLI/runtime pairs through native semantic-search smoke jobs
- require the packaged dylibs to match current-publisher signing, notarization, and cryptographic attestation evidence
- bind each native execution receipt to the exact CLI, runtime archive, nested dylib, source commit, Buildkite build/job, and authoritative untranslated host
- make final GitHub release assembly fail closed when any identity, digest, provenance, host-authority, or semantic-readiness proof is absent or inconsistent

## Release impact

This does not mutate v1.0.2. After merge, a new release cannot assemble unless both macOS pairs load ONNX Runtime and reach semantic-ready with the exact bytes being published.

Addresses #658.

## Validation

- //:assemble_github_release_assets_tests
- //:authenticated_semantic_receipt_tests
- //:semantic_release_smoke_tests
- //:buildkite_pipeline_check
- repository policy and public-disclosure guard

All four focused tests passed uncached after rebasing onto current main. No release or publication workflow was triggered.