### PR TITLE
fix(discovery): admit large flat Codex archives

### DIFF
--- a/crates/ctx-history-source-discovery/src/provider_sources/probes.rs
+++ b/crates/ctx-history-source-discovery/src/provider_sources/probes.rs
@@ -18,6 +18,7 @@ use ctx_history_source_io::{
     open_provider_source_path, provider_metadata_is_link_like, provider_safe_path_segment,
     read_provider_jsonl_line_or_skip_oversized, OpenedProviderSourcePath, ProviderJsonlLineRead,
     ProviderSourceDirectory, ProviderSourceRoot, SourceIoError,
+    PROVIDER_JSONL_INVENTORY_MAX_ELIGIBLE_PATHS, PROVIDER_JSONL_INVENTORY_MAX_METADATA_ENTRIES,
 };
 
 #[cfg(test)]
@@ -55,12 +56,7 @@ pub(super) fn default_location_import_probe(
         CaptureProvider::Codex if location.source_format == "codex_history_jsonl" => {
             path_is_file_probe(path)
         }
-        CaptureProvider::Codex => has_file_under_matching(path, 10_000, |candidate| {
-            candidate
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.ends_with(".jsonl") || name.ends_with(".jsonl.zst"))
-        }),
+        CaptureProvider::Codex => has_codex_session_file(path),
         CaptureProvider::GrokBuild => has_jsonl_file_under_matching(path, 10_000, |candidate| {
             candidate.file_name().and_then(|name| name.to_str()) == Some("updates.jsonl")
         }),
@@ -740,6 +736,94 @@ fn path_is_dir_probe(path: &Path) -> BoundedProbe {
         PathProbe::IoError => BoundedProbe::IoError,
         _ => BoundedProbe::NotFound,
     }
+}
+
+fn has_codex_session_file(root: &Path) -> BoundedProbe {
+    // Codex archives are legitimately flat and can exceed the generic recursive
+    // probe's sorting budget. Scan that one directory as a constant-memory
+    // stream under the downstream inventory's exact bounds, consuming the
+    // complete bounded stream so filesystem enumeration order cannot decide the
+    // result. Nested layouts retain the existing sorted recursive probe.
+    match has_direct_codex_session_file(root) {
+        BoundedProbe::NotFound => has_file_under_matching(root, 10_000, is_codex_session_file),
+        outcome => outcome,
+    }
+}
+
+fn has_direct_codex_session_file(root: &Path) -> BoundedProbe {
+    match path_metadata_probe(root) {
+        PathProbe::File => return BoundedProbe::from_bool(is_codex_session_file(root)),
+        PathProbe::Dir => {}
+        PathProbe::Missing | PathProbe::Other => return BoundedProbe::NotFound,
+        PathProbe::IoError => return BoundedProbe::IoError,
+    }
+
+    let entries = match fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(_) => return BoundedProbe::IoError,
+    };
+    bounded_direct_match_probe(
+        entries.map(|entry| {
+            let path = match entry {
+                Ok(entry) => entry.path(),
+                Err(_) => return DirectMatchEntry::IoError,
+            };
+            let metadata = match fs::symlink_metadata(&path) {
+                Ok(metadata) => metadata,
+                Err(_) => return DirectMatchEntry::Other,
+            };
+            if !provider_metadata_is_link_like(&metadata)
+                && metadata.file_type().is_file()
+                && is_codex_session_file(&path)
+            {
+                DirectMatchEntry::Match
+            } else {
+                DirectMatchEntry::Other
+            }
+        }),
+        PROVIDER_JSONL_INVENTORY_MAX_METADATA_ENTRIES,
+        PROVIDER_JSONL_INVENTORY_MAX_ELIGIBLE_PATHS,
+    )
+}
+
+enum DirectMatchEntry {
+    Match,
+    Other,
+    IoError,
+}
+
+fn bounded_direct_match_probe(
+    entries: impl Iterator<Item = DirectMatchEntry>,
+    max_entries: usize,
+    max_matches: usize,
+) -> BoundedProbe {
+    let mut visited = 0usize;
+    let mut matches = 0usize;
+    let mut found = false;
+    for entry in entries {
+        if visited >= max_entries {
+            return BoundedProbe::BudgetExhausted;
+        }
+        visited = visited.saturating_add(1);
+        match entry {
+            DirectMatchEntry::Match => {
+                if matches >= max_matches {
+                    return BoundedProbe::BudgetExhausted;
+                }
+                matches = matches.saturating_add(1);
+                found = true;
+            }
+            DirectMatchEntry::Other => {}
+            DirectMatchEntry::IoError => return BoundedProbe::IoError,
+        }
+    }
+    BoundedProbe::from_bool(found)
+}
+
+fn is_codex_session_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".jsonl") || name.ends_with(".jsonl.zst"))
 }
 
 fn has_jsonl_file_under_matching(

--- a/crates/ctx-history-source-discovery/src/provider_sources/probes_tests.rs
+++ b/crates/ctx-history-source-discovery/src/provider_sources/probes_tests.rs
@@ -482,6 +482,94 @@ fn oversized_directories_exhaust_before_order_can_change_the_result() {
 }
 
 #[test]
+fn codex_flat_session_probe_admits_more_than_ten_thousand_direct_entries() {
+    let entries = (0..13_001).map(|_| DirectMatchEntry::Match);
+
+    assert_eq!(
+        bounded_direct_match_probe(
+            entries,
+            PROVIDER_JSONL_INVENTORY_MAX_METADATA_ENTRIES,
+            PROVIDER_JSONL_INVENTORY_MAX_ELIGIBLE_PATHS
+        ),
+        BoundedProbe::Found
+    );
+}
+
+#[test]
+fn codex_flat_session_probe_checks_its_complete_bounded_stream() {
+    let over_entry_bound =
+        (0..=PROVIDER_JSONL_INVENTORY_MAX_METADATA_ENTRIES).map(|_| DirectMatchEntry::Other);
+    assert_eq!(
+        bounded_direct_match_probe(
+            over_entry_bound,
+            PROVIDER_JSONL_INVENTORY_MAX_METADATA_ENTRIES,
+            PROVIDER_JSONL_INVENTORY_MAX_ELIGIBLE_PATHS
+        ),
+        BoundedProbe::BudgetExhausted
+    );
+    let over_match_bound =
+        (0..=PROVIDER_JSONL_INVENTORY_MAX_ELIGIBLE_PATHS).map(|_| DirectMatchEntry::Match);
+    assert_eq!(
+        bounded_direct_match_probe(
+            over_match_bound,
+            PROVIDER_JSONL_INVENTORY_MAX_METADATA_ENTRIES,
+            PROVIDER_JSONL_INVENTORY_MAX_ELIGIBLE_PATHS
+        ),
+        BoundedProbe::BudgetExhausted
+    );
+    assert_eq!(
+        bounded_direct_match_probe(
+            [DirectMatchEntry::Match, DirectMatchEntry::IoError].into_iter(),
+            2,
+            2
+        ),
+        BoundedProbe::IoError
+    );
+}
+
+#[test]
+fn codex_filesystem_probe_admits_a_flat_tree_above_the_generic_budget() {
+    const DIRECT_ENTRIES: usize = 10_001;
+    const SEEDS: usize = 16;
+
+    let temp = tempdir();
+    let root = temp.path().join("archived_sessions");
+    let seeds = temp.path().join("seeds");
+    fs::create_dir(&root).unwrap();
+    fs::create_dir(&seeds).unwrap();
+    let seed_paths = (0..SEEDS)
+        .map(|index| {
+            let path = seeds.join(format!("seed-{index:02}.jsonl"));
+            fs::write(&path, b"{}\n").unwrap();
+            path
+        })
+        .collect::<Vec<_>>();
+    for index in 0..DIRECT_ENTRIES {
+        fs::hard_link(
+            &seed_paths[index % SEEDS],
+            root.join(format!("rollout-{index:05}.jsonl")),
+        )
+        .unwrap();
+    }
+
+    assert_eq!(has_codex_session_file(&root), BoundedProbe::Found);
+}
+
+#[cfg(unix)]
+#[test]
+fn codex_flat_session_probe_does_not_admit_a_symlinked_jsonl() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir();
+    let outside = tempdir();
+    let target = outside.path().join("session.jsonl");
+    fs::write(&target, b"{}\n").unwrap();
+    symlink(&target, temp.path().join("session.jsonl")).unwrap();
+
+    assert_eq!(has_codex_session_file(temp.path()), BoundedProbe::NotFound);
+}
+
+#[test]
 fn auggie_probe_matches_the_adapter_flat_directory_selections() {
     let direct = tempdir();
     fs::write(direct.path().join("direct.json"), b"{}\n").unwrap();

--- a/crates/ctx-history-source-discovery/src/provider_sources/tests/probe_status.rs
+++ b/crates/ctx-history-source-discovery/src/provider_sources/tests/probe_status.rs
@@ -4,9 +4,7 @@ use super::super::probes::BoundedProbe;
 #[cfg(unix)]
 use super::super::ProviderSource;
 use super::super::{ProviderDefaultLocation, ProviderSourceKind, ProviderSourceStatus};
-use super::support::{assert_source_status, tempdir};
-#[cfg(unix)]
-use super::support::{EnvGuard, ENV_LOCK};
+use super::support::{tempdir, EnvGuard, ENV_LOCK};
 
 fn default_location_import_probe(
     data_root: Option<&std::path::Path>,
@@ -41,18 +39,30 @@ fn discover_provider_sources_for_provider_report(
 }
 
 #[test]
-fn bounded_probe_reports_budget_exhausted_source_as_unknown() {
+fn codex_nested_probe_reports_budget_exhaustion_as_explicit_unknown() {
+    let _lock = ENV_LOCK.lock().unwrap();
     let temp = tempdir();
-    let claude = temp.path().join(".claude/projects");
-    std::fs::create_dir_all(&claude).unwrap();
+    let _codex_home = EnvGuard::remove("CODEX_HOME");
+    let sessions = temp.path().join(".codex/sessions");
+    std::fs::create_dir_all(&sessions).unwrap();
     for index in 0..10_001 {
-        std::fs::create_dir(claude.join(format!("project-{index:05}"))).unwrap();
+        std::fs::create_dir(sessions.join(format!("partition-{index:05}"))).unwrap();
     }
 
-    assert_source_status(
+    let report = super::super::discover_provider_sources_for_provider_report(
+        &super::super::TEST_PROVIDER_PROBES,
         temp.path(),
-        CaptureProvider::Claude,
-        ProviderSourceStatus::Unknown,
+        CaptureProvider::Codex,
+    );
+    let source = report
+        .sources
+        .iter()
+        .find(|source| source.path == sessions)
+        .expect("bounded Codex source remains visible as incomplete");
+    assert_eq!(source.status, ProviderSourceStatus::Unknown);
+    assert_eq!(
+        source.unsupported_reason,
+        Some("path exists but the Codex session transcript probe hit its scan budget")
     );
 }
 

--- a/crates/ctx-history-source-discovery/src/provider_sources/tests/support.rs
+++ b/crates/ctx-history-source-discovery/src/provider_sources/tests/support.rs
@@ -1,8 +1,4 @@
-use std::{env, ffi::OsString, path::Path, sync::Mutex};
-
-use ctx_history_core::CaptureProvider;
-
-use super::super::ProviderSourceStatus;
+use std::{env, ffi::OsString, sync::Mutex};
 
 pub(super) static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -32,16 +28,4 @@ impl Drop for EnvGuard {
             env::remove_var(self.name);
         }
     }
-}
-
-pub(super) fn assert_source_status(
-    home: &Path,
-    provider: CaptureProvider,
-    expected: ProviderSourceStatus,
-) {
-    let source = super::super::discover_provider_sources(&super::super::TEST_PROVIDER_PROBES, home)
-        .into_iter()
-        .find(|source| source.provider == provider)
-        .unwrap();
-    assert_eq!(source.status, expected, "{provider:?}");
 }


### PR DESCRIPTION
## Summary

- admit flat Codex archive directories beyond the generic 10,000-entry discovery probe
- use the downstream inventory's bounded 262,144 metadata / 131,072 eligible-path authority
- consume the complete bounded stream so filesystem enumeration order cannot decide admission
- keep nested-layout exhaustion explicit and fail closed

## Validation

- `scripts/bazelw test //crates/ctx-history-source-discovery:unit_tests --config=test`
- `scripts/bazelw test //crates/ctx-history-source-discovery:unit_tests //crates/ctx-history-source-discovery:qualification_tests --config=ci --test_output=errors`
- independent code review: no findings
- real corpus inspection: 13,082 flat archived Codex sessions
