### PR TITLE
fix(release): stage exact qualified evidence

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,6 +158,7 @@ steps:
     artifact_paths:
       - "target/public-cli-native-smoke/macos-arm64/candidate-smoke.json"
       - "target/public-cli-native-smoke/macos-arm64/ctx-macos-arm64.native-execution.json"
+      - "target/public-cli-native-smoke/macos-arm64/ctx-macos-arm64.signing.json"
 
   - label: ":test_tube: public CLI macos-x64 exact-byte validation"
     key: "public-cli-macos-x64-native-smoke"
@@ -178,6 +179,7 @@ steps:
     artifact_paths:
       - "target/public-cli-native-smoke/macos-x64/candidate-smoke.json"
       - "target/public-cli-native-smoke/macos-x64/ctx-macos-x64.native-execution.json"
+      - "target/public-cli-native-smoke/macos-x64/ctx-macos-x64.signing.json"
 
   - label: ":package: Semantic macos-x64 runtime"
     key: "public-cli-macos-x64-runtime-producer"
@@ -237,6 +239,12 @@ steps:
       buildkite-agent artifact download "target/public-cli-native-smoke/macos-arm64/ctx-macos-arm64.native-execution.json" . --step public-cli-macos-arm64-native-smoke
       buildkite-agent artifact download "target/public-cli-native-smoke/macos-x64/ctx-macos-x64.native-execution.json" . --step public-cli-macos-x64-native-smoke
       buildkite-agent artifact download "target/public-cli-native-smoke/windows-x64/ctx-windows-x64.native-execution.json" . --step public-cli-windows-x64-native-smoke
+      BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS=false buildkite-agent artifact download \
+        "target/public-cli-native-smoke/macos-arm64/ctx-macos-arm64.signing.json" . \
+        --step public-cli-macos-arm64-native-smoke
+      BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS=false buildkite-agent artifact download \
+        "target/public-cli-native-smoke/macos-x64/ctx-macos-x64.signing.json" . \
+        --step public-cli-macos-x64-native-smoke
       CTX_PUBLIC_RELEASE_SOURCE_COMMIT="$${source_commit}" \
         scripts/stage-github-release-assets.sh \
           target/public-cli-artifacts \

--- a/scripts/check-buildkite-pipeline.sh
+++ b/scripts/check-buildkite-pipeline.sh
@@ -283,11 +283,16 @@ for key, (platform, queue, os_name, arch) in native.items():
             fail(f"{key} must not consume semantic model/runtime input ({marker})")
     if re.search(r"cargo (?:build|zigbuild)|bazelw run //:ctx_release", command):
         fail(f"{key} must never rebuild the candidate")
-    if step.get("artifact_paths") != [
+    expected_artifacts = [
         f"target/public-cli-native-smoke/{platform}/candidate-smoke.json",
         f"target/public-cli-native-smoke/{platform}/ctx-{platform}.native-execution.json",
-    ]:
-        fail(f"{key} must upload only its exact Core validation evidence")
+    ]
+    if platform.startswith("macos-"):
+        expected_artifacts.append(
+            f"target/public-cli-native-smoke/{platform}/ctx-{platform}.signing.json"
+        )
+    if step.get("artifact_paths") != expected_artifacts:
+        fail(f"{key} must upload its exact Core validation evidence")
 
     output = f"target/public-cli-native-smoke/{platform}"
     mutated = command.replace(
@@ -341,6 +346,22 @@ for proof in native.values():
     platform = proof[0]
     if f"ctx-{platform}.native-execution.json" not in candidate_command:
         fail(f"Core candidate staging must consume native {platform} proof")
+logical_candidate_command = "\n".join(
+    " ".join(line.split())
+    for line in re.sub(r"\\\n[ \t]*", " ", candidate_command).splitlines()
+)
+for platform in ("macos-arm64", "macos-x64"):
+    expected_signing_download = (
+        "BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS=false "
+        "buildkite-agent artifact download "
+        f'"target/public-cli-native-smoke/{platform}/ctx-{platform}.signing.json" . '
+        f"--step public-cli-{platform}-native-smoke"
+    )
+    if logical_candidate_command.count(expected_signing_download) != 1:
+        fail(
+            "Core candidate staging must consume the exact native-passed "
+            f"{platform} signing evidence"
+        )
 
 semantic_keys = {
     "public-cli-macos-x64-runtime-producer",

--- a/scripts/release-sbom.py
+++ b/scripts/release-sbom.py
@@ -682,10 +682,10 @@ def verify_bundle_only(
     ):
         raise ValueError("candidate manifest does not bind its exact build-info")
     evidence_paths = {
-        "binary_size_report": args.size_report,
-        "build_info": args.build_info,
-        "cyclonedx_sbom": args.sbom,
-        "third_party_notices": args.notices,
+        "binary_size_report": (args.size_report, ".size.json"),
+        "build_info": (args.build_info, ".build-info.json"),
+        "cyclonedx_sbom": (args.sbom, ".cdx.json"),
+        "third_party_notices": (args.notices, ".third-party-notices.txt"),
     }
     evidence = candidate.get("evidence")
     if not isinstance(evidence, dict) or set(evidence) != CANDIDATE_EVIDENCE_FIELDS:
@@ -699,10 +699,13 @@ def verify_bundle_only(
             or HEX_64.fullmatch(str(record.get("sha256"))) is None
         ):
             raise ValueError(f"candidate manifest {name} evidence is malformed")
-    for name, path in evidence_paths.items():
+    for name, (path, suffix) in evidence_paths.items():
         record = evidence.get(name)
         payload = regular_bytes(path, name.replace("_", " "), 32 * 1024 * 1024)
-        if record != {"file": path.name, "sha256": sha256_bytes(payload)}:
+        if record != {
+            "file": f"{candidate_artifact_name}{suffix}",
+            "sha256": sha256_bytes(payload),
+        }:
             raise ValueError(f"candidate manifest does not bind {name}")
     size_report, _ = read_canonical_json(
         args.size_report, "binary size report", 256 * 1024

--- a/scripts/stage-github-release-assets.sh
+++ b/scripts/stage-github-release-assets.sh
@@ -309,7 +309,9 @@ stage_cli_evidence() {
 stage_macos_cli_verifier_inputs() {
   local source_name="$1"
   local dest_name="$2"
+  local platform="$3"
   local source_path="${artifact_dir%/}/${source_name}"
+  local native_signing_evidence="${native_proof_dir%/}/${platform}/${source_name}.signing.json"
   local suffix source destination source_digest destination_digest
 
   for suffix in \
@@ -319,7 +321,11 @@ stage_macos_cli_verifier_inputs() {
     .attestation.json \
     .attestation.cms \
     .notary-submit.json; do
-    source="${source_path}${suffix}"
+    if [[ "${suffix}" == .signing.json ]]; then
+      source="${native_signing_evidence}"
+    else
+      source="${source_path}${suffix}"
+    fi
     destination="${out_dir%/}/${dest_name}${suffix}"
     require_regular_input "${source}" "macOS CLI verifier input"
     [[ -s "${source}" ]] || {
@@ -410,7 +416,7 @@ validate_macos_cli_signing_evidence() (
   local platform="$1"
   local binary="${out_dir%/}/ctx-${platform}"
   local binary_checksum="${artifact_dir%/}/ctx-${platform}.sha256"
-  local cli_evidence="${artifact_dir%/}/ctx-${platform}.signing.json"
+  local cli_evidence="${out_dir%/}/ctx-${platform}.signing.json"
   local cli_attestation="${artifact_dir%/}/ctx-${platform}.attestation.json"
   local cli_attestation_cms="${artifact_dir%/}/ctx-${platform}.attestation.cms"
   local build_info="${artifact_dir%/}/ctx-${platform}.build-info.json"
@@ -484,10 +490,10 @@ stage_asset ctx-linux-aarch64 ctx-linux-aarch64
 stage_cli_evidence ctx-linux-aarch64 ctx-linux-aarch64
 stage_asset ctx-macos-arm64 ctx-macos-arm64
 stage_cli_evidence ctx-macos-arm64 ctx-macos-arm64
-stage_macos_cli_verifier_inputs ctx-macos-arm64 ctx-macos-arm64
+stage_macos_cli_verifier_inputs ctx-macos-arm64 ctx-macos-arm64 macos-arm64
 stage_asset ctx-macos-x64 ctx-macos-x64
 stage_cli_evidence ctx-macos-x64 ctx-macos-x64
-stage_macos_cli_verifier_inputs ctx-macos-x64 ctx-macos-x64
+stage_macos_cli_verifier_inputs ctx-macos-x64 ctx-macos-x64 macos-x64
 stage_asset ctx.exe ctx-windows-x64.exe
 stage_cli_evidence ctx.exe ctx-windows-x64.exe
 

--- a/scripts/tests/release-sbom-test.py
+++ b/scripts/tests/release-sbom-test.py
@@ -682,6 +682,12 @@ repository = "https://example.invalid/{name}"
         staged_artifact.write_bytes(self.artifact.read_bytes())
         self.artifact = staged_artifact
         self.assertNotEqual(self.run_command("verify-bundle", check=False).returncode, 0)
+        staged_sbom = self.root / "ctx-linux-x64.cdx.json"
+        staged_sbom.write_bytes(self.sbom.read_bytes())
+        self.sbom = staged_sbom
+        staged_notices = self.root / "ctx-linux-x64.third-party-notices.txt"
+        staged_notices.write_bytes(self.notices.read_bytes())
+        self.notices = staged_notices
         renamed = subprocess.run(
             self.command("verify-bundle") + ["--candidate-artifact-name", "ctx"],
             check=True,

--- a/scripts/tests/stage-github-release-assets-test.sh
+++ b/scripts/tests/stage-github-release-assets-test.sh
@@ -176,7 +176,8 @@ for binary in "${cli_sources[@]}"; do
     > "${matrix}/${binary}.dependency-advisory.json"
 done
 for platform in macos-arm64 macos-x64; do
-  printf '{}\n' > "${matrix}/ctx-${platform}.signing.json"
+  printf '{"origin":"factory-pending"}\n' \
+    > "${matrix}/ctx-${platform}.signing.json"
   printf '{}\n' > "${matrix}/ctx-${platform}.attestation.json"
   printf 'cms\n' > "${matrix}/ctx-${platform}.attestation.cms"
   printf '{}\n' > "${matrix}/ctx-${platform}.notary-submit.json"
@@ -195,6 +196,10 @@ for platform in linux-x64 linux-aarch64 macos-arm64 macos-x64 windows-x64; do
       --artifact "${matrix}/${binary}" \
       --smoke-result "${proof_root}/${platform}/candidate-smoke.json" \
       --output "${proof_root}/${platform}/ctx-${platform}.native-execution.json" >/dev/null
+  if [[ "${platform}" == macos-* ]]; then
+    printf '{"origin":"native-passed"}\n' \
+      > "${proof_root}/${platform}/ctx-${platform}.signing.json"
+  fi
 done
 export CTX_PUBLIC_NATIVE_PROOF_DIR="${proof_root}"
 
@@ -402,6 +407,12 @@ CTX_FAKE_SBOM_LOG="${default_sbom_log}" \
   PATH="${fake_bin}:${PATH}" \
   /bin/bash "${stage}" "${matrix}" "${default_output}"
 assert_exact_assets "${default_output}" 15 "${default_assets[@]}"
+for platform in macos-arm64 macos-x64; do
+  grep -Fq '"origin":"native-passed"' \
+    "${default_output}/ctx-${platform}.signing.json"
+  grep -Fq '"origin":"factory-pending"' \
+    "${matrix}/ctx-${platform}.signing.json"
+done
 default_authority="${default_output}.authority"
 test "$(find "${default_authority}" -maxdepth 1 -type f | wc -l)" -eq 20
 for candidate in \

--- a/scripts/validate-public-cli-factory-artifact.sh
+++ b/scripts/validate-public-cli-factory-artifact.sh
@@ -133,4 +133,11 @@ python3 -I scripts/native-execution-proof.py create \
   --artifact "${artifact}" \
   --smoke-result "${output_dir%/}/candidate-smoke.json" \
   --output "${output_dir%/}/ctx-${platform}.native-execution.json"
+if [[ "${platform}" == macos-* ]]; then
+  signing_evidence="${artifact_dir%/}/ctx-${platform}.signing.json"
+  [[ -f "${signing_evidence}" && ! -L "${signing_evidence}" ]] || \
+    die "passed macOS signing evidence is not a regular file"
+  install -m 0644 "${signing_evidence}" \
+    "${output_dir%/}/ctx-${platform}.signing.json"
+fi
 printf 'native exact-byte validation passed: %s sha256=%s\n' "${platform}" "${after}"


### PR DESCRIPTION
Summary

- Verify renamed GitHub SBOM and notice assets against their original candidate-manifest names and exact bytes.
- Export native-passed macOS signing evidence separately from the immutable factory bundle and consume only the current retry attempt.
- Keep pending signing evidence and mismatched candidate evidence fail-closed.

Validation

- Repository policy and LOC gate
- Buildkite pipeline contract, release SBOM, GitHub staging, and factory validator Bazel tests
- Exact public build #143 artifact replay through corrected staging
- Negative replay with pending macOS signing evidence