### PR TITLE
Keep consent forwarding compatible with current checks

### DIFF
--- a/crates/ctx-cli/src/companion.rs
+++ b/crates/ctx-cli/src/companion.rs
@@ -222,7 +222,7 @@ fn forward_mcp_environment(environment: &mut CompanionEnvironment, data_root: &P
     forward_environment(environment);
     let analytics_enabled = crate::config::AppConfig::load(data_root)
         .as_ref()
-        .is_ok_and(|config| crate::config::resolved_analytics_consent(config));
+        .is_ok_and(crate::config::resolved_analytics_consent);
     environment.set(
         EnvironmentKey::AnalyticsEnabled,
         if analytics_enabled { "true" } else { "false" },

--- a/crates/ctx-cli/src/core_capability.rs
+++ b/crates/ctx-cli/src/core_capability.rs
@@ -355,7 +355,7 @@ fn wake_refresh_facts(data_root: &Path) -> Value {
     let config = crate::config::AppConfig::load(data_root);
     let analytics_enabled = config
         .as_ref()
-        .is_ok_and(|config| crate::config::resolved_analytics_consent(config));
+        .is_ok_and(crate::config::resolved_analytics_consent);
     if let Ok(config) = config {
         crate::semantic::maybe_autostart_daemon(
             data_root,


### PR DESCRIPTION
## Summary

- use the existing consent predicate directly at both forwarding boundaries
- preserve identical fail-closed behavior and payload shape

## Validation

- full CLI unit target with current CI lint settings
- independent correctness, privacy, and simplicity review
- repository policy and diff checks