### PR TITLE
refactor(search): simplify candidate execution

### DIFF
--- a/crates/ctx-history-cli/src/source_index/search.rs
+++ b/crates/ctx-history-cli/src/source_index/search.rs
@@ -256,9 +256,6 @@ impl From<ctx_history_read_application::SearchExecutionError> for SourceSearchFa
                 Self::Semantic(error)
             }
             ctx_history_read_application::SearchExecutionError::Index(error) => Self::from(error),
-            ctx_history_read_application::SearchExecutionError::Lexical(error) => {
-                Self::Other(anyhow::Error::new(error))
-            }
             ctx_history_read_application::SearchExecutionError::Application(error) => {
                 Self::from(error)
             }

--- a/crates/ctx-history-index-query/src/contract.rs
+++ b/crates/ctx-history-index-query/src/contract.rs
@@ -374,7 +374,7 @@ impl SemanticEventPage {
 #[derive(Debug, Clone)]
 pub struct SemanticFilterProjection {
     pub(super) generation_id: String,
-    pub(super) event_ids: HashSet<Uuid>,
+    pub(super) event_identities: HashMap<Uuid, [u8; 32]>,
 }
 
 impl SemanticFilterProjection {
@@ -383,19 +383,23 @@ impl SemanticFilterProjection {
     }
 
     pub fn len(&self) -> usize {
-        self.event_ids.len()
+        self.event_identities.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.event_ids.is_empty()
+        self.event_identities.is_empty()
     }
 
     pub fn contains(&self, event_id: Uuid) -> bool {
-        self.event_ids.contains(&event_id)
+        self.event_identities.contains_key(&event_id)
+    }
+
+    pub fn event_identity_digest(&self, event_id: Uuid) -> Option<[u8; 32]> {
+        self.event_identities.get(&event_id).copied()
     }
 
     pub fn event_ids(&self) -> impl Iterator<Item = Uuid> + '_ {
-        self.event_ids.iter().copied()
+        self.event_identities.keys().copied()
     }
 }
 

--- a/crates/ctx-history-index-query/src/contract.rs
+++ b/crates/ctx-history-index-query/src/contract.rs
@@ -507,15 +507,6 @@ impl EventSearchFilters {
         Ok(())
     }
 
-    pub fn matches_source_identity(&self, event: &EventRecord) -> bool {
-        if !self.has_source_identity_filter() {
-            return true;
-        }
-        custom_source_identity(event).is_some_and(|(provider_key, source_id)| {
-            source_identity_values_match(self, provider_key, source_id)
-        })
-    }
-
     pub(super) fn has_source_identity_filter(&self) -> bool {
         self.history_source.is_some() || self.provider_key.is_some() || self.source_id.is_some()
     }
@@ -551,6 +542,30 @@ impl CompiledSearchFilter {
 
     pub const fn filters(&self) -> &EventSearchFilters {
         &self.filters
+    }
+
+    pub(super) fn matches_source_identity(&self, event: &EventRecord) -> bool {
+        if !self.filters.has_source_identity_filter() {
+            return true;
+        }
+        custom_source_identity(event).is_some_and(|(provider_key, source_id)| {
+            let filters = &self.filters;
+            !filters.history_source.as_deref().is_some_and(|selector| {
+                selector
+                    .trim()
+                    .split_once('/')
+                    .is_none_or(|(provider, source)| {
+                        provider != provider_key || source != source_id
+                    })
+            }) && filters
+                .provider_key
+                .as_deref()
+                .is_none_or(|expected| expected.trim() == provider_key)
+                && filters
+                    .source_id
+                    .as_deref()
+                    .is_none_or(|expected| expected.trim() == source_id)
+        })
     }
 }
 

--- a/crates/ctx-history-index-query/src/contract/lexical.rs
+++ b/crates/ctx-history-index-query/src/contract/lexical.rs
@@ -277,17 +277,6 @@ impl std::fmt::Display for LexicalWorkExhaustion {
 
 impl std::error::Error for LexicalWorkExhaustion {}
 
-/// Errors from compatibility lexical APIs that cannot represent partial work.
-#[derive(Debug, thiserror::Error)]
-pub enum LexicalSearchError {
-    #[error(transparent)]
-    Index(#[from] IndexError),
-    #[error("lexical search work exhausted: {0}")]
-    WorkExhausted(#[from] LexicalWorkExhaustion),
-}
-
-pub type LexicalSearchResult<T> = std::result::Result<T, LexicalSearchError>;
-
 /// Explicit term coverage retained with every manual lexical candidate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LexicalTermCoverage {

--- a/crates/ctx-history-index-query/src/execution/search.rs
+++ b/crates/ctx-history-index-query/src/execution/search.rs
@@ -811,24 +811,6 @@ fn finish_lexical_batch(
     }
 }
 
-#[cfg(any(test, feature = "test-support"))]
-fn complete_compatibility_candidates(
-    batch: LexicalSearchBatch,
-) -> LexicalSearchResult<Vec<EventSearchCandidate>> {
-    let LexicalSearchBatch {
-        candidates,
-        complete,
-        exhaustion,
-        ..
-    } = batch;
-    if !complete {
-        return Err(LexicalSearchError::WorkExhausted(exhaustion.expect(
-            "an incomplete lexical batch always has an exhaustion reason",
-        )));
-    }
-    Ok(candidates.into_iter().map(Into::into).collect())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ctx-history-index-query/src/execution/search/executor.rs
+++ b/crates/ctx-history-index-query/src/execution/search/executor.rs
@@ -130,77 +130,6 @@ impl VerifiedIndex {
         }
     }
 
-    /// Test-only compatibility wrapper for a complete manual lexical result.
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn search_event_candidates(
-        &self,
-        natural_text: &str,
-        limit: usize,
-    ) -> LexicalSearchResult<Vec<EventSearchCandidate>> {
-        self.search_event_candidates_with_filters(
-            natural_text,
-            &EventSearchFilters::default(),
-            limit,
-        )
-    }
-
-    /// Test-only compatibility wrapper for complete filtered lexical results.
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn search_event_candidates_with_filters(
-        &self,
-        natural_text: &str,
-        filters: &EventSearchFilters,
-        limit: usize,
-    ) -> LexicalSearchResult<Vec<EventSearchCandidate>> {
-        self.search_event_candidates_any_with_filters(&[natural_text], filters, limit)
-    }
-
-    /// Test-only compatibility wrapper for complete OR-composed results.
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn search_event_candidates_any_with_filters(
-        &self,
-        natural_texts: &[&str],
-        filters: &EventSearchFilters,
-        limit: usize,
-    ) -> LexicalSearchResult<Vec<EventSearchCandidate>> {
-        complete_compatibility_candidates(self.execute_compatibility_lexical(
-            LexicalMode::Search(natural_texts),
-            filters,
-            limit,
-        )?)
-    }
-
-    /// Test-only compatibility wrapper for a complete filtered List result.
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn list_event_candidates_with_filters(
-        &self,
-        filters: &EventSearchFilters,
-        limit: usize,
-    ) -> LexicalSearchResult<Vec<EventSearchCandidate>> {
-        complete_compatibility_candidates(self.execute_compatibility_lexical(
-            LexicalMode::List,
-            filters,
-            limit,
-        )?)
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    fn execute_compatibility_lexical(
-        &self,
-        mode: LexicalMode<'_>,
-        filters: &EventSearchFilters,
-        limit: usize,
-    ) -> LexicalSearchResult<LexicalSearchBatch> {
-        let filter = CompiledSearchFilter::compile(filters.clone())?;
-        self.execute_lexical(LexicalExecution::new(mode, &filter, limit))
-            .map(|observed| observed.batch)
-            .map_err(|failure| LexicalSearchError::Index(failure.error))
-    }
-
     fn execute_lexical_inner(
         &self,
         execution: LexicalExecution<'_>,
@@ -402,33 +331,18 @@ impl VerifiedIndex {
             ) {
                 break;
             }
-            let fast = core_event_fast_preflight(&self.searcher, candidate.address)?;
-            if fast.1 != candidate.order.encoded_core_bytes()
-                || fast.2 != candidate.order.content_bytes()
-            {
-                return Err(IndexError::InvalidStoredDocumentField(
-                    EVENT_RANGE_ORDER_FAST_FIELD,
-                ));
-            }
             #[cfg(any(test, feature = "test-support"))]
             if lexical_candidate_materialization_should_fail() {
                 return Err(IndexError::InvalidStoredDocumentField(
                     "test_lexical_candidate_materialization_failure",
                 ));
             }
-            let (event, encoded_core_bytes) = ranked_event_ref_at_address_with_order(
+            let (event, _) = ranked_event_ref_at_address_with_order(
                 &self.searcher,
                 candidate.address,
                 fields,
                 candidate.order,
             )?;
-            if encoded_core_bytes != candidate.order.encoded_core_bytes()
-                || event.event_id != fast.0
-            {
-                return Err(IndexError::InvalidStoredDocumentField(
-                    EVENT_RANGE_ORDER_FAST_FIELD,
-                ));
-            }
             candidates.push(LexicalSearchCandidate {
                 event,
                 score: candidate.score,

--- a/crates/ctx-history-index-query/src/execution/search/semantic_projection.rs
+++ b/crates/ctx-history-index-query/src/execution/search/semantic_projection.rs
@@ -19,7 +19,7 @@ impl VerifiedIndex {
                 IndexRecordOption::Basic,
             )),
         ]));
-        let source_identity_query = self.source_identity_query(filter.filters(), fields)?;
+        let source_identity_query = self.source_identity_query(filter, fields)?;
         let query =
             filtered_event_query(semantic_eligibility, source_identity_query, filter, fields)?;
         let addresses = self
@@ -41,13 +41,13 @@ impl VerifiedIndex {
 
     fn source_identity_query(
         &self,
-        filters: &EventSearchFilters,
+        filter: &CompiledSearchFilter,
         fields: Fields,
     ) -> Result<Option<Box<dyn Query>>> {
+        let filters = filter.filters();
         if !filters.has_source_identity_filter() {
             return Ok(None);
         }
-        filters.validate_source_identity_filters()?;
         let mut clauses: Vec<(Occur, Box<dyn Query>)> = vec![(
             Occur::Must,
             Box::new(TermQuery::new(

--- a/crates/ctx-history-index-query/src/execution/search/semantic_projection.rs
+++ b/crates/ctx-history-index-query/src/execution/search/semantic_projection.rs
@@ -26,16 +26,20 @@ impl VerifiedIndex {
             .searcher
             .search(query.as_ref(), &DocSetCollector)
             .map_err(IndexError::from)?;
-        let mut event_ids = HashSet::with_capacity(addresses.len());
+        let mut event_identities = HashMap::with_capacity(addresses.len());
         for address in addresses {
-            let (event_id, _, _) = core_event_fast_preflight(&self.searcher, address)?;
-            if !event_ids.insert(event_id) {
+            let (event_id, event_identity_digest) =
+                core_event_identity_fast_preflight(&self.searcher, address)?;
+            if event_identities
+                .insert(event_id, event_identity_digest)
+                .is_some()
+            {
                 return Err(IndexError::DuplicateEventIdentity(event_id.to_string()));
             }
         }
         Ok(SemanticFilterProjection {
             generation_id: self.generation_id.clone(),
-            event_ids,
+            event_identities,
         })
     }
 

--- a/crates/ctx-history-index-query/src/filtering.rs
+++ b/crates/ctx-history-index-query/src/filtering.rs
@@ -637,32 +637,6 @@ pub(super) fn custom_source_identity(event: &EventRecord) -> Option<(&str, &str)
     event.custom_source_identity()
 }
 
-pub(super) fn source_identity_values_match(
-    filters: &EventSearchFilters,
-    provider_key: &str,
-    source_id: &str,
-) -> bool {
-    if filters.history_source.as_deref().is_some_and(|selector| {
-        selector
-            .trim()
-            .split_once('/')
-            .is_none_or(|(provider, source)| provider != provider_key || source != source_id)
-    }) {
-        return false;
-    }
-    if filters
-        .provider_key
-        .as_deref()
-        .is_some_and(|expected| expected.trim() != provider_key)
-    {
-        return false;
-    }
-    filters
-        .source_id
-        .as_deref()
-        .is_none_or(|expected| expected.trim() == source_id)
-}
-
 pub(super) fn add_optional_text_filter(
     clauses: &mut Vec<(Occur, Box<dyn Query>)>,
     field: tantivy::schema::Field,

--- a/crates/ctx-history-index-query/src/filtering/core_match.rs
+++ b/crates/ctx-history-index-query/src/filtering/core_match.rs
@@ -71,7 +71,7 @@ impl CompiledSearchFilter {
                 SearchAgentScope::Primary => event.agent_scope != Some(CoreAgentScope::Primary),
                 SearchAgentScope::Subagent => event.agent_scope != Some(CoreAgentScope::Subagent),
             }
-            || !filters.matches_source_identity(event)
+            || !self.matches_source_identity(event)
         {
             return Ok(false);
         }

--- a/crates/ctx-history-index-query/src/lib.rs
+++ b/crates/ctx-history-index-query/src/lib.rs
@@ -18,8 +18,9 @@ pub use reader::{
 };
 pub(crate) use records::stored_event_record;
 use records::{
-    core_event_fast_preflight, stored_core_event_record, stored_core_event_record_with_size,
-    stored_core_event_record_with_source_json, EventAddressCandidate, SessionEventAddressCandidate,
+    core_event_fast_preflight, core_event_identity_fast_preflight, stored_core_event_record,
+    stored_core_event_record_with_size, stored_core_event_record_with_source_json,
+    EventAddressCandidate, SessionEventAddressCandidate,
 };
 use records::{ranked_event_ref_at_address, ranked_event_ref_at_address_with_order};
 
@@ -27,7 +28,7 @@ use records::{ranked_event_ref_at_address, ranked_event_ref_at_address_with_orde
 use std::cell::{Cell, RefCell};
 use std::{
     cmp::{Ordering, Reverse},
-    collections::{BTreeMap, BTreeSet, BinaryHeap, HashSet},
+    collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap},
     ops::Bound,
 };
 

--- a/crates/ctx-history-index-query/src/records.rs
+++ b/crates/ctx-history-index-query/src/records.rs
@@ -254,6 +254,28 @@ pub(super) fn core_event_fast_preflight(
     ))
 }
 
+/// Returns the compact event address and exact full identity digest without
+/// loading a stored document.
+pub(super) fn core_event_identity_fast_preflight(
+    searcher: &tantivy::Searcher,
+    address: DocAddress,
+) -> Result<(Uuid, [u8; 32])> {
+    let (event_id, _, _) = core_event_fast_preflight(searcher, address)?;
+    let event_identity_digest =
+        event_range_order_at_address(searcher, address)?.event_identity_digest();
+    if (ctx_history_index_format::CompactIdentity {
+        digest: event_identity_digest,
+    })
+    .as_uuid()
+        != event_id
+    {
+        return Err(IndexError::InvalidStoredDocumentField(
+            SEARCH_REF_EVENT_RANGE_ORDER_FIELD,
+        ));
+    }
+    Ok((event_id, event_identity_digest))
+}
+
 pub(super) fn stored_core_event_record_with_source_json(
     searcher: &tantivy::Searcher,
     address: DocAddress,

--- a/crates/ctx-history-index-query/tests/writer_integration.rs
+++ b/crates/ctx-history-index-query/tests/writer_integration.rs
@@ -235,9 +235,9 @@ fn add_literal_fact(record: &mut CoreRecord, kind: LiteralFactKind, value: impl 
 
 fn filtered_session_ids(index: &VerifiedIndex, filters: EventSearchFilters) -> Vec<Uuid> {
     sorted_uuids(
-        index
-            .search_event_candidates_with_filters("shared needle", &filters, 10)
+        lexical_search_batch(index, &["shared needle"], &filters, 10)
             .unwrap()
+            .candidates
             .into_iter()
             .map(|candidate| candidate.event.session_id)
             .collect(),
@@ -249,7 +249,7 @@ fn lexical_search_batch(
     natural_texts: &[&str],
     filters: &EventSearchFilters,
     limit: usize,
-) -> ctx_history_index_query::LexicalSearchResult<ctx_history_index_query::LexicalSearchBatch> {
+) -> ctx_history_index_query::Result<ctx_history_index_query::LexicalSearchBatch> {
     execute_lexical_batch(
         index,
         ctx_history_index_query::LexicalMode::Search(natural_texts),
@@ -265,7 +265,7 @@ fn lexical_search_batch_with_budget(
     filters: &EventSearchFilters,
     limit: usize,
     budget: ctx_history_index_query::LexicalWorkBudget,
-) -> ctx_history_index_query::LexicalSearchResult<ctx_history_index_query::LexicalSearchBatch> {
+) -> ctx_history_index_query::Result<ctx_history_index_query::LexicalSearchBatch> {
     execute_lexical_batch(
         index,
         ctx_history_index_query::LexicalMode::Search(natural_texts),
@@ -279,7 +279,7 @@ fn lexical_list_batch(
     index: &VerifiedIndex,
     filters: &EventSearchFilters,
     limit: usize,
-) -> ctx_history_index_query::LexicalSearchResult<ctx_history_index_query::LexicalSearchBatch> {
+) -> ctx_history_index_query::Result<ctx_history_index_query::LexicalSearchBatch> {
     execute_lexical_batch(
         index,
         ctx_history_index_query::LexicalMode::List,
@@ -294,7 +294,7 @@ fn lexical_list_batch_with_budget(
     filters: &EventSearchFilters,
     limit: usize,
     budget: ctx_history_index_query::LexicalWorkBudget,
-) -> ctx_history_index_query::LexicalSearchResult<ctx_history_index_query::LexicalSearchBatch> {
+) -> ctx_history_index_query::Result<ctx_history_index_query::LexicalSearchBatch> {
     execute_lexical_batch(
         index,
         ctx_history_index_query::LexicalMode::List,
@@ -310,7 +310,7 @@ fn execute_lexical_batch(
     filters: &EventSearchFilters,
     limit: usize,
     budget: Option<ctx_history_index_query::LexicalWorkBudget>,
-) -> ctx_history_index_query::LexicalSearchResult<ctx_history_index_query::LexicalSearchBatch> {
+) -> ctx_history_index_query::Result<ctx_history_index_query::LexicalSearchBatch> {
     let filter = CompiledSearchFilter::compile(filters.clone())?;
     let execution = ctx_history_index_query::LexicalExecution::new(mode, &filter, limit);
     let execution = match budget {
@@ -320,7 +320,7 @@ fn execute_lexical_batch(
     index
         .execute_lexical(execution)
         .map(|observed| observed.batch)
-        .map_err(|failure| ctx_history_index_query::LexicalSearchError::Index(failure.error))
+        .map_err(|failure| failure.error)
 }
 
 fn sorted_uuids(mut ids: Vec<Uuid>) -> Vec<Uuid> {

--- a/crates/ctx-history-index-query/tests/writer_integration/query/lexical.rs
+++ b/crates/ctx-history-index-query/tests/writer_integration/query/lexical.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[path = "lexical_segment_boundaries.rs"]
+mod segment_boundaries;
+
 fn publish_records(temp: &TempDir, source: &SourceKey, records: Vec<CoreRecord>) -> VerifiedIndex {
     let document_count = u64::try_from(records.len()).unwrap();
     let mut writer = GenerationWriter::open(temp.path(), WriterOptions::default())
@@ -97,21 +100,26 @@ fn script_aware_analysis_indexes_cjk_and_long_technical_identifiers() {
 
     let index = VerifiedIndex::open(temp.path()).unwrap();
     assert_eq!(
-        index
-            .search_event_candidates("数据库迁移", 10)
+        lexical_search_batch(&index, &["数据库迁移"], &EventSearchFilters::default(), 10,)
             .unwrap()
+            .candidates
             .into_iter()
             .map(|candidate| candidate.event.event_id)
             .collect::<Vec<_>>(),
         vec![cjk.event_id.as_uuid()]
     );
     assert_eq!(
-        index
-            .search_event_candidates(&long_component, 10)
-            .unwrap()
-            .into_iter()
-            .map(|candidate| candidate.event.event_id)
-            .collect::<Vec<_>>(),
+        lexical_search_batch(
+            &index,
+            &[&long_component],
+            &EventSearchFilters::default(),
+            10,
+        )
+        .unwrap()
+        .candidates
+        .into_iter()
+        .map(|candidate| candidate.event.event_id)
+        .collect::<Vec<_>>(),
         vec![identifier.event_id.as_uuid()]
     );
 }
@@ -135,9 +143,14 @@ fn multi_term_search_ranks_full_coverage_before_one_term_partial_matches() {
     writer.commit(|_| true).unwrap();
 
     let index = VerifiedIndex::open(temp.path()).unwrap();
-    let candidates = index
-        .search_event_candidates("coveragealpha coveragebeta", 10)
-        .unwrap();
+    let candidates = lexical_search_batch(
+        &index,
+        &["coveragealpha coveragebeta"],
+        &EventSearchFilters::default(),
+        10,
+    )
+    .unwrap()
+    .candidates;
     assert_eq!(
         candidates
             .iter()
@@ -172,9 +185,14 @@ fn multi_term_search_ranks_full_coverage_before_one_term_partial_matches() {
         ]
     );
     assert_eq!(
-        index
-            .search_event_candidates("coveragealpha coveragebeta", 1)
-            .unwrap()[0]
+        lexical_search_batch(
+            &index,
+            &["coveragealpha coveragebeta"],
+            &EventSearchFilters::default(),
+            1,
+        )
+        .unwrap()
+        .candidates[0]
             .event
             .event_id,
         exact.event_id.as_uuid()
@@ -328,31 +346,32 @@ fn lexical_result_limits_reject_oversized_and_usize_max_before_query_work() {
     let (_temp, index) = lexical_query_limit_fixture();
     for requested in [MAX_LEXICAL_QUERY_RESULTS + 1, usize::MAX] {
         ctx_history_index_query::reset_lexical_query_work();
-        let error = index
-            .search_event_candidates("bounded", requested)
-            .unwrap_err();
+        let error = lexical_search_batch(
+            &index,
+            &["bounded"],
+            &EventSearchFilters::default(),
+            requested,
+        )
+        .unwrap_err();
         assert!(matches!(
             error,
-            ctx_history_index_query::LexicalSearchError::Index(
-                IndexError::InvalidLexicalResultLimit {
+            IndexError::InvalidLexicalResultLimit {
                 requested: actual,
                 maximum
-            })
+            }
                 if actual == requested && maximum == MAX_LEXICAL_QUERY_RESULTS
         ));
         assert_no_lexical_query_was_constructed_or_executed();
 
         ctx_history_index_query::reset_lexical_query_work();
-        let error = index
-            .list_event_candidates_with_filters(&EventSearchFilters::default(), requested)
-            .unwrap_err();
+        let error =
+            lexical_list_batch(&index, &EventSearchFilters::default(), requested).unwrap_err();
         assert!(matches!(
             error,
-            ctx_history_index_query::LexicalSearchError::Index(
-                IndexError::InvalidLexicalResultLimit {
+            IndexError::InvalidLexicalResultLimit {
                 requested: actual,
                 maximum
-            })
+            }
                 if actual == requested && maximum == MAX_LEXICAL_QUERY_RESULTS
         ));
         assert_no_lexical_query_was_constructed_or_executed();
@@ -688,14 +707,15 @@ fn oversized_single_query_is_rejected_before_query_construction() {
     let oversized = "x".repeat(LEXICAL_QUERY_LIMITS.maximum_aggregate_bytes + 1);
     ctx_history_index_query::reset_lexical_query_work();
 
-    let error = index.search_event_candidates(&oversized, 10).unwrap_err();
+    let error = lexical_search_batch(&index, &[&oversized], &EventSearchFilters::default(), 10)
+        .unwrap_err();
 
     assert!(matches!(
         error,
-        ctx_history_index_query::LexicalSearchError::Index(IndexError::LexicalQueryBytesTooLarge {
+        IndexError::LexicalQueryBytesTooLarge {
             actual,
             maximum,
-        }) if actual == LEXICAL_QUERY_LIMITS.maximum_aggregate_bytes + 1
+        } if actual == LEXICAL_QUERY_LIMITS.maximum_aggregate_bytes + 1
             && maximum == LEXICAL_QUERY_LIMITS.maximum_aggregate_bytes
     ));
     assert_no_lexical_query_was_constructed_or_executed();
@@ -707,16 +727,15 @@ fn repeated_terms_are_rejected_before_query_construction() {
     let alternatives = vec!["bounded"; LEXICAL_QUERY_LIMITS.maximum_alternatives + 1];
     ctx_history_index_query::reset_lexical_query_work();
 
-    let error = index
-        .search_event_candidates_any_with_filters(&alternatives, &EventSearchFilters::default(), 10)
+    let error = lexical_search_batch(&index, &alternatives, &EventSearchFilters::default(), 10)
         .unwrap_err();
 
     assert!(matches!(
         error,
-        ctx_history_index_query::LexicalSearchError::Index(IndexError::LexicalQueryAlternativesTooMany {
+        IndexError::LexicalQueryAlternativesTooMany {
             observed,
             maximum
-        })
+        }
             if observed == LEXICAL_QUERY_LIMITS.maximum_alternatives + 1
                 && maximum == LEXICAL_QUERY_LIMITS.maximum_alternatives
     ));
@@ -732,14 +751,15 @@ fn analyzed_tokens_are_rejected_before_deduplication_or_query_construction() {
         .join(" ");
     ctx_history_index_query::reset_lexical_query_work();
 
-    let error = index.search_event_candidates(&query, 10).unwrap_err();
+    let error =
+        lexical_search_batch(&index, &[&query], &EventSearchFilters::default(), 10).unwrap_err();
 
     assert!(matches!(
         error,
-        ctx_history_index_query::LexicalSearchError::Index(IndexError::LexicalQueryTokensTooMany {
+        IndexError::LexicalQueryTokensTooMany {
             observed,
             maximum
-        })
+        }
             if observed == LEXICAL_QUERY_LIMITS.maximum_unique_tokens + 1
                 && maximum == LEXICAL_QUERY_LIMITS.maximum_unique_tokens
     ));
@@ -748,12 +768,12 @@ fn analyzed_tokens_are_rejected_before_deduplication_or_query_construction() {
     let repeated = std::iter::repeat_n("bounded", LEXICAL_QUERY_LIMITS.maximum_unique_tokens + 1)
         .collect::<Vec<_>>()
         .join(" ");
-    let error = index.search_event_candidates(&repeated, 10).unwrap_err();
+    let error =
+        lexical_search_batch(&index, &[&repeated], &EventSearchFilters::default(), 10).unwrap_err();
     assert!(matches!(
         error,
-        ctx_history_index_query::LexicalSearchError::Index(
-            IndexError::LexicalQueryTokensTooMany { observed, maximum }
-        ) if observed == LEXICAL_QUERY_LIMITS.maximum_unique_tokens + 1
+        IndexError::LexicalQueryTokensTooMany { observed, maximum }
+            if observed == LEXICAL_QUERY_LIMITS.maximum_unique_tokens + 1
             && maximum == LEXICAL_QUERY_LIMITS.maximum_unique_tokens
     ));
     assert_no_lexical_query_was_constructed_or_executed();

--- a/crates/ctx-history-index-query/tests/writer_integration/query/lexical_segment_boundaries.rs
+++ b/crates/ctx-history-index-query/tests/writer_integration/query/lexical_segment_boundaries.rs
@@ -1,0 +1,139 @@
+use super::*;
+
+const QUERY: &str = "segmentboundaryneedle";
+
+fn publish_unmerged_segments(segment_count: usize) -> (TempDir, VerifiedIndex, Vec<[u8; 32]>) {
+    let temp = tempdir().unwrap();
+    let source = source(&format!("lexical-segments-{segment_count}.jsonl"));
+    let records = (0..segment_count)
+        .map(|index| {
+            document_for_session(
+                &source,
+                &format!("lexical-segment-session-{index}"),
+                1,
+                QUERY,
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut exact = records
+        .iter()
+        .map(|record| record.event_id.digest())
+        .collect::<Vec<_>>();
+    exact.sort();
+
+    let initial = publish_records(&temp, &source, records.clone());
+    drop(initial);
+    let (searcher, manifest) = open_unverified_generation(temp.path());
+    drop(searcher);
+    let directory = DurableMmapDirectory::open(active_generation_path(temp.path())).unwrap();
+    let tantivy_index = Index::open(directory).unwrap();
+    let fields = fields_from_schema(&tantivy_index.schema()).unwrap();
+    let generation_id = manifest.generation_id().unwrap();
+    let mut writer = tantivy_index
+        .writer_with_num_threads::<TantivyDocument>(1, INDEX_MEMORY_MIN_PER_THREAD)
+        .unwrap();
+    writer.set_merge_policy(Box::<NoMergePolicy>::default());
+    writer.delete_all_documents().unwrap();
+    writer.commit().unwrap();
+
+    for (index, record) in records.into_iter().enumerate() {
+        let authority = ctx_history_index_format::SessionAuthorityKey::exact(
+            record.session_id,
+            record.source.identity(),
+        )
+        .unwrap();
+        let mut document = indexed_document(record);
+        document.add_bytes(fields.session_authority, authority.as_bytes());
+        writer.add_document(document).unwrap();
+        if index + 1 == segment_count {
+            let mut prepared = writer.prepare_commit().unwrap();
+            prepared.set_payload(
+                &serde_json::to_string(&CommitPayload {
+                    version: COMMIT_PAYLOAD_VERSION,
+                    generation_id: generation_id.clone(),
+                    publication_metadata: None,
+                })
+                .unwrap(),
+            );
+            prepared.commit().unwrap();
+        } else {
+            writer.commit().unwrap();
+        }
+    }
+    writer.wait_merging_threads().unwrap();
+    let metas = tantivy_index.load_metas().unwrap();
+    assert_eq!(metas.segments.len(), segment_count);
+    assert!(metas.segments.iter().all(|segment| segment.num_docs() == 1));
+
+    let pointer = load_active_generation_pointer(temp.path())
+        .unwrap()
+        .unwrap();
+    let generation_path = active_generation_path(temp.path());
+    let digest =
+        physical_integrity_digest(&tantivy_index, &generation_path, Some(&pointer)).unwrap();
+    let active = GenerationSlot::new(
+        generation_id,
+        pointer.active().directory().to_owned(),
+        digest,
+    )
+    .unwrap();
+    publish_active_generation_pointer(
+        temp.path(),
+        &ActiveGenerationPointer::new(active, None).unwrap(),
+    )
+    .unwrap();
+
+    let index = VerifiedIndex::open(temp.path()).unwrap();
+    (temp, index, exact)
+}
+
+#[test]
+fn real_segment_topology_limits_preserve_exact_prefixes() {
+    for segment_count in [1_usize, 64, 65, 512] {
+        let (_temp, index, exact) = publish_unmerged_segments(segment_count);
+        for limit in [1, 10, 20, 200] {
+            let batch =
+                lexical_search_batch(&index, &[QUERY], &EventSearchFilters::default(), limit)
+                    .unwrap();
+            assert!(
+                batch.complete,
+                "segment_count={segment_count} limit={limit}"
+            );
+            assert_eq!(batch.counters.segments, segment_count as u64);
+            assert_eq!(
+                batch
+                    .candidates
+                    .iter()
+                    .map(|candidate| candidate.event.event_identity_digest)
+                    .collect::<Vec<_>>(),
+                exact[..exact.len().min(limit)],
+                "segment_count={segment_count} limit={limit}"
+            );
+            assert_eq!(batch.candidate_set_exhaustive, exact.len() <= limit);
+        }
+    }
+
+    let (_temp, index, _) = publish_unmerged_segments(513);
+    let exhausted =
+        lexical_search_batch(&index, &[QUERY], &EventSearchFilters::default(), 200).unwrap();
+    assert!(!exhausted.complete);
+    assert!(!exhausted.candidate_set_exhaustive);
+    assert!(exhausted.candidates.is_empty());
+    assert_eq!(
+        exhausted.counters,
+        ctx_history_index_query::LexicalWorkCounters {
+            analyzed_tokens: 1,
+            exact_filter_terms: 1,
+            ..ctx_history_index_query::LexicalWorkCounters::default()
+        }
+    );
+    let exhaustion = exhausted.exhaustion.unwrap();
+    assert_eq!(
+        exhaustion.counter,
+        ctx_history_index_query::LexicalWorkCounter::Segments
+    );
+    assert_eq!(exhaustion.used, 0);
+    assert_eq!(exhaustion.limit, 512);
+    assert!(exhaustion.segment.is_none());
+    assert!(exhaustion.next_doc.is_none());
+}

--- a/crates/ctx-history-index-query/tests/writer_integration/query/lookup.rs
+++ b/crates/ctx-history-index-query/tests/writer_integration/query/lookup.rs
@@ -20,9 +20,14 @@ fn pinned_query_api_returns_typed_records_in_deterministic_order() {
     assert_eq!(index.session_count().unwrap(), 1);
     assert_eq!(index.event_type_count("message").unwrap(), 2);
     assert_eq!(index.event_type_count("tool_call").unwrap(), 0);
-    let candidates = index
-        .search_event_candidates("atomic:generation", 10)
-        .unwrap();
+    let candidates = lexical_search_batch(
+        &index,
+        &["atomic:generation"],
+        &EventSearchFilters::default(),
+        10,
+    )
+    .unwrap()
+    .candidates;
     let mut expected_search_ids = vec![second.event_id.as_uuid(), first.event_id.as_uuid()];
     expected_search_ids.sort();
     assert_eq!(
@@ -201,16 +206,17 @@ fn decoded_core_event_preserves_searchable_literal_files_in_provider_order() {
         ["src/lib.rs", "src/lib.rs", "src/new.rs", "src/old.rs"]
     );
     for file in ["SRC/LIB.RS", "src/new.rs", "src/old.rs"] {
-        let matches = index
-            .search_event_candidates_with_filters(
-                "repository:file:activity",
-                &EventSearchFilters {
-                    file: Some(file.to_owned()),
-                    ..EventSearchFilters::default()
-                },
-                10,
-            )
-            .unwrap();
+        let matches = lexical_search_batch(
+            &index,
+            &["repository:file:activity"],
+            &EventSearchFilters {
+                file: Some(file.to_owned()),
+                ..EventSearchFilters::default()
+            },
+            10,
+        )
+        .unwrap()
+        .candidates;
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].event.event_id, expected.event_id.as_uuid());
     }
@@ -235,26 +241,32 @@ fn literal_file_fact_is_searchable_without_repository_attribution() {
     let index = VerifiedIndex::open(temp.path()).unwrap();
 
     assert_eq!(
-        index
-            .search_event_candidates("unknownoriginsearchneedle", 10)
-            .unwrap()
-            .len(),
+        lexical_search_batch(
+            &index,
+            &["unknownoriginsearchneedle"],
+            &EventSearchFilters::default(),
+            10,
+        )
+        .unwrap()
+        .candidates
+        .len(),
         1
     );
     assert_eq!(
-        index
-            .search_event_candidates_with_filters(
-                "unknownoriginsearchneedle",
-                &EventSearchFilters {
-                    file: Some("SRC/UNKNOWN.RS".to_owned()),
-                    ..EventSearchFilters::default()
-                },
-                10,
-            )
-            .unwrap()
-            .into_iter()
-            .map(|candidate| candidate.event.event_id)
-            .collect::<Vec<_>>(),
+        lexical_search_batch(
+            &index,
+            &["unknownoriginsearchneedle"],
+            &EventSearchFilters {
+                file: Some("SRC/UNKNOWN.RS".to_owned()),
+                ..EventSearchFilters::default()
+            },
+            10,
+        )
+        .unwrap()
+        .candidates
+        .into_iter()
+        .map(|candidate| candidate.event.event_id)
+        .collect::<Vec<_>>(),
         vec![unknown.event_id.as_uuid()]
     );
 }
@@ -817,7 +829,10 @@ fn lexical_candidates_remain_thin_while_other_collectors_decode_only_selected_re
     );
 
     ctx_history_index_query::reset_stored_event_record_materializations();
-    let candidates = index.search_event_candidates("ambiguity", 5).unwrap();
+    let candidates =
+        lexical_search_batch(&index, &["ambiguity"], &EventSearchFilters::default(), 5)
+            .unwrap()
+            .candidates;
     assert_eq!(candidates.len(), 5);
     assert_eq!(
         ctx_history_index_query::stored_event_record_materializations(),

--- a/crates/ctx-history-index-query/tests/writer_integration/query/lookup/query_constraints.rs
+++ b/crates/ctx-history-index-query/tests/writer_integration/query/lookup/query_constraints.rs
@@ -37,9 +37,9 @@ fn custom_source_filters_use_the_core_native_event_identity() {
         ..EventSearchFilters::default()
     };
     ctx_history_index_query::reset_stored_core_event_record_materializations();
-    let hits = index
-        .search_event_candidates_with_filters("identity", &filters, 10)
-        .unwrap();
+    let hits = lexical_search_batch(&index, &["identity"], &filters, 10)
+        .unwrap()
+        .candidates;
     assert_eq!(
         hits.iter()
             .map(|candidate| candidate.event.event_id)
@@ -48,7 +48,6 @@ fn custom_source_filters_use_the_core_native_event_identity() {
     );
     let hydrated = index.event_by_id(event_id.as_uuid()).unwrap().unwrap();
     assert_eq!(hydrated.native_event_id.as_ref(), Some(&native_event_id));
-    assert!(filters.matches_source_identity(&hydrated));
     let listed = lexical_list_batch(&index, &filters, 10).unwrap();
     assert!(listed.complete);
     assert!(listed.candidate_set_exhaustive);
@@ -65,16 +64,17 @@ fn custom_source_filters_use_the_core_native_event_identity() {
         "custom source filtering must use bounded indexed identity metadata"
     );
 
-    let misses = index
-        .search_event_candidates_with_filters(
-            "identity",
-            &EventSearchFilters {
-                source_id: Some("another-source".to_owned()),
-                ..EventSearchFilters::default()
-            },
-            10,
-        )
-        .unwrap();
+    let misses = lexical_search_batch(
+        &index,
+        &["identity"],
+        &EventSearchFilters {
+            source_id: Some("another-source".to_owned()),
+            ..EventSearchFilters::default()
+        },
+        10,
+    )
+    .unwrap()
+    .candidates;
     assert!(misses.is_empty());
 }
 
@@ -103,25 +103,26 @@ fn allowed_source_keys_select_exact_physical_sources_in_one_index() {
         allowed_source_keys: Some(vec![source_token(&personal)]),
         ..EventSearchFilters::default()
     };
-    let hits = index
-        .search_event_candidates_with_filters("needle", &personal_only, 10)
-        .unwrap();
+    let hits = lexical_search_batch(&index, &["needle"], &personal_only, 10)
+        .unwrap()
+        .candidates;
     assert_eq!(hits.len(), 1);
     assert_eq!(
         hits[0].event.source_owner_digest,
         personal.identity().digest()
     );
 
-    let none = index
-        .search_event_candidates_with_filters(
-            "needle",
-            &EventSearchFilters {
-                allowed_source_keys: Some(Vec::new()),
-                ..EventSearchFilters::default()
-            },
-            10,
-        )
-        .unwrap();
+    let none = lexical_search_batch(
+        &index,
+        &["needle"],
+        &EventSearchFilters {
+            allowed_source_keys: Some(Vec::new()),
+            ..EventSearchFilters::default()
+        },
+        10,
+    )
+    .unwrap()
+    .candidates;
     assert!(none.is_empty());
 }
 

--- a/crates/ctx-history-index-query/tests/writer_integration/query/search.rs
+++ b/crates/ctx-history-index-query/tests/writer_integration/query/search.rs
@@ -69,17 +69,22 @@ fn copied_events_remain_searchable_and_preserve_exact_copy_claims() {
         .iter()
         .map(|event_id| event_id.digest())
         .collect::<HashSet<_>>();
-    let lexical = index
-        .search_event_candidates("lineagewindowneedle", 4)
-        .unwrap();
+    let lexical = lexical_search_batch(
+        &index,
+        &["lineagewindowneedle"],
+        &EventSearchFilters::default(),
+        4,
+    )
+    .unwrap()
+    .candidates;
     assert_eq!(lexical.len(), 4);
     assert_eq!(
         candidate_ids(&lexical).into_iter().collect::<HashSet<_>>(),
         expected_digests
     );
-    let listed = index
-        .list_event_candidates_with_filters(&EventSearchFilters::default(), 4)
-        .unwrap();
+    let listed = lexical_list_batch(&index, &EventSearchFilters::default(), 4)
+        .unwrap()
+        .candidates;
     assert_eq!(listed.len(), 4);
     assert_eq!(
         candidate_ids(&listed).into_iter().collect::<HashSet<_>>(),
@@ -137,9 +142,9 @@ fn multiple_exact_session_exclusions_filter_lexical_and_semantic_candidates() {
         ..EventSearchFilters::default()
     };
 
-    let lexical = index
-        .search_event_candidates_with_filters("multiple exclusion needle", &filters, 10)
-        .unwrap();
+    let lexical = lexical_search_batch(&index, &["multiple exclusion needle"], &filters, 10)
+        .unwrap()
+        .candidates;
     assert_eq!(
         lexical
             .iter()
@@ -147,9 +152,7 @@ fn multiple_exact_session_exclusions_filter_lexical_and_semantic_candidates() {
             .collect::<Vec<_>>(),
         vec![retained.session_id.as_uuid()]
     );
-    let listed = index
-        .list_event_candidates_with_filters(&filters, 10)
-        .unwrap();
+    let listed = lexical_list_batch(&index, &filters, 10).unwrap().candidates;
     assert_eq!(
         listed
             .iter()
@@ -234,9 +237,9 @@ fn agent_scope_filter_uses_only_explicit_core_agent_scope() {
         ..EventSearchFilters::default()
     };
 
-    let lexical = index
-        .search_event_candidates_with_filters("primaryauthorityneedle", &primary_scope, 3)
-        .unwrap();
+    let lexical = lexical_search_batch(&index, &["primaryauthorityneedle"], &primary_scope, 3)
+        .unwrap()
+        .candidates;
     let expected_primary = HashSet::from([primary.event_id, delegated.event_id, workflow.event_id]);
     let expected_primary_digests = expected_primary
         .iter()
@@ -257,33 +260,35 @@ fn agent_scope_filter_uses_only_explicit_core_agent_scope() {
             .collect()
     );
 
-    let explicit_subagent = index
-        .search_event_candidates_with_filters(
-            "primaryauthorityneedle",
-            &EventSearchFilters {
-                agent_scope: AgentScope::Subagent,
-                ..EventSearchFilters::default()
-            },
-            2,
-        )
-        .unwrap();
+    let explicit_subagent = lexical_search_batch(
+        &index,
+        &["primaryauthorityneedle"],
+        &EventSearchFilters {
+            agent_scope: AgentScope::Subagent,
+            ..EventSearchFilters::default()
+        },
+        2,
+    )
+    .unwrap()
+    .candidates;
     assert_eq!(
         candidate_ids(&explicit_subagent),
         vec![forked.event_id.digest()]
     );
 
     for expected in [&delegated, &workflow] {
-        let explicit_session = index
-            .search_event_candidates_with_filters(
-                "nonprimaryexplicitneedle",
-                &EventSearchFilters {
-                    session_id: Some(expected.session_id.as_uuid()),
-                    agent_scope: AgentScope::Primary,
-                    ..EventSearchFilters::default()
-                },
-                1,
-            )
-            .unwrap();
+        let explicit_session = lexical_search_batch(
+            &index,
+            &["nonprimaryexplicitneedle"],
+            &EventSearchFilters {
+                session_id: Some(expected.session_id.as_uuid()),
+                agent_scope: AgentScope::Primary,
+                ..EventSearchFilters::default()
+            },
+            1,
+        )
+        .unwrap()
+        .candidates;
         assert_eq!(
             candidate_ids(&explicit_session),
             vec![expected.event_id.digest()]
@@ -296,18 +301,19 @@ fn agent_scope_filter_uses_only_explicit_core_agent_scope() {
         assert_eq!(direct.session_relationship, expected.session_relationship);
         assert_eq!(direct.agent_scope, Some(CoreAgentScope::Primary));
     }
-    assert!(index
-        .search_event_candidates_with_filters(
-            "primaryauthorityneedle",
-            &EventSearchFilters {
-                session_id: Some(resumed.session_id.as_uuid()),
-                agent_scope: AgentScope::Primary,
-                ..EventSearchFilters::default()
-            },
-            1,
-        )
-        .unwrap()
-        .is_empty());
+    assert!(lexical_search_batch(
+        &index,
+        &["primaryauthorityneedle"],
+        &EventSearchFilters {
+            session_id: Some(resumed.session_id.as_uuid()),
+            agent_scope: AgentScope::Primary,
+            ..EventSearchFilters::default()
+        },
+        1,
+    )
+    .unwrap()
+    .candidates
+    .is_empty());
 }
 
 #[test]
@@ -355,9 +361,14 @@ fn copied_bodies_contribute_ordinary_search_postings() {
     let expected_copy = duplicated[2].clone();
     let (duplicated_temp, duplicated_index) = publish_class_aware_records(duplicated);
 
-    let duplicated_hits = duplicated_index
-        .search_event_candidates(NEEDLE, COPIES as usize + 2)
-        .unwrap();
+    let duplicated_hits = lexical_search_batch(
+        &duplicated_index,
+        &[NEEDLE],
+        &EventSearchFilters::default(),
+        COPIES as usize + 2,
+    )
+    .unwrap()
+    .candidates;
     assert_eq!(duplicated_hits.len(), COPIES as usize + 2);
     assert!(duplicated_hits
         .iter()
@@ -430,12 +441,22 @@ fn many_retrieval_derived_bodies_add_no_postings_or_score_order_changes() {
     let (duplicated_temp, duplicated_index) = publish_class_aware_records(duplicated);
     let (_control_temp, control_index) = publish_class_aware_records(control);
 
-    let duplicated_hits = duplicated_index
-        .search_event_candidates(NEEDLE, EXCLUDED as usize + 2)
-        .unwrap();
-    let control_hits = control_index
-        .search_event_candidates(NEEDLE, EXCLUDED as usize + 2)
-        .unwrap();
+    let duplicated_hits = lexical_search_batch(
+        &duplicated_index,
+        &[NEEDLE],
+        &EventSearchFilters::default(),
+        EXCLUDED as usize + 2,
+    )
+    .unwrap()
+    .candidates;
+    let control_hits = lexical_search_batch(
+        &control_index,
+        &[NEEDLE],
+        &EventSearchFilters::default(),
+        EXCLUDED as usize + 2,
+    )
+    .unwrap()
+    .candidates;
     assert_eq!(duplicated_hits.len(), 2);
     assert_eq!(
         candidate_ids(&duplicated_hits),
@@ -781,7 +802,14 @@ fn complete_core_body_beyond_16k_round_trips_reopens_and_has_no_stored_preview()
         );
     }
     assert_eq!(
-        index.search_event_candidates("tailonlyneedle", 10).unwrap()[0]
+        lexical_search_batch(
+            &index,
+            &["tailonlyneedle"],
+            &EventSearchFilters::default(),
+            10,
+        )
+        .unwrap()
+        .candidates[0]
             .event
             .event_id,
         expected.event_id.as_uuid()
@@ -855,39 +883,47 @@ fn retrieval_derived_records_are_absent_from_discovery_but_present_in_core_enume
     writer.commit(|_| true).unwrap();
     let index = VerifiedIndex::open_pinned(temp.path()).unwrap();
 
-    assert!(index
-        .search_event_candidates("retrievalderivedcanary", 10)
-        .unwrap()
-        .is_empty());
+    assert!(lexical_search_batch(
+        &index,
+        &["retrievalderivedcanary"],
+        &EventSearchFilters::default(),
+        10,
+    )
+    .unwrap()
+    .candidates
+    .is_empty());
     for scope in [SearchContentScope::Calls, SearchContentScope::Outputs] {
         let filters = EventSearchFilters {
             content_scope: scope,
             ..EventSearchFilters::default()
         };
-        assert!(index
-            .search_event_candidates_with_filters("retrievalderivedcanary", &filters, 10)
+        assert!(
+            lexical_search_batch(&index, &["retrievalderivedcanary"], &filters, 10)
+                .unwrap()
+                .candidates
+                .is_empty()
+        );
+        assert!(lexical_list_batch(&index, &filters, 10)
             .unwrap()
-            .is_empty());
-        assert!(index
-            .list_event_candidates_with_filters(&filters, 10)
-            .unwrap()
+            .candidates
             .is_empty());
     }
-    assert!(index
-        .list_event_candidates_with_filters(
-            &EventSearchFilters {
-                file: Some("retrievalderivedcanary.rs".to_owned()),
-                ..EventSearchFilters::default()
-            },
-            10,
-        )
-        .unwrap()
-        .is_empty());
+    assert!(lexical_list_batch(
+        &index,
+        &EventSearchFilters {
+            file: Some("retrievalderivedcanary.rs".to_owned()),
+            ..EventSearchFilters::default()
+        },
+        10,
+    )
+    .unwrap()
+    .candidates
+    .is_empty());
     assert_eq!(
         candidate_ids(
-            &index
-                .list_event_candidates_with_filters(&EventSearchFilters::default(), 10)
+            &lexical_list_batch(&index, &EventSearchFilters::default(), 10)
                 .unwrap()
+                .candidates
         ),
         vec![ordinary.event_id.digest()]
     );
@@ -937,47 +973,54 @@ fn empty_or_invalid_programmatic_queries_are_safe() {
     writer.commit(|_| true).unwrap();
     let index = VerifiedIndex::open(temp.path()).unwrap();
 
-    assert!(index.search_event_candidates("", 10).unwrap().is_empty());
-    assert!(index.search_event_candidates("body", 0).unwrap().is_empty());
+    assert!(
+        lexical_search_batch(&index, &[""], &EventSearchFilters::default(), 10)
+            .unwrap()
+            .candidates
+            .is_empty()
+    );
+    assert!(
+        lexical_search_batch(&index, &["body"], &EventSearchFilters::default(), 0)
+            .unwrap()
+            .candidates
+            .is_empty()
+    );
     assert!(matches!(
-        index.search_event_candidates_with_filters(
-            "body",
+        lexical_search_batch(
+            &index,
+            &["body"],
             &EventSearchFilters {
                 provider: Some("  ".to_owned()),
                 ..EventSearchFilters::default()
             },
             10,
         ),
-        Err(ctx_history_index_query::LexicalSearchError::Index(
-            IndexError::EmptyQueryFilter { field: "provider" }
-        ))
+        Err(IndexError::EmptyQueryFilter { field: "provider" })
     ));
     for (query, limit) in [("", 10), ("body", 0)] {
         assert!(matches!(
-            index.search_event_candidates_with_filters(
-                query,
+            lexical_search_batch(
+                &index,
+                &[query],
                 &EventSearchFilters {
                     provider: Some("  ".to_owned()),
                     ..EventSearchFilters::default()
                 },
                 limit,
             ),
-            Err(ctx_history_index_query::LexicalSearchError::Index(
-                IndexError::EmptyQueryFilter { field: "provider" }
-            ))
+            Err(IndexError::EmptyQueryFilter { field: "provider" })
         ));
     }
     assert!(matches!(
-        index.list_event_candidates_with_filters(
+        lexical_list_batch(
+            &index,
             &EventSearchFilters {
                 file: Some("  ".to_owned()),
                 ..EventSearchFilters::default()
             },
             0,
         ),
-        Err(ctx_history_index_query::LexicalSearchError::Index(
-            IndexError::EmptyQueryFilter { field: "file" }
-        ))
+        Err(IndexError::EmptyQueryFilter { field: "file" })
     ));
     assert!(matches!(
         index.events_by_id_prefix("not-a-uuid"),
@@ -1021,14 +1064,17 @@ fn class_aware_record(
     record
 }
 
-fn candidate_ids(candidates: &[EventSearchCandidate]) -> Vec<[u8; 32]> {
+fn candidate_ids(candidates: &[ctx_history_index_query::LexicalSearchCandidate]) -> Vec<[u8; 32]> {
     candidates
         .iter()
         .map(|candidate| candidate.event.event_identity_digest)
         .collect()
 }
 
-fn candidate_score(candidates: &[EventSearchCandidate], event_id: StableEntityId) -> Score {
+fn candidate_score(
+    candidates: &[ctx_history_index_query::LexicalSearchCandidate],
+    event_id: StableEntityId,
+) -> Score {
     candidates
         .iter()
         .find(|candidate| candidate.event.event_identity_digest == event_id.digest())
@@ -1076,19 +1122,25 @@ fn all_scope_applies_class_weights_and_retains_unknown_types_with_stable_ties() 
         .collect::<std::collections::HashMap<_, _>>();
     let (_temp, index) = publish_class_aware_records(records);
 
-    let omitted = index
-        .search_event_candidates("classweightneedle", 20)
-        .unwrap();
-    let explicit_all = index
-        .search_event_candidates_with_filters(
-            "classweightneedle",
-            &EventSearchFilters {
-                content_scope: SearchContentScope::All,
-                ..EventSearchFilters::default()
-            },
-            20,
-        )
-        .unwrap();
+    let omitted = lexical_search_batch(
+        &index,
+        &["classweightneedle"],
+        &EventSearchFilters::default(),
+        20,
+    )
+    .unwrap()
+    .candidates;
+    let explicit_all = lexical_search_batch(
+        &index,
+        &["classweightneedle"],
+        &EventSearchFilters {
+            content_scope: SearchContentScope::All,
+            ..EventSearchFilters::default()
+        },
+        20,
+    )
+    .unwrap()
+    .candidates;
     assert_eq!(omitted, explicit_all, "omitted and explicit all must agree");
     assert_eq!(omitted.len(), event_types.len());
 
@@ -1165,7 +1217,9 @@ fn explicit_scopes_filter_search_list_and_semantic_projection_with_ordinary_io_w
         .collect::<Vec<_>>();
     let (_temp, index) = publish_class_aware_records(records);
 
-    let all = index.search_event_candidates("scopeneedle", 20).unwrap();
+    let all = lexical_search_batch(&index, &["scopeneedle"], &EventSearchFilters::default(), 20)
+        .unwrap()
+        .candidates;
     for (scope, expected_types) in [
         (
             SearchContentScope::Transcript,
@@ -1184,12 +1238,10 @@ fn explicit_scopes_filter_search_list_and_semantic_projection_with_ordinary_io_w
             content_scope: scope,
             ..EventSearchFilters::default()
         };
-        let searched = index
-            .search_event_candidates_with_filters("scopeneedle", &filters, 20)
-            .unwrap();
-        let listed = index
-            .list_event_candidates_with_filters(&filters, 20)
-            .unwrap();
+        let searched = lexical_search_batch(&index, &["scopeneedle"], &filters, 20)
+            .unwrap()
+            .candidates;
+        let listed = lexical_list_batch(&index, &filters, 20).unwrap().candidates;
         let expected_ids = record_ids_by_type
             .iter()
             .filter(|(event_type, _)| expected_types.contains(event_type.as_str()))
@@ -1219,26 +1271,28 @@ fn explicit_scopes_filter_search_list_and_semantic_projection_with_ordinary_io_w
         }
     }
 
-    let calls = index
-        .search_event_candidates_with_filters(
-            "scopeneedle",
-            &EventSearchFilters {
-                content_scope: SearchContentScope::Calls,
-                ..EventSearchFilters::default()
-            },
-            20,
-        )
-        .unwrap();
-    let outputs = index
-        .search_event_candidates_with_filters(
-            "scopeneedle",
-            &EventSearchFilters {
-                content_scope: SearchContentScope::Outputs,
-                ..EventSearchFilters::default()
-            },
-            20,
-        )
-        .unwrap();
+    let calls = lexical_search_batch(
+        &index,
+        &["scopeneedle"],
+        &EventSearchFilters {
+            content_scope: SearchContentScope::Calls,
+            ..EventSearchFilters::default()
+        },
+        20,
+    )
+    .unwrap()
+    .candidates;
+    let outputs = lexical_search_batch(
+        &index,
+        &["scopeneedle"],
+        &EventSearchFilters {
+            content_scope: SearchContentScope::Outputs,
+            ..EventSearchFilters::default()
+        },
+        20,
+    )
+    .unwrap()
+    .candidates;
     assert_score_ratio(
         candidate_score(&all, call_id),
         candidate_score(&calls, call_id),
@@ -1290,9 +1344,14 @@ fn output_heavy_candidates_do_not_starve_the_stronger_transcript_before_top_docs
         "the fixture must put an output first without class weighting"
     );
 
-    let weighted = index
-        .search_event_candidates("saturationneedle", 1)
-        .unwrap();
+    let weighted = lexical_search_batch(
+        &index,
+        &["saturationneedle"],
+        &EventSearchFilters::default(),
+        1,
+    )
+    .unwrap()
+    .candidates;
     assert_eq!(weighted[0].event.event_id, transcript_id.as_uuid());
 }
 
@@ -1313,18 +1372,12 @@ fn exact_event_type_conflicts_with_every_explicit_content_scope_at_the_index_bou
             ..EventSearchFilters::default()
         };
         for error in [
-            index
-                .search_event_candidates_with_filters("conflictneedle", &filters, 0)
-                .unwrap_err(),
-            index
-                .list_event_candidates_with_filters(&filters, 0)
-                .unwrap_err(),
+            lexical_search_batch(&index, &["conflictneedle"], &filters, 0).unwrap_err(),
+            lexical_list_batch(&index, &filters, 0).unwrap_err(),
         ] {
             assert!(matches!(
                 error,
-                ctx_history_index_query::LexicalSearchError::Index(
-                    IndexError::ContentScopeEventTypeConflict { scope: actual }
-                )
+                IndexError::ContentScopeEventTypeConflict { scope: actual }
                     if actual == scope.as_str()
             ));
         }

--- a/crates/ctx-history-read-application/src/search.rs
+++ b/crates/ctx-history-read-application/src/search.rs
@@ -3,14 +3,14 @@ use ctx_history_core::{
     AgentScope, CaptureProvider, EventType, ProviderNativeEventCopy,
     ProviderNativeSessionRelationship,
 };
+#[cfg(test)]
+use ctx_history_index_query::SearchContentScope;
 use ctx_history_index_query::{
     CompiledSearchFilter, EventRecord, EventSearchCandidate, EventSearchFilters, IndexError,
-    LexicalExecution, LexicalMode, LexicalSearchBatch, LexicalSearchError, RankedEventRef,
-    SearchAgentScope, SearchFamilyKey, SearchSessionCoordinate, SessionGroupingClaims,
-    VerifiedIndex, MAX_LEXICAL_QUERY_RESULTS,
+    LexicalExecution, LexicalMode, LexicalSearchBatch, RankedEventRef, SearchAgentScope,
+    SearchFamilyKey, SearchSessionCoordinate, SessionGroupingClaims, VerifiedIndex,
+    MAX_LEXICAL_QUERY_RESULTS,
 };
-#[cfg(test)]
-use ctx_history_index_query::{LexicalSearchResult, SearchContentScope};
 pub use ctx_history_index_query::{SearchDiversificationDecision, SearchDiversificationStatus};
 use serde_json::{json, Value};
 use thiserror::Error;
@@ -151,8 +151,6 @@ pub enum SearchExecutionError {
     Semantic(#[from] HistorySemanticError),
     #[error(transparent)]
     Index(#[from] IndexError),
-    #[error(transparent)]
-    Lexical(#[from] LexicalSearchError),
     #[error(transparent)]
     Application(#[from] anyhow::Error),
 }
@@ -496,7 +494,7 @@ fn collect_lexical_search_hits_using<LexicalSearch, GroupingClaims>(
     grouping_claims: GroupingClaims,
 ) -> SearchExecutionResult<RankedSearchCollection>
 where
-    LexicalSearch: FnOnce(usize) -> LexicalSearchResult<LexicalSearchBatch>,
+    LexicalSearch: FnOnce(usize) -> ctx_history_index_query::Result<LexicalSearchBatch>,
     GroupingClaims: FnOnce(
         &[SearchSessionCoordinate],
     ) -> ctx_history_index_query::Result<Vec<SessionGroupingClaims>>,

--- a/crates/ctx-history-read-application/src/search/fusion.rs
+++ b/crates/ctx-history-read-application/src/search/fusion.rs
@@ -65,7 +65,6 @@ pub(super) fn search_candidate_order(
                 .cmp(&left.event.occurred_at_unix_ms)
         })
         .then_with(|| right.event.event_sequence.cmp(&left.event.event_sequence))
-        .then_with(|| left.event.event_id.cmp(&right.event.event_id))
         .then_with(|| {
             left.event
                 .event_identity_digest

--- a/crates/ctx-history-read-application/src/search/tests.rs
+++ b/crates/ctx-history-read-application/src/search/tests.rs
@@ -1194,6 +1194,42 @@ fn hybrid_fusion_keeps_full_ids_that_share_a_compact_uuid_and_ties_deterministic
 }
 
 #[test]
+fn hybrid_k_one_tie_uses_full_identity_when_uuid_order_opposes() {
+    let mut compact_preferred_digest = [0x30; 32];
+    compact_preferred_digest[6] = 0xf0;
+    let mut exact_winner_digest = [0x30; 32];
+    exact_winner_digest[6] = 0x0f;
+    let mut compact_preferred = candidate(10.0, 1, None, None, 1);
+    compact_preferred.event.event_id = ctx_history_index_format::CompactIdentity {
+        digest: compact_preferred_digest,
+    }
+    .as_uuid();
+    compact_preferred.event.event_identity_digest = compact_preferred_digest;
+    let mut exact_winner = candidate(10.0, 2, None, None, 1);
+    exact_winner.event.event_id = ctx_history_index_format::CompactIdentity {
+        digest: exact_winner_digest,
+    }
+    .as_uuid();
+    exact_winner.event.event_identity_digest = exact_winner_digest;
+    assert!(compact_preferred.event.event_id < exact_winner.event.event_id);
+    assert!(
+        exact_winner.event.event_identity_digest < compact_preferred.event.event_identity_digest
+    );
+
+    let fused = fuse_source_candidates(vec![compact_preferred], vec![exact_winner.clone()], 0.5)
+        .into_iter()
+        .take(1)
+        .collect::<Vec<_>>();
+
+    assert_eq!(fused.len(), 1);
+    assert_eq!(fused[0].event.event_id, exact_winner.event.event_id);
+    assert_eq!(
+        fused[0].event.event_identity_digest,
+        exact_winner.event.event_identity_digest
+    );
+}
+
+#[test]
 fn hybrid_semantic_endpoint_drops_the_lexical_only_zero_score_tail() {
     let lexical_only = candidate(f32::MAX, 1, None, None, 1);
     let shared = candidate(1.0, 2, None, None, 1);

--- a/crates/ctx-semantic-index/src/query_index.rs
+++ b/crates/ctx-semantic-index/src/query_index.rs
@@ -199,12 +199,12 @@ fn semantic_candidates_with_embedding(
     let active_events = pinned.stats().active_events;
     let metadata_matches = projection.len();
     let requested_k = candidate_limit.min(metadata_matches.max(1));
-    let event_is_eligible = |event_id| projection.contains(event_id);
+    let event_identity_digest = |event_id| projection.event_identity_digest(event_id);
     let search = scan_exact_generation(
         pinned,
         embeddings,
         requested_k,
-        Some(&event_is_eligible),
+        &event_identity_digest,
         Instant::now(),
     )?;
     let stats = search.stats.clone();
@@ -235,7 +235,10 @@ fn semantic_candidates_with_embedding(
         })?;
     let mut candidates = Vec::with_capacity(records.len());
     for (hit, record) in positive_hits.into_iter().zip(records) {
-        if record.event_id != hit.event_id || !projection.contains(hit.event_id) {
+        if record.event_id != hit.event_id
+            || record.event_identity_digest != hit.event_identity_digest
+            || !projection.contains(hit.event_id)
+        {
             return Err(semantic_not_ready(
                 "semantic_projection_event_mismatch",
                 format!(

--- a/crates/ctx-semantic-index/src/tests/vector_store.rs
+++ b/crates/ctx-semantic-index/src/tests/vector_store.rs
@@ -7,6 +7,13 @@ use super::super::{
 };
 use super::*;
 
+fn test_event_identity_digest(event_id: Uuid) -> Option<[u8; 32]> {
+    let mut digest = [0; 32];
+    digest[..16].copy_from_slice(event_id.as_bytes());
+    digest[16..].copy_from_slice(event_id.as_bytes());
+    Some(digest)
+}
+
 fn exact_search(
     store: &SemanticVectorStore,
     query_embedding: &[f32],
@@ -20,7 +27,7 @@ fn exact_search(
         &pinned,
         &query_embeddings,
         limit,
-        None,
+        &test_event_identity_digest,
         std::time::Instant::now(),
     )
 }
@@ -37,7 +44,7 @@ fn exact_search_multi(
         &pinned,
         query_embeddings,
         limit,
-        None,
+        &test_event_identity_digest,
         std::time::Instant::now(),
     )
 }

--- a/crates/ctx-semantic-index/src/vector_store.rs
+++ b/crates/ctx-semantic-index/src/vector_store.rs
@@ -1,5 +1,6 @@
 pub(super) struct SemanticVectorHit {
     pub(super) event_id: Uuid,
+    pub(super) event_identity_digest: [u8; 32],
     pub(super) similarity: f32,
     #[cfg_attr(not(test), expect(dead_code))]
     pub(super) query_ordinal: usize,

--- a/crates/ctx-semantic-index/src/vector_store/flat_scan.rs
+++ b/crates/ctx-semantic-index/src/vector_store/flat_scan.rs
@@ -69,15 +69,21 @@ pub(crate) struct FlatScanLocation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ActiveChunk {
     pub(crate) event_id: Uuid,
+    pub(crate) event_identity_digest: [u8; 32],
     pub(crate) chunk_ordinal: u32,
     location: Option<FlatScanLocation>,
 }
 
 impl ActiveChunk {
     #[cfg(test)]
-    pub(crate) const fn new(event_id: Uuid, chunk_ordinal: u32) -> Self {
+    pub(crate) const fn new(
+        event_id: Uuid,
+        event_identity_digest: [u8; 32],
+        chunk_ordinal: u32,
+    ) -> Self {
         Self {
             event_id,
+            event_identity_digest,
             chunk_ordinal,
             location: None,
         }
@@ -85,11 +91,13 @@ impl ActiveChunk {
 
     pub(crate) const fn at_location(
         event_id: Uuid,
+        event_identity_digest: [u8; 32],
         chunk_ordinal: u32,
         location: FlatScanLocation,
     ) -> Self {
         Self {
             event_id,
+            event_identity_digest,
             chunk_ordinal,
             location: Some(location),
         }
@@ -131,7 +139,7 @@ pub(crate) struct FlatScanCounters {
 
 #[derive(Debug, Clone)]
 pub(crate) struct FlatScanResult {
-    /// Similarity descending, then event UUID ascending.
+    /// Similarity descending, then full event identity digest ascending.
     pub(crate) hits: Vec<FlatScanHit>,
     pub(crate) counters: FlatScanCounters,
 }
@@ -139,6 +147,7 @@ pub(crate) struct FlatScanResult {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct FlatScanHit {
     pub(crate) event_id: Uuid,
+    pub(crate) event_identity_digest: [u8; 32],
     pub(crate) chunk_ordinal: u32,
     pub(crate) query_ordinal: usize,
     pub(crate) similarity: f32,
@@ -149,7 +158,7 @@ impl PartialEq for FlatScanHit {
     fn eq(&self, other: &Self) -> bool {
         // Location is provenance, not rank identity. Active-generation
         // resolution guarantees one source record for an event chunk.
-        self.event_id == other.event_id
+        self.event_identity_digest == other.event_identity_digest
             && self.chunk_ordinal == other.chunk_ordinal
             && self.query_ordinal == other.query_ordinal
             && self.similarity.total_cmp(&other.similarity) == Ordering::Equal
@@ -170,7 +179,7 @@ impl Ord for FlatScanHit {
         // the worst retained result at the BinaryHeap root.
         self.similarity
             .total_cmp(&other.similarity)
-            .then_with(|| other.event_id.cmp(&self.event_id))
+            .then_with(|| other.event_identity_digest.cmp(&self.event_identity_digest))
             .then_with(|| other.query_ordinal.cmp(&self.query_ordinal))
             .then_with(|| other.chunk_ordinal.cmp(&self.chunk_ordinal))
     }
@@ -639,6 +648,7 @@ impl<'query> ExactFlatF32Scan<'query> {
         self.counters.chunks_scanned = self.counters.chunks_scanned.saturating_add(1);
         let candidate = FlatScanHit {
             event_id: metadata.event_id,
+            event_identity_digest: metadata.event_identity_digest,
             chunk_ordinal: metadata.chunk_ordinal,
             query_ordinal,
             similarity,

--- a/crates/ctx-semantic-index/src/vector_store/flat_scan/tests.rs
+++ b/crates/ctx-semantic-index/src/vector_store/flat_scan/tests.rs
@@ -4,6 +4,24 @@ fn event_id(value: u128) -> Uuid {
     Uuid::from_u128(value)
 }
 
+fn event_id_for_digest(digest: [u8; 32]) -> Uuid {
+    let mut bytes = [0; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    bytes[6] = 0x80 | (bytes[6] & 0x0f);
+    bytes[8] = 0x80 | (bytes[8] & 0x3f);
+    Uuid::from_bytes(bytes)
+}
+
+fn event_identity_digest(value: u128) -> [u8; 32] {
+    let mut digest = [0; 32];
+    digest[16..].copy_from_slice(&value.to_be_bytes());
+    digest
+}
+
+fn active_chunk(event: u128, chunk_ordinal: u32) -> ActiveChunk {
+    ActiveChunk::new(event_id(event), event_identity_digest(event), chunk_ordinal)
+}
+
 fn normalized(mut values: Vec<f32>) -> Vec<f32> {
     let norm = values
         .iter()
@@ -103,6 +121,7 @@ fn exact_slice_and_byte_scans_match_the_f32_oracle() {
         .map(|(event, chunks)| {
             let mut best = FlatScanHit {
                 event_id: event_id(event as u128 + 1),
+                event_identity_digest: event_identity_digest(event as u128 + 1),
                 chunk_ordinal: 0,
                 query_ordinal: 0,
                 similarity: oracle_dot(&query, &chunks[0]),
@@ -111,6 +130,7 @@ fn exact_slice_and_byte_scans_match_the_f32_oracle() {
             for (chunk, vector) in chunks.iter().enumerate().skip(1) {
                 let candidate = FlatScanHit {
                     event_id: best.event_id,
+                    event_identity_digest: best.event_identity_digest,
                     chunk_ordinal: chunk as u32,
                     query_ordinal: 0,
                     similarity: oracle_dot(&query, vector),
@@ -132,7 +152,7 @@ fn exact_slice_and_byte_scans_match_the_f32_oracle() {
         .scan_f32(vectors.iter().enumerate().flat_map(|(event, chunks)| {
             chunks.iter().enumerate().map(move |(chunk, vector)| {
                 (
-                    ActiveChunk::new(event_id(event as u128 + 1), chunk as u32),
+                    active_chunk(event as u128 + 1, chunk as u32),
                     vector.as_slice(),
                 )
             })
@@ -154,7 +174,7 @@ fn exact_slice_and_byte_scans_match_the_f32_oracle() {
         .scan_le_bytes(encoded.iter().enumerate().flat_map(|(event, chunks)| {
             chunks.iter().enumerate().map(move |(chunk, vector)| {
                 (
-                    ActiveChunk::new(event_id(event as u128 + 1), chunk as u32),
+                    active_chunk(event as u128 + 1, chunk as u32),
                     vector.as_slice(),
                 )
             })
@@ -215,7 +235,7 @@ fn multivector_scan_matches_scalar_top_k_union_and_max_dedupe() {
         vectors.iter().enumerate().flat_map(|(event, chunks)| {
             chunks.iter().enumerate().map(move |(chunk, vector)| {
                 (
-                    ActiveChunk::new(event_id(event as u128 + 1), chunk as u32),
+                    active_chunk(event as u128 + 1, chunk as u32),
                     vector.as_slice(),
                 )
             })
@@ -268,9 +288,9 @@ fn multivector_equal_scores_keep_first_query_before_lower_chunk() {
     let second_query = [0.0, 1.0];
     let queries = [first_query.as_slice(), second_query.as_slice()];
     let records = [
-        (ActiveChunk::new(event_id(1), 0), second_query.as_slice()),
-        (ActiveChunk::new(event_id(1), 5), first_query.as_slice()),
-        (ActiveChunk::new(event_id(2), 0), first_query.as_slice()),
+        (active_chunk(1, 0), second_query.as_slice()),
+        (active_chunk(1, 5), first_query.as_slice()),
+        (active_chunk(2, 0), first_query.as_slice()),
     ];
     let mut scan = ExactFlatF32Scan::new_multi(&queries, FlatScanConfig::new(2, 2)).unwrap();
     scan.scan_f32(records).unwrap();
@@ -293,7 +313,7 @@ fn prevalidated_mmap_path_matches_the_checked_path() {
     let records = || {
         vectors.iter().enumerate().map(|(index, vector)| {
             (
-                ActiveChunk::new(event_id(index as u128 + 1), index as u32),
+                active_chunk(index as u128 + 1, index as u32),
                 vector.as_slice(),
             )
         })
@@ -312,13 +332,13 @@ fn prevalidated_mmap_path_matches_the_checked_path() {
 }
 
 #[test]
-fn ties_use_uuid_then_lower_chunk_ordinal() {
+fn ties_use_full_identity_then_lower_chunk_ordinal() {
     let query = [1.0, 0.0];
     let same = [1.0, 0.0];
     let records = [
-        (ActiveChunk::new(event_id(2), 9), same.as_slice()),
-        (ActiveChunk::new(event_id(2), 4), same.as_slice()),
-        (ActiveChunk::new(event_id(1), 7), same.as_slice()),
+        (active_chunk(2, 9), same.as_slice()),
+        (active_chunk(2, 4), same.as_slice()),
+        (active_chunk(1, 7), same.as_slice()),
     ];
     let mut scan = ExactFlatF32Scan::new(&query, FlatScanConfig::new(2, 2)).unwrap();
     scan.scan_f32(records).unwrap();
@@ -332,6 +352,44 @@ fn ties_use_uuid_then_lower_chunk_ordinal() {
 }
 
 #[test]
+fn top_k_one_admission_uses_full_identity_when_uuid_order_opposes() {
+    let query = [1.0, 0.0];
+    let same = [1.0, 0.0];
+    let mut compact_preferred_digest = [0x30; 32];
+    compact_preferred_digest[6] = 0xf0;
+    let mut exact_winner_digest = [0x30; 32];
+    exact_winner_digest[6] = 0x0f;
+    let compact_preferred = ActiveChunk::new(
+        event_id_for_digest(compact_preferred_digest),
+        compact_preferred_digest,
+        0,
+    );
+    let exact_winner = ActiveChunk::new(
+        event_id_for_digest(exact_winner_digest),
+        exact_winner_digest,
+        0,
+    );
+    assert!(compact_preferred.event_id < exact_winner.event_id);
+    assert!(exact_winner.event_identity_digest < compact_preferred.event_identity_digest);
+
+    let mut scan = ExactFlatF32Scan::new(&query, FlatScanConfig::new(2, 1)).unwrap();
+    scan.scan_f32([
+        (compact_preferred, same.as_slice()),
+        (exact_winner, same.as_slice()),
+    ])
+    .unwrap();
+    let result = scan.finish().unwrap();
+
+    assert_eq!(result.hits.len(), 1);
+    assert_eq!(result.hits[0].event_id, exact_winner.event_id);
+    assert_eq!(
+        result.hits[0].event_identity_digest,
+        exact_winner.event_identity_digest
+    );
+    assert_eq!(result.counters.heap_replacements, 1);
+}
+
+#[test]
 fn best_chunk_is_retained_before_top_k_admission() {
     let query = [1.0, 0.0];
     let weak = normalized(vec![1.0, 3.0]);
@@ -341,6 +399,7 @@ fn best_chunk_is_retained_before_top_k_admission() {
         (
             ActiveChunk::at_location(
                 event_id(20),
+                event_identity_digest(20),
                 0,
                 FlatScanLocation {
                     segment_index: 2,
@@ -352,6 +411,7 @@ fn best_chunk_is_retained_before_top_k_admission() {
         (
             ActiveChunk::at_location(
                 event_id(20),
+                event_identity_digest(20),
                 1,
                 FlatScanLocation {
                     segment_index: 2,
@@ -363,6 +423,7 @@ fn best_chunk_is_retained_before_top_k_admission() {
         (
             ActiveChunk::at_location(
                 event_id(10),
+                event_identity_digest(10),
                 0,
                 FlatScanLocation {
                     segment_index: 1,
@@ -397,9 +458,9 @@ fn heap_and_skip_counters_stay_bounded_and_attributable() {
     let best = [1.0, 0.0];
     let mut scan = ExactFlatF32Scan::new(&query, FlatScanConfig::new(2, 1)).unwrap();
     scan.scan_f32([
-        (ActiveChunk::new(event_id(1), 0), orthogonal.as_slice()),
-        (ActiveChunk::new(event_id(2), 0), best.as_slice()),
-        (ActiveChunk::new(event_id(2), 1), best.as_slice()),
+        (active_chunk(1, 0), orthogonal.as_slice()),
+        (active_chunk(2, 0), best.as_slice()),
+        (active_chunk(2, 1), best.as_slice()),
     ])
     .unwrap();
     scan.skip_event(2, FlatScanSkipReason::Filtered).unwrap();
@@ -440,12 +501,12 @@ fn heap_never_retains_more_than_top_k() {
         vectors.push(normalized(vec![index as f32 + 1.0, 100.0]));
     }
     let mut scan = ExactFlatF32Scan::new(&query, FlatScanConfig::new(2, 7)).unwrap();
-    scan.scan_f32(vectors.iter().enumerate().map(|(index, vector)| {
-        (
-            ActiveChunk::new(event_id(index as u128 + 1), 0),
-            vector.as_slice(),
-        )
-    }))
+    scan.scan_f32(
+        vectors
+            .iter()
+            .enumerate()
+            .map(|(index, vector)| (active_chunk(index as u128 + 1, 0), vector.as_slice())),
+    )
     .unwrap();
     let result = scan.finish().unwrap();
 
@@ -514,7 +575,7 @@ fn vector_validation_rejects_slices_and_bytes_and_poisoned_scan() {
     let mut scan = ExactFlatF32Scan::new(&query, FlatScanConfig::new(2, 1)).unwrap();
     let short = [1.0];
     assert!(matches!(
-        scan.scan_f32([(ActiveChunk::new(event_id(1), 0), short.as_slice())]),
+        scan.scan_f32([(active_chunk(1, 0), short.as_slice())]),
         Err(FlatScanError::DimensionMismatch {
             input: FlatScanInput::Vector,
             ..
@@ -532,7 +593,7 @@ fn vector_validation_rejects_slices_and_bytes_and_poisoned_scan() {
     let mut non_finite = ExactFlatF32Scan::new(&query, FlatScanConfig::new(2, 1)).unwrap();
     let bad = [f32::INFINITY, 0.0];
     assert!(matches!(
-        non_finite.scan_f32([(ActiveChunk::new(event_id(1), 4), bad.as_slice())]),
+        non_finite.scan_f32([(active_chunk(1, 4), bad.as_slice())]),
         Err(FlatScanError::NonFinite {
             input: FlatScanInput::Vector,
             chunk_ordinal: Some(4),
@@ -543,7 +604,7 @@ fn vector_validation_rejects_slices_and_bytes_and_poisoned_scan() {
     let mut not_normalized = ExactFlatF32Scan::new(&query, FlatScanConfig::new(2, 1)).unwrap();
     let bad = [0.5, 0.0];
     assert!(matches!(
-        not_normalized.scan_f32([(ActiveChunk::new(event_id(1), 5), bad.as_slice())]),
+        not_normalized.scan_f32([(active_chunk(1, 5), bad.as_slice())]),
         Err(FlatScanError::NotNormalized {
             input: FlatScanInput::Vector,
             chunk_ordinal: Some(5),
@@ -553,7 +614,7 @@ fn vector_validation_rejects_slices_and_bytes_and_poisoned_scan() {
 
     let mut bytes = ExactFlatF32Scan::new(&query, FlatScanConfig::new(2, 1)).unwrap();
     assert!(matches!(
-        bytes.scan_le_bytes([(ActiveChunk::new(event_id(1), 6), [0_u8; 7].as_slice())]),
+        bytes.scan_le_bytes([(active_chunk(1, 6), [0_u8; 7].as_slice())]),
         Err(FlatScanError::ByteLengthMismatch {
             input: FlatScanInput::Vector,
             chunk_ordinal: Some(6),
@@ -567,7 +628,7 @@ fn zero_top_k_scores_without_retaining_hits() {
     let query = [1.0, 0.0];
     let vector = [1.0, 0.0];
     let mut scan = ExactFlatF32Scan::new(&query, FlatScanConfig::new(2, 0)).unwrap();
-    scan.scan_f32([(ActiveChunk::new(event_id(1), 0), vector.as_slice())])
+    scan.scan_f32([(active_chunk(1, 0), vector.as_slice())])
         .unwrap();
     let result = scan.finish().unwrap();
 

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/content.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/content.rs
@@ -41,8 +41,19 @@ fn control_filter_and_full_tail_remain_generation_exact() -> Result<()> {
     };
     let mut query = vec![0.0; SEMANTIC_DIMENSIONS];
     query[0] = 1.0;
-    let search =
-        scan_exact_generation(&pin, std::slice::from_ref(&query), 1, None, Instant::now())?;
+    let event_identity_digest = |event_id: Uuid| {
+        let mut digest = [0; 32];
+        digest[..16].copy_from_slice(event_id.as_bytes());
+        digest[16..].copy_from_slice(event_id.as_bytes());
+        Some(digest)
+    };
+    let search = scan_exact_generation(
+        &pin,
+        std::slice::from_ref(&query),
+        1,
+        &event_identity_digest,
+        Instant::now(),
+    )?;
     assert_eq!(search.hits[0].event_id, tail_event);
     for directory in [
         fixture.semantic_path.clone(),

--- a/crates/ctx-semantic-index/src/vector_store_search.rs
+++ b/crates/ctx-semantic-index/src/vector_store_search.rs
@@ -27,7 +27,7 @@ pub(super) fn scan_exact_generation(
     reader: &PinnedFlatGeneration,
     query_embeddings: &[Vec<f32>],
     limit: usize,
-    event_is_eligible: Option<&dyn Fn(Uuid) -> bool>,
+    event_identity_digest: &dyn Fn(Uuid) -> Option<[u8; 32]>,
     started: Instant,
 ) -> Result<SemanticVectorSearch> {
     if query_embeddings.is_empty() {
@@ -64,41 +64,14 @@ pub(super) fn scan_exact_generation(
         ExactFlatF32Scan::new_multi(&query_vectors, FlatScanConfig::new(dimensions, limit))
             .map_err(|error| SemanticVectorStoreError::unavailable(error.to_string()))?;
 
-    if let Some(event_is_eligible) = event_is_eligible {
-        for (segment_index, segment) in reader.scan_segments().iter().enumerate() {
-            let mut chunks = segment.scoring_chunks().peekable();
-            while let Some(chunk) = chunks.next() {
-                if event_is_eligible(chunk.event_id) {
-                    scan.scan_prevalidated_f32(std::iter::once((
-                        ActiveChunk::at_location(
-                            chunk.event_id,
-                            chunk.chunk_index,
-                            FlatScanLocation {
-                                segment_index,
-                                segment_ordinal: chunk.ordinal,
-                            },
-                        ),
-                        chunk.vector,
-                    )))
-                    .map_err(|error| SemanticVectorStoreError::unavailable(error.to_string()))?;
-                    continue;
-                }
-                let event_id = chunk.event_id;
-                let mut skipped = 1_usize;
-                while chunks.peek().is_some_and(|next| next.event_id == event_id) {
-                    let _ = chunks.next();
-                    skipped = skipped.saturating_add(1);
-                }
-                scan.skip_event(skipped, FlatScanSkipReason::Filtered)
-                    .map_err(|error| SemanticVectorStoreError::unavailable(error.to_string()))?;
-            }
-        }
-    } else {
-        for (segment_index, segment) in reader.scan_segments().iter().enumerate() {
-            scan.scan_prevalidated_f32(segment.scoring_chunks().map(|chunk| {
-                (
+    for (segment_index, segment) in reader.scan_segments().iter().enumerate() {
+        let mut chunks = segment.scoring_chunks().peekable();
+        while let Some(chunk) = chunks.next() {
+            if let Some(event_identity_digest) = event_identity_digest(chunk.event_id) {
+                scan.scan_prevalidated_f32(std::iter::once((
                     ActiveChunk::at_location(
                         chunk.event_id,
+                        event_identity_digest,
                         chunk.chunk_index,
                         FlatScanLocation {
                             segment_index,
@@ -106,9 +79,18 @@ pub(super) fn scan_exact_generation(
                         },
                     ),
                     chunk.vector,
-                )
-            }))
-            .map_err(|error| SemanticVectorStoreError::unavailable(error.to_string()))?;
+                )))
+                .map_err(|error| SemanticVectorStoreError::unavailable(error.to_string()))?;
+                continue;
+            }
+            let event_id = chunk.event_id;
+            let mut skipped = 1_usize;
+            while chunks.peek().is_some_and(|next| next.event_id == event_id) {
+                let _ = chunks.next();
+                skipped = skipped.saturating_add(1);
+            }
+            scan.skip_event(skipped, FlatScanSkipReason::Filtered)
+                .map_err(|error| SemanticVectorStoreError::unavailable(error.to_string()))?;
         }
     }
     let scanned = scan
@@ -134,6 +116,7 @@ pub(super) fn scan_exact_generation(
             })?;
         hits.push(SemanticVectorHit {
             event_id: chunk.event_id,
+            event_identity_digest: hit.event_identity_digest,
             similarity: hit.similarity,
             query_ordinal: hit.query_ordinal,
             source_text_hash: chunk.source_text_hash.to_hex(),
@@ -208,6 +191,7 @@ mod tests {
         let temp = tempfile::tempdir()?;
         let mut store = SemanticVectorStore::open(&temp.path().join("search").join("semantic"))?;
         let event_id = Uuid::new_v4();
+        let event_identity_digest = [7; 32];
         let mut embedding = vec![0.0; SEMANTIC_DIMENSIONS];
         embedding[0] = 1.0;
         store.publish_chunk_replacements(
@@ -239,7 +223,7 @@ mod tests {
                 &pinned,
                 std::slice::from_ref(&embedding),
                 1,
-                None,
+                &|candidate| (candidate == event_id).then_some(event_identity_digest),
                 Instant::now(),
             );
             let _ = result_tx.send(result);


### PR DESCRIPTION
Removes the obsolete complete-result compatibility layer.

Compiles one filter, runs one lexical candidate pass, and hydrates winners only.

Carries the full event digest through semantic projection and vector ranking so compact UUID collisions cannot decide equal-score ties.

Preserves the manual semantic refresh behavior from #726.

Tests cover real segment boundaries and adversarial full-identity ties; the reviewed performance evidence covers bounded candidate execution and winner-only hydration.