### PR TITLE
Let Custom History own its explicit JSONL route

### DIFF
--- a/crates/ctx-history-capture-composition/src/source_backed/registration/families/jsonl/other.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/registration/families/jsonl/other.rs
@@ -1,4 +1,5 @@
 use super::*;
+use ctx_history_provider_runtime::ProviderRouteRegistrar;
 
 macro_rules! register_shared_jsonl_route {
     ($registry:expr, $source:expr, $selection:expr, $adapter:expr) => {{
@@ -190,18 +191,10 @@ pub fn register_custom_history_source_backed_route(
     source: ProviderSource,
     catalog_lineage: [u8; 32],
 ) -> SourceBackedCoordinatorResult<()> {
-    let adapter = ctx_history_providers_jsonl_shared::adapters::custom_history::<
-        crate::provider::source_backed::family::jsonl::JsonlFamilyRuntime,
-    >(source.path.clone(), catalog_lineage)
-    .map_err(|error| invalid_route(source.provider, error.to_string()))?;
-    let driver = crate::provider::source_backed::family::jsonl::jsonl_family_driver(
-        adapter,
-        source.path.clone(),
-    );
-    registry.register(SourceBackedRoute::explicit_manual(
-        source,
-        SourceBackedSelectorAuthority::CatalogLineage,
-        driver,
-    )?);
-    Ok(())
+    let provider = source.provider;
+    let registration = ctx_history_providers_jsonl_shared::custom_history_explicit_route::<
+        CaptureProviderRuntime,
+    >(source, catalog_lineage)
+    .map_err(|error| invalid_route(provider, error.to_string()))?;
+    registry.register_provider_route(registration)
 }

--- a/crates/ctx-history-providers-jsonl-shared/src/lib.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/lib.rs
@@ -5,6 +5,8 @@
 
 mod error;
 pub use error::{CaptureError, ProviderJsonlInventoryLimit, Result};
+mod registration;
+pub use registration::custom_history_explicit_route;
 
 pub use ctx_history_capture_model::{
     fnv1a64, stable_capture_uuid, CatalogSummary, ProviderImportFailure, ProviderImportSummary,
@@ -13,6 +15,7 @@ pub use ctx_history_capture_model::{
 
 pub const MAX_PROVIDER_JSONL_LINE_BYTES: usize =
     ctx_history_source_io::MAX_PROVIDER_JSONL_LINE_BYTES;
+pub(crate) const CUSTOM_HISTORY_SOURCE_FORMAT: &str = "ctx_history_jsonl_v2";
 pub const MAX_OPENCLAW_SESSION_INDEX_BYTES: usize = 1024 * 1024;
 pub const JUNIE_SESSION_EVENTS_SOURCE_FORMAT: &str = "junie_session_events_jsonl_tree";
 pub const OPENCLAW_SOURCE_FORMAT: &str = "openclaw_session_jsonl_tree";
@@ -80,34 +83,6 @@ pub mod adapters {
             occurred_at: fact.occurred_at,
             lexical_text: fact.lexical_text,
         }
-    }
-
-    pub fn custom_history<R: JsonlProviderRuntime>(
-        path: PathBuf,
-        catalog_lineage: [u8; 32],
-    ) -> Result<Arc<dyn JsonlFamilyAdapter<Runtime = R>>> {
-        provider::custom_history_jsonl::custom_history_jsonl_family_adapter::<R>(
-            provider::custom_history_jsonl::CustomHistorySourceBackedInput::explicit(
-                path,
-                catalog_lineage,
-            ),
-        )
-        .map_err(|error| crate::CaptureError::InvalidPayload(error.to_string()))
-    }
-
-    pub fn custom_history_with_source_root_lineage<R: JsonlProviderRuntime>(
-        path: PathBuf,
-        catalog_lineage: [u8; 32],
-        source_root_lineage: Option<[u8; 32]>,
-    ) -> Result<Arc<dyn JsonlFamilyAdapter<Runtime = R>>> {
-        provider::custom_history_jsonl::custom_history_jsonl_family_adapter::<R>(
-            provider::custom_history_jsonl::CustomHistorySourceBackedInput::explicit_with_source_root_lineage(
-                path,
-                catalog_lineage,
-                source_root_lineage,
-            ),
-        )
-        .map_err(|error| crate::CaptureError::InvalidPayload(error.to_string()))
     }
 
     pub fn junie<R: JsonlProviderRuntime>() -> Arc<dyn JsonlFamilyAdapter<Runtime = R>> {

--- a/crates/ctx-history-providers-jsonl-shared/src/provider/custom_history_jsonl/nativepath/source_backed.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/provider/custom_history_jsonl/nativepath/source_backed.rs
@@ -60,7 +60,7 @@ use parser::parse_projection;
 
 const CUSTOM_SOURCE_IDENTITY_VERSION: u32 = 1;
 const CUSTOM_HISTORY_PUBLIC_SCHEMA_VERSION: &str = CTX_HISTORY_JSONL_SCHEMA_VERSION;
-const CUSTOM_ROUTE_SOURCE_FORMAT: &str = "ctx_history_jsonl_v2";
+const CUSTOM_ROUTE_SOURCE_FORMAT: &str = crate::CUSTOM_HISTORY_SOURCE_FORMAT;
 const CUSTOM_SOURCE_SCHEMA_VARIANT: &str = "ctx-history-jsonl-v2-source-backed-v1";
 pub(super) const CUSTOM_SOURCE_BACKED_PARSER_REVISION: &str =
     "custom-history-jsonl-source-backed-v9-provider-session-identity";
@@ -183,6 +183,7 @@ impl CustomHistorySourceBackedInput {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn explicit_with_source_root_lineage(
         path: impl Into<PathBuf>,
         catalog_lineage: [u8; 32],

--- a/crates/ctx-history-providers-jsonl-shared/src/registration.rs
+++ b/crates/ctx-history-providers-jsonl-shared/src/registration.rs
@@ -1,0 +1,42 @@
+use ctx_history_capture_model::ProviderSource;
+use ctx_history_capture_runtime::{SourceBackedRouteSelection, SourceBackedSelectorAuthority};
+use ctx_history_core::CaptureProvider;
+use ctx_history_provider_runtime::{
+    provider_jsonl_family_driver, ProviderJsonlRuntime, ProviderRouteRegistration,
+    ProviderRuntimeBinding,
+};
+
+use crate::{provider, CaptureError, Result, CUSTOM_HISTORY_SOURCE_FORMAT};
+
+/// Constructs the only valid Custom History route: an explicit v2 JSONL
+/// source whose durable identity is supplied by the caller-owned catalog.
+pub fn custom_history_explicit_route<B: ProviderRuntimeBinding>(
+    source: ProviderSource,
+    catalog_lineage: [u8; 32],
+) -> Result<ProviderRouteRegistration<B>> {
+    if source.provider != CaptureProvider::Custom
+        || source.source_format != CUSTOM_HISTORY_SOURCE_FORMAT
+    {
+        return Err(CaptureError::InvalidPayload(
+            "Custom History routes require the ctx_history_jsonl_v2 source format".to_owned(),
+        ));
+    }
+
+    let adapter = provider::custom_history_jsonl::custom_history_jsonl_family_adapter::<
+        ProviderJsonlRuntime<B>,
+    >(
+        provider::custom_history_jsonl::CustomHistorySourceBackedInput::explicit(
+            source.path.clone(),
+            catalog_lineage,
+        ),
+    )
+    .map_err(|error| CaptureError::InvalidPayload(error.to_string()))?;
+    let driver = provider_jsonl_family_driver::<B>(adapter, source.path.clone());
+
+    Ok(ProviderRouteRegistration {
+        source,
+        selection: SourceBackedRouteSelection::ExplicitManual,
+        selector_authority: SourceBackedSelectorAuthority::CatalogLineage,
+        driver,
+    })
+}


### PR DESCRIPTION
## Summary\n\n- Move complete Custom History v2 explicit-route construction into the shared JSONL provider package.\n- Reduce capture composition to installing the provider-owned ProviderRouteRegistration.\n- Delete the two public Custom adapter factories and remove the obsolete source-root-lineage constructor from production builds.\n\n## Exact range\n\n- Base: ee9cb129b84036d29b9721db0f6a940f2bcf42cf\n- Head: 8570ac306c5d69d957e91590b4d16b981315e585\n- Scope: 4 files, +54 / -43 LOC\n- Stable patch-id: ed59bda1f0173c92e23036a4f502c2c09362fbbe\n\nThe rebase onto #701 was conflict-free. Git range-diff reports the reviewed and rebased commits as identical, and #701 changed no files in this PR.\n\n## Mechanism replacement\n\nOld:\ncomposition assembled the Custom adapter, JSONL driver, selection, and selector authority through public adapter factories.\n\nNew:\nctx-history-providers-jsonl-shared validates the Custom v2 source and returns the complete explicit ProviderRouteRegistration. Composition only installs that registration.\n\nDeleted:\nadapters::custom_history, adapters::custom_history_with_source_root_lineage, and composition-owned Custom driver assembly. The source-root-lineage input constructor is now test-only.\n\n## Contracts retained\n\n- CaptureProvider::Custom and ctx_history_jsonl_v2 only.\n- ExplicitManual selection with CatalogLineage selector authority.\n- The same catalog lineage, source path, ProviderJsonlRuntime binding, adapter, and JSONL family driver.\n- No parser revision, checkpoint, projection, publication, refresh, or generation-storage behavior changes.\n\n## Validation\n\nAll commands passed again on the rebased exact head:\n\n- ctx-history-providers-jsonl-shared unit tests\n- ctx-history-capture-composition unit tests\n- full JSONL publication qualification suite\n- provider-pack boundary check and mutation tests\n- provider-runtime dependency boundary check and mutation tests\n- setup_sources_import CLI contracts filtered to Custom\n- cargo fmt --all --check\n- git diff --check\n- repository policy check\n- guarded public push policy\n\nThe lifecycle qualification exercises cold import, exact repeat, append, replacement, and deletion with identical provider output and certificates.\n\n## Performance\n\nThis changes only route construction; it does not change parsing, scanning, byte reads, checkpointing, or SQLite work.\n\nFive alternating warm lifecycle runs:\n- Base elapsed: 0.28, 0.34, 0.39, 0.35, 0.46 s; median 0.35 s.\n- Candidate elapsed: 0.30, 0.34, 0.29, 0.40, 0.47 s; median 0.34 s.\n- Base median peak RSS: 71,444 KiB.\n- Candidate median peak RSS: 71,032 KiB.\n- Warm test-process filesystem input operations were 0 to 48 for base and 0 for candidate. This metric is cache-sensitive and is not byte-read evidence.\n\nThese results support non-regression only; no speed, memory, or bytes-read improvement is claimed. A separate SQLite latency result is not relevant because this route does not use SQLite.\n\n## Independent review\n\nAPPROVE with no actionable findings. The rebased patch has the same stable patch-id and an equal range-diff, so the reviewed semantics are unchanged. Residual non-blocking risk: invalid provider and format guards do not have direct unit assertions, while composition classification and the valid production path are covered.\n\n## Risks and merge order\n\n- No overlap with #701 or other known active branches.\n- No migration or compatibility requirement.\n- Independently mergeable; no required merge order.