### PR TITLE
fix: default daemon-free foreground Core ML execution to CPU

### DIFF
--- a/crates/ctx-daemon-cli/src/model_config.rs
+++ b/crates/ctx-daemon-cli/src/model_config.rs
@@ -180,7 +180,8 @@ fn semantic_model_config_from_environment(
         Err(error) => config.with_backend_preference_error(error.to_string()),
     };
     match parse_coreml_compute_mode(environment.coreml_compute_mode.as_deref()) {
-        Ok(mode) => config.with_coreml_compute_mode(mode),
+        Ok(Some(mode)) => config.with_coreml_compute_mode(mode),
+        Ok(None) => config,
         Err(error) => config.with_coreml_compute_mode_error(error.to_string()),
     }
 }
@@ -204,12 +205,13 @@ fn parse_backend_preference(value: Option<&str>) -> Result<SemanticBackendPrefer
     }
 }
 
-fn parse_coreml_compute_mode(value: Option<&str>) -> Result<SemanticCoreMlComputeMode> {
-    match value.unwrap_or("all").trim().to_ascii_lowercase().as_str() {
-        "all" => Ok(SemanticCoreMlComputeMode::All),
-        "ane" | "cpu-ane" => Ok(SemanticCoreMlComputeMode::CpuAndNeuralEngine),
-        "gpu" | "cpu-gpu" => Ok(SemanticCoreMlComputeMode::CpuAndGpu),
-        "cpu" => Ok(SemanticCoreMlComputeMode::CpuOnly),
+fn parse_coreml_compute_mode(value: Option<&str>) -> Result<Option<SemanticCoreMlComputeMode>> {
+    match value.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+        None => Ok(None),
+        Some("all") => Ok(Some(SemanticCoreMlComputeMode::All)),
+        Some("ane" | "cpu-ane") => Ok(Some(SemanticCoreMlComputeMode::CpuAndNeuralEngine)),
+        Some("gpu" | "cpu-gpu") => Ok(Some(SemanticCoreMlComputeMode::CpuAndGpu)),
+        Some("cpu") => Ok(Some(SemanticCoreMlComputeMode::CpuOnly)),
         value => Err(anyhow!(
             "unsupported CTX_SEMANTIC_COREML_NATIVE_COMPUTE mode {value:?}"
         )),

--- a/crates/ctx-daemon-cli/src/model_config_tests.rs
+++ b/crates/ctx-daemon-cli/src/model_config_tests.rs
@@ -115,9 +115,65 @@ fn backend_and_coreml_controls_preserve_strict_parsing() {
     assert!(parse_backend_preference(Some("gpu")).is_err());
     assert_eq!(
         parse_coreml_compute_mode(Some(" CPU-ANE ")).unwrap(),
-        SemanticCoreMlComputeMode::CpuAndNeuralEngine
+        Some(SemanticCoreMlComputeMode::CpuAndNeuralEngine)
     );
     assert!(parse_coreml_compute_mode(Some("")).is_err());
+}
+
+#[test]
+fn coreml_compute_mode_composition_preserves_absence_and_foreground_defaults() {
+    assert_eq!(parse_coreml_compute_mode(None).unwrap(), None);
+
+    let data_root = Path::new("/data");
+    let absent = semantic_model_config_from_environment(data_root, &environment());
+    assert_eq!(
+        absent.coreml_compute_mode().unwrap(),
+        SemanticCoreMlComputeMode::All
+    );
+    assert_eq!(
+        crate::query_adapter::foreground_coreml_model_config(absent)
+            .coreml_compute_mode()
+            .unwrap(),
+        SemanticCoreMlComputeMode::CpuOnly
+    );
+
+    for (value, expected) in [
+        ("all", SemanticCoreMlComputeMode::All),
+        ("cpu", SemanticCoreMlComputeMode::CpuOnly),
+        ("cpu-ane", SemanticCoreMlComputeMode::CpuAndNeuralEngine),
+        ("cpu-gpu", SemanticCoreMlComputeMode::CpuAndGpu),
+    ] {
+        let environment = SemanticHostEnvironment {
+            coreml_compute_mode: Some(value.to_owned()),
+            ..environment()
+        };
+        let config = semantic_model_config_from_environment(data_root, &environment);
+        assert_eq!(config.coreml_compute_mode().unwrap(), expected, "{value}");
+        assert_eq!(
+            crate::query_adapter::foreground_coreml_model_config(config)
+                .coreml_compute_mode()
+                .unwrap(),
+            expected,
+            "{value}"
+        );
+    }
+
+    for value in ["", "invalid"] {
+        let environment = SemanticHostEnvironment {
+            coreml_compute_mode: Some(value.to_owned()),
+            ..environment()
+        };
+        let config = semantic_model_config_from_environment(data_root, &environment);
+        let error = crate::query_adapter::foreground_coreml_model_config(config)
+            .coreml_compute_mode()
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("CTX_SEMANTIC_COREML_NATIVE_COMPUTE"),
+            "{value:?} must remain invalid after foreground composition"
+        );
+    }
 }
 
 #[test]

--- a/crates/ctx-daemon-cli/src/query_adapter.rs
+++ b/crates/ctx-daemon-cli/src/query_adapter.rs
@@ -139,13 +139,15 @@ impl<'data_root> SemanticQueryAdapter<'data_root> {
         data_root: &'data_root Path,
         config: SemanticEmbeddingExecutorConfig,
     ) -> Self {
+        let model_config =
+            foreground_coreml_model_config(crate::model_config::semantic_model_config(data_root));
         let executor = crate::semantic_embedding_executor_auth_from_environment()
             .and_then(|auth| {
                 SemanticEmbeddingExecutorHandle::build_with_auth(
                     config,
                     auth,
                     SharedSemanticRuntime::default(),
-                    crate::model_config::semantic_model_config(data_root),
+                    model_config,
                 )
             })
             .map(Box::new)
@@ -155,6 +157,12 @@ impl<'data_root> SemanticQueryAdapter<'data_root> {
             execution: SemanticQueryExecution::Foreground { executor },
         }
     }
+}
+
+pub(crate) fn foreground_coreml_model_config(
+    config: ctx_semantic_model::SemanticModelConfig,
+) -> ctx_semantic_model::SemanticModelConfig {
+    config.with_foreground_coreml_cpu_default()
 }
 
 impl HistorySemanticPort for SemanticQueryAdapter<'_> {

--- a/crates/ctx-semantic-model/src/configuration.rs
+++ b/crates/ctx-semantic-model/src/configuration.rs
@@ -130,8 +130,7 @@ pub struct SemanticModelConfig {
     paths: SemanticModelPaths,
     backend_preference: SemanticBackendPreference,
     backend_preference_error: Option<String>,
-    coreml_compute_mode: SemanticCoreMlComputeMode,
-    coreml_compute_mode_explicit: bool,
+    coreml_compute_mode: Option<SemanticCoreMlComputeMode>,
     coreml_compute_mode_error: Option<String>,
     thread_override: Option<usize>,
     batch_size_override: Option<usize>,
@@ -144,8 +143,7 @@ impl SemanticModelConfig {
             paths,
             backend_preference: SemanticBackendPreference::Auto,
             backend_preference_error: None,
-            coreml_compute_mode: SemanticCoreMlComputeMode::All,
-            coreml_compute_mode_explicit: false,
+            coreml_compute_mode: None,
             coreml_compute_mode_error: None,
             thread_override: None,
             batch_size_override: None,
@@ -165,8 +163,7 @@ impl SemanticModelConfig {
     }
 
     pub fn with_coreml_compute_mode(mut self, mode: SemanticCoreMlComputeMode) -> Self {
-        self.coreml_compute_mode = mode;
-        self.coreml_compute_mode_explicit = true;
+        self.coreml_compute_mode = Some(mode);
         self.coreml_compute_mode_error = None;
         self
     }
@@ -203,24 +200,19 @@ impl SemanticModelConfig {
             })
     }
 
-    #[cfg(all(ctx_semantic_fastembed, target_os = "macos"))]
-    pub(crate) fn coreml_compute_mode(&self) -> Result<SemanticCoreMlComputeMode> {
+    pub fn coreml_compute_mode(&self) -> Result<SemanticCoreMlComputeMode> {
         self.coreml_compute_mode_error
             .as_ref()
-            .map_or(Ok(self.coreml_compute_mode), |error| {
+            .map_or(Ok(self.coreml_compute_mode.unwrap_or_default()), |error| {
                 Err(anyhow!(error.clone()))
             })
     }
 
-    #[cfg(any(all(ctx_semantic_fastembed, target_os = "macos"), test))]
-    pub(crate) fn foreground_coreml_compute_mode(&self) -> Result<SemanticCoreMlComputeMode> {
-        self.coreml_compute_mode().map(|mode| {
-            if self.coreml_compute_mode_explicit {
-                mode
-            } else {
-                SemanticCoreMlComputeMode::CpuOnly
-            }
-        })
+    pub fn with_foreground_coreml_cpu_default(mut self) -> Self {
+        if self.coreml_compute_mode.is_none() && self.coreml_compute_mode_error.is_none() {
+            self.coreml_compute_mode = Some(SemanticCoreMlComputeMode::CpuOnly);
+        }
+        self
     }
 
     pub(crate) const fn thread_override(&self) -> Option<usize> {

--- a/crates/ctx-semantic-model/src/configuration.rs
+++ b/crates/ctx-semantic-model/src/configuration.rs
@@ -131,6 +131,7 @@ pub struct SemanticModelConfig {
     backend_preference: SemanticBackendPreference,
     backend_preference_error: Option<String>,
     coreml_compute_mode: SemanticCoreMlComputeMode,
+    coreml_compute_mode_explicit: bool,
     coreml_compute_mode_error: Option<String>,
     thread_override: Option<usize>,
     batch_size_override: Option<usize>,
@@ -144,6 +145,7 @@ impl SemanticModelConfig {
             backend_preference: SemanticBackendPreference::Auto,
             backend_preference_error: None,
             coreml_compute_mode: SemanticCoreMlComputeMode::All,
+            coreml_compute_mode_explicit: false,
             coreml_compute_mode_error: None,
             thread_override: None,
             batch_size_override: None,
@@ -164,6 +166,7 @@ impl SemanticModelConfig {
 
     pub fn with_coreml_compute_mode(mut self, mode: SemanticCoreMlComputeMode) -> Self {
         self.coreml_compute_mode = mode;
+        self.coreml_compute_mode_explicit = true;
         self.coreml_compute_mode_error = None;
         self
     }
@@ -207,6 +210,17 @@ impl SemanticModelConfig {
             .map_or(Ok(self.coreml_compute_mode), |error| {
                 Err(anyhow!(error.clone()))
             })
+    }
+
+    #[cfg(any(all(ctx_semantic_fastembed, target_os = "macos"), test))]
+    pub(crate) fn foreground_coreml_compute_mode(&self) -> Result<SemanticCoreMlComputeMode> {
+        self.coreml_compute_mode().map(|mode| {
+            if self.coreml_compute_mode_explicit {
+                mode
+            } else {
+                SemanticCoreMlComputeMode::CpuOnly
+            }
+        })
     }
 
     pub(crate) const fn thread_override(&self) -> Option<usize> {

--- a/crates/ctx-semantic-model/src/model_runtime/coreml.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/coreml.rs
@@ -72,7 +72,7 @@ pub(super) fn acquire_coreml_backend(
     preference: SemanticBackendPreference,
     fallback: Option<&'static str>,
 ) -> Result<SemanticEmbedder> {
-    let compute = coreml_compute_config(config.foreground_coreml_compute_mode()?);
+    let compute = coreml_compute_config(config.coreml_compute_mode()?);
     if let Some(deferred) = semantic_model_load_deferred(
         SemanticSystemResources::current().available_memory_bytes,
         compute.compute_class,

--- a/crates/ctx-semantic-model/src/model_runtime/coreml.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/coreml.rs
@@ -72,7 +72,7 @@ pub(super) fn acquire_coreml_backend(
     preference: SemanticBackendPreference,
     fallback: Option<&'static str>,
 ) -> Result<SemanticEmbedder> {
-    let compute = coreml_compute_config(config.coreml_compute_mode()?);
+    let compute = coreml_compute_config(config.foreground_coreml_compute_mode()?);
     if let Some(deferred) = semantic_model_load_deferred(
         SemanticSystemResources::current().available_memory_bytes,
         compute.compute_class,

--- a/crates/ctx-semantic-model/src/model_runtime/tests.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/tests.rs
@@ -344,6 +344,30 @@ pub(super) fn coreml_cpu_only_uses_cpu_quiet_policy_class() {
 }
 
 #[test]
+fn foreground_coreml_defaults_to_cpu_but_honors_explicit_compute_mode() {
+    let temp = tempfile::tempdir().unwrap();
+    let default_config = test_config(temp.path());
+    assert_eq!(
+        default_config.coreml_compute_mode().unwrap(),
+        SemanticCoreMlComputeMode::All
+    );
+    assert_eq!(
+        default_config.foreground_coreml_compute_mode().unwrap(),
+        SemanticCoreMlComputeMode::CpuOnly
+    );
+
+    for mode in [
+        SemanticCoreMlComputeMode::All,
+        SemanticCoreMlComputeMode::CpuAndNeuralEngine,
+        SemanticCoreMlComputeMode::CpuAndGpu,
+        SemanticCoreMlComputeMode::CpuOnly,
+    ] {
+        let config = test_config(temp.path()).with_coreml_compute_mode(mode);
+        assert_eq!(config.foreground_coreml_compute_mode().unwrap(), mode);
+    }
+}
+
+#[test]
 pub(super) fn normalization_is_central_and_strict() {
     let mut vector = vec![0.0; SEMANTIC_DIMENSIONS];
     vector[0] = 3.0;

--- a/crates/ctx-semantic-model/src/model_runtime/tests.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/tests.rs
@@ -344,16 +344,19 @@ pub(super) fn coreml_cpu_only_uses_cpu_quiet_policy_class() {
 }
 
 #[test]
-fn foreground_coreml_defaults_to_cpu_but_honors_explicit_compute_mode() {
+fn foreground_coreml_config_defaults_to_cpu_but_honors_explicit_compute_mode() {
     let temp = tempfile::tempdir().unwrap();
     let default_config = test_config(temp.path());
     assert_eq!(
         default_config.coreml_compute_mode().unwrap(),
         SemanticCoreMlComputeMode::All
     );
+    let foreground_config = default_config.with_foreground_coreml_cpu_default();
+    let foreground_mode = foreground_config.coreml_compute_mode().unwrap();
+    assert_eq!(foreground_mode, SemanticCoreMlComputeMode::CpuOnly);
     assert_eq!(
-        default_config.foreground_coreml_compute_mode().unwrap(),
-        SemanticCoreMlComputeMode::CpuOnly
+        coreml_compute_class(foreground_mode),
+        SemanticComputeClass::Cpu
     );
 
     for mode in [
@@ -362,8 +365,10 @@ fn foreground_coreml_defaults_to_cpu_but_honors_explicit_compute_mode() {
         SemanticCoreMlComputeMode::CpuAndGpu,
         SemanticCoreMlComputeMode::CpuOnly,
     ] {
-        let config = test_config(temp.path()).with_coreml_compute_mode(mode);
-        assert_eq!(config.foreground_coreml_compute_mode().unwrap(), mode);
+        let config = test_config(temp.path())
+            .with_coreml_compute_mode(mode)
+            .with_foreground_coreml_cpu_default();
+        assert_eq!(config.coreml_compute_mode().unwrap(), mode);
     }
 }
 


### PR DESCRIPTION
## Summary

- Default daemon-free foreground Core ML execution to CPU only when no compute mode was explicitly selected.
- Preserve every explicit Core ML compute selection and the daemon/shared model default.
- Apply the policy at foreground query composition, keeping shared semantic model configuration context-neutral.

This replacement preserves Yusoof Moh contribution from #825 as commit f3520bd8d5acb2ca376bbc7f596673f0b754a2e7, with the same patch ID and author, then adds the reviewed scoping correction in 2e3498f4c608eb95845747d14b5db0444f49127b. Because the source branch could not receive the maintainer corrective push, this PR supersedes #825 while retaining contributor attribution.

## Why the correction is needed

#825 correctly identified the foreground Core ML stall and introduced the CPU fallback. As written, its fallback lived inside the shared semantic model configuration/runtime layer. The corrective commit moves that default into the daemon CLI foreground adapter, so daemon and other shared-config consumers retain the existing `All` default while finite foreground execution gets `CpuOnly`. Explicit `all`, CPU+ANE, CPU+GPU, and CPU-only selections remain unchanged, and invalid overrides still fail strictly.

## Validation

Independent code review approved this two-commit result with no findings.

- Affected-target suite: 87/87 passed.
- Focused Rust tests: 451 passed.
- Strict builds passed.
- Native macOS x64 configuration tests: 2 passed.
- Live branch checks: clean diff check and conflict-free merge tree against current `main`.

Not run: arm64 validation or end-to-end model inference.

Supersedes #825.
Closes #823.