### PR TITLE
refactor(sdk): deprecate hosted placeholders

### DIFF
--- a/crates/ctx-sdk/README.md
+++ b/crates/ctx-sdk/README.md
@@ -24,8 +24,9 @@ let results = client.search(SearchOptions {
 
 - Local backend: shells out to `ctx` JSON commands and never performs network
   calls or provider API calls.
-- Hosted backend: accepted for future compatibility but currently returns a
-  structured `not_supported` error.
+- Hosted backend: Hosted SDK placeholders are deprecated and will be removed in
+  the next breaking SDK revision; hosted operations remain unsupported. Valid
+  operations continue to return a structured `not_supported` error.
 
 ## Public Operations
 

--- a/crates/ctx-sdk/src/lib.rs
+++ b/crates/ctx-sdk/src/lib.rs
@@ -59,6 +59,10 @@ impl AgentHistoryError {
 #[derive(Debug, Clone)]
 pub enum AgentHistoryBackend {
     Local(LocalBackendConfig),
+    #[allow(deprecated)]
+    #[deprecated(
+        note = "Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK revision; hosted operations remain unsupported."
+    )]
     Hosted(HostedBackendConfig),
 }
 
@@ -82,6 +86,9 @@ impl Default for LocalBackendConfig {
 }
 
 #[derive(Debug, Clone)]
+#[deprecated(
+    note = "Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK revision; hosted operations remain unsupported."
+)]
 pub struct HostedBackendConfig {
     pub base_url: String,
     pub timeout: Duration,
@@ -239,6 +246,10 @@ impl AgentHistoryClient {
         }
     }
 
+    #[allow(deprecated)]
+    #[deprecated(
+        note = "Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK revision; hosted operations remain unsupported."
+    )]
     pub fn hosted(config: HostedBackendConfig) -> Self {
         Self {
             backend: AgentHistoryBackend::Hosted(config),
@@ -253,6 +264,7 @@ impl AgentHistoryClient {
                     .as_ref()
                     .map(|path| path.to_string_lossy().into_owned()),
             ),
+            #[allow(deprecated)]
             AgentHistoryBackend::Hosted(config) => {
                 BackendInfo::hosted(Some(config.base_url.clone()))
             }
@@ -404,6 +416,7 @@ impl AgentHistoryClient {
     fn local_backend_config(&self) -> Result<&LocalBackendConfig, AgentHistoryError> {
         match &self.backend {
             AgentHistoryBackend::Local(config) => Ok(config),
+            #[allow(deprecated)]
             AgentHistoryBackend::Hosted(config) => {
                 let mut details = JsonObject::new();
                 details.insert("backend".to_owned(), json!("hosted"));

--- a/crates/ctx-sdk/src/tests/additional.rs
+++ b/crates/ctx-sdk/src/tests/additional.rs
@@ -472,6 +472,7 @@ fn status_normalization_rejects_counters_outside_the_exact_json_domain() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn hosted_backend_returns_structured_error() {
     let client = AgentHistoryClient::hosted(HostedBackendConfig {
         base_url: "https://ctx.example.invalid".to_owned(),

--- a/sdks/dotnet/README.md
+++ b/sdks/dotnet/README.md
@@ -5,8 +5,10 @@ default: it shells out to the `ctx` CLI, reads JSON from stdout, and wraps the
 result in agent-history-v1 envelopes. Local mode does not make network calls or upload
 transcripts.
 
-The hosted configuration surface is present as a placeholder for a future ctx
-service. Hosted operations currently throw a structured `not_supported` error.
+`AgentHistoryClient.Hosted(HostedAgentHistoryConfig)` is a hosted SDK placeholder.
+Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK
+revision; hosted operations remain unsupported. Calls continue to throw a structured
+`not_supported` error without making network calls.
 
 ## Projects
 

--- a/sdks/dotnet/src/Ctx.AgentHistory/AgentHistoryClient.cs
+++ b/sdks/dotnet/src/Ctx.AgentHistory/AgentHistoryClient.cs
@@ -19,10 +19,13 @@ public sealed class AgentHistoryClient
         return new AgentHistoryClient(new LocalCliAdapter(config));
     }
 
+#pragma warning disable CS0618 // The obsolete factory intentionally composes obsolete hosted API types.
+    [Obsolete("Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK revision; hosted operations remain unsupported.", error: false)]
     public static AgentHistoryClient Hosted(HostedAgentHistoryConfig config)
     {
         return new AgentHistoryClient(new HostedAdapter(config));
     }
+#pragma warning restore CS0618
 
     public async Task<StatusResponse> StatusAsync(CancellationToken cancellationToken = default)
     {

--- a/sdks/dotnet/src/Ctx.AgentHistory/Configuration.cs
+++ b/sdks/dotnet/src/Ctx.AgentHistory/Configuration.cs
@@ -11,6 +11,7 @@ public sealed record LocalAgentHistoryConfig
 }
 
 /// <summary>Placeholder configuration for a future hosted agent-history-v1 transport.</summary>
+[Obsolete("Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK revision; hosted operations remain unsupported.", error: false)]
 public sealed record HostedAgentHistoryConfig
 {
     public HostedAgentHistoryConfig(string baseUrl)

--- a/sdks/dotnet/src/Ctx.AgentHistory/Errors.cs
+++ b/sdks/dotnet/src/Ctx.AgentHistory/Errors.cs
@@ -92,6 +92,8 @@ public sealed class CtxAgentHistoryValidationException : CtxAgentHistoryExceptio
     }
 }
 
+#pragma warning disable CS0618 // This obsolete exception retains the obsolete hosted configuration contract.
+[Obsolete("Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK revision; hosted operations remain unsupported.", error: false)]
 public sealed class HostedTransportNotImplementedException : CtxAgentHistoryException
 {
     public HostedTransportNotImplementedException(string method, HostedAgentHistoryConfig config)
@@ -120,3 +122,4 @@ public sealed class HostedTransportNotImplementedException : CtxAgentHistoryExce
         return details;
     }
 }
+#pragma warning restore CS0618

--- a/sdks/dotnet/src/Ctx.AgentHistory/HostedAdapter.cs
+++ b/sdks/dotnet/src/Ctx.AgentHistory/HostedAdapter.cs
@@ -2,7 +2,9 @@ using System.Text.Json.Nodes;
 
 namespace Ctx.AgentHistory;
 
+#pragma warning disable CS0618 // This obsolete placeholder composes only obsolete hosted API types.
 /// <summary>Hosted agent-history-v1 placeholder. It performs no network I/O.</summary>
+[Obsolete("Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK revision; hosted operations remain unsupported.", error: false)]
 public sealed class HostedAdapter : IAgentHistoryTransport
 {
     public HostedAdapter(HostedAgentHistoryConfig config)
@@ -36,3 +38,4 @@ public sealed class HostedAdapter : IAgentHistoryTransport
         return Task.FromResult<string?>(null);
     }
 }
+#pragma warning restore CS0618

--- a/sdks/dotnet/tests/Ctx.AgentHistory.Tests/Program.cs
+++ b/sdks/dotnet/tests/Ctx.AgentHistory.Tests/Program.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Reflection;
 using System.Text;
 using System.Text.Json.Nodes;
 using Ctx.AgentHistory;
@@ -1113,8 +1114,18 @@ internal static class Program
         Equal(CtxAgentHistoryVersions.SdkVersion, versioning.SdkVersion);
     }
 
+#pragma warning disable CS0618 // Direct hosted-placeholder coverage intentionally verifies obsolete APIs.
     private static Task HostedPlaceholderError()
     {
+        AssertHostedObsolete(typeof(HostedAgentHistoryConfig));
+        AssertHostedObsolete(typeof(HostedAdapter));
+        AssertHostedObsolete(typeof(HostedTransportNotImplementedException));
+        var hostedFactory = typeof(AgentHistoryClient).GetMethod(
+            nameof(AgentHistoryClient.Hosted),
+            [typeof(HostedAgentHistoryConfig)]);
+        True(hostedFactory is not null, "AgentHistoryClient.Hosted is missing");
+        AssertHostedObsolete(hostedFactory!);
+
         var client = AgentHistoryClient.Hosted(new HostedAgentHistoryConfig("https://ctx.example.invalid"));
         return ThrowsAsync<HostedTransportNotImplementedException>(async () =>
         {
@@ -1130,6 +1141,16 @@ internal static class Program
                 throw;
             }
         });
+    }
+#pragma warning restore CS0618
+
+    private static void AssertHostedObsolete(MemberInfo member)
+    {
+        const string expected = "Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK revision; hosted operations remain unsupported.";
+        var obsolete = member.GetCustomAttribute<ObsoleteAttribute>();
+        True(obsolete is not null, $"{member.Name} is missing ObsoleteAttribute");
+        Equal(expected, obsolete!.Message ?? "");
+        Equal(false, obsolete.IsError);
     }
 
     private static Task UsesAgentHistoryV1ErrorCodes()

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -81,5 +81,6 @@ failure classes.
 ## Hosted Placeholder
 
 `HostedConfig` and `NewHostedClient` reserve the hosted transport API. The
-hosted transport is not implemented yet; operations return
+Hosted SDK placeholders are deprecated and will be removed in the next breaking
+SDK revision; hosted operations remain unsupported. Calls continue to return
 `ErrorKindHostedNotImplemented` without making network calls.

--- a/sdks/go/hosted.go
+++ b/sdks/go/hosted.go
@@ -3,6 +3,9 @@ package ctxagenthistory
 import "context"
 
 // HostedConfig reserves the hosted agent-history-v1 configuration surface.
+//
+// Deprecated: Hosted SDK placeholders are deprecated and will be removed in
+// the next breaking SDK revision; hosted operations remain unsupported.
 type HostedConfig struct {
 	BaseURL string
 	APIKey  string
@@ -10,6 +13,9 @@ type HostedConfig struct {
 
 // NewHostedClient creates a placeholder hosted client. Operations return
 // ErrorKindHostedNotImplemented without making network calls.
+//
+// Deprecated: Hosted SDK placeholders are deprecated and will be removed in
+// the next breaking SDK revision; hosted operations remain unsupported.
 func NewHostedClient(config HostedConfig) *Client {
 	return NewClient(WithTransport(hostedTransport{config: config}))
 }

--- a/sdks/jvm/README.md
+++ b/sdks/jvm/README.md
@@ -42,8 +42,10 @@ Linux and macOS installations). It fails closed on Windows and on POSIX systems
 without either containment launcher. Fake transports and typed response parsing
 remain platform independent.
 
-Hosted configuration is present as `AgentHistoryClient.hosted(HostedConfig)` and
-returns a structured `not_supported` error until a hosted ctx service exists.
+`AgentHistoryClient.hosted(HostedConfig)` is a hosted SDK placeholder. Hosted SDK
+placeholders are deprecated and will be removed in the next breaking SDK revision;
+hosted operations remain unsupported. Calls continue to return a structured
+`not_supported` error without making network calls.
 
 ## Example
 

--- a/sdks/jvm/src/main/java/rs/ctx/agenthistory/AgentHistoryClient.java
+++ b/sdks/jvm/src/main/java/rs/ctx/agenthistory/AgentHistoryClient.java
@@ -22,6 +22,14 @@ public class AgentHistoryClient {
         return new AgentHistoryClient(new LocalCliAdapter(config));
     }
 
+    /**
+     * Creates the explicit hosted placeholder client.
+     *
+     * @deprecated Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK
+     *     revision; hosted operations remain unsupported.
+     */
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings("removal")
     public static HostedAgentHistoryClient hosted(HostedConfig config) {
         return new HostedAgentHistoryClient(config);
     }

--- a/sdks/jvm/src/main/java/rs/ctx/agenthistory/HostedAgentHistoryClient.java
+++ b/sdks/jvm/src/main/java/rs/ctx/agenthistory/HostedAgentHistoryClient.java
@@ -3,7 +3,14 @@ package rs.ctx.agenthistory;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-/** Explicit hosted placeholder. It never performs network calls. */
+/**
+ * Explicit hosted placeholder. It never performs network calls.
+ *
+ * @deprecated Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK
+ *     revision; hosted operations remain unsupported.
+ */
+@Deprecated(forRemoval = true)
+@SuppressWarnings("removal")
 public final class HostedAgentHistoryClient extends AgentHistoryClient {
     private final HostedConfig config;
 

--- a/sdks/jvm/src/main/java/rs/ctx/agenthistory/HostedConfig.java
+++ b/sdks/jvm/src/main/java/rs/ctx/agenthistory/HostedConfig.java
@@ -1,6 +1,13 @@
 package rs.ctx.agenthistory;
 
-/** Placeholder configuration for a future hosted agent-history-v1 backend. */
+/**
+ * Placeholder configuration for a future hosted agent-history-v1 backend.
+ *
+ * @deprecated Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK
+ *     revision; hosted operations remain unsupported.
+ */
+@Deprecated(forRemoval = true)
+@SuppressWarnings("removal")
 public final class HostedConfig {
     private final String baseUrl;
     private final String apiKey;
@@ -41,4 +48,3 @@ public final class HostedConfig {
         }
     }
 }
-

--- a/sdks/jvm/src/test/java/rs/ctx/agenthistory/AgentHistoryClientTest.java
+++ b/sdks/jvm/src/test/java/rs/ctx/agenthistory/AgentHistoryClientTest.java
@@ -990,7 +990,19 @@ public final class AgentHistoryClientTest {
         }
     }
 
-    private static void hostedIsExplicitlyUnsupported() {
+    @SuppressWarnings("removal")
+    private static void hostedIsExplicitlyUnsupported() throws NoSuchMethodException {
+        assertDeprecatedForRemoval(
+                HostedConfig.class.getAnnotation(Deprecated.class), "HostedConfig");
+        assertDeprecatedForRemoval(
+                HostedAgentHistoryClient.class.getAnnotation(Deprecated.class),
+                "HostedAgentHistoryClient");
+        assertDeprecatedForRemoval(
+                AgentHistoryClient.class
+                        .getMethod("hosted", HostedConfig.class)
+                        .getAnnotation(Deprecated.class),
+                "AgentHistoryClient.hosted");
+
         AgentHistoryClient client = AgentHistoryClient.hosted(HostedConfig.builder().baseUrl("https://ctx.example.invalid").build());
         try {
             client.status();
@@ -999,6 +1011,12 @@ public final class AgentHistoryClientTest {
             assertEquals("not_supported", error.code());
             assertEquals("hosted", error.details().get("backend"));
             assertEquals("https://ctx.example.invalid", error.details().get("baseUrl"));
+        }
+    }
+
+    private static void assertDeprecatedForRemoval(Deprecated annotation, String name) {
+        if (annotation == null || !annotation.forRemoval()) {
+            throw new AssertionError("expected " + name + " to be @Deprecated(forRemoval=true)");
         }
     }
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -3,9 +3,10 @@
 Experimental Python SDK for the local ctx `agent-history-v1` API.
 
 The SDK is intentionally small and network-free by default. It wraps local
-`ctx` CLI JSON and normalizes it into the shared `agent-history-v1` contract. Hosted
-configuration types are present so application code can be written against one
-client shape, but hosted transport is not implemented yet.
+`ctx` CLI JSON and normalizes it into the shared `agent-history-v1` contract.
+Hosted configuration types remain as compatibility placeholders. Hosted SDK
+placeholders are deprecated and will be removed in the next breaking SDK
+revision; hosted operations remain unsupported.
 
 ## Install For Local Development
 
@@ -81,12 +82,19 @@ All SDK errors inherit from `CtxAgentHistoryError` and expose:
 CLI failures raise `CtxAgentHistoryCliError` with `exit_code`, `stderr`, and the
 command argv. Invalid or missing JSON raises `CtxAgentHistoryProtocolError`.
 
-## Hosted Placeholder
+## Deprecated Hosted Placeholder
+
+`HostedConfig`, `ctx_agent_history.transport.HostedAdapter`,
+`HostedTransportNotImplementedError`, `AgentHistoryClient.hosted()`, and the
+`HostedConfig` arm of `AgentHistoryClient.from_config()` are deprecated. Hosted
+SDK placeholders are deprecated and will be removed in the next breaking SDK
+revision; hosted operations remain unsupported.
 
 ```python
 from ctx_agent_history import HostedConfig, AgentHistoryClient
 
-client = AgentHistoryClient.hosted(HostedConfig(base_url="https://example.invalid"))
+config = HostedConfig(base_url="https://example.invalid")  # emits DeprecationWarning
+client = AgentHistoryClient.hosted(config)
 client.status()  # raises HostedTransportNotImplementedError
 ```
 

--- a/sdks/python/src/ctx_agent_history/client.py
+++ b/sdks/python/src/ctx_agent_history/client.py
@@ -65,10 +65,21 @@ class AgentHistoryClient:
 
     @classmethod
     def hosted(cls, config: HostedConfig) -> "AgentHistoryClient":
+        """Create a deprecated hosted placeholder client.
+
+        Hosted SDK placeholders are deprecated and will be removed in the next
+        breaking SDK revision; hosted operations remain unsupported.
+        """
         return cls(HostedAdapter(config))
 
     @classmethod
     def from_config(cls, config: Union[LocalConfig, HostedConfig]) -> "AgentHistoryClient":
+        """Create a client from local configuration or a deprecated hosted placeholder.
+
+        Passing ``HostedConfig`` is deprecated. Hosted SDK placeholders are
+        deprecated and will be removed in the next breaking SDK revision;
+        hosted operations remain unsupported.
+        """
         if isinstance(config, LocalConfig):
             return cls(LocalCliAdapter(config))
         if isinstance(config, HostedConfig):

--- a/sdks/python/src/ctx_agent_history/config.py
+++ b/sdks/python/src/ctx_agent_history/config.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Optional
+
+
+_HOSTED_DEPRECATION_MESSAGE = (
+    "Hosted SDK placeholders are deprecated and will be removed in the next "
+    "breaking SDK revision; hosted operations remain unsupported."
+)
 
 
 @dataclass(frozen=True)
@@ -20,8 +27,19 @@ class LocalConfig:
 
 @dataclass(frozen=True)
 class HostedConfig:
-    """Placeholder configuration for a future hosted agent-history-v1 transport."""
+    """Deprecated placeholder configuration for a hosted agent-history-v1 transport.
+
+    Hosted SDK placeholders are deprecated and will be removed in the next
+    breaking SDK revision; hosted operations remain unsupported.
+    """
 
     base_url: str
     api_key: Optional[str] = None
     timeout: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        warnings.warn(
+            _HOSTED_DEPRECATION_MESSAGE,
+            DeprecationWarning,
+            stacklevel=3,
+        )

--- a/sdks/python/src/ctx_agent_history/errors.py
+++ b/sdks/python/src/ctx_agent_history/errors.py
@@ -123,7 +123,11 @@ class CtxAgentHistoryTimeoutError(CtxAgentHistoryError):
 
 
 class HostedTransportNotImplementedError(CtxAgentHistoryError):
-    """Raised by the hosted placeholder transport."""
+    """Raised by the deprecated hosted placeholder transport.
+
+    Hosted SDK placeholders are deprecated and will be removed in the next
+    breaking SDK revision; hosted operations remain unsupported.
+    """
 
     def __init__(self, method: str) -> None:
         super().__init__(

--- a/sdks/python/src/ctx_agent_history/transport.py
+++ b/sdks/python/src/ctx_agent_history/transport.py
@@ -413,7 +413,11 @@ class LocalCliAdapter:
 
 
 class HostedAdapter:
-    """Hosted agent-history-v1 placeholder that performs no network I/O."""
+    """Deprecated hosted placeholder that performs no network I/O.
+
+    Hosted SDK placeholders are deprecated and will be removed in the next
+    breaking SDK revision; hosted operations remain unsupported.
+    """
 
     name = "hosted"
 

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 import os
 import stat
@@ -7,9 +8,9 @@ import subprocess
 import sys
 import tempfile
 import textwrap
-import unittest
-import inspect
 import typing
+import unittest
+import warnings
 from unittest import mock
 from pathlib import Path
 
@@ -26,7 +27,7 @@ from ctx_agent_history import (
 from ctx_agent_history.errors import CtxAgentHistoryCliError, CtxAgentHistoryProtocolError
 from ctx_agent_history.errors import CtxAgentHistoryTimeoutError, CtxAgentHistoryValidationError
 from ctx_agent_history.agent_history_v1 import normalize_event, normalize_import, normalize_sources, normalize_status
-from ctx_agent_history.transport import LocalCliAdapter
+from ctx_agent_history.transport import HostedAdapter, LocalCliAdapter
 from ctx_agent_history.types import (
     AgentHistoryErrorCode,
     Event,
@@ -637,8 +638,31 @@ class LocalCliAdapterTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, "timeout")
         self.assertTrue(raised.exception.retryable)
 
-    def test_hosted_config_is_placeholder(self) -> None:
-        client = AgentHistoryClient.hosted(HostedConfig(base_url="https://example.invalid"))
+    def test_hosted_config_is_deprecated_placeholder(self) -> None:
+        deprecation_message = (
+            "Hosted SDK placeholders are deprecated and will be removed in the next "
+            "breaking SDK revision; hosted operations remain unsupported."
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", DeprecationWarning)
+            client = AgentHistoryClient.hosted(
+                HostedConfig(base_url="https://example.invalid")
+            )
+
+        self.assertEqual(len(caught), 1)
+        self.assertIs(caught[0].category, DeprecationWarning)
+        self.assertEqual(str(caught[0].message), deprecation_message)
+        self.assertEqual(Path(caught[0].filename), Path(__file__))
+        for deprecated_api in (
+            HostedConfig,
+            HostedAdapter,
+            HostedTransportNotImplementedError,
+            AgentHistoryClient.hosted,
+            AgentHistoryClient.from_config,
+        ):
+            doc = " ".join((deprecated_api.__doc__ or "").split())
+            self.assertIn(deprecation_message, doc)
 
         with self.assertRaises(HostedTransportNotImplementedError) as raised:
             client.status()

--- a/sdks/swift/README.md
+++ b/sdks/swift/README.md
@@ -88,9 +88,10 @@ systems fail closed with a structured `not_supported` error; injected fake
 For tests, inject a `CommandRunner` through `LocalCLIAdapter` so no real ctx
 binary is required.
 
-## Hosted Placeholder
+## Hosted Placeholder (Deprecated)
 
-Hosted configuration is reserved for a future ctx service:
+Hosted SDK placeholders are deprecated and will be removed in the next breaking
+SDK revision; hosted operations remain unsupported.
 
 ```swift
 let client = AgentHistoryClient.hosted(

--- a/sdks/swift/Sources/CtxAgentHistory/AgentHistoryClient.swift
+++ b/sdks/swift/Sources/CtxAgentHistory/AgentHistoryClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct AgentHistoryClient: Sendable {
     private enum Backend: Sendable {
         case local(LocalCLIAdapter)
-        case hosted(HostedConfig)
+        case hosted(baseURL: URL?, apiKey: String?)
     }
 
     private var backend: Backend
@@ -34,8 +34,15 @@ public struct AgentHistoryClient: Sendable {
         )
     }
 
+    @available(
+        *,
+        deprecated,
+        message: "Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK revision; hosted operations remain unsupported."
+    )
     public static func hosted(_ config: HostedConfig = HostedConfig()) -> AgentHistoryClient {
-        AgentHistoryClient(backend: .hosted(config))
+        AgentHistoryClient(
+            backend: .hosted(baseURL: config.baseURL, apiKey: config.apiKey)
+        )
     }
 
     public func status() throws -> StatusResponse {
@@ -155,8 +162,8 @@ public struct AgentHistoryClient: Sendable {
         switch backend {
         case let .local(adapter):
             backendValue = adapter.backend
-        case let .hosted(config):
-            backendValue = AgentHistoryBackend(kind: "hosted", baseURL: config.baseURL?.absoluteString)
+        case let .hosted(baseURL, _):
+            backendValue = AgentHistoryBackend(kind: "hosted", baseURL: baseURL?.absoluteString)
         }
         return AgentHistoryEnvelope(operation: operation, backend: backendValue, error: error.contractError)
     }

--- a/sdks/swift/Sources/CtxAgentHistory/AgentHistoryOptions.swift
+++ b/sdks/swift/Sources/CtxAgentHistory/AgentHistoryOptions.swift
@@ -115,6 +115,11 @@ public struct ShowSessionOptions: Sendable {
     }
 }
 
+@available(
+    *,
+    deprecated,
+    message: "Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK revision; hosted operations remain unsupported."
+)
 public struct HostedConfig: Sendable {
     public var baseURL: URL?
     public var apiKey: String?

--- a/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
+++ b/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
@@ -686,6 +686,11 @@ final class CtxAgentHistoryTests: XCTestCase {
         XCTAssertEqual(normalized["acquisition"]?["cursor"], .string("opaque-checkpoint"))
     }
 
+    @available(
+        *,
+        deprecated,
+        message: "Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK revision; hosted operations remain unsupported."
+    )
     func testHostedClientIsExplicitPlaceholder() throws {
         let client = AgentHistoryClient.hosted(
             HostedConfig(baseURL: URL(string: "https://ctx.example.invalid"))

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -83,9 +83,14 @@ the CLI root exits first.
 
 ## Hosted Placeholder
 
-`createHostedAgentHistoryClient()` and `createAgentHistoryClient({ hosted: true })` reserve
-the future hosted transport shape. Any data method rejects with
-`CtxUnsupportedError` until ctx exposes a hosted agent-history-v1 service.
+Hosted SDK placeholders are deprecated and will be removed in the next breaking
+SDK revision; hosted operations remain unsupported.
+
+`HostedAgentHistoryClientOptions`, `HostedAgentHistoryClient`,
+`createHostedAgentHistoryClient()`, and hosted calls through
+`createAgentHistoryClient()` remain available during the deprecation window.
+Use `createLocalAgentHistoryClient()` with the local CLI adapter instead. Hosted
+data methods continue to reject with `CtxUnsupportedError`.
 
 ## Errors
 

--- a/sdks/typescript/src/index.d.ts
+++ b/sdks/typescript/src/index.d.ts
@@ -57,9 +57,25 @@ export interface LocalAgentHistoryClientOptions extends LocalCliAdapterOptions {
   adapter?: LocalCliAdapter;
 }
 
+/**
+ * @deprecated Hosted SDK placeholders are deprecated and will be removed in
+ * the next breaking SDK revision; hosted operations remain unsupported.
+ */
 export interface HostedAgentHistoryClientOptions {
+  /**
+   * @deprecated Hosted SDK placeholders are deprecated and will be removed in
+   * the next breaking SDK revision; hosted operations remain unsupported.
+   */
   hosted?: boolean;
+  /**
+   * @deprecated Hosted SDK placeholders are deprecated and will be removed in
+   * the next breaking SDK revision; hosted operations remain unsupported.
+   */
   baseUrl?: string;
+  /**
+   * @deprecated Hosted SDK placeholders are deprecated and will be removed in
+   * the next breaking SDK revision; hosted operations remain unsupported.
+   */
   apiKey?: string;
 }
 
@@ -502,10 +518,18 @@ export declare class LocalAgentHistoryClient {
   version(): Promise<VersionInfo>;
 }
 
+/**
+ * @deprecated Hosted SDK placeholders are deprecated and will be removed in
+ * the next breaking SDK revision; hosted operations remain unsupported.
+ */
 export declare class HostedAgentHistoryClient {
   kind: "hosted";
   baseUrl?: string;
   apiKey?: string;
+  /**
+   * @deprecated Hosted SDK placeholders are deprecated and will be removed in
+   * the next breaking SDK revision; hosted operations remain unsupported.
+   */
   constructor(options?: HostedAgentHistoryClientOptions);
   status(): Promise<never>;
   init(): Promise<never>;
@@ -519,6 +543,10 @@ export declare class HostedAgentHistoryClient {
 }
 
 export declare function createLocalAgentHistoryClient(options?: LocalAgentHistoryClientOptions): LocalAgentHistoryClient;
+/**
+ * @deprecated Hosted SDK placeholders are deprecated and will be removed in
+ * the next breaking SDK revision; hosted operations remain unsupported.
+ */
 export declare function createHostedAgentHistoryClient(options?: HostedAgentHistoryClientOptions): HostedAgentHistoryClient;
 export declare function createAgentHistoryClient(
   options?: LocalAgentHistoryClientOptions | HostedAgentHistoryClientOptions,

--- a/sdks/typescript/src/index.js
+++ b/sdks/typescript/src/index.js
@@ -378,7 +378,15 @@ function validateNoDuplicateJSONMembers(json) {
   if (index !== json.length) fail("trailing data");
 }
 
+/**
+ * @deprecated Hosted SDK placeholders are deprecated and will be removed in
+ * the next breaking SDK revision; hosted operations remain unsupported.
+ */
 export class HostedAgentHistoryClient {
+  /**
+   * @deprecated Hosted SDK placeholders are deprecated and will be removed in
+   * the next breaking SDK revision; hosted operations remain unsupported.
+   */
   constructor(options = {}) {
     this.kind = "hosted";
     this.baseUrl = options.baseUrl;
@@ -432,6 +440,10 @@ export function createLocalAgentHistoryClient(options = {}) {
   return new LocalAgentHistoryClient(options);
 }
 
+/**
+ * @deprecated Hosted SDK placeholders are deprecated and will be removed in
+ * the next breaking SDK revision; hosted operations remain unsupported.
+ */
 export function createHostedAgentHistoryClient(options = {}) {
   return new HostedAgentHistoryClient(options);
 }


### PR DESCRIPTION
## Summary

- add native deprecation markers and messages to the hosted placeholder surfaces across all seven SDKs
- retain every existing API for the required tagged source-release compatibility window
- preserve the existing network-free, fail-closed hosted behavior and shared wire contracts
- update only direct SDK documentation and deprecation assertions

## Validation

- physical Rust crate-size preflight
- repository policy and diff checks
- affected selection: 17/17 targets passed
- SDK contracts: 17 fixtures, 21 adversarial MCP fixtures, seven alias-rejection checks, and the no-publish guard
- patch-equivalent reviewed candidate previously passed all seven SDK groups, supported warning-as-error gates, package dry run, and full public CI