### PR TITLE
fix(semantic): enable CUDA on WSL and report backend

### DIFF
--- a/crates/ctx-daemon-cli/src/daemon_status/render.rs
+++ b/crates/ctx-daemon-cli/src/daemon_status/render.rs
@@ -293,22 +293,22 @@ pub(crate) fn render_daemon_status_human(
             semantic_state(semantic, runtime_active, semantic_fallback);
         let mut semantic_fields = vec![state_field("Status", semantic_state, semantic_token)];
         let mut semantic_details = Vec::new();
+        let runtime = semantic.and_then(|job| job.get("embedding_runtime"));
+        if let Some(backend) = runtime
+            .and_then(|runtime| runtime.get("backend"))
+            .and_then(Value::as_str)
+            .filter(|backend| !backend.is_empty())
+        {
+            semantic_details.push(("Backend", humanize_code(backend)));
+        }
+        if let Some(compute) = runtime
+            .and_then(|runtime| runtime.get("compute_mode"))
+            .and_then(Value::as_str)
+            .filter(|compute| !compute.is_empty())
+        {
+            semantic_details.push(("Compute", humanize_code(compute)));
+        }
         if let Some(fallback) = semantic_fallback {
-            let runtime = semantic.and_then(|job| job.get("embedding_runtime"));
-            if let Some(backend) = runtime
-                .and_then(|runtime| runtime.get("backend"))
-                .and_then(Value::as_str)
-                .filter(|backend| !backend.is_empty())
-            {
-                semantic_details.push(("Backend", humanize_code(backend)));
-            }
-            if let Some(compute) = runtime
-                .and_then(|runtime| runtime.get("compute_mode"))
-                .and_then(Value::as_str)
-                .filter(|compute| !compute.is_empty())
-            {
-                semantic_details.push(("Compute", humanize_code(compute)));
-            }
             semantic_details.push(("Fallback", humanize_code(fallback)));
         }
         if let Some(reason) = semantic

--- a/crates/ctx-daemon-cli/src/daemon_status/tests.rs
+++ b/crates/ctx-daemon-cli/src/daemon_status/tests.rs
@@ -126,7 +126,9 @@ fn running_status_is_outcome_first_and_omits_internal_details() {
         "Sources  1,248 certified sources\n",
         "\n",
         "Semantic\n",
-        "Status  active\n",
+        "Status   active\n",
+        "Backend  cuda\n",
+        "Compute  accelerated\n",
     );
     assert_exact_cross_width(
         |context| render_status(context, &running_report()),
@@ -145,7 +147,9 @@ fn running_status_is_outcome_first_and_omits_internal_details() {
                     "         sources\n",
                     "\n",
                     "Semantic\n",
-                    "Status  active\n",
+                    "Status   active\n",
+                    "Backend  cuda\n",
+                    "Compute  accelerated\n",
                 ),
             ),
             (48, wide),
@@ -163,7 +167,9 @@ fn running_status_is_outcome_first_and_omits_internal_details() {
             "\u{1b}[2mSources\u{1b}[0m  1,248 certified sources\n",
             "\n",
             "\u{1b}[1mSemantic\u{1b}[0m\n",
-            "\u{1b}[2mStatus\u{1b}[0m  \u{1b}[32mactive\u{1b}[0m\n",
+            "\u{1b}[2mStatus\u{1b}[0m   \u{1b}[32mactive\u{1b}[0m\n",
+            "\u{1b}[2mBackend\u{1b}[0m  cuda\n",
+            "\u{1b}[2mCompute\u{1b}[0m  accelerated\n",
         ),
     );
 
@@ -174,8 +180,6 @@ fn running_status_is_outcome_first_and_omits_internal_details() {
         "internal-lock-owner",
         "internal-endpoint",
         "daemon_scheduler",
-        "cuda",
-        "accelerated",
     ] {
         assert!(
             !rendered.contains(omitted),

--- a/crates/ctx-daemon-cli/src/paths_status.rs
+++ b/crates/ctx-daemon-cli/src/paths_status.rs
@@ -158,6 +158,9 @@ fn daemon_semantic_job_report(
     } else {
         last_run_reason.clone()
     };
+    let embedding_runtime = (context.daemon_running && context.semantic_runtime_active)
+        .then(|| crate::query_service::daemon_query_service_embedding_runtime(data_root))
+        .flatten();
     compact_json(json!({
         "status": status,
         "enabled": enabled,
@@ -192,6 +195,7 @@ fn daemon_semantic_job_report(
         "model_key": status_value
             .as_ref()
             .and_then(|value| json_string(value, "model_key")),
+        "embedding_runtime": embedding_runtime,
         "daemon_mode": context.daemon_mode.as_str(),
     }))
 }

--- a/crates/ctx-daemon-cli/src/query_service.rs
+++ b/crates/ctx-daemon-cli/src/query_service.rs
@@ -11,20 +11,34 @@ use crate::compact_json;
 pub(crate) use ctx_daemon_service::daemon_query_request;
 
 pub(crate) fn daemon_query_service_available(data_root: &Path) -> bool {
-    daemon_query_service_ping(data_root).unwrap_or(false)
+    daemon_query_service_ping(data_root)
+        .is_ok_and(|response| response.is_some_and(|value| response_ok(&value)))
 }
 
-fn daemon_query_service_ping(data_root: &Path) -> Result<bool> {
-    let response = daemon_query_request(
+fn daemon_query_service_ping(data_root: &Path) -> Result<Option<Value>> {
+    daemon_query_request(
         data_root,
         compact_json(json!({"schema_version": 1, "op": "ping"})),
         Duration::from_secs(1),
         1024,
-    )?;
-    Ok(response
-        .as_ref()
-        .and_then(|value: &Value| value.get("ok").and_then(Value::as_bool))
-        == Some(true))
+    )
+}
+
+fn response_ok(response: &Value) -> bool {
+    response.get("ok").and_then(Value::as_bool) == Some(true)
+}
+
+pub(crate) fn daemon_query_service_embedding_runtime(data_root: &Path) -> Option<Value> {
+    daemon_query_service_ping(data_root)
+        .ok()
+        .flatten()
+        .filter(response_ok)
+        .and_then(|response| {
+            response
+                .get("embedding_runtime")
+                .filter(|value| value.is_object())
+                .cloned()
+        })
 }
 
 pub fn wait_for_daemon_query_service(data_root: &Path, timeout: Duration) -> bool {

--- a/crates/ctx-semantic-model/src/model_runtime/onnx.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/onnx.rs
@@ -436,11 +436,21 @@ pub(super) fn semantic_onnxruntime_candidates(
 
 #[cfg(all(ctx_semantic_fastembed, target_os = "linux", target_arch = "x86_64"))]
 pub(super) fn nvidia_accelerator_present() -> bool {
-    nvidia_accelerator_present_in(Path::new("/proc"), Path::new("/sys"))
+    nvidia_accelerator_present_in(
+        Path::new("/proc"),
+        Path::new("/sys"),
+        Path::new("/dev"),
+        Path::new("/usr/lib/wsl/lib"),
+    )
 }
 
 #[cfg(any(all(target_os = "linux", target_arch = "x86_64"), test))]
-fn nvidia_accelerator_present_in(proc_root: &Path, sys_root: &Path) -> bool {
+fn nvidia_accelerator_present_in(
+    proc_root: &Path,
+    sys_root: &Path,
+    dev_root: &Path,
+    wsl_driver_root: &Path,
+) -> bool {
     proc_root.join("driver/nvidia/version").is_file()
         || sys_root.join("module/nvidia").is_dir()
         || fs::read_dir(sys_root.join("class/drm")).is_ok_and(|entries| {
@@ -449,6 +459,7 @@ fn nvidia_accelerator_present_in(proc_root: &Path, sys_root: &Path) -> bool {
                     .is_ok_and(|vendor| vendor.trim().eq_ignore_ascii_case("0x10de"))
             })
         })
+        || (dev_root.join("dxg").exists() && wsl_driver_root.join("libnvidia-ml.so.1").is_file())
 }
 
 #[cfg(ctx_semantic_fastembed)]
@@ -559,14 +570,61 @@ mod ort_runtime_tests {
         let temp = tempfile::tempdir().unwrap();
         let proc_root = temp.path().join("proc");
         let sys_root = temp.path().join("sys");
+        let dev_root = temp.path().join("dev");
+        let wsl_driver_root = temp.path().join("usr/lib/wsl/lib");
         fs::create_dir_all(proc_root.join("driver/nvidia")).unwrap();
         fs::write(proc_root.join("driver/nvidia/version"), b"test").unwrap();
-        assert!(nvidia_accelerator_present_in(&proc_root, &sys_root));
+        assert!(nvidia_accelerator_present_in(
+            &proc_root,
+            &sys_root,
+            &dev_root,
+            &wsl_driver_root,
+        ));
 
         fs::remove_file(proc_root.join("driver/nvidia/version")).unwrap();
         fs::create_dir_all(sys_root.join("class/drm/card0/device")).unwrap();
         fs::write(sys_root.join("class/drm/card0/device/vendor"), b"0x10de\n").unwrap();
-        assert!(nvidia_accelerator_present_in(&proc_root, &sys_root));
+        assert!(nvidia_accelerator_present_in(
+            &proc_root,
+            &sys_root,
+            &dev_root,
+            &wsl_driver_root,
+        ));
+    }
+
+    #[test]
+    fn nvidia_probe_requires_wsl_gpu_and_nvidia_evidence() {
+        let temp = tempfile::tempdir().unwrap();
+        let proc_root = temp.path().join("proc");
+        let sys_root = temp.path().join("sys");
+        let dev_root = temp.path().join("dev");
+        let wsl_driver_root = temp.path().join("usr/lib/wsl/lib");
+        fs::create_dir_all(&dev_root).unwrap();
+        fs::write(dev_root.join("dxg"), b"test").unwrap();
+        assert!(!nvidia_accelerator_present_in(
+            &proc_root,
+            &sys_root,
+            &dev_root,
+            &wsl_driver_root,
+        ));
+
+        fs::remove_file(dev_root.join("dxg")).unwrap();
+        fs::create_dir_all(&wsl_driver_root).unwrap();
+        fs::write(wsl_driver_root.join("libnvidia-ml.so.1"), b"test").unwrap();
+        assert!(!nvidia_accelerator_present_in(
+            &proc_root,
+            &sys_root,
+            &dev_root,
+            &wsl_driver_root,
+        ));
+
+        fs::write(dev_root.join("dxg"), b"test").unwrap();
+        assert!(nvidia_accelerator_present_in(
+            &proc_root,
+            &sys_root,
+            &dev_root,
+            &wsl_driver_root,
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- recognize WSL2 GPU forwarding as NVIDIA acceleration evidence
- expose the active semantic backend and compute mode in `ctx status`
- preserve native Linux detection and avoid daemon pings when semantic runtime is inactive

## Validation

- `scripts/bazel-affected.sh origin/main` (86/86)
- focused semantic-model, daemon-cli, and rustfmt checks

Fixes #717