### PR TITLE
docs: refresh Codex attribution parser revision

### DIFF
--- a/docs/mcp-tool-call-attribution-capabilities.json
+++ b/docs/mcp-tool-call-attribution-capabilities.json
@@ -432,7 +432,7 @@
       "provider_id": "codex", "route": "native_import", "source_format": "codex_session_jsonl_tree", "source_schema": "codex-nativepath-jsonl-v0",
       "producer_bound": {"kind": "unversioned", "generation": 1, "unknown_generations": "not-qualified"},
       "implementation_source": "crates/ctx-history-provider-codex/src/codex/nativepath/source_backed.rs",
-      "parser_revision": "codex-nativepath-core-activity-v8-inherited-session-lineage",
+      "parser_revision": "codex-nativepath-core-activity-v9-record-coverage",
       "suite_id": "ctx-history-provider-codex::native_unit",
       "tests": [
         {"id": "codex::nativepath::rows::tests::mcp_terminal_activity_preserves_exact_server_tool_and_linkage", "source": "crates/ctx-history-provider-codex/src/codex/nativepath/rows/tests.rs"},

--- a/docs/mcp-tool-call-attribution.md
+++ b/docs/mcp-tool-call-attribution.md
@@ -85,7 +85,7 @@ trace. Capability revision 4 exact providers are Codex, Warp, and Copilot CLI.
 The exact full tuples are:
 
 - Codex `codex_session_jsonl_tree` / `codex-nativepath-jsonl-v0`, parser
-  `codex-nativepath-core-activity-v8-inherited-session-lineage`, for unversioned producer
+  `codex-nativepath-core-activity-v9-record-coverage`, for unversioned producer
   generation 1 only. Codex producer versions 0.200.0, 0.201.0, and 0.202.0 are
   separate explicit `not-qualified` lanes and never inherit exact status.
 - Warp `warp_sqlite` / `warp-agent-task-protobuf-v1`, parser

--- a/scripts/check_mcp_tool_call_attribution_capabilities_lib.py
+++ b/scripts/check_mcp_tool_call_attribution_capabilities_lib.py
@@ -817,7 +817,7 @@ def validate_public_docs(
     required = (
         "Codex `codex_session_jsonl_tree` / `codex-nativepath-jsonl-v0`",
         "49 capability lanes: three `exact`, 45 `not-qualified`, and one `excluded`",
-        "`codex-nativepath-core-activity-v8-inherited-session-lineage`",
+        "`codex-nativepath-core-activity-v9-record-coverage`",
         "`warp-source-backed-logical-v7-neutral-activity-agent-scope`",
         "`copilot-cli-direct-native-jsonl-v8-optional-activity-admission`",
         "`activity.invocation`",


### PR DESCRIPTION
## Summary

- align the Codex MCP attribution capability metadata with the v9 record-coverage parser revision
- restore the current-main docs gate after the runtime parser revision advanced

## Validation

- `scripts/check-docs.sh` (including 26 capability tests)
- `git diff --check HEAD^ HEAD`
- guarded public push checks