### PR TITLE
fix(history): admit valid large index segment topology

### DIFF
--- a/crates/ctx-history-index-format/src/contracts.rs
+++ b/crates/ctx-history-index-format/src/contracts.rs
@@ -294,6 +294,11 @@ pub enum IndexError {
     },
     #[error("stored lexical document field {0} is missing, malformed, or inconsistent")]
     InvalidStoredDocumentField(&'static str),
+    #[error("session authority lookup work limit exceeded for {operation}: maximum {maximum}")]
+    SessionAuthorityWorkLimitExceeded {
+        operation: &'static str,
+        maximum: usize,
+    },
     #[error("one session has conflicting provider-native lineage claims: {0}")]
     ConflictingProviderNativeSessionClaim(&'static str),
     #[error(

--- a/crates/ctx-history-index/src/identity.rs
+++ b/crates/ctx-history-index/src/identity.rs
@@ -16,7 +16,9 @@ use crate::{
 use std::cell::Cell;
 
 pub(crate) const MAX_SESSION_WITNESS_VISITS: usize = 32;
-pub(crate) const MAX_SESSION_WITNESS_SEGMENT_PROBES: usize = 64;
+/// Bounds the fixed segment fan-out before the sparse authority dictionary is
+/// opened. Keep this aligned with the manual lexical query ceiling.
+pub(crate) const MAX_SESSION_WITNESS_SEGMENT_PROBES: usize = 512;
 
 /// Test-only accounting for the bounded base witness lookup.
 #[cfg(test)]
@@ -212,7 +214,10 @@ fn ensure_witness_visit_cap(visits: usize) -> Result<()> {
 
 fn ensure_witness_segment_probe_cap(probes: usize) -> Result<()> {
     if probes > MAX_SESSION_WITNESS_SEGMENT_PROBES {
-        return Err(IndexError::InvalidStoredDocumentField("session_authority"));
+        return Err(IndexError::SessionAuthorityWorkLimitExceeded {
+            operation: "segment probes",
+            maximum: MAX_SESSION_WITNESS_SEGMENT_PROBES,
+        });
     }
     Ok(())
 }
@@ -245,5 +250,27 @@ pub(crate) fn register_compact_identity(
                 new_digest: hex(&digest),
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_witness_segment_probe_cap_is_typed_and_inclusive() {
+        assert!(ensure_witness_segment_probe_cap(MAX_SESSION_WITNESS_SEGMENT_PROBES).is_ok());
+        let error =
+            ensure_witness_segment_probe_cap(MAX_SESSION_WITNESS_SEGMENT_PROBES + 1).unwrap_err();
+        assert!(matches!(
+            &error,
+            IndexError::SessionAuthorityWorkLimitExceeded {
+                operation: "segment probes",
+                maximum: MAX_SESSION_WITNESS_SEGMENT_PROBES,
+            }
+        ));
+        assert!(crate::prior_session_identity_lookup_failure_is_passthrough(
+            &error
+        ));
     }
 }

--- a/crates/ctx-history-index/src/lib.rs
+++ b/crates/ctx-history-index/src/lib.rs
@@ -326,6 +326,14 @@ fn classify_active_integrity_failure(
     }
 }
 
+fn prior_session_identity_lookup_failure_is_passthrough(error: &IndexError) -> bool {
+    matches!(
+        error,
+        IndexError::CompactIdentityCollision { .. }
+            | IndexError::SessionAuthorityWorkLimitExceeded { .. }
+    )
+}
+
 #[cfg(test)]
 type GenerationPathHook = Box<dyn FnOnce(&Path) + Send>;
 
@@ -675,7 +683,7 @@ impl GenerationWriter {
                         match lookup {
                             Ok(prior) => prior,
                             Err(error)
-                                if matches!(error, IndexError::CompactIdentityCollision { .. }) =>
+                                if prior_session_identity_lookup_failure_is_passthrough(&error) =>
                             {
                                 return Err(error);
                             }

--- a/crates/ctx-history-index/src/tests/writer/complexity_contract.rs
+++ b/crates/ctx-history-index/src/tests/writer/complexity_contract.rs
@@ -523,7 +523,8 @@ fn repeated_replacement_tombstones_hit_the_witness_cap_and_fail_closed() {
 }
 
 #[test]
-fn session_witness_segment_probe_cap_accepts_64_and_rejects_65() {
+fn session_witness_segment_probe_cap_admits_65_segment_generation() {
+    const VALID_SEGMENT_COUNT: usize = 65;
     let root = tempdir().unwrap();
     let target = source("witness-segment-cap-target.jsonl");
     let options = WriterOptions {
@@ -535,7 +536,7 @@ fn session_witness_segment_probe_cap_accepts_64_and_rejects_65() {
         .into_writer()
         .unwrap();
     initial.test_disable_merges().unwrap();
-    for segment in 0..MAX_SESSION_WITNESS_SEGMENT_PROBES {
+    for segment in 0..VALID_SEGMENT_COUNT {
         let current = if segment == 0 {
             target.clone()
         } else {
@@ -556,10 +557,7 @@ fn session_witness_segment_probe_cap_accepts_64_and_rejects_65() {
     }
     initial.commit(|_| true).unwrap();
     let (searcher, _) = open_unverified_generation(root.path());
-    assert_eq!(
-        searcher.segment_readers().len(),
-        MAX_SESSION_WITNESS_SEGMENT_PROBES
-    );
+    assert_eq!(searcher.segment_readers().len(), VALID_SEGMENT_COUNT);
 
     let mut accepted = GenerationWriter::open(root.path(), options.clone())
         .unwrap()
@@ -576,7 +574,7 @@ fn session_witness_segment_probe_cap_accepts_64_and_rejects_65() {
         .unwrap();
     assert_eq!(
         crate::prior_session_identity_lookup_work().segment_range_probes,
-        MAX_SESSION_WITNESS_SEGMENT_PROBES
+        VALID_SEGMENT_COUNT
     );
     accepted
         .certify_source_append(
@@ -591,34 +589,11 @@ fn session_witness_segment_probe_cap_accepts_64_and_rejects_65() {
         .unwrap();
     accepted.commit(|_| true).unwrap();
     let (searcher, _) = open_unverified_generation(root.path());
-    assert_eq!(
-        searcher.segment_readers().len(),
-        MAX_SESSION_WITNESS_SEGMENT_PROBES + 1
-    );
-
-    let mut rejected = GenerationWriter::open(root.path(), options.clone())
-        .unwrap()
-        .into_writer()
-        .unwrap();
-    rejected.begin_source_append(target.clone()).unwrap();
-    crate::reset_prior_session_identity_lookup_work();
-    assert!(matches!(
-        rejected.add_core_record(document(&target, 3, "rejected past segment cap")),
-        Err(IndexError::ActiveGenerationNeedsRebuild { .. })
-    ));
-    assert_eq!(
-        crate::prior_session_identity_lookup_work().segment_range_probes,
-        MAX_SESSION_WITNESS_SEGMENT_PROBES + 1
-    );
-    assert!(matches!(
-        rejected.commit(|_| true),
-        Err(IndexError::ActiveGenerationNeedsRebuild { .. })
-    ));
-    let rebuild = GenerationWriter::open(root.path(), options)
-        .unwrap()
-        .into_writer()
-        .unwrap();
-    assert!(rebuild.base_manifest().is_none());
+    assert_eq!(searcher.segment_readers().len(), VALID_SEGMENT_COUNT + 1);
+    assert!(!root
+        .path()
+        .join("active-generation-rebuild-required.json")
+        .exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- raise the bounded session-authority segment probe ceiling from 64 to the existing 512-segment lexical limit
- return a typed work-limit error above that ceiling without falsely marking a valid generation corrupt
- preserve the existing tombstone witness recovery behavior
- cover a real 65-segment reopen-and-append flow

## Why

Release dogfooding published a valid 44.2 GiB / 8.2M-document generation with 76 Tantivy segments. Search remained healthy, but the next incremental refresh failed before reading segment 65 and mislabeled the 64-probe work bound as malformed session_authority, creating a false rebuild marker.

## Validation

- uncached //crates/ctx-history-index:unit_tests with CI configuration
- //:repository_policy_check with CI configuration
- full //crates/ctx-cli:ctx CI build and Clippy with warnings denied
- cargo fmt check and git diff --check
- independent final review: ship

The existing 76-segment real-corpus generation is being exercised with the patched binary in parallel; this PR does not change any persisted schema or wire contract.