### PR TITLE
release: allow Apple Security framework on macOS

### DIFF
--- a/scripts/check-release-binary-compat.sh
+++ b/scripts/check-release-binary-compat.sh
@@ -490,12 +490,13 @@ check_macos() {
   minimum="$(macho_min_version)"
   [[ -n "${minimum}" ]] || fail "missing macOS minimum version load command"
   version_le "${minimum}" 13.0 || fail "minimum macOS ${minimum} is newer than 13.0"
-  # Core ML support and the persistent daemon's FSEvents watcher are compiled
-  # into both macOS artifacts. CoreServices.framework is the exact native API
-  # dependency of that watcher. The C++ runtime is retained when a native
-  # linker records it, but Zig can correctly omit that unused load command
-  # after linking the same static esaxx object. Keep every other system-library
-  # entry exact so an accidental third-party dylib still fails.
+  # Core ML support, the locked platform TLS verifier, and the persistent
+  # daemon's FSEvents watcher are compiled into both macOS artifacts.
+  # CoreServices.framework and Security.framework are their exact native API
+  # dependencies. The C++ runtime is retained when a native linker records it,
+  # but Zig can correctly omit that unused load command after linking the same
+  # static esaxx object. Keep every other system-library entry exact so an
+  # accidental third-party dylib still fails.
   local expected_macos_dylibs expected_macos_dylibs_with_cxx actual_macos_dylibs
   expected_macos_dylibs="/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
 /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
@@ -505,6 +506,7 @@ check_macos() {
 /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
 /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
 /System/Library/Frameworks/Metal.framework/Versions/A/Metal
+/System/Library/Frameworks/Security.framework/Versions/A/Security
 /usr/lib/libSystem.B.dylib
 /usr/lib/libcharset.1.dylib
 /usr/lib/libiconv.2.dylib

--- a/scripts/tests/check-release-binary-compat-test.sh
+++ b/scripts/tests/check-release-binary-compat-test.sh
@@ -308,6 +308,9 @@ Load command 8
      name /System/Library/Frameworks/Metal.framework/Versions/A/Metal (offset 24)
 Load command 9
       cmd LC_LOAD_DYLIB
+     name /System/Library/Frameworks/Security.framework/Versions/A/Security (offset 24)
+Load command 10
+      cmd LC_LOAD_DYLIB
      name /usr/lib/libSystem.B.dylib (offset 24)
 Load command 11
       cmd LC_LOAD_DYLIB
@@ -419,8 +422,8 @@ sed '/NeededLibraries \[/a\  ld-linux-aarch64.so.1\
   libgcc_s.so.1' "${linux_arm64}" >"${linux_arm64_gnu_runtime}"
 expect_pass linux_arm64_optional_gnu_runtime run_check linux-aarch64 \
   "${linux_arm64_gnu_runtime}"
-expect_pass mac_arm64_frameworks run_check macos-arm64 "${mac_arm_readobj}" "${mac_objdump}"
-expect_pass mac_x64_frameworks run_check macos-x64 "${mac_x64_readobj}" "${mac_objdump}"
+expect_pass mac_arm64_security_framework run_check macos-arm64 "${mac_arm_readobj}" "${mac_objdump}"
+expect_pass mac_x64_security_framework run_check macos-x64 "${mac_x64_readobj}" "${mac_objdump}"
 expect_pass windows run_check windows-x64 "${windows}"
 expect_pass windows_declared_tool run_declared_windows_check "${windows}"
 expect_fail malformed run_check linux-x64 "${tmp}/empty"
@@ -582,14 +585,11 @@ sed 's#/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
   "${mac_objdump}" > "${bad_mac_framework_path}"
 expect_fail mac_arbitrary_framework_path run_check macos-arm64 "${mac_arm_readobj}" "${bad_mac_framework_path}"
 expect_fail mac_x64_arbitrary_framework_path run_check macos-x64 "${mac_x64_readobj}" "${bad_mac_framework_path}"
-unexpected_mac_security="${tmp}/unexpected-mac-security.txt"
-sed '/name \/usr\/lib\/libobjc.A.dylib/a\
-Load command 15\
-      cmd LC_LOAD_DYLIB\
-     name /System/Library/Frameworks/Security.framework/Versions/A/Security (offset 24)' \
-  "${mac_objdump}" > "${unexpected_mac_security}"
-expect_fail mac_unexpected_security_framework run_check macos-arm64 "${mac_arm_readobj}" "${unexpected_mac_security}"
-expect_fail mac_x64_unexpected_security_framework run_check macos-x64 "${mac_x64_readobj}" "${unexpected_mac_security}"
+bad_mac_security_sibling="${tmp}/bad-mac-security-sibling.txt"
+sed 's#/System/Library/Frameworks/Security.framework/Versions/A/Security#/System/Library/Frameworks/Security.framework/Versions/B/Security#' \
+  "${mac_objdump}" > "${bad_mac_security_sibling}"
+expect_fail mac_security_sibling run_check macos-arm64 "${mac_arm_readobj}" "${bad_mac_security_sibling}"
+expect_fail mac_x64_security_sibling run_check macos-x64 "${mac_x64_readobj}" "${bad_mac_security_sibling}"
 missing_mac_core_services="${tmp}/missing-mac-core-services.txt"
 sed '/CoreServices.framework\/Versions\/A\/CoreServices/d' "${mac_objdump}" > "${missing_mac_core_services}"
 expect_fail mac_missing_core_services_framework run_check macos-arm64 "${mac_arm_readobj}" "${missing_mac_core_services}"


### PR DESCRIPTION
## Summary

- allow the exact Apple system Security framework in the macOS release-binary compatibility contract
- keep the Mach-O dylib inventory exact for both macOS architectures
- reject an adjacent unapproved Security framework version and retain all existing third-party, RPATH, architecture, and minimum-OS checks

## Root cause

The locked macOS platform TLS verifier now links `/System/Library/Frameworks/Security.framework/Versions/A/Security`, while the release allowlist still described the 1.2.4 dependency set. The v1.3 candidate was correct; the compatibility baseline was stale.

## Validation

- `//:release_binary_compat_tests`
- `//:loc_check`
- `//:repository_policy_check`
- shell syntax and diff checks
