### PR TITLE
fix(history): shrink source ownership failure state

### DIFF
--- a/crates/ctx-history-capture-composition/src/source_backed/publication.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/publication.rs
@@ -65,6 +65,7 @@ use ownership::source_owner_covers_base_source;
 use ownership::{
     automatic_carried_route_retirements, capture_staged_source_route_revalidation_receipts,
     require_complete_base_source_ownership, revalidate_staged_source_route,
+    BaseSourceOwnershipEvidence,
 };
 
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/ctx-history-capture-composition/src/source_backed/publication/execution.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/publication/execution.rs
@@ -371,11 +371,13 @@ pub(super) fn refresh_source_backed_generation_with_detailed_progress_and_discov
             registry,
             &owners,
             &complete_inventory_owners,
-            &attempt_carried,
-            &partial_routes,
-            &successful_this_attempt,
-            &failed_routes,
-            &logical_source_failures,
+            BaseSourceOwnershipEvidence {
+                carried_routes: &attempt_carried,
+                partial_routes: &partial_routes,
+                successful_routes: &successful_this_attempt,
+                failed_routes: &failed_routes,
+                logical_source_failures: &logical_source_failures,
+            },
         )?;
 
         let has_carried_source = lifecycle.base_snapshot().is_some_and(|base| {

--- a/crates/ctx-history-capture-composition/src/source_backed/publication/ownership.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/publication/ownership.rs
@@ -168,16 +168,20 @@ fn route_callback(
     result.map_err(|source| SourceBackedCoordinatorError::RouteScan { provider, source })
 }
 
+pub(super) struct BaseSourceOwnershipEvidence<'a> {
+    pub(super) carried_routes: &'a BTreeSet<SourceRouteIdentity>,
+    pub(super) partial_routes: &'a BTreeSet<SourceRouteIdentity>,
+    pub(super) successful_routes: &'a BTreeSet<SourceRouteIdentity>,
+    pub(super) failed_routes: &'a BTreeMap<SourceRouteIdentity, SourceBackedFailedRoute>,
+    pub(super) logical_source_failures: &'a SourceBackedLogicalSourceFailures,
+}
+
 pub(super) fn require_complete_base_source_ownership(
     lifecycle: &impl CaptureLifecycleSink<Error = IndexError>,
     registry: &SourceBackedProviderRegistry,
     owners: &HashMap<[u8; 32], SourceOwner>,
     complete_inventory_owners: &[CompleteInventoryOwner],
-    carried_routes: &BTreeSet<SourceRouteIdentity>,
-    partial_routes: &BTreeSet<SourceRouteIdentity>,
-    successful_routes: &BTreeSet<SourceRouteIdentity>,
-    failed_routes: &BTreeMap<SourceRouteIdentity, SourceBackedFailedRoute>,
-    logical_source_failures: &SourceBackedLogicalSourceFailures,
+    evidence: BaseSourceOwnershipEvidence<'_>,
 ) -> SourceBackedCoordinatorResult<()> {
     let Some(base) = lifecycle.base_snapshot() else {
         return Ok(());
@@ -188,8 +192,8 @@ pub(super) fn require_complete_base_source_ownership(
                 && route.metadata.route_identity.as_ref() == Some(snapshot.route_identity())
         });
         if covered_by_missing_route
-            || carried_routes.contains(snapshot.route_identity())
-            || partial_routes.contains(snapshot.route_identity())
+            || evidence.carried_routes.contains(snapshot.route_identity())
+            || evidence.partial_routes.contains(snapshot.route_identity())
             || registry
                 .provider_root_route_retirements
                 .contains(snapshot.route_identity())
@@ -208,7 +212,7 @@ pub(super) fn require_complete_base_source_ownership(
                         .and_then(|route| route.metadata.route_identity.as_ref()),
                     None => Some(snapshot.route_identity()),
                 }
-                .filter(|route_identity| successful_routes.contains(*route_identity))
+                .filter(|route_identity| evidence.successful_routes.contains(*route_identity))
                 .cloned()
                 .ok_or_else(|| {
                     SourceBackedCoordinatorError::Index(index_writer_invariant(
@@ -218,11 +222,12 @@ pub(super) fn require_complete_base_source_ownership(
                 return Err(SourceBackedCoordinatorError::UnclaimedBaseSource {
                     source_id: source.identity().to_string(),
                     route_identity,
-                    route_failures: failed_routes
+                    route_failures: evidence
+                        .failed_routes
                         .values()
                         .map(SourceBackedFailedRouteOutcome::from)
                         .collect(),
-                    logical_source_failures: logical_source_failures.clone(),
+                    logical_source_failures: Box::new(evidence.logical_source_failures.clone()),
                 });
             }
         }

--- a/crates/ctx-history-capture-runtime/src/source_backed/driver.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/driver.rs
@@ -204,7 +204,7 @@ where
         source_id: String,
         route_identity: SourceRouteIdentity,
         route_failures: Vec<SourceBackedFailedRouteOutcome>,
-        logical_source_failures: SourceBackedLogicalSourceFailures,
+        logical_source_failures: Box<SourceBackedLogicalSourceFailures>,
     },
     #[error("source deletion was not certified by its supplied authoritative inventory")]
     InvalidDeletionWitness,

--- a/crates/ctx-history-refresh/src/engine/attempt_helpers/tests.rs
+++ b/crates/ctx-history-refresh/src/engine/attempt_helpers/tests.rs
@@ -42,7 +42,7 @@ fn unclaimed_base_source_is_terminal_and_not_retryable() {
         source_id: "fixture-source".into(),
         route_identity: route.clone(),
         route_failures: Vec::new(),
-        logical_source_failures: Default::default(),
+        logical_source_failures: Box::default(),
     }
     .into();
 
@@ -78,7 +78,7 @@ fn unclaimed_base_source_preserves_peer_route_dispositions() {
         source_id: "fixture-source".into(),
         route_identity: culprit.clone(),
         route_failures: vec![(&failed_route).into()],
-        logical_source_failures: Default::default(),
+        logical_source_failures: Box::default(),
     }
     .into();
 


### PR DESCRIPTION
## Summary

- box bounded logical-source diagnostics on the cold unclaimed-source error path
- group related ownership evidence into one borrowed input
- preserve retry classification and payload contents while restoring strict Clippy compatibility

## Validation

- affected Clippy targets pass on `092a8a58`
- affected Bazel unit suites pass: 4/4
- `scripts/check.sh --mode=ci` passed 214/214 test targets on the same patch before the base advanced
- on the latest base, the full gate reaches an unrelated Clippy failure in `ctx-history-index` introduced by #754; this PR does not touch that code