### PR TITLE
fix(opencode): handle file parts without indexing payloads

### DIFF
--- a/crates/ctx-cli-contract-tests/tests/contracts/native_provider_rejections.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/native_provider_rejections.rs
@@ -55,6 +55,61 @@ fn source_refresh_failure(command: &mut Command) -> String {
 }
 
 #[test]
+fn opencode_rejection_diagnostics_reach_the_import_contract() {
+    let temp = daemon_test_root();
+    let marker = "opencode retained peer oracle";
+    let database = write_native_opencode_fixture(&temp, marker);
+    let connection = Connection::open(&database).unwrap();
+    connection
+        .execute(
+            "insert into part values (?1, ?2, ?3, 1782259201003, 1782259201003, ?4)",
+            params![
+                "opencode-cli-native-unsupported",
+                "opencode-cli-native-assistant",
+                "opencode-cli-native",
+                json!({"type": "future_part", "value": "unsupported"}).to_string(),
+            ],
+        )
+        .unwrap();
+    drop(connection);
+
+    let report = json_output(ctx(&temp).args([
+        "import",
+        "--provider",
+        "opencode",
+        "--path",
+        &database,
+        "--format=json",
+        "--progress",
+        "none",
+    ]));
+    let source = assert_source_backed_publication(&report, "opencode", "opencode_sqlite", 1);
+    let diagnostics = source["rejection_diagnostics"].as_array().unwrap();
+    assert_eq!(diagnostics.len(), 1, "{report:#}");
+    assert_eq!(diagnostics[0]["provider"], "opencode", "{report:#}");
+    assert_eq!(diagnostics[0]["line"], 3, "{report:#}");
+    assert_eq!(diagnostics[0]["payload_type"], "sqlite_row", "{report:#}");
+    assert_eq!(diagnostics[0]["class"], "unsupported_record", "{report:#}");
+    assert!(
+        diagnostics[0]["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("unsupported record type")),
+        "{report:#}"
+    );
+
+    let search = json_output(ctx(&temp).args([
+        "search",
+        marker,
+        "--provider",
+        "opencode",
+        "--refresh",
+        "off",
+        "--format=json",
+    ]));
+    assert_search_provider_oracle(&search, "opencode", marker, 1, "message");
+}
+
+#[test]
 fn partial_source_import_keeps_cli_classification_and_searchable_records() {
     let temp = daemon_test_root();
     let session = temp.path().join("partial-source.jsonl");

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/json.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/json.rs
@@ -78,6 +78,15 @@ pub(super) fn project_json(
         .as_ref()
         .and_then(|value| object_text(&value.value, "role"));
     let effective_type = effective_type(column_type, body_role, body_type, parent_role);
+    if is_ignored_type(family, &effective_type) {
+        if body.duplicate_key || parent.as_ref().is_some_and(|value| value.duplicate_key) {
+            return OpenCodeJsonProjection::Rejected(OpenCodeNativeRejectionKind::MalformedJson);
+        }
+        // OpenCode file carriers may contain inline data URLs. Recognize valid
+        // file parts before generic output detection without copying attachment
+        // bytes or metadata into Core.
+        return OpenCodeJsonProjection::Output(OpenCodeOutputJson { diagnostic: None });
+    }
     let output = direct_column_output
         || is_direct_output_token(&effective_type)
         || body.forbidden_output
@@ -271,5 +280,36 @@ mod tests {
                 _
             )
         ));
+    }
+
+    #[test]
+    fn current_file_parts_are_known_ignored_carriers() {
+        let (projection, explicit_time) = project(
+            r#"{"type":"file","mime":"image/png","filename":"diagram.png","url":"data:image/png;base64,must-not-be-indexed"}"#,
+            "part",
+            Some(r#"{"role":"user"}"#),
+            OpenCodeNativeSchemaFamily::MessagePart,
+        );
+
+        assert!(!explicit_time);
+        assert_eq!(
+            projection,
+            OpenCodeJsonProjection::Output(OpenCodeOutputJson { diagnostic: None })
+        );
+    }
+
+    #[test]
+    fn current_file_parts_cannot_enter_generic_output_retention() {
+        let (projection, _) = project(
+            r#"{"type":"file","mime":"image/png","url":"data:image/png;base64,must-not-be-indexed","metadata":{"output":"must-not-be-indexed","result":"must-not-be-indexed"}}"#,
+            "part",
+            Some(r#"{"role":"user"}"#),
+            OpenCodeNativeSchemaFamily::MessagePart,
+        );
+
+        assert_eq!(
+            projection,
+            OpenCodeJsonProjection::Output(OpenCodeOutputJson { diagnostic: None })
+        );
     }
 }

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/json/output.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/json/output.rs
@@ -81,6 +81,10 @@ pub(super) fn is_retained_type(family: Option<OpenCodeNativeSchemaFamily>, value
         && normalize_token(value) == "message")
 }
 
+pub(super) fn is_ignored_type(family: OpenCodeNativeSchemaFamily, value: &str) -> bool {
+    family == OpenCodeNativeSchemaFamily::MessagePart && normalize_token(value) == "file"
+}
+
 pub(super) fn is_tool_token(value: &str) -> bool {
     matches!(normalize_token(value).as_str(), "tool" | "shell")
 }

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed.rs
@@ -6,6 +6,7 @@
 
 use std::{collections::BTreeSet, path::Path};
 
+use ctx_history_capture_runtime::SourceBackedRecordRejectionDraft;
 use ctx_history_core::{
     derive_event_id, derive_session_id, CaptureProvider, CertifiedSource, CoreRecord,
     CoreRecordError, EventIdentityInput, NativeItemKey, NativeSessionKey, ProjectionContractError,
@@ -44,7 +45,7 @@ use crate::{
 
 const SOURCE_ANCHOR_KEY: &str = "active-database";
 const SOURCE_IDENTITY_VERSION: u32 = 1;
-const PARSER_REVISION: &str = "opencode-family-source-backed-v11-optional-metadata-admission";
+const PARSER_REVISION: &str = "opencode-family-source-backed-v12-known-file-carriers";
 const LOGICAL_SESSION_KIND: &str = "opencode-family-session";
 const LOGICAL_EVENT_KIND: &str = "opencode-family-event";
 const NATIVE_SESSION_NAMESPACE: &str = "opencode-family.session-id";
@@ -92,6 +93,7 @@ impl SqliteSourceErrorComposition for OpenCodeSourceBackedError {
 }
 
 mod adapter;
+mod diagnostics;
 mod fingerprint;
 mod ordering;
 mod projection;
@@ -100,6 +102,10 @@ mod value;
 pub use adapter::{
     adapter as source_backed_adapter, adapter_scoped as source_backed_adapter_scoped,
     OpenCodeDocumentTreeAdapter,
+};
+use diagnostics::{
+    core_projection_rejection_draft, projection_rejection_draft,
+    record_local_core_projection_failure,
 };
 use fingerprint::*;
 use ordering::{
@@ -232,11 +238,13 @@ enum OpenCodeScanOutput {
     Begin(SourceKey),
     CompletedBytes(u64),
     Document(CoreRecord),
+    Rejection(SourceBackedRecordRejectionDraft),
     Progress(SourceBackedCurrentSourceProgress),
 }
 
 #[derive(Debug)]
 struct SourceEventRow {
+    source_rowid: i64,
     native_identity: String,
     message_identity: String,
     session_identity: String,
@@ -492,6 +500,15 @@ fn stream_logical_rows(
                 ProjectionDisposition::Retained => {}
                 ProjectionDisposition::Rejected => {
                     counts.rejected_records = checked_add(counts.rejected_records, 1)?;
+                    if let Some(rejection) = projection_rejection_draft(
+                        source,
+                        dialect,
+                        path,
+                        event.source_rowid,
+                        &event.projection,
+                    ) {
+                        emit(OpenCodeScanOutput::Rejection(rejection))?;
+                    }
                 }
                 ProjectionDisposition::Ignored => {
                     counts.ignored_records = checked_add(counts.ignored_records, 1)?;
@@ -524,6 +541,7 @@ fn stream_logical_rows(
             let session = current_session.as_ref().ok_or_else(|| {
                 OpenCodeSourceBackedError::MissingSession(event.session_identity.clone())
             })?;
+            let source_rowid = event.source_rowid;
             let document = match core_record(
                 source,
                 schema.family,
@@ -539,6 +557,15 @@ fn stream_logical_rows(
                         return Err(OpenCodeSourceBackedError::CoreRecord(error));
                     }
                     counts.rejected_records = checked_add(counts.rejected_records, 1)?;
+                    emit(OpenCodeScanOutput::Rejection(
+                        core_projection_rejection_draft(
+                            source,
+                            dialect,
+                            path,
+                            source_rowid,
+                            &error,
+                        ),
+                    ))?;
                     return Ok(());
                 }
                 Err(error) => return Err(error),
@@ -583,16 +610,6 @@ fn stream_logical_rows(
             max_buffered_payload_bytes: fallback_stats.max_hydration_batch_bytes,
         },
     })
-}
-
-fn record_local_core_projection_failure(error: &CoreRecordError) -> bool {
-    matches!(
-        error,
-        CoreRecordError::FieldTooLarge {
-            field: "normalized_body" | "structured_content" | "selected_content",
-            ..
-        }
-    )
 }
 
 fn scan_session_evidence(

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/adapter.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/adapter.rs
@@ -134,6 +134,10 @@ impl<B: crate::LogicalSqliteRuntimeBinding> ReplacementDocumentTree
                 OpenCodeScanOutput::Document(document) => {
                     sink.emit_core_record(document).map_err(Into::into)
                 }
+                OpenCodeScanOutput::Rejection(rejection) => {
+                    sink.record_rejection(rejection);
+                    Ok(())
+                }
                 OpenCodeScanOutput::Progress(progress) => sink
                     .report_current_source_progress(progress)
                     .map_err(Into::into),

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/diagnostics.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/diagnostics.rs
@@ -1,0 +1,123 @@
+use std::path::Path;
+
+use ctx_history_capture_runtime::{
+    SourceBackedRecordRejectionClass, SourceBackedRecordRejectionDraft,
+};
+use ctx_history_core::{CoreRecordError, SourceKey};
+
+use super::super::{json::OpenCodeJsonProjection, model::OpenCodeNativeRejectionKind};
+use crate::provider::providers::opencode::OpenCodeSqliteDialect;
+
+pub(super) fn record_local_core_projection_failure(error: &CoreRecordError) -> bool {
+    matches!(
+        error,
+        CoreRecordError::FieldTooLarge {
+            field: "normalized_body" | "structured_content" | "selected_content",
+            ..
+        }
+    )
+}
+
+pub(super) fn projection_rejection_draft(
+    source: &SourceKey,
+    dialect: &OpenCodeSqliteDialect,
+    path: &Path,
+    source_rowid: i64,
+    projection: &OpenCodeJsonProjection,
+) -> Option<SourceBackedRecordRejectionDraft> {
+    let kind = match projection {
+        OpenCodeJsonProjection::Rejected(kind)
+        | OpenCodeJsonProjection::RejectedWithReason(kind, _) => *kind,
+        OpenCodeJsonProjection::Retained(_) | OpenCodeJsonProjection::Output(_) => return None,
+    };
+    let detail = format!(
+        "{} SQLite row {}",
+        dialect.display_name,
+        rejection_detail(kind)
+    );
+    Some(sqlite_record_rejection_draft(
+        source,
+        dialect,
+        path,
+        source_rowid,
+        rejection_class(kind),
+        detail,
+    ))
+}
+
+pub(super) fn core_projection_rejection_draft(
+    source: &SourceKey,
+    dialect: &OpenCodeSqliteDialect,
+    path: &Path,
+    source_rowid: i64,
+    error: &CoreRecordError,
+) -> SourceBackedRecordRejectionDraft {
+    sqlite_record_rejection_draft(
+        source,
+        dialect,
+        path,
+        source_rowid,
+        SourceBackedRecordRejectionClass::UnsupportedRecord,
+        format!(
+            "{} SQLite row exceeds Core projection limits: {error}",
+            dialect.display_name
+        ),
+    )
+}
+
+fn sqlite_record_rejection_draft(
+    source: &SourceKey,
+    dialect: &OpenCodeSqliteDialect,
+    path: &Path,
+    source_rowid: i64,
+    class: SourceBackedRecordRejectionClass,
+    detail: String,
+) -> SourceBackedRecordRejectionDraft {
+    SourceBackedRecordRejectionDraft {
+        source: source.clone(),
+        provider: dialect.provider,
+        source_selector: path.to_string_lossy().into_owned(),
+        line_number: u64::try_from(source_rowid).unwrap_or(0),
+        payload_type: Some("sqlite_row".to_owned()),
+        class,
+        detail,
+    }
+}
+
+const fn rejection_class(kind: OpenCodeNativeRejectionKind) -> SourceBackedRecordRejectionClass {
+    match kind {
+        OpenCodeNativeRejectionKind::MalformedJson
+        | OpenCodeNativeRejectionKind::MalformedResultJson
+        | OpenCodeNativeRejectionKind::MissingSession
+        | OpenCodeNativeRejectionKind::MissingMessage
+        | OpenCodeNativeRejectionKind::SessionRelationshipMismatch
+        | OpenCodeNativeRejectionKind::InvalidTimestamp => {
+            SourceBackedRecordRejectionClass::MalformedRecord
+        }
+        OpenCodeNativeRejectionKind::UnsupportedStorageClass
+        | OpenCodeNativeRejectionKind::OversizedRetainedContent
+        | OpenCodeNativeRejectionKind::UnknownRecordType => {
+            SourceBackedRecordRejectionClass::UnsupportedRecord
+        }
+    }
+}
+
+const fn rejection_detail(kind: OpenCodeNativeRejectionKind) -> &'static str {
+    match kind {
+        OpenCodeNativeRejectionKind::MalformedJson => "contains malformed JSON",
+        OpenCodeNativeRejectionKind::MalformedResultJson => "contains malformed result JSON",
+        OpenCodeNativeRejectionKind::UnsupportedStorageClass => {
+            "uses an unsupported SQLite storage class"
+        }
+        OpenCodeNativeRejectionKind::OversizedRetainedContent => {
+            "exceeds the retained-content size limit"
+        }
+        OpenCodeNativeRejectionKind::MissingSession => "references a missing session",
+        OpenCodeNativeRejectionKind::MissingMessage => "references a missing message",
+        OpenCodeNativeRejectionKind::SessionRelationshipMismatch => {
+            "has inconsistent session relationships"
+        }
+        OpenCodeNativeRejectionKind::UnknownRecordType => "has an unsupported record type",
+        OpenCodeNativeRejectionKind::InvalidTimestamp => "has an invalid timestamp",
+    }
+}

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/pack_tests.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/pack_tests.rs
@@ -197,7 +197,24 @@ fn scan_current_schema(
     OpenCodeSourceBackedScan,
     Vec<CoreRecord>,
 ) {
-    scan_current_schema_result(
+    let (observation, scan, records, _) = scan_current_schema_result_with_rejections(
+        path,
+        crate::test_provider_sqlite_data_root(),
+        OPENCODE_FALLBACK_SCRATCH_MAX_BYTES,
+    )
+    .unwrap();
+    (observation, scan, records)
+}
+
+fn scan_current_schema_with_rejections(
+    path: &Path,
+) -> (
+    OpenCodeLogicalObservation,
+    OpenCodeSourceBackedScan,
+    Vec<CoreRecord>,
+    Vec<SourceBackedRecordRejectionDraft>,
+) {
+    scan_current_schema_result_with_rejections(
         path,
         crate::test_provider_sqlite_data_root(),
         OPENCODE_FALLBACK_SCRATCH_MAX_BYTES,
@@ -214,12 +231,28 @@ fn scan_current_schema_result(
     OpenCodeSourceBackedScan,
     Vec<CoreRecord>,
 )> {
+    let (observation, scan, records, _) =
+        scan_current_schema_result_with_rejections(path, data_root, scratch_limit)?;
+    Ok((observation, scan, records))
+}
+
+fn scan_current_schema_result_with_rejections(
+    path: &Path,
+    data_root: &Path,
+    scratch_limit: u64,
+) -> OpenCodeSourceBackedResult<(
+    OpenCodeLogicalObservation,
+    OpenCodeSourceBackedScan,
+    Vec<CoreRecord>,
+    Vec<SourceBackedRecordRejectionDraft>,
+)> {
     let authorized = open_root_authorized_snapshot_retained(data_root, path)?;
     let observation = observe_logical_source(
         authorized.sqlite_snapshot.connection()?,
         &crate::provider::providers::opencode::OPENCODE_SQLITE_DIALECT,
     )?;
     let mut records = Vec::new();
+    let mut rejections = Vec::new();
     let scan = scan_pinned_source_with_scratch_limit(
         path,
         &crate::provider::providers::opencode::OPENCODE_SQLITE_DIALECT,
@@ -227,13 +260,17 @@ fn scan_current_schema_result(
         authorized.sqlite_snapshot,
         scratch_limit,
         &mut |output| {
-            if let OpenCodeScanOutput::Document(record) = output {
-                records.push(record);
+            match output {
+                OpenCodeScanOutput::Document(record) => records.push(record),
+                OpenCodeScanOutput::Rejection(rejection) => rejections.push(rejection),
+                OpenCodeScanOutput::Begin(_)
+                | OpenCodeScanOutput::CompletedBytes(_)
+                | OpenCodeScanOutput::Progress(_) => {}
             }
             Ok(())
         },
     )?;
-    Ok((observation, scan, records))
+    Ok((observation, scan, records, rejections))
 }
 
 #[test]
@@ -407,35 +444,6 @@ fn empty_and_oversized_call_ids_omit_dependent_activity_without_losing_content()
         assert!(!activity.facts.is_empty());
         record.validate_contract().unwrap();
     }
-}
-
-#[test]
-fn invalid_call_id_never_publishes_a_summary_after_raw_content_no_longer_fits() {
-    let temp = crate::test_support_paths::tempdir().unwrap();
-    let database = temp.path().join("oversized-invalid-call-opencode.db");
-    let mut body = json!({
-        "type": "tool",
-        "call_id": "",
-        "tool": "read_file",
-        "state": {"input": {"payload": ""}}
-    });
-    let fixed_bytes = body.to_string().len();
-    body["state"]["input"]["payload"] = serde_json::Value::String(
-        "x".repeat(ctx_history_core::MAX_CORE_CONTENT_BYTES - fixed_bytes - 8),
-    );
-    assert_eq!(
-        body.to_string().len(),
-        ctx_history_core::MAX_CORE_CONTENT_BYTES - 8
-    );
-    drop(write_current_schema(&database, temp.path(), &body));
-
-    let (_, scan, records) = scan_current_schema(&database);
-
-    assert!(records.is_empty());
-    let counts = scan.certificate.counts();
-    assert_eq!(counts.complete_records, 1);
-    assert_eq!(counts.retained_records, 0);
-    assert_eq!(counts.rejected_records, 1);
 }
 
 #[test]
@@ -1004,6 +1012,7 @@ fn rejection_heavy_scan_reports_authoritative_completed_bytes_before_finishing()
     .unwrap();
     let mut completed_bytes = Vec::new();
     let mut accepted = 0_u64;
+    let mut rejections = 0_u64;
     let scan = scan_pinned_source(
         &database,
         &crate::provider::providers::opencode::OPENCODE_SQLITE_DIALECT,
@@ -1014,6 +1023,9 @@ fn rejection_heavy_scan_reports_authoritative_completed_bytes_before_finishing()
                 OpenCodeScanOutput::Begin(_) => {}
                 OpenCodeScanOutput::CompletedBytes(bytes) => completed_bytes.push(bytes),
                 OpenCodeScanOutput::Document(_) => accepted = accepted.saturating_add(1),
+                OpenCodeScanOutput::Rejection(_) => {
+                    rejections = rejections.saturating_add(1);
+                }
                 OpenCodeScanOutput::Progress(_) => {}
             }
             Ok(())
@@ -1026,6 +1038,7 @@ fn rejection_heavy_scan_reports_authoritative_completed_bytes_before_finishing()
     assert_eq!(counts.retained_records, 1);
     assert_eq!(counts.rejected_records, (ROWS - 1) as u64);
     assert_eq!(accepted, 1);
+    assert_eq!(rejections, (ROWS - 1) as u64);
     assert_eq!(completed_bytes.len(), ROWS as usize);
     assert_eq!(completed_bytes.iter().sum::<u64>(), counts.certified_bytes);
 }

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/projection.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/projection.rs
@@ -199,6 +199,7 @@ pub(super) fn decode_source_event_row(
     // payload or timestamp evidence is present in the same unsafe row.
     projection = apply_relationship_rejection(projection, relationship_code)?;
     Ok(SourceEventRow {
+        source_rowid: row.get(11)?,
         native_order: source_backed_decode_order(
             order_tag,
             &session_identity,

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/tests/current_schema.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/tests/current_schema.rs
@@ -1,4 +1,130 @@
 use super::*;
+use ctx_history_capture_runtime::SourceBackedRecordRejectionClass;
+
+#[test]
+fn current_file_parts_are_ignored_without_indexing_attachment_payloads() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let database = temp.path().join("current-file-part-opencode.db");
+    let attachment_sentinel = "attachment-payload-must-not-be-indexed";
+    drop(write_current_schema(
+        &database,
+        temp.path(),
+        &json!({
+            "type": "file",
+            "mime": "image/png",
+            "filename": "diagram.png",
+            "url": format!("data:image/png;base64,{attachment_sentinel}"),
+            "source": {
+                "type": "file",
+                "path": "diagram.png",
+                "text": {"value": attachment_sentinel, "start": 0, "end": 1}
+            }
+        }),
+    ));
+
+    let (_, scan, records, rejections) = scan_current_schema_with_rejections(&database);
+
+    assert!(records.is_empty());
+    assert!(rejections.is_empty());
+    assert_eq!(scan.certificate.counts().complete_records, 1);
+    assert_eq!(scan.certificate.counts().retained_records, 0);
+    assert_eq!(scan.certificate.counts().rejected_records, 0);
+    assert_eq!(scan.certificate.counts().ignored_records, 1);
+}
+
+#[test]
+fn unsupported_current_parts_emit_bounded_row_diagnostics() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let database = temp.path().join("unsupported-current-part-opencode.db");
+    drop(write_current_schema(
+        &database,
+        temp.path(),
+        &json!({"type": "future_part", "value": "unsupported"}),
+    ));
+
+    let (_, scan, records, rejections) = scan_current_schema_with_rejections(&database);
+
+    assert!(records.is_empty());
+    assert_eq!(scan.certificate.counts().rejected_records, 1);
+    let [rejection] = rejections.as_slice() else {
+        panic!("expected one bounded OpenCode row diagnostic");
+    };
+    assert_eq!(rejection.provider, CaptureProvider::OpenCode);
+    assert_eq!(rejection.source_selector, database.to_string_lossy());
+    assert_eq!(rejection.line_number, 1);
+    assert_eq!(rejection.payload_type.as_deref(), Some("sqlite_row"));
+    assert_eq!(
+        rejection.class,
+        SourceBackedRecordRejectionClass::UnsupportedRecord
+    );
+    assert!(rejection.detail.contains("unsupported record type"));
+}
+
+#[test]
+fn invalid_timestamp_diagnostics_do_not_echo_provider_values() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let database = temp.path().join("invalid-timestamp-opencode.db");
+    let connection = write_current_schema(
+        &database,
+        temp.path(),
+        &json!({"type": "text", "text": "invalid timestamp"}),
+    );
+    connection
+        .execute("update part set time_created = ?1", [i64::MAX])
+        .unwrap();
+    drop(connection);
+
+    let (_, scan, records, rejections) = scan_current_schema_with_rejections(&database);
+
+    assert!(records.is_empty());
+    assert_eq!(scan.certificate.counts().rejected_records, 1);
+    let [rejection] = rejections.as_slice() else {
+        panic!("expected one invalid timestamp diagnostic");
+    };
+    assert_eq!(
+        rejection.class,
+        SourceBackedRecordRejectionClass::MalformedRecord
+    );
+    assert!(rejection.detail.contains("invalid timestamp"));
+    assert!(!rejection.detail.contains(&i64::MAX.to_string()));
+}
+
+#[test]
+fn core_projection_failures_emit_row_diagnostics() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let database = temp.path().join("oversized-invalid-call-opencode.db");
+    let mut body = json!({
+        "type": "tool",
+        "call_id": "",
+        "tool": "read_file",
+        "state": {"input": {"payload": ""}}
+    });
+    let fixed_bytes = body.to_string().len();
+    body["state"]["input"]["payload"] = serde_json::Value::String(
+        "x".repeat(ctx_history_core::MAX_CORE_CONTENT_BYTES - fixed_bytes - 8),
+    );
+    assert_eq!(
+        body.to_string().len(),
+        ctx_history_core::MAX_CORE_CONTENT_BYTES - 8
+    );
+    drop(write_current_schema(&database, temp.path(), &body));
+
+    let (_, scan, records, rejections) = scan_current_schema_with_rejections(&database);
+
+    assert!(records.is_empty());
+    let counts = scan.certificate.counts();
+    assert_eq!(counts.complete_records, 1);
+    assert_eq!(counts.retained_records, 0);
+    assert_eq!(counts.rejected_records, 1);
+    let [rejection] = rejections.as_slice() else {
+        panic!("expected one Core projection rejection diagnostic");
+    };
+    assert_eq!(
+        rejection.class,
+        SourceBackedRecordRejectionClass::UnsupportedRecord
+    );
+    assert!(rejection.detail.contains("Core projection limits"));
+}
 
 pub(super) fn create_current_fixture(path: &Path) -> Connection {
     fs::create_dir_all(path.parent().unwrap()).unwrap();


### PR DESCRIPTION
## Summary

- treat OpenCode-family message file parts as known ignored carriers before generic output routing
- keep attachment bytes, data URLs, filenames, MIME metadata, and source paths out of searchable Core content
- publish bounded SQLite row diagnostics for genuinely malformed or unsupported records
- cover scanner, adapter, CLI import, projection-limit, and privacy behavior

## Provider consistency

Existing providers use mixed attachment behavior: explicit media is commonly ignored, while some generic tool JSON paths retain embedded values. None of the audited providers dereference attachment files or perform OCR. This change keeps OpenCode on the safer explicit-media boundary.

## Validation

- scripts/check.sh --mode=ci
- authentic OpenCode 1.18.18 server capture: main reported 3 complete / 2 retained / 1 rejected with no diagnostic; this branch reports 3 complete / 2 retained / 1 ignored / 0 rejected
- independent code, test, and privacy reviews

Fixes #815