### PR TITLE
fix(cli): preserve empty sources in JSON

### DIFF
--- a/crates/ctx-history-cli/src/sources.rs
+++ b/crates/ctx-history-cli/src/sources.rs
@@ -70,7 +70,9 @@ where
         },
     )?;
     let discovery_report = listing.discovery;
-    let sources = &listing.visible_sources;
+    let mut sources = listing.visible_sources;
+    sources.retain(|source| source_is_visible_for_output(source, show_all_sources, request.format));
+    let sources = &sources;
     let plugin_sources = listing.plugins.sources;
     let plugin_failures = listing.plugins.failures;
     let existing = sources.iter().filter(|source| source.exists).count();
@@ -142,6 +144,14 @@ where
         content_bytes,
         output_bytes,
     })
+}
+
+fn source_is_visible_for_output(
+    source: &SourceInfo,
+    show_all_sources: bool,
+    format: OutputFormat,
+) -> bool {
+    format == OutputFormat::Json || show_all_sources || source.status != ProviderSourceStatus::Empty
 }
 
 #[cfg(test)]

--- a/crates/ctx-history-cli/src/sources_ui_tests.rs
+++ b/crates/ctx-history-cli/src/sources_ui_tests.rs
@@ -292,18 +292,23 @@ fn sources_empty_state_is_actionable() {
 }
 
 #[test]
-fn default_sources_hide_empty_provider_while_all_retains_it() {
+fn concise_sources_hide_empty_provider_while_json_and_all_retain_it() {
     let mut empty = source(ProviderSourceStatus::Empty, "/tmp/gemini");
     empty.provider = CaptureProvider::Gemini;
     empty.source_format = "gemini_session_json_tree";
     let default_sources = std::slice::from_ref(&empty)
         .iter()
-        .filter(|source| source_is_visible(source, false, &[], &[]))
+        .filter(|source| source_is_visible_for_output(source, false, OutputFormat::Text))
         .cloned()
         .collect::<Vec<_>>();
     let all_sources = std::slice::from_ref(&empty)
         .iter()
-        .filter(|source| source_is_visible(source, true, &[], &[]))
+        .filter(|source| source_is_visible_for_output(source, true, OutputFormat::Text))
+        .cloned()
+        .collect::<Vec<_>>();
+    let json_sources = std::slice::from_ref(&empty)
+        .iter()
+        .filter(|source| source_is_visible_for_output(source, false, OutputFormat::Json))
         .cloned()
         .collect::<Vec<_>>();
     let context = context(80, ColorMode::Never);
@@ -318,6 +323,8 @@ fn default_sources_hide_empty_provider_while_all_retains_it() {
         "{default}"
     );
     assert!(!default.contains("gemini"), "{default}");
+    assert_eq!(json_sources.len(), 1);
+    assert_eq!(json_sources[0].status, ProviderSourceStatus::Empty);
 
     let all = render_sources_human(
         &context,

--- a/crates/ctx-history-ingest-application/src/listing.rs
+++ b/crates/ctx-history-ingest-application/src/listing.rs
@@ -159,12 +159,11 @@ pub fn source_is_visible(
     default_visible_missing_providers: &[CaptureProvider],
 ) -> bool {
     show_all_sources
-        || (source.status != ProviderSourceStatus::Empty
-            && (source.route_provenance.configured_root().is_some()
-                || configured_provider_roots
-                    .iter()
-                    .any(|root| provider_source_belongs_to_configured_root(root, source))
-                || source_visible_by_default(source, default_visible_missing_providers)))
+        || source.route_provenance.configured_root().is_some()
+        || configured_provider_roots
+            .iter()
+            .any(|root| provider_source_belongs_to_configured_root(root, source))
+        || source_visible_by_default(source, default_visible_missing_providers)
 }
 fn source_visible_by_default(
     source: &ProviderSource,
@@ -286,7 +285,7 @@ mod tests {
     }
 
     #[test]
-    fn existing_empty_source_is_hidden_by_default_and_retained_by_all() {
+    fn existing_empty_source_remains_in_default_listing() {
         let temp = tempfile::tempdir().unwrap();
         let report = DiscoveryReport {
             sources: vec![source("empty-history", ProviderSourceStatus::Empty)],
@@ -294,7 +293,7 @@ mod tests {
         };
         let default = assemble_source_listing(
             &Port {
-                all: report.clone(),
+                all: report,
                 calls: Cell::new(0),
             },
             temp.path(),
@@ -306,24 +305,11 @@ mod tests {
             },
         )
         .unwrap();
-        assert!(default.visible_sources.is_empty());
+        assert_eq!(default.visible_sources.len(), 1);
+        assert_eq!(
+            default.visible_sources[0].status,
+            ProviderSourceStatus::Empty
+        );
         assert_eq!(default.hidden_missing_sources, 0);
-
-        let all = assemble_source_listing(
-            &Port {
-                all: report,
-                calls: Cell::new(0),
-            },
-            temp.path(),
-            SourceListingRequest {
-                provider_filter: None,
-                show_all: true,
-                configured_provider_roots: vec![],
-                default_visible_missing_providers: vec![CaptureProvider::Codex],
-            },
-        )
-        .unwrap();
-        assert_eq!(all.visible_sources.len(), 1);
-        assert_eq!(all.visible_sources[0].status, ProviderSourceStatus::Empty);
     }
 }


### PR DESCRIPTION
## Summary

- Restore discovered empty provider rows to the stable default JSON source inventory.
- Keep empty providers hidden only in concise human source output, while preserving sources --all.
- Leave import-all selection and the setup/status/doctor history-health presentation unchanged.

## Root cause

#713 added an empty-provider suppression rule to the shared source-listing predicate. Both human rendering and default JSON consumed that shared filtered list, so the presentation improvement unintentionally removed the empty Gemini row that import-all compatibility coverage expects.

This repair restores the shared inventory contract and applies the quiet-empty rule at the human-output seam instead. It does not enable all-scope JSON or expose otherwise-hidden missing providers.

## Behavior matrix

| Surface | Result |
| --- | --- |
| Default human sources | Empty providers remain hidden |
| Default JSON sources | Discovered empty providers are retained; missing-source scope is unchanged |
| sources --all | Empty and missing providers remain visible |
| import --all | Empty providers remain non-importable, are skipped, and the import succeeds |
| setup/status/doctor | #713 history-health presentation remains unchanged |

## Validation

- Focused six-target Bazel matrix passed, including history listing/CLI/presentation/status units and setup_sources_import_tests.
- The original import_all_skips_empty_gemini_source contract passes.
- Affected testing selected 60 targets; all repair-owned targets passed.
- Full CI strict build passed; 211 of 214 broad tests passed on the pinned base. The three failures were unrelated current-main failures at that SHA: docs_check (subsequently repaired by #715) and the two native-provider runtime contracts covered by #712.
- Repository policy, formatting, diff checks, and clean-merge simulation against current main passed.
- Fresh exact-diff compatibility review returned no findings.

## Performance

This is presentation/listing-only. It adds one linear in-memory filter over already-discovered source descriptors and no extra discovery, filesystem, import, storage, daemon, or serialization work, so no performance benchmark is warranted.