### PR TITLE
fix(index): certify candidates before activation

### DIFF
--- a/crates/ctx-history-index-generation/src/certification.rs
+++ b/crates/ctx-history-index-generation/src/certification.rs
@@ -15,31 +15,29 @@ use tantivy::directory::Directory as _;
 use ctx_history_platform::platform_security::ensure_private_directory;
 
 use crate::{
-    active_index_files, load_active_generation_pointer, manifest_path, physical_integrity_audit,
-    slot_path, ActiveGenerationPointer, DurableMmapDirectory, GenerationError as IndexError,
-    GenerationSlot, PhysicalIntegrityAudit, Result, INDEX_GENERATIONS_DIRECTORY,
-    MANIFEST_DIRECTORY,
+    active_index_files, load_active_generation_pointer, manifest_path,
+    physical::physical_integrity_digest_from_parts, physical_integrity_audit, slot_path,
+    ActiveGenerationPointer, DurableMmapDirectory, GenerationError as IndexError, GenerationSlot,
+    PhysicalIntegrityAudit, Result, INDEX_GENERATIONS_DIRECTORY, MANIFEST_DIRECTORY,
 };
 
-#[cfg(not(windows))]
-const CERTIFICATION_VERSION: u32 = 3;
-#[cfg(windows)]
-const CERTIFICATION_VERSION: u32 = 4;
+// Version 5 deliberately drops the active-pointer identity. A certification
+// names the immutable slot it authenticated, so it can be completed and
+// reopened before that slot becomes active.
+const CERTIFICATION_VERSION: u32 = 5;
 const CERTIFICATION_SUFFIX: &str = ".physical-certification.json";
 const CERTIFICATION_DIRECTORY: &str = "integrity-certifications";
 const TANTIVY_META_FILE: &str = "meta.json";
 #[cfg(windows)]
 const MANAGED_FILE: &str = ".managed.json";
 const ARTIFACT_STABLE_SNAPSHOT_ATTEMPTS: usize = 4;
-pub const MAX_CERTIFICATION_BYTES: usize = 1024 * 1024;
-pub const MAX_CERTIFIED_ARTIFACTS: usize = 1024;
+pub const MAX_CERTIFICATION_BYTES: usize = 8 * 1024 * 1024;
+pub const MAX_CERTIFIED_ARTIFACTS: usize = crate::physical::MAX_MANAGED_FILE_ENTRIES + 1;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct GenerationIntegrityCertification {
     version: u32,
-    pointer: ActiveGenerationPointer,
-    pointer_identity: FileIdentity,
     manifest_identity: FileIdentity,
     slot: GenerationSlot,
     #[serde(deserialize_with = "deserialize_artifacts")]
@@ -286,7 +284,15 @@ pub fn verify_or_certify_physical_integrity(
     if audit.digest() != slot.physical_integrity_digest() {
         return Err(IndexError::ChecksumMismatch);
     }
-    install_certification(root, pointer, slot, index, &audit, false)
+    install_certification(
+        root,
+        Some(pointer),
+        None,
+        slot,
+        index,
+        &audit,
+        CertificationInstallPolicy::ACTIVE_CACHE,
+    )
 }
 
 /// Verifies one immutable generation from its existing publication-time
@@ -325,6 +331,7 @@ pub fn verify_physical_integrity_read_only(
     if serde_json::to_vec(&certification)? != bytes
         || certification.version != CERTIFICATION_VERSION
         || certification.slot != *slot
+        || !certification_digest_matches_slot(&certification)?
         || capture_single_link_control(&manifest_path(root, slot.generation_id()))?
             != certification.manifest_identity
     {
@@ -375,13 +382,20 @@ pub fn scrub_and_certify_physical_integrity(
     if audit.digest() != slot.physical_integrity_digest() {
         return Err(IndexError::ChecksumMismatch);
     }
-    install_certification(root, pointer, slot, index, &audit, false)
+    install_certification(
+        root,
+        Some(pointer),
+        None,
+        slot,
+        index,
+        &audit,
+        CertificationInstallPolicy::ACTIVE_CACHE,
+    )
 }
 
-/// Installs the certification for a candidate that was fully hashed before
-/// pointer publication. Every artifact identity must still match the audit.
-/// A hard-link transition invalidates the fast-path certification because it
-/// can mask a same-size, restored-mtime write.
+/// Backwards-compatible spelling for callers that certify an already-active
+/// slot. New publication paths must use [`certify_candidate_physical_integrity`]
+/// before replacing the active pointer.
 pub fn certify_activated_generation(
     root: &Path,
     pointer: &ActiveGenerationPointer,
@@ -389,112 +403,16 @@ pub fn certify_activated_generation(
     index: &tantivy::Index,
     audit: &PhysicalIntegrityAudit,
 ) -> Result<()> {
-    install_certification(root, pointer, slot, index, audit, true).map(|_| ())
-}
-
-fn install_certification(
-    root: &Path,
-    pointer: &ActiveGenerationPointer,
-    slot: &GenerationSlot,
-    index: &tantivy::Index,
-    audit: &PhysicalIntegrityAudit,
-    allow_readonly_seal: bool,
-) -> Result<CertifiedPhysicalIntegrity> {
-    if load_current_pointer(root)? != *pointer {
-        return Err(IndexError::ConcurrentGenerationChange);
-    }
-    let expected_paths = expected_artifact_paths(index)?;
-    if audit.artifact_paths() != expected_paths {
-        return Err(IndexError::ChecksumMismatch);
-    }
-
-    let generation_path = slot_path(root, slot);
-    ensure_real_directory(root)?;
-    ensure_real_directory(&root.join(MANIFEST_DIRECTORY))?;
-    ensure_real_directory(&root.join(INDEX_GENERATIONS_DIRECTORY))?;
-    ensure_real_directory(&generation_path)?;
-
-    let pointer_identity = capture_pointer_bound_single_link_control(
+    install_certification(
         root,
-        pointer,
-        &root.join("active-generation.json"),
-    )?;
-    let manifest_identity = capture_pointer_bound_single_link_control(
-        root,
-        pointer,
-        &manifest_path(root, slot.generation_id()),
-    )?;
-    let mut artifacts = Vec::with_capacity(audit.files().len());
-    for prior in audit.files() {
-        let mut current = capture_artifact(
-            root,
-            &generation_path,
-            Path::new(&prior.artifact.path),
-            Some(pointer),
-        )?;
-        let follows_allowed_seal = allow_readonly_seal && {
-            #[cfg(windows)]
-            {
-                current
-                    .identity
-                    .follows_readonly_seal(&prior.artifact.identity)
-            }
-            #[cfg(not(windows))]
-            {
-                false
-            }
-        };
-        if current.identity != prior.artifact.identity && !follows_allowed_seal {
-            return if prior.artifact.same_payload_identity_changed(&current) {
-                Err(IndexError::ConcurrentGenerationChange)
-            } else {
-                Err(IndexError::ChecksumMismatch)
-            };
-        }
-        let sealed = artifact_should_be_sealed(&prior.artifact.path);
-        if sealed {
-            current = seal_artifact(
-                root,
-                &generation_path,
-                Path::new(&prior.artifact.path),
-                Some(pointer),
-                &current,
-            )?;
-        }
-        artifacts.push(CertifiedArtifact {
-            artifact: current,
-            sha256: prior.sha256,
-            sealed,
-        });
-    }
-    let certification = GenerationIntegrityCertification {
-        version: CERTIFICATION_VERSION,
-        pointer: pointer.clone(),
-        pointer_identity,
-        manifest_identity,
-        slot: slot.clone(),
-        artifacts,
-    };
-    if certification.artifacts.len() <= MAX_CERTIFIED_ARTIFACTS {
-        let bytes = serde_json::to_vec(&certification)?;
-        if bytes.len() <= MAX_CERTIFICATION_BYTES {
-            let certification_directory = root.join(CERTIFICATION_DIRECTORY);
-            if ensure_private_directory(&certification_directory).is_ok()
-                && ensure_real_directory(&certification_directory).is_ok()
-            {
-                if let Ok(directory) = DurableMmapDirectory::open(root) {
-                    let relative_path =
-                        Path::new(CERTIFICATION_DIRECTORY).join(certification_file_name(slot));
-                    if directory.atomic_write(&relative_path, &bytes).is_ok()
-                        && matching_certification(root, pointer, slot, index)?.is_none()
-                    {
-                        return Err(IndexError::ConcurrentGenerationChange);
-                    }
-                }
-            }
-        }
-    }
-    Ok(CertifiedPhysicalIntegrity { certification })
+        Some(pointer),
+        None,
+        slot,
+        index,
+        audit,
+        CertificationInstallPolicy::ACTIVATED_CACHE,
+    )
+    .map(|_| ())
 }
 
 fn seal_artifact(
@@ -765,8 +683,8 @@ fn matching_certification(
     };
     if serde_json::to_vec(&certification)? != bytes
         || certification.version != CERTIFICATION_VERSION
-        || certification.pointer != *pointer
         || certification.slot != *slot
+        || !certification_digest_matches_slot(&certification)?
     {
         return Ok(None);
     }
@@ -779,16 +697,8 @@ fn matching_certification(
     ensure_real_directory(&root.join(INDEX_GENERATIONS_DIRECTORY))?;
     let generation_path = slot_path(root, slot);
     ensure_real_directory(&generation_path)?;
-    if capture_pointer_bound_single_link_control(
-        root,
-        pointer,
-        &root.join("active-generation.json"),
-    )? != certification.pointer_identity
-        || capture_pointer_bound_single_link_control(
-            root,
-            pointer,
-            &manifest_path(root, slot.generation_id()),
-        )? != certification.manifest_identity
+    if capture_single_link_control(&manifest_path(root, slot.generation_id()))?
+        != certification.manifest_identity
     {
         return Ok(None);
     }
@@ -833,7 +743,7 @@ pub fn verify_certified_physical_integrity(
     candidate_audit: Option<&PhysicalIntegrityAudit>,
 ) -> Result<()> {
     let certification = &certified.certification;
-    if certification.pointer != *pointer || certification.slot != *slot {
+    if certification.slot != *slot {
         return Err(IndexError::ConcurrentGenerationChange);
     }
     if load_current_pointer(root)? != *pointer {
@@ -844,16 +754,8 @@ pub fn verify_certified_physical_integrity(
     ensure_real_directory(&root.join(INDEX_GENERATIONS_DIRECTORY))?;
     let generation_path = slot_path(root, slot);
     ensure_real_directory(&generation_path)?;
-    if capture_pointer_bound_single_link_control(
-        root,
-        pointer,
-        &root.join("active-generation.json"),
-    )? != certification.pointer_identity
-        || capture_pointer_bound_single_link_control(
-            root,
-            pointer,
-            &manifest_path(root, slot.generation_id()),
-        )? != certification.manifest_identity
+    if capture_single_link_control(&manifest_path(root, slot.generation_id()))?
+        != certification.manifest_identity
     {
         return Err(IndexError::ConcurrentGenerationChange);
     }
@@ -941,7 +843,16 @@ pub(crate) use artifact_io::{
     capture_artifact_identity, open_artifact, open_authenticated_artifact, recapture_artifact,
     recapture_authenticated_artifact,
 };
+mod candidate;
+mod install;
+mod pointer_fence;
 mod sidecar;
+use candidate::certification_digest_matches_slot;
+pub use candidate::{
+    certify_candidate_physical_integrity, verify_candidate_physical_integrity_read_only,
+};
+use install::{install_certification, CertificationInstallPolicy};
+pub use pointer_fence::ActiveGenerationPointerFence;
 
 #[cfg(any(test, feature = "test-support"))]
 pub use sidecar::certification_file_for_active;

--- a/crates/ctx-history-index-generation/src/certification/artifact_io.rs
+++ b/crates/ctx-history-index-generation/src/certification/artifact_io.rs
@@ -299,6 +299,7 @@ pub(super) fn capture_single_link_control(path: &Path) -> Result<FileIdentity> {
     Ok(identity)
 }
 
+#[cfg(test)]
 pub(super) fn capture_pointer_bound_single_link_control(
     root: &Path,
     pointer: &ActiveGenerationPointer,

--- a/crates/ctx-history-index-generation/src/certification/candidate.rs
+++ b/crates/ctx-history-index-generation/src/certification/candidate.rs
@@ -1,0 +1,97 @@
+use super::*;
+
+/// Verifies a durably certified candidate before it is named by the active
+/// pointer. The predecessor fence is not part of the certification identity.
+pub fn verify_candidate_physical_integrity_read_only(
+    root: &Path,
+    predecessor_fence: &ActiveGenerationPointerFence,
+    slot: &GenerationSlot,
+    index: &tantivy::Index,
+) -> Result<()> {
+    ensure_real_directory(root)?;
+    ensure_real_directory(&root.join(MANIFEST_DIRECTORY))?;
+    ensure_real_directory(&root.join(INDEX_GENERATIONS_DIRECTORY))?;
+    let generation_path = slot_path(root, slot);
+    ensure_real_directory(&generation_path)?;
+    ensure_real_directory(&root.join(CERTIFICATION_DIRECTORY))?;
+
+    predecessor_fence.validate(root)?;
+    let bytes =
+        read_certification(&certification_path(root, slot)).ok_or(IndexError::ChecksumMismatch)?;
+    let certification = serde_json::from_slice::<GenerationIntegrityCertification>(&bytes)
+        .map_err(|_| IndexError::ChecksumMismatch)?;
+    if serde_json::to_vec(&certification)? != bytes
+        || certification.version != CERTIFICATION_VERSION
+        || certification.slot != *slot
+        || !certification_digest_matches_slot(&certification)?
+        || capture_single_link_control(&manifest_path(root, slot.generation_id()))?
+            != certification.manifest_identity
+    {
+        return Err(IndexError::ChecksumMismatch);
+    }
+    let expected_paths = expected_artifact_paths(index)?;
+    if certification
+        .artifacts
+        .iter()
+        .map(|artifact| artifact.artifact.path.clone())
+        .collect::<Vec<_>>()
+        != expected_paths
+    {
+        return Err(IndexError::ChecksumMismatch);
+    }
+    let retained_alias_directories = predecessor_fence
+        .topology_authority()
+        .into_iter()
+        .flat_map(|pointer| std::iter::once(pointer.active()).chain(pointer.previous()))
+        .chain(std::iter::once(slot))
+        .map(|slot| slot.directory().to_owned())
+        .collect::<HashSet<_>>();
+    for expected in &certification.artifacts {
+        let current = capture_artifact_with_retained_aliases(
+            root,
+            &generation_path,
+            Path::new(&expected.artifact.path),
+            &retained_alias_directories,
+        )?;
+        if current != expected.artifact {
+            return Err(IndexError::ChecksumMismatch);
+        }
+    }
+    predecessor_fence.validate(root)?;
+    Ok(())
+}
+
+/// Durably certifies one exact, fully hashed candidate before pointer
+/// publication. The sidecar is bound to its immutable slot, manifest, and
+/// artifact identities rather than to the active-pointer inode.
+pub fn certify_candidate_physical_integrity(
+    root: &Path,
+    predecessor_fence: &ActiveGenerationPointerFence,
+    slot: &GenerationSlot,
+    index: &tantivy::Index,
+    audit: &PhysicalIntegrityAudit,
+) -> Result<CertifiedPhysicalIntegrity> {
+    install_certification(
+        root,
+        predecessor_fence.topology_authority(),
+        Some(predecessor_fence),
+        slot,
+        index,
+        audit,
+        CertificationInstallPolicy::CANDIDATE,
+    )
+}
+
+pub(super) fn certification_digest_matches_slot(
+    certification: &GenerationIntegrityCertification,
+) -> Result<bool> {
+    Ok(
+        physical_integrity_digest_from_parts(certification.artifacts.iter().map(|artifact| {
+            (
+                artifact.artifact.path.as_str(),
+                artifact.artifact.identity.length(),
+                artifact.sha256,
+            )
+        }))? == certification.slot.physical_integrity_digest(),
+    )
+}

--- a/crates/ctx-history-index-generation/src/certification/install.rs
+++ b/crates/ctx-history-index-generation/src/certification/install.rs
@@ -1,0 +1,185 @@
+use super::*;
+
+#[derive(Clone, Copy)]
+pub(super) struct CertificationInstallPolicy {
+    allow_readonly_seal: bool,
+    seal_artifacts: bool,
+    require_durable_sidecar: bool,
+}
+
+impl CertificationInstallPolicy {
+    pub(super) const ACTIVE_CACHE: Self = Self {
+        allow_readonly_seal: false,
+        seal_artifacts: true,
+        require_durable_sidecar: false,
+    };
+    pub(super) const ACTIVATED_CACHE: Self = Self {
+        allow_readonly_seal: true,
+        seal_artifacts: true,
+        require_durable_sidecar: false,
+    };
+    pub(super) const CANDIDATE: Self = Self {
+        allow_readonly_seal: cfg!(windows),
+        seal_artifacts: true,
+        require_durable_sidecar: true,
+    };
+}
+
+pub(super) fn install_certification(
+    root: &Path,
+    topology_authority: Option<&ActiveGenerationPointer>,
+    predecessor_fence: Option<&ActiveGenerationPointerFence>,
+    slot: &GenerationSlot,
+    index: &tantivy::Index,
+    audit: &PhysicalIntegrityAudit,
+    policy: CertificationInstallPolicy,
+) -> Result<CertifiedPhysicalIntegrity> {
+    if audit.digest() != slot.physical_integrity_digest() {
+        return Err(IndexError::ChecksumMismatch);
+    }
+    if let Some(fence) = predecessor_fence {
+        fence.validate(root)?;
+    } else if let Some(pointer) = topology_authority {
+        if load_current_pointer(root)? != *pointer {
+            return Err(IndexError::ConcurrentGenerationChange);
+        }
+    }
+    let expected_paths = expected_artifact_paths(index)?;
+    if audit.artifact_paths() != expected_paths {
+        return Err(IndexError::ChecksumMismatch);
+    }
+
+    let generation_path = slot_path(root, slot);
+    ensure_real_directory(root)?;
+    ensure_real_directory(&root.join(MANIFEST_DIRECTORY))?;
+    ensure_real_directory(&root.join(INDEX_GENERATIONS_DIRECTORY))?;
+    ensure_real_directory(&generation_path)?;
+
+    let manifest_identity =
+        capture_single_link_control(&manifest_path(root, slot.generation_id()))?;
+    let mut artifacts = Vec::with_capacity(audit.files().len());
+    for prior in audit.files() {
+        let mut current = capture_artifact(
+            root,
+            &generation_path,
+            Path::new(&prior.artifact.path),
+            topology_authority,
+        )?;
+        let follows_allowed_seal = policy.allow_readonly_seal && {
+            #[cfg(windows)]
+            {
+                current
+                    .identity
+                    .follows_readonly_seal(&prior.artifact.identity)
+            }
+            #[cfg(not(windows))]
+            {
+                false
+            }
+        };
+        if current.identity != prior.artifact.identity && !follows_allowed_seal {
+            return if prior.artifact.same_payload_identity_changed(&current) {
+                Err(IndexError::ConcurrentGenerationChange)
+            } else {
+                Err(IndexError::ChecksumMismatch)
+            };
+        }
+        let sealed = policy.seal_artifacts && artifact_should_be_sealed(&prior.artifact.path);
+        if sealed {
+            current = seal_artifact(
+                root,
+                &generation_path,
+                Path::new(&prior.artifact.path),
+                topology_authority,
+                &current,
+            )?;
+        }
+        artifacts.push(CertifiedArtifact {
+            artifact: current,
+            sha256: prior.sha256,
+            sealed,
+        });
+    }
+    let certification = GenerationIntegrityCertification {
+        version: CERTIFICATION_VERSION,
+        manifest_identity,
+        slot: slot.clone(),
+        artifacts,
+    };
+    let sidecar_result = install_certification_sidecar(
+        root,
+        topology_authority,
+        predecessor_fence,
+        slot,
+        index,
+        &certification,
+        policy.require_durable_sidecar,
+    );
+    if policy.require_durable_sidecar {
+        sidecar_result?;
+    }
+    Ok(CertifiedPhysicalIntegrity { certification })
+}
+
+fn install_certification_sidecar(
+    root: &Path,
+    topology_authority: Option<&ActiveGenerationPointer>,
+    predecessor_fence: Option<&ActiveGenerationPointerFence>,
+    slot: &GenerationSlot,
+    index: &tantivy::Index,
+    certification: &GenerationIntegrityCertification,
+    require_durable_sidecar: bool,
+) -> Result<()> {
+    if certification.artifacts.len() > MAX_CERTIFIED_ARTIFACTS {
+        return if require_durable_sidecar {
+            Err(IndexError::ChecksumMismatch)
+        } else {
+            Ok(())
+        };
+    }
+    let bytes = serde_json::to_vec(certification)?;
+    if bytes.len() > MAX_CERTIFICATION_BYTES {
+        return if require_durable_sidecar {
+            Err(IndexError::ChecksumMismatch)
+        } else {
+            Ok(())
+        };
+    }
+    let certification_directory = root.join(CERTIFICATION_DIRECTORY);
+    if require_durable_sidecar {
+        ensure_private_directory(&certification_directory)?;
+        ensure_real_directory(&certification_directory)?;
+        let directory = DurableMmapDirectory::open(root).map_err(tantivy::TantivyError::from)?;
+        let relative_path = Path::new(CERTIFICATION_DIRECTORY).join(certification_file_name(slot));
+        directory.atomic_write(&relative_path, &bytes)?;
+        return verify_candidate_physical_integrity_read_only(
+            root,
+            predecessor_fence.ok_or(IndexError::ConcurrentGenerationChange)?,
+            slot,
+            index,
+        );
+    }
+
+    // Ordinary reader/open certification remains a cache optimization. A
+    // verified full hash is still authoritative when setup or the sidecar
+    // write fails. Once replacement succeeds, reread errors remain terminal so
+    // an observed identity race cannot be mistaken for a usable cache entry.
+    if ensure_private_directory(&certification_directory).is_err()
+        || ensure_real_directory(&certification_directory).is_err()
+    {
+        return Ok(());
+    }
+    let Ok(directory) = DurableMmapDirectory::open(root) else {
+        return Ok(());
+    };
+    let relative_path = Path::new(CERTIFICATION_DIRECTORY).join(certification_file_name(slot));
+    if directory.atomic_write(&relative_path, &bytes).is_err() {
+        return Ok(());
+    }
+    let pointer = topology_authority.ok_or(IndexError::ConcurrentGenerationChange)?;
+    if matching_certification(root, pointer, slot, index)?.is_some() {
+        Ok(())
+    } else {
+        Err(IndexError::ConcurrentGenerationChange)
+    }
+}

--- a/crates/ctx-history-index-generation/src/certification/pointer_fence.rs
+++ b/crates/ctx-history-index-generation/src/certification/pointer_fence.rs
@@ -1,0 +1,89 @@
+use std::io::Read as _;
+
+use super::*;
+
+struct PointerFileSnapshot {
+    file: File,
+    identity: FileIdentity,
+}
+
+/// Exact durable predecessor authority retained from writer admission through
+/// candidate activation. An incompatible pointer remains opaque but is still
+/// fenced by its native control-file identity.
+pub struct ActiveGenerationPointerFence {
+    expected: Option<PointerFileSnapshot>,
+    topology_authority: Option<ActiveGenerationPointer>,
+}
+
+impl ActiveGenerationPointerFence {
+    /// Captures the current pointer without decoding an unsupported version.
+    /// A present pointer may be opaque only when the normal loader independently
+    /// classifies that exact native file as version-incompatible.
+    #[doc(hidden)]
+    pub fn capture(
+        root: &Path,
+        topology_authority: Option<&ActiveGenerationPointer>,
+    ) -> Result<Self> {
+        ensure_real_directory(root)?;
+        let path = root.join(crate::ACTIVE_GENERATION_POINTER_FILE);
+        let expected = match fs::symlink_metadata(&path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.into()),
+            Ok(_) => {
+                let (mut file, identity) = open_regular_file(&path)?;
+                let length =
+                    usize::try_from(identity.length()).map_err(|_| IndexError::CountOverflow)?;
+                let mut bytes = Vec::with_capacity(length);
+                file.read_to_end(&mut bytes)?;
+                if bytes.len() != length {
+                    return Err(IndexError::ConcurrentGenerationChange);
+                }
+                if let Some(pointer) = topology_authority {
+                    if serde_json::to_vec(pointer)? != bytes {
+                        return Err(IndexError::ConcurrentGenerationChange);
+                    }
+                } else if !matches!(
+                    load_active_generation_pointer(root),
+                    Err(IndexError::UnsupportedActiveGenerationPointer(_))
+                ) {
+                    return Err(IndexError::ConcurrentGenerationChange);
+                }
+                Some(PointerFileSnapshot { file, identity })
+            }
+        };
+        if topology_authority.is_some() && expected.is_none() {
+            return Err(IndexError::ConcurrentGenerationChange);
+        }
+        let fence = Self {
+            expected,
+            topology_authority: topology_authority.cloned(),
+        };
+        fence.validate(root)?;
+        Ok(fence)
+    }
+
+    pub(crate) fn topology_authority(&self) -> Option<&ActiveGenerationPointer> {
+        self.topology_authority.as_ref()
+    }
+
+    pub fn validate(&self, root: &Path) -> Result<()> {
+        let path = root.join(crate::ACTIVE_GENERATION_POINTER_FILE);
+        let Some(expected) = &self.expected else {
+            return match fs::symlink_metadata(path) {
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                _ => Err(IndexError::ConcurrentGenerationChange),
+            };
+        };
+        if file_identity(&expected.file).map_err(|_| IndexError::ConcurrentGenerationChange)?
+            != expected.identity
+        {
+            return Err(IndexError::ConcurrentGenerationChange);
+        }
+        let (_, current) =
+            open_regular_file(&path).map_err(|_| IndexError::ConcurrentGenerationChange)?;
+        if current != expected.identity {
+            return Err(IndexError::ConcurrentGenerationChange);
+        }
+        Ok(())
+    }
+}

--- a/crates/ctx-history-index-generation/src/certification/tests.rs
+++ b/crates/ctx-history-index-generation/src/certification/tests.rs
@@ -45,7 +45,16 @@ fn read_only_certification_fixture() -> ReadOnlyCertificationFixture {
     fs::create_dir_all(root.join(MANIFEST_DIRECTORY)).unwrap();
     fs::write(manifest_path(root, slot.generation_id()), b"manifest").unwrap();
     crate::publish_active_generation_pointer(root, &pointer).unwrap();
-    let certified = install_certification(root, &pointer, &slot, &index, &audit, false).unwrap();
+    let certified = install_certification(
+        root,
+        Some(&pointer),
+        None,
+        &slot,
+        &index,
+        &audit,
+        CertificationInstallPolicy::ACTIVE_CACHE,
+    )
+    .unwrap();
     let relative_artifact_path = active_index_files(&index)
         .unwrap()
         .into_iter()
@@ -66,6 +75,34 @@ fn read_only_certification_fixture() -> ReadOnlyCertificationFixture {
         relative_artifact_path,
         certified_artifact,
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn candidate_certification_rejects_a_slot_with_a_different_physical_digest() {
+    let fixture = read_only_certification_fixture();
+    let pointer = load_current_pointer(fixture.root()).unwrap();
+    let generation_path = slot_path(fixture.root(), &fixture.slot);
+    let audit = physical_integrity_audit(&fixture.index, &generation_path, Some(&pointer)).unwrap();
+    let mismatched_slot = GenerationSlot::new(
+        fixture.slot.generation_id().to_owned(),
+        fixture.slot.directory().to_owned(),
+        "0".repeat(64),
+    )
+    .unwrap();
+    let predecessor_fence =
+        ActiveGenerationPointerFence::capture(fixture.root(), Some(&pointer)).unwrap();
+
+    assert!(matches!(
+        certify_candidate_physical_integrity(
+            fixture.root(),
+            &predecessor_fence,
+            &mismatched_slot,
+            &fixture.index,
+            &audit,
+        ),
+        Err(IndexError::ChecksumMismatch)
+    ));
 }
 
 #[cfg(unix)]

--- a/crates/ctx-history-index-generation/src/lib.rs
+++ b/crates/ctx-history-index-generation/src/lib.rs
@@ -23,10 +23,11 @@ pub use certification::{
     certification_file_for_active, MAX_CERTIFICATION_BYTES, MAX_CERTIFIED_ARTIFACTS,
 };
 pub use certification::{
-    certify_activated_generation, reclaim_unreferenced_certifications,
-    scrub_and_certify_physical_integrity, verify_certified_physical_integrity,
+    certify_activated_generation, certify_candidate_physical_integrity,
+    reclaim_unreferenced_certifications, scrub_and_certify_physical_integrity,
+    verify_candidate_physical_integrity_read_only, verify_certified_physical_integrity,
     verify_or_certify_physical_integrity, verify_physical_integrity_read_only,
-    CertifiedPhysicalIntegrity,
+    ActiveGenerationPointerFence, CertifiedPhysicalIntegrity,
 };
 #[cfg(any(test, feature = "test-support"))]
 pub use clone::{

--- a/crates/ctx-history-index-generation/src/physical.rs
+++ b/crates/ctx-history-index-generation/src/physical.rs
@@ -526,6 +526,17 @@ fn hash_physical_file(
 }
 
 fn canonical_physical_integrity_digest(entries: &[PhysicalDigestPart]) -> Result<String> {
+    physical_integrity_digest_from_parts(
+        entries
+            .iter()
+            .map(|entry| (entry.path.as_str(), entry.length, entry.sha256)),
+    )
+}
+
+pub(super) fn physical_integrity_digest_from_parts<'a>(
+    entries: impl IntoIterator<Item = (&'a str, u64, [u8; 32])>,
+) -> Result<String> {
+    let entries = entries.into_iter().collect::<Vec<_>>();
     let mut digest = Sha256::new();
     digest.update(PHYSICAL_INTEGRITY_DOMAIN);
     digest.update(
@@ -534,15 +545,15 @@ fn canonical_physical_integrity_digest(entries: &[PhysicalDigestPart]) -> Result
             .to_be_bytes(),
     );
     for entry in entries {
-        let path = entry.path.as_bytes();
+        let path = entry.0.as_bytes();
         digest.update(
             u64::try_from(path.len())
                 .map_err(|_| IndexError::CountOverflow)?
                 .to_be_bytes(),
         );
         digest.update(path);
-        digest.update(entry.length.to_be_bytes());
-        digest.update(entry.sha256);
+        digest.update(entry.1.to_be_bytes());
+        digest.update(entry.2);
     }
     Ok(hex(&digest.finalize()))
 }

--- a/crates/ctx-history-index-query/src/reader.rs
+++ b/crates/ctx-history-index-query/src/reader.rs
@@ -13,8 +13,8 @@ use ctx_history_index_format::{
 };
 use ctx_history_index_generation::{
     load_active_generation_pointer, load_generation_retention_lease, open_slot_index,
-    verify_physical_integrity_read_only, ActiveGenerationPointer, GenerationReadLease,
-    GenerationRetentionLease, GenerationSlot,
+    verify_candidate_physical_integrity_read_only, verify_physical_integrity_read_only,
+    ActiveGenerationPointer, GenerationReadLease, GenerationRetentionLease, GenerationSlot,
 };
 use tantivy::{ReloadPolicy, Searcher};
 
@@ -94,6 +94,50 @@ impl VerifiedIndex {
     /// current generations.
     pub fn open_pinned(root: impl AsRef<Path>) -> Result<Self> {
         Self::open_inner(root.as_ref(), false, false)
+    }
+
+    /// Reopens an exact candidate from durable state before its active-pointer
+    /// replacement. This is intentionally separate from the writer's in-memory
+    /// candidate searcher and accepts an absent authority for initial publish.
+    #[doc(hidden)]
+    pub fn open_certified_candidate_before_activation(
+        root: impl AsRef<Path>,
+        predecessor_fence: &ctx_history_index_generation::ActiveGenerationPointerFence,
+        slot: &GenerationSlot,
+    ) -> Result<Self> {
+        let control_directory =
+            DurableMmapDirectory::open(root).map_err(tantivy::TantivyError::from)?;
+        let root = control_directory.root_path().to_path_buf();
+        predecessor_fence.validate(&root)?;
+        let index = open_slot_index(&root, slot)?;
+        register_body_analyzer(&index);
+        validate_schema(&index.schema())?;
+        let metas = index.load_metas()?;
+        let publication = load_publication_for_metas(&root, &metas)?;
+        let (generation_id, manifest, publication_metadata) = publication.into_parts();
+        if generation_id != slot.generation_id() {
+            return Err(IndexError::ConcurrentGenerationChange);
+        }
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()?;
+        let searcher = reader.searcher();
+        if searcher_generation(&searcher) != meta_generation(&metas) {
+            return Err(IndexError::ConcurrentGenerationChange);
+        }
+        #[cfg(any(test, feature = "test-support"))]
+        VERIFIED_INDEX_REOPEN_COUNT.with(|count| count.set(count.get().saturating_add(1)));
+        verify_candidate_physical_integrity_read_only(&root, predecessor_fence, slot, &index)?;
+        verify_searcher_structure(&searcher, &manifest)?;
+        predecessor_fence.validate(&root)?;
+        Ok(Self {
+            searcher,
+            manifest,
+            generation_id,
+            publication_metadata,
+            semantic_eligibility_postings: OnceLock::new(),
+        })
     }
 
     /// Opens exactly the requested active or retained previous generation.

--- a/crates/ctx-history-index/src/commit_contract.rs
+++ b/crates/ctx-history-index/src/commit_contract.rs
@@ -83,11 +83,6 @@ impl CommitReceipt {
             manifest,
         )
     }
-
-    #[cfg(test)]
-    pub(crate) fn shared_manifest(&self) -> Arc<GenerationManifest> {
-        Arc::clone(&self.manifest)
-    }
 }
 
 /// Whether a commit call advanced the durable generation pointer or reused the

--- a/crates/ctx-history-index/src/lib.rs
+++ b/crates/ctx-history-index/src/lib.rs
@@ -109,12 +109,11 @@ pub use preparation::{
 pub(crate) use publication::publish_active_generation_pointer;
 #[cfg(all(test, target_os = "linux"))]
 pub(crate) use publication::republish_current_for_qualification;
-#[cfg(not(windows))]
-pub(crate) use publication::verify_candidate_physical_fence;
 #[cfg(test)]
 pub(crate) use publication::verify_searcher;
 pub(crate) use publication::{
-    best_effort_post_republish_cleanup, canonical_commit_payload, create_candidate_generation,
+    best_effort_post_republish_cleanup, canonical_commit_payload,
+    certify_candidate_physical_integrity, create_candidate_generation,
     load_active_generation_pointer, meta_generation, open_slot_index, payload_generation_id,
     prepare_successor_manifest, prime_candidate_physical_proof,
     publish_active_generation_pointer_validated, reclaim_inactive_generation_directories,
@@ -365,6 +364,7 @@ pub struct GenerationWriter {
     root: PathBuf,
     index: Index,
     active_pointer: Option<ActiveGenerationPointer>,
+    active_pointer_fence: ctx_history_index_generation::ActiveGenerationPointerFence,
     candidate_directory_name: Option<String>,
     candidate_physical_proof: Option<CandidatePhysicalProof>,
     candidate_activation_fence: Option<CandidateActivationFence>,

--- a/crates/ctx-history-index/src/publication.rs
+++ b/crates/ctx-history-index/src/publication.rs
@@ -14,10 +14,8 @@ pub(crate) use ctx_history_index_generation::manifest_path;
 #[cfg(test)]
 pub(crate) use ctx_history_index_generation::physical_integrity_digest;
 pub(crate) use ctx_history_index_generation::sync_directory;
-#[cfg(not(windows))]
-pub(crate) use ctx_history_index_generation::verify_candidate_physical_fence;
 pub(crate) use ctx_history_index_generation::{
-    certify_activated_generation, reclaim_unreferenced_certifications,
+    certify_candidate_physical_integrity, reclaim_unreferenced_certifications,
     reclaim_unreferenced_manifests,
 };
 pub(crate) use ctx_history_index_generation::{

--- a/crates/ctx-history-index/src/publication/republish.rs
+++ b/crates/ctx-history-index/src/publication/republish.rs
@@ -4,13 +4,13 @@ use tantivy::{indexer::NoMergePolicy, Index, ReloadPolicy};
 
 use crate::{
     fields_from_schema, validate_schema, writer_support::construct_index_writer_with_retry,
-    GenerationManifest, IndexError, Result, WriterOptions,
+    GenerationManifest, IndexError, Result, VerifiedIndex, WriterOptions,
 };
 use ctx_history_index_format::{register_body_analyzer, verify_searcher_structure};
 use ctx_history_index_generation::DurableMmapDirectory;
 
 use super::{
-    canonical_commit_payload, certify_activated_generation, lexical_index_settings,
+    canonical_commit_payload, certify_candidate_physical_integrity, lexical_index_settings,
     load_active_generation_pointer, load_generation_retention_lease, load_publication_for_metas,
     meta_generation, open_slot_index, payload_generation_id, physical_integrity_audit,
     publish_active_generation_pointer, reclaim_inactive_generation_directories,
@@ -20,7 +20,6 @@ use super::{
     INDEX_GENERATIONS_DIRECTORY,
 };
 
-#[cfg(windows)]
 use super::{publish_active_generation_pointer_validated, validate_candidate_managed_files};
 
 mod clone {
@@ -177,6 +176,10 @@ fn republish_candidate(
     current_manifest: Arc<GenerationManifest>,
     current_generation_id: String,
 ) -> Result<CurrentRepublishOutcome> {
+    let predecessor_fence = ctx_history_index_generation::ActiveGenerationPointerFence::capture(
+        root,
+        Some(base_pointer),
+    )?;
     republish_checkpoint(RepublishStage::AfterCandidateCreation, Some(candidate_path))?;
     candidate.validate_binding()?;
     let candidate_index = candidate.index();
@@ -262,46 +265,55 @@ fn republish_candidate(
     candidate.validate_binding()?;
     let next_pointer =
         ActiveGenerationPointer::new(verified.slot.clone(), Some(base_pointer.active().clone()))?;
+    #[cfg(windows)]
+    let mut terminal_guard = Some(
+        ctx_history_index_generation::acquire_terminal_publication_guard(
+            root,
+            candidate_path,
+            &verified.index,
+            Some(base_pointer),
+        )?,
+    );
+    certify_candidate_physical_integrity(
+        root,
+        &predecessor_fence,
+        &verified.slot,
+        &verified.index,
+        &verified.physical_integrity_audit,
+    )?;
+    let _reopened_candidate = VerifiedIndex::open_certified_candidate_before_activation(
+        root,
+        &predecessor_fence,
+        &verified.slot,
+    )?;
     republish_checkpoint(
         RepublishStage::BeforePointerPublication,
         Some(candidate_path),
     )?;
     candidate.validate_binding()?;
-    #[cfg(windows)]
     let publication_result =
         publish_active_generation_pointer_validated(root, &next_pointer, || {
-            let terminal_guard = ctx_history_index_generation::acquire_terminal_publication_guard(
-                root,
-                candidate_path,
-                &verified.index,
-                Some(base_pointer),
-            )?;
             candidate.validate_binding()?;
             validate_candidate_managed_files(&verified.index, candidate_path, Some(base_pointer))?;
-            let terminal_verified = verify_candidate(
+            ctx_history_index_generation::verify_candidate_physical_integrity_read_only(
                 root,
-                base_pointer,
-                candidate_path,
-                candidate_directory_name,
-                base_metas,
-                publication_metadata.as_deref(),
-                &current_manifest,
-                &current_generation_id,
-            )
-            .map_err(|_| ctx_history_index_generation::GenerationError::ChecksumMismatch)?;
-            if terminal_verified.slot != verified.slot {
-                return Err(
+                &predecessor_fence,
+                &verified.slot,
+                &verified.index,
+            )?;
+            #[cfg(windows)]
+            {
+                let terminal_guard = terminal_guard.take().ok_or(
                     ctx_history_index_generation::GenerationError::ConcurrentGenerationChange,
-                );
+                )?;
+                terminal_guard.verify_physical_fence(&verified.physical_integrity_audit)?;
+                terminal_guard.verify_identities()?;
+                Ok(terminal_guard)
             }
-            terminal_guard.verify_physical_fence(&verified.physical_integrity_audit)?;
-            candidate.validate_binding()?;
-            terminal_guard.verify_identities()?;
-            Ok(terminal_guard)
+            #[cfg(not(windows))]
+            Ok(())
         });
-    #[cfg(not(windows))]
-    let publication_result = publish_active_generation_pointer(root, &next_pointer);
-    let outcome = match publication_result {
+    match publication_result {
         Ok(PointerPublicationOutcome::Durable) => {
             Ok(CurrentRepublishOutcome::Published(next_pointer))
         }
@@ -311,21 +323,7 @@ fn republish_candidate(
         // The atomic-write contract guarantees that every `Err` occurred
         // before replacement, so the predecessor remains query authority.
         Err(error) => Err(error),
-    };
-    if let Ok(
-        CurrentRepublishOutcome::Published(pointer)
-        | CurrentRepublishOutcome::CommittedVisible { pointer, .. },
-    ) = &outcome
-    {
-        let _ = certify_activated_generation(
-            root,
-            pointer,
-            pointer.active(),
-            &verified.index,
-            &verified.physical_integrity_audit,
-        );
     }
-    outcome
 }
 
 struct VerifiedRepublishCandidate {

--- a/crates/ctx-history-index/src/tests/integrity_certification.rs
+++ b/crates/ctx-history-index/src/tests/integrity_certification.rs
@@ -954,6 +954,39 @@ fn missing_and_corrupt_certification_force_one_rehash_then_reuse() {
 }
 
 #[test]
+fn legacy_pointer_bound_certifications_rehash_once_into_generation_bound_format() {
+    for legacy_version in [3, 4] {
+        let (temp, _, _) =
+            published_fixture(&format!("legacy-v{legacy_version}-certification.jsonl"));
+        let pointer = load_active_generation_pointer(temp.path())
+            .unwrap()
+            .unwrap();
+        let certification = crate::publication::certification_file_for_active(temp.path()).unwrap();
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&fs::read(&certification).unwrap()).unwrap();
+        value["version"] = serde_json::json!(legacy_version);
+        value["pointer"] = serde_json::to_value(&pointer).unwrap();
+        value["pointer_identity"] = value["manifest_identity"].clone();
+        fs::write(&certification, serde_json::to_vec(&value).unwrap()).unwrap();
+
+        crate::publication::reset_verification_activity();
+        drop(VerifiedIndex::open_pinned(temp.path()).unwrap());
+        assert_eq!(crate::publication::verification_activity().0, 1);
+        assert!(crate::publication::hashed_artifact_bytes() > 0);
+
+        let upgraded: serde_json::Value =
+            serde_json::from_slice(&fs::read(&certification).unwrap()).unwrap();
+        assert_eq!(upgraded["version"], 5);
+        assert!(upgraded.get("pointer").is_none());
+        assert!(upgraded.get("pointer_identity").is_none());
+        crate::publication::reset_verification_activity();
+        drop(VerifiedIndex::open_pinned(temp.path()).unwrap());
+        assert_eq!(crate::publication::verification_activity().0, 0);
+        assert_eq!(crate::publication::hashed_artifact_bytes(), 0);
+    }
+}
+
+#[test]
 fn oversized_and_overcount_certifications_fallback_without_unbounded_decode() {
     for overcount in [false, true] {
         let (temp, _, _) = published_fixture(if overcount {
@@ -1003,7 +1036,7 @@ fn oversized_and_overcount_certifications_fallback_without_unbounded_decode() {
 }
 
 #[test]
-fn pointer_manifest_and_artifact_identity_replacement_force_rehash() {
+fn generation_certification_ignores_pointer_inode_but_rehashes_generation_replacements() {
     let replacements = ["pointer", "manifest", "artifact"];
     for replacement in replacements {
         let (temp, _, _) = published_fixture(&format!("{replacement}-replacement.jsonl"));
@@ -1020,9 +1053,37 @@ fn pointer_manifest_and_artifact_identity_replacement_force_rehash() {
 
         crate::publication::reset_verification_activity();
         drop(VerifiedIndex::open_pinned(temp.path()).unwrap());
-        assert_eq!(crate::publication::verification_activity().0, 1);
-        assert!(crate::publication::hashed_artifact_bytes() > 0);
+        if replacement == "pointer" {
+            assert_eq!(crate::publication::verification_activity().0, 0);
+            assert_eq!(crate::publication::hashed_artifact_bytes(), 0);
+        } else {
+            assert_eq!(crate::publication::verification_activity().0, 1);
+            assert!(crate::publication::hashed_artifact_bytes() > 0);
+        }
     }
+}
+
+#[test]
+fn certification_sha_authority_must_recompute_to_the_exact_slot_digest() {
+    let (temp, _, _) = published_fixture("certificate-digest-binding.jsonl");
+    let certification = crate::publication::certification_file_for_active(temp.path()).unwrap();
+    let mut value: serde_json::Value =
+        serde_json::from_slice(&fs::read(&certification).unwrap()).unwrap();
+    let sha = value
+        .get_mut("artifacts")
+        .and_then(serde_json::Value::as_array_mut)
+        .and_then(|artifacts| artifacts.first_mut())
+        .and_then(|artifact| artifact.get_mut("sha256"))
+        .and_then(serde_json::Value::as_array_mut)
+        .unwrap();
+    let first = sha.first_mut().unwrap();
+    *first = serde_json::Value::from(first.as_u64().unwrap() ^ 0x5a);
+    fs::write(&certification, serde_json::to_vec(&value).unwrap()).unwrap();
+
+    crate::publication::reset_verification_activity();
+    drop(VerifiedIndex::open_pinned(temp.path()).unwrap());
+    assert_eq!(crate::publication::verification_activity().0, 1);
+    assert!(crate::publication::hashed_artifact_bytes() > 0);
 }
 
 #[cfg(unix)]

--- a/crates/ctx-history-index/src/tests/publication_metadata.rs
+++ b/crates/ctx-history-index/src/tests/publication_metadata.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, panic::AssertUnwindSafe, sync::Arc};
+use std::{cell::Cell, panic::AssertUnwindSafe};
 
 use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine as _};
 use tantivy::{
@@ -115,7 +115,7 @@ fn raw_term_count(root: &Path, term_text: &str) -> usize {
 }
 
 #[test]
-fn metadata_factory_runs_inside_the_terminal_authority_fence_without_reopen() {
+fn metadata_factory_runs_inside_the_terminal_authority_fence_with_exact_reopen() {
     let temp = tempdir().unwrap();
     let source = source("publication-metadata-ordering.jsonl");
     let inventory = complete_inventory(&source, 1, vec![source.clone()]);
@@ -182,15 +182,11 @@ fn metadata_factory_runs_inside_the_terminal_authority_fence_without_reopen() {
         crate::publication::candidate_lineage_verification_activity(),
         (0, 0)
     );
-    assert_eq!(ctx_history_index_query::verified_index_reopen_count(), 0);
+    assert_eq!(ctx_history_index_query::verified_index_reopen_count(), 1);
     assert_eq!(
         ctx_history_index_query::verified_index_publication_construction_count(),
-        1
+        0
     );
-    assert!(Arc::ptr_eq(
-        &published.receipt().shared_manifest(),
-        published.verified_index().test_shared_manifest()
-    ));
     assert_eq!(crate::publication::complete_session_id_traversals(), 0);
 
     let expected_payload = format!(
@@ -240,7 +236,7 @@ fn receipt_only_commit_does_not_construct_a_return_pin() {
         crate::publication::candidate_lineage_verification_activity(),
         (0, 0)
     );
-    assert_eq!(ctx_history_index_query::verified_index_reopen_count(), 0);
+    assert_eq!(ctx_history_index_query::verified_index_reopen_count(), 1);
     assert_eq!(
         ctx_history_index_query::verified_index_publication_construction_count(),
         0

--- a/crates/ctx-history-index/src/tests/recovery.rs
+++ b/crates/ctx-history-index/src/tests/recovery.rs
@@ -307,7 +307,13 @@ fn terminal_activation_fence_rejects_candidate_manifest_replacement() {
     }));
 
     let error = candidate.commit(|_| true).unwrap_err();
-    assert!(matches!(error, IndexError::ChecksumMismatch), "{error:?}");
+    assert!(
+        matches!(
+            error,
+            IndexError::ChecksumMismatch | IndexError::ManifestDigestMismatch { .. }
+        ),
+        "{error:?}"
+    );
     assert_eq!(
         fs::read(temp.path().join("active-generation.json")).unwrap(),
         pointer_before
@@ -360,6 +366,7 @@ fn terminal_activation_fence_rejects_post_verification_directory_substitution() 
             IndexError::CurrentRepublishSourceTopology(_)
                 | IndexError::ConcurrentGenerationChange
                 | IndexError::ChecksumMismatch
+                | IndexError::Tantivy(_)
         ),
         "{error:?}"
     );

--- a/crates/ctx-history-index/src/tests/republish.rs
+++ b/crates/ctx-history-index/src/tests/republish.rs
@@ -477,7 +477,11 @@ fn metadata_only_republish_keeps_stored_core_replay_explicit() {
         crate::publication::candidate_lineage_verification_activity(),
         (0, 0)
     );
-    assert_eq!(ctx_history_index_query::verified_index_reopen_count(), 1);
+    assert_eq!(
+        ctx_history_index_query::verified_index_reopen_count(),
+        2,
+        "republish verifies the inactive candidate and independently returns the activated generation"
+    );
 
     let (searcher, _) = open_unverified_generation(predecessor.root());
     let explicit_scrub =

--- a/crates/ctx-history-index/src/tests/republish/additional.rs
+++ b/crates/ctx-history-index/src/tests/republish/additional.rs
@@ -444,6 +444,172 @@ fn pause_subprocess(marker: &Path, continue_path: &Path, witness: &str) -> io::R
     Ok(())
 }
 
+fn is_candidate_certification_target(target: &Path) -> bool {
+    target
+        .parent()
+        .and_then(|parent| parent.file_name())
+        .and_then(|name| name.to_str())
+        == Some("integrity-certifications")
+        && target
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".physical-certification.json"))
+}
+
+fn publish_subprocess_successor(
+    root: &Path,
+    report_progress: impl FnMut(PublicationStage) -> Result<()>,
+) -> Result<PublishedGeneration> {
+    let source = source("golden-predecessor.jsonl");
+    let mut writer = GenerationWriter::open(root, WriterOptions::default())?
+        .into_writer()
+        .map_err(|_| IndexError::WriterInvariant("unexpected committed recovery"))?;
+    writer.begin_source(source.clone())?;
+    for sequence in 1..=4 {
+        writer.add_core_record(document(
+            &source,
+            sequence,
+            &format!("certified candidate evidence {sequence}"),
+        ))?;
+    }
+    writer.certify_source(certificate(&source, 2, 4))?;
+    writer.commit_with_complete_inventory_revalidation_and_publication_metadata_and_progress(
+        |_| true,
+        |_| true,
+        |_| Ok(PUBLICATION_METADATA.to_vec()),
+        report_progress,
+    )
+}
+
+#[test]
+fn candidate_certification_publication_subprocess_worker() {
+    let Ok(mode) = env::var(SUBPROCESS_MODE_ENV) else {
+        return;
+    };
+    let root = PathBuf::from(env::var_os(SUBPROCESS_ROOT_ENV).unwrap());
+    let marker = PathBuf::from(env::var_os(SUBPROCESS_MARKER_ENV).unwrap());
+    let continue_path = PathBuf::from(env::var_os(SUBPROCESS_CONTINUE_ENV).unwrap());
+    let result = PathBuf::from(env::var_os(SUBPROCESS_RESULT_ENV).unwrap());
+    let pause_after_certification = mode == "pause-after-candidate-certification";
+    let progress_marker = marker.clone();
+    let progress_continue_path = continue_path.clone();
+    let atomic_guard = if mode == "pause-candidate-certification" {
+        Some(AtomicWriteTestHookGuard::set(move |stage, target| {
+            if stage == AtomicWriteStage::AfterTemporarySyncBeforeReplace
+                && is_candidate_certification_target(target)
+            {
+                pause_subprocess(
+                    &marker,
+                    &continue_path,
+                    "candidate-certification-temp-synced",
+                )?;
+            }
+            Ok(())
+        }))
+    } else if mode == "fail-candidate-certification-write" {
+        Some(AtomicWriteTestHookGuard::set(|stage, target| {
+            if stage == AtomicWriteStage::BeforeTemporaryWrite
+                && is_candidate_certification_target(target)
+            {
+                return Err(io::Error::from_raw_os_error(libc::ENOSPC));
+            }
+            Ok(())
+        }))
+    } else if pause_after_certification {
+        None
+    } else {
+        panic!("unknown candidate certification child mode {mode}");
+    };
+    let detail = match publish_subprocess_successor(&root, move |stage| {
+        if pause_after_certification && stage == PublicationStage::Activation {
+            pause_subprocess(
+                &progress_marker,
+                &progress_continue_path,
+                "candidate-certified-and-reopened",
+            )?;
+        }
+        Ok(())
+    }) {
+        Ok(published) => format!(
+            "PUBLISHED {} {}",
+            published.receipt().generation_id,
+            published.verified_index().generation_id()
+        ),
+        Err(error) => format!("ERROR {error:?}\n{error}"),
+    };
+    fs::write(result, detail).unwrap();
+    drop(atomic_guard);
+}
+
+#[test]
+fn candidate_certification_reader_subprocess_worker() {
+    let Some(root) = env::var_os("CTX_CANDIDATE_CERTIFICATION_READER_ROOT").map(PathBuf::from)
+    else {
+        return;
+    };
+    let detail = match VerifiedIndex::open_pinned(&root) {
+        Ok(index) => format!(
+            "READER {} {}",
+            index.generation_id(),
+            index.document_count()
+        ),
+        Err(error) => format!("ERROR {error:?}\n{error}"),
+    };
+    fs::write(root.join("candidate-certification-reader.result"), detail).unwrap();
+}
+
+#[test]
+fn certified_candidate_reader_subprocess_worker() {
+    let Some(root) = env::var_os("CTX_CERTIFIED_CANDIDATE_READER_ROOT").map(PathBuf::from) else {
+        return;
+    };
+    let result = root.join("certified-candidate-reader.result");
+    let detail = (|| -> Result<String> {
+        let pointer = load_active_generation_pointer(&root)?
+            .ok_or(IndexError::MissingActiveGenerationPointer)?;
+        let predecessor_fence =
+            ctx_history_index_generation::ActiveGenerationPointerFence::capture(
+                &root,
+                Some(&pointer),
+            )?;
+        let certification_directory = root.join("integrity-certifications");
+        let mut candidate_slot = None;
+        for entry in fs::read_dir(certification_directory)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_file() {
+                continue;
+            }
+            let value: serde_json::Value = serde_json::from_slice(&fs::read(entry.path())?)?;
+            let Some(slot) = value.get("slot") else {
+                continue;
+            };
+            let slot: GenerationSlot = serde_json::from_value(slot.clone())?;
+            if slot.generation_id() != pointer.active().generation_id()
+                && candidate_slot.replace(slot).is_some()
+            {
+                return Err(IndexError::WriterInvariant(
+                    "multiple inactive certified candidates",
+                ));
+            }
+        }
+        let slot = candidate_slot.ok_or(IndexError::WriterInvariant(
+            "inactive certified candidate missing",
+        ))?;
+        let index = VerifiedIndex::open_certified_candidate_before_activation(
+            &root,
+            &predecessor_fence,
+            &slot,
+        )?;
+        Ok(format!(
+            "CANDIDATE {} {}",
+            index.generation_id(),
+            index.document_count()
+        ))
+    })()
+    .unwrap_or_else(|error| format!("ERROR {error:?}\n{error}"));
+    fs::write(result, detail).unwrap();
+}
+
 #[test]
 fn predecessor_republish_subprocess_worker() {
     let Ok(mode) = env::var(SUBPROCESS_MODE_ENV) else {
@@ -555,6 +721,74 @@ pub(super) fn spawn_republish_subprocess(root: &Path, mode: &str) -> Child {
         .unwrap()
 }
 
+fn spawn_candidate_certification_subprocess(root: &Path, mode: &str) -> Child {
+    let (marker, continue_path, result) = subprocess_paths(root);
+    for path in [&marker, &continue_path, &result] {
+        let _ = fs::remove_file(path);
+    }
+    Command::new(env::current_exe().unwrap())
+        .arg("--exact")
+        .arg("tests::republish::additional::candidate_certification_publication_subprocess_worker")
+        .arg("--nocapture")
+        .arg("--test-threads=1")
+        .env(SUBPROCESS_MODE_ENV, mode)
+        .env(SUBPROCESS_ROOT_ENV, root)
+        .env(SUBPROCESS_MARKER_ENV, marker)
+        .env(SUBPROCESS_CONTINUE_ENV, continue_path)
+        .env(SUBPROCESS_RESULT_ENV, result)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .unwrap()
+}
+
+fn fresh_reader_subprocess(root: &Path) -> String {
+    let result = root.join("candidate-certification-reader.result");
+    let _ = fs::remove_file(&result);
+    let mut child = Command::new(env::current_exe().unwrap())
+        .arg("--exact")
+        .arg("tests::republish::additional::candidate_certification_reader_subprocess_worker")
+        .arg("--nocapture")
+        .arg("--test-threads=1")
+        .env("CTX_CANDIDATE_CERTIFICATION_READER_ROOT", root)
+        .spawn()
+        .unwrap();
+    let status = wait_for_subprocess_exit(&mut child);
+    assert!(status.success());
+    fs::read_to_string(result).unwrap()
+}
+
+fn fresh_certified_candidate_subprocess(root: &Path) -> String {
+    let result = root.join("certified-candidate-reader.result");
+    let _ = fs::remove_file(&result);
+    let mut child = Command::new(env::current_exe().unwrap())
+        .arg("--exact")
+        .arg("tests::republish::additional::certified_candidate_reader_subprocess_worker")
+        .arg("--nocapture")
+        .arg("--test-threads=1")
+        .env("CTX_CERTIFIED_CANDIDATE_READER_ROOT", root)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .unwrap();
+    let status = wait_for_subprocess_exit(&mut child);
+    assert!(status.success());
+    fs::read_to_string(result).unwrap()
+}
+
+fn wait_for_subprocess_exit(child: &mut Child) -> std::process::ExitStatus {
+    let deadline = Instant::now() + SUBPROCESS_TIMEOUT;
+    while Instant::now() < deadline {
+        if let Some(status) = child.try_wait().unwrap() {
+            return status;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    child.kill().unwrap();
+    let status = child.wait().unwrap();
+    panic!("timed out waiting for subprocess exit: {status}");
+}
+
 pub(super) fn wait_for_subprocess_marker(child: &mut Child, marker: &Path) {
     let deadline = Instant::now() + SUBPROCESS_TIMEOUT;
     while Instant::now() < deadline {
@@ -571,7 +805,7 @@ pub(super) fn wait_for_subprocess_marker(child: &mut Child, marker: &Path) {
 
 fn kill_republish_subprocess(child: &mut Child) {
     child.kill().unwrap();
-    assert!(!child.wait().unwrap().success());
+    assert!(!wait_for_subprocess_exit(child).success());
 }
 
 #[test]
@@ -607,11 +841,137 @@ fn subprocess_process_death_around_commit_sync_and_pointer_rename_recovers_corre
 }
 
 #[test]
+fn delayed_candidate_certification_io_keeps_predecessor_visible_to_fresh_process() {
+    let predecessor = GoldenPredecessor::copy();
+    let pointer_before = fs::read(predecessor.root().join("active-generation.json")).unwrap();
+    let (marker, continue_path, _) = subprocess_paths(predecessor.root());
+    let mut child = spawn_candidate_certification_subprocess(
+        predecessor.root(),
+        "pause-candidate-certification",
+    );
+    wait_for_subprocess_marker(&mut child, &marker);
+    assert_eq!(
+        fs::read_to_string(&marker).unwrap(),
+        "candidate-certification-temp-synced"
+    );
+    assert_eq!(
+        fs::read(predecessor.root().join("active-generation.json")).unwrap(),
+        pointer_before
+    );
+    assert_eq!(
+        fresh_reader_subprocess(predecessor.root()),
+        format!("READER {} 3", predecessor.generation_id())
+    );
+
+    fs::write(continue_path, b"release").unwrap();
+    assert!(wait_for_subprocess_exit(&mut child).success());
+}
+
+#[test]
+fn candidate_certification_is_durable_and_reopenable_before_pointer_activation() {
+    let predecessor = GoldenPredecessor::copy();
+    let pointer_before = fs::read(predecessor.root().join("active-generation.json")).unwrap();
+    let (marker, continue_path, result) = subprocess_paths(predecessor.root());
+    let mut child = spawn_candidate_certification_subprocess(
+        predecessor.root(),
+        "pause-after-candidate-certification",
+    );
+    wait_for_subprocess_marker(&mut child, &marker);
+    assert_eq!(
+        fs::read_to_string(&marker).unwrap(),
+        "candidate-certified-and-reopened"
+    );
+    assert_eq!(
+        fs::read(predecessor.root().join("active-generation.json")).unwrap(),
+        pointer_before
+    );
+    let fresh_candidate = fresh_certified_candidate_subprocess(predecessor.root());
+    let mut candidate_fields = fresh_candidate.split_whitespace();
+    assert_eq!(
+        candidate_fields.next(),
+        Some("CANDIDATE"),
+        "{fresh_candidate}"
+    );
+    let candidate_generation_id = candidate_fields.next().unwrap().to_owned();
+    assert_eq!(candidate_fields.next(), Some("4"), "{fresh_candidate}");
+    assert_eq!(candidate_fields.next(), None, "{fresh_candidate}");
+    assert_eq!(
+        fresh_reader_subprocess(predecessor.root()),
+        format!("READER {} 3", predecessor.generation_id())
+    );
+
+    fs::write(continue_path, b"release").unwrap();
+    assert!(wait_for_subprocess_exit(&mut child).success());
+    let published = fs::read_to_string(result).unwrap();
+    let mut fields = published.split_whitespace();
+    assert_eq!(fields.next(), Some("PUBLISHED"), "{published}");
+    let receipt_generation_id = fields.next().unwrap();
+    let reopened_generation_id = fields.next().unwrap();
+    assert_eq!(fields.next(), None, "{published}");
+    assert_eq!(receipt_generation_id, reopened_generation_id);
+    assert_eq!(receipt_generation_id, candidate_generation_id);
+    assert_ne!(receipt_generation_id, predecessor.generation_id());
+    assert_eq!(
+        fresh_reader_subprocess(predecessor.root()),
+        format!("READER {receipt_generation_id} 4")
+    );
+}
+
+#[test]
+fn process_death_after_candidate_certification_preserves_predecessor_authority() {
+    let predecessor = GoldenPredecessor::copy();
+    let pointer_before = fs::read(predecessor.root().join("active-generation.json")).unwrap();
+    let (marker, _, _) = subprocess_paths(predecessor.root());
+    let mut child = spawn_candidate_certification_subprocess(
+        predecessor.root(),
+        "pause-after-candidate-certification",
+    );
+    wait_for_subprocess_marker(&mut child, &marker);
+    assert!(fresh_certified_candidate_subprocess(predecessor.root()).starts_with("CANDIDATE "));
+    kill_republish_subprocess(&mut child);
+    assert_eq!(
+        fs::read(predecessor.root().join("active-generation.json")).unwrap(),
+        pointer_before
+    );
+    assert_eq!(
+        fresh_reader_subprocess(predecessor.root()),
+        format!("READER {} 3", predecessor.generation_id())
+    );
+    drop(
+        GenerationWriter::open(predecessor.root(), WriterOptions::default())
+            .unwrap()
+            .into_writer()
+            .unwrap(),
+    );
+}
+
+#[test]
+fn candidate_certification_write_failure_cannot_publish() {
+    let predecessor = GoldenPredecessor::copy();
+    let pointer_before = fs::read(predecessor.root().join("active-generation.json")).unwrap();
+    let mut child = spawn_candidate_certification_subprocess(
+        predecessor.root(),
+        "fail-candidate-certification-write",
+    );
+    assert!(wait_for_subprocess_exit(&mut child).success());
+    let (_, _, result) = subprocess_paths(predecessor.root());
+    assert!(fs::read_to_string(result).unwrap().starts_with("ERROR"));
+    assert_eq!(
+        fs::read(predecessor.root().join("active-generation.json")).unwrap(),
+        pointer_before
+    );
+    assert_eq!(
+        fresh_reader_subprocess(predecessor.root()),
+        format!("READER {} 3", predecessor.generation_id())
+    );
+}
+
+#[test]
 fn subprocess_pointer_enospc_is_prepublication_failure_and_retry_migrates() {
     let predecessor = GoldenPredecessor::copy();
     let pointer_before = fs::read(predecessor.root().join("active-generation.json")).unwrap();
     let mut child = spawn_republish_subprocess(predecessor.root(), "fail-pointer-write-enospc");
-    assert!(child.wait().unwrap().success());
+    assert!(wait_for_subprocess_exit(&mut child).success());
     let (_, _, result) = subprocess_paths(predecessor.root());
     assert!(fs::read_to_string(result).unwrap().starts_with("ERROR"));
     assert_eq!(
@@ -630,7 +990,7 @@ fn subprocess_pointer_enospc_is_prepublication_failure_and_retry_migrates() {
 fn subprocess_post_rename_fsync_failure_is_committed_and_restart_reads_successor() {
     let predecessor = GoldenPredecessor::copy();
     let mut child = spawn_republish_subprocess(predecessor.root(), "fail-pointer-directory-sync");
-    assert!(child.wait().unwrap().success());
+    assert!(wait_for_subprocess_exit(&mut child).success());
     let (_, _, result) = subprocess_paths(predecessor.root());
     let result = fs::read_to_string(result).unwrap();
     assert!(result.starts_with("COMMITTED "), "{result}");

--- a/crates/ctx-history-index/src/writer_open.rs
+++ b/crates/ctx-history-index/src/writer_open.rs
@@ -73,6 +73,13 @@ impl GenerationWriter {
                 }
             }
         }
+        let active_pointer_fence =
+            ctx_history_index_generation::ActiveGenerationPointerFence::capture(
+                &root,
+                active_authority
+                    .as_ref()
+                    .map(ActivePublicationAuthority::pointer),
+            )?;
         if !pointer_requires_rebuild {
             let active_pointer_ref = active_authority
                 .as_ref()
@@ -204,6 +211,7 @@ impl GenerationWriter {
                 root,
                 index,
                 active_pointer,
+                active_pointer_fence,
                 candidate_directory_name,
                 candidate_physical_proof,
                 candidate_activation_fence,

--- a/crates/ctx-history-index/src/writer_publication.rs
+++ b/crates/ctx-history-index/src/writer_publication.rs
@@ -586,7 +586,6 @@ impl GenerationWriter {
         if let Some(hook) = self.before_pointer_publication.take() {
             hook(&candidate_path);
         }
-        report_progress(PublicationStage::Activation)?;
         let activation_fence =
             self.candidate_activation_fence
                 .as_ref()
@@ -595,14 +594,29 @@ impl GenerationWriter {
                 ))?;
         let terminal_index = verified.publication.publication().searcher().index();
         let expected_audit = verified.publication.physical_integrity_audit();
-        match publish_active_generation_pointer_validated(&root, &next_pointer, || {
-            #[cfg(windows)]
-            let terminal_guard = ctx_history_index_generation::acquire_terminal_publication_guard(
+        #[cfg(windows)]
+        let mut terminal_guard = Some(
+            ctx_history_index_generation::acquire_terminal_publication_guard(
                 &root,
                 &candidate_path,
                 terminal_index,
                 self.active_pointer.as_ref(),
-            )?;
+            )?,
+        );
+        certify_candidate_physical_integrity(
+            &root,
+            &self.active_pointer_fence,
+            &verified.slot,
+            terminal_index,
+            expected_audit,
+        )?;
+        let reopened_candidate = VerifiedIndex::open_certified_candidate_before_activation(
+            &root,
+            &self.active_pointer_fence,
+            &verified.slot,
+        )?;
+        report_progress(PublicationStage::Activation)?;
+        match publish_active_generation_pointer_validated(&root, &next_pointer, || {
             activation_fence.validate_binding()?;
             prepared_manifest
                 .verify_persisted(&root)
@@ -612,18 +626,23 @@ impl GenerationWriter {
                 &candidate_path,
                 self.active_pointer.as_ref(),
             )?;
-            #[cfg(not(windows))]
-            verify_candidate_physical_fence(
+            ctx_history_index_generation::verify_candidate_physical_integrity_read_only(
+                &root,
+                &self.active_pointer_fence,
+                &verified.slot,
                 terminal_index,
-                &candidate_path,
-                self.active_pointer.as_ref(),
-                expected_audit,
             )?;
             #[cfg(windows)]
-            terminal_guard.verify_physical_fence(expected_audit)?;
+            terminal_guard
+                .as_ref()
+                .ok_or(ctx_history_index_generation::GenerationError::ConcurrentGenerationChange)?
+                .verify_physical_fence(expected_audit)?;
             activation_fence.validate_binding()?;
             #[cfg(windows)]
             {
+                let terminal_guard = terminal_guard.take().ok_or(
+                    ctx_history_index_generation::GenerationError::ConcurrentGenerationChange,
+                )?;
                 terminal_guard.verify_identities()?;
                 Ok(terminal_guard)
             }
@@ -675,22 +694,12 @@ impl GenerationWriter {
                 retention_lease.as_ref(),
             );
         }
-        let _ = publication::certify_activated_generation(
-            &root,
-            &next_pointer,
-            next_pointer.active(),
-            verified.publication.publication().searcher().index(),
-            verified.publication.physical_integrity_audit(),
-        );
-
         let receipt = CommitReceipt::from_verified_manifest(
             opstamp,
             generation_id.clone(),
             std::sync::Arc::clone(verified.publication.publication().shared_manifest()),
         );
-        let verified_index = return_verified_index.then(|| {
-            VerifiedIndex::from_verified_publication(verified.publication.into_publication())
-        });
+        let verified_index = return_verified_index.then_some(reopened_candidate);
         Ok(CommitGenerationOutcome {
             receipt,
             disposition: PublicationDisposition::Published,


### PR DESCRIPTION
Fixes #660

## Summary

- durably finish and certify each exact candidate before replacing the active-generation pointer
- bind certification to the candidate physical digest and independently reopen that exact generation from durable state before reporting Published
- retain an identity fence for the predecessor pointer, including opaque legacy pointer versions, through activation
- add fresh-process regressions for delayed certification I/O, exact pre-activation candidate reopen, process death, certification write failure, digest tampering, and legacy certificate upgrades

## Performance

Publication still performs one full physical hash. The independent reopen validates the durable certificate, generation metadata, and search structure without a second artifact-body hash or stored-document audit.

## Validation

- all 85 Bazel affected targets passed
- CI-mode Clippy and unit tests passed for ctx-history-index-generation, ctx-history-index-query, and ctx-history-index
- source-backed legacy-pointer recovery and refresh compatibility suites passed
- x86_64-pc-windows-gnu cargo check passed for all three modified crates
- repository policy, rustfmt, and git diff checks passed
- two-stage independent code review completed; final verdict: ship, no blocking findings