### PR TITLE
Remove dormant Bazel REAPI profile

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,17 +11,6 @@ build --java_runtime_version=remotejdk_21
 test --cache_test_results=auto
 test --test_output=errors
 
-# Optional REAPI execution keeps every eligible spawn action remote-only.
-build:ctx-reapi --spawn_strategy=remote
-build:ctx-reapi --genrule_strategy=remote
-build:ctx-reapi --remote_local_fallback=false
-build:ctx-reapi --incompatible_legacy_local_fallback=false
-build:ctx-reapi --remote_download_outputs=toplevel
-build:ctx-reapi --remote_timeout=60s
-build:ctx-reapi --remote_retries=2
-test:ctx-reapi --test_strategy=remote
-test:ctx-reapi --test_output=errors
-
 # Fast local Linux iteration: stable fastbuild key, no Rust debug info, and the
 # content-pinned mold input declared in MODULE.bazel.
 build:dev-linux --compilation_mode=fastbuild

--- a/docs/bazel-development.md
+++ b/docs/bazel-development.md
@@ -136,21 +136,6 @@ or an explicitly empty governor path fails with status 125. A governed host
 defaults Bazel jobs and local CPU resources to 16 while preserving explicit
 resource overrides.
 
-## Optional remote execution
-
-The repository defines one opt-in REAPI profile: `--config=ctx-reapi`. It sends
-every remotely eligible spawn action to the configured executor and disables
-local fallback. Connection and authentication settings remain external to the
-repository and must be supplied by the Bazel invocation or machine
-configuration.
-
-After those external settings are available, use the profile with an ordinary
-wrapper command:
-
-```bash
-scripts/bazelw test //crates/ctx-cli:unit_tests --config=ctx-reapi
-```
-
 ## Focused, affected, and complete checks
 
 ```bash

--- a/scripts/tests/bazelw-test.sh
+++ b/scripts/tests/bazelw-test.sh
@@ -163,15 +163,6 @@ selected_cache="$(ctx_bazel_cache_root)"
 [[ "${selected_cache}" == "${XDG_CACHE_HOME}/ctx/bazel" ]] \
   || fail 'low-inode spacious root did not fall back before invoking Bazel'
 
-grep -Fqx 'build:ctx-reapi --spawn_strategy=remote' "${repo_root}/.bazelrc" \
-  || fail 'ctx-reapi must force eligible spawn actions to remote execution'
-grep -Fqx 'build:ctx-reapi --remote_local_fallback=false' "${repo_root}/.bazelrc" \
-  || fail 'ctx-reapi must disable local fallback'
-grep -Fqx 'test:ctx-reapi --test_strategy=remote' "${repo_root}/.bazelrc" \
-  || fail 'ctx-reapi must force test actions to remote execution'
-[[ "$(grep -cE '^[^#[:space:]][^:[:space:]]*:ctx-reapi[[:space:]]' "${repo_root}/.bazelrc")" == "9" ]] \
-  || fail 'ctx-reapi repository policy has an unexpected directive count'
-
 # An explicitly activated generic host governor wraps build-capable commands,
 # raises healthy single-build defaults, and leaves query/read commands light.
 export XDG_CONFIG_HOME="${test_root}/governor-config"


### PR DESCRIPTION
## Summary

- remove the repository-defined `ctx-reapi` Bazel profile and its stale development documentation
- remove wrapper assertions that only verified that retired profile
- retain the standard Bazel wrapper, generic host-governor discovery/fail-closed behavior, and adaptive local resource limits unchanged

## Deletion map

- optional remote profile -> standard repository Bazel wrapper and generic host governance -> delete the profile directives
- profile-specific documentation -> retained generic governor and wrapper documentation -> delete the optional remote-execution section
- profile-only test assertions -> retained wrapper/governor/resource-policy coverage -> delete only the retired assertions

## Validation

Exact base: `49a2c22a6ab25416b0ebb4d94448e107a5210d26`
Exact head: `a382b98e1a339c3cc7668f4d8bfbd000871eaa44`

- `git diff --check origin/main...HEAD`
- `scripts/bazelw test //:repository_policy_check //:bazel_wrapper_tests --config=ci --nocache_test_results` (2/2 pass)
- `CTX_AFFECTED_DRY_RUN=1 scripts/bazel-affected.sh origin/main` (correctly selects `//...` for `.bazelrc`)
- `scripts/check.sh --mode=ci` (448/448 build targets; 215/215 tests)
- managed public-push disclosure and repository-policy guard (clean)
- matched uncached wrapper action: 0.5s before, 0.5s after

Independent review: APPROVE; no actionable findings.

## Risk

Intentional compatibility retirement: an external script that still passes `--config=ctx-reapi` will now receive Bazel unknown-config behavior. The repository no longer advertises or implements that profile.