### PR TITLE
fix(history): preserve SQLite import file headroom

### DIFF
--- a/crates/ctx-history-capture-runtime/src/source_backed/document.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/document.rs
@@ -501,7 +501,7 @@ where
         move |source| owns_adapter.owns_source(source),
         move |target| revalidate_document_target(&source_state, target),
     )
-    .with_complete_inventory_revalidation(move |inventory| {
+    .with_fallible_complete_inventory_revalidation(move |inventory| {
         revalidate_document_inventory(inventory_adapter.as_ref(), &inventory_state, inventory)
     })
     .with_publication_revalidation(move || {

--- a/crates/ctx-history-capture-runtime/src/source_backed/document/revalidation.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/document/revalidation.rs
@@ -6,7 +6,10 @@ use std::{
 use ctx_history_core::{CertifiedSource, CertifiedSourceInventory, SourceKey};
 
 use super::super::SourceBackedRevalidationTarget;
-use super::{CompleteDocumentTree, ReplacementDocumentTree};
+use super::{
+    document_internal, CompleteDocumentTree, ReplacementDocumentTree, SourceBackedRouteErrorKind,
+    SourceBackedRouteResult,
+};
 
 pub(super) struct CurrentDocumentSources {
     ordered: Vec<SourceKey>,
@@ -190,28 +193,31 @@ pub(super) fn revalidate_document_inventory<A>(
     adapter: &A,
     state: &Mutex<DocumentCommitState<A::Leaf, A::TreeAuthority>>,
     inventory: &CertifiedSourceInventory,
-) -> bool
+) -> SourceBackedRouteResult<bool>
 where
     A: ReplacementDocumentTree,
 {
-    let Ok(state) = state.lock() else {
-        return false;
-    };
+    let state = state
+        .lock()
+        .map_err(|_| document_internal("document commit state lock was poisoned"))?;
     let Some(expected) = state.expected.as_ref() else {
-        return false;
+        return Ok(false);
     };
     if expected.inventory != *inventory {
-        return false;
+        return Ok(false);
     }
 
     // Source and deletion callbacks only bind writer targets to this expected
     // route. The final inventory callback owns the one live terminal tree
     // observation, so changes between callbacks cannot inherit an earlier
     // successful result.
-    adapter
-        .revalidate_complete(&expected.tree)
-        .is_ok_and(|terminal| terminal == expected.tree.tree_fingerprint)
-        && revalidate_durable_replay_sources(adapter, &expected.tree)
+    let terminal = match adapter.revalidate_complete(&expected.tree) {
+        Ok(terminal) => terminal,
+        Err(error) if error.kind == SourceBackedRouteErrorKind::SourceChanged => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    Ok(terminal == expected.tree.tree_fingerprint
+        && revalidate_durable_replay_sources(adapter, &expected.tree))
 }
 
 pub(super) fn revalidate_durable_replay_sources<A>(

--- a/crates/ctx-history-capture-runtime/src/source_backed/parallel/tests/document_lifecycle.rs
+++ b/crates/ctx-history-capture-runtime/src/source_backed/parallel/tests/document_lifecycle.rs
@@ -65,6 +65,7 @@ struct LifecycleState {
     peak_scans: usize,
     mutate_before_scan: Option<u8>,
     mutate_on_revalidate: bool,
+    terminal_failure: Option<SourceBackedRouteErrorKind>,
     unavailable_leaf: Option<u8>,
     append_base: Option<CertifiedSource>,
 }
@@ -421,6 +422,12 @@ impl ReplacementDocumentTree for LifecycleAdapter {
         tree: &CompleteDocumentTree<Self::Leaf, Self::TreeAuthority>,
     ) -> SourceBackedRouteResult<[u8; 32]> {
         let mut state = self.state.lock().unwrap();
+        if let Some(kind) = state.terminal_failure {
+            return Err(SourceBackedRouteError::new(
+                kind,
+                "injected document terminal failure",
+            ));
+        }
         if state.mutate_on_revalidate {
             state.leaves[0].revision = state.leaves[0].revision.saturating_add(1);
             state.mutate_on_revalidate = false;
@@ -990,4 +997,28 @@ fn active_source_family_contract_document_races_duplicates_and_terminal_inventor
         .revalidate_complete_inventory(&inventory)
         .unwrap()
         .unwrap());
+
+    let changed = LifecycleAdapter::new(vec![leaf(21)]);
+    let driver = changed.driver();
+    let mut scanned = SinkHarness::open(Path::new("/unused"));
+    driver.scan(&mut scanned.sink()).unwrap();
+    changed.state.lock().unwrap().terminal_failure =
+        Some(SourceBackedRouteErrorKind::SourceChanged);
+    let inventory = scanned.complete_inventories[0].inventory.clone();
+    assert!(!driver
+        .revalidate_complete_inventory(&inventory)
+        .unwrap()
+        .unwrap());
+
+    let internal = LifecycleAdapter::new(vec![leaf(22)]);
+    let driver = internal.driver();
+    let mut scanned = SinkHarness::open(Path::new("/unused"));
+    driver.scan(&mut scanned.sink()).unwrap();
+    internal.state.lock().unwrap().terminal_failure = Some(SourceBackedRouteErrorKind::Internal);
+    let inventory = scanned.complete_inventories[0].inventory.clone();
+    let error = driver
+        .revalidate_complete_inventory(&inventory)
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(error.kind, SourceBackedRouteErrorKind::Internal);
 }

--- a/crates/ctx-history-index/src/writer_open.rs
+++ b/crates/ctx-history-index/src/writer_open.rs
@@ -17,6 +17,7 @@ impl GenerationWriter {
         root: impl AsRef<Path>,
         options: WriterOptions,
     ) -> Result<GenerationWriterOpenOutcome> {
+        ctx_history_platform::raise_open_file_soft_limit();
         let indexer_threads = options.indexer_threads.clamp(1, 8);
         let minimum = INDEX_MEMORY_MIN_PER_THREAD.saturating_mul(indexer_threads);
         if options.memory_bytes < minimum {
@@ -459,5 +460,93 @@ impl GenerationWriter {
             });
         }
         Ok(Some(ExactReplayInventoryWitness { base }))
+    }
+}
+
+#[cfg(all(test, unix))]
+mod process_resource_tests {
+    use std::{env, fs::File, process::Command};
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    const CHILD_ENV: &str = "CTX_TEST_GENERATION_WRITER_OPEN_FILE_LIMIT_CHILD";
+    const LOW_SOFT_LIMIT: libc::rlim_t = 64;
+    const EXPECTED_SOFT_LIMIT_TARGET: libc::rlim_t = 4_096;
+
+    #[test]
+    fn generation_writer_open_raises_child_open_file_limit_before_staging() {
+        if env::var_os(CHILD_ENV).is_some() {
+            run_open_file_limit_child();
+            return;
+        }
+
+        let parent_limits_before = open_file_limits();
+        assert!(
+            parent_limits_before.1 > LOW_SOFT_LIMIT,
+            "regression requires a hard open-file limit above {LOW_SOFT_LIMIT}"
+        );
+        let status = Command::new(env::current_exe().unwrap())
+            .arg("--exact")
+            .arg(
+                "writer_open::process_resource_tests::generation_writer_open_raises_child_open_file_limit_before_staging",
+            )
+            .arg("--nocapture")
+            .env(CHILD_ENV, "1")
+            .status()
+            .unwrap();
+        assert!(status.success(), "open-file limit child failed: {status}");
+        assert_eq!(open_file_limits(), parent_limits_before);
+    }
+
+    fn run_open_file_limit_child() {
+        let root = tempdir().unwrap();
+        let inherited = open_file_limits();
+        assert!(inherited.1 > LOW_SOFT_LIMIT);
+        let lowered = libc::rlimit {
+            rlim_cur: LOW_SOFT_LIMIT,
+            rlim_max: inherited.1,
+        };
+        assert_eq!(
+            unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &raw const lowered) },
+            0,
+            "failed to lower only the child open-file soft limit: {}",
+            std::io::Error::last_os_error()
+        );
+        assert_eq!(open_file_limits(), (LOW_SOFT_LIMIT, inherited.1));
+
+        let mut retained_files = Vec::new();
+        loop {
+            match File::open("/dev/null") {
+                Ok(file) => retained_files.push(file),
+                Err(error) => {
+                    assert_eq!(error.raw_os_error(), Some(libc::EMFILE));
+                    break;
+                }
+            }
+        }
+
+        let outcome =
+            GenerationWriter::open(root.path().join("index"), WriterOptions::default()).unwrap();
+        let raised = open_file_limits();
+        assert_eq!(raised.1, inherited.1);
+        assert_eq!(raised.0, inherited.1.min(EXPECTED_SOFT_LIMIT_TARGET));
+        drop(outcome);
+        drop(retained_files);
+    }
+
+    fn open_file_limits() -> (libc::rlim_t, libc::rlim_t) {
+        let mut limits = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        assert_eq!(
+            unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &raw mut limits) },
+            0,
+            "failed to read the open-file limit: {}",
+            std::io::Error::last_os_error()
+        );
+        (limits.rlim_cur, limits.rlim_max)
     }
 }

--- a/crates/ctx-history-platform/src/lib.rs
+++ b/crates/ctx-history-platform/src/lib.rs
@@ -12,10 +12,12 @@ pub type Result<T> = std::result::Result<T, PlatformError>;
 
 pub mod paths;
 pub mod platform_security;
+mod process_resources;
 
 pub use paths::{
     config_path, default_data_root, device_path, history_dir, logs_dir, managed_data_root,
 };
+pub use process_resources::raise_open_file_soft_limit;
 
 #[cfg(test)]
 mod tests;

--- a/crates/ctx-history-platform/src/process_resources.rs
+++ b/crates/ctx-history-platform/src/process_resources.rs
@@ -1,0 +1,68 @@
+//! Best-effort process resource headroom for bounded ctx operations.
+
+#[cfg(unix)]
+use std::sync::Mutex;
+
+#[cfg(unix)]
+const OPEN_FILE_SOFT_LIMIT_TARGET: libc::rlim_t = 4_096;
+
+#[cfg(unix)]
+static OPEN_FILE_LIMIT_LOCK: Mutex<()> = Mutex::new(());
+
+/// Best-effort raises the process open-file soft limit to bounded headroom.
+///
+/// Unix raises are capped by the existing hard limit. Failures are ignored so
+/// environments that prohibit `setrlimit` can still run imports that fit their
+/// configured limit. Other platforms require no process-level adjustment.
+pub fn raise_open_file_soft_limit() {
+    #[cfg(unix)]
+    raise_unix_open_file_soft_limit();
+}
+
+#[cfg(unix)]
+fn raise_unix_open_file_soft_limit() {
+    let _guard = match OPEN_FILE_LIMIT_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let mut limits = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &raw mut limits) } != 0 {
+        return;
+    }
+    let Some(raised_soft_limit) = raised_open_file_soft_limit(limits.rlim_cur, limits.rlim_max)
+    else {
+        return;
+    };
+    limits.rlim_cur = raised_soft_limit;
+    let _ = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &raw const limits) };
+}
+
+#[cfg(unix)]
+fn raised_open_file_soft_limit(
+    current_soft_limit: libc::rlim_t,
+    hard_limit: libc::rlim_t,
+) -> Option<libc::rlim_t> {
+    let target = hard_limit.min(OPEN_FILE_SOFT_LIMIT_TARGET);
+    (current_soft_limit < target).then_some(target)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_file_soft_limit_raise_is_capped_by_the_hard_limit() {
+        assert_eq!(raised_open_file_soft_limit(64, 1_024), Some(1_024));
+        assert_eq!(raised_open_file_soft_limit(64, 8_192), Some(4_096));
+    }
+
+    #[test]
+    fn open_file_soft_limit_raise_never_lowers_or_exceeds_a_fixed_limit() {
+        assert_eq!(raised_open_file_soft_limit(64, 64), None);
+        assert_eq!(raised_open_file_soft_limit(4_096, 8_192), None);
+        assert_eq!(raised_open_file_soft_limit(8_192, 8_192), None);
+    }
+}


### PR DESCRIPTION
## Summary

- Raise the Unix open-file soft limit to bounded headroom before lexical index staging.
- Preserve typed terminal revalidation failures; only a genuine source change is treated as route invalidation.
- Add regressions for typed error propagation and descriptor exhaustion before writer open.

## Root cause

Large imports could consume the macOS default 256-descriptor soft limit while Tantivy staged the index. The final SQLite identity check then failed to retain one more capability with EMFILE. The callback collapsed that resource error to false, so the coordinator misleadingly reported that the source route changed.

## Validation

- Reproduced the terminal failure with a 5,247-session, 475,998-record OpenCode fixture under a 64-descriptor limit; the same fixture passes with this fix.
- Focused runtime, composition, platform, and index tests pass.
- All 120 current-main affected targets pass, including formatting and policy gates.
- macOS x64 targeted tests pass at the native soft=256, hard=unlimited limits.
- Independent final review found no issues and marked the change merge-ready.

Fixes #755