### PR TITLE
Fix first-run daemon and snapshot races

### DIFF
--- a/crates/ctx-daemon-application/src/lib.rs
+++ b/crates/ctx-daemon-application/src/lib.rs
@@ -235,6 +235,10 @@ impl<'a> DaemonApplication<'a> {
         lifecycle::daemon_start_is_fenced(self.host)
     }
 
+    pub fn active_daemon_matches_current_executable(&self, data_root: &Path) -> Result<bool> {
+        lifecycle::active_daemon_matches_current_executable(data_root)
+    }
+
     pub fn request_daemon_start(
         &self,
         data_root: &Path,

--- a/crates/ctx-daemon-application/src/lifecycle.rs
+++ b/crates/ctx-daemon-application/src/lifecycle.rs
@@ -167,6 +167,19 @@ pub fn daemon_start_is_fenced(host: &dyn DaemonApplicationHost) -> bool {
     hosted_uninstall_fences_daemon_autostart(host)
 }
 
+/// Returns whether a live daemon is already owned by this exact executable.
+///
+/// Ordinary foreground commands use this to reuse a healthy installed daemon
+/// without reconciling native supervision from the invoking shell's ambient
+/// environment. Explicit setup and binary-mismatch repair still follow the
+/// full supervisor handoff path.
+pub fn active_daemon_matches_current_executable(data_root: &Path) -> Result<bool> {
+    if !daemon_lock_is_active(data_root) {
+        return Ok(false);
+    }
+    daemon_lock_matches_executable(data_root, &daemon_autostart_exe()?)
+}
+
 fn read_daemon_owner_identity(data_root: &Path) -> Result<Option<DaemonOwnerIdentity>> {
     if !daemon_lock_is_active(data_root) {
         return Ok(None);

--- a/crates/ctx-daemon-application/src/lifecycle/tests.rs
+++ b/crates/ctx-daemon-application/src/lifecycle/tests.rs
@@ -138,6 +138,19 @@ fn test_config() -> DaemonConfigSnapshot {
 }
 
 #[test]
+fn active_same_binary_daemon_is_reused_without_supervisor_reconciliation() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let lock = ctx_daemon_runtime::DaemonLock::acquire(temp.path())?
+        .expect("test process should acquire daemon ownership");
+
+    assert!(active_daemon_matches_current_executable(temp.path())?);
+
+    drop(lock);
+    assert!(!active_daemon_matches_current_executable(temp.path())?);
+    Ok(())
+}
+
+#[test]
 fn finite_core_worker_launch_is_forced_internal_and_has_no_persistent_timer() {
     let launch = configured_finite_core_worker_command(
         Path::new("/managed/ctx"),

--- a/crates/ctx-daemon-cli/src/daemon_autostart/autostart.rs
+++ b/crates/ctx-daemon-cli/src/daemon_autostart/autostart.rs
@@ -35,6 +35,12 @@ pub fn maybe_autostart_daemon(
         if application.daemon_start_is_fenced() {
             return;
         }
+        if application
+            .active_daemon_matches_current_executable(data_root)
+            .unwrap_or(false)
+        {
+            return;
+        }
         if daemon_autostart_suppression_reason().is_none() {
             match super::super::daemon_supervisor::ensure_daemon_supervisor(application, data_root)
             {

--- a/crates/ctx-history-snapshot-reader/src/lib.rs
+++ b/crates/ctx-history-snapshot-reader/src/lib.rs
@@ -87,6 +87,8 @@ pub enum SnapshotError {
     UnsafePath(String),
     #[error("generation read lease conflicts with reclamation: {0}")]
     LeaseConflict(String),
+    #[error("snapshot changed while a verified reader was opening: {0}")]
+    ConcurrentGenerationChange(String),
     #[error("snapshot schema mismatch")]
     SchemaMismatch {
         expected: SnapshotSchema,
@@ -656,6 +658,9 @@ fn map_generation_error(
         GenerationError::GenerationRetentionLeaseConflict { .. } => {
             SnapshotError::LeaseConflict(generation_id.to_owned())
         }
+        error @ GenerationError::ConcurrentGenerationChange => {
+            SnapshotError::ConcurrentGenerationChange(error.to_string())
+        }
         GenerationError::Io(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
             SnapshotError::UnsafePath("permission denied".to_owned())
         }
@@ -674,6 +679,9 @@ fn map_index_error(
         | IndexError::MissingManifest(_) => SnapshotError::NotFound(generation_id.to_owned()),
         IndexError::GenerationRetentionLeaseConflict { .. } => {
             SnapshotError::LeaseConflict(generation_id.to_owned())
+        }
+        error @ IndexError::ConcurrentGenerationChange => {
+            SnapshotError::ConcurrentGenerationChange(error.to_string())
         }
         IndexError::CoreRecordContractMismatch { actual, .. } => {
             SnapshotError::FingerprintMismatch {

--- a/crates/ctx-history-snapshot-reader/src/tests.rs
+++ b/crates/ctx-history-snapshot-reader/src/tests.rs
@@ -57,6 +57,25 @@ impl Fixture {
 }
 
 #[test]
+fn concurrent_publication_is_not_reported_as_corruption() {
+    assert!(matches!(
+        map_generation_error(
+            ctx_history_index_generation::GenerationError::ConcurrentGenerationChange,
+            &"a".repeat(64),
+        ),
+        SnapshotError::ConcurrentGenerationChange(_)
+    ));
+    assert!(matches!(
+        map_index_error(
+            ctx_history_index_query::IndexError::ConcurrentGenerationChange,
+            &"b".repeat(64),
+            &SnapshotContract::current().unwrap(),
+        ),
+        SnapshotError::ConcurrentGenerationChange(_)
+    ));
+}
+
+#[test]
 fn durable_exact_target_opens_after_more_than_two_publications() {
     let fixture = Fixture::new();
     let source = source("durable-retained");


### PR DESCRIPTION
Summary:
- reuse a live same-binary daemon without reconciling supervision from ordinary caller environments
- preserve concurrent generation rollover as a typed transient snapshot error
- keep explicit setup and binary mismatch repair on the existing fail-closed handoff path

Validation:
- scripts/bazelw test //crates/ctx-daemon-application:unit_tests //crates/ctx-daemon-cli:unit_tests //crates/ctx-history-snapshot-reader:unit_tests --test_output=errors