### PR TITLE
refactor(cli): unify human count formatting

### DIFF
--- a/crates/ctx-cli-presentation/src/commands/history_health.rs
+++ b/crates/ctx-cli-presentation/src/commands/history_health.rs
@@ -1,4 +1,4 @@
-use ctx_history_cli::{format_bytes, provider_display_name};
+use ctx_history_cli::{format_bytes, format_count, provider_display_name};
 use ctx_history_read_application::{HistoryHealthReport, HistoryRootCoverage};
 
 pub(super) fn history_health_fields(
@@ -36,9 +36,9 @@ pub(super) fn history_health_fields(
         values.push(("Roots", coverage));
     }
     values.extend([
-        ("Sessions", grouped_count(health.sessions)),
-        ("Messages", grouped_count(health.messages)),
-        ("Tool calls", grouped_count(health.tool_calls)),
+        ("Sessions", format_count(health.sessions)),
+        ("Messages", format_count(health.messages)),
+        ("Tool calls", format_count(health.tool_calls)),
     ]);
     let mut data = format!("{} processed", format_bytes(health.data.processed));
     if let Some(excluded) = health.data.excluded.filter(|excluded| *excluded > 0) {
@@ -157,19 +157,7 @@ fn nonempty_root_coverage(health: &HistoryHealthReport) -> Option<HistoryRootCov
 
 pub(super) fn counted(count: u64, singular: &str, plural: &str) -> String {
     let noun = if count == 1 { singular } else { plural };
-    format!("{} {noun}", grouped_count(count))
-}
-
-pub(super) fn grouped_count(count: u64) -> String {
-    let digits = count.to_string();
-    let mut reversed = String::with_capacity(digits.len().saturating_add(digits.len() / 3));
-    for (index, character) in digits.chars().rev().enumerate() {
-        if index > 0 && index % 3 == 0 {
-            reversed.push(',');
-        }
-        reversed.push(character);
-    }
-    reversed.chars().rev().collect()
+    format!("{} {noun}", format_count(count))
 }
 
 #[cfg(test)]

--- a/crates/ctx-cli-presentation/src/commands/index_dashboard.rs
+++ b/crates/ctx-cli-presentation/src/commands/index_dashboard.rs
@@ -159,16 +159,13 @@ fn render_searchable_fields(readiness: &Value, context: &RenderContext) -> Docum
         values.push(("Processed", format_bytes(bytes)));
     }
     if let Some(sources) = u64_at(readiness, &["lexical", "indexed_sources"]) {
-        values.push(("Sources", format_count_u64(sources)));
+        values.push(("Sources", format_count(sources)));
     }
     if let Some(sessions) = u64_at(readiness, &["lexical", "indexed_sessions"]) {
-        values.push(("Sessions", format_count_u64(sessions)));
+        values.push(("Sessions", format_count(sessions)));
     }
     if let Some(records) = u64_at(readiness, &["lexical", "indexed_items"]) {
-        values.push((
-            "Records",
-            format!("{} searchable", format_count_u64(records)),
-        ));
+        values.push(("Records", format!("{} searchable", format_count(records))));
     }
     let field_values = values
         .iter()
@@ -181,7 +178,7 @@ fn render_active(readiness: &Value, context: &RenderContext) -> Document {
     let mut document = render_refresh_progress(readiness, context);
     let current = if bool_at(readiness, &["initialized"]) {
         u64_at(readiness, &["lexical", "indexed_items"])
-            .map(|count| format!("{} searchable records", format_count_u64(count)))
+            .map(|count| format!("{} searchable records", format_count(count)))
             .unwrap_or_else(|| "searchable generation published".to_owned())
     } else {
         "not published".to_owned()
@@ -248,11 +245,11 @@ fn render_semantic(readiness: &Value, context: &RenderContext) -> Document {
         .map(|total| {
             format!(
                 "{} / {} records",
-                format_count_u64(embedded),
-                format_count_u64(total)
+                format_count(embedded),
+                format_count(total)
             )
         })
-        .unwrap_or_else(|| format!("{} records", format_count_u64(embedded)));
+        .unwrap_or_else(|| format!("{} records", format_count(embedded)));
     document.push_blank();
     document.append(fields(context, &[Field::new("Embedded", &embedded_value)]));
     document
@@ -337,26 +334,6 @@ fn append_separated(document: &mut Document, other: Document) {
 
 fn humanize(value: &str) -> String {
     value.replace('_', " ")
-}
-
-fn format_count_u64(value: u64) -> String {
-    if let Ok(value) = usize::try_from(value) {
-        return format_count(value);
-    }
-
-    let digits = value.to_string();
-    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
-    let first_group_len = digits.len() % 3;
-    for (index, ch) in digits.chars().enumerate() {
-        if index > 0
-            && (index == first_group_len
-                || (index > first_group_len && (index - first_group_len).is_multiple_of(3)))
-        {
-            out.push(',');
-        }
-        out.push(ch);
-    }
-    out
 }
 
 fn value_at<'a>(value: &'a Value, path: &[&str]) -> Option<&'a Value> {
@@ -465,6 +442,8 @@ mod tests {
     fn searchable_generation_and_refresh_progress_are_separate_truths() {
         let rendered = render_dashboard(&readiness(), &context(80), true).render_plain();
         assert!(rendered.starts_with("✓ Your history is searchable"));
+        assert!(rendered.contains("3,486"));
+        assert!(rendered.contains("854,466 searchable"));
         assert!(rendered.contains("Refresh"));
         assert!(rendered.contains("Agent histories  OpenCode"));
         assert!(rendered.contains("Sessions         18"));
@@ -547,10 +526,5 @@ mod tests {
         let styled = document.render(&context);
         assert!(styled.contains("\u{1b}["));
         assert_eq!(strip_ansi(&styled), document.render_plain());
-    }
-
-    #[test]
-    fn count_formatting_preserves_the_full_u64_domain() {
-        assert_eq!(format_count_u64(u64::MAX), "18,446,744,073,709,551,615");
     }
 }

--- a/crates/ctx-daemon-cli/src/daemon_status/render.rs
+++ b/crates/ctx-daemon-cli/src/daemon_status/render.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use serde_json::Value;
 
 use ctx_terminal::{
-    fields, format_bytes, hint, outcome, section, Action, Document, Field, Hint, Outcome,
-    OutcomeState, RenderContext, Token,
+    fields, format_bytes, format_count, hint, outcome, section, Action, Document, Field, Hint,
+    Outcome, OutcomeState, RenderContext, Token,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -884,17 +884,5 @@ fn humanize_code(value: &str) -> String {
 
 fn counted(count: u64, singular: &str, plural: &str) -> String {
     let noun = if count == 1 { singular } else { plural };
-    format!("{} {noun}", grouped_count(count))
-}
-
-fn grouped_count(count: u64) -> String {
-    let digits = count.to_string();
-    let mut reversed = String::with_capacity(digits.len().saturating_add(digits.len() / 3));
-    for (index, character) in digits.chars().rev().enumerate() {
-        if index > 0 && index % 3 == 0 {
-            reversed.push(',');
-        }
-        reversed.push(character);
-    }
-    reversed.chars().rev().collect()
+    format!("{} {noun}", format_count(count))
 }

--- a/crates/ctx-terminal/src/progress.rs
+++ b/crates/ctx-terminal/src/progress.rs
@@ -952,7 +952,7 @@ fn scaled_bytes(bytes: u64) -> (f64, &'static str) {
 
 const BYTE_UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
 
-pub fn format_count(value: usize) -> String {
+pub fn format_count(value: u64) -> String {
     let digits = value.to_string();
     let mut out = String::with_capacity(digits.len() + digits.len() / 3);
     let first_group_len = digits.len() % 3;

--- a/crates/ctx-terminal/src/progress/tests.rs
+++ b/crates/ctx-terminal/src/progress/tests.rs
@@ -598,3 +598,10 @@ fn progress_text_is_control_safe_utf8_and_bounded() {
     assert!(!bounded.contains('\n'));
     assert!(bounded.ends_with("..."));
 }
+
+#[test]
+fn count_formatting_groups_the_full_u64_domain() {
+    assert_eq!(format_count(999), "999");
+    assert_eq!(format_count(1_000), "1,000");
+    assert_eq!(format_count(u64::MAX), "18,446,744,073,709,551,615");
+}

--- a/crates/ctx-terminal/src/ui/components/refresh_progress.rs
+++ b/crates/ctx-terminal/src/ui/components/refresh_progress.rs
@@ -467,9 +467,9 @@ fn shared_refresh_progress(
         },
     );
 
-    let sessions = format_count_u64(snapshot.progress.processed_sessions);
-    let messages = format_count_u64(snapshot.progress.processed_messages);
-    let tool_calls = format_count_u64(snapshot.progress.processed_tool_calls);
+    let sessions = format_count(snapshot.progress.processed_sessions);
+    let messages = format_count(snapshot.progress.processed_messages);
+    let tool_calls = format_count(snapshot.progress.processed_tool_calls);
     let scanned = format_bytes(snapshot.progress.processed_bytes);
     let elapsed = snapshot
         .progress
@@ -570,9 +570,9 @@ fn setup_live_refresh_progress(
         },
     );
 
-    let sessions = format_count_u64(snapshot.progress.processed_sessions);
-    let messages = format_count_u64(snapshot.progress.processed_messages);
-    let tool_calls = format_count_u64(snapshot.progress.processed_tool_calls);
+    let sessions = format_count(snapshot.progress.processed_sessions);
+    let messages = format_count(snapshot.progress.processed_messages);
+    let tool_calls = format_count(snapshot.progress.processed_tool_calls);
     let scanned = format_bytes(snapshot.progress.processed_bytes);
     let elapsed = snapshot
         .progress
@@ -755,8 +755,8 @@ fn source_count_text(snapshot: &RefreshProgressSnapshot) -> String {
     if snapshot.total_sources_known {
         format!(
             "{} / {}",
-            format_count_u64(snapshot.progress.completed_sources),
-            format_count_u64(
+            format_count(snapshot.progress.completed_sources),
+            format_count(
                 snapshot
                     .progress
                     .total_sources
@@ -802,12 +802,6 @@ fn bounded_dynamic_text(value: &str) -> String {
         end -= 1;
     }
     format!("{}{}", &value[..end], SUFFIX)
-}
-
-fn format_count_u64(value: u64) -> String {
-    usize::try_from(value)
-        .map(format_count)
-        .unwrap_or_else(|_| value.to_string())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- consolidate human-readable CLI count rendering on the existing `ctx_terminal::format_count(u64)` authority
- remove local `format_count_u64` and `grouped_count` adapters from presentation, daemon status, and refresh progress code
- preserve supported-platform output, pluralization, public APIs, manifests, and release behavior

This exact-current-main replacement supersedes stale PR #710; the older PR remains untouched.

Net change: 6 files, 33 additions, 82 deletions (`-49`).

## Exact candidate

- Head: `19b21686175144e10679ebe3deba899191a7eb1f`
- Tree: `a327b2208e33671547edb7717df034353c8f385d`
- Sole parent/base: `076fb90a177d265d2e56f7f704098e679462b784`
- Base tree: `419676fecf09f0836fd2e30a025d65eb31e81f63`
- Stable patch ID: `e02c016c0264ebfaceefe0a5590f5a8f34ccdb33`

## Validation

- Four focused Bazel libraries built with CI/Clippy configuration.
- Six focused test targets passed.
- Affected suite: 60/60 targets passed.
- `git diff --check` passed.