### PR TITLE
fix(semantic): prevent maintenance starvation

### DIFF
--- a/crates/ctx-daemon-service/src/daemon.rs
+++ b/crates/ctx-daemon-service/src/daemon.rs
@@ -52,8 +52,9 @@ mod watch_runtime;
 
 use automatic_upgrade::abort_prepared_automatic_upgrade;
 use config_reload::{
-    daemon_semantic_runtime_active, reload_daemon_runtime_config, DaemonConfigReloadContext,
-    DaemonConfigReloadOutcome, DaemonConfigReloadState,
+    daemon_semantic_runtime_active, daemon_semantic_runtime_requested,
+    reload_daemon_runtime_config, DaemonConfigReloadContext, DaemonConfigReloadOutcome,
+    DaemonConfigReloadState,
 };
 use lifecycle::*;
 pub(super) use source_watch::daemon_wait_duration;
@@ -68,8 +69,6 @@ use super::daemon_wakeup::DaemonFileWatcher;
 #[cfg(test)]
 use ctx_history_capture::SourceBackedWatchCatalog;
 
-#[cfg(test)]
-use config_reload::daemon_semantic_runtime_requested;
 #[cfg(test)]
 use telemetry::{
     daemon_liveness_interval, DAEMON_LIVENESS_JITTER_WINDOW, DAEMON_LIVENESS_MIN_INTERVAL,
@@ -100,6 +99,17 @@ impl DaemonIteration {
         self.provider_refresh_events = events;
         self
     }
+}
+
+fn daemon_semantic_maintenance_requested(
+    runtime: &DaemonRuntime,
+    reload: &DaemonConfigReloadState,
+) -> bool {
+    reload.status != "failed"
+        && daemon_semantic_runtime_requested(
+            &runtime.config,
+            super::query_service::daemon_query_service_transport_supported(),
+        )
 }
 
 #[derive(Default)]
@@ -629,8 +639,8 @@ where
             let events = telemetry.liveness_events(Instant::now());
             send_daemon_events(ports.observation, data_root, &events);
             let cycle_started = Instant::now();
-            let semantic_runtime_active =
-                daemon_semantic_runtime_active(&runtime, query_service.as_ref());
+            let semantic_maintenance_requested =
+                daemon_semantic_maintenance_requested(&runtime, &config_reload);
             let source_refresh = refresh_service
                 .as_ref()
                 .and(daemon_scheduler_source_refresh(&source_refresh_coordinator));
@@ -651,7 +661,7 @@ where
                 &mut runtime,
                 DaemonSchedulerCycleContext {
                     deadline: None,
-                    semantic_enabled: semantic_runtime_active,
+                    semantic_enabled: semantic_maintenance_requested,
                     query_activity: query_service
                         .as_ref()
                         .map(|service| service.activity.as_ref()),

--- a/crates/ctx-daemon-service/src/daemon/tests.rs
+++ b/crates/ctx-daemon-service/src/daemon/tests.rs
@@ -1,6 +1,8 @@
 #[path = "semantic_activation_backoff_tests.rs"]
 mod semantic_activation_backoff;
 
+#[path = "tests/semantic_maintenance.rs"]
+mod semantic_maintenance;
 #[path = "tests/startup_recovery.rs"]
 mod startup_recovery;
 

--- a/crates/ctx-daemon-service/src/daemon/tests/semantic_maintenance.rs
+++ b/crates/ctx-daemon-service/src/daemon/tests/semantic_maintenance.rs
@@ -1,0 +1,156 @@
+use anyhow::{anyhow, Result};
+use ctx_history_core::{
+    derive_event_id, derive_session_id, AgentScope, CertifiedSource, CoreDiscoveryExclusion,
+    CoreRecord, EventIdentityInput, EventRole, EventType, NativeItemKey, NativeSessionKey,
+    ScannedSourceCounts, SessionIdentityInput, SourceAnchor, SourceKey, SourceObservation,
+    TypedKey,
+};
+use ctx_history_index::{GenerationWriter, WriterOptions};
+use ctx_semantic_model::{ExternalSemanticSpace, SemanticEmbeddingExecutorConfig};
+
+use super::*;
+use crate::{
+    daemon_scheduler::{DaemonSchedulerCycleContext, DaemonSchedulerPorts, DaemonSemanticJobPorts},
+    paths_status::{daemon_semantic_job_path, read_daemon_job_status},
+    test_support::{ARTIFACT, GENERATION_PUBLISHED, OBSERVATION},
+    DaemonConfigSnapshot,
+};
+
+struct RejectingSemanticAuth;
+
+impl DaemonConfigPort for RejectingSemanticAuth {
+    fn load(&self, data_root: &Path) -> Result<DaemonConfigSnapshot> {
+        crate::test_support::CONFIG.load(data_root)
+    }
+
+    fn semantic_model_config(&self, data_root: &Path) -> ctx_semantic_model::SemanticModelConfig {
+        crate::test_support::CONFIG.semantic_model_config(data_root)
+    }
+
+    fn semantic_executor_auth(&self) -> Result<ctx_semantic_model::SemanticEmbeddingExecutorAuth> {
+        Err(anyhow!("semantic query activation has no credentials"))
+    }
+
+    fn discovery_context(&self, data_root: &Path) -> Result<ctx_history_capture::DiscoveryContext> {
+        crate::test_support::CONFIG.discovery_context(data_root)
+    }
+}
+
+static REJECTING_SEMANTIC_AUTH: RejectingSemanticAuth = RejectingSemanticAuth;
+
+fn publish_zero_eligible_generation(data_root: &Path) -> Result<String> {
+    let source = SourceKey::derive(
+        "gemini",
+        "gemini_cli_chat_recording_jsonl",
+        "session",
+        1,
+        SourceAnchor::CatalogLineage([42; 32]),
+    )?;
+    let session_key = NativeSessionKey::native_id("session", TypedKey::utf8("zero-eligible")?)?;
+    let session_id = derive_session_id(SessionIdentityInput {
+        source: &source,
+        logical_session_kind: "thread",
+        native_session_key: &session_key,
+    })?;
+    let item = NativeItemKey::native_id("message", TypedKey::U64(1))?;
+    let event_id = derive_event_id(EventIdentityInput {
+        source: &source,
+        session_id,
+        logical_item_kind: "message",
+        native_item_key: &item,
+        subrecord_selector: None,
+    })?;
+    let mut record = CoreRecord::new_selected(
+        event_id,
+        session_id,
+        source.clone(),
+        1,
+        EventType::Message.as_str(),
+        "semantic-maintenance-test-v1",
+        "excluded retrieval result",
+    )?;
+    record.role = Some(EventRole::User.as_str().to_owned());
+    record.agent_scope = Some(AgentScope::Primary);
+    record.content.discovery_exclusion = Some(CoreDiscoveryExclusion::CtxRetrievalDerived);
+    record.validate_contract()?;
+    let mut writer = GenerationWriter::open(
+        crate::source_backed_refresh_coordinator::source_backed_index_root(data_root),
+        WriterOptions::default(),
+    )?
+    .into_writer()
+    .map_err(crate::committed_generation_recovery_error)?;
+    writer.begin_source(source.clone())?;
+    writer.add_core_record(record)?;
+    let observation = SourceObservation::new(source, "fixture-v1", vec![1])?;
+    writer.certify_source(CertifiedSource::certify(
+        observation.clone(),
+        observation,
+        "fixture-parser-v1",
+        [1; 32],
+        ScannedSourceCounts {
+            complete_records: 1,
+            retained_records: 1,
+            indexed_documents: 1,
+            certified_bytes: 80,
+            ..ScannedSourceCounts::default()
+        },
+    )?)?;
+    Ok(writer.commit(|_| true)?.generation_id)
+}
+
+#[test]
+fn zero_eligible_maintenance_runs_when_query_activation_has_no_auth() -> Result<()> {
+    let temporary = tempfile::tempdir()?;
+    let generation = publish_zero_eligible_generation(temporary.path())?;
+    let mut runtime = DaemonRuntime::default();
+    runtime.config.daemon.enabled = true;
+    runtime.config.semantic_enabled = true;
+    runtime.config.semantic_executor = SemanticEmbeddingExecutorConfig::http(
+        "http://127.0.0.1:9",
+        ExternalSemanticSpace::new("zero-eligible-maintenance", 96)?,
+    )?;
+    runtime.sidecar_drain.generation = Some(generation.clone());
+    runtime.sidecar_drain.semantic_turn_pending = true;
+    let mut reload = DaemonConfigReloadState::pending(&runtime.config);
+    reload.status = "activation_failed";
+
+    assert!(!daemon_semantic_runtime_active(&runtime, None));
+    assert!(daemon_semantic_maintenance_requested(&runtime, &reload));
+    let semantic_enabled = daemon_semantic_maintenance_requested(&runtime, &reload);
+    let iteration = crate::daemon_scheduler::run_daemon_scheduler_cycle_with_activity(
+        &test_daemon_run_args(),
+        temporary.path(),
+        &mut runtime,
+        DaemonSchedulerCycleContext {
+            deadline: None,
+            semantic_enabled,
+            query_activity: None,
+            source_refresh: None,
+        },
+        DaemonSchedulerPorts {
+            generation_published: &GENERATION_PUBLISHED,
+            semantic: DaemonSemanticJobPorts {
+                artifact_fetcher: &ARTIFACT,
+                config: &REJECTING_SEMANTIC_AUTH,
+            },
+            observation: &OBSERVATION,
+        },
+    )?;
+
+    assert!(
+        iteration.did_work,
+        "scheduler skipped maintenance: {iteration:?}; sidecar generation={:?}; attempted={:?}; pending={}",
+        runtime.sidecar_drain.generation,
+        runtime.sidecar_drain.semantic_attempted_generation,
+        runtime.sidecar_drain.semantic_turn_pending,
+    );
+    let job = read_daemon_job_status(&daemon_semantic_job_path(temporary.path()))
+        .ok_or_else(|| anyhow!("semantic maintenance did not persist a job"))?;
+    assert!(!iteration.failed, "{job:#}");
+    assert_eq!(job["status"], "ready", "{job:#}");
+    assert_eq!(job["core_generation_id"], generation, "{job:#}");
+    assert!(runtime.semantic_executor.is_none());
+    reload.status = "failed";
+    assert!(!daemon_semantic_maintenance_requested(&runtime, &reload));
+    Ok(())
+}

--- a/crates/ctx-daemon-service/src/daemon_scheduler.rs
+++ b/crates/ctx-daemon-service/src/daemon_scheduler.rs
@@ -1,38 +1,25 @@
 #[path = "daemon_scheduler_retry_deferral.rs"]
 mod retry_deferral;
+mod semantic_fairness;
 mod semantic_progress;
 
 pub(super) use retry_deferral::DaemonConsumerRetryDeferral;
-use semantic_progress::bind_semantic_generation;
-
-#[derive(Default)]
-pub(super) struct DaemonSidecarDrain {
-    pub(super) generation: Option<String>,
-    pub(super) semantic_attempted_generation: Option<String>,
-}
+pub(super) use semantic_fairness::{
+    restore_daemon_consumer_retries, DaemonSchedulerPorts, DaemonSemanticJobPorts,
+    DaemonSidecarDrain,
+};
+use {
+    semantic_fairness::{
+        semantic_turn_continues, DaemonSemanticCatchUpBudget, DaemonSemanticGeneration,
+    },
+    semantic_progress::bind_semantic_generation,
+};
 
 pub(super) struct DaemonSchedulerCycleContext<'a> {
     pub(super) deadline: Option<Instant>,
     pub(super) semantic_enabled: bool,
     pub(super) query_activity: Option<&'a DaemonQueryActivity>,
     pub(super) source_refresh: Option<&'a CoreRefreshEngine>,
-}
-
-#[derive(Clone, Copy)]
-pub(super) struct DaemonSemanticJobPorts<'a> {
-    pub(super) artifact_fetcher: &'a dyn ctx_semantic_model::ArtifactFetcher,
-    pub(super) config: &'a dyn crate::DaemonConfigPort,
-}
-
-#[derive(Clone, Copy)]
-struct DaemonSemanticGeneration<'a> {
-    source_generation: &'a PinnedSourceBackedGeneration,
-    contract: &'a ctx_semantic_index::SemanticModelContract,
-}
-pub(super) struct DaemonSchedulerPorts<'a, N: ?Sized> {
-    pub(super) generation_published: &'a N,
-    pub(super) semantic: DaemonSemanticJobPorts<'a>,
-    pub(super) observation: &'a dyn crate::DaemonObservationPort,
 }
 
 fn immediate_follow_up(mut iteration: DaemonIteration) -> DaemonIteration {
@@ -123,6 +110,22 @@ where
         return Ok(iteration);
     }
     let query_generation = query_activity.map(|activity| activity.snapshot().1);
+    if source_refresh_requested
+        && runtime.sidecar_drain.semantic_turn_pending
+        && runtime.history_retry.ready()
+        && !daemon_foreground_query_preempts(query_activity, query_generation)
+    {
+        if let Some(iteration) = run_pending_core_semantic_catch_up(
+            data_root,
+            runtime,
+            deadline,
+            semantic_enabled,
+            semantic,
+            DaemonSemanticCatchUpBudget::OneDurableBoundary,
+        )? {
+            return Ok(iteration);
+        }
+    }
     if source_refresh_requested {
         runtime.consumer_retry_deferral.reset();
         if let Some(activity) = query_activity {
@@ -179,10 +182,13 @@ where
         deadline,
         semantic_enabled,
         semantic,
+        DaemonSemanticCatchUpBudget::Drain,
     )? {
+        runtime.sidecar_drain.semantic_turn_pending = false;
         return Ok(iteration);
     }
     if runtime.sidecar_drain.generation.take().is_some() {
+        runtime.sidecar_drain.semantic_turn_pending = false;
         return Ok(DaemonIteration::new(
             false,
             false,
@@ -223,6 +229,7 @@ fn run_pending_core_semantic_catch_up(
     deadline: Option<Instant>,
     semantic_enabled: bool,
     semantic_ports: DaemonSemanticJobPorts<'_>,
+    catch_up_budget: DaemonSemanticCatchUpBudget,
 ) -> Result<Option<DaemonIteration>> {
     if !semantic_enabled
         || !daemon_mode_runs_core_semantic_projection(runtime.config.daemon.mode)
@@ -268,7 +275,14 @@ fn run_pending_core_semantic_catch_up(
             contract: &semantic_contract,
         },
         semantic_ports,
+        catch_up_budget,
     );
+    if matches!(
+        catch_up_budget,
+        DaemonSemanticCatchUpBudget::OneDurableBoundary
+    ) {
+        runtime.sidecar_drain.semantic_turn_pending = semantic_turn_continues(&job);
+    }
     let did_work = daemon_semantic_job_did_work(&job);
     write_daemon_job_status_unless_deadline_skip(&daemon_semantic_job_path(data_root), &job)?;
     runtime.sidecar_drain.semantic_attempted_generation = Some(generation_id.to_owned());
@@ -398,7 +412,7 @@ where
         observation,
     );
     if let Some(generation) = published_generation {
-        runtime.sidecar_drain.generation = Some(generation);
+        runtime.sidecar_drain.record_core_publication(generation);
         // A successor queued behind an exact-route fence must yield to the
         // daemon loop once so pending watcher events enter the dirty-route
         // ledger before that successor is admitted.
@@ -461,7 +475,9 @@ where
     let state = daemon_core_cycle_state(&job);
     if !failed && job.get("status").and_then(Value::as_str) == Some("completed") {
         if let Some(generation) = job.get("published_generation").and_then(Value::as_str) {
-            runtime.sidecar_drain.generation = Some(generation.to_owned());
+            runtime
+                .sidecar_drain
+                .record_core_publication(generation.to_owned());
         }
         let iteration = with_provider_refresh(
             DaemonIteration::new(run.did_work, false, state),
@@ -510,7 +526,7 @@ where
     })
     .flatten();
     if let Some(generation) = published_generation {
-        runtime.sidecar_drain.generation = Some(generation);
+        runtime.sidecar_drain.record_core_publication(generation);
         Ok(immediate_follow_up(DaemonIteration::new(
             did_work, false, state,
         )))
@@ -608,29 +624,6 @@ pub(super) fn restore_daemon_source_refresh_retry(runtime: &mut DaemonRuntime, d
     runtime.history_retry.restore(finalization);
 }
 
-pub(super) fn restore_daemon_consumer_retries(runtime: &mut DaemonRuntime, data_root: &Path) {
-    let semantic = read_daemon_job_status(&daemon_semantic_job_path(data_root));
-    restore_consumer_retry(&mut runtime.semantic_retry, semantic.as_ref());
-}
-
-fn restore_consumer_retry(backoff: &mut DaemonRetryBackoff, status: Option<&Value>) {
-    backoff.restore(status);
-    let persisted_failures = status
-        .and_then(|status| status.get("consecutive_failures"))
-        .and_then(Value::as_u64)
-        .unwrap_or(0)
-        .min(u64::from(u32::MAX)) as u32;
-    if backoff.consecutive_failures == 0
-        && persisted_failures > 0
-        && status
-            .and_then(|status| status.get("retryable"))
-            .and_then(Value::as_bool)
-            == Some(true)
-    {
-        backoff.consecutive_failures = persisted_failures;
-    }
-}
-
 pub(super) fn daemon_consumer_retry_due(runtime: &DaemonRuntime) -> bool {
     runtime.semantic_retry.consecutive_failures > 0 && runtime.semantic_retry.ready()
 }
@@ -713,6 +706,7 @@ fn run_daemon_semantic_job_with_retry(
     deadline: Option<Instant>,
     generation: DaemonSemanticGeneration<'_>,
     ports: DaemonSemanticJobPorts<'_>,
+    catch_up_budget: DaemonSemanticCatchUpBudget,
 ) -> Value {
     if let Some(job) = runtime.semantic_blocked_job.as_ref() {
         return job.clone();
@@ -721,7 +715,13 @@ fn run_daemon_semantic_job_with_retry(
         let job = daemon_semantic_retry_backoff_job(data_root, &runtime.semantic_retry);
         return bind_semantic_generation(data_root, job, generation);
     }
-    let job = run_daemon_semantic_job(
+    let run = match catch_up_budget {
+        DaemonSemanticCatchUpBudget::Drain => run_daemon_semantic_job,
+        DaemonSemanticCatchUpBudget::OneDurableBoundary => {
+            run_daemon_semantic_job_one_durable_boundary
+        }
+    };
+    let job = run(
         data_root,
         generation.source_generation,
         runtime,
@@ -832,12 +832,7 @@ fn selected_semantic_contract(
         }
         return semantic_index_contract(active);
     }
-    if runtime.config.semantic_executor.is_builtin() {
-        return semantic_index_contract(runtime.config.semantic_executor.contract());
-    }
-    Err(anyhow::anyhow!(
-        "selected semantic embedding executor is not active"
-    ))
+    semantic_index_contract(runtime.config.semantic_executor.contract())
 }
 
 pub(super) fn record_daemon_job_retry(backoff: &mut DaemonRetryBackoff, mut job: Value) -> Value {
@@ -967,7 +962,7 @@ use super::{
     daemon_retry::{semantic_failure_class_from_job, DaemonRetryBackoff, SemanticFailureClass},
     daemon_worker::{
         daemon_semantic_failed_job, daemon_semantic_retry_backoff_job, run_daemon_semantic_job,
-        semantic_index_contract,
+        run_daemon_semantic_job_one_durable_boundary, semantic_index_contract,
     },
     paths_status::{
         daemon_core_refresh_job_path, daemon_semantic_job_path, read_daemon_job_status,
@@ -975,9 +970,7 @@ use super::{
     },
     query_service::DaemonQueryActivity,
     runtime_limits::DAEMON_MIN_REMAINING_FOR_JOB_SECS,
-    source_backed_refresh_coordinator::{
-        pin_published_generation, CoreRefreshEngine, PinnedSourceBackedGeneration,
-    },
+    source_backed_refresh_coordinator::{pin_published_generation, CoreRefreshEngine},
 };
 
 #[cfg(test)]

--- a/crates/ctx-daemon-service/src/daemon_scheduler/semantic_fairness.rs
+++ b/crates/ctx-daemon-service/src/daemon_scheduler/semantic_fairness.rs
@@ -1,0 +1,104 @@
+#[derive(Default)]
+pub(crate) struct DaemonSidecarDrain {
+    pub(crate) generation: Option<String>,
+    pub(crate) semantic_attempted_generation: Option<String>,
+    pub(crate) semantic_turn_pending: bool,
+}
+
+impl DaemonSidecarDrain {
+    pub(super) fn record_core_publication(&mut self, generation: String) {
+        self.generation = Some(generation);
+        self.semantic_attempted_generation = None;
+        self.semantic_turn_pending = true;
+    }
+}
+
+pub(super) fn semantic_turn_continues(job: &serde_json::Value) -> bool {
+    job.get("status").and_then(serde_json::Value::as_str) == Some("budget_exhausted")
+        && job
+            .get("semantic_progress_sequence")
+            .and_then(serde_json::Value::as_u64)
+            .is_some()
+        && job
+            .get("source_generation_ready")
+            .and_then(serde_json::Value::as_bool)
+            == Some(false)
+        && job
+            .get("source_work_remaining")
+            .and_then(serde_json::Value::as_bool)
+            == Some(true)
+}
+
+pub(crate) fn restore_daemon_consumer_retries(
+    runtime: &mut crate::daemon::DaemonRuntime,
+    data_root: &std::path::Path,
+) {
+    let semantic = crate::paths_status::read_daemon_job_status(
+        &crate::paths_status::daemon_semantic_job_path(data_root),
+    );
+    restore_consumer_retry(&mut runtime.semantic_retry, semantic.as_ref());
+    let core = crate::paths_status::read_daemon_job_status(
+        &crate::paths_status::daemon_core_refresh_job_path(data_root),
+    );
+    let core_generation = core
+        .as_ref()
+        .and_then(|job| job.get("published_generation"))
+        .and_then(serde_json::Value::as_str);
+    let semantic_generation = semantic
+        .as_ref()
+        .and_then(|job| job.get("core_generation_id"))
+        .and_then(serde_json::Value::as_str);
+    let generation = core_generation.or(semantic_generation);
+    if semantic.as_ref().is_some_and(semantic_turn_continues)
+        || core_generation.is_some_and(|generation| semantic_generation != Some(generation))
+    {
+        runtime.sidecar_drain.generation = generation.map(str::to_owned);
+        runtime.sidecar_drain.semantic_turn_pending = true;
+    }
+}
+
+fn restore_consumer_retry(
+    backoff: &mut crate::daemon_retry::DaemonRetryBackoff,
+    status: Option<&serde_json::Value>,
+) {
+    backoff.restore(status);
+    let persisted_failures = status
+        .and_then(|status| status.get("consecutive_failures"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0)
+        .min(u64::from(u32::MAX)) as u32;
+    if backoff.consecutive_failures == 0
+        && persisted_failures > 0
+        && status
+            .and_then(|status| status.get("retryable"))
+            .and_then(serde_json::Value::as_bool)
+            == Some(true)
+    {
+        backoff.consecutive_failures = persisted_failures;
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum DaemonSemanticCatchUpBudget {
+    Drain,
+    OneDurableBoundary,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct DaemonSemanticGeneration<'a> {
+    pub(super) source_generation:
+        &'a crate::source_backed_refresh_coordinator::PinnedSourceBackedGeneration,
+    pub(super) contract: &'a ctx_semantic_index::SemanticModelContract,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct DaemonSemanticJobPorts<'a> {
+    pub(crate) artifact_fetcher: &'a dyn ctx_semantic_model::ArtifactFetcher,
+    pub(crate) config: &'a dyn crate::DaemonConfigPort,
+}
+
+pub(crate) struct DaemonSchedulerPorts<'a, N: ?Sized> {
+    pub(crate) generation_published: &'a N,
+    pub(crate) semantic: DaemonSemanticJobPorts<'a>,
+    pub(crate) observation: &'a dyn crate::DaemonObservationPort,
+}

--- a/crates/ctx-daemon-service/src/daemon_scheduler_tests.rs
+++ b/crates/ctx-daemon-service/src/daemon_scheduler_tests.rs
@@ -48,7 +48,7 @@ use super::{
     record_daemon_job_retry, record_source_refresh_retry, restore_daemon_consumer_retries,
     run_daemon_semantic_job_with_retry, run_pending_core_refresh, write_daemon_job_status,
     DaemonRetryBackoff, DaemonRuntime, DaemonSchedulerCycleContext, DaemonSchedulerPorts,
-    DaemonSemanticGeneration, DaemonSemanticJobPorts,
+    DaemonSemanticCatchUpBudget, DaemonSemanticGeneration, DaemonSemanticJobPorts,
 };
 
 const READINESS_QUERY: &str = "readiness-boundary-regression";
@@ -382,6 +382,7 @@ fn one_scheduler_pin_controls_worker_mutation_receipt_and_retry_accounting() {
             artifact_fetcher: &crate::test_support::ARTIFACT,
             config: &crate::test_support::CONFIG,
         },
+        DaemonSemanticCatchUpBudget::Drain,
     );
 
     assert_eq!(job["status"], "ready", "{job:#}");
@@ -776,6 +777,223 @@ fn one_core_cycle_then_scheduler_drains_semantic_consumer() {
     )
     .unwrap();
     assert!(!drained.continue_immediately);
+}
+
+#[test]
+fn queued_core_successor_waits_for_semantic_readiness_across_restart() {
+    let temp = tempfile::tempdir().unwrap();
+    let coordinator = CoreRefreshEngine::with_executor(std::sync::Arc::new(
+        |execution: SourceBackedRefreshExecution<'_>| {
+            Ok(publish_empty_authoritative_generation(&execution))
+        },
+    ));
+    coordinator.enqueue_for_test(None);
+    let mut runtime = DaemonRuntime::default();
+
+    let first_core = run_daemon_scheduler_cycle_with_activity(
+        &daemon_args(),
+        temp.path(),
+        &mut runtime,
+        None,
+        true,
+        None,
+        Some(&coordinator),
+    )
+    .unwrap();
+    assert!(first_core.did_work);
+    let first_generation = pinned_generation(temp.path());
+
+    coordinator.enqueue_for_test(Some(first_generation.clone()));
+    let calls = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+    let mut publication_restart = DaemonRuntime::default();
+    super::restore_daemon_consumer_retries(&mut publication_restart, temp.path());
+    assert!(publication_restart.sidecar_drain.semantic_turn_pending);
+    runtime = publication_restart;
+    let semantic = {
+        let _jobs = install_jobs(
+            calls.clone(),
+            Some(json!({
+                "status": "budget_exhausted",
+                "semantic_progress_sequence": 1,
+                "source_records_decoded": 1,
+                "source_generation_ready": false,
+                "source_work_remaining": true,
+            })),
+        );
+        run_daemon_scheduler_cycle_with_activity(
+            &daemon_args(),
+            temp.path(),
+            &mut runtime,
+            None,
+            true,
+            None,
+            Some(&coordinator),
+        )
+        .unwrap()
+    };
+    assert!(semantic.continue_immediately);
+    assert_eq!(&*calls.borrow(), &["semantic_index"]);
+    assert!(
+        coordinator.has_pending_request(),
+        "one semantic turn must not consume the queued Core successor"
+    );
+    assert_eq!(pinned_generation(temp.path()), first_generation);
+    assert!(runtime.sidecar_drain.semantic_turn_pending);
+    assert_eq!(
+        runtime
+            .sidecar_drain
+            .semantic_attempted_generation
+            .as_deref(),
+        Some(first_generation.as_str())
+    );
+
+    let mut restarted_runtime = DaemonRuntime::default();
+    super::restore_daemon_consumer_retries(&mut restarted_runtime, temp.path());
+    assert!(restarted_runtime.sidecar_drain.semantic_turn_pending);
+    runtime = restarted_runtime;
+
+    let second_semantic = {
+        let _jobs = install_jobs(
+            calls.clone(),
+            Some(json!({
+                "status": "budget_exhausted",
+                "semantic_progress_sequence": 2,
+                "source_records_decoded": 1,
+                "source_generation_ready": false,
+                "source_work_remaining": true,
+            })),
+        );
+        run_daemon_scheduler_cycle_with_activity(
+            &daemon_args(),
+            temp.path(),
+            &mut runtime,
+            None,
+            true,
+            None,
+            Some(&coordinator),
+        )
+        .unwrap()
+    };
+    assert!(second_semantic.continue_immediately);
+    assert_eq!(&*calls.borrow(), &["semantic_index", "semantic_index"]);
+    assert!(coordinator.has_pending_request());
+    assert!(runtime.sidecar_drain.semantic_turn_pending);
+    assert_eq!(pinned_generation(temp.path()), first_generation);
+
+    let ready_semantic = {
+        let _jobs = install_jobs(
+            calls.clone(),
+            Some(json!({
+                "status": "ready",
+                "semantic_progress_sequence": 3,
+                "source_records_decoded": 1,
+                "source_generation_ready": true,
+                "source_work_remaining": false,
+            })),
+        );
+        run_daemon_scheduler_cycle_with_activity(
+            &daemon_args(),
+            temp.path(),
+            &mut runtime,
+            None,
+            true,
+            None,
+            Some(&coordinator),
+        )
+        .unwrap()
+    };
+    assert!(ready_semantic.continue_immediately);
+    assert_eq!(calls.borrow().len(), 3);
+    assert!(coordinator.has_pending_request());
+    assert!(!runtime.sidecar_drain.semantic_turn_pending);
+
+    let successor = run_daemon_scheduler_cycle_with_activity(
+        &daemon_args(),
+        temp.path(),
+        &mut runtime,
+        None,
+        true,
+        None,
+        Some(&coordinator),
+    )
+    .unwrap();
+    assert!(!successor.failed);
+    assert!(!coordinator.has_pending_request());
+    assert_eq!(calls.borrow().len(), 3);
+    assert_eq!(pinned_generation(temp.path()), first_generation);
+    assert!(runtime.sidecar_drain.semantic_turn_pending);
+    assert!(runtime
+        .sidecar_drain
+        .semantic_attempted_generation
+        .is_none());
+}
+
+#[test]
+fn foreground_query_skips_semantic_turn_without_blocking_core() {
+    let temp = tempfile::tempdir().unwrap();
+    let coordinator = CoreRefreshEngine::with_executor(Arc::new(
+        |execution: SourceBackedRefreshExecution<'_>| {
+            Ok(publish_empty_authoritative_generation(&execution))
+        },
+    ));
+    coordinator.enqueue_for_test(None);
+    let mut runtime = DaemonRuntime::default();
+    run_daemon_scheduler_cycle_with_activity(
+        &daemon_args(),
+        temp.path(),
+        &mut runtime,
+        None,
+        true,
+        None,
+        Some(&coordinator),
+    )
+    .unwrap();
+
+    let generation = pinned_generation(temp.path());
+    coordinator.enqueue_for_test(Some(generation));
+    let calls = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+    let _jobs = install_jobs(
+        calls.clone(),
+        Some(json!({
+            "status": "budget_exhausted",
+            "semantic_progress_sequence": 1,
+            "source_generation_ready": false,
+            "source_work_remaining": true,
+        })),
+    );
+    let activity = Arc::new(crate::query_service::DaemonQueryActivity::new());
+    let request = activity.begin_request().expect("foreground query admitted");
+
+    let core = run_daemon_scheduler_cycle_with_activity(
+        &daemon_args(),
+        temp.path(),
+        &mut runtime,
+        None,
+        true,
+        Some(activity.as_ref()),
+        Some(&coordinator),
+    )
+    .unwrap();
+    assert!(!core.failed);
+    assert!(!coordinator.has_pending_request());
+    assert!(calls.borrow().is_empty());
+
+    drop(request);
+    let latest_generation = pinned_generation(temp.path());
+    coordinator.enqueue_for_test(Some(latest_generation));
+    let semantic = run_daemon_scheduler_cycle_with_activity(
+        &daemon_args(),
+        temp.path(),
+        &mut runtime,
+        None,
+        true,
+        Some(activity.as_ref()),
+        Some(&coordinator),
+    )
+    .unwrap();
+    assert!(semantic.continue_immediately);
+    assert_eq!(&*calls.borrow(), &["semantic_index"]);
+    assert!(coordinator.has_pending_request());
 }
 
 #[test]

--- a/crates/ctx-daemon-service/src/daemon_worker.rs
+++ b/crates/ctx-daemon-service/src/daemon_worker.rs
@@ -191,6 +191,12 @@ where
     }
 }
 
+#[derive(Clone, Copy)]
+enum DaemonSemanticReconciliationBudget {
+    Drain,
+    OneDurableBoundary,
+}
+
 pub(super) fn run_daemon_semantic_job(
     data_root: &Path,
     source_generation: &PinnedSourceBackedGeneration,
@@ -199,6 +205,50 @@ pub(super) fn run_daemon_semantic_job(
     semantic_enabled: bool,
     artifact_fetcher: &dyn ArtifactFetcher,
     config: &dyn DaemonConfigPort,
+) -> Result<Value> {
+    run_daemon_semantic_job_with_budget(
+        data_root,
+        source_generation,
+        runtime,
+        deadline,
+        semantic_enabled,
+        artifact_fetcher,
+        config,
+        DaemonSemanticReconciliationBudget::Drain,
+    )
+}
+
+pub(super) fn run_daemon_semantic_job_one_durable_boundary(
+    data_root: &Path,
+    source_generation: &PinnedSourceBackedGeneration,
+    runtime: &mut DaemonRuntime,
+    deadline: Option<Instant>,
+    semantic_enabled: bool,
+    artifact_fetcher: &dyn ArtifactFetcher,
+    config: &dyn DaemonConfigPort,
+) -> Result<Value> {
+    run_daemon_semantic_job_with_budget(
+        data_root,
+        source_generation,
+        runtime,
+        deadline,
+        semantic_enabled,
+        artifact_fetcher,
+        config,
+        DaemonSemanticReconciliationBudget::OneDurableBoundary,
+    )
+}
+
+#[allow(clippy::too_many_arguments)] // Scheduler ports and reconciliation budget are independent controls.
+fn run_daemon_semantic_job_with_budget(
+    data_root: &Path,
+    source_generation: &PinnedSourceBackedGeneration,
+    runtime: &mut DaemonRuntime,
+    deadline: Option<Instant>,
+    semantic_enabled: bool,
+    artifact_fetcher: &dyn ArtifactFetcher,
+    config: &dyn DaemonConfigPort,
+    reconciliation_budget: DaemonSemanticReconciliationBudget,
 ) -> Result<Value> {
     let last_run_at_ms = utc_now().timestamp_millis();
     if !semantic_enabled {
@@ -251,12 +301,17 @@ pub(super) fn run_daemon_semantic_job(
             None,
         ));
     }
-    // An empty Core generation still needs its durable semantic acknowledgement,
-    // but has no embedding work. Admit that index publication through the same
-    // deadline and resource boundaries as ordinary daemon work, then complete
-    // it from the configuration-derived contract before resolving credentials
-    // or constructing an executor.
-    if source_eligible_events == 0 && !vector_path.exists() {
+    // A generation with no semantic-eligible events still needs its durable
+    // acknowledgement, but has no embedding work. Admit that index publication
+    // through the same deadline and resource boundaries as ordinary daemon
+    // work, then reconcile it from the configuration-derived contract before
+    // resolving credentials or constructing an executor. The vector path may
+    // already exist for the fixed built-in contract when a bounded
+    // reconciliation resumes or removes stale vectors. Existing external
+    // state is admitted only when its matching read and writable open share
+    // the writer coordination guard. Unknown or mismatched state follows the
+    // verified executor path below, so contract drift cannot race a reset.
+    if source_eligible_events == 0 {
         if let Some(deferred) = semantic_index_publication_resource_deferred(
             data_root,
             &runtime.config.semantic_executor,
@@ -266,14 +321,27 @@ pub(super) fn run_daemon_semantic_job(
                 deferred,
             ));
         }
-        let mut vector_store = SemanticVectorStore::open(&vector_path, &index_contract)?;
-        let (outcome, indexed_chunks) =
-            reconcile_empty_source_backed_semantic_page(source_generation, &mut vector_store)?;
-        return Ok(daemon_semantic_reconciliation_job(
-            last_run_at_ms,
-            outcome,
-            indexed_chunks,
-        ));
+        let executor_free_store =
+            if !vector_path.exists() || runtime.config.semantic_executor.is_builtin() {
+                Some(SemanticVectorStore::open(&vector_path, &index_contract)?)
+            } else {
+                SemanticVectorStore::open_source_backed_reconciliation_if_contract_matches_at(
+                    &vector_path,
+                    &index_contract,
+                )?
+            };
+        if let Some(mut vector_store) = executor_free_store {
+            let (outcome, indexed_chunks) = reconcile_empty_source_backed_semantic_page(
+                source_generation,
+                &mut vector_store,
+                reconciliation_budget,
+            )?;
+            return Ok(daemon_semantic_reconciliation_job(
+                last_run_at_ms,
+                outcome,
+                indexed_chunks,
+            ));
+        }
     }
 
     let executor = match runtime.semantic_executor.clone() {
@@ -392,6 +460,7 @@ pub(super) fn run_daemon_semantic_job(
         semantic_executor,
         deadline,
         &mut publish_progress,
+        reconciliation_budget,
     )?;
     Ok(daemon_semantic_reconciliation_job(
         last_run_at_ms,
@@ -467,6 +536,7 @@ fn reconcile_source_backed_semantic_page(
     executor: &dyn SemanticEmbeddingExecutor,
     deadline: Option<Instant>,
     progress: &mut dyn FnMut(u64) -> Result<()>,
+    reconciliation_budget: DaemonSemanticReconciliationBudget,
 ) -> Result<(SourceBackedSemanticOutcome, usize)> {
     let index = generation.verified_index();
     let mut builder = SourceBackedSemanticDocumentBuilder::new(index);
@@ -475,24 +545,48 @@ fn reconcile_source_backed_semantic_page(
         deadline,
         indexed_chunks: 0,
     };
-    let outcome = vector_store.reconcile_source_backed_index_with_checkpoint_and_progress(
-        index,
-        &mut builder,
-        &mut embedder,
-        &mut || Ok(()),
-        progress,
-    )?;
+    let outcome = match reconciliation_budget {
+        DaemonSemanticReconciliationBudget::Drain => vector_store
+            .reconcile_source_backed_index_with_checkpoint_and_progress(
+                index,
+                &mut builder,
+                &mut embedder,
+                &mut || Ok(()),
+                progress,
+            )?,
+        DaemonSemanticReconciliationBudget::OneDurableBoundary => vector_store
+            .reconcile_source_backed_index_one_durable_boundary_with_checkpoint_and_progress(
+                index,
+                &mut builder,
+                &mut embedder,
+                &mut || Ok(()),
+                progress,
+            )?,
+    };
     Ok((outcome, embedder.indexed_chunks))
 }
 
 fn reconcile_empty_source_backed_semantic_page(
     generation: &PinnedSourceBackedGeneration,
     vector_store: &mut SemanticVectorStore,
+    reconciliation_budget: DaemonSemanticReconciliationBudget,
 ) -> Result<(SourceBackedSemanticOutcome, usize)> {
     let index = generation.verified_index();
     let mut builder = SourceBackedSemanticDocumentBuilder::new(index);
     let mut embedder = EmptySourceSemanticEmbedder;
-    let outcome = vector_store.reconcile_source_backed_index(index, &mut builder, &mut embedder)?;
+    let outcome = match reconciliation_budget {
+        DaemonSemanticReconciliationBudget::Drain => {
+            vector_store.reconcile_source_backed_index(index, &mut builder, &mut embedder)?
+        }
+        DaemonSemanticReconciliationBudget::OneDurableBoundary => vector_store
+            .reconcile_source_backed_index_one_durable_boundary_with_checkpoint_and_progress(
+                index,
+                &mut builder,
+                &mut embedder,
+                &mut || Ok(()),
+                &mut |_| Ok(()),
+            )?,
+    };
     Ok((outcome, 0))
 }
 

--- a/crates/ctx-daemon-service/src/daemon_worker_tests.rs
+++ b/crates/ctx-daemon-service/src/daemon_worker_tests.rs
@@ -9,11 +9,15 @@ use std::{
 use anyhow::{anyhow, Result};
 use ctx_history_capture::{DiscoveryContext, SourceBackedRefreshScope};
 use ctx_history_core::{
-    derive_event_id, derive_session_id, AgentScope, CaptureProvider, CertifiedSource, CoreRecord,
-    EventIdentityInput, EventRole, EventType, NativeItemKey, NativeSessionKey, ScannedSourceCounts,
-    SessionIdentityInput, SourceAnchor, SourceKey, SourceObservation, TypedKey,
+    derive_event_id, derive_session_id, AgentScope, CaptureProvider, CertifiedSource,
+    CoreDiscoveryExclusion, CoreRecord, EventIdentityInput, EventRole, EventType, NativeItemKey,
+    NativeSessionKey, ScannedSourceCounts, SessionIdentityInput, SourceAnchor, SourceKey,
+    SourceObservation, TypedKey,
 };
-use ctx_history_index::{CoreEventPageBudget, GenerationWriter, VerifiedIndex, WriterOptions};
+use ctx_history_index::{
+    CoreEventPageBudget, GenerationWriter, VerifiedIndex, WriterOptions,
+    MAX_SOURCE_EVENT_PAGE_ITEMS,
+};
 use ctx_history_refresh::RefreshOperation;
 use ctx_semantic_index::{
     source_backed_semantic_vector_path, SemanticDocumentBuilder, SemanticVectorStore,
@@ -52,6 +56,7 @@ use crate::{
     daemon_scheduler::record_daemon_job_retry,
     source_backed_refresh_coordinator::{
         publish_authoritative_empty_generation_for_test, source_backed_index_root,
+        PinnedSourceBackedGeneration,
     },
     test_support::{ARTIFACT, CONFIG},
     DaemonConfigSnapshot, CONFIG_FILE,
@@ -279,6 +284,111 @@ fn remote_space_drift_fails_permanently_before_store_reset() -> Result<()> {
 }
 
 #[test]
+fn zero_eligible_remote_space_drift_fails_before_store_reset() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let (endpoint, server) = contract_response_endpoint(
+        r#"{"schema_version":2,"space_id":"drifted-space","dimensions":128}"#,
+    )?;
+    let old_config = SemanticEmbeddingExecutorConfig::http(
+        &endpoint,
+        ExternalSemanticSpace::new("old-space", 64)?,
+    )?;
+    let selected_config = SemanticEmbeddingExecutorConfig::http(
+        &endpoint,
+        ExternalSemanticSpace::new("selected-space", 128)?,
+    )?;
+    let vector_path = source_backed_semantic_vector_path(temp.path());
+    let old_index_contract = semantic_index_contract(old_config.contract())?;
+    drop(SemanticVectorStore::open(
+        &vector_path,
+        &old_index_contract,
+    )?);
+    publish_authoritative_empty_generation_for_test(
+        &source_backed_index_root(temp.path()),
+        "zero-eligible-external-drift",
+        RefreshOperation::Refresh,
+        SourceBackedRefreshScope::All,
+        None,
+    )?;
+    let source_generation =
+        crate::source_backed_refresh_coordinator::pin_published_generation(temp.path())?
+            .expect("published zero-eligible Core generation");
+    let mut runtime = DaemonRuntime::default();
+    runtime.config.semantic_executor = selected_config;
+
+    let error = run_daemon_semantic_job_one_durable_boundary(
+        temp.path(),
+        &source_generation,
+        &mut runtime,
+        None,
+        true,
+        &ARTIFACT,
+        &CONFIG,
+    )
+    .expect_err("endpoint verification must fail before writable store open");
+    assert!(
+        format!("{error:#}").contains("asserted a different semantic space"),
+        "{error:#}"
+    );
+    assert!(
+        SemanticVectorStore::open_read_only(&vector_path, &old_index_contract)?.is_some(),
+        "verification failure must preserve the previous contract's store"
+    );
+    server.join().expect("contract response server panicked")?;
+    Ok(())
+}
+
+#[test]
+fn zero_eligible_external_v5_store_verifies_then_migrates() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let (endpoint, server) = contract_response_endpoint(
+        r#"{"schema_version":2,"space_id":"v5-space","dimensions":96}"#,
+    )?;
+    let selected = SemanticEmbeddingExecutorConfig::http(
+        &endpoint,
+        ExternalSemanticSpace::new("v5-space", 96)?,
+    )?;
+    let vector_path = source_backed_semantic_vector_path(temp.path());
+    let index_contract = semantic_index_contract(selected.contract())?;
+    drop(SemanticVectorStore::open(&vector_path, &index_contract)?);
+    let control = rusqlite::Connection::open(vector_path.join("state.sqlite"))?;
+    control.pragma_update(None, "user_version", 5)?;
+    drop(control);
+    publish_authoritative_empty_generation_for_test(
+        &source_backed_index_root(temp.path()),
+        "zero-eligible-external-v5",
+        RefreshOperation::Refresh,
+        SourceBackedRefreshScope::All,
+        None,
+    )?;
+    let source_generation =
+        crate::source_backed_refresh_coordinator::pin_published_generation(temp.path())?
+            .expect("published zero-eligible Core generation");
+    let mut runtime = DaemonRuntime::default();
+    runtime.config.semantic_executor = selected;
+
+    let job = run_daemon_semantic_job_one_durable_boundary(
+        temp.path(),
+        &source_generation,
+        &mut runtime,
+        None,
+        true,
+        &ARTIFACT,
+        &CONFIG,
+    )?;
+
+    assert_eq!(job["status"], "ready", "{job:#}");
+    assert!(runtime.semantic_executor.is_some());
+    let control = rusqlite::Connection::open(vector_path.join("state.sqlite"))?;
+    assert_eq!(
+        control.query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))?,
+        crate::test_support::current_semantic_vector_schema_version()
+    );
+    server.join().expect("contract response server panicked")?;
+    Ok(())
+}
+
+#[test]
 fn malformed_contract_output_fails_permanently_before_store_reset() -> Result<()> {
     assert_contract_verification_failure_preserves_store(
         r#"{"schema_version":2,"space_id":17,"dimensions":"bad"}"#,
@@ -360,6 +470,134 @@ fn ready_empty_v2_generation_is_observed_without_constructing_an_executor() -> R
         store.source_backed_generation_pin_exact(&generation, 0)?,
         SourceBackedGenerationPin::ReadyEmpty
     ));
+    Ok(())
+}
+
+#[test]
+fn bounded_zero_eligible_reconciliation_advances_one_boundary_without_executor() -> Result<()> {
+    let fixture = CoreFixture::new();
+    let record_count = MAX_SOURCE_EVENT_PAGE_ITEMS + 1;
+    let mut records = Vec::with_capacity(record_count);
+    for sequence in 0..record_count as u64 {
+        let mut record = fixture.record(sequence, EventRole::User, "excluded retrieval result");
+        record.content.discovery_exclusion = Some(CoreDiscoveryExclusion::CtxRetrievalDerived);
+        record.validate_contract()?;
+        records.push(record);
+    }
+    let source_generation = PinnedSourceBackedGeneration::from_index(fixture.index(records));
+    assert_eq!(source_generation.semantic_eligible_event_count()?, 0);
+    let mut runtime = DaemonRuntime::default();
+
+    let first = run_daemon_semantic_job_one_durable_boundary(
+        fixture.temp.path(),
+        &source_generation,
+        &mut runtime,
+        None,
+        true,
+        &ARTIFACT,
+        &CONFIG,
+    )?;
+    assert_eq!(first["status"], "budget_exhausted", "{first:#}");
+    assert_eq!(first["semantic_progress_sequence"], 1, "{first:#}");
+    assert_eq!(
+        first["source_records_decoded"], MAX_SOURCE_EVENT_PAGE_ITEMS,
+        "{first:#}"
+    );
+    assert!(runtime.semantic_executor.is_none());
+
+    let second = run_daemon_semantic_job_one_durable_boundary(
+        fixture.temp.path(),
+        &source_generation,
+        &mut runtime,
+        None,
+        true,
+        &ARTIFACT,
+        &CONFIG,
+    )?;
+    assert_eq!(second["status"], "budget_exhausted", "{second:#}");
+    assert_eq!(second["semantic_progress_sequence"], 2, "{second:#}");
+    assert_eq!(second["source_records_decoded"], 1, "{second:#}");
+    assert!(runtime.semantic_executor.is_none());
+
+    let third = run_daemon_semantic_job_one_durable_boundary(
+        fixture.temp.path(),
+        &source_generation,
+        &mut runtime,
+        None,
+        true,
+        &ARTIFACT,
+        &CONFIG,
+    )?;
+    assert_eq!(third["status"], "budget_exhausted", "{third:#}");
+    assert_eq!(third["semantic_progress_sequence"], 3, "{third:#}");
+    assert_eq!(third["source_records_decoded"], 0, "{third:#}");
+    assert!(runtime.semantic_executor.is_none());
+
+    let ready = run_daemon_semantic_job_one_durable_boundary(
+        fixture.temp.path(),
+        &source_generation,
+        &mut runtime,
+        None,
+        true,
+        &ARTIFACT,
+        &CONFIG,
+    )?;
+    assert_eq!(ready["status"], "ready", "{ready:#}");
+    assert_eq!(ready["semantic_progress_sequence"], 4, "{ready:#}");
+    assert_eq!(ready["source_generation_ready"], true, "{ready:#}");
+    assert!(runtime.semantic_executor.is_none());
+    Ok(())
+}
+
+#[test]
+fn bounded_zero_eligible_external_reconciliation_resumes_without_auth() -> Result<()> {
+    let fixture = CoreFixture::new();
+    let record_count = MAX_SOURCE_EVENT_PAGE_ITEMS + 1;
+    let mut records = Vec::with_capacity(record_count);
+    for sequence in 0..record_count as u64 {
+        let mut record = fixture.record(sequence, EventRole::User, "excluded retrieval result");
+        record.content.discovery_exclusion = Some(CoreDiscoveryExclusion::CtxRetrievalDerived);
+        record.validate_contract()?;
+        records.push(record);
+    }
+    let source_generation = PinnedSourceBackedGeneration::from_index(fixture.index(records));
+    assert_eq!(source_generation.semantic_eligible_event_count()?, 0);
+    let mut runtime = DaemonRuntime::default();
+    runtime.config.semantic_executor = SemanticEmbeddingExecutorConfig::http(
+        "http://127.0.0.1:9",
+        ExternalSemanticSpace::new("zero-eligible-resume", 96)?,
+    )?;
+
+    let mut expected_sequence = 1;
+    loop {
+        let job = run_daemon_semantic_job_one_durable_boundary(
+            fixture.temp.path(),
+            &source_generation,
+            &mut runtime,
+            None,
+            true,
+            &ARTIFACT,
+            &RejectingSemanticAuthConfig,
+        )?;
+        assert_eq!(
+            job["semantic_progress_sequence"], expected_sequence,
+            "{job:#}"
+        );
+        assert!(runtime.semantic_executor.is_none());
+        if job["status"] == "ready" {
+            assert!(
+                expected_sequence > 1,
+                "the external resume path was not exercised"
+            );
+            break;
+        }
+        assert_eq!(job["status"], "budget_exhausted", "{job:#}");
+        expected_sequence += 1;
+        assert!(
+            expected_sequence <= 16,
+            "bounded reconciliation did not finish"
+        );
+    }
     Ok(())
 }
 

--- a/crates/ctx-semantic-index/src/vector_store/source_projection.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 use super::control::FULL_REBUILD_STATE;
 use super::flat_segments::{
     FlatActiveEventLookup, FlatEventMetadataUpdate, FlatSourceHash, FlatSourceReceiptInput,
-    FlatSourceStageResume, PinnedFlatGeneration,
+    FlatSourceStageResume,
 };
 use super::{SemanticChunkDocument, SemanticVectorStore};
 use crate::{
@@ -47,6 +47,8 @@ use manifest::{
 };
 use outcome::merge_outcome;
 pub use outcome::SourceBackedSemanticOutcome;
+use progress::SourceBackedReconciliationBoundaryLimit;
+pub use state::SourceBackedGenerationPin;
 use state::{
     advance_frontier_progress, clear_active_source, commit_frontier_after_flat,
     source_projection_states, source_receipt_allows_vector_reuse, source_receipt_matches,
@@ -200,12 +202,6 @@ pub trait SemanticDocumentBuilder {
         -> Result<Option<SemanticEventDocument>>;
 }
 
-pub enum SourceBackedGenerationPin {
-    NotReady,
-    ReadyEmpty,
-    Ready(PinnedFlatGeneration),
-}
-
 impl SemanticVectorStore {
     pub fn reconcile_source_backed_index(
         &mut self,
@@ -250,9 +246,11 @@ impl SemanticVectorStore {
             embedder,
             &mut || Ok(()),
             &mut |_| Ok(()),
+            SourceBackedReconciliationBoundaryLimit::Unbounded,
         )
     }
 
+    #[allow(clippy::too_many_arguments)] // Authority/progress hooks and the boundary budget are independent controls.
     fn reconcile_source_backed_generation_with_checkpoint(
         &mut self,
         index: &VerifiedIndex,
@@ -261,6 +259,7 @@ impl SemanticVectorStore {
         embedder: &mut dyn SemanticBatchEmbedder,
         checkpoint: &mut dyn FnMut() -> Result<()>,
         progress: &mut dyn FnMut(u64) -> Result<()>,
+        boundary_limit: SourceBackedReconciliationBoundaryLimit,
     ) -> Result<SourceBackedSemanticOutcome> {
         validate_generation(generation)?;
         if generation.core_generation_id != index.generation_id() {
@@ -296,7 +295,9 @@ impl SemanticVectorStore {
                 if let Some(outcome) =
                     self.reconcile_pending_full_rebuild(&mut frontier, progress)?
                 {
-                    return Ok(outcome);
+                    if boundary_limit.stops_after_full_rebuild(&outcome) {
+                        return Ok(outcome);
+                    }
                 }
             }
             let mut states =
@@ -341,7 +342,11 @@ impl SemanticVectorStore {
                             )?
                         }
                     };
+                    let boundary_exhausted = boundary_limit.exhausted_by(&next);
                     merge_outcome(&mut total, next);
+                    if boundary_exhausted {
+                        return Ok(total);
+                    }
                     continue;
                 }
 
@@ -372,7 +377,11 @@ impl SemanticVectorStore {
                         return Ok(total);
                     }
                 };
+                let boundary_exhausted = boundary_limit.exhausted_by(&next);
                 merge_outcome(&mut total, next);
+                if boundary_exhausted {
+                    return Ok(total);
+                }
             }
         })();
         let end = self

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/progress.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/progress.rs
@@ -7,6 +7,22 @@ use super::{
     FULL_REBUILD_STATE,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SourceBackedReconciliationBoundaryLimit {
+    Unbounded,
+    One,
+}
+
+impl SourceBackedReconciliationBoundaryLimit {
+    pub(super) fn exhausted_by(self, outcome: &SourceBackedSemanticOutcome) -> bool {
+        self == Self::One && outcome.semantic_progress_sequence().is_some()
+    }
+
+    pub(super) fn stops_after_full_rebuild(self, outcome: &SourceBackedSemanticOutcome) -> bool {
+        self == Self::Unbounded || self.exhausted_by(outcome)
+    }
+}
+
 impl SemanticVectorStore {
     /// Reconciles one pinned Core generation and reports each durable semantic
     /// boundary before continuing with later source pages. The sequence is
@@ -19,6 +35,51 @@ impl SemanticVectorStore {
         checkpoint: &mut dyn FnMut() -> Result<()>,
         progress: &mut dyn FnMut(u64) -> Result<()>,
     ) -> Result<SourceBackedSemanticOutcome> {
+        self.reconcile_source_backed_index_with_boundary_limit(
+            index,
+            builder,
+            embedder,
+            checkpoint,
+            progress,
+            SourceBackedReconciliationBoundaryLimit::Unbounded,
+        )
+    }
+
+    /// Reconciles at most one durable source-backed semantic progress boundary
+    /// for the exact pinned Core generation.
+    ///
+    /// A page or source-finalization boundary returns a successful not-ready
+    /// outcome with work remaining. A generation-acknowledgement boundary
+    /// returns a successful ready outcome. Traversal-only state changes do not
+    /// consume the boundary budget.
+    pub fn reconcile_source_backed_index_one_durable_boundary_with_checkpoint_and_progress(
+        &mut self,
+        index: &VerifiedIndex,
+        builder: &mut dyn SemanticDocumentBuilder,
+        embedder: &mut dyn SemanticBatchEmbedder,
+        checkpoint: &mut dyn FnMut() -> Result<()>,
+        progress: &mut dyn FnMut(u64) -> Result<()>,
+    ) -> Result<SourceBackedSemanticOutcome> {
+        self.reconcile_source_backed_index_with_boundary_limit(
+            index,
+            builder,
+            embedder,
+            checkpoint,
+            progress,
+            SourceBackedReconciliationBoundaryLimit::One,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)] // Authority/progress hooks and the turn budget are independent controls.
+    fn reconcile_source_backed_index_with_boundary_limit(
+        &mut self,
+        index: &VerifiedIndex,
+        builder: &mut dyn SemanticDocumentBuilder,
+        embedder: &mut dyn SemanticBatchEmbedder,
+        checkpoint: &mut dyn FnMut() -> Result<()>,
+        progress: &mut dyn FnMut(u64) -> Result<()>,
+        boundary_limit: SourceBackedReconciliationBoundaryLimit,
+    ) -> Result<SourceBackedSemanticOutcome> {
         let work_before = self.flat.work_stats();
         let generation =
             SourceBackedSemanticGeneration::from_verified_index(index, self.contract())?;
@@ -29,6 +90,7 @@ impl SemanticVectorStore {
             embedder,
             checkpoint,
             progress,
+            boundary_limit,
         )?;
         let work = self.flat.work_since(work_before);
         outcome.vectors_touched = work.vectors_touched;

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/state.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/state.rs
@@ -1,9 +1,9 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, path::Path};
 
 use anyhow::Result;
 use ctx_history_index::{SemanticGenerationPolicy, SourceCoreRecordAggregate, VerifiedIndex};
 use ctx_semantic_model::SemanticModelContract;
-use rusqlite::{params, OptionalExtension, Transaction};
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
@@ -15,19 +15,26 @@ use super::manifest::{
     SOURCE_FRONTIER_STATE,
 };
 use super::{
-    SemanticVectorStore, SourceBackedGenerationPin, SourceBackedSemanticGeneration,
-    SourceBackedSemanticOutcome, SourceBackedSemanticSource,
+    SemanticVectorStore, SourceBackedSemanticGeneration, SourceBackedSemanticOutcome,
+    SourceBackedSemanticSource,
 };
 use crate::{
     vector_store::control::FULL_REBUILD_STATE,
     vector_store::flat_segments::{
         FlatPublicationToken, FlatPublishOutcome, FlatSourceReceipt, FlatSourceState,
+        PinnedFlatGeneration,
     },
     vector_store_schema::{semantic_owned_sidecar_result, SemanticVectorStoreError},
 };
 
 const SOURCE_RECONCILIATION_DOMAIN: &[u8] = b"ctx-semantic-source-reconciliation-v1\0";
 const RECEIPT_SET_DOMAIN: &[u8] = b"ctx-semantic-source-receipt-set-v1\0";
+
+pub enum SourceBackedGenerationPin {
+    NotReady,
+    ReadyEmpty,
+    Ready(PinnedFlatGeneration),
+}
 
 pub(super) type SourceProjectionStates = BTreeMap<String, Option<FlatSourceReceipt>>;
 
@@ -87,6 +94,75 @@ impl SourceBackedSemanticGeneration {
 }
 
 impl SemanticVectorStore {
+    pub fn source_backed_reconciliation_contract_matches_at(
+        path: &Path,
+        contract: &SemanticModelContract,
+    ) -> Result<Option<bool>> {
+        if !path.exists() {
+            return Ok(None);
+        }
+        let store = match Self::open_read_only(path, contract) {
+            Ok(Some(store)) => store,
+            Ok(None) => return Ok(Some(false)),
+            Err(error)
+                if crate::vector_store_schema::semantic_vector_failure_kind(&error)
+                    == Some(
+                        crate::vector_store_schema::SemanticVectorFailureKind::ResetRequired,
+                    ) =>
+            {
+                return Ok(Some(false));
+            }
+            Err(error) => return Err(error),
+        };
+        Ok(Some(store.source_backed_reconciliation_contract_matches()?))
+    }
+
+    pub fn open_source_backed_reconciliation_if_contract_matches_at(
+        path: &Path,
+        contract: &SemanticModelContract,
+    ) -> Result<Option<Self>> {
+        Self::open_writable_if_matching(path, contract, |store| {
+            store.source_backed_reconciliation_contract_matches()
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_source_backed_reconciliation_if_contract_matches_after_match(
+        path: &Path,
+        contract: &SemanticModelContract,
+        matched: impl FnOnce(),
+    ) -> Result<Option<Self>> {
+        Self::open_writable_if_matching_after_match(
+            path,
+            contract,
+            |store| store.source_backed_reconciliation_contract_matches(),
+            matched,
+        )
+    }
+
+    fn source_backed_reconciliation_contract_matches(&self) -> Result<bool> {
+        match self.flat.active_stats() {
+            Ok(_) => {}
+            Err(
+                crate::vector_store::flat_segments::FlatStoreError::Corrupt(_)
+                | crate::vector_store::flat_segments::FlatStoreError::Incompatible(_)
+                | crate::vector_store::flat_segments::FlatStoreError::LegacySchema(_),
+            ) => return Ok(false),
+            Err(error) => return Err(anyhow::Error::new(error)),
+        }
+        let expected = source_contract_fingerprint(&self.contract)?;
+        let frontier: Option<SourceProjectionFrontier> =
+            maintenance_json_from_connection(&self.conn, SOURCE_FRONTIER_STATE)?;
+        let acknowledgement: Option<SourceProjectionAcknowledgement> =
+            maintenance_json_from_connection(&self.conn, SOURCE_ACKNOWLEDGEMENT_STATE)?;
+        let persisted = frontier
+            .map(|frontier| frontier.contract_fingerprint)
+            .or_else(|| {
+                acknowledgement.map(|acknowledgement| acknowledgement.contract_fingerprint)
+            });
+        Ok(persisted.as_deref() == Some(expected.as_str()))
+    }
+
     pub(crate) fn record_flat_model_contract_reset(&self) -> Result<()> {
         let transaction = self.conn.unchecked_transaction()?;
         transaction.execute(
@@ -205,24 +281,7 @@ impl SemanticVectorStore {
     where
         T: for<'de> Deserialize<'de>,
     {
-        let value = self
-            .conn
-            .query_row(
-                "SELECT value FROM semantic_maintenance_state WHERE key = ?1",
-                [key],
-                |row| row.get::<_, String>(0),
-            )
-            .optional()?;
-        value
-            .map(|value| {
-                serde_json::from_str(&value).map_err(|error| {
-                    SemanticVectorStoreError::reset_required(format!(
-                        "semantic vector store has invalid {key} state: {error}"
-                    ))
-                    .into()
-                })
-            })
-            .transpose()
+        maintenance_json_from_connection(&self.conn, key)
     }
 
     pub(super) fn store_source_frontier(&self, frontier: &SourceProjectionFrontier) -> Result<()> {
@@ -775,6 +834,29 @@ fn frontier_from_acknowledgement(
         flat_staging: None,
         semantic_progress_sequence: acknowledgement.semantic_progress_sequence,
     }
+}
+
+fn maintenance_json_from_connection<T>(conn: &Connection, key: &str) -> Result<Option<T>>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let value = conn
+        .query_row(
+            "SELECT value FROM semantic_maintenance_state WHERE key = ?1",
+            [key],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    value
+        .map(|value| {
+            serde_json::from_str(&value).map_err(|error| {
+                SemanticVectorStoreError::reset_required(format!(
+                    "semantic vector store has invalid {key} state: {error}"
+                ))
+                .into()
+            })
+        })
+        .transpose()
 }
 
 pub(super) fn store_frontier(

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests.rs
@@ -30,6 +30,7 @@ use super::*;
 use crate::legacy_fixed_http_semantic_model_contract;
 use crate::vector_store_search::scan_exact_generation;
 
+mod bounded_reconciliation;
 mod content;
 mod filter_accounting;
 mod generation_identity;

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/bounded_reconciliation.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/bounded_reconciliation.rs
@@ -1,0 +1,136 @@
+use super::*;
+
+#[test]
+fn empty_full_rebuild_transition_continues_to_a_sequenced_boundary() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let index = fixture.publish("bounded-empty-full-rebuild", &[])?;
+    let mut store = open_store(&fixture.semantic_path)?;
+    store.record_flat_model_contract_reset()?;
+    let mut sequences = Vec::new();
+
+    let outcome = store
+        .reconcile_source_backed_index_one_durable_boundary_with_checkpoint_and_progress(
+            &index,
+            &mut CoreBuilder::default(),
+            &mut MarkerEmbedder::default(),
+            &mut || Ok(()),
+            &mut |sequence| {
+                sequences.push(sequence);
+                Ok(())
+            },
+        )?;
+
+    assert!(outcome.ready());
+    assert!(!outcome.work_remaining());
+    assert_eq!(outcome.semantic_progress_sequence(), Some(1));
+    assert_eq!(sequences, vec![1]);
+    Ok(())
+}
+
+#[test]
+fn one_durable_boundary_per_call_resumes_a_multi_page_source() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let record_count = MAX_SOURCE_EVENT_PAGE_ITEMS + 1;
+    let index = fixture.publish(
+        "bounded-multi-page",
+        &[(0, bodies("bounded", record_count))],
+    )?;
+    let mut store = open_store(&fixture.semantic_path)?;
+    let mut builder = CoreBuilder::default();
+    let mut embedder = MarkerEmbedder::default();
+    let mut sequences = Vec::new();
+
+    let first = store
+        .reconcile_source_backed_index_one_durable_boundary_with_checkpoint_and_progress(
+            &index,
+            &mut builder,
+            &mut embedder,
+            &mut || Ok(()),
+            &mut |sequence| {
+                sequences.push(sequence);
+                Ok(())
+            },
+        )?;
+    assert!(!first.ready());
+    assert!(first.work_remaining());
+    assert_eq!(first.semantic_progress_sequence(), Some(1));
+    assert_eq!(first.records_decoded(), MAX_SOURCE_EVENT_PAGE_ITEMS);
+    assert_eq!(builder.calls.len(), MAX_SOURCE_EVENT_PAGE_ITEMS);
+    assert_eq!(sequences, vec![1]);
+
+    let second = store
+        .reconcile_source_backed_index_one_durable_boundary_with_checkpoint_and_progress(
+            &index,
+            &mut builder,
+            &mut embedder,
+            &mut || Ok(()),
+            &mut |sequence| {
+                sequences.push(sequence);
+                Ok(())
+            },
+        )?;
+    assert!(!second.ready());
+    assert!(second.work_remaining());
+    assert_eq!(second.semantic_progress_sequence(), Some(2));
+    assert_eq!(second.records_decoded(), 1);
+    assert_eq!(builder.calls.len(), record_count);
+    assert_eq!(sequences, vec![1, 2]);
+
+    let third = store
+        .reconcile_source_backed_index_one_durable_boundary_with_checkpoint_and_progress(
+            &index,
+            &mut builder,
+            &mut embedder,
+            &mut || Ok(()),
+            &mut |sequence| {
+                sequences.push(sequence);
+                Ok(())
+            },
+        )?;
+    assert!(!third.ready());
+    assert!(third.work_remaining());
+    assert_eq!(third.semantic_progress_sequence(), Some(3));
+    assert_eq!(third.records_decoded(), 0);
+    assert_eq!(builder.calls.len(), record_count);
+    assert_eq!(sequences, vec![1, 2, 3]);
+
+    let fourth = store
+        .reconcile_source_backed_index_one_durable_boundary_with_checkpoint_and_progress(
+            &index,
+            &mut builder,
+            &mut embedder,
+            &mut || Ok(()),
+            &mut |sequence| {
+                sequences.push(sequence);
+                Ok(())
+            },
+        )?;
+    assert!(fourth.ready());
+    assert!(!fourth.work_remaining());
+    assert_eq!(fourth.semantic_progress_sequence(), Some(4));
+    assert_eq!(builder.calls.len(), record_count);
+    assert_eq!(sequences, vec![1, 2, 3, 4]);
+    Ok(())
+}
+
+#[test]
+fn ordinary_reconciliation_still_drains_a_multi_page_source() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let record_count = MAX_SOURCE_EVENT_PAGE_ITEMS + 1;
+    let index = fixture.publish(
+        "ordinary-multi-page",
+        &[(0, bodies("ordinary", record_count))],
+    )?;
+    let mut store = open_store(&fixture.semantic_path)?;
+    let mut builder = CoreBuilder::default();
+    let mut embedder = MarkerEmbedder::default();
+
+    let outcome = store.reconcile_source_backed_index(&index, &mut builder, &mut embedder)?;
+
+    assert!(outcome.ready());
+    assert!(!outcome.work_remaining());
+    assert_eq!(outcome.semantic_progress_sequence(), Some(4));
+    assert_eq!(outcome.records_decoded(), record_count);
+    assert_eq!(builder.calls.len(), record_count);
+    Ok(())
+}

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/policy_rebuild.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/policy_rebuild.rs
@@ -413,6 +413,14 @@ fn flat_contract_reset_survives_both_control_handoff_crash_windows() -> Result<(
     assert!(changed.model_contract_reset_pending()?);
     drop(changed); // Crash after Flat publication and before the control handoff.
 
+    assert_eq!(
+        SemanticVectorStore::source_backed_reconciliation_contract_matches_at(
+            &fixture.semantic_path,
+            contract,
+        )?,
+        Some(false),
+        "a matching control receipt must not hide a mismatched Flat publication"
+    );
     assert!(SemanticVectorStore::open_read_only(&fixture.semantic_path, contract)?.is_none());
     let store = SemanticVectorStore::open(&fixture.semantic_path, contract)?;
     assert!(store.source_acknowledgement()?.is_none());
@@ -439,6 +447,69 @@ fn flat_contract_reset_survives_both_control_handoff_crash_windows() -> Result<(
         store.source_backed_generation_pin_exact(index.generation_id(), 3)?,
         SourceBackedGenerationPin::Ready(_)
     ));
+    Ok(())
+}
+
+#[test]
+fn matching_external_admission_excludes_contract_reset_race() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let index = fixture.publish("external-admission-race", &[(0, bodies("first", 1))])?;
+    let endpoint = "http://127.0.0.1:43129/v1/embeddings";
+    let current = external_contract(endpoint, "space-current", 6)?;
+    let replacement = external_contract(endpoint, "space-replacement", 6)?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, &current)?;
+    reconcile_all(
+        &mut store,
+        &index,
+        &mut CoreBuilder::default(),
+        &mut DimensionEmbedder::new(&current),
+    )?;
+    drop(store);
+
+    let (start_reset, await_start) = std::sync::mpsc::channel();
+    let (reset_started, await_reset_started) = std::sync::mpsc::channel();
+    let (reset_finished, await_reset_finished) = std::sync::mpsc::channel();
+    let racing_path = fixture.semantic_path.clone();
+    let racing = std::thread::spawn(move || {
+        await_start.recv().expect("receive reset start");
+        let result =
+            SemanticVectorStore::open_after_private_root_ready(&racing_path, &replacement, || {
+                reset_started.send(()).expect("report reset lock attempt")
+            })
+            .map(drop);
+        reset_finished.send(result).expect("report reset result");
+    });
+
+    let admitted =
+        SemanticVectorStore::open_source_backed_reconciliation_if_contract_matches_after_match(
+            &fixture.semantic_path,
+            &current,
+            || {
+                start_reset.send(()).expect("start competing reset");
+                await_reset_started
+                    .recv()
+                    .expect("competing reset reached writer admission");
+                assert!(
+                    await_reset_finished
+                        .recv_timeout(std::time::Duration::from_millis(100))
+                        .is_err(),
+                    "a competing contract reset must wait through matching writable admission"
+                );
+            },
+        )?;
+    assert!(admitted.is_some());
+    drop(admitted);
+    await_reset_finished
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("competing reset remained blocked")?;
+    racing.join().expect("join competing reset");
+    assert_eq!(
+        SemanticVectorStore::source_backed_reconciliation_contract_matches_at(
+            &fixture.semantic_path,
+            &current,
+        )?,
+        Some(false)
+    );
     Ok(())
 }
 

--- a/crates/ctx-semantic-index/src/vector_store_schema.rs
+++ b/crates/ctx-semantic-index/src/vector_store_schema.rs
@@ -137,6 +137,77 @@ impl SemanticVectorStore {
         Ok(store)
     }
 
+    pub(super) fn open_writable_if_matching(
+        path: &Path,
+        contract: &SemanticModelContract,
+        matches: impl FnOnce(&Self) -> Result<bool>,
+    ) -> Result<Option<Self>> {
+        Self::open_writable_if_matching_with_hook(path, contract, matches, || {})
+    }
+
+    fn open_writable_if_matching_with_hook(
+        path: &Path,
+        contract: &SemanticModelContract,
+        matches: impl FnOnce(&Self) -> Result<bool>,
+        matched: impl FnOnce(),
+    ) -> Result<Option<Self>> {
+        let path = private_fs::writable_private_root(path)?;
+        control::preflight_writable_compatibility(&path)?;
+        private_fs::create_private_dir_all(&path)?;
+        let flat_contract = flat_model_contract(contract).map_err(semantic_flat_store_error)?;
+        let (flat, coordination) = FlatSegmentStore::prepare_writable_open(&path, flat_contract)
+            .map_err(semantic_flat_store_error)?;
+        let snapshot = match Self::open_read_only(&path, contract) {
+            Ok(Some(store)) => store,
+            Ok(None) => return Ok(None),
+            Err(error)
+                if semantic_vector_failure_kind(&error)
+                    == Some(SemanticVectorFailureKind::ResetRequired) =>
+            {
+                return Ok(None);
+            }
+            Err(error) => return Err(error),
+        };
+        if !matches(&snapshot)? {
+            return Ok(None);
+        }
+        drop(snapshot);
+        matched();
+        let conn = control::open_writable(&path)?;
+        let flat = flat
+            .finish_writable_open()
+            .map_err(semantic_flat_store_error)?;
+        let store = Self {
+            conn,
+            flat,
+            contract: contract.clone(),
+            _passive_snapshot: None,
+        };
+        if store
+            .flat
+            .model_contract_reset_pending()
+            .map_err(semantic_flat_store_error)?
+        {
+            store.record_flat_model_contract_reset()?;
+            store
+                .flat
+                .acknowledge_model_contract_reset()
+                .map_err(semantic_flat_store_error)?;
+        }
+        drop(coordination);
+        Ok(Some(store))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_writable_if_matching_after_match(
+        path: &Path,
+        contract: &SemanticModelContract,
+        matches: impl FnOnce(&Self) -> Result<bool>,
+        matched: impl FnOnce(),
+    ) -> Result<Option<Self>> {
+        Self::open_writable_if_matching_with_hook(path, contract, matches, matched)
+    }
+
     #[cfg(test)]
     pub(crate) fn open_after_private_root_ready(
         path: &Path,

--- a/docs/daemon-semantic-indexing-spec.md
+++ b/docs/daemon-semantic-indexing-spec.md
@@ -22,6 +22,13 @@ When auto remains effective, ctx installs or repairs supervision and starts the
 daemon; manual mode stops it and removes supervision.
 The canonical config is `[indexing] mode = "auto"|"manual"`.
 
+After an automatic Core publication, the daemon advances opted-in semantic
+indexing through bounded durable turns until that Core generation is ready
+before running an already queued Core successor. Yielding between turns keeps
+deadline, resource, and foreground-query checks active while preventing
+continuously changing Core generations from restarting semantic work forever.
+Foreground query activity and semantic deferral or failure still let Core run.
+
 Search is an interactive read path and never becomes a duplicate importer.
 Automatic background search may start or signal the persistent daemon. Manual
 background search reads the current indexes without contacting a process;
@@ -98,11 +105,17 @@ responsibility boundary is the
 [external semantic executor contract](semantic-executors.md). This document
 owns only its daemon lifecycle integration.
 
-The daemon constructs one executor per applied configuration and uses it for
-both indexing and query embedding. Endpoint identity drift fails closed without
-falling back to E5. Rerunning `ctx semantic enable --executor URL` explicitly
-accepts the current identity; if it changed, ctx wipes and rebuilds only the
-derived semantic index. Core history and lexical generations remain intact.
+The daemon constructs one executor per applied configuration and uses it when
+indexing or a query requires embeddings. A Core generation with no eligible
+semantic events can publish its semantic acknowledgement from the selected
+configuration contract without credentials or an executor. Existing external
+state is admitted this way only when its control, Flat, and source contracts
+match under the same writer lock used for writable opening; drift still
+requires endpoint verification before reset. Endpoint identity drift fails
+closed without falling back to E5. Rerunning `ctx semantic enable --executor
+URL` explicitly accepts the current identity; if it changed, ctx wipes and
+rebuilds only the derived semantic index. Core history and lexical generations
+remain intact.
 
 Built-in semantic document indexing is throttled by default. The effective
 default is `builtin_throttling = true` even when the key is absent. An operator
@@ -192,7 +205,10 @@ executor, ctx stops the old query service and releases the old executor before
 it prepares the replacement. If replacement activation fails, ctx does not
 resume or send work to the old executor; requested intent remains visible,
 while applied semantic state and runtime ownership are inactive and the
-semantic job is not reported as enabled.
+semantic job is not reported as enabled for embedding or queries. Executor-free
+maintenance may still acknowledge an exact Core generation with no eligible
+semantic events; it cannot contact the endpoint or reset mismatched external
+state.
 
 ## Foreground Progress Commands
 


### PR DESCRIPTION
## Summary

- guarantee semantic maintenance receives bounded scheduler turns even under continuous Core refresh
- make bounded projection reconciliation restart-safe and preserve valid external vector-store state
- add regression coverage for queue pressure, restarts, zero-eligible maintenance, and writer races

## Validation

- `scripts/bazelw test //crates/ctx-daemon-service:unit_tests //crates/ctx-semantic-index:unit_tests --config=ci --test_output=errors --nocache_test_results`
- `scripts/bazel-affected.sh origin/main` (66/66 passed)

Fixes #860