### PR TITLE
refactor(semantic): separate embedding contract from execution

### DIFF
--- a/crates/ctx-daemon-cli/src/query_adapter.rs
+++ b/crates/ctx-daemon-cli/src/query_adapter.rs
@@ -1,17 +1,19 @@
 use std::{path::Path, time::Duration as StdDuration, time::Instant};
 
 use anyhow::{anyhow, Result};
+use ctx_daemon_service::DaemonQueryServiceUnavailable;
 use ctx_history_index::{CompiledSearchFilter, EventSearchCandidate, VerifiedIndex};
 use ctx_history_read_application::{
     HistorySemanticBatch, HistorySemanticError, HistorySemanticPort, HistorySemanticQuery,
     SemanticReason,
 };
 use ctx_semantic_index::{
-    source_backed_semantic_vector_path, SemanticBatchEmbedder, SemanticChunkDocument,
-    SemanticNotReady, SemanticQueryPin, SemanticVectorStore, SourceBackedSemanticDocumentBuilder,
+    semantic_model_contract, source_backed_semantic_vector_path, SemanticBatchEmbedder,
+    SemanticChunkDocument, SemanticModelContract, SemanticNotReady, SemanticQueryPin,
+    SemanticVectorStore, SourceBackedSemanticDocumentBuilder,
 };
 use ctx_semantic_model::{
-    semantic_model_key, SemanticModelConfig, SharedSemanticRuntime, SEMANTIC_DIMENSIONS,
+    BuiltinSemanticEmbeddingExecutor, SemanticEmbeddingExecutor, SharedSemanticRuntime,
 };
 use serde_json::{json, Value};
 
@@ -27,8 +29,7 @@ pub struct SemanticQueryAdapter<'data_root> {
 enum SemanticQueryExecution {
     Daemon,
     Foreground {
-        runtime: SharedSemanticRuntime,
-        model_config: Box<SemanticModelConfig>,
+        executor: Box<BuiltinSemanticEmbeddingExecutor>,
     },
 }
 
@@ -40,14 +41,17 @@ impl<'data_root> SemanticQueryAdapter<'data_root> {
         }
     }
 
-    /// Uses one foreground runtime for semantic reconciliation and the query
-    /// embedding. Intended for explicit manual `--refresh wait`.
+    /// Uses one foreground built-in executor for semantic reconciliation and
+    /// the query embedding. Intended for explicit manual `--refresh wait`.
     pub fn foreground(data_root: &'data_root Path) -> Self {
+        let executor = BuiltinSemanticEmbeddingExecutor::new(
+            SharedSemanticRuntime::default(),
+            crate::model_config::semantic_model_config(data_root),
+        );
         Self {
             data_root,
             execution: SemanticQueryExecution::Foreground {
-                runtime: SharedSemanticRuntime::default(),
-                model_config: Box::new(crate::model_config::semantic_model_config(data_root)),
+                executor: Box::new(executor),
             },
         }
     }
@@ -65,66 +69,51 @@ impl HistorySemanticPort for SemanticQueryAdapter<'_> {
     ) -> std::result::Result<Self::Query<'a>, HistorySemanticError> {
         match &self.execution {
             SemanticQueryExecution::Daemon => SemanticQuerySession::begin(index, self.data_root),
-            SemanticQueryExecution::Foreground {
-                runtime,
-                model_config,
-            } => match SemanticQuerySession::begin_foreground(
-                index,
-                self.data_root,
-                runtime,
-                model_config,
-            ) {
-                Ok(session) => Ok(session),
-                Err(SemanticQueryError::NotReady { .. }) => {
-                    reconcile_foreground_semantic(index, self.data_root, runtime, model_config)
-                        .map_err(SemanticQueryError::from)?;
-                    SemanticQuerySession::begin_foreground(
-                        index,
-                        self.data_root,
-                        runtime,
-                        model_config,
-                    )
+            SemanticQueryExecution::Foreground { executor } => {
+                match SemanticQuerySession::begin_foreground(index, self.data_root, executor) {
+                    Ok(session) => Ok(session),
+                    Err(SemanticQueryError::NotReady { .. }) => {
+                        reconcile_foreground_semantic(index, self.data_root, executor)
+                            .map_err(SemanticQueryError::from)?;
+                        SemanticQuerySession::begin_foreground(index, self.data_root, executor)
+                    }
+                    Err(error) => Err(error),
                 }
-                Err(error) => Err(error),
-            },
+            }
         }
         .map_err(HistorySemanticError::from)
     }
 }
 
 struct ForegroundSemanticEmbedder<'a> {
-    runtime: &'a SharedSemanticRuntime,
-    model_config: &'a SemanticModelConfig,
+    executor: &'a BuiltinSemanticEmbeddingExecutor,
 }
 
 impl SemanticBatchEmbedder for ForegroundSemanticEmbedder<'_> {
     fn embed_chunks(&mut self, chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
-        ensure_foreground_runtime(self.runtime, self.model_config)?;
+        ensure_foreground_executor(self.executor)?;
         let texts = chunks
             .iter()
             .map(|chunk| chunk.text().to_owned())
             .collect::<Vec<_>>();
-        self.runtime
-            .embed_documents(self.model_config, texts, None)
-            .map(|(embeddings, _)| embeddings)
+        let executor: &dyn SemanticEmbeddingExecutor = self.executor;
+        executor.embed_documents(executor.contract().prepare_documents(texts), None)
     }
 }
 
 fn reconcile_foreground_semantic(
     index: &VerifiedIndex,
     data_root: &Path,
-    runtime: &SharedSemanticRuntime,
-    model_config: &SemanticModelConfig,
+    executor: &BuiltinSemanticEmbeddingExecutor,
 ) -> Result<()> {
     if index.semantic_eligible_event_count()? > 0 {
-        ensure_foreground_runtime(runtime, model_config)?;
+        ensure_foreground_executor(executor)?;
     }
-    let mut store = SemanticVectorStore::open(&source_backed_semantic_vector_path(data_root))?;
+    let contract = semantic_index_contract(executor)?;
+    let mut store =
+        SemanticVectorStore::open(&source_backed_semantic_vector_path(data_root), &contract)?;
     let mut builder = SourceBackedSemanticDocumentBuilder::new(index);
-    let mut embedder = ForegroundSemanticEmbedder {
-        runtime,
-        model_config,
-    };
+    let mut embedder = ForegroundSemanticEmbedder { executor };
     loop {
         let outcome = store.reconcile_source_backed_index(index, &mut builder, &mut embedder)?;
         if outcome.ready() {
@@ -142,6 +131,7 @@ pub struct SemanticQuerySession<'a> {
     pin: SemanticQueryPin,
     index: &'a VerifiedIndex,
     data_root: &'a Path,
+    contract: SemanticModelContract,
     embedding_source: SemanticQueryEmbeddingSource<'a>,
     embeddings: Vec<Vec<f32>>,
 }
@@ -150,8 +140,7 @@ pub struct SemanticQuerySession<'a> {
 enum SemanticQueryEmbeddingSource<'a> {
     Daemon,
     Foreground {
-        runtime: &'a SharedSemanticRuntime,
-        model_config: &'a SemanticModelConfig,
+        executor: &'a BuiltinSemanticEmbeddingExecutor,
     },
 }
 
@@ -160,12 +149,14 @@ impl SemanticQuerySession<'_> {
         index: &'a VerifiedIndex,
         data_root: &'a Path,
     ) -> std::result::Result<SemanticQuerySession<'a>, SemanticQueryError> {
-        let pin =
-            SemanticQueryPin::preflight(index, data_root).map_err(SemanticQueryError::from)?;
+        let contract = semantic_model_contract();
+        let pin = SemanticQueryPin::preflight(index, data_root, contract)
+            .map_err(SemanticQueryError::from)?;
         Ok(SemanticQuerySession {
             pin,
             index,
             data_root,
+            contract: contract.clone(),
             embedding_source: SemanticQueryEmbeddingSource::Daemon,
             embeddings: Vec::new(),
         })
@@ -174,15 +165,19 @@ impl SemanticQuerySession<'_> {
     fn begin_foreground<'a>(
         index: &'a VerifiedIndex,
         data_root: &'a Path,
-        runtime: &'a SharedSemanticRuntime,
-        model_config: &'a SemanticModelConfig,
+        executor: &'a BuiltinSemanticEmbeddingExecutor,
     ) -> std::result::Result<SemanticQuerySession<'a>, SemanticQueryError> {
-        let mut session = Self::begin(index, data_root)?;
-        session.embedding_source = SemanticQueryEmbeddingSource::Foreground {
-            runtime,
-            model_config,
-        };
-        Ok(session)
+        let contract = semantic_index_contract(executor).map_err(SemanticQueryError::from)?;
+        let pin = SemanticQueryPin::preflight(index, data_root, &contract)
+            .map_err(SemanticQueryError::from)?;
+        Ok(SemanticQuerySession {
+            pin,
+            index,
+            data_root,
+            contract,
+            embedding_source: SemanticQueryEmbeddingSource::Foreground { executor },
+            embeddings: Vec::new(),
+        })
     }
 
     fn prepare_alternative(
@@ -193,12 +188,10 @@ impl SemanticQuerySession<'_> {
             SemanticQueryEmbeddingSource::Daemon => {
                 self.prepare_alternative_with(query, daemon_query_embedding)
             }
-            SemanticQueryEmbeddingSource::Foreground {
-                runtime,
-                model_config,
-            } => self.prepare_alternative_with(query, |_, query| {
-                foreground_query_embedding(runtime, model_config, query).map(Some)
-            }),
+            SemanticQueryEmbeddingSource::Foreground { executor } => self
+                .prepare_alternative_with(query, |_, _, query| {
+                    foreground_query_embedding(executor, query).map(Some)
+                }),
         }
     }
 
@@ -208,7 +201,7 @@ impl SemanticQuerySession<'_> {
         mut embed_query: EmbedQuery,
     ) -> std::result::Result<Value, SemanticQueryError>
     where
-        EmbedQuery: FnMut(&Path, &str) -> Result<Option<(Vec<f32>, u64)>>,
+        EmbedQuery: FnMut(&Path, &SemanticModelContract, &str) -> Result<Option<(Vec<f32>, u64)>>,
     {
         if !self
             .pin
@@ -219,7 +212,7 @@ impl SemanticQuerySession<'_> {
                 "query_embed_ms": null,
             })));
         }
-        let (embedding, query_embed_ms) = embed_query(self.data_root, query)
+        let (embedding, query_embed_ms) = embed_query(self.data_root, &self.contract, query)
             .map_err(SemanticQueryError::from)?
             .ok_or_else(|| {
                 SemanticQueryError::not_ready(
@@ -254,29 +247,43 @@ impl SemanticQuerySession<'_> {
             pin,
             index,
             data_root,
+            contract: semantic_model_contract().clone(),
             embedding_source: SemanticQueryEmbeddingSource::Daemon,
             embeddings: Vec::new(),
         }
     }
 }
 
+fn semantic_index_contract(
+    executor: &BuiltinSemanticEmbeddingExecutor,
+) -> Result<SemanticModelContract> {
+    // Bazel may materialize the model crate separately across this dependency
+    // boundary. Compare the portable fingerprint, then return the index
+    // crate's own contract type.
+    let contract = semantic_model_contract();
+    if executor.contract().fingerprint() != contract.fingerprint() {
+        return Err(anyhow!(
+            "semantic executor model contract does not match the semantic index contract"
+        ));
+    }
+    Ok(contract.clone())
+}
+
 fn foreground_query_embedding(
-    runtime: &SharedSemanticRuntime,
-    model_config: &SemanticModelConfig,
+    executor: &BuiltinSemanticEmbeddingExecutor,
     semantic_text: &str,
 ) -> Result<(Vec<f32>, u64)> {
-    ensure_foreground_runtime(runtime, model_config)?;
+    ensure_foreground_executor(executor)?;
     let started = Instant::now();
-    let (embedding, _) = runtime.embed_query(model_config, semantic_text.to_owned())?;
+    let executor: &dyn SemanticEmbeddingExecutor = executor;
+    let embedding =
+        executor.embed_query(executor.contract().prepare_query(semantic_text.to_owned()))?;
     Ok((embedding, started.elapsed().as_millis() as u64))
 }
 
-fn ensure_foreground_runtime(
-    runtime: &SharedSemanticRuntime,
-    model_config: &SemanticModelConfig,
-) -> Result<()> {
-    runtime.ensure_loaded_with_acquisition(
-        model_config,
+fn ensure_foreground_executor(executor: &BuiltinSemanticEmbeddingExecutor) -> Result<()> {
+    executor.shared_runtime().ensure_loaded_with_acquisition(
+        executor.config(),
         &crate::daemon_service_ports::ARTIFACT_FETCHER,
     )?;
     Ok(())
@@ -339,7 +346,14 @@ impl From<anyhow::Error> for SemanticQueryError {
             Ok(not_ready) => {
                 Self::not_ready(not_ready.code(), not_ready.detail(), not_ready.retryable())
             }
-            Err(error) => Self::failed(format!("{error:#}")),
+            Err(error) => match error.downcast::<DaemonQueryServiceUnavailable>() {
+                Ok(error) => Self::not_ready(
+                    "semantic_query_service_unavailable",
+                    error.to_string(),
+                    true,
+                ),
+                Err(error) => Self::failed(format!("{error:#}")),
+            },
         }
     }
 }
@@ -359,35 +373,74 @@ impl From<SemanticQueryError> for HistorySemanticError {
 
 fn daemon_query_embedding(
     data_root: &Path,
+    contract: &SemanticModelContract,
     semantic_text: &str,
 ) -> Result<Option<(Vec<f32>, u64)>> {
     let Some(response) = daemon_query_request(
         data_root,
-        compact_json(json!({
-            "schema_version": 1,
-            "op": "embed_query",
-            "model_key": semantic_model_key(),
-            "text": semantic_text,
-        })),
+        daemon_query_embedding_request(contract, semantic_text),
         StdDuration::from_secs(30),
         1024 * 1024,
     )?
     else {
         return Ok(None);
     };
-    if response.get("ok").and_then(Value::as_bool) != Some(true) {
+    parse_daemon_query_embedding_response(&response, contract).map(Some)
+}
+
+fn daemon_query_embedding_request(contract: &SemanticModelContract, semantic_text: &str) -> Value {
+    compact_json(json!({
+        "schema_version": 1,
+        "op": "embed_query",
+        "model_key": contract.model_key(),
+        "model_contract_fingerprint": contract.fingerprint(),
+        "text": semantic_text,
+    }))
+}
+
+fn parse_daemon_query_embedding_response(
+    response: &Value,
+    contract: &SemanticModelContract,
+) -> Result<(Vec<f32>, u64)> {
+    let ok = response.get("ok").and_then(Value::as_bool);
+    let legacy_v1 = contract.supports_frozen_legacy_v1()
+        && response.get("model_contract_fingerprint").is_none();
+    if !legacy_v1 {
+        if response.get("schema_version").and_then(Value::as_u64) != Some(1) {
+            return Err(anyhow!("daemon query response schema_version mismatch"));
+        }
+        let model_key = response
+            .get("model_key")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if model_key != contract.model_key() {
+            return Err(anyhow!("daemon query response model key mismatch"));
+        }
+        let model_contract_fingerprint = response
+            .get("model_contract_fingerprint")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if model_contract_fingerprint != contract.fingerprint() {
+            return Err(anyhow!(
+                "daemon query response model contract fingerprint mismatch"
+            ));
+        }
+    } else if ok == Some(true)
+        && (response
+            .get("schema_version")
+            .is_some_and(|value| value.as_u64() != Some(1))
+            || response.get("model_key").and_then(Value::as_str) != Some(contract.model_key()))
+    {
+        return Err(anyhow!(
+            "legacy daemon query response protocol identity mismatch"
+        ));
+    }
+    if ok != Some(true) {
         let message = response
             .get("error")
             .and_then(Value::as_str)
             .unwrap_or("daemon query failed");
         return Err(anyhow!("{message}"));
-    }
-    let model_key = response
-        .get("model_key")
-        .and_then(Value::as_str)
-        .unwrap_or("");
-    if model_key != semantic_model_key() {
-        return Err(anyhow!("daemon query response model key mismatch"));
     }
     let query_embed_ms = response
         .get("query_embed_ms")
@@ -405,14 +458,28 @@ fn daemon_query_embedding(
                 .ok_or_else(|| anyhow!("daemon query embedding contains a non-number"))
         })
         .collect::<Result<Vec<_>>>()?;
-    if embedding.len() != SEMANTIC_DIMENSIONS {
+    if embedding.len() != contract.dimensions() {
         return Err(anyhow!(
             "daemon query embedding returned {} dimensions, expected {}",
             embedding.len(),
-            SEMANTIC_DIMENSIONS
+            contract.dimensions()
         ));
     }
-    Ok(Some((embedding, query_embed_ms)))
+    if embedding.iter().any(|value| !value.is_finite()) {
+        return Err(anyhow!(
+            "daemon query embedding contains a non-finite value"
+        ));
+    }
+    let norm_squared = embedding.iter().fold(0.0_f64, |norm_squared, value| {
+        f64::from(*value).mul_add(f64::from(*value), norm_squared)
+    });
+    const NORMALIZED_NORM_SQUARED_TOLERANCE: f64 = 1.0e-3;
+    if !norm_squared.is_finite() || (norm_squared - 1.0).abs() > NORMALIZED_NORM_SQUARED_TOLERANCE {
+        return Err(anyhow!(
+            "daemon query embedding is not L2-normalized (norm squared {norm_squared})"
+        ));
+    }
+    Ok((embedding, query_embed_ms))
 }
 
 #[cfg(test)]

--- a/crates/ctx-daemon-cli/src/query_adapter/tests.rs
+++ b/crates/ctx-daemon-cli/src/query_adapter/tests.rs
@@ -136,9 +136,20 @@ fn acknowledge_empty_generation(
 }
 
 fn embedding() -> Vec<f32> {
-    let mut embedding = vec![0.0; SEMANTIC_DIMENSIONS];
+    let mut embedding = vec![0.0; semantic_model_contract().dimensions()];
     embedding[0] = 1.0;
     embedding
+}
+
+fn daemon_embedding_response(contract: &SemanticModelContract, embedding: Value) -> Value {
+    compact_json(json!({
+        "ok": true,
+        "schema_version": 1,
+        "model_key": contract.model_key(),
+        "model_contract_fingerprint": contract.fingerprint(),
+        "query_embed_ms": 17,
+        "embedding": embedding,
+    }))
 }
 
 #[test]
@@ -150,16 +161,159 @@ fn request_adapter_borrows_the_exact_data_root() {
 }
 
 #[test]
+fn daemon_query_embedding_request_preserves_schema_v1_and_binds_the_model_contract() {
+    let contract = semantic_model_contract();
+
+    assert_eq!(
+        daemon_query_embedding_request(contract, "query text"),
+        compact_json(json!({
+            "schema_version": 1,
+            "op": "embed_query",
+            "model_key": contract.model_key(),
+            "model_contract_fingerprint": contract.fingerprint(),
+            "text": "query text",
+        }))
+    );
+}
+
+#[test]
+fn daemon_query_embedding_response_accepts_the_exact_model_contract() -> Result<()> {
+    let contract = semantic_model_contract();
+    let expected = embedding();
+    let response = daemon_embedding_response(contract, json!(expected));
+
+    let (actual, query_embed_ms) = parse_daemon_query_embedding_response(&response, contract)?;
+
+    assert_eq!(actual, expected);
+    assert_eq!(query_embed_ms, 17);
+    Ok(())
+}
+
+#[test]
+fn daemon_query_embedding_response_accepts_the_frozen_legacy_v1_contract() -> Result<()> {
+    let contract = semantic_model_contract();
+    let expected = embedding();
+    let mut response = daemon_embedding_response(contract, json!(expected));
+    let response_object = response.as_object_mut().expect("object");
+    response_object.remove("model_contract_fingerprint");
+    response_object.remove("schema_version");
+
+    let (actual, query_embed_ms) = parse_daemon_query_embedding_response(&response, contract)?;
+
+    assert_eq!(actual, expected);
+    assert_eq!(query_embed_ms, 17);
+    Ok(())
+}
+
+#[test]
+fn daemon_query_embedding_response_rejects_incompatible_protocol_identity() {
+    let contract = semantic_model_contract();
+    let valid = daemon_embedding_response(contract, json!(embedding()));
+    let mut invalid = Vec::new();
+
+    let mut missing_ok = valid.clone();
+    missing_ok.as_object_mut().expect("object").remove("ok");
+    invalid.push(("missing ok".to_owned(), missing_ok, "daemon query failed"));
+
+    let mut negative_ok = valid.clone();
+    negative_ok["ok"] = Value::Bool(false);
+    negative_ok["error"] = json!("daemon rejected response");
+    invalid.push((
+        "negative ok".to_owned(),
+        negative_ok,
+        "daemon rejected response",
+    ));
+
+    for (case, field, mismatch, expected) in [
+        (
+            "schema",
+            "schema_version",
+            json!(2),
+            "daemon query response schema_version mismatch",
+        ),
+        (
+            "model key",
+            "model_key",
+            json!("different-model"),
+            "daemon query response model key mismatch",
+        ),
+        (
+            "model contract fingerprint",
+            "model_contract_fingerprint",
+            json!("sha256:mismatched"),
+            "daemon query response model contract fingerprint mismatch",
+        ),
+    ] {
+        if field != "model_contract_fingerprint" {
+            let mut missing = valid.clone();
+            missing.as_object_mut().expect("object").remove(field);
+            invalid.push((format!("missing {case}"), missing, expected));
+        }
+
+        let mut mismatched = valid.clone();
+        mismatched[field] = mismatch;
+        invalid.push((format!("mismatched {case}"), mismatched, expected));
+    }
+
+    for (case, response, expected) in invalid {
+        let error = parse_daemon_query_embedding_response(&response, contract)
+            .expect_err("an incompatible daemon response must fail closed");
+
+        assert_eq!(error.to_string(), expected, "{case}");
+    }
+}
+
+#[test]
+fn daemon_query_embedding_response_rejects_malformed_vectors() {
+    let contract = semantic_model_contract();
+    let malformed = [
+        (
+            "dimensions",
+            json!(vec![0.0; contract.dimensions() - 1]),
+            "dimensions, expected",
+        ),
+        (
+            "finiteness",
+            {
+                let mut vector = embedding().into_iter().map(Value::from).collect::<Vec<_>>();
+                vector[0] = json!(f64::MAX);
+                Value::Array(vector)
+            },
+            "contains a non-finite value",
+        ),
+        (
+            "normalization",
+            {
+                let mut vector = embedding();
+                vector[0] = 2.0;
+                json!(vector)
+            },
+            "is not L2-normalized",
+        ),
+    ];
+
+    for (case, vector, expected) in malformed {
+        let response = daemon_embedding_response(contract, vector);
+        let error = parse_daemon_query_embedding_response(&response, contract)
+            .expect_err("a malformed daemon vector must fail closed");
+        assert!(
+            error.to_string().contains(expected),
+            "{case} error was {error:#}"
+        );
+    }
+}
+
+#[test]
 fn foreground_adapter_is_lazy_and_borrows_the_exact_data_root() {
     let data_root = std::path::PathBuf::from("foreground-query-root");
     let adapter = SemanticQueryAdapter::foreground(&data_root);
 
     assert!(std::ptr::eq(adapter.data_root, data_root.as_path()));
-    let SemanticQueryExecution::Foreground { runtime, .. } = &adapter.execution else {
+    let SemanticQueryExecution::Foreground { executor } = &adapter.execution else {
         panic!("manual wait must select foreground semantic execution");
     };
     assert!(
-        !runtime.is_loaded(),
+        !executor.shared_runtime().is_loaded(),
         "constructing the adapter must not load the model before semantic retrieval begins"
     );
 }
@@ -177,10 +331,10 @@ fn foreground_empty_generation_converges_without_loading_a_model() -> Result<()>
         session.prepare_alternative("empty generation")?,
         compact_json(json!({"query_embed_ms": null}))
     );
-    let SemanticQueryExecution::Foreground { runtime, .. } = &adapter.execution else {
+    let SemanticQueryExecution::Foreground { executor } = &adapter.execution else {
         unreachable!("foreground constructor selected daemon execution")
     };
-    assert!(!runtime.is_loaded());
+    assert!(!executor.shared_runtime().is_loaded());
     Ok(())
 }
 
@@ -193,7 +347,9 @@ impl SemanticBatchEmbedder for FixtureSemanticEmbedder {
 }
 
 fn reconcile_ready_nonempty_generation(index: &VerifiedIndex, data_root: &Path) -> Result<()> {
-    let mut store = SemanticVectorStore::open(&source_backed_semantic_vector_path(data_root))?;
+    let contract = semantic_model_contract();
+    let mut store =
+        SemanticVectorStore::open(&source_backed_semantic_vector_path(data_root), contract)?;
     let mut builder = SourceBackedSemanticDocumentBuilder::new(index);
     let mut embedder = FixtureSemanticEmbedder;
     for _ in 0..32 {
@@ -232,11 +388,11 @@ fn foreground_ready_nonempty_generation_skips_model_and_writable_reconciliation(
         started.elapsed() < Duration::from_secs(1),
         "a ready foreground query must not wait on the Flat write transaction lock"
     );
-    let SemanticQueryExecution::Foreground { runtime, .. } = &adapter.execution else {
+    let SemanticQueryExecution::Foreground { executor } = &adapter.execution else {
         unreachable!("foreground constructor selected daemon execution")
     };
     assert!(
-        !runtime.is_loaded(),
+        !executor.shared_runtime().is_loaded(),
         "a ready foreground query must not acquire or load the semantic model"
     );
     Ok(())
@@ -248,7 +404,8 @@ fn ready_adapter<'a>(
     event_id: Uuid,
     vector_root: &Path,
 ) -> Result<SemanticQuerySession<'a>> {
-    let mut store = SemanticVectorStore::open(vector_root)?;
+    let contract = semantic_model_contract();
+    let mut store = SemanticVectorStore::open(vector_root, contract)?;
     publish_chunk_replacements(
         &mut store,
         &[(
@@ -274,7 +431,8 @@ fn adapter_never_embeds_before_missing_or_unacknowledged_store_preflight() -> Re
         let temp = tempfile::tempdir()?;
         let (index, _) = semantic_index(temp.path())?;
         if unacknowledged_store {
-            SemanticVectorStore::open(&source_backed_semantic_vector_path(temp.path()))?;
+            let contract = semantic_model_contract();
+            SemanticVectorStore::open(&source_backed_semantic_vector_path(temp.path()), contract)?;
         }
         let error = SemanticQuerySession::begin(&index, temp.path())
             .err()
@@ -300,7 +458,8 @@ fn adapter_never_embeds_before_acknowledged_stale_generation_preflight() -> Resu
     let temp = tempfile::tempdir()?;
     let (stale_index, _) = semantic_index_revision(temp.path(), 1, false)?;
     let semantic_path = source_backed_semantic_vector_path(temp.path());
-    let mut store = SemanticVectorStore::open(&semantic_path)?;
+    let contract = semantic_model_contract();
+    let mut store = SemanticVectorStore::open(&semantic_path, contract)?;
     acknowledge_empty_generation(&mut store, &stale_index)?;
     assert!(matches!(
         store.source_backed_generation_pin_exact(stale_index.generation_id(), 0)?,
@@ -334,7 +493,7 @@ fn adapter_never_embeds_for_mismatched_or_ready_empty_pins() -> Result<()> {
         )?;
         let mut adapter = SemanticQuerySession::from_pin(&index, temp.path(), pin);
         let calls = Cell::new(0_u8);
-        let result = adapter.prepare_alternative_with("query", |_, _| {
+        let result = adapter.prepare_alternative_with("query", |_, _, _| {
             calls.set(calls.get() + 1);
             Ok(Some((embedding(), 1)))
         });
@@ -395,13 +554,13 @@ fn adapter_embeds_ordered_queries_then_runs_one_scan_with_one_filter_projection(
     let filters = default_compiled_filter();
 
     let first_diagnostics =
-        adapter.prepare_alternative_with("first normalized query", |_, _| {
+        adapter.prepare_alternative_with("first normalized query", |_, _, _| {
             calls.set(calls.get() + 1);
             Ok(Some((embedding(), 17)))
         })?;
     assert_eq!(first_diagnostics["query_embed_ms"], 17);
     let second_diagnostics =
-        adapter.prepare_alternative_with("second normalized query", |_, _| {
+        adapter.prepare_alternative_with("second normalized query", |_, _, _| {
             calls.set(calls.get() + 1);
             Ok(Some((embedding(), 17)))
         })?;
@@ -424,7 +583,7 @@ fn adapter_preserves_daemon_query_service_unavailable_contract() -> Result<()> {
     let calls = Cell::new(0_u8);
 
     let error = adapter
-        .prepare_alternative_with("query", |_, _| {
+        .prepare_alternative_with("query", |_, _, _| {
             calls.set(calls.get() + 1);
             Ok(None)
         })
@@ -452,7 +611,7 @@ fn adapter_scores_only_the_active_flat_core_intersection() -> Result<()> {
         &temp.path().join("vectors"),
     )?;
 
-    adapter.prepare_alternative_with("query", |_, _| Ok(Some((embedding(), 1))))?;
+    adapter.prepare_alternative_with("query", |_, _, _| Ok(Some((embedding(), 1))))?;
     let (candidates, diagnostics) = adapter.search(&default_compiled_filter(), 1)?;
 
     assert!(candidates.is_empty());
@@ -476,6 +635,22 @@ fn adapter_downcasts_engine_not_ready_without_parsing_display_text() {
             detail,
             retryable: true,
         } if detail == "typed engine detail"
+    ));
+}
+
+#[test]
+fn adapter_classifies_stale_daemon_endpoint_as_retryable_not_ready() {
+    let classified = SemanticQueryError::from(anyhow::Error::new(
+        ctx_daemon_service::DaemonQueryServiceUnavailable,
+    ));
+
+    assert!(matches!(
+        classified,
+        SemanticQueryError::NotReady {
+            code: "semantic_query_service_unavailable",
+            retryable: true,
+            ..
+        }
     ));
 }
 

--- a/crates/ctx-daemon-cli/src/query_service.rs
+++ b/crates/ctx-daemon-cli/src/query_service.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use anyhow::Result;
+use ctx_semantic_model::semantic_model_contract;
 use serde_json::{json, Value};
 
 use crate::compact_json;
@@ -12,7 +13,7 @@ pub(crate) use ctx_daemon_service::daemon_query_request;
 
 pub(crate) fn daemon_query_service_available(data_root: &Path) -> bool {
     daemon_query_service_ping(data_root)
-        .is_ok_and(|response| response.is_some_and(|value| response_ok(&value)))
+        .is_ok_and(|response| response.is_some_and(|value| ping_response_is_compatible(&value)))
 }
 
 fn daemon_query_service_ping(data_root: &Path) -> Result<Option<Value>> {
@@ -24,15 +25,26 @@ fn daemon_query_service_ping(data_root: &Path) -> Result<Option<Value>> {
     )
 }
 
-fn response_ok(response: &Value) -> bool {
+fn ping_response_is_compatible(response: &Value) -> bool {
+    let contract = semantic_model_contract();
+    let fingerprint = contract.fingerprint();
     response.get("ok").and_then(Value::as_bool) == Some(true)
+        && response.get("schema_version").and_then(Value::as_u64) == Some(1)
+        && response.get("model_key").and_then(Value::as_str) == Some(contract.model_key())
+        && match response
+            .get("model_contract_fingerprint")
+            .and_then(Value::as_str)
+        {
+            Some(response_fingerprint) => response_fingerprint == fingerprint,
+            None => contract.supports_frozen_legacy_v1(),
+        }
 }
 
 pub(crate) fn daemon_query_service_embedding_runtime(data_root: &Path) -> Option<Value> {
     daemon_query_service_ping(data_root)
         .ok()
         .flatten()
-        .filter(response_ok)
+        .filter(ping_response_is_compatible)
         .and_then(|response| {
             response
                 .get("embedding_runtime")
@@ -54,5 +66,79 @@ pub fn wait_for_daemon_query_service(data_root: &Path, timeout: Duration) -> boo
             return false;
         }
         std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compatible_ping_response() -> Value {
+        let contract = semantic_model_contract();
+        compact_json(json!({
+            "ok": true,
+            "schema_version": 1,
+            "model_key": contract.model_key(),
+            "model_contract_fingerprint": contract.fingerprint(),
+            "embedding_runtime": null,
+            "busy": false,
+        }))
+    }
+
+    #[test]
+    fn readiness_accepts_the_current_ping_contract() {
+        assert!(ping_response_is_compatible(&compatible_ping_response()));
+    }
+
+    #[test]
+    fn readiness_accepts_the_frozen_legacy_v1_ping_without_a_fingerprint() {
+        let mut response = compatible_ping_response();
+        response
+            .as_object_mut()
+            .expect("object")
+            .remove("model_contract_fingerprint");
+
+        assert!(ping_response_is_compatible(&response));
+    }
+
+    #[test]
+    fn readiness_rejects_missing_or_mismatched_ping_contract_fields() {
+        let valid = compatible_ping_response();
+        let mut invalid = Vec::new();
+
+        let mut response = valid.clone();
+        response.as_object_mut().expect("object").remove("ok");
+        invalid.push(("missing ok", response));
+
+        let mut response = valid.clone();
+        response["ok"] = Value::Bool(false);
+        invalid.push(("negative ok", response));
+
+        for (case, field, mismatch) in [
+            ("schema", "schema_version", json!(2)),
+            ("model key", "model_key", json!("different-model")),
+            (
+                "model contract fingerprint",
+                "model_contract_fingerprint",
+                json!("sha256:different"),
+            ),
+        ] {
+            if field != "model_contract_fingerprint" {
+                let mut missing = valid.clone();
+                missing.as_object_mut().expect("object").remove(field);
+                invalid.push((case, missing));
+            }
+
+            let mut mismatched = valid.clone();
+            mismatched[field] = mismatch;
+            invalid.push((case, mismatched));
+        }
+
+        for (case, response) in invalid {
+            assert!(
+                !ping_response_is_compatible(&response),
+                "readiness accepted {case}: {response}"
+            );
+        }
     }
 }

--- a/crates/ctx-daemon-cli/src/source_status.rs
+++ b/crates/ctx-daemon-cli/src/source_status.rs
@@ -6,7 +6,8 @@ use ctx_history_index::{
 };
 use ctx_history_read_application::{history_health_report, HistoryHealthReport};
 use ctx_semantic_index::{
-    source_backed_semantic_vector_path, SemanticVectorStore, SourceBackedGenerationPin,
+    semantic_model_contract, source_backed_semantic_vector_path, SemanticVectorStore,
+    SourceBackedGenerationPin,
 };
 use serde_json::{json, Value};
 
@@ -558,7 +559,7 @@ fn semantic_report(
         }));
     }
 
-    let flat_f32 = match SemanticVectorStore::open_read_only(&path) {
+    let flat_f32 = match SemanticVectorStore::open_read_only(&path, semantic_model_contract()) {
         Ok(Some(store)) => match index.semantic_eligible_event_count() {
             Ok(semantic_documents) => {
                 match validate_public_semantic_counter("semantic_documents", semantic_documents) {

--- a/crates/ctx-daemon-cli/src/source_status_tests.rs
+++ b/crates/ctx-daemon-cli/src/source_status_tests.rs
@@ -8,8 +8,8 @@ use ctx_history_core::{
 };
 use ctx_history_index::{CoreEventRecord, GenerationWriter, WriterOptions};
 use ctx_semantic_index::{
-    SemanticBatchEmbedder, SemanticChunkDocument, SemanticDocumentBuilder, SemanticEventDocument,
-    SemanticVectorStore,
+    semantic_model_contract, SemanticBatchEmbedder, SemanticChunkDocument, SemanticDocumentBuilder,
+    SemanticEventDocument, SemanticVectorStore,
 };
 use ctx_semantic_model::SEMANTIC_DIMENSIONS;
 
@@ -292,8 +292,11 @@ fn semantic_status_reports_ready_only_with_exact_projected_and_filtered_counts()
         .unwrap();
     writer.commit(|_| true).unwrap();
     let index = VerifiedIndex::open(data_root.join("search/lexical")).unwrap();
-    let mut store =
-        SemanticVectorStore::open(&source_backed_semantic_vector_path(&data_root)).unwrap();
+    let mut store = SemanticVectorStore::open(
+        &source_backed_semantic_vector_path(&data_root),
+        semantic_model_contract(),
+    )
+    .unwrap();
     for _ in 0..16 {
         let outcome = store
             .reconcile_source_backed_index(

--- a/crates/ctx-daemon-service/src/daemon_scheduler.rs
+++ b/crates/ctx-daemon-service/src/daemon_scheduler.rs
@@ -757,7 +757,9 @@ fn run_daemon_semantic_job_with_retry(
 }
 
 fn bind_semantic_generation(mut job: Value, core_generation_id: Option<&str>) -> Value {
-    if let Ok(fingerprint) = ctx_semantic_index::source_backed_semantic_contract_fingerprint() {
+    if let Ok(fingerprint) = ctx_semantic_index::source_backed_semantic_contract_fingerprint(
+        ctx_semantic_index::semantic_model_contract(),
+    ) {
         job["source_contract_fingerprint"] = Value::String(fingerprint);
     }
     if let Some(core_generation_id) = core_generation_id {
@@ -767,9 +769,9 @@ fn bind_semantic_generation(mut job: Value, core_generation_id: Option<&str>) ->
 }
 
 fn semantic_generation_needs_catch_up(data_root: &Path, core_generation_id: &str) -> bool {
-    let Ok(contract_fingerprint) =
-        ctx_semantic_index::source_backed_semantic_contract_fingerprint()
-    else {
+    let Ok(contract_fingerprint) = ctx_semantic_index::source_backed_semantic_contract_fingerprint(
+        ctx_semantic_index::semantic_model_contract(),
+    ) else {
         return true;
     };
     let Some(job) = read_daemon_job_status(&daemon_semantic_job_path(data_root)) else {

--- a/crates/ctx-daemon-service/src/daemon_worker.rs
+++ b/crates/ctx-daemon-service/src/daemon_worker.rs
@@ -9,8 +9,8 @@ use ctx_semantic_index::{
 };
 use ctx_semantic_model::{
     semantic_model_acquisition_integrity_error, semantic_model_key, ArtifactFetcher,
-    SemanticDaemonCpuFallbackRequired, SemanticDaemonModelAcquisition, SemanticModelConfig,
-    SemanticModelLoadDeferred, SharedSemanticRuntime,
+    BuiltinSemanticEmbeddingExecutor, SemanticDaemonCpuFallbackRequired,
+    SemanticDaemonModelAcquisition, SemanticEmbeddingExecutor, SemanticModelLoadDeferred,
 };
 use serde_json::{json, Value};
 
@@ -193,14 +193,27 @@ pub(super) fn run_daemon_semantic_job(
         ));
     }
 
-    let admission_operation = if runtime.semantic_runtime.is_loaded() {
+    let executor = BuiltinSemanticEmbeddingExecutor::new(
+        runtime.semantic_runtime.clone(),
+        config.semantic_model_config(data_root),
+    );
+    // Bazel may materialize the model crate separately across this dependency
+    // boundary, so bridge compatibility by fingerprint before opening the
+    // index with its own contract type.
+    let index_contract = ctx_semantic_index::semantic_model_contract();
+    if executor.contract().fingerprint() != index_contract.fingerprint() {
+        return Err(anyhow::anyhow!(
+            "semantic executor model contract does not match the semantic index contract"
+        ));
+    }
+    let admission_operation = if executor.shared_runtime().is_loaded() {
         SemanticBackgroundOperation::IndexBatch
     } else {
         SemanticBackgroundOperation::ModelLoad
     };
     if let Some(deferred) = semantic_background_resource_deferred(data_root, admission_operation) {
         if semantic_resource_deferral_releases_runtime(deferred.reason()) {
-            let _ = runtime.semantic_runtime.release_if_idle();
+            let _ = executor.shared_runtime().release_if_idle();
         }
         return Ok(daemon_semantic_resource_deferred_job(
             last_run_at_ms,
@@ -209,7 +222,7 @@ pub(super) fn run_daemon_semantic_job(
     }
 
     let vector_path = source_backed_semantic_vector_path(data_root);
-    let mut vector_store = SemanticVectorStore::open(&vector_path)?;
+    let mut vector_store = SemanticVectorStore::open(&vector_path, index_contract)?;
     let source_eligible_events = source_generation.semantic_eligible_event_count()?;
     let source_pending = matches!(
         vector_store.source_backed_generation_pin_exact(
@@ -227,7 +240,7 @@ pub(super) fn run_daemon_semantic_job(
             None,
         ));
     }
-    let min_remaining_secs = if runtime.semantic_runtime.is_loaded() {
+    let min_remaining_secs = if executor.shared_runtime().is_loaded() {
         DAEMON_MIN_REMAINING_FOR_JOB_SECS
     } else {
         SEMANTIC_MODEL_INIT_MIN_REMAINING_SECS
@@ -243,25 +256,24 @@ pub(super) fn run_daemon_semantic_job(
         ));
     }
     let source_model_load_needed =
-        source_eligible_events > 0 && !runtime.semantic_runtime.is_loaded();
-    let model_config = config.semantic_model_config(data_root);
+        source_eligible_events > 0 && !executor.shared_runtime().is_loaded();
     if source_model_load_needed {
         match run_daemon_semantic_model_startup_with(
             last_run_at_ms,
             || {
-                runtime
-                    .semantic_runtime
-                    .acquire_for_daemon(&model_config, artifact_fetcher)
+                executor
+                    .shared_runtime()
+                    .acquire_for_daemon(executor.config(), artifact_fetcher)
             },
             |fallback| {
-                runtime
-                    .semantic_runtime
-                    .acquire_cpu_fallback_for_daemon(&model_config, fallback)
+                executor
+                    .shared_runtime()
+                    .acquire_cpu_fallback_for_daemon(executor.config(), fallback)
             },
             |acquisition| {
-                runtime
-                    .semantic_runtime
-                    .ensure_loaded_after_daemon_acquisition(&model_config, acquisition)?;
+                executor
+                    .shared_runtime()
+                    .ensure_loaded_after_daemon_acquisition(executor.config(), acquisition)?;
                 Ok(())
             },
         )? {
@@ -273,8 +285,7 @@ pub(super) fn run_daemon_semantic_job(
         data_root,
         source_generation,
         &mut vector_store,
-        &runtime.semantic_runtime,
-        &model_config,
+        &executor,
         deadline,
     )?;
     let (status, reason, last_error) = if outcome.ready() {
@@ -297,15 +308,13 @@ fn reconcile_source_backed_semantic_page(
     _data_root: &Path,
     generation: PinnedSourceBackedGeneration,
     vector_store: &mut SemanticVectorStore,
-    runtime: &SharedSemanticRuntime,
-    model_config: &SemanticModelConfig,
+    executor: &dyn SemanticEmbeddingExecutor,
     deadline: Option<Instant>,
 ) -> Result<(SourceBackedSemanticOutcome, usize)> {
     let index = generation.into_index();
     let mut builder = SourceBackedSemanticDocumentBuilder::new(&index);
     let mut embedder = RuntimeSourceSemanticEmbedder {
-        runtime,
-        model_config,
+        executor,
         deadline,
         indexed_chunks: 0,
     };
@@ -329,8 +338,7 @@ fn annotate_source_backed_semantic_progress(
 }
 
 struct RuntimeSourceSemanticEmbedder<'a> {
-    runtime: &'a SharedSemanticRuntime,
-    model_config: &'a SemanticModelConfig,
+    executor: &'a dyn SemanticEmbeddingExecutor,
     deadline: Option<Instant>,
     indexed_chunks: usize,
 }
@@ -341,12 +349,18 @@ impl SemanticBatchEmbedder for RuntimeSourceSemanticEmbedder<'_> {
             .iter()
             .map(|chunk| chunk.text().to_owned())
             .collect::<Vec<_>>();
-        let (embeddings, _) =
-            self.runtime
-                .embed_documents(self.model_config, texts, self.deadline)?;
+        let embeddings = execute_document_embeddings(self.executor, texts, self.deadline)?;
         self.indexed_chunks = self.indexed_chunks.saturating_add(embeddings.len());
         Ok(embeddings)
     }
+}
+
+fn execute_document_embeddings(
+    executor: &dyn SemanticEmbeddingExecutor,
+    texts: Vec<String>,
+    deadline: Option<Instant>,
+) -> Result<Vec<Vec<f32>>> {
+    executor.embed_documents(executor.contract().prepare_documents(texts), deadline)
 }
 
 pub(super) fn daemon_semantic_skipped_job(

--- a/crates/ctx-daemon-service/src/daemon_worker_tests.rs
+++ b/crates/ctx-daemon-service/src/daemon_worker_tests.rs
@@ -9,6 +9,10 @@ use ctx_semantic_index::{
     source_backed_semantic_vector_path, SemanticDocumentBuilder,
     SourceBackedSemanticDocumentBuilder,
 };
+use ctx_semantic_model::{
+    semantic_model_contract, PreparedSemanticDocuments, PreparedSemanticQuery,
+    SemanticModelContract,
+};
 
 #[cfg(any(
     all(
@@ -35,6 +39,69 @@ use super::*;
 use crate::{
     daemon_retry::DaemonRetryBackoff, daemon_scheduler::record_daemon_job_retry, CONFIG_FILE,
 };
+
+struct RecordingSemanticExecutor {
+    contract: SemanticModelContract,
+    documents: std::sync::Mutex<Vec<(Vec<String>, Option<Instant>)>>,
+}
+
+impl SemanticEmbeddingExecutor for RecordingSemanticExecutor {
+    fn contract(&self) -> &SemanticModelContract {
+        &self.contract
+    }
+
+    fn embed_query(&self, _query: PreparedSemanticQuery) -> Result<Vec<f32>> {
+        unreachable!("document execution test must not invoke query inference")
+    }
+
+    fn embed_documents(
+        &self,
+        documents: PreparedSemanticDocuments,
+        deadline: Option<Instant>,
+    ) -> Result<Vec<Vec<f32>>> {
+        let documents = documents.into_texts();
+        self.documents
+            .lock()
+            .expect("record semantic documents")
+            .push((documents.clone(), deadline));
+        Ok(documents
+            .iter()
+            .map(|_| {
+                let mut embedding = vec![0.0; self.contract.dimensions()];
+                embedding[0] = 1.0;
+                embedding
+            })
+            .collect())
+    }
+}
+
+#[test]
+fn daemon_document_execution_uses_the_pluggable_prepared_input_seam() -> Result<()> {
+    let executor = RecordingSemanticExecutor {
+        contract: semantic_model_contract().clone(),
+        documents: std::sync::Mutex::new(Vec::new()),
+    };
+    let deadline = Instant::now() + std::time::Duration::from_secs(1);
+
+    let embeddings = execute_document_embeddings(
+        &executor,
+        vec!["raw document".to_owned(), "passage: prepared".to_owned()],
+        Some(deadline),
+    )?;
+
+    assert_eq!(embeddings.len(), 2);
+    assert_eq!(
+        *executor.documents.lock().expect("recorded documents"),
+        [(
+            vec![
+                "passage: raw document".to_owned(),
+                "passage: prepared".to_owned(),
+            ],
+            Some(deadline),
+        )]
+    );
+    Ok(())
+}
 
 #[test]
 fn daemon_job_json_keeps_outcomes_without_live_worker_snapshots() {

--- a/crates/ctx-daemon-service/src/query_service/server/dispatch.rs
+++ b/crates/ctx-daemon-service/src/query_service/server/dispatch.rs
@@ -6,7 +6,8 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use ctx_semantic_model::{
-    semantic_model_cache_available, semantic_model_key, SharedSemanticRuntime,
+    semantic_model_cache_available, semantic_model_contract, BuiltinSemanticEmbeddingExecutor,
+    SemanticEmbeddingExecutor, SemanticModelContract, SharedSemanticRuntime,
 };
 use serde_json::{json, Value};
 
@@ -283,7 +284,7 @@ impl AuthenticatedRequestHandler for CtxAuthenticatedRequestHandler {
             };
         }
         if service.as_str() == SEMANTIC_QUERY_SERVICE_ID {
-            return HandlerOutcome::response(self.handle_semantic_query(&request));
+            return HandlerOutcome::response(Ok(self.semantic_query_response(&request)));
         }
         HandlerOutcome::response(Err(anyhow!(
             "unknown authenticated IPC service `{}`",
@@ -349,6 +350,19 @@ enum SourceRefreshResponse {
 }
 
 impl CtxAuthenticatedRequestHandler {
+    fn semantic_query_response(&self, request: &Value) -> Value {
+        self.handle_semantic_query(request).unwrap_or_else(|error| {
+            let contract = semantic_model_contract();
+            compact_json(json!({
+                "ok": false,
+                "schema_version": 1,
+                "model_key": contract.model_key(),
+                "model_contract_fingerprint": contract.fingerprint(),
+                "error": format!("{error:#}"),
+            }))
+        })
+    }
+
     fn lifecycle_response(&self, key: &str, value: impl Into<Value>) -> SourceRefreshResponse {
         let mut response = json!({
             "schema_version": 1,
@@ -413,25 +427,39 @@ impl CtxAuthenticatedRequestHandler {
 
     fn handle_semantic_query(&self, request: &Value) -> Result<Value> {
         let op = request.get("op").and_then(Value::as_str).unwrap_or("");
+        if !matches!(op, "ping" | "embed_query") {
+            return Err(anyhow!("unknown daemon query operation `{op}`"));
+        }
+        if request.get("schema_version").and_then(Value::as_u64) != Some(1) {
+            return Err(anyhow!("daemon query request schema_version must be 1"));
+        }
+        let contract = semantic_model_contract();
         if op == "ping" {
             let (embedding_runtime, busy) = self.runtime.try_runtime_status_json()?;
             return Ok(compact_json(json!({
                 "ok": true,
                 "schema_version": 1,
-                "model_key": semantic_model_key(),
+                "model_key": contract.model_key(),
+                "model_contract_fingerprint": contract.fingerprint(),
                 "embedding_runtime": embedding_runtime,
                 "busy": busy,
             })));
-        }
-        if op != "embed_query" {
-            return Err(anyhow!("unknown daemon query operation `{op}`"));
         }
         let model_key = request
             .get("model_key")
             .and_then(Value::as_str)
             .unwrap_or("");
-        if model_key != semantic_model_key() {
+        if model_key != contract.model_key() {
             return Err(anyhow!("daemon query model key mismatch"));
+        }
+        let request_contract_fingerprint = request
+            .get("model_contract_fingerprint")
+            .and_then(Value::as_str);
+        if !match request_contract_fingerprint {
+            Some(fingerprint) => fingerprint == contract.fingerprint(),
+            None => contract.supports_frozen_legacy_v1(),
+        } {
+            return Err(anyhow!("daemon query model contract fingerprint mismatch"));
         }
         let text = request
             .get("text")
@@ -442,24 +470,111 @@ impl CtxAuthenticatedRequestHandler {
             return Err(anyhow!("daemon query text is empty"));
         }
         let started = Instant::now();
-        let model_config = self.config.semantic_model_config(&self.data_root);
-        if !self.runtime.is_loaded()
-            && !semantic_model_cache_available(model_config.paths().model_cache_dir())
+        let executor = BuiltinSemanticEmbeddingExecutor::new(
+            self.runtime.clone(),
+            self.config.semantic_model_config(&self.data_root),
+        );
+        if !executor.shared_runtime().is_loaded()
+            && !semantic_model_cache_available(executor.config().paths().model_cache_dir())
         {
             return Err(anyhow!(
                 "semantic model cache is not available to daemon query service"
             ));
         }
-        self.runtime.ensure_loaded_from_cache(&model_config)?;
-        let (embedding, embedding_runtime) =
-            self.runtime.embed_query(&model_config, text.to_owned())?;
+        executor
+            .shared_runtime()
+            .ensure_loaded_from_cache(executor.config())?;
+        let semantic_executor: &dyn SemanticEmbeddingExecutor = &executor;
+        let embedding = semantic_executor
+            .embed_query(semantic_executor.contract().prepare_query(text.to_owned()))?;
         let query_embed_ms = started.elapsed().as_millis() as u64;
-        Ok(compact_json(json!({
-            "ok": true,
-            "model_key": semantic_model_key(),
-            "embedding_runtime": embedding_runtime.to_json(),
-            "query_embed_ms": query_embed_ms,
-            "embedding": embedding,
-        })))
+        successful_semantic_query_response(
+            executor.shared_runtime(),
+            semantic_executor.contract(),
+            embedding,
+            query_embed_ms,
+        )
+    }
+}
+
+fn successful_semantic_query_response(
+    runtime: &SharedSemanticRuntime,
+    contract: &SemanticModelContract,
+    embedding: Vec<f32>,
+    query_embed_ms: u64,
+) -> Result<Value> {
+    let (embedding_runtime, busy) = runtime.try_runtime_status_json()?;
+    Ok(compact_json(json!({
+        "ok": true,
+        "schema_version": 1,
+        "model_key": contract.model_key(),
+        "model_contract_fingerprint": contract.fingerprint(),
+        "embedding_runtime": embedding_runtime,
+        "busy": busy,
+        "query_embed_ms": query_embed_ms,
+        "embedding": embedding,
+    })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn successful_embedding_keeps_busy_runtime_diagnostics_non_fatal() -> Result<()> {
+        let runtime = SharedSemanticRuntime::default();
+        let _busy = runtime.lock_for_test()?;
+        let contract = semantic_model_contract();
+        let mut embedding = vec![0.0; contract.dimensions()];
+        embedding[0] = 1.0;
+        let response =
+            successful_semantic_query_response(&runtime, contract, embedding.clone(), 17)?;
+
+        assert_eq!(response["ok"], true);
+        assert_eq!(response["schema_version"], 1);
+        assert_eq!(response["model_key"], contract.model_key());
+        assert_eq!(
+            response["model_contract_fingerprint"],
+            contract.fingerprint()
+        );
+        assert!(response["embedding_runtime"].is_null());
+        assert_eq!(response["busy"], true);
+        assert_eq!(response["query_embed_ms"], 17);
+        assert_eq!(response["embedding"], json!(embedding));
+        Ok(())
+    }
+
+    #[test]
+    fn semantic_errors_keep_the_current_protocol_identity() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let wakeup = Arc::new(DaemonWakeup::default());
+        let source_refresh = Arc::new(crate::source_backed_refresh_adapter::refresh_engine(
+            &crate::test_support::CONFIG,
+        ));
+        let handler = ctx_authenticated_request_handler(
+            temp.path(),
+            SharedSemanticRuntime::default(),
+            source_refresh,
+            wakeup,
+            &crate::test_support::CONFIG,
+        );
+        let response = handler.semantic_query_response(&compact_json(json!({
+            "schema_version": 1,
+            "op": "embed_query",
+            "model_key": "wrong-model",
+            "text": "query",
+        })));
+        let contract = semantic_model_contract();
+
+        assert_eq!(response["ok"], false);
+        assert_eq!(response["schema_version"], 1);
+        assert_eq!(response["model_key"], contract.model_key());
+        assert_eq!(
+            response["model_contract_fingerprint"],
+            contract.fingerprint()
+        );
+        assert!(response["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("model key mismatch")));
     }
 }

--- a/crates/ctx-daemon-service/src/query_service_transport_tests.rs
+++ b/crates/ctx-daemon-service/src/query_service_transport_tests.rs
@@ -25,13 +25,21 @@ fn short_test_query_socket_path() -> Result<(tempfile::TempDir, PathBuf)> {
 
 #[cfg(any(unix, windows))]
 fn start_test_query_service(data_root: &Path) -> Result<DaemonQueryService> {
+    start_test_query_service_with_runtime(data_root, SharedSemanticRuntime::default())
+}
+
+#[cfg(any(unix, windows))]
+fn start_test_query_service_with_runtime(
+    data_root: &Path,
+    runtime: SharedSemanticRuntime,
+) -> Result<DaemonQueryService> {
     let wakeup = Arc::new(super::daemon_wakeup::DaemonWakeup::default());
     let source_refresh = Arc::new(super::source_backed_refresh_adapter::refresh_engine(
         &crate::test_support::CONFIG,
     ));
     let handler = ctx_authenticated_request_handler(
         data_root,
-        SharedSemanticRuntime::default(),
+        runtime,
         source_refresh,
         wakeup,
         &crate::test_support::CONFIG,
@@ -778,9 +786,146 @@ fn query_service_ping_stays_healthy_while_embedder_is_busy() -> Result<()> {
     .expect("query response");
 
     assert_eq!(response.get("ok").and_then(Value::as_bool), Some(true));
+    assert_eq!(response["schema_version"], 1);
+    assert!(response["model_key"]
+        .as_str()
+        .is_some_and(|model_key| !model_key.is_empty()));
+    assert!(response["model_contract_fingerprint"]
+        .as_str()
+        .is_some_and(|fingerprint| fingerprint.starts_with("sha256:")));
     assert_eq!(response.get("busy").and_then(Value::as_bool), Some(true));
     assert!(response["embedding_runtime"].is_null());
     assert!(started.elapsed() < StdDuration::from_millis(500));
+    drop(service);
+    Ok(())
+}
+
+#[cfg(any(unix, windows))]
+#[test]
+fn semantic_query_protocol_rejects_incompatible_requests_before_model_access() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let runtime = SharedSemanticRuntime::default();
+    let service = start_test_query_service_with_runtime(temp.path(), runtime.clone())?;
+    let negotiated = daemon_query_request(
+        temp.path(),
+        compact_json(json!({"schema_version": 1, "op": "ping"})),
+        StdDuration::from_secs(1),
+        64 * 1024,
+    )?
+    .expect("query response");
+    assert_eq!(negotiated["ok"], true);
+    assert_eq!(negotiated["schema_version"], 1);
+    let model_key = negotiated["model_key"]
+        .as_str()
+        .ok_or_else(|| anyhow!("ping response omitted model key"))?
+        .to_owned();
+    let contract_fingerprint = negotiated["model_contract_fingerprint"]
+        .as_str()
+        .ok_or_else(|| anyhow!("ping response omitted model contract fingerprint"))?
+        .to_owned();
+    let exact_embed = compact_json(json!({
+        "schema_version": 1,
+        "op": "embed_query",
+        "model_key": model_key,
+        "model_contract_fingerprint": contract_fingerprint,
+        "text": "query text",
+    }));
+    let mut invalid = Vec::new();
+
+    for schema in [None, Some(2)] {
+        let mut ping = compact_json(json!({"op": "ping"}));
+        let mut embed = exact_embed.clone();
+        embed
+            .as_object_mut()
+            .expect("object")
+            .remove("schema_version");
+        if let Some(schema) = schema {
+            ping["schema_version"] = json!(schema);
+            embed["schema_version"] = json!(schema);
+        }
+        invalid.push((
+            "ping schema",
+            ping,
+            "daemon query request schema_version must be 1",
+        ));
+        invalid.push((
+            "embed schema",
+            embed,
+            "daemon query request schema_version must be 1",
+        ));
+    }
+
+    let mut mismatched_fingerprint = exact_embed.clone();
+    mismatched_fingerprint["model_contract_fingerprint"] = json!("sha256:mismatched");
+    invalid.push((
+        "mismatched embed fingerprint",
+        mismatched_fingerprint,
+        "daemon query model contract fingerprint mismatch",
+    ));
+
+    let runtime_guard = runtime.lock_for_test()?;
+    for (case, request, expected_error) in invalid {
+        let response =
+            daemon_query_request(temp.path(), request, StdDuration::from_secs(1), 64 * 1024)?
+                .expect("query response");
+        assert_eq!(response["ok"], false, "{case}: {response}");
+        assert_eq!(response["error"], expected_error, "{case}: {response}");
+    }
+    drop(runtime_guard);
+    assert!(!runtime.is_loaded());
+
+    let mut legacy_embed = exact_embed.clone();
+    legacy_embed
+        .as_object_mut()
+        .expect("object")
+        .remove("model_contract_fingerprint");
+    let legacy_response = daemon_query_request(
+        temp.path(),
+        legacy_embed,
+        StdDuration::from_secs(1),
+        64 * 1024,
+    )?
+    .expect("legacy query response");
+    assert_eq!(legacy_response["ok"], false);
+    assert_eq!(legacy_response["schema_version"], 1);
+    assert_eq!(legacy_response["model_key"], model_key);
+    assert_eq!(
+        legacy_response["model_contract_fingerprint"],
+        contract_fingerprint
+    );
+    assert_eq!(
+        legacy_response["error"],
+        "semantic model cache is not available to daemon query service"
+    );
+
+    let exact_ping = daemon_query_request(
+        temp.path(),
+        compact_json(json!({"schema_version": 1, "op": "ping"})),
+        StdDuration::from_secs(1),
+        64 * 1024,
+    )?
+    .expect("query response");
+    assert_eq!(exact_ping["ok"], true);
+    assert_eq!(exact_ping["schema_version"], 1);
+    assert_eq!(exact_ping["model_key"], model_key);
+    assert_eq!(
+        exact_ping["model_contract_fingerprint"],
+        contract_fingerprint
+    );
+
+    let exact_embed = daemon_query_request(
+        temp.path(),
+        exact_embed,
+        StdDuration::from_secs(1),
+        64 * 1024,
+    )?
+    .expect("query response");
+    assert_eq!(exact_embed["ok"], false);
+    assert_eq!(
+        exact_embed["error"],
+        "semantic model cache is not available to daemon query service"
+    );
+    assert!(!runtime.is_loaded());
     drop(service);
     Ok(())
 }

--- a/crates/ctx-daemon-service/src/test_support.rs
+++ b/crates/ctx-daemon-service/src/test_support.rs
@@ -5,7 +5,7 @@ use ctx_client_observability::analytics::{
     Outcome, ProviderRefreshCompletedV1, PublicEventV1, Surface,
 };
 use ctx_history_capture::DiscoveryContext;
-use ctx_semantic_index::{SemanticVectorStore, SourceBackedGenerationPin};
+use ctx_semantic_index::{semantic_model_contract, SemanticVectorStore, SourceBackedGenerationPin};
 use ctx_semantic_model::{
     ArtifactFetchRequest, ArtifactFetcher, SemanticModelConfig, SemanticModelPaths,
     SemanticOnnxRuntimePaths,
@@ -26,7 +26,7 @@ pub(crate) static ARTIFACT: TestArtifact = TestArtifact;
 pub(crate) static OBSERVATION: TestObservation = TestObservation;
 
 pub(crate) fn semantic_contract_fingerprint() -> Result<String> {
-    ctx_semantic_index::source_backed_semantic_contract_fingerprint()
+    ctx_semantic_index::source_backed_semantic_contract_fingerprint(semantic_model_contract())
 }
 
 pub(crate) fn semantic_vector_path(data_root: &Path) -> std::path::PathBuf {
@@ -34,7 +34,10 @@ pub(crate) fn semantic_vector_path(data_root: &Path) -> std::path::PathBuf {
 }
 
 pub(crate) fn seed_filter_unaware_semantic_state(path: &Path) -> Result<()> {
-    ctx_semantic_index::test_support::seed_filter_unaware_derived_state(path)
+    ctx_semantic_index::test_support::seed_filter_unaware_derived_state(
+        path,
+        semantic_model_contract(),
+    )
 }
 
 pub(crate) fn current_semantic_vector_schema_version() -> i64 {
@@ -42,7 +45,7 @@ pub(crate) fn current_semantic_vector_schema_version() -> i64 {
 }
 
 pub(crate) fn semantic_generation_is_ready_empty(path: &Path, generation: &str) -> Result<bool> {
-    let Some(store) = SemanticVectorStore::open_read_only(path)? else {
+    let Some(store) = SemanticVectorStore::open_read_only(path, semantic_model_contract())? else {
         return Ok(false);
     };
     Ok(matches!(

--- a/crates/ctx-semantic-index/src/indexing.rs
+++ b/crates/ctx-semantic-index/src/indexing.rs
@@ -1,4 +1,4 @@
-use ctx_semantic_model::semantic_e5_passage_text;
+use ctx_semantic_model::SemanticModelContract;
 use sha2::{Digest, Sha256};
 
 use super::{vector_store::SemanticChunkDocument, SemanticEventDocument};
@@ -26,7 +26,7 @@ pub(super) fn semantic_chunks_for_document(
                 seq: doc.seq,
                 chunk_index,
                 source_text_hash: source_text_hash.to_owned(),
-                text: semantic_embedded_chunk_text(doc, &text),
+                text: semantic_document_input_text(doc, &text),
                 start_char,
                 end_char,
             },
@@ -35,6 +35,7 @@ pub(super) fn semantic_chunks_for_document(
 }
 
 pub(super) fn semantic_document_hash(
+    model_contract: &SemanticModelContract,
     doc: &SemanticEventDocument,
     source_text: &str,
     semantic_policy_fingerprint: &str,
@@ -44,22 +45,33 @@ pub(super) fn semantic_document_hash(
     // without invalidating otherwise identical vectors.
     semantic_text_hash(&format!(
         "semantic_policy: {semantic_policy_fingerprint}\n\n{}",
-        semantic_embedded_document_text(doc, source_text)
+        semantic_embedded_document_text(model_contract, doc, source_text)
     ))
 }
 
-pub(super) fn semantic_embedded_document_text(doc: &SemanticEventDocument, body: &str) -> String {
-    semantic_embedded_chunk_text(doc, body)
+pub(super) fn semantic_embedded_document_text(
+    model_contract: &SemanticModelContract,
+    doc: &SemanticEventDocument,
+    body: &str,
+) -> String {
+    semantic_embedded_chunk_text(model_contract, doc, body)
 }
 
-pub(super) fn semantic_embedded_chunk_text(doc: &SemanticEventDocument, body: &str) -> String {
+pub(super) fn semantic_embedded_chunk_text(
+    model_contract: &SemanticModelContract,
+    doc: &SemanticEventDocument,
+    body: &str,
+) -> String {
+    model_contract.document_text(&semantic_document_input_text(doc, body))
+}
+
+fn semantic_document_input_text(doc: &SemanticEventDocument, body: &str) -> String {
     let header = semantic_document_header(doc);
-    let text = if header.is_empty() {
+    if header.is_empty() {
         body.to_owned()
     } else {
         format!("{header}\n\n{body}")
-    };
-    semantic_e5_passage_text(&text)
+    }
 }
 
 pub(super) fn semantic_document_header(doc: &SemanticEventDocument) -> String {
@@ -155,12 +167,13 @@ pub(super) fn semantic_text_hash(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use ctx_history_core::{EventRole, EventType};
+    use ctx_semantic_model::semantic_model_contract;
     use uuid::Uuid;
 
     use super::*;
 
     #[test]
-    fn document_hash_keeps_one_e5_passage_prefix() {
+    fn document_hash_uses_the_contract_document_prefix_exactly_once() {
         let document = SemanticEventDocument {
             event_id: Uuid::nil(),
             session_id: None,
@@ -175,15 +188,29 @@ mod tests {
             literal_facts: Vec::new(),
             text: "daemon failed to restart".to_owned(),
         };
-        let embedded = semantic_embedded_document_text(&document, &document.text);
+        let model_contract = semantic_model_contract();
+        let embedded = semantic_embedded_document_text(model_contract, &document, &document.text);
+        let chunks = semantic_chunks_for_document(&document, &document.text, &"0".repeat(64));
 
         assert_eq!(
             embedded,
             "passage: semantic_document: v3\nevent_type: message\nrole: user\n\ndaemon failed to restart"
         );
         assert_eq!(embedded.matches("passage: ").count(), 1);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].text.matches("passage: ").count(), 0);
         assert_eq!(
-            semantic_document_hash(&document, &document.text, "semantic-policy-fixture"),
+            model_contract.document_text(&chunks[0].text),
+            embedded,
+            "the executor must perform the sole preparation step"
+        );
+        assert_eq!(
+            semantic_document_hash(
+                model_contract,
+                &document,
+                &document.text,
+                "semantic-policy-fixture",
+            ),
             "759a8ad7af9c74ee56fe04157b610ad76537e48c83d224bc794f95e9f14f83bc"
         );
     }

--- a/crates/ctx-semantic-index/src/lib.rs
+++ b/crates/ctx-semantic-index/src/lib.rs
@@ -15,6 +15,7 @@ mod vector_store_schema;
 mod vector_store_search;
 mod vector_store_state;
 
+pub use ctx_semantic_model::{semantic_model_contract, SemanticModelContract};
 pub use document::SemanticEventDocument;
 pub use query_index::{SemanticNotReady, SemanticQueryPin};
 pub use source_document::SourceBackedSemanticDocumentBuilder;
@@ -35,7 +36,7 @@ pub mod test_support {
         query_index::SemanticQueryPin,
         vector_store::{flat_segments::PinnedFlatGeneration, SemanticChunkDocument},
         vector_store_schema::SemanticVectorStoreError,
-        SemanticVectorStore, SourceBackedGenerationPin,
+        SemanticModelContract, SemanticVectorStore, SourceBackedGenerationPin,
     };
 
     #[allow(clippy::too_many_arguments)]
@@ -100,8 +101,11 @@ pub mod test_support {
         super::vector_store_schema::SEMANTIC_VECTOR_SCHEMA_VERSION
     }
 
-    pub fn seed_filter_unaware_derived_state(root: &std::path::Path) -> Result<()> {
-        super::vector_store::seed_filter_unaware_derived_state(root)
+    pub fn seed_filter_unaware_derived_state(
+        root: &std::path::Path,
+        contract: &SemanticModelContract,
+    ) -> Result<()> {
+        super::vector_store::seed_filter_unaware_derived_state(root, contract)
     }
 }
 

--- a/crates/ctx-semantic-index/src/query_index.rs
+++ b/crates/ctx-semantic-index/src/query_index.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, Result};
 use ctx_history_index::{
     CompiledSearchFilter, EventSearchCandidate, SemanticFilterProjection, VerifiedIndex,
 };
+use ctx_semantic_model::SemanticModelContract;
 use serde_json::{json, Value};
 use thiserror::Error;
 
@@ -72,9 +73,13 @@ pub struct SemanticQueryPin {
 }
 
 impl SemanticQueryPin {
-    pub fn preflight(index: &VerifiedIndex, data_root: &Path) -> Result<Self> {
+    pub fn preflight(
+        index: &VerifiedIndex,
+        data_root: &Path,
+        contract: &SemanticModelContract,
+    ) -> Result<Self> {
         let vector_root = source_backed_semantic_vector_path(data_root);
-        let vector_store = SemanticVectorStore::open_read_only(&vector_root)
+        let vector_store = SemanticVectorStore::open_read_only(&vector_root, contract)
             .map_err(|error| {
                 semantic_not_ready("semantic_store_unavailable", format!("{error:#}"))
             })?

--- a/crates/ctx-semantic-index/src/query_index/tests.rs
+++ b/crates/ctx-semantic-index/src/query_index/tests.rs
@@ -8,7 +8,7 @@ use ctx_history_core::{
 };
 use ctx_history_index::EventSearchFilters;
 use ctx_history_index::{GenerationWriter, WriterOptions};
-use ctx_semantic_model::SEMANTIC_DIMENSIONS;
+use ctx_semantic_model::semantic_model_contract;
 
 #[test]
 fn semantic_query_boundary_rejects_more_than_32_vectors() {
@@ -87,6 +87,8 @@ fn semantic_filter_is_applied_before_top_k_across_more_than_4096_candidates() ->
     const UNRELATED_EVENTS: u64 = 4_096;
 
     let temp = tempfile::tempdir()?;
+    let contract = semantic_model_contract();
+    let dimensions = contract.dimensions();
     let source = SourceKey::derive(
         "codex",
         "codex_session_jsonl",
@@ -153,9 +155,9 @@ fn semantic_filter_is_applied_before_top_k_across_more_than_4096_candidates() ->
         writer.add_core_record(record)?;
 
         let embedding = if is_target {
-            normalized_test_embedding(0.5, 0.75_f32.sqrt())
+            normalized_test_embedding(dimensions, 0.5, 0.75_f32.sqrt())
         } else {
-            normalized_test_embedding(1.0, 0.0)
+            normalized_test_embedding(dimensions, 1.0, 0.0)
         };
         vector_items.push((
             super::super::vector_store::SemanticChunkDocument {
@@ -187,7 +189,7 @@ fn semantic_filter_is_applied_before_top_k_across_more_than_4096_candidates() ->
     writer.commit(|_| true)?;
     let index = VerifiedIndex::open_pinned(&index_root)?;
 
-    let mut store = SemanticVectorStore::open(&temp.path().join("vectors"))?;
+    let mut store = SemanticVectorStore::open(&temp.path().join("vectors"), contract)?;
     store.publish_chunk_replacements(&vector_items, &[])?;
     let pinned = store
         .flat_pin_generation()?
@@ -208,8 +210,8 @@ fn semantic_filter_is_applied_before_top_k_across_more_than_4096_candidates() ->
         &index,
         &filter,
         &[
-            normalized_test_embedding(0.0, 1.0),
-            normalized_test_embedding(1.0, 0.0),
+            normalized_test_embedding(dimensions, 0.0, 1.0),
+            normalized_test_embedding(dimensions, 1.0, 0.0),
         ],
         1,
     )?;
@@ -236,6 +238,8 @@ fn semantic_filter_is_applied_before_top_k_across_more_than_4096_candidates() ->
 #[test]
 fn semantic_query_scores_only_active_flat_events_that_match_core_metadata() -> Result<()> {
     let temp = tempfile::tempdir()?;
+    let contract = semantic_model_contract();
+    let dimensions = contract.dimensions();
     let source = SourceKey::derive(
         "codex",
         "codex_session_jsonl",
@@ -309,7 +313,7 @@ fn semantic_query_scores_only_active_flat_events_that_match_core_metadata() -> R
                     start_char: 0,
                     end_char: 1,
                 },
-                normalized_test_embedding(1.0, 0.0),
+                normalized_test_embedding(dimensions, 1.0, 0.0),
             ));
         }
     }
@@ -330,7 +334,7 @@ fn semantic_query_scores_only_active_flat_events_that_match_core_metadata() -> R
     writer.commit(|_| true)?;
     let index = VerifiedIndex::open_pinned(&index_root)?;
 
-    let mut store = SemanticVectorStore::open(&temp.path().join("vectors"))?;
+    let mut store = SemanticVectorStore::open(&temp.path().join("vectors"), contract)?;
     store.publish_chunk_replacements(&vector_items, &[])?;
     let pinned = store
         .flat_pin_generation()?
@@ -344,8 +348,12 @@ fn semantic_query_scores_only_active_flat_events_that_match_core_metadata() -> R
         workspace: Some("shared".to_owned()),
         ..EventSearchFilters::default()
     })?;
-    let (candidates, diagnostics) =
-        pin.search(&index, &shared, &[normalized_test_embedding(1.0, 0.0)], 3)?;
+    let (candidates, diagnostics) = pin.search(
+        &index,
+        &shared,
+        &[normalized_test_embedding(dimensions, 1.0, 0.0)],
+        3,
+    )?;
     assert_eq!(candidates.len(), 1);
     assert_eq!(
         candidates[0].event.event_id,
@@ -360,7 +368,7 @@ fn semantic_query_scores_only_active_flat_events_that_match_core_metadata() -> R
     let (candidates, diagnostics) = pin.search(
         &index,
         &filtered_only,
-        &[normalized_test_embedding(1.0, 0.0)],
+        &[normalized_test_embedding(dimensions, 1.0, 0.0)],
         3,
     )?;
     assert!(candidates.is_empty());
@@ -368,8 +376,8 @@ fn semantic_query_scores_only_active_flat_events_that_match_core_metadata() -> R
     Ok(())
 }
 
-fn normalized_test_embedding(first: f32, second: f32) -> Vec<f32> {
-    let mut embedding = vec![0.0; SEMANTIC_DIMENSIONS];
+fn normalized_test_embedding(dimensions: usize, first: f32, second: f32) -> Vec<f32> {
+    let mut embedding = vec![0.0; dimensions];
     let norm = first.mul_add(first, second * second).sqrt();
     embedding[0] = first / norm;
     embedding[1] = second / norm;

--- a/crates/ctx-semantic-index/src/tests.rs
+++ b/crates/ctx-semantic-index/src/tests.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use anyhow::Result;
-use ctx_semantic_model::SEMANTIC_DIMENSIONS;
+use ctx_semantic_model::{semantic_model_contract, SemanticModelContract};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
@@ -10,8 +10,12 @@ use crate::{
     SemanticVectorStore,
 };
 
-fn test_embedding(first: f32, second: f32) -> Vec<f32> {
-    let mut embedding = vec![0.0; SEMANTIC_DIMENSIONS];
+fn test_contract() -> SemanticModelContract {
+    semantic_model_contract().clone()
+}
+
+fn test_embedding(contract: &SemanticModelContract, first: f32, second: f32) -> Vec<f32> {
+    let mut embedding = vec![0.0; contract.dimensions()];
     let norm = first.mul_add(first, second * second).sqrt();
     if norm > 0.0 {
         embedding[0] = first / norm;

--- a/crates/ctx-semantic-index/src/tests/vector_store.rs
+++ b/crates/ctx-semantic-index/src/tests/vector_store.rs
@@ -60,9 +60,11 @@ fn active_counts(store: &SemanticVectorStore) -> Result<(usize, usize)> {
 fn flat_store_control_catalog_has_no_vectors_or_plaintext() -> Result<()> {
     let temp = tempfile::tempdir()?;
     let root = source_backed_semantic_vector_path(temp.path());
+    let contract = test_contract();
     assert_eq!(root, temp.path().join("search").join("semantic"));
-    let store = SemanticVectorStore::open(&root)?;
+    let store = SemanticVectorStore::open(&root, &contract)?;
 
+    assert_eq!(store.contract(), &contract);
     assert!(root.is_dir());
     assert!(root.join("state.sqlite").is_file());
     assert_eq!(
@@ -82,30 +84,38 @@ fn flat_store_control_catalog_has_no_vectors_or_plaintext() -> Result<()> {
     assert!(!schema.contains("event_embedding"));
     assert!(!schema.contains("chunk_text"));
     assert!(!schema.contains("USING vec"));
+    let read_only = SemanticVectorStore::open_read_only(&root, &contract)?
+        .expect("created semantic store must reopen read-only");
+    assert_eq!(read_only.contract(), &contract);
     Ok(())
 }
 
 #[test]
 fn flat_search_is_unique_deterministic_bounded_and_exact() -> Result<()> {
     let temp = tempfile::tempdir()?;
-    let mut store = SemanticVectorStore::open(&source_backed_semantic_vector_path(temp.path()))?;
+    let contract = test_contract();
+    let mut store =
+        SemanticVectorStore::open(&source_backed_semantic_vector_path(temp.path()), &contract)?;
     let first = Uuid::new_v4();
     let second = Uuid::new_v4();
     let first_chunk = test_chunk_at(first, 2, "first", 0, 2);
     let first_hash = first_chunk.source_text_hash.clone();
     store.publish_chunk_replacements(
         &[
-            (first_chunk, test_embedding(1.0, 0.0)),
+            (first_chunk, test_embedding(&contract, 1.0, 0.0)),
             (
                 test_chunk_at(first, 2, "first", 1, 2),
-                test_embedding(0.8, 0.6),
+                test_embedding(&contract, 0.8, 0.6),
             ),
-            (test_chunk(second, 1, "second"), test_embedding(1.0, 0.0)),
+            (
+                test_chunk(second, 1, "second"),
+                test_embedding(&contract, 1.0, 0.0),
+            ),
         ],
         &[],
     )?;
 
-    let search = exact_search(&store, &test_embedding(1.0, 0.0), 2)?;
+    let search = exact_search(&store, &test_embedding(&contract, 1.0, 0.0), 2)?;
     let mut expected = vec![first, second];
     expected.sort();
     assert_eq!(
@@ -130,7 +140,7 @@ fn flat_search_is_unique_deterministic_bounded_and_exact() -> Result<()> {
     );
     let error = exact_search(
         &store,
-        &test_embedding(1.0, 0.0),
+        &test_embedding(&contract, 1.0, 0.0),
         SEMANTIC_EXACT_TOP_K_MAX + 1,
     )
     .err()
@@ -145,29 +155,34 @@ fn flat_search_is_unique_deterministic_bounded_and_exact() -> Result<()> {
 #[test]
 fn thirty_two_query_vectors_touch_each_flat_chunk_once() -> Result<()> {
     let temp = tempfile::tempdir()?;
-    let mut store = SemanticVectorStore::open(&source_backed_semantic_vector_path(temp.path()))?;
+    let contract = test_contract();
+    let mut store =
+        SemanticVectorStore::open(&source_backed_semantic_vector_path(temp.path()), &contract)?;
     let first = Uuid::new_v4();
     let second = Uuid::new_v4();
     store.publish_chunk_replacements(
         &[
             (
                 test_chunk_at(first, 1, "first", 0, 2),
-                test_embedding(1.0, 0.0),
+                test_embedding(&contract, 1.0, 0.0),
             ),
             (
                 test_chunk_at(first, 1, "first", 1, 2),
-                test_embedding(0.8, 0.6),
+                test_embedding(&contract, 0.8, 0.6),
             ),
-            (test_chunk(second, 2, "second"), test_embedding(0.0, 1.0)),
+            (
+                test_chunk(second, 2, "second"),
+                test_embedding(&contract, 0.0, 1.0),
+            ),
         ],
         &[],
     )?;
     let queries = (0..32)
         .map(|index| {
             if index % 2 == 0 {
-                test_embedding(1.0, 0.0)
+                test_embedding(&contract, 1.0, 0.0)
             } else {
-                test_embedding(0.0, 1.0)
+                test_embedding(&contract, 0.0, 1.0)
             }
         })
         .collect::<Vec<_>>();
@@ -181,7 +196,7 @@ fn thirty_two_query_vectors_touch_each_flat_chunk_once() -> Result<()> {
     assert_eq!(search.stats.dot_products, 96);
     assert_eq!(
         search.stats.vector_bytes_read,
-        3 * SEMANTIC_DIMENSIONS * std::mem::size_of::<f32>()
+        3 * contract.dimensions() * std::mem::size_of::<f32>()
     );
     assert_eq!(
         search
@@ -208,32 +223,36 @@ fn thirty_two_query_vectors_touch_each_flat_chunk_once() -> Result<()> {
 fn flat_rewrite_truncation_delete_and_restart_do_not_resurrect_chunks() -> Result<()> {
     let temp = tempfile::tempdir()?;
     let root = source_backed_semantic_vector_path(temp.path());
+    let contract = test_contract();
     let rewritten = Uuid::new_v4();
     let deleted = Uuid::new_v4();
     let rewritten_chunk = test_chunk(rewritten, 4, "rewrite-new");
     let rewritten_hash = rewritten_chunk.source_text_hash.clone();
     {
-        let mut store = SemanticVectorStore::open(&root)?;
+        let mut store = SemanticVectorStore::open(&root, &contract)?;
         store.publish_chunk_replacements(
             &[
                 (
                     test_chunk_at(rewritten, 4, "rewrite-old", 0, 2),
-                    test_embedding(1.0, 0.0),
+                    test_embedding(&contract, 1.0, 0.0),
                 ),
                 (
                     test_chunk_at(rewritten, 4, "rewrite-old", 1, 2),
-                    test_embedding(1.0, 0.0),
+                    test_embedding(&contract, 1.0, 0.0),
                 ),
                 (
                     test_chunk(deleted, 5, "delete-me"),
-                    test_embedding(0.0, 1.0),
+                    test_embedding(&contract, 0.0, 1.0),
                 ),
             ],
             &[],
         )?;
-        store.publish_chunk_replacements(&[(rewritten_chunk, test_embedding(0.0, 1.0))], &[])?;
+        store.publish_chunk_replacements(
+            &[(rewritten_chunk, test_embedding(&contract, 0.0, 1.0))],
+            &[],
+        )?;
         assert_eq!(active_counts(&store)?, (2, 2));
-        let rewritten_hit = exact_search(&store, &test_embedding(1.0, 0.0), 2)?
+        let rewritten_hit = exact_search(&store, &test_embedding(&contract, 1.0, 0.0), 2)?
             .hits
             .into_iter()
             .find(|hit| hit.event_id == rewritten)
@@ -243,9 +262,9 @@ fn flat_rewrite_truncation_delete_and_restart_do_not_resurrect_chunks() -> Resul
         assert_eq!(store.delete_events(&[deleted])?, 1);
     }
 
-    let store = SemanticVectorStore::open(&root)?;
+    let store = SemanticVectorStore::open(&root, &contract)?;
     assert_eq!(active_counts(&store)?, (1, 1));
-    let hits = exact_search(&store, &test_embedding(1.0, 0.0), 10)?.hits;
+    let hits = exact_search(&store, &test_embedding(&contract, 1.0, 0.0), 10)?.hits;
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].event_id, rewritten);
     assert_eq!(hits[0].similarity, 0.0);
@@ -257,11 +276,12 @@ fn flat_rewrite_truncation_delete_and_restart_do_not_resurrect_chunks() -> Resul
 fn future_control_schema_prevents_writable_flat_recovery_mutation() -> Result<()> {
     let temp = tempfile::tempdir()?;
     let root = source_backed_semantic_vector_path(temp.path());
-    let mut store = SemanticVectorStore::open(&root)?;
+    let contract = test_contract();
+    let mut store = SemanticVectorStore::open(&root, &contract)?;
     store.publish_chunk_replacements(
         &[(
             test_chunk(Uuid::new_v4(), 1, "future-schema"),
-            test_embedding(1.0, 0.0),
+            test_embedding(&contract, 1.0, 0.0),
         )],
         &[],
     )?;
@@ -275,7 +295,7 @@ fn future_control_schema_prevents_writable_flat_recovery_mutation() -> Result<()
     control.pragma_update(None, "user_version", SEMANTIC_VECTOR_SCHEMA_VERSION + 1)?;
     drop(control);
 
-    let error = SemanticVectorStore::open(&root)
+    let error = SemanticVectorStore::open(&root, &contract)
         .err()
         .expect("a future control schema must reject writable open");
     assert_eq!(

--- a/crates/ctx-semantic-index/src/vector_store.rs
+++ b/crates/ctx-semantic-index/src/vector_store.rs
@@ -51,7 +51,15 @@ impl SemanticChunkDocument {
 pub struct SemanticVectorStore {
     pub(super) conn: Connection,
     pub(super) flat: flat_segments::FlatSegmentStore,
+    pub(super) contract: SemanticModelContract,
 }
+
+impl SemanticVectorStore {
+    pub fn contract(&self) -> &SemanticModelContract {
+        &self.contract
+    }
+}
+use ctx_semantic_model::SemanticModelContract;
 use rusqlite::Connection;
 use uuid::Uuid;
 
@@ -67,15 +75,16 @@ pub(super) mod flat_scan;
 pub(super) mod flat_segments;
 
 #[cfg(any(test, feature = "test-support"))]
-pub(crate) fn seed_filter_unaware_derived_state(path: &std::path::Path) -> anyhow::Result<()> {
+pub(crate) fn seed_filter_unaware_derived_state(
+    path: &std::path::Path,
+    contract: &SemanticModelContract,
+) -> anyhow::Result<()> {
     const FILTER_UNAWARE_CONTROL_SCHEMA_VERSION: i64 = 5;
 
+    let flat_contract =
+        crate::vector_store_schema::flat_model_contract(contract).map_err(anyhow::Error::new)?;
     let connection = Connection::open(path.join(control::CONTROL_FILE))?;
     connection.pragma_update(None, "user_version", FILTER_UNAWARE_CONTROL_SCHEMA_VERSION)?;
     drop(connection);
-    flat_segments::seed_filter_unaware_manifest(
-        path,
-        crate::vector_store_schema::active_model_contract(),
-    )
-    .map_err(anyhow::Error::new)
+    flat_segments::seed_filter_unaware_manifest(path, flat_contract).map_err(anyhow::Error::new)
 }

--- a/crates/ctx-semantic-index/src/vector_store/flat_segments.rs
+++ b/crates/ctx-semantic-index/src/vector_store/flat_segments.rs
@@ -10,7 +10,6 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use ctx_semantic_model::semantic_model_contract;
 use memmap2::{Mmap, MmapOptions};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -49,6 +48,7 @@ pub(crate) type FlatResult<T> = std::result::Result<T, FlatStoreError>;
 
 const COMPACT_SEGMENT_THRESHOLD: usize = 16;
 const FLAT_SOURCE_RECEIPT_DOMAIN: &[u8] = b"ctx-flat-source-receipt-v1\0";
+pub(crate) const MODEL_CONTRACT_RESET_PENDING_FILE: &str = "flat-model-contract-reset-pending-v1";
 
 #[derive(Debug, Error)]
 pub(crate) enum FlatStoreError {
@@ -85,6 +85,12 @@ pub(crate) struct FlatModelContract {
     pub(crate) pooling: String,
     pub(crate) dimensions: u32,
     pub(crate) normalization: String,
+}
+
+impl FlatModelContract {
+    pub(crate) fn validate(&self) -> FlatResult<()> {
+        validate_model_contract(self)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/crates/ctx-semantic-index/src/vector_store/flat_segments/recovery.rs
+++ b/crates/ctx-semantic-index/src/vector_store/flat_segments/recovery.rs
@@ -1,6 +1,38 @@
 use super::*;
 
 impl FlatSegmentStore {
+    pub(crate) fn model_contract_reset_pending(&self) -> FlatResult<bool> {
+        let path = self.root.join(MODEL_CONTRACT_RESET_PENDING_FILE);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+                Err(FlatStoreError::Corrupt(format!(
+                    "{} is not a regular model-contract reset marker",
+                    path.display()
+                )))
+            }
+            Ok(_) => Ok(true),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(source) => Err(io_error(
+                "inspect model-contract reset marker",
+                &path,
+                source,
+            )),
+        }
+    }
+
+    pub(crate) fn acknowledge_model_contract_reset(&self) -> FlatResult<()> {
+        let path = self.root.join(MODEL_CONTRACT_RESET_PENDING_FILE);
+        match fs::remove_file(&path) {
+            Ok(()) => sync_directory(&self.root),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(source) => Err(io_error(
+                "remove model-contract reset marker",
+                &path,
+                source,
+            )),
+        }
+    }
+
     pub(crate) fn compact(&self) -> FlatResult<FlatPublishOutcome> {
         self.require_writable()?;
         let _transaction = self.lock_transaction()?;
@@ -165,6 +197,7 @@ impl FlatSegmentStore {
         let selected = match select_manifest_any(&self.root) {
             Ok(selected) => selected,
             Err(FlatStoreError::LegacySchema(_)) => {
+                record_model_contract_reset_pending(&self.root)?;
                 reset_legacy_store(&self.root, &self.contract, &mut report)?;
                 self.clear_pinned()?;
                 report.model_contract_reset = true;
@@ -186,6 +219,7 @@ impl FlatSegmentStore {
                     &mut report,
                     cleanup_obsolete_locked(&self.root, &selected)?,
                 );
+                record_model_contract_reset_pending(&self.root)?;
                 let generation = next_generation(Some(&selected))?;
                 let staged = write_empty_base_segment(&self.root, &self.contract, generation)?;
                 sync_directory(&segments_directory(&self.root))?;
@@ -205,6 +239,23 @@ impl FlatSegmentStore {
         }
         Ok(report)
     }
+}
+
+fn record_model_contract_reset_pending(root: &Path) -> FlatResult<()> {
+    let path = root.join(MODEL_CONTRACT_RESET_PENDING_FILE);
+    if path.exists() {
+        let _ = symlink_metadata_file(&path)?;
+        return Ok(());
+    }
+    let temporary = unique_temporary_path(root, "model-contract-reset");
+    let mut file = create_new_file(&temporary)?;
+    file.write_all(b"pending\n")
+        .map_err(|source| io_error("write model-contract reset marker", &temporary, source))?;
+    file.sync_all()
+        .map_err(|source| io_error("sync model-contract reset marker", &temporary, source))?;
+    drop(file);
+    commit_unique_file(&temporary, &path)?;
+    sync_directory(root)
 }
 
 fn reset_legacy_store(

--- a/crates/ctx-semantic-index/src/vector_store/flat_segments/tests.rs
+++ b/crates/ctx-semantic-index/src/vector_store/flat_segments/tests.rs
@@ -58,6 +58,60 @@ fn visible_chunks(pinned: &PinnedFlatGeneration) -> Vec<(Uuid, u64, u32, Vec<f32
 }
 
 #[test]
+fn explicit_non_default_dimensions_drive_flat_vector_validation() -> FlatResult<()> {
+    let temporary = tempfile::tempdir()
+        .map_err(|source| io_error("create test directory", Path::new("."), source))?;
+    let mut contract = contract();
+    contract.dimensions = 3;
+    let store = FlatSegmentStore::open(temporary.path(), contract.clone())?;
+    let event = Uuid::from_u128(1);
+
+    store.publish_replacement_event_chunks(
+        &[replacement(
+            event,
+            1,
+            1,
+            vec![FlatChunk {
+                chunk_index: 0,
+                start_char: 0,
+                end_char: 1,
+                vector: vec![1.0, 0.0, 0.0],
+            }],
+        )],
+        &[],
+    )?;
+    let wrong_dimensions = replacement(event, 2, 2, vec![chunk(0, [1.0, 0.0, 0.0, 0.0])]);
+    assert!(matches!(
+        store.publish_replacement_event_chunks(&[wrong_dimensions], &[]),
+        Err(FlatStoreError::InvalidInput(_))
+    ));
+    assert_eq!(
+        store
+            .pin_generation()?
+            .ok_or_else(|| FlatStoreError::Corrupt("expected generation".to_owned()))?
+            .model_contract(),
+        &contract
+    );
+    Ok(())
+}
+
+#[test]
+fn invalid_flat_contract_fails_before_creating_writable_state() -> FlatResult<()> {
+    let temporary = tempfile::tempdir()
+        .map_err(|source| io_error("create test directory", Path::new("."), source))?;
+    let root = temporary.path().join("invalid-contract");
+    let mut invalid = contract();
+    invalid.normalization = "L2".to_owned();
+
+    assert!(matches!(
+        FlatSegmentStore::open(&root, invalid),
+        Err(FlatStoreError::InvalidInput(_))
+    ));
+    assert!(!root.exists());
+    Ok(())
+}
+
+#[test]
 fn filter_unaware_manifest_schema_is_rebuilt_as_empty_derived_state() -> FlatResult<()> {
     let temporary = tempfile::tempdir()
         .map_err(|source| io_error("create test directory", Path::new("."), source))?;

--- a/crates/ctx-semantic-index/src/vector_store/flat_segments/validation.rs
+++ b/crates/ctx-semantic-index/src/vector_store/flat_segments/validation.rs
@@ -509,13 +509,10 @@ pub(super) fn validate_vector(vector: &[f32], dimensions: usize) -> FlatResult<(
 }
 
 pub(super) fn validate_model_contract(contract: &FlatModelContract) -> FlatResult<()> {
-    let required_normalization = semantic_model_contract().normalization();
     if contract.contract_version == 0
         || contract.dimensions == 0
         || contract.dimensions > MAX_DIMENSIONS
-        || !contract
-            .normalization
-            .eq_ignore_ascii_case(required_normalization)
+        || contract.normalization != "l2"
     {
         return Err(FlatStoreError::InvalidInput(
             "model contract version/dimensions/normalization are invalid".to_owned(),

--- a/crates/ctx-semantic-index/src/vector_store/source_projection.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection.rs
@@ -10,7 +10,7 @@ use ctx_history_index::{
     SourceCoreRecordAggregate, SourceEventCursor, VerifiedIndex, LEXICAL_SCHEMA_VERSION,
     MAX_SOURCE_EVENT_PAGE_ITEMS,
 };
-use ctx_semantic_model::{semantic_model_contract_descriptor, SEMANTIC_DIMENSIONS};
+use ctx_semantic_model::SemanticModelContract;
 use sha2::{Digest, Sha256};
 #[cfg(test)]
 use uuid::Uuid;
@@ -39,20 +39,22 @@ use manifest::{
 };
 use state::{
     clear_active_source, commit_frontier_after_flat, source_projection_states,
-    source_receipt_matches, SourceProjectionStates,
+    source_receipt_allows_vector_reuse, source_receipt_matches, SourceProjectionStates,
 };
 
 const SEARCH_DIRECTORY: &str = "search";
 const SEMANTIC_DIRECTORY: &str = "semantic";
-
 pub fn source_backed_semantic_vector_path(data_root: &Path) -> PathBuf {
     data_root.join(SEARCH_DIRECTORY).join(SEMANTIC_DIRECTORY)
 }
 
-pub fn source_backed_semantic_contract_fingerprint() -> Result<String> {
-    source_contract_fingerprint()
+/// Returns persisted projection identity for one vector space, excluding
+/// executor, runtime, accelerator, and artifact identity.
+pub fn source_backed_semantic_contract_fingerprint(
+    model_contract: &SemanticModelContract,
+) -> Result<String> {
+    source_contract_fingerprint(model_contract)
 }
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SourceBackedSemanticSource {
     source: SourceKey,
@@ -64,6 +66,7 @@ pub(super) struct SourceBackedSemanticGeneration {
     pub(super) core_generation_id: String,
     pub(super) semantic_policy_fingerprint: String,
     contract_fingerprint: String,
+    trusted_legacy_contract_fingerprint: Option<String>,
     model_descriptor: String,
     semantic_policy: SemanticGenerationPolicy,
     sources: Vec<SourceBackedSemanticSource>,
@@ -72,18 +75,14 @@ pub(super) struct SourceBackedSemanticGeneration {
 impl SourceBackedSemanticGeneration {
     /// Binds semantic catch-up to one verified current-schema Core manifest and
     /// mirrors its exact per-source Core commitments.
-    pub(super) fn from_verified_index(index: &VerifiedIndex) -> Result<Self> {
-        Self::from_verified_index_with_policy(index, current_semantic_generation_policy())
-    }
-
-    fn from_verified_index_with_policy(
+    pub(super) fn from_verified_index(
         index: &VerifiedIndex,
-        semantic_policy: SemanticGenerationPolicy,
+        model_contract: &SemanticModelContract,
     ) -> Result<Self> {
-        Self::from_verified_index_with_authority(
+        Self::from_verified_index_with_policy(
             index,
-            semantic_policy,
-            semantic_model_contract_descriptor(),
+            current_semantic_generation_policy(),
+            model_contract,
         )
     }
 
@@ -133,6 +132,7 @@ impl SourceBackedSemanticGeneration {
             core_generation_id,
             semantic_policy_fingerprint,
             contract_fingerprint,
+            trusted_legacy_contract_fingerprint: None,
             model_descriptor,
             semantic_policy,
             sources,
@@ -307,7 +307,8 @@ impl SemanticVectorStore {
     ) -> Result<SourceBackedSemanticOutcome> {
         semantic_owned_sidecar_result((|| {
             let work_before = self.flat.work_stats();
-            let generation = SourceBackedSemanticGeneration::from_verified_index(index)?;
+            let generation =
+                SourceBackedSemanticGeneration::from_verified_index(index, self.contract())?;
             let mut outcome =
                 self.reconcile_source_backed_generation(index, &generation, builder, embedder)?;
             let work = self.flat.work_since(work_before);
@@ -474,10 +475,8 @@ impl SemanticVectorStore {
         {
             let source_identity_digest = source.aggregate.source_identity_digest();
             let receipt = states.get(source_identity_digest).and_then(Option::as_ref);
-            let vector_reuse_allowed = receipt.is_some_and(|receipt| {
-                receipt.contract_fingerprint == generation.contract_fingerprint
-                    && receipt.semantic_policy_fingerprint == generation.semantic_policy_fingerprint
-            });
+            let vector_reuse_allowed = receipt
+                .is_some_and(|receipt| source_receipt_allows_vector_reuse(receipt, generation));
             if receipt.is_none_or(|receipt| {
                 !source_receipt_matches(
                     receipt,
@@ -551,6 +550,7 @@ impl SemanticVectorStore {
         builder: &mut dyn SemanticDocumentBuilder,
         embedder: &mut dyn SemanticBatchEmbedder,
     ) -> Result<SourceBackedSemanticOutcome> {
+        let model_contract = self.contract().clone();
         let after = frontier
             .after_identity
             .as_deref()
@@ -704,6 +704,7 @@ impl SemanticVectorStore {
                 continue;
             }
             let source_text_sha256 = semantic_document_hash(
+                &model_contract,
                 &document,
                 &source_text,
                 &frontier.semantic_policy_fingerprint,
@@ -783,7 +784,7 @@ impl SemanticVectorStore {
             if embeddings.len() != pending_chunks.len()
                 || embeddings
                     .iter()
-                    .any(|embedding| embedding.len() != SEMANTIC_DIMENSIONS)
+                    .any(|embedding| embedding.len() != model_contract.dimensions())
             {
                 return Err(SemanticVectorStoreError::unavailable(
                     "source-backed semantic embedder returned an invalid batch",

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/manifest.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/manifest.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, Result};
 use ctx_history_core::{core_record_contract_fingerprint, StableEntityKind, IDENTITY_VERSION};
 use ctx_history_index::{current_semantic_generation_policy_hash, CoreEventRecord};
-use ctx_semantic_model::semantic_model_contract_descriptor;
+#[cfg(test)]
+use ctx_semantic_model::semantic_model_contract;
+use ctx_semantic_model::SemanticModelContract;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -206,11 +208,25 @@ pub(super) fn semantic_policy_fingerprint() -> Result<String> {
     Ok(current_semantic_generation_policy_hash()?)
 }
 
-pub(super) fn source_contract_fingerprint() -> Result<String> {
+pub(super) fn source_contract_fingerprint(
+    model_contract: &SemanticModelContract,
+) -> Result<String> {
     source_contract_fingerprint_with_authority(
         &semantic_policy_fingerprint()?,
-        &semantic_model_contract_descriptor(),
+        model_contract.descriptor(),
     )
+}
+
+pub(super) fn trusted_legacy_source_contract_fingerprint(
+    model_contract: &SemanticModelContract,
+    semantic_policy_fingerprint: &str,
+) -> Result<Option<String>> {
+    model_contract
+        .legacy_builtin_descriptor_alias()
+        .map(|descriptor| {
+            source_contract_fingerprint_with_authority(semantic_policy_fingerprint, descriptor)
+        })
+        .transpose()
 }
 
 pub(super) fn source_contract_fingerprint_with_authority(
@@ -252,6 +268,23 @@ fn hex(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
 
+    fn revise_descriptor_component(descriptor: &str, revised_index: usize) -> String {
+        descriptor
+            .split('|')
+            .enumerate()
+            .map(|(index, component)| {
+                if index != revised_index {
+                    return component.to_owned();
+                }
+                component.split_once('=').map_or_else(
+                    || format!("{component}-test-only-revision"),
+                    |(field, _)| format!("{field}=test-only-revision"),
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("|")
+    }
+
     #[test]
     fn source_input_revision_exactly_mirrors_core_schema() {
         assert_eq!(
@@ -262,15 +295,25 @@ mod tests {
 
     #[test]
     fn complete_model_descriptor_participates_in_semantic_contract_identity() {
-        let descriptor = semantic_model_contract_descriptor();
+        let model_contract = semantic_model_contract();
+        let descriptor = model_contract.descriptor();
         let policy = semantic_policy_fingerprint().unwrap();
-        let baseline = source_contract_fingerprint_with_authority(&policy, &descriptor).unwrap();
-        let revised = source_contract_fingerprint_with_authority(
-            &policy,
-            &format!("{descriptor}|test-only-sequence-length-change"),
-        )
-        .unwrap();
-        assert_ne!(baseline, revised);
-        assert_eq!(baseline, source_contract_fingerprint().unwrap());
+        let baseline = source_contract_fingerprint_with_authority(&policy, descriptor).unwrap();
+        for (index, component) in descriptor.split('|').enumerate() {
+            let field = component
+                .split_once('=')
+                .map_or("contract_version", |(field, _)| field);
+            let revised = revise_descriptor_component(descriptor, index);
+            assert_ne!(descriptor, revised, "fixture did not revise {field}");
+            assert_ne!(
+                baseline,
+                source_contract_fingerprint_with_authority(&policy, &revised).unwrap(),
+                "{field} did not rotate source projection identity"
+            );
+        }
+        assert_eq!(
+            baseline,
+            source_contract_fingerprint(model_contract).unwrap()
+        );
     }
 }

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/state.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/state.rs
@@ -1,16 +1,18 @@
 use std::collections::BTreeMap;
 
 use anyhow::Result;
-use ctx_history_index::SourceCoreRecordAggregate;
+use ctx_history_index::{SemanticGenerationPolicy, SourceCoreRecordAggregate, VerifiedIndex};
+use ctx_semantic_model::SemanticModelContract;
 use rusqlite::{params, OptionalExtension, Transaction};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
 use super::manifest::{
     semantic_policy_fingerprint, source_consumer_build_id, source_contract_fingerprint,
-    validate_generation_id, AcknowledgedSourceProjection, SourceProjectionAcknowledgement,
-    SourceProjectionFrontier, SourceTraversalPhase, SOURCE_ACKNOWLEDGEMENT_STATE,
-    SOURCE_CONTRACT_VERSION, SOURCE_FRONTIER_STATE,
+    trusted_legacy_source_contract_fingerprint, validate_generation_id,
+    AcknowledgedSourceProjection, SourceProjectionAcknowledgement, SourceProjectionFrontier,
+    SourceTraversalPhase, SOURCE_ACKNOWLEDGEMENT_STATE, SOURCE_CONTRACT_VERSION,
+    SOURCE_FRONTIER_STATE,
 };
 use super::{
     SemanticVectorStore, SourceBackedGenerationPin, SourceBackedSemanticGeneration,
@@ -54,7 +56,52 @@ pub(super) fn source_receipt_matches(
             == Some(receipt.semantic_eligible_documents)
 }
 
+pub(super) fn source_receipt_allows_vector_reuse(
+    receipt: &FlatSourceReceipt,
+    generation: &SourceBackedSemanticGeneration,
+) -> bool {
+    receipt.semantic_policy_fingerprint == generation.semantic_policy_fingerprint
+        && (receipt.contract_fingerprint == generation.contract_fingerprint
+            || generation.trusted_legacy_contract_fingerprint.as_deref()
+                == Some(receipt.contract_fingerprint.as_str()))
+}
+
+impl SourceBackedSemanticGeneration {
+    pub(super) fn from_verified_index_with_policy(
+        index: &VerifiedIndex,
+        semantic_policy: SemanticGenerationPolicy,
+        model_contract: &SemanticModelContract,
+    ) -> Result<Self> {
+        let mut generation = Self::from_verified_index_with_authority(
+            index,
+            semantic_policy,
+            model_contract.descriptor().to_owned(),
+        )?;
+        generation.trusted_legacy_contract_fingerprint =
+            trusted_legacy_source_contract_fingerprint(
+                model_contract,
+                &generation.semantic_policy_fingerprint,
+            )?;
+        Ok(generation)
+    }
+}
+
 impl SemanticVectorStore {
+    pub(crate) fn record_flat_model_contract_reset(&self) -> Result<()> {
+        let transaction = self.conn.unchecked_transaction()?;
+        transaction.execute(
+            "INSERT INTO semantic_maintenance_state(key, value) VALUES (?1, 'true')
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [FULL_REBUILD_STATE],
+        )?;
+        transaction.execute(
+            "DELETE FROM semantic_maintenance_state WHERE key IN (?1, ?2)",
+            [SOURCE_FRONTIER_STATE, SOURCE_ACKNOWLEDGEMENT_STATE],
+        )?;
+        transaction.commit()?;
+        Ok(())
+    }
+
     pub(super) fn source_frontier(&self) -> Result<Option<SourceProjectionFrontier>> {
         self.maintenance_json(SOURCE_FRONTIER_STATE)
     }
@@ -410,10 +457,10 @@ impl SemanticVectorStore {
         if self.source_frontier()?.is_some() {
             return Ok(None);
         }
-        let fingerprint = expected_contract_fingerprint
-            .map(str::to_owned)
-            .map(Ok)
-            .unwrap_or_else(source_contract_fingerprint)?;
+        let fingerprint = match expected_contract_fingerprint {
+            Some(fingerprint) => fingerprint.to_owned(),
+            None => source_contract_fingerprint(self.contract())?,
+        };
         if acknowledgement.contract_version != SOURCE_CONTRACT_VERSION
             || acknowledgement.contract_fingerprint != fingerprint
             || acknowledgement.core_generation_id != core_generation_id

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests.rs
@@ -17,6 +17,7 @@ use ctx_history_index::{
     current_semantic_generation_policy, CoreEventRecord, GenerationWriter, SourceEventRole,
     VerifiedIndex, WriterOptions,
 };
+use ctx_semantic_model::semantic_model_contract;
 use tempfile::TempDir;
 
 use super::*;
@@ -32,6 +33,10 @@ mod recovery;
 
 const TAIL_TOKEN: &str = "semantic-tail-token-7f0d";
 const EMPTY_DOCUMENT_TOKEN: &str = "semantic-empty-document-fixture-7f0d";
+
+fn open_store(path: &Path) -> Result<SemanticVectorStore> {
+    SemanticVectorStore::open(path, semantic_model_contract())
+}
 
 #[derive(Default)]
 struct CoreBuilder {
@@ -93,7 +98,7 @@ impl SemanticBatchEmbedder for MarkerEmbedder {
         Ok(chunks
             .iter()
             .map(|chunk| {
-                let mut embedding = vec![0.0; SEMANTIC_DIMENSIONS];
+                let mut embedding = vec![0.0; semantic_model_contract().dimensions()];
                 embedding[usize::from(!chunk.text.contains(TAIL_TOKEN))] = 1.0;
                 embedding
             })
@@ -319,7 +324,8 @@ impl Fixture {
     }
 
     fn source_digest(&self, index: &VerifiedIndex, source_index: usize) -> Result<String> {
-        let generation = SourceBackedSemanticGeneration::from_verified_index(index)?;
+        let generation =
+            SourceBackedSemanticGeneration::from_verified_index(index, semantic_model_contract())?;
         generation
             .sources
             .iter()
@@ -366,7 +372,7 @@ fn reconcile_generation(
     index: &VerifiedIndex,
     generation: &SourceBackedSemanticGeneration,
     builder: &mut CoreBuilder,
-    embedder: &mut MarkerEmbedder,
+    embedder: &mut dyn SemanticBatchEmbedder,
 ) -> Result<SourceBackedSemanticOutcome> {
     let mut total = SourceBackedSemanticOutcome::default();
     for _ in 0..128 {
@@ -391,12 +397,12 @@ fn reconcile_all(
     store: &mut SemanticVectorStore,
     index: &VerifiedIndex,
     builder: &mut CoreBuilder,
-    embedder: &mut MarkerEmbedder,
+    embedder: &mut dyn SemanticBatchEmbedder,
 ) -> Result<SourceBackedSemanticOutcome> {
     reconcile_generation(
         store,
         index,
-        &SourceBackedSemanticGeneration::from_verified_index(index)?,
+        &SourceBackedSemanticGeneration::from_verified_index(index, semantic_model_contract())?,
         builder,
         embedder,
     )
@@ -500,7 +506,8 @@ fn semantic_generation_uses_exact_per_source_core_aggregates_without_candidate_t
         "aggregate",
         &[(0, bodies("stable", 3)), (1, bodies("changed", 2))],
     )?;
-    let generation = SourceBackedSemanticGeneration::from_verified_index(&index)?;
+    let generation =
+        SourceBackedSemanticGeneration::from_verified_index(&index, semantic_model_contract())?;
     assert_eq!(SOURCE_CONTRACT_VERSION, 13);
     assert_eq!(SOURCE_INPUT_LEXICAL_SCHEMA_VERSION, 22);
     assert_eq!(index.semantic_eligible_event_count()?, 5);
@@ -561,7 +568,7 @@ fn retrieval_excluded_events_never_enter_the_source_backed_semantic_projection()
     assert!(semantic.terminal);
     assert!(semantic.items.is_empty());
 
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     let outcome = reconcile_all(&mut store, &index, &mut builder, &mut embedder)?;
@@ -622,7 +629,7 @@ fn mixed_core_roles_build_and_pin_only_the_semantic_candidate() -> Result<()> {
     assert_eq!(semantic_page.items.len(), 1);
     assert_eq!(semantic_page.items[0].event_id, user.event_id);
 
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     let outcome = reconcile_all(&mut store, &index, &mut builder, &mut embedder)?;
@@ -680,7 +687,7 @@ fn page_embedding_batches_multiple_documents_in_one_embedder_call() -> Result<()
     writer.commit(|_| true)?;
     let index = VerifiedIndex::open(root)?;
 
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     let outcome = reconcile_all(&mut store, &index, &mut builder, &mut embedder)?;
@@ -736,7 +743,7 @@ fn role_policy_transition_rebuilds_semantic_state_without_reingesting_core() -> 
     let index = VerifiedIndex::open(&root)?;
     let core_generation_id = index.generation_id().to_owned();
 
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     reconcile_all(&mut store, &index, &mut builder, &mut embedder)?;
@@ -744,8 +751,11 @@ fn role_policy_transition_rebuilds_semantic_state_without_reingesting_core() -> 
 
     let mut assistant_policy = current_semantic_generation_policy();
     assistant_policy.candidate_roles = [SourceEventRole::Assistant];
-    let revised =
-        SourceBackedSemanticGeneration::from_verified_index_with_policy(&index, assistant_policy)?;
+    let revised = SourceBackedSemanticGeneration::from_verified_index_with_policy(
+        &index,
+        assistant_policy,
+        semantic_model_contract(),
+    )?;
     builder.calls.clear();
     let rebuilt = reconcile_generation(&mut store, &index, &revised, &mut builder, &mut embedder)?;
     assert_eq!(rebuilt.records_decoded, 2);
@@ -779,7 +789,7 @@ fn role_policy_transition_rebuilds_semantic_state_without_reingesting_core() -> 
 fn exact_generation_pin_distinguishes_not_ready_empty_and_pinned() -> Result<()> {
     let fixture = Fixture::new(1)?;
     let empty = fixture.publish("pin-empty", &[(0, Vec::new())])?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     assert!(matches!(
         store.source_backed_generation_pin_exact(empty.generation_id(), 0)?,
         SourceBackedGenerationPin::NotReady
@@ -830,7 +840,7 @@ fn four_event_source_work_is_independent_of_740k_equivalent_corpus() -> Result<(
         &[(0, stable_large.clone()), (1, stable_small)],
     )?;
     let target = fixture.publish("complexity-b", &[(0, stable_large), (1, appended_small)])?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     assert_eq!(
@@ -864,7 +874,10 @@ fn four_event_source_work_is_independent_of_740k_equivalent_corpus() -> Result<(
     assert_eq!(outcome.records_decoded, 4);
     assert_eq!(builder.calls.len(), 4);
     assert_eq!(outcome.vectors_touched, 1);
-    assert_eq!(outcome.vector_bytes_touched, SEMANTIC_DIMENSIONS as u64 * 4);
+    assert_eq!(
+        outcome.vector_bytes_touched,
+        semantic_model_contract().dimensions() as u64 * 4
+    );
     assert!(outcome.metadata_records_touched < 64);
     // The untouched source contributes zero records, vectors, and bytes to the
     // measured refresh. The same bound therefore applies at the production
@@ -900,7 +913,7 @@ fn sequence_only_core_change_updates_authority_without_embedding() -> Result<()>
         "sequence-b",
         &[(0, vec![(91, "same semantic body".to_owned())])],
     )?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
@@ -940,7 +953,7 @@ fn multi_page_reconciliation_constructs_one_flat_view() -> Result<()> {
     let record_count = MAX_SOURCE_EVENT_PAGE_ITEMS + 4;
     let initial = fixture.publish("view-a", &[(0, bodies("initial", record_count))])?;
     let target = fixture.publish("view-b", &[(0, bodies("rewritten", record_count))])?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
@@ -993,7 +1006,7 @@ fn multipage_source_scales_independently_of_hundreds_of_global_descriptors() -> 
     ));
     let initial = fixture.publish("scaled-global-a", &initial_specs)?;
     let target = fixture.publish("scaled-global-b", &target_specs)?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     reconcile_all(
         &mut store,
         &initial,
@@ -1034,7 +1047,7 @@ fn multi_page_restart_reconstructs_one_view_for_remaining_pages() -> Result<()> 
     let fixture = Fixture::new(1)?;
     let record_count = MAX_SOURCE_EVENT_PAGE_ITEMS + 4;
     let index = fixture.publish("view-restart", &[(0, bodies("restart", record_count))])?;
-    let mut clean = SemanticVectorStore::open(&fixture.data_root.join("semantic-clean-page"))?;
+    let mut clean = open_store(&fixture.data_root.join("semantic-clean-page"))?;
     reconcile_all(
         &mut clean,
         &index,
@@ -1048,7 +1061,7 @@ fn multi_page_restart_reconstructs_one_view_for_remaining_pages() -> Result<()> 
     };
     let mut embedder = MarkerEmbedder::default();
     {
-        let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+        let mut store = open_store(&fixture.semantic_path)?;
         let error = store
             .reconcile_source_backed_index(&index, &mut builder, &mut embedder)
             .unwrap_err();
@@ -1060,7 +1073,7 @@ fn multi_page_restart_reconstructs_one_view_for_remaining_pages() -> Result<()> 
 
     builder.fail_after = None;
     builder.calls.clear();
-    let mut restarted = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut restarted = open_store(&fixture.semantic_path)?;
     assert!(restarted.flat_pin_generation()?.is_none());
     restarted.reset_flat_active_event_snapshot_count();
     let resumed = reconcile_all(&mut restarted, &index, &mut builder, &mut embedder)?;
@@ -1069,7 +1082,7 @@ fn multi_page_restart_reconstructs_one_view_for_remaining_pages() -> Result<()> 
     assert_eq!(resumed.vectors_touched, 4);
     assert_eq!(
         resumed.vector_bytes_touched,
-        4 * SEMANTIC_DIMENSIONS as u64 * 4
+        4 * semantic_model_contract().dimensions() as u64 * 4
     );
     assert_eq!(active_events(&restarted)?, record_count);
     assert_eq!(
@@ -1100,7 +1113,7 @@ fn restart_after_source_receipt_finalization_is_exact() -> Result<()> {
     let fixture = Fixture::new(1)?;
     let initial = fixture.publish("receipt-fault-a", &[(0, bodies("before", 3))])?;
     let target = fixture.publish("receipt-fault-b", &[(0, bodies("after", 4))])?;
-    let mut clean = SemanticVectorStore::open(&fixture.data_root.join("semantic-clean-receipt"))?;
+    let mut clean = open_store(&fixture.data_root.join("semantic-clean-receipt"))?;
     reconcile_all(
         &mut clean,
         &initial,
@@ -1115,7 +1128,7 @@ fn restart_after_source_receipt_finalization_is_exact() -> Result<()> {
     )?;
     let expected = projection_snapshot(&clean)?;
 
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
@@ -1128,7 +1141,7 @@ fn restart_after_source_receipt_finalization_is_exact() -> Result<()> {
         .contains("injected failure after semantic source finalization"));
     drop(store);
 
-    let mut restarted = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut restarted = open_store(&fixture.semantic_path)?;
     reconcile_all(&mut restarted, &target, &mut builder, &mut embedder)?;
     assert_eq!(projection_snapshot(&restarted)?, expected);
     Ok(())
@@ -1142,7 +1155,7 @@ fn restart_after_removed_source_finalization_is_exact() -> Result<()> {
         &[(0, bodies("retained", 2)), (1, bodies("removed", 3))],
     )?;
     let target = fixture.publish("remove-fault-b", &[(0, bodies("retained", 2))])?;
-    let mut clean = SemanticVectorStore::open(&fixture.data_root.join("semantic-clean-removal"))?;
+    let mut clean = open_store(&fixture.data_root.join("semantic-clean-removal"))?;
     reconcile_all(
         &mut clean,
         &initial,
@@ -1157,7 +1170,7 @@ fn restart_after_removed_source_finalization_is_exact() -> Result<()> {
     )?;
     let expected = projection_snapshot(&clean)?;
 
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
@@ -1170,7 +1183,7 @@ fn restart_after_removed_source_finalization_is_exact() -> Result<()> {
         .contains("injected failure after semantic source finalization"));
     drop(store);
 
-    let mut restarted = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut restarted = open_store(&fixture.semantic_path)?;
     reconcile_all(&mut restarted, &target, &mut builder, &mut embedder)?;
     assert_eq!(projection_snapshot(&restarted)?, expected);
     Ok(())
@@ -1180,7 +1193,7 @@ fn restart_after_removed_source_finalization_is_exact() -> Result<()> {
 fn restart_after_final_acknowledgement_is_exact() -> Result<()> {
     let fixture = Fixture::new(1)?;
     let index = fixture.publish("ack-fault", &[(0, bodies("ack", 3))])?;
-    let mut clean = SemanticVectorStore::open(&fixture.data_root.join("semantic-clean-ack"))?;
+    let mut clean = open_store(&fixture.data_root.join("semantic-clean-ack"))?;
     reconcile_all(
         &mut clean,
         &index,
@@ -1189,7 +1202,7 @@ fn restart_after_final_acknowledgement_is_exact() -> Result<()> {
     )?;
     let expected = projection_snapshot(&clean)?;
 
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     store.flat.fail_after_source_acknowledgement_once();
     let error = store
         .reconcile_source_backed_index(
@@ -1203,7 +1216,7 @@ fn restart_after_final_acknowledgement_is_exact() -> Result<()> {
         .contains("injected failure after semantic source acknowledgement"));
     drop(store);
 
-    let mut restarted = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut restarted = open_store(&fixture.semantic_path)?;
     reconcile_all(
         &mut restarted,
         &index,
@@ -1222,7 +1235,7 @@ fn threshold_compaction_rewrites_only_the_changed_source() -> Result<()> {
         "threshold-0",
         &[(0, stable.clone()), (1, bodies("mutable-threshold-0", 2))],
     )?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
@@ -1248,7 +1261,7 @@ fn threshold_compaction_rewrites_only_the_changed_source() -> Result<()> {
     );
     assert_eq!(
         threshold.vector_bytes_touched,
-        4 * SEMANTIC_DIMENSIONS as u64 * 4
+        4 * semantic_model_contract().dimensions() as u64 * 4
     );
     assert_eq!(source_rows(&store, &stable_digest)?, stable_rows);
     assert_eq!(
@@ -1285,7 +1298,7 @@ fn append_rewrite_and_removal_touch_only_owned_source() -> Result<()> {
         ],
     )?;
     let removed = fixture.publish("lifecycle-d", &[(0, bodies("retained", 5))])?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
@@ -1341,7 +1354,7 @@ fn large_multipage_lifecycle_replays_each_source_catalog_once() -> Result<()> {
         ],
     )?;
     let removed = fixture.publish("large-linear-d", &[(0, retained)])?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
@@ -1399,7 +1412,7 @@ fn frontier_commit_manifest_rollback_replays_sequence_and_same_id_rewrite() -> R
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
 
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
     let embedded_initial = embedder.chunks;
     store.flat.fail_after_source_frontier_commit_once();
@@ -1417,7 +1430,7 @@ fn frontier_commit_manifest_rollback_replays_sequence_and_same_id_rewrite() -> R
     assert_eq!(store.flat.rollback_active_manifest()?, committed);
     drop(store);
 
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let replayed = reconcile_all(&mut store, &sequence_only, &mut builder, &mut embedder)?;
     assert_eq!(replayed.records_decoded, 1);
     assert_eq!(replayed.records_reused, 0);
@@ -1459,7 +1472,7 @@ fn frontier_commit_manifest_rollback_replays_sequence_and_same_id_rewrite() -> R
     assert_eq!(store.flat.rollback_active_manifest()?, committed);
     drop(store);
 
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let replayed = reconcile_all(&mut store, &rewrite, &mut builder, &mut embedder)?;
     assert_eq!(replayed.records_decoded, 1);
     assert_eq!(replayed.records_embedded, 1);

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/content.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/content.rs
@@ -27,7 +27,7 @@ fn control_filter_and_full_tail_remain_generation_exact() -> Result<()> {
         .ok_or_else(|| anyhow!("missing complete tail content"))?
         .event_id
         .as_uuid();
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     let outcome = reconcile_all(&mut store, &index, &mut builder, &mut embedder)?;
@@ -39,7 +39,7 @@ fn control_filter_and_full_tail_remain_generation_exact() -> Result<()> {
             return Err(anyhow!("nonempty reconciled generation was not pinned"));
         }
     };
-    let mut query = vec![0.0; SEMANTIC_DIMENSIONS];
+    let mut query = vec![0.0; semantic_model_contract().dimensions()];
     query[0] = 1.0;
     let event_identity_digest = |event_id: Uuid| {
         let mut digest = [0; 32];

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/filter_accounting.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/filter_accounting.rs
@@ -15,7 +15,7 @@ fn mixed_controls_and_empty_content_publish_exact_filter_accounting() -> Result<
             ],
         )],
     )?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let outcome = reconcile_all(
         &mut store,
         &index,
@@ -107,7 +107,7 @@ fn all_filtered_generation_is_ready_empty_with_exact_accounting() -> Result<()> 
             ],
         )],
     )?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let outcome = reconcile_all(
         &mut store,
         &index,
@@ -144,7 +144,7 @@ fn unaccounted_source_drop_cannot_publish_a_receipt() -> Result<()> {
             ],
         )],
     )?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     store.flat.fail_after_source_frontier_commit_once();
     let error = store
         .reconcile_source_backed_index(
@@ -191,7 +191,7 @@ fn corrupted_filter_acknowledgement_is_not_query_ready() -> Result<()> {
             ],
         )],
     )?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     reconcile_all(
         &mut store,
         &index,
@@ -236,7 +236,7 @@ fn vector_reuse_preserves_intentional_filter_accounting() -> Result<()> {
     ];
     let initial = fixture.publish_with_event_sequences("reuse-filter-a", &[(0, records)])?;
     let target = fixture.publish_with_event_sequences("reuse-filter-b", &[(0, resequenced)])?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     reconcile_all(
         &mut store,
         &initial,

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/generation_identity.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/generation_identity.rs
@@ -8,7 +8,7 @@ fn incremental_delta_reopens_catches_up_and_acknowledges_verified_generation() -
     let initial_generation_id = initial.generation_id().to_owned();
     assert_eq!(initial.manifest().generation_id()?, initial_generation_id);
 
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     assert!(reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?.ready);
@@ -30,7 +30,8 @@ fn incremental_delta_reopens_catches_up_and_acknowledges_verified_generation() -
         reopened.manifest().generation_id()?,
         reopened.generation_id()
     );
-    let generation = SourceBackedSemanticGeneration::from_verified_index(&reopened)?;
+    let generation =
+        SourceBackedSemanticGeneration::from_verified_index(&reopened, semantic_model_contract())?;
     assert_eq!(generation.core_generation_id, reopened.generation_id());
 
     let mut stale = generation.clone();

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/generation_recovery.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/generation_recovery.rs
@@ -4,7 +4,7 @@ fn two_lost_candidate_publications_rebuild_from_flat_authority() -> Result<()> {
     let initial = fixture.publish("two-loss-a", &[(0, bodies("initial", 3))])?;
     let middle = fixture.publish("two-loss-b", &[(0, bodies("middle", 3))])?;
     let target = fixture.publish("two-loss-c", &[(0, bodies("target", 4))])?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
@@ -17,7 +17,8 @@ fn two_lost_candidate_publications_rebuild_from_flat_authority() -> Result<()> {
     drop(store);
 
     builder.calls.clear();
-    let mut restarted = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut restarted =
+        SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     reconcile_all(&mut restarted, &target, &mut builder, &mut embedder)?;
     assert!(
         !builder.calls.is_empty(),
@@ -31,7 +32,7 @@ fn two_lost_candidate_publications_rebuild_from_flat_authority() -> Result<()> {
 fn same_generation_wrong_hash_fails_closed() -> Result<()> {
     let fixture = Fixture::new(1)?;
     let index = fixture.publish("wrong-hash", &[(0, bodies("hash", 2))])?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     store.flat.fail_after_source_frontier_commit_once();
     let error = store
         .reconcile_source_backed_index(
@@ -50,7 +51,8 @@ fn same_generation_wrong_hash_fails_closed() -> Result<()> {
     store.store_source_frontier(&frontier)?;
     drop(store);
 
-    let mut restarted = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut restarted =
+        SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let error = restarted
         .reconcile_source_backed_index(
             &index,
@@ -66,7 +68,7 @@ fn same_generation_wrong_hash_fails_closed() -> Result<()> {
 fn disagreeing_retained_candidate_fails_closed() -> Result<()> {
     let fixture = Fixture::new(1)?;
     let index = fixture.publish("candidate-hash", &[(0, bodies("candidate", 2))])?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     store.flat.fail_after_source_finalization_once();
     let error = store
         .reconcile_source_backed_index(
@@ -84,7 +86,8 @@ fn disagreeing_retained_candidate_fails_closed() -> Result<()> {
         .map_err(anyhow::Error::new)?;
     drop(store);
 
-    let mut restarted = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut restarted =
+        SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let error = restarted
         .reconcile_source_backed_index(
             &index,
@@ -121,7 +124,7 @@ fn full_compaction_preserves_receipts_and_readiness_exactly() -> Result<()> {
             ),
         ],
     )?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     reconcile_all(
         &mut store,
         &index,
@@ -169,7 +172,7 @@ fn core_advance_mid_catch_up_never_pins_mixed_generation() -> Result<()> {
             (1, vec!["version a".to_owned()]),
         ],
     )?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/policy_rebuild.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/policy_rebuild.rs
@@ -1,20 +1,76 @@
 use super::*;
-use ctx_semantic_model::semantic_model_contract_descriptor;
+
+#[test]
+fn flat_contract_reset_survives_both_control_handoff_crash_windows() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let index = fixture.publish("flat-contract-reset", &[(0, bodies("first", 3))])?;
+    let contract = semantic_model_contract();
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, contract)?;
+    reconcile_all(
+        &mut store,
+        &index,
+        &mut CoreBuilder::default(),
+        &mut MarkerEmbedder::default(),
+    )?;
+    assert!(store.source_acknowledgement()?.is_some());
+    drop(store);
+
+    let mut changed_flat =
+        crate::vector_store_schema::flat_model_contract(contract).map_err(anyhow::Error::new)?;
+    changed_flat.model_revision.push_str("-test-only");
+    let changed = crate::vector_store::flat_segments::FlatSegmentStore::open(
+        &fixture.semantic_path,
+        changed_flat,
+    )
+    .map_err(anyhow::Error::new)?;
+    assert!(changed.model_contract_reset_pending()?);
+    drop(changed); // Crash after Flat publication and before the control handoff.
+
+    assert!(SemanticVectorStore::open_read_only(&fixture.semantic_path, contract)?.is_none());
+    let store = SemanticVectorStore::open(&fixture.semantic_path, contract)?;
+    assert!(store.source_acknowledgement()?.is_none());
+    assert!(store.source_frontier()?.is_none());
+    assert!(!store.flat.model_contract_reset_pending()?);
+    drop(store);
+
+    fs::write(
+        fixture
+            .semantic_path
+            .join(crate::vector_store::flat_segments::MODEL_CONTRACT_RESET_PENDING_FILE),
+        b"pending\n",
+    )?; // Crash after the control commit and before marker acknowledgement.
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, contract)?;
+    assert!(store.source_acknowledgement()?.is_none());
+    assert!(!store.flat.model_contract_reset_pending()?);
+
+    let mut builder = CoreBuilder::default();
+    let mut embedder = MarkerEmbedder::default();
+    let rebuilt = reconcile_all(&mut store, &index, &mut builder, &mut embedder)?;
+    assert_eq!(rebuilt.records_embedded, 3);
+    assert!(store.source_acknowledgement()?.is_some());
+    assert!(matches!(
+        store.source_backed_generation_pin_exact(index.generation_id(), 3)?,
+        SourceBackedGenerationPin::Ready(_)
+    ));
+    Ok(())
+}
 
 #[test]
 fn descriptor_only_model_change_rebuilds_every_vector_from_unchanged_core() -> Result<()> {
     let fixture = Fixture::new(1)?;
     let index = fixture.publish("revision", &[(0, bodies("first", 130))])?;
     let core_generation_id = index.generation_id().to_owned();
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     reconcile_all(&mut store, &index, &mut builder, &mut embedder)?;
-    let baseline_generation = SourceBackedSemanticGeneration::from_verified_index(&index)?;
+    let model_contract = semantic_model_contract();
+    let baseline_generation =
+        SourceBackedSemanticGeneration::from_verified_index(&index, model_contract)?;
     let baseline_contract = baseline_generation.contract_fingerprint.clone();
     store.reset_flat_active_event_snapshot_count();
 
-    let descriptor = semantic_model_contract_descriptor();
+    let descriptor = model_contract.descriptor();
     let revised_descriptor =
         descriptor.replacen("max_sequence_length=512", "max_sequence_length=513", 1);
     assert_ne!(descriptor, revised_descriptor);
@@ -48,6 +104,180 @@ fn descriptor_only_model_change_rebuilds_every_vector_from_unchanged_core() -> R
         core_generation_id,
         "a semantic-model-only rebuild must leave committed Core active"
     );
+
+    builder.calls.clear();
+    let embedded_chunks = embedder.chunks;
+    let no_op = reconcile_generation(&mut store, &index, &revised, &mut builder, &mut embedder)?;
+    assert_eq!(no_op.records_decoded, 0);
+    assert_eq!(no_op.records_embedded, 0);
+    assert!(builder.calls.is_empty());
+    assert_eq!(embedder.chunks, embedded_chunks);
+    Ok(())
+}
+
+#[test]
+fn exact_builtin_legacy_descriptor_migrates_without_reembedding_across_restart() -> Result<()> {
+    let fixture = Fixture::new(2)?;
+    let index = fixture.publish(
+        "legacy-descriptor-migration",
+        &[(0, bodies("first", 1)), (1, bodies("second", 1))],
+    )?;
+    let model_contract = semantic_model_contract();
+    let legacy_descriptor = model_contract
+        .legacy_builtin_descriptor_alias()
+        .ok_or_else(|| anyhow!("exact built-in contract lost its legacy descriptor alias"))?;
+    assert_eq!(
+        format!("sha256:{:x}", Sha256::digest(legacy_descriptor.as_bytes())),
+        "sha256:c812eb325bc5e90e7278b2b8da3933206340c5b5a46fd678be40016e06a89fc3"
+    );
+    let legacy = SourceBackedSemanticGeneration::from_verified_index_with_authority(
+        &index,
+        current_semantic_generation_policy(),
+        legacy_descriptor.to_owned(),
+    )?;
+    let current = SourceBackedSemanticGeneration::from_verified_index(&index, model_contract)?;
+    assert_ne!(legacy.contract_fingerprint, current.contract_fingerprint);
+    assert_eq!(legacy.trusted_legacy_contract_fingerprint, None);
+    assert_eq!(
+        current.trusted_legacy_contract_fingerprint.as_deref(),
+        Some(legacy.contract_fingerprint.as_str())
+    );
+
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, model_contract)?;
+    let mut builder = CoreBuilder::default();
+    let mut embedder = MarkerEmbedder::default();
+    let initial = reconcile_generation(&mut store, &index, &legacy, &mut builder, &mut embedder)?;
+    assert_eq!(initial.records_embedded, 2);
+    let legacy_chunks = projection_snapshot(&store)?.chunks;
+    let legacy_receipts = store
+        .flat
+        .source_states()
+        .map_err(anyhow::Error::new)?
+        .into_iter()
+        .map(|state| {
+            state
+                .receipt
+                .ok_or_else(|| anyhow!("missing legacy receipt"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    assert_eq!(legacy_receipts.len(), 2);
+    assert!(legacy_receipts.iter().all(|receipt| {
+        receipt.contract_fingerprint == legacy.contract_fingerprint
+            && receipt.semantic_policy_fingerprint == legacy.semantic_policy_fingerprint
+    }));
+    assert_eq!(
+        store
+            .source_acknowledgement()?
+            .ok_or_else(|| anyhow!("missing legacy acknowledgement"))?
+            .contract_fingerprint,
+        legacy.contract_fingerprint
+    );
+
+    let mut malformed = legacy_receipts[0].clone();
+    malformed.contract_fingerprint.push('0');
+    assert!(!source_receipt_allows_vector_reuse(&malformed, &current));
+    malformed.contract_fingerprint = legacy.contract_fingerprint.clone();
+    malformed.semantic_policy_fingerprint.push('0');
+    assert!(!source_receipt_allows_vector_reuse(&malformed, &current));
+
+    builder.calls.clear();
+    builder.fail_after = Some(1);
+    let embedding_calls = embedder.calls;
+    let embedded_chunks = embedder.chunks;
+    let error = store
+        .reconcile_source_backed_generation(&index, &current, &mut builder, &mut embedder)
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("forced Core projection interruption"));
+    assert_eq!(embedder.calls, embedding_calls);
+    assert_eq!(embedder.chunks, embedded_chunks);
+    let interrupted_fingerprints = store
+        .flat
+        .source_states()
+        .map_err(anyhow::Error::new)?
+        .into_iter()
+        .map(|state| {
+            state
+                .receipt
+                .map(|receipt| receipt.contract_fingerprint)
+                .ok_or_else(|| anyhow!("missing interrupted migration receipt"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    assert_eq!(
+        interrupted_fingerprints
+            .iter()
+            .filter(|fingerprint| *fingerprint == &current.contract_fingerprint)
+            .count(),
+        1
+    );
+    assert_eq!(
+        interrupted_fingerprints
+            .iter()
+            .filter(|fingerprint| *fingerprint == &legacy.contract_fingerprint)
+            .count(),
+        1
+    );
+    let frontier = store
+        .source_frontier()?
+        .ok_or_else(|| anyhow!("interrupted migration lost its frontier"))?;
+    assert_eq!(frontier.contract_fingerprint, current.contract_fingerprint);
+    assert!(frontier.vector_reuse_allowed);
+
+    drop(store);
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, model_contract)?;
+    builder.fail_after = None;
+    builder.calls.clear();
+    let resumed = reconcile_generation(&mut store, &index, &current, &mut builder, &mut embedder)?;
+    assert_eq!(resumed.records_embedded, 0);
+    assert_eq!(resumed.records_reused, 1);
+    assert_eq!(embedder.calls, embedding_calls);
+    assert_eq!(embedder.chunks, embedded_chunks);
+    assert_eq!(projection_snapshot(&store)?.chunks, legacy_chunks);
+
+    let acknowledgement = store
+        .source_acknowledgement()?
+        .ok_or_else(|| anyhow!("missing migrated acknowledgement"))?;
+    assert_eq!(
+        acknowledgement.contract_fingerprint,
+        current.contract_fingerprint
+    );
+    assert_eq!(
+        acknowledgement.semantic_policy_fingerprint,
+        current.semantic_policy_fingerprint
+    );
+    assert_eq!(
+        acknowledgement.consumer_build_id,
+        super::super::manifest::source_consumer_build_id(
+            &current.contract_fingerprint,
+            index.generation_id(),
+        )
+    );
+    let migrated_receipts = store
+        .flat
+        .source_states()
+        .map_err(anyhow::Error::new)?
+        .into_iter()
+        .map(|state| {
+            state
+                .receipt
+                .ok_or_else(|| anyhow!("missing migrated receipt"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    assert_eq!(migrated_receipts.len(), 2);
+    assert!(migrated_receipts.iter().all(|receipt| {
+        receipt.contract_fingerprint == current.contract_fingerprint
+            && receipt.semantic_policy_fingerprint == current.semantic_policy_fingerprint
+    }));
+
+    builder.calls.clear();
+    let no_op = reconcile_all(&mut store, &index, &mut builder, &mut embedder)?;
+    assert_eq!(no_op.records_decoded, 0);
+    assert_eq!(no_op.records_embedded, 0);
+    assert_eq!(no_op.metadata_records_touched, 0);
+    assert!(builder.calls.is_empty());
+    assert_eq!(embedder.calls, embedding_calls);
+    assert_eq!(embedder.chunks, embedded_chunks);
     Ok(())
 }
 
@@ -58,7 +288,7 @@ fn policy_rebuild_persists_linear_source_traversal_across_restart() -> Result<()
         .map(|source| (source, bodies(&format!("source-{source}"), 1)))
         .collect::<Vec<_>>();
     let index = fixture.publish("linear-rebuild", &specs)?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     reconcile_all(
         &mut store,
         &index,
@@ -71,8 +301,11 @@ fn policy_rebuild_persists_linear_source_traversal_across_restart() -> Result<()
         .chunking_revision
         .checked_add(1)
         .ok_or_else(|| anyhow!("semantic chunking revision overflow"))?;
-    let revised =
-        SourceBackedSemanticGeneration::from_verified_index_with_policy(&index, revised_policy)?;
+    let revised = SourceBackedSemanticGeneration::from_verified_index_with_policy(
+        &index,
+        revised_policy,
+        semantic_model_contract(),
+    )?;
     let mut builder = CoreBuilder {
         fail_after: Some(3),
         ..CoreBuilder::default()
@@ -89,7 +322,7 @@ fn policy_rebuild_persists_linear_source_traversal_across_restart() -> Result<()
     let completed_before_fault = builder.calls[..3].iter().copied().collect::<HashSet<_>>();
 
     drop(store);
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     store.reset_flat_active_event_snapshot_count();
     builder.fail_after = None;
     builder.calls.clear();
@@ -113,7 +346,7 @@ fn control_reset_retires_unowned_flat_vectors_before_rebuild() -> Result<()> {
     let initial = fixture.publish("reset-a", &[(0, bodies("retained", record_count))])?;
     let target = fixture.publish("reset-b", &[(0, bodies("retained", 3))])?;
     let removed_event = fixture.event_id(0, u64::try_from(record_count - 1)?)?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
@@ -122,14 +355,14 @@ fn control_reset_retires_unowned_flat_vectors_before_rebuild() -> Result<()> {
     let control = rusqlite::Connection::open(fixture.semantic_path.join("state.sqlite"))?;
     control.pragma_update(None, "user_version", 5)?;
     drop(control);
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     builder.calls.clear();
     let first_drain = store.reconcile_source_backed_index(&target, &mut builder, &mut embedder)?;
     assert_eq!(first_drain.deleted_chunks, MAX_SOURCE_EVENT_PAGE_ITEMS);
     assert!(first_drain.work_remaining);
 
     drop(store);
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     store.reset_flat_active_event_snapshot_count();
     let rebuilt = reconcile_all(&mut store, &target, &mut builder, &mut embedder)?;
     assert_eq!(rebuilt.records_decoded, 3);

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/proportionality.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/proportionality.rs
@@ -47,7 +47,8 @@ fn changed_logical_source_replay_work_is_measured_for_jsonl_and_sqlite() -> Resu
             &[(0, replacement_bodies.clone())],
         )?;
         let removed = fixture.publish("proportional-removed", &[])?;
-        let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+        let mut store =
+            SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
         let mut builder = CoreBuilder::default();
         let mut embedder = MarkerEmbedder::default();
         reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
@@ -72,7 +73,8 @@ fn changed_logical_source_replay_work_is_measured_for_jsonl_and_sqlite() -> Resu
         );
 
         drop(store);
-        let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+        let mut store =
+            SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
         let restarted = reconcile_all(&mut store, &appended, &mut builder, &mut embedder)?;
         assert_eq!(restarted.records_decoded, 0);
         assert_eq!(restarted.record_bytes_decoded, 0);
@@ -125,7 +127,8 @@ fn interrupted_restart_redecodes_the_uncommitted_page_for_jsonl_and_sqlite() -> 
         };
         let mut embedder = MarkerEmbedder::default();
         {
-            let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+            let mut store =
+                SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
             let error = store
                 .reconcile_source_backed_index(&index, &mut builder, &mut embedder)
                 .unwrap_err();
@@ -136,7 +139,8 @@ fn interrupted_restart_redecodes_the_uncommitted_page_for_jsonl_and_sqlite() -> 
 
         builder.fail_after = None;
         builder.calls.clear();
-        let mut restarted = SemanticVectorStore::open(&fixture.semantic_path)?;
+        let mut restarted =
+            SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
         let resumed = reconcile_all(&mut restarted, &index, &mut builder, &mut embedder)?;
         let resumed_bytes = encoded_record_bytes(&fixture, 0, &bodies, 0)?;
         assert_eq!(resumed.records_decoded, LONG_SOURCE_RECORDS);

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/provider_native.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/provider_native.rs
@@ -83,7 +83,7 @@ fn provider_native_copies_enter_semantic_projection_without_target_resolution() 
         copied_with_missing_target.event_copy
     );
 
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     let outcome = reconcile_all(&mut store, &index, &mut builder, &mut embedder)?;

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/recovery.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/recovery.rs
@@ -14,12 +14,147 @@ fn source_stage_entries(root: &Path) -> Result<Vec<String>> {
     Ok(entries)
 }
 
+#[derive(Clone, Copy, Debug)]
+enum InvalidEmbeddingBatch {
+    Error,
+    Short,
+    Long,
+    WrongDimensions,
+    Nan,
+    Infinity,
+    ZeroNorm,
+    OutsideNormalizationTolerance,
+    InsideNormalizationTolerance,
+}
+
+struct InvalidEmbedder(InvalidEmbeddingBatch);
+
+impl SemanticBatchEmbedder for InvalidEmbedder {
+    fn embed_chunks(&mut self, chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
+        let dimensions = semantic_model_contract().dimensions();
+        let unit = || {
+            let mut vector = vec![0.0; dimensions];
+            vector[0] = 1.0;
+            vector
+        };
+        match self.0 {
+            InvalidEmbeddingBatch::Error => Err(anyhow!("injected executor failure")),
+            InvalidEmbeddingBatch::Short => Ok((0..chunks.len().saturating_sub(1))
+                .map(|_| unit())
+                .collect()),
+            InvalidEmbeddingBatch::Long => Ok((0..=chunks.len()).map(|_| unit()).collect()),
+            InvalidEmbeddingBatch::WrongDimensions => {
+                Ok(chunks.iter().map(|_| vec![1.0; dimensions - 1]).collect())
+            }
+            InvalidEmbeddingBatch::Nan => Ok(chunks
+                .iter()
+                .map(|_| {
+                    let mut vector = unit();
+                    vector[0] = f32::NAN;
+                    vector
+                })
+                .collect()),
+            InvalidEmbeddingBatch::Infinity => Ok(chunks
+                .iter()
+                .map(|_| {
+                    let mut vector = unit();
+                    vector[0] = f32::INFINITY;
+                    vector
+                })
+                .collect()),
+            InvalidEmbeddingBatch::ZeroNorm => {
+                Ok(chunks.iter().map(|_| vec![0.0; dimensions]).collect())
+            }
+            InvalidEmbeddingBatch::OutsideNormalizationTolerance => Ok(chunks
+                .iter()
+                .map(|_| {
+                    let mut vector = vec![0.0; dimensions];
+                    vector[0] = 1.001_f32;
+                    vector
+                })
+                .collect()),
+            InvalidEmbeddingBatch::InsideNormalizationTolerance => Ok(chunks
+                .iter()
+                .map(|_| {
+                    let mut vector = vec![0.0; dimensions];
+                    vector[0] = 1.000_4_f32;
+                    vector
+                })
+                .collect()),
+        }
+    }
+}
+
+#[test]
+fn malformed_executor_pages_never_publish_and_retry_cleanly_after_restart() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let index = fixture.publish("invalid-executor", &[(0, bodies("invalid", 1))])?;
+    let mut store = open_store(&fixture.semantic_path)?;
+    let baseline = store
+        .flat
+        .active_publication_token()
+        .map_err(anyhow::Error::new)?;
+    let mut durable_frontier = None;
+
+    for mode in [
+        InvalidEmbeddingBatch::Error,
+        InvalidEmbeddingBatch::Short,
+        InvalidEmbeddingBatch::Long,
+        InvalidEmbeddingBatch::WrongDimensions,
+        InvalidEmbeddingBatch::Nan,
+        InvalidEmbeddingBatch::Infinity,
+        InvalidEmbeddingBatch::ZeroNorm,
+        InvalidEmbeddingBatch::OutsideNormalizationTolerance,
+    ] {
+        let error = store
+            .reconcile_source_backed_index(
+                &index,
+                &mut CoreBuilder::default(),
+                &mut InvalidEmbedder(mode),
+            )
+            .expect_err("malformed executor output must fail closed");
+        assert!(!error.to_string().is_empty(), "missing error for {mode:?}");
+        assert_eq!(
+            store
+                .flat
+                .active_publication_token()
+                .map_err(anyhow::Error::new)?,
+            baseline,
+            "{mode:?} changed active Flat authority"
+        );
+        assert!(store.source_acknowledgement()?.is_none());
+        let frontier = store
+            .source_frontier()?
+            .ok_or_else(|| anyhow!("{mode:?} lost its retry frontier"))?;
+        if let Some(expected) = durable_frontier.as_ref() {
+            assert_eq!(&frontier, expected, "{mode:?} advanced the frontier");
+        } else {
+            durable_frontier = Some(frontier);
+        }
+        drop(store);
+        store = open_store(&fixture.semantic_path)?;
+    }
+
+    let rebuilt = reconcile_all(
+        &mut store,
+        &index,
+        &mut CoreBuilder::default(),
+        &mut InvalidEmbedder(InvalidEmbeddingBatch::InsideNormalizationTolerance),
+    )?;
+    assert_eq!(rebuilt.records_embedded, 1);
+    assert!(store.source_acknowledgement()?.is_some());
+    Ok(())
+}
+
 #[test]
 fn final_changed_source_commit_restart_replays_durable_stage_cleanup() -> Result<()> {
     let fixture = Fixture::new(1)?;
     let initial = fixture.publish("final-commit-initial", &[(0, bodies("initial", 2))])?;
     let target = fixture.publish("final-commit-target", &[(0, bodies("changed", 3))])?;
-    let mut clean = SemanticVectorStore::open(&fixture.data_root.join("semantic-clean-final"))?;
+    let mut clean = SemanticVectorStore::open(
+        &fixture.data_root.join("semantic-clean-final"),
+        semantic_model_contract(),
+    )?;
     reconcile_all(
         &mut clean,
         &initial,
@@ -34,7 +169,7 @@ fn final_changed_source_commit_restart_replays_durable_stage_cleanup() -> Result
     )?;
     let expected = projection_snapshot(&clean)?;
 
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
@@ -63,7 +198,8 @@ fn final_changed_source_commit_restart_replays_durable_stage_cleanup() -> Result
     drop(store);
 
     builder.calls.clear();
-    let mut restarted = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut restarted =
+        SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let restarted_outcome = reconcile_all(&mut restarted, &target, &mut builder, &mut embedder)?;
     assert_eq!(restarted_outcome.records_decoded, 0);
     assert!(
@@ -80,7 +216,7 @@ fn tampered_final_candidate_cannot_acknowledge_or_delete_staging() -> Result<()>
     let fixture = Fixture::new(1)?;
     let initial = fixture.publish("tampered-ack-initial", &[(0, bodies("initial", 2))])?;
     let target = fixture.publish("tampered-ack-target", &[(0, bodies("changed", 3))])?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
     let mut embedder = MarkerEmbedder::default();
     reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
@@ -97,7 +233,8 @@ fn tampered_final_candidate_cannot_acknowledge_or_delete_staging() -> Result<()>
     let active = projection_snapshot(&store)?;
     drop(store);
 
-    let mut restarted = SemanticVectorStore::open(&fixture.semantic_path)?;
+    let mut restarted =
+        SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let error = restarted
         .reconcile_source_backed_index(&target, &mut builder, &mut embedder)
         .unwrap_err();

--- a/crates/ctx-semantic-index/src/vector_store_schema.rs
+++ b/crates/ctx-semantic-index/src/vector_store_schema.rs
@@ -1,10 +1,7 @@
 use std::{fmt, path::Path};
 
 use anyhow::Result;
-use ctx_semantic_model::{
-    semantic_tokenizer_fingerprint, SEMANTIC_DIMENSIONS, SEMANTIC_MODEL_CONTRACT_VERSION,
-    SEMANTIC_MODEL_ID, SEMANTIC_MODEL_REVISION, SEMANTIC_NORMALIZATION, SEMANTIC_POOLING,
-};
+use ctx_semantic_model::SemanticModelContract;
 
 use super::vector_store::{
     control,
@@ -78,34 +75,71 @@ pub fn semantic_vector_failure_kind(error: &anyhow::Error) -> Option<SemanticVec
 }
 
 impl SemanticVectorStore {
-    pub fn open(path: &Path) -> Result<Self> {
+    pub fn open(path: &Path, contract: &SemanticModelContract) -> Result<Self> {
+        let flat_contract = flat_model_contract(contract).map_err(semantic_flat_store_error)?;
         let conn = control::open_writable(path)?;
-        let flat = FlatSegmentStore::open(path, active_model_contract())
-            .map_err(semantic_flat_store_error)?;
-        Ok(Self { conn, flat })
+        let flat =
+            FlatSegmentStore::open(path, flat_contract).map_err(semantic_flat_store_error)?;
+        let store = Self {
+            conn,
+            flat,
+            contract: contract.clone(),
+        };
+        if store
+            .flat
+            .model_contract_reset_pending()
+            .map_err(semantic_flat_store_error)?
+        {
+            store.record_flat_model_contract_reset()?;
+            store
+                .flat
+                .acknowledge_model_contract_reset()
+                .map_err(semantic_flat_store_error)?;
+        }
+        Ok(store)
     }
 
-    pub fn open_read_only(path: &Path) -> Result<Option<Self>> {
+    pub fn open_read_only(path: &Path, contract: &SemanticModelContract) -> Result<Option<Self>> {
+        let flat_contract = flat_model_contract(contract).map_err(semantic_flat_store_error)?;
         let Some(conn) = control::open_read_only(path)? else {
             return Ok(None);
         };
-        let flat = FlatSegmentStore::open_read_only(path, active_model_contract())
+        let flat = FlatSegmentStore::open_read_only(path, flat_contract)
             .map_err(semantic_flat_store_error)?;
-        Ok(Some(Self { conn, flat }))
+        if flat
+            .model_contract_reset_pending()
+            .map_err(semantic_flat_store_error)?
+        {
+            return Ok(None);
+        }
+        Ok(Some(Self {
+            conn,
+            flat,
+            contract: contract.clone(),
+        }))
     }
 }
 
-pub(super) fn active_model_contract() -> FlatModelContract {
-    let tokenizer = semantic_tokenizer_fingerprint();
-    FlatModelContract {
-        contract_version: SEMANTIC_MODEL_CONTRACT_VERSION,
-        model_id: SEMANTIC_MODEL_ID.to_owned(),
-        model_revision: SEMANTIC_MODEL_REVISION.to_owned(),
-        tokenizer,
-        pooling: SEMANTIC_POOLING.to_owned(),
-        dimensions: SEMANTIC_DIMENSIONS as u32,
-        normalization: SEMANTIC_NORMALIZATION.to_owned(),
-    }
+pub(super) fn flat_model_contract(
+    contract: &SemanticModelContract,
+) -> std::result::Result<FlatModelContract, FlatStoreError> {
+    let dimensions = u32::try_from(contract.dimensions()).map_err(|_| {
+        FlatStoreError::InvalidInput(format!(
+            "model contract dimensions {} exceed the flat F32 format",
+            contract.dimensions()
+        ))
+    })?;
+    let flat = FlatModelContract {
+        contract_version: contract.contract_version(),
+        model_id: contract.model_id().to_owned(),
+        model_revision: contract.model_revision().to_owned(),
+        tokenizer: contract.tokenizer_fingerprint().to_owned(),
+        pooling: contract.pooling().to_owned(),
+        dimensions,
+        normalization: contract.normalization().to_owned(),
+    };
+    flat.validate()?;
+    Ok(flat)
 }
 
 pub(super) fn semantic_owned_sidecar_result<T>(result: Result<T>) -> Result<T> {

--- a/crates/ctx-semantic-index/src/vector_store_search.rs
+++ b/crates/ctx-semantic-index/src/vector_store_search.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use anyhow::Result;
-use ctx_semantic_model::SEMANTIC_DIMENSIONS;
 use uuid::Uuid;
 
 use super::{
@@ -36,10 +35,11 @@ pub(super) fn scan_exact_generation(
         )
         .into());
     }
+    let dimensions = usize::try_from(reader.model_contract().dimensions)?;
     for (query_ordinal, query_embedding) in query_embeddings.iter().enumerate() {
-        if query_embedding.len() != SEMANTIC_DIMENSIONS {
+        if query_embedding.len() != dimensions {
             return Err(SemanticVectorStoreError::unavailable(format!(
-                "semantic query alternative {query_ordinal} has {} dimensions, expected {SEMANTIC_DIMENSIONS}",
+                "semantic query alternative {query_ordinal} has {} dimensions, expected {dimensions}",
                 query_embedding.len()
             ))
             .into());
@@ -55,7 +55,6 @@ pub(super) fn scan_exact_generation(
         return Ok(SemanticVectorSearch::default());
     }
     let _permit = EXACT_QUERY_LIMITER.acquire();
-    let dimensions = usize::try_from(reader.model_contract().dimensions)?;
     let query_vectors = query_embeddings
         .iter()
         .map(Vec::as_slice)
@@ -183,16 +182,77 @@ impl Drop for ExactQueryPermit<'_> {
 mod tests {
     use std::{sync::mpsc, time::Duration};
 
+    use ctx_semantic_model::semantic_model_contract;
+
     use super::*;
-    use crate::vector_store::{SemanticChunkDocument, SemanticVectorStore};
+    use crate::vector_store::{
+        flat_segments::{
+            FlatChunk, FlatEventReplacement, FlatModelContract, FlatSegmentStore, FlatSourceHash,
+        },
+        SemanticChunkDocument, SemanticVectorStore,
+    };
+
+    #[test]
+    fn direct_exact_generation_scan_validates_pinned_contract_dimensions() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store = FlatSegmentStore::open(
+            temp.path(),
+            FlatModelContract {
+                contract_version: 2,
+                model_id: "test/non-builtin-dimensions".to_owned(),
+                model_revision: "revision-1".to_owned(),
+                tokenizer: "tokenizer-sha256".to_owned(),
+                pooling: "attention-mask-mean".to_owned(),
+                dimensions: 4,
+                normalization: "l2".to_owned(),
+            },
+        )?;
+        let event_id = Uuid::new_v4();
+        let event_identity_digest = [7; 32];
+        store.publish_replacement_event_chunks(
+            &[FlatEventReplacement {
+                event_id,
+                seq: 1,
+                source_text_hash: FlatSourceHash::from_bytes([8; 32]),
+                chunks: vec![FlatChunk {
+                    chunk_index: 0,
+                    start_char: 0,
+                    end_char: 1,
+                    vector: vec![1.0, 0.0, 0.0, 0.0],
+                }],
+            }],
+            &[],
+        )?;
+        let pinned = store
+            .pin_generation()?
+            .expect("fixture must publish a flat generation");
+
+        let error = scan_exact_generation(
+            &pinned,
+            &[vec![1.0, 0.0, 0.0]],
+            1,
+            &|candidate| (candidate == event_id).then_some(event_identity_digest),
+            Instant::now(),
+        )
+        .err()
+        .expect("the query must match the pinned flat generation dimensions");
+
+        assert_eq!(
+            error.to_string(),
+            "semantic query alternative 0 has 3 dimensions, expected 4"
+        );
+        Ok(())
+    }
 
     #[test]
     fn direct_exact_generation_scan_waits_for_bounded_admission() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let mut store = SemanticVectorStore::open(&temp.path().join("search").join("semantic"))?;
+        let contract = semantic_model_contract();
+        let mut store =
+            SemanticVectorStore::open(&temp.path().join("search").join("semantic"), contract)?;
         let event_id = Uuid::new_v4();
         let event_identity_digest = [7; 32];
-        let mut embedding = vec![0.0; SEMANTIC_DIMENSIONS];
+        let mut embedding = vec![0.0; contract.dimensions()];
         embedding[0] = 1.0;
         store.publish_chunk_replacements(
             &[(

--- a/crates/ctx-semantic-index/src/vector_store_state.rs
+++ b/crates/ctx-semantic-index/src/vector_store_state.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
 
 use anyhow::Result;
-use ctx_semantic_model::SEMANTIC_DIMENSIONS;
 use uuid::Uuid;
 
 use super::{
@@ -27,16 +26,16 @@ impl SemanticVectorStore {
         items: &[(SemanticChunkDocument, Vec<f32>)],
         event_ids: &[Uuid],
     ) -> Result<usize> {
+        let dimensions = self.contract().dimensions();
         semantic_owned_sidecar_result((|| {
             if items.is_empty() && event_ids.is_empty() {
                 return Ok(0);
             }
             if items.iter().any(|(_, embedding)| {
-                embedding.len() != SEMANTIC_DIMENSIONS
-                    || embedding.iter().any(|value| !value.is_finite())
+                embedding.len() != dimensions || embedding.iter().any(|value| !value.is_finite())
             }) {
                 return Err(SemanticVectorStoreError::unavailable(format!(
-                    "semantic embeddings must be finite f32[{SEMANTIC_DIMENSIONS}]"
+                    "semantic embeddings must be finite f32[{dimensions}]"
                 ))
                 .into());
             }
@@ -80,13 +79,13 @@ impl SemanticVectorStore {
         event_ids: &[Uuid],
         existing: &FlatActiveEventLookup,
     ) -> Result<FlatSourcePageOutcome> {
+        let dimensions = self.contract().dimensions();
         semantic_owned_sidecar_result((|| {
             if items.iter().any(|(_, embedding)| {
-                embedding.len() != SEMANTIC_DIMENSIONS
-                    || embedding.iter().any(|value| !value.is_finite())
+                embedding.len() != dimensions || embedding.iter().any(|value| !value.is_finite())
             }) {
                 return Err(SemanticVectorStoreError::unavailable(format!(
-                    "semantic embeddings must be finite f32[{SEMANTIC_DIMENSIONS}]"
+                    "semantic embeddings must be finite f32[{dimensions}]"
                 ))
                 .into());
             }

--- a/crates/ctx-semantic-model/src/embedding_executor.rs
+++ b/crates/ctx-semantic-model/src/embedding_executor.rs
@@ -1,0 +1,280 @@
+use std::time::Instant;
+
+#[cfg(not(ctx_semantic_fastembed))]
+use anyhow::anyhow;
+use anyhow::Result;
+
+#[cfg(not(ctx_semantic_fastembed))]
+use crate::SEMANTIC_MODEL_ID;
+use crate::{
+    semantic_model_contract, PreparedSemanticDocuments, PreparedSemanticQuery, SemanticModelConfig,
+    SemanticModelContract, SharedSemanticRuntime,
+};
+
+/// Produces vectors in one declared semantic compatibility space.
+///
+/// This is an internal execution interface, not a user-selectable plugin or an
+/// admission/security boundary. Product composition must choose a trusted
+/// implementation. A future implementation may use another process or host,
+/// but its client is responsible for explicit privacy authorization,
+/// authenticated contract negotiation, conformance checks, and fail-closed
+/// routing before it reaches this interface. Local artifact acquisition and
+/// backend selection remain implementation details of the built-in executor.
+/// Inputs carry the fingerprint of the contract that prepared them.
+pub trait SemanticEmbeddingExecutor: Send + Sync {
+    fn contract(&self) -> &SemanticModelContract;
+
+    fn embed_query(&self, query: PreparedSemanticQuery) -> Result<Vec<f32>>;
+
+    /// Embeds one atomic document page.
+    ///
+    /// `pacing_deadline` bounds cooperative quiet time between internal
+    /// batches. It does not cancel inference or permit a partial page result.
+    fn embed_documents(
+        &self,
+        documents: PreparedSemanticDocuments,
+        pacing_deadline: Option<Instant>,
+    ) -> Result<Vec<Vec<f32>>>;
+}
+
+/// The default local semantic embedding executor shipped with ctx.
+///
+/// Clones share one loaded model runtime while retaining owned configuration
+/// and vector-space contract values.
+#[derive(Clone)]
+pub struct BuiltinSemanticEmbeddingExecutor {
+    runtime: SharedSemanticRuntime,
+    config: SemanticModelConfig,
+    contract: SemanticModelContract,
+}
+
+impl BuiltinSemanticEmbeddingExecutor {
+    pub fn new(runtime: SharedSemanticRuntime, config: SemanticModelConfig) -> Self {
+        Self {
+            runtime,
+            config,
+            contract: semantic_model_contract().clone(),
+        }
+    }
+
+    pub fn contract(&self) -> &SemanticModelContract {
+        &self.contract
+    }
+
+    /// Provides the local lifecycle, acquisition, and status surface used by
+    /// the built-in executor without adding those operations to the portable
+    /// inference trait.
+    pub fn shared_runtime(&self) -> &SharedSemanticRuntime {
+        &self.runtime
+    }
+
+    pub fn config(&self) -> &SemanticModelConfig {
+        &self.config
+    }
+}
+
+impl SemanticEmbeddingExecutor for BuiltinSemanticEmbeddingExecutor {
+    fn contract(&self) -> &SemanticModelContract {
+        self.contract()
+    }
+
+    fn embed_query(&self, query: PreparedSemanticQuery) -> Result<Vec<f32>> {
+        ensure_prepared_contract(query.contract_fingerprint(), self.contract())?;
+        #[cfg(ctx_semantic_fastembed)]
+        {
+            self.runtime
+                .embed_query(&self.config, query)
+                .map(|(embedding, _runtime)| embedding)
+        }
+        #[cfg(not(ctx_semantic_fastembed))]
+        {
+            let _ = query;
+            Err(anyhow!(
+                "semantic embedding model {SEMANTIC_MODEL_ID} is not supported on this platform"
+            ))
+        }
+    }
+
+    fn embed_documents(
+        &self,
+        documents: PreparedSemanticDocuments,
+        pacing_deadline: Option<Instant>,
+    ) -> Result<Vec<Vec<f32>>> {
+        ensure_prepared_contract(documents.contract_fingerprint(), self.contract())?;
+        #[cfg(ctx_semantic_fastembed)]
+        {
+            self.runtime
+                .embed_documents(&self.config, documents, pacing_deadline)
+                .map(|(embeddings, _quiet_policy)| embeddings)
+        }
+        #[cfg(not(ctx_semantic_fastembed))]
+        {
+            let _ = (documents, pacing_deadline);
+            Err(anyhow!(
+                "semantic embedding model {SEMANTIC_MODEL_ID} is not supported on this platform"
+            ))
+        }
+    }
+}
+
+fn ensure_prepared_contract(
+    prepared_fingerprint: &str,
+    contract: &SemanticModelContract,
+) -> Result<()> {
+    if prepared_fingerprint != contract.fingerprint() {
+        return Err(anyhow::anyhow!(
+            "semantic input was prepared for a different model contract"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        path::PathBuf,
+        sync::Mutex,
+        time::{Duration, Instant},
+    };
+
+    use super::*;
+    use crate::{
+        SemanticModelPaths, SemanticOnnxRuntimePaths, SEMANTIC_DIMENSIONS, SEMANTIC_MODEL_KEY,
+    };
+
+    #[derive(Debug, PartialEq)]
+    enum TestCall {
+        Query(String),
+        Documents(Vec<String>, Option<Instant>),
+    }
+
+    struct TestExecutor {
+        contract: SemanticModelContract,
+        calls: Mutex<Vec<TestCall>>,
+    }
+
+    impl SemanticEmbeddingExecutor for TestExecutor {
+        fn contract(&self) -> &SemanticModelContract {
+            &self.contract
+        }
+
+        fn embed_query(&self, query: PreparedSemanticQuery) -> Result<Vec<f32>> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(TestCall::Query(query.into_text()));
+            let mut embedding = vec![0.0; self.contract.dimensions()];
+            embedding[0] = 1.0;
+            Ok(embedding)
+        }
+
+        fn embed_documents(
+            &self,
+            documents: PreparedSemanticDocuments,
+            pacing_deadline: Option<Instant>,
+        ) -> Result<Vec<Vec<f32>>> {
+            let documents = documents.into_texts();
+            self.calls
+                .lock()
+                .unwrap()
+                .push(TestCall::Documents(documents.clone(), pacing_deadline));
+            Ok(documents
+                .into_iter()
+                .map(|_| {
+                    let mut embedding = vec![0.0; self.contract.dimensions()];
+                    embedding[1] = 1.0;
+                    embedding
+                })
+                .collect())
+        }
+    }
+
+    #[test]
+    fn trait_dispatch_returns_only_contract_vectors_and_propagates_pacing_deadline() {
+        let test_executor = TestExecutor {
+            contract: semantic_model_contract().clone(),
+            calls: Mutex::new(Vec::new()),
+        };
+        let executor: &dyn SemanticEmbeddingExecutor = &test_executor;
+        fn assert_send_sync<T: Send + Sync + ?Sized>() {}
+        assert_send_sync::<dyn SemanticEmbeddingExecutor>();
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+
+        assert_eq!(executor.contract().model_key(), SEMANTIC_MODEL_KEY);
+        assert_eq!(
+            executor
+                .embed_query(executor.contract().prepare_query("needle".to_owned()))
+                .unwrap()
+                .len(),
+            SEMANTIC_DIMENSIONS
+        );
+        assert_eq!(
+            executor
+                .embed_documents(
+                    executor
+                        .contract()
+                        .prepare_documents(vec!["one".to_owned(), "two".to_owned()]),
+                    Some(deadline),
+                )
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            *test_executor.calls.lock().unwrap(),
+            [
+                TestCall::Query("query: needle".to_owned()),
+                TestCall::Documents(
+                    vec!["passage: one".to_owned(), "passage: two".to_owned()],
+                    Some(deadline),
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn builtin_executor_seam_owns_config_and_contract_without_loading_assets() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<BuiltinSemanticEmbeddingExecutor>();
+
+        let runtime = SharedSemanticRuntime::default();
+        let model_cache_dir = PathBuf::from("test-model-cache");
+        let runtime_cache_dir = PathBuf::from("test-runtime-cache");
+        let config = SemanticModelConfig::new(SemanticModelPaths::new(
+            model_cache_dir.clone(),
+            SemanticOnnxRuntimePaths::new(runtime_cache_dir),
+        ));
+        let executor = BuiltinSemanticEmbeddingExecutor::new(runtime, config);
+        let trait_object: &dyn SemanticEmbeddingExecutor = &executor;
+        let cloned = executor.clone();
+
+        assert_eq!(trait_object.contract(), semantic_model_contract());
+        assert_eq!(executor.config().paths().model_cache_dir(), model_cache_dir);
+        assert!(!executor.shared_runtime().is_loaded());
+        assert_eq!(cloned.contract(), executor.contract());
+        let _busy = executor.shared_runtime().lock_for_test().unwrap();
+        assert!(!cloned.shared_runtime().release_if_idle().unwrap());
+    }
+
+    #[test]
+    fn builtin_executor_rejects_input_prepared_by_another_contract() {
+        let runtime = SharedSemanticRuntime::default();
+        let config = SemanticModelConfig::new(SemanticModelPaths::new(
+            PathBuf::from("test-model-cache"),
+            SemanticOnnxRuntimePaths::new(PathBuf::from("test-runtime-cache")),
+        ));
+        let executor = BuiltinSemanticEmbeddingExecutor::new(runtime, config);
+        let other_contract = semantic_model_contract()
+            .clone()
+            .with_test_language_scope("test-only-incompatible-language-scope");
+        let error = executor
+            .embed_query(other_contract.prepare_query("needle".to_owned()))
+            .expect_err("cross-contract prepared input must fail closed");
+
+        assert_eq!(
+            error.to_string(),
+            "semantic input was prepared for a different model contract"
+        );
+    }
+}

--- a/crates/ctx-semantic-model/src/lib.rs
+++ b/crates/ctx-semantic-model/src/lib.rs
@@ -1,6 +1,7 @@
 mod artifact_fetch;
 mod cache_paths;
 mod configuration;
+mod embedding_executor;
 mod health_search;
 mod json;
 #[cfg(any(target_os = "macos", test, feature = "test-support"))]
@@ -25,19 +26,22 @@ pub use configuration::{
     SemanticBackendPreference, SemanticCoreMlComputeMode, SemanticModelConfig, SemanticModelPaths,
     SemanticOnnxRuntimePaths,
 };
+pub use embedding_executor::{BuiltinSemanticEmbeddingExecutor, SemanticEmbeddingExecutor};
 pub use health_search::{
     semantic_model_acquisition_integrity_error, semantic_model_cache_available,
 };
 pub use model_contract::{
     semantic_e5_passage_text, semantic_model_contract, semantic_model_contract_descriptor,
-    semantic_model_key, semantic_provisioning_coreml_asset_matches,
-    semantic_provisioning_model_contract_matches, semantic_provisioning_model_path_count,
-    semantic_provisioning_model_path_matches, semantic_required_model_file_count,
-    semantic_required_model_file_matches, semantic_tokenizer_fingerprint, SemanticModelContract,
+    semantic_model_contract_fingerprint, semantic_model_key,
+    semantic_provisioning_coreml_asset_matches, semantic_provisioning_model_contract_matches,
+    semantic_provisioning_model_path_count, semantic_provisioning_model_path_matches,
+    semantic_required_model_file_count, semantic_required_model_file_matches,
+    semantic_tokenizer_behavior_fingerprint, semantic_tokenizer_fingerprint,
+    PreparedSemanticDocuments, PreparedSemanticQuery, SemanticModelContract,
     SemanticModelLoadDeferred, SemanticOrtModelVariant, SEMANTIC_BACKEND, SEMANTIC_DIMENSIONS,
-    SEMANTIC_MODEL_CONTRACT_VERSION, SEMANTIC_MODEL_ID, SEMANTIC_MODEL_KEY,
-    SEMANTIC_MODEL_REVISION, SEMANTIC_NORMALIZATION, SEMANTIC_PASSAGE_PREFIX, SEMANTIC_POOLING,
-    SEMANTIC_QUERY_PREFIX,
+    SEMANTIC_LANGUAGE_SCOPE, SEMANTIC_MODEL_CONTRACT_VERSION, SEMANTIC_MODEL_ID,
+    SEMANTIC_MODEL_KEY, SEMANTIC_MODEL_REVISION, SEMANTIC_NORMALIZATION, SEMANTIC_PASSAGE_PREFIX,
+    SEMANTIC_POOLING, SEMANTIC_QUERY_PREFIX,
 };
 #[cfg(any(test, feature = "test-support"))]
 #[doc(hidden)]

--- a/crates/ctx-semantic-model/src/model_contract.rs
+++ b/crates/ctx-semantic-model/src/model_contract.rs
@@ -1,4 +1,6 @@
-use std::fmt;
+use std::{fmt, sync::OnceLock};
+
+use sha2::{Digest, Sha256};
 
 pub const SEMANTIC_BACKEND: &str = "multilingual-e5";
 pub const SEMANTIC_MODEL_KEY: &str = "e5-small-v1:mean-pool:l2:query-passage";
@@ -53,49 +55,268 @@ pub const SEMANTIC_POOLING: &str = "attention-mask-mean";
 pub const SEMANTIC_NORMALIZATION: &str = "l2";
 pub const SEMANTIC_PASSAGE_PREFIX: &str = "passage: ";
 pub const SEMANTIC_QUERY_PREFIX: &str = "query: ";
+pub const SEMANTIC_LANGUAGE_SCOPE: &str = "unicode-global";
 pub(super) const SEMANTIC_CONTRACT_CANARY_TEXT: &str = "búsqueda semántica 世界";
+pub(super) const SEMANTIC_TOKENIZER_BEHAVIOR_PATHS: &[&str] = &[
+    "tokenizer.json",
+    "config.json",
+    "special_tokens_map.json",
+    "tokenizer_config.json",
+];
+const LEGACY_BUILTIN_DESCRIPTOR_FINGERPRINT: &str =
+    "sha256:c812eb325bc5e90e7278b2b8da3933206340c5b5a46fd678be40016e06a89fc3";
+const LEGACY_COMPATIBLE_VECTOR_CONTRACT_FINGERPRINT: &str =
+    "sha256:611f11c9b715543137d1b6be8d87497a2b6ef4945d425f3c0b973d2cb0c6036d";
 #[allow(dead_code)] // Signed provisioning consumes this seam in a separate integration lane.
 const SEMANTIC_RELEASE_POOLING: &str = "attention_mask_mean";
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Query text prepared according to one semantic vector-space contract.
+#[derive(Clone, Eq, PartialEq)]
+pub struct PreparedSemanticQuery {
+    contract_fingerprint: String,
+    text: String,
+}
+
+impl PreparedSemanticQuery {
+    pub fn contract_fingerprint(&self) -> &str {
+        &self.contract_fingerprint
+    }
+
+    pub fn into_text(self) -> String {
+        self.text
+    }
+}
+
+/// Document texts prepared according to one semantic vector-space contract.
+#[derive(Clone, Eq, PartialEq)]
+pub struct PreparedSemanticDocuments {
+    contract_fingerprint: String,
+    texts: Vec<String>,
+}
+
+impl PreparedSemanticDocuments {
+    pub fn contract_fingerprint(&self) -> &str {
+        &self.contract_fingerprint
+    }
+
+    pub fn into_texts(self) -> Vec<String> {
+        self.texts
+    }
+}
+
+/// The complete compatibility identity of one semantic vector space.
+///
+/// This value intentionally excludes executor, runtime, accelerator, and
+/// artifact-publication identity. Those details describe how ctx produces a
+/// vector, not whether that vector is compatible with an existing index.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SemanticModelContract {
-    model_id: &'static str,
-    model_revision: &'static str,
-    contract_revision: u32,
+    model_key: String,
+    model_id: String,
+    model_revision: String,
+    contract_version: u32,
+    tokenizer_fingerprint: String,
+    tokenizer_behavior_fingerprint: String,
     dimensions: usize,
-    normalization: &'static str,
+    max_sequence_length: usize,
+    pooling: String,
+    normalization: String,
+    query_prefix: String,
+    document_prefix: String,
+    language_scope: String,
+    descriptor: String,
+    fingerprint: String,
 }
 
 impl SemanticModelContract {
-    pub const fn model_id(self) -> &'static str {
-        self.model_id
+    pub fn model_key(&self) -> &str {
+        &self.model_key
     }
 
-    pub const fn model_revision(self) -> &'static str {
-        self.model_revision
+    pub fn model_id(&self) -> &str {
+        &self.model_id
     }
 
-    pub const fn contract_revision(self) -> u32 {
-        self.contract_revision
+    pub fn model_revision(&self) -> &str {
+        &self.model_revision
     }
 
-    pub const fn dimensions(self) -> usize {
+    pub const fn contract_version(&self) -> u32 {
+        self.contract_version
+    }
+
+    pub const fn contract_revision(&self) -> u32 {
+        self.contract_version()
+    }
+
+    pub fn tokenizer_fingerprint(&self) -> &str {
+        &self.tokenizer_fingerprint
+    }
+
+    /// Identifies every pinned file that can alter fastembed tokenization.
+    ///
+    /// `tokenizer_fingerprint` intentionally remains the historical
+    /// tokenizer.json-only Flat-format field. New vector-space compatibility
+    /// must use this complete behavior fingerprint through `descriptor`.
+    pub fn tokenizer_behavior_fingerprint(&self) -> &str {
+        &self.tokenizer_behavior_fingerprint
+    }
+
+    pub const fn dimensions(&self) -> usize {
         self.dimensions
     }
 
-    pub const fn normalization(self) -> &'static str {
-        self.normalization
+    pub const fn max_sequence_length(&self) -> usize {
+        self.max_sequence_length
+    }
+
+    pub fn pooling(&self) -> &str {
+        &self.pooling
+    }
+
+    pub fn normalization(&self) -> &str {
+        &self.normalization
+    }
+
+    pub fn query_prefix(&self) -> &str {
+        &self.query_prefix
+    }
+
+    pub fn document_prefix(&self) -> &str {
+        &self.document_prefix
+    }
+
+    pub fn language_scope(&self) -> &str {
+        &self.language_scope
+    }
+
+    /// Prepares query input for this vector space exactly once.
+    pub fn prepare_query(&self, text: String) -> PreparedSemanticQuery {
+        PreparedSemanticQuery {
+            contract_fingerprint: self.fingerprint().to_owned(),
+            text: semantic_prefixed_text(self.query_prefix(), text),
+        }
+    }
+
+    /// Prepares document inputs for this vector space exactly once.
+    pub fn prepare_documents(&self, texts: Vec<String>) -> PreparedSemanticDocuments {
+        PreparedSemanticDocuments {
+            contract_fingerprint: self.fingerprint().to_owned(),
+            texts: texts
+                .into_iter()
+                .map(|text| semantic_prefixed_text(self.document_prefix(), text))
+                .collect(),
+        }
+    }
+
+    /// Returns query text prepared for this vector space.
+    pub fn query_text(&self, text: &str) -> String {
+        self.prepare_query(text.to_owned()).into_text()
+    }
+
+    /// Returns document text prepared for this vector space.
+    pub fn document_text(&self, text: &str) -> String {
+        semantic_prefixed_text(self.document_prefix(), text.to_owned())
+    }
+
+    /// Returns the canonical compatibility descriptor for this vector space.
+    pub fn descriptor(&self) -> &str {
+        &self.descriptor
+    }
+
+    fn rebuild_identity(&mut self) {
+        self.descriptor = format!(
+            "ctx-semantic-vector-space-v{}|model_key={}|model_id={}|model_revision={}|tokenizer_fingerprint={}|tokenizer_behavior_fingerprint={}|dimensions={}|max_sequence_length={}|pooling={}|normalization={}|query_prefix={}|document_prefix={}|language_scope={}",
+            self.contract_version,
+            self.model_key,
+            self.model_id,
+            self.model_revision,
+            self.tokenizer_fingerprint,
+            self.tokenizer_behavior_fingerprint,
+            self.dimensions,
+            self.max_sequence_length,
+            self.pooling,
+            self.normalization,
+            self.query_prefix,
+            self.document_prefix,
+            self.language_scope,
+        );
+        self.fingerprint = sha256_fingerprint(&self.descriptor);
+    }
+
+    /// Returns the canonical SHA-256 identity of this vector space.
+    pub fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+
+    /// Reports whether frozen fingerprint-less daemon V1 compatibility is safe.
+    pub fn supports_frozen_legacy_v1(&self) -> bool {
+        let builtin = builtin_semantic_model_contract();
+        self.fingerprint() == LEGACY_COMPATIBLE_VECTOR_CONTRACT_FINGERPRINT
+            && (std::ptr::eq(self, builtin) || self == builtin)
+    }
+
+    /// Returns the exact pre-refactor built-in descriptor for index migration.
+    ///
+    /// The alias is available only for the exact built-in vector contract and
+    /// only while reconstruction still matches the descriptor digest shipped
+    /// before executor identity was separated from vector-space identity.
+    pub fn legacy_builtin_descriptor_alias(&self) -> Option<&'static str> {
+        if !self.supports_frozen_legacy_v1() {
+            return None;
+        }
+        static ALIAS: OnceLock<Option<String>> = OnceLock::new();
+        ALIAS
+            .get_or_init(|| {
+                let descriptor = legacy_builtin_semantic_model_descriptor();
+                (sha256_fingerprint(&descriptor) == LEGACY_BUILTIN_DESCRIPTOR_FINGERPRINT)
+                    .then_some(descriptor)
+            })
+            .as_deref()
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_test_tokenizer_behavior_fingerprint(mut self, fingerprint: &str) -> Self {
+        self.tokenizer_behavior_fingerprint = fingerprint.to_owned();
+        self.rebuild_identity();
+        self
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_test_language_scope(mut self, language_scope: &str) -> Self {
+        self.language_scope = language_scope.to_owned();
+        self.rebuild_identity();
+        self
     }
 }
 
-pub const fn semantic_model_contract() -> SemanticModelContract {
-    SemanticModelContract {
-        model_id: SEMANTIC_MODEL_ID,
-        model_revision: SEMANTIC_MODEL_REVISION,
-        contract_revision: SEMANTIC_MODEL_CONTRACT_VERSION,
-        dimensions: SEMANTIC_DIMENSIONS,
-        normalization: SEMANTIC_NORMALIZATION,
-    }
+pub fn semantic_model_contract() -> &'static SemanticModelContract {
+    builtin_semantic_model_contract()
+}
+
+fn builtin_semantic_model_contract() -> &'static SemanticModelContract {
+    static CONTRACT: OnceLock<SemanticModelContract> = OnceLock::new();
+    CONTRACT.get_or_init(|| {
+        let mut contract = SemanticModelContract {
+            model_key: SEMANTIC_MODEL_KEY.to_owned(),
+            model_id: SEMANTIC_MODEL_ID.to_owned(),
+            model_revision: SEMANTIC_MODEL_REVISION.to_owned(),
+            contract_version: SEMANTIC_MODEL_CONTRACT_VERSION,
+            tokenizer_fingerprint: semantic_tokenizer_fingerprint(),
+            tokenizer_behavior_fingerprint: semantic_tokenizer_behavior_fingerprint(),
+            dimensions: SEMANTIC_DIMENSIONS,
+            max_sequence_length: SEMANTIC_MAX_SEQUENCE_LENGTH,
+            pooling: SEMANTIC_POOLING.to_owned(),
+            normalization: SEMANTIC_NORMALIZATION.to_owned(),
+            query_prefix: SEMANTIC_QUERY_PREFIX.to_owned(),
+            document_prefix: SEMANTIC_PASSAGE_PREFIX.to_owned(),
+            language_scope: SEMANTIC_LANGUAGE_SCOPE.to_owned(),
+            descriptor: String::new(),
+            fingerprint: String::new(),
+        };
+        contract.rebuild_identity();
+        contract
+    })
 }
 
 const UNPROVISIONED_SHA256: &str =
@@ -400,25 +621,35 @@ impl fmt::Display for SemanticProvisioningRequired {
 impl std::error::Error for SemanticProvisioningRequired {}
 
 pub fn semantic_model_contract_descriptor() -> String {
+    builtin_semantic_model_contract().descriptor().to_owned()
+}
+
+pub fn semantic_model_contract_fingerprint() -> String {
+    builtin_semantic_model_contract().fingerprint().to_owned()
+}
+
+fn legacy_builtin_semantic_model_descriptor() -> String {
     let mut descriptor = format!(
         "ctx-semantic-e5-v{}|backend={SEMANTIC_BACKEND}|model_key={SEMANTIC_MODEL_KEY}|model={SEMANTIC_MODEL_ID}|revision={SEMANTIC_MODEL_REVISION}|dimensions={SEMANTIC_DIMENSIONS}|max_sequence_length={SEMANTIC_MAX_SEQUENCE_LENGTH}|pooling={SEMANTIC_POOLING}|normalization={SEMANTIC_NORMALIZATION}|query_prefix={SEMANTIC_QUERY_PREFIX}|passage_prefix={SEMANTIC_PASSAGE_PREFIX}|language=unicode-global",
         SEMANTIC_MODEL_CONTRACT_VERSION,
     );
+    append_builtin_semantic_executor_identity(&mut descriptor);
+    descriptor
+}
+
+fn append_builtin_semantic_executor_identity(descriptor: &mut String) {
     for variant in [
         SemanticOrtModelVariant::CpuFp32,
         SemanticOrtModelVariant::AcceleratorO4Fp16,
     ] {
         for file in variant.required_files() {
-            use std::fmt::Write as _;
-            write!(
-                descriptor,
+            descriptor.push_str(&format!(
                 "|variant={}|file={}:{}:{}",
                 variant.as_str(),
                 file.path,
                 file.size,
                 file.sha256
-            )
-            .expect("writing to String cannot fail");
+            ));
         }
     }
     for backend in [
@@ -427,20 +658,15 @@ pub fn semantic_model_contract_descriptor() -> String {
         SemanticBackendKind::OrtCuda,
         SemanticBackendKind::WindowsMl,
     ] {
-        use std::fmt::Write as _;
-        write!(
-            descriptor,
+        descriptor.push_str(&format!(
             "|backend_variant={}:{}:{}",
             backend.as_str(),
             backend.execution_provider(),
             backend.contract_id(),
-        )
-        .expect("writing to String cannot fail");
+        ));
     }
     let coreml = COREML_BUNDLE_CONTRACT;
-    use std::fmt::Write as _;
-    write!(
-        descriptor,
+    descriptor.push_str(&format!(
         "|coreml_artifact_url={}|coreml_artifact_name={}|coreml_archive_sha256={}|coreml_manifest_sha256={}|coreml_bundle_id={}|coreml_bundle_version={}|coreml_schema_version={}|coreml_model_id={}|coreml_source_revision={}|coreml_embedding_space_id={}|coreml_precision={}|coreml_minimum_macos={}|coreml_inputs={}:{};{}:{};{}:{}|coreml_output={}:{}|coreml_document_batch_size={}|coreml_query_batch_size={:?}|coreml_max_sequence_length={}|coreml_dimensions={}|coreml_document_prefix={}|coreml_query_prefix={}|coreml_pooling={}|coreml_normalization={}|coreml_tokenizer_artifact={}|coreml_document_model_artifact={}|coreml_query_model_artifact={}",
         coreml.artifact_url,
         coreml.artifact_name,
@@ -473,9 +699,11 @@ pub fn semantic_model_contract_descriptor() -> String {
         coreml.tokenizer_artifact,
         coreml.document_model_artifact,
         coreml.query_model_artifact,
-    )
-    .expect("writing to String cannot fail");
-    descriptor
+    ));
+}
+
+fn sha256_fingerprint(descriptor: &str) -> String {
+    format!("sha256:{:x}", Sha256::digest(descriptor.as_bytes()))
 }
 
 pub fn semantic_model_key() -> &'static str {
@@ -490,7 +718,25 @@ pub fn semantic_tokenizer_fingerprint() -> String {
         .unwrap_or_else(|| "missing-tokenizer-contract".to_owned())
 }
 
-fn semantic_e5_prefixed_text(prefix: &str, text: &str) -> String {
+pub fn semantic_tokenizer_behavior_fingerprint() -> String {
+    semantic_tokenizer_behavior_fingerprint_for(SEMANTIC_REQUIRED_MODEL_FILES)
+}
+
+pub(super) fn semantic_tokenizer_behavior_fingerprint_for(files: &[SemanticModelFile]) -> String {
+    let mut descriptor = "ctx-semantic-tokenizer-behavior-v1".to_owned();
+    for path in SEMANTIC_TOKENIZER_BEHAVIOR_PATHS {
+        match files.iter().find(|file| file.path == *path) {
+            Some(file) => descriptor.push_str(&format!(
+                "|file={}:{}:{}",
+                file.path, file.size, file.sha256
+            )),
+            None => descriptor.push_str(&format!("|missing={path}")),
+        }
+    }
+    sha256_fingerprint(&descriptor)
+}
+
+fn semantic_prefixed_text(prefix: &str, text: String) -> String {
     let text = text.trim_start();
     if text.starts_with(prefix) {
         text.to_owned()
@@ -500,9 +746,9 @@ fn semantic_e5_prefixed_text(prefix: &str, text: &str) -> String {
 }
 
 pub fn semantic_e5_passage_text(text: &str) -> String {
-    semantic_e5_prefixed_text(SEMANTIC_PASSAGE_PREFIX, text)
+    builtin_semantic_model_contract().document_text(text)
 }
 
 pub(super) fn semantic_e5_query_text(text: &str) -> String {
-    semantic_e5_prefixed_text(SEMANTIC_QUERY_PREFIX, text)
+    builtin_semantic_model_contract().query_text(text)
 }

--- a/crates/ctx-semantic-model/src/model_contract_tests.rs
+++ b/crates/ctx-semantic-model/src/model_contract_tests.rs
@@ -6,9 +6,25 @@ use crate::model_contract::*;
 fn semantic_model_identity_and_descriptor_bytes_are_frozen() {
     let contract = semantic_model_contract();
     assert_eq!(contract.contract_revision(), 2);
+    assert_eq!(contract.contract_version(), 2);
+    assert_eq!(contract.model_key(), SEMANTIC_MODEL_KEY);
     assert_eq!(contract.model_id(), "intfloat/multilingual-e5-small");
+    assert_eq!(contract.model_revision(), SEMANTIC_MODEL_REVISION);
+    assert_eq!(
+        contract.tokenizer_fingerprint(),
+        "sha256:0b44a9d7b51c3c62626640cda0e2c2f70fdacdc25bbbd68038369d14ebdf4c39"
+    );
+    assert_eq!(
+        contract.tokenizer_behavior_fingerprint(),
+        "sha256:c61e5e2d53de677ea9023debfa95e4c618b601c63e2de6c43c0c64850560c2c0"
+    );
     assert_eq!(contract.dimensions(), 384);
+    assert_eq!(contract.max_sequence_length(), 512);
+    assert_eq!(contract.pooling(), "attention-mask-mean");
     assert_eq!(contract.normalization(), "l2");
+    assert_eq!(contract.query_prefix(), "query: ");
+    assert_eq!(contract.document_prefix(), "passage: ");
+    assert_eq!(contract.language_scope(), "unicode-global");
     assert_eq!(SEMANTIC_MODEL_KEY, "e5-small-v1:mean-pool:l2:query-passage");
     assert_eq!(
         SEMANTIC_MODEL_REVISION,
@@ -69,9 +85,95 @@ fn semantic_model_identity_and_descriptor_bytes_are_frozen() {
     );
     let descriptor = semantic_model_contract_descriptor();
     let descriptor_sha256 = format!("{:x}", Sha256::digest(descriptor.as_bytes()));
+    assert_eq!(descriptor, contract.descriptor());
+    assert_eq!(
+        semantic_model_contract_fingerprint(),
+        contract.fingerprint()
+    );
+    assert_eq!(
+        semantic_model_contract_fingerprint(),
+        format!("sha256:{descriptor_sha256}")
+    );
     assert_eq!(
         descriptor_sha256,
-        "c812eb325bc5e90e7278b2b8da3933206340c5b5a46fd678be40016e06a89fc3"
+        "611f11c9b715543137d1b6be8d87497a2b6ef4945d425f3c0b973d2cb0c6036d"
+    );
+
+    assert!(std::ptr::eq(contract, semantic_model_contract()));
+}
+
+#[test]
+fn tokenizer_behavior_identity_covers_every_fastembed_behavior_file_only() {
+    assert_eq!(
+        SEMANTIC_TOKENIZER_BEHAVIOR_PATHS,
+        [
+            "tokenizer.json",
+            "config.json",
+            "special_tokens_map.json",
+            "tokenizer_config.json",
+        ]
+    );
+    let baseline = semantic_tokenizer_behavior_fingerprint();
+    for path in SEMANTIC_TOKENIZER_BEHAVIOR_PATHS {
+        let mut changed = SEMANTIC_REQUIRED_MODEL_FILES.to_vec();
+        let file = changed
+            .iter_mut()
+            .find(|file| file.path == *path)
+            .expect("behavior file must be pinned");
+        *file = SemanticModelFile::new(
+            file.path,
+            file.size,
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        );
+        assert_ne!(
+            semantic_tokenizer_behavior_fingerprint_for(&changed),
+            baseline,
+            "{path} did not participate in tokenizer behavior identity"
+        );
+    }
+
+    let mut changed_model_only = SEMANTIC_REQUIRED_MODEL_FILES.to_vec();
+    changed_model_only[0] = SemanticModelFile::new(
+        "onnx/model.onnx",
+        470_268_510,
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    );
+    assert_eq!(
+        semantic_tokenizer_behavior_fingerprint_for(&changed_model_only),
+        baseline,
+        "execution artifact identity leaked into tokenizer behavior identity"
+    );
+    assert_eq!(
+        semantic_tokenizer_fingerprint(),
+        "sha256:0b44a9d7b51c3c62626640cda0e2c2f70fdacdc25bbbd68038369d14ebdf4c39",
+        "the Flat-format tokenizer.json identity must remain unchanged"
+    );
+}
+
+#[test]
+fn exact_builtin_contract_exposes_only_the_frozen_pre_refactor_alias() {
+    let contract = semantic_model_contract();
+    let descriptor = contract
+        .legacy_builtin_descriptor_alias()
+        .expect("exact built-in contract must expose its migration alias");
+    assert_eq!(
+        format!("sha256:{:x}", Sha256::digest(descriptor.as_bytes())),
+        "sha256:c812eb325bc5e90e7278b2b8da3933206340c5b5a46fd678be40016e06a89fc3"
+    );
+    assert!(descriptor.starts_with("ctx-semantic-e5-v2|backend=multilingual-e5|"));
+    assert!(descriptor.contains("|backend_variant=cpu:CPUExecutionProvider:"));
+    assert!(descriptor.contains("|coreml_manifest_sha256="));
+
+    let non_builtin = contract
+        .clone()
+        .with_test_tokenizer_behavior_fingerprint("sha256:test-only");
+    assert_eq!(non_builtin.legacy_builtin_descriptor_alias(), None);
+    let revised_language_scope = contract
+        .clone()
+        .with_test_language_scope("test-only-language-scope");
+    assert_eq!(
+        revised_language_scope.legacy_builtin_descriptor_alias(),
+        None
     );
 }
 
@@ -123,76 +225,81 @@ fn provisioning_inventory_keeps_both_pinned_e5_variants_exact() {
 }
 
 #[test]
-fn semantic_generation_descriptor_covers_every_runtime_and_artifact_authority() {
-    let descriptor = semantic_model_contract_descriptor();
+fn semantic_descriptor_excludes_executor_and_publication_identity() {
+    let contract_descriptor = semantic_model_contract_descriptor();
     for required in [
+        format!("model_key={SEMANTIC_MODEL_KEY}"),
+        format!("model_id={SEMANTIC_MODEL_ID}"),
+        format!("model_revision={SEMANTIC_MODEL_REVISION}"),
+        format!("tokenizer_fingerprint={}", semantic_tokenizer_fingerprint()),
+        format!(
+            "tokenizer_behavior_fingerprint={}",
+            semantic_tokenizer_behavior_fingerprint()
+        ),
+        format!("dimensions={SEMANTIC_DIMENSIONS}"),
         format!("max_sequence_length={SEMANTIC_MAX_SEQUENCE_LENGTH}"),
         format!("pooling={SEMANTIC_POOLING}"),
+        format!("normalization={SEMANTIC_NORMALIZATION}"),
         format!("query_prefix={SEMANTIC_QUERY_PREFIX}"),
-        format!("passage_prefix={SEMANTIC_PASSAGE_PREFIX}"),
-        format!(
-            "coreml_manifest_sha256={}",
-            COREML_BUNDLE_CONTRACT.manifest_sha256
-        ),
-        format!(
-            "coreml_inputs={}:{}",
-            COREML_BUNDLE_CONTRACT.inputs[0].0, COREML_BUNDLE_CONTRACT.inputs[0].1
-        ),
-        format!(
-            "coreml_output={}:{}",
-            COREML_BUNDLE_CONTRACT.output_name, COREML_BUNDLE_CONTRACT.output_dtype
-        ),
+        format!("document_prefix={SEMANTIC_PASSAGE_PREFIX}"),
+        format!("language_scope={SEMANTIC_LANGUAGE_SCOPE}"),
     ] {
         assert!(
-            descriptor.contains(&required),
-            "missing descriptor authority: {required}"
+            contract_descriptor.contains(&required),
+            "missing vector-space authority: {required}"
         );
     }
-    for variant in [
-        SemanticOrtModelVariant::CpuFp32,
-        SemanticOrtModelVariant::AcceleratorO4Fp16,
+    for executor_only in [
+        "model_contract=",
+        "variant=",
+        "file=",
+        "backend_variant=",
+        "execution_provider",
+        "coreml_",
+        "artifact_url=",
+        "archive_sha256=",
+        "runtime=",
     ] {
-        for file in variant.required_files() {
-            assert!(descriptor.contains(&format!(
-                "variant={}|file={}:{}:{}",
-                variant.as_str(),
-                file.path,
-                file.size,
-                file.sha256
-            )));
-        }
-    }
-    for backend in [
-        SemanticBackendKind::Cpu,
-        SemanticBackendKind::CoreMl,
-        SemanticBackendKind::OrtCuda,
-        SemanticBackendKind::WindowsMl,
-    ] {
-        assert!(descriptor.contains(&format!(
-            "backend_variant={}:{}:{}",
-            backend.as_str(),
-            backend.execution_provider(),
-            backend.contract_id()
-        )));
+        assert!(
+            !contract_descriptor.contains(executor_only),
+            "executor identity leaked into vector contract: {executor_only}"
+        );
     }
 }
 
 #[test]
 fn e5_query_and_passage_policy_applies_each_role_prefix_exactly_once() {
+    let contract = semantic_model_contract();
+    assert_eq!(
+        contract.query_text("find a daemon failure"),
+        "query: find a daemon failure"
+    );
+    assert_eq!(
+        contract.query_text("  query: find a daemon failure"),
+        "query: find a daemon failure"
+    );
+    assert_eq!(
+        contract.document_text("daemon failed to restart"),
+        "passage: daemon failed to restart"
+    );
+    assert_eq!(
+        contract.document_text("  passage: daemon failed to restart"),
+        "passage: daemon failed to restart"
+    );
     assert_eq!(
         semantic_e5_query_text("find a daemon failure"),
-        "query: find a daemon failure"
+        contract.query_text("find a daemon failure")
     );
     assert_eq!(
         semantic_e5_query_text("  query: find a daemon failure"),
-        "query: find a daemon failure"
+        contract.query_text("  query: find a daemon failure")
     );
     assert_eq!(
         semantic_e5_passage_text("daemon failed to restart"),
-        "passage: daemon failed to restart"
+        contract.document_text("daemon failed to restart")
     );
     assert_eq!(
         semantic_e5_passage_text("  passage: daemon failed to restart"),
-        "passage: daemon failed to restart"
+        contract.document_text("  passage: daemon failed to restart")
     );
 }

--- a/crates/ctx-semantic-model/src/model_runtime.rs
+++ b/crates/ctx-semantic-model/src/model_runtime.rs
@@ -15,7 +15,7 @@ use super::{
     configuration::{SemanticBackendPreference, SemanticModelConfig},
     health_search::semantic_embed_policy_for,
     model_contract::{
-        semantic_e5_passage_text, semantic_e5_query_text, semantic_model_key, SemanticBackendKind,
+        semantic_model_key, PreparedSemanticQuery, SemanticBackendKind,
         SemanticCpuModelCacheMissing, SemanticCpuModelIntegrityError, SemanticModelFile,
         SemanticOrtModelVariant, SEMANTIC_BACKEND, SEMANTIC_DIMENSIONS,
         SEMANTIC_MODEL_CONTRACT_VERSION, SEMANTIC_MODEL_ID, SEMANTIC_MODEL_REVISION,
@@ -215,16 +215,17 @@ impl SharedSemanticRuntime {
     }
 
     #[cfg(ctx_semantic_fastembed)]
-    pub fn embed_query(
+    pub(crate) fn embed_query(
         &self,
         config: &SemanticModelConfig,
-        query: String,
+        query: PreparedSemanticQuery,
     ) -> Result<(Vec<f32>, SemanticEmbeddingRuntimeInfo)> {
+        let query = query.into_text();
         let mut embedder = self.lock()?;
         let first = embedder
             .as_mut()
             .ok_or_else(|| anyhow!("semantic embedder was not initialized"))?
-            .embed_query(query.clone());
+            .embed_prepared_query(query.clone());
         let embedding = match first {
             Ok(embedding) => embedding,
             Err(first_error) => {
@@ -237,7 +238,7 @@ impl SharedSemanticRuntime {
                 *embedder = None;
                 let mut replacement = reacquire_semantic_embedder(config, &runtime)
                     .context("reinitialize semantic embedder after query inference failure")?;
-                let retry = replacement.embed_query(query).with_context(|| {
+                let retry = replacement.embed_prepared_query(query).with_context(|| {
                     format!("semantic query inference failed twice; first failure: {first_error:#}")
                 })?;
                 *embedder = Some(replacement);
@@ -482,8 +483,7 @@ enum SemanticEmbeddingBackend {
 
 #[cfg(ctx_semantic_fastembed)]
 impl SemanticEmbeddingBackend {
-    pub(super) fn embed_query(&mut self, query: String) -> Result<Vec<f32>> {
-        let query = semantic_e5_query_text(&query);
+    pub(super) fn embed_prepared_query(&mut self, query: String) -> Result<Vec<f32>> {
         let raw = match self {
             Self::Ort { model, .. } => model
                 .embed(vec![query], Some(1))
@@ -497,7 +497,7 @@ impl SemanticEmbeddingBackend {
             .ok_or_else(|| anyhow!("semantic query embedding was empty"))
     }
 
-    pub(super) fn embed_documents(
+    pub(super) fn embed_prepared_documents(
         &mut self,
         documents: Vec<String>,
         batch_size: usize,
@@ -506,10 +506,6 @@ impl SemanticEmbeddingBackend {
         if expected == 0 {
             return Ok(Vec::new());
         }
-        let documents = documents
-            .into_iter()
-            .map(|text| semantic_e5_passage_text(&text))
-            .collect::<Vec<_>>();
         let raw = match self {
             Self::Ort { model, .. } => {
                 model.embed(documents, Some(batch_size)).with_context(|| {
@@ -596,12 +592,16 @@ pub(super) struct SemanticEmbedder {
 
 #[cfg(ctx_semantic_fastembed)]
 impl SemanticEmbedder {
-    pub(super) fn embed_query(&mut self, query: String) -> Result<Vec<f32>> {
-        self.backend.embed_query(query)
+    pub(super) fn embed_prepared_query(&mut self, query: String) -> Result<Vec<f32>> {
+        self.backend.embed_prepared_query(query)
     }
 
-    pub(super) fn embed_documents(&mut self, documents: Vec<String>) -> Result<Vec<Vec<f32>>> {
-        self.backend.embed_documents(documents, self.batch_size)
+    pub(super) fn embed_prepared_documents(
+        &mut self,
+        documents: Vec<String>,
+    ) -> Result<Vec<Vec<f32>>> {
+        self.backend
+            .embed_prepared_documents(documents, self.batch_size)
     }
 
     pub(super) fn runtime_info(&self) -> SemanticEmbeddingRuntimeInfo {

--- a/crates/ctx-semantic-model/src/model_runtime/cpu.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/cpu.rs
@@ -454,11 +454,11 @@ pub(super) trait SemanticContractCanaryExecutor {
 #[cfg(ctx_semantic_fastembed)]
 impl SemanticContractCanaryExecutor for SemanticEmbedder {
     fn embed_canary_query(&mut self, text: &str) -> Result<Vec<f32>> {
-        self.embed_query(text.to_owned())
+        self.embed_prepared_query(semantic_e5_query_text(text))
     }
 
     fn embed_canary_passage(&mut self, text: &str) -> Result<Vec<f32>> {
-        self.embed_documents(vec![text.to_owned()])?
+        self.embed_prepared_documents(vec![semantic_e5_passage_text(text)])?
             .pop()
             .ok_or_else(|| anyhow!("semantic canary document embedding is missing"))
     }
@@ -484,10 +484,7 @@ pub(super) fn run_semantic_contract_canary(
 }
 
 fn model_fingerprint() -> String {
-    format!(
-        "sha256:{:x}",
-        Sha256::digest(semantic_model_contract_descriptor().as_bytes())
-    )
+    semantic_model_contract_fingerprint()
 }
 
 fn backend_fingerprint(
@@ -556,9 +553,9 @@ use crate::{
     configuration::{SemanticBackendPreference, SemanticModelConfig},
     health_search::{semantic_embed_policy_for, SemanticEmbedPolicy},
     model_contract::{
-        semantic_model_contract_descriptor, SemanticBackendKind, SemanticOrtModelVariant,
-        SemanticProvisioningRequired, SEMANTIC_CONTRACT_CANARY_TEXT, SEMANTIC_MAX_SEQUENCE_LENGTH,
-        SEMANTIC_MODEL_ID,
+        semantic_e5_passage_text, semantic_e5_query_text, semantic_model_contract_fingerprint,
+        SemanticBackendKind, SemanticOrtModelVariant, SemanticProvisioningRequired,
+        SEMANTIC_CONTRACT_CANARY_TEXT, SEMANTIC_MAX_SEQUENCE_LENGTH, SEMANTIC_MODEL_ID,
     },
     resource_policy::{semantic_cpu_model_load_deferred, SemanticComputeClass},
 };

--- a/crates/ctx-semantic-model/src/model_runtime/document_batches.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/document_batches.rs
@@ -6,15 +6,16 @@ use super::{
     reacquire_semantic_embedder, throttle_semantic_batch, SemanticModelConfig, SemanticQuietPolicy,
     SharedSemanticRuntime,
 };
+use crate::PreparedSemanticDocuments;
 
 impl SharedSemanticRuntime {
-    pub fn embed_documents(
+    pub(crate) fn embed_documents(
         &self,
         config: &SemanticModelConfig,
-        texts: Vec<String>,
-        deadline: Option<Instant>,
+        texts: PreparedSemanticDocuments,
+        pacing_deadline: Option<Instant>,
     ) -> Result<(Vec<Vec<f32>>, SemanticQuietPolicy)> {
-        let mut pending = texts.into_iter();
+        let mut pending = texts.into_texts().into_iter();
         if pending.len() == 0 {
             let embedder = self.lock()?;
             let quiet_policy = embedder
@@ -38,7 +39,7 @@ impl SharedSemanticRuntime {
             let first = embedder
                 .as_mut()
                 .ok_or_else(|| anyhow!("semantic embedder was not initialized"))?
-                .embed_documents(batch.clone());
+                .embed_prepared_documents(batch.clone());
             let batch_embeddings = match first {
                 Ok(embeddings) => embeddings,
                 Err(first_error) => {
@@ -52,7 +53,9 @@ impl SharedSemanticRuntime {
                     let mut replacement = reacquire_semantic_embedder(config, &runtime).context(
                         "reinitialize semantic embedder after document inference failure",
                     )?;
-                    let retry = replacement.embed_documents(batch).with_context(|| {
+                    let retry = replacement
+                        .embed_prepared_documents(batch)
+                        .with_context(|| {
                         format!(
                             "semantic document inference failed twice; first failure: {first_error:#}"
                         )
@@ -70,8 +73,12 @@ impl SharedSemanticRuntime {
             embeddings.extend(batch_embeddings);
             final_quiet_policy = Some(quiet_policy);
             let active = started.elapsed();
+            // A source page is one atomic reconciliation unit, so this is not
+            // a cancellation deadline. It only caps cooperative quiet time
+            // after each inference batch; all vectors for the page still
+            // complete together before publication.
             let remaining =
-                deadline.map(|deadline| deadline.saturating_duration_since(Instant::now()));
+                pacing_deadline.map(|deadline| deadline.saturating_duration_since(Instant::now()));
             throttle_semantic_batch(active, quiet_policy, remaining);
         }
 

--- a/tools/bazel/check-semantic-index-dependency-boundary.sh
+++ b/tools/bazel/check-semantic-index-dependency-boundary.sh
@@ -142,16 +142,8 @@ done
 
 expected_model_imports="${tmp}/expected-model-imports.txt"
 printf '%s\n' \
-  'SEMANTIC_DIMENSIONS' \
-  'SEMANTIC_MODEL_CONTRACT_VERSION' \
-  'SEMANTIC_MODEL_ID' \
-  'SEMANTIC_MODEL_REVISION' \
-  'SEMANTIC_NORMALIZATION' \
-  'SEMANTIC_POOLING' \
-  'semantic_e5_passage_text' \
-  'semantic_model_contract' \
-  'semantic_model_contract_descriptor' \
-  'semantic_tokenizer_fingerprint' | LC_ALL=C sort >"${expected_model_imports}"
+  'SemanticModelContract' \
+  'semantic_model_contract' | LC_ALL=C sort >"${expected_model_imports}"
 
 actual_model_imports="${tmp}/actual-model-imports.txt"
 fully_qualified_model_uses="${tmp}/fully-qualified-model-uses.txt"


### PR DESCRIPTION
Separate semantic vector-space compatibility from embedding execution.

- add a contract-bound executor interface with the built-in local implementation
- preserve exact legacy index and daemon compatibility
- harden Flat contract migration and protocol validation
- route indexing and query execution through the seam