### PR TITLE
feat(import): report net index deltas

### DIFF
--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration.rs
@@ -557,6 +557,11 @@ fn manual_indexing_import_uses_a_finite_worker_and_background_search_stays_inert
             .timeout(Duration::from_secs(20)),
     );
     assert_eq!(imported["outcome"], "success", "{imported:#}");
+    assert_eq!(imported["totals"]["current_indexed_sessions"], 1);
+    assert!(
+        imported["totals"].get("index_delta").is_none(),
+        "a first import must not synthesize a delta from an empty baseline: {imported:#}"
+    );
     assert_eq!(
         imported["sources"][0]["status"], "published",
         "{imported:#}"

--- a/crates/ctx-cli/src/commands/import/application_adapter.rs
+++ b/crates/ctx-cli/src/commands/import/application_adapter.rs
@@ -4,7 +4,8 @@ use anyhow::Result;
 use ctx_history_capture::{source_backed_source_failure_identity, ProviderSource};
 use ctx_history_core::CaptureProvider;
 use ctx_history_ingest_application::{
-    HistorySourcePluginSource, ImportPathMissingDuringRefresh, IngestPublication, RefreshSelection,
+    HistorySourcePluginSource, ImportIndexFacts, ImportPathMissingDuringRefresh, IngestPublication,
+    RefreshSelection,
 };
 use ctx_history_platform::platform_security::establish_private_data_root;
 use ctx_history_refresh::ExplicitSourceCatalogUpsert;
@@ -95,6 +96,36 @@ impl ctx_history_cli::ImportApplicationPort for CliImportHost {
                 }
             })?;
         let pinned_generation = refresh.pin.generation_id().to_owned();
+        let current_index = refresh.pin.verified_index();
+        let current_sessions = current_index.session_count()?;
+        let current_searchable_events = current_index.document_count();
+        let previous_cardinalities = match refresh.request_previous_generation.as_deref() {
+            None => None,
+            Some(previous_generation) if previous_generation == pinned_generation => {
+                Some((current_sessions, current_searchable_events))
+            }
+            Some(previous_generation) => {
+                // The import publication is already authoritative. A later
+                // publication may have retired its predecessor before this
+                // optional presentation measurement, so omit the delta
+                // instead of failing a successful import or guessing.
+                optional_import_baseline(|| {
+                    let previous = ctx_history_refresh::pin_retained_generation(
+                        data_root,
+                        previous_generation,
+                    )?;
+                    Ok((
+                        previous.verified_index().session_count()?,
+                        previous.verified_index().document_count(),
+                    ))
+                })
+            }
+        };
+        let index_facts = ImportIndexFacts::from_cardinalities(
+            current_sessions,
+            current_searchable_events,
+            previous_cardinalities,
+        );
         let policy_schema_hash = exact_route_lineages.is_none().then(|| {
             refresh
                 .pin
@@ -122,13 +153,29 @@ impl ctx_history_cli::ImportApplicationPort for CliImportHost {
             pinned_generation,
             policy_schema_hash,
             catalog_content,
+            index_facts: Some(index_facts),
             receipt: refresh.receipt,
         })
     }
 }
 
+fn optional_import_baseline(measure: impl FnOnce() -> Result<(u64, u64)>) -> Option<(u64, u64)> {
+    measure().ok()
+}
+
 #[cfg(test)]
 mod tests {
+    use super::optional_import_baseline;
+
+    #[test]
+    fn optional_baseline_measurement_cannot_fail_a_successful_import() {
+        assert_eq!(
+            optional_import_baseline(|| anyhow::bail!("retained generation was reclaimed")),
+            None
+        );
+        assert_eq!(optional_import_baseline(|| Ok((3, 8))), Some((3, 8)));
+    }
+
     #[test]
     fn final_host_contains_only_concrete_side_effect_adapters() {
         let source = include_str!("application_adapter.rs");

--- a/crates/ctx-history-cli/src/import_report.rs
+++ b/crates/ctx-history-cli/src/import_report.rs
@@ -72,7 +72,12 @@ pub fn import_report_json(report: &IngestReport) -> Value {
 fn import_totals_json(totals: &ImportTotals) -> Value {
     let mut value = compact_json(json!({
         "current_source_count": totals.current_source_count,
+        "current_indexed_sessions": totals.current_indexed_sessions,
         "current_indexed_documents": totals.current_indexed_documents,
+        "index_delta": totals.index_delta.map(|delta| json!({
+            "sessions": delta.sessions,
+            "searchable_events": delta.searchable_events,
+        })),
         "current_complete_records": totals.current_complete_records,
         "current_retained_records": totals.current_retained_records,
         "current_rejected_records": totals.current_rejected_records,
@@ -144,6 +149,18 @@ pub fn render_import_report_human(context: &RenderContext, report: &IngestReport
         },
     );
 
+    if let Some(delta) = totals.index_delta {
+        let net_change = [
+            ("Sessions", signed_count(delta.sessions)),
+            ("Searchable events", signed_count(delta.searchable_events)),
+        ];
+        document.push_blank();
+        document.append(section(
+            "Net index change",
+            fields_from_owned(context, &net_change),
+        ));
+    }
+
     let mut imported = Vec::new();
     if totals.per_run_counts_available {
         imported.push(("Sources", totals.imported_sources.to_string()));
@@ -161,6 +178,7 @@ pub fn render_import_report_human(context: &RenderContext, report: &IngestReport
 
     let mut current = Vec::new();
     push_optional(&mut current, "Sources", totals.current_source_count);
+    push_optional(&mut current, "Sessions", totals.current_indexed_sessions);
     push_optional(
         &mut current,
         "Searchable events",
@@ -201,6 +219,14 @@ pub fn render_import_report_human(context: &RenderContext, report: &IngestReport
         ));
     }
     document
+}
+
+fn signed_count(value: i64) -> String {
+    if value > 0 {
+        format!("+{value}")
+    } else {
+        value.to_string()
+    }
 }
 
 const MAX_HUMAN_SOURCE_FAILURES: usize = 3;

--- a/crates/ctx-history-cli/src/import_report/tests.rs
+++ b/crates/ctx-history-cli/src/import_report/tests.rs
@@ -1,6 +1,7 @@
 use std::{io::Write as _, path::Path};
 
 use ctx_history_capture::ProviderImportWorkResult;
+use ctx_history_ingest_application::ImportIndexDelta;
 use unicode_width::UnicodeWidthStr as _;
 
 use crate::ui::{ColorMode, StreamKind, TestContext};
@@ -35,7 +36,12 @@ fn changed_report() -> IngestReport {
             imported_edges: 1,
             skipped: 1,
             current_source_count: Some(1),
+            current_indexed_sessions: Some(2),
             current_indexed_documents: Some(7),
+            index_delta: Some(ImportIndexDelta {
+                sessions: 2,
+                searchable_events: 7,
+            }),
             current_complete_records: Some(7),
             current_retained_records: Some(7),
             current_rejected_records: Some(0),
@@ -163,6 +169,10 @@ fn human_import_report_has_stable_copy_and_source_failure_recovery() {
         "✓ History import completed\n\
          Local history changed.\n\
          \n\
+         Net index change\n\
+         Sessions           +2\n\
+         Searchable events  +7\n\
+         \n\
          Imported\n\
          Sources          1\n\
          Sessions         2\n\
@@ -172,6 +182,7 @@ fn human_import_report_has_stable_copy_and_source_failure_recovery() {
          \n\
          Current index\n\
          Sources            1\n\
+         Sessions           2\n\
          Searchable events  7\n\
          Removed sources    0\n"
     );
@@ -442,7 +453,12 @@ fn import_json_contract_is_unchanged_by_human_renderer() {
                 "skipped": 1,
                 "rejected_records": 0,
                 "current_source_count": 1,
+                "current_indexed_sessions": 2,
                 "current_indexed_documents": 7,
+                "index_delta": {
+                    "sessions": 2,
+                    "searchable_events": 7
+                },
                 "current_complete_records": 7,
                 "current_retained_records": 7,
                 "current_rejected_records": 0,
@@ -455,6 +471,44 @@ fn import_json_contract_is_unchanged_by_human_renderer() {
             "sources": [],
         })
     );
+}
+
+#[test]
+fn import_index_deltas_render_as_signed_counts_and_are_absent_on_first_import() {
+    for (sessions, searchable_events, expected_sessions, expected_events) in
+        [(2, 7, "+2", "+7"), (0, 0, "0", "0"), (-1, -3, "-1", "-3")]
+    {
+        let mut report = changed_report();
+        report.totals.index_delta = Some(ImportIndexDelta {
+            sessions,
+            searchable_events,
+        });
+        let rendered =
+            render_import_report_human(&context(80, ColorMode::Never), &report).render_plain();
+        assert!(
+            rendered.contains(&format!("Sessions           {expected_sessions}")),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains(&format!("Searchable events  {expected_events}")),
+            "{rendered}"
+        );
+        let json = import_report_json(&report);
+        assert_eq!(json["totals"]["index_delta"]["sessions"], sessions);
+        assert_eq!(
+            json["totals"]["index_delta"]["searchable_events"],
+            searchable_events
+        );
+    }
+
+    let mut first = changed_report();
+    first.totals.index_delta = None;
+    let rendered =
+        render_import_report_human(&context(80, ColorMode::Never), &first).render_plain();
+    assert!(!rendered.contains("Net index change"), "{rendered}");
+    assert!(import_report_json(&first)["totals"]
+        .get("index_delta")
+        .is_none());
 }
 
 #[test]

--- a/crates/ctx-history-ingest-application/src/lib.rs
+++ b/crates/ctx-history-ingest-application/src/lib.rs
@@ -41,4 +41,7 @@ pub use routing::{
     CaptureAdmissionPort, IngestProgressPort, IngestRefreshPort, IngestRequest, IngestRoute,
     ProviderSelectionGuidance, SourceDiscoveryPort,
 };
-pub use totals::{ImportFailureScope, ImportFailureType, ImportOutcome, ImportTotals};
+pub use totals::{
+    ImportFailureScope, ImportFailureType, ImportIndexDelta, ImportIndexFacts, ImportOutcome,
+    ImportTotals,
+};

--- a/crates/ctx-history-ingest-application/src/lifecycle.rs
+++ b/crates/ctx-history-ingest-application/src/lifecycle.rs
@@ -90,6 +90,7 @@ where
         rejected_record_total,
         sources_completed_with_rejections,
         publication.request_generation_changed,
+        publication.index_facts,
     );
     let has_source_failures = source_failure_total != 0;
     let has_rejections = rejected_record_total != 0;
@@ -248,7 +249,7 @@ fn exact_report(
         ..ProviderImportSummary::default()
     };
     let current = receipt.current;
-    let totals = ImportTotals {
+    let mut totals = ImportTotals {
         per_run_counts_available: false,
         terminal_route_counts_available: true,
         source_files: stats.files,
@@ -275,6 +276,7 @@ fn exact_report(
         },
         ..ImportTotals::default()
     };
+    apply_index_facts(&mut totals, publication.index_facts);
     let failure_type = exact_failure_type(
         requested_source_failed,
         requested_rejected,
@@ -432,7 +434,7 @@ fn plugin_report(
         ..ProviderImportSummary::default()
     };
     let current = receipt.current;
-    let totals = ImportTotals {
+    let mut totals = ImportTotals {
         terminal_route_counts_available: true,
         failed: usize::try_from(rejected_record_total).unwrap_or(usize::MAX),
         sources_completed_with_rejections: usize::from(rejected_record_total != 0),
@@ -454,6 +456,7 @@ fn plugin_report(
         },
         ..ImportTotals::default()
     };
+    apply_index_facts(&mut totals, publication.index_facts);
     let has_rejections = rejected_record_total != 0;
     let source_outcome = PluginPublicationOutcome {
         status: if has_rejections {
@@ -557,8 +560,9 @@ fn terminal_totals(
     rejected_record_total: u64,
     sources_completed_with_rejections: usize,
     generation_changed: bool,
+    index_facts: Option<crate::ImportIndexFacts>,
 ) -> ImportTotals {
-    ImportTotals {
+    let mut totals = ImportTotals {
         per_run_counts_available: false,
         terminal_route_counts_available: true,
         failed_sources: source_failure_total,
@@ -579,6 +583,15 @@ fn terminal_totals(
             ProviderImportWorkResult::NoOp
         },
         ..ImportTotals::default()
+    };
+    apply_index_facts(&mut totals, index_facts);
+    totals
+}
+
+fn apply_index_facts(totals: &mut ImportTotals, facts: Option<crate::ImportIndexFacts>) {
+    if let Some(facts) = facts {
+        totals.current_indexed_sessions = Some(facts.current_sessions);
+        totals.index_delta = facts.delta;
     }
 }
 

--- a/crates/ctx-history-ingest-application/src/lifecycle_tests.rs
+++ b/crates/ctx-history-ingest-application/src/lifecycle_tests.rs
@@ -258,6 +258,7 @@ fn publication(receipt: SourceBackedRefreshReceipt) -> IngestPublication {
         pinned_generation: receipt.published_generation.clone(),
         policy_schema_hash: Some("policy-v1".to_owned()),
         catalog_content: std::collections::BTreeMap::new(),
+        index_facts: None,
         receipt: Some(receipt),
     }
 }

--- a/crates/ctx-history-ingest-application/src/outcome.rs
+++ b/crates/ctx-history-ingest-application/src/outcome.rs
@@ -4,7 +4,7 @@ use ctx_history_capture_model::{ProviderImportSummary, ProviderSource};
 use ctx_history_core::CaptureProvider;
 use ctx_history_refresh::{ExplicitSourceCatalogAuthority, SourceBackedRefreshCurrent};
 
-use crate::{HistorySourcePluginSource, ImportTotals, SourceStats};
+use crate::{HistorySourcePluginSource, ImportIndexFacts, ImportTotals, SourceStats};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IngestStatus {
@@ -315,5 +315,6 @@ pub struct IngestPublication {
     pub pinned_generation: String,
     pub policy_schema_hash: Option<String>,
     pub catalog_content: std::collections::BTreeMap<String, (bool, bool)>,
+    pub index_facts: Option<ImportIndexFacts>,
     pub receipt: Option<ctx_history_refresh::SourceBackedRefreshReceipt>,
 }

--- a/crates/ctx-history-ingest-application/src/totals.rs
+++ b/crates/ctx-history-ingest-application/src/totals.rs
@@ -3,6 +3,48 @@ use ctx_history_capture_model::{ProviderImportSummary, ProviderImportWorkResult}
 use crate::SourceStats;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ImportIndexDelta {
+    pub sessions: i64,
+    pub searchable_events: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ImportIndexFacts {
+    pub current_sessions: u64,
+    pub delta: Option<ImportIndexDelta>,
+}
+
+impl ImportIndexFacts {
+    pub fn from_cardinalities(
+        current_sessions: u64,
+        current_searchable_events: u64,
+        previous: Option<(u64, u64)>,
+    ) -> Self {
+        let delta = previous.and_then(|(previous_sessions, previous_searchable_events)| {
+            Some(ImportIndexDelta {
+                sessions: signed_count_delta(current_sessions, previous_sessions)?,
+                searchable_events: signed_count_delta(
+                    current_searchable_events,
+                    previous_searchable_events,
+                )?,
+            })
+        });
+        Self {
+            current_sessions,
+            delta,
+        }
+    }
+}
+
+fn signed_count_delta(current: u64, previous: u64) -> Option<i64> {
+    if current >= previous {
+        i64::try_from(current - previous).ok()
+    } else {
+        i64::try_from(previous - current).ok()?.checked_neg()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImportOutcome {
     Success,
     Failure,
@@ -63,8 +105,9 @@ impl ImportFailureType {
     }
 }
 
-/// Typed outcome totals. Presentation layers decide which fields are rendered;
-/// these facts do not imply a per-record or per-run Core delta.
+/// Typed outcome totals. `index_delta` is the only explicit Core cardinality
+/// delta; imported, skipped, source, and current-generation counters do not
+/// imply a per-record or per-run delta.
 #[derive(Debug, Clone, Default)]
 pub struct ImportTotals {
     pub per_run_counts_available: bool,
@@ -83,7 +126,9 @@ pub struct ImportTotals {
     pub skipped: usize,
     pub failed: usize,
     pub current_source_count: Option<usize>,
+    pub current_indexed_sessions: Option<u64>,
     pub current_indexed_documents: Option<u64>,
+    pub index_delta: Option<ImportIndexDelta>,
     pub current_complete_records: Option<u64>,
     pub current_retained_records: Option<u64>,
     pub current_rejected_records: Option<u64>,
@@ -189,6 +234,39 @@ impl ImportTotals {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn index_facts_omit_a_cold_or_unrepresentable_delta() {
+        assert_eq!(
+            ImportIndexFacts::from_cardinalities(3, 8, None),
+            ImportIndexFacts {
+                current_sessions: 3,
+                delta: None,
+            }
+        );
+        assert_eq!(
+            ImportIndexFacts::from_cardinalities(u64::MAX, 8, Some((0, 7))).delta,
+            None
+        );
+    }
+
+    #[test]
+    fn index_facts_report_positive_zero_and_negative_net_change() {
+        for (current, previous, expected) in [
+            ((3, 8), (1, 4), (2, 4)),
+            ((3, 8), (3, 8), (0, 0)),
+            ((1, 4), (3, 8), (-2, -4)),
+        ] {
+            let facts = ImportIndexFacts::from_cardinalities(current.0, current.1, Some(previous));
+            assert_eq!(
+                facts.delta,
+                Some(ImportIndexDelta {
+                    sessions: expected.0,
+                    searchable_events: expected.1,
+                })
+            );
+        }
+    }
 
     #[test]
     fn aggregate_outcomes_preserve_machine_compatibility_and_genuine_failures() {

--- a/crates/ctx-history-ingest-application/tests/contracts/import_change_reporting.rs
+++ b/crates/ctx-history-ingest-application/tests/contracts/import_change_reporting.rs
@@ -197,10 +197,31 @@ fn codex_source(message: &str) -> String {
     .collect()
 }
 
-fn import_codex(temp: &TempDir) -> Value {
+fn codex_response_item(id: &str, timestamp: &str, message: &str) -> String {
+    format!(
+        "{}\n",
+        serde_json::to_string(&json!({
+            "timestamp": timestamp,
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "id": id,
+                "role": "user",
+                "content": [{
+                    "type": "input_text",
+                    "text": message
+                }]
+            }
+        }))
+        .unwrap()
+    )
+}
+
+fn import_codex_with_selection(temp: &TempDir, selection: &[&str]) -> Value {
     let events_path = temp.path().join("analytics.jsonl");
-    let output = isolated_ctx(temp)
-        .args(["import", "--all"])
+    let mut command = isolated_ctx(temp);
+    command.arg("import").args(selection);
+    let output = command
         .args(["--no-daemon", "--format=json", "--progress", "none"])
         .env("CTX_ANALYTICS_ENABLED", "true")
         .env("CTX_ANALYTICS_DEBUG", "1")
@@ -220,6 +241,14 @@ fn import_codex(temp: &TempDir) -> Value {
         String::from_utf8_lossy(&output.stderr)
     );
     serde_json::from_slice(&output.stdout).unwrap()
+}
+
+fn import_codex(temp: &TempDir) -> Value {
+    import_codex_with_selection(temp, &["--provider", "codex"])
+}
+
+fn import_all_codex(temp: &TempDir) -> Value {
+    import_codex_with_selection(temp, &["--all"])
 }
 
 fn assert_change(report: &Value, expected: &str) {
@@ -261,11 +290,16 @@ fn assert_new_generation(report: &Value, prior_generation: &str) -> String {
 fn assert_current_generation(
     report: &Value,
     source_count: u64,
+    indexed_sessions: u64,
     indexed_documents: u64,
     rejected_records: u64,
 ) {
     assert_eq!(
         report["totals"]["current_source_count"], source_count,
+        "{report:#}"
+    );
+    assert_eq!(
+        report["totals"]["current_indexed_sessions"], indexed_sessions,
         "{report:#}"
     );
     assert_eq!(
@@ -319,6 +353,21 @@ fn assert_current_generation(
     assert!(report["totals"]["rejections"].is_object(), "{report:#}");
 }
 
+fn assert_index_delta(report: &Value, sessions: i64, searchable_events: i64) {
+    assert_eq!(
+        report["totals"]["index_delta"]["sessions"], sessions,
+        "{report:#}"
+    );
+    assert_eq!(
+        report["totals"]["index_delta"]["searchable_events"], searchable_events,
+        "{report:#}"
+    );
+    assert!(
+        report["sources"][0].get("index_delta").is_none(),
+        "run-level index delta leaked into a source row: {report:#}"
+    );
+}
+
 fn latest_source_refresh_properties(temp: &TempDir) -> serde_json::Map<String, Value> {
     let event = read_analytics_events(&temp.path().join("analytics.jsonl"))
         .last()
@@ -341,20 +390,20 @@ fn latest_source_refresh_properties(temp: &TempDir) -> serde_json::Map<String, V
 #[test]
 fn codex_reimport_rebuilds_from_provider_source() {
     let temp = tempdir();
-    let _daemon = start_source_refresh_daemon(&temp);
     let source_root = home_root(&temp).join(".codex/sessions");
     let source = source_root.join("2026/07/23/rollout-2026-07-23T01-00-00-source-authority.jsonl");
     fs::create_dir_all(source.parent().unwrap()).unwrap();
     fs::write(&source, codex_source("ctxsupersededtoken")).unwrap();
+    let _daemon = start_source_refresh_daemon(&temp);
 
-    let initial = import_codex(&temp);
+    let initial = import_all_codex(&temp);
     let initial_change = initial["sources"][0]["change"]
         .as_str()
         .expect("initial change classification");
     assert!(matches!(initial_change, "changed" | "no_op"), "{initial:#}");
     assert_change(&initial, initial_change);
     assert_eq!(initial["outcome"], "success", "{initial:#}");
-    assert_current_generation(&initial, 1, 1, 0);
+    assert_current_generation(&initial, 1, 1, 1, 0);
     assert_eq!(
         initial["sources"][0]["generation_changed"],
         initial_change == "changed",
@@ -376,10 +425,11 @@ fn codex_reimport_rebuilds_from_provider_source() {
     assert!(initial_analytics.get("provider").is_none());
     assert!(initial_analytics.get("events_bucket").is_none());
     assert!(initial_analytics.get("rejections_bucket").is_none());
-    let unchanged = import_codex(&temp);
+    let unchanged = import_all_codex(&temp);
     assert_change(&unchanged, "no_op");
     assert_eq!(unchanged["outcome"], "success", "{unchanged:#}");
-    assert_current_generation(&unchanged, 1, 1, 0);
+    assert_current_generation(&unchanged, 1, 1, 1, 0);
+    assert_index_delta(&unchanged, 0, 0);
     assert_eq!(
         unchanged["sources"][0]["previous_generation"],
         initial_generation
@@ -390,6 +440,19 @@ fn codex_reimport_rebuilds_from_provider_source() {
     );
     assert_eq!(unchanged["sources"][0]["generation_changed"], false);
     assert_eq!(latest_source_refresh_properties(&temp)["change"], "no_op");
+
+    let mut source_file = fs::OpenOptions::new().append(true).open(&source).unwrap();
+    source_file
+        .write_all(
+            codex_response_item("message-two", "2026-07-23T01:00:02Z", "ctxappendtoken").as_bytes(),
+        )
+        .unwrap();
+    source_file.sync_all().unwrap();
+    let appended = import_all_codex(&temp);
+    assert_eq!(appended["outcome"], "success", "{appended:#}");
+    assert_current_generation(&appended, 1, 1, 2, 0);
+    assert_index_delta(&appended, 0, 1);
+    let appended_generation = assert_new_generation(&appended, &initial_generation);
 
     let rewritten_source = fs::read_to_string(&source)
         .unwrap()
@@ -402,10 +465,11 @@ fn codex_reimport_rebuilds_from_provider_source() {
     source_file.write_all(rewritten_source.as_bytes()).unwrap();
     source_file.sync_all().unwrap();
 
-    let replay = import_codex(&temp);
+    let replay = import_all_codex(&temp);
     assert_eq!(replay["outcome"], "success", "{replay:#}");
-    assert_current_generation(&replay, 1, 1, 0);
-    let replay_generation = assert_new_generation(&replay, &initial_generation);
+    assert_current_generation(&replay, 1, 1, 2, 0);
+    assert_index_delta(&replay, 0, 0);
+    let replay_generation = assert_new_generation(&replay, &appended_generation);
     let search = json_output(isolated_ctx(&temp).args([
         "search",
         "ctxreplacementtext",
@@ -440,12 +504,13 @@ fn codex_reimport_rebuilds_from_provider_source() {
         fs::read_to_string(&source).unwrap()
     );
     fs::write(&source, with_rejection).unwrap();
-    let rejected = import_codex(&temp);
+    let rejected = import_all_codex(&temp);
     assert_eq!(
         rejected["outcome"], "completed_with_rejections",
         "{rejected:#}"
     );
-    assert_current_generation(&rejected, 1, 1, 1);
+    assert_current_generation(&rejected, 1, 1, 2, 1);
+    assert_index_delta(&rejected, 0, 0);
     let rejected_generation = assert_new_generation(&rejected, &replay_generation);
     assert_eq!(rejected["totals"]["rejected_records"], 1);
     assert_eq!(rejected["totals"]["sources_completed_with_rejections"], 1);
@@ -459,15 +524,16 @@ fn codex_reimport_rebuilds_from_provider_source() {
     assert!(rejection_analytics.get("source_mode").is_none());
 
     fs::remove_file(&source).unwrap();
-    let mut deleted = import_codex(&temp);
+    let mut deleted = import_all_codex(&temp);
     for _ in 1..3 {
         if deleted["totals"]["current_source_count"] == 0 {
             break;
         }
-        deleted = import_codex(&temp);
+        deleted = import_all_codex(&temp);
     }
     assert_eq!(deleted["outcome"], "success", "{deleted:#}");
-    assert_current_generation(&deleted, 0, 0, 0);
+    assert_current_generation(&deleted, 0, 0, 0, 0);
+    assert_index_delta(&deleted, -1, -2);
     assert_change(&deleted, "changed");
     assert_eq!(deleted["sources"][0]["generation_changed"], true);
     assert_ne!(
@@ -481,7 +547,6 @@ fn codex_reimport_rebuilds_from_provider_source() {
 #[test]
 fn discovered_codex_session_tree_reports_admitted_source_format() {
     let tree_temp = tempdir();
-    let _daemon = start_source_refresh_daemon(&tree_temp);
     let tree = home_root(&tree_temp).join(".codex/sessions");
     fs::create_dir_all(tree.join("2026/07/23")).unwrap();
     let compressed =
@@ -491,6 +556,7 @@ fn discovered_codex_session_tree_reports_admitted_source_format() {
         compressed,
     )
     .unwrap();
+    let _daemon = start_source_refresh_daemon(&tree_temp);
     let tree_report = import_codex(&tree_temp);
     assert_eq!(tree_report["outcome"], "success", "{tree_report:#}");
     assert_eq!(
@@ -508,6 +574,7 @@ fn discovered_codex_session_tree_reports_admitted_source_format() {
     ));
     assert!(tree_report["totals"].get("imported_sessions").is_none());
     assert!(tree_report["totals"].get("imported_events").is_none());
+    assert_eq!(tree_report["totals"]["current_indexed_sessions"], 1);
     assert_eq!(tree_report["totals"]["current_indexed_documents"], 1);
 
     let unchanged = import_codex(&tree_temp);
@@ -519,5 +586,7 @@ fn discovered_codex_session_tree_reports_admitted_source_format() {
     );
     assert_eq!(unchanged["sources"][0]["certified_source_count"], 1);
     assert_eq!(unchanged["sources"][0]["published_generation"], generation);
+    assert_eq!(unchanged["totals"]["current_indexed_sessions"], 1);
     assert_eq!(unchanged["totals"]["current_indexed_documents"], 1);
+    assert_index_delta(&unchanged, 0, 0);
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -504,6 +504,15 @@ Import results report `change: changed|no_op` independently from import and
 skip counters. `change: changed` remains truthful even when a source projects
 to the same stable event identities.
 
+After a manual re-import, the human receipt reports signed `Sessions` and
+`Searchable events` under `Net index change`, followed by their current totals
+under `Current index`. Positive, zero, and negative values are net changes in
+the exact Core publication, not newly parsed or imported records. The first
+import shows current totals without a delta because there is no preceding Core
+generation to compare. If concurrent publication has already retired that
+preceding generation, ctx omits the delta rather than guessing. Background
+refresh and setup output do not gain this manual-import receipt section.
+
 In automatic mode, `import` may start the persistent daemon and uses its
 source-refresh endpoint for foreground Core publication. In manual mode, an
 explicit import may start the same Core engine as a finite worker; it waits for

--- a/docs/contracts/json.md
+++ b/docs/contracts/json.md
@@ -496,6 +496,15 @@ up to five rejection details when every content record was rejected.
 changed; it is independent of insert counters. A deterministic source
 replacement can therefore report `change: "changed"`, zero newly imported
 events, and skipped existing events while reconciling those rows in place.
+Run-level `totals` also includes `current_indexed_sessions`. On a manual import
+with a safely retained preceding Core generation, it includes an additive
+`index_delta` object whose signed `sessions` and `searchable_events` members
+report the net cardinality change in that exact Core publication. The object is
+omitted on the first import and whenever the preceding generation is no longer
+available; omission means unknown, not zero. A no-op reports zero deltas, while
+a same-cardinality rewrite may report `change: "changed"` with zero deltas.
+These are generation-wide index facts, not `imported_*` work counters, and are
+not repeated on individual source rows.
 Rejection details are exposed as `rejections`
 (bounded to five entries); `failed_sources` remains the count of source-level
 failures. `sources_completed_with_rejections` counts sources that committed


### PR DESCRIPTION
## Summary

- show the exact current indexed session total after ctx import
- when a prior Core generation is safely available, show signed net changes for indexed sessions and searchable events
- omit the delta on the first cold import or when the predecessor cannot be measured, without failing an otherwise successful import
- keep changed/no-op status independent from cardinality deltas and expose the new data only for explicit manual imports
- add the same optional run-level fields to the version 2 JSON receipt and document their semantics

## Testing

- scripts/bazel-affected.sh origin/main — 62/62 affected targets passed on the final rebased commit
- focused formatting, CLI unit, ingest unit, import mutation contract, and cold import contract suite — 5/5 targets passed
- independent final code review — no actionable findings

Discussion: https://github.com/ctxrs/ctx/discussions/175