### PR TITLE
fix(history): contain provider input failures

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -574,7 +574,7 @@
           "FILE:@@//crates/ctx-terminal/Cargo.toml 15f8740c8756c4e30e65864e4e4148e47c6e7fbb2ffb4ad3c036d7e131a57458",
           "FILE:@@//crates/ctx-history-ingest-application/Cargo.toml 0fdad960edeb31222f10d474799875b20a90e5a789989c8eebe745a8f129917a",
           "FILE:@@//crates/ctx-cli-contract-tests/Cargo.toml 52abd1f7de73a58131585a2936e99e5c0b31c2d298b4367fc097e35708edda3b",
-          "FILE:@@//crates/ctx-history-capture-composition-qualification/Cargo.toml a80e2112e41238fb04f8ce9709a8c92cd63809923e47b578e0e427fc36757232",
+          "FILE:@@//crates/ctx-history-capture-composition-qualification/Cargo.toml 7a780b023d28a1d4e8575db2c943b28967c6dd7e3c6b8533c778af1da8d6e44a",
           "FILE:@@//crates/ctx-history-snapshot-reader/Cargo.toml 421fa3f97f01c8b9301e794546b04e69ffd4662fb3ee6d03fb640adb34f26e09",
           "FILE:@@//crates/ctx-deepseek-harness-qualification/Cargo.toml 24ede89a630318af377313accedcd95712825d3db1764aaeee3a1857c2ca0b64",
           "FILE:@@//crates/ctx-grok-build-qualification/Cargo.toml 7665dd6f79fa97b2f5a668305f6039cb83acd5ebc8fec262dd4518161c26e501",

--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration/additional.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration/additional.rs
@@ -389,6 +389,120 @@ fn import_all_publishes_valid_routes_and_reports_one_invalid_route() {
 }
 
 #[test]
+fn warm_import_all_advances_with_changed_codex_and_failed_opencode() {
+    let temp = daemon_test_root();
+    let opencode_query = "opencode warm carry forward oracle";
+    let new_codex_query = "codex warm success boundary oracle";
+    write_codex_setup_session(&temp);
+    install_provider_default_fixture(
+        &temp,
+        temp.path(),
+        "open_code",
+        opencode_query,
+        "OpenCode warm carry forward response",
+    );
+
+    let cold =
+        json_output(ctx(&temp).args(["import", "--all", "--format=json", "--progress", "none"]));
+    assert_eq!(cold["outcome"], "success", "{cold:#}");
+    assert_eq!(cold["totals"]["failed_sources"], 0, "{cold:#}");
+    let cold_generation = published_generation(&cold);
+    let cold_opencode_counts = provider_core_counts(&data_root(&temp), "opencode");
+    assert!(cold_opencode_counts.0 > 0, "{cold:#}");
+    assert!(cold_opencode_counts.1 > 0, "{cold:#}");
+    assert!(provider_core_counts(&data_root(&temp), "codex").1 > 0);
+
+    let codex_session = temp
+        .path()
+        .join(".codex/sessions/2026/06/24/codex-session-setup.jsonl");
+    let mut codex = fs::OpenOptions::new()
+        .append(true)
+        .open(codex_session)
+        .unwrap();
+    writeln!(
+        codex,
+        "{}",
+        json!({
+            "timestamp": "2026-06-24T10:00:02.000Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": new_codex_query}]
+            }
+        })
+    )
+    .unwrap();
+    drop(codex);
+    fs::write(
+        temp.path().join(".local/share/opencode/opencode.db"),
+        b"not sqlite",
+    )
+    .unwrap();
+
+    let warm =
+        json_output(ctx(&temp).args(["import", "--all", "--format=json", "--progress", "none"]));
+    assert_eq!(
+        warm["outcome"], "completed_with_source_failures",
+        "{warm:#}"
+    );
+    assert_eq!(warm["failure_scope"], "source", "{warm:#}");
+    assert_eq!(warm["failure_type"], "source_failure", "{warm:#}");
+    assert_eq!(warm["totals"]["failed_sources"], 1, "{warm:#}");
+
+    let sources = warm["sources"].as_array().unwrap();
+    let failed = sources
+        .iter()
+        .find(|source| source["provider"] == "opencode")
+        .expect("typed OpenCode source failure");
+    assert_eq!(failed["status"], "failure", "{warm:#}");
+    assert_eq!(failed["source_failure_class"], "unreadable", "{warm:#}");
+    assert_eq!(failed["carried_forward"], true, "{warm:#}");
+
+    let publication = sources
+        .iter()
+        .find(|source| source["source_format"] == "provider_authoritative_all")
+        .expect("successful import-all publication");
+    let warm_generation = publication["published_generation"]
+        .as_str()
+        .expect("warm import should publish a generation")
+        .to_owned();
+    assert_ne!(warm_generation, cold_generation, "{warm:#}");
+    wait_for_core_generation(&temp, &warm_generation);
+    assert_eq!(
+        provider_core_counts(&data_root(&temp), "opencode"),
+        cold_opencode_counts
+    );
+
+    for (provider, query) in [("codex", new_codex_query), ("opencode", opencode_query)] {
+        let search = json_output(ctx(&temp).args([
+            "search",
+            query,
+            "--provider",
+            provider,
+            "--refresh",
+            "off",
+            "--format=json",
+        ]));
+        assert_eq!(
+            search["retrieval"]["generation_id"], warm_generation,
+            "{search:#}"
+        );
+        assert!(
+            search["results"].as_array().is_some_and(|results| {
+                results.iter().any(|result| {
+                    result["provider"] == provider
+                        && result["snippet"]
+                            .as_str()
+                            .is_some_and(|snippet| snippet.contains(query))
+                })
+            }),
+            "{search:#}"
+        );
+    }
+}
+
+#[test]
 fn failed_import_attempt_does_not_count_as_indexed_history() {
     let temp = tempdir();
     let opencode_dir = temp.path().join(".local/share/opencode");

--- a/crates/ctx-cli-presentation/src/commands/doctor_presentation.rs
+++ b/crates/ctx-cli-presentation/src/commands/doctor_presentation.rs
@@ -2,8 +2,22 @@ use serde_json::Value;
 
 use crate::ui::{
     evidence_list, fields, hint, outcome, section, Action, Document, Evidence, Field, Hint,
-    Outcome, OutcomeState, RenderContext,
+    Outcome, OutcomeState, RenderContext, Span,
 };
+
+const MAX_REFRESH_ERROR_BYTES: usize = 512;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DoctorSearchAvailability {
+    Available,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DoctorRefreshFailure<'a> {
+    pub detail: &'a str,
+    pub search: DoctorSearchAvailability,
+}
 
 pub fn source_epoch_findings(report: &Value, semantic_required: bool) -> Vec<String> {
     let mut findings = Vec::new();
@@ -38,8 +52,23 @@ pub fn render_doctor_human(
     automatic_upgrades: &str,
     findings: &[String],
     rejected_records: u64,
+    refresh_failure: Option<DoctorRefreshFailure<'_>>,
 ) -> Document {
-    let title = match findings.len() {
+    let mut human_findings = findings
+        .iter()
+        .filter(|finding| refresh_failure.is_none() || !is_derivative_refresh_finding(finding))
+        .map(|finding| humanize_doctor_finding(finding))
+        .collect::<Vec<_>>();
+    if let Some(failure) = refresh_failure {
+        human_findings.insert(
+            0,
+            HumanDoctorFinding {
+                summary: "History refresh failed".to_owned(),
+                detail: Some(bounded_terminal_detail(failure.detail)),
+            },
+        );
+    }
+    let title = match human_findings.len() {
         0 => "No problems found".to_owned(),
         1 => "ctx found 1 issue".to_owned(),
         count => format!("ctx found {count} issues"),
@@ -47,7 +76,7 @@ pub fn render_doctor_human(
     let mut document = outcome(
         context,
         Outcome {
-            state: if findings.is_empty() {
+            state: if human_findings.is_empty() {
                 OutcomeState::Success
             } else {
                 OutcomeState::Warning
@@ -64,24 +93,32 @@ pub fn render_doctor_human(
             &[Field::new("Automatic upgrades", automatic_upgrades)],
         ),
     ));
-    if rejected_records > 0 {
+    if rejected_records > 0 || refresh_failure.is_some() {
+        let rejected_records = rejected_records.to_string();
+        let mut history_fields = Vec::new();
+        if let Some(failure) = refresh_failure {
+            history_fields.push(Field::new(
+                "Search",
+                match failure.search {
+                    DoctorSearchAvailability::Available => {
+                        "Available — last verified index remains searchable"
+                    }
+                    DoctorSearchAvailability::Unavailable => {
+                        "Unavailable — no verified index is searchable"
+                    }
+                },
+            ));
+        }
+        if rejected_records != "0" {
+            history_fields.push(Field::new("Skipped records", &rejected_records));
+        }
         document.push_blank();
-        document.append(section(
-            "History",
-            fields(
-                context,
-                &[Field::new("Skipped records", &rejected_records.to_string())],
-            ),
-        ));
+        document.append(section("History", fields(context, &history_fields)));
     }
-    if findings.is_empty() {
+    if human_findings.is_empty() {
         return document;
     }
 
-    let human_findings = findings
-        .iter()
-        .map(|finding| humanize_doctor_finding(finding))
-        .collect::<Vec<_>>();
     let references = (1..=human_findings.len())
         .map(|index| index.to_string())
         .collect::<Vec<_>>();
@@ -103,14 +140,18 @@ pub fn render_doctor_human(
     document.append(hint(
         context,
         Hint {
-            text: if refresh_failed {
+            text: if refresh_failure.is_some() {
+                "Fix the refresh error above, then retry."
+            } else if refresh_failed {
                 "Check the history refresh service."
             } else {
                 "Resolve the issues above, then check again."
             },
         },
         Some(Action {
-            command: if refresh_failed {
+            command: if refresh_failure.is_some() {
+                "ctx import --all"
+            } else if refresh_failed {
                 "ctx status"
             } else {
                 "ctx doctor"
@@ -118,6 +159,33 @@ pub fn render_doctor_human(
         }),
     ));
     document
+}
+
+fn is_derivative_refresh_finding(finding: &str) -> bool {
+    [
+        "history_epoch is unavailable (source_refresh_failed)",
+        "history_epoch is unavailable (core_refresh_failed)",
+        "lexical is unavailable (source_refresh_failed)",
+        "lexical is unavailable (core_refresh_failed)",
+        "lexical is unavailable (lexical_generation_unavailable)",
+        "catalog is pending (catalog_publication_pending)",
+        "catalog is pending (core_generation_pending)",
+        "refresh is unavailable (core_refresh_failed)",
+        "semantic is pending (lexical_generation_unavailable)",
+    ]
+    .contains(&finding)
+}
+
+fn bounded_terminal_detail(detail: &str) -> String {
+    let escaped = Span::text(detail).content().to_owned();
+    if escaped.len() <= MAX_REFRESH_ERROR_BYTES {
+        return escaped;
+    }
+    let mut end = MAX_REFRESH_ERROR_BYTES - 3;
+    while !escaped.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &escaped[..end])
 }
 
 struct HumanDoctorFinding {
@@ -195,7 +263,7 @@ mod ui_tests {
     #[test]
     fn healthy_doctor_is_concise_and_outcome_first() {
         let context = context(80);
-        let rendered = render_doctor_human(&context, "apply", &[], 0).render_plain();
+        let rendered = render_doctor_human(&context, "apply", &[], 0, None).render_plain();
         assert_eq!(
             rendered,
             "✓ No problems found\n\nConfiguration\nAutomatic upgrades  apply\n"
@@ -204,7 +272,7 @@ mod ui_tests {
 
     #[test]
     fn healthy_doctor_presents_record_rejections_as_skipped_records() {
-        let rendered = render_doctor_human(&context(80), "apply", &[], 2).render_plain();
+        let rendered = render_doctor_human(&context(80), "apply", &[], 2, None).render_plain();
 
         assert!(rendered.starts_with("✓ No problems found\n"), "{rendered}");
         assert!(
@@ -248,7 +316,8 @@ mod ui_tests {
         let finding = "history configuration is unavailable; repair the local configuration, then run `ctx doctor`".to_owned();
         for width in [32, 48, 80, 120] {
             let context = context(width);
-            let document = render_doctor_human(&context, "off", std::slice::from_ref(&finding), 0);
+            let document =
+                render_doctor_human(&context, "off", std::slice::from_ref(&finding), 0, None);
             let rendered = document.render_plain();
             assert!(rendered.starts_with("! ctx found 1 issue\n"));
             assert!(rendered.contains("Issues\n[1]"));
@@ -269,7 +338,7 @@ mod ui_tests {
 
         for width in [32, 48, 80, 120] {
             let context = context(width);
-            let document = render_doctor_human(&context, "apply", &findings, 0);
+            let document = render_doctor_human(&context, "apply", &findings, 0, None);
             let rendered = document.render_plain();
             let flattened = rendered.split_whitespace().collect::<Vec<_>>().join(" ");
             assert!(rendered.starts_with("! ctx found 4 issues\n"));
@@ -300,5 +369,60 @@ mod ui_tests {
             assert!(!rendered.contains("ctx doctor\n"), "{rendered}");
             assert_fits(&document, &context);
         }
+    }
+
+    #[test]
+    fn refresh_failure_is_one_root_issue_with_explicit_search_availability() {
+        let findings = [
+            "history_epoch is unavailable (source_refresh_failed)",
+            "lexical is unavailable (source_refresh_failed)",
+            "catalog is pending (catalog_publication_pending)",
+            "refresh is unavailable (core_refresh_failed)",
+        ]
+        .map(str::to_owned);
+
+        for (search, expected) in [
+            (
+                DoctorSearchAvailability::Available,
+                "Available — last verified index remains searchable",
+            ),
+            (
+                DoctorSearchAvailability::Unavailable,
+                "Unavailable — no verified index is searchable",
+            ),
+        ] {
+            let rendered = render_doctor_human(
+                &context(80),
+                "apply",
+                &findings,
+                0,
+                Some(DoctorRefreshFailure {
+                    detail: "Claude transcript repeats a stable event identity at lines 1 and 2",
+                    search,
+                }),
+            )
+            .render_plain();
+            assert!(rendered.starts_with("! ctx found 1 issue\n"), "{rendered}");
+            assert!(rendered.contains(expected), "{rendered}");
+            assert_eq!(rendered.matches("History refresh failed").count(), 1);
+            assert!(
+                !rendered.contains("Search index is unavailable"),
+                "{rendered}"
+            );
+            assert!(!rendered.contains("source catalog"), "{rendered}");
+            assert!(rendered.contains("ctx import --all"), "{rendered}");
+        }
+    }
+
+    #[test]
+    fn refresh_failure_detail_is_control_escaped_and_byte_bounded() {
+        let detail = format!("start\n\u{1b}[31m{}tail", "é".repeat(400));
+        let bounded = bounded_terminal_detail(&detail);
+        assert!(bounded.len() <= MAX_REFRESH_ERROR_BYTES);
+        assert!(bounded.len() > MAX_REFRESH_ERROR_BYTES - 5);
+        assert!(bounded.starts_with("start\\n\\x1b[31m"), "{bounded:?}");
+        assert!(bounded.ends_with("..."), "{bounded:?}");
+        assert!(!bounded.contains('\n'));
+        assert!(!bounded.contains('\u{1b}'));
     }
 }

--- a/crates/ctx-cli-presentation/src/commands/mod.rs
+++ b/crates/ctx-cli-presentation/src/commands/mod.rs
@@ -15,7 +15,9 @@ mod status_presentation;
 mod status_usage;
 
 pub use doctor::DoctorArgs;
-pub use doctor_presentation::{render_doctor_human, source_epoch_findings};
+pub use doctor_presentation::{
+    render_doctor_human, source_epoch_findings, DoctorRefreshFailure, DoctorSearchAvailability,
+};
 pub use import_diagnostics::render_partial_deprecation;
 pub use index::IndexArgs;
 pub use list::{ListArgs, ListEventsArgs, ListTarget};

--- a/crates/ctx-cli/src/commands/doctor.rs
+++ b/crates/ctx-cli/src/commands/doctor.rs
@@ -38,10 +38,35 @@ pub(crate) fn run_doctor(
             config.auto_upgrade_mode().as_str(),
             &findings,
             rejected_records,
+            human_refresh_failure(&source_report),
         );
         ui.write_stdout(&document)?;
     }
     Ok(())
+}
+
+fn human_refresh_failure(
+    report: &Value,
+) -> Option<ctx_cli_presentation::commands::DoctorRefreshFailure<'_>> {
+    let refresh = report.get("refresh")?;
+    if refresh.get("reason").and_then(Value::as_str) != Some("core_refresh_failed") {
+        return None;
+    }
+    let detail = refresh
+        .get("last_error")
+        .and_then(Value::as_str)
+        .filter(|detail| !detail.is_empty())?;
+    let search = match report
+        .get("lexical")
+        .and_then(|lexical| lexical.get("status"))
+        .and_then(Value::as_str)
+    {
+        Some("ready" | "stale") => {
+            ctx_cli_presentation::commands::DoctorSearchAvailability::Available
+        }
+        _ => ctx_cli_presentation::commands::DoctorSearchAvailability::Unavailable,
+    };
+    Some(ctx_cli_presentation::commands::DoctorRefreshFailure { detail, search })
 }
 
 pub(crate) fn doctor_facts(data_root: &std::path::Path) -> Result<Value> {
@@ -67,4 +92,40 @@ pub(crate) fn doctor_facts(data_root: &std::path::Path) -> Result<Value> {
         "daemon": daemon,
         "upgrade": upgrade,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ctx_cli_presentation::commands::DoctorSearchAvailability;
+
+    #[test]
+    fn human_refresh_failure_distinguishes_retained_and_cold_search() {
+        for (lexical, expected) in [
+            ("stale", DoctorSearchAvailability::Available),
+            ("unavailable", DoctorSearchAvailability::Unavailable),
+        ] {
+            let report = json!({
+                "lexical": {"status": lexical},
+                "refresh": {
+                    "status": "unavailable",
+                    "reason": "core_refresh_failed",
+                    "last_error": "root cause",
+                },
+            });
+            let failure = human_refresh_failure(&report).unwrap();
+            assert_eq!(failure.detail, "root cause");
+            assert_eq!(failure.search, expected);
+        }
+    }
+
+    #[test]
+    fn human_refresh_failure_requires_the_root_failure_detail() {
+        for report in [
+            json!({"lexical": {"status": "ready"}, "refresh": {"reason": "core_refresh_failed"}}),
+            json!({"lexical": {"status": "ready"}, "refresh": {"reason": "daemon_unavailable", "last_error": "noise"}}),
+        ] {
+            assert!(human_refresh_failure(&report).is_none());
+        }
+    }
 }

--- a/crates/ctx-history-capture-composition-qualification/BUILD.bazel
+++ b/crates/ctx-history-capture-composition-qualification/BUILD.bazel
@@ -54,3 +54,19 @@ ctx_rust_test(
     proc_macro_deps = all_crate_deps(proc_macro_dev = True),
     rustc_env = {"CARGO_MANIFEST_DIR": "crates/ctx-history-capture-composition-qualification"},
 )
+
+ctx_rust_test(
+    name = "claude_failure_boundary_tests",
+    testonly = True,
+    srcs = ["tests/claude_failure_boundaries.rs"],
+    crate_name = "ctx_history_capture_composition_qualification_claude",
+    crate_root = "tests/claude_failure_boundaries.rs",
+    edition = crate_edition(),
+    aliases = aliases(normal_dev = True, proc_macro_dev = True),
+    deps = all_crate_deps(normal_dev = True) + [
+        "//crates/ctx-history-capture-composition:lib",
+        "//crates/ctx-history-core:lib",
+        "//crates/ctx-history-index:lib",
+    ],
+    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
+)

--- a/crates/ctx-history-capture-composition-qualification/Cargo.toml
+++ b/crates/ctx-history-capture-composition-qualification/Cargo.toml
@@ -18,6 +18,10 @@ path = "tests/mistral_vibe_publication.rs"
 name = "jsonl_publication"
 path = "tests/jsonl_publication.rs"
 
+[[test]]
+name = "claude_failure_boundaries"
+path = "tests/claude_failure_boundaries.rs"
+
 [dev-dependencies]
 ctx-history-capture-composition = { path = "../ctx-history-capture-composition", features = ["test-support"] }
 ctx-history-capture-model = { path = "../ctx-history-capture-model" }

--- a/crates/ctx-history-capture-composition-qualification/tests/claude_failure_boundaries.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/claude_failure_boundaries.rs
@@ -1,0 +1,166 @@
+#![cfg(unix)]
+
+use std::{fs, os::unix::fs::symlink, path::Path};
+
+use ctx_history_capture_composition::{
+    refresh_source_backed_generation, register_landed_source_backed_route, ProviderCatalogSupport,
+    ProviderImportSupport, ProviderSource, ProviderSourceKind, ProviderSourceStatus,
+    SourceBackedProviderRegistry, SourceBackedRecordRejectionClass, SourceBackedRouteSelection,
+    SourceBackedSourceFailureClass,
+};
+use ctx_history_core::CaptureProvider;
+use ctx_history_index::{VerifiedIndex, WriterOptions};
+
+fn write_session(root: &Path, session: &str, uuid: &str, marker: &str) {
+    let path = root.join("project").join(format!("{session}.jsonl"));
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(
+        path,
+        serde_json::json!({
+            "type": "user",
+            "uuid": uuid,
+            "sessionId": session,
+            "message": {"role": "user", "content": marker},
+        })
+        .to_string()
+            + "\n",
+    )
+    .unwrap();
+}
+
+fn registry(root: &Path) -> SourceBackedProviderRegistry {
+    let mut registry = SourceBackedProviderRegistry::new();
+    register_landed_source_backed_route(
+        &mut registry,
+        ProviderSource {
+            provider: CaptureProvider::Claude,
+            path: root.to_path_buf(),
+            exists: true,
+            source_format: "claude_projects_jsonl_tree",
+            source_kind: ProviderSourceKind::NativeHistory,
+            import_support: ProviderImportSupport::Native,
+            catalog_support: ProviderCatalogSupport::None,
+            status: ProviderSourceStatus::Available,
+            unsupported_reason: None,
+        },
+        SourceBackedRouteSelection::Automatic,
+    )
+    .unwrap();
+    registry
+}
+
+fn refresh(
+    root: &Path,
+    index: &Path,
+) -> ctx_history_capture_composition::SourceBackedRefreshReceipt {
+    refresh_source_backed_generation(
+        index,
+        &registry(root),
+        WriterOptions {
+            indexer_threads: 1,
+            memory_bytes: 15_000_000,
+        },
+    )
+    .unwrap()
+}
+
+fn marker_count(index: &Path, marker: &str) -> usize {
+    VerifiedIndex::open(index)
+        .unwrap()
+        .search_event_candidates(marker, 16)
+        .unwrap()
+        .len()
+}
+
+fn assert_unreadable_failure(
+    receipt: &ctx_history_capture_composition::SourceBackedRefreshReceipt,
+    carried_forward: bool,
+) {
+    assert!(receipt.failed_routes.is_empty());
+    assert_eq!(receipt.logical_source_failures.total(), 1);
+    let [failure] = receipt.logical_source_failures.failures() else {
+        panic!("one Claude logical-source failure expected");
+    };
+    assert_eq!(failure.class, SourceBackedSourceFailureClass::Unreadable);
+    assert_eq!(failure.carried_forward, carried_forward);
+    assert_eq!(failure.source.provider(), CaptureProvider::Claude.as_str());
+    assert!(failure.detail.contains("is unreadable"), "{failure:?}");
+}
+
+#[test]
+fn cold_unreadable_claude_file_quarantines_only_that_session_and_repairs() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("projects");
+    let index = temp.path().join("index");
+    write_session(&root, "healthy", "healthy-cold", "healthycoldmarker");
+    let broken = root.join("project/broken.jsonl");
+    symlink(root.join("missing-target.jsonl"), &broken).unwrap();
+
+    let cold = refresh(&root, &index);
+    assert_unreadable_failure(&cold, false);
+    assert_eq!(marker_count(&index, "healthycoldmarker"), 1);
+
+    fs::remove_file(&broken).unwrap();
+    write_session(&root, "broken", "broken-repaired", "coldrepairedmarker");
+    let repaired = refresh(&root, &index);
+    assert!(repaired.failed_routes.is_empty());
+    assert!(repaired.logical_source_failures.is_empty());
+    assert_eq!(marker_count(&index, "healthycoldmarker"), 1);
+    assert_eq!(marker_count(&index, "coldrepairedmarker"), 1);
+}
+
+#[test]
+fn warm_unreadable_claude_file_carries_last_good_while_sibling_advances() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("projects");
+    let index = temp.path().join("index");
+    write_session(&root, "healthy", "healthy-before", "healthybeforemarker");
+    write_session(&root, "fragile", "fragile-before", "fragilebeforemarker");
+    let initial = refresh(&root, &index);
+    assert!(initial.logical_source_failures.is_empty());
+
+    let fragile = root.join("project/fragile.jsonl");
+    fs::remove_file(&fragile).unwrap();
+    symlink(root.join("missing-target.jsonl"), &fragile).unwrap();
+    write_session(&root, "healthy", "healthy-after", "healthyaftermarker");
+
+    let quarantined = refresh(&root, &index);
+    assert_unreadable_failure(&quarantined, true);
+    assert_eq!(marker_count(&index, "healthybeforemarker"), 0);
+    assert_eq!(marker_count(&index, "healthyaftermarker"), 1);
+    assert_eq!(marker_count(&index, "fragilebeforemarker"), 1);
+
+    fs::remove_file(&fragile).unwrap();
+    write_session(&root, "fragile", "fragile-after", "fragileaftermarker");
+    let repaired = refresh(&root, &index);
+    assert!(repaired.failed_routes.is_empty());
+    assert!(repaired.logical_source_failures.is_empty());
+    assert_eq!(marker_count(&index, "healthyaftermarker"), 1);
+    assert_eq!(marker_count(&index, "fragilebeforemarker"), 0);
+    assert_eq!(marker_count(&index, "fragileaftermarker"), 1);
+}
+
+#[test]
+fn malformed_claude_record_is_reported_without_losing_valid_records() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("projects");
+    let index = temp.path().join("index");
+    write_session(&root, "mixed", "mixed-valid", "mixedvalidmarker");
+    let transcript = root.join("project/mixed.jsonl");
+    let valid = fs::read_to_string(&transcript).unwrap();
+    fs::write(&transcript, format!("not-json\n{valid}")).unwrap();
+
+    let receipt = refresh(&root, &index);
+    assert!(receipt.failed_routes.is_empty());
+    assert!(receipt.logical_source_failures.is_empty());
+    assert_eq!(receipt.record_rejections.total(), 1);
+    let [rejection] = receipt.record_rejections.rejections() else {
+        panic!("one malformed Claude record rejection expected");
+    };
+    assert_eq!(
+        rejection.class,
+        SourceBackedRecordRejectionClass::MalformedRecord
+    );
+    assert_eq!(rejection.line_number, 1);
+    assert_eq!(marker_count(&index, "mixedvalidmarker"), 1);
+}

--- a/crates/ctx-history-capture-composition-qualification/tests/claude_failure_boundaries.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/claude_failure_boundaries.rs
@@ -1,6 +1,6 @@
 #![cfg(unix)]
 
-use std::{fs, os::unix::fs::symlink, path::Path};
+use std::{fs, os::unix::fs::PermissionsExt, path::Path};
 
 use ctx_history_capture_composition::{
     refresh_source_backed_generation, register_landed_source_backed_route, ProviderCatalogSupport,
@@ -72,6 +72,10 @@ fn marker_count(index: &Path, marker: &str) -> usize {
         .len()
 }
 
+fn set_mode(path: &Path, mode: u32) {
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).unwrap();
+}
+
 fn assert_unreadable_failure(
     receipt: &ctx_history_capture_composition::SourceBackedRefreshReceipt,
     carried_forward: bool,
@@ -88,19 +92,21 @@ fn assert_unreadable_failure(
 }
 
 #[test]
-fn cold_unreadable_claude_file_quarantines_only_that_session_and_repairs() {
+fn cold_permission_denied_claude_file_quarantines_only_that_session_and_repairs() {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path().join("projects");
     let index = temp.path().join("index");
     write_session(&root, "healthy", "healthy-cold", "healthycoldmarker");
+    write_session(&root, "broken", "broken-cold", "mustnotpublish");
     let broken = root.join("project/broken.jsonl");
-    symlink(root.join("missing-target.jsonl"), &broken).unwrap();
+    set_mode(&broken, 0o000);
 
     let cold = refresh(&root, &index);
     assert_unreadable_failure(&cold, false);
     assert_eq!(marker_count(&index, "healthycoldmarker"), 1);
+    assert_eq!(marker_count(&index, "mustnotpublish"), 0);
 
-    fs::remove_file(&broken).unwrap();
+    set_mode(&broken, 0o600);
     write_session(&root, "broken", "broken-repaired", "coldrepairedmarker");
     let repaired = refresh(&root, &index);
     assert!(repaired.failed_routes.is_empty());
@@ -110,7 +116,7 @@ fn cold_unreadable_claude_file_quarantines_only_that_session_and_repairs() {
 }
 
 #[test]
-fn warm_unreadable_claude_file_carries_last_good_while_sibling_advances() {
+fn warm_permission_denied_claude_file_carries_last_good_while_sibling_advances() {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path().join("projects");
     let index = temp.path().join("index");
@@ -120,8 +126,7 @@ fn warm_unreadable_claude_file_carries_last_good_while_sibling_advances() {
     assert!(initial.logical_source_failures.is_empty());
 
     let fragile = root.join("project/fragile.jsonl");
-    fs::remove_file(&fragile).unwrap();
-    symlink(root.join("missing-target.jsonl"), &fragile).unwrap();
+    set_mode(&fragile, 0o000);
     write_session(&root, "healthy", "healthy-after", "healthyaftermarker");
 
     let quarantined = refresh(&root, &index);
@@ -130,7 +135,7 @@ fn warm_unreadable_claude_file_carries_last_good_while_sibling_advances() {
     assert_eq!(marker_count(&index, "healthyaftermarker"), 1);
     assert_eq!(marker_count(&index, "fragilebeforemarker"), 1);
 
-    fs::remove_file(&fragile).unwrap();
+    set_mode(&fragile, 0o600);
     write_session(&root, "fragile", "fragile-after", "fragileaftermarker");
     let repaired = refresh(&root, &index);
     assert!(repaired.failed_routes.is_empty());

--- a/crates/ctx-history-capture-composition-qualification/tests/claude_failure_boundaries.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/claude_failure_boundaries.rs
@@ -12,7 +12,11 @@ use ctx_history_core::CaptureProvider;
 use ctx_history_index::{VerifiedIndex, WriterOptions};
 
 fn write_session(root: &Path, session: &str, uuid: &str, marker: &str) {
-    let path = root.join("project").join(format!("{session}.jsonl"));
+    write_project_session(root, "project", session, uuid, marker);
+}
+
+fn write_project_session(root: &Path, project: &str, session: &str, uuid: &str, marker: &str) {
+    let path = root.join(project).join(format!("{session}.jsonl"));
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     fs::write(
         path,
@@ -26,6 +30,24 @@ fn write_session(root: &Path, session: &str, uuid: &str, marker: &str) {
             + "\n",
     )
     .unwrap();
+}
+
+fn assert_duplicate_source_failure(
+    receipt: &ctx_history_capture_composition::SourceBackedRefreshReceipt,
+    carried_forward: bool,
+) {
+    assert!(receipt.failed_routes.is_empty());
+    assert_eq!(receipt.logical_source_failures.total(), 1);
+    let [failure] = receipt.logical_source_failures.failures() else {
+        panic!("one duplicate Claude source failure expected");
+    };
+    assert_eq!(failure.class, SourceBackedSourceFailureClass::Unreadable);
+    assert_eq!(failure.carried_forward, carried_forward);
+    assert_eq!(failure.source.provider(), CaptureProvider::Claude.as_str());
+    assert!(
+        failure.detail.contains("repeats a native session identity"),
+        "{failure:?}"
+    );
 }
 
 fn registry(root: &Path) -> SourceBackedProviderRegistry {
@@ -143,6 +165,111 @@ fn warm_permission_denied_claude_file_carries_last_good_while_sibling_advances()
     assert_eq!(marker_count(&index, "healthyaftermarker"), 1);
     assert_eq!(marker_count(&index, "fragilebeforemarker"), 0);
     assert_eq!(marker_count(&index, "fragileaftermarker"), 1);
+}
+
+#[test]
+fn cold_duplicate_claude_source_quarantines_only_the_ambiguous_session_and_repairs() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("projects");
+    let index = temp.path().join("index");
+    write_project_session(
+        &root,
+        "project-a",
+        "duplicate",
+        "duplicate-a",
+        "duplicateamarker",
+    );
+    write_project_session(
+        &root,
+        "project-b",
+        "duplicate",
+        "duplicate-b",
+        "duplicatebmarker",
+    );
+    write_project_session(
+        &root,
+        "project-c",
+        "healthy",
+        "healthy-duplicate-peer",
+        "healthyduplicatemarker",
+    );
+
+    let cold = refresh(&root, &index);
+    assert_duplicate_source_failure(&cold, false);
+    assert_eq!(marker_count(&index, "duplicateamarker"), 0);
+    assert_eq!(marker_count(&index, "duplicatebmarker"), 0);
+    assert_eq!(marker_count(&index, "healthyduplicatemarker"), 1);
+
+    fs::remove_file(root.join("project-b/duplicate.jsonl")).unwrap();
+    let repaired = refresh(&root, &index);
+    assert!(repaired.failed_routes.is_empty());
+    assert!(repaired.logical_source_failures.is_empty());
+    assert_eq!(marker_count(&index, "duplicateamarker"), 1);
+    assert_eq!(marker_count(&index, "duplicatebmarker"), 0);
+    assert_eq!(marker_count(&index, "healthyduplicatemarker"), 1);
+}
+
+#[test]
+fn warm_unreadable_duplicate_claude_source_carries_last_good_while_sibling_advances() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("projects");
+    let index = temp.path().join("index");
+    write_project_session(
+        &root,
+        "project-a",
+        "fragile",
+        "fragile-before",
+        "fragileduplicatebeforemarker",
+    );
+    write_project_session(
+        &root,
+        "project-c",
+        "healthy",
+        "healthy-before",
+        "healthyduplicatebeforemarker",
+    );
+    let initial = refresh(&root, &index);
+    assert!(initial.logical_source_failures.is_empty());
+
+    write_project_session(
+        &root,
+        "project-a",
+        "fragile",
+        "fragile-after",
+        "fragileduplicateaftermarker",
+    );
+    write_project_session(
+        &root,
+        "project-b",
+        "fragile",
+        "fragile-unreadable",
+        "mustnotpublishduplicate",
+    );
+    let duplicate = root.join("project-b/fragile.jsonl");
+    set_mode(&duplicate, 0o000);
+    write_project_session(
+        &root,
+        "project-c",
+        "healthy",
+        "healthy-after",
+        "healthyduplicateaftermarker",
+    );
+
+    let quarantined = refresh(&root, &index);
+    assert_duplicate_source_failure(&quarantined, true);
+    assert_eq!(marker_count(&index, "fragileduplicatebeforemarker"), 1);
+    assert_eq!(marker_count(&index, "fragileduplicateaftermarker"), 0);
+    assert_eq!(marker_count(&index, "mustnotpublishduplicate"), 0);
+    assert_eq!(marker_count(&index, "healthyduplicatebeforemarker"), 0);
+    assert_eq!(marker_count(&index, "healthyduplicateaftermarker"), 1);
+
+    fs::remove_file(&duplicate).unwrap();
+    let repaired = refresh(&root, &index);
+    assert!(repaired.failed_routes.is_empty());
+    assert!(repaired.logical_source_failures.is_empty());
+    assert_eq!(marker_count(&index, "fragileduplicatebeforemarker"), 0);
+    assert_eq!(marker_count(&index, "fragileduplicateaftermarker"), 1);
+    assert_eq!(marker_count(&index, "healthyduplicateaftermarker"), 1);
 }
 
 #[test]

--- a/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/claude_cursor.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/claude_cursor.rs
@@ -45,8 +45,19 @@ fn registry(
     root: &Path,
 ) -> SourceBackedProviderRegistry {
     let mut registry = SourceBackedProviderRegistry::new();
+    register_source(&mut registry, provider, source_format, root);
+    assert_eq!(registry.routes().len(), 1);
+    registry
+}
+
+fn register_source(
+    registry: &mut SourceBackedProviderRegistry,
+    provider: CaptureProvider,
+    source_format: &'static str,
+    root: &Path,
+) {
     register_landed_source_backed_route(
-        &mut registry,
+        registry,
         ProviderSource {
             provider,
             path: root.to_path_buf(),
@@ -61,8 +72,6 @@ fn registry(
         SourceBackedRouteSelection::Automatic,
     )
     .unwrap();
-    assert_eq!(registry.routes().len(), 1);
-    registry
 }
 
 fn write_transcript(path: &Path, rows: &[Value]) {

--- a/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/claude_cursor.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/claude_cursor.rs
@@ -45,19 +45,8 @@ fn registry(
     root: &Path,
 ) -> SourceBackedProviderRegistry {
     let mut registry = SourceBackedProviderRegistry::new();
-    register_source(&mut registry, provider, source_format, root);
-    assert_eq!(registry.routes().len(), 1);
-    registry
-}
-
-fn register_source(
-    registry: &mut SourceBackedProviderRegistry,
-    provider: CaptureProvider,
-    source_format: &'static str,
-    root: &Path,
-) {
     register_landed_source_backed_route(
-        registry,
+        &mut registry,
         ProviderSource {
             provider,
             path: root.to_path_buf(),
@@ -72,6 +61,8 @@ fn register_source(
         SourceBackedRouteSelection::Automatic,
     )
     .unwrap();
+    assert_eq!(registry.routes().len(), 1);
+    registry
 }
 
 fn write_transcript(path: &Path, rows: &[Value]) {

--- a/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/claude_cursor.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/claude_cursor.rs
@@ -45,8 +45,19 @@ fn registry(
     root: &Path,
 ) -> SourceBackedProviderRegistry {
     let mut registry = SourceBackedProviderRegistry::new();
+    register_source(&mut registry, provider, source_format, root);
+    assert_eq!(registry.routes().len(), 1);
+    registry
+}
+
+fn register_source(
+    registry: &mut SourceBackedProviderRegistry,
+    provider: CaptureProvider,
+    source_format: &'static str,
+    root: &Path,
+) {
     register_landed_source_backed_route(
-        &mut registry,
+        registry,
         ProviderSource {
             provider,
             path: root.to_path_buf(),
@@ -61,8 +72,6 @@ fn registry(
         SourceBackedRouteSelection::Automatic,
     )
     .unwrap();
-    assert_eq!(registry.routes().len(), 1);
-    registry
 }
 
 fn write_transcript(path: &Path, rows: &[Value]) {
@@ -695,4 +704,180 @@ fn cold_unavailable_configured_claude_home_does_not_block_healthy_peer() {
         .unwrap();
     assert_eq!(personal_root.routes().len(), 1);
     assert!(work_root.routes().is_empty());
+}
+
+#[test]
+fn claude_duplicate_identity_retains_warm_source_atomically_while_sibling_advances_and_repairs() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let projects = temp.path().join("projects");
+    let index = temp.path().join("index");
+    let retained_session = "retained-claude-session";
+    let sibling_session = "advancing-claude-session";
+    let retained_transcript = projects
+        .join("project")
+        .join(format!("{retained_session}.jsonl"));
+    let sibling_transcript = projects
+        .join("project")
+        .join(format!("{sibling_session}.jsonl"));
+    write_transcript(
+        &retained_transcript,
+        &[claude_message(
+            "user",
+            "retained-event",
+            retained_session,
+            "retained before failure",
+        )],
+    );
+    write_transcript(
+        &sibling_transcript,
+        &[claude_message(
+            "user",
+            "sibling-first",
+            sibling_session,
+            "sibling first",
+        )],
+    );
+    let registry = registry(
+        CaptureProvider::Claude,
+        "claude_projects_jsonl_tree",
+        &projects,
+    );
+
+    let initial = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
+    assert!(initial.failed_routes.is_empty());
+    let initial_generation = VerifiedIndex::open(&index)
+        .unwrap()
+        .generation_id()
+        .to_owned();
+    let retained_before = indexed_records(&index, CaptureProvider::Claude, retained_session);
+    assert_literal_bodies(&retained_before, &["retained before failure"]);
+
+    append_transcript(
+        &retained_transcript,
+        &claude_message(
+            "assistant",
+            "retained-event",
+            retained_session,
+            "must never publish partially",
+        ),
+    );
+    append_transcript(
+        &sibling_transcript,
+        &claude_message(
+            "assistant",
+            "sibling-second",
+            sibling_session,
+            "sibling second",
+        ),
+    );
+
+    let quarantined =
+        refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
+    assert!(quarantined.failed_routes.is_empty());
+    assert_eq!(quarantined.logical_source_failures.total(), 1);
+    let [failure] = quarantined.logical_source_failures.failures() else {
+        panic!("one Claude source failure expected");
+    };
+    assert!(failure.carried_forward);
+    assert_eq!(failure.source.provider(), CaptureProvider::Claude.as_str());
+    assert!(failure.detail.contains("repeats a stable event identity"));
+    assert_ne!(
+        VerifiedIndex::open(&index).unwrap().generation_id(),
+        initial_generation
+    );
+    assert_eq!(
+        indexed_records(&index, CaptureProvider::Claude, retained_session),
+        retained_before
+    );
+    assert_literal_bodies(
+        &indexed_records(&index, CaptureProvider::Claude, sibling_session),
+        &["sibling first", "sibling second"],
+    );
+
+    write_transcript(
+        &retained_transcript,
+        &[claude_message(
+            "assistant",
+            "repaired-event",
+            retained_session,
+            "repaired replacement",
+        )],
+    );
+    let repaired = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
+    assert!(repaired.failed_routes.is_empty());
+    assert!(repaired.logical_source_failures.is_empty());
+    assert_literal_bodies(
+        &indexed_records(&index, CaptureProvider::Claude, retained_session),
+        &["repaired replacement"],
+    );
+}
+
+#[test]
+fn cold_bad_claude_leaf_does_not_block_sibling_or_cursor_provider() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let projects = temp.path().join("projects");
+    let cursor_root = temp.path().join("cursor-data");
+    let index = temp.path().join("index");
+    let bad_session = "cold-bad-claude-session";
+    let sibling_session = "cold-good-claude-session";
+    let cursor_session = "cold-good-cursor-session";
+    write_transcript(
+        &projects
+            .join("bad-project")
+            .join(format!("{bad_session}.jsonl")),
+        &[
+            claude_message("user", "duplicate", bad_session, "bad first"),
+            claude_message("assistant", "duplicate", bad_session, "bad second"),
+        ],
+    );
+    write_transcript(
+        &projects
+            .join("good-project")
+            .join(format!("{sibling_session}.jsonl")),
+        &[claude_message(
+            "user",
+            "good-claude",
+            sibling_session,
+            "good Claude sibling",
+        )],
+    );
+    write_transcript(
+        &cursor_root
+            .join("projects/project/agent-transcripts")
+            .join(cursor_session)
+            .join(format!("{cursor_session}.jsonl")),
+        &[cursor_message(
+            "user",
+            "2026-08-23T00:00:00Z",
+            "good Cursor provider",
+        )],
+    );
+    let mut registry = SourceBackedProviderRegistry::new();
+    register_source(
+        &mut registry,
+        CaptureProvider::Claude,
+        "claude_projects_jsonl_tree",
+        &projects,
+    );
+    register_source(
+        &mut registry,
+        CaptureProvider::Cursor,
+        "cursor_agent_transcript_jsonl_tree",
+        &cursor_root,
+    );
+
+    let receipt = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
+    assert!(receipt.failed_routes.is_empty());
+    assert_eq!(receipt.successful_route_ids.len(), 2);
+    assert_eq!(receipt.logical_source_failures.total(), 1);
+    assert!(!receipt.logical_source_failures.failures()[0].carried_forward);
+    assert!(indexed_records(&index, CaptureProvider::Claude, bad_session).is_empty());
+    assert_literal_bodies(
+        &indexed_records(&index, CaptureProvider::Claude, sibling_session),
+        &["good Claude sibling"],
+    );
+    assert_literal_bodies(
+        &indexed_records(&index, CaptureProvider::Cursor, cursor_session),
+        &["good Cursor provider"],
+    );
 }

--- a/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/gemini_retrieval_exclusion.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/gemini_retrieval_exclusion.rs
@@ -709,7 +709,7 @@ fn gemini_legacy_v1_generation_migrates_atomically_to_all_v2_recordings_then_noo
     assert_eq!(migrated.sources.len(), 2);
     assert!(migrated.sources.iter().all(|source| {
         source.observation().source().provider_identity_version() == 2
-            && source.parser_revision() == "gemini-nativepath-core-activity-v2"
+            && source.parser_revision() == "gemini-nativepath-core-activity-v2-record-rejections"
     }));
     let sources = gemini_sources(&index);
     assert_eq!(sources.len(), 2);

--- a/crates/ctx-history-capture-composition-qualification/tests/mistral_vibe_publication.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/mistral_vibe_publication.rs
@@ -40,7 +40,7 @@ const NATIVE_EVENT_REUSED_TOOL_CALL_POSITION_KIND: &str =
     "mistral-vibe-duplicate-tool-call-id-ordinal";
 const LOGICAL_SESSION_KIND: &str = "mistral-vibe-session";
 const LOGICAL_EVENT_KIND: &str = "mistral-vibe-event";
-const PARSER_REVISION: &str = "mistral-vibe-source-backed-v14-optional-admission";
+const PARSER_REVISION: &str = "mistral-vibe-source-backed-v15-optional-admission-record-rejections";
 const PRE_AGENT_SCOPE_PARSER_REVISION: &str = "mistral-vibe-source-backed-v12-core-activity";
 
 fn source_key(native_session_id: &str) -> SourceKey {

--- a/crates/ctx-history-capture-composition/src/source_backed/registration/families/document.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/registration/families/document.rs
@@ -455,71 +455,6 @@ mod tests {
     }
 
     #[test]
-    fn cline_sdk_invalid_catalog_row_preserves_its_peer_and_last_good_source() {
-        let temp = crate::test_support_paths::tempdir().unwrap();
-        let provider_root = temp.path().join("cline-data");
-        let ctx_data_root = temp.path().join("ctx-data");
-        let index = temp.path().join("index");
-        fs::create_dir_all(provider_root.join("sessions")).unwrap();
-        fs::create_dir_all(&ctx_data_root).unwrap();
-        write_cline_sdk_two_session_index(&provider_root, None);
-        write_cline_sdk_session_messages(&provider_root, "broken", &["broken old"]);
-        write_cline_sdk_session_messages(&provider_root, "healthy", &["healthy old"]);
-        let registry = cline_sdk_registry(&provider_root, &ctx_data_root);
-
-        let cold =
-            refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
-        write_cline_sdk_two_session_index(&provider_root, Some("../../outside.messages.json"));
-        write_cline_sdk_session_messages(&provider_root, "healthy", &["healthy new"]);
-        let degraded =
-            refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
-
-        assert_ne!(degraded.commit.generation_id, cold.commit.generation_id);
-        assert_eq!(degraded.logical_source_failures.total(), 1);
-        assert!(degraded.logical_source_failures.failures()[0].carried_forward);
-        assert_eq!(
-            cline_sdk_message_bodies(&index, &degraded),
-            vec![
-                ("broken".to_owned(), "broken old".to_owned()),
-                ("healthy".to_owned(), "healthy new".to_owned()),
-            ]
-        );
-
-        write_cline_sdk_two_session_index(&provider_root, None);
-        write_cline_sdk_session_messages(&provider_root, "broken", &["broken repaired"]);
-        let repaired =
-            refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
-        assert!(repaired.logical_source_failures.is_empty());
-        assert_eq!(
-            cline_sdk_message_bodies(&index, &repaired),
-            vec![
-                ("broken".to_owned(), "broken repaired".to_owned()),
-                ("healthy".to_owned(), "healthy new".to_owned()),
-            ]
-        );
-
-        let cold_root = temp.path().join("cold-cline-data");
-        let cold_ctx_data_root = temp.path().join("cold-ctx-data");
-        let cold_index = temp.path().join("cold-index");
-        fs::create_dir_all(cold_root.join("sessions")).unwrap();
-        fs::create_dir_all(&cold_ctx_data_root).unwrap();
-        write_cline_sdk_two_session_index(&cold_root, Some("../../outside.messages.json"));
-        write_cline_sdk_session_messages(&cold_root, "healthy", &["cold healthy"]);
-        let isolated = refresh_source_backed_generation(
-            &cold_index,
-            &cline_sdk_registry(&cold_root, &cold_ctx_data_root),
-            WriterOptions::default(),
-        )
-        .unwrap();
-        assert_eq!(isolated.logical_source_failures.total(), 1);
-        assert!(!isolated.logical_source_failures.failures()[0].carried_forward);
-        assert_eq!(
-            cline_sdk_message_bodies(&cold_index, &isolated),
-            vec![("healthy".to_owned(), "cold healthy".to_owned())]
-        );
-    }
-
-    #[test]
     fn cline_sdk_real_automatic_and_exact_discovery_import_the_common_data_root() {
         let temp = crate::test_support_paths::tempdir().unwrap();
         let home = temp.path().join("home");
@@ -757,95 +692,30 @@ mod tests {
     }
 
     fn write_cline_sdk_messages(root: &Path, bodies: &[&str]) {
-        write_cline_sdk_session_messages_with_id_prefix(root, "session-a", "message", bodies);
-    }
-
-    fn write_cline_sdk_two_session_index(root: &Path, broken_messages_path: Option<&str>) {
-        let mut broken = serde_json::json!({
-            "sessionId": "broken",
-            "model": "cline-model",
-            "cwd": "/fixture/cwd"
-        });
-        if let Some(path) = broken_messages_path {
-            broken["messagesPath"] = serde_json::Value::String(path.to_owned());
-        }
-        fs::write(
-            root.join("sessions/sessions.index.json"),
-            serde_json::to_vec(&serde_json::json!({
-                "version": 1,
-                "sessions": {
-                    "broken": broken,
-                    "healthy": {
-                        "sessionId": "healthy",
-                        "model": "cline-model",
-                        "cwd": "/fixture/cwd"
-                    }
-                }
-            }))
-            .unwrap(),
-        )
-        .unwrap();
-    }
-
-    fn write_cline_sdk_session_messages(root: &Path, session_id: &str, bodies: &[&str]) {
-        write_cline_sdk_session_messages_with_id_prefix(
-            root,
-            session_id,
-            &format!("message-{session_id}"),
-            bodies,
-        );
-    }
-
-    fn write_cline_sdk_session_messages_with_id_prefix(
-        root: &Path,
-        session_id: &str,
-        message_id_prefix: &str,
-        bodies: &[&str],
-    ) {
         let messages = bodies
             .iter()
             .enumerate()
             .map(|(index, body)| {
                 serde_json::json!({
-                    "id": format!("{message_id_prefix}-{index}"),
+                    "id": format!("message-{index}"),
                     "role": if index == 0 { "user" } else { "assistant" },
                     "content": [{"type": "text", "text": body}]
                 })
             })
             .collect::<Vec<_>>();
-        let directory = root.join("sessions").join(session_id);
-        fs::create_dir_all(&directory).unwrap();
         fs::write(
-            directory.join(format!("{session_id}.messages.json")),
+            root.join("sessions/session-a/session-a.messages.json"),
             serde_json::to_vec(&serde_json::json!({
                 "version": 1,
                 "updated_at": "2026-08-18T12:00:00Z",
                 "agent": "lead",
-                "sessionId": session_id,
+                "sessionId": "session-a",
                 "system_prompt": "You are Cline.",
                 "messages": messages
             }))
             .unwrap(),
         )
         .unwrap();
-    }
-
-    fn cline_sdk_message_bodies(
-        index: &Path,
-        receipt: &SourceBackedRefreshReceipt,
-    ) -> Vec<(String, String)> {
-        let mut bodies = cline_sdk_events(index, receipt)
-            .into_iter()
-            .filter(|event| event.event_sequence > 0)
-            .map(|event| {
-                (
-                    event.provider_session_id.clone().unwrap(),
-                    event.core_record.content.meaningful_text().to_owned(),
-                )
-            })
-            .collect::<Vec<_>>();
-        bodies.sort();
-        bodies
     }
 
     fn cline_sdk_events(

--- a/crates/ctx-history-capture-composition/src/source_backed/registration/families/document.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/registration/families/document.rs
@@ -455,6 +455,71 @@ mod tests {
     }
 
     #[test]
+    fn cline_sdk_invalid_catalog_row_preserves_its_peer_and_last_good_source() {
+        let temp = crate::test_support_paths::tempdir().unwrap();
+        let provider_root = temp.path().join("cline-data");
+        let ctx_data_root = temp.path().join("ctx-data");
+        let index = temp.path().join("index");
+        fs::create_dir_all(provider_root.join("sessions")).unwrap();
+        fs::create_dir_all(&ctx_data_root).unwrap();
+        write_cline_sdk_two_session_index(&provider_root, None);
+        write_cline_sdk_session_messages(&provider_root, "broken", &["broken old"]);
+        write_cline_sdk_session_messages(&provider_root, "healthy", &["healthy old"]);
+        let registry = cline_sdk_registry(&provider_root, &ctx_data_root);
+
+        let cold =
+            refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
+        write_cline_sdk_two_session_index(&provider_root, Some("../../outside.messages.json"));
+        write_cline_sdk_session_messages(&provider_root, "healthy", &["healthy new"]);
+        let degraded =
+            refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
+
+        assert_ne!(degraded.commit.generation_id, cold.commit.generation_id);
+        assert_eq!(degraded.logical_source_failures.total(), 1);
+        assert!(degraded.logical_source_failures.failures()[0].carried_forward);
+        assert_eq!(
+            cline_sdk_message_bodies(&index, &degraded),
+            vec![
+                ("broken".to_owned(), "broken old".to_owned()),
+                ("healthy".to_owned(), "healthy new".to_owned()),
+            ]
+        );
+
+        write_cline_sdk_two_session_index(&provider_root, None);
+        write_cline_sdk_session_messages(&provider_root, "broken", &["broken repaired"]);
+        let repaired =
+            refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
+        assert!(repaired.logical_source_failures.is_empty());
+        assert_eq!(
+            cline_sdk_message_bodies(&index, &repaired),
+            vec![
+                ("broken".to_owned(), "broken repaired".to_owned()),
+                ("healthy".to_owned(), "healthy new".to_owned()),
+            ]
+        );
+
+        let cold_root = temp.path().join("cold-cline-data");
+        let cold_ctx_data_root = temp.path().join("cold-ctx-data");
+        let cold_index = temp.path().join("cold-index");
+        fs::create_dir_all(cold_root.join("sessions")).unwrap();
+        fs::create_dir_all(&cold_ctx_data_root).unwrap();
+        write_cline_sdk_two_session_index(&cold_root, Some("../../outside.messages.json"));
+        write_cline_sdk_session_messages(&cold_root, "healthy", &["cold healthy"]);
+        let isolated = refresh_source_backed_generation(
+            &cold_index,
+            &cline_sdk_registry(&cold_root, &cold_ctx_data_root),
+            WriterOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(isolated.logical_source_failures.total(), 1);
+        assert!(!isolated.logical_source_failures.failures()[0].carried_forward);
+        assert_eq!(
+            cline_sdk_message_bodies(&cold_index, &isolated),
+            vec![("healthy".to_owned(), "cold healthy".to_owned())]
+        );
+    }
+
+    #[test]
     fn cline_sdk_real_automatic_and_exact_discovery_import_the_common_data_root() {
         let temp = crate::test_support_paths::tempdir().unwrap();
         let home = temp.path().join("home");
@@ -692,30 +757,95 @@ mod tests {
     }
 
     fn write_cline_sdk_messages(root: &Path, bodies: &[&str]) {
+        write_cline_sdk_session_messages_with_id_prefix(root, "session-a", "message", bodies);
+    }
+
+    fn write_cline_sdk_two_session_index(root: &Path, broken_messages_path: Option<&str>) {
+        let mut broken = serde_json::json!({
+            "sessionId": "broken",
+            "model": "cline-model",
+            "cwd": "/fixture/cwd"
+        });
+        if let Some(path) = broken_messages_path {
+            broken["messagesPath"] = serde_json::Value::String(path.to_owned());
+        }
+        fs::write(
+            root.join("sessions/sessions.index.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "version": 1,
+                "sessions": {
+                    "broken": broken,
+                    "healthy": {
+                        "sessionId": "healthy",
+                        "model": "cline-model",
+                        "cwd": "/fixture/cwd"
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn write_cline_sdk_session_messages(root: &Path, session_id: &str, bodies: &[&str]) {
+        write_cline_sdk_session_messages_with_id_prefix(
+            root,
+            session_id,
+            &format!("message-{session_id}"),
+            bodies,
+        );
+    }
+
+    fn write_cline_sdk_session_messages_with_id_prefix(
+        root: &Path,
+        session_id: &str,
+        message_id_prefix: &str,
+        bodies: &[&str],
+    ) {
         let messages = bodies
             .iter()
             .enumerate()
             .map(|(index, body)| {
                 serde_json::json!({
-                    "id": format!("message-{index}"),
+                    "id": format!("{message_id_prefix}-{index}"),
                     "role": if index == 0 { "user" } else { "assistant" },
                     "content": [{"type": "text", "text": body}]
                 })
             })
             .collect::<Vec<_>>();
+        let directory = root.join("sessions").join(session_id);
+        fs::create_dir_all(&directory).unwrap();
         fs::write(
-            root.join("sessions/session-a/session-a.messages.json"),
+            directory.join(format!("{session_id}.messages.json")),
             serde_json::to_vec(&serde_json::json!({
                 "version": 1,
                 "updated_at": "2026-08-18T12:00:00Z",
                 "agent": "lead",
-                "sessionId": "session-a",
+                "sessionId": session_id,
                 "system_prompt": "You are Cline.",
                 "messages": messages
             }))
             .unwrap(),
         )
         .unwrap();
+    }
+
+    fn cline_sdk_message_bodies(
+        index: &Path,
+        receipt: &SourceBackedRefreshReceipt,
+    ) -> Vec<(String, String)> {
+        let mut bodies = cline_sdk_events(index, receipt)
+            .into_iter()
+            .filter(|event| event.event_sequence > 0)
+            .map(|event| {
+                (
+                    event.provider_session_id.clone().unwrap(),
+                    event.core_record.content.meaningful_text().to_owned(),
+                )
+            })
+            .collect::<Vec<_>>();
+        bodies.sort();
+        bodies
     }
 
     fn cline_sdk_events(

--- a/crates/ctx-history-capture-runtime/src/source_backed/document/sink.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/document/sink.rs
@@ -150,6 +150,10 @@ where
         self.record_rejections.merge(rejections);
     }
 
+    pub fn record_rejection(&mut self, rejection: SourceBackedRecordRejectionDraft) {
+        self.record_rejections.record(rejection);
+    }
+
     pub(super) fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
         std::mem::take(&mut self.record_rejections)
     }

--- a/crates/ctx-history-jsonl/src/family.rs
+++ b/crates/ctx-history-jsonl/src/family.rs
@@ -182,10 +182,10 @@ pub use route::{
     JsonlFamilyInventory, JsonlFamilyInventoryMember, JsonlFamilyInventoryMode, JsonlFamilyLeaf,
     JsonlFamilyLeafDisposition, JsonlFamilyMembershipObservation, JsonlFamilyOpenedMember,
     JsonlFamilyOptimizedLeafOutcome, JsonlFamilyPendingLeaf, JsonlFamilyPhysicalSourceIdentity,
-    JsonlFamilyProjectionMode, JsonlFamilyProjector, JsonlFamilyPublication,
-    JsonlFamilyRejectedLeaf, JsonlFamilyRootMissingMode, JsonlFamilySemanticExecutor,
-    JsonlFamilySemanticPage, JsonlFamilySemanticPreflight, JsonlFamilySemanticSummary,
-    JsonlFamilyTerminalProof, JsonlFamilyWorkerContext,
+    JsonlFamilyProjectionMode, JsonlFamilyProjector, JsonlFamilyProjectorPreflightError,
+    JsonlFamilyPublication, JsonlFamilyRejectedLeaf, JsonlFamilyRootMissingMode,
+    JsonlFamilySemanticExecutor, JsonlFamilySemanticPage, JsonlFamilySemanticPreflight,
+    JsonlFamilySemanticSummary, JsonlFamilyTerminalProof, JsonlFamilyWorkerContext,
 };
 pub use single_file::jsonl_single_file_inventory;
 const PAGE_MAX_RECORDS: usize = 64;

--- a/crates/ctx-history-jsonl/src/family.rs
+++ b/crates/ctx-history-jsonl/src/family.rs
@@ -8,6 +8,10 @@ use std::{
 use sha2::{Digest, Sha256};
 
 use ctx_history_capture_runtime::{CaptureLifecycleSink, SourceBackedRouteDriver};
+pub use ctx_history_capture_runtime::{
+    SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDraft,
+    SourceBackedRecordRejectionDrafts,
+};
 use ctx_history_source_io::{
     MappedOpenedProviderSourceFile, MappedOpenedProviderSourcePath, MappedProviderSourceDirectory,
     MappedProviderSourceRoot, SourceIoError, MAX_PROVIDER_JSONL_LINE_BYTES,

--- a/crates/ctx-history-jsonl/src/family.rs
+++ b/crates/ctx-history-jsonl/src/family.rs
@@ -21,6 +21,7 @@ mod checkpoint;
 mod framing;
 mod identity;
 mod physical;
+mod rejections;
 mod revalidation;
 mod route;
 mod single_file;
@@ -159,6 +160,7 @@ pub use physical::{
     MAX_STANDARD_ZSTD_DECOMPRESSED_BYTES, MAX_STANDARD_ZSTD_PARALLEL_STREAMS,
     MAX_STANDARD_ZSTD_TEMP_BYTES_PER_LEAF,
 };
+pub use rejections::JsonlRecordRejections;
 use revalidation::hash_prefix;
 pub use revalidation::revalidate_frozen_prefix;
 pub(crate) use revalidation::{

--- a/crates/ctx-history-jsonl/src/family/rejections.rs
+++ b/crates/ctx-history-jsonl/src/family/rejections.rs
@@ -1,0 +1,110 @@
+use ctx_history_capture_runtime::{
+    SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDraft,
+    SourceBackedRecordRejectionDrafts,
+};
+use ctx_history_core::{CaptureProvider, SourceKey};
+
+use super::JsonlRecordRef;
+
+/// Bounded diagnostics and exact aggregate count for rejected JSONL records.
+#[derive(Debug)]
+pub struct JsonlRecordRejections {
+    source: SourceKey,
+    provider: CaptureProvider,
+    source_selector: String,
+    count: u64,
+    drafts: SourceBackedRecordRejectionDrafts,
+}
+
+impl JsonlRecordRejections {
+    pub fn new(
+        source: SourceKey,
+        provider: CaptureProvider,
+        source_selector: impl Into<String>,
+    ) -> Self {
+        Self {
+            source,
+            provider,
+            source_selector: source_selector.into(),
+            count: 0,
+            drafts: SourceBackedRecordRejectionDrafts::default(),
+        }
+    }
+
+    pub fn record(
+        &mut self,
+        record: JsonlRecordRef<'_>,
+        class: SourceBackedRecordRejectionClass,
+        detail: impl Into<String>,
+    ) {
+        self.count = self.count.saturating_add(1);
+        self.drafts.record(SourceBackedRecordRejectionDraft {
+            source: self.source.clone(),
+            provider: self.provider,
+            source_selector: self.source_selector.clone(),
+            line_number: record.evidence().physical_ordinal().saturating_add(1),
+            payload_type: None,
+            class,
+            detail: detail.into(),
+        });
+    }
+
+    pub fn malformed(&mut self, record: JsonlRecordRef<'_>, detail: impl Into<String>) {
+        self.record(
+            record,
+            SourceBackedRecordRejectionClass::MalformedRecord,
+            detail,
+        );
+    }
+
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    pub fn take_drafts(&mut self) -> SourceBackedRecordRejectionDrafts {
+        std::mem::take(&mut self.drafts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_exact_count_while_diagnostics_are_drained() {
+        let source = SourceKey::derive(
+            "pi",
+            "test-jsonl",
+            "test-v1",
+            1,
+            ctx_history_core::SourceAnchor::provider_native(
+                "test.source",
+                ctx_history_core::TypedKey::utf8("source").unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let mut rejections = JsonlRecordRejections::new(
+            source.clone(),
+            CaptureProvider::Pi,
+            "/provider/source.jsonl",
+        );
+
+        rejections.malformed(JsonlRecordRef::for_test(b"{", 4), "malformed test row");
+
+        assert_eq!(rejections.count(), 1);
+        let (drafts, omitted) = rejections.take_drafts().into_parts();
+        assert_eq!(drafts.len(), 1);
+        assert_eq!(omitted, 0);
+        assert_eq!(drafts[0].source, source);
+        assert_eq!(drafts[0].line_number, 5);
+        assert_eq!(
+            drafts[0].class,
+            SourceBackedRecordRejectionClass::MalformedRecord
+        );
+        let (drained, omitted) = rejections.take_drafts().into_parts();
+        assert!(drained.is_empty());
+        assert_eq!(omitted, 0);
+        assert_eq!(rejections.count(), 1);
+    }
+}

--- a/crates/ctx-history-jsonl/src/family/route.rs
+++ b/crates/ctx-history-jsonl/src/family/route.rs
@@ -70,7 +70,7 @@ use ownership::base_sources_for_root;
 mod membership;
 pub use membership::{JsonlFamilyAppendTrustContract, JsonlFamilyMembershipObservation};
 mod projector;
-pub use projector::JsonlFamilyProjector;
+pub use projector::{JsonlFamilyProjector, JsonlFamilyProjectorPreflightError};
 mod resident;
 use resident::{AuthenticatedSourceObservation, FamilyResident};
 mod revalidation;

--- a/crates/ctx-history-jsonl/src/family/route/capture.rs
+++ b/crates/ctx-history-jsonl/src/family/route/capture.rs
@@ -369,11 +369,15 @@ pub(super) fn capture<R: JsonlFamilyRuntime>(
         .members()
         .iter()
         .filter_map(|member| match member {
-            JsonlFamilyInventoryMember::Quarantined { leaf, .. } => Some((
-                leaf.source_path.as_path(),
-                leaf.authority_path.as_path(),
-                &leaf.observation,
-            )),
+            JsonlFamilyInventoryMember::Quarantined { leaf, .. } => {
+                leaf.observation.as_ref().map(|observation| {
+                    (
+                        leaf.source_path.as_path(),
+                        leaf.authority_path.as_path(),
+                        observation,
+                    )
+                })
+            }
             JsonlFamilyInventoryMember::Pending { leaf, .. } => Some((
                 leaf.source_path.as_path(),
                 leaf.authority_path.as_path(),
@@ -592,27 +596,33 @@ fn classify_incomplete_first_records<R: JsonlFamilyRuntime>(
                 });
             }
             JsonlFamilyInventoryMember::Quarantined { identity, leaf } => {
-                let authority = exact_member_authority(
-                    &opening.authorities,
-                    &leaf.source_path,
-                    &leaf.authority_path,
-                )?;
-                if first_record_is_incomplete(
-                    &leaf.source_path,
-                    authority,
-                    &leaf.authority_path,
-                    &leaf.observation,
-                    leaf.physical_encoding,
-                    adapter.record_framing(),
-                    false,
-                )? {
+                let incomplete = if let Some(observation) = &leaf.observation {
+                    let authority = exact_member_authority(
+                        &opening.authorities,
+                        &leaf.source_path,
+                        &leaf.authority_path,
+                    )?;
+                    first_record_is_incomplete(
+                        &leaf.source_path,
+                        authority,
+                        &leaf.authority_path,
+                        observation,
+                        leaf.physical_encoding,
+                        adapter.record_framing(),
+                        false,
+                    )?
+                } else {
+                    false
+                };
+                if incomplete {
                     changed = true;
                     classified.push(JsonlFamilyInventoryMember::Pending {
                         identity,
                         leaf: JsonlFamilyPendingLeaf::bind_observed(
                             leaf.source_path,
                             leaf.authority_path,
-                            leaf.observation,
+                            leaf.observation
+                                .expect("incomplete quarantined leaf has an admitted observation"),
                             leaf.proof,
                             leaf.quarantined_source,
                         ),

--- a/crates/ctx-history-jsonl/src/family/route/capture.rs
+++ b/crates/ctx-history-jsonl/src/family/route/capture.rs
@@ -195,9 +195,11 @@ pub(super) fn capture<R: JsonlFamilyRuntime>(
     let opening_membership = adapter
         .observe_terminal_membership(root, &opening)
         .map_err(|error| route_discovery(adapter, error))?;
+    // A rejected member with exact quarantine ownership belongs to a
+    // source-local failure even when a peer member owns the one diagnostic.
     let route_fatal_rejected = opening
         .quarantined_leaves()
-        .filter(|leaf| leaf.logical_source_failure.is_none())
+        .filter(|leaf| leaf.logical_source_failure.is_none() && leaf.quarantined_source.is_none())
         .collect::<Vec<_>>();
     if opening.accepted_len() == 0 && !route_fatal_rejected.is_empty() && bases.is_empty() {
         let rejected_records = route_fatal_rejected.iter().try_fold(0_u64, |total, leaf| {
@@ -560,7 +562,7 @@ pub(super) fn capture<R: JsonlFamilyRuntime>(
 /// classification. A nonempty first record without its framing terminator is
 /// pending/incomplete; zero-byte files and complete malformed records retain
 /// their existing provider semantics.
-fn classify_incomplete_first_records<R: JsonlFamilyRuntime>(
+pub(super) fn classify_incomplete_first_records<R: JsonlFamilyRuntime>(
     adapter: &dyn JsonlFamilyAdapter<Runtime = R>,
     opening: &mut JsonlFamilyInventory<JsonlRuntimeError<R>>,
 ) -> JsonlResult<(), JsonlRuntimeError<R>> {
@@ -596,7 +598,11 @@ fn classify_incomplete_first_records<R: JsonlFamilyRuntime>(
                 });
             }
             JsonlFamilyInventoryMember::Quarantined { identity, leaf } => {
-                let incomplete = if let Some(observation) = &leaf.observation {
+                // Provider classification wins once a member owns a diagnosed
+                // source failure; a framing probe must not erase that outcome.
+                let incomplete = if leaf.logical_source_failure.is_some() {
+                    false
+                } else if let Some(observation) = &leaf.observation {
                     let authority = exact_member_authority(
                         &opening.authorities,
                         &leaf.source_path,

--- a/crates/ctx-history-jsonl/src/family/route/capture.rs
+++ b/crates/ctx-history-jsonl/src/family/route/capture.rs
@@ -221,10 +221,13 @@ pub(super) fn capture<R: JsonlFamilyRuntime>(
         if let Some((source, detail)) = &rejected.logical_source_failure {
             let failure =
                 SourceBackedRouteError::new(SourceBackedRouteErrorKind::InvalidSource, detail);
+            let carried_forward = bases
+                .iter()
+                .any(|base| base.observation().source().exact_descriptor_eq(source));
             if adapter.provider() == CaptureProvider::Codex {
                 sink.record_logical_source_quarantine(source.clone(), failure)
             } else {
-                sink.record_logical_source_failure(source.clone(), failure, false)
+                sink.record_logical_source_failure(source.clone(), failure, carried_forward)
             }
             .map_err(route_internal)?;
         }
@@ -403,10 +406,19 @@ pub(super) fn capture<R: JsonlFamilyRuntime>(
             SourceBackedRouteErrorKind::InvalidSource,
             &quarantined.detail,
         );
+        let carried_forward = bases.iter().any(|base| {
+            base.observation()
+                .source()
+                .exact_descriptor_eq(&quarantined.failure_source)
+        });
         if adapter.provider() == CaptureProvider::Codex {
             sink.record_logical_source_quarantine(quarantined.failure_source.clone(), failure)
         } else {
-            sink.record_logical_source_failure(quarantined.failure_source.clone(), failure, false)
+            sink.record_logical_source_failure(
+                quarantined.failure_source.clone(),
+                failure,
+                carried_forward,
+            )
         }
         .map_err(route_internal)?;
     }

--- a/crates/ctx-history-jsonl/src/family/route/leaf/prepare.rs
+++ b/crates/ctx-history-jsonl/src/family/route/leaf/prepare.rs
@@ -1,3 +1,4 @@
+use super::super::JsonlFamilyProjectorPreflightError;
 use super::*;
 
 #[cfg(test)]
@@ -276,22 +277,47 @@ pub(in super::super) fn prepare_leaf_with_resources<R: JsonlFamilyRuntime>(
         base.is_some().then(|| base_event_lookup.clone()),
         projection_mode,
     )?;
+    let mut logical_source_quarantine = None;
     if projector_preflight {
         let initial = reader.execution_position()?;
-        let retry = projector.preflight(
+        let retry = match projector.preflight_with_failure_scope(
             &mut reader,
             resumed.map(|checkpoint| checkpoint.physical.complete_prefix_end()),
-        )?;
-        let physical_ready = reader.settle_semantic_preflight(initial, !retry, true)?;
-        if (retry || !physical_ready) && !is_append {
-            return Err(JsonlRuntimeError::<R>::system_invariant(
-                "JSONL projector replaced a non-append",
-            ));
-        }
-        if retry || !physical_ready {
-            projector.retry_replacement();
+        ) {
+            Ok(retry) => retry,
+            Err(JsonlFamilyProjectorPreflightError::RecordRejection { .. }) => {
+                return Err(JsonlRuntimeError::<R>::system_invariant(
+                    "JSONL projector leaked a record rejection from preflight",
+                ));
+            }
+            Err(JsonlFamilyProjectorPreflightError::LogicalSourceFailure { source, detail }) => {
+                if !source.exact_descriptor_eq(leaf.source()) {
+                    return Err(JsonlRuntimeError::<R>::system_invariant(
+                        "JSONL projector failed another logical source",
+                    ));
+                }
+                logical_source_quarantine = Some((source, detail));
+                false
+            }
+            Err(JsonlFamilyProjectorPreflightError::Internal(error)) => return Err(error),
+        };
+        let source_failed = logical_source_quarantine.is_some();
+        let physical_ready =
+            reader.settle_semantic_preflight(initial, !retry && !source_failed, true)?;
+        if source_failed {
             resumed = None;
             is_append = false;
+        } else {
+            if (retry || !physical_ready) && !is_append {
+                return Err(JsonlRuntimeError::<R>::system_invariant(
+                    "JSONL projector replaced a non-append",
+                ));
+            }
+            if retry || !physical_ready {
+                projector.retry_replacement();
+                resumed = None;
+                is_append = false;
+            }
         }
     }
     let mut physical_records = resumed.map_or_else(
@@ -309,20 +335,22 @@ pub(in super::super) fn prepare_leaf_with_resources<R: JsonlFamilyRuntime>(
     loop {
         let page = reader.visit_page(&mut |record| -> JsonlResult<(), JsonlRuntimeError<R>> {
             physical_records = checked_increment::<JsonlRuntimeError<R>>(physical_records)?;
-            let before = documents;
-            projector.project(record, worker, &mut |core_record| {
-                if !core_record.source.exact_descriptor_eq(leaf.source()) {
-                    return Err(JsonlRuntimeError::<R>::invalid_payload(
-                        "JSONL projector changed the bound source".to_owned(),
-                    ));
+            if logical_source_quarantine.is_none() {
+                let before = documents;
+                projector.project(record, worker, &mut |core_record| {
+                    if !core_record.source.exact_descriptor_eq(leaf.source()) {
+                        return Err(JsonlRuntimeError::<R>::invalid_payload(
+                            "JSONL projector changed the bound source".to_owned(),
+                        ));
+                    }
+                    output.emit_record(is_append, core_record)?;
+                    documents = checked_increment::<JsonlRuntimeError<R>>(documents)?;
+                    Ok(())
+                })?;
+                if documents != before {
+                    represented_records =
+                        checked_increment::<JsonlRuntimeError<R>>(represented_records)?;
                 }
-                output.emit_record(is_append, core_record)?;
-                documents = checked_increment::<JsonlRuntimeError<R>>(documents)?;
-                Ok(())
-            })?;
-            if documents != before {
-                represented_records =
-                    checked_increment::<JsonlRuntimeError<R>>(represented_records)?;
             }
             Ok(())
         })?;
@@ -332,27 +360,39 @@ pub(in super::super) fn prepare_leaf_with_resources<R: JsonlFamilyRuntime>(
         }
     }
     let before_finish = documents;
-    projector.finish_projecting(worker, &mut |core_record| {
-        if !core_record.source.exact_descriptor_eq(leaf.source()) {
-            return Err(JsonlRuntimeError::<R>::invalid_payload(
-                "JSONL projector changed the bound source".to_owned(),
-            ));
-        }
-        output.emit_record(is_append, core_record)?;
-        documents = checked_increment::<JsonlRuntimeError<R>>(documents)?;
-        Ok(())
-    })?;
+    if logical_source_quarantine.is_none() {
+        projector.finish_projecting(worker, &mut |core_record| {
+            if !core_record.source.exact_descriptor_eq(leaf.source()) {
+                return Err(JsonlRuntimeError::<R>::invalid_payload(
+                    "JSONL projector changed the bound source".to_owned(),
+                ));
+            }
+            output.emit_record(is_append, core_record)?;
+            documents = checked_increment::<JsonlRuntimeError<R>>(documents)?;
+            Ok(())
+        })?;
+    }
     output.flush()?;
     let rejected_records = resumed
         .map_or(leaf.identity_probe_rejected_records, |checkpoint| {
             checkpoint.rejected_records
         })
-        .checked_add(projector.rejected_records())
+        .checked_add(if logical_source_quarantine.is_some() {
+            0
+        } else {
+            projector.rejected_records()
+        })
         .ok_or_else(|| {
             JsonlRuntimeError::<R>::invalid_payload("JSONL rejected count overflowed".to_owned())
         })?;
-    let record_rejections = projector.take_record_rejections();
-    let provider_checkpoint = projector.provider_checkpoint()?;
+    let (record_rejections, provider_checkpoint) = if logical_source_quarantine.is_some() {
+        (SourceBackedRecordRejectionDrafts::default(), None)
+    } else {
+        (
+            projector.take_record_rejections(),
+            projector.provider_checkpoint()?,
+        )
+    };
     if documents != before_finish {
         represented_records = physical_records;
     }
@@ -442,6 +482,6 @@ pub(in super::super) fn prepare_leaf_with_resources<R: JsonlFamilyRuntime>(
         append,
         terminal_proof,
         record_rejections,
-        logical_source_quarantine: None,
+        logical_source_quarantine,
     })
 }

--- a/crates/ctx-history-jsonl/src/family/route/leaf/prepare.rs
+++ b/crates/ctx-history-jsonl/src/family/route/leaf/prepare.rs
@@ -296,7 +296,7 @@ pub(in super::super) fn prepare_leaf_with_resources<R: JsonlFamilyRuntime>(
                         "JSONL projector failed another logical source",
                     ));
                 }
-                logical_source_quarantine = Some((source, detail));
+                logical_source_quarantine = Some((*source, detail));
                 false
             }
             Err(JsonlFamilyProjectorPreflightError::Internal(error)) => return Err(error),

--- a/crates/ctx-history-jsonl/src/family/route/member.rs
+++ b/crates/ctx-history-jsonl/src/family/route/member.rs
@@ -70,7 +70,9 @@ impl JsonlFamilyRejectedLeaf {
     /// Binds the exact provider source claimed by this physical member.
     /// Core may also fill this from an exact prior certificate at the same
     /// path. It is retention/retry authority only and never admits rejected
-    /// bytes to the certified inventory.
+    /// bytes to the certified inventory. When several conflicting physical
+    /// members claim one source, every member carries this authority while one
+    /// deterministic member carries the logical-source diagnostic.
     pub fn with_quarantined_source(mut self, source: SourceKey) -> Self {
         self.quarantined_source = Some(source);
         self

--- a/crates/ctx-history-jsonl/src/family/route/member.rs
+++ b/crates/ctx-history-jsonl/src/family/route/member.rs
@@ -4,7 +4,7 @@ use super::*;
 pub struct JsonlFamilyRejectedLeaf {
     pub(super) source_path: PathBuf,
     pub(super) authority_path: PathBuf,
-    pub(super) observation: JsonlFileObservation,
+    pub(super) observation: Option<JsonlFileObservation>,
     pub(super) proof: TypedKey,
     pub(super) rejected_records: u64,
     pub(super) logical_source_failure: Option<(SourceKey, String)>,
@@ -23,7 +23,28 @@ impl JsonlFamilyRejectedLeaf {
         Self {
             source_path,
             authority_path,
-            observation,
+            observation: Some(observation),
+            proof,
+            rejected_records,
+            logical_source_failure: None,
+            quarantined_source: None,
+            physical_encoding: JsonlPhysicalEncoding::RawJsonl,
+        }
+    }
+
+    /// Binds a selected physical member that could not be opened or observed.
+    /// The retained root authority and terminal membership observation fence
+    /// publication; no unread bytes are admitted as source evidence.
+    pub fn bind_unobserved(
+        source_path: PathBuf,
+        authority_path: PathBuf,
+        proof: TypedKey,
+        rejected_records: u64,
+    ) -> Self {
+        Self {
+            source_path,
+            authority_path,
+            observation: None,
             proof,
             rejected_records,
             logical_source_failure: None,

--- a/crates/ctx-history-jsonl/src/family/route/membership.rs
+++ b/crates/ctx-history-jsonl/src/family/route/membership.rs
@@ -25,6 +25,8 @@ struct JsonlFamilyMembershipRoute<E: JsonlFamilyError> {
     authority_path: PathBuf,
 }
 
+type UnobservedMembershipRoutes = BTreeMap<PathBuf, BTreeSet<PathBuf>>;
+
 impl<E: JsonlFamilyError> JsonlFamilyMembershipObservation<E> {
     pub fn observe(root: &Path, opening: &JsonlFamilyInventory<E>) -> JsonlResult<Self, E> {
         if opening.root_missing {
@@ -52,9 +54,10 @@ impl<E: JsonlFamilyError> JsonlFamilyMembershipObservation<E> {
 
     pub fn observe_authorities(opening: &JsonlFamilyInventory<E>) -> JsonlResult<Self, E> {
         let mut state = JsonlFamilyMembershipState::default();
+        let unobserved_routes = unobserved_membership_routes(opening)?;
         for authority in &opening.authorities {
             let directory = authority.directory()?;
-            observe_membership_directory(&directory, 0, &mut state)?;
+            observe_membership_directory(&directory, 0, &mut state, &unobserved_routes)?;
             authority.revalidate_same_object()?;
         }
         Self::from_routes(state.routes, opening)
@@ -97,9 +100,16 @@ impl<E: JsonlFamilyError> JsonlFamilyMembershipObservation<E> {
                 "JSONL membership path depth exceeds the provider inventory bound".to_owned(),
             ));
         }
-        let opened = authority.open_file(authority_path)?;
-        opened.revalidate_same_object()?;
         let mut routes = BTreeMap::new();
+        if matches!(
+            member,
+            JsonlFamilyInventoryMember::Quarantined { leaf, .. } if leaf.observation.is_none()
+        ) {
+            observe_unopened_member(&authority, authority_path)?;
+        } else {
+            let opened = authority.open_file(authority_path)?;
+            opened.revalidate_same_object()?;
+        }
         routes.insert(
             source_path.to_path_buf(),
             JsonlFamilyMembershipRoute {
@@ -216,6 +226,7 @@ fn observe_membership_directory<E: JsonlFamilyError>(
     directory: &ProviderSourceDirectory<E>,
     depth: usize,
     state: &mut JsonlFamilyMembershipState<E>,
+    unobserved_routes: &UnobservedMembershipRoutes,
 ) -> JsonlResult<(), E> {
     if depth > PROVIDER_JSONL_INVENTORY_MAX_DEPTH {
         return Err(E::invalid_payload(
@@ -248,6 +259,27 @@ fn observe_membership_directory<E: JsonlFamilyError>(
         let authority = directory.authority_root();
         let source_path = authority.named_path().join(&authority_path);
         check_membership_path::<E>(&source_path)?;
+        if unobserved_routes
+            .get(authority.named_path())
+            .is_some_and(|routes| routes.contains(&authority_path))
+        {
+            if state
+                .routes
+                .insert(
+                    source_path,
+                    JsonlFamilyMembershipRoute {
+                        authority: Arc::new(authority),
+                        authority_path,
+                    },
+                )
+                .is_some()
+            {
+                return Err(E::invalid_payload(
+                    "JSONL membership contains a duplicate authority route".to_owned(),
+                ));
+            }
+            continue;
+        }
         let opened = match directory.open_child(&name) {
             Ok(opened) => opened,
             // Admission never admits a link-like or non-regular route (a
@@ -263,7 +295,12 @@ fn observe_membership_directory<E: JsonlFamilyError>(
         };
         match opened {
             OpenedProviderSourcePath::Directory(child) => {
-                observe_membership_directory(&child, depth.saturating_add(1), state)?;
+                observe_membership_directory(
+                    &child,
+                    depth.saturating_add(1),
+                    state,
+                    unobserved_routes,
+                )?;
             }
             OpenedProviderSourcePath::File(opened)
                 if source_path
@@ -306,6 +343,48 @@ fn observe_membership_directory<E: JsonlFamilyError>(
     if depth > 0 {
         directory.revalidate()?;
     }
+    Ok(())
+}
+
+fn unobserved_membership_routes<E: JsonlFamilyError>(
+    opening: &JsonlFamilyInventory<E>,
+) -> JsonlResult<UnobservedMembershipRoutes, E> {
+    let mut routes = BTreeMap::<PathBuf, BTreeSet<PathBuf>>::new();
+    for member in &opening.members {
+        let JsonlFamilyInventoryMember::Quarantined { leaf, .. } = member else {
+            continue;
+        };
+        if leaf.observation.is_some() {
+            continue;
+        }
+        let authority = exact_member_authority(
+            &opening.authorities,
+            &leaf.source_path,
+            &leaf.authority_path,
+        )?;
+        routes
+            .entry(authority.named_path().to_path_buf())
+            .or_default()
+            .insert(leaf.authority_path.clone());
+    }
+    Ok(routes)
+}
+
+fn observe_unopened_member<E: JsonlFamilyError>(
+    authority: &ProviderSourceRoot<E>,
+    authority_path: &Path,
+) -> JsonlResult<(), E> {
+    let name = authority_path.file_name().ok_or_else(|| {
+        E::invalid_payload("unobserved JSONL membership path has no file name".to_owned())
+    })?;
+    let parent = authority_path.parent().unwrap_or_else(|| Path::new(""));
+    let directory = authority.open_directory(parent)?;
+    let children = directory.entries(PROVIDER_JSONL_INVENTORY_MAX_METADATA_ENTRIES)?;
+    if !children.iter().any(|child| child == name) {
+        return Err(E::source_changed());
+    }
+    directory.revalidate()?;
+    authority.revalidate_same_object()?;
     Ok(())
 }
 

--- a/crates/ctx-history-jsonl/src/family/route/projector.rs
+++ b/crates/ctx-history-jsonl/src/family/route/projector.rs
@@ -1,13 +1,68 @@
 use ctx_history_capture_runtime::SourceBackedRecordRejectionDrafts;
-use ctx_history_core::{CoreRecord, TypedKey};
+use ctx_history_core::{CoreRecord, SourceKey, TypedKey};
 
 use super::super::{
     JsonlFamilyRuntime, JsonlReader, JsonlRecordRef, JsonlResult, JsonlRuntimeError,
 };
 use super::JsonlFamilyWorkerContext;
 
+/// Explicit failure scope for provider semantic preflight.
+///
+/// Ordinary runtime errors stay internal to the leaf scan and retain their
+/// existing route-level classification. A provider may select the logical
+/// source variant only after a complete pre-staging pass proves that one
+/// exactly owned source is independently invalid. Record rejections are
+/// handled by the projector while it keeps scanning; surfacing one here is a
+/// contract violation because the shared family cannot safely resume an
+/// interrupted preflight callback.
+#[derive(Debug)]
+pub enum JsonlFamilyProjectorPreflightError<E> {
+    RecordRejection { detail: String },
+    LogicalSourceFailure { source: SourceKey, detail: String },
+    Internal(E),
+}
+
+impl<E> JsonlFamilyProjectorPreflightError<E> {
+    pub fn record_rejection(detail: impl Into<String>) -> Self {
+        Self::RecordRejection {
+            detail: detail.into(),
+        }
+    }
+
+    pub fn logical_source_failure(source: SourceKey, detail: impl Into<String>) -> Self {
+        Self::LogicalSourceFailure {
+            source,
+            detail: detail.into(),
+        }
+    }
+
+    pub fn internal(error: E) -> Self {
+        Self::Internal(error)
+    }
+}
+
+impl<E> From<E> for JsonlFamilyProjectorPreflightError<E> {
+    fn from(error: E) -> Self {
+        Self::Internal(error)
+    }
+}
+
 pub trait JsonlFamilyProjector: Send {
     type Runtime: JsonlFamilyRuntime;
+
+    /// Classifies only provider semantic failures proven before writer
+    /// staging. Existing projectors inherit the route-fatal runtime behavior;
+    /// adapters that can prove one exact logical source invalid may override
+    /// this method without changing every projector's ordinary error type.
+    fn preflight_with_failure_scope(
+        &mut self,
+        reader: &mut JsonlReader<JsonlRuntimeError<Self::Runtime>>,
+        certified_prefix_end: Option<u64>,
+    ) -> JsonlResult<bool, JsonlFamilyProjectorPreflightError<JsonlRuntimeError<Self::Runtime>>>
+    {
+        self.preflight(reader, certified_prefix_end)
+            .map_err(JsonlFamilyProjectorPreflightError::Internal)
+    }
 
     fn preflight(
         &mut self,

--- a/crates/ctx-history-jsonl/src/family/route/projector.rs
+++ b/crates/ctx-history-jsonl/src/family/route/projector.rs
@@ -17,8 +17,13 @@ use super::JsonlFamilyWorkerContext;
 /// interrupted preflight callback.
 #[derive(Debug)]
 pub enum JsonlFamilyProjectorPreflightError<E> {
-    RecordRejection { detail: String },
-    LogicalSourceFailure { source: SourceKey, detail: String },
+    RecordRejection {
+        detail: String,
+    },
+    LogicalSourceFailure {
+        source: Box<SourceKey>,
+        detail: String,
+    },
     Internal(E),
 }
 
@@ -31,7 +36,7 @@ impl<E> JsonlFamilyProjectorPreflightError<E> {
 
     pub fn logical_source_failure(source: SourceKey, detail: impl Into<String>) -> Self {
         Self::LogicalSourceFailure {
-            source,
+            source: Box::new(source),
             detail: detail.into(),
         }
     }

--- a/crates/ctx-history-jsonl/src/family/route/revalidation.rs
+++ b/crates/ctx-history-jsonl/src/family/route/revalidation.rs
@@ -266,7 +266,10 @@ pub(super) fn inventory_observation<E: JsonlFamilyError>(
         digest.update(leaf.authority_path.as_os_str().as_encoded_bytes());
         digest.update((leaf.source_path.as_os_str().as_encoded_bytes().len() as u64).to_be_bytes());
         digest.update(leaf.source_path.as_os_str().as_encoded_bytes());
-        digest.update(serde_json::to_vec(&leaf.observation)?);
+        match &leaf.observation {
+            Some(observation) => digest.update(serde_json::to_vec(observation)?),
+            None => digest.update(b"unobserved-quarantined-leaf-v1\0"),
+        }
         digest.update(serde_json::to_vec(&leaf.proof)?);
         digest.update(b"bound-source-v1\0");
         if let Some(source) = &leaf.quarantined_source {

--- a/crates/ctx-history-jsonl/src/family/route/tests.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests.rs
@@ -14,6 +14,7 @@ use super::super::{
     track_jsonl_prefix_hash_bytes, JsonlReader as RuntimeJsonlReader, JsonlRecordRef,
 };
 use super::*;
+use crate::family::JsonlRecordRejections;
 use ctx_history_capture_model::AttemptHistoryProgress;
 use ctx_history_capture_model::SourceRouteIdentity;
 use ctx_history_capture_runtime::{
@@ -23,9 +24,9 @@ use ctx_history_capture_runtime::{
     CorePreparationFailureKind, CorePreparationPort, ImmutableCaptureSnapshot, PresentCaptureRoute,
     SourceBackedGenerationSink as RuntimeSourceBackedGenerationSink,
     SourceBackedLogicalSourceFailures, SourceBackedReconciliationDemand,
-    SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDraft,
-    SourceBackedRecordRejectionDrafts, SourceBackedRecordRejections,
-    SourceBackedRevalidationTarget, SourceBackedRouteResources, VerifiedCapture,
+    SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDrafts,
+    SourceBackedRecordRejections, SourceBackedRevalidationTarget, SourceBackedRouteResources,
+    VerifiedCapture,
 };
 use ctx_history_core::{
     derive_event_id, derive_session_id, CertifiedSourceAppend, CertifiedSourceDeletion, CoreRecord,

--- a/crates/ctx-history-jsonl/src/family/route/tests.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests.rs
@@ -23,8 +23,9 @@ use ctx_history_capture_runtime::{
     CorePreparationFailureKind, CorePreparationPort, ImmutableCaptureSnapshot, PresentCaptureRoute,
     SourceBackedGenerationSink as RuntimeSourceBackedGenerationSink,
     SourceBackedLogicalSourceFailures, SourceBackedReconciliationDemand,
-    SourceBackedRecordRejections, SourceBackedRevalidationTarget, SourceBackedRouteResources,
-    VerifiedCapture,
+    SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDraft,
+    SourceBackedRecordRejectionDrafts, SourceBackedRecordRejections,
+    SourceBackedRevalidationTarget, SourceBackedRouteResources, VerifiedCapture,
 };
 use ctx_history_core::{
     derive_event_id, derive_session_id, CertifiedSourceAppend, CertifiedSourceDeletion, CoreRecord,

--- a/crates/ctx-history-jsonl/src/family/route/tests/behavior/semantic_projection.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/behavior/semantic_projection.rs
@@ -587,3 +587,64 @@ fn generic_projection_streams_record_and_finish_fanout_before_record_65() {
         assert_eq!(prepared.certificate.counts().indexed_documents, 129);
     }
 }
+
+fn scoped_preflight_failure_fixture(
+    behavior: ScopedPreflightTestBehavior,
+) -> (CaptureError, usize) {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let root = temp.path().join("sessions");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("scoped.jsonl"), TEST_RECORD).unwrap();
+    let adapter = ScopedPreflightTestAdapter { behavior };
+    let inventory = adapter.discover(&root).unwrap();
+    let leaf = inventory.accepted_leaves().next().unwrap();
+    let writer = match TestLifecycle::open(&temp.path().join("index"), ()).unwrap() {
+        CaptureLifecycleOpenOutcome::Ready(writer) => writer,
+        CaptureLifecycleOpenOutcome::RecoveryRequired { .. } => unreachable!(),
+    };
+    let admitted = Arc::new(AtomicUsize::new(0));
+    let observed = Arc::clone(&admitted);
+    let mut emit = move |event| {
+        if matches!(event, JsonlLeafOutputEvent::Record { .. }) {
+            observed.fetch_add(1, Ordering::SeqCst);
+        }
+        Ok(())
+    };
+    let mut output = JsonlLeafOutput::new(&mut emit);
+    let mut worker = JsonlFamilyWorkerContext::default();
+    let error = prepare_leaf(
+        &adapter,
+        leaf,
+        None,
+        &writer.base_event_identity_lookup(),
+        &mut worker,
+        &mut output,
+        true,
+    )
+    .err()
+    .expect("scoped preflight fixture must fail");
+    (error, admitted.load(Ordering::SeqCst))
+}
+
+#[test]
+fn preflight_wrong_source_and_generic_internal_claims_remain_fatal() {
+    let (wrong_source, admitted) =
+        scoped_preflight_failure_fixture(ScopedPreflightTestBehavior::WrongSource);
+    assert_eq!(admitted, 0);
+    assert!(wrong_source
+        .to_string()
+        .contains("JSONL projector failed another logical source"));
+
+    let (generic, admitted) =
+        scoped_preflight_failure_fixture(ScopedPreflightTestBehavior::GenericInternal);
+    assert_eq!(admitted, 0);
+    assert!(generic.to_string().contains("generic preflight failure"));
+}
+
+#[test]
+fn failure_after_staging_cannot_be_reclassified_as_source_local() {
+    let (error, admitted) =
+        scoped_preflight_failure_fixture(ScopedPreflightTestBehavior::PostStagingFailure);
+    assert!(admitted > 0, "fixture must cross the staging boundary");
+    assert!(error.to_string().contains("post-staging generic failure"));
+}

--- a/crates/ctx-history-jsonl/src/family/route/tests/behavior/semantic_projection.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/behavior/semantic_projection.rs
@@ -2,6 +2,71 @@ use super::*;
 use ctx_history_capture_runtime::{CaptureLifecycleOpenOutcome, CaptureLifecycleSink};
 
 #[test]
+fn newline_record_rejections_resume_after_malformed_and_oversized_rows() {
+    for oversized in [false, true] {
+        let temp = crate::test_support_paths::tempdir().unwrap();
+        let root = temp.path().join("sessions");
+        fs::create_dir_all(&root).unwrap();
+        let mut fixture = br#"{"message":"first"}
+"#
+        .to_vec();
+        if oversized {
+            fixture.extend_from_slice(br#"{"message":"#);
+            fixture.extend(std::iter::repeat_n(b'x', MAX_PROVIDER_JSONL_LINE_BYTES));
+            fixture.extend_from_slice(b"\"}\n");
+        } else {
+            fixture.extend_from_slice(b"{\n");
+        }
+        fixture.extend_from_slice(b"{\"message\":\"last\"}\n");
+        fs::write(root.join("boundaries.jsonl"), fixture).unwrap();
+
+        let adapter = RecordRejectionTestAdapter;
+        let inventory = adapter.discover(&root).unwrap();
+        let leaf = inventory.accepted_leaves().next().unwrap();
+        let writer = match TestLifecycle::open(&temp.path().join("index"), ()).unwrap() {
+            CaptureLifecycleOpenOutcome::Ready(writer) => writer,
+            CaptureLifecycleOpenOutcome::RecoveryRequired { .. } => unreachable!(),
+        };
+        let mut emitted = 0;
+        let mut emit = |event| {
+            match event {
+                JsonlLeafOutputEvent::Page { records, .. } => emitted += records.len(),
+                JsonlLeafOutputEvent::Record { .. } => emitted += 1,
+                JsonlLeafOutputEvent::Flush => {}
+            }
+            Ok(())
+        };
+        let mut output = JsonlLeafOutput::new(&mut emit);
+        let mut worker = JsonlFamilyWorkerContext::default();
+        let prepared = prepare_leaf(
+            &adapter,
+            leaf,
+            None,
+            &writer.base_event_identity_lookup(),
+            &mut worker,
+            &mut output,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(emitted, 2);
+        let counts = prepared.certificate.counts();
+        assert_eq!(counts.complete_records, 3);
+        assert_eq!(counts.retained_records, 2);
+        assert_eq!(counts.rejected_records, 1);
+        assert_eq!(counts.ignored_records, 0);
+        let (rejections, omitted) = prepared.record_rejections.into_parts();
+        assert_eq!(omitted, 0);
+        assert_eq!(rejections.len(), 1);
+        assert_eq!(rejections[0].line_number, 2);
+        assert_eq!(
+            rejections[0].class,
+            SourceBackedRecordRejectionClass::MalformedRecord
+        );
+    }
+}
+
+#[test]
 fn rejected_leaf_exact_proof_rejects_change_since_discovery() {
     let temp = crate::test_support_paths::tempdir().unwrap();
     let root = temp.path().join("sessions");

--- a/crates/ctx-history-jsonl/src/family/route/tests/projection_support.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/projection_support.rs
@@ -142,6 +142,114 @@ impl_standard_jsonl_test_adapter!(
     }
 );
 
+pub(super) struct RecordRejectionTestAdapter;
+
+pub(super) struct RecordRejectionTestProjector {
+    source: SourceKey,
+    source_selector: String,
+    rejected_records: u64,
+    record_rejections: SourceBackedRecordRejectionDrafts,
+}
+
+impl JsonlFamilyAdapter for RecordRejectionTestAdapter {
+    type Runtime = TestJsonlRuntime;
+
+    fn provider(&self) -> CaptureProvider {
+        CaptureProvider::Pi
+    }
+
+    fn source_format(&self) -> &'static str {
+        TEST_SOURCE_FORMAT
+    }
+
+    fn schema_variant(&self) -> &'static str {
+        TEST_SCHEMA
+    }
+
+    fn parser_revision(&self) -> &'static str {
+        "record-rejection-test-parser-v1"
+    }
+
+    fn append_mode(&self) -> JsonlFamilyAppendMode {
+        JsonlFamilyAppendMode::CertifiedSuffix
+    }
+
+    fn oversized_record_policy(&self) -> JsonlOversizedRecordPolicy {
+        JsonlOversizedRecordPolicy::RejectRecord
+    }
+
+    fn discover(&self, root: &Path) -> Result<JsonlFamilyInventory> {
+        TestAdapter.discover(root)
+    }
+
+    fn projector(
+        &self,
+        leaf: &JsonlFamilyLeaf,
+        _source_file: Arc<OpenedProviderSourceFile>,
+        _imported_at: DateTime<Utc>,
+    ) -> Result<Box<JsonlFamilyProjectorObject>> {
+        Ok(Box::new(RecordRejectionTestProjector {
+            source: leaf.source().clone(),
+            source_selector: leaf.source_path().display().to_string(),
+            rejected_records: 0,
+            record_rejections: SourceBackedRecordRejectionDrafts::default(),
+        }))
+    }
+}
+
+impl JsonlFamilyProjector for RecordRejectionTestProjector {
+    type Runtime = TestJsonlRuntime;
+
+    fn project(
+        &mut self,
+        record: JsonlRecordRef<'_>,
+        _worker: &mut JsonlFamilyWorkerContext,
+        emit: &mut dyn FnMut(CoreRecord) -> Result<()>,
+    ) -> Result<()> {
+        if record.bytes().iter().all(u8::is_ascii_whitespace) {
+            return Ok(());
+        }
+        let detail = if record.oversized() {
+            Some("test record exceeds the JSONL record bound".to_owned())
+        } else {
+            serde_json::from_slice::<serde_json::Value>(record.bytes())
+                .err()
+                .map(|error| format!("malformed test JSONL: {error}"))
+        };
+        if let Some(detail) = detail {
+            self.rejected_records =
+                self.rejected_records
+                    .checked_add(1)
+                    .ok_or(CaptureError::SystemInvariant(
+                        "test record rejection count overflowed",
+                    ))?;
+            self.record_rejections
+                .record(SourceBackedRecordRejectionDraft {
+                    source: self.source.clone(),
+                    provider: CaptureProvider::Pi,
+                    source_selector: self.source_selector.clone(),
+                    line_number: record.evidence().physical_ordinal().saturating_add(1),
+                    payload_type: None,
+                    class: SourceBackedRecordRejectionClass::MalformedRecord,
+                    detail,
+                });
+            return Ok(());
+        }
+        emit(emission_test_record(
+            &self.source,
+            record.evidence().physical_ordinal(),
+        )?)
+    }
+
+    fn rejected_records(&self) -> u64 {
+        self.rejected_records
+    }
+
+    fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
+        std::mem::take(&mut self.record_rejections)
+    }
+}
+
 pub(super) struct FramingPolicyTestAdapter {
     pub(super) projected: Arc<Mutex<Vec<Vec<u8>>>>,
     pub(super) record_framing: JsonlRecordFraming,

--- a/crates/ctx-history-jsonl/src/family/route/tests/projection_support.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/projection_support.rs
@@ -146,9 +146,7 @@ pub(super) struct RecordRejectionTestAdapter;
 
 pub(super) struct RecordRejectionTestProjector {
     source: SourceKey,
-    source_selector: String,
-    rejected_records: u64,
-    record_rejections: SourceBackedRecordRejectionDrafts,
+    rejections: JsonlRecordRejections,
 }
 
 impl JsonlFamilyAdapter for RecordRejectionTestAdapter {
@@ -190,9 +188,11 @@ impl JsonlFamilyAdapter for RecordRejectionTestAdapter {
     ) -> Result<Box<JsonlFamilyProjectorObject>> {
         Ok(Box::new(RecordRejectionTestProjector {
             source: leaf.source().clone(),
-            source_selector: leaf.source_path().display().to_string(),
-            rejected_records: 0,
-            record_rejections: SourceBackedRecordRejectionDrafts::default(),
+            rejections: JsonlRecordRejections::new(
+                leaf.source().clone(),
+                CaptureProvider::Pi,
+                leaf.source_path().display().to_string(),
+            ),
         }))
     }
 }
@@ -217,22 +217,7 @@ impl JsonlFamilyProjector for RecordRejectionTestProjector {
                 .map(|error| format!("malformed test JSONL: {error}"))
         };
         if let Some(detail) = detail {
-            self.rejected_records =
-                self.rejected_records
-                    .checked_add(1)
-                    .ok_or(CaptureError::SystemInvariant(
-                        "test record rejection count overflowed",
-                    ))?;
-            self.record_rejections
-                .record(SourceBackedRecordRejectionDraft {
-                    source: self.source.clone(),
-                    provider: CaptureProvider::Pi,
-                    source_selector: self.source_selector.clone(),
-                    line_number: record.evidence().physical_ordinal().saturating_add(1),
-                    payload_type: None,
-                    class: SourceBackedRecordRejectionClass::MalformedRecord,
-                    detail,
-                });
+            self.rejections.malformed(record, detail);
             return Ok(());
         }
         emit(emission_test_record(
@@ -242,11 +227,11 @@ impl JsonlFamilyProjector for RecordRejectionTestProjector {
     }
 
     fn rejected_records(&self) -> u64 {
-        self.rejected_records
+        self.rejections.count()
     }
 
     fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
-        std::mem::take(&mut self.record_rejections)
+        self.rejections.take_drafts()
     }
 }
 

--- a/crates/ctx-history-jsonl/src/family/route/tests/projection_support.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/projection_support.rs
@@ -250,6 +250,87 @@ impl JsonlFamilyProjector for RecordRejectionTestProjector {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ScopedPreflightTestBehavior {
+    WrongSource,
+    GenericInternal,
+    PostStagingFailure,
+}
+
+pub(super) struct ScopedPreflightTestAdapter {
+    pub(super) behavior: ScopedPreflightTestBehavior,
+}
+
+struct ScopedPreflightTestProjector {
+    behavior: ScopedPreflightTestBehavior,
+    source: SourceKey,
+    wrong_source: SourceKey,
+}
+
+impl JsonlFamilyProjector for ScopedPreflightTestProjector {
+    type Runtime = TestJsonlRuntime;
+
+    fn preflight_with_failure_scope(
+        &mut self,
+        reader: &mut JsonlReader,
+        _certified_prefix_end: Option<u64>,
+    ) -> std::result::Result<bool, JsonlFamilyProjectorPreflightError<CaptureError>> {
+        match self.behavior {
+            ScopedPreflightTestBehavior::WrongSource => {
+                return Err(JsonlFamilyProjectorPreflightError::logical_source_failure(
+                    self.wrong_source.clone(),
+                    "wrong-source preflight claim",
+                ));
+            }
+            ScopedPreflightTestBehavior::GenericInternal => {
+                return Err(JsonlFamilyProjectorPreflightError::internal(
+                    CaptureError::InvalidPayload("generic preflight failure".to_owned()),
+                ));
+            }
+            ScopedPreflightTestBehavior::PostStagingFailure => {}
+        }
+        while reader
+            .visit_page(&mut |_record| -> Result<()> { Ok(()) })?
+            .is_some()
+        {}
+        Ok(false)
+    }
+
+    fn project(
+        &mut self,
+        _record: JsonlRecordRef<'_>,
+        _worker: &mut JsonlFamilyWorkerContext,
+        emit: &mut dyn FnMut(CoreRecord) -> Result<()>,
+    ) -> Result<()> {
+        for ordinal in 0..65 {
+            emit(emission_test_record(&self.source, ordinal)?)?;
+        }
+        Err(CaptureError::InvalidPayload(
+            "post-staging generic failure".to_owned(),
+        ))
+    }
+}
+
+impl_standard_jsonl_test_adapter!(
+    ScopedPreflightTestAdapter,
+    "scoped-preflight-test-parser-v1",
+    JsonlFamilyAppendMode::ProjectorPreflight(true),
+    |adapter, leaf, _source_file, _imported_at| {
+        let wrong_source = SourceKey::derive(
+            CaptureProvider::Pi.as_str(),
+            TEST_SOURCE_FORMAT,
+            TEST_SCHEMA,
+            1,
+            SourceAnchor::CatalogLineage([0xfe; 32]),
+        )
+        .map_err(test_contract_error)?;
+        Ok(Box::new(ScopedPreflightTestProjector {
+            behavior: adapter.behavior,
+            source: leaf.source().clone(),
+            wrong_source,
+        }))
+    }
+);
 pub(super) struct FramingPolicyTestAdapter {
     pub(super) projected: Arc<Mutex<Vec<Vec<u8>>>>,
     pub(super) record_framing: JsonlRecordFraming,

--- a/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
@@ -203,6 +203,75 @@ fn canonical_inventory_rejects_two_dispositions_for_one_physical_leaf() {
         .contains("physical inventory contains duplicate member"));
 }
 
+#[test]
+fn diagnosed_quarantine_owner_is_not_reclassified_as_pending() {
+    let temp = tempfile::tempdir().unwrap();
+    let owner_path = temp.path().join("owner.jsonl");
+    let peer_path = temp.path().join("peer.jsonl");
+    fs::write(&owner_path, b"{\"message\":\"incomplete\"").unwrap();
+    fs::write(&peer_path, TEST_RECORD).unwrap();
+
+    let discovered = TestAdapter.discover(temp.path()).unwrap();
+    let source = discovered
+        .accepted_leaves()
+        .find(|leaf| leaf.source_path() == owner_path)
+        .unwrap()
+        .source()
+        .clone();
+    let owner_observation = discovered
+        .accepted_leaves()
+        .find(|leaf| leaf.source_path() == owner_path)
+        .unwrap()
+        .observation()
+        .clone();
+    let peer_observation = discovered
+        .accepted_leaves()
+        .find(|leaf| leaf.source_path() == peer_path)
+        .unwrap()
+        .observation()
+        .clone();
+    let authority = Arc::clone(&discovered.authorities[0]);
+    let mut inventory = JsonlFamilyInventory::present_with_rejected(
+        CaptureProvider::Pi,
+        temp.path(),
+        authority,
+        Vec::new(),
+        vec![
+            JsonlFamilyRejectedLeaf::bind_observed(
+                owner_path,
+                PathBuf::from("owner.jsonl"),
+                owner_observation,
+                TypedKey::utf8("owner").unwrap(),
+                0,
+            )
+            .with_logical_source_failure(source.clone(), "duplicate source")
+            .with_quarantined_source(source.clone()),
+            JsonlFamilyRejectedLeaf::bind_observed(
+                peer_path,
+                PathBuf::from("peer.jsonl"),
+                peer_observation,
+                TypedKey::utf8("peer").unwrap(),
+                0,
+            )
+            .with_quarantined_source(source),
+        ],
+    )
+    .unwrap();
+
+    super::super::capture::classify_incomplete_first_records(&PendingOnlyAdapter, &mut inventory)
+        .unwrap();
+
+    assert_eq!(inventory.quarantined_len(), 2);
+    assert_eq!(inventory.pending_len(), 0);
+    assert_eq!(
+        inventory
+            .quarantined_leaves()
+            .filter(|leaf| leaf.logical_source_failure.is_some())
+            .count(),
+        1
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn unobserved_membership_uses_parent_enumeration_without_opening_the_leaf() {

--- a/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
@@ -203,6 +203,60 @@ fn canonical_inventory_rejects_two_dispositions_for_one_physical_leaf() {
         .contains("physical inventory contains duplicate member"));
 }
 
+#[cfg(unix)]
+#[test]
+fn unobserved_membership_uses_parent_enumeration_without_opening_the_leaf() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("sessions");
+    fs::create_dir_all(&root).unwrap();
+    let path = root.join("denied.jsonl");
+    fs::write(&path, TEST_RECORD).unwrap();
+    let discovered = TestAdapter.discover(&root).unwrap();
+    let source = discovered
+        .accepted_leaves()
+        .next()
+        .unwrap()
+        .source()
+        .clone();
+    let authority = Arc::clone(&discovered.authorities[0]);
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+    let inventory = JsonlFamilyInventory::present_with_rejected(
+        CaptureProvider::Pi,
+        &root,
+        authority,
+        Vec::new(),
+        vec![JsonlFamilyRejectedLeaf::bind_unobserved(
+            path.clone(),
+            PathBuf::from("denied.jsonl"),
+            TypedKey::utf8("denied").unwrap(),
+            0,
+        )
+        .with_logical_source_failure(source.clone(), "permission denied")
+        .with_quarantined_source(source)],
+    )
+    .unwrap();
+
+    let opening = JsonlFamilyMembershipObservation::observe(&root, &inventory).unwrap();
+    let unchanged = JsonlFamilyMembershipObservation::observe(&root, &inventory).unwrap();
+    assert!(opening.admits(
+        &unchanged,
+        JsonlFamilyInventoryMode::Exact,
+        &HashMap::new(),
+        &HashMap::new(),
+    ));
+
+    fs::remove_file(&path).unwrap();
+    let removed = JsonlFamilyMembershipObservation::observe(&root, &inventory).unwrap();
+    assert!(!opening.admits(
+        &removed,
+        JsonlFamilyInventoryMode::Exact,
+        &HashMap::new(),
+        &HashMap::new(),
+    ));
+}
+
 #[test]
 fn canonical_inventory_rejects_duplicate_logical_sources_before_staging() {
     let temp = tempfile::tempdir().unwrap();

--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed.rs
@@ -33,11 +33,14 @@ use ctx_history_provider_runtime::{
     observe_opened_file,
     source_io::{OpenedProviderSourceFile, ProviderSourceRoot},
     CaptureError, JsonlAppendOccurrenceState, JsonlFamilyAppendMode, JsonlFamilyProjectionMode,
-    JsonlFamilyProjector, JsonlFamilyRejectedLeaf, JsonlFileObservation, JsonlRecordRef,
-    ProviderBaseEventLookup, ProviderJsonlInventory, ProviderJsonlLeaf, ProviderJsonlReader,
-    ProviderJsonlRuntime, ProviderJsonlWorkerContext, ProviderRuntimeBinding, Result,
+    JsonlFamilyProjector, JsonlFamilyRejectedLeaf, JsonlRecordRef, ProviderBaseEventLookup,
+    ProviderJsonlInventory, ProviderJsonlLeaf, ProviderJsonlReader, ProviderJsonlRuntime,
+    ProviderJsonlWorkerContext, ProviderRuntimeBinding, Result,
 };
-use ctx_history_source_io::visit_bounded_tree_files_isolating_selected;
+use ctx_history_source_io::{
+    visit_bounded_tree_files_isolating_selected, NON_REGULAR_PROVIDER_SOURCE_REASON,
+    REPARSE_PROVIDER_SOURCE_REASON, SYMLINK_PROVIDER_SOURCE_REASON,
+};
 
 type JsonlFamilyLeaf = ProviderJsonlLeaf;
 type JsonlReader = ProviderJsonlReader;
@@ -168,12 +171,15 @@ where
                 Ok(())
             },
             &mut |path, error| {
+                if !is_quarantinable_claude_leaf_error(&error) {
+                    return Err(error);
+                }
                 unreadable.push((path.to_path_buf(), error.to_string()));
                 Ok(())
             },
         )?;
 
-        let mut selected = HashMap::<[u8; 32], JsonlFileObservation>::new();
+        let mut claimed_sources = HashMap::<[u8; 32], SourceKey>::new();
         let mut leaves = Vec::new();
         let mut rejected_leaves = Vec::new();
         observed.sort_by(|left, right| left.0.cmp(&right.0));
@@ -190,26 +196,14 @@ where
             };
             let source = source_key(binding.source_root_lineage, &binding.key)?;
             let relative_path = relative_to_authority(&authority, &path)?;
-            let digest = source.exact_descriptor_digest();
-            if let Some(previous) = selected.get(&digest) {
-                if previous == &observation {
-                    continue;
-                }
-                return Err(CaptureError::InvalidPayload(
-                    "Claude inventory repeats a native session identity".to_owned(),
-                ));
-            }
-            selected.insert(digest, observation);
+            claim_claude_source(&mut claimed_sources, &source)?;
             leaves.push(ProviderJsonlLeaf::bind_observed(
                 source,
                 path,
                 Arc::clone(&authority),
                 relative_path,
                 TypedKey::bytes(serde_json::to_vec(&binding)?).map_err(contract)?,
-                selected
-                    .get(&digest)
-                    .expect("selected Claude observation was just inserted")
-                    .clone(),
+                observation,
             ));
         }
         unreadable.sort_by(|left, right| left.0.cmp(&right.0));
@@ -226,6 +220,7 @@ where
             };
             let source = source_key(binding.source_root_lineage, &binding.key)?;
             let relative_path = relative_to_authority(&authority, &path)?;
+            claim_claude_source(&mut claimed_sources, &source)?;
             rejected_leaves.push(
                 JsonlFamilyRejectedLeaf::bind_unobserved(
                     path.clone(),
@@ -930,6 +925,34 @@ fn fallback_event_key_parts(identity: FallbackEventIdentity) -> Result<Vec<Typed
 
 fn contract(error: impl std::fmt::Display) -> CaptureError {
     CaptureError::InvalidPayload(error.to_string())
+}
+
+fn is_quarantinable_claude_leaf_error(error: &CaptureError) -> bool {
+    matches!(error, CaptureError::Io(source) if source.kind() == io::ErrorKind::PermissionDenied)
+        || matches!(
+            error,
+            CaptureError::InvalidProviderTranscriptPath { reason, .. }
+                if *reason == SYMLINK_PROVIDER_SOURCE_REASON
+                    || *reason == REPARSE_PROVIDER_SOURCE_REASON
+                    || *reason == NON_REGULAR_PROVIDER_SOURCE_REASON
+        )
+}
+
+fn claim_claude_source(
+    claimed: &mut HashMap<[u8; 32], SourceKey>,
+    source: &SourceKey,
+) -> Result<()> {
+    let digest = source.exact_descriptor_digest();
+    if let Some(previous) = claimed.get(&digest) {
+        let detail = if previous.exact_descriptor_eq(source) {
+            "Claude inventory repeats a native session identity"
+        } else {
+            "Claude source descriptor digest collision"
+        };
+        return Err(CaptureError::InvalidPayload(detail.to_owned()));
+    }
+    claimed.insert(digest, source.clone());
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed.rs
@@ -20,15 +20,13 @@ use sha2::{Digest, Sha256};
 
 use super::{
     record::parse_native_record,
-    rows::{
-        ClaudePhysicalLocator, ClaudeRetainedRow, ClaudeSessionMetadata, CLAUDE_MAX_RECORD_ROWS,
-    },
+    rows::{ClaudePhysicalLocator, ClaudeRetainedRow, ClaudeSessionMetadata},
     source::{classify_claude_path, claude_projects_root, ClaudeSessionKey, SessionLayout},
 };
 use crate::CLAUDE_PROJECTS_SOURCE_FORMAT;
 use ctx_history_jsonl::{
     fit_jsonl_activity, selected_content_fits, JsonlActivityObservedBytes, JsonlFamilyAdapter,
-    JsonlFamilyBaseScope,
+    JsonlFamilyBaseScope, JsonlOversizedRecordPolicy,
 };
 use ctx_history_provider_runtime::{
     observe_opened_file,
@@ -56,9 +54,15 @@ const PARSER_REVISION: &str = "claude-shared-jsonl-core-activity-v1";
 
 mod binding;
 mod normalized_body;
+mod preflight;
 
 use binding::*;
 use normalized_body::{event_kind, lexical_body};
+use preflight::{
+    parsed_record_is_rejected, scope_claude_row_validation_error, stable_native_event_identity,
+    typed_claude_record_key, validate_claude_row_annotation, ClaudePreflightError,
+    ClaudeRecordKeyField, ClaudeRowValidationError,
+};
 
 #[derive(Debug, Default)]
 struct ClaudeJsonlAdapter<B> {
@@ -120,6 +124,10 @@ where
         // transition cold-scans the new owner while topology retirement drops
         // the old route atomically.
         JsonlFamilyBaseScope::Route
+    }
+
+    fn oversized_record_policy(&self) -> JsonlOversizedRecordPolicy {
+        JsonlOversizedRecordPolicy::RejectRecord
     }
 
     fn discover(&self, root: &Path) -> Result<ProviderJsonlInventory> {
@@ -267,13 +275,18 @@ where
 {
     type Runtime = ProviderJsonlRuntime<B>;
 
-    fn preflight(
+    fn preflight_with_failure_scope(
         &mut self,
         reader: &mut JsonlReader,
         _certified_prefix_end: Option<u64>,
-    ) -> Result<bool> {
-        crate::consume_neutral_preflight(reader)?;
-        Ok(false)
+    ) -> std::result::Result<bool, ClaudePreflightError> {
+        preflight::validate_source(
+            reader,
+            &self.source_path,
+            &self.binding,
+            &self.source,
+            self.identities.session_id,
+        )
     }
 
     fn retry_replacement(&mut self) {
@@ -288,6 +301,9 @@ where
         _worker: &mut JsonlFamilyWorkerContext<B>,
         emit: &mut dyn FnMut(CoreRecord) -> Result<()>,
     ) -> Result<()> {
+        if record.oversized() {
+            return self.reject_record();
+        }
         let evidence = record.evidence();
         let ordinal = evidence.physical_ordinal();
         let line_number = ordinal.checked_add(1).ok_or(CaptureError::SystemInvariant(
@@ -304,15 +320,40 @@ where
             Ok(parsed) => parsed,
             Err(_) => return self.reject_record(),
         };
-        if parsed
-            .session_id
-            .as_deref()
-            .filter(|session| !session.trim().is_empty())
-            .is_some_and(|session| session != self.binding.key.root_session_id)
-            || (parsed.rows.is_empty() && !parsed.ignored_private_thinking)
-            || parsed.rows.len() > CLAUDE_MAX_RECORD_ROWS
-        {
+        if parsed_record_is_rejected(&parsed, &self.binding) {
             return self.reject_record();
+        }
+        for row in &parsed.rows {
+            match stable_native_event_identity(row, &self.source, self.identities.session_id) {
+                Ok(_) => {}
+                Err(error) => match scope_claude_row_validation_error(error) {
+                    ClaudePreflightError::RecordRejection { .. } => {
+                        return self.reject_record();
+                    }
+                    ClaudePreflightError::Internal(error) => return Err(error),
+                    ClaudePreflightError::LogicalSourceFailure { .. } => {
+                        return Err(CaptureError::SystemInvariant(
+                            "Claude row validation produced a source failure",
+                        ));
+                    }
+                },
+            }
+            match validate_claude_row_annotation(
+                row,
+                parsed.cwd.as_deref(),
+                parsed.git_branch.as_deref(),
+            ) {
+                Ok(()) => {}
+                Err(ClaudePreflightError::RecordRejection { .. }) => {
+                    return self.reject_record();
+                }
+                Err(ClaudePreflightError::Internal(error)) => return Err(error),
+                Err(ClaudePreflightError::LogicalSourceFailure { .. }) => {
+                    return Err(CaptureError::SystemInvariant(
+                        "Claude row validation produced a source failure",
+                    ));
+                }
+            }
         }
         self.session.observe(
             parsed.timestamp.as_deref(),
@@ -326,7 +367,13 @@ where
         for row in parsed.rows {
             let normalized_body = lexical_body(&row);
             let annotation =
-                claude_annotation(&row, parsed.cwd.as_deref(), parsed.git_branch.as_deref())?;
+                claude_annotation(&row, parsed.cwd.as_deref(), parsed.git_branch.as_deref())
+                    .map_err(|error| match error {
+                        ClaudeRowValidationError::Record(_) => CaptureError::SystemInvariant(
+                            "Claude row annotation changed after prevalidation",
+                        ),
+                        ClaudeRowValidationError::Fatal(error) => error,
+                    })?;
             let fallback_identity = next_fallback_event_identity::<B>(
                 &row,
                 &self.source,
@@ -360,7 +407,7 @@ fn claude_annotation(
     row: &ClaudeRetainedRow,
     declared_cwd: Option<&str>,
     declared_branch: Option<&str>,
-) -> Result<CoreRecordAnnotation> {
+) -> std::result::Result<CoreRecordAnnotation, ClaudeRowValidationError> {
     let occurred_at_unix_ms = row
         .occurred_at
         .as_deref()
@@ -382,7 +429,10 @@ fn claude_annotation(
             call.call_id.as_deref().filter(|value| !value.is_empty()),
             call.tool_name.as_deref().filter(|value| !value.is_empty()),
         ) {
-            provider_call_id = Some(TypedKey::utf8(call_id).map_err(contract)?);
+            provider_call_id = Some(typed_claude_record_key(
+                ClaudeRecordKeyField::ProviderCallId,
+                call_id,
+            )?);
             let (protocol, server, tool) = exact_claude_tool_identity(
                 tool_name,
                 call.protocol.as_deref(),
@@ -406,7 +456,10 @@ fn claude_annotation(
             .as_deref()
             .filter(|value| !value.is_empty())
         {
-            provider_call_id = Some(TypedKey::utf8(call_id).map_err(contract)?);
+            provider_call_id = Some(typed_claude_record_key(
+                ClaudeRecordKeyField::ProviderCallId,
+                call_id,
+            )?);
             result = Some(ActivityResult {
                 status: None,
                 completed_at_unix_ms: occurred_at_unix_ms,
@@ -793,123 +846,4 @@ fn contract(error: impl std::fmt::Display) -> CaptureError {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use ctx_history_core::{ActivityJsonCapture, ActivityTextCapture};
-
-    fn locator(bytes: &[u8]) -> ClaudePhysicalLocator {
-        ClaudePhysicalLocator {
-            path: PathBuf::from("fixture.jsonl"),
-            byte_start: 0,
-            byte_end_exclusive: bytes.len() as u64,
-            line_number: 1,
-            record_sha256: Sha256::digest(bytes).into(),
-        }
-    }
-
-    #[test]
-    fn identical_native_sessions_under_distinct_logical_roots_have_distinct_sources() {
-        let key = ClaudeSessionKey {
-            root_session_id: "shared-session".to_owned(),
-            workflow_run_id: None,
-            agent_id: None,
-        };
-        let personal = [1; 32];
-        let work = [2; 32];
-
-        let personal_source = source_key(Some(personal), &key).unwrap();
-        let work_source = source_key(Some(work), &key).unwrap();
-
-        assert!(!personal_source.exact_descriptor_eq(&work_source));
-        assert!(personal_source.exact_descriptor_eq(&source_key(Some(personal), &key).unwrap()));
-    }
-
-    #[test]
-    fn automatic_source_identity_keeps_the_released_unqualified_lineage() {
-        let key = ClaudeSessionKey {
-            root_session_id: "released-session".to_owned(),
-            workflow_run_id: None,
-            agent_id: None,
-        };
-        let released = SourceKey::derive_provider_native(
-            CaptureProvider::Claude.as_str(),
-            CLAUDE_PROJECTS_SOURCE_FORMAT,
-            SOURCE_SCHEMA_VARIANT,
-            1,
-            SOURCE_ANCHOR_NAMESPACE,
-            session_typed_key(&key).unwrap(),
-        )
-        .unwrap();
-
-        assert!(released.exact_descriptor_eq(&source_key(None, &key).unwrap()));
-    }
-
-    #[test]
-    fn malformed_record_is_rejected_before_any_core_activity_exists() {
-        let bytes = b"not-json";
-        assert!(parse_native_record(bytes, 0, &locator(bytes)).is_err());
-    }
-
-    #[test]
-    fn claude_result_preserves_complete_native_block_without_renaming() {
-        let bytes = br#"{"type":"user","uuid":"row","message":{"content":[{"type":"tool_result","tool_use_id":" call-1 ","is_error":true,"content":" exact text ","unknown":{"future":[1,2]}}]}}"#;
-        let parsed = parse_native_record(bytes, 0, &locator(bytes)).unwrap();
-        let row = &parsed.rows[0];
-        let native = serde_json::json!({
-            "type":"tool_result",
-            "tool_use_id":" call-1 ",
-            "is_error":true,
-            "content":" exact text ",
-            "unknown":{"future":[1,2]},
-        });
-        assert_eq!(row.tool_result.as_ref().unwrap().native_content, native);
-        let annotation = claude_annotation(row, None, None).unwrap();
-        assert_eq!(annotation.structured_content.as_ref(), Some(&native));
-        let result = annotation.activity.unwrap().result.unwrap();
-        assert_eq!(
-            result.text,
-            ActivityTextCapture::Present {
-                value: " exact text ".to_owned(),
-            }
-        );
-        assert_eq!(
-            result.structured_content,
-            ActivityJsonCapture::Present { value: native }
-        );
-    }
-
-    #[test]
-    fn claude_flattened_mcp_name_stays_native_and_facts_keep_raw_order() {
-        let bytes = br#"{"type":"assistant","uuid":"row","message":{"role":"assistant","content":[{"type":"tool_use","id":"call","name":"mcp__forge__read","input":{"command":" c ","path":" p ","url":" u "}}]}}"#;
-        let parsed = parse_native_record(bytes, 0, &locator(bytes)).unwrap();
-        let annotation = claude_annotation(&parsed.rows[0], None, None).unwrap();
-        let activity = annotation.activity.unwrap();
-        let invocation = activity.invocation.unwrap();
-        assert_eq!(invocation.tool, "mcp__forge__read");
-        assert_eq!((invocation.protocol, invocation.server), (None, None));
-        assert_eq!(
-            activity
-                .facts
-                .iter()
-                .map(|fact| (fact.kind, fact.value.as_str()))
-                .collect::<Vec<_>>(),
-            [
-                (LiteralFactKind::Command, " c "),
-                (LiteralFactKind::File, " p "),
-                (LiteralFactKind::Url, " u "),
-            ]
-        );
-    }
-
-    #[test]
-    fn claude_duplicate_result_content_retains_row_and_marks_capture_unavailable() {
-        let bytes = br#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"call","content":"one","content":"two"}]}}"#;
-        let parsed = parse_native_record(bytes, 0, &locator(bytes)).unwrap();
-        assert_eq!(parsed.rows.len(), 1);
-        let annotation = claude_annotation(&parsed.rows[0], None, None).unwrap();
-        assert!(annotation.structured_content.is_none());
-        let result = annotation.activity.unwrap().result.unwrap();
-        assert_eq!(result.text, ActivityTextCapture::Unavailable);
-        assert_eq!(result.structured_content, ActivityJsonCapture::Unavailable);
-    }
-}
+mod tests;

--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed.rs
@@ -37,10 +37,7 @@ use ctx_history_provider_runtime::{
     ProviderJsonlInventory, ProviderJsonlLeaf, ProviderJsonlReader, ProviderJsonlRuntime,
     ProviderJsonlWorkerContext, ProviderRuntimeBinding, Result,
 };
-use ctx_history_source_io::{
-    visit_bounded_tree_files_isolating_selected, NON_REGULAR_PROVIDER_SOURCE_REASON,
-    REPARSE_PROVIDER_SOURCE_REASON, SYMLINK_PROVIDER_SOURCE_REASON,
-};
+use ctx_history_source_io::visit_bounded_tree_files_isolating_selected;
 
 type JsonlFamilyLeaf = ProviderJsonlLeaf;
 type JsonlReader = ProviderJsonlReader;
@@ -994,44 +991,6 @@ fn fallback_event_key_parts(identity: FallbackEventIdentity) -> Result<Vec<Typed
         TypedKey::bytes(identity.digest.to_vec()).map_err(contract)?,
         TypedKey::U64(identity.duplicate_occurrence),
     ])
-}
-
-fn contract(error: impl std::fmt::Display) -> CaptureError {
-    CaptureError::InvalidPayload(error.to_string())
-}
-
-fn is_quarantinable_claude_leaf_error(error: &CaptureError) -> bool {
-    matches!(error, CaptureError::Io(source) if source.kind() == io::ErrorKind::PermissionDenied)
-        || matches!(
-            error,
-            CaptureError::InvalidProviderTranscriptPath { reason, .. }
-                if *reason == SYMLINK_PROVIDER_SOURCE_REASON
-                    || *reason == REPARSE_PROVIDER_SOURCE_REASON
-                    || *reason == NON_REGULAR_PROVIDER_SOURCE_REASON
-        )
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ClaudeSourceClaim {
-    New,
-    Duplicate,
-}
-
-fn claim_claude_source(
-    claimed: &mut HashMap<[u8; 32], SourceKey>,
-    source: &SourceKey,
-) -> Result<ClaudeSourceClaim> {
-    let digest = source.exact_descriptor_digest();
-    if let Some(previous) = claimed.get(&digest) {
-        if previous.exact_descriptor_eq(source) {
-            return Ok(ClaudeSourceClaim::Duplicate);
-        }
-        return Err(CaptureError::InvalidPayload(
-            "Claude source descriptor digest collision".to_owned(),
-        ));
-    }
-    claimed.insert(digest, source.clone());
-    Ok(ClaudeSourceClaim::New)
 }
 
 #[cfg(test)]

--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed.rs
@@ -1,7 +1,7 @@
 //! Claude Code adapter for the shared borrowed JSONL replacement family.
 
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::HashMap,
     fs, io,
     path::{Path, PathBuf},
     sync::Arc,
@@ -26,17 +26,18 @@ use super::{
 use crate::CLAUDE_PROJECTS_SOURCE_FORMAT;
 use ctx_history_jsonl::{
     fit_jsonl_activity, selected_content_fits, JsonlActivityObservedBytes, JsonlFamilyAdapter,
-    JsonlFamilyBaseScope, JsonlOversizedRecordPolicy,
+    JsonlFamilyBaseScope, JsonlOversizedRecordPolicy, JsonlRecordRejections,
+    SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDrafts,
 };
 use ctx_history_provider_runtime::{
     observe_opened_file,
     source_io::{OpenedProviderSourceFile, ProviderSourceRoot},
     CaptureError, JsonlAppendOccurrenceState, JsonlFamilyAppendMode, JsonlFamilyProjectionMode,
-    JsonlFamilyProjector, JsonlFileObservation, JsonlRecordRef, ProviderBaseEventLookup,
-    ProviderJsonlInventory, ProviderJsonlLeaf, ProviderJsonlReader, ProviderJsonlRuntime,
-    ProviderJsonlWorkerContext, ProviderRuntimeBinding, Result,
+    JsonlFamilyProjector, JsonlFamilyRejectedLeaf, JsonlFileObservation, JsonlRecordRef,
+    ProviderBaseEventLookup, ProviderJsonlInventory, ProviderJsonlLeaf, ProviderJsonlReader,
+    ProviderJsonlRuntime, ProviderJsonlWorkerContext, ProviderRuntimeBinding, Result,
 };
-use ctx_history_source_io::visit_bounded_tree_files;
+use ctx_history_source_io::visit_bounded_tree_files_isolating_selected;
 
 type JsonlFamilyLeaf = ProviderJsonlLeaf;
 type JsonlReader = ProviderJsonlReader;
@@ -50,7 +51,7 @@ const FALLBACK_EVENT_ID_DOMAIN: &[u8] = b"ctx-claude-fallback-event-id-v1\0";
 const LOGICAL_SESSION_KIND: &str = "claude-session";
 const LOGICAL_EVENT_KIND: &str = "claude-event";
 const SOURCE_SCHEMA_VARIANT: &str = "claude-nativepath-jsonl-v6";
-const PARSER_REVISION: &str = "claude-shared-jsonl-core-activity-v1";
+const PARSER_REVISION: &str = "claude-shared-jsonl-core-activity-v2-record-rejections";
 
 mod binding;
 mod normalized_body;
@@ -148,8 +149,9 @@ where
         let projects_root = claude_projects_root(&canonical_root);
         let source_root_lineage = self.source_root_lineage;
         let authority = Arc::new(ProviderSourceRoot::open(&canonical_root)?);
-        let mut paths = BTreeSet::new();
-        visit_bounded_tree_files::<CaptureError, _>(
+        let mut observed = Vec::new();
+        let mut unreadable = Vec::new();
+        visit_bounded_tree_files_isolating_selected::<CaptureError, _>(
             &canonical_root,
             &mut |candidate| {
                 candidate
@@ -159,14 +161,23 @@ where
                     == Some("jsonl")
             },
             &mut |source_file| {
-                paths.insert(fs::canonicalize(source_file.path())?);
+                let path = source_file.path().to_path_buf();
+                let relative_path = relative_to_authority(&authority, &path)?;
+                let opened = authority.open_file(&relative_path)?;
+                observed.push((path.clone(), observe_opened_file(&path, &opened)?));
+                Ok(())
+            },
+            &mut |path, error| {
+                unreadable.push((path.to_path_buf(), error.to_string()));
                 Ok(())
             },
         )?;
 
         let mut selected = HashMap::<[u8; 32], JsonlFileObservation>::new();
         let mut leaves = Vec::new();
-        for path in paths {
+        let mut rejected_leaves = Vec::new();
+        observed.sort_by(|left, right| left.0.cmp(&right.0));
+        for (path, observation) in observed {
             let Some((project_dir, layout, key)) = classify_claude_path(&projects_root, &path)?
             else {
                 continue;
@@ -179,8 +190,6 @@ where
             };
             let source = source_key(binding.source_root_lineage, &binding.key)?;
             let relative_path = relative_to_authority(&authority, &path)?;
-            let opened = authority.open_file(&relative_path)?;
-            let observation = observe_opened_file(&path, &opened)?;
             let digest = source.exact_descriptor_digest();
             if let Some(previous) = selected.get(&digest) {
                 if previous == &observation {
@@ -191,15 +200,56 @@ where
                 ));
             }
             selected.insert(digest, observation);
-            leaves.push(ProviderJsonlLeaf::observe(
+            leaves.push(ProviderJsonlLeaf::bind_observed(
                 source,
                 path,
                 Arc::clone(&authority),
                 relative_path,
                 TypedKey::bytes(serde_json::to_vec(&binding)?).map_err(contract)?,
-            )?);
+                selected
+                    .get(&digest)
+                    .expect("selected Claude observation was just inserted")
+                    .clone(),
+            ));
         }
-        ProviderJsonlInventory::present(self.provider(), root, authority, leaves)
+        unreadable.sort_by(|left, right| left.0.cmp(&right.0));
+        for (path, detail) in unreadable {
+            let Some((project_dir, layout, key)) = classify_claude_path(&projects_root, &path)?
+            else {
+                continue;
+            };
+            let binding = Binding {
+                project_dir,
+                source_root_lineage,
+                key,
+                layout,
+            };
+            let source = source_key(binding.source_root_lineage, &binding.key)?;
+            let relative_path = relative_to_authority(&authority, &path)?;
+            rejected_leaves.push(
+                JsonlFamilyRejectedLeaf::bind_unobserved(
+                    path.clone(),
+                    relative_path,
+                    TypedKey::bytes(serde_json::to_vec(&binding)?).map_err(contract)?,
+                    0,
+                )
+                .with_logical_source_failure(
+                    source.clone(),
+                    format!(
+                        "Claude transcript {} is unreadable: {detail}",
+                        path.display()
+                    ),
+                )
+                .with_quarantined_source(source),
+            );
+        }
+        ProviderJsonlInventory::present_with_rejected(
+            self.provider(),
+            root,
+            authority,
+            leaves,
+            rejected_leaves,
+        )
     }
 
     fn projector_with_provider_checkpoint(
@@ -226,7 +276,11 @@ where
             session: ClaudeSessionMetadata::new(binding.key.clone()),
             binding,
             identities,
-            rejected_records: 0,
+            rejections: JsonlRecordRejections::new(
+                leaf.source().clone(),
+                CaptureProvider::Claude,
+                leaf.source_path().to_string_lossy(),
+            ),
             fallback_identities: match (mode, base_event_lookup) {
                 (JsonlFamilyProjectionMode::CertifiedAppend, Some(base_lookup)) => {
                     JsonlAppendOccurrenceState::for_append(base_lookup)
@@ -250,7 +304,7 @@ struct ClaudeProjector<B: ProviderRuntimeBinding> {
     binding: Binding,
     identities: Identities,
     session: ClaudeSessionMetadata,
-    rejected_records: u64,
+    rejections: JsonlRecordRejections,
     fallback_identities: JsonlAppendOccurrenceState<[u8; 32], ProviderBaseEventLookup<B>>,
 }
 
@@ -261,10 +315,13 @@ struct FallbackEventIdentity {
 }
 
 impl<B: ProviderRuntimeBinding> ClaudeProjector<B> {
-    fn reject_record(&mut self) -> Result<()> {
-        self.rejected_records = self.rejected_records.checked_add(1).ok_or_else(|| {
-            CaptureError::InvalidPayload("Claude rejected-record count overflowed".to_owned())
-        })?;
+    fn reject_record(
+        &mut self,
+        record: JsonlRecordRef<'_>,
+        class: SourceBackedRecordRejectionClass,
+        detail: impl Into<String>,
+    ) -> Result<()> {
+        self.rejections.record(record, class, detail);
         Ok(())
     }
 }
@@ -291,7 +348,11 @@ where
 
     fn retry_replacement(&mut self) {
         self.session = ClaudeSessionMetadata::new(self.binding.key.clone());
-        self.rejected_records = 0;
+        self.rejections = JsonlRecordRejections::new(
+            self.source.clone(),
+            CaptureProvider::Claude,
+            self.source_path.clone(),
+        );
         self.fallback_identities = JsonlAppendOccurrenceState::default();
     }
 
@@ -302,7 +363,11 @@ where
         emit: &mut dyn FnMut(CoreRecord) -> Result<()>,
     ) -> Result<()> {
         if record.oversized() {
-            return self.reject_record();
+            return self.reject_record(
+                record,
+                SourceBackedRecordRejectionClass::UnsupportedRecord,
+                "Claude JSONL record exceeds the supported size bound",
+            );
         }
         let evidence = record.evidence();
         let ordinal = evidence.physical_ordinal();
@@ -318,17 +383,31 @@ where
         };
         let parsed = match parse_native_record(record.bytes(), ordinal, &locator) {
             Ok(parsed) => parsed,
-            Err(_) => return self.reject_record(),
+            Err(error) => {
+                return self.reject_record(
+                    record,
+                    SourceBackedRecordRejectionClass::MalformedRecord,
+                    format!("malformed Claude JSONL record: {error}"),
+                );
+            }
         };
         if parsed_record_is_rejected(&parsed, &self.binding) {
-            return self.reject_record();
+            return self.reject_record(
+                record,
+                SourceBackedRecordRejectionClass::UnsupportedRecord,
+                "Claude JSONL record is outside the admitted session shape",
+            );
         }
         for row in &parsed.rows {
             match stable_native_event_identity(row, &self.source, self.identities.session_id) {
                 Ok(_) => {}
                 Err(error) => match scope_claude_row_validation_error(error) {
-                    ClaudePreflightError::RecordRejection { .. } => {
-                        return self.reject_record();
+                    ClaudePreflightError::RecordRejection { detail } => {
+                        return self.reject_record(
+                            record,
+                            SourceBackedRecordRejectionClass::UnsupportedRecord,
+                            detail,
+                        );
                     }
                     ClaudePreflightError::Internal(error) => return Err(error),
                     ClaudePreflightError::LogicalSourceFailure { .. } => {
@@ -344,8 +423,12 @@ where
                 parsed.git_branch.as_deref(),
             ) {
                 Ok(()) => {}
-                Err(ClaudePreflightError::RecordRejection { .. }) => {
-                    return self.reject_record();
+                Err(ClaudePreflightError::RecordRejection { detail }) => {
+                    return self.reject_record(
+                        record,
+                        SourceBackedRecordRejectionClass::UnsupportedRecord,
+                        detail,
+                    );
                 }
                 Err(ClaudePreflightError::Internal(error)) => return Err(error),
                 Err(ClaudePreflightError::LogicalSourceFailure { .. }) => {
@@ -399,7 +482,11 @@ where
     }
 
     fn rejected_records(&self) -> u64 {
-        self.rejected_records
+        self.rejections.count()
+    }
+
+    fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
+        self.rejections.take_drafts()
     }
 }
 

--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed.rs
@@ -1,7 +1,7 @@
 //! Claude Code adapter for the shared borrowed JSONL replacement family.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs, io,
     path::{Path, PathBuf},
     sync::Arc,
@@ -180,8 +180,9 @@ where
         )?;
 
         let mut claimed_sources = HashMap::<[u8; 32], SourceKey>::new();
-        let mut leaves = Vec::new();
-        let mut rejected_leaves = Vec::new();
+        let mut duplicate_sources = HashSet::new();
+        let mut source_owner_paths = HashMap::<[u8; 32], PathBuf>::new();
+        let mut prepared_observed = Vec::new();
         observed.sort_by(|left, right| left.0.cmp(&right.0));
         for (path, observation) in observed {
             let Some((project_dir, layout, key)) = classify_claude_path(&projects_root, &path)?
@@ -196,16 +197,22 @@ where
             };
             let source = source_key(binding.source_root_lineage, &binding.key)?;
             let relative_path = relative_to_authority(&authority, &path)?;
-            claim_claude_source(&mut claimed_sources, &source)?;
-            leaves.push(ProviderJsonlLeaf::bind_observed(
-                source,
-                path,
-                Arc::clone(&authority),
-                relative_path,
-                TypedKey::bytes(serde_json::to_vec(&binding)?).map_err(contract)?,
-                observation,
-            ));
+            let proof = TypedKey::bytes(serde_json::to_vec(&binding)?).map_err(contract)?;
+            let digest = source.exact_descriptor_digest();
+            if claim_claude_source(&mut claimed_sources, &source)? == ClaudeSourceClaim::Duplicate {
+                duplicate_sources.insert(digest);
+            }
+            source_owner_paths
+                .entry(digest)
+                .and_modify(|owner| {
+                    if path.as_path() < owner.as_path() {
+                        *owner = path.clone();
+                    }
+                })
+                .or_insert_with(|| path.clone());
+            prepared_observed.push((source, path, relative_path, proof, observation));
         }
+        let mut prepared_unreadable = Vec::new();
         unreadable.sort_by(|left, right| left.0.cmp(&right.0));
         for (path, detail) in unreadable {
             let Some((project_dir, layout, key)) = classify_claude_path(&projects_root, &path)?
@@ -220,23 +227,89 @@ where
             };
             let source = source_key(binding.source_root_lineage, &binding.key)?;
             let relative_path = relative_to_authority(&authority, &path)?;
-            claim_claude_source(&mut claimed_sources, &source)?;
-            rejected_leaves.push(
-                JsonlFamilyRejectedLeaf::bind_unobserved(
+            let digest = source.exact_descriptor_digest();
+            if claim_claude_source(&mut claimed_sources, &source)? == ClaudeSourceClaim::Duplicate {
+                duplicate_sources.insert(digest);
+            }
+            source_owner_paths
+                .entry(digest)
+                .and_modify(|owner| {
+                    if path.as_path() < owner.as_path() {
+                        *owner = path.clone();
+                    }
+                })
+                .or_insert_with(|| path.clone());
+            prepared_unreadable.push((
+                source,
+                path,
+                relative_path,
+                TypedKey::bytes(serde_json::to_vec(&binding)?).map_err(contract)?,
+                detail,
+            ));
+        }
+
+        let mut leaves = Vec::new();
+        let mut rejected_leaves = Vec::new();
+        for (source, path, relative_path, proof, observation) in prepared_observed {
+            let digest = source.exact_descriptor_digest();
+            if duplicate_sources.contains(&digest) {
+                let mut rejected = JsonlFamilyRejectedLeaf::bind_observed(
                     path.clone(),
                     relative_path,
-                    TypedKey::bytes(serde_json::to_vec(&binding)?).map_err(contract)?,
+                    observation,
+                    proof,
                     0,
                 )
-                .with_logical_source_failure(
-                    source.clone(),
-                    format!(
-                        "Claude transcript {} is unreadable: {detail}",
-                        path.display()
-                    ),
+                .with_quarantined_source(source.clone());
+                if source_owner_paths
+                    .get(&digest)
+                    .is_some_and(|owner| owner == &path)
+                {
+                    rejected = rejected.with_logical_source_failure(
+                        source.clone(),
+                        format!(
+                            "Claude transcript {} repeats a native session identity claimed by another transcript",
+                            path.display()
+                        ),
+                    );
+                }
+                rejected_leaves.push(rejected);
+            } else {
+                leaves.push(ProviderJsonlLeaf::bind_observed(
+                    source,
+                    path,
+                    Arc::clone(&authority),
+                    relative_path,
+                    proof,
+                    observation,
+                ));
+            }
+        }
+        for (source, path, relative_path, proof, detail) in prepared_unreadable {
+            let digest = source.exact_descriptor_digest();
+            let duplicate = duplicate_sources.contains(&digest);
+            let failure_detail = if duplicate {
+                format!(
+                    "Claude transcript {} repeats a native session identity claimed by another transcript and is unreadable: {detail}",
+                    path.display()
                 )
-                .with_quarantined_source(source),
-            );
+            } else {
+                format!(
+                    "Claude transcript {} is unreadable: {detail}",
+                    path.display()
+                )
+            };
+            let mut rejected =
+                JsonlFamilyRejectedLeaf::bind_unobserved(path.clone(), relative_path, proof, 0)
+                    .with_quarantined_source(source.clone());
+            if !duplicate
+                || source_owner_paths
+                    .get(&digest)
+                    .is_some_and(|owner| owner == &path)
+            {
+                rejected = rejected.with_logical_source_failure(source, failure_detail);
+            }
+            rejected_leaves.push(rejected);
         }
         ProviderJsonlInventory::present_with_rejected(
             self.provider(),
@@ -938,21 +1011,27 @@ fn is_quarantinable_claude_leaf_error(error: &CaptureError) -> bool {
         )
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaudeSourceClaim {
+    New,
+    Duplicate,
+}
+
 fn claim_claude_source(
     claimed: &mut HashMap<[u8; 32], SourceKey>,
     source: &SourceKey,
-) -> Result<()> {
+) -> Result<ClaudeSourceClaim> {
     let digest = source.exact_descriptor_digest();
     if let Some(previous) = claimed.get(&digest) {
-        let detail = if previous.exact_descriptor_eq(source) {
-            "Claude inventory repeats a native session identity"
-        } else {
-            "Claude source descriptor digest collision"
-        };
-        return Err(CaptureError::InvalidPayload(detail.to_owned()));
+        if previous.exact_descriptor_eq(source) {
+            return Ok(ClaudeSourceClaim::Duplicate);
+        }
+        return Err(CaptureError::InvalidPayload(
+            "Claude source descriptor digest collision".to_owned(),
+        ));
     }
     claimed.insert(digest, source.clone());
-    Ok(())
+    Ok(ClaudeSourceClaim::New)
 }
 
 #[cfg(test)]

--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/binding.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/binding.rs
@@ -1,4 +1,8 @@
 use super::*;
+use ctx_history_source_io::{
+    NON_REGULAR_PROVIDER_SOURCE_REASON, REPARSE_PROVIDER_SOURCE_REASON,
+    SYMLINK_PROVIDER_SOURCE_REASON,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -26,4 +30,42 @@ pub(super) fn relative_to_authority(
             path: path.to_path_buf(),
             reason: "Claude transcripts must remain below their selected authority",
         })
+}
+
+pub(super) fn contract(error: impl std::fmt::Display) -> CaptureError {
+    CaptureError::InvalidPayload(error.to_string())
+}
+
+pub(super) fn is_quarantinable_claude_leaf_error(error: &CaptureError) -> bool {
+    matches!(error, CaptureError::Io(source) if source.kind() == io::ErrorKind::PermissionDenied)
+        || matches!(
+            error,
+            CaptureError::InvalidProviderTranscriptPath { reason, .. }
+                if *reason == SYMLINK_PROVIDER_SOURCE_REASON
+                    || *reason == REPARSE_PROVIDER_SOURCE_REASON
+                    || *reason == NON_REGULAR_PROVIDER_SOURCE_REASON
+        )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ClaudeSourceClaim {
+    New,
+    Duplicate,
+}
+
+pub(super) fn claim_claude_source(
+    claimed: &mut HashMap<[u8; 32], SourceKey>,
+    source: &SourceKey,
+) -> Result<ClaudeSourceClaim> {
+    let digest = source.exact_descriptor_digest();
+    if let Some(previous) = claimed.get(&digest) {
+        if previous.exact_descriptor_eq(source) {
+            return Ok(ClaudeSourceClaim::Duplicate);
+        }
+        return Err(CaptureError::InvalidPayload(
+            "Claude source descriptor digest collision".to_owned(),
+        ));
+    }
+    claimed.insert(digest, source.clone());
+    Ok(ClaudeSourceClaim::New)
 }

--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/preflight.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/preflight.rs
@@ -1,0 +1,265 @@
+//! Bounded Claude source preflight and row-error classification.
+
+use std::path::PathBuf;
+
+use ctx_history_core::{
+    derive_event_id, EventIdentityInput, NativeItemKey, ProjectionContractError, SourceKey,
+    StableEntityId, TypedKey,
+};
+use ctx_history_jsonl::JsonlFamilyProjectorPreflightError;
+use ctx_history_provider_runtime::CaptureError;
+use sha2::{Digest, Sha256};
+
+use super::{
+    claude_annotation, contract, Binding, JsonlReader, LOGICAL_EVENT_KIND,
+    NATIVE_EVENT_KEY_NAMESPACE,
+};
+use crate::claude::nativepath::{
+    record::{parse_native_record, ParsedClaudeRecord},
+    rows::{ClaudePhysicalLocator, ClaudeRetainedRow, CLAUDE_MAX_RECORD_ROWS},
+};
+
+pub(super) const MAX_PREFLIGHT_EVENT_IDENTITIES: usize = 1_048_576;
+
+pub(super) type ClaudePreflightError = JsonlFamilyProjectorPreflightError<CaptureError>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) struct ClaudePreflightIdentity {
+    event_digest: [u8; 32],
+    line_number: u64,
+}
+
+#[derive(Debug)]
+pub(super) enum ClaudeRecordValidationError {
+    InvalidNativeRecordId(ProjectionContractError),
+    InvalidProviderCallId(ProjectionContractError),
+}
+
+impl ClaudeRecordValidationError {
+    fn detail(self) -> String {
+        match self {
+            Self::InvalidNativeRecordId(error) => {
+                format!("Claude native record identity is invalid: {error}")
+            }
+            Self::InvalidProviderCallId(error) => {
+                format!("Claude provider call identity is invalid: {error}")
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) enum ClaudeRowValidationError {
+    Record(ClaudeRecordValidationError),
+    Fatal(CaptureError),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum ClaudeRecordKeyField {
+    NativeRecordId,
+    ProviderCallId,
+}
+
+pub(super) fn classify_typed_record_key_error(
+    field: ClaudeRecordKeyField,
+    error: ProjectionContractError,
+) -> ClaudeRowValidationError {
+    match error {
+        error @ (ProjectionContractError::EmptyField {
+            field: "typed_key_utf8",
+        }
+        | ProjectionContractError::FieldTooLarge {
+            field: "typed_key_utf8",
+            ..
+        }) => ClaudeRowValidationError::Record(match field {
+            ClaudeRecordKeyField::NativeRecordId => {
+                ClaudeRecordValidationError::InvalidNativeRecordId(error)
+            }
+            ClaudeRecordKeyField::ProviderCallId => {
+                ClaudeRecordValidationError::InvalidProviderCallId(error)
+            }
+        }),
+        error => ClaudeRowValidationError::Fatal(contract(error)),
+    }
+}
+
+pub(super) fn typed_claude_record_key(
+    field: ClaudeRecordKeyField,
+    value: &str,
+) -> std::result::Result<TypedKey, ClaudeRowValidationError> {
+    TypedKey::utf8(value).map_err(|error| classify_typed_record_key_error(field, error))
+}
+
+pub(super) fn scope_claude_row_validation_error(
+    error: ClaudeRowValidationError,
+) -> ClaudePreflightError {
+    match error {
+        ClaudeRowValidationError::Record(error) => {
+            ClaudePreflightError::record_rejection(error.detail())
+        }
+        ClaudeRowValidationError::Fatal(error) => ClaudePreflightError::internal(error),
+    }
+}
+
+pub(super) fn checked_preflight_identity_count(
+    current: usize,
+    additional: usize,
+) -> std::result::Result<usize, ClaudePreflightError> {
+    current
+        .checked_add(additional)
+        .filter(|count| *count <= MAX_PREFLIGHT_EVENT_IDENTITIES)
+        .ok_or_else(|| {
+            ClaudePreflightError::internal(CaptureError::SystemInvariant(
+                "Claude preflight event identity bound exceeded",
+            ))
+        })
+}
+
+pub(super) fn validate_source(
+    reader: &mut JsonlReader,
+    source_path: &str,
+    binding: &Binding,
+    source: &SourceKey,
+    session_id: StableEntityId,
+) -> std::result::Result<bool, ClaudePreflightError> {
+    let mut identities = Vec::new();
+    while reader
+        .visit_page(
+            &mut |record| -> std::result::Result<(), ClaudePreflightError> {
+                if record.oversized() {
+                    return Ok(());
+                }
+                let evidence = record.evidence();
+                let ordinal = evidence.physical_ordinal();
+                let line_number = ordinal.checked_add(1).ok_or_else(|| {
+                    ClaudePreflightError::internal(CaptureError::SystemInvariant(
+                        "Claude line number overflowed",
+                    ))
+                })?;
+                let locator = ClaudePhysicalLocator {
+                    path: PathBuf::from(source_path),
+                    byte_start: evidence.byte_start(),
+                    byte_end_exclusive: evidence.byte_end_exclusive(),
+                    line_number,
+                    record_sha256: Sha256::digest(record.bytes()).into(),
+                };
+                let Ok(parsed) = parse_native_record(record.bytes(), ordinal, &locator) else {
+                    return Ok(());
+                };
+                if parsed_record_is_rejected(&parsed, binding) {
+                    return Ok(());
+                }
+
+                let mut record_identities = Vec::new();
+                record_identities
+                    .try_reserve_exact(parsed.rows.len())
+                    .map_err(|_| {
+                        ClaudePreflightError::internal(CaptureError::SystemInvariant(
+                            "Claude preflight record identity allocation failed",
+                        ))
+                    })?;
+                for row in &parsed.rows {
+                    match stable_native_event_identity(row, source, session_id) {
+                        Ok(Some(event_id)) => record_identities.push(ClaudePreflightIdentity {
+                            event_digest: event_id.digest(),
+                            line_number,
+                        }),
+                        Ok(None) => {}
+                        Err(error) => match scope_claude_row_validation_error(error) {
+                            ClaudePreflightError::RecordRejection { .. } => return Ok(()),
+                            error => return Err(error),
+                        },
+                    }
+                    match validate_claude_row_annotation(
+                        row,
+                        parsed.cwd.as_deref(),
+                        parsed.git_branch.as_deref(),
+                    ) {
+                        Ok(()) => {}
+                        Err(ClaudePreflightError::RecordRejection { .. }) => return Ok(()),
+                        Err(error) => return Err(error),
+                    }
+                }
+                let count =
+                    checked_preflight_identity_count(identities.len(), record_identities.len())?;
+                identities
+                    .try_reserve_exact(count - identities.len())
+                    .map_err(|_| {
+                        ClaudePreflightError::internal(CaptureError::SystemInvariant(
+                            "Claude preflight source identity allocation failed",
+                        ))
+                    })?;
+                identities.extend(record_identities);
+                Ok(())
+            },
+        )?
+        .is_some()
+    {}
+    identities.sort_unstable();
+    if let Some(pair) = identities
+        .windows(2)
+        .find(|pair| pair[0].event_digest == pair[1].event_digest)
+    {
+        return Err(ClaudePreflightError::logical_source_failure(
+            source.clone(),
+            format!(
+                "Claude transcript repeats a stable event identity at lines {} and {}",
+                pair[0].line_number, pair[1].line_number
+            ),
+        ));
+    }
+    Ok(false)
+}
+
+pub(super) fn parsed_record_is_rejected(parsed: &ParsedClaudeRecord, binding: &Binding) -> bool {
+    parsed
+        .session_id
+        .as_deref()
+        .filter(|session| !session.trim().is_empty())
+        .is_some_and(|session| session != binding.key.root_session_id)
+        || (parsed.rows.is_empty() && !parsed.ignored_private_thinking)
+        || parsed.rows.len() > CLAUDE_MAX_RECORD_ROWS
+}
+
+pub(super) fn stable_native_event_identity(
+    row: &ClaudeRetainedRow,
+    source: &SourceKey,
+    session_id: StableEntityId,
+) -> std::result::Result<Option<StableEntityId>, ClaudeRowValidationError> {
+    if row.native_record_id.is_none() {
+        return Ok(None);
+    }
+    let native_record_id = typed_claude_record_key(
+        ClaudeRecordKeyField::NativeRecordId,
+        row.native_record_id
+            .as_deref()
+            .expect("native record identity was checked above"),
+    )?;
+    let native_item_key = NativeItemKey::composite(
+        NATIVE_EVENT_KEY_NAMESPACE,
+        vec![
+            native_record_id,
+            TypedKey::U64(row.identity.source_subrecord_index),
+        ],
+    )
+    .map_err(|error| ClaudeRowValidationError::Fatal(contract(error)))?;
+    derive_event_id(EventIdentityInput {
+        source,
+        session_id,
+        logical_item_kind: LOGICAL_EVENT_KIND,
+        native_item_key: &native_item_key,
+        subrecord_selector: None,
+    })
+    .map(Some)
+    .map_err(|error| ClaudeRowValidationError::Fatal(contract(error)))
+}
+
+pub(super) fn validate_claude_row_annotation(
+    row: &ClaudeRetainedRow,
+    declared_cwd: Option<&str>,
+    declared_branch: Option<&str>,
+) -> std::result::Result<(), ClaudePreflightError> {
+    claude_annotation(row, declared_cwd, declared_branch)
+        .map(drop)
+        .map_err(scope_claude_row_validation_error)
+}

--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/preflight.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/preflight.rs
@@ -183,7 +183,7 @@ pub(super) fn validate_source(
                 let count =
                     checked_preflight_identity_count(identities.len(), record_identities.len())?;
                 identities
-                    .try_reserve_exact(count - identities.len())
+                    .try_reserve(count - identities.len())
                     .map_err(|_| {
                         ClaudePreflightError::internal(CaptureError::SystemInvariant(
                             "Claude preflight source identity allocation failed",

--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/tests.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/tests.rs
@@ -7,11 +7,14 @@ use sha2::{Digest, Sha256};
 
 use super::preflight::{
     checked_preflight_identity_count, classify_typed_record_key_error,
-    scope_claude_row_validation_error, ClaudePreflightError, ClaudePreflightIdentity,
-    ClaudeRecordKeyField, ClaudeRecordValidationError, ClaudeRowValidationError,
-    MAX_PREFLIGHT_EVENT_IDENTITIES,
+    scope_claude_row_validation_error, stable_native_event_identity, ClaudePreflightError,
+    ClaudePreflightIdentity, ClaudeRecordKeyField, ClaudeRecordValidationError,
+    ClaudeRowValidationError, MAX_PREFLIGHT_EVENT_IDENTITIES,
 };
-use super::{claude_annotation, parse_native_record, ClaudePhysicalLocator};
+use super::{
+    claude_annotation, parse_native_record, session_identity, session_typed_key, source_key,
+    ClaudePhysicalLocator, ClaudeSessionKey,
+};
 
 #[test]
 fn identical_native_sessions_under_distinct_logical_roots_have_distinct_sources() {
@@ -61,6 +64,34 @@ fn locator(bytes: &[u8]) -> ClaudePhysicalLocator {
 fn malformed_record_is_rejected_before_any_core_activity_exists() {
     let bytes = b"not-json";
     assert!(parse_native_record(bytes, 0, &locator(bytes)).is_err());
+}
+
+#[test]
+fn repeated_native_uuid_and_subrecord_index_repeat_the_stable_event_identity() {
+    let key = ClaudeSessionKey {
+        root_session_id: "session".to_owned(),
+        workflow_run_id: None,
+        agent_id: None,
+    };
+    let source = source_key(&key).unwrap();
+    let session_id = session_identity(&source, session_typed_key(&key).unwrap()).unwrap();
+    let parse = |body: &str| {
+        let bytes = serde_json::to_vec(&serde_json::json!({
+            "type": "user",
+            "uuid": "repeated",
+            "message": {"role": "user", "content": body}
+        }))
+        .unwrap();
+        parse_native_record(&bytes, 0, &locator(&bytes))
+            .unwrap()
+            .rows
+            .remove(0)
+    };
+
+    assert_eq!(
+        stable_native_event_identity(&parse("first"), &source, session_id).unwrap(),
+        stable_native_event_identity(&parse("second"), &source, session_id).unwrap()
+    );
 }
 
 #[test]

--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/tests.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/tests.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 use ctx_history_core::{
     ActivityJsonCapture, ActivityTextCapture, LiteralFactKind, ProjectionContractError, TypedKey,
@@ -15,6 +15,79 @@ use super::{
     claude_annotation, parse_native_record, session_identity, session_typed_key, source_key,
     ClaudePhysicalLocator, ClaudeSessionKey,
 };
+
+#[test]
+fn unreadable_leaf_scope_accepts_only_stable_leaf_local_open_failures() {
+    let permission = ctx_history_provider_runtime::CaptureError::Io(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        "denied",
+    ));
+    assert!(super::is_quarantinable_claude_leaf_error(&permission));
+
+    for reason in [
+        ctx_history_source_io::SYMLINK_PROVIDER_SOURCE_REASON,
+        ctx_history_source_io::REPARSE_PROVIDER_SOURCE_REASON,
+        ctx_history_source_io::NON_REGULAR_PROVIDER_SOURCE_REASON,
+    ] {
+        let rejected = ctx_history_provider_runtime::CaptureError::InvalidProviderTranscriptPath {
+            path: PathBuf::from("rejected.jsonl"),
+            reason,
+        };
+        assert!(super::is_quarantinable_claude_leaf_error(&rejected));
+    }
+
+    for systemic in [
+        ctx_history_provider_runtime::CaptureError::SourceChangedDuringCapture,
+        ctx_history_provider_runtime::CaptureError::SystemInvariant("invariant"),
+        ctx_history_provider_runtime::CaptureError::WorkerPanicked("worker"),
+        ctx_history_provider_runtime::CaptureError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "race",
+        )),
+        ctx_history_provider_runtime::CaptureError::Io(std::io::Error::other("resource")),
+        ctx_history_provider_runtime::CaptureError::SystemIo {
+            operation: "read",
+            source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "system denied"),
+        },
+        ctx_history_provider_runtime::CaptureError::InvalidProviderTranscriptPath {
+            path: PathBuf::from("other.jsonl"),
+            reason: "other invalid path",
+        },
+    ] {
+        assert!(!super::is_quarantinable_claude_leaf_error(&systemic));
+    }
+}
+
+#[test]
+fn source_claims_reject_cross_disposition_duplicates_and_digest_collisions() {
+    let key = ClaudeSessionKey {
+        root_session_id: "duplicate-session".to_owned(),
+        workflow_run_id: None,
+        agent_id: None,
+    };
+    let source = source_key(None, &key).unwrap();
+    let mut claims = HashMap::new();
+    super::claim_claude_source(&mut claims, &source).unwrap();
+    let duplicate = super::claim_claude_source(&mut claims, &source).unwrap_err();
+    assert!(duplicate
+        .to_string()
+        .contains("repeats a native session identity"));
+
+    let other = source_key(
+        None,
+        &ClaudeSessionKey {
+            root_session_id: "other-session".to_owned(),
+            workflow_run_id: None,
+            agent_id: None,
+        },
+    )
+    .unwrap();
+    let mut collision = HashMap::from([(source.exact_descriptor_digest(), other)]);
+    let collision = super::claim_claude_source(&mut collision, &source).unwrap_err();
+    assert!(collision
+        .to_string()
+        .contains("source descriptor digest collision"));
+}
 
 #[test]
 fn identical_native_sessions_under_distinct_logical_roots_have_distinct_sources() {
@@ -73,7 +146,7 @@ fn repeated_native_uuid_and_subrecord_index_repeat_the_stable_event_identity() {
         workflow_run_id: None,
         agent_id: None,
     };
-    let source = source_key(&key).unwrap();
+    let source = source_key(None, &key).unwrap();
     let session_id = session_identity(&source, session_typed_key(&key).unwrap()).unwrap();
     let parse = |body: &str| {
         let bytes = serde_json::to_vec(&serde_json::json!({

--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/tests.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/tests.rs
@@ -59,7 +59,7 @@ fn unreadable_leaf_scope_accepts_only_stable_leaf_local_open_failures() {
 }
 
 #[test]
-fn source_claims_reject_cross_disposition_duplicates_and_digest_collisions() {
+fn source_claims_quarantine_exact_duplicates_and_reject_digest_collisions() {
     let key = ClaudeSessionKey {
         root_session_id: "duplicate-session".to_owned(),
         workflow_run_id: None,
@@ -67,11 +67,14 @@ fn source_claims_reject_cross_disposition_duplicates_and_digest_collisions() {
     };
     let source = source_key(None, &key).unwrap();
     let mut claims = HashMap::new();
-    super::claim_claude_source(&mut claims, &source).unwrap();
-    let duplicate = super::claim_claude_source(&mut claims, &source).unwrap_err();
-    assert!(duplicate
-        .to_string()
-        .contains("repeats a native session identity"));
+    assert_eq!(
+        super::claim_claude_source(&mut claims, &source).unwrap(),
+        super::ClaudeSourceClaim::New
+    );
+    assert_eq!(
+        super::claim_claude_source(&mut claims, &source).unwrap(),
+        super::ClaudeSourceClaim::Duplicate
+    );
 
     let other = source_key(
         None,

--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/tests.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/tests.rs
@@ -1,0 +1,193 @@
+use std::path::PathBuf;
+
+use ctx_history_core::{
+    ActivityJsonCapture, ActivityTextCapture, LiteralFactKind, ProjectionContractError, TypedKey,
+};
+use sha2::{Digest, Sha256};
+
+use super::preflight::{
+    checked_preflight_identity_count, classify_typed_record_key_error,
+    scope_claude_row_validation_error, ClaudePreflightError, ClaudePreflightIdentity,
+    ClaudeRecordKeyField, ClaudeRecordValidationError, ClaudeRowValidationError,
+    MAX_PREFLIGHT_EVENT_IDENTITIES,
+};
+use super::{claude_annotation, parse_native_record, ClaudePhysicalLocator};
+
+#[test]
+fn identical_native_sessions_under_distinct_logical_roots_have_distinct_sources() {
+    let key = super::ClaudeSessionKey {
+        root_session_id: "shared-session".to_owned(),
+        workflow_run_id: None,
+        agent_id: None,
+    };
+    let personal_source = super::source_key(Some([1; 32]), &key).unwrap();
+    let work_source = super::source_key(Some([2; 32]), &key).unwrap();
+
+    assert!(!personal_source.exact_descriptor_eq(&work_source));
+    assert!(personal_source.exact_descriptor_eq(&super::source_key(Some([1; 32]), &key).unwrap()));
+}
+
+#[test]
+fn automatic_source_identity_keeps_the_released_unqualified_lineage() {
+    let key = super::ClaudeSessionKey {
+        root_session_id: "released-session".to_owned(),
+        workflow_run_id: None,
+        agent_id: None,
+    };
+    let released = ctx_history_core::SourceKey::derive_provider_native(
+        ctx_history_core::CaptureProvider::Claude.as_str(),
+        crate::CLAUDE_PROJECTS_SOURCE_FORMAT,
+        super::SOURCE_SCHEMA_VARIANT,
+        1,
+        super::SOURCE_ANCHOR_NAMESPACE,
+        super::session_typed_key(&key).unwrap(),
+    )
+    .unwrap();
+
+    assert!(released.exact_descriptor_eq(&super::source_key(None, &key).unwrap()));
+}
+
+fn locator(bytes: &[u8]) -> ClaudePhysicalLocator {
+    ClaudePhysicalLocator {
+        path: PathBuf::from("fixture.jsonl"),
+        byte_start: 0,
+        byte_end_exclusive: bytes.len() as u64,
+        line_number: 1,
+        record_sha256: Sha256::digest(bytes).into(),
+    }
+}
+
+#[test]
+fn malformed_record_is_rejected_before_any_core_activity_exists() {
+    let bytes = b"not-json";
+    assert!(parse_native_record(bytes, 0, &locator(bytes)).is_err());
+}
+
+#[test]
+fn only_explicit_record_errors_enter_record_rejection_scope() {
+    let typed_error = TypedKey::utf8("").unwrap_err();
+    assert!(matches!(
+        scope_claude_row_validation_error(classify_typed_record_key_error(
+            ClaudeRecordKeyField::NativeRecordId,
+            typed_error,
+        )),
+        ClaudePreflightError::RecordRejection { .. }
+    ));
+
+    let generic = scope_claude_row_validation_error(classify_typed_record_key_error(
+        ClaudeRecordKeyField::NativeRecordId,
+        ProjectionContractError::SourceChanged,
+    ));
+    assert!(matches!(
+        generic,
+        ClaudePreflightError::Internal(ctx_history_provider_runtime::CaptureError::InvalidPayload(
+            detail
+        )) if detail == "source certification compared different sources"
+    ));
+}
+
+#[test]
+fn preflight_identity_cost_is_bounded_and_cap_failure_is_internal() {
+    assert_eq!(
+        checked_preflight_identity_count(MAX_PREFLIGHT_EVENT_IDENTITIES, 0).unwrap(),
+        MAX_PREFLIGHT_EVENT_IDENTITIES
+    );
+    let error = checked_preflight_identity_count(MAX_PREFLIGHT_EVENT_IDENTITIES, 1)
+        .expect_err("one identity beyond the cap must fail");
+    assert!(matches!(
+        error,
+        ClaudePreflightError::Internal(
+            ctx_history_provider_runtime::CaptureError::SystemInvariant(
+                "Claude preflight event identity bound exceeded"
+            )
+        )
+    ));
+    assert!(
+        MAX_PREFLIGHT_EVENT_IDENTITIES
+            .checked_mul(std::mem::size_of::<ClaudePreflightIdentity>())
+            .is_some_and(|bytes| bytes <= 40 * 1024 * 1024),
+        "the fixed logical identity payload must remain at or below 40 MiB"
+    );
+}
+
+#[test]
+fn oversized_provider_call_id_is_an_explicit_record_error() {
+    let bytes = br#"{"type":"assistant","uuid":"row","message":{"role":"assistant","content":[{"type":"tool_use","id":"call","name":"tool","input":{}}]}}"#;
+    let mut parsed = parse_native_record(bytes, 0, &locator(bytes)).unwrap();
+    parsed.rows[0]
+        .tool_call
+        .as_mut()
+        .expect("tool-call row")
+        .call_id = Some("x".repeat(64 * 1024 + 1));
+    assert!(matches!(
+        claude_annotation(&parsed.rows[0], None, None),
+        Err(ClaudeRowValidationError::Record(
+            ClaudeRecordValidationError::InvalidProviderCallId(
+                ProjectionContractError::FieldTooLarge { .. }
+            )
+        ))
+    ));
+}
+
+#[test]
+fn claude_result_preserves_complete_native_block_without_renaming() {
+    let bytes = br#"{"type":"user","uuid":"row","message":{"content":[{"type":"tool_result","tool_use_id":" call-1 ","is_error":true,"content":" exact text ","unknown":{"future":[1,2]}}]}}"#;
+    let parsed = parse_native_record(bytes, 0, &locator(bytes)).unwrap();
+    let row = &parsed.rows[0];
+    let native = serde_json::json!({
+        "type":"tool_result",
+        "tool_use_id":" call-1 ",
+        "is_error":true,
+        "content":" exact text ",
+        "unknown":{"future":[1,2]},
+    });
+    assert_eq!(row.tool_result.as_ref().unwrap().native_content, native);
+    let annotation = claude_annotation(row, None, None).unwrap();
+    assert_eq!(annotation.structured_content.as_ref(), Some(&native));
+    let result = annotation.activity.unwrap().result.unwrap();
+    assert_eq!(
+        result.text,
+        ActivityTextCapture::Present {
+            value: " exact text ".to_owned(),
+        }
+    );
+    assert_eq!(
+        result.structured_content,
+        ActivityJsonCapture::Present { value: native }
+    );
+}
+
+#[test]
+fn claude_flattened_mcp_name_stays_native_and_facts_keep_raw_order() {
+    let bytes = br#"{"type":"assistant","uuid":"row","message":{"role":"assistant","content":[{"type":"tool_use","id":"call","name":"mcp__forge__read","input":{"command":" c ","path":" p ","url":" u "}}]}}"#;
+    let parsed = parse_native_record(bytes, 0, &locator(bytes)).unwrap();
+    let annotation = claude_annotation(&parsed.rows[0], None, None).unwrap();
+    let activity = annotation.activity.unwrap();
+    let invocation = activity.invocation.unwrap();
+    assert_eq!(invocation.tool, "mcp__forge__read");
+    assert_eq!((invocation.protocol, invocation.server), (None, None));
+    assert_eq!(
+        activity
+            .facts
+            .iter()
+            .map(|fact| (fact.kind, fact.value.as_str()))
+            .collect::<Vec<_>>(),
+        [
+            (LiteralFactKind::Command, " c "),
+            (LiteralFactKind::File, " p "),
+            (LiteralFactKind::Url, " u "),
+        ]
+    );
+}
+
+#[test]
+fn claude_duplicate_result_content_retains_row_and_marks_capture_unavailable() {
+    let bytes = br#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"call","content":"one","content":"two"}]}}"#;
+    let parsed = parse_native_record(bytes, 0, &locator(bytes)).unwrap();
+    assert_eq!(parsed.rows.len(), 1);
+    let annotation = claude_annotation(&parsed.rows[0], None, None).unwrap();
+    assert!(annotation.structured_content.is_none());
+    let result = annotation.activity.unwrap().result.unwrap();
+    assert_eq!(result.text, ActivityTextCapture::Unavailable);
+    assert_eq!(result.structured_content, ActivityJsonCapture::Unavailable);
+}

--- a/crates/ctx-history-provider-claude-cursor/src/cursor/parser.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/cursor/parser.rs
@@ -15,10 +15,23 @@ pub(crate) enum CursorRejectionKind {
     UnsupportedShape,
 }
 
+impl CursorRejectionKind {
+    fn from_json_error(error: &serde_json::Error) -> Self {
+        match error.classify() {
+            serde_json::error::Category::Syntax | serde_json::error::Category::Eof => {
+                Self::MalformedJson
+            }
+            serde_json::error::Category::Data | serde_json::error::Category::Io => {
+                Self::UnsupportedShape
+            }
+        }
+    }
+}
+
 pub(super) enum CursorJsonlRecordOutcome {
     Events(Vec<super::projection::CursorNativeEvent>),
     Ignored,
-    Rejected(String),
+    Rejected(CursorRejectionKind, String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -95,7 +108,7 @@ pub(super) fn project_cursor_jsonl_record(
             byte_end_exclusive,
         )? {
             CursorJsonlRecordOutcome::Events(events) => Some(events),
-            CursorJsonlRecordOutcome::Ignored | CursorJsonlRecordOutcome::Rejected(_) => None,
+            CursorJsonlRecordOutcome::Ignored | CursorJsonlRecordOutcome::Rejected(_, _) => None,
         },
     )
 }
@@ -112,10 +125,16 @@ pub(super) fn project_cursor_jsonl_record_with_rejection(
     }
     let classification = match classify_cursor_line(bytes) {
         Ok(classification) => classification,
-        Err(CursorRejectionKind::UnsupportedShape) => return Ok(CursorJsonlRecordOutcome::Ignored),
+        Err(CursorRejectionKind::UnsupportedShape) => {
+            return Ok(CursorJsonlRecordOutcome::Rejected(
+                CursorRejectionKind::UnsupportedShape,
+                "Cursor record has a well-formed but unsupported shape".to_owned(),
+            ))
+        }
         Err(CursorRejectionKind::MalformedJson) => {
             return Ok(CursorJsonlRecordOutcome::Rejected(
-                "Cursor record is malformed JSON or repeats a critical selector".to_owned(),
+                CursorRejectionKind::MalformedJson,
+                "Cursor record is malformed JSON".to_owned(),
             ))
         }
     };
@@ -129,9 +148,10 @@ pub(super) fn project_cursor_jsonl_record_with_rejection(
     ) {
         Ok(record) => record,
         Err(error) => {
-            return Ok(CursorJsonlRecordOutcome::Rejected(format!(
-                "Cursor record could not be decoded safely: {error}"
-            )))
+            return Ok(CursorJsonlRecordOutcome::Rejected(
+                CursorRejectionKind::from_json_error(&error),
+                format!("Cursor record could not be decoded safely: {error}"),
+            ))
         }
     };
     Ok(CursorJsonlRecordOutcome::Events(
@@ -683,7 +703,26 @@ fn cursor_literal_kind_for_key(key: &str) -> Option<ctx_history_core::LiteralFac
 
 #[cfg(test)]
 mod tests {
-    use super::project_cursor_jsonl_record;
+    use super::{
+        project_cursor_jsonl_record, project_cursor_jsonl_record_with_rejection,
+        CursorJsonlRecordOutcome, CursorRejectionKind,
+    };
+
+    #[test]
+    fn cursor_distinguishes_malformed_json_from_unsupported_shapes() {
+        for (record, expected) in [
+            (b"{".as_slice(), CursorRejectionKind::MalformedJson),
+            (b"[]".as_slice(), CursorRejectionKind::UnsupportedShape),
+        ] {
+            let outcome =
+                project_cursor_jsonl_record_with_rejection(record, 0, 0, 0, record.len() as u64)
+                    .unwrap();
+            assert!(matches!(
+                outcome,
+                CursorJsonlRecordOutcome::Rejected(kind, _) if kind == expected
+            ));
+        }
+    }
 
     fn assert_rejected(label: &str, record: &[u8]) {
         assert!(

--- a/crates/ctx-history-provider-claude-cursor/src/cursor/parser.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/cursor/parser.rs
@@ -15,6 +15,12 @@ pub(crate) enum CursorRejectionKind {
     UnsupportedShape,
 }
 
+pub(super) enum CursorJsonlRecordOutcome {
+    Events(Vec<super::projection::CursorNativeEvent>),
+    Ignored,
+    Rejected(String),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum CursorSafePart {
     BodyFree {
@@ -80,12 +86,38 @@ pub(super) fn project_cursor_jsonl_record(
     byte_start: u64,
     byte_end_exclusive: u64,
 ) -> Result<Option<Vec<super::projection::CursorNativeEvent>>> {
+    Ok(
+        match project_cursor_jsonl_record_with_rejection(
+            bytes,
+            semantic_ordinal,
+            physical_ordinal,
+            byte_start,
+            byte_end_exclusive,
+        )? {
+            CursorJsonlRecordOutcome::Events(events) => Some(events),
+            CursorJsonlRecordOutcome::Ignored | CursorJsonlRecordOutcome::Rejected(_) => None,
+        },
+    )
+}
+
+pub(super) fn project_cursor_jsonl_record_with_rejection(
+    bytes: &[u8],
+    semantic_ordinal: u64,
+    physical_ordinal: u64,
+    byte_start: u64,
+    byte_end_exclusive: u64,
+) -> Result<CursorJsonlRecordOutcome> {
     if bytes.iter().all(u8::is_ascii_whitespace) {
-        return Ok(None);
+        return Ok(CursorJsonlRecordOutcome::Ignored);
     }
     let classification = match classify_cursor_line(bytes) {
         Ok(classification) => classification,
-        Err(_) => return Ok(None),
+        Err(CursorRejectionKind::UnsupportedShape) => return Ok(CursorJsonlRecordOutcome::Ignored),
+        Err(CursorRejectionKind::MalformedJson) => {
+            return Ok(CursorJsonlRecordOutcome::Rejected(
+                "Cursor record is malformed JSON or repeats a critical selector".to_owned(),
+            ))
+        }
     };
     let sanitized = match decode_sanitized_record(
         bytes,
@@ -96,9 +128,15 @@ pub(super) fn project_cursor_jsonl_record(
         &classification,
     ) {
         Ok(record) => record,
-        Err(_) => return Ok(None),
+        Err(error) => {
+            return Ok(CursorJsonlRecordOutcome::Rejected(format!(
+                "Cursor record could not be decoded safely: {error}"
+            )))
+        }
     };
-    Ok(Some(super::projection::project_cursor_record(sanitized)?))
+    Ok(CursorJsonlRecordOutcome::Events(
+        super::projection::project_cursor_record(sanitized)?,
+    ))
 }
 
 fn decode_sanitized_record(

--- a/crates/ctx-history-provider-claude-cursor/src/cursor/parser/classification.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/cursor/parser/classification.rs
@@ -49,10 +49,10 @@ pub(super) fn classify_cursor_line(
     let mut deserializer = serde_json::Deserializer::from_slice(bytes);
     let classified = CursorClassificationSeed
         .deserialize(&mut deserializer)
-        .map_err(|_| CursorRejectionKind::MalformedJson)?;
+        .map_err(|error| CursorRejectionKind::from_json_error(&error))?;
     deserializer
         .end()
-        .map_err(|_| CursorRejectionKind::MalformedJson)?;
+        .map_err(|error| CursorRejectionKind::from_json_error(&error))?;
     classified.ok_or(CursorRejectionKind::UnsupportedShape)
 }
 

--- a/crates/ctx-history-provider-claude-cursor/src/cursor/source_backed.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/cursor/source_backed.rs
@@ -28,12 +28,17 @@ use std::{
 use super::{
     discover_cursor_transcripts,
     layout::CursorTranscriptPath,
-    parser::project_cursor_jsonl_record,
+    parser::{
+        project_cursor_jsonl_record, project_cursor_jsonl_record_with_rejection,
+        CursorJsonlRecordOutcome,
+    },
     projection::{CursorEventBody, CursorNativeEvent},
 };
 use crate::CURSOR_AGENT_TRANSCRIPT_SOURCE_FORMAT;
 use ctx_history_jsonl::{
     fit_jsonl_activity, selected_content_fits, JsonlActivityObservedBytes, JsonlFamilyAdapter,
+    JsonlOversizedRecordPolicy, SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDraft,
+    SourceBackedRecordRejectionDrafts,
 };
 use ctx_history_provider_runtime::{
     read_bounded_record_unhashed, source_io::OpenedProviderSourceFile, CaptureError,
@@ -55,7 +60,7 @@ const NATIVE_EVENT_LOGICAL_KIND: &str = "cursor.logical-event-v3";
 const LOGICAL_SESSION_KIND: &str = "cursor-session";
 const LOGICAL_EVENT_KIND: &str = "cursor-event";
 const SOURCE_SCHEMA_VARIANT: &str = "cursor-agent-transcript-jsonl-v1";
-const PARSER_REVISION: &str = "cursor-shared-jsonl-core-activity-v1";
+const PARSER_REVISION: &str = "cursor-shared-jsonl-core-activity-v2-record-rejections";
 const EVENT_SEQUENCE_PARTS: u64 = u16::MAX as u64 + 1;
 
 mod binding;
@@ -156,6 +161,10 @@ where
 
     fn append_mode(&self) -> JsonlFamilyAppendMode {
         JsonlFamilyAppendMode::ProjectorPreflight(true)
+    }
+
+    fn oversized_record_policy(&self) -> JsonlOversizedRecordPolicy {
+        JsonlOversizedRecordPolicy::RejectRecord
     }
 
     fn discover(&self, root: &Path) -> Result<ProviderJsonlInventory> {
@@ -265,6 +274,7 @@ where
         let session_id = session_id(leaf.source(), &binding.native_session_id)?;
         Ok(Box::new(CursorProjector {
             source: leaf.source().clone(),
+            source_selector: leaf.source_path().display().to_string(),
             native_session_id: binding.native_session_id,
             session_id,
             event_identities: match (mode, base_event_lookup) {
@@ -273,16 +283,43 @@ where
                 }
                 _ => JsonlOrderedAppendOccurrenceState::default(),
             },
+            rejected_records: 0,
+            record_rejections: SourceBackedRecordRejectionDrafts::default(),
         }))
     }
 }
 
 struct CursorProjector<B: ProviderRuntimeBinding> {
     source: SourceKey,
+    source_selector: String,
     native_session_id: String,
     session_id: StableEntityId,
     event_identities:
         JsonlOrderedAppendOccurrenceState<CursorLogicalEventIdentity, ProviderBaseEventLookup<B>>,
+    rejected_records: u64,
+    record_rejections: SourceBackedRecordRejectionDrafts,
+}
+
+impl<B: ProviderRuntimeBinding> CursorProjector<B> {
+    fn reject(&mut self, record: JsonlRecordRef<'_>, detail: String) -> Result<()> {
+        self.rejected_records =
+            self.rejected_records
+                .checked_add(1)
+                .ok_or(CaptureError::SystemInvariant(
+                    "Cursor record rejection count overflowed",
+                ))?;
+        self.record_rejections
+            .record(SourceBackedRecordRejectionDraft {
+                source: self.source.clone(),
+                provider: CaptureProvider::Cursor,
+                source_selector: self.source_selector.clone(),
+                line_number: record.evidence().physical_ordinal().saturating_add(1),
+                payload_type: None,
+                class: SourceBackedRecordRejectionClass::MalformedRecord,
+                detail,
+            });
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -333,16 +370,23 @@ where
     ) -> Result<()> {
         #[cfg(any(test, feature = "test-support"))]
         observe_cursor_projected_record(&self.source);
+        if record.oversized() {
+            return self.reject(
+                record,
+                format!("Cursor record exceeds the {MAX_PROVIDER_JSONL_LINE_BYTES} byte limit"),
+            );
+        }
         let evidence = record.evidence();
-        let Some(events) = project_cursor_jsonl_record(
+        let events = match project_cursor_jsonl_record_with_rejection(
             record.bytes(),
             evidence.physical_ordinal(),
             evidence.physical_ordinal(),
             evidence.byte_start(),
             evidence.byte_end_exclusive(),
-        )?
-        else {
-            return Ok(());
+        )? {
+            CursorJsonlRecordOutcome::Events(events) => events,
+            CursorJsonlRecordOutcome::Ignored => return Ok(()),
+            CursorJsonlRecordOutcome::Rejected(detail) => return self.reject(record, detail),
         };
         for event in events {
             let duplicate_occurrence = next_event_occurrence::<B>(
@@ -372,6 +416,14 @@ where
 
     fn provider_checkpoint(&self) -> Result<Option<TypedKey>> {
         Ok(None)
+    }
+
+    fn rejected_records(&self) -> u64 {
+        self.rejected_records
+    }
+
+    fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
+        std::mem::take(&mut self.record_rejections)
     }
 }
 

--- a/crates/ctx-history-provider-claude-cursor/src/cursor/source_backed.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/cursor/source_backed.rs
@@ -30,14 +30,14 @@ use super::{
     layout::CursorTranscriptPath,
     parser::{
         project_cursor_jsonl_record, project_cursor_jsonl_record_with_rejection,
-        CursorJsonlRecordOutcome,
+        CursorJsonlRecordOutcome, CursorRejectionKind,
     },
     projection::{CursorEventBody, CursorNativeEvent},
 };
 use crate::CURSOR_AGENT_TRANSCRIPT_SOURCE_FORMAT;
 use ctx_history_jsonl::{
     fit_jsonl_activity, selected_content_fits, JsonlActivityObservedBytes, JsonlFamilyAdapter,
-    JsonlOversizedRecordPolicy, SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDraft,
+    JsonlOversizedRecordPolicy, JsonlRecordRejections, SourceBackedRecordRejectionClass,
     SourceBackedRecordRejectionDrafts,
 };
 use ctx_history_provider_runtime::{
@@ -274,7 +274,6 @@ where
         let session_id = session_id(leaf.source(), &binding.native_session_id)?;
         Ok(Box::new(CursorProjector {
             source: leaf.source().clone(),
-            source_selector: leaf.source_path().display().to_string(),
             native_session_id: binding.native_session_id,
             session_id,
             event_identities: match (mode, base_event_lookup) {
@@ -283,42 +282,33 @@ where
                 }
                 _ => JsonlOrderedAppendOccurrenceState::default(),
             },
-            rejected_records: 0,
-            record_rejections: SourceBackedRecordRejectionDrafts::default(),
+            rejections: JsonlRecordRejections::new(
+                leaf.source().clone(),
+                CaptureProvider::Cursor,
+                leaf.source_path().display().to_string(),
+            ),
         }))
     }
 }
 
 struct CursorProjector<B: ProviderRuntimeBinding> {
     source: SourceKey,
-    source_selector: String,
     native_session_id: String,
     session_id: StableEntityId,
     event_identities:
         JsonlOrderedAppendOccurrenceState<CursorLogicalEventIdentity, ProviderBaseEventLookup<B>>,
-    rejected_records: u64,
-    record_rejections: SourceBackedRecordRejectionDrafts,
+    rejections: JsonlRecordRejections,
 }
 
 impl<B: ProviderRuntimeBinding> CursorProjector<B> {
-    fn reject(&mut self, record: JsonlRecordRef<'_>, detail: String) -> Result<()> {
-        self.rejected_records =
-            self.rejected_records
-                .checked_add(1)
-                .ok_or(CaptureError::SystemInvariant(
-                    "Cursor record rejection count overflowed",
-                ))?;
-        self.record_rejections
-            .record(SourceBackedRecordRejectionDraft {
-                source: self.source.clone(),
-                provider: CaptureProvider::Cursor,
-                source_selector: self.source_selector.clone(),
-                line_number: record.evidence().physical_ordinal().saturating_add(1),
-                payload_type: None,
-                class: SourceBackedRecordRejectionClass::MalformedRecord,
-                detail,
-            });
-        Ok(())
+    fn reject(&mut self, record: JsonlRecordRef<'_>, kind: CursorRejectionKind, detail: String) {
+        let class = match kind {
+            CursorRejectionKind::MalformedJson => SourceBackedRecordRejectionClass::MalformedRecord,
+            CursorRejectionKind::UnsupportedShape => {
+                SourceBackedRecordRejectionClass::UnsupportedRecord
+            }
+        };
+        self.rejections.record(record, class, detail);
     }
 }
 
@@ -371,10 +361,12 @@ where
         #[cfg(any(test, feature = "test-support"))]
         observe_cursor_projected_record(&self.source);
         if record.oversized() {
-            return self.reject(
+            self.reject(
                 record,
+                CursorRejectionKind::MalformedJson,
                 format!("Cursor record exceeds the {MAX_PROVIDER_JSONL_LINE_BYTES} byte limit"),
             );
+            return Ok(());
         }
         let evidence = record.evidence();
         let events = match project_cursor_jsonl_record_with_rejection(
@@ -386,7 +378,10 @@ where
         )? {
             CursorJsonlRecordOutcome::Events(events) => events,
             CursorJsonlRecordOutcome::Ignored => return Ok(()),
-            CursorJsonlRecordOutcome::Rejected(detail) => return self.reject(record, detail),
+            CursorJsonlRecordOutcome::Rejected(kind, detail) => {
+                self.reject(record, kind, detail);
+                return Ok(());
+            }
         };
         for event in events {
             let duplicate_occurrence = next_event_occurrence::<B>(
@@ -419,11 +414,11 @@ where
     }
 
     fn rejected_records(&self) -> u64 {
-        self.rejected_records
+        self.rejections.count()
     }
 
     fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
-        std::mem::take(&mut self.record_rejections)
+        self.rejections.take_drafts()
     }
 }
 

--- a/crates/ctx-history-provider-gemini/src/nativepath/parser.rs
+++ b/crates/ctx-history-provider-gemini/src/nativepath/parser.rs
@@ -144,14 +144,20 @@ pub(crate) struct GeminiBorrowedRecordParser {
 
 pub(crate) struct GeminiBorrowedRecordProjection {
     pub(crate) events: Vec<GeminiRetainedEvent>,
-    pub(crate) rejection_reason: Option<String>,
+    pub(crate) rejection: Option<(GeminiRecordRejectionKind, String)>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum GeminiRecordRejectionKind {
+    Malformed,
+    Unsupported,
 }
 
 impl GeminiBorrowedRecordProjection {
     fn events(events: Vec<GeminiRetainedEvent>) -> Self {
         Self {
             events,
-            rejection_reason: None,
+            rejection: None,
         }
     }
 
@@ -159,10 +165,10 @@ impl GeminiBorrowedRecordProjection {
         Self::events(Vec::new())
     }
 
-    fn rejected(reason: impl Into<String>) -> Self {
+    fn rejected(kind: GeminiRecordRejectionKind, reason: impl Into<String>) -> Self {
         Self {
             events: Vec::new(),
-            rejection_reason: Some(reason.into()),
+            rejection: Some((kind, reason.into())),
         }
     }
 }
@@ -198,9 +204,18 @@ impl GeminiBorrowedRecordParser {
         let probe = match serde_json::from_slice::<GeminiRecordProbe>(payload) {
             Ok(probe) => probe,
             Err(error) => {
-                return Ok(GeminiBorrowedRecordProjection::rejected(format!(
-                    "malformed Gemini JSONL: {error}"
-                )))
+                let kind = match error.classify() {
+                    serde_json::error::Category::Syntax | serde_json::error::Category::Eof => {
+                        GeminiRecordRejectionKind::Malformed
+                    }
+                    serde_json::error::Category::Data | serde_json::error::Category::Io => {
+                        GeminiRecordRejectionKind::Unsupported
+                    }
+                };
+                return Ok(GeminiBorrowedRecordProjection::rejected(
+                    kind,
+                    format!("Gemini JSONL record could not be decoded: {error}"),
+                ));
             }
         };
         let class = probe.classify();
@@ -251,7 +266,12 @@ impl GeminiBorrowedRecordParser {
             GeminiRecordClass::Result => {
                 let decoded = match decode_result_record(payload, raw_ordinal, source_record) {
                     Ok(decoded) => decoded,
-                    Err(reason) => return Ok(GeminiBorrowedRecordProjection::rejected(reason)),
+                    Err(reason) => {
+                        return Ok(GeminiBorrowedRecordProjection::rejected(
+                            GeminiRecordRejectionKind::Unsupported,
+                            reason,
+                        ))
+                    }
                 };
                 if decoded
                     .events
@@ -259,6 +279,7 @@ impl GeminiBorrowedRecordParser {
                     .any(|(_, bytes)| *bytes > MAX_GEMINI_SINGLE_RECORD_PAGE_BYTES)
                 {
                     return Ok(GeminiBorrowedRecordProjection::rejected(
+                        GeminiRecordRejectionKind::Unsupported,
                         "Gemini result record exceeds the bounded event size",
                     ));
                 }
@@ -272,17 +293,26 @@ impl GeminiBorrowedRecordParser {
                     match decode_retained_event(payload, class, raw_ordinal, source_record) {
                         Ok(decoded) => decoded,
                         Err(GeminiDecodingError::Invalid(reason)) => {
-                            return Ok(GeminiBorrowedRecordProjection::rejected(reason));
+                            return Ok(GeminiBorrowedRecordProjection::rejected(
+                                GeminiRecordRejectionKind::Unsupported,
+                                reason,
+                            ));
                         }
                     };
                 let mut events = Vec::with_capacity(decoded.len());
                 for decoded in decoded {
                     let event_bytes = match retained_event_bytes(&decoded) {
                         Ok(event_bytes) => event_bytes,
-                        Err(reason) => return Ok(GeminiBorrowedRecordProjection::rejected(reason)),
+                        Err(reason) => {
+                            return Ok(GeminiBorrowedRecordProjection::rejected(
+                                GeminiRecordRejectionKind::Unsupported,
+                                reason,
+                            ))
+                        }
                     };
                     if event_bytes > MAX_GEMINI_SINGLE_RECORD_PAGE_BYTES {
                         return Ok(GeminiBorrowedRecordProjection::rejected(
+                            GeminiRecordRejectionKind::Unsupported,
                             "Gemini record exceeds the bounded event size",
                         ));
                     }

--- a/crates/ctx-history-provider-gemini/src/nativepath/parser.rs
+++ b/crates/ctx-history-provider-gemini/src/nativepath/parser.rs
@@ -142,6 +142,31 @@ pub(crate) struct GeminiBorrowedRecordParser {
     page_physical_records: usize,
 }
 
+pub(crate) struct GeminiBorrowedRecordProjection {
+    pub(crate) events: Vec<GeminiRetainedEvent>,
+    pub(crate) rejection_reason: Option<String>,
+}
+
+impl GeminiBorrowedRecordProjection {
+    fn events(events: Vec<GeminiRetainedEvent>) -> Self {
+        Self {
+            events,
+            rejection_reason: None,
+        }
+    }
+
+    fn ignored() -> Self {
+        Self::events(Vec::new())
+    }
+
+    fn rejected(reason: impl Into<String>) -> Self {
+        Self {
+            events: Vec::new(),
+            rejection_reason: Some(reason.into()),
+        }
+    }
+}
+
 impl GeminiBorrowedRecordParser {
     pub(crate) fn new(source: GeminiTranscriptSource, session: GeminiSession) -> Self {
         Self {
@@ -160,7 +185,7 @@ impl GeminiBorrowedRecordParser {
         byte_start: u64,
         byte_end_exclusive: u64,
         record_digest: [u8; 32],
-    ) -> GeminiScanResult<Vec<GeminiRetainedEvent>> {
+    ) -> GeminiScanResult<GeminiBorrowedRecordProjection> {
         if self.page_physical_records == MAX_GEMINI_NATIVE_PAGE_RECORDS {
             self.page_native_event_ids = GeminiNativeEventIds::default();
             self.page_physical_records = 0;
@@ -168,11 +193,15 @@ impl GeminiBorrowedRecordParser {
         self.page_physical_records = self.page_physical_records.saturating_add(1);
 
         if payload.iter().all(u8::is_ascii_whitespace) {
-            return Ok(Vec::new());
+            return Ok(GeminiBorrowedRecordProjection::ignored());
         }
         let probe = match serde_json::from_slice::<GeminiRecordProbe>(payload) {
             Ok(probe) => probe,
-            Err(_) => return Ok(Vec::new()),
+            Err(error) => {
+                return Ok(GeminiBorrowedRecordProjection::rejected(format!(
+                    "malformed Gemini JSONL: {error}"
+                )))
+            }
         };
         let class = probe.classify();
         if class == GeminiRecordClass::Header {
@@ -196,10 +225,10 @@ impl GeminiBorrowedRecordParser {
                 return Err(GeminiError::SourceChangedDuringCapture.into());
             }
             self.header_seen = true;
-            return Ok(Vec::new());
+            return Ok(GeminiBorrowedRecordProjection::ignored());
         }
         if !self.header_seen {
-            return Ok(Vec::new());
+            return Ok(GeminiBorrowedRecordProjection::ignored());
         }
 
         let native_event_id = nonempty(probe.id.clone());
@@ -209,7 +238,7 @@ impl GeminiBorrowedRecordParser {
                 .validate(native_event_id, raw_ordinal)
                 .is_err()
             {
-                return Ok(Vec::new());
+                return Ok(GeminiBorrowedRecordProjection::ignored());
             }
         }
 
@@ -222,14 +251,16 @@ impl GeminiBorrowedRecordParser {
             GeminiRecordClass::Result => {
                 let decoded = match decode_result_record(payload, raw_ordinal, source_record) {
                     Ok(decoded) => decoded,
-                    Err(_) => return Ok(Vec::new()),
+                    Err(reason) => return Ok(GeminiBorrowedRecordProjection::rejected(reason)),
                 };
                 if decoded
                     .events
                     .iter()
                     .any(|(_, bytes)| *bytes > MAX_GEMINI_SINGLE_RECORD_PAGE_BYTES)
                 {
-                    return Ok(Vec::new());
+                    return Ok(GeminiBorrowedRecordProjection::rejected(
+                        "Gemini result record exceeds the bounded event size",
+                    ));
                 }
                 decoded.events.into_iter().map(|(event, _)| event).collect()
             }
@@ -241,17 +272,19 @@ impl GeminiBorrowedRecordParser {
                     match decode_retained_event(payload, class, raw_ordinal, source_record) {
                         Ok(decoded) => decoded,
                         Err(GeminiDecodingError::Invalid(reason)) => {
-                            drop(reason);
-                            return Ok(Vec::new());
+                            return Ok(GeminiBorrowedRecordProjection::rejected(reason));
                         }
                     };
                 let mut events = Vec::with_capacity(decoded.len());
                 for decoded in decoded {
-                    let Ok(event_bytes) = retained_event_bytes(&decoded) else {
-                        return Ok(Vec::new());
+                    let event_bytes = match retained_event_bytes(&decoded) {
+                        Ok(event_bytes) => event_bytes,
+                        Err(reason) => return Ok(GeminiBorrowedRecordProjection::rejected(reason)),
                     };
                     if event_bytes > MAX_GEMINI_SINGLE_RECORD_PAGE_BYTES {
-                        return Ok(Vec::new());
+                        return Ok(GeminiBorrowedRecordProjection::rejected(
+                            "Gemini record exceeds the bounded event size",
+                        ));
                     }
                     let mut event = decoded.event;
                     if event.occurred_at.is_none() {
@@ -267,7 +300,7 @@ impl GeminiBorrowedRecordParser {
             self.page_native_event_ids
                 .commit_at(native_event_id, raw_ordinal);
         }
-        Ok(events)
+        Ok(GeminiBorrowedRecordProjection::events(events))
     }
 
     pub(crate) fn finish(&self) -> GeminiScanResult<()> {

--- a/crates/ctx-history-provider-gemini/src/nativepath/source_backed.rs
+++ b/crates/ctx-history-provider-gemini/src/nativepath/source_backed.rs
@@ -21,7 +21,9 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 use super::dto::{GeminiEventBody, GeminiTranscriptLayout};
-use super::parser::{read_gemini_session_header, GeminiBorrowedRecordParser};
+use super::parser::{
+    read_gemini_session_header, GeminiBorrowedRecordParser, GeminiRecordRejectionKind,
+};
 use super::{
     discover_gemini_transcripts, GeminiFileObservation, GeminiScanError, GeminiSession,
     GeminiTranscriptSource,
@@ -30,8 +32,8 @@ use crate::io::{OpenedProviderSourceFile, ProviderSourceRoot};
 use ctx_history_jsonl::{
     JsonlFamilyAdapter, JsonlFamilyAppendMode, JsonlFamilyInventory, JsonlFamilyLeaf,
     JsonlFamilyProjector, JsonlFamilyTerminalProof, JsonlFamilyWorkerContext,
-    JsonlOversizedRecordPolicy, JsonlReader, JsonlRecordRef, SourceBackedRecordRejectionClass,
-    SourceBackedRecordRejectionDraft, SourceBackedRecordRejectionDrafts,
+    JsonlOversizedRecordPolicy, JsonlReader, JsonlRecordRef, JsonlRecordRejections,
+    SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDrafts,
 };
 use ctx_history_source_io::MAX_PROVIDER_JSONL_LINE_BYTES;
 
@@ -347,7 +349,6 @@ impl<R: GeminiRuntime> JsonlFamilyAdapter for GeminiJsonlAdapter<R> {
         Ok(Box::new(GeminiProjector {
             parser: GeminiBorrowedRecordParser::new(transcript.clone(), binding.session.clone()),
             source: leaf.source().clone(),
-            source_selector: leaf.source_path().display().to_string(),
             session: binding.session,
             session_id,
             parent_session_id,
@@ -356,8 +357,11 @@ impl<R: GeminiRuntime> JsonlFamilyAdapter for GeminiJsonlAdapter<R> {
             authority: Arc::clone(leaf.authority()),
             native_item_ids: GeminiSourceNativeItemIds::default(),
             emitted_event_digests: BTreeSet::new(),
-            rejected_records: 0,
-            record_rejections: SourceBackedRecordRejectionDrafts::default(),
+            rejections: JsonlRecordRejections::new(
+                leaf.source().clone(),
+                CaptureProvider::Gemini,
+                leaf.source_path().display().to_string(),
+            ),
             runtime: PhantomData,
         }))
     }
@@ -405,7 +409,6 @@ fn owns_gemini_source(source: &SourceKey) -> bool {
 struct GeminiProjector<R> {
     parser: GeminiBorrowedRecordParser,
     source: SourceKey,
-    source_selector: String,
     session: GeminiSession,
     session_id: StableEntityId,
     parent_session_id: Option<StableEntityId>,
@@ -414,31 +417,8 @@ struct GeminiProjector<R> {
     authority: Arc<ProviderSourceRoot>,
     native_item_ids: GeminiSourceNativeItemIds,
     emitted_event_digests: BTreeSet<[u8; 32]>,
-    rejected_records: u64,
-    record_rejections: SourceBackedRecordRejectionDrafts,
+    rejections: JsonlRecordRejections,
     runtime: PhantomData<fn() -> R>,
-}
-
-impl<R> GeminiProjector<R> {
-    fn reject(&mut self, record: JsonlRecordRef<'_>, detail: String) -> GeminiResult<()> {
-        self.rejected_records =
-            self.rejected_records
-                .checked_add(1)
-                .ok_or(GeminiError::SystemInvariant(
-                    "Gemini record rejection count overflowed",
-                ))?;
-        self.record_rejections
-            .record(SourceBackedRecordRejectionDraft {
-                source: self.source.clone(),
-                provider: CaptureProvider::Gemini,
-                source_selector: self.source_selector.clone(),
-                line_number: record.evidence().physical_ordinal().saturating_add(1),
-                payload_type: None,
-                class: SourceBackedRecordRejectionClass::MalformedRecord,
-                detail,
-            });
-        Ok(())
-    }
 }
 
 #[derive(Debug, Default)]
@@ -513,10 +493,11 @@ impl<R: GeminiRuntime> JsonlFamilyProjector for GeminiProjector<R> {
         emit: &mut dyn FnMut(CoreRecord) -> GeminiResult<()>,
     ) -> GeminiResult<()> {
         if record.oversized() {
-            return self.reject(
+            self.rejections.malformed(
                 record,
                 format!("Gemini record exceeds the {MAX_PROVIDER_JSONL_LINE_BYTES} byte limit"),
             );
+            return Ok(());
         }
         let native_item_id = self.native_item_ids.candidate(record.bytes());
         if native_item_id
@@ -536,8 +517,17 @@ impl<R: GeminiRuntime> JsonlFamilyProjector for GeminiProjector<R> {
                 evidence.record_digest(),
             )
             .map_err(capture_scan_error)?;
-        if let Some(reason) = projection.rejection_reason {
-            return self.reject(record, reason);
+        if let Some((kind, reason)) = projection.rejection {
+            let class = match kind {
+                GeminiRecordRejectionKind::Malformed => {
+                    SourceBackedRecordRejectionClass::MalformedRecord
+                }
+                GeminiRecordRejectionKind::Unsupported => {
+                    SourceBackedRecordRejectionClass::UnsupportedRecord
+                }
+            };
+            self.rejections.record(record, class, reason);
+            return Ok(());
         }
         let events = projection.events;
         if !events.is_empty() {
@@ -578,11 +568,11 @@ impl<R: GeminiRuntime> JsonlFamilyProjector for GeminiProjector<R> {
     }
 
     fn rejected_records(&self) -> u64 {
-        self.rejected_records
+        self.rejections.count()
     }
 
     fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
-        std::mem::take(&mut self.record_rejections)
+        self.rejections.take_drafts()
     }
 }
 

--- a/crates/ctx-history-provider-gemini/src/nativepath/source_backed.rs
+++ b/crates/ctx-history-provider-gemini/src/nativepath/source_backed.rs
@@ -29,9 +29,11 @@ use super::{
 use crate::io::{OpenedProviderSourceFile, ProviderSourceRoot};
 use ctx_history_jsonl::{
     JsonlFamilyAdapter, JsonlFamilyAppendMode, JsonlFamilyInventory, JsonlFamilyLeaf,
-    JsonlFamilyProjector, JsonlFamilyTerminalProof, JsonlFamilyWorkerContext, JsonlReader,
-    JsonlRecordRef,
+    JsonlFamilyProjector, JsonlFamilyTerminalProof, JsonlFamilyWorkerContext,
+    JsonlOversizedRecordPolicy, JsonlReader, JsonlRecordRef, SourceBackedRecordRejectionClass,
+    SourceBackedRecordRejectionDraft, SourceBackedRecordRejectionDrafts,
 };
+use ctx_history_source_io::MAX_PROVIDER_JSONL_LINE_BYTES;
 
 use crate::{GeminiError, GeminiResult, GeminiRuntime, GEMINI_CLI_SOURCE_FORMAT};
 #[cfg(any(test, feature = "test-support"))]
@@ -47,7 +49,8 @@ const GEMINI_LOGICAL_EVENT_KIND: &str = "gemini-event";
 const GEMINI_SOURCE_SCHEMA_VARIANT: &str = "gemini-nativepath-jsonl-v0";
 #[cfg(any(test, feature = "test-support"))]
 const GEMINI_SOURCE_BACKED_PARSER_REVISION_V1: &str = "gemini-nativepath-core-activity-v1";
-const GEMINI_SOURCE_BACKED_PARSER_REVISION: &str = "gemini-nativepath-core-activity-v2";
+const GEMINI_SOURCE_BACKED_PARSER_REVISION: &str =
+    "gemini-nativepath-core-activity-v2-record-rejections";
 const MAX_GEMINI_ACTIVITY_FIELD_BYTES: usize = 64 * 1024;
 
 #[cfg(any(test, feature = "test-support"))]
@@ -186,6 +189,10 @@ impl<R: GeminiRuntime> JsonlFamilyAdapter for GeminiJsonlAdapter<R> {
 
     fn append_mode(&self) -> JsonlFamilyAppendMode {
         JsonlFamilyAppendMode::ProjectorPreflight(false)
+    }
+
+    fn oversized_record_policy(&self) -> JsonlOversizedRecordPolicy {
+        JsonlOversizedRecordPolicy::RejectRecord
     }
 
     fn discover(&self, root: &Path) -> GeminiResult<JsonlFamilyInventory<GeminiError>> {
@@ -340,6 +347,7 @@ impl<R: GeminiRuntime> JsonlFamilyAdapter for GeminiJsonlAdapter<R> {
         Ok(Box::new(GeminiProjector {
             parser: GeminiBorrowedRecordParser::new(transcript.clone(), binding.session.clone()),
             source: leaf.source().clone(),
+            source_selector: leaf.source_path().display().to_string(),
             session: binding.session,
             session_id,
             parent_session_id,
@@ -348,6 +356,8 @@ impl<R: GeminiRuntime> JsonlFamilyAdapter for GeminiJsonlAdapter<R> {
             authority: Arc::clone(leaf.authority()),
             native_item_ids: GeminiSourceNativeItemIds::default(),
             emitted_event_digests: BTreeSet::new(),
+            rejected_records: 0,
+            record_rejections: SourceBackedRecordRejectionDrafts::default(),
             runtime: PhantomData,
         }))
     }
@@ -395,6 +405,7 @@ fn owns_gemini_source(source: &SourceKey) -> bool {
 struct GeminiProjector<R> {
     parser: GeminiBorrowedRecordParser,
     source: SourceKey,
+    source_selector: String,
     session: GeminiSession,
     session_id: StableEntityId,
     parent_session_id: Option<StableEntityId>,
@@ -403,7 +414,31 @@ struct GeminiProjector<R> {
     authority: Arc<ProviderSourceRoot>,
     native_item_ids: GeminiSourceNativeItemIds,
     emitted_event_digests: BTreeSet<[u8; 32]>,
+    rejected_records: u64,
+    record_rejections: SourceBackedRecordRejectionDrafts,
     runtime: PhantomData<fn() -> R>,
+}
+
+impl<R> GeminiProjector<R> {
+    fn reject(&mut self, record: JsonlRecordRef<'_>, detail: String) -> GeminiResult<()> {
+        self.rejected_records =
+            self.rejected_records
+                .checked_add(1)
+                .ok_or(GeminiError::SystemInvariant(
+                    "Gemini record rejection count overflowed",
+                ))?;
+        self.record_rejections
+            .record(SourceBackedRecordRejectionDraft {
+                source: self.source.clone(),
+                provider: CaptureProvider::Gemini,
+                source_selector: self.source_selector.clone(),
+                line_number: record.evidence().physical_ordinal().saturating_add(1),
+                payload_type: None,
+                class: SourceBackedRecordRejectionClass::MalformedRecord,
+                detail,
+            });
+        Ok(())
+    }
 }
 
 #[derive(Debug, Default)]
@@ -477,6 +512,12 @@ impl<R: GeminiRuntime> JsonlFamilyProjector for GeminiProjector<R> {
         _worker: &mut JsonlFamilyWorkerContext<R>,
         emit: &mut dyn FnMut(CoreRecord) -> GeminiResult<()>,
     ) -> GeminiResult<()> {
+        if record.oversized() {
+            return self.reject(
+                record,
+                format!("Gemini record exceeds the {MAX_PROVIDER_JSONL_LINE_BYTES} byte limit"),
+            );
+        }
         let native_item_id = self.native_item_ids.candidate(record.bytes());
         if native_item_id
             .as_deref()
@@ -485,7 +526,7 @@ impl<R: GeminiRuntime> JsonlFamilyProjector for GeminiProjector<R> {
             return Ok(());
         }
         let evidence = record.evidence();
-        let events = self
+        let projection = self
             .parser
             .project(
                 record.bytes(),
@@ -495,6 +536,10 @@ impl<R: GeminiRuntime> JsonlFamilyProjector for GeminiProjector<R> {
                 evidence.record_digest(),
             )
             .map_err(capture_scan_error)?;
+        if let Some(reason) = projection.rejection_reason {
+            return self.reject(record, reason);
+        }
+        let events = projection.events;
         if !events.is_empty() {
             self.native_item_ids.remember(native_item_id);
         }
@@ -530,6 +575,14 @@ impl<R: GeminiRuntime> JsonlFamilyProjector for GeminiProjector<R> {
         self.parser.finish().map_err(capture_scan_error)?;
         self.source_file.revalidate_leaf()?;
         self.authority.revalidate()
+    }
+
+    fn rejected_records(&self) -> u64 {
+        self.rejected_records
+    }
+
+    fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
+        std::mem::take(&mut self.record_rejections)
     }
 }
 

--- a/crates/ctx-history-provider-mistral-mux/src/mistral_vibe/native_path/source_backed.rs
+++ b/crates/ctx-history-provider-mistral-mux/src/mistral_vibe/native_path/source_backed.rs
@@ -26,8 +26,7 @@ use ctx_history_jsonl::{
     fit_jsonl_activity, FallbackEventIdentityState, JsonlActivityObservedBytes, JsonlFamilyAdapter,
     JsonlFamilyAppendMode, JsonlFamilyInventory, JsonlFamilyLeaf, JsonlFamilyProjectionMode,
     JsonlFamilyProjector, JsonlFamilyWorkerContext, JsonlOversizedRecordPolicy, JsonlRecordRef,
-    SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDraft,
-    SourceBackedRecordRejectionDrafts,
+    JsonlRecordRejections, SourceBackedRecordRejectionDrafts,
 };
 use ctx_history_provider_runtime::{
     source_io::{OpenedProviderSourceFile, ProviderSourceRoot},
@@ -251,7 +250,6 @@ where
         let binding = decode_binding(leaf)?;
         Ok(Box::new(MistralProjector::<B> {
             source: leaf.source().clone(),
-            source_selector: leaf.source_path().display().to_string(),
             fallback_identities: FallbackEventIdentityState::new(
                 leaf.source().clone(),
                 binding.session_id,
@@ -263,42 +261,21 @@ where
             )?,
             native_identities: MistralNativeIdentityTracker::default(),
             binding,
-            rejected_records: 0,
-            record_rejections: SourceBackedRecordRejectionDrafts::default(),
+            rejections: JsonlRecordRejections::new(
+                leaf.source().clone(),
+                CaptureProvider::MistralVibe,
+                leaf.source_path().display().to_string(),
+            ),
         }))
     }
 }
 
 struct MistralProjector<B: ProviderRuntimeBinding> {
     source: SourceKey,
-    source_selector: String,
     binding: Binding,
     fallback_identities: FallbackEventIdentityState<ProviderBaseEventLookup<B>, CaptureError>,
     native_identities: MistralNativeIdentityTracker,
-    rejected_records: u64,
-    record_rejections: SourceBackedRecordRejectionDrafts,
-}
-
-impl<B: ProviderRuntimeBinding> MistralProjector<B> {
-    fn reject(&mut self, record: JsonlRecordRef<'_>, detail: String) -> Result<()> {
-        self.rejected_records =
-            self.rejected_records
-                .checked_add(1)
-                .ok_or(CaptureError::SystemInvariant(
-                    "Mistral Vibe record rejection count overflowed",
-                ))?;
-        self.record_rejections
-            .record(SourceBackedRecordRejectionDraft {
-                source: self.source.clone(),
-                provider: CaptureProvider::MistralVibe,
-                source_selector: self.source_selector.clone(),
-                line_number: record.evidence().physical_ordinal().saturating_add(1),
-                payload_type: None,
-                class: SourceBackedRecordRejectionClass::MalformedRecord,
-                detail,
-            });
-        Ok(())
-    }
+    rejections: JsonlRecordRejections,
 }
 
 impl<B> JsonlFamilyProjector for MistralProjector<B>
@@ -313,23 +290,34 @@ where
         _worker: &mut JsonlFamilyWorkerContext<Self::Runtime>,
         emit: &mut dyn FnMut(CoreRecord) -> Result<()>,
     ) -> Result<()> {
+        let bytes = record.bytes();
         if record.oversized() {
-            return self.reject(
+            self.rejections.malformed(
                 record,
                 format!(
                     "Mistral Vibe record exceeds the {MAX_PROVIDER_JSONL_LINE_BYTES} byte limit"
                 ),
             );
+            return Ok(());
         }
-        if let Err(error) = serde_json::from_slice::<Value>(record.bytes()) {
-            return self.reject(record, format!("malformed Mistral Vibe JSONL: {error}"));
+        if bytes.iter().all(u8::is_ascii_whitespace) {
+            return Ok(());
         }
-        if let Some(document) = core_record(
+        let value = match serde_json::from_slice::<Value>(bytes) {
+            Ok(value) => value,
+            Err(error) => {
+                self.rejections
+                    .malformed(record, format!("malformed Mistral Vibe JSONL: {error}"));
+                return Ok(());
+            }
+        };
+        if let Some(document) = core_record_with_value(
             &self.source,
             &self.binding,
             &mut self.fallback_identities,
             &mut self.native_identities,
             record,
+            value,
         )? {
             emit(document)?;
         }
@@ -341,31 +329,26 @@ where
     }
 
     fn rejected_records(&self) -> u64 {
-        self.rejected_records
+        self.rejections.count()
     }
 
     fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
-        std::mem::take(&mut self.record_rejections)
+        self.rejections.take_drafts()
     }
 }
 
-fn core_record<L>(
+fn core_record_with_value<L>(
     source: &SourceKey,
     binding: &Binding,
     fallback_identities: &mut FallbackEventIdentityState<L, CaptureError>,
     native_identities: &mut MistralNativeIdentityTracker,
     record: JsonlRecordRef<'_>,
+    value: Value,
 ) -> Result<Option<CoreRecord>>
 where
     L: BaseEventLookup,
 {
     let bytes = record.bytes();
-    if bytes.iter().all(u8::is_ascii_whitespace) {
-        return Ok(None);
-    }
-    let Ok(value) = serde_json::from_slice::<Value>(bytes) else {
-        return Ok(None);
-    };
     let ordinal = record.evidence().physical_ordinal();
     let requires_collision_position = native_identities.requires_collision_position(&value);
     let Ok(role) = valid_mistral_vibe_record_role(&value) else {
@@ -485,6 +468,28 @@ where
         .map_err(contract)?;
     record.validate_contract().map_err(contract)?;
     Ok(Some(record))
+}
+
+#[cfg(test)]
+fn core_record<L>(
+    source: &SourceKey,
+    binding: &Binding,
+    fallback_identities: &mut FallbackEventIdentityState<L, CaptureError>,
+    native_identities: &mut MistralNativeIdentityTracker,
+    record: JsonlRecordRef<'_>,
+) -> Result<Option<CoreRecord>>
+where
+    L: BaseEventLookup,
+{
+    let value = serde_json::from_slice::<Value>(record.bytes())?;
+    core_record_with_value(
+        source,
+        binding,
+        fallback_identities,
+        native_identities,
+        record,
+        value,
+    )
 }
 
 fn mistral_vibe_record_timestamp(value: &Value) -> Option<DateTime<Utc>> {

--- a/crates/ctx-history-provider-mistral-mux/src/mistral_vibe/native_path/source_backed.rs
+++ b/crates/ctx-history-provider-mistral-mux/src/mistral_vibe/native_path/source_backed.rs
@@ -25,7 +25,9 @@ use super::*;
 use ctx_history_jsonl::{
     fit_jsonl_activity, FallbackEventIdentityState, JsonlActivityObservedBytes, JsonlFamilyAdapter,
     JsonlFamilyAppendMode, JsonlFamilyInventory, JsonlFamilyLeaf, JsonlFamilyProjectionMode,
-    JsonlFamilyProjector, JsonlFamilyWorkerContext, JsonlRecordRef,
+    JsonlFamilyProjector, JsonlFamilyWorkerContext, JsonlOversizedRecordPolicy, JsonlRecordRef,
+    SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDraft,
+    SourceBackedRecordRejectionDrafts,
 };
 use ctx_history_provider_runtime::{
     source_io::{OpenedProviderSourceFile, ProviderSourceRoot},
@@ -44,7 +46,7 @@ const NATIVE_EVENT_REUSED_TOOL_CALL_POSITION_KIND: &str =
     "mistral-vibe-duplicate-tool-call-id-ordinal";
 const LOGICAL_SESSION_KIND: &str = "mistral-vibe-session";
 const LOGICAL_EVENT_KIND: &str = "mistral-vibe-event";
-const PARSER_REVISION: &str = "mistral-vibe-source-backed-v14-optional-admission";
+const PARSER_REVISION: &str = "mistral-vibe-source-backed-v15-optional-admission-record-rejections";
 const EVENT_IDENTITY_REVISION: &str = "mistral-vibe-content-occurrence-v1";
 const FALLBACK_FINGERPRINT_DOMAIN: &[u8] = b"ctx.mistral-vibe.fallback-event-fingerprint.v1\0";
 const SOURCE_REVISION_DIGEST_DOMAIN: &[u8] = b"ctx.mistral-vibe.source-revision.v1\0";
@@ -120,6 +122,10 @@ where
 
     fn append_mode(&self) -> JsonlFamilyAppendMode {
         JsonlFamilyAppendMode::Replacement
+    }
+
+    fn oversized_record_policy(&self) -> JsonlOversizedRecordPolicy {
+        JsonlOversizedRecordPolicy::RejectRecord
     }
 
     fn discover(&self, root: &Path) -> Result<JsonlFamilyInventory<CaptureError>> {
@@ -245,6 +251,7 @@ where
         let binding = decode_binding(leaf)?;
         Ok(Box::new(MistralProjector::<B> {
             source: leaf.source().clone(),
+            source_selector: leaf.source_path().display().to_string(),
             fallback_identities: FallbackEventIdentityState::new(
                 leaf.source().clone(),
                 binding.session_id,
@@ -256,15 +263,42 @@ where
             )?,
             native_identities: MistralNativeIdentityTracker::default(),
             binding,
+            rejected_records: 0,
+            record_rejections: SourceBackedRecordRejectionDrafts::default(),
         }))
     }
 }
 
 struct MistralProjector<B: ProviderRuntimeBinding> {
     source: SourceKey,
+    source_selector: String,
     binding: Binding,
     fallback_identities: FallbackEventIdentityState<ProviderBaseEventLookup<B>, CaptureError>,
     native_identities: MistralNativeIdentityTracker,
+    rejected_records: u64,
+    record_rejections: SourceBackedRecordRejectionDrafts,
+}
+
+impl<B: ProviderRuntimeBinding> MistralProjector<B> {
+    fn reject(&mut self, record: JsonlRecordRef<'_>, detail: String) -> Result<()> {
+        self.rejected_records =
+            self.rejected_records
+                .checked_add(1)
+                .ok_or(CaptureError::SystemInvariant(
+                    "Mistral Vibe record rejection count overflowed",
+                ))?;
+        self.record_rejections
+            .record(SourceBackedRecordRejectionDraft {
+                source: self.source.clone(),
+                provider: CaptureProvider::MistralVibe,
+                source_selector: self.source_selector.clone(),
+                line_number: record.evidence().physical_ordinal().saturating_add(1),
+                payload_type: None,
+                class: SourceBackedRecordRejectionClass::MalformedRecord,
+                detail,
+            });
+        Ok(())
+    }
 }
 
 impl<B> JsonlFamilyProjector for MistralProjector<B>
@@ -279,6 +313,17 @@ where
         _worker: &mut JsonlFamilyWorkerContext<Self::Runtime>,
         emit: &mut dyn FnMut(CoreRecord) -> Result<()>,
     ) -> Result<()> {
+        if record.oversized() {
+            return self.reject(
+                record,
+                format!(
+                    "Mistral Vibe record exceeds the {MAX_PROVIDER_JSONL_LINE_BYTES} byte limit"
+                ),
+            );
+        }
+        if let Err(error) = serde_json::from_slice::<Value>(record.bytes()) {
+            return self.reject(record, format!("malformed Mistral Vibe JSONL: {error}"));
+        }
         if let Some(document) = core_record(
             &self.source,
             &self.binding,
@@ -293,6 +338,14 @@ where
 
     fn finish(&mut self) -> Result<()> {
         self.fallback_identities.finish()
+    }
+
+    fn rejected_records(&self) -> u64 {
+        self.rejected_records
+    }
+
+    fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
+        std::mem::take(&mut self.record_rejections)
     }
 }
 

--- a/crates/ctx-history-provider-mistral-mux/src/mux/native_path/source_backed.rs
+++ b/crates/ctx-history-provider-mistral-mux/src/mux/native_path/source_backed.rs
@@ -18,7 +18,7 @@ use sha2::{Digest, Sha256};
 use ctx_history_jsonl::{
     observe_opened_file, JsonlFamilyAdapter, JsonlFamilyAppendMode, JsonlFamilyInventory,
     JsonlFamilyLeaf, JsonlFamilyProjectionMode, JsonlFamilyProjector, JsonlFamilyTerminalProof,
-    JsonlFileObservation, JsonlOversizedRecordPolicy,
+    JsonlFileObservation,
 };
 use ctx_history_provider_runtime::{
     source_io::{OpenedProviderSourceFile, ProviderSourceRoot},
@@ -42,7 +42,7 @@ const LOGICAL_SESSION_KIND: &str = "mux-session";
 const LOGICAL_EVENT_KIND: &str = "mux-event";
 const SOURCE_SCHEMA_VARIANT: &str = "mux-session-tree-source-backed-v2";
 const PARSER_REVISION: &str =
-    "mux-source-backed-v16-multiplicity-aware-archive-seam-record-rejections";
+    "mux-source-backed-v15-multiplicity-aware-archive-seam-bounded-inventory";
 const EVENT_IDENTITY_REVISION: &str = "mux-content-occurrence-v1";
 const COMPOUND_REVISION_DOMAIN: &[u8] = b"ctx.mux.compound-source.v3\0";
 const PARTIAL_EVENT_SEQUENCE_BASE: u64 = 1_u64 << 62;
@@ -123,10 +123,6 @@ where
 
     fn append_mode(&self) -> JsonlFamilyAppendMode {
         JsonlFamilyAppendMode::Replacement
-    }
-
-    fn oversized_record_policy(&self) -> JsonlOversizedRecordPolicy {
-        JsonlOversizedRecordPolicy::RejectRecord
     }
 
     fn discover(&self, root: &Path) -> Result<JsonlFamilyInventory<CaptureError>> {

--- a/crates/ctx-history-provider-mistral-mux/src/mux/native_path/source_backed.rs
+++ b/crates/ctx-history-provider-mistral-mux/src/mux/native_path/source_backed.rs
@@ -18,7 +18,7 @@ use sha2::{Digest, Sha256};
 use ctx_history_jsonl::{
     observe_opened_file, JsonlFamilyAdapter, JsonlFamilyAppendMode, JsonlFamilyInventory,
     JsonlFamilyLeaf, JsonlFamilyProjectionMode, JsonlFamilyProjector, JsonlFamilyTerminalProof,
-    JsonlFileObservation,
+    JsonlFileObservation, JsonlOversizedRecordPolicy,
 };
 use ctx_history_provider_runtime::{
     source_io::{OpenedProviderSourceFile, ProviderSourceRoot},
@@ -42,7 +42,7 @@ const LOGICAL_SESSION_KIND: &str = "mux-session";
 const LOGICAL_EVENT_KIND: &str = "mux-event";
 const SOURCE_SCHEMA_VARIANT: &str = "mux-session-tree-source-backed-v2";
 const PARSER_REVISION: &str =
-    "mux-source-backed-v15-multiplicity-aware-archive-seam-bounded-inventory";
+    "mux-source-backed-v16-multiplicity-aware-archive-seam-record-rejections";
 const EVENT_IDENTITY_REVISION: &str = "mux-content-occurrence-v1";
 const COMPOUND_REVISION_DOMAIN: &[u8] = b"ctx.mux.compound-source.v3\0";
 const PARTIAL_EVENT_SEQUENCE_BASE: u64 = 1_u64 << 62;
@@ -123,6 +123,10 @@ where
 
     fn append_mode(&self) -> JsonlFamilyAppendMode {
         JsonlFamilyAppendMode::Replacement
+    }
+
+    fn oversized_record_policy(&self) -> JsonlOversizedRecordPolicy {
+        JsonlOversizedRecordPolicy::RejectRecord
     }
 
     fn discover(&self, root: &Path) -> Result<JsonlFamilyInventory<CaptureError>> {

--- a/crates/ctx-history-provider-mistral-mux/src/mux/native_path/source_backed/projection.rs
+++ b/crates/ctx-history-provider-mistral-mux/src/mux/native_path/source_backed/projection.rs
@@ -17,8 +17,10 @@ use sha2::{Digest, Sha256};
 
 use ctx_history_jsonl::{
     fit_jsonl_activity, FallbackEventIdentityState, JsonlActivityObservedBytes,
-    JsonlFamilyProjectionMode, JsonlFamilyProjector, JsonlFamilyWorkerContext, JsonlReader,
-    JsonlRecordFraming, JsonlRecordRef, JsonlSourceIdentity,
+    JsonlFamilyProjectionMode, JsonlFamilyProjector, JsonlFamilyWorkerContext,
+    JsonlOversizedRecordPolicy, JsonlReader, JsonlRecordFraming, JsonlRecordRef,
+    JsonlSourceIdentity, SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDraft,
+    SourceBackedRecordRejectionDrafts,
 };
 use ctx_history_provider_runtime::{
     source_io::ProviderSourceRoot, CaptureError, ProviderBaseEventLookup, ProviderJsonlRuntime,
@@ -51,6 +53,8 @@ pub(super) struct MuxProjector<L: BaseEventLookup> {
     seen_native_record_ids: HashSet<String>,
     next_history_sequence: u64,
     archive_seam: MuxArchiveSeam,
+    rejected_records: u64,
+    record_rejections: SourceBackedRecordRejectionDrafts,
 }
 
 impl<L> MuxProjector<L>
@@ -81,7 +85,40 @@ where
             seen_native_record_ids: HashSet::new(),
             next_history_sequence: 0,
             archive_seam: MuxArchiveSeam::new(),
+            rejected_records: 0,
+            record_rejections: SourceBackedRecordRejectionDrafts::default(),
         })
+    }
+
+    fn reject(
+        &mut self,
+        stream: MuxStreamKind,
+        record: JsonlRecordRef<'_>,
+        detail: String,
+    ) -> Result<()> {
+        let selector = self
+            .authority
+            .named_path()
+            .join(&bound_stream(&self.binding, stream)?.relative_path)
+            .display()
+            .to_string();
+        self.rejected_records =
+            self.rejected_records
+                .checked_add(1)
+                .ok_or(CaptureError::SystemInvariant(
+                    "Mux record rejection count overflowed",
+                ))?;
+        self.record_rejections
+            .record(SourceBackedRecordRejectionDraft {
+                source: self.source.clone(),
+                provider: ctx_history_core::CaptureProvider::Mux,
+                source_selector: selector,
+                line_number: record.evidence().physical_ordinal().saturating_add(1),
+                payload_type: None,
+                class: SourceBackedRecordRejectionClass::MalformedRecord,
+                detail,
+            });
+        Ok(())
     }
 
     pub(super) fn project_record(
@@ -94,8 +131,21 @@ where
         if bytes.iter().all(u8::is_ascii_whitespace) {
             return Ok(());
         }
-        let Ok(value) = serde_json::from_slice::<Value>(bytes) else {
-            return Ok(());
+        if record.oversized() {
+            return self.reject(
+                stream,
+                record,
+                format!(
+                    "Mux record exceeds the {} byte limit",
+                    ctx_history_source_io::MAX_PROVIDER_JSONL_LINE_BYTES
+                ),
+            );
+        }
+        let value = match serde_json::from_slice::<Value>(bytes) {
+            Ok(value) => value,
+            Err(error) => {
+                return self.reject(stream, record, format!("malformed Mux JSONL: {error}"))
+            }
         };
         if !value.is_object() {
             return Ok(());
@@ -299,6 +349,9 @@ where
                 JsonlRecordFraming::ordinary(),
             )?
         };
+        if !stream.is_partial() {
+            reader.set_oversized_record_policy(JsonlOversizedRecordPolicy::RejectRecord);
+        }
         while reader
             .visit_page(&mut |record| self.project_record(stream, record, emit))?
             .is_some()
@@ -313,6 +366,14 @@ where
 
     pub(super) fn finish(&self) -> Result<()> {
         self.fallback_identities.finish()
+    }
+
+    pub(super) fn rejected_records(&self) -> u64 {
+        self.rejected_records
+    }
+
+    pub(super) fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
+        std::mem::take(&mut self.record_rejections)
     }
 }
 
@@ -491,6 +552,14 @@ where
             }
         }
         self.inner.finish()
+    }
+
+    fn rejected_records(&self) -> u64 {
+        self.inner.rejected_records()
+    }
+
+    fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
+        self.inner.take_record_rejections()
     }
 }
 

--- a/crates/ctx-history-provider-mistral-mux/src/mux/native_path/source_backed/projection.rs
+++ b/crates/ctx-history-provider-mistral-mux/src/mux/native_path/source_backed/projection.rs
@@ -17,10 +17,8 @@ use sha2::{Digest, Sha256};
 
 use ctx_history_jsonl::{
     fit_jsonl_activity, FallbackEventIdentityState, JsonlActivityObservedBytes,
-    JsonlFamilyProjectionMode, JsonlFamilyProjector, JsonlFamilyWorkerContext,
-    JsonlOversizedRecordPolicy, JsonlReader, JsonlRecordFraming, JsonlRecordRef,
-    JsonlSourceIdentity, SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDraft,
-    SourceBackedRecordRejectionDrafts,
+    JsonlFamilyProjectionMode, JsonlFamilyProjector, JsonlFamilyWorkerContext, JsonlReader,
+    JsonlRecordFraming, JsonlRecordRef, JsonlSourceIdentity,
 };
 use ctx_history_provider_runtime::{
     source_io::ProviderSourceRoot, CaptureError, ProviderBaseEventLookup, ProviderJsonlRuntime,
@@ -53,8 +51,6 @@ pub(super) struct MuxProjector<L: BaseEventLookup> {
     seen_native_record_ids: HashSet<String>,
     next_history_sequence: u64,
     archive_seam: MuxArchiveSeam,
-    rejected_records: u64,
-    record_rejections: SourceBackedRecordRejectionDrafts,
 }
 
 impl<L> MuxProjector<L>
@@ -85,40 +81,7 @@ where
             seen_native_record_ids: HashSet::new(),
             next_history_sequence: 0,
             archive_seam: MuxArchiveSeam::new(),
-            rejected_records: 0,
-            record_rejections: SourceBackedRecordRejectionDrafts::default(),
         })
-    }
-
-    fn reject(
-        &mut self,
-        stream: MuxStreamKind,
-        record: JsonlRecordRef<'_>,
-        detail: String,
-    ) -> Result<()> {
-        let selector = self
-            .authority
-            .named_path()
-            .join(&bound_stream(&self.binding, stream)?.relative_path)
-            .display()
-            .to_string();
-        self.rejected_records =
-            self.rejected_records
-                .checked_add(1)
-                .ok_or(CaptureError::SystemInvariant(
-                    "Mux record rejection count overflowed",
-                ))?;
-        self.record_rejections
-            .record(SourceBackedRecordRejectionDraft {
-                source: self.source.clone(),
-                provider: ctx_history_core::CaptureProvider::Mux,
-                source_selector: selector,
-                line_number: record.evidence().physical_ordinal().saturating_add(1),
-                payload_type: None,
-                class: SourceBackedRecordRejectionClass::MalformedRecord,
-                detail,
-            });
-        Ok(())
     }
 
     pub(super) fn project_record(
@@ -131,21 +94,8 @@ where
         if bytes.iter().all(u8::is_ascii_whitespace) {
             return Ok(());
         }
-        if record.oversized() {
-            return self.reject(
-                stream,
-                record,
-                format!(
-                    "Mux record exceeds the {} byte limit",
-                    ctx_history_source_io::MAX_PROVIDER_JSONL_LINE_BYTES
-                ),
-            );
-        }
-        let value = match serde_json::from_slice::<Value>(bytes) {
-            Ok(value) => value,
-            Err(error) => {
-                return self.reject(stream, record, format!("malformed Mux JSONL: {error}"))
-            }
+        let Ok(value) = serde_json::from_slice::<Value>(bytes) else {
+            return Ok(());
         };
         if !value.is_object() {
             return Ok(());
@@ -349,9 +299,6 @@ where
                 JsonlRecordFraming::ordinary(),
             )?
         };
-        if !stream.is_partial() {
-            reader.set_oversized_record_policy(JsonlOversizedRecordPolicy::RejectRecord);
-        }
         while reader
             .visit_page(&mut |record| self.project_record(stream, record, emit))?
             .is_some()
@@ -366,14 +313,6 @@ where
 
     pub(super) fn finish(&self) -> Result<()> {
         self.fallback_identities.finish()
-    }
-
-    pub(super) fn rejected_records(&self) -> u64 {
-        self.rejected_records
-    }
-
-    pub(super) fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
-        std::mem::take(&mut self.record_rejections)
     }
 }
 
@@ -552,14 +491,6 @@ where
             }
         }
         self.inner.finish()
-    }
-
-    fn rejected_records(&self) -> u64 {
-        self.inner.rejected_records()
-    }
-
-    fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
-        self.inner.take_record_rejections()
     }
 }
 

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/deepseek_harness.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/deepseek_harness.rs
@@ -46,8 +46,7 @@ use ctx_history_jsonl::{JsonlFamilyExecutionIo, JsonlPhysicalEncoding};
 pub(crate) const TREE_SOURCE_FORMAT: &str = "deepseek_harness_session_jsonl_tree";
 pub(crate) const EXPLICIT_SOURCE_FORMAT: &str = "deepseek_harness_session_jsonl";
 
-const PARSER_REVISION: &str =
-    "deepseek-harness-native-jsonl-v4-selected-core-activity-raw-recovery";
+const PARSER_REVISION: &str = "deepseek-harness-native-jsonl-v3-selected-core-activity";
 const EVENT_IDENTITY_REVISION: &str = "deepseek-harness-sequence-v1";
 
 #[derive(Debug, Clone, Copy)]
@@ -270,14 +269,15 @@ impl<R: JsonlProviderRuntime> DeepSeekHarnessSemanticExecutor<R> {
                     return Err(CaptureError::InvalidPayload(error));
                 }
                 Err(error) if project && (ordinal != 0 || row_index != 0) => {
-                    let span =
-                        rejected_sequence_span(self.encoding, self.expected_sequence, row, &error)?;
-                    let rejected = span.len;
+                    let span = sequence_span(row);
+                    let rejected = span.map_or(1, |span| span.len);
                     let line_number = self
                         .logical_complete_rows
                         .saturating_add(logical_complete_rows)
                         .saturating_add(1);
-                    self.validate_sequence(span)?;
+                    if let Some(span) = span {
+                        self.validate_sequence(span)?;
+                    }
                     logical_complete_rows = checked_add_rows(logical_complete_rows, rejected)?;
                     rejected_rows = checked_add_rows(rejected_rows, rejected)?;
                     self.record_rejections
@@ -515,26 +515,6 @@ fn checked_add_rows(current: u64, additional: u64) -> Result<u64> {
         ))
 }
 
-fn rejected_sequence_span(
-    encoding: JsonlPhysicalEncoding,
-    expected_sequence: u64,
-    row: &[u8],
-    parse_error: &str,
-) -> Result<SequenceSpan> {
-    if let Some(span) = sequence_span(row) {
-        return Ok(span);
-    }
-    if encoding == JsonlPhysicalEncoding::RawJsonl {
-        return Ok(SequenceSpan {
-            first: expected_sequence,
-            len: 1,
-        });
-    }
-    Err(CaptureError::InvalidPayload(format!(
-        "malformed packed DeepSeek Harness row has ambiguous sequence occurrence: {parse_error}"
-    )))
-}
-
 fn visit_frame_rows(
     bytes: &[u8],
     encoding: JsonlPhysicalEncoding,
@@ -677,32 +657,4 @@ fn decode_binding(leaf: &JsonlFamilyLeaf) -> Result<SessionHeader> {
 
 fn contract(error: impl std::fmt::Display) -> CaptureError {
     CaptureError::InvalidPayload(error.to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn raw_malformed_row_has_one_provable_sequence_occurrence() {
-        let span =
-            rejected_sequence_span(JsonlPhysicalEncoding::RawJsonl, 7, b"{", "malformed JSON")
-                .unwrap();
-
-        assert_eq!(span.first, 7);
-        assert_eq!(span.len, 1);
-    }
-
-    #[test]
-    fn packed_malformed_row_without_sequence_is_source_fatal() {
-        let error = rejected_sequence_span(
-            JsonlPhysicalEncoding::ChecksummedZstdFrames,
-            7,
-            b"{",
-            "malformed JSON",
-        )
-        .unwrap_err();
-
-        assert!(matches!(error, CaptureError::InvalidPayload(_)));
-    }
 }

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/deepseek_harness.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/deepseek_harness.rs
@@ -46,7 +46,8 @@ use ctx_history_jsonl::{JsonlFamilyExecutionIo, JsonlPhysicalEncoding};
 pub(crate) const TREE_SOURCE_FORMAT: &str = "deepseek_harness_session_jsonl_tree";
 pub(crate) const EXPLICIT_SOURCE_FORMAT: &str = "deepseek_harness_session_jsonl";
 
-const PARSER_REVISION: &str = "deepseek-harness-native-jsonl-v3-selected-core-activity";
+const PARSER_REVISION: &str =
+    "deepseek-harness-native-jsonl-v4-selected-core-activity-raw-recovery";
 const EVENT_IDENTITY_REVISION: &str = "deepseek-harness-sequence-v1";
 
 #[derive(Debug, Clone, Copy)]
@@ -269,15 +270,14 @@ impl<R: JsonlProviderRuntime> DeepSeekHarnessSemanticExecutor<R> {
                     return Err(CaptureError::InvalidPayload(error));
                 }
                 Err(error) if project && (ordinal != 0 || row_index != 0) => {
-                    let span = sequence_span(row);
-                    let rejected = span.map_or(1, |span| span.len);
+                    let span =
+                        rejected_sequence_span(self.encoding, self.expected_sequence, row, &error)?;
+                    let rejected = span.len;
                     let line_number = self
                         .logical_complete_rows
                         .saturating_add(logical_complete_rows)
                         .saturating_add(1);
-                    if let Some(span) = span {
-                        self.validate_sequence(span)?;
-                    }
+                    self.validate_sequence(span)?;
                     logical_complete_rows = checked_add_rows(logical_complete_rows, rejected)?;
                     rejected_rows = checked_add_rows(rejected_rows, rejected)?;
                     self.record_rejections
@@ -515,6 +515,26 @@ fn checked_add_rows(current: u64, additional: u64) -> Result<u64> {
         ))
 }
 
+fn rejected_sequence_span(
+    encoding: JsonlPhysicalEncoding,
+    expected_sequence: u64,
+    row: &[u8],
+    parse_error: &str,
+) -> Result<SequenceSpan> {
+    if let Some(span) = sequence_span(row) {
+        return Ok(span);
+    }
+    if encoding == JsonlPhysicalEncoding::RawJsonl {
+        return Ok(SequenceSpan {
+            first: expected_sequence,
+            len: 1,
+        });
+    }
+    Err(CaptureError::InvalidPayload(format!(
+        "malformed packed DeepSeek Harness row has ambiguous sequence occurrence: {parse_error}"
+    )))
+}
+
 fn visit_frame_rows(
     bytes: &[u8],
     encoding: JsonlPhysicalEncoding,
@@ -657,4 +677,32 @@ fn decode_binding(leaf: &JsonlFamilyLeaf) -> Result<SessionHeader> {
 
 fn contract(error: impl std::fmt::Display) -> CaptureError {
     CaptureError::InvalidPayload(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_malformed_row_has_one_provable_sequence_occurrence() {
+        let span =
+            rejected_sequence_span(JsonlPhysicalEncoding::RawJsonl, 7, b"{", "malformed JSON")
+                .unwrap();
+
+        assert_eq!(span.first, 7);
+        assert_eq!(span.len, 1);
+    }
+
+    #[test]
+    fn packed_malformed_row_without_sequence_is_source_fatal() {
+        let error = rejected_sequence_span(
+            JsonlPhysicalEncoding::ChecksummedZstdFrames,
+            7,
+            b"{",
+            "malformed JSON",
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, CaptureError::InvalidPayload(_)));
+    }
 }

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/junie/nativepath/projection.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/junie/nativepath/projection.rs
@@ -84,8 +84,17 @@ impl JunieProjection {
         self.state.cwd.as_deref()
     }
 
+    pub(super) fn rejected_records(&self) -> u64 {
+        self.rejected_records
+    }
+
     pub(super) fn project(&mut self, record: JsonlRecordRef<'_>) -> Result<Vec<EventDraft>> {
         let evidence = record.evidence();
+        if record.oversized() {
+            self.reset_turn(evidence.byte_end_exclusive());
+            self.reject();
+            return Ok(Vec::new());
+        }
         if evidence
             .byte_end_exclusive()
             .saturating_sub(self.turn_start)

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/junie/nativepath/source_backed.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/junie/nativepath/source_backed.rs
@@ -24,7 +24,7 @@ use crate::{
         family::jsonl::{
             JsonlFamilyAdapter, JsonlFamilyAppendMode, JsonlFamilyInventory, JsonlFamilyLeaf,
             JsonlFamilyProjectionMode, JsonlFamilyProjector, JsonlFamilyWorkerContext,
-            JsonlRecordRef,
+            JsonlOversizedRecordPolicy, JsonlRecordRef,
         },
         FallbackEventIdentityState,
     },
@@ -42,7 +42,8 @@ const NATIVE_SESSION_NAMESPACE: &str = "junie.session";
 const LOGICAL_SESSION_KIND: &str = "junie-session";
 const LOGICAL_EVENT_KIND: &str = "junie-event";
 const SOURCE_SCHEMA_VARIANT: &str = "junie-session-events-v2";
-const PARSER_REVISION: &str = "junie-source-backed-v7-optional-activity-admission";
+const PARSER_REVISION: &str =
+    "junie-source-backed-v8-optional-activity-admission-record-rejections";
 const EVENT_IDENTITY_REVISION: &str = "junie-content-occurrence-v2";
 const FALLBACK_FINGERPRINT_DOMAIN: &[u8] = b"ctx.junie.fallback-event-fingerprint.v1\0";
 
@@ -87,6 +88,10 @@ impl<R: JsonlProviderRuntime> JsonlFamilyAdapter for JunieJsonlAdapter<R> {
 
     fn append_mode(&self) -> JsonlFamilyAppendMode {
         JsonlFamilyAppendMode::Replacement
+    }
+
+    fn oversized_record_policy(&self) -> JsonlOversizedRecordPolicy {
+        JsonlOversizedRecordPolicy::RejectRecord
     }
 
     fn discover(&self, root: &Path) -> Result<JsonlFamilyInventory> {
@@ -232,6 +237,10 @@ impl<R: JsonlProviderRuntime> JsonlFamilyProjector for JunieProjector<R> {
         let rows = self.projection.finish()?;
         self.emit_rows(rows, emit)?;
         self.fallback_identities.finish()
+    }
+
+    fn rejected_records(&self) -> u64 {
+        self.projection.rejected_records()
     }
 }
 

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/junie/nativepath/source_backed.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/junie/nativepath/source_backed.rs
@@ -24,7 +24,8 @@ use crate::{
         family::jsonl::{
             JsonlFamilyAdapter, JsonlFamilyAppendMode, JsonlFamilyInventory, JsonlFamilyLeaf,
             JsonlFamilyProjectionMode, JsonlFamilyProjector, JsonlFamilyWorkerContext,
-            JsonlOversizedRecordPolicy, JsonlRecordRef,
+            JsonlOversizedRecordPolicy, JsonlRecordRef, JsonlRecordRejections,
+            SourceBackedRecordRejectionDrafts,
         },
         FallbackEventIdentityState,
     },
@@ -204,6 +205,11 @@ impl<R: JsonlProviderRuntime> JsonlFamilyAdapter for JunieJsonlAdapter<R> {
             workspace,
             projection,
             fallback_identities,
+            rejections: JsonlRecordRejections::new(
+                leaf.source().clone(),
+                CaptureProvider::Junie,
+                leaf.source_path().display().to_string(),
+            ),
         }))
     }
 }
@@ -214,6 +220,7 @@ struct JunieProjector<R: JsonlProviderRuntime> {
     workspace: Option<String>,
     projection: JunieProjection,
     fallback_identities: FallbackEventIdentityState<R>,
+    rejections: JsonlRecordRejections,
 }
 
 impl<R: JsonlProviderRuntime> JsonlFamilyProjector for JunieProjector<R> {
@@ -225,7 +232,19 @@ impl<R: JsonlProviderRuntime> JsonlFamilyProjector for JunieProjector<R> {
         _worker: &mut JsonlFamilyWorkerContext<R>,
         emit: &mut dyn FnMut(CoreRecord) -> Result<()>,
     ) -> Result<()> {
+        let rejected_before = self.projection.rejected_records();
         let rows = self.projection.project(record)?;
+        let rejected_after = self.projection.rejected_records();
+        debug_assert!(
+            rejected_after == rejected_before
+                || rejected_after == rejected_before.saturating_add(1)
+        );
+        if rejected_after > rejected_before {
+            self.rejections.malformed(
+                record,
+                "Junie record could not be projected within its structural bounds",
+            );
+        }
         self.emit_rows(rows, emit)
     }
 
@@ -240,7 +259,11 @@ impl<R: JsonlProviderRuntime> JsonlFamilyProjector for JunieProjector<R> {
     }
 
     fn rejected_records(&self) -> u64 {
-        self.projection.rejected_records()
+        self.rejections.count()
+    }
+
+    fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
+        self.rejections.take_drafts()
     }
 }
 

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/kimi/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/kimi/native_path/source_backed.rs
@@ -37,7 +37,8 @@ use crate::{
         family::jsonl::{
             JsonlFamilyAdapter, JsonlFamilyAppendMode, JsonlFamilyInventory, JsonlFamilyLeaf,
             JsonlFamilyProjectionMode, JsonlFamilyProjector, JsonlFamilyWorkerContext,
-            JsonlRecordRef,
+            JsonlOversizedRecordPolicy, JsonlRecordRef, SourceBackedRecordRejectionClass,
+            SourceBackedRecordRejectionDraft, SourceBackedRecordRejectionDrafts,
         },
         FallbackEventIdentityState,
     },
@@ -61,9 +62,9 @@ const KIMI_SOURCE_ANCHOR_NAMESPACE: &str = "kimi-code-cli-wire-lineage-v1";
 const KIMI_NATIVE_SESSION_NAMESPACE: &str = "kimi-code-cli-session-v1";
 const KIMI_LOGICAL_SESSION_KIND: &str = "agent-session";
 const KIMI_LOGICAL_EVENT_KIND: &str = "wire-event";
-// v6 omits optional activity fields that do not satisfy the Core admission bounds.
+// v7 also reports malformed newline-framed records without rejecting valid peers.
 const KIMI_SOURCE_PARSER_REVISION: &str =
-    "kimi-code-cli-source-backed-v6-optional-activity-admission";
+    "kimi-code-cli-source-backed-v7-optional-activity-admission-record-rejections";
 const KIMI_EVENT_IDENTITY_REVISION: &str = "kimi-code-cli-content-occurrence-v1";
 const KIMI_FALLBACK_FINGERPRINT_DOMAIN: &[u8] =
     b"ctx.kimi-code-cli.fallback-event-fingerprint.v1\0";
@@ -174,6 +175,10 @@ impl<R: JsonlProviderRuntime> JsonlFamilyAdapter for KimiJsonlAdapter<R> {
         JsonlFamilyAppendMode::Replacement
     }
 
+    fn oversized_record_policy(&self) -> JsonlOversizedRecordPolicy {
+        JsonlOversizedRecordPolicy::RejectRecord
+    }
+
     fn discover(&self, root: &Path) -> crate::Result<JsonlFamilyInventory> {
         let inventory = discover_kimi_wire_files(root).map_err(capture_error)?;
         if inventory.root_missing {
@@ -259,24 +264,52 @@ impl<R: JsonlProviderRuntime> JsonlFamilyAdapter for KimiJsonlAdapter<R> {
         .map_err(capture_error)?;
         Ok(Box::new(KimiProjector::<R> {
             compound,
+            source_selector: leaf.source_path().display().to_string(),
             session_id,
             fallback_timestamp,
             authority: Arc::clone(leaf.authority()),
             state,
             index,
             fallback_identities,
+            rejected_records: 0,
+            record_rejections: SourceBackedRecordRejectionDrafts::default(),
         }))
     }
 }
 
 struct KimiProjector<R: JsonlProviderRuntime> {
     compound: KimiCompoundObservation,
+    source_selector: String,
     session_id: StableEntityId,
     fallback_timestamp: DateTime<Utc>,
     authority: Arc<ProviderSourceRoot>,
     state: Option<OpenedProviderSourceFile>,
     index: Option<OpenedProviderSourceFile>,
     fallback_identities: FallbackEventIdentityState<R>,
+    rejected_records: u64,
+    record_rejections: SourceBackedRecordRejectionDrafts,
+}
+
+impl<R: JsonlProviderRuntime> KimiProjector<R> {
+    fn reject(&mut self, record: JsonlRecordRef<'_>, detail: String) -> crate::Result<()> {
+        self.rejected_records =
+            self.rejected_records
+                .checked_add(1)
+                .ok_or(CaptureError::SystemInvariant(
+                    "Kimi record rejection count overflowed",
+                ))?;
+        self.record_rejections
+            .record(SourceBackedRecordRejectionDraft {
+                source: self.compound.source.clone(),
+                provider: CaptureProvider::KimiCodeCli,
+                source_selector: self.source_selector.clone(),
+                line_number: record.evidence().physical_ordinal().saturating_add(1),
+                payload_type: None,
+                class: SourceBackedRecordRejectionClass::MalformedRecord,
+                detail,
+            });
+        Ok(())
+    }
 }
 
 impl<R: JsonlProviderRuntime> JsonlFamilyProjector for KimiProjector<R> {
@@ -292,8 +325,18 @@ impl<R: JsonlProviderRuntime> JsonlFamilyProjector for KimiProjector<R> {
         if bytes.iter().all(u8::is_ascii_whitespace) {
             return Ok(());
         }
-        let Ok(value) = serde_json::from_slice::<Value>(bytes) else {
-            return Ok(());
+        if record.oversized() {
+            return self.reject(
+                record,
+                format!(
+                    "Kimi record exceeds the {} byte limit",
+                    crate::MAX_PROVIDER_JSONL_LINE_BYTES
+                ),
+            );
+        }
+        let value = match serde_json::from_slice::<Value>(bytes) {
+            Ok(value) => value,
+            Err(error) => return self.reject(record, format!("malformed Kimi JSONL: {error}")),
         };
         if value.get("type").and_then(Value::as_str) == Some("metadata") {
             return Ok(());
@@ -324,6 +367,14 @@ impl<R: JsonlProviderRuntime> JsonlFamilyProjector for KimiProjector<R> {
         }
         self.authority.revalidate()?;
         self.fallback_identities.finish()
+    }
+
+    fn rejected_records(&self) -> u64 {
+        self.rejected_records
+    }
+
+    fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
+        std::mem::take(&mut self.record_rejections)
     }
 }
 

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/kimi/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/kimi/native_path/source_backed.rs
@@ -37,8 +37,8 @@ use crate::{
         family::jsonl::{
             JsonlFamilyAdapter, JsonlFamilyAppendMode, JsonlFamilyInventory, JsonlFamilyLeaf,
             JsonlFamilyProjectionMode, JsonlFamilyProjector, JsonlFamilyWorkerContext,
-            JsonlOversizedRecordPolicy, JsonlRecordRef, SourceBackedRecordRejectionClass,
-            SourceBackedRecordRejectionDraft, SourceBackedRecordRejectionDrafts,
+            JsonlOversizedRecordPolicy, JsonlRecordRef, JsonlRecordRejections,
+            SourceBackedRecordRejectionDrafts,
         },
         FallbackEventIdentityState,
     },
@@ -264,52 +264,30 @@ impl<R: JsonlProviderRuntime> JsonlFamilyAdapter for KimiJsonlAdapter<R> {
         .map_err(capture_error)?;
         Ok(Box::new(KimiProjector::<R> {
             compound,
-            source_selector: leaf.source_path().display().to_string(),
             session_id,
             fallback_timestamp,
             authority: Arc::clone(leaf.authority()),
             state,
             index,
             fallback_identities,
-            rejected_records: 0,
-            record_rejections: SourceBackedRecordRejectionDrafts::default(),
+            rejections: JsonlRecordRejections::new(
+                leaf.source().clone(),
+                CaptureProvider::KimiCodeCli,
+                leaf.source_path().display().to_string(),
+            ),
         }))
     }
 }
 
 struct KimiProjector<R: JsonlProviderRuntime> {
     compound: KimiCompoundObservation,
-    source_selector: String,
     session_id: StableEntityId,
     fallback_timestamp: DateTime<Utc>,
     authority: Arc<ProviderSourceRoot>,
     state: Option<OpenedProviderSourceFile>,
     index: Option<OpenedProviderSourceFile>,
     fallback_identities: FallbackEventIdentityState<R>,
-    rejected_records: u64,
-    record_rejections: SourceBackedRecordRejectionDrafts,
-}
-
-impl<R: JsonlProviderRuntime> KimiProjector<R> {
-    fn reject(&mut self, record: JsonlRecordRef<'_>, detail: String) -> crate::Result<()> {
-        self.rejected_records =
-            self.rejected_records
-                .checked_add(1)
-                .ok_or(CaptureError::SystemInvariant(
-                    "Kimi record rejection count overflowed",
-                ))?;
-        self.record_rejections
-            .record(SourceBackedRecordRejectionDraft {
-                source: self.compound.source.clone(),
-                provider: CaptureProvider::KimiCodeCli,
-                source_selector: self.source_selector.clone(),
-                line_number: record.evidence().physical_ordinal().saturating_add(1),
-                payload_type: None,
-                class: SourceBackedRecordRejectionClass::MalformedRecord,
-                detail,
-            });
-        Ok(())
-    }
+    rejections: JsonlRecordRejections,
 }
 
 impl<R: JsonlProviderRuntime> JsonlFamilyProjector for KimiProjector<R> {
@@ -322,21 +300,26 @@ impl<R: JsonlProviderRuntime> JsonlFamilyProjector for KimiProjector<R> {
         emit: &mut dyn FnMut(CoreRecord) -> crate::Result<()>,
     ) -> crate::Result<()> {
         let bytes = record.bytes();
-        if bytes.iter().all(u8::is_ascii_whitespace) {
-            return Ok(());
-        }
         if record.oversized() {
-            return self.reject(
+            self.rejections.malformed(
                 record,
                 format!(
                     "Kimi record exceeds the {} byte limit",
                     crate::MAX_PROVIDER_JSONL_LINE_BYTES
                 ),
             );
+            return Ok(());
+        }
+        if bytes.iter().all(u8::is_ascii_whitespace) {
+            return Ok(());
         }
         let value = match serde_json::from_slice::<Value>(bytes) {
             Ok(value) => value,
-            Err(error) => return self.reject(record, format!("malformed Kimi JSONL: {error}")),
+            Err(error) => {
+                self.rejections
+                    .malformed(record, format!("malformed Kimi JSONL: {error}"));
+                return Ok(());
+            }
         };
         if value.get("type").and_then(Value::as_str) == Some("metadata") {
             return Ok(());
@@ -370,11 +353,11 @@ impl<R: JsonlProviderRuntime> JsonlFamilyProjector for KimiProjector<R> {
     }
 
     fn rejected_records(&self) -> u64 {
-        self.rejected_records
+        self.rejections.count()
     }
 
     fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
-        std::mem::take(&mut self.record_rejections)
+        self.rejections.take_drafts()
     }
 }
 

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/openclaw/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/openclaw/native_path/source_backed.rs
@@ -29,8 +29,10 @@ use crate::{
     provider::source_backed::family::jsonl::{
         JsonlAppendOccurrenceState, JsonlFamilyAdapter, JsonlFamilyAppendMode,
         JsonlFamilyInventory, JsonlFamilyLeaf, JsonlFamilyProjectionMode, JsonlFamilyProjector,
-        JsonlFamilyTerminalProof, JsonlFamilyWorkerContext, JsonlReader, JsonlRecordRef,
-        JsonlTerminalAuthority, JsonlTerminalObservationRegion,
+        JsonlFamilyTerminalProof, JsonlFamilyWorkerContext, JsonlOversizedRecordPolicy,
+        JsonlReader, JsonlRecordRef, JsonlTerminalAuthority, JsonlTerminalObservationRegion,
+        SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDraft,
+        SourceBackedRecordRejectionDrafts,
     },
     CaptureError, Result, MAX_OPENCLAW_SESSION_INDEX_BYTES, OPENCLAW_SOURCE_FORMAT,
 };
@@ -51,7 +53,7 @@ const LOGICAL_SESSION_KIND: &str = "openclaw-legacy-session";
 const LOGICAL_EVENT_KIND: &str = "openclaw-legacy-event";
 const SOURCE_SCHEMA_VARIANT: &str = "openclaw-legacy-jsonl-v2";
 const PARSER_REVISION: &str =
-    "openclaw-source-backed-v18-source-wide-call-id-admission-agent-scope-raw-lineage-exact-authored-text";
+    "openclaw-source-backed-v19-call-id-admission-lineage-record-rejections";
 const MAX_TERMINAL_CALL_IDS: usize = 4096;
 const MAX_TERMINAL_LINKAGE_IDS: usize = MAX_TERMINAL_CALL_IDS * 2;
 const MAX_SELECTOR_CALL_ID_BYTES: usize = 16 * 1024;
@@ -105,6 +107,10 @@ impl<R: JsonlProviderRuntime> JsonlFamilyAdapter for OpenClawJsonlAdapter<R> {
 
     fn append_mode(&self) -> JsonlFamilyAppendMode {
         JsonlFamilyAppendMode::ProjectorPreflight(true)
+    }
+
+    fn oversized_record_policy(&self) -> JsonlOversizedRecordPolicy {
+        JsonlOversizedRecordPolicy::RejectRecord
     }
 
     fn discover(&self, root: &Path) -> Result<JsonlFamilyInventory> {
@@ -240,6 +246,7 @@ impl<R: JsonlProviderRuntime> JsonlFamilyAdapter for OpenClawJsonlAdapter<R> {
         }
         Ok(Box::new(OpenClawProjector::<R> {
             source: leaf.source().clone(),
+            source_selector: leaf.source_path().display().to_string(),
             native_session_id: binding.native_session_id,
             session_id,
             session,
@@ -253,12 +260,15 @@ impl<R: JsonlProviderRuntime> JsonlFamilyAdapter for OpenClawJsonlAdapter<R> {
                 }
                 _ => FallbackEventIdentityState::<R>::default(),
             },
+            rejected_records: 0,
+            record_rejections: SourceBackedRecordRejectionDrafts::default(),
         }))
     }
 }
 
 struct OpenClawProjector<R: JsonlProviderRuntime> {
     source: SourceKey,
+    source_selector: String,
     native_session_id: String,
     session_id: StableEntityId,
     session: SessionState,
@@ -267,6 +277,8 @@ struct OpenClawProjector<R: JsonlProviderRuntime> {
     authority: Arc<ProviderSourceRoot>,
     terminal_authority: OpenClawTerminalAuthority,
     fallback_identities: FallbackEventIdentityState<R>,
+    rejected_records: u64,
+    record_rejections: SourceBackedRecordRejectionDrafts,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/openclaw/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/openclaw/native_path/source_backed.rs
@@ -30,8 +30,8 @@ use crate::{
         JsonlAppendOccurrenceState, JsonlFamilyAdapter, JsonlFamilyAppendMode,
         JsonlFamilyInventory, JsonlFamilyLeaf, JsonlFamilyProjectionMode, JsonlFamilyProjector,
         JsonlFamilyTerminalProof, JsonlFamilyWorkerContext, JsonlOversizedRecordPolicy,
-        JsonlReader, JsonlRecordRef, JsonlTerminalAuthority, JsonlTerminalObservationRegion,
-        SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDraft,
+        JsonlReader, JsonlRecordRef, JsonlRecordRejections, JsonlTerminalAuthority,
+        JsonlTerminalObservationRegion, SourceBackedRecordRejectionClass,
         SourceBackedRecordRejectionDrafts,
     },
     CaptureError, Result, MAX_OPENCLAW_SESSION_INDEX_BYTES, OPENCLAW_SOURCE_FORMAT,
@@ -53,7 +53,7 @@ const LOGICAL_SESSION_KIND: &str = "openclaw-legacy-session";
 const LOGICAL_EVENT_KIND: &str = "openclaw-legacy-event";
 const SOURCE_SCHEMA_VARIANT: &str = "openclaw-legacy-jsonl-v2";
 const PARSER_REVISION: &str =
-    "openclaw-source-backed-v19-call-id-admission-lineage-record-rejections";
+    "openclaw-source-backed-v19-source-wide-call-id-admission-agent-scope-raw-lineage-exact-authored-text-record-rejections";
 const MAX_TERMINAL_CALL_IDS: usize = 4096;
 const MAX_TERMINAL_LINKAGE_IDS: usize = MAX_TERMINAL_CALL_IDS * 2;
 const MAX_SELECTOR_CALL_ID_BYTES: usize = 16 * 1024;
@@ -246,7 +246,6 @@ impl<R: JsonlProviderRuntime> JsonlFamilyAdapter for OpenClawJsonlAdapter<R> {
         }
         Ok(Box::new(OpenClawProjector::<R> {
             source: leaf.source().clone(),
-            source_selector: leaf.source_path().display().to_string(),
             native_session_id: binding.native_session_id,
             session_id,
             session,
@@ -260,15 +259,17 @@ impl<R: JsonlProviderRuntime> JsonlFamilyAdapter for OpenClawJsonlAdapter<R> {
                 }
                 _ => FallbackEventIdentityState::<R>::default(),
             },
-            rejected_records: 0,
-            record_rejections: SourceBackedRecordRejectionDrafts::default(),
+            rejections: JsonlRecordRejections::new(
+                leaf.source().clone(),
+                CaptureProvider::OpenClaw,
+                leaf.source_path().display().to_string(),
+            ),
         }))
     }
 }
 
 struct OpenClawProjector<R: JsonlProviderRuntime> {
     source: SourceKey,
-    source_selector: String,
     native_session_id: String,
     session_id: StableEntityId,
     session: SessionState,
@@ -277,8 +278,7 @@ struct OpenClawProjector<R: JsonlProviderRuntime> {
     authority: Arc<ProviderSourceRoot>,
     terminal_authority: OpenClawTerminalAuthority,
     fallback_identities: FallbackEventIdentityState<R>,
-    rejected_records: u64,
-    record_rejections: SourceBackedRecordRejectionDrafts,
+    rejections: JsonlRecordRejections,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/openclaw/native_path/source_backed/projection.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/openclaw/native_path/source_backed/projection.rs
@@ -298,25 +298,33 @@ impl<R: crate::JsonlProviderRuntime> JsonlFamilyProjector for OpenClawProjector<
         emit: &mut dyn FnMut(CoreRecord) -> Result<()>,
     ) -> Result<()> {
         let bytes = record.bytes();
-        if bytes.iter().all(u8::is_ascii_whitespace) {
-            return Ok(());
-        }
         if record.oversized() {
-            return self.reject_record(
+            self.rejections.malformed(
                 record,
                 format!(
                     "OpenClaw record exceeds the {} byte limit",
                     crate::MAX_PROVIDER_JSONL_LINE_BYTES
                 ),
             );
+            return Ok(());
+        }
+        if bytes.iter().all(u8::is_ascii_whitespace) {
+            return Ok(());
         }
         let value = match serde_json::from_slice::<Value>(bytes) {
             Ok(value) => value,
             Err(error) => {
-                return self.reject_record(record, format!("malformed OpenClaw JSONL: {error}"))
+                self.rejections
+                    .malformed(record, format!("malformed OpenClaw JSONL: {error}"));
+                return Ok(());
             }
         };
         if !value.is_object() {
+            self.rejections.record(
+                record,
+                SourceBackedRecordRejectionClass::UnsupportedRecord,
+                "OpenClaw record has a well-formed but unsupported shape",
+            );
             return Ok(());
         }
         if value.get("type").and_then(Value::as_str) == Some("session") {
@@ -382,33 +390,11 @@ impl<R: crate::JsonlProviderRuntime> JsonlFamilyProjector for OpenClawProjector<
     }
 
     fn rejected_records(&self) -> u64 {
-        self.rejected_records
+        self.rejections.count()
     }
 
     fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
-        std::mem::take(&mut self.record_rejections)
-    }
-}
-
-impl<R: crate::JsonlProviderRuntime> OpenClawProjector<R> {
-    fn reject_record(&mut self, record: JsonlRecordRef<'_>, detail: String) -> Result<()> {
-        self.rejected_records =
-            self.rejected_records
-                .checked_add(1)
-                .ok_or(CaptureError::SystemInvariant(
-                    "OpenClaw record rejection count overflowed",
-                ))?;
-        self.record_rejections
-            .record(SourceBackedRecordRejectionDraft {
-                source: self.source.clone(),
-                provider: CaptureProvider::OpenClaw,
-                source_selector: self.source_selector.clone(),
-                line_number: record.evidence().physical_ordinal().saturating_add(1),
-                payload_type: None,
-                class: SourceBackedRecordRejectionClass::MalformedRecord,
-                detail,
-            });
-        Ok(())
+        self.rejections.take_drafts()
     }
 }
 

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/providers/openclaw/native_path/source_backed/projection.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/providers/openclaw/native_path/source_backed/projection.rs
@@ -301,8 +301,20 @@ impl<R: crate::JsonlProviderRuntime> JsonlFamilyProjector for OpenClawProjector<
         if bytes.iter().all(u8::is_ascii_whitespace) {
             return Ok(());
         }
-        let Ok(value) = serde_json::from_slice::<Value>(bytes) else {
-            return Ok(());
+        if record.oversized() {
+            return self.reject_record(
+                record,
+                format!(
+                    "OpenClaw record exceeds the {} byte limit",
+                    crate::MAX_PROVIDER_JSONL_LINE_BYTES
+                ),
+            );
+        }
+        let value = match serde_json::from_slice::<Value>(bytes) {
+            Ok(value) => value,
+            Err(error) => {
+                return self.reject_record(record, format!("malformed OpenClaw JSONL: {error}"))
+            }
         };
         if !value.is_object() {
             return Ok(());
@@ -367,6 +379,36 @@ impl<R: crate::JsonlProviderRuntime> JsonlFamilyProjector for OpenClawProjector<
 
     fn provider_checkpoint(&self) -> Result<Option<TypedKey>> {
         encode_projector_checkpoint(self).map(Some)
+    }
+
+    fn rejected_records(&self) -> u64 {
+        self.rejected_records
+    }
+
+    fn take_record_rejections(&mut self) -> SourceBackedRecordRejectionDrafts {
+        std::mem::take(&mut self.record_rejections)
+    }
+}
+
+impl<R: crate::JsonlProviderRuntime> OpenClawProjector<R> {
+    fn reject_record(&mut self, record: JsonlRecordRef<'_>, detail: String) -> Result<()> {
+        self.rejected_records =
+            self.rejected_records
+                .checked_add(1)
+                .ok_or(CaptureError::SystemInvariant(
+                    "OpenClaw record rejection count overflowed",
+                ))?;
+        self.record_rejections
+            .record(SourceBackedRecordRejectionDraft {
+                source: self.source.clone(),
+                provider: CaptureProvider::OpenClaw,
+                source_selector: self.source_selector.clone(),
+                line_number: record.evidence().physical_ordinal().saturating_add(1),
+                payload_type: None,
+                class: SourceBackedRecordRejectionClass::MalformedRecord,
+                detail,
+            });
+        Ok(())
     }
 }
 

--- a/crates/ctx-history-providers-sqlite-inventory/src/lib.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/lib.rs
@@ -60,9 +60,10 @@ pub mod lifecycle {
         DocumentRecordSpool, DocumentSourceTerminal, ObservedDocumentLeaf, ReplacementDocumentTree,
         SourceBackedCoordinatorError, SourceBackedCoordinatorResult,
         SourceBackedCurrentSourceProgress, SourceBackedCurrentSourceProgressStage,
-        SourceBackedReconciliationDemand, SourceBackedRouteError, SourceBackedRouteErrorKind,
-        SourceBackedRouteResult, SourceBackedRouteSelection, SourceBackedRouteWatchTargets,
-        SourceBackedSelectorAuthority,
+        SourceBackedReconciliationDemand, SourceBackedRecordRejectionClass,
+        SourceBackedRecordRejectionDraft, SourceBackedRecordRejectionDrafts,
+        SourceBackedRouteError, SourceBackedRouteErrorKind, SourceBackedRouteResult,
+        SourceBackedRouteSelection, SourceBackedRouteWatchTargets, SourceBackedSelectorAuthority,
     };
 }
 

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/mod.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/mod.rs
@@ -51,6 +51,44 @@ pub(crate) mod sqlite {
 pub(crate) mod source_backed {
     pub(crate) use crate::lifecycle::*;
 
+    pub(crate) fn record_sqlite_rejection(
+        rejections: &mut SourceBackedRecordRejectionDrafts,
+        source: &ctx_history_core::SourceKey,
+        provider: ctx_history_core::CaptureProvider,
+        source_path: &std::path::Path,
+        physical_record: u64,
+        class: SourceBackedRecordRejectionClass,
+        detail: impl Into<String>,
+    ) {
+        rejections.record(sqlite_rejection_draft(
+            source,
+            provider,
+            source_path,
+            physical_record,
+            class,
+            detail,
+        ));
+    }
+
+    pub(crate) fn sqlite_rejection_draft(
+        source: &ctx_history_core::SourceKey,
+        provider: ctx_history_core::CaptureProvider,
+        source_path: &std::path::Path,
+        physical_record: u64,
+        class: SourceBackedRecordRejectionClass,
+        detail: impl Into<String>,
+    ) -> SourceBackedRecordRejectionDraft {
+        SourceBackedRecordRejectionDraft {
+            source: source.clone(),
+            provider,
+            source_selector: source_path.to_string_lossy().into_owned(),
+            line_number: physical_record,
+            payload_type: Some("sqlite_row".to_owned()),
+            class,
+            detail: detail.into(),
+        }
+    }
+
     pub(crate) fn route_error(error: impl std::fmt::Display) -> SourceBackedRouteError {
         SourceBackedRouteError::new(SourceBackedRouteErrorKind::InvalidSource, error.to_string())
     }

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/astrbot/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/astrbot/native_path/source_backed.rs
@@ -26,7 +26,7 @@ const INVENTORY_AUTHORITY_KEY: &str = "winner-and-launcher-instances-v0";
 const INVENTORY_REVISION_KIND: &str = "astrbot-bounded-discovery-v0";
 #[cfg(test)]
 const INVENTORY_DISCOVERY_REVISION: &str = "astrbot-winner-launcher-inventory-v0";
-pub(crate) const PARSER_REVISION: &str = "astrbot-source-backed-core-v2-neutral-core";
+pub(crate) const PARSER_REVISION: &str = "astrbot-source-backed-core-v3-record-rejections";
 const SELECTED_SOURCE_NAMESPACE: &str = "astrbot.selected-core";
 const LAUNCHER_SOURCE_NAMESPACE: &str = "astrbot.launcher-instance";
 const SESSION_NAMESPACE: &str = "astrbot.session";
@@ -66,3 +66,18 @@ pub(crate) enum AstrBotSourceBackedErrorV0 {
 }
 
 pub(crate) type AstrBotSourceBackedResultV0<T> = std::result::Result<T, AstrBotSourceBackedErrorV0>;
+
+fn astrbot_row_projection_error(error: &AstrBotSourceBackedErrorV0) -> bool {
+    matches!(
+        error,
+        AstrBotSourceBackedErrorV0::Projection(ProjectionContractError::EmptyField {
+            field: "typed_key_utf8",
+        }) | AstrBotSourceBackedErrorV0::Projection(ProjectionContractError::FieldTooLarge {
+            field: "typed_key_utf8" | "typed_composite_key",
+            ..
+        }) | AstrBotSourceBackedErrorV0::CoreRecord(CoreRecordError::FieldTooLarge {
+            field: "normalized_body" | "structured_content" | "selected_content",
+            ..
+        })
+    )
+}

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/astrbot/native_path/source_backed/parsing.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/astrbot/native_path/source_backed/parsing.rs
@@ -421,7 +421,7 @@ fn process_conversation_row(
                     .ok_or(AstrBotSourceBackedErrorV0::MissingSelectedContent)?
             };
             let session = conversation_session_fact(&row);
-            let document = conversation_document(
+            let document = match conversation_document(
                 source,
                 candidate.physical_rowid,
                 item_index,
@@ -430,9 +430,21 @@ fn process_conversation_row(
                 &session,
                 &event,
                 &complete_text,
-            )?;
-            emit_bounded(sink, page, document)?;
-            add_retained(counts)?;
+            ) {
+                Ok(document) => Some(document),
+                Err(
+                    AstrBotSourceBackedErrorV0::Projection(_)
+                    | AstrBotSourceBackedErrorV0::CoreRecord(_),
+                ) => {
+                    add_rejected(counts)?;
+                    None
+                }
+                Err(error) => return Err(error),
+            };
+            if let Some(document) = document {
+                emit_bounded(sink, page, document)?;
+                add_retained(counts)?;
+            }
         } else {
             add_ignored(counts)?;
         }
@@ -522,16 +534,28 @@ fn process_platform_row(
             let (complete_text, provider_content) = selected_content
                 .as_ref()
                 .ok_or(AstrBotSourceBackedErrorV0::MissingSelectedContent)?;
-            let document = platform_document(
+            let document = match platform_document(
                 source,
                 candidate.legacy_order.logical_id,
                 &unit.session,
                 &event,
                 complete_text,
                 provider_content,
-            )?;
-            emit_bounded(sink, page, document)?;
-            add_retained(counts)?;
+            ) {
+                Ok(document) => Some(document),
+                Err(
+                    AstrBotSourceBackedErrorV0::Projection(_)
+                    | AstrBotSourceBackedErrorV0::CoreRecord(_),
+                ) => {
+                    add_rejected(counts)?;
+                    None
+                }
+                Err(error) => return Err(error),
+            };
+            if let Some(document) = document {
+                emit_bounded(sink, page, document)?;
+                add_retained(counts)?;
+            }
         } else {
             add_ignored(counts)?;
         }

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/astrbot/native_path/source_backed/parsing.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/astrbot/native_path/source_backed/parsing.rs
@@ -4,12 +4,18 @@ use chrono::{DateTime, Utc};
 use ctx_history_capture_model::normalization::{
     provider_json_text, provider_timestamp_millis, provider_value_text,
 };
-use ctx_history_core::{CertifiedSource, CoreRecord, EventRole, EventType, ScannedSourceCounts};
+use ctx_history_core::{
+    CaptureProvider, CertifiedSource, CoreRecord, EventRole, EventType, ScannedSourceCounts,
+};
 use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use crate::{
+    provider::source_backed::{
+        record_sqlite_rejection, SourceBackedRecordRejectionClass,
+        SourceBackedRecordRejectionDrafts,
+    },
     provider::sqlite::sqlite_schema_fingerprint,
     provider_sources::{SqliteLogicalSnapshot, SqliteSourceReadSnapshot},
     CaptureError, MAX_PROVIDER_SQLITE_VALUE_BYTES,
@@ -28,6 +34,7 @@ use super::super::super::{
 #[cfg(test)]
 use super::discovery::open_root_authorized_snapshot;
 use super::{
+    astrbot_row_projection_error,
     discovery::AstrBotSourceBackedSourceV0,
     identity::{
         conversation_document, logical_values_digest, platform_document, EventFact, SessionFact,
@@ -175,7 +182,8 @@ pub(crate) fn scan_astrbot_source_backed_v0(
     sink: &mut impl AstrBotSourceBackedSinkV0,
 ) -> AstrBotSourceBackedResultV0<CertifiedSource> {
     let (source_root, sqlite_snapshot) = open_root_authorized_snapshot(data_root, &source.path)?;
-    let certificate = scan_astrbot_snapshot_v0(source, sqlite_snapshot, sink)?;
+    let mut rejections = SourceBackedRecordRejectionDrafts::default();
+    let certificate = scan_astrbot_snapshot_v0(source, sqlite_snapshot, sink, &mut rejections)?;
     source_root.revalidate()?;
     Ok(certificate)
 }
@@ -184,6 +192,7 @@ pub(crate) fn scan_astrbot_snapshot_v0(
     source: &AstrBotSourceBackedSourceV0,
     sqlite_snapshot: SqliteSourceReadSnapshot,
     sink: &mut impl AstrBotSourceBackedSinkV0,
+    rejections: &mut SourceBackedRecordRejectionDrafts,
 ) -> AstrBotSourceBackedResultV0<CertifiedSource> {
     let scan = (|| {
         let conn = sqlite_snapshot.connection()?;
@@ -229,6 +238,8 @@ pub(crate) fn scan_astrbot_snapshot_v0(
                         &mut counts,
                         &mut content_chain,
                         &mut native_ordinal,
+                        source,
+                        rejections,
                     )?;
                     let candidate = candidates.get(candidate_index).copied().ok_or(
                         AstrBotSourceBackedErrorV0::Capture(
@@ -251,6 +262,7 @@ pub(crate) fn scan_astrbot_snapshot_v0(
                         &mut counts,
                         &mut content_chain,
                         &mut native_ordinal,
+                        rejections,
                     )
                 },
             )?;
@@ -261,6 +273,8 @@ pub(crate) fn scan_astrbot_snapshot_v0(
                 &mut counts,
                 &mut content_chain,
                 &mut native_ordinal,
+                source,
+                rejections,
             )?;
             if candidate_index != candidates.len() {
                 return Err(CaptureError::SourceChangedDuringCapture.into());
@@ -300,6 +314,8 @@ pub(crate) fn scan_astrbot_snapshot_v0(
                         &mut counts,
                         &mut content_chain,
                         &mut native_ordinal,
+                        source,
+                        rejections,
                     )?;
                     let candidate = candidates.get(candidate_index).copied().ok_or(
                         AstrBotSourceBackedErrorV0::Capture(
@@ -322,6 +338,7 @@ pub(crate) fn scan_astrbot_snapshot_v0(
                         &mut counts,
                         &mut content_chain,
                         &mut native_ordinal,
+                        rejections,
                     )
                 })?;
                 process_oversize_run(
@@ -331,6 +348,8 @@ pub(crate) fn scan_astrbot_snapshot_v0(
                     &mut counts,
                     &mut content_chain,
                     &mut native_ordinal,
+                    source,
+                    rejections,
                 )?;
                 if candidate_index != candidates.len() {
                     return Err(CaptureError::SourceChangedDuringCapture.into());
@@ -386,6 +405,7 @@ fn process_conversation_row(
     counts: &mut ScannedSourceCounts,
     content_chain: &mut [u8; 32],
     native_ordinal: &mut u64,
+    rejections: &mut SourceBackedRecordRejectionDrafts,
 ) -> AstrBotSourceBackedResultV0<()> {
     add_certified_bytes(counts, candidate.observed_bytes()?)?;
     let row_digest = logical_values_digest(&super::super::super::model::conversation_values(
@@ -432,11 +452,18 @@ fn process_conversation_row(
                 &complete_text,
             ) {
                 Ok(document) => Some(document),
-                Err(
-                    AstrBotSourceBackedErrorV0::Projection(_)
-                    | AstrBotSourceBackedErrorV0::CoreRecord(_),
-                ) => {
+                Err(error) if astrbot_row_projection_error(&error) => {
                     add_rejected(counts)?;
+                    record_sqlite_rejection(
+                        rejections,
+                        &source.source_key,
+                        CaptureProvider::AstrBot,
+                        &source.path,
+                        u64::try_from(candidate.physical_rowid)
+                            .unwrap_or(native_ordinal.saturating_add(1)),
+                        SourceBackedRecordRejectionClass::UnsupportedRecord,
+                        error.to_string(),
+                    );
                     None
                 }
                 Err(error) => return Err(error),
@@ -521,14 +548,24 @@ fn process_platform_row(
     counts: &mut ScannedSourceCounts,
     content_chain: &mut [u8; 32],
     native_ordinal: &mut u64,
+    rejections: &mut SourceBackedRecordRejectionDrafts,
 ) -> AstrBotSourceBackedResultV0<()> {
     add_certified_bytes(counts, candidate.observed_bytes()?)?;
     add_complete(counts)?;
     let (unit, rejection, row_digest, selected_content) =
         source_backed_platform_unit(&row, *native_ordinal, checkpoint_links)?;
     *content_chain = chain_hash(*content_chain, row_digest);
-    if rejection.is_some() {
+    if let Some(rejection) = rejection {
         add_rejected(counts)?;
+        record_sqlite_rejection(
+            rejections,
+            &source.source_key,
+            CaptureProvider::AstrBot,
+            &source.path,
+            u64::try_from(candidate.physical_rowid).unwrap_or(native_ordinal.saturating_add(1)),
+            SourceBackedRecordRejectionClass::UnsupportedRecord,
+            rejection,
+        );
     } else if let Some(unit) = unit {
         if let Some(event) = unit.event {
             let (complete_text, provider_content) = selected_content
@@ -543,11 +580,18 @@ fn process_platform_row(
                 provider_content,
             ) {
                 Ok(document) => Some(document),
-                Err(
-                    AstrBotSourceBackedErrorV0::Projection(_)
-                    | AstrBotSourceBackedErrorV0::CoreRecord(_),
-                ) => {
+                Err(error) if astrbot_row_projection_error(&error) => {
                     add_rejected(counts)?;
+                    record_sqlite_rejection(
+                        rejections,
+                        &source.source_key,
+                        CaptureProvider::AstrBot,
+                        &source.path,
+                        u64::try_from(candidate.physical_rowid)
+                            .unwrap_or(native_ordinal.saturating_add(1)),
+                        SourceBackedRecordRejectionClass::UnsupportedRecord,
+                        error.to_string(),
+                    );
                     None
                 }
                 Err(error) => return Err(error),
@@ -573,6 +617,7 @@ fn candidate_is_oversize(candidate: RowCandidate) -> AstrBotSourceBackedResultV0
         > u64::try_from(MAX_PROVIDER_SQLITE_VALUE_BYTES).unwrap_or(u64::MAX))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn process_oversize_run(
     candidates: &[RowCandidate],
     index: &mut usize,
@@ -580,6 +625,8 @@ fn process_oversize_run(
     counts: &mut ScannedSourceCounts,
     content_chain: &mut [u8; 32],
     native_ordinal: &mut u64,
+    source: &AstrBotSourceBackedSourceV0,
+    rejections: &mut SourceBackedRecordRejectionDrafts,
 ) -> AstrBotSourceBackedResultV0<()> {
     while candidates
         .get(*index)
@@ -594,6 +641,8 @@ fn process_oversize_run(
             counts,
             content_chain,
             native_ordinal,
+            source,
+            rejections,
         )?;
         *index += 1;
     }
@@ -606,11 +655,22 @@ fn process_oversize_candidate(
     counts: &mut ScannedSourceCounts,
     content_chain: &mut [u8; 32],
     native_ordinal: &mut u64,
+    source: &AstrBotSourceBackedSourceV0,
+    rejections: &mut SourceBackedRecordRejectionDrafts,
 ) -> AstrBotSourceBackedResultV0<()> {
     add_certified_bytes(counts, candidate.observed_bytes()?)?;
     *content_chain = chain_hash(*content_chain, candidate_hash(hash_domain, candidate));
     add_complete(counts)?;
     add_rejected(counts)?;
+    record_sqlite_rejection(
+        rejections,
+        &source.source_key,
+        CaptureProvider::AstrBot,
+        &source.path,
+        u64::try_from(candidate.physical_rowid).unwrap_or(native_ordinal.saturating_add(1)),
+        SourceBackedRecordRejectionClass::UnsupportedRecord,
+        "AstrBot SQLite row exceeds the supported value-size bound",
+    );
     *native_ordinal = native_ordinal
         .checked_add(1)
         .ok_or(AstrBotSourceBackedErrorV0::CountOverflow)?;

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/astrbot/native_path/source_backed/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/astrbot/native_path/source_backed/tests.rs
@@ -306,6 +306,47 @@ fn cold_scan_is_bounded_deterministic_and_emits_valid_stable_core() {
 }
 
 #[test]
+fn row_local_projection_failure_rejects_only_its_conversation() {
+    let temp = tempdir().unwrap();
+    let path = temp.path().join("data_v4.db");
+    create_database(&path, "bad-session", "bad body");
+    let connection = Connection::open(&path).unwrap();
+    connection
+        .execute(
+            "update conversations set inner_conversation_id = ?1 where id = 1",
+            ["x".repeat(70 * 1024)],
+        )
+        .unwrap();
+    insert_conversation(
+        &connection,
+        2,
+        "healthy-session",
+        "healthy body",
+        "healthy-message",
+    );
+    drop(connection);
+
+    let source = selected_source(&path);
+    let mut records = Vec::new();
+    let certificate = scan_astrbot_source_backed_v0(
+        crate::test_provider_sqlite_data_root(),
+        &source,
+        &mut |record| {
+            records.push(record);
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].content.meaningful_text(), "healthy body");
+    assert_eq!(certificate.counts().complete_records, 2);
+    assert_eq!(certificate.counts().retained_records, 1);
+    assert_eq!(certificate.counts().rejected_records, 1);
+    assert_eq!(certificate.counts().indexed_documents, 1);
+}
+
+#[test]
 fn complete_native_structure_and_event_fields_survive_direct_core_projection() {
     let temp = tempdir().unwrap();
     let path = temp.path().join("data_v4.db");

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/astrbot/native_path/source_backed/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/astrbot/native_path/source_backed/tests.rs
@@ -134,9 +134,12 @@ fn transferred_snapshot_scan_failure_reports_cleanup_fatal_error() {
     )
     .unwrap();
 
-    let error = scan_astrbot_snapshot_v0(&source, snapshot, &mut |_record| {
-        Err(AstrBotSourceBackedErrorV0::CountOverflow)
-    })
+    let error = scan_astrbot_snapshot_v0(
+        &source,
+        snapshot,
+        &mut |_record| Err(AstrBotSourceBackedErrorV0::CountOverflow),
+        &mut crate::lifecycle::SourceBackedRecordRejectionDrafts::default(),
+    )
     .unwrap_err();
     let AstrBotSourceBackedErrorV0::SnapshotCleanup { primary, cleanup } = error else {
         panic!("expected typed primary-plus-cleanup failure");
@@ -344,6 +347,27 @@ fn row_local_projection_failure_rejects_only_its_conversation() {
     assert_eq!(certificate.counts().retained_records, 1);
     assert_eq!(certificate.counts().rejected_records, 1);
     assert_eq!(certificate.counts().indexed_documents, 1);
+}
+
+#[test]
+fn row_local_projection_filter_preserves_core_invariants() {
+    assert!(astrbot_row_projection_error(
+        &AstrBotSourceBackedErrorV0::Projection(ProjectionContractError::FieldTooLarge {
+            field: "typed_key_utf8",
+            actual: 2,
+            maximum: 1,
+        })
+    ));
+    for error in [
+        AstrBotSourceBackedErrorV0::Projection(ProjectionContractError::SourceChanged),
+        AstrBotSourceBackedErrorV0::Projection(ProjectionContractError::InvalidDerivedIdentity),
+        AstrBotSourceBackedErrorV0::CoreRecord(CoreRecordError::Projection(
+            ProjectionContractError::SourceChanged,
+        )),
+        AstrBotSourceBackedErrorV0::CoreRecord(CoreRecordError::InvalidIdentityRelationship),
+    ] {
+        assert!(!astrbot_row_projection_error(&error), "{error:?}");
+    }
 }
 
 #[test]

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path/source_backed.rs
@@ -587,9 +587,16 @@ where
                     let session = session
                         .as_ref()
                         .ok_or(CrushSourceBackedErrorV0::UnexpectedNativeRow)?;
-                    sink.emit_core_record(core_record(source, &row, session, &projection)?)?;
-                    counts.retained_records = checked_add(counts.retained_records, 1)?;
-                    counts.indexed_documents = checked_add(counts.indexed_documents, 1)?;
+                    match project_core_record(source, &row, session, &projection)? {
+                        Some(record) => {
+                            sink.emit_core_record(record)?;
+                            counts.retained_records = checked_add(counts.retained_records, 1)?;
+                            counts.indexed_documents = checked_add(counts.indexed_documents, 1)?;
+                        }
+                        None => {
+                            counts.rejected_records = checked_add(counts.rejected_records, 1)?;
+                        }
+                    }
                 }
                 CrushRecordProjection::Message(_) => {
                     counts.ignored_records = checked_add(counts.ignored_records, 1)?;
@@ -601,6 +608,21 @@ where
         content_digest: digest.finalize().into(),
         counts,
     })
+}
+
+fn project_core_record(
+    source: &OpenedSource,
+    row: &super::super::projection::CrushMessageRow,
+    session: &CrushSessionRow,
+    projection: &CrushMessageProjection,
+) -> CrushSourceBackedResultV0<Option<CoreRecord>> {
+    match core_record(source, row, session, projection) {
+        Ok(record) => Ok(Some(record)),
+        Err(CrushSourceBackedErrorV0::Projection(_) | CrushSourceBackedErrorV0::CoreRecord(_)) => {
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 fn core_record(

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path/source_backed.rs
@@ -30,7 +30,10 @@ use super::{
 use crate::{
     common::io::{OpenedProviderSourceFile, ProviderSourceRoot},
     fnv1a64,
-    provider::source_backed::{family::document::ChangedDocumentSink, SourceBackedRouteError},
+    provider::source_backed::{
+        family::document::ChangedDocumentSink, sqlite_rejection_draft,
+        SourceBackedRecordRejectionClass, SourceBackedRouteError,
+    },
     provider_sources::{
         retain_sqlite_source_directory_authority, SqliteFailurePhase, SqliteLogicalSnapshot,
         SqliteSourceAccessError, SqliteSourceDirectoryAuthority, SqliteSourceReadSnapshot,
@@ -57,8 +60,7 @@ const CRUSH_SOURCE_ANCHOR_NAMESPACE: &str = "crush.project-database";
 const CRUSH_INVENTORY_AUTHORITY_NAMESPACE: &str = "crush.project-inventory";
 const CRUSH_INVENTORY_REVISION_KIND: &str = "crush-selected-registered-projects-v0";
 pub(crate) const CRUSH_SOURCE_SCHEMA_VARIANT: &str = "crush-project-sqlite-v0";
-pub(crate) const CRUSH_PARSER_REVISION: &str =
-    "crush-sqlite-source-backed-v4-neutral-core-agent-scope";
+pub(crate) const CRUSH_PARSER_REVISION: &str = "crush-sqlite-source-backed-v5-record-rejections";
 const CRUSH_NATIVE_SESSION_NAMESPACE: &str = "crush.session";
 const CRUSH_NATIVE_MESSAGE_NAMESPACE: &str = "crush.message";
 const CRUSH_LOGICAL_SESSION_KIND: &str = "crush-session";
@@ -571,6 +573,14 @@ where
                 Err(error) if row_decode_error_is_local(&error) => {
                     counts.rejected_records = checked_add(counts.rejected_records, 1)?;
                     hash_rejected_candidate(&mut digest, candidate, error.to_string().as_bytes());
+                    sink.record_rejection(sqlite_rejection_draft(
+                        &source.database.source_key,
+                        CaptureProvider::Crush,
+                        &source.database.canonical_path,
+                        u64::try_from(candidate.rowid).unwrap_or_default(),
+                        SourceBackedRecordRejectionClass::MalformedRecord,
+                        error.to_string(),
+                    ));
                     continue;
                 }
                 Err(error) => return Err(error.into()),
@@ -582,20 +592,37 @@ where
             match project_message(&row, session.as_ref())? {
                 CrushRecordProjection::Rejection => {
                     counts.rejected_records = checked_add(counts.rejected_records, 1)?;
+                    sink.record_rejection(sqlite_rejection_draft(
+                        &source.database.source_key,
+                        CaptureProvider::Crush,
+                        &source.database.canonical_path,
+                        u64::try_from(candidate.rowid).unwrap_or_default(),
+                        SourceBackedRecordRejectionClass::UnsupportedRecord,
+                        "Crush SQLite row has an unsupported message shape",
+                    ));
                 }
                 CrushRecordProjection::Message(projection) if projection.event.is_some() => {
                     let session = session
                         .as_ref()
                         .ok_or(CrushSourceBackedErrorV0::UnexpectedNativeRow)?;
-                    match project_core_record(source, &row, session, &projection)? {
-                        Some(record) => {
+                    match core_record(source, &row, session, &projection) {
+                        Ok(record) => {
                             sink.emit_core_record(record)?;
                             counts.retained_records = checked_add(counts.retained_records, 1)?;
                             counts.indexed_documents = checked_add(counts.indexed_documents, 1)?;
                         }
-                        None => {
+                        Err(error) if crush_row_projection_error(&error) => {
                             counts.rejected_records = checked_add(counts.rejected_records, 1)?;
+                            sink.record_rejection(sqlite_rejection_draft(
+                                &source.database.source_key,
+                                CaptureProvider::Crush,
+                                &source.database.canonical_path,
+                                u64::try_from(candidate.rowid).unwrap_or_default(),
+                                SourceBackedRecordRejectionClass::UnsupportedRecord,
+                                error.to_string(),
+                            ));
                         }
+                        Err(error) => return Err(error),
                     }
                 }
                 CrushRecordProjection::Message(_) => {
@@ -610,19 +637,25 @@ where
     })
 }
 
-fn project_core_record(
-    source: &OpenedSource,
-    row: &super::super::projection::CrushMessageRow,
-    session: &CrushSessionRow,
-    projection: &CrushMessageProjection,
-) -> CrushSourceBackedResultV0<Option<CoreRecord>> {
-    match core_record(source, row, session, projection) {
-        Ok(record) => Ok(Some(record)),
-        Err(CrushSourceBackedErrorV0::Projection(_) | CrushSourceBackedErrorV0::CoreRecord(_)) => {
-            Ok(None)
-        }
-        Err(error) => Err(error),
-    }
+fn crush_row_projection_error(error: &CrushSourceBackedErrorV0) -> bool {
+    matches!(
+        error,
+        CrushSourceBackedErrorV0::Projection(ProjectionContractError::EmptyField {
+            field: "typed_key_utf8",
+        }) | CrushSourceBackedErrorV0::Projection(ProjectionContractError::FieldTooLarge {
+            field: "typed_key_utf8",
+            ..
+        }) | CrushSourceBackedErrorV0::CoreRecord(CoreRecordError::EmptyField {
+            field: "activity.invocation.tool" | "activity.result.status",
+        }) | CrushSourceBackedErrorV0::CoreRecord(CoreRecordError::FieldTooLarge {
+            field: "normalized_body"
+                | "structured_content"
+                | "selected_content"
+                | "activity.invocation.tool"
+                | "activity.result.status",
+            ..
+        })
+    )
 }
 
 fn core_record(

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path/source_backed/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path/source_backed/tests.rs
@@ -280,10 +280,30 @@ fn row_local_projection_failure_becomes_a_record_rejection() {
         panic!("expected the oversized identity row to reach Core projection");
     };
 
-    assert!(project_core_record(&source, &row, &session, &projection)
-        .unwrap()
-        .is_none());
+    let error = core_record(&source, &row, &session, &projection).unwrap_err();
+    assert!(crush_row_projection_error(&error));
     assert!(finish_opened_source(source).unwrap());
+}
+
+#[test]
+fn row_local_projection_filter_preserves_core_invariants() {
+    assert!(crush_row_projection_error(
+        &CrushSourceBackedErrorV0::Projection(ProjectionContractError::FieldTooLarge {
+            field: "typed_key_utf8",
+            actual: 2,
+            maximum: 1,
+        })
+    ));
+    for error in [
+        CrushSourceBackedErrorV0::Projection(ProjectionContractError::SourceChanged),
+        CrushSourceBackedErrorV0::Projection(ProjectionContractError::InvalidDerivedIdentity),
+        CrushSourceBackedErrorV0::CoreRecord(CoreRecordError::Projection(
+            ProjectionContractError::SourceChanged,
+        )),
+        CrushSourceBackedErrorV0::CoreRecord(CoreRecordError::InvalidSessionRelationship),
+    ] {
+        assert!(!crush_row_projection_error(&error), "{error:?}");
+    }
 }
 
 #[test]

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path/source_backed/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/crush/native_path/source_backed/tests.rs
@@ -235,6 +235,58 @@ fn record_for_only_message(source: &OpenedSource) -> ctx_history_core::CoreRecor
 }
 
 #[test]
+fn row_local_projection_failure_becomes_a_record_rejection() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let path = temp.path().join("row-local.db");
+    write_database(&path, "session", "message", "body");
+    Connection::open(&path)
+        .unwrap()
+        .execute(
+            "update messages set id = ?1 where id = 'message'",
+            ["x".repeat(70 * 1024)],
+        )
+        .unwrap();
+    let frozen = bind_inventory(
+        crate::test_provider_sqlite_data_root(),
+        inventory(b"row-local", vec![database("project", &path)]),
+    )
+    .unwrap();
+    let source = open_source(frozen.databases.into_iter().next().unwrap()).unwrap();
+    let candidate = super::super::query::next_candidate(
+        source.connection().unwrap(),
+        &source.schema,
+        &CrushNativeFrontier { after_rowid: None },
+    )
+    .unwrap()
+    .unwrap();
+    let CrushLoadedRow {
+        row,
+        session: Some(session),
+        ..
+    } = super::super::query::load_message_batch(
+        source.connection().unwrap(),
+        &source.schema,
+        &[candidate],
+    )
+    .unwrap()
+    .remove(&candidate.rowid)
+    .unwrap()
+    .unwrap()
+    else {
+        panic!("expected one parented Crush message row");
+    };
+    let CrushRecordProjection::Message(projection) = project_message(&row, Some(&session)).unwrap()
+    else {
+        panic!("expected the oversized identity row to reach Core projection");
+    };
+
+    assert!(project_core_record(&source, &row, &session, &projection)
+        .unwrap()
+        .is_none());
+    assert!(finish_opened_source(source).unwrap());
+}
+
+#[test]
 fn source_backed_message_round_trips_full_policy_body_and_structured_content() {
     let temp = crate::test_support_paths::tempdir().unwrap();
     let path = temp.path().join("full-body.db");

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/lingma/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/lingma/native_path/source_backed.rs
@@ -18,7 +18,7 @@ const INVENTORY_AUTHORITY_NAMESPACE: &str = "lingma.installed-client-profile-ver
 const INVENTORY_REVISION_KIND: &str = "lingma-finite-database-inventory-v0";
 #[cfg(test)]
 const INVENTORY_DISCOVERY_REVISION: &str = "lingma-installed-database-discovery-v0";
-pub(crate) const PARSER_REVISION: &str = "lingma-source-backed-core-v2-neutral-core";
+pub(crate) const PARSER_REVISION: &str = "lingma-source-backed-core-v3-record-rejections";
 const NATIVE_SESSION_NAMESPACE: &str = "lingma.session";
 const NATIVE_REQUEST_NAMESPACE: &str = "lingma.chat-record.request";
 const NATIVE_POSITION_KIND: &str = "lingma.chat-record.scan-ordinal";
@@ -62,3 +62,18 @@ pub(crate) enum LingmaSourceBackedErrorV0 {
 }
 
 pub(crate) type LingmaSourceBackedResultV0<T> = Result<T, LingmaSourceBackedErrorV0>;
+
+fn lingma_row_projection_error(error: &LingmaSourceBackedErrorV0) -> bool {
+    matches!(
+        error,
+        LingmaSourceBackedErrorV0::Projection(ProjectionContractError::EmptyField {
+            field: "typed_key_utf8",
+        }) | LingmaSourceBackedErrorV0::Projection(ProjectionContractError::FieldTooLarge {
+            field: "typed_key_utf8" | "typed_composite_key",
+            ..
+        }) | LingmaSourceBackedErrorV0::CoreRecord(CoreRecordError::FieldTooLarge {
+            field: "normalized_body" | "structured_content" | "selected_content",
+            ..
+        }) | LingmaSourceBackedErrorV0::EmptySelectedBody
+    )
+}

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/lingma/native_path/source_backed/parsing.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/lingma/native_path/source_backed/parsing.rs
@@ -2,10 +2,16 @@ use std::collections::BTreeSet;
 
 #[cfg(test)]
 use ctx_history_core::CertifiedSourceInventory;
-use ctx_history_core::{CertifiedSource, CoreRecord, ScannedSourceCounts, SourceKey};
+use ctx_history_core::{
+    CaptureProvider, CertifiedSource, CoreRecord, ScannedSourceCounts, SourceKey,
+};
 use sha2::Digest;
 
 use crate::{
+    provider::source_backed::{
+        record_sqlite_rejection, SourceBackedRecordRejectionClass,
+        SourceBackedRecordRejectionDrafts,
+    },
     provider::sqlite::sqlite_schema_fingerprint,
     provider_sources::{SqliteLogicalSnapshot, SqliteSourceReadSnapshot},
     CaptureError,
@@ -21,7 +27,8 @@ use super::{discovery::LingmaRootAuthorizedSource, INVENTORY_DISCOVERY_REVISION}
 use super::{
     discovery::{LingmaDatabaseSourceV0, LingmaSourceInventoryV0},
     identity::{project_row, ParsedRow},
-    LingmaSourceBackedErrorV0, LingmaSourceBackedResultV0, PARSER_REVISION,
+    lingma_row_projection_error, LingmaSourceBackedErrorV0, LingmaSourceBackedResultV0,
+    PARSER_REVISION,
 };
 
 const SOURCE_BACKED_PAGE_ROWS: usize = 64;
@@ -107,10 +114,15 @@ where
         let root_authority = LingmaRootAuthorizedSource::retain(data_root, &database.path)?;
         let sqlite_snapshot = root_authority.open_snapshot()?;
         let mut records = Vec::new();
-        let certificate = scan_lingma_snapshot_v0(database, sqlite_snapshot, &mut |record| {
-            records.push(record);
-            Ok(())
-        })?;
+        let certificate = scan_lingma_snapshot_v0(
+            database,
+            sqlite_snapshot,
+            &mut |record| {
+                records.push(record);
+                Ok(())
+            },
+            &mut SourceBackedRecordRejectionDrafts::default(),
+        )?;
         root_authority.source_root.revalidate()?;
         databases.push(LingmaDatabaseScanV0 {
             certificate,
@@ -151,6 +163,7 @@ pub(crate) fn scan_lingma_snapshot_v0(
     database: &LingmaDatabaseSourceV0,
     sqlite_snapshot: SqliteSourceReadSnapshot,
     sink: &mut impl LingmaSourceBackedSinkV0,
+    rejections: &mut SourceBackedRecordRejectionDrafts,
 ) -> LingmaSourceBackedResultV0<CertifiedSource> {
     let scan = (|| {
         let source = database.source_key()?;
@@ -160,7 +173,14 @@ pub(crate) fn scan_lingma_snapshot_v0(
             .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
             .map_err(CaptureError::from)?;
         let schema_fingerprint = sqlite_schema_fingerprint(connection)?;
-        let parsed = scan_rows(connection, encoding, &source, sink)?;
+        let parsed = scan_rows(
+            connection,
+            encoding,
+            &source,
+            database.path(),
+            sink,
+            rejections,
+        )?;
         before_database_certification();
         let schema_evidence = format!(
             "user_version={user_version}\0schema={schema_fingerprint}\0encoding={}",
@@ -215,7 +235,9 @@ fn scan_rows(
     connection: &rusqlite::Connection,
     encoding: SqliteEncoding,
     source: &SourceKey,
+    source_path: &std::path::Path,
     sink: &mut impl LingmaSourceBackedSinkV0,
+    rejections: &mut SourceBackedRecordRejectionDrafts,
 ) -> LingmaSourceBackedResultV0<ParsedScan> {
     let mut after_rowid = None;
     let mut physical_ordinal = 0_u64;
@@ -249,8 +271,10 @@ fn scan_rows(
                     None,
                     encoding,
                     source,
+                    source_path,
                     &duplicate_requests,
                     sink,
+                    rejections,
                     &mut page,
                     &mut hasher,
                     &mut physical_ordinal,
@@ -274,8 +298,10 @@ fn scan_rows(
                 Some(raw),
                 encoding,
                 source,
+                source_path,
                 &duplicate_requests,
                 sink,
+                rejections,
                 &mut page,
                 &mut hasher,
                 &mut physical_ordinal,
@@ -295,8 +321,10 @@ fn scan_rows(
                 None,
                 encoding,
                 source,
+                source_path,
                 &duplicate_requests,
                 sink,
+                rejections,
                 &mut page,
                 &mut hasher,
                 &mut physical_ordinal,
@@ -336,8 +364,10 @@ fn process_candidate(
     raw: Option<RawRow>,
     encoding: SqliteEncoding,
     source: &SourceKey,
+    source_path: &std::path::Path,
     duplicate_requests: &BTreeSet<DuplicateRequestIdentity>,
     sink: &mut impl LingmaSourceBackedSinkV0,
+    rejections: &mut SourceBackedRecordRejectionDrafts,
     page: &mut Vec<CoreRecord>,
     hasher: &mut sha2::Sha256,
     physical_ordinal: &mut u64,
@@ -404,18 +434,41 @@ fn process_candidate(
                     }
                     page.extend(projected);
                 }
-                Err(
-                    LingmaSourceBackedErrorV0::Projection(_)
-                    | LingmaSourceBackedErrorV0::CoreRecord(_)
-                    | LingmaSourceBackedErrorV0::EmptySelectedBody,
-                ) => {
+                Err(error) if lingma_row_projection_error(&error) => {
                     *rejected_records = rejected_records.saturating_add(1);
+                    record_sqlite_rejection(
+                        rejections,
+                        source,
+                        CaptureProvider::Lingma,
+                        source_path,
+                        u64::try_from(candidate.rowid)
+                            .unwrap_or(physical_ordinal.saturating_add(1)),
+                        SourceBackedRecordRejectionClass::UnsupportedRecord,
+                        error.to_string(),
+                    );
                 }
                 Err(error) => return Err(error),
             }
         }
         None => {
             *rejected_records = rejected_records.saturating_add(1);
+            record_sqlite_rejection(
+                rejections,
+                source,
+                CaptureProvider::Lingma,
+                source_path,
+                u64::try_from(candidate.rowid).unwrap_or(physical_ordinal.saturating_add(1)),
+                if candidate.can_decode() {
+                    SourceBackedRecordRejectionClass::MalformedRecord
+                } else {
+                    SourceBackedRecordRejectionClass::UnsupportedRecord
+                },
+                if candidate.can_decode() {
+                    "Lingma SQLite row could not be decoded"
+                } else {
+                    "Lingma SQLite row exceeds the supported shape or size bound"
+                },
+            );
         }
     }
     *physical_ordinal = physical_ordinal.saturating_add(1);

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/lingma/native_path/source_backed/parsing.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/lingma/native_path/source_backed/parsing.rs
@@ -366,9 +366,6 @@ fn process_candidate(
         }
         Some(row) => {
             let logical_records = 1_u64 + u64::from(assistant_text(&row).is_some());
-            *retained_records = retained_records
-                .checked_add(logical_records)
-                .ok_or(LingmaSourceBackedErrorV0::CountOverflow)?;
             let record_digest = lingma_logical_record_sha256(&native_values(&row));
             let request_identity_unique = row
                 .request_id
@@ -381,7 +378,7 @@ fn process_candidate(
                     ))
                 });
             let mut projected = Vec::with_capacity(2);
-            project_row(
+            let projection = project_row(
                 source,
                 ParsedRow {
                     ordinal: *physical_ordinal,
@@ -390,17 +387,32 @@ fn process_candidate(
                     request_identity_unique,
                 },
                 &mut projected,
-            )?;
-            *indexed_documents = indexed_documents
-                .checked_add(
-                    u64::try_from(projected.len())
-                        .map_err(|_| LingmaSourceBackedErrorV0::CountOverflow)?,
-                )
-                .ok_or(LingmaSourceBackedErrorV0::CountOverflow)?;
-            if page.len().saturating_add(projected.len()) > SOURCE_BACKED_PAGE_ROWS {
-                emit_page(sink, page)?;
+            );
+            match projection {
+                Ok(()) => {
+                    *retained_records = retained_records
+                        .checked_add(logical_records)
+                        .ok_or(LingmaSourceBackedErrorV0::CountOverflow)?;
+                    *indexed_documents = indexed_documents
+                        .checked_add(
+                            u64::try_from(projected.len())
+                                .map_err(|_| LingmaSourceBackedErrorV0::CountOverflow)?,
+                        )
+                        .ok_or(LingmaSourceBackedErrorV0::CountOverflow)?;
+                    if page.len().saturating_add(projected.len()) > SOURCE_BACKED_PAGE_ROWS {
+                        emit_page(sink, page)?;
+                    }
+                    page.extend(projected);
+                }
+                Err(
+                    LingmaSourceBackedErrorV0::Projection(_)
+                    | LingmaSourceBackedErrorV0::CoreRecord(_)
+                    | LingmaSourceBackedErrorV0::EmptySelectedBody,
+                ) => {
+                    *rejected_records = rejected_records.saturating_add(1);
+                }
+                Err(error) => return Err(error),
             }
-            page.extend(projected);
         }
         None => {
             *rejected_records = rejected_records.saturating_add(1);

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/lingma/native_path/source_backed/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/lingma/native_path/source_backed/tests.rs
@@ -216,6 +216,23 @@ fn row_local_projection_failure_rejects_only_its_chat_record() {
 }
 
 #[test]
+fn row_local_projection_filter_preserves_core_invariants() {
+    assert!(lingma_row_projection_error(
+        &LingmaSourceBackedErrorV0::EmptySelectedBody
+    ));
+    for error in [
+        LingmaSourceBackedErrorV0::Projection(ProjectionContractError::SourceChanged),
+        LingmaSourceBackedErrorV0::Projection(ProjectionContractError::InvalidDerivedIdentity),
+        LingmaSourceBackedErrorV0::CoreRecord(CoreRecordError::Projection(
+            ProjectionContractError::SourceChanged,
+        )),
+        LingmaSourceBackedErrorV0::CoreRecord(CoreRecordError::InvalidIdentityRelationship),
+    ] {
+        assert!(!lingma_row_projection_error(&error), "{error:?}");
+    }
+}
+
+#[test]
 fn finite_inventory_certifies_complete_bodies_and_order_independent_ids() {
     let temp = crate::test_support_paths::tempdir().unwrap();
     let first_path = temp.path().join("vscode-local.db");

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/lingma/native_path/source_backed/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/lingma/native_path/source_backed/tests.rs
@@ -177,6 +177,45 @@ fn cold_scan_is_bounded_deterministic_and_emits_valid_stable_core() {
 }
 
 #[test]
+fn row_local_projection_failure_rejects_only_its_chat_record() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let path = temp.path().join("local.db");
+    let connection = create_database(&path);
+    insert_row(
+        &connection,
+        &"x".repeat(70 * 1024),
+        "bad-request",
+        "bad prompt",
+        None,
+    );
+    insert_row(
+        &connection,
+        "healthy-session",
+        "healthy-request",
+        "healthy prompt",
+        None,
+    );
+    drop(connection);
+    let opening = inventory(vec![database(&path, "vscode:stable:row-local")]);
+    let closing = opening.clone();
+
+    let scan =
+        scan_lingma_source_backed_v0(crate::test_provider_sqlite_data_root(), opening, || {
+            Ok(closing)
+        })
+        .unwrap();
+    let records = all_records(&scan);
+    let counts = scan.databases()[0].certificate.counts();
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].content.meaningful_text(), "healthy prompt");
+    assert_eq!(counts.complete_records, 2);
+    assert_eq!(counts.retained_records, 1);
+    assert_eq!(counts.rejected_records, 1);
+    assert_eq!(counts.indexed_documents, 1);
+}
+
+#[test]
 fn finite_inventory_certifies_complete_bodies_and_order_independent_ids() {
     let temp = crate::test_support_paths::tempdir().unwrap();
     let first_path = temp.path().join("vscode-local.db");

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/shelley/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/shelley/native_path/source_backed.rs
@@ -12,10 +12,11 @@ use std::{
 
 use ctx_history_core::{
     derive_event_id, derive_session_id, ActivityJsonCapture, ActivityResult, ActivityTextCapture,
-    AgentScope, CertifiedSource, CoreActivity, CoreRecord, EventIdentityInput, LiteralFactKind,
-    NativeItemKey, NativeSessionKey, ProjectionContractError, ProviderDeclaredFact,
-    ProviderNativeSessionRelationship, ScannedSourceCounts, SessionIdentityInput, SourceAnchor,
-    SourceKey, StableEntityId, TypedKey, CORE_ACTIVITY_REVISION,
+    AgentScope, CertifiedSource, CoreActivity, CoreRecord, CoreRecordError, EventIdentityInput,
+    LiteralFactKind, NativeItemKey, NativeSessionKey, ProjectionContractError,
+    ProviderDeclaredFact, ProviderNativeSessionRelationship, ScannedSourceCounts,
+    SessionIdentityInput, SourceAnchor, SourceKey, StableEntityId, TypedKey,
+    CORE_ACTIVITY_REVISION,
 };
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -81,6 +82,8 @@ pub(crate) enum ShelleySourceBackedError {
     },
     #[error(transparent)]
     Projection(#[from] ProjectionContractError),
+    #[error(transparent)]
+    CoreRecord(#[from] CoreRecordError),
     #[error("Shelley source-backed scan was not drained to terminal certification")]
     ScanIncomplete,
     #[error("Shelley source-backed counts overflowed")]
@@ -399,11 +402,7 @@ impl ShelleySourceBackedScan {
                             );
                             checked_add_count(&mut page.counts.ignored_records, 1)?;
                         }
-                        Err(
-                            error @ (ShelleySourceBackedError::Projection(_)
-                            | ShelleySourceBackedError::MissingLexicalBody
-                            | ShelleySourceBackedError::InvalidResultShape(_)),
-                        ) => {
+                        Err(error) if shelley_row_projection_error(&error) => {
                             self.hash_record(
                                 rowid,
                                 scanner_digest,
@@ -660,10 +659,7 @@ fn build_record(
         event_type.as_str(),
         SHELLEY_SOURCE_PARSER_REVISION,
         body,
-    )
-    .map_err(|error| {
-        ShelleySourceBackedError::Capture(CaptureError::InvalidPayload(error.to_string()))
-    })?;
+    )?;
     record.agent_scope = Some(if lineage.parent_session_id.is_some() {
         AgentScope::Subagent
     } else {
@@ -691,12 +687,7 @@ fn build_record(
             .then(|| result.call_ids[0].as_str())
             .filter(|_| result.tool_names.len() <= 1)
     });
-    let provider_call_id = linked_result
-        .map(TypedKey::utf8)
-        .transpose()
-        .map_err(|error| {
-            ShelleySourceBackedError::Capture(CaptureError::InvalidPayload(error.to_string()))
-        })?;
+    let provider_call_id = linked_result.map(TypedKey::utf8).transpose()?;
     let activity_result = provider_call_id.as_ref().map(|_| ActivityResult {
         status: shelley_literal_status(&native_body),
         completed_at_unix_ms: Some(occurred_at.timestamp_millis()),
@@ -713,10 +704,7 @@ fn build_record(
             facts,
         });
     }
-    if record.content.encoded_content_bytes().map_err(|error| {
-        ShelleySourceBackedError::Capture(CaptureError::InvalidPayload(error.to_string()))
-    })? > ctx_history_core::MAX_CORE_CONTENT_BYTES
-    {
+    if record.content.encoded_content_bytes()? > ctx_history_core::MAX_CORE_CONTENT_BYTES {
         if let Some(capture @ ActivityJsonCapture::Present { .. }) = record
             .content
             .activity
@@ -738,14 +726,19 @@ fn build_record(
     }
     record
         .content
-        .omit_structured_content_if_aggregate_exceeds_limit()
-        .map_err(|error| {
-            ShelleySourceBackedError::Capture(CaptureError::InvalidPayload(error.to_string()))
-        })?;
-    record.validate_contract().map_err(|error| {
-        ShelleySourceBackedError::Capture(CaptureError::InvalidPayload(error.to_string()))
-    })?;
+        .omit_structured_content_if_aggregate_exceeds_limit()?;
+    record.validate_contract()?;
     Ok(Some(record))
+}
+
+fn shelley_row_projection_error(error: &ShelleySourceBackedError) -> bool {
+    matches!(
+        error,
+        ShelleySourceBackedError::Projection(_)
+            | ShelleySourceBackedError::CoreRecord(_)
+            | ShelleySourceBackedError::MissingLexicalBody
+            | ShelleySourceBackedError::InvalidResultShape(_)
+    )
 }
 
 pub(crate) fn shelley_literal_status(value: &serde_json::Value) -> Option<String> {

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/shelley/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/shelley/native_path/source_backed.rs
@@ -60,7 +60,7 @@ const SHELLEY_SOURCE_ANCHOR_NAMESPACE: &str = "shelley.exact-cwd-slot";
 const SHELLEY_SOURCE_ANCHOR_KEY: &str = "shelley.db";
 const SHELLEY_SOURCE_SCHEMA_VARIANT: &str = "shelley-exact-cwd-sqlite-v1";
 pub(crate) const SHELLEY_SOURCE_PARSER_REVISION: &str =
-    "shelley-source-backed-v4-neutral-core-agent-scope";
+    "shelley-source-backed-v5-record-rejections";
 const SHELLEY_LOGICAL_SESSION_KIND: &str = "shelley-conversation";
 const SHELLEY_NATIVE_SESSION_NAMESPACE: &str = "shelley.conversation";
 const SHELLEY_LOGICAL_EVENT_KIND: &str = "shelley-message";
@@ -734,9 +734,20 @@ fn build_record(
 fn shelley_row_projection_error(error: &ShelleySourceBackedError) -> bool {
     matches!(
         error,
-        ShelleySourceBackedError::Projection(_)
-            | ShelleySourceBackedError::CoreRecord(_)
-            | ShelleySourceBackedError::MissingLexicalBody
+        ShelleySourceBackedError::Projection(ProjectionContractError::EmptyField {
+            field: "typed_key_utf8",
+        }) | ShelleySourceBackedError::Projection(ProjectionContractError::FieldTooLarge {
+            field: "typed_key_utf8" | "typed_composite_key",
+            ..
+        }) | ShelleySourceBackedError::CoreRecord(CoreRecordError::EmptyField {
+            field: "provider_declared_fact.value",
+        }) | ShelleySourceBackedError::CoreRecord(CoreRecordError::FieldTooLarge {
+            field: "normalized_body"
+                | "structured_content"
+                | "selected_content"
+                | "provider_declared_fact.value",
+            ..
+        }) | ShelleySourceBackedError::MissingLexicalBody
             | ShelleySourceBackedError::InvalidResultShape(_)
     )
 }

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/shelley/native_path/source_backed/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/shelley/native_path/source_backed/tests.rs
@@ -151,7 +151,7 @@ fn active_wal_scan_reads_latest_rows_without_persistent_source_writes() {
 fn row_local_core_record_filter_does_not_absorb_capture_or_sqlite_failures() {
     assert!(shelley_row_projection_error(
         &ShelleySourceBackedError::CoreRecord(CoreRecordError::FieldTooLarge {
-            field: "provider_session_id",
+            field: "normalized_body",
             actual: 70 * 1024,
             maximum: 64 * 1024,
         })
@@ -164,6 +164,18 @@ fn row_local_core_record_filter_does_not_absorb_capture_or_sqlite_failures() {
     assert!(!shelley_row_projection_error(
         &ShelleySourceBackedError::SqliteSource(SqliteSourceAccessError::SourceChanged)
     ));
+    for error in [
+        ShelleySourceBackedError::Projection(ProjectionContractError::SourceChanged),
+        ShelleySourceBackedError::Projection(ProjectionContractError::InvalidDerivedIdentity),
+        ShelleySourceBackedError::CoreRecord(CoreRecordError::Projection(
+            ProjectionContractError::SourceChanged,
+        )),
+        ShelleySourceBackedError::CoreRecord(CoreRecordError::InvalidIdentityRelationship),
+        ShelleySourceBackedError::CoreRecord(CoreRecordError::InvalidSessionRelationship),
+        ShelleySourceBackedError::CoreRecord(CoreRecordError::InvalidActivity),
+    ] {
+        assert!(!shelley_row_projection_error(&error), "{error:?}");
+    }
 }
 
 fn drain(adapter: &ShelleySourceBackedAdapter) -> (Vec<CoreRecord>, ShelleySourceBackedReceipt) {

--- a/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/shelley/native_path/source_backed/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/provider/providers/shelley/native_path/source_backed/tests.rs
@@ -147,6 +147,25 @@ fn active_wal_scan_reads_latest_rows_without_persistent_source_writes() {
     drop(writer);
 }
 
+#[test]
+fn row_local_core_record_filter_does_not_absorb_capture_or_sqlite_failures() {
+    assert!(shelley_row_projection_error(
+        &ShelleySourceBackedError::CoreRecord(CoreRecordError::FieldTooLarge {
+            field: "provider_session_id",
+            actual: 70 * 1024,
+            maximum: 64 * 1024,
+        })
+    ));
+    assert!(!shelley_row_projection_error(
+        &ShelleySourceBackedError::Capture(CaptureError::InvalidPayload(
+            "non-row capture failure".to_owned(),
+        ))
+    ));
+    assert!(!shelley_row_projection_error(
+        &ShelleySourceBackedError::SqliteSource(SqliteSourceAccessError::SourceChanged)
+    ));
+}
+
 fn drain(adapter: &ShelleySourceBackedAdapter) -> (Vec<CoreRecord>, ShelleySourceBackedReceipt) {
     let mut scan = adapter.start_scan().unwrap();
     let mut documents = Vec::new();

--- a/crates/ctx-history-providers-sqlite-inventory/src/registration.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/registration.rs
@@ -4,9 +4,10 @@ use std::{
 };
 
 use ctx_history_capture_runtime::{
-    CaptureLifecycleSink, DocumentRecordSpool, ReplacementDocumentTree, SourceBackedRouteError,
-    SourceBackedRouteErrorKind, SourceBackedRouteResult, SourceBackedRouteSelection,
-    SourceBackedRouteWatchTargets, SourceBackedSelectorAuthority,
+    CaptureLifecycleSink, DocumentRecordSpool, ReplacementDocumentTree,
+    SourceBackedRecordRejectionDrafts, SourceBackedRouteError, SourceBackedRouteErrorKind,
+    SourceBackedRouteResult, SourceBackedRouteSelection, SourceBackedRouteWatchTargets,
+    SourceBackedSelectorAuthority,
 };
 use ctx_history_core::{CaptureProvider, CertifiedSource, TypedKey};
 use ctx_history_source_discovery::{LingmaDiscoveredInventory, LingmaDiscoveryUnavailable};
@@ -29,7 +30,10 @@ use crate::{
         PARSER_REVISION as ASTRBOT_SOURCE_BACKED_PARSER_REVISION,
     },
     provider::source_backed::family::document::ChangedDocumentSink,
-    provider::source_backed::{combine_primary_and_cleanup_route_errors, route_error},
+    provider::source_backed::{
+        combine_primary_and_cleanup_route_errors, route_error, sqlite_rejection_draft,
+        SourceBackedRecordRejectionClass,
+    },
     provider_sources::SqliteSourceReadSnapshot,
 };
 
@@ -211,19 +215,27 @@ where
         sink: &mut ChangedDocumentSink<'_, '_, L, S>,
     ) -> SourceBackedRouteResult<CertifiedSource> {
         let mut sink_failure = None;
-        let certificate = scan_astrbot_snapshot_v0(leaf, snapshot, &mut |record| {
-            if let Err(error) = sink.emit_core_record(record) {
-                let detail = error.to_string();
-                sink_failure = Some(error);
-                return Err(
+        let mut rejections = SourceBackedRecordRejectionDrafts::default();
+        let certificate = scan_astrbot_snapshot_v0(
+            leaf,
+            snapshot,
+            &mut |record| {
+                if let Err(error) = sink.emit_core_record(record) {
+                    let detail = error.to_string();
+                    sink_failure = Some(error);
+                    return Err(
                     crate::provider::providers::astrbot::native_path::source_backed::AstrBotSourceBackedErrorV0::Capture(
                         CaptureError::InvalidPayload(detail),
                     ),
                 );
-            }
-            Ok(())
-        });
-        astrbot_scan_route_result(sink_failure, certificate)
+                }
+                Ok(())
+            },
+            &mut rejections,
+        );
+        let certificate = astrbot_scan_route_result(sink_failure, certificate)?;
+        sink.record_rejections(rejections);
+        Ok(certificate)
     }
 }
 
@@ -385,6 +397,16 @@ where
                     return Err(abort_shelley_inventory_scan(scan, primary));
                 }
             };
+            for rejection in page.rejections {
+                sink.record_rejection(sqlite_rejection_draft(
+                    leaf.source(),
+                    CaptureProvider::Shelley,
+                    leaf.database_path(),
+                    u64::try_from(rejection.rowid).unwrap_or_default(),
+                    SourceBackedRecordRejectionClass::UnsupportedRecord,
+                    rejection.reason,
+                ));
+            }
             for document in page.documents {
                 if let Err(primary) = sink.emit_core_record(document) {
                     return Err(abort_shelley_inventory_scan(scan, primary));
@@ -550,17 +572,25 @@ where
         sink: &mut ChangedDocumentSink<'_, '_, L, S>,
     ) -> SourceBackedRouteResult<CertifiedSource> {
         let mut sink_failure = None;
-        let certificate = scan_lingma_snapshot_v0(leaf, snapshot, &mut |record| {
-            if let Err(error) = sink.emit_core_record(record) {
-                let detail = error.to_string();
-                sink_failure = Some(error);
-                return Err(LingmaSourceBackedErrorV0::Capture(
-                    CaptureError::InvalidPayload(detail),
-                ));
-            }
-            Ok(())
-        });
-        lingma_scan_route_result(sink_failure, certificate)
+        let mut rejections = SourceBackedRecordRejectionDrafts::default();
+        let certificate = scan_lingma_snapshot_v0(
+            leaf,
+            snapshot,
+            &mut |record| {
+                if let Err(error) = sink.emit_core_record(record) {
+                    let detail = error.to_string();
+                    sink_failure = Some(error);
+                    return Err(LingmaSourceBackedErrorV0::Capture(
+                        CaptureError::InvalidPayload(detail),
+                    ));
+                }
+                Ok(())
+            },
+            &mut rejections,
+        );
+        let certificate = lingma_scan_route_result(sink_failure, certificate)?;
+        sink.record_rejections(rejections);
+        Ok(certificate)
     }
 }
 

--- a/crates/ctx-history-providers-sqlite-inventory/src/registration.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/registration.rs
@@ -704,8 +704,10 @@ pub(crate) fn sqlite_source_route_error_kind(
         SourceBackedRouteErrorKind::SourceChanged
     } else if error.is_snapshot_capacity_failure() {
         SourceBackedRouteErrorKind::Unavailable
-    } else if error.is_systemic_resource_failure() || error.is_busy_or_locked() {
+    } else if error.is_systemic_resource_failure() {
         SourceBackedRouteErrorKind::ResourceUnavailable
+    } else if error.is_busy_or_locked() {
+        SourceBackedRouteErrorKind::Unavailable
     } else if error.is_ctx_owned_corruption() {
         SourceBackedRouteErrorKind::Internal
     } else if error.is_provider_corruption() || error.is_provider_path_unavailable() {
@@ -728,10 +730,12 @@ pub(crate) fn sqlite_capture_route_error(
             Some(SourceBackedRouteErrorKind::ResourceUnavailable)
         }
         CaptureError::Sqlite(error)
-            if crate::provider_sources::rusqlite_resource_failure(error)
-                || crate::provider_sources::rusqlite_busy_or_locked(error) =>
+            if crate::provider_sources::rusqlite_resource_failure(error) =>
         {
             Some(SourceBackedRouteErrorKind::ResourceUnavailable)
+        }
+        CaptureError::Sqlite(error) if crate::provider_sources::rusqlite_busy_or_locked(error) => {
+            Some(SourceBackedRouteErrorKind::Unavailable)
         }
         CaptureError::Io(_) | CaptureError::SystemIo { .. } | CaptureError::Sqlite(_) => {
             Some(SourceBackedRouteErrorKind::Internal)

--- a/crates/ctx-history-providers-sqlite-inventory/src/registration.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/registration.rs
@@ -706,7 +706,7 @@ pub(crate) fn sqlite_source_route_error_kind(
         SourceBackedRouteErrorKind::Unavailable
     } else if error.is_systemic_resource_failure() {
         SourceBackedRouteErrorKind::ResourceUnavailable
-    } else if error.is_busy_or_locked() {
+    } else if sqlite_provider_artifact_is_busy_or_locked(error) {
         SourceBackedRouteErrorKind::Unavailable
     } else if error.is_ctx_owned_corruption() {
         SourceBackedRouteErrorKind::Internal
@@ -717,6 +717,20 @@ pub(crate) fn sqlite_source_route_error_kind(
     } else {
         SourceBackedRouteErrorKind::InvalidSource
     }
+}
+
+fn sqlite_provider_artifact_is_busy_or_locked(
+    error: &crate::provider_sources::SqliteSourceAccessError,
+) -> bool {
+    error.is_busy_or_locked()
+        && error.diagnostic().is_some_and(|diagnostic| {
+            matches!(
+                diagnostic.artifact,
+                crate::provider_sources::SqliteArtifactKind::ProviderDatabase
+                    | crate::provider_sources::SqliteArtifactKind::ProviderWal
+                    | crate::provider_sources::SqliteArtifactKind::ProviderSharedMemory
+            )
+        })
 }
 
 pub(crate) fn sqlite_capture_route_error(
@@ -733,9 +747,6 @@ pub(crate) fn sqlite_capture_route_error(
             if crate::provider_sources::rusqlite_resource_failure(error) =>
         {
             Some(SourceBackedRouteErrorKind::ResourceUnavailable)
-        }
-        CaptureError::Sqlite(error) if crate::provider_sources::rusqlite_busy_or_locked(error) => {
-            Some(SourceBackedRouteErrorKind::Unavailable)
         }
         CaptureError::Io(_) | CaptureError::SystemIo { .. } | CaptureError::Sqlite(_) => {
             Some(SourceBackedRouteErrorKind::Internal)

--- a/crates/ctx-history-providers-sqlite-inventory/src/registration/crush.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/registration/crush.rs
@@ -142,11 +142,6 @@ fn crush_route_error(error: CrushSourceBackedErrorV0) -> SourceBackedRouteError 
         {
             SourceBackedRouteErrorKind::ResourceUnavailable
         }
-        CrushSourceBackedErrorV0::Sqlite(error)
-            if crate::provider_sources::rusqlite_busy_or_locked(error) =>
-        {
-            SourceBackedRouteErrorKind::Unavailable
-        }
         CrushSourceBackedErrorV0::Io(error)
             if crate::provider_sources::resource_exhaustion_io_error(error) =>
         {
@@ -224,25 +219,31 @@ mod tests {
     #[test]
     fn crush_production_mapper_preserves_sqlite_resource_and_corruption_taxonomy() {
         for code in [ffi::SQLITE_BUSY, ffi::SQLITE_LOCKED] {
-            let error = SqliteSourceAccessError::SqliteControl {
-                operation: "using the production Crush SQLite snapshot",
-                code,
-            }
-            .with_diagnostic(
-                SqliteFailurePhase::Projection,
-                SqliteArtifactKind::PrivateSourceCopy,
-                4,
-                16_384,
-                SqliteCleanupStatus::NotRequired,
+            let diagnosed = |artifact| {
+                SqliteSourceAccessError::SqliteControl {
+                    operation: "using the production Crush SQLite snapshot",
+                    code,
+                }
+                .with_diagnostic(
+                    SqliteFailurePhase::Projection,
+                    artifact,
+                    4,
+                    16_384,
+                    SqliteCleanupStatus::NotRequired,
+                )
+            };
+            assert_eq!(
+                crush_route_error(diagnosed(SqliteArtifactKind::ProviderDatabase).into()).kind,
+                SourceBackedRouteErrorKind::Unavailable
             );
             assert_eq!(
-                crush_route_error(error.into()).kind,
-                SourceBackedRouteErrorKind::Unavailable
+                crush_route_error(diagnosed(SqliteArtifactKind::PrivateSourceCopy).into()).kind,
+                SourceBackedRouteErrorKind::Internal
             );
             let raw = rusqlite::Error::SqliteFailure(ffi::Error::new(code), None);
             assert_eq!(
                 crush_route_error(CrushSourceBackedErrorV0::Sqlite(raw)).kind,
-                SourceBackedRouteErrorKind::Unavailable
+                SourceBackedRouteErrorKind::Internal
             );
         }
 

--- a/crates/ctx-history-providers-sqlite-inventory/src/registration/crush.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/registration/crush.rs
@@ -138,10 +138,14 @@ fn crush_route_error(error: CrushSourceBackedErrorV0) -> SourceBackedRouteError 
             sqlite_capture_route_error(error).unwrap_or(SourceBackedRouteErrorKind::InvalidSource)
         }
         CrushSourceBackedErrorV0::Sqlite(error)
-            if crate::provider_sources::rusqlite_resource_failure(error)
-                || crate::provider_sources::rusqlite_busy_or_locked(error) =>
+            if crate::provider_sources::rusqlite_resource_failure(error) =>
         {
             SourceBackedRouteErrorKind::ResourceUnavailable
+        }
+        CrushSourceBackedErrorV0::Sqlite(error)
+            if crate::provider_sources::rusqlite_busy_or_locked(error) =>
+        {
+            SourceBackedRouteErrorKind::Unavailable
         }
         CrushSourceBackedErrorV0::Io(error)
             if crate::provider_sources::resource_exhaustion_io_error(error) =>
@@ -219,12 +223,7 @@ mod tests {
 
     #[test]
     fn crush_production_mapper_preserves_sqlite_resource_and_corruption_taxonomy() {
-        for code in [
-            ffi::SQLITE_BUSY,
-            ffi::SQLITE_LOCKED,
-            ffi::SQLITE_FULL,
-            ffi::SQLITE_NOMEM,
-        ] {
+        for code in [ffi::SQLITE_BUSY, ffi::SQLITE_LOCKED] {
             let error = SqliteSourceAccessError::SqliteControl {
                 operation: "using the production Crush SQLite snapshot",
                 code,
@@ -238,6 +237,34 @@ mod tests {
             );
             assert_eq!(
                 crush_route_error(error.into()).kind,
+                SourceBackedRouteErrorKind::Unavailable
+            );
+            let raw = rusqlite::Error::SqliteFailure(ffi::Error::new(code), None);
+            assert_eq!(
+                crush_route_error(CrushSourceBackedErrorV0::Sqlite(raw)).kind,
+                SourceBackedRouteErrorKind::Unavailable
+            );
+        }
+
+        for code in [ffi::SQLITE_FULL, ffi::SQLITE_NOMEM] {
+            let error = SqliteSourceAccessError::SqliteControl {
+                operation: "using the production Crush SQLite snapshot",
+                code,
+            }
+            .with_diagnostic(
+                SqliteFailurePhase::Projection,
+                SqliteArtifactKind::PrivateSourceCopy,
+                4,
+                16_384,
+                SqliteCleanupStatus::NotRequired,
+            );
+            assert_eq!(
+                crush_route_error(error.into()).kind,
+                SourceBackedRouteErrorKind::ResourceUnavailable
+            );
+            let raw = rusqlite::Error::SqliteFailure(ffi::Error::new(code), None);
+            assert_eq!(
+                crush_route_error(CrushSourceBackedErrorV0::Sqlite(raw)).kind,
                 SourceBackedRouteErrorKind::ResourceUnavailable
             );
         }

--- a/crates/ctx-history-providers-sqlite-inventory/src/registration/shared/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/registration/shared/tests.rs
@@ -22,7 +22,9 @@ use sha2::{Digest, Sha256};
 
 use super::*;
 use crate::{
-    provider_sources::SqliteSourceAccessError,
+    provider_sources::{
+        SqliteArtifactKind, SqliteCleanupStatus, SqliteFailurePhase, SqliteSourceAccessError,
+    },
     registration::{
         astrbot_scan_route_result, lingma_scan_route_result, AstrBotSourceBackedErrorV0,
         LingmaSourceBackedErrorV0,
@@ -878,10 +880,19 @@ fn warm_busy_source_is_carried_while_changed_exact_sibling_succeeds() {
     provider.reset_run();
     provider.fail_scan(
         busy_path,
-        sqlite_source_route_error(SqliteSourceAccessError::SqliteControl {
-            operation: "querying the busy test provider database",
-            code: rusqlite::ffi::SQLITE_BUSY,
-        }),
+        sqlite_source_route_error(
+            SqliteSourceAccessError::SqliteControl {
+                operation: "querying the busy test provider database",
+                code: rusqlite::ffi::SQLITE_BUSY,
+            }
+            .with_diagnostic(
+                SqliteFailurePhase::Projection,
+                SqliteArtifactKind::ProviderDatabase,
+                0,
+                0,
+                SqliteCleanupStatus::NotRequired,
+            ),
+        ),
     );
 
     let warm = run_provider(&data_root, provider, 4, cold_sources).unwrap();

--- a/crates/ctx-history-providers-sqlite-inventory/src/registration/shared/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/registration/shared/tests.rs
@@ -65,6 +65,7 @@ struct TestState {
     peak_scans: usize,
     active_scans_by_path: HashMap<PathBuf, usize>,
     max_active_scans_per_path: usize,
+    scan_failures: HashMap<PathBuf, SourceBackedRouteError>,
 }
 
 enum TestAfterSealAction {
@@ -104,6 +105,11 @@ impl TestProvider {
         assert!(replaced.is_none());
     }
 
+    fn fail_scan(&self, path: PathBuf, error: SourceBackedRouteError) {
+        let replaced = self.state.lock().unwrap().scan_failures.insert(path, error);
+        assert!(replaced.is_none());
+    }
+
     fn sorted_outputs(&self) -> Vec<ProjectionOutput> {
         let mut outputs = self.state.lock().unwrap().outputs.clone();
         outputs.sort_by_key(|output| {
@@ -129,6 +135,7 @@ impl TestProvider {
         state.peak_scans = 0;
         state.max_active_scans_per_path = 0;
         state.scan_barrier = None;
+        state.scan_failures.clear();
     }
 }
 
@@ -216,6 +223,16 @@ impl SqliteInventoryProvider<TestLifecycle, TestSpool> for TestProvider {
         let (_activity, barrier) = TestScanActivity::begin(&self.state, &leaf.path);
         if let Some(barrier) = barrier {
             barrier.wait();
+        }
+        let scan_failure = self
+            .state
+            .lock()
+            .unwrap()
+            .scan_failures
+            .get(&leaf.path)
+            .cloned();
+        if let Some(error) = scan_failure {
+            return Err(abort_sqlite_inventory_snapshot(snapshot, error));
         }
         let rows = {
             let connection = snapshot.connection().map_err(sqlite_source_route_error)?;
@@ -796,6 +813,108 @@ fn independent_databases_have_one_vs_four_parity_and_one_snapshot_each() {
     assert_no_snapshot_temp_leak(&serial_data_root);
     assert_no_snapshot_temp_leak(&parallel_data_root);
     drop(writers);
+}
+
+#[test]
+fn warm_busy_source_is_carried_while_changed_exact_sibling_succeeds() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let provider_dir = temp.path().join("provider");
+    let data_root = temp.path().join("data");
+    let busy_path = provider_dir.join("busy.sqlite");
+    let healthy_path = provider_dir.join("healthy.sqlite");
+    let busy_source = test_source("busy.sqlite");
+    let healthy_source = test_source("healthy.sqlite");
+    let busy_writer = active_wal_database(&busy_path, "busy baseline");
+    let healthy_writer = active_wal_database(&healthy_path, "healthy baseline");
+    let provider = TestProvider::with_test_workers(
+        Arc::new(Mutex::new(vec![
+            TestLeaf {
+                source: busy_source.clone(),
+                path: busy_path.clone(),
+            },
+            TestLeaf {
+                source: healthy_source.clone(),
+                path: healthy_path,
+            },
+        ])),
+        1,
+    );
+
+    let cold = run_provider(&data_root, provider.clone(), 4, Vec::new()).unwrap();
+    let cold_sources = cold.lifecycle.sources();
+    let busy_base = cold_sources
+        .iter()
+        .find(|source| {
+            source
+                .observation()
+                .source()
+                .exact_descriptor_eq(&busy_source)
+        })
+        .unwrap()
+        .clone();
+    let healthy_base = cold_sources
+        .iter()
+        .find(|source| {
+            source
+                .observation()
+                .source()
+                .exact_descriptor_eq(&healthy_source)
+        })
+        .unwrap()
+        .clone();
+
+    healthy_writer
+        .execute(
+            "update messages set body = 'healthy replacement' where id = 1",
+            [],
+        )
+        .unwrap();
+    busy_writer
+        .execute(
+            "update messages set body = 'busy replacement' where id = 1",
+            [],
+        )
+        .unwrap();
+    provider.reset_run();
+    provider.fail_scan(
+        busy_path,
+        sqlite_source_route_error(SqliteSourceAccessError::SqliteControl {
+            operation: "querying the busy test provider database",
+            code: rusqlite::ffi::SQLITE_BUSY,
+        }),
+    );
+
+    let warm = run_provider(&data_root, provider, 4, cold_sources).unwrap();
+    assert_eq!(warm.logical_source_failures.total(), 1);
+    let failure = &warm.logical_source_failures.failures()[0];
+    assert!(failure.source.exact_descriptor_eq(&busy_source));
+    assert!(failure.carried_forward);
+    assert_eq!(warm.lifecycle.sources().len(), 2);
+    let warm_busy = warm
+        .lifecycle
+        .sources()
+        .into_iter()
+        .find(|source| {
+            source
+                .observation()
+                .source()
+                .exact_descriptor_eq(&busy_source)
+        })
+        .unwrap();
+    let warm_healthy = warm
+        .lifecycle
+        .sources()
+        .into_iter()
+        .find(|source| {
+            source
+                .observation()
+                .source()
+                .exact_descriptor_eq(&healthy_source)
+        })
+        .unwrap();
+    assert_eq!(warm_busy, busy_base);
+    assert_ne!(warm_healthy.content_digest(), healthy_base.content_digest());
+    drop((busy_writer, healthy_writer));
 }
 
 #[test]

--- a/crates/ctx-history-providers-sqlite-inventory/src/registration/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/registration/tests.rs
@@ -539,6 +539,45 @@ fn shelley_registration_preserves_resource_unavailable_classification() {
 }
 
 #[test]
+fn sqlite_contention_is_logical_but_exhaustion_remains_route_fatal() {
+    for code in [rusqlite::ffi::SQLITE_BUSY, rusqlite::ffi::SQLITE_LOCKED] {
+        let source = SqliteSourceAccessError::SqliteControl {
+            operation: "querying a contended provider database",
+            code,
+        };
+        let raw = rusqlite::Error::SqliteFailure(rusqlite::ffi::Error::new(code), None);
+
+        assert_eq!(
+            sqlite_source_route_error_kind(&source),
+            SourceBackedRouteErrorKind::Unavailable
+        );
+        assert!(sqlite_source_route_error_kind(&source).is_logical_source_failure());
+        assert_eq!(
+            sqlite_capture_route_error(&CaptureError::Sqlite(raw)),
+            Some(SourceBackedRouteErrorKind::Unavailable)
+        );
+    }
+
+    for code in [rusqlite::ffi::SQLITE_FULL, rusqlite::ffi::SQLITE_NOMEM] {
+        let source = SqliteSourceAccessError::SqliteControl {
+            operation: "querying an exhausted provider database",
+            code,
+        };
+        let raw = rusqlite::Error::SqliteFailure(rusqlite::ffi::Error::new(code), None);
+
+        assert_eq!(
+            sqlite_source_route_error_kind(&source),
+            SourceBackedRouteErrorKind::ResourceUnavailable
+        );
+        assert!(!sqlite_source_route_error_kind(&source).is_logical_source_failure());
+        assert_eq!(
+            sqlite_capture_route_error(&CaptureError::Sqlite(raw)),
+            Some(SourceBackedRouteErrorKind::ResourceUnavailable)
+        );
+    }
+}
+
+#[test]
 fn sqlite_inventory_snapshot_capacity_failure_is_route_local() {
     let error = shelley_registration_error(SqliteSourceAccessError::InsufficientScratchSpace {
         path: PathBuf::from("ctx-data"),

--- a/crates/ctx-history-providers-sqlite-inventory/src/registration/tests.rs
+++ b/crates/ctx-history-providers-sqlite-inventory/src/registration/tests.rs
@@ -16,7 +16,9 @@ use rusqlite::Connection;
 use uuid::Uuid;
 
 use super::*;
-use crate::provider_sources::SqliteSourceAccessError;
+use crate::provider_sources::{
+    SqliteArtifactKind, SqliteCleanupStatus, SqliteFailurePhase, SqliteSourceAccessError,
+};
 
 #[derive(Clone, Default)]
 pub(crate) struct NoopLookup;
@@ -541,20 +543,35 @@ fn shelley_registration_preserves_resource_unavailable_classification() {
 #[test]
 fn sqlite_contention_is_logical_but_exhaustion_remains_route_fatal() {
     for code in [rusqlite::ffi::SQLITE_BUSY, rusqlite::ffi::SQLITE_LOCKED] {
-        let source = SqliteSourceAccessError::SqliteControl {
-            operation: "querying a contended provider database",
-            code,
+        let diagnosed = |artifact| {
+            SqliteSourceAccessError::SqliteControl {
+                operation: "querying a contended provider database",
+                code,
+            }
+            .with_diagnostic(
+                SqliteFailurePhase::Projection,
+                artifact,
+                0,
+                0,
+                SqliteCleanupStatus::NotRequired,
+            )
         };
+        let provider = diagnosed(SqliteArtifactKind::ProviderDatabase);
+        let private = diagnosed(SqliteArtifactKind::PrivateSourceCopy);
         let raw = rusqlite::Error::SqliteFailure(rusqlite::ffi::Error::new(code), None);
 
         assert_eq!(
-            sqlite_source_route_error_kind(&source),
+            sqlite_source_route_error_kind(&provider),
             SourceBackedRouteErrorKind::Unavailable
         );
-        assert!(sqlite_source_route_error_kind(&source).is_logical_source_failure());
+        assert!(sqlite_source_route_error_kind(&provider).is_logical_source_failure());
+        assert_eq!(
+            sqlite_source_route_error_kind(&private),
+            SourceBackedRouteErrorKind::Internal
+        );
         assert_eq!(
             sqlite_capture_route_error(&CaptureError::Sqlite(raw)),
-            Some(SourceBackedRouteErrorKind::Unavailable)
+            Some(SourceBackedRouteErrorKind::Internal)
         );
     }
 

--- a/crates/ctx-history-providers-task-docs/src/providers/cline_sdk/source.rs
+++ b/crates/ctx-history-providers-task-docs/src/providers/cline_sdk/source.rs
@@ -99,6 +99,7 @@ pub(super) struct SessionLeaf {
     pub(super) provider_session_id: String,
     pub(super) source_key_digest: [u8; 32],
     pub(super) catalog_evidence: [u8; 32],
+    pub(super) catalog_binding_failure: Option<String>,
     pub(super) manifest_relative_path: PathBuf,
     pub(super) manifest: Option<FileEvidence>,
     pub(super) messages: Option<FileEvidence>,
@@ -117,6 +118,10 @@ impl SessionLeaf {
         hash_optional_file(&mut digest, self.manifest.as_ref());
         hash_optional_file(&mut digest, self.messages.as_ref());
         hash_path(&mut digest, &self.messages_relative_path);
+        if let Some(detail) = self.catalog_binding_failure.as_deref() {
+            digest.update(b"ctx.cline.sdk.catalog-binding-failure.v1\0");
+            hash_text(&mut digest, detail);
+        }
         digest.finalize().into()
     }
 }
@@ -444,15 +449,33 @@ fn bind_session_leaf(
         metadata_from_catalog(entry.database_row.as_ref(), true),
     );
     overlay_manifest_metadata(&mut metadata, manifest_value.as_ref());
-    let messages_path = string_field(entry.database_row.as_ref(), "messages_path")
-        .or_else(|| string_field(entry.index_row.as_ref(), "messagesPath"))
+    let catalog_messages_path = string_field(entry.database_row.as_ref(), "messages_path")
+        .or_else(|| string_field(entry.index_row.as_ref(), "messagesPath"));
+    let messages_path = catalog_messages_path
+        .clone()
         .or_else(|| string_field(manifest_value.as_ref(), "messages_path"));
-    let messages_relative_path = normalize_messages_path(
+    let messages_binding = normalize_messages_path(
         authority.named_path(),
         &session_id,
         messages_path.as_deref(),
-    )?;
-    let messages = open_optional_evidence(authority, &messages_relative_path)?;
+    );
+    // The catalog key already established exact source ownership. Isolate only
+    // that row's invalid path binding; manifest fallbacks and artifact I/O keep
+    // their existing route-fatal behavior.
+    let (messages_relative_path, messages, catalog_binding_failure) = match messages_binding {
+        Ok(messages_relative_path) => {
+            let messages = open_optional_evidence(authority, &messages_relative_path)?;
+            (messages_relative_path, messages, None)
+        }
+        Err(ClineSdkError::Invalid(detail)) if catalog_messages_path.is_some() => (
+            canonical_messages_path(&session_id),
+            None,
+            Some(format!(
+                "Cline SDK catalog row {session_id:?} has an invalid messages path: {detail}"
+            )),
+        ),
+        Err(error) => return Err(error),
+    };
 
     let mut catalog_digest = Sha256::new();
     catalog_digest.update(b"ctx.cline.sdk.catalog-evidence.v1\0");
@@ -467,6 +490,7 @@ fn bind_session_leaf(
         provider_session_id: session_id,
         source_key_digest,
         catalog_evidence: catalog_digest.finalize().into(),
+        catalog_binding_failure,
         manifest_relative_path: manifest_relative,
         manifest,
         messages,
@@ -565,13 +589,8 @@ fn manifest_session_matches(value: &Value, session_id: &str) -> bool {
 }
 
 fn normalize_messages_path(root: &Path, session_id: &str, raw: Option<&str>) -> Result<PathBuf> {
-    let canonical = || {
-        PathBuf::from("sessions")
-            .join(session_id)
-            .join(format!("{session_id}.messages.json"))
-    };
     let Some(raw) = raw.filter(|value| !value.is_empty()) else {
-        return Ok(canonical());
+        return Ok(canonical_messages_path(session_id));
     };
     if raw.len() > MAX_PATH_BYTES {
         return Err(ClineSdkError::Invalid("messages_path is too long".into()));
@@ -610,6 +629,12 @@ fn normalize_messages_path(root: &Path, session_id: &str, raw: Option<&str>) -> 
         ));
     }
     Ok(relative)
+}
+
+fn canonical_messages_path(session_id: &str) -> PathBuf {
+    PathBuf::from("sessions")
+        .join(session_id)
+        .join(format!("{session_id}.messages.json"))
 }
 
 pub(super) fn read_bound_leaf_files(

--- a/crates/ctx-history-providers-task-docs/src/providers/cline_sdk/source_backed.rs
+++ b/crates/ctx-history-providers-task-docs/src/providers/cline_sdk/source_backed.rs
@@ -160,6 +160,9 @@ where
     L: CaptureLifecycleSink,
     S: DocumentRecordSpool,
 {
+    if let Some(detail) = leaf.snapshot.catalog_binding_failure.as_deref() {
+        return Err(invalid_route(detail));
+    }
     let (manifest, messages) =
         read_bound_leaf_files(&authority.root, &leaf.snapshot).map_err(route_error)?;
     let source_revision = source_revision(&leaf.snapshot, manifest.as_deref(), messages.as_deref());

--- a/crates/ctx-history-providers-task-docs/src/providers/cline_sdk/tests.rs
+++ b/crates/ctx-history-providers-task-docs/src/providers/cline_sdk/tests.rs
@@ -399,6 +399,37 @@ fn another_sessions_catalog_row_does_not_invalidate_an_unchanged_leaf() {
 }
 
 #[test]
+fn invalid_catalog_messages_path_marks_only_its_owned_session_leaf() {
+    let fixture = Fixture::new();
+    fixture.write_index(json!({
+        "version": 1,
+        "sessions": {
+            "broken": {"sessionId": "broken", "messagesPath": "../../outside.json"},
+            "healthy": {"sessionId": "healthy"}
+        }
+    }));
+    fixture.write_messages("healthy", &messages_document("healthy", Vec::new()));
+
+    let tree = discover_cline_sdk_tree(&fixture.provider_root, &fixture.ctx_root).unwrap();
+    assert_eq!(tree.leaves.len(), 2);
+    let broken = tree
+        .leaves
+        .iter()
+        .find(|leaf| leaf.provider_session_id == "broken")
+        .unwrap();
+    let healthy = tree
+        .leaves
+        .iter()
+        .find(|leaf| leaf.provider_session_id == "healthy")
+        .unwrap();
+    assert!(broken.catalog_binding_failure.is_some());
+    assert!(broken.messages.is_none());
+    assert!(healthy.catalog_binding_failure.is_none());
+    assert!(healthy.messages.is_some());
+    assert_ne!(broken.fingerprint(), healthy.fingerprint());
+}
+
+#[test]
 fn another_sqlite_row_does_not_invalidate_an_unchanged_leaf() {
     let fixture = Fixture::new();
     let connection = fixture.open_database();


### PR DESCRIPTION
## Summary

- reject malformed JSONL records and SQLite rows at their owning record boundary while retaining actionable provider, path, and row/line diagnostics
- quarantine invalid, unreadable, or conflicting Claude transcript sources without blocking healthy sibling sources or unrelated providers
- preserve last-good source data during transient source failures and surface refresh failure detail in `ctx doctor`
- add shared conformance coverage for cold and warm multi-provider publication boundaries

Provider-originated defects are now contained at the narrowest safe boundary. Failures in ctx-owned storage, generation integrity, or publication remain fatal.

## Testing

- `scripts/check.sh --mode ci --force-rerun`
- physical Rust crate-size gate
- 439 build/clippy targets
- 209/209 tests

Fixes #664