### PR TITLE
fix(jsonl): quarantine duplicate source identities

### DIFF
--- a/crates/ctx-history-jsonl/src/family/route.rs
+++ b/crates/ctx-history-jsonl/src/family/route.rs
@@ -27,7 +27,7 @@ use ctx_history_core::{
     TypedKey,
 };
 use ctx_history_source_io::{
-    open_provider_source_path_mapped as open_provider_source_path,
+    open_provider_source_path_mapped as open_provider_source_path, opened_file_prefix_sha256,
     PROVIDER_JSONL_INVENTORY_MAX_DEPTH, PROVIDER_JSONL_INVENTORY_MAX_DIRECTORIES,
     PROVIDER_JSONL_INVENTORY_MAX_METADATA_ENTRIES, PROVIDER_JSONL_INVENTORY_MAX_PATH_BYTES,
 };

--- a/crates/ctx-history-jsonl/src/family/route.rs
+++ b/crates/ctx-history-jsonl/src/family/route.rs
@@ -701,6 +701,10 @@ impl<E: JsonlFamilyError> JsonlFamilyLeaf<E> {
         &self.source_path
     }
 
+    pub fn authority_path(&self) -> &Path {
+        &self.authority_path
+    }
+
     pub fn authority(&self) -> &Arc<ProviderSourceRoot<E>> {
         &self.authority
     }

--- a/crates/ctx-history-jsonl/src/family/route/inventory.rs
+++ b/crates/ctx-history-jsonl/src/family/route/inventory.rs
@@ -395,29 +395,23 @@ fn validate_unique_accepted_sources<E: JsonlFamilyError>(
     Ok(())
 }
 
-/// Reconciles accepted physical leaves that resolve to the same logical source
-/// identity without aborting the whole provider route.
+#[derive(Debug, Clone, Copy)]
+enum DuplicateDisposition {
+    IdenticalAlias,
+    Unsafe { report_failure: bool },
+}
+
+/// Reconciles physical leaves that claim one logical source without guessing
+/// which divergent transcript is authoritative.
 ///
-/// When several accepted leaves claim one logical source (for example two
-/// transcript files an adapter emitted with a colliding `SourceKey`), the
-/// inventory deterministically retains one leaf and quarantines the remaining
-/// duplicates. Retention is chosen by stable physical ordering -- the
-/// lexicographically smallest source path -- so the outcome never depends on
-/// volatile file metadata such as length or modification time, which would make
-/// the choice non-deterministic across separate discovery passes.
-///
-/// A genuine descriptor digest collision (distinct descriptors hashing to the
-/// same digest) remains an error because no member can be chosen safely.
-///
-/// Quarantined duplicates are recorded with a logical-source diagnostic but are
-/// deliberately *not* marked with `quarantined_source`. That marker would enter
-/// `rejected_quarantine_sources` and cause `capture` to filter the retained
-/// accepted leaf out of publication, defeating the purpose of the dedup.
+/// Byte-identical leaves are safe aliases: the lowest path remains accepted and
+/// the other physical copies are reported as quarantined aliases. If any copy
+/// differs, every copy is withheld and one deterministic logical-source
+/// failure is reported. Providers that can prove a stronger semantic equality
+/// may collapse their aliases before constructing this generic inventory.
 fn reconcile_duplicate_accepted_sources<E: JsonlFamilyError>(
     members: &mut Vec<JsonlFamilyInventoryMember<E>>,
 ) -> JsonlResult<(), E> {
-    use std::collections::HashMap;
-
     let mut groups: HashMap<[u8; 32], Vec<usize>> = HashMap::new();
     for (index, member) in members.iter().enumerate() {
         if let JsonlFamilyInventoryMember::Accepted { leaf, .. } = member {
@@ -428,7 +422,7 @@ fn reconcile_duplicate_accepted_sources<E: JsonlFamilyError>(
         }
     }
 
-    let mut duplicates: Vec<usize> = Vec::new();
+    let mut dispositions = HashMap::<usize, DuplicateDisposition>::new();
     for indices in groups.values() {
         if indices.len() < 2 {
             continue;
@@ -448,46 +442,73 @@ fn reconcile_duplicate_accepted_sources<E: JsonlFamilyError>(
                 "JSONL physical inventory contains a source descriptor digest collision".to_owned(),
             ));
         }
-        let mut keeper = indices[0];
-        for &index in &indices[1..] {
-            if members[index].source_path() < members[keeper].source_path() {
-                keeper = index;
+        let mut content_digest = None;
+        let mut identical = true;
+        for &index in indices {
+            let leaf = match &members[index] {
+                JsonlFamilyInventoryMember::Accepted { leaf, .. } => leaf,
+                _ => unreachable!("duplicate group references an accepted member"),
+            };
+            let observed = authenticated_leaf_content_digest(leaf)?;
+            match content_digest {
+                Some(expected) if expected != observed => identical = false,
+                Some(_) => {}
+                None => content_digest = Some(observed),
             }
         }
-        for &index in indices {
-            if index != keeper {
-                duplicates.push(index);
+        if identical {
+            for &index in &indices[1..] {
+                dispositions.insert(index, DuplicateDisposition::IdenticalAlias);
+            }
+        } else {
+            for (position, &index) in indices.iter().enumerate() {
+                dispositions.insert(
+                    index,
+                    DuplicateDisposition::Unsafe {
+                        report_failure: position == 0,
+                    },
+                );
             }
         }
     }
 
-    if duplicates.is_empty() {
+    if dispositions.is_empty() {
         return Ok(());
     }
 
-    let mut taken = vec![false; members.len()];
-    for index in duplicates {
-        taken[index] = true;
-    }
     let original = std::mem::take(members);
     let mut rebuilt = Vec::with_capacity(original.len());
     for (index, member) in original.into_iter().enumerate() {
-        if taken[index] {
+        if let Some(disposition) = dispositions.get(&index).copied() {
             let (identity, leaf) = match member {
                 JsonlFamilyInventoryMember::Accepted { identity, leaf } => (identity, leaf),
                 _ => unreachable!("duplicate index references an accepted member"),
             };
-            let rejected = JsonlFamilyRejectedLeaf::bind_observed(
+            let source = leaf.source().clone();
+            let mut rejected = JsonlFamilyRejectedLeaf::bind_observed(
                 leaf.source_path().to_path_buf(),
                 leaf.authority_path().to_path_buf(),
                 leaf.observation().clone(),
                 leaf.binding().clone(),
                 0,
-            )
-            .with_logical_source_failure(
-                leaf.source().clone(),
-                "duplicate physical leaf resolved to an already-present logical source identity; quarantined",
             );
+            match disposition {
+                DuplicateDisposition::IdenticalAlias => {
+                    rejected = rejected.with_logical_source_failure(
+                        source,
+                        "byte-identical physical leaf repeats an already-present logical source identity; quarantined alias",
+                    );
+                }
+                DuplicateDisposition::Unsafe { report_failure } => {
+                    rejected = rejected.with_quarantined_source(source.clone());
+                    if report_failure {
+                        rejected = rejected.with_logical_source_failure(
+                            source,
+                            "physical leaves claim one logical source identity but their contents differ; all copies quarantined",
+                        );
+                    }
+                }
+            }
             rebuilt.push(JsonlFamilyInventoryMember::Quarantined {
                 identity,
                 leaf: rejected,
@@ -498,4 +519,19 @@ fn reconcile_duplicate_accepted_sources<E: JsonlFamilyError>(
     }
     *members = rebuilt;
     Ok(())
+}
+
+fn authenticated_leaf_content_digest<E: JsonlFamilyError>(
+    leaf: &JsonlFamilyLeaf<E>,
+) -> JsonlResult<[u8; 32], E> {
+    let opened = leaf.authority().open_file(leaf.authority_path())?;
+    let before = observe_opened_file(leaf.source_path(), &opened)?;
+    if &before != leaf.observation() {
+        return Err(E::source_changed());
+    }
+    let digest = opened_file_prefix_sha256(opened.file(), before.length())?;
+    if observe_opened_file(leaf.source_path(), &opened)? != before {
+        return Err(E::source_changed());
+    }
+    Ok(digest)
 }

--- a/crates/ctx-history-jsonl/src/family/route/inventory.rs
+++ b/crates/ctx-history-jsonl/src/family/route/inventory.rs
@@ -132,7 +132,7 @@ impl<E: JsonlFamilyError> JsonlFamilyInventory<E> {
         }
         members.sort_by(|left, right| left.source_path().cmp(right.source_path()));
         validate_unique_members(&members)?;
-        reconcile_duplicate_accepted_sources(&mut members)?;
+        let exact_dependencies = reconcile_duplicate_accepted_sources(&mut members)?;
         validate_unique_accepted_sources(&members)?;
         let observation = inventory_observation(provider, root, false, &authorities, &members)?;
         Ok(Self {
@@ -142,7 +142,7 @@ impl<E: JsonlFamilyError> JsonlFamilyInventory<E> {
             observation,
             authorities,
             members,
-            exact_dependencies: Vec::new(),
+            exact_dependencies,
         })
     }
 
@@ -161,9 +161,9 @@ impl<E: JsonlFamilyError> JsonlFamilyInventory<E> {
 
     pub fn with_exact_dependencies(
         mut self,
-        exact_dependencies: Vec<JsonlFamilyTerminalProof<E>>,
+        mut exact_dependencies: Vec<JsonlFamilyTerminalProof<E>>,
     ) -> Self {
-        self.exact_dependencies = exact_dependencies;
+        self.exact_dependencies.append(&mut exact_dependencies);
         self
     }
 
@@ -395,23 +395,16 @@ fn validate_unique_accepted_sources<E: JsonlFamilyError>(
     Ok(())
 }
 
-#[derive(Debug, Clone, Copy)]
-enum DuplicateDisposition {
-    IdenticalAlias,
-    Unsafe { report_failure: bool },
-}
-
-/// Reconciles physical leaves that claim one logical source without guessing
-/// which divergent transcript is authoritative.
+/// Collapses byte-identical physical aliases without weakening publication.
 ///
-/// Byte-identical leaves are safe aliases: the lowest path remains accepted and
-/// the other physical copies are reported as quarantined aliases. If any copy
-/// differs, every copy is withheld and one deterministic logical-source
-/// failure is reported. Providers that can prove a stronger semantic equality
-/// may collapse their aliases before constructing this generic inventory.
+/// The lowest path remains the accepted leaf. Every discarded copy becomes an
+/// exact terminal dependency, so a mutation anywhere in the duplicate group
+/// invalidates publication. Divergent bytes remain an adapter error: only the
+/// provider can decide whether distinct encodings are semantically equivalent,
+/// one is a strict extension, or one copy is otherwise preferable.
 fn reconcile_duplicate_accepted_sources<E: JsonlFamilyError>(
     members: &mut Vec<JsonlFamilyInventoryMember<E>>,
-) -> JsonlResult<(), E> {
+) -> JsonlResult<Vec<JsonlFamilyTerminalProof<E>>, E> {
     let mut groups: HashMap<[u8; 32], Vec<usize>> = HashMap::new();
     for (index, member) in members.iter().enumerate() {
         if let JsonlFamilyInventoryMember::Accepted { leaf, .. } = member {
@@ -422,7 +415,7 @@ fn reconcile_duplicate_accepted_sources<E: JsonlFamilyError>(
         }
     }
 
-    let mut dispositions = HashMap::<usize, DuplicateDisposition>::new();
+    let mut aliases = HashMap::<usize, JsonlFamilyTerminalProof<E>>::new();
     for indices in groups.values() {
         if indices.len() < 2 {
             continue;
@@ -443,87 +436,55 @@ fn reconcile_duplicate_accepted_sources<E: JsonlFamilyError>(
             ));
         }
         let mut content_digest = None;
-        let mut identical = true;
+        let mut observed = Vec::with_capacity(indices.len());
         for &index in indices {
             let leaf = match &members[index] {
                 JsonlFamilyInventoryMember::Accepted { leaf, .. } => leaf,
                 _ => unreachable!("duplicate group references an accepted member"),
             };
-            let observed = authenticated_leaf_content_digest(leaf)?;
+            let (digest, proof) = authenticated_leaf_content(leaf)?;
             match content_digest {
-                Some(expected) if expected != observed => identical = false,
+                Some(expected) if expected != digest => {
+                    return Err(E::invalid_payload(format!(
+                        "JSONL physical leaves claim logical source identity {} but their contents differ; the provider must resolve divergent copies semantically",
+                        representative.identity(),
+                    )));
+                }
                 Some(_) => {}
-                None => content_digest = Some(observed),
+                None => content_digest = Some(digest),
             }
+            observed.push((index, proof));
         }
-        if identical {
-            for &index in &indices[1..] {
-                dispositions.insert(index, DuplicateDisposition::IdenticalAlias);
-            }
-        } else {
-            for (position, &index) in indices.iter().enumerate() {
-                dispositions.insert(
-                    index,
-                    DuplicateDisposition::Unsafe {
-                        report_failure: position == 0,
-                    },
-                );
-            }
+        for (index, proof) in observed.into_iter().skip(1) {
+            aliases.insert(index, proof);
         }
     }
 
-    if dispositions.is_empty() {
-        return Ok(());
+    if aliases.is_empty() {
+        return Ok(Vec::new());
     }
 
     let original = std::mem::take(members);
     let mut rebuilt = Vec::with_capacity(original.len());
+    let mut exact_dependencies = Vec::with_capacity(aliases.len());
     for (index, member) in original.into_iter().enumerate() {
-        if let Some(disposition) = dispositions.get(&index).copied() {
-            let (identity, leaf) = match member {
-                JsonlFamilyInventoryMember::Accepted { identity, leaf } => (identity, leaf),
-                _ => unreachable!("duplicate index references an accepted member"),
-            };
-            let source = leaf.source().clone();
-            let mut rejected = JsonlFamilyRejectedLeaf::bind_observed(
-                leaf.source_path().to_path_buf(),
-                leaf.authority_path().to_path_buf(),
-                leaf.observation().clone(),
-                leaf.binding().clone(),
-                0,
-            );
-            match disposition {
-                DuplicateDisposition::IdenticalAlias => {
-                    rejected = rejected.with_logical_source_failure(
-                        source,
-                        "byte-identical physical leaf repeats an already-present logical source identity; quarantined alias",
-                    );
-                }
-                DuplicateDisposition::Unsafe { report_failure } => {
-                    rejected = rejected.with_quarantined_source(source.clone());
-                    if report_failure {
-                        rejected = rejected.with_logical_source_failure(
-                            source,
-                            "physical leaves claim one logical source identity but their contents differ; all copies quarantined",
-                        );
-                    }
-                }
-            }
-            rebuilt.push(JsonlFamilyInventoryMember::Quarantined {
-                identity,
-                leaf: rejected,
-            });
+        if let Some(proof) = aliases.remove(&index) {
+            debug_assert!(matches!(
+                member,
+                JsonlFamilyInventoryMember::Accepted { .. }
+            ));
+            exact_dependencies.push(proof);
         } else {
             rebuilt.push(member);
         }
     }
     *members = rebuilt;
-    Ok(())
+    Ok(exact_dependencies)
 }
 
-fn authenticated_leaf_content_digest<E: JsonlFamilyError>(
+fn authenticated_leaf_content<E: JsonlFamilyError>(
     leaf: &JsonlFamilyLeaf<E>,
-) -> JsonlResult<[u8; 32], E> {
+) -> JsonlResult<([u8; 32], JsonlFamilyTerminalProof<E>), E> {
     let opened = leaf.authority().open_file(leaf.authority_path())?;
     let before = observe_opened_file(leaf.source_path(), &opened)?;
     if &before != leaf.observation() {
@@ -533,5 +494,11 @@ fn authenticated_leaf_content_digest<E: JsonlFamilyError>(
     if observe_opened_file(leaf.source_path(), &opened)? != before {
         return Err(E::source_changed());
     }
-    Ok(digest)
+    let proof = JsonlFamilyTerminalProof::exact_opened_path(
+        leaf.source_path().to_path_buf(),
+        Arc::clone(leaf.authority()),
+        leaf.authority_path().to_path_buf(),
+        &opened,
+    )?;
+    Ok((digest, proof))
 }

--- a/crates/ctx-history-jsonl/src/family/route/inventory.rs
+++ b/crates/ctx-history-jsonl/src/family/route/inventory.rs
@@ -132,6 +132,7 @@ impl<E: JsonlFamilyError> JsonlFamilyInventory<E> {
         }
         members.sort_by(|left, right| left.source_path().cmp(right.source_path()));
         validate_unique_members(&members)?;
+        reconcile_duplicate_accepted_sources(&mut members)?;
         validate_unique_accepted_sources(&members)?;
         let observation = inventory_observation(provider, root, false, &authorities, &members)?;
         Ok(Self {
@@ -391,5 +392,110 @@ fn validate_unique_accepted_sources<E: JsonlFamilyError>(
             ));
         }
     }
+    Ok(())
+}
+
+/// Reconciles accepted physical leaves that resolve to the same logical source
+/// identity without aborting the whole provider route.
+///
+/// When several accepted leaves claim one logical source (for example two
+/// transcript files an adapter emitted with a colliding `SourceKey`), the
+/// inventory deterministically retains one leaf and quarantines the remaining
+/// duplicates. Retention is chosen by stable physical ordering -- the
+/// lexicographically smallest source path -- so the outcome never depends on
+/// volatile file metadata such as length or modification time, which would make
+/// the choice non-deterministic across separate discovery passes.
+///
+/// A genuine descriptor digest collision (distinct descriptors hashing to the
+/// same digest) remains an error because no member can be chosen safely.
+///
+/// Quarantined duplicates are recorded with a logical-source diagnostic but are
+/// deliberately *not* marked with `quarantined_source`. That marker would enter
+/// `rejected_quarantine_sources` and cause `capture` to filter the retained
+/// accepted leaf out of publication, defeating the purpose of the dedup.
+fn reconcile_duplicate_accepted_sources<E: JsonlFamilyError>(
+    members: &mut Vec<JsonlFamilyInventoryMember<E>>,
+) -> JsonlResult<(), E> {
+    use std::collections::HashMap;
+
+    let mut groups: HashMap<[u8; 32], Vec<usize>> = HashMap::new();
+    for (index, member) in members.iter().enumerate() {
+        if let JsonlFamilyInventoryMember::Accepted { leaf, .. } = member {
+            groups
+                .entry(leaf.source().exact_descriptor_digest())
+                .or_default()
+                .push(index);
+        }
+    }
+
+    let mut duplicates: Vec<usize> = Vec::new();
+    for indices in groups.values() {
+        if indices.len() < 2 {
+            continue;
+        }
+        let representative = match &members[indices[0]] {
+            JsonlFamilyInventoryMember::Accepted { leaf, .. } => leaf.source().clone(),
+            _ => unreachable!("duplicate group references an accepted member"),
+        };
+        let all_equal = indices.iter().all(|&index| match &members[index] {
+            JsonlFamilyInventoryMember::Accepted { leaf, .. } => {
+                leaf.source().exact_descriptor_eq(&representative)
+            }
+            _ => false,
+        });
+        if !all_equal {
+            return Err(E::invalid_payload(
+                "JSONL physical inventory contains a source descriptor digest collision".to_owned(),
+            ));
+        }
+        let mut keeper = indices[0];
+        for &index in &indices[1..] {
+            if members[index].source_path() < members[keeper].source_path() {
+                keeper = index;
+            }
+        }
+        for &index in indices {
+            if index != keeper {
+                duplicates.push(index);
+            }
+        }
+    }
+
+    if duplicates.is_empty() {
+        return Ok(());
+    }
+
+    let mut taken = vec![false; members.len()];
+    for index in duplicates {
+        taken[index] = true;
+    }
+    let original = std::mem::take(members);
+    let mut rebuilt = Vec::with_capacity(original.len());
+    for (index, member) in original.into_iter().enumerate() {
+        if taken[index] {
+            let (identity, leaf) = match member {
+                JsonlFamilyInventoryMember::Accepted { identity, leaf } => (identity, leaf),
+                _ => unreachable!("duplicate index references an accepted member"),
+            };
+            let rejected = JsonlFamilyRejectedLeaf::bind_observed(
+                leaf.source_path().to_path_buf(),
+                leaf.authority_path().to_path_buf(),
+                leaf.observation().clone(),
+                leaf.binding().clone(),
+                0,
+            )
+            .with_logical_source_failure(
+                leaf.source().clone(),
+                "duplicate physical leaf resolved to an already-present logical source identity; quarantined",
+            );
+            rebuilt.push(JsonlFamilyInventoryMember::Quarantined {
+                identity,
+                leaf: rejected,
+            });
+        } else {
+            rebuilt.push(member);
+        }
+    }
+    *members = rebuilt;
     Ok(())
 }

--- a/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
@@ -603,7 +603,6 @@ fn canonical_inventory_preserves_unrelated_source_when_deduplicating() {
         .collect();
     assert!(accepted_paths.contains(&third_path.as_path()));
     assert!(accepted_paths.contains(&first_path.as_path()));
-
 }
 
 #[test]

--- a/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
@@ -500,7 +500,7 @@ fn unobserved_membership_uses_parent_enumeration_without_opening_the_leaf() {
 }
 
 #[test]
-fn canonical_inventory_rejects_duplicate_logical_sources_before_staging() {
+fn canonical_inventory_quarantines_duplicate_logical_sources_without_aborting_route() {
     let temp = tempfile::tempdir().unwrap();
     let first_path = temp.path().join("first.jsonl");
     let second_path = temp.path().join("second.jsonl");
@@ -514,27 +514,200 @@ fn canonical_inventory_rejects_duplicate_logical_sources_before_staging() {
         .clone();
     let second = JsonlFamilyLeaf::observe(
         first.source().clone(),
-        second_path,
+        second_path.clone(),
         Arc::clone(first.authority()),
         PathBuf::from("second.jsonl"),
         TypedKey::utf8("second-binding").unwrap(),
     )
     .unwrap();
 
-    let error = JsonlFamilyInventory::present(
+    let inventory = JsonlFamilyInventory::present(
         CaptureProvider::Pi,
         temp.path(),
         Arc::clone(first.authority()),
         vec![first, second],
     )
-    .unwrap_err();
+    .unwrap();
+
+    // One leaf is retained as accepted, the colliding duplicate is quarantined.
+    assert_eq!(inventory.accepted_len(), 1);
+    assert_eq!(inventory.quarantined_len(), 1);
+
+    // The retained leaf is determined by stable physical ordering: the smallest
+    // source path wins, independent of file length or modification time.
+    let retained = inventory.accepted_leaves().next().unwrap();
+    assert_eq!(retained.source_path(), first_path);
+    assert_eq!(
+        retained.source(),
+        discovered.accepted_leaves().next().unwrap().source()
+    );
+
+    let quarantined = inventory.quarantined_leaves().next().unwrap();
+    assert_eq!(quarantined.source_path(), second_path);
+    assert_eq!(
+        quarantined.logical_source_failure.as_ref().unwrap().0,
+        retained.source().clone()
+    );
+}
+
+#[test]
+fn canonical_inventory_preserves_unrelated_source_when_deduplicating() {
+    let temp = tempfile::tempdir().unwrap();
+    let first_path = temp.path().join("first.jsonl");
+    let second_path = temp.path().join("second.jsonl");
+    let third_path = temp.path().join("third.jsonl");
+    fs::write(&first_path, TEST_RECORD).unwrap();
+    fs::write(&second_path, TEST_RECORD).unwrap();
+    fs::write(&third_path, TEST_RECORD).unwrap();
+    let discovered = TestAdapter.discover(temp.path()).unwrap();
+
+    // Two leaves collide on `first`s source; `third` is an independent source.
+    let first = discovered
+        .accepted_leaves()
+        .find(|leaf| leaf.source_path() == first_path)
+        .unwrap()
+        .clone();
+    let second = JsonlFamilyLeaf::observe(
+        first.source().clone(),
+        second_path.clone(),
+        Arc::clone(first.authority()),
+        PathBuf::from("second.jsonl"),
+        TypedKey::utf8("second-binding").unwrap(),
+    )
+    .unwrap();
+    let third = discovered
+        .accepted_leaves()
+        .find(|leaf| leaf.source_path() == third_path)
+        .unwrap()
+        .clone();
+
+    let inventory = JsonlFamilyInventory::present(
+        CaptureProvider::Pi,
+        temp.path(),
+        Arc::clone(first.authority()),
+        vec![first, second, third],
+    )
+    .unwrap();
+
+    assert_eq!(inventory.accepted_len(), 2);
+    assert_eq!(inventory.quarantined_len(), 1);
+
+    // The unrelated source is untouched and still published.
+    let accepted_paths: Vec<&Path> = inventory
+        .accepted_leaves()
+        .map(|leaf| leaf.source_path())
+        .collect();
+    assert!(accepted_paths.contains(&third_path.as_path()));
+    assert!(accepted_paths.contains(&first_path.as_path()));
+
+    let quarantined = inventory.quarantined_leaves().next().unwrap();
+    assert_eq!(quarantined.source_path(), second_path);
+}
+
+#[test]
+fn canonical_inventory_deduplication_is_deterministic_regardless_of_leaf_order() {
+    let temp = tempfile::tempdir().unwrap();
+    let first_path = temp.path().join("first.jsonl");
+    let second_path = temp.path().join("zzz.jsonl");
+    fs::write(&first_path, TEST_RECORD).unwrap();
+    fs::write(&second_path, TEST_RECORD).unwrap();
+    let discovered = TestAdapter.discover(temp.path()).unwrap();
+    let first = discovered
+        .accepted_leaves()
+        .find(|leaf| leaf.source_path() == first_path)
+        .unwrap()
+        .clone();
+    let second = JsonlFamilyLeaf::observe(
+        first.source().clone(),
+        second_path.clone(),
+        Arc::clone(first.authority()),
+        PathBuf::from("zzz.jsonl"),
+        TypedKey::utf8("second-binding").unwrap(),
+    )
+    .unwrap();
+
+    // The larger path sorts after the smaller one, so `first` must be retained
+    // even when the colliding leaf is supplied first.
+    let forward = JsonlFamilyInventory::present(
+        CaptureProvider::Pi,
+        temp.path(),
+        Arc::clone(first.authority()),
+        vec![first.clone(), second.clone()],
+    )
+    .unwrap();
+    let reversed = JsonlFamilyInventory::present(
+        CaptureProvider::Pi,
+        temp.path(),
+        Arc::clone(first.authority()),
+        vec![second, first],
+    )
+    .unwrap();
+
+    for inventory in [&forward, &reversed] {
+        assert_eq!(inventory.accepted_len(), 1);
+        assert_eq!(inventory.quarantined_len(), 1);
+        assert_eq!(
+            inventory.accepted_leaves().next().unwrap().source_path(),
+            first_path
+        );
+        assert_eq!(
+            inventory.quarantined_leaves().next().unwrap().source_path(),
+            second_path
+        );
+    }
+}
+
+#[test]
+fn canonical_inventory_still_rejects_duplicate_physical_member_among_accepted_leaves() {
+    // Two accepted leaves that resolve to the same physical path are a distinct
+    // invariant from a duplicate logical source and must still fail. This avoids
+    // the shared root-authority disposition checks so it is independent of host
+    // path canonicalization.
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("same.jsonl");
+    fs::write(&path, TEST_RECORD).unwrap();
+    let discovered = TestAdapter.discover(temp.path()).unwrap();
+    let authority = Arc::clone(&discovered.authorities[0]);
+    let one = JsonlFamilyLeaf::observe(
+        SourceKey::derive_provider_native(
+            CaptureProvider::Pi.as_str(),
+            TEST_SOURCE_FORMAT,
+            TEST_SCHEMA,
+            1,
+            "terminal-witness-file",
+            TypedKey::bytes(b"one".to_vec()).unwrap(),
+        )
+        .unwrap(),
+        path.clone(),
+        Arc::clone(&authority),
+        PathBuf::from("same.jsonl"),
+        TypedKey::utf8("one-binding").unwrap(),
+    )
+    .unwrap();
+    let two = JsonlFamilyLeaf::observe(
+        SourceKey::derive_provider_native(
+            CaptureProvider::Pi.as_str(),
+            TEST_SOURCE_FORMAT,
+            TEST_SCHEMA,
+            1,
+            "terminal-witness-file",
+            TypedKey::bytes(b"two".to_vec()).unwrap(),
+        )
+        .unwrap(),
+        path.clone(),
+        Arc::clone(&authority),
+        PathBuf::from("same.jsonl"),
+        TypedKey::utf8("two-binding").unwrap(),
+    )
+    .unwrap();
+
+    let error =
+        JsonlFamilyInventory::present(CaptureProvider::Pi, temp.path(), authority, vec![one, two])
+            .unwrap_err();
 
     assert!(error
         .to_string()
-        .contains("duplicate logical source identity"));
-    assert!(!error
-        .to_string()
-        .contains("source replacement has already started"));
+        .contains("physical inventory contains duplicate member"));
 }
 
 #[test]

--- a/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
@@ -605,6 +605,65 @@ fn canonical_inventory_preserves_unrelated_source_when_deduplicating() {
 }
 
 #[test]
+fn canonical_inventory_withholds_divergent_duplicates_and_preserves_unrelated_source() {
+    let temp = tempfile::tempdir().unwrap();
+    let first_path = temp.path().join("first.jsonl");
+    let second_path = temp.path().join("second.jsonl");
+    let third_path = temp.path().join("third.jsonl");
+    fs::write(&first_path, TEST_RECORD).unwrap();
+    fs::write(&second_path, b"{\"message\":\"different\"}\n").unwrap();
+    fs::write(&third_path, TEST_RECORD).unwrap();
+    let discovered = TestAdapter.discover(temp.path()).unwrap();
+    let first = discovered
+        .accepted_leaves()
+        .find(|leaf| leaf.source_path() == first_path)
+        .unwrap()
+        .clone();
+    let source = first.source().clone();
+    let second = JsonlFamilyLeaf::observe(
+        source.clone(),
+        second_path.clone(),
+        Arc::clone(first.authority()),
+        PathBuf::from("second.jsonl"),
+        TypedKey::utf8("second-binding").unwrap(),
+    )
+    .unwrap();
+    let third = discovered
+        .accepted_leaves()
+        .find(|leaf| leaf.source_path() == third_path)
+        .unwrap()
+        .clone();
+
+    let inventory = JsonlFamilyInventory::present(
+        CaptureProvider::Pi,
+        temp.path(),
+        Arc::clone(first.authority()),
+        vec![first, second, third],
+    )
+    .unwrap();
+
+    assert_eq!(inventory.accepted_len(), 1);
+    assert_eq!(inventory.quarantined_len(), 2);
+    assert_eq!(
+        inventory.accepted_leaves().next().unwrap().source_path(),
+        third_path
+    );
+    let quarantined = inventory.quarantined_leaves().collect::<Vec<_>>();
+    assert_eq!(
+        quarantined
+            .iter()
+            .filter(|leaf| leaf.logical_source_failure.is_some())
+            .count(),
+        1
+    );
+    assert!(quarantined.iter().all(|leaf| leaf
+        .source()
+        .is_some_and(|claimed| claimed.exact_descriptor_eq(&source))));
+    assert_eq!(quarantined[0].source_path(), first_path);
+    assert_eq!(quarantined[1].source_path(), second_path);
+}
+
+#[test]
 fn canonical_inventory_deduplication_is_deterministic_regardless_of_leaf_order() {
     let temp = tempfile::tempdir().unwrap();
     let first_path = temp.path().join("first.jsonl");

--- a/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/source_adapters.rs
@@ -500,7 +500,7 @@ fn unobserved_membership_uses_parent_enumeration_without_opening_the_leaf() {
 }
 
 #[test]
-fn canonical_inventory_quarantines_duplicate_logical_sources_without_aborting_route() {
+fn canonical_inventory_collapses_byte_identical_logical_source_aliases() {
     let temp = tempfile::tempdir().unwrap();
     let first_path = temp.path().join("first.jsonl");
     let second_path = temp.path().join("second.jsonl");
@@ -529,9 +529,11 @@ fn canonical_inventory_quarantines_duplicate_logical_sources_without_aborting_ro
     )
     .unwrap();
 
-    // One leaf is retained as accepted, the colliding duplicate is quarantined.
+    // One leaf is retained and the physical alias is fenced without turning a
+    // healthy logical source into a quarantined or failed source.
     assert_eq!(inventory.accepted_len(), 1);
-    assert_eq!(inventory.quarantined_len(), 1);
+    assert_eq!(inventory.quarantined_len(), 0);
+    assert_eq!(inventory.exact_dependencies.len(), 1);
 
     // The retained leaf is determined by stable physical ordering: the smallest
     // source path wins, independent of file length or modification time.
@@ -542,12 +544,13 @@ fn canonical_inventory_quarantines_duplicate_logical_sources_without_aborting_ro
         discovered.accepted_leaves().next().unwrap().source()
     );
 
-    let quarantined = inventory.quarantined_leaves().next().unwrap();
-    assert_eq!(quarantined.source_path(), second_path);
-    assert_eq!(
-        quarantined.logical_source_failure.as_ref().unwrap().0,
-        retained.source().clone()
-    );
+    inventory.exact_dependencies[0]
+        .revalidate_dependency()
+        .unwrap();
+    fs::write(&second_path, b"changed\n").unwrap();
+    assert!(inventory.exact_dependencies[0]
+        .revalidate_dependency()
+        .is_err());
 }
 
 #[test]
@@ -590,7 +593,8 @@ fn canonical_inventory_preserves_unrelated_source_when_deduplicating() {
     .unwrap();
 
     assert_eq!(inventory.accepted_len(), 2);
-    assert_eq!(inventory.quarantined_len(), 1);
+    assert_eq!(inventory.quarantined_len(), 0);
+    assert_eq!(inventory.exact_dependencies.len(), 1);
 
     // The unrelated source is untouched and still published.
     let accepted_paths: Vec<&Path> = inventory
@@ -600,12 +604,10 @@ fn canonical_inventory_preserves_unrelated_source_when_deduplicating() {
     assert!(accepted_paths.contains(&third_path.as_path()));
     assert!(accepted_paths.contains(&first_path.as_path()));
 
-    let quarantined = inventory.quarantined_leaves().next().unwrap();
-    assert_eq!(quarantined.source_path(), second_path);
 }
 
 #[test]
-fn canonical_inventory_withholds_divergent_duplicates_and_preserves_unrelated_source() {
+fn canonical_inventory_requires_provider_resolution_for_divergent_duplicates() {
     let temp = tempfile::tempdir().unwrap();
     let first_path = temp.path().join("first.jsonl");
     let second_path = temp.path().join("second.jsonl");
@@ -619,9 +621,8 @@ fn canonical_inventory_withholds_divergent_duplicates_and_preserves_unrelated_so
         .find(|leaf| leaf.source_path() == first_path)
         .unwrap()
         .clone();
-    let source = first.source().clone();
     let second = JsonlFamilyLeaf::observe(
-        source.clone(),
+        first.source().clone(),
         second_path.clone(),
         Arc::clone(first.authority()),
         PathBuf::from("second.jsonl"),
@@ -634,33 +635,17 @@ fn canonical_inventory_withholds_divergent_duplicates_and_preserves_unrelated_so
         .unwrap()
         .clone();
 
-    let inventory = JsonlFamilyInventory::present(
+    let error = JsonlFamilyInventory::present(
         CaptureProvider::Pi,
         temp.path(),
         Arc::clone(first.authority()),
         vec![first, second, third],
     )
-    .unwrap();
+    .unwrap_err();
 
-    assert_eq!(inventory.accepted_len(), 1);
-    assert_eq!(inventory.quarantined_len(), 2);
-    assert_eq!(
-        inventory.accepted_leaves().next().unwrap().source_path(),
-        third_path
-    );
-    let quarantined = inventory.quarantined_leaves().collect::<Vec<_>>();
-    assert_eq!(
-        quarantined
-            .iter()
-            .filter(|leaf| leaf.logical_source_failure.is_some())
-            .count(),
-        1
-    );
-    assert!(quarantined.iter().all(|leaf| leaf
-        .source()
-        .is_some_and(|claimed| claimed.exact_descriptor_eq(&source))));
-    assert_eq!(quarantined[0].source_path(), first_path);
-    assert_eq!(quarantined[1].source_path(), second_path);
+    assert!(error
+        .to_string()
+        .contains("provider must resolve divergent copies semantically"));
 }
 
 #[test]
@@ -704,14 +689,11 @@ fn canonical_inventory_deduplication_is_deterministic_regardless_of_leaf_order()
 
     for inventory in [&forward, &reversed] {
         assert_eq!(inventory.accepted_len(), 1);
-        assert_eq!(inventory.quarantined_len(), 1);
+        assert_eq!(inventory.quarantined_len(), 0);
+        assert_eq!(inventory.exact_dependencies.len(), 1);
         assert_eq!(
             inventory.accepted_leaves().next().unwrap().source_path(),
             first_path
-        );
-        assert_eq!(
-            inventory.quarantined_leaves().next().unwrap().source_path(),
-            second_path
         );
     }
 }


### PR DESCRIPTION
## What

Handle multiple physical JSONL files that resolve to one logical source without silently choosing disagreeing history.

- Byte-identical aliases collapse to the lowest-sorted path.
- Every discarded identical alias is authenticated and fenced against mutation.
- Divergent bytes fail explicitly so the owning provider can apply a semantic policy.
- Unrelated healthy sources remain accepted.

## Why

Duplicate physical paths can be harmless aliases, but choosing between different contents in the shared JSONL layer can discard real history. The shared layer now handles only the case it can prove safe and delegates true conflicts to provider-specific logic.

## Verification

- Added deterministic identical-alias coverage.
- Added mutation-fence and duplicate-path coverage.
- Added divergent-alias failure coverage.
- Verified healthy sibling preservation.
- Exact candidate passed all 214 repository test targets and the private disclosure gate.