### PR TITLE
fix(history): isolate deep verification and bound daemon shutdown

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -533,7 +533,7 @@
           "FILE:@@//crates/ctx-history-capture-model/Cargo.toml 273f1943466052bde8841b92e7d546f302ebfb39a821b9c2f800420cb4a1f281",
           "FILE:@@//crates/ctx-history-index-generation/Cargo.toml f7fcfd466d969b8aecb5a44809aaff9ade6d61d4c95c44ae9dea4befa0dbf234",
           "FILE:@@//crates/ctx-semantic-model/Cargo.toml d1a66b94c2ae1cb1c8f6e8f26996f0ee87a08da96d5224ae9f51d13777a18253",
-          "FILE:@@//crates/ctx-history-index-query/Cargo.toml 7205aa0491fd198a34dda75cd099cec781dec87626384fb9bf6b7583a452d95e",
+          "FILE:@@//crates/ctx-history-index-query/Cargo.toml 7908b60ce283ebd8c9b627f7e291c5219f385f9a24261c17d8719a60a1d5e652",
           "FILE:@@//crates/ctx-companion-bridge/Cargo.toml 12e098a4fc96ce3d85d71927a7f9fd0d6bd1d91e90f7d80661b1c31c8d2b028c",
           "FILE:@@//crates/ctx-cli/Cargo.toml 93593eccb3b1907844f23525e3b78cd4a289d1183c1170cf340e22e901d47988",
           "FILE:@@//crates/ctx-cli-presentation/Cargo.toml d06c41fd3f921da6bb9bfa715796f7071f639aea92b67cac7edbfbe0d99424e1",

--- a/crates/ctx-agent-application/tests/contracts/mcp_attribution_privacy.rs
+++ b/crates/ctx-agent-application/tests/contracts/mcp_attribution_privacy.rs
@@ -152,7 +152,7 @@ fn seed_attributed_core(data_root: &Path) -> uuid::Uuid {
         .unwrap();
     writer.commit(|_| true).unwrap();
 
-    let stored = VerifiedIndex::open(&index_root)
+    let stored = VerifiedIndex::open_pinned(&index_root)
         .unwrap()
         .core_record_by_id(event_id.as_uuid())
         .unwrap()
@@ -198,7 +198,7 @@ fn mcp_activity_is_searchable_but_stays_out_of_analytics_usage_and_diagnostics()
     let state = temp.path().join("state");
     let analytics_path = temp.path().join("analytics.jsonl");
     let attributed_event_id = seed_attributed_core(&data_root);
-    let verified = VerifiedIndex::open(data_root.join("search/lexical")).unwrap();
+    let verified = VerifiedIndex::open_pinned(data_root.join("search/lexical")).unwrap();
     let filter = CompiledSearchFilter::compile(Default::default()).unwrap();
     for term in [BODY_ORACLE, SERVER_CANARY, TOOL_CANARY] {
         let queries = [term];
@@ -364,7 +364,7 @@ fn mcp_activity_is_searchable_but_stays_out_of_analytics_usage_and_diagnostics()
         }
     }
 
-    let stored = VerifiedIndex::open(data_root.join("search/lexical"))
+    let stored = VerifiedIndex::open_pinned(data_root.join("search/lexical"))
         .unwrap()
         .core_record_by_id(attributed_event_id)
         .unwrap()

--- a/crates/ctx-agent-application/tests/contracts/support.rs
+++ b/crates/ctx-agent-application/tests/contracts/support.rs
@@ -570,7 +570,7 @@ pub(crate) fn initialize_authoritative_empty_core(data_root: &Path) -> String {
     .into_writer()
     .unwrap();
     let core_receipt = writer.commit(|_| true).unwrap();
-    let verified = VerifiedIndex::open(&index_root).unwrap();
+    let verified = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(verified.generation_id(), core_receipt.generation_id);
     let generation_id = core_receipt.generation_id;
     let route_identity = "ab".repeat(32);

--- a/crates/ctx-cli-contract-tests/tests/contracts/native_providers.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/native_providers.rs
@@ -1083,7 +1083,7 @@ struct ShelleyLifecycleSnapshot {
 
 fn shelley_lifecycle_snapshot(data_root: &Path) -> ShelleyLifecycleSnapshot {
     let records = provider_core_records(data_root, "shelley");
-    let index = VerifiedIndex::open(data_root.join("search/lexical")).unwrap();
+    let index = VerifiedIndex::open_pinned(data_root.join("search/lexical")).unwrap();
     let route_ownership = index
         .manifest()
         .source_routes()

--- a/crates/ctx-cli-contract-tests/tests/contracts/native_providers/additional.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/native_providers/additional.rs
@@ -417,9 +417,10 @@ fn task_json_cli_imports_cline_and_roo_and_searches() {
         (1, 5),
         "Roo route publication must carry the prior Cline source unchanged"
     );
-    let retained =
-        ctx_history_index::VerifiedIndex::open(data_root(&temp).join("search").join("lexical"))
-            .unwrap();
+    let retained = ctx_history_index::VerifiedIndex::open_pinned(
+        data_root(&temp).join("search").join("lexical"),
+    )
+    .unwrap();
     let retained_cline_route = retained
         .manifest()
         .source_routes()

--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration/relocation.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration/relocation.rs
@@ -43,9 +43,10 @@ fn explicit_custom_relocation_preserves_route_source_session_and_event_identity(
         .as_str()
         .expect("automatic import generation");
     assert_ne!(automatic_generation, first_generation);
-    let retained =
-        ctx_history_index::VerifiedIndex::open(data_root(&temp).join("search").join("lexical"))
-            .unwrap();
+    let retained = ctx_history_index::VerifiedIndex::open_pinned(
+        data_root(&temp).join("search").join("lexical"),
+    )
+    .unwrap();
     assert!(retained
         .manifest()
         .source_routes()
@@ -130,9 +131,10 @@ fn failed_explicit_replacement_preserves_retained_relocation_witness() {
     assert_eq!(failed["sources"][0]["carried_forward"], false, "{failed:#}");
     assert_eq!(published_generation(&failed), first_generation);
 
-    let retained =
-        ctx_history_index::VerifiedIndex::open(data_root(&temp).join("search").join("lexical"))
-            .unwrap();
+    let retained = ctx_history_index::VerifiedIndex::open_pinned(
+        data_root(&temp).join("search").join("lexical"),
+    )
+    .unwrap();
     assert!(retained
         .manifest()
         .source_routes()
@@ -194,9 +196,10 @@ fn replaced_explicit_custom_route_cannot_reuse_a_stale_relocation_witness() {
     assert_eq!(replacement["outcome"], "success", "{replacement:#}");
     let replacement_generation = published_generation(&replacement);
     let replacement_route = replacement["sources"][0]["route_identity"].clone();
-    let replaced =
-        ctx_history_index::VerifiedIndex::open(data_root(&temp).join("search").join("lexical"))
-            .unwrap();
+    let replaced = ctx_history_index::VerifiedIndex::open_pinned(
+        data_root(&temp).join("search").join("lexical"),
+    )
+    .unwrap();
     assert!(!replaced
         .manifest()
         .source_routes()

--- a/crates/ctx-cli-contract-tests/tests/contracts/support/fixtures.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/support/fixtures.rs
@@ -83,7 +83,7 @@ pub(crate) fn initialize_generation_only_core(data_root: &Path) -> String {
     .into_writer()
     .unwrap();
     let core_receipt = writer.commit(|_| true).unwrap();
-    let verified = VerifiedIndex::open(index_root).unwrap();
+    let verified = VerifiedIndex::open_pinned(index_root).unwrap();
     assert_eq!(verified.generation_id(), core_receipt.generation_id);
     core_receipt.generation_id
 }
@@ -189,7 +189,7 @@ pub(crate) fn write_codex_message_fixture(root: &Path, session_id: &str, message
 }
 
 pub(crate) fn provider_core_records(data_root: &Path, provider: &str) -> Vec<CoreRecord> {
-    let index = VerifiedIndex::open(data_root.join("search/lexical")).unwrap();
+    let index = VerifiedIndex::open_pinned(data_root.join("search/lexical")).unwrap();
     let sources = index
         .manifest()
         .sources

--- a/crates/ctx-daemon-cli/src/source_status_tests.rs
+++ b/crates/ctx-daemon-cli/src/source_status_tests.rs
@@ -291,7 +291,7 @@ fn semantic_status_reports_ready_only_with_exact_projected_and_filtered_counts()
         )
         .unwrap();
     writer.commit(|_| true).unwrap();
-    let index = VerifiedIndex::open(data_root.join("search/lexical")).unwrap();
+    let index = VerifiedIndex::open_pinned(data_root.join("search/lexical")).unwrap();
     let mut store = SemanticVectorStore::open(
         &source_backed_semantic_vector_path(&data_root),
         semantic_model_contract(),
@@ -689,7 +689,7 @@ fn authoritative_empty_stays_query_ready_when_the_latest_refresh_failed() {
 fn legacy_zero_source_publication_is_not_projected_as_ready() {
     let (_temp, data_root, generation_id) = core_publication_fixture();
     let index_root = data_root.join("search/lexical");
-    let current = VerifiedIndex::open(&index_root).unwrap();
+    let current = VerifiedIndex::open_pinned(&index_root).unwrap();
     let mut metadata: Value =
         serde_json::from_slice(current.publication_metadata().unwrap()).unwrap();
     metadata["version"] = json!(1);
@@ -896,7 +896,7 @@ fn catalog_status_reports_automatic_roots_and_request_scoped_explicit_overlays()
     .commit(|_| true)
     .unwrap()
     .generation_id;
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let ready = catalog_report(Some(&generation_id), Some(&index));
     assert_eq!(ready["status"], "ready");
     assert_eq!(ready["authority"], "automatic_provider_registry");

--- a/crates/ctx-daemon-cli/tests/contracts/native/process_control.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/native/process_control.rs
@@ -57,14 +57,30 @@ pub(super) fn process_is_running(pid: u32) -> bool {
 }
 
 #[cfg(unix)]
-pub(super) fn request_graceful_shutdown(pid: u32) -> std::io::Result<()> {
+#[derive(Clone, Copy, Debug)]
+pub(super) enum ShutdownSignal {
+    Interrupt,
+    Terminate,
+}
+
+#[cfg(unix)]
+pub(super) fn request_shutdown(pid: u32, signal: ShutdownSignal) -> std::io::Result<()> {
     let pid = libc::pid_t::try_from(pid)
         .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "pid exceeds pid_t"))?;
-    if unsafe { libc::kill(pid, libc::SIGTERM) } == 0 {
+    let signal = match signal {
+        ShutdownSignal::Interrupt => libc::SIGINT,
+        ShutdownSignal::Terminate => libc::SIGTERM,
+    };
+    if unsafe { libc::kill(pid, signal) } == 0 {
         Ok(())
     } else {
         Err(std::io::Error::last_os_error())
     }
+}
+
+#[cfg(unix)]
+pub(super) fn request_graceful_shutdown(pid: u32) -> std::io::Result<()> {
+    request_shutdown(pid, ShutdownSignal::Terminate)
 }
 
 #[cfg(unix)]

--- a/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle/lifecycle_regressions.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle/lifecycle_regressions.rs
@@ -39,8 +39,7 @@ fn long_lived_mcp_search_recovers_daemon_after_startup() {
         }
     }));
     assert!(
-        searched.get("error").is_none()
-            && searched["result"]["isError"].as_bool() != Some(true),
+        searched.get("error").is_none() && searched["result"]["isError"].as_bool() != Some(true),
         "{searched:#}"
     );
     let recovered = wait_for_daemon(&harness, Some(daemon_pid));
@@ -98,4 +97,134 @@ fn live_readiness_rejoins_while_the_main_scheduler_is_blocked() {
 
     fs::remove_file(block).unwrap();
     harness.json(&["daemon", "disable", "--format=json"]);
+}
+
+#[cfg(unix)]
+#[test]
+fn active_daemon_work_exits_within_the_process_signal_deadline() {
+    let _serial = TEST_SERIAL
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    for signal in [ShutdownSignal::Terminate, ShutdownSignal::Interrupt] {
+        let harness = Harness::new();
+        let source = write_codex_session(
+            harness.home(),
+            &format!("active daemon {signal:?} retained generation oracle"),
+        );
+        let generation = harness.setup_wait();
+        let initial_daemon = wait_for_daemon(&harness, None);
+        let initial_pid = live_pid(&initial_daemon);
+        wait_for_core_generation(&harness, &generation);
+        request_graceful_shutdown(initial_pid).unwrap_or_else(|error| {
+            panic!("stop initial daemon {initial_pid} before {signal:?} case: {error}")
+        });
+        wait_for_process_state(initial_pid, false, Duration::from_secs(2))
+            .unwrap_or_else(|error| panic!("initial daemon {initial_pid} did not stop: {error}"));
+
+        let child = harness.spawn(&["daemon", "run", "--force"], None);
+        let pid = child.id();
+        let foreground_daemon = wait_for_daemon(&harness, Some(initial_pid));
+        assert_eq!(live_pid(&foreground_daemon), pid, "{foreground_daemon:#}");
+
+        let pointer_path = harness.root().join("search/lexical/active-generation.json");
+        let meta_path = active_generation_meta_path(harness.root(), &generation);
+        let manifest_path = generation_manifest_path(harness.root(), &generation);
+        let retained_pointer = snapshot_file(&pointer_path);
+        let retained_meta = snapshot_file(&meta_path);
+        let retained_manifest = snapshot_file(&manifest_path);
+
+        let block = harness
+            .root()
+            .join(".block-daemon-main-after-ready-for-test");
+        let blocked = harness
+            .root()
+            .join(".daemon-main-blocked-after-ready-for-test");
+        fs::write(&block, b"block\n").unwrap();
+        let unpublished_query = format!("active daemon {signal:?} unpublished work oracle");
+        append_codex_message(
+            &source,
+            "2026-07-29T12:01:00.000Z",
+            "assistant",
+            &unpublished_query,
+        );
+        let mut refresh_wait = harness.spawn(
+            &[
+                "search",
+                &unpublished_query,
+                "--provider",
+                "codex",
+                "--refresh",
+                "wait",
+                "--format=json",
+            ],
+            None,
+        );
+        let marker_result = wait_for_marker(&blocked, "daemon active refresh cycle");
+        let _ = refresh_wait.kill();
+        let _ = refresh_wait.wait_with_output();
+        marker_result.unwrap_or_else(|error| panic!("{error}"));
+
+        let signaled_at = Instant::now();
+        request_shutdown(pid, signal)
+            .unwrap_or_else(|error| panic!("send {signal:?} to daemon {pid}: {error}"));
+        let shutdown_bound = Duration::from_secs(2);
+        let output = wait_for_output(child, shutdown_bound, &["daemon", "run", "--signal"]);
+        assert!(
+            signaled_at.elapsed() <= shutdown_bound,
+            "daemon exceeded the {shutdown_bound:?} {signal:?} shutdown bound"
+        );
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "deadline-forced {signal:?} shutdown should report failure:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        assert_eq!(snapshot_file(&pointer_path), retained_pointer);
+        assert_eq!(snapshot_file(&meta_path), retained_meta);
+        assert_eq!(snapshot_file(&manifest_path), retained_manifest);
+        let _ = active_generation_meta_path(harness.root(), &generation);
+
+        let stale = read_lock(harness.root()).expect("deadline-forced daemon lock metadata");
+        assert_eq!(json_u32(&stale, "pid"), Some(pid), "{stale:#}");
+        assert_eq!(stale["released"], false, "{stale:#}");
+        #[cfg(target_os = "linux")]
+        assert!(
+            linux_daemon_processes(&harness).is_empty(),
+            "signal test unexpectedly restarted or leaked a daemon"
+        );
+
+        fs::remove_file(&block).expect("release active-work test gate after daemon exit");
+        fs::remove_file(&blocked).expect("remove stale active-work test marker");
+        harness.best_effort_disable();
+        assert!(
+            read_lock(harness.root())
+                .as_ref()
+                .and_then(|lock| json_u32(lock, "pid"))
+                .is_none_or(|owner| !process_is_running(owner)),
+            "signal test cleanup left a live daemon lock owner"
+        );
+        #[cfg(target_os = "linux")]
+        assert!(
+            linux_daemon_processes(&harness).is_empty(),
+            "signal test cleanup left a daemon process"
+        );
+    }
+}
+
+#[cfg(unix)]
+fn wait_for_marker(path: &Path, description: &str) -> Result<(), String> {
+    let deadline = Instant::now() + OBSERVATION_TIMEOUT;
+    while !path.exists() {
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "timed out waiting for {description} marker {}",
+                path.display()
+            ));
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    Ok(())
 }

--- a/crates/ctx-daemon-service/src/daemon.rs
+++ b/crates/ctx-daemon-service/src/daemon.rs
@@ -27,6 +27,7 @@ use crate::{
 use super::source_backed_refresh_coordinator::CoreRefreshEngine;
 
 use super::{
+    daemon_process_signal::install_daemon_process_signal_handler,
     daemon_retry::DaemonRetryBackoff,
     daemon_scheduler::{
         daemon_retry_due, daemon_run_start_mode, daemon_scheduled_refresh_due,
@@ -231,20 +232,6 @@ where
     UO: ctx_upgrade_engine::UpgradeObserver<AppConfig>,
 {
     run_daemon_inner(args, data_root, config, ports, upgrade)
-}
-
-fn install_daemon_process_signal_handler(
-    wakeup: Arc<DaemonWakeup>,
-    lifecycle_state: Arc<DaemonLifecycleState>,
-) -> Result<()> {
-    // A daemon launched as a shell background job can inherit SIGINT as
-    // ignored across exec. This process owns its signal lifecycle, so replace
-    // inherited dispositions instead of rejecting an otherwise valid launch.
-    ctrlc::set_handler(move || {
-        lifecycle_state.mark_stopping();
-        wakeup.signal_shutdown();
-    })
-    .context("install ctx daemon process signal handler")
 }
 
 fn publish_daemon_fatal_status_while_owned(
@@ -649,6 +636,9 @@ where
             let source_refresh = refresh_service
                 .as_ref()
                 .and(daemon_scheduler_source_refresh(&source_refresh_coordinator));
+            if source_refresh.is_some_and(CoreRefreshEngine::has_pending_request) {
+                ctx_daemon_runtime::block_daemon_main_after_ready_for_test(data_root)?;
+            }
             if finite_core_worker_exit.as_mut().is_some_and(|exit| {
                 exit.begin_stopping(
                     source_refresh,

--- a/crates/ctx-daemon-service/src/daemon_process_signal.rs
+++ b/crates/ctx-daemon-service/src/daemon_process_signal.rs
@@ -1,0 +1,43 @@
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc,
+    },
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+
+use crate::{daemon_wakeup::DaemonWakeup, query_service::DaemonLifecycleState};
+
+const SHUTDOWN_DEADLINE: Duration = Duration::from_secs(1);
+const FORCED_EXIT_CODE: i32 = 1;
+
+pub(super) fn install_daemon_process_signal_handler(
+    wakeup: Arc<DaemonWakeup>,
+    lifecycle_state: Arc<DaemonLifecycleState>,
+) -> Result<()> {
+    let signal_received = AtomicBool::new(false);
+    let (deadline_sender, deadline_receiver) = mpsc::sync_channel(1);
+    // Background daemons can inherit ignored SIGINT. This process owns its
+    // signal lifecycle, so install handlers for both SIGINT and SIGTERM.
+    ctrlc::set_handler(move || {
+        if signal_received.swap(true, Ordering::SeqCst) {
+            std::process::exit(FORCED_EXIT_CODE);
+        }
+        let _ = deadline_sender.try_send(());
+        lifecycle_state.mark_stopping();
+        wakeup.signal_shutdown();
+    })
+    .context("install ctx daemon process signal handler")?;
+    std::thread::Builder::new()
+        .name("ctx-daemon-signal-deadline".to_owned())
+        .spawn(move || {
+            if deadline_receiver.recv().is_ok() {
+                std::thread::sleep(SHUTDOWN_DEADLINE);
+                std::process::exit(FORCED_EXIT_CODE);
+            }
+        })
+        .context("start ctx daemon process signal deadline")?;
+    Ok(())
+}

--- a/crates/ctx-daemon-service/src/daemon_worker_tests.rs
+++ b/crates/ctx-daemon-service/src/daemon_worker_tests.rs
@@ -381,7 +381,7 @@ impl CoreFixture {
             )
             .unwrap();
         writer.commit(|_| true).unwrap();
-        VerifiedIndex::open(self.temp.path().join("index")).unwrap()
+        VerifiedIndex::open_pinned(self.temp.path().join("index")).unwrap()
     }
 }
 

--- a/crates/ctx-daemon-service/src/lib.rs
+++ b/crates/ctx-daemon-service/src/lib.rs
@@ -23,6 +23,7 @@ use ctx_semantic_model::SharedSemanticRuntime;
 use serde_json::{json, Value};
 
 mod daemon;
+mod daemon_process_signal;
 mod daemon_retry;
 mod daemon_scheduler;
 mod daemon_wakeup;

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client/progress_poll_tests.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client/progress_poll_tests.rs
@@ -46,7 +46,7 @@ fn verified_source_count_routes(route_bytes: &[u8]) -> (tempfile::TempDir, Verif
     }
     writer.set_present_source_routes(routes).unwrap();
     writer.commit(|_| true).unwrap();
-    let verified = VerifiedIndex::open(temp.path()).unwrap();
+    let verified = VerifiedIndex::open_pinned(temp.path()).unwrap();
     (temp, verified)
 }
 

--- a/crates/ctx-deepseek-harness-qualification/tests/deepseek_harness.rs
+++ b/crates/ctx-deepseek-harness-qualification/tests/deepseek_harness.rs
@@ -841,7 +841,7 @@ fn private_reasoning_and_image_only_messages_are_retained_but_not_searchable() {
     assert_not_searchable(&harness, reasoning_marker);
 
     let lexical = harness.data_root.join("search/lexical");
-    let index = VerifiedIndex::open(&lexical).expect("open verified lexical generation");
+    let index = VerifiedIndex::open_pinned(&lexical).expect("open verified lexical generation");
     let parent_search = harness.search(PARENT_ORACLE);
     let parent_result = one_matching_result(&parent_search, PARENT_ORACLE);
     let parent_session_id = Uuid::parse_str(
@@ -1135,7 +1135,7 @@ fn complete_tail_body_is_searchable_and_tantivy_stores_only_core_record() {
     one_matching_result(&harness.search(tail), tail);
 
     let lexical = harness.data_root.join("search/lexical");
-    let index = VerifiedIndex::open(&lexical).expect("open verified lexical generation");
+    let index = VerifiedIndex::open_pinned(&lexical).expect("open verified lexical generation");
     let hits = complete_lexical_candidates(&index, tail, 10);
     assert_eq!(hits.len(), 1);
     let expected_event_id = hits[0].event.event_id;

--- a/crates/ctx-history-capture-composition-qualification/tests/claude_failure_boundaries.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/claude_failure_boundaries.rs
@@ -91,8 +91,12 @@ fn refresh(
 }
 
 fn marker_count(index: &Path, marker: &str) -> usize {
-    lexical_test_support::search_event_candidates(&VerifiedIndex::open(index).unwrap(), marker, 16)
-        .len()
+    lexical_test_support::search_event_candidates(
+        &VerifiedIndex::open_pinned(index).unwrap(),
+        marker,
+        16,
+    )
+    .len()
 }
 
 fn set_mode(path: &Path, mode: u32) {

--- a/crates/ctx-history-capture-composition-qualification/tests/fx_publication.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/fx_publication.rs
@@ -109,7 +109,7 @@ fn assert_partial_receipt(receipt: &SourceBackedRefreshReceipt, expected_sources
 }
 
 fn records(index: &Path) -> Vec<CoreRecord> {
-    let verified = VerifiedIndex::open(index).unwrap();
+    let verified = VerifiedIndex::open_pinned(index).unwrap();
     let mut records = verified
         .manifest()
         .sources
@@ -140,7 +140,7 @@ fn records_for(index: &Path, native_session_id: &str) -> Vec<CoreRecord> {
 }
 
 fn source_for(index: &Path, native_session_id: &str) -> SourceKey {
-    VerifiedIndex::open(index)
+    VerifiedIndex::open_pinned(index)
         .unwrap()
         .manifest()
         .sources
@@ -169,7 +169,7 @@ fn source_native_session_id(source: &SourceKey) -> Option<&str> {
 }
 
 fn assert_search_hit(index: &Path, query: &str, native_session_id: &str) {
-    let verified = VerifiedIndex::open(index).unwrap();
+    let verified = VerifiedIndex::open_pinned(index).unwrap();
     assert!(
         search_event_candidates(&verified, query, 16)
             .iter()
@@ -361,7 +361,10 @@ fn authentic_v006_sessions_publish_searchable_content_and_noop_with_stable_ident
 
     let cold = refresh(&index, &registry);
     assert_clean_receipt(&cold, 2);
-    assert_eq!(VerifiedIndex::open(&index).unwrap().document_count(), 4);
+    assert_eq!(
+        VerifiedIndex::open_pinned(&index).unwrap().document_count(),
+        4
+    );
     let cold_records = records(&index);
     assert_eq!(cold_records.len(), 4);
     let tool_free = records_for(&index, TOOL_FREE_ID);
@@ -593,7 +596,7 @@ fn uncommitted_tail_is_excluded_then_committed_append_preserves_old_ids() {
     assert_clean_receipt(&dirty, 1);
     assert_eq!(records_for(&index, TOOL_FREE_ID), cold_records);
     assert!(search_event_candidates(
-        &VerifiedIndex::open(&index).unwrap(),
+        &VerifiedIndex::open_pinned(&index).unwrap(),
         "zzfxuncommittedassistanttoken7q9",
         16
     )

--- a/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/claude_cursor.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/claude_cursor.rs
@@ -102,7 +102,7 @@ fn indexed_records(
     provider: CaptureProvider,
     native_session_id: &str,
 ) -> Vec<CoreRecord> {
-    let verified = VerifiedIndex::open(index).unwrap();
+    let verified = VerifiedIndex::open_pinned(index).unwrap();
     let mut records = verified
         .manifest()
         .sources
@@ -138,7 +138,7 @@ fn lexical_match_count(index: &VerifiedIndex, text: &str) -> usize {
 }
 
 fn certified_prefix_bytes(index: &Path, provider: CaptureProvider) -> u64 {
-    let verified = VerifiedIndex::open(index).unwrap();
+    let verified = VerifiedIndex::open_pinned(index).unwrap();
     verified
         .manifest()
         .sources
@@ -348,7 +348,7 @@ fn cursor_malformed_nested_role_rejects_only_that_record() {
         &indexed_records(&index, CaptureProvider::Cursor, native_session_id),
         &["cursorisolationbeforemarker", "cursorisolationaftermarker"],
     );
-    let published = VerifiedIndex::open(&index).unwrap();
+    let published = VerifiedIndex::open_pinned(&index).unwrap();
     for marker in ["cursorisolationbeforemarker", "cursorisolationaftermarker"] {
         assert_eq!(
             lexical_match_count(&published, marker),
@@ -381,7 +381,7 @@ fn cursor_top_level_role_revision_reparses_unchanged_prior_rejection_state() {
     let registry = registry(CaptureProvider::Cursor, CURSOR_SOURCE_FORMAT, &root);
     refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
 
-    let current = VerifiedIndex::open(&index).unwrap();
+    let current = VerifiedIndex::open_pinned(&index).unwrap();
     let current_certificate = current
         .manifest()
         .sources
@@ -421,7 +421,7 @@ fn cursor_top_level_role_revision_reparses_unchanged_prior_rejection_state() {
     writer.set_present_source_routes(source_routes).unwrap();
     let prior_generation = writer.commit(|_| true).unwrap().generation_id;
 
-    let prior = VerifiedIndex::open(&index).unwrap();
+    let prior = VerifiedIndex::open_pinned(&index).unwrap();
     let prior_source = prior
         .manifest()
         .sources
@@ -468,7 +468,7 @@ fn cursor_top_level_role_revision_reparses_unchanged_prior_rejection_state() {
         &[marker],
     );
     assert_eq!(
-        lexical_match_count(&VerifiedIndex::open(&index).unwrap(), marker),
+        lexical_match_count(&VerifiedIndex::open_pinned(&index).unwrap(), marker),
         1
     );
 }
@@ -622,7 +622,7 @@ fn automatic_claude_root_replacement_retires_sources_absent_from_strict_subset()
     assert_eq!(receipt.complete_inventory_route_ids.len(), 1);
     assert_eq!(receipt.removals.len(), 1);
 
-    let verified = VerifiedIndex::open(&index).unwrap();
+    let verified = VerifiedIndex::open_pinned(&index).unwrap();
     assert_eq!(
         verified
             .manifest()
@@ -734,7 +734,7 @@ fn claude_roots_with_the_same_relative_session_path_publish_independent_sources(
     );
     assert_eq!(result.successful_route_ids.len(), 2);
 
-    let verified = VerifiedIndex::open(&index).unwrap();
+    let verified = VerifiedIndex::open_pinned(&index).unwrap();
     let claude_sources = verified
         .manifest()
         .sources
@@ -864,7 +864,7 @@ fn unavailable_configured_claude_home_carries_only_itself_while_peer_refreshes()
     );
     let work_records = indexed_records(&index, CaptureProvider::Claude, "work-session");
     assert_literal_bodies(&work_records, &["work retained marker"]);
-    let published = VerifiedIndex::open(&index).unwrap();
+    let published = VerifiedIndex::open_pinned(&index).unwrap();
     assert_eq!(published.manifest().provider_roots().len(), 2);
     assert!(published
         .manifest()
@@ -951,7 +951,7 @@ fn cold_unavailable_configured_claude_home_does_not_block_healthy_peer() {
         &indexed_records(&index, CaptureProvider::Claude, "personal-session"),
         &["personal cold marker"],
     );
-    let published = VerifiedIndex::open(&index).unwrap();
+    let published = VerifiedIndex::open_pinned(&index).unwrap();
     let personal_root = published
         .manifest()
         .provider_roots()
@@ -1055,7 +1055,7 @@ fn claude_incompatible_duplicate_kind_quarantines_only_its_source_and_repairs() 
 
     let initial = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
     assert!(initial.failed_routes.is_empty());
-    let initial_generation = VerifiedIndex::open(&index)
+    let initial_generation = VerifiedIndex::open_pinned(&index)
         .unwrap()
         .generation_id()
         .to_owned();
@@ -1094,7 +1094,7 @@ fn claude_incompatible_duplicate_kind_quarantines_only_its_source_and_repairs() 
         .detail
         .contains("repeats a stable event identity with incompatible event kinds"));
     assert_ne!(
-        VerifiedIndex::open(&index).unwrap().generation_id(),
+        VerifiedIndex::open_pinned(&index).unwrap().generation_id(),
         initial_generation
     );
     assert_eq!(

--- a/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/copilot.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/copilot.rs
@@ -236,7 +236,7 @@ fn copilot_route_discards_physical_line_above_shared_ceiling_and_publishes_neigh
         }
     );
 
-    let records = core_records(&VerifiedIndex::open(&index_path).unwrap());
+    let records = core_records(&VerifiedIndex::open_pinned(&index_path).unwrap());
     assert_eq!(records.len(), 5);
     for expected in [
         "before-start",
@@ -317,7 +317,7 @@ fn copilot_route_enforces_independent_exact_identity_component_boundaries() {
     assert!(receipt.record_rejections.is_empty());
     assert_eq!(receipt.sources.len(), 4);
 
-    let records = core_records(&VerifiedIndex::open(&index_path).unwrap());
+    let records = core_records(&VerifiedIndex::open_pinned(&index_path).unwrap());
     assert_eq!(records.len(), 12);
     assert_eq!(
         invocation_identity(record_by_native_id(&records, "server-exact-start")),
@@ -370,7 +370,7 @@ fn copilot_activity_append_replay_preserves_stable_event_ids() {
     let registry = copilot_registry(&root, temp.path());
 
     refresh_source_backed_generation(&index_path, &registry, WriterOptions::default()).unwrap();
-    let initial = core_records(&VerifiedIndex::open(&index_path).unwrap());
+    let initial = core_records(&VerifiedIndex::open_pinned(&index_path).unwrap());
     let initial_start = record_by_native_id(&initial, "first-start");
     let initial_complete = record_by_native_id(&initial, "first-complete");
     let initial_start_id = initial_start.event_id;
@@ -404,7 +404,7 @@ fn copilot_activity_append_replay_preserves_stable_event_ids() {
     assert!(appended.failed_routes.is_empty());
     assert!(appended.logical_source_failures.is_empty());
     let appended_generation = appended.commit.generation_id.clone();
-    let appended_records = core_records(&VerifiedIndex::open(&index_path).unwrap());
+    let appended_records = core_records(&VerifiedIndex::open_pinned(&index_path).unwrap());
     let first_start = record_by_native_id(&appended_records, "first-start");
     let first_complete = record_by_native_id(&appended_records, "first-complete");
     assert_eq!(first_start.event_id, initial_start_id);
@@ -431,7 +431,7 @@ fn copilot_activity_append_replay_preserves_stable_event_ids() {
     assert_eq!(replay.commit.generation_id, appended_generation);
 
     refresh_source_backed_generation(&cold_path, &registry, WriterOptions::default()).unwrap();
-    let cold_records = core_records(&VerifiedIndex::open(&cold_path).unwrap());
+    let cold_records = core_records(&VerifiedIndex::open_pinned(&cold_path).unwrap());
     assert_eq!(
         cold_records
             .iter()

--- a/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/gemini_retrieval_exclusion.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/gemini_retrieval_exclusion.rs
@@ -132,7 +132,7 @@ fn gemini_provider_source(root: &Path) -> ProviderSource {
 }
 
 fn indexed_records(index: &Path) -> Vec<CoreRecord> {
-    let verified = VerifiedIndex::open(index).unwrap();
+    let verified = VerifiedIndex::open_pinned(index).unwrap();
     let source = verified
         .manifest()
         .sources
@@ -154,7 +154,7 @@ fn indexed_records(index: &Path) -> Vec<CoreRecord> {
 }
 
 fn gemini_sources(index: &Path) -> Vec<SourceKey> {
-    VerifiedIndex::open(index)
+    VerifiedIndex::open_pinned(index)
         .unwrap()
         .manifest()
         .sources
@@ -167,7 +167,7 @@ fn gemini_sources(index: &Path) -> Vec<SourceKey> {
 }
 
 fn all_gemini_records(index: &Path) -> Vec<CoreRecord> {
-    let verified = VerifiedIndex::open(index).unwrap();
+    let verified = VerifiedIndex::open_pinned(index).unwrap();
     let sources = verified
         .manifest()
         .sources
@@ -192,7 +192,7 @@ fn all_gemini_records(index: &Path) -> Vec<CoreRecord> {
 }
 
 fn certified_prefix_bytes(index: &Path) -> u64 {
-    let verified = VerifiedIndex::open(index).unwrap();
+    let verified = VerifiedIndex::open_pinned(index).unwrap();
     verified
         .manifest()
         .sources

--- a/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/jsonl_shared_publication.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/jsonl_shared_publication.rs
@@ -32,7 +32,7 @@ fn writer_options() -> WriterOptions {
 }
 
 fn all_indexed_records(index: &Path) -> Vec<CoreRecord> {
-    let verified = VerifiedIndex::open(index).unwrap();
+    let verified = VerifiedIndex::open_pinned(index).unwrap();
     let mut records = verified
         .manifest()
         .sources
@@ -348,7 +348,9 @@ fn custom_history_registered_route_preserves_lifecycle_and_core_publication() {
     assert!(deleted.sources.is_empty());
     assert_eq!(deleted.removals.len(), 1);
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().document_count(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .document_count(),
         0
     );
 }
@@ -378,7 +380,9 @@ fn custom_history_registered_route_replaces_when_forward_reference_closes() {
     assert_eq!(cold.commit.indexed_documents, 0);
     assert_eq!(cold.sources.len(), 1);
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().document_count(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .document_count(),
         0
     );
 
@@ -468,7 +472,7 @@ fn custom_history_structural_manifest_failures_retain_generation_and_restore() {
         &initial_generation,
         SourceBackedSourceFailureClass::Unreadable,
     );
-    let retained = VerifiedIndex::open(&index_root).unwrap();
+    let retained = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(retained.generation_id(), initial_generation);
     assert_eq!(retained.document_count(), 1);
     assert_eq!(retained.manifest().sources, initial.sources);
@@ -479,7 +483,7 @@ fn custom_history_structural_manifest_failures_retain_generation_and_restore() {
     assert_eq!(restored.commit.indexed_documents, 1);
     assert_eq!(restored.sources.len(), 1);
     assert_ne!(restored.commit.generation_id, initial_generation);
-    let recovered = VerifiedIndex::open(&index_root).unwrap();
+    let recovered = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(recovered.generation_id(), restored.commit.generation_id);
     assert_eq!(recovered.document_count(), 1);
 }
@@ -793,7 +797,7 @@ fn openclaw_unsupported_sqlite_root_failure_is_carried_and_restored() {
         &initial_generation,
         SourceBackedSourceFailureClass::Unreadable,
     );
-    let retained = VerifiedIndex::open(&index).unwrap();
+    let retained = VerifiedIndex::open_pinned(&index).unwrap();
     assert_eq!(retained.generation_id(), initial_generation);
     assert_eq!(retained.document_count(), 1);
     assert_eq!(retained.manifest().sources, initial.sources);
@@ -812,7 +816,10 @@ fn openclaw_unsupported_sqlite_root_failure_is_carried_and_restored() {
     assert_eq!(restored.commit.indexed_documents, 1);
     assert_eq!(restored.sources.len(), 1);
     assert_ne!(restored.commit.generation_id, initial_generation);
-    assert_eq!(VerifiedIndex::open(&index).unwrap().document_count(), 1);
+    assert_eq!(
+        VerifiedIndex::open_pinned(&index).unwrap().document_count(),
+        1
+    );
 }
 
 #[test]

--- a/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/mux_publication.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/mux_publication.rs
@@ -76,7 +76,7 @@ fn append_jsonl(path: &Path, record: &Value) {
 }
 
 fn mux_records(index: &Path) -> Vec<CoreRecord> {
-    let verified = VerifiedIndex::open(index).unwrap();
+    let verified = VerifiedIndex::open_pinned(index).unwrap();
     let mut records = verified
         .manifest()
         .sources
@@ -223,7 +223,10 @@ fn mux_compound_route_cold_noop_companion_replacement_and_deletion() {
     assert!(deleted.failed_routes.is_empty());
     assert!(deleted.sources.is_empty());
     assert_eq!(deleted.removals.len(), 1);
-    assert_eq!(VerifiedIndex::open(&index).unwrap().document_count(), 0);
+    assert_eq!(
+        VerifiedIndex::open_pinned(&index).unwrap().document_count(),
+        0
+    );
 }
 
 #[test]

--- a/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/openclaw_sqlite.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/jsonl_publication/openclaw_sqlite.rs
@@ -160,7 +160,7 @@ fn registered_registry(data_root: &Path, database: &Path) -> SourceBackedProvide
 }
 
 fn records(index_root: &Path) -> Vec<CoreRecord> {
-    let index = VerifiedIndex::open(index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(index_root).unwrap();
     let mut records = index
         .manifest()
         .sources
@@ -286,7 +286,9 @@ fn registered_adapter_terminal_revalidation_rejects_concurrent_change_and_retry_
         SourceBackedSourceFailureClass::SourceChanged
     );
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().generation_id(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .generation_id(),
         cold.commit.generation_id
     );
     assert_eq!(

--- a/crates/ctx-history-capture-composition-qualification/tests/mistral_vibe_publication.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/mistral_vibe_publication.rs
@@ -163,7 +163,7 @@ fn publish(root: &Path, index: &Path) -> Vec<CoreRecord> {
 
 fn published_session(index: &Path, provider_session_id: &str) -> Vec<CoreRecord> {
     let source = source_key(provider_session_id);
-    let mut records = VerifiedIndex::open(index)
+    let mut records = VerifiedIndex::open_pinned(index)
         .unwrap()
         .core_source_event_page(&source, None, 64)
         .unwrap()
@@ -198,7 +198,7 @@ fn unchanged_v15_lineage_certificate_is_replaced_by_v17_direct_only_projection()
         .unwrap();
 
     let source = source_key(SESSION_ID);
-    let current = VerifiedIndex::open(&index).unwrap();
+    let current = VerifiedIndex::open_pinned(&index).unwrap();
     let current_certificate = current
         .manifest()
         .sources
@@ -266,7 +266,7 @@ fn unchanged_v15_lineage_certificate_is_replaced_by_v17_direct_only_projection()
         replaced[0].content.meaningful_text(),
         "unchanged direct parent migration fixture"
     );
-    let replaced_index = VerifiedIndex::open(&index).unwrap();
+    let replaced_index = VerifiedIndex::open_pinned(&index).unwrap();
     assert_eq!(
         replaced_index
             .manifest()

--- a/crates/ctx-history-capture-composition-qualification/tests/openclaw_configured_root_lifecycle.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/openclaw_configured_root_lifecycle.rs
@@ -116,7 +116,7 @@ fn truncated_openclaw_compound_root_retains_exact_agent_membership() {
     )
     .unwrap();
     assert!(initial_receipt.failed_routes.is_empty());
-    let initial_index = VerifiedIndex::open(&index_root).unwrap();
+    let initial_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_marker(&initial_index, ALPHA_MARKER);
     assert_marker(&initial_index, BETA_MARKER);
     let retained_roots = initial_index.manifest().provider_roots().to_vec();
@@ -150,7 +150,7 @@ fn truncated_openclaw_compound_root_retains_exact_agent_membership() {
     )
     .unwrap();
     assert!(cold_receipt.sources.is_empty());
-    let cold_index = VerifiedIndex::open(&cold_index_root).unwrap();
+    let cold_index = VerifiedIndex::open_pinned(&cold_index_root).unwrap();
     assert!(cold_index.manifest().sources.is_empty());
     assert!(cold_index.manifest().provider_roots()[0]
         .routes()
@@ -174,7 +174,7 @@ fn truncated_openclaw_compound_root_retains_exact_agent_membership() {
     )
     .unwrap();
     assert!(retained_receipt.failed_routes.is_empty());
-    let retained_index = VerifiedIndex::open(&index_root).unwrap();
+    let retained_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         retained_index.manifest().provider_roots()[0].routes().len(),
         2
@@ -240,7 +240,7 @@ fn missing_openclaw_compound_root_retains_exact_agent_membership_until_restored(
     )
     .unwrap();
     assert!(initial_receipt.failed_routes.is_empty());
-    let initial_index = VerifiedIndex::open(&index_root).unwrap();
+    let initial_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_marker(&initial_index, ALPHA_MARKER);
     assert_marker(&initial_index, BETA_MARKER);
     let retained_roots = initial_index.manifest().provider_roots().to_vec();
@@ -275,7 +275,7 @@ fn missing_openclaw_compound_root_retains_exact_agent_membership_until_restored(
     )
     .unwrap();
     assert!(cold_receipt.sources.is_empty());
-    let cold_index = VerifiedIndex::open(&cold_index_root).unwrap();
+    let cold_index = VerifiedIndex::open_pinned(&cold_index_root).unwrap();
     assert!(cold_index.manifest().sources.is_empty());
     assert!(cold_index.manifest().provider_roots()[0]
         .routes()
@@ -299,7 +299,7 @@ fn missing_openclaw_compound_root_retains_exact_agent_membership_until_restored(
     )
     .unwrap();
     assert!(missing_receipt.failed_routes.is_empty());
-    let retained_index = VerifiedIndex::open(&index_root).unwrap();
+    let retained_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         retained_index.manifest().provider_roots()[0].routes().len(),
         2
@@ -320,7 +320,7 @@ fn missing_openclaw_compound_root_retains_exact_agent_membership_until_restored(
     )
     .unwrap();
     assert!(restored_receipt.failed_routes.is_empty());
-    let restored_index = VerifiedIndex::open(&index_root).unwrap();
+    let restored_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         restored_index.manifest().provider_roots()[0].routes().len(),
         2

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence.rs
@@ -453,7 +453,7 @@ fn install_single_source_certificate(
     native_session_id: &str,
     provider_checkpoint: TypedKey,
 ) -> String {
-    let current = VerifiedIndex::open(index_root).unwrap();
+    let current = VerifiedIndex::open_pinned(index_root).unwrap();
     let routes = current.manifest().source_routes().to_vec();
     let replacement =
         certificate_with_provider_checkpoint(&current, native_session_id, provider_checkpoint);
@@ -600,7 +600,7 @@ fn assert_legacy_provider_checkpoint_is_inert(
         native_session_id,
         provider_checkpoint(native_session_id),
     );
-    let injected = VerifiedIndex::open(&index_root).unwrap();
+    let injected = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(injected.generation_id(), injected_generation);
     assert_eq!(
         certificate_for(&injected, native_session_id).parser_revision(),
@@ -613,7 +613,7 @@ fn assert_legacy_provider_checkpoint_is_inert(
     let unchanged =
         refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert_eq!(unchanged.commit.generation_id, injected_generation);
-    let unchanged_index = VerifiedIndex::open(&index_root).unwrap();
+    let unchanged_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         serde_json::to_vec(&certificate_for(&unchanged_index, native_session_id)).unwrap(),
         injected_certificate_bytes
@@ -625,7 +625,7 @@ fn assert_legacy_provider_checkpoint_is_inert(
     assert!(appended.failed_routes.is_empty());
     assert!(appended.logical_source_failures.is_empty());
 
-    let rebuilt = VerifiedIndex::open(&index_root).unwrap();
+    let rebuilt = VerifiedIndex::open_pinned(&index_root).unwrap();
     let rebuilt_snapshot = source_snapshot(&rebuilt, native_session_id, &marker);
     let (_, _, _, rebuilt_checkpoint) = provider_checkpoint_envelope(&rebuilt, native_session_id);
     assert_current_provider_checkpoint(&rebuilt_checkpoint);
@@ -644,7 +644,7 @@ fn assert_legacy_provider_checkpoint_is_inert(
         cold.commit.certified_source_bytes,
         appended.commit.certified_source_bytes
     );
-    let cold = VerifiedIndex::open(&cold_root).unwrap();
+    let cold = VerifiedIndex::open_pinned(&cold_root).unwrap();
     assert_eq!(
         source_snapshot(&cold, native_session_id, &marker),
         rebuilt_snapshot

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/compressed.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/compressed.rs
@@ -94,7 +94,7 @@ fn revert_rollouts_use_embedded_owner_for_raw_and_compressed_tree_and_explicit_r
     assert!(receipt.failed_routes.is_empty());
     assert!(receipt.logical_source_failures.is_empty());
     assert_eq!(receipt.sources.len(), 2);
-    let index = VerifiedIndex::open(&tree_index).unwrap();
+    let index = VerifiedIndex::open_pinned(&tree_index).unwrap();
     for (native_session_id, _, _, marker) in cases {
         assert_eq!(records_for(&index, native_session_id).len(), 1);
         assert_eq!(search_event_candidates(&index, marker, 8).len(), 1);
@@ -130,7 +130,7 @@ fn revert_rollouts_use_embedded_owner_for_raw_and_compressed_tree_and_explicit_r
     assert!(receipt.failed_routes.is_empty());
     assert!(receipt.logical_source_failures.is_empty());
     assert_eq!(receipt.sources.len(), 2);
-    let index = VerifiedIndex::open(&explicit_index).unwrap();
+    let index = VerifiedIndex::open_pinned(&explicit_index).unwrap();
     for (native_session_id, _, _, marker) in explicit_cases {
         assert_eq!(records_for(&index, native_session_id).len(), 1);
         assert_eq!(search_event_candidates(&index, marker, 8).len(), 1);
@@ -167,8 +167,8 @@ fn exact_compressed_and_raw_rollouts_have_identical_logical_identity() {
             .unwrap();
     assert!(compressed_receipt.failed_routes.is_empty());
 
-    let raw = VerifiedIndex::open(&raw_index).unwrap();
-    let compressed = VerifiedIndex::open(&compressed_index).unwrap();
+    let raw = VerifiedIndex::open_pinned(&raw_index).unwrap();
+    let compressed = VerifiedIndex::open_pinned(&compressed_index).unwrap();
     let raw_records = records_for(&raw, native_session_id);
     let compressed_records = records_for(&compressed, native_session_id);
     assert_eq!(raw_records.len(), 1);
@@ -206,7 +206,7 @@ fn exact_noncanonical_compressed_rollout_uses_embedded_session_identity() {
     assert!(receipt.failed_routes.is_empty());
     assert!(receipt.logical_source_failures.is_empty());
     assert_eq!(receipt.sources.len(), 1);
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let records = records_for(&index, native_session_id);
     assert_eq!(records.len(), 1);
     assert_eq!(search_event_candidates(&index, marker, 8).len(), 1);
@@ -240,7 +240,7 @@ fn mixed_raw_and_compressed_tree_imports_each_native_session() {
     assert!(receipt.failed_routes.is_empty());
     assert!(receipt.logical_source_failures.is_empty());
     assert_eq!(receipt.sources.len(), 2);
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(records_for(&index, raw_id).len(), 1);
     assert_eq!(records_for(&index, compressed_id).len(), 1);
     assert_eq!(
@@ -264,7 +264,7 @@ fn raw_to_compressed_representation_transition_replaces_physical_state_only() {
     let registry = register_tree(&[&sessions]);
 
     refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
-    let before = VerifiedIndex::open(&index_root).unwrap();
+    let before = VerifiedIndex::open_pinned(&index_root).unwrap();
     let before_records = records_for(&before, native_session_id);
     let before_identity = logical_identity(&before_records);
     drop(before);
@@ -277,7 +277,7 @@ fn raw_to_compressed_representation_transition_replaces_physical_state_only() {
     assert!(transitioned.logical_source_failures.is_empty());
     assert_eq!(transitioned.sources.len(), 1);
 
-    let after = VerifiedIndex::open(&index_root).unwrap();
+    let after = VerifiedIndex::open_pinned(&index_root).unwrap();
     let after_records = records_for(&after, native_session_id);
     assert_eq!(logical_identity(&after_records), before_identity);
     assert_eq!(after_records.len(), 1);
@@ -310,7 +310,7 @@ fn overlapping_raw_and_compressed_representations_coalesce_raw_first_and_keep_id
     assert!(cold.failed_routes.is_empty());
     assert!(cold.logical_source_failures.is_empty());
     assert_eq!(cold.sources.len(), 1);
-    let cold_index = VerifiedIndex::open(&index_root).unwrap();
+    let cold_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let identity = logical_identity(&records_for(&cold_index, native_session_id));
     assert_eq!(
         certificate_for(&cold_index, native_session_id)
@@ -327,7 +327,7 @@ fn overlapping_raw_and_compressed_representations_coalesce_raw_first_and_keep_id
         refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(compressed_only.failed_routes.is_empty());
     assert_eq!(compressed_only.sources.len(), 1);
-    let compressed_index = VerifiedIndex::open(&index_root).unwrap();
+    let compressed_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         logical_identity(&records_for(&compressed_index, native_session_id)),
         identity
@@ -346,7 +346,7 @@ fn overlapping_raw_and_compressed_representations_coalesce_raw_first_and_keep_id
         refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(overlapping_again.failed_routes.is_empty());
     assert_eq!(overlapping_again.sources.len(), 1);
-    let overlapping_index = VerifiedIndex::open(&index_root).unwrap();
+    let overlapping_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         logical_identity(&records_for(&overlapping_index, native_session_id)),
         identity
@@ -364,7 +364,7 @@ fn overlapping_raw_and_compressed_representations_coalesce_raw_first_and_keep_id
     let raw_only =
         refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(raw_only.failed_routes.is_empty());
-    let raw_index = VerifiedIndex::open(&index_root).unwrap();
+    let raw_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         logical_identity(&records_for(&raw_index, native_session_id)),
         identity
@@ -456,7 +456,7 @@ fn automatic_compressed_route_fails_without_a_usable_frame_owner() {
         panic!("unexpected compressed ownership error: {error:?}");
     };
     assert_eq!(failed_sources.total(), 1);
-    assert!(VerifiedIndex::open(&index_root).is_err());
+    assert!(VerifiedIndex::open_pinned(&index_root).is_err());
 }
 
 #[test]
@@ -487,7 +487,7 @@ fn repeated_consistent_compressed_metadata_across_frames_remains_admissible() {
         refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(receipt.failed_routes.is_empty());
     assert!(receipt.logical_source_failures.is_empty());
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(records_for(&index, native_session_id).len(), 1);
     assert_eq!(search_event_candidates(&index, marker, 8).len(), 1);
 }

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/configured_roots.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/configured_roots.rs
@@ -29,7 +29,7 @@ fn partial_codex_home_adopts_released_identity_without_duplicate_records() {
     refresh_source_backed_generation(&automatic_index, &automatic.registry, writer_options())
         .unwrap();
     let automatic_records = serde_json::to_vec(&records_for(
-        &VerifiedIndex::open(&automatic_index).unwrap(),
+        &VerifiedIndex::open_pinned(&automatic_index).unwrap(),
         native_session_id,
     ))
     .unwrap();
@@ -58,7 +58,7 @@ fn partial_codex_home_adopts_released_identity_without_duplicate_records() {
         let index_root = fixture.join(format!("configured-index-{automatic_enabled}"));
         refresh_source_backed_generation(&index_root, &configured.registry, writer_options())
             .unwrap();
-        let index = VerifiedIndex::open(&index_root).unwrap();
+        let index = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert_eq!(index.manifest().sources.len(), 1);
         assert_eq!(
             serde_json::to_vec(&records_for(&index, native_session_id)).unwrap(),
@@ -184,7 +184,7 @@ fn configured_codex_homes_with_the_same_native_session_publish_independent_sourc
         archive_refresh.failed_routes
     );
 
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let codex_sources = index
         .manifest()
         .sources
@@ -322,7 +322,7 @@ fn unavailable_configured_codex_home_carries_only_itself_while_peer_refreshes() 
         2,
         "the healthy peer retains typed absence for its optional routes"
     );
-    let retained = VerifiedIndex::open(&index_root).unwrap();
+    let retained = VerifiedIndex::open_pinned(&index_root).unwrap();
     current
         .registry
         .retain_unavailable_provider_root_routes(retained.manifest().provider_roots())
@@ -339,7 +339,7 @@ fn unavailable_configured_codex_home_carries_only_itself_while_peer_refreshes() 
     assert!(receipt.failed_routes.iter().all(|failure| {
         failure.class == SourceBackedSourceFailureClass::Unavailable && !failure.carried_forward
     }));
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(source_records_contain(
         &index,
         personal_session_id,
@@ -441,7 +441,7 @@ fn cold_unavailable_configured_codex_home_does_not_block_healthy_peer() {
         3,
         "the inferred missing defaults and healthy named home remain independent"
     );
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(source_records_contain(
         &index,
         personal_session_id,
@@ -494,7 +494,7 @@ fn codex_subagent_preserves_provider_root_session_in_core_records() {
         refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(receipt.failed_routes.is_empty());
     assert!(receipt.logical_source_failures.is_empty());
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let records = records_for(&index, child_native_session_id);
     assert_eq!(records.len(), 1);
     let record = &records[0];

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/continuous_append.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/continuous_append.rs
@@ -53,7 +53,7 @@ fn codex_cold_appends_during_bounded_capture_catch_up_once() {
     );
     assert!(cold.logical_source_failures.is_empty());
 
-    let initial = VerifiedIndex::open(&index_root).unwrap();
+    let initial = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(source_records_contain(
         &initial,
         native_session_id,
@@ -76,7 +76,7 @@ fn codex_cold_appends_during_bounded_capture_catch_up_once() {
         refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(caught_up.failed_routes.is_empty());
     assert!(caught_up.logical_source_failures.is_empty());
-    let current = VerifiedIndex::open(&index_root).unwrap();
+    let current = VerifiedIndex::open_pinned(&index_root).unwrap();
     let caught_up_generation = current.generation_id().to_owned();
     assert_eq!(records_for(&current, native_session_id).len(), 5);
     for marker in [
@@ -99,7 +99,7 @@ fn codex_cold_appends_during_bounded_capture_catch_up_once() {
     let no_op = refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(no_op.failed_routes.is_empty());
     assert!(no_op.logical_source_failures.is_empty());
-    let terminal = VerifiedIndex::open(&index_root).unwrap();
+    let terminal = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(terminal.generation_id(), caught_up_generation);
     assert_eq!(records_for(&terminal, native_session_id).len(), 5);
 }

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/item_completed.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/item_completed.rs
@@ -90,7 +90,7 @@ fn paginated_item_completed_fixture_keeps_raw_messages_once_and_projects_turn_qu
         3
     );
 
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let records = records_for(&index, NATIVE_SESSION_ID);
     assert_eq!(records.len(), 6, "four raw messages and two Plans");
     for marker in [
@@ -195,8 +195,8 @@ fn paginated_item_completed_append_noop_and_cold_replay_are_equivalent() {
         .collect::<Vec<_>>();
     assert_eq!(appended_rejections, cold_rejections);
 
-    let appended_index = VerifiedIndex::open(&prefix_index).unwrap();
-    let cold_index = VerifiedIndex::open(&cold_index).unwrap();
+    let appended_index = VerifiedIndex::open_pinned(&prefix_index).unwrap();
+    let cold_index = VerifiedIndex::open_pinned(&cold_index).unwrap();
     assert_eq!(
         records_identity(&appended_index),
         records_identity(&cold_index)
@@ -260,8 +260,8 @@ fn paginated_item_completed_raw_and_zstd_rollouts_have_identical_semantics() {
         .collect::<Vec<_>>();
     assert_eq!(raw_rejections, zstd_rejections);
 
-    let raw_index = VerifiedIndex::open(&raw_index).unwrap();
-    let zstd_index = VerifiedIndex::open(&zstd_index).unwrap();
+    let raw_index = VerifiedIndex::open_pinned(&raw_index).unwrap();
+    let zstd_index = VerifiedIndex::open_pinned(&zstd_index).unwrap();
     assert_eq!(records_identity(&raw_index), records_identity(&zstd_index));
 }
 

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/lifecycle.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/lifecycle.rs
@@ -122,7 +122,7 @@ fn automatic_codex_root_replacement_retires_archived_only_sources() {
         .contains(&replacement_tree_route));
     assert_eq!(replacement_receipt.removals.len(), 1);
 
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         index
             .manifest()
@@ -236,7 +236,7 @@ fn automatic_codex_root_replacement_partial_inventory_carries_archived_members()
             "{disposition} replacement route was incorrectly complete"
         );
         assert!(receipt.removals.is_empty(), "{disposition}");
-        let index = VerifiedIndex::open(&index_root).unwrap();
+        let index = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert_eq!(
             index
                 .manifest()
@@ -279,7 +279,7 @@ fn overlapping_automatic_and_explicit_routes_keep_selected_generation_ownership(
     assert_eq!(cold.sources.len(), 1);
     assert_eq!(
         search_event_candidates(
-            &VerifiedIndex::open(&index_root).unwrap(),
+            &VerifiedIndex::open_pinned(&index_root).unwrap(),
             "automatic-explicit-cold-marker",
             8,
         )
@@ -307,7 +307,7 @@ fn overlapping_automatic_and_explicit_routes_keep_selected_generation_ownership(
     )
     .unwrap();
     assert!(automatic.failed_routes.is_empty());
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let records = records_for(&index, native_session_id);
     for marker in [
         "automatic-explicit-cold-marker",
@@ -350,7 +350,7 @@ fn codex_mcp_activity_append_replay_preserves_stable_ids_and_exact_content() {
     let registry = register_tree(&[&sessions]);
 
     refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
-    let initial = VerifiedIndex::open(&index_root).unwrap();
+    let initial = VerifiedIndex::open_pinned(&index_root).unwrap();
     let initial_record = records_for(&initial, native_session_id)
         .into_iter()
         .find(|record| {
@@ -383,7 +383,7 @@ fn codex_mcp_activity_append_replay_preserves_stable_ids_and_exact_content() {
     assert!(appended.logical_source_failures.is_empty());
     let appended_generation = appended.commit.generation_id.clone();
 
-    let appended_index = VerifiedIndex::open(&index_root).unwrap();
+    let appended_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let records = records_for(&appended_index, native_session_id);
     let first = records
         .iter()
@@ -431,7 +431,7 @@ fn codex_mcp_activity_append_replay_preserves_stable_ids_and_exact_content() {
     assert_eq!(replay.commit.generation_id, appended_generation);
 
     refresh_source_backed_generation(&cold_root, &registry, writer_options()).unwrap();
-    let cold = VerifiedIndex::open(&cold_root).unwrap();
+    let cold = VerifiedIndex::open_pinned(&cold_root).unwrap();
     assert_eq!(
         source_snapshot(&cold, native_session_id, "second activity result"),
         appended_snapshot

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/projection_behaviors.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/projection_behaviors.rs
@@ -38,7 +38,7 @@ fn codex_inline_image_over_page_limit_does_not_fail_route() {
     assert!(receipt.failed_routes.is_empty());
     assert!(receipt.logical_source_failures.is_empty());
     assert!(receipt.record_rejections.is_empty());
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let records = records_for(&index, native_session_id);
     assert_eq!(records.len(), 4);
     let oversized = records
@@ -89,7 +89,7 @@ fn codex_inline_image_over_page_limit_does_not_fail_route() {
     assert!(replayed.failed_routes.is_empty());
     assert!(replayed.logical_source_failures.is_empty());
     assert!(replayed.record_rejections.is_empty());
-    let replayed_index = VerifiedIndex::open(&index_root).unwrap();
+    let replayed_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         replayed_index
             .core_record_by_id(oversized_record.event_id.as_uuid())
@@ -145,7 +145,7 @@ fn codex_valid_custom_tool_result_over_16_mib_is_retained() {
         "unexpected rejections: {:?}",
         receipt.record_rejections
     );
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let records = records_for(&index, native_session_id);
     assert_eq!(records.len(), 1);
     assert!(matches!(
@@ -215,7 +215,7 @@ fn codex_core_envelope_rejection_preserves_siblings_and_their_ids() {
         diagnostic.detail,
         "Codex retained record exceeds the Core selected-content envelope"
     );
-    let rejected_index = VerifiedIndex::open(&index_root).unwrap();
+    let rejected_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let sibling_ids = [before_marker, after_marker].map(|marker| {
         search_event_candidates(&rejected_index, marker, 8)
             .into_iter()
@@ -245,7 +245,7 @@ fn codex_core_envelope_rejection_preserves_siblings_and_their_ids() {
     assert!(repaired.failed_routes.is_empty());
     assert!(repaired.logical_source_failures.is_empty());
     assert!(repaired.record_rejections.is_empty());
-    let repaired_index = VerifiedIndex::open(&index_root).unwrap();
+    let repaired_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     for (marker, event_id) in [before_marker, after_marker]
         .into_iter()
         .zip(sibling_ids.iter().copied())
@@ -259,7 +259,7 @@ fn codex_core_envelope_rejection_preserves_siblings_and_their_ids() {
     let (replayed, _) = incremental_refresh(&index_root, &registry, &repaired);
     assert_eq!(replayed.commit.generation_id, repaired.commit.generation_id);
     assert!(replayed.record_rejections.is_empty());
-    let replayed_index = VerifiedIndex::open(&index_root).unwrap();
+    let replayed_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     for (marker, event_id) in [before_marker, after_marker]
         .into_iter()
         .zip(sibling_ids.iter().copied())
@@ -341,7 +341,7 @@ fn inherited_codex_session_metadata_is_admitted_in_both_provider_orders() {
     assert!(receipt.logical_source_failures.is_empty());
     assert_eq!(receipt.sources.len(), 3);
 
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     for (native_session_id, marker) in [
         (owner_first_id, "ownerfirstinheritedmetadatamarker"),
         (ancestor_first_id, "ancestorfirstinheritedmetadatamarker"),
@@ -401,7 +401,7 @@ fn codex_rollout_ownership_quarantine_retries_after_file_repair() {
         refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(initial.failed_routes.is_empty());
     assert!(initial.logical_source_failures.is_empty());
-    let initial_index = VerifiedIndex::open(&index_root).unwrap();
+    let initial_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(records_for(&initial_index, repairable_session_id).len(), 1);
     drop(initial_index);
 
@@ -457,7 +457,7 @@ fn codex_rollout_ownership_quarantine_retries_after_file_repair() {
     );
     assert_eq!(failure.source.provider(), CaptureProvider::Codex.as_str());
 
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(search_event_candidates(&index, neighbor_marker, 32)
         .into_iter()
         .any(|candidate| candidate.event.provider_session_id.as_deref() == Some(valid_session_id)));
@@ -497,7 +497,7 @@ fn codex_rollout_ownership_quarantine_retries_after_file_repair() {
     );
     assert!(repaired.failed_routes.is_empty());
     assert!(repaired.logical_source_failures.is_empty());
-    let repaired_index = VerifiedIndex::open(&index_root).unwrap();
+    let repaired_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(records_for(&repaired_index, repairable_session_id).len(), 1);
     assert!(!source_records_contain(
         &repaired_index,
@@ -537,7 +537,7 @@ fn codex_retrieval_exclusion_survives_raw_append_hydration_and_keeps_ids_stable(
 
     let cold = refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(cold.failed_routes.is_empty());
-    let cold_index = VerifiedIndex::open(&index_root).unwrap();
+    let cold_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let cold_records = records_for(&cold_index, native_session_id);
     assert_eq!(cold_records.len(), 1);
     assert_eq!(
@@ -560,7 +560,7 @@ fn codex_retrieval_exclusion_survives_raw_append_hydration_and_keeps_ids_stable(
     );
     let (appended, _) = incremental_refresh(&index_root, &registry, &cold);
     assert!(appended.failed_routes.is_empty());
-    let appended_index = VerifiedIndex::open(&index_root).unwrap();
+    let appended_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let appended_records = records_for(&appended_index, native_session_id);
     assert_eq!(appended_records.len(), 2);
     assert_eq!(appended_records[0].event_id, retrieval_invocation_id);
@@ -587,7 +587,7 @@ fn codex_retrieval_exclusion_survives_raw_append_hydration_and_keeps_ids_stable(
     let controlled =
         refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(controlled.failed_routes.is_empty());
-    let controlled_index = VerifiedIndex::open(&index_root).unwrap();
+    let controlled_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let controlled_records = records_for(&controlled_index, native_session_id);
     assert_eq!(controlled_records.len(), 4);
     assert_eq!(controlled_records[0].event_id, retrieval_invocation_id);

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/quarantine.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/quarantine.rs
@@ -16,7 +16,7 @@ fn catalog_owner_rejection_fails_cold_and_repairs() {
         panic!("unexpected cold rejection error: {error:?}");
     };
     assert_eq!(failed_sources.total(), 1);
-    assert!(VerifiedIndex::open(&index_root).is_err());
+    assert!(VerifiedIndex::open_pinned(&index_root).is_err());
 
     let repaired_id = "019fb000-0000-7000-8000-000000000063";
     fs::write(
@@ -33,7 +33,7 @@ fn catalog_owner_rejection_fails_cold_and_repairs() {
     assert!(repaired.logical_source_failures.is_empty());
     assert_eq!(
         search_event_candidates(
-            &VerifiedIndex::open(&index_root).unwrap(),
+            &VerifiedIndex::open_pinned(&index_root).unwrap(),
             "catalogownerrepairedmarker",
             8,
         )
@@ -86,7 +86,7 @@ fn malformed_codex_record_retains_valid_peers_and_reports_local_line() {
         rejection.detail,
         "Codex record is not valid projectable JSON"
     );
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(source_records_contain(
         &index,
         native_session_id,
@@ -140,7 +140,7 @@ fn codex_prefix_ownership_quarantine_retains_prior_source_and_repairs() {
     let (quarantined, _) = incremental_refresh(&index_root, &registry, &initial);
     assert!(quarantined.failed_routes.is_empty());
     assert_eq!(quarantined.logical_source_failures.total(), 1);
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(index.manifest().sources, initial.sources);
     assert!(index.manifest().sources.iter().any(|certificate| {
         source_native_session_id(certificate.observation().source()) == Some(native_session_id)
@@ -169,7 +169,7 @@ fn codex_prefix_ownership_quarantine_retains_prior_source_and_repairs() {
     );
     assert!(repaired.failed_routes.is_empty());
     assert!(repaired.logical_source_failures.is_empty());
-    let repaired_index = VerifiedIndex::open(&index_root).unwrap();
+    let repaired_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let repaired_records = records_for(&repaired_index, native_session_id);
     assert_eq!(repaired_records.len(), 1);
     assert!(
@@ -231,7 +231,7 @@ fn malformed_late_session_meta_quarantines_only_its_rollout() {
         refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(receipt.failed_routes.is_empty());
     assert_eq!(receipt.logical_source_failures.total(), 1);
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     for marker in ["malformedmetabeforemarker", "malformedmetaaftermarker"] {
         assert_eq!(search_event_candidates(&index, marker, 8).len(), 1);
     }
@@ -278,7 +278,7 @@ fn selector_ambiguous_session_meta_fails_without_a_usable_rollout() {
         panic!("unexpected ambiguous-source error: {error:?}");
     };
     assert_eq!(failed_sources.total(), 1);
-    assert!(VerifiedIndex::open(&index_root).is_err());
+    assert!(VerifiedIndex::open_pinned(&index_root).is_err());
 }
 
 #[test]
@@ -327,7 +327,7 @@ fn committed_codex_good_bad_good_retains_prior_source_while_neighbor_advances() 
 
     let (middle, _) = incremental_refresh(&index_root, &registry, &cold);
     assert!(middle.failed_routes.is_empty());
-    let middle_index = VerifiedIndex::open(&index_root).unwrap();
+    let middle_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(records_for(&middle_index, repairable_id).len(), 1);
     assert!(source_records_contain(
         &middle_index,
@@ -356,7 +356,7 @@ fn committed_codex_good_bad_good_retains_prior_source_while_neighbor_advances() 
     .unwrap();
     let (repaired, _) = incremental_refresh(&index_root, &registry, &middle);
     assert!(repaired.failed_routes.is_empty());
-    let repaired_index = VerifiedIndex::open(&index_root).unwrap();
+    let repaired_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(!source_records_contain(
         &repaired_index,
         repairable_id,
@@ -421,7 +421,7 @@ fn fully_quarantined_codex_session_tree_fails_instead_of_publishing_empty() {
         .failures()
         .iter()
         .all(|failure| !failure.carried_forward));
-    assert!(VerifiedIndex::open(&index_root).is_err());
+    assert!(VerifiedIndex::open_pinned(&index_root).is_err());
 }
 
 #[test]
@@ -463,7 +463,7 @@ fn committed_codex_good_partial_repaired_retains_prior_source_while_neighbor_adv
     assert!(middle.failed_routes.is_empty());
     assert!(middle.logical_source_failures.is_empty());
     assert!(middle.record_rejections.is_empty());
-    let middle_index = VerifiedIndex::open(&index_root).unwrap();
+    let middle_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(records_for(&middle_index, repairable_id).len(), 1);
     assert!(source_records_contain(
         &middle_index,
@@ -487,7 +487,7 @@ fn committed_codex_good_partial_repaired_retains_prior_source_while_neighbor_adv
     .unwrap();
     let (repaired, _) = incremental_refresh(&index_root, &registry, &middle);
     assert!(repaired.failed_routes.is_empty());
-    let repaired_index = VerifiedIndex::open(&index_root).unwrap();
+    let repaired_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(!source_records_contain(
         &repaired_index,
         repairable_id,

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/repository.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/repository.rs
@@ -22,7 +22,7 @@ fn destructive_precommit_truncate_and_replacement_preserve_last_good_generation_
         );
         let registry = register_tree(&[&sessions]);
         refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
-        let before = VerifiedIndex::open(&index_root).unwrap();
+        let before = VerifiedIndex::open_pinned(&index_root).unwrap();
         let generation = before.generation_id().to_owned();
         let snapshot = source_snapshot(&before, native_session_id, "lastgooduniquetoken");
         drop(before);
@@ -60,7 +60,7 @@ fn destructive_precommit_truncate_and_replacement_preserve_last_good_generation_
             }
             Err(error) => panic!("unexpected {mutation} failure: {error:?}"),
         }
-        let retained = VerifiedIndex::open(&index_root).unwrap();
+        let retained = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert_eq!(retained.generation_id(), generation, "{mutation}");
         assert_eq!(
             source_snapshot(&retained, native_session_id, "lastgooduniquetoken"),
@@ -101,7 +101,7 @@ fn current_authority_reappearance_before_publication_carries_last_good_generatio
     let initial =
         refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(initial.failed_routes.is_empty());
-    let before = VerifiedIndex::open(&index_root).unwrap();
+    let before = VerifiedIndex::open_pinned(&index_root).unwrap();
     let generation = before.generation_id().to_owned();
     let retained_snapshot = source_snapshot(&before, retained_session, retained_marker);
     let deleted_snapshot = source_snapshot(&before, deleted_session, deleted_marker);
@@ -129,7 +129,7 @@ fn current_authority_reappearance_before_publication_carries_last_good_generatio
                 && failure.carried_forward
     ));
     assert!(failed.removals.is_empty());
-    let retained = VerifiedIndex::open(&index_root).unwrap();
+    let retained = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(retained.generation_id(), generation);
     assert_eq!(
         source_snapshot(&retained, retained_session, retained_marker),

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/terminal_results.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence/terminal_results.rs
@@ -28,7 +28,7 @@ fn codex_cold_duplicate_direct_and_mcp_terminals_fail_open() {
     let receipt =
         refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(receipt.failed_routes.is_empty());
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let records = records_for(&index, native_session_id);
     assert_eq!(records.len(), 5);
     let invocation = records
@@ -105,7 +105,7 @@ fn codex_appended_duplicate_direct_and_mcp_terminals_retract_exclusion_with_stab
 
     let cold = refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(cold.failed_routes.is_empty());
-    let cold_index = VerifiedIndex::open(&index_root).unwrap();
+    let cold_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let cold_direct = records_for(&cold_index, direct_session_id);
     let cold_mcp = records_for(&cold_index, mcp_session_id);
     assert_eq!(cold_direct.len(), 2);
@@ -128,7 +128,7 @@ fn codex_appended_duplicate_direct_and_mcp_terminals_retract_exclusion_with_stab
     );
     let (appended, _) = incremental_refresh(&index_root, &registry, &cold);
     assert!(appended.failed_routes.is_empty());
-    let appended_index = VerifiedIndex::open(&index_root).unwrap();
+    let appended_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let direct = records_for(&appended_index, direct_session_id);
     let mcp = records_for(&appended_index, mcp_session_id);
     assert_eq!(direct.len(), 3);
@@ -183,7 +183,7 @@ fn codex_incremental_unique_terminal_append_and_restart_stay_suffix_bounded() {
     let registry = register_tree(&[&sessions]);
     let cold = refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(cold.failed_routes.is_empty());
-    let cold_index = VerifiedIndex::open(&index_root).unwrap();
+    let cold_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let cold_records = records_for(&cold_index, native_session_id);
     let first_event_id = result_record_for_call(&cold_records, first_call_id).event_id;
     assert_eq!(
@@ -201,7 +201,7 @@ fn codex_incremental_unique_terminal_append_and_restart_stay_suffix_bounded() {
     let (appended, completed_records) = incremental_refresh(&index_root, &registry, &cold);
     assert!(appended.failed_routes.is_empty());
     assert_eq!(completed_records, 1);
-    let appended_index = VerifiedIndex::open(&index_root).unwrap();
+    let appended_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let appended_records = records_for(&appended_index, native_session_id);
     assert_eq!(
         result_record_for_call(&appended_records, first_call_id).event_id,
@@ -231,7 +231,7 @@ fn codex_incremental_unique_terminal_append_and_restart_stay_suffix_bounded() {
         incremental_refresh(&index_root, &restarted_registry, &appended);
     assert!(restarted.failed_routes.is_empty());
     assert_eq!(restart_completed_records, 2);
-    let restarted_index = VerifiedIndex::open(&index_root).unwrap();
+    let restarted_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let restarted_records = records_for(&restarted_index, native_session_id);
     assert_eq!(
         result_record_for_call(&restarted_records, first_call_id).event_id,
@@ -293,7 +293,7 @@ fn inferred_codex_member_refresh_keeps_released_identity_and_stays_bounded() {
         "a member workset should not fall back to whole-tree discovery"
     );
     assert!(source_records_contain(
-        &VerifiedIndex::open(&index_root).unwrap(),
+        &VerifiedIndex::open_pinned(&index_root).unwrap(),
         selected_session_id,
         "inferred bounded appended"
     ));
@@ -337,7 +337,7 @@ fn codex_incremental_4097th_terminal_saturates_and_replaces_fail_open() {
     let registry = register_tree(&[&sessions]);
     let cold = refresh_source_backed_generation(&index_root, &registry, writer_options()).unwrap();
     assert!(cold.failed_routes.is_empty());
-    let cold_index = VerifiedIndex::open(&index_root).unwrap();
+    let cold_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let cold_records = records_for(&cold_index, native_session_id);
     let first = result_record_for_call(&cold_records, first_call_id);
     let first_event_id = first.event_id;
@@ -355,7 +355,7 @@ fn codex_incremental_4097th_terminal_saturates_and_replaces_fail_open() {
     );
     let (saturated, completed_records) = incremental_refresh(&index_root, &registry, &cold);
     assert!(saturated.failed_routes.is_empty());
-    let saturated_index = VerifiedIndex::open(&index_root).unwrap();
+    let saturated_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let saturated_records = records_for(&saturated_index, native_session_id);
     assert!(completed_records > 1);
     assert_eq!(completed_records, saturated_records.len() as u64);

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/compound_root_ownership.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/compound_root_ownership.rs
@@ -210,7 +210,7 @@ fn publish(path: &Path, registry: &SourceBackedProviderRegistry) -> VerifiedInde
         "{:?}",
         receipt.failed_routes
     );
-    VerifiedIndex::open(path).unwrap()
+    VerifiedIndex::open_pinned(path).unwrap()
 }
 
 fn source_bytes(index: &VerifiedIndex, marker: &str) -> StableSourceBytes {

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/publication_registry.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/publication_registry.rs
@@ -402,7 +402,7 @@ fn terminal_failure_on_either_side_of_success_keeps_replacement_atomic() {
             .is_some());
         assert!(failed.commit.manifest().source_route(&first_id).is_none());
         assert!(failed.commit.manifest().source_route(&second_id).is_none());
-        let failed_index = ctx_history_index::VerifiedIndex::open(temp.path()).unwrap();
+        let failed_index = ctx_history_index::VerifiedIndex::open_pinned(temp.path()).unwrap();
         assert!(search_event_candidates(&failed_index, "atomicterminalfirst", 8).is_empty());
         assert!(search_event_candidates(&failed_index, "atomicterminalsecond", 8).is_empty());
         drop(failed_index);
@@ -745,7 +745,7 @@ fn logical_all_publication_withdraws_removed_root_without_deleting_history() {
     refresh_source_backed_generation(temp.path(), &initial_registry, WriterOptions::default())
         .unwrap();
     assert_eq!(
-        VerifiedIndex::open(temp.path())
+        VerifiedIndex::open_pinned(temp.path())
             .unwrap()
             .manifest()
             .sources
@@ -778,7 +778,7 @@ fn logical_all_publication_withdraws_removed_root_without_deleting_history() {
         .unwrap();
     assert!(receipt.route_controls.is_empty());
 
-    let published = VerifiedIndex::open(temp.path()).unwrap();
+    let published = VerifiedIndex::open_pinned(temp.path()).unwrap();
     assert_eq!(published.manifest().sources.len(), 2);
     assert!(published.manifest().source_route(&work_id).is_some());
     assert!(published.manifest().source_route(&personal_id).is_some());
@@ -916,7 +916,9 @@ fn empty_replacement_cannot_hide_a_cold_route_failure_behind_retired_content() {
             if failed_routes.len() == 1 && failed_routes[0].route_identity == failed_id
     ));
     assert_eq!(
-        VerifiedIndex::open(temp.path()).unwrap().generation_id(),
+        VerifiedIndex::open_pinned(temp.path())
+            .unwrap()
+            .generation_id(),
         initial.commit.generation_id
     );
 }
@@ -1060,7 +1062,7 @@ fn automatic_whole_route_missing_grace_resets_and_unknown_aborts_atomically() {
         );
     }
 
-    let retained_generation = VerifiedIndex::open(temp.path())
+    let retained_generation = VerifiedIndex::open_pinned(temp.path())
         .unwrap()
         .generation_id()
         .to_owned();
@@ -1077,7 +1079,9 @@ fn automatic_whole_route_missing_grace_resets_and_unknown_aborts_atomically() {
         Err(SourceBackedCoordinatorError::UnavailableRoute { .. })
     ));
     assert_eq!(
-        VerifiedIndex::open(temp.path()).unwrap().generation_id(),
+        VerifiedIndex::open_pinned(temp.path())
+            .unwrap()
+            .generation_id(),
         retained_generation
     );
 
@@ -1120,7 +1124,9 @@ fn automatic_whole_route_missing_grace_resets_and_unknown_aborts_atomically() {
     assert!(deleted.sources.is_empty());
     assert!(deleted.commit.manifest().source_routes().is_empty());
     assert_eq!(
-        VerifiedIndex::open(temp.path()).unwrap().document_count(),
+        VerifiedIndex::open_pinned(temp.path())
+            .unwrap()
+            .document_count(),
         0
     );
 }
@@ -1165,7 +1171,7 @@ fn cold_certified_missing_route_reappearance_at_precommit_cannot_publish_empty()
             if invalidated == route_identity.as_str()
     ));
     assert!(matches!(
-        VerifiedIndex::open(temp.path()),
+        VerifiedIndex::open_pinned(temp.path()),
         Err(IndexError::MissingActiveGenerationPointer)
     ));
 }
@@ -1202,7 +1208,7 @@ fn previously_empty_certified_missing_route_reappearance_at_precommit_retains_ba
         SourceBackedCoordinatorError::Index(IndexError::SourceInvalidated(ref invalidated))
             if invalidated == route_identity.as_str()
     ));
-    let retained = VerifiedIndex::open(temp.path()).unwrap();
+    let retained = VerifiedIndex::open_pinned(temp.path()).unwrap();
     assert_eq!(retained.generation_id(), initial.commit.generation_id);
     let retained_route = retained.manifest().source_route(&route_identity).unwrap();
     assert!(retained_route.sources().is_empty());
@@ -1253,7 +1259,7 @@ fn certified_missing_route_reappearance_at_precommit_cannot_delete_the_route() {
         )
         .unwrap();
     }
-    let retained_generation = VerifiedIndex::open(temp.path())
+    let retained_generation = VerifiedIndex::open_pinned(temp.path())
         .unwrap()
         .generation_id()
         .to_owned();
@@ -1275,7 +1281,7 @@ fn certified_missing_route_reappearance_at_precommit_cannot_delete_the_route() {
             if invalidated == route_id.as_str()
     ));
 
-    let retained = VerifiedIndex::open(temp.path()).unwrap();
+    let retained = VerifiedIndex::open_pinned(temp.path()).unwrap();
     assert_eq!(retained.generation_id(), retained_generation);
     assert!(retained.manifest().source_route(&route_id).is_some());
     assert_eq!(retained.document_count(), 1);
@@ -1332,7 +1338,7 @@ fn relocated_route_rechecks_old_path_absence_at_terminal_publication() {
         SourceBackedCoordinatorError::Index(IndexError::SourceInvalidated(ref invalidated))
             if invalidated == preserved.as_str()
     ));
-    let retained = VerifiedIndex::open(temp.path()).unwrap();
+    let retained = VerifiedIndex::open_pinned(temp.path()).unwrap();
     assert_eq!(retained.generation_id(), initial.commit.generation_id);
     assert!(retained.manifest().source_route(&preserved).is_some());
     assert_eq!(retained.document_count(), 1);
@@ -1382,7 +1388,7 @@ fn mutating_refresh_rejects_an_unclaimed_base_source_from_the_same_family() {
         } if source_id == &initial_source.identity().to_string()
             && route_identity == &incomplete_route
     ));
-    let retained = VerifiedIndex::open(temp.path()).unwrap();
+    let retained = VerifiedIndex::open_pinned(temp.path()).unwrap();
     assert_eq!(retained.generation_id(), initial_generation);
     assert_eq!(retained.manifest().sources, initial.sources);
 }
@@ -1477,7 +1483,7 @@ fn refresh_receipt_stays_bound_to_commit_when_current_generation_advances() {
     assert!(g1.removals.is_empty());
     assert!(g2.removals.is_empty());
     assert_eq!(
-        VerifiedIndex::open(root).unwrap().generation_id(),
+        VerifiedIndex::open_pinned(root).unwrap().generation_id(),
         g2.commit.generation_id
     );
 }

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/released_root_equivalence.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/released_root_equivalence.rs
@@ -308,7 +308,7 @@ fn publication_bytes(
         receipt.failed_routes
     );
     assert!(!receipt.sources.is_empty());
-    let index = VerifiedIndex::open(index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(index_root).unwrap();
     let manifest = index.manifest();
     let mut sources = manifest
         .sources
@@ -364,10 +364,10 @@ fn assert_publication_bytes_eq(
 }
 
 fn records_matching(index_root: &Path, marker: &str) -> Vec<CoreRecord> {
-    search_event_candidates(&VerifiedIndex::open(index_root).unwrap(), marker, 32)
+    search_event_candidates(&VerifiedIndex::open_pinned(index_root).unwrap(), marker, 32)
         .into_iter()
         .map(|candidate| {
-            VerifiedIndex::open(index_root)
+            VerifiedIndex::open_pinned(index_root)
                 .unwrap()
                 .core_record_by_id(candidate.event.event_id.as_uuid())
                 .unwrap()
@@ -384,7 +384,7 @@ fn only_record_matching(index_root: &Path, marker: &str) -> CoreRecord {
 }
 
 fn auggie_record_owned_by_root(index_root: &Path, root_id: &str, marker: &str) -> CoreRecord {
-    let index = VerifiedIndex::open(index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(index_root).unwrap();
     let allowed = index
         .manifest()
         .provider_root_source_tokens(&[root_id.to_owned()], &[])
@@ -849,7 +849,7 @@ fn moved_openhands_current_root_retains_released_authority_through_full_lifecycl
                 serde_json::to_vec(&only_record_matching(&index_root, MOVED_MARKER)).unwrap(),
                 serde_json::to_vec(&automatic_record).unwrap()
             );
-            let missing_index = VerifiedIndex::open(&index_root).unwrap();
+            let missing_index = VerifiedIndex::open_pinned(&index_root).unwrap();
             assert!(missing_index
                 .manifest()
                 .source_route(&automatic_route)
@@ -932,7 +932,9 @@ fn moved_openhands_current_root_retains_released_authority_through_full_lifecycl
             usize::from(automatic_enabled)
         );
         assert_eq!(
-            VerifiedIndex::open(&index_root).unwrap().document_count(),
+            VerifiedIndex::open_pinned(&index_root)
+                .unwrap()
+                .document_count(),
             expected_route_count as u64
         );
     }

--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/sqlite_selected.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/sqlite_selected.rs
@@ -67,7 +67,7 @@ fn goose_v15_active_wal_append_preserves_identities_and_replays_exactly() {
     let cold = refresh_source_backed_generation(&index, &registry, writer_options()).unwrap();
     assert_clean_refresh(&cold);
 
-    let verified = VerifiedIndex::open(&index).unwrap();
+    let verified = VerifiedIndex::open_pinned(&index).unwrap();
     let source = verified
         .manifest()
         .sources
@@ -328,7 +328,7 @@ fn replace_once(bytes: &mut [u8], original: &[u8], replacement: &[u8]) {
 }
 
 fn only_indexed_record(index_root: &Path, provider: CaptureProvider, marker: &str) -> CoreRecord {
-    let index = VerifiedIndex::open(index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(index_root).unwrap();
     let records = super::lexical_test_support::search_event_candidates(&index, marker, 16)
         .into_iter()
         .filter_map(|candidate| {

--- a/crates/ctx-history-capture-composition/src/source_backed/automatic_route_split/tests.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/automatic_route_split/tests.rs
@@ -532,7 +532,7 @@ fn failed_witnessed_cohort_keeps_the_bridge_generation_active() {
             .refresh(&index_root, |_| Ok(()))
             .is_err()
     );
-    let retained = ctx_history_index::VerifiedIndex::open(&index_root).unwrap();
+    let retained = ctx_history_index::VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(retained.generation_id(), bridge.commit.generation_id);
     assert!(retained.manifest().source_route(&legacy).is_some());
 }

--- a/crates/ctx-history-capture-composition/src/source_backed/registration/families/document.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/registration/families/document.rs
@@ -299,7 +299,10 @@ mod tests {
         let deleted =
             refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
         assert_eq!(deleted.commit.indexed_documents, 0);
-        assert_eq!(VerifiedIndex::open(&index).unwrap().document_count(), 0);
+        assert_eq!(
+            VerifiedIndex::open_pinned(&index).unwrap().document_count(),
+            0
+        );
         let deleted_replay =
             refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
         assert_eq!(
@@ -478,7 +481,10 @@ mod tests {
         let malformed =
             refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
         assert_eq!(malformed.commit.generation_id, rewrite.commit.generation_id);
-        assert_eq!(VerifiedIndex::open(&index).unwrap().document_count(), 3);
+        assert_eq!(
+            VerifiedIndex::open_pinned(&index).unwrap().document_count(),
+            3
+        );
 
         write_cline_sdk_messages(&provider_root, &["repaired"]);
         refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
@@ -486,7 +492,10 @@ mod tests {
         let deleted =
             refresh_source_backed_generation(&index, &registry, WriterOptions::default()).unwrap();
         assert_eq!(deleted.commit.indexed_documents, 0);
-        assert_eq!(VerifiedIndex::open(&index).unwrap().document_count(), 0);
+        assert_eq!(
+            VerifiedIndex::open_pinned(&index).unwrap().document_count(),
+            0
+        );
     }
 
     #[test]
@@ -544,7 +553,7 @@ mod tests {
             .iter()
             .any(|event| { event.core_record.content.meaningful_text() == "same content" }));
         assert!(matches!(
-            VerifiedIndex::open(&index)
+            VerifiedIndex::open_pinned(&index)
                 .unwrap()
                 .core_source_event_page(&source_a, None, 64),
             Err(ctx_history_index::IndexError::SourceEventSourceNotRetained(
@@ -655,7 +664,7 @@ mod tests {
         ctx_history_core::StableEntityId,
         ctx_history_core::StableEntityId,
     ) {
-        let verified = VerifiedIndex::open(index).unwrap();
+        let verified = VerifiedIndex::open_pinned(index).unwrap();
         let events = receipt
             .sources
             .iter()
@@ -674,7 +683,7 @@ mod tests {
     }
 
     fn rovodev_events(index: &Path, receipt: &SourceBackedRefreshReceipt) -> Vec<CoreEventRecord> {
-        let verified = VerifiedIndex::open(index).unwrap();
+        let verified = VerifiedIndex::open_pinned(index).unwrap();
         let mut events = receipt
             .sources
             .iter()
@@ -859,7 +868,7 @@ mod tests {
         index: &Path,
         receipt: &SourceBackedRefreshReceipt,
     ) -> Vec<CoreEventRecord> {
-        let verified = VerifiedIndex::open(index).unwrap();
+        let verified = VerifiedIndex::open_pinned(index).unwrap();
         receipt
             .sources
             .iter()

--- a/crates/ctx-history-capture-composition/src/source_backed/registration/families/event_file/automatic_lifecycle_tests.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/registration/families/event_file/automatic_lifecycle_tests.rs
@@ -513,7 +513,7 @@ fn indexed_bodies(index: &Path, receipt: &SourceBackedRefreshReceipt) -> Vec<Str
 }
 
 fn indexed_events(index: &Path, receipt: &SourceBackedRefreshReceipt) -> Vec<CoreRecord> {
-    let verified = VerifiedIndex::open(index).unwrap();
+    let verified = VerifiedIndex::open_pinned(index).unwrap();
     let mut events = receipt
         .sources
         .iter()

--- a/crates/ctx-history-capture-composition/src/source_backed/registration/families/event_file/test_helpers.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/registration/families/event_file/test_helpers.rs
@@ -4,7 +4,7 @@ use ctx_history_index::VerifiedIndex;
 use std::path::Path;
 
 pub(super) fn indexed_bodies(index: &Path, receipt: &SourceBackedRefreshReceipt) -> Vec<String> {
-    let verified = VerifiedIndex::open(index).unwrap();
+    let verified = VerifiedIndex::open_pinned(index).unwrap();
     let mut bodies = receipt
         .sources
         .iter()
@@ -26,7 +26,7 @@ pub(super) fn indexed_events(
     index: &Path,
     receipt: &SourceBackedRefreshReceipt,
 ) -> Vec<CoreRecord> {
-    let verified = VerifiedIndex::open(index).unwrap();
+    let verified = VerifiedIndex::open_pinned(index).unwrap();
     let mut events = receipt
         .sources
         .iter()

--- a/crates/ctx-history-capture-composition/src/source_backed/registration/families/event_file/tests/automatic.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/registration/families/event_file/tests/automatic.rs
@@ -69,7 +69,10 @@ fn equal_automatic_legacy_and_configured_current_roots_publish_each_event_once()
         bodies.iter().filter(|body| *body == "current body").count(),
         1
     );
-    assert_eq!(VerifiedIndex::open(&index).unwrap().document_count(), 2);
+    assert_eq!(
+        VerifiedIndex::open_pinned(&index).unwrap().document_count(),
+        2
+    );
 }
 
 #[test]
@@ -145,7 +148,10 @@ fn current_cli_automatic_discovery_covers_append_rewrite_and_conversation_deleti
     assert_eq!(current_route.source.path, conversations);
     assert_eq!(current_route.source.status, ProviderSourceStatus::Empty);
     refresh_source_backed_generation(&index, &deleted_registry, WriterOptions::default()).unwrap();
-    assert_eq!(VerifiedIndex::open(&index).unwrap().document_count(), 0);
+    assert_eq!(
+        VerifiedIndex::open_pinned(&index).unwrap().document_count(),
+        0
+    );
 }
 
 #[test]

--- a/crates/ctx-history-capture-composition/src/source_backed/registration/families/jsonl/codex/prompt_history_lifecycle_tests.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/registration/families/jsonl/codex/prompt_history_lifecycle_tests.rs
@@ -114,7 +114,7 @@ fn active_source_family_contract_prompt_history_rejects_same_content_pathname_re
         SourceBackedSourceFailureClass::SourceChanged
     );
     assert!(refreshed.failed_routes[0].carried_forward);
-    let retained = VerifiedIndex::open(&index_root).unwrap();
+    let retained = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(retained.generation_id(), initial.commit.generation_id);
     assert_eq!(retained.document_count(), 1);
 }
@@ -186,7 +186,7 @@ fn active_source_family_contract_prompt_history_rejects_scanner_leaf_open_same_l
         SourceBackedSourceFailureClass::SourceChanged
     );
     assert!(failed.failed_routes[0].carried_forward);
-    let retained = VerifiedIndex::open(&index_root).unwrap();
+    let retained = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(retained.document_count(), 1);
     assert_eq!(
         complete_lexical_events(&retained, "retained seed", Default::default(), 8).len(),
@@ -249,7 +249,9 @@ fn active_source_family_contract_prompt_history_rejects_inflight_disappearance_t
     );
     assert!(failed.failed_routes[0].carried_forward);
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().document_count(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .document_count(),
         1
     );
 
@@ -262,7 +264,9 @@ fn active_source_family_contract_prompt_history_rejects_inflight_disappearance_t
     );
     assert_ne!(deleted.commit.generation_id, initial.commit.generation_id);
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().document_count(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .document_count(),
         0
     );
 }
@@ -329,7 +333,9 @@ fn active_source_family_contract_prompt_history_defers_live_suffix_exactly_once(
     );
     assert_eq!(deferred.commit.generation_id, cold.commit.generation_id);
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().document_count(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .document_count(),
         1
     );
 
@@ -337,7 +343,9 @@ fn active_source_family_contract_prompt_history_defers_live_suffix_exactly_once(
         refresh_source_backed_generation(&index_root, &registry, WriterOptions::default()).unwrap();
     assert!(caught_up.failed_routes.is_empty());
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().document_count(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .document_count(),
         2
     );
 
@@ -345,7 +353,9 @@ fn active_source_family_contract_prompt_history_defers_live_suffix_exactly_once(
         refresh_source_backed_generation(&index_root, &registry, WriterOptions::default()).unwrap();
     assert_eq!(no_op.commit.generation_id, caught_up.commit.generation_id);
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().document_count(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .document_count(),
         2
     );
 }
@@ -437,7 +447,7 @@ fn active_source_family_contract_prompt_history_preserves_append_noop_rewrite_an
     let cold =
         refresh_source_backed_generation(&index_root, &registry, WriterOptions::default()).unwrap();
     let cold_id = cold.commit.generation_id;
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let one = complete_lexical_events(&index, "one", Default::default(), 8);
     assert_eq!(one.len(), 1);
     let first_event_id = one[0].event.event_id;
@@ -447,7 +457,7 @@ fn active_source_family_contract_prompt_history_preserves_append_noop_rewrite_an
         refresh_source_backed_generation(&index_root, &registry, WriterOptions::default()).unwrap();
     assert_ne!(appended.commit.generation_id, cold_id);
     let appended_id = appended.commit.generation_id;
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(index.document_count(), 2);
     assert_eq!(
         complete_lexical_events(&index, "two", Default::default(), 8).len(),
@@ -466,7 +476,7 @@ fn active_source_family_contract_prompt_history_preserves_append_noop_rewrite_an
         ],
     );
     refresh_source_backed_generation(&index_root, &registry, WriterOptions::default()).unwrap();
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(index.document_count(), 2);
     let rewritten = complete_lexical_events(&index, "rewritten", Default::default(), 8);
     assert_eq!(rewritten.len(), 1);
@@ -477,7 +487,7 @@ fn active_source_family_contract_prompt_history_preserves_append_noop_rewrite_an
     append(&history, &tail);
     refresh_source_backed_generation(&index_root, &registry, WriterOptions::default()).unwrap();
     assert!(complete_lexical_events(
-        &VerifiedIndex::open(&index_root).unwrap(),
+        &VerifiedIndex::open_pinned(&index_root).unwrap(),
         "deferred",
         Default::default(),
         8,
@@ -485,7 +495,7 @@ fn active_source_family_contract_prompt_history_preserves_append_noop_rewrite_an
     .is_empty());
     append(&history, b"\n");
     refresh_source_backed_generation(&index_root, &registry, WriterOptions::default()).unwrap();
-    let index = VerifiedIndex::open(&index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(index.document_count(), 3);
     assert_eq!(
         complete_lexical_events(&index, "deferred", Default::default(), 8).len(),

--- a/crates/ctx-history-capture-composition/src/source_backed/tests/hermes.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/tests/hermes.rs
@@ -147,7 +147,7 @@ fn fixture_registry(data_root: &Path, database: &Path) -> SourceBackedProviderRe
 }
 
 fn unique_search_record(index_root: &Path, needle: &str) -> CoreRecord {
-    let index = VerifiedIndex::open(index_root).unwrap();
+    let index = VerifiedIndex::open_pinned(index_root).unwrap();
     let candidates = complete_lexical_events(&index, needle, Default::default(), 8);
     candidates
         .iter()
@@ -250,7 +250,9 @@ fn incremental_cursor_advances_only_with_successful_core_publication() {
             );
     assert!(failed.is_err());
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().generation_id(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .generation_id(),
         cold.commit.generation_id
     );
 
@@ -299,7 +301,9 @@ fn failed_exhaustive_publication_retains_due_control_and_retry_converges() {
             );
     assert!(failed.is_err());
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().generation_id(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .generation_id(),
         cold.commit.generation_id
     );
     let due = overdue_controls.values().next().unwrap();
@@ -347,7 +351,9 @@ fn hermes_mutation_before_and_after_snapshot_seal_retains_published_generation_a
     )
     .unwrap();
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().generation_id(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .generation_id(),
         cold.commit.generation_id
     );
     assert_eq!(before.failed_routes.len(), 1);
@@ -380,7 +386,9 @@ fn hermes_mutation_before_and_after_snapshot_seal_retains_published_generation_a
     )
     .unwrap();
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().generation_id(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .generation_id(),
         after_before.commit.generation_id
     );
     assert_eq!(after.failed_routes.len(), 1);

--- a/crates/ctx-history-capture-composition/src/source_backed/tests/inventory/astrbot.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/tests/inventory/astrbot.rs
@@ -110,7 +110,7 @@ fn released_astrbot_root_scans_only_its_inventory_and_cannot_absorb_named_peer()
         WriterOptions::default(),
     )
     .unwrap();
-    let published = VerifiedIndex::open(temp.path().join("index")).unwrap();
+    let published = VerifiedIndex::open_pinned(temp.path().join("index")).unwrap();
     for (root, own, peer) in [
         ("first", "astrbotrootalpha", "astrbotrootbeta"),
         ("second", "astrbotrootbeta", "astrbotrootalpha"),

--- a/crates/ctx-history-capture-composition/src/source_backed/tests/registry.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/tests/registry.rs
@@ -366,7 +366,9 @@ fn cold_second_route_failure_after_output_publishes_first_without_partial_record
     assert!(receipt.commit.manifest().source_route(&second_id).is_none());
     assert_eq!(receipt.commit.indexed_documents, 1);
     assert_eq!(
-        VerifiedIndex::open(temp.path()).unwrap().document_count(),
+        VerifiedIndex::open_pinned(temp.path())
+            .unwrap()
+            .document_count(),
         1
     );
     assert_eq!(
@@ -580,7 +582,7 @@ fn internal_route_failure_aborts_the_whole_cold_refresh() {
         })
     ));
     assert!(matches!(
-        VerifiedIndex::open(temp.path()),
+        VerifiedIndex::open_pinned(temp.path()),
         Err(IndexError::MissingActiveGenerationPointer)
     ));
     assert_eq!(
@@ -684,7 +686,7 @@ fn real_shared_resource_exhaustion_aborts_warm_refresh_and_retains_complete_prio
         }
     ));
 
-    let retained = VerifiedIndex::open(temp.path()).unwrap();
+    let retained = VerifiedIndex::open_pinned(temp.path()).unwrap();
     assert_eq!(retained.generation_id(), initial_generation);
     assert_eq!(retained.document_count(), 2);
     assert_eq!(retained.manifest().sources, initial_sources);
@@ -909,7 +911,7 @@ fn cold_refresh_with_only_failed_routes_does_not_publish_ready_data() {
                 && failed_routes[0].class == SourceBackedSourceFailureClass::Unavailable
     ));
     assert!(matches!(
-        VerifiedIndex::open(temp.path()),
+        VerifiedIndex::open_pinned(temp.path()),
         Err(IndexError::MissingActiveGenerationPointer)
     ));
 }

--- a/crates/ctx-history-capture-composition/src/source_backed/tests/registry/inventory_replay.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/tests/registry/inventory_replay.rs
@@ -284,7 +284,7 @@ fn unsupported_detected_format_stays_typed_and_never_executes() {
     assert_eq!(receipt.unsupported_routes.len(), 1);
     assert!(receipt.sources.is_empty());
     assert!(receipt.removals.is_empty());
-    assert!(VerifiedIndex::open(temp.path())
+    assert!(VerifiedIndex::open_pinned(temp.path())
         .unwrap()
         .manifest()
         .sources

--- a/crates/ctx-history-capture-composition/src/source_backed/tests/registry/progress.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/tests/registry/progress.rs
@@ -74,7 +74,9 @@ fn committed_progress_failure_does_not_hide_visible_publication() {
 
     assert_eq!(receipt.sources, vec![certificate]);
     assert_eq!(
-        VerifiedIndex::open(temp.path()).unwrap().generation_id(),
+        VerifiedIndex::open_pinned(temp.path())
+            .unwrap()
+            .generation_id(),
         receipt.commit.generation_id
     );
 }
@@ -146,7 +148,7 @@ fn committing_progress_failure_prevents_publication() {
         SourceBackedCoordinatorError::Progress(SourceBackedRouteError { detail, .. })
             if detail == "injected committing status failure"
     ));
-    assert!(VerifiedIndex::open(temp.path()).is_err());
+    assert!(VerifiedIndex::open_pinned(temp.path()).is_err());
 }
 
 #[test]
@@ -245,5 +247,5 @@ fn accepted_record_progress_failure_stays_typed_and_prevents_publication() {
         SourceBackedCoordinatorError::Progress(SourceBackedRouteError { detail, .. })
             if detail == "injected source-record progress failure"
     ));
-    assert!(VerifiedIndex::open(temp.path()).is_err());
+    assert!(VerifiedIndex::open_pinned(temp.path()).is_err());
 }

--- a/crates/ctx-history-index-format/src/lib.rs
+++ b/crates/ctx-history-index-format/src/lib.rs
@@ -92,11 +92,11 @@ pub use stored_document::{
 pub use verification::{
     load_active_publication_authority, open_pinned_publication, open_publication_candidate,
     verify_and_bind_publication_candidate, verify_and_bind_publication_candidate_with_progress,
-    verify_and_bind_reusable_publication, verify_complete_searcher,
-    verify_pinned_publication_authority, verify_publication_candidate, verify_searcher,
-    verify_searcher_structure, ActivePublicationAuthority, CandidatePublicationVerificationError,
-    EmptyPublicationIndex, OpenedPinnedPublication, OpenedPublicationCandidate, PinnedPublication,
-    ReusablePublicationError, VerifiedCandidatePublication, VerifiedPublication,
+    verify_and_bind_reusable_publication, verify_pinned_publication_authority,
+    verify_publication_candidate, verify_searcher_structure, ActivePublicationAuthority,
+    CandidatePublicationVerificationError, EmptyPublicationIndex, OpenedPinnedPublication,
+    OpenedPublicationCandidate, PinnedPublication, ReusablePublicationError,
+    VerifiedCandidatePublication, VerifiedPublication,
 };
 #[doc(hidden)]
 pub use verification_record::{
@@ -118,5 +118,6 @@ pub use ctx_history_index_generation::{
 pub use verification::{
     candidate_identity_verification_activity, candidate_lineage_verification_activity,
     candidate_projection_verification_activity, complete_session_id_traversals,
-    reset_verification_activity, verification_activity, verify_searcher_with_metrics,
+    reset_verification_activity, verification_activity, verify_searcher,
+    verify_searcher_with_metrics,
 };

--- a/crates/ctx-history-index-format/src/verification.rs
+++ b/crates/ctx-history-index-format/src/verification.rs
@@ -1,61 +1,75 @@
-// Explicit scrub and legacy test-support helpers remain available even when
-// the production candidate path no longer calls their incremental replay code.
+// Qualification-only deep verification retains a few focused helper paths
+// that are intentionally not part of the production publication verifier.
 #![allow(dead_code)]
 
+use std::{collections::HashSet, path::Path, sync::Arc};
+
+#[cfg(any(test, feature = "test-support"))]
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    path::Path,
+    collections::{BTreeMap, HashMap},
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc, Barrier,
+        Barrier,
     },
 };
 
 use ctx_history_index_generation::{
     lexical_index_settings, load_active_generation_pointer, DurableMmapDirectory,
 };
-use sha2::{Digest, Sha256};
 use tantivy::{
-    postings::Postings,
-    schema::{Field, IndexRecordOption},
-    termdict::TermMerger,
-    tokenizer::TokenStream,
-    DocAddress, DocSet, Executor, Index, InvertedIndexReader, ReloadPolicy, Searcher, Term,
-    TERMINATED,
+    schema::Field, termdict::TermMerger, DocAddress, Index, InvertedIndexReader, ReloadPolicy,
+    Searcher,
 };
 use uuid::Uuid;
 
 #[cfg(any(test, feature = "test-support"))]
+use sha2::{Digest, Sha256};
+#[cfg(any(test, feature = "test-support"))]
 use std::cell::Cell;
+#[cfg(any(test, feature = "test-support"))]
+use tantivy::{
+    postings::Postings, schema::IndexRecordOption, tokenizer::TokenStream, DocSet, Executor, Term,
+    TERMINATED,
+};
 
+#[cfg(any(test, feature = "test-support"))]
 use crate::{
-    accumulate_core_record, core_record_accumulator_leaf, fields_from_schema, hex,
-    load_publication_for_metas, meta_generation, open_slot_index, searcher_generation,
-    stored_verification_record, validate_schema, validate_verification_projection,
-    verify_certified_physical_integrity, verify_or_certify_physical_integrity,
-    ActiveGenerationPointer, CandidatePhysicalProof, CertifiedPhysicalIntegrity, CompactIdentity,
-    Fields, GenerationManifest, GenerationSlot, IdentityFieldRole, IndexError, LoadedPublication,
-    PhysicalIntegrityAudit, Result, SessionAuthorityKey, SourceCoreRecordAggregate,
+    accumulate_core_record, core_record_accumulator_leaf, hex, stored_verification_record,
+    validate_verification_projection, CompactIdentity, IdentityFieldRole, SessionAuthorityKey,
     VerificationRecord,
+};
+use crate::{
+    fields_from_schema, load_publication_for_metas, meta_generation, open_slot_index,
+    searcher_generation, validate_schema, verify_certified_physical_integrity,
+    verify_or_certify_physical_integrity, ActiveGenerationPointer, CandidatePhysicalProof,
+    CertifiedPhysicalIntegrity, Fields, GenerationManifest, GenerationSlot, IndexError,
+    LoadedPublication, PhysicalIntegrityAudit, Result, SourceCoreRecordAggregate,
 };
 use ctx_history_core::CertifiedSource;
 
-use super::{physical_integrity_audit_with_candidate_proof, verify_physical_integrity};
+use super::physical_integrity_audit_with_candidate_proof;
 
+mod postings;
+mod scratch;
+#[cfg(any(test, feature = "test-support"))]
 mod spill;
 
+use postings::{canonical_uuid_term, for_each_live_posting};
+use scratch::{reserve_verification_scratch, with_verification_scratch_budget, ScratchReservation};
+#[cfg(any(test, feature = "test-support"))]
 use spill::{
-    reserve_verification_scratch, with_verification_scratch_budget, ProjectionAccumulator,
-    ProjectionDeltas, ScratchReservation, SpillVerificationIdentities, VerificationSpill,
+    ProjectionAccumulator, ProjectionDeltas, SpillVerificationIdentities, VerificationSpill,
     VERIFICATION_SPILL_BUFFER_BYTES, VERIFICATION_SPILL_RECORD_BYTES,
 };
 
+#[cfg(any(test, feature = "test-support"))]
 #[derive(Default)]
 struct SourceAggregate {
     count: u64,
     accumulator: [u8; 32],
 }
 
+#[cfg(any(test, feature = "test-support"))]
 struct SegmentVerification {
     document_count: u64,
     document_decodes: usize,
@@ -66,6 +80,7 @@ struct SegmentVerification {
     root_session_documents: u64,
 }
 
+#[cfg(any(test, feature = "test-support"))]
 #[derive(Clone, Copy)]
 struct SegmentVerificationTask {
     segment_ord: usize,
@@ -73,16 +88,19 @@ struct SegmentVerificationTask {
     end_doc_id: u32,
 }
 
+#[cfg(any(test, feature = "test-support"))]
 #[derive(Default)]
 struct VerificationCounters {
     active_workers: AtomicUsize,
     max_active_workers: AtomicUsize,
 }
 
+#[cfg(any(test, feature = "test-support"))]
 struct ActiveVerificationWorker<'a> {
     counters: Option<&'a VerificationCounters>,
 }
 
+#[cfg(any(test, feature = "test-support"))]
 impl<'a> ActiveVerificationWorker<'a> {
     fn enter(counters: Option<&'a VerificationCounters>) -> Self {
         if let Some(counters) = counters {
@@ -95,6 +113,7 @@ impl<'a> ActiveVerificationWorker<'a> {
     }
 }
 
+#[cfg(any(test, feature = "test-support"))]
 impl Drop for ActiveVerificationWorker<'_> {
     fn drop(&mut self) {
         if let Some(counters) = self.counters {
@@ -103,6 +122,7 @@ impl Drop for ActiveVerificationWorker<'_> {
     }
 }
 
+#[cfg(any(test, feature = "test-support"))]
 #[derive(Default)]
 struct VerificationRunMetrics {
     #[cfg(any(test, feature = "test-support"))]
@@ -143,6 +163,7 @@ pub fn verify_searcher_structure(searcher: &Searcher, manifest: &GenerationManif
     Ok(())
 }
 
+#[cfg(any(test, feature = "test-support"))]
 pub fn verify_searcher(searcher: &Searcher, manifest: &GenerationManifest) -> Result<()> {
     let worker_budget = verification_worker_budget(searcher.num_docs());
     verify_searcher_with_options(searcher, manifest, worker_budget, false, false).map(|_| ())
@@ -571,23 +592,7 @@ pub fn verify_and_bind_reusable_publication(
     })
 }
 
-/// Verifies the complete publication authority carried by one immutable searcher.
-pub fn verify_complete_searcher(
-    searcher: &Searcher,
-    manifest: &GenerationManifest,
-    generation_path: &Path,
-    topology_authority: Option<&ActiveGenerationPointer>,
-    expected_physical_integrity_digest: &str,
-) -> Result<()> {
-    verify_physical_integrity(
-        searcher.index(),
-        generation_path,
-        topology_authority,
-        expected_physical_integrity_digest,
-    )?;
-    verify_searcher(searcher, manifest)
-}
-
+#[cfg(any(test, feature = "test-support"))]
 const MAX_VERIFICATION_WORKERS: usize = 24;
 
 /// Verifies the compact logical invariants required to publish a writer candidate.
@@ -598,7 +603,8 @@ const MAX_VERIFICATION_WORKERS: usize = 24;
 /// segments to reject a duplicate retained identity. Retained segments are
 /// trusted through the separately revalidated base authority. This path never
 /// decodes stored Core or replays query, source, session, or lineage projections;
-/// [`verify_searcher`] retains that exhaustive behavior for explicit scrubbing.
+/// Test and qualification builds retain exhaustive stored-Core verification as
+/// a separate oracle; it is not compiled into production libraries.
 pub fn verify_publication_candidate(
     searcher: &Searcher,
     manifest: &GenerationManifest,
@@ -840,6 +846,7 @@ pub fn note_candidate_lineage_spill() {
 #[cfg(not(any(test, feature = "test-support")))]
 pub fn note_candidate_lineage_spill() {}
 
+#[cfg(any(test, feature = "test-support"))]
 fn verification_worker_budget(document_count: u64) -> usize {
     let available = std::thread::available_parallelism()
         .map(usize::from)
@@ -874,6 +881,7 @@ fn verification_tasks_split_large_segments_into_contiguous_bounded_ranges() {
 #[cfg(test)]
 mod candidate_identity_tests;
 
+#[cfg(any(test, feature = "test-support"))]
 include!("verification/logical.rs");
 
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/ctx-history-index-format/src/verification/logical.rs
+++ b/crates/ctx-history-index-format/src/verification/logical.rs
@@ -881,8 +881,8 @@ fn verify_manifest_aggregates(
 
 mod logical_identity;
 use logical_identity::{
-    canonical_uuid_term, for_each_live_posting, relationship_kind_tag, verify_event_identities,
-    verify_session_identities, verify_session_witness_key,
+    relationship_kind_tag, verify_event_identities, verify_session_identities,
+    verify_session_witness_key,
 };
 
 #[cfg(test)]

--- a/crates/ctx-history-index-format/src/verification/logical_identity.rs
+++ b/crates/ctx-history-index-format/src/verification/logical_identity.rs
@@ -267,35 +267,6 @@ fn identity_for_role(
     }
 }
 
-pub(super) fn for_each_live_posting(
-    inverted: &InvertedIndexReader,
-    term_info: &tantivy::postings::TermInfo,
-    segment_ord: usize,
-    segment: &tantivy::SegmentReader,
-    mut visit: impl FnMut(DocAddress) -> Result<()>,
-) -> Result<()> {
-    let mut postings = inverted.read_postings_from_terminfo(term_info, IndexRecordOption::Basic)?;
-    let segment_ord = u32::try_from(segment_ord).map_err(|_| IndexError::CountOverflow)?;
-    let mut doc_id = postings.doc();
-    while doc_id != TERMINATED {
-        if !segment.is_deleted(doc_id) {
-            visit(DocAddress::new(segment_ord, doc_id))?;
-        }
-        doc_id = postings.advance();
-    }
-    Ok(())
-}
-
-pub(super) fn canonical_uuid_term(term: &[u8], field: &'static str) -> Result<Uuid> {
-    let term =
-        std::str::from_utf8(term).map_err(|_| IndexError::InvalidStoredDocumentField(field))?;
-    let uuid = Uuid::parse_str(term).map_err(|_| IndexError::InvalidStoredDocumentField(field))?;
-    if uuid.to_string() != term {
-        return Err(IndexError::InvalidStoredDocumentField(field));
-    }
-    Ok(uuid)
-}
-
 #[cfg(test)]
 mod tests {
     use ctx_history_core::{

--- a/crates/ctx-history-index-format/src/verification/postings.rs
+++ b/crates/ctx-history-index-format/src/verification/postings.rs
@@ -1,0 +1,36 @@
+use tantivy::{
+    postings::TermInfo, schema::IndexRecordOption, DocAddress, DocSet, InvertedIndexReader,
+    SegmentReader, TERMINATED,
+};
+use uuid::Uuid;
+
+use crate::{IndexError, Result};
+
+pub(super) fn for_each_live_posting(
+    inverted: &InvertedIndexReader,
+    term_info: &TermInfo,
+    segment_ord: usize,
+    segment: &SegmentReader,
+    mut visit: impl FnMut(DocAddress) -> Result<()>,
+) -> Result<()> {
+    let mut postings = inverted.read_postings_from_terminfo(term_info, IndexRecordOption::Basic)?;
+    let segment_ord = u32::try_from(segment_ord).map_err(|_| IndexError::CountOverflow)?;
+    let mut doc_id = postings.doc();
+    while doc_id != TERMINATED {
+        if !segment.is_deleted(doc_id) {
+            visit(DocAddress::new(segment_ord, doc_id))?;
+        }
+        doc_id = postings.advance();
+    }
+    Ok(())
+}
+
+pub(super) fn canonical_uuid_term(term: &[u8], field: &'static str) -> Result<Uuid> {
+    let term =
+        std::str::from_utf8(term).map_err(|_| IndexError::InvalidStoredDocumentField(field))?;
+    let uuid = Uuid::parse_str(term).map_err(|_| IndexError::InvalidStoredDocumentField(field))?;
+    if uuid.to_string() != term {
+        return Err(IndexError::InvalidStoredDocumentField(field));
+    }
+    Ok(uuid)
+}

--- a/crates/ctx-history-index-format/src/verification/scratch.rs
+++ b/crates/ctx-history-index-format/src/verification/scratch.rs
@@ -1,0 +1,157 @@
+use std::{
+    cell::RefCell,
+    sync::{Arc, Mutex},
+};
+
+use crate::{IndexError, Result};
+
+// The candidate verifier needs only bounded heap scratch. Test and
+// qualification builds additionally use the disk allowance for the exhaustive
+// logical verifier's spill files.
+const MAX_VERIFICATION_SCRATCH_DISK_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+pub(super) const MAX_VERIFICATION_SCRATCH_HEAP_BYTES: u64 = 16 * 1024 * 1024;
+
+thread_local! {
+    static ACTIVE_SCRATCH_BUDGET: RefCell<Option<VerificationScratchBudget>> = const { RefCell::new(None) };
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct VerificationScratchBudget {
+    state: Arc<Mutex<ScratchUsage>>,
+    maximum_disk_bytes: u64,
+    maximum_heap_bytes: u64,
+}
+
+#[derive(Debug, Default)]
+struct ScratchUsage {
+    disk_bytes: u64,
+    heap_bytes: u64,
+}
+
+#[derive(Debug)]
+pub(super) struct ScratchReservation {
+    pub(super) budget: VerificationScratchBudget,
+    disk_bytes: u64,
+    heap_bytes: u64,
+}
+
+struct ActiveScratchGuard;
+
+impl VerificationScratchBudget {
+    pub(super) fn production() -> Self {
+        Self::with_limits(
+            MAX_VERIFICATION_SCRATCH_DISK_BYTES,
+            MAX_VERIFICATION_SCRATCH_HEAP_BYTES,
+        )
+    }
+
+    pub(super) fn with_limits(maximum_disk_bytes: u64, maximum_heap_bytes: u64) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(ScratchUsage::default())),
+            maximum_disk_bytes,
+            maximum_heap_bytes,
+        }
+    }
+
+    pub(super) fn reserve(&self, disk_bytes: u64, heap_bytes: u64) -> Result<ScratchReservation> {
+        let mut usage = self.state.lock().map_err(|_| {
+            IndexError::WriterInvariant("verification scratch budget lock poisoned")
+        })?;
+        let required_disk_bytes = usage
+            .disk_bytes
+            .checked_add(disk_bytes)
+            .ok_or(IndexError::CountOverflow)?;
+        if required_disk_bytes > self.maximum_disk_bytes {
+            return Err(IndexError::VerificationScratchLimitExceeded {
+                required_bytes: required_disk_bytes,
+                maximum_bytes: self.maximum_disk_bytes,
+            });
+        }
+        let required_heap_bytes = usage
+            .heap_bytes
+            .checked_add(heap_bytes)
+            .ok_or(IndexError::CountOverflow)?;
+        if required_heap_bytes > self.maximum_heap_bytes {
+            return Err(IndexError::VerificationScratchLimitExceeded {
+                required_bytes: required_heap_bytes,
+                maximum_bytes: self.maximum_heap_bytes,
+            });
+        }
+        usage.disk_bytes = required_disk_bytes;
+        usage.heap_bytes = required_heap_bytes;
+        drop(usage);
+        Ok(ScratchReservation {
+            budget: self.clone(),
+            disk_bytes,
+            heap_bytes,
+        })
+    }
+}
+
+impl ScratchReservation {
+    pub(super) fn absorb(&mut self, mut other: Self) -> Result<()> {
+        if !Arc::ptr_eq(&self.budget.state, &other.budget.state) {
+            return Err(IndexError::WriterInvariant(
+                "verification scratch reservation budget changed",
+            ));
+        }
+        self.disk_bytes = self
+            .disk_bytes
+            .checked_add(other.disk_bytes)
+            .ok_or(IndexError::CountOverflow)?;
+        self.heap_bytes = self
+            .heap_bytes
+            .checked_add(other.heap_bytes)
+            .ok_or(IndexError::CountOverflow)?;
+        other.disk_bytes = 0;
+        other.heap_bytes = 0;
+        Ok(())
+    }
+}
+
+impl Drop for ScratchReservation {
+    fn drop(&mut self) {
+        let mut usage = self
+            .budget
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        usage.disk_bytes = usage.disk_bytes.saturating_sub(self.disk_bytes);
+        usage.heap_bytes = usage.heap_bytes.saturating_sub(self.heap_bytes);
+    }
+}
+
+impl Drop for ActiveScratchGuard {
+    fn drop(&mut self) {
+        ACTIVE_SCRATCH_BUDGET.with(|active| {
+            active.borrow_mut().take();
+        });
+    }
+}
+
+pub(super) fn with_verification_scratch_budget<T>(verify: impl FnOnce() -> Result<T>) -> Result<T> {
+    let installed = ACTIVE_SCRATCH_BUDGET.with(|active| {
+        let mut active = active.borrow_mut();
+        if active.is_some() {
+            false
+        } else {
+            *active = Some(VerificationScratchBudget::production());
+            true
+        }
+    });
+    let _guard = installed.then_some(ActiveScratchGuard);
+    verify()
+}
+
+pub(super) fn active_scratch_budget() -> VerificationScratchBudget {
+    ACTIVE_SCRATCH_BUDGET
+        .with(|active| active.borrow().clone())
+        .unwrap_or_else(VerificationScratchBudget::production)
+}
+
+pub(super) fn reserve_verification_scratch(
+    disk_bytes: u64,
+    heap_bytes: u64,
+) -> Result<ScratchReservation> {
+    active_scratch_budget().reserve(disk_bytes, heap_bytes)
+}

--- a/crates/ctx-history-index-format/src/verification/spill.rs
+++ b/crates/ctx-history-index-format/src/verification/spill.rs
@@ -1,15 +1,17 @@
 use std::{
-    cell::RefCell,
     cmp::Reverse,
     collections::BinaryHeap,
     fs::File,
     io::{BufWriter, Write},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 use memmap2::{MmapMut, MmapOptions};
 use tantivy::DocAddress;
 
+use super::scratch::{active_scratch_budget, ScratchReservation};
+#[cfg(test)]
+use super::scratch::{VerificationScratchBudget, MAX_VERIFICATION_SCRATCH_HEAP_BYTES};
 use crate::{CompactIdentity, IndexError, Result};
 
 pub(super) const VERIFICATION_SPILL_BUFFER_BYTES: usize = 8 * 1024;
@@ -20,161 +22,10 @@ const QUERY_PROJECTION_ACCUMULATOR_BYTES: usize = 32;
 pub(super) const VERIFICATION_SPILL_RECORD_BYTES: usize =
     IDENTITY_SPILL_RECORD_BYTES + QUERY_PROJECTION_ACCUMULATOR_BYTES;
 const MAX_VERIFICATION_LAYOUT_HEAP_BYTES: usize = 16 * 1024 * 1024;
-// The production corpus contract admits at least 12 million records. Sixteen
-// GiB covers their complete logical spill plus the simultaneous incremental
-// changed/retired/key/sort-run envelope while remaining an explicit fail-closed
-// ceiling for malicious candidates.
-const MAX_VERIFICATION_SCRATCH_DISK_BYTES: u64 = 16 * 1024 * 1024 * 1024;
-const MAX_VERIFICATION_SCRATCH_HEAP_BYTES: u64 = 16 * 1024 * 1024;
 const IDENTITY_SORT_RUN_RECORDS: usize = 4_096;
 
 type IdentitySortRun = (u64, usize);
 type IdentitySortHeapEntry = Reverse<([u8; COMPACT_IDENTITY_BYTES], usize)>;
-
-thread_local! {
-    static ACTIVE_SCRATCH_BUDGET: RefCell<Option<VerificationScratchBudget>> = const { RefCell::new(None) };
-}
-
-#[derive(Clone, Debug)]
-pub(super) struct VerificationScratchBudget {
-    state: Arc<Mutex<ScratchUsage>>,
-    maximum_disk_bytes: u64,
-    maximum_heap_bytes: u64,
-}
-
-#[derive(Debug, Default)]
-struct ScratchUsage {
-    disk_bytes: u64,
-    heap_bytes: u64,
-}
-
-#[derive(Debug)]
-pub(super) struct ScratchReservation {
-    budget: VerificationScratchBudget,
-    disk_bytes: u64,
-    heap_bytes: u64,
-}
-
-struct ActiveScratchGuard;
-
-impl VerificationScratchBudget {
-    fn production() -> Self {
-        Self::with_limits(
-            MAX_VERIFICATION_SCRATCH_DISK_BYTES,
-            MAX_VERIFICATION_SCRATCH_HEAP_BYTES,
-        )
-    }
-
-    fn with_limits(maximum_disk_bytes: u64, maximum_heap_bytes: u64) -> Self {
-        Self {
-            state: Arc::new(Mutex::new(ScratchUsage::default())),
-            maximum_disk_bytes,
-            maximum_heap_bytes,
-        }
-    }
-
-    fn reserve(&self, disk_bytes: u64, heap_bytes: u64) -> Result<ScratchReservation> {
-        let mut usage = self.state.lock().map_err(|_| {
-            IndexError::WriterInvariant("verification scratch budget lock poisoned")
-        })?;
-        let required_disk_bytes = usage
-            .disk_bytes
-            .checked_add(disk_bytes)
-            .ok_or(IndexError::CountOverflow)?;
-        if required_disk_bytes > self.maximum_disk_bytes {
-            return Err(IndexError::VerificationScratchLimitExceeded {
-                required_bytes: required_disk_bytes,
-                maximum_bytes: self.maximum_disk_bytes,
-            });
-        }
-        let required_heap_bytes = usage
-            .heap_bytes
-            .checked_add(heap_bytes)
-            .ok_or(IndexError::CountOverflow)?;
-        if required_heap_bytes > self.maximum_heap_bytes {
-            return Err(IndexError::VerificationScratchLimitExceeded {
-                required_bytes: required_heap_bytes,
-                maximum_bytes: self.maximum_heap_bytes,
-            });
-        }
-        usage.disk_bytes = required_disk_bytes;
-        usage.heap_bytes = required_heap_bytes;
-        drop(usage);
-        Ok(ScratchReservation {
-            budget: self.clone(),
-            disk_bytes,
-            heap_bytes,
-        })
-    }
-}
-
-impl ScratchReservation {
-    fn absorb(&mut self, mut other: Self) -> Result<()> {
-        if !Arc::ptr_eq(&self.budget.state, &other.budget.state) {
-            return Err(IndexError::WriterInvariant(
-                "verification scratch reservation budget changed",
-            ));
-        }
-        self.disk_bytes = self
-            .disk_bytes
-            .checked_add(other.disk_bytes)
-            .ok_or(IndexError::CountOverflow)?;
-        self.heap_bytes = self
-            .heap_bytes
-            .checked_add(other.heap_bytes)
-            .ok_or(IndexError::CountOverflow)?;
-        other.disk_bytes = 0;
-        other.heap_bytes = 0;
-        Ok(())
-    }
-}
-
-impl Drop for ScratchReservation {
-    fn drop(&mut self) {
-        let mut usage = self
-            .budget
-            .state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        usage.disk_bytes = usage.disk_bytes.saturating_sub(self.disk_bytes);
-        usage.heap_bytes = usage.heap_bytes.saturating_sub(self.heap_bytes);
-    }
-}
-
-impl Drop for ActiveScratchGuard {
-    fn drop(&mut self) {
-        ACTIVE_SCRATCH_BUDGET.with(|active| {
-            active.borrow_mut().take();
-        });
-    }
-}
-
-pub(super) fn with_verification_scratch_budget<T>(verify: impl FnOnce() -> Result<T>) -> Result<T> {
-    let installed = ACTIVE_SCRATCH_BUDGET.with(|active| {
-        let mut active = active.borrow_mut();
-        if active.is_some() {
-            false
-        } else {
-            *active = Some(VerificationScratchBudget::production());
-            true
-        }
-    });
-    let _guard = installed.then_some(ActiveScratchGuard);
-    verify()
-}
-
-fn active_scratch_budget() -> VerificationScratchBudget {
-    ACTIVE_SCRATCH_BUDGET
-        .with(|active| active.borrow().clone())
-        .unwrap_or_else(VerificationScratchBudget::production)
-}
-
-pub(super) fn reserve_verification_scratch(
-    disk_bytes: u64,
-    heap_bytes: u64,
-) -> Result<ScratchReservation> {
-    active_scratch_budget().reserve(disk_bytes, heap_bytes)
-}
 
 #[derive(Debug, Clone, Copy, Default)]
 pub(super) struct ProjectionAccumulator([u8; QUERY_PROJECTION_ACCUMULATOR_BYTES]);

--- a/crates/ctx-history-index-qualification/tests/source_backed_recovery.rs
+++ b/crates/ctx-history-index-qualification/tests/source_backed_recovery.rs
@@ -84,7 +84,7 @@ fn subprocess_generation_worker() {
 #[test]
 fn process_death_before_commit_preserves_and_can_advance_the_previous_generation() {
     let fixture = RecoveryFixture::new();
-    let old_reader = VerifiedIndex::open(&fixture.root).unwrap();
+    let old_reader = VerifiedIndex::open_pinned(&fixture.root).unwrap();
     let mut child = fixture.spawn_stopped_child("pause_before_commit", None);
     fixture.kill_at_marker(&mut child);
 
@@ -108,7 +108,7 @@ fn process_death_before_commit_preserves_and_can_advance_the_previous_generation
 #[test]
 fn process_death_after_commit_keeps_new_visibility_and_old_reader_pinning() {
     let fixture = RecoveryFixture::new();
-    let old_reader = VerifiedIndex::open(&fixture.root).unwrap();
+    let old_reader = VerifiedIndex::open_pinned(&fixture.root).unwrap();
     let mut child = fixture.spawn_stopped_child("pause_after_commit", None);
     fixture.kill_at_marker(&mut child);
 
@@ -139,7 +139,7 @@ fn version_one_pointer_refresh_rebuilds_atomically_without_compatibility_reading
     fs::write(&pointer_path, &version_one_pointer).unwrap();
 
     assert!(matches!(
-        VerifiedIndex::open(&fixture.root),
+        VerifiedIndex::open_pinned(&fixture.root),
         Err(IndexError::UnsupportedActiveGenerationPointer(1))
     ));
 
@@ -156,7 +156,7 @@ fn version_one_pointer_refresh_rebuilds_atomically_without_compatibility_reading
         .unwrap()
         .is_empty());
     assert!(matches!(
-        VerifiedIndex::open(&fixture.root),
+        VerifiedIndex::open_pinned(&fixture.root),
         Err(IndexError::UnsupportedActiveGenerationPointer(1))
     ));
 
@@ -296,7 +296,7 @@ fn torn_manifest_and_meta_fail_closed_without_damaging_the_previous_root() {
         .join(format!("{}.json", fixture.baseline.generation_id));
     fs::write(manifest_path, b"{\"manifest_version\":1").unwrap();
     assert!(
-        VerifiedIndex::open(&manifest_copy).is_err(),
+        VerifiedIndex::open_pinned(&manifest_copy).is_err(),
         "torn manifest was accepted"
     );
 
@@ -306,7 +306,7 @@ fn torn_manifest_and_meta_fail_closed_without_damaging_the_previous_root() {
     )
     .unwrap();
     assert!(
-        VerifiedIndex::open(&meta_copy).is_err(),
+        VerifiedIndex::open_pinned(&meta_copy).is_err(),
         "torn meta.json was accepted"
     );
 
@@ -325,14 +325,14 @@ fn active_segment_corruption_is_detected_and_rebuild_is_deterministic() {
     let rebuild_root = fixture.temp.path().join("rebuild");
     copy_tree(&fixture.root, &corrupt_copy);
 
-    assert!(VerifiedIndex::open(&corrupt_copy)
+    assert!(VerifiedIndex::open_pinned(&corrupt_copy)
         .unwrap()
         .validate_checksums()
         .unwrap()
         .is_empty());
     let damaged_path = corrupt_active_store(&corrupt_copy);
     assert!(
-        VerifiedIndex::open(&corrupt_copy).is_err(),
+        VerifiedIndex::open_pinned(&corrupt_copy).is_err(),
         "verified open admitted a malformed active document"
     );
     let damaged = Index::open_in_dir(active_generation_path(&corrupt_copy))
@@ -377,7 +377,7 @@ fn incompatible_zstd_generation_rebuilds_from_sources_without_cloning_the_slot()
     meta["index_settings"]["docstore_blocksize"] = serde_json::Value::from(64 * 1024);
     fs::write(&meta_path, serde_json::to_vec(&meta).unwrap()).unwrap();
     assert!(matches!(
-        VerifiedIndex::open(&fixture.root),
+        VerifiedIndex::open_pinned(&fixture.root),
         Err(IndexError::IndexSettingsMismatch(_))
     ));
 
@@ -496,7 +496,7 @@ fn inactive_generation_and_atomic_pointer_process_death_matrix() {
 fn retry_after_pre_pointer_crash_reclaims_inactive_generation() {
     let shim = required_fault_shim();
     let fixture = RecoveryFixture::new();
-    let pinned_reader = VerifiedIndex::open(&fixture.root).unwrap();
+    let pinned_reader = VerifiedIndex::open_pinned(&fixture.root).unwrap();
     let case = FaultCase::stop(
         "rename",
         "pointer_final",
@@ -938,7 +938,7 @@ fn run_stopped_fault_case(shim: &Path, case: FaultCase) {
         "fault case {case:?}; baseline generation {}",
         fixture.baseline.generation_id
     );
-    let old_reader = VerifiedIndex::open(&fixture.root).unwrap();
+    let old_reader = VerifiedIndex::open_pinned(&fixture.root).unwrap();
     let mut child = fixture.spawn_stopped_child("commit", Some((shim, case)));
     fixture.kill_at_marker(&mut child);
 
@@ -950,7 +950,7 @@ fn run_stopped_fault_case(shim: &Path, case: FaultCase) {
             "candidate",
         ),
         Visibility::New => {
-            let current = VerifiedIndex::open(&fixture.root).unwrap();
+            let current = VerifiedIndex::open_pinned(&fixture.root).unwrap();
             assert_ne!(current.generation_id(), fixture.baseline.generation_id);
             assert_reader_terms(&current, "candidate", "previous");
         }
@@ -1251,7 +1251,7 @@ fn document(source: &SourceKey, body: &str) -> CoreRecord {
 }
 
 fn assert_generation(root: &Path, generation_id: &str, present: &str, absent: &str) {
-    let index = VerifiedIndex::open(root).unwrap();
+    let index = VerifiedIndex::open_pinned(root).unwrap();
     assert_eq!(index.generation_id(), generation_id);
     assert_reader_terms(&index, present, absent);
 }

--- a/crates/ctx-history-index-query/BUILD.bazel
+++ b/crates/ctx-history-index-query/BUILD.bazel
@@ -69,7 +69,7 @@ ctx_rust_test(
     crate_root = "src/lib.rs",
     edition = crate_edition(),
     aliases = aliases(normal_dev = True, proc_macro_dev = True),
-    deps = all_crate_deps(normal = True, normal_dev = True) + QUERY_DEPS,
+    deps = all_crate_deps(normal = True, normal_dev = True) + QUERY_TEST_SUPPORT_DEPS,
     proc_macro_deps = all_crate_deps(proc_macro = True, proc_macro_dev = True),
     rustc_env = COMMON_RUSTC_ENV,
 )

--- a/crates/ctx-history-index-query/Cargo.toml
+++ b/crates/ctx-history-index-query/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 publish = false
 
 [features]
-test-support = []
+test-support = ["ctx-history-index-format/test-support"]
 
 [dependencies]
 ctx-history-core = { path = "../ctx-history-core" }

--- a/crates/ctx-history-index-query/src/reader.rs
+++ b/crates/ctx-history-index-query/src/reader.rs
@@ -7,10 +7,12 @@ use std::{
 use crate::{IndexError, Result};
 use ctx_history_index_format::{
     is_generation_id, load_publication_for_metas, meta_generation, payload_generation_id,
-    register_body_analyzer, scrub_and_certify_physical_integrity, searcher_generation,
-    validate_schema, verify_or_certify_physical_integrity, verify_searcher,
-    verify_searcher_structure, DurableMmapDirectory, GenerationManifest, VerifiedPublication,
+    register_body_analyzer, searcher_generation, validate_schema,
+    verify_or_certify_physical_integrity, verify_searcher_structure, DurableMmapDirectory,
+    GenerationManifest, VerifiedPublication,
 };
+#[cfg(any(test, feature = "test-support"))]
+use ctx_history_index_format::{scrub_and_certify_physical_integrity, verify_searcher};
 use ctx_history_index_generation::{
     load_active_generation_pointer, load_generation_retention_lease, open_slot_index,
     verify_candidate_physical_integrity_read_only, verify_physical_integrity_read_only,
@@ -44,6 +46,14 @@ pub struct VerifiedIndex {
     pub(crate) semantic_eligibility_postings: OnceLock<crate::SemanticEligibilityPostings>,
 }
 
+#[derive(Clone, Copy)]
+enum ReopenPhysicalVerification {
+    VerifyOrCertify,
+    ReadOnly,
+    #[cfg(any(test, feature = "test-support"))]
+    ScrubAndCertify,
+}
+
 impl VerifiedIndex {
     /// Returns the generation named by the validated active pointer, commit
     /// payload, and current Core manifest contract.
@@ -71,17 +81,25 @@ impl VerifiedIndex {
         Ok(Some(publication.generation_id().to_owned()))
     }
 
-    /// Opens a generation, validates its durable physical identity
-    /// certification (rehashing if it is unavailable or stale), and audits
-    /// every stored Core record plus its source and identity aggregates.
+    /// Test and qualification oracle that performs the bounded production open
+    /// and then audits every stored Core record and logical projection.
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn open(root: impl AsRef<Path>) -> Result<Self> {
-        Self::open_inner(root.as_ref(), true, false)
+        let verified = Self::open_pinned(root)?;
+        verify_searcher(&verified.searcher, &verified.manifest)?;
+        Ok(verified)
     }
 
-    /// Forces a complete physical SHA-256/CRC scrub and exhaustive stored-Core
-    /// audit, then refreshes the durable identity certification.
+    /// Test and qualification oracle that forces a complete physical scrub and
+    /// exhaustive logical audit.
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn scrub(root: impl AsRef<Path>) -> Result<Self> {
-        Self::open_inner(root.as_ref(), true, true)
+        let verified =
+            Self::open_inner(root.as_ref(), ReopenPhysicalVerification::ScrubAndCertify)?;
+        verify_searcher(&verified.searcher, &verified.manifest)?;
+        Ok(verified)
     }
 
     /// Opens a previously audited immutable generation for querying.
@@ -93,7 +111,7 @@ impl VerifiedIndex {
     /// publication-time O(document-count) identity audit is not repeated for
     /// current generations.
     pub fn open_pinned(root: impl AsRef<Path>) -> Result<Self> {
-        Self::open_inner(root.as_ref(), false, false)
+        Self::open_inner(root.as_ref(), ReopenPhysicalVerification::VerifyOrCertify)
     }
 
     /// Reopens an exact candidate from durable state before its active-pointer
@@ -184,9 +202,7 @@ impl VerifiedIndex {
             &root,
             &first_pointer,
             lease.target(),
-            false,
-            false,
-            true,
+            ReopenPhysicalVerification::ReadOnly,
             |actual_generation_id| IndexError::PinnedGenerationMismatch {
                 expected_generation_id: lease.generation_id().to_owned(),
                 actual_generation_id,
@@ -202,9 +218,7 @@ impl VerifiedIndex {
             &root,
             &observed_pointer,
             lease.target(),
-            false,
-            false,
-            true,
+            ReopenPhysicalVerification::ReadOnly,
             |actual_generation_id| IndexError::PinnedGenerationMismatch {
                 expected_generation_id: lease.generation_id().to_owned(),
                 actual_generation_id,
@@ -376,9 +390,7 @@ impl VerifiedIndex {
             root,
             pointer,
             peer,
-            false,
-            false,
-            false,
+            ReopenPhysicalVerification::VerifyOrCertify,
             |actual_generation_id| IndexError::PinnedGenerationMismatch {
                 expected_generation_id: expected_peer_generation_id,
                 actual_generation_id,
@@ -419,9 +431,7 @@ impl VerifiedIndex {
             root,
             pointer,
             slot,
-            false,
-            false,
-            false,
+            ReopenPhysicalVerification::VerifyOrCertify,
             |actual_generation_id| IndexError::PinnedGenerationMismatch {
                 expected_generation_id: expected_generation_id.to_owned(),
                 actual_generation_id,
@@ -429,11 +439,7 @@ impl VerifiedIndex {
         )
     }
 
-    fn open_inner(
-        root: &Path,
-        audit_stored_core: bool,
-        force_physical_scrub: bool,
-    ) -> Result<Self> {
+    fn open_inner(root: &Path, physical_verification: ReopenPhysicalVerification) -> Result<Self> {
         if !root.is_dir() {
             return Err(IndexError::MissingActiveGenerationPointer);
         }
@@ -446,9 +452,7 @@ impl VerifiedIndex {
             &root,
             &pointer,
             pointer.active(),
-            audit_stored_core,
-            force_physical_scrub,
-            false,
+            physical_verification,
             |_| IndexError::InvalidActiveGenerationPointer,
         )
     }
@@ -457,9 +461,7 @@ impl VerifiedIndex {
         root: &Path,
         pointer: &ActiveGenerationPointer,
         slot: &GenerationSlot,
-        audit_stored_core: bool,
-        force_physical_scrub: bool,
-        read_only_physical_verification: bool,
+        physical_verification: ReopenPhysicalVerification,
         generation_mismatch: F,
     ) -> Result<Self>
     where
@@ -484,18 +486,19 @@ impl VerifiedIndex {
         if searcher_generation(&searcher) != meta_generation(&metas) {
             return Err(IndexError::ConcurrentGenerationChange);
         }
-        if force_physical_scrub {
-            scrub_and_certify_physical_integrity(root, pointer, slot, &index)?;
-        } else if read_only_physical_verification {
-            verify_physical_integrity_read_only(root, slot, &index)?;
-        } else {
-            verify_or_certify_physical_integrity(root, pointer, slot, &index)?;
+        match physical_verification {
+            ReopenPhysicalVerification::VerifyOrCertify => {
+                verify_or_certify_physical_integrity(root, pointer, slot, &index)?;
+            }
+            ReopenPhysicalVerification::ReadOnly => {
+                verify_physical_integrity_read_only(root, slot, &index)?;
+            }
+            #[cfg(any(test, feature = "test-support"))]
+            ReopenPhysicalVerification::ScrubAndCertify => {
+                scrub_and_certify_physical_integrity(root, pointer, slot, &index)?;
+            }
         }
-        if audit_stored_core {
-            verify_searcher(&searcher, &manifest)?;
-        } else {
-            verify_searcher_structure(&searcher, &manifest)?;
-        }
+        verify_searcher_structure(&searcher, &manifest)?;
         Ok(Self {
             searcher,
             manifest,

--- a/crates/ctx-history-providers-sqlite-logical/tests/bazel/capture_facade_replay.rs
+++ b/crates/ctx-history-providers-sqlite-logical/tests/bazel/capture_facade_replay.rs
@@ -496,7 +496,9 @@ fn assert_opencode_family_changed_wal_capture_then_exact_replay(provider: Captur
         }) if detail == "injected logical SQLite replay progress failure"
     ));
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().generation_id(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .generation_id(),
         changed_generation
     );
 }

--- a/crates/ctx-history-read-application/tests/support/fixtures.rs
+++ b/crates/ctx-history-read-application/tests/support/fixtures.rs
@@ -83,7 +83,7 @@ pub(crate) fn initialize_generation_only_core(data_root: &Path) -> String {
     .into_writer()
     .unwrap();
     let core_receipt = writer.commit(|_| true).unwrap();
-    let verified = VerifiedIndex::open(index_root).unwrap();
+    let verified = VerifiedIndex::open_pinned(index_root).unwrap();
     assert_eq!(verified.generation_id(), core_receipt.generation_id);
     core_receipt.generation_id
 }
@@ -188,7 +188,7 @@ pub(crate) fn write_codex_message_fixture(root: &Path, session_id: &str, message
 }
 
 pub(crate) fn provider_core_records(data_root: &Path, provider: &str) -> Vec<CoreRecord> {
-    let index = VerifiedIndex::open(data_root.join("search/lexical")).unwrap();
+    let index = VerifiedIndex::open_pinned(data_root.join("search/lexical")).unwrap();
     let sources = index
         .manifest()
         .sources

--- a/crates/ctx-history-read-application/tests/support/search_show/pi_flow.rs
+++ b/crates/ctx-history-read-application/tests/support/search_show/pi_flow.rs
@@ -2,7 +2,8 @@ const PI_V9_PARSER_REVISION: &str = "pi-shared-jsonl-v9-omp-title-slot";
 const PI_V10_PARSER_REVISION: &str = "pi-shared-jsonl-v10-child-local-lineage";
 
 fn pi_parser_revision(data_root: &Path) -> String {
-    let index = ctx_history_index::VerifiedIndex::open(data_root.join("search/lexical")).unwrap();
+    let index =
+        ctx_history_index::VerifiedIndex::open_pinned(data_root.join("search/lexical")).unwrap();
     index
         .manifest()
         .sources
@@ -16,7 +17,7 @@ fn pi_parser_revision(data_root: &Path) -> String {
 fn publish_pi_v9_predecessor(data_root: &Path) -> String {
     let index_root = data_root.join("search/lexical");
     let (source, routes, mut certificate) = {
-        let index = ctx_history_index::VerifiedIndex::open(&index_root).unwrap();
+        let index = ctx_history_index::VerifiedIndex::open_pinned(&index_root).unwrap();
         let current = index
             .manifest()
             .sources
@@ -60,7 +61,7 @@ fn publish_pi_v9_predecessor(data_root: &Path) -> String {
     writer.certify_source(legacy_certificate).unwrap();
     let legacy_generation = writer.commit(|_| true).unwrap().generation_id;
 
-    let legacy = ctx_history_index::VerifiedIndex::open(&index_root).unwrap();
+    let legacy = ctx_history_index::VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(legacy.generation_id(), legacy_generation);
     assert!(legacy.publication_metadata().is_none());
     assert_eq!(pi_parser_revision(data_root), PI_V9_PARSER_REVISION);

--- a/crates/ctx-history-refresh-execution/src/tests.rs
+++ b/crates/ctx-history-refresh-execution/src/tests.rs
@@ -28,7 +28,7 @@ impl PublishedSourceBackedStatePort for TestPublishedState {
                 route_controls: BTreeMap::new(),
             });
         }
-        let verified_index = match VerifiedIndex::open(&index_root) {
+        let verified_index = match VerifiedIndex::open_pinned(&index_root) {
             Ok(index) => Some(index),
             Err(IndexError::MissingActiveGenerationPointer) => None,
             Err(error)
@@ -358,6 +358,21 @@ fn publish_pin_source(index_root: &Path, source: SourceKey) -> String {
     writer.commit(|_| true).unwrap().generation_id
 }
 
+#[test]
+fn watch_catalog_reconstruction_uses_bounded_open_and_no_deep_logical_pass() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    let index_root = source_backed_index_root(&data_root);
+    publish_pin_source(&index_root, publication_pin_source_with_anchor(0x99));
+    let (_, _, discovery) = discovery_fixture(&temp.path().join("discovery"));
+
+    // This unit target intentionally depends on the production index library,
+    // where the exhaustive `VerifiedIndex::open` oracle does not exist. The
+    // watch-catalog path therefore cannot compile if it becomes reachable from
+    // a deep logical open again.
+    source_backed_watch_catalog(&data_root, &discovery).unwrap();
+}
+
 fn test_publication(generation_id: impl Into<String>) -> SourceBackedRefreshPublication {
     SourceBackedRefreshPublication {
         route_results: Vec::new(),
@@ -385,7 +400,7 @@ fn test_publication(generation_id: impl Into<String>) -> SourceBackedRefreshPubl
 fn query_readiness_accepts_nonempty_generation_without_metadata() {
     let temp = tempfile::tempdir().unwrap();
     let generation_id = publish_pin_source(temp.path(), publication_pin_source_with_anchor(0x95));
-    let verified = VerifiedIndex::open(temp.path()).unwrap();
+    let verified = VerifiedIndex::open_pinned(temp.path()).unwrap();
 
     assert_eq!(verified.generation_id(), generation_id);
     assert!(verified.publication_metadata().is_none());

--- a/crates/ctx-history-refresh-execution/src/tests/execution_path.rs
+++ b/crates/ctx-history-refresh-execution/src/tests/execution_path.rs
@@ -596,7 +596,7 @@ fn warm_exact_carries_unselected_routes_while_receipt_stays_selected() {
 
     assert_eq!(exact.route_results.len(), 1);
     assert_eq!(exact.route_results[0].route_identity, codex_route.as_str());
-    let published = VerifiedIndex::open(&index_root).unwrap();
+    let published = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(published.manifest().source_route(&codex_route).is_some());
     assert!(published.manifest().source_route(&claude_route).is_some());
 }
@@ -659,7 +659,7 @@ fn disabling_automatic_discovery_stops_selection_without_deleting_retained_histo
     )
     .unwrap();
     assert_eq!(
-        VerifiedIndex::open(&index_root)
+        VerifiedIndex::open_pinned(&index_root)
             .unwrap()
             .manifest()
             .indexed_documents,
@@ -680,7 +680,7 @@ fn disabling_automatic_discovery_stops_selection_without_deleting_retained_histo
     )
     .unwrap();
 
-    let published = VerifiedIndex::open(&index_root).unwrap();
+    let published = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(!published.manifest().automatic_provider_discovery());
     assert!(published.manifest().source_route(&route).is_some());
     assert_eq!(published.manifest().sources.len(), 1);

--- a/crates/ctx-history-refresh-execution/src/tests/execution_path/compound_root_lifecycle.rs
+++ b/crates/ctx-history-refresh-execution/src/tests/execution_path/compound_root_lifecycle.rs
@@ -423,7 +423,7 @@ fn configured_codex_root_keeps_unsafe_static_child_membership_while_peer_advance
         &data_root,
         &index_root,
     );
-    let initial = VerifiedIndex::open(&index_root).unwrap();
+    let initial = VerifiedIndex::open_pinned(&index_root).unwrap();
     let retained_history = stable_source_bytes(&initial, HISTORY_MARKER);
     assert_root_marker(&initial, ROOT_ID, HISTORY_MARKER, 1);
     drop(initial);
@@ -445,7 +445,7 @@ fn configured_codex_root_keeps_unsafe_static_child_membership_while_peer_advance
         &data_root,
         &index_root,
     );
-    let unavailable = VerifiedIndex::open(&index_root).unwrap();
+    let unavailable = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         unavailable
             .complete_lexical_search(SESSION_ADVANCED, 8)
@@ -470,7 +470,7 @@ fn configured_codex_root_keeps_unsafe_static_child_membership_while_peer_advance
         &data_root,
         &index_root,
     );
-    let restarted = VerifiedIndex::open(&index_root).unwrap();
+    let restarted = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         stable_source_bytes(&restarted, HISTORY_MARKER),
         retained_history
@@ -488,7 +488,7 @@ fn configured_codex_root_keeps_unsafe_static_child_membership_while_peer_advance
         &data_root,
         &index_root,
     );
-    let restored = VerifiedIndex::open(&index_root).unwrap();
+    let restored = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         stable_source_bytes(&restored, HISTORY_MARKER),
         retained_history
@@ -516,7 +516,7 @@ fn unavailable_only_released_member_is_carried_while_automatic_peer_advances() {
         let roots = &roots[..1];
 
         refresh(&base, provider, roots, true, &data_root, &index_root);
-        let initial = VerifiedIndex::open(&index_root).unwrap();
+        let initial = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert_eq!(initial.manifest().source_routes()[0].sources().len(), 2);
         let alpha = stable_source_bytes(&initial, "lifecycleinitial0");
         let route = initial.manifest().provider_roots()[0].routes()[0].clone();
@@ -532,7 +532,7 @@ fn unavailable_only_released_member_is_carried_while_automatic_peer_advances() {
         }
 
         refresh(&base, provider, roots, true, &data_root, &index_root);
-        let missing = VerifiedIndex::open(&index_root).unwrap();
+        let missing = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert_eq!(
             missing
                 .complete_lexical_search("automaticpeeradvanced", 8)
@@ -571,7 +571,7 @@ fn removing_final_released_alias_preserves_shared_route_history_without_refreshi
         let roots = &roots[..1];
 
         refresh(&base, provider, roots, true, &data_root, &index_root);
-        let initial = VerifiedIndex::open(&index_root).unwrap();
+        let initial = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert_eq!(initial.manifest().source_routes()[0].sources().len(), 2);
         let alpha = stable_source_bytes(&initial, "lifecycleinitial0");
         let automatic = stable_source_bytes(&initial, "lifecycleinitial1");
@@ -591,7 +591,7 @@ fn removing_final_released_alias_preserves_shared_route_history_without_refreshi
         }
 
         refresh(&base, provider, &[], false, &data_root, &index_root);
-        let removed = VerifiedIndex::open(&index_root).unwrap();
+        let removed = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert!(removed.manifest().provider_roots().is_empty());
         assert_eq!(removed.manifest().source_routes()[0].sources().len(), 2);
         assert!(matches!(
@@ -620,7 +620,7 @@ fn removing_final_released_alias_preserves_shared_route_history_without_refreshi
         drop(removed);
 
         refresh(&base, provider, &[], true, &data_root, &index_root);
-        let resumed = VerifiedIndex::open(&index_root).unwrap();
+        let resumed = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert!(resumed.manifest().provider_roots().is_empty());
         assert!(matches!(
             resumed
@@ -667,7 +667,7 @@ fn shared_compound_route_survives_warm_policy_moves_absence_and_alias_removal() 
         let (base, mut roots, paths) = fixture(&fixture_root, provider);
 
         refresh(&base, provider, &roots, true, &data_root, &index_root);
-        let initial = VerifiedIndex::open(&index_root).unwrap();
+        let initial = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert_eq!(initial_count(&initial), 3);
         let initial_alpha = stable_record_bytes(&initial, "lifecycleinitial0");
         let initial_automatic = stable_record_bytes(&initial, "lifecycleinitial2");
@@ -687,7 +687,7 @@ fn shared_compound_route_survives_warm_policy_moves_absence_and_alias_removal() 
             _ => unreachable!(),
         }
         refresh(&base, provider, &roots, false, &data_root, &index_root);
-        let automatic_off = VerifiedIndex::open(&index_root).unwrap();
+        let automatic_off = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert_eq!(initial_count(&automatic_off), 3);
         assert_eq!(
             automatic_off
@@ -710,7 +710,7 @@ fn shared_compound_route_survives_warm_policy_moves_absence_and_alias_removal() 
         );
         drop(automatic_off);
         refresh(&base, provider, &roots, false, &data_root, &index_root);
-        assert!(VerifiedIndex::open(&index_root)
+        assert!(VerifiedIndex::open_pinned(&index_root)
             .unwrap()
             .complete_lexical_search("automaticnewrecord", 8)
             .unwrap()
@@ -718,7 +718,7 @@ fn shared_compound_route_survives_warm_policy_moves_absence_and_alias_removal() 
 
         refresh(&base, provider, &roots, true, &data_root, &index_root);
         assert_eq!(
-            VerifiedIndex::open(&index_root)
+            VerifiedIndex::open_pinned(&index_root)
                 .unwrap()
                 .complete_lexical_search("automaticnewrecord", 8)
                 .unwrap()
@@ -732,7 +732,7 @@ fn shared_compound_route_survives_warm_policy_moves_absence_and_alias_removal() 
             fs::rename(&roots[0].path, &moved).unwrap();
             roots[0].path = moved;
             refresh(&base, provider, &roots, true, &data_root, &index_root);
-            let moved_index = VerifiedIndex::open(&index_root).unwrap();
+            let moved_index = VerifiedIndex::open_pinned(&index_root).unwrap();
             assert_eq!(
                 moved_index.manifest().provider_roots()[0].routes(),
                 std::slice::from_ref(&route)
@@ -754,7 +754,7 @@ fn shared_compound_route_survives_warm_policy_moves_absence_and_alias_removal() 
             _ => unreachable!(),
         }
         refresh(&base, provider, &roots, true, &data_root, &index_root);
-        let missing = VerifiedIndex::open(&index_root).unwrap();
+        let missing = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert_eq!(
             missing
                 .complete_lexical_search("remainingpeeradvanced", 8)
@@ -783,7 +783,7 @@ fn shared_compound_route_survives_warm_policy_moves_absence_and_alias_removal() 
 
         fs::rename(&absent, &roots[0].path).unwrap();
         refresh(&base, provider, &roots, true, &data_root, &index_root);
-        let reappeared = VerifiedIndex::open(&index_root).unwrap();
+        let reappeared = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert_eq!(
             stable_record_bytes(&reappeared, "lifecycleinitial0"),
             initial_alpha
@@ -803,7 +803,7 @@ fn shared_compound_route_survives_warm_policy_moves_absence_and_alias_removal() 
             _ => unreachable!(),
         }
         refresh(&base, provider, &roots[1..], false, &data_root, &index_root);
-        let removed = VerifiedIndex::open(&index_root).unwrap();
+        let removed = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert_eq!(removed.manifest().provider_roots().len(), 1);
         assert!(matches!(
             removed

--- a/crates/ctx-history-refresh-execution/src/tests/execution_path/configured_root_moves/continuity.rs
+++ b/crates/ctx-history-refresh-execution/src/tests/execution_path/configured_root_moves/continuity.rs
@@ -49,11 +49,13 @@ fn configured_claude_home_is_additive_and_naming_the_automatic_home_deduplicates
                 &mut progress,
             )
             .unwrap();
-            let automatic_source_key = VerifiedIndex::open(&index_root).unwrap().manifest().sources
-                [0]
-            .observation()
-            .source()
-            .clone();
+            let automatic_source_key = VerifiedIndex::open_pinned(&index_root)
+                .unwrap()
+                .manifest()
+                .sources[0]
+                .observation()
+                .source()
+                .clone();
 
             let configured_home = if same_home {
                 automatic_home.clone()
@@ -117,7 +119,7 @@ fn configured_claude_home_is_additive_and_naming_the_automatic_home_deduplicates
             )
             .unwrap();
 
-            let published = VerifiedIndex::open(&index_root).unwrap();
+            let published = VerifiedIndex::open_pinned(&index_root).unwrap();
             // Disabling inference changes future selection; it does not use a
             // config toggle as deletion authority for already indexed history.
             let expected_route_count = if same_home { 1 } else { 2 };
@@ -214,7 +216,7 @@ fn watch_catalog_preserves_released_identity_across_path_and_group_replacement()
         &mut progress,
     )
     .unwrap();
-    let published = VerifiedIndex::open(&index_root).unwrap();
+    let published = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         published.manifest().provider_roots()[0].source_identity(),
         ProviderRootSourceIdentity::Released
@@ -349,7 +351,7 @@ fn released_overlap_root_move_remove_and_readd_preserves_exact_identity() {
         )
         .unwrap();
 
-        let published = VerifiedIndex::open(&index_root).unwrap();
+        let published = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert_eq!(published.manifest().sources.len(), 3);
         assert_eq!(published.manifest().source_routes().len(), 2);
         assert_eq!(published.manifest().provider_roots().len(), 1);
@@ -419,7 +421,7 @@ fn released_overlap_root_move_remove_and_readd_preserves_exact_identity() {
             &mut progress,
         )
         .unwrap();
-        let removed = VerifiedIndex::open(&index_root).unwrap();
+        let removed = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert!(removed.manifest().provider_roots().is_empty());
         assert_eq!(removed.manifest().source_routes().len(), 1);
         assert_eq!(
@@ -465,7 +467,7 @@ fn released_overlap_root_move_remove_and_readd_preserves_exact_identity() {
             &mut progress,
         )
         .unwrap();
-        let rejoined = VerifiedIndex::open(&index_root).unwrap();
+        let rejoined = VerifiedIndex::open_pinned(&index_root).unwrap();
         assert_eq!(rejoined.manifest().source_routes().len(), 2);
         assert_eq!(rejoined.manifest().provider_roots().len(), 1);
         assert_eq!(
@@ -653,7 +655,7 @@ fn naming_a_failing_automatic_home_carries_it_while_named_peer_advances() {
     .unwrap();
 
     assert!(!publication.route_results.is_empty());
-    let published = VerifiedIndex::open(&index_root).unwrap();
+    let published = VerifiedIndex::open_pinned(&index_root).unwrap();
     let automatic_root = published
         .manifest()
         .provider_roots()
@@ -755,7 +757,7 @@ fn unchanged_symlinked_configured_root_retains_history_while_peer_advances() {
         &mut progress,
     )
     .unwrap();
-    let first = VerifiedIndex::open(&index_root).unwrap();
+    let first = VerifiedIndex::open_pinned(&index_root).unwrap();
     let retained_routes = first
         .manifest()
         .provider_roots()
@@ -804,7 +806,7 @@ fn unchanged_symlinked_configured_root_retains_history_while_peer_advances() {
     )
     .unwrap();
 
-    let published = VerifiedIndex::open(&index_root).unwrap();
+    let published = VerifiedIndex::open_pinned(&index_root).unwrap();
     let retained_root = published
         .manifest()
         .provider_roots()
@@ -887,7 +889,10 @@ fn removing_last_configured_claude_home_returns_to_one_automatic_route() {
         &mut progress,
     )
     .unwrap();
-    let configured_source_key = VerifiedIndex::open(&index_root).unwrap().manifest().sources[0]
+    let configured_source_key = VerifiedIndex::open_pinned(&index_root)
+        .unwrap()
+        .manifest()
+        .sources[0]
         .observation()
         .source()
         .clone();
@@ -908,7 +913,7 @@ fn removing_last_configured_claude_home_returns_to_one_automatic_route() {
     )
     .unwrap();
 
-    let published = VerifiedIndex::open(&index_root).unwrap();
+    let published = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(published.manifest().source_routes().len(), 1);
     assert!(published
         .manifest()

--- a/crates/ctx-history-refresh-execution/src/tests/execution_path/configured_root_moves/removal.rs
+++ b/crates/ctx-history-refresh-execution/src/tests/execution_path/configured_root_moves/removal.rs
@@ -181,7 +181,7 @@ fn partial_released_codex_overlap_move_remove_readd_preserves_exact_identity() {
         &mut progress,
     )
     .unwrap();
-    let automatic = VerifiedIndex::open(&index_root).unwrap();
+    let automatic = VerifiedIndex::open_pinned(&index_root).unwrap();
     let baseline = exact_history_bytes(&automatic, marker);
     assert_eq!(automatic.manifest().sources.len(), 1);
     drop(automatic);
@@ -197,7 +197,7 @@ fn partial_released_codex_overlap_move_remove_readd_preserves_exact_identity() {
         .clone()
         .with_configured_provider_roots(vec![definition(first_home.clone())]);
     refresh_discovered_codex(&overlapping_discovery, &data_root, &index_root);
-    let overlapping = VerifiedIndex::open(&index_root).unwrap();
+    let overlapping = VerifiedIndex::open_pinned(&index_root).unwrap();
     exact_history_bytes(&overlapping, marker).assert_core_history_eq(&baseline);
     assert_eq!(overlapping.manifest().sources.len(), 1);
     let overlapping_routes = overlapping
@@ -225,7 +225,7 @@ fn partial_released_codex_overlap_move_remove_readd_preserves_exact_identity() {
         .with_env("CODEX_HOME", first_home.as_os_str())
         .with_configured_provider_roots(vec![definition(moved_home.clone())]);
     refresh_discovered_codex(&moved_discovery, &data_root, &index_root);
-    let moved = VerifiedIndex::open(&index_root).unwrap();
+    let moved = VerifiedIndex::open_pinned(&index_root).unwrap();
     exact_history_bytes(&moved, marker).assert_core_history_eq(&baseline);
     assert_eq!(moved.manifest().sources.len(), 1);
     let moved_routes = moved
@@ -253,7 +253,7 @@ fn partial_released_codex_overlap_move_remove_readd_preserves_exact_identity() {
         .clone()
         .with_env("CODEX_HOME", first_home.as_os_str());
     refresh_discovered_codex(&removed_discovery, &data_root, &index_root);
-    let removed = VerifiedIndex::open(&index_root).unwrap();
+    let removed = VerifiedIndex::open_pinned(&index_root).unwrap();
     exact_history_bytes(&removed, marker).assert_core_history_eq(&baseline);
     assert!(removed.manifest().provider_roots().is_empty());
     assert_eq!(
@@ -276,7 +276,7 @@ fn partial_released_codex_overlap_move_remove_readd_preserves_exact_identity() {
         .with_env("CODEX_HOME", first_home.as_os_str())
         .with_configured_provider_roots(vec![definition(moved_home)]);
     refresh_discovered_codex(&readded_discovery, &data_root, &index_root);
-    let readded = VerifiedIndex::open(&index_root).unwrap();
+    let readded = VerifiedIndex::open_pinned(&index_root).unwrap();
     exact_history_bytes(&readded, marker).assert_core_history_eq(&baseline);
     assert_eq!(readded.manifest().sources.len(), 1);
     assert!(readded
@@ -425,7 +425,7 @@ fn removed_standalone_named_codex_root_retains_exact_history_until_readded() {
         &mut progress,
     )
     .unwrap();
-    let initial = VerifiedIndex::open(&index_root).unwrap();
+    let initial = VerifiedIndex::open_pinned(&index_root).unwrap();
     let initial_exact = exact_history_bytes(&initial, "standaloneremovalretention");
     let route = initial.manifest().provider_root("work").unwrap().routes()[0].clone();
     let peer_route = initial
@@ -464,7 +464,7 @@ fn removed_standalone_named_codex_root_retains_exact_history_until_readded() {
         &mut progress,
     )
     .unwrap();
-    let moved = VerifiedIndex::open(&index_root).unwrap();
+    let moved = VerifiedIndex::open_pinned(&index_root).unwrap();
     let moved_exact = exact_history_bytes(&moved, "standaloneremovalretention");
     moved_exact.assert_core_history_eq(&initial_exact);
     assert_eq!(
@@ -495,7 +495,7 @@ fn removed_standalone_named_codex_root_retains_exact_history_until_readded() {
         &mut progress,
     )
     .unwrap();
-    let removed = VerifiedIndex::open(&index_root).unwrap();
+    let removed = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(removed.manifest().provider_roots().len(), 1);
     assert_eq!(
         removed.manifest().provider_roots()[0].definition().id,
@@ -561,7 +561,7 @@ fn removed_standalone_named_codex_root_retains_exact_history_until_readded() {
         &mut progress,
     )
     .unwrap();
-    let restarted = VerifiedIndex::open(&index_root).unwrap();
+    let restarted = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(restarted.generation_id(), removed_generation);
     assert_eq!(
         exact_history_bytes(&restarted, "standaloneremovalretention"),
@@ -601,7 +601,7 @@ fn removed_standalone_named_codex_root_retains_exact_history_until_readded() {
         &mut progress,
     )
     .unwrap();
-    let readded = VerifiedIndex::open(&index_root).unwrap();
+    let readded = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(readded.manifest().sources.len(), 2);
     assert_eq!(readded.manifest().source_routes().len(), 2);
     let readded_exact = exact_history_bytes(&readded, "standaloneremovalretention");

--- a/crates/ctx-history-refresh-execution/src/tests/execution_path/configured_root_moves/replacement.rs
+++ b/crates/ctx-history-refresh-execution/src/tests/execution_path/configured_root_moves/replacement.rs
@@ -71,7 +71,7 @@ fn moving_named_qoder_transcript_tree_preserves_supported_layouts_and_identity()
     ));
     run_report(&first_discovery, first_report, &data_root, &index_root).unwrap();
 
-    let first = VerifiedIndex::open(&index_root).unwrap();
+    let first = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         first
             .complete_lexical_search(DIRECT_MARKER, 8)
@@ -129,7 +129,7 @@ fn moving_named_qoder_transcript_tree_preserves_supported_layouts_and_identity()
     );
     run_report(&moved_discovery, moved_report, &data_root, &index_root).unwrap();
 
-    let moved = VerifiedIndex::open(&index_root).unwrap();
+    let moved = VerifiedIndex::open_pinned(&index_root).unwrap();
     let moved_root_manifest = moved.manifest().provider_root(ROOT_ID).unwrap();
     assert_eq!(moved_root_manifest.routes(), first_routes);
     assert_eq!(moved_root_manifest.definition().path, moved_root);
@@ -236,7 +236,7 @@ fn failed_same_name_incompatible_replacement_keeps_predecessor_until_success() {
         &mut progress,
     )
     .unwrap();
-    let initial_index = VerifiedIndex::open(&index_root).unwrap();
+    let initial_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     let predecessor_root = initial_index.manifest().provider_root("work").unwrap();
     let predecessor_routes = predecessor_root.routes().to_vec();
     let predecessor_tokens = initial_index
@@ -296,7 +296,7 @@ fn failed_same_name_incompatible_replacement_keeps_predecessor_until_success() {
         .route_results
         .iter()
         .any(|result| result.outcome.failure_class().is_some()));
-    let failed_index = VerifiedIndex::open(&index_root).unwrap();
+    let failed_index = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         failed_index
             .complete_lexical_search("atomicpredecessorhistory", 8)
@@ -366,7 +366,7 @@ fn failed_same_name_incompatible_replacement_keeps_predecessor_until_success() {
         &mut progress,
     )
     .unwrap();
-    let succeeded = VerifiedIndex::open(&index_root).unwrap();
+    let succeeded = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(
         predecessor_routes
             .iter()
@@ -457,7 +457,7 @@ fn failed_same_provider_kind_replacement_keeps_predecessor_until_success() {
         &mut progress,
     )
     .unwrap();
-    let predecessor = VerifiedIndex::open(&index_root).unwrap();
+    let predecessor = VerifiedIndex::open_pinned(&index_root).unwrap();
     let predecessor_route = predecessor
         .manifest()
         .provider_root("work")
@@ -500,7 +500,7 @@ fn failed_same_provider_kind_replacement_keeps_predecessor_until_success() {
         &mut progress,
     )
     .unwrap();
-    let failed = VerifiedIndex::open(&index_root).unwrap();
+    let failed = VerifiedIndex::open_pinned(&index_root).unwrap();
     let failed_root = failed.manifest().provider_root("work").unwrap();
     assert_eq!(
         failed_root.definition().kind,
@@ -533,7 +533,7 @@ fn failed_same_provider_kind_replacement_keeps_predecessor_until_success() {
         &mut progress,
     )
     .unwrap();
-    let succeeded = VerifiedIndex::open(&index_root).unwrap();
+    let succeeded = VerifiedIndex::open_pinned(&index_root).unwrap();
     let succeeded_root = succeeded.manifest().provider_root("work").unwrap();
     assert_eq!(
         succeeded_root.definition().kind,
@@ -610,7 +610,7 @@ fn compound_same_name_replacement_waits_for_every_successor_in_either_route_orde
             "unexpected initial rejections: {:#?}",
             initial_receipt.route_results
         );
-        let initial_index = VerifiedIndex::open(&index_root).unwrap();
+        let initial_index = VerifiedIndex::open_pinned(&index_root).unwrap();
         let predecessor_root = initial_index.manifest().provider_root("work").unwrap();
         assert_eq!(
             predecessor_root.source_identity(),
@@ -720,7 +720,7 @@ fn compound_same_name_replacement_waits_for_every_successor_in_either_route_orde
             .route_results
             .iter()
             .any(|result| result.outcome.failure_class().is_some()));
-        let failed_index = VerifiedIndex::open(&index_root).unwrap();
+        let failed_index = VerifiedIndex::open_pinned(&index_root).unwrap();
         let failed_root = failed_index.manifest().provider_root("work").unwrap();
         assert_eq!(failed_root.definition().provider, CaptureProvider::Claude);
         assert_eq!(
@@ -783,7 +783,7 @@ fn compound_same_name_replacement_waits_for_every_successor_in_either_route_orde
                 &mut progress,
             )
             .unwrap();
-            let reverted = VerifiedIndex::open(&index_root).unwrap();
+            let reverted = VerifiedIndex::open_pinned(&index_root).unwrap();
             assert!(reverted
                 .complete_lexical_search("compoundsessionsuccess", 8)
                 .unwrap()
@@ -846,7 +846,7 @@ fn compound_same_name_replacement_waits_for_every_successor_in_either_route_orde
             "unexpected successor outcomes: {:#?}",
             succeeded.route_results
         );
-        let succeeded_index = VerifiedIndex::open(&index_root).unwrap();
+        let succeeded_index = VerifiedIndex::open_pinned(&index_root).unwrap();
         let succeeded_root = succeeded_index.manifest().provider_root("work").unwrap();
         assert_eq!(succeeded_root.definition().provider, CaptureProvider::Codex);
         assert!(succeeded_root.exact_source_memberships().is_empty());
@@ -931,7 +931,7 @@ fn moving_a_named_claude_home_preserves_route_and_source_identity() {
         &mut progress,
     )
     .unwrap();
-    let first = VerifiedIndex::open(&index_root).unwrap();
+    let first = VerifiedIndex::open_pinned(&index_root).unwrap();
     let first_route = first.manifest().provider_roots()[0].routes()[0].clone();
     let first_source = first.manifest().sources[0].observation().source().clone();
     drop(first);
@@ -964,7 +964,7 @@ fn moving_a_named_claude_home_preserves_route_and_source_identity() {
     )
     .unwrap();
 
-    let moved = VerifiedIndex::open(&index_root).unwrap();
+    let moved = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(moved.manifest().source_routes().len(), 1);
     assert_eq!(
         moved.manifest().provider_roots()[0].routes(),
@@ -1057,7 +1057,7 @@ fn moving_a_named_codex_home_preserves_route_and_source_identity() {
         &mut progress,
     )
     .unwrap();
-    let first = VerifiedIndex::open(&index_root).unwrap();
+    let first = VerifiedIndex::open_pinned(&index_root).unwrap();
     let first_route = first.manifest().provider_roots()[0].routes()[0].clone();
     let first_source = first.manifest().sources[0].observation().source().clone();
     drop(first);
@@ -1090,7 +1090,7 @@ fn moving_a_named_codex_home_preserves_route_and_source_identity() {
     )
     .unwrap();
 
-    let moved = VerifiedIndex::open(&index_root).unwrap();
+    let moved = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(moved.manifest().source_routes().len(), 1);
     assert_eq!(
         moved.manifest().provider_roots()[0].routes(),
@@ -1227,7 +1227,7 @@ fn same_id_provider_replacement_retires_old_routes_and_publishes_the_new_root() 
     )
     .unwrap();
 
-    let replaced = VerifiedIndex::open(&index_root).unwrap();
+    let replaced = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(replaced
         .complete_lexical_search("retiredproviderfixture", 10)
         .unwrap()

--- a/crates/ctx-history-refresh-execution/src/tests/receipt.rs
+++ b/crates/ctx-history-refresh-execution/src/tests/receipt.rs
@@ -5,7 +5,7 @@ use super::*;
 fn terminal_receipt_fixture() -> (tempfile::TempDir, Value, VerifiedIndex) {
     let temp = tempfile::tempdir().unwrap();
     let generation = publish_pin_source(temp.path(), publication_pin_source_with_anchor(0x91));
-    let verified = VerifiedIndex::open(temp.path()).unwrap();
+    let verified = VerifiedIndex::open_pinned(temp.path()).unwrap();
     let mut publication = test_publication(generation.clone());
     publication.current =
         SourceBackedRefreshCurrent::from_sources(&verified.manifest().sources, 0).unwrap();
@@ -167,7 +167,7 @@ fn receipt_source_count_intersects_request_routes_with_certified_generation_rout
         ])
         .unwrap();
     let generation = writer.commit(|_| true).unwrap().generation_id;
-    let verified = VerifiedIndex::open(temp.path()).unwrap();
+    let verified = VerifiedIndex::open_pinned(temp.path()).unwrap();
     let receipt = SourceBackedRefreshReceipt {
         zero_source_authority: Vec::new(),
         previous_generation: None,

--- a/crates/ctx-history-refresh-execution/src/tests/registry_policy.rs
+++ b/crates/ctx-history-refresh-execution/src/tests/registry_policy.rs
@@ -426,7 +426,7 @@ fn distinct_nanoclaw_registry_failures_match_retained_automatic_routes() {
     }
     writer.set_present_source_routes(retained_routes).unwrap();
     writer.commit(|_| true).unwrap();
-    let retained = VerifiedIndex::open(&index_root).unwrap();
+    let retained = VerifiedIndex::open_pinned(&index_root).unwrap();
 
     let issues = sources.map(|source| SourceBackedAutomaticRegistryIssue::Unavailable {
         source,
@@ -498,7 +498,7 @@ fn mixed_codex_and_unsupported_warp_routes_continue_with_typed_evidence() {
     );
     assert!(is_sha256_identity(&failure.route_identity));
     assert!(is_sha256_identity(&failure.source_identity));
-    let verified = VerifiedIndex::open(&index_root).unwrap();
+    let verified = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(verified.manifest().sources.len(), 1);
     assert_eq!(
         verified
@@ -592,7 +592,7 @@ fn all_route_execution_preserves_a_healthy_peer_during_source_local_registration
     assert_eq!(failures[0].provider, "shelley");
     assert_eq!(failures[0].class, "unreadable");
     assert!(failures[0].detail.contains("not a database"));
-    let verified = VerifiedIndex::open(&index_root).unwrap();
+    let verified = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(verified.manifest().sources.len(), 1);
     assert_eq!(
         verified
@@ -670,7 +670,7 @@ fn unsupported_warp_preserves_same_epoch_last_good_route_as_stale() {
         failure.detail,
         "fixture Warp route is intentionally unsupported"
     );
-    let retained = VerifiedIndex::open(&index_root).unwrap();
+    let retained = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(retained.generation_id(), retained_generation);
     assert!(retained.manifest().source_route(&route_identity).is_some());
     assert_eq!(retained.manifest().sources.len(), 1);

--- a/crates/ctx-history-refresh-execution/src/tests/settings_upgrade.rs
+++ b/crates/ctx-history-refresh-execution/src/tests/settings_upgrade.rs
@@ -55,7 +55,7 @@ fn automatic_execution_replaces_an_incompatible_settings_generation() {
     meta["index_settings"]["docstore_blocksize"] = Value::from(64 * 1024);
     std::fs::write(&meta_path, serde_json::to_vec(&meta).unwrap()).unwrap();
     assert!(matches!(
-        VerifiedIndex::open(&index_root),
+        VerifiedIndex::open_pinned(&index_root),
         Err(IndexError::IndexSettingsMismatch(_))
     ));
 
@@ -65,7 +65,9 @@ fn automatic_execution_replaces_an_incompatible_settings_generation() {
     assert_ne!(std::fs::read(&pointer_path).unwrap(), pointer_before);
     assert!(!old_generation_path.exists());
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().generation_id(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .generation_id(),
         baseline.generation_id
     );
 }

--- a/crates/ctx-history-refresh/src/engine/startup_observation.rs
+++ b/crates/ctx-history-refresh/src/engine/startup_observation.rs
@@ -184,7 +184,7 @@ mod tests {
                 },
             )
             .unwrap();
-        VerifiedIndex::open(root).unwrap()
+        VerifiedIndex::open_pinned(root).unwrap()
     }
 
     fn empty_hermes_route_index(
@@ -249,7 +249,7 @@ mod tests {
                 },
             )
             .unwrap();
-        VerifiedIndex::open(root).unwrap()
+        VerifiedIndex::open_pinned(root).unwrap()
     }
 
     #[test]

--- a/crates/ctx-history-refresh/src/engine/tests/codex_union.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/codex_union.rs
@@ -116,7 +116,8 @@ fn automatic_and_explicit_empty_routes_preserve_generation_bound_authority() {
         .iter()
         .all(|authority| authority.generation_id == publication.generation_id));
     assert!(
-        verified_generation_is_query_ready(&VerifiedIndex::open(&index_root).unwrap()).unwrap()
+        verified_generation_is_query_ready(&VerifiedIndex::open_pinned(&index_root).unwrap())
+            .unwrap()
     );
 }
 
@@ -170,7 +171,7 @@ fn successful_codex_route_derives_rejected_records_from_committed_core_sources()
     assert_eq!(publication.current.rejected_records, 1);
     assert_eq!(
         complete_lexical_candidates(
-            &VerifiedIndex::open(&index_root).unwrap(),
+            &VerifiedIndex::open_pinned(&index_root).unwrap(),
             "validpeerrecordmarker",
             10,
         )
@@ -328,7 +329,7 @@ fn codex_nested_root_advisory_is_admitted_from_each_childs_own_bytes() {
     assert_eq!(publication.current.source_count, 4);
     assert_eq!(publication.certified_source_count, 4);
     assert_eq!(publication.current.rejected_records, 0);
-    let verified = VerifiedIndex::open(&index_root).unwrap();
+    let verified = VerifiedIndex::open_pinned(&index_root).unwrap();
     let records = codex_core_records(&verified);
     assert_eq!(records.len(), 4);
     for marker in [
@@ -460,7 +461,7 @@ fn codex_deep_root_advisory_chain_has_exact_linear_cardinality() {
     assert_eq!(publication.current.source_count, SOURCES);
     assert_eq!(publication.certified_source_count, SOURCES);
     assert_eq!(publication.current.rejected_records, 0);
-    let verified = VerifiedIndex::open(&index_root).unwrap();
+    let verified = VerifiedIndex::open_pinned(&index_root).unwrap();
     let records = codex_core_records(&verified);
     assert_eq!(records.len(), SOURCES);
     assert_eq!(
@@ -577,7 +578,7 @@ fn registered_codex_parent_and_exact_subdir_share_route_scoped_ownership() {
         parent_publication.route_results[0].route_identity
     );
     assert!(first.route_results[0].outcome.is_success());
-    let verified = VerifiedIndex::open(&index_root).unwrap();
+    let verified = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(!verified.manifest().sources.is_empty());
     assert_eq!(
         complete_lexical_candidates(&verified, "automaticrootmarker", 10)
@@ -625,7 +626,7 @@ fn registered_codex_parent_and_exact_subdir_share_route_scoped_ownership() {
     );
     assert_eq!(
         complete_lexical_candidates(
-            &VerifiedIndex::open(&index_root).unwrap(),
+            &VerifiedIndex::open_pinned(&index_root).unwrap(),
             "explicitappendafterimportmarker",
             10,
         )
@@ -702,7 +703,7 @@ fn automatic_parent_and_explicit_directory_child_normalize_in_one_generation() {
         .all(|result| result.outcome.is_success()));
     assert_eq!(publication.certified_source_count, 2);
     assert_codex_parent_child_records(
-        &VerifiedIndex::open(&index_root).unwrap(),
+        &VerifiedIndex::open_pinned(&index_root).unwrap(),
         "automaticparentdirectorymarker",
         "explicitdirectorychildmarker",
     );
@@ -771,7 +772,7 @@ fn automatic_parent_and_explicit_file_child_normalize_in_one_generation() {
         .all(|result| result.outcome.is_success()));
     assert_eq!(publication.certified_source_count, 2);
     assert_codex_parent_child_records(
-        &VerifiedIndex::open(&index_root).unwrap(),
+        &VerifiedIndex::open_pinned(&index_root).unwrap(),
         "automaticparentfilemarker",
         "explicitfilechildmarker",
     );
@@ -863,7 +864,7 @@ fn explicit_child_without_selected_parent_publishes_unresolved_and_never_reroots
         .route_results
         .iter()
         .all(|result| result.outcome.is_success()));
-    let records = codex_core_records(&VerifiedIndex::open(&index_root).unwrap());
+    let records = codex_core_records(&VerifiedIndex::open_pinned(&index_root).unwrap());
     assert_eq!(records.len(), 2);
     let selected = records
         .iter()

--- a/crates/ctx-history-refresh/src/engine/tests/unsupported_refresh.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/unsupported_refresh.rs
@@ -54,7 +54,7 @@ pub(super) fn run_report(
 }
 
 fn replace_metadata_version(index_root: &Path, version: u64) -> VerifiedIndex {
-    let current = VerifiedIndex::open(index_root).unwrap();
+    let current = VerifiedIndex::open_pinned(index_root).unwrap();
     let generation_id = current.generation_id().to_owned();
     let mut metadata: Value =
         serde_json::from_slice(current.publication_metadata().unwrap()).unwrap();
@@ -108,12 +108,12 @@ fn present_unsupported_only_refresh_fails_cold_and_reports_against_a_warm_genera
         "{cold_detail}"
     );
     assert!(matches!(
-        VerifiedIndex::open(&index_root),
+        VerifiedIndex::open_pinned(&index_root),
         Err(IndexError::MissingActiveGenerationPointer)
     ));
 
     let retained_generation = publish_pin_source(&index_root, publication_pin_source());
-    let legacy_nonempty = VerifiedIndex::open(&index_root).unwrap();
+    let legacy_nonempty = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(legacy_nonempty.publication_metadata().is_none());
     assert_eq!(
         verify_generation_query_readiness(&legacy_nonempty).unwrap(),
@@ -129,7 +129,7 @@ fn present_unsupported_only_refresh_fails_cold_and_reports_against_a_warm_genera
     };
     assert_eq!(failed_route.outcome.failure_class(), Some("incompatible"));
     assert!(!failed_route.outcome.is_success());
-    let retained = VerifiedIndex::open(&index_root).unwrap();
+    let retained = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(retained.generation_id(), retained_generation);
     assert_eq!(retained.manifest().sources.len(), 1);
 }
@@ -162,7 +162,7 @@ fn executable_empty_inventory_publishes_v2_authority_and_survives_restart() {
     );
     assert_eq!(authority.generation_id, publication.generation_id);
 
-    let restarted = VerifiedIndex::open(&index_root).unwrap();
+    let restarted = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert_eq!(
         verify_generation_query_readiness(&restarted).unwrap(),
         GenerationQueryReadiness::Ready
@@ -193,7 +193,7 @@ fn executable_empty_inventory_publishes_v2_authority_and_survives_restart() {
     drop(legacy);
     let recertified = run_report(&discovery, report, &data_root, &index_root).unwrap();
     assert_eq!(recertified.generation_id, publication.generation_id);
-    let recertified = VerifiedIndex::open(&index_root).unwrap();
+    let recertified = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(verified_generation_is_query_ready(&recertified).unwrap());
     assert!(pin_retained_generation(&data_root, &publication.generation_id).is_ok());
     assert_eq!(
@@ -248,7 +248,7 @@ fn genuinely_empty_catalog_publishes_a_verified_noop_generation() {
     assert!(publication.route_results.is_empty());
     assert!(publication.zero_source_authority.is_empty());
 
-    let restarted = VerifiedIndex::open(&index_root).unwrap();
+    let restarted = VerifiedIndex::open_pinned(&index_root).unwrap();
     assert!(verified_generation_is_query_ready(&restarted).unwrap());
     let metadata = SourceBackedPublicationMetadata::decode(&restarted).unwrap();
     assert_eq!(metadata.refresh_scope, SourceBackedRefreshScope::All);
@@ -308,7 +308,9 @@ fn confirmed_deletion_can_publish_empty_but_mixed_unavailable_cannot() {
     .unwrap_err();
     assert!(format!("{mixed_error:#}").contains(TERMINAL_COVERAGE_ERROR_CODE));
     assert_eq!(
-        VerifiedIndex::open(&index_root).unwrap().generation_id(),
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .generation_id(),
         deletion_generation
     );
 }

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests.rs
@@ -276,7 +276,7 @@ impl Fixture {
             )?)?;
         }
         writer.commit(|_| true)?;
-        Ok(VerifiedIndex::open(root)?)
+        Ok(VerifiedIndex::open_pinned(root)?)
     }
 
     fn publish_with_event_sequences(
@@ -320,7 +320,7 @@ impl Fixture {
             )?)?;
         }
         writer.commit(|_| true)?;
-        Ok(VerifiedIndex::open(root)?)
+        Ok(VerifiedIndex::open_pinned(root)?)
     }
 
     fn source_digest(&self, index: &VerifiedIndex, source_index: usize) -> Result<String> {
@@ -557,7 +557,7 @@ fn retrieval_excluded_events_never_enter_the_source_backed_semantic_projection()
         },
     )?)?;
     writer.commit(|_| true)?;
-    let index = VerifiedIndex::open(root)?;
+    let index = VerifiedIndex::open_pinned(root)?;
     let source_digest = index.manifest().core_record_aggregates[0]
         .source_identity_digest()
         .to_owned();
@@ -614,7 +614,7 @@ fn mixed_core_roles_build_and_pin_only_the_semantic_candidate() -> Result<()> {
         },
     )?)?;
     writer.commit(|_| true)?;
-    let index = VerifiedIndex::open(root)?;
+    let index = VerifiedIndex::open_pinned(root)?;
 
     assert_eq!(index.manifest().indexed_documents, 2);
     let source_aggregate = &index.manifest().core_record_aggregates[0];
@@ -685,7 +685,7 @@ fn page_embedding_batches_multiple_documents_in_one_embedder_call() -> Result<()
         },
     )?)?;
     writer.commit(|_| true)?;
-    let index = VerifiedIndex::open(root)?;
+    let index = VerifiedIndex::open_pinned(root)?;
 
     let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
     let mut builder = CoreBuilder::default();
@@ -740,7 +740,7 @@ fn role_policy_transition_rebuilds_semantic_state_without_reingesting_core() -> 
         },
     )?)?;
     writer.commit(|_| true)?;
-    let index = VerifiedIndex::open(&root)?;
+    let index = VerifiedIndex::open_pinned(&root)?;
     let core_generation_id = index.generation_id().to_owned();
 
     let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
@@ -779,7 +779,7 @@ fn role_policy_transition_rebuilds_semantic_state_without_reingesting_core() -> 
     );
     assert_eq!(index.generation_id(), core_generation_id);
     assert_eq!(
-        VerifiedIndex::open(root)?.generation_id(),
+        VerifiedIndex::open_pinned(root)?.generation_id(),
         core_generation_id
     );
     Ok(())

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/generation_identity.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/generation_identity.rs
@@ -24,7 +24,7 @@ fn incremental_delta_reopens_catches_up_and_acknowledges_verified_generation() -
     );
     drop(published);
 
-    let reopened = VerifiedIndex::open(&root)?;
+    let reopened = VerifiedIndex::open_pinned(&root)?;
     assert_eq!(reopened.generation_id(), published_generation_id);
     assert_ne!(
         reopened.manifest().generation_id()?,

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/policy_rebuild.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/policy_rebuild.rs
@@ -100,7 +100,7 @@ fn descriptor_only_model_change_rebuilds_every_vector_from_unchanged_core() -> R
     );
     assert_eq!(index.generation_id(), core_generation_id);
     assert_eq!(
-        VerifiedIndex::open(fixture.data_root.join("index-revision"))?.generation_id(),
+        VerifiedIndex::open_pinned(fixture.data_root.join("index-revision"))?.generation_id(),
         core_generation_id,
         "a semantic-model-only rebuild must leave committed Core active"
     );

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/provider_native.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/provider_native.rs
@@ -60,7 +60,7 @@ fn provider_native_copies_enter_semantic_projection_without_target_resolution() 
         )?)?;
     }
     writer.commit(|_| true)?;
-    let index = VerifiedIndex::open(root)?;
+    let index = VerifiedIndex::open_pinned(root)?;
 
     assert_eq!(index.manifest().indexed_documents, 3);
     assert!(index


### PR DESCRIPTION
## Summary

- keep exhaustive index verification behind test-only support so production opens remain bounded
- migrate ordinary tests to the production-style bounded open path
- bound SIGINT/SIGTERM daemon shutdown to one second during stuck active work, with a second signal exiting immediately
- preserve the last published generation when shutdown interrupts active work

## Context

Follow-up hardening for #804 and #805 after the narrow watch-catalog fix in #811. Raw signals stop the current daemon process; restart policy remains with systemd or live clients.

## Validation

- `scripts/check.sh --mode=ci`
- `scripts/bazel-affected.sh origin/main` (216/216 tests)
- `scripts/bazelw build //crates/ctx-cli:ctx --config=release`
- formatting, repository policy, dependency-boundary, and release-graph checks
- two independent code reviews