### PR TITLE
Centralize bounded provider root collections

### DIFF
--- a/crates/ctx-history-capture-model/src/lib.rs
+++ b/crates/ctx-history-capture-model/src/lib.rs
@@ -40,10 +40,10 @@ pub use progress::{
 };
 pub use provider_root::{
     provider_root_encoded_path_len, provider_root_path_within_limit, provider_source_config_digest,
-    ProviderRootConnectorBinding, ProviderRootDefinition, ProviderRootKind,
-    ProviderRootSourceIdentity, ReleasedProviderRootAutomaticRole, RetainedProviderRootAuthority,
-    MAX_CONFIGURED_PROVIDER_ROOTS, MAX_PROVIDER_ROOT_ENCODED_PATH_BYTES,
-    MAX_PROVIDER_ROOT_SELECTOR_BYTES,
+    ProviderRootConnectorBinding, ProviderRootDefinition, ProviderRootKind, ProviderRootSet,
+    ProviderRootSetError, ProviderRootSourceIdentity, ReleasedProviderRootAutomaticRole,
+    RetainedProviderRootAuthority, MAX_CONFIGURED_PROVIDER_ROOTS,
+    MAX_PROVIDER_ROOT_ENCODED_PATH_BYTES, MAX_PROVIDER_ROOT_SELECTOR_BYTES,
 };
 pub use record::RecordDigest;
 pub use route::{

--- a/crates/ctx-history-capture-model/src/provider_root.rs
+++ b/crates/ctx-history-capture-model/src/provider_root.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    ops::Deref,
+    path::{Path, PathBuf},
+};
 
 use ctx_history_core::CaptureProvider;
 use serde::{Deserialize, Serialize};
@@ -7,6 +10,64 @@ use sha2::{Digest, Sha256};
 pub const MAX_CONFIGURED_PROVIDER_ROOTS: usize = 64;
 pub const MAX_PROVIDER_ROOT_SELECTOR_BYTES: usize = 64;
 pub const MAX_PROVIDER_ROOT_ENCODED_PATH_BYTES: usize = 16 * 1024;
+
+/// Bounded, deterministic provider-root input for discovery and persistence.
+///
+/// This type owns only resource bounds and ordering. Provider support,
+/// filesystem kind, physical equivalence, and overlap policy require the
+/// caller's current configuration or filesystem authority and remain outside
+/// this value object.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ProviderRootSet(Vec<ProviderRootDefinition>);
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ProviderRootSetError {
+    #[error("configured provider roots exceed the maximum of {MAX_CONFIGURED_PROVIDER_ROOTS}")]
+    TooMany,
+    #[error(
+        "configured provider root `{root_id}` exceeds the {MAX_PROVIDER_ROOT_ENCODED_PATH_BYTES}-byte encoded path limit"
+    )]
+    PathTooLong { root_id: String },
+}
+
+impl ProviderRootSet {
+    /// Validates every supplied root instead of silently dropping input.
+    pub fn try_new(mut roots: Vec<ProviderRootDefinition>) -> Result<Self, ProviderRootSetError> {
+        if roots.len() > MAX_CONFIGURED_PROVIDER_ROOTS {
+            return Err(ProviderRootSetError::TooMany);
+        }
+        if let Some(root) = roots.iter().find(|root| !root.has_bounded_path()) {
+            return Err(ProviderRootSetError::PathTooLong {
+                root_id: root.id.clone(),
+            });
+        }
+        roots.sort_by(|left, right| left.id.cmp(&right.id));
+        Ok(Self(roots))
+    }
+
+    /// Compatibility boundary for public discovery contexts built from
+    /// untrusted definitions. Invalid paths are omitted and excess roots are
+    /// deterministically truncated, preserving the historical non-failing
+    /// builder while enforcing the shared discovery work bound.
+    pub fn from_untrusted_lossy(mut roots: Vec<ProviderRootDefinition>) -> Self {
+        roots.retain(ProviderRootDefinition::has_bounded_path);
+        roots.sort_by(|left, right| left.id.cmp(&right.id));
+        roots.truncate(MAX_CONFIGURED_PROVIDER_ROOTS);
+        Self(roots)
+    }
+
+    pub fn as_slice(&self) -> &[ProviderRootDefinition] {
+        &self.0
+    }
+}
+
+impl Deref for ProviderRootSet {
+    type Target = [ProviderRootDefinition];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
 
 /// Platform-native encoded length used by configured-root resource bounds.
 pub fn provider_root_encoded_path_len(path: &Path) -> usize {
@@ -343,12 +404,69 @@ pub fn provider_source_config_digest(
     format!("{:x}", digest.finalize())
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use std::{ffi::OsString, os::unix::ffi::OsStringExt};
 
     use super::*;
 
+    fn claude_root(id: impl Into<String>, path: impl Into<PathBuf>) -> ProviderRootDefinition {
+        ProviderRootDefinition {
+            id: id.into(),
+            provider: CaptureProvider::Claude,
+            path: path.into(),
+            group: None,
+            kind: None,
+        }
+    }
+
+    #[test]
+    fn provider_root_set_rejects_unbounded_input_and_orders_valid_roots() {
+        let roots = ProviderRootSet::try_new(vec![
+            claude_root("work", "/history/work"),
+            claude_root("personal", "/history/personal"),
+        ])
+        .unwrap();
+        assert_eq!(
+            roots
+                .iter()
+                .map(|root| root.id.as_str())
+                .collect::<Vec<_>>(),
+            ["personal", "work"]
+        );
+
+        let overlong = PathBuf::from("x".repeat(MAX_PROVIDER_ROOT_ENCODED_PATH_BYTES + 1));
+        assert_eq!(
+            ProviderRootSet::try_new(vec![claude_root("oversized", overlong)]),
+            Err(ProviderRootSetError::PathTooLong {
+                root_id: "oversized".to_owned(),
+            })
+        );
+
+        let excess = (0..=MAX_CONFIGURED_PROVIDER_ROOTS)
+            .map(|index| claude_root(format!("root-{index:03}"), format!("/history/{index}")))
+            .collect();
+        assert_eq!(
+            ProviderRootSet::try_new(excess),
+            Err(ProviderRootSetError::TooMany)
+        );
+    }
+
+    #[test]
+    fn lossy_provider_root_set_enforces_the_same_work_bound_deterministically() {
+        let roots = (0..=MAX_CONFIGURED_PROVIDER_ROOTS)
+            .rev()
+            .map(|index| claude_root(format!("root-{index:03}"), format!("/history/{index}")))
+            .collect();
+        let roots = ProviderRootSet::from_untrusted_lossy(roots);
+
+        assert_eq!(roots.len(), MAX_CONFIGURED_PROVIDER_ROOTS);
+        assert_eq!(roots.first().unwrap().id, "root-000");
+        assert_eq!(roots.last().unwrap().id, "root-063");
+    }
+
+    #[cfg(unix)]
     #[test]
     fn digest_is_total_and_distinct_for_non_unicode_public_api_paths() {
         let root = |byte| ProviderRootDefinition {

--- a/crates/ctx-history-capture/src/lib.rs
+++ b/crates/ctx-history-capture/src/lib.rs
@@ -52,10 +52,10 @@ pub use ctx_history_capture_model::{
     provider_root_encoded_path_len, provider_root_path_within_limit, provider_source_config_digest,
     stable_capture_uuid, CatalogSummary, OutputObservationKind, OutputOutcome,
     OutputOutcomeMetadata, ProviderImportFailure, ProviderImportSummary, ProviderImportWorkResult,
-    ProviderRootDefinition, ProviderRootKind, ProviderRootSourceIdentity, ProviderRouteRole,
-    ProviderRouteRoleError, ProviderSourceFailureKind, MAX_CONFIGURED_PROVIDER_ROOTS,
-    MAX_PROVIDER_ROOT_ENCODED_PATH_BYTES, MAX_PROVIDER_ROOT_SELECTOR_BYTES,
-    MAX_PROVIDER_ROUTE_ROLE_BYTES,
+    ProviderRootDefinition, ProviderRootKind, ProviderRootSet, ProviderRootSetError,
+    ProviderRootSourceIdentity, ProviderRouteRole, ProviderRouteRoleError,
+    ProviderSourceFailureKind, MAX_CONFIGURED_PROVIDER_ROOTS, MAX_PROVIDER_ROOT_ENCODED_PATH_BYTES,
+    MAX_PROVIDER_ROOT_SELECTOR_BYTES, MAX_PROVIDER_ROUTE_ROLE_BYTES,
 };
 mod error;
 pub use error::{CaptureError, ProviderJsonlInventoryLimit, Result};

--- a/crates/ctx-history-source-discovery/src/provider_sources/context.rs
+++ b/crates/ctx-history-source-discovery/src/provider_sources/context.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ctx_history_capture_model::ProviderRootDefinition;
+use ctx_history_capture_model::{ProviderRootDefinition, ProviderRootSet, ProviderRootSetError};
 use directories::BaseDirs;
 
 /// Process environment keys that discovery may inherit.
@@ -138,7 +138,7 @@ pub struct DiscoveryContext {
     platform_dirs: DiscoveryPlatformDirs,
     inherited_env: BTreeMap<&'static str, OsString>,
     automatic_provider_discovery: bool,
-    configured_provider_roots: Vec<ProviderRootDefinition>,
+    configured_provider_roots: ProviderRootSet,
 }
 
 impl DiscoveryContext {
@@ -157,7 +157,7 @@ impl DiscoveryContext {
             platform_dirs: DiscoveryPlatformDirs::from_process(),
             inherited_env,
             automatic_provider_discovery: true,
-            configured_provider_roots: Vec::new(),
+            configured_provider_roots: ProviderRootSet::default(),
         }
     }
 
@@ -177,7 +177,7 @@ impl DiscoveryContext {
             platform_dirs,
             inherited_env: BTreeMap::new(),
             automatic_provider_discovery: true,
-            configured_provider_roots: Vec::new(),
+            configured_provider_roots: ProviderRootSet::default(),
         }
     }
 
@@ -196,7 +196,7 @@ impl DiscoveryContext {
             platform_dirs,
             inherited_env: BTreeMap::new(),
             automatic_provider_discovery: true,
-            configured_provider_roots: Vec::new(),
+            configured_provider_roots: ProviderRootSet::default(),
         }
     }
 
@@ -276,18 +276,28 @@ impl DiscoveryContext {
         self
     }
 
-    pub fn with_configured_provider_roots(
+    pub fn with_configured_provider_roots(mut self, roots: Vec<ProviderRootDefinition>) -> Self {
+        self.configured_provider_roots = ProviderRootSet::from_untrusted_lossy(roots);
+        self
+    }
+
+    /// Supplies roots through the strict bounded model used by typed config
+    /// and other callers that must reject, rather than omit, invalid input.
+    pub fn try_with_configured_provider_roots(
         mut self,
-        mut roots: Vec<ProviderRootDefinition>,
-    ) -> Self {
-        roots.retain(ProviderRootDefinition::has_bounded_path);
-        roots.sort_by(|left, right| left.id.cmp(&right.id));
+        roots: Vec<ProviderRootDefinition>,
+    ) -> Result<Self, ProviderRootSetError> {
+        self.configured_provider_roots = ProviderRootSet::try_new(roots)?;
+        Ok(self)
+    }
+
+    pub fn with_provider_root_set(mut self, roots: ProviderRootSet) -> Self {
         self.configured_provider_roots = roots;
         self
     }
 
     pub fn configured_provider_roots(&self) -> &[ProviderRootDefinition] {
-        &self.configured_provider_roots
+        self.configured_provider_roots.as_slice()
     }
 
     pub fn with_automatic_provider_discovery(mut self, enabled: bool) -> Self {
@@ -332,13 +342,17 @@ mod tests {
         };
         assert!(!root.has_bounded_path());
 
-        let context = DiscoveryContext::new(
+        let base = DiscoveryContext::new(
             "/home/test",
             "/work/test",
             DiscoveryPlatform::Linux,
             DiscoveryPlatformDirs::default(),
-        )
-        .with_configured_provider_roots(vec![root]);
+        );
+        assert!(matches!(
+            base.clone().try_with_configured_provider_roots(vec![root.clone()]),
+            Err(ProviderRootSetError::PathTooLong { root_id }) if root_id == "oversized"
+        ));
+        let context = base.with_configured_provider_roots(vec![root]);
 
         assert!(context.configured_provider_roots().is_empty());
     }

--- a/crates/ctx-history-source-discovery/src/provider_sources/mod.rs
+++ b/crates/ctx-history-source-discovery/src/provider_sources/mod.rs
@@ -59,7 +59,9 @@ pub use configured_roots::{
 pub use context::{
     DiscoveryContext, DiscoveryPlatform, DiscoveryPlatformDirs, DISCOVERY_ENV_ALLOWLIST,
 };
-pub use ctx_history_capture_model::ProviderRootDefinition;
+pub use ctx_history_capture_model::{
+    ProviderRootDefinition, ProviderRootSet, ProviderRootSetError,
+};
 pub(crate) use ctx_history_source_io::open_ordinary_file_without_following;
 pub use ctx_history_source_io::OrdinaryFileObservation;
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- introduce `ProviderRootSet` as the shared bounded, ordered representation for provider roots
- make `DiscoveryContext` store the typed set while retaining the existing `Vec<ProviderRoot>` compatibility builder
- add a strict fallible builder for validated callers and cap lossy/untrusted construction at the existing 64-root limit

## Compatibility

- preserves deterministic root ordering and omission of overlong paths in the compatibility builder
- leaves provider probing, no-follow behavior, physical-equivalence checks, compound-root expansion, digests, and registration revalidation unchanged
- the only intentional edge behavior change is deterministic truncation of direct public-builder input above 64 roots; persisted configuration already rejects that count

## Validation

- `//crates/ctx-history-capture-model:unit_tests`
- `//crates/ctx-history-source-discovery:unit_tests`
- `//crates/ctx-history-source-discovery-qualification:configured_roots_tests`
- `//crates/ctx-history-source-discovery-qualification:configured_root_matrix_tests`
- `//crates/ctx-history-capture:lib`
- `cargo fmt --all`
- `git diff --check`
- public-push LOC and Cargo/Bazel ownership gates

All build and test invocations ran through the shared build governor. The representation remains a `Vec`, construction retains the prior `O(n log n)` sort, and the bound reduces worst-case downstream work without adding I/O or probes.
