### PR TITLE
fix: default foreground Core ML embeddings to CPU

### DIFF
--- a/crates/ctx-semantic-model/src/configuration.rs
+++ b/crates/ctx-semantic-model/src/configuration.rs
@@ -131,6 +131,7 @@ pub struct SemanticModelConfig {
     backend_preference: SemanticBackendPreference,
     backend_preference_error: Option<String>,
     coreml_compute_mode: SemanticCoreMlComputeMode,
+    coreml_compute_mode_explicit: bool,
     coreml_compute_mode_error: Option<String>,
     thread_override: Option<usize>,
     batch_size_override: Option<usize>,
@@ -144,6 +145,7 @@ impl SemanticModelConfig {
             backend_preference: SemanticBackendPreference::Auto,
             backend_preference_error: None,
             coreml_compute_mode: SemanticCoreMlComputeMode::All,
+            coreml_compute_mode_explicit: false,
             coreml_compute_mode_error: None,
             thread_override: None,
             batch_size_override: None,
@@ -164,6 +166,7 @@ impl SemanticModelConfig {
 
     pub fn with_coreml_compute_mode(mut self, mode: SemanticCoreMlComputeMode) -> Self {
         self.coreml_compute_mode = mode;
+        self.coreml_compute_mode_explicit = true;
         self.coreml_compute_mode_error = None;
         self
     }
@@ -207,6 +210,17 @@ impl SemanticModelConfig {
             .map_or(Ok(self.coreml_compute_mode), |error| {
                 Err(anyhow!(error.clone()))
             })
+    }
+
+    #[cfg(any(all(ctx_semantic_fastembed, target_os = "macos"), test))]
+    pub(crate) fn foreground_coreml_compute_mode(&self) -> Result<SemanticCoreMlComputeMode> {
+        self.coreml_compute_mode().map(|mode| {
+            if self.coreml_compute_mode_explicit {
+                mode
+            } else {
+                SemanticCoreMlComputeMode::CpuOnly
+            }
+        })
     }
 
     pub(crate) const fn thread_override(&self) -> Option<usize> {

--- a/crates/ctx-semantic-model/src/model_runtime/coreml.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/coreml.rs
@@ -72,7 +72,7 @@ pub(super) fn acquire_coreml_backend(
     preference: SemanticBackendPreference,
     fallback: Option<&'static str>,
 ) -> Result<SemanticEmbedder> {
-    let compute = coreml_compute_config(config.coreml_compute_mode()?);
+    let compute = coreml_compute_config(config.foreground_coreml_compute_mode()?);
     if let Some(deferred) = semantic_model_load_deferred(
         SemanticSystemResources::current().available_memory_bytes,
         compute.compute_class,

--- a/crates/ctx-semantic-model/src/model_runtime/tests.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/tests.rs
@@ -344,6 +344,30 @@ pub(super) fn coreml_cpu_only_uses_cpu_quiet_policy_class() {
 }
 
 #[test]
+fn foreground_coreml_defaults_to_cpu_but_honors_explicit_compute_mode() {
+    let temp = tempfile::tempdir().unwrap();
+    let default_config = test_config(temp.path());
+    assert_eq!(
+        default_config.coreml_compute_mode().unwrap(),
+        SemanticCoreMlComputeMode::All
+    );
+    assert_eq!(
+        default_config.foreground_coreml_compute_mode().unwrap(),
+        SemanticCoreMlComputeMode::CpuOnly
+    );
+
+    for mode in [
+        SemanticCoreMlComputeMode::All,
+        SemanticCoreMlComputeMode::CpuAndNeuralEngine,
+        SemanticCoreMlComputeMode::CpuAndGpu,
+        SemanticCoreMlComputeMode::CpuOnly,
+    ] {
+        let config = test_config(temp.path()).with_coreml_compute_mode(mode);
+        assert_eq!(config.foreground_coreml_compute_mode().unwrap(), mode);
+    }
+}
+
+#[test]
 pub(super) fn normalization_is_central_and_strict() {
     let mut vector = vec![0.0; SEMANTIC_DIMENSIONS];
     vector[0] = 3.0;


### PR DESCRIPTION
## Summary

- Default foreground Core ML model acquisition to CPU when no compute mode was explicitly selected.
- Continue honoring every explicit Core ML compute override.
- Leave daemon acquisition behavior unchanged.

## Why

On macOS, the stock v1.2.3 binary remained in implicit Core ML/ANE compilation and model loading for more than eight minutes during a daemon-free `--refresh wait` search. The same binary completed in 29.41 seconds with `CTX_SEMANTIC_COREML_NATIVE_COMPUTE=cpu` and left no background ctx process.

Foreground searches are finite, user-triggered work. A reliable implicit default is more useful there than waiting indefinitely on accelerator setup. Users who want an accelerator can still select one explicitly.

## Validation

```text
cargo fmt --all -- --check
cargo test -p ctx-semantic-model --no-default-features
94 passed; 0 failed

cargo test -p ctx-semantic-model foreground_coreml_defaults_to_cpu_but_honors_explicit_compute_mode -- --nocapture
1 passed; 0 failed
```

The regression test checks that foreground acquisition defaults to CPU and that explicit `all`, `cpuAndNeuralEngine`, `cpuAndGPU`, and `cpuOnly` selections remain unchanged.

Closes #823
