### PR TITLE
fix(history): simplify SQLite terminal publication

### DIFF
--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/sqlite_selected.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/sqlite_selected.rs
@@ -1,21 +1,25 @@
 use std::{fs, path::Path};
 
-use ctx_history_core::{CaptureProvider, TypedKey};
+use ctx_history_core::{CaptureProvider, CoreRecord, TypedKey};
 use ctx_history_index::{VerifiedIndex, WriterOptions};
-use rusqlite::Connection;
+use rusqlite::{params, Connection};
 
 use crate::{provider_sources::provider_source_for_path, test_support_paths};
 use ctx_history_capture_composition::{
     refresh_source_backed_generation, register_goose_source_backed_route,
-    register_landed_source_backed_route_with_data_root, SourceBackedCoordinatorError,
-    SourceBackedProviderRegistry, SourceBackedRouteErrorKind, SourceBackedRouteSelection,
+    register_landed_source_backed_route_with_data_root, register_warp_source_backed_route,
+    SourceBackedCoordinatorError, SourceBackedProviderRegistry, SourceBackedRefreshReceipt,
+    SourceBackedRouteErrorKind, SourceBackedRouteSelection,
 };
 
 #[test]
-fn goose_v15_literal_parent_and_native_identities_publish_consistently() {
+fn goose_v15_active_wal_append_preserves_identities_and_replays_exactly() {
     let temp = test_support_paths::tempdir().unwrap();
     let database = temp.path().join("sessions.db");
     let connection = Connection::open(&database).unwrap();
+    connection
+        .pragma_update(None, "journal_mode", "WAL")
+        .unwrap();
     connection
         .execute_batch(
             "create table schema_version (version integer not null);
@@ -45,10 +49,10 @@ fn goose_v15_literal_parent_and_native_identities_publish_consistently() {
                   '[{\"type\":\"toolRequest\",\"toolCall\":{\"id\":\"tool-call-exact\",\"name\":\"read_file\"}}]', 3);",
         )
         .unwrap();
-    drop(connection);
+    assert_active_wal(&database);
 
     let mut registry = SourceBackedProviderRegistry::new();
-    let source = provider_source_for_path(CaptureProvider::Goose, database);
+    let source = provider_source_for_path(CaptureProvider::Goose, database.clone());
     register_goose_source_backed_route(
         &mut registry,
         source,
@@ -60,15 +64,8 @@ fn goose_v15_literal_parent_and_native_identities_publish_consistently() {
     )
     .unwrap();
     let index = temp.path().join("index");
-    refresh_source_backed_generation(
-        &index,
-        &registry,
-        WriterOptions {
-            indexer_threads: 1,
-            memory_bytes: 15_000_000,
-        },
-    )
-    .unwrap();
+    let cold = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
+    assert_clean_refresh(&cold);
 
     let verified = VerifiedIndex::open(&index).unwrap();
     let source = verified
@@ -128,6 +125,119 @@ fn goose_v15_literal_parent_and_native_identities_publish_consistently() {
         .and_then(|value| value.pointer("/provider_native_tool_call_ids/0"))
         .and_then(serde_json::Value::as_str)
         .is_none());
+
+    connection
+        .execute(
+            "insert into messages
+                 (message_id, session_id, role, content_json, created_timestamp)
+             values (?1, ?2, ?3, ?4, ?5)",
+            params![
+                "goose-wal-append",
+                "child-session",
+                "user",
+                r#"[{"type":"text","text":"goose lifecycle wal append"}]"#,
+                4,
+            ],
+        )
+        .unwrap();
+    assert_active_wal(&database);
+
+    let changed = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
+    assert_clean_refresh(&changed);
+    assert_ne!(changed.commit.generation_id, cold.commit.generation_id);
+    let changed_record =
+        only_indexed_record(&index, CaptureProvider::Goose, "goose lifecycle wal append");
+
+    let replay = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
+    assert_clean_refresh(&replay);
+    assert_eq!(replay.commit.generation_id, changed.commit.generation_id);
+    assert_eq!(replay.sources, changed.sources);
+    assert_eq!(
+        only_indexed_record(&index, CaptureProvider::Goose, "goose lifecycle wal append",),
+        changed_record
+    );
+}
+
+#[test]
+fn warp_active_wal_update_publishes_and_then_replays_exactly() {
+    const INITIAL_PROMPT: &str = "warp sqlite oracle prompt";
+    const UPDATED_PROMPT: &str = "warp wal lifecycle update";
+
+    let temp = test_support_paths::tempdir().unwrap();
+    let provider = temp.path().join("provider");
+    fs::create_dir(&provider).unwrap();
+    let database = provider.join("warp.sqlite");
+    fs::copy(
+        test_support_paths::capture_repo_root()
+            .join("tests/fixtures/provider-history/warp/v1/warp.sqlite"),
+        &database,
+    )
+    .unwrap();
+    let connection = Connection::open(&database).unwrap();
+    connection
+        .pragma_update(None, "journal_mode", "WAL")
+        .unwrap();
+    connection
+        .execute(
+            "update agent_tasks set last_modified_at = ?1 where task_id = ?2",
+            params!["2026-06-24 12:00:06", "warp-task-root"],
+        )
+        .unwrap();
+    assert_active_wal(&database);
+
+    let mut registry = SourceBackedProviderRegistry::new();
+    let source = provider_source_for_path(CaptureProvider::Warp, database.clone());
+    register_warp_source_backed_route(
+        &mut registry,
+        source,
+        SourceBackedRouteSelection::Automatic,
+        &temp.path().join("data-root"),
+        "linux:stable:gui",
+        None,
+    )
+    .unwrap();
+    let index = temp.path().join("index");
+    let cold = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
+    assert_clean_refresh(&cold);
+    only_indexed_record(&index, CaptureProvider::Warp, INITIAL_PROMPT);
+
+    let (task_id, mut task) = connection
+        .query_row(
+            "select task_id, task from agent_tasks where task_id = ?1",
+            ["warp-task-root"],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?)),
+        )
+        .unwrap();
+    replace_once(
+        &mut task,
+        INITIAL_PROMPT.as_bytes(),
+        UPDATED_PROMPT.as_bytes(),
+    );
+    connection
+        .execute(
+            "update agent_tasks set task = ?1, last_modified_at = ?2 where task_id = ?3",
+            params![task, "2026-06-24 12:00:07", task_id],
+        )
+        .unwrap();
+    assert_active_wal(&database);
+
+    let changed = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
+    assert_clean_refresh(&changed);
+    assert_ne!(changed.commit.generation_id, cold.commit.generation_id);
+    assert_eq!(
+        changed.commit.indexed_documents,
+        cold.commit.indexed_documents
+    );
+    let changed_record = only_indexed_record(&index, CaptureProvider::Warp, UPDATED_PROMPT);
+
+    let replay = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
+    assert_clean_refresh(&replay);
+    assert_eq!(replay.commit.generation_id, changed.commit.generation_id);
+    assert_eq!(replay.sources, changed.sources);
+    assert_eq!(
+        only_indexed_record(&index, CaptureProvider::Warp, UPDATED_PROMPT),
+        changed_record
+    );
 }
 
 #[test]
@@ -177,4 +287,64 @@ fn kiro_schema_failure_reports_cleanup_failure_without_staging_leftovers() {
 
 fn assert_directory_empty(path: &Path) {
     assert_eq!(fs::read_dir(path).unwrap().count(), 0);
+}
+
+fn writer_options() -> WriterOptions {
+    WriterOptions {
+        indexer_threads: 1,
+        memory_bytes: 15_000_000,
+    }
+}
+
+fn assert_clean_refresh(receipt: &SourceBackedRefreshReceipt) {
+    assert!(
+        receipt.failed_routes.is_empty(),
+        "unexpected route failures: {:?}",
+        receipt.failed_routes
+    );
+    assert!(receipt.logical_source_failures.is_empty());
+    assert_eq!(receipt.successful_route_ids.len(), 1);
+}
+
+fn assert_active_wal(database: &Path) {
+    let mut wal = database.as_os_str().to_os_string();
+    wal.push("-wal");
+    assert!(Path::new(&wal).is_file(), "active WAL sidecar is missing");
+}
+
+fn replace_once(bytes: &mut [u8], original: &[u8], replacement: &[u8]) {
+    assert_eq!(original.len(), replacement.len());
+    let offset = {
+        let mut matches = bytes
+            .windows(original.len())
+            .enumerate()
+            .filter(|(_, candidate)| *candidate == original)
+            .map(|(offset, _)| offset);
+        let offset = matches.next().expect("fixture prompt is missing");
+        assert!(matches.next().is_none(), "fixture prompt is ambiguous");
+        offset
+    };
+    bytes[offset..offset + replacement.len()].copy_from_slice(replacement);
+}
+
+fn only_indexed_record(index_root: &Path, provider: CaptureProvider, marker: &str) -> CoreRecord {
+    let index = VerifiedIndex::open(index_root).unwrap();
+    let records = super::lexical_test_support::search_event_candidates(&index, marker, 16)
+        .into_iter()
+        .filter_map(|candidate| {
+            index
+                .core_record_by_id(candidate.event.event_id.as_uuid())
+                .unwrap()
+        })
+        .filter(|record| {
+            record.source.provider() == provider.as_str()
+                && record.content.meaningful_text().contains(marker)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        records.len(),
+        1,
+        "expected one indexed {provider} record containing {marker:?}"
+    );
+    records.into_iter().next().unwrap()
 }

--- a/crates/ctx-history-providers-sqlite-logical/src/lib.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/lib.rs
@@ -137,7 +137,7 @@ pub(crate) mod provider_sources {
         SqliteArtifactKind, SqliteCleanupStatus, SqliteFailurePhase, SqliteLogicalSnapshot,
         SqliteRetryDecision, SqliteSourceAccessError, SqliteSourceDirectoryAuthority,
         SqliteSourceErrorComposition, SqliteSourceEvidence, SqliteSourceProgressError,
-        SqliteSourceReadSnapshot,
+        SqliteSourceReadSnapshot, SqliteSourceTerminalFence,
     };
 }
 

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed.rs
@@ -37,7 +37,7 @@ use crate::{
         retain_sqlite_source_directory_authority, sqlite_retry_decision, SqliteArtifactKind,
         SqliteCleanupStatus, SqliteFailurePhase, SqliteLogicalSnapshot, SqliteRetryDecision,
         SqliteSourceAccessError, SqliteSourceDirectoryAuthority, SqliteSourceErrorComposition,
-        SqliteSourceProgressError, SqliteSourceReadSnapshot,
+        SqliteSourceProgressError, SqliteSourceReadSnapshot, SqliteSourceTerminalFence,
     },
     CaptureError, MAX_PROVIDER_SQLITE_VALUE_BYTES,
 };
@@ -154,6 +154,8 @@ pub(crate) const fn opencode_family_source_backed_registrations(
 pub(crate) struct OpenCodeSourceBackedScan {
     pub(crate) source: SourceKey,
     pub(crate) certificate: CertifiedSource,
+    terminal_fence: SqliteSourceTerminalFence,
+    #[cfg_attr(not(test), allow(dead_code))]
     bounds: OpenCodeScanBounds,
 }
 
@@ -216,7 +218,9 @@ struct OpenCodeLogicalObservation {
 
 #[derive(Debug)]
 struct OpenCodeAuthorizedSnapshot {
+    #[cfg_attr(not(test), allow(dead_code))]
     source_root: ProviderSourceRoot,
+    #[cfg_attr(not(test), allow(dead_code))]
     sqlite_authority: SqliteSourceDirectoryAuthority,
     sqlite_snapshot: SqliteSourceReadSnapshot,
 }
@@ -325,11 +329,12 @@ fn scan_pinned_source_with_scratch_limit(
         Ok(working) => working,
         Err(error) => return Err(adapter::abort_opencode_snapshot(sqlite_snapshot, error)),
     };
-    sqlite_snapshot.finish()?;
+    let terminal_fence = sqlite_snapshot.seal()?;
     let certificate = working.logical_snapshot.certify(working.source.clone())?;
     Ok(OpenCodeSourceBackedScan {
         source: working.source,
         certificate,
+        terminal_fence,
         bounds: working.bounds,
     })
 }

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/adapter.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/adapter.rs
@@ -8,10 +8,6 @@ use std::{
 use ctx_history_core::{CaptureProvider, SourceAnchorScope, SourceKey};
 use sha2::{Digest, Sha256};
 
-use super::ordering::{
-    OPENCODE_HYDRATION_BATCH_BYTES, OPENCODE_HYDRATION_BATCH_ROWS,
-    OPENCODE_HYDRATION_SINGLETON_MAX_BYTES,
-};
 use super::{
     observe_logical_source_with_progress_scoped,
     open_root_authorized_snapshot_retained_with_progress,
@@ -30,8 +26,8 @@ use crate::{
         SourceBackedRouteError, SourceBackedRouteErrorKind, SourceBackedRouteResult,
     },
     provider_sources::{
-        SqliteSourceAccessError, SqliteSourceDirectoryAuthority, SqliteSourceEvidence,
-        SqliteSourceReadSnapshot,
+        SqliteSourceAccessError, SqliteSourceEvidence, SqliteSourceReadSnapshot,
+        SqliteSourceTerminalFence,
     },
     CaptureError, ProviderSource,
 };
@@ -57,56 +53,11 @@ pub enum OpenCodeTreeAuthority {
 
 pub struct OpenCodeDocumentLeaf {
     observation: OpenCodeLogicalObservation,
-    source_root: ProviderSourceRoot,
-    sqlite_authority: SqliteSourceDirectoryAuthority,
     snapshot: Mutex<Option<SqliteSourceReadSnapshot>>,
-    terminal_revalidate:
-        Box<dyn Fn() -> Result<(), SqliteSourceAccessError> + Send + Sync + 'static>,
-    work: Mutex<OpenCodeSqliteWorkCounters>,
+    terminal_fence: Mutex<Option<SqliteSourceTerminalFence>>,
 }
 
 type OpenCodeDocumentTree = CompleteDocumentTree<OpenCodeDocumentLeaf, OpenCodeTreeAuthority>;
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(super) struct OpenCodeSqliteWorkCounters {
-    pub(super) snapshot_opens: u64,
-    pub(super) immutable_snapshot_opens: u64,
-    pub(super) copied_snapshot_opens: u64,
-    pub(super) source_bytes_copied: u64,
-    pub(super) schema_probe_passes: u64,
-    pub(super) schema_event_validation_traversals: u64,
-    pub(super) logical_fingerprint_passes: u64,
-    pub(super) logical_row_traversals: u64,
-    pub(super) projection_passes: u64,
-    pub(super) logical_rows_projected: u64,
-    pub(super) documents_staged: u64,
-    pub(super) max_buffered_documents: u64,
-    pub(super) session_rows_scanned: u64,
-    pub(super) session_metadata_loads: u64,
-    pub(super) max_buffered_session_metadata: u64,
-    pub(super) max_session_ancestry_depth: u64,
-    pub(super) fallback_payload_hydrations: u64,
-    pub(super) max_buffered_payload_rows: u64,
-    pub(super) fallback_disk_sort: bool,
-    pub(super) fallback_sort_rows: u64,
-    pub(super) fallback_scratch_bytes: u64,
-    pub(super) ordering_data_statements: u64,
-    pub(super) ordering_sort_key_batches: u64,
-    pub(super) ordering_hydration_batches: u64,
-    pub(super) max_sort_key_batch_rows: u64,
-    pub(super) max_buffered_payload_bytes: u64,
-    pub(super) exact_replays: u64,
-    pub(super) terminal_fences: u64,
-    pub(super) terminal_revalidations: u64,
-    pub(super) active_snapshots: u64,
-    pub(super) max_active_snapshots: u64,
-}
-
-#[cfg(test)]
-thread_local! {
-    static LAST_WORK_COUNTERS: std::cell::RefCell<Option<OpenCodeSqliteWorkCounters>> =
-        const { std::cell::RefCell::new(None) };
-}
 
 impl<B: crate::LogicalSqliteRuntimeBinding> ReplacementDocumentTree
     for OpenCodeDocumentTreeAdapter<B>
@@ -194,32 +145,7 @@ impl<B: crate::LogicalSqliteRuntimeBinding> ReplacementDocumentTree
                 "OpenCode-family projection did not match its logical observation",
             ));
         }
-        {
-            let mut work = leaf
-                .work
-                .lock()
-                .map_err(|_| source_internal("OpenCode-family work counter lock was poisoned"))?;
-            work.projection_passes = 1;
-            work.logical_row_traversals = 1;
-            work.logical_rows_projected = scan.certificate.counts().complete_records;
-            work.documents_staged = scan.certificate.counts().indexed_documents;
-            work.max_buffered_documents =
-                u64::from(scan.certificate.counts().indexed_documents != 0);
-            work.session_rows_scanned = scan.bounds.session_rows_scanned;
-            work.session_metadata_loads = scan.bounds.session_metadata_loads;
-            work.max_buffered_session_metadata = scan.bounds.max_buffered_session_metadata;
-            work.max_session_ancestry_depth = scan.bounds.max_session_ancestry_depth;
-            work.fallback_payload_hydrations = scan.bounds.fallback_payload_hydrations;
-            work.max_buffered_payload_rows = scan.bounds.max_buffered_payload_rows;
-            work.fallback_disk_sort = scan.bounds.fallback_disk_sort;
-            work.fallback_sort_rows = scan.bounds.fallback_sort_rows;
-            work.fallback_scratch_bytes = scan.bounds.fallback_scratch_bytes;
-            work.ordering_data_statements = scan.bounds.ordering_data_statements;
-            work.ordering_sort_key_batches = scan.bounds.ordering_sort_key_batches;
-            work.ordering_hydration_batches = scan.bounds.ordering_hydration_batches;
-            work.max_sort_key_batch_rows = scan.bounds.max_sort_key_batch_rows;
-            work.max_buffered_payload_bytes = scan.bounds.max_buffered_payload_bytes;
-        }
+        install_terminal_fence(leaf, scan.terminal_fence)?;
         let observation = scan.certificate.observation().clone();
         Ok(DocumentSourceTerminal {
             source: scan.source,
@@ -243,24 +169,18 @@ impl<B: crate::LogicalSqliteRuntimeBinding> ReplacementDocumentTree
                     ));
                 };
                 let leaf = &observed.provider_leaf;
-                let exact_replay = if let Some(snapshot) = leaf
+                if let Some(snapshot) = leaf
                     .snapshot
                     .lock()
                     .map_err(|_| source_internal("OpenCode-family snapshot lock was poisoned"))?
                     .take()
                 {
-                    snapshot
-                        .finish()
-                        .map_err(|error| route_error(error.into()))?;
-                    true
-                } else {
-                    false
-                };
-                leaf.source_root
-                    .revalidate_same_object()
+                    let fence = snapshot.seal().map_err(|error| route_error(error.into()))?;
+                    install_terminal_fence(leaf, fence)?;
+                }
+                retained_terminal_fence(leaf)?
+                    .revalidate()
                     .map_err(|error| route_error(error.into()))?;
-                (leaf.terminal_revalidate)().map_err(|error| route_error(error.into()))?;
-                finalize_work_counters(leaf, exact_replay)?;
                 Ok(tree.tree_fingerprint)
             }
             OpenCodeTreeAuthority::Missing {
@@ -369,7 +289,6 @@ fn observe_present_document_tree_with_progress(
         Ok(observation) => observation,
         Err(error) => return Err(abort_authorized_snapshot(authorized, error)),
     };
-    let terminal_revalidate = authorized.sqlite_snapshot.terminal_revalidator();
     let leaf_fingerprint = DocumentLeafFingerprint::new(admitted_leaf_fingerprint(
         &observation.source,
         authorized.sqlite_snapshot.evidence(),
@@ -377,7 +296,6 @@ fn observe_present_document_tree_with_progress(
     let replay_from_frontier = authorized
         .sqlite_snapshot
         .admitted_revision_is_replay_safe();
-    let schema_event_validation_traversals = observation.schema.event_validation_traversals;
     let tree_fingerprint = leaf_fingerprint.as_bytes();
     Ok(CompleteDocumentTree::new(
         tree_fingerprint,
@@ -385,15 +303,8 @@ fn observe_present_document_tree_with_progress(
             leaf_fingerprint,
             OpenCodeDocumentLeaf {
                 observation,
-                source_root: authorized.source_root,
-                sqlite_authority: authorized.sqlite_authority,
                 snapshot: Mutex::new(Some(authorized.sqlite_snapshot)),
-                terminal_revalidate,
-                work: Mutex::new(OpenCodeSqliteWorkCounters {
-                    schema_probe_passes: 1,
-                    schema_event_validation_traversals,
-                    ..OpenCodeSqliteWorkCounters::default()
-                }),
+                terminal_fence: Mutex::new(None),
             },
             replay_from_frontier,
         )],
@@ -480,86 +391,30 @@ fn revalidate_missing_database(
     Ok(())
 }
 
-fn finalize_work_counters(
+fn install_terminal_fence(
     leaf: &OpenCodeDocumentLeaf,
-    exact_replay: bool,
-) -> SourceBackedRouteResult<OpenCodeSqliteWorkCounters> {
-    let snapshot = leaf.sqlite_authority.snapshot_counters();
-    let mut work = leaf
-        .work
+    fence: SqliteSourceTerminalFence,
+) -> SourceBackedRouteResult<()> {
+    let mut terminal_fence = leaf
+        .terminal_fence
         .lock()
-        .map_err(|_| source_internal("OpenCode-family work counter lock was poisoned"))?;
-    work.immutable_snapshot_opens = snapshot.immutable_snapshot_opens();
-    work.copied_snapshot_opens = snapshot.copied_snapshot_opens();
-    work.snapshot_opens = work
-        .immutable_snapshot_opens
-        .checked_add(work.copied_snapshot_opens)
-        .ok_or_else(|| source_internal("OpenCode-family snapshot open count overflowed"))?;
-    work.source_bytes_copied = snapshot.source_bytes_copied();
-    work.terminal_fences = snapshot.terminal_fences();
-    work.terminal_revalidations = snapshot.terminal_revalidations();
-    work.active_snapshots = snapshot.active_snapshots();
-    work.max_active_snapshots = snapshot.max_active_snapshots();
-    work.exact_replays = u64::from(exact_replay);
-    let counters = *work;
-    if counters.snapshot_opens != 1
-        || counters.immutable_snapshot_opens != 0
-        || counters.copied_snapshot_opens != 1
-        || counters.schema_probe_passes != 1
-        || counters.logical_fingerprint_passes != 0
-        || counters.terminal_fences != 1
-        || counters.terminal_revalidations < 2
-        || counters.active_snapshots != 0
-        || counters.max_active_snapshots != 1
-        || counters.projection_passes + counters.exact_replays != 1
-        || counters.max_buffered_documents > 1
-        || counters.max_buffered_session_metadata > 1
-        || counters.max_session_ancestry_depth > 64
-        || counters.max_buffered_payload_rows > OPENCODE_HYDRATION_BATCH_ROWS as u64
-        || counters.max_sort_key_batch_rows > OPENCODE_HYDRATION_BATCH_ROWS as u64
-        || counters.max_buffered_payload_bytes > OPENCODE_HYDRATION_SINGLETON_MAX_BYTES
-        || (counters.max_buffered_payload_bytes > OPENCODE_HYDRATION_BATCH_BYTES
-            && counters.max_buffered_payload_rows != 1)
-        || counters.session_metadata_loads > counters.session_rows_scanned
-        || (counters.fallback_disk_sort
-            && counters.fallback_payload_hydrations != counters.logical_rows_projected)
-        || (!counters.fallback_disk_sort && counters.fallback_payload_hydrations != 0)
-        || (counters.fallback_disk_sort
-            && (counters.fallback_sort_rows != counters.logical_rows_projected
-                || counters.fallback_scratch_bytes == 0))
-        || (!counters.fallback_disk_sort
-            && (counters.fallback_sort_rows != 0 || counters.fallback_scratch_bytes != 0))
-        || (counters.fallback_disk_sort
-            && counters.ordering_data_statements
-                != 2_u64
-                    .saturating_add(counters.ordering_sort_key_batches)
-                    .saturating_add(counters.ordering_hydration_batches))
-        || (!counters.fallback_disk_sort
-            && (counters.ordering_data_statements != 0
-                || counters.ordering_sort_key_batches != 0
-                || counters.ordering_hydration_batches != 0
-                || counters.max_sort_key_batch_rows != 0
-                || counters.max_buffered_payload_bytes != 0))
-        || (leaf.observation.schema.message_part_indexed_streaming
-            && counters.schema_event_validation_traversals != 2)
-        || (exact_replay
-            && (counters.projection_passes != 0
-                || counters.logical_row_traversals != 0
-                || counters.logical_rows_projected != 0
-                || counters.documents_staged != 0
-                || counters.max_buffered_documents != 0))
-        || (!exact_replay
-            && (counters.projection_passes != 1
-                || counters.logical_row_traversals != 1
-                || counters.documents_staged > counters.logical_rows_projected))
-    {
+        .map_err(|_| source_internal("OpenCode-family terminal fence lock was poisoned"))?;
+    if terminal_fence.replace(fence).is_some() {
         return Err(source_internal(
-            "OpenCode-family lifecycle violated its one-snapshot bounded-work contract",
+            "OpenCode-family snapshot produced more than one terminal fence",
         ));
     }
-    #[cfg(test)]
-    LAST_WORK_COUNTERS.with(|slot| slot.replace(Some(counters)));
-    Ok(counters)
+    Ok(())
+}
+
+fn retained_terminal_fence(
+    leaf: &OpenCodeDocumentLeaf,
+) -> SourceBackedRouteResult<SqliteSourceTerminalFence> {
+    leaf.terminal_fence
+        .lock()
+        .map_err(|_| source_internal("OpenCode-family terminal fence lock was poisoned"))?
+        .clone()
+        .ok_or_else(|| source_internal("OpenCode-family snapshot did not produce a terminal fence"))
 }
 
 fn source_missing(error: &OpenCodeSourceBackedError) -> bool {
@@ -582,6 +437,12 @@ pub(super) fn route_error(error: OpenCodeSourceBackedError) -> SourceBackedRoute
     let kind = match &error {
         OpenCodeSourceBackedError::Capture(CaptureError::SourceChangedDuringCapture) => {
             SourceBackedRouteErrorKind::SourceChanged
+        }
+        OpenCodeSourceBackedError::SqliteSource(error) if error.is_snapshot_capacity_failure() => {
+            SourceBackedRouteErrorKind::Unavailable
+        }
+        OpenCodeSourceBackedError::SqliteSource(error) if error.is_systemic_resource_failure() => {
+            SourceBackedRouteErrorKind::ResourceUnavailable
         }
         OpenCodeSourceBackedError::SqliteSource(error) if error.is_source_changed() => {
             SourceBackedRouteErrorKind::SourceChanged
@@ -619,15 +480,9 @@ pub(super) fn route_error(error: OpenCodeSourceBackedError) -> SourceBackedRoute
         OpenCodeSourceBackedError::SqliteSource(error) if error.is_ctx_owned_corruption() => {
             SourceBackedRouteErrorKind::Internal
         }
-        OpenCodeSourceBackedError::SqliteSource(error) if error.is_snapshot_capacity_failure() => {
-            SourceBackedRouteErrorKind::Unavailable
-        }
         OpenCodeSourceBackedError::SqliteSource(SqliteSourceAccessError::ResourceUnavailable {
             ..
         }) => SourceBackedRouteErrorKind::ResourceUnavailable,
-        OpenCodeSourceBackedError::SqliteSource(error) if error.is_systemic_resource_failure() => {
-            SourceBackedRouteErrorKind::ResourceUnavailable
-        }
         _ => SourceBackedRouteErrorKind::InvalidSource,
     };
     SourceBackedRouteError::new(kind, error.to_string())

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/tests/sqlite_diagnostics.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/tests/sqlite_diagnostics.rs
@@ -21,6 +21,23 @@ fn snapshot_capacity_failure_is_isolated_to_the_opencode_route() {
 }
 
 #[test]
+fn terminal_change_with_resource_cleanup_failure_stays_systemic() {
+    let error = OpenCodeSourceBackedError::SqliteSource(SqliteSourceAccessError::Finalization {
+        primary: Box::new(SqliteSourceAccessError::SourceChanged),
+        cleanup: Box::new(SqliteSourceAccessError::ResourceUnavailable {
+            operation: "cleaning an OpenCode SQLite snapshot",
+            path: PathBuf::from("ctx-owned-snapshot.sqlite"),
+            source: std::io::Error::from(std::io::ErrorKind::OutOfMemory),
+        }),
+    });
+
+    assert_eq!(
+        adapter::route_error(error).kind,
+        SourceBackedRouteErrorKind::ResourceUnavailable
+    );
+}
+
+#[test]
 #[ignore = "explicit multi-gibibyte copy/open resource proof"]
 fn opencode_source_above_two_gibibytes_copies_opens_observes_and_cleans_up() {
     const ABOVE_TWO_GIB: u64 = 2 * 1024 * 1024 * 1024 + 4096;

--- a/crates/ctx-history-providers-sqlite-logical/tests/bazel/capture_facade_replay.rs
+++ b/crates/ctx-history-providers-sqlite-logical/tests/bazel/capture_facade_replay.rs
@@ -192,6 +192,12 @@ where
 }
 
 fn only_matching_event(index: &VerifiedIndex, marker: &str) -> ctx_history_index::EventRecord {
+    let mut matches = matching_events(index, marker);
+    assert_eq!(matches.len(), 1);
+    matches.remove(0)
+}
+
+fn matching_events(index: &VerifiedIndex, marker: &str) -> Vec<ctx_history_index::EventRecord> {
     let filter = CompiledSearchFilter::compile(Default::default()).unwrap();
     let queries = [marker];
     let batch = index
@@ -207,17 +213,17 @@ fn only_matching_event(index: &VerifiedIndex, marker: &str) -> ctx_history_index
         "lexical execution must complete: {:?}",
         batch.exhaustion
     );
-    let mut matches = batch
+    batch
         .candidates
         .into_iter()
-        .map(ctx_history_index::EventSearchCandidate::from)
-        .collect::<Vec<_>>();
-    assert_eq!(matches.len(), 1);
-    let winner = matches.remove(0);
-    index
-        .event_by_id(winner.event.event_id)
-        .unwrap()
-        .expect("selected lexical winner must hydrate")
+        .map(|candidate| {
+            let winner = ctx_history_index::EventSearchCandidate::from(candidate);
+            index
+                .event_by_id(winner.event.event_id)
+                .unwrap()
+                .expect("selected lexical winner must hydrate")
+        })
+        .collect()
 }
 
 fn create_deepagents_database(path: &Path, text: &str) {
@@ -329,16 +335,30 @@ fn create_zed_database(path: &Path, text: &str) {
 }
 
 #[test]
-fn unchanged_replay_finishes_progress_and_propagates_systemic_failure() {
+fn opencode_family_changed_wal_capture_then_exact_replay_finishes_progress() {
+    for provider in [
+        CaptureProvider::OpenCode,
+        CaptureProvider::Kilo,
+        CaptureProvider::MiMoCode,
+    ] {
+        assert_opencode_family_changed_wal_capture_then_exact_replay(provider);
+    }
+}
+
+fn assert_opencode_family_changed_wal_capture_then_exact_replay(provider: CaptureProvider) {
     let temp = tempfile::tempdir().unwrap();
     let data_root = tempfile::tempdir().unwrap();
-    let database = temp.path().join("source/opencode.sqlite");
-    create_opencode_database(&database);
+    let database = temp
+        .path()
+        .join("source")
+        .join(format!("{}.sqlite", provider.as_str()));
+    let writer = create_opencode_wal_database(&database, "logical SQLite facade cold capture");
+    assert_active_wal(&database);
     let index_root = temp.path().join("index");
     let mut registry = SourceBackedProviderRegistry::new();
     register_landed_source_backed_route_with_data_root(
         &mut registry,
-        provider_source_for_path(CaptureProvider::OpenCode, database),
+        provider_source_for_path(provider, database.clone()),
         SourceBackedRouteSelection::ExplicitManual,
         data_root.path(),
     )
@@ -358,14 +378,53 @@ fn unchanged_replay_finishes_progress_and_propagates_systemic_failure() {
         )
         .unwrap();
     let cold_generation = cold.commit.generation_id.clone();
-    let cold_opstamp = cold.commit.opstamp;
-    assert_eq!(cold.successful_route_outcomes.len(), 1);
-    assert!(cold.successful_route_outcomes[0].changed);
+    assert_eq!(cold.successful_route_outcomes.len(), 1, "{provider:?}");
+    assert!(cold.successful_route_outcomes[0].changed, "{provider:?}");
     assert_eq!(
         cold.take_verified_publication().unwrap().0,
-        CapturePublicationDisposition::Published
+        CapturePublicationDisposition::Published,
+        "{provider:?}"
     );
 
+    let changed_marker = format!("{} logical SQLite changed WAL capture", provider.as_str());
+    append_opencode_message(&writer, &changed_marker);
+    assert_active_wal(&database);
+    let mut changed = executor
+        .refresh_scope_with_detailed_progress_and_publication_metadata(
+            &index_root,
+            SourceBackedRefreshScope::All,
+            |_| Ok(()),
+            |_| {
+                metadata_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(b"logical-sqlite-replay-v2".to_vec())
+            },
+        )
+        .unwrap();
+    assert_eq!(changed.successful_route_outcomes.len(), 1, "{provider:?}");
+    assert!(changed.successful_route_outcomes[0].changed, "{provider:?}");
+    assert_ne!(
+        changed.commit.generation_id, cold_generation,
+        "{provider:?}"
+    );
+    assert_eq!(changed.sources.len(), 1, "{provider:?}");
+    assert_eq!(
+        changed.sources[0].observation().source().provider(),
+        provider.as_str(),
+        "{provider:?}"
+    );
+    let changed_generation = changed.commit.generation_id.clone();
+    let changed_opstamp = changed.commit.opstamp;
+    let (changed_disposition, changed_pin) = changed.take_verified_publication().unwrap();
+    assert_eq!(
+        changed_disposition,
+        CapturePublicationDisposition::Published,
+        "{provider:?}"
+    );
+    let changed_index = changed_pin.into_inner().into_verified_index();
+    assert!(
+        !matching_events(&changed_index, &changed_marker).is_empty(),
+        "{provider:?}"
+    );
     let mut updates = Vec::new();
     let mut replay = executor
         .refresh_scope_with_detailed_progress_and_publication_metadata(
@@ -381,21 +440,38 @@ fn unchanged_replay_finishes_progress_and_propagates_systemic_failure() {
             },
         )
         .unwrap();
-    assert_eq!(replay.commit.generation_id, cold_generation);
-    assert_eq!(replay.commit.opstamp, cold_opstamp);
-    assert_eq!(metadata_calls.load(Ordering::SeqCst), 1);
-    assert_eq!(replay.successful_route_outcomes.len(), 1);
-    assert!(!replay.successful_route_outcomes[0].changed);
     assert_eq!(
-        replay.take_verified_publication().unwrap().0,
-        CapturePublicationDisposition::Reused
+        replay.commit.generation_id, changed_generation,
+        "{provider:?}"
+    );
+    assert_eq!(replay.commit.opstamp, changed_opstamp, "{provider:?}");
+    assert_eq!(metadata_calls.load(Ordering::SeqCst), 2, "{provider:?}");
+    assert_eq!(replay.successful_route_outcomes.len(), 1, "{provider:?}");
+    assert!(!replay.successful_route_outcomes[0].changed, "{provider:?}");
+    let (replay_disposition, replay_pin) = replay.take_verified_publication().unwrap();
+    assert_eq!(
+        replay_disposition,
+        CapturePublicationDisposition::Reused,
+        "{provider:?}"
+    );
+    let replay_index = replay_pin.into_inner().into_verified_index();
+    assert!(
+        !matching_events(&replay_index, &changed_marker).is_empty(),
+        "{provider:?}"
     );
     let terminal = updates.last().expect("terminal replay progress");
-    assert_eq!(terminal.progress.phase, "committed");
-    assert!(terminal.current_source_progress.is_none());
-    assert!(terminal.progress.current_source.is_none());
-    assert!(terminal.progress.completed_records.is_none());
-    assert!(terminal.progress.completed_bytes.is_none());
+    assert_eq!(terminal.progress.phase, "committed", "{provider:?}");
+    assert!(terminal.current_source_progress.is_none(), "{provider:?}");
+    assert!(terminal.progress.current_source.is_none(), "{provider:?}");
+    assert!(
+        terminal.progress.completed_records.is_none(),
+        "{provider:?}"
+    );
+    assert!(terminal.progress.completed_bytes.is_none(), "{provider:?}");
+
+    if provider != CaptureProvider::OpenCode {
+        return;
+    }
 
     let error = executor
         .refresh_scope_with_detailed_progress(
@@ -421,13 +497,22 @@ fn unchanged_replay_finishes_progress_and_propagates_systemic_failure() {
     ));
     assert_eq!(
         VerifiedIndex::open(&index_root).unwrap().generation_id(),
-        cold_generation
+        changed_generation
     );
 }
 
-fn create_opencode_database(path: &Path) {
+fn create_opencode_wal_database(path: &Path, text: &str) -> Connection {
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     let connection = Connection::open(path).unwrap();
+    let journal_mode = connection
+        .query_row("pragma journal_mode = wal", [], |row| {
+            row.get::<_, String>(0)
+        })
+        .unwrap();
+    assert_eq!(journal_mode, "wal");
+    connection
+        .pragma_update(None, "wal_autocheckpoint", 0)
+        .unwrap();
     connection
         .execute_batch(
             "create table session (
@@ -439,17 +524,24 @@ fn create_opencode_database(path: &Path) {
                  time_created integer not null,
                  time_updated integer not null
              );
-             create table session_message (
+             create table message (
                  id text primary key,
                  session_id text not null,
-                 type text not null,
-                 seq integer not null,
                  time_created integer not null,
                  time_updated integer not null,
                  data text not null
              );
-             create unique index session_message_session_seq_idx
-                 on session_message(session_id, seq);
+             create table part (
+                 id text primary key,
+                 message_id text not null,
+                 session_id text not null,
+                 time_created integer not null,
+                 time_updated integer not null,
+                 data text not null
+             );
+             create index message_session_time_created_id_idx
+                 on message(session_id, time_created, id);
+             create index part_message_id_id_idx on part(message_id, id);
              insert into session values (
                  'session-1', null, '/tmp/project', 'main', 'build', 1, 1
              );",
@@ -457,15 +549,52 @@ fn create_opencode_database(path: &Path) {
         .unwrap();
     connection
         .execute(
-            "insert into session_message values (
-                'message-1', 'session-1', 'message', 1, 1, 1, ?1
+            "insert into message values (
+                'message-1', 'session-1', 1, 1, ?1
             )",
             params![json!({
                 "role": "user",
-                "time": {"created": 1},
-                "text": "logical SQLite facade replay"
+                "time": {"created": 1}
             })
             .to_string()],
         )
         .unwrap();
+    connection
+        .execute(
+            "insert into part values (
+                'part-1', 'message-1', 'session-1', 1, 1, ?1
+            )",
+            params![json!({"type": "text", "text": text}).to_string()],
+        )
+        .unwrap();
+    connection
+}
+
+fn append_opencode_message(connection: &Connection, text: &str) {
+    connection
+        .execute(
+            "insert into message values (
+                'message-2', 'session-1', 2, 2, ?1
+            )",
+            params![json!({
+                "role": "assistant",
+                "time": {"created": 2}
+            })
+            .to_string()],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "insert into part values (
+                'part-2', 'message-2', 'session-1', 2, 2, ?1
+            )",
+            params![json!({"type": "text", "text": text}).to_string()],
+        )
+        .unwrap();
+}
+
+fn assert_active_wal(database: &Path) {
+    let mut wal = database.as_os_str().to_owned();
+    wal.push("-wal");
+    assert!(fs::metadata(Path::new(&wal)).unwrap().len() > 0);
 }

--- a/crates/ctx-history-providers-sqlite-selected/src/lib.rs
+++ b/crates/ctx-history-providers-sqlite-selected/src/lib.rs
@@ -92,6 +92,29 @@ pub(crate) mod provider {
             )
         }
 
+        pub(crate) fn sqlite_source_route_error(
+            error: crate::provider_sources::SqliteSourceAccessError,
+        ) -> SourceBackedRouteError {
+            let kind = if error.is_snapshot_capacity_failure() {
+                SourceBackedRouteErrorKind::Unavailable
+            } else if error.is_systemic_resource_failure() {
+                SourceBackedRouteErrorKind::ResourceUnavailable
+            } else if error.is_source_changed() {
+                SourceBackedRouteErrorKind::SourceChanged
+            } else if error.is_ctx_owned_corruption() {
+                SourceBackedRouteErrorKind::Internal
+            } else if error.is_provider_corruption() || error.is_provider_path_unavailable() {
+                SourceBackedRouteErrorKind::InvalidSource
+            } else if error.is_busy_or_locked() {
+                SourceBackedRouteErrorKind::ResourceUnavailable
+            } else if error.is_operational_failure() {
+                SourceBackedRouteErrorKind::Internal
+            } else {
+                SourceBackedRouteErrorKind::InvalidSource
+            };
+            SourceBackedRouteError::new(kind, error.to_string())
+        }
+
         pub(crate) fn combine_primary_and_cleanup_route_errors(
             primary: SourceBackedRouteError,
             cleanup: SourceBackedRouteError,
@@ -118,6 +141,46 @@ pub(crate) mod provider {
                 SourceBackedRouteErrorKind::InvalidSource => 3,
                 SourceBackedRouteErrorKind::Unsupported => 2,
                 SourceBackedRouteErrorKind::Unavailable => 1,
+            }
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use std::{io, path::PathBuf};
+
+            use super::*;
+            use crate::provider_sources::SqliteSourceAccessError;
+
+            #[test]
+            fn sqlite_terminal_fence_errors_keep_their_route_class_and_detail() {
+                let resource = SqliteSourceAccessError::ResourceUnavailable {
+                    operation: "revalidating a selected SQLite terminal fence",
+                    path: PathBuf::from("provider.sqlite"),
+                    source: io::Error::from(io::ErrorKind::OutOfMemory),
+                };
+                let detail = resource.to_string();
+                let route = sqlite_source_route_error(resource);
+                assert_eq!(route.kind, SourceBackedRouteErrorKind::ResourceUnavailable);
+                assert_eq!(route.detail, detail);
+
+                let changed = sqlite_source_route_error(SqliteSourceAccessError::SourceChanged);
+                assert_eq!(changed.kind, SourceBackedRouteErrorKind::SourceChanged);
+
+                let composite = SqliteSourceAccessError::Finalization {
+                    primary: Box::new(SqliteSourceAccessError::SourceChanged),
+                    cleanup: Box::new(SqliteSourceAccessError::ResourceUnavailable {
+                        operation: "cleaning a selected SQLite snapshot",
+                        path: PathBuf::from("ctx-owned-snapshot.sqlite"),
+                        source: io::Error::from(io::ErrorKind::OutOfMemory),
+                    }),
+                };
+                let composite = sqlite_source_route_error(composite);
+                assert_eq!(
+                    composite.kind,
+                    SourceBackedRouteErrorKind::ResourceUnavailable
+                );
+                assert!(composite.detail.contains("changed"));
+                assert!(composite.detail.contains("cleanup"));
             }
         }
     }

--- a/crates/ctx-history-providers-sqlite-selected/src/providers/firebender/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-selected/src/providers/firebender/native_path/source_backed.rs
@@ -13,7 +13,10 @@ use thiserror::Error;
 
 use super::super::{firebender_event_parts, firebender_message_time, firebender_result_content};
 use super::FirebenderRow;
-use crate::{native_source::NativeSqliteValue, CaptureError, FIREBENDER_SQLITE_SOURCE_FORMAT};
+use crate::{
+    native_source::NativeSqliteValue, provider_sources::SqliteSourceAccessError, CaptureError,
+    FIREBENDER_SQLITE_SOURCE_FORMAT,
+};
 
 mod direct;
 mod direct_snapshot;
@@ -33,6 +36,8 @@ pub(super) const FIREBENDER_SOURCE_SCHEMA_VARIANT: &str = "firebender-chat-sessi
 pub(crate) enum FirebenderSourceBackedError {
     #[error(transparent)]
     Capture(#[from] CaptureError),
+    #[error(transparent)]
+    SqliteSource(#[from] SqliteSourceAccessError),
     #[error(transparent)]
     Projection(#[from] ProjectionContractError),
     #[error(transparent)]

--- a/crates/ctx-history-providers-sqlite-selected/src/providers/firebender/native_path/source_backed/direct.rs
+++ b/crates/ctx-history-providers-sqlite-selected/src/providers/firebender/native_path/source_backed/direct.rs
@@ -20,10 +20,10 @@ use super::{
 use crate::{
     document_inventory_authority,
     provider::source_backed::{
-        route_error, ChangedDocumentSink, CompleteDocumentTree, DocumentLeafFingerprint,
-        DocumentSourceTerminal, ObservedDocumentLeaf, ReplacementDocumentTree,
-        SourceBackedRouteDriver, SourceBackedRouteError, SourceBackedRouteErrorKind,
-        SourceBackedRouteResult,
+        route_error, sqlite_source_route_error, ChangedDocumentSink, CompleteDocumentTree,
+        DocumentLeafFingerprint, DocumentSourceTerminal, ObservedDocumentLeaf,
+        ReplacementDocumentTree, SourceBackedRouteDriver, SourceBackedRouteError,
+        SourceBackedRouteErrorKind, SourceBackedRouteResult,
     },
     provider::sqlite::{
         sqlite_schema_fingerprint, sqlite_table_columns, SqliteLengthPreflightGuard,
@@ -71,12 +71,6 @@ struct FirebenderPresentAuthority {
     opening_evidence: SqliteSourceEvidence,
     _sqlite_authority: SqliteSourceDirectoryAuthority,
     snapshot: Mutex<Option<Box<OpenedSnapshot>>>,
-    terminal_revalidate: Box<
-        dyn Fn() -> Result<(), crate::provider_sources::SqliteSourceAccessError>
-            + Send
-            + Sync
-            + 'static,
-    >,
 }
 
 #[derive(Debug)]
@@ -109,15 +103,15 @@ impl<B: SelectedSqliteCaptureBinding> ReplacementDocumentTree for FirebenderDocu
         let (database_path, source) =
             firebender_database_path_and_source_scoped(&self.path, self.source_scope)
                 .map_err(route_error)?;
-        match open_database_leaf(&self.data_root, &database_path).map_err(route_error)? {
+        match open_database_leaf(&self.data_root, &database_path).map_err(firebender_scan_error)? {
             OpenDatabaseLeaf::Present(snapshot) => {
-                let opening_evidence = snapshot.evidence().map_err(route_error)?.clone();
+                let opening_evidence = snapshot.evidence().map_err(firebender_scan_error)?.clone();
                 let fingerprint = observe_logical_snapshot(
-                    snapshot.connection().map_err(route_error)?,
+                    snapshot.connection().map_err(firebender_scan_error)?,
                     &database_path,
                 )
-                .map_err(route_error)?;
-                snapshot.revalidate().map_err(route_error)?;
+                .map_err(firebender_scan_error)?;
+                snapshot.revalidate().map_err(firebender_scan_error)?;
                 Ok(CompleteDocumentTree::new(
                     fingerprint,
                     vec![ObservedDocumentLeaf::new(
@@ -127,9 +121,6 @@ impl<B: SelectedSqliteCaptureBinding> ReplacementDocumentTree for FirebenderDocu
                     FirebenderTreeAuthority::Present(Box::new(FirebenderPresentAuthority {
                         opening_evidence,
                         _sqlite_authority: snapshot.sqlite_authority(),
-                        terminal_revalidate: snapshot
-                            .terminal_revalidator()
-                            .map_err(route_error)?,
                         snapshot: Mutex::new(Some(snapshot)),
                     })),
                 ))
@@ -174,7 +165,7 @@ impl<B: SelectedSqliteCaptureBinding> ReplacementDocumentTree for FirebenderDocu
                 "Firebender SQLite physical inventory changed during logical projection",
             ));
         }
-        snapshot.revalidate().map_err(route_error)?;
+        snapshot.revalidate().map_err(firebender_scan_error)?;
         restore_opened_snapshot(&authority.snapshot, snapshot)?;
         Ok(document_terminal(scan))
     }
@@ -186,13 +177,15 @@ impl<B: SelectedSqliteCaptureBinding> ReplacementDocumentTree for FirebenderDocu
         match &tree.authority {
             FirebenderTreeAuthority::Present(authority) => {
                 let snapshot = take_opened_snapshot(&authority.snapshot)?;
-                let evidence = snapshot.finish().map_err(route_error)?;
+                let (terminal_fence, evidence) = snapshot.seal().map_err(firebender_scan_error)?;
                 if evidence != authority.opening_evidence {
                     return Err(source_changed(
                         "Firebender SQLite physical inventory changed before commit",
                     ));
                 }
-                (authority.terminal_revalidate)().map_err(route_error)?;
+                terminal_fence
+                    .revalidate()
+                    .map_err(sqlite_source_route_error)?;
             }
             FirebenderTreeAuthority::Missing(fence) if !fence.revalidate() => {
                 return Err(source_changed(
@@ -664,6 +657,7 @@ fn firebender_database_path_and_source_scoped(
 fn firebender_scan_error(error: FirebenderSourceBackedError) -> SourceBackedRouteError {
     match error {
         FirebenderSourceBackedError::Route(error) => error,
+        FirebenderSourceBackedError::SqliteSource(error) => sqlite_source_route_error(error),
         error => route_error(error),
     }
 }
@@ -678,7 +672,56 @@ fn internal_error(detail: impl Into<String>) -> SourceBackedRouteError {
 
 #[cfg(test)]
 mod tests {
+    use std::{io, path::PathBuf};
+
     use super::*;
+    use crate::provider_sources::SqliteSourceAccessError;
+
+    #[test]
+    fn sqlite_source_errors_keep_their_shared_route_classification() {
+        let cases = [
+            (
+                SqliteSourceAccessError::SourceChanged,
+                SourceBackedRouteErrorKind::SourceChanged,
+            ),
+            (
+                SqliteSourceAccessError::SnapshotTooLarge {
+                    path: PathBuf::from("firebender.sqlite"),
+                    length: 2,
+                    maximum: 1,
+                },
+                SourceBackedRouteErrorKind::Unavailable,
+            ),
+            (
+                SqliteSourceAccessError::ResourceUnavailable {
+                    operation: "sealing a Firebender SQLite snapshot",
+                    path: PathBuf::from("firebender.sqlite"),
+                    source: io::Error::from(io::ErrorKind::OutOfMemory),
+                },
+                SourceBackedRouteErrorKind::ResourceUnavailable,
+            ),
+            (
+                SqliteSourceAccessError::ProviderContentCorruption {
+                    source: Box::new(SqliteSourceAccessError::SqliteControl {
+                        operation: "reading a Firebender SQLite snapshot",
+                        code: rusqlite::ffi::SQLITE_CORRUPT,
+                    }),
+                },
+                SourceBackedRouteErrorKind::InvalidSource,
+            ),
+            (
+                SqliteSourceAccessError::SqliteControl {
+                    operation: "revalidating a Firebender SQLite terminal fence",
+                    code: rusqlite::ffi::SQLITE_BUSY,
+                },
+                SourceBackedRouteErrorKind::ResourceUnavailable,
+            ),
+        ];
+
+        for (error, expected_kind) in cases {
+            assert_eq!(firebender_scan_error(error.into()).kind, expected_kind);
+        }
+    }
 
     #[test]
     fn indivisible_tool_result_larger_than_page_target_is_retained() {

--- a/crates/ctx-history-providers-sqlite-selected/src/providers/firebender/native_path/source_backed/direct_snapshot.rs
+++ b/crates/ctx-history-providers-sqlite-selected/src/providers/firebender/native_path/source_backed/direct_snapshot.rs
@@ -12,6 +12,7 @@ use crate::{
     provider_sources::{
         open_root_handle_sqlite_source_snapshot, retain_sqlite_source_directory_authority,
         SqliteSourceDirectoryAuthority, SqliteSourceEvidence, SqliteSourceReadSnapshot,
+        SqliteSourceTerminalFence,
     },
     CaptureError,
 };
@@ -96,7 +97,7 @@ impl OpenedSnapshot {
                 CaptureError::SystemInvariant("Firebender SQLite snapshot is inactive"),
             ))?
             .connection()
-            .map_err(|error| CaptureError::InvalidPayload(error.to_string()).into())
+            .map_err(Into::into)
     }
 
     pub(super) fn evidence(&self) -> FirebenderSourceBackedResult<&SqliteSourceEvidence> {
@@ -109,25 +110,6 @@ impl OpenedSnapshot {
             .evidence())
     }
 
-    pub(super) fn terminal_revalidator(
-        &self,
-    ) -> FirebenderSourceBackedResult<
-        Box<
-            dyn Fn() -> Result<(), crate::provider_sources::SqliteSourceAccessError>
-                + Send
-                + Sync
-                + 'static,
-        >,
-    > {
-        Ok(self
-            .snapshot
-            .as_ref()
-            .ok_or(FirebenderSourceBackedError::Capture(
-                CaptureError::SystemInvariant("Firebender SQLite snapshot is inactive"),
-            ))?
-            .terminal_revalidator())
-    }
-
     pub(super) fn sqlite_authority(&self) -> SqliteSourceDirectoryAuthority {
         self.authority.clone()
     }
@@ -138,26 +120,26 @@ impl OpenedSnapshot {
             .ok_or(FirebenderSourceBackedError::Capture(
                 CaptureError::SystemInvariant("Firebender SQLite snapshot is inactive"),
             ))?
-            .revalidate()
-            .map_err(|error| CaptureError::InvalidPayload(error.to_string()))?;
+            .revalidate()?;
         self.directory.revalidate()?;
         self.root.revalidate()?;
         Ok(())
     }
 
-    pub(super) fn finish(mut self) -> FirebenderSourceBackedResult<SqliteSourceEvidence> {
+    pub(super) fn seal(
+        mut self,
+    ) -> FirebenderSourceBackedResult<(SqliteSourceTerminalFence, SqliteSourceEvidence)> {
         let snapshot = self
             .snapshot
             .take()
             .ok_or(FirebenderSourceBackedError::Capture(
                 CaptureError::SystemInvariant("Firebender SQLite snapshot is inactive"),
             ))?;
-        let evidence = snapshot
-            .finish()
-            .map_err(|error| CaptureError::InvalidPayload(error.to_string()))?;
+        let terminal_fence = snapshot.seal()?;
+        let evidence = terminal_fence.evidence().clone();
         self.directory.revalidate()?;
         self.root.revalidate()?;
-        Ok(evidence)
+        Ok((terminal_fence, evidence))
     }
 }
 
@@ -171,13 +153,9 @@ fn open_snapshot_from_authority(
     let handle = directory
         .try_clone_authority_handle()
         .map_err(CaptureError::Io)?;
-    let authority = retain_sqlite_source_directory_authority(data_root, &handle, parent)
-        .map_err(|error| CaptureError::InvalidPayload(error.to_string()))?;
-    let snapshot = open_root_handle_sqlite_source_snapshot(&authority, leaf)
-        .map_err(|error| CaptureError::InvalidPayload(error.to_string()))?;
-    snapshot
-        .revalidate()
-        .map_err(|error| CaptureError::InvalidPayload(error.to_string()))?;
+    let authority = retain_sqlite_source_directory_authority(data_root, &handle, parent)?;
+    let snapshot = open_root_handle_sqlite_source_snapshot(&authority, leaf)?;
+    snapshot.revalidate()?;
     directory.revalidate()?;
     root.revalidate()?;
     Ok(OpenedSnapshot {

--- a/crates/ctx-history-providers-sqlite-selected/src/providers/goose/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-selected/src/providers/goose/source_backed.rs
@@ -36,9 +36,10 @@ use super::{
 use crate::{
     common::io::{OpenedProviderSourcePath, ProviderSourceDirectory, ProviderSourceRoot},
     provider::source_backed::{
-        route_error, ChangedDocumentSink, CompleteDocumentTree, DocumentLeafFingerprint,
-        DocumentRecordSpool, DocumentSourceTerminal, ObservedDocumentLeaf, ReplacementDocumentTree,
-        SourceBackedRouteError, SourceBackedRouteErrorKind, SourceBackedRouteResult,
+        route_error, sqlite_source_route_error, ChangedDocumentSink, CompleteDocumentTree,
+        DocumentLeafFingerprint, DocumentRecordSpool, DocumentSourceTerminal, ObservedDocumentLeaf,
+        ReplacementDocumentTree, SourceBackedRouteError, SourceBackedRouteErrorKind,
+        SourceBackedRouteResult,
     },
     provider_sources::{
         open_root_handle_sqlite_source_snapshot, retain_sqlite_source_directory_authority,
@@ -183,7 +184,6 @@ impl<B> GooseSourceBackedAdapterV0<B> {
 pub(crate) struct GoosePresentAuthority {
     retained: RetainedGooseDirectory,
     snapshot: Mutex<Option<SqliteSourceReadSnapshot>>,
-    terminal_revalidate: Box<dyn Fn() -> bool + Send + Sync>,
 }
 
 pub(crate) enum GooseTreeAuthority {
@@ -225,7 +225,6 @@ impl<B: SelectedSqliteCaptureBinding> ReplacementDocumentTree for GooseSourceBac
         let fingerprint =
             observe_goose_logical_fingerprint(snapshot.connection().map_err(route_error)?)
                 .map_err(route_error)?;
-        let terminal_revalidate = snapshot.terminal_revalidator();
         Ok(CompleteDocumentTree::new(
             fingerprint,
             vec![ObservedDocumentLeaf::new(
@@ -235,7 +234,6 @@ impl<B: SelectedSqliteCaptureBinding> ReplacementDocumentTree for GooseSourceBac
             GooseTreeAuthority::Present(Box::new(GoosePresentAuthority {
                 retained,
                 snapshot: Mutex::new(Some(snapshot)),
-                terminal_revalidate: Box::new(move || terminal_revalidate().is_ok()),
             })),
         ))
     }
@@ -321,14 +319,11 @@ fn finish_present_authority(
     authority: &GoosePresentAuthority,
     snapshot: SqliteSourceReadSnapshot,
 ) -> SourceBackedRouteResult<()> {
-    snapshot.finish().map_err(route_error)?;
+    let terminal_fence = snapshot.seal().map_err(sqlite_source_route_error)?;
     authority.retained.revalidate()?;
-    if !(authority.terminal_revalidate)() {
-        return Err(source_changed(
-            "Goose retained terminal fence changed before publication",
-        ));
-    }
-    Ok(())
+    terminal_fence
+        .revalidate()
+        .map_err(sqlite_source_route_error)
 }
 
 pub(crate) struct RetainedGooseDirectory {

--- a/crates/ctx-history-providers-sqlite-selected/src/providers/kiro/source_backed/registration.rs
+++ b/crates/ctx-history-providers-sqlite-selected/src/providers/kiro/source_backed/registration.rs
@@ -433,14 +433,14 @@ pub(crate) fn kiro_scan_error(error: KiroSourceBackedErrorV0) -> SourceBackedRou
         KiroSourceBackedErrorV0::Capture(CaptureError::SourceChangedDuringCapture) => {
             SourceBackedRouteErrorKind::SourceChanged
         }
-        KiroSourceBackedErrorV0::SqliteSource(error) if error.is_source_changed() => {
-            SourceBackedRouteErrorKind::SourceChanged
-        }
         KiroSourceBackedErrorV0::SqliteSource(error) if error.is_snapshot_capacity_failure() => {
             SourceBackedRouteErrorKind::Unavailable
         }
         KiroSourceBackedErrorV0::SqliteSource(error) if error.is_systemic_resource_failure() => {
             SourceBackedRouteErrorKind::ResourceUnavailable
+        }
+        KiroSourceBackedErrorV0::SqliteSource(error) if error.is_source_changed() => {
+            SourceBackedRouteErrorKind::SourceChanged
         }
         KiroSourceBackedErrorV0::SqliteSource(error) if error.is_ctx_owned_corruption() => {
             SourceBackedRouteErrorKind::Internal

--- a/crates/ctx-history-providers-sqlite-selected/src/providers/kiro/source_backed/tests/temp_authority.rs
+++ b/crates/ctx-history-providers-sqlite-selected/src/providers/kiro/source_backed/tests/temp_authority.rs
@@ -367,6 +367,23 @@ fn kiro_terminal_revalidation_resource_exhaustion_stays_systemic() {
 }
 
 #[test]
+fn kiro_terminal_change_with_resource_cleanup_failure_stays_systemic() {
+    let error = KiroSourceBackedErrorV0::SqliteSource(SqliteSourceAccessError::Finalization {
+        primary: Box::new(SqliteSourceAccessError::SourceChanged),
+        cleanup: Box::new(SqliteSourceAccessError::ResourceUnavailable {
+            operation: "cleaning a Kiro SQLite snapshot",
+            path: Path::new("ctx-owned-snapshot.sqlite").to_path_buf(),
+            source: std::io::Error::from(std::io::ErrorKind::OutOfMemory),
+        }),
+    });
+
+    assert_eq!(
+        super::super::registration::kiro_scan_error(error).kind,
+        crate::provider::source_backed::SourceBackedRouteErrorKind::ResourceUnavailable
+    );
+}
+
+#[test]
 fn production_kiro_route_taxonomy_preserves_change_and_corruption_provenance() {
     assert_eq!(
         super::super::registration::route_kiro_sqlite_call::<()>(Err(

--- a/crates/ctx-history-providers-sqlite-selected/src/providers/warp/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-selected/src/providers/warp/source_backed.rs
@@ -27,9 +27,10 @@ use super::{
 use crate::{
     common::io::{OpenedProviderSourcePath, ProviderSourceDirectory, ProviderSourceRoot},
     provider::source_backed::{
-        route_error, ChangedDocumentSink, CompleteDocumentTree, DocumentLeafFingerprint,
-        DocumentRecordSpool, DocumentSourceTerminal, ObservedDocumentLeaf, ReplacementDocumentTree,
-        SourceBackedRouteError, SourceBackedRouteErrorKind, SourceBackedRouteResult,
+        route_error, sqlite_source_route_error, ChangedDocumentSink, CompleteDocumentTree,
+        DocumentLeafFingerprint, DocumentRecordSpool, DocumentSourceTerminal, ObservedDocumentLeaf,
+        ReplacementDocumentTree, SourceBackedRouteError, SourceBackedRouteErrorKind,
+        SourceBackedRouteResult,
     },
     provider_sources::{
         open_root_handle_sqlite_source_snapshot, retain_sqlite_source_directory_authority,
@@ -145,7 +146,6 @@ pub(crate) struct WarpReplacementTreeAdapter<B> {
 pub(crate) struct WarpPresentAuthority {
     retained: RetainedWarpDirectory,
     snapshot: Mutex<Option<SqliteSourceReadSnapshot>>,
-    terminal_revalidate: Box<dyn Fn() -> bool + Send + Sync>,
 }
 
 pub(crate) enum WarpTreeAuthority {
@@ -187,7 +187,6 @@ impl<B: SelectedSqliteCaptureBinding> ReplacementDocumentTree for WarpReplacemen
             &self.source,
         )
         .map_err(route_error)?;
-        let terminal_revalidate = snapshot.terminal_revalidator();
         Ok(CompleteDocumentTree::new(
             fingerprint,
             vec![ObservedDocumentLeaf::new(
@@ -197,7 +196,6 @@ impl<B: SelectedSqliteCaptureBinding> ReplacementDocumentTree for WarpReplacemen
             WarpTreeAuthority::Present(Box::new(WarpPresentAuthority {
                 retained,
                 snapshot: Mutex::new(Some(snapshot)),
-                terminal_revalidate: Box::new(move || terminal_revalidate().is_ok()),
             })),
         ))
     }
@@ -285,14 +283,11 @@ fn finish_warp_authority(
     authority: &WarpPresentAuthority,
     snapshot: SqliteSourceReadSnapshot,
 ) -> SourceBackedRouteResult<()> {
-    snapshot.finish().map_err(route_error)?;
+    let terminal_fence = snapshot.seal().map_err(sqlite_source_route_error)?;
     authority.retained.revalidate()?;
-    if !(authority.terminal_revalidate)() {
-        return Err(source_changed(
-            "Warp retained terminal fence changed before publication",
-        ));
-    }
-    Ok(())
+    terminal_fence
+        .revalidate()
+        .map_err(sqlite_source_route_error)
 }
 
 pub(crate) struct RetainedWarpDirectory {


### PR DESCRIPTION
## Summary

- replace the OpenCode-family late counter reconstruction with the typed terminal fence produced by the SQLite snapshot
- preserve terminal SQLite error classifications in Goose, Warp, and Firebender, and harden composite-error precedence in Kiro
- add active-WAL changed-capture, exact-replay, and cleanup/resource regression coverage

## Validation

- 91 mechanically affected targets passed
- OpenCode, Kilo, MiMoCode, Goose, and Warp active-WAL lifecycle coverage passed
- parser revisions and persisted identities remain unchanged

Fixes #799