### PR TITLE
fix(history): preserve partial status and rejection diagnostics

### DIFF
--- a/crates/ctx-cli-contract-tests/tests/contracts/native_provider_rejections.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/native_provider_rejections.rs
@@ -615,6 +615,42 @@ fn codex_mixed_session_replay_preserves_source_backed_rejection_counts() {
         }
     }
 
+    fs::write(
+        &session,
+        concat!(
+            r#"{"timestamp":"2026-07-13T12:00:00.000Z","type":"session_meta","payload":{"id":"codex-mixed-replay","timestamp":"2026-07-13T12:00:00.000Z","cwd":"/repo","originator":"codex-cli","cli_version":"0.200.0","source":"cli","model_provider":"openai"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-07-13T12:00:03.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":{"different_failed_attempt":"#,
+            "\n",
+        ),
+    )
+    .unwrap();
+    let carried = json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "codex",
+        "--path",
+        path,
+        "--format=json",
+        "--progress",
+        "none",
+    ]));
+    assert_eq!(
+        carried["outcome"], "completed_with_rejections_and_source_failures",
+        "{carried:#}"
+    );
+    let carried_source = &carried["sources"][0];
+    assert_eq!(carried_source["status"], "partial", "{carried:#}");
+    assert_eq!(carried_source["carried_forward"], true, "{carried:#}");
+    assert_eq!(carried_source["current_rejected_records"], 1, "{carried:#}");
+    assert_eq!(carried_source["rejected_record_total"], 1, "{carried:#}");
+    assert!(
+        carried_source["rejection_diagnostics"]
+            .as_array()
+            .is_some_and(Vec::is_empty),
+        "failed-attempt rejection must not borrow carried certificate capacity: {carried:#}"
+    );
+
     let search = json_output(ctx(&temp).args([
         "search",
         "codex mixed replay oracle",

--- a/crates/ctx-cli-contract-tests/tests/contracts/native_provider_rejections.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/native_provider_rejections.rs
@@ -644,11 +644,20 @@ fn codex_mixed_session_replay_preserves_source_backed_rejection_counts() {
     assert_eq!(carried_source["carried_forward"], true, "{carried:#}");
     assert_eq!(carried_source["current_rejected_records"], 1, "{carried:#}");
     assert_eq!(carried_source["rejected_record_total"], 1, "{carried:#}");
+    let carried_diagnostics = carried_source["rejection_diagnostics"]
+        .as_array()
+        .unwrap_or_else(|| panic!("missing carried rejection diagnostics in {carried:#}"));
+    assert_eq!(carried_diagnostics.len(), 1, "{carried:#}");
+    assert_eq!(carried_diagnostics[0]["line"], 3, "{carried:#}");
+    assert_eq!(
+        carried_diagnostics[0]["class"], "malformed_record",
+        "{carried:#}"
+    );
     assert!(
-        carried_source["rejection_diagnostics"]
-            .as_array()
-            .is_some_and(Vec::is_empty),
-        "failed-attempt rejection must not borrow carried certificate capacity: {carried:#}"
+        carried_diagnostics[0]["detail"]
+            .as_str()
+            .is_some_and(|detail| !detail.is_empty()),
+        "the carried diagnostic must remain committed while the new failed-attempt rejection is suppressed: {carried:#}"
     );
 
     let search = json_output(ctx(&temp).args([

--- a/crates/ctx-cli-contract-tests/tests/contracts/native_providers.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/native_providers.rs
@@ -149,6 +149,24 @@ fn qwen_kimi_mistral_mux_and_qoder_default_sources_import_search_and_reimport() 
             second["totals"]["current_rejected_records"], 1,
             "{second:#}"
         );
+        if stored_provider == "qwen_code" {
+            let diagnostic = second["sources"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|source| source["status"] == "rejection")
+                .unwrap_or_else(|| {
+                    panic!("missing replayed Qwen rejection diagnostic in {second:#}")
+                });
+            assert_eq!(diagnostic["provider"], "qwen_code", "{second:#}");
+            assert_eq!(diagnostic["line"], 3, "{second:#}");
+            assert!(
+                diagnostic["detail"]
+                    .as_str()
+                    .is_some_and(|detail| detail.contains("invalid shape")),
+                "{second:#}"
+            );
+        }
     }
 }
 

--- a/crates/ctx-cli/src/commands/status.rs
+++ b/crates/ctx-cli/src/commands/status.rs
@@ -188,6 +188,7 @@ mod tests {
                     "receipt": receipt.to_json(),
                     "route_observations": [null],
                     "route_controls": {},
+                    "committed_rejection_diagnostics": {},
                 }))
                 .map_err(|error| {
                     ctx_history_index::IndexError::PublicationMetadata(error.to_string())

--- a/crates/ctx-daemon-cli/src/source_status_tests.rs
+++ b/crates/ctx-daemon-cli/src/source_status_tests.rs
@@ -61,6 +61,7 @@ fn core_publication_fixture() -> (tempfile::TempDir, std::path::PathBuf, String)
                 "receipt": receipt.to_json(),
                 "route_observations": [null],
                 "route_controls": {},
+                "committed_rejection_diagnostics": {},
             }))
             .map_err(|error| ctx_history_index::IndexError::PublicationMetadata(error.to_string()))
         },
@@ -586,7 +587,9 @@ fn legacy_zero_source_publication_is_not_projected_as_ready() {
         .as_object_mut()
         .unwrap()
         .remove("zero_source_authority");
-    metadata.as_object_mut().unwrap().remove("route_controls");
+    let metadata_fields = metadata.as_object_mut().unwrap();
+    metadata_fields.remove("route_controls");
+    metadata_fields.remove("committed_rejection_diagnostics");
     drop(current);
     let writer = GenerationWriter::open(&index_root, WriterOptions::default())
         .unwrap()

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator.rs
@@ -177,6 +177,7 @@ pub(crate) fn publish_authoritative_empty_generation_with_route_results_for_test
                     "receipt": receipt.to_json(),
                     "route_observations": vec![Value::Null; metadata_authority_routes.len()],
                     "route_controls": {},
+                    "committed_rejection_diagnostics": {},
                 }))
                 .map_err(|error| IndexError::PublicationMetadata(error.to_string()))
             },

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/projection_behaviors.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/projection_behaviors.rs
@@ -53,6 +53,126 @@ fn codex_valid_custom_tool_result_over_16_mib_is_retained() {
 }
 
 #[test]
+fn codex_core_envelope_rejection_preserves_siblings_and_their_ids() {
+    let temp = tempdir().unwrap();
+    let sessions = temp.path().join("sessions-core-envelope-rejection");
+    let index_root = temp.path().join("index-core-envelope-rejection");
+    fs::create_dir_all(&sessions).unwrap();
+    let native_session_id = "019fb000-0000-7000-8000-000000000075";
+    let path = session_path(&sessions, native_session_id);
+    let before_marker = "core-envelope-before";
+    let after_marker = "core-envelope-after";
+    let oversized_body = "x".repeat(ctx_history_core::MAX_CORE_CONTENT_BYTES);
+    let repeated_native_id = "core-envelope-repeated-native-id";
+    let mut before = message(before_marker);
+    before["payload"]["id"] = serde_json::json!(repeated_native_id);
+    let mut oversized = message(&oversized_body);
+    oversized["payload"]["id"] = serde_json::json!(repeated_native_id);
+    let mut after = message(after_marker);
+    after["payload"]["id"] = serde_json::json!(repeated_native_id);
+    fs::write(
+        &path,
+        jsonl_bytes([
+            session_meta(
+                native_session_id,
+                ProviderNativeSessionRelationship::Root,
+                None,
+            ),
+            before.clone(),
+            oversized,
+            after.clone(),
+        ]),
+    )
+    .unwrap();
+    let registry = register_tree(&[&sessions]);
+
+    let rejected =
+        refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
+
+    assert!(rejected.failed_routes.is_empty());
+    assert!(rejected.logical_source_failures.is_empty());
+    assert_eq!(rejected.record_rejections.total(), 1);
+    let counts = rejected.sources[0].counts();
+    assert_eq!(counts.complete_records, 4);
+    assert_eq!(counts.retained_records, 2);
+    assert_eq!(counts.rejected_records, 1);
+    assert_eq!(counts.ignored_records, 1);
+    let [diagnostic] = rejected.record_rejections.rejections() else {
+        panic!("one bounded Codex rejection diagnostic expected");
+    };
+    assert_eq!(diagnostic.provider, CaptureProvider::Codex);
+    assert_eq!(diagnostic.source_selector, path.display().to_string());
+    assert_eq!(diagnostic.line_number, 3);
+    assert_eq!(
+        diagnostic.class,
+        ctx_history_capture_runtime::SourceBackedRecordRejectionClass::UnsupportedRecord
+    );
+    assert_eq!(
+        diagnostic.detail,
+        "Codex retained record exceeds the Core selected-content envelope"
+    );
+    let rejected_index = VerifiedIndex::open(&index_root).unwrap();
+    let sibling_ids = [before_marker, after_marker].map(|marker| {
+        rejected_index
+            .search_event_candidates(marker, 8)
+            .unwrap()
+            .into_iter()
+            .find(|candidate| {
+                candidate.event.provider_session_id.as_deref() == Some(native_session_id)
+            })
+            .unwrap_or_else(|| panic!("missing retained sibling {marker}"))
+            .event
+            .event_id
+    });
+    drop(rejected_index);
+
+    fs::write(
+        &path,
+        jsonl_bytes([
+            session_meta(
+                native_session_id,
+                ProviderNativeSessionRelationship::Root,
+                None,
+            ),
+            before,
+            after,
+        ]),
+    )
+    .unwrap();
+    let (repaired, _) = incremental_refresh(&index_root, &registry, &rejected);
+    assert!(repaired.failed_routes.is_empty());
+    assert!(repaired.logical_source_failures.is_empty());
+    assert!(repaired.record_rejections.is_empty());
+    let repaired_index = VerifiedIndex::open(&index_root).unwrap();
+    for (marker, event_id) in [before_marker, after_marker]
+        .into_iter()
+        .zip(sibling_ids.iter().copied())
+    {
+        assert!(repaired_index
+            .search_event_candidates(marker, 8)
+            .unwrap()
+            .into_iter()
+            .any(|candidate| candidate.event.event_id == event_id));
+    }
+    drop(repaired_index);
+
+    let (replayed, _) = incremental_refresh(&index_root, &registry, &repaired);
+    assert_eq!(replayed.commit.generation_id, repaired.commit.generation_id);
+    assert!(replayed.record_rejections.is_empty());
+    let replayed_index = VerifiedIndex::open(&index_root).unwrap();
+    for (marker, event_id) in [before_marker, after_marker]
+        .into_iter()
+        .zip(sibling_ids.iter().copied())
+    {
+        assert!(replayed_index
+            .search_event_candidates(marker, 8)
+            .unwrap()
+            .into_iter()
+            .any(|candidate| candidate.event.event_id == event_id));
+    }
+}
+
+#[test]
 fn inherited_codex_session_metadata_is_admitted_in_both_provider_orders() {
     let temp = tempdir().unwrap();
     let sessions = temp.path().join("sessions-inherited-metadata-orders");

--- a/crates/ctx-history-capture-runtime/src/source_backed/diagnostics.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/diagnostics.rs
@@ -127,12 +127,18 @@ pub struct SourceBackedRecordRejection {
     pub payload_type: Option<String>,
     pub class: SourceBackedRecordRejectionClass,
     pub detail: String,
+    /// Whether this diagnostic belongs to a logical source certified by the
+    /// current attempt. Failed-attempt diagnostics remain available for
+    /// completion classification, but must not be published as committed
+    /// rejection evidence.
+    pub(crate) committed: bool,
 }
 
-/// Bounded record-level diagnostics from routes that still certified and
-/// published their valid records. Entries are kept in canonical route/scan
-/// order. `omitted` counts additional committed-route rejections beyond the
-/// diagnostic bound; diagnostics staged by a rolled-back route are removed.
+/// Bounded record-level diagnostics observed during the refresh attempt.
+/// Entries are kept in canonical route/scan order. `omitted` counts additional
+/// observations beyond the diagnostic bound; diagnostics staged by a
+/// rolled-back route are removed. Publication selects only entries whose
+/// logical source was certified by the current attempt.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct SourceBackedRecordRejections {
     rejections: Vec<SourceBackedRecordRejection>,
@@ -175,6 +181,12 @@ impl SourceBackedRecordRejections {
     pub fn truncate(&mut self, retained: usize, omitted: usize) {
         self.rejections.truncate(retained);
         self.omitted = omitted;
+    }
+}
+
+impl SourceBackedRecordRejection {
+    pub fn is_committed(&self) -> bool {
+        self.committed
     }
 }
 

--- a/crates/ctx-history-capture-runtime/src/source_backed/document/independent.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/document/independent.rs
@@ -125,7 +125,9 @@ where
                         "independent document source outcome no longer matches its plan",
                     ));
                 }
-                sink.record_rejections(std::mem::take(&mut failure.record_rejections));
+                sink.record_failed_attempt_rejections(std::mem::take(
+                    &mut failure.record_rejections,
+                ));
                 if let Some(retained) = failure.retained {
                     certificates.push(retained);
                 }

--- a/crates/ctx-history-capture-runtime/src/source_backed/document/sink.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/document/sink.rs
@@ -161,7 +161,7 @@ where
     pub(super) fn preserve_record_rejections_on_failure(&mut self) {
         let rejections = std::mem::take(&mut self.record_rejections);
         if let ChangedDocumentTarget::Generation(sink) = &mut self.target {
-            sink.record_rejections(rejections);
+            sink.record_failed_attempt_rejections(rejections);
         }
     }
 

--- a/crates/ctx-history-capture-runtime/src/source_backed/driver.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/driver.rs
@@ -682,7 +682,11 @@ impl<L: CaptureLifecycleSink> SourceBackedGenerationSink<'_, L> {
         Ok(())
     }
 
-    pub fn record_rejection(&mut self, rejection: SourceBackedRecordRejectionDraft) {
+    fn record_rejection_with_provenance(
+        &mut self,
+        rejection: SourceBackedRecordRejectionDraft,
+        committed: bool,
+    ) {
         self.record_rejections.record(SourceBackedRecordRejection {
             route_index: self.route_index,
             route_identity: self.route_identity.clone(),
@@ -704,13 +708,29 @@ impl<L: CaptureLifecycleSink> SourceBackedGenerationSink<'_, L> {
                 &rejection.detail,
                 MAX_SOURCE_BACKED_FAILURE_DETAIL_BYTES,
             ),
+            committed,
         });
     }
 
     pub fn record_rejections(&mut self, rejections: SourceBackedRecordRejectionDrafts) {
+        self.record_rejections_with_provenance(rejections, true);
+    }
+
+    pub fn record_failed_attempt_rejections(
+        &mut self,
+        rejections: SourceBackedRecordRejectionDrafts,
+    ) {
+        self.record_rejections_with_provenance(rejections, false);
+    }
+
+    fn record_rejections_with_provenance(
+        &mut self,
+        rejections: SourceBackedRecordRejectionDrafts,
+        committed: bool,
+    ) {
         let (rejections, omitted) = rejections.into_parts();
         for rejection in rejections {
-            self.record_rejection(rejection);
+            self.record_rejection_with_provenance(rejection, committed);
         }
         self.record_omitted_rejections(omitted);
     }

--- a/crates/ctx-history-capture-runtime/src/source_backed/parallel/tests/document_lifecycle.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/parallel/tests/document_lifecycle.rs
@@ -719,7 +719,9 @@ fn active_source_family_contract_document_cold_all_rejected_is_a_source_failure(
     assert_eq!(failure.class.as_str(), "unreadable");
     assert!(!failure.carried_forward);
     assert_eq!(failed.record_rejections.total(), 1);
-    assert_eq!(failed.record_rejections.rejections()[0].line_number, 1);
+    let rejection = &failed.record_rejections.rejections()[0];
+    assert_eq!(rejection.line_number, 1);
+    assert!(!rejection.is_committed());
 }
 
 #[test]
@@ -733,6 +735,7 @@ fn active_source_family_contract_document_serial_all_rejected_fails_before_publi
     assert!(failed.writer.certified_sources.is_empty());
     assert!(failed.writer.records.is_empty());
     assert_eq!(failed.record_rejections.total(), 1);
+    assert!(!failed.record_rejections.rejections()[0].is_committed());
 }
 
 #[test]
@@ -911,6 +914,7 @@ fn active_source_family_contract_document_mixed_retained_and_rejected_records_pu
     assert_eq!(published.writer.records.len(), 1);
     assert_eq!(published.logical_source_failures.total(), 0);
     assert_eq!(published.record_rejections.total(), 1);
+    assert!(published.record_rejections.rejections()[0].is_committed());
     assert_eq!(
         published.record_rejections.rejections()[0].class,
         SourceBackedRecordRejectionClass::MalformedRecord

--- a/crates/ctx-history-cli/src/test_query_authority.rs
+++ b/crates/ctx-history-cli/src/test_query_authority.rs
@@ -116,6 +116,7 @@ fn publication_metadata(
     });
     if version == SOURCE_REFRESH_PUBLICATION_METADATA_VERSION {
         metadata["route_controls"] = json!({});
+        metadata["committed_rejection_diagnostics"] = json!({});
     }
     serde_json::to_vec(&metadata).unwrap()
 }

--- a/crates/ctx-history-jsonl/src/family/route/capture.rs
+++ b/crates/ctx-history-jsonl/src/family/route/capture.rs
@@ -354,6 +354,7 @@ pub(super) fn capture<R: JsonlFamilyRuntime>(
                     .frozen_scan_observation()
                     .map(|observation| observation.length()),
                 record_rejections: SourceBackedRecordRejectionDrafts::default(),
+                record_rejections_committed: true,
             },
         );
     }

--- a/crates/ctx-history-jsonl/src/family/route/leaf.rs
+++ b/crates/ctx-history-jsonl/src/family/route/leaf.rs
@@ -188,7 +188,7 @@ fn scan_leaf_serial<R: JsonlFamilyRuntime>(
             retained.is_some(),
         )
         .map_err(route_internal)?;
-        sink.record_rejections(record_rejections);
+        sink.record_failed_attempt_rejections(record_rejections);
         sink.report_completed_bytes_with_exact(
             certificate.counts().certified_bytes,
             leaf.frozen_scan_observation()
@@ -204,6 +204,7 @@ fn scan_leaf_serial<R: JsonlFamilyRuntime>(
                 .frozen_scan_observation()
                 .map(|observation| observation.length()),
             record_rejections: SourceBackedRecordRejectionDrafts::default(),
+            record_rejections_committed: false,
         }));
     }
     sink.record_rejections(record_rejections);
@@ -238,6 +239,7 @@ fn scan_leaf_serial<R: JsonlFamilyRuntime>(
                     .frozen_scan_observation()
                     .map(|observation| observation.length()),
                 record_rejections: SourceBackedRecordRejectionDrafts::default(),
+                record_rejections_committed: true,
             }))
         }
         None => {
@@ -267,6 +269,7 @@ fn scan_leaf_serial<R: JsonlFamilyRuntime>(
                     .frozen_scan_observation()
                     .map(|observation| observation.length()),
                 record_rejections: SourceBackedRecordRejectionDrafts::default(),
+                record_rejections_committed: true,
             }))
         }
     }
@@ -473,6 +476,7 @@ fn run_parallel_leaf_job_batch<R: JsonlFamilyRuntime>(
                             .frozen_scan_observation()
                             .map(|observation| observation.length()),
                         record_rejections: SourceBackedRecordRejectionDrafts::default(),
+                        record_rejections_committed: false,
                     });
                 emitter
                     .complete(ParallelLeafScanComplete::source_failure_with_rejections(
@@ -511,6 +515,7 @@ fn run_parallel_leaf_job_batch<R: JsonlFamilyRuntime>(
                                     .frozen_scan_observation()
                                     .map(|observation| observation.length()),
                                 record_rejections,
+                                record_rejections_committed: true,
                             }),
                         ))
                         .map_err(ParallelLeafScanWorkerError::from)?;
@@ -535,6 +540,7 @@ fn run_parallel_leaf_job_batch<R: JsonlFamilyRuntime>(
                             .frozen_scan_observation()
                             .map(|observation| observation.length()),
                         record_rejections,
+                        record_rejections_committed: true,
                     };
                     emitter
                         .complete(ParallelLeafScanComplete::replace(
@@ -555,7 +561,11 @@ fn run_parallel_leaf_job_batch<R: JsonlFamilyRuntime>(
     for outcome in &outcomes {
         match outcome {
             LeafScanOutcome::Certified(evidence) => {
-                sink.record_rejections(evidence.record_rejections.clone());
+                if evidence.record_rejections_committed {
+                    sink.record_rejections(evidence.record_rejections.clone());
+                } else {
+                    sink.record_failed_attempt_rejections(evidence.record_rejections.clone());
+                }
                 sink.report_completed_bytes_with_exact(
                     terminal_byte_remainder(
                         evidence.observed_certificate(),

--- a/crates/ctx-history-jsonl/src/family/route/leaf/evidence.rs
+++ b/crates/ctx-history-jsonl/src/family/route/leaf/evidence.rs
@@ -8,6 +8,7 @@ pub(crate) struct TerminalSourceEvidence<E: JsonlFamilyError> {
     pub(crate) emitted_bytes: u64,
     pub(crate) exact_scan_bytes: Option<u64>,
     pub(crate) record_rejections: SourceBackedRecordRejectionDrafts,
+    pub(crate) record_rejections_committed: bool,
 }
 
 impl<E: JsonlFamilyError> Clone for TerminalSourceEvidence<E> {
@@ -19,6 +20,7 @@ impl<E: JsonlFamilyError> Clone for TerminalSourceEvidence<E> {
             emitted_bytes: self.emitted_bytes,
             exact_scan_bytes: self.exact_scan_bytes,
             record_rejections: self.record_rejections.clone(),
+            record_rejections_committed: self.record_rejections_committed,
         }
     }
 }

--- a/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
@@ -725,6 +725,7 @@ pub(super) fn expected_state(
                     emitted_bytes: 0,
                     exact_scan_bytes: None,
                     record_rejections: SourceBackedRecordRejectionDrafts::default(),
+                    record_rejections_committed: true,
                 },
             )
         })

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/reader/project.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/reader/project.rs
@@ -401,10 +401,50 @@ impl CodexNativeScanner {
         match mutation {
             CodexContextMutation::SourceBackedRow {
                 row,
-                estimated_bytes: _,
+                estimated_bytes,
                 insert_pending_call,
                 remove_pending_call_id,
             } => {
+                let record = if emit_record {
+                    debug_assert!(self.active_core_page.is_some());
+                    let owner = self.owner.as_ref().ok_or(CaptureError::SystemInvariant(
+                        "Codex retained record has no session owner",
+                    ))?;
+                    let raw_ordinal = row.raw_ordinal;
+                    let retained_body_bytes =
+                        u64::try_from(row.lexical_body.len()).unwrap_or(u64::MAX);
+                    let record = codex_core_record(
+                        &self.core_source,
+                        self.core_session_id,
+                        self.source.source_root_lineage,
+                        owner,
+                        row,
+                        &mut self.event_identity_state,
+                    )?;
+                    let Some(record) = record else {
+                        self.counters.retained_records =
+                            self.counters.retained_records.saturating_sub(1);
+                        self.counters.retained_body_bytes = self
+                            .counters
+                            .retained_body_bytes
+                            .saturating_sub(retained_body_bytes);
+                        if let Some(page) = self.active_core_page.as_mut() {
+                            page.serialized_bytes =
+                                page.serialized_bytes.saturating_sub(estimated_bytes);
+                        }
+                        self.reject_record_at_ordinal(
+                            raw_ordinal,
+                            None,
+                            SourceBackedRecordRejectionClass::UnsupportedRecord,
+                            "Codex retained record exceeds the Core selected-content envelope",
+                            false,
+                        );
+                        return Ok(());
+                    };
+                    Some(record)
+                } else {
+                    None
+                };
                 if let Some(call_id) = remove_pending_call_id {
                     self.pending_calls.remove(&call_id);
                 }
@@ -434,22 +474,8 @@ impl CodexNativeScanner {
                         }
                     }
                 }
-                if emit_record {
-                    debug_assert!(self.active_core_page.is_some());
-                    let owner = self.owner.as_ref().ok_or(CaptureError::SystemInvariant(
-                        "Codex retained record has no session owner",
-                    ))?;
-                    let record = codex_core_record(
-                        &self.core_source,
-                        self.core_session_id,
-                        self.source.source_root_lineage,
-                        owner,
-                        row,
-                        &mut self.event_identity_state,
-                    )?;
-                    if let Some(page) = self.active_core_page.as_mut() {
-                        page.records.push(record);
-                    }
+                if let (Some(page), Some(record)) = (self.active_core_page.as_mut(), record) {
+                    page.records.push(record);
                 }
             }
         }
@@ -474,13 +500,24 @@ impl CodexNativeScanner {
         detail: &'static str,
         oversized: bool,
     ) {
+        self.reject_record_at_ordinal(physical.raw_ordinal, payload_type, class, detail, oversized);
+    }
+
+    fn reject_record_at_ordinal(
+        &mut self,
+        raw_ordinal: u64,
+        payload_type: Option<&str>,
+        class: SourceBackedRecordRejectionClass,
+        detail: &'static str,
+        oversized: bool,
+    ) {
         self.reject(oversized);
         self.record_rejections
             .record(SourceBackedRecordRejectionDraft {
                 source: self.core_source.clone(),
                 provider: ctx_history_core::CaptureProvider::Codex,
                 source_selector: self.source.source_path.display().to_string(),
-                line_number: physical.raw_ordinal.saturating_add(1),
+                line_number: raw_ordinal.saturating_add(1),
                 payload_type: payload_type.map(str::to_owned),
                 class,
                 detail: detail.to_owned(),

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/source_backed/identity.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/source_backed/identity.rs
@@ -211,7 +211,7 @@ pub(in crate::codex::nativepath) fn codex_core_record(
     owner: &CodexSessionRow,
     row: CodexCoreRecordDraft,
     event_identity_state: &mut CodexEventIdentityStateV0,
-) -> CodexSourceBackedResultV0<CoreRecord> {
+) -> CodexSourceBackedResultV0<Option<CoreRecord>> {
     let native_session_id = owner.native_session_id.as_str();
     let parent_session_id = owner
         .parent_native_session_id
@@ -227,28 +227,14 @@ pub(in crate::codex::nativepath) fn codex_core_record(
             codex_session_id_for_native_id(source_root_lineage, native_session_id)
         })
         .transpose()?;
-    let (event_id, native_event_id, provider_occurrence) =
-        event_identity_state.next_identity(source, session_id, &row)?;
-    let CodexCoreRecordDraft {
-        raw_ordinal,
-        provider_event_identity,
-        provider_event_copy,
-        occurred_at,
-        event_type,
-        role,
-        session_cwd,
-        lexical_body,
-        structured_content,
-        discovery_exclusion,
-        mut activity,
-    } = row;
-    if lexical_body.is_empty() {
+    let mut row = row;
+    if row.lexical_body.is_empty() {
         return Err(CodexSourceBackedErrorV0::MissingLexicalBody);
     }
-    let content_omission = (lexical_body.len() > ctx_history_core::MAX_CORE_CONTENT_BYTES)
+    let content_omission = (row.lexical_body.len() > ctx_history_core::MAX_CORE_CONTENT_BYTES)
         .then_some("Codex provider record content exceeds the Core content limit");
     let mut session_facts = Vec::new();
-    if let Some(cwd) = session_cwd.as_deref().filter(|value| !value.is_empty()) {
+    if let Some(cwd) = row.session_cwd.as_deref().filter(|value| !value.is_empty()) {
         session_facts.push(ctx_history_core::ProviderDeclaredFact {
             kind: ctx_history_core::LiteralFactKind::SessionCwd,
             value: cwd.to_owned(),
@@ -278,7 +264,7 @@ pub(in crate::codex::nativepath) fn codex_core_record(
         }
     }
     if !session_facts.is_empty() {
-        if let Some(activity) = activity.as_mut() {
+        if let Some(activity) = row.activity.as_mut() {
             if activity
                 .facts
                 .len()
@@ -289,7 +275,7 @@ pub(in crate::codex::nativepath) fn codex_core_record(
             }
             activity.facts.splice(0..0, session_facts);
         } else {
-            activity = Some(ctx_history_core::CoreActivity {
+            row.activity = Some(ctx_history_core::CoreActivity {
                 revision: ctx_history_core::CORE_ACTIVITY_REVISION,
                 provider_call_id: None,
                 invocation: None,
@@ -298,6 +284,46 @@ pub(in crate::codex::nativepath) fn codex_core_record(
             });
         }
     }
+    if content_omission.is_none() {
+        if !ctx_history_jsonl::selected_content_fits(
+            &row.lexical_body,
+            row.structured_content.as_ref(),
+            row.activity.as_ref(),
+            ctx_history_core::MAX_CORE_CONTENT_BYTES,
+        ) {
+            row.structured_content = None;
+        }
+        ctx_history_jsonl::fit_jsonl_activity(
+            &row.lexical_body,
+            row.structured_content.as_ref(),
+            &mut row.activity,
+            ctx_history_jsonl::JsonlActivityObservedBytes::infer_from_present(),
+            ctx_history_core::MAX_CORE_CONTENT_BYTES,
+        );
+        if !ctx_history_jsonl::selected_content_fits(
+            &row.lexical_body,
+            row.structured_content.as_ref(),
+            row.activity.as_ref(),
+            ctx_history_core::MAX_CORE_CONTENT_BYTES,
+        ) {
+            return Ok(None);
+        }
+    }
+    let (event_id, native_event_id, provider_occurrence) =
+        event_identity_state.next_identity(source, session_id, &row)?;
+    let CodexCoreRecordDraft {
+        raw_ordinal,
+        provider_event_identity,
+        provider_event_copy,
+        occurred_at,
+        event_type,
+        role,
+        session_cwd: _,
+        lexical_body,
+        structured_content,
+        discovery_exclusion,
+        activity,
+    } = row;
     let mut record = CoreRecord::new_selected(
         event_id,
         session_id,
@@ -345,32 +371,8 @@ pub(in crate::codex::nativepath) fn codex_core_record(
         };
         record.content.normalized_body = None;
         record.validate_contract()?;
-        return Ok(record);
+        return Ok(Some(record));
     }
-    let mut structured_content = structured_content;
-    if !ctx_history_jsonl::selected_content_fits(
-        record
-            .content
-            .normalized_body
-            .as_deref()
-            .unwrap_or_default(),
-        structured_content.as_ref(),
-        activity.as_ref(),
-        ctx_history_core::MAX_CORE_CONTENT_BYTES,
-    ) {
-        structured_content = None;
-    }
-    ctx_history_jsonl::fit_jsonl_activity(
-        record
-            .content
-            .normalized_body
-            .as_deref()
-            .unwrap_or_default(),
-        structured_content.as_ref(),
-        &mut activity,
-        ctx_history_jsonl::JsonlActivityObservedBytes::infer_from_present(),
-        ctx_history_core::MAX_CORE_CONTENT_BYTES,
-    );
     record.content.structured_content = structured_content;
     record.content.discovery_exclusion = discovery_exclusion;
     record.content.activity = activity;
@@ -378,7 +380,7 @@ pub(in crate::codex::nativepath) fn codex_core_record(
         .content
         .omit_structured_content_if_aggregate_exceeds_limit()?;
     record.validate_contract()?;
-    Ok(record)
+    Ok(Some(record))
 }
 
 fn codex_session_id_for_native_id(

--- a/crates/ctx-history-refresh-execution/src/execution/publication.rs
+++ b/crates/ctx-history-refresh-execution/src/execution/publication.rs
@@ -182,7 +182,7 @@ pub(super) fn provider_route_results<S: ImmutableCaptureSnapshot + ?Sized>(
     {
         bail!("capture-owned source refresh receipt has an incomplete or overlapping terminal route-result partition");
     }
-    let committed_rejections = committed_route_rejected_records(facts.snapshot)?;
+    let committed_rejections = committed_rejected_records(facts.snapshot)?;
     let successful_route_rejections = facts
         .successful_route_outcomes
         .iter()
@@ -191,7 +191,7 @@ pub(super) fn provider_route_results<S: ImmutableCaptureSnapshot + ?Sized>(
                 outcome.route_identity.as_str().to_owned(),
                 committed_rejections
                     .get(&outcome.route_identity)
-                    .copied()
+                    .map(|rejections| rejections.total)
                     .unwrap_or_default(),
             )
         })
@@ -227,7 +227,26 @@ pub(super) fn provider_route_results<S: ImmutableCaptureSnapshot + ?Sized>(
             });
     }
     let mut rejections_by_route = BTreeMap::<String, Vec<_>>::new();
+    let mut reported_rejections_by_source = HashMap::new();
     for rejection in facts.record_rejections.rejections() {
+        if !rejection.is_committed() {
+            continue;
+        }
+        let source_digest = rejection.source.exact_descriptor_digest();
+        let committed_total = committed_rejections
+            .get(&rejection.route_identity)
+            .and_then(|route| route.by_source.get(&source_digest))
+            .copied()
+            .ok_or_else(|| anyhow!("committed rejection has no exact certified source"))?;
+        let reported = reported_rejections_by_source
+            .entry((rejection.route_identity.clone(), source_digest))
+            .or_insert(0_u64);
+        *reported = reported
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("committed source rejection diagnostic total overflow"))?;
+        if *reported > committed_total {
+            bail!("committed source has more rejection diagnostics than rejected records");
+        }
         let route_identity = rejection.route_identity.as_str().to_owned();
         rejections_by_route
             .entry(route_identity.clone())
@@ -304,34 +323,47 @@ fn source_key_identity(source: &ctx_history_core::SourceKey) -> String {
         .collect()
 }
 
-fn committed_route_rejected_records(
+struct CommittedRouteRejectedRecords {
+    total: u64,
+    by_source: HashMap<[u8; 32], u64>,
+}
+
+fn committed_rejected_records(
     snapshot: &(impl ImmutableCaptureSnapshot + ?Sized),
-) -> Result<HashMap<SourceRouteIdentity, u64>> {
+) -> Result<HashMap<SourceRouteIdentity, CommittedRouteRejectedRecords>> {
     let certificates = snapshot
         .sources()
         .iter()
         .map(|source| (source.observation().source().identity().digest(), source))
         .collect::<HashMap<_, _>>();
-    snapshot
-        .source_routes()
-        .map(|route| {
-            let total = route.sources().iter().try_fold(0_u64, |total, source| {
-                let certificate = certificates
-                    .get(&source.identity().digest())
-                    .filter(|candidate| {
-                        candidate.observation().source().exact_descriptor_eq(source)
-                    })
-                    .ok_or_else(|| {
-                        anyhow!(
-                            "committed route {} names a source without an exact certificate",
-                            route.route_identity().as_str()
-                        )
-                    })?;
-                total
-                    .checked_add(certificate.counts().rejected_records)
-                    .ok_or_else(|| anyhow!("committed route rejected-record total overflow"))
-            })?;
-            Ok((route.route_identity().clone(), total))
-        })
-        .collect()
+    let mut by_route = HashMap::new();
+    for route in snapshot.source_routes() {
+        let mut by_source = HashMap::new();
+        let total = route.sources().iter().try_fold(0_u64, |total, source| {
+            let certificate = certificates
+                .get(&source.identity().digest())
+                .filter(|candidate| candidate.observation().source().exact_descriptor_eq(source))
+                .ok_or_else(|| {
+                    anyhow!(
+                        "committed route {} names a source without an exact certificate",
+                        route.route_identity().as_str()
+                    )
+                })?;
+            let rejected_records = certificate.counts().rejected_records;
+            if by_source
+                .insert(source.exact_descriptor_digest(), rejected_records)
+                .is_some()
+            {
+                bail!("committed route contains a duplicate exact source");
+            }
+            total
+                .checked_add(rejected_records)
+                .ok_or_else(|| anyhow!("committed route rejected-record total overflow"))
+        })?;
+        by_route.insert(
+            route.route_identity().clone(),
+            CommittedRouteRejectedRecords { total, by_source },
+        );
+    }
+    Ok(by_route)
 }

--- a/crates/ctx-history-refresh-execution/src/execution/publication.rs
+++ b/crates/ctx-history-refresh-execution/src/execution/publication.rs
@@ -11,31 +11,44 @@ pub fn exclusive_scan_stage_duration(
     scan_stage_duration.saturating_sub(commit_duration)
 }
 
+pub(super) struct PublicationMetadataEvidence<'a> {
+    pub(super) committed_rejection_diagnostics: &'a [SourceBackedRefreshRecordRejection],
+    pub(super) route_observations: BTreeMap<SourceRouteIdentity, String>,
+    pub(super) route_controls: BTreeMap<SourceRouteIdentity, Vec<u8>>,
+}
+
 pub(super) fn encode_publication_metadata(
     request_id: &str,
     operation: RefreshOperation,
     scope: &SourceBackedRefreshScope,
     previous_generation: Option<&str>,
     publication: &SourceBackedRefreshPublication,
-    route_observations: BTreeMap<SourceRouteIdentity, String>,
-    route_controls: BTreeMap<SourceRouteIdentity, Vec<u8>>,
+    evidence: PublicationMetadataEvidence<'_>,
 ) -> Result<Vec<u8>> {
     let terminal = SourceBackedRefreshReceipt::from_verified_publication(
         previous_generation.map(str::to_owned),
         publication.generation_id.clone(),
         publication,
     )?;
-    SourceBackedPublicationMetadata {
+    let metadata = SourceBackedPublicationMetadata {
         version: SOURCE_REFRESH_PUBLICATION_METADATA_VERSION,
         request_id: request_id.to_owned(),
         operation,
         refresh_scope: scope.clone(),
         receipt: terminal.to_json(),
-        route_observations,
-        route_controls,
+        route_observations: evidence.route_observations,
+        route_controls: evidence.route_controls,
+    };
+    let mut committed_rejection_diagnostics = evidence.committed_rejection_diagnostics.to_vec();
+    loop {
+        let ledger_json = rejection_diagnostics_ledger_json(&committed_rejection_diagnostics)?;
+        match metadata.encode_with_committed_rejection_diagnostics(&ledger_json) {
+            Ok(encoded) => return Ok(encoded),
+            Err(IndexError::PublicationMetadataTooLarge { .. })
+                if committed_rejection_diagnostics.pop().is_some() => {}
+            Err(error) => return Err(error.into()),
+        }
     }
-    .encode()
-    .map_err(Into::into)
 }
 
 pub(super) fn publication_from_verified_metadata(
@@ -71,6 +84,283 @@ pub(super) fn publication_from_verified_metadata(
         timings,
         verified_index: Some(verified_index),
     })
+}
+
+/// Replays only rejection evidence already authenticated by the retained
+/// generation and still backed by an identical source certificate. Automatic
+/// route identities may change while a source is carried unchanged, so source
+/// certificates—not transient route identity—own this evidence.
+pub(super) fn preserve_carried_rejection_diagnostics(
+    route_results: &mut [SourceBackedRefreshRouteResult],
+    snapshot: &(impl ImmutableCaptureSnapshot + ?Sized),
+    retained_generation: Option<&VerifiedIndex>,
+) -> Result<Vec<SourceBackedRefreshRecordRejection>> {
+    let authority = current_rejection_authority(snapshot)?;
+    let (previous_diagnostics, stable_sources) = match retained_generation
+        .filter(|retained| retained.publication_metadata().is_some())
+    {
+        Some(retained_generation) => {
+            let (metadata, committed_rejection_diagnostics) =
+                SourceBackedPublicationMetadata::decode_with_committed_rejection_diagnostics(
+                    retained_generation,
+                )?;
+            let previous = published_refresh_receipt_for_index(
+                &metadata.response_value(),
+                retained_generation,
+            )?;
+            if previous.published_generation != retained_generation.generation_id() {
+                bail!("carried Core rejection diagnostics do not match the retained generation");
+            }
+            (
+                committed_rejection_diagnostics.unwrap_or_else(|| {
+                    previous
+                        .route_results
+                        .iter()
+                        .filter(|result| result.outcome.is_success())
+                        .flat_map(|result| result.rejection_diagnostics.iter().cloned())
+                        .collect()
+                }),
+                stable_source_identities(snapshot, retained_generation),
+            )
+        }
+        None => (Vec::new(), BTreeSet::new()),
+    };
+    let current_diagnostics = route_results
+        .iter()
+        .filter(|result| result.outcome.is_success())
+        .flat_map(|result| result.rejection_diagnostics.iter().cloned())
+        .collect::<Vec<_>>();
+    let ledger = build_committed_rejection_ledger(
+        &current_diagnostics,
+        &previous_diagnostics,
+        &stable_sources,
+        &authority,
+    )?;
+    for result in route_results {
+        if !result.outcome.is_success()
+            || result.rejected_record_total == 0
+            || result.rejection_diagnostics.len() as u64 >= result.rejected_record_total
+        {
+            continue;
+        }
+        carry_route_rejection_diagnostics(result, &ledger, &authority)?;
+    }
+    Ok(ledger)
+}
+
+struct CurrentRejectionAuthority {
+    sources: HashMap<String, RejectionSourceAuthority>,
+}
+
+struct RejectionSourceAuthority {
+    route_identity: String,
+    capacity: u64,
+}
+
+fn current_rejection_authority(
+    snapshot: &(impl ImmutableCaptureSnapshot + ?Sized),
+) -> Result<CurrentRejectionAuthority> {
+    let current_certificates = snapshot
+        .sources()
+        .iter()
+        .map(|certificate| {
+            (
+                certificate.observation().source().identity().digest(),
+                certificate,
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    let mut sources = HashMap::<String, Option<RejectionSourceAuthority>>::new();
+    for route in snapshot.source_routes() {
+        let route_identity = route.route_identity().as_str().to_owned();
+        for source in route.sources() {
+            let certificate = current_certificates
+                .get(&source.identity().digest())
+                .filter(|candidate| candidate.observation().source().exact_descriptor_eq(source))
+                .ok_or_else(|| {
+                    anyhow!("committed route names a source without an exact certificate")
+                })?;
+            let source_identity = source_key_identity(source);
+            let capacity = certificate.counts().rejected_records;
+            match sources.entry(source_identity) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(Some(RejectionSourceAuthority {
+                        route_identity: route_identity.clone(),
+                        capacity,
+                    }));
+                }
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    entry.insert(None);
+                }
+            }
+        }
+    }
+    Ok(CurrentRejectionAuthority {
+        sources: sources
+            .into_iter()
+            .filter_map(|(source, authority)| authority.map(|authority| (source, authority)))
+            .collect(),
+    })
+}
+
+fn stable_source_identities(
+    snapshot: &(impl ImmutableCaptureSnapshot + ?Sized),
+    retained_generation: &VerifiedIndex,
+) -> BTreeSet<String> {
+    let retained_certificates = retained_generation
+        .manifest()
+        .sources
+        .iter()
+        .map(|certificate| {
+            (
+                certificate.observation().source().identity().digest(),
+                certificate,
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    snapshot
+        .sources()
+        .iter()
+        .filter(|certificate| {
+            retained_certificates
+                .get(&certificate.observation().source().identity().digest())
+                .is_some_and(|retained| *retained == *certificate)
+        })
+        .map(|certificate| source_key_identity(certificate.observation().source()))
+        .collect()
+}
+
+fn build_committed_rejection_ledger(
+    current_diagnostics: &[SourceBackedRefreshRecordRejection],
+    previous_diagnostics: &[SourceBackedRefreshRecordRejection],
+    stable_sources: &BTreeSet<String>,
+    authority: &CurrentRejectionAuthority,
+) -> Result<Vec<SourceBackedRefreshRecordRejection>> {
+    let mut ledger = Vec::new();
+    let mut reported_by_source = HashMap::<String, u64>::new();
+    let mut exact_diagnostics = BTreeSet::new();
+    for rejection in current_diagnostics.iter().chain(
+        previous_diagnostics
+            .iter()
+            .filter(|rejection| stable_sources.contains(&rejection.source_identity)),
+    ) {
+        if ledger.len() >= ctx_history_capture_runtime::MAX_RECORDED_SOURCE_BACKED_RECORD_REJECTIONS
+        {
+            break;
+        }
+        let Some(source_authority) = authority.sources.get(&rejection.source_identity) else {
+            continue;
+        };
+        let identity = rejection_diagnostic_identity(rejection);
+        if exact_diagnostics.contains(&identity) {
+            continue;
+        }
+        let reported = reported_by_source
+            .entry(rejection.source_identity.clone())
+            .or_default();
+        if *reported >= source_authority.capacity {
+            continue;
+        }
+        *reported = reported
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("committed source rejection diagnostic total overflow"))?;
+        exact_diagnostics.insert(identity);
+        let mut rejection = rejection.clone();
+        rejection
+            .route_identity
+            .clone_from(&source_authority.route_identity);
+        ledger.push(rejection);
+    }
+    Ok(ledger)
+}
+
+fn rejection_diagnostics_ledger_json(
+    diagnostics: &[SourceBackedRefreshRecordRejection],
+) -> Result<Value> {
+    let mut by_route = BTreeMap::<String, SourceBackedRefreshRouteResult>::new();
+    for rejection in diagnostics {
+        let result = by_route
+            .entry(rejection.route_identity.clone())
+            .or_insert_with(|| {
+                SourceBackedRefreshRouteResult::succeeded(rejection.route_identity.clone(), false)
+            });
+        result.rejected_record_total = result
+            .rejected_record_total
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("committed rejection-diagnostic ledger total overflow"))?;
+        result.rejection_diagnostics.push(rejection.clone());
+    }
+    let mut routes = serde_json::Map::new();
+    for (route_identity, result) in by_route {
+        result.validate_source_failures()?;
+        routes.insert(route_identity, result.compact_json());
+    }
+    Ok(Value::Object(routes))
+}
+
+fn carry_route_rejection_diagnostics(
+    result: &mut SourceBackedRefreshRouteResult,
+    previous_diagnostics: &[SourceBackedRefreshRecordRejection],
+    authority: &CurrentRejectionAuthority,
+) -> Result<()> {
+    let mut reported_by_source = HashMap::<String, u64>::new();
+    let mut exact_diagnostics = result
+        .rejection_diagnostics
+        .iter()
+        .map(rejection_diagnostic_identity)
+        .collect::<BTreeSet<_>>();
+    for rejection in &result.rejection_diagnostics {
+        let reported = reported_by_source
+            .entry(rejection.source_identity.clone())
+            .or_default();
+        *reported = reported
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("committed source rejection diagnostic total overflow"))?;
+    }
+    for rejection in previous_diagnostics {
+        if result.rejection_diagnostics.len() as u64 >= result.rejected_record_total {
+            break;
+        }
+        let identity = rejection_diagnostic_identity(rejection);
+        if exact_diagnostics.contains(&identity) {
+            continue;
+        }
+        let Some(source_authority) = authority
+            .sources
+            .get(&rejection.source_identity)
+            .filter(|authority| authority.route_identity == result.route_identity)
+        else {
+            continue;
+        };
+        let reported = reported_by_source
+            .entry(rejection.source_identity.clone())
+            .or_default();
+        if *reported >= source_authority.capacity {
+            continue;
+        }
+        *reported = reported
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("carried source rejection diagnostic total overflow"))?;
+        exact_diagnostics.insert(identity);
+        let mut rejection = rejection.clone();
+        rejection.route_identity.clone_from(&result.route_identity);
+        result.rejection_diagnostics.push(rejection);
+    }
+    result.validate_source_failures()
+}
+
+fn rejection_diagnostic_identity(
+    rejection: &SourceBackedRefreshRecordRejection,
+) -> (String, String, String, u64, String, String, String) {
+    (
+        rejection.source_identity.clone(),
+        rejection.provider.clone(),
+        rejection.source_selector.clone(),
+        rejection.line,
+        rejection.payload_type.clone(),
+        rejection.class.clone(),
+        rejection.detail.clone(),
+    )
 }
 
 pub(super) fn validate_recertified_metadata(
@@ -366,4 +656,159 @@ fn committed_rejected_records(
         );
     }
     Ok(by_route)
+}
+
+#[cfg(test)]
+mod carried_rejection_tests {
+    use super::*;
+
+    fn rejection(source_identity: &str, line: u64) -> SourceBackedRefreshRecordRejection {
+        SourceBackedRefreshRecordRejection {
+            route_identity: "a".repeat(64),
+            source_identity: source_identity.to_owned(),
+            provider: "codex".to_owned(),
+            source_selector: format!("source:{source_identity}"),
+            line,
+            payload_type: "message".to_owned(),
+            class: "malformed_record".to_owned(),
+            detail: format!("rejected source {source_identity} line {line}"),
+        }
+    }
+
+    #[test]
+    fn carried_diagnostics_cannot_consume_another_sources_capacity() {
+        let source_a = "b".repeat(64);
+        let source_b = "c".repeat(64);
+        let mut current = SourceBackedRefreshRouteResult::succeeded("a".repeat(64), false);
+        current.rejected_record_total = 2;
+        current.rejection_diagnostics = vec![rejection(&source_a, 2)];
+        let previous_diagnostics = vec![rejection(&source_a, 1), rejection(&source_b, 1)];
+        let authority = CurrentRejectionAuthority {
+            sources: HashMap::from([
+                (
+                    source_a.clone(),
+                    RejectionSourceAuthority {
+                        route_identity: current.route_identity.clone(),
+                        capacity: 1,
+                    },
+                ),
+                (
+                    source_b.clone(),
+                    RejectionSourceAuthority {
+                        route_identity: current.route_identity.clone(),
+                        capacity: 1,
+                    },
+                ),
+            ]),
+        };
+
+        carry_route_rejection_diagnostics(&mut current, &previous_diagnostics, &authority).unwrap();
+
+        assert_eq!(
+            current
+                .rejection_diagnostics
+                .iter()
+                .map(|rejection| (rejection.source_identity.as_str(), rejection.line))
+                .collect::<Vec<_>>(),
+            vec![(source_a.as_str(), 2), (source_b.as_str(), 1)]
+        );
+    }
+
+    #[test]
+    fn metadata_size_truncation_is_deterministic_and_does_not_revive_evidence() {
+        let route_identity = "a".repeat(64);
+        let source_identity = "b".repeat(64);
+        let route = SourceRouteIdentity::from_sha256(route_identity.clone()).unwrap();
+        let diagnostics = (1..=64)
+            .map(|line| {
+                let mut rejection = rejection(&source_identity, line);
+                rejection.source_selector = "s".repeat(512);
+                rejection.payload_type = "p".repeat(128);
+                rejection.detail = "d".repeat(512);
+                rejection
+            })
+            .collect::<Vec<_>>();
+        let mut result = SourceBackedRefreshRouteResult::succeeded(route_identity.clone(), false);
+        result.rejected_record_total = diagnostics.len() as u64;
+        result.rejection_diagnostics = diagnostics.clone();
+        let publication = SourceBackedRefreshPublication {
+            generation_id: "c".repeat(64),
+            published_explicit_source_catalog: None,
+            unsupported_routes: 0,
+            certified_source_count: 1,
+            certified_source_bytes: 1,
+            current: SourceBackedRefreshCurrent {
+                source_count: 1,
+                complete_records: diagnostics.len() as u64,
+                rejected_records: diagnostics.len() as u64,
+                certified_source_bytes: 1,
+                sources_with_rejections: 1,
+                ..SourceBackedRefreshCurrent::default()
+            },
+            route_results: vec![result],
+            zero_source_authority: Vec::new(),
+            catalog_route_bindings: Vec::new(),
+            timings: SourceBackedRefreshTimings::default(),
+            verified_index: None,
+        };
+        let encode = || {
+            encode_publication_metadata(
+                "metadata-ledger-size-test",
+                RefreshOperation::Refresh,
+                &SourceBackedRefreshScope::exact([route.clone()]),
+                Some(&publication.generation_id),
+                &publication,
+                PublicationMetadataEvidence {
+                    committed_rejection_diagnostics: &diagnostics,
+                    route_observations: BTreeMap::new(),
+                    route_controls: BTreeMap::from([(
+                        route.clone(),
+                        vec![0; MAX_SOURCE_BACKED_ROUTE_CONTROL_BYTES],
+                    )]),
+                },
+            )
+            .unwrap()
+        };
+
+        let first = encode();
+        let second = encode();
+        assert_eq!(first, second);
+        let encoded: Value = serde_json::from_slice(&first).unwrap();
+        let persisted = required_route_results(
+            encoded.get(crate::metadata::COMMITTED_REJECTION_DIAGNOSTICS_FIELD),
+        )
+        .unwrap()
+        .into_iter()
+        .flat_map(|result| result.rejection_diagnostics)
+        .collect::<Vec<_>>();
+        assert!(!persisted.is_empty());
+        assert!(persisted.len() < diagnostics.len());
+
+        let authority = CurrentRejectionAuthority {
+            sources: HashMap::from([(
+                source_identity.clone(),
+                RejectionSourceAuthority {
+                    route_identity: route_identity.clone(),
+                    capacity: diagnostics.len() as u64,
+                },
+            )]),
+        };
+        let carried = build_committed_rejection_ledger(
+            &[],
+            &persisted,
+            &BTreeSet::from([source_identity]),
+            &authority,
+        )
+        .unwrap();
+        assert_eq!(carried, persisted);
+        assert!(!carried.iter().any(|rejection| rejection.line == 64));
+        let mut next = SourceBackedRefreshRouteResult::succeeded(route_identity, false);
+        next.rejected_record_total = diagnostics.len() as u64;
+        carry_route_rejection_diagnostics(&mut next, &carried, &authority).unwrap();
+        assert_eq!(next.rejection_diagnostics, persisted);
+        assert_eq!(
+            next.rejected_record_total - next.rejection_diagnostics.len() as u64,
+            (diagnostics.len() - persisted.len()) as u64
+        );
+    }
 }

--- a/crates/ctx-history-refresh-execution/src/execution/route_local.rs
+++ b/crates/ctx-history-refresh-execution/src/execution/route_local.rs
@@ -237,7 +237,7 @@ pub(super) fn refresh_all_provider_sources_route_local_with_reconciliation(
                         ExactMemberFallbackRequired.to_string(),
                     ));
                 }
-                let route_results = provider_route_results(
+                let mut route_results = provider_route_results(
                     ProviderPublicationFacts {
                         selected_route_ids: &context
                             .selected_route_ids()
@@ -254,6 +254,13 @@ pub(super) fn refresh_all_provider_sources_route_local_with_reconciliation(
                     &expected_selected_route_ids,
                 )
                 .map_err(|error| IndexError::PublicationMetadata(format!("{error:#}")))?;
+                let committed_rejection_diagnostics =
+                    publication::preserve_carried_rejection_diagnostics(
+                    &mut route_results,
+                    context.snapshot(),
+                    retained_generation.as_ref(),
+                )
+                    .map_err(|error| IndexError::PublicationMetadata(format!("{error:#}")))?;
                 let current = SourceBackedRefreshCurrent::from_sources(
                     context.snapshot().sources(),
                     context.removed_source_count(),
@@ -321,8 +328,11 @@ pub(super) fn refresh_all_provider_sources_route_local_with_reconciliation(
                     &scope,
                     previous_generation.as_deref(),
                     &publication,
-                    route_observations,
-                    context.route_controls().clone(),
+                    publication::PublicationMetadataEvidence {
+                        committed_rejection_diagnostics: &committed_rejection_diagnostics,
+                        route_observations,
+                        route_controls: context.route_controls().clone(),
+                    },
                 )
                 .map_err(|error| IndexError::PublicationMetadata(format!("{error:#}")))
             },
@@ -373,7 +383,7 @@ pub(super) fn refresh_all_provider_sources_route_local_with_reconciliation(
             "capture-owned source refresh receipt does not match its retained generation cardinalities"
         );
     }
-    let route_results = provider_route_results(
+    let mut route_results = provider_route_results(
         ProviderPublicationFacts {
             selected_route_ids: &receipt.selected_route_ids,
             successful_route_outcomes: &receipt.successful_route_outcomes,
@@ -385,6 +395,11 @@ pub(super) fn refresh_all_provider_sources_route_local_with_reconciliation(
         },
         &registry_failures,
         &expected_selected_route_ids,
+    )?;
+    let committed_rejection_diagnostics = publication::preserve_carried_rejection_diagnostics(
+        &mut route_results,
+        receipt.commit.snapshot(),
+        retained_generation.as_ref(),
     )?;
     let (published_explicit_source_catalog, catalog_route_bindings) =
         reconcile_published_catalog_witness(
@@ -460,8 +475,11 @@ pub(super) fn refresh_all_provider_sources_route_local_with_reconciliation(
             &scope,
             previous_generation.as_deref(),
             &publication,
-            route_observations,
-            receipt.route_controls.clone(),
+            publication::PublicationMetadataEvidence {
+                committed_rejection_diagnostics: &committed_rejection_diagnostics,
+                route_observations,
+                route_controls: receipt.route_controls.clone(),
+            },
         )?;
         let writer = GenerationWriter::open(index_root, WriterOptions::default())?
             .into_writer()

--- a/crates/ctx-history-refresh-execution/src/metadata.rs
+++ b/crates/ctx-history-refresh-execution/src/metadata.rs
@@ -1,9 +1,11 @@
 use super::*;
 use ctx_history_index::MAX_PUBLICATION_METADATA_BYTES;
 
-pub const SOURCE_REFRESH_PUBLICATION_METADATA_VERSION: u64 = 3;
+pub const SOURCE_REFRESH_PUBLICATION_METADATA_VERSION: u64 = 4;
 const LEGACY_SOURCE_REFRESH_PUBLICATION_METADATA_VERSION: u64 = 1;
 const PREVIOUS_SOURCE_REFRESH_PUBLICATION_METADATA_VERSION: u64 = 2;
+const ROUTE_CONTROL_SOURCE_REFRESH_PUBLICATION_METADATA_VERSION: u64 = 3;
+pub(crate) const COMMITTED_REJECTION_DIAGNOSTICS_FIELD: &str = "committed_rejection_diagnostics";
 
 /// Provider-neutral query-readiness verdict for one physically verified Core
 /// generation.
@@ -46,11 +48,20 @@ pub struct SourceBackedPublicationMetadata {
 impl SourceBackedPublicationMetadata {
     #[doc(hidden)]
     pub fn encode(&self) -> ctx_history_index::Result<Vec<u8>> {
+        self.encode_with_committed_rejection_diagnostics(&json!({}))
+    }
+
+    pub(crate) fn encode_with_committed_rejection_diagnostics(
+        &self,
+        committed_rejection_diagnostics: &Value,
+    ) -> ctx_history_index::Result<Vec<u8>> {
         if self.version != SOURCE_REFRESH_PUBLICATION_METADATA_VERSION {
             return Err(IndexError::PublicationMetadata(
-                "new Core source-refresh publications must use metadata v3".to_owned(),
+                "new Core source-refresh publications must use metadata v4".to_owned(),
             ));
         }
+        parse_committed_rejection_diagnostics(Some(committed_rejection_diagnostics))
+            .map_err(|error| IndexError::PublicationMetadata(error.to_string()))?;
         validate_v2_receipt(&self.receipt, None, &self.refresh_scope)
             .map_err(|error| IndexError::PublicationMetadata(error.to_string()))?;
         let route_ids = receipt_route_ids(&self.receipt)
@@ -81,7 +92,8 @@ impl SourceBackedPublicationMetadata {
                 "route control exceeds its bounded contract".to_owned(),
             ));
         }
-        let encoded = self.encode_with_observations(route_observations)?;
+        let encoded =
+            self.encode_with_observations(route_observations, committed_rejection_diagnostics)?;
         if encoded.len() <= MAX_PUBLICATION_METADATA_BYTES {
             return Ok(encoded);
         }
@@ -89,7 +101,10 @@ impl SourceBackedPublicationMetadata {
         // authority. Drop them as one deterministic unit before rejecting a
         // legitimate exact receipt; startup then performs the normal
         // fail-closed refresh for every route.
-        let encoded = self.encode_with_observations(vec![Value::Null; route_ids.len()])?;
+        let encoded = self.encode_with_observations(
+            vec![Value::Null; route_ids.len()],
+            committed_rejection_diagnostics,
+        )?;
         if encoded.len() > MAX_PUBLICATION_METADATA_BYTES {
             return Err(IndexError::PublicationMetadataTooLarge {
                 actual: encoded.len(),
@@ -102,6 +117,7 @@ impl SourceBackedPublicationMetadata {
     fn encode_with_observations(
         &self,
         route_observations: Vec<Value>,
+        committed_rejection_diagnostics: &Value,
     ) -> ctx_history_index::Result<Vec<u8>> {
         let route_controls = self
             .route_controls
@@ -121,12 +137,19 @@ impl SourceBackedPublicationMetadata {
             "receipt": self.receipt,
             "route_observations": route_observations,
             "route_controls": route_controls,
+            (COMMITTED_REJECTION_DIAGNOSTICS_FIELD): committed_rejection_diagnostics,
         }));
         serde_json::to_vec(&value)
             .map_err(|error| IndexError::PublicationMetadata(error.to_string()))
     }
 
     pub fn decode(index: &VerifiedIndex) -> Result<Self> {
+        Self::decode_with_committed_rejection_diagnostics(index).map(|(metadata, _)| metadata)
+    }
+
+    pub(crate) fn decode_with_committed_rejection_diagnostics(
+        index: &VerifiedIndex,
+    ) -> Result<(Self, Option<Vec<SourceBackedRefreshRecordRejection>>)> {
         let bytes = index
             .publication_metadata()
             .ok_or_else(|| anyhow!("active Core publication has no source-refresh metadata"))?;
@@ -146,6 +169,7 @@ impl SourceBackedPublicationMetadata {
             version,
             LEGACY_SOURCE_REFRESH_PUBLICATION_METADATA_VERSION
                 | PREVIOUS_SOURCE_REFRESH_PUBLICATION_METADATA_VERSION
+                | ROUTE_CONTROL_SOURCE_REFRESH_PUBLICATION_METADATA_VERSION
                 | SOURCE_REFRESH_PUBLICATION_METADATA_VERSION
         ) {
             bail!("unsupported Core source-refresh publication metadata version");
@@ -158,8 +182,15 @@ impl SourceBackedPublicationMetadata {
             "route_observations",
             "version",
         ]);
-        if version == SOURCE_REFRESH_PUBLICATION_METADATA_VERSION {
+        if matches!(
+            version,
+            ROUTE_CONTROL_SOURCE_REFRESH_PUBLICATION_METADATA_VERSION
+                | SOURCE_REFRESH_PUBLICATION_METADATA_VERSION
+        ) {
             expected.insert("route_controls");
+        }
+        if version == SOURCE_REFRESH_PUBLICATION_METADATA_VERSION {
+            expected.insert(COMMITTED_REJECTION_DIAGNOSTICS_FIELD);
         }
         if fields.keys().map(String::as_str).collect::<BTreeSet<_>>() != expected {
             bail!("Core source-refresh publication metadata has unknown or missing fields");
@@ -187,6 +218,7 @@ impl SourceBackedPublicationMetadata {
                 validate_receipt_generation(&receipt, index)?;
             }
             PREVIOUS_SOURCE_REFRESH_PUBLICATION_METADATA_VERSION
+            | ROUTE_CONTROL_SOURCE_REFRESH_PUBLICATION_METADATA_VERSION
             | SOURCE_REFRESH_PUBLICATION_METADATA_VERSION => {
                 validate_v2_receipt(&receipt, Some(index), &refresh_scope)?;
             }
@@ -222,7 +254,11 @@ impl SourceBackedPublicationMetadata {
             .iter()
             .map(|route| route.route_identity().clone())
             .collect::<BTreeSet<_>>();
-        let route_controls = if version == SOURCE_REFRESH_PUBLICATION_METADATA_VERSION {
+        let route_controls = if matches!(
+            version,
+            ROUTE_CONTROL_SOURCE_REFRESH_PUBLICATION_METADATA_VERSION
+                | SOURCE_REFRESH_PUBLICATION_METADATA_VERSION
+        ) {
             fields
                 .get("route_controls")
                 .and_then(Value::as_object)
@@ -241,15 +277,26 @@ impl SourceBackedPublicationMetadata {
         } else {
             BTreeMap::new()
         };
-        Ok(Self {
-            version,
-            request_id,
-            operation,
-            refresh_scope,
-            receipt,
-            route_observations,
-            route_controls,
-        })
+        let committed_rejection_diagnostics = (version
+            == SOURCE_REFRESH_PUBLICATION_METADATA_VERSION)
+            .then(|| {
+                parse_committed_rejection_diagnostics(
+                    fields.get(COMMITTED_REJECTION_DIAGNOSTICS_FIELD),
+                )
+            })
+            .transpose()?;
+        Ok((
+            Self {
+                version,
+                request_id,
+                operation,
+                refresh_scope,
+                receipt,
+                route_observations,
+                route_controls,
+            },
+            committed_rejection_diagnostics,
+        ))
     }
 
     pub fn response_value(&self) -> Value {
@@ -280,30 +327,77 @@ impl SourceBackedPublicationMetadata {
         match source_count {
             Some(1..) => true,
             Some(0) => {
-                self.version == SOURCE_REFRESH_PUBLICATION_METADATA_VERSION
-                    && required_route_results(self.receipt.get("route_results"))
-                        .and_then(|route_results| {
-                            crate::receipt_parse::parse_zero_source_authority(
-                                self.receipt.get("zero_source_authority"),
-                                &route_results,
-                            )
-                            .map(|authority| (route_results, authority))
-                        })
-                        .is_ok_and(|(route_results, authority)| {
-                            if authority.is_empty() {
-                                route_results.is_empty()
-                                    && self.refresh_scope == SourceBackedRefreshScope::All
-                                    && index.manifest().source_routes().is_empty()
-                            } else {
-                                authority
-                                    .iter()
-                                    .all(|entry| entry.generation_id == index.generation_id())
-                            }
-                        })
+                matches!(
+                    self.version,
+                    ROUTE_CONTROL_SOURCE_REFRESH_PUBLICATION_METADATA_VERSION
+                        | SOURCE_REFRESH_PUBLICATION_METADATA_VERSION
+                ) && required_route_results(self.receipt.get("route_results"))
+                    .and_then(|route_results| {
+                        crate::receipt_parse::parse_zero_source_authority(
+                            self.receipt.get("zero_source_authority"),
+                            &route_results,
+                        )
+                        .map(|authority| (route_results, authority))
+                    })
+                    .is_ok_and(|(route_results, authority)| {
+                        if authority.is_empty() {
+                            route_results.is_empty()
+                                && self.refresh_scope == SourceBackedRefreshScope::All
+                                && index.manifest().source_routes().is_empty()
+                        } else {
+                            authority
+                                .iter()
+                                .all(|entry| entry.generation_id == index.generation_id())
+                        }
+                    })
             }
             None => false,
         }
     }
+}
+
+fn parse_committed_rejection_diagnostics(
+    value: Option<&Value>,
+) -> Result<Vec<SourceBackedRefreshRecordRejection>> {
+    let route_results = required_route_results(value)?;
+    let diagnostic_total = route_results.iter().try_fold(0_usize, |total, result| {
+        if result.outcome.changed() != Some(false)
+            || result.source_failure_total != 0
+            || !result.source_failures.is_empty()
+            || result.rejected_record_total != result.rejection_diagnostics.len() as u64
+        {
+            bail!("committed rejection-diagnostic ledger is inconsistent");
+        }
+        total
+            .checked_add(result.rejection_diagnostics.len())
+            .ok_or_else(|| anyhow!("committed rejection-diagnostic ledger total overflow"))
+    })?;
+    if diagnostic_total > ctx_history_capture_runtime::MAX_RECORDED_SOURCE_BACKED_RECORD_REJECTIONS
+    {
+        bail!("committed rejection-diagnostic ledger exceeds its bounded contract");
+    }
+    let diagnostics = route_results
+        .into_iter()
+        .flat_map(|result| result.rejection_diagnostics)
+        .collect::<Vec<_>>();
+    let unique = diagnostics
+        .iter()
+        .map(|rejection| {
+            (
+                rejection.source_identity.as_str(),
+                rejection.provider.as_str(),
+                rejection.source_selector.as_str(),
+                rejection.line,
+                rejection.payload_type.as_str(),
+                rejection.class.as_str(),
+                rejection.detail.as_str(),
+            )
+        })
+        .collect::<BTreeSet<_>>();
+    if unique.len() != diagnostics.len() {
+        bail!("committed rejection-diagnostic ledger contains a duplicate diagnostic");
+    }
+    Ok(diagnostics)
 }
 
 fn encode_route_control(control: &[u8]) -> String {
@@ -453,6 +547,95 @@ mod tests {
             route_observations: BTreeMap::new(),
             route_controls: BTreeMap::new(),
         }
+    }
+
+    fn rejection(
+        route_identity: &str,
+        source_identity: &str,
+        line: u64,
+    ) -> SourceBackedRefreshRecordRejection {
+        SourceBackedRefreshRecordRejection {
+            route_identity: route_identity.to_owned(),
+            source_identity: source_identity.to_owned(),
+            provider: "qwen_code".to_owned(),
+            source_selector: "/tmp/qwen.jsonl".to_owned(),
+            line,
+            payload_type: "message".to_owned(),
+            class: "malformed_record".to_owned(),
+            detail: "invalid shape".to_owned(),
+        }
+    }
+
+    fn ledger_json(
+        entries: impl IntoIterator<Item = (String, Vec<SourceBackedRefreshRecordRejection>)>,
+    ) -> Value {
+        Value::Object(
+            entries
+                .into_iter()
+                .map(|(route_identity, diagnostics)| {
+                    let mut result =
+                        SourceBackedRefreshRouteResult::succeeded(route_identity.clone(), false);
+                    result.rejected_record_total = diagnostics.len() as u64;
+                    result.rejection_diagnostics = diagnostics;
+                    (route_identity, result.compact_json())
+                })
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn metadata_v4_keeps_the_committed_ledger_outside_the_typed_receipt() {
+        let value = metadata(json!({"route_results": {}}));
+        let receipt = value.receipt.clone();
+
+        let encoded = value.encode().unwrap();
+        let encoded: Value = serde_json::from_slice(&encoded).unwrap();
+
+        assert_eq!(
+            encoded["version"],
+            SOURCE_REFRESH_PUBLICATION_METADATA_VERSION
+        );
+        assert_eq!(encoded[COMMITTED_REJECTION_DIAGNOSTICS_FIELD], json!({}));
+        assert_eq!(encoded["receipt"], receipt);
+        assert!(encoded["receipt"]
+            .get(COMMITTED_REJECTION_DIAGNOSTICS_FIELD)
+            .is_none());
+    }
+
+    #[test]
+    fn committed_ledger_rejects_malformed_duplicate_and_over_bound_evidence() {
+        assert!(parse_committed_rejection_diagnostics(Some(&json!([]))).is_err());
+
+        let source_identity = "33".repeat(32);
+        let first_route = "11".repeat(32);
+        let second_route = "22".repeat(32);
+        let duplicate = ledger_json([
+            (
+                first_route.clone(),
+                vec![rejection(&first_route, &source_identity, 3)],
+            ),
+            (
+                second_route.clone(),
+                vec![rejection(&second_route, &source_identity, 3)],
+            ),
+        ]);
+        assert!(format!(
+            "{:#}",
+            parse_committed_rejection_diagnostics(Some(&duplicate)).unwrap_err()
+        )
+        .contains("duplicate diagnostic"));
+
+        let over_bound = ledger_json([(
+            first_route.clone(),
+            (0..=ctx_history_capture_runtime::MAX_RECORDED_SOURCE_BACKED_RECORD_REJECTIONS)
+                .map(|line| rejection(&first_route, &source_identity, line as u64 + 1))
+                .collect(),
+        )]);
+        assert!(format!(
+            "{:#}",
+            parse_committed_rejection_diagnostics(Some(&over_bound)).unwrap_err()
+        )
+        .contains("bounded contract"));
     }
 
     #[test]

--- a/crates/ctx-history-refresh-execution/src/tests.rs
+++ b/crates/ctx-history-refresh-execution/src/tests.rs
@@ -453,6 +453,121 @@ fn query_readiness_decodes_metadata_before_certifying_generation() {
 }
 
 #[test]
+fn publication_metadata_versions_preserve_receipt_shape_and_gate_the_v4_ledger() {
+    let temp = tempfile::tempdir().unwrap();
+    let generation_id = publish_pin_source(temp.path(), publication_pin_source_with_anchor(0x98));
+    let publication = test_publication(generation_id.clone());
+    let receipt = SourceBackedRefreshReceipt::from_verified_publication(
+        None,
+        generation_id.clone(),
+        &publication,
+    )
+    .unwrap();
+    let route_identity = "11".repeat(32);
+    let source_identity = "22".repeat(32);
+    let ledger = json!({
+        (&route_identity): [
+            "s",
+            false,
+            0,
+            0,
+            [],
+            1,
+            [[
+                source_identity,
+                "qwen_code",
+                "/tmp/qwen.jsonl",
+                3,
+                "message",
+                "m",
+                "invalid shape"
+            ]]
+        ]
+    });
+    let metadata = SourceBackedPublicationMetadata {
+        version: SOURCE_REFRESH_PUBLICATION_METADATA_VERSION,
+        request_id: "metadata-version-ledger".to_owned(),
+        operation: RefreshOperation::Refresh,
+        refresh_scope: SourceBackedRefreshScope::All,
+        receipt: receipt.to_json(),
+        route_observations: BTreeMap::new(),
+        route_controls: BTreeMap::new(),
+    };
+    let current = metadata
+        .encode_with_committed_rejection_diagnostics(&ledger)
+        .unwrap();
+    let republish = |bytes: Vec<u8>| {
+        let writer = GenerationWriter::open(temp.path(), WriterOptions::default())
+            .unwrap()
+            .into_writer()
+            .unwrap();
+        writer
+            .republish_current_publication_metadata(&generation_id, bytes)
+            .unwrap()
+    };
+
+    let verified = republish(current.clone());
+    let (decoded, decoded_ledger) =
+        SourceBackedPublicationMetadata::decode_with_committed_rejection_diagnostics(&verified)
+            .unwrap();
+    assert_eq!(decoded.version, SOURCE_REFRESH_PUBLICATION_METADATA_VERSION);
+    assert_eq!(decoded_ledger.unwrap().len(), 1);
+    assert_eq!(decoded.response_value()["receipt"], receipt.to_json());
+    assert!(decoded.response_value()["receipt"]
+        .get(crate::metadata::COMMITTED_REJECTION_DIAGNOSTICS_FIELD)
+        .is_none());
+    assert_eq!(
+        published_refresh_receipt_for_index(&decoded.response_value(), &verified).unwrap(),
+        receipt
+    );
+    drop(verified);
+
+    for version in [1_u64, 2, 3] {
+        let mut legacy: Value = serde_json::from_slice(&current).unwrap();
+        legacy["version"] = json!(version);
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove(crate::metadata::COMMITTED_REJECTION_DIAGNOSTICS_FIELD);
+        if version < 3 {
+            legacy.as_object_mut().unwrap().remove("route_controls");
+        }
+        if version == 1 {
+            legacy["receipt"]
+                .as_object_mut()
+                .unwrap()
+                .remove("zero_source_authority");
+        }
+        let verified = republish(serde_json::to_vec(&legacy).unwrap());
+        let (decoded, decoded_ledger) =
+            SourceBackedPublicationMetadata::decode_with_committed_rejection_diagnostics(&verified)
+                .unwrap();
+        assert_eq!(decoded.version, version);
+        assert!(decoded_ledger.is_none());
+        drop(verified);
+    }
+
+    for mutation in ["missing", "unknown"] {
+        let mut invalid: Value = serde_json::from_slice(&current).unwrap();
+        if mutation == "missing" {
+            invalid
+                .as_object_mut()
+                .unwrap()
+                .remove(crate::metadata::COMMITTED_REJECTION_DIAGNOSTICS_FIELD);
+        } else {
+            invalid["unexpected"] = json!(true);
+        }
+        let verified = republish(serde_json::to_vec(&invalid).unwrap());
+        assert!(format!(
+            "{:#}",
+            SourceBackedPublicationMetadata::decode(&verified).unwrap_err()
+        )
+        .contains("unknown or missing fields"));
+        drop(verified);
+    }
+}
+
+#[test]
 fn persisted_metadata_rejects_malformed_route_identity() {
     let temp = tempfile::tempdir().unwrap();
     let generation_id = publish_pin_source(temp.path(), publication_pin_source_with_anchor(0x97));

--- a/crates/ctx-history-refresh/src/engine/tests/unsupported_refresh.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/unsupported_refresh.rs
@@ -60,6 +60,12 @@ fn replace_metadata_version(index_root: &Path, version: u64) -> VerifiedIndex {
         serde_json::from_slice(current.publication_metadata().unwrap()).unwrap();
     metadata["version"] = json!(version);
     if version != SOURCE_REFRESH_PUBLICATION_METADATA_VERSION {
+        metadata
+            .as_object_mut()
+            .unwrap()
+            .remove("committed_rejection_diagnostics");
+    }
+    if version < 3 {
         metadata.as_object_mut().unwrap().remove("route_controls");
     }
     if version == 1 {


### PR DESCRIPTION
This is a forward regression repair for #712.

## Summary

- Preserve last-good source-backed data while reporting a partial route when an oversized Codex row is rejected.
- Retain a previously committed, certificate-bound rejection diagnostic across an unchanged Qwen refresh while excluding diagnostics from failed attempts.
- Keep carried diagnostics bounded by exact source capacity and store them in internal publication metadata without changing the public receipt shape.

## Validation

- Qwen unchanged-refresh contract: 10/10 uncached runs
- Oversized Codex contract: 17/17 uncached runs
- Affected targets: 93/93
- Native-provider and lifecycle matrix: 5/5
- Strict build: 447/447
- Full CI: 214/214
- Alternating exact-binary Qwen cold/no-op campaign: 6/6 candidate cold and 6/6 candidate no-op behavior passes, with independent performance review passing
