### PR TITLE
fix: retain native ONNX loader diagnostics across paths

### DIFF
--- a/crates/ctx-semantic-model/src/model_runtime/onnx.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/onnx.rs
@@ -115,6 +115,14 @@ pub(super) struct SemanticOnnxRuntimeCandidate {
     try_even_if_missing: bool,
 }
 
+fn format_runtime_load_failure<E: std::fmt::Display>(
+    source: &str,
+    path: &Path,
+    error: E,
+) -> String {
+    format!("{source} {}: {error:#}", path.display())
+}
+
 #[cfg(ctx_semantic_fastembed)]
 pub(super) fn ensure_semantic_onnxruntime_loaded(paths: &SemanticModelPaths) -> Result<PathBuf> {
     if let Some(runtime) = LOADED_RUNTIME.get() {
@@ -216,10 +224,10 @@ pub(super) fn load_semantic_onnxruntime(
                 let _ = builder.commit();
                 return Ok(candidate.path);
             }
-            Err(error) => failures.push(format!(
-                "{} {}: {error:#}",
+            Err(error) => failures.push(format_runtime_load_failure(
                 candidate.source,
-                candidate.path.display()
+                &candidate.path,
+                error,
             )),
         }
     }
@@ -555,6 +563,29 @@ mod ort_runtime_tests {
     use std::env;
 
     use super::*;
+
+    struct ChainedLoadError;
+
+    impl std::fmt::Display for ChainedLoadError {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            if formatter.alternate() {
+                write!(formatter, "dlopen failed: image not found")
+            } else {
+                write!(formatter, "dlopen failed")
+            }
+        }
+    }
+
+    #[test]
+    fn runtime_load_failure_preserves_native_error_chain() {
+        let formatted = format_runtime_load_failure(
+            "ctx_installed_runtime",
+            Path::new("/tmp/libonnxruntime.dylib"),
+            ChainedLoadError,
+        );
+        assert!(formatted.contains("dlopen failed"));
+        assert!(formatted.contains("image not found"));
+    }
 
     fn test_absolute_path(path: &str) -> PathBuf {
         let root = if cfg!(windows) {

--- a/crates/ctx-semantic-model/src/model_runtime/onnx.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/onnx.rs
@@ -115,12 +115,23 @@ pub(super) struct SemanticOnnxRuntimeCandidate {
     try_even_if_missing: bool,
 }
 
-fn format_runtime_load_failure<E: std::fmt::Display>(
-    source: &str,
-    path: &Path,
-    error: E,
-) -> String {
-    format!("{source} {}: {error:#}", path.display())
+#[cfg(ctx_semantic_fastembed)]
+fn format_runtime_load_failure(source: &str, path: &Path, error: &ort::LoadDynamicError) -> String {
+    // `ort::LoadDynamicError` deliberately does not expose its `Dlopen`
+    // libloading error through `Error::source()`, so walk that one public
+    // variant explicitly. The libloading source holds the native loader text.
+    let native_cause = match error {
+        ort::LoadDynamicError::Dlopen { error, .. } => {
+            std::error::Error::source(error).map(|native_cause| native_cause.to_string())
+        }
+        _ => None,
+    };
+    let mut formatted = format!("{source} {}: {error}", path.display());
+    if let Some(native_cause) = native_cause {
+        formatted.push_str(": ");
+        formatted.push_str(&native_cause);
+    }
+    formatted
 }
 
 #[cfg(ctx_semantic_fastembed)]
@@ -227,7 +238,7 @@ pub(super) fn load_semantic_onnxruntime(
             Err(error) => failures.push(format_runtime_load_failure(
                 candidate.source,
                 &candidate.path,
-                error,
+                &error,
             )),
         }
     }
@@ -564,27 +575,41 @@ mod ort_runtime_tests {
 
     use super::*;
 
-    struct ChainedLoadError;
+    #[test]
+    fn runtime_load_failure_preserves_real_native_loader_detail() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing_dylib = temp.path().join(SEMANTIC_ONNXRUNTIME_DYLIB);
+        let error = match ort::init_from(&missing_dylib) {
+            Ok(_) => panic!("a missing dynamic library should not load"),
+            Err(error) => error,
+        };
+        let native_cause = match &error {
+            ort::LoadDynamicError::Dlopen { error, .. } => std::error::Error::source(error)
+                .expect("a dynamic loader failure should retain its native cause")
+                .to_string(),
+            other => panic!("expected a dynamic loader failure, got {other:?}"),
+        };
+        let formatted =
+            format_runtime_load_failure("ctx_installed_runtime", &missing_dylib, &error);
+        assert!(formatted.contains("dlopen failed"));
+        assert!(formatted.contains(&native_cause), "{formatted}");
 
-    impl std::fmt::Display for ChainedLoadError {
-        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            if formatter.alternate() {
-                write!(formatter, "dlopen failed: image not found")
-            } else {
-                write!(formatter, "dlopen failed")
-            }
-        }
+        #[cfg(target_os = "linux")]
+        assert!(native_cause.contains("cannot open shared object file"));
     }
 
     #[test]
-    fn runtime_load_failure_preserves_native_error_chain() {
+    fn runtime_load_failure_formats_other_ort_variants() {
+        let missing_api = ort::LoadDynamicError::MissingApi {
+            path: test_absolute_path(SEMANTIC_ONNXRUNTIME_DYLIB),
+        };
         let formatted = format_runtime_load_failure(
             "ctx_installed_runtime",
-            Path::new("/tmp/libonnxruntime.dylib"),
-            ChainedLoadError,
+            Path::new("/tmp/libonnxruntime"),
+            &missing_api,
         );
-        assert!(formatted.contains("dlopen failed"));
-        assert!(formatted.contains("image not found"));
+        assert!(formatted.contains("does not export `OrtGetApiBase`"));
+        assert!(!formatted.ends_with(": "));
     }
 
     fn test_absolute_path(path: &str) -> PathBuf {

--- a/crates/ctx-semantic-model/src/model_runtime/onnx.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/onnx.rs
@@ -116,7 +116,7 @@ pub(super) struct SemanticOnnxRuntimeCandidate {
 }
 
 #[cfg(ctx_semantic_fastembed)]
-fn format_runtime_load_failure(source: &str, path: &Path, error: &ort::LoadDynamicError) -> String {
+fn format_runtime_load_error(error: &ort::LoadDynamicError) -> String {
     // `ort::LoadDynamicError` deliberately does not expose its `Dlopen`
     // libloading error through `Error::source()`, so walk that one public
     // variant explicitly. The libloading source holds the native loader text.
@@ -126,12 +126,23 @@ fn format_runtime_load_failure(source: &str, path: &Path, error: &ort::LoadDynam
         }
         _ => None,
     };
-    let mut formatted = format!("{source} {}: {error}", path.display());
-    if let Some(native_cause) = native_cause {
+    let mut formatted = error.to_string();
+    if let Some(native_cause) =
+        native_cause.filter(|native_cause| !formatted.contains(native_cause))
+    {
         formatted.push_str(": ");
         formatted.push_str(&native_cause);
     }
     formatted
+}
+
+#[cfg(ctx_semantic_fastembed)]
+fn format_runtime_load_failure(source: &str, path: &Path, error: &ort::LoadDynamicError) -> String {
+    format!(
+        "{source} {}: {}",
+        path.display(),
+        format_runtime_load_error(error)
+    )
 }
 
 #[cfg(ctx_semantic_fastembed)]
@@ -224,7 +235,7 @@ pub(super) fn load_semantic_onnxruntime(
         #[cfg(target_os = "windows")]
         if let Err(error) = preload_windows_onnxruntime(&candidate.path) {
             failures.push(format!(
-                "{} {}: {error}",
+                "{} {}: {error:#}",
                 candidate.source,
                 candidate.path.display()
             ));
@@ -275,7 +286,7 @@ fn load_verified_accelerator_runtime(
         };
         #[cfg(target_os = "windows")]
         if let Err(error) = preload_windows_onnxruntime(&path) {
-            failures.push(format!("{}: {error}", path.display()));
+            failures.push(format!("{}: {error:#}", path.display()));
             continue;
         }
         #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -305,7 +316,11 @@ fn load_verified_accelerator_runtime(
                     flavor,
                 });
             }
-            Err(error) => failures.push(format!("{}: {error}", path.display())),
+            Err(error) => failures.push(format!(
+                "{}: {}",
+                path.display(),
+                format_runtime_load_error(&error)
+            )),
         }
     }
     let detail = if failures.is_empty() {
@@ -589,13 +604,38 @@ mod ort_runtime_tests {
                 .to_string(),
             other => panic!("expected a dynamic loader failure, got {other:?}"),
         };
+        let loader_display = error.to_string();
         let formatted =
             format_runtime_load_failure("ctx_installed_runtime", &missing_dylib, &error);
-        assert!(formatted.contains("dlopen failed"));
+        assert!(formatted.contains(&loader_display), "{formatted}");
         assert!(formatted.contains(&native_cause), "{formatted}");
+    }
 
-        #[cfg(target_os = "linux")]
-        assert!(native_cause.contains("cannot open shared object file"));
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn production_candidate_loader_preserves_preload_error_chain() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing_dylib = temp.path().join(SEMANTIC_ONNXRUNTIME_DYLIB);
+        let preload_error = preload_windows_onnxruntime(&missing_dylib)
+            .expect_err("a missing ONNX Runtime library should not preload");
+        let preload_chain = format!("{preload_error:#}");
+        assert_ne!(preload_chain, preload_error.to_string());
+
+        let production_error = load_semantic_onnxruntime(
+            &test_absolute_path("model-cache"),
+            &SemanticOnnxRuntimePaths {
+                ctx_dylib: Some(missing_dylib.clone()),
+                ..SemanticOnnxRuntimePaths::default()
+            },
+        )
+        .expect_err("a missing ONNX Runtime library should not load");
+        let production_display = production_error.to_string();
+        assert!(production_display.contains("failed to load ONNX Runtime dynamic library"));
+        assert!(production_display.contains(&missing_dylib.display().to_string()));
+        assert!(
+            production_display.contains(&preload_chain),
+            "{production_display}"
+        );
     }
 
     #[test]
@@ -608,8 +648,10 @@ mod ort_runtime_tests {
             Path::new("/tmp/libonnxruntime"),
             &missing_api,
         );
-        assert!(formatted.contains("does not export `OrtGetApiBase`"));
-        assert!(!formatted.ends_with(": "));
+        assert_eq!(
+            formatted,
+            format!("ctx_installed_runtime /tmp/libonnxruntime: {missing_api}")
+        );
     }
 
     fn test_absolute_path(path: &str) -> PathBuf {

--- a/crates/ctx-semantic-model/src/model_runtime/onnx.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/onnx.rs
@@ -217,7 +217,7 @@ pub(super) fn load_semantic_onnxruntime(
                 return Ok(candidate.path);
             }
             Err(error) => failures.push(format!(
-                "{} {}: {error}",
+                "{} {}: {error:#}",
                 candidate.source,
                 candidate.path.display()
             )),


### PR DESCRIPTION
## Provenance

This supersedes #824 and retains the two commits authored by Yusoof Moh.

## Summary

- Preserve the native detail nested in typed `ort::LoadDynamicError::Dlopen` failures without duplicating it.
- Render Windows preload `anyhow` chains in full for CPU and accelerator candidate loaders.
- Cover the real loader path without Unix-specific diagnostic literals, and add a Windows-only production candidate-loader regression.

## Scope

Diagnostics only; #658 remains open.

## Validation

- `cargo test -p ctx-semantic-model --lib` — 127 passed, 1 ignored.
- `cargo clippy -p ctx-semantic-model --all-targets -- -D warnings`
- `cargo check -p ctx-semantic-model --target x86_64-pc-windows-gnu`
- `cargo fmt --all -- --check` and `git diff origin/main...HEAD --check`
- The Windows pre-fix native regression exited 1 as expected. Exact-head Windows and macOS native runs were submitted through `ctx-build-governor remote -- ctx-lab run`, but lab admission remained unavailable because its filesystem and memory-pressure safeguards were below threshold.