### PR TITLE
fix(release): validate unmanaged upgrade fail-safe

### DIFF
--- a/scripts/run-native-candidate-smoke.sh
+++ b/scripts/run-native-candidate-smoke.sh
@@ -458,9 +458,13 @@ if ! status_top_level_bool daemon enabled true "${root}/status.json"; then
   exit 1
 fi
 status_compact="$(tr '\r\n' '  ' < "${root}/status.json")"
+# Both validation layouts deliberately omit the hosted-install marker. The
+# control inventory above proves the released `apply` default; this runtime
+# probe proves an isolated, unmanaged candidate fails safe instead of trying to
+# self-upgrade.
 if ! printf '%s\n' "${status_compact}" \
-  | grep -Eq '"upgrade"[[:space:]]*:[[:space:]]*\{[^}]*"auto"[[:space:]]*:[[:space:]]*"apply"[^}]*"auto_enabled"[[:space:]]*:[[:space:]]*true'; then
-  printf 'candidate does not report managed auto-upgrade apply as the default\n' >&2
+  | grep -Eq '"upgrade"[[:space:]]*:[[:space:]]*\{[^}]*"auto"[[:space:]]*:[[:space:]]*"off"[^}]*"auto_enabled"[[:space:]]*:[[:space:]]*false'; then
+  printf 'candidate does not disable auto-upgrade in the unmanaged validation layout\n' >&2
   exit 1
 fi
 if [ ! -s "${analytics_default_events}" ]; then

--- a/scripts/tests/run-native-candidate-smoke-test.sh
+++ b/scripts/tests/run-native-candidate-smoke-test.sh
@@ -200,8 +200,8 @@ case "${1:-}" in
     "enabled": true
   },
   "upgrade": {
-    "auto": "apply",
-    "auto_enabled": true
+    "auto": "off",
+    "auto_enabled": false
   },
   "semantic": {
     "config_source": "default",


### PR DESCRIPTION
The native exact-byte release smoke copies candidates into isolated layouts without a hosted-install marker. Validate the resulting fail-safe `off`/disabled runtime upgrade state while retaining the separate released-default inventory check for managed installs.

Validation:
- `bazel test //:native_candidate_smoke_tests`
- exact Linux x64 factory artifact native validation
- `bash -n` and `git diff --check`

This is the minimal release-blocking correction found while preparing ctx 1.2.0.