### PR TITLE
telemetry: add privacy-safe delivery observability

### DIFF
--- a/contracts/telemetry-v1/README.md
+++ b/contracts/telemetry-v1/README.md
@@ -1,15 +1,16 @@
 # Public telemetry v1
 
-ctx emits only four durable, content-free event families:
+ctx emits only five durable, content-free event families:
 
 - `operation_completed@1`
 - `provider_refresh_completed@1`
 - `runtime_observation@1`
+- `analytics_delivery_observation@1`
 - `install_stage@1`
 
 On the wire, each family is represented by `event_name` plus
 `event_version: 1`. Producers use closed enums and typed payloads; arbitrary
-property maps are not part of the producer API. The first three fixtures show
+property maps are not part of the producer API. The first four fixtures show
 valid batch event envelopes, not an exhaustive list of every operation-specific
 property. The `install_stage@1` fixture is the exact standalone hosted endpoint
 body.
@@ -27,8 +28,8 @@ or at least seven days old; managed upgrades preserve the original timestamp.
 
 Each outbound batch contains at most 50 events. A pending capability snapshot is
 attached only to events in the first batch and is acknowledged after that batch
-succeeds. A later batch failure does not undo that successful acknowledgement;
-failure of the snapshot-bearing batch leaves the claim unacknowledged.
+is accepted by the network service or durably handed to the bounded local
+outbox. Failure of both paths leaves the claim unacknowledged.
 
 `operation_completed@1` records one terminal event for an eligible operation.
 `provider_refresh_completed@1` records one completed aggregate for every
@@ -48,7 +49,10 @@ Its decision fields are closed:
 - `failure_scope`: `none`, `record`, `source`, `system`, `mixed`, or `unknown`;
 - `failure_type`: `none`, `record_rejection`, `unsupported_schema`,
   `not_found`, `permission`, `source_database`, `malformed_source`, `store`,
-  `worker_panic`, `system_io`, `system`, `other`, `mixed`, or `unknown`.
+  `worker_panic`, `system_io`, `system`, `other`, `mixed`, or `unknown`;
+- `failure_code`: `none` or one closed structured Core terminal code from the
+  public producer enum; and
+- `retryable`: a boolean copied from the same structured terminal receipt.
 
 Optional workload measurements are limited to bucketed records and logical
 bytes. Per-provider duration is independently bucketed; a
@@ -56,7 +60,10 @@ multi-provider refresh never copies one aggregate duration into every provider
 event. Daemon terminals may additionally report only whether a successor is
 pending and, for failures, whether the previous generation was retained.
 `runtime_observation@1` is reserved for low-frequency lifecycle and liveness
-observations. `install_stage@1` is produced only by the hosted shell and
+observations. `analytics_delivery_observation@1` carries exactly bucketed queue
+depth, retry attempts, dropped count, oldest queued age, and one closed failure
+class. It never contains an endpoint, response, request body, or raw error.
+`install_stage@1` is produced only by the hosted shell and
 PowerShell installers and records one closed installer stage/status pair with
 coarse platform, architecture, and script-family fields.
 
@@ -69,3 +76,12 @@ locators, cursors, exact timestamps, permanent ingestion-engine labels, and
 free-form failure or rewrite reasons. Exact CPU time, resident memory, worker
 counts, preparation bytes, Store receipts, and journal sizes are never
 serialized; unavailable runtime dimensions are omitted rather than inferred.
+
+Failed batch delivery uses an owner-private, cross-process-locked local outbox.
+It preserves the original serialized event IDs, binds each entry to a one-way
+endpoint fingerprint, retries at most 10 entries per delivery call, and is
+bounded to 128 entries, 2 MiB total, 512 KiB per entry, and 30 days. An explicit
+analytics opt-out removes the outbox the next time ctx opens analytics state.
+Malformed or oversized owner-private state resets to an empty valid outbox and
+later reports one `local_io` drop; unsafe paths or permissions still fail
+closed.

--- a/contracts/telemetry-v1/fixtures/analytics_delivery_observation.valid.json
+++ b/contracts/telemetry-v1/fixtures/analytics_delivery_observation.valid.json
@@ -1,0 +1,17 @@
+{
+  "event_id": "965515a7-07f9-4b1f-91ba-73bda3a0c7cf",
+  "event_name": "analytics_delivery_observation",
+  "event_version": 1,
+  "occurred_at": "2026-07-22T12:34:00Z",
+  "surface": "cli",
+  "operation": "outbox",
+  "outcome": "failure",
+  "duration_bucket": "unknown",
+  "properties": {
+    "queued_count_bucket": "2-5",
+    "retry_attempt_count_bucket": "2-5",
+    "dropped_count_bucket": "1",
+    "oldest_queued_age_bucket": "lt_10m",
+    "failure_class": "transport"
+  }
+}

--- a/contracts/telemetry-v1/fixtures/provider_refresh_completed.valid.json
+++ b/contracts/telemetry-v1/fixtures/provider_refresh_completed.valid.json
@@ -15,6 +15,8 @@
     "core_result": "complete",
     "failure_scope": "none",
     "failure_type": "none",
+    "failure_code": "none",
+    "retryable": false,
     "work_remaining": false,
     "records_bucket": "6-20",
     "logical_bytes_bucket": "lt_100kb"

--- a/crates/ctx-cli/src/analytics_outbox.rs
+++ b/crates/ctx-cli/src/analytics_outbox.rs
@@ -1,0 +1,600 @@
+use std::{
+    fs,
+    io::{Read as _, Write as _},
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use anyhow::{bail, Context as _, Result};
+use ctx_client_observability::analytics::{
+    AnalyticsDeliveryFailureClass, AnalyticsDeliveryObservationV1,
+};
+use ctx_history_core::utc_now;
+use ctx_history_platform::platform_security::{restrict_private_file_handle, verify_private_file};
+use fs2::FileExt as _;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest as _, Sha256};
+
+const OUTBOX_SCHEMA_VERSION: u16 = 1;
+const OUTBOX_MAX_BYTES: u64 = 2 * 1024 * 1024;
+const OUTBOX_MAX_BODY_BYTES: usize = 512 * 1024;
+const OUTBOX_MAX_ENTRIES: usize = 128;
+const OUTBOX_MAX_FLUSH_PER_CALL: usize = 10;
+const OUTBOX_MAX_AGE_SECONDS: i64 = 30 * 24 * 60 * 60;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct OutboxEntry {
+    schema_version: u16,
+    endpoint_fingerprint: String,
+    queued_at_epoch_seconds: i64,
+    attempts: u16,
+    payload: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct OutboxState {
+    schema_version: u16,
+    entries: Vec<OutboxEntry>,
+    retry_attempts: u64,
+    dropped: u64,
+    failure_sequence: u64,
+    last_failure_class: Option<AnalyticsDeliveryFailureClass>,
+}
+
+impl OutboxState {
+    fn empty() -> Self {
+        Self {
+            schema_version: OUTBOX_SCHEMA_VERSION,
+            entries: Vec::new(),
+            retry_attempts: 0,
+            dropped: 0,
+            failure_sequence: 0,
+            last_failure_class: None,
+        }
+    }
+
+    fn recovered() -> Self {
+        Self {
+            dropped: 1,
+            failure_sequence: 1,
+            last_failure_class: Some(AnalyticsDeliveryFailureClass::LocalIo),
+            ..Self::empty()
+        }
+    }
+}
+
+enum StoredOutbox {
+    Missing,
+    Corrupt,
+    State(OutboxState),
+}
+
+pub(crate) struct OutboxObservation {
+    pub(crate) event: AnalyticsDeliveryObservationV1,
+    retry_attempts: u64,
+    dropped: u64,
+    failure_sequence: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FlushStatus {
+    Available,
+    Blocked(AnalyticsDeliveryFailureClass),
+}
+
+pub(crate) struct AnalyticsOutbox {
+    path: PathBuf,
+    _lock: OutboxLock,
+    state: OutboxState,
+}
+
+impl AnalyticsOutbox {
+    pub(crate) fn open(path: PathBuf) -> Result<Self> {
+        let parent = path
+            .parent()
+            .context("analytics outbox path has no parent")?;
+        fs::create_dir_all(parent).context("create analytics outbox directory")?;
+        let lock = OutboxLock::acquire(&path.with_extension("lock"))?;
+        let (state, recovered) = match read_state(&path)? {
+            StoredOutbox::Missing => (OutboxState::empty(), false),
+            StoredOutbox::Corrupt => (OutboxState::recovered(), true),
+            StoredOutbox::State(state) => (state, false),
+        };
+        let mut outbox = Self {
+            path,
+            _lock: lock,
+            state,
+        };
+        let recovered = recovered || outbox.recover_invalid_state();
+        if recovered || outbox.prune_expired() {
+            outbox.persist()?;
+        }
+        Ok(outbox)
+    }
+
+    pub(crate) fn purge(path: &Path) -> Result<()> {
+        match fs::symlink_metadata(path) {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error).context("inspect analytics outbox"),
+        }
+        let Some(parent) = path.parent() else {
+            bail!("analytics outbox path has no parent");
+        };
+        fs::create_dir_all(parent).context("create analytics outbox directory")?;
+        let _lock = OutboxLock::acquire(&path.with_extension("lock"))?;
+        match fs::remove_file(path) {
+            Ok(()) => sync_parent(parent),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error).context("remove analytics outbox"),
+        }
+    }
+
+    pub(crate) fn flush(
+        &mut self,
+        endpoint: &str,
+        mut post: impl FnMut(&[u8]) -> std::result::Result<(), AnalyticsDeliveryFailureClass>,
+    ) -> Result<FlushStatus> {
+        let fingerprint = endpoint_fingerprint(endpoint);
+        let mut index = 0;
+        let mut attempted = 0;
+        while index < self.state.entries.len() && attempted < OUTBOX_MAX_FLUSH_PER_CALL {
+            if self.state.entries[index].endpoint_fingerprint != fingerprint {
+                index += 1;
+                continue;
+            }
+            attempted += 1;
+            self.state.retry_attempts = self.state.retry_attempts.saturating_add(1);
+            self.state.entries[index].attempts =
+                self.state.entries[index].attempts.saturating_add(1);
+            let body = self.state.entries[index].payload.as_bytes().to_vec();
+            match post(&body) {
+                Ok(()) => {
+                    self.state.entries.remove(index);
+                    self.persist()?;
+                }
+                Err(class) => {
+                    self.record_failure(class);
+                    self.persist()?;
+                    return Ok(FlushStatus::Blocked(class));
+                }
+            }
+        }
+        Ok(FlushStatus::Available)
+    }
+
+    pub(crate) fn enqueue(
+        &mut self,
+        endpoint: &str,
+        body: &[u8],
+        failure_class: AnalyticsDeliveryFailureClass,
+    ) -> Result<()> {
+        if body.len() > OUTBOX_MAX_BODY_BYTES {
+            self.state.dropped = self.state.dropped.saturating_add(1);
+            self.record_failure(failure_class);
+            self.persist()?;
+            bail!("analytics payload exceeds the outbox body bound");
+        }
+        let parsed: Value =
+            serde_json::from_slice(body).context("parse content-free analytics payload")?;
+        if !parsed.is_object() {
+            bail!("analytics outbox payload must be a JSON object");
+        }
+        let payload = std::str::from_utf8(body)
+            .context("analytics outbox payload is not UTF-8")?
+            .to_owned();
+        self.state.entries.push(OutboxEntry {
+            schema_version: OUTBOX_SCHEMA_VERSION,
+            endpoint_fingerprint: endpoint_fingerprint(endpoint),
+            queued_at_epoch_seconds: utc_now().timestamp(),
+            attempts: 0,
+            payload,
+        });
+        self.record_failure(failure_class);
+        self.enforce_bounds()?;
+        self.persist()
+    }
+
+    pub(crate) fn observation(&self) -> Option<OutboxObservation> {
+        if self.state.entries.is_empty()
+            && self.state.retry_attempts == 0
+            && self.state.dropped == 0
+            && self.state.last_failure_class.is_none()
+        {
+            return None;
+        }
+        let now = utc_now().timestamp();
+        let oldest_age_seconds = self
+            .state
+            .entries
+            .iter()
+            .map(|entry| now.saturating_sub(entry.queued_at_epoch_seconds).max(0) as u64)
+            .max()
+            .unwrap_or(0);
+        Some(OutboxObservation {
+            event: AnalyticsDeliveryObservationV1::new(
+                self.state.entries.len() as u64,
+                self.state.retry_attempts,
+                self.state.dropped,
+                Duration::from_secs(oldest_age_seconds),
+                self.state
+                    .last_failure_class
+                    .unwrap_or(AnalyticsDeliveryFailureClass::None),
+            ),
+            retry_attempts: self.state.retry_attempts,
+            dropped: self.state.dropped,
+            failure_sequence: self.state.failure_sequence,
+        })
+    }
+
+    pub(crate) fn acknowledge(&mut self, observation: &OutboxObservation) -> Result<()> {
+        self.state.retry_attempts = self
+            .state
+            .retry_attempts
+            .saturating_sub(observation.retry_attempts);
+        self.state.dropped = self.state.dropped.saturating_sub(observation.dropped);
+        if self.state.failure_sequence == observation.failure_sequence {
+            self.state.last_failure_class = None;
+        }
+        self.persist()
+    }
+
+    fn prune_expired(&mut self) -> bool {
+        let cutoff = utc_now().timestamp().saturating_sub(OUTBOX_MAX_AGE_SECONDS);
+        let before = self.state.entries.len();
+        self.state
+            .entries
+            .retain(|entry| entry.queued_at_epoch_seconds >= cutoff);
+        let removed = before.saturating_sub(self.state.entries.len()) as u64;
+        self.state.dropped = self.state.dropped.saturating_add(removed);
+        removed != 0
+    }
+
+    fn enforce_bounds(&mut self) -> Result<()> {
+        while self.state.entries.len() > OUTBOX_MAX_ENTRIES {
+            self.state.entries.remove(0);
+            self.state.dropped = self.state.dropped.saturating_add(1);
+        }
+        loop {
+            let body = serde_json::to_vec(&self.state).context("serialize analytics outbox")?;
+            if body.len() as u64 <= OUTBOX_MAX_BYTES {
+                return Ok(());
+            }
+            if self.state.entries.is_empty() {
+                bail!("analytics outbox metadata exceeds its size bound");
+            }
+            self.state.entries.remove(0);
+            self.state.dropped = self.state.dropped.saturating_add(1);
+        }
+    }
+
+    fn record_failure(&mut self, class: AnalyticsDeliveryFailureClass) {
+        self.state.failure_sequence = self.state.failure_sequence.saturating_add(1);
+        self.state.last_failure_class = Some(class);
+    }
+
+    fn recover_invalid_state(&mut self) -> bool {
+        if self.validate_state().is_ok() {
+            return false;
+        }
+        self.state = OutboxState::recovered();
+        true
+    }
+
+    fn validate_state(&self) -> Result<()> {
+        if self.state.schema_version != OUTBOX_SCHEMA_VERSION {
+            bail!("unsupported analytics outbox schema");
+        }
+        if self.state.entries.len() > OUTBOX_MAX_ENTRIES {
+            bail!("analytics outbox exceeds its entry bound");
+        }
+        for entry in &self.state.entries {
+            if entry.schema_version != OUTBOX_SCHEMA_VERSION
+                || entry.endpoint_fingerprint.len() != 64
+                || !entry
+                    .endpoint_fingerprint
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+                || entry.payload.len() > OUTBOX_MAX_BODY_BYTES
+                || !serde_json::from_str::<Value>(&entry.payload)
+                    .is_ok_and(|value| value.is_object())
+            {
+                bail!("analytics outbox entry is invalid");
+            }
+        }
+        Ok(())
+    }
+
+    fn persist(&self) -> Result<()> {
+        let body = serde_json::to_vec(&self.state).context("serialize analytics outbox")?;
+        if body.len() as u64 > OUTBOX_MAX_BYTES {
+            bail!("analytics outbox exceeds its size bound");
+        }
+        write_private_file_durably(&self.path, &body)
+    }
+}
+
+fn endpoint_fingerprint(endpoint: &str) -> String {
+    format!("{:x}", Sha256::digest(endpoint.as_bytes()))
+}
+
+fn read_state(path: &Path) -> Result<StoredOutbox> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(StoredOutbox::Missing);
+        }
+        Err(error) => return Err(error).context("inspect analytics outbox"),
+    };
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        bail!("analytics outbox is not a safe regular file");
+    }
+    verify_private_file(path).context("verify analytics outbox permissions")?;
+    if metadata.len() > OUTBOX_MAX_BYTES {
+        return Ok(StoredOutbox::Corrupt);
+    }
+    let file = fs::File::open(path).context("open analytics outbox")?;
+    let mut body = Vec::with_capacity(metadata.len() as usize);
+    file.take(OUTBOX_MAX_BYTES.saturating_add(1))
+        .read_to_end(&mut body)
+        .context("read analytics outbox")?;
+    if body.len() as u64 > OUTBOX_MAX_BYTES {
+        return Ok(StoredOutbox::Corrupt);
+    }
+    Ok(match serde_json::from_slice(&body) {
+        Ok(state) => StoredOutbox::State(state),
+        Err(_) => StoredOutbox::Corrupt,
+    })
+}
+
+struct OutboxLock(fs::File);
+
+impl OutboxLock {
+    fn acquire(path: &Path) -> Result<Self> {
+        let mut options = fs::OpenOptions::new();
+        options.read(true).write(true).create(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options
+                .mode(0o600)
+                .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt as _;
+            const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+            options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+        }
+        let file = options.open(path).context("open analytics outbox lock")?;
+        restrict_private_file_handle(&file).context("protect analytics outbox lock")?;
+        file.lock_exclusive()
+            .context("acquire analytics outbox lock")?;
+        Ok(Self(file))
+    }
+}
+
+impl Drop for OutboxLock {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.0);
+    }
+}
+
+fn write_private_file_durably(path: &Path, body: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("analytics outbox path has no parent")?;
+    let temp = parent.join(format!(".analytics-outbox-{}.tmp", uuid::Uuid::new_v4()));
+    let result = (|| -> Result<()> {
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        }
+        let mut file = options
+            .open(&temp)
+            .context("create analytics outbox temporary file")?;
+        restrict_private_file_handle(&file).context("protect analytics outbox temporary file")?;
+        file.write_all(body)
+            .context("write analytics outbox temporary file")?;
+        file.sync_all()
+            .context("sync analytics outbox temporary file")?;
+        drop(file);
+        replace_file(&temp, path).context("publish analytics outbox")?;
+        verify_private_file(path).context("verify analytics outbox permissions")?;
+        sync_parent(parent)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+    result
+}
+
+#[cfg(not(windows))]
+fn replace_file(source: &Path, target: &Path) -> std::io::Result<()> {
+    fs::rename(source, target)
+}
+
+#[cfg(windows)]
+fn replace_file(source: &Path, target: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let source = source
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let target = target
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let moved = unsafe {
+        MoveFileExW(
+            source.as_ptr(),
+            target.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if moved == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn sync_parent(path: &Path) -> Result<()> {
+    fs::File::open(path)
+        .context("open analytics outbox directory")?
+        .sync_all()
+        .context("sync analytics outbox directory")
+}
+
+#[cfg(not(unix))]
+fn sync_parent(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ctx_client_observability::analytics::CountBucket;
+
+    fn body(event_id: &str) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "client_profile_id": "00000000-0000-4000-8000-000000000001",
+            "data_root_id": "00000000-0000-4000-8000-000000000002",
+            "events": [{"event_id": event_id, "properties": {}}]
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn failed_body_retries_with_the_original_event_id() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("outbox.json");
+        let mut outbox = AnalyticsOutbox::open(path.clone()).unwrap();
+        let original = body("c220e8ef-eb0b-43d9-89c8-c64806e87d93");
+        outbox
+            .enqueue(
+                "https://cli.ctx.rs/functions/v1/analytics",
+                &original,
+                AnalyticsDeliveryFailureClass::Transport,
+            )
+            .unwrap();
+        drop(outbox);
+
+        let mut observed = Vec::new();
+        let mut reopened = AnalyticsOutbox::open(path).unwrap();
+        let status = reopened
+            .flush("https://cli.ctx.rs/functions/v1/analytics", |payload| {
+                observed.push(payload.to_vec());
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(status, FlushStatus::Available);
+        assert_eq!(observed, vec![original]);
+        assert_eq!(
+            reopened.observation().unwrap().event.queued,
+            ctx_client_observability::analytics::CountBucket::Zero
+        );
+    }
+
+    #[test]
+    fn endpoint_fingerprint_prevents_cross_endpoint_replay() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("outbox.json");
+        let mut outbox = AnalyticsOutbox::open(path).unwrap();
+        outbox
+            .enqueue(
+                "https://one.example.test/events",
+                &body("c220e8ef-eb0b-43d9-89c8-c64806e87d93"),
+                AnalyticsDeliveryFailureClass::Transport,
+            )
+            .unwrap();
+        let mut posts = 0;
+
+        outbox
+            .flush("https://two.example.test/events", |_| {
+                posts += 1;
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(posts, 0);
+        assert_eq!(outbox.state.entries.len(), 1);
+    }
+
+    #[test]
+    fn purge_removes_payload_and_does_not_create_missing_state() {
+        let root = tempfile::tempdir().unwrap();
+        let missing = root.path().join("missing").join("outbox.json");
+        AnalyticsOutbox::purge(&missing).unwrap();
+        assert!(!missing.parent().unwrap().exists());
+
+        let path = root.path().join("outbox.json");
+        let mut outbox = AnalyticsOutbox::open(path.clone()).unwrap();
+        outbox
+            .enqueue(
+                "https://cli.ctx.rs/functions/v1/analytics",
+                &body("c220e8ef-eb0b-43d9-89c8-c64806e87d93"),
+                AnalyticsDeliveryFailureClass::Transport,
+            )
+            .unwrap();
+        drop(outbox);
+        assert!(path.exists());
+
+        AnalyticsOutbox::purge(&path).unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn corrupt_private_state_recovers_and_reports_one_safe_drop() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("outbox.json");
+        write_private_file_durably(&path, b"not-json").unwrap();
+
+        let outbox = AnalyticsOutbox::open(path.clone()).unwrap();
+        let observation = outbox.observation().unwrap().event;
+
+        assert!(outbox.state.entries.is_empty());
+        assert_eq!(observation.dropped, CountBucket::One);
+        assert_eq!(
+            observation.failure_class,
+            AnalyticsDeliveryFailureClass::LocalIo
+        );
+        assert!(serde_json::from_slice::<OutboxState>(&fs::read(path).unwrap()).is_ok());
+    }
+
+    #[test]
+    fn unsafe_state_path_still_fails_closed() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("outbox.json");
+        fs::create_dir(&path).unwrap();
+
+        assert!(AnalyticsOutbox::open(path).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unsafe_state_permissions_still_fail_closed() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("outbox.json");
+        write_private_file_durably(&path, b"not-json").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert!(AnalyticsOutbox::open(path).is_err());
+    }
+}

--- a/crates/ctx-cli/src/commands/import/entry.rs
+++ b/crates/ctx-cli/src/commands/import/entry.rs
@@ -300,6 +300,11 @@ mod tests {
             refresh.failure_type,
             ProviderRefreshFailureType::MalformedSource
         );
+        assert_eq!(
+            refresh.failure_code,
+            crate::analytics::ProviderRefreshFailureCode::MalformedSource
+        );
+        assert!(!refresh.retryable);
         assert!(!refresh.work_remaining);
         assert_eq!(refresh.counts, None);
         assert!(!format!("{events:?}").contains("content-bearing raw terminal detail"));
@@ -324,6 +329,11 @@ mod tests {
         assert_eq!(refresh.core_result, ProviderCoreResult::Failure);
         assert_eq!(refresh.failure_scope, ProviderRefreshFailureScope::Source);
         assert_eq!(refresh.failure_type, ProviderRefreshFailureType::Unknown);
+        assert_eq!(
+            refresh.failure_code,
+            crate::analytics::ProviderRefreshFailureCode::SourceFailures
+        );
+        assert!(refresh.retryable);
         assert!(refresh.work_remaining);
         assert_eq!(refresh.counts, None);
         assert!(!format!("{events:?}").contains("content-bearing raw terminal detail"));

--- a/crates/ctx-cli/src/commands/import/provider_refresh.rs
+++ b/crates/ctx-cli/src/commands/import/provider_refresh.rs
@@ -10,8 +10,8 @@ use ctx_history_refresh::{
 use crate::analytics::{
     duration_bucket, DurationBucket, ForegroundProviderRefreshV1, Outcome, ProviderCoreResult,
     ProviderRefreshChange, ProviderRefreshCompletedV1, ProviderRefreshCountsV1,
-    ProviderRefreshFailureScope, ProviderRefreshFailureType, ProviderRefreshResult,
-    ProviderRefreshTrigger, PublicEventV1,
+    ProviderRefreshFailureCode, ProviderRefreshFailureScope, ProviderRefreshFailureType,
+    ProviderRefreshResult, ProviderRefreshTrigger, PublicEventV1,
 };
 
 use super::SourceStats;
@@ -36,6 +36,8 @@ enum CoreRefreshAnalyticsFacts {
         trigger: ProviderRefreshTrigger,
         failure_scope: ProviderRefreshFailureScope,
         failure_type: ProviderRefreshFailureType,
+        failure_code: ProviderRefreshFailureCode,
+        retryable: bool,
         work_remaining: bool,
     },
 }
@@ -170,6 +172,10 @@ impl ProviderRefreshCollector {
             trigger,
             failure_scope,
             failure_type,
+            failure_code: code
+                .map(provider_refresh_failure_code)
+                .unwrap_or(ProviderRefreshFailureCode::Unknown),
+            retryable: work_remaining,
             work_remaining,
         });
     }
@@ -240,6 +246,8 @@ impl ProviderRefreshCollector {
                         } else {
                             ProviderRefreshFailureType::None
                         },
+                        failure_code: ProviderRefreshFailureCode::None,
+                        retryable: false,
                         work_remaining: totals.capture_work_remaining,
                         counts: Some(ProviderRefreshCountsV1::new(
                             count_u64(totals.imported_events),
@@ -257,6 +265,8 @@ impl ProviderRefreshCollector {
                     trigger,
                     failure_scope,
                     failure_type,
+                    failure_code,
+                    retryable,
                     work_remaining,
                 } => {
                     let mut event = ProviderRefreshCompletedV1::foreground_bucketed(
@@ -270,6 +280,8 @@ impl ProviderRefreshCollector {
                             core_result: ProviderCoreResult::Failure,
                             failure_scope,
                             failure_type,
+                            failure_code,
+                            retryable,
                             work_remaining,
                             counts: None,
                         },
@@ -318,6 +330,8 @@ impl ProviderRefreshCollector {
                                 (true, false) => ProviderRefreshFailureType::Unknown,
                                 (true, true) => ProviderRefreshFailureType::Mixed,
                             },
+                            failure_code: ProviderRefreshFailureCode::None,
+                            retryable: false,
                             work_remaining: false,
                             counts: None,
                         },
@@ -356,6 +370,42 @@ impl ProviderRefreshCollector {
         self.aggregates
             .last_mut()
             .expect("a provider refresh aggregate was just inserted")
+    }
+}
+
+fn provider_refresh_failure_code(code: RefreshOutcomeCode) -> ProviderRefreshFailureCode {
+    match code {
+        RefreshOutcomeCode::SourceUnavailable => ProviderRefreshFailureCode::SourceUnavailable,
+        RefreshOutcomeCode::ExplicitSourcePathMissing => {
+            ProviderRefreshFailureCode::ExplicitSourcePathMissing
+        }
+        RefreshOutcomeCode::SourceChanged => ProviderRefreshFailureCode::SourceChanged,
+        RefreshOutcomeCode::MalformedSource => ProviderRefreshFailureCode::MalformedSource,
+        RefreshOutcomeCode::UnsupportedSchema => ProviderRefreshFailureCode::UnsupportedSchema,
+        RefreshOutcomeCode::SourceFailures => ProviderRefreshFailureCode::SourceFailures,
+        RefreshOutcomeCode::LogicalSourceFailures => {
+            ProviderRefreshFailureCode::LogicalSourceFailures
+        }
+        RefreshOutcomeCode::SourceUnclaimed => ProviderRefreshFailureCode::SourceUnclaimed,
+        RefreshOutcomeCode::SourceRefreshFailed => ProviderRefreshFailureCode::SourceRefreshFailed,
+        RefreshOutcomeCode::SourceRefreshInternal => {
+            ProviderRefreshFailureCode::SourceRefreshInternal
+        }
+        RefreshOutcomeCode::ResourceUnavailable => ProviderRefreshFailureCode::ResourceUnavailable,
+        RefreshOutcomeCode::IndexIncompatible => ProviderRefreshFailureCode::IndexIncompatible,
+        RefreshOutcomeCode::IndexCorruption => ProviderRefreshFailureCode::IndexCorruption,
+        RefreshOutcomeCode::SourceRefreshAdmissionFailed => {
+            ProviderRefreshFailureCode::SourceRefreshAdmissionFailed
+        }
+        RefreshOutcomeCode::AllProviderTerminalCoverageUnavailable => {
+            ProviderRefreshFailureCode::AllProviderTerminalCoverageUnavailable
+        }
+        RefreshOutcomeCode::Completed
+        | RefreshOutcomeCode::CompletedWithRejections
+        | RefreshOutcomeCode::CompletedWithSourceFailures
+        | RefreshOutcomeCode::CompletedWithRejectionsAndSourceFailures => {
+            ProviderRefreshFailureCode::None
+        }
     }
 }
 

--- a/crates/ctx-cli/src/config.rs
+++ b/crates/ctx-cli/src/config.rs
@@ -424,18 +424,15 @@ impl AppConfig {
         observe_app_config_load();
         let mut config = Self::default();
         let path = data_root.join(CONFIG_FILE);
-        match mutation::read_config_text_migrating_retired_controls(&path)? {
-            Some(text) => {
-                let parsed = parse_toml_subset(&text)
-                    .with_context(|| format!("parse {}", path.display()))?;
-                config
-                    .apply_values(&parsed)
-                    .with_context(|| format!("load {}", path.display()))?;
-                config
-                    .validate_provider_root_data_root(data_root)
-                    .with_context(|| format!("load {}", path.display()))?;
-            }
-            None => {}
+        if let Some(text) = mutation::read_config_text_migrating_retired_controls(&path)? {
+            let parsed =
+                parse_toml_subset(&text).with_context(|| format!("parse {}", path.display()))?;
+            config
+                .apply_values(&parsed)
+                .with_context(|| format!("load {}", path.display()))?;
+            config
+                .validate_provider_root_data_root(data_root)
+                .with_context(|| format!("load {}", path.display()))?;
         }
         Ok(config)
     }

--- a/crates/ctx-cli/src/main.rs
+++ b/crates/ctx-cli/src/main.rs
@@ -29,6 +29,7 @@ macro_rules! eprintln {
 }
 
 mod analytics;
+mod analytics_outbox;
 mod cli;
 mod commands;
 mod companion;

--- a/crates/ctx-cli/src/mcp.rs
+++ b/crates/ctx-cli/src/mcp.rs
@@ -127,12 +127,22 @@ impl McpUsagePort for LocalUsagePort {
 }
 
 fn product_telemetry(data_root: PathBuf) -> McpTelemetry {
-    let enabled = config::AppConfig::load(&data_root).is_ok_and(|config| config.analytics.enabled);
+    let initial_config = config::AppConfig::load(&data_root).ok();
+    let enabled = initial_config
+        .as_ref()
+        .is_some_and(|config| config.analytics.enabled);
+    if let Some(config) = initial_config
+        .as_ref()
+        .filter(|config| !config.analytics.enabled)
+    {
+        crate::analytics::send_batch(&data_root, config, &[]);
+    }
     McpTelemetry::start(enabled, move |events: &[PublicEventV1]| {
         let Ok(config) = config::AppConfig::load(&data_root) else {
             return Ok(());
         };
         if !config.analytics.enabled {
+            crate::analytics::send_batch(&data_root, &config, &[]);
             return Ok(());
         }
         crate::analytics::send_batch(&data_root, &config, events);

--- a/crates/ctx-cli/src/net.rs
+++ b/crates/ctx-cli/src/net.rs
@@ -10,33 +10,103 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use url::{Host, Url};
 
+use crate::analytics::AnalyticsDeliveryFailureClass;
+
 pub(crate) const TELEMETRY_HTTP_TIMEOUT: Duration = Duration::from_millis(250);
 const MAX_ARTIFACT_REDIRECTS: usize = 5;
 
-pub(crate) fn post_telemetry_json(endpoint: &str, body: &[u8]) -> Result<()> {
+#[derive(Debug)]
+pub(crate) struct TelemetryPostError {
+    class: AnalyticsDeliveryFailureClass,
+    source: anyhow::Error,
+}
+
+impl TelemetryPostError {
+    pub(crate) fn class(&self) -> AnalyticsDeliveryFailureClass {
+        self.class
+    }
+
+    fn new(class: AnalyticsDeliveryFailureClass, source: impl Into<anyhow::Error>) -> Self {
+        Self {
+            class,
+            source: source.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for TelemetryPostError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.source.fmt(formatter)
+    }
+}
+
+impl std::error::Error for TelemetryPostError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.source()
+    }
+}
+
+pub(crate) fn post_telemetry_json(
+    endpoint: &str,
+    body: &[u8],
+) -> std::result::Result<(), TelemetryPostError> {
     post_json_with_timeout(endpoint, body, TELEMETRY_HTTP_TIMEOUT)
 }
 
-fn post_json_with_timeout(endpoint: &str, body: &[u8], timeout: Duration) -> Result<()> {
-    if let Some(path) = file_url_path(endpoint)? {
+fn post_json_with_timeout(
+    endpoint: &str,
+    body: &[u8],
+    timeout: Duration,
+) -> std::result::Result<(), TelemetryPostError> {
+    let file_path = file_url_path(endpoint).map_err(|error| {
+        TelemetryPostError::new(AnalyticsDeliveryFailureClass::Configuration, error)
+    })?;
+    if let Some(path) = file_path {
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
             .open(&path)
-            .with_context(|| format!("open {}", path.display()))?;
-        file.write_all(body)?;
-        file.write_all(b"\n")?;
+            .with_context(|| format!("open {}", path.display()))
+            .map_err(|error| {
+                TelemetryPostError::new(AnalyticsDeliveryFailureClass::LocalIo, error)
+            })?;
+        file.write_all(body).map_err(|error| {
+            TelemetryPostError::new(AnalyticsDeliveryFailureClass::LocalIo, error)
+        })?;
+        file.write_all(b"\n").map_err(|error| {
+            TelemetryPostError::new(AnalyticsDeliveryFailureClass::LocalIo, error)
+        })?;
         return Ok(());
     }
-    require_https_or_localhost(endpoint)?;
-    ureq::post(endpoint)
+    require_https_or_localhost(endpoint).map_err(|error| {
+        TelemetryPostError::new(AnalyticsDeliveryFailureClass::Configuration, error)
+    })?;
+    let result = ureq::post(endpoint)
         // ureq applies this overall deadline to connection establishment too
         // when no separate connect timeout overrides it.
         .timeout(timeout)
         .set("content-type", "application/json")
-        .send_bytes(body)
-        .map(|_| ())
-        .map_err(|err| anyhow!("POST {endpoint}: {err}"))
+        .send_bytes(body);
+    match result {
+        Ok(_) => Ok(()),
+        Err(error) => {
+            let class = match &error {
+                ureq::Error::Status(429, _) => AnalyticsDeliveryFailureClass::RateLimited,
+                ureq::Error::Status(status, _) if (400..500).contains(status) => {
+                    AnalyticsDeliveryFailureClass::ClientRejection
+                }
+                ureq::Error::Status(status, _) if (500..600).contains(status) => {
+                    AnalyticsDeliveryFailureClass::Server
+                }
+                ureq::Error::Status(_, _) => AnalyticsDeliveryFailureClass::Unknown,
+                ureq::Error::Transport(_) => AnalyticsDeliveryFailureClass::Transport,
+            };
+            Err(TelemetryPostError::new(
+                class,
+                anyhow!("POST {endpoint}: {error}"),
+            ))
+        }
+    }
 }
 
 pub fn get_bytes_limited(endpoint: &str, max_bytes: usize) -> Result<Vec<u8>> {
@@ -439,6 +509,12 @@ mod tests {
         assert!(require_https_or_localhost("http://example.com@localhost/events").is_err());
         assert!(require_https_or_localhost("https://user@example.com/events").is_err());
         assert!(require_https_or_localhost("https://").is_err());
+        assert_eq!(
+            post_telemetry_json("http://example.com/events", b"{}")
+                .unwrap_err()
+                .class(),
+            AnalyticsDeliveryFailureClass::Configuration
+        );
     }
 
     #[test]
@@ -487,7 +563,10 @@ mod tests {
         release_tx.send(()).unwrap();
         server.join().unwrap();
 
-        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().class(),
+            AnalyticsDeliveryFailureClass::Transport
+        );
         assert!(
             elapsed < Duration::from_secs(1),
             "telemetry request took {elapsed:?}"

--- a/crates/ctx-cli/src/observability_composition.rs
+++ b/crates/ctx-cli/src/observability_composition.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::{
-    analytics::{AnalyticsDeliveryAuthority, PublicEventV1},
+    analytics::{AnalyticsDeliveryAuthority, AnalyticsDeliveryFailureClass, PublicEventV1},
     config::{AppConfig, LocalUsageConfigResolver, LocalUsageConfigState},
     local_usage::{UsageControlRevision, UsageControlSnapshot},
 };
@@ -19,16 +19,21 @@ pub(crate) fn local_usage_storage_authority(
 
 const CAPABILITY_CLAIM_FILE: &str = "execution-capabilities-v1.claim";
 const CAPABILITY_REPORTED_FILE: &str = "execution-capabilities-v1.reported";
+const ANALYTICS_OUTBOX_FILE: &str = "analytics-outbox-v1.json";
 
 pub(crate) fn deliver_analytics_batch(
     data_root: &Path,
     config: &AppConfig,
     events: &[PublicEventV1],
 ) -> anyhow::Result<()> {
-    if events.is_empty()
-        || !config.analytics.enabled
-        || std::env::var_os("CTX_ANALYTICS_DRY_RUN").is_some()
-    {
+    if std::env::var_os("CTX_ANALYTICS_DRY_RUN").is_some() {
+        return Ok(());
+    }
+    let outbox_path = crate::identity::device_state_path(ANALYTICS_OUTBOX_FILE, data_root)?;
+    if !config.analytics.enabled {
+        return crate::analytics_outbox::AnalyticsOutbox::purge(&outbox_path);
+    }
+    if events.is_empty() {
         return Ok(());
     }
     let client_profile_id = crate::identity::device_id(data_root)?;
@@ -54,9 +59,53 @@ pub(crate) fn deliver_analytics_batch(
             .map(|marker| marker.install_attempt_id.as_str()),
         capability_snapshot,
     };
-    ctx_client_observability::analytics::deliver_batch(&mut authority, events, |body| {
+    let mut outbox = crate::analytics_outbox::AnalyticsOutbox::open(outbox_path)?;
+    let flush = outbox.flush(&config.analytics.endpoint, |body| {
         crate::net::post_telemetry_json(&config.analytics.endpoint, body)
-    })
+            .map_err(|error| error.class())
+    })?;
+    let mut blocked = match flush {
+        crate::analytics_outbox::FlushStatus::Available => None,
+        crate::analytics_outbox::FlushStatus::Blocked(class) => Some(class),
+    };
+    {
+        let mut post_or_queue = |body: &[u8]| -> anyhow::Result<()> {
+            if blocked.is_none() {
+                match crate::net::post_telemetry_json(&config.analytics.endpoint, body) {
+                    Ok(()) => return Ok(()),
+                    Err(error) => blocked = Some(error.class()),
+                }
+            }
+            let class = blocked.unwrap_or(AnalyticsDeliveryFailureClass::Unknown);
+            outbox.enqueue(&config.analytics.endpoint, body, class)
+        };
+        ctx_client_observability::analytics::deliver_batch(
+            &mut authority,
+            events,
+            &mut post_or_queue,
+        )?;
+    }
+    if let Some(observation) = outbox.observation() {
+        {
+            let mut post_or_queue = |body: &[u8]| -> anyhow::Result<()> {
+                if blocked.is_none() {
+                    match crate::net::post_telemetry_json(&config.analytics.endpoint, body) {
+                        Ok(()) => return Ok(()),
+                        Err(error) => blocked = Some(error.class()),
+                    }
+                }
+                let class = blocked.unwrap_or(AnalyticsDeliveryFailureClass::Unknown);
+                outbox.enqueue(&config.analytics.endpoint, body, class)
+            };
+            ctx_client_observability::analytics::deliver_delivery_observation(
+                &authority,
+                observation.event,
+                &mut post_or_queue,
+            )?;
+        }
+        outbox.acknowledge(&observation)?;
+    }
+    Ok(())
 }
 
 pub(crate) const fn usage_control_snapshot(enabled: bool) -> UsageControlSnapshot {

--- a/crates/ctx-cli/src/semantic.rs
+++ b/crates/ctx-cli/src/semantic.rs
@@ -313,7 +313,11 @@ pub(crate) fn run_daemon_command(
 
 impl ctx_daemon_cli::DaemonCliHost for CtxDaemonCliHost {
     fn load_config(&self, data_root: &Path) -> Result<DaemonCliConfig<'static>> {
-        crate::config::AppConfig::load(data_root).map(owned_daemon_cli_config)
+        let config = crate::config::AppConfig::load(data_root)?;
+        if !config.analytics.enabled {
+            crate::analytics::send_batch(data_root, &config, &[]);
+        }
+        Ok(owned_daemon_cli_config(config))
     }
 
     fn persisted_daemon_enabled(&self, data_root: &Path) -> Result<bool> {
@@ -357,9 +361,7 @@ impl ctx_daemon_cli::DaemonCliHost for CtxDaemonCliHost {
         let Ok(config) = crate::config::AppConfig::load(data_root) else {
             return;
         };
-        if config.analytics.enabled {
-            crate::analytics::send_batch(data_root, &config, events);
-        }
+        crate::analytics::send_batch(data_root, &config, events);
     }
 
     fn fetch_to_writer(

--- a/crates/ctx-client-observability/src/analytics/delivery.rs
+++ b/crates/ctx-client-observability/src/analytics/delivery.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use super::{count_bucket, duration_bucket, CountBucket, DurationBucket, Outcome};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnalyticsDeliveryFailureClass {
+    None,
+    Transport,
+    RateLimited,
+    ClientRejection,
+    Server,
+    LocalIo,
+    Configuration,
+    Unknown,
+}
+
+impl AnalyticsDeliveryFailureClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Transport => "transport",
+            Self::RateLimited => "rate_limited",
+            Self::ClientRejection => "client_rejection",
+            Self::Server => "server",
+            Self::LocalIo => "local_io",
+            Self::Configuration => "configuration",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AnalyticsDeliveryObservationV1 {
+    pub queued: CountBucket,
+    pub retry_attempts: CountBucket,
+    pub dropped: CountBucket,
+    pub oldest_queued_age: DurationBucket,
+    pub failure_class: AnalyticsDeliveryFailureClass,
+}
+
+impl AnalyticsDeliveryObservationV1 {
+    pub fn new(
+        queued: u64,
+        retry_attempts: u64,
+        dropped: u64,
+        oldest_queued_age: Duration,
+        failure_class: AnalyticsDeliveryFailureClass,
+    ) -> Self {
+        Self {
+            queued: count_bucket(queued),
+            retry_attempts: count_bucket(retry_attempts),
+            dropped: count_bucket(dropped),
+            oldest_queued_age: duration_bucket(oldest_queued_age),
+            failure_class,
+        }
+    }
+
+    pub fn outcome(self) -> Outcome {
+        if self.queued == CountBucket::Zero
+            && self.dropped == CountBucket::Zero
+            && self.failure_class == AnalyticsDeliveryFailureClass::None
+        {
+            Outcome::Success
+        } else {
+            Outcome::Failure
+        }
+    }
+}

--- a/crates/ctx-client-observability/src/analytics/mod.rs
+++ b/crates/ctx-client-observability/src/analytics/mod.rs
@@ -4,6 +4,8 @@ mod client;
 pub use client::*;
 mod daemon;
 pub use daemon::*;
+mod delivery;
+pub use delivery::*;
 mod mcp;
 pub use mcp::*;
 mod provider;
@@ -19,7 +21,7 @@ pub use operation::*;
 mod product;
 pub use product::*;
 mod sender;
-pub use sender::{deliver_batch, AnalyticsDeliveryAuthority};
+pub use sender::{deliver_batch, deliver_delivery_observation, AnalyticsDeliveryAuthority};
 
 #[cfg(test)]
 mod tests;

--- a/crates/ctx-client-observability/src/analytics/provider.rs
+++ b/crates/ctx-client-observability/src/analytics/provider.rs
@@ -156,6 +156,58 @@ impl ProviderRefreshFailureType {
     }
 }
 
+/// Stable content-free reason for a terminal Core refresh failure.
+///
+/// This deliberately mirrors only the closed structured outcome vocabulary.
+/// Raw error detail, retry advice, route identifiers, and source coordinates
+/// are never represented here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderRefreshFailureCode {
+    None,
+    SourceUnavailable,
+    ExplicitSourcePathMissing,
+    SourceChanged,
+    MalformedSource,
+    UnsupportedSchema,
+    SourceFailures,
+    LogicalSourceFailures,
+    SourceUnclaimed,
+    SourceRefreshFailed,
+    SourceRefreshInternal,
+    ResourceUnavailable,
+    IndexIncompatible,
+    IndexCorruption,
+    SourceRefreshAdmissionFailed,
+    AllProviderTerminalCoverageUnavailable,
+    Unknown,
+}
+
+impl ProviderRefreshFailureCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::SourceUnavailable => "source_unavailable",
+            Self::ExplicitSourcePathMissing => "explicit_source_path_missing",
+            Self::SourceChanged => "source_changed",
+            Self::MalformedSource => "malformed_source",
+            Self::UnsupportedSchema => "unsupported_schema",
+            Self::SourceFailures => "source_failures",
+            Self::LogicalSourceFailures => "logical_source_failures",
+            Self::SourceUnclaimed => "source_unclaimed",
+            Self::SourceRefreshFailed => "source_refresh_failed",
+            Self::SourceRefreshInternal => "source_refresh_internal",
+            Self::ResourceUnavailable => "resource_unavailable",
+            Self::IndexIncompatible => "index_incompatible",
+            Self::IndexCorruption => "index_corruption",
+            Self::SourceRefreshAdmissionFailed => "source_refresh_admission_failed",
+            Self::AllProviderTerminalCoverageUnavailable => {
+                "all_provider_terminal_coverage_unavailable"
+            }
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProviderRefreshCountsV1 {
     pub records: Option<CountBucket>,
@@ -188,6 +240,8 @@ pub struct ForegroundProviderRefreshV1 {
     pub core_result: ProviderCoreResult,
     pub failure_scope: ProviderRefreshFailureScope,
     pub failure_type: ProviderRefreshFailureType,
+    pub failure_code: ProviderRefreshFailureCode,
+    pub retryable: bool,
     pub work_remaining: bool,
     pub counts: Option<ProviderRefreshCountsV1>,
 }
@@ -290,6 +344,8 @@ mod tests {
                     core_result: ProviderCoreResult::Partial,
                     failure_scope: ProviderRefreshFailureScope::Record,
                     failure_type: ProviderRefreshFailureType::RecordRejection,
+                    failure_code: ProviderRefreshFailureCode::None,
+                    retryable: false,
                     work_remaining: true,
                     counts: Some(ProviderRefreshCountsV1::new(8, 2048)),
                 },
@@ -312,6 +368,8 @@ mod tests {
                 "core_result": "partial",
                 "failure_scope": "record",
                 "failure_type": "record_rejection",
+                "failure_code": "none",
+                "retryable": false,
                 "work_remaining": true,
                 "records_bucket": "6-20",
                 "logical_bytes_bucket": "lt_100kb",
@@ -334,6 +392,8 @@ mod tests {
                     core_result: ProviderCoreResult::Failure,
                     failure_scope: ProviderRefreshFailureScope::System,
                     failure_type: ProviderRefreshFailureType::System,
+                    failure_code: ProviderRefreshFailureCode::IndexCorruption,
+                    retryable: true,
                     work_remaining: true,
                     counts: None,
                 },

--- a/crates/ctx-client-observability/src/analytics/sender.rs
+++ b/crates/ctx-client-observability/src/analytics/sender.rs
@@ -71,6 +71,22 @@ pub fn deliver_batch(
     )
 }
 
+pub fn deliver_delivery_observation(
+    authority: &AnalyticsDeliveryAuthority<'_>,
+    observation: AnalyticsDeliveryObservationV1,
+    mut post: impl FnMut(&[u8]) -> Result<()>,
+) -> Result<()> {
+    let occurred_at = minute_rounded_now();
+    let event = serialize_delivery_observation(observation, occurred_at);
+    let body = serialize_batch_body(
+        authority.app_version,
+        authority.client_profile_id,
+        authority.data_root_id,
+        &[event],
+    )?;
+    post(&body)
+}
+
 fn serialize_batch_body(
     app_version: &str,
     client_profile_id: &str,
@@ -108,6 +124,29 @@ fn minute_rounded_now() -> chrono::DateTime<chrono::Utc> {
         .with_second(0)
         .and_then(|value| value.with_nanosecond(0))
         .expect("rounding a valid UTC timestamp to a minute must succeed")
+}
+
+fn serialize_delivery_observation(
+    observation: AnalyticsDeliveryObservationV1,
+    occurred_at: chrono::DateTime<chrono::Utc>,
+) -> Value {
+    json!({
+        "event_id": Uuid::new_v4().to_string(),
+        "event_name": "analytics_delivery_observation",
+        "event_version": 1,
+        "occurred_at": occurred_at,
+        "surface": "cli",
+        "operation": "outbox",
+        "outcome": observation.outcome().as_str(),
+        "duration_bucket": "unknown",
+        "properties": {
+            "queued_count_bucket": observation.queued.as_str(),
+            "retry_attempt_count_bucket": observation.retry_attempts.as_str(),
+            "dropped_count_bucket": observation.dropped.as_str(),
+            "oldest_queued_age_bucket": observation.oldest_queued_age.as_str(),
+            "failure_class": observation.failure_class.as_str(),
+        },
+    })
 }
 
 pub(super) fn serialize_event(
@@ -240,6 +279,8 @@ fn insert_provider_refresh_properties(
     insert_str(properties, "core_result", refresh.core_result.as_str());
     insert_str(properties, "failure_scope", refresh.failure_scope.as_str());
     insert_str(properties, "failure_type", refresh.failure_type.as_str());
+    insert_str(properties, "failure_code", refresh.failure_code.as_str());
+    insert_bool(properties, "retryable", refresh.retryable);
     insert_bool(properties, "work_remaining", refresh.work_remaining);
     if let Some(counts) = refresh.counts {
         insert_optional_count(properties, "records_bucket", counts.records);
@@ -768,6 +809,34 @@ mod tests {
 
     fn numbered_events(count: usize) -> Vec<Value> {
         (0..count).map(|index| json!({ "index": index })).collect()
+    }
+
+    #[test]
+    fn delivery_observation_is_closed_bucketed_and_content_free() {
+        let occurred_at = chrono::DateTime::parse_from_rfc3339("2026-07-22T12:34:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let event = serialize_delivery_observation(
+            AnalyticsDeliveryObservationV1::new(
+                3,
+                4,
+                1,
+                std::time::Duration::from_secs(7 * 60),
+                AnalyticsDeliveryFailureClass::Transport,
+            ),
+            occurred_at,
+        );
+        let mut expected: Value = serde_json::from_str(include_str!(
+            "../../../../contracts/telemetry-v1/fixtures/analytics_delivery_observation.valid.json"
+        ))
+        .unwrap();
+        expected["event_id"] = event["event_id"].clone();
+
+        assert_eq!(event, expected);
+        let encoded = event.to_string();
+        for forbidden in ["endpoint", "response", "error_message", "path", "command"] {
+            assert!(!encoded.contains(forbidden));
+        }
     }
 
     #[test]

--- a/crates/ctx-client-observability/src/analytics/tests.rs
+++ b/crates/ctx-client-observability/src/analytics/tests.rs
@@ -212,6 +212,8 @@ fn durable_family_serialization_matches_public_goldens() {
                     core_result: ProviderCoreResult::Complete,
                     failure_scope: ProviderRefreshFailureScope::None,
                     failure_type: ProviderRefreshFailureType::None,
+                    failure_code: ProviderRefreshFailureCode::None,
+                    retryable: false,
                     work_remaining: false,
                     counts: Some(ProviderRefreshCountsV1::new(8, 2048)),
                 },

--- a/crates/ctx-client-observability/tests/contracts/analytics.rs
+++ b/crates/ctx-client-observability/tests/contracts/analytics.rs
@@ -61,7 +61,7 @@ fn capability_snapshot_is_sent_once_after_successful_delivery() {
 }
 
 #[test]
-fn capability_snapshot_failure_keeps_claim_and_suppresses_replay() {
+fn capability_snapshot_durable_queue_handoff_marks_once_and_replays() {
     let temp = tempdir();
     let delivery_dir = temp.path().join("missing-delivery-dir");
     let events_path = delivery_dir.join("analytics.jsonl");
@@ -86,12 +86,12 @@ fn capability_snapshot_failure_keeps_claim_and_suppresses_replay() {
     let claim_path = expected_capability_claim_path(&home, &state);
     assert!(!events_path.exists());
     assert!(
-        !marker_path.exists(),
-        "failed delivery must not look successfully reported"
+        marker_path.exists(),
+        "durable queue handoff counts as accepted delivery"
     );
     assert!(
-        claim_path.exists(),
-        "uncertain delivery must retain the claim"
+        !claim_path.exists(),
+        "accepted delivery must clear the capability claim"
     );
 
     fs::create_dir_all(&delivery_dir).unwrap();
@@ -108,15 +108,31 @@ fn capability_snapshot_failure_keeps_claim_and_suppresses_replay() {
         .success();
 
     let events = read_analytics_events(&events_path);
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0]["events"].as_array().unwrap().len(), 1);
-    let properties = analytics_event_properties(&events[0]);
+    assert_eq!(
+        events.len(),
+        4,
+        "the queued event and failure observation should replay before the current event and recovery observation"
+    );
+    let replayed_properties = analytics_event_properties(&events[0]);
+    assert_capability_snapshot_is_coarse(replayed_properties);
+    assert_analytics_properties_are_allowlisted(replayed_properties);
+
+    assert_eq!(
+        events[1]["events"][0]["event_name"],
+        "analytics_delivery_observation"
+    );
+
+    let current_properties = analytics_event_properties(&events[2]);
     for key in CAPABILITY_PROPERTY_KEYS {
-        assert!(!properties.contains_key(key));
+        assert!(!current_properties.contains_key(key));
     }
-    assert_analytics_properties_are_allowlisted(properties);
-    assert!(!marker_path.exists());
-    assert!(claim_path.exists());
+    assert_analytics_properties_are_allowlisted(current_properties);
+    assert_eq!(
+        events[3]["events"][0]["event_name"],
+        "analytics_delivery_observation"
+    );
+    assert!(marker_path.exists());
+    assert!(!claim_path.exists());
 }
 
 #[test]

--- a/crates/ctx-daemon-cli/src/daemon_service_ports/provider_refresh.rs
+++ b/crates/ctx-daemon-cli/src/daemon_service_ports/provider_refresh.rs
@@ -11,8 +11,9 @@ use serde_json::Value;
 use ctx_client_observability::analytics::{
     duration_bucket, DurationBucket, ForegroundProviderRefreshV1, Outcome, ProviderCoreResult,
     ProviderRefreshChange, ProviderRefreshCompletedV1, ProviderRefreshCountsV1,
-    ProviderRefreshFailureScope, ProviderRefreshFailureType, ProviderRefreshResult,
-    ProviderRefreshTerminalHealthV1, ProviderRefreshTrigger, PublicEventV1, Surface,
+    ProviderRefreshFailureCode, ProviderRefreshFailureScope, ProviderRefreshFailureType,
+    ProviderRefreshResult, ProviderRefreshTerminalHealthV1, ProviderRefreshTrigger, PublicEventV1,
+    Surface,
 };
 
 pub(super) fn provider_refresh_event(
@@ -79,6 +80,8 @@ pub(super) fn provider_refresh_event(
             },
             failure_scope,
             failure_type,
+            failure_code: ProviderRefreshFailureCode::None,
+            retryable: structured_retryable,
             work_remaining: successor_pending || structured_retryable,
             counts,
         },
@@ -118,6 +121,8 @@ fn failed_provider_refresh_event(
                 core_result: ProviderCoreResult::Failure,
                 failure_scope,
                 failure_type,
+                failure_code: terminal_failure_code(outcome.code),
+                retryable: outcome.retryable,
                 work_remaining: successor_pending || outcome.retryable,
                 counts,
             },
@@ -127,6 +132,42 @@ fn failed_provider_refresh_event(
             Some(retained_previous_generation),
         )),
     ))
+}
+
+fn terminal_failure_code(code: RefreshOutcomeCode) -> ProviderRefreshFailureCode {
+    match code {
+        RefreshOutcomeCode::SourceUnavailable => ProviderRefreshFailureCode::SourceUnavailable,
+        RefreshOutcomeCode::ExplicitSourcePathMissing => {
+            ProviderRefreshFailureCode::ExplicitSourcePathMissing
+        }
+        RefreshOutcomeCode::SourceChanged => ProviderRefreshFailureCode::SourceChanged,
+        RefreshOutcomeCode::MalformedSource => ProviderRefreshFailureCode::MalformedSource,
+        RefreshOutcomeCode::UnsupportedSchema => ProviderRefreshFailureCode::UnsupportedSchema,
+        RefreshOutcomeCode::SourceFailures => ProviderRefreshFailureCode::SourceFailures,
+        RefreshOutcomeCode::LogicalSourceFailures => {
+            ProviderRefreshFailureCode::LogicalSourceFailures
+        }
+        RefreshOutcomeCode::SourceUnclaimed => ProviderRefreshFailureCode::SourceUnclaimed,
+        RefreshOutcomeCode::SourceRefreshFailed => ProviderRefreshFailureCode::SourceRefreshFailed,
+        RefreshOutcomeCode::SourceRefreshInternal => {
+            ProviderRefreshFailureCode::SourceRefreshInternal
+        }
+        RefreshOutcomeCode::ResourceUnavailable => ProviderRefreshFailureCode::ResourceUnavailable,
+        RefreshOutcomeCode::IndexIncompatible => ProviderRefreshFailureCode::IndexIncompatible,
+        RefreshOutcomeCode::IndexCorruption => ProviderRefreshFailureCode::IndexCorruption,
+        RefreshOutcomeCode::SourceRefreshAdmissionFailed => {
+            ProviderRefreshFailureCode::SourceRefreshAdmissionFailed
+        }
+        RefreshOutcomeCode::AllProviderTerminalCoverageUnavailable => {
+            ProviderRefreshFailureCode::AllProviderTerminalCoverageUnavailable
+        }
+        RefreshOutcomeCode::Completed
+        | RefreshOutcomeCode::CompletedWithRejections
+        | RefreshOutcomeCode::CompletedWithSourceFailures
+        | RefreshOutcomeCode::CompletedWithRejectionsAndSourceFailures => {
+            ProviderRefreshFailureCode::None
+        }
+    }
 }
 
 fn refresh_terminal_health(

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -755,16 +755,17 @@ metadata checks do not send provider
 transcript text, search queries, result snippets, source paths, repository
 names, or command output.
 
-ctx first-party telemetry is default-on and uses four content-free, versioned
+ctx first-party telemetry is default-on and uses five content-free, versioned
 families only: `operation_completed@1`, `provider_refresh_completed@1`,
-`runtime_observation@1`, and `install_stage@1`. The root-local `install.json`
-is product state independent of analytics.
+`runtime_observation@1`, `analytics_delivery_observation@1`, and
+`install_stage@1`. The root-local `install.json` is product state independent
+of analytics.
 
 `operation_completed@1` reports one terminal outcome for eligible foreground
 operations. Current CLI coverage includes setup, explicit import, status,
 index, sources, show, search, docs, integrations, upgrade, and doctor. Help,
-version output, and command-line parse errors are not
-observed. MCP and the daemon are first-class reporting surfaces rather than
+version output, and command-line parse errors are not observed. MCP and the
+daemon are first-class reporting surfaces.
 
 `provider_refresh_completed@1` carries only closed provider-refresh summaries
 that a producer already has safely available. Source sizes use coarse buckets
@@ -776,9 +777,15 @@ provider/source-mode aggregate may also include the process-lifetime RSS
 high-water mark observed at completion. That field is explicitly not a
 provider-window peak and is omitted from multi-aggregate batches and
 long-lived daemon surfaces.
+Terminal refresh failures also carry a closed `failure_code` copied from the
+structured Core receipt and a boolean `retryable` value. Neither field contains
+an error message, source coordinate, route, path, or retry instruction.
 `runtime_observation@1` is for low-frequency daemon or MCP lifecycle and
-liveness observations, not per-loop or per-request tracing. These three batch
-families are delivered to
+liveness observations, not per-loop or per-request tracing.
+`analytics_delivery_observation@1` reports only bucketed queue depth, retry
+attempts, drops, oldest queued age, and a closed delivery failure class. It is
+the receipt that distinguishes "the product succeeded" from "the analytics
+report never reached the service." These four batch families are delivered to
 `https://cli.ctx.rs/functions/v1/analytics`; `file://` endpoints remain
 available as local test sinks. `install_stage@1` is produced only by the hosted
 shell and PowerShell installers and is sent as a standalone body to the hosted
@@ -799,7 +806,7 @@ search query text, result rows or snippets, source bodies, source or
 repository paths, target values, repository or branch names, native session
 IDs, command text or output, raw error strings, credentials, authorization
 headers, access tokens, secrets, usernames, hostnames, raw IP addresses, exact
-CPU or GPU names, serial numbers, hardware IDs, exact resource values, live
+CPU or GPU names, serial numbers, hardware IDs, or exact resource values.
 
 The data-root identifier lives in `install.json` and represents that local
 index even when analytics are disabled. The client-profile identifier is a
@@ -807,9 +814,24 @@ random UUID used only for analytics events; it lives outside the ctx data root
 in OS user state, such as `$XDG_STATE_HOME/ctx/device.json` or
 `~/.local/state/ctx/device.json` on Linux. When a capability snapshot is
 eligible, ctx creates a private versioned claim in that state directory and
-promotes it to a version marker after delivery. A failed or uncertain delivery
-does not change command output or exit status and leaves the claim in place to
-avoid replay. For an official hosted installation, eligible product-analytics
+promotes it to a version marker after network acceptance or durable local
+queueing. A failed or uncertain local handoff does not change command output or
+exit status and leaves the claim in place to avoid replay.
+
+If delivery fails, ctx stores the exact already-serialized content-free batch
+in the same OS user-state directory as `analytics-outbox-v1.json`. The file is
+owner-private, is never stored under the ctx data root, and contains no response
+body or raw error. It stores a one-way endpoint fingerprint plus queue time and
+attempt bookkeeping so a payload is not replayed to a different endpoint. ctx
+retries up to 10 queued batches per delivery call and bounds the outbox to 128
+entries, 2 MiB total, 512 KiB per batch, and 30 days. Oldest entries are dropped
+when a bound is reached, and the drop is reported only through the closed
+delivery-health fields. If this owner-private file is malformed or oversized,
+ctx replaces it with an empty valid outbox and reports one `local_io` drop on
+the next successful delivery. Unsafe paths, links, and permissions still fail
+closed instead of being replaced.
+
+For an official hosted installation, eligible product-analytics
 events may also carry the installer attempt identifier for less than seven days
 after the marker's installation timestamp so aggregate reporting can measure
 initial activation. ctx omits that bridge at the seven-day boundary and
@@ -828,7 +850,9 @@ export CTX_ANALYTICS_ENABLED=false
 ```
 
 Either explicit opt-out disables CLI analytics. A config opt-out wins over
-`CTX_ANALYTICS_ENABLED=true` and over an endpoint override.
+`CTX_ANALYTICS_ENABLED=true` and over an endpoint override. The next ctx process
+that opens analytics state removes any existing analytics outbox without
+creating an analytics identity or making a telemetry request.
 
 ### Installer diagnostics
 


### PR DESCRIPTION
## Summary

- report closed provider refresh failure codes and retryability without changing refresh behavior
- queue failed content-free analytics privately and replay original event IDs
- report closed delivery health and purge queued payloads on opt-out
- self-heal malformed private queue state and document the privacy contract
- include one behavior-neutral Clippy cleanup required by current main

Issue #802 retry and user-remediation behavior is unchanged.

## Testing

- scripts/check.sh --mode=ci (216/216)
- scripts/bazel-affected.sh origin/main (91/91)
- isolated source-built 503 to retry to 204 dogfood with byte-exact replay