### PR TITLE
fix(cli): satisfy doctor Clippy gate

### DIFF
--- a/crates/ctx-cli/src/commands/doctor.rs
+++ b/crates/ctx-cli/src/commands/doctor.rs
@@ -48,7 +48,7 @@ pub(crate) fn run_doctor(
             ui.stdout_context(),
             &findings,
             model.health.as_ref(),
-            human_refresh_failure(&source_report),
+            human_refresh_failure(source_report),
         );
         ui.write_stdout(&document)?;
     }


### PR DESCRIPTION
## Summary

- remove the needless borrow in the doctor human-render path
- restore the exact public CLI CI build on current main

## Validation

- `ctx-build-governor exec -- scripts/bazelw build //crates/ctx-cli:ctx --config=ci`
- `git diff --check HEAD^ HEAD`