### PR TITLE
fix(jsonl): authenticate ctime-only source changes

### DIFF
--- a/crates/ctx-history-jsonl/src/family.rs
+++ b/crates/ctx-history-jsonl/src/family.rs
@@ -157,7 +157,9 @@ pub use physical::{
 };
 use revalidation::hash_prefix;
 pub use revalidation::revalidate_frozen_prefix;
-pub(crate) use revalidation::revalidate_frozen_prefix_sha256;
+pub(crate) use revalidation::{
+    authenticate_frozen_prefix, authenticate_frozen_prefix_sha256, revalidate_frozen_prefix_sha256,
+};
 #[cfg(any(test, feature = "test-support"))]
 pub use revalidation::{
     jsonl_prefix_hash_bytes, reset_jsonl_prefix_hash_bytes, set_after_final_jsonl_prefix_hash_hook,

--- a/crates/ctx-history-jsonl/src/family/reader.rs
+++ b/crates/ctx-history-jsonl/src/family/reader.rs
@@ -283,6 +283,31 @@ impl<E: JsonlFamilyError> JsonlReader<E> {
                 source_change = JsonlSourceChange::Unchanged;
                 skip_scan = true;
                 unchanged_checkpoint = Some(previous.clone());
+            } else if previous_observation.differs_only_by_change_identity(&observation) {
+                if let Some(admitted_eof_sha256) = previous.admitted_eof_sha256() {
+                    super::authenticate_frozen_prefix_sha256(
+                        identity.source_path(),
+                        source_file.as_ref(),
+                        &observation,
+                        observation.length(),
+                        admitted_eof_sha256,
+                    )?;
+                } else if previous.complete_prefix_end() == previous_observation.length() {
+                    super::authenticate_frozen_prefix(
+                        identity.source_path(),
+                        source_file.as_ref(),
+                        &observation,
+                        observation.length(),
+                        *previous.complete_prefix_sha256(),
+                    )?;
+                } else {
+                    return Err(E::source_changed());
+                }
+                complete_prefix_end = previous.complete_prefix_end();
+                next_physical_ordinal = previous.next_physical_ordinal();
+                source_change = JsonlSourceChange::Unchanged;
+                skip_scan = true;
+                unchanged_checkpoint = Some(previous.clone());
             } else if physical_suffix_resume
                 && same_file
                 && observation.length() >= previous.complete_prefix_end()
@@ -375,12 +400,20 @@ impl<E: JsonlFamilyError> JsonlReader<E> {
                 next_physical_ordinal = probe.next_physical_ordinal;
             }
         }
-        let full_hasher = if used_direct_append {
-            bind_admitted_eof.then(|| {
-                semantic_append_resume
-                    .as_ref()
-                    .and_then(|resume| resume.previous.restore_admitted_eof_hasher())
-                    .expect("direct admitted-EOF resume was validated above")
+        let full_hasher = if whole_record || skip_scan {
+            None
+        } else if used_direct_append {
+            let restored = semantic_append_resume
+                .as_ref()
+                .and_then(|resume| resume.previous.restore_admitted_eof_hasher());
+            Some(match restored {
+                Some(restored) => restored,
+                None => hash_prefix::<E, _>(
+                    identity.source_path(),
+                    &mut file,
+                    complete_prefix_end,
+                    JsonlResumableSha256::new(),
+                )?,
             })
         } else if semantic_append_resume
             .as_ref()
@@ -388,16 +421,20 @@ impl<E: JsonlFamilyError> JsonlReader<E> {
         {
             Some(JsonlResumableSha256::new())
         } else {
-            bind_admitted_eof
-                .then(|| {
-                    hash_prefix::<E, _>(
-                        identity.source_path(),
-                        &mut file,
-                        complete_prefix_end,
-                        JsonlResumableSha256::new(),
-                    )
-                })
-                .transpose()?
+            let restored = (source_change == JsonlSourceChange::Append)
+                .then_some(previous)
+                .flatten()
+                .filter(|previous| previous.source_observation().length() == complete_prefix_end)
+                .and_then(JsonlCheckpoint::restore_admitted_eof_hasher);
+            Some(match restored {
+                Some(restored) => restored,
+                None => hash_prefix::<E, _>(
+                    identity.source_path(),
+                    &mut file,
+                    complete_prefix_end,
+                    JsonlResumableSha256::new(),
+                )?,
+            })
         };
         file.seek(SeekFrom::Start(complete_prefix_end))?;
         let (reader, physical) = if whole_record {
@@ -886,10 +923,30 @@ impl<E: JsonlFamilyError> JsonlReader<E> {
                 self.source_file.revalidate()?;
             }
         } else {
-            if !self.append_log {
+            if self.observation.differs_only_by_change_identity(&current) {
+                if let Some(admitted_eof_sha256) = checkpoint.admitted_eof_sha256() {
+                    super::authenticate_frozen_prefix_sha256(
+                        self.identity.source_path(),
+                        self.source_file.as_ref(),
+                        &current,
+                        current.length(),
+                        admitted_eof_sha256,
+                    )?;
+                } else if checkpoint.complete_prefix_end() == self.observation.length() {
+                    super::authenticate_frozen_prefix(
+                        self.identity.source_path(),
+                        self.source_file.as_ref(),
+                        &current,
+                        current.length(),
+                        *checkpoint.complete_prefix_sha256(),
+                    )?;
+                } else {
+                    return Err(E::source_changed());
+                }
+                self.source_file.revalidate_same_object()?;
+            } else if !self.append_log {
                 return Err(E::source_changed());
-            }
-            if self.direct_append_resume {
+            } else if self.direct_append_resume {
                 if !self.observation.admits_frozen_prefix_in(&current) {
                     return Err(E::source_changed());
                 }

--- a/crates/ctx-history-jsonl/src/family/revalidation.rs
+++ b/crates/ctx-history-jsonl/src/family/revalidation.rs
@@ -282,6 +282,25 @@ pub fn revalidate_frozen_prefix<E: JsonlFamilyError>(
         prefix_length,
         expected_prefix_digest,
         new_prefix_hasher(),
+        false,
+    )
+}
+
+pub(crate) fn authenticate_frozen_prefix<E: JsonlFamilyError>(
+    source_path: &Path,
+    source_file: &OpenedProviderSourceFile<E>,
+    frozen: &JsonlFileObservation,
+    prefix_length: u64,
+    expected_prefix_digest: [u8; 32],
+) -> JsonlResult<JsonlFileObservation, E> {
+    revalidate_frozen_prefix_with_hasher(
+        source_path,
+        source_file,
+        frozen,
+        prefix_length,
+        expected_prefix_digest,
+        new_prefix_hasher(),
+        true,
     )
 }
 
@@ -299,6 +318,25 @@ pub(crate) fn revalidate_frozen_prefix_sha256<E: JsonlFamilyError>(
         prefix_length,
         expected_prefix_digest,
         Sha256::default(),
+        false,
+    )
+}
+
+pub(crate) fn authenticate_frozen_prefix_sha256<E: JsonlFamilyError>(
+    source_path: &Path,
+    source_file: &OpenedProviderSourceFile<E>,
+    frozen: &JsonlFileObservation,
+    prefix_length: u64,
+    expected_prefix_digest: [u8; 32],
+) -> JsonlResult<JsonlFileObservation, E> {
+    revalidate_frozen_prefix_with_hasher(
+        source_path,
+        source_file,
+        frozen,
+        prefix_length,
+        expected_prefix_digest,
+        Sha256::default(),
+        true,
     )
 }
 
@@ -309,6 +347,7 @@ fn revalidate_frozen_prefix_with_hasher<E: JsonlFamilyError>(
     prefix_length: u64,
     expected_prefix_digest: [u8; 32],
     prefix_hasher: impl JsonlPrefixHasher,
+    force_authentication: bool,
 ) -> JsonlResult<JsonlFileObservation, E> {
     if prefix_length > frozen.length() {
         return Err(E::source_changed());
@@ -325,7 +364,7 @@ fn revalidate_frozen_prefix_with_hasher<E: JsonlFamilyError>(
 
     // An unchanged strong observation already binds the retained bytes. This
     // keeps an exact no-op metadata-only instead of rehashing the whole corpus.
-    if &before == frozen {
+    if &before == frozen && !force_authentication {
         return Ok(before);
     }
 

--- a/crates/ctx-history-jsonl/src/family/route.rs
+++ b/crates/ctx-history-jsonl/src/family/route.rs
@@ -72,7 +72,7 @@ pub use membership::{JsonlFamilyAppendTrustContract, JsonlFamilyMembershipObserv
 mod projector;
 pub use projector::JsonlFamilyProjector;
 mod resident;
-use resident::FamilyResident;
+use resident::{AuthenticatedSourceObservation, FamilyResident};
 mod revalidation;
 #[cfg(any(test, feature = "test-support"))]
 pub use revalidation::set_before_jsonl_terminal_physical_revalidation_hook;
@@ -749,6 +749,11 @@ impl<E: JsonlFamilyError> JsonlFamilyLeaf<E> {
         if current == self.observation {
             return Ok((self.clone(), Arc::new(opened)));
         }
+        if self.observation.differs_only_by_change_identity(&current) {
+            let mut leaf = self.clone();
+            leaf.observation = current;
+            return Ok((leaf, Arc::new(opened)));
+        }
         if self.whole_record
             || current.length() <= self.observation.length()
             || !self.observation.admits_frozen_prefix_in(&current)
@@ -846,6 +851,15 @@ impl FamilyCheckpoint {
             Err(ProjectionContractError::FieldTooLarge { .. }) => Ok(false),
             Err(error) => Err(E::invalid_payload(error.to_string())),
         }
+    }
+
+    fn exact_admitted_eof_sha256(&self) -> Option<[u8; 32]> {
+        self.admitted_eof_sha256
+            .or_else(|| self.physical.admitted_eof_sha256())
+    }
+
+    fn authenticates_admitted_eof(&self) -> bool {
+        self.exact_admitted_eof_sha256().is_some() || self.physical.authenticates_admitted_eof()
     }
 
     fn valid_for<R: JsonlFamilyRuntime>(

--- a/crates/ctx-history-jsonl/src/family/route/capture.rs
+++ b/crates/ctx-history-jsonl/src/family/route/capture.rs
@@ -102,6 +102,57 @@ pub fn jsonl_family_driver<R: JsonlFamilyRuntime>(
     })
 }
 
+/// Restores an authenticatable ctime/ChangeTime ambiguity to the retained
+/// receipt observation. A certificate-bound resident observation may advance
+/// the task-local terminal proof after one successful content authentication;
+/// otherwise the terminal witness must authenticate the exact admitted EOF.
+fn normalize_authenticated_change_time_hints<R: JsonlFamilyRuntime>(
+    adapter: &dyn JsonlFamilyAdapter<Runtime = R>,
+    opening: &mut JsonlFamilyInventory<JsonlRuntimeError<R>>,
+    bases: &HashMap<[u8; 32], &CertifiedSource>,
+    resident: &Mutex<FamilyResident<JsonlRuntimeError<R>>>,
+) -> JsonlResult<HashMap<[u8; 32], JsonlFileObservation>, JsonlRuntimeError<R>> {
+    let authenticated = resident
+        .lock()
+        .map_err(|_| {
+            JsonlRuntimeError::<R>::invalid_payload(
+                "JSONL resident catalog lock was poisoned".to_owned(),
+            )
+        })?
+        .authenticated_source_observations
+        .clone();
+    let mut reusable = HashMap::new();
+    let mut normalized = false;
+    for member in &mut opening.members {
+        let JsonlFamilyInventoryMember::Accepted { leaf, .. } = member else {
+            continue;
+        };
+        let Some(base) = base_for_leaf(bases, leaf) else {
+            continue;
+        };
+        let Ok(checkpoint) = decode_checkpoint(adapter, leaf, base) else {
+            continue;
+        };
+        let retained = checkpoint.physical.source_observation();
+        if retained.differs_only_by_change_identity(&leaf.observation)
+            && checkpoint.authenticates_admitted_eof()
+        {
+            let digest = leaf.source().exact_descriptor_digest();
+            if authenticated.get(&digest).is_some_and(|authenticated| {
+                authenticated.certificate == *base && authenticated.observation == leaf.observation
+            }) {
+                reusable.insert(digest, leaf.observation.clone());
+            }
+            leaf.observation = retained.clone();
+            normalized = true;
+        }
+    }
+    if normalized {
+        opening.rebuild_observation()?;
+    }
+    Ok(reusable)
+}
+
 pub(super) fn capture<R: JsonlFamilyRuntime>(
     adapter: &dyn JsonlFamilyAdapter<Runtime = R>,
     root: &Path,
@@ -133,6 +184,14 @@ pub(super) fn capture<R: JsonlFamilyRuntime>(
     }
     let bases = base_sources_for_root(adapter, &opening, root, sink)?;
     bind_prior_disposition_sources(adapter, &mut opening, &bases)?;
+    let bases_by_descriptor = bases_by_descriptor(&bases)?;
+    let authenticated_change_time_hints = normalize_authenticated_change_time_hints(
+        adapter,
+        &mut opening,
+        &bases_by_descriptor,
+        resident,
+    )
+    .map_err(|error| route_scan(adapter, error))?;
     let opening_membership = adapter
         .observe_terminal_membership(root, &opening)
         .map_err(|error| route_discovery(adapter, error))?;
@@ -215,7 +274,6 @@ pub(super) fn capture<R: JsonlFamilyRuntime>(
                 .map_err(route_internal)?;
         }
     }
-    let bases_by_descriptor = bases_by_descriptor(&bases)?;
     let base_event_lookup = sink.base_event_lookup();
     let mut scan_selected_leaves = Vec::with_capacity(selected_leaves.len());
     let mut retained_terminal_sources = HashMap::new();
@@ -247,7 +305,7 @@ pub(super) fn capture<R: JsonlFamilyRuntime>(
             scan_selected_leaves.push(leaf.clone());
             continue;
         };
-        if !checkpoint.physical.terminal() {
+        if !checkpoint.physical.terminal() && !checkpoint.authenticates_admitted_eof() {
             scan_selected_leaves.push(leaf.clone());
             continue;
         }
@@ -258,7 +316,15 @@ pub(super) fn capture<R: JsonlFamilyRuntime>(
             scan_selected_leaves.push(leaf.clone());
             continue;
         }
-        let terminal_proof = JsonlFamilyTerminalProof::unchanged(adapter, leaf, base, &checkpoint)
+        let digest = leaf.source().exact_descriptor_digest();
+        let terminal_proof =
+            if let Some(authenticated) = authenticated_change_time_hints.get(&digest) {
+                let mut proof_leaf = leaf.clone();
+                proof_leaf.observation = authenticated.clone();
+                JsonlFamilyTerminalProof::unchanged(adapter, &proof_leaf, base, &checkpoint, true)
+            } else {
+                JsonlFamilyTerminalProof::unchanged(adapter, leaf, base, &checkpoint, false)
+            }
             .map_err(|error| route_scan(adapter, error))?;
         sink.retain_source(base.clone()).map_err(route_internal)?;
         sink.report_completed_bytes_with_exact(
@@ -268,7 +334,7 @@ pub(super) fn capture<R: JsonlFamilyRuntime>(
         )
         .map_err(route_internal)?;
         retained_terminal_sources.insert(
-            leaf.source().exact_descriptor_digest(),
+            digest,
             TerminalSourceEvidence {
                 certificate: base.clone(),
                 terminal_certificate: None,
@@ -410,7 +476,7 @@ pub(super) fn capture<R: JsonlFamilyRuntime>(
         resident.ownership_initialized = false;
         resident.owned_sources = owned_sources;
         resident.quarantined_sources = quarantined_source_ownership;
-        resident.terminal_sources = terminal_sources;
+        resident.replace_terminal_sources(terminal_sources);
         resident.absent_sources.clear();
         resident.opening_membership = None;
         resident.certified_inventory = None;
@@ -455,7 +521,7 @@ pub(super) fn capture<R: JsonlFamilyRuntime>(
     resident.ownership_initialized = true;
     resident.owned_sources = owned_sources;
     resident.quarantined_sources = quarantined_source_ownership;
-    resident.terminal_sources = terminal_sources;
+    resident.replace_terminal_sources(terminal_sources);
     resident.absent_sources = absent_sources;
     resident.opening_membership = Some(opening_membership);
     resident.certified_inventory = Some(inventory);
@@ -759,7 +825,7 @@ fn capture_partial_members<R: JsonlFamilyRuntime>(
     resident.ownership_initialized = false;
     resident.owned_sources = owned_sources;
     resident.quarantined_sources.clear();
-    resident.terminal_sources = terminal_sources;
+    resident.replace_terminal_sources(terminal_sources);
     resident.absent_sources.clear();
     resident.opening_membership = None;
     resident.certified_inventory = None;

--- a/crates/ctx-history-jsonl/src/family/route/leaf/checkpoint.rs
+++ b/crates/ctx-history-jsonl/src/family/route/leaf/checkpoint.rs
@@ -31,8 +31,50 @@ pub(super) fn terminal_proof_for_checkpoint<R: JsonlFamilyRuntime>(
     checkpoint: &FamilyCheckpoint,
     append_only_trust_allowed: bool,
 ) -> JsonlResult<JsonlFamilyTerminalProof<JsonlRuntimeError<R>>, JsonlRuntimeError<R>> {
-    if leaf.whole_record || !adapter.append_mode().certified_suffix() {
-        JsonlFamilyTerminalProof::exact_file(adapter, leaf, certificate)
+    let retained = checkpoint.physical.source_observation();
+    let force_authentication = retained.differs_only_by_change_identity(leaf.observation());
+    if force_authentication {
+        if let Some(admitted_eof_sha256) = checkpoint.exact_admitted_eof_sha256() {
+            JsonlFamilyTerminalProof::forced_frozen_prefix_with_hash(
+                adapter,
+                leaf,
+                certificate,
+                retained.length(),
+                admitted_eof_sha256,
+                super::super::terminal::JsonlFamilyTerminalPrefixHash::Sha256,
+            )
+        } else if checkpoint.physical.complete_prefix_end() == retained.length() {
+            JsonlFamilyTerminalProof::forced_frozen_prefix_with_hash(
+                adapter,
+                leaf,
+                certificate,
+                retained.length(),
+                *checkpoint.physical.complete_prefix_sha256(),
+                super::super::terminal::JsonlFamilyTerminalPrefixHash::SharedJsonlDomain,
+            )
+        } else {
+            Err(JsonlRuntimeError::<R>::source_changed())
+        }
+    } else if leaf.whole_record || !adapter.append_mode().certified_suffix() {
+        if let Some(admitted_eof_sha256) = checkpoint.exact_admitted_eof_sha256() {
+            JsonlFamilyTerminalProof::frozen_prefix(
+                adapter,
+                leaf,
+                certificate,
+                retained.length(),
+                admitted_eof_sha256,
+            )
+        } else if checkpoint.physical.complete_prefix_end() == retained.length() {
+            JsonlFamilyTerminalProof::frozen_shared_prefix(
+                adapter,
+                leaf,
+                certificate,
+                retained.length(),
+                *checkpoint.physical.complete_prefix_sha256(),
+            )
+        } else {
+            JsonlFamilyTerminalProof::exact_file(adapter, leaf, certificate)
+        }
     } else if append_only_trust_allowed
         && adapter.append_trust_contract() == JsonlFamilyAppendTrustContract::AppendOnlySameObjectV1
         && adapter.allows_direct_append_for_leaf(leaf)
@@ -42,8 +84,9 @@ pub(super) fn terminal_proof_for_checkpoint<R: JsonlFamilyRuntime>(
             leaf,
             certificate,
             checkpoint.physical.complete_prefix_end(),
+            checkpoint.exact_admitted_eof_sha256(),
         )
-    } else if let Some(admitted_eof_sha256) = checkpoint.admitted_eof_sha256 {
+    } else if let Some(admitted_eof_sha256) = checkpoint.exact_admitted_eof_sha256() {
         JsonlFamilyTerminalProof::frozen_prefix(
             adapter,
             leaf,

--- a/crates/ctx-history-jsonl/src/family/route/leaf/prepare.rs
+++ b/crates/ctx-history-jsonl/src/family/route/leaf/prepare.rs
@@ -82,6 +82,11 @@ pub(in super::super) fn prepare_leaf_with_resources<R: JsonlFamilyRuntime>(
     // reconsidered without replaying already certified records.
     let previous_physical = previous.as_ref().filter(|checkpoint| {
         checkpoint.physical.source_observation() == leaf.observation()
+            || (checkpoint
+                .physical
+                .source_observation()
+                .differs_only_by_change_identity(leaf.observation())
+                && checkpoint.authenticates_admitted_eof())
             || append_mode.certified_suffix()
     });
     let open_reader = |previous| {

--- a/crates/ctx-history-jsonl/src/family/route/resident.rs
+++ b/crates/ctx-history-jsonl/src/family/route/resident.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+#[derive(Clone)]
+pub(super) struct AuthenticatedSourceObservation {
+    pub(super) certificate: CertifiedSource,
+    pub(super) observation: JsonlFileObservation,
+}
+
 pub(super) struct FamilyResident<E: JsonlFamilyError> {
     pub(super) ownership_initialized: bool,
     pub(super) owned_sources: HashMap<[u8; 32], SourceKey>,
@@ -9,6 +15,24 @@ pub(super) struct FamilyResident<E: JsonlFamilyError> {
     pub(super) opening_membership: Option<JsonlFamilyMembershipObservation<E>>,
     pub(super) certified_inventory: Option<CertifiedSourceInventory>,
     pub(super) opening_inventory: Option<JsonlFamilyInventory<E>>,
+    /// Process-local advancement of an immutable certificate's authenticated
+    /// live metadata. This is never serialized or used across certificates.
+    pub(super) authenticated_source_observations: HashMap<[u8; 32], AuthenticatedSourceObservation>,
+}
+
+impl<E: JsonlFamilyError> FamilyResident<E> {
+    pub(super) fn replace_terminal_sources(
+        &mut self,
+        terminal_sources: HashMap<[u8; 32], TerminalSourceEvidence<E>>,
+    ) {
+        self.authenticated_source_observations
+            .retain(|digest, authenticated| {
+                terminal_sources
+                    .get(digest)
+                    .is_some_and(|evidence| evidence.certificate == authenticated.certificate)
+            });
+        self.terminal_sources = terminal_sources;
+    }
 }
 
 impl<E: JsonlFamilyError> Default for FamilyResident<E> {
@@ -22,6 +46,7 @@ impl<E: JsonlFamilyError> Default for FamilyResident<E> {
             opening_membership: None,
             certified_inventory: None,
             opening_inventory: None,
+            authenticated_source_observations: HashMap::new(),
         }
     }
 }

--- a/crates/ctx-history-jsonl/src/family/route/revalidation.rs
+++ b/crates/ctx-history-jsonl/src/family/route/revalidation.rs
@@ -144,10 +144,20 @@ pub(super) fn revalidate_complete_inventory<R: JsonlFamilyRuntime>(
     // work and are never repeated here.
     #[cfg(any(test, feature = "test-support"))]
     run_before_jsonl_terminal_physical_revalidation_hook(root);
-    for evidence in expected_sources.values() {
-        evidence
+    let mut authenticated_source_observations = Vec::new();
+    for (digest, evidence) in &expected_sources {
+        let observation = evidence
             .terminal_proof
             .revalidate_for(evidence.observed_certificate())?;
+        if evidence.terminal_certificate.is_none() {
+            authenticated_source_observations.push((
+                *digest,
+                AuthenticatedSourceObservation {
+                    certificate: evidence.certificate.clone(),
+                    observation,
+                },
+            ));
+        }
     }
     for dependency in &opening_inventory.exact_dependencies {
         dependency.revalidate_dependency()?;
@@ -158,6 +168,28 @@ pub(super) fn revalidate_complete_inventory<R: JsonlFamilyRuntime>(
         }
     }
     opening_inventory.revalidate_terminal_root(root, adapter.inventory_mode())?;
+    let mut resident = resident.lock().map_err(|_| {
+        JsonlRuntimeError::<R>::invalid_payload(
+            "JSONL resident catalog lock was poisoned".to_owned(),
+        )
+    })?;
+    if resident.certified_inventory.as_ref() != Some(expected_inventory) {
+        return Ok(false);
+    }
+    for (digest, authenticated) in authenticated_source_observations {
+        if resident
+            .terminal_sources
+            .get(&digest)
+            .is_some_and(|evidence| {
+                evidence.terminal_certificate.is_none()
+                    && evidence.certificate == authenticated.certificate
+            })
+        {
+            resident
+                .authenticated_source_observations
+                .insert(digest, authenticated);
+        }
+    }
     Ok(true)
 }
 

--- a/crates/ctx-history-jsonl/src/family/route/terminal.rs
+++ b/crates/ctx-history-jsonl/src/family/route/terminal.rs
@@ -4,8 +4,9 @@ use ctx_history_core::{CertifiedSource, SourceKey};
 use sha2::{Digest, Sha256};
 
 use super::super::{
-    observe_opened_file, observe_opened_file_allow_append, revalidate_frozen_prefix,
-    revalidate_frozen_prefix_sha256, JsonlFileObservation,
+    authenticate_frozen_prefix, authenticate_frozen_prefix_sha256, observe_opened_file,
+    observe_opened_file_allow_append, revalidate_frozen_prefix, revalidate_frozen_prefix_sha256,
+    JsonlFileObservation,
 };
 use super::super::{
     JsonlFamilyError, JsonlFamilyRuntime, JsonlResult, JsonlRuntimeError, OpenedProviderSourceFile,
@@ -34,11 +35,13 @@ pub enum JsonlFamilyTerminalPrefixHash {
 enum JsonlFamilyTerminalPhysicalBinding {
     AppendOnlySameObjectV1 {
         certified_prefix_end: u64,
+        admitted_eof_sha256: Option<[u8; 32]>,
     },
     FrozenPrefix {
         prefix_length: u64,
         prefix_sha256: [u8; 32],
         hash_kind: JsonlFamilyTerminalPrefixHash,
+        force_authentication: bool,
     },
     ExactFile,
 }
@@ -172,6 +175,7 @@ pub enum JsonlFamilyTerminalProof<E: JsonlFamilyError> {
         authority: Arc<ProviderSourceRoot<E>>,
         admitted: JsonlFileObservation,
         certified_prefix_end: u64,
+        admitted_eof_sha256: Option<[u8; 32]>,
     },
     FrozenPrefix {
         binding: Option<JsonlFamilyTerminalLeafBinding>,
@@ -182,6 +186,7 @@ pub enum JsonlFamilyTerminalProof<E: JsonlFamilyError> {
         prefix_length: u64,
         prefix_sha256: [u8; 32],
         hash_kind: JsonlFamilyTerminalPrefixHash,
+        force_authentication: bool,
     },
     ExactFile {
         binding: Option<JsonlFamilyTerminalLeafBinding>,
@@ -202,6 +207,7 @@ impl<E: JsonlFamilyError> Clone for JsonlFamilyTerminalProof<E> {
                 authority,
                 admitted,
                 certified_prefix_end,
+                admitted_eof_sha256,
             } => Self::AppendOnlySameObjectV1 {
                 binding: binding.clone(),
                 source_path: source_path.clone(),
@@ -209,6 +215,7 @@ impl<E: JsonlFamilyError> Clone for JsonlFamilyTerminalProof<E> {
                 authority: Arc::clone(authority),
                 admitted: admitted.clone(),
                 certified_prefix_end: *certified_prefix_end,
+                admitted_eof_sha256: *admitted_eof_sha256,
             },
             Self::FrozenPrefix {
                 binding,
@@ -219,6 +226,7 @@ impl<E: JsonlFamilyError> Clone for JsonlFamilyTerminalProof<E> {
                 prefix_length,
                 prefix_sha256,
                 hash_kind,
+                force_authentication,
             } => Self::FrozenPrefix {
                 binding: binding.clone(),
                 source_path: source_path.clone(),
@@ -228,6 +236,7 @@ impl<E: JsonlFamilyError> Clone for JsonlFamilyTerminalProof<E> {
                 prefix_length: *prefix_length,
                 prefix_sha256: *prefix_sha256,
                 hash_kind: *hash_kind,
+                force_authentication: *force_authentication,
             },
             Self::ExactFile {
                 binding,
@@ -255,17 +264,22 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
         leaf: &JsonlFamilyLeaf<E>,
         certificate: &CertifiedSource,
         certified_prefix_end: u64,
+        admitted_eof_sha256: Option<[u8; 32]>,
     ) -> JsonlResult<Self, E> {
         let proof = Self::bind_admitted_append_only_same_object_v1(
             adapter,
             leaf,
             certificate,
             certified_prefix_end,
+            admitted_eof_sha256,
         )?;
         let opened = leaf.authority.open_file(&leaf.authority_path)?;
         let current = observe_opened_file_allow_append(&leaf.source_path, &opened)?;
         if !leaf.observation.admits_frozen_prefix_in(&current) {
             return Err(E::source_changed());
+        }
+        if leaf.observation.differs_only_by_change_identity(&current) {
+            Self::authenticate_append_only_dirty_hint(&proof, &opened)?;
         }
         Ok(proof)
     }
@@ -275,6 +289,7 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
         leaf: &JsonlFamilyLeaf<E>,
         certificate: &CertifiedSource,
         certified_prefix_end: u64,
+        admitted_eof_sha256: Option<[u8; 32]>,
     ) -> JsonlResult<Self, E> {
         if certified_prefix_end > leaf.observation.length()
             || certified_prefix_end != certificate.counts().certified_bytes
@@ -283,6 +298,7 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
         }
         let physical = JsonlFamilyTerminalPhysicalBinding::AppendOnlySameObjectV1 {
             certified_prefix_end,
+            admitted_eof_sha256,
         };
         let binding = JsonlFamilyTerminalLeafBinding::new(adapter, leaf, certificate, physical)?;
         Ok(Self::AppendOnlySameObjectV1 {
@@ -292,6 +308,7 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
             authority: Arc::clone(&leaf.authority),
             admitted: leaf.observation.clone(),
             certified_prefix_end,
+            admitted_eof_sha256,
         })
     }
 
@@ -309,6 +326,7 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
             prefix_length,
             prefix_sha256,
             JsonlFamilyTerminalPrefixHash::Sha256,
+            false,
         )
     }
 
@@ -326,6 +344,26 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
             prefix_length,
             prefix_sha256,
             JsonlFamilyTerminalPrefixHash::SharedJsonlDomain,
+            false,
+        )
+    }
+
+    pub(super) fn forced_frozen_prefix_with_hash<R: JsonlFamilyRuntime<Error = E>>(
+        adapter: &dyn JsonlFamilyAdapter<Runtime = R>,
+        leaf: &JsonlFamilyLeaf<E>,
+        certificate: &CertifiedSource,
+        prefix_length: u64,
+        prefix_sha256: [u8; 32],
+        hash_kind: JsonlFamilyTerminalPrefixHash,
+    ) -> JsonlResult<Self, E> {
+        Self::frozen_prefix_with_hash(
+            adapter,
+            leaf,
+            certificate,
+            prefix_length,
+            prefix_sha256,
+            hash_kind,
+            true,
         )
     }
 
@@ -336,6 +374,7 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
         prefix_length: u64,
         prefix_sha256: [u8; 32],
         hash_kind: JsonlFamilyTerminalPrefixHash,
+        force_authentication: bool,
     ) -> JsonlResult<Self, E> {
         if prefix_length > leaf.observation.length() {
             return Err(E::source_changed());
@@ -345,23 +384,16 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
         if !leaf.observation.admits_frozen_prefix_in(&current) {
             return Err(E::source_changed());
         }
-        if current != leaf.observation {
-            match hash_kind {
-                JsonlFamilyTerminalPrefixHash::Sha256 => revalidate_frozen_prefix_sha256(
-                    &leaf.source_path,
-                    &opened,
-                    &leaf.observation,
-                    prefix_length,
-                    prefix_sha256,
-                )?,
-                JsonlFamilyTerminalPrefixHash::SharedJsonlDomain => revalidate_frozen_prefix(
-                    &leaf.source_path,
-                    &opened,
-                    &leaf.observation,
-                    prefix_length,
-                    prefix_sha256,
-                )?,
-            };
+        if current != leaf.observation || force_authentication {
+            Self::authenticate_prefix(
+                &leaf.source_path,
+                &opened,
+                &leaf.observation,
+                prefix_length,
+                prefix_sha256,
+                hash_kind,
+                force_authentication,
+            )?;
         }
         Self::bind_admitted_frozen_prefix(
             adapter,
@@ -370,6 +402,7 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
             prefix_length,
             prefix_sha256,
             hash_kind,
+            force_authentication,
         )
     }
 
@@ -380,6 +413,7 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
         prefix_length: u64,
         prefix_sha256: [u8; 32],
         hash_kind: JsonlFamilyTerminalPrefixHash,
+        force_authentication: bool,
     ) -> JsonlResult<Self, E> {
         if prefix_length > leaf.observation.length() {
             return Err(E::source_changed());
@@ -388,6 +422,7 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
             prefix_length,
             prefix_sha256,
             hash_kind,
+            force_authentication,
         };
         let binding = JsonlFamilyTerminalLeafBinding::new(adapter, leaf, certificate, physical)?;
         Ok(Self::FrozenPrefix {
@@ -399,6 +434,7 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
             prefix_length,
             prefix_sha256,
             hash_kind,
+            force_authentication,
         })
     }
 
@@ -462,8 +498,64 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
         leaf: &JsonlFamilyLeaf<E>,
         certificate: &CertifiedSource,
         checkpoint: &FamilyCheckpoint,
+        authenticated_change_time_hint: bool,
     ) -> JsonlResult<Self, E> {
+        let retained = checkpoint.physical.source_observation();
+        let change_time_hint = retained.differs_only_by_change_identity(&leaf.observation);
+        if authenticated_change_time_hint && !change_time_hint {
+            return Err(E::system_invariant(
+                "JSONL resident observation does not advance a change-time-only hint",
+            ));
+        }
+        let force_authentication = change_time_hint && !authenticated_change_time_hint;
+        if force_authentication {
+            if let Some(admitted_eof_sha256) = checkpoint.exact_admitted_eof_sha256() {
+                return Self::bind_admitted_frozen_prefix(
+                    adapter,
+                    leaf,
+                    certificate,
+                    retained.length(),
+                    admitted_eof_sha256,
+                    JsonlFamilyTerminalPrefixHash::Sha256,
+                    true,
+                );
+            }
+            if checkpoint.physical.complete_prefix_end() == retained.length() {
+                return Self::bind_admitted_frozen_prefix(
+                    adapter,
+                    leaf,
+                    certificate,
+                    retained.length(),
+                    *checkpoint.physical.complete_prefix_sha256(),
+                    JsonlFamilyTerminalPrefixHash::SharedJsonlDomain,
+                    true,
+                );
+            }
+            return Err(E::source_changed());
+        }
         if leaf.whole_record || !adapter.append_mode().certified_suffix() {
+            if let Some(admitted_eof_sha256) = checkpoint.exact_admitted_eof_sha256() {
+                return Self::bind_admitted_frozen_prefix(
+                    adapter,
+                    leaf,
+                    certificate,
+                    retained.length(),
+                    admitted_eof_sha256,
+                    JsonlFamilyTerminalPrefixHash::Sha256,
+                    false,
+                );
+            }
+            if checkpoint.physical.complete_prefix_end() == retained.length() {
+                return Self::bind_admitted_frozen_prefix(
+                    adapter,
+                    leaf,
+                    certificate,
+                    retained.length(),
+                    *checkpoint.physical.complete_prefix_sha256(),
+                    JsonlFamilyTerminalPrefixHash::SharedJsonlDomain,
+                    false,
+                );
+            }
             return Self::bind_admitted_exact_file(adapter, leaf, certificate);
         }
         if adapter.append_trust_contract() == JsonlFamilyAppendTrustContract::AppendOnlySameObjectV1
@@ -474,10 +566,11 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
                 leaf,
                 certificate,
                 checkpoint.physical.complete_prefix_end(),
+                checkpoint.exact_admitted_eof_sha256(),
             );
         }
         let (prefix_length, prefix_sha256, hash_kind) =
-            if let Some(admitted_eof_sha256) = checkpoint.admitted_eof_sha256 {
+            if let Some(admitted_eof_sha256) = checkpoint.exact_admitted_eof_sha256() {
                 (
                     checkpoint.physical.source_observation().length(),
                     admitted_eof_sha256,
@@ -497,6 +590,7 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
             prefix_length,
             prefix_sha256,
             hash_kind,
+            false,
         )
     }
 
@@ -554,19 +648,23 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
         match self {
             Self::AppendOnlySameObjectV1 {
                 certified_prefix_end,
+                admitted_eof_sha256,
                 ..
             } => JsonlFamilyTerminalPhysicalBinding::AppendOnlySameObjectV1 {
                 certified_prefix_end: *certified_prefix_end,
+                admitted_eof_sha256: *admitted_eof_sha256,
             },
             Self::FrozenPrefix {
                 prefix_length,
                 prefix_sha256,
                 hash_kind,
+                force_authentication,
                 ..
             } => JsonlFamilyTerminalPhysicalBinding::FrozenPrefix {
                 prefix_length: *prefix_length,
                 prefix_sha256: *prefix_sha256,
                 hash_kind: *hash_kind,
+                force_authentication: *force_authentication,
             },
             Self::ExactFile { .. } => JsonlFamilyTerminalPhysicalBinding::ExactFile,
         }
@@ -600,7 +698,10 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
         Ok(())
     }
 
-    pub(crate) fn revalidate_for(&self, certificate: &CertifiedSource) -> JsonlResult<(), E> {
+    pub(crate) fn revalidate_for(
+        &self,
+        certificate: &CertifiedSource,
+    ) -> JsonlResult<JsonlFileObservation, E> {
         let binding = self.binding().ok_or_else(|| {
             E::invalid_payload(
                 "JSONL leaf terminal proof has no leaf/certificate binding".to_owned(),
@@ -621,7 +722,7 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
                 "JSONL leaf proof cannot be reused as an exact dependency".to_owned(),
             ));
         }
-        self.revalidate_physical()
+        self.revalidate_physical().map(drop)
     }
 
     fn route_matches_binding(&self, binding: &JsonlFamilyTerminalLeafBinding) -> bool {
@@ -662,7 +763,7 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
         }
     }
 
-    fn revalidate_physical(&self) -> JsonlResult<(), E> {
+    fn revalidate_physical(&self) -> JsonlResult<JsonlFileObservation, E> {
         match self {
             Self::AppendOnlySameObjectV1 {
                 binding: _,
@@ -671,6 +772,7 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
                 authority,
                 admitted,
                 certified_prefix_end,
+                admitted_eof_sha256: _,
             } => {
                 if *certified_prefix_end > admitted.length() {
                     return Err(E::source_changed());
@@ -679,6 +781,11 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
                 let current = observe_opened_file_allow_append(source_path, &opened)?;
                 if !admitted.admits_frozen_prefix_in(&current) {
                     return Err(E::source_changed());
+                }
+                if admitted.differs_only_by_change_identity(&current) {
+                    Self::authenticate_append_only_dirty_hint(self, &opened)
+                } else {
+                    Ok(current)
                 }
             }
             Self::FrozenPrefix {
@@ -690,24 +797,18 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
                 prefix_length,
                 prefix_sha256,
                 hash_kind,
+                force_authentication,
             } => {
                 let opened = authority.open_file(authority_path)?;
-                match hash_kind {
-                    JsonlFamilyTerminalPrefixHash::Sha256 => revalidate_frozen_prefix_sha256(
-                        source_path,
-                        &opened,
-                        admitted,
-                        *prefix_length,
-                        *prefix_sha256,
-                    )?,
-                    JsonlFamilyTerminalPrefixHash::SharedJsonlDomain => revalidate_frozen_prefix(
-                        source_path,
-                        &opened,
-                        admitted,
-                        *prefix_length,
-                        *prefix_sha256,
-                    )?,
-                };
+                Self::authenticate_prefix(
+                    source_path,
+                    &opened,
+                    admitted,
+                    *prefix_length,
+                    *prefix_sha256,
+                    *hash_kind,
+                    *force_authentication,
+                )
             }
             Self::ExactFile {
                 binding: _,
@@ -717,12 +818,95 @@ impl<E: JsonlFamilyError> JsonlFamilyTerminalProof<E> {
                 observation,
             } => {
                 let opened = authority.open_file(authority_path)?;
-                if observe_opened_file(source_path, &opened)? != *observation {
+                let current = observe_opened_file(source_path, &opened)?;
+                if current != *observation {
                     return Err(E::source_changed());
                 }
                 opened.revalidate_leaf()?;
+                Ok(current)
             }
         }
-        Ok(())
+    }
+
+    fn authenticate_prefix(
+        source_path: &std::path::Path,
+        opened: &OpenedProviderSourceFile<E>,
+        admitted: &JsonlFileObservation,
+        prefix_length: u64,
+        prefix_sha256: [u8; 32],
+        hash_kind: JsonlFamilyTerminalPrefixHash,
+        force_authentication: bool,
+    ) -> JsonlResult<JsonlFileObservation, E> {
+        match (hash_kind, force_authentication) {
+            (JsonlFamilyTerminalPrefixHash::Sha256, true) => authenticate_frozen_prefix_sha256(
+                source_path,
+                opened,
+                admitted,
+                prefix_length,
+                prefix_sha256,
+            ),
+            (JsonlFamilyTerminalPrefixHash::Sha256, false) => revalidate_frozen_prefix_sha256(
+                source_path,
+                opened,
+                admitted,
+                prefix_length,
+                prefix_sha256,
+            ),
+            (JsonlFamilyTerminalPrefixHash::SharedJsonlDomain, true) => authenticate_frozen_prefix(
+                source_path,
+                opened,
+                admitted,
+                prefix_length,
+                prefix_sha256,
+            ),
+            (JsonlFamilyTerminalPrefixHash::SharedJsonlDomain, false) => revalidate_frozen_prefix(
+                source_path,
+                opened,
+                admitted,
+                prefix_length,
+                prefix_sha256,
+            ),
+        }
+    }
+
+    fn authenticate_append_only_dirty_hint(
+        proof: &Self,
+        opened: &OpenedProviderSourceFile<E>,
+    ) -> JsonlResult<JsonlFileObservation, E> {
+        let Self::AppendOnlySameObjectV1 {
+            binding,
+            source_path,
+            admitted,
+            certified_prefix_end,
+            admitted_eof_sha256,
+            ..
+        } = proof
+        else {
+            return Err(E::system_invariant(
+                "JSONL append-only dirty-hint authentication received another proof kind",
+            ));
+        };
+        if let Some(admitted_eof_sha256) = admitted_eof_sha256 {
+            return authenticate_frozen_prefix_sha256(
+                source_path,
+                opened,
+                admitted,
+                admitted.length(),
+                *admitted_eof_sha256,
+            );
+        }
+        let binding = binding.as_ref().ok_or_else(|| {
+            E::invalid_payload("JSONL append-only terminal proof lost its binding".to_owned())
+        })?;
+        if *certified_prefix_end != admitted.length() {
+            return Err(E::source_changed());
+        }
+        authenticate_frozen_prefix(
+            source_path,
+            opened,
+            admitted,
+            *certified_prefix_end,
+            binding.certified_prefix_digest,
+        )
     }
 }

--- a/crates/ctx-history-jsonl/src/family/route/tests/behavior/parallel_revalidation.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/behavior/parallel_revalidation.rs
@@ -1,5 +1,35 @@
 use super::*;
 
+fn retained_observation(receipt: &IndexCaptureCommitReceipt) -> JsonlFileObservation {
+    let checkpoint = FamilyCheckpoint::decode_frontier_key::<CaptureError>(
+        receipt.manifest().sources[0]
+            .frontier()
+            .unwrap()
+            .checkpoint(),
+    )
+    .unwrap();
+    checkpoint.physical.source_observation().clone()
+}
+
+fn churn_hardlink(source_path: &Path, link_path: &Path) {
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    fs::hard_link(source_path, link_path).unwrap();
+    fs::remove_file(link_path).unwrap();
+}
+
+fn assert_change_identity_only(
+    adapter: &JsonlFamilyAdapterObject,
+    root: &Path,
+    retained: &JsonlFileObservation,
+) {
+    let inventory = adapter.discover(root).unwrap();
+    let current = inventory.accepted_leaves().next().unwrap().observation();
+    assert!(
+        retained.differs_only_by_change_identity(current),
+        "hardlink churn must preserve length, mtime, attributes, and stable object identity"
+    );
+}
+
 #[test]
 fn borrowed_jsonl_worker_policy_honors_default_and_requested_counts() {
     assert_eq!(family_scanner_worker_count_policy(0, None), 0);
@@ -105,6 +135,159 @@ fn unchanged_complete_sources_do_not_enter_jsonl_ingestion_tasks() {
     assert_eq!(unchanged.generation_id, cold.generation_id);
     assert_eq!(unchanged.manifest().sources, cold.manifest().sources);
     assert_eq!(unchanged_activity, JsonlFamilyScannerActivity::default());
+}
+
+#[test]
+fn hardlink_churn_authenticates_incomplete_tail_without_reparse_or_publication() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let root = temp.path().join("sessions");
+    let index = temp.path().join("index");
+    fs::create_dir_all(&root).unwrap();
+    let source_path = root.join("incomplete.jsonl");
+    let mut bytes = TEST_RECORD.to_vec();
+    bytes.extend_from_slice(b"{\"message\":\"incomplete\"");
+    fs::write(&source_path, &bytes).unwrap();
+    let adapter = ParallelTestAdapter;
+    let resident = Mutex::new(FamilyResident::default());
+    let (cold, _) = capture_parallel_test_generation_with_resident_and_terminal_revalidation(
+        &adapter, &root, &index, 1, &resident,
+    )
+    .unwrap();
+    let retained = retained_observation(&cold);
+
+    churn_hardlink(&source_path, &temp.path().join("temporary-link.jsonl"));
+    assert_change_identity_only(&adapter, &root, &retained);
+    let prefix_hash = track_jsonl_prefix_hash_bytes(source_path.clone());
+
+    let (unchanged, activity) =
+        capture_parallel_test_generation_with_resident_and_terminal_revalidation(
+            &adapter, &root, &index, 1, &resident,
+        )
+        .unwrap();
+
+    assert_eq!(unchanged.generation_id, cold.generation_id);
+    assert_eq!(unchanged.manifest().sources, cold.manifest().sources);
+    assert_eq!(activity, JsonlFamilyScannerActivity::default());
+    assert_eq!(prefix_hash.bytes(), 3 * bytes.len() as u64);
+
+    let repeated_hash = track_jsonl_prefix_hash_bytes(source_path);
+    let (repeated, activity) =
+        capture_parallel_test_generation_with_resident_and_terminal_revalidation(
+            &adapter, &root, &index, 1, &resident,
+        )
+        .unwrap();
+    assert_eq!(repeated.generation_id, cold.generation_id);
+    assert_eq!(repeated.manifest().sources, cold.manifest().sources);
+    assert_eq!(activity, JsonlFamilyScannerActivity::default());
+    assert_eq!(repeated_hash.bytes(), 0);
+}
+
+#[test]
+fn terminal_hardlink_churn_is_an_authenticated_noop() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let root = temp.path().join("sessions");
+    let index = temp.path().join("index");
+    fs::create_dir_all(&root).unwrap();
+    let source_path = root.join("terminal-race.jsonl");
+    fs::write(&source_path, TEST_RECORD).unwrap();
+    let adapter = ParallelTestAdapter;
+    let resident = Mutex::new(FamilyResident::default());
+    let (cold, _) = capture_parallel_test_generation_with_resident_and_terminal_revalidation(
+        &adapter, &root, &index, 1, &resident,
+    )
+    .unwrap();
+    let retained = retained_observation(&cold);
+    let hook_ran = Arc::new(AtomicBool::new(false));
+    let hook_observation = Arc::clone(&hook_ran);
+    let hook_source = source_path.clone();
+    let hook_link = temp.path().join("terminal-link.jsonl");
+    set_before_jsonl_terminal_physical_revalidation_hook(root.clone(), move || {
+        churn_hardlink(&hook_source, &hook_link);
+        hook_observation.store(true, Ordering::SeqCst);
+    });
+    let prefix_hash = track_jsonl_prefix_hash_bytes(source_path.clone());
+
+    let (unchanged, activity) =
+        capture_parallel_test_generation_with_resident_and_terminal_revalidation(
+            &adapter, &root, &index, 1, &resident,
+        )
+        .unwrap();
+
+    assert!(hook_ran.load(Ordering::SeqCst));
+    assert_change_identity_only(&adapter, &root, &retained);
+    assert_eq!(unchanged.generation_id, cold.generation_id);
+    assert_eq!(unchanged.manifest().sources, cold.manifest().sources);
+    assert_eq!(activity, JsonlFamilyScannerActivity::default());
+    assert_eq!(prefix_hash.bytes(), 3 * TEST_RECORD.len() as u64);
+
+    let repeated_hash = track_jsonl_prefix_hash_bytes(source_path);
+    let (repeated, activity) =
+        capture_parallel_test_generation_with_resident_and_terminal_revalidation(
+            &adapter, &root, &index, 1, &resident,
+        )
+        .unwrap();
+    assert_eq!(repeated.generation_id, cold.generation_id);
+    assert_eq!(repeated.manifest().sources, cold.manifest().sources);
+    assert_eq!(activity, JsonlFamilyScannerActivity::default());
+    assert_eq!(repeated_hash.bytes(), 0);
+}
+
+#[cfg(any(unix, target_os = "windows"))]
+#[test]
+fn same_size_rewrite_with_restored_mtime_fails_closed_and_retains_last_good() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let root = temp.path().join("sessions");
+    let index = temp.path().join("index");
+    fs::create_dir_all(&root).unwrap();
+    let source_path = root.join("restored-mtime.jsonl");
+    fs::write(&source_path, TEST_RECORD).unwrap();
+    let original_modified = fs::metadata(&source_path).unwrap().modified().unwrap();
+    let adapter = ParallelTestAdapter;
+    let resident = Mutex::new(FamilyResident::default());
+    let (cold, _) = capture_parallel_test_generation_with_resident_and_terminal_revalidation(
+        &adapter, &root, &index, 1, &resident,
+    )
+    .unwrap();
+    let retained = retained_observation(&cold);
+
+    churn_hardlink(&source_path, &temp.path().join("memoized-link.jsonl"));
+    let (hardlink_noop, activity) =
+        capture_parallel_test_generation_with_resident_and_terminal_revalidation(
+            &adapter, &root, &index, 1, &resident,
+        )
+        .unwrap();
+    assert_eq!(hardlink_noop.generation_id, cold.generation_id);
+    assert_eq!(hardlink_noop.manifest().sources, cold.manifest().sources);
+    assert_eq!(activity, JsonlFamilyScannerActivity::default());
+
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    let replacement = b"{\"message\":\"after!\"}\n";
+    assert_eq!(replacement.len(), TEST_RECORD.len());
+    fs::write(&source_path, replacement).unwrap();
+    fs::File::options()
+        .write(true)
+        .open(&source_path)
+        .unwrap()
+        .set_times(std::fs::FileTimes::new().set_modified(original_modified))
+        .unwrap();
+    let current = adapter.discover(&root).unwrap();
+    assert!(retained
+        .differs_only_by_change_identity(current.accepted_leaves().next().unwrap().observation()));
+
+    let error = capture_parallel_test_generation_with_resident_and_terminal_revalidation(
+        &adapter, &root, &index, 1, &resident,
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, SourceIoError::SourceChangedDuringCapture));
+    assert_eq!(
+        jsonl_family_scanner_activity(),
+        JsonlFamilyScannerActivity::default()
+    );
+    assert_eq!(
+        test_generations().lock().unwrap().get(&index),
+        Some(cold.manifest())
+    );
 }
 
 #[test]
@@ -285,7 +468,7 @@ fn unchanged_terminal_proof_fails_closed_on_prepublication_source_races() {
             &replacement_adapter as &JsonlFamilyAdapterObject,
         ),
     ] {
-        for race in ["mutation", "replacement", "deletion"] {
+        for race in ["mutation", "named-replacement", "deletion"] {
             let temp = crate::test_support_paths::tempdir().unwrap();
             let root = temp.path().join("sessions");
             let index = temp.path().join("index");
@@ -296,7 +479,7 @@ fn unchanged_terminal_proof_fails_closed_on_prepublication_source_races() {
 
             let displaced = temp.path().join("displaced.jsonl");
             let replacement = temp.path().join("replacement.jsonl");
-            if race == "replacement" {
+            if race == "named-replacement" {
                 fs::write(&replacement, TEST_RECORD).unwrap();
             }
             let hook_ran = Arc::new(AtomicBool::new(false));
@@ -307,7 +490,7 @@ fn unchanged_terminal_proof_fails_closed_on_prepublication_source_races() {
                     "mutation" => {
                         fs::write(&hook_source, b"{\"message\":\"after!\"}\n").unwrap();
                     }
-                    "replacement" => {
+                    "named-replacement" => {
                         fs::rename(&hook_source, displaced).unwrap();
                         fs::rename(replacement, &hook_source).unwrap();
                     }

--- a/crates/ctx-history-jsonl/src/family/route/tests/harness.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/harness.rs
@@ -76,6 +76,37 @@ pub(super) fn capture_parallel_test_generation_with_terminal_revalidation(
     Ok((commit, activity))
 }
 
+pub(super) fn capture_parallel_test_generation_with_resident_and_terminal_revalidation(
+    adapter: &JsonlFamilyAdapterObject,
+    root: &Path,
+    index_root: &Path,
+    workers: usize,
+    resident: &Mutex<FamilyResident>,
+) -> Result<(IndexCaptureCommitReceipt, JsonlFamilyScannerActivity)> {
+    let (writer, ()) = capture_test_generation_with_resident!(
+        resident,
+        adapter,
+        root,
+        index_root,
+        workers,
+        |resident, sink| { capture(adapter, root, resident, sink).unwrap() }
+    );
+    let inventory = resident
+        .lock()
+        .map_err(|_| CaptureError::SystemInvariant("JSONL test resident lock was poisoned"))?
+        .certified_inventory
+        .clone()
+        .ok_or(CaptureError::SystemInvariant(
+            "JSONL test capture did not certify an inventory",
+        ))?;
+    if !revalidate_complete_inventory(adapter, root, resident, &inventory)? {
+        return Err(CaptureError::SourceChangedDuringCapture);
+    }
+    let activity = jsonl_family_scanner_activity();
+    let commit = IndexCaptureCommitReceipt::new(writer.commit(|_| true, |_| true)?);
+    Ok((commit, activity))
+}
+
 pub(super) fn capture_checkpoint_test_generation(
     root: &Path,
     index_root: &Path,

--- a/crates/ctx-history-jsonl/src/family/route/tests/shared_runtime.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/shared_runtime.rs
@@ -502,9 +502,10 @@ impl CaptureLifecycleSink for TestLifecycle {
     }
 }
 
-macro_rules! capture_test_generation {
-    ($adapter:expr, $root:expr, $index_root:expr, $workers:expr, $capture:expr) => {{
-        capture_test_generation!(
+macro_rules! capture_test_generation_with_resident {
+    ($resident:expr, $adapter:expr, $root:expr, $index_root:expr, $workers:expr, $capture:expr) => {{
+        capture_test_generation_with_resident!(
+            $resident,
             $adapter,
             $root,
             $index_root,
@@ -513,8 +514,7 @@ macro_rules! capture_test_generation {
             $capture
         )
     }};
-    ($adapter:expr, $root:expr, $index_root:expr, $workers:expr, $demand:expr, $capture:expr) => {{
-        let resident = Mutex::new(FamilyResident::default());
+    ($resident:expr, $adapter:expr, $root:expr, $index_root:expr, $workers:expr, $demand:expr, $capture:expr) => {{
         let mut writer = match IndexCaptureLifecycle::open($index_root, ()).unwrap() {
             CaptureLifecycleOpenOutcome::Ready(lifecycle) => lifecycle,
             CaptureLifecycleOpenOutcome::RecoveryRequired { .. } => {
@@ -543,8 +543,36 @@ macro_rules! capture_test_generation {
                 None,
                 None,
             );
-            with_family_scanner_workers($workers, || $capture(&resident, &mut sink))
+            with_family_scanner_workers($workers, || $capture($resident, &mut sink))
         };
+        (writer, result)
+    }};
+}
+
+pub(super) use capture_test_generation_with_resident;
+
+macro_rules! capture_test_generation {
+    ($adapter:expr, $root:expr, $index_root:expr, $workers:expr, $capture:expr) => {{
+        capture_test_generation!(
+            $adapter,
+            $root,
+            $index_root,
+            $workers,
+            SourceBackedReconciliationDemand::Incremental,
+            $capture
+        )
+    }};
+    ($adapter:expr, $root:expr, $index_root:expr, $workers:expr, $demand:expr, $capture:expr) => {{
+        let resident = Mutex::new(FamilyResident::default());
+        let (writer, result) = capture_test_generation_with_resident!(
+            &resident,
+            $adapter,
+            $root,
+            $index_root,
+            $workers,
+            $demand,
+            $capture
+        );
         (writer, resident, result)
     }};
 }

--- a/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
@@ -414,6 +414,7 @@ pub(super) fn expected_state(
             opening_membership: Some(opening_membership),
             certified_inventory: Some(inventory.clone()),
             opening_inventory: Some(observed),
+            authenticated_source_observations: HashMap::new(),
         },
         inventory,
     )

--- a/crates/ctx-history-jsonl/src/model.rs
+++ b/crates/ctx-history-jsonl/src/model.rs
@@ -89,6 +89,21 @@ impl JsonlFileObservation {
         self.stable_identity.is_some() && self.change_identity.is_some()
     }
 
+    /// Whether two strong observations differ only in the platform change
+    /// stamp. Unix ctime and Windows ChangeTime can move when a hard link is
+    /// added or removed even though the named ordinary file and its bytes are
+    /// unchanged. This is only a candidate for content authentication: it is
+    /// never proof of equality by itself.
+    pub fn differs_only_by_change_identity(&self, current: &Self) -> bool {
+        self.length == current.length
+            && self.modified == current.modified
+            && self.readonly == current.readonly
+            && self.supports_exact_revalidation()
+            && current.supports_exact_revalidation()
+            && self.same_stable_file(current)
+            && self.change_identity != current.change_identity
+    }
+
     /// Whether `current` is physically eligible to contain the frozen prefix.
     /// Strict callers must still authenticate that prefix. A caller using an
     /// explicit append-only provider contract may instead trust that contract.
@@ -96,7 +111,8 @@ impl JsonlFileObservation {
         self == current
             || (current.length >= self.length
                 && self.supports_exact_revalidation()
-                && self.same_stable_file(current))
+                && self.same_stable_file(current)
+                && self.readonly == current.readonly)
     }
 }
 
@@ -194,6 +210,11 @@ impl JsonlCheckpoint {
     pub fn admitted_eof_sha256(&self) -> Option<[u8; 32]> {
         self.restore_admitted_eof_hasher()
             .map(|hasher| hasher.digest())
+    }
+
+    pub fn authenticates_admitted_eof(&self) -> bool {
+        self.admitted_eof_sha256().is_some()
+            || self.complete_prefix_end == self.source_observation.length
     }
 
     pub fn next_physical_ordinal(&self) -> u64 {
@@ -367,6 +388,61 @@ impl JsonlScanOutcome {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn change_identity_only_candidate_requires_all_portable_object_facts_to_match() {
+        let retained =
+            JsonlFileObservation::new(17, UNIX_EPOCH, false, Some([1; 32]), Some([2; 32]));
+        let change_time_only =
+            JsonlFileObservation::new(17, UNIX_EPOCH, false, Some([1; 32]), Some([3; 32]));
+
+        assert!(retained.differs_only_by_change_identity(&change_time_only));
+        assert!(
+            !retained.differs_only_by_change_identity(&JsonlFileObservation::new(
+                17,
+                UNIX_EPOCH,
+                false,
+                Some([4; 32]),
+                Some([3; 32]),
+            ))
+        );
+        assert!(
+            !retained.differs_only_by_change_identity(&JsonlFileObservation::new(
+                18,
+                UNIX_EPOCH,
+                false,
+                Some([1; 32]),
+                Some([3; 32]),
+            ))
+        );
+        assert!(
+            !retained.differs_only_by_change_identity(&JsonlFileObservation::new(
+                17,
+                UNIX_EPOCH + std::time::Duration::from_secs(1),
+                false,
+                Some([1; 32]),
+                Some([3; 32]),
+            ))
+        );
+        assert!(
+            !retained.differs_only_by_change_identity(&JsonlFileObservation::new(
+                17,
+                UNIX_EPOCH,
+                true,
+                Some([1; 32]),
+                Some([3; 32]),
+            ))
+        );
+        assert!(
+            !retained.differs_only_by_change_identity(&JsonlFileObservation::new(
+                17,
+                UNIX_EPOCH,
+                false,
+                None,
+                Some([3; 32]),
+            ))
+        );
+    }
 
     fn continuation_checkpoint() -> JsonlCheckpoint {
         let bytes = b"one complete JSONL record\n";

--- a/crates/ctx-history-source-io/src/ordinary_file.rs
+++ b/crates/ctx-history-source-io/src/ordinary_file.rs
@@ -475,6 +475,56 @@ mod tests {
         assert_eq!(identity.change(), <[u8; 32]>::from(change.finalize()));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn shared_jsonl_v1_identity_treats_hardlink_churn_as_change_only() {
+        let temp = crate::test_support_paths::tempdir().unwrap();
+        let path = temp.path().join("source.jsonl");
+        let link = temp.path().join("temporary-link.jsonl");
+        std::fs::write(&path, b"content\n").unwrap();
+        let file = File::open(&path).unwrap();
+        let before_metadata = file.metadata().unwrap();
+        let before = retained_jsonl_file_identity_v1(&path, &file, &before_metadata)
+            .unwrap()
+            .unwrap();
+
+        std::thread::sleep(Duration::from_millis(2));
+        std::fs::hard_link(&path, &link).unwrap();
+        std::fs::remove_file(&link).unwrap();
+
+        let after_metadata = file.metadata().unwrap();
+        let after = retained_jsonl_file_identity_v1(&path, &file, &after_metadata)
+            .unwrap()
+            .unwrap();
+        assert_eq!(before_metadata.len(), after_metadata.len());
+        assert_eq!(
+            before_metadata.modified().unwrap(),
+            after_metadata.modified().unwrap()
+        );
+        assert_eq!(before.stable(), after.stable());
+        assert_ne!(before.change(), after.change());
+    }
+
+    #[cfg(any(unix, target_os = "windows"))]
+    #[test]
+    fn shared_jsonl_v1_identity_is_repeatable_for_the_same_opened_object() {
+        let temp = crate::test_support_paths::tempdir().unwrap();
+        let path = temp.path().join("source.jsonl");
+        std::fs::write(&path, b"content\n").unwrap();
+        let file = File::open(&path).unwrap();
+        let metadata = file.metadata().unwrap();
+
+        let first = retained_jsonl_file_identity_v1(&path, &file, &metadata)
+            .unwrap()
+            .unwrap();
+        let second = retained_jsonl_file_identity_v1(&path, &file, &file.metadata().unwrap())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(first.stable(), second.stable());
+        assert_eq!(first.change(), second.change());
+    }
+
     #[test]
     fn observation_token_is_derived_from_the_opened_object_stamp() {
         let temp = crate::test_support_paths::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- authenticate ctime/ChangeTime-only JSONL source deltas against retained prefix or admitted-EOF digests
- preserve no-op capture and publication when hardlink churn changes metadata without changing file content
- retain fail-closed behavior when exact content authentication is unavailable or fails

## Validation

- exact-head Bazel unit suites for ctx-history-jsonl and ctx-history-source-io passed
- affected selection passed 88/89 targets initially; the sole native-provider integration target passed both the exact failed case and its complete 38-test target on retry
- native Windows x64 hardlink/ChangeTime qualification passed: 2 passed, 0 failed

Fixes #662