### PR TITLE
Add semantic lifecycle commands and runtime-only repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ Search uses BM25 lexical matching by default. Give it likely terms—an error, f
 Semantic search helps when related ideas use different wording. ctx computes embeddings locally and searches them directly, without a vector database to run. Enable it with:
 
 ```bash
-ctx setup --semantic
-ctx index
+ctx semantic enable
+ctx semantic status
 ```
 
-Semantic search requires automatic indexing, which is the default. If you use manual indexing, run `ctx index mode auto` first. Lexical search remains available while embeddings build; once they are ready, hybrid search uses lexical and semantic evidence automatically.
+Automatic indexing is the default, so enablement starts or recovers the daemon that acquires the local model and builds the semantic projection. Add `--wait` to wait for readiness. If you selected manual indexing, plain enablement records the opt-in without changing modes; run `ctx index mode auto` for automatic catch-up or use an explicit semantic search with `--refresh wait`. Lexical search remains available while embeddings build; hybrid search uses lexical and semantic evidence automatically when coverage is ready. `ctx semantic disable` turns the feature off without deleting downloaded assets.
 
 ctx does not send your prompts, transcripts, or indexed history to a cloud service, call model APIs, require API keys, or write into your source repositories. Transcript text is preserved rather than automatically redacted, so review copied output before sharing it outside your machine.
 

--- a/crates/ctx-cli-contract-tests/tests/contracts/cli_public_help_docs.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/cli_public_help_docs.rs
@@ -151,6 +151,7 @@ fn help_exposes_session_retrieval_commands() {
         "blame",
         "referral",
         "setup",
+        "semantic",
         "status",
         "stats",
         "index",
@@ -435,9 +436,17 @@ fn public_subcommand_help_is_golden_enough_for_session_retrieval() {
                 "Usage: ctx setup",
                 "--catalog-only",
                 "Deprecated and ignored; setup follows its normal refresh lifecycle",
-                "--semantic",
-                "Enable local semantic search in config",
                 "--format <FORMAT>",
+            ],
+        ),
+        (
+            "semantic",
+            vec![
+                "Usage: ctx semantic [OPTIONS] <COMMAND>",
+                "enable",
+                "status",
+                "disable",
+                "Manage local semantic search",
             ],
         ),
         ("status", vec!["Usage: ctx status", "--format <FORMAT>"]),
@@ -580,6 +589,9 @@ fn public_subcommand_help_is_golden_enough_for_session_retrieval() {
                 "{command} help leaked {forbidden} in\n{help}"
             );
         }
+        if command == "setup" {
+            assert!(!help.contains("--semantic"), "{help}");
+        }
     }
 }
 
@@ -588,6 +600,9 @@ fn machine_readable_output_uses_format_without_a_json_alias() {
     let temp = tempdir();
     for args in [
         &["setup", "--help"][..],
+        &["semantic", "enable", "--help"],
+        &["semantic", "status", "--help"],
+        &["semantic", "disable", "--help"],
         &["status", "--help"],
         &["stats", "--help"],
         &["index", "--help"],

--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle.rs
@@ -1,6 +1,7 @@
 use super::{
     assert_daemon_process_running, assert_daemon_process_running_with_status,
-    assert_no_daemon_autostart_mutation, ctx, support, support::*, write_codex_setup_session,
+    assert_no_daemon_autostart_mutation, ctx, support, support::*, wait_for_daemon_status,
+    write_codex_setup_session,
 };
 
 #[path = "../support/setup_sources_import/lifecycle_helpers.rs"]
@@ -373,6 +374,191 @@ fn setup_semantic_clean_cache_queues_daemon_without_foreground_download() {
         !semantic_cache.exists(),
         "foreground setup must leave clean semantic cache acquisition to the daemon"
     );
+}
+
+#[test]
+fn semantic_namespace_is_explicit_readable_and_retains_downloaded_assets() {
+    let temp = tempdir();
+
+    let initial = json_output(ctx(&temp).args(["semantic", "status", "--format=json"]));
+    assert_eq!(initial["operation"], "status", "{initial:#}");
+    assert_eq!(initial["enabled"], false, "{initial:#}");
+    assert_eq!(initial["status"], "disabled", "{initial:#}");
+    assert_eq!(initial["read_only"], true, "{initial:#}");
+    assert!(!data_root(&temp).exists());
+
+    fs::create_dir_all(data_root(&temp).join("semantic-model-cache")).unwrap();
+    fs::write(
+        data_root(&temp).join("config.toml"),
+        "# retained setting\n[indexing]\nmode = \"manual\"\n",
+    )
+    .unwrap();
+    let retained_asset = data_root(&temp)
+        .join("semantic-model-cache")
+        .join("retained-model.bin");
+    fs::write(&retained_asset, b"retained").unwrap();
+
+    let enabled = json_output(ctx(&temp).args(["semantic", "enable", "--format=json"]));
+    assert_eq!(enabled["operation"], "enable", "{enabled:#}");
+    assert_eq!(enabled["enabled"], true, "{enabled:#}");
+    assert_eq!(enabled["indexing"]["mode"], "manual", "{enabled:#}");
+    assert_eq!(enabled["read_only"], false, "{enabled:#}");
+    let configured = fs::read_to_string(data_root(&temp).join("config.toml")).unwrap();
+    assert!(configured.contains("# retained setting"), "{configured}");
+    assert!(
+        configured.contains("[search]\nsemantic = true\n"),
+        "{configured}"
+    );
+
+    let status = json_output(ctx(&temp).args(["semantic", "status", "--format=json"]));
+    assert_eq!(status["enabled"], true, "{status:#}");
+    assert_eq!(status["read_only"], true, "{status:#}");
+
+    let disabled = json_output(ctx(&temp).args(["semantic", "disable", "--format=json"]));
+    assert_eq!(disabled["operation"], "disable", "{disabled:#}");
+    assert_eq!(disabled["enabled"], false, "{disabled:#}");
+    assert_eq!(disabled["status"], "disabled", "{disabled:#}");
+    assert_eq!(disabled["read_only"], false, "{disabled:#}");
+    assert_eq!(fs::read(&retained_asset).unwrap(), b"retained");
+}
+
+#[test]
+fn semantic_wait_rejects_manual_mode_before_persisting_opt_in() {
+    let temp = tempdir();
+    fs::create_dir_all(data_root(&temp)).unwrap();
+    fs::write(
+        data_root(&temp).join("config.toml"),
+        "[indexing]\nmode = \"manual\"\n",
+    )
+    .unwrap();
+
+    ctx(&temp)
+        .args(["semantic", "enable", "--wait"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("ctx index mode auto"));
+
+    let configured = fs::read_to_string(data_root(&temp).join("config.toml")).unwrap();
+    assert!(!configured.contains("semantic"), "{configured}");
+}
+
+#[test]
+fn semantic_disable_does_not_claim_success_under_an_enabling_process_override() {
+    let temp = tempdir();
+    fs::create_dir_all(data_root(&temp)).unwrap();
+    fs::write(
+        data_root(&temp).join("config.toml"),
+        "[indexing]\nmode = \"manual\"\n\n[search]\nsemantic = true\n",
+    )
+    .unwrap();
+
+    ctx(&temp)
+        .args(["semantic", "disable"])
+        .env("CTX_SEARCH_SEMANTIC", "true")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("active process override"));
+
+    let configured = fs::read_to_string(data_root(&temp).join("config.toml")).unwrap();
+    assert!(
+        configured.contains("[search]\nsemantic = false\n"),
+        "{configured}"
+    );
+}
+
+#[test]
+fn semantic_enable_persists_opt_in_but_reports_a_disabling_process_override() {
+    let temp = tempdir();
+    fs::create_dir_all(data_root(&temp)).unwrap();
+    fs::write(
+        data_root(&temp).join("config.toml"),
+        "[indexing]\nmode = \"manual\"\n",
+    )
+    .unwrap();
+
+    ctx(&temp)
+        .args(["semantic", "enable"])
+        .env("CTX_SEARCH_SEMANTIC", "false")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("active process override"));
+
+    let configured = fs::read_to_string(data_root(&temp).join("config.toml")).unwrap();
+    assert!(
+        configured.contains("[search]\nsemantic = true\n"),
+        "{configured}"
+    );
+    let status = json_output(
+        ctx(&temp)
+            .args(["semantic", "status", "--format=json"])
+            .env("CTX_SEARCH_SEMANTIC", "false"),
+    );
+    assert_eq!(status["enabled"], false, "{status:#}");
+    assert_eq!(status["config_source"], "environment", "{status:#}");
+    assert_no_daemon_autostart_mutation(&temp);
+}
+
+#[test]
+fn setup_semantic_alias_uses_the_same_process_override_validation() {
+    let temp = tempdir();
+
+    ctx(&temp)
+        .args(["setup", "--semantic", "--progress", "none"])
+        .env("CTX_SEARCH_SEMANTIC", "false")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("active process override"));
+
+    let configured = fs::read_to_string(data_root(&temp).join("config.toml")).unwrap();
+    assert!(
+        configured.contains("[search]\nsemantic = true\n"),
+        "{configured}"
+    );
+    assert!(!data_root(&temp).join("search").exists());
+    assert!(!data_root(&temp).join("relational.sqlite").exists());
+    assert!(!data_root(&temp).join("catalogs").exists());
+    assert_no_daemon_autostart_mutation(&temp);
+}
+
+#[test]
+fn semantic_enable_auto_starts_the_existing_daemon_acquisition_path() {
+    let temp = daemon_test_root();
+
+    let enabled = json_output(ctx(&temp).args(["semantic", "enable", "--format=json"]));
+    assert_eq!(enabled["operation"], "enable", "{enabled:#}");
+    assert_eq!(enabled["enabled"], true, "{enabled:#}");
+    assert_eq!(enabled["indexing"]["mode"], "auto", "{enabled:#}");
+
+    let status = wait_for_daemon_status(&temp, "running", true, "semantic");
+    assert_eq!(
+        status["daemon"]["jobs"]["semantic_index"]["semantic_enabled"], true,
+        "{status:#}"
+    );
+    assert!(fs::read_to_string(data_root(&temp).join("config.toml"))
+        .unwrap()
+        .contains("[search]\nsemantic = true\n"));
+
+    let waited = json_output(ctx(&temp).args(["semantic", "enable", "--wait", "--format=json"]));
+    assert_eq!(waited["status"], "ready", "{waited:#}");
+    assert_eq!(waited["selection"]["semantic"], true, "{waited:#}");
+    assert_eq!(waited["read_only"], false, "{waited:#}");
+
+    let disabled = json_output(ctx(&temp).args(["semantic", "disable", "--format=json"]));
+    assert_eq!(disabled["enabled"], false, "{disabled:#}");
+    assert_eq!(disabled["status"], "disabling", "{disabled:#}");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let status = json_output(ctx(&temp).args(["daemon", "status", "--format=json"]));
+        let semantic = &status["daemon"]["jobs"]["semantic_index"];
+        if semantic["semantic_enabled"] == false && semantic["runtime_active"] == false {
+            assert_eq!(status["daemon"]["running"], true, "{status:#}");
+            break;
+        }
+        assert!(Instant::now() < deadline, "{status:#}");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let disabled = json_output(ctx(&temp).args(["semantic", "status", "--format=json"]));
+    assert_eq!(disabled["status"], "disabled", "{disabled:#}");
 }
 
 #[test]

--- a/crates/ctx-cli-contract-tests/tests/contracts/support/upgrade.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/support/upgrade.rs
@@ -89,6 +89,271 @@ pub(crate) fn sign_test_release_metadata(bytes: &[u8]) -> String {
     BASE64.encode(signature)
 }
 
+#[cfg(windows)]
+#[derive(Debug)]
+pub(crate) struct WindowsRuntimeRepairRelease {
+    pub(crate) target: PathBuf,
+    pub(crate) metadata: PathBuf,
+    pub(crate) signature: PathBuf,
+    pub(crate) runtime_target: PathBuf,
+    pub(crate) runtime_artifact_sha: String,
+    pub(crate) runtime_version: String,
+}
+
+#[cfg(windows)]
+fn windows_file_url(path: &Path) -> String {
+    let rendered = path.display().to_string();
+    let local = rendered.strip_prefix("\\\\?\\").unwrap_or(&rendered);
+    assert!(
+        !local.chars().any(|value| matches!(value, '%' | '?' | '#')),
+        "Windows runtime repair fixture path requires URL escaping: {local}"
+    );
+    format!("file:///{}", local.replace('\\', "/"))
+}
+
+/// Builds the exact Windows ONNX Runtime ZIP shape consumed by the production
+/// PowerShell extractor without adding a second archive implementation as a
+/// test dependency. The entries are stored (rather than compressed), but carry
+/// the Unix type bits which the extractor validates before publication.
+#[cfg(windows)]
+fn write_windows_runtime_zip(path: &Path, version: &str) {
+    const DIRECTORY_MODE: u32 = 0o040755;
+    const FILE_MODE: u32 = 0o100644;
+
+    let entries = vec![
+        ("LICENSE".to_owned(), b"test license\n".to_vec(), FILE_MODE),
+        (
+            "MICROSOFT_VC_RUNTIME_LICENSE.rtf".to_owned(),
+            b"test Microsoft VC runtime license\n".to_vec(),
+            FILE_MODE,
+        ),
+        (
+            "ThirdPartyNotices.txt".to_owned(),
+            b"test notices\n".to_vec(),
+            FILE_MODE,
+        ),
+        (
+            "VERSION_NUMBER".to_owned(),
+            format!("{version}\n").into_bytes(),
+            FILE_MODE,
+        ),
+        (
+            "GIT_COMMIT_ID".to_owned(),
+            b"test-runtime-commit\n".to_vec(),
+            FILE_MODE,
+        ),
+        ("lib/".to_owned(), Vec::new(), DIRECTORY_MODE),
+        (
+            "lib/onnxruntime.dll".to_owned(),
+            b"fake onnxruntime DLL\n".to_vec(),
+            FILE_MODE,
+        ),
+        (
+            "lib/msvcp140.dll".to_owned(),
+            b"fake msvcp140 DLL\n".to_vec(),
+            FILE_MODE,
+        ),
+        (
+            "lib/msvcp140_1.dll".to_owned(),
+            b"fake msvcp140_1 DLL\n".to_vec(),
+            FILE_MODE,
+        ),
+        (
+            "lib/vcruntime140.dll".to_owned(),
+            b"fake vcruntime140 DLL\n".to_vec(),
+            FILE_MODE,
+        ),
+        (
+            "lib/vcruntime140_1.dll".to_owned(),
+            b"fake vcruntime140_1 DLL\n".to_vec(),
+            FILE_MODE,
+        ),
+    ];
+
+    let mut archive = Vec::new();
+    let mut central_directory = Vec::new();
+    let entry_count = u16::try_from(entries.len()).unwrap();
+    for (name, contents, mode) in entries {
+        let local_offset = u32::try_from(archive.len()).unwrap();
+        let name = name.as_bytes();
+        let crc32 = zip_crc32(&contents);
+        let size = u32::try_from(contents.len()).unwrap();
+        let name_length = u16::try_from(name.len()).unwrap();
+
+        zip_u32(&mut archive, 0x0403_4b50);
+        zip_u16(&mut archive, 20);
+        zip_u16(&mut archive, 0);
+        zip_u16(&mut archive, 0);
+        zip_u16(&mut archive, 0);
+        zip_u16(&mut archive, 0);
+        zip_u32(&mut archive, crc32);
+        zip_u32(&mut archive, size);
+        zip_u32(&mut archive, size);
+        zip_u16(&mut archive, name_length);
+        zip_u16(&mut archive, 0);
+        archive.extend_from_slice(name);
+        archive.extend_from_slice(&contents);
+
+        zip_u32(&mut central_directory, 0x0201_4b50);
+        zip_u16(&mut central_directory, 0x0314);
+        zip_u16(&mut central_directory, 20);
+        zip_u16(&mut central_directory, 0);
+        zip_u16(&mut central_directory, 0);
+        zip_u16(&mut central_directory, 0);
+        zip_u16(&mut central_directory, 0);
+        zip_u32(&mut central_directory, crc32);
+        zip_u32(&mut central_directory, size);
+        zip_u32(&mut central_directory, size);
+        zip_u16(&mut central_directory, name_length);
+        zip_u16(&mut central_directory, 0);
+        zip_u16(&mut central_directory, 0);
+        zip_u16(&mut central_directory, 0);
+        zip_u16(&mut central_directory, 0);
+        zip_u32(&mut central_directory, mode << 16);
+        zip_u32(&mut central_directory, local_offset);
+        central_directory.extend_from_slice(name);
+    }
+
+    let central_offset = u32::try_from(archive.len()).unwrap();
+    let central_size = u32::try_from(central_directory.len()).unwrap();
+    archive.extend_from_slice(&central_directory);
+    zip_u32(&mut archive, 0x0605_4b50);
+    zip_u16(&mut archive, 0);
+    zip_u16(&mut archive, 0);
+    zip_u16(&mut archive, entry_count);
+    zip_u16(&mut archive, entry_count);
+    zip_u32(&mut archive, central_size);
+    zip_u32(&mut archive, central_offset);
+    zip_u16(&mut archive, 0);
+
+    fs::write(path, archive).unwrap();
+}
+
+#[cfg(windows)]
+fn zip_u16(out: &mut Vec<u8>, value: u16) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+#[cfg(windows)]
+fn zip_u32(out: &mut Vec<u8>, value: u32) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+#[cfg(windows)]
+fn zip_crc32(bytes: &[u8]) -> u32 {
+    let mut crc = !0_u32;
+    for byte in bytes {
+        crc ^= u32::from(*byte);
+        for _ in 0..8 {
+            crc = if crc & 1 == 0 {
+                crc >> 1
+            } else {
+                (crc >> 1) ^ 0xedb8_8320
+            };
+        }
+    }
+    !crc
+}
+
+#[cfg(windows)]
+pub(crate) fn windows_runtime_repair_release(
+    temp: &TempDir,
+    target: &Path,
+) -> WindowsRuntimeRepairRelease {
+    let target = fs::canonicalize(target).unwrap();
+    let release_dir = temp.path().join("windows-runtime-repair-release");
+    fs::create_dir(&release_dir).unwrap();
+
+    let release_binary = release_dir.join("ctx.exe");
+    fs::copy(&target, &release_binary).unwrap();
+    let release_binary_sha = sha256_hex(&fs::read(&release_binary).unwrap());
+    let runtime_version = "1.27.0";
+    let runtime_artifact = release_dir.join("ctx-onnxruntime-windows-x64.zip");
+    write_windows_runtime_zip(&runtime_artifact, runtime_version);
+    let runtime_artifact_sha = sha256_hex(&fs::read(&runtime_artifact).unwrap());
+
+    let mut metadata_body = format!(
+        "CTX_RELEASE_SCHEMA_VERSION=1\n\
+CTX_RELEASE_CHANNEL=stable\n\
+CTX_RELEASE_VERSION={}\n\
+CTX_RELEASE_BASE_URL={}\n\
+CTX_RELEASE_ARTIFACT_windows_x64=ctx.exe\n\
+CTX_RELEASE_SHA256_windows_x64={release_binary_sha}\n\
+CTX_RELEASE_SELF_UPGRADE_ALLOWED=true\n\
+CTX_RELEASE_AUTO_UPGRADE_ALLOWED=true\n\
+CTX_RELEASE_ONNXRUNTIME_VERSION={runtime_version}\n",
+        env!("CARGO_PKG_VERSION"),
+        windows_file_url(&release_dir),
+    );
+    for key in [
+        "linux_x64",
+        "linux_aarch64",
+        "macos_arm64",
+        "macos_x64",
+        "windows_x64",
+        "freebsd_x64",
+    ] {
+        let platform = key.replace('_', "-");
+        let extension = if key == "windows_x64" {
+            "zip"
+        } else {
+            "tar.gz"
+        };
+        metadata_body.push_str(&format!(
+            "CTX_RELEASE_ONNXRUNTIME_ARTIFACT_{key}=ctx-onnxruntime-{platform}.{extension}\n\
+CTX_RELEASE_ONNXRUNTIME_SHA256_{key}={runtime_artifact_sha}\n"
+        ));
+    }
+    let metadata = release_dir.join("ctx-release-metadata.env");
+    let signature = release_dir.join("ctx-release-metadata.env.sig");
+    fs::write(&metadata, &metadata_body).unwrap();
+    fs::write(
+        &signature,
+        format!("{}\n", sign_test_release_metadata(metadata_body.as_bytes())),
+    )
+    .unwrap();
+
+    WindowsRuntimeRepairRelease {
+        target,
+        metadata,
+        signature,
+        runtime_target: data_root(temp)
+            .join("runtime")
+            .join("onnxruntime")
+            .join(runtime_version)
+            .join("windows-x64"),
+        runtime_artifact_sha,
+        runtime_version: runtime_version.to_owned(),
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn windows_runtime_repair_release_env<'a>(
+    command: &'a mut Command,
+    release: &WindowsRuntimeRepairRelease,
+) -> &'a mut Command {
+    command
+        .env("CTX_UPGRADE_TEST_TARGET", &release.target)
+        .env(
+            "CTX_RELEASE_METADATA_URL",
+            windows_file_url(&release.metadata),
+        )
+        .env(
+            "CTX_RELEASE_METADATA_SIGNATURE_URL",
+            windows_file_url(&release.signature),
+        )
+        .env(
+            "CTX_RELEASE_METADATA_PUBLIC_KEY_PEM",
+            TEST_RELEASE_PUBLIC_KEY_PEM,
+        )
+}
+
+#[cfg(windows)]
+pub(crate) fn windows_install_transaction_path(target: &Path) -> PathBuf {
+    let file_name = target.file_name().unwrap().to_string_lossy();
+    target.with_file_name(format!(".{file_name}.upgrade-install-transaction.json"))
+}
+
 #[cfg(unix)]
 #[derive(Debug)]
 pub(crate) struct FakeRelease {

--- a/crates/ctx-cli-presentation/src/commands/index.rs
+++ b/crates/ctx-cli-presentation/src/commands/index.rs
@@ -21,6 +21,8 @@ pub struct IndexArgs {
     format: JsonOutputFormat,
     #[command(subcommand)]
     command: Option<IndexCommand>,
+    #[arg(skip)]
+    wait_read_only: Option<bool>,
 }
 
 impl IndexArgs {
@@ -32,6 +34,21 @@ impl IndexArgs {
                 Some(IndexCommand::Watch(args)) => args.format == IndexWatchFormat::Jsonl,
                 Some(IndexCommand::Wait(args)) => args.format.is_json(),
             }
+    }
+
+    pub fn semantic_wait(format: JsonOutputFormat) -> Self {
+        Self {
+            format,
+            wait_read_only: Some(false),
+            command: Some(IndexCommand::Wait(IndexWaitArgs {
+                format,
+                lexical: false,
+                semantic: true,
+                all: false,
+                timeout_seconds: None,
+                interval_seconds: 2,
+            })),
+        }
     }
 }
 
@@ -121,6 +138,7 @@ pub fn run_index(
     ui: &mut Ui,
 ) -> Result<()> {
     let parent_json = args.format.is_json();
+    let wait_read_only = args.wait_read_only.unwrap_or(true);
     match args.command {
         None => {
             telemetry.operation = Some(IndexOperation::Status);
@@ -161,7 +179,15 @@ pub fn run_index(
             if parent_json {
                 args.format = JsonOutputFormat::Json;
             }
-            run_index_wait(args, &data_root, quiet, telemetry, readiness, ui)
+            run_index_wait(
+                args,
+                &data_root,
+                quiet,
+                wait_read_only,
+                telemetry,
+                readiness,
+                ui,
+            )
         }
     }
 }
@@ -373,6 +399,7 @@ fn run_index_wait(
     args: IndexWaitArgs,
     data_root: &Path,
     quiet: bool,
+    read_only: bool,
     telemetry: &mut IndexTelemetry,
     readiness: &mut dyn IndexReadinessPort,
     ui: &mut Ui,
@@ -390,7 +417,7 @@ fn run_index_wait(
         if let Some(message) = index_terminal_error(&status, selection) {
             telemetry.wait_outcome = Some(WaitOutcome::Blocked);
             if args.format.is_json() {
-                print_json(index_wait_json(status, selection, "blocked"))?;
+                print_json(index_wait_json(status, selection, "blocked", read_only))?;
             } else if !quiet {
                 if selection.semantic
                     && !bool_at(&status, &["semantic", "enabled"])
@@ -411,7 +438,7 @@ fn run_index_wait(
         if index_ready(&status, selection) {
             telemetry.wait_outcome = Some(WaitOutcome::Ready);
             if args.format.is_json() {
-                print_json(index_wait_json(status, selection, "ready"))?;
+                print_json(index_wait_json(status, selection, "ready", read_only))?;
             } else if !quiet {
                 human_output.print(ui, &status, selection)?;
             }
@@ -423,7 +450,7 @@ fn run_index_wait(
         {
             telemetry.wait_outcome = Some(WaitOutcome::Timeout);
             if args.format.is_json() {
-                print_json(index_wait_json(status, selection, "timeout"))?;
+                print_json(index_wait_json(status, selection, "timeout", read_only))?;
             } else if !quiet {
                 human_output.print_final(ui, &status, selection)?;
             }
@@ -609,7 +636,12 @@ fn forward_index_terminal_error(message: String, human_output_rendered: bool) ->
     }
 }
 
-fn index_wait_json(status: Value, selection: IndexSelection, wait_status: &str) -> Value {
+fn index_wait_json(
+    status: Value,
+    selection: IndexSelection,
+    wait_status: &str,
+    read_only: bool,
+) -> Value {
     let local_only = status["local_only"].as_bool().unwrap_or(true);
     compact_json(json!({
         "schema_version": 1,
@@ -620,7 +652,7 @@ fn index_wait_json(status: Value, selection: IndexSelection, wait_status: &str) 
         },
         "readiness": status,
         "local_only": local_only,
-        "read_only": true,
+        "read_only": read_only,
     }))
 }
 

--- a/crates/ctx-cli-presentation/src/commands/index_dashboard.rs
+++ b/crates/ctx-cli-presentation/src/commands/index_dashboard.rs
@@ -93,7 +93,7 @@ pub(super) fn render_semantic_disabled_wait(
             fields(context, &[Field::new("Status", "Off")]),
         ),
     );
-    append_action(&mut document, "ctx setup --semantic");
+    append_action(&mut document, "ctx semantic enable");
     document
 }
 

--- a/crates/ctx-cli-presentation/src/commands/index_tests.rs
+++ b/crates/ctx-cli-presentation/src/commands/index_tests.rs
@@ -252,7 +252,7 @@ fn failed_refresh_is_terminal_only_when_refresh_convergence_is_selected() {
 #[test]
 fn wait_json_names_the_readiness_payload() {
     let status = readiness("ready", 12, true);
-    let output = index_wait_json(status, IndexSelection::all(), "ready");
+    let output = index_wait_json(status, IndexSelection::all(), "ready", true);
     assert!(output.get("readiness").is_some());
     assert!(output.get("index").is_none());
 }

--- a/crates/ctx-cli-presentation/src/commands/mod.rs
+++ b/crates/ctx-cli-presentation/src/commands/mod.rs
@@ -26,6 +26,9 @@ pub use index::IndexArgs;
 pub use list::{ListArgs, ListEventsArgs, ListTarget};
 pub use locate::{LocateArgs, LocateTarget};
 pub use search::{CliRefreshArg, ContentScopeArg, SearchArgs, SearchBackendArg};
+pub use semantic::{
+    render_semantic_disabled, render_semantic_status, SemanticArgs, SemanticCommand,
+};
 pub use setup::{render_setup_human, SetupArgs, SetupDaemonState};
 pub use show::{ShowArgs, ShowEventArgs, ShowSessionArgs, ShowTarget};
 pub use sources::SourcesArgs;
@@ -37,4 +40,5 @@ pub use status_usage::{
     render_malformed_status_config_failure, render_removed_cloud_config_failure,
     render_usage_action_human, render_usage_failure, usage_action_error_json, usage_action_json,
 };
+pub mod semantic;
 pub mod setup;

--- a/crates/ctx-cli-presentation/src/commands/semantic.rs
+++ b/crates/ctx-cli-presentation/src/commands/semantic.rs
@@ -1,0 +1,266 @@
+use clap::{Args, Subcommand};
+use serde_json::Value;
+
+use crate::output::JsonOutputFormat;
+use crate::ui::{
+    fields, outcome, section, Document, Field, Line, Outcome, OutcomeState, Span, Token,
+};
+
+#[derive(Debug, Args)]
+pub struct SemanticArgs {
+    #[command(subcommand)]
+    pub command: SemanticCommand,
+}
+
+impl SemanticArgs {
+    pub fn json_output(&self) -> bool {
+        match &self.command {
+            SemanticCommand::Enable(args) => args.format.is_json(),
+            SemanticCommand::Status(args) | SemanticCommand::Disable(args) => args.format.is_json(),
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SemanticCommand {
+    #[command(about = "Enable local semantic search and start model indexing")]
+    Enable(SemanticEnableArgs),
+    #[command(about = "Show local semantic search readiness")]
+    Status(SemanticFormatArgs),
+    #[command(about = "Disable local semantic search and retain downloaded assets")]
+    Disable(SemanticFormatArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct SemanticEnableArgs {
+    #[arg(
+        long,
+        help = "Wait until semantic search is ready for the current index"
+    )]
+    pub wait: bool,
+    #[arg(long, value_enum, default_value_t = JsonOutputFormat::Text)]
+    pub format: JsonOutputFormat,
+}
+
+#[derive(Debug, Args)]
+pub struct SemanticFormatArgs {
+    #[arg(long, value_enum, default_value_t = JsonOutputFormat::Text)]
+    pub format: JsonOutputFormat,
+}
+
+pub fn render_semantic_status(context: &crate::ui::RenderContext, report: &Value) -> Document {
+    let enabled = bool_at(report, "/enabled");
+    let status = str_at(report, "/status", "unavailable");
+    let indexing_mode = str_at(report, "/indexing/mode", "unknown");
+    let (state, title, detail) = if !enabled {
+        if status == "disabling" {
+            (
+                OutcomeState::Neutral,
+                "Semantic search is disabling",
+                Some("The opt-out is saved; background semantic serving is stopping."),
+            )
+        } else {
+            (
+                OutcomeState::Neutral,
+                "Semantic search is disabled",
+                Some("No model acquisition or semantic indexing will run."),
+            )
+        }
+    } else {
+        match status {
+            "ready" => (
+                OutcomeState::Success,
+                "Semantic search is ready",
+                Some("Hybrid and semantic search can use the current index."),
+            ),
+            "pending" if indexing_mode == "manual" => (
+                OutcomeState::Neutral,
+                "Semantic search is enabled",
+                Some("Automatic model acquisition and indexing are paused in manual mode."),
+            ),
+            "pending" => (
+                OutcomeState::Neutral,
+                "Semantic search is preparing",
+                Some("Model acquisition or semantic indexing is still in progress."),
+            ),
+            "failed" | "unavailable" => (
+                OutcomeState::Warning,
+                "Semantic search needs attention",
+                Some("Inspect the reported reason or run ctx doctor."),
+            ),
+            _ => (
+                OutcomeState::Neutral,
+                "Semantic search is enabled",
+                Some("Background maintenance has not reported a ready index yet."),
+            ),
+        }
+    };
+    let mut document = outcome(
+        context,
+        Outcome {
+            state,
+            title,
+            detail,
+        },
+    );
+    let daemon_status = str_at(report, "/daemon/status", "unavailable");
+    let reason = report
+        .pointer("/reason")
+        .and_then(Value::as_str)
+        .filter(|reason| !reason.is_empty());
+    let mut values = vec![
+        Field::new("Status", status),
+        Field::new("Indexing", indexing_mode),
+        Field::new("Background", daemon_status),
+    ];
+    if let Some(reason) = reason {
+        values.push(Field::new("Reason", reason));
+    }
+    document.push_blank();
+    document.append(section("Semantic", fields(context, &values)));
+
+    let next = if !enabled {
+        Some("ctx semantic enable")
+    } else if status == "ready" {
+        Some("ctx search \"your query\"")
+    } else if indexing_mode == "manual" {
+        Some("ctx index mode auto")
+    } else if matches!(status, "failed" | "unavailable") {
+        Some("ctx doctor")
+    } else {
+        Some("ctx semantic status")
+    };
+    if let Some(next) = next {
+        document.push_blank();
+        document.append(section(
+            "Next",
+            Document::from_line(
+                Line::new()
+                    .with(Span::text("  "))
+                    .with(Span::new(next, Token::Command)),
+            ),
+        ));
+    }
+    document
+}
+
+pub fn render_semantic_disabled(context: &crate::ui::RenderContext, report: &Value) -> Document {
+    let status = str_at(report, "/status", "disabled");
+    let pending = status == "disabling";
+    let mut document = outcome(
+        context,
+        Outcome {
+            state: if pending {
+                OutcomeState::Neutral
+            } else {
+                OutcomeState::Success
+            },
+            title: if pending {
+                "Semantic search is disabling"
+            } else {
+                "Semantic search disabled"
+            },
+            detail: Some(if pending {
+                "The opt-out is saved; background serving is stopping. Downloaded assets are retained."
+            } else {
+                "Downloaded model, runtime, and semantic index data were retained."
+            }),
+        },
+    );
+    document.push_blank();
+    document.append(section(
+        "Semantic",
+        fields(context, &[Field::new("Status", status)]),
+    ));
+    document
+}
+
+fn bool_at(report: &Value, pointer: &str) -> bool {
+    report
+        .pointer(pointer)
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn str_at<'a>(report: &'a Value, pointer: &str, fallback: &'a str) -> &'a str {
+    report
+        .pointer(pointer)
+        .and_then(Value::as_str)
+        .unwrap_or(fallback)
+}
+
+#[cfg(test)]
+mod tests {
+    use ctx_terminal::{RenderContext, StreamKind, TestContext};
+    use serde_json::json;
+
+    use super::*;
+
+    fn context() -> RenderContext {
+        RenderContext::for_test(TestContext::pipe(StreamKind::Stdout))
+    }
+
+    #[test]
+    fn disabled_status_points_to_the_namespace() {
+        let rendered = render_semantic_status(
+            &context(),
+            &json!({
+                "enabled": false,
+                "status": "disabled",
+                "indexing": {"mode": "auto"},
+                "daemon": {"status": "running"},
+            }),
+        )
+        .render_plain();
+
+        assert!(
+            rendered.contains("Semantic search is disabled"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("ctx semantic enable"), "{rendered}");
+    }
+
+    #[test]
+    fn manual_pending_status_explains_the_required_lifecycle() {
+        let rendered = render_semantic_status(
+            &context(),
+            &json!({
+                "enabled": true,
+                "status": "pending",
+                "reason": "flat_f32_projection_missing",
+                "indexing": {"mode": "manual"},
+                "daemon": {"status": "disabled"},
+            }),
+        )
+        .render_plain();
+
+        assert!(
+            rendered.contains("Semantic search is enabled"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("Automatic model acquisition and indexing are paused"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("ctx index mode auto"), "{rendered}");
+    }
+
+    #[test]
+    fn pending_disable_reports_saved_policy_and_background_shutdown() {
+        let rendered = render_semantic_disabled(
+            &context(),
+            &json!({
+                "enabled": false,
+                "status": "disabling",
+            }),
+        )
+        .render_plain();
+
+        assert!(
+            rendered.contains("Semantic search is disabling"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("opt-out is saved"), "{rendered}");
+        assert!(rendered.contains("Status  disabling"), "{rendered}");
+    }
+}

--- a/crates/ctx-cli-presentation/src/commands/setup.rs
+++ b/crates/ctx-cli-presentation/src/commands/setup.rs
@@ -20,10 +20,7 @@ pub struct SetupArgs {
         help = "Deprecated and ignored; setup follows its normal refresh lifecycle"
     )]
     pub catalog_only: bool,
-    #[arg(
-        long,
-        help = "Enable local semantic search in config (requires daemon maintenance)"
-    )]
+    #[arg(long, hide = true, help = "Deprecated; use `ctx semantic enable`")]
     pub semantic: bool,
     #[arg(long, help = "Do not start daemon maintenance after setup")]
     pub no_daemon: bool,

--- a/crates/ctx-cli-qualification/tests/index.rs
+++ b/crates/ctx-cli-qualification/tests/index.rs
@@ -791,7 +791,7 @@ fn human_wait_semantic_disabled_renders_a_truthful_blocked_snapshot() {
     assert_single_human_diagnosis(
         &output,
         "Semantic indexing is blocked",
-        "ctx setup --semantic",
+        "ctx semantic enable",
     );
     let stderr = String::from_utf8(output.stderr).unwrap();
 
@@ -803,7 +803,7 @@ fn human_wait_semantic_disabled_renders_a_truthful_blocked_snapshot() {
     assert!(stderr.contains("Keyword search remains available."));
     assert!(stderr.contains("\nKeyword search\n"));
     assert!(stderr.contains("\nSemantic search\nStatus  Off\n"));
-    assert!(stderr.ends_with("\nNext\n  ctx setup --semantic\n"));
+    assert!(stderr.ends_with("\nNext\n  ctx semantic enable\n"));
     assert!(!stderr.contains("Your history is searchable"));
     assert!(!stderr.contains("ctx doctor"));
 }

--- a/crates/ctx-cli/src/cli.rs
+++ b/crates/ctx-cli/src/cli.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anstyle::{AnsiColor, Color, Style};
 use clap::{Args, Parser, Subcommand, ValueEnum};
-use ctx_cli_presentation::commands::{DoctorArgs, SetupArgs, StatusArgs};
+use ctx_cli_presentation::commands::{DoctorArgs, SemanticArgs, SetupArgs, StatusArgs};
 
 use crate::{
     commands,
@@ -129,6 +129,8 @@ pub(crate) enum CommandRoot {
     Referral,
     #[command(about = "Create local ctx storage and index discovered history")]
     Setup(SetupArgs),
+    #[command(about = "Manage local semantic search")]
+    Semantic(SemanticArgs),
     #[command(about = "Show local ctx index and health status")]
     Status(StatusArgs),
     #[command(about = "Show local history retrieval and value statistics")]
@@ -301,6 +303,7 @@ pub(crate) enum DaemonTriggerCommandArg {
     Setup,
     Import,
     Search,
+    Semantic,
 }
 
 fn parse_semantic_worker_batch(value: &str) -> Result<usize, String> {

--- a/crates/ctx-cli/src/commands/mod.rs
+++ b/crates/ctx-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod index;
 pub(crate) mod list;
 pub(crate) mod locate;
 pub(crate) mod search;
+pub(crate) mod semantic;
 pub(crate) mod setup;
 pub(crate) mod show;
 /// Final-host compatibility names for MCP/cross-product adapters. Command

--- a/crates/ctx-cli/src/commands/semantic.rs
+++ b/crates/ctx-cli/src/commands/semantic.rs
@@ -1,0 +1,253 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Result};
+use ctx_cli_presentation::commands::{
+    render_semantic_disabled, render_semantic_status, SemanticArgs, SemanticCommand,
+};
+use ctx_history_cli::HistoryConfigPort;
+use serde_json::{json, Value};
+
+use crate::{
+    config,
+    history_config::CliHistoryConfigAdapter,
+    output::{compact_json, print_json},
+    ui::Ui,
+};
+
+pub(crate) fn run_semantic(
+    args: SemanticArgs,
+    data_root: PathBuf,
+    quiet: bool,
+    config: &mut config::AppConfig,
+    ui: &mut Ui,
+) -> Result<()> {
+    match args.command {
+        SemanticCommand::Status(args) => {
+            let report = semantic_report(&data_root, config, "status", true)?;
+            render_report(report, args.format.is_json(), quiet, ui)
+        }
+        SemanticCommand::Enable(args) => {
+            if args.wait && !config.automatic_indexing_enabled() {
+                bail!(
+                    "semantic --wait requires automatic indexing; run `ctx index mode auto` or omit --wait and use an explicit semantic search with --refresh wait"
+                );
+            }
+            set_semantic_policy(&data_root, config, true)?;
+            if config.automatic_indexing_enabled() {
+                crate::semantic::autostart_daemon_and_wait(
+                    &data_root,
+                    config,
+                    crate::DaemonTriggerCommandArg::Semantic,
+                )?;
+            }
+
+            if args.wait {
+                let mut telemetry = crate::analytics::IndexTelemetry::default();
+                return super::index::run_index(
+                    ctx_cli_presentation::commands::index::IndexArgs::semantic_wait(args.format),
+                    data_root,
+                    quiet,
+                    &mut telemetry,
+                    ui,
+                );
+            }
+            let report = semantic_report(&data_root, config, "enable", false)?;
+            render_report(report, args.format.is_json(), quiet, ui)
+        }
+        SemanticCommand::Disable(args) => {
+            set_semantic_policy(&data_root, config, false)?;
+            let report = semantic_report(&data_root, config, "disable", false)?;
+            if args.format.is_json() {
+                print_json(report)
+            } else if !quiet {
+                ui.write_stdout(&render_semantic_disabled(ui.stdout_context(), &report))?;
+                Ok(())
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
+
+pub(crate) fn persist_semantic_enabled(
+    data_root: &Path,
+    config: &mut config::AppConfig,
+    enabled: bool,
+) -> Result<()> {
+    CliHistoryConfigAdapter::new(data_root, config).set_semantic_search_enabled(enabled)
+}
+
+pub(crate) fn set_semantic_policy(
+    data_root: &Path,
+    config: &mut config::AppConfig,
+    enabled: bool,
+) -> Result<()> {
+    persist_semantic_enabled(data_root, config, enabled)?;
+    *config = config::AppConfig::load(data_root)?;
+    if config.semantic_search_enabled() != enabled {
+        if enabled {
+            bail!(
+                "semantic search was enabled in config, but an active process override keeps it disabled; unset CTX_SEARCH_SEMANTIC or set it to true"
+            );
+        }
+        bail!(
+            "semantic search was disabled in config, but an active process override keeps it enabled; unset CTX_SEARCH_SEMANTIC or set it to false"
+        );
+    }
+    Ok(())
+}
+
+fn semantic_report(
+    data_root: &Path,
+    config: &config::AppConfig,
+    operation: &str,
+    read_only: bool,
+) -> Result<Value> {
+    let source = crate::semantic::source_epoch_status_report(data_root, config)?;
+    let semantic = &source.report["semantic"];
+    let daemon = &source.report["daemon"];
+    let daemon_semantic = daemon
+        .get("jobs")
+        .and_then(|jobs| jobs.get("semantic_index"));
+    let (status, reason) = semantic_lifecycle_state(semantic, daemon, daemon_semantic, config);
+    Ok(compact_json(json!({
+        "schema_version": 1,
+        "operation": operation,
+        "enabled": semantic.get("enabled"),
+        "status": status,
+        "reason": reason,
+        "config_source": config.semantic_search_source(),
+        "indexing": {
+            "mode": config.indexing.mode.as_str(),
+        },
+        "projection": semantic.get("flat_f32"),
+        "catch_up": semantic.get("catch_up"),
+        "daemon": {
+            "status": daemon.get("status"),
+            "running": daemon.get("running"),
+            "semantic_index": daemon_semantic,
+        },
+        "local_only": true,
+        "read_only": read_only,
+    })))
+}
+
+fn semantic_lifecycle_state(
+    semantic: &Value,
+    daemon: &Value,
+    daemon_semantic: Option<&Value>,
+    config: &config::AppConfig,
+) -> (Value, Value) {
+    let enabled = semantic
+        .get("enabled")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let daemon_still_semantic = daemon_semantic.is_some_and(|job| {
+        [
+            "semantic_enabled",
+            "runtime_active",
+            "configuration_pending",
+        ]
+        .into_iter()
+        .any(|field| job.get(field).and_then(Value::as_bool).unwrap_or(false))
+    });
+    if !enabled && daemon_still_semantic {
+        return (json!("disabling"), json!("daemon_config_reload_pending"));
+    }
+    if enabled {
+        let daemon_job_status = daemon_semantic
+            .and_then(|job| job.get("status"))
+            .and_then(Value::as_str);
+        if matches!(daemon_job_status, Some("failed" | "unavailable")) {
+            let reason = daemon_semantic
+                .and_then(|job| job.get("reason"))
+                .cloned()
+                .unwrap_or_else(|| json!("daemon_semantic_job_failed"));
+            return (json!("failed"), reason);
+        }
+        let source_pending = semantic.get("status").and_then(Value::as_str) == Some("pending");
+        let daemon_running = daemon
+            .get("running")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if source_pending && config.automatic_indexing_enabled() && !daemon_running {
+            return (json!("unavailable"), json!("daemon_not_running"));
+        }
+    }
+    (
+        semantic.get("status").cloned().unwrap_or(Value::Null),
+        semantic.get("reason").cloned().unwrap_or(Value::Null),
+    )
+}
+
+fn render_report(report: Value, json: bool, quiet: bool, ui: &mut Ui) -> Result<()> {
+    if json {
+        print_json(report)
+    } else if !quiet {
+        ui.write_stdout(&render_semantic_status(ui.stdout_context(), &report))?;
+        Ok(())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn persistence_helper_is_idempotent_and_preserves_other_config() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join(config::CONFIG_FILE),
+            "# user setting\n[analytics]\nenabled = false\n",
+        )
+        .unwrap();
+        let mut config = config::AppConfig::load(temp.path()).unwrap();
+
+        persist_semantic_enabled(temp.path(), &mut config, true).unwrap();
+        let once = fs::read_to_string(temp.path().join(config::CONFIG_FILE)).unwrap();
+        persist_semantic_enabled(temp.path(), &mut config, true).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(temp.path().join(config::CONFIG_FILE)).unwrap(),
+            once
+        );
+        assert!(once.contains("# user setting"), "{once}");
+        assert!(once.contains("[search]\nsemantic = true\n"), "{once}");
+    }
+
+    #[test]
+    fn lifecycle_reports_pending_disable_until_the_daemon_quiesces() {
+        let config = config::AppConfig::default();
+        let semantic = json!({"enabled": false, "status": "disabled", "reason": "opt_out"});
+        let daemon = json!({"running": true});
+        let job = json!({
+            "status": "ready",
+            "semantic_enabled": true,
+            "runtime_active": true,
+            "configuration_pending": false,
+        });
+
+        let (status, reason) = semantic_lifecycle_state(&semantic, &daemon, Some(&job), &config);
+
+        assert_eq!(status, "disabling");
+        assert_eq!(reason, "daemon_config_reload_pending");
+    }
+
+    #[test]
+    fn lifecycle_surfaces_daemon_semantic_failure_reason() {
+        let mut config = config::AppConfig::default();
+        config.search.semantic = Some(true);
+        let semantic = json!({"enabled": true, "status": "pending"});
+        let daemon = json!({"running": true});
+        let job = json!({"status": "failed", "reason": "model_checksum_mismatch"});
+
+        let (status, reason) = semantic_lifecycle_state(&semantic, &daemon, Some(&job), &config);
+
+        assert_eq!(status, "failed");
+        assert_eq!(reason, "model_checksum_mismatch");
+    }
+}

--- a/crates/ctx-cli/src/commands/setup.rs
+++ b/crates/ctx-cli/src/commands/setup.rs
@@ -32,7 +32,7 @@ pub(crate) fn run_setup(
 ) -> Result<()> {
     let suppression_reason = daemon_autostart_suppression_reason();
     if args.semantic {
-        CliHistoryConfigAdapter::new(&data_root, config).set_semantic_search_enabled(true)?;
+        super::semantic::set_semantic_policy(&data_root, config, true)?;
     }
     CliHistoryConfigAdapter::new(&data_root, config).write_default_config()?;
 

--- a/crates/ctx-cli/src/config.rs
+++ b/crates/ctx-cli/src/config.rs
@@ -308,6 +308,24 @@ pub struct DaemonConfig {
 #[derive(Debug, Clone)]
 pub struct SearchConfig {
     pub semantic: Option<bool>,
+    semantic_source: SemanticSearchSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SemanticSearchSource {
+    Default,
+    Config,
+    Environment,
+}
+
+impl SemanticSearchSource {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Config => "config",
+            Self::Environment => "environment",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -339,7 +357,10 @@ impl Default for AppConfig {
             daemon: DaemonConfig {
                 mode: DaemonMode::Full,
             },
-            search: SearchConfig { semantic: None },
+            search: SearchConfig {
+                semantic: None,
+                semantic_source: SemanticSearchSource::Default,
+            },
             sources: SourcesConfig { automatic: true },
             provider_roots: BTreeMap::new(),
         }
@@ -370,10 +391,13 @@ impl AppConfig {
     }
 
     pub fn semantic_search_source(&self) -> &'static str {
-        if self.search.semantic.is_some() {
-            "config"
-        } else {
-            "default"
+        self.search.semantic_source.as_str()
+    }
+
+    pub(crate) fn apply_persisted_semantic_search_enabled(&mut self, enabled: bool) {
+        if self.search.semantic_source != SemanticSearchSource::Environment {
+            self.search.semantic = Some(enabled);
+            self.search.semantic_source = SemanticSearchSource::Config;
         }
     }
 
@@ -508,6 +532,7 @@ impl AppConfig {
                 }
                 "search.semantic" => {
                     self.search.semantic = Some(parse_config_bool(key, value)?);
+                    self.search.semantic_source = SemanticSearchSource::Config;
                 }
                 "sources.automatic" => {
                     self.sources.automatic = parse_config_bool(key, value)?;
@@ -653,6 +678,7 @@ impl AppConfig {
         if let Ok(value) = env::var("CTX_SEARCH_SEMANTIC") {
             if let Some(enabled) = parse_bool_value(&value) {
                 self.search.semantic = Some(enabled);
+                self.search.semantic_source = SemanticSearchSource::Environment;
             }
         }
         Ok(())

--- a/crates/ctx-cli/src/config_tests.rs
+++ b/crates/ctx-cli/src/config_tests.rs
@@ -809,11 +809,13 @@ fn env_overrides_search_semantic_config() {
     env_guard.set("CTX_SEARCH_SEMANTIC", "true");
     let config = AppConfig::load(temp.path()).unwrap();
     assert_eq!(config.search.semantic, Some(true));
+    assert_eq!(config.semantic_search_source(), "environment");
 
     fs::write(temp.path().join(CONFIG_FILE), "[search]\nsemantic = true\n").unwrap();
     env_guard.set("CTX_SEARCH_SEMANTIC", "false");
     let config = AppConfig::load(temp.path()).unwrap();
     assert_eq!(config.search.semantic, Some(false));
+    assert_eq!(config.semantic_search_source(), "environment");
 }
 
 #[test]

--- a/crates/ctx-cli/src/dispatch.rs
+++ b/crates/ctx-cli/src/dispatch.rs
@@ -19,6 +19,7 @@ use crate::{
         list::run_list,
         locate::run_locate,
         search::run_search,
+        semantic::run_semantic,
         setup::run_setup,
         show::{run_show, ShowArgs, ShowTarget},
         sources::run_sources,
@@ -283,6 +284,9 @@ pub(crate) fn run_cli() -> Result<()> {
             &mut config,
             &mut ui,
         ),
+        CommandRoot::Semantic(args) => {
+            run_semantic(args, data_root.clone(), quiet, &mut config, &mut ui)
+        }
         CommandRoot::Status(args) => run_status(
             args,
             &data_root,
@@ -646,6 +650,7 @@ fn command_json_output(command: &CommandRoot) -> bool {
     match command {
         CommandRoot::Pro | CommandRoot::Blame | CommandRoot::Referral => false,
         CommandRoot::Setup(args) => args.format.is_json(),
+        CommandRoot::Semantic(args) => args.json_output(),
         CommandRoot::Status(args) => args.format.is_json(),
         CommandRoot::Stats(args) => args.format.is_json(),
         CommandRoot::Index(args) => args.json_output(),
@@ -762,6 +767,17 @@ pub(crate) fn command_operation_descriptor(command: &CommandRoot) -> OperationDe
                 args.no_daemon,
             ),
         }),
+        CommandRoot::Semantic(args) => match &args.command {
+            ctx_cli_presentation::commands::SemanticCommand::Enable(_) => {
+                CliOperation::SemanticEnable
+            }
+            ctx_cli_presentation::commands::SemanticCommand::Status(_) => {
+                CliOperation::SemanticStatus
+            }
+            ctx_cli_presentation::commands::SemanticCommand::Disable(_) => {
+                CliOperation::SemanticDisable
+            }
+        },
         CommandRoot::Status(_) => CliOperation::Status(StatusTelemetry::default()),
         CommandRoot::Stats(_) => CliOperation::Stats,
         CommandRoot::Index(_) => CliOperation::Index(IndexTelemetry::default()),

--- a/crates/ctx-cli/src/history_config.rs
+++ b/crates/ctx-cli/src/history_config.rs
@@ -57,7 +57,7 @@ impl HistoryConfigPort for CliHistoryConfigAdapter<'_> {
 
     fn set_semantic_search_enabled(&mut self, enabled: bool) -> Result<(), Self::Error> {
         config::set_semantic_search_enabled(self.data_root, enabled)?;
-        self.config.search.semantic = Some(enabled);
+        self.config.apply_persisted_semantic_search_enabled(enabled);
         Ok(())
     }
 }

--- a/crates/ctx-cli/src/main_tests.rs
+++ b/crates/ctx-cli/src/main_tests.rs
@@ -157,11 +157,11 @@ fn complete_cli_grammar_renders_and_parses_help_recursively() {
     let command = Cli::command();
     let mut paths = Vec::new();
     collect_paths(&command, &[], &mut paths);
-    // Private semantic leaves now live behind the opaque companion gate; the
+    // Semantic lifecycle is a public namespace with three closed leaves; the
     // two named-provider-home mutations are public source-management leaves.
     assert_eq!(
         paths.len(),
-        50,
+        54,
         "unexpected public CLI grammar depth: {paths:?}"
     );
 

--- a/crates/ctx-cli/src/semantic.rs
+++ b/crates/ctx-cli/src/semantic.rs
@@ -167,6 +167,9 @@ fn daemon_trigger(
         crate::DaemonTriggerCommandArg::Setup => ctx_daemon_cli::DaemonTriggerCommandArg::Setup,
         crate::DaemonTriggerCommandArg::Import => ctx_daemon_cli::DaemonTriggerCommandArg::Import,
         crate::DaemonTriggerCommandArg::Search => ctx_daemon_cli::DaemonTriggerCommandArg::Search,
+        crate::DaemonTriggerCommandArg::Semantic => {
+            ctx_daemon_cli::DaemonTriggerCommandArg::Semantic
+        }
     }
 }
 

--- a/crates/ctx-cli/src/upgrade/ports.rs
+++ b/crates/ctx-cli/src/upgrade/ports.rs
@@ -217,6 +217,7 @@ impl DaemonUpgradePort for CliDaemonUpgrade {
             "setup" => crate::DaemonTriggerCommandArg::Setup,
             "import" => crate::DaemonTriggerCommandArg::Import,
             "search" => crate::DaemonTriggerCommandArg::Search,
+            "semantic" => crate::DaemonTriggerCommandArg::Semantic,
             other => return Err(anyhow!("invalid daemon upgrade restart trigger {other}")),
         };
         Ok(CliDaemonUpgradeLease(

--- a/crates/ctx-client-observability/src/analytics/daemon.rs
+++ b/crates/ctx-client-observability/src/analytics/daemon.rs
@@ -37,6 +37,7 @@ pub enum DaemonTriggerV1 {
     Setup,
     Import,
     Search,
+    Semantic,
 }
 
 impl DaemonTriggerV1 {
@@ -45,6 +46,7 @@ impl DaemonTriggerV1 {
             Self::Setup => "setup",
             Self::Import => "import",
             Self::Search => "search",
+            Self::Semantic => "semantic",
         }
     }
 }

--- a/crates/ctx-client-observability/src/analytics/sender.rs
+++ b/crates/ctx-client-observability/src/analytics/sender.rs
@@ -316,6 +316,9 @@ fn insert_client_operation_properties(
             );
             insert_import_result_properties(properties, &value.import);
         }
+        CliOperation::SemanticEnable
+        | CliOperation::SemanticStatus
+        | CliOperation::SemanticDisable => {}
         CliOperation::Status(value) => {
             insert_optional_bool(properties, "initialized", value.initialized);
             insert_optional_count(properties, "indexed_items_bucket", value.indexed_items);

--- a/crates/ctx-client-observability/src/analytics/tests.rs
+++ b/crates/ctx-client-observability/src/analytics/tests.rs
@@ -63,6 +63,18 @@ fn public_surfaces_are_exhaustive_and_stable() {
 }
 
 #[test]
+fn semantic_lifecycle_operations_emit_closed_client_analytics_names() {
+    for (operation, expected) in [
+        (CliOperation::SemanticEnable, "semantic_enable"),
+        (CliOperation::SemanticStatus, "semantic_status"),
+        (CliOperation::SemanticDisable, "semantic_disable"),
+    ] {
+        assert!(operation.emits_client_analytics());
+        assert_eq!(operation.analytics_name(), expected);
+    }
+}
+
+#[test]
 fn runtime_observation_has_typed_constructor_seams() {
     let daemon = PublicEventV1::RuntimeObservation(RuntimeObservationV1::daemon(
         DaemonRuntimeObservationV1::ready(DaemonRunFactsV1::new(

--- a/crates/ctx-client-observability/src/operation_descriptor.rs
+++ b/crates/ctx-client-observability/src/operation_descriptor.rs
@@ -20,6 +20,9 @@ pub enum OperationDescriptor {
 #[derive(Debug)]
 pub enum CliOperation {
     Setup(SetupTelemetry),
+    SemanticEnable,
+    SemanticStatus,
+    SemanticDisable,
     Status(StatusTelemetry),
     Stats,
     Index(IndexTelemetry),
@@ -47,6 +50,9 @@ impl CliOperation {
     pub const fn analytics_name(&self) -> &'static str {
         match self {
             Self::Setup(_) => "setup",
+            Self::SemanticEnable => "semantic_enable",
+            Self::SemanticStatus => "semantic_status",
+            Self::SemanticDisable => "semantic_disable",
             Self::Status(_) => "status",
             Self::Stats => "stats",
             Self::Index(_) => "index",
@@ -71,6 +77,9 @@ impl CliOperation {
         matches!(
             self,
             Self::Setup(_)
+                | Self::SemanticEnable
+                | Self::SemanticStatus
+                | Self::SemanticDisable
                 | Self::Status(_)
                 | Self::Index(_)
                 | Self::Sources(_)
@@ -89,6 +98,7 @@ impl CliOperation {
     pub const fn local_usage_operation(&self) -> Option<LocalUsageOperation> {
         match self {
             Self::Setup(_) => Some(LocalUsageOperation::Setup),
+            Self::SemanticEnable | Self::SemanticStatus | Self::SemanticDisable => None,
             Self::Status(_) | Self::Stats => None,
             Self::Index(_) => Some(LocalUsageOperation::Index),
             Self::Sources(_) => Some(LocalUsageOperation::Sources),

--- a/crates/ctx-daemon-application/src/lib.rs
+++ b/crates/ctx-daemon-application/src/lib.rs
@@ -128,6 +128,7 @@ pub enum DaemonTrigger {
     Setup,
     Import,
     Search,
+    Semantic,
 }
 
 impl DaemonTrigger {
@@ -136,6 +137,7 @@ impl DaemonTrigger {
             Self::Setup => "setup",
             Self::Import => "import",
             Self::Search => "search",
+            Self::Semantic => "semantic",
         }
     }
 
@@ -144,6 +146,7 @@ impl DaemonTrigger {
             "setup" => Some(Self::Setup),
             "import" => Some(Self::Import),
             "search" => Some(Self::Search),
+            "semantic" => Some(Self::Semantic),
             _ => None,
         }
     }
@@ -481,6 +484,7 @@ mod dto_tests {
             (DaemonTrigger::Setup, "setup"),
             (DaemonTrigger::Import, "import"),
             (DaemonTrigger::Search, "search"),
+            (DaemonTrigger::Semantic, "semantic"),
         ] {
             assert_eq!(trigger.as_str(), name);
             assert_eq!(DaemonTrigger::parse_persisted(name), Some(trigger));

--- a/crates/ctx-daemon-cli/src/daemon_service_ports.rs
+++ b/crates/ctx-daemon-cli/src/daemon_service_ports.rs
@@ -103,6 +103,7 @@ where
             ctx_daemon_application::DaemonTrigger::Setup => DaemonTrigger::Setup,
             ctx_daemon_application::DaemonTrigger::Import => DaemonTrigger::Import,
             ctx_daemon_application::DaemonTrigger::Search => DaemonTrigger::Search,
+            ctx_daemon_application::DaemonTrigger::Semantic => DaemonTrigger::Semantic,
         }),
         supervisor: if matches!(
             request.start_mode,
@@ -300,5 +301,6 @@ fn cli_trigger(trigger: DaemonTrigger) -> DaemonTriggerCommandArg {
         DaemonTrigger::Setup => DaemonTriggerCommandArg::Setup,
         DaemonTrigger::Import => DaemonTriggerCommandArg::Import,
         DaemonTrigger::Search => DaemonTriggerCommandArg::Search,
+        DaemonTrigger::Semantic => DaemonTriggerCommandArg::Semantic,
     }
 }

--- a/crates/ctx-daemon-cli/src/daemon_supervisor.rs
+++ b/crates/ctx-daemon-cli/src/daemon_supervisor.rs
@@ -198,6 +198,7 @@ pub(super) const fn daemon_trigger_arg(
         ctx_daemon_application::DaemonTrigger::Setup => crate::DaemonTriggerCommandArg::Setup,
         ctx_daemon_application::DaemonTrigger::Import => crate::DaemonTriggerCommandArg::Import,
         ctx_daemon_application::DaemonTrigger::Search => crate::DaemonTriggerCommandArg::Search,
+        ctx_daemon_application::DaemonTrigger::Semantic => crate::DaemonTriggerCommandArg::Semantic,
     }
 }
 
@@ -208,6 +209,7 @@ pub(super) const fn daemon_trigger(
         crate::DaemonTriggerCommandArg::Setup => ctx_daemon_application::DaemonTrigger::Setup,
         crate::DaemonTriggerCommandArg::Import => ctx_daemon_application::DaemonTrigger::Import,
         crate::DaemonTriggerCommandArg::Search => ctx_daemon_application::DaemonTrigger::Search,
+        crate::DaemonTriggerCommandArg::Semantic => ctx_daemon_application::DaemonTrigger::Semantic,
     }
 }
 

--- a/crates/ctx-daemon-cli/src/lib.rs
+++ b/crates/ctx-daemon-cli/src/lib.rs
@@ -78,6 +78,7 @@ pub enum DaemonTriggerCommandArg {
     Setup,
     Import,
     Search,
+    Semantic,
 }
 
 impl DaemonTriggerCommandArg {
@@ -86,6 +87,7 @@ impl DaemonTriggerCommandArg {
             Self::Setup => "setup",
             Self::Import => "import",
             Self::Search => "search",
+            Self::Semantic => "semantic",
         }
     }
 }

--- a/crates/ctx-daemon-service/src/daemon.rs
+++ b/crates/ctx-daemon-service/src/daemon.rs
@@ -204,6 +204,7 @@ fn daemon_run_facts(args: &DaemonRunArgs) -> DaemonRunFactsV1 {
         DaemonTriggerCommandArg::Setup => DaemonTriggerV1::Setup,
         DaemonTriggerCommandArg::Import => DaemonTriggerV1::Import,
         DaemonTriggerCommandArg::Search => DaemonTriggerV1::Search,
+        DaemonTriggerCommandArg::Semantic => DaemonTriggerV1::Semantic,
     });
     DaemonRunFactsV1::new(start_mode, supervisor, trigger)
 }

--- a/crates/ctx-daemon-service/src/ports.rs
+++ b/crates/ctx-daemon-service/src/ports.rs
@@ -55,6 +55,7 @@ pub enum DaemonTrigger {
     Setup,
     Import,
     Search,
+    Semantic,
 }
 
 impl DaemonTrigger {
@@ -63,6 +64,7 @@ impl DaemonTrigger {
             Self::Setup => "setup",
             Self::Import => "import",
             Self::Search => "search",
+            Self::Semantic => "semantic",
         }
     }
 }

--- a/crates/ctx-history-cli/src/source_index/search.rs
+++ b/crates/ctx-history-cli/src/source_index/search.rs
@@ -580,7 +580,7 @@ pub(super) fn render_semantic_fallback_warning(
         Some(SemanticReason::PolicyDisabled) => (
             "Semantic search is unavailable",
             "Keyword search was used because semantic search is disabled.",
-            "ctx setup --semantic",
+            "ctx semantic enable",
         ),
         Some(SemanticReason::ContentScopeUnsupported | SemanticReason::EventTypeUnsupported) => (
             "Semantic search does not support this filter",

--- a/crates/ctx-history-cli/src/source_index/tests/semantic_fallback.rs
+++ b/crates/ctx-history-cli/src/source_index/tests/semantic_fallback.rs
@@ -16,7 +16,7 @@ fn semantic_fallback_warning_is_structured_and_actionable_without_backend_codes(
         let styled = rendered.render(&context);
         assert!(plain.contains("Semantic search is unavailable"));
         assert!(plain.contains("Keyword search was used"));
-        assert!(plain.contains("ctx setup --semantic"));
+        assert!(plain.contains("ctx semantic enable"));
         assert!(!plain.contains("semantic_disabled"));
         assert!(!plain.contains("backend_error"));
         assert!(!plain.contains("/private/model/cache"));

--- a/crates/ctx-upgrade-engine/BUILD.bazel
+++ b/crates/ctx-upgrade-engine/BUILD.bazel
@@ -157,6 +157,7 @@ ctx_binary_contract_test(
         "//crates/ctx-cli-contract-tests:upgrade_runtime_support_srcs",
         "tests/contracts/upgrade/release_validation.rs",
         "tests/contracts/upgrade/unmanaged.rs",
+        "tests/contracts/upgrade/windows_semantic_runtime.rs",
     ],
     rustc_env_files = ["//crates/ctx-cli:cargo_toml_env_vars"],
 )

--- a/crates/ctx-upgrade-engine/src/upgrade/install/transaction/journal.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/transaction/journal.rs
@@ -345,6 +345,18 @@ pub(super) fn validate(
     validate_paths(journal, semantic_layout)
 }
 
+/// Validate the complete bounded publication shape before it becomes durable
+/// transaction authority. Recovery and the Windows helper apply the same
+/// policy to the journal they later consume.
+pub(super) fn validate_for_publication(
+    journal: &InstallTransactionJournal,
+    semantic_layout: &dyn SemanticLayoutPort,
+) -> Result<()> {
+    validate_identity(journal)?;
+    validate_phase_state(journal)?;
+    validate_paths(journal, semantic_layout)
+}
+
 /// A copied Windows helper cannot use `current_exe()` as an install identity.
 /// It instead authenticates the explicit journal target and every invariant
 /// shared with ordinary recovery.
@@ -354,23 +366,13 @@ pub(super) fn validate_for_helper(
     install_path: &Path,
     semantic_layout: &dyn SemanticLayoutPort,
 ) -> Result<()> {
-    validate_without_current_executable(journal, semantic_layout)?;
+    validate_for_publication(journal, semantic_layout)?;
     if journal.install_path != install_path {
         return Err(anyhow!(
             "Windows replacement helper targets a different executable"
         ));
     }
     Ok(())
-}
-
-#[cfg(windows)]
-fn validate_without_current_executable(
-    journal: &InstallTransactionJournal,
-    semantic_layout: &dyn SemanticLayoutPort,
-) -> Result<()> {
-    validate_identity(journal)?;
-    validate_phase_state(journal)?;
-    validate_paths(journal, semantic_layout)
 }
 
 fn validate_paths(
@@ -389,7 +391,7 @@ fn validate_paths_for_platform(
     platform: &str,
     semantic_layout: &dyn SemanticLayoutPort,
 ) -> Result<()> {
-    if !(2..=6).contains(&journal.paths.len()) {
+    if !(1..=6).contains(&journal.paths.len()) {
         return Err(anyhow!("install transaction has an unexpected path count"));
     }
     let binary = optional_one_path(journal, "ctx binary")?;
@@ -408,7 +410,7 @@ fn validate_paths_for_platform(
         .iter()
         .filter(|path| path.label == "ONNX Runtime sidecar")
         .collect::<Vec<_>>();
-    if runtimes.len() > 1 || (!runtimes.is_empty() && binary.is_none()) {
+    if runtimes.len() > 1 {
         return Err(anyhow!("install transaction has invalid runtime paths"));
     }
     if let Some(runtime) = runtimes.first() {
@@ -425,7 +427,7 @@ fn validate_paths_for_platform(
         ));
     }
     if semantic.is_empty() {
-        if binary.is_none() {
+        if binary.is_none() && runtimes.is_empty() {
             return Err(anyhow!("install transaction has no publishable paths"));
         }
     } else {
@@ -502,10 +504,12 @@ fn validate_windows_helper(journal: &InstallTransactionJournal) -> Result<()> {
         || !valid_sha256(&helper.expected_binary_sha256)
         || !valid_sha256(&helper.expected_marker_sha256)
         || helper.daemon_restart.as_ref().is_some_and(|restart| {
-            !matches!(restart.trigger.as_str(), "setup" | "import" | "search")
-                || restart
-                    .loop_interval_seconds
-                    .is_some_and(|value| value == 0 || value > 3_600)
+            !matches!(
+                restart.trigger.as_str(),
+                "setup" | "import" | "search" | "semantic"
+            ) || restart
+                .loop_interval_seconds
+                .is_some_and(|value| value == 0 || value > 3_600)
         })
         || helper
             .failure

--- a/crates/ctx-upgrade-engine/src/upgrade/install/transaction/tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/transaction/tests.rs
@@ -1,4 +1,3 @@
-#[cfg(unix)]
 use std::fs;
 
 #[cfg(unix)]
@@ -8,6 +7,8 @@ use super::journal::{
     self, InstallTransactionJournal, JournalPath, JournalPathIdentity, JournalPathKind,
     JournalPathState, JournalPhase,
 };
+#[cfg(windows)]
+use super::journal::{WindowsHelperJournal, WindowsTerminalJournal};
 #[cfg(unix)]
 use super::RecoveryOutcome;
 use crate::upgrade::SemanticLayoutPort as _;
@@ -91,6 +92,66 @@ fn coreml_semantic_journal(root: &std::path::Path) -> InstallTransactionJournal 
     );
     journal.semantic_cache_root = Some(cache_root);
     journal
+}
+
+fn legacy_runtime_only_journal(root: &std::path::Path) -> InstallTransactionJournal {
+    let attempt_id = "runtime-only-repair";
+    ctx_history_platform::platform_security::restrict_private_directory(root).unwrap();
+    let root = fs::canonicalize(root).unwrap();
+    let runtime_root = root.join("runtime");
+    ctx_history_platform::platform_security::create_private_directory_all(&runtime_root).unwrap();
+    let platform = super::super::super::platform_key().unwrap();
+    let target = runtime_root
+        .join("onnxruntime")
+        .join("1.27.0")
+        .join(platform);
+    let install_path = root.join("ctx");
+    #[cfg(windows)]
+    let windows_helper = Some(WindowsHelperJournal {
+        parent_pid: 1,
+        helper_pid: None,
+        helper_path: root.join(format!(".ctx.ctx-upgrade-{attempt_id}.helper.exe")),
+        expected_binary_sha256: "a".repeat(64),
+        expected_marker_sha256: "b".repeat(64),
+        daemon_restart: None,
+        failure: None,
+        terminal: None::<WindowsTerminalJournal>,
+    });
+    #[cfg(not(windows))]
+    let windows_helper = None;
+    InstallTransactionJournal::new(
+        attempt_id.to_owned(),
+        root,
+        runtime_root,
+        install_path,
+        vec![semantic_journal_path(
+            attempt_id,
+            "ONNX Runtime sidecar",
+            target,
+            "runtime",
+            JournalPathKind::Directory,
+        )],
+        windows_helper,
+    )
+}
+
+#[test]
+fn same_version_legacy_runtime_repair_is_a_complete_publication_transaction() {
+    let temp = tempfile::tempdir().unwrap();
+    let journal = legacy_runtime_only_journal(temp.path());
+
+    journal::validate_for_publication(&journal, &crate::upgrade::TEST_SEMANTIC_LAYOUT).unwrap();
+}
+
+#[test]
+fn empty_publication_transaction_remains_invalid() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut journal = legacy_runtime_only_journal(temp.path());
+    journal.paths.clear();
+
+    assert!(
+        journal::validate_for_publication(&journal, &crate::upgrade::TEST_SEMANTIC_LAYOUT).is_err()
+    );
 }
 
 #[test]

--- a/crates/ctx-upgrade-engine/src/upgrade/install/transaction/unix.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/transaction/unix.rs
@@ -131,6 +131,7 @@ pub(super) fn publish_install(
                 .context("canonicalize selected Semantic cache root")?,
         );
     }
+    journal::validate_for_publication(&transaction, semantic_layout)?;
     journal::write(&transaction)?;
     before_publish()?;
     transaction.phase = JournalPhase::Publishing;

--- a/crates/ctx-upgrade-engine/src/upgrade/install/transaction/windows.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/transaction/windows.rs
@@ -108,6 +108,7 @@ pub(super) fn publish_install(
             .context("canonicalize selected Semantic cache root")?,
         );
     }
+    journal::validate_for_publication(&transaction, semantic_layout)?;
     journal::write(&transaction)?;
     before_publish()?;
     let helper_pid = helper::spawn(

--- a/crates/ctx-upgrade-engine/src/upgrade/install/transaction/windows.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/transaction/windows.rs
@@ -149,7 +149,7 @@ pub(in crate::upgrade) fn run_replacement_helper<D: DaemonUpgradePort + ?Sized>(
         ));
     }
     let current = std::env::current_exe().context("resolve Windows replacement helper path")?;
-    if current != expected.helper_path() {
+    if !super::super::managed_install_path_identity_matches(&current, expected.helper_path()) {
         return Err(anyhow!(
             "Windows replacement helper was not launched from its journaled copy"
         ));

--- a/crates/ctx-upgrade-engine/src/upgrade/install/transaction/windows/layout.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/transaction/windows/layout.rs
@@ -116,7 +116,7 @@ fn path_record(
 }
 
 pub(super) fn revalidate_fingerprint(transaction: &InstallTransactionJournal) -> Result<()> {
-    if publication_started(transaction)? {
+    if binary_publication_started(transaction)? {
         return Ok(());
     }
     let helper = transaction
@@ -134,24 +134,38 @@ pub(super) fn revalidate_fingerprint(transaction: &InstallTransactionJournal) ->
     Ok(())
 }
 
+fn binary_publication_started(transaction: &InstallTransactionJournal) -> Result<bool> {
+    let Some(binary) = transaction
+        .paths
+        .iter()
+        .find(|path| path.label == "ctx binary")
+    else {
+        return Ok(false);
+    };
+    path_publication_started(binary)
+}
+
 fn publication_started(transaction: &InstallTransactionJournal) -> Result<bool> {
     for path in &transaction.paths {
-        let staged = path.staged.try_exists()?;
-        let target = path.target.try_exists()?;
-        let backup = path.backup.try_exists()?;
-        let binary_only_backed_up = path.label == "ctx binary"
-            && path.state == JournalPathState::BackedUp
-            && staged
-            && target;
-        if (!binary_only_backed_up && path.state != JournalPathState::Staged)
-            || (path.label != "ctx binary" && backup)
-            || !staged
-            || (path.target_preexisted && !target)
-        {
+        if path_publication_started(path)? {
             return Ok(true);
         }
     }
     Ok(false)
+}
+
+fn path_publication_started(path: &JournalPath) -> Result<bool> {
+    let staged = path.staged.try_exists()?;
+    let target = path.target.try_exists()?;
+    let backup = path.backup.try_exists()?;
+    let binary_only_backed_up =
+        path.label == "ctx binary" && path.state == JournalPathState::BackedUp && staged && target;
+    Ok(
+        (!binary_only_backed_up && path.state != JournalPathState::Staged)
+            || (path.label != "ctx binary" && backup)
+            || !staged
+            || (path.target_preexisted && !target),
+    )
 }
 
 pub(super) fn publish_paths(transaction: &mut InstallTransactionJournal) -> Result<()> {

--- a/crates/ctx-upgrade-engine/src/upgrade/install/transaction/windows/tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/transaction/windows/tests.rs
@@ -163,6 +163,63 @@ fn terminal_journal_has_no_scheduler_or_telemetry_receipt() {
 }
 
 #[test]
+fn runtime_only_publication_does_not_exempt_install_fingerprint_revalidation() {
+    let temp = tempfile::tempdir().unwrap();
+    let target = temp.path().join("ctx");
+    let marker = super::super::super::marker::install_marker_path(&target);
+    fs::write(&target, b"original executable").unwrap();
+    fs::write(&marker, b"original marker").unwrap();
+    let fingerprint = super::super::super::marker::install_fingerprint(&target).unwrap();
+
+    let staged = temp.path().join("runtime.staged");
+    let runtime = temp.path().join("runtime");
+    let backup = temp.path().join("runtime.backup");
+    fs::write(&staged, b"new runtime").unwrap();
+    fs::write(&runtime, b"old runtime").unwrap();
+    fs::write(&backup, b"old runtime").unwrap();
+    let runtime_path = path_record(
+        "ONNX Runtime sidecar",
+        &staged,
+        &runtime,
+        &backup,
+        JournalPathState::BackedUp,
+    );
+    let mut transaction = transaction(temp.path(), vec![runtime_path]);
+    transaction.install_path = target.clone();
+    let helper = transaction.windows_helper.as_mut().unwrap();
+    helper.expected_binary_sha256 = fingerprint.binary_sha256;
+    helper.expected_marker_sha256 = fingerprint.marker_sha256;
+
+    layout::revalidate_fingerprint(&transaction).unwrap();
+    fs::write(&target, b"replacement executable").unwrap();
+    assert!(layout::revalidate_fingerprint(&transaction).is_err());
+    fs::write(&target, b"original executable").unwrap();
+    fs::write(&marker, b"replacement marker").unwrap();
+    assert!(layout::revalidate_fingerprint(&transaction).is_err());
+}
+
+#[test]
+fn binary_publication_retains_the_fingerprint_revalidation_exemption() {
+    let temp = tempfile::tempdir().unwrap();
+    let target = temp.path().join("ctx");
+    let staged = temp.path().join("ctx.new");
+    let backup = temp.path().join("ctx.backup");
+    fs::write(&target, b"published executable").unwrap();
+    fs::write(&backup, b"original executable").unwrap();
+    let binary_path = path_record(
+        "ctx binary",
+        &staged,
+        &target,
+        &backup,
+        JournalPathState::Published,
+    );
+    let mut transaction = transaction(temp.path(), vec![binary_path]);
+    transaction.install_path = target;
+
+    layout::revalidate_fingerprint(&transaction).unwrap();
+}
+
+#[test]
 fn failed_replace_repairs_missing_executable_before_any_wait() {
     let temp = tempfile::tempdir().unwrap();
     let target = temp.path().join("ctx");

--- a/crates/ctx-upgrade-engine/tests/contracts/upgrade.rs
+++ b/crates/ctx-upgrade-engine/tests/contracts/upgrade.rs
@@ -12,6 +12,10 @@ mod release_validation;
 #[path = "upgrade/unmanaged.rs"]
 mod unmanaged;
 
+#[cfg(windows)]
+#[path = "upgrade/windows_semantic_runtime.rs"]
+mod windows_semantic_runtime;
+
 fn assert_safe_platform_install_action(action: &str) {
     assert!(
         action.contains("ctx daemon disable --prepare-uninstall --format=json"),

--- a/crates/ctx-upgrade-engine/tests/contracts/upgrade/release_validation.rs
+++ b/crates/ctx-upgrade-engine/tests/contracts/upgrade/release_validation.rs
@@ -236,6 +236,72 @@ fn semantic_enabled_same_version_upgrade_repairs_missing_legacy_runtime() {
 
 #[cfg(unix)]
 #[test]
+fn interrupted_same_version_runtime_repair_recovers_without_replacing_ctx() {
+    let temp = tempdir();
+    let release = fake_legacy_release(&temp, env!("CARGO_PKG_VERSION"));
+    let runtime = add_fake_release_runtime(&temp, &release);
+    let marker_path = install_marker_path(&release.target);
+    let cli_before = fs::read(&release.target).unwrap();
+    let marker_before = fs::read(&marker_path).unwrap();
+
+    let installed = json_output(
+        fake_release_env(ctx(&temp).args(["upgrade", "--format=json"]), &release)
+            .env("CTX_SEARCH_SEMANTIC", "true"),
+    );
+    assert_eq!(installed["status"], "applied", "{installed:#}");
+
+    let manifest_path = runtime.target.join("ctx-runtime-install.json");
+    let mut manifest: Value = serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
+    manifest["sha256"] = json!("f".repeat(64));
+    let corrupted_manifest = serde_json::to_vec_pretty(&manifest).unwrap();
+    fs::write(&manifest_path, &corrupted_manifest).unwrap();
+
+    let interrupted = fake_release_env(ctx(&temp).args(["upgrade", "--format=json"]), &release)
+        .env("CTX_SEARCH_SEMANTIC", "true")
+        .env("CTX_UPGRADE_ABORT_AFTER_BACKUP_FOR_TESTS", "runtime")
+        .output()
+        .unwrap();
+    assert!(!interrupted.status.success(), "{interrupted:?}");
+    let journal_path = release
+        .target
+        .with_file_name(".ctx.upgrade-install-transaction.json");
+    assert!(journal_path.exists());
+    assert_eq!(fs::read(&release.target).unwrap(), cli_before);
+    assert_eq!(fs::read(&marker_path).unwrap(), marker_before);
+
+    let recovered = json_output(
+        fake_release_env(
+            ctx(&temp).args(["upgrade", "check", "--format=json"]),
+            &release,
+        )
+        .env("CTX_SEARCH_SEMANTIC", "true"),
+    );
+    assert_eq!(recovered["status"], "up_to_date", "{recovered:#}");
+    assert!(!journal_path.exists());
+    assert_eq!(fs::read(&manifest_path).unwrap(), corrupted_manifest);
+    assert_eq!(fs::read(&release.target).unwrap(), cli_before);
+    assert_eq!(fs::read(&marker_path).unwrap(), marker_before);
+
+    let repaired = json_output(
+        fake_release_env(ctx(&temp).args(["upgrade", "--format=json"]), &release)
+            .env("CTX_SEARCH_SEMANTIC", "true"),
+    );
+    assert_eq!(repaired["status"], "applied", "{repaired:#}");
+    let repaired_manifest: Value =
+        serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
+    assert_eq!(repaired_manifest["sha256"], runtime.artifact_sha);
+    assert_eq!(fs::read(&release.target).unwrap(), cli_before);
+    assert_eq!(fs::read(&marker_path).unwrap(), marker_before);
+
+    let repeated = json_output(
+        fake_release_env(ctx(&temp).args(["upgrade", "--format=json"]), &release)
+            .env("CTX_SEARCH_SEMANTIC", "true"),
+    );
+    assert_eq!(repeated["status"], "up_to_date", "{repeated:#}");
+}
+
+#[cfg(unix)]
+#[test]
 fn semantic_disabled_same_version_upgrade_does_not_install_legacy_runtime() {
     let temp = tempdir();
     let release = fake_legacy_release(&temp, env!("CARGO_PKG_VERSION"));

--- a/crates/ctx-upgrade-engine/tests/contracts/upgrade/windows_semantic_runtime.rs
+++ b/crates/ctx-upgrade-engine/tests/contracts/upgrade/windows_semantic_runtime.rs
@@ -1,0 +1,133 @@
+use super::*;
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
+
+const HELPER_TERMINAL_TIMEOUT: Duration = Duration::from_secs(30);
+const HELPER_TERMINAL_POLL: Duration = Duration::from_millis(25);
+
+#[test]
+fn semantic_enabled_same_version_upgrade_publishes_legacy_runtime_via_windows_helper() {
+    let temp = tempdir();
+    let target = fs::canonicalize(bind_test_ctx_binary(&temp)).unwrap();
+    unmanaged::install_managed_contract_marker(&target);
+    let release = windows_runtime_repair_release(&temp, &target);
+    let marker_path = hosted_install_marker_path(&target);
+    let binary_before = fs::read(&target).unwrap();
+    let marker_before = fs::read(&marker_path).unwrap();
+
+    let scheduled = json_output(
+        windows_runtime_repair_release_env(
+            ctx_from_binary(&temp, &target).args(["upgrade", "--format=json"]),
+            &release,
+        )
+        .env("CTX_SEARCH_SEMANTIC", "true"),
+    );
+    assert_eq!(scheduled["status"], "scheduled", "{scheduled:#}");
+    assert_eq!(scheduled["applied"], false, "{scheduled:#}");
+    assert!(
+        scheduled["upgrade_attempt_id"].as_str().is_some(),
+        "scheduled helper must identify its durable attempt: {scheduled:#}"
+    );
+
+    let journal_path = windows_install_transaction_path(&target);
+    let terminal = wait_for_applied_helper_terminal(&journal_path);
+    assert_eq!(terminal["phase"], "committed", "{terminal:#}");
+    assert_eq!(
+        terminal["windows_helper"]["terminal"]["outcome"], "applied",
+        "{terminal:#}"
+    );
+
+    assert_eq!(fs::read(&target).unwrap(), binary_before);
+    assert_eq!(fs::read(&marker_path).unwrap(), marker_before);
+    assert_windows_runtime_tree(&release);
+
+    let repeated = json_output(
+        windows_runtime_repair_release_env(
+            ctx_from_binary(&temp, &target).args(["upgrade", "--format=json"]),
+            &release,
+        )
+        .env("CTX_SEARCH_SEMANTIC", "true"),
+    );
+    assert_eq!(repeated["status"], "up_to_date", "{repeated:#}");
+    assert_eq!(repeated["applied"], false, "{repeated:#}");
+    assert!(
+        !journal_path.exists(),
+        "the second command must reconcile the helper terminal journal"
+    );
+    assert_eq!(fs::read(&target).unwrap(), binary_before);
+    assert_eq!(fs::read(&marker_path).unwrap(), marker_before);
+}
+
+fn wait_for_applied_helper_terminal(journal_path: &Path) -> Value {
+    let deadline = Instant::now() + HELPER_TERMINAL_TIMEOUT;
+    loop {
+        match fs::read(journal_path) {
+            Ok(bytes) => {
+                let journal: Value = serde_json::from_slice(&bytes).unwrap_or_else(|error| {
+                    panic!(
+                        "parse Windows helper journal {} while polling terminal outcome: {error}",
+                        journal_path.display()
+                    )
+                });
+                match journal["windows_helper"]["terminal"]["outcome"].as_str() {
+                    Some("applied") => return journal,
+                    Some("failed") => {
+                        panic!("Windows helper reported failed terminal outcome: {journal:#}")
+                    }
+                    Some(outcome) => {
+                        panic!(
+                            "unexpected Windows helper terminal outcome {outcome:?}: {journal:#}"
+                        )
+                    }
+                    None => {}
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => panic!(
+                "read Windows helper journal {} while polling terminal outcome: {error}",
+                journal_path.display()
+            ),
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for Windows helper terminal outcome at {}",
+            journal_path.display()
+        );
+        thread::sleep(HELPER_TERMINAL_POLL);
+    }
+}
+
+fn assert_windows_runtime_tree(release: &WindowsRuntimeRepairRelease) {
+    let lib = release.runtime_target.join("lib");
+    for file in [
+        "onnxruntime.dll",
+        "msvcp140.dll",
+        "msvcp140_1.dll",
+        "vcruntime140.dll",
+        "vcruntime140_1.dll",
+    ] {
+        assert!(lib.join(file).is_file(), "missing runtime DLL {file}");
+    }
+    assert_eq!(
+        fs::read_to_string(release.runtime_target.join("VERSION_NUMBER")).unwrap(),
+        format!("{}\n", release.runtime_version)
+    );
+    let manifest: Value = serde_json::from_slice(
+        &fs::read(release.runtime_target.join("ctx-runtime-install.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(manifest["manager"], "ctx-hosted-installer", "{manifest:#}");
+    assert_eq!(
+        manifest["metadata_trust"], "signed-release-metadata",
+        "{manifest:#}"
+    );
+    assert_eq!(manifest["runtime"], "onnxruntime", "{manifest:#}");
+    assert_eq!(manifest["platform"], "windows-x64", "{manifest:#}");
+    assert_eq!(manifest["version"], release.runtime_version, "{manifest:#}");
+    assert_eq!(
+        manifest["sha256"], release.runtime_artifact_sha,
+        "{manifest:#}"
+    );
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -49,6 +49,10 @@ ctx index mode auto
 ctx index mode manual
 ctx index watch
 ctx index wait
+ctx semantic enable
+ctx semantic enable --wait
+ctx semantic status
+ctx semantic disable
 ctx daemon run
 ```
 
@@ -116,6 +120,12 @@ ctx daemon run
   met; `--format jsonl` emits one snapshot per line. `index wait` blocks until
   the selected lexical, semantic, or combined readiness target is met and
   supports one final `--format json` result.
+- `semantic enable` persists the explicit semantic-search opt-in. In auto mode
+  it starts or recovers daemon-owned model acquisition and semantic catch-up;
+  `--wait` waits for the current projection. `semantic status` is read-only.
+  `semantic disable` opts out without deleting downloaded model/runtime assets
+  or derived semantic indexes. Plain enablement in manual mode does not change
+  indexing mode.
 - `daemon run` is an advanced command that runs persistent local maintenance in
   the foreground and blocks until stopped. It does not change the configured
   indexing mode. In manual mode, pass `--force` to run it explicitly. Each pass
@@ -124,17 +134,12 @@ ctx daemon run
   model for semantic indexing. A looping daemon keeps the embedding model
   resident after cold start, reloads daemon/semantic configuration between
   cycles, and performs recent-work freshness checks before settling into idle
-  loops. Enabling
-  `[search] semantic = true` and rerunning setup activates the existing daemon;
-  no unrelated restart is required.
+  loops.
 
 Automatic indexing is the default. Its canonical configuration is
 `[indexing] mode = "auto"`; the other supported value is `"manual"`.
-Enable local semantic search with `ctx setup --semantic`. Semantic indexing
-requires auto mode, so run `ctx index mode auto` first if the current mode is
-manual. Lexical search remains available while embeddings build, and hybrid
-search uses lexical and semantic evidence automatically when semantic coverage
-is ready.
+Lexical search remains available while embeddings build, and hybrid search uses
+lexical and semantic evidence automatically when semantic coverage is ready.
 
 Setup and health checks do not change shell startup files, install repository
 integrations, write into source repositories, call model APIs, or require API

--- a/docs/contracts/json.md
+++ b/docs/contracts/json.md
@@ -118,6 +118,27 @@ available. `daemon` reports process and relevant job state. These diagnostic
 objects can contain local paths and should not be persisted or forwarded outside
 local diagnostics.
 
+## Semantic Lifecycle
+
+```bash
+ctx semantic enable --format json
+ctx semantic status --format json
+ctx semantic disable --format json
+```
+
+These commands return `schema_version: 1`, `operation` (`enable`, `status`, or
+`disable`), the effective `enabled`, `status`, `reason`, and `config_source`,
+`indexing.mode`, optional `projection` and `catch_up` diagnostics, reduced
+`daemon` state, `local_only: true`, and `read_only`. Status is read-only;
+enable and disable persist policy and report `read_only: false`. Disablement
+retains downloaded model/runtime assets and derived semantic indexes.
+
+In auto mode, enablement starts or recovers the persistent daemon and returns
+after semantic work is accepted. `ctx semantic enable --wait --format json`
+uses the Index Readiness wait result below and waits for the current Core
+generation's semantic projection. Plain enablement in manual mode records the
+opt-in without changing mode; wait requires auto mode.
+
 ## Index Readiness
 
 ```bash
@@ -188,10 +209,10 @@ nullable may be omitted when unavailable:
 - `pid`, nullable/omitted;
 - `started_at_ms`, `heartbeat_at_ms`, and `finished_at_ms`, nullable/omitted;
 - `last_error`, nullable/omitted;
-- `start_mode`, nullable/omitted, currently `auto` for setup/import/search
+- `start_mode`, nullable/omitted, currently `auto` for setup/import/search/semantic
   process starts or `manual` for explicit daemon runs;
-- `trigger_command`, nullable/omitted, currently `setup`, `import`, or `search`
-  for automatic or finite starts;
+- `trigger_command`, nullable/omitted, currently `setup`, `import`, `search`, or
+  `semantic` for automatic or finite starts;
 - `semantic_runtime_active`, true only while the running daemon owns its
   semantic query service;
 - `config_reload`, with `status`, `out_of_sync`, `requested`, `applied`,

--- a/docs/daemon-semantic-indexing-spec.md
+++ b/docs/daemon-semantic-indexing-spec.md
@@ -27,8 +27,11 @@ Search is an interactive read path and never becomes a duplicate importer.
 Automatic background search may start or signal the persistent daemon. Manual
 background search reads the current indexes without contacting a process;
 explicit `--refresh wait` may start the same Core engine as a finite worker.
-Neither search path performs inline history refresh, lexical publication,
-semantic document projection, or embedding in the query process.
+Neither search path performs inline history refresh or lexical publication in
+the query process. After the finite worker publishes Core in manual mode, an
+opted-in semantic or nonzero-weight hybrid `--refresh wait` may reconcile the
+semantic document projection for that exact generation and embed the query in
+the waiting foreground process.
 
 The public retrieval modes are:
 
@@ -77,10 +80,11 @@ history, start persistent daemon maintenance in automatic mode, and return
 promptly. Manual setup starts no worker. Setup should not block for full
 semantic completion by default.
 
-`ctx setup --semantic` enables semantic search and requires auto mode. A user in
-manual mode runs `ctx index mode auto` first. Lexical search remains available
-while embeddings build; hybrid retrieval uses both indexes when coverage is
-ready.
+`ctx semantic enable` records the semantic-search opt-in. In auto mode it starts
+or recovers daemon-owned model acquisition and indexing; `--wait` waits for the
+current projection. A user who wants automatic catch-up from manual mode runs
+`ctx index mode auto` first. Lexical search remains available while embeddings
+build; hybrid retrieval uses both indexes when coverage is ready.
 
 Default human output should include a strong foreground signal:
 
@@ -214,15 +218,22 @@ background startup; there is no separate public daemon start command.
 
 - No public `auto` retrieval mode.
 - No lexical-then-semantic fallback as the default strategy.
-- No foreground semantic embedding from `ctx search`.
-- No model download from foreground setup, import, search, status, doctor, MCP,
-  or index-observer commands. Only the opted-in daemon may acquire or repair the
-  pinned model, and unverified bytes must fail closed before cache publication.
+- No foreground semantic embedding from implicit/background or `--refresh off`
+  search. An opted-in manual-mode semantic or nonzero-weight hybrid
+  `--refresh wait` is the sole query-process exception: after finite Core
+  publication it may acquire the pinned local model, reconcile semantic
+  coverage for that exact generation, and embed the query.
+- No model download from foreground setup, import, status, doctor, MCP, or
+  index-observer commands. Acquisition belongs to the opted-in daemon in auto
+  mode and the explicit manual `--refresh wait` exception above; unverified
+  bytes must fail closed before cache publication.
 - No duplicate inline importer. Persistent and finite publication both use the
   same daemon/Core refresh engine.
 - A finite Core worker installs no supervision, runs no watcher/timer/semantic/
   upgrade maintenance, admits at least one request before idle exit, and exits
-  only when Core work is terminal and IPC is quiescent.
+  only when Core work is terminal and IPC is quiescent. Manual semantic
+  reconciliation occurs afterward in the explicit waiting query process, not
+  in that Core worker.
 - No LLM-generated semantic documents.
 - Prefer one persisted semantic-document projection over reconstructing the
   corpus from raw events for every worker pass.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -120,14 +120,18 @@ installed platform.
 Enable local semantic search with:
 
 ```bash
-ctx setup --semantic
-ctx index
+ctx semantic enable
+ctx semantic status
 ```
 
-Semantic indexing requires auto mode. If you selected manual indexing, run
-`ctx index mode auto` before `ctx setup --semantic`. Lexical search remains
-available while embeddings build; hybrid search uses lexical and semantic
-evidence automatically when coverage is ready.
+Automatic indexing is the default, so enablement starts or recovers the daemon
+that acquires the local model and builds the semantic projection. Add `--wait`
+to wait for readiness. If you selected manual indexing, plain enablement records
+the opt-in without changing modes; run `ctx index mode auto` for automatic
+catch-up or use an explicit semantic search with `--refresh wait`. Lexical
+search remains available while embeddings build; hybrid search uses lexical and
+semantic evidence automatically when coverage is ready. `ctx semantic disable`
+turns the feature off without deleting downloaded assets.
 
 ctx has no hosted-history client or `ctx cloud` subcommand. Official
 installer-managed binaries can separately run signed CLI

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -78,10 +78,11 @@ shipped.
   validated local runtime remain lexical-safe: `hybrid` falls back to lexical
   and explicit `semantic` reports a local unavailable/runtime error instead of
   linking an unsupported backend.
-- Semantic indexing requires auto mode. Use `ctx index mode auto` before
-  `ctx setup --semantic` when manual mode is configured. Lexical search remains
-  available while embeddings build, and hybrid uses both backends when coverage
-  is ready.
+- Automatic semantic indexing requires auto mode. Use `ctx index mode auto`
+  before `ctx semantic enable --wait` when manual mode is configured. A plain
+  `ctx semantic enable` still records the opt-in in manual mode. Lexical search
+  remains available while embeddings build, and hybrid uses both backends when
+  coverage is ready.
 - The ctx macOS CLI targets macOS 13, but ONNX Runtime 1.27 follows its upstream
   macOS 14 minimum. On macOS 13, daemon-backed lexical search remains available
   while semantic search is unavailable.

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -73,9 +73,11 @@ a hosted research agent.
 - `ctx daemon run` is an advanced foreground, blocking maintenance command. It
   does not change the configured indexing mode. The daemon performs bounded
   native provider-history refresh and local semantic indexing/freshness work.
-- `ctx setup --semantic` enables local semantic search and requires auto mode.
-  Lexical search remains available while embeddings build; hybrid search uses
-  lexical and semantic evidence when semantic coverage is ready.
+- `ctx semantic enable|status|disable` owns the local semantic-search lifecycle.
+  Enablement is the explicit opt-in and starts daemon-owned model acquisition
+  and catch-up in auto mode; status is read-only; disablement retains downloaded
+  assets. Lexical search remains available while embeddings build; hybrid
+  search uses lexical and semantic evidence when semantic coverage is ready.
 - `ctx stats` reports bounded local usage/value aggregates from the separate
   owner-private `usage.sqlite` sidecar. This default-on product state is
   independent of remote event reporting, has no network path or identity, keeps

--- a/docs/search.md
+++ b/docs/search.md
@@ -236,8 +236,8 @@ silently reused.
 Enable local semantic search with:
 
 ```bash
-ctx setup --semantic
-ctx index
+ctx semantic enable
+ctx semantic status
 ```
 
 Semantic opt-in is independent of indexing mode. In auto mode, the daemon keeps

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -19,8 +19,11 @@ the local retrieval product.
   a bounded daemon-owned refresh of discovered native provider history before
   querying the active Core generation. Manual background search and
   `--refresh off` must not start or wake a process. The query process does not
-  write Core generations or projections. Without semantic opt-in, default
-  search must not download embedding models or start semantic indexing.
+  write Core generations. In manual mode, an opted-in semantic or nonzero-weight
+  hybrid `--refresh wait` may acquire the pinned model and write semantic
+  projection data only after finite Core publication for the exact pinned
+  generation. Without semantic opt-in, default search must not download
+  embedding models or start semantic indexing.
 - `ctx show` writes nothing in local-only security mode, except
   `ctx show session --out` writes only the explicit path when one is provided.
 - `ctx status` does not mutate canonical history: missing stores stay missing,
@@ -70,7 +73,7 @@ the local retrieval product.
   only bounded native local provider-history refresh and bounded semantic
   catch-up. It must not run history-source plugins.
   Network model acquisition is allowed only for the local embedding model when
-  semantic search is explicitly enabled with `ctx setup --semantic` in auto
+  semantic search is explicitly enabled with `ctx semantic enable` in auto
   mode. `ctx daemon run` blocks in the foreground and does not mutate indexing
   mode.
 - A finite Core worker may start only for explicit import or search

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -332,6 +332,8 @@ local upsert as described above.
 | Command | Reads | Writes |
 | --- | --- | --- |
 | `ctx setup` | provider transcript files and bounded path metadata for source discovery | data root, source catalog/epoch metadata, `search/lexical`, and optional persistent daemon lock/status/job files in automatic mode; old Store artifacts are neither opened nor deleted |
+| `ctx semantic status` | semantic policy, generation and local asset metadata, indexing mode, and daemon state | none |
+| `ctx semantic enable` / `ctx semantic disable` | semantic policy, generation and local asset metadata, indexing mode, and daemon state | atomically updates `config.toml`; automatic-mode enable may start the daemon and acquire the local runtime and model, while disable lets daemon maintenance quiesce semantic work and retains downloaded assets |
 | `ctx status` | data root metadata, source epoch, lexical/semantic generation metadata, daemon state, and compact local usage health | none; does not mutate provider history, Core generations, or usage aggregates |
 | `ctx index` / `ctx index watch` / `ctx index wait` | indexing mode, lexical/semantic generation metadata, and daemon state | none |
 | `ctx index mode` | `config.toml` when present | none when reading; `auto` or `manual` writes `config.toml` and establishes or removes persistent supervision |
@@ -365,10 +367,10 @@ daemon maintenance, start semantic workers, schedule semantic indexing, or
 write any derived generation. It serves results from the active Core
 generation. Default `--backend hybrid --refresh off`
 uses semantic evidence only when semantic coverage is complete and dirty work is
-drained, and otherwise falls back to lexical. Explicit semantic searches may ask
-the daemon query service to embed the query from an already-cached local model
-and read partial existing semantic generation coverage, but they do not
-download a model or write semantic catch-up work during search.
+drained, and otherwise falls back to lexical. Explicit semantic searches with
+`--refresh off` may ask the daemon query service to embed the query from an
+already-cached local model and read partial existing semantic generation
+coverage, but they do not download a model or write semantic catch-up work.
 Semantic coverage is exact across the content-filter boundary. Persisted
 flat-F32 source receipts account for every pre-filter Core candidate as either
 an active projected event or an intentionally filtered event. Query metadata
@@ -383,15 +385,16 @@ rebuild. Manual indexing remains passive and performs no scheduled migration.
 Explicit imports may best-effort mark recent semantic-eligible items dirty in
 the semantic generation when it already exists; this does not create semantic
 storage, initialize the model, or embed text.
-Explicit semantic search also refuses to initialize or download the embedding
-model when the required local cache is missing; hybrid falls back to lexical in
-that case. In automatic mode, default `--refresh background` lets persistent
-daemon maintenance own native provider refresh and may autostart the configured
-daemon query service for semantic/hybrid retrieval. In manual mode, background
-refresh serves the last published generation without starting or waking a
-process. Explicit `--refresh wait` may start a finite Core worker, but that
-worker never starts semantic services or catch-up. History-source plugins are
-refreshed only by an explicit selected-plugin import in 1.0.
+When the required local cache is missing, `--refresh off` refuses to initialize
+or download the embedding model; hybrid falls back to lexical in that case. In
+automatic mode, default `--refresh background` lets persistent daemon
+maintenance own native provider refresh and may autostart the configured daemon
+query service for semantic/hybrid retrieval. In manual mode, background refresh
+serves the last published generation without starting or waking a process. An
+explicit semantic or nonzero-weight hybrid `--refresh wait` may start a finite
+Core worker and, after Core publication, acquire the opted-in local model and
+reconcile semantic coverage for that exact pinned generation. History-source
+plugins are refreshed only by an explicit selected-plugin import in 1.0.
 
 When auto mode or `ctx daemon run` starts the persistent coordinator, it stores
 private lock/status files under `daemon/` in the ctx data root. Auto mode owns

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -137,16 +137,22 @@ Finite Core workers do not perform upgrade maintenance.
 
 ## Semantic Search Is Not Ready
 
-Semantic indexing requires auto mode. Enable it and inspect current health with:
+Continuous semantic indexing requires auto mode. Enable it and inspect current
+health with:
 
 ```bash
 ctx index mode auto
-ctx setup --semantic
-ctx index
+ctx semantic enable --wait
+ctx semantic status
 ```
 
 Lexical search remains available while embeddings build. Hybrid search begins
 using both lexical and semantic evidence when coverage is ready.
+
+In manual mode, there is no background semantic maintenance. After enabling
+semantic search, run an explicit semantic or nonzero-weight hybrid search with
+`--refresh wait` to acquire the local model when needed and reconcile the
+semantic projection for that request's pinned Core generation.
 
 ## Store Problems
 


### PR DESCRIPTION
## Summary

- add the ctx semantic enable, status, and disable lifecycle commands
- keep semantic assets out of ordinary setup while automatic enablement acquires the runtime and model and begins indexing
- allow bounded same-version ONNX Runtime-only repair publication, including Windows helper path identity and recovery validation
- update the public README, CLI reference, and product contracts

## Validation

- affected Bazel suite: 216/216 passed
- focused upgrade, formatting, documentation, and repository-policy checks passed
- native Windows runtime-only repair qualification passed
- independent semantic-lifecycle and transaction-publication reviews concluded ship

Fixes #769