### PR TITLE
refactor: remove inert telemetry correlation

### DIFF
--- a/crates/ctx-cli/src/mcp.rs
+++ b/crates/ctx-cli/src/mcp.rs
@@ -106,8 +106,6 @@ impl McpUsagePort for LocalUsagePort {
             let operation = observed_mcp_product_operation(operation)?;
             let mut invocation = McpInvocation::from_operation(operation);
             invocation.bind_tool_usage(crate::observability_product::mcp_tool_usage(usage));
-            // Usage-v2 owns bounded, process-local search-to-show correlation
-            // inside this delivery boundary; target IDs remain process-local.
             let completion = crate::observability_product::mcp_completion_facts(
                 operation,
                 response,

--- a/crates/ctx-cli/src/observability_product.rs
+++ b/crates/ctx-cli/src/observability_product.rs
@@ -4,10 +4,7 @@ use ctx_client_observability::{
     analytics::{
         ImportSourceMode, ImportTelemetry, ProgressMode, RenderFormat, TranscriptModeKind,
     },
-    local_usage::{
-        McpCompletionFacts, McpContextTarget, McpCorrelationFact, McpToolUsageFacts,
-        SearchContextObservation,
-    },
+    local_usage::{McpCompletionFacts, McpToolUsageFacts, SearchContextObservation},
 };
 use serde_json::Value;
 
@@ -146,65 +143,9 @@ pub(crate) fn mcp_completion_facts(
             .and_then(Value::as_array)
             .map(Vec::len)
     });
-    let mut correlation = Vec::new();
-    if !failed {
-        match operation {
-            crate::operation_descriptor::ObservedMcpProductOperation::Search => {
-                if let Some(results) = structured
-                    .and_then(|value| value.get("results"))
-                    .and_then(Value::as_array)
-                {
-                    for result in results {
-                        let target = match (
-                            result.get("result_scope").and_then(Value::as_str),
-                            result.get("result_type").and_then(Value::as_str),
-                        ) {
-                            (Some("session"), Some("session_result")) => result
-                                .get("ctx_session_id")
-                                .and_then(Value::as_str)
-                                .and_then(|id| uuid::Uuid::parse_str(id).ok())
-                                .map(McpContextTarget::Session),
-                            (Some("event"), Some("event")) => result
-                                .get("ctx_event_id")
-                                .and_then(Value::as_str)
-                                .and_then(|id| uuid::Uuid::parse_str(id).ok())
-                                .map(McpContextTarget::Event),
-                            _ => None,
-                        };
-                        if let Some(target) = target {
-                            correlation.push(McpCorrelationFact::Found(target));
-                        }
-                    }
-                }
-            }
-            crate::operation_descriptor::ObservedMcpProductOperation::ShowSession => {
-                if let Some(target) = structured
-                    .and_then(|value| value.get("ctx_session_id"))
-                    .and_then(Value::as_str)
-                    .and_then(|id| uuid::Uuid::parse_str(id).ok())
-                    .map(McpContextTarget::Session)
-                {
-                    correlation.push(McpCorrelationFact::Opened(target));
-                }
-            }
-            crate::operation_descriptor::ObservedMcpProductOperation::ShowEvent
-            | crate::operation_descriptor::ObservedMcpProductOperation::QueryEvents => {
-                if let Some(target) = structured
-                    .and_then(|value| value.get("ctx_event_id"))
-                    .and_then(Value::as_str)
-                    .and_then(|id| uuid::Uuid::parse_str(id).ok())
-                    .map(McpContextTarget::Event)
-                {
-                    correlation.push(McpCorrelationFact::Opened(target));
-                }
-            }
-            _ => {}
-        }
-    }
     McpCompletionFacts {
         failed,
         result_count,
         delivered_output_bytes,
-        correlation,
     }
 }

--- a/crates/ctx-client-observability/src/local_usage/correlation.rs
+++ b/crates/ctx-client-observability/src/local_usage/correlation.rs
@@ -1,70 +1,13 @@
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    hash::Hash,
-    time::Duration,
-};
+use std::time::Duration;
 
 use super::{
-    store, LocalUsageStorageAuthority, McpCompletionFacts, McpContextTarget, McpCorrelationFact,
-    McpInvocation, Outcome, UsageControlRevision, UsageControlSnapshot,
+    store, LocalUsageStorageAuthority, McpCompletionFacts, McpInvocation, UsageControlSnapshot,
 };
-
-pub(super) const CONTEXT_CORRELATION_MAX_RECORDS: usize = 1_024;
-
-#[derive(Debug, Clone, Copy, Default)]
-struct ContextRecordState {
-    opened: bool,
-}
-
-/// Bounded, process-local search-to-open correlation.
-///
-/// The keys never cross the persistence boundary. This state is observational
-/// only and is cleared on a local-usage control revision.
-#[derive(Debug, Clone)]
-struct EphemeralContextCorrelation<K> {
-    records: HashMap<K, ContextRecordState>,
-}
-
-impl<K> Default for EphemeralContextCorrelation<K> {
-    fn default() -> Self {
-        Self {
-            records: HashMap::new(),
-        }
-    }
-}
-
-impl<K: Eq + Hash> EphemeralContextCorrelation<K> {
-    fn record_found(&mut self, key: K) -> bool {
-        if self.records.len() >= CONTEXT_CORRELATION_MAX_RECORDS {
-            return false;
-        }
-        if let Entry::Vacant(entry) = self.records.entry(key) {
-            entry.insert(ContextRecordState::default());
-            true
-        } else {
-            false
-        }
-    }
-
-    fn record_opened(&mut self, key: &K) -> bool {
-        let Some(state) = self.records.get_mut(key) else {
-            return false;
-        };
-        if state.opened {
-            false
-        } else {
-            state.opened = true;
-            true
-        }
-    }
-}
 
 pub struct McpUsageRecorder {
     storage: LocalUsageStorageAuthority,
     control: Box<dyn FnMut() -> UsageControlSnapshot>,
     enabled: bool,
-    control_revision: Option<UsageControlRevision>,
-    context: EphemeralContextCorrelation<McpContextTarget>,
     #[cfg(any(test, feature = "test-support"))]
     trace: Option<std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>>,
 }
@@ -79,8 +22,6 @@ impl McpUsageRecorder {
             storage,
             control: Box::new(control),
             enabled: snapshot.enabled(),
-            control_revision: snapshot.revision().cloned(),
-            context: EphemeralContextCorrelation::default(),
             #[cfg(any(test, feature = "test-support"))]
             trace: None,
         }
@@ -99,12 +40,7 @@ impl McpUsageRecorder {
             return;
         };
         let operation = invocation.completed(&facts, duration);
-        let mut next_context = self.context.clone();
-        if operation.outcome == Outcome::Success {
-            Self::apply_delivered_correlation(&mut next_context, &facts);
-        }
         if store::record_authorized(&self.storage, operation).is_ok() {
-            self.context = next_context;
             #[cfg(any(test, feature = "test-support"))]
             if let Some(trace) = &self.trace {
                 trace.lock().unwrap().push("local_usage");
@@ -136,41 +72,6 @@ impl McpUsageRecorder {
     }
 
     fn refresh_control(&mut self) {
-        let snapshot = (self.control)();
-        if !snapshot.available()
-            || snapshot.revision().is_none()
-            || self.control_revision.as_ref() != snapshot.revision()
-            || self.enabled && !snapshot.enabled()
-        {
-            self.context = EphemeralContextCorrelation::default();
-        }
-        self.control_revision = snapshot.revision().cloned();
-        self.enabled = snapshot.enabled();
-    }
-
-    fn apply_delivered_correlation(
-        context: &mut EphemeralContextCorrelation<McpContextTarget>,
-        facts: &McpCompletionFacts,
-    ) -> bool {
-        let mut opened = false;
-        for fact in &facts.correlation {
-            match fact {
-                McpCorrelationFact::Found(target) => {
-                    context.record_found(*target);
-                }
-                McpCorrelationFact::Opened(target) => {
-                    opened |= context.record_opened(target);
-                }
-            }
-        }
-        opened
-    }
-
-    #[cfg(test)]
-    pub(in crate::local_usage) fn correlate_delivered_for_test(
-        &mut self,
-        facts: &McpCompletionFacts,
-    ) -> bool {
-        Self::apply_delivered_correlation(&mut self.context, facts)
+        self.enabled = (self.control)().enabled();
     }
 }

--- a/crates/ctx-client-observability/src/local_usage/mod.rs
+++ b/crates/ctx-client-observability/src/local_usage/mod.rs
@@ -2,7 +2,6 @@ use crate::operation_descriptor::{
     LocalUsageOperation, ObservedMcpProductOperation, OperationDescriptor,
 };
 use std::time::Duration;
-use uuid::Uuid;
 
 pub use crate::operation_descriptor::ResultObservationAction;
 
@@ -134,15 +133,6 @@ impl SearchContextObservation {
             )),
             ContextCoverage::Unavailable | ContextCoverage::NotApplicable => None,
         }
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    pub const fn metadata_for_test(self) -> (ContextCoverage, u64, u64) {
-        (
-            self.coverage,
-            self.delivered_context_bytes,
-            self.matched_normalized_session_bytes,
-        )
     }
 }
 
@@ -288,7 +278,6 @@ pub struct CliUsage {
     operation: Option<LocalUsageOperation>,
     result_count: usize,
     output_bytes: usize,
-    output_bytes_measured: bool,
     search_context: Option<SearchContextObservation>,
     value_class: ValueClass,
 }
@@ -306,7 +295,6 @@ impl CliUsage {
             operation,
             result_count: 0,
             output_bytes: 0,
-            output_bytes_measured: false,
             search_context: None,
             value_class: ValueClass::NotApplicable,
         }
@@ -317,7 +305,6 @@ impl CliUsage {
             operation: None,
             result_count: 0,
             output_bytes: 0,
-            output_bytes_measured: false,
             search_context: None,
             value_class: ValueClass::NotApplicable,
         }
@@ -344,7 +331,6 @@ impl CliUsage {
 
     pub fn set_measured_output_bytes(&mut self, output_bytes: usize) {
         self.output_bytes = output_bytes;
-        self.output_bytes_measured = true;
     }
 
     pub fn set_search_context_observation(&mut self, observation: SearchContextObservation) {
@@ -354,11 +340,7 @@ impl CliUsage {
     pub fn completed(self, success: bool, duration: Duration) -> Option<CompletedOperation> {
         let operation = self.operation?;
         let mut completed = CompletedOperation::cli(operation, success, duration);
-        completed.delivered_output_bytes = if self.output_bytes_measured {
-            u64::try_from(self.output_bytes).unwrap_or(u64::MAX)
-        } else {
-            0
-        };
+        completed.delivered_output_bytes = u64::try_from(self.output_bytes).unwrap_or(u64::MAX);
         if !success {
             return Some(completed);
         }
@@ -393,24 +375,11 @@ pub fn record_best_effort(
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum McpContextTarget {
-    Session(Uuid),
-    Event(Uuid),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum McpCorrelationFact {
-    Found(McpContextTarget),
-    Opened(McpContextTarget),
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct McpCompletionFacts {
     pub failed: bool,
     pub result_count: Option<usize>,
     pub delivered_output_bytes: usize,
-    pub correlation: Vec<McpCorrelationFact>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/ctx-client-observability/src/local_usage/tests/mcp_tests.rs
+++ b/crates/ctx-client-observability/src/local_usage/tests/mcp_tests.rs
@@ -1,13 +1,10 @@
 use std::{cell::Cell, time::Duration};
 
-use uuid::Uuid;
-
 use super::private_tempdir;
 use crate::{
     local_usage::{
-        ContextCoverage, LocalUsageStorageAuthority, McpCompletionFacts, McpContextTarget,
-        McpCorrelationFact, McpInvocation, McpUsageRecorder, SearchContextObservation,
-        UsageControlSnapshot, ValueClass,
+        ContextCoverage, LocalUsageStorageAuthority, McpCompletionFacts, McpInvocation,
+        McpUsageRecorder, SearchContextObservation, UsageControlSnapshot, ValueClass,
     },
     operation_descriptor::ObservedMcpProductOperation,
 };
@@ -37,27 +34,6 @@ fn mcp_search_records_transport_bytes_and_adapter_supplied_canonical_context() {
         (ContextCoverage::Complete, 12, 40)
     );
     assert_eq!(completed.delivered_output_bytes, 777);
-}
-
-#[test]
-fn bounded_uuid_correlation_never_stores_raw_selectors() {
-    let root = private_tempdir();
-    let authority = LocalUsageStorageAuthority::new(root.path().join("usage.sqlite"), "1.0.0");
-    let mut recorder =
-        McpUsageRecorder::start(authority, || UsageControlSnapshot::unversioned(true));
-    let target =
-        McpContextTarget::Session(Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap());
-    let found = McpCompletionFacts {
-        correlation: vec![McpCorrelationFact::Found(target)],
-        ..McpCompletionFacts::default()
-    };
-    assert!(!recorder.correlate_delivered_for_test(&found));
-    let opened = McpCompletionFacts {
-        correlation: vec![McpCorrelationFact::Opened(target)],
-        ..McpCompletionFacts::default()
-    };
-    assert!(recorder.correlate_delivered_for_test(&opened));
-    assert!(!recorder.correlate_delivered_for_test(&opened));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- remove process-local Search and Show UUID correlation state that is never persisted or surfaced
- simplify local output-byte completion without changing recorded values
- remove an unused local-usage test helper

## Validation

- `//crates/ctx-client-observability:unit_tests`
- `//crates/ctx-client-observability:local_usage_tests`
- `//crates/ctx-agent-application:unit_tests`
- `//crates/ctx-agent-application:mcp_local_usage_v2_tests`
- `//crates/ctx-cli:unit_tests`

All five targets pass on current main. Independent review found no behavior changes to persisted usage, stats, hosted telemetry, definition compatibility, or Blame.