### PR TITLE
fix(cursor): bound transcript discovery by layout

### DIFF
--- a/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/claude_cursor.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/claude_cursor.rs
@@ -16,6 +16,8 @@ use crate::{
     SourceBackedProviderRegistry, SourceBackedRouteSelection, SourceBackedSourceFailureClass,
 };
 
+const CURSOR_SOURCE_FORMAT: &str = "cursor_agent_transcript_jsonl_tree";
+
 fn writer_options() -> WriterOptions {
     WriterOptions {
         indexer_threads: 1,
@@ -142,19 +144,26 @@ fn exercise_lifecycle(
 ) {
     write_transcript(transcript, &[first]);
     let registry = registry(provider, source_format, source_root);
+    let records = || indexed_records(index, provider, native_session_id);
 
     let cold = refresh_source_backed_generation(index, &registry, writer_options()).unwrap();
     assert!(cold.failed_routes.is_empty());
     assert_eq!(cold.successful_route_ids.len(), 1);
-    let cold_records = indexed_records(index, provider, native_session_id);
+    let cold_records = records();
     assert_literal_bodies(&cold_records, &["literal first"]);
     let cold_checkpoint = certified_prefix_bytes(index, provider);
     assert_eq!(cold_checkpoint, fs::metadata(transcript).unwrap().len());
 
+    let noop = refresh_source_backed_generation(index, &registry, writer_options()).unwrap();
+    assert!(noop.failed_routes.is_empty());
+    assert_eq!(noop.commit.generation_id, cold.commit.generation_id);
+    assert_eq!(records(), cold_records);
+    assert_eq!(certified_prefix_bytes(index, provider), cold_checkpoint);
+
     append_transcript(transcript, &second);
     let appended = refresh_source_backed_generation(index, &registry, writer_options()).unwrap();
     assert!(appended.failed_routes.is_empty());
-    let appended_records = indexed_records(index, provider, native_session_id);
+    let appended_records = records();
     assert_literal_bodies(&appended_records, &["literal first", "literal second"]);
     assert_eq!(appended_records[0].event_id, cold_records[0].event_id);
     let appended_checkpoint = certified_prefix_bytes(index, provider);
@@ -179,14 +188,11 @@ fn exercise_lifecycle(
                 && failure.carried_forward
     ));
     assert_eq!(certified_prefix_bytes(index, provider), appended_checkpoint);
-    assert_eq!(
-        indexed_records(index, provider, native_session_id),
-        appended_records
-    );
+    assert_eq!(records(), appended_records);
 
     let recovered = refresh_source_backed_generation(index, &registry, writer_options()).unwrap();
     assert!(recovered.failed_routes.is_empty());
-    let recovered_records = indexed_records(index, provider, native_session_id);
+    let recovered_records = records();
     assert_literal_bodies(
         &recovered_records,
         &["literal first", "literal second", "race-after!"],
@@ -220,7 +226,7 @@ fn cursor_route_publishes_cold_append_and_recovers_from_carried_checkpoint() {
         .join(format!("{native_session_id}.jsonl"));
     exercise_lifecycle(
         CaptureProvider::Cursor,
-        "cursor_agent_transcript_jsonl_tree",
+        CURSOR_SOURCE_FORMAT,
         &root,
         &transcript,
         &temp.path().join("cursor-index"),
@@ -229,6 +235,44 @@ fn cursor_route_publishes_cold_append_and_recovers_from_carried_checkpoint() {
         cursor_message("assistant", "2026-08-16T00:00:01Z", "literal second"),
         cursor_message("assistant", "2026-08-16T00:00:02Z", "race-before"),
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn cursor_incomplete_canonical_inventory_retains_last_good_generation() {
+    use std::os::unix::fs::symlink;
+
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let root = temp.path().join("cursor-data");
+    let native_session_id = "retained-cursor-session";
+    let transcript = root
+        .join("projects/project/agent-transcripts")
+        .join(native_session_id)
+        .join(format!("{native_session_id}.jsonl"));
+    let retained = cursor_message("user", "2026-08-16T00:00:00Z", "retained literal");
+    write_transcript(&transcript, &[retained]);
+    let index = temp.path().join("cursor-index");
+    let registry = registry(CaptureProvider::Cursor, CURSOR_SOURCE_FORMAT, &root);
+    let records = || indexed_records(&index, CaptureProvider::Cursor, native_session_id);
+    let checkpoint = || certified_prefix_bytes(&index, CaptureProvider::Cursor);
+    let cold = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
+    assert!(cold.failed_routes.is_empty());
+    let cold_records = records();
+    let cold_checkpoint = checkpoint();
+
+    let linked_target = temp.path().join("linked-project-target");
+    fs::create_dir_all(&linked_target).unwrap();
+    symlink(&linked_target, root.join("projects/a-linked-project")).unwrap();
+
+    let failed = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
+
+    assert!(matches!(
+        failed.failed_routes.as_slice(),
+        [failure] if failure.carried_forward
+    ));
+    assert_eq!(failed.commit.generation_id, cold.commit.generation_id);
+    assert_eq!(records(), cold_records);
+    assert_eq!(checkpoint(), cold_checkpoint);
 }
 
 fn claude_message(kind: &str, uuid: &str, session_id: &str, text: &str) -> Value {

--- a/crates/ctx-history-capture/src/provider_sources.rs
+++ b/crates/ctx-history-capture/src/provider_sources.rs
@@ -3,7 +3,9 @@
 use std::path::{Path, PathBuf};
 
 use ctx_history_core::CaptureProvider;
-use ctx_history_provider_claude_cursor::{discover_cursor_transcripts, CursorDiscoveryIssueKind};
+use ctx_history_provider_claude_cursor::cursor::{
+    probe_cursor_transcript_availability, CursorTranscriptAvailability,
+};
 use ctx_history_source_discovery::{
     CursorProbeFragment, CursorTranscriptProbeOutcome, StaticProviderProbeCatalog,
 };
@@ -30,27 +32,13 @@ pub(crate) static BUILTIN_PROVIDER_PROBES: StaticProviderProbeCatalog =
     StaticProviderProbeCatalog::new(CursorProbeFragment::new(probe_cursor_transcripts));
 
 fn probe_cursor_transcripts(path: &Path) -> CursorTranscriptProbeOutcome {
-    let input = if path.is_dir() && path.join("projects").is_dir() {
-        path.join("projects")
-    } else {
-        path.to_path_buf()
-    };
-    let inventory = discover_cursor_transcripts(&input);
-    if !inventory.completed() {
-        if inventory.has_issue_kind(CursorDiscoveryIssueKind::LimitExceeded) {
-            return CursorTranscriptProbeOutcome::BudgetExhausted;
+    match probe_cursor_transcript_availability(path) {
+        CursorTranscriptAvailability::Found => CursorTranscriptProbeOutcome::Found,
+        CursorTranscriptAvailability::NotFound => CursorTranscriptProbeOutcome::NotFound,
+        CursorTranscriptAvailability::BudgetExhausted => {
+            CursorTranscriptProbeOutcome::BudgetExhausted
         }
-        if inventory.has_issue_kind(CursorDiscoveryIssueKind::Io)
-            || inventory.has_issue_kind(CursorDiscoveryIssueKind::Symlink)
-        {
-            return CursorTranscriptProbeOutcome::IoError;
-        }
-        return CursorTranscriptProbeOutcome::NotFound;
-    }
-    if !inventory.has_transcripts() {
-        CursorTranscriptProbeOutcome::NotFound
-    } else {
-        CursorTranscriptProbeOutcome::Found
+        CursorTranscriptAvailability::IoError => CursorTranscriptProbeOutcome::IoError,
     }
 }
 
@@ -292,6 +280,38 @@ mod extraction_regression_tests {
         assert_eq!(
             discover_provider_sources_for_provider(empty.path(), CaptureProvider::Cursor)[0].status,
             ProviderSourceStatus::Empty
+        );
+    }
+
+    #[test]
+    fn capture_provider_cursor_missing_probe_is_typed_not_found() {
+        let temp = tempdir();
+        let missing = temp.path().join(".cursor/projects");
+
+        assert_eq!(
+            probe_cursor_transcripts(&missing),
+            CursorTranscriptProbeOutcome::NotFound
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capture_catalog_cursor_availability_is_existential() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir();
+        let projects = temp.path().join(".cursor/projects");
+        let target = temp.path().join("linked-project-target");
+        std::fs::create_dir_all(&projects).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        symlink(&target, projects.join("a-linked-project")).unwrap();
+        let transcript = projects.join("z-valid-project/agent-transcripts/session/session.jsonl");
+        std::fs::create_dir_all(transcript.parent().unwrap()).unwrap();
+        std::fs::write(transcript, b"{}\n").unwrap();
+
+        assert_eq!(
+            discover_provider_sources_for_provider(temp.path(), CaptureProvider::Cursor)[0].status,
+            ProviderSourceStatus::Available
         );
     }
 

--- a/crates/ctx-history-provider-claude-cursor/src/cursor.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/cursor.rs
@@ -1,11 +1,16 @@
 //! Provider-owned Cursor discovery, parsing, and complete Core projection.
 
 mod layout;
+#[cfg(test)]
+mod layout_tests;
 mod parser;
 mod projection;
 pub(crate) mod source_backed;
 
-pub use layout::{discover_cursor_transcripts, CursorDiscoveryIssueKind};
+pub use layout::{
+    discover_cursor_transcripts, probe_cursor_transcript_availability, CursorDiscoveryIssueKind,
+    CursorTranscriptAvailability,
+};
 pub(crate) use source_backed::cursor_jsonl_adapter;
 
 #[cfg(test)]

--- a/crates/ctx-history-provider-claude-cursor/src/cursor/layout.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/cursor/layout.rs
@@ -1,21 +1,81 @@
 use std::{
-    collections::{BTreeSet, VecDeque},
+    collections::BTreeSet,
     ffi::OsStr,
     path::{Path, PathBuf},
 };
 
 use ctx_history_provider_runtime::source_io::{
     open_provider_source_path, OpenedProviderSourceFile, OpenedProviderSourcePath,
-    ProviderSourceDirectory, ProviderSourceRoot,
+    ProviderSourceDirectory, ProviderSourceRoot, PROVIDER_JSONL_INVENTORY_MAX_DIRECTORIES,
+    PROVIDER_JSONL_INVENTORY_MAX_ELIGIBLE_PATHS, PROVIDER_JSONL_INVENTORY_MAX_METADATA_ENTRIES,
+    PROVIDER_JSONL_INVENTORY_MAX_PATH_BYTES,
 };
 use ctx_history_provider_runtime::CaptureError;
 
-const AGENT_TRANSCRIPTS: &str = "agent-transcripts";
-pub(super) const CURSOR_MAX_DIRECTORY_DEPTH: usize = 128;
-pub(super) const CURSOR_MAX_DIRECTORY_ENTRIES: usize = 1_024;
-pub(super) const CURSOR_MAX_TRAVERSAL_ENTRIES: usize = 4_096;
+#[path = "layout_helpers.rs"]
+mod helpers;
+use helpers::*;
+
+pub(super) const AGENT_TRANSCRIPTS: &str = "agent-transcripts";
+pub(super) const PROJECTS: &str = "projects";
 pub(super) const CURSOR_MAX_DISCOVERY_ISSUE_SAMPLES: usize = 128;
-pub(super) const CURSOR_MAX_TRANSCRIPTS: usize = 128;
+
+fn is_literal_projects_root(path: &Path) -> bool {
+    path.file_name() == Some(OsStr::new(PROJECTS))
+}
+
+fn require_literal_projects_root(
+    candidate: &Path,
+    projects_root: &Path,
+    inventory: &mut CursorRootInventory,
+) -> bool {
+    if is_literal_projects_root(projects_root) {
+        return true;
+    }
+    inventory.reject(
+        candidate.to_path_buf(),
+        CursorDiscoveryIssueKind::InvalidLayout,
+        "Cursor transcript entry points must be beneath a literal projects directory",
+        true,
+    );
+    false
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct CursorInventoryLimits {
+    pub(super) max_directories: usize,
+    pub(super) max_transcripts: usize,
+    pub(super) max_metadata_entries: usize,
+    pub(super) max_path_bytes: usize,
+}
+
+impl Default for CursorInventoryLimits {
+    fn default() -> Self {
+        // Cursor's fixed shape needs no recursive depth budget. Reuse the
+        // ordinary source-I/O inventory ceilings for the remaining dimensions
+        // instead of maintaining smaller provider-local corpus ceilings.
+        Self {
+            max_directories: PROVIDER_JSONL_INVENTORY_MAX_DIRECTORIES,
+            max_transcripts: PROVIDER_JSONL_INVENTORY_MAX_ELIGIBLE_PATHS,
+            max_metadata_entries: PROVIDER_JSONL_INVENTORY_MAX_METADATA_ENTRIES,
+            max_path_bytes: PROVIDER_JSONL_INVENTORY_MAX_PATH_BYTES,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CursorScanGoal {
+    CompleteInventory,
+    FirstTranscript,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CursorTranscriptAvailability {
+    Found,
+    NotFound,
+    BudgetExhausted,
+    IoError,
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct CursorTranscriptPath {
@@ -36,6 +96,9 @@ impl CursorTranscriptPath {
         ordinary_file_token: [u8; 32],
         authority: ProviderSourceRoot,
     ) -> Result<Self, &'static str> {
+        if !is_literal_projects_root(projects_root) {
+            return Err("Cursor transcript must be beneath a literal projects directory");
+        }
         let relative = path
             .strip_prefix(projects_root)
             .map_err(|_| "Cursor transcript is outside the selected projects root")?;
@@ -103,7 +166,7 @@ impl PartialEq for CursorTranscriptPath {
 
 impl Eq for CursorTranscriptPath {}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CursorDiscoveryIssueKind {
     Io,
     InvalidLayout,
@@ -138,6 +201,7 @@ pub struct CursorRootInventory {
     pub(crate) completed: bool,
     pub(crate) stats: CursorDiscoveryStats,
     authority: Option<ProviderSourceRoot>,
+    issue_kinds: BTreeSet<CursorDiscoveryIssueKind>,
 }
 
 impl CursorRootInventory {
@@ -146,7 +210,7 @@ impl CursorRootInventory {
     }
 
     pub fn has_issue_kind(&self, expected: CursorDiscoveryIssueKind) -> bool {
-        self.issues.iter().any(|issue| issue.kind == expected)
+        self.issue_kinds.contains(&expected)
     }
 
     pub fn has_transcripts(&self) -> bool {
@@ -162,6 +226,7 @@ impl CursorRootInventory {
             completed: true,
             stats: CursorDiscoveryStats::default(),
             authority: None,
+            issue_kinds: BTreeSet::new(),
         }
     }
 
@@ -173,6 +238,7 @@ impl CursorRootInventory {
         invalidates_completion: bool,
     ) {
         self.stats.rejected_candidates = self.stats.rejected_candidates.saturating_add(1);
+        self.issue_kinds.insert(kind);
         if self.issues.len() < CURSOR_MAX_DISCOVERY_ISSUE_SAMPLES {
             self.issues.push(CursorDiscoveryIssue {
                 path,
@@ -222,20 +288,59 @@ impl PartialEq for CursorRootInventory {
             && self.issues == other.issues
             && self.completed == other.completed
             && self.stats == other.stats
+            && self.issue_kinds == other.issue_kinds
     }
 }
 
 impl Eq for CursorRootInventory {}
 
+pub fn probe_cursor_transcript_availability(input: &Path) -> CursorTranscriptAvailability {
+    probe_cursor_transcript_availability_with_limits(input, CursorInventoryLimits::default())
+}
+
+pub(super) fn probe_cursor_transcript_availability_with_limits(
+    input: &Path,
+    limits: CursorInventoryLimits,
+) -> CursorTranscriptAvailability {
+    let inventory = scan_cursor_transcripts(input, limits, CursorScanGoal::FirstTranscript);
+    if inventory.has_transcripts() {
+        CursorTranscriptAvailability::Found
+    } else if inventory.has_issue_kind(CursorDiscoveryIssueKind::LimitExceeded) {
+        CursorTranscriptAvailability::BudgetExhausted
+    } else if inventory.has_issue_kind(CursorDiscoveryIssueKind::NotFound) {
+        CursorTranscriptAvailability::NotFound
+    } else if !inventory.completed() {
+        CursorTranscriptAvailability::IoError
+    } else {
+        CursorTranscriptAvailability::NotFound
+    }
+}
+
 pub fn discover_cursor_transcripts(input: &Path) -> CursorRootInventory {
+    discover_cursor_transcripts_with_limits(input, CursorInventoryLimits::default())
+}
+
+pub(super) fn discover_cursor_transcripts_with_limits(
+    input: &Path,
+    limits: CursorInventoryLimits,
+) -> CursorRootInventory {
+    scan_cursor_transcripts(input, limits, CursorScanGoal::CompleteInventory)
+}
+
+fn scan_cursor_transcripts(
+    input: &Path,
+    limits: CursorInventoryLimits,
+    goal: CursorScanGoal,
+) -> CursorRootInventory {
     let mut inventory = CursorRootInventory::new(input);
+    if !admit_metadata_entry(input, limits, &mut inventory) {
+        return inventory;
+    }
     let opened = match open_provider_source_path(input) {
         Ok(opened) => opened,
         Err(error) => {
             let kind = match &error {
-                CaptureError::Io(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                    CursorDiscoveryIssueKind::NotFound
-                }
+                error if capture_error_is_not_found(error) => CursorDiscoveryIssueKind::NotFound,
                 CaptureError::InvalidProviderTranscriptPath { .. } => {
                     CursorDiscoveryIssueKind::Symlink
                 }
@@ -247,7 +352,6 @@ pub fn discover_cursor_transcripts(input: &Path) -> CursorRootInventory {
     };
     match opened {
         OpenedProviderSourcePath::File(file) => {
-            inventory.stats.entries_visited = 1;
             inventory.stats.regular_files_visited = 1;
             let (authority, relative_path) = match cursor_explicit_authority(input) {
                 Ok(admitted) => admitted,
@@ -264,25 +368,26 @@ pub fn discover_cursor_transcripts(input: &Path) -> CursorRootInventory {
             inventory.authority = Some(authority.clone());
             inspect_file(
                 input,
-                input,
                 relative_path,
                 file,
                 authority,
                 &mut inventory,
                 true,
+                limits,
             );
         }
         OpenedProviderSourcePath::Directory(directory) => {
-            let authority = directory.authority_root();
-            inventory.authority = Some(authority.clone());
-            let (scan_path, scan_directory) =
-                select_projects_directory(input, directory, &mut inventory);
-            inventory.input = scan_path.clone();
-            visit_directories(&scan_path, scan_directory, authority, &mut inventory);
+            if !admit_directory(input, limits, &mut inventory) {
+                return inventory;
+            }
+            inventory.authority = Some(directory.authority_root());
+            discover_from_directory(input, directory, limits, goal, &mut inventory);
         }
     }
     inventory.finish();
-    if inventory.completed {
+    if inventory.completed
+        || (goal == CursorScanGoal::FirstTranscript && inventory.has_transcripts())
+    {
         if let Err(error) = inventory.revalidate() {
             inventory.reject(
                 inventory.input.clone(),
@@ -290,6 +395,10 @@ pub fn discover_cursor_transcripts(input: &Path) -> CursorRootInventory {
                 error.to_string(),
                 true,
             );
+            if goal == CursorScanGoal::FirstTranscript {
+                inventory.transcripts.clear();
+                inventory.finish();
+            }
         }
     }
     inventory
@@ -313,13 +422,124 @@ fn cursor_explicit_authority(
     Ok((ProviderSourceRoot::open(parent)?, relative_path))
 }
 
-fn select_projects_directory(
+#[derive(Debug)]
+enum CursorDirectoryEntryPoint {
+    Session { projects_root: PathBuf },
+    AgentTranscripts { projects_root: PathBuf },
+    Project { projects_root: PathBuf },
+    Projects,
+    ProviderRoot,
+}
+
+fn cursor_directory_entry_points(input: &Path) -> Vec<CursorDirectoryEntryPoint> {
+    let mut entry_points = Vec::with_capacity(5);
+    if let Some(agent_transcripts) = input
+        .parent()
+        .filter(|parent| parent.file_name() == Some(OsStr::new(AGENT_TRANSCRIPTS)))
+    {
+        if let Some(projects_root) = agent_transcripts
+            .parent()
+            .and_then(Path::parent)
+            .filter(|root| is_literal_projects_root(root))
+        {
+            entry_points.push(CursorDirectoryEntryPoint::Session {
+                projects_root: projects_root.to_path_buf(),
+            });
+        }
+    }
+    if input.file_name() == Some(OsStr::new(AGENT_TRANSCRIPTS)) {
+        if let Some(projects_root) = input
+            .parent()
+            .and_then(Path::parent)
+            .filter(|root| is_literal_projects_root(root))
+        {
+            entry_points.push(CursorDirectoryEntryPoint::AgentTranscripts {
+                projects_root: projects_root.to_path_buf(),
+            });
+        }
+    }
+    if let Some(projects_root) = input.parent().filter(|root| is_literal_projects_root(root)) {
+        entry_points.push(CursorDirectoryEntryPoint::Project {
+            projects_root: projects_root.to_path_buf(),
+        });
+    }
+    if is_literal_projects_root(input) {
+        entry_points.push(CursorDirectoryEntryPoint::Projects);
+    }
+    entry_points.push(CursorDirectoryEntryPoint::ProviderRoot);
+    entry_points
+}
+
+fn discover_from_directory(
     input: &Path,
     directory: ProviderSourceDirectory,
+    limits: CursorInventoryLimits,
+    goal: CursorScanGoal,
     inventory: &mut CursorRootInventory,
-) -> (PathBuf, ProviderSourceDirectory) {
-    let names = match directory.entries(CURSOR_MAX_DIRECTORY_ENTRIES.saturating_add(1)) {
-        Ok(names) => names,
+) {
+    let fingerprint = directory.authority_fingerprint();
+    let baseline = inventory.clone();
+    let mut first_directory = Some(directory);
+    let mut fallback = None;
+    for entry_point in cursor_directory_entry_points(input) {
+        let Some(directory) = first_directory
+            .take()
+            .or_else(|| reopen_cursor_directory(input, fingerprint, limits, inventory))
+        else {
+            return;
+        };
+        let authority = directory.authority_root();
+        inventory.authority = Some(authority.clone());
+        scan_directory_entry_point(
+            input,
+            directory,
+            authority,
+            entry_point,
+            limits,
+            goal,
+            inventory,
+        );
+        if inventory.has_transcripts() {
+            return;
+        }
+        fallback.get_or_insert_with(|| inventory.clone());
+        if inventory.has_issue_kind(CursorDiscoveryIssueKind::LimitExceeded) {
+            return;
+        }
+        let work = inventory.stats.clone();
+        *inventory = baseline.clone();
+        inventory.stats.directories_visited = work.directories_visited;
+        inventory.stats.entries_visited = work.entries_visited;
+        inventory.stats.regular_files_visited = work.regular_files_visited;
+    }
+    if let Some(mut selected) = fallback {
+        selected.stats.directories_visited = inventory.stats.directories_visited;
+        selected.stats.entries_visited = inventory.stats.entries_visited;
+        selected.stats.regular_files_visited = inventory.stats.regular_files_visited;
+        *inventory = selected;
+    }
+}
+
+fn reopen_cursor_directory(
+    input: &Path,
+    expected_fingerprint: [u8; 32],
+    limits: CursorInventoryLimits,
+    inventory: &mut CursorRootInventory,
+) -> Option<ProviderSourceDirectory> {
+    if !admit_metadata_entry(input, limits, inventory) {
+        return None;
+    }
+    let directory = match open_provider_source_path(input) {
+        Ok(OpenedProviderSourcePath::Directory(directory)) => directory,
+        Ok(OpenedProviderSourcePath::File(_)) => {
+            inventory.reject(
+                input.to_path_buf(),
+                CursorDiscoveryIssueKind::Io,
+                "Cursor directory entry point changed into a file during discovery",
+                true,
+            );
+            return None;
+        }
         Err(error) => {
             inventory.reject(
                 input.to_path_buf(),
@@ -327,180 +547,318 @@ fn select_projects_directory(
                 error.to_string(),
                 true,
             );
-            return (input.to_path_buf(), directory);
+            return None;
         }
     };
-    if names.iter().any(|name| name == OsStr::new("projects")) {
-        if let Ok(OpenedProviderSourcePath::Directory(projects)) =
-            directory.open_child(OsStr::new("projects"))
-        {
-            return (input.join("projects"), projects);
-        }
+    if directory.authority_fingerprint() != expected_fingerprint {
+        inventory.reject(
+            input.to_path_buf(),
+            CursorDiscoveryIssueKind::Io,
+            "Cursor directory entry point changed while resolving its fixed-shape layout",
+            true,
+        );
+        return None;
     }
-    (input.to_path_buf(), directory)
+    admit_directory(input, limits, inventory).then_some(directory)
 }
 
-fn visit_directories(
+#[allow(clippy::too_many_arguments)]
+fn scan_directory_entry_point(
     input: &Path,
-    first_directory: ProviderSourceDirectory,
+    directory: ProviderSourceDirectory,
     authority: ProviderSourceRoot,
+    entry_point: CursorDirectoryEntryPoint,
+    limits: CursorInventoryLimits,
+    goal: CursorScanGoal,
     inventory: &mut CursorRootInventory,
 ) {
-    let first_relative = first_directory.relative_path().to_path_buf();
-    let mut pending = VecDeque::from([(input.to_path_buf(), first_relative, 0_usize)]);
-    drop(first_directory);
-    while let Some((directory_path, relative_path, depth)) = pending.pop_front() {
-        if inventory.stats.entries_visited >= CURSOR_MAX_TRAVERSAL_ENTRIES {
-            inventory.reject(
-                directory_path,
-                CursorDiscoveryIssueKind::LimitExceeded,
-                format!(
-                    "Cursor discovery exceeds the {CURSOR_MAX_TRAVERSAL_ENTRIES}-entry traversal limit"
-                ),
-                true,
-            );
-            break;
-        }
-        inventory.stats.directories_visited = inventory.stats.directories_visited.saturating_add(1);
-        let directory = match authority.open_directory(&relative_path) {
-            Ok(directory) => directory,
-            Err(error) => {
+    match entry_point {
+        CursorDirectoryEntryPoint::Session { projects_root } => {
+            let Some(session_id) = input
+                .file_name()
+                .and_then(OsStr::to_str)
+                .filter(|value| !value.trim().is_empty())
+            else {
                 inventory.reject(
-                    directory_path,
-                    CursorDiscoveryIssueKind::Io,
-                    error.to_string(),
+                    input.to_path_buf(),
+                    CursorDiscoveryIssueKind::InvalidLayout,
+                    "Cursor session directory must be nonempty UTF-8",
+                    false,
+                );
+                revalidate_directory(input, &directory, goal, inventory);
+                return;
+            };
+            scan_session(
+                &projects_root,
+                input,
+                session_id,
+                directory,
+                authority,
+                limits,
+                goal,
+                inventory,
+            );
+        }
+        CursorDirectoryEntryPoint::AgentTranscripts { projects_root } => {
+            scan_agent_transcripts(
+                &projects_root,
+                input,
+                directory,
+                authority,
+                limits,
+                goal,
+                inventory,
+            );
+        }
+        CursorDirectoryEntryPoint::Project { projects_root } => scan_project(
+            &projects_root,
+            input,
+            directory,
+            authority,
+            limits,
+            goal,
+            inventory,
+        ),
+        CursorDirectoryEntryPoint::Projects => {
+            scan_projects(input, directory, authority, limits, goal, inventory);
+        }
+        CursorDirectoryEntryPoint::ProviderRoot => match open_direct_child(
+            input,
+            &directory,
+            OsStr::new(PROJECTS),
+            true,
+            true,
+            limits,
+            inventory,
+        ) {
+            DirectChild::Directory(projects) => {
+                let projects_path = input.join(PROJECTS);
+                inventory.input = projects_path.clone();
+                scan_projects(&projects_path, projects, authority, limits, goal, inventory);
+                revalidate_directory(input, &directory, goal, inventory);
+            }
+            DirectChild::Failed => revalidate_directory(input, &directory, goal, inventory),
+            DirectChild::File(_) => {
+                inventory.reject(
+                    input.join(PROJECTS),
+                    CursorDiscoveryIssueKind::InvalidLayout,
+                    "Cursor projects component must be a directory",
                     true,
                 );
-                continue;
+                revalidate_directory(input, &directory, goal, inventory);
             }
-        };
-        let entries = read_directory_entries(&directory_path, &directory, inventory);
-        for name in entries {
-            let path = directory_path.join(&name);
-            match directory.open_child(&name) {
-                Ok(OpenedProviderSourcePath::Directory(child_directory)) => {
-                    if depth >= CURSOR_MAX_DIRECTORY_DEPTH {
-                        inventory.reject(
-                        path,
-                        CursorDiscoveryIssueKind::LimitExceeded,
-                        format!(
-                            "Cursor discovery exceeds the {CURSOR_MAX_DIRECTORY_DEPTH}-level directory depth limit"
-                        ),
-                        true,
-                    );
-                    } else {
-                        pending.push_back((
-                            path,
-                            child_directory.relative_path().to_path_buf(),
-                            depth.saturating_add(1),
-                        ));
-                    }
-                }
-                Ok(OpenedProviderSourcePath::File(file)) => {
-                    inventory.stats.regular_files_visited =
-                        inventory.stats.regular_files_visited.saturating_add(1);
-                    inspect_file(
-                        input,
-                        &path,
-                        relative_path.join(name),
-                        file,
-                        authority.clone(),
-                        inventory,
-                        false,
-                    );
-                }
-                Err(error) => {
-                    // A non-regular entry (Unix-domain socket, FIFO, device
-                    // node) is safely refused by the authority walk. Skip it
-                    // without invalidating completion: its mere presence beside
-                    // valid transcripts must not mark the whole Cursor source
-                    // unreadable, which would otherwise fail the full refresh.
-                    if ctx_history_provider_runtime::source_io::is_non_regular_source_rejection(
-                        &error,
-                    ) {
-                        inventory.reject(
-                            path,
-                            CursorDiscoveryIssueKind::SpecialFile,
-                            error.to_string(),
-                            false,
-                        );
-                    } else {
-                        inventory.reject(
-                            path,
-                            CursorDiscoveryIssueKind::Symlink,
-                            error.to_string(),
-                            true,
-                        );
-                    }
-                }
+            DirectChild::Missing if input.file_name() == Some(OsStr::new(".cursor")) => {
+                revalidate_directory(input, &directory, goal, inventory);
             }
-        }
-        if let Err(error) = directory.revalidate() {
-            inventory.reject(
-                directory_path,
-                CursorDiscoveryIssueKind::Io,
-                error.to_string(),
-                true,
-            );
-        }
+            DirectChild::Missing => {
+                inventory.reject(
+                    input.to_path_buf(),
+                    CursorDiscoveryIssueKind::InvalidLayout,
+                    "Cursor directory entry point must be a provider root containing projects or be beneath a literal projects directory",
+                    true,
+                );
+                revalidate_directory(input, &directory, goal, inventory);
+            }
+        },
     }
 }
 
-fn read_directory_entries(
-    directory_path: &Path,
-    directory: &ProviderSourceDirectory,
+fn scan_projects(
+    projects_root: &Path,
+    projects: ProviderSourceDirectory,
+    authority: ProviderSourceRoot,
+    limits: CursorInventoryLimits,
+    goal: CursorScanGoal,
     inventory: &mut CursorRootInventory,
-) -> Vec<std::ffi::OsString> {
-    let reader = match directory.entries(CURSOR_MAX_DIRECTORY_ENTRIES.saturating_add(1)) {
-        Ok(entries) => entries,
-        Err(error) => {
-            inventory.reject(
-                directory_path.to_path_buf(),
-                CursorDiscoveryIssueKind::Io,
-                error.to_string(),
-                true,
-            );
-            return Vec::new();
-        }
-    };
-    let mut entries = Vec::new();
-    for name in reader {
-        if entries.len() >= CURSOR_MAX_DIRECTORY_ENTRIES {
-            inventory.reject(
-                directory_path.to_path_buf(),
-                CursorDiscoveryIssueKind::LimitExceeded,
-                format!("Cursor directory exceeds the {CURSOR_MAX_DIRECTORY_ENTRIES}-entry limit"),
-                true,
-            );
-            entries.clear();
-            break;
-        }
-        if inventory.stats.entries_visited >= CURSOR_MAX_TRAVERSAL_ENTRIES {
-            inventory.reject(
-                directory_path.to_path_buf(),
-                CursorDiscoveryIssueKind::LimitExceeded,
-                format!(
-                    "Cursor discovery exceeds the {CURSOR_MAX_TRAVERSAL_ENTRIES}-entry traversal limit"
-                ),
-                true,
-            );
-            entries.clear();
-            break;
-        }
-        inventory.stats.entries_visited = inventory.stats.entries_visited.saturating_add(1);
-        entries.push(name);
+) {
+    if !require_literal_projects_root(projects_root, projects_root, inventory) {
+        revalidate_directory(projects_root, &projects, goal, inventory);
+        return;
     }
-    entries
+    let entries = read_directory_entries(projects_root, &projects, limits, inventory);
+    for name in entries {
+        if scan_should_stop(goal, inventory) {
+            break;
+        }
+        let project_path = projects_root.join(&name);
+        match open_enumerated_child(
+            &project_path,
+            &projects,
+            &name,
+            true,
+            false,
+            limits,
+            inventory,
+        ) {
+            Some(OpenedProviderSourcePath::Directory(project)) => scan_project(
+                projects_root,
+                &project_path,
+                project,
+                authority.clone(),
+                limits,
+                goal,
+                inventory,
+            ),
+            Some(OpenedProviderSourcePath::File(_)) | None => {}
+        }
+    }
+    revalidate_directory(projects_root, &projects, goal, inventory);
+}
+
+fn scan_project(
+    projects_root: &Path,
+    project_path: &Path,
+    project: ProviderSourceDirectory,
+    authority: ProviderSourceRoot,
+    limits: CursorInventoryLimits,
+    goal: CursorScanGoal,
+    inventory: &mut CursorRootInventory,
+) {
+    if !require_literal_projects_root(project_path, projects_root, inventory) {
+        revalidate_directory(project_path, &project, goal, inventory);
+        return;
+    }
+    match open_direct_child(
+        project_path,
+        &project,
+        OsStr::new(AGENT_TRANSCRIPTS),
+        true,
+        true,
+        limits,
+        inventory,
+    ) {
+        DirectChild::Directory(agent_transcripts) => scan_agent_transcripts(
+            projects_root,
+            &project_path.join(AGENT_TRANSCRIPTS),
+            agent_transcripts,
+            authority,
+            limits,
+            goal,
+            inventory,
+        ),
+        DirectChild::File(_) => inventory.reject(
+            project_path.join(AGENT_TRANSCRIPTS),
+            CursorDiscoveryIssueKind::InvalidLayout,
+            "Cursor agent-transcripts component must be a directory",
+            true,
+        ),
+        DirectChild::Missing | DirectChild::Failed => {}
+    }
+    revalidate_directory(project_path, &project, goal, inventory);
+}
+
+fn scan_agent_transcripts(
+    projects_root: &Path,
+    agent_transcripts_path: &Path,
+    agent_transcripts: ProviderSourceDirectory,
+    authority: ProviderSourceRoot,
+    limits: CursorInventoryLimits,
+    goal: CursorScanGoal,
+    inventory: &mut CursorRootInventory,
+) {
+    if !require_literal_projects_root(agent_transcripts_path, projects_root, inventory) {
+        revalidate_directory(agent_transcripts_path, &agent_transcripts, goal, inventory);
+        return;
+    }
+    let entries = read_directory_entries(
+        agent_transcripts_path,
+        &agent_transcripts,
+        limits,
+        inventory,
+    );
+    for name in entries {
+        if scan_should_stop(goal, inventory) {
+            break;
+        }
+        let session_path = agent_transcripts_path.join(&name);
+        let Some(session_id) = name.to_str().filter(|value| !value.trim().is_empty()) else {
+            inventory.reject(
+                session_path,
+                CursorDiscoveryIssueKind::InvalidLayout,
+                "Cursor session directory must be nonempty UTF-8",
+                false,
+            );
+            continue;
+        };
+        match open_enumerated_child(
+            &session_path,
+            &agent_transcripts,
+            &name,
+            true,
+            false,
+            limits,
+            inventory,
+        ) {
+            Some(OpenedProviderSourcePath::Directory(session)) => scan_session(
+                projects_root,
+                &session_path,
+                session_id,
+                session,
+                authority.clone(),
+                limits,
+                goal,
+                inventory,
+            ),
+            Some(OpenedProviderSourcePath::File(_)) | None => {}
+        }
+    }
+    revalidate_directory(agent_transcripts_path, &agent_transcripts, goal, inventory);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn scan_session(
+    projects_root: &Path,
+    session_path: &Path,
+    session_id: &str,
+    session: ProviderSourceDirectory,
+    authority: ProviderSourceRoot,
+    limits: CursorInventoryLimits,
+    goal: CursorScanGoal,
+    inventory: &mut CursorRootInventory,
+) {
+    if !require_literal_projects_root(session_path, projects_root, inventory) {
+        revalidate_directory(session_path, &session, goal, inventory);
+        return;
+    }
+    let transcript_name = format!("{session_id}.jsonl");
+    let transcript_path = session_path.join(&transcript_name);
+    match open_direct_child(
+        session_path,
+        &session,
+        OsStr::new(&transcript_name),
+        true,
+        true,
+        limits,
+        inventory,
+    ) {
+        DirectChild::File(file) => inspect_file(
+            &transcript_path,
+            session.relative_path().join(&transcript_name),
+            file,
+            authority,
+            inventory,
+            false,
+            limits,
+        ),
+        DirectChild::Directory(_) => inventory.reject(
+            transcript_path,
+            CursorDiscoveryIssueKind::InvalidLayout,
+            "Cursor transcript leaf must be a regular file",
+            true,
+        ),
+        DirectChild::Missing | DirectChild::Failed => {}
+    }
+    revalidate_directory(session_path, &session, goal, inventory);
 }
 
 fn inspect_file(
-    input: &Path,
     path: &Path,
     authority_relative_path: PathBuf,
     source_file: OpenedProviderSourceFile,
     authority: ProviderSourceRoot,
     inventory: &mut CursorRootInventory,
     explicit_file: bool,
+    limits: CursorInventoryLimits,
 ) {
     if path.extension().and_then(OsStr::to_str) != Some("jsonl") {
         if explicit_file {
@@ -536,6 +894,10 @@ fn inspect_file(
     let Some(projects_root) = project.parent() else {
         return;
     };
+    if !require_literal_projects_root(path, projects_root, inventory) {
+        return;
+    }
+    let selected_root = if explicit_file { path } else { projects_root };
     if ![
         projects_root,
         project,
@@ -543,7 +905,7 @@ fn inspect_file(
         session_directory,
         path,
     ]
-    .contains(&input)
+    .contains(&selected_root)
     {
         inventory.reject(
             path.to_path_buf(),
@@ -577,13 +939,16 @@ fn inspect_file(
         ordinary_file_token,
         authority,
     ) {
-        Ok(source) if inventory.transcripts.len() < CURSOR_MAX_TRANSCRIPTS => {
-            inventory.transcripts.push(source);
+        Ok(source) if inventory.transcripts.len() < limits.max_transcripts => {
+            inventory.transcripts.push(source)
         }
         Ok(_) => inventory.reject(
             path.to_path_buf(),
             CursorDiscoveryIssueKind::LimitExceeded,
-            format!("Cursor discovery exceeds the {CURSOR_MAX_TRANSCRIPTS}-transcript limit"),
+            format!(
+                "Cursor discovery exceeds the {}-transcript inventory limit",
+                limits.max_transcripts
+            ),
             true,
         ),
         Err(reason) => inventory.reject(
@@ -611,63 +976,4 @@ fn cursor_catalog_token(
         reopened.revalidate_leaf()?;
     }
     Ok(token)
-}
-
-#[cfg(all(test, unix))]
-mod tests {
-    use super::*;
-    use std::ffi::CString;
-    use std::os::unix::ffi::OsStrExt as _;
-
-    // Creates a non-regular special file (FIFO) at `path`. A FIFO shares the
-    // exact authority-walk rejection path as the reported Cursor `worker.sock`
-    // Unix-domain socket (both classify as NON_REGULAR_PROVIDER_SOURCE_REASON),
-    // and unlike a bound socket it is not constrained by the platform sun_path
-    // length limit under a deep temp directory. The socket-specific errno
-    // mapping is covered separately in the root_handle unix tests.
-    fn make_special_file(path: &Path) {
-        let raw = CString::new(path.as_os_str().as_bytes()).unwrap();
-        let result = unsafe { libc::mkfifo(raw.as_ptr(), 0o600) };
-        assert_eq!(result, 0, "mkfifo {}", path.display());
-    }
-
-    #[test]
-    fn cursor_special_file_beside_transcript_is_skipped_without_failing_discovery() {
-        // Regression: a live special file (for example Cursor's `worker.sock`)
-        // sitting beside valid transcripts must be safely skipped, not treated
-        // as an unreadable source. Previously it invalidated completion, marked
-        // the whole Cursor provider `unknown`, and failed the full refresh so
-        // no lexical index was published for any provider.
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path();
-        let session_directory = root
-            .join("projects")
-            .join("acme")
-            .join(AGENT_TRANSCRIPTS)
-            .join("session-a");
-        std::fs::create_dir_all(&session_directory).unwrap();
-        std::fs::write(session_directory.join("session-a.jsonl"), b"{}\n").unwrap();
-        make_special_file(&session_directory.join("worker.sock"));
-
-        let inventory = discover_cursor_transcripts(root);
-
-        assert!(
-            inventory.completed,
-            "special-file entry must not invalidate completion: {:?}",
-            inventory.issues
-        );
-        assert_eq!(
-            inventory.transcripts.len(),
-            1,
-            "the valid transcript is still discovered alongside the special file"
-        );
-        assert!(
-            inventory
-                .issues
-                .iter()
-                .any(|issue| issue.kind == CursorDiscoveryIssueKind::SpecialFile),
-            "the skipped special file is recorded as a non-fatal issue: {:?}",
-            inventory.issues
-        );
-    }
 }

--- a/crates/ctx-history-provider-claude-cursor/src/cursor/layout_helpers.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/cursor/layout_helpers.rs
@@ -1,0 +1,244 @@
+use super::*;
+
+pub(super) enum DirectChild {
+    Missing,
+    File(OpenedProviderSourceFile),
+    Directory(ProviderSourceDirectory),
+    Failed,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn open_direct_child(
+    parent_path: &Path,
+    parent: &ProviderSourceDirectory,
+    name: &OsStr,
+    symlink_invalidates: bool,
+    special_invalidates: bool,
+    limits: CursorInventoryLimits,
+    inventory: &mut CursorRootInventory,
+) -> DirectChild {
+    let path = parent_path.join(name);
+    if !admit_metadata_entry(&path, limits, inventory) {
+        return DirectChild::Failed;
+    }
+    match parent.open_child(name) {
+        Ok(OpenedProviderSourcePath::File(file)) => {
+            inventory.stats.regular_files_visited =
+                inventory.stats.regular_files_visited.saturating_add(1);
+            DirectChild::File(file)
+        }
+        Ok(OpenedProviderSourcePath::Directory(directory)) => {
+            if admit_directory(&path, limits, inventory) {
+                DirectChild::Directory(directory)
+            } else {
+                DirectChild::Failed
+            }
+        }
+        Err(error) if capture_error_is_not_found(&error) => DirectChild::Missing,
+        Err(error) => {
+            reject_open_error(
+                path,
+                error,
+                symlink_invalidates,
+                special_invalidates,
+                inventory,
+            );
+            DirectChild::Failed
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn open_enumerated_child(
+    path: &Path,
+    parent: &ProviderSourceDirectory,
+    name: &OsStr,
+    symlink_invalidates: bool,
+    special_invalidates: bool,
+    limits: CursorInventoryLimits,
+    inventory: &mut CursorRootInventory,
+) -> Option<OpenedProviderSourcePath> {
+    match parent.open_child(name) {
+        Ok(OpenedProviderSourcePath::File(file)) => {
+            inventory.stats.regular_files_visited =
+                inventory.stats.regular_files_visited.saturating_add(1);
+            Some(OpenedProviderSourcePath::File(file))
+        }
+        Ok(OpenedProviderSourcePath::Directory(directory)) => {
+            admit_directory(path, limits, inventory)
+                .then_some(OpenedProviderSourcePath::Directory(directory))
+        }
+        Err(error) => {
+            reject_open_error(
+                path.to_path_buf(),
+                error,
+                symlink_invalidates,
+                special_invalidates,
+                inventory,
+            );
+            None
+        }
+    }
+}
+
+pub(super) fn read_directory_entries(
+    directory_path: &Path,
+    directory: &ProviderSourceDirectory,
+    limits: CursorInventoryLimits,
+    inventory: &mut CursorRootInventory,
+) -> Vec<std::ffi::OsString> {
+    // Both scan goals use this bounded sorted view. Complete inventory needs
+    // deterministic order; retaining it for the existential goal also keeps
+    // Found-versus-budget outcomes independent of native enumeration order.
+    let remaining = limits
+        .max_metadata_entries
+        .saturating_sub(inventory.stats.entries_visited);
+    let reader = match directory.entries(remaining.saturating_add(1)) {
+        Ok(entries) => entries,
+        Err(CaptureError::InvalidProviderTranscriptPath { .. }) => {
+            inventory.reject(
+                directory_path.to_path_buf(),
+                CursorDiscoveryIssueKind::LimitExceeded,
+                format!(
+                    "Cursor discovery exceeds the {}-metadata-entry inventory limit",
+                    limits.max_metadata_entries
+                ),
+                true,
+            );
+            return Vec::new();
+        }
+        Err(error) => {
+            inventory.reject(
+                directory_path.to_path_buf(),
+                CursorDiscoveryIssueKind::Io,
+                error.to_string(),
+                true,
+            );
+            return Vec::new();
+        }
+    };
+    let mut entries = Vec::new();
+    for name in reader {
+        let path = directory_path.join(&name);
+        if !admit_metadata_entry(&path, limits, inventory) {
+            return Vec::new();
+        }
+        entries.push(name);
+    }
+    entries
+}
+
+pub(super) fn admit_metadata_entry(
+    path: &Path,
+    limits: CursorInventoryLimits,
+    inventory: &mut CursorRootInventory,
+) -> bool {
+    let observed = inventory.stats.entries_visited.saturating_add(1);
+    if observed > limits.max_metadata_entries {
+        inventory.reject(
+            path.to_path_buf(),
+            CursorDiscoveryIssueKind::LimitExceeded,
+            format!(
+                "Cursor discovery exceeds the {}-metadata-entry inventory limit",
+                limits.max_metadata_entries
+            ),
+            true,
+        );
+        return false;
+    }
+    if path.as_os_str().as_encoded_bytes().len() > limits.max_path_bytes {
+        inventory.reject(
+            path.to_path_buf(),
+            CursorDiscoveryIssueKind::LimitExceeded,
+            format!(
+                "Cursor discovery path exceeds the {}-encoded-byte inventory limit",
+                limits.max_path_bytes
+            ),
+            true,
+        );
+        return false;
+    }
+    inventory.stats.entries_visited = observed;
+    true
+}
+
+pub(super) fn admit_directory(
+    path: &Path,
+    limits: CursorInventoryLimits,
+    inventory: &mut CursorRootInventory,
+) -> bool {
+    let observed = inventory.stats.directories_visited.saturating_add(1);
+    if observed > limits.max_directories {
+        inventory.reject(
+            path.to_path_buf(),
+            CursorDiscoveryIssueKind::LimitExceeded,
+            format!(
+                "Cursor discovery exceeds the {}-directory inventory limit",
+                limits.max_directories
+            ),
+            true,
+        );
+        return false;
+    }
+    inventory.stats.directories_visited = observed;
+    true
+}
+
+fn reject_open_error(
+    path: PathBuf,
+    error: CaptureError,
+    symlink_invalidates: bool,
+    special_invalidates: bool,
+    inventory: &mut CursorRootInventory,
+) {
+    if ctx_history_provider_runtime::source_io::is_symlink_source_rejection(&error) {
+        inventory.reject(
+            path,
+            CursorDiscoveryIssueKind::Symlink,
+            error.to_string(),
+            symlink_invalidates,
+        );
+    } else if ctx_history_provider_runtime::source_io::is_non_regular_source_rejection(&error) {
+        inventory.reject(
+            path,
+            CursorDiscoveryIssueKind::SpecialFile,
+            error.to_string(),
+            special_invalidates,
+        );
+    } else {
+        inventory.reject(path, CursorDiscoveryIssueKind::Io, error.to_string(), true);
+    }
+}
+
+pub(super) fn capture_error_is_not_found(error: &CaptureError) -> bool {
+    matches!(error, CaptureError::Io(error) if error.kind() == std::io::ErrorKind::NotFound)
+        || matches!(
+            error,
+            CaptureError::SystemIo { source, .. }
+                if source.kind() == std::io::ErrorKind::NotFound
+        )
+}
+
+pub(super) fn revalidate_directory(
+    path: &Path,
+    directory: &ProviderSourceDirectory,
+    goal: CursorScanGoal,
+    inventory: &mut CursorRootInventory,
+) {
+    if let Err(error) = directory.revalidate() {
+        inventory.reject(
+            path.to_path_buf(),
+            CursorDiscoveryIssueKind::Io,
+            error.to_string(),
+            true,
+        );
+        if goal == CursorScanGoal::FirstTranscript {
+            inventory.transcripts.clear();
+        }
+    }
+}
+
+pub(super) fn scan_should_stop(goal: CursorScanGoal, inventory: &CursorRootInventory) -> bool {
+    inventory.has_issue_kind(CursorDiscoveryIssueKind::LimitExceeded)
+        || (goal == CursorScanGoal::FirstTranscript && inventory.has_transcripts())
+}

--- a/crates/ctx-history-provider-claude-cursor/src/cursor/layout_tests.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/cursor/layout_tests.rs
@@ -1,0 +1,274 @@
+use super::layout::*;
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::{ffi::CString, os::unix::ffi::OsStrExt as _};
+
+fn write_transcript(projects_root: &Path, project: &str, session_id: &str) -> PathBuf {
+    let session_directory = projects_root
+        .join(project)
+        .join(AGENT_TRANSCRIPTS)
+        .join(session_id);
+    std::fs::create_dir_all(&session_directory).unwrap();
+    let transcript = session_directory.join(format!("{session_id}.jsonl"));
+    std::fs::write(&transcript, b"{}\n").unwrap();
+    transcript
+}
+
+#[test]
+fn cursor_discovers_129_and_1258_canonical_transcripts() {
+    for expected in [129_usize, 1_258] {
+        let temp = tempfile::tempdir().unwrap();
+        let projects = temp.path().join(PROJECTS);
+        for index in 0..expected {
+            write_transcript(&projects, "acme", &format!("session-{index:04}"));
+        }
+
+        let inventory = discover_cursor_transcripts(&projects);
+
+        assert!(
+            inventory.completed,
+            "{expected}-transcript inventory failed: {:?}",
+            inventory.issues
+        );
+        assert_eq!(inventory.transcripts.len(), expected);
+    }
+}
+
+#[test]
+fn cursor_never_enumerates_more_than_4096_unrelated_subtree_entries() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join(".cursor");
+    let projects = root.join(PROJECTS);
+    let canvases = projects.join("acme/canvases");
+    std::fs::create_dir_all(&canvases).unwrap();
+    for index in 0..4_097 {
+        std::fs::write(canvases.join(format!("canvas-{index:04}")), b"state").unwrap();
+    }
+    let transcript = write_transcript(&projects, "acme", "ordinary-session");
+
+    let inventory = discover_cursor_transcripts(&root);
+
+    assert!(inventory.completed, "{:?}", inventory.issues);
+    assert_eq!(inventory.transcripts.len(), 1);
+    assert_eq!(inventory.transcripts[0].path(), transcript);
+    assert!(
+        inventory.stats.entries_visited < 16,
+        "unrelated canvas entries leaked into fixed-shape work: {:?}",
+        inventory.stats
+    );
+    assert_eq!(
+        probe_cursor_transcript_availability(&root),
+        CursorTranscriptAvailability::Found
+    );
+}
+
+#[test]
+fn cursor_preserves_all_six_entry_points_across_reserved_name_collisions() {
+    for (root_name, project_name, session_id) in [
+        (".cursor", "acme", "session-a"),
+        (PROJECTS, AGENT_TRANSCRIPTS, AGENT_TRANSCRIPTS),
+    ] {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join(root_name);
+        let projects = root.join(PROJECTS);
+        let transcript = write_transcript(&projects, project_name, session_id);
+        let session = transcript.parent().unwrap().to_path_buf();
+        let agent_transcripts = session.parent().unwrap().to_path_buf();
+        let project = agent_transcripts.parent().unwrap().to_path_buf();
+
+        for input in [
+            root,
+            projects,
+            project,
+            agent_transcripts,
+            session,
+            transcript.clone(),
+        ] {
+            let inventory = discover_cursor_transcripts(&input);
+            assert!(
+                inventory.completed,
+                "entry point {} failed: {:?}",
+                input.display(),
+                inventory.issues
+            );
+            assert_eq!(
+                inventory.transcripts.len(),
+                1,
+                "entry point {} selected the wrong cardinality",
+                input.display()
+            );
+            assert_eq!(inventory.transcripts[0].path(), transcript);
+            assert!(
+                inventory.stats.entries_visited < 64,
+                "{:?}",
+                inventory.stats
+            );
+            assert_eq!(
+                probe_cursor_transcript_availability(&input),
+                CursorTranscriptAvailability::Found
+            );
+        }
+    }
+}
+
+#[test]
+fn cursor_rejects_every_lower_entry_point_outside_literal_projects() {
+    let temp = tempfile::tempdir().unwrap();
+    let not_projects = temp.path().join("not-projects");
+    let transcript = write_transcript(&not_projects, "acme", "session-a");
+    let session = transcript.parent().unwrap().to_path_buf();
+    let agent_transcripts = session.parent().unwrap().to_path_buf();
+    let project = agent_transcripts.parent().unwrap().to_path_buf();
+
+    for input in [
+        not_projects,
+        project,
+        agent_transcripts,
+        session,
+        transcript,
+    ] {
+        let inventory = discover_cursor_transcripts(&input);
+        assert!(
+            !inventory.completed,
+            "loose entry point {} unexpectedly completed",
+            input.display()
+        );
+        assert!(
+            inventory.has_issue_kind(CursorDiscoveryIssueKind::InvalidLayout),
+            "loose entry point {} was not rejected as invalid: {:?}",
+            input.display(),
+            inventory.issues
+        );
+        assert!(
+            inventory.transcripts.is_empty(),
+            "loose entry point {} selected a transcript",
+            input.display()
+        );
+        assert_ne!(
+            probe_cursor_transcript_availability(&input),
+            CursorTranscriptAvailability::Found,
+            "loose entry point {} proved availability",
+            input.display()
+        );
+    }
+}
+
+#[test]
+fn cursor_missing_input_is_not_found_but_complete_inventory_fails_closed() {
+    let temp = tempfile::tempdir().unwrap();
+    let missing = temp.path().join(".cursor").join(PROJECTS);
+
+    assert_eq!(
+        probe_cursor_transcript_availability(&missing),
+        CursorTranscriptAvailability::NotFound
+    );
+    let inventory = discover_cursor_transcripts(&missing);
+    assert!(!inventory.completed);
+    assert!(inventory.has_issue_kind(CursorDiscoveryIssueKind::NotFound));
+    assert!(inventory.transcripts.is_empty());
+}
+
+#[test]
+fn cursor_transcript_limit_plus_one_fails_complete_inventory_but_not_availability() {
+    let temp = tempfile::tempdir().unwrap();
+    let projects = temp.path().join(PROJECTS);
+    for index in 0..=2 {
+        write_transcript(&projects, "acme", &format!("session-{index}"));
+    }
+    let limits = CursorInventoryLimits {
+        max_transcripts: 2,
+        ..CursorInventoryLimits::default()
+    };
+
+    let inventory = discover_cursor_transcripts_with_limits(&projects, limits);
+
+    assert!(!inventory.completed);
+    assert!(inventory.has_issue_kind(CursorDiscoveryIssueKind::LimitExceeded));
+    assert_eq!(inventory.transcripts.len(), 2);
+    assert_eq!(
+        probe_cursor_transcript_availability_with_limits(&projects, limits),
+        CursorTranscriptAvailability::Found
+    );
+}
+
+// Creates a non-regular special file (FIFO) at `path`. A FIFO shares the
+// exact authority-walk rejection path as the reported Cursor `worker.sock`
+// Unix-domain socket (both classify as NON_REGULAR_PROVIDER_SOURCE_REASON),
+// and unlike a bound socket it is not constrained by the platform sun_path
+// length limit under a deep temp directory. The socket-specific errno mapping
+// is covered separately in the root_handle unix tests.
+#[cfg(unix)]
+fn make_special_file(path: &Path) {
+    let raw = CString::new(path.as_os_str().as_bytes()).unwrap();
+    let result = unsafe { libc::mkfifo(raw.as_ptr(), 0o600) };
+    assert_eq!(result, 0, "mkfifo {}", path.display());
+}
+
+#[cfg(unix)]
+#[test]
+fn cursor_ignores_unrelated_links_and_special_files_but_fails_canonical_ones() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().unwrap();
+    let projects = temp.path().join(PROJECTS);
+    let transcript = write_transcript(&projects, "acme", "session-a");
+    let session = transcript.parent().unwrap();
+    let project = projects.join("acme");
+    let canvases = project.join("canvases");
+    let terminals = project.join("terminals");
+    std::fs::create_dir_all(&canvases).unwrap();
+    std::fs::create_dir_all(&terminals).unwrap();
+    symlink(temp.path(), canvases.join("linked-state")).unwrap();
+    make_special_file(&terminals.join("worker.sock"));
+    make_special_file(&session.join("worker.sock"));
+
+    let unrelated = discover_cursor_transcripts(&projects);
+
+    assert!(
+        unrelated.completed,
+        "unrelated entries must not invalidate completion: {:?}",
+        unrelated.issues
+    );
+    assert_eq!(unrelated.transcripts.len(), 1);
+    assert!(!unrelated.has_issue_kind(CursorDiscoveryIssueKind::Symlink));
+    assert!(!unrelated.has_issue_kind(CursorDiscoveryIssueKind::SpecialFile));
+
+    let agent_transcripts = project.join(AGENT_TRANSCRIPTS);
+    let linked_session = agent_transcripts.join("linked-session");
+    std::fs::create_dir_all(&linked_session).unwrap();
+    symlink(&transcript, linked_session.join("linked-session.jsonl")).unwrap();
+    let special_session = agent_transcripts.join("special-session");
+    std::fs::create_dir_all(&special_session).unwrap();
+    make_special_file(&special_session.join("special-session.jsonl"));
+
+    let canonical = discover_cursor_transcripts(&projects);
+
+    assert!(!canonical.completed);
+    assert!(canonical.has_issue_kind(CursorDiscoveryIssueKind::Symlink));
+    assert!(canonical.has_issue_kind(CursorDiscoveryIssueKind::SpecialFile));
+    assert_eq!(canonical.transcripts.len(), 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn cursor_availability_is_existential_when_complete_inventory_is_unsafe() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().unwrap();
+    let projects = temp.path().join(PROJECTS);
+    let target = temp.path().join("target");
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::create_dir_all(&projects).unwrap();
+    symlink(&target, projects.join("a-linked-project")).unwrap();
+    write_transcript(&projects, "z-valid-project", "ordinary-session");
+
+    let inventory = discover_cursor_transcripts(&projects);
+
+    assert!(!inventory.completed);
+    assert!(inventory.has_issue_kind(CursorDiscoveryIssueKind::Symlink));
+    assert_eq!(inventory.transcripts.len(), 1);
+    assert_eq!(
+        probe_cursor_transcript_availability(&projects),
+        CursorTranscriptAvailability::Found
+    );
+}


### PR DESCRIPTION
## Summary
- traverse only Cursor’s fixed `projects/<project>/agent-transcripts/<session>/<session>.jsonl` layout instead of recursively walking unrelated state
- separate bounded availability probing from fail-closed complete inventory
- preserve deterministic ordering, safe symlink/race handling, all six entry points including reserved-name collisions, and last-good publication on incomplete discovery

## Validation
- `scripts/bazel-affected.sh origin/main` — 125/126 passed; the sole unrelated lifecycle timing failure passed on an isolated rerun
- `bash scripts/check.sh --mode=ci` — physical crate-size gate passed, strict Clippy passed across all 437 targets, and all 208 test targets passed
- fresh independent review of exact commit `95bc45a` — SHIP, no findings

Fixes #665