### PR TITLE
fix: harden portable import and daemon handoff

### DIFF
--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration/additional.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration/additional.rs
@@ -298,16 +298,21 @@ fn import_all_without_sources_does_not_report_missing_explicit_path() {
 
 #[test]
 fn import_all_discovers_sources_when_home_unset_and_userprofile_set() {
-    let temp = tempdir();
+    let temp = daemon_test_root();
     copy_dir_all(
         Path::new(&provider_history_fixture("codex-sessions")),
         &temp.path().join(".codex").join("sessions"),
     );
+    // Establish the exact retained daemon while the fixture-owned HOME is
+    // intact. The import below exercises USERPROFILE discovery without
+    // authorizing a detached child to escape through the installed-user home.
+    let _daemon = start_full_source_refresh_daemon(&temp);
 
     let imported = json_output(
         ctx(&temp)
             .env_remove("HOME")
             .env("USERPROFILE", temp.path())
+            .env("CTX_DAEMON_AUTOSTART_OFF", "1")
             .args(["import", "--all", "--format=json", "--progress", "none"]),
     );
     assert!(imported["totals"]["current_source_count"]
@@ -317,6 +322,26 @@ fn import_all_discovers_sources_when_home_unset_and_userprofile_set() {
     assert_eq!(
         imported["sources"][0]["source_format"],
         "provider_authoritative_all"
+    );
+
+    let discovered = json_output(
+        ctx(&temp)
+            .env_remove("HOME")
+            .env("USERPROFILE", temp.path())
+            .env("CTX_DAEMON_AUTOSTART_OFF", "1")
+            .args(["sources", "--format=json"]),
+    );
+    let codex = discovered["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|source| {
+            source["provider"] == "codex" && source["source_format"] == "codex_session_jsonl_tree"
+        })
+        .unwrap_or_else(|| panic!("missing USERPROFILE Codex route: {discovered:#}"));
+    assert!(
+        Path::new(codex["path"].as_str().unwrap()).starts_with(temp.path()),
+        "USERPROFILE discovery escaped the fixture root: {codex:#}"
     );
 }
 

--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle/additional.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle/additional.rs
@@ -654,18 +654,20 @@ fn foreground_import_returns_at_ready_core_generation() {
         import["totals"]["current_indexed_documents"], 1,
         "{import:#}"
     );
-    let generation = import["sources"][0]["published_generation"]
-        .as_str()
-        .unwrap();
+    let source = &import["sources"][0];
+    assert_eq!(source["status"], "published", "{import:#}");
+    let request_id = source["daemon_request_id"].as_str().unwrap();
+    assert!(!request_id.is_empty(), "{import:#}");
+    assert_eq!(
+        source["daemon_request_metadata"]["owner"], "daemon",
+        "{import:#}",
+    );
+    let generation = source["published_generation"].as_str().unwrap();
+    assert!(!generation.is_empty(), "{import:#}");
 
     let status = json_output(ctx_from_binary(&temp, &binary).args(["status", "--format=json"]));
     assert_eq!(status["lexical"]["generation_id"], generation, "{status:#}");
     assert_eq!(status["lexical"]["status"], "ready", "{status:#}");
-    assert_eq!(status["refresh"]["status"], "ready", "{status:#}");
-    assert_eq!(
-        status["refresh"]["published_generation"], generation,
-        "{status:#}"
-    );
     assert!(status.get("relational").is_none(), "{status:#}");
     assert!(!data_root(&temp).join("relational.sqlite").exists());
 
@@ -684,6 +686,10 @@ fn foreground_import_returns_at_ready_core_generation() {
         "prompt history daemon refresh oracle",
         1,
         "message",
+    );
+    assert_eq!(
+        search["retrieval"]["generation_id"], generation,
+        "{search:#}"
     );
 
     drop(core_daemon);

--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/source_inventory.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/source_inventory.rs
@@ -438,7 +438,7 @@ fn sources_lists_supported_personal_agent_provider_defaults() {
     let temp = tempdir();
     install_default_hermes_fixture(&temp, "hermes-sources-oracle");
     install_default_kilo_fixture(&temp, "kilo-sources-oracle");
-    install_default_kiro_fixture(&temp, "kiro-sources-oracle");
+    let kiro_fixture = install_default_kiro_fixture(&temp, "kiro-sources-oracle");
     install_default_astrbot_fixture(&temp, "astrbot-sources-oracle");
     install_default_continue_fixture(&temp, "continue-sources-oracle");
     install_default_forgecode_fixture(&temp, "forgecode-sources-oracle");
@@ -454,7 +454,6 @@ fn sources_lists_supported_personal_agent_provider_defaults() {
     for (provider, source_format) in [
         ("hermes", "hermes_state_sqlite"),
         ("kilo", "kilo_sqlite"),
-        ("kiro_cli", "kiro_cli_sqlite"),
         ("astrbot", "astrbot_data_v4_sqlite"),
         ("continue", "continue_cli_sessions_json"),
         ("forgecode", "forgecode_sqlite"),
@@ -473,6 +472,19 @@ fn sources_lists_supported_personal_agent_provider_defaults() {
         assert_eq!(source["importable"], true);
         assert!(source["unsupported_reason"].is_null());
     }
+
+    let kiro_sources = source_entries(&sources)
+        .iter()
+        .filter(|source| source["provider"] == "kiro_cli")
+        .collect::<Vec<_>>();
+    if cfg!(target_os = "windows") {
+        assert!(kiro_sources.is_empty(), "{sources:#}");
+    } else {
+        assert_eq!(kiro_sources.len(), 1, "{sources:#}");
+        assert_eq!(kiro_sources[0]["status"], "available");
+        assert_eq!(kiro_sources[0]["source_format"], "kiro_cli_sqlite");
+        assert_eq!(kiro_sources[0]["path"], kiro_fixture.to_str().unwrap());
+    }
 }
 
 #[test]
@@ -488,7 +500,7 @@ fn sources_reports_adjacent_current_and_legacy_routes_without_unsupported_duplic
     .unwrap();
     fs::write(openclaw_sessions.join("session.jsonl"), "{}\n").unwrap();
 
-    install_default_kiro_fixture(&temp, "kiro-coexistence-oracle");
+    let kiro_fixture = install_default_kiro_fixture(&temp, "kiro-coexistence-oracle");
     fs::create_dir_all(temp.path().join(".kiro/sessions")).unwrap();
 
     let qoder_root = temp.path().join(".qoder/projects");
@@ -542,12 +554,23 @@ fn sources_reports_adjacent_current_and_legacy_routes_without_unsupported_duplic
         .iter()
         .filter(|source| source["provider"] == "kiro_cli")
         .collect::<Vec<_>>();
-    assert_eq!(kiro.len(), 2, "{sources:#}");
-    assert!(kiro.iter().any(|source| {
-        source["source_format"] == "kiro_cli_sqlite"
-            && source["status"] == "available"
-            && source["importable"] == true
-    }));
+    assert_eq!(
+        kiro.len(),
+        if cfg!(target_os = "windows") { 1 } else { 2 },
+        "{sources:#}",
+    );
+    if cfg!(target_os = "windows") {
+        assert!(kiro
+            .iter()
+            .all(|source| source["path"] != kiro_fixture.to_str().unwrap()));
+    } else {
+        assert!(kiro.iter().any(|source| {
+            source["source_format"] == "kiro_cli_sqlite"
+                && source["status"] == "available"
+                && source["importable"] == true
+                && source["path"] == kiro_fixture.to_str().unwrap()
+        }));
+    }
     assert!(kiro.iter().any(|source| {
         source["status"] == "unsupported"
             && source["path"] == temp.path().join(".kiro/sessions").to_str().unwrap()
@@ -724,17 +747,19 @@ fn nanoclaw_identity_snapshot(temp: &TempDir) -> (String, String, usize) {
     )
 }
 
-fn registered_nanoclaw(temp: &TempDir, query: &str) -> (PathBuf, PathBuf) {
-    let project = PathBuf::from(write_native_nanoclaw_fixture(temp, query));
+fn registered_nanoclaw(temp: &TempDir, query: &str) -> (PathBuf, PathBuf, bool) {
+    let fixture = PathBuf::from(write_native_nanoclaw_fixture(temp, query));
+    let project = temp.path().join("native & nanoclaw");
+    fs::rename(fixture, &project).unwrap();
     let registered = project
         .parent()
         .unwrap()
         .join(".")
         .join(project.file_name().unwrap());
-    write_nanoclaw_systemd_registration(temp, &registered);
+    let has_service_registration = write_nanoclaw_service_registration(temp, &registered);
     let unrelated_cwd = temp.path().join("unrelated-cwd");
     fs::create_dir_all(&unrelated_cwd).unwrap();
-    (project, unrelated_cwd)
+    (project, unrelated_cwd, has_service_registration)
 }
 
 fn assert_nanoclaw_counts(counts: &Value, sources: u64, documents: u64) {
@@ -777,11 +802,25 @@ fn import_nanoclaw(temp: &TempDir, cwd: Option<&Path>, path: Option<&Path>) -> V
 fn nanoclaw_automatic_then_explicit_import_preserves_one_source_session_and_result() {
     let temp = tempdir();
     let query = "nanoclaw-lexical-registration-auto-refresh-oracle";
-    let (project, unrelated_cwd) = registered_nanoclaw(&temp, query);
+    let (project, unrelated_cwd, has_service_registration) = registered_nanoclaw(&temp, query);
 
     let mut sources_command = ctx(&temp);
     sources_command.current_dir(&unrelated_cwd);
     let sources = json_output(sources_command.args(["sources", "--format=json"]));
+    if !has_service_registration {
+        assert!(source_entries(&sources)
+            .iter()
+            .all(|source| source["provider"] != "nanoclaw"));
+        import_nanoclaw(&temp, Some(&unrelated_cwd), None);
+        assert!(provider_core_records(&data_root(&temp), "nanoclaw").is_empty());
+
+        ctx(&temp).args(["daemon", "enable"]).assert().success();
+        let imported = import_nanoclaw(&temp, None, Some(&project));
+        assert_eq!(imported["totals"]["current_rejected_records"], 0);
+        assert_nanoclaw_counts(&imported["totals"], 1, 2);
+        assert_nanoclaw_search(&temp, query, None);
+        return;
+    }
     let nanoclaw = source_entry(&sources, "nanoclaw", None);
     assert_eq!(nanoclaw["status"], "available");
     assert_eq!(nanoclaw["import_support"], "native");
@@ -811,12 +850,28 @@ fn nanoclaw_automatic_then_explicit_import_preserves_one_source_session_and_resu
 fn nanoclaw_explicit_then_automatic_import_preserves_one_source_session_and_result() {
     let temp = tempdir();
     let query = "nanoclaw-explicit-then-automatic-oracle";
-    let (project, unrelated_cwd) = registered_nanoclaw(&temp, query);
+    let (project, unrelated_cwd, has_service_registration) = registered_nanoclaw(&temp, query);
 
     ctx(&temp).args(["daemon", "enable"]).assert().success();
     let explicit = import_nanoclaw(&temp, None, Some(&project));
     assert_nanoclaw_counts(&explicit["totals"], 1, 2);
     let explicit_identity = nanoclaw_identity_snapshot(&temp);
+    assert_nanoclaw_search(&temp, query, None);
+
+    if !has_service_registration {
+        let mut sources_command = ctx(&temp);
+        sources_command.current_dir(&unrelated_cwd);
+        let sources = json_output(sources_command.args([
+            "sources",
+            "--provider",
+            "nanoclaw",
+            "--format=json",
+        ]));
+        assert!(source_entries(&sources)
+            .iter()
+            .all(|source| source["provider"] != "nanoclaw"));
+        return;
+    }
 
     let automatic = import_nanoclaw(&temp, Some(&unrelated_cwd), None);
     assert_nanoclaw_counts(&automatic["totals"], 1, 2);
@@ -831,13 +886,16 @@ fn nanoclaw_service_registration_import_all_indexes_two_checkouts_without_exact_
     let first_fixture = PathBuf::from(write_native_nanoclaw_fixture(&temp, first_query));
     let first_project = temp.path().join("registered NanoClaw checkout one");
     fs::rename(&first_fixture, &first_project).unwrap();
-    write_nanoclaw_systemd_registration(&temp, &first_project);
+    let has_service_registration = write_nanoclaw_service_registration(&temp, &first_project);
 
     let second_query = "marigoldvelvetpulsar";
     let second_fixture = PathBuf::from(write_native_nanoclaw_fixture(&temp, second_query));
     let second_project = temp.path().join("registered NanoClaw checkout two");
     fs::rename(&second_fixture, &second_project).unwrap();
-    write_nanoclaw_systemd_registration(&temp, &second_project);
+    assert_eq!(
+        write_nanoclaw_service_registration(&temp, &second_project),
+        has_service_registration,
+    );
     let unrelated_cwd = temp.path().join("unrelated-cwd");
     fs::create_dir_all(&unrelated_cwd).unwrap();
 
@@ -845,6 +903,18 @@ fn nanoclaw_service_registration_import_all_indexes_two_checkouts_without_exact_
     sources_command.current_dir(&unrelated_cwd);
     let sources =
         json_output(sources_command.args(["sources", "--provider", "nanoclaw", "--format=json"]));
+    if !has_service_registration {
+        assert!(source_entries(&sources).is_empty(), "{sources:#}");
+        for (project, query) in [
+            (&first_project, first_query),
+            (&second_project, second_query),
+        ] {
+            let imported = import_nanoclaw(&temp, None, Some(project));
+            assert_nanoclaw_counts(&imported["totals"], 1, 2);
+            assert_nanoclaw_search(&temp, query, None);
+        }
+        return;
+    }
     let mut nanoclaw_paths = source_entries(&sources)
         .iter()
         .filter(|source| source["provider"] == "nanoclaw")
@@ -874,6 +944,18 @@ fn nanoclaw_service_registration_import_all_indexes_two_checkouts_without_exact_
     }
 }
 
+fn write_nanoclaw_service_registration(temp: &TempDir, project: &Path) -> bool {
+    if cfg!(target_os = "linux") {
+        write_nanoclaw_systemd_registration(temp, project);
+        true
+    } else if cfg!(target_os = "macos") {
+        write_nanoclaw_launchd_registration(temp, project);
+        true
+    } else {
+        false
+    }
+}
+
 fn write_nanoclaw_systemd_registration(temp: &TempDir, project: &Path) {
     let slug = nanoclaw_test_sha1_slug(project.to_string_lossy().as_bytes());
     let unit = temp
@@ -894,6 +976,41 @@ fn write_nanoclaw_systemd_registration(temp: &TempDir, project: &Path) {
         ),
     )
     .unwrap();
+}
+
+fn write_nanoclaw_launchd_registration(temp: &TempDir, project: &Path) {
+    let slug = nanoclaw_test_sha1_slug(project.to_string_lossy().as_bytes());
+    let label = format!("com.nanoclaw-v2-{slug}");
+    let plist = temp
+        .path()
+        .join("Library/LaunchAgents")
+        .join(format!("{label}.plist"));
+    fs::create_dir_all(plist.parent().unwrap()).unwrap();
+    let project = project.to_str().unwrap();
+    let home = temp.path().to_str().unwrap();
+    fs::write(
+        plist,
+        format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n    <key>Label</key>\n    <string>{}</string>\n    <key>ProgramArguments</key>\n    <array>\n        <string>/usr/local/bin/node</string>\n        <string>{}</string>\n    </array>\n    <key>WorkingDirectory</key>\n    <string>{}</string>\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>EnvironmentVariables</key>\n    <dict>\n        <key>PATH</key>\n        <string>/usr/local/bin:/usr/bin:/bin:{}/.local/bin</string>\n        <key>HOME</key>\n        <string>{}</string>\n    </dict>\n    <key>StandardOutPath</key>\n    <string>{}/logs/nanoclaw.log</string>\n    <key>StandardErrorPath</key>\n    <string>{}/logs/nanoclaw.error.log</string>\n</dict>\n</plist>",
+            nanoclaw_xml_escape(&label),
+            nanoclaw_xml_escape(&format!("{project}/dist/index.js")),
+            nanoclaw_xml_escape(project),
+            nanoclaw_xml_escape(home),
+            nanoclaw_xml_escape(home),
+            nanoclaw_xml_escape(project),
+            nanoclaw_xml_escape(project),
+        ),
+    )
+    .unwrap();
+}
+
+fn nanoclaw_xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
 }
 
 fn nanoclaw_test_sha1_slug(input: &[u8]) -> String {

--- a/crates/ctx-cli-contract-tests/tests/contracts/support/native_fixtures/default_installs.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/support/native_fixtures/default_installs.rs
@@ -6,7 +6,9 @@ use std::{
 };
 use tempfile::TempDir;
 
-use crate::support::{copy_dir_all, provider_history_fixture, write_codex_message_fixture};
+use crate::support::{
+    copy_dir_all, data_root, provider_history_fixture, write_codex_message_fixture,
+};
 
 use super::{
     install_default_astrbot_fixture, install_default_auggie_fixture,
@@ -46,7 +48,7 @@ pub(crate) fn install_provider_default_fixture(
         "open_code" => install_opencode(temp, user_text),
         "kilo" => install_kilo(temp, user_text),
         "mimocode" => install_mimocode(temp, user_text),
-        "kiro_cli" => install_default_kiro_fixture(temp, user_text),
+        "kiro_cli" => install_kiro(temp, user_text),
         "crush" => install_fixture_file("crush/v1/crush.db", &workspace.join(".crush/crush.db")),
         "goose" => install_fixture_file(
             "goose/v15/sessions.db",
@@ -96,6 +98,25 @@ pub(crate) fn install_provider_default_fixture(
         ),
         "fx" => install_fx(temp, user_text, assistant_text),
         other => panic!("missing default fixture installer for matrix provider {other}"),
+    }
+}
+
+fn install_kiro(temp: &TempDir, user_text: &str) {
+    let path = install_default_kiro_fixture(temp, user_text);
+    if cfg!(target_os = "windows") {
+        let config = data_root(temp).join("config.toml");
+        fs::create_dir_all(config.parent().unwrap()).unwrap();
+        let mut config = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(config)
+            .unwrap();
+        writeln!(
+            config,
+            "[sources.roots.kiro_windows_conformance]\nprovider = \"kiro_cli\"\npath = {:?}\n",
+            path.display().to_string(),
+        )
+        .unwrap();
     }
 }
 

--- a/crates/ctx-cli-contract-tests/tests/contracts/support/native_fixtures/installs.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/support/native_fixtures/installs.rs
@@ -67,11 +67,21 @@ pub(crate) fn install_default_mimocode_fixture(temp: &TempDir, query: &str) {
     write_mimocode_sqlite_fixture(&target.join("mimocode.db"), query, "mimocode-default");
 }
 
-pub(crate) fn install_default_kiro_fixture(temp: &TempDir, query: &str) {
+pub(crate) fn install_default_kiro_fixture(temp: &TempDir, query: &str) -> PathBuf {
     let source = PathBuf::from(write_native_kiro_fixture(temp, query));
-    let target = temp.path().join(".local/share/kiro-cli");
-    fs::create_dir_all(&target).unwrap();
-    fs::copy(source, target.join("data.sqlite3")).unwrap();
+    let target = if cfg!(target_os = "linux") {
+        temp.path().join(".local/share/kiro-cli/data.sqlite3")
+    } else if cfg!(target_os = "macos") {
+        temp.path()
+            .join("Library/Application Support/kiro-cli/data.sqlite3")
+    } else {
+        // Kiro has no released automatic legacy default on Windows. Keep an
+        // exact-path fixture for tests that explicitly exercise support.
+        temp.path().join("exact/kiro-cli/data.sqlite3")
+    };
+    fs::create_dir_all(target.parent().unwrap()).unwrap();
+    fs::copy(source, &target).unwrap();
+    target
 }
 
 pub(crate) fn install_default_astrbot_fixture(temp: &TempDir, query: &str) {

--- a/crates/ctx-cli-contract-tests/tests/contracts/support/runner.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/support/runner.rs
@@ -133,6 +133,7 @@ pub(crate) fn apply_hermetic_env(command: &mut Command, temp: &TempDir) {
     command.env_remove("ASTRBOT_ROOT");
     command.env_remove("SHELLEY_DB");
     command.env_remove("KILO_DB");
+    command.env_remove("KIRO_HOME");
     command.env_remove("MIMOCODE_HOME");
     command.env_remove("MIMOCODE_CONFIG_DIR");
     command.env_remove("MIMOCODE_DB");
@@ -188,7 +189,6 @@ pub(crate) fn apply_hermetic_env(command: &mut Command, temp: &TempDir) {
             "GOOSE_PATH_ROOT",
             "JUNIE_HOME",
             "KIMI_CODE_HOME",
-            "KIRO_HOME",
             "MUX_ROOT",
             "OH_PERSISTENCE_DIR",
             "OPENCLAW_HOME",

--- a/crates/ctx-daemon-application/src/lifecycle.rs
+++ b/crates/ctx-daemon-application/src/lifecycle.rs
@@ -105,6 +105,13 @@ struct DaemonOwnerIdentity {
     binary_sha256: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DaemonOwnerWaitOutcome {
+    Owner(DaemonOwnerIdentity),
+    Released,
+    StillActiveWithoutStableOwner,
+}
+
 enum DaemonAutostartRequest {
     Suppressed(&'static str),
     Existing(DaemonOwnerIdentity),
@@ -254,6 +261,40 @@ fn wait_for_daemon_owner_identity(data_root: &Path) -> Result<Option<DaemonOwner
     }
 }
 
+fn classify_daemon_owner_wait_with(
+    wait_for_owner: impl FnOnce() -> Result<Option<DaemonOwnerIdentity>>,
+    lock_is_active: impl FnOnce() -> bool,
+) -> Result<DaemonOwnerWaitOutcome> {
+    Ok(match wait_for_owner()? {
+        Some(owner) => DaemonOwnerWaitOutcome::Owner(owner),
+        None if lock_is_active() => DaemonOwnerWaitOutcome::StillActiveWithoutStableOwner,
+        None => DaemonOwnerWaitOutcome::Released,
+    })
+}
+
+fn classify_daemon_owner_wait(data_root: &Path) -> Result<DaemonOwnerWaitOutcome> {
+    classify_daemon_owner_wait_with(
+        || wait_for_daemon_owner_identity(data_root),
+        || daemon_lock_is_active(data_root),
+    )
+}
+
+fn existing_daemon_request_after_owner_wait(
+    outcome: DaemonOwnerWaitOutcome,
+) -> Result<Option<DaemonAutostartRequest>> {
+    match outcome {
+        DaemonOwnerWaitOutcome::Owner(owner) => Ok(Some(DaemonAutostartRequest::Existing(owner))),
+        DaemonOwnerWaitOutcome::Released => Ok(None),
+        DaemonOwnerWaitOutcome::StillActiveWithoutStableOwner => {
+            Err(ActiveDaemonOwnerIdentityError.into())
+        }
+    }
+}
+
+fn existing_daemon_request(data_root: &Path) -> Result<Option<DaemonAutostartRequest>> {
+    existing_daemon_request_after_owner_wait(classify_daemon_owner_wait(data_root)?)
+}
+
 fn recover_unusable_daemon_owner(
     host: &dyn DaemonApplicationHost,
     data_root: &Path,
@@ -334,22 +375,19 @@ fn request_daemon_autostart(
     {
         let executable = daemon_autostart_exe()?;
         if daemon_lock_matches_executable(data_root, &executable)? {
-            return Ok(DaemonAutostartRequest::Existing(
-                wait_for_daemon_owner_identity(data_root)?.ok_or_else(|| {
-                    anyhow!("active ctx daemon lock has no stable owner identity")
-                })?,
-            ));
-        }
-        if daemon_autostart_suppression_reason().is_some() {
-            return Err(binary_identity_handoff_error());
-        }
-        handoff_mismatched_daemon_owner(host, data_root, &executable)?;
-        if daemon_lock_is_active(data_root) {
-            return Ok(DaemonAutostartRequest::Existing(
-                wait_for_daemon_owner_identity(data_root)?.ok_or_else(|| {
-                    anyhow!("active replacement ctx daemon has no stable owner identity")
-                })?,
-            ));
+            if let Some(existing) = existing_daemon_request(data_root)? {
+                return Ok(existing);
+            }
+        } else {
+            if daemon_autostart_suppression_reason().is_some() {
+                return Err(binary_identity_handoff_error());
+            }
+            handoff_mismatched_daemon_owner(host, data_root, &executable)?;
+            if daemon_lock_is_active(data_root) {
+                if let Some(existing) = existing_daemon_request(data_root)? {
+                    return Ok(existing);
+                }
+            }
         }
     }
     if let Some(reason) = daemon_autostart_suppression_reason() {
@@ -374,11 +412,9 @@ fn request_daemon_autostart(
         let executable = daemon_autostart_exe()?;
         handoff_mismatched_daemon_owner(host, data_root, &executable)?;
         if daemon_lock_is_active(data_root) {
-            return Ok(DaemonAutostartRequest::Existing(
-                wait_for_daemon_owner_identity(data_root)?.ok_or_else(|| {
-                    anyhow!("active replacement ctx daemon has no stable owner identity")
-                })?,
-            ));
+            if let Some(existing) = existing_daemon_request(data_root)? {
+                return Ok(existing);
+            }
         }
     }
     let exe = match daemon_autostart_exe() {
@@ -733,6 +769,17 @@ impl fmt::Display for BinaryIdentityHandoffError {
 }
 
 impl std::error::Error for BinaryIdentityHandoffError {}
+
+#[derive(Debug)]
+struct ActiveDaemonOwnerIdentityError;
+
+impl fmt::Display for ActiveDaemonOwnerIdentityError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("active ctx daemon lock has no stable owner identity")
+    }
+}
+
+impl std::error::Error for ActiveDaemonOwnerIdentityError {}
 
 fn daemon_handoff_observation(
     host: &dyn DaemonApplicationHost,

--- a/crates/ctx-daemon-application/src/lifecycle/tests.rs
+++ b/crates/ctx-daemon-application/src/lifecycle/tests.rs
@@ -639,6 +639,78 @@ fn owner_replacement_during_probe_rejects_readiness() {
 }
 
 #[test]
+fn owner_wait_rechecks_the_lock_after_a_finite_owner_retires() -> Result<()> {
+    let events = RefCell::new(Vec::new());
+    let outcome = classify_daemon_owner_wait_with(
+        || {
+            events.borrow_mut().push("owner_wait");
+            Ok(None)
+        },
+        || {
+            events.borrow_mut().push("lock_recheck");
+            false
+        },
+    )?;
+
+    assert_eq!(outcome, DaemonOwnerWaitOutcome::Released);
+    assert_eq!(events.borrow().as_slice(), &["owner_wait", "lock_recheck"]);
+    assert!(existing_daemon_request_after_owner_wait(outcome)?.is_none());
+    Ok(())
+}
+
+#[test]
+fn owner_wait_retains_a_typed_error_while_the_lock_remains_active() -> Result<()> {
+    let events = RefCell::new(Vec::new());
+    let outcome = classify_daemon_owner_wait_with(
+        || {
+            events.borrow_mut().push("owner_wait");
+            Ok(None)
+        },
+        || {
+            events.borrow_mut().push("lock_recheck");
+            true
+        },
+    )?;
+
+    assert_eq!(
+        outcome,
+        DaemonOwnerWaitOutcome::StillActiveWithoutStableOwner
+    );
+    assert_eq!(events.borrow().as_slice(), &["owner_wait", "lock_recheck"]);
+    let error = match existing_daemon_request_after_owner_wait(outcome) {
+        Ok(_) => panic!("an active unstable owner unexpectedly permitted startup"),
+        Err(error) => error,
+    };
+    assert!(error.is::<ActiveDaemonOwnerIdentityError>());
+    assert_eq!(
+        error.to_string(),
+        "active ctx daemon lock has no stable owner identity"
+    );
+    Ok(())
+}
+
+#[test]
+fn owner_wait_uses_a_stable_owner_without_a_second_lock_classification() -> Result<()> {
+    let owner = test_daemon_owner("stable-wait-owner", 51);
+    let lock_rechecked = Cell::new(false);
+    let outcome = classify_daemon_owner_wait_with(
+        || Ok(Some(owner.clone())),
+        || {
+            lock_rechecked.set(true);
+            false
+        },
+    )?;
+
+    assert_eq!(outcome, DaemonOwnerWaitOutcome::Owner(owner.clone()));
+    assert!(!lock_rechecked.get());
+    match existing_daemon_request_after_owner_wait(outcome)? {
+        Some(DaemonAutostartRequest::Existing(observed)) => assert_eq!(observed, owner),
+        _ => panic!("stable owner was not reused"),
+    }
+    Ok(())
+}
+
+#[test]
 fn identity_stable_starting_endpoint_reports_progress_without_readiness() {
     let owner = test_daemon_owner("starting-owner", 46);
     let expected = test_config();

--- a/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle/lifecycle_regressions.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle/lifecycle_regressions.rs
@@ -164,6 +164,7 @@ fn active_daemon_work_exits_within_the_process_signal_deadline() {
         let _ = refresh_wait.kill();
         let _ = refresh_wait.wait_with_output();
         marker_result.unwrap_or_else(|error| panic!("{error}"));
+        assert_eq!(snapshot_file(&pointer_path), retained_pointer);
 
         let signaled_at = Instant::now();
         request_shutdown(pid, signal)

--- a/crates/ctx-daemon-service/src/daemon.rs
+++ b/crates/ctx-daemon-service/src/daemon.rs
@@ -482,9 +482,6 @@ where
                 ports.installation,
                 !finite_core_worker,
             )?;
-        if lifecycle_ready {
-            ctx_daemon_runtime::block_daemon_main_after_ready_for_test(data_root)?;
-        }
         // The ready persistent daemon is the automatic-check driver; foreground commands never are.
         if lifecycle_ready
             && !finite_core_worker
@@ -637,9 +634,6 @@ where
             let source_refresh = refresh_service
                 .as_ref()
                 .and(daemon_scheduler_source_refresh(&source_refresh_coordinator));
-            if source_refresh.is_some_and(CoreRefreshEngine::has_pending_request) {
-                ctx_daemon_runtime::block_daemon_main_after_ready_for_test(data_root)?;
-            }
             if finite_core_worker_exit.as_mut().is_some_and(|exit| {
                 exit.begin_stopping(
                     source_refresh,
@@ -650,6 +644,7 @@ where
             }) {
                 break;
             }
+            ctx_daemon_runtime::block_daemon_main_after_ready_for_test(data_root)?;
             let mut iteration = run_daemon_scheduler_cycle_with_activity(
                 &args,
                 data_root,

--- a/crates/ctx-history-source-discovery/src/provider_sources/resolvers/platform_tests.rs
+++ b/crates/ctx-history-source-discovery/src/provider_sources/resolvers/platform_tests.rs
@@ -149,6 +149,63 @@ fn kiro_legacy_selection_is_os_gated_and_xdg_is_replacement() {
 }
 
 #[test]
+fn kiro_default_fixture_matrix_matches_released_platform_locations() {
+    for platform in [
+        DiscoveryPlatform::Linux,
+        DiscoveryPlatform::MacOS,
+        DiscoveryPlatform::Windows,
+        DiscoveryPlatform::OtherUnix,
+    ] {
+        let temp = tempdir();
+        let context = context(temp.path(), platform);
+        let current = context.home().join(".kiro/sessions");
+        let linux_legacy = context.home().join(".local/share/kiro-cli/data.sqlite3");
+        let macos_legacy = context
+            .home()
+            .join("Library/Application Support/kiro-cli/data.sqlite3");
+        fs::create_dir_all(&current).unwrap();
+        write_file(&linux_legacy, b"linux legacy");
+        write_file(&macos_legacy, b"macos legacy");
+
+        let report = provider_report(&context, CaptureProvider::KiroCli);
+        assert_eq!(report.issues, [], "{platform:?}");
+        if platform == DiscoveryPlatform::OtherUnix {
+            assert!(report.sources.is_empty(), "{platform:?}: {report:#?}");
+            continue;
+        }
+
+        let current_source = report
+            .sources
+            .iter()
+            .find(|source| source.path == current)
+            .unwrap_or_else(|| panic!("missing current Kiro route for {platform:?}: {report:#?}"));
+        assert_eq!(current_source.status, ProviderSourceStatus::Unsupported);
+        assert_eq!(
+            current_source.source_kind,
+            ProviderSourceKind::DetectionOnly
+        );
+
+        let available = report
+            .sources
+            .iter()
+            .filter(|source| source.status == ProviderSourceStatus::Available)
+            .collect::<Vec<_>>();
+        match platform {
+            DiscoveryPlatform::Linux => {
+                assert_eq!(available.len(), 1, "{report:#?}");
+                assert_eq!(available[0].path, linux_legacy);
+            }
+            DiscoveryPlatform::MacOS => {
+                assert_eq!(available.len(), 1, "{report:#?}");
+                assert_eq!(available[0].path, macos_legacy);
+            }
+            DiscoveryPlatform::Windows => assert!(available.is_empty(), "{report:#?}"),
+            DiscoveryPlatform::OtherUnix => unreachable!(),
+        }
+    }
+}
+
+#[test]
 fn kiro_relative_home_is_manual_and_does_not_fall_back() {
     let temp = tempdir();
     let context =

--- a/crates/ctx-history-source-discovery/src/provider_sources/resolvers/profile_project_tests.rs
+++ b/crates/ctx-history-source-discovery/src/provider_sources/resolvers/profile_project_tests.rs
@@ -236,6 +236,46 @@ fn nanoclaw_macos_launchd_registration_discovers_checkout() {
 }
 
 #[test]
+fn nanoclaw_platform_matrix_uses_only_authentic_service_authority() {
+    for platform in [
+        DiscoveryPlatform::Linux,
+        DiscoveryPlatform::MacOS,
+        DiscoveryPlatform::Windows,
+        DiscoveryPlatform::OtherUnix,
+    ] {
+        let temp = tempdir();
+        let home = temp.path().join("home");
+        let cwd = temp.path().join("exact-cwd");
+        let registered = temp.path().join("registered-project");
+        write_nanoclaw_project(&cwd);
+        write_nanoclaw_project(&registered);
+        write_nanoclaw_systemd_unit(&home, &registered);
+        write_nanoclaw_launchd_plist(&home, &registered);
+
+        let discovery =
+            DiscoveryContext::new(&home, &cwd, platform, DiscoveryPlatformDirs::default());
+        let report = report(&discovery, CaptureProvider::NanoClaw);
+        assert_eq!(report.issues, [], "{platform:?}");
+        let mut paths = report
+            .sources
+            .iter()
+            .map(|source| source.path.clone())
+            .collect::<Vec<_>>();
+        paths.sort();
+        let mut expected = if matches!(
+            platform,
+            DiscoveryPlatform::Linux | DiscoveryPlatform::MacOS
+        ) {
+            vec![cwd, registered]
+        } else {
+            Vec::new()
+        };
+        expected.sort();
+        assert_eq!(paths, expected, "{platform:?}");
+    }
+}
+
+#[test]
 fn nanoclaw_exact_cwd_coexists_with_distinct_registration_and_dedupes_itself() {
     let temp = tempdir();
     let home = temp.path().join("home");


### PR DESCRIPTION
## Summary

- isolate the daemon-backed USERPROFILE import fixture without changing production home or data-root authority
- retry lifecycle autostart when a finite owner releases the lock during handoff, while retaining the typed error for an active owner without stable identity
- use platform-authentic NanoClaw service and Kiro default fixtures across synthetic Linux, macOS, and Windows matrices, with Warp unchanged
- assert foreground import publication rather than scheduler-wide quiescence
- place the existing debug scheduler gate before the scheduler cycle for byte-exact forced-shutdown coverage

## Scope

This is a five-commit fix-forward replay on `a7f9da834f42eb6ebe44aa39d90ebdba098bed06` after #843. Four changes are test-only; the finite-owner handoff change is the bounded product fix. It adds no app-config source, production resolver broadening, Warp fixture change, or lockfile drift.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check a7f9da834f42eb6ebe44aa39d90ebdba098bed06..HEAD`
- all eight branch-owned regression selectors, uncached
- affected daemon/source-discovery unit targets: 4/4 passed uncached
- complete setup/import, persistent daemon lifecycle, native-provider, and provider-conformance targets passed uncached
- strict affected Bazel Clippy passed with `-Dwarnings`
- repository policy, test taxonomy, LOC, source-diff, rustfmt, and affected dependency-boundary checks: 9/9 passed uncached
- physical crate-size preflight passed; `ctx` is 17,627 / 21,000 lines on this post-#843 tree

The earlier frozen-base `ctx` crate-size result of 21,804 / 21,000 was inherited from that base and is cleared by #843's app-config split; this series does not reintroduce it. Synthetic all-platform fixture matrices and the Linux-host binaries are covered here; native macOS and Windows execution remains separate follow-up evidence.