### PR TITLE
docs(mcp): drop mirrored parser revision pins

### DIFF
--- a/docs/mcp-tool-call-attribution-capabilities.json
+++ b/docs/mcp-tool-call-attribution-capabilities.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "capability": "exact_mcp_tool_call_attribution",
   "capability_revision": 4,
   "scope": "Exact event-local MCP dispatch server alias and advertised tool identity only; general provider import support is defined separately.",
@@ -432,7 +432,6 @@
       "provider_id": "codex", "route": "native_import", "source_format": "codex_session_jsonl_tree", "source_schema": "codex-nativepath-jsonl-v0",
       "producer_bound": {"kind": "unversioned", "generation": 1, "unknown_generations": "not-qualified"},
       "implementation_source": "crates/ctx-history-provider-codex/src/codex/nativepath/source_backed.rs",
-      "parser_revision": "codex-nativepath-core-activity-v9-record-coverage",
       "suite_id": "ctx-history-provider-codex::native_unit",
       "tests": [
         {"id": "codex::nativepath::rows::tests::mcp_terminal_activity_preserves_exact_server_tool_and_linkage", "source": "crates/ctx-history-provider-codex/src/codex/nativepath/rows/tests.rs"},
@@ -444,7 +443,6 @@
       "provider_id": "warp", "route": "native_import", "source_format": "warp_sqlite", "source_schema": "warp-agent-task-protobuf-v1",
       "producer_bound": {"kind": "unversioned", "generation": 1, "unknown_generations": "not-qualified"},
       "implementation_source": "crates/ctx-history-providers-sqlite-selected/src/providers/warp/source_backed.rs",
-      "parser_revision": "warp-source-backed-logical-v7-neutral-activity-agent-scope",
       "suite_id": "ctx-history-providers-sqlite-selected::native_unit",
       "tests": [
         {"id": "providers::warp::nativepath::decode::tests::qualified_mcp_success_error_cancellation_and_nontext_results_link_exactly", "source": "crates/ctx-history-providers-sqlite-selected/src/providers/warp/nativepath/decode/tests.rs"},
@@ -456,7 +454,6 @@
       "provider_id": "copilot_cli", "route": "native_import", "source_format": "copilot_cli_session_events_jsonl", "source_schema": "copilot-cli-direct-native-jsonl-v1",
       "producer_bound": {"kind": "unversioned", "generation": 1, "unknown_generations": "not-qualified"},
       "implementation_source": "crates/ctx-history-provider-native-jsonl/src/native_path/copilot.rs",
-      "parser_revision": "copilot-cli-direct-native-jsonl-v8-optional-activity-admission",
       "suite_id": "ctx-history-provider-native-jsonl::native_unit",
       "tests": [
         {"id": "native_path::source_backed::copilot_tests::invocation_preserves_exact_native_identity_and_arguments", "source": "crates/ctx-history-provider-native-jsonl/src/native_path/source_backed_copilot_tests.rs"},

--- a/docs/mcp-tool-call-attribution-evidence.md
+++ b/docs/mcp-tool-call-attribution-evidence.md
@@ -30,10 +30,10 @@ duplicate, or ambiguous identity evidence must not become a qualifying
 The machine-readable authority is
 [`mcp-tool-call-attribution-capabilities.json`](mcp-tool-call-attribution-capabilities.json).
 Its 49 capability lanes contain three `exact`, 45 `not-qualified`, and one
-`excluded` row. Each exact row names its current implementation and parser
-revision plus the owning Cargo/Bazel suite and live Rust tests. The checker
-resolves those references against the repository; the owning targets execute
-the behavioral tests through normal CI.
+`excluded` row. Each exact row names its current implementation plus the owning
+Cargo/Bazel suite and live Rust tests. The checker resolves those references
+against the repository; the owning targets execute the behavioral tests through
+normal CI.
 
 For Codex's session-tree route, only unversioned generation 1 is exact.
 Producer versions 0.200.0, 0.201.0, and 0.202.0 are distinct
@@ -75,9 +75,8 @@ unrelated metadata.
    implication.
 2. Record public evidence, observed pins, and fail-closed treatment of unknown
    generations.
-3. For `exact`, bind the current parser revision and the owning runtime tests.
-   For `not-qualified`, choose one primary typed reason and explain secondary
-   defects in `detail`.
+3. For `exact`, bind the owning runtime tests. For `not-qualified`, choose one
+   primary typed reason and explain secondary defects in `detail`.
 4. Run `python3 scripts/check-mcp-tool-call-attribution-capabilities.py`, its
    mutation tests, the three focused provider suites, and the normal docs
    check.

--- a/docs/mcp-tool-call-attribution.md
+++ b/docs/mcp-tool-call-attribution.md
@@ -84,19 +84,17 @@ Agents contributes its local SQLite import plus a separately excluded hosted
 trace. Capability revision 4 exact providers are Codex, Warp, and Copilot CLI.
 The exact full tuples are:
 
-- Codex `codex_session_jsonl_tree` / `codex-nativepath-jsonl-v0`, parser
-  `codex-nativepath-core-activity-v9-record-coverage`, for unversioned producer
-  generation 1 only. Codex producer versions 0.200.0, 0.201.0, and 0.202.0 are
+- Codex `codex_session_jsonl_tree` / `codex-nativepath-jsonl-v0`, for
+  unversioned producer generation 1 only. Codex producer versions 0.200.0,
+  0.201.0, and 0.202.0 are
   separate explicit `not-qualified` lanes and never inherit exact status.
-- Warp `warp_sqlite` / `warp-agent-task-protobuf-v1`, parser
-  `warp-source-backed-logical-v7-neutral-activity-agent-scope`, for strict unversioned
+- Warp `warp_sqlite` / `warp-agent-task-protobuf-v1`, for strict unversioned
   generation 1. The pinned source commits are evidence for that shape, not
   runtime writer-version selectors.
 - Copilot CLI `copilot_cli_session_events_jsonl` /
-  `copilot-cli-direct-native-jsonl-v1`, parser
-  `copilot-cli-direct-native-jsonl-v8-optional-activity-admission`, for strict unversioned
-  generation 1. Observed versions and the pinned source commit are evidence,
-  not runtime admission selectors.
+  `copilot-cli-direct-native-jsonl-v1`, for strict unversioned generation 1.
+  Observed versions and the pinned source commit are evidence, not runtime
+  admission selectors.
 
 The 45 `not-qualified` rows do not mean their providers are unsupported. They
 mean only that ctx does not claim exact MCP server/tool activity for those

--- a/scripts/check_mcp_tool_call_attribution_capabilities_lib.py
+++ b/scripts/check_mcp_tool_call_attribution_capabilities_lib.py
@@ -109,7 +109,7 @@ ROW_FIELDS = set(
 )
 CHECK_FIELDS = set(
     "provider_id route source_format source_schema producer_bound implementation_source "
-    "parser_revision suite_id tests".split()
+    "suite_id tests".split()
 )
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 VERSION_RE = re.compile(r"^\d+(?:\.\d+){1,3}(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$")
@@ -749,11 +749,8 @@ def validate_exact_checks(
             check.get("implementation_source"), f"{label}.implementation_source"
         )
         implementation_text = implementation.read_text(encoding="utf-8")
-        parser_revision = require_string(check.get("parser_revision"), f"{label}.parser_revision")
         if f'"{schema}"' not in implementation_text:
             fail(f"{label}.source_schema is absent from its implementation source")
-        if f'"{parser_revision}"' not in implementation_text:
-            fail(f"{label}.parser_revision is stale or absent from its implementation source")
         suite_id = require_string(check.get("suite_id"), f"{label}.suite_id")
         binding, package_dir, target, _manifest = resolve_suite(suite_id)
         suites.add(suite_id)
@@ -817,9 +814,6 @@ def validate_public_docs(
     required = (
         "Codex `codex_session_jsonl_tree` / `codex-nativepath-jsonl-v0`",
         "49 capability lanes: three `exact`, 45 `not-qualified`, and one `excluded`",
-        "`codex-nativepath-core-activity-v9-record-coverage`",
-        "`warp-source-backed-logical-v7-neutral-activity-agent-scope`",
-        "`copilot-cli-direct-native-jsonl-v8-optional-activity-admission`",
         "`activity.invocation`",
         "`provider_call_id`",
         "`protocol` equal to `mcp`",
@@ -856,8 +850,8 @@ def validate_contract(
 ) -> dict[str, Any]:
     if support.get("schema_version") != 2:
         fail("provider support matrix schema_version must be 2")
-    if capability.get("schema_version") != 4 or capability.get("capability_revision") != 4:
-        fail("capability schema_version and capability_revision must be 4")
+    if capability.get("schema_version") != 5 or capability.get("capability_revision") != 4:
+        fail("capability schema_version must be 5 and capability_revision must be 4")
     if capability.get("capability") != "exact_mcp_tool_call_attribution":
         fail("unexpected capability name")
     if capability.get("key_fields") != [

--- a/scripts/tests/test_mcp_tool_call_attribution_capabilities.py
+++ b/scripts/tests/test_mcp_tool_call_attribution_capabilities.py
@@ -273,12 +273,6 @@ class CapabilityMutationTests(unittest.TestCase):
         self.exact_row("codex")["evidence"] = ["https://github.com/openai/codex"]
         self.assert_invalid("not a pinned GitHub blob/tree URL")
 
-    def test_stale_parser_revision_is_rejected(self) -> None:
-        self.capability["exact_checks"][1]["parser_revision"] = (
-            "warp-source-backed-logical-v3"
-        )
-        self.assert_invalid("parser_revision is stale")
-
     def test_contradictory_provider_docs_are_rejected(self) -> None:
         fixed = (
             "Capability revision 4 exact providers are Codex, Warp, and Copilot CLI."


### PR DESCRIPTION
Summary

- Remove `exact_checks[].parser_revision` from the public capability record and delete the checker that compared those copied values with same-repository source literals.
- Keep capability revision 4 intact while bumping the JSON shape to schema version 5.
- Preserve all 41 providers, 46 base routes, 49 capability lanes, three exact suites, nine owning tests, source schemas, producer bounds, MCP routes, and runtime parser-revision behavior.
- Remove the now-inert stale-parser mutation case and update the public guide/evidence runbook to describe the behavior-owned contract.

Why

#715 truthfully synchronized the Codex mirror from v8 to v9, but that update also demonstrates the maintenance coupling: runtime parser revisions are replay/invalidation identities, not independent MCP capability criteria. Exact attribution remains owned by route/schema/producer bounds plus executable behavior tests.

Validation

- Capability checker: 41 providers, 46 routes, 49 lanes, 3 suites, 9 tests, 4 links
- Python checker mutation suite: 25 passed
- `docs_check` and `repository_policy_check`: passed
- Codex, Warp, Copilot CLI, and active-source contract suites: 10/10 targets passed
- Affected selection: 49/51 passed; one transient native smoke failure passed in full CI, and the remaining Codex oversize-status failure is unchanged current-base runtime behavior outside this docs-only diff
- Full CI: crate-size preflight passed; build 447/447; tests 213/214, with only `complete_oversize_only_codex_refresh_preserves_last_good_generation` failing on the unchanged runtime path
- Independent exact-diff review: no blocking findings

Risk and order

Strict consumers of the old `exact_checks` object shape must accept schema version 5; capability semantics remain revision 4. This branch is based after #715, #716, and #719 and has no source conflict or semantic ordering dependency with the separate runtime oversize-status repair. That repair is still required for an entirely green current-main CI run.