### PR TITLE
fix(search): wait for semantic catch-up after refresh

### DIFF
--- a/crates/ctx-daemon-cli/src/lib.rs
+++ b/crates/ctx-daemon-cli/src/lib.rs
@@ -159,7 +159,7 @@ pub use ctx_semantic_index::SemanticNotReady;
 #[allow(unused_imports)]
 pub use runtime_limits::SEMANTIC_WORKER_BATCH_MAX;
 mod query_adapter;
-pub use query_adapter::SemanticQueryAdapter;
+pub use query_adapter::{wait_for_daemon_semantic_generation, SemanticQueryAdapter};
 mod query_service;
 pub use query_service::wait_for_daemon_query_service;
 mod daemon;

--- a/crates/ctx-daemon-cli/src/query_adapter.rs
+++ b/crates/ctx-daemon-cli/src/query_adapter.rs
@@ -1,8 +1,12 @@
-use std::{path::Path, time::Duration as StdDuration, time::Instant};
+use std::{
+    path::Path,
+    thread,
+    time::{Duration as StdDuration, Instant},
+};
 
 use anyhow::{anyhow, Result};
-use ctx_daemon_service::DaemonQueryServiceUnavailable;
-use ctx_history_index::{CompiledSearchFilter, EventSearchCandidate, VerifiedIndex};
+use ctx_daemon_service::{DaemonQueryServiceUnavailable, PinnedSourceBackedGeneration};
+use ctx_history_index::{CompiledSearchFilter, EventSearchCandidate, IndexError, VerifiedIndex};
 use ctx_history_read_application::{
     HistorySemanticBatch, HistorySemanticError, HistorySemanticPort, HistorySemanticQuery,
     SemanticReason,
@@ -20,6 +24,94 @@ use serde_json::{json, Value};
 use crate::compact_json;
 
 use super::query_service::daemon_query_request;
+
+const SEMANTIC_GENERATION_POLL_INTERVAL: StdDuration = StdDuration::from_millis(100);
+
+/// Waits for daemon-owned semantic coverage of the current verified Core
+/// generation. A newer active Core generation replaces the original pin so
+/// query preflight never combines generations and does not wait for semantic
+/// coverage that the daemon has legitimately superseded.
+pub fn wait_for_daemon_semantic_generation(
+    data_root: &Path,
+    pin: PinnedSourceBackedGeneration,
+    timeout: StdDuration,
+) -> Result<PinnedSourceBackedGeneration> {
+    wait_for_daemon_semantic_generation_with(
+        data_root,
+        pin,
+        timeout,
+        || crate::pin_active_verified_generation(data_root),
+        thread::sleep,
+    )
+}
+
+fn wait_for_daemon_semantic_generation_with<Repin, Pause>(
+    data_root: &Path,
+    mut pin: PinnedSourceBackedGeneration,
+    timeout: StdDuration,
+    mut repin: Repin,
+    mut pause: Pause,
+) -> Result<PinnedSourceBackedGeneration>
+where
+    Repin: FnMut() -> Result<PinnedSourceBackedGeneration>,
+    Pause: FnMut(StdDuration),
+{
+    let started = Instant::now();
+    loop {
+        match repin() {
+            Ok(next) => {
+                if next.generation_id() != pin.generation_id() {
+                    pin = next;
+                }
+            }
+            Err(error) if active_generation_changed_during_repin(&error) => {
+                let remaining = timeout.saturating_sub(started.elapsed());
+                if remaining.is_zero() {
+                    return Err(error);
+                }
+                pause(SEMANTIC_GENERATION_POLL_INTERVAL.min(remaining));
+                continue;
+            }
+            Err(error) => return Err(error),
+        }
+        match SemanticQueryPin::preflight(
+            pin.verified_index(),
+            data_root,
+            semantic_model_contract(),
+        ) {
+            Ok(_) => return Ok(pin),
+            Err(error) if semantic_generation_wait_is_retryable(&error) => {}
+            Err(_) => return Ok(pin),
+        }
+        let remaining = timeout.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            return Ok(pin);
+        }
+        pause(SEMANTIC_GENERATION_POLL_INTERVAL.min(remaining));
+    }
+}
+
+fn active_generation_changed_during_repin(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<IndexError>(),
+            Some(IndexError::ConcurrentGenerationChange)
+        )
+    })
+}
+
+fn semantic_generation_wait_is_retryable(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<SemanticNotReady>()
+        .is_some_and(|error| {
+            matches!(
+                error.code(),
+                "semantic_store_unavailable"
+                    | "semantic_store_missing"
+                    | "semantic_generation_not_acknowledged"
+            )
+        })
+}
 
 pub struct SemanticQueryAdapter<'data_root> {
     data_root: &'data_root Path,

--- a/crates/ctx-daemon-cli/src/query_adapter/tests.rs
+++ b/crates/ctx-daemon-cli/src/query_adapter/tests.rs
@@ -35,6 +35,14 @@ fn semantic_index_revision(
     revision: u64,
     include_record: bool,
 ) -> Result<(VerifiedIndex, Uuid)> {
+    semantic_index_revision_at(&root.join("index"), revision, include_record)
+}
+
+fn semantic_index_revision_at(
+    index_root: &Path,
+    revision: u64,
+    include_record: bool,
+) -> Result<(VerifiedIndex, Uuid)> {
     let source = SourceKey::derive(
         "codex",
         "codex_session_jsonl",
@@ -56,8 +64,7 @@ fn semantic_index_revision(
         native_item_key: &NativeItemKey::native_id("message", TypedKey::U64(revision))?,
         subrecord_selector: None,
     })?;
-    let index_root = root.join("index");
-    let mut writer = GenerationWriter::open(&index_root, WriterOptions::default())?
+    let mut writer = GenerationWriter::open(index_root, WriterOptions::default())?
         .into_writer()
         .map_err(crate::committed_generation_recovery_error)?;
     writer.begin_source(source.clone())?;
@@ -94,7 +101,7 @@ fn semantic_index_revision(
         },
     )?)?;
     writer.commit(|_| true)?;
-    Ok((VerifiedIndex::open_pinned(&index_root)?, event_id.as_uuid()))
+    Ok((VerifiedIndex::open_pinned(index_root)?, event_id.as_uuid()))
 }
 
 struct RejectingSemanticPorts;
@@ -450,6 +457,138 @@ fn adapter_never_embeds_before_missing_or_unacknowledged_store_preflight() -> Re
             }
         ));
     }
+    Ok(())
+}
+
+#[test]
+fn daemon_generation_wait_observes_delayed_acknowledgement_without_sleeping() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let index_root = ctx_history_refresh::source_backed_index_root(temp.path());
+    let (index, _) = semantic_index_revision_at(&index_root, 1, true)?;
+    let generation = index.generation_id().to_owned();
+    let reconciliation_index = VerifiedIndex::open_pinned(&index_root)?;
+    let pauses = Cell::new(0_u32);
+
+    let pin = wait_for_daemon_semantic_generation_with(
+        temp.path(),
+        PinnedSourceBackedGeneration::from_index(index),
+        Duration::from_secs(1),
+        || crate::pin_active_verified_generation(temp.path()),
+        |_| {
+            pauses.set(pauses.get() + 1);
+            reconcile_ready_nonempty_generation(&reconciliation_index, temp.path()).unwrap();
+        },
+    )?;
+
+    assert_eq!(pauses.get(), 1);
+    assert_eq!(pin.generation_id(), generation);
+    SemanticQueryPin::preflight(pin.verified_index(), temp.path(), semantic_model_contract())?;
+    Ok(())
+}
+
+#[test]
+fn daemon_generation_wait_repins_both_indexes_after_core_supersession() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let index_root = ctx_history_refresh::source_backed_index_root(temp.path());
+    let (first, _) = semantic_index_revision_at(&index_root, 1, true)?;
+    let first_generation = first.generation_id().to_owned();
+    let (second, _) = semantic_index_revision_at(&index_root, 2, true)?;
+    let second_generation = second.generation_id().to_owned();
+    reconcile_ready_nonempty_generation(&second, temp.path())?;
+
+    let pin = wait_for_daemon_semantic_generation_with(
+        temp.path(),
+        PinnedSourceBackedGeneration::from_index(first),
+        Duration::from_secs(1),
+        || crate::pin_active_verified_generation(temp.path()),
+        |_| {},
+    )?;
+
+    assert_ne!(first_generation, second_generation);
+    assert_eq!(pin.generation_id(), second_generation);
+    SemanticQueryPin::preflight(pin.verified_index(), temp.path(), semantic_model_contract())?;
+    Ok(())
+}
+
+#[test]
+fn daemon_generation_wait_repins_before_returning_a_ready_old_generation() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let index_root = ctx_history_refresh::source_backed_index_root(temp.path());
+    let (first, _) = semantic_index_revision_at(&index_root, 1, true)?;
+    reconcile_ready_nonempty_generation(&first, temp.path())?;
+    let (second, _) = semantic_index_revision_at(&index_root, 2, true)?;
+    let second_generation = second.generation_id().to_owned();
+    reconcile_ready_nonempty_generation(&second, temp.path())?;
+
+    let pin = wait_for_daemon_semantic_generation_with(
+        temp.path(),
+        PinnedSourceBackedGeneration::from_index(first),
+        Duration::from_secs(1),
+        || crate::pin_active_verified_generation(temp.path()),
+        |_| {},
+    )?;
+
+    assert_eq!(pin.generation_id(), second_generation);
+    Ok(())
+}
+
+#[test]
+fn daemon_generation_wait_retries_a_concurrent_repin_before_preflight() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let index_root = ctx_history_refresh::source_backed_index_root(temp.path());
+    let (first, _) = semantic_index_revision_at(&index_root, 1, true)?;
+    reconcile_ready_nonempty_generation(&first, temp.path())?;
+    let (second, _) = semantic_index_revision_at(&index_root, 2, true)?;
+    let second_generation = second.generation_id().to_owned();
+    reconcile_ready_nonempty_generation(&second, temp.path())?;
+    let repins = Cell::new(0_u32);
+
+    let pin = wait_for_daemon_semantic_generation_with(
+        temp.path(),
+        PinnedSourceBackedGeneration::from_index(first),
+        Duration::from_secs(1),
+        || {
+            repins.set(repins.get() + 1);
+            if repins.get() == 1 {
+                Err(IndexError::ConcurrentGenerationChange.into())
+            } else {
+                crate::pin_active_verified_generation(temp.path())
+            }
+        },
+        |_| {},
+    )?;
+
+    assert_eq!(repins.get(), 2);
+    assert_eq!(pin.generation_id(), second_generation);
+    Ok(())
+}
+
+#[test]
+fn daemon_generation_wait_timeout_preserves_typed_query_preflight_failure() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let index_root = ctx_history_refresh::source_backed_index_root(temp.path());
+    let (index, _) = semantic_index_revision_at(&index_root, 1, true)?;
+    SemanticVectorStore::open(
+        &source_backed_semantic_vector_path(temp.path()),
+        semantic_model_contract(),
+    )?;
+
+    let pin = wait_for_daemon_semantic_generation_with(
+        temp.path(),
+        PinnedSourceBackedGeneration::from_index(index),
+        Duration::ZERO,
+        || crate::pin_active_verified_generation(temp.path()),
+        |_| panic!("zero timeout must not sleep"),
+    )?;
+    let error =
+        SemanticQueryPin::preflight(pin.verified_index(), temp.path(), semantic_model_contract())
+            .err()
+            .expect("unacknowledged generation must remain a typed query failure");
+    let not_ready = error
+        .downcast_ref::<SemanticNotReady>()
+        .expect("semantic preflight failure remains typed");
+    assert_eq!(not_ready.code(), "semantic_generation_not_acknowledged");
+    assert!(not_ready.retryable());
     Ok(())
 }
 

--- a/crates/ctx-history-cli/src/source_index/search.rs
+++ b/crates/ctx-history-cli/src/source_index/search.rs
@@ -28,8 +28,9 @@ use crate::{
     HistoryCliConfig, RefreshMode, SearchExecutionObservation, SearchFailurePhase,
 };
 use ctx_daemon_cli::{
-    wait_for_daemon_query_service, PinnedSourceBackedGeneration,
-    SourceBackedRefreshDaemonUnavailable, SourceBackedRefreshMode, SourceBackedRefreshObservation,
+    wait_for_daemon_query_service, wait_for_daemon_semantic_generation,
+    PinnedSourceBackedGeneration, SourceBackedRefreshDaemonUnavailable, SourceBackedRefreshMode,
+    SourceBackedRefreshObservation,
 };
 
 use super::{
@@ -63,6 +64,7 @@ pub(super) use test_support::{
 };
 
 const MAX_USAGE_CONTEXT_EVENTS_PER_SESSION: usize = 256;
+const SEMANTIC_GENERATION_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 type RefreshArg = RefreshMode;
 pub(super) const MISSING_INDEX_ERROR: &str =
     "the Core index does not exist; retry with daemon refresh enabled";
@@ -370,18 +372,23 @@ fn run_search_inner<P: HistorySemanticPort>(
     let requested_backend = request.backend.unwrap_or(policy.default_backend);
     observation.backend_requested = Some(requested_backend);
     let semantic_weight = request.semantic_weight;
-    if refresh_mode == RefreshArg::Background
-        && policy.semantic == SemanticAvailability::Available
-        && matches!(
-            requested_backend,
-            SearchBackend::Semantic | SearchBackend::Hybrid
-        )
-        && unsupported_semantic_scope(request).is_none()
-        && !(requested_backend == SearchBackend::Hybrid && semantic_weight == 0.0)
-    {
+    let needs_semantic = search_needs_semantic_evidence(
+        request,
+        requested_backend,
+        semantic_weight,
+        policy.semantic,
+    );
+    if refresh_mode == RefreshArg::Background && needs_semantic {
         wait_for_daemon_query_service(&data_root, Duration::from_secs(3));
     }
-    let refresh = observed_refresh_for_search(request, refresh_mode, &data_root, observation)?;
+    let mut refresh = observed_refresh_for_search(request, refresh_mode, &data_root, observation)?;
+    if refresh_mode == RefreshArg::Wait && config.daemon.enabled && needs_semantic {
+        refresh.pin = wait_for_daemon_semantic_generation(
+            &data_root,
+            refresh.pin,
+            SEMANTIC_GENERATION_WAIT_TIMEOUT,
+        )?;
+    }
     let search_result = search_pinned_generation(
         plan,
         &data_root,
@@ -489,6 +496,21 @@ fn run_search_inner<P: HistorySemanticPort>(
     local_usage.set_search_context_observation(search_context);
     local_usage.set_measured_output_bytes(output_bytes);
     Ok(())
+}
+
+pub(super) fn search_needs_semantic_evidence(
+    request: &SourceSearchRequest,
+    requested_backend: SearchBackend,
+    semantic_weight: f32,
+    availability: SemanticAvailability,
+) -> bool {
+    availability == SemanticAvailability::Available
+        && matches!(
+            requested_backend,
+            SearchBackend::Semantic | SearchBackend::Hybrid
+        )
+        && unsupported_semantic_scope(request).is_none()
+        && !(requested_backend == SearchBackend::Hybrid && semantic_weight == 0.0)
 }
 
 pub(super) const fn compact_search_projection(json_output: bool, verbose: bool) -> bool {

--- a/crates/ctx-history-cli/src/source_index/tests/additional.rs
+++ b/crates/ctx-history-cli/src/source_index/tests/additional.rs
@@ -606,6 +606,56 @@ fn manual_wait_makes_semantic_execution_available_only_for_that_cli_search() {
 }
 
 #[test]
+fn semantic_generation_wait_is_limited_to_queries_that_need_semantic_evidence() {
+    let available = ctx_history_read_application::SemanticAvailability::Available;
+    let mut source_request = request(RefreshArg::Wait);
+
+    source_request.backend = Some(SearchBackendArg::Semantic);
+    assert!(super::search::search_needs_semantic_evidence(
+        &source_request,
+        SearchBackendArg::Semantic,
+        source_request.semantic_weight,
+        available,
+    ));
+
+    source_request.backend = Some(SearchBackendArg::Lexical);
+    assert!(!super::search::search_needs_semantic_evidence(
+        &source_request,
+        SearchBackendArg::Lexical,
+        source_request.semantic_weight,
+        available,
+    ));
+
+    source_request.backend = Some(SearchBackendArg::Hybrid);
+    source_request.semantic_weight = 0.0;
+    assert!(!super::search::search_needs_semantic_evidence(
+        &source_request,
+        SearchBackendArg::Hybrid,
+        source_request.semantic_weight,
+        available,
+    ));
+
+    source_request.semantic_weight = 0.35;
+    source_request.content_scope = SearchContentScope::Calls;
+    assert!(!super::search::search_needs_semantic_evidence(
+        &source_request,
+        SearchBackendArg::Hybrid,
+        source_request.semantic_weight,
+        available,
+    ));
+
+    source_request.content_scope = SearchContentScope::All;
+    assert!(!super::search::search_needs_semantic_evidence(
+        &source_request,
+        SearchBackendArg::Hybrid,
+        source_request.semantic_weight,
+        ctx_history_read_application::SemanticAvailability::Unavailable(
+            ctx_history_read_application::SemanticReason::PolicyDisabled,
+        ),
+    ));
+}
+
+#[test]
 fn daemon_disabled_mcp_default_and_hybrid_return_lexical_fallback() {
     let temp = tempdir().unwrap();
     write_test_generation(temp.path());

--- a/docs/daemon-semantic-indexing-spec.md
+++ b/docs/daemon-semantic-indexing-spec.md
@@ -53,6 +53,12 @@ Freshness is separate from retrieval mode:
 | `off` | Serve current indexes and do not start, poke, wait for, or run indexing. |
 | `wait` | Wait for authoritative Core publication from the persistent daemon or a manual-mode finite Core worker, then search or fail with a clear local error. |
 
+When an automatic-mode `wait` search needs semantic evidence, it also waits
+for the daemon's semantic acknowledgement of the selected Core generation. If
+Core advances during that bounded wait, search repins Core and semantic
+together before querying. Lexical, zero-weight hybrid, and unsupported semantic
+scopes skip this wait.
+
 The existing `strict` behavior can map to `wait` for command-line users while
 the public docs move to `wait`. Do not add compatibility aliases unless a
 specific external contract requires them.

--- a/docs/search.md
+++ b/docs/search.md
@@ -285,10 +285,13 @@ an explicit import.
 finite Core worker in manual mode, then waits for the requested source frontier
 and lexical-generation receipt. It fails with a typed source, lag, or system
 error when that receipt cannot publish; it does not fall back to a foreground
-importer. In manual mode, a semantic or nonzero-weight hybrid request then fully
-reconciles semantic coverage for that same pinned Core generation and uses the
-same foreground model runtime to embed the query. Lexical, zero-weight hybrid,
-and unsupported semantic scopes do no semantic model or projection work.
+importer. In auto mode, a semantic or nonzero-weight hybrid request also waits
+for daemon acknowledgement of the selected Core generation; if Core advances
+during that bounded wait, the query repins both indexes together. In manual
+mode, the same request fully reconciles semantic coverage for the pinned Core
+generation and uses the same foreground model runtime to embed the query.
+Lexical, zero-weight hybrid, and unsupported semantic scopes do no semantic
+model or projection work.
 
 `--refresh off` queries the currently published generations without provider
 discovery, plugin execution, refresh scheduling, semantic catch-up, or model


### PR DESCRIPTION
## Summary

- wait for daemon semantic acknowledgement after an automatic Core refresh when semantic evidence is required
- repin to the active verified Core generation before each readiness check so Core and semantic search stay generation-consistent
- preserve existing timeout, fallback, and bypass behavior for lexical, zero-weight hybrid, unsupported scopes, and non-wait modes

## Testing

- `scripts/bazelw test //crates/ctx-daemon-cli:unit_tests //crates/ctx-history-cli:unit_tests //crates/ctx-history-read-application:search_refresh_tests`
- `scripts/check.sh --mode=ci`

Fixes #814