### PR TITLE
refactor(telemetry): move delivery into daemon

### DIFF
--- a/contracts/telemetry-v1/README.md
+++ b/contracts/telemetry-v1/README.md
@@ -28,8 +28,8 @@ or at least seven days old; managed upgrades preserve the original timestamp.
 
 Each outbound batch contains at most 50 events. A pending capability snapshot is
 attached only to events in the first batch and is acknowledged after that batch
-is accepted by the network service or durably handed to the bounded local
-outbox. Failure of both paths leaves the claim unacknowledged.
+is durably handed to the bounded local outbox. A failed local handoff leaves the
+claim unacknowledged.
 
 `operation_completed@1` records one terminal event for an eligible operation.
 `provider_refresh_completed@1` records one completed aggregate for every
@@ -77,11 +77,28 @@ free-form failure or rewrite reasons. Exact CPU time, resident memory, worker
 counts, preparation bytes, Store receipts, and journal sizes are never
 serialized; unavailable runtime dimensions are omitted rather than inferred.
 
-Failed batch delivery uses an owner-private, cross-process-locked local outbox.
-It preserves the original serialized event IDs, binds each entry to a one-way
-endpoint fingerprint, retries at most 10 entries per delivery call, and is
-bounded to 128 entries, 2 MiB total, 512 KiB per entry, and 30 days. An explicit
-analytics opt-out removes the outbox the next time ctx opens analytics state.
+Foreground CLI and MCP producers perform no telemetry network I/O. They
+serialize each eligible event once, preserving its UUIDv4 event ID in the exact
+batch body, and durably append that body to an owner-private,
+cross-process-locked local outbox. If the persistent daemon is disabled or
+absent, entries remain local until later delivery or bounded expiry.
+
+The enabled persistent daemon is the sole network uploader. On startup, active
+wakes, and periodic cycles it briefly locks and snapshots at most 10 entries,
+releases the state lock before HTTP, then re-locks to reconcile exact outbox
+entry IDs. Only a final 2xx response removes an accepted entry. A crash after
+server acceptance therefore replays the unchanged event IDs, which the server
+treats idempotently. Network failures, HTTP 408/429, and 5xx responses retry
+under persisted capped exponential backoff with jitter; bounded `Retry-After`
+can extend that delay. Other permanent HTTP rejections are dropped. Daemon
+shutdown appends terminal events without starting another upload.
+
+Delivery failures are coalesced into one closed
+`analytics_delivery_observation@1` only after ordinary delivery recovers;
+failure to deliver that health event does not recursively create another one.
+The outbox binds each entry to a one-way endpoint fingerprint and is bounded to
+128 entries, 2 MiB total, 512 KiB per entry, and 30 days. An explicit analytics
+opt-out removes it the next time ctx opens analytics state, before any drain.
 Malformed or oversized owner-private state resets to an empty valid outbox and
-later reports one `local_io` drop; unsafe paths or permissions still fail
-closed.
+later reports one `local_io` drop after recovery; unsafe paths or permissions
+still fail closed.

--- a/crates/ctx-agent-application/tests/contracts/mcp_attribution_privacy.rs
+++ b/crates/ctx-agent-application/tests/contracts/mcp_attribution_privacy.rs
@@ -320,11 +320,18 @@ fn mcp_activity_is_searchable_but_stays_out_of_analytics_usage_and_diagnostics()
     );
     command_output_omits_canaries("progress diagnostics", &progress);
 
-    assert!(analytics_path.is_file(), "analytics sink was not exercised");
-    let analytics = fs::read(&analytics_path).unwrap();
-    assert!(!analytics.is_empty(), "analytics sink emitted no events");
-    assert_bytes_omit_canaries("analytics sink", &analytics);
-    let analytics_events = read_analytics_events(&analytics_path);
+    let analytics_outboxes = analytics_outbox_paths(temp.path());
+    assert!(
+        !analytics_outboxes.is_empty(),
+        "analytics outbox was not exercised"
+    );
+    for outbox in &analytics_outboxes {
+        assert_bytes_omit_canaries(
+            &format!("analytics outbox {}", outbox.display()),
+            &fs::read(outbox).unwrap(),
+        );
+    }
+    let analytics_events = read_queued_analytics_events(temp.path());
     assert!(analytics_events.len() >= 6, "{analytics_events:#?}");
     let operations = analytics_events
         .iter()

--- a/crates/ctx-agent-application/tests/contracts/mcp_telemetry.rs
+++ b/crates/ctx-agent-application/tests/contracts/mcp_telemetry.rs
@@ -129,7 +129,7 @@ fn mcp_telemetry_is_content_free_coalesced_and_stdout_pure() {
         .iter()
         .all(|response| response.get("jsonrpc") == Some(&json!("2.0"))));
 
-    let payloads = read_analytics_events(&events_path);
+    let payloads = read_queued_analytics_events(temp.path());
     let events = payloads
         .iter()
         .flat_map(|payload| payload["events"].as_array().unwrap())
@@ -311,6 +311,9 @@ fn mcp_opt_out_creates_no_identity_or_sink_output() {
         .stdout
         .clone();
     assert_eq!(String::from_utf8(output).unwrap().lines().count(), 2);
-    assert!(!events_path.exists());
+    assert!(
+        analytics_outbox_paths(temp.path()).is_empty(),
+        "analytics opt-out left a durable outbox behind"
+    );
     assert!(!expected_device_path(&home, &state).exists());
 }

--- a/crates/ctx-agent-application/tests/contracts/skill.rs
+++ b/crates/ctx-agent-application/tests/contracts/skill.rs
@@ -854,7 +854,7 @@ fn skill_remove_is_idempotent_preserves_siblings_and_keeps_telemetry_identifiers
         "keep sibling"
     );
 
-    let events = read_analytics_events(&analytics_path);
+    let events = read_queued_analytics_events(temp.path());
     let event = analytics_cli_event(events.last().unwrap());
     let properties = event["properties"].as_object().unwrap();
     assert_eq!(properties["integration_action"], "remove");

--- a/crates/ctx-agent-application/tests/contracts/support.rs
+++ b/crates/ctx-agent-application/tests/contracts/support.rs
@@ -25,6 +25,7 @@ pub(crate) use mcp::*;
 const BOUND_CTX_BINARY_TEST_ROOT_MARKER: &str = ".ctx-test-bound-binary";
 const READY_CTX_BINARY_TEST_ROOT_MARKER: &str = ".ctx-test-copy-ready";
 const PERSISTENT_DAEMON_TEST_ROOT_MARKER: &str = ".ctx-test-owned-daemon";
+const ANALYTICS_OUTBOX_FILE: &str = "analytics-outbox-v1.json";
 const DAEMON_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 const DAEMON_STOP_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
@@ -382,11 +383,68 @@ pub(crate) fn ctx_product_version(temp: &TempDir) -> String {
         .to_owned()
 }
 
-pub(crate) fn read_analytics_events(path: &Path) -> Vec<Value> {
-    fs::read_to_string(path)
-        .unwrap()
-        .lines()
-        .map(|line| serde_json::from_str(line).unwrap())
+pub(crate) fn analytics_outbox_paths(root: &Path) -> Vec<PathBuf> {
+    fn visit(directory: &Path, outboxes: &mut Vec<PathBuf>) {
+        let entries = fs::read_dir(directory).unwrap_or_else(|error| {
+            panic!(
+                "inspect hermetic analytics root {}: {error}",
+                directory.display()
+            )
+        });
+        for entry in entries {
+            let entry = entry.unwrap_or_else(|error| {
+                panic!(
+                    "inspect analytics entry under {}: {error}",
+                    directory.display()
+                )
+            });
+            let file_type = entry.file_type().unwrap_or_else(|error| {
+                panic!("inspect analytics path {}: {error}", entry.path().display())
+            });
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                visit(&entry.path(), outboxes);
+            } else if file_type.is_file() && entry.file_name() == ANALYTICS_OUTBOX_FILE {
+                outboxes.push(entry.path());
+            }
+        }
+    }
+
+    let mut outboxes = Vec::new();
+    if root.is_dir() {
+        visit(root, &mut outboxes);
+    }
+    outboxes.sort();
+    outboxes
+}
+
+pub(crate) fn read_queued_analytics_events(root: &Path) -> Vec<Value> {
+    analytics_outbox_paths(root)
+        .into_iter()
+        .flat_map(|outbox| {
+            let state: Value = serde_json::from_slice(&fs::read(&outbox).unwrap_or_else(|error| {
+                panic!("read analytics outbox {}: {error}", outbox.display())
+            }))
+            .unwrap_or_else(|error| panic!("parse analytics outbox {}: {error}", outbox.display()));
+            state["entries"]
+                .as_array()
+                .unwrap_or_else(|| panic!("analytics outbox has no entries array: {state:#}"))
+                .iter()
+                .map(|entry| {
+                    let payload = entry["payload"].as_str().unwrap_or_else(|| {
+                        panic!("analytics outbox entry has no JSON payload: {entry:#}")
+                    });
+                    serde_json::from_str(payload).unwrap_or_else(|error| {
+                        panic!(
+                            "parse queued analytics payload in {}: {error}",
+                            outbox.display()
+                        )
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
         .collect()
 }
 

--- a/crates/ctx-cli-contract-tests/tests/contracts/support/analytics.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/support/analytics.rs
@@ -10,6 +10,8 @@ use std::{
 
 use super::{bind_test_ctx_binary, ctx, TempDir};
 
+const ANALYTICS_OUTBOX_FILE: &str = "analytics-outbox-v1.json";
+
 pub(crate) struct SourceRefreshDaemon {
     child: Option<Child>,
 }
@@ -33,6 +35,26 @@ pub(crate) fn start_source_refresh_daemon(
     data_root: &Path,
     home: &Path,
     state: &Path,
+) -> SourceRefreshDaemon {
+    start_source_refresh_daemon_inner(temp, data_root, home, state, None)
+}
+
+pub(crate) fn start_source_refresh_daemon_with_analytics(
+    temp: &TempDir,
+    data_root: &Path,
+    home: &Path,
+    state: &Path,
+    endpoint: &str,
+) -> SourceRefreshDaemon {
+    start_source_refresh_daemon_inner(temp, data_root, home, state, Some(endpoint))
+}
+
+fn start_source_refresh_daemon_inner(
+    temp: &TempDir,
+    data_root: &Path,
+    home: &Path,
+    state: &Path,
+    analytics_endpoint: Option<&str>,
 ) -> SourceRefreshDaemon {
     fs::create_dir_all(data_root).unwrap();
     fs::write(
@@ -62,6 +84,11 @@ pub(crate) fn start_source_refresh_daemon(
         .env("CTX_DAEMON_MODE", "source-refresh-only")
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
+    if let Some(endpoint) = analytics_endpoint {
+        command
+            .env("CTX_ANALYTICS_ENABLED", "true")
+            .env("CTX_ANALYTICS_ENDPOINT", endpoint);
+    }
     let child = command
         .spawn()
         .unwrap_or_else(|error| panic!("start isolated source-refresh daemon: {error}"));
@@ -81,12 +108,17 @@ pub(crate) fn start_source_refresh_daemon(
                 .unwrap();
             panic!("source-refresh daemon exited before becoming ready ({exit}): {stderr}");
         }
-        let status = ctx(temp)
+        let mut status_command = ctx(temp);
+        status_command
             .args(["daemon", "status", "--format=json"])
             .env("CTX_DATA_ROOT", data_root)
             .env("HOME", home)
             .env("XDG_STATE_HOME", state)
-            .env("LOCALAPPDATA", state)
+            .env("LOCALAPPDATA", state);
+        if analytics_endpoint.is_some() {
+            status_command.env("CTX_ANALYTICS_DRY_RUN", "1");
+        }
+        let status = status_command
             .output()
             .ok()
             .filter(|output| output.status.success())
@@ -95,7 +127,8 @@ pub(crate) fn start_source_refresh_daemon(
             status["daemon"]["running"] == true
                 && status["daemon"]["core_refresh_endpoint"]["available"] == true
         }) {
-            ctx(temp)
+            let mut warm_import = ctx(temp);
+            warm_import
                 .args([
                     "import",
                     "--all",
@@ -107,9 +140,11 @@ pub(crate) fn start_source_refresh_daemon(
                 .env("CTX_DATA_ROOT", data_root)
                 .env("HOME", home)
                 .env("XDG_STATE_HOME", state)
-                .env("LOCALAPPDATA", state)
-                .assert()
-                .success();
+                .env("LOCALAPPDATA", state);
+            if analytics_endpoint.is_some() {
+                warm_import.env("CTX_ANALYTICS_DRY_RUN", "1");
+            }
+            warm_import.assert().success();
             return daemon;
         }
         assert!(
@@ -118,6 +153,53 @@ pub(crate) fn start_source_refresh_daemon(
         );
         std::thread::sleep(Duration::from_millis(25));
     }
+}
+
+/// Spawn the persistent source-refresh daemon with analytics enabled, without
+/// using a foreground status/import probe. The delivered sink itself is the
+/// readiness oracle for daemon-owned uploader tests.
+pub(crate) fn spawn_source_refresh_daemon_with_analytics(
+    temp: &TempDir,
+    data_root: &Path,
+    home: &Path,
+    state: &Path,
+    endpoint: &str,
+) -> SourceRefreshDaemon {
+    fs::create_dir_all(data_root).unwrap();
+    fs::write(
+        data_root.join("config.toml"),
+        "[daemon]\nenabled = true\nmode = \"source-refresh-only\"\n\n[search]\nsemantic = false\n",
+    )
+    .unwrap();
+    bind_test_ctx_binary(temp);
+    let prepared = ctx(temp);
+    let mut command = StdCommand::new(prepared.get_program());
+    for (name, value) in prepared.get_envs() {
+        match value {
+            Some(value) => {
+                command.env(name, value);
+            }
+            None => {
+                command.env_remove(name);
+            }
+        }
+    }
+    command
+        .args(["daemon", "run", "--force", "--loop-interval-seconds", "600"])
+        .env("CTX_DATA_ROOT", data_root)
+        .env("HOME", home)
+        .env("XDG_STATE_HOME", state)
+        .env("LOCALAPPDATA", state)
+        .env("CTX_ANALYTICS_ENABLED", "true")
+        .env("CTX_ANALYTICS_ENDPOINT", endpoint)
+        .env("CTX_UPGRADE_AUTO", "off")
+        .env("CTX_DAEMON_MODE", "source-refresh-only")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    let child = command
+        .spawn()
+        .unwrap_or_else(|error| panic!("start analytics source-refresh daemon: {error}"));
+    SourceRefreshDaemon { child: Some(child) }
 }
 
 pub(crate) const CAPABILITY_PROPERTY_KEYS: [&str; 5] = [
@@ -129,11 +211,135 @@ pub(crate) const CAPABILITY_PROPERTY_KEYS: [&str; 5] = [
 ];
 
 pub(crate) fn read_analytics_events(path: &Path) -> Vec<Value> {
-    fs::read_to_string(path)
-        .unwrap()
-        .lines()
+    match fs::read_to_string(path) {
+        Ok(body) => parse_analytics_sink(&body),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            read_queued_analytics_events(&hermetic_temp_root(path))
+        }
+        Err(error) => panic!("read analytics sink {}: {error}", path.display()),
+    }
+}
+
+pub(crate) fn read_delivered_analytics_events(path: &Path) -> Vec<Value> {
+    let body = fs::read_to_string(path).unwrap_or_else(|error| {
+        panic!("read delivered analytics sink {}: {error}", path.display())
+    });
+    parse_analytics_sink(&body)
+}
+
+pub(crate) fn read_analytics_operation_payloads(path: &Path) -> Vec<Value> {
+    let mut payloads = match fs::read_to_string(path) {
+        Ok(body) => parse_analytics_sink(&body),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => panic!("read analytics sink {}: {error}", path.display()),
+    };
+    payloads.extend(read_queued_analytics_events(&hermetic_temp_root(path)));
+    let mut seen = BTreeSet::new();
+    payloads
+        .into_iter()
+        .filter(|payload| {
+            payload["events"].as_array().is_some_and(|events| {
+                events.iter().any(|event| {
+                    event["event_name"] == "operation_completed" && event["surface"] == "cli"
+                })
+            })
+        })
+        .filter(|payload| seen.insert(serde_json::to_string(payload).unwrap()))
+        .collect()
+}
+
+fn parse_analytics_sink(body: &str) -> Vec<Value> {
+    body.lines()
+        .filter(|line| !line.trim().is_empty())
         .map(|line| serde_json::from_str(line).unwrap())
         .collect()
+}
+
+pub(crate) fn analytics_outbox_paths(root: &Path) -> Vec<PathBuf> {
+    fn visit(directory: &Path, outboxes: &mut Vec<PathBuf>) {
+        let entries = fs::read_dir(directory).unwrap_or_else(|error| {
+            panic!(
+                "inspect hermetic analytics root {}: {error}",
+                directory.display()
+            )
+        });
+        for entry in entries {
+            let entry = entry.unwrap_or_else(|error| {
+                panic!(
+                    "inspect analytics entry under {}: {error}",
+                    directory.display()
+                )
+            });
+            let file_type = entry.file_type().unwrap_or_else(|error| {
+                panic!("inspect analytics path {}: {error}", entry.path().display())
+            });
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                visit(&entry.path(), outboxes);
+            } else if file_type.is_file() && entry.file_name() == ANALYTICS_OUTBOX_FILE {
+                outboxes.push(entry.path());
+            }
+        }
+    }
+
+    let mut outboxes = Vec::new();
+    if root.is_dir() {
+        visit(root, &mut outboxes);
+    }
+    outboxes.sort();
+    outboxes
+}
+
+pub(crate) fn read_queued_analytics_events(root: &Path) -> Vec<Value> {
+    let mut payloads = Vec::new();
+    for outbox in analytics_outbox_paths(root) {
+        let state: Value =
+            serde_json::from_slice(&fs::read(&outbox).unwrap_or_else(|error| {
+                panic!("read analytics outbox {}: {error}", outbox.display())
+            }))
+            .unwrap_or_else(|error| panic!("parse analytics outbox {}: {error}", outbox.display()));
+        let entries = state["entries"]
+            .as_array()
+            .unwrap_or_else(|| panic!("analytics outbox has no entries array: {state:#}"));
+        for entry in entries {
+            let body = entry
+                .get("payload")
+                .or_else(|| entry.get("body"))
+                .unwrap_or_else(|| panic!("analytics outbox entry has no payload body: {entry:#}"));
+            let payload = match body {
+                Value::String(body) => serde_json::from_str(body).unwrap_or_else(|error| {
+                    panic!(
+                        "parse queued analytics payload in {}: {error}",
+                        outbox.display()
+                    )
+                }),
+                Value::Object(_) => body.clone(),
+                _ => panic!("analytics outbox payload is not JSON text: {entry:#}"),
+            };
+            payloads.push(payload);
+        }
+    }
+    payloads
+}
+
+fn hermetic_temp_root(path: &Path) -> PathBuf {
+    path.ancestors()
+        .find(|ancestor| {
+            ancestor
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("ctx-search-mvp-"))
+        })
+        .or_else(|| path.ancestors().find(|ancestor| ancestor.is_dir()))
+        .unwrap_or_else(|| {
+            panic!(
+                "analytics sink has no searchable hermetic root: {}",
+                path.display()
+            )
+        })
+        .to_path_buf()
 }
 
 pub(crate) fn analytics_event_properties(event: &Value) -> &serde_json::Map<String, Value> {
@@ -151,6 +357,23 @@ pub(crate) fn analytics_cli_event(event: &Value) -> &Value {
             })
         })
         .unwrap_or_else(|| panic!("analytics batch has no CLI operation event: {event:#}"))
+}
+
+pub(crate) fn analytics_operation_event_id(
+    payloads: &[Value],
+    operation: &str,
+) -> Option<uuid::Uuid> {
+    payloads
+        .iter()
+        .filter_map(|payload| payload["events"].as_array())
+        .flatten()
+        .find(|event| {
+            event["event_name"] == "operation_completed"
+                && event["surface"] == "cli"
+                && event["operation"] == operation
+        })
+        .and_then(|event| event["event_id"].as_str())
+        .and_then(|event_id| uuid::Uuid::parse_str(event_id).ok())
 }
 
 pub(crate) fn assert_operation_event(event: &Value, operation: &str, outcome: &str) {

--- a/crates/ctx-cli/src/analytics.rs
+++ b/crates/ctx-cli/src/analytics.rs
@@ -28,41 +28,24 @@ impl Drop for DeliveryFailureOutputGuard {
     }
 }
 
-pub(crate) fn send_batch(
-    data_root: &std::path::Path,
-    config: &ctx_app_config::AppConfig,
-    events: &[PublicEventV1],
-) {
-    send_batch_with_timeout(
-        data_root,
-        config,
-        events,
-        crate::net::TELEMETRY_HTTP_TIMEOUT,
-    );
+pub(crate) fn send_batch(data_root: &std::path::Path, events: &[PublicEventV1]) {
+    report_delivery_failure(crate::observability_composition::append_analytics_batch(
+        data_root, events,
+    ));
 }
 
-pub(crate) fn send_daemon_batch(
-    data_root: &std::path::Path,
-    config: &ctx_app_config::AppConfig,
-    events: &[PublicEventV1],
-) {
-    send_batch_with_timeout(
+pub(crate) fn send_daemon_batch(data_root: &std::path::Path, events: &[PublicEventV1]) {
+    report_delivery_failure(crate::observability_composition::append_analytics_batch(
+        data_root, events,
+    ));
+    report_delivery_failure(crate::observability_composition::drain_analytics_outbox(
         data_root,
-        config,
-        events,
         crate::net::DAEMON_TELEMETRY_HTTP_TIMEOUT,
-    );
+    ));
 }
 
-fn send_batch_with_timeout(
-    data_root: &std::path::Path,
-    config: &ctx_app_config::AppConfig,
-    events: &[PublicEventV1],
-    timeout: std::time::Duration,
-) {
-    if let Err(error) = crate::observability_composition::deliver_analytics_batch(
-        data_root, config, events, timeout,
-    ) {
+fn report_delivery_failure(result: anyhow::Result<()>) {
+    if let Err(error) = result {
         let quiet = DELIVERY_FAILURE_OUTPUT_QUIET.get();
         if !quiet && std::env::var_os("CTX_ANALYTICS_DEBUG").is_some() {
             eprintln!("ctx analytics delivery failed: {error:#}");

--- a/crates/ctx-cli/src/analytics_outbox.rs
+++ b/crates/ctx-cli/src/analytics_outbox.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     fs,
     io::{Read as _, Write as _},
     path::{Path, PathBuf},
@@ -16,20 +17,35 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest as _, Sha256};
 
-const OUTBOX_SCHEMA_VERSION: u16 = 1;
+const RELEASED_OUTBOX_SCHEMA_VERSION: u16 = 1;
+const OUTBOX_SCHEMA_VERSION: u16 = 2;
 const OUTBOX_MAX_BYTES: u64 = 2 * 1024 * 1024;
 const OUTBOX_MAX_BODY_BYTES: usize = 512 * 1024;
 const OUTBOX_MAX_ENTRIES: usize = 128;
 const OUTBOX_MAX_FLUSH_PER_CALL: usize = 10;
 const OUTBOX_MAX_AGE_SECONDS: i64 = 30 * 24 * 60 * 60;
+const RETRY_BASE_SECONDS: u64 = 5;
+const RETRY_MAX_SECONDS: u64 = 60 * 60;
+const OUTBOX_TEMP_PREFIX: &str = ".analytics-outbox-";
+const OUTBOX_TEMP_SUFFIX: &str = ".tmp";
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum OutboxEntryKind {
+    Ordinary,
+    DeliveryObservation,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct OutboxEntry {
     schema_version: u16,
+    entry_id: String,
     endpoint_fingerprint: String,
     queued_at_epoch_seconds: i64,
     attempts: u16,
+    next_attempt_at_epoch_seconds: i64,
+    kind: OutboxEntryKind,
     payload: String,
 }
 
@@ -38,6 +54,28 @@ struct OutboxEntry {
 struct OutboxState {
     schema_version: u16,
     entries: Vec<OutboxEntry>,
+    retry_attempts: u64,
+    dropped: u64,
+    failure_sequence: u64,
+    last_failure_class: Option<AnalyticsDeliveryFailureClass>,
+    observation_due: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReleasedOutboxEntryV1 {
+    schema_version: u16,
+    endpoint_fingerprint: String,
+    queued_at_epoch_seconds: i64,
+    attempts: u16,
+    payload: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReleasedOutboxStateV1 {
+    schema_version: u16,
+    entries: Vec<ReleasedOutboxEntryV1>,
     retry_attempts: u64,
     dropped: u64,
     failure_sequence: u64,
@@ -53,6 +91,7 @@ impl OutboxState {
             dropped: 0,
             failure_sequence: 0,
             last_failure_class: None,
+            observation_due: false,
         }
     }
 
@@ -64,12 +103,92 @@ impl OutboxState {
             ..Self::empty()
         }
     }
+
+    fn record_failure(&mut self, class: AnalyticsDeliveryFailureClass) {
+        self.failure_sequence = self.failure_sequence.saturating_add(1);
+        self.last_failure_class = Some(class);
+        // A later success must precede any observation that includes this
+        // failure. This also coalesces an interrupted recovery with the next
+        // one instead of reporting a failure as though it had recovered.
+        self.observation_due = false;
+    }
+
+    fn record_ordinary_drop(&mut self, class: AnalyticsDeliveryFailureClass) {
+        self.dropped = self.dropped.saturating_add(1);
+        self.record_failure(class);
+    }
+
+    fn prune_expired(&mut self, now_epoch_seconds: i64) -> bool {
+        let cutoff = now_epoch_seconds.saturating_sub(OUTBOX_MAX_AGE_SECONDS);
+        let mut ordinary_dropped = 0_u64;
+        let before = self.entries.len();
+        self.entries.retain(|entry| {
+            let keep = entry.queued_at_epoch_seconds >= cutoff;
+            if !keep && entry.kind == OutboxEntryKind::Ordinary {
+                ordinary_dropped = ordinary_dropped.saturating_add(1);
+            }
+            keep
+        });
+        if ordinary_dropped != 0 {
+            self.dropped = self.dropped.saturating_add(ordinary_dropped);
+            self.record_failure(AnalyticsDeliveryFailureClass::LocalIo);
+        }
+        self.entries.len() != before
+    }
+
+    fn normalize_timestamps(&mut self, now_epoch_seconds: i64) -> bool {
+        let latest_retry = now_epoch_seconds.saturating_add(RETRY_MAX_SECONDS as i64);
+        let mut normalized = false;
+        for entry in &mut self.entries {
+            if entry.queued_at_epoch_seconds > now_epoch_seconds {
+                entry.queued_at_epoch_seconds = now_epoch_seconds;
+                normalized = true;
+            }
+            if entry.next_attempt_at_epoch_seconds > latest_retry {
+                entry.next_attempt_at_epoch_seconds = latest_retry;
+                normalized = true;
+            }
+        }
+        if normalized {
+            self.record_failure(AnalyticsDeliveryFailureClass::LocalIo);
+        }
+        normalized
+    }
+
+    fn enforce_bounds(&mut self) -> Result<()> {
+        while self.entries.len() > OUTBOX_MAX_ENTRIES {
+            self.drop_oldest_for_bound();
+        }
+        loop {
+            let body = serde_json::to_vec(self).context("serialize analytics outbox")?;
+            if body.len() as u64 <= OUTBOX_MAX_BYTES {
+                return Ok(());
+            }
+            if self.entries.is_empty() {
+                bail!("analytics outbox metadata exceeds its size bound");
+            }
+            self.drop_oldest_for_bound();
+        }
+    }
+
+    fn drop_oldest_for_bound(&mut self) {
+        let entry = self.entries.remove(0);
+        if entry.kind == OutboxEntryKind::Ordinary {
+            self.record_ordinary_drop(AnalyticsDeliveryFailureClass::LocalIo);
+        }
+    }
+}
+
+struct LoadedState {
+    state: OutboxState,
+    dirty: bool,
+    missing: bool,
 }
 
 enum StoredOutbox {
     Missing,
     Corrupt,
-    State(OutboxState),
+    State(OutboxState, bool),
 }
 
 pub(crate) struct OutboxObservation {
@@ -79,237 +198,396 @@ pub(crate) struct OutboxObservation {
     failure_sequence: u64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum FlushStatus {
-    Available,
-    Blocked(AnalyticsDeliveryFailureClass),
+#[derive(Debug, Clone)]
+pub(crate) struct SnapshotEntry {
+    entry_id: String,
+    endpoint_fingerprint: String,
+    payload: String,
+    attempts: u16,
+    kind: OutboxEntryKind,
+}
+
+impl SnapshotEntry {
+    pub(crate) fn payload(&self) -> &[u8] {
+        self.payload.as_bytes()
+    }
+
+    fn matches(&self, entry: &OutboxEntry) -> bool {
+        entry.entry_id == self.entry_id
+            && entry.endpoint_fingerprint == self.endpoint_fingerprint
+            && entry.payload == self.payload
+            && entry.attempts == self.attempts
+            && entry.kind == self.kind
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum DeliveryDisposition {
+    Accepted,
+    Retry {
+        class: AnalyticsDeliveryFailureClass,
+        retry_after: Option<Duration>,
+    },
+    Permanent {
+        class: AnalyticsDeliveryFailureClass,
+    },
 }
 
 pub(crate) struct AnalyticsOutbox {
     path: PathBuf,
+}
+
+pub(crate) struct UploaderLease {
     _lock: OutboxLock,
-    state: OutboxState,
 }
 
 impl AnalyticsOutbox {
     pub(crate) fn open(path: PathBuf) -> Result<Self> {
+        Self::open_at(path, utc_now().timestamp())
+    }
+
+    fn open_at(path: PathBuf, now_epoch_seconds: i64) -> Result<Self> {
         let parent = path
             .parent()
-            .context("analytics outbox path has no parent")?;
-        fs::create_dir_all(parent).context("create analytics outbox directory")?;
-        let lock = OutboxLock::acquire(&path.with_extension("lock"))?;
-        let (state, recovered) = match read_state(&path)? {
-            StoredOutbox::Missing => (OutboxState::empty(), false),
-            StoredOutbox::Corrupt => (OutboxState::recovered(), true),
-            StoredOutbox::State(state) => (state, false),
-        };
-        let mut outbox = Self {
-            path,
-            _lock: lock,
-            state,
-        };
-        let recovered = recovered || outbox.recover_invalid_state();
-        if recovered || outbox.prune_expired() {
-            outbox.persist()?;
+            .context("analytics outbox path has no parent")?
+            .to_path_buf();
+        fs::create_dir_all(&parent).context("create analytics outbox directory")?;
+        let outbox = Self { path };
+        let _lock = OutboxLock::acquire(&outbox.state_lock_path())?;
+        if cleanup_orphan_temps(&parent)? {
+            sync_parent(&parent)?;
+        }
+        let loaded = outbox.load_normalized(now_epoch_seconds)?;
+        if loaded.dirty {
+            outbox.persist(&loaded.state)?;
         }
         Ok(outbox)
     }
 
     pub(crate) fn purge(path: &Path) -> Result<()> {
-        match fs::symlink_metadata(path) {
-            Ok(_) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-            Err(error) => return Err(error).context("inspect analytics outbox"),
-        }
         let Some(parent) = path.parent() else {
             bail!("analytics outbox path has no parent");
         };
-        fs::create_dir_all(parent).context("create analytics outbox directory")?;
+        match fs::symlink_metadata(parent) {
+            Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {}
+            Ok(_) => bail!("analytics outbox parent is not a safe directory"),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error).context("inspect analytics outbox directory"),
+        }
         let _lock = OutboxLock::acquire(&path.with_extension("lock"))?;
+        let mut changed = cleanup_orphan_temps(parent)?;
         match fs::remove_file(path) {
-            Ok(()) => sync_parent(parent),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(error) => Err(error).context("remove analytics outbox"),
+            Ok(()) => changed = true,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error).context("remove analytics outbox"),
+        }
+        if changed {
+            sync_parent(parent)
+        } else {
+            Ok(())
         }
     }
 
-    pub(crate) fn flush(
-        &mut self,
-        endpoint: &str,
-        mut post: impl FnMut(&[u8]) -> std::result::Result<(), AnalyticsDeliveryFailureClass>,
-    ) -> Result<FlushStatus> {
-        let fingerprint = endpoint_fingerprint(endpoint);
-        let mut index = 0;
-        let mut attempted = 0;
-        while index < self.state.entries.len() && attempted < OUTBOX_MAX_FLUSH_PER_CALL {
-            if self.state.entries[index].endpoint_fingerprint != fingerprint {
-                index += 1;
-                continue;
-            }
-            attempted += 1;
-            self.state.retry_attempts = self.state.retry_attempts.saturating_add(1);
-            self.state.entries[index].attempts =
-                self.state.entries[index].attempts.saturating_add(1);
-            let body = self.state.entries[index].payload.as_bytes().to_vec();
-            match post(&body) {
-                Ok(()) => {
-                    self.state.entries.remove(index);
-                    self.persist()?;
-                }
-                Err(class) => {
-                    self.record_failure(class);
-                    self.persist()?;
-                    return Ok(FlushStatus::Blocked(class));
-                }
-            }
-        }
-        Ok(FlushStatus::Available)
+    pub(crate) fn try_begin_upload(&self) -> Result<Option<UploaderLease>> {
+        Ok(
+            OutboxLock::try_acquire(&self.path.with_extension("uploader.lock"))?
+                .map(|lock| UploaderLease { _lock: lock }),
+        )
     }
 
-    pub(crate) fn enqueue(
-        &mut self,
-        endpoint: &str,
-        body: &[u8],
-        failure_class: AnalyticsDeliveryFailureClass,
-    ) -> Result<()> {
+    pub(crate) fn append(&self, endpoint: &str, body: &[u8]) -> Result<()> {
+        self.append_at(endpoint, body, utc_now().timestamp())
+    }
+
+    fn append_at(&self, endpoint: &str, body: &[u8], now_epoch_seconds: i64) -> Result<()> {
+        let payload = validate_payload(body)?;
+        let _lock = OutboxLock::acquire(&self.state_lock_path())?;
+        let mut loaded = self.load_normalized(now_epoch_seconds)?;
         if body.len() > OUTBOX_MAX_BODY_BYTES {
-            self.state.dropped = self.state.dropped.saturating_add(1);
-            self.record_failure(failure_class);
-            self.persist()?;
+            loaded
+                .state
+                .record_ordinary_drop(AnalyticsDeliveryFailureClass::LocalIo);
+            self.persist(&loaded.state)?;
             bail!("analytics payload exceeds the outbox body bound");
         }
-        let parsed: Value =
-            serde_json::from_slice(body).context("parse content-free analytics payload")?;
-        if !parsed.is_object() {
-            bail!("analytics outbox payload must be a JSON object");
-        }
-        let payload = std::str::from_utf8(body)
-            .context("analytics outbox payload is not UTF-8")?
-            .to_owned();
-        self.state.entries.push(OutboxEntry {
+        loaded.state.entries.push(OutboxEntry {
             schema_version: OUTBOX_SCHEMA_VERSION,
+            entry_id: uuid::Uuid::new_v4().to_string(),
             endpoint_fingerprint: endpoint_fingerprint(endpoint),
-            queued_at_epoch_seconds: utc_now().timestamp(),
+            queued_at_epoch_seconds: now_epoch_seconds,
             attempts: 0,
+            next_attempt_at_epoch_seconds: 0,
+            kind: OutboxEntryKind::Ordinary,
             payload,
         });
-        self.record_failure(failure_class);
-        self.enforce_bounds()?;
-        self.persist()
+        loaded.state.enforce_bounds()?;
+        self.persist(&loaded.state)
     }
 
-    pub(crate) fn observation(&self) -> Option<OutboxObservation> {
-        if self.state.entries.is_empty()
-            && self.state.retry_attempts == 0
-            && self.state.dropped == 0
-            && self.state.last_failure_class.is_none()
-        {
-            return None;
+    pub(crate) fn snapshot(&self, endpoint: &str) -> Result<Vec<SnapshotEntry>> {
+        self.snapshot_at(endpoint, utc_now().timestamp())
+    }
+
+    fn snapshot_at(&self, endpoint: &str, now_epoch_seconds: i64) -> Result<Vec<SnapshotEntry>> {
+        let _lock = OutboxLock::acquire(&self.state_lock_path())?;
+        let loaded = self.load_normalized(now_epoch_seconds)?;
+        if loaded.dirty {
+            self.persist(&loaded.state)?;
         }
-        let now = utc_now().timestamp();
-        let oldest_age_seconds = self
+        let fingerprint = endpoint_fingerprint(endpoint);
+        Ok(loaded
             .state
             .entries
             .iter()
-            .map(|entry| now.saturating_sub(entry.queued_at_epoch_seconds).max(0) as u64)
+            .filter(|entry| {
+                entry.endpoint_fingerprint == fingerprint
+                    && entry.next_attempt_at_epoch_seconds <= now_epoch_seconds
+            })
+            .take(OUTBOX_MAX_FLUSH_PER_CALL)
+            .map(|entry| SnapshotEntry {
+                entry_id: entry.entry_id.clone(),
+                endpoint_fingerprint: entry.endpoint_fingerprint.clone(),
+                payload: entry.payload.clone(),
+                attempts: entry.attempts,
+                kind: entry.kind,
+            })
+            .collect())
+    }
+
+    pub(crate) fn reconcile(
+        &self,
+        attempts: &[(SnapshotEntry, DeliveryDisposition)],
+    ) -> Result<()> {
+        self.reconcile_at(attempts, utc_now().timestamp())
+    }
+
+    pub(crate) fn contains_snapshot(&self, snapshot: &SnapshotEntry) -> Result<bool> {
+        let _lock = OutboxLock::acquire(&self.state_lock_path())?;
+        let loaded = self.load_normalized(utc_now().timestamp())?;
+        if loaded.dirty {
+            self.persist(&loaded.state)?;
+        }
+        Ok(!loaded.missing
+            && loaded
+                .state
+                .entries
+                .iter()
+                .any(|entry| snapshot.matches(entry)))
+    }
+
+    fn reconcile_at(
+        &self,
+        attempts: &[(SnapshotEntry, DeliveryDisposition)],
+        now_epoch_seconds: i64,
+    ) -> Result<()> {
+        if attempts.is_empty() {
+            return Ok(());
+        }
+        let _lock = OutboxLock::acquire(&self.state_lock_path())?;
+        let mut loaded = self.load_normalized(now_epoch_seconds)?;
+        if loaded.missing {
+            return Ok(());
+        }
+        for (snapshot, disposition) in attempts {
+            let Some(index) = loaded
+                .state
+                .entries
+                .iter()
+                .position(|entry| entry.entry_id == snapshot.entry_id)
+            else {
+                continue;
+            };
+            let entry = &loaded.state.entries[index];
+            if !snapshot.matches(entry) {
+                bail!("analytics outbox entry changed while delivery was in flight");
+            }
+            match *disposition {
+                DeliveryDisposition::Accepted => {
+                    let accepted = loaded.state.entries.remove(index);
+                    if accepted.kind == OutboxEntryKind::Ordinary
+                        && (loaded.state.retry_attempts != 0
+                            || loaded.state.dropped != 0
+                            || loaded.state.last_failure_class.is_some())
+                    {
+                        loaded.state.observation_due = true;
+                    }
+                }
+                DeliveryDisposition::Retry { class, retry_after } => {
+                    if snapshot.kind == OutboxEntryKind::Ordinary {
+                        loaded.state.retry_attempts = loaded.state.retry_attempts.saturating_add(1);
+                        loaded.state.record_failure(class);
+                    }
+                    let entry = &mut loaded.state.entries[index];
+                    entry.attempts = entry.attempts.saturating_add(1);
+                    let delay = retry_delay(&entry.entry_id, entry.attempts, retry_after);
+                    entry.next_attempt_at_epoch_seconds = now_epoch_seconds
+                        .saturating_add(i64::try_from(delay.as_secs()).unwrap_or(i64::MAX));
+                }
+                DeliveryDisposition::Permanent { class } => {
+                    let rejected = loaded.state.entries.remove(index);
+                    if rejected.kind == OutboxEntryKind::Ordinary {
+                        loaded.state.record_ordinary_drop(class);
+                    }
+                }
+            }
+        }
+        loaded.state.enforce_bounds()?;
+        self.persist(&loaded.state)
+    }
+
+    pub(crate) fn pending_observation(&self) -> Result<Option<OutboxObservation>> {
+        self.pending_observation_at(utc_now().timestamp())
+    }
+
+    fn pending_observation_at(&self, now_epoch_seconds: i64) -> Result<Option<OutboxObservation>> {
+        let _lock = OutboxLock::acquire(&self.state_lock_path())?;
+        let mut loaded = self.load_normalized(now_epoch_seconds)?;
+        let health_pending = loaded
+            .state
+            .entries
+            .iter()
+            .any(|entry| entry.kind == OutboxEntryKind::DeliveryObservation);
+        let has_counters = loaded.state.retry_attempts != 0
+            || loaded.state.dropped != 0
+            || loaded.state.last_failure_class.is_some();
+        if loaded.state.observation_due && !has_counters {
+            loaded.state.observation_due = false;
+            loaded.dirty = true;
+        }
+        if loaded.dirty {
+            self.persist(&loaded.state)?;
+        }
+        if !loaded.state.observation_due || health_pending || !has_counters {
+            return Ok(None);
+        }
+        let oldest_age_seconds = loaded
+            .state
+            .entries
+            .iter()
+            .filter(|entry| entry.kind == OutboxEntryKind::Ordinary)
+            .map(|entry| {
+                now_epoch_seconds
+                    .saturating_sub(entry.queued_at_epoch_seconds)
+                    .max(0) as u64
+            })
             .max()
             .unwrap_or(0);
-        Some(OutboxObservation {
+        Ok(Some(OutboxObservation {
             event: AnalyticsDeliveryObservationV1::new(
-                self.state.entries.len() as u64,
-                self.state.retry_attempts,
-                self.state.dropped,
+                loaded
+                    .state
+                    .entries
+                    .iter()
+                    .filter(|entry| entry.kind == OutboxEntryKind::Ordinary)
+                    .count() as u64,
+                loaded.state.retry_attempts,
+                loaded.state.dropped,
                 Duration::from_secs(oldest_age_seconds),
-                self.state
+                loaded
+                    .state
                     .last_failure_class
                     .unwrap_or(AnalyticsDeliveryFailureClass::None),
             ),
-            retry_attempts: self.state.retry_attempts,
-            dropped: self.state.dropped,
-            failure_sequence: self.state.failure_sequence,
-        })
+            retry_attempts: loaded.state.retry_attempts,
+            dropped: loaded.state.dropped,
+            failure_sequence: loaded.state.failure_sequence,
+        }))
     }
 
-    pub(crate) fn acknowledge(&mut self, observation: &OutboxObservation) -> Result<()> {
-        self.state.retry_attempts = self
+    pub(crate) fn queue_observation(
+        &self,
+        endpoint: &str,
+        body: &[u8],
+        observation: &OutboxObservation,
+    ) -> Result<()> {
+        self.queue_observation_at(endpoint, body, observation, utc_now().timestamp())
+    }
+
+    fn queue_observation_at(
+        &self,
+        endpoint: &str,
+        body: &[u8],
+        observation: &OutboxObservation,
+        now_epoch_seconds: i64,
+    ) -> Result<()> {
+        let payload = validate_payload(body)?;
+        if body.len() > OUTBOX_MAX_BODY_BYTES {
+            bail!("analytics delivery observation exceeds the outbox body bound");
+        }
+        let _lock = OutboxLock::acquire(&self.state_lock_path())?;
+        let mut loaded = self.load_normalized(now_epoch_seconds)?;
+        if !loaded.state.observation_due
+            || loaded
+                .state
+                .entries
+                .iter()
+                .any(|entry| entry.kind == OutboxEntryKind::DeliveryObservation)
+        {
+            return Ok(());
+        }
+        if loaded.state.retry_attempts < observation.retry_attempts
+            || loaded.state.dropped < observation.dropped
+        {
+            bail!("analytics delivery observation is stale");
+        }
+        loaded.state.entries.push(OutboxEntry {
+            schema_version: OUTBOX_SCHEMA_VERSION,
+            entry_id: uuid::Uuid::new_v4().to_string(),
+            endpoint_fingerprint: endpoint_fingerprint(endpoint),
+            queued_at_epoch_seconds: now_epoch_seconds,
+            attempts: 0,
+            next_attempt_at_epoch_seconds: 0,
+            kind: OutboxEntryKind::DeliveryObservation,
+            payload,
+        });
+        loaded.state.retry_attempts = loaded
             .state
             .retry_attempts
             .saturating_sub(observation.retry_attempts);
-        self.state.dropped = self.state.dropped.saturating_sub(observation.dropped);
-        if self.state.failure_sequence == observation.failure_sequence {
-            self.state.last_failure_class = None;
+        loaded.state.dropped = loaded.state.dropped.saturating_sub(observation.dropped);
+        if loaded.state.failure_sequence == observation.failure_sequence {
+            loaded.state.last_failure_class = None;
+            loaded.state.observation_due = false;
+        } else {
+            loaded.state.observation_due = true;
         }
-        self.persist()
+        loaded.state.enforce_bounds()?;
+        if loaded.state.failure_sequence != observation.failure_sequence {
+            loaded.state.observation_due = true;
+        }
+        self.persist(&loaded.state)
     }
 
-    fn prune_expired(&mut self) -> bool {
-        let cutoff = utc_now().timestamp().saturating_sub(OUTBOX_MAX_AGE_SECONDS);
-        let before = self.state.entries.len();
-        self.state
-            .entries
-            .retain(|entry| entry.queued_at_epoch_seconds >= cutoff);
-        let removed = before.saturating_sub(self.state.entries.len()) as u64;
-        self.state.dropped = self.state.dropped.saturating_add(removed);
-        removed != 0
+    fn state_lock_path(&self) -> PathBuf {
+        self.path.with_extension("lock")
     }
 
-    fn enforce_bounds(&mut self) -> Result<()> {
-        while self.state.entries.len() > OUTBOX_MAX_ENTRIES {
-            self.state.entries.remove(0);
-            self.state.dropped = self.state.dropped.saturating_add(1);
+    fn load_normalized(&self, now_epoch_seconds: i64) -> Result<LoadedState> {
+        let (mut state, mut dirty, missing) = match read_state(&self.path)? {
+            StoredOutbox::Missing => (OutboxState::empty(), false, true),
+            StoredOutbox::Corrupt => (OutboxState::recovered(), true, false),
+            StoredOutbox::State(state, migrated) => (state, migrated, false),
+        };
+        if validate_state(&state).is_err() {
+            state = OutboxState::recovered();
+            dirty = true;
         }
-        loop {
-            let body = serde_json::to_vec(&self.state).context("serialize analytics outbox")?;
-            if body.len() as u64 <= OUTBOX_MAX_BYTES {
-                return Ok(());
-            }
-            if self.state.entries.is_empty() {
-                bail!("analytics outbox metadata exceeds its size bound");
-            }
-            self.state.entries.remove(0);
-            self.state.dropped = self.state.dropped.saturating_add(1);
+        if state.normalize_timestamps(now_epoch_seconds) {
+            dirty = true;
         }
+        if state.prune_expired(now_epoch_seconds) {
+            dirty = true;
+        }
+        state.enforce_bounds()?;
+        Ok(LoadedState {
+            state,
+            dirty,
+            missing,
+        })
     }
 
-    fn record_failure(&mut self, class: AnalyticsDeliveryFailureClass) {
-        self.state.failure_sequence = self.state.failure_sequence.saturating_add(1);
-        self.state.last_failure_class = Some(class);
-    }
-
-    fn recover_invalid_state(&mut self) -> bool {
-        if self.validate_state().is_ok() {
-            return false;
-        }
-        self.state = OutboxState::recovered();
-        true
-    }
-
-    fn validate_state(&self) -> Result<()> {
-        if self.state.schema_version != OUTBOX_SCHEMA_VERSION {
-            bail!("unsupported analytics outbox schema");
-        }
-        if self.state.entries.len() > OUTBOX_MAX_ENTRIES {
-            bail!("analytics outbox exceeds its entry bound");
-        }
-        for entry in &self.state.entries {
-            if entry.schema_version != OUTBOX_SCHEMA_VERSION
-                || entry.endpoint_fingerprint.len() != 64
-                || !entry
-                    .endpoint_fingerprint
-                    .bytes()
-                    .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
-                || entry.payload.len() > OUTBOX_MAX_BODY_BYTES
-                || !serde_json::from_str::<Value>(&entry.payload)
-                    .is_ok_and(|value| value.is_object())
-            {
-                bail!("analytics outbox entry is invalid");
-            }
-        }
-        Ok(())
-    }
-
-    fn persist(&self) -> Result<()> {
-        let body = serde_json::to_vec(&self.state).context("serialize analytics outbox")?;
+    fn persist(&self, state: &OutboxState) -> Result<()> {
+        let body = serde_json::to_vec(state).context("serialize analytics outbox")?;
         if body.len() as u64 > OUTBOX_MAX_BYTES {
             bail!("analytics outbox exceeds its size bound");
         }
@@ -317,8 +595,71 @@ impl AnalyticsOutbox {
     }
 }
 
+fn validate_payload(body: &[u8]) -> Result<String> {
+    let parsed: Value =
+        serde_json::from_slice(body).context("parse content-free analytics payload")?;
+    if !parsed.is_object() {
+        bail!("analytics outbox payload must be a JSON object");
+    }
+    Ok(std::str::from_utf8(body)
+        .context("analytics outbox payload is not UTF-8")?
+        .to_owned())
+}
+
+fn retry_delay(entry_id: &str, attempts: u16, retry_after: Option<Duration>) -> Duration {
+    let exponent = u32::from(attempts.saturating_sub(1)).min(31);
+    let exponential = RETRY_BASE_SECONDS
+        .saturating_mul(1_u64 << exponent)
+        .min(RETRY_MAX_SECONDS);
+    let jitter_window = exponential / 2;
+    let mut hasher = Sha256::new();
+    hasher.update(entry_id.as_bytes());
+    hasher.update(attempts.to_be_bytes());
+    let digest = hasher.finalize();
+    let jitter_seed = u64::from_be_bytes(digest[..8].try_into().unwrap_or([0; 8]));
+    let jitter = jitter_seed % jitter_window.saturating_add(1);
+    let backoff = exponential.saturating_add(jitter).min(RETRY_MAX_SECONDS);
+    let retry_after = retry_after
+        .map(|value| value.as_secs().min(RETRY_MAX_SECONDS))
+        .unwrap_or(0);
+    Duration::from_secs(backoff.max(retry_after))
+}
+
 fn endpoint_fingerprint(endpoint: &str) -> String {
     format!("{:x}", Sha256::digest(endpoint.as_bytes()))
+}
+
+fn validate_state(state: &OutboxState) -> Result<()> {
+    if state.schema_version != OUTBOX_SCHEMA_VERSION {
+        bail!("unsupported analytics outbox schema");
+    }
+    if state.entries.len() > OUTBOX_MAX_ENTRIES {
+        bail!("analytics outbox exceeds its entry bound");
+    }
+    let mut ids = HashSet::with_capacity(state.entries.len());
+    let mut health_entries = 0_usize;
+    for entry in &state.entries {
+        if entry.kind == OutboxEntryKind::DeliveryObservation {
+            health_entries = health_entries.saturating_add(1);
+        }
+        if entry.schema_version != OUTBOX_SCHEMA_VERSION
+            || uuid::Uuid::parse_str(&entry.entry_id).is_err()
+            || !ids.insert(entry.entry_id.as_str())
+            || entry.endpoint_fingerprint.len() != 64
+            || !entry
+                .endpoint_fingerprint
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+            || entry.payload.len() > OUTBOX_MAX_BODY_BYTES
+            || !serde_json::from_str::<Value>(&entry.payload).is_ok_and(|value| value.is_object())
+        {
+            bail!("analytics outbox entry is invalid");
+        }
+    }
+    if health_entries > 1 {
+        bail!("analytics outbox contains multiple delivery observations");
+    }
+    Ok(())
 }
 
 fn read_state(path: &Path) -> Result<StoredOutbox> {
@@ -344,9 +685,56 @@ fn read_state(path: &Path) -> Result<StoredOutbox> {
     if body.len() as u64 > OUTBOX_MAX_BYTES {
         return Ok(StoredOutbox::Corrupt);
     }
-    Ok(match serde_json::from_slice(&body) {
-        Ok(state) => StoredOutbox::State(state),
-        Err(_) => StoredOutbox::Corrupt,
+    let Ok(value) = serde_json::from_slice::<Value>(&body) else {
+        return Ok(StoredOutbox::Corrupt);
+    };
+    let schema_version = value
+        .get("schema_version")
+        .and_then(Value::as_u64)
+        .and_then(|value| u16::try_from(value).ok());
+    match schema_version {
+        Some(OUTBOX_SCHEMA_VERSION) => Ok(serde_json::from_value(value)
+            .map(|state| StoredOutbox::State(state, false))
+            .unwrap_or(StoredOutbox::Corrupt)),
+        Some(RELEASED_OUTBOX_SCHEMA_VERSION) => Ok(serde_json::from_value(value)
+            .ok()
+            .and_then(migrate_released_v1)
+            .map(|state| StoredOutbox::State(state, true))
+            .unwrap_or(StoredOutbox::Corrupt)),
+        _ => Ok(StoredOutbox::Corrupt),
+    }
+}
+
+fn migrate_released_v1(released: ReleasedOutboxStateV1) -> Option<OutboxState> {
+    if released.schema_version != RELEASED_OUTBOX_SCHEMA_VERSION
+        || released
+            .entries
+            .iter()
+            .any(|entry| entry.schema_version != RELEASED_OUTBOX_SCHEMA_VERSION)
+    {
+        return None;
+    }
+    Some(OutboxState {
+        schema_version: OUTBOX_SCHEMA_VERSION,
+        entries: released
+            .entries
+            .into_iter()
+            .map(|entry| OutboxEntry {
+                schema_version: OUTBOX_SCHEMA_VERSION,
+                entry_id: uuid::Uuid::new_v4().to_string(),
+                endpoint_fingerprint: entry.endpoint_fingerprint,
+                queued_at_epoch_seconds: entry.queued_at_epoch_seconds,
+                attempts: entry.attempts,
+                next_attempt_at_epoch_seconds: 0,
+                kind: OutboxEntryKind::Ordinary,
+                payload: entry.payload,
+            })
+            .collect(),
+        retry_attempts: released.retry_attempts,
+        dropped: released.dropped,
+        failure_sequence: released.failure_sequence,
+        last_failure_class: released.last_failure_class,
+        observation_due: false,
     })
 }
 
@@ -354,26 +742,19 @@ struct OutboxLock(fs::File);
 
 impl OutboxLock {
     fn acquire(path: &Path) -> Result<Self> {
-        let mut options = fs::OpenOptions::new();
-        options.read(true).write(true).create(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt as _;
-            options
-                .mode(0o600)
-                .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
-        }
-        #[cfg(windows)]
-        {
-            use std::os::windows::fs::OpenOptionsExt as _;
-            const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-            options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
-        }
-        let file = options.open(path).context("open analytics outbox lock")?;
-        restrict_private_file_handle(&file).context("protect analytics outbox lock")?;
+        let file = open_lock_file(path)?;
         file.lock_exclusive()
             .context("acquire analytics outbox lock")?;
         Ok(Self(file))
+    }
+
+    fn try_acquire(path: &Path) -> Result<Option<Self>> {
+        let file = open_lock_file(path)?;
+        match file.try_lock_exclusive() {
+            Ok(()) => Ok(Some(Self(file))),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+            Err(error) => Err(error).context("acquire analytics uploader lock"),
+        }
     }
 }
 
@@ -383,11 +764,61 @@ impl Drop for OutboxLock {
     }
 }
 
+fn open_lock_file(path: &Path) -> Result<fs::File> {
+    let mut options = fs::OpenOptions::new();
+    options.read(true).write(true).create(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options
+            .mode(0o600)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt as _;
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+    let file = options.open(path).context("open analytics outbox lock")?;
+    restrict_private_file_handle(&file).context("protect analytics outbox lock")?;
+    Ok(file)
+}
+
+fn cleanup_orphan_temps(parent: &Path) -> Result<bool> {
+    let mut removed = false;
+    for entry in fs::read_dir(parent).context("inspect analytics outbox temporary files")? {
+        let entry = entry.context("inspect analytics outbox temporary entry")?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let Some(id) = name
+            .strip_prefix(OUTBOX_TEMP_PREFIX)
+            .and_then(|name| name.strip_suffix(OUTBOX_TEMP_SUFFIX))
+        else {
+            continue;
+        };
+        if uuid::Uuid::parse_str(id).is_err() {
+            continue;
+        }
+        let metadata = fs::symlink_metadata(entry.path())
+            .context("inspect analytics outbox temporary file")?;
+        if metadata.is_file() || metadata.file_type().is_symlink() {
+            fs::remove_file(entry.path()).context("remove analytics outbox temporary file")?;
+            removed = true;
+        }
+    }
+    Ok(removed)
+}
+
 fn write_private_file_durably(path: &Path, body: &[u8]) -> Result<()> {
     let parent = path
         .parent()
         .context("analytics outbox path has no parent")?;
-    let temp = parent.join(format!(".analytics-outbox-{}.tmp", uuid::Uuid::new_v4()));
+    let temp = parent.join(format!(
+        "{OUTBOX_TEMP_PREFIX}{}{OUTBOX_TEMP_SUFFIX}",
+        uuid::Uuid::new_v4()
+    ));
     let result = (|| -> Result<()> {
         let mut options = fs::OpenOptions::new();
         options.write(true).create_new(true);
@@ -465,136 +896,5 @@ fn sync_parent(_path: &Path) -> Result<()> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use ctx_client_observability::analytics::CountBucket;
-
-    fn body(event_id: &str) -> Vec<u8> {
-        serde_json::to_vec(&serde_json::json!({
-            "client_profile_id": "00000000-0000-4000-8000-000000000001",
-            "data_root_id": "00000000-0000-4000-8000-000000000002",
-            "events": [{"event_id": event_id, "properties": {}}]
-        }))
-        .unwrap()
-    }
-
-    #[test]
-    fn failed_body_retries_with_the_original_event_id() {
-        let root = tempfile::tempdir().unwrap();
-        let path = root.path().join("outbox.json");
-        let mut outbox = AnalyticsOutbox::open(path.clone()).unwrap();
-        let original = body("c220e8ef-eb0b-43d9-89c8-c64806e87d93");
-        outbox
-            .enqueue(
-                "https://cli.ctx.rs/functions/v1/analytics",
-                &original,
-                AnalyticsDeliveryFailureClass::Transport,
-            )
-            .unwrap();
-        drop(outbox);
-
-        let mut observed = Vec::new();
-        let mut reopened = AnalyticsOutbox::open(path).unwrap();
-        let status = reopened
-            .flush("https://cli.ctx.rs/functions/v1/analytics", |payload| {
-                observed.push(payload.to_vec());
-                Ok(())
-            })
-            .unwrap();
-
-        assert_eq!(status, FlushStatus::Available);
-        assert_eq!(observed, vec![original]);
-        assert_eq!(
-            reopened.observation().unwrap().event.queued,
-            ctx_client_observability::analytics::CountBucket::Zero
-        );
-    }
-
-    #[test]
-    fn endpoint_fingerprint_prevents_cross_endpoint_replay() {
-        let root = tempfile::tempdir().unwrap();
-        let path = root.path().join("outbox.json");
-        let mut outbox = AnalyticsOutbox::open(path).unwrap();
-        outbox
-            .enqueue(
-                "https://one.example.test/events",
-                &body("c220e8ef-eb0b-43d9-89c8-c64806e87d93"),
-                AnalyticsDeliveryFailureClass::Transport,
-            )
-            .unwrap();
-        let mut posts = 0;
-
-        outbox
-            .flush("https://two.example.test/events", |_| {
-                posts += 1;
-                Ok(())
-            })
-            .unwrap();
-
-        assert_eq!(posts, 0);
-        assert_eq!(outbox.state.entries.len(), 1);
-    }
-
-    #[test]
-    fn purge_removes_payload_and_does_not_create_missing_state() {
-        let root = tempfile::tempdir().unwrap();
-        let missing = root.path().join("missing").join("outbox.json");
-        AnalyticsOutbox::purge(&missing).unwrap();
-        assert!(!missing.parent().unwrap().exists());
-
-        let path = root.path().join("outbox.json");
-        let mut outbox = AnalyticsOutbox::open(path.clone()).unwrap();
-        outbox
-            .enqueue(
-                "https://cli.ctx.rs/functions/v1/analytics",
-                &body("c220e8ef-eb0b-43d9-89c8-c64806e87d93"),
-                AnalyticsDeliveryFailureClass::Transport,
-            )
-            .unwrap();
-        drop(outbox);
-        assert!(path.exists());
-
-        AnalyticsOutbox::purge(&path).unwrap();
-        assert!(!path.exists());
-    }
-
-    #[test]
-    fn corrupt_private_state_recovers_and_reports_one_safe_drop() {
-        let root = tempfile::tempdir().unwrap();
-        let path = root.path().join("outbox.json");
-        write_private_file_durably(&path, b"not-json").unwrap();
-
-        let outbox = AnalyticsOutbox::open(path.clone()).unwrap();
-        let observation = outbox.observation().unwrap().event;
-
-        assert!(outbox.state.entries.is_empty());
-        assert_eq!(observation.dropped, CountBucket::One);
-        assert_eq!(
-            observation.failure_class,
-            AnalyticsDeliveryFailureClass::LocalIo
-        );
-        assert!(serde_json::from_slice::<OutboxState>(&fs::read(path).unwrap()).is_ok());
-    }
-
-    #[test]
-    fn unsafe_state_path_still_fails_closed() {
-        let root = tempfile::tempdir().unwrap();
-        let path = root.path().join("outbox.json");
-        fs::create_dir(&path).unwrap();
-
-        assert!(AnalyticsOutbox::open(path).is_err());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn unsafe_state_permissions_still_fail_closed() {
-        use std::os::unix::fs::PermissionsExt as _;
-
-        let root = tempfile::tempdir().unwrap();
-        let path = root.path().join("outbox.json");
-        write_private_file_durably(&path, b"not-json").unwrap();
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
-
-        assert!(AnalyticsOutbox::open(path).is_err());
-    }
-}
+#[path = "analytics_outbox/tests.rs"]
+mod tests;

--- a/crates/ctx-cli/src/analytics_outbox/tests.rs
+++ b/crates/ctx-cli/src/analytics_outbox/tests.rs
@@ -1,0 +1,571 @@
+use std::{sync::mpsc, thread, time::Duration};
+
+use ctx_client_observability::analytics::CountBucket;
+
+use super::*;
+
+const ENDPOINT: &str = "https://cli.ctx.rs/functions/v1/analytics";
+const NOW: i64 = 1_800_000_000;
+
+fn body(event_id: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "client_profile_id": "00000000-0000-4000-8000-000000000001",
+        "data_root_id": "00000000-0000-4000-8000-000000000002",
+        "events": [{"event_id": event_id, "properties": {}}]
+    }))
+    .unwrap()
+}
+
+fn event_id(index: usize) -> String {
+    format!("00000000-0000-4000-8000-{index:012}")
+}
+
+fn test_outbox() -> (tempfile::TempDir, PathBuf, AnalyticsOutbox) {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("outbox.json");
+    let outbox = AnalyticsOutbox::open_at(path.clone(), NOW).unwrap();
+    (root, path, outbox)
+}
+
+fn read_v2(path: &Path) -> OutboxState {
+    serde_json::from_slice(&fs::read(path).unwrap()).unwrap()
+}
+
+fn retry(class: AnalyticsDeliveryFailureClass) -> DeliveryDisposition {
+    DeliveryDisposition::Retry {
+        class,
+        retry_after: None,
+    }
+}
+
+#[test]
+fn released_v1_migrates_without_changing_payload_or_endpoint_fingerprint() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("outbox.json");
+    let payload = "{ \"events\" : [{\"event_id\":\"preserved\"}] }";
+    let fingerprint = endpoint_fingerprint(ENDPOINT);
+    let released = serde_json::json!({
+        "schema_version": 1,
+        "entries": [{
+            "schema_version": 1,
+            "endpoint_fingerprint": fingerprint,
+            "queued_at_epoch_seconds": NOW,
+            "attempts": 3,
+            "payload": payload,
+        }],
+        "retry_attempts": 7,
+        "dropped": 2,
+        "failure_sequence": 4,
+        "last_failure_class": "transport",
+    });
+    write_private_file_durably(&path, &serde_json::to_vec(&released).unwrap()).unwrap();
+
+    let outbox = AnalyticsOutbox::open_at(path.clone(), NOW).unwrap();
+    let state = read_v2(&path);
+    let snapshot = outbox.snapshot_at(ENDPOINT, NOW).unwrap();
+
+    assert_eq!(state.schema_version, OUTBOX_SCHEMA_VERSION);
+    assert_eq!(state.entries[0].payload, payload);
+    assert_eq!(state.entries[0].endpoint_fingerprint, fingerprint);
+    assert_eq!(state.entries[0].attempts, 3);
+    assert_eq!(snapshot[0].payload(), payload.as_bytes());
+    assert!(uuid::Uuid::parse_str(&snapshot[0].entry_id).is_ok());
+}
+
+#[test]
+fn snapshot_releases_state_lock_and_uploader_lease_does_not_block_foreground_append() {
+    let (_root, path, outbox) = test_outbox();
+    outbox
+        .append_at(ENDPOINT, &body(&event_id(1)), NOW)
+        .unwrap();
+    let _uploader = outbox.try_begin_upload().unwrap().unwrap();
+    let snapshot = outbox.snapshot_at(ENDPOINT, NOW).unwrap();
+    assert_eq!(snapshot.len(), 1);
+
+    let (sent, received) = mpsc::channel();
+    let writer = thread::spawn(move || {
+        let concurrent = AnalyticsOutbox::open_at(path, NOW).unwrap();
+        concurrent
+            .append_at(ENDPOINT, &body(&event_id(2)), NOW)
+            .unwrap();
+        sent.send(()).unwrap();
+    });
+
+    received
+        .recv_timeout(Duration::from_secs(2))
+        .expect("foreground writer was blocked by an in-flight upload");
+    writer.join().unwrap();
+    assert_eq!(outbox.snapshot_at(ENDPOINT, NOW).unwrap().len(), 2);
+}
+
+#[test]
+fn uploader_mutex_is_device_global_and_nonblocking() {
+    let (_root, path, first) = test_outbox();
+    let second = AnalyticsOutbox::open_at(path, NOW).unwrap();
+    let lease = first.try_begin_upload().unwrap().unwrap();
+    assert!(second.try_begin_upload().unwrap().is_none());
+    drop(lease);
+    assert!(second.try_begin_upload().unwrap().is_some());
+}
+
+#[test]
+fn restart_replays_the_same_outbox_id_payload_and_event_id() {
+    let (_root, path, outbox) = test_outbox();
+    let original = body("c220e8ef-eb0b-43d9-89c8-c64806e87d93");
+    outbox.append_at(ENDPOINT, &original, NOW).unwrap();
+    let before = outbox.snapshot_at(ENDPOINT, NOW).unwrap().remove(0);
+    drop(outbox);
+
+    let reopened = AnalyticsOutbox::open_at(path, NOW + 1).unwrap();
+    let after = reopened.snapshot_at(ENDPOINT, NOW + 1).unwrap().remove(0);
+
+    assert_eq!(after.entry_id, before.entry_id);
+    assert_eq!(after.payload(), original);
+    assert_eq!(after.payload, before.payload);
+}
+
+#[test]
+fn crash_after_server_acceptance_replays_instead_of_guessing() {
+    let (_root, path, outbox) = test_outbox();
+    let original = body(&event_id(1));
+    outbox.append_at(ENDPOINT, &original, NOW).unwrap();
+    let accepted_but_unreconciled = outbox.snapshot_at(ENDPOINT, NOW).unwrap().remove(0);
+    drop(outbox);
+
+    let reopened = AnalyticsOutbox::open_at(path, NOW + 1).unwrap();
+    let replay = reopened.snapshot_at(ENDPOINT, NOW + 1).unwrap().remove(0);
+
+    assert_eq!(replay.entry_id, accepted_but_unreconciled.entry_id);
+    assert_eq!(replay.payload(), original);
+}
+
+#[test]
+fn exact_id_reconciliation_preserves_a_concurrent_writer() {
+    let (_root, _path, outbox) = test_outbox();
+    let first_body = body(&event_id(1));
+    let second_body = body(&event_id(2));
+    outbox.append_at(ENDPOINT, &first_body, NOW).unwrap();
+    let first = outbox.snapshot_at(ENDPOINT, NOW).unwrap().remove(0);
+    outbox.append_at(ENDPOINT, &second_body, NOW).unwrap();
+
+    outbox
+        .reconcile_at(&[(first, DeliveryDisposition::Accepted)], NOW)
+        .unwrap();
+
+    let remaining = outbox.snapshot_at(ENDPOINT, NOW).unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].payload(), second_body);
+}
+
+#[test]
+fn retry_is_retained_with_backoff_while_permanent_rejection_is_dropped() {
+    let (_root, path, outbox) = test_outbox();
+    outbox
+        .append_at(ENDPOINT, &body(&event_id(1)), NOW)
+        .unwrap();
+    outbox
+        .append_at(ENDPOINT, &body(&event_id(2)), NOW)
+        .unwrap();
+    let snapshot = outbox.snapshot_at(ENDPOINT, NOW).unwrap();
+
+    outbox
+        .reconcile_at(
+            &[
+                (
+                    snapshot[0].clone(),
+                    retry(AnalyticsDeliveryFailureClass::Transport),
+                ),
+                (
+                    snapshot[1].clone(),
+                    DeliveryDisposition::Permanent {
+                        class: AnalyticsDeliveryFailureClass::ClientRejection,
+                    },
+                ),
+            ],
+            NOW,
+        )
+        .unwrap();
+
+    let state = read_v2(&path);
+    assert_eq!(state.entries.len(), 1);
+    assert_eq!(state.entries[0].entry_id, snapshot[0].entry_id);
+    assert_eq!(state.entries[0].attempts, 1);
+    assert!(state.entries[0].next_attempt_at_epoch_seconds > NOW);
+    assert_eq!(state.retry_attempts, 1);
+    assert_eq!(state.dropped, 1);
+    assert!(outbox.snapshot_at(ENDPOINT, NOW).unwrap().is_empty());
+}
+
+#[test]
+fn exponential_backoff_and_retry_after_are_deterministic_and_capped() {
+    let id = "c220e8ef-eb0b-43d9-89c8-c64806e87d93";
+    let first = retry_delay(id, 1, None);
+    assert_eq!(first, retry_delay(id, 1, None));
+    assert!(first >= Duration::from_secs(RETRY_BASE_SECONDS));
+    assert!(first <= Duration::from_secs(RETRY_BASE_SECONDS * 3 / 2));
+    assert_eq!(
+        retry_delay(id, u16::MAX, None),
+        Duration::from_secs(RETRY_MAX_SECONDS)
+    );
+    assert_eq!(
+        retry_delay(id, 1, Some(Duration::from_secs(RETRY_MAX_SECONDS * 10))),
+        Duration::from_secs(RETRY_MAX_SECONDS)
+    );
+    assert!(retry_delay(id, 1, Some(Duration::from_secs(120))) >= Duration::from_secs(120));
+}
+
+#[test]
+fn expired_entries_are_dropped_at_the_clock_seam() {
+    let (_root, path, outbox) = test_outbox();
+    outbox
+        .append_at(ENDPOINT, &body(&event_id(1)), NOW)
+        .unwrap();
+    drop(outbox);
+
+    let reopened =
+        AnalyticsOutbox::open_at(path.clone(), NOW + OUTBOX_MAX_AGE_SECONDS + 1).unwrap();
+    let state = read_v2(&path);
+
+    assert!(reopened
+        .snapshot_at(ENDPOINT, NOW + OUTBOX_MAX_AGE_SECONDS + 1)
+        .unwrap()
+        .is_empty());
+    assert_eq!(state.dropped, 1);
+}
+
+#[test]
+fn corrupted_future_timestamps_are_bounded_and_cannot_evade_expiry() {
+    let (_root, path, outbox) = test_outbox();
+    let mut state = OutboxState::empty();
+    state.entries.push(OutboxEntry {
+        schema_version: OUTBOX_SCHEMA_VERSION,
+        entry_id: uuid::Uuid::new_v4().to_string(),
+        endpoint_fingerprint: endpoint_fingerprint(ENDPOINT),
+        queued_at_epoch_seconds: i64::MAX,
+        attempts: 1,
+        next_attempt_at_epoch_seconds: i64::MAX,
+        kind: OutboxEntryKind::Ordinary,
+        payload: String::from_utf8(body(&event_id(1))).unwrap(),
+    });
+    outbox.persist(&state).unwrap();
+    drop(outbox);
+
+    let normalized = AnalyticsOutbox::open_at(path.clone(), NOW).unwrap();
+    let state = read_v2(&path);
+    assert_eq!(state.entries[0].queued_at_epoch_seconds, NOW);
+    assert_eq!(
+        state.entries[0].next_attempt_at_epoch_seconds,
+        NOW + RETRY_MAX_SECONDS as i64
+    );
+    assert_eq!(
+        state.last_failure_class,
+        Some(AnalyticsDeliveryFailureClass::LocalIo)
+    );
+    drop(normalized);
+
+    let expired = AnalyticsOutbox::open_at(path.clone(), NOW + OUTBOX_MAX_AGE_SECONDS + 1).unwrap();
+    assert!(expired
+        .snapshot_at(ENDPOINT, NOW + OUTBOX_MAX_AGE_SECONDS + 1)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn corrupt_private_state_recovers_and_reports_one_safe_drop() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("outbox.json");
+    write_private_file_durably(&path, b"not-json").unwrap();
+
+    let outbox = AnalyticsOutbox::open_at(path.clone(), NOW).unwrap();
+    let state = read_v2(&path);
+
+    assert!(state.entries.is_empty());
+    assert_eq!(state.dropped, 1);
+    assert_eq!(
+        state.last_failure_class,
+        Some(AnalyticsDeliveryFailureClass::LocalIo)
+    );
+    assert!(outbox.pending_observation_at(NOW).unwrap().is_none());
+}
+
+#[test]
+fn count_and_total_byte_bounds_drop_oldest_entries() {
+    let (_root, path, outbox) = test_outbox();
+    let mut state = OutboxState::empty();
+    for index in 0..OUTBOX_MAX_ENTRIES {
+        state.entries.push(OutboxEntry {
+            schema_version: OUTBOX_SCHEMA_VERSION,
+            entry_id: uuid::Uuid::new_v4().to_string(),
+            endpoint_fingerprint: endpoint_fingerprint(ENDPOINT),
+            queued_at_epoch_seconds: NOW,
+            attempts: 0,
+            next_attempt_at_epoch_seconds: 0,
+            kind: OutboxEntryKind::Ordinary,
+            payload: String::from_utf8(body(&event_id(index))).unwrap(),
+        });
+    }
+    outbox.persist(&state).unwrap();
+    let oldest = state.entries[0].entry_id.clone();
+    outbox
+        .append_at(ENDPOINT, &body(&event_id(999)), NOW)
+        .unwrap();
+    let bounded = read_v2(&path);
+    assert_eq!(bounded.entries.len(), OUTBOX_MAX_ENTRIES);
+    assert!(!bounded.entries.iter().any(|entry| entry.entry_id == oldest));
+    assert_eq!(bounded.dropped, 1);
+
+    let large = serde_json::to_vec(&serde_json::json!({"padding": "x".repeat(400_000)})).unwrap();
+    for _ in 0..6 {
+        outbox.append_at(ENDPOINT, &large, NOW).unwrap();
+    }
+    assert!(fs::metadata(&path).unwrap().len() <= OUTBOX_MAX_BYTES);
+    assert!(read_v2(&path).entries.len() <= OUTBOX_MAX_ENTRIES);
+}
+
+#[test]
+fn per_entry_bound_is_enforced_and_counted() {
+    let (_root, path, outbox) = test_outbox();
+    let oversized = serde_json::to_vec(&serde_json::json!({
+        "padding": "x".repeat(OUTBOX_MAX_BODY_BYTES)
+    }))
+    .unwrap();
+    assert!(outbox.append_at(ENDPOINT, &oversized, NOW).is_err());
+    let state = read_v2(&path);
+    assert!(state.entries.is_empty());
+    assert_eq!(state.dropped, 1);
+}
+
+#[test]
+fn snapshot_is_bounded_to_ten_entries() {
+    let (_root, _path, outbox) = test_outbox();
+    for index in 0..(OUTBOX_MAX_FLUSH_PER_CALL + 2) {
+        outbox
+            .append_at(ENDPOINT, &body(&event_id(index)), NOW)
+            .unwrap();
+    }
+    assert_eq!(
+        outbox.snapshot_at(ENDPOINT, NOW).unwrap().len(),
+        OUTBOX_MAX_FLUSH_PER_CALL
+    );
+}
+
+#[test]
+fn endpoint_fingerprint_prevents_cross_endpoint_replay() {
+    let (_root, _path, outbox) = test_outbox();
+    outbox
+        .append_at(ENDPOINT, &body(&event_id(1)), NOW)
+        .unwrap();
+    assert!(outbox
+        .snapshot_at("https://other.example.test/events", NOW)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn health_is_created_only_after_retry_recovery_and_never_recurses() {
+    let (_root, path, outbox) = test_outbox();
+    outbox
+        .append_at(ENDPOINT, &body(&event_id(1)), NOW)
+        .unwrap();
+    let first = outbox.snapshot_at(ENDPOINT, NOW).unwrap().remove(0);
+    outbox
+        .reconcile_at(
+            &[(first, retry(AnalyticsDeliveryFailureClass::Server))],
+            NOW,
+        )
+        .unwrap();
+    assert!(outbox.pending_observation_at(NOW).unwrap().is_none());
+
+    let retry_at = read_v2(&path).entries[0].next_attempt_at_epoch_seconds;
+    let recovered = outbox.snapshot_at(ENDPOINT, retry_at).unwrap().remove(0);
+    outbox
+        .reconcile_at(&[(recovered, DeliveryDisposition::Accepted)], retry_at)
+        .unwrap();
+    let observation = outbox
+        .pending_observation_at(retry_at)
+        .unwrap()
+        .expect("retry recovery should authorize one health observation");
+    assert_eq!(observation.event.retry_attempts, CountBucket::One);
+
+    let health_body = serde_json::to_vec(&serde_json::json!({
+        "events": [{"event_name": "analytics_delivery_observation"}]
+    }))
+    .unwrap();
+    outbox
+        .queue_observation_at(ENDPOINT, &health_body, &observation, retry_at)
+        .unwrap();
+    let health = outbox.snapshot_at(ENDPOINT, retry_at).unwrap().remove(0);
+    assert_eq!(health.kind, OutboxEntryKind::DeliveryObservation);
+    outbox
+        .reconcile_at(
+            &[(health, retry(AnalyticsDeliveryFailureClass::Transport))],
+            retry_at,
+        )
+        .unwrap();
+
+    let state = read_v2(&path);
+    assert_eq!(state.retry_attempts, 0);
+    assert_eq!(state.dropped, 0);
+    assert!(!state.observation_due);
+    assert!(outbox.pending_observation_at(retry_at).unwrap().is_none());
+
+    let health_retry_at = state.entries[0].next_attempt_at_epoch_seconds;
+    let health = outbox
+        .snapshot_at(ENDPOINT, health_retry_at)
+        .unwrap()
+        .remove(0);
+    outbox
+        .reconcile_at(
+            &[(
+                health,
+                DeliveryDisposition::Permanent {
+                    class: AnalyticsDeliveryFailureClass::ClientRejection,
+                },
+            )],
+            health_retry_at,
+        )
+        .unwrap();
+    let state = read_v2(&path);
+    assert!(state.entries.is_empty());
+    assert_eq!(state.retry_attempts, 0);
+    assert_eq!(state.dropped, 0);
+    assert!(!state.observation_due);
+}
+
+#[test]
+fn local_drops_wait_for_a_later_success_before_health_is_due() {
+    let (_root, _path, outbox) = test_outbox();
+    let oversized = serde_json::to_vec(&serde_json::json!({
+        "padding": "x".repeat(OUTBOX_MAX_BODY_BYTES)
+    }))
+    .unwrap();
+    assert!(outbox.append_at(ENDPOINT, &oversized, NOW).is_err());
+    assert!(outbox.pending_observation_at(NOW).unwrap().is_none());
+
+    outbox
+        .append_at(ENDPOINT, &body(&event_id(1)), NOW)
+        .unwrap();
+    let delivered = outbox.snapshot_at(ENDPOINT, NOW).unwrap().remove(0);
+    outbox
+        .reconcile_at(&[(delivered, DeliveryDisposition::Accepted)], NOW)
+        .unwrap();
+
+    let observation = outbox
+        .pending_observation_at(NOW)
+        .unwrap()
+        .expect("a successful ordinary delivery should recover a local drop");
+    assert_eq!(observation.event.dropped, CountBucket::One);
+}
+
+#[test]
+fn a_later_failure_defers_coalesced_health_until_another_success() {
+    let (_root, path, outbox) = test_outbox();
+    outbox
+        .append_at(ENDPOINT, &body(&event_id(1)), NOW)
+        .unwrap();
+    outbox
+        .append_at(ENDPOINT, &body(&event_id(2)), NOW)
+        .unwrap();
+    let snapshot = outbox.snapshot_at(ENDPOINT, NOW).unwrap();
+
+    outbox
+        .reconcile_at(
+            &[
+                (snapshot[0].clone(), DeliveryDisposition::Accepted),
+                (
+                    snapshot[1].clone(),
+                    retry(AnalyticsDeliveryFailureClass::Transport),
+                ),
+            ],
+            NOW,
+        )
+        .unwrap();
+    assert!(outbox.pending_observation_at(NOW).unwrap().is_none());
+
+    let retry_at = read_v2(&path).entries[0].next_attempt_at_epoch_seconds;
+    let recovered = outbox.snapshot_at(ENDPOINT, retry_at).unwrap().remove(0);
+    outbox
+        .reconcile_at(&[(recovered, DeliveryDisposition::Accepted)], retry_at)
+        .unwrap();
+    assert!(outbox.pending_observation_at(retry_at).unwrap().is_some());
+}
+
+#[test]
+fn purge_removes_payload_and_does_not_create_missing_state() {
+    let root = tempfile::tempdir().unwrap();
+    let missing = root.path().join("missing").join("outbox.json");
+    AnalyticsOutbox::purge(&missing).unwrap();
+    assert!(!missing.parent().unwrap().exists());
+
+    let path = root.path().join("outbox.json");
+    let outbox = AnalyticsOutbox::open_at(path.clone(), NOW).unwrap();
+    outbox
+        .append_at(ENDPOINT, &body(&event_id(1)), NOW)
+        .unwrap();
+    AnalyticsOutbox::purge(&path).unwrap();
+    assert!(!path.exists());
+}
+
+#[test]
+fn open_and_purge_reclaim_crash_orphaned_temporary_payloads() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("outbox.json");
+    let orphan = root.path().join(format!(
+        "{OUTBOX_TEMP_PREFIX}{}{OUTBOX_TEMP_SUFFIX}",
+        uuid::Uuid::new_v4()
+    ));
+    fs::write(&orphan, body(&event_id(1))).unwrap();
+
+    let outbox = AnalyticsOutbox::open_at(path.clone(), NOW).unwrap();
+    assert!(!orphan.exists());
+    outbox
+        .append_at(ENDPOINT, &body(&event_id(2)), NOW)
+        .unwrap();
+    let orphan = root.path().join(format!(
+        "{OUTBOX_TEMP_PREFIX}{}{OUTBOX_TEMP_SUFFIX}",
+        uuid::Uuid::new_v4()
+    ));
+    fs::write(&orphan, body(&event_id(3))).unwrap();
+
+    AnalyticsOutbox::purge(&path).unwrap();
+
+    assert!(!path.exists());
+    assert!(!orphan.exists());
+}
+
+#[test]
+fn purge_wins_over_in_flight_reconciliation() {
+    let (_root, path, outbox) = test_outbox();
+    outbox
+        .append_at(ENDPOINT, &body(&event_id(1)), NOW)
+        .unwrap();
+    let snapshot = outbox.snapshot_at(ENDPOINT, NOW).unwrap().remove(0);
+    AnalyticsOutbox::purge(&path).unwrap();
+    assert!(!outbox.contains_snapshot(&snapshot).unwrap());
+
+    outbox
+        .reconcile_at(&[(snapshot, DeliveryDisposition::Accepted)], NOW)
+        .unwrap();
+
+    assert!(!path.exists());
+}
+
+#[test]
+fn unsafe_state_path_still_fails_closed() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("outbox.json");
+    fs::create_dir(&path).unwrap();
+    assert!(AnalyticsOutbox::open_at(path, NOW).is_err());
+}
+
+#[cfg(unix)]
+#[test]
+fn unsafe_state_permissions_still_fail_closed() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("outbox.json");
+    write_private_file_durably(&path, b"not-json").unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+    assert!(AnalyticsOutbox::open_at(path, NOW).is_err());
+}

--- a/crates/ctx-cli/src/dispatch.rs
+++ b/crates/ctx-cli/src/dispatch.rs
@@ -48,7 +48,8 @@ mod semantic_completion_error;
 mod test_support;
 
 use finalization::{
-    complete_local_usage, flush_cli_output, record_search_final_delivery, send_online_after_output,
+    complete_local_usage, flush_cli_output, record_analytics_after_output,
+    record_search_final_delivery,
 };
 use parse::parse_cli_from;
 
@@ -510,8 +511,8 @@ pub(crate) fn run_cli() -> Result<()> {
             ));
         }
     }
-    let output_result = send_online_after_output(output_result, || {
-        analytics::send_batch(&data_root, &config, &events);
+    let output_result = record_analytics_after_output(output_result, || {
+        analytics::send_batch(&data_root, &events);
     });
     if result.is_ok() {
         if let Some(trigger) = daemon_autostart_trigger {

--- a/crates/ctx-cli/src/dispatch/finalization.rs
+++ b/crates/ctx-cli/src/dispatch/finalization.rs
@@ -62,7 +62,7 @@ pub(super) fn record_search_final_delivery(
     served
 }
 
-pub(super) fn send_online_after_output(
+pub(super) fn record_analytics_after_output(
     output_result: anyhow::Result<()>,
     send: impl FnOnce(),
 ) -> anyhow::Result<()> {
@@ -98,8 +98,8 @@ mod tests {
     use clap::Parser;
 
     use super::{
-        complete_local_usage, flush_cli_output, record_search_final_delivery,
-        send_online_after_output,
+        complete_local_usage, flush_cli_output, record_analytics_after_output,
+        record_search_final_delivery,
     };
     use crate::{
         analytics::{
@@ -142,13 +142,13 @@ mod tests {
     #[test]
     fn online_delivery_precedes_output_failure_return_and_is_unchanged_on_success() {
         let sends = Cell::new(0);
-        let failure = send_online_after_output(Err(anyhow::anyhow!("output failed")), || {
+        let failure = record_analytics_after_output(Err(anyhow::anyhow!("output failed")), || {
             sends.set(sends.get() + 1);
         });
         assert!(failure.is_err());
         assert_eq!(sends.get(), 1);
 
-        send_online_after_output(Ok(()), || sends.set(sends.get() + 1)).unwrap();
+        record_analytics_after_output(Ok(()), || sends.set(sends.get() + 1)).unwrap();
         assert_eq!(sends.get(), 2);
     }
 
@@ -201,7 +201,7 @@ mod tests {
         // succeeded at the terminal boundary.
         let served = record_search_final_delivery(&mut telemetry, true, Duration::from_millis(3));
         let sends = Cell::new(0);
-        send_online_after_output(Ok(()), || sends.set(sends.get() + 1)).unwrap();
+        record_analytics_after_output(Ok(()), || sends.set(sends.get() + 1)).unwrap();
 
         assert!(!served);
         assert_eq!(telemetry.output_served, Some(false));
@@ -226,7 +226,7 @@ mod tests {
         let event = draft.finish(false, Duration::from_millis(9));
         let sent = std::cell::RefCell::new(None);
 
-        let error = send_online_after_output(
+        let error = record_analytics_after_output(
             Err(anyhow::anyhow!("flush CLI stdout: broken pipe")),
             || {
                 sent.replace(Some(event));

--- a/crates/ctx-cli/src/mcp.rs
+++ b/crates/ctx-cli/src/mcp.rs
@@ -131,21 +131,21 @@ fn product_telemetry(data_root: PathBuf) -> McpTelemetry {
     let enabled = initial_config
         .as_ref()
         .is_some_and(|config| config.analytics.enabled);
-    if let Some(config) = initial_config
+    if initial_config
         .as_ref()
-        .filter(|config| !config.analytics.enabled)
+        .is_some_and(|config| !config.analytics.enabled)
     {
-        crate::analytics::send_batch(&data_root, config, &[]);
+        crate::analytics::send_batch(&data_root, &[]);
     }
     McpTelemetry::start(enabled, move |events: &[PublicEventV1]| {
         let Ok(config) = config::AppConfig::load(&data_root) else {
             return Ok(());
         };
         if !config.analytics.enabled {
-            crate::analytics::send_batch(&data_root, &config, &[]);
+            crate::analytics::send_batch(&data_root, &[]);
             return Ok(());
         }
-        crate::analytics::send_batch(&data_root, &config, events);
+        crate::analytics::send_batch(&data_root, events);
         Ok(())
     })
 }

--- a/crates/ctx-cli/src/net.rs
+++ b/crates/ctx-cli/src/net.rs
@@ -2,7 +2,7 @@ use std::{
     fs,
     fs::OpenOptions,
     io::{Read, Seek, Write},
-    net::Ipv4Addr,
+    net::{Ipv4Addr, SocketAddr, ToSocketAddrs as _},
     path::PathBuf,
     time::{Duration, Instant},
 };
@@ -12,13 +12,58 @@ use url::{Host, Url};
 
 use crate::analytics::AnalyticsDeliveryFailureClass;
 
-pub(crate) const TELEMETRY_HTTP_TIMEOUT: Duration = Duration::from_millis(250);
+#[cfg(test)]
+const TELEMETRY_HTTP_TIMEOUT: Duration = Duration::from_millis(250);
 pub(crate) const DAEMON_TELEMETRY_HTTP_TIMEOUT: Duration = Duration::from_secs(2);
+const TELEMETRY_MAX_RETRY_AFTER: Duration = Duration::from_secs(60 * 60);
 const MAX_ARTIFACT_REDIRECTS: usize = 5;
+
+#[derive(Clone, Copy)]
+struct DeadlineResolver {
+    timeout: Duration,
+}
+
+impl ureq::Resolver for DeadlineResolver {
+    fn resolve(&self, netloc: &str) -> std::io::Result<Vec<SocketAddr>> {
+        resolve_with_timeout(netloc, self.timeout, |netloc| {
+            netloc.to_socket_addrs().map(Iterator::collect)
+        })
+    }
+}
+
+fn resolve_with_timeout<F>(
+    netloc: &str,
+    timeout: Duration,
+    resolve: F,
+) -> std::io::Result<Vec<SocketAddr>>
+where
+    F: FnOnce(&str) -> std::io::Result<Vec<SocketAddr>> + Send + 'static,
+{
+    let netloc = netloc.to_owned();
+    let (send, receive) = std::sync::mpsc::sync_channel(1);
+    std::thread::Builder::new()
+        .name("ctx-telemetry-dns".to_owned())
+        .spawn(move || {
+            let result = resolve(&netloc);
+            let _ = send.send(result);
+        })
+        .map_err(|error| std::io::Error::other(format!("start telemetry resolver: {error}")))?;
+    receive.recv_timeout(timeout).map_err(|error| match error {
+        std::sync::mpsc::RecvTimeoutError::Timeout => std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "telemetry DNS resolution timed out",
+        ),
+        std::sync::mpsc::RecvTimeoutError::Disconnected => {
+            std::io::Error::other("telemetry DNS resolver stopped without a result")
+        }
+    })?
+}
 
 #[derive(Debug)]
 pub(crate) struct TelemetryPostError {
     class: AnalyticsDeliveryFailureClass,
+    retryable: bool,
+    retry_after: Option<Duration>,
     source: anyhow::Error,
 }
 
@@ -27,9 +72,32 @@ impl TelemetryPostError {
         self.class
     }
 
-    fn new(class: AnalyticsDeliveryFailureClass, source: impl Into<anyhow::Error>) -> Self {
+    pub(crate) fn retryable(&self) -> bool {
+        self.retryable
+    }
+
+    pub(crate) fn retry_after(&self) -> Option<Duration> {
+        self.retry_after
+    }
+
+    fn permanent(class: AnalyticsDeliveryFailureClass, source: impl Into<anyhow::Error>) -> Self {
         Self {
             class,
+            retryable: false,
+            retry_after: None,
+            source: source.into(),
+        }
+    }
+
+    fn retry(
+        class: AnalyticsDeliveryFailureClass,
+        retry_after: Option<Duration>,
+        source: impl Into<anyhow::Error>,
+    ) -> Self {
+        Self {
+            class,
+            retryable: true,
+            retry_after,
             source: source.into(),
         }
     }
@@ -57,8 +125,22 @@ pub(crate) fn post_telemetry_json_with_timeout(
     body: &[u8],
     timeout: Duration,
 ) -> std::result::Result<(), TelemetryPostError> {
+    post_telemetry_json_with_timeout_at(
+        endpoint,
+        body,
+        timeout,
+        ctx_history_core::utc_now().timestamp(),
+    )
+}
+
+fn post_telemetry_json_with_timeout_at(
+    endpoint: &str,
+    body: &[u8],
+    timeout: Duration,
+    now_epoch_seconds: i64,
+) -> std::result::Result<(), TelemetryPostError> {
     let file_path = file_url_path(endpoint).map_err(|error| {
-        TelemetryPostError::new(AnalyticsDeliveryFailureClass::Configuration, error)
+        TelemetryPostError::permanent(AnalyticsDeliveryFailureClass::Configuration, error)
     })?;
     if let Some(path) = file_path {
         let mut file = OpenOptions::new()
@@ -67,45 +149,119 @@ pub(crate) fn post_telemetry_json_with_timeout(
             .open(&path)
             .with_context(|| format!("open {}", path.display()))
             .map_err(|error| {
-                TelemetryPostError::new(AnalyticsDeliveryFailureClass::LocalIo, error)
+                TelemetryPostError::retry(AnalyticsDeliveryFailureClass::LocalIo, None, error)
             })?;
         file.write_all(body).map_err(|error| {
-            TelemetryPostError::new(AnalyticsDeliveryFailureClass::LocalIo, error)
+            TelemetryPostError::retry(AnalyticsDeliveryFailureClass::LocalIo, None, error)
         })?;
         file.write_all(b"\n").map_err(|error| {
-            TelemetryPostError::new(AnalyticsDeliveryFailureClass::LocalIo, error)
+            TelemetryPostError::retry(AnalyticsDeliveryFailureClass::LocalIo, None, error)
+        })?;
+        file.flush().map_err(|error| {
+            TelemetryPostError::retry(AnalyticsDeliveryFailureClass::LocalIo, None, error)
         })?;
         return Ok(());
     }
     require_https_or_localhost(endpoint).map_err(|error| {
-        TelemetryPostError::new(AnalyticsDeliveryFailureClass::Configuration, error)
+        TelemetryPostError::permanent(AnalyticsDeliveryFailureClass::Configuration, error)
     })?;
-    let result = ureq::post(endpoint)
+    let agent = ureq::AgentBuilder::new()
+        .redirects(0)
+        .try_proxy_from_env(false)
+        .resolver(DeadlineResolver { timeout })
+        .build();
+    let response = match agent
+        .post(endpoint)
         // ureq applies this overall deadline to connection establishment too
-        // when no separate connect timeout overrides it.
+        // and carries the same deadline into response-body reads.
         .timeout(timeout)
         .set("content-type", "application/json")
-        .send_bytes(body);
-    match result {
-        Ok(_) => Ok(()),
-        Err(error) => {
-            let class = match &error {
-                ureq::Error::Status(429, _) => AnalyticsDeliveryFailureClass::RateLimited,
-                ureq::Error::Status(status, _) if (400..500).contains(status) => {
-                    AnalyticsDeliveryFailureClass::ClientRejection
-                }
-                ureq::Error::Status(status, _) if (500..600).contains(status) => {
-                    AnalyticsDeliveryFailureClass::Server
-                }
-                ureq::Error::Status(_, _) => AnalyticsDeliveryFailureClass::Unknown,
-                ureq::Error::Transport(_) => AnalyticsDeliveryFailureClass::Transport,
-            };
-            Err(TelemetryPostError::new(
-                class,
+        .send_bytes(body)
+    {
+        Ok(response) => response,
+        Err(ureq::Error::Status(_, response)) => response,
+        Err(error @ ureq::Error::Transport(_)) => {
+            return Err(TelemetryPostError::retry(
+                AnalyticsDeliveryFailureClass::Transport,
+                None,
                 anyhow!("POST {endpoint}: {error}"),
-            ))
+            ));
+        }
+    };
+    let status = response.status();
+    let retry_after = response
+        .header("retry-after")
+        .and_then(|value| parse_retry_after(value, now_epoch_seconds));
+    if let Some(error) = telemetry_status_error(endpoint, status, retry_after) {
+        return Err(error);
+    }
+    consume_telemetry_response(response).map_err(|error| {
+        TelemetryPostError::retry(
+            AnalyticsDeliveryFailureClass::Transport,
+            retry_after,
+            anyhow!("POST {endpoint}: consume response body: {error}"),
+        )
+    })?;
+    Ok(())
+}
+
+fn telemetry_status_error(
+    endpoint: &str,
+    status: u16,
+    retry_after: Option<Duration>,
+) -> Option<TelemetryPostError> {
+    match status {
+        200..=299 => None,
+        408 => Some(TelemetryPostError::retry(
+            AnalyticsDeliveryFailureClass::Transport,
+            retry_after,
+            anyhow!("POST {endpoint}: HTTP {status}"),
+        )),
+        429 => Some(TelemetryPostError::retry(
+            AnalyticsDeliveryFailureClass::RateLimited,
+            retry_after,
+            anyhow!("POST {endpoint}: HTTP {status}"),
+        )),
+        500..=599 => Some(TelemetryPostError::retry(
+            AnalyticsDeliveryFailureClass::Server,
+            retry_after,
+            anyhow!("POST {endpoint}: HTTP {status}"),
+        )),
+        400..=499 => Some(TelemetryPostError::permanent(
+            AnalyticsDeliveryFailureClass::ClientRejection,
+            anyhow!("POST {endpoint}: HTTP {status}"),
+        )),
+        _ => Some(TelemetryPostError::permanent(
+            AnalyticsDeliveryFailureClass::Unknown,
+            anyhow!("POST {endpoint}: HTTP {status}"),
+        )),
+    }
+}
+
+fn consume_telemetry_response(response: ureq::Response) -> std::io::Result<()> {
+    let mut reader = response.into_reader();
+    let mut buffer = [0_u8; 8 * 1024];
+    loop {
+        if reader.read(&mut buffer)? == 0 {
+            return Ok(());
         }
     }
+}
+
+fn parse_retry_after(value: &str, now_epoch_seconds: i64) -> Option<Duration> {
+    let value = value.trim();
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Some(Duration::from_secs(
+            seconds.min(TELEMETRY_MAX_RETRY_AFTER.as_secs()),
+        ));
+    }
+    let retry_at = chrono::DateTime::parse_from_rfc2822(value)
+        .ok()?
+        .timestamp();
+    let seconds = retry_at.saturating_sub(now_epoch_seconds).max(0) as u64;
+    Some(Duration::from_secs(
+        seconds.min(TELEMETRY_MAX_RETRY_AFTER.as_secs()),
+    ))
 }
 
 pub fn get_bytes_limited(endpoint: &str, max_bytes: usize) -> Result<Vec<u8>> {
@@ -468,9 +624,75 @@ fn is_localhost_host(host: Host<&str>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::{net::TcpListener, sync::mpsc, thread};
+    use std::{
+        io::{Read as _, Write as _},
+        net::TcpListener,
+        sync::mpsc,
+        thread,
+    };
 
     use super::*;
+
+    pub(super) fn consume_http_request(stream: &mut std::net::TcpStream) {
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 4096];
+        loop {
+            let count = stream.read(&mut buffer).unwrap();
+            assert!(count != 0, "client closed before completing its request");
+            request.extend_from_slice(&buffer[..count]);
+            assert!(request.len() <= 64 * 1024, "test request exceeded bound");
+            let Some(header_end) = request.windows(4).position(|part| part == b"\r\n\r\n") else {
+                continue;
+            };
+            let body_start = header_end + 4;
+            let headers = std::str::from_utf8(&request[..header_end]).unwrap();
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().unwrap())
+                })
+                .unwrap_or(0);
+            if request.len() >= body_start + content_length {
+                return;
+            }
+        }
+    }
+
+    fn telemetry_response(
+        status: u16,
+        retry_after: Option<&str>,
+    ) -> std::result::Result<(), TelemetryPostError> {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let retry_after = retry_after
+            .map(|value| format!("Retry-After: {value}\r\n"))
+            .unwrap_or_default();
+        let location = if (300..400).contains(&status) {
+            "Location: http://127.0.0.1/elsewhere\r\n"
+        } else {
+            ""
+        };
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            consume_http_request(&mut stream);
+            write!(
+                stream,
+                "HTTP/1.1 {status} Test\r\nContent-Length: 0\r\n{retry_after}{location}Connection: close\r\n\r\n"
+            )
+            .unwrap();
+            stream.flush().unwrap();
+        });
+        let result = post_telemetry_json_with_timeout_at(
+            &format!("http://{address}/events"),
+            b"{}",
+            Duration::from_secs(5),
+            1_800_000_000,
+        );
+        server.join().unwrap();
+        result
+    }
 
     #[test]
     fn file_urls_must_be_absolute_local_paths() {
@@ -514,6 +736,54 @@ mod tests {
                 .class(),
             AnalyticsDeliveryFailureClass::Configuration
         );
+        assert!(!post_telemetry_json("http://example.com/events", b"{}")
+            .unwrap_err()
+            .retryable());
+    }
+
+    #[test]
+    fn telemetry_statuses_distinguish_retryable_and_permanent_rejections() {
+        assert!(telemetry_response(204, None).is_ok());
+        for (status, class) in [
+            (408, AnalyticsDeliveryFailureClass::Transport),
+            (429, AnalyticsDeliveryFailureClass::RateLimited),
+            (503, AnalyticsDeliveryFailureClass::Server),
+        ] {
+            let error = telemetry_response(status, None).unwrap_err();
+            assert_eq!(error.class(), class, "HTTP {status}");
+            assert!(error.retryable(), "HTTP {status}");
+        }
+        for status in [302, 400, 401, 422] {
+            let error = telemetry_response(status, None).unwrap_err();
+            assert!(!error.retryable(), "HTTP {status}");
+        }
+    }
+
+    #[test]
+    fn retry_after_accepts_delta_and_http_date_and_clamps_both() {
+        assert_eq!(
+            parse_retry_after("120", 1_800_000_000),
+            Some(Duration::from_secs(120))
+        );
+        assert_eq!(
+            parse_retry_after("999999999999", 1_800_000_000),
+            Some(TELEMETRY_MAX_RETRY_AFTER)
+        );
+        let retry_at = chrono::DateTime::parse_from_rfc2822("Wed, 02 Sep 2026 12:01:00 GMT")
+            .unwrap()
+            .timestamp();
+        assert_eq!(
+            parse_retry_after("Wed, 02 Sep 2026 12:01:00 GMT", retry_at - 60),
+            Some(Duration::from_secs(60))
+        );
+        assert_eq!(
+            parse_retry_after("Wed, 02 Sep 2026 12:01:00 GMT", retry_at + 1),
+            Some(Duration::ZERO)
+        );
+        assert_eq!(parse_retry_after("not-a-date", 1_800_000_000), None);
+
+        let error = telemetry_response(429, Some("120")).unwrap_err();
+        assert_eq!(error.retry_after(), Some(Duration::from_secs(120)));
     }
 
     #[test]
@@ -575,6 +845,38 @@ mod tests {
             elapsed < Duration::from_secs(1),
             "telemetry request took {elapsed:?}"
         );
+    }
+
+    #[test]
+    fn telemetry_deadline_includes_response_body_consumption() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (release_tx, release_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\nConnection: close\r\n\r\nx")
+                .unwrap();
+            stream.flush().unwrap();
+            release_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        });
+
+        let started = Instant::now();
+        let error = post_telemetry_json_with_timeout(
+            &format!("http://{address}/events"),
+            b"{}",
+            Duration::from_millis(100),
+        )
+        .unwrap_err();
+        let elapsed = started.elapsed();
+        release_tx.send(()).unwrap();
+        server.join().unwrap();
+
+        assert_eq!(error.class(), AnalyticsDeliveryFailureClass::Transport);
+        assert!(error.retryable());
+        assert!(elapsed < Duration::from_secs(1), "request took {elapsed:?}");
     }
 
     #[test]
@@ -677,3 +979,7 @@ mod tests {
         assert!(fs::read(destination).unwrap().is_empty());
     }
 }
+
+#[cfg(test)]
+#[path = "net/deadline_tests.rs"]
+mod deadline_tests;

--- a/crates/ctx-cli/src/net/deadline_tests.rs
+++ b/crates/ctx-cli/src/net/deadline_tests.rs
@@ -1,0 +1,47 @@
+use super::tests::consume_http_request;
+use super::*;
+use std::{net::TcpListener, sync::mpsc, thread};
+
+#[test]
+fn telemetry_dns_resolution_obeys_the_complete_request_deadline() {
+    let started = Instant::now();
+    let error = resolve_with_timeout("blocked.example:443", Duration::from_millis(20), |_| {
+        thread::sleep(Duration::from_secs(1));
+        Ok(Vec::new())
+    })
+    .unwrap_err();
+
+    assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+    assert!(started.elapsed() < Duration::from_secs(1));
+}
+
+#[test]
+fn permanent_rejection_does_not_become_retryable_when_its_body_stalls() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let (release_tx, release_rx) = mpsc::channel();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        consume_http_request(&mut stream);
+        stream
+            .write_all(b"HTTP/1.1 422 Rejected\r\nContent-Length: 4\r\nConnection: close\r\n\r\nx")
+            .unwrap();
+        stream.flush().unwrap();
+        release_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+    });
+
+    let error = post_telemetry_json_with_timeout(
+        &format!("http://{address}/events"),
+        b"{}",
+        Duration::from_millis(100),
+    )
+    .unwrap_err();
+    release_tx.send(()).unwrap();
+    server.join().unwrap();
+
+    assert_eq!(
+        error.class(),
+        AnalyticsDeliveryFailureClass::ClientRejection
+    );
+    assert!(!error.retryable());
+}

--- a/crates/ctx-cli/src/observability_composition.rs
+++ b/crates/ctx-cli/src/observability_composition.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    analytics::{AnalyticsDeliveryAuthority, AnalyticsDeliveryFailureClass, PublicEventV1},
+    analytics::{AnalyticsDeliveryAuthority, PublicEventV1},
     local_usage::{UsageControlRevision, UsageControlSnapshot},
 };
 use ctx_app_config::{AppConfig, LocalUsageConfigResolver, LocalUsageConfigState};
@@ -24,21 +24,60 @@ const CAPABILITY_CLAIM_FILE: &str = "execution-capabilities-v1.claim";
 const CAPABILITY_REPORTED_FILE: &str = "execution-capabilities-v1.reported";
 const ANALYTICS_OUTBOX_FILE: &str = "analytics-outbox-v1.json";
 
-pub(crate) fn deliver_analytics_batch(
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AnalyticsPolicy {
+    Purge,
+    DryRun,
+    Active,
+}
+
+enum ResolvedAnalyticsPolicy {
+    Purge,
+    DryRun,
+    Active(AppConfig),
+}
+
+const fn analytics_policy_for(enabled: bool, dry_run: bool) -> AnalyticsPolicy {
+    if !enabled {
+        AnalyticsPolicy::Purge
+    } else if dry_run {
+        AnalyticsPolicy::DryRun
+    } else {
+        AnalyticsPolicy::Active
+    }
+}
+
+fn analytics_policy(config: &AppConfig) -> AnalyticsPolicy {
+    analytics_policy_for(
+        crate::analytics::effective_analytics_enabled(config),
+        std::env::var_os("CTX_ANALYTICS_DRY_RUN").is_some(),
+    )
+}
+
+fn resolve_analytics_policy(data_root: &Path) -> anyhow::Result<ResolvedAnalyticsPolicy> {
+    if ctx_app_config::normalized_analytics_environment_override() == Some(false) {
+        return Ok(ResolvedAnalyticsPolicy::Purge);
+    }
+    let config = AppConfig::load(data_root)?;
+    Ok(match analytics_policy(&config) {
+        AnalyticsPolicy::Purge => ResolvedAnalyticsPolicy::Purge,
+        AnalyticsPolicy::DryRun => ResolvedAnalyticsPolicy::DryRun,
+        AnalyticsPolicy::Active => ResolvedAnalyticsPolicy::Active(config),
+    })
+}
+
+pub(crate) fn append_analytics_batch(
     data_root: &Path,
-    config: &AppConfig,
     events: &[PublicEventV1],
-    timeout: Duration,
 ) -> anyhow::Result<()> {
-    if std::env::var_os("CTX_ANALYTICS_DRY_RUN").is_some() {
-        return Ok(());
-    }
     let outbox_path = crate::identity::device_state_path(ANALYTICS_OUTBOX_FILE, data_root)?;
-    if !config.analytics.enabled {
-        return crate::analytics_outbox::AnalyticsOutbox::purge(&outbox_path);
-    }
-    if events.is_empty() {
-        return Ok(());
+    match resolve_analytics_policy(data_root)? {
+        ResolvedAnalyticsPolicy::Purge => {
+            return crate::analytics_outbox::AnalyticsOutbox::purge(&outbox_path)
+        }
+        ResolvedAnalyticsPolicy::DryRun => return Ok(()),
+        ResolvedAnalyticsPolicy::Active(_) if events.is_empty() => return Ok(()),
+        ResolvedAnalyticsPolicy::Active(_) => {}
     }
     let client_profile_id = crate::identity::device_id(data_root)?;
     let data_root_id = crate::identity::installation_id(data_root)?;
@@ -63,61 +102,109 @@ pub(crate) fn deliver_analytics_batch(
             .map(|marker| marker.install_attempt_id.as_str()),
         capability_snapshot,
     };
-    let mut outbox = crate::analytics_outbox::AnalyticsOutbox::open(outbox_path)?;
-    let flush = outbox.flush(&config.analytics.endpoint, |body| {
-        crate::net::post_telemetry_json_with_timeout(&config.analytics.endpoint, body, timeout)
-            .map_err(|error| error.class())
-    })?;
-    let mut blocked = match flush {
-        crate::analytics_outbox::FlushStatus::Available => None,
-        crate::analytics_outbox::FlushStatus::Blocked(class) => Some(class),
+    let outbox = crate::analytics_outbox::AnalyticsOutbox::open(outbox_path.clone())?;
+    ctx_client_observability::analytics::deliver_batch(&mut authority, events, |body| {
+        match resolve_analytics_policy(data_root)? {
+            ResolvedAnalyticsPolicy::Purge => {
+                crate::analytics_outbox::AnalyticsOutbox::purge(&outbox_path)?;
+                anyhow::bail!("analytics was disabled before durable append")
+            }
+            ResolvedAnalyticsPolicy::DryRun => {
+                anyhow::bail!("analytics dry-run was enabled before durable append")
+            }
+            ResolvedAnalyticsPolicy::Active(current) => {
+                outbox.append(&current.analytics.endpoint, body)
+            }
+        }
+    })
+}
+
+pub(crate) fn drain_analytics_outbox(data_root: &Path, timeout: Duration) -> anyhow::Result<()> {
+    let outbox_path = crate::identity::device_state_path(ANALYTICS_OUTBOX_FILE, data_root)?;
+    let config = match resolve_analytics_policy(data_root)? {
+        ResolvedAnalyticsPolicy::Purge => {
+            return crate::analytics_outbox::AnalyticsOutbox::purge(&outbox_path)
+        }
+        ResolvedAnalyticsPolicy::DryRun => return Ok(()),
+        ResolvedAnalyticsPolicy::Active(config) => config,
     };
-    {
-        let mut post_or_queue = |body: &[u8]| -> anyhow::Result<()> {
-            if blocked.is_none() {
-                match crate::net::post_telemetry_json_with_timeout(
-                    &config.analytics.endpoint,
-                    body,
-                    timeout,
-                ) {
-                    Ok(()) => return Ok(()),
-                    Err(error) => blocked = Some(error.class()),
+    let outbox = crate::analytics_outbox::AnalyticsOutbox::open(outbox_path.clone())?;
+    let Some(_uploader) = outbox.try_begin_upload()? else {
+        return Ok(());
+    };
+    let snapshot = outbox.snapshot(&config.analytics.endpoint)?;
+    let mut attempted = Vec::with_capacity(snapshot.len());
+    for entry in snapshot {
+        let current = match resolve_analytics_policy(data_root)? {
+            ResolvedAnalyticsPolicy::Purge => {
+                return crate::analytics_outbox::AnalyticsOutbox::purge(&outbox_path)
+            }
+            ResolvedAnalyticsPolicy::DryRun => return Ok(()),
+            ResolvedAnalyticsPolicy::Active(current) => current,
+        };
+        if current.analytics.endpoint != config.analytics.endpoint
+            || !outbox.contains_snapshot(&entry)?
+        {
+            break;
+        }
+        let disposition = match crate::net::post_telemetry_json_with_timeout(
+            &current.analytics.endpoint,
+            entry.payload(),
+            timeout,
+        ) {
+            Ok(()) => crate::analytics_outbox::DeliveryDisposition::Accepted,
+            Err(error) if error.retryable() => {
+                crate::analytics_outbox::DeliveryDisposition::Retry {
+                    class: error.class(),
+                    retry_after: error.retry_after(),
                 }
             }
-            let class = blocked.unwrap_or(AnalyticsDeliveryFailureClass::Unknown);
-            outbox.enqueue(&config.analytics.endpoint, body, class)
+            Err(error) => crate::analytics_outbox::DeliveryDisposition::Permanent {
+                class: error.class(),
+            },
         };
-        ctx_client_observability::analytics::deliver_batch(
-            &mut authority,
-            events,
-            &mut post_or_queue,
-        )?;
-    }
-    if let Some(observation) = outbox.observation() {
-        {
-            let mut post_or_queue = |body: &[u8]| -> anyhow::Result<()> {
-                if blocked.is_none() {
-                    match crate::net::post_telemetry_json_with_timeout(
-                        &config.analytics.endpoint,
-                        body,
-                        timeout,
-                    ) {
-                        Ok(()) => return Ok(()),
-                        Err(error) => blocked = Some(error.class()),
-                    }
-                }
-                let class = blocked.unwrap_or(AnalyticsDeliveryFailureClass::Unknown);
-                outbox.enqueue(&config.analytics.endpoint, body, class)
-            };
-            ctx_client_observability::analytics::deliver_delivery_observation(
-                &authority,
-                observation.event,
-                &mut post_or_queue,
-            )?;
+        let retry_later = matches!(
+            disposition,
+            crate::analytics_outbox::DeliveryDisposition::Retry { .. }
+        );
+        attempted.push((entry, disposition));
+        if retry_later {
+            break;
         }
-        outbox.acknowledge(&observation)?;
     }
-    Ok(())
+    let config = match resolve_analytics_policy(data_root)? {
+        ResolvedAnalyticsPolicy::Purge => {
+            return crate::analytics_outbox::AnalyticsOutbox::purge(&outbox_path)
+        }
+        ResolvedAnalyticsPolicy::DryRun => return Ok(()),
+        ResolvedAnalyticsPolicy::Active(current) => current,
+    };
+    outbox.reconcile(&attempted)?;
+    queue_pending_delivery_observation(data_root, &config, &outbox)
+}
+
+fn queue_pending_delivery_observation(
+    data_root: &Path,
+    config: &AppConfig,
+    outbox: &crate::analytics_outbox::AnalyticsOutbox,
+) -> anyhow::Result<()> {
+    let Some(observation) = outbox.pending_observation()? else {
+        return Ok(());
+    };
+    let client_profile_id = crate::identity::device_id(data_root)?;
+    let data_root_id = crate::identity::installation_id(data_root)?;
+    let authority = AnalyticsDeliveryAuthority {
+        app_version: env!("CARGO_PKG_VERSION"),
+        client_profile_id: &client_profile_id,
+        data_root_id: &data_root_id,
+        install_attempt_id: None,
+        capability_snapshot: None,
+    };
+    ctx_client_observability::analytics::deliver_delivery_observation(
+        &authority,
+        observation.event,
+        |body| outbox.queue_observation(&config.analytics.endpoint, body, &observation),
+    )
 }
 
 pub(crate) const fn usage_control_snapshot(enabled: bool) -> UsageControlSnapshot {
@@ -213,7 +300,48 @@ impl LocalUsageControlAuthority {
 
 #[cfg(test)]
 mod tests {
+    use std::{ffi::OsString, fs, net::TcpListener};
+
+    use crate::analytics::{DaemonOperationV1, OperationCompletedV1, Outcome};
+
     use super::*;
+
+    struct RestoreEnvironment {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl RestoreEnvironment {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for RestoreEnvironment {
+        fn drop(&mut self) {
+            if let Some(previous) = self.previous.take() {
+                std::env::set_var(self.key, previous);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn daemon_event() -> PublicEventV1 {
+        PublicEventV1::OperationCompleted(OperationCompletedV1::for_daemon(
+            DaemonOperationV1::Status,
+            Outcome::Success,
+            Duration::ZERO,
+        ))
+    }
 
     #[test]
     fn storage_authority_grants_only_the_exact_legacy_database_path() {
@@ -222,5 +350,50 @@ mod tests {
             local_usage_storage_authority(root).database_path(),
             root.join("usage.sqlite")
         );
+    }
+
+    #[test]
+    fn opt_out_precedes_dry_run_policy() {
+        assert_eq!(analytics_policy_for(false, true), AnalyticsPolicy::Purge);
+        assert_eq!(analytics_policy_for(true, true), AnalyticsPolicy::DryRun);
+        assert_eq!(analytics_policy_for(true, false), AnalyticsPolicy::Active);
+    }
+
+    #[test]
+    fn foreground_append_opens_no_network_connection_and_dry_run_creates_no_backlog() {
+        let _env_lock = ctx_app_config::TEST_LOCAL_USAGE_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let data_root = tempfile::tempdir().unwrap();
+        let device_root = tempfile::tempdir().unwrap();
+        let _state = RestoreEnvironment::set("XDG_STATE_HOME", device_root.path());
+        let _home = RestoreEnvironment::set("HOME", device_root.path());
+        let _enabled = RestoreEnvironment::set("CTX_ANALYTICS_ENABLED", "true");
+        let _dry_run = RestoreEnvironment::remove("CTX_ANALYTICS_DRY_RUN");
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let endpoint = format!("http://{}/events", listener.local_addr().unwrap());
+        let _endpoint = RestoreEnvironment::set("CTX_ANALYTICS_ENDPOINT", &endpoint);
+        append_analytics_batch(data_root.path(), &[daemon_event()]).unwrap();
+
+        assert_eq!(
+            listener.accept().unwrap_err().kind(),
+            std::io::ErrorKind::WouldBlock
+        );
+        let path =
+            crate::identity::device_state_path(ANALYTICS_OUTBOX_FILE, data_root.path()).unwrap();
+        let outbox = crate::analytics_outbox::AnalyticsOutbox::open(path.clone()).unwrap();
+        assert_eq!(outbox.snapshot(&endpoint).unwrap().len(), 1);
+
+        let _dry_run = RestoreEnvironment::set("CTX_ANALYTICS_DRY_RUN", "1");
+        crate::analytics_outbox::AnalyticsOutbox::purge(&path).unwrap();
+        append_analytics_batch(data_root.path(), &[daemon_event()]).unwrap();
+        assert!(!path.exists());
+
+        drop(_enabled);
+        let _disabled = RestoreEnvironment::set("CTX_ANALYTICS_ENABLED", "false");
+        fs::write(&path, b"must be purged").unwrap();
+        append_analytics_batch(data_root.path(), &[daemon_event()]).unwrap();
+        assert!(!path.exists(), "opt-out must purge even during dry-run");
     }
 }

--- a/crates/ctx-cli/src/semantic.rs
+++ b/crates/ctx-cli/src/semantic.rs
@@ -533,7 +533,7 @@ impl ctx_daemon_cli::DaemonCliHost for CtxDaemonCliHost {
     fn load_config(&self, data_root: &Path) -> Result<DaemonRuntimeConfig> {
         let config = ctx_app_config::AppConfig::load(data_root)?;
         if !config.analytics.enabled {
-            crate::analytics::send_batch(data_root, &config, &[]);
+            crate::analytics::send_batch(data_root, &[]);
         }
         Ok(owned_daemon_cli_config(config))
     }
@@ -565,13 +565,11 @@ impl ctx_daemon_cli::DaemonCliHost for CtxDaemonCliHost {
     }
 
     fn deliver_daemon_events(&self, data_root: &Path, events: &[PublicEventV1]) {
-        if events.is_empty() {
-            return;
-        }
-        let Ok(config) = ctx_app_config::AppConfig::load(data_root) else {
-            return;
-        };
-        crate::analytics::send_daemon_batch(data_root, &config, events);
+        crate::analytics::send_batch(data_root, events);
+    }
+
+    fn upload_daemon_events(&self, data_root: &Path, events: &[PublicEventV1]) {
+        crate::analytics::send_daemon_batch(data_root, events);
     }
 
     fn fetch_to_writer(

--- a/crates/ctx-cli/src/semantic/tests.rs
+++ b/crates/ctx-cli/src/semantic/tests.rs
@@ -251,11 +251,18 @@ fn daemon_cli_projection_suppresses_staging_but_keeps_managed_upgrades() {
 }
 
 #[test]
-fn nonempty_daemon_observation_batch_loads_config_once() -> Result<()> {
+fn daemon_observation_delivery_rechecks_config_at_each_ownership_boundary() -> Result<()> {
     let _env_lock = ctx_app_config::TEST_LOCAL_USAGE_ENV_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let _dry_run = RestoreEnvironment::set("CTX_ANALYTICS_DRY_RUN", "1");
+    let device_root = tempfile::tempdir()?;
+    let _state = RestoreEnvironment::set("XDG_STATE_HOME", device_root.path());
+    let _home = RestoreEnvironment::set("HOME", device_root.path());
+    let _enabled = RestoreEnvironment::set("CTX_ANALYTICS_ENABLED", "true");
+    let _endpoint =
+        RestoreEnvironment::set("CTX_ANALYTICS_ENDPOINT", "http://127.0.0.1:9/telemetry");
+    let _dry_run = RestoreEnvironment::capture("CTX_ANALYTICS_DRY_RUN");
+    std::env::remove_var("CTX_ANALYTICS_DRY_RUN");
     initialize()?;
     let root = tempfile::tempdir()?;
     fs::write(
@@ -268,13 +275,17 @@ fn nonempty_daemon_observation_batch_loads_config_once() -> Result<()> {
         Duration::ZERO,
     ));
 
-    let (_, empty_loads) =
+    let (_, empty_append_loads) =
         ctx_app_config::count_app_config_loads(|| deliver_daemon_events(root.path(), &[]));
-    assert_eq!(empty_loads, 0);
+    assert_eq!(empty_append_loads, 1);
+    let (_, empty_upload_loads) = ctx_app_config::count_app_config_loads(|| {
+        ctx_daemon_cli::DaemonCliHost::upload_daemon_events(&CtxDaemonCliHost, root.path(), &[]);
+    });
+    assert_eq!(empty_upload_loads, 3);
     let (_, nonempty_loads) = ctx_app_config::count_app_config_loads(|| {
         deliver_daemon_events(root.path(), std::slice::from_ref(&event));
     });
-    assert_eq!(nonempty_loads, 1);
+    assert_eq!(nonempty_loads, 2);
     Ok(())
 }
 

--- a/crates/ctx-cli/tests/offline_default.rs
+++ b/crates/ctx-cli/tests/offline_default.rs
@@ -3,13 +3,142 @@ mod support;
 use support::*;
 
 use std::{
-    io::{Read, Write},
-    net::TcpListener,
+    io::{self, Read, Write},
+    net::{TcpListener, TcpStream},
+    path::PathBuf,
     process::{Child, Command as StdCommand, Stdio},
+    sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, TryRecvError},
+    thread::JoinHandle,
 };
 
 struct OfflineSourceRefreshDaemon {
     child: Option<Child>,
+}
+
+struct IsolatedProcessEnvironment {
+    home: PathBuf,
+    xdg_config: PathBuf,
+    xdg_data: PathBuf,
+    xdg_state: PathBuf,
+    local_app_data: PathBuf,
+}
+
+impl IsolatedProcessEnvironment {
+    fn new(root: &Path) -> Self {
+        let environment = Self {
+            home: root.join("home"),
+            xdg_config: root.join("xdg-config"),
+            xdg_data: root.join("xdg-data"),
+            xdg_state: root.join("xdg-state"),
+            local_app_data: root.join("local-app-data"),
+        };
+        for (_, path) in environment.variables() {
+            fs::create_dir_all(path).unwrap();
+        }
+        environment
+    }
+
+    fn variables(&self) -> [(&'static str, &Path); 5] {
+        [
+            ("HOME", &self.home),
+            ("XDG_CONFIG_HOME", &self.xdg_config),
+            ("XDG_DATA_HOME", &self.xdg_data),
+            ("XDG_STATE_HOME", &self.xdg_state),
+            ("LOCALAPPDATA", &self.local_app_data),
+        ]
+    }
+}
+
+struct ScriptedAnalyticsServer {
+    requests: Receiver<Result<Value, String>>,
+    stop: Option<Sender<()>>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl ScriptedAnalyticsServer {
+    fn start(listener: TcpListener) -> Self {
+        let (request_tx, requests) = mpsc::channel();
+        let (stop, stop_rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || loop {
+            match stop_rx.try_recv() {
+                Ok(()) | Err(TryRecvError::Disconnected) => break,
+                Err(TryRecvError::Empty) => {}
+            }
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let request = read_http_json_request(&mut stream);
+                    if request_tx.send(request).is_err() {
+                        break;
+                    }
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    match stop_rx.recv_timeout(Duration::from_millis(10)) {
+                        Ok(()) | Err(RecvTimeoutError::Disconnected) => break,
+                        Err(RecvTimeoutError::Timeout) => {}
+                    }
+                }
+                Err(error) => {
+                    let _ = request_tx.send(Err(format!("accept analytics request: {error}")));
+                    break;
+                }
+            }
+        });
+        Self {
+            requests,
+            stop: Some(stop),
+            worker: Some(worker),
+        }
+    }
+
+    fn wait_for_operation(
+        &self,
+        daemon: &mut OfflineSourceRefreshDaemon,
+        operation: &str,
+        expected_event_id: uuid::Uuid,
+    ) -> Value {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for daemon analytics event {expected_event_id}"
+            );
+            match self
+                .requests
+                .recv_timeout(remaining.min(Duration::from_millis(100)))
+            {
+                Ok(Ok(payload)) => {
+                    if analytics_operation_event_id(std::slice::from_ref(&payload), operation)
+                        == Some(expected_event_id)
+                    {
+                        return payload;
+                    }
+                }
+                Ok(Err(error)) => panic!("scripted analytics server failed: {error}"),
+                Err(RecvTimeoutError::Timeout) => daemon.assert_running(),
+                Err(RecvTimeoutError::Disconnected) => {
+                    panic!("scripted analytics server stopped before delivery")
+                }
+            }
+        }
+    }
+}
+
+impl Drop for ScriptedAnalyticsServer {
+    fn drop(&mut self) {
+        if let Some(stop) = self.stop.take() {
+            let _ = stop.send(());
+        }
+        if let Some(worker) = self.worker.take() {
+            if worker.join().is_err() {
+                if std::thread::panicking() {
+                    eprintln!("scripted analytics server also panicked during teardown");
+                } else {
+                    panic!("scripted analytics server panicked");
+                }
+            }
+        }
+    }
 }
 
 impl Drop for OfflineSourceRefreshDaemon {
@@ -24,6 +153,90 @@ impl Drop for OfflineSourceRefreshDaemon {
             }
         }
     }
+}
+
+impl OfflineSourceRefreshDaemon {
+    fn assert_running(&mut self) {
+        let child = self.child.as_mut().unwrap();
+        let Some(exit) = child.try_wait().unwrap() else {
+            return;
+        };
+        let mut stderr = String::new();
+        child
+            .stderr
+            .as_mut()
+            .unwrap()
+            .read_to_string(&mut stderr)
+            .unwrap();
+        panic!("source-refresh daemon exited before analytics delivery ({exit}): {stderr}");
+    }
+}
+
+fn read_http_json_request(stream: &mut TcpStream) -> Result<Value, String> {
+    let payload = read_http_json_request_body(stream)?;
+    stream
+        .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+        .map_err(|error| format!("write analytics response: {error}"))?;
+    Ok(payload)
+}
+
+fn read_http_json_request_body(stream: &mut TcpStream) -> Result<Value, String> {
+    const MAX_REQUEST_BYTES: usize = 1024 * 1024;
+
+    stream
+        .set_nonblocking(false)
+        .map_err(|error| format!("make accepted analytics stream blocking: {error}"))?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .map_err(|error| format!("set analytics request timeout: {error}"))?;
+    let mut request = Vec::new();
+    let (body_start, content_length) = loop {
+        let mut chunk = [0_u8; 4096];
+        let size = stream
+            .read(&mut chunk)
+            .map_err(|error| format!("read analytics request: {error}"))?;
+        if size == 0 {
+            return Err("analytics request ended before its headers".to_owned());
+        }
+        request.extend_from_slice(&chunk[..size]);
+        if request.len() > MAX_REQUEST_BYTES {
+            return Err("analytics request exceeded test bound".to_owned());
+        }
+        let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n") else {
+            continue;
+        };
+        let body_start = header_end + 4;
+        let headers = std::str::from_utf8(&request[..header_end])
+            .map_err(|error| format!("analytics request headers are not UTF-8: {error}"))?;
+        let content_length = headers
+            .lines()
+            .filter_map(|line| line.split_once(':'))
+            .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+            .ok_or_else(|| "analytics request omitted Content-Length".to_owned())?
+            .1
+            .trim()
+            .parse::<usize>()
+            .map_err(|error| format!("invalid analytics Content-Length: {error}"))?;
+        if body_start.saturating_add(content_length) > MAX_REQUEST_BYTES {
+            return Err("analytics request body exceeded test bound".to_owned());
+        }
+        break (body_start, content_length);
+    };
+    while request.len() < body_start + content_length {
+        let mut chunk = [0_u8; 4096];
+        let size = stream
+            .read(&mut chunk)
+            .map_err(|error| format!("read analytics request body: {error}"))?;
+        if size == 0 {
+            return Err("analytics request ended before its body".to_owned());
+        }
+        request.extend_from_slice(&chunk[..size]);
+        if request.len() > MAX_REQUEST_BYTES {
+            return Err("analytics request exceeded test bound".to_owned());
+        }
+    }
+    serde_json::from_slice(&request[body_start..body_start + content_length])
+        .map_err(|error| format!("parse analytics request body: {error}"))
 }
 
 fn write_network_endpoints(data_root: &Path, endpoint: &str, analytics_enabled: Option<bool>) {
@@ -56,6 +269,70 @@ fn local_command(temp: &TempDir, data_root: &Path) -> Command {
         .env("CTX_CLOUD_TOKEN", "stale-token")
         .env("CTX_CLOUD_API_BASE", "http://127.0.0.1:9");
     command
+}
+
+fn isolated_local_command(
+    temp: &TempDir,
+    data_root: &Path,
+    environment: &IsolatedProcessEnvironment,
+) -> Command {
+    let mut command = local_command(temp, data_root);
+    for (name, path) in environment.variables() {
+        command.env(name, path);
+    }
+    command
+}
+
+fn spawn_isolated_source_refresh_daemon(
+    temp: &TempDir,
+    data_root: &Path,
+    environment: &IsolatedProcessEnvironment,
+) -> OfflineSourceRefreshDaemon {
+    bind_test_ctx_binary(temp);
+    let prepared = isolated_local_command(temp, data_root, environment);
+    let mut command = StdCommand::new(prepared.get_program());
+    for (name, value) in prepared.get_envs() {
+        match value {
+            Some(value) => {
+                command.env(name, value);
+            }
+            None => {
+                command.env_remove(name);
+            }
+        }
+    }
+    command
+        .current_dir(temp.path())
+        .args(["daemon", "run", "--force", "--loop-interval-seconds", "600"])
+        .env("CTX_DAEMON_MODE", "source-refresh-only")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    let child = command
+        .spawn()
+        .unwrap_or_else(|error| panic!("start isolated analytics daemon: {error}"));
+    OfflineSourceRefreshDaemon { child: Some(child) }
+}
+
+fn assert_listener_received_no_connection(listener: &TcpListener, operation: &str) {
+    match listener.accept() {
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+        Ok((stream, peer)) => {
+            drop(stream);
+            panic!("foreground {operation} connected to analytics endpoint from {peer}");
+        }
+        Err(error) => panic!("inspect analytics listener after {operation}: {error}"),
+    }
+}
+
+fn assert_owner_private_outbox(path: &Path) {
+    assert!(path.is_file(), "analytics outbox is not a regular file");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode = fs::metadata(path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "analytics outbox must be owner-private");
+    }
 }
 
 fn start_offline_source_refresh_daemon(
@@ -179,30 +456,100 @@ fn local_import_status_and_daemon_are_network_inert_when_analytics_are_disabled(
 }
 
 #[test]
-fn explicit_analytics_opt_in_connects_to_configured_endpoint() {
+fn analytics_opt_in_queues_offline_and_only_the_daemon_uploads_the_same_event_id() {
     let temp = tempdir();
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
     let endpoint = format!("http://{}", listener.local_addr().unwrap());
     let data_root = temp.path().join("opted-in");
+    let environment = IsolatedProcessEnvironment::new(temp.path());
     write_network_endpoints(&data_root, &endpoint, Some(true));
 
-    let server = std::thread::spawn(move || {
-        let (mut stream, _) = listener.accept().unwrap();
-        stream
-            .set_read_timeout(Some(Duration::from_secs(5)))
-            .unwrap();
-        let mut request = [0_u8; 4096];
-        let size = stream.read(&mut request).unwrap();
-        assert!(size > 0, "analytics connection sent no request");
-        stream
-            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
-            .unwrap();
-    });
-
-    local_command(&temp, &data_root)
+    isolated_local_command(&temp, &data_root, &environment)
         .args(["doctor", "--format=json"])
         .env("CTX_UPGRADE_AUTO", "off")
         .assert()
         .success();
-    server.join().unwrap();
+    assert_listener_received_no_connection(&listener, "doctor");
+
+    let outboxes = analytics_outbox_paths(temp.path());
+    assert_eq!(outboxes.len(), 1, "expected one hermetic analytics outbox");
+    assert_owner_private_outbox(&outboxes[0]);
+    let initially_queued = read_queued_analytics_events(temp.path());
+    let doctor_event_id = analytics_operation_event_id(&initially_queued, "doctor")
+        .expect("queued doctor event must have an event ID");
+    assert_eq!(doctor_event_id.get_version_num(), 4);
+
+    isolated_local_command(&temp, &data_root, &environment)
+        .args(["daemon", "status", "--format=json"])
+        .env("CTX_UPGRADE_AUTO", "off")
+        .assert()
+        .success();
+    assert_listener_received_no_connection(&listener, "daemon status");
+    assert_eq!(
+        analytics_operation_event_id(&read_queued_analytics_events(temp.path()), "doctor"),
+        Some(doctor_event_id),
+        "a later foreground process must retain the exact queued event ID"
+    );
+    assert_owner_private_outbox(&outboxes[0]);
+
+    let server = ScriptedAnalyticsServer::start(listener);
+    let mut daemon = spawn_isolated_source_refresh_daemon(&temp, &data_root, &environment);
+    let delivered = server.wait_for_operation(&mut daemon, "doctor", doctor_event_id);
+    assert_eq!(
+        analytics_operation_event_id(std::slice::from_ref(&delivered), "doctor"),
+        Some(doctor_event_id),
+        "daemon delivery must preserve the queued UUIDv4 event ID"
+    );
+}
+
+#[test]
+fn daemon_forced_shutdown_leaves_an_in_flight_event_safely_queued() {
+    let temp = tempdir();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let endpoint = format!("http://{}", listener.local_addr().unwrap());
+    let data_root = temp.path().join("shutdown");
+    let environment = IsolatedProcessEnvironment::new(temp.path());
+    write_network_endpoints(&data_root, &endpoint, Some(true));
+
+    isolated_local_command(&temp, &data_root, &environment)
+        .args(["doctor", "--format=json"])
+        .env("CTX_UPGRADE_AUTO", "off")
+        .assert()
+        .success();
+    let queued = read_queued_analytics_events(temp.path());
+    let event_id = analytics_operation_event_id(&queued, "doctor").unwrap();
+
+    let mut daemon = spawn_isolated_source_refresh_daemon(&temp, &data_root, &environment);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let (mut in_flight, _) = loop {
+        match listener.accept() {
+            Ok(connection) => break connection,
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                daemon.assert_running();
+                assert!(
+                    Instant::now() < deadline,
+                    "timed out waiting for daemon uploader"
+                );
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) => panic!("accept daemon analytics request: {error}"),
+        }
+    };
+    let attempted = read_http_json_request_body(&mut in_flight)
+        .unwrap_or_else(|error| panic!("read in-flight daemon request: {error}"));
+    assert_eq!(
+        analytics_operation_event_id(std::slice::from_ref(&attempted), "doctor"),
+        Some(event_id)
+    );
+
+    terminate_and_reap_test_child(&mut daemon.child, "in-flight analytics daemon").unwrap();
+    drop(in_flight);
+
+    assert_eq!(
+        analytics_operation_event_id(&read_queued_analytics_events(temp.path()), "doctor"),
+        Some(event_id),
+        "an event without a complete 2xx response must survive daemon shutdown"
+    );
 }

--- a/crates/ctx-client-observability/tests/contracts/analytics.rs
+++ b/crates/ctx-client-observability/tests/contracts/analytics.rs
@@ -61,7 +61,7 @@ fn capability_snapshot_is_sent_once_after_successful_delivery() {
 }
 
 #[test]
-fn capability_snapshot_durable_queue_handoff_marks_once_and_replays() {
+fn capability_snapshot_durable_queue_handoff_marks_once_and_daemon_replays() {
     let temp = tempdir();
     let delivery_dir = temp.path().join("missing-delivery-dir");
     let events_path = delivery_dir.join("analytics.jsonl");
@@ -93,10 +93,15 @@ fn capability_snapshot_durable_queue_handoff_marks_once_and_replays() {
         !claim_path.exists(),
         "accepted delivery must clear the capability claim"
     );
+    let initially_queued = read_analytics_events(&events_path);
+    assert_eq!(initially_queued.len(), 1, "{initially_queued:#?}");
+    assert_operation_event(&initially_queued[0], "doctor", "success");
+    let doctor_event_id = analytics_operation_event_id(&initially_queued, "doctor").unwrap();
+    assert_eq!(doctor_event_id.get_version_num(), 4);
 
     fs::create_dir_all(&delivery_dir).unwrap();
     ctx(&temp)
-        .arg("doctor")
+        .args(["status", "--format=json"])
         .env("CTX_DATA_ROOT", &data_root)
         .env("HOME", &home)
         .env("XDG_STATE_HOME", &state)
@@ -107,30 +112,79 @@ fn capability_snapshot_durable_queue_handoff_marks_once_and_replays() {
         .assert()
         .success();
 
-    let events = read_analytics_events(&events_path);
-    assert_eq!(
-        events.len(),
-        4,
-        "the queued event and failure observation should replay before the current event and recovery observation"
+    assert!(
+        !events_path.exists(),
+        "a second foreground command must not drain the analytics outbox"
     );
-    let replayed_properties = analytics_event_properties(&events[0]);
-    assert_capability_snapshot_is_coarse(replayed_properties);
-    assert_analytics_properties_are_allowlisted(replayed_properties);
-
+    let queued_after_reopen = read_analytics_events(&events_path);
     assert_eq!(
-        events[1]["events"][0]["event_name"],
-        "analytics_delivery_observation"
+        analytics_operation_event_id(&queued_after_reopen, "doctor"),
+        Some(doctor_event_id),
+        "the reopened outbox must retain the exact queued event ID"
     );
-
-    let current_properties = analytics_event_properties(&events[2]);
+    let status_event_id = analytics_operation_event_id(&queued_after_reopen, "status").unwrap();
+    assert_eq!(status_event_id.get_version_num(), 4);
+    let current_properties = analytics_event_properties(
+        queued_after_reopen
+            .iter()
+            .find(|payload| {
+                analytics_operation_event_id(std::slice::from_ref(*payload), "status")
+                    == Some(status_event_id)
+            })
+            .unwrap(),
+    );
     for key in CAPABILITY_PROPERTY_KEYS {
         assert!(!current_properties.contains_key(key));
     }
     assert_analytics_properties_are_allowlisted(current_properties);
-    assert_eq!(
-        events[3]["events"][0]["event_name"],
-        "analytics_delivery_observation"
+
+    let _daemon = spawn_source_refresh_daemon_with_analytics(
+        &temp,
+        &data_root,
+        &home,
+        &state,
+        &file_url(&events_path),
     );
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let events = loop {
+        if events_path.exists() {
+            let body = fs::read_to_string(&events_path).unwrap();
+            let delivered = body
+                .lines()
+                .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+                .collect::<Vec<_>>();
+            if analytics_operation_event_id(&delivered, "doctor") == Some(doctor_event_id)
+                && analytics_operation_event_id(&delivered, "status") == Some(status_event_id)
+            {
+                break read_delivered_analytics_events(&events_path);
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for daemon-owned analytics delivery"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    };
+    assert_eq!(
+        analytics_operation_event_id(&events, "doctor"),
+        Some(doctor_event_id),
+        "daemon delivery must preserve the queued doctor event ID"
+    );
+    assert_eq!(
+        analytics_operation_event_id(&events, "status"),
+        Some(status_event_id),
+        "daemon delivery must preserve the queued status event ID"
+    );
+    let replayed = events
+        .iter()
+        .find(|payload| {
+            analytics_operation_event_id(std::slice::from_ref(*payload), "doctor")
+                == Some(doctor_event_id)
+        })
+        .unwrap();
+    let replayed_properties = analytics_event_properties(replayed);
+    assert_capability_snapshot_is_coarse(replayed_properties);
+    assert_analytics_properties_are_allowlisted(replayed_properties);
     assert!(marker_path.exists());
     assert!(!claim_path.exists());
 }
@@ -166,7 +220,7 @@ fn concurrent_invocations_claim_at_most_one_capability_snapshot() {
         assert!(child.wait().unwrap().success());
     }
 
-    let body = fs::read_to_string(&events_path).unwrap();
+    let body = serde_json::to_string(&read_analytics_events(&events_path)).unwrap();
     assert_eq!(body.matches("capability_snapshot_schema").count(), 1);
     assert!(expected_capability_marker_path(&home, &state).exists());
     assert!(!expected_capability_claim_path(&home, &state).exists());
@@ -362,7 +416,13 @@ fn import_and_index_emit_closed_safe_summaries() {
             .assert()
             .success();
     };
-    let _daemon = start_source_refresh_daemon(&temp, &data_root, &home, &state);
+    let _daemon = start_source_refresh_daemon_with_analytics(
+        &temp,
+        &data_root,
+        &home,
+        &state,
+        &file_url(&events_path),
+    );
     run(&[
         "import",
         "--provider",
@@ -381,7 +441,7 @@ fn import_and_index_emit_closed_safe_summaries() {
         "1",
     ]);
 
-    let events = read_analytics_events(&events_path);
+    let events = read_analytics_operation_payloads(&events_path);
     assert_eq!(events.len(), 2);
     assert_operation_event(&events[0], "import", "success");
     assert_operation_event(&events[1], "index", "success");
@@ -526,7 +586,13 @@ fn analytics_payloads_omit_sensitive_command_data() {
     let data_root = temp.path().join("ctx-data");
     let events_path = temp.path().join("analytics.jsonl");
     fs::create_dir_all(&home).unwrap();
-    let _daemon = start_source_refresh_daemon(&temp, &data_root, &home, &state);
+    let _daemon = start_source_refresh_daemon_with_analytics(
+        &temp,
+        &data_root,
+        &home,
+        &state,
+        &file_url(&events_path),
+    );
     assert!(data_root.join("search/lexical").is_dir());
     assert!(!data_root.join("work.sqlite").exists());
     let private_query = "prompt text source-body-secret /home/alice/private/acme-secret \
@@ -583,7 +649,7 @@ fn analytics_payloads_omit_sensitive_command_data() {
         .assert()
         .failure();
 
-    let events = read_analytics_events(&events_path);
+    let events = read_analytics_operation_payloads(&events_path);
     assert_eq!(events.len(), 4);
     let operations = events
         .iter()
@@ -659,7 +725,13 @@ fn search_analytics_reports_empty_source_backed_generation() {
     let data_root = temp.path().join("ctx-data");
     let events_path = temp.path().join("analytics.jsonl");
     fs::create_dir_all(&home).unwrap();
-    let _daemon = start_source_refresh_daemon(&temp, &data_root, &home, &state);
+    let _daemon = start_source_refresh_daemon_with_analytics(
+        &temp,
+        &data_root,
+        &home,
+        &state,
+        &file_url(&events_path),
+    );
 
     ctx(&temp)
         .args(["search", "activation telemetry", "--refresh", "off"])
@@ -673,7 +745,7 @@ fn search_analytics_reports_empty_source_backed_generation() {
         .assert()
         .success();
 
-    let events = read_analytics_events(&events_path);
+    let events = read_analytics_operation_payloads(&events_path);
     assert_eq!(events.len(), 1);
     assert_operation_event(&events[0], "search", "success");
     let properties = analytics_event_properties(&events[0]);
@@ -696,7 +768,13 @@ fn search_analytics_reports_existing_indexed_content() {
     let events_path = temp.path().join("analytics.jsonl");
     fs::create_dir_all(&home).unwrap();
     let fixture = provider_history_fixture("codex-sessions");
-    let _daemon = start_source_refresh_daemon(&temp, &data_root, &home, &state);
+    let _daemon = start_source_refresh_daemon_with_analytics(
+        &temp,
+        &data_root,
+        &home,
+        &state,
+        &file_url(&events_path),
+    );
 
     ctx(&temp)
         .args([
@@ -729,7 +807,7 @@ fn search_analytics_reports_existing_indexed_content() {
         .assert()
         .success();
 
-    let events = read_analytics_events(&events_path);
+    let events = read_analytics_operation_payloads(&events_path);
     assert_eq!(events.len(), 1);
     assert_operation_event(&events[0], "search", "success");
     let properties = analytics_event_properties(&events[0]);
@@ -1094,7 +1172,13 @@ fn setup_wait_analytics_reports_ready_source_epoch() {
         ),
     )
     .unwrap();
-    let _daemon = start_source_refresh_daemon(&temp, &data_root, &home, &state);
+    let _daemon = start_source_refresh_daemon_with_analytics(
+        &temp,
+        &data_root,
+        &home,
+        &state,
+        &file_url(&events_path),
+    );
 
     ctx(&temp)
         .args(["setup", "--wait", "--progress", "none"])
@@ -1108,7 +1192,7 @@ fn setup_wait_analytics_reports_ready_source_epoch() {
         .assert()
         .success();
 
-    let events = read_analytics_events(&events_path);
+    let events = read_analytics_operation_payloads(&events_path);
     assert_eq!(events.len(), 1);
     assert_operation_event(&events[0], "setup", "success");
     let completed = analytics_event_properties(&events[0]);
@@ -1129,7 +1213,13 @@ fn foreground_provider_refreshes_batch_once_per_source_backed_import() {
     let events_path = temp.path().join("analytics.jsonl");
     let fixture = provider_history_fixture("codex-sessions");
     fs::create_dir_all(&home).unwrap();
-    let _daemon = start_source_refresh_daemon(&temp, &data_root, &home, &state);
+    let _daemon = start_source_refresh_daemon_with_analytics(
+        &temp,
+        &data_root,
+        &home,
+        &state,
+        &file_url(&events_path),
+    );
 
     for _ in 0..2 {
         ctx(&temp)
@@ -1153,7 +1243,7 @@ fn foreground_provider_refreshes_batch_once_per_source_backed_import() {
             .success();
     }
 
-    let payloads = read_analytics_events(&events_path);
+    let payloads = read_analytics_operation_payloads(&events_path);
     assert_eq!(payloads.len(), 2, "each invocation must send one batch");
     for (payload, expected_change) in payloads.iter().zip(["changed", "no_op"]) {
         let expected_core_result = if expected_change == "changed" {

--- a/crates/ctx-client-observability/tests/contracts/analytics_policy.rs
+++ b/crates/ctx-client-observability/tests/contracts/analytics_policy.rs
@@ -1,5 +1,6 @@
 mod support;
 
+use std::net::TcpListener;
 use support::*;
 
 #[test]
@@ -99,6 +100,72 @@ fn analytics_config_opt_out_suppresses_delivery() {
         "disabled analytics should not create a capability marker"
     );
     assert_no_capability_state(temp.path(), &state);
+}
+
+#[test]
+fn analytics_opt_out_purges_a_backlogged_outbox_without_connecting() {
+    let temp = tempdir();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let endpoint = format!("http://{}", listener.local_addr().unwrap());
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let data_root = data_root(&temp);
+    fs::create_dir_all(&home).unwrap();
+
+    ctx(&temp)
+        .arg("doctor")
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env("CTX_ANALYTICS_ENABLED", "true")
+        .env("CTX_ANALYTICS_ENDPOINT", &endpoint)
+        .env("CTX_UPGRADE_AUTO", "off")
+        .assert()
+        .success();
+    assert!(
+        listener
+            .accept()
+            .is_err_and(|error| error.kind() == std::io::ErrorKind::WouldBlock),
+        "foreground analytics enqueue attempted an endpoint connection"
+    );
+    let outboxes = analytics_outbox_paths(temp.path());
+    assert_eq!(outboxes.len(), 1, "expected one backlogged outbox");
+    assert!(outboxes[0].is_file());
+    assert!(
+        analytics_operation_event_id(&read_queued_analytics_events(temp.path()), "doctor")
+            .is_some()
+    );
+
+    fs::write(
+        data_root.join("config.toml"),
+        "[analytics]\nenabled = false\n",
+    )
+    .unwrap();
+    ctx(&temp)
+        .arg("doctor")
+        .env("CTX_DATA_ROOT", &data_root)
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", &state)
+        .env("LOCALAPPDATA", &state)
+        .env("CTX_ANALYTICS_ENABLED", "true")
+        .env("CTX_ANALYTICS_ENDPOINT", &endpoint)
+        .env("CTX_UPGRADE_AUTO", "off")
+        .assert()
+        .success();
+
+    assert!(
+        listener
+            .accept()
+            .is_err_and(|error| error.kind() == std::io::ErrorKind::WouldBlock),
+        "analytics opt-out attempted an endpoint connection"
+    );
+    assert!(
+        !outboxes[0].exists(),
+        "analytics opt-out must purge the preexisting outbox"
+    );
+    assert!(analytics_outbox_paths(temp.path()).is_empty());
 }
 
 #[test]

--- a/crates/ctx-daemon-cli/src/composition.rs
+++ b/crates/ctx-daemon-cli/src/composition.rs
@@ -200,6 +200,7 @@ pub trait DaemonCliHost: Send + Sync {
         config: &DaemonRuntimeConfig,
     ) -> Result<()>;
     fn deliver_daemon_events(&self, data_root: &Path, events: &[PublicEventV1]);
+    fn upload_daemon_events(&self, data_root: &Path, events: &[PublicEventV1]);
     fn fetch_to_writer(
         &self,
         endpoint: &str,
@@ -305,6 +306,8 @@ impl DaemonCliHost for TestHost {
     }
 
     fn deliver_daemon_events(&self, _data_root: &Path, _events: &[PublicEventV1]) {}
+
+    fn upload_daemon_events(&self, _data_root: &Path, _events: &[PublicEventV1]) {}
 
     fn fetch_to_writer(
         &self,

--- a/crates/ctx-daemon-cli/src/daemon_service_ports.rs
+++ b/crates/ctx-daemon-cli/src/daemon_service_ports.rs
@@ -290,16 +290,17 @@ impl DaemonObservationPort for CliDaemonObservationPort {
         provider_refresh::provider_refresh_event(job, successor_pending)
     }
 
-    fn deliver(&self, data_root: &Path, events: &[PublicEventV1]) {
-        if events.is_empty() {
-            return;
-        }
-        crate::analytics::send_batch(data_root, events);
+    fn append(&self, data_root: &Path, events: &[PublicEventV1]) {
+        crate::analytics::append_batch(data_root, events);
+    }
+
+    fn append_and_upload(&self, data_root: &Path, events: &[PublicEventV1]) {
+        crate::analytics::append_and_upload_batch(data_root, events);
     }
 }
 
 pub fn deliver_daemon_events(data_root: &Path, events: &[PublicEventV1]) {
-    OBSERVATION.deliver(data_root, events);
+    OBSERVATION.append(data_root, events);
 }
 
 pub(super) struct CliDaemonArtifactFetcher;

--- a/crates/ctx-daemon-cli/src/daemon_supervisor.rs
+++ b/crates/ctx-daemon-cli/src/daemon_supervisor.rs
@@ -189,7 +189,7 @@ impl ctx_daemon_application::DaemonApplicationHost for CliDaemonApplicationHost<
     }
 
     fn deliver_daemon_events(&self, data_root: &Path, events: &[PublicEventV1]) {
-        super::daemon_service_ports::OBSERVATION.deliver(data_root, events);
+        super::daemon_service_ports::OBSERVATION.append(data_root, events);
     }
 }
 

--- a/crates/ctx-daemon-cli/src/lib.rs
+++ b/crates/ctx-daemon-cli/src/lib.rs
@@ -173,8 +173,12 @@ mod analytics {
 
     use ctx_client_observability::analytics::PublicEventV1;
 
-    pub fn send_batch(data_root: &Path, events: &[PublicEventV1]) {
+    pub fn append_batch(data_root: &Path, events: &[PublicEventV1]) {
         crate::composition::host().deliver_daemon_events(data_root, events);
+    }
+
+    pub fn append_and_upload_batch(data_root: &Path, events: &[PublicEventV1]) {
+        crate::composition::host().upload_daemon_events(data_root, events);
     }
 }
 

--- a/crates/ctx-daemon-service/src/daemon.rs
+++ b/crates/ctx-daemon-service/src/daemon.rs
@@ -61,7 +61,7 @@ pub(super) use source_watch::daemon_wait_duration;
 use source_watch::{
     daemon_scheduler_source_refresh, install_source_watch_ingress, source_route_ledger_now_ms,
 };
-use telemetry::{daemon_safety_reconcile_interval, send_daemon_events, DaemonTelemetry};
+use telemetry::{daemon_safety_reconcile_interval, DaemonTelemetry};
 use watch_runtime::{DaemonWatchRuntime, WatchCatalogReconcileTrigger};
 
 #[cfg(test)]
@@ -188,10 +188,9 @@ fn daemon_iteration_events(
     iteration: &mut DaemonIteration,
     duration: StdDuration,
 ) -> Vec<PublicEventV1> {
-    if let Some(telemetry) = telemetry {
-        telemetry.observe_cycle(iteration, duration)
-    } else {
-        std::mem::take(&mut iteration.provider_refresh_events)
+    match telemetry {
+        Some(telemetry) => telemetry.observe_cycle(iteration, duration),
+        None => std::mem::take(&mut iteration.provider_refresh_events),
     }
 }
 
@@ -290,15 +289,16 @@ where
     AP: ctx_upgrade_engine::AutomaticUpgradePolicyProvider<Snapshot = AppConfig>,
     UO: ctx_upgrade_engine::UpgradeObserver<AppConfig>,
 {
-    let finite_core_worker = args.profile == DaemonRunProfile::FiniteCoreWorker;
-    if finite_core_worker {
+    let finite_worker = args.profile == DaemonRunProfile::FiniteCoreWorker;
+    let observation = ports.observation;
+    if finite_worker {
         config.daemon.mode = DaemonMode::SourceRefreshOnly;
         config.semantic_enabled = false;
     }
-    if !config.daemon.enabled && !args.force && !finite_core_worker {
+    if !config.daemon.enabled && !args.force && !finite_worker {
         return Ok(());
     }
-    let automatic_recovery_allowed = daemon_automatic_recovery_allowed(&config, finite_core_worker);
+    let automatic_recovery_allowed = daemon_automatic_recovery_allowed(&config, finite_worker);
     if ports
         .installation
         .lifecycle_blocks_current_process(data_root, automatic_recovery_allowed)
@@ -353,7 +353,7 @@ where
             .installation
             .current_process_owns_upgrade_handoff(data_root),
         automatic_recovery_allowed,
-        !finite_core_worker,
+        !finite_worker,
     ) {
         Ok(Some(lease)) => Some(lease),
         Ok(None) => {
@@ -393,7 +393,7 @@ where
             false,
             &config_reload.to_json(),
         )?;
-        if finite_core_worker {
+        if finite_worker {
             restore_daemon_source_refresh_retry(&mut runtime, data_root);
         } else if !runtime.config.daemon.mode.runs_only_source_refresh() {
             restore_daemon_source_refresh_retry(&mut runtime, data_root);
@@ -416,7 +416,7 @@ where
                 config_port: ports.config,
             },
         ) == DaemonConfigReloadOutcome::StopDisabled;
-        if !finite_core_worker {
+        if !finite_worker {
             install_source_watch_ingress(
                 &wakeup,
                 refresh_service
@@ -446,7 +446,7 @@ where
         ensure_daemon_ipc_services_healthy(query_service.as_ref(), refresh_service.as_ref())?;
         #[cfg(any(test, feature = "test-support"))]
         fail_daemon_before_ready_for_test(data_root)?;
-        if !finite_core_worker && !runtime.config.daemon.mode.runs_only_source_refresh() {
+        if !finite_worker && !runtime.config.daemon.mode.runs_only_source_refresh() {
             ports.installation.resume_completed(data_root)?;
         }
         write_daemon_lifecycle_status_with_runtime(
@@ -460,8 +460,8 @@ where
             &config_reload.to_json(),
         )?;
         ctx_daemon_runtime::block_daemon_main_before_ready_for_test(data_root)?;
-        let mut watch_runtime = (!finite_core_worker)
-            .then(|| DaemonWatchRuntime::new(Arc::clone(&wakeup), ports.config));
+        let mut watch_runtime =
+            (!finite_worker).then(|| DaemonWatchRuntime::new(Arc::clone(&wakeup), ports.config));
         if let Some(watch_runtime) = watch_runtime.as_mut() {
             watch_runtime.reconcile_catalog_and_route_authority(
                 data_root,
@@ -490,11 +490,11 @@ where
                 data_root,
                 &lifecycle_state,
                 ports.installation,
-                !finite_core_worker,
+                !finite_worker,
             )?;
         // The ready persistent daemon is the automatic-check driver; foreground commands never are.
         if lifecycle_ready
-            && !finite_core_worker
+            && !finite_worker
             && daemon_should_schedule_auto_upgrade(
                 runtime.config.daemon.enabled,
                 runtime.config.daemon.mode,
@@ -513,7 +513,8 @@ where
         }
         if lifecycle_ready {
             let events = telemetry.ready_events(recovered_previous_run, Instant::now());
-            send_daemon_events(ports.observation, data_root, &events);
+            let uploader_enabled = !finite_worker && runtime.config.daemon.enabled;
+            telemetry::deliver_active(observation, data_root, uploader_enabled, &events);
         }
         let mut next_safety_reconcile = Instant::now() + safety_interval;
         // Recovery installs the coordinator once before IPC activation, and
@@ -523,7 +524,7 @@ where
         // every iteration.
         let source_refresh_coordinator = runtime.source_refresh_coordinator.clone();
         let mut finite_core_worker_exit =
-            finite_core_worker.then(|| FiniteCoreWorkerExit::new(refresh_service.as_ref()));
+            finite_worker.then(|| FiniteCoreWorkerExit::new(refresh_service.as_ref()));
         loop {
             // Hermetic callers may remove their complete temporary data root
             // during shutdown. Do not recreate the deleted root merely to
@@ -575,7 +576,7 @@ where
                 break;
             }
             ensure_daemon_ipc_services_healthy(query_service.as_ref(), refresh_service.as_ref())?;
-            if !finite_core_worker {
+            if !finite_worker {
                 install_source_watch_ingress(
                     &wakeup,
                     refresh_service
@@ -608,7 +609,7 @@ where
                 &config_reload.to_json(),
             )?;
             let automatic_recovery_allowed =
-                daemon_automatic_recovery_allowed(&runtime.config, finite_core_worker);
+                daemon_automatic_recovery_allowed(&runtime.config, finite_worker);
             if prepared_auto_upgrade.is_none() && automatic_recovery_allowed {
                 prepared_auto_upgrade = upgrade
                     .engine
@@ -620,7 +621,7 @@ where
                     )
                     .unwrap_or(None);
             }
-            if !finite_core_worker
+            if !finite_worker
                 && prepared_auto_upgrade.is_none()
                 && !runtime.config.daemon.mode.runs_only_source_refresh()
             {
@@ -637,7 +638,8 @@ where
                 break;
             }
             let events = telemetry.liveness_events(Instant::now());
-            send_daemon_events(ports.observation, data_root, &events);
+            let uploader_enabled = !finite_worker && runtime.config.daemon.enabled;
+            telemetry::deliver_active(observation, data_root, uploader_enabled, &events);
             let cycle_started = Instant::now();
             let semantic_maintenance_requested =
                 daemon_semantic_maintenance_requested(&runtime, &config_reload);
@@ -680,7 +682,8 @@ where
             let cycle_duration = cycle_started.elapsed();
             let iteration_events =
                 daemon_iteration_events(Some(&mut telemetry), &mut iteration, cycle_duration);
-            send_daemon_events(ports.observation, data_root, &iteration_events);
+            let uploader_enabled = !finite_worker && runtime.config.daemon.enabled;
+            telemetry::deliver_active(observation, data_root, uploader_enabled, &iteration_events);
             wakeup.record_cycle(iteration.did_work);
             write_daemon_lifecycle_status_with_runtime(
                 data_root,
@@ -693,7 +696,7 @@ where
                 &config_reload.to_json(),
             )?;
             failed |= iteration.failed;
-            if finite_core_worker {
+            if finite_worker {
                 let pending_core_refresh = source_refresh
                     .is_some_and(|source_refresh| source_refresh.has_pending_request());
                 if finite_core_worker_exit.as_mut().is_some_and(|exit| {
@@ -830,7 +833,7 @@ where
                 );
             }
             let automatic_recovery_allowed =
-                daemon_automatic_recovery_allowed(&runtime.config, finite_core_worker);
+                daemon_automatic_recovery_allowed(&runtime.config, finite_worker);
             if ports
                 .installation
                 .upgrade_handoff_blocks_current_process(data_root)
@@ -897,13 +900,13 @@ where
                 error,
             );
             let events = telemetry.fatal_events(Instant::now());
-            send_daemon_events(ports.observation, data_root, &events);
+            telemetry::append_terminal_events(observation, data_root, &events);
             return Err(error);
         }
     };
     let owned_shutdown_result = (|| -> Result<()> {
         if let Some(installation_daemon_lease) = installation_daemon_lease {
-            if finite_core_worker {
+            if finite_worker {
                 drop(installation_daemon_lease);
                 return Ok(());
             }
@@ -942,7 +945,7 @@ where
         }
     }
     let events = telemetry.stopped_events(failed, Instant::now());
-    send_daemon_events(ports.observation, data_root, &events);
+    telemetry::append_terminal_events(observation, data_root, &events);
     if let Some(prepared) = prepared_auto_upgrade {
         upgrade.engine.finish_automatic(
             upgrade.automatic_policy,

--- a/crates/ctx-daemon-service/src/daemon/telemetry.rs
+++ b/crates/ctx-daemon-service/src/daemon/telemetry.rs
@@ -244,7 +244,23 @@ pub(super) fn runtime_event(
     PublicEventV1::RuntimeObservation(RuntimeObservationV1::daemon(observation, outcome, duration))
 }
 
-pub(super) fn send_daemon_events(
+pub(super) fn deliver_active(
+    observation: &dyn DaemonObservationPort,
+    data_root: &Path,
+    uploader_enabled: bool,
+    events: &[PublicEventV1],
+) {
+    if events.is_empty() && !uploader_enabled {
+        return;
+    }
+    if uploader_enabled {
+        observation.append_and_upload(data_root, events);
+    } else {
+        observation.append(data_root, events);
+    }
+}
+
+pub(super) fn append_terminal_events(
     observation: &dyn DaemonObservationPort,
     data_root: &Path,
     events: &[PublicEventV1],
@@ -252,12 +268,102 @@ pub(super) fn send_daemon_events(
     if events.is_empty() {
         return;
     }
-    observation.deliver(data_root, events);
+    observation.append(data_root, events);
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
+
+    #[derive(Default)]
+    struct RecordingObservation {
+        deliveries: Mutex<Vec<(usize, bool)>>,
+    }
+
+    impl RecordingObservation {
+        fn deliveries(&self) -> Vec<(usize, bool)> {
+            self.deliveries
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        }
+    }
+
+    impl DaemonObservationPort for RecordingObservation {
+        fn provider_refresh_event(
+            &self,
+            _job: &serde_json::Value,
+            _successor_pending: bool,
+        ) -> Option<PublicEventV1> {
+            None
+        }
+
+        fn append(&self, _data_root: &Path, events: &[PublicEventV1]) {
+            self.deliveries
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push((events.len(), false));
+        }
+
+        fn append_and_upload(&self, _data_root: &Path, events: &[PublicEventV1]) {
+            self.deliveries
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push((events.len(), true));
+        }
+    }
+
+    fn test_run() -> DaemonRunFactsV1 {
+        DaemonRunFactsV1::new(
+            crate::analytics::DaemonStartModeV1::Manual,
+            crate::analytics::DaemonSupervisorV1::User,
+            None,
+        )
+    }
+
+    #[test]
+    fn active_empty_tick_requests_upload() {
+        let observation = RecordingObservation::default();
+
+        deliver_active(&observation, Path::new("test-root"), true, &[]);
+
+        assert_eq!(observation.deliveries(), [(0, true)]);
+    }
+
+    #[test]
+    fn finite_worker_events_append_without_upload() {
+        let observation = RecordingObservation::default();
+        let started = Instant::now();
+        let telemetry = DaemonTelemetry::new(test_run(), started, 0);
+        let events = telemetry.ready_events(false, started);
+
+        deliver_active(&observation, Path::new("test-root"), false, &events);
+
+        assert_eq!(observation.deliveries(), [(1, false)]);
+    }
+
+    #[test]
+    fn fatal_and_stopped_events_append_without_upload() {
+        let observation = RecordingObservation::default();
+        let started = Instant::now();
+        let mut fatal = DaemonTelemetry::new(test_run(), started, 0);
+        let mut stopped = DaemonTelemetry::new(test_run(), started, 1);
+
+        append_terminal_events(
+            &observation,
+            Path::new("test-root"),
+            &fatal.fatal_events(started),
+        );
+        append_terminal_events(
+            &observation,
+            Path::new("test-root"),
+            &stopped.stopped_events(false, started),
+        );
+
+        assert_eq!(observation.deliveries(), [(1, false), (1, false)]);
+    }
 
     #[test]
     fn safety_reconciliation_admits_a_sixty_minute_hermes_deadline_within_eighty_minutes() {

--- a/crates/ctx-daemon-service/src/ports.rs
+++ b/crates/ctx-daemon-service/src/ports.rs
@@ -350,7 +350,8 @@ pub trait CoreGenerationPublishedPort: Sync {
 pub trait DaemonObservationPort: Sync {
     fn provider_refresh_event(&self, job: &Value, successor_pending: bool)
         -> Option<PublicEventV1>;
-    fn deliver(&self, data_root: &Path, events: &[PublicEventV1]);
+    fn append(&self, data_root: &Path, events: &[PublicEventV1]);
+    fn append_and_upload(&self, data_root: &Path, events: &[PublicEventV1]);
 }
 
 pub struct DaemonServicePorts<'a, C: ?Sized, A: ?Sized, I, N: ?Sized, O: ?Sized> {

--- a/crates/ctx-daemon-service/src/test_support.rs
+++ b/crates/ctx-daemon-service/src/test_support.rs
@@ -75,7 +75,9 @@ impl DaemonObservationPort for TestObservation {
         ))
     }
 
-    fn deliver(&self, _data_root: &Path, _events: &[PublicEventV1]) {}
+    fn append(&self, _data_root: &Path, _events: &[PublicEventV1]) {}
+
+    fn append_and_upload(&self, _data_root: &Path, _events: &[PublicEventV1]) {}
 }
 
 impl DaemonAvailabilityPort for TestAvailability {

--- a/crates/ctx-history-cli/src/source_index/tests/fixtures.rs
+++ b/crates/ctx-history-cli/src/source_index/tests/fixtures.rs
@@ -76,6 +76,13 @@ impl ctx_daemon_cli::DaemonCliHost for BuiltinSemanticTestHost {
     ) {
     }
 
+    fn upload_daemon_events(
+        &self,
+        _data_root: &Path,
+        _events: &[ctx_client_observability::analytics::PublicEventV1],
+    ) {
+    }
+
     fn fetch_to_writer(
         &self,
         _endpoint: &str,

--- a/crates/ctx-history-ingest-application/tests/contracts/import_change_reporting.rs
+++ b/crates/ctx-history-ingest-application/tests/contracts/import_change_reporting.rs
@@ -118,6 +118,8 @@ fn start_source_refresh_daemon(temp: &TempDir) -> SourceRefreshDaemon {
     command
         .args(["daemon", "run", "--force", "--loop-interval-seconds", "600"])
         .env("CTX_DAEMON_MODE", "source-refresh-only")
+        .env("CTX_ANALYTICS_ENABLED", "true")
+        .env("CTX_ANALYTICS_DRY_RUN", "1")
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
     let spawn_deadline = Instant::now() + Duration::from_secs(1);
@@ -235,9 +237,8 @@ fn import_codex_with_selection(temp: &TempDir, selection: &[&str]) -> Value {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        events_path.exists(),
-        "analytics sender did not create {}: {}",
-        events_path.display(),
+        !read_queued_analytics_events(temp.path()).is_empty(),
+        "analytics outbox queued no events: {}",
         String::from_utf8_lossy(&output.stderr)
     );
     serde_json::from_slice(&output.stdout).unwrap()
@@ -369,7 +370,7 @@ fn assert_index_delta(report: &Value, sessions: i64, searchable_events: i64) {
 }
 
 fn latest_source_refresh_properties(temp: &TempDir) -> serde_json::Map<String, Value> {
-    let event = read_analytics_events(&temp.path().join("analytics.jsonl"))
+    let event = read_queued_analytics_events(temp.path())
         .last()
         .and_then(|payload| payload["events"].as_array())
         .and_then(|events| {

--- a/crates/ctx-history-ingest-application/tests/support/analytics.rs
+++ b/crates/ctx-history-ingest-application/tests/support/analytics.rs
@@ -10,6 +10,8 @@ use std::{
 
 use super::{bind_test_ctx_binary, ctx, TempDir};
 
+const ANALYTICS_OUTBOX_FILE: &str = "analytics-outbox-v1.json";
+
 pub(crate) struct SourceRefreshDaemon {
     child: Option<Child>,
 }
@@ -158,11 +160,68 @@ pub(crate) const CAPABILITY_PROPERTY_KEYS: [&str; 5] = [
     "acceleration_candidate",
 ];
 
-pub(crate) fn read_analytics_events(path: &Path) -> Vec<Value> {
-    fs::read_to_string(path)
-        .unwrap()
-        .lines()
-        .map(|line| serde_json::from_str(line).unwrap())
+pub(crate) fn analytics_outbox_paths(root: &Path) -> Vec<PathBuf> {
+    fn visit(directory: &Path, outboxes: &mut Vec<PathBuf>) {
+        let entries = fs::read_dir(directory).unwrap_or_else(|error| {
+            panic!(
+                "inspect hermetic analytics root {}: {error}",
+                directory.display()
+            )
+        });
+        for entry in entries {
+            let entry = entry.unwrap_or_else(|error| {
+                panic!(
+                    "inspect analytics entry under {}: {error}",
+                    directory.display()
+                )
+            });
+            let file_type = entry.file_type().unwrap_or_else(|error| {
+                panic!("inspect analytics path {}: {error}", entry.path().display())
+            });
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                visit(&entry.path(), outboxes);
+            } else if file_type.is_file() && entry.file_name() == ANALYTICS_OUTBOX_FILE {
+                outboxes.push(entry.path());
+            }
+        }
+    }
+
+    let mut outboxes = Vec::new();
+    if root.is_dir() {
+        visit(root, &mut outboxes);
+    }
+    outboxes.sort();
+    outboxes
+}
+
+pub(crate) fn read_queued_analytics_events(root: &Path) -> Vec<Value> {
+    analytics_outbox_paths(root)
+        .into_iter()
+        .flat_map(|outbox| {
+            let state: Value = serde_json::from_slice(&fs::read(&outbox).unwrap_or_else(|error| {
+                panic!("read analytics outbox {}: {error}", outbox.display())
+            }))
+            .unwrap_or_else(|error| panic!("parse analytics outbox {}: {error}", outbox.display()));
+            state["entries"]
+                .as_array()
+                .unwrap_or_else(|| panic!("analytics outbox has no entries array: {state:#}"))
+                .iter()
+                .map(|entry| {
+                    let payload = entry["payload"].as_str().unwrap_or_else(|| {
+                        panic!("analytics outbox entry has no JSON payload: {entry:#}")
+                    });
+                    serde_json::from_str(payload).unwrap_or_else(|error| {
+                        panic!(
+                            "parse queued analytics payload in {}: {error}",
+                            outbox.display()
+                        )
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
         .collect()
 }
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -918,22 +918,40 @@ random UUID used only for analytics events; it lives outside the ctx data root
 in OS user state, such as `$XDG_STATE_HOME/ctx/device.json` or
 `~/.local/state/ctx/device.json` on Linux. When a capability snapshot is
 eligible, ctx creates a private versioned claim in that state directory and
-promotes it to a version marker after network acceptance or durable local
-queueing. A failed or uncertain local handoff does not change command output or
-exit status and leaves the claim in place to avoid replay.
+promotes it to a version marker after durable local queueing. A failed or
+uncertain local handoff does not change command output or exit status and leaves
+the claim in place to avoid replay.
 
-If delivery fails, ctx stores the exact already-serialized content-free batch
-in the same OS user-state directory as `analytics-outbox-v1.json`. The file is
+Foreground CLI and MCP commands never open a telemetry connection. They
+serialize each eligible event once, preserving its UUIDv4 event ID in the exact
+content-free batch body, and durably append that body to
+`analytics-outbox-v1.json` in the same OS user-state directory. The file is
 owner-private, is never stored under the ctx data root, and contains no response
 body or raw error. It stores a one-way endpoint fingerprint plus queue time and
-attempt bookkeeping so a payload is not replayed to a different endpoint. ctx
-retries up to 10 queued batches per delivery call and bounds the outbox to 128
-entries, 2 MiB total, 512 KiB per batch, and 30 days. Oldest entries are dropped
-when a bound is reached, and the drop is reported only through the closed
-delivery-health fields. If this owner-private file is malformed or oversized,
-ctx replaces it with an empty valid outbox and reports one `local_io` drop on
-the next successful delivery. Unsafe paths, links, and permissions still fail
-closed instead of being replaced.
+attempt bookkeeping so a payload is not replayed to a different endpoint. If
+the persistent daemon is disabled or absent, entries remain local until a later
+daemon run delivers them or the bounds below expire them.
+
+The enabled persistent daemon is the sole telemetry network uploader. It drains
+on startup, active wakes, and periodic cycles. Each drain briefly locks and
+snapshots up to 10 entries, releases the state lock while HTTP executes under
+one approximately two-second deadline, then re-locks to reconcile exact outbox
+entry IDs. Foreground writers therefore never wait behind a slow request. Only
+a final 2xx response removes an accepted entry; a crash after server acceptance
+replays the unchanged event IDs and relies on server idempotency. Network
+failures, HTTP 408/429, and 5xx responses retry under persisted capped
+exponential backoff with jitter. A valid bounded `Retry-After` can extend the
+delay. Other permanent HTTP rejections are dropped, and daemon shutdown appends
+its terminal event without starting another request.
+
+Delivery retry, drop, age, and failure counters are coalesced into one closed
+`analytics_delivery_observation@1` only after an ordinary payload is accepted.
+Failure to deliver that health event never recursively creates another health
+event. The outbox is bounded to 128 entries, 2 MiB total, 512 KiB per batch, and
+30 days. Oldest entries are dropped when a bound is reached. If this
+owner-private file is malformed or oversized, ctx replaces it with an empty
+valid outbox and reports one `local_io` drop after delivery recovers. Unsafe
+paths, links, and permissions still fail closed instead of being replaced.
 
 For an official hosted installation, eligible product-analytics
 events may also carry the installer attempt identifier for less than seven days


### PR DESCRIPTION
## Summary

- keep the durable stable-ID client outbox while making foreground CLI and MCP telemetry append-only with zero delivery I/O
- move startup, wake-driven, and periodic draining into the persistent daemon; snapshot under a short lock, perform HTTP unlocked, and reconcile exact IDs afterward
- enforce complete-request deadlines, Retry-After and capped jittered backoff, permanent 4xx drops, opt-out purging, bounded expiry/corruption recovery, coalesced recovery health, and shutdown-safe retention

## Validation

- `scripts/bazel-affected.sh origin/main` — 64/64 targets passed on the rebased commit
- focused CLI, observability, daemon service, and daemon CLI suite — 8/8 targets passed
- persistent daemon lifecycle acceptance — passed
- repository policy, cargo-shear, rustfmt, and diff checks — passed

Fixes #861