### PR TITLE
fix(upgrade): allow Core-only managed updates

### DIFF
--- a/crates/ctx-daemon-cli/BUILD.bazel
+++ b/crates/ctx-daemon-cli/BUILD.bazel
@@ -169,6 +169,7 @@ daemon_cli_binary_contract(
     name = "auto_upgrade_acceptance_tests",
     src = "tests/contracts/auto_upgrade_acceptance.rs",
     extra_srcs = [
+        "tests/contracts/auto_upgrade_acceptance/core_only_release.rs",
         "tests/contracts/auto_upgrade_acceptance/invalid_marker.rs",
         "tests/contracts/auto_upgrade_acceptance/foreground_authority.rs",
     ],

--- a/crates/ctx-daemon-cli/tests/contracts/auto_upgrade_acceptance.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/auto_upgrade_acceptance.rs
@@ -925,6 +925,12 @@ mod unix {
         include!("auto_upgrade_acceptance/foreground_authority.rs");
     }
 
+    mod core_only_release {
+        use super::*;
+
+        include!("auto_upgrade_acceptance/core_only_release.rs");
+    }
+
     #[test]
     fn daemon_disabled_has_no_automatic_upgrade_side_effects() {
         let temp = tempdir();

--- a/crates/ctx-daemon-cli/tests/contracts/auto_upgrade_acceptance/core_only_release.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/auto_upgrade_acceptance/core_only_release.rs
@@ -1,0 +1,22 @@
+#[test]
+fn persistent_daemon_upgrades_without_legacy_runtime_metadata() {
+    let temp = tempdir();
+    let mut release = fake_legacy_release(&temp, FIXTURE_TARGET_VERSION);
+    let binary = managed_hook_candidate(&temp, "ia_daemon_core_only_release");
+    patch_release_artifact_with_next_ctx(&mut release, &binary, FIXTURE_TARGET_VERSION);
+    seed_authoritative_codex_source(temp.path());
+
+    managed_daemon(&temp, &release, &binary)
+        .env("CTX_DAEMON_AUTOSTART_OFF", "1")
+        .assert()
+        .success();
+
+    let marker: Value =
+        serde_json::from_slice(&fs::read(install_marker_path(&binary)).unwrap()).unwrap();
+    let state: Value =
+        serde_json::from_slice(&fs::read(scheduler_state_path(&binary)).unwrap()).unwrap();
+    assert_eq!(marker["version"], FIXTURE_TARGET_VERSION);
+    assert_eq!(state["status"], "applied");
+    assert_eq!(state["attempt_source"], "automatic");
+    assert!(!data_root(&temp).join("runtime").exists());
+}

--- a/crates/ctx-upgrade-engine/src/upgrade/command.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/command.rs
@@ -579,15 +579,6 @@ fn apply_upgrade<D: DaemonUpgradePort + ?Sized>(
                 plan.latest_version
             ));
         }
-        if plan.update_available
-            && plan.semantic_provisioning.is_none()
-            && plan.metadata.onnxruntime.is_none()
-        {
-            return Err(anyhow!(
-                "release {} is newer than this ctx build but has no complete ONNX Runtime sidecar metadata; refusing a downgrade-compatible legacy update",
-                plan.latest_version
-            ));
-        }
         if dry_run {
             write_state_checked_locked(
                 data_root,
@@ -639,6 +630,9 @@ fn apply_upgrade<D: DaemonUpgradePort + ?Sized>(
         } else {
             None
         };
+        // Supplementary runtime metadata is optional for Core-only releases.
+        // Preserve or repair the legacy runtime only when signed metadata
+        // actually carries that runtime contract.
         let mut runtime_artifact = if (plan.update_available || repairs.legacy_runtime)
             && plan.semantic_provisioning.is_none()
         {

--- a/crates/ctx-upgrade-engine/src/upgrade/command/daemon.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/command/daemon.rs
@@ -255,15 +255,6 @@ where
                 plan.latest_version
             ));
         }
-        if plan.update_available
-            && plan.semantic_provisioning.is_none()
-            && plan.metadata.onnxruntime.is_none()
-        {
-            return Err(anyhow!(
-                "release {} has no complete ONNX Runtime sidecar metadata",
-                plan.latest_version
-            ));
-        }
         let artifact = if plan.update_available {
             Some(
                 DownloadedArtifact::download_verified(
@@ -297,6 +288,7 @@ where
                     )
                     .with_context(|| format!("download or reuse {runtime_url}"))?,
                 ),
+                (None, None) => None,
                 _ => return Err(anyhow!("incomplete ONNX Runtime upgrade plan")),
             }
         } else {

--- a/crates/ctx-upgrade-engine/tests/contracts/upgrade.rs
+++ b/crates/ctx-upgrade-engine/tests/contracts/upgrade.rs
@@ -675,19 +675,19 @@ fn upgrade_status_accepts_current_legacy_metadata_without_sidecar_fields() {
 
 #[cfg(unix)]
 #[test]
-fn upgrade_refuses_newer_legacy_metadata_without_sidecar_fields() {
+fn upgrade_applies_newer_metadata_without_sidecar_fields() {
     let temp = tempdir();
     let release = fake_legacy_release(&temp, "9.9.9");
 
-    let stderr = failure_stderr(fake_release_env(
+    let outcome = json_output(fake_release_env(
         ctx(&temp).args(["upgrade", "--format=json"]),
         &release,
     ));
 
-    assert!(
-        stderr.contains("has no complete ONNX Runtime sidecar metadata"),
-        "{stderr}"
-    );
+    assert_eq!(outcome["status"], "applied");
+    assert!(fs::read_to_string(&release.target)
+        .unwrap()
+        .contains("ctx 9.9.9"));
     assert!(!data_root(&temp).join("runtime").exists());
 }
 


### PR DESCRIPTION
## Summary

- allow managed installations to apply signed Core-only releases when supplementary ONNX Runtime metadata is intentionally absent
- retain legacy runtime download and repair whenever signed release metadata carries that contract
- cover both explicit and persistent-daemon automatic upgrades

## Testing

- `scripts/bazelw test //crates/ctx-upgrade-engine:upgrade_tests --test_filter=upgrade_applies_newer_metadata_without_sidecar_fields --test_output=errors`
- `scripts/bazelw test //crates/ctx-daemon-cli:auto_upgrade_acceptance_tests --test_arg=unix::core_only_release::persistent_daemon_upgrades_without_legacy_runtime_metadata --test_arg=--exact --test_output=errors`
- `cargo fmt --all -- --check`
- `git diff --check`

A broader daemon acceptance invocation also passed the new test and 22 other cases; one unrelated existing invalid-marker case failed before the focused exact rerun passed.