### PR TITLE
Preserve final companion delivery outcomes

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -534,7 +534,7 @@
           "FILE:@@//crates/ctx-history-index-generation/Cargo.toml e2391f5473d5f1bca3c90ea9efcdceecf13e38a90ddbd652f0c1e9c5599694db",
           "FILE:@@//crates/ctx-semantic-model/Cargo.toml d1a66b94c2ae1cb1c8f6e8f26996f0ee87a08da96d5224ae9f51d13777a18253",
           "FILE:@@//crates/ctx-history-index-query/Cargo.toml b17f03410fe9fa227f10055464367e8870734b80567477e892c9547ca7932027",
-          "FILE:@@//crates/ctx-companion-bridge/Cargo.toml 0b94102078181995f2cb623fd9371aec559654e8314b9239b03dce582d2f72fe",
+          "FILE:@@//crates/ctx-companion-bridge/Cargo.toml afb6be0255a2be58424a563abab368c2790c2bdb0f682c072ab610181c017c48",
           "FILE:@@//crates/ctx-cli/Cargo.toml 2439a828254baf4f84bf2ee717dc7b37d133efe77625a69a6900d721daf0b8a9",
           "FILE:@@//crates/ctx-cli-presentation/Cargo.toml d06c41fd3f921da6bb9bfa715796f7071f639aea92b67cac7edbfbe0d99424e1",
           "FILE:@@//crates/ctx-history-cli/Cargo.toml 91e36849eeb955300d69c8c54e5b1383d85e2492557c607fe8a31d451110c554",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -534,7 +534,7 @@
           "FILE:@@//crates/ctx-history-index-generation/Cargo.toml e2391f5473d5f1bca3c90ea9efcdceecf13e38a90ddbd652f0c1e9c5599694db",
           "FILE:@@//crates/ctx-semantic-model/Cargo.toml d1a66b94c2ae1cb1c8f6e8f26996f0ee87a08da96d5224ae9f51d13777a18253",
           "FILE:@@//crates/ctx-history-index-query/Cargo.toml b17f03410fe9fa227f10055464367e8870734b80567477e892c9547ca7932027",
-          "FILE:@@//crates/ctx-companion-bridge/Cargo.toml afb6be0255a2be58424a563abab368c2790c2bdb0f682c072ab610181c017c48",
+          "FILE:@@//crates/ctx-companion-bridge/Cargo.toml 87822f9b66b1eaf181ce751d3ca9c075c0b483ff3284a7232aaace7539339c4b",
           "FILE:@@//crates/ctx-cli/Cargo.toml 2439a828254baf4f84bf2ee717dc7b37d133efe77625a69a6900d721daf0b8a9",
           "FILE:@@//crates/ctx-cli-presentation/Cargo.toml d06c41fd3f921da6bb9bfa715796f7071f639aea92b67cac7edbfbe0d99424e1",
           "FILE:@@//crates/ctx-history-cli/Cargo.toml 91e36849eeb955300d69c8c54e5b1383d85e2492557c607fe8a31d451110c554",

--- a/crates/ctx-agent-application/src/mcp/mod.rs
+++ b/crates/ctx-agent-application/src/mcp/mod.rs
@@ -13,7 +13,10 @@ use ctx_agent_integrations::{
         McpInputLine, McpServerIdentity, McpToolKind, McpUsage, RequestDescriptor,
         MCP_MAX_LINE_BYTES, MCP_PRESENTATION_MAX_OUTPUT_BYTES,
     },
-    tool_backend::{OpaqueMcpProxyError, ToolBackend, ToolSearchFailurePhase, ToolUsageFacts},
+    tool_backend::{
+        OpaqueMcpDeliveryOutcome, OpaqueMcpProxyError, ToolBackend, ToolSearchFailurePhase,
+        ToolUsageFacts,
+    },
 };
 use ctx_client_observability::analytics::{McpErrorClassV1, McpStopReasonV1, Outcome};
 use serde_json::{json, Value};
@@ -137,6 +140,7 @@ where
             return Ok(());
         };
         let request_started = Instant::now();
+        let mut companion_completion = None;
         let (handled, descriptor) = match input {
             McpInputLine::Line(line) => {
                 let trimmed = line.trim();
@@ -153,28 +157,50 @@ where
                                     if operation.is_companion_owned()
                             )
                         {
-                            let encoded =
-                                match backend.proxy_companion_mcp(line.as_bytes()) {
-                                    Ok(response) => response,
-                                    Err(error) => encode_response_line(
+                            let response = match backend.proxy_companion_mcp(line.as_bytes()) {
+                                Ok(response) => response,
+                                Err(error) => {
+                                    let encoded = encode_response_line(
                                         &companion_proxy_error_response(&message, error),
                                     )
-                                    .map(String::into_bytes)
                                     .map_err(|error| McpServeFailure {
                                         reason: McpStopReasonV1::ResponseSerializeError,
                                         error: error.into(),
-                                    })?,
-                                };
-                            stdout
-                                .write_all(&encoded)
-                                .map_err(|error| McpServeFailure {
+                                    })?;
+                                    stdout.write_all(encoded.as_bytes()).map_err(|error| {
+                                        McpServeFailure {
+                                            reason: McpStopReasonV1::StdoutWriteError,
+                                            error: error.into(),
+                                        }
+                                    })?;
+                                    stdout.flush().map_err(|error| McpServeFailure {
+                                        reason: McpStopReasonV1::StdoutFlushError,
+                                        error: error.into(),
+                                    })?;
+                                    telemetry.record_delivered(
+                                        descriptor,
+                                        None,
+                                        None,
+                                        request_started.elapsed(),
+                                    );
+                                    continue;
+                                }
+                            };
+                            if let Err(error) = stdout.write_all(response.response_bytes()) {
+                                response.finish(OpaqueMcpDeliveryOutcome::OutputFailed);
+                                return Err(McpServeFailure {
                                     reason: McpStopReasonV1::StdoutWriteError,
                                     error: error.into(),
-                                })?;
-                            stdout.flush().map_err(|error| McpServeFailure {
-                                reason: McpStopReasonV1::StdoutFlushError,
-                                error: error.into(),
-                            })?;
+                                });
+                            }
+                            if let Err(error) = stdout.flush() {
+                                response.finish(OpaqueMcpDeliveryOutcome::OutputFailed);
+                                return Err(McpServeFailure {
+                                    reason: McpStopReasonV1::StdoutFlushError,
+                                    error: error.into(),
+                                });
+                            }
+                            response.finish(OpaqueMcpDeliveryOutcome::WrittenAndFlushed);
                             telemetry.record_delivered(
                                 descriptor,
                                 None,
@@ -196,7 +222,7 @@ where
                         );
                         if *initialized && descriptor == RequestDescriptor::ToolsList {
                             if let Some(response) = handled.value.as_mut() {
-                                append_companion_tool_definitions(
+                                companion_completion = append_companion_tool_definitions(
                                     &message,
                                     line.as_bytes(),
                                     response,
@@ -292,6 +318,9 @@ where
                     error: error.into(),
                 });
             }
+            if let Some(completion) = companion_completion.take() {
+                completion.finish(OpaqueMcpDeliveryOutcome::WrittenAndFlushed);
+            }
             mark_search_output_completed(&mut delivered_usage, output_started.elapsed());
             let duration = request_started.elapsed();
             let telemetry_usage = delivered_usage.as_ref().map(|usage| usage.facts);
@@ -344,35 +373,33 @@ fn append_companion_tool_definitions<B: ToolBackend>(
     raw_request: &[u8],
     response: &mut Value,
     backend: &B,
-) {
-    let Some(core_tools) = response.pointer("/result/tools").and_then(Value::as_array) else {
-        return;
-    };
-    let Some(mut merged_tools) = validated_core_tools(core_tools) else {
-        return;
-    };
+) -> Option<ctx_agent_integrations::tool_backend::OpaqueMcpProxyResponse> {
+    let core_tools = response
+        .pointer("/result/tools")
+        .and_then(Value::as_array)?;
+    let mut merged_tools = validated_core_tools(core_tools)?;
     let Ok(companion_response) = backend.proxy_companion_mcp(raw_request) else {
-        return;
+        return None;
     };
-    let Some(companion_tools) =
-        validated_companion_tools(&companion_response, message.get("id"), &merged_tools)
-    else {
-        return;
-    };
+    let companion_tools = validated_companion_tools(
+        companion_response.response_bytes(),
+        message.get("id"),
+        &merged_tools,
+    )?;
     merged_tools.extend(companion_tools);
 
     let mut merged_response = response.clone();
-    let Some(tools) = merged_response
+    let tools = merged_response
         .pointer_mut("/result/tools")
-        .and_then(Value::as_array_mut)
-    else {
-        return;
-    };
+        .and_then(Value::as_array_mut)?;
     *tools = merged_tools;
     let within_bound = serde_json::to_vec(&merged_response)
         .is_ok_and(|encoded| encoded.len().saturating_add(1) <= MCP_PRESENTATION_MAX_OUTPUT_BYTES);
     if within_bound {
         *response = merged_response;
+        Some(companion_response)
+    } else {
+        None
     }
 }
 

--- a/crates/ctx-agent-application/src/mcp/mod.rs
+++ b/crates/ctx-agent-application/src/mcp/mod.rs
@@ -285,6 +285,9 @@ where
             };
             let output_started = Instant::now();
             if let Err(error) = stdout.write_all(encoded.as_bytes()) {
+                if let Some(completion) = companion_completion.take() {
+                    completion.finish(OpaqueMcpDeliveryOutcome::OutputFailed);
+                }
                 mark_search_failure(
                     &mut delivered_usage,
                     ToolSearchFailurePhase::Output,
@@ -302,6 +305,9 @@ where
                 });
             }
             if let Err(error) = stdout.flush() {
+                if let Some(completion) = companion_completion.take() {
+                    completion.finish(OpaqueMcpDeliveryOutcome::OutputFailed);
+                }
                 mark_search_failure(
                     &mut delivered_usage,
                     ToolSearchFailurePhase::Output,

--- a/crates/ctx-agent-application/src/mcp/tests.rs
+++ b/crates/ctx-agent-application/src/mcp/tests.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use ctx_agent_integrations::tool_backend::{
-    OpaqueMcpProxyError, ToolBackend, ToolExecutionError, ToolOperation, ToolOutcome,
-    ToolUsageFacts,
+    OpaqueMcpDeliveryOutcome, OpaqueMcpProxyError, OpaqueMcpProxyResponse, ToolBackend,
+    ToolExecutionError, ToolOperation, ToolOutcome, ToolUsageFacts,
 };
 use ctx_client_observability::{
     analytics::{Outcome, SearchFailurePhase, SearchTerminalFacts},
@@ -27,6 +27,7 @@ enum OutputFailure {
 struct TracedWriter {
     failure: OutputFailure,
     trace: Arc<Mutex<Vec<&'static str>>>,
+    output: Vec<u8>,
 }
 
 impl Write for TracedWriter {
@@ -36,6 +37,7 @@ impl Write for TracedWriter {
             return Err(Error::new(ErrorKind::BrokenPipe, "test write failure"));
         }
         self.trace.lock().unwrap().push("write");
+        self.output.extend_from_slice(bytes);
         Ok(bytes.len())
     }
 
@@ -56,7 +58,10 @@ impl ToolBackend for TestBackend {
         Ok(ToolOutcome::plain(json!({"payload_type": "status"})))
     }
 
-    fn proxy_companion_mcp(&self, _request: &[u8]) -> Result<Vec<u8>, OpaqueMcpProxyError> {
+    fn proxy_companion_mcp(
+        &self,
+        _request: &[u8],
+    ) -> Result<OpaqueMcpProxyResponse, OpaqueMcpProxyError> {
         panic!("Core status must not use the companion")
     }
 
@@ -108,6 +113,7 @@ fn run_one_response(failure: OutputFailure, tool: &str, arguments: Value) -> Res
     let mut output = TracedWriter {
         failure,
         trace: trace.clone(),
+        output: Vec::new(),
     };
     let delivery_trace = trace.clone();
     let search_events = Arc::new(Mutex::new(Vec::new()));
@@ -288,6 +294,23 @@ fn malformed_input_recovers_with_exact_json_rpc_parse_error() {
 struct RecordingProxyBackend {
     request: Mutex<Vec<u8>>,
     response: Vec<u8>,
+    completions: Arc<Mutex<Vec<OpaqueMcpDeliveryOutcome>>>,
+    trace: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl RecordingProxyBackend {
+    fn new(response: Vec<u8>) -> Self {
+        Self::with_trace(response, Arc::new(Mutex::new(Vec::new())))
+    }
+
+    fn with_trace(response: Vec<u8>, trace: Arc<Mutex<Vec<&'static str>>>) -> Self {
+        Self {
+            request: Mutex::new(Vec::new()),
+            response,
+            completions: Arc::new(Mutex::new(Vec::new())),
+            trace,
+        }
+    }
 }
 
 impl ToolBackend for RecordingProxyBackend {
@@ -295,9 +318,21 @@ impl ToolBackend for RecordingProxyBackend {
         panic!("companion-owned calls must bypass public tool execution")
     }
 
-    fn proxy_companion_mcp(&self, request: &[u8]) -> Result<Vec<u8>, OpaqueMcpProxyError> {
+    fn proxy_companion_mcp(
+        &self,
+        request: &[u8],
+    ) -> Result<OpaqueMcpProxyResponse, OpaqueMcpProxyError> {
         self.request.lock().unwrap().extend_from_slice(request);
-        Ok(self.response.clone())
+        let completions = Arc::clone(&self.completions);
+        let trace = Arc::clone(&self.trace);
+        OpaqueMcpProxyResponse::new(self.response.clone(), move |outcome| {
+            completions.lock().unwrap().push(outcome);
+            trace.lock().unwrap().push(match outcome {
+                OpaqueMcpDeliveryOutcome::WrittenAndFlushed => "written_and_flushed",
+                OpaqueMcpDeliveryOutcome::OutputFailed => "output_failed",
+            });
+        })
+        .ok_or(OpaqueMcpProxyError::CompanionIncompatible)
     }
 
     fn parse_provider(&self, _value: &str) -> Option<CaptureProvider> {
@@ -314,13 +349,14 @@ fn companion_owned_call_is_proxied_as_exact_opaque_bytes() {
     let request = b" {\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"tools/call\",\"params\":{\"name\":\"blame\",\"arguments\":{\"private\":\"opaque\"}}} \n";
     let initialized = b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n";
     let mut input = Cursor::new([initialized.as_slice(), request.as_slice()].concat());
-    let expected_response =
-        b"{\"jsonrpc\":\"2.0\",\"id\":7,\"result\":{\"opaque\":true}}\n".to_vec();
-    let backend = RecordingProxyBackend {
-        request: Mutex::new(Vec::new()),
-        response: expected_response.clone(),
+    let expected_response = b"opaque\xff\n".to_vec();
+    let trace = Arc::new(Mutex::new(Vec::new()));
+    let backend = RecordingProxyBackend::with_trace(expected_response.clone(), trace.clone());
+    let mut output = TracedWriter {
+        failure: OutputFailure::None,
+        trace: trace.clone(),
+        output: Vec::new(),
     };
-    let mut output = Vec::new();
     let mut usage = TracedUsagePort(Arc::new(Mutex::new(Vec::new())));
 
     serve_stdio(
@@ -338,7 +374,78 @@ fn companion_owned_call_is_proxied_as_exact_opaque_bytes() {
     .unwrap();
 
     assert_eq!(*backend.request.lock().unwrap(), request);
-    assert_eq!(output, expected_response);
+    assert_eq!(output.output, expected_response);
+    assert_eq!(
+        *backend.completions.lock().unwrap(),
+        [OpaqueMcpDeliveryOutcome::WrittenAndFlushed]
+    );
+    let trace = trace.lock().unwrap();
+    let flushed_at = trace.iter().position(|entry| *entry == "flush").unwrap();
+    let completed_at = trace
+        .iter()
+        .position(|entry| *entry == "written_and_flushed")
+        .unwrap();
+    assert!(flushed_at < completed_at, "{trace:?}");
+}
+
+#[test]
+fn companion_owned_write_and_flush_failures_complete_as_output_failed_once() {
+    let request = b"{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"tools/call\",\"params\":{\"name\":\"blame\",\"arguments\":{}}}\n";
+    let initialized = b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n";
+    let expected_response = b"opaque\xff\n".to_vec();
+
+    for (failure, expected_reason, failed_label) in [
+        (
+            OutputFailure::Write,
+            McpStopReasonV1::StdoutWriteError,
+            "write_failed",
+        ),
+        (
+            OutputFailure::Flush,
+            McpStopReasonV1::StdoutFlushError,
+            "flush_failed",
+        ),
+    ] {
+        let mut input = Cursor::new([initialized.as_slice(), request.as_slice()].concat());
+        let trace = Arc::new(Mutex::new(Vec::new()));
+        let backend = RecordingProxyBackend::with_trace(expected_response.clone(), trace.clone());
+        let mut output = TracedWriter {
+            failure,
+            trace: trace.clone(),
+            output: Vec::new(),
+        };
+        let mut usage = TracedUsagePort(Arc::new(Mutex::new(Vec::new())));
+
+        let failure = serve_stdio(
+            &mut input,
+            &mut output,
+            ProductIdentity {
+                name: "ctx",
+                version: "test",
+            },
+            &backend,
+            &render_generic_tool_text,
+            &mut usage,
+            McpTelemetry::start(false, |_| Ok(())),
+        )
+        .unwrap_err();
+
+        assert_eq!(failure.reason, expected_reason);
+        assert_eq!(
+            *backend.completions.lock().unwrap(),
+            [OpaqueMcpDeliveryOutcome::OutputFailed]
+        );
+        let trace = trace.lock().unwrap();
+        let failed_at = trace
+            .iter()
+            .position(|entry| *entry == failed_label)
+            .unwrap();
+        let completed_at = trace
+            .iter()
+            .position(|entry| *entry == "output_failed")
+            .unwrap();
+        assert!(failed_at < completed_at, "{trace:?}");
+    }
 }
 
 fn tools_list_with_backend(backend: &impl ToolBackend) -> Value {
@@ -389,10 +496,7 @@ fn tools_list_appends_private_definitions_without_interpreting_their_fields() {
     }))
     .unwrap();
     companion_response.push(b'\n');
-    let backend = RecordingProxyBackend {
-        request: Mutex::new(Vec::new()),
-        response: companion_response,
-    };
+    let backend = RecordingProxyBackend::new(companion_response);
 
     let response = tools_list_with_backend(&backend);
     let tools = response["result"]["tools"].as_array().unwrap();
@@ -402,6 +506,58 @@ fn tools_list_appends_private_definitions_without_interpreting_their_fields() {
         *backend.request.lock().unwrap(),
         b" {\"jsonrpc\":\"2.0\",\"id\":11,\"method\":\"tools/list\"} \n"
     );
+    assert_eq!(
+        *backend.completions.lock().unwrap(),
+        [OpaqueMcpDeliveryOutcome::WrittenAndFlushed]
+    );
+}
+
+#[test]
+fn tools_list_write_and_flush_failures_complete_as_output_failed_once() {
+    let initialized = b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n";
+    let request = b"{\"jsonrpc\":\"2.0\",\"id\":11,\"method\":\"tools/list\"}\n";
+    let mut companion_response = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": 11,
+        "result": {"tools": [{"name": "blame"}]},
+    }))
+    .unwrap();
+    companion_response.push(b'\n');
+
+    for (failure, expected_reason) in [
+        (OutputFailure::Write, McpStopReasonV1::StdoutWriteError),
+        (OutputFailure::Flush, McpStopReasonV1::StdoutFlushError),
+    ] {
+        let mut input = Cursor::new([initialized.as_slice(), request.as_slice()].concat());
+        let trace = Arc::new(Mutex::new(Vec::new()));
+        let backend = RecordingProxyBackend::with_trace(companion_response.clone(), trace.clone());
+        let mut output = TracedWriter {
+            failure,
+            trace,
+            output: Vec::new(),
+        };
+        let mut usage = TracedUsagePort(Arc::new(Mutex::new(Vec::new())));
+
+        let failure = serve_stdio(
+            &mut input,
+            &mut output,
+            ProductIdentity {
+                name: "ctx",
+                version: "test",
+            },
+            &backend,
+            &render_generic_tool_text,
+            &mut usage,
+            McpTelemetry::start(false, |_| Ok(())),
+        )
+        .unwrap_err();
+
+        assert_eq!(failure.reason, expected_reason);
+        assert_eq!(
+            *backend.completions.lock().unwrap(),
+            [OpaqueMcpDeliveryOutcome::OutputFailed]
+        );
+    }
 }
 
 #[test]
@@ -432,10 +588,7 @@ fn tools_list_omits_all_private_definitions_when_the_response_fails_closed() {
         vec![b'x'; MCP_MAX_LINE_BYTES + 1],
     ];
     for response in invalid_responses {
-        let backend = RecordingProxyBackend {
-            request: Mutex::new(Vec::new()),
-            response,
-        };
+        let backend = RecordingProxyBackend::new(response);
         let response = tools_list_with_backend(&backend);
         let names = tool_names(&response);
         assert!(!names.contains(&"blame"), "{names:?}");
@@ -462,7 +615,10 @@ impl ToolBackend for FailingProxyBackend {
         panic!("companion-owned calls must bypass public tool execution")
     }
 
-    fn proxy_companion_mcp(&self, _request: &[u8]) -> Result<Vec<u8>, OpaqueMcpProxyError> {
+    fn proxy_companion_mcp(
+        &self,
+        _request: &[u8],
+    ) -> Result<OpaqueMcpProxyResponse, OpaqueMcpProxyError> {
         Err(self.0)
     }
 

--- a/crates/ctx-agent-integrations/src/mcp/mod.rs
+++ b/crates/ctx-agent-integrations/src/mcp/mod.rs
@@ -796,8 +796,8 @@ mod request_id_tests {
         MCP_MAX_ENCODED_REQUEST_ID_BYTES, PROVIDER_ROOT_SELECTOR_PATTERN,
     };
     use crate::tool_backend::{
-        OpaqueMcpProxyError, ToolBackend, ToolExecutionError, ToolOperation, ToolOutcome,
-        ToolSearchBackend,
+        OpaqueMcpProxyError, OpaqueMcpProxyResponse, ToolBackend, ToolExecutionError,
+        ToolOperation, ToolOutcome, ToolSearchBackend,
     };
 
     struct UnusedBackend;
@@ -807,7 +807,10 @@ mod request_id_tests {
             panic!("request-ID validation must run before the backend")
         }
 
-        fn proxy_companion_mcp(&self, _request: &[u8]) -> Result<Vec<u8>, OpaqueMcpProxyError> {
+        fn proxy_companion_mcp(
+            &self,
+            _request: &[u8],
+        ) -> Result<OpaqueMcpProxyResponse, OpaqueMcpProxyError> {
             panic!("request-ID validation must run before the backend")
         }
 

--- a/crates/ctx-agent-integrations/src/tool_backend.rs
+++ b/crates/ctx-agent-integrations/src/tool_backend.rs
@@ -274,12 +274,72 @@ pub enum OpaqueMcpProxyError {
     CompanionIncompatible,
 }
 
+/// The closed, product-neutral result of attempting final MCP output delivery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpaqueMcpDeliveryOutcome {
+    WrittenAndFlushed,
+    OutputFailed,
+}
+
+/// One bounded companion response awaiting its final output-delivery result.
+pub struct OpaqueMcpProxyResponse {
+    response: Vec<u8>,
+    completion: Option<Box<dyn FnOnce(OpaqueMcpDeliveryOutcome) + Send>>,
+}
+
+impl OpaqueMcpProxyResponse {
+    pub fn new(
+        response: Vec<u8>,
+        completion: impl FnOnce(OpaqueMcpDeliveryOutcome) + Send + 'static,
+    ) -> Option<Self> {
+        (response.len() <= crate::mcp::MCP_MAX_LINE_BYTES).then(|| Self {
+            response,
+            completion: Some(Box::new(completion)),
+        })
+    }
+
+    pub fn response_bytes(&self) -> &[u8] {
+        &self.response
+    }
+
+    /// Records the explicit client-delivery outcome. The callback is
+    /// intentionally infallible: any companion finalization failure happens
+    /// after the product response was already written and cannot change that
+    /// result. Direct bridge callers use `McpResponse::finish` to observe it.
+    pub fn finish(mut self, outcome: OpaqueMcpDeliveryOutcome) {
+        if let Some(completion) = self.completion.take() {
+            completion(outcome);
+        }
+    }
+}
+
+impl fmt::Debug for OpaqueMcpProxyResponse {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OpaqueMcpProxyResponse")
+            .field("response_bytes", &self.response.len())
+            .field("unfinished", &self.completion.is_some())
+            .finish()
+    }
+}
+
+impl Drop for OpaqueMcpProxyResponse {
+    fn drop(&mut self) {
+        // A dropped proxy response has an unknown client outcome. Only an
+        // explicit `finish(OutputFailed)` may report that terminal receipt.
+        self.completion.take();
+    }
+}
+
 /// Product execution boundary. Implementations remain in the owning application.
 pub trait ToolBackend: Send + Sync {
     fn execute(&self, operation: ToolOperation) -> Result<ToolOutcome, ToolExecutionError>;
 
     /// Proxies one already-framed companion-owned MCP request without parsing its arguments.
-    fn proxy_companion_mcp(&self, request: &[u8]) -> Result<Vec<u8>, OpaqueMcpProxyError>;
+    fn proxy_companion_mcp(
+        &self,
+        request: &[u8],
+    ) -> Result<OpaqueMcpProxyResponse, OpaqueMcpProxyError>;
 
     /// Resolves an MCP provider spelling through the application's provider registry.
     fn parse_provider(&self, value: &str) -> Option<CaptureProvider>;
@@ -388,3 +448,41 @@ impl fmt::Display for ToolBackendError {
 }
 
 impl std::error::Error for ToolBackendError {}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::{OpaqueMcpDeliveryOutcome, OpaqueMcpProxyResponse};
+
+    #[test]
+    fn opaque_mcp_completion_is_exactly_once() {
+        let outcomes = Arc::new(Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&outcomes);
+        let response = OpaqueMcpProxyResponse::new(b"opaque\n".to_vec(), move |outcome| {
+            recorded.lock().unwrap().push(outcome);
+        })
+        .unwrap();
+
+        response.finish(OpaqueMcpDeliveryOutcome::WrittenAndFlushed);
+
+        assert_eq!(
+            *outcomes.lock().unwrap(),
+            [OpaqueMcpDeliveryOutcome::WrittenAndFlushed]
+        );
+    }
+
+    #[test]
+    fn dropped_opaque_mcp_response_has_no_terminal_completion() {
+        let outcomes = Arc::new(Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&outcomes);
+        let response = OpaqueMcpProxyResponse::new(b"opaque\n".to_vec(), move |outcome| {
+            recorded.lock().unwrap().push(outcome);
+        })
+        .unwrap();
+
+        drop(response);
+
+        assert!(outcomes.lock().unwrap().is_empty());
+    }
+}

--- a/crates/ctx-cli/src/companion.rs
+++ b/crates/ctx-cli/src/companion.rs
@@ -7,11 +7,12 @@ use std::{
     time::Duration,
 };
 
+use ctx_agent_integrations::tool_backend::{OpaqueMcpDeliveryOutcome, OpaqueMcpProxyResponse};
 use ctx_companion_bridge::{
     BridgeError, BridgeLimits, CancellationToken, CliRequest, CompanionBridge,
     CompanionEnvironment, EnvironmentKey, ExitClass, InstalledCompanion, LimitConfiguration,
-    MaintenanceRequest, ManagedPairExpectations, McpRequest, ProtocolVersion, ReleaseChannel,
-    TerminationReason, MAX_ADMISSION_WAIT, MAX_ARGUMENTS, MAX_CAPTURED_WALL_TIME,
+    MaintenanceRequest, ManagedPairExpectations, McpFinishOutcome, McpRequest, ProtocolVersion,
+    ReleaseChannel, TerminationReason, MAX_ADMISSION_WAIT, MAX_ARGUMENTS, MAX_CAPTURED_WALL_TIME,
     MAX_CONCURRENT_PROCESSES, MAX_CONTROL_BYTES, MAX_ENVIRONMENT_ENTRIES, MAX_STDERR_BYTES,
 };
 use serde_json::{json, Value};
@@ -137,14 +138,14 @@ pub(crate) fn forward_paid_cli_if_selected(arguments: Vec<OsString>) -> Option<E
 pub(crate) fn proxy_paid_mcp(
     request_line: &[u8],
     data_root: &Path,
-) -> Result<Vec<u8>, CompanionRouteError> {
+) -> Result<OpaqueMcpProxyResponse, CompanionRouteError> {
     if request_line.len() > MCP_PROXY_MAX_BYTES {
         return Err(CompanionRouteError::Unavailable);
     }
     let companion = installed_companion().map_err(CompanionRouteError::from)?;
     let mut request = McpRequest::new(request_line);
     forward_mcp_environment(request.environment_mut(), data_root);
-    let output = CompanionBridge::new(mcp_limits()?)
+    let response = CompanionBridge::new(mcp_limits()?)
         .launch_mcp(
             &companion,
             request,
@@ -152,21 +153,18 @@ pub(crate) fn proxy_paid_mcp(
         )
         .map_err(classify_bridge_error)
         .map_err(CompanionRouteError::from)?;
-    write_companion_stderr(output.stderr()).map_err(|_| CompanionRouteError::Unavailable)?;
-    if matches!(
-        output.exit_class(),
-        ExitClass::Terminated(TerminationReason::Cancelled)
-    ) {
-        return Err(CompanionRouteError::Unavailable);
-    }
-    if output.stdout_truncated()
-        || output.stderr_truncated()
-        || output.exit_class() != ExitClass::Success
-        || !is_one_framed_line(output.stdout())
-    {
+    if !is_one_framed_line(response.response_frame()) {
         return Err(CompanionRouteError::Incompatible);
     }
-    Ok(output.stdout().to_vec())
+    let response_frame = response.response_frame().to_vec();
+    OpaqueMcpProxyResponse::new(response_frame, move |outcome| {
+        let outcome = match outcome {
+            OpaqueMcpDeliveryOutcome::WrittenAndFlushed => McpFinishOutcome::WrittenAndFlushed,
+            OpaqueMcpDeliveryOutcome::OutputFailed => McpFinishOutcome::OutputFailed,
+        };
+        let _ = response.finish(outcome);
+    })
+    .ok_or(CompanionRouteError::Incompatible)
 }
 
 pub(crate) fn wake_verified_private_maintenance(
@@ -519,13 +517,14 @@ fn classify_bridge_error(error: BridgeError) -> CompanionLaunchError {
             reason: "detached installation verification failed",
         },
         BridgeError::InvalidProtocolResponse(_) => CompanionLaunchError::InvalidLaunch {
-            reason: "Pro returned an invalid Protocol V3 response",
+            reason: "Pro returned an invalid companion protocol response",
         },
         BridgeError::ExecutableMetadata { .. }
         | BridgeError::Limit(_)
         | BridgeError::InvalidEnvironmentName
         | BridgeError::QueueTimeout
         | BridgeError::CancelledBeforeSpawn
+        | BridgeError::McpExchangeFailed { .. }
         | BridgeError::Spawn(_)
         | BridgeError::Transport(_)
         | BridgeError::WorkerFailed
@@ -543,11 +542,6 @@ fn exit_code(exit: ExitClass) -> ExitCode {
         ExitClass::UnknownFailure | ExitClass::Terminated(_) => 1,
     };
     ExitCode::from(code)
-}
-
-fn write_companion_stderr(bytes: &[u8]) -> std::io::Result<()> {
-    std::io::stderr().write_all(bytes)?;
-    std::io::stderr().flush()
 }
 
 fn write_cli_launch_error(error: &CompanionLaunchError) {

--- a/crates/ctx-cli/src/companion.rs
+++ b/crates/ctx-cli/src/companion.rs
@@ -568,8 +568,8 @@ fn cli_launch_error_document(error: &CompanionLaunchError) -> Value {
             stderr,
             stderr_truncated,
         } => json!({
-            "reason": "companion exited before Protocol V3 handshake",
-            "stderr": String::from_utf8_lossy(stderr),
+            "reason": "companion exited before Protocol V4 handshake",
+            "stderr_present": !stderr.is_empty(),
             "stderr_truncated": stderr_truncated,
         }),
         CompanionLaunchError::InvalidLaunch { reason } => json!({"reason": reason}),

--- a/crates/ctx-cli/src/companion/contract_tests.rs
+++ b/crates/ctx-cli/src/companion/contract_tests.rs
@@ -531,9 +531,9 @@ fn protocol_mismatch_is_a_distinct_typed_error() {
     std::fs::write(&pro, b"#!/bin/sh\nprintf '{\"protocol_version\":2}\\n'\n").unwrap();
     std::fs::set_permissions(&pro, std::fs::Permissions::from_mode(0o700)).unwrap();
     let error = CompanionBridge::default()
-        .launch_mcp(
+        .launch_cli(
             &InstalledCompanion::new(&pro),
-            McpRequest::new(b"{}\n"),
+            CliRequest::new(Vec::new()),
             &CancellationToken::new(),
         )
         .unwrap_err();
@@ -565,7 +565,8 @@ fn pre_handshake_exit_is_retryable_unavailable_not_protocol_mismatch() {
     assert_eq!(error.code(), "companion_unavailable");
     assert!(error.retryable());
     let document = cli_launch_error_document(&error);
-    assert_eq!(document["details"]["stderr"], "loader diagnostic");
+    assert_eq!(document["details"]["stderr_present"], true);
+    assert!(document["details"].get("stderr").is_none());
     assert_eq!(document["details"]["stderr_truncated"], false);
     assert!(document["details"]
         .get("observed_protocol_version")

--- a/crates/ctx-cli/src/companion/contract_tests.rs
+++ b/crates/ctx-cli/src/companion/contract_tests.rs
@@ -461,7 +461,7 @@ fn missing_pro_is_a_distinct_typed_error() {
     let error = CompanionBridge::default()
         .launch_mcp(
             &companion,
-            McpRequest::new(Vec::new()),
+            McpRequest::new(b"{}\n"),
             &CancellationToken::new(),
         )
         .unwrap_err();
@@ -475,7 +475,7 @@ fn missing_pro_is_a_distinct_typed_error() {
 
 #[cfg(unix)]
 #[test]
-fn protocol_v3_alone_launches_pro_without_any_context_environment() {
+fn protocol_v4_alone_launches_pro_without_any_context_environment() {
     use std::os::unix::fs::PermissionsExt as _;
 
     let temp = tempfile::tempdir().unwrap();
@@ -486,18 +486,22 @@ fn protocol_v3_alone_launches_pro_without_any_context_environment() {
     std::fs::write(
         &pro,
         br##"#!/bin/sh
-if [ "$1" = "--ctx-pro-protocol-v3" ] && [ "$2" = "handshake" ]; then
-  printf '{"protocol_version":3}\n'
+if [ "$1" = "--ctx-pro-protocol-v4" ] && [ "$2" = "handshake" ]; then
+  printf '{"protocol_version":4}\n'
   exit 0
 fi
-if [ "$1" != "--ctx-pro-protocol-v3" ] || [ "$2" != "mcp-serve" ]; then
+if [ "$1" != "--ctx-pro-protocol-v4" ] || [ "$2" != "mcp-serve" ]; then
   exit 91
 fi
 for name in CTX_PRO_PATH CTX_PRO_INSTALL_CONTEXT CTX_DATA_ROOT CTX_PRO_DATA_ROOT CTX_MANAGED_PAIR_CHANNEL CTX_PRO_INSTALLATION_ID CTX_MANAGED_PAIR_INVOCATION_FINGERPRINT CTX_MANAGED_PAIR_CORE_CAPABILITY_FINGERPRINT CTX_RELEASE_BUILD_SOURCE_COMMIT; do
   eval "value=\${$name-}"
   [ -z "$value" ] || exit 92
 done
+IFS= read -r request || exit 93
+[ "$request" = '{}' ] || exit 94
 printf '{"jsonrpc":"2.0"}\n'
+IFS= read -r receipt || exit 95
+[ "$receipt" = 'written_and_flushed' ] || exit 96
 "##,
     )
     .unwrap();
@@ -506,14 +510,15 @@ printf '{"jsonrpc":"2.0"}\n'
     let response = CompanionBridge::default()
         .launch_mcp(
             &companion,
-            McpRequest::new(Vec::new()),
+            McpRequest::new(b"{}\n"),
             &CancellationToken::new(),
         )
         .unwrap();
 
-    assert_eq!(response.exit_class(), ExitClass::Success);
-    assert_eq!(response.stdout(), b"{\"jsonrpc\":\"2.0\"}\n");
-    assert!(response.stderr().is_empty());
+    assert_eq!(response.response_frame(), b"{\"jsonrpc\":\"2.0\"}\n");
+    response
+        .finish(McpFinishOutcome::WrittenAndFlushed)
+        .unwrap();
 }
 
 #[cfg(unix)]
@@ -528,7 +533,7 @@ fn protocol_mismatch_is_a_distinct_typed_error() {
     let error = CompanionBridge::default()
         .launch_mcp(
             &InstalledCompanion::new(&pro),
-            McpRequest::new(Vec::new()),
+            McpRequest::new(b"{}\n"),
             &CancellationToken::new(),
         )
         .unwrap_err();
@@ -538,7 +543,7 @@ fn protocol_mismatch_is_a_distinct_typed_error() {
         CompanionLaunchError::ProtocolMismatch {
             expected,
             observed,
-        } if expected.get() == 3 && observed.get() == 2
+        } if expected.get() == 4 && observed.get() == 2
     ));
     assert_eq!(error.code(), "companion_protocol_mismatch");
 }

--- a/crates/ctx-cli/src/tool_backend/application.rs
+++ b/crates/ctx-cli/src/tool_backend/application.rs
@@ -15,12 +15,12 @@ use ctx_history_index::{
 use serde_json::Value;
 
 use super::{
-    CursorFailureKind, OpaqueMcpProxyError, QueryEventsRequest, ShowEventRequest,
-    ShowSessionRequest, StructuredToolError, ToolBackend, ToolBackendError, ToolEventContent,
-    ToolEventRangeDirection, ToolEventRangeScope, ToolExecutionError, ToolOperation, ToolOutcome,
-    ToolSearchBackend, ToolSearchContentScope, ToolSearchFailurePhase, ToolSearchRefreshStatus,
-    ToolSearchRequest, ToolSearchStopReason, ToolSearchTerminalFacts, ToolSearchUsageFacts,
-    ToolTranscriptMode, ToolUsageFacts,
+    CursorFailureKind, OpaqueMcpProxyError, OpaqueMcpProxyResponse, QueryEventsRequest,
+    ShowEventRequest, ShowSessionRequest, StructuredToolError, ToolBackend, ToolBackendError,
+    ToolEventContent, ToolEventRangeDirection, ToolEventRangeScope, ToolExecutionError,
+    ToolOperation, ToolOutcome, ToolSearchBackend, ToolSearchContentScope, ToolSearchFailurePhase,
+    ToolSearchRefreshStatus, ToolSearchRequest, ToolSearchStopReason, ToolSearchTerminalFacts,
+    ToolSearchUsageFacts, ToolTranscriptMode, ToolUsageFacts,
 };
 use crate::{
     commands::list::events::{
@@ -437,7 +437,10 @@ impl ToolBackend for LocalToolBackend {
         invoke_mcp_tool_call(operation, self, self, self)
     }
 
-    fn proxy_companion_mcp(&self, request: &[u8]) -> Result<Vec<u8>, OpaqueMcpProxyError> {
+    fn proxy_companion_mcp(
+        &self,
+        request: &[u8],
+    ) -> Result<OpaqueMcpProxyResponse, OpaqueMcpProxyError> {
         crate::companion::proxy_paid_mcp(request, &self.data_root).map_err(|error| match error {
             crate::companion::CompanionRouteError::Unavailable => {
                 OpaqueMcpProxyError::CompanionUnavailable

--- a/crates/ctx-companion-bridge/Cargo.toml
+++ b/crates/ctx-companion-bridge/Cargo.toml
@@ -22,7 +22,7 @@ thiserror.workspace = true
 libc.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_SystemInformation", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/ctx-companion-bridge/Cargo.toml
+++ b/crates/ctx-companion-bridge/Cargo.toml
@@ -22,7 +22,7 @@ thiserror.workspace = true
 libc.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/ctx-companion-bridge/src/error.rs
+++ b/crates/ctx-companion-bridge/src/error.rs
@@ -25,14 +25,16 @@ pub enum BridgeError {
         expected: ProtocolVersion,
         observed: ProtocolVersion,
     },
-    #[error("installed companion exited before completing the Protocol V3 handshake")]
+    #[error("installed companion exited before completing the Core companion handshake")]
     HandshakeFailed {
         exit: ExitClass,
         stderr: Vec<u8>,
         stderr_truncated: bool,
     },
-    #[error("installed companion returned an invalid Protocol V3 {0} response")]
+    #[error("installed companion returned an invalid Core companion {0} response")]
     InvalidProtocolResponse(&'static str),
+    #[error("installed companion did not complete the MCP exchange: {exit:?}")]
+    McpExchangeFailed { exit: ExitClass },
     #[error("managed companion request exceeds the {0} limit")]
     Limit(&'static str),
     #[error("managed companion request contains an invalid environment name")]

--- a/crates/ctx-companion-bridge/src/lib.rs
+++ b/crates/ctx-companion-bridge/src/lib.rs
@@ -404,3 +404,5 @@ impl Drop for ConcurrencyPermit {
 
 #[cfg(test)]
 mod tests;
+#[cfg(all(test, windows))]
+mod tests_windows;

--- a/crates/ctx-companion-bridge/src/lib.rs
+++ b/crates/ctx-companion-bridge/src/lib.rs
@@ -136,7 +136,7 @@ impl std::fmt::Debug for McpResponse {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("McpResponse")
-            .field("response_frame", &self.response_frame)
+            .field("response_frame_bytes", &self.response_frame.len())
             .finish_non_exhaustive()
     }
 }

--- a/crates/ctx-companion-bridge/src/lib.rs
+++ b/crates/ctx-companion-bridge/src/lib.rs
@@ -1,8 +1,9 @@
-//! Neutral Protocol V3 launch and bounded byte transport for installed Pro.
+//! Neutral Protocol V4 launch and bounded byte transport for an installed companion.
 //!
-//! Core supplies only the installed Pro executable and a typed operation. The
-//! bridge performs a bounded Protocol V3 handshake against that executable,
-//! clears ambient environment authority, and launches the operation directly.
+//! Core supplies only the installed companion executable and a typed operation. The
+//! bridge clears ambient environment authority and launches the operation
+//! directly. CLI and maintenance perform a bounded Protocol V4 handshake;
+//! MCP's versioned invocation is its own protocol gate.
 //!
 //! The detached signed-envelope API remains available solely to distribution
 //! and installation callers. Launch does not invoke it or consume pair identity.
@@ -18,7 +19,7 @@ mod verifier;
 
 use std::{
     fs, io,
-    sync::{Condvar, Mutex},
+    sync::{Arc, Condvar, Mutex},
     time::{Duration, Instant},
 };
 
@@ -31,7 +32,9 @@ pub use limits::{
     MAX_STDERR_BYTES, MAX_STDOUT_BYTES,
 };
 pub use process::{ExitClass, TerminationReason};
-pub use protocol::{InstalledCompanion, ProtocolVersion, CORE_PRO_PROTOCOL_VERSION};
+pub use protocol::{
+    InstalledCompanion, ProtocolVersion, CORE_COMPANION_PROTOCOL_VERSION, CORE_PRO_PROTOCOL_VERSION,
+};
 pub use request::{CancellationToken, CliRequest, MaintenanceRequest, McpRequest};
 pub use verifier::{
     verify_signed_managed_pair_envelope, ManagedPairExpectations, ReleaseChannel,
@@ -39,7 +42,7 @@ pub use verifier::{
     MANAGED_PAIR_ENVELOPE_FILENAME, MANAGED_PAIR_STATE_FILENAME,
 };
 
-use process::{ProcessExit, ProcessOutput};
+use process::ProcessExit;
 use protocol::parse_handshake_receipt;
 use request::ProcessRequest;
 
@@ -49,13 +52,25 @@ const HANDSHAKE_WALL_TIME: Duration = Duration::from_secs(5);
 const MAINTENANCE_WALL_TIME: Duration = Duration::from_secs(6 * 60 * 60);
 const MAINTENANCE_RECEIPT: &[u8] = b"{\"accepted\":true,\"schema_version\":1}\n";
 
-#[derive(Debug)]
 pub struct McpResponse {
-    exit: ExitClass,
-    stdout: Vec<u8>,
-    stderr: Vec<u8>,
-    stdout_truncated: bool,
-    stderr_truncated: bool,
+    response_frame: Vec<u8>,
+    outcome: Option<std::sync::mpsc::SyncSender<McpFinishOutcome>>,
+    lifecycle_owner: Option<std::thread::JoinHandle<Result<(), BridgeError>>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum McpFinishOutcome {
+    WrittenAndFlushed,
+    OutputFailed,
+}
+
+impl McpFinishOutcome {
+    pub(crate) const fn receipt_frame(self) -> &'static [u8] {
+        match self {
+            Self::WrittenAndFlushed => protocol::MCP_WRITTEN_AND_FLUSHED_RECEIPT,
+            Self::OutputFailed => protocol::MCP_OUTPUT_FAILED_RECEIPT,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -75,24 +90,54 @@ impl CliResponse {
 }
 
 impl McpResponse {
-    pub const fn exit_class(&self) -> ExitClass {
-        self.exit
+    pub fn response_frame(&self) -> &[u8] {
+        &self.response_frame
     }
 
     pub fn stdout(&self) -> &[u8] {
-        &self.stdout
+        self.response_frame()
     }
 
-    pub fn stderr(&self) -> &[u8] {
-        &self.stderr
+    pub fn finish(mut self, outcome: McpFinishOutcome) -> Result<(), BridgeError> {
+        let outcome_sent = self
+            .outcome
+            .take()
+            .ok_or(BridgeError::WorkerFailed)?
+            .send(outcome)
+            .is_ok();
+        let result = self
+            .lifecycle_owner
+            .take()
+            .ok_or(BridgeError::WorkerFailed)?
+            .join()
+            .map_err(|_| BridgeError::WorkerFailed)?;
+        if outcome_sent {
+            result
+        } else {
+            result.and(Err(BridgeError::WorkerFailed))
+        }
     }
+}
 
-    pub const fn stdout_truncated(&self) -> bool {
-        self.stdout_truncated
+impl Drop for McpResponse {
+    fn drop(&mut self) {
+        // Disconnect means the final client outcome is unknown. The owner
+        // terminates and reaps without sending either terminal receipt. A Drop
+        // implementation cannot surface teardown results; explicit `finish`
+        // returns every finalization error to Core.
+        self.outcome.take();
+        if let Some(owner) = self.lifecycle_owner.take() {
+            let _ = owner.join();
+        }
     }
+}
 
-    pub const fn stderr_truncated(&self) -> bool {
-        self.stderr_truncated
+impl std::fmt::Debug for McpResponse {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("McpResponse")
+            .field("response_frame", &self.response_frame)
+            .finish_non_exhaustive()
     }
 }
 
@@ -102,28 +147,16 @@ impl MaintenanceResponse {
     }
 }
 
-impl From<ProcessOutput> for McpResponse {
-    fn from(output: ProcessOutput) -> Self {
-        Self {
-            exit: output.exit,
-            stdout: output.stdout,
-            stderr: output.stderr,
-            stdout_truncated: output.stdout_truncated,
-            stderr_truncated: output.stderr_truncated,
-        }
-    }
-}
-
 pub struct CompanionBridge {
     limits: LimitConfiguration,
-    gate: ConcurrencyGate,
+    gate: Arc<ConcurrencyGate>,
 }
 
 impl CompanionBridge {
     pub fn new(limits: BridgeLimits) -> Self {
         let limits = limits.configuration();
         Self {
-            gate: ConcurrencyGate::new(limits.concurrent_processes),
+            gate: Arc::new(ConcurrencyGate::new(limits.concurrent_processes)),
             limits,
         }
     }
@@ -134,10 +167,22 @@ impl CompanionBridge {
         request: McpRequest,
         cancellation: &CancellationToken,
     ) -> Result<McpResponse, BridgeError> {
+        request.validate(self.limits)?;
         let request = request.into_process();
         request.validate(self.limits)?;
-        let _permit = self.prepare_launch(companion, cancellation)?;
-        process::run_captured(companion, request, cancellation, self.limits).map(McpResponse::from)
+        let permit = self.prepare_mcp_launch(companion, cancellation)?;
+        let output = process::launch_mcp(
+            companion,
+            request,
+            cancellation.clone(),
+            self.limits,
+            permit,
+        )?;
+        Ok(McpResponse {
+            response_frame: output.response_frame,
+            outcome: Some(output.outcome),
+            lifecycle_owner: Some(output.lifecycle_owner),
+        })
     }
 
     pub fn launch_maintenance(
@@ -171,7 +216,7 @@ impl CompanionBridge {
         Ok(MaintenanceResponse { accepted: true })
     }
 
-    /// Launches a Protocol V3 CLI operation with the caller's existing standard
+    /// Launches a Protocol V4 CLI operation with the caller's existing standard
     /// streams inherited directly. Once admitted, the child runs until it exits
     /// or cancellation terminates its process tree.
     pub fn launch_cli(
@@ -187,11 +232,11 @@ impl CompanionBridge {
         Ok(CliResponse { exit })
     }
 
-    fn prepare_launch<'a>(
-        &'a self,
+    fn prepare_launch(
+        &self,
         companion: &InstalledCompanion,
         cancellation: &CancellationToken,
-    ) -> Result<ConcurrencyPermit<'a>, BridgeError> {
+    ) -> Result<ConcurrencyPermit, BridgeError> {
         validate_executable(companion)?;
         let permit = self
             .gate
@@ -203,6 +248,23 @@ impl CompanionBridge {
         if cancellation.is_cancelled() {
             return Err(BridgeError::CancelledBeforeSpawn);
         }
+        Ok(permit)
+    }
+
+    fn prepare_mcp_launch(
+        &self,
+        companion: &InstalledCompanion,
+        cancellation: &CancellationToken,
+    ) -> Result<ConcurrencyPermit, BridgeError> {
+        validate_executable(companion)?;
+        let permit = self
+            .gate
+            .acquire(cancellation, self.limits.admission_wait)?;
+        if cancellation.is_cancelled() {
+            return Err(BridgeError::CancelledBeforeSpawn);
+        }
+        // MCP V4's versioned invocation is its protocol gate. CLI and
+        // maintenance retain their separate captured handshake.
         Ok(permit)
     }
 
@@ -232,9 +294,9 @@ impl CompanionBridge {
         }
         let observed = parse_handshake_receipt(&output.stdout)
             .ok_or(BridgeError::InvalidProtocolResponse("handshake"))?;
-        if observed != CORE_PRO_PROTOCOL_VERSION {
+        if observed != CORE_COMPANION_PROTOCOL_VERSION {
             return Err(BridgeError::ProtocolMismatch {
-                expected: CORE_PRO_PROTOCOL_VERSION,
+                expected: CORE_COMPANION_PROTOCOL_VERSION,
                 observed,
             });
         }
@@ -299,10 +361,10 @@ impl ConcurrencyGate {
     }
 
     fn acquire(
-        &self,
+        self: &Arc<Self>,
         cancellation: &CancellationToken,
         timeout: Duration,
-    ) -> Result<ConcurrencyPermit<'_>, BridgeError> {
+    ) -> Result<ConcurrencyPermit, BridgeError> {
         let started = Instant::now();
         let mut active = self.active.lock().map_err(|_| BridgeError::WorkerFailed)?;
         while *active >= self.maximum {
@@ -321,15 +383,17 @@ impl ConcurrencyGate {
             active = next;
         }
         *active += 1;
-        Ok(ConcurrencyPermit { gate: self })
+        Ok(ConcurrencyPermit {
+            gate: Arc::clone(self),
+        })
     }
 }
 
-struct ConcurrencyPermit<'a> {
-    gate: &'a ConcurrencyGate,
+struct ConcurrencyPermit {
+    gate: Arc<ConcurrencyGate>,
 }
 
-impl Drop for ConcurrencyPermit<'_> {
+impl Drop for ConcurrencyPermit {
     fn drop(&mut self) {
         if let Ok(mut active) = self.gate.active.lock() {
             *active = active.saturating_sub(1);

--- a/crates/ctx-companion-bridge/src/process.rs
+++ b/crates/ctx-companion-bridge/src/process.rs
@@ -9,12 +9,16 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[path = "process/mcp.rs"]
+mod mcp;
 #[cfg(unix)]
 #[path = "process/unix.rs"]
 mod platform;
 #[cfg(windows)]
 #[path = "process/windows.rs"]
 mod platform;
+
+pub(crate) use mcp::launch_mcp;
 
 use crate::{
     limits::LimitConfiguration,

--- a/crates/ctx-companion-bridge/src/process/mcp.rs
+++ b/crates/ctx-companion-bridge/src/process/mcp.rs
@@ -1,10 +1,13 @@
 use std::{
-    io::{self, Write as _},
+    io,
     process::{Child, ChildStderr, ChildStdin, ChildStdout, ExitStatus, Stdio},
     sync::mpsc::{self, Receiver, SyncSender, TryRecvError},
     thread,
     time::{Duration, Instant},
 };
+
+#[cfg(unix)]
+use std::io::Write as _;
 
 use crate::{
     limits::LimitConfiguration,
@@ -16,9 +19,12 @@ use crate::{
 use super::{classify_exit, configure_command, platform};
 
 const POLL_INTERVAL: Duration = Duration::from_millis(5);
-// The only post-outcome operation deadline. It covers receipt write/flush and
-// direct-child exit validation in the established bounded delivery window.
+// The one final-delivery deadline starts when Core receives the response. It
+// bounds unknown outcome wait, receipt write/flush, and direct-child exit.
+#[cfg(not(test))]
 const FINALIZATION_GRACE: Duration = Duration::from_secs(60);
+#[cfg(test)]
+const FINALIZATION_GRACE: Duration = Duration::from_millis(500);
 
 pub(crate) struct McpProcessOutput {
     pub(crate) response_frame: Vec<u8>,
@@ -175,15 +181,9 @@ impl LifecycleOwner {
                 });
             }
             if self.cancellation.is_cancelled() {
-                if let Ok(outcome) = outcome_receiver.try_recv() {
-                    return self.finalize(outcome);
-                }
                 return Err(self.terminated(TerminationReason::Cancelled));
             }
             if self.started.elapsed() >= self.wall_time {
-                if let Ok(outcome) = outcome_receiver.try_recv() {
-                    return self.finalize(outcome);
-                }
                 return Err(self.terminated(TerminationReason::WallTime));
             }
             if self.request_complete && self.frame_seen {
@@ -196,7 +196,7 @@ impl LifecycleOwner {
                 response_sender
                     .send(Ok(response))
                     .map_err(|_| BridgeError::WorkerFailed)?;
-                return self.await_outcome(outcome_receiver);
+                return self.await_outcome(outcome_receiver, Instant::now() + FINALIZATION_GRACE);
             }
             self.sleep_until(self.started + self.wall_time);
         }
@@ -205,32 +205,36 @@ impl LifecycleOwner {
     fn await_outcome(
         &mut self,
         outcome_receiver: Receiver<McpFinishOutcome>,
+        deadline: Instant,
     ) -> Result<(), BridgeError> {
         loop {
             // A queued known outcome wins over cancellation/deadline checks.
             match outcome_receiver.try_recv() {
-                Ok(outcome) => return self.finalize(outcome),
+                Ok(outcome) => return self.finalize(outcome, deadline),
                 Err(TryRecvError::Disconnected) => return Err(BridgeError::WorkerFailed),
                 Err(TryRecvError::Empty) => {}
             }
             if self.cancellation.is_cancelled() {
                 if let Ok(outcome) = outcome_receiver.try_recv() {
-                    return self.finalize(outcome);
+                    return self.finalize(outcome, deadline);
                 }
                 return Err(self.terminated(TerminationReason::Cancelled));
             }
-            if self.started.elapsed() >= self.wall_time {
+            if Instant::now() >= deadline {
                 if let Ok(outcome) = outcome_receiver.try_recv() {
-                    return self.finalize(outcome);
+                    return self.finalize(outcome, deadline);
                 }
                 return Err(self.terminated(TerminationReason::WallTime));
             }
-            self.sleep_until(self.started + self.wall_time);
+            self.sleep_until(deadline);
         }
     }
 
-    fn finalize(&mut self, outcome: McpFinishOutcome) -> Result<(), BridgeError> {
-        let deadline = Instant::now() + FINALIZATION_GRACE;
+    fn finalize(
+        &mut self,
+        outcome: McpFinishOutcome,
+        deadline: Instant,
+    ) -> Result<(), BridgeError> {
         self.write_receipt(outcome, deadline)?;
         self.stdin.take();
         loop {
@@ -296,8 +300,10 @@ impl LifecycleOwner {
         #[cfg(windows)]
         {
             let stdin = self.stdin.take().ok_or(BridgeError::WorkerFailed)?;
-            self.pipe_writer =
-                Some(platform::PipeWriter::spawn(stdin, frame).map_err(BridgeError::Transport)?);
+            self.pipe_writer = Some(
+                platform::PipeWriter::spawn(stdin, frame.to_vec())
+                    .map_err(BridgeError::Transport)?,
+            );
             loop {
                 if let Some(result) = self
                     .pipe_writer
@@ -337,25 +343,25 @@ impl LifecycleOwner {
                     Err(error) => return Err(BridgeError::Transport(error)),
                 }
             }
-        }
-        loop {
-            if Instant::now() >= deadline {
-                return Err(BridgeError::Transport(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    "MCP receipt flush timed out",
-                )));
-            }
-            match self
-                .stdin
-                .as_mut()
-                .ok_or(BridgeError::WorkerFailed)?
-                .flush()
-            {
-                Ok(()) => return Ok(()),
-                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
-                    self.sleep_until(deadline)
+            loop {
+                if Instant::now() >= deadline {
+                    return Err(BridgeError::Transport(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "MCP receipt flush timed out",
+                    )));
                 }
-                Err(error) => return Err(BridgeError::Transport(error)),
+                match self
+                    .stdin
+                    .as_mut()
+                    .ok_or(BridgeError::WorkerFailed)?
+                    .flush()
+                {
+                    Ok(()) => return Ok(()),
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                        self.sleep_until(deadline)
+                    }
+                    Err(error) => return Err(BridgeError::Transport(error)),
+                }
             }
         }
     }
@@ -448,6 +454,7 @@ impl Drop for LifecycleOwner {
     }
 }
 
+#[cfg(unix)]
 fn write_zero(message: &'static str) -> BridgeError {
     BridgeError::Transport(io::Error::new(io::ErrorKind::WriteZero, message))
 }

--- a/crates/ctx-companion-bridge/src/process/mcp.rs
+++ b/crates/ctx-companion-bridge/src/process/mcp.rs
@@ -1,0 +1,430 @@
+use std::{
+    io::{self, Write as _},
+    process::{Child, ChildStderr, ChildStdin, ChildStdout, ExitStatus, Stdio},
+    sync::mpsc::{self, Receiver, SyncSender, TryRecvError},
+    thread,
+    time::{Duration, Instant},
+};
+
+use crate::{
+    limits::LimitConfiguration,
+    protocol::InstalledCompanion,
+    request::{CancellationToken, CapturedProcessRequest},
+    BridgeError, ConcurrencyPermit, ExitClass, McpFinishOutcome, TerminationReason,
+};
+
+use super::{classify_exit, configure_command, platform};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(5);
+// The only post-outcome operation deadline. It covers receipt write/flush and
+// direct-child exit validation in the established bounded delivery window.
+const FINALIZATION_GRACE: Duration = Duration::from_secs(60);
+
+pub(crate) struct McpProcessOutput {
+    pub(crate) response_frame: Vec<u8>,
+    pub(crate) outcome: SyncSender<McpFinishOutcome>,
+    pub(crate) lifecycle_owner: thread::JoinHandle<Result<(), BridgeError>>,
+}
+
+pub(crate) fn launch_mcp(
+    companion: &InstalledCompanion,
+    request: CapturedProcessRequest,
+    cancellation: CancellationToken,
+    limits: LimitConfiguration,
+    permit: ConcurrencyPermit,
+) -> Result<McpProcessOutput, BridgeError> {
+    let (response_sender, response_receiver) = mpsc::sync_channel(1);
+    let (outcome_sender, outcome_receiver) = mpsc::sync_channel(1);
+    let companion = companion.clone();
+    let lifecycle_owner = thread::Builder::new()
+        .name("ctx-companion-mcp-owner".to_owned())
+        .spawn(move || {
+            LifecycleOwner::spawn_and_run(
+                companion,
+                request,
+                cancellation,
+                limits,
+                permit,
+                response_sender,
+                outcome_receiver,
+            )
+        })
+        .map_err(BridgeError::Transport)?;
+    match response_receiver.recv() {
+        Ok(Ok(response_frame)) => Ok(McpProcessOutput {
+            response_frame,
+            outcome: outcome_sender,
+            lifecycle_owner,
+        }),
+        Ok(Err(error)) => {
+            let _ = lifecycle_owner.join();
+            Err(error)
+        }
+        Err(_) => match lifecycle_owner.join() {
+            Ok(Err(error)) => Err(error),
+            Ok(Ok(())) | Err(_) => Err(BridgeError::WorkerFailed),
+        },
+    }
+}
+
+struct LifecycleOwner {
+    child: Child,
+    tree: platform::ProcessTree,
+    stdin: Option<ChildStdin>,
+    #[cfg(windows)]
+    request_writer: Option<platform::RequestWriter>,
+    stdout: Option<ChildStdout>,
+    stderr: Option<ChildStderr>,
+    request_frame: Vec<u8>,
+    #[cfg(unix)]
+    request_offset: usize,
+    request_complete: bool,
+    response_frame: Vec<u8>,
+    frame_seen: bool,
+    cancellation: CancellationToken,
+    started: Instant,
+    wall_time: Duration,
+    stdout_limit: usize,
+    terminated: bool,
+    _permit: ConcurrencyPermit,
+}
+
+impl LifecycleOwner {
+    #[allow(clippy::too_many_arguments)]
+    fn spawn_and_run(
+        companion: InstalledCompanion,
+        request: CapturedProcessRequest,
+        cancellation: CancellationToken,
+        limits: LimitConfiguration,
+        permit: ConcurrencyPermit,
+        response_sender: SyncSender<Result<Vec<u8>, BridgeError>>,
+        outcome_receiver: Receiver<McpFinishOutcome>,
+    ) -> Result<(), BridgeError> {
+        let CapturedProcessRequest {
+            control,
+            stdin: request_frame,
+        } = request;
+        let mut command = std::process::Command::new(companion.executable());
+        configure_command(&mut command, &control)?;
+        command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let started = Instant::now();
+        let (mut child, tree) = platform::spawn(&mut command)?;
+        let pipes = (|| {
+            let stdin = take_pipe(child.stdin.take(), "child stdin missing")?;
+            let stdout = take_pipe(child.stdout.take(), "child stdout missing")?;
+            let stderr = take_pipe(child.stderr.take(), "child stderr missing")?;
+            platform::prepare_pipes(&stdin, &stdout, &stderr).map_err(BridgeError::Transport)?;
+            Ok::<_, BridgeError>((stdin, stdout, stderr))
+        })();
+        let (stdin, stdout, stderr) = match pipes {
+            Ok(pipes) => pipes,
+            Err(error) => {
+                tree.terminate();
+                let _ = child.wait();
+                return Err(error);
+            }
+        };
+        let mut owner = Self {
+            child,
+            tree,
+            stdin: Some(stdin),
+            #[cfg(windows)]
+            request_writer: None,
+            stdout: Some(stdout),
+            stderr: Some(stderr),
+            request_frame,
+            #[cfg(unix)]
+            request_offset: 0,
+            request_complete: false,
+            response_frame: Vec::new(),
+            frame_seen: false,
+            cancellation,
+            started,
+            wall_time: limits.captured_wall_time,
+            stdout_limit: limits.stdout_bytes,
+            terminated: false,
+            _permit: permit,
+        };
+        #[cfg(windows)]
+        {
+            let stdin = owner.stdin.take().ok_or(BridgeError::WorkerFailed)?;
+            owner.request_writer = Some(
+                match platform::RequestWriter::spawn(stdin, owner.request_frame.clone()) {
+                    Ok(writer) => writer,
+                    Err(error) => return Err(BridgeError::Transport(error)),
+                },
+            );
+        }
+        owner.run(response_sender, outcome_receiver)
+    }
+
+    fn run(
+        &mut self,
+        response_sender: SyncSender<Result<Vec<u8>, BridgeError>>,
+        outcome_receiver: Receiver<McpFinishOutcome>,
+    ) -> Result<(), BridgeError> {
+        loop {
+            self.poll_request_write()?;
+            self.drain_pipes(false)?;
+            if let Some(status) = self.try_wait()? {
+                return Err(BridgeError::McpExchangeFailed {
+                    exit: classify_exit(status),
+                });
+            }
+            if self.cancellation.is_cancelled() {
+                if let Ok(outcome) = outcome_receiver.try_recv() {
+                    return self.finalize(outcome);
+                }
+                return Err(self.terminated(TerminationReason::Cancelled));
+            }
+            if self.started.elapsed() >= self.wall_time {
+                if let Ok(outcome) = outcome_receiver.try_recv() {
+                    return self.finalize(outcome);
+                }
+                return Err(self.terminated(TerminationReason::WallTime));
+            }
+            if self.request_complete && self.frame_seen {
+                // Check bytes already ready, then close Core's local read ends.
+                // Escaped pipe holders cannot retain this owner or its permit.
+                self.drain_pipes(true)?;
+                self.stdout.take();
+                self.stderr.take();
+                let response = std::mem::take(&mut self.response_frame);
+                response_sender
+                    .send(Ok(response))
+                    .map_err(|_| BridgeError::WorkerFailed)?;
+                return self.await_outcome(outcome_receiver);
+            }
+            self.sleep_until(self.started + self.wall_time);
+        }
+    }
+
+    fn await_outcome(
+        &mut self,
+        outcome_receiver: Receiver<McpFinishOutcome>,
+    ) -> Result<(), BridgeError> {
+        loop {
+            // A queued known outcome wins over cancellation/deadline checks.
+            match outcome_receiver.try_recv() {
+                Ok(outcome) => return self.finalize(outcome),
+                Err(TryRecvError::Disconnected) => return Err(BridgeError::WorkerFailed),
+                Err(TryRecvError::Empty) => {}
+            }
+            if self.cancellation.is_cancelled() {
+                if let Ok(outcome) = outcome_receiver.try_recv() {
+                    return self.finalize(outcome);
+                }
+                return Err(self.terminated(TerminationReason::Cancelled));
+            }
+            if self.started.elapsed() >= self.wall_time {
+                if let Ok(outcome) = outcome_receiver.try_recv() {
+                    return self.finalize(outcome);
+                }
+                return Err(self.terminated(TerminationReason::WallTime));
+            }
+            self.sleep_until(self.started + self.wall_time);
+        }
+    }
+
+    fn finalize(&mut self, outcome: McpFinishOutcome) -> Result<(), BridgeError> {
+        let deadline = Instant::now() + FINALIZATION_GRACE;
+        self.write_receipt(outcome, deadline)?;
+        self.stdin.take();
+        loop {
+            if let Some(status) = self.try_wait()? {
+                return if status.success() {
+                    Ok(())
+                } else {
+                    Err(BridgeError::McpExchangeFailed {
+                        exit: classify_exit(status),
+                    })
+                };
+            }
+            if Instant::now() >= deadline {
+                return Err(self.terminated(if self.cancellation.is_cancelled() {
+                    TerminationReason::Cancelled
+                } else {
+                    TerminationReason::WallTime
+                }));
+            }
+            self.sleep_until(deadline);
+        }
+    }
+
+    fn poll_request_write(&mut self) -> Result<(), BridgeError> {
+        #[cfg(unix)]
+        {
+            if self.request_complete {
+                return Ok(());
+            }
+            let stdin = self.stdin.as_mut().ok_or(BridgeError::WorkerFailed)?;
+            match stdin.write(&self.request_frame[self.request_offset..]) {
+                Ok(0) => return Err(write_zero("MCP request pipe closed")),
+                Ok(written) => self.request_offset += written,
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+                Err(error) => return Err(BridgeError::Transport(error)),
+            }
+            if self.request_offset == self.request_frame.len() {
+                stdin.flush().map_err(BridgeError::Transport)?;
+                self.request_complete = true;
+            }
+        }
+        #[cfg(windows)]
+        {
+            let Some(writer) = self.request_writer.as_mut() else {
+                return Ok(());
+            };
+            let Some(result) = writer.poll() else {
+                return Ok(());
+            };
+            self.stdin = Some(result.map_err(BridgeError::Transport)?);
+            self.request_writer = None;
+            self.request_complete = true;
+        }
+        Ok(())
+    }
+
+    fn write_receipt(
+        &mut self,
+        outcome: McpFinishOutcome,
+        deadline: Instant,
+    ) -> Result<(), BridgeError> {
+        let frame = outcome.receipt_frame();
+        let mut offset = 0;
+        while offset < frame.len() {
+            if Instant::now() >= deadline {
+                return Err(BridgeError::Transport(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "MCP receipt write timed out",
+                )));
+            }
+            let stdin = self.stdin.as_mut().ok_or(BridgeError::WorkerFailed)?;
+            match stdin.write(&frame[offset..]) {
+                Ok(0) => return Err(write_zero("MCP receipt pipe closed")),
+                Ok(written) => offset += written,
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    self.sleep_until(deadline)
+                }
+                Err(error) => return Err(BridgeError::Transport(error)),
+            }
+        }
+        loop {
+            if Instant::now() >= deadline {
+                return Err(BridgeError::Transport(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "MCP receipt flush timed out",
+                )));
+            }
+            match self
+                .stdin
+                .as_mut()
+                .ok_or(BridgeError::WorkerFailed)?
+                .flush()
+            {
+                Ok(()) => return Ok(()),
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    self.sleep_until(deadline)
+                }
+                Err(error) => return Err(BridgeError::Transport(error)),
+            }
+        }
+    }
+
+    fn drain_pipes(&mut self, allow_stdout_close: bool) -> Result<(), BridgeError> {
+        let mut buffer = [0_u8; 8 * 1024];
+        while let Some(stdout) = self.stdout.as_mut() {
+            match platform::read_pipe(stdout, &mut buffer).map_err(BridgeError::Transport)? {
+                platform::PipeRead::Data(read) => self.consume_stdout(&buffer[..read])?,
+                platform::PipeRead::Pending => break,
+                platform::PipeRead::Closed => {
+                    self.stdout.take();
+                    if !allow_stdout_close || !self.frame_seen {
+                        return Err(BridgeError::InvalidProtocolResponse("MCP response frame"));
+                    }
+                    break;
+                }
+            }
+        }
+        if let Some(stderr) = self.stderr.as_mut() {
+            match platform::read_pipe(stderr, &mut buffer).map_err(BridgeError::Transport)? {
+                platform::PipeRead::Data(_) => {
+                    return Err(BridgeError::InvalidProtocolResponse("MCP stderr"))
+                }
+                platform::PipeRead::Pending => {}
+                platform::PipeRead::Closed => {
+                    self.stderr.take();
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn consume_stdout(&mut self, bytes: &[u8]) -> Result<(), BridgeError> {
+        if self.frame_seen {
+            return Err(BridgeError::InvalidProtocolResponse("MCP response frame"));
+        }
+        if let Some(newline) = bytes.iter().position(|byte| *byte == b'\n') {
+            if self.response_frame.len().saturating_add(newline + 1) > self.stdout_limit {
+                return Err(BridgeError::Limit("stdout bytes"));
+            }
+            self.response_frame.extend_from_slice(&bytes[..=newline]);
+            self.frame_seen = true;
+            if newline + 1 != bytes.len() {
+                return Err(BridgeError::InvalidProtocolResponse("MCP response frame"));
+            }
+        } else {
+            if self.response_frame.len().saturating_add(bytes.len()) >= self.stdout_limit {
+                return Err(BridgeError::Limit("stdout bytes"));
+            }
+            self.response_frame.extend_from_slice(bytes);
+        }
+        Ok(())
+    }
+
+    fn try_wait(&mut self) -> Result<Option<ExitStatus>, BridgeError> {
+        self.child.try_wait().map_err(BridgeError::Transport)
+    }
+
+    fn terminated(&self, reason: TerminationReason) -> BridgeError {
+        BridgeError::McpExchangeFailed {
+            exit: ExitClass::Terminated(reason),
+        }
+    }
+
+    fn sleep_until(&self, deadline: Instant) {
+        thread::sleep(POLL_INTERVAL.min(deadline.saturating_duration_since(Instant::now())));
+    }
+
+    fn terminate_and_reap(&mut self) {
+        if self.terminated {
+            return;
+        }
+        self.terminated = true;
+        self.tree.terminate();
+        self.stdin.take();
+        self.stdout.take();
+        self.stderr.take();
+        #[cfg(windows)]
+        if let Some(writer) = self.request_writer.take() {
+            let _ = writer.cancel_and_join();
+        }
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for LifecycleOwner {
+    fn drop(&mut self) {
+        self.terminate_and_reap();
+    }
+}
+
+fn write_zero(message: &'static str) -> BridgeError {
+    BridgeError::Transport(io::Error::new(io::ErrorKind::WriteZero, message))
+}
+
+fn take_pipe<T>(pipe: Option<T>, message: &'static str) -> Result<T, BridgeError> {
+    pipe.ok_or_else(|| BridgeError::Transport(io::Error::new(io::ErrorKind::BrokenPipe, message)))
+}

--- a/crates/ctx-companion-bridge/src/process/mcp.rs
+++ b/crates/ctx-companion-bridge/src/process/mcp.rs
@@ -72,7 +72,7 @@ struct LifecycleOwner {
     tree: platform::ProcessTree,
     stdin: Option<ChildStdin>,
     #[cfg(windows)]
-    request_writer: Option<platform::RequestWriter>,
+    pipe_writer: Option<platform::PipeWriter>,
     stdout: Option<ChildStdout>,
     stderr: Option<ChildStderr>,
     request_frame: Vec<u8>,
@@ -132,7 +132,7 @@ impl LifecycleOwner {
             tree,
             stdin: Some(stdin),
             #[cfg(windows)]
-            request_writer: None,
+            pipe_writer: None,
             stdout: Some(stdout),
             stderr: Some(stderr),
             request_frame,
@@ -151,8 +151,8 @@ impl LifecycleOwner {
         #[cfg(windows)]
         {
             let stdin = owner.stdin.take().ok_or(BridgeError::WorkerFailed)?;
-            owner.request_writer = Some(
-                match platform::RequestWriter::spawn(stdin, owner.request_frame.clone()) {
+            owner.pipe_writer = Some(
+                match platform::PipeWriter::spawn(stdin, owner.request_frame.clone()) {
                     Ok(writer) => writer,
                     Err(error) => return Err(BridgeError::Transport(error)),
                 },
@@ -274,14 +274,14 @@ impl LifecycleOwner {
         }
         #[cfg(windows)]
         {
-            let Some(writer) = self.request_writer.as_mut() else {
+            let Some(writer) = self.pipe_writer.as_mut() else {
                 return Ok(());
             };
             let Some(result) = writer.poll() else {
                 return Ok(());
             };
             self.stdin = Some(result.map_err(BridgeError::Transport)?);
-            self.request_writer = None;
+            self.pipe_writer = None;
             self.request_complete = true;
         }
         Ok(())
@@ -293,22 +293,49 @@ impl LifecycleOwner {
         deadline: Instant,
     ) -> Result<(), BridgeError> {
         let frame = outcome.receipt_frame();
-        let mut offset = 0;
-        while offset < frame.len() {
-            if Instant::now() >= deadline {
-                return Err(BridgeError::Transport(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    "MCP receipt write timed out",
-                )));
-            }
-            let stdin = self.stdin.as_mut().ok_or(BridgeError::WorkerFailed)?;
-            match stdin.write(&frame[offset..]) {
-                Ok(0) => return Err(write_zero("MCP receipt pipe closed")),
-                Ok(written) => offset += written,
-                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
-                    self.sleep_until(deadline)
+        #[cfg(windows)]
+        {
+            let stdin = self.stdin.take().ok_or(BridgeError::WorkerFailed)?;
+            self.pipe_writer =
+                Some(platform::PipeWriter::spawn(stdin, frame).map_err(BridgeError::Transport)?);
+            loop {
+                if let Some(result) = self
+                    .pipe_writer
+                    .as_mut()
+                    .and_then(platform::PipeWriter::poll)
+                {
+                    self.stdin = Some(result.map_err(BridgeError::Transport)?);
+                    self.pipe_writer = None;
+                    return Ok(());
                 }
-                Err(error) => return Err(BridgeError::Transport(error)),
+                if Instant::now() >= deadline {
+                    return Err(BridgeError::Transport(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "MCP receipt write timed out",
+                    )));
+                }
+                self.sleep_until(deadline);
+            }
+        }
+        #[cfg(unix)]
+        {
+            let mut offset = 0;
+            while offset < frame.len() {
+                if Instant::now() >= deadline {
+                    return Err(BridgeError::Transport(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "MCP receipt write timed out",
+                    )));
+                }
+                let stdin = self.stdin.as_mut().ok_or(BridgeError::WorkerFailed)?;
+                match stdin.write(&frame[offset..]) {
+                    Ok(0) => return Err(write_zero("MCP receipt pipe closed")),
+                    Ok(written) => offset += written,
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                        self.sleep_until(deadline)
+                    }
+                    Err(error) => return Err(BridgeError::Transport(error)),
+                }
             }
         }
         loop {
@@ -408,7 +435,7 @@ impl LifecycleOwner {
         self.stdout.take();
         self.stderr.take();
         #[cfg(windows)]
-        if let Some(writer) = self.request_writer.take() {
+        if let Some(writer) = self.pipe_writer.take() {
             let _ = writer.cancel_and_join();
         }
         let _ = self.child.wait();

--- a/crates/ctx-companion-bridge/src/process/unix.rs
+++ b/crates/ctx-companion-bridge/src/process/unix.rs
@@ -1,7 +1,7 @@
 use std::{
-    io,
-    os::unix::process::CommandExt as _,
-    process::{Child, Command},
+    io::{self, Read},
+    os::unix::{io::AsRawFd as _, process::CommandExt as _},
+    process::{Child, ChildStderr, ChildStdin, ChildStdout, Command},
 };
 
 use crate::BridgeError;
@@ -124,4 +124,34 @@ pub(super) fn spawn(command: &mut Command) -> Result<(Child, ProcessTree), Bridg
         process_group: child.id(),
     };
     Ok((child, tree))
+}
+
+pub(super) enum PipeRead {
+    Data(usize),
+    Pending,
+    Closed,
+}
+
+pub(super) fn prepare_pipes(
+    stdin: &ChildStdin,
+    stdout: &ChildStdout,
+    stderr: &ChildStderr,
+) -> io::Result<()> {
+    for fd in [stdin.as_raw_fd(), stdout.as_raw_fd(), stderr.as_raw_fd()] {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if flags == -1 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1
+        {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn read_pipe(pipe: &mut impl Read, buffer: &mut [u8]) -> io::Result<PipeRead> {
+    match pipe.read(buffer) {
+        Ok(0) => Ok(PipeRead::Closed),
+        Ok(read) => Ok(PipeRead::Data(read)),
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(PipeRead::Pending),
+        Err(error) => Err(error),
+    }
 }

--- a/crates/ctx-companion-bridge/src/process/windows.rs
+++ b/crates/ctx-companion-bridge/src/process/windows.rs
@@ -4,9 +4,8 @@ use std::{
     mem::size_of,
     os::windows::{
         ffi::OsStringExt as _,
-        io::{AsRawHandle as _, FromRawHandle as _, OwnedHandle},
+        io::{AsRawHandle, FromRawHandle as _, OwnedHandle},
         process::CommandExt as _,
-        thread::JoinHandleExt as _,
     },
     process::{Child, Command},
     ptr,
@@ -139,7 +138,8 @@ pub(super) fn read_pipe<T: Read + AsRawHandle>(
     if available == 0 {
         return Ok(PipeRead::Pending);
     }
-    match pipe.read(&mut buffer[..buffer.len().min(available as usize)])? {
+    let readable = buffer.len().min(available as usize);
+    match pipe.read(&mut buffer[..readable])? {
         0 => Ok(PipeRead::Closed),
         read => Ok(PipeRead::Data(read)),
     }
@@ -204,24 +204,30 @@ impl PipeWriter {
 
     pub(super) fn cancel_and_join(mut self) -> io::Result<()> {
         use windows_sys::Win32::Foundation::{GetLastError, ERROR_NOT_FOUND};
-        use windows_sys::Win32::System::Threading::CancelSynchronousIo;
+        use windows_sys::Win32::System::IO::CancelSynchronousIo;
 
         let Some(worker) = self.worker.take() else {
             return Ok(());
         };
         // Set the flag before native cancellation. If the writer is between
-        // writes (`ERROR_NOT_FOUND`), it cannot begin another blocking write;
-        // if it is in one, CancelSynchronousIo completes it with cancellation.
+        // writes (`ERROR_NOT_FOUND`), retry across that race; if it is in a
+        // write, CancelSynchronousIo completes it with cancellation.
         self.cancelled.store(true, Ordering::Release);
-        let cancellation_error = if unsafe { CancelSynchronousIo(worker.as_raw_handle()) } == 0 {
+        let cancellation_error = loop {
+            if worker.is_finished() {
+                break None;
+            }
+            if unsafe { CancelSynchronousIo(worker.as_raw_handle()) } != 0 {
+                break None;
+            }
             let error = unsafe { GetLastError() };
             if error != ERROR_NOT_FOUND {
-                Some(io::Error::from_raw_os_error(error as i32))
-            } else {
-                None
+                break Some(io::Error::from_raw_os_error(error as i32));
             }
-        } else {
-            None
+            // The writer can be between its cancellation check and the next
+            // blocking write. Retry until that write is either cancelled or
+            // the worker observes the flag and exits.
+            std::thread::yield_now();
         };
         match worker.join() {
             Ok(_) => cancellation_error.map_or(Ok(()), Err),

--- a/crates/ctx-companion-bridge/src/process/windows.rs
+++ b/crates/ctx-companion-bridge/src/process/windows.rs
@@ -1,14 +1,19 @@
 use std::{
     ffi::OsString,
-    io,
+    io::{self, Read, Write},
     mem::size_of,
     os::windows::{
         ffi::OsStringExt as _,
         io::{AsRawHandle as _, FromRawHandle as _, OwnedHandle},
         process::CommandExt as _,
+        thread::JoinHandleExt as _,
     },
     process::{Child, Command},
     ptr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 
 use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
@@ -84,6 +89,171 @@ pub(super) fn spawn(command: &mut Command) -> Result<(Child, ProcessTree), Bridg
             let _ = child.wait();
             Err(BridgeError::Spawn(error))
         }
+    }
+}
+
+pub(super) enum PipeRead {
+    Data(usize),
+    Pending,
+    Closed,
+}
+
+pub(super) fn prepare_pipes(
+    _stdin: &std::process::ChildStdin,
+    _stdout: &std::process::ChildStdout,
+    _stderr: &std::process::ChildStderr,
+) -> io::Result<()> {
+    Ok(())
+}
+
+pub(super) fn read_pipe<T: Read + AsRawHandle>(
+    pipe: &mut T,
+    buffer: &mut [u8],
+) -> io::Result<PipeRead> {
+    use windows_sys::Win32::{
+        Foundation::{GetLastError, ERROR_BROKEN_PIPE, ERROR_NO_DATA, ERROR_PIPE_NOT_CONNECTED},
+        System::Pipes::PeekNamedPipe,
+    };
+
+    let mut available = 0u32;
+    if unsafe {
+        PeekNamedPipe(
+            pipe.as_raw_handle(),
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null_mut(),
+            &mut available,
+            std::ptr::null_mut(),
+        )
+    } == 0
+    {
+        let error = unsafe { GetLastError() };
+        if matches!(
+            error,
+            ERROR_BROKEN_PIPE | ERROR_NO_DATA | ERROR_PIPE_NOT_CONNECTED
+        ) {
+            return Ok(PipeRead::Closed);
+        }
+        return Err(io::Error::from_raw_os_error(error as i32));
+    }
+    if available == 0 {
+        return Ok(PipeRead::Pending);
+    }
+    match pipe.read(&mut buffer[..buffer.len().min(available as usize)])? {
+        0 => Ok(PipeRead::Closed),
+        read => Ok(PipeRead::Data(read)),
+    }
+}
+
+/// Windows anonymous pipes cannot make the up-to-4 MiB request write pollable.
+/// This is the only helper thread: it owns the one blocking write and is always
+/// cancelled with `CancelSynchronousIo` and joined before its child is reaped.
+pub(super) struct RequestWriter {
+    worker: Option<std::thread::JoinHandle<(std::process::ChildStdin, io::Result<()>)>>,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl RequestWriter {
+    pub(super) fn spawn(stdin: std::process::ChildStdin, request: Vec<u8>) -> io::Result<Self> {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let worker_cancelled = Arc::clone(&cancelled);
+        let worker = std::thread::Builder::new()
+            .name("ctx-companion-mcp-request".to_owned())
+            .spawn(move || {
+                let mut stdin = stdin;
+                let mut offset = 0;
+                let result = loop {
+                    if worker_cancelled.load(Ordering::Acquire) {
+                        break Err(io::Error::new(
+                            io::ErrorKind::Interrupted,
+                            "MCP request write cancelled",
+                        ));
+                    }
+                    if offset == request.len() {
+                        break stdin.flush();
+                    }
+                    match stdin.write(&request[offset..]) {
+                        Ok(0) => {
+                            break Err(io::Error::new(
+                                io::ErrorKind::WriteZero,
+                                "MCP request pipe closed",
+                            ));
+                        }
+                        Ok(written) => offset += written,
+                        Err(error) => break Err(error),
+                    }
+                };
+                (stdin, result)
+            })?;
+        Ok(Self {
+            worker: Some(worker),
+            cancelled,
+        })
+    }
+
+    pub(super) fn poll(&mut self) -> Option<io::Result<std::process::ChildStdin>> {
+        if !self.worker.as_ref()?.is_finished() {
+            return None;
+        }
+        let worker = self.worker.take()?;
+        Some(match worker.join() {
+            Ok((stdin, result)) => result.map(|()| stdin),
+            Err(_) => Err(io::Error::other("MCP request writer panicked")),
+        })
+    }
+
+    pub(super) fn cancel_and_join(mut self) -> io::Result<()> {
+        use windows_sys::Win32::Foundation::{GetLastError, ERROR_NOT_FOUND};
+        use windows_sys::Win32::System::Threading::CancelSynchronousIo;
+
+        let Some(worker) = self.worker.take() else {
+            return Ok(());
+        };
+        // Set the flag before native cancellation. If the writer is between
+        // writes (`ERROR_NOT_FOUND`), it cannot begin another blocking write;
+        // if it is in one, CancelSynchronousIo completes it with cancellation.
+        self.cancelled.store(true, Ordering::Release);
+        let cancellation_error = if unsafe { CancelSynchronousIo(worker.as_raw_handle()) } == 0 {
+            let error = unsafe { GetLastError() };
+            if error != ERROR_NOT_FOUND {
+                Some(io::Error::from_raw_os_error(error as i32))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        match worker.join() {
+            Ok(_) => cancellation_error.map_or(Ok(()), Err),
+            Err(_) => Err(io::Error::other("MCP request writer panicked")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RequestWriter;
+    use std::{
+        process::Stdio,
+        thread,
+        time::{Duration, Instant},
+    };
+
+    #[test]
+    fn cancelled_request_writer_joins_without_leaking() {
+        let mut child = std::process::Command::new("cmd")
+            .args(["/C", "timeout /T 60 /NOBREAK >NUL"])
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let writer =
+            RequestWriter::spawn(child.stdin.take().unwrap(), vec![b'x'; 4 * 1024 * 1024]).unwrap();
+        thread::sleep(Duration::from_millis(25));
+        let started = Instant::now();
+        writer.cancel_and_join().unwrap();
+        assert!(started.elapsed() < Duration::from_secs(2));
+        let _ = child.kill();
+        let _ = child.wait();
     }
 }
 

--- a/crates/ctx-companion-bridge/src/process/windows.rs
+++ b/crates/ctx-companion-bridge/src/process/windows.rs
@@ -145,20 +145,20 @@ pub(super) fn read_pipe<T: Read + AsRawHandle>(
     }
 }
 
-/// Windows anonymous pipes cannot make the up-to-4 MiB request write pollable.
-/// This is the only helper thread: it owns the one blocking write and is always
+/// Windows anonymous child-stdin pipes are not pollable. This is the sole
+/// helper-thread mechanism for both sequential bounded writes: it is always
 /// cancelled with `CancelSynchronousIo` and joined before its child is reaped.
-pub(super) struct RequestWriter {
+pub(super) struct PipeWriter {
     worker: Option<std::thread::JoinHandle<(std::process::ChildStdin, io::Result<()>)>>,
     cancelled: Arc<AtomicBool>,
 }
 
-impl RequestWriter {
-    pub(super) fn spawn(stdin: std::process::ChildStdin, request: Vec<u8>) -> io::Result<Self> {
+impl PipeWriter {
+    pub(super) fn spawn(stdin: std::process::ChildStdin, frame: Vec<u8>) -> io::Result<Self> {
         let cancelled = Arc::new(AtomicBool::new(false));
         let worker_cancelled = Arc::clone(&cancelled);
         let worker = std::thread::Builder::new()
-            .name("ctx-companion-mcp-request".to_owned())
+            .name("ctx-companion-mcp-pipe-write".to_owned())
             .spawn(move || {
                 let mut stdin = stdin;
                 let mut offset = 0;
@@ -169,10 +169,10 @@ impl RequestWriter {
                             "MCP request write cancelled",
                         ));
                     }
-                    if offset == request.len() {
+                    if offset == frame.len() {
                         break stdin.flush();
                     }
-                    match stdin.write(&request[offset..]) {
+                    match stdin.write(&frame[offset..]) {
                         Ok(0) => {
                             break Err(io::Error::new(
                                 io::ErrorKind::WriteZero,
@@ -232,7 +232,7 @@ impl RequestWriter {
 
 #[cfg(test)]
 mod tests {
-    use super::RequestWriter;
+    use super::PipeWriter;
     use std::{
         process::Stdio,
         thread,
@@ -247,7 +247,7 @@ mod tests {
             .spawn()
             .unwrap();
         let writer =
-            RequestWriter::spawn(child.stdin.take().unwrap(), vec![b'x'; 4 * 1024 * 1024]).unwrap();
+            PipeWriter::spawn(child.stdin.take().unwrap(), vec![b'x'; 4 * 1024 * 1024]).unwrap();
         thread::sleep(Duration::from_millis(25));
         let started = Instant::now();
         writer.cancel_and_join().unwrap();

--- a/crates/ctx-companion-bridge/src/protocol.rs
+++ b/crates/ctx-companion-bridge/src/protocol.rs
@@ -2,12 +2,15 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-pub const CORE_PRO_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::new(3);
-pub(crate) const PROTOCOL_ENTRYPOINT_ARGUMENT: &str = "--ctx-pro-protocol-v3";
+pub const CORE_COMPANION_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::new(4);
+pub const CORE_PRO_PROTOCOL_VERSION: ProtocolVersion = CORE_COMPANION_PROTOCOL_VERSION;
+pub(crate) const PROTOCOL_ENTRYPOINT_ARGUMENT: &str = "--ctx-pro-protocol-v4";
 pub(crate) const PROTOCOL_HANDSHAKE_COMMAND: &str = "handshake";
 pub(crate) const PROTOCOL_CLI_COMMAND: &str = "cli";
 pub(crate) const PROTOCOL_MCP_COMMAND: &str = "mcp-serve";
 pub(crate) const PROTOCOL_MAINTENANCE_COMMAND: &str = "maintenance";
+pub(crate) const MCP_WRITTEN_AND_FLUSHED_RECEIPT: &[u8] = b"written_and_flushed\n";
+pub(crate) const MCP_OUTPUT_FAILED_RECEIPT: &[u8] = b"output_failed\n";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ProtocolVersion(u16);

--- a/crates/ctx-companion-bridge/src/request.rs
+++ b/crates/ctx-companion-bridge/src/request.rs
@@ -79,6 +79,18 @@ impl McpRequest {
         &mut self.environment
     }
 
+    pub(crate) fn validate(&self, limits: LimitConfiguration) -> Result<(), BridgeError> {
+        if self.input.len() > limits.input_bytes {
+            return Err(BridgeError::Limit("input bytes"));
+        }
+        if self.input.last() != Some(&b'\n')
+            || self.input[..self.input.len().saturating_sub(1)].contains(&b'\n')
+        {
+            return Err(BridgeError::InvalidProtocolResponse("MCP request frame"));
+        }
+        Ok(())
+    }
+
     pub(crate) fn into_process(self) -> CapturedProcessRequest {
         CapturedProcessRequest {
             control: ProcessRequest {

--- a/crates/ctx-companion-bridge/src/tests.rs
+++ b/crates/ctx-companion-bridge/src/tests.rs
@@ -550,6 +550,7 @@ fn known_outcome_after_wall_deadline_writes_ack_before_teardown() {
     )
     .unwrap();
     let pid = response_pid(&response);
+    thread::sleep(Duration::from_millis(125));
     let started = Instant::now();
     response
         .finish(McpFinishOutcome::WrittenAndFlushed)

--- a/crates/ctx-companion-bridge/src/tests.rs
+++ b/crates/ctx-companion-bridge/src/tests.rs
@@ -55,11 +55,12 @@ impl Fixture {
             &pro,
             br##"#!/bin/sh
 printf '%s' "$0" > "${0}.launched"
-if [ "$1" = "--ctx-pro-protocol-v3" ] && [ "$2" = "handshake" ]; then
-  printf '{"protocol_version":3}\n'
+printf '%s\n' "$2" >> "${0}.commands"
+if [ "$1" = "--ctx-pro-protocol-v4" ] && [ "$2" = "handshake" ]; then
+  printf '{"protocol_version":4}\n'
   exit 0
 fi
-if [ "$1" != "--ctx-pro-protocol-v3" ]; then
+if [ "$1" != "--ctx-pro-protocol-v4" ]; then
   exit 90
 fi
 case "$2" in
@@ -104,23 +105,29 @@ fn launch_mcp_with(
 }
 
 #[test]
-fn protocol_v3_mcp_request_and_response_are_sufficient() {
-    let fixture =
-        Fixture::new(b"#!/bin/sh\nIFS= read -r value\nprintf 'compatible:%s' \"$value\"\n");
-    let output = CompanionBridge::default()
+fn protocol_v4_mcp_request_and_response_are_sufficient() {
+    let fixture = Fixture::new(
+        b"#!/usr/bin/python3\nimport os,sys\nrequest=sys.stdin.buffer.readline()\nos.write(1,b'compatible:'+request)\nreceipt=sys.stdin.buffer.readline()\nraise SystemExit(0 if receipt == b'written_and_flushed\\n' else 9)\n",
+    );
+    let response = CompanionBridge::default()
         .launch_mcp(
             &fixture.companion(),
             McpRequest::new(b"ok\n"),
             &CancellationToken::new(),
         )
         .unwrap();
-    assert_eq!(output.exit_class(), ExitClass::Success);
-    assert_eq!(output.stdout(), b"compatible:ok");
-    assert!(output.stderr().is_empty());
+    assert_eq!(response.response_frame(), b"compatible:ok\n");
+    response
+        .finish(McpFinishOutcome::WrittenAndFlushed)
+        .unwrap();
+    assert_eq!(
+        fs::read_to_string(fixture.pro.with_extension("commands")).unwrap(),
+        "mcp-serve\n"
+    );
 }
 
 #[test]
-fn protocol_v3_cli_request_is_typed_and_launches_directly() {
+fn protocol_v4_cli_request_is_typed_and_launches_directly() {
     let prior_endpoint = std::env::var_os("CTX_ANALYTICS_ENDPOINT");
     std::env::set_var(
         "CTX_ANALYTICS_ENDPOINT",
@@ -156,7 +163,7 @@ fn protocol_v3_cli_request_is_typed_and_launches_directly() {
 }
 
 #[test]
-fn protocol_v3_maintenance_response_is_closed_and_typed() {
+fn protocol_v4_maintenance_response_is_closed_and_typed() {
     let fixture = Fixture::new(
         b"#!/bin/sh\n/usr/bin/sleep 0.15\nprintf '{\"accepted\":true,\"schema_version\":1}\\n'\n",
     );
@@ -193,11 +200,7 @@ fn protocol_mismatch_is_typed_and_prevents_operation() {
         .as_bytes(),
     );
     let error = CompanionBridge::default()
-        .launch_mcp(
-            &InstalledCompanion::new(&pro),
-            McpRequest::new(Vec::new()),
-            &CancellationToken::new(),
-        )
+        .handshake(&InstalledCompanion::new(&pro), &CancellationToken::new())
         .unwrap_err();
     assert!(matches!(
         error,
@@ -218,11 +221,7 @@ fn pre_handshake_exit_is_a_launch_failure_with_bounded_stderr() {
         b"#!/bin/sh\nprintf 'loader diagnostic' >&2\nexit 70\n",
     );
     let error = CompanionBridge::default()
-        .launch_mcp(
-            &InstalledCompanion::new(&pro),
-            McpRequest::new(Vec::new()),
-            &CancellationToken::new(),
-        )
+        .handshake(&InstalledCompanion::new(&pro), &CancellationToken::new())
         .unwrap_err();
     assert!(matches!(
         error,
@@ -241,7 +240,7 @@ fn missing_pro_is_distinct_from_protocol_mismatch() {
     let error = CompanionBridge::default()
         .launch_mcp(
             &InstalledCompanion::new(&missing),
-            McpRequest::new(Vec::new()),
+            McpRequest::new(b"\n"),
             &CancellationToken::new(),
         )
         .unwrap_err();
@@ -254,17 +253,19 @@ fn missing_pro_is_distinct_from_protocol_mismatch() {
 #[test]
 fn launch_environment_contains_no_install_context_authority() {
     let fixture = Fixture::new(
-        b"#!/usr/bin/python3\nimport os\nforbidden=['CTX_PRO_PATH','CTX_PRO_INSTALL_CONTEXT','CTX_DATA_ROOT','CTX_PRO_DATA_ROOT','CTX_MANAGED_PAIR_CHANNEL','CTX_PRO_INSTALLATION_ID','CTX_MANAGED_PAIR_INVOCATION_FINGERPRINT','CTX_MANAGED_PAIR_CORE_CAPABILITY_FINGERPRINT','CTX_RELEASE_BUILD_SOURCE_COMMIT']\npresent=[name for name in forbidden if name in os.environ]\nos.write(1, '\\n'.join(present).encode())\n",
+        b"#!/usr/bin/python3\nimport os,sys\nsys.stdin.buffer.readline()\nforbidden=['CTX_PRO_PATH','CTX_PRO_INSTALL_CONTEXT','CTX_DATA_ROOT','CTX_PRO_DATA_ROOT','CTX_MANAGED_PAIR_CHANNEL','CTX_PRO_INSTALLATION_ID','CTX_MANAGED_PAIR_INVOCATION_FINGERPRINT','CTX_MANAGED_PAIR_CORE_CAPABILITY_FINGERPRINT','CTX_RELEASE_BUILD_SOURCE_COMMIT']\npresent=[name for name in forbidden if name in os.environ]\nos.write(1, ('ok' if not present else ','.join(present)).encode()+b'\\n')\nreceipt=sys.stdin.buffer.readline()\nraise SystemExit(0 if receipt == b'written_and_flushed\\n' else 9)\n",
     );
-    let output = CompanionBridge::default()
+    let response = CompanionBridge::default()
         .launch_mcp(
             &fixture.companion(),
-            McpRequest::new(Vec::new()),
+            McpRequest::new(b"request\n"),
             &CancellationToken::new(),
         )
         .unwrap();
-    assert_eq!(output.exit_class(), ExitClass::Success);
-    assert!(output.stdout().is_empty());
+    assert_eq!(response.response_frame(), b"ok\n");
+    response
+        .finish(McpFinishOutcome::WrittenAndFlushed)
+        .unwrap();
 }
 
 #[test]
@@ -273,7 +274,7 @@ fn relative_and_directory_pro_paths_have_typed_errors() {
     assert!(matches!(
         CompanionBridge::default().launch_mcp(
             &relative,
-            McpRequest::new(Vec::new()),
+            McpRequest::new(b"request\n"),
             &CancellationToken::new(),
         ),
         Err(BridgeError::InvalidExecutablePath)
@@ -284,7 +285,7 @@ fn relative_and_directory_pro_paths_have_typed_errors() {
     assert!(matches!(
         CompanionBridge::default().launch_mcp(
             &directory,
-            McpRequest::new(Vec::new()),
+            McpRequest::new(b"request\n"),
             &CancellationToken::new(),
         ),
         Err(BridgeError::ExecutableNotFile { .. })
@@ -294,9 +295,9 @@ fn relative_and_directory_pro_paths_have_typed_errors() {
 #[test]
 fn typed_environment_allowlist_is_preserved_and_ambient_is_cleared() {
     let fixture = Fixture::new(
-        b"#!/usr/bin/python3\nimport os\nnames=['PATH','LANG','HOME','TERM','COLORTERM','NO_COLOR','CLICOLOR','CLICOLOR_FORCE','CI','CTX_ANALYTICS_ENABLED']\nvalues=[os.getenv(name,'<missing>') for name in names]\nos.write(1, '\\0'.join(values).encode())\n",
+        b"#!/usr/bin/python3\nimport os,sys\nsys.stdin.buffer.readline()\nnames=['PATH','LANG','HOME','TERM','COLORTERM','NO_COLOR','CLICOLOR','CLICOLOR_FORCE','CI','CTX_ANALYTICS_ENABLED']\nvalues=[os.getenv(name,'<missing>') for name in names]\nos.write(1, '\\0'.join(values).encode()+b'\\n')\nreceipt=sys.stdin.buffer.readline()\nraise SystemExit(0 if receipt == b'written_and_flushed\\n' else 9)\n",
     );
-    let mut request = McpRequest::new(Vec::new());
+    let mut request = McpRequest::new(b"request\n");
     request
         .environment_mut()
         .set(EnvironmentKey::Home, OsStr::new("/home/tester"))
@@ -312,14 +313,15 @@ fn typed_environment_allowlist_is_preserved_and_ambient_is_cleared() {
         .set(EnvironmentKey::CliColorForce, OsStr::new("1"))
         .set(EnvironmentKey::Ci, OsStr::new("true"))
         .set(EnvironmentKey::AnalyticsEnabled, OsStr::new("false"));
-    let output = launch_mcp_with(
+    let response = launch_mcp_with(
         &fixture,
         request,
         LimitConfiguration::default(),
         &CancellationToken::new(),
     )
     .unwrap();
-    let fields: Vec<_> = output.stdout().split(|byte| *byte == 0).collect();
+    let frame = response.response_frame().strip_suffix(b"\n").unwrap();
+    let fields: Vec<_> = frame.split(|byte| *byte == 0).collect();
     assert_eq!(
         fields,
         [
@@ -335,25 +337,27 @@ fn typed_environment_allowlist_is_preserved_and_ambient_is_cleared() {
             b"false",
         ]
     );
+    response
+        .finish(McpFinishOutcome::WrittenAndFlushed)
+        .unwrap();
 }
 
 #[test]
-fn exit_class_and_binary_output_are_preserved() {
+fn output_failed_sends_the_exact_closed_receipt() {
     let fixture = Fixture::new(
-        b"#!/usr/bin/python3\nimport os\nos.write(1,b'out\\xff')\nos.write(2,b'err\\xfe')\nraise SystemExit(17)\n",
+        b"#!/usr/bin/python3\nimport os,pathlib,sys\nsys.stdin.buffer.readline()\nos.write(1,b'opaque\\n')\nreceipt=sys.stdin.buffer.readline()\npathlib.Path(sys.argv[0]).with_suffix('.receipt').write_bytes(receipt)\nraise SystemExit(0 if receipt == b'output_failed\\n' else 17)\n",
     );
-    let output = launch_mcp_with(
+    let receipt = fixture.pro.with_extension("receipt");
+    let response = launch_mcp_with(
         &fixture,
-        McpRequest::new(Vec::new()),
+        McpRequest::new(b"request\n"),
         LimitConfiguration::default(),
         &CancellationToken::new(),
     )
     .unwrap();
-    assert_eq!(output.exit_class(), ExitClass::Code(17));
-    assert_eq!(output.stdout(), b"out\xff");
-    assert_eq!(output.stderr(), b"err\xfe");
-    assert!(!output.stdout_truncated());
-    assert!(!output.stderr_truncated());
+    assert_eq!(response.response_frame(), b"opaque\n");
+    response.finish(McpFinishOutcome::OutputFailed).unwrap();
+    assert_eq!(fs::read(receipt).unwrap(), b"output_failed\n");
 }
 
 #[test]
@@ -377,7 +381,7 @@ fn control_input_and_output_bounds_fail_closed() {
         Err(BridgeError::Limit("input bytes"))
     ));
 
-    let mut oversized_control = McpRequest::new(Vec::new());
+    let mut oversized_control = McpRequest::new(b"\n");
     oversized_control
         .environment_mut()
         .set(EnvironmentKey::Home, "x".repeat(512));
@@ -391,7 +395,7 @@ fn control_input_and_output_bounds_fail_closed() {
         Err(BridgeError::Limit("control bytes"))
     ));
 
-    let mut invalid_environment_name = McpRequest::new(Vec::new());
+    let mut invalid_environment_name = McpRequest::new(b"\n");
     invalid_environment_name
         .environment_mut()
         .set_named("INVALID=NAME", "value");
@@ -405,19 +409,67 @@ fn control_input_and_output_bounds_fail_closed() {
         Err(BridgeError::InvalidEnvironmentName)
     ));
 
-    let output = launch_mcp_with(
+    let error = launch_mcp_with(
         &fixture,
-        McpRequest::new(Vec::new()),
+        McpRequest::new(b"ok\n"),
         small,
         &CancellationToken::new(),
     )
-    .unwrap();
-    assert_eq!(
-        output.exit_class(),
-        ExitClass::Terminated(TerminationReason::StdoutLimit)
+    .unwrap_err();
+    assert!(matches!(error, BridgeError::Limit("stdout bytes")));
+
+    assert!(matches!(
+        launch_mcp_with(
+            &fixture,
+            McpRequest::new(b"bad"),
+            small,
+            &CancellationToken::new(),
+        ),
+        Err(BridgeError::InvalidProtocolResponse("MCP request frame"))
+    ));
+}
+
+#[test]
+fn missing_extra_and_stderr_output_fail_closed() {
+    let eof = Fixture::new(b"#!/bin/sh\nIFS= read -r _\nexit 0\n");
+    assert!(matches!(
+        launch_mcp_with(
+            &eof,
+            McpRequest::new(b"request\n"),
+            LimitConfiguration::default(),
+            &CancellationToken::new(),
+        ),
+        Err(BridgeError::InvalidProtocolResponse("MCP response frame"))
+            | Err(BridgeError::McpExchangeFailed {
+                exit: ExitClass::Success
+            })
+    ));
+
+    let extra = Fixture::new(
+        b"#!/usr/bin/python3\nimport os,sys\nsys.stdin.buffer.readline()\nos.write(1,b'first\\nsecond\\n')\nsys.stdin.buffer.readline()\n",
     );
-    assert_eq!(output.stdout(), vec![b'x'; 32]);
-    assert!(output.stdout_truncated());
+    assert!(matches!(
+        launch_mcp_with(
+            &extra,
+            McpRequest::new(b"request\n"),
+            LimitConfiguration::default(),
+            &CancellationToken::new(),
+        ),
+        Err(BridgeError::InvalidProtocolResponse("MCP response frame"))
+    ));
+
+    let stderr = Fixture::new(
+        b"#!/bin/sh\nIFS= read -r _\nprintf diagnostic >&2\nprintf 'response\\n'\nIFS= read -r _\n",
+    );
+    assert!(matches!(
+        launch_mcp_with(
+            &stderr,
+            McpRequest::new(b"request\n"),
+            LimitConfiguration::default(),
+            &CancellationToken::new(),
+        ),
+        Err(BridgeError::InvalidProtocolResponse("MCP stderr"))
+    ));
 }
 
 #[test]
@@ -482,43 +534,42 @@ fn streaming_child_lifetime_is_independent_of_captured_wall_time() {
 
 #[cfg(target_os = "linux")]
 #[test]
-fn timeout_terminates_the_descendant_process_group() {
-    let fixture = Fixture::new(b"#!/bin/sh\n/usr/bin/sleep 60 &\nprintf '%s\\n' \"$!\"\nwait\n");
-    let output = launch_mcp_with(
+fn known_outcome_after_wall_deadline_writes_ack_before_teardown() {
+    let fixture = Fixture::new(
+        b"#!/bin/sh\nIFS= read -r _\n/usr/bin/sleep 60 &\nprintf '%s\\n' \"$!\"\nIFS= read -r receipt\nprintf '%s\\n' \"$receipt\" > \"${0}.receipt\"\n/usr/bin/sleep 0.15\nexit 0\n",
+    );
+    let receipt = fixture.pro.with_extension("operation.receipt");
+    let response = launch_mcp_with(
         &fixture,
-        McpRequest::new(Vec::new()),
+        McpRequest::new(b"request\n"),
         LimitConfiguration {
-            captured_wall_time: Duration::from_millis(150),
+            captured_wall_time: Duration::from_millis(100),
             ..LimitConfiguration::default()
         },
         &CancellationToken::new(),
     )
     .unwrap();
-    assert_eq!(
-        output.exit_class(),
-        ExitClass::Terminated(TerminationReason::WallTime)
-    );
-    let pid = String::from_utf8(output.stdout().to_vec())
-        .unwrap()
-        .trim()
-        .parse()
+    let pid = response_pid(&response);
+    let started = Instant::now();
+    response
+        .finish(McpFinishOutcome::WrittenAndFlushed)
         .unwrap();
+    assert!(started.elapsed() >= Duration::from_millis(100));
+    assert_eq!(fs::read(receipt).unwrap(), b"written_and_flushed\n");
     assert_process_stopped(pid);
 }
 
 #[cfg(target_os = "linux")]
 #[test]
-fn cancellation_terminates_the_descendant_process_group() {
-    let fixture = Fixture::new(b"#!/bin/sh\n/usr/bin/sleep 60 &\nprintf '%s\\n' \"$!\"\nwait\n");
+fn queued_outcome_wins_over_cancellation_and_writes_nack() {
+    let fixture = Fixture::new(
+        b"#!/bin/sh\nIFS= read -r _\n/usr/bin/sleep 60 &\nprintf '%s\\n' \"$!\"\nIFS= read -r receipt\nprintf '%s\\n' \"$receipt\" > \"${0}.receipt\"\nexit 0\n",
+    );
+    let receipt = fixture.pro.with_extension("operation.receipt");
     let cancellation = CancellationToken::new();
-    let trigger = cancellation.clone();
-    let canceller = thread::spawn(move || {
-        thread::sleep(Duration::from_millis(100));
-        trigger.cancel();
-    });
-    let output = launch_mcp_with(
+    let response = launch_mcp_with(
         &fixture,
-        McpRequest::new(Vec::new()),
+        McpRequest::new(b"request\n"),
         LimitConfiguration {
             captured_wall_time: Duration::from_secs(2),
             ..LimitConfiguration::default()
@@ -526,17 +577,102 @@ fn cancellation_terminates_the_descendant_process_group() {
         &cancellation,
     )
     .unwrap();
-    canceller.join().unwrap();
-    assert_eq!(
-        output.exit_class(),
-        ExitClass::Terminated(TerminationReason::Cancelled)
+    let pid = response_pid(&response);
+    cancellation.cancel();
+    response.finish(McpFinishOutcome::OutputFailed).unwrap();
+    assert_eq!(fs::read(receipt).unwrap(), b"output_failed\n");
+    assert_process_stopped(pid);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn dropping_pending_response_is_unknown_and_sends_no_terminal_receipt() {
+    let fixture = Fixture::new(
+        b"#!/bin/sh\nIFS= read -r _\n/usr/bin/sleep 60 &\nprintf '%s\\n' \"$!\"\nif IFS= read -r receipt; then printf '%s\\n' \"$receipt\" > \"${0}.receipt\"; fi\nwait\n",
     );
-    let pid = String::from_utf8(output.stdout().to_vec())
+    let response = launch_mcp_with(
+        &fixture,
+        McpRequest::new(b"request\n"),
+        LimitConfiguration::default(),
+        &CancellationToken::new(),
+    )
+    .unwrap();
+    let operation = fixture.pro.with_extension("operation");
+    let pid = response_pid(&response);
+    let started = Instant::now();
+    drop(response);
+    assert!(started.elapsed() < Duration::from_secs(1));
+    assert!(!PathBuf::from(format!("{}.receipt", operation.display())).exists());
+    assert_process_stopped(pid);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn dropping_with_an_escaped_pipe_descendant_is_bounded_and_releases_the_permit() {
+    let fixture = Fixture::new(
+        b"#!/usr/bin/python3\nimport os,pathlib,subprocess,sys\nsys.stdin.buffer.readline()\nchild=subprocess.Popen(['/usr/bin/sleep','60'],start_new_session=True)\nos.write(1,f'{child.pid}\\n'.encode())\nreceipt=sys.stdin.buffer.readline()\npathlib.Path(sys.argv[0]).with_suffix('.receipt').write_bytes(receipt)\n",
+    );
+    let bridge = CompanionBridge::new(
+        BridgeLimits::new(LimitConfiguration {
+            concurrent_processes: 1,
+            admission_wait: Duration::from_millis(100),
+            ..LimitConfiguration::default()
+        })
+        .unwrap(),
+    );
+    let response = bridge
+        .launch_mcp(
+            &fixture.companion(),
+            McpRequest::new(b"request\n"),
+            &CancellationToken::new(),
+        )
+        .unwrap();
+    let escaped_pid = response_pid(&response);
+    let receipt = fixture.pro.with_extension("receipt");
+    let started = Instant::now();
+    drop(response);
+    assert!(started.elapsed() < Duration::from_secs(1));
+
+    let permit = bridge
+        .gate
+        .acquire(&CancellationToken::new(), Duration::from_millis(100))
+        .unwrap();
+    drop(permit);
+
+    assert!(!receipt.exists());
+    unsafe {
+        libc::kill(escaped_pid as libc::pid_t, libc::SIGKILL);
+    }
+    assert_process_stopped(escaped_pid);
+}
+
+#[test]
+fn receipt_write_failure_is_typed_and_still_reaps_the_child() {
+    let fixture = Fixture::new(
+        b"#!/usr/bin/python3\nimport os,sys,time\nsys.stdin.buffer.readline()\nos.write(1,b'response\\n')\nos.close(0)\ntime.sleep(60)\n",
+    );
+    let response = launch_mcp_with(
+        &fixture,
+        McpRequest::new(b"request\n"),
+        LimitConfiguration::default(),
+        &CancellationToken::new(),
+    )
+    .unwrap();
+    let started = Instant::now();
+    let error = response
+        .finish(McpFinishOutcome::WrittenAndFlushed)
+        .unwrap_err();
+    assert!(matches!(error, BridgeError::Transport(_)));
+    assert!(started.elapsed() < Duration::from_secs(1));
+}
+
+#[cfg(target_os = "linux")]
+fn response_pid(response: &McpResponse) -> u32 {
+    String::from_utf8(response.response_frame().to_vec())
         .unwrap()
         .trim()
         .parse()
-        .unwrap();
-    assert_process_stopped(pid);
+        .unwrap()
 }
 
 #[cfg(target_os = "linux")]
@@ -555,7 +691,7 @@ fn assert_process_stopped(pid: u32) {
 
 #[test]
 fn admission_queue_wait_remains_bounded() {
-    let gate = ConcurrencyGate::new(1);
+    let gate = Arc::new(ConcurrencyGate::new(1));
     let cancellation = CancellationToken::new();
     let _permit = gate.acquire(&cancellation, Duration::from_secs(1)).unwrap();
     let started = Instant::now();
@@ -571,7 +707,7 @@ fn admission_queue_wait_remains_bounded() {
 #[test]
 fn configured_concurrency_is_a_real_gate() {
     let fixture = Arc::new(Fixture::new(
-        b"#!/bin/sh\n/usr/bin/sleep 0.2\nprintf done\n",
+        b"#!/bin/sh\nIFS= read -r _\n/usr/bin/sleep 0.2\nprintf 'done\\n'\nIFS= read -r receipt\n[ \"$receipt\" = written_and_flushed ]\n",
     ));
     let bridge = Arc::new(CompanionBridge::new(
         BridgeLimits::new(LimitConfiguration {
@@ -587,17 +723,22 @@ fn configured_concurrency_is_a_real_gate() {
         let fixture = Arc::clone(&fixture);
         let bridge = Arc::clone(&bridge);
         workers.push(thread::spawn(move || {
-            bridge
+            let response = bridge
                 .launch_mcp(
                     &fixture.companion(),
-                    McpRequest::new(Vec::new()),
+                    McpRequest::new(b"request\n"),
                     &CancellationToken::new(),
                 )
-                .unwrap()
+                .unwrap();
+            let frame = response.response_frame().to_vec();
+            response
+                .finish(McpFinishOutcome::WrittenAndFlushed)
+                .unwrap();
+            frame
         }));
     }
     for worker in workers {
-        assert_eq!(worker.join().unwrap().stdout(), b"done");
+        assert_eq!(worker.join().unwrap(), b"done\n");
     }
     assert!(started.elapsed() >= Duration::from_millis(350));
 }

--- a/crates/ctx-companion-bridge/src/tests_windows.rs
+++ b/crates/ctx-companion-bridge/src/tests_windows.rs
@@ -1,0 +1,183 @@
+#![cfg(windows)]
+
+use std::{
+    fs,
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use super::*;
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    pro: PathBuf,
+}
+
+impl Fixture {
+    fn new(operation: &str) -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let pro = temp.path().join("ctx-pro.cmd");
+        fs::write(
+            &pro,
+            format!(
+                "@echo off\r\nif not \"%~1\"==\"--ctx-pro-protocol-v4\" exit /b 90\r\nif not \"%~2\"==\"mcp-serve\" exit /b 91\r\n{operation}\r\n"
+            ),
+        )
+        .unwrap();
+        Self { _temp: temp, pro }
+    }
+
+    fn companion(&self) -> InstalledCompanion {
+        InstalledCompanion::new(&self.pro)
+    }
+
+    fn receipt(&self) -> PathBuf {
+        PathBuf::from(format!("{}.receipt", self.pro.display()))
+    }
+}
+
+fn launch(fixture: &Fixture) -> Result<McpResponse, BridgeError> {
+    launch_request(fixture, b"request\n".to_vec())
+}
+
+fn launch_request(fixture: &Fixture, request: Vec<u8>) -> Result<McpResponse, BridgeError> {
+    launch_request_with(fixture, request, LimitConfiguration::default())
+}
+
+fn launch_request_with(
+    fixture: &Fixture,
+    request: Vec<u8>,
+    limits: LimitConfiguration,
+) -> Result<McpResponse, BridgeError> {
+    CompanionBridge::new(BridgeLimits::new(limits).unwrap()).launch_mcp(
+        &fixture.companion(),
+        McpRequest::new(request),
+        &CancellationToken::new(),
+    )
+}
+
+#[test]
+fn windows_known_outcome_wins_over_the_generic_deadline() {
+    let fixture = Fixture::new(
+        "set /p request=\r\necho response:%request%\r\nset /p receipt=\r\n>\"%~f0.receipt\" echo %receipt%\r\nif \"%receipt%\"==\"written_and_flushed\" exit /b 0\r\nexit /b 9",
+    );
+    let response = launch_request_with(
+        &fixture,
+        b"request\n".to_vec(),
+        LimitConfiguration {
+            captured_wall_time: Duration::from_millis(100),
+            ..LimitConfiguration::default()
+        },
+    )
+    .unwrap();
+    std::thread::sleep(Duration::from_millis(125));
+    response
+        .finish(McpFinishOutcome::WrittenAndFlushed)
+        .unwrap();
+    assert_eq!(
+        fs::read_to_string(fixture.receipt()).unwrap().trim(),
+        "written_and_flushed"
+    );
+}
+
+#[test]
+fn windows_mcp_ack_and_nack_reach_one_child_and_reap_it() {
+    for (outcome, expected) in [
+        (McpFinishOutcome::WrittenAndFlushed, "written_and_flushed"),
+        (McpFinishOutcome::OutputFailed, "output_failed"),
+    ] {
+        let fixture = Fixture::new(
+            "set /p request=\r\necho response:%request%\r\nset /p receipt=\r\n>\"%~f0.receipt\" echo %receipt%\r\nif \"%receipt%\"==\"written_and_flushed\" exit /b 0\r\nif \"%receipt%\"==\"output_failed\" exit /b 0\r\nexit /b 9",
+        );
+        let response = launch(&fixture).unwrap();
+        assert_eq!(response.response_frame(), b"response:request\r\n");
+        response.finish(outcome).unwrap();
+        assert_eq!(
+            fs::read_to_string(fixture.receipt()).unwrap().trim(),
+            expected
+        );
+    }
+}
+
+#[test]
+fn windows_unknown_drop_with_inherited_pipes_is_bounded_and_releases_the_permit() {
+    let fixture = Arc::new(Fixture::new(
+        "set /p request=\r\nstart \"\" /b \"%ComSpec%\" /d /c \"timeout /t 60 /nobreak ^>nul\"\r\necho response:%request%\r\nset /p receipt=\r\n>\"%~f0.receipt\" echo %receipt%",
+    ));
+    let bridge = CompanionBridge::new(
+        BridgeLimits::new(LimitConfiguration {
+            concurrent_processes: 1,
+            admission_wait: Duration::from_millis(250),
+            ..LimitConfiguration::default()
+        })
+        .unwrap(),
+    );
+    let response = bridge
+        .launch_mcp(
+            &fixture.companion(),
+            McpRequest::new(b"request\n"),
+            &CancellationToken::new(),
+        )
+        .unwrap();
+    let started = Instant::now();
+    drop(response);
+    assert!(started.elapsed() < Duration::from_secs(2));
+    assert!(!fixture.receipt().exists());
+
+    let permit = bridge
+        .gate
+        .acquire(&CancellationToken::new(), Duration::from_millis(250))
+        .unwrap();
+    drop(permit);
+}
+
+#[test]
+fn windows_mcp_child_crash_is_bounded() {
+    let fixture = Fixture::new("set /p request=\r\nexit /b 23");
+    let started = Instant::now();
+    let error = launch(&fixture).unwrap_err();
+    assert!(matches!(
+        error,
+        BridgeError::McpExchangeFailed {
+            exit: ExitClass::Code(23)
+        } | BridgeError::InvalidProtocolResponse("MCP response frame")
+    ));
+    assert!(started.elapsed() < Duration::from_secs(2));
+}
+
+#[test]
+fn windows_malformed_response_is_rejected_and_reaped() {
+    let fixture = Fixture::new(
+        "set /p request=\r\necho response-one\r\necho response-two\r\nset /p receipt=",
+    );
+    let started = Instant::now();
+    let error = launch(&fixture).unwrap_err();
+    assert!(matches!(
+        error,
+        BridgeError::InvalidProtocolResponse("MCP response frame")
+    ));
+    assert!(started.elapsed() < Duration::from_secs(2));
+}
+
+#[test]
+fn windows_blocked_receipt_reaches_one_deadline_and_joins_the_writer() {
+    // The child reads exactly enough of a 64 KiB request for the remaining
+    // 4 KiB to occupy the anonymous pipe, then returns its response without
+    // consuming those bytes. The receipt write must therefore be cancelled
+    // through the same owned PipeWriter mechanism at the test deadline.
+    let fixture = Fixture::new(
+        r#"powershell.exe -NoLogo -NoProfile -NonInteractive -Command "$inputStream=[Console]::OpenStandardInput();$buffer=New-Object byte[] 61440;$offset=0;while($offset -lt $buffer.Length){$read=$inputStream.Read($buffer,$offset,$buffer.Length-$offset);if($read -eq 0){exit 81};$offset += $read};[Console]::Out.WriteLine('response');[Console]::Out.Flush();Start-Sleep -Seconds 60""#,
+    );
+    let mut request = vec![b'x'; 64 * 1024];
+    *request.last_mut().unwrap() = b'\n';
+    let response = launch_request(&fixture, request).unwrap();
+    assert_eq!(response.response_frame(), b"response\n");
+    let started = Instant::now();
+    let error = response
+        .finish(McpFinishOutcome::WrittenAndFlushed)
+        .unwrap_err();
+    assert!(matches!(error, BridgeError::Transport(_)));
+    assert!(started.elapsed() >= Duration::from_millis(400));
+    assert!(started.elapsed() < Duration::from_secs(2));
+}


### PR DESCRIPTION
Summary

- keep the neutral companion bridge alive through the actual MCP response write and flush
- return one bounded written-and-flushed or output-failed receipt before centralized teardown
- cover deadline races, crashes, malformed responses, inherited pipe holders, and Windows cancellation

Validation

- `scripts/bazelw test //crates/ctx-companion-bridge:unit_tests //crates/ctx-agent-application:unit_tests --config=ci`
- `cargo check -p ctx-companion-bridge --tests --target x86_64-pc-windows-gnu` through the build governor
- repository policy and public disclosure guard
- two independent lifecycle/simplicity reviews