### PR TITLE
test(index): assert append work against live topology

### DIFF
--- a/crates/ctx-history-index/src/tests/writer/complexity_contract.rs
+++ b/crates/ctx-history-index/src/tests/writer/complexity_contract.rs
@@ -276,7 +276,7 @@ fn exact_noop_work_is_zero_for_n_and_2n_retained_documents() {
 }
 
 #[test]
-fn one_record_append_verification_work_is_independent_of_retained_corpus_size() {
+fn one_record_append_verification_work_tracks_live_segment_topology() {
     let (n, n_base_segments) = measure_one_record_append(RETAINED_N);
     let (two_n, two_n_base_segments) = measure_one_record_append(RETAINED_2N);
 
@@ -294,16 +294,25 @@ fn one_record_append_verification_work_is_independent_of_retained_corpus_size() 
     assert_eq!(n.lineage_spills, 0);
     assert_eq!(n.complete_session_id_traversals, 0);
     assert_eq!(n.writer_constructions, 1);
-    assert_eq!(
-        n.authority_lookup.segment_range_probes, n_base_segments,
-        "the append must probe each live base segment exactly once"
-    );
-    assert_eq!(
-        two_n.authority_lookup.segment_range_probes, two_n_base_segments,
-        "the append must probe each live base segment exactly once"
-    );
-    assert!(n.authority_lookup.segment_range_probes <= MAX_SESSION_WITNESS_SEGMENT_PROBES);
-    assert_eq!(n.authority_lookup.dictionary_terms, 1);
+    for (lookup, base_segments) in [
+        (n.authority_lookup, n_base_segments),
+        (two_n.authority_lookup, two_n_base_segments),
+    ] {
+        assert_eq!(
+            lookup.segment_range_probes, base_segments,
+            "the append must probe each live base segment exactly once"
+        );
+        assert!(lookup.segment_range_probes <= MAX_SESSION_WITNESS_SEGMENT_PROBES);
+        assert_eq!(
+            (
+                lookup.dictionary_terms,
+                lookup.postings,
+                lookup.core_decodes
+            ),
+            (1, 1, 1),
+            "retained corpus size must not increase sparse witness work"
+        );
+    }
     assert_eq!(two_n.identity_terms, n.identity_terms);
     assert_eq!(two_n.identity_documents, n.identity_documents);
     assert_eq!(two_n.projection_documents, n.projection_documents);
@@ -314,7 +323,6 @@ fn one_record_append_verification_work_is_independent_of_retained_corpus_size() 
         n.complete_session_id_traversals
     );
     assert_eq!(two_n.writer_constructions, n.writer_constructions);
-    assert_eq!(two_n.authority_lookup, n.authority_lookup);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- assert authority-range probe work against each independent fixture actual live segment count
- keep sparse dictionary-term, posting, and Core-decode work exact and corpus-size independent
- retain the deterministic eight-segment, 65-segment, and 512/513 cap coverage added around #724

## Root cause

Successful session-authority lookup probes every live base segment exactly once. The default writer can finalize independent 32- and 64-document fixtures with different valid physical segment counts (observed 7 and 8) depending on worker flush scheduling. Whole-struct equality therefore froze an incidental assumption that both fixtures had identical topology.

The post-#724 suite exposed this pre-existing brittle assertion. #724 raised the admitted segment cap and added dedicated topology coverage; it did not change the successful lookup path.

## Validation

- exact-main pre-fix implicated test: 20/20 isolated passes
- exact-main pre-fix history-index unit target: 10/10 passes
- repaired semantic test: 20/20 passes
- deterministic eight-segment test: 20/20 passes
- 65-segment real lookup path: 5/5 passes
- affected CI: 15/15 targets passed
- uncached full current CI: 213/214 targets passed; the sole failure is the separately owned native-provider oversize-refresh expectation, outside this diff
- independent topology and final correctness review: no findings

Performance impact: none in production; this changes one test assertion only.