### PR TITLE
fix(telemetry): recover background delivery health

### DIFF
--- a/crates/ctx-cli/src/analytics.rs
+++ b/crates/ctx-cli/src/analytics.rs
@@ -26,9 +26,36 @@ pub(crate) fn send_batch(
     config: &crate::config::AppConfig,
     events: &[PublicEventV1],
 ) {
-    if let Err(error) =
-        crate::observability_composition::deliver_analytics_batch(data_root, config, events)
-    {
+    send_batch_with_timeout(
+        data_root,
+        config,
+        events,
+        crate::net::TELEMETRY_HTTP_TIMEOUT,
+    );
+}
+
+pub(crate) fn send_daemon_batch(
+    data_root: &std::path::Path,
+    config: &crate::config::AppConfig,
+    events: &[PublicEventV1],
+) {
+    send_batch_with_timeout(
+        data_root,
+        config,
+        events,
+        crate::net::DAEMON_TELEMETRY_HTTP_TIMEOUT,
+    );
+}
+
+fn send_batch_with_timeout(
+    data_root: &std::path::Path,
+    config: &crate::config::AppConfig,
+    events: &[PublicEventV1],
+    timeout: std::time::Duration,
+) {
+    if let Err(error) = crate::observability_composition::deliver_analytics_batch(
+        data_root, config, events, timeout,
+    ) {
         let quiet = DELIVERY_FAILURE_OUTPUT_QUIET.get();
         if !quiet && std::env::var_os("CTX_ANALYTICS_DEBUG").is_some() {
             eprintln!("ctx analytics delivery failed: {error:#}");

--- a/crates/ctx-cli/src/net.rs
+++ b/crates/ctx-cli/src/net.rs
@@ -13,6 +13,7 @@ use url::{Host, Url};
 use crate::analytics::AnalyticsDeliveryFailureClass;
 
 pub(crate) const TELEMETRY_HTTP_TIMEOUT: Duration = Duration::from_millis(250);
+pub(crate) const DAEMON_TELEMETRY_HTTP_TIMEOUT: Duration = Duration::from_secs(2);
 const MAX_ARTIFACT_REDIRECTS: usize = 5;
 
 #[derive(Debug)]
@@ -46,14 +47,12 @@ impl std::error::Error for TelemetryPostError {
     }
 }
 
-pub(crate) fn post_telemetry_json(
-    endpoint: &str,
-    body: &[u8],
-) -> std::result::Result<(), TelemetryPostError> {
-    post_json_with_timeout(endpoint, body, TELEMETRY_HTTP_TIMEOUT)
+#[cfg(test)]
+fn post_telemetry_json(endpoint: &str, body: &[u8]) -> std::result::Result<(), TelemetryPostError> {
+    post_telemetry_json_with_timeout(endpoint, body, TELEMETRY_HTTP_TIMEOUT)
 }
 
-fn post_json_with_timeout(
+pub(crate) fn post_telemetry_json_with_timeout(
     endpoint: &str,
     body: &[u8],
     timeout: Duration,
@@ -543,8 +542,13 @@ mod tests {
     }
 
     #[test]
-    fn telemetry_http_budget_is_at_most_250_milliseconds() {
+    fn interactive_telemetry_budget_stays_bounded() {
         assert_eq!(TELEMETRY_HTTP_TIMEOUT, Duration::from_millis(250));
+    }
+
+    #[test]
+    fn background_daemon_telemetry_can_wait_for_durable_ingest() {
+        assert_eq!(DAEMON_TELEMETRY_HTTP_TIMEOUT, Duration::from_secs(2));
     }
 
     #[test]

--- a/crates/ctx-cli/src/observability_composition.rs
+++ b/crates/ctx-cli/src/observability_composition.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use crate::{
     analytics::{AnalyticsDeliveryAuthority, AnalyticsDeliveryFailureClass, PublicEventV1},
@@ -25,6 +28,7 @@ pub(crate) fn deliver_analytics_batch(
     data_root: &Path,
     config: &AppConfig,
     events: &[PublicEventV1],
+    timeout: Duration,
 ) -> anyhow::Result<()> {
     if std::env::var_os("CTX_ANALYTICS_DRY_RUN").is_some() {
         return Ok(());
@@ -61,7 +65,7 @@ pub(crate) fn deliver_analytics_batch(
     };
     let mut outbox = crate::analytics_outbox::AnalyticsOutbox::open(outbox_path)?;
     let flush = outbox.flush(&config.analytics.endpoint, |body| {
-        crate::net::post_telemetry_json(&config.analytics.endpoint, body)
+        crate::net::post_telemetry_json_with_timeout(&config.analytics.endpoint, body, timeout)
             .map_err(|error| error.class())
     })?;
     let mut blocked = match flush {
@@ -71,7 +75,11 @@ pub(crate) fn deliver_analytics_batch(
     {
         let mut post_or_queue = |body: &[u8]| -> anyhow::Result<()> {
             if blocked.is_none() {
-                match crate::net::post_telemetry_json(&config.analytics.endpoint, body) {
+                match crate::net::post_telemetry_json_with_timeout(
+                    &config.analytics.endpoint,
+                    body,
+                    timeout,
+                ) {
                     Ok(()) => return Ok(()),
                     Err(error) => blocked = Some(error.class()),
                 }
@@ -89,7 +97,11 @@ pub(crate) fn deliver_analytics_batch(
         {
             let mut post_or_queue = |body: &[u8]| -> anyhow::Result<()> {
                 if blocked.is_none() {
-                    match crate::net::post_telemetry_json(&config.analytics.endpoint, body) {
+                    match crate::net::post_telemetry_json_with_timeout(
+                        &config.analytics.endpoint,
+                        body,
+                        timeout,
+                    ) {
                         Ok(()) => return Ok(()),
                         Err(error) => blocked = Some(error.class()),
                     }

--- a/crates/ctx-cli/src/semantic.rs
+++ b/crates/ctx-cli/src/semantic.rs
@@ -361,7 +361,7 @@ impl ctx_daemon_cli::DaemonCliHost for CtxDaemonCliHost {
         let Ok(config) = crate::config::AppConfig::load(data_root) else {
             return;
         };
-        crate::analytics::send_batch(data_root, &config, events);
+        crate::analytics::send_daemon_batch(data_root, &config, events);
     }
 
     fn fetch_to_writer(

--- a/crates/ctx-history-refresh/src/engine/read_model.rs
+++ b/crates/ctx-history-refresh/src/engine/read_model.rs
@@ -129,6 +129,8 @@ fn automatic_retry_json(
         .iter()
         .map(|(route, checkpoint)| (route.as_str().to_owned(), checkpoint.to_json()))
         .collect::<serde_json::Map<_, _>>();
+    // Keep these released reason values stable even though eligibility now
+    // also covers the terminal-coverage outcome.
     Some(json!({
         "state": state,
         "reason": if paused {
@@ -154,8 +156,16 @@ pub(super) struct SourceBackedRefreshFailureOutcome {
 
 impl SourceBackedRefreshFailureOutcome {
     pub(super) fn is_automatic_retry_eligible(&self) -> bool {
-        self.code == RefreshOutcomeCode::SourceRefreshFailed
-            && self.class == RefreshOutcomeClass::Internal
+        matches!(
+            (self.code, self.class),
+            (
+                RefreshOutcomeCode::SourceRefreshFailed,
+                RefreshOutcomeClass::Internal,
+            ) | (
+                RefreshOutcomeCode::AllProviderTerminalCoverageUnavailable,
+                RefreshOutcomeClass::Coverage,
+            )
+        )
     }
 
     pub(super) fn pause_automatic_retry_routes(&mut self, routes: &BTreeSet<SourceRouteIdentity>) {

--- a/crates/ctx-history-refresh/src/engine/tests/additional.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/additional.rs
@@ -475,6 +475,13 @@ fn failing_executor(calls: Arc<AtomicUsize>) -> Arc<dyn SourceBackedRefreshExecu
     })
 }
 
+fn coverage_failure_executor(calls: Arc<AtomicUsize>) -> Arc<dyn SourceBackedRefreshExecutor> {
+    Arc::new(move |_: SourceBackedRefreshExecution<'_>| {
+        calls.fetch_add(1, Ordering::SeqCst);
+        Err(ZeroSourcePublicationBlocked::new("stable terminal coverage failure").into())
+    })
+}
+
 #[test]
 fn mixed_automatic_retry_serialization_round_trips_through_recovery() {
     let paused_route = route_identity(0x72);
@@ -835,6 +842,34 @@ fn automatic_internal_retry_confirms_once_then_pauses_without_losing_last_good()
             .generation_id(),
         retained_generation
     );
+}
+
+#[test]
+fn automatic_terminal_coverage_retry_confirms_once_then_pauses() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (_temp, data_root, _source_path, coordinator, _catalog, route, _generation) =
+        automatic_retry_fixture(coverage_failure_executor(Arc::clone(&calls)));
+
+    let first = run_due_failure(&coordinator, &data_root, &route);
+    assert_eq!(
+        first.job["structured_outcome"]["code"],
+        "all_provider_terminal_coverage_unavailable"
+    );
+    assert_eq!(first.job["automatic_retry"]["state"], "confirming");
+    assert_eq!(
+        first.job["automatic_retry"]["reason"],
+        "internal_failure_confirmation"
+    );
+
+    let second = run_due_failure(&coordinator, &data_root, &route);
+    assert_eq!(second.job["automatic_retry"]["state"], "paused");
+    assert_eq!(
+        second.job["automatic_retry"]["reason"],
+        "repeated_internal_failure"
+    );
+    assert_eq!(second.job["structured_outcome"]["retryable"], false);
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert!(!coordinator.has_scheduled_route_work());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- preserve the 250 ms interactive telemetry budget while allowing daemon-owned background delivery up to two seconds for durable ingest
- use the longer budget for outbox draining and current daemon observations without adding latency to user commands
- apply the existing two-identical-failure pause/rearm policy to `all_provider_terminal_coverage_unavailable` while preserving the released durable JSON reason values

## Validation

- final governed affected run: 130/130 targets passed
- focused `//crates/ctx-cli:unit_tests` and `//crates/ctx-history-refresh:unit_tests` passed
- the unrelated search integration target that failed once on the stale base passed after rebasing onto current `origin/main`

## Incident evidence

The bounded production view still shows current transport backlogs and repeated terminal-coverage refresh failures after legacy event-volume noise is excluded. Investigation retained only aggregate counts and closed diagnostic buckets; no payloads, event IDs, raw errors, or identity hashes were queried.