### PR TITLE
fix(cli): keep configured empty roots visible

### DIFF
--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration/additional.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration/additional.rs
@@ -339,6 +339,8 @@ fn import_all_skips_empty_gemini_source() {
     assert_eq!(gemini["status"], "empty");
     assert_eq!(gemini["native_import"], true);
     assert_eq!(gemini["importable"], false);
+    let concise = success_stdout(ctx(&temp).arg("sources"));
+    assert!(!concise.contains("~/.gemini"), "{concise}");
 
     let imported =
         json_output(ctx(&temp).args(["import", "--all", "--format=json", "--progress", "none"]));

--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/source_inventory.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/source_inventory.rs
@@ -1,5 +1,26 @@
 use super::{ctx, support::*};
 
+fn strip_ansi_output(bytes: &[u8]) -> String {
+    let mut stripped = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == 0x1b && bytes.get(index + 1) == Some(&b'[') {
+            index += 2;
+            while index < bytes.len() {
+                let byte = bytes[index];
+                index += 1;
+                if (0x40..=0x7e).contains(&byte) {
+                    break;
+                }
+            }
+        } else {
+            stripped.push(bytes[index]);
+            index += 1;
+        }
+    }
+    String::from_utf8(stripped).unwrap()
+}
+
 fn source_entries(report: &Value) -> &[Value] {
     report["sources"].as_array().unwrap()
 }
@@ -145,6 +166,96 @@ fn configured_missing_roots_remain_listed_without_exposing_automatic_missing_rou
         human.contains("--root <replacement-path> --replace"),
         "{human}"
     );
+}
+
+#[test]
+fn configured_empty_root_is_complete_and_format_independent() {
+    let temp = tempdir();
+    let root = temp.path().join("work-gemini");
+    let state = temp.path().join("state");
+    let text_events = temp.path().join("sources-text-analytics.jsonl");
+    let json_events = temp.path().join("sources-json-analytics.jsonl");
+    fs::create_dir_all(&root).unwrap();
+    fs::create_dir_all(data_root(&temp)).unwrap();
+    fs::write(
+        data_root(&temp).join("config.toml"),
+        format!(
+            "[sources]\nautomatic = false\n\n[sources.roots.work]\nprovider = \"gemini\"\npath = {:?}\ngroup = \"team\"\n",
+            root.display().to_string(),
+        ),
+    )
+    .unwrap();
+
+    let plain = ctx(&temp)
+        .args(["--color=never", "sources"])
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env("CTX_ANALYTICS_ENABLED", "1")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&text_events))
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let plain_stdout = String::from_utf8(plain.stdout).unwrap();
+    assert!(plain_stdout.contains("gemini"), "{plain_stdout}");
+    assert!(plain_stdout.contains("empty"), "{plain_stdout}");
+    assert!(plain_stdout.contains("work (team)"), "{plain_stdout}");
+    let concise_root = Path::new("~").join("work-gemini");
+    assert!(
+        plain_stdout.contains(concise_root.to_str().unwrap()),
+        "{plain_stdout}"
+    );
+    assert!(
+        !plain_stdout.contains("no named roots are available"),
+        "{plain_stdout}"
+    );
+
+    let styled = ctx(&temp)
+        .args(["--color=always", "sources"])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    assert_eq!(strip_ansi_output(&styled.stdout), plain_stdout);
+
+    let json = ctx(&temp)
+        .args(["--color=always", "sources", "--format=json"])
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env("CTX_ANALYTICS_ENABLED", "1")
+        .env("CTX_ANALYTICS_ENDPOINT", file_url(&json_events))
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let report: Value = serde_json::from_slice(&json.stdout).unwrap();
+    let source = source_entry(&report, "gemini", Some("gemini_cli_chat_recording_jsonl"));
+    assert_eq!(source["status"], "empty", "{report:#}");
+    assert_eq!(source["importable"], false, "{report:#}");
+    assert_eq!(
+        source["selection"],
+        json!({"kind": "configured", "root": "work", "group": "team"}),
+        "{report:#}"
+    );
+
+    let all = json_output(ctx(&temp).args(["--color=always", "sources", "--all", "--format=json"]));
+    let all_source = source_entry(&all, "gemini", Some("gemini_cli_chat_recording_jsonl"));
+    assert_eq!(all_source["status"], "empty", "{all:#}");
+
+    let text_event = read_analytics_events(&text_events).remove(0);
+    let json_event = read_analytics_events(&json_events).remove(0);
+    assert_operation_event(&text_event, "sources", "success");
+    assert_operation_event(&json_event, "sources", "success");
+    let text_properties = analytics_event_properties(&text_event);
+    let json_properties = analytics_event_properties(&json_event);
+    for (property, expected) in [
+        ("providers_detected_bucket", "1"),
+        ("providers_existing_bucket", "1"),
+        ("providers_importable_bucket", "0"),
+    ] {
+        assert_eq!(text_properties[property], expected, "{text_properties:#?}");
+        assert_eq!(json_properties[property], expected, "{json_properties:#?}");
+    }
 }
 
 #[test]

--- a/crates/ctx-history-cli/src/sources.rs
+++ b/crates/ctx-history-cli/src/sources.rs
@@ -70,34 +70,21 @@ where
         },
     )?;
     let discovery_report = listing.discovery;
-    let mut sources = listing.visible_sources;
-    sources.retain(|source| source_is_visible_for_output(source, show_all_sources, request.format));
-    let sources = &sources;
+    let sources = listing.visible_sources;
+    let output_sources = sources
+        .iter()
+        .filter(|source| source_is_visible_for_output(source, show_all_sources, request.format))
+        .cloned()
+        .collect::<Vec<_>>();
     let plugin_sources = listing.plugins.sources;
     let plugin_failures = listing.plugins.failures;
-    let existing = sources.iter().filter(|source| source.exists).count();
-    let existing_plugin_sources = plugin_sources
-        .iter()
-        .filter(|source| history_source_plugin_report(source).is_importable())
-        .count();
-    let importable = sources
-        .iter()
-        .filter(|source| {
-            source.exists
-                && source.import_support.is_importable()
-                && source.status == ProviderSourceStatus::Available
-        })
-        .count();
-    on_discovery(SourcesDiscoveryObservation {
-        providers_detected: sources
-            .len()
-            .saturating_add(plugin_sources.len())
-            .saturating_add(plugin_failures.len()) as u64,
-        providers_existing: existing.saturating_add(existing_plugin_sources) as u64,
-        providers_importable: importable.saturating_add(existing_plugin_sources) as u64,
-    });
+    on_discovery(sources_discovery_observation(
+        &sources,
+        &plugin_sources,
+        &plugin_failures,
+    ));
     let hidden_missing_sources = listing.hidden_missing_sources;
-    let mut canonical_entries = sources_json_with_selection(sources, &provider_roots);
+    let mut canonical_entries = sources_json_with_selection(&output_sources, &provider_roots);
     canonical_entries.extend(plugin_sources_json(&plugin_sources));
     canonical_entries.extend(plugin_manifest_failures_json(&plugin_failures));
     let result_count = canonical_entries.len();
@@ -124,7 +111,7 @@ where
         output_bytes
     } else {
         let render_input = SourcesHumanRenderInput {
-            sources,
+            sources: &output_sources,
             issues: &discovery_report.issues,
             plugin_sources: &plugin_sources,
             plugin_failures: &plugin_failures,
@@ -146,12 +133,43 @@ where
     })
 }
 
+fn sources_discovery_observation(
+    sources: &[SourceInfo],
+    plugin_sources: &[HistorySourcePluginSource],
+    plugin_failures: &[HistorySourcePluginManifestFailure],
+) -> SourcesDiscoveryObservation {
+    let existing = sources.iter().filter(|source| source.exists).count();
+    let existing_plugin_sources = plugin_sources
+        .iter()
+        .filter(|source| history_source_plugin_report(source).is_importable())
+        .count();
+    let importable = sources
+        .iter()
+        .filter(|source| {
+            source.exists
+                && source.import_support.is_importable()
+                && source.status == ProviderSourceStatus::Available
+        })
+        .count();
+    SourcesDiscoveryObservation {
+        providers_detected: sources
+            .len()
+            .saturating_add(plugin_sources.len())
+            .saturating_add(plugin_failures.len()) as u64,
+        providers_existing: existing.saturating_add(existing_plugin_sources) as u64,
+        providers_importable: importable.saturating_add(existing_plugin_sources) as u64,
+    }
+}
+
 fn source_is_visible_for_output(
     source: &SourceInfo,
     show_all_sources: bool,
     format: OutputFormat,
 ) -> bool {
-    format == OutputFormat::Json || show_all_sources || source.status != ProviderSourceStatus::Empty
+    format == OutputFormat::Json
+        || show_all_sources
+        || source.status != ProviderSourceStatus::Empty
+        || source.route_provenance.configured_root().is_some()
 }
 
 #[cfg(test)]

--- a/crates/ctx-history-cli/src/sources_ui_tests.rs
+++ b/crates/ctx-history-cli/src/sources_ui_tests.rs
@@ -292,10 +292,25 @@ fn sources_empty_state_is_actionable() {
 }
 
 #[test]
-fn concise_sources_hide_empty_provider_while_json_and_all_retain_it() {
+fn concise_sources_hide_automatic_empty_provider_but_preserve_configured_empty_roots() {
     let mut empty = source(ProviderSourceStatus::Empty, "/tmp/gemini");
     empty.provider = CaptureProvider::Gemini;
     empty.source_format = "gemini_session_json_tree";
+    let mut configured_empty = empty.clone();
+    configured_empty.path = PathBuf::from("/tmp/work-gemini");
+    configured_empty.route_provenance = ProviderSourceRouteProvenance::ConfiguredRoot {
+        root_id: "work".to_owned(),
+        root_path: configured_empty.path.clone(),
+        route_role: ProviderRouteRole::from_static("gemini-sessions"),
+        automatic_route_role: None,
+    };
+    let configured_root = ctx_history_capture::ProviderRootDefinition {
+        id: "work".to_owned(),
+        provider: CaptureProvider::Gemini,
+        path: configured_empty.path.clone(),
+        group: Some("team".to_owned()),
+        kind: None,
+    };
     let default_sources = std::slice::from_ref(&empty)
         .iter()
         .filter(|source| source_is_visible_for_output(source, false, OutputFormat::Text))
@@ -311,10 +326,15 @@ fn concise_sources_hide_empty_provider_while_json_and_all_retain_it() {
         .filter(|source| source_is_visible_for_output(source, false, OutputFormat::Json))
         .cloned()
         .collect::<Vec<_>>();
-    let context = context(80, ColorMode::Never);
+    let configured_sources = std::slice::from_ref(&configured_empty)
+        .iter()
+        .filter(|source| source_is_visible_for_output(source, false, OutputFormat::Text))
+        .cloned()
+        .collect::<Vec<_>>();
+    let plain_context = context(80, ColorMode::Never);
 
     let default = render_sources_human(
-        &context,
+        &plain_context,
         SourcesHumanRenderInput::from_sources(&default_sources),
     )
     .render_plain();
@@ -326,8 +346,36 @@ fn concise_sources_hide_empty_provider_while_json_and_all_retain_it() {
     assert_eq!(json_sources.len(), 1);
     assert_eq!(json_sources[0].status, ProviderSourceStatus::Empty);
 
+    assert_eq!(configured_sources.len(), 1);
+    assert_eq!(
+        sources_discovery_observation(std::slice::from_ref(&empty), &[], &[]),
+        SourcesDiscoveryObservation {
+            providers_detected: 1,
+            providers_existing: 1,
+            providers_importable: 0,
+        }
+    );
+    let configured_input = SourcesHumanRenderInput::from_sources(&configured_sources)
+        .with_automatic_provider_discovery(false)
+        .with_provider_roots(std::slice::from_ref(&configured_root));
+    let configured = render_sources_human(&plain_context, configured_input).render_plain();
+    assert!(configured.contains("gemini"), "{configured}");
+    assert!(configured.contains("empty"), "{configured}");
+    assert!(configured.contains("work (team)"), "{configured}");
+    assert!(
+        !configured.contains("no named roots are available"),
+        "{configured}"
+    );
+
+    let styled = context(80, ColorMode::Always);
+    let styled_document = render_sources_human(&styled, configured_input);
+    assert_eq!(
+        strip_ansi(&styled_document.render(&styled)),
+        styled_document.render_plain()
+    );
+
     let all = render_sources_human(
-        &context,
+        &plain_context,
         SourcesHumanRenderInput::from_sources(&all_sources),
     )
     .render_plain();

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -141,13 +141,13 @@ ctx sources --format json
 ```
 
 `sources` checks known provider locations on the current machine. Its concise
-default hides empty providers; `ctx sources --all` retains empty and missing
-locations for diagnostics. Today it
+default hides empty automatic locations while keeping configured roots visible;
+`ctx sources --all` retains the full empty and missing inventory for diagnostics. Today it
 reports supported Codex, Pi, Antigravity, Claude, OpenCode, Kilo Code, Gemini,
 Cursor, Zed, Copilot CLI, Factory AI Droid, Warp, and other supported local
 history paths. JSON rows include
-`status` and `importable`; `status: "empty"` means the default location exists
-but no provider-specific transcript files were found there, and
+`status` and `importable`; `status: "empty"` means the automatic location or
+configured root exists but no provider-specific transcript files were found there, and
 `status: "unknown"` means the bounded transcript probe hit its scan budget.
 
 ## 4. Re-Run Or Target Imports


### PR DESCRIPTION
## Summary

- keep configured empty named roots visible in concise human `ctx sources` output
- continue hiding irrelevant automatic empty providers while preserving JSON and `--all` inventory compatibility
- compute discovery provider counts from the complete listing so text and JSON report the same facts
- retain output-specific execution metrics and document the distinction

## Validation

- `//crates/ctx-history-ingest-application:unit_tests`
- `//crates/ctx-history-cli:unit_tests`
- `//crates/ctx-cli-contract-tests:setup_sources_import_tests`
- `//crates/ctx-agent-application:mcp_tests`
- `//:docs_check`
- Cargo fmt, repository policy/ownership, and `git diff --check`
- independent post-fix review: ship

All Bazel targets passed with `--config=ci` and Clippy `-D warnings`.