### PR TITLE
release: allow Windows native trust DLL

### DIFF
--- a/scripts/check-release-binary-compat.sh
+++ b/scripts/check-release-binary-compat.sh
@@ -572,6 +572,8 @@ check_windows() {
   version_le "${os_version}" 10.0 || fail "Windows header OS version ${os_version} is newer than 10.0"
   version_le "${subsystem_version}" 10.0 || fail "Windows subsystem version ${subsystem_version} is newer than 10.0"
 
+  # The locked platform TLS verifier uses the native Windows certificate store,
+  # which imports crypt32.dll. Keep every DLL exact so unrelated imports fail.
   assert_exact_lines "PE imported DLLs" "$(pe_imports)" "advapi32.dll
 api-ms-win-crt-environment-l1-1-0.dll
 api-ms-win-crt-heap-l1-1-0.dll
@@ -585,6 +587,7 @@ api-ms-win-crt-utility-l1-1-0.dll
 api-ms-win-core-synch-l1-2-0.dll
 bcrypt.dll
 bcryptprimitives.dll
+crypt32.dll
 kernel32.dll
 ntdll.dll
 ole32.dll

--- a/scripts/tests/check-release-binary-compat-test.sh
+++ b/scripts/tests/check-release-binary-compat-test.sh
@@ -387,6 +387,9 @@ Import {
   Name: bcryptprimitives.dll
 }
 Import {
+  Name: crypt32.dll
+}
+Import {
   Name: KERNEL32.dll
 }
 Import {
@@ -424,7 +427,7 @@ expect_pass linux_arm64_optional_gnu_runtime run_check linux-aarch64 \
   "${linux_arm64_gnu_runtime}"
 expect_pass mac_arm64_security_framework run_check macos-arm64 "${mac_arm_readobj}" "${mac_objdump}"
 expect_pass mac_x64_security_framework run_check macos-x64 "${mac_x64_readobj}" "${mac_objdump}"
-expect_pass windows run_check windows-x64 "${windows}"
+expect_pass windows_native_trust_store run_check windows-x64 "${windows}"
 expect_pass windows_declared_tool run_declared_windows_check "${windows}"
 expect_fail malformed run_check linux-x64 "${tmp}/empty"
 grep -Fq "scanner-inputs=llvm-readobj=${tmp}/llvm-readobj" \
@@ -655,6 +658,7 @@ mutate_and_fail windows_subsystem windows-x64 "${windows}" 's/IMAGE_SUBSYSTEM_WI
 mutate_and_fail windows_version windows-x64 "${windows}" 's/MajorOperatingSystemVersion: 10/MajorOperatingSystemVersion: 11/'
 mutate_and_fail windows_subsystem_version windows-x64 "${windows}" 's/MajorSubsystemVersion: 6/MajorSubsystemVersion: 11/'
 mutate_and_fail windows_missing_restart_manager windows-x64 "${windows}" '/Name: rstrtmgr.dll/d'
+mutate_and_fail windows_crypt32_sibling windows-x64 "${windows}" 's/crypt32.dll/cryptnet.dll/'
 mutate_and_fail windows_dll windows-x64 "${windows}" 's/ws2_32.dll/winhttp.dll/'
 mutate_and_fail windows_static_symbols windows-x64 "${windows}" 's/Import {/Symbols [\n  Symbol {\n    Name: main (1)\n  }\n]\nImport {/'
 # The no-Buildkite local runner validates published bytes through this public


### PR DESCRIPTION
## Summary

- allow the exact Windows system crypt32.dll import in the release-binary compatibility contract
- keep the PE DLL inventory exact
- reject the adjacent cryptnet.dll sibling and retain all existing architecture, mitigation, signature, scanner, subsystem, version, and symbol checks

## Root cause

The locked platform TLS verifier uses the native Windows certificate store and imports crypt32.dll. The v1.3 candidate matched that dependency graph; the compatibility baseline was stale.

## Validation

- exact Windows Cargo dependency and feature-tree proof
- //:release_binary_compat_tests
- //:loc_check
- //:repository_policy_check
- shell syntax and diff checks

This is the Windows counterpart to #848.