### PR TITLE
Simplify human search result metadata

### DIFF
--- a/crates/ctx-history-cli/src/source_index/render/goldens/search.txt
+++ b/crates/ctx-history-cli/src/source_index/render/goldens/search.txt
@@ -1,10 +1,11 @@
-1 result · relevance order · all agent sessions
+1 result
 
 1. Fix the Unicode cache key regression in the parser.
    Provider  Codex
    Session   01900000
    Root      01900000
-   Event     01900001 · 2026-07-30T12:00:00.123Z
+   Event     01900001
+   Time      2026-07-30T12:00:00.123Z
    More      2 results from this session
 
    Inspect

--- a/crates/ctx-history-cli/src/source_index/render/search.rs
+++ b/crates/ctx-history-cli/src/source_index/render/search.rs
@@ -7,9 +7,7 @@ use crate::{
     },
 };
 
-use super::human::{
-    display_width, push_action, push_field, push_heading, push_prefixed, push_wrapped,
-};
+use super::human::{push_action, push_field, push_heading, push_prefixed, push_wrapped};
 
 const CARD_INDENT: usize = 3;
 const CARD_LABEL_WIDTH: usize = 8;
@@ -59,7 +57,7 @@ pub(in crate::source_index) fn render_search_document(
     }
 
     let mut document = Document::new();
-    render_results_heading(&mut document, value, results.len(), context);
+    render_results_heading(&mut document, results.len());
 
     for (position, result) in results.iter().enumerate() {
         document.push_blank();
@@ -95,12 +93,7 @@ fn render_search_footers(document: &mut Document, value: &Value, context: &Rende
     }
 }
 
-fn render_results_heading(
-    document: &mut Document,
-    value: &Value,
-    result_count: usize,
-    context: &RenderContext,
-) {
+fn render_results_heading(document: &mut Document, result_count: usize) {
     let outcome = format!(
         "{result_count} {}",
         if result_count == 1 {
@@ -109,35 +102,7 @@ fn render_results_heading(
             "results"
         }
     );
-    let order = "relevance order";
-    let scope = if value["filters"]["primary_only"] == true {
-        "primary sessions"
-    } else {
-        "all agent sessions"
-    };
-    let separator = if context.unicode() { " · " } else { " | " };
-    let width = display_width(&outcome)
-        .saturating_add(display_width(separator).saturating_mul(2))
-        .saturating_add(display_width(order))
-        .saturating_add(display_width(scope));
-
-    if context
-        .content_width()
-        .is_none_or(|available| width <= available)
-    {
-        document.push_line(
-            Line::new()
-                .with(Span::new(outcome, Token::Heading))
-                .with(Span::new(separator, Token::Label))
-                .with(Span::new(order, Token::Label))
-                .with(Span::new(separator, Token::Label))
-                .with(Span::new(scope, Token::Label)),
-        );
-    } else {
-        push_heading(document, &outcome, Token::Heading);
-        push_wrapped(document, context, 2, order, Token::Label);
-        push_wrapped(document, context, 2, scope, Token::Label);
-    }
+    push_heading(document, &outcome, Token::Heading);
 }
 
 fn render_empty(value: &Value, context: &RenderContext) -> Document {
@@ -292,51 +257,24 @@ fn render_event_summary(
         .map_or(("time unavailable", Token::Label), |timestamp| {
             (timestamp, Token::Text)
         });
-    let separator = if context.unicode() { " · " } else { " | " };
-    let prefix_width = CARD_INDENT
-        .saturating_add(CARD_LABEL_WIDTH)
-        .saturating_add(2);
-    let combined_width = prefix_width
-        .saturating_add(display_width(event_id))
-        .saturating_add(display_width(separator))
-        .saturating_add(display_width(time));
-
-    if context
-        .content_width()
-        .is_none_or(|available| combined_width <= available)
-    {
-        document.push_line(
-            Line::new()
-                .with(Span::text(" ".repeat(CARD_INDENT)))
-                .with(Span::new("Event", Token::Label))
-                .with(Span::text(" ".repeat(
-                    CARD_LABEL_WIDTH.saturating_sub(display_width("Event")),
-                )))
-                .with(Span::text("  "))
-                .with(Span::new(event_id, Token::Reference))
-                .with(Span::new(separator, Token::Label))
-                .with(Span::new(time, time_token)),
-        );
-    } else {
-        push_field(
-            document,
-            context,
-            CARD_INDENT,
-            "Event",
-            CARD_LABEL_WIDTH,
-            event_id,
-            Token::Reference,
-        );
-        push_field(
-            document,
-            context,
-            CARD_INDENT,
-            "Time",
-            CARD_LABEL_WIDTH,
-            time,
-            time_token,
-        );
-    }
+    push_field(
+        document,
+        context,
+        CARD_INDENT,
+        "Event",
+        CARD_LABEL_WIDTH,
+        event_id,
+        Token::Reference,
+    );
+    push_field(
+        document,
+        context,
+        CARD_INDENT,
+        "Time",
+        CARD_LABEL_WIDTH,
+        time,
+        time_token,
+    );
 }
 
 fn render_verbose_fields(document: &mut Document, context: &RenderContext, result: &Value) {

--- a/crates/ctx-history-cli/src/source_index/render/tests.rs
+++ b/crates/ctx-history-cli/src/source_index/render/tests.rs
@@ -485,41 +485,37 @@ fn primary_renderers_match_reference_goldens_at_80_columns() {
 }
 
 #[test]
-fn search_heading_discloses_relevance_order_and_truthful_agent_scope() {
-    for unicode in [true, false] {
-        let separator = if unicode { " · " } else { " | " };
-        let all_agents =
-            render_search_document(&search_value(), false, &context_with_unicode(80, unicode))
-                .render_plain();
-        assert!(
-            all_agents.starts_with(&format!(
-                "1 result{separator}relevance order{separator}all agent sessions\n"
-            )),
-            "{all_agents}"
-        );
+fn search_heading_only_reports_result_count() {
+    let singular = search_value();
+    let mut plural = search_value();
+    let second = plural["results"][0].clone();
+    plural["results"]
+        .as_array_mut()
+        .expect("search fixture results are an array")
+        .push(second);
+    plural["result_window"]["returned"] = json!(2);
 
-        let mut primary_only = search_value();
-        primary_only["filters"]["primary_only"] = json!(true);
-        let primary_only =
-            render_search_document(&primary_only, false, &context_with_unicode(80, unicode))
-                .render_plain();
-        assert!(primary_only.starts_with(&format!(
-            "1 result{separator}relevance order{separator}primary sessions\n"
-        )));
-        assert!(!primary_only.contains("all agent sessions"));
-    }
-
-    let narrow = render_search_document(&search_value(), false, &context_with_unicode(32, true))
-        .render_plain();
-    assert!(narrow.starts_with("1 result\n  relevance order\n  all agent sessions\n"));
-
-    for width in [32, 48, 80, 120] {
-        let context = context(width, ColorMode::Never);
-        let first = render_search_document(&search_value(), false, &context);
-        let second = render_search_document(&search_value(), false, &context);
-        assert_eq!(first.render_plain(), second.render_plain());
-        assert!(first.render_plain().contains("all agent sessions"));
-        assert_fits(&first, &context);
+    for (value, expected_heading) in [(&singular, "1 result"), (&plural, "2 results")] {
+        for primary_only in [false, true] {
+            let mut filtered = value.clone();
+            filtered["filters"]["primary_only"] = json!(primary_only);
+            for unicode in [true, false] {
+                for width in [32, 48, 80, 120] {
+                    let context = context_with_unicode(width, unicode);
+                    let document = render_search_document(&filtered, false, &context);
+                    let rendered = document.render_plain();
+                    assert_eq!(
+                        rendered.lines().next(),
+                        Some(expected_heading),
+                        "{rendered}"
+                    );
+                    for removed in ["relevance order", "all agent sessions", "primary sessions"] {
+                        assert!(!rendered.contains(removed), "{rendered}");
+                    }
+                    assert_fits(&document, &context);
+                }
+            }
+        }
     }
 }
 
@@ -720,38 +716,66 @@ fn normal_search_uses_compact_refs_and_verbose_uses_full_ctx_ids() {
 }
 
 #[test]
-fn search_event_row_uses_exact_milliseconds_and_quiet_missing_time() {
-    let document = render_search_document(
-        &compact_search_value(),
-        false,
-        &context(80, ColorMode::Never),
-    );
-    let rendered = document.render_plain();
-    assert!(rendered.contains("Event     01900001 · 2026-07-30T12:00:00.123Z"));
-    assert!(!rendered.contains("Match"));
-    assert!(document
-        .lines()
-        .iter()
-        .flat_map(|line| line.spans())
-        .any(|span| span.content() == "01900001" && span.token() == Token::Reference));
-    assert!(document
-        .lines()
-        .iter()
-        .flat_map(|line| line.spans())
-        .any(|span| {
-            span.content() == "2026-07-30T12:00:00.123Z" && span.token() == Token::Text
-        }));
+fn search_event_and_time_are_separate_fields_with_exact_milliseconds() {
+    for unicode in [true, false] {
+        for width in [32, 48, 80, 120] {
+            let context = context_with_unicode(width, unicode);
+            let document = render_search_document(&compact_search_value(), false, &context);
+            let rendered = document.render_plain();
+            assert!(!rendered.contains("Match"));
 
-    let ascii = render_search_document(
-        &compact_search_value(),
-        false,
-        &context_with_unicode(80, false),
-    )
-    .render_plain();
-    assert!(
-        ascii.contains("Event     01900001 | 2026-07-30T12:00:00.123Z"),
-        "{ascii}"
-    );
+            let event_line = document
+                .lines()
+                .iter()
+                .position(|line| {
+                    line.spans()
+                        .iter()
+                        .any(|span| span.content() == "Event" && span.token() == Token::Label)
+                })
+                .expect("event field is rendered");
+            let time_line = document
+                .lines()
+                .iter()
+                .position(|line| {
+                    line.spans()
+                        .iter()
+                        .any(|span| span.content() == "Time" && span.token() == Token::Label)
+                })
+                .expect("time field is rendered");
+            assert_ne!(event_line, time_line, "{rendered}");
+            assert!(
+                document.lines()[event_line]
+                    .spans()
+                    .iter()
+                    .any(|span| span.content() == "01900001" && span.token() == Token::Reference),
+                "{rendered}"
+            );
+            let time_end = document
+                .lines()
+                .iter()
+                .enumerate()
+                .skip(time_line + 1)
+                .find_map(|(index, line)| {
+                    line.spans()
+                        .iter()
+                        .any(|span| span.content() == "More" && span.token() == Token::Label)
+                        .then_some(index)
+                })
+                .unwrap_or(document.lines().len());
+            let time_value: String = document.lines()[time_line..time_end]
+                .iter()
+                .flat_map(|line| line.spans())
+                .filter(|span| span.token() == Token::Text)
+                .flat_map(|span| span.content().chars())
+                .filter(|character| !character.is_whitespace())
+                .collect();
+            assert!(
+                time_value.contains("2026-07-30T12:00:00.123Z"),
+                "{rendered}"
+            );
+            assert_fits(&document, &context);
+        }
+    }
 
     let mut missing = compact_search_value();
     missing["results"][0]["timestamp"] = Value::Null;

--- a/crates/ctx-history-read-application/tests/support/search_show/search_flows.rs
+++ b/crates/ctx-history-read-application/tests/support/search_show/search_flows.rs
@@ -259,10 +259,7 @@ fn fresh_home_search_mvp_flow() {
         .stdout
         .clone();
     let human_search = String::from_utf8(human_search).unwrap();
-    assert!(
-        human_search.starts_with("1 result · relevance order · all agent sessions\n\n"),
-        "{human_search}"
-    );
+    assert!(human_search.starts_with("1 result\n\n"), "{human_search}");
     assert!(human_search.contains("1. "));
     assert!(human_search.contains("Provider  Codex"), "{human_search}");
     assert!(
@@ -270,10 +267,11 @@ fn fresh_home_search_mvp_flow() {
         "{human_search}"
     );
     assert!(
-        human_search.contains(&format!(
-            "Event     {} · 2026-06-23T15:00:02.000Z",
-            &ctx_event_id[..8]
-        )),
+        human_search.contains(&format!("Event     {}", &ctx_event_id[..8])),
+        "{human_search}"
+    );
+    assert!(
+        human_search.contains("Time      2026-06-23T15:00:02.000Z"),
         "{human_search}"
     );
     assert!(

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -707,9 +707,9 @@ search uses a non-default data root. Each result's `rank` is its one-based
 position in the final shaped window. `retrieval_score` preserves the backend's
 diagnostic score, which can be non-monotonic after query-coverage and family
 shaping.
-Human output states `relevance order` and the selected agent scope in the
-result heading. Its compact `Event` row pairs the dynamic event reference with
-the exact matched-event UTC RFC 3339 millisecond time;
+Human output uses only the pluralized rendered-result count in the heading.
+Separate `Event` and `Time` rows show the dynamic event reference and the exact
+matched-event UTC RFC 3339 millisecond time;
 timestamps never re-sort results. `--verbose` additionally renders the stored
 event sequence and available workspace/working-directory, branch, agent, and
 parent/root lineage without repeating equal values.

--- a/docs/search.md
+++ b/docs/search.md
@@ -24,12 +24,11 @@ Ordinary results include primary and subagent sessions. When history carries an
 exact root-session claim, ctx groups sessions by that claim and returns one best
 result per root task before repeating a root; a session without that claim is
 its own group. Agent scope is result metadata or an explicit filter; it does
-not silently rerank relevance. Human output labels the result window as
-relevance ordered and identifies the selected agent scope. Each result's
-`Event` row shows the short ctx event ID and the
-matched event's exact
-UTC RFC 3339 millisecond timestamp; an indexed event without a timestamp says
-`time unavailable`. These timestamps do not change result ordering.
+not silently rerank relevance. Human output uses only the pluralized result
+count in the heading. Each result has separate `Event` and `Time` rows showing
+the short ctx event ID and the matched event's exact UTC RFC 3339 millisecond
+timestamp; an indexed event without a timestamp says `time unavailable`. These
+timestamps do not change result ordering.
 
 ## Search examples
 


### PR DESCRIPTION
Render only the pluralized result count in human search headings and keep Event and Time as independent fields at every terminal width. This does not change machine output, ranking, filtering, refresh, or search semantics.