### PR TITLE
fix: use traversal-only Windows source ancestors

### DIFF
--- a/crates/ctx-history-jsonl/src/family.rs
+++ b/crates/ctx-history-jsonl/src/family.rs
@@ -61,6 +61,9 @@ pub trait JsonlFamilyError:
     fn source_changed() -> Self;
     fn is_not_found(&self) -> bool;
     fn is_source_changed(&self) -> bool;
+    fn is_source_unavailable(&self) -> bool {
+        false
+    }
     fn is_resource_unavailable(&self) -> bool;
     fn is_internal(&self) -> bool;
     fn is_ignorable_membership_entry(&self) -> bool;
@@ -121,8 +124,18 @@ impl JsonlFamilyError for SourceIoError {
             )
     }
 
+    fn is_source_unavailable(&self) -> bool {
+        matches!(
+            self,
+            Self::SystemIo { operation, source }
+                if ctx_history_source_io::is_provider_source_unavailable_io(operation, source)
+        )
+    }
+
     fn is_resource_unavailable(&self) -> bool {
-        matches!(self, Self::Io(_) | Self::SystemIo { .. }) && !self.is_not_found()
+        matches!(self, Self::Io(_) | Self::SystemIo { .. })
+            && !self.is_not_found()
+            && !self.is_source_unavailable()
     }
 
     fn is_internal(&self) -> bool {

--- a/crates/ctx-history-jsonl/src/family/route/errors.rs
+++ b/crates/ctx-history-jsonl/src/family/route/errors.rs
@@ -36,6 +36,8 @@ pub(super) fn normalized_jsonl_error_kind<E: JsonlFamilyError>(
         Some(SourceBackedRouteErrorKind::SourceChanged)
     } else if error.is_not_found() {
         None
+    } else if error.is_source_unavailable() {
+        Some(SourceBackedRouteErrorKind::Unavailable)
     } else if error.is_resource_unavailable() {
         Some(SourceBackedRouteErrorKind::ResourceUnavailable)
     } else if error.is_internal() {

--- a/crates/ctx-history-jsonl/src/family/route/tests/behavior/terminal_inventory.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/behavior/terminal_inventory.rs
@@ -442,7 +442,21 @@ fn jsonl_terminal_drift_and_io_failures_keep_distinct_route_kinds() {
         Some(SourceBackedRouteErrorKind::ResourceUnavailable)
     );
     assert_eq!(
+        normalized_jsonl_error_kind(&CaptureError::SystemIo {
+            operation: "provider source target open",
+            source: std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+        }),
+        Some(SourceBackedRouteErrorKind::Unavailable)
+    );
+    assert_eq!(
         normalized_jsonl_error_kind(&CaptureError::Io(std::io::Error::from_raw_os_error(24))),
+        Some(SourceBackedRouteErrorKind::ResourceUnavailable)
+    );
+    assert_eq!(
+        normalized_jsonl_error_kind(&CaptureError::SystemIo {
+            operation: "provider source target open",
+            source: std::io::Error::from_raw_os_error(24),
+        }),
         Some(SourceBackedRouteErrorKind::ResourceUnavailable)
     );
     assert_eq!(

--- a/crates/ctx-history-provider-gemini/src/lib.rs
+++ b/crates/ctx-history-provider-gemini/src/lib.rs
@@ -78,11 +78,20 @@ impl JsonlFamilyError for GeminiError {
             || matches!(self, Self::Source(error) if error.is_source_changed())
     }
 
+    fn is_source_unavailable(&self) -> bool {
+        matches!(
+            self,
+            Self::Source(SourceIoError::SystemIo { operation, source })
+                if ctx_history_source_io::is_provider_source_unavailable_io(operation, source)
+        )
+    }
+
     fn is_resource_unavailable(&self) -> bool {
         matches!(
             self,
             Self::Source(SourceIoError::Io(_) | SourceIoError::SystemIo { .. })
         ) && !self.is_not_found()
+            && !self.is_source_unavailable()
     }
 
     fn is_internal(&self) -> bool {

--- a/crates/ctx-history-provider-native-jsonl/src/lib.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/lib.rs
@@ -118,8 +118,17 @@ impl JsonlFamilyError for NativeJsonlError {
                 }
         )
     }
+    fn is_source_unavailable(&self) -> bool {
+        matches!(
+            self,
+            Self::SystemIo { operation, source }
+                if ctx_history_source_io::is_provider_source_unavailable_io(operation, source)
+        )
+    }
     fn is_resource_unavailable(&self) -> bool {
-        matches!(self, Self::Io(_) | Self::SystemIo { .. }) && !self.is_not_found()
+        matches!(self, Self::Io(_) | Self::SystemIo { .. })
+            && !self.is_not_found()
+            && !self.is_source_unavailable()
     }
     fn is_internal(&self) -> bool {
         matches!(self, Self::SystemInvariant(_) | Self::WorkerPanicked(_))

--- a/crates/ctx-history-provider-runtime/src/error.rs
+++ b/crates/ctx-history-provider-runtime/src/error.rs
@@ -155,8 +155,18 @@ impl JsonlFamilyError for CaptureError {
             )
     }
 
+    fn is_source_unavailable(&self) -> bool {
+        matches!(
+            self,
+            Self::SystemIo { operation, source }
+                if ctx_history_source_io::is_provider_source_unavailable_io(operation, source)
+        )
+    }
+
     fn is_resource_unavailable(&self) -> bool {
-        matches!(self, Self::Io(_) | Self::SystemIo { .. }) && !self.is_not_found()
+        matches!(self, Self::Io(_) | Self::SystemIo { .. })
+            && !self.is_not_found()
+            && !self.is_source_unavailable()
     }
 
     fn is_internal(&self) -> bool {
@@ -177,6 +187,28 @@ impl JsonlFamilyError for CaptureError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn source_io_mapping_preserves_provider_source_unavailability() {
+        let mapped = CaptureError::from(ctx_history_source_io::SourceIoError::SystemIo {
+            operation: "provider source target open",
+            source: std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+        });
+
+        assert!(mapped.is_source_unavailable());
+        assert!(!mapped.is_resource_unavailable());
+    }
+
+    #[test]
+    fn source_io_mapping_preserves_tagged_resource_exhaustion() {
+        let mapped = CaptureError::from(ctx_history_source_io::SourceIoError::SystemIo {
+            operation: "provider source target open",
+            source: std::io::Error::from_raw_os_error(24),
+        });
+
+        assert!(!mapped.is_source_unavailable());
+        assert!(mapped.is_resource_unavailable());
+    }
 
     #[test]
     fn source_io_mapping_preserves_inventory_limit_identity() {

--- a/crates/ctx-history-source-io/src/error.rs
+++ b/crates/ctx-history-source-io/src/error.rs
@@ -52,3 +52,14 @@ pub enum SourceIoError {
 }
 
 pub type Result<T> = std::result::Result<T, SourceIoError>;
+
+pub const PROVIDER_SOURCE_IO_OPERATION_PREFIX: &str = "provider source ";
+
+pub fn is_provider_source_io_operation(operation: &str) -> bool {
+    operation.starts_with(PROVIDER_SOURCE_IO_OPERATION_PREFIX)
+}
+
+pub fn is_provider_source_unavailable_io(operation: &str, source: &std::io::Error) -> bool {
+    is_provider_source_io_operation(operation)
+        && source.kind() == std::io::ErrorKind::PermissionDenied
+}

--- a/crates/ctx-history-source-io/src/io/root_handle.rs
+++ b/crates/ctx-history-source-io/src/io/root_handle.rs
@@ -33,6 +33,13 @@ use sha2::{Digest, Sha256};
 use crate::ordinary_file::ORDINARY_FILE_V2_TOKEN_DOMAIN;
 use crate::{Result, SourceIoError};
 
+#[path = "root_handle/diagnostics.rs"]
+mod diagnostics;
+use diagnostics::{
+    changed_path, ensure_absolute_traversal_free, invalid_path, map_changed_open_error,
+    map_open_error, provider_source_io_result, validate_child_name, validate_relative_path,
+};
+
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
 #[path = "root_handle/unix.rs"]
 mod platform;
@@ -51,6 +58,17 @@ mod platform;
 #[derive(Debug)]
 pub(super) enum AuthorityOpenError {
     Io(io::Error),
+    #[cfg_attr(
+        not(any(target_os = "windows", test, feature = "test-support")),
+        allow(
+            dead_code,
+            reason = "Windows source authority reports exact system operations"
+        )
+    )]
+    SystemIo {
+        operation: &'static str,
+        source: io::Error,
+    },
     Rejected(&'static str),
 }
 
@@ -164,7 +182,11 @@ impl ProviderSourceRoot {
     }
 
     pub fn directory(&self) -> Result<ProviderSourceDirectory> {
-        let directory = self.inner.directory.try_clone()?;
+        let directory = provider_source_io_result(
+            self.named_path(),
+            "provider source directory-handle clone",
+            self.inner.directory.try_clone(),
+        )?;
         Ok(ProviderSourceDirectory {
             root: self.clone(),
             relative_path: PathBuf::new(),
@@ -222,8 +244,16 @@ impl ProviderSourceRoot {
     /// Confirms both the retained directory and its current named route still
     /// identify the exact root admitted at construction.
     pub fn revalidate(&self) -> Result<()> {
-        let current_metadata = self.inner.directory.metadata()?;
-        let current = platform::object_stamp(&self.inner.directory, &current_metadata)?;
+        let current_metadata = provider_source_io_result(
+            &self.inner.named_path,
+            "provider source retained-directory metadata query",
+            self.inner.directory.metadata(),
+        )?;
+        let current = provider_source_io_result(
+            &self.inner.named_path,
+            "provider source retained-directory identity query",
+            platform::object_stamp(&self.inner.directory, &current_metadata),
+        )?;
         if current != self.inner.opened {
             return Err(changed_path(&self.inner.named_path));
         }
@@ -232,7 +262,11 @@ impl ProviderSourceRoot {
         let platform::OpenedPath::Directory { file, metadata, .. } = reopened else {
             return Err(changed_path(&self.inner.named_path));
         };
-        let named = platform::object_stamp(&file, &metadata)?;
+        let named = provider_source_io_result(
+            &self.inner.named_path,
+            "provider source reopened-directory identity query",
+            platform::object_stamp(&file, &metadata),
+        )?;
         if named != self.inner.opened {
             return Err(changed_path(&self.inner.named_path));
         }
@@ -244,8 +278,16 @@ impl ProviderSourceRoot {
     /// children being added, removed, or updated. Inventory owners use
     /// [`Self::revalidate`] separately when they require an exact tree fence.
     pub fn revalidate_same_object(&self) -> Result<()> {
-        let current_metadata = self.inner.directory.metadata()?;
-        let current = platform::object_stamp(&self.inner.directory, &current_metadata)?;
+        let current_metadata = provider_source_io_result(
+            &self.inner.named_path,
+            "provider source retained-directory metadata query",
+            self.inner.directory.metadata(),
+        )?;
+        let current = provider_source_io_result(
+            &self.inner.named_path,
+            "provider source retained-directory identity query",
+            platform::object_stamp(&self.inner.directory, &current_metadata),
+        )?;
         if !platform::same_object(&current, &self.inner.opened) {
             return Err(changed_path(&self.inner.named_path));
         }
@@ -254,7 +296,11 @@ impl ProviderSourceRoot {
         let platform::OpenedPath::Directory { file, metadata, .. } = reopened else {
             return Err(changed_path(&self.inner.named_path));
         };
-        let named = platform::object_stamp(&file, &metadata)?;
+        let named = provider_source_io_result(
+            &self.inner.named_path,
+            "provider source reopened-directory identity query",
+            platform::object_stamp(&file, &metadata),
+        )?;
         if !platform::same_object(&named, &self.inner.opened) {
             return Err(changed_path(&self.inner.named_path));
         }
@@ -333,15 +379,20 @@ impl ProviderSourceDirectory {
     pub fn open_child(&self, name: &OsStr) -> Result<OpenedProviderSourcePath> {
         validate_child_name(name, self.display_path())?;
         let relative_path = self.relative_path.join(name);
+        let named_path = self.root.named_path().join(&relative_path);
         let opened = platform::open_child(&self.directory, name, &self.root.inner.filesystem)
-            .map_err(|error| map_open_error(&self.root.named_path().join(&relative_path), error))?;
+            .map_err(|error| map_open_error(&named_path, error))?;
         match opened {
             platform::OpenedPath::File {
                 file,
                 metadata,
                 filesystem: _,
             } => {
-                let stamp = platform::object_stamp(&file, &metadata)?;
+                let stamp = provider_source_io_result(
+                    &named_path,
+                    "provider source opened-file identity query",
+                    platform::object_stamp(&file, &metadata),
+                )?;
                 Ok(OpenedProviderSourcePath::File(OpenedProviderSourceFile {
                     route: ProviderSourceFileRoute::Relative {
                         root: self.root.clone(),
@@ -357,7 +408,11 @@ impl ProviderSourceDirectory {
                 metadata,
                 filesystem: _,
             } => {
-                let stamp = platform::object_stamp(&file, &metadata)?;
+                let stamp = provider_source_io_result(
+                    &named_path,
+                    "provider source opened-directory identity query",
+                    platform::object_stamp(&file, &metadata),
+                )?;
                 Ok(OpenedProviderSourcePath::Directory(
                     ProviderSourceDirectory {
                         root: self.root.clone(),
@@ -373,8 +428,16 @@ impl ProviderSourceDirectory {
     /// Detects mutation of the directory while its children were enumerated
     /// and opened.
     pub fn revalidate(&self) -> Result<()> {
-        let metadata = self.directory.metadata()?;
-        let current = platform::object_stamp(&self.directory, &metadata)?;
+        let metadata = provider_source_io_result(
+            self.display_path(),
+            "provider source retained-directory metadata query",
+            self.directory.metadata(),
+        )?;
+        let current = provider_source_io_result(
+            self.display_path(),
+            "provider source retained-directory identity query",
+            platform::object_stamp(&self.directory, &metadata),
+        )?;
         if current != self.opened {
             return Err(changed_path(self.display_path()));
         }
@@ -427,8 +490,16 @@ impl OpenedProviderSourceFile {
 
     /// Strong token for the retained file's current metadata observation.
     pub fn current_ordinary_file_token(&self) -> Result<[u8; 32]> {
-        let metadata = self.file.metadata()?;
-        let current = platform::object_stamp(&self.file, &metadata)?;
+        let metadata = provider_source_io_result(
+            self.display_path(),
+            "provider source retained-file metadata query",
+            self.file.metadata(),
+        )?;
+        let current = provider_source_io_result(
+            self.display_path(),
+            "provider source retained-file identity query",
+            platform::object_stamp(&self.file, &metadata),
+        )?;
         Ok(ordinary_file_token(&current))
     }
 
@@ -450,7 +521,11 @@ impl OpenedProviderSourceFile {
                 let platform::OpenedPath::File { file, metadata, .. } = reopened else {
                     return Err(changed_path(path));
                 };
-                let opened = platform::object_stamp(&file, &metadata)?;
+                let opened = provider_source_io_result(
+                    path,
+                    "provider source reopened-file identity query",
+                    platform::object_stamp(&file, &metadata),
+                )?;
                 if !platform::same_object(&opened, &self.opened) {
                     return Err(changed_path(path));
                 }
@@ -476,7 +551,12 @@ impl OpenedProviderSourceFile {
                 "provider source file exceeds {maximum_bytes} bytes"
             )));
         }
-        Ok(self.file.try_clone()?.take(self.len()))
+        Ok(provider_source_io_result(
+            self.display_path(),
+            "provider source file-handle clone",
+            self.file.try_clone(),
+        )?
+        .take(self.len()))
     }
 
     pub fn read_all_bounded(&self, maximum_bytes: usize) -> Result<Vec<u8>> {
@@ -487,7 +567,11 @@ impl OpenedProviderSourceFile {
             SourceIoError::InvalidPayload("provider source file is too large".into())
         })?;
         let mut bytes = Vec::with_capacity(capacity);
-        reader.read_to_end(&mut bytes)?;
+        provider_source_io_result(
+            self.display_path(),
+            "provider source bounded file read",
+            reader.read_to_end(&mut bytes),
+        )?;
         if bytes.len() != capacity {
             return Err(changed_path(self.display_path()));
         }
@@ -517,7 +601,11 @@ impl OpenedProviderSourceFile {
             ));
         }
         let mut bytes = vec![0_u8; length];
-        platform::read_exact_at(&self.file, &mut bytes, offset)?;
+        provider_source_io_result(
+            self.display_path(),
+            "provider source exact range read",
+            platform::read_exact_at(&self.file, &mut bytes, offset),
+        )?;
         self.revalidate()?;
         Ok(bytes)
     }
@@ -541,14 +629,23 @@ impl OpenedProviderSourceFile {
         let end = offset.checked_add(length_u64).ok_or_else(|| {
             SourceIoError::InvalidPayload("provider source range overflows".into())
         })?;
-        let current_len = self.file.metadata()?.len();
+        let current_len = provider_source_io_result(
+            self.display_path(),
+            "provider source retained-file metadata query",
+            self.file.metadata(),
+        )?
+        .len();
         if end > current_len {
             return Err(SourceIoError::InvalidPayload(
                 "provider source range exceeds the opened file".into(),
             ));
         }
         let mut bytes = vec![0_u8; length];
-        platform::read_exact_at(&self.file, &mut bytes, offset)?;
+        provider_source_io_result(
+            self.display_path(),
+            "provider source exact range read",
+            platform::read_exact_at(&self.file, &mut bytes, offset),
+        )?;
         self.revalidate_same_object()?;
         Ok(bytes)
     }
@@ -559,8 +656,16 @@ impl OpenedProviderSourceFile {
     /// Relative callers must perform one terminal [`ProviderSourceRoot::revalidate`]
     /// after all leaf checks before publishing aggregate evidence.
     pub fn revalidate_leaf(&self) -> Result<()> {
-        let current_metadata = self.file.metadata()?;
-        let current = platform::object_stamp(&self.file, &current_metadata)?;
+        let current_metadata = provider_source_io_result(
+            self.display_path(),
+            "provider source retained-file metadata query",
+            self.file.metadata(),
+        )?;
+        let current = provider_source_io_result(
+            self.display_path(),
+            "provider source retained-file identity query",
+            platform::object_stamp(&self.file, &current_metadata),
+        )?;
         if current != self.opened {
             return Err(changed_path(self.display_path()));
         }
@@ -583,7 +688,11 @@ impl OpenedProviderSourceFile {
         let platform::OpenedPath::File { file, metadata, .. } = reopened else {
             return Err(changed_path(self.display_path()));
         };
-        let named = platform::object_stamp(&file, &metadata)?;
+        let named = provider_source_io_result(
+            self.display_path(),
+            "provider source reopened-file identity query",
+            platform::object_stamp(&file, &metadata),
+        )?;
         if named != self.opened {
             return Err(changed_path(self.display_path()));
         }
@@ -593,8 +702,16 @@ impl OpenedProviderSourceFile {
     /// Confirms the route still names the same ordinary file while allowing
     /// append-only metadata changes on that object.
     pub fn revalidate_same_object_leaf(&self) -> Result<()> {
-        let current_metadata = self.file.metadata()?;
-        let current = platform::object_stamp(&self.file, &current_metadata)?;
+        let current_metadata = provider_source_io_result(
+            self.display_path(),
+            "provider source retained-file metadata query",
+            self.file.metadata(),
+        )?;
+        let current = provider_source_io_result(
+            self.display_path(),
+            "provider source retained-file identity query",
+            platform::object_stamp(&self.file, &current_metadata),
+        )?;
         if !platform::same_object(&current, &self.opened) {
             return Err(changed_path(self.display_path()));
         }
@@ -619,7 +736,11 @@ impl OpenedProviderSourceFile {
         let platform::OpenedPath::File { file, metadata, .. } = reopened else {
             return Err(changed_path(self.display_path()));
         };
-        let named = platform::object_stamp(&file, &metadata)?;
+        let named = provider_source_io_result(
+            self.display_path(),
+            "provider source reopened-file identity query",
+            platform::object_stamp(&file, &metadata),
+        )?;
         if !platform::same_object(&named, &self.opened) {
             return Err(changed_path(self.display_path()));
         }
@@ -760,7 +881,11 @@ pub fn open_provider_source_path(path: &Path) -> Result<OpenedProviderSourcePath
             metadata,
             filesystem: _,
         } => {
-            let stamp = platform::object_stamp(&file, &metadata)?;
+            let stamp = provider_source_io_result(
+                &path,
+                "provider source opened-file identity query",
+                platform::object_stamp(&file, &metadata),
+            )?;
             Ok(OpenedProviderSourcePath::File(OpenedProviderSourceFile {
                 route: ProviderSourceFileRoute::Absolute(path),
                 file,
@@ -773,7 +898,11 @@ pub fn open_provider_source_path(path: &Path) -> Result<OpenedProviderSourcePath
             metadata,
             filesystem,
         } => {
-            let stamp = platform::object_stamp(&file, &metadata)?;
+            let stamp = provider_source_io_result(
+                &path,
+                "provider source opened-directory identity query",
+                platform::object_stamp(&file, &metadata),
+            )?;
             let root = ProviderSourceRoot {
                 inner: Arc::new(ProviderSourceRootInner {
                     named_path: path,
@@ -784,77 +913,6 @@ pub fn open_provider_source_path(path: &Path) -> Result<OpenedProviderSourcePath
             };
             Ok(OpenedProviderSourcePath::Directory(root.directory()?))
         }
-    }
-}
-
-fn ensure_absolute_traversal_free(path: &Path) -> Result<()> {
-    if !path.is_absolute()
-        || path.as_os_str().is_empty()
-        || path
-            .components()
-            .any(|component| matches!(component, Component::ParentDir))
-    {
-        return Err(invalid_path(
-            path,
-            "provider source authority paths must be absolute and traversal-free",
-        ));
-    }
-    Ok(())
-}
-
-fn validate_relative_path(path: &Path) -> Result<()> {
-    if path.is_absolute()
-        || path
-            .components()
-            .any(|component| !matches!(component, Component::Normal(_) | Component::CurDir))
-    {
-        return Err(invalid_path(
-            path,
-            "provider source descendants must be traversal-free relative paths",
-        ));
-    }
-    Ok(())
-}
-
-fn validate_child_name(name: &OsStr, path: &Path) -> Result<()> {
-    if name.is_empty()
-        || name == OsStr::new(".")
-        || name == OsStr::new("..")
-        || Path::new(name).components().count() != 1
-        || !matches!(
-            Path::new(name).components().next(),
-            Some(Component::Normal(_))
-        )
-    {
-        return Err(invalid_path(
-            path,
-            "provider source child names must be single normal components",
-        ));
-    }
-    Ok(())
-}
-
-fn map_open_error(path: &Path, error: AuthorityOpenError) -> SourceIoError {
-    match error {
-        AuthorityOpenError::Io(error) => error.into(),
-        AuthorityOpenError::Rejected(reason) => invalid_path(path, reason),
-    }
-}
-
-fn map_changed_open_error(path: &Path, error: AuthorityOpenError) -> SourceIoError {
-    match error {
-        AuthorityOpenError::Io(error)
-            if matches!(
-                error.kind(),
-                io::ErrorKind::NotFound
-                    | io::ErrorKind::InvalidData
-                    | io::ErrorKind::PermissionDenied
-            ) =>
-        {
-            changed_path(path)
-        }
-        AuthorityOpenError::Rejected(_) => changed_path(path),
-        AuthorityOpenError::Io(error) => error.into(),
     }
 }
 
@@ -900,20 +958,6 @@ pub fn is_symlink_source_rejection(error: &SourceIoError) -> bool {
             if *reason == SYMLINK_PROVIDER_SOURCE_REASON
                 || *reason == REPARSE_PROVIDER_SOURCE_REASON
     )
-}
-
-fn invalid_path(path: &Path, reason: &'static str) -> SourceIoError {
-    SourceIoError::InvalidProviderTranscriptPath {
-        path: path.to_path_buf(),
-        reason,
-    }
-}
-
-fn changed_path(path: &Path) -> SourceIoError {
-    SourceIoError::InvalidProviderTranscriptPath {
-        path: path.to_path_buf(),
-        reason: "provider source changed while its authority handle was retained",
-    }
 }
 
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/ctx-history-source-io/src/io/root_handle/diagnostics.rs
+++ b/crates/ctx-history-source-io/src/io/root_handle/diagnostics.rs
@@ -1,0 +1,158 @@
+use std::{
+    ffi::OsStr,
+    io,
+    path::{Component, Path, PathBuf},
+};
+
+use crate::{Result, SourceIoError};
+
+use super::AuthorityOpenError;
+
+pub(super) fn ensure_absolute_traversal_free(path: &Path) -> Result<()> {
+    if !path.is_absolute()
+        || path.as_os_str().is_empty()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(invalid_path(
+            path,
+            "provider source authority paths must be absolute and traversal-free",
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn validate_relative_path(path: &Path) -> Result<()> {
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_) | Component::CurDir))
+    {
+        return Err(invalid_path(
+            path,
+            "provider source descendants must be traversal-free relative paths",
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn validate_child_name(name: &OsStr, path: &Path) -> Result<()> {
+    if name.is_empty()
+        || name == OsStr::new(".")
+        || name == OsStr::new("..")
+        || Path::new(name).components().count() != 1
+        || !matches!(
+            Path::new(name).components().next(),
+            Some(Component::Normal(_))
+        )
+    {
+        return Err(invalid_path(
+            path,
+            "provider source child names must be single normal components",
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn map_open_error(path: &Path, error: AuthorityOpenError) -> SourceIoError {
+    match error {
+        AuthorityOpenError::Io(source) => source.into(),
+        AuthorityOpenError::SystemIo { operation, source } => {
+            provider_source_system_io(path, operation, source)
+        }
+        AuthorityOpenError::Rejected(reason) => invalid_path(path, reason),
+    }
+}
+
+pub(super) fn map_changed_open_error(path: &Path, error: AuthorityOpenError) -> SourceIoError {
+    match error {
+        AuthorityOpenError::Io(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::NotFound
+                    | io::ErrorKind::InvalidData
+                    | io::ErrorKind::PermissionDenied
+            ) =>
+        {
+            changed_path(path)
+        }
+        AuthorityOpenError::SystemIo { source, .. }
+            if matches!(
+                source.kind(),
+                io::ErrorKind::NotFound
+                    | io::ErrorKind::InvalidData
+                    | io::ErrorKind::PermissionDenied
+            ) =>
+        {
+            changed_path(path)
+        }
+        AuthorityOpenError::Rejected(_) => changed_path(path),
+        AuthorityOpenError::Io(source) => source.into(),
+        AuthorityOpenError::SystemIo { operation, source } => {
+            provider_source_system_io(path, operation, source)
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ProviderSourceIoContext {
+    path: PathBuf,
+    source: io::Error,
+}
+
+impl std::fmt::Display for ProviderSourceIoContext {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "provider source path {:?}: {}",
+            self.path, self.source
+        )
+    }
+}
+
+impl std::error::Error for ProviderSourceIoContext {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+fn provider_source_system_io(
+    path: &Path,
+    operation: &'static str,
+    source: io::Error,
+) -> SourceIoError {
+    let kind = source.kind();
+    SourceIoError::SystemIo {
+        operation,
+        source: io::Error::new(
+            kind,
+            ProviderSourceIoContext {
+                path: path.to_path_buf(),
+                source,
+            },
+        ),
+    }
+}
+
+pub(super) fn provider_source_io_result<T>(
+    path: &Path,
+    operation: &'static str,
+    result: io::Result<T>,
+) -> Result<T> {
+    result.map_err(|source| provider_source_system_io(path, operation, source))
+}
+
+pub(super) fn invalid_path(path: &Path, reason: &'static str) -> SourceIoError {
+    SourceIoError::InvalidProviderTranscriptPath {
+        path: path.to_path_buf(),
+        reason,
+    }
+}
+
+pub(super) fn changed_path(path: &Path) -> SourceIoError {
+    SourceIoError::InvalidProviderTranscriptPath {
+        path: path.to_path_buf(),
+        reason: "provider source changed while its authority handle was retained",
+    }
+}

--- a/crates/ctx-history-source-io/src/io/root_handle/tests.rs
+++ b/crates/ctx-history-source-io/src/io/root_handle/tests.rs
@@ -3,6 +3,30 @@ use std::{fs, io::Read, time::Duration};
 use super::*;
 
 #[test]
+fn provider_source_system_io_names_the_operation_and_path() {
+    let path = Path::new("provider-root/history.jsonl");
+    let error = map_open_error(
+        path,
+        AuthorityOpenError::SystemIo {
+            operation: "provider source target open",
+            source: io::Error::from(io::ErrorKind::PermissionDenied),
+        },
+    );
+    let rendered = error.to_string();
+
+    assert!(matches!(
+        error,
+        SourceIoError::SystemIo {
+            operation: "provider source target open",
+            ..
+        }
+    ));
+    assert!(rendered.contains("provider source target open"));
+    assert!(rendered.contains("provider-root/history.jsonl"));
+    assert!(rendered.contains("permission denied"));
+}
+
+#[test]
 fn streaming_entries_stop_at_the_existing_bounded_entry_diagnostic() {
     let temp = crate::test_support_paths::tempdir().unwrap();
     let root = temp.path().join("root");

--- a/crates/ctx-history-source-io/src/io/root_handle/windows.rs
+++ b/crates/ctx-history-source-io/src/io/root_handle/windows.rs
@@ -33,6 +33,10 @@ use sha2::{Digest, Sha256};
 
 use super::{AuthorityOpenError, DirectoryEntryVisitError};
 
+#[path = "windows/access.rs"]
+mod access;
+use access::ProviderSourceOpenKind;
+
 const DIRECTORY_QUERY_BUFFER_BYTES: usize = 64 * 1024;
 const ERROR_NO_MORE_FILES: i32 = 18;
 const ERROR_CLOUD_FILE_NOT_UNDER_SYNC_ROOT_HRESULT: i32 =
@@ -40,17 +44,33 @@ const ERROR_CLOUD_FILE_NOT_UNDER_SYNC_ROOT_HRESULT: i32 =
 const ERROR_INVALID_FUNCTION_HRESULT: i32 = win32_error_hresult(ERROR_INVALID_FUNCTION);
 const CF_SYNC_ROOT_INFO_BASIC: i32 = 0;
 
-const FILE_READ_ATTRIBUTES: u32 = 0x0000_0080;
-const FILE_READ_DATA: u32 = 0x0000_0001;
-const SYNCHRONIZE: u32 = 0x0010_0000;
-const PROVIDER_SOURCE_READ_ACCESS: u32 = FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE;
 const OBJ_CASE_INSENSITIVE: u32 = 0x0000_0040;
-const FILE_SYNCHRONOUS_IO_NONALERT: u32 = 0x0000_0020;
-const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
 const DRIVE_FIXED: u32 = 3;
 
 const fn win32_error_hresult(error: u32) -> i32 {
     (0x8007_0000_u32 | (error & 0x0000_FFFF)) as i32
+}
+
+#[derive(Debug)]
+struct WindowsIoContext {
+    operation: &'static str,
+    source: io::Error,
+}
+
+impl std::fmt::Display for WindowsIoContext {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.operation, self.source)
+    }
+}
+
+impl std::error::Error for WindowsIoContext {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+fn contextual_windows_io(operation: &'static str, source: io::Error) -> io::Error {
+    io::Error::new(source.kind(), WindowsIoContext { operation, source })
 }
 
 #[link(name = "ntdll")]
@@ -152,16 +172,26 @@ pub(super) fn open_absolute(path: &Path) -> Result<OpenedPath, AuthorityOpenErro
         ));
     }
 
+    let root_kind = if names.is_empty() {
+        ProviderSourceOpenKind::Target
+    } else {
+        ProviderSourceOpenKind::AncestorDirectory
+    };
     let root = OpenOptions::new()
-        .read(true)
+        .access_mode(root_kind.desired_access())
         .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
-        .open(drive_root_path)?;
+        .open(drive_root_path)
+        .map_err(|source| AuthorityOpenError::SystemIo {
+            operation: "provider source drive-root open",
+            source,
+        })?;
     let mut current = classify_opened(root)?;
     verify_root_drive(&current, drive)?;
     let root_filesystem = opened_filesystem(&current).clone();
 
-    for name in names {
+    let final_component = names.len().saturating_sub(1);
+    for (index, name) in names.into_iter().enumerate() {
         let parent = match &current {
             OpenedPath::Directory { file, .. } => file,
             OpenedPath::File { .. } => {
@@ -170,7 +200,12 @@ pub(super) fn open_absolute(path: &Path) -> Result<OpenedPath, AuthorityOpenErro
                 ));
             }
         };
-        current = open_child(parent, name, &root_filesystem)?;
+        let kind = if index == final_component {
+            ProviderSourceOpenKind::Target
+        } else {
+            ProviderSourceOpenKind::AncestorDirectory
+        };
+        current = open_child_with_kind(parent, name, &root_filesystem, kind)?;
     }
     Ok(current)
 }
@@ -180,8 +215,17 @@ pub(super) fn open_child(
     name: &OsStr,
     filesystem: &FilesystemIdentity,
 ) -> Result<OpenedPath, AuthorityOpenError> {
+    open_child_with_kind(parent, name, filesystem, ProviderSourceOpenKind::Target)
+}
+
+fn open_child_with_kind(
+    parent: &File,
+    name: &OsStr,
+    filesystem: &FilesystemIdentity,
+    kind: ProviderSourceOpenKind,
+) -> Result<OpenedPath, AuthorityOpenError> {
     validate_child_name(name)?;
-    let file = nt_open_child(parent, name)?;
+    let file = nt_open_child(parent, name, kind)?;
     let opened = classify_opened(file)?;
     if opened_filesystem(&opened) != filesystem {
         return Err(AuthorityOpenError::Rejected(
@@ -239,7 +283,12 @@ pub(super) fn visit_directory_entries<E>(
             if cause.raw_os_error() == Some(ERROR_NO_MORE_FILES) {
                 break;
             }
-            return Err(DirectoryEntryVisitError::Authority(cause.into()));
+            return Err(DirectoryEntryVisitError::Authority(
+                AuthorityOpenError::SystemIo {
+                    operation: "provider source directory enumeration",
+                    source: cause,
+                },
+            ));
         }
         restart = false;
         visit_directory_buffer(&buffer, visit)?;
@@ -297,14 +346,32 @@ pub(super) fn retained_file_identity(
     version: super::RetainedFileIdentityVersion,
 ) -> Result<Option<([u8; 32], [u8; 32])>, AuthorityOpenError> {
     let mut basic = FILE_BASIC_INFO::default();
-    query_handle_info(file, FileBasicInfo, &mut basic)?;
+    query_handle_info(
+        file,
+        FileBasicInfo,
+        &mut basic,
+        "GetFileInformationByHandleEx(FileBasicInfo)",
+    )
+    .map_err(|source| AuthorityOpenError::SystemIo {
+        operation: "provider source retained-identity query",
+        source,
+    })?;
     if basic.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
         return Err(AuthorityOpenError::Rejected(
             "reparse-point provider transcript files are rejected",
         ));
     }
     let mut id = FILE_ID_INFO::default();
-    query_handle_info(file, FileIdInfo, &mut id)?;
+    query_handle_info(
+        file,
+        FileIdInfo,
+        &mut id,
+        "GetFileInformationByHandleEx(FileIdInfo)",
+    )
+    .map_err(|source| AuthorityOpenError::SystemIo {
+        operation: "provider source retained-identity query",
+        source,
+    })?;
     let mut stable = Sha256::new();
     let mut change = Sha256::new();
     match version {
@@ -396,7 +463,7 @@ fn read_at(file: &File, bytes: &mut [u8], offset: u64) -> io::Result<usize> {
         if cause.raw_os_error() == Some(ERROR_HANDLE_EOF as i32) {
             Ok(0)
         } else {
-            Err(cause)
+            Err(contextual_windows_io("ReadFile", cause))
         }
     }
 }
@@ -466,7 +533,11 @@ fn validate_child_name(name: &OsStr) -> Result<(), AuthorityOpenError> {
     Ok(())
 }
 
-fn nt_open_child(parent: &File, name: &OsStr) -> Result<File, AuthorityOpenError> {
+fn nt_open_child(
+    parent: &File,
+    name: &OsStr,
+    kind: ProviderSourceOpenKind,
+) -> Result<File, AuthorityOpenError> {
     let mut units = name.encode_wide().collect::<Vec<_>>();
     let length = units
         .len()
@@ -498,17 +569,25 @@ fn nt_open_child(parent: &File, name: &OsStr) -> Result<File, AuthorityOpenError
     let status = unsafe {
         NtOpenFile(
             &mut handle,
-            PROVIDER_SOURCE_READ_ACCESS,
+            kind.desired_access(),
             &attributes,
             &mut io_status,
             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-            FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT,
+            kind.open_options(),
         )
     };
     if status < 0 {
         let windows_error = unsafe { RtlNtStatusToDosError(status) };
         let windows_error = i32::try_from(windows_error).unwrap_or(i32::MAX);
-        return Err(io::Error::from_raw_os_error(windows_error).into());
+        return Err(AuthorityOpenError::SystemIo {
+            operation: match kind {
+                ProviderSourceOpenKind::AncestorDirectory => {
+                    "provider source ancestor-directory open"
+                }
+                ProviderSourceOpenKind::Target => "provider source target open",
+            },
+            source: io::Error::from_raw_os_error(windows_error),
+        });
     }
     if handle.is_null() {
         return Err(AuthorityOpenError::Rejected(
@@ -519,8 +598,16 @@ fn nt_open_child(parent: &File, name: &OsStr) -> Result<File, AuthorityOpenError
 }
 
 fn classify_opened(file: File) -> Result<OpenedPath, AuthorityOpenError> {
-    let metadata = file.metadata()?;
-    let details = handle_details(&file)?;
+    let metadata = file
+        .metadata()
+        .map_err(|source| AuthorityOpenError::SystemIo {
+            operation: "provider source metadata query",
+            source,
+        })?;
+    let details = handle_details(&file).map_err(|source| AuthorityOpenError::SystemIo {
+        operation: "provider source handle-information query",
+        source,
+    })?;
     ensure_handle_is_ordinary(&file, &details)?;
     let filesystem = filesystem_identity(&file, &details)?;
     ensure_not_cloud_root(&file, &filesystem)?;
@@ -551,11 +638,26 @@ struct HandleDetails {
 
 fn handle_details(file: &File) -> io::Result<HandleDetails> {
     let mut basic = FILE_BASIC_INFO::default();
-    query_handle_info(file, FileBasicInfo, &mut basic)?;
+    query_handle_info(
+        file,
+        FileBasicInfo,
+        &mut basic,
+        "GetFileInformationByHandleEx(FileBasicInfo)",
+    )?;
     let mut id = FILE_ID_INFO::default();
-    query_handle_info(file, FileIdInfo, &mut id)?;
+    query_handle_info(
+        file,
+        FileIdInfo,
+        &mut id,
+        "GetFileInformationByHandleEx(FileIdInfo)",
+    )?;
     let mut tags = FILE_ATTRIBUTE_TAG_INFO::default();
-    query_handle_info(file, FileAttributeTagInfo, &mut tags)?;
+    query_handle_info(
+        file,
+        FileAttributeTagInfo,
+        &mut tags,
+        "GetFileInformationByHandleEx(FileAttributeTagInfo)",
+    )?;
     Ok(HandleDetails {
         basic,
         id,
@@ -563,7 +665,12 @@ fn handle_details(file: &File) -> io::Result<HandleDetails> {
     })
 }
 
-fn query_handle_info<T>(file: &File, class: i32, output: &mut T) -> io::Result<()> {
+fn query_handle_info<T>(
+    file: &File,
+    class: i32,
+    output: &mut T,
+    operation: &'static str,
+) -> io::Result<()> {
     let output_size = u32::try_from(size_of::<T>())
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "handle info is too large"))?;
     let result = unsafe {
@@ -575,7 +682,7 @@ fn query_handle_info<T>(file: &File, class: i32, output: &mut T) -> io::Result<(
         )
     };
     if result == 0 {
-        Err(io::Error::last_os_error())
+        Err(contextual_windows_io(operation, io::Error::last_os_error()))
     } else {
         Ok(())
     }
@@ -699,7 +806,10 @@ fn filesystem_identity(
         )
     };
     if result == 0 {
-        return Err(io::Error::last_os_error().into());
+        return Err(AuthorityOpenError::SystemIo {
+            operation: "provider source volume-information query",
+            source: io::Error::last_os_error(),
+        });
     }
     let end = filesystem_name
         .iter()
@@ -740,7 +850,10 @@ fn verify_root_drive(opened: &OpenedPath, expected_drive: u8) -> Result<(), Auth
         )
     };
     if required == 0 {
-        return Err(io::Error::last_os_error().into());
+        return Err(AuthorityOpenError::SystemIo {
+            operation: "provider source drive-path qualification",
+            source: io::Error::last_os_error(),
+        });
     }
     let mut buffer = vec![0_u16; required as usize + 1];
     let written = unsafe {
@@ -752,7 +865,10 @@ fn verify_root_drive(opened: &OpenedPath, expected_drive: u8) -> Result<(), Auth
         )
     };
     if written == 0 || written as usize >= buffer.len() {
-        return Err(io::Error::last_os_error().into());
+        return Err(AuthorityOpenError::SystemIo {
+            operation: "provider source drive-path qualification",
+            source: io::Error::last_os_error(),
+        });
     }
     buffer.truncate(written as usize);
     let prefix = [
@@ -859,70 +975,5 @@ fn ascii_upper_u16(value: u16) -> u16 {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn verified_ntfs() -> FilesystemIdentity {
-        FilesystemIdentity {
-            volume_serial_number: 1,
-            filesystem_name: "NTFS".to_owned(),
-        }
-    }
-
-    #[test]
-    fn explicit_non_cloud_and_unsupported_verified_ntfs_results_are_accepted() {
-        let filesystem = verified_ntfs();
-        assert!(
-            qualify_sync_root_query(ERROR_CLOUD_FILE_NOT_UNDER_SYNC_ROOT_HRESULT, &filesystem,)
-                .is_ok()
-        );
-        assert!(qualify_sync_root_query(ERROR_INVALID_FUNCTION_HRESULT, &filesystem).is_ok());
-    }
-
-    #[test]
-    fn unsupported_cloud_query_requires_verified_ntfs() {
-        let unqualified = FilesystemIdentity {
-            volume_serial_number: 1,
-            filesystem_name: "ReFS".to_owned(),
-        };
-        assert!(matches!(
-            qualify_sync_root_query(ERROR_INVALID_FUNCTION_HRESULT, &unqualified),
-            Err(AuthorityOpenError::Rejected(
-                "Windows could not qualify the provider source as non-cloud storage"
-            ))
-        ));
-    }
-
-    #[test]
-    fn not_a_cloud_placeholder_does_not_prove_not_under_sync_root() {
-        let filesystem = verified_ntfs();
-
-        let not_a_cloud_file =
-            win32_error_hresult(windows_sys::Win32::Foundation::ERROR_NOT_A_CLOUD_FILE);
-        assert!(matches!(
-            qualify_sync_root_query(not_a_cloud_file, &filesystem),
-            Err(AuthorityOpenError::Rejected(
-                "Windows could not qualify the provider source as non-cloud storage"
-            ))
-        ));
-    }
-
-    #[test]
-    fn sync_root_and_ambiguous_query_results_remain_rejected() {
-        let filesystem = verified_ntfs();
-        let access_denied =
-            win32_error_hresult(windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED);
-        assert!(matches!(
-            qualify_sync_root_query(0, &filesystem),
-            Err(AuthorityOpenError::Rejected(
-                "cloud-synchronized provider source roots are rejected"
-            ))
-        ));
-        assert!(matches!(
-            qualify_sync_root_query(access_denied, &filesystem),
-            Err(AuthorityOpenError::Rejected(
-                "Windows could not qualify the provider source as non-cloud storage"
-            ))
-        ));
-    }
-}
+#[path = "windows/tests.rs"]
+mod tests;

--- a/crates/ctx-history-source-io/src/io/root_handle/windows/access.rs
+++ b/crates/ctx-history-source-io/src/io/root_handle/windows/access.rs
@@ -1,0 +1,64 @@
+const FILE_READ_ATTRIBUTES: u32 = 0x0000_0080;
+const FILE_READ_DATA: u32 = 0x0000_0001;
+const FILE_TRAVERSE: u32 = 0x0000_0020;
+const SYNCHRONIZE: u32 = 0x0010_0000;
+const PROVIDER_SOURCE_TARGET_ACCESS: u32 = FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE;
+const PROVIDER_SOURCE_ANCESTOR_ACCESS: u32 = FILE_TRAVERSE | FILE_READ_ATTRIBUTES | SYNCHRONIZE;
+const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
+const FILE_SYNCHRONOUS_IO_NONALERT: u32 = 0x0000_0020;
+const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+
+#[derive(Clone, Copy)]
+pub(super) enum ProviderSourceOpenKind {
+    AncestorDirectory,
+    Target,
+}
+
+impl ProviderSourceOpenKind {
+    pub(super) const fn desired_access(self) -> u32 {
+        match self {
+            Self::AncestorDirectory => PROVIDER_SOURCE_ANCESTOR_ACCESS,
+            Self::Target => PROVIDER_SOURCE_TARGET_ACCESS,
+        }
+    }
+
+    pub(super) const fn open_options(self) -> u32 {
+        let options = FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT;
+        match self {
+            Self::AncestorDirectory => options | FILE_DIRECTORY_FILE,
+            Self::Target => options,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ancestor_walk_requests_traverse_without_directory_listing() {
+        let access = ProviderSourceOpenKind::AncestorDirectory.desired_access();
+
+        assert_eq!(access & FILE_READ_DATA, 0);
+        assert_ne!(access & FILE_TRAVERSE, 0);
+        assert_ne!(access & FILE_READ_ATTRIBUTES, 0);
+        assert_ne!(access & SYNCHRONIZE, 0);
+        assert_ne!(
+            ProviderSourceOpenKind::AncestorDirectory.open_options() & FILE_DIRECTORY_FILE,
+            0
+        );
+    }
+
+    #[test]
+    fn target_open_retains_the_data_or_directory_listing_right() {
+        let access = ProviderSourceOpenKind::Target.desired_access();
+
+        assert_ne!(access & FILE_READ_DATA, 0);
+        assert_ne!(access & FILE_READ_ATTRIBUTES, 0);
+        assert_ne!(access & SYNCHRONIZE, 0);
+        assert_eq!(
+            ProviderSourceOpenKind::Target.open_options() & FILE_DIRECTORY_FILE,
+            0
+        );
+    }
+}

--- a/crates/ctx-history-source-io/src/io/root_handle/windows/tests.rs
+++ b/crates/ctx-history-source-io/src/io/root_handle/windows/tests.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+fn verified_ntfs() -> FilesystemIdentity {
+    FilesystemIdentity {
+        volume_serial_number: 1,
+        filesystem_name: "NTFS".to_owned(),
+    }
+}
+
+#[test]
+fn explicit_non_cloud_and_unsupported_verified_ntfs_results_are_accepted() {
+    let filesystem = verified_ntfs();
+    assert!(
+        qualify_sync_root_query(ERROR_CLOUD_FILE_NOT_UNDER_SYNC_ROOT_HRESULT, &filesystem,).is_ok()
+    );
+    assert!(qualify_sync_root_query(ERROR_INVALID_FUNCTION_HRESULT, &filesystem).is_ok());
+}
+
+#[test]
+fn unsupported_cloud_query_requires_verified_ntfs() {
+    let unqualified = FilesystemIdentity {
+        volume_serial_number: 1,
+        filesystem_name: "ReFS".to_owned(),
+    };
+    assert!(matches!(
+        qualify_sync_root_query(ERROR_INVALID_FUNCTION_HRESULT, &unqualified),
+        Err(AuthorityOpenError::Rejected(
+            "Windows could not qualify the provider source as non-cloud storage"
+        ))
+    ));
+}
+
+#[test]
+fn not_a_cloud_placeholder_does_not_prove_not_under_sync_root() {
+    let filesystem = verified_ntfs();
+
+    let not_a_cloud_file =
+        win32_error_hresult(windows_sys::Win32::Foundation::ERROR_NOT_A_CLOUD_FILE);
+    assert!(matches!(
+        qualify_sync_root_query(not_a_cloud_file, &filesystem),
+        Err(AuthorityOpenError::Rejected(
+            "Windows could not qualify the provider source as non-cloud storage"
+        ))
+    ));
+}
+
+#[test]
+fn sync_root_and_ambiguous_query_results_remain_rejected() {
+    let filesystem = verified_ntfs();
+    let access_denied = win32_error_hresult(windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED);
+    assert!(matches!(
+        qualify_sync_root_query(0, &filesystem),
+        Err(AuthorityOpenError::Rejected(
+            "cloud-synchronized provider source roots are rejected"
+        ))
+    ));
+    assert!(matches!(
+        qualify_sync_root_query(access_denied, &filesystem),
+        Err(AuthorityOpenError::Rejected(
+            "Windows could not qualify the provider source as non-cloud storage"
+        ))
+    ));
+}

--- a/crates/ctx-history-source-io/src/io_tests.rs
+++ b/crates/ctx-history-source-io/src/io_tests.rs
@@ -12,7 +12,7 @@ use std::io::Read;
 use std::{
     io::ErrorKind,
     os::windows::fs::{symlink_dir, symlink_file},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use super::{
@@ -303,6 +303,28 @@ fn windows_ordinary_absolute_provider_file_is_accepted() {
     let source = open_provider_source_file(&path).unwrap();
     assert_eq!(source.read_all_bounded(8).unwrap(), b"provider");
     source.revalidate().unwrap();
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn windows_qualified_external_provider_file_is_accepted() {
+    let mut retained_temp = None;
+    let path = match std::env::var_os("CTX_TEST_WINDOWS_PROVIDER_FILE") {
+        Some(path) => PathBuf::from(path),
+        None => {
+            let temp = crate::test_support_paths::tempdir().unwrap();
+            let path = temp.path().join("provider-external.db");
+            fs::write(&path, b"provider").unwrap();
+            retained_temp = Some(temp);
+            path
+        }
+    };
+    let expected = fs::read(&path).unwrap();
+
+    let source = open_provider_source_file(&path).unwrap();
+    assert_eq!(source.read_all_bounded(1024 * 1024).unwrap(), expected);
+    source.revalidate().unwrap();
+    drop(retained_temp);
 }
 
 #[cfg(target_os = "windows")]

--- a/crates/ctx-history-source-io/src/lib.rs
+++ b/crates/ctx-history-source-io/src/lib.rs
@@ -16,7 +16,10 @@ mod path_identity;
 
 pub use bounded_tree::*;
 pub use error::ProviderJsonlInventoryLimit as SourceIoJsonlInventoryLimit;
-pub use error::{ProviderJsonlInventoryLimit, Result, SourceIoError};
+pub use error::{
+    is_provider_source_io_operation, is_provider_source_unavailable_io,
+    ProviderJsonlInventoryLimit, Result, SourceIoError, PROVIDER_SOURCE_IO_OPERATION_PREFIX,
+};
 pub use event_files::*;
 pub use io::*;
 pub use mapped_io::*;


### PR DESCRIPTION
## Summary

- request only traverse, attribute, and synchronization rights for Windows ancestor directories
- retain data or directory-list access for the final provider source target
- report provider source operation and path for access failures
- isolate provider permission failures while preserving systemic resource failures

## Validation

- native Windows allow-only ACL A/B: unchanged main failed with error code 5; fixed build passed
- ordinary File.Open passed and the ancestor contained zero Deny ACEs
- 286 focused source and provider tests passed
- 144 capture-composition tests passed
- final Windows ctx cross-check passed
- formatting, diff, LOC, and repository ownership checks passed

Closes #841