### PR TITLE
fix(history): contain child open failures during tree discovery

### DIFF
--- a/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/tests.rs
+++ b/crates/ctx-history-provider-claude-cursor/src/claude/nativepath/source_backed/tests.rs
@@ -1,5 +1,8 @@
 use std::{collections::HashMap, path::PathBuf};
 
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+
 use ctx_history_capture_model::{ProviderRootDefinition, ProviderRootSourceIdentity};
 use ctx_history_core::{
     ActivityJsonCapture, ActivityTextCapture, LiteralFactKind, ProjectionContractError, TypedKey,
@@ -16,6 +19,64 @@ use super::{
     claude_annotation, parse_native_record, session_identity, session_typed_key, source_key,
     ClaudePhysicalLocator, ClaudeSessionKey,
 };
+
+#[cfg(unix)]
+#[allow(
+    dead_code,
+    reason = "the shared test runtime includes helpers this discovery-only test does not use"
+)]
+#[path = "../../../tests/runtime.rs"]
+mod runtime;
+
+#[test]
+#[cfg(unix)]
+fn claude_discovery_ignores_workflow_alias_with_independently_discovered_target() {
+    let temp = tempfile::tempdir().unwrap();
+    let claude_home = temp.path().join(".claude");
+    let project = claude_home.join("projects/project");
+    let canonical_workflow = project.join("session-a/subagents/workflows/shared-workflow");
+    let canonical_agent = canonical_workflow.join("agent-worker.jsonl");
+    std::fs::create_dir_all(&canonical_workflow).unwrap();
+    std::fs::write(&canonical_agent, b"{\"type\":\"user\"}\n").unwrap();
+
+    let healthy_primary = project.join("session-b.jsonl");
+    std::fs::write(&healthy_primary, b"{\"type\":\"user\"}\n").unwrap();
+    let alias_parent = project.join("session-b/subagents/workflows");
+    std::fs::create_dir_all(&alias_parent).unwrap();
+    // Claude owns this alias, but its canonical target is independently
+    // discovered, so discovery ignores the alias instead of traversing or
+    // presenting it as a quarantined transcript.
+    symlink(&canonical_workflow, alias_parent.join("shared-workflow")).unwrap();
+
+    let inventory = super::claude_jsonl_adapter::<runtime::LowerTestRuntimeBinding>()
+        .discover(&claude_home)
+        .unwrap();
+    let mut accepted = inventory
+        .accepted_leaves()
+        .map(|leaf| {
+            (
+                leaf.source_path().to_path_buf(),
+                super::decode_binding(leaf)
+                    .unwrap()
+                    .key
+                    .provider_session_id(),
+            )
+        })
+        .collect::<Vec<_>>();
+    accepted.sort();
+
+    assert_eq!(
+        accepted,
+        [
+            (
+                canonical_agent,
+                "session-a/subagents/workflows/shared-workflow/agent-worker".to_owned(),
+            ),
+            (healthy_primary, "session-b".to_owned()),
+        ]
+    );
+    assert_eq!(inventory.quarantined_len(), 0);
+}
 
 fn canonical_identity_hex(identity: ctx_history_core::StableEntityId) -> String {
     use std::fmt::Write as _;

--- a/crates/ctx-history-source-io/src/bounded_tree.rs
+++ b/crates/ctx-history-source-io/src/bounded_tree.rs
@@ -10,8 +10,9 @@ use std::{
 use tempfile::TempDir;
 
 use crate::{
-    open_provider_source_path, OpenedProviderSourceFile, OpenedProviderSourcePath,
-    ProviderSourceDirectory, SourceIoError, PROVIDER_JSONL_INVENTORY_MAX_METADATA_ENTRIES,
+    is_non_regular_source_rejection, is_symlink_source_rejection, open_provider_source_path,
+    OpenedProviderSourceFile, OpenedProviderSourcePath, ProviderSourceDirectory, SourceIoError,
+    PROVIDER_JSONL_INVENTORY_MAX_METADATA_ENTRIES,
 };
 
 const BOUNDED_TREE_MAX_DIRECTORY_DEPTH: usize = 128;
@@ -65,21 +66,20 @@ where
     })
 }
 
-/// Visits a tree while containing admission/read failures for child entries.
+/// Visits a tree while containing admission/read failures for selected files.
 ///
-/// A child that cannot be opened is named and handed to `child_error`, which
-/// decides whether the caller can carry on without it. That covers rejected
-/// path components, which make a subtree unreachable by policy no matter how
-/// the traversal proceeds, so failing the whole scan over one of them discards
-/// every healthy sibling for nothing.
+/// Unselected symlink, reparse, and non-regular children are never followed and
+/// are skipped. Other unselected open failures stay fatal because they may hide
+/// a genuine directory subtree.
 ///
-/// Root and directory-enumeration failures stay fatal. Neither names a child to
-/// contain, and an enumeration that stops early would drop files silently.
+/// Root-open and directory-enumeration failures stay fatal. Neither names a
+/// selected child to contain, and an enumeration that stops early would drop
+/// files silently.
 pub fn visit_bounded_tree_files_isolating_selected<E, Selected>(
     root: &Path,
     selected: &mut Selected,
     visit: &mut dyn FnMut(BoundedTreeSourceFile) -> std::result::Result<(), E>,
-    child_error: &mut dyn FnMut(&Path, E) -> std::result::Result<(), E>,
+    selected_file_error: &mut dyn FnMut(&Path, E) -> std::result::Result<(), E>,
 ) -> std::result::Result<usize, E>
 where
     E: From<SourceIoError>,
@@ -105,7 +105,7 @@ where
                     Ok(1)
                 }
                 Err(error) => {
-                    child_error(root, error)?;
+                    selected_file_error(root, error)?;
                     Ok(0)
                 }
             }
@@ -117,7 +117,7 @@ where
                 directory,
                 selected,
                 visit,
-                child_error,
+                selected_file_error,
                 0,
             )?;
             authority.revalidate().map_err(E::from)?;
@@ -132,7 +132,7 @@ fn visit_bounded_tree_files_at_depth<E, Selected>(
     directory: ProviderSourceDirectory,
     selected: &mut Selected,
     visit: &mut dyn FnMut(BoundedTreeSourceFile) -> std::result::Result<(), E>,
-    child_error: &mut dyn FnMut(&Path, E) -> std::result::Result<(), E>,
+    selected_file_error: &mut dyn FnMut(&Path, E) -> std::result::Result<(), E>,
     depth: usize,
 ) -> std::result::Result<usize, E>
 where
@@ -156,10 +156,17 @@ where
         });
         let opened = match directory.open_child(&name) {
             Ok(opened) => opened,
-            Err(error) => {
-                child_error(&child_path, error.into())?;
+            Err(error) if is_selected => {
+                selected_file_error(&child_path, error.into())?;
                 return Ok(());
             }
+            Err(error)
+                if is_symlink_source_rejection(&error)
+                    || is_non_regular_source_rejection(&error) =>
+            {
+                return Ok(());
+            }
+            Err(error) => return Err(error.into()),
         };
         if let OpenedProviderSourcePath::Directory(child_directory) = opened {
             visited = visited.saturating_add(visit_bounded_tree_files_at_depth(
@@ -167,7 +174,7 @@ where
                 child_directory,
                 selected,
                 visit,
-                child_error,
+                selected_file_error,
                 depth.saturating_add(1),
             )?);
         } else if is_selected {
@@ -185,7 +192,7 @@ where
                 visit(file.clone()).and_then(|()| file.opened.revalidate().map_err(E::from));
             match outcome {
                 Ok(()) => visited = visited.saturating_add(1),
-                Err(error) => child_error(&child_path, error)?,
+                Err(error) => selected_file_error(&child_path, error)?,
             }
         }
         Ok(())
@@ -851,7 +858,7 @@ mod tests {
         fs::write(root.join("c-kept.jsonl"), b"{}\n").unwrap();
 
         let mut visited = Vec::new();
-        let mut failures = Vec::new();
+        let mut isolated = 0;
         let count = visit_bounded_tree_files_isolating_selected(
             &root,
             &mut |candidate| candidate.path().extension() == Some(OsStr::new("jsonl")),
@@ -859,8 +866,8 @@ mod tests {
                 visited.push(source_file.path().file_name().unwrap().to_owned());
                 Ok::<(), SourceIoError>(())
             },
-            &mut |path, _error| {
-                failures.push(path.file_name().unwrap().to_owned());
+            &mut |_path, _error| {
+                isolated += 1;
                 Ok(())
             },
         )
@@ -872,7 +879,37 @@ mod tests {
             visited,
             [OsString::from("c-kept.jsonl"), OsString::from("kept.jsonl")]
         );
-        assert_eq!(failures, [OsString::from("b-linked-dir")]);
+        assert_eq!(isolated, 0);
+    }
+
+    #[test]
+    fn ordinary_unselected_child_open_failure_is_fatal() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("tree");
+        let raced = root.join("raced-away");
+        fs::create_dir_all(&raced).unwrap();
+        let mut isolated = 0;
+
+        let error = visit_bounded_tree_files_isolating_selected(
+            &root,
+            &mut |candidate| {
+                if candidate.path() == raced {
+                    fs::remove_dir(&raced).unwrap();
+                }
+                false
+            },
+            &mut |_| Ok::<(), SourceIoError>(()),
+            &mut |_path, _error| {
+                isolated += 1;
+                Ok(())
+            },
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(error, SourceIoError::Io(error) if error.kind() == io::ErrorKind::NotFound)
+        );
+        assert_eq!(isolated, 0);
     }
 
     #[test]

--- a/crates/ctx-history-source-io/src/bounded_tree.rs
+++ b/crates/ctx-history-source-io/src/bounded_tree.rs
@@ -65,14 +65,21 @@ where
     })
 }
 
-/// Visits a tree while containing admission/read failures for selected child
-/// files. Root and directory-enumeration failures remain fatal because no
-/// independent source boundary has been established for them.
+/// Visits a tree while containing admission/read failures for child entries.
+///
+/// A child that cannot be opened is named and handed to `child_error`, which
+/// decides whether the caller can carry on without it. That covers rejected
+/// path components, which make a subtree unreachable by policy no matter how
+/// the traversal proceeds, so failing the whole scan over one of them discards
+/// every healthy sibling for nothing.
+///
+/// Root and directory-enumeration failures stay fatal. Neither names a child to
+/// contain, and an enumeration that stops early would drop files silently.
 pub fn visit_bounded_tree_files_isolating_selected<E, Selected>(
     root: &Path,
     selected: &mut Selected,
     visit: &mut dyn FnMut(BoundedTreeSourceFile) -> std::result::Result<(), E>,
-    selected_file_error: &mut dyn FnMut(&Path, E) -> std::result::Result<(), E>,
+    child_error: &mut dyn FnMut(&Path, E) -> std::result::Result<(), E>,
 ) -> std::result::Result<usize, E>
 where
     E: From<SourceIoError>,
@@ -98,7 +105,7 @@ where
                     Ok(1)
                 }
                 Err(error) => {
-                    selected_file_error(root, error)?;
+                    child_error(root, error)?;
                     Ok(0)
                 }
             }
@@ -110,7 +117,7 @@ where
                 directory,
                 selected,
                 visit,
-                selected_file_error,
+                child_error,
                 0,
             )?;
             authority.revalidate().map_err(E::from)?;
@@ -125,7 +132,7 @@ fn visit_bounded_tree_files_at_depth<E, Selected>(
     directory: ProviderSourceDirectory,
     selected: &mut Selected,
     visit: &mut dyn FnMut(BoundedTreeSourceFile) -> std::result::Result<(), E>,
-    selected_file_error: &mut dyn FnMut(&Path, E) -> std::result::Result<(), E>,
+    child_error: &mut dyn FnMut(&Path, E) -> std::result::Result<(), E>,
     depth: usize,
 ) -> std::result::Result<usize, E>
 where
@@ -149,11 +156,10 @@ where
         });
         let opened = match directory.open_child(&name) {
             Ok(opened) => opened,
-            Err(error) if is_selected => {
-                selected_file_error(&child_path, error.into())?;
+            Err(error) => {
+                child_error(&child_path, error.into())?;
                 return Ok(());
             }
-            Err(error) => return Err(error.into()),
         };
         if let OpenedProviderSourcePath::Directory(child_directory) = opened {
             visited = visited.saturating_add(visit_bounded_tree_files_at_depth(
@@ -161,7 +167,7 @@ where
                 child_directory,
                 selected,
                 visit,
-                selected_file_error,
+                child_error,
                 depth.saturating_add(1),
             )?);
         } else if is_selected {
@@ -179,7 +185,7 @@ where
                 visit(file.clone()).and_then(|()| file.opened.revalidate().map_err(E::from));
             match outcome {
                 Ok(()) => visited = visited.saturating_add(1),
-                Err(error) => selected_file_error(&child_path, error)?,
+                Err(error) => child_error(&child_path, error)?,
             }
         }
         Ok(())
@@ -829,6 +835,44 @@ mod tests {
         assert_eq!(count, 1);
         assert_eq!(visited, [OsString::from("a-healthy.jsonl")]);
         assert_eq!(failures, [OsString::from("b-rejected.jsonl")]);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn rejected_child_directory_is_isolated_from_healthy_siblings() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("tree");
+        let reachable = root.join("a-reachable");
+        fs::create_dir_all(&reachable).unwrap();
+        fs::write(reachable.join("kept.jsonl"), b"{}\n").unwrap();
+        // A symlinked directory carries no `.jsonl` extension, so selection
+        // never claims it and the traversal used to fail the entire scan here.
+        symlink(&reachable, root.join("b-linked-dir")).unwrap();
+        fs::write(root.join("c-kept.jsonl"), b"{}\n").unwrap();
+
+        let mut visited = Vec::new();
+        let mut failures = Vec::new();
+        let count = visit_bounded_tree_files_isolating_selected(
+            &root,
+            &mut |candidate| candidate.path().extension() == Some(OsStr::new("jsonl")),
+            &mut |source_file| {
+                visited.push(source_file.path().file_name().unwrap().to_owned());
+                Ok::<(), SourceIoError>(())
+            },
+            &mut |path, _error| {
+                failures.push(path.file_name().unwrap().to_owned());
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(count, 2);
+        visited.sort();
+        assert_eq!(
+            visited,
+            [OsString::from("c-kept.jsonl"), OsString::from("kept.jsonl")]
+        );
+        assert_eq!(failures, [OsString::from("b-linked-dir")]);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #707.

## Summary

- hand every child open failure to the caller's error handler, not only failures on children selection already claimed
- keep root and directory-enumeration failures fatal
- add a regression test for a rejected child directory beside healthy siblings

## Why

`visit_bounded_tree_files_at_depth` only delegated an open failure when `is_selected` was true:

```rust
Err(error) if is_selected => {
    selected_file_error(&child_path, error.into())?;
    return Ok(());
}
Err(error) => return Err(error.into()),
```

A symlinked directory carries no selected extension, so a rejected path component took the fatal branch and failed the whole scan. That path never reached `is_quarantinable_claude_leaf_error`, which already returns true for `SYMLINK_PROVIDER_SOURCE_REASON`, so the containment from #676 was present but unreachable from discovery.

In practice one such directory removed an entire provider's history from the index, and the refresh reported it with an empty failure entry. #707 has the reproduction and the measured impact.

The handler is caller-supplied and already decides what it can continue without, so per-provider policy is unchanged and a provider that does not recognise an error still fails. The parameter is renamed `child_error` to match its widened scope.

Root and directory-enumeration failures stay fatal, as the doc comment now states explicitly: neither names a child to contain, and a truncated enumeration would drop files silently. `root_failure_is_never_downgraded_to_a_selected_file_failure` still passes unchanged.

## Verification

The new test fails without the change. Restoring the `is_selected` guard:

```text
test bounded_tree::tests::rejected_child_directory_is_isolated_from_healthy_siblings ... FAILED
```

- `cargo test -p ctx-history-source-io --lib`, 68 passed
- `cargo test -p ctx-history-provider-claude-cursor --lib`, 36 passed
- `cargo test -p ctx-history-provider-native-jsonl --lib`, 44 passed
- `cargo fmt --all -- --check`
- `cargo clippy -p ctx-history-source-io --all-targets`, no new warnings

I have not run the Bazel gates; `scripts/bazelw` pulls a pinned toolchain that is not installed here. Point me at the gate you want and I will run it.

Happy to reshape this if you would rather restrict delegation to rejected path components specifically, or solve it at the provider layer instead.
