### PR TITLE
fix(search): explain removed --include-subagents option

### DIFF
--- a/crates/ctx-cli/src/dispatch/parse.rs
+++ b/crates/ctx-cli/src/dispatch/parse.rs
@@ -104,6 +104,20 @@ fn human_clap_document(
             )
         }
         ErrorKind::UnknownArgument
+            if leaf.as_deref() == Some("ctx search")
+                && arguments_select_option(arguments, "--include-subagents") =>
+        {
+            (
+                "The --include-subagents option has been removed".to_owned(),
+                Some(
+                    "ctx search already includes primary and subagent sessions. Use --primary-only only when you want to exclude subagent work."
+                        .to_owned(),
+                ),
+                Some("ctx search [OPTIONS] [QUERY]".to_owned()),
+                Some("ctx search --help"),
+            )
+        }
+        ErrorKind::UnknownArgument
             if leaf.as_deref() == Some("ctx daemon run")
                 && arguments_select_option(arguments, "--idle-exit-seconds") =>
         {

--- a/crates/ctx-cli/src/dispatch/parse/tests.rs
+++ b/crates/ctx-cli/src/dispatch/parse/tests.rs
@@ -168,6 +168,30 @@ fn removed_idle_exit_has_persistent_foreground_recovery() {
 }
 
 #[test]
+fn removed_include_subagents_explains_the_all_agent_default() {
+    const RECOVERY: &str = "  ctx search --help";
+    for width in [32, 80] {
+        let output = human_output(&["ctx", "search", "incident", "--include-subagents"], width);
+        let normalized = normalized(&output);
+        assert!(
+            normalized.contains("The --include-subagents option has been removed"),
+            "{output}"
+        );
+        assert!(
+            normalized.contains("ctx search already includes primary and subagent sessions"),
+            "{output}"
+        );
+        assert!(
+            normalized.contains("Use --primary-only only when you want to exclude subagent work"),
+            "{output}"
+        );
+        assert!(output.contains(RECOVERY), "{output}");
+        assert!(!output.contains("--include-current-session"), "{output}");
+        assert_width_safe(&output, width, &[]);
+    }
+}
+
+#[test]
 fn retired_once_recommends_foreground_import() {
     const RECOVERY: &str = "  ctx import --help";
     for width in [32, 80] {
@@ -191,6 +215,16 @@ fn retired_once_recommends_foreground_import() {
 #[test]
 fn machine_parse_errors_remain_raw_clap_bytes() {
     for (arguments, expected_fragment) in [
+        (
+            &[
+                "ctx",
+                "search",
+                "incident",
+                "--include-subagents",
+                "--format=json",
+            ][..],
+            "unexpected argument '--include-subagents'",
+        ),
         (
             &["ctx", "daemon", "run", "--once", "--format=json"][..],
             "--force",

--- a/docs/search.md
+++ b/docs/search.md
@@ -141,6 +141,16 @@ Ordinary search uses the all-agent, root-diverse behavior described above. Use
 `--primary-only` only when a deliberately narrow search should exclude
 subagent work.
 
+`--include-subagents` is an obsolete pre-1.0 option because subagent work is
+already included by default. Remove it from older command templates. If a
+managed ctx skill still recommends it after a CLI upgrade, inspect and refresh
+that skill with:
+
+```bash
+ctx integrations status skills --agent <agent>
+ctx integrations install skills --agent <agent>
+```
+
 Direct CLI searches automatically exclude the current session tree for Codex,
 DeepSeek Harness, Grok Build, Pi, Claude Code, Goose, Hermes, Shelley, Qwen
 Code, and Mux when the current session can be identified unambiguously.


### PR DESCRIPTION
## Summary

`ctx search` now includes primary and subagent sessions by default, but older skills and command templates can still pass the removed `--include-subagents` option. The generic unknown-argument error currently suggests the unrelated `--include-current-session` flag, which makes the removal look like missing subagent support.

This keeps the current all-agent/root-first search contract and adds a targeted human diagnostic that explains:

- subagents are already included by default;
- `--primary-only` is the explicit narrower scope;
- `ctx search --help` is the canonical recovery path.

The search docs also explain how to inspect and refresh a stale managed ctx skill after a CLI upgrade.

## Compatibility

This does not restore `--include-subagents` as a redundant no-op or change search results. The option remains rejected with a nonzero exit, and machine/JSON invocations retain the raw Clap error bytes. Only the interactive human diagnostic changes.

## Test evidence

- `cargo test -p ctx dispatch::parse::tests -- --nocapture` (10 passed)
- `bash scripts/check-docs.sh`
- `cargo fmt --all -- --check`
- `git diff --check`

The broader CLI unit target reaches 213 passing tests locally, then fails in six unrelated hosted core-capability tests. A representative failure (`legacy_refresh_request_still_writes_exactly_one_terminal_response`) reproduces unchanged from clean `origin/main` at `8c6d6708`.
