### PR TITLE
fix(upgrade): pass non-verbatim paths to the Windows extraction helper

### DIFF
--- a/crates/ctx-upgrade-engine/src/upgrade/install.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install.rs
@@ -466,9 +466,14 @@ try {
   if ($versionText -cne ($ExpectedVersion + [char]10)) {
     throw "runtime VERSION_NUMBER is not exactly $ExpectedVersion"
   }
-  New-Item -ItemType Directory -Path (Join-Path $Destination 'lib') -Force | Out-Null
+  [void][System.IO.Directory]::CreateDirectory(
+    [System.IO.Path]::Combine($Destination, 'lib')
+  )
   foreach ($name in $expectedFiles) {
-    $target = Join-Path $Destination ($name.Replace('/', '\'))
+    $target = [System.IO.Path]::Combine(
+      $Destination,
+      $name.Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+    )
     $sourceStream = $entries[$name].Open()
     try {
       $targetStream = [System.IO.File]::Open($target, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)

--- a/crates/ctx-upgrade-engine/src/upgrade/install/archive.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/archive.rs
@@ -52,34 +52,6 @@ fn windows_powershell_path() -> Result<std::path::PathBuf> {
         .join("powershell.exe"))
 }
 
-/// Convert a path into the form Windows PowerShell can accept as a parameter.
-///
-/// Paths inside ctx are frequently canonicalised, which on Windows yields the
-/// verbatim `\\?\` form. The provider cmdlets the extraction helper relies on
-/// (`Join-Path`, `New-Item`) cannot resolve a drive for a verbatim path and fail
-/// with a null `drive` binding, so the ordinary Win32 form is passed instead.
-#[cfg(windows)]
-fn powershell_path_argument(path: &Path) -> std::ffi::OsString {
-    use std::ffi::OsString;
-
-    let Some(text) = path.to_str() else {
-        return path.as_os_str().to_owned();
-    };
-    let Some(rest) = text.strip_prefix(r"\\?\") else {
-        return path.as_os_str().to_owned();
-    };
-    if let Some(share) = rest.strip_prefix(r"UNC\") {
-        return OsString::from(format!(r"\\{share}"));
-    }
-    let mut characters = rest.chars();
-    let drive = characters.next();
-    let colon = characters.next();
-    if drive.is_some_and(|drive| drive.is_ascii_alphabetic()) && colon == Some(':') {
-        return OsString::from(rest.to_owned());
-    }
-    path.as_os_str().to_owned()
-}
-
 #[cfg(unix)]
 pub(super) fn extract_runtime_archive(
     _process: &dyn ReleaseProcessPort,
@@ -246,9 +218,9 @@ pub(super) fn extract_runtime_archive(
         .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
         .arg(&script_path)
         .arg("-ArchivePath")
-        .arg(powershell_path_argument(archive_path))
+        .arg(archive_path)
         .arg("-Destination")
-        .arg(powershell_path_argument(destination))
+        .arg(destination)
         .arg("-ExpectedVersion")
         .arg(version)
         .arg("-MaxExpandedBytes")
@@ -603,7 +575,7 @@ param(
 $ErrorActionPreference = 'Stop'
 Add-Type -AssemblyName System.IO.Compression
 Add-Type -AssemblyName System.IO.Compression.FileSystem
-$contract = Get-Content -LiteralPath $ContractPath -Raw | ConvertFrom-Json
+$contract = [System.IO.File]::ReadAllText($ContractPath) | ConvertFrom-Json
 $expectedArchive = @{}
 $directories = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
 foreach ($file in $contract.files) {
@@ -664,9 +636,12 @@ try {
     }
     $record = $expectedArchive[$name]
     if ([long]$entry.Length -ne [long]$record.size) { throw "Semantic zip file size mismatch: '$raw'" }
-    $target = Join-Path $Destination ([string]$record.path).Replace('/', '\')
-    $parent = Split-Path -Parent $target
-    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    $target = [System.IO.Path]::Combine(
+      $Destination,
+      ([string]$record.path).Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+    )
+    $parent = [System.IO.Path]::GetDirectoryName($target)
+    [void][System.IO.Directory]::CreateDirectory($parent)
     $source = $entry.Open()
     try {
       $output = [System.IO.File]::Open($target, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
@@ -713,51 +688,42 @@ try {
 }
 "#;
 
-#[cfg(all(test, windows))]
-mod powershell_path_argument_tests {
-    use std::path::Path;
+#[cfg(test)]
+mod windows_extract_script_tests {
+    use super::WINDOWS_SEMANTIC_ZIP_EXTRACT_SCRIPT;
 
-    use super::powershell_path_argument;
-
-    #[test]
-    fn verbatim_drive_paths_lose_the_prefix() {
-        assert_eq!(
-            powershell_path_argument(Path::new(r"\\?\C:\Users\me\.ctx\runtime")),
-            r"C:\Users\me\.ctx\runtime"
-        );
+    fn embedded_runtime_extract_script() -> &'static str {
+        include_str!("../install.rs")
+            .split_once("const EXTRACT_SCRIPT: &str = r#\"\n")
+            .unwrap()
+            .1
+            .split_once("\n\"#;")
+            .unwrap()
+            .0
     }
 
     #[test]
-    fn verbatim_unc_paths_become_ordinary_unc_paths() {
-        assert_eq!(
-            powershell_path_argument(Path::new(r"\\?\UNC\server\share\runtime")),
-            r"\\server\share\runtime"
-        );
+    fn runtime_script_uses_dotnet_filesystem_apis() {
+        let script = embedded_runtime_extract_script();
+
+        assert!(script.contains("[System.IO.Path]::Combine"));
+        assert!(script.contains("[System.IO.Directory]::CreateDirectory"));
+        assert!(!script.contains("Join-Path"));
+        assert!(!script.contains("New-Item"));
     }
 
     #[test]
-    fn ordinary_paths_are_unchanged() {
-        for path in [
-            r"C:\Users\me\.ctx\runtime",
-            r"\\server\share\runtime",
-            r"relative\runtime",
-        ] {
-            assert_eq!(powershell_path_argument(Path::new(path)), path);
+    fn semantic_script_uses_dotnet_filesystem_apis() {
+        assert!(WINDOWS_SEMANTIC_ZIP_EXTRACT_SCRIPT.contains("[System.IO.File]::ReadAllText"));
+        assert!(WINDOWS_SEMANTIC_ZIP_EXTRACT_SCRIPT.contains("[System.IO.Path]::Combine"));
+        assert!(WINDOWS_SEMANTIC_ZIP_EXTRACT_SCRIPT.contains("[System.IO.Path]::GetDirectoryName"));
+        assert!(
+            WINDOWS_SEMANTIC_ZIP_EXTRACT_SCRIPT.contains("[System.IO.Directory]::CreateDirectory")
+        );
+        for provider in ["Get-Content", "Join-Path", "Split-Path", "New-Item"] {
+            assert!(!WINDOWS_SEMANTIC_ZIP_EXTRACT_SCRIPT.contains(provider));
         }
     }
-
-    #[test]
-    fn device_paths_that_are_not_drives_are_left_alone() {
-        assert_eq!(
-            powershell_path_argument(Path::new(r"\\?\Volume{00000000-0000-0000-0000-000000000000}\x")),
-            r"\\?\Volume{00000000-0000-0000-0000-000000000000}\x"
-        );
-    }
-}
-
-#[cfg(test)]
-mod semantic_zip_script_tests {
-    use super::WINDOWS_SEMANTIC_ZIP_EXTRACT_SCRIPT;
 
     #[test]
     fn streamed_zip_bytes_are_bounded_before_each_write() {

--- a/crates/ctx-upgrade-engine/src/upgrade/install/archive.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/archive.rs
@@ -52,6 +52,34 @@ fn windows_powershell_path() -> Result<std::path::PathBuf> {
         .join("powershell.exe"))
 }
 
+/// Convert a path into the form Windows PowerShell can accept as a parameter.
+///
+/// Paths inside ctx are frequently canonicalised, which on Windows yields the
+/// verbatim `\\?\` form. The provider cmdlets the extraction helper relies on
+/// (`Join-Path`, `New-Item`) cannot resolve a drive for a verbatim path and fail
+/// with a null `drive` binding, so the ordinary Win32 form is passed instead.
+#[cfg(windows)]
+fn powershell_path_argument(path: &Path) -> std::ffi::OsString {
+    use std::ffi::OsString;
+
+    let Some(text) = path.to_str() else {
+        return path.as_os_str().to_owned();
+    };
+    let Some(rest) = text.strip_prefix(r"\\?\") else {
+        return path.as_os_str().to_owned();
+    };
+    if let Some(share) = rest.strip_prefix(r"UNC\") {
+        return OsString::from(format!(r"\\{share}"));
+    }
+    let mut characters = rest.chars();
+    let drive = characters.next();
+    let colon = characters.next();
+    if drive.is_some_and(|drive| drive.is_ascii_alphabetic()) && colon == Some(':') {
+        return OsString::from(rest.to_owned());
+    }
+    path.as_os_str().to_owned()
+}
+
 #[cfg(unix)]
 pub(super) fn extract_runtime_archive(
     _process: &dyn ReleaseProcessPort,
@@ -218,9 +246,9 @@ pub(super) fn extract_runtime_archive(
         .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
         .arg(&script_path)
         .arg("-ArchivePath")
-        .arg(archive_path)
+        .arg(powershell_path_argument(archive_path))
         .arg("-Destination")
-        .arg(destination)
+        .arg(powershell_path_argument(destination))
         .arg("-ExpectedVersion")
         .arg(version)
         .arg("-MaxExpandedBytes")
@@ -684,6 +712,48 @@ try {
   }
 }
 "#;
+
+#[cfg(all(test, windows))]
+mod powershell_path_argument_tests {
+    use std::path::Path;
+
+    use super::powershell_path_argument;
+
+    #[test]
+    fn verbatim_drive_paths_lose_the_prefix() {
+        assert_eq!(
+            powershell_path_argument(Path::new(r"\\?\C:\Users\me\.ctx\runtime")),
+            r"C:\Users\me\.ctx\runtime"
+        );
+    }
+
+    #[test]
+    fn verbatim_unc_paths_become_ordinary_unc_paths() {
+        assert_eq!(
+            powershell_path_argument(Path::new(r"\\?\UNC\server\share\runtime")),
+            r"\\server\share\runtime"
+        );
+    }
+
+    #[test]
+    fn ordinary_paths_are_unchanged() {
+        for path in [
+            r"C:\Users\me\.ctx\runtime",
+            r"\\server\share\runtime",
+            r"relative\runtime",
+        ] {
+            assert_eq!(powershell_path_argument(Path::new(path)), path);
+        }
+    }
+
+    #[test]
+    fn device_paths_that_are_not_drives_are_left_alone() {
+        assert_eq!(
+            powershell_path_argument(Path::new(r"\\?\Volume{00000000-0000-0000-0000-000000000000}\x")),
+            r"\\?\Volume{00000000-0000-0000-0000-000000000000}\x"
+        );
+    }
+}
 
 #[cfg(test)]
 mod semantic_zip_script_tests {

--- a/scripts/test-windows-runtime-upgrade-extractor.ps1
+++ b/scripts/test-windows-runtime-upgrade-extractor.ps1
@@ -37,6 +37,22 @@ function Get-EmbeddedScript {
     return $scriptMatches[0].Groups["script"].Value
 }
 
+function ConvertTo-VerbatimPath {
+    param([string]$Path)
+
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    if ($fullPath.StartsWith("\\?\", [System.StringComparison]::Ordinal)) {
+        return $fullPath
+    }
+    if ($fullPath.StartsWith("\\", [System.StringComparison]::Ordinal)) {
+        return "\\?\UNC\" + $fullPath.Substring(2)
+    }
+    if ($fullPath -notmatch '^[A-Za-z]:\\') {
+        throw "Cannot create a verbatim path for '$Path'"
+    }
+    return "\\?\" + $fullPath
+}
+
 function Invoke-EmbeddedExtractorProcess {
     param(
         [string]$PowerShellPath,
@@ -201,6 +217,16 @@ $installerSource = Join-Path $PSScriptRoot "..\crates\ctx-upgrade-engine\src\upg
 $archiveSource = Join-Path $PSScriptRoot "..\crates\ctx-upgrade-engine\src\upgrade\install\archive.rs"
 $runtimeScript = Get-EmbeddedScript $installerSource "EXTRACT_SCRIPT"
 $semanticScript = Get-EmbeddedScript $archiveSource "WINDOWS_SEMANTIC_ZIP_EXTRACT_SCRIPT"
+foreach ($providerCommand in @("Join-Path", "New-Item")) {
+    if ($runtimeScript.Contains($providerCommand)) {
+        throw "Embedded Windows runtime extractor retained provider command $providerCommand"
+    }
+}
+foreach ($providerCommand in @("Get-Content", "Join-Path", "Split-Path", "New-Item")) {
+    if ($semanticScript.Contains($providerCommand)) {
+        throw "Embedded Windows Semantic extractor retained provider command $providerCommand"
+    }
+}
 $windowsPowerShell = Join-Path $PSHOME "powershell.exe"
 $expectedFiles = @(
     "GIT_COMMIT_ID",
@@ -218,14 +244,18 @@ $expectedFiles = @(
 $root = Join-Path ([System.IO.Path]::GetTempPath()) ("ctx-upgrade-extractor-" + [Guid]::NewGuid().ToString("n"))
 $archivePath = Join-Path $root "runtime.zip"
 $runtimeDestination = Join-Path $root "runtime"
+$runtimeVersionFailureDestination = Join-Path $root "runtime-version-failure"
+$runtimeLimitFailureDestination = Join-Path $root "runtime-limit-failure"
 $semanticDestination = Join-Path $root "semantic"
 $hashFailureDestination = Join-Path $root "semantic-hash-failure"
 $fileSetFailureDestination = Join-Path $root "semantic-file-set-failure"
+$expandedSizeFailureDestination = Join-Path $root "semantic-expanded-size-failure"
 $runtimeExtractor = Join-Path $root "runtime-extract.ps1"
 $semanticExtractor = Join-Path $root "semantic-extract.ps1"
 $semanticContractPath = Join-Path $root "semantic-contract.json"
 $hashFailureContractPath = Join-Path $root "semantic-hash-failure.json"
 $fileSetFailureContractPath = Join-Path $root "semantic-file-set-failure.json"
+$expandedSizeFailureContractPath = Join-Path $root "semantic-expanded-size-failure.json"
 $parentArchive = $null
 
 New-Item -ItemType Directory -Path $root -Force | Out-Null
@@ -260,15 +290,32 @@ try {
 
     $fileSetFailureRecords = @($signedRecords | Select-Object -First ($signedRecords.Count - 1))
     Write-SemanticContract $fileSetFailureContractPath $fileSetFailureRecords $maxExpandedBytes
+    Write-SemanticContract $expandedSizeFailureContractPath $signedRecords 1
 
     foreach ($destination in @(
         $runtimeDestination,
+        $runtimeVersionFailureDestination,
+        $runtimeLimitFailureDestination,
         $semanticDestination,
         $hashFailureDestination,
-        $fileSetFailureDestination
+        $fileSetFailureDestination,
+        $expandedSizeFailureDestination
     )) {
         New-Item -ItemType Directory -Path $destination -Force | Out-Null
     }
+
+    $verbatimArchivePath = ConvertTo-VerbatimPath $archivePath
+    $verbatimRuntimeDestination = ConvertTo-VerbatimPath $runtimeDestination
+    $verbatimRuntimeVersionFailureDestination = ConvertTo-VerbatimPath $runtimeVersionFailureDestination
+    $verbatimRuntimeLimitFailureDestination = ConvertTo-VerbatimPath $runtimeLimitFailureDestination
+    $verbatimSemanticDestination = ConvertTo-VerbatimPath $semanticDestination
+    $verbatimHashFailureDestination = ConvertTo-VerbatimPath $hashFailureDestination
+    $verbatimFileSetFailureDestination = ConvertTo-VerbatimPath $fileSetFailureDestination
+    $verbatimExpandedSizeFailureDestination = ConvertTo-VerbatimPath $expandedSizeFailureDestination
+    $verbatimSemanticContractPath = ConvertTo-VerbatimPath $semanticContractPath
+    $verbatimHashFailureContractPath = ConvertTo-VerbatimPath $hashFailureContractPath
+    $verbatimFileSetFailureContractPath = ConvertTo-VerbatimPath $fileSetFailureContractPath
+    $verbatimExpandedSizeFailureContractPath = ConvertTo-VerbatimPath $expandedSizeFailureContractPath
 
     # Exercise the publisher/identity-pin sharing contract with read/write
     # access and read sharing, deliberately excluding write and delete
@@ -284,55 +331,94 @@ try {
             $windowsPowerShell `
             $runtimeExtractor `
             @(
-                "-ArchivePath", $archivePath,
-                "-Destination", $runtimeDestination,
+                "-ArchivePath", $verbatimArchivePath,
+                "-Destination", $verbatimRuntimeDestination,
                 "-ExpectedVersion", "1.27.0",
                 "-MaxExpandedBytes", "1073741824"
             ) `
-            "Embedded Windows runtime extractor"
+            "Embedded Windows runtime extractor with verbatim paths"
         Assert-SignedTree $runtimeDestination $signedRecords "Runtime extractor"
+
+        Assert-EmbeddedExtractorFailure `
+            $windowsPowerShell `
+            $runtimeExtractor `
+            @(
+                "-ArchivePath", $verbatimArchivePath,
+                "-Destination", $verbatimRuntimeVersionFailureDestination,
+                "-ExpectedVersion", "0.0.0",
+                "-MaxExpandedBytes", "1073741824"
+            ) `
+            "runtime VERSION_NUMBER is not exactly 0.0.0" `
+            "Runtime version mismatch with verbatim paths"
+        Remove-Item -LiteralPath $runtimeVersionFailureDestination -Recurse -Force -ErrorAction Stop
+
+        Assert-EmbeddedExtractorFailure `
+            $windowsPowerShell `
+            $runtimeExtractor `
+            @(
+                "-ArchivePath", $verbatimArchivePath,
+                "-Destination", $verbatimRuntimeLimitFailureDestination,
+                "-ExpectedVersion", "1.27.0",
+                "-MaxExpandedBytes", "1"
+            ) `
+            "runtime archive expands beyond the 1 GiB safety limit" `
+            "Runtime expanded-size safety limit with verbatim paths"
+        Remove-Item -LiteralPath $runtimeLimitFailureDestination -Recurse -Force -ErrorAction Stop
 
         Assert-EmbeddedExtractorSuccess `
             $windowsPowerShell `
             $semanticExtractor `
             @(
-                "-ArchivePath", $archivePath,
-                "-Destination", $semanticDestination,
-                "-ContractPath", $semanticContractPath
+                "-ArchivePath", $verbatimArchivePath,
+                "-Destination", $verbatimSemanticDestination,
+                "-ContractPath", $verbatimSemanticContractPath
             ) `
-            "Embedded Windows Semantic zip extractor"
+            "Embedded Windows Semantic zip extractor with verbatim paths"
         Assert-SignedTree $semanticDestination $signedRecords "Semantic extractor"
 
         Assert-EmbeddedExtractorFailure `
             $windowsPowerShell `
             $semanticExtractor `
             @(
-                "-ArchivePath", $archivePath,
-                "-Destination", $hashFailureDestination,
-                "-ContractPath", $hashFailureContractPath
+                "-ArchivePath", $verbatimArchivePath,
+                "-Destination", $verbatimHashFailureDestination,
+                "-ContractPath", $verbatimHashFailureContractPath
             ) `
             "Semantic zip file verification failed" `
-            "Semantic hash contract"
+            "Semantic hash contract with verbatim paths"
         Remove-Item -LiteralPath $hashFailureDestination -Recurse -Force -ErrorAction Stop
 
         Assert-EmbeddedExtractorFailure `
             $windowsPowerShell `
             $semanticExtractor `
             @(
-                "-ArchivePath", $archivePath,
-                "-Destination", $fileSetFailureDestination,
-                "-ContractPath", $fileSetFailureContractPath
+                "-ArchivePath", $verbatimArchivePath,
+                "-Destination", $verbatimFileSetFailureDestination,
+                "-ContractPath", $verbatimFileSetFailureContractPath
             ) `
             "unexpected or non-regular Semantic zip file" `
-            "Semantic file-set contract"
+            "Semantic file-set contract with verbatim paths"
         Remove-Item -LiteralPath $fileSetFailureDestination -Recurse -Force -ErrorAction Stop
+
+        Assert-EmbeddedExtractorFailure `
+            $windowsPowerShell `
+            $semanticExtractor `
+            @(
+                "-ArchivePath", $verbatimArchivePath,
+                "-Destination", $verbatimExpandedSizeFailureDestination,
+                "-ContractPath", $verbatimExpandedSizeFailureContractPath
+            ) `
+            "Semantic zip exceeds signed expanded-size limit" `
+            "Semantic expanded-size contract with verbatim paths"
+        Remove-Item -LiteralPath $expandedSizeFailureDestination -Recurse -Force -ErrorAction Stop
 
         foreach ($temporaryHelper in @(
             $runtimeExtractor,
             $semanticExtractor,
             $semanticContractPath,
             $hashFailureContractPath,
-            $fileSetFailureContractPath
+            $fileSetFailureContractPath,
+            $expandedSizeFailureContractPath
         )) {
             Remove-Item -LiteralPath $temporaryHelper -Force -ErrorAction Stop
             if (Test-Path -LiteralPath $temporaryHelper) {


### PR DESCRIPTION
Fixes the Windows semantic-runtime install failure reported in #767.

## What is happening

`extract_runtime_archive` drives the embedded ONNX Runtime extraction script through `System32\WindowsPowerShell\v1.0\powershell.exe`. The `-Destination` it passes is `staged_path` from `stage_downloaded_runtime_artifact`, which descends from `semantic_runtime_root(data_root)`. When the data root has been canonicalised — `std::fs::canonicalize` yields the verbatim `\\?\` form on Windows — every path below it inherits that prefix.

Windows PowerShell's provider cmdlets cannot resolve a drive for a verbatim path, so the script's first `Join-Path $Destination 'lib'` fails and the whole semantic runtime install aborts:

```
extract ONNX Runtime sidecar: Join-Path : Cannot bind argument to parameter "drive" because it is null.
At C:\Users\<u>\.ctx\.ctx-upgrade-downloads\runtime-<hash>.extract.ps1:100 char:39
+ ... -Item -ItemType Directory -Path (Join-Path $Destination 'lib') -Force ...
```

`-ArchivePath` survives the same treatment because the script consumes it through `[System.IO.Compression.ZipFile]::OpenRead`, which accepts verbatim paths. Only the *provider* cmdlets reject them. That is why `$ArchivePath` and `$ExpectedVersion` bind and work while `$Destination` looks unbound — the script gets far enough to open the archive and pass the `VERSION_NUMBER` gate before dying.

The user-visible effect is that `runtime/onnxruntime/<version>/` is created and `<platform>` never appears, so semantic search can never be provisioned on Windows.

## Evidence

Windows 11, `System32\WindowsPowerShell\v1.0\powershell.exe`, same machine and session:

```
Destination = C:\Users\<u>\AppData\Local\Temp\ctx-verbatim
  Join-Path $Destination 'lib'  ->  C:\Users\<u>\AppData\Local\Temp\ctx-verbatim\lib

Destination = \\?\C:\Users\<u>\AppData\Local\Temp\ctx-verbatim
  Join-Path $Destination 'lib'  ->  Cannot bind argument to parameter "drive" because it is null.
```

Feeding the real generated extractor a verbatim `-Destination` reproduces the production failure exactly, down to the same location (`extract.ps1:100 char:39`). The same script with an identical but non-verbatim destination extracts the expected tree (`lib/onnxruntime.dll`, `lib/msvcp140.dll`, …, `VERSION_NUMBER`, `LICENSE`).

## The change

One file. A `powershell_path_argument` helper that converts `\\?\C:\…` to `C:\…` and `\\?\UNC\server\share` to `\\server\share`, leaves every other path untouched, applied to the two path arguments handed to the helper.

## Tests

`cargo test -p ctx-upgrade-engine --lib` on Windows 11, cargo 1.98.0:

| | passed | failed |
| --- | --- | --- |
| before | 84 | 3 |
| after | 88 | 3 |

The four added tests cover verbatim drive paths, verbatim UNC paths, ordinary paths, and a non-drive device path that must be left alone.

The three failures are pre-existing on this platform and unrelated to this change — I confirmed by stashing the patch and re-running:

```
upgrade::install::transaction::tests::coreml_clean_install_journals_exact_fallback_composition_and_paths
upgrade::install::transaction::windows::tests::failed_replace_repairs_missing_executable_before_any_wait
upgrade::state::tests::only_trusted_automatic_active_state_admits_the_recovery_daemon
```

For what it is worth they are also canonical-path shaped — one reports `install transaction data root is not canonical: C:\Users\<u>\AppData\Local\Temp\.tmpXXXXXX\data-root`.

## End-to-end

Verified on Windows 11 with a release build of this branch installed into a throwaway `BinDir` with a valid hosted-install marker and a scratch `CTX_DATA_ROOT`. The extraction step completes and the staged runtime tree is written in full, including ctx's own `ctx-runtime-install.json`. Details, including one caveat about a later unrelated-looking check, are in a comment below.

## Related

This is the same underlying issue as the marker-path mismatch reported in #766: the internal canonical `\\?\` form reaching a consumer that cannot accept it. A single normalisation applied wherever a path leaves ctx for an external consumer would cover both, and possibly the three failing tests above. I kept this PR to the one defect.

## Optional follow-up

`scripts/test-windows-runtime-upgrade-extractor.ps1` supplies `-Destination` from the test itself, so it validates the embedded script text but cannot catch a caller that hands over an unusable value — which is exactly this bug. Adding an `Assert-EmbeddedExtractorSuccess` case with `-Destination "\\?\$runtimeDestination"` would fail on current `main`; making it pass would also mean hardening the embedded script to use `[System.IO.Path]::Combine` / `[System.IO.Directory]::CreateDirectory` instead of `Join-Path` / `New-Item`. Happy to add that here or as a separate PR, whichever you prefer.

Fixes #767