### PR TITLE
test(daemon): consolidate throttling fixtures

### DIFF
--- a/crates/ctx-daemon-service/src/daemon/config_reload/tests.rs
+++ b/crates/ctx-daemon-service/src/daemon/config_reload/tests.rs
@@ -91,6 +91,19 @@ fn semantic_config(executor: SemanticEmbeddingExecutorConfig) -> DaemonConfigSna
     }
 }
 
+fn assert_builtin_throttling_status(status: &Value, configured: bool, effective: Option<bool>) {
+    for binding in ["requested", "applied"] {
+        assert_eq!(
+            status[binding]["semantic_builtin_throttling_configured"],
+            configured
+        );
+        assert_eq!(
+            status[binding]["semantic_builtin_throttling_effective"],
+            json!(effective)
+        );
+    }
+}
+
 fn http_executor(
     endpoint: &str,
     space_id: &str,
@@ -515,22 +528,7 @@ fn successful_executor_switches_replace_runtime_and_query_service_including_buil
             status["applied"]["semantic_contract_fingerprint"],
             expected.contract().fingerprint()
         );
-        assert_eq!(
-            status["requested"]["semantic_builtin_throttling_configured"],
-            true
-        );
-        assert_eq!(
-            status["requested"]["semantic_builtin_throttling_effective"],
-            json!(expected.builtin_throttling())
-        );
-        assert_eq!(
-            status["applied"]["semantic_builtin_throttling_configured"],
-            true
-        );
-        assert_eq!(
-            status["applied"]["semantic_builtin_throttling_effective"],
-            json!(expected.builtin_throttling())
-        );
+        assert_builtin_throttling_status(&status, true, expected.builtin_throttling());
         assert!(old_executor.upgrade().is_none());
         assert!(context.runtime.sidecar_drain.generation.is_none());
         assert!(context
@@ -584,22 +582,7 @@ fn builtin_throttling_change_replaces_executor_and_updates_reload_identity() {
         Some(false)
     );
     let status = context.reload.to_json();
-    assert_eq!(
-        status["requested"]["semantic_builtin_throttling_configured"],
-        false
-    );
-    assert_eq!(
-        status["requested"]["semantic_builtin_throttling_effective"],
-        false
-    );
-    assert_eq!(
-        status["applied"]["semantic_builtin_throttling_configured"],
-        false
-    );
-    assert_eq!(
-        status["applied"]["semantic_builtin_throttling_effective"],
-        false
-    );
+    assert_builtin_throttling_status(&status, false, Some(false));
 }
 
 #[cfg(any(unix, windows))]

--- a/crates/ctx-daemon-service/src/daemon_worker_tests.rs
+++ b/crates/ctx-daemon-service/src/daemon_worker_tests.rs
@@ -1055,19 +1055,23 @@ fn core_builder_preserves_assistant_after_more_than_sixty_four_tool_events() {
     assert_eq!(document.occurred_at_ms(), (TOOL_EVENTS + 2) as i64);
 }
 
-#[test]
-fn daemon_lifecycle_receipt_preserves_service_trigger_metadata() -> anyhow::Result<()> {
-    let temp = tempfile::tempdir()?;
-    let args = DaemonRunArgs {
+fn lifecycle_args(trigger_command: crate::DaemonTrigger) -> DaemonRunArgs {
+    DaemonRunArgs {
         loop_interval_seconds: None,
         max_chunks: None,
         handle_process_signals: false,
         force: false,
         profile: crate::DaemonRunProfile::Persistent,
         start_mode: Some(crate::DaemonStartMode::Auto),
-        trigger_command: Some(crate::DaemonTrigger::Setup),
+        trigger_command: Some(trigger_command),
         supervisor: crate::DaemonSupervisor::User,
-    };
+    }
+}
+
+#[test]
+fn daemon_lifecycle_receipt_preserves_service_trigger_metadata() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let args = lifecycle_args(crate::DaemonTrigger::Setup);
 
     write_daemon_lifecycle_status(temp.path(), &args, "running", 123, None, None)?;
     let status = crate::paths_status::read_daemon_status(temp.path()).expect("daemon status");
@@ -1080,16 +1084,7 @@ fn daemon_lifecycle_receipt_preserves_service_trigger_metadata() -> anyhow::Resu
 #[test]
 fn daemon_lifecycle_receipt_preserves_not_applicable_builtin_throttling() -> anyhow::Result<()> {
     let temp = tempfile::tempdir()?;
-    let args = DaemonRunArgs {
-        loop_interval_seconds: None,
-        max_chunks: None,
-        handle_process_signals: false,
-        force: false,
-        profile: crate::DaemonRunProfile::Persistent,
-        start_mode: Some(crate::DaemonStartMode::Auto),
-        trigger_command: Some(crate::DaemonTrigger::Search),
-        supervisor: crate::DaemonSupervisor::User,
-    };
+    let args = lifecycle_args(crate::DaemonTrigger::Search);
     let reload = json!({
         "status": "activation_failed",
         "requested": {
@@ -1114,14 +1109,12 @@ fn daemon_lifecycle_receipt_preserves_not_applicable_builtin_throttling() -> any
     )?;
 
     let status = crate::paths_status::read_daemon_status(temp.path()).expect("daemon status");
-    assert_eq!(
-        status["config_reload"]["requested"]["semantic_builtin_throttling_effective"],
-        Value::Null
-    );
-    assert_eq!(
-        status["config_reload"]["applied"]["semantic_builtin_throttling_effective"],
-        Value::Null
-    );
+    for binding in ["requested", "applied"] {
+        assert_eq!(
+            status["config_reload"][binding]["semantic_builtin_throttling_effective"],
+            Value::Null
+        );
+    }
     assert!(status["config_reload"]["applied"]
         .get("semantic_builtin_throttling_configured")
         .is_none());

--- a/crates/ctx-daemon-service/src/semantic_completion/tests.rs
+++ b/crates/ctx-daemon-service/src/semantic_completion/tests.rs
@@ -3,23 +3,14 @@ use serde_json::json;
 use super::*;
 
 fn target() -> DaemonSemanticCompletionTarget {
-    DaemonSemanticCompletionTarget::new(
-        "generation-1",
-        "sha256:model",
-        "sha256:source",
-        DaemonSemanticConfigBinding::new(
-            true,
-            "full",
-            true,
-            "https://semantic.example.test/",
-            "sha256:model",
-            true,
-            None,
-        ),
-    )
+    target_with_throttling("https://semantic.example.test/", true, None)
 }
 
-fn unthrottled_builtin_target() -> DaemonSemanticCompletionTarget {
+fn target_with_throttling(
+    executor: &str,
+    configured: bool,
+    effective: Option<bool>,
+) -> DaemonSemanticCompletionTarget {
     DaemonSemanticCompletionTarget::new(
         "generation-1",
         "sha256:model",
@@ -28,66 +19,50 @@ fn unthrottled_builtin_target() -> DaemonSemanticCompletionTarget {
             true,
             "full",
             true,
-            "builtin",
+            executor,
             "sha256:model",
-            false,
-            Some(false),
+            configured,
+            effective,
         ),
     )
 }
 
 fn status(reload_status: &str, requested_executor: &str, applied_executor: &str) -> Value {
+    status_with_throttling(
+        reload_status,
+        requested_executor,
+        applied_executor,
+        true,
+        None,
+    )
+}
+
+fn status_with_throttling(
+    reload_status: &str,
+    requested_executor: &str,
+    applied_executor: &str,
+    configured: bool,
+    effective: Option<bool>,
+) -> Value {
+    let binding = |executor| {
+        json!({
+            "daemon_enabled": true,
+            "daemon_mode": "full",
+            "semantic_enabled": true,
+            "semantic_executor": executor,
+            "semantic_contract_fingerprint": "sha256:model",
+            "semantic_builtin_throttling_configured": configured,
+            "semantic_builtin_throttling_effective": effective,
+        })
+    };
     json!({
         "status": "running",
         "config_reload": {
             "status": reload_status,
             "last_attempt_at_ms": 100,
             "last_applied_at_ms": 90,
-            "requested": {
-                "daemon_enabled": true,
-                "daemon_mode": "full",
-                "semantic_enabled": true,
-                "semantic_executor": requested_executor,
-                "semantic_contract_fingerprint": "sha256:model",
-                "semantic_builtin_throttling_configured": true,
-                "semantic_builtin_throttling_effective": null,
-            },
-            "applied": {
-                "daemon_enabled": true,
-                "daemon_mode": "full",
-                "semantic_enabled": true,
-                "semantic_executor": applied_executor,
-                "semantic_contract_fingerprint": "sha256:model",
-                "semantic_builtin_throttling_configured": true,
-                "semantic_builtin_throttling_effective": null,
-            },
-        },
-    })
-}
-
-fn unthrottled_builtin_status() -> Value {
-    json!({
-        "status": "running",
-        "config_reload": {
-            "status": "applied",
-            "requested": {
-                "daemon_enabled": true,
-                "daemon_mode": "full",
-                "semantic_enabled": true,
-                "semantic_executor": "builtin",
-                "semantic_contract_fingerprint": "sha256:model",
-                "semantic_builtin_throttling_configured": false,
-                "semantic_builtin_throttling_effective": false,
-            },
-            "applied": {
-                "daemon_enabled": true,
-                "daemon_mode": "full",
-                "semantic_enabled": true,
-                "semantic_executor": "builtin",
-                "semantic_contract_fingerprint": "sha256:model",
-                "semantic_builtin_throttling_configured": false,
-                "semantic_builtin_throttling_effective": false,
-            },
+            "requested": binding(requested_executor),
+            "applied": binding(applied_executor),
         },
     })
 }
@@ -144,8 +119,8 @@ fn ready_requires_exact_requested_applied_and_job_bindings() {
 
 #[test]
 fn ready_requires_exact_unthrottled_builtin_requested_and_applied_identity() {
-    let target = unthrottled_builtin_target();
-    let exact = unthrottled_builtin_status();
+    let target = target_with_throttling("builtin", false, Some(false));
+    let exact = status_with_throttling("applied", "builtin", "builtin", false, Some(false));
     assert_eq!(
         classify_exact_daemon_semantic_completion(&exact, Some(&job("ready")), &target),
         DaemonSemanticCompletionObservation::Ready


### PR DESCRIPTION
## Summary

- consolidate duplicated semantic throttling test fixtures and assertions
- preserve every requested/applied, null, false, and executor identity check
- restore the ctx-daemon-service physical Rust size margin without changing production code or raising the gate

## Validation

- exact crate-size gate: 20,969 / 21,000 CLOC
- ctx-daemon-service: 230 tests passed
- strict Clippy and formatting
- repository policy, LOC, and diff checks

This is a behavior-neutral release-source follow-up to #781.