### PR TITLE
fix(jsonl): reconcile replaced provider roots

### DIFF
--- a/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/claude_cursor.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/claude_cursor.rs
@@ -316,6 +316,98 @@ fn claude_route_publishes_cold_append_and_recovers_from_carried_checkpoint() {
 }
 
 #[test]
+fn automatic_claude_root_replacement_retires_sources_absent_from_strict_subset() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let first_home = temp.path().join("first");
+    let first_projects = first_home.join("projects");
+    let replacement_projects = temp.path().join("replacement/projects");
+    let retained_session = "retained-session";
+    let retired_session = "retired-session";
+    let retired_transcript = first_projects.join(format!("project/{retired_session}.jsonl"));
+    write_transcript(
+        &first_projects.join(format!("project/{retained_session}.jsonl")),
+        &[claude_message(
+            "user",
+            "first-retained-event",
+            retained_session,
+            "first root retained content",
+        )],
+    );
+    write_transcript(
+        &retired_transcript,
+        &[claude_message(
+            "user",
+            "first-retired-event",
+            retired_session,
+            "first root retired content",
+        )],
+    );
+    write_transcript(
+        &replacement_projects.join(format!("project/{retained_session}.jsonl")),
+        &[claude_message(
+            "user",
+            "replacement-retained-event",
+            retained_session,
+            "replacement root retained content",
+        )],
+    );
+
+    let index = temp.path().join("index");
+    let initial_context = DiscoveryContext::new(
+        temp.path(),
+        temp.path(),
+        DiscoveryPlatform::Linux,
+        crate::DiscoveryPlatformDirs::default(),
+    )
+    .with_env("CLAUDE_CONFIG_DIR", &first_home);
+    let data_root = temp.path().join("data");
+    let initial =
+        build_discovered_provider_registry(&initial_context, &data_root, CaptureProvider::Claude);
+    assert!(initial.issues.is_empty(), "{:?}", initial.issues);
+    refresh_source_backed_generation(&index, &initial.registry, writer_options()).unwrap();
+
+    let replacement_home = temp.path().join("replacement");
+    let replacement_context = DiscoveryContext::new(
+        temp.path(),
+        temp.path(),
+        DiscoveryPlatform::Linux,
+        crate::DiscoveryPlatformDirs::default(),
+    )
+    .with_env("CLAUDE_CONFIG_DIR", &replacement_home);
+    let replacement = build_discovered_provider_registry(
+        &replacement_context,
+        &data_root,
+        CaptureProvider::Claude,
+    );
+    assert!(replacement.issues.is_empty(), "{:?}", replacement.issues);
+    let receipt =
+        refresh_source_backed_generation(&index, &replacement.registry, writer_options()).unwrap();
+    assert!(receipt.failed_routes.is_empty());
+    assert_eq!(receipt.complete_inventory_route_ids.len(), 1);
+    assert_eq!(receipt.removals.len(), 1);
+
+    let verified = VerifiedIndex::open(&index).unwrap();
+    assert_eq!(
+        verified
+            .manifest()
+            .sources
+            .iter()
+            .filter(|source| source.observation().source().provider() == "claude")
+            .count(),
+        1
+    );
+    assert_literal_bodies(
+        &indexed_records(&index, CaptureProvider::Claude, retained_session),
+        &["replacement root retained content"],
+    );
+    assert!(indexed_records(&index, CaptureProvider::Claude, retired_session).is_empty());
+    assert!(retired_transcript.exists());
+    assert!(fs::read_to_string(retired_transcript)
+        .unwrap()
+        .contains("first root retired content"));
+}
+
+#[test]
 fn claude_roots_with_the_same_relative_session_path_publish_independent_sources() {
     let temp = crate::test_support_paths::tempdir().unwrap();
     let personal = temp.path().join("personal/projects");

--- a/crates/ctx-history-capture-composition/src/source_backed/tests/codex_child_independence/lifecycle.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/tests/codex_child_independence/lifecycle.rs
@@ -24,6 +24,27 @@ fn mcp_terminal(
     })
 }
 
+fn codex_discovery_context(root: &Path, home: &Path) -> DiscoveryContext {
+    DiscoveryContext::new(
+        root,
+        root,
+        DiscoveryPlatform::Linux,
+        crate::DiscoveryPlatformDirs::default(),
+    )
+    .with_env("CODEX_HOME", home)
+}
+
+fn automatic_codex_tree_route(registry: &SourceBackedProviderRegistry) -> SourceRouteIdentity {
+    registry
+        .routes()
+        .find(|route| {
+            route.source.provider == CaptureProvider::Codex
+                && route.source.source_format == "codex_session_jsonl_tree"
+        })
+        .and_then(|route| route.route_identity.clone())
+        .unwrap()
+}
+
 #[test]
 fn retired_semantic_v2_checkpoint_is_inert_and_append_matches_cold() {
     assert_legacy_provider_checkpoint_is_inert("retiredv2", retired_semantic_v2_checkpoint);
@@ -37,6 +58,192 @@ fn retired_semantic_v6_checkpoint_is_inert_and_append_matches_cold() {
 #[test]
 fn malformed_semantic_checkpoint_key_is_inert_and_append_matches_cold() {
     assert_legacy_provider_checkpoint_is_inert("malformedkey", |_| TypedKey::U64(2));
+}
+
+#[test]
+fn automatic_codex_root_replacement_retires_archived_only_sources() {
+    let temp = tempdir().unwrap();
+    let first_home = temp.path().join("first");
+    let first_sessions = first_home.join("sessions");
+    let first_archive = first_home.join("archived_sessions");
+    let replacement_home = temp.path().join("replacement");
+    let replacement_sessions = replacement_home.join("sessions");
+    let replacement_archive = replacement_home.join("archived_sessions");
+    let index_root = temp.path().join("index");
+    for root in [&first_sessions, &first_archive, &replacement_sessions] {
+        fs::create_dir_all(root).unwrap();
+    }
+    let archived_session = "019fb000-0000-7000-8000-000000000019";
+    let replacement_session = "019fb000-0000-7000-8000-000000000020";
+    write_session(
+        &first_archive,
+        archived_session,
+        ProviderNativeSessionRelationship::Root,
+        None,
+        [message("archived-only-before-root-change")],
+    );
+    write_session(
+        &replacement_sessions,
+        replacement_session,
+        ProviderNativeSessionRelationship::Root,
+        None,
+        [message("active-after-root-change")],
+    );
+
+    let initial_context = codex_discovery_context(temp.path(), &first_home);
+    let data_root = temp.path().join("data");
+    let initial = build_discovered_codex_registry(&initial_context, &data_root);
+    assert!(initial.issues.is_empty(), "{:?}", initial.issues);
+    let initial_receipt =
+        refresh_source_backed_generation(&index_root, &initial.registry, writer_options()).unwrap();
+    assert!(initial_receipt.failed_routes.is_empty());
+
+    let replacement_context = codex_discovery_context(temp.path(), &replacement_home);
+    let probes = crate::test_provider_probes();
+    let replacement_report =
+        ctx_history_source_discovery::discover_provider_sources_for_provider_with_context(
+            &probes,
+            &replacement_context,
+            CaptureProvider::Codex,
+        );
+    assert!(replacement_report
+        .sources
+        .iter()
+        .any(|source| source.path == replacement_archive && !source.exists));
+    let replacement = build_discovered_codex_registry(&replacement_context, &data_root);
+    assert!(replacement.issues.is_empty(), "{:?}", replacement.issues);
+    let replacement_tree_route = automatic_codex_tree_route(&replacement.registry);
+    let replacement_receipt =
+        refresh_source_backed_generation(&index_root, &replacement.registry, writer_options())
+            .unwrap();
+    assert!(replacement_receipt.failed_routes.is_empty());
+    assert!(replacement_receipt
+        .complete_inventory_route_ids
+        .contains(&replacement_tree_route));
+    assert_eq!(replacement_receipt.removals.len(), 1);
+
+    let index = VerifiedIndex::open(&index_root).unwrap();
+    assert_eq!(
+        index
+            .manifest()
+            .sources
+            .iter()
+            .filter(|source| source.observation().source().provider() == "codex")
+            .count(),
+        1
+    );
+    assert!(source_records_contain(
+        &index,
+        replacement_session,
+        "active-after-root-change"
+    ));
+    assert!(first_archive.exists());
+    assert!(
+        fs::read_to_string(session_path(&first_archive, archived_session))
+            .unwrap()
+            .contains("archived-only-before-root-change")
+    );
+}
+
+#[test]
+fn automatic_codex_root_replacement_partial_inventory_carries_archived_members() {
+    for disposition in ["pending", "quarantined"] {
+        let temp = tempdir().unwrap();
+        let first_home = temp.path().join("first");
+        let first_archive = first_home.join("archived_sessions");
+        let replacement_home = temp.path().join("replacement");
+        let replacement_sessions = replacement_home.join("sessions");
+        let index_root = temp.path().join("index");
+        fs::create_dir_all(&first_archive).unwrap();
+        fs::create_dir_all(&replacement_sessions).unwrap();
+        let archived_session = "019fb000-0000-7000-8000-000000000021";
+        let archived_marker = format!("{disposition}-archived-before-root-change");
+        write_session(
+            &first_archive,
+            archived_session,
+            ProviderNativeSessionRelationship::Root,
+            None,
+            [message(&archived_marker)],
+        );
+        let replacement_session = "019fb000-0000-7000-8000-000000000022";
+        let replacement_path = session_path(&replacement_sessions, replacement_session);
+        match disposition {
+            "pending" => fs::write(&replacement_path, b"{\"type\":\"session_meta\"").unwrap(),
+            "quarantined" => {
+                write_session(
+                    &replacement_sessions,
+                    replacement_session,
+                    ProviderNativeSessionRelationship::Root,
+                    None,
+                    [message("quarantined-replacement-prefix")],
+                );
+                for ordinal in 0..33 {
+                    append_event(
+                        &replacement_path,
+                        message(&format!("quarantined-replacement-prefix-{ordinal}")),
+                    );
+                }
+                append_event(
+                    &replacement_path,
+                    session_meta(
+                        "019fb000-0000-7000-8000-000000000023",
+                        ProviderNativeSessionRelationship::Root,
+                        None,
+                    ),
+                );
+            }
+            _ => unreachable!(),
+        }
+
+        let initial_context = codex_discovery_context(temp.path(), &first_home);
+        let data_root = temp.path().join("data");
+        let initial = build_discovered_codex_registry(&initial_context, &data_root);
+        assert!(
+            initial.issues.is_empty(),
+            "{disposition}: {:?}",
+            initial.issues
+        );
+        let initial_receipt =
+            refresh_source_backed_generation(&index_root, &initial.registry, writer_options())
+                .unwrap();
+        assert!(initial_receipt.failed_routes.is_empty(), "{disposition}");
+
+        let replacement_context = codex_discovery_context(temp.path(), &replacement_home);
+        let replacement = build_discovered_codex_registry(&replacement_context, &data_root);
+        assert!(
+            replacement.issues.is_empty(),
+            "{disposition}: {:?}",
+            replacement.issues
+        );
+        let replacement_tree_route = automatic_codex_tree_route(&replacement.registry);
+        let receipt =
+            refresh_source_backed_generation(&index_root, &replacement.registry, writer_options())
+                .unwrap();
+
+        assert!(receipt.failed_routes.is_empty(), "{disposition}");
+        assert!(
+            !receipt
+                .complete_inventory_route_ids
+                .contains(&replacement_tree_route),
+            "{disposition} replacement route was incorrectly complete"
+        );
+        assert!(receipt.removals.is_empty(), "{disposition}");
+        let index = VerifiedIndex::open(&index_root).unwrap();
+        assert_eq!(
+            index
+                .manifest()
+                .sources
+                .iter()
+                .filter(|source| source.observation().source().provider() == "codex")
+                .count(),
+            1,
+            "{disposition}"
+        );
+        assert!(
+            source_records_contain(&index, archived_session, &archived_marker),
+            "{disposition} did not carry the archived source"
+        );
+    }
 }
 
 #[test]

--- a/crates/ctx-history-capture-composition/src/source_backed/tests/codex_child_independence/repository.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/tests/codex_child_independence/repository.rs
@@ -73,3 +73,73 @@ fn destructive_precommit_truncate_and_replacement_preserve_last_good_generation_
             .is_empty());
     }
 }
+
+#[test]
+fn current_authority_reappearance_before_publication_carries_last_good_generation() {
+    let temp = tempdir().unwrap();
+    let sessions = temp.path().join("sessions");
+    let index_root = temp.path().join("index");
+    fs::create_dir_all(&sessions).unwrap();
+    let retained_session = "019fb000-0000-7000-8000-000000000043";
+    let deleted_session = "019fb000-0000-7000-8000-000000000044";
+    let retained_marker = "currentauthorityretainedmarker";
+    let deleted_marker = "currentauthoritydeletedmarker";
+    write_session(
+        &sessions,
+        retained_session,
+        ProviderNativeSessionRelationship::Root,
+        None,
+        [message(retained_marker)],
+    );
+    let deleted_path = session_path(&sessions, deleted_session);
+    write_session(
+        &sessions,
+        deleted_session,
+        ProviderNativeSessionRelationship::Root,
+        None,
+        [message(deleted_marker)],
+    );
+    let registry = register_tree(&[&sessions]);
+    let route_identity = route_identity(&registry, &sessions);
+    let initial =
+        refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
+    assert!(initial.failed_routes.is_empty());
+    let before = VerifiedIndex::open(&index_root).unwrap();
+    let generation = before.generation_id().to_owned();
+    let retained_snapshot = source_snapshot(&before, retained_session, retained_marker);
+    let deleted_snapshot = source_snapshot(&before, deleted_session, deleted_marker);
+    drop(before);
+
+    fs::remove_file(&deleted_path).unwrap();
+    let hook_sessions = sessions.clone();
+    set_before_jsonl_terminal_physical_revalidation_hook(sessions.clone(), move || {
+        write_session(
+            &hook_sessions,
+            deleted_session,
+            ProviderNativeSessionRelationship::Root,
+            None,
+            [message(deleted_marker)],
+        );
+    });
+
+    let failed =
+        refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
+    assert!(matches!(
+        failed.failed_routes.as_slice(),
+        [failure]
+            if failure.route_identity == route_identity
+                && failure.class == SourceBackedSourceFailureClass::SourceChanged
+                && failure.carried_forward
+    ));
+    assert!(failed.removals.is_empty());
+    let retained = VerifiedIndex::open(&index_root).unwrap();
+    assert_eq!(retained.generation_id(), generation);
+    assert_eq!(
+        source_snapshot(&retained, retained_session, retained_marker),
+        retained_snapshot
+    );
+    assert_eq!(
+        source_snapshot(&retained, deleted_session, deleted_marker),
+        deleted_snapshot
+    );
+}

--- a/crates/ctx-history-jsonl/src/family/route/ownership.rs
+++ b/crates/ctx-history-jsonl/src/family/route/ownership.rs
@@ -26,20 +26,23 @@ pub(super) fn base_sources_for_root<R: JsonlFamilyRuntime>(
             .filter(|source| adapter.owns(source.observation().source()))
             .collect(),
     };
-    sources
-        .into_iter()
-        .filter_map(|source| match adapter.base_source_path(&source) {
-            Ok(path)
-                if inventory.authorities.is_empty() && path.starts_with(requested_root)
-                    || inventory
-                        .authorities
-                        .iter()
-                        .any(|authority| path.starts_with(authority.named_path())) =>
-            {
-                Some(Ok(source))
-            }
-            Ok(_) => None,
-            Err(error) => Some(Err(route_invalid(error))),
-        })
-        .collect()
+    match adapter.base_scope() {
+        JsonlFamilyBaseScope::ProviderFamily => sources
+            .into_iter()
+            .filter_map(|source| match adapter.base_source_path(&source) {
+                Ok(path)
+                    if inventory.authorities.is_empty() && path.starts_with(requested_root)
+                        || inventory
+                            .authorities
+                            .iter()
+                            .any(|authority| path.starts_with(authority.named_path())) =>
+                {
+                    Some(Ok(source))
+                }
+                Ok(_) => None,
+                Err(error) => Some(Err(route_invalid(error))),
+            })
+            .collect(),
+        JsonlFamilyBaseScope::Route => Ok(sources),
+    }
 }

--- a/crates/ctx-history-jsonl/src/family/route/retirement.rs
+++ b/crates/ctx-history-jsonl/src/family/route/retirement.rs
@@ -34,14 +34,23 @@ pub(super) fn retirement_absence_dependency<R: JsonlFamilyRuntime>(
     base_source: &SourceKey,
     base_path: &Path,
 ) -> Option<JsonlFamilyAbsentMember<JsonlRuntimeError<R>>> {
-    if certified_owned_same_path_replacement(
+    let same_path_replacement = certified_owned_same_path_replacement(
         adapter,
         opening,
         inventory,
         terminal_sources,
         base_source,
         base_path,
-    ) {
+    );
+    // A complete current inventory is terminal authority for an exact route
+    // whose named root changed; reopening the former root would reject an
+    // intentional replacement merely because the old home still exists.
+    let external_exact_route_replacement = adapter.base_scope() == JsonlFamilyBaseScope::Route
+        && opening
+            .authorities
+            .iter()
+            .all(|authority| !base_path.starts_with(authority.named_path()));
+    if same_path_replacement || external_exact_route_replacement {
         None
     } else {
         JsonlFamilyAbsentMember::from_path(opening, base_path.to_path_buf())

--- a/crates/ctx-history-jsonl/src/family/route/tests/behavior/terminal_inventory.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/behavior/terminal_inventory.rs
@@ -377,6 +377,50 @@ fn active_source_family_contract_jsonl_frozen_multi_root_defers_new_leaves() {
 }
 
 #[test]
+fn route_base_scope_retains_prior_sources_outside_replacement_authorities() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let first_root = temp.path().join("first-root");
+    let replacement_root = temp.path().join("replacement-root");
+    let selection_root = temp.path().join("selection");
+    let index_root = temp.path().join("index");
+    fs::create_dir_all(&first_root).unwrap();
+    fs::create_dir_all(&replacement_root).unwrap();
+    fs::write(first_root.join("retired.jsonl"), TEST_RECORD).unwrap();
+    fs::write(replacement_root.join("active.jsonl"), TEST_RECORD).unwrap();
+
+    let initial_adapter = FrozenMultiRootTestAdapter {
+        roots: vec![first_root],
+    };
+    let (resident, _inventory) = expected_state(&initial_adapter, &selection_root);
+    let prior = expected_source(&resident);
+    test_generations().lock().unwrap().insert(
+        index_root.clone(),
+        TestSnapshot {
+            sources: vec![prior.clone()],
+            route_identity: Some(test_route_identity()),
+            route_sources: vec![prior.observation().source().clone()],
+            records: Vec::new(),
+        },
+    );
+
+    let replacement_adapter = FrozenMultiRootTestAdapter {
+        roots: vec![replacement_root],
+    };
+    let (_writer, _resident, bases) = capture_test_generation!(
+        &replacement_adapter,
+        &selection_root,
+        &index_root,
+        1,
+        |_resident, sink| {
+            let inventory = replacement_adapter.discover(&selection_root).unwrap();
+            base_sources_for_root(&replacement_adapter, &inventory, &selection_root, sink)
+        }
+    );
+
+    assert_eq!(bases.unwrap().len(), 1);
+}
+
+#[test]
 fn active_source_family_contract_jsonl_frozen_root_replacement_fails_closed() {
     let temp = crate::test_support_paths::tempdir().unwrap();
     let root = temp.path().join("sessions");


### PR DESCRIPTION
## Summary

- Reconcile every prior member owned by an exact JSONL source route before applying current-root retirement.
- When `CODEX_HOME` or another provider home moves, let a complete replacement inventory retire old-root members even if the old directory still exists.
- Preserve incomplete-inventory, current-authority reappearance, and Gemini same-path identity-migration safety fences.

## Testing

- `scripts/check.sh --mode=ci` (crate-size preflight, strict all-target build/Clippy, 208/208 test targets)
- Focused JSONL, composition, qualification, and Gemini suites uncached (87/180/31/49 tests)
- Independent implementation review and final exact-tree code review

Fixes #661