### PR TITLE
fix(claude): derive preflight and projection event keys from one place

### DIFF
--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed.rs
@@ -872,6 +872,15 @@ fn session_identity(source: &SourceKey, native_key: TypedKey) -> Result<StableEn
     .map_err(contract)
 }
 
+/// Key parts for a row that carries a native record id.
+///
+/// The preflight audit and the projection below must derive byte-identical
+/// event identities for the same row. Building the parts once is what stops the
+/// two from drifting apart.
+fn native_event_key_parts(native_record_id: TypedKey, subrecord_index: u64) -> Vec<TypedKey> {
+    vec![native_record_id, TypedKey::U64(subrecord_index)]
+}
+
 fn native_item_key(
     row: &ClaudeRetainedRow,
     fallback_identity: Option<FallbackEventIdentity>,
@@ -879,10 +888,10 @@ fn native_item_key(
     if let Some(native_record_id) = row.native_record_id.as_deref() {
         return NativeItemKey::composite(
             NATIVE_EVENT_KEY_NAMESPACE,
-            vec![
+            native_event_key_parts(
                 TypedKey::utf8(native_record_id).map_err(contract)?,
-                TypedKey::U64(row.identity.source_subrecord_index),
-            ],
+                row.identity.source_subrecord_index,
+            ),
         )
         .map_err(contract);
     }
@@ -901,10 +910,10 @@ fn native_event_typed_key(
     fallback_identity: Option<FallbackEventIdentity>,
 ) -> Result<TypedKey> {
     if let Some(native_record_id) = row.native_record_id.as_deref() {
-        return TypedKey::composite(vec![
+        return TypedKey::composite(native_event_key_parts(
             TypedKey::utf8(native_record_id).map_err(contract)?,
-            TypedKey::U64(row.identity.source_subrecord_index),
-        ])
+            row.identity.source_subrecord_index,
+        ))
         .map_err(contract);
     }
     let fallback_identity = fallback_identity.ok_or(CaptureError::SystemInvariant(

--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/preflight.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/preflight.rs
@@ -11,7 +11,7 @@ use ctx_history_provider_runtime::CaptureError;
 use sha2::{Digest, Sha256};
 
 use super::{
-    claude_annotation, contract, Binding, JsonlReader, LOGICAL_EVENT_KIND,
+    claude_annotation, contract, native_event_key_parts, Binding, JsonlReader, LOGICAL_EVENT_KIND,
     NATIVE_EVENT_KEY_NAMESPACE,
 };
 use crate::claude::nativepath::{
@@ -237,10 +237,7 @@ pub(super) fn stable_native_event_identity(
     )?;
     let native_item_key = NativeItemKey::composite(
         NATIVE_EVENT_KEY_NAMESPACE,
-        vec![
-            native_record_id,
-            TypedKey::U64(row.identity.source_subrecord_index),
-        ],
+        native_event_key_parts(native_record_id, row.identity.source_subrecord_index),
     )
     .map_err(|error| ClaudeRowValidationError::Fatal(contract(error)))?;
     derive_event_id(EventIdentityInput {

--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/tests.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/tests.rs
@@ -1,7 +1,8 @@
 use std::{collections::HashMap, path::PathBuf};
 
 use ctx_history_core::{
-    ActivityJsonCapture, ActivityTextCapture, LiteralFactKind, ProjectionContractError, TypedKey,
+    derive_event_id, ActivityJsonCapture, ActivityTextCapture, EventIdentityInput, LiteralFactKind,
+    ProjectionContractError, TypedKey,
 };
 use sha2::{Digest, Sha256};
 
@@ -12,8 +13,8 @@ use super::preflight::{
     ClaudeRowValidationError, MAX_PREFLIGHT_EVENT_IDENTITIES,
 };
 use super::{
-    claude_annotation, parse_native_record, session_identity, session_typed_key, source_key,
-    ClaudePhysicalLocator, ClaudeSessionKey,
+    claude_annotation, native_item_key, parse_native_record, session_identity, session_typed_key,
+    source_key, ClaudePhysicalLocator, ClaudeSessionKey, LOGICAL_EVENT_KIND,
 };
 
 #[test]
@@ -167,6 +168,42 @@ fn repeated_native_uuid_and_subrecord_index_repeat_the_stable_event_identity() {
     assert_eq!(
         stable_native_event_identity(&parse("first"), &source, session_id).unwrap(),
         stable_native_event_identity(&parse("second"), &source, session_id).unwrap()
+    );
+}
+
+#[test]
+fn preflight_and_projection_agree_on_the_native_event_identity() {
+    let key = ClaudeSessionKey {
+        root_session_id: "session".to_owned(),
+        workflow_run_id: None,
+        agent_id: None,
+    };
+    let source = source_key(None, &key).unwrap();
+    let session_id = session_identity(&source, session_typed_key(&key).unwrap()).unwrap();
+    let bytes = serde_json::to_vec(&serde_json::json!({
+        "type": "user",
+        "uuid": "shared",
+        "message": {"role": "user", "content": "body"}
+    }))
+    .unwrap();
+    let row = parse_native_record(&bytes, 0, &locator(&bytes))
+        .unwrap()
+        .rows
+        .remove(0);
+
+    let projected = derive_event_id(EventIdentityInput {
+        source: &source,
+        session_id,
+        logical_item_kind: LOGICAL_EVENT_KIND,
+        native_item_key: &native_item_key(&row, None).unwrap(),
+        subrecord_selector: None,
+    })
+    .unwrap();
+
+    assert_eq!(
+        stable_native_event_identity(&row, &source, session_id).unwrap(),
+        Some(projected),
+        "preflight quarantines a source on identities the projection never produces"
     );
 }
 


### PR DESCRIPTION
## Summary

- extract the native event key parts into one helper shared by the preflight audit and both projection key builders
- add a test asserting the preflight and the projection derive the same event identity for one row

No behavior change. All three call sites already produced identical keys.

## Why

#676 added `preflight::stable_native_event_identity`, which derives a Claude event identity so a transcript repeating one can be quarantined without failing every provider. It builds the key inline:

```rust
vec![
    native_record_id,
    TypedKey::U64(row.identity.source_subrecord_index),
]
```

`native_item_key` and `native_event_typed_key` build the same shape independently in `source_backed.rs`. That is three copies of one definition, with nothing failing if they drift.

They agree today, so this change is inert on its own. It matters for the next change to that key.

#663 adds occurrence disambiguation to the projection key so a repeated `uuid` stops colliding. That PR predates #676 and does not touch `preflight.rs`. Rebased onto main as written, the projection would stop producing duplicate identities while the preflight kept deriving the old two-part key, still found a collision, and still quarantined the whole transcript. The fix would merge and change nothing for the users hitting it.

Its description also notes that `native_item_key` and `native_event_typed_key` "shared the same parts already, so they now share one `event_key_parts`", which is the same consolidation as here; #676 simply added a third copy after that PR was written.

I confirmed the failure mode rather than assuming it, by temporarily giving the projection an extra key part and running the new test:

```text
assertion `left == right` failed: preflight quarantines a source on
identities the projection never produces
```

Reverted before committing.

## Testing

- `cargo test -p ctx-history-provider-claude-cursor --lib`, 35 passed
- `cargo fmt --all -- --check`
- `cargo clippy -p ctx-history-provider-claude-cursor --all-targets`, no warnings in this crate

I have not run the Bazel gates. `scripts/bazelw` pulls a pinned toolchain that is not installed here, so I stayed with cargo for the touched crate. Point me at the gate you want and I will run it.
