### PR TITLE
fix(codex): retain bounded record diagnostics

### DIFF
--- a/crates/ctx-daemon-cli/src/source_status.rs
+++ b/crates/ctx-daemon-cli/src/source_status.rs
@@ -226,6 +226,87 @@ fn refresh_report(job: Option<&Value>, generation_id: Option<&str>, daemon: &Val
             .and_then(|receipt| receipt.get("source_failure_total")),
         "rejected_record_total": request_outcome
             .and_then(|receipt| receipt.get("rejected_record_total")),
+        "diagnostics": refresh_diagnostics_report(request_outcome),
+    }))
+}
+
+fn refresh_diagnostics_report(receipt: Option<&Value>) -> Option<Value> {
+    let receipt = receipt?;
+    let mut source_failures = Vec::new();
+    let mut record_rejections = Vec::new();
+    for (route_identity, result) in receipt
+        .get("route_results")
+        .and_then(Value::as_object)
+        .into_iter()
+        .flatten()
+    {
+        let Some(fields) = result.as_array() else {
+            continue;
+        };
+        let outcome = fields.first().and_then(Value::as_str);
+        if matches!(outcome, Some("s" | "f")) {
+            if let Some(failures) = fields.get(4).and_then(Value::as_array) {
+                source_failures.extend(
+                    failures.iter().filter_map(|failure| {
+                        compact_source_failure_report(route_identity, failure)
+                    }),
+                );
+            }
+        }
+        if outcome == Some("s") {
+            if let Some(rejections) = fields.get(6).and_then(Value::as_array) {
+                record_rejections.extend(rejections.iter().filter_map(|rejection| {
+                    compact_record_rejection_report(route_identity, rejection)
+                }));
+            }
+        }
+    }
+    Some(compact_json(json!({
+        "source_failure_total": receipt.get("source_failure_total"),
+        "source_failures_shown": source_failures.len(),
+        "source_failures_omitted": receipt.get("source_failures_omitted"),
+        "source_failures": source_failures,
+        "rejected_record_total": receipt.get("rejected_record_total"),
+        "rejection_diagnostics_shown": record_rejections.len(),
+        "rejection_diagnostics_omitted": receipt.get("rejection_diagnostics_omitted"),
+        "record_rejections": record_rejections,
+    })))
+}
+
+fn compact_source_failure_report(route_identity: &str, value: &Value) -> Option<Value> {
+    let fields = value.as_array().filter(|fields| fields.len() == 6)?;
+    Some(json!({
+        "route_identity": route_identity,
+        "source_identity": fields[0].as_str()?,
+        "provider": fields[1].as_str()?,
+        "class": match fields[2].as_str()? {
+            "u" => "unavailable",
+            "c" => "source_changed",
+            "r" => "unreadable",
+            "i" => "incompatible",
+            _ => return None,
+        },
+        "carried_forward": fields[3].as_bool()?,
+        "source_selector": fields[4].as_str()?,
+        "detail": fields[5].as_str()?,
+    }))
+}
+
+fn compact_record_rejection_report(route_identity: &str, value: &Value) -> Option<Value> {
+    let fields = value.as_array().filter(|fields| fields.len() == 7)?;
+    Some(json!({
+        "route_identity": route_identity,
+        "source_identity": fields[0].as_str()?,
+        "provider": fields[1].as_str()?,
+        "source_selector": fields[2].as_str()?,
+        "line": fields[3].as_u64()?,
+        "payload_type": fields[4].as_str()?,
+        "class": match fields[5].as_str()? {
+            "m" => "malformed_record",
+            "u" => "unsupported_record",
+            _ => return None,
+        },
+        "detail": fields[6].as_str()?,
     }))
 }
 

--- a/crates/ctx-daemon-cli/src/source_status_tests.rs
+++ b/crates/ctx-daemon-cli/src/source_status_tests.rs
@@ -641,6 +641,72 @@ fn published_record_rejections_are_ready_but_remain_diagnostic() {
 }
 
 #[test]
+fn automatic_refresh_diagnostics_expose_bounded_local_drilldown() {
+    let daemon = json!({"running": true});
+    let report = refresh_report(
+        Some(&json!({
+            "request_state": "published",
+            "published_generation": "generation-1",
+            "receipt": {
+                "outcome": "completed_with_rejections_and_source_failures",
+                "source_failure_total": 2,
+                "source_failures_omitted": 1,
+                "rejected_record_total": 3,
+                "rejection_diagnostics_omitted": 2,
+                "current": {"current_rejected_records": 3},
+                "route_results": {
+                    "route-1": [
+                        "s",
+                        false,
+                        2,
+                        0,
+                        [[
+                            "source-failure-1",
+                            "codex",
+                            "r",
+                            true,
+                            "logical-source:source-failure-1",
+                            "missing or conflicting Codex session owner"
+                        ]],
+                        3,
+                        [[
+                            "source-rejection-1",
+                            "codex",
+                            "/local/codex/rollout.jsonl",
+                            37,
+                            "unspecified",
+                            "m",
+                            "Codex record is not valid projectable JSON"
+                        ]]
+                    ]
+                }
+            },
+        })),
+        Some("generation-1"),
+        &daemon,
+    );
+
+    let diagnostics = &report["diagnostics"];
+    assert_eq!(diagnostics["source_failure_total"], 2);
+    assert_eq!(diagnostics["source_failures_shown"], 1);
+    assert_eq!(diagnostics["source_failures_omitted"], 1);
+    assert_eq!(diagnostics["source_failures"][0]["class"], "unreadable");
+    assert_eq!(diagnostics["source_failures"][0]["carried_forward"], true);
+    assert_eq!(diagnostics["rejected_record_total"], 3);
+    assert_eq!(diagnostics["rejection_diagnostics_shown"], 1);
+    assert_eq!(diagnostics["rejection_diagnostics_omitted"], 2);
+    assert_eq!(
+        diagnostics["record_rejections"][0]["source_selector"],
+        "/local/codex/rollout.jsonl"
+    );
+    assert_eq!(diagnostics["record_rejections"][0]["line"], 37);
+    assert_eq!(
+        diagnostics["record_rejections"][0]["class"],
+        "malformed_record"
+    );
+}
+
+#[test]
 fn source_failures_and_combined_diagnostics_remain_partial() {
     let daemon = json!({"running": true});
     for (outcome, rejected_records) in [

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence.rs
@@ -17,7 +17,7 @@ use ctx_history_core::{
 };
 use ctx_history_index::{GenerationWriter, RevalidationTarget, WriterOptions};
 
-const CURRENT_PARSER_REVISION: &str = "codex-nativepath-core-activity-v8-inherited-session-lineage";
+const CURRENT_PARSER_REVISION: &str = "codex-nativepath-core-activity-v9-record-coverage";
 
 #[path = "codex_child_independence/quarantine.rs"]
 mod quarantine;
@@ -236,6 +236,18 @@ fn successful_result(call_id: &str, output: String) -> serde_json::Value {
             "output": format!(
                 "Chunk ID: abc123\nWall time: 0.125 seconds\nProcess exited with code 0\nFinal output:\n{output}"
             )
+        }
+    })
+}
+
+fn custom_tool_result(call_id: &str, output: String) -> serde_json::Value {
+    serde_json::json!({
+        "timestamp": "2026-08-09T12:00:04Z",
+        "type": "response_item",
+        "payload": {
+            "type": "custom_tool_call_output",
+            "call_id": call_id,
+            "output": output
         }
     })
 }

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/lifecycle.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/lifecycle.rs
@@ -221,6 +221,14 @@ fn automatic_codex_root_replacement_partial_inventory_carries_archived_members()
                 .unwrap();
 
         assert!(receipt.failed_routes.is_empty(), "{disposition}");
+        match disposition {
+            "pending" => assert!(
+                receipt.logical_source_failures.is_empty(),
+                "an incomplete first record must not become an ownership quarantine"
+            ),
+            "quarantined" => assert_eq!(receipt.logical_source_failures.total(), 1),
+            _ => unreachable!(),
+        }
         assert!(
             !receipt
                 .complete_inventory_route_ids

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/projection_behaviors.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/projection_behaviors.rs
@@ -1,6 +1,58 @@
 use super::*;
 
 #[test]
+fn codex_valid_custom_tool_result_over_16_mib_is_retained() {
+    let temp = tempdir().unwrap();
+    let sessions = temp.path().join("sessions-valid-large-result");
+    let index_root = temp.path().join("index-valid-large-result");
+    fs::create_dir_all(&sessions).unwrap();
+    let native_session_id = "019fb000-0000-7000-8000-000000000074";
+    let marker = "valid-large-custom-tool-result";
+    let mut output = marker.to_owned();
+    output.push_str(&" ".repeat((17 * 1024 * 1024) - marker.len()));
+    write_session(
+        &sessions,
+        native_session_id,
+        ProviderNativeSessionRelationship::Root,
+        None,
+        [custom_tool_result("large-custom-tool-call", output)],
+    );
+    assert!(
+        fs::metadata(session_path(&sessions, native_session_id))
+            .unwrap()
+            .len()
+            > 16 * 1024 * 1024
+    );
+    assert!(
+        fs::metadata(session_path(&sessions, native_session_id))
+            .unwrap()
+            .len()
+            < 32 * 1024 * 1024
+    );
+    let registry = register_tree(&[&sessions]);
+
+    let receipt =
+        refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
+
+    assert!(receipt.failed_routes.is_empty());
+    assert!(receipt.logical_source_failures.is_empty());
+    assert!(
+        receipt.record_rejections.is_empty(),
+        "unexpected rejections: {:?}",
+        receipt.record_rejections
+    );
+    let index = VerifiedIndex::open(&index_root).unwrap();
+    let records = records_for(&index, native_session_id);
+    assert_eq!(records.len(), 1);
+    assert!(matches!(
+        &records[0].content.policy_status,
+        ctx_history_core::CoreContentPolicyStatus::Omitted { reason }
+            if reason == "Codex provider record content exceeds the Core content limit"
+    ));
+    assert!(records[0].content.normalized_body.is_none());
+}
+
+#[test]
 fn inherited_codex_session_metadata_is_admitted_in_both_provider_orders() {
     let temp = tempdir().unwrap();
     let sessions = temp.path().join("sessions-inherited-metadata-orders");

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/quarantine.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/quarantine.rs
@@ -38,6 +38,63 @@ fn catalog_owner_rejection_is_retryable_without_a_valid_sibling() {
 }
 
 #[test]
+fn malformed_codex_record_retains_valid_peers_and_reports_local_line() {
+    let temp = tempdir().unwrap();
+    let sessions = temp.path().join("sessions-record-rejection");
+    let index_root = temp.path().join("index-record-rejection");
+    fs::create_dir_all(&sessions).unwrap();
+    let native_session_id = "019fb000-0000-7000-8000-000000000073";
+    let path = session_path(&sessions, native_session_id);
+    write_session(
+        &sessions,
+        native_session_id,
+        ProviderNativeSessionRelationship::Root,
+        None,
+        [message("record-rejection-before")],
+    );
+    OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap()
+        .write_all(
+            b"{\"timestamp\":\"2026-08-09T12:00:01Z\",\"type\":\"response_item\" \"payload\":{}}\n",
+        )
+        .unwrap();
+    append_event(&path, message("record-rejection-after"));
+
+    let registry = register_tree(&[&sessions]);
+    let receipt =
+        refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
+
+    assert!(receipt.failed_routes.is_empty());
+    assert!(receipt.logical_source_failures.is_empty());
+    assert_eq!(receipt.record_rejections.total(), 1);
+    let rejection = &receipt.record_rejections.rejections()[0];
+    assert_eq!(rejection.provider, CaptureProvider::Codex);
+    assert_eq!(rejection.source_selector, path.display().to_string());
+    assert_eq!(rejection.line_number, 3);
+    assert_eq!(
+        rejection.class,
+        ctx_history_capture_runtime::SourceBackedRecordRejectionClass::MalformedRecord
+    );
+    assert_eq!(
+        rejection.detail,
+        "Codex record is not valid projectable JSON"
+    );
+    let index = VerifiedIndex::open(&index_root).unwrap();
+    assert!(source_records_contain(
+        &index,
+        native_session_id,
+        "record-rejection-before"
+    ));
+    assert!(source_records_contain(
+        &index,
+        native_session_id,
+        "record-rejection-after"
+    ));
+}
+
+#[test]
 fn codex_prefix_ownership_quarantine_retains_prior_source_and_repairs() {
     let temp = tempdir().unwrap();
     let sessions = temp.path().join("sessions-prefix-owner-conflict");
@@ -356,6 +413,8 @@ fn committed_codex_good_partial_repaired_retains_prior_source_while_neighbor_adv
 
     let (middle, _) = incremental_refresh(&index_root, &registry, &cold);
     assert!(middle.failed_routes.is_empty());
+    assert!(middle.logical_source_failures.is_empty());
+    assert!(middle.record_rejections.is_empty());
     let middle_index = VerifiedIndex::open(&index_root).unwrap();
     assert_eq!(records_for(&middle_index, repairable_id).len(), 1);
     assert!(source_records_contain(

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/reader.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/reader.rs
@@ -1,6 +1,10 @@
 use std::{collections::BTreeMap, fs::File, path::Path, sync::Arc};
 
 use chrono::{DateTime, Utc};
+use ctx_history_capture_runtime::{
+    SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDraft,
+    SourceBackedRecordRejectionDrafts,
+};
 use ctx_history_core::{CoreRecord, SourceKey, StableEntityId};
 use serde_json::Value;
 
@@ -10,7 +14,8 @@ use super::{
     record::{
         classify_after_selector_ambiguity, classify_codex_record, parse_decoded_record,
         parse_session_meta, parse_turn_context, prefilter_codex_record, CodexRecordAdmission,
-        CodexRecordClass, CodexRecordProbe, CodexResultKind, CodexSkipProjection,
+        CodexRecordClass, CodexRecordProbe, CodexResultKind, CodexRetainedKind,
+        CodexSkipProjection,
     },
     rows::{
         audit_codex_record, build_source_backed_event_row, build_source_backed_sparse_output_row,
@@ -37,10 +42,10 @@ const MAX_CODEX_PAGE_UNITS: usize = 16;
 const MAX_CODEX_SOURCE_BACKED_PAGE_RECORDS: u64 = 4 * 1024;
 const MAX_CODEX_SOURCE_BACKED_PAGE_PROGRESS_BYTES: u64 = 32 * 1024 * 1024;
 const PAGE_FIXED_WIRE_BYTES: usize = 4 * 1024;
-pub(crate) const MAX_CODEX_RECORD_BYTES: usize = 16 * 1024 * 1024;
+pub(crate) const MAX_CODEX_RECORD_BYTES: usize = 32 * 1024 * 1024;
 pub(crate) const MAX_CODEX_PAGE_BYTES: usize = 8 * 1024 * 1024;
 // One source-backed row may retain both decoded text and structured/path data
-// derived from a single 16 MiB provider record. The ordinary page bound is a
+// derived from a single 32 MiB provider record. The ordinary page bound is a
 // rollover target; this larger envelope is valid only for a singleton row.
 pub(crate) const MAX_CODEX_SOURCE_BACKED_SINGLE_ROW_PAGE_BYTES: usize =
     PAGE_FIXED_WIRE_BYTES + (MAX_CODEX_RECORD_BYTES * 2) + (1024 * 1024);
@@ -82,6 +87,7 @@ pub(crate) struct CodexNativePage {
 pub(super) struct CodexSemanticScan {
     pub(super) checkpoint: Option<super::checkpoint::CodexSemanticCheckpoint>,
     pub(super) counters: CodexScanCounters,
+    pub(super) record_rejections: SourceBackedRecordRejectionDrafts,
 }
 
 pub(crate) struct CodexNativeScanner {
@@ -91,6 +97,7 @@ pub(crate) struct CodexNativeScanner {
     pending_calls: BTreeMap<String, CodexPendingCallV0>,
     terminal_authority: CodexTerminalAuthority,
     counters: CodexScanCounters,
+    record_rejections: SourceBackedRecordRejectionDrafts,
     local_turn_started: bool,
     core_source: SourceKey,
     core_session_id: StableEntityId,

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/reader/page_builder.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/reader/page_builder.rs
@@ -65,6 +65,7 @@ impl CodexNativeScanner {
         Ok(CodexSemanticScan {
             checkpoint,
             counters: self.counters,
+            record_rejections: self.record_rejections,
         })
     }
 

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/reader/project.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/reader/project.rs
@@ -36,9 +36,16 @@ impl CodexNativeScanner {
             .filter(|probe| !probe.lineage_malformed())
             .or_else(|| classify_after_selector_ambiguity(record))
         else {
-            self.reject(false);
+            self.reject_record(
+                physical,
+                None,
+                SourceBackedRecordRejectionClass::MalformedRecord,
+                "Codex record is not valid projectable JSON",
+                false,
+            );
             return Ok(CodexRecordProjection::default());
         };
+        let payload_type = codex_record_payload_type(probe.class);
         match probe.class {
             CodexRecordClass::DescendantActivity | CodexRecordClass::DescendantStarted => {
                 self.counters.ignored_records = self.counters.ignored_records.saturating_add(1);
@@ -48,7 +55,13 @@ impl CodexNativeScanner {
                 self.counters.typed_json_parses = self.counters.typed_json_parses.saturating_add(1);
                 match parse_session_meta(record) {
                     Some(metadata) => self.observe_session_metadata(metadata)?,
-                    None => self.reject(false),
+                    None => self.reject_record(
+                        physical,
+                        Some(payload_type),
+                        SourceBackedRecordRejectionClass::MalformedRecord,
+                        "Codex session_meta record is malformed",
+                        false,
+                    ),
                 }
                 Ok(CodexRecordProjection::default())
             }
@@ -61,7 +74,13 @@ impl CodexNativeScanner {
                             valid_local_turn_boundary(&owner.native_session_id, turn_id)
                         });
                     }
-                    (None, _) | (_, None) => self.reject(false),
+                    (None, _) | (_, None) => self.reject_record(
+                        physical,
+                        Some(payload_type),
+                        SourceBackedRecordRejectionClass::MalformedRecord,
+                        "Codex turn_context record is malformed or has no admitted owner",
+                        false,
+                    ),
                 }
                 Ok(CodexRecordProjection::default())
             }
@@ -71,14 +90,26 @@ impl CodexNativeScanner {
             }
             CodexRecordClass::Retained(kind) => {
                 let Some(owner) = self.owner.as_ref() else {
-                    self.reject(false);
+                    self.reject_record(
+                        physical,
+                        Some(payload_type),
+                        SourceBackedRecordRejectionClass::MalformedRecord,
+                        "Codex retained record has no admitted session owner",
+                        false,
+                    );
                     return Ok(CodexRecordProjection::default());
                 };
                 self.counters.retained_json_parses =
                     self.counters.retained_json_parses.saturating_add(1);
                 self.counters.typed_json_parses = self.counters.typed_json_parses.saturating_add(1);
                 let Some(retained) = parse_decoded_record(record, owner) else {
-                    self.reject(false);
+                    self.reject_record(
+                        physical,
+                        Some(payload_type),
+                        SourceBackedRecordRejectionClass::MalformedRecord,
+                        "Codex retained record payload is malformed",
+                        false,
+                    );
                     return Ok(CodexRecordProjection::default());
                 };
                 let mut built = match build_source_backed_event_row(
@@ -94,7 +125,13 @@ impl CodexNativeScanner {
                         return Ok(CodexRecordProjection::default());
                     }
                     Err(CodexRetainedNonMaterialized::Malformed) => {
-                        self.reject(false);
+                        self.reject_record(
+                            physical,
+                            Some(payload_type),
+                            SourceBackedRecordRejectionClass::MalformedRecord,
+                            "Codex retained record semantic payload is malformed",
+                            false,
+                        );
                         return Ok(CodexRecordProjection::default());
                     }
                 };
@@ -110,7 +147,13 @@ impl CodexNativeScanner {
                     > MAX_CODEX_SOURCE_BACKED_SINGLE_ROW_PAGE_BYTES
                         .saturating_sub(PAGE_FIXED_WIRE_BYTES)
                 {
-                    self.reject(false);
+                    self.reject_record(
+                        physical,
+                        Some(payload_type),
+                        SourceBackedRecordRejectionClass::UnsupportedRecord,
+                        "Codex retained record exceeds the bounded projection row envelope",
+                        false,
+                    );
                     return Ok(CodexRecordProjection::default());
                 }
                 let lexical_bytes = built.row.lexical_body.len();
@@ -254,11 +297,23 @@ impl CodexNativeScanner {
                 })
         });
         let Some(owner) = self.owner.clone() else {
-            self.reject(false);
+            self.reject_record(
+                physical,
+                Some(codex_record_payload_type(probe.class)),
+                SourceBackedRecordRejectionClass::MalformedRecord,
+                "Codex result record has no admitted session owner",
+                false,
+            );
             return Ok(CodexRecordProjection::default());
         };
         let Some(occurred_at) = probe_timestamp(probe, owner.started_at) else {
-            self.reject(false);
+            self.reject_record(
+                physical,
+                Some(codex_record_payload_type(probe.class)),
+                SourceBackedRecordRejectionClass::MalformedRecord,
+                "Codex result record has no valid timestamp",
+                false,
+            );
             return Ok(CodexRecordProjection::default());
         };
 
@@ -280,7 +335,9 @@ impl CodexNativeScanner {
                 value => serde_json::to_string(value)?,
             }
         };
-        let structured_content = (!audit.any_selector_ambiguous()).then(|| decoded.payload.clone());
+        let content_exceeds_core = normalized_body.len() > ctx_history_core::MAX_CORE_CONTENT_BYTES;
+        let structured_content = (!content_exceeds_core && !audit.any_selector_ambiguous())
+            .then(|| decoded.payload.clone());
         let core_row = build_source_backed_sparse_output_row(
             physical.raw_ordinal,
             provider_event_identity(&decoded.payload),
@@ -304,7 +361,13 @@ impl CodexNativeScanner {
                     > MAX_CODEX_SOURCE_BACKED_SINGLE_ROW_PAGE_BYTES
                         .saturating_sub(PAGE_FIXED_WIRE_BYTES)
                 {
-                    self.reject(false);
+                    self.reject_record(
+                        physical,
+                        Some(codex_record_payload_type(probe.class)),
+                        SourceBackedRecordRejectionClass::UnsupportedRecord,
+                        "Codex result record exceeds the bounded projection row envelope",
+                        false,
+                    );
                     return Ok(CodexRecordProjection::default());
                 }
                 self.counters.retained_records = self.counters.retained_records.saturating_add(1);
@@ -401,6 +464,49 @@ impl CodexNativeScanner {
         }
         self.counters.rejected_complete_records =
             self.counters.rejected_complete_records.saturating_add(1);
+    }
+
+    pub(super) fn reject_record(
+        &mut self,
+        physical: CodexPhysicalRecordContext,
+        payload_type: Option<&str>,
+        class: SourceBackedRecordRejectionClass,
+        detail: &'static str,
+        oversized: bool,
+    ) {
+        self.reject(oversized);
+        self.record_rejections
+            .record(SourceBackedRecordRejectionDraft {
+                source: self.core_source.clone(),
+                provider: ctx_history_core::CaptureProvider::Codex,
+                source_selector: self.source.source_path.display().to_string(),
+                line_number: physical.raw_ordinal.saturating_add(1),
+                payload_type: payload_type.map(str::to_owned),
+                class,
+                detail: detail.to_owned(),
+            });
+    }
+}
+
+fn codex_record_payload_type(class: CodexRecordClass) -> &'static str {
+    match class {
+        CodexRecordClass::SessionMeta => "session_meta",
+        CodexRecordClass::TurnContext => "turn_context",
+        CodexRecordClass::DescendantActivity => "agent_message",
+        CodexRecordClass::DescendantStarted => "agent_message.started",
+        CodexRecordClass::Retained(CodexRetainedKind::Message) => "message",
+        CodexRecordClass::Retained(CodexRetainedKind::Reasoning) => "reasoning",
+        CodexRecordClass::Retained(CodexRetainedKind::Compacted) => "compacted",
+        CodexRecordClass::Retained(CodexRetainedKind::ToolCall) => "tool_call",
+        CodexRecordClass::ExcludedResult(CodexResultKind::FunctionCallOutput) => {
+            "function_call_output"
+        }
+        CodexRecordClass::ExcludedResult(CodexResultKind::CustomToolCallOutput) => {
+            "custom_tool_call_output"
+        }
+        CodexRecordClass::ExcludedResult(CodexResultKind::ToolSearchOutput) => "tool_search_output",
+        CodexRecordClass::ExcludedResult(CodexResultKind::OtherResult) => "tool_result",
+        CodexRecordClass::Ignored => "ignored",
     }
 }
 

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/reader/scanner.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/reader/scanner.rs
@@ -20,6 +20,7 @@ impl CodexNativeScanner {
             pending_calls: BTreeMap::new(),
             terminal_authority: CodexTerminalAuthority::default(),
             counters: CodexScanCounters::default(),
+            record_rejections: SourceBackedRecordRejectionDrafts::default(),
             local_turn_started: false,
             core_source,
             core_session_id,
@@ -184,6 +185,11 @@ impl CodexNativeScanner {
             }
 
             self.counters.complete_records = self.counters.complete_records.saturating_add(1);
+            let physical = CodexPhysicalRecordContext {
+                raw_ordinal: record.physical_ordinal(),
+                start_byte: record.byte_start(),
+                end_byte: record.byte_end_exclusive(),
+            };
             let mut projection = if self.ownership_quarantined {
                 if record.terminal_nul_padding() {
                     self.counters.ignored_records = self.counters.ignored_records.saturating_add(1);
@@ -195,17 +201,16 @@ impl CodexNativeScanner {
                 self.counters.ignored_records = self.counters.ignored_records.saturating_add(1);
                 CodexRecordProjection::default()
             } else if record.oversized() {
-                self.reject(true);
+                self.reject_record(
+                    physical,
+                    None,
+                    SourceBackedRecordRejectionClass::UnsupportedRecord,
+                    "Codex record exceeds the bounded 32 MiB record size",
+                    true,
+                );
                 CodexRecordProjection::default()
             } else {
-                self.process_record(
-                    input.record_bytes(record)?,
-                    CodexPhysicalRecordContext {
-                        raw_ordinal: record.physical_ordinal(),
-                        start_byte: record.byte_start(),
-                        end_byte: record.byte_end_exclusive(),
-                    },
-                )?
+                self.process_record(input.record_bytes(record)?, physical)?
             };
 
             let page = self.active_semantic_page()?;
@@ -227,7 +232,13 @@ impl CodexNativeScanner {
                     self.restore_semantic(input, position)?;
                     return self.emit_active_semantic_page().map(Some);
                 }
-                self.reject(false);
+                self.reject_record(
+                    physical,
+                    None,
+                    SourceBackedRecordRejectionClass::UnsupportedRecord,
+                    "Codex record exceeds the bounded projection page envelope",
+                    false,
+                );
                 projection = CodexRecordProjection::default();
             } else {
                 self.active_semantic_page()?.serialized_bytes = next_bytes;

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/rows.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/rows.rs
@@ -223,21 +223,30 @@ pub(super) fn build_source_backed_sparse_output_row(
     session_cwd: Option<String>,
 ) -> CaptureResult<Option<CodexCoreRecordDraft>> {
     let audit = audit_codex_record(raw_record)?;
+    let content_exceeds_core = normalized_body.len() > ctx_history_core::MAX_CORE_CONTENT_BYTES;
     let lexical_body =
         source_backed_lexical_body(result_event_type, Some(EventRole::Tool), &normalized_body);
-    let activity = codex_result_activity(
-        provider_call_id,
-        result_content,
-        payload,
-        &audit,
-        occurred_at,
-    );
-    let discovery_exclusion = codex_result_discovery_exclusion(
-        raw_record,
-        linked_invocation_discovery_exclusion,
-        source_unique_terminal,
-        activity.as_ref(),
-    );
+    let activity = (!content_exceeds_core)
+        .then(|| {
+            codex_result_activity(
+                provider_call_id,
+                result_content,
+                payload,
+                &audit,
+                occurred_at,
+            )
+        })
+        .flatten();
+    let discovery_exclusion = (!content_exceeds_core)
+        .then(|| {
+            codex_result_discovery_exclusion(
+                raw_record,
+                linked_invocation_discovery_exclusion,
+                source_unique_terminal,
+                activity.as_ref(),
+            )
+        })
+        .flatten();
     Ok(Some(CodexCoreRecordDraft {
         raw_ordinal,
         provider_event_identity: (!audit.selector_ambiguous(SelectorGroup::CallId))

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/source_backed.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/source_backed.rs
@@ -43,7 +43,7 @@ const CODEX_NATIVE_SESSION_NAMESPACE: &str = "codex.session";
 const CODEX_LOGICAL_SESSION_KIND: &str = "codex-session";
 const CODEX_LOGICAL_EVENT_KIND: &str = "codex-event";
 const CODEX_SOURCE_SCHEMA_VARIANT: &str = "codex-nativepath-jsonl-v0";
-const CODEX_PARSER_REVISION: &str = "codex-nativepath-core-activity-v8-inherited-session-lineage";
+const CODEX_PARSER_REVISION: &str = "codex-nativepath-core-activity-v9-record-coverage";
 
 type CodexSessionPlanV0 = (CodexCatalogSource, SourceKey, String);
 

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/source_backed/identity.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/source_backed/identity.rs
@@ -245,6 +245,8 @@ pub(in crate::codex::nativepath) fn codex_core_record(
     if lexical_body.is_empty() {
         return Err(CodexSourceBackedErrorV0::MissingLexicalBody);
     }
+    let content_omission = (lexical_body.len() > ctx_history_core::MAX_CORE_CONTENT_BYTES)
+        .then_some("Codex provider record content exceeds the Core content limit");
     let mut session_facts = Vec::new();
     if let Some(cwd) = session_cwd.as_deref().filter(|value| !value.is_empty()) {
         session_facts.push(ctx_history_core::ProviderDeclaredFact {
@@ -303,7 +305,7 @@ pub(in crate::codex::nativepath) fn codex_core_record(
         raw_ordinal,
         event_type.as_str(),
         CODEX_PARSER_REVISION,
-        lexical_body,
+        content_omission.map_or(lexical_body, |_| "Codex content omitted".to_owned()),
     )?;
     record.parent_session_id = parent_session_id;
     record.root_session_id = match owner.session_relationship {
@@ -337,6 +339,14 @@ pub(in crate::codex::nativepath) fn codex_core_record(
             ctx_history_core::AgentScope::Subagent
         }
     });
+    if let Some(reason) = content_omission {
+        record.content.policy_status = ctx_history_core::CoreContentPolicyStatus::Omitted {
+            reason: reason.to_owned(),
+        };
+        record.content.normalized_body = None;
+        record.validate_contract()?;
+        return Ok(record);
+    }
     let mut structured_content = structured_content;
     if !ctx_history_jsonl::selected_content_fits(
         record

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/source_backed/jsonl_family.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/source_backed/jsonl_family.rs
@@ -5,13 +5,13 @@ use crate::provider::source_backed::{ProviderBaseEventLookup, ProviderRuntimeBin
 use crate::{
     provider::source_backed::{
         family::jsonl::{
-            observe_opened_file, observe_opened_file_allow_append, JsonlFamilyAdapter,
-            JsonlFamilyAppendMode, JsonlFamilyExecutionIo, JsonlFamilyInventory,
-            JsonlFamilyInventoryMode, JsonlFamilyLeaf, JsonlFamilyMembershipObservation,
-            JsonlFamilyOpenedMember, JsonlFamilyProjectionMode, JsonlFamilyRejectedLeaf,
-            JsonlFamilyRootMissingMode, JsonlFamilySemanticExecutor, JsonlFamilySemanticPage,
-            JsonlFamilySemanticPreflight, JsonlFamilySemanticSummary, JsonlFamilyWorkerContext,
-            JsonlFileObservation, JsonlRecordFraming,
+            observe_opened_file, observe_opened_file_allow_append, probe_records_until,
+            JsonlFamilyAdapter, JsonlFamilyAppendMode, JsonlFamilyExecutionIo,
+            JsonlFamilyInventory, JsonlFamilyInventoryMode, JsonlFamilyLeaf,
+            JsonlFamilyMembershipObservation, JsonlFamilyOpenedMember, JsonlFamilyProjectionMode,
+            JsonlFamilyRejectedLeaf, JsonlFamilyRootMissingMode, JsonlFamilySemanticExecutor,
+            JsonlFamilySemanticPage, JsonlFamilySemanticPreflight, JsonlFamilySemanticSummary,
+            JsonlFamilyWorkerContext, JsonlFileObservation, JsonlRecordFraming,
         },
         SourceBackedRouteErrorKind,
     },
@@ -65,6 +65,17 @@ fn generation_source_owner_is_admissible_v0(
         return Ok(true);
     }
     let opened = reopen_codex_source_capability(source)?;
+    if probe_records_until(&source.source_path, &opened, 1, |_| {
+        Ok::<Option<()>, CaptureError>(Some(()))
+    })?
+    .is_none()
+    {
+        // A nonempty file without one complete first physical record is an
+        // in-progress JSONL write. Shared JSONL will classify it as pending;
+        // it has no complete provider record on which to make an ownership
+        // decision yet.
+        return Ok(true);
+    }
     let observed = match crate::provider::codex::catalog::probe_codex_native_session_id(
         &source.source_path,
         &opened,
@@ -293,7 +304,8 @@ impl<B: ProviderRuntimeBinding> JsonlFamilySemanticExecutor for CodexSessionSema
             scan.counters.retained_records,
             scan.counters.rejected_complete_records,
             provider_checkpoint,
-        );
+        )
+        .with_record_rejections(scan.record_rejections);
         Ok(match ownership_quarantine {
             Some((source, detail)) => summary.with_logical_source_quarantine(source, detail),
             None => summary,
@@ -549,7 +561,7 @@ impl<B: ProviderRuntimeBinding> JsonlFamilyAdapter for CodexSessionJsonlFamilyAd
     }
 
     fn record_framing(&self) -> JsonlRecordFraming {
-        JsonlRecordFraming::terminal_nul_padded(crate::MAX_PROVIDER_JSONL_LINE_BYTES)
+        JsonlRecordFraming::terminal_nul_padded(super::super::reader::MAX_CODEX_RECORD_BYTES)
     }
 
     fn physical_encoding(&self, leaf: &JsonlFamilyLeaf) -> JsonlPhysicalEncoding {


### PR DESCRIPTION
## Summary

- admit structurally valid Codex records up to the established 32 MiB provider bound
- retain identity and context while omitting content above Core's 16 MiB content envelope
- treat a non-newline-terminated first record as pending without weakening complete ownerless/conflicting rollout quarantine
- preserve bounded record-level rejection diagnostics and expose additive local status JSON drilldown

## Validation

- `//crates/ctx-history-provider-codex:unit_tests`
- `//crates/ctx-daemon-cli:unit_tests`
- `//crates/ctx-history-capture-composition-qualification:provider_lifecycle_tests`
- real-corpus structural analysis: rejected records 11 -> 9, rejected sources 10 -> 8, source failures 2 -> 1
