### PR TITLE
Clarify human search result identity

### DIFF
--- a/crates/ctx-cli-presentation/src/commands/status_presentation.rs
+++ b/crates/ctx-cli-presentation/src/commands/status_presentation.rs
@@ -323,7 +323,7 @@ mod tests {
             let rendered = document.render_plain();
             let normalized = rendered.split_whitespace().collect::<Vec<_>>().join(" ");
             assert!(rendered.starts_with("✓ ctx is healthy\n\nHistory\n"));
-            assert!(normalized.contains("Agent histories Claude, Codex"));
+            assert!(normalized.contains("Agent histories Claude Code, Codex"));
             assert!(normalized.contains("Roots 3 included roots"));
             assert!(!rendered.contains("747"));
             assert!(normalized.contains("Sessions 2"));

--- a/crates/ctx-history-capture-model/src/source.rs
+++ b/crates/ctx-history-capture-model/src/source.rs
@@ -155,7 +155,6 @@ pub struct ProviderDefaultLocation {
 #[derive(Debug, Clone, Copy)]
 pub struct ProviderSourceSpec {
     pub provider: CaptureProvider,
-    pub display_name: &'static str,
     pub default_locations: &'static [ProviderDefaultLocation],
     pub import_support: ProviderImportSupport,
     pub catalog_support: ProviderCatalogSupport,

--- a/crates/ctx-history-cli/src/progress.rs
+++ b/crates/ctx-history-cli/src/progress.rs
@@ -1,6 +1,5 @@
 //! Neutral refresh-progress conversion and terminal reporting.
 
-use ctx_history_capture::provider_source_spec;
 use ctx_history_core::CaptureProvider;
 use ctx_history_refresh::{
     RefreshLogicalPhase as EngineLogicalPhase, RefreshRequestState as EngineRequestState,
@@ -216,14 +215,10 @@ fn presentation_whole_run_stage(value: EngineWholeRunStage) -> RefreshWholeRunSt
 }
 
 pub fn provider_display_name(provider: &str) -> String {
-    provider
-        .parse::<CaptureProvider>()
-        .ok()
-        .and_then(provider_source_spec)
-        .map_or_else(
-            || provider.replace('_', " "),
-            |spec| spec.display_name.to_owned(),
-        )
+    provider.parse::<CaptureProvider>().map_or_else(
+        |_| provider.replace('_', " "),
+        |provider| provider.display_name().to_owned(),
+    )
 }
 
 fn presentation_request_state(value: EngineRequestState) -> RefreshRequestState {
@@ -340,6 +335,20 @@ mod tests {
         );
         assert!(!snapshot.is_terminal());
         assert_eq!(snapshot.phase(), "committed");
+    }
+
+    #[test]
+    fn provider_names_use_products_and_preserve_unknown_fallbacks() {
+        for (provider, expected) in [
+            ("claude", "Claude Code"),
+            ("gemini", "Gemini"),
+            ("copilot_cli", "GitHub Copilot"),
+            ("kiro_cli", "Kiro"),
+            ("kimi_code_cli", "Kimi Code"),
+            ("custom_provider", "custom provider"),
+        ] {
+            assert_eq!(provider_display_name(provider), expected);
+        }
     }
 
     #[test]

--- a/crates/ctx-history-cli/src/provider_sources.rs
+++ b/crates/ctx-history-cli/src/provider_sources.rs
@@ -96,7 +96,7 @@ pub fn provider_selection_guidance(
     provider: CaptureProvider,
 ) -> ctx_history_ingest_application::ProviderSelectionGuidance {
     ctx_history_ingest_application::ProviderSelectionGuidance {
-        display_name: provider_cli_name(provider).to_owned(),
+        display_name: provider.display_name().to_owned(),
         manual_path_command: manual_path_guidance(provider),
     }
 }
@@ -703,10 +703,28 @@ mod tests {
     #[test]
     fn hermes_has_importable_application_guidance() {
         let guidance = provider_selection_guidance(CaptureProvider::Hermes);
-        assert_eq!(guidance.display_name, "hermes");
+        assert_eq!(guidance.display_name, "Hermes Agent");
         assert_eq!(
             guidance.manual_path_command,
             "ctx import --provider hermes --path <path>"
         );
+    }
+
+    #[test]
+    fn provider_guidance_separates_human_labels_from_cli_selectors() {
+        for (provider, display_name, selector) in [
+            (CaptureProvider::Claude, "Claude Code", "claude"),
+            (CaptureProvider::Gemini, "Gemini", "gemini"),
+            (CaptureProvider::CopilotCli, "GitHub Copilot", "copilot-cli"),
+            (CaptureProvider::KiroCli, "Kiro", "kiro-cli"),
+            (CaptureProvider::KimiCodeCli, "Kimi Code", "kimi-code-cli"),
+        ] {
+            let guidance = provider_selection_guidance(provider);
+            assert_eq!(guidance.display_name, display_name);
+            assert_eq!(
+                guidance.manual_path_command,
+                format!("ctx import --provider {selector} --path <path>")
+            );
+        }
     }
 }

--- a/crates/ctx-history-cli/src/source_index/render/goldens/search.txt
+++ b/crates/ctx-history-cli/src/source_index/render/goldens/search.txt
@@ -1,10 +1,11 @@
 1 result · relevance order · all agent sessions
 
 1. Fix the Unicode cache key regression in the parser.
-   Session  codex · demo-unicode-session
-   Agent    primary
-   Event    01900001 · 2026-07-30T12:00:00.123Z
-   More     2 results from this session
+   Provider  Codex
+   Session   01900000
+   Root      01900000
+   Event     01900001 · 2026-07-30T12:00:00.123Z
+   More      2 results from this session
 
    Inspect
-     ctx show event 01900001-0000-7000-8000-000000000002 --window 10
+     ctx show event 01900001 --window 10

--- a/crates/ctx-history-cli/src/source_index/render/human.rs
+++ b/crates/ctx-history-cli/src/source_index/render/human.rs
@@ -8,13 +8,6 @@ pub(super) fn display_width(text: &str) -> usize {
     UnicodeWidthStr::width(text)
 }
 
-pub(super) fn compact_or_legacy_short_id(value: &str) -> String {
-    if uuid::Uuid::parse_str(value).is_ok() {
-        return value.chars().take(8).collect();
-    }
-    value.to_owned()
-}
-
 pub(super) fn push_heading(document: &mut Document, text: &str, token: Token) {
     document.push_line(Line::styled(text, token));
 }

--- a/crates/ctx-history-cli/src/source_index/render/search.rs
+++ b/crates/ctx-history-cli/src/source_index/render/search.rs
@@ -8,12 +8,11 @@ use crate::{
 };
 
 use super::human::{
-    compact_or_legacy_short_id, display_width, push_action, push_field, push_heading,
-    push_prefixed, push_wrapped,
+    display_width, push_action, push_field, push_heading, push_prefixed, push_wrapped,
 };
 
 const CARD_INDENT: usize = 3;
-const CARD_LABEL_WIDTH: usize = 7;
+const CARD_LABEL_WIDTH: usize = 8;
 const VERBOSE_LABEL_WIDTH: usize = 16;
 
 pub(in crate::source_index) fn render_search_not_ready_document(
@@ -189,26 +188,38 @@ fn render_result(
         push_wrapped(document, context, CARD_INDENT, line, Token::Text);
     }
 
-    let provider = result_source_label(result);
-    let provider_session = result["provider_session_id"]
-        .as_str()
-        .filter(|value| !value.is_empty());
-    let ctx_session = result["ctx_session_id"].as_str().unwrap_or("unknown");
-    let separator = if context.unicode() { " · " } else { " | " };
-    let session = provider_session.map_or_else(
-        || format!("{provider}{separator}session {ctx_session}"),
-        |provider_session| format!("{provider}{separator}{provider_session}"),
+    let provider = result_provider_label(result);
+    push_field(
+        document,
+        context,
+        CARD_INDENT,
+        "Provider",
+        CARD_LABEL_WIDTH,
+        &provider,
+        Token::Text,
     );
+    if let Some(source) = result_source_identity(result) {
+        push_field(
+            document,
+            context,
+            CARD_INDENT,
+            "Source",
+            CARD_LABEL_WIDTH,
+            &source,
+            Token::Text,
+        );
+    }
+    let ctx_session = result["ctx_session_id"].as_str().unwrap_or("unknown");
     push_field(
         document,
         context,
         CARD_INDENT,
         "Session",
         CARD_LABEL_WIDTH,
-        &session,
-        Token::Text,
+        ctx_session,
+        Token::Reference,
     );
-    render_agent_field(document, context, result);
+    render_direct_lineage_fields(document, context, result);
 
     let event_id = result["ctx_event_id"].as_str().unwrap_or("unknown");
     render_event_summary(document, context, event_id, result["timestamp"].as_str());
@@ -276,7 +287,6 @@ fn render_event_summary(
     event_id: &str,
     timestamp: Option<&str>,
 ) {
-    let event_id = compact_or_legacy_short_id(event_id);
     let (time, time_token) = timestamp
         .filter(|timestamp| !timestamp.is_empty())
         .map_or(("time unavailable", Token::Label), |timestamp| {
@@ -287,7 +297,7 @@ fn render_event_summary(
         .saturating_add(CARD_LABEL_WIDTH)
         .saturating_add(2);
     let combined_width = prefix_width
-        .saturating_add(display_width(&event_id))
+        .saturating_add(display_width(event_id))
         .saturating_add(display_width(separator))
         .saturating_add(display_width(time));
 
@@ -314,7 +324,7 @@ fn render_event_summary(
             CARD_INDENT,
             "Event",
             CARD_LABEL_WIDTH,
-            &event_id,
+            event_id,
             Token::Reference,
         );
         push_field(
@@ -332,12 +342,10 @@ fn render_event_summary(
 fn render_verbose_fields(document: &mut Document, context: &RenderContext, result: &Value) {
     for (label, key, token) in [
         ("Type", "title", Token::Text),
-        ("Event", "ctx_event_id", Token::Reference),
-        ("Ctx session", "ctx_session_id", Token::Reference),
         ("Provider session", "provider_session_id", Token::Reference),
         ("Provider key", "provider_key", Token::Text),
         ("Source ID", "source_id", Token::Text),
-        ("Source", "source_format", Token::Text),
+        ("Source format", "source_format", Token::Text),
     ] {
         if let Some(value) = result[key].as_str().filter(|value| !value.is_empty()) {
             push_field(
@@ -362,7 +370,6 @@ fn render_verbose_fields(document: &mut Document, context: &RenderContext, resul
             Token::Text,
         );
     }
-    render_lineage_fields(document, context, result);
     if let Some(rank) = result["rank"].as_u64() {
         push_field(
             document,
@@ -387,175 +394,56 @@ fn render_verbose_fields(document: &mut Document, context: &RenderContext, resul
     }
 }
 
-fn result_source_label(result: &Value) -> String {
-    match (
-        result["provider_key"].as_str(),
-        result["source_id"].as_str(),
-    ) {
-        (Some(provider_key), Some(source_id)) => format!("{provider_key}/{source_id}"),
-        _ => result["provider"].as_str().unwrap_or("unknown").to_owned(),
-    }
+fn result_provider_label(result: &Value) -> String {
+    crate::provider_display_name(result["provider"].as_str().unwrap_or("unknown"))
 }
 
-fn render_agent_field(document: &mut Document, context: &RenderContext, result: &Value) {
-    let agent = result["agent_scope"]
+fn result_source_identity(result: &Value) -> Option<String> {
+    let provider = result["provider"]
         .as_str()
         .filter(|value| !value.is_empty())
         .unwrap_or("unknown");
-    let mut chunks = vec![agent_chunk(agent, Token::Text)];
-    if agent == "subagent" {
-        let parent = result["parent_ctx_session_id"]
-            .as_str()
-            .filter(|value| !value.is_empty());
-        let root = result["root_ctx_session_id"]
-            .as_str()
-            .filter(|value| !value.is_empty());
-        match (parent, root) {
-            (Some(parent), Some(root)) if parent == root => {
-                chunks.push(agent_reference_chunk("parent/root", parent));
-            }
-            (parent, root) => {
-                if let Some(parent) = parent {
-                    chunks.push(agent_reference_chunk("parent", parent));
-                }
-                if let Some(root) = root {
-                    chunks.push(agent_reference_chunk("root", root));
-                }
-            }
+    let provider_key = result["provider_key"]
+        .as_str()
+        .filter(|value| !value.is_empty());
+    let source_id = result["source_id"]
+        .as_str()
+        .filter(|value| !value.is_empty());
+    let identity = match (provider_key, source_id) {
+        (Some(provider_key), Some(source_id)) if provider_key == source_id => {
+            provider_key.to_owned()
         }
-    }
-    push_agent_chunks(document, context, chunks);
-}
-
-type AgentChunk = Vec<(String, Token)>;
-
-fn agent_chunk(text: &str, token: Token) -> AgentChunk {
-    let span = Span::new(text, token);
-    vec![(span.content().to_owned(), token)]
-}
-
-fn agent_reference_chunk(label: &str, reference: &str) -> AgentChunk {
-    let mut chunk = agent_chunk(&format!("{label} "), Token::Text);
-    // The application projection has already chosen the shortest prefix that
-    // is unambiguous in the pinned generation. Preserve that reference exactly;
-    // optional provider claims that cannot be resolved remain full UUIDs.
-    chunk.extend(agent_chunk(reference, Token::Reference));
-    chunk
-}
-
-fn push_agent_chunks(document: &mut Document, context: &RenderContext, chunks: Vec<AgentChunk>) {
-    let label = Span::new("Agent", Token::Label).content().to_owned();
-    let label_width = CARD_LABEL_WIDTH.max(display_width(&label));
-    let aligned_prefix_width = CARD_INDENT.saturating_add(label_width).saturating_add(2);
-    let aligned = context
-        .content_width()
-        .is_none_or(|width| width >= aligned_prefix_width.saturating_add(8));
-    let value_indent = if aligned {
-        aligned_prefix_width
-    } else {
-        document.push_line(
-            Line::new()
-                .with(Span::text(" ".repeat(CARD_INDENT)))
-                .with(Span::new(&label, Token::Label)),
-        );
-        CARD_INDENT.saturating_add(2)
+        (Some(provider_key), Some(source_id)) => format!("{provider_key}/{source_id}"),
+        (Some(provider_key), None) => provider_key.to_owned(),
+        (None, Some(source_id)) => source_id.to_owned(),
+        (None, None) => return None,
     };
-    let value_width = context
-        .content_width()
-        .map(|width| width.saturating_sub(value_indent).max(1));
-    let separator = if context.unicode() { " · " } else { " | " };
-    let separator = Span::new(separator, Token::Label).content().to_owned();
-    let separator_width = display_width(&separator);
-
-    let mut rows = Vec::<AgentChunk>::new();
-    let mut row = AgentChunk::new();
-    let mut row_width = 0usize;
-    for chunk in chunks {
-        let chunk_width = chunk.iter().fold(0usize, |width, (text, _)| {
-            width.saturating_add(display_width(text))
-        });
-        let next_separator_width = if row.is_empty() { 0 } else { separator_width };
-        let next_width = row_width
-            .saturating_add(next_separator_width)
-            .saturating_add(chunk_width);
-        if !row.is_empty() && value_width.is_some_and(|available| next_width > available) {
-            rows.push(std::mem::take(&mut row));
-            row_width = 0;
-        }
-        if !row.is_empty() {
-            row.push((separator.clone(), Token::Label));
-            row_width = row_width.saturating_add(separator_width);
-        }
-        row.extend(chunk);
-        row_width = row_width.saturating_add(chunk_width);
-    }
-    if !row.is_empty() {
-        rows.push(row);
-    }
-
-    for (index, row) in rows.into_iter().enumerate() {
-        let mut line = Line::new().with(Span::text(" ".repeat(CARD_INDENT)));
-        if aligned {
-            if index == 0 {
-                line.push(Span::new(&label, Token::Label));
-                line.push(Span::text(
-                    " ".repeat(label_width.saturating_sub(display_width(&label))),
-                ));
-            } else {
-                line.push(Span::text(" ".repeat(label_width)));
-            }
-            line.push(Span::text("  "));
-        } else {
-            line.push(Span::text("  "));
-        }
-        for (text, token) in row {
-            line.push(Span::new(text, token));
-        }
-        document.push_line(line);
+    let display_provider = crate::provider_display_name(provider);
+    if identity == provider || identity == display_provider {
+        None
+    } else {
+        Some(identity)
     }
 }
 
-fn render_lineage_fields(document: &mut Document, context: &RenderContext, result: &Value) {
-    let direct = result["ctx_session_id"].as_str();
-    let parent = result["parent_ctx_session_id"]
-        .as_str()
-        .filter(|parent| Some(*parent) != direct);
-    let root = result["root_ctx_session_id"]
-        .as_str()
-        .filter(|root| Some(*root) != direct);
-    match (parent, root) {
-        (Some(parent), Some(root)) if parent == root => push_field(
-            document,
-            context,
-            CARD_INDENT,
-            "Parent / root",
-            VERBOSE_LABEL_WIDTH,
-            parent,
-            Token::Reference,
-        ),
-        (parent, root) => {
-            if let Some(parent) = parent {
-                push_field(
-                    document,
-                    context,
-                    CARD_INDENT,
-                    "Parent",
-                    VERBOSE_LABEL_WIDTH,
-                    parent,
-                    Token::Reference,
-                );
-            }
-            if let Some(root) = root {
-                push_field(
-                    document,
-                    context,
-                    CARD_INDENT,
-                    "Root",
-                    VERBOSE_LABEL_WIDTH,
-                    root,
-                    Token::Reference,
-                );
-            }
+fn render_direct_lineage_fields(document: &mut Document, context: &RenderContext, result: &Value) {
+    for (label, key) in [
+        ("Parent", "parent_ctx_session_id"),
+        ("Root", "root_ctx_session_id"),
+    ] {
+        if let Some(reference) = result[key].as_str().filter(|value| !value.is_empty()) {
+            // The compact application projection has already chosen the
+            // shortest unambiguous prefix. Optional unresolved claims stay
+            // full, and verbose rendering receives the unprojected full IDs.
+            push_field(
+                document,
+                context,
+                CARD_INDENT,
+                label,
+                CARD_LABEL_WIDTH,
+                reference,
+                Token::Reference,
+            );
         }
     }
 }

--- a/crates/ctx-history-cli/src/source_index/render/tests.rs
+++ b/crates/ctx-history-cli/src/source_index/render/tests.rs
@@ -14,11 +14,13 @@ use crate::ui::{
 };
 
 const SESSION_ID: &str = "01900000-0000-7000-8000-000000000001";
+const SESSION_REF: &str = "01900000";
 const PARENT_SESSION_ID: &str = "01900010-0000-7000-8000-000000000010";
 const ROOT_SESSION_ID: &str = "01900020-0000-7000-8000-000000000020";
 const PARENT_SESSION_REF: &str = "019000100";
 const ROOT_SESSION_REF: &str = "019000101";
 const EVENT_ID: &str = "01900001-0000-7000-8000-000000000002";
+const EVENT_REF: &str = "01900001";
 const SECOND_EVENT_ID: &str = "01900002-0000-7000-8000-000000000003";
 
 #[test]
@@ -256,7 +258,7 @@ fn search_agent_value(
     parent: Option<&str>,
     root: Option<&str>,
 ) -> Value {
-    let mut value = search_value();
+    let mut value = compact_search_value();
     let result = value["results"][0]
         .as_object_mut()
         .expect("search fixture result is an object");
@@ -273,6 +275,20 @@ fn search_agent_value(
         "root_ctx_session_id".to_owned(),
         root.map_or(Value::Null, |root| json!(root)),
     );
+    value
+}
+
+fn compact_search_value() -> Value {
+    let mut value = search_value();
+    let result = &mut value["results"][0];
+    result["ctx_event_id"] = json!(EVENT_REF);
+    result["ctx_session_id"] = json!(SESSION_REF);
+    result["root_ctx_session_id"] = json!(SESSION_REF);
+    result["suggested_next_commands"] = json!([
+        format!("ctx show event {EVENT_REF} --window 10"),
+        format!("ctx show session {SESSION_REF}"),
+        format!("ctx search 'Unicode cache key' --session {SESSION_REF}"),
+    ]);
     value
 }
 
@@ -451,7 +467,7 @@ fn strip_ansi(rendered: &str) -> String {
 fn primary_renderers_match_reference_goldens_at_80_columns() {
     let context = context(80, ColorMode::Never);
     assert_eq!(
-        render_search_document(&search_value(), false, &context).render_plain(),
+        render_search_document(&compact_search_value(), false, &context).render_plain(),
         include_str!("goldens/search.txt")
     );
     assert_eq!(
@@ -508,61 +524,64 @@ fn search_heading_discloses_relevance_order_and_truthful_agent_scope() {
 }
 
 #[test]
-fn normal_search_agent_field_renders_primary() {
+fn normal_search_card_separates_provider_session_and_literal_root() {
     for width in [32, 48, 80, 120] {
         let context = context(width, ColorMode::Never);
-        let document = render_search_document(&search_value(), false, &context);
+        let document = render_search_document(&compact_search_value(), false, &context);
         let rendered = document.render_plain();
 
-        assert!(rendered.contains("   Agent    primary"), "{rendered}");
-        assert_eq!(rendered.matches("Agent").count(), 1, "{rendered}");
+        assert!(!rendered.contains("Agent"), "{rendered}");
+        assert!(!rendered.contains("demo-unicode-session"), "{rendered}");
         assert_fits(&document, &context);
     }
+
+    let rendered = render_search_document(
+        &compact_search_value(),
+        false,
+        &context(120, ColorMode::Never),
+    )
+    .render_plain();
+    assert!(rendered.contains("   Provider  Codex"), "{rendered}");
+    assert!(
+        rendered.contains(&format!("   Session   {SESSION_REF}")),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains(&format!("   Root      {SESSION_REF}")),
+        "{rendered}"
+    );
+    assert!(!rendered.contains("   Source"), "{rendered}");
 }
 
 #[test]
-fn normal_search_agent_field_collapses_child_parent_and_root() {
+fn normal_search_card_keeps_equal_parent_and_root_as_separate_claims() {
     let value = search_agent_value(
         Some("subagent"),
         Some(ROOT_SESSION_REF),
         Some(ROOT_SESSION_REF),
     );
-    for unicode in [true, false] {
-        let separator = if unicode { " · " } else { " | " };
-        let document = render_search_document(&value, false, &context_with_unicode(80, unicode));
-        let rendered = document.render_plain();
-        assert!(
-            rendered.contains(&format!(
-                "   Agent    subagent{separator}parent/root {ROOT_SESSION_REF}"
-            )),
-            "{rendered}"
-        );
-        assert!(document
-            .lines()
-            .iter()
-            .flat_map(|line| line.spans())
-            .any(|span| span.content() == ROOT_SESSION_REF && span.token() == Token::Reference));
-    }
+    let document = render_search_document(&value, false, &context(120, ColorMode::Never));
+    let rendered = document.render_plain();
+    assert!(
+        rendered.contains(&format!("   Parent    {ROOT_SESSION_REF}")),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains(&format!("   Root      {ROOT_SESSION_REF}")),
+        "{rendered}"
+    );
+    assert_eq!(rendered.matches(ROOT_SESSION_REF).count(), 2, "{rendered}");
+    assert!(!rendered.contains("Parent / root"), "{rendered}");
+    assert!(!rendered.contains("Agent"), "{rendered}");
 }
 
 #[test]
-fn normal_search_agent_field_renders_nested_direct_lineage() {
+fn normal_search_card_renders_nested_direct_lineage() {
     let value = search_agent_value(
         Some("subagent"),
         Some(PARENT_SESSION_REF),
         Some(ROOT_SESSION_REF),
     );
-    for unicode in [true, false] {
-        let separator = if unicode { " · " } else { " | " };
-        let rendered = render_search_document(&value, false, &context_with_unicode(80, unicode))
-            .render_plain();
-        assert!(
-            rendered.contains(&format!(
-                "   Agent    subagent{separator}parent {PARENT_SESSION_REF}{separator}root {ROOT_SESSION_REF}"
-            )),
-            "{rendered}"
-        );
-    }
 
     for width in [32, 48, 80, 120] {
         let styled = context(width, ColorMode::Always);
@@ -588,21 +607,21 @@ fn normal_search_agent_field_renders_nested_direct_lineage() {
 }
 
 #[test]
-fn normal_search_agent_field_renders_only_available_direct_lineage() {
+fn normal_search_card_renders_only_present_direct_lineage() {
     let cases = [
         (
             Some(PARENT_SESSION_REF),
             None,
-            "   Agent    subagent · parent 019000100",
-            "root 019000101",
+            "   Parent    019000100",
+            "   Root",
         ),
         (
             None,
             Some(ROOT_SESSION_REF),
-            "   Agent    subagent · root 019000101",
-            "parent 019000100",
+            "   Root      019000101",
+            "   Parent",
         ),
-        (None, None, "   Agent    subagent", "parent/root"),
+        (None, None, "   Session", "   Parent"),
     ];
     for (parent, root, expected, absent) in cases {
         let rendered = render_search_document(
@@ -613,22 +632,22 @@ fn normal_search_agent_field_renders_only_available_direct_lineage() {
         .render_plain();
         assert!(rendered.contains(expected), "{rendered}");
         assert!(!rendered.contains(absent), "{rendered}");
+        if root.is_none() {
+            assert!(!rendered.contains("   Root"), "{rendered}");
+        }
+        assert!(!rendered.contains("Agent"), "{rendered}");
     }
-
-    let controlled = search_agent_value(Some("subagent"), Some("parent\u{1b}[31m"), None);
-    let rendered =
-        render_search_document(&controlled, false, &context(48, ColorMode::Never)).render_plain();
-    assert!(rendered.contains("parent\\x1b[31m"), "{rendered}");
-    assert_control_safe(&rendered);
 }
 
 #[test]
-fn normal_search_agent_field_preserves_an_unresolved_full_reference() {
-    let value = search_agent_value(Some("subagent"), Some(PARENT_SESSION_ID), None);
+fn normal_search_card_preserves_an_unresolved_full_reference() {
+    let mut value = search_agent_value(Some("subagent"), Some(PARENT_SESSION_ID), None);
+    value["results"][0]["ctx_event_id"] = json!(EVENT_ID);
     let document = render_search_document(&value, false, &context(120, ColorMode::Never));
     let rendered = document.render_plain();
 
     assert!(rendered.contains(PARENT_SESSION_ID), "{rendered}");
+    assert!(rendered.contains(EVENT_ID), "{rendered}");
     assert!(document
         .lines()
         .iter()
@@ -637,21 +656,78 @@ fn normal_search_agent_field_preserves_an_unresolved_full_reference() {
 }
 
 #[test]
-fn normal_search_agent_field_does_not_infer_unknown_scope_from_lineage() {
-    let value = search_agent_value(None, Some(PARENT_SESSION_ID), Some(ROOT_SESSION_ID));
+fn normal_search_card_renders_custom_source_identity_without_provider_duplication() {
+    let mut custom = compact_search_value();
+    custom["results"][0]["provider"] = json!("custom");
+    custom["results"][0]["provider_key"] = json!("acme-history");
+    custom["results"][0]["source_id"] = json!("workstation");
     let rendered =
-        render_search_document(&value, false, &context(120, ColorMode::Never)).render_plain();
+        render_search_document(&custom, false, &context(120, ColorMode::Never)).render_plain();
+    assert!(rendered.contains("   Provider  Custom"), "{rendered}");
+    assert!(
+        rendered.contains("   Source    acme-history/workstation"),
+        "{rendered}"
+    );
 
-    assert!(rendered.contains("   Agent    unknown"), "{rendered}");
-    assert!(!rendered.contains("01900010"), "{rendered}");
-    assert!(!rendered.contains("01900020"), "{rendered}");
+    custom["results"][0]["provider"] = json!("acme_history");
+    custom["results"][0]["provider_key"] = json!("acme_history");
+    custom["results"][0]["source_id"] = Value::Null;
+    let rendered =
+        render_search_document(&custom, false, &context(120, ColorMode::Never)).render_plain();
+    assert!(rendered.contains("   Provider  acme history"), "{rendered}");
+    assert!(!rendered.contains("   Source"), "{rendered}");
+}
+
+#[test]
+fn search_card_dynamic_identity_fields_are_control_safe() {
+    let mut value = search_agent_value(None, Some("parent\u{1b}[31m"), None);
+    value["results"][0]["provider"] = json!("custom");
+    value["results"][0]["provider_key"] = json!("plugin\u{1b}[2J");
+    value["results"][0]["source_id"] = json!("line\nbreak\tvalue");
+    let document = render_search_document(&value, false, &context(48, ColorMode::Never));
+    let rendered = document.render_plain();
+    assert!(
+        rendered.contains("plugin\\x1b[2J/line\\nbreak\\tvalue"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("parent\\x1b[31m"), "{rendered}");
+    assert_control_safe(&rendered);
+    assert_fits(&document, &context(48, ColorMode::Never));
+}
+
+#[test]
+fn normal_search_uses_compact_refs_and_verbose_uses_full_ctx_ids() {
+    let mut ordinary_value = compact_search_value();
+    ordinary_value["results"][0]["parent_ctx_session_id"] = json!(PARENT_SESSION_REF);
+    ordinary_value["results"][0]["root_ctx_session_id"] = json!(ROOT_SESSION_REF);
+    let ordinary = render_search_document(&ordinary_value, false, &context(120, ColorMode::Never))
+        .render_plain();
+    for expected in [SESSION_REF, EVENT_REF, PARENT_SESSION_REF, ROOT_SESSION_REF] {
+        assert!(ordinary.contains(expected), "{ordinary}");
+    }
+    for unexpected in [SESSION_ID, EVENT_ID, PARENT_SESSION_ID, ROOT_SESSION_ID] {
+        assert!(!ordinary.contains(unexpected), "{ordinary}");
+    }
+
+    let mut verbose_value = search_value();
+    verbose_value["results"][0]["parent_ctx_session_id"] = json!(PARENT_SESSION_ID);
+    verbose_value["results"][0]["root_ctx_session_id"] = json!(ROOT_SESSION_ID);
+    let verbose = render_search_document(&verbose_value, true, &context(120, ColorMode::Never))
+        .render_plain();
+    for expected in [SESSION_ID, EVENT_ID, PARENT_SESSION_ID, ROOT_SESSION_ID] {
+        assert!(verbose.contains(expected), "{verbose}");
+    }
 }
 
 #[test]
 fn search_event_row_uses_exact_milliseconds_and_quiet_missing_time() {
-    let document = render_search_document(&search_value(), false, &context(80, ColorMode::Never));
+    let document = render_search_document(
+        &compact_search_value(),
+        false,
+        &context(80, ColorMode::Never),
+    );
     let rendered = document.render_plain();
-    assert!(rendered.contains("Event    01900001 · 2026-07-30T12:00:00.123Z"));
+    assert!(rendered.contains("Event     01900001 · 2026-07-30T12:00:00.123Z"));
     assert!(!rendered.contains("Match"));
     assert!(document
         .lines()
@@ -666,19 +742,26 @@ fn search_event_row_uses_exact_milliseconds_and_quiet_missing_time() {
             span.content() == "2026-07-30T12:00:00.123Z" && span.token() == Token::Text
         }));
 
-    let ascii = render_search_document(&search_value(), false, &context_with_unicode(80, false))
-        .render_plain();
+    let ascii = render_search_document(
+        &compact_search_value(),
+        false,
+        &context_with_unicode(80, false),
+    )
+    .render_plain();
     assert!(
-        ascii.contains("Event    01900001 | 2026-07-30T12:00:00.123Z"),
+        ascii.contains("Event     01900001 | 2026-07-30T12:00:00.123Z"),
         "{ascii}"
     );
 
-    let mut missing = search_value();
+    let mut missing = compact_search_value();
     missing["results"][0]["timestamp"] = Value::Null;
     let document = render_search_document(&missing, false, &context(32, ColorMode::Never));
     let rendered = document.render_plain();
-    assert!(rendered.contains("Event    01900001"), "{rendered}");
-    assert!(rendered.contains("Time     time unavailable"), "{rendered}");
+    assert!(rendered.contains("Event     01900001"), "{rendered}");
+    assert!(
+        rendered.contains("Time      time unavailable"),
+        "{rendered}"
+    );
     assert!(document
         .lines()
         .iter()
@@ -688,32 +771,45 @@ fn search_event_row_uses_exact_milliseconds_and_quiet_missing_time() {
 
 #[test]
 fn verbose_search_exposes_context_without_redundant_values_or_citation() {
-    let ordinary = render_search_document(&search_value(), false, &context(120, ColorMode::Never))
-        .render_plain();
+    let ordinary = render_search_document(
+        &compact_search_value(),
+        false,
+        &context(120, ColorMode::Never),
+    )
+    .render_plain();
     assert!(!ordinary.contains("Sequence"), "{ordinary}");
-    assert!(ordinary.contains("Agent    primary"), "{ordinary}");
+    assert!(ordinary.contains("Provider  Codex"), "{ordinary}");
+    assert!(!ordinary.contains("Provider session"), "{ordinary}");
+    assert!(!ordinary.contains("Agent"), "{ordinary}");
 
     let verbose = render_search_document(&search_value(), true, &context(120, ColorMode::Never))
         .render_plain();
     assert!(verbose.contains("Sequence          17"), "{verbose}");
-    assert!(verbose.contains("Agent    primary"), "{verbose}");
+    assert!(
+        verbose.contains("Provider session  demo-unicode-session"),
+        "{verbose}"
+    );
+    assert!(
+        verbose.contains("Source format     codex_session_jsonl"),
+        "{verbose}"
+    );
     assert!(!verbose.contains("Citation"), "{verbose}");
-    assert_eq!(verbose.matches("Agent").count(), 1, "{verbose}");
-    assert_eq!(verbose.matches("primary").count(), 1, "{verbose}");
+    assert!(!verbose.contains("Agent"), "{verbose}");
 
     let mut nested = search_value();
     nested["results"][0]["agent_scope"] = json!("subagent");
-    nested["results"][0]["parent_ctx_session_id"] = json!(PARENT_SESSION_REF);
-    nested["results"][0]["root_ctx_session_id"] = json!(ROOT_SESSION_REF);
+    nested["results"][0]["parent_ctx_session_id"] = json!(PARENT_SESSION_ID);
+    nested["results"][0]["root_ctx_session_id"] = json!(ROOT_SESSION_ID);
     let nested =
         render_search_document(&nested, true, &context(120, ColorMode::Never)).render_plain();
     for expected in [
-        "Agent    subagent · parent 019000100 · root 019000101",
-        "Parent            019000100",
-        "Root              019000101",
+        format!("Parent    {PARENT_SESSION_ID}"),
+        format!("Root      {ROOT_SESSION_ID}"),
     ] {
-        assert!(nested.contains(expected), "{nested}");
+        assert!(nested.contains(&expected), "{nested}");
     }
+    assert_eq!(nested.matches(PARENT_SESSION_ID).count(), 1, "{nested}");
+    assert_eq!(nested.matches(ROOT_SESSION_ID).count(), 1, "{nested}");
 }
 
 #[test]

--- a/crates/ctx-history-cli/src/source_index/search.rs
+++ b/crates/ctx-history-cli/src/source_index/search.rs
@@ -364,6 +364,7 @@ fn run_search_inner<P: HistorySemanticPort>(
     semantic_port: &P,
     observation: &mut SearchExecutionObservation,
 ) -> SourceSearchResult<()> {
+    let compact_projection = compact_search_projection(json_output, verbose);
     let plan = ctx_history_read_application::plan_search(request, policy)?;
     let request = plan.request();
     let requested_backend = request.backend.unwrap_or(policy.default_backend);
@@ -386,7 +387,7 @@ fn run_search_inner<P: HistorySemanticPort>(
         &data_root,
         refresh_mode,
         refresh,
-        !json_output,
+        compact_projection,
         semantic_port,
         super::detected_active_session(),
         observation,
@@ -426,7 +427,7 @@ fn run_search_inner<P: HistorySemanticPort>(
 
     observation.failure_phase = Some(SearchFailurePhase::ResultProjection);
     let render_started = Instant::now();
-    let compact_value = match (!json_output)
+    let compact_value = match compact_projection
         .then(|| application.project_read_model(&value))
         .transpose()
     {
@@ -488,6 +489,10 @@ fn run_search_inner<P: HistorySemanticPort>(
     local_usage.set_search_context_observation(search_context);
     local_usage.set_measured_output_bytes(output_bytes);
     Ok(())
+}
+
+pub(super) const fn compact_search_projection(json_output: bool, verbose: bool) -> bool {
+    !json_output && !verbose
 }
 
 #[cfg(test)]

--- a/crates/ctx-history-cli/src/source_index/tests.rs
+++ b/crates/ctx-history-cli/src/source_index/tests.rs
@@ -69,6 +69,14 @@ const TEST_QUERY: &str = "pinnedgenerationrouting";
 
 const TEST_MCP_OUTPUT_LIMIT: usize = crate::presentation_limit::CLI_PRESENTATION_MAX_OUTPUT_BYTES;
 
+#[test]
+fn search_projection_keeps_machine_and_verbose_ids_full() {
+    assert!(super::search::compact_search_projection(false, false));
+    assert!(!super::search::compact_search_projection(false, true));
+    assert!(!super::search::compact_search_projection(true, false));
+    assert!(!super::search::compact_search_projection(true, true));
+}
+
 fn history_config(daemon_enabled: bool, semantic_search_enabled: bool) -> config::AppConfig {
     config::AppConfig::from_snapshot(HistoryCliConfig {
         daemon_enabled,

--- a/crates/ctx-history-cli/src/sources.rs
+++ b/crates/ctx-history-cli/src/sources.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use serde_json::json;
 
 use ctx_history_capture::{DiscoveryIssue, DiscoveryIssueKind, ProviderSourceStatus};
-use ctx_history_core::CaptureProvider;
 
 use crate::provider_sources::{
     configured_root_conflict_details, configured_root_for_issue, configured_root_for_source,
@@ -322,7 +321,7 @@ fn render_sources_human(context: &RenderContext, input: SourcesHumanRenderInput<
                 },
             );
             locations.push_row([
-                source_provider_cli_name(source.provider).to_owned(),
+                source.provider.display_name().to_owned(),
                 source.status.as_str().to_owned(),
                 human_path(&source.path, home),
                 selection,
@@ -350,7 +349,7 @@ fn render_sources_human(context: &RenderContext, input: SourcesHumanRenderInput<
         .iter()
         .filter(|source| source.status == ProviderSourceStatus::Unsupported)
     {
-        let provider = source_provider_cli_name(source.provider);
+        let provider = source.provider.display_name();
         let summary = format!("{provider} history cannot be imported automatically");
         let location = human_path(&source.path, home);
         let reason = source
@@ -492,7 +491,8 @@ fn render_discovery_issue(
     provider_roots: &[ctx_history_capture::ProviderRootDefinition],
     automatic_provider_discovery: bool,
 ) -> Document {
-    let provider = source_provider_cli_name(issue.provider);
+    let provider = issue.provider.display_name();
+    let provider_selector = provider_cli_name(issue.provider);
     if issue.kind == DiscoveryIssueKind::ConfiguredRootConflict {
         let details =
             configured_root_conflict_details(issue, provider_roots, automatic_provider_discovery);
@@ -534,14 +534,14 @@ fn render_discovery_issue(
                 "Remove one named root, or move `{}` persistently with `ctx sources add {} --provider {} --root <different-path> --replace`.",
                 root.id,
                 root.id,
-                provider,
+                provider_selector,
             ),
             (Some(ConfiguredRootConflictKind::AutomaticConfigured), Some(root)) => format!(
                 "Remove or move `{}`; if named roots should replace automatic discovery, set `[sources] automatic=false`.",
                 root.id,
             ),
             _ => format!(
-                "Repair the persisted roots with `ctx sources remove <name>` or `ctx sources add <name> --provider {provider} --root <different-path> --replace`; use `[sources] automatic=false` when automatic discovery should be disabled."
+                "Repair the persisted roots with `ctx sources remove <name>` or `ctx sources add <name> --provider {provider_selector} --root <different-path> --replace`; use `[sources] automatic=false` when automatic discovery should be disabled."
             ),
         };
         let action_command = repair_root.map(|root| format!("ctx sources remove {}", root.id));
@@ -573,7 +573,7 @@ fn render_discovery_issue(
         }
         fields.push(Field::new("Reason", issue.reason));
         let detail = format!(
-            "The named root remains configured, but its provider-owned state is absent. Restore it, replace its persisted path with `ctx sources add <name> --provider {provider} --root <replacement-path> --replace`, or remove `{root_name}` when it is no longer needed."
+            "The named root remains configured, but its provider-owned state is absent. Restore it, replace its persisted path with `ctx sources add <name> --provider {provider_selector} --root <replacement-path> --replace`, or remove `{root_name}` when it is no longer needed."
         );
         let action_command = root.map(|root| format!("ctx sources remove {}", root.id));
         return diagnostic(
@@ -614,10 +614,6 @@ fn render_discovery_issue(
             action: Some(Action { command: &command }),
         },
     )
-}
-
-pub(crate) fn source_provider_cli_name(provider: CaptureProvider) -> &'static str {
-    provider_cli_name(provider)
 }
 
 #[cfg(test)]

--- a/crates/ctx-history-cli/src/sources_ui_tests.rs
+++ b/crates/ctx-history-cli/src/sources_ui_tests.rs
@@ -4,6 +4,7 @@ use ctx_history_capture::{
     ProviderCatalogSupport, ProviderImportSupport, ProviderRouteRole, ProviderSource,
     ProviderSourceKind, ProviderSourceRouteProvenance,
 };
+use ctx_history_core::CaptureProvider;
 use unicode_width::UnicodeWidthStr as _;
 
 use super::*;
@@ -186,7 +187,7 @@ fn sources_success_is_outcome_first_and_responsive() {
             "{width}: {rendered}"
         );
         assert!(rendered.contains("ctx sources --all"));
-        for atom in ["codex", "available"] {
+        for atom in ["Codex", "available"] {
             assert_eq!(
                 rendered
                     .split_whitespace()
@@ -200,7 +201,7 @@ fn sources_success_is_outcome_first_and_responsive() {
         assert!(!rendered.contains("jsonl"), "{width}: {rendered}");
         if width < 100 {
             assert!(
-                rendered.contains("Source\n  codex\nStatus\n  available\n"),
+                rendered.contains("Source\n  Codex\nStatus\n  available\n"),
                 "{width}: {rendered}"
             );
         } else {
@@ -255,7 +256,7 @@ fn sources_stack_when_fixed_columns_do_not_fit_and_keep_atoms_whole() {
             SourcesHumanRenderInput::from_sources(&sources).with_home(Some(&home)),
         );
         let rendered = document.render_plain();
-        for atom in ["factory-ai-droid", "available", "cursor"] {
+        for atom in ["Factory", "AI", "Droid", "available", "Cursor"] {
             assert!(
                 rendered.split_whitespace().any(|token| token == atom),
                 "{atom:?} did not remain intact at {width} columns: {rendered}"
@@ -269,7 +270,7 @@ fn sources_stack_when_fixed_columns_do_not_fit_and_keep_atoms_whole() {
         assert!(!rendered.contains("jsonl"), "{width}: {rendered}");
         if width < 120 {
             assert!(
-                rendered.contains("Source\n  factory-ai-droid\nStatus\n  available\n"),
+                rendered.contains("Source\n  Factory AI Droid\nStatus\n  available\n"),
                 "{rendered}"
             );
         } else {
@@ -342,7 +343,7 @@ fn concise_sources_hide_automatic_empty_provider_but_preserve_configured_empty_r
         default.starts_with("No history sources found\n"),
         "{default}"
     );
-    assert!(!default.contains("gemini"), "{default}");
+    assert!(!default.contains("Gemini"), "{default}");
     assert_eq!(json_sources.len(), 1);
     assert_eq!(json_sources[0].status, ProviderSourceStatus::Empty);
 
@@ -359,7 +360,7 @@ fn concise_sources_hide_automatic_empty_provider_but_preserve_configured_empty_r
         .with_automatic_provider_discovery(false)
         .with_provider_roots(std::slice::from_ref(&configured_root));
     let configured = render_sources_human(&plain_context, configured_input).render_plain();
-    assert!(configured.contains("gemini"), "{configured}");
+    assert!(configured.contains("Gemini"), "{configured}");
     assert!(configured.contains("empty"), "{configured}");
     assert!(configured.contains("work (team)"), "{configured}");
     assert!(
@@ -379,7 +380,7 @@ fn concise_sources_hide_automatic_empty_provider_but_preserve_configured_empty_r
         SourcesHumanRenderInput::from_sources(&all_sources),
     )
     .render_plain();
-    assert!(all.contains("gemini"), "{all}");
+    assert!(all.contains("Gemini"), "{all}");
     assert!(all.contains("empty"), "{all}");
     assert!(all.contains("/tmp/gemini"), "{all}");
 }

--- a/crates/ctx-history-core/src/provider.rs
+++ b/crates/ctx-history-core/src/provider.rs
@@ -298,7 +298,9 @@ pub const fn provider_support_matrix_schema_version() -> u32 {
 mod tests {
     use std::{collections::BTreeSet, fs, path::PathBuf};
 
-    use super::{ProviderId, ProviderSupportMatrixDocument, ProviderSupportStatus};
+    use super::{
+        CaptureProvider, ProviderId, ProviderSupportMatrixDocument, ProviderSupportStatus,
+    };
 
     fn workspace_file(path: &str) -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -393,6 +395,30 @@ mod tests {
             assert_eq!(entry.status, status, "{id:?} support status changed");
             assert_eq!(entry.display_name, env_name);
         }
+    }
+
+    #[test]
+    fn provider_support_matrix_uses_capture_provider_display_names() {
+        let matrix = fs::read_to_string(workspace_file("docs/provider-support-matrix.json"))
+            .expect("provider support matrix scaffold should exist");
+        let parsed: ProviderSupportMatrixDocument =
+            serde_json::from_str(&matrix).expect("matrix scaffold should parse");
+
+        for entry in parsed.providers {
+            let Some(provider) = entry.capture_provider else {
+                continue;
+            };
+            assert_eq!(
+                entry.display_name,
+                provider.display_name(),
+                "{:?} must mirror CaptureProvider::{provider:?}",
+                entry.id,
+            );
+        }
+
+        assert_eq!(CaptureProvider::Claude.display_name(), "Claude Code");
+        assert_eq!(CaptureProvider::Gemini.display_name(), "Gemini");
+        assert_eq!(CaptureProvider::CopilotCli.display_name(), "GitHub Copilot");
     }
 
     #[test]

--- a/crates/ctx-history-core/src/source.rs
+++ b/crates/ctx-history-core/src/source.rs
@@ -57,3 +57,144 @@ text_enum! {
     }
     default Unknown
 }
+
+impl CaptureProvider {
+    /// Human-readable product name for ordinary history presentation.
+    ///
+    /// Machine identities, selectors, serialization, and protocol surfaces
+    /// continue to use [`Self::as_str`].
+    pub const fn display_name(self) -> &'static str {
+        match self {
+            Self::Codex => "Codex",
+            Self::GrokBuild => "Grok Build",
+            Self::DeepSeekHarness => "DeepSeek Harness",
+            Self::Claude => "Claude Code",
+            Self::Pi => "Pi",
+            Self::OpenCode => "OpenCode",
+            Self::Kilo => "Kilo Code",
+            Self::KiroCli => "Kiro",
+            Self::Antigravity => "Antigravity",
+            Self::Gemini => "Gemini",
+            Self::Tabnine => "Tabnine",
+            Self::Cursor => "Cursor",
+            Self::Zed => "Zed",
+            Self::CopilotCli => "GitHub Copilot",
+            Self::FactoryAiDroid => "Factory AI Droid",
+            Self::QwenCode => "Qwen Code",
+            Self::KimiCodeCli => "Kimi Code",
+            Self::Auggie => "Auggie",
+            Self::Junie => "Junie",
+            Self::Firebender => "Firebender",
+            Self::ForgeCode => "ForgeCode",
+            Self::DeepAgents => "Deep Agents",
+            Self::MistralVibe => "Mistral Vibe",
+            Self::Mux => "Mux",
+            Self::RovoDev => "Rovo Dev",
+            Self::OpenClaw => "OpenClaw",
+            Self::Hermes => "Hermes Agent",
+            Self::NanoClaw => "NanoClaw",
+            Self::AstrBot => "AstrBot",
+            Self::Shelley => "Shelley",
+            Self::Continue => "Continue",
+            Self::OpenHands => "OpenHands",
+            Self::Cline => "Cline",
+            Self::RooCode => "Roo Code",
+            Self::Crush => "Crush",
+            Self::Goose => "Goose",
+            Self::Lingma => "Lingma",
+            Self::Qoder => "Qoder",
+            Self::Warp => "Warp",
+            Self::CodeBuddy => "CodeBuddy",
+            Self::Fx => "fx",
+            Self::Shell => "Shell",
+            Self::Git => "Git",
+            Self::Jj => "Jujutsu",
+            Self::Gh => "GitHub CLI",
+            Self::Custom => "Custom",
+            Self::Unknown => "Unknown",
+            Self::MiMoCode => "MiMo Code",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_names_are_exhaustive_and_machine_contracts_stay_stable() {
+        let cases = [
+            (CaptureProvider::Codex, "codex", "Codex"),
+            (CaptureProvider::GrokBuild, "grok_build", "Grok Build"),
+            (
+                CaptureProvider::DeepSeekHarness,
+                "deepseek_harness",
+                "DeepSeek Harness",
+            ),
+            (CaptureProvider::Claude, "claude", "Claude Code"),
+            (CaptureProvider::Pi, "pi", "Pi"),
+            (CaptureProvider::OpenCode, "opencode", "OpenCode"),
+            (CaptureProvider::Kilo, "kilo", "Kilo Code"),
+            (CaptureProvider::KiroCli, "kiro_cli", "Kiro"),
+            (CaptureProvider::Antigravity, "antigravity", "Antigravity"),
+            (CaptureProvider::Gemini, "gemini", "Gemini"),
+            (CaptureProvider::Tabnine, "tabnine", "Tabnine"),
+            (CaptureProvider::Cursor, "cursor", "Cursor"),
+            (CaptureProvider::Zed, "zed", "Zed"),
+            (CaptureProvider::CopilotCli, "copilot_cli", "GitHub Copilot"),
+            (
+                CaptureProvider::FactoryAiDroid,
+                "factory_ai_droid",
+                "Factory AI Droid",
+            ),
+            (CaptureProvider::QwenCode, "qwen_code", "Qwen Code"),
+            (CaptureProvider::KimiCodeCli, "kimi_code_cli", "Kimi Code"),
+            (CaptureProvider::Auggie, "auggie", "Auggie"),
+            (CaptureProvider::Junie, "junie", "Junie"),
+            (CaptureProvider::Firebender, "firebender", "Firebender"),
+            (CaptureProvider::ForgeCode, "forgecode", "ForgeCode"),
+            (CaptureProvider::DeepAgents, "deepagents", "Deep Agents"),
+            (CaptureProvider::MistralVibe, "mistral_vibe", "Mistral Vibe"),
+            (CaptureProvider::Mux, "mux", "Mux"),
+            (CaptureProvider::RovoDev, "rovodev", "Rovo Dev"),
+            (CaptureProvider::OpenClaw, "openclaw", "OpenClaw"),
+            (CaptureProvider::Hermes, "hermes", "Hermes Agent"),
+            (CaptureProvider::NanoClaw, "nanoclaw", "NanoClaw"),
+            (CaptureProvider::AstrBot, "astrbot", "AstrBot"),
+            (CaptureProvider::Shelley, "shelley", "Shelley"),
+            (CaptureProvider::Continue, "continue", "Continue"),
+            (CaptureProvider::OpenHands, "openhands", "OpenHands"),
+            (CaptureProvider::Cline, "cline", "Cline"),
+            (CaptureProvider::RooCode, "roo_code", "Roo Code"),
+            (CaptureProvider::Crush, "crush", "Crush"),
+            (CaptureProvider::Goose, "goose", "Goose"),
+            (CaptureProvider::Lingma, "lingma", "Lingma"),
+            (CaptureProvider::Qoder, "qoder", "Qoder"),
+            (CaptureProvider::Warp, "warp", "Warp"),
+            (CaptureProvider::CodeBuddy, "codebuddy", "CodeBuddy"),
+            (CaptureProvider::Fx, "fx", "fx"),
+            (CaptureProvider::Shell, "shell", "Shell"),
+            (CaptureProvider::Git, "git", "Git"),
+            (CaptureProvider::Jj, "jj", "Jujutsu"),
+            (CaptureProvider::Gh, "gh", "GitHub CLI"),
+            (CaptureProvider::Custom, "custom", "Custom"),
+            (CaptureProvider::Unknown, "unknown", "Unknown"),
+            (CaptureProvider::MiMoCode, "mimocode", "MiMo Code"),
+        ];
+
+        assert_eq!(cases.len(), CaptureProvider::variants().len());
+        for (provider, machine_name, display_name) in cases {
+            assert_eq!(provider.as_str(), machine_name);
+            assert_eq!(provider.display_name(), display_name);
+            assert_eq!(provider.to_string(), machine_name);
+            assert_eq!(
+                serde_json::to_string(&provider).unwrap(),
+                format!("\"{machine_name}\"")
+            );
+            assert_eq!(
+                serde_json::from_str::<CaptureProvider>(&format!("\"{machine_name}\"")).unwrap(),
+                provider
+            );
+        }
+    }
+}

--- a/crates/ctx-history-ingest-application/tests/contracts/custom_root_discovery.rs
+++ b/crates/ctx-history-ingest-application/tests/contracts/custom_root_discovery.rs
@@ -208,7 +208,7 @@ fn provider_filtered_human_sources_and_import_errors_are_actionable() {
         "--format=json",
     ]));
     assert!(
-        stderr.contains("no importable firebender history source was discovered"),
+        stderr.contains("no importable Firebender history source was discovered"),
         "{stderr}"
     );
     assert!(
@@ -236,7 +236,7 @@ fn provider_filtered_human_sources_and_import_errors_are_actionable() {
         "--format=json",
     ]));
     assert!(
-        stderr.contains("no importable firebender history source was discovered"),
+        stderr.contains("no importable Firebender history source was discovered"),
         "{stderr}"
     );
     assert!(

--- a/crates/ctx-history-read-application/tests/support/search_show/search_flows.rs
+++ b/crates/ctx-history-read-application/tests/support/search_show/search_flows.rs
@@ -264,10 +264,14 @@ fn fresh_home_search_mvp_flow() {
         "{human_search}"
     );
     assert!(human_search.contains("1. "));
-    assert!(human_search.contains("Session  codex · "), "{human_search}");
+    assert!(human_search.contains("Provider  Codex"), "{human_search}");
+    assert!(
+        human_search.contains(&format!("Session   {session_prefix}")),
+        "{human_search}"
+    );
     assert!(
         human_search.contains(&format!(
-            "Event    {} · 2026-06-23T15:00:02.000Z",
+            "Event     {} · 2026-06-23T15:00:02.000Z",
             &ctx_event_id[..8]
         )),
         "{human_search}"
@@ -291,7 +295,10 @@ fn fresh_home_search_mvp_flow() {
         .clone();
     let verbose_search = String::from_utf8(verbose_search).unwrap();
     assert!(verbose_search.contains("Event"));
-    assert!(verbose_search.contains("Ctx session"));
+    assert!(
+        verbose_search.contains(&format!("Session   {ctx_session_id}")),
+        "{verbose_search}"
+    );
     assert!(verbose_search.contains("Provider session"));
     assert!(verbose_search.contains("Rank"));
     assert!(verbose_search.contains("Retrieval score"));

--- a/crates/ctx-history-source-discovery/src/provider_sources/discovery/explicit.rs
+++ b/crates/ctx-history-source-discovery/src/provider_sources/discovery/explicit.rs
@@ -58,7 +58,6 @@ fn provider_source_for_path_with_optional_data_root(
 ) -> ProviderSource {
     let unknown_spec = ProviderSourceSpec {
         provider,
-        display_name: "unknown",
         default_locations: &[],
         import_support: ProviderImportSupport::Unsupported,
         catalog_support: ProviderCatalogSupport::None,

--- a/crates/ctx-history-source-discovery/src/provider_sources/specs.rs
+++ b/crates/ctx-history-source-discovery/src/provider_sources/specs.rs
@@ -356,7 +356,6 @@ const FX_DEFAULTS: &[ProviderDefaultLocation] = &[ProviderDefaultLocation {
 pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     ProviderSourceSpec {
         provider: CaptureProvider::Codex,
-        display_name: "Codex",
         default_locations: CODEX_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::Native,
@@ -364,7 +363,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::GrokBuild,
-        display_name: "Grok Build",
         default_locations: GROK_BUILD_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -372,7 +370,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::DeepSeekHarness,
-        display_name: "DeepSeek Harness",
         default_locations: DEEPSEEK_HARNESS_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -380,7 +377,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Pi,
-        display_name: "Pi",
         default_locations: PI_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -388,7 +384,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Claude,
-        display_name: "Claude",
         default_locations: CLAUDE_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -396,7 +391,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::OpenCode,
-        display_name: "OpenCode",
         default_locations: OPENCODE_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -404,7 +398,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Kilo,
-        display_name: "Kilo Code",
         default_locations: KILO_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -412,7 +405,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::MiMoCode,
-        display_name: "MiMo Code",
         default_locations: MIMOCODE_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -420,7 +412,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::KiroCli,
-        display_name: "Kiro CLI",
         default_locations: KIRO_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -428,7 +419,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Crush,
-        display_name: "Crush",
         default_locations: CRUSH_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -436,7 +426,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Goose,
-        display_name: "Goose",
         default_locations: GOOSE_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -444,7 +433,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Antigravity,
-        display_name: "Antigravity",
         default_locations: ANTIGRAVITY_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -452,7 +440,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Gemini,
-        display_name: "Gemini",
         default_locations: GEMINI_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -460,7 +447,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Tabnine,
-        display_name: "Tabnine",
         default_locations: TABNINE_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -468,7 +454,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Cursor,
-        display_name: "Cursor",
         default_locations: CURSOR_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -476,7 +461,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Zed,
-        display_name: "Zed",
         default_locations: ZED_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -484,7 +468,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::CopilotCli,
-        display_name: "Copilot CLI",
         default_locations: COPILOT_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -492,7 +475,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::FactoryAiDroid,
-        display_name: "Factory AI Droid",
         default_locations: FACTORY_DROID_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -500,7 +482,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::QwenCode,
-        display_name: "Qwen Code",
         default_locations: QWEN_CODE_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -508,7 +489,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::KimiCodeCli,
-        display_name: "Kimi Code CLI",
         default_locations: KIMI_CODE_CLI_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -516,7 +496,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Auggie,
-        display_name: "Auggie",
         default_locations: AUGGIE_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -524,7 +503,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Junie,
-        display_name: "Junie",
         default_locations: JUNIE_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -532,7 +510,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Firebender,
-        display_name: "Firebender",
         default_locations: FIREBENDER_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -540,7 +517,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::ForgeCode,
-        display_name: "ForgeCode",
         default_locations: FORGECODE_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -548,7 +524,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::DeepAgents,
-        display_name: "Deep Agents",
         default_locations: DEEPAGENTS_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -556,7 +531,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::MistralVibe,
-        display_name: "Mistral Vibe",
         default_locations: MISTRAL_VIBE_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -564,7 +538,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Mux,
-        display_name: "Mux",
         default_locations: MUX_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -572,7 +545,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::RovoDev,
-        display_name: "Rovo Dev",
         default_locations: ROVODEV_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -580,7 +552,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::OpenClaw,
-        display_name: "OpenClaw",
         default_locations: OPENCLAW_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -588,7 +559,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Hermes,
-        display_name: "Hermes Agent",
         default_locations: HERMES_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -596,7 +566,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::NanoClaw,
-        display_name: "NanoClaw",
         default_locations: NANOCLAW_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -604,7 +573,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::AstrBot,
-        display_name: "AstrBot",
         default_locations: ASTRBOT_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -612,7 +580,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Shelley,
-        display_name: "Shelley",
         default_locations: SHELLEY_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -620,7 +587,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Continue,
-        display_name: "Continue",
         default_locations: CONTINUE_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -628,7 +594,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::OpenHands,
-        display_name: "OpenHands",
         default_locations: OPENHANDS_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -636,7 +601,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Cline,
-        display_name: "Cline",
         default_locations: CLINE_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -644,7 +608,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::RooCode,
-        display_name: "Roo Code",
         default_locations: ROO_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -652,7 +615,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Lingma,
-        display_name: "Lingma",
         default_locations: LINGMA_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -660,7 +622,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Qoder,
-        display_name: "Qoder",
         default_locations: QODER_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -668,7 +629,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Warp,
-        display_name: "Warp",
         default_locations: WARP_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -676,7 +636,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::CodeBuddy,
-        display_name: "CodeBuddy",
         default_locations: CODEBUDDY_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,
@@ -684,7 +643,6 @@ pub(super) const PROVIDER_SPECS: &[ProviderSourceSpec] = &[
     },
     ProviderSourceSpec {
         provider: CaptureProvider::Fx,
-        display_name: "fx",
         default_locations: FX_DEFAULTS,
         import_support: ProviderImportSupport::Native,
         catalog_support: ProviderCatalogSupport::None,

--- a/docs/first-10-minutes.md
+++ b/docs/first-10-minutes.md
@@ -51,8 +51,9 @@ ctx sources --format json
 ```
 
 Expect rows for supported local import providers such as Codex, Pi,
-Antigravity, Claude, OpenCode, Kilo Code, OpenClaw, Hermes Agent, Gemini, Cursor,
-Zed, Copilot CLI, Factory AI Droid, and Warp Terminal restoration SQLite.
+Antigravity, Claude Code, OpenCode, Kilo Code, OpenClaw, Hermes Agent, Gemini,
+Cursor, Zed, GitHub Copilot, Factory AI Droid, and Warp Terminal restoration
+SQLite.
 NanoClaw is supported from an exact project CWD or official launchd/systemd
 service registration; AstrBot appears as supported when a bounded `data_v4.db`
 source exists. Warp is supported from documented local `warp.sqlite` paths. A

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -143,8 +143,8 @@ ctx sources --format json
 `sources` checks known provider locations on the current machine. Its concise
 default hides empty automatic locations while keeping configured roots visible;
 `ctx sources --all` retains the full empty and missing inventory for diagnostics. Today it
-reports supported Codex, Pi, Antigravity, Claude, OpenCode, Kilo Code, Gemini,
-Cursor, Zed, Copilot CLI, Factory AI Droid, Warp, and other supported local
+reports supported Codex, Pi, Antigravity, Claude Code, OpenCode, Kilo Code,
+Gemini, Cursor, Zed, GitHub Copilot, Factory AI Droid, Warp, and other supported local
 history paths. JSON rows include
 `status` and `importable`; `status: "empty"` means the automatic location or
 configured root exists but no provider-specific transcript files were found there, and

--- a/docs/provider-import-policy.md
+++ b/docs/provider-import-policy.md
@@ -174,11 +174,11 @@ Secondary traits are noted only to guide tests and hardening work.
 | Grok Build | `grok_build_session_updates_jsonl_tree` | JSONL transcript stream/tree | Session directories contain authoritative `updates.jsonl`; exact leaves use `grok_build_session_updates_jsonl`. Derived sidecars are excluded. |
 | DeepSeek Harness | `deepseek_harness_session_jsonl_tree` | JSONL transcript stream/tree | Supported for local format version 0 only. Nested leaves use default `session.jsonl.zstd` or configured raw `session.jsonl`; exact leaves use `deepseek_harness_session_jsonl`. Hosted/cloud history is excluded. |
 | Pi | `pi_session_jsonl` | JSONL transcript stream/tree | Single-provider JSONL sessions, including OMP-compatible paths. |
-| Claude | `claude_projects_jsonl_tree` | JSONL transcript stream/tree | Project tree of JSONL transcripts. |
+| Claude Code | `claude_projects_jsonl_tree` | JSONL transcript stream/tree | Project tree of JSONL transcripts. |
 | OpenCode | `opencode_sqlite` | SQLite message store | Current schemas may split messages and parts. |
 | Kilo Code | `kilo_sqlite` | SQLite message store | Current schemas may split messages and parts. |
 | MiMo Code | `mimocode_sqlite` | SQLite message store | OpenCode-family sessions with messages and parts. |
-| Kiro CLI | `kiro_cli_sqlite` | SQLite message store | SQLite conversation key/value rows containing message JSON. |
+| Kiro | `kiro_cli_sqlite` | SQLite message store | SQLite conversation key/value rows containing message JSON. |
 | Crush | `crush_sqlite` | SQLite message store | SQLite sessions with message parts and tool metadata. |
 | Goose | `goose_sessions_sqlite` | SQLite message store | SQLite sessions/messages with structured content JSON. |
 | Lingma | `lingma_sqlite` | SQLite message store | SQLite chat rows with prompt/assistant fields. |
@@ -198,10 +198,10 @@ Secondary traits are noted only to guide tests and hardening work.
 | Tabnine | `tabnine_cli_chat_recording_jsonl` | JSONL transcript stream/tree | Chat recording JSONL. |
 | Cursor | `cursor_agent_transcript_jsonl_tree` | JSONL transcript stream/tree | Agent transcript tree. |
 | Zed | `zed_threads_sqlite` | SQLite encoded/blob store | SQLite thread rows with decoded JSON payloads. |
-| Copilot CLI | `copilot_cli_session_events_jsonl` | JSONL transcript stream/tree | Session event JSONL. |
+| GitHub Copilot | `copilot_cli_session_events_jsonl` | JSONL transcript stream/tree | Session event JSONL. |
 | Factory AI Droid | `factory_ai_droid_sessions_jsonl` | JSONL transcript stream/tree | Session JSONL. |
 | Qwen Code | `qwen_code_chat_jsonl_tree` | JSONL transcript stream/tree | Chat JSONL tree. |
-| Kimi Code CLI | `kimi_code_cli_wire_jsonl_tree` | JSONL transcript stream/tree | Wire-event JSONL tree. |
+| Kimi Code | `kimi_code_cli_wire_jsonl_tree` | JSONL transcript stream/tree | Wire-event JSONL tree. |
 | Auggie | `auggie_session_json` | JSON session/task document | Single-session JSON. |
 | Junie | `junie_session_events_jsonl_tree` | JSONL transcript stream/tree | Session event tree. |
 | Firebender | `firebender_chat_history_sqlite` | SQLite message store | SQLite chat history. |

--- a/docs/provider-support-matrix.json
+++ b/docs/provider-support-matrix.json
@@ -250,7 +250,7 @@
     },
     {
       "id": "claude_code",
-      "display_name": "Claude",
+      "display_name": "Claude Code",
       "status": "supported",
       "capture_provider": "claude",
       "configured_root": {
@@ -459,7 +459,7 @@
     },
     {
       "id": "kiro_cli",
-      "display_name": "Kiro CLI",
+      "display_name": "Kiro",
       "status": "supported",
       "capture_provider": "kiro_cli",
       "configured_root": {
@@ -1498,7 +1498,7 @@
     },
     {
       "id": "copilot_cli",
-      "display_name": "Copilot CLI",
+      "display_name": "GitHub Copilot",
       "status": "supported",
       "capture_provider": "copilot_cli",
       "configured_root": {
@@ -1656,7 +1656,7 @@
     },
     {
       "id": "kimi_code_cli",
-      "display_name": "Kimi Code CLI",
+      "display_name": "Kimi Code",
       "status": "supported",
       "capture_provider": "kimi_code_cli",
       "configured_root": {

--- a/docs/provider-support.md
+++ b/docs/provider-support.md
@@ -74,11 +74,11 @@ support matrix is:
 | Grok Build | Supported | `grok_build_session_updates_jsonl_tree` |
 | DeepSeek Harness | Supported | `deepseek_harness_session_jsonl_tree` |
 | Pi | Supported | `pi_session_jsonl` |
-| Claude | Supported | `claude_projects_jsonl_tree` |
+| Claude Code | Supported | `claude_projects_jsonl_tree` |
 | OpenCode | Supported | `opencode_sqlite` |
 | Kilo Code | Supported | `kilo_sqlite` |
 | MiMo Code | Supported | `mimocode_sqlite` |
-| Kiro CLI | Supported | `kiro_cli_sqlite` |
+| Kiro | Supported | `kiro_cli_sqlite` |
 | Crush | Supported | `crush_sqlite` |
 | Goose | Supported | `goose_sessions_sqlite` |
 | Lingma | Supported | `lingma_sqlite` |
@@ -97,10 +97,10 @@ support matrix is:
 | Tabnine | Supported | `tabnine_cli_chat_recording_jsonl` |
 | Cursor | Supported | `cursor_agent_transcript_jsonl_tree` |
 | Zed | Supported | `zed_threads_sqlite` |
-| Copilot CLI | Supported | `copilot_cli_session_events_jsonl` |
+| GitHub Copilot | Supported | `copilot_cli_session_events_jsonl` |
 | Factory AI Droid | Supported | `factory_ai_droid_sessions_jsonl` |
 | Qwen Code | Supported | `qwen_code_chat_jsonl_tree` |
-| Kimi Code CLI | Supported | `kimi_code_cli_wire_jsonl_tree` |
+| Kimi Code | Supported | `kimi_code_cli_wire_jsonl_tree` |
 | Auggie | Supported | `auggie_session_json` |
 | Junie | Supported | `junie_session_events_jsonl_tree` |
 | Firebender | Supported | `firebender_chat_history_sqlite` |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -11,7 +11,7 @@ shared incremental, read-only architecture.
 
 The public CLI supports these local-history harnesses:
 
-Codex, Grok Build, DeepSeek Harness, Pi, Claude, OpenCode, Kilo Code, Kiro CLI, Crush, Goose, Lingma, Qoder, Warp, CodeBuddy, OpenClaw, Hermes Agent, NanoClaw, AstrBot, Shelley, Continue, OpenHands, Antigravity, Gemini, Tabnine, Cursor, Zed, Copilot CLI, Factory AI Droid, Qwen Code, Kimi Code CLI, Auggie, Junie, Firebender, ForgeCode, Deep Agents, Mistral Vibe, Mux, Rovo Dev, Cline, Roo Code, MiMo Code, fx.
+Codex, Grok Build, DeepSeek Harness, Pi, Claude Code, OpenCode, Kilo Code, Kiro, Crush, Goose, Lingma, Qoder, Warp, CodeBuddy, OpenClaw, Hermes Agent, NanoClaw, AstrBot, Shelley, Continue, OpenHands, Antigravity, Gemini, Tabnine, Cursor, Zed, GitHub Copilot, Factory AI Droid, Qwen Code, Kimi Code, Auggie, Junie, Firebender, ForgeCode, Deep Agents, Mistral Vibe, Mux, Rovo Dev, Cline, Roo Code, MiMo Code, fx.
 
 Use `ctx sources` for the truth on the current machine:
 


### PR DESCRIPTION
## Summary
- use one canonical human provider-name authority, including Claude Code
- render Provider, optional Source, compact Session, and independent direct Parent and Root fields
- keep verbose and machine search output full and unchanged

## Validation
- affected graph: 122/122
- complete CI graph: 217/217
- real xterm captures at wide and narrow widths
- independent semantic and visual reviews: ship