### PR TITLE
fix(search): preflight ready semantic generations

### DIFF
--- a/crates/ctx-daemon-cli/src/query_adapter.rs
+++ b/crates/ctx-daemon-cli/src/query_adapter.rs
@@ -68,11 +68,25 @@ impl HistorySemanticPort for SemanticQueryAdapter<'_> {
             SemanticQueryExecution::Foreground {
                 runtime,
                 model_config,
-            } => {
-                reconcile_foreground_semantic(index, self.data_root, runtime, model_config)
-                    .map_err(SemanticQueryError::from)?;
-                SemanticQuerySession::begin_foreground(index, self.data_root, runtime, model_config)
-            }
+            } => match SemanticQuerySession::begin_foreground(
+                index,
+                self.data_root,
+                runtime,
+                model_config,
+            ) {
+                Ok(session) => Ok(session),
+                Err(SemanticQueryError::NotReady { .. }) => {
+                    reconcile_foreground_semantic(index, self.data_root, runtime, model_config)
+                        .map_err(SemanticQueryError::from)?;
+                    SemanticQuerySession::begin_foreground(
+                        index,
+                        self.data_root,
+                        runtime,
+                        model_config,
+                    )
+                }
+                Err(error) => Err(error),
+            },
         }
         .map_err(HistorySemanticError::from)
     }

--- a/crates/ctx-daemon-cli/src/query_adapter/tests.rs
+++ b/crates/ctx-daemon-cli/src/query_adapter/tests.rs
@@ -1,4 +1,8 @@
-use std::cell::Cell;
+use std::{
+    cell::Cell,
+    fs::{self, OpenOptions},
+    time::{Duration, Instant},
+};
 
 use ctx_history_core::{
     derive_event_id, derive_session_id, CertifiedSource, CoreRecord, EventIdentityInput,
@@ -11,7 +15,9 @@ use ctx_semantic_index::{
     test_support::{pinned_flat_generation, publish_chunk_replacements, semantic_chunk_document},
     SemanticBatchEmbedder, SemanticChunkDocument, SemanticDocumentBuilder, SemanticEventDocument,
     SemanticQueryPin, SemanticVectorStore, SourceBackedGenerationPin,
+    SourceBackedSemanticDocumentBuilder,
 };
+use fs2::FileExt as _;
 use uuid::Uuid;
 
 use super::*;
@@ -175,6 +181,64 @@ fn foreground_empty_generation_converges_without_loading_a_model() -> Result<()>
         unreachable!("foreground constructor selected daemon execution")
     };
     assert!(!runtime.is_loaded());
+    Ok(())
+}
+
+struct FixtureSemanticEmbedder;
+
+impl SemanticBatchEmbedder for FixtureSemanticEmbedder {
+    fn embed_chunks(&mut self, chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
+        Ok(chunks.iter().map(|_| embedding()).collect())
+    }
+}
+
+fn reconcile_ready_nonempty_generation(index: &VerifiedIndex, data_root: &Path) -> Result<()> {
+    let mut store = SemanticVectorStore::open(&source_backed_semantic_vector_path(data_root))?;
+    let mut builder = SourceBackedSemanticDocumentBuilder::new(index);
+    let mut embedder = FixtureSemanticEmbedder;
+    for _ in 0..32 {
+        if store
+            .reconcile_source_backed_index(index, &mut builder, &mut embedder)?
+            .ready()
+        {
+            return Ok(());
+        }
+    }
+    Err(anyhow!("nonempty semantic fixture did not converge"))
+}
+
+#[test]
+fn foreground_ready_nonempty_generation_skips_model_and_writable_reconciliation() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let (index, _) = semantic_index(temp.path())?;
+    reconcile_ready_nonempty_generation(&index, temp.path())?;
+    let semantic_path = source_backed_semantic_vector_path(temp.path());
+    let transaction_lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(semantic_path.join("flat_transaction.lock"))?;
+    transaction_lock.lock_exclusive()?;
+    let state_path = semantic_path.join("state.sqlite");
+    let mut state_permissions = fs::metadata(&state_path)?.permissions();
+    state_permissions.set_readonly(true);
+    fs::set_permissions(&state_path, state_permissions)?;
+
+    let adapter = SemanticQueryAdapter::foreground(temp.path());
+    let started = Instant::now();
+    let _session = adapter
+        .begin_query(&index)
+        .map_err(|error| anyhow!(error.to_string()))?;
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "a ready foreground query must not wait on the Flat write transaction lock"
+    );
+    let SemanticQueryExecution::Foreground { runtime, .. } = &adapter.execution else {
+        unreachable!("foreground constructor selected daemon execution")
+    };
+    assert!(
+        !runtime.is_loaded(),
+        "a ready foreground query must not acquire or load the semantic model"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Preflight foreground semantic queries before writable reconciliation so already-ready generations avoid the Flat write path and model loading.

Reconcile only typed not-ready results, then preflight again. Add regression coverage for the ready nonempty path under a held Flat write lock and read-only semantic state.

Follow-up to #726.