### PR TITLE
fix(upgrade): repair legacy semantic runtime

### DIFF
--- a/contracts/telemetry-v1/source-provenance.json
+++ b/contracts/telemetry-v1/source-provenance.json
@@ -16,7 +16,7 @@
     "crates/ctx-client-observability/src/analytics/sender.rs": "c50a45a1db9554a4fe6000e97baf731d3bc25a1536f6d950450b141f50661eb2",
     "crates/ctx-cli/src/upgrade/command.rs": "0e0929c0cc854bf3d79637b293159dde3a6bd09fe06d5067e6506d2e036a5e10",
     "crates/ctx-cli/src/upgrade/ports.rs": "08e16fd1d1ad294cad261d0355d0a63ae24c0c9420b127d9739505fbb5696650",
-    "crates/ctx-upgrade-engine/src/upgrade/command/daemon.rs": "294ee5c5b425747ecdc01648476c1686fabc1e221d927b640b56e8f5eaea2386",
+    "crates/ctx-upgrade-engine/src/upgrade/command/daemon.rs": "0606db67fbadfec3c830571b99da65edbe77a4275700b68e72c05223580a790a",
     "crates/ctx-upgrade-engine/src/upgrade/state.rs": "77657769f52ab3dbefa7a66c2f714bf4bc8309bada5792a6ca2c473647a29dd8"
   }
 }

--- a/crates/ctx-upgrade-engine/src/upgrade/command.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/command.rs
@@ -14,8 +14,8 @@ use ctx_history_platform::platform_security::{
 
 use super::download::DownloadedArtifact;
 use super::install::{
-    apply_artifact, capture_install_snapshot, current_install_path, pending_recovery,
-    recover_interrupted_install, remove_terminal_recovery, semantic_install_required, ApplyResult,
+    apply_artifact, capture_install_snapshot, classify_repair_requirements, current_install_path,
+    pending_recovery, recover_interrupted_install, remove_terminal_recovery, ApplyResult,
     InstallRecovery, PendingRecovery, TerminalRecovery,
 };
 #[cfg(unix)]
@@ -517,9 +517,13 @@ fn apply_upgrade<D: DaemonUpgradePort + ?Sized>(
     let attempt = begin_manual_attempt_locked(data_root, &upgrade_lock, "manual_apply")?;
     let result = (|| -> Result<UpgradeOutcome> {
         let plan = build_upgrade_plan(engine, &upgrade_lock, policy, channel_override, true)?;
-        let semantic_repair_required =
-            semantic_install_required(engine.semantic_layout, &plan, data_root)?;
-        if !plan.update_available && !semantic_repair_required {
+        let repairs = classify_repair_requirements(
+            engine.semantic_layout,
+            &plan,
+            data_root,
+            policy.semantic_enabled,
+        )?;
+        if !plan.update_available && !repairs.any() {
             write_state_checked_locked(
                 data_root,
                 &upgrade_lock,
@@ -573,6 +577,11 @@ fn apply_upgrade<D: DaemonUpgradePort + ?Sized>(
                         "ctx {} would upgrade to {}.",
                         plan.current_version, plan.latest_version
                     )
+                } else if repairs.legacy_runtime {
+                    format!(
+                        "ctx {} would repair its signed legacy ONNX Runtime installation.",
+                        plan.current_version
+                    )
                 } else {
                     format!(
                         "ctx {} would provision signed Semantic model and runtime assets.",
@@ -601,7 +610,8 @@ fn apply_upgrade<D: DaemonUpgradePort + ?Sized>(
         } else {
             None
         };
-        let mut runtime_artifact = if plan.update_available && plan.semantic_provisioning.is_none()
+        let mut runtime_artifact = if (plan.update_available || repairs.legacy_runtime)
+            && plan.semantic_provisioning.is_none()
         {
             match (
                 plan.metadata.onnxruntime.as_ref(),
@@ -625,7 +635,7 @@ fn apply_upgrade<D: DaemonUpgradePort + ?Sized>(
             None
         };
         let mut semantic_artifacts = Vec::new();
-        if semantic_repair_required {
+        if repairs.catalog {
             let provisioning = plan
                 .semantic_provisioning
                 .as_ref()
@@ -696,6 +706,9 @@ fn apply_upgrade<D: DaemonUpgradePort + ?Sized>(
                     plan.latest_version,
                     plan.install_path.display()
                 )
+            } else if repairs.legacy_runtime {
+                "scheduled signed legacy ONNX Runtime repair; replacement will finish after this process exits"
+                    .to_owned()
             } else {
                 "scheduled signed Semantic asset repair; replacement will finish after this process exits"
                     .to_owned()
@@ -737,6 +750,11 @@ fn apply_upgrade<D: DaemonUpgradePort + ?Sized>(
                 plan.current_version,
                 plan.latest_version,
                 plan.install_path.display()
+            )
+        } else if repairs.legacy_runtime {
+            format!(
+                "repaired signed legacy ONNX Runtime installation for ctx {}",
+                plan.current_version
             )
         } else {
             format!(

--- a/crates/ctx-upgrade-engine/src/upgrade/command/daemon.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/command/daemon.rs
@@ -140,9 +140,13 @@ where
             semantic_enabled: current.semantic_enabled(),
         };
         let plan = build_upgrade_plan(engine, lock.as_ref().unwrap(), policy, None, true)?;
-        let semantic_repair_required =
-            semantic_install_required(engine.semantic_layout, &plan, data_root)?;
-        if !plan.update_available && !semantic_repair_required {
+        let repairs = classify_repair_requirements(
+            engine.semantic_layout,
+            &plan,
+            data_root,
+            policy.semantic_enabled,
+        )?;
+        if !plan.update_available && !repairs.any() {
             write_state_checked_locked(
                 data_root,
                 lock.as_ref().unwrap(),
@@ -197,7 +201,9 @@ where
         } else {
             None
         };
-        let runtime_artifact = if plan.update_available && plan.semantic_provisioning.is_none() {
+        let runtime_artifact = if (plan.update_available || repairs.legacy_runtime)
+            && plan.semantic_provisioning.is_none()
+        {
             match (
                 plan.metadata.onnxruntime.as_ref(),
                 plan.onnxruntime_artifact_url(),
@@ -219,7 +225,7 @@ where
             None
         };
         let mut semantic_artifacts = Vec::new();
-        if semantic_repair_required {
+        if repairs.catalog {
             let provisioning = plan
                 .semantic_provisioning
                 .as_ref()

--- a/crates/ctx-upgrade-engine/src/upgrade/install.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install.rs
@@ -33,7 +33,6 @@ pub use marker::{
     unmanaged_install_conversion_guidance, InstallMarker,
 };
 pub use marker::{managed_install_marker_for_current_exe, ManagedInstallMarker};
-pub(super) use runtime::semantic_install_required;
 pub(super) use transaction::ApplyResult;
 #[cfg(windows)]
 pub(in crate::upgrade) use transaction::HelperOutcome;
@@ -44,6 +43,42 @@ pub(super) use transaction::{PendingRecovery, TerminalRecovery};
 use self::lock::canonical_executable;
 pub(in crate::upgrade) use self::lock::InstallationLock;
 use super::{ReleaseProcessPort, SemanticLayoutPort, UpgradePlan};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct RepairRequirements {
+    pub(super) catalog: bool,
+    pub(super) legacy_runtime: bool,
+}
+
+impl RepairRequirements {
+    pub(super) fn any(self) -> bool {
+        self.catalog || self.legacy_runtime
+    }
+}
+
+pub(super) fn classify_repair_requirements(
+    layout: &dyn SemanticLayoutPort,
+    plan: &UpgradePlan,
+    data_root: &Path,
+    semantic_enabled: bool,
+) -> Result<RepairRequirements> {
+    let catalog = runtime::semantic_install_required(layout, plan, data_root)?;
+    let legacy_runtime = if !plan.update_available
+        && plan.latest_version == plan.current_version
+        && semantic_enabled
+        && plan.semantic_provisioning.is_none()
+        && plan.metadata.onnxruntime.is_some()
+    {
+        runtime::legacy_runtime_install_required(plan, data_root)?
+    } else {
+        false
+    };
+    debug_assert!(!(catalog && legacy_runtime));
+    Ok(RepairRequirements {
+        catalog,
+        legacy_runtime,
+    })
+}
 
 #[cfg(unix)]
 pub(in crate::upgrade) fn discard_legacy_previous_binary(install_path: &Path) -> Result<()> {

--- a/crates/ctx-upgrade-engine/src/upgrade/install/runtime.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/runtime.rs
@@ -25,6 +25,9 @@ use super::archive::{extract_runtime_archive, extract_semantic_archive};
 use super::durability::sync_directory;
 use super::durability::sync_parent;
 
+mod legacy;
+pub(in crate::upgrade) use legacy::install_required as legacy_runtime_install_required;
+
 #[derive(Debug)]
 pub(super) struct StagedRuntime {
     pub(super) staged_path: PathBuf,
@@ -153,7 +156,16 @@ fn canonicalize_selected_root(root: &Path) -> Result<PathBuf> {
 fn ensure_private_directory(path: &Path) -> Result<()> {
     match fs::create_dir(path) {
         Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let metadata = fs::symlink_metadata(path)
+                .with_context(|| format!("inspect runtime directory {}", path.display()))?;
+            if !metadata.is_dir() || metadata.file_type().is_symlink() {
+                return Err(anyhow!(
+                    "runtime directory is not a real directory: {}",
+                    path.display()
+                ));
+            }
+        }
         Err(error) => {
             return Err(error)
                 .with_context(|| format!("create runtime directory {}", path.display()));

--- a/crates/ctx-upgrade-engine/src/upgrade/install/runtime/legacy.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/runtime/legacy.rs
@@ -1,0 +1,237 @@
+use std::{collections::BTreeSet, fs, io::Read as _, path::Path};
+
+use anyhow::{anyhow, Context, Result};
+use serde::Deserialize;
+
+use super::{open_nofollow, semantic_runtime_root, RUNTIME_INSTALL_MANIFEST};
+use crate::upgrade::UpgradePlan;
+
+const RUNTIME_INSTALL_MANIFEST_MAX_BYTES: usize = 1024 * 1024;
+const RUNTIME_VERSION_MAX_BYTES: usize = 64;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyRuntimeInstallManifest {
+    schema_version: u32,
+    manager: String,
+    metadata_trust: String,
+    runtime: String,
+    platform: String,
+    version: String,
+    sha256: String,
+    artifact_url: String,
+    installed_at: String,
+}
+
+pub(in crate::upgrade) fn install_required(plan: &UpgradePlan, data_root: &Path) -> Result<bool> {
+    let runtime = plan
+        .metadata
+        .onnxruntime
+        .as_ref()
+        .ok_or_else(|| anyhow!("legacy runtime repair has no signed ONNX Runtime metadata"))?;
+    let runtime_root = semantic_runtime_root(data_root)?;
+    match fs::symlink_metadata(&runtime_root) {
+        Ok(metadata) if !metadata.is_dir() || metadata.file_type().is_symlink() => {
+            return Err(anyhow!(
+                "configured runtime root is not a real directory: {}",
+                runtime_root.display()
+            ));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("inspect runtime root {}", runtime_root.display()));
+        }
+    }
+    let target = runtime_root
+        .join("onnxruntime")
+        .join(&runtime.version)
+        .join(&plan.platform);
+    Ok(verify_install(plan, &runtime_root, &target).is_err())
+}
+
+fn verify_install(plan: &UpgradePlan, runtime_root: &Path, target: &Path) -> Result<()> {
+    let runtime = plan
+        .metadata
+        .onnxruntime
+        .as_ref()
+        .ok_or_else(|| anyhow!("legacy runtime verification has no signed metadata"))?;
+    let mut component = runtime_root.to_path_buf();
+    for name in [
+        "onnxruntime",
+        runtime.version.as_str(),
+        plan.platform.as_str(),
+    ] {
+        component.push(name);
+        let metadata = fs::symlink_metadata(&component)
+            .with_context(|| format!("inspect legacy runtime target {}", component.display()))?;
+        if metadata.file_type().is_symlink() {
+            return Err(anyhow!(
+                "legacy runtime target contains a symlink: {}",
+                component.display()
+            ));
+        }
+    }
+
+    verify_layout(target, &plan.platform, &runtime.version)?;
+    let manifest_path = target.join(RUNTIME_INSTALL_MANIFEST);
+    let bytes = read_bounded_regular_file(
+        &manifest_path,
+        RUNTIME_INSTALL_MANIFEST_MAX_BYTES,
+        "runtime install manifest",
+    )?;
+    let manifest: LegacyRuntimeInstallManifest = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parse runtime manifest {}", manifest_path.display()))?;
+    let artifact_url = plan
+        .onnxruntime_artifact_url()
+        .ok_or_else(|| anyhow!("legacy runtime verification has no artifact URL"))?;
+    if manifest.schema_version != 1
+        || manifest.manager != "ctx-hosted-installer"
+        || manifest.metadata_trust != "signed-release-metadata"
+        || manifest.runtime != "onnxruntime"
+        || manifest.platform != plan.platform
+        || manifest.version != runtime.version
+        || manifest.sha256 != runtime.sha256
+        || manifest.artifact_url != artifact_url
+        || manifest.installed_at.trim().is_empty()
+    {
+        return Err(anyhow!(
+            "legacy runtime install manifest does not match signed release metadata"
+        ));
+    }
+    Ok(())
+}
+
+fn verify_layout(root: &Path, platform: &str, version: &str) -> Result<()> {
+    let root_metadata = fs::symlink_metadata(root)
+        .with_context(|| format!("inspect legacy runtime installation {}", root.display()))?;
+    if !root_metadata.is_dir() || root_metadata.file_type().is_symlink() {
+        return Err(anyhow!(
+            "legacy runtime installation root is not a real directory: {}",
+            root.display()
+        ));
+    }
+    // The extracted-file allowlist is kept identical to the legacy archive
+    // extractor contract. The installer-owned manifest is the sole allowed
+    // post-extraction addition.
+    let mut expected_files = expected_files(platform)?;
+    expected_files.insert(RUNTIME_INSTALL_MANIFEST.to_owned());
+    let mut expected = expected_files.clone();
+    expected.insert("lib".to_owned());
+    let mut actual = BTreeSet::new();
+    let mut folded = BTreeSet::new();
+    let mut pending = vec![(root.to_path_buf(), String::new())];
+    while let Some((directory, relative_dir)) = pending.pop() {
+        for entry in fs::read_dir(&directory)? {
+            let entry = entry?;
+            let name = entry
+                .file_name()
+                .into_string()
+                .map_err(|_| anyhow!("legacy runtime contains a non-UTF-8 path"))?;
+            let relative = if relative_dir.is_empty() {
+                name
+            } else {
+                format!("{relative_dir}/{name}")
+            };
+            if !folded.insert(relative.to_ascii_lowercase()) {
+                return Err(anyhow!(
+                    "legacy runtime contains a case-colliding path: {relative}"
+                ));
+            }
+            let metadata = fs::symlink_metadata(entry.path())?;
+            if metadata.file_type().is_symlink() {
+                return Err(anyhow!("legacy runtime contains a link: {relative}"));
+            }
+            if metadata.is_dir() {
+                if relative != "lib" {
+                    return Err(anyhow!(
+                        "legacy runtime contains an unexpected directory: {relative}"
+                    ));
+                }
+                pending.push((entry.path(), relative.clone()));
+            } else if !metadata.is_file() || !expected_files.contains(&relative) {
+                return Err(anyhow!(
+                    "legacy runtime contains an unexpected file: {relative}"
+                ));
+            }
+            actual.insert(relative);
+        }
+    }
+    if actual != expected {
+        return Err(anyhow!(
+            "legacy runtime installed layout does not match the canonical extracted layout"
+        ));
+    }
+    let version_path = root.join("VERSION_NUMBER");
+    let actual_version = read_bounded_regular_file(
+        &version_path,
+        RUNTIME_VERSION_MAX_BYTES,
+        "runtime version file",
+    )?;
+    if actual_version != format!("{version}\n").as_bytes() {
+        return Err(anyhow!("runtime VERSION_NUMBER is not exactly {version}"));
+    }
+    Ok(())
+}
+
+fn expected_files(platform: &str) -> Result<BTreeSet<String>> {
+    #[cfg(unix)]
+    {
+        let library = if platform.starts_with("macos-") {
+            "libonnxruntime.dylib"
+        } else if platform.starts_with("linux-") {
+            "libonnxruntime.so"
+        } else {
+            return Err(anyhow!("unsupported legacy runtime platform {platform}"));
+        };
+        return Ok(BTreeSet::from([
+            "LICENSE".to_owned(),
+            "ThirdPartyNotices.txt".to_owned(),
+            "VERSION_NUMBER".to_owned(),
+            "GIT_COMMIT_ID".to_owned(),
+            format!("lib/{library}"),
+        ]));
+    }
+    #[cfg(windows)]
+    {
+        if platform != "windows-x64" {
+            return Err(anyhow!("unsupported legacy runtime platform {platform}"));
+        }
+        return Ok([
+            "LICENSE",
+            "MICROSOFT_VC_RUNTIME_LICENSE.rtf",
+            "ThirdPartyNotices.txt",
+            "VERSION_NUMBER",
+            "GIT_COMMIT_ID",
+            "lib/onnxruntime.dll",
+            "lib/msvcp140.dll",
+            "lib/msvcp140_1.dll",
+            "lib/vcruntime140.dll",
+            "lib/vcruntime140_1.dll",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect());
+    }
+    #[allow(unreachable_code)]
+    Err(anyhow!("legacy runtime verification is unsupported"))
+}
+
+fn read_bounded_regular_file(path: &Path, max_bytes: usize, label: &str) -> Result<Vec<u8>> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("inspect {label} {}", path.display()))?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return Err(anyhow!("{label} is not a regular file"));
+    }
+    if metadata.len() > max_bytes as u64 {
+        return Err(anyhow!("{label} is too large"));
+    }
+    let file = open_nofollow(path).with_context(|| format!("open {label} {}", path.display()))?;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(max_bytes as u64 + 1).read_to_end(&mut bytes)?;
+    if bytes.len() > max_bytes {
+        return Err(anyhow!("{label} is too large"));
+    }
+    Ok(bytes)
+}

--- a/crates/ctx-upgrade-engine/tests/contracts/upgrade/release_validation.rs
+++ b/crates/ctx-upgrade-engine/tests/contracts/upgrade/release_validation.rs
@@ -180,3 +180,73 @@ fn upgrade_rejects_unsafe_metadata_and_bad_artifacts() {
     ));
     assert!(stderr.contains("artifact checksum mismatch"), "{stderr}");
 }
+
+#[cfg(unix)]
+#[test]
+fn semantic_enabled_same_version_upgrade_repairs_missing_legacy_runtime() {
+    let temp = tempdir();
+    let release = fake_legacy_release(&temp, env!("CARGO_PKG_VERSION"));
+    let runtime = add_fake_release_runtime(&temp, &release);
+    let marker_path = install_marker_path(&release.target);
+    let cli_before = fs::read(&release.target).unwrap();
+    let marker_before = fs::read(&marker_path).unwrap();
+
+    let applied = json_output(
+        fake_release_env(ctx(&temp).args(["upgrade", "--format=json"]), &release)
+            .env("CTX_SEARCH_SEMANTIC", "true"),
+    );
+
+    assert_eq!(applied["status"], "applied");
+    assert_eq!(fs::read(&release.target).unwrap(), cli_before);
+    assert_eq!(fs::read(&marker_path).unwrap(), marker_before);
+    assert_eq!(
+        fs::read_to_string(runtime.target.join("VERSION_NUMBER")).unwrap(),
+        format!("{}\n", runtime.version)
+    );
+
+    let repeated = json_output(
+        fake_release_env(ctx(&temp).args(["upgrade", "--format=json"]), &release)
+            .env("CTX_SEARCH_SEMANTIC", "true"),
+    );
+    assert_eq!(repeated["status"], "up_to_date");
+    assert_eq!(repeated["applied"], false);
+    assert_eq!(fs::read(&release.target).unwrap(), cli_before);
+    assert_eq!(fs::read(&marker_path).unwrap(), marker_before);
+
+    let manifest_path = runtime.target.join("ctx-runtime-install.json");
+    let mut manifest: Value = serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
+    manifest["sha256"] = json!("f".repeat(64));
+    fs::write(
+        &manifest_path,
+        serde_json::to_vec_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+
+    let repaired = json_output(
+        fake_release_env(ctx(&temp).args(["upgrade", "--format=json"]), &release)
+            .env("CTX_SEARCH_SEMANTIC", "true"),
+    );
+    assert_eq!(repaired["status"], "applied");
+    let repaired_manifest: Value =
+        serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
+    assert_eq!(repaired_manifest["sha256"], runtime.artifact_sha);
+    assert_eq!(fs::read(&release.target).unwrap(), cli_before);
+    assert_eq!(fs::read(&marker_path).unwrap(), marker_before);
+}
+
+#[cfg(unix)]
+#[test]
+fn semantic_disabled_same_version_upgrade_does_not_install_legacy_runtime() {
+    let temp = tempdir();
+    let release = fake_legacy_release(&temp, env!("CARGO_PKG_VERSION"));
+    let runtime = add_fake_release_runtime(&temp, &release);
+
+    let outcome = json_output(
+        fake_release_env(ctx(&temp).args(["upgrade", "--format=json"]), &release)
+            .env("CTX_SEARCH_SEMANTIC", "false"),
+    );
+
+    assert_eq!(outcome["status"], "up_to_date");
+    assert_eq!(outcome["applied"], false);
+    assert!(!runtime.target.exists());
+}


### PR DESCRIPTION
Fixes #678

## Summary

- repair a missing or corrupt legacy signed semantic runtime during a same-version upgrade
- preserve the ordinary up-to-date result when the runtime is healthy or semantic search is disabled
- cover missing, corrupt, disabled, and idempotent same-version cases

This is the CLI half of the hosted semantic-install repair. The installer rollout uses the supported `upgrade --format=json` interface; this change makes that same-version handoff actually restore legacy runtime assets.

## Testing

- `scripts/bazelw test //crates/ctx-upgrade-engine:upgrade_tests --config=test`
- `scripts/bazel-affected.sh origin/main` (93/93)
- `cargo fmt --all -- --check`
- native Windows `cargo check -p ctx-upgrade-engine` through ctx-lab
- repository LOC, ownership, provenance, and diff checks