### PR TITLE
test(search): match semantic generation fallback

### DIFF
--- a/crates/ctx-history-read-application/tests/contracts/search_show.rs
+++ b/crates/ctx-history-read-application/tests/contracts/search_show.rs
@@ -850,7 +850,7 @@ fn search_backend_defaults_and_supported_semantic_config_are_reported() {
     assert_eq!(supported_hybrid["retrieval"]["effective_mode"], "lexical");
     assert_eq!(
         supported_hybrid["retrieval"]["semantic_fallback_code"],
-        "semantic_store_missing"
+        "semantic_generation_not_acknowledged"
     );
 
     let missing_index_strict_semantic = ctx(&temp)


### PR DESCRIPTION
## Summary

- update the hybrid-search release oracle for #821's exact semantic generation state
- keep the product behavior unchanged: the fallback remains lexical and reports the more precise unacknowledged-generation code

## Validation

- `//crates/ctx-history-read-application:search_show_tests` (36 cases)
- repository/LOC policy
- `git diff --check`
- exact public #141 release qualification isolated this as the only observed assertion failure so far