### PR TITLE
Report refresh terminal convergence

### DIFF
--- a/contracts/telemetry-v1/source-provenance.json
+++ b/contracts/telemetry-v1/source-provenance.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "repository": "ctxrs/ctx",
-  "base_commit": "b33107ed37ead44e20df85da789258826f9724ae",
+  "base_commit": "cccd67b6f653f85862acdb48a4924e18a5c4fcbe",
   "provenance_kind": "content_addressed_candidate",
   "scope": "selected_typed_telemetry_contract_inventory",
   "files": {
@@ -11,9 +11,9 @@
     "crates/ctx-client-observability/src/analytics/mcp.rs": "66d95252fe028e45d9df9769cd9b9eccc2282c6957e3fc2286e8c36623bebe86",
     "crates/ctx-client-observability/src/analytics/runtime.rs": "b48a7abde2457c047f843e808214685a50d324881a7d8b7b7315c5615213e2c4",
     "crates/ctx-client-observability/src/analytics/buckets.rs": "09fe640f4ccf24ab0a816616ca78561119a497cc9acacb152612c78ae32d1a99",
-    "crates/ctx-client-observability/src/analytics/provider.rs": "7bf6c6f082adddf62f87309c68ccea24a7f81465aba5719cd2c22d00360fb1ff",
+    "crates/ctx-client-observability/src/analytics/provider.rs": "c9075696c951e77a4a45b60705e482101c49bc02f168648781ca56f693f3d1f7",
     "crates/ctx-client-observability/src/analytics/product.rs": "b484e53d7ca99d788f6cfdee93b595f527363c41ac6855c07f7855e09b5cc577",
-    "crates/ctx-client-observability/src/analytics/sender.rs": "c50a45a1db9554a4fe6000e97baf731d3bc25a1536f6d950450b141f50661eb2",
+    "crates/ctx-client-observability/src/analytics/sender.rs": "2d01f9c68c7c701c4c807afa833b565f900053f4d2761c7b0c077377e2861f21",
     "crates/ctx-cli/src/upgrade/command.rs": "d3dabb8e56d33f41903181acd917cda8407f78d3f180252bb1792c0846d433e5",
     "crates/ctx-cli/src/upgrade/ports.rs": "08e16fd1d1ad294cad261d0355d0a63ae24c0c9420b127d9739505fbb5696650",
     "crates/ctx-upgrade-engine/src/upgrade/command/daemon.rs": "e9dc563d7581bdc3d43c51371c192f83d20113600c05578eac7a81e2f83044da",

--- a/contracts/telemetry-v1/source-provenance.json
+++ b/contracts/telemetry-v1/source-provenance.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "repository": "ctxrs/ctx",
-  "base_commit": "cccd67b6f653f85862acdb48a4924e18a5c4fcbe",
+  "base_commit": "d429e3211aa232de07777c188d0390d4c78dd0ff",
   "provenance_kind": "content_addressed_candidate",
   "scope": "selected_typed_telemetry_contract_inventory",
   "files": {

--- a/crates/ctx-cli/src/observability_composition.rs
+++ b/crates/ctx-cli/src/observability_composition.rs
@@ -174,7 +174,7 @@ mod tests {
         assert_eq!(provenance["repository"], "ctxrs/ctx");
         assert_eq!(
             provenance["base_commit"],
-            "cccd67b6f653f85862acdb48a4924e18a5c4fcbe"
+            "d429e3211aa232de07777c188d0390d4c78dd0ff"
         );
         assert_eq!(provenance["provenance_kind"], "content_addressed_candidate");
         assert_eq!(

--- a/crates/ctx-cli/src/observability_composition.rs
+++ b/crates/ctx-cli/src/observability_composition.rs
@@ -174,7 +174,7 @@ mod tests {
         assert_eq!(provenance["repository"], "ctxrs/ctx");
         assert_eq!(
             provenance["base_commit"],
-            "b33107ed37ead44e20df85da789258826f9724ae"
+            "cccd67b6f653f85862acdb48a4924e18a5c4fcbe"
         );
         assert_eq!(provenance["provenance_kind"], "content_addressed_candidate");
         assert_eq!(

--- a/crates/ctx-client-observability/src/analytics/provider.rs
+++ b/crates/ctx-client-observability/src/analytics/provider.rs
@@ -355,12 +355,24 @@ pub struct ForegroundProviderRefreshV1 {
     pub performance: Option<ProviderRefreshPerformanceV1>,
 }
 
+/// Optional bucketed health facts from the daemon's durable terminal job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderRefreshTerminalHealthV1 {
+    pub queue_wait_duration: Option<DurationBucket>,
+    pub discovery_duration: Option<DurationBucket>,
+    pub scan_stage_duration: Option<DurationBucket>,
+    pub commit_duration: Option<DurationBucket>,
+    pub coalesced_request_count: Option<CountBucket>,
+    pub successor_pending: bool,
+}
+
 #[derive(Debug)]
 pub struct ProviderRefreshCompletedV1 {
     pub surface: Surface,
     pub outcome: Outcome,
     pub duration: DurationBucket,
     pub foreground: Option<ForegroundProviderRefreshV1>,
+    pub terminal_health: Option<ProviderRefreshTerminalHealthV1>,
 }
 
 impl ProviderRefreshCompletedV1 {
@@ -371,6 +383,7 @@ impl ProviderRefreshCompletedV1 {
             outcome,
             duration: duration_bucket(duration),
             foreground: None,
+            terminal_health: None,
         }
     }
 
@@ -385,6 +398,7 @@ impl ProviderRefreshCompletedV1 {
             outcome,
             duration: duration_bucket(duration),
             foreground: Some(foreground),
+            terminal_health: None,
         }
     }
 
@@ -407,7 +421,16 @@ impl ProviderRefreshCompletedV1 {
             outcome,
             duration,
             foreground: Some(foreground),
+            terminal_health: None,
         }
+    }
+
+    pub fn with_terminal_health(
+        mut self,
+        terminal_health: ProviderRefreshTerminalHealthV1,
+    ) -> Self {
+        self.terminal_health = Some(terminal_health);
+        self
     }
 }
 
@@ -506,30 +529,40 @@ mod tests {
     }
 
     #[test]
-    fn daemon_setup_refresh_serializes_sparse_receipt_facts_without_cli_defaults() {
-        let event = PublicEventV1::ProviderRefreshCompleted(ProviderRefreshCompletedV1::bucketed(
-            Surface::Daemon,
-            Outcome::Success,
-            duration_bucket(Duration::from_secs(2)),
-            ForegroundProviderRefreshV1 {
-                provider: Some(CaptureProvider::Codex),
-                trigger: ProviderRefreshTrigger::Setup,
-                source_mode: Some(ProviderRefreshSourceMode::Discovered),
-                change: ProviderRefreshChange::Changed,
-                content_evidence: ProviderRefreshContentEvidence::Unknown,
-                work_kind: Some(ProviderRefreshWorkKind::Fresh),
-                refresh_result: ProviderRefreshResult::Complete,
-                core_result: ProviderCoreResult::Complete,
-                failure_scope: ProviderRefreshFailureScope::None,
-                failure_type: ProviderRefreshFailureType::None,
-                work_remaining: false,
-                retired_records: None,
-                counts: Some(ProviderRefreshCountsV1::from_refresh_receipt(
-                    2, 7, 0, 0, 4096,
-                )),
-                performance: None,
-            },
-        ));
+    fn daemon_setup_refresh_serializes_sparse_receipt_facts_and_present_zero_health() {
+        let event = PublicEventV1::ProviderRefreshCompleted(
+            ProviderRefreshCompletedV1::bucketed(
+                Surface::Daemon,
+                Outcome::Success,
+                duration_bucket(Duration::from_secs(2)),
+                ForegroundProviderRefreshV1 {
+                    provider: Some(CaptureProvider::Codex),
+                    trigger: ProviderRefreshTrigger::Setup,
+                    source_mode: Some(ProviderRefreshSourceMode::Discovered),
+                    change: ProviderRefreshChange::Changed,
+                    content_evidence: ProviderRefreshContentEvidence::Unknown,
+                    work_kind: Some(ProviderRefreshWorkKind::Fresh),
+                    refresh_result: ProviderRefreshResult::Complete,
+                    core_result: ProviderCoreResult::Complete,
+                    failure_scope: ProviderRefreshFailureScope::None,
+                    failure_type: ProviderRefreshFailureType::None,
+                    work_remaining: false,
+                    retired_records: None,
+                    counts: Some(ProviderRefreshCountsV1::from_refresh_receipt(
+                        2, 7, 0, 0, 4096,
+                    )),
+                    performance: None,
+                },
+            )
+            .with_terminal_health(ProviderRefreshTerminalHealthV1 {
+                queue_wait_duration: Some(duration_bucket(Duration::ZERO)),
+                discovery_duration: None,
+                scan_stage_duration: Some(duration_bucket(Duration::from_secs(2))),
+                commit_duration: Some(duration_bucket(Duration::from_secs(6))),
+                coalesced_request_count: Some(count_bucket(0)),
+                successor_pending: true,
+            }),
+        );
         let occurred_at = chrono::DateTime::parse_from_rfc3339("2026-07-22T12:34:00Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
@@ -541,6 +574,23 @@ mod tests {
         assert_eq!(serialized["properties"]["work_kind"], "fresh");
         assert_eq!(serialized["properties"]["sessions_bucket"], "6-20");
         assert_eq!(serialized["properties"]["bytes_bucket"], "lt_100kb");
+        assert_eq!(
+            serialized["properties"]["refresh_queue_wait_duration_bucket"],
+            "lt_100ms"
+        );
+        assert_eq!(
+            serialized["properties"]["refresh_scan_stage_duration_bucket"],
+            "lt_5s"
+        );
+        assert_eq!(
+            serialized["properties"]["refresh_commit_duration_bucket"],
+            "lt_30s"
+        );
+        assert_eq!(
+            serialized["properties"]["refresh_coalesced_request_count_bucket"],
+            "0"
+        );
+        assert_eq!(serialized["properties"]["refresh_successor_pending"], true);
         let properties = serialized["properties"].as_object().unwrap();
         for absent in [
             "source_files_bucket",
@@ -550,6 +600,7 @@ mod tests {
             "retired_records_bucket",
             "cpu_duration_bucket",
             "observed_process_peak_rss_bucket",
+            "refresh_discovery_duration_bucket",
         ] {
             assert!(!properties.contains_key(absent));
         }

--- a/crates/ctx-client-observability/src/analytics/sender.rs
+++ b/crates/ctx-client-observability/src/analytics/sender.rs
@@ -142,6 +142,9 @@ pub(super) fn serialize_event(
             if let Some(foreground) = event.foreground {
                 insert_provider_refresh_properties(&mut properties, &foreground);
             }
+            if let Some(health) = event.terminal_health {
+                insert_provider_refresh_terminal_health_properties(&mut properties, &health);
+            }
             (
                 "provider_refresh_completed",
                 event.surface,
@@ -281,6 +284,42 @@ fn insert_provider_refresh_properties(
             performance.observed_process_peak_rss,
         );
     }
+}
+
+fn insert_provider_refresh_terminal_health_properties(
+    properties: &mut Map<String, Value>,
+    health: &ProviderRefreshTerminalHealthV1,
+) {
+    insert_optional_duration(
+        properties,
+        "refresh_queue_wait_duration_bucket",
+        health.queue_wait_duration,
+    );
+    insert_optional_duration(
+        properties,
+        "refresh_discovery_duration_bucket",
+        health.discovery_duration,
+    );
+    insert_optional_duration(
+        properties,
+        "refresh_scan_stage_duration_bucket",
+        health.scan_stage_duration,
+    );
+    insert_optional_duration(
+        properties,
+        "refresh_commit_duration_bucket",
+        health.commit_duration,
+    );
+    insert_optional_count(
+        properties,
+        "refresh_coalesced_request_count_bucket",
+        health.coalesced_request_count,
+    );
+    insert_bool(
+        properties,
+        "refresh_successor_pending",
+        health.successor_pending,
+    );
 }
 
 fn insert_client_operation_properties(

--- a/crates/ctx-daemon-cli/src/daemon_service_ports/provider_refresh.rs
+++ b/crates/ctx-daemon-cli/src/daemon_service_ports/provider_refresh.rs
@@ -9,11 +9,12 @@ use ctx_history_refresh::{
 use serde_json::Value;
 
 use ctx_client_observability::analytics::{
-    duration_bucket, DurationBucket, ForegroundProviderRefreshV1, Outcome, ProviderCoreResult,
-    ProviderRefreshChange, ProviderRefreshCompletedV1, ProviderRefreshContentEvidence,
-    ProviderRefreshCountsV1, ProviderRefreshFailureScope, ProviderRefreshFailureType,
-    ProviderRefreshResult, ProviderRefreshSourceMode, ProviderRefreshTrigger,
-    ProviderRefreshWorkKind, PublicEventV1, Surface,
+    count_bucket, duration_bucket, DurationBucket, ForegroundProviderRefreshV1, Outcome,
+    ProviderCoreResult, ProviderRefreshChange, ProviderRefreshCompletedV1,
+    ProviderRefreshContentEvidence, ProviderRefreshCountsV1, ProviderRefreshFailureScope,
+    ProviderRefreshFailureType, ProviderRefreshResult, ProviderRefreshSourceMode,
+    ProviderRefreshTerminalHealthV1, ProviderRefreshTrigger, ProviderRefreshWorkKind,
+    PublicEventV1, Surface,
 };
 
 pub(super) fn provider_refresh_event(
@@ -115,7 +116,8 @@ pub(super) fn provider_refresh_event(
             // observations around only this shared engine call.
             performance: None,
         },
-    );
+    )
+    .with_terminal_health(refresh_terminal_health(job, successor_pending));
     Some(PublicEventV1::ProviderRefreshCompleted(event))
 }
 
@@ -168,8 +170,44 @@ fn failed_provider_refresh_event(
                 counts,
                 performance: None,
             },
-        ),
+        )
+        .with_terminal_health(refresh_terminal_health(job, successor_pending)),
     ))
+}
+
+fn refresh_terminal_health(
+    job: &Value,
+    successor_pending: bool,
+) -> ProviderRefreshTerminalHealthV1 {
+    ProviderRefreshTerminalHealthV1 {
+        queue_wait_duration: elapsed_millis(job, "requested_at_ms", "started_at_ms")
+            .map(duration_bucket),
+        discovery_duration: timing_duration(job, "discovery").map(duration_bucket),
+        scan_stage_duration: timing_duration(job, "scan_stage").map(duration_bucket),
+        commit_duration: timing_duration(job, "commit").map(duration_bucket),
+        coalesced_request_count: job
+            .get("coalesced_requests")
+            .and_then(Value::as_u64)
+            .map(count_bucket),
+        successor_pending,
+    }
+}
+
+fn elapsed_millis(job: &Value, started_field: &str, finished_field: &str) -> Option<Duration> {
+    job.get(finished_field)
+        .and_then(Value::as_i64)
+        .zip(job.get(started_field).and_then(Value::as_i64))
+        .and_then(|(finished, started)| finished.checked_sub(started))
+        .and_then(|millis| u64::try_from(millis).ok())
+        .map(Duration::from_millis)
+}
+
+fn timing_duration(job: &Value, field: &str) -> Option<Duration> {
+    job.get("timings_us")
+        .and_then(Value::as_object)
+        .and_then(|timings| timings.get(field))
+        .and_then(Value::as_u64)
+        .map(Duration::from_micros)
 }
 
 fn completed_failure(
@@ -337,8 +375,15 @@ mod tests {
             "operation": "refresh",
             "trigger": trigger,
             "source_count": 1,
+            "requested_at_ms": 500,
             "started_at_ms": 1_000,
             "finished_at_ms": 3_500,
+            "coalesced_requests": 3,
+            "timings_us": {
+                "discovery": 100_000,
+                "scan_stage": 2_000_000,
+                "commit": 6_000_000,
+            },
             "previous_generation": previous_generation,
             "published_generation": published_generation,
             "generation_changed": generation_changed,
@@ -387,6 +432,25 @@ mod tests {
         assert_eq!(facts.failure_scope, ProviderRefreshFailureScope::Mixed);
         assert_eq!(facts.failure_type, ProviderRefreshFailureType::Mixed);
         assert_eq!(facts.retired_records, None);
+        let health = event.terminal_health.expect("terminal health");
+        assert_eq!(
+            health.queue_wait_duration,
+            Some(duration_bucket(Duration::from_millis(500)))
+        );
+        assert_eq!(
+            health.discovery_duration,
+            Some(duration_bucket(Duration::from_micros(100_000)))
+        );
+        assert_eq!(
+            health.scan_stage_duration,
+            Some(duration_bucket(Duration::from_micros(2_000_000)))
+        );
+        assert_eq!(
+            health.commit_duration,
+            Some(duration_bucket(Duration::from_micros(6_000_000)))
+        );
+        assert_eq!(health.coalesced_request_count, Some(count_bucket(3)));
+        assert!(!health.successor_pending);
         assert_eq!(
             event.duration,
             duration_bucket(Duration::from_millis(2_500))
@@ -421,6 +485,8 @@ mod tests {
         assert_eq!(facts.work_kind, Some(ProviderRefreshWorkKind::NoOp));
         assert_eq!(facts.core_result, ProviderCoreResult::NoOp);
         assert!(facts.work_remaining);
+        let health = event.terminal_health.expect("terminal health");
+        assert!(health.successor_pending);
     }
 
     #[test]
@@ -544,6 +610,7 @@ mod tests {
             "physical_attempt_state": "failed",
             "progress_owner_request_id": request_id,
             "progress_owner_attempt_state": "failed",
+            "requested_at_ms": 500,
             "started_at_ms": 1_000,
             "finished_at_ms": 3_500,
             "progress": {
@@ -591,6 +658,8 @@ mod tests {
         );
         assert!(facts.work_remaining);
         assert_eq!(facts.retired_records, None);
+        let health = event.terminal_health.expect("terminal health");
+        assert!(health.successor_pending);
         assert_eq!(
             facts.counts.expect("known failed-run counts").sources,
             Some(count_bucket(2))
@@ -609,5 +678,41 @@ mod tests {
             true,
         )
         .is_none());
+    }
+
+    #[test]
+    fn malformed_optional_health_fields_do_not_suppress_the_base_event() {
+        let mut job = completed_job("periodic", Some("generation-a"), true);
+        job["requested_at_ms"] = json!(2_000);
+        job["started_at_ms"] = json!(1_000);
+        job["coalesced_requests"] = json!("invalid");
+        job["timings_us"]["discovery"] = json!("invalid");
+        job["timings_us"]["scan_stage"] = Value::Null;
+
+        let event = refresh(provider_refresh_event(&job, false).expect("base refresh event"));
+        let health = event.terminal_health.expect("terminal health");
+
+        assert_eq!(health.queue_wait_duration, None);
+        assert_eq!(health.discovery_duration, None);
+        assert_eq!(health.scan_stage_duration, None);
+        assert!(health.commit_duration.is_some());
+        assert_eq!(health.coalesced_request_count, None);
+    }
+
+    #[test]
+    fn explicit_zero_terminal_health_remains_present() {
+        let mut job = completed_job("periodic", Some("generation-a"), true);
+        job["requested_at_ms"] = json!(1_000);
+        job["started_at_ms"] = json!(1_000);
+        job["coalesced_requests"] = json!(0);
+
+        let event = refresh(provider_refresh_event(&job, false).expect("base refresh event"));
+        let health = event.terminal_health.expect("terminal health");
+
+        assert_eq!(
+            health.queue_wait_duration,
+            Some(duration_bucket(Duration::ZERO))
+        );
+        assert_eq!(health.coalesced_request_count, Some(count_bucket(0)));
     }
 }


### PR DESCRIPTION
## Summary

- report bounded queue, discovery, scan, and commit timing from the durable refresh job
- preserve coalesced-request and successor-work facts without adding new refresh state
- keep missing values absent and explicit zero observable

## Validation

- focused observability, daemon, and CLI tests
- source-provenance hash verification
- repository policy, formatting, and diff checks