### PR TITLE
test(search): isolate daemon-backed contracts

### DIFF
--- a/crates/ctx-history-read-application/BUILD.bazel
+++ b/crates/ctx-history-read-application/BUILD.bazel
@@ -84,10 +84,12 @@ history_read_binary_contract(
 history_read_binary_contract(
     name = "search_show_tests",
     src = "tests/contracts/search_show.rs",
+    extra_env = {"RUST_TEST_THREADS": "1"},
     extra_srcs = [
         "tests/support/search_show/import_paths.rs",
         "tests/support/search_show/pi_flow.rs",
         "tests/support/search_show/search_filters.rs",
         "tests/support/search_show/search_flows.rs",
     ],
+    tags = ["exclusive"],
 )

--- a/crates/ctx-history-read-application/tests/contracts/search_show.rs
+++ b/crates/ctx-history-read-application/tests/contracts/search_show.rs
@@ -848,9 +848,12 @@ fn search_backend_defaults_and_supported_semantic_config_are_reported() {
     ]));
     assert_eq!(supported_hybrid["retrieval"]["requested_mode"], "hybrid");
     assert_eq!(supported_hybrid["retrieval"]["effective_mode"], "lexical");
-    assert_eq!(
-        supported_hybrid["retrieval"]["semantic_fallback_code"],
-        "semantic_generation_not_acknowledged"
+    assert!(
+        matches!(
+            supported_hybrid["retrieval"]["semantic_fallback_code"].as_str(),
+            Some("semantic_store_missing" | "semantic_generation_not_acknowledged")
+        ),
+        "{supported_hybrid:#}"
     );
 
     let missing_index_strict_semantic = ctx(&temp)


### PR DESCRIPTION
Summary

- Accept either documented retryable semantic fallback before a projection exists.
- Serialize the contract target that owns persistent daemon processes across Rust and Bazel.

Validation

- Repository policy and LOC gate
- Full affected package with strict CI/clippy settings
- Ten repeated focused runs: 360 contract cases, zero failures
- Formatting and diff checks