### PR TITLE
fix(import): skip unchanged SQLite source copies

### DIFF
--- a/crates/ctx-daemon-service/src/daemon/telemetry.rs
+++ b/crates/ctx-daemon-service/src/daemon/telemetry.rs
@@ -371,11 +371,14 @@ mod tests {
         let profile_source_descriptor = [4_u8; 32];
         let database_identity = [1_u8; 32];
         let schema_evidence = [2_u8; 32];
+        let physical_revision = [3_u8; 32];
         let control = serde_json::to_vec(&serde_json::json!({
             "kind": "hermes-route-control-v1",
-            "version": 2,
+            "version": 3,
+            "parser_revision": "hermes-source-backed-v5-optional-admission",
             "profile_source_descriptor": profile_source_descriptor,
             "database_identity": database_identity,
+            "physical_revision": physical_revision,
             "schema_evidence": schema_evidence,
             "session_rowid": 4,
             "message_rowid": 9,

--- a/crates/ctx-history-capture-composition/src/source_backed/tests/hermes.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/tests/hermes.rs
@@ -205,6 +205,70 @@ fn incremental_refresh(
         .unwrap()
 }
 
+#[test]
+fn exhaustive_noop_replays_hermes_without_snapshot_copy_or_logical_scan() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data-root");
+    let index_root = temp.path().join("index");
+    let database = temp.path().join("source/state.db");
+    let (registry, cold) = cold_fixture(&data_root, &index_root, &database);
+    reset_hermes_work_counters();
+    let mut updates = Vec::new();
+
+    let replay =
+        SourceBackedRefreshExecutor::new(registry.clone(), source_backed_refresh_writer_options())
+            .with_base_route_controls(cold.route_controls.clone())
+            .refresh_scope_with_detailed_progress_and_reconciliation(
+                &index_root,
+                SourceBackedRefreshScope::All,
+                SourceBackedReconciliationDemand::Exhaustive,
+                |update| {
+                    updates.push(update);
+                    Ok(())
+                },
+            )
+            .unwrap();
+
+    let work = hermes_work_counters();
+    assert_eq!(work.logical_row_traversals, 0);
+    assert_eq!(work.inventory_observation_rows, 0);
+    assert!(updates
+        .iter()
+        .all(|update| update.current_source_progress.is_none()));
+    assert_eq!(updates.last().unwrap().progress.processed_bytes, 0);
+    assert_eq!(
+        certificates_by_identity(&replay),
+        certificates_by_identity(&cold)
+    );
+
+    let expected_generation = replay.commit.generation_id.clone();
+    let raced_database = database.clone();
+    set_before_hermes_snapshot_seal_hook(move || {
+        Connection::open(&raced_database)
+            .unwrap()
+            .execute(
+                "update messages set content = 'physical replay race' where id = 10",
+                [],
+            )
+            .unwrap();
+    });
+    let raced = SourceBackedRefreshExecutor::new(registry, source_backed_refresh_writer_options())
+        .with_base_route_controls(replay.route_controls.clone())
+        .refresh_scope_with_detailed_progress_and_reconciliation(
+            &index_root,
+            SourceBackedRefreshScope::All,
+            SourceBackedReconciliationDemand::Exhaustive,
+            |_| Ok(()),
+        );
+    assert!(raced.is_err());
+    assert_eq!(
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .generation_id(),
+        expected_generation
+    );
+}
+
 fn rewritten_route_controls(
     receipt: &SourceBackedRefreshReceipt,
     rewrite: impl FnOnce(&mut serde_json::Value),
@@ -216,6 +280,145 @@ fn rewritten_route_controls(
     rewrite(&mut parsed);
     *control = serde_json::to_vec(&parsed).unwrap();
     controls
+}
+
+#[test]
+fn legacy_v2_control_forces_one_scan_then_v3_zero_copy_replay() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data-root");
+    let index_root = temp.path().join("index");
+    let database = temp.path().join("source/state.db");
+    let (registry, cold) = cold_fixture(&data_root, &index_root, &database);
+    let legacy = rewritten_route_controls(&cold, |control| {
+        let object = control.as_object_mut().unwrap();
+        object.insert("version".into(), 2.into());
+        object.remove("parser_revision");
+        object.remove("physical_revision");
+    });
+
+    reset_hermes_work_counters();
+    let migrated =
+        SourceBackedRefreshExecutor::new(registry.clone(), source_backed_refresh_writer_options())
+            .with_base_route_controls(legacy)
+            .refresh_scope_with_detailed_progress_and_reconciliation(
+                &index_root,
+                SourceBackedRefreshScope::All,
+                SourceBackedReconciliationDemand::Incremental,
+                |_| Ok(()),
+            )
+            .unwrap();
+    let migrated_control: serde_json::Value =
+        serde_json::from_slice(migrated.route_controls.values().next().unwrap()).unwrap();
+    assert_eq!(migrated_control["version"], 3);
+    assert!(migrated_control["parser_revision"].is_string());
+    assert!(migrated_control["physical_revision"].is_array());
+    let migration_work = hermes_work_counters();
+    assert_eq!(migration_work.inventory_observation_rows, 4);
+
+    reset_hermes_work_counters();
+    let replay = SourceBackedRefreshExecutor::new(registry, source_backed_refresh_writer_options())
+        .with_base_route_controls(migrated.route_controls.clone())
+        .refresh_scope_with_detailed_progress_and_reconciliation(
+            &index_root,
+            SourceBackedRefreshScope::All,
+            SourceBackedReconciliationDemand::Exhaustive,
+            |_| Ok(()),
+        )
+        .unwrap();
+    let replay_work = hermes_work_counters();
+    assert_eq!(replay_work.logical_row_traversals, 0);
+    assert_eq!(replay_work.inventory_observation_rows, 0);
+    assert_eq!(
+        certificates_by_identity(&replay),
+        certificates_by_identity(&migrated)
+    );
+}
+
+#[test]
+fn incremental_old_row_edit_forces_next_exhaustive_scan_before_replay() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data-root");
+    let index_root = temp.path().join("index");
+    let database = temp.path().join("source/state.db");
+    let (registry, cold) = cold_fixture(&data_root, &index_root, &database);
+    let cold_control: serde_json::Value =
+        serde_json::from_slice(cold.route_controls.values().next().unwrap()).unwrap();
+    let exhaustively_certified_revision = cold_control["physical_revision"].clone();
+    Connection::open(&database)
+        .unwrap()
+        .execute_batch(
+            "update messages set content = 'rewritten old row' where id = 10;
+             insert into messages (id, session_id, role, content, timestamp)
+                 values (30, 'parent-session', 'assistant',
+                         'incremental append', 1782259204.0);",
+        )
+        .unwrap();
+
+    reset_hermes_work_counters();
+    let incremental = incremental_refresh(&index_root, &registry, &cold);
+    let incremental_work = hermes_work_counters();
+    assert_eq!(incremental_work.logical_row_traversals, 1);
+    assert_eq!(incremental_work.inventory_observation_rows, 1);
+    let incremental_control: serde_json::Value =
+        serde_json::from_slice(incremental.route_controls.values().next().unwrap()).unwrap();
+    assert_eq!(
+        incremental_control["physical_revision"],
+        exhaustively_certified_revision
+    );
+    assert!(unique_search_record(&index_root, "parent stable needle")
+        .content
+        .normalized_body
+        .unwrap()
+        .contains("parent stable needle"));
+    assert!(unique_search_record(&index_root, "incremental append")
+        .content
+        .normalized_body
+        .unwrap()
+        .contains("incremental append"));
+
+    reset_hermes_work_counters();
+    let exhaustive =
+        SourceBackedRefreshExecutor::new(registry.clone(), source_backed_refresh_writer_options())
+            .with_base_route_controls(incremental.route_controls.clone())
+            .refresh_scope_with_detailed_progress_and_reconciliation(
+                &index_root,
+                SourceBackedRefreshScope::All,
+                SourceBackedReconciliationDemand::Exhaustive,
+                |_| Ok(()),
+            )
+            .unwrap();
+    let exhaustive_work = hermes_work_counters();
+    assert_eq!(exhaustive_work.inventory_observation_rows, 5);
+    assert!(exhaustive_work.logical_row_traversals > 0);
+    assert!(unique_search_record(&index_root, "rewritten old row")
+        .content
+        .normalized_body
+        .unwrap()
+        .contains("rewritten old row"));
+    let exhaustive_control: serde_json::Value =
+        serde_json::from_slice(exhaustive.route_controls.values().next().unwrap()).unwrap();
+    assert_ne!(
+        exhaustive_control["physical_revision"],
+        exhaustively_certified_revision
+    );
+
+    reset_hermes_work_counters();
+    let replay = SourceBackedRefreshExecutor::new(registry, source_backed_refresh_writer_options())
+        .with_base_route_controls(exhaustive.route_controls.clone())
+        .refresh_scope_with_detailed_progress_and_reconciliation(
+            &index_root,
+            SourceBackedRefreshScope::All,
+            SourceBackedReconciliationDemand::Exhaustive,
+            |_| Ok(()),
+        )
+        .unwrap();
+    let replay_work = hermes_work_counters();
+    assert_eq!(replay_work.logical_row_traversals, 0);
+    assert_eq!(replay_work.inventory_observation_rows, 0);
+    assert_eq!(
+        certificates_by_identity(&replay),
+        certificates_by_identity(&exhaustive)
+    );
 }
 
 #[test]

--- a/crates/ctx-history-provider-hermes/src/provider/source_backed.rs
+++ b/crates/ctx-history-provider-hermes/src/provider/source_backed.rs
@@ -7,6 +7,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    ffi::OsString,
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -32,7 +33,7 @@ use crate::{
         retain_sqlite_source_directory_authority, ProviderSource, SqliteArtifactKind,
         SqliteCleanupStatus, SqliteFailurePhase, SqliteSourceAccessError,
         SqliteSourceDirectoryAuthority, SqliteSourceErrorComposition, SqliteSourceEvidence,
-        SqliteSourceProgressError, SqliteSourceReadSnapshot,
+        SqliteSourceProgressError, SqliteSourceReadSnapshot, SqliteSourceReplayFence,
     },
     source_backed::{
         family::document::{DocumentAppendBase, DocumentLeafFingerprint, ObservedDocumentLeaf},
@@ -76,7 +77,8 @@ const HERMES_INCREMENTAL_FINGERPRINT_DOMAIN: &[u8] = b"ctx-hermes-incremental-se
 const HERMES_INCREMENTAL_CONTENT_DOMAIN: &[u8] = b"ctx-hermes-incremental-content-v1\0";
 const HERMES_EXACT_INTERVAL_MS: i64 = 60 * 60 * 1_000;
 const HERMES_ROUTE_CONTROL_KIND: &str = "hermes-route-control-v1";
-const HERMES_ROUTE_CONTROL_VERSION: u32 = 2;
+const HERMES_LEGACY_ROUTE_CONTROL_VERSION: u32 = 2;
+const HERMES_ROUTE_CONTROL_VERSION: u32 = 3;
 const HERMES_SESSION_DIGEST_DOMAIN: &[u8] = b"ctx-hermes-source-backed-session-v1\0";
 const HERMES_REJECTION_DIGEST_DOMAIN: &[u8] = b"ctx-hermes-source-backed-rejection-v1\0";
 
@@ -162,6 +164,28 @@ trait HermesReconciliationContext<L: CaptureLifecycleSink> {
 pub(crate) struct HermesRefreshReceipt {
     kind: String,
     version: u32,
+    parser_revision: String,
+    profile_source_descriptor: [u8; 32],
+    database_identity: [u8; 32],
+    physical_revision: [u8; 32],
+    schema_evidence: [u8; 32],
+    session_rowid: i64,
+    message_rowid: i64,
+    last_successful_exhaustive_at_ms: i64,
+    exact_due_at_ms: i64,
+    exhaustive_sequence: u64,
+    mode: String,
+    outcome: String,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+// The full legacy shape is intentional: retirement may only trust identities
+// extracted from an otherwise well-formed v2 receipt.
+#[allow(dead_code)]
+struct HermesLegacyRefreshReceiptV2 {
+    kind: String,
+    version: u32,
     profile_source_descriptor: [u8; 32],
     database_identity: [u8; 32],
     schema_evidence: [u8; 32],
@@ -174,12 +198,18 @@ pub(crate) struct HermesRefreshReceipt {
     outcome: String,
 }
 
+#[derive(Clone, Copy)]
+struct HermesPhysicalSourceRevision {
+    database_identity: [u8; 32],
+    physical_revision: [u8; 32],
+}
+
 fn observe_hermes_reconciliation_inventory<L: CaptureLifecycleSink>(
     candidate: &HermesSourceCandidate,
     conn: &rusqlite::Connection,
     base_route_control: Option<&[u8]>,
     requested: SourceBackedReconciliationDemand,
-    database_identity: [u8; 32],
+    physical: HermesPhysicalSourceRevision,
     now_ms: i64,
     context: &mut dyn HermesReconciliationContext<L>,
 ) -> HermesSourceBackedResult<HermesSessionInventory<L>>
@@ -194,8 +224,9 @@ where
     let forced_exhaustive = prior.as_ref().is_none_or(|receipt| {
         receipt.kind != HERMES_ROUTE_CONTROL_KIND
             || receipt.version != HERMES_ROUTE_CONTROL_VERSION
+            || receipt.parser_revision != HERMES_SOURCE_PARSER_REVISION
             || receipt.profile_source_descriptor != candidate.source.exact_descriptor_digest()
-            || receipt.database_identity != database_identity
+            || receipt.database_identity != physical.database_identity
             || receipt.schema_evidence != schema_digest
             || current_session_rowid < receipt.session_rowid
             || current_message_rowid < receipt.message_rowid
@@ -257,11 +288,25 @@ where
         }
         _ => demand.as_str().to_owned(),
     };
+    // Incremental reconciliation visits only rows beyond the prior rowid
+    // frontiers. Preserve the revision from the last exhaustive proof so an
+    // in-place edit to an older row cannot be blessed for later exact replay.
+    let physical_revision = match demand {
+        SourceBackedReconciliationDemand::Exhaustive => physical.physical_revision,
+        SourceBackedReconciliationDemand::Incremental => {
+            prior
+                .as_ref()
+                .expect("incremental Hermes receipt")
+                .physical_revision
+        }
+    };
     let receipt = HermesRefreshReceipt {
         kind: HERMES_ROUTE_CONTROL_KIND.to_owned(),
         version: HERMES_ROUTE_CONTROL_VERSION,
+        parser_revision: HERMES_SOURCE_PARSER_REVISION.to_owned(),
         profile_source_descriptor: candidate.source.exact_descriptor_digest(),
-        database_identity,
+        database_identity: physical.database_identity,
+        physical_revision,
         schema_evidence: schema_digest,
         session_rowid: inventory.max_session_rowid,
         message_rowid: inventory.max_message_rowid,
@@ -296,6 +341,7 @@ pub fn hermes_route_control_exact_due(control: &[u8], now_ms: i64) -> Option<boo
     Some(
         serde_json::from_value::<HermesRefreshReceipt>(value).map_or(true, |receipt| {
             receipt.version != HERMES_ROUTE_CONTROL_VERSION
+                || receipt.parser_revision != HERMES_SOURCE_PARSER_REVISION
                 || receipt.outcome != "successful"
                 || receipt.exact_due_at_ms <= now_ms
         }),
@@ -310,17 +356,43 @@ pub fn hermes_route_control_exact_due_for_profile(
     let receipt = hermes_refresh_receipt(Some(control))?;
     (receipt.kind == HERMES_ROUTE_CONTROL_KIND
         && receipt.version == HERMES_ROUTE_CONTROL_VERSION
+        && receipt.parser_revision == HERMES_SOURCE_PARSER_REVISION
         && receipt.outcome == "successful"
         && receipt.profile_source_descriptor == profile_source_descriptor)
         .then_some(receipt.exact_due_at_ms <= now_ms)
 }
 
 pub fn hermes_route_control_database_identity(control: &[u8]) -> Option<[u8; 32]> {
-    let receipt = hermes_refresh_receipt(Some(control))?;
-    (receipt.kind == HERMES_ROUTE_CONTROL_KIND
-        && receipt.version == HERMES_ROUTE_CONTROL_VERSION
-        && receipt.outcome == "successful")
-        .then_some(receipt.database_identity)
+    if let Some(receipt) = hermes_refresh_receipt(Some(control)) {
+        return (receipt.kind == HERMES_ROUTE_CONTROL_KIND
+            && receipt.version == HERMES_ROUTE_CONTROL_VERSION
+            && receipt.outcome == "successful")
+            .then_some(receipt.database_identity);
+    }
+    let HermesLegacyRefreshReceiptV2 {
+        kind,
+        version,
+        profile_source_descriptor: _,
+        database_identity,
+        schema_evidence: _,
+        session_rowid: _,
+        message_rowid: _,
+        last_successful_exhaustive_at_ms: _,
+        exact_due_at_ms: _,
+        exhaustive_sequence: _,
+        mode: _,
+        outcome,
+    } = serde_json::from_slice(control).ok()?;
+    (kind == HERMES_ROUTE_CONTROL_KIND
+        && version == HERMES_LEGACY_ROUTE_CONTROL_VERSION
+        && outcome == "successful")
+        .then_some(database_identity)
+}
+
+struct HermesRetainedSource {
+    source_root: ProviderSourceRoot,
+    sqlite_authority: SqliteSourceDirectoryAuthority,
+    database_leaf: OsString,
 }
 
 #[cfg(test)]
@@ -374,31 +446,19 @@ fn open_root_authorized_snapshot_with_hook_and_progress(
         SourceBackedCurrentSourceProgress,
     ) -> SourceBackedRouteResult<()>,
 ) -> HermesSourceBackedResult<(SqliteSourceDirectoryAuthority, SqliteSourceReadSnapshot)> {
-    let parent = path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let database_leaf =
-        path.file_name()
-            .ok_or_else(|| CaptureError::InvalidProviderTranscriptPath {
-                path: path.to_path_buf(),
-                reason: SQLITE_SOURCE_INVALID_REASON,
-            })?;
-    let admission_root = ProviderSourceRoot::open(parent)?;
-    let admission_directory = admission_root.directory()?;
-    let parent_handle = admission_directory
-        .try_clone_authority_handle()
-        .map_err(CaptureError::from)?;
-    let sqlite_authority =
-        retain_sqlite_source_directory_authority(data_root, &parent_handle, parent)?;
+    let retained = retain_root_authorized_source(data_root, path)?;
     let sqlite_snapshot = if incremental {
-        sqlite_authority.open_incremental_snapshot_with_progress(database_leaf, |progress| {
-            report_progress(sqlite_source_progress(progress))
-        })
+        retained
+            .sqlite_authority
+            .open_incremental_snapshot_with_progress(&retained.database_leaf, |progress| {
+                report_progress(sqlite_source_progress(progress))
+            })
     } else {
-        sqlite_authority.open_stable_snapshot_with_progress(database_leaf, |progress| {
-            report_progress(sqlite_source_progress(progress))
-        })
+        retained
+            .sqlite_authority
+            .open_stable_snapshot_with_progress(&retained.database_leaf, |progress| {
+                report_progress(sqlite_source_progress(progress))
+            })
     }
     .map_err(|error| match error {
         SqliteSourceProgressError::Source(error) => HermesSourceBackedError::from(error),
@@ -413,6 +473,7 @@ fn open_root_authorized_snapshot_with_hook_and_progress(
     after_authorize();
     let configure = (|| {
         sqlite_snapshot.revalidate()?;
+        retained.source_root.revalidate_same_object()?;
         let connection = sqlite_snapshot.connection()?;
         let value_limit = i32::try_from(MAX_PROVIDER_SQLITE_VALUE_BYTES)
             .map_err(|_| HermesSourceBackedError::CountOverflow)?;
@@ -431,7 +492,35 @@ fn open_root_authorized_snapshot_with_hook_and_progress(
     if let Err(error) = configure {
         return Err(abort_hermes_snapshot(sqlite_snapshot, error));
     }
-    Ok((sqlite_authority, sqlite_snapshot))
+    Ok((retained.sqlite_authority, sqlite_snapshot))
+}
+
+fn retain_root_authorized_source(
+    data_root: &Path,
+    path: &Path,
+) -> HermesSourceBackedResult<HermesRetainedSource> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let database_leaf =
+        path.file_name()
+            .ok_or_else(|| CaptureError::InvalidProviderTranscriptPath {
+                path: path.to_path_buf(),
+                reason: SQLITE_SOURCE_INVALID_REASON,
+            })?;
+    let admission_root = ProviderSourceRoot::open(parent)?;
+    let admission_directory = admission_root.directory()?;
+    let parent_handle = admission_directory
+        .try_clone_authority_handle()
+        .map_err(CaptureError::from)?;
+    let sqlite_authority =
+        retain_sqlite_source_directory_authority(data_root, &parent_handle, parent)?;
+    Ok(HermesRetainedSource {
+        source_root: admission_root,
+        sqlite_authority,
+        database_leaf: database_leaf.to_os_string(),
+    })
 }
 
 fn abort_hermes_snapshot(

--- a/crates/ctx-history-provider-hermes/src/provider/source_backed/replacement.rs
+++ b/crates/ctx-history-provider-hermes/src/provider/source_backed/replacement.rs
@@ -73,7 +73,12 @@ pub(crate) struct HermesTreeAuthority {
     publication_receipt: HermesRefreshReceipt,
     terminal_revalidate:
         Option<Box<dyn Fn() -> Result<(), SqliteSourceAccessError> + Send + Sync + 'static>>,
+    physical_replay: Option<HermesPhysicalReplay>,
     deferred_incremental: bool,
+}
+
+struct HermesPhysicalReplay {
+    fence: SqliteSourceReplayFence,
 }
 
 struct HermesCompleteReconciliationContext<'a, L: CaptureLifecycleSink> {
@@ -381,6 +386,28 @@ where
         &self,
         tree: &CompleteDocumentTree<Self::Leaf, Self::TreeAuthority>,
     ) -> SourceBackedRouteResult<[u8; 32]> {
+        if let Some(replay) = &tree.authority.physical_replay {
+            let snapshot_present = tree
+                .authority
+                .snapshot
+                .lock()
+                .map_err(|_| hermes_internal("Hermes snapshot lock was poisoned"))?
+                .is_some();
+            if !tree.leaves.is_empty() || snapshot_present {
+                return Err(hermes_internal(
+                    "exact Hermes replay retained logical snapshot work",
+                ));
+            }
+            #[cfg(any(test, feature = "test-support"))]
+            run_before_hermes_snapshot_seal_hook();
+            #[cfg(any(test, feature = "test-support"))]
+            run_after_hermes_snapshot_seal_hook();
+            replay
+                .fence
+                .revalidate()
+                .map_err(hermes_sqlite_route_error)?;
+            return Ok(tree.tree_fingerprint);
+        }
         if tree.authority.deferred_incremental {
             let snapshot_present = tree
                 .authority
@@ -432,6 +459,15 @@ where
     }
     let reconciliation_demand = context.reconciliation_demand();
     let base_route_control = context.route_control().map(<[u8]>::to_vec);
+    if reconciliation_demand == SourceBackedReconciliationDemand::Exhaustive {
+        if let Some(tree) = discover_hermes_physical_replay(
+            candidate,
+            base_route_control.as_deref(),
+            hermes_now_ms(),
+        )? {
+            return Ok(tree);
+        }
+    }
     let may_increment = reconciliation_demand == SourceBackedReconciliationDemand::Incremental
         && hermes_refresh_receipt(base_route_control.as_deref()).is_some();
     let (mut sqlite_authority, mut snapshot, mut admitted_demand) = if may_increment {
@@ -467,6 +503,7 @@ where
                         message_spool: None,
                         publication_receipt,
                         terminal_revalidate: None,
+                        physical_replay: None,
                         deferred_incremental: true,
                     },
                 ));
@@ -520,7 +557,10 @@ where
         snapshot.connection().map_err(hermes_sqlite_route_error)?,
         base_route_control.as_deref(),
         admitted_demand,
-        *opening_evidence.identity(),
+        HermesPhysicalSourceRevision {
+            database_identity: *opening_evidence.identity(),
+            physical_revision: *opening_evidence.physical_revision(),
+        },
         hermes_now_ms(),
         context,
     ) {
@@ -541,6 +581,7 @@ where
         _schema_evidence: inventory.schema_evidence,
         _sqlite_authority: Some(sqlite_authority),
         terminal_revalidate: Some(snapshot.terminal_revalidator()),
+        physical_replay: None,
         snapshot: Mutex::new(Some(snapshot)),
         message_spool: inventory.message_spool.map(Mutex::new),
         publication_receipt,
@@ -559,6 +600,96 @@ where
             authority,
         ))
     }
+}
+
+fn discover_hermes_physical_replay<L: CaptureLifecycleSink>(
+    candidate: &HermesSourceCandidate,
+    base_route_control: Option<&[u8]>,
+    now_ms: i64,
+) -> SourceBackedRouteResult<Option<CompleteDocumentTree<HermesSessionLeaf<L>, HermesTreeAuthority>>>
+where
+    L::PinnedAppendBase: Clone,
+{
+    let Some(prior) = hermes_refresh_receipt(base_route_control) else {
+        return Ok(None);
+    };
+    if prior.kind != HERMES_ROUTE_CONTROL_KIND
+        || prior.version != HERMES_ROUTE_CONTROL_VERSION
+        || prior.parser_revision != HERMES_SOURCE_PARSER_REVISION
+        || prior.outcome != "successful"
+        || prior.profile_source_descriptor != candidate.source.exact_descriptor_digest()
+    {
+        return Ok(None);
+    }
+    let retained = retain_root_authorized_source(&candidate.data_root, candidate.path())
+        .map_err(hermes_route_error)?;
+    let physical_fence = match retained
+        .sqlite_authority
+        .observe_replay_fence(&retained.database_leaf)
+    {
+        Ok(fence) => fence,
+        Err(error) if error.is_source_changed() => return Ok(None),
+        Err(error) => return Err(hermes_sqlite_route_error(error)),
+    };
+    let physical_revision = *physical_fence.revision();
+    if physical_revision != prior.physical_revision {
+        return Ok(None);
+    }
+    let publication_receipt = hermes_physical_replay_receipt(prior, now_ms);
+    let tree_fingerprint = hermes_physical_replay_tree_fingerprint(
+        &candidate.source,
+        physical_revision,
+        &publication_receipt,
+    )?;
+    Ok(Some(CompleteDocumentTree::new_partial(
+        tree_fingerprint,
+        Vec::new(),
+        HermesTreeAuthority {
+            opening_evidence: None,
+            schema: None,
+            _schema_evidence: Vec::new(),
+            _sqlite_authority: None,
+            snapshot: Mutex::new(None),
+            message_spool: None,
+            publication_receipt,
+            terminal_revalidate: None,
+            physical_replay: Some(HermesPhysicalReplay {
+                fence: physical_fence,
+            }),
+            deferred_incremental: false,
+        },
+    )))
+}
+
+fn hermes_physical_replay_receipt(
+    mut prior: HermesRefreshReceipt,
+    now_ms: i64,
+) -> HermesRefreshReceipt {
+    if prior.last_successful_exhaustive_at_ms != now_ms {
+        prior.exhaustive_sequence = prior.exhaustive_sequence.saturating_add(1);
+    }
+    prior.last_successful_exhaustive_at_ms = now_ms;
+    prior.exact_due_at_ms = now_ms.saturating_add(HERMES_EXACT_INTERVAL_MS);
+    prior.mode = "exhaustive".to_owned();
+    prior.outcome = "successful".to_owned();
+    prior
+}
+
+fn hermes_physical_replay_tree_fingerprint(
+    profile_source: &SourceKey,
+    physical_revision: [u8; 32],
+    receipt: &HermesRefreshReceipt,
+) -> SourceBackedRouteResult<[u8; 32]> {
+    let receipt = serde_json::to_vec(receipt)
+        .map_err(HermesSourceBackedError::from)
+        .map_err(hermes_route_error)?;
+    let mut digest = Sha256::new();
+    digest.update(b"ctx-hermes-exact-physical-replay-v1\0");
+    digest.update(profile_source.exact_descriptor_digest());
+    digest.update(physical_revision);
+    digest.update((receipt.len() as u64).to_be_bytes());
+    digest.update(receipt);
+    Ok(digest.finalize().into())
 }
 
 fn hermes_incremental_snapshot_unavailable(error: &HermesSourceBackedError) -> bool {

--- a/crates/ctx-history-provider-hermes/src/provider/source_backed/tests.rs
+++ b/crates/ctx-history-provider-hermes/src/provider/source_backed/tests.rs
@@ -387,8 +387,10 @@ fn renamed_profile_control_is_rejected_for_a_different_profile_descriptor() {
     let receipt = HermesRefreshReceipt {
         kind: HERMES_ROUTE_CONTROL_KIND.to_owned(),
         version: HERMES_ROUTE_CONTROL_VERSION,
+        parser_revision: HERMES_SOURCE_PARSER_REVISION.to_owned(),
         profile_source_descriptor: [1; 32],
         database_identity: [2; 32],
+        physical_revision: [4; 32],
         schema_evidence: [3; 32],
         session_rowid: 10,
         message_rowid: 20,
@@ -406,6 +408,79 @@ fn renamed_profile_control_is_rejected_for_a_different_profile_descriptor() {
     assert_eq!(
         hermes_route_control_exact_due_for_profile(&control, [1; 32], 1500),
         Some(false)
+    );
+}
+
+#[test]
+fn legacy_v2_control_forces_refresh_but_preserves_rename_retirement_identity() {
+    let profile_source_descriptor = [1_u8; 32];
+    let database_identity = [2_u8; 32];
+    let schema_evidence = [3_u8; 32];
+    let control = serde_json::to_vec(&serde_json::json!({
+        "kind": HERMES_ROUTE_CONTROL_KIND,
+        "version": HERMES_LEGACY_ROUTE_CONTROL_VERSION,
+        "profile_source_descriptor": profile_source_descriptor,
+        "database_identity": database_identity,
+        "schema_evidence": schema_evidence,
+        "session_rowid": 10,
+        "message_rowid": 20,
+        "last_successful_exhaustive_at_ms": 1000,
+        "exact_due_at_ms": 2000,
+        "exhaustive_sequence": 1,
+        "mode": "incremental",
+        "outcome": "successful",
+    }))
+    .unwrap();
+
+    assert_eq!(hermes_route_control_exact_due(&control, 1500), Some(true));
+    assert_eq!(
+        hermes_route_control_exact_due_for_profile(&control, profile_source_descriptor, 1500),
+        None
+    );
+    assert_eq!(
+        hermes_route_control_database_identity(&control),
+        Some(database_identity)
+    );
+
+    let mut malformed: serde_json::Value = serde_json::from_slice(&control).unwrap();
+    malformed["unexpected"] = serde_json::json!(true);
+    assert_eq!(
+        hermes_route_control_database_identity(&serde_json::to_vec(&malformed).unwrap()),
+        None
+    );
+
+    let prior_parser_v3 = HermesRefreshReceipt {
+        kind: HERMES_ROUTE_CONTROL_KIND.to_owned(),
+        version: HERMES_ROUTE_CONTROL_VERSION,
+        parser_revision: "retired-hermes-parser".to_owned(),
+        profile_source_descriptor,
+        database_identity,
+        physical_revision: [4; 32],
+        schema_evidence,
+        session_rowid: 10,
+        message_rowid: 20,
+        last_successful_exhaustive_at_ms: 1000,
+        exact_due_at_ms: 2000,
+        exhaustive_sequence: 1,
+        mode: "exhaustive".to_owned(),
+        outcome: "successful".to_owned(),
+    };
+    let prior_parser_v3 = serde_json::to_vec(&prior_parser_v3).unwrap();
+    assert_eq!(
+        hermes_route_control_exact_due(&prior_parser_v3, 1500),
+        Some(true)
+    );
+    assert_eq!(
+        hermes_route_control_exact_due_for_profile(
+            &prior_parser_v3,
+            profile_source_descriptor,
+            1500
+        ),
+        None
+    );
+    assert_eq!(
+        hermes_route_control_database_identity(&prior_parser_v3),
+        Some(database_identity)
     );
 }
 

--- a/crates/ctx-history-provider-hermes/src/provider/source_backed/tests/inventory_mutation_tests.rs
+++ b/crates/ctx-history-provider-hermes/src/provider/source_backed/tests/inventory_mutation_tests.rs
@@ -132,7 +132,10 @@ fn observe_exact(
         snapshot.connection().unwrap(),
         None,
         SourceBackedReconciliationDemand::Exhaustive,
-        *snapshot.evidence().identity(),
+        HermesPhysicalSourceRevision {
+            database_identity: *snapshot.evidence().identity(),
+            physical_revision: *snapshot.evidence().physical_revision(),
+        },
         1_000,
         &mut context,
     )
@@ -292,7 +295,10 @@ fn incremental_inventory_touches_only_the_appended_session() {
         snapshot.connection().unwrap(),
         Some(&route_control),
         SourceBackedReconciliationDemand::Incremental,
-        *snapshot.evidence().identity(),
+        HermesPhysicalSourceRevision {
+            database_identity: *snapshot.evidence().identity(),
+            physical_revision: *snapshot.evidence().physical_revision(),
+        },
         2_000,
         &mut context,
     )

--- a/crates/ctx-history-providers-sqlite-logical/src/lib.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/lib.rs
@@ -137,7 +137,7 @@ pub(crate) mod provider_sources {
         SqliteArtifactKind, SqliteCleanupStatus, SqliteFailurePhase, SqliteLogicalSnapshot,
         SqliteRetryDecision, SqliteSourceAccessError, SqliteSourceDirectoryAuthority,
         SqliteSourceErrorComposition, SqliteSourceEvidence, SqliteSourceProgressError,
-        SqliteSourceReadSnapshot, SqliteSourceTerminalFence,
+        SqliteSourceReadSnapshot, SqliteSourceReplayFence, SqliteSourceTerminalFence,
     };
 }
 

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed.rs
@@ -35,10 +35,10 @@ use crate::{
         },
     },
     provider_sources::{
-        retain_sqlite_source_directory_authority, sqlite_retry_decision, SqliteArtifactKind,
-        SqliteCleanupStatus, SqliteFailurePhase, SqliteLogicalSnapshot, SqliteRetryDecision,
-        SqliteSourceAccessError, SqliteSourceDirectoryAuthority, SqliteSourceErrorComposition,
-        SqliteSourceProgressError, SqliteSourceReadSnapshot, SqliteSourceTerminalFence,
+        sqlite_retry_decision, SqliteArtifactKind, SqliteCleanupStatus, SqliteFailurePhase,
+        SqliteLogicalSnapshot, SqliteRetryDecision, SqliteSourceAccessError,
+        SqliteSourceDirectoryAuthority, SqliteSourceErrorComposition, SqliteSourceProgressError,
+        SqliteSourceReadSnapshot, SqliteSourceTerminalFence,
     },
     CaptureError, MAX_PROVIDER_SQLITE_VALUE_BYTES,
 };
@@ -93,6 +93,7 @@ impl SqliteSourceErrorComposition for OpenCodeSourceBackedError {
 }
 
 mod adapter;
+mod authority;
 mod diagnostics;
 mod fingerprint;
 mod ordering;
@@ -103,6 +104,7 @@ pub use adapter::{
     adapter as source_backed_adapter, adapter_scoped as source_backed_adapter_scoped,
     OpenCodeDocumentTreeAdapter,
 };
+use authority::retain_root_authorized_source;
 use diagnostics::{
     core_projection_rejection_draft, projection_rejection_draft,
     record_local_core_projection_failure,
@@ -846,29 +848,15 @@ fn open_root_authorized_snapshot_retained_with_hook_and_progress(
     ) -> SourceBackedRouteResult<()>,
 ) -> OpenCodeSourceBackedResult<OpenCodeAuthorizedSnapshot> {
     const SOURCE_TRANSITION_ATTEMPTS: usize = 2;
-    let parent = path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let database_leaf =
-        path.file_name()
-            .ok_or_else(|| CaptureError::InvalidProviderTranscriptPath {
-                path: path.to_path_buf(),
-                reason: SQLITE_SOURCE_INVALID_REASON,
-            })?;
-    let source_root = ProviderSourceRoot::open(parent)?;
-    let source_directory = source_root.directory()?;
-    let parent_handle = source_directory
-        .try_clone_authority_handle()
-        .map_err(CaptureError::from)?;
-    let sqlite_authority =
-        retain_sqlite_source_directory_authority(data_root, &parent_handle, parent)?;
+    let retained = retain_root_authorized_source(data_root, path)?;
     let sqlite_snapshot = {
         let mut attempt = 0;
         loop {
-            match sqlite_authority.open_stable_snapshot_with_progress(database_leaf, |progress| {
-                report_progress(sqlite_source_progress(progress))
-            }) {
+            match retained
+                .sqlite_authority
+                .open_stable_snapshot_with_progress(&retained.database_leaf, |progress| {
+                    report_progress(sqlite_source_progress(progress))
+                }) {
                 Ok(snapshot) => break snapshot,
                 Err(SqliteSourceProgressError::Source(error))
                     if sqlite_retry_decision(&error)
@@ -896,7 +884,7 @@ fn open_root_authorized_snapshot_retained_with_hook_and_progress(
     after_authorize();
     let configure = (|| {
         sqlite_snapshot.revalidate()?;
-        source_root.revalidate_same_object()?;
+        retained.source_root.revalidate_same_object()?;
         let connection = sqlite_snapshot.connection()?;
         let value_limit = i32::try_from(MAX_PROVIDER_SQLITE_VALUE_BYTES)
             .map_err(|_| OpenCodeSourceBackedError::CountOverflow)?;
@@ -943,8 +931,8 @@ fn open_root_authorized_snapshot_retained_with_hook_and_progress(
         return Err(adapter::abort_opencode_snapshot(sqlite_snapshot, error));
     }
     Ok(OpenCodeAuthorizedSnapshot {
-        source_root,
-        sqlite_authority,
+        source_root: retained.source_root,
+        sqlite_authority: retained.sqlite_authority,
         sqlite_snapshot,
     })
 }

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/adapter.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/adapter.rs
@@ -5,15 +5,16 @@ use std::{
     sync::Mutex,
 };
 
-use ctx_history_core::{CaptureProvider, SourceAnchorScope, SourceKey};
+use ctx_history_capture_runtime::decode_document_full_snapshot_checkpoint;
+use ctx_history_core::{CaptureProvider, CertifiedSource, SourceAnchorScope, SourceKey};
 use sha2::{Digest, Sha256};
 
 use super::{
     observe_logical_source_with_progress_scoped,
     open_root_authorized_snapshot_retained_with_progress,
-    opencode_family_source_backed_registrations, scan_pinned_source, OpenCodeAuthorizedSnapshot,
-    OpenCodeLogicalObservation, OpenCodeScanOutput, OpenCodeSourceBackedError,
-    OpenCodeSourceBackedRegistration, OpenCodeSourceBackedResult,
+    opencode_family_source_backed_registrations, retain_root_authorized_source, scan_pinned_source,
+    OpenCodeAuthorizedSnapshot, OpenCodeLogicalObservation, OpenCodeScanOutput,
+    OpenCodeSourceBackedError, OpenCodeSourceBackedRegistration, OpenCodeSourceBackedResult,
     SourceBackedCurrentSourceProgress, PARSER_REVISION, SQLITE_SOURCE_INVALID_REASON,
 };
 use crate::{
@@ -26,8 +27,8 @@ use crate::{
         SourceBackedRouteError, SourceBackedRouteErrorKind, SourceBackedRouteResult,
     },
     provider_sources::{
-        SqliteSourceAccessError, SqliteSourceEvidence, SqliteSourceReadSnapshot,
-        SqliteSourceTerminalFence,
+        sqlite_retry_decision, SqliteRetryDecision, SqliteSourceAccessError,
+        SqliteSourceReadSnapshot, SqliteSourceReplayFence, SqliteSourceTerminalFence,
     },
     CaptureError, ProviderSource,
 };
@@ -52,9 +53,16 @@ pub enum OpenCodeTreeAuthority {
 }
 
 pub struct OpenCodeDocumentLeaf {
-    observation: OpenCodeLogicalObservation,
+    observation: Option<OpenCodeLogicalObservation>,
     snapshot: Mutex<Option<SqliteSourceReadSnapshot>>,
     terminal_fence: Mutex<Option<SqliteSourceTerminalFence>>,
+    replay: Option<OpenCodeReplayLeaf>,
+}
+
+struct OpenCodeReplayLeaf {
+    source: SourceKey,
+    physical_fence: SqliteSourceReplayFence,
+    leaf_fingerprint: [u8; 32],
 }
 
 type OpenCodeDocumentTree = CompleteDocumentTree<OpenCodeDocumentLeaf, OpenCodeTreeAuthority>;
@@ -88,7 +96,7 @@ impl<B: crate::LogicalSqliteRuntimeBinding> ReplacementDocumentTree
 
     fn discover_complete_with_progress(
         &self,
-        _base_sources: &[ctx_history_core::CertifiedSource],
+        base_sources: &[CertifiedSource],
         report_progress: &mut dyn FnMut(
             SourceBackedCurrentSourceProgress,
         ) -> SourceBackedRouteResult<()>,
@@ -98,6 +106,7 @@ impl<B: crate::LogicalSqliteRuntimeBinding> ReplacementDocumentTree
             &self.path,
             self.registration.dialect,
             self.source_scope,
+            base_sources,
             report_progress,
         )
         .map_err(route_error)
@@ -115,6 +124,9 @@ impl<B: crate::LogicalSqliteRuntimeBinding> ReplacementDocumentTree
                 "missing OpenCode-family tree unexpectedly contained a leaf",
             ));
         };
+        let observation = leaf.observation.as_ref().ok_or_else(|| {
+            source_internal("exact OpenCode-family replay unexpectedly required a logical scan")
+        })?;
         let snapshot = leaf
             .snapshot
             .lock()
@@ -124,7 +136,7 @@ impl<B: crate::LogicalSqliteRuntimeBinding> ReplacementDocumentTree
         let scan = scan_pinned_source(
             &self.path,
             self.registration.dialect,
-            &leaf.observation,
+            observation,
             snapshot,
             &mut |output| match output {
                 OpenCodeScanOutput::Begin(source) => sink.begin_source(source).map_err(Into::into),
@@ -144,7 +156,7 @@ impl<B: crate::LogicalSqliteRuntimeBinding> ReplacementDocumentTree
             },
         )
         .map_err(route_error)?;
-        if !scan.source.exact_descriptor_eq(&leaf.observation.source) {
+        if !scan.source.exact_descriptor_eq(&observation.source) {
             return Err(source_changed(
                 "OpenCode-family projection did not match its logical observation",
             ));
@@ -173,6 +185,22 @@ impl<B: crate::LogicalSqliteRuntimeBinding> ReplacementDocumentTree
                     ));
                 };
                 let leaf = &observed.provider_leaf;
+                if let Some(replay) = &leaf.replay {
+                    replay
+                        .physical_fence
+                        .revalidate()
+                        .map_err(|error| route_error(error.into()))?;
+                    let current_fingerprint =
+                        admitted_leaf_fingerprint(&replay.source, replay.physical_fence.revision());
+                    if current_fingerprint != replay.leaf_fingerprint
+                        || current_fingerprint != tree.tree_fingerprint
+                    {
+                        return Err(source_changed(
+                            "OpenCode-family replay revision changed during staging",
+                        ));
+                    }
+                    return Ok(current_fingerprint);
+                }
                 if let Some(snapshot) = leaf
                     .snapshot
                     .lock()
@@ -196,6 +224,22 @@ impl<B: crate::LogicalSqliteRuntimeBinding> ReplacementDocumentTree
                 Ok(*tree_fingerprint)
             }
         }
+    }
+
+    fn durable_replay_source(
+        &self,
+        _authority: &Self::TreeAuthority,
+        leaf: &Self::Leaf,
+    ) -> SourceBackedRouteResult<Option<SourceKey>> {
+        Ok(leaf
+            .replay
+            .as_ref()
+            .map(|replay| replay.source.clone())
+            .or_else(|| {
+                leaf.observation
+                    .as_ref()
+                    .map(|observation| observation.source.clone())
+            }))
     }
 }
 
@@ -236,7 +280,9 @@ fn discover_document_tree(
     dialect: &'static crate::provider::providers::opencode::OpenCodeSqliteDialect,
     source_scope: SourceAnchorScope,
 ) -> OpenCodeSourceBackedResult<OpenCodeDocumentTree> {
-    discover_document_tree_with_progress(data_root, path, dialect, source_scope, &mut |_| Ok(()))
+    discover_document_tree_with_progress(data_root, path, dialect, source_scope, &[], &mut |_| {
+        Ok(())
+    })
 }
 
 #[cfg(test)]
@@ -253,10 +299,21 @@ fn discover_document_tree_with_progress(
     path: &std::path::Path,
     dialect: &'static crate::provider::providers::opencode::OpenCodeSqliteDialect,
     source_scope: SourceAnchorScope,
+    base_sources: &[CertifiedSource],
     report_progress: &mut dyn FnMut(
         SourceBackedCurrentSourceProgress,
     ) -> SourceBackedRouteResult<()>,
 ) -> OpenCodeSourceBackedResult<OpenCodeDocumentTree> {
+    if let Some(base) = exact_replay_base(base_sources, dialect.provider, source_scope) {
+        match observe_exact_replay_tree(data_root, path, base) {
+            Ok(Some(tree)) => return Ok(tree),
+            Ok(None) => {}
+            Err(OpenCodeSourceBackedError::SqliteSource(error))
+                if sqlite_retry_decision(&error) == SqliteRetryDecision::RetrySourceTransition => {}
+            Err(error) if source_missing(&error) => return observe_missing_document_tree(path),
+            Err(error) => return Err(error),
+        }
+    }
     match observe_present_document_tree_with_progress(
         data_root,
         path,
@@ -268,6 +325,59 @@ fn discover_document_tree_with_progress(
         Err(error) if source_missing(&error) => observe_missing_document_tree(path),
         Err(error) => Err(error),
     }
+}
+
+fn exact_replay_base(
+    base_sources: &[CertifiedSource],
+    provider: CaptureProvider,
+    source_scope: SourceAnchorScope,
+) -> Option<&CertifiedSource> {
+    let registration = registration_for_provider(provider)?;
+    let [base] = base_sources else {
+        return None;
+    };
+    (base.parser_revision() == PARSER_REVISION
+        && registration.owns_source(base.observation().source(), source_scope)
+        && decode_document_full_snapshot_checkpoint(base).is_ok())
+    .then_some(base)
+}
+
+fn observe_exact_replay_tree(
+    data_root: &Path,
+    path: &Path,
+    base: &CertifiedSource,
+) -> OpenCodeSourceBackedResult<Option<OpenCodeDocumentTree>> {
+    let Ok(checkpoint) = decode_document_full_snapshot_checkpoint(base) else {
+        return Ok(None);
+    };
+    let retained = retain_root_authorized_source(data_root, path)?;
+    let physical_fence = retained
+        .sqlite_authority
+        .observe_replay_fence(&retained.database_leaf)?;
+    let physical_revision = *physical_fence.revision();
+    let source = base.observation().source().clone();
+    let leaf_fingerprint = admitted_leaf_fingerprint(&source, &physical_revision);
+    if checkpoint.physical_fingerprint() != leaf_fingerprint {
+        return Ok(None);
+    }
+    Ok(Some(CompleteDocumentTree::new(
+        leaf_fingerprint,
+        vec![ObservedDocumentLeaf::with_durable_replay(
+            DocumentLeafFingerprint::new(leaf_fingerprint),
+            OpenCodeDocumentLeaf {
+                observation: None,
+                snapshot: Mutex::new(None),
+                terminal_fence: Mutex::new(None),
+                replay: Some(OpenCodeReplayLeaf {
+                    source,
+                    physical_fence,
+                    leaf_fingerprint,
+                }),
+            },
+            true,
+        )],
+        OpenCodeTreeAuthority::Present,
+    )))
 }
 
 fn observe_present_document_tree_with_progress(
@@ -295,7 +405,7 @@ fn observe_present_document_tree_with_progress(
     };
     let leaf_fingerprint = DocumentLeafFingerprint::new(admitted_leaf_fingerprint(
         &observation.source,
-        authorized.sqlite_snapshot.evidence(),
+        authorized.sqlite_snapshot.evidence().physical_revision(),
     ));
     let replay_from_frontier = authorized
         .sqlite_snapshot
@@ -306,9 +416,10 @@ fn observe_present_document_tree_with_progress(
         vec![ObservedDocumentLeaf::with_durable_replay(
             leaf_fingerprint,
             OpenCodeDocumentLeaf {
-                observation,
+                observation: Some(observation),
                 snapshot: Mutex::new(Some(authorized.sqlite_snapshot)),
                 terminal_fence: Mutex::new(None),
+                replay: None,
             },
             replay_from_frontier,
         )],
@@ -338,13 +449,13 @@ pub(super) fn abort_opencode_snapshot(
     }
 }
 
-fn admitted_leaf_fingerprint(source: &SourceKey, evidence: &SqliteSourceEvidence) -> [u8; 32] {
+fn admitted_leaf_fingerprint(source: &SourceKey, physical_revision: &[u8; 32]) -> [u8; 32] {
     let mut digest = Sha256::new();
-    digest.update(b"ctx.opencode-family-admitted-sqlite-revision-v1\0");
+    digest.update(b"ctx.opencode-family-admitted-sqlite-revision-v2\0");
     digest.update(source.exact_descriptor_digest());
     digest.update((PARSER_REVISION.len() as u64).to_be_bytes());
     digest.update(PARSER_REVISION.as_bytes());
-    digest.update(evidence.revision());
+    digest.update(physical_revision);
     digest.finalize().into()
 }
 

--- a/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/authority.rs
+++ b/crates/ctx-history-providers-sqlite-logical/src/providers/opencode/native_path/source_backed/authority.rs
@@ -1,0 +1,43 @@
+use std::{ffi::OsString, path::Path};
+
+use super::{OpenCodeSourceBackedResult, SQLITE_SOURCE_INVALID_REASON};
+use crate::{
+    common::io::ProviderSourceRoot,
+    provider_sources::{retain_sqlite_source_directory_authority, SqliteSourceDirectoryAuthority},
+    CaptureError,
+};
+
+#[derive(Debug)]
+pub(super) struct OpenCodeRetainedSource {
+    pub(super) source_root: ProviderSourceRoot,
+    pub(super) sqlite_authority: SqliteSourceDirectoryAuthority,
+    pub(super) database_leaf: OsString,
+}
+
+pub(super) fn retain_root_authorized_source(
+    data_root: &Path,
+    path: &Path,
+) -> OpenCodeSourceBackedResult<OpenCodeRetainedSource> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let database_leaf =
+        path.file_name()
+            .ok_or_else(|| CaptureError::InvalidProviderTranscriptPath {
+                path: path.to_path_buf(),
+                reason: SQLITE_SOURCE_INVALID_REASON,
+            })?;
+    let source_root = ProviderSourceRoot::open(parent)?;
+    let source_directory = source_root.directory()?;
+    let parent_handle = source_directory
+        .try_clone_authority_handle()
+        .map_err(CaptureError::from)?;
+    let sqlite_authority =
+        retain_sqlite_source_directory_authority(data_root, &parent_handle, parent)?;
+    Ok(OpenCodeRetainedSource {
+        source_root,
+        sqlite_authority,
+        database_leaf: database_leaf.to_os_string(),
+    })
+}

--- a/crates/ctx-history-providers-sqlite-logical/tests/bazel/capture_facade_replay.rs
+++ b/crates/ctx-history-providers-sqlite-logical/tests/bazel/capture_facade_replay.rs
@@ -6,10 +6,9 @@ use std::{
 
 use ctx_history_capture::{
     provider_source_for_path, register_landed_source_backed_route_with_data_root,
-    CaptureDocumentSpool, SourceBackedCoordinatorError, SourceBackedProviderRegistry,
-    SourceBackedRefreshExecutor, SourceBackedRefreshScope, SourceBackedRoute,
-    SourceBackedRouteControlExpectation, SourceBackedRouteError, SourceBackedRouteErrorKind,
-    SourceBackedRouteSelection, SourceBackedSelectorAuthority,
+    CaptureDocumentSpool, SourceBackedProviderRegistry, SourceBackedRefreshExecutor,
+    SourceBackedRefreshScope, SourceBackedRoute, SourceBackedRouteControlExpectation,
+    SourceBackedRouteErrorKind, SourceBackedRouteSelection, SourceBackedSelectorAuthority,
 };
 use ctx_history_capture_composition::IndexCaptureLifecycle;
 use ctx_history_capture_runtime::{
@@ -335,7 +334,7 @@ fn create_zed_database(path: &Path, text: &str) {
 }
 
 #[test]
-fn opencode_family_changed_wal_capture_then_exact_replay_finishes_progress() {
+fn opencode_family_changed_wal_capture_then_exact_replay_skips_source_family_copy() {
     for provider in [
         CaptureProvider::OpenCode,
         CaptureProvider::Kilo,
@@ -468,38 +467,61 @@ fn assert_opencode_family_changed_wal_capture_then_exact_replay(provider: Captur
         "{provider:?}"
     );
     assert!(terminal.progress.completed_bytes.is_none(), "{provider:?}");
+    assert!(
+        updates
+            .iter()
+            .all(|update| update.current_source_progress.is_none()),
+        "unchanged {provider:?} replay unexpectedly copied or scanned its SQLite source"
+    );
 
-    if provider != CaptureProvider::OpenCode {
-        return;
-    }
-
-    let error = executor
-        .refresh_scope_with_detailed_progress(
-            &index_root,
-            SourceBackedRefreshScope::All,
-            |update| {
-                if update.current_source_progress.is_some() {
-                    return Err(SourceBackedRouteError::new(
-                        SourceBackedRouteErrorKind::ResourceUnavailable,
-                        "injected logical SQLite replay progress failure",
-                    ));
-                }
-                Ok(())
-            },
+    let source = provider_source_for_path(provider, database.clone());
+    let LogicalSqliteRoutePlan::OpenCodeFamily { adapter, .. } =
+        logical_sqlite_route_plan_scoped::<ScopedReplayBinding>(
+            source,
+            SourceBackedRouteSelection::ExplicitManual,
+            data_root.path(),
+            SourceAnchorScope::Unqualified,
         )
-        .unwrap_err();
-    assert!(matches!(
-        error,
-        SourceBackedCoordinatorError::Progress(SourceBackedRouteError {
-            kind: SourceBackedRouteErrorKind::ResourceUnavailable,
-            detail,
-        }) if detail == "injected logical SQLite replay progress failure"
-    ));
+        .unwrap()
+    else {
+        panic!("unexpected logical SQLite replay provider")
+    };
+    let duplicate_bases = vec![replay.sources[0].clone(), replay.sources[0].clone()];
+    let mut duplicate_progress = Vec::new();
+    let duplicate_tree = adapter
+        .discover_complete_with_progress(&duplicate_bases, &mut |progress| {
+            duplicate_progress.push(progress);
+            Ok(())
+        })
+        .unwrap();
+    assert!(
+        !duplicate_progress.is_empty(),
+        "multi-source {provider:?} base incorrectly used exact replay"
+    );
+    drop(duplicate_tree);
+    let mut discovery_progress = Vec::new();
+    let replay_tree = adapter
+        .discover_complete_with_progress(&replay.sources, &mut |progress| {
+            discovery_progress.push(progress);
+            Ok(())
+        })
+        .unwrap();
+    assert!(discovery_progress.is_empty(), "{provider:?}");
+    writer
+        .execute(
+            "update part set data = ?1 where id = 'part-2'",
+            params![json!({
+                "type": "text",
+                "text": format!("{} post-discovery mutation", provider.as_str())
+            })
+            .to_string()],
+        )
+        .unwrap();
+    let error = adapter.revalidate_complete(&replay_tree).unwrap_err();
     assert_eq!(
-        VerifiedIndex::open_pinned(&index_root)
-            .unwrap()
-            .generation_id(),
-        changed_generation
+        error.kind,
+        SourceBackedRouteErrorKind::SourceChanged,
+        "{provider:?}"
     );
 }
 

--- a/crates/ctx-history-refresh-execution/src/tests/registry_policy.rs
+++ b/crates/ctx-history-refresh-execution/src/tests/registry_policy.rs
@@ -191,13 +191,38 @@ fn warm_automatic_hermes_profile_rename_retires_the_old_route_and_remains_refres
         &index_root,
     )
     .unwrap();
-    assert!(cold
-        .verified_index
-        .as_ref()
+    let (cold_generation, legacy_metadata) = {
+        let cold_index = cold.verified_index.as_ref().unwrap();
+        assert!(cold_index.manifest().source_route(&alpha_route).is_some());
+        let mut metadata = SourceBackedPublicationMetadata::decode(cold_index).unwrap();
+        let mut legacy: serde_json::Value = serde_json::from_slice(
+            metadata
+                .route_controls
+                .get(&alpha_route)
+                .expect("cold Hermes route control"),
+        )
+        .unwrap();
+        legacy["version"] = serde_json::json!(2);
+        legacy.as_object_mut().unwrap().remove("parser_revision");
+        legacy.as_object_mut().unwrap().remove("physical_revision");
+        metadata
+            .route_controls
+            .insert(alpha_route.clone(), serde_json::to_vec(&legacy).unwrap());
+        (
+            cold_index.generation_id().to_owned(),
+            metadata.encode().unwrap(),
+        )
+    };
+    drop(cold);
+    let writer = GenerationWriter::open(&index_root, WriterOptions::default())
         .unwrap()
-        .manifest()
-        .source_route(&alpha_route)
-        .is_some());
+        .into_writer()
+        .unwrap();
+    drop(
+        writer
+            .republish_current_publication_metadata(&cold_generation, legacy_metadata)
+            .unwrap(),
+    );
 
     std::fs::rename(alpha.parent().unwrap(), beta.parent().unwrap()).unwrap();
     let beta_source = provider_source_for_path(CaptureProvider::Hermes, beta);

--- a/crates/ctx-history-refresh/src/engine/startup_observation.rs
+++ b/crates/ctx-history-refresh/src/engine/startup_observation.rs
@@ -99,11 +99,14 @@ mod tests {
         .unwrap();
         let database_identity = [1_u8; 32];
         let schema_evidence = [2_u8; 32];
+        let physical_revision = [3_u8; 32];
         let revision = serde_json::to_vec(&serde_json::json!({
             "kind": "hermes-route-control-v1",
-            "version": 2,
+            "version": 3,
+            "parser_revision": "hermes-source-backed-v5-optional-admission",
             "profile_source_descriptor": profile_source_descriptor,
             "database_identity": database_identity,
+            "physical_revision": physical_revision,
             "schema_evidence": schema_evidence,
             "session_rowid": 4,
             "message_rowid": 9,

--- a/crates/ctx-history-source-sqlite/src/sqlite_source.rs
+++ b/crates/ctx-history-source-sqlite/src/sqlite_source.rs
@@ -269,6 +269,7 @@ pub struct SqliteSourceEvidence {
     length: u64,
     wal_length: Option<u64>,
     shared_memory_length: Option<u64>,
+    physical_revision: [u8; 32],
     schema: SqliteSchemaEvidence,
     source: SqliteConnectionEvidence,
     revision: [u8; 32],
@@ -286,6 +287,16 @@ impl SqliteSourceEvidence {
 
     pub fn revision(&self) -> &[u8; 32] {
         &self.revision
+    }
+
+    /// Returns the move-stable bounded DB/WAL content revision that can be
+    /// reobserved without copying or opening a logical SQLite snapshot.
+    ///
+    /// This token is suitable only for exact replay. Callers must reobserve it
+    /// through [`SqliteSourceReplayFence::revalidate`] at terminal validation
+    /// before publishing retained logical content.
+    pub fn physical_revision(&self) -> &[u8; 32] {
+        &self.physical_revision
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -364,9 +375,32 @@ impl SqliteSourceDirectoryAuthority {
         self.snapshot_context.snapshot()
     }
 
-    /// Observes one bounded physical DB/WAL family revision without copying or
-    /// opening a logical SQLite snapshot. The returned token is valid only for
-    /// exact replay and must be observed again during terminal revalidation.
+    /// Retains one exact physical DB/WAL revision for no-copy replay.
+    ///
+    /// Provider policy must first establish that its prior logical receipt or
+    /// frontier is eligible for replay. The returned fence owns physical
+    /// authority only and must be revalidated before retained logical content
+    /// is published.
+    pub fn observe_replay_fence(
+        &self,
+        database_name: &OsStr,
+    ) -> SqliteSourceAccessResult<SqliteSourceReplayFence> {
+        let family = SqliteSourceFamily::open(self, database_name, || {})?;
+        let evidence = family.capture_revision_evidence()?;
+        family.revalidate_revision(&evidence)?;
+        let revision = evidence.content_revision_token();
+        Ok(SqliteSourceReplayFence {
+            authority: self.clone(),
+            database_name: database_name.to_os_string(),
+            revision,
+            evidence,
+        })
+    }
+
+    /// Observes one bounded physical DB/WAL family revision without retaining
+    /// a fence. This lower-level API exists for bounded inventory routes that
+    /// cannot retain one directory authority per leaf; single-database replay
+    /// routes should prefer [`Self::observe_replay_fence`].
     pub fn observe_physical_revision(
         &self,
         database_name: &OsStr,
@@ -471,6 +505,38 @@ impl SqliteSourceDirectoryAuthority {
         } else {
             Err(SqliteSourceAccessError::SourceChanged)
         }
+    }
+}
+
+/// Retained physical authority for exact replay of one unchanged SQLite
+/// DB/WAL family.
+///
+/// This fence proves only that the provider-owned physical source is still the
+/// revision observed at construction. Parser, logical-source, and publication
+/// policy remain the responsibility of the provider adapter.
+#[derive(Debug)]
+#[must_use = "exact replay requires terminal revalidation before publication"]
+pub struct SqliteSourceReplayFence {
+    authority: SqliteSourceDirectoryAuthority,
+    database_name: OsString,
+    revision: [u8; 32],
+    evidence: SqliteFamilyEvidence,
+}
+
+impl SqliteSourceReplayFence {
+    pub fn revision(&self) -> &[u8; 32] {
+        &self.revision
+    }
+
+    /// Reobserves the retained DB/WAL family and fails closed unless its exact
+    /// native objects, metadata, and bounded content evidence still match the
+    /// admitted replay family.
+    pub fn revalidate(&self) -> SqliteSourceAccessResult<()> {
+        let family = SqliteSourceFamily::open(&self.authority, &self.database_name, || {})
+            .map_err(map_revalidation_error)?;
+        family
+            .revalidate_revision(&self.evidence)
+            .map_err(map_revalidation_error)
     }
 }
 

--- a/crates/ctx-history-source-sqlite/src/sqlite_source/family.rs
+++ b/crates/ctx-history-source-sqlite/src/sqlite_source/family.rs
@@ -668,6 +668,7 @@ impl SqliteSourceEvidence {
                 .as_ref()
                 .and_then(|state| (state.length != 0).then_some(state.length)),
             shared_memory_length: native.shared_memory.as_ref().map(|state| state.length),
+            physical_revision: native.content_revision_token(),
             schema: sqlite.schema.clone(),
             source: sqlite.source.clone(),
             revision: revision.finalize().into(),
@@ -676,6 +677,30 @@ impl SqliteSourceEvidence {
 }
 
 impl SqliteFamilyEvidence {
+    /// Bounded DB/WAL content evidence suitable for persisted replay policy.
+    ///
+    /// Native object and parent identities are deliberately excluded so an
+    /// unchanged SQLite family keeps the same content revision when moved.
+    /// A replay fence retains the full native evidence separately and still
+    /// rejects object replacement during one publication attempt.
+    pub(super) fn content_revision_token(&self) -> [u8; 32] {
+        let mut digest = Sha256::new();
+        digest.update(EVIDENCE_DOMAIN);
+        digest.update(b"content-revision\0");
+        digest.update(self.database.length.to_le_bytes());
+        digest.update(self.database_token);
+        let committed_wal = self.wal.as_ref().filter(|state| state.length != 0);
+        match committed_wal.zip(self.wal_token) {
+            Some((wal, wal_token)) => {
+                digest.update([1]);
+                digest.update(wal.length.to_le_bytes());
+                digest.update(wal_token);
+            }
+            None => digest.update([0]),
+        }
+        digest.finalize().into()
+    }
+
     pub(super) fn revision_token(&self) -> [u8; 32] {
         let mut digest = Sha256::new();
         digest.update(EVIDENCE_DOMAIN);

--- a/crates/ctx-history-source-sqlite/src/sqlite_source/tests.rs
+++ b/crates/ctx-history-source-sqlite/src/sqlite_source/tests.rs
@@ -158,6 +158,115 @@ fn read_values_from_connection(connection: &Connection) -> Vec<String> {
         .unwrap()
 }
 
+#[test]
+fn physical_replay_fence_unchanged_is_zero_copy() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let data_root = crate::test_support_paths::tempdir().unwrap();
+    let database = temp.path().join("provider.sqlite");
+    create_database(&database, "first");
+    let authority = retain_parent_in_data_root(data_root.path(), temp.path());
+    let fence = authority
+        .observe_replay_fence(OsStr::new("provider.sqlite"))
+        .unwrap();
+    let revision = *fence.revision();
+
+    fence.revalidate().unwrap();
+    assert_eq!(authority.snapshot_counters(), Default::default());
+    assert_eq!(staging_entries(data_root.path()), 0);
+    assert_eq!(*fence.revision(), revision);
+}
+
+#[test]
+fn physical_replay_revision_survives_move_but_old_fence_rejects_it() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let data_root = crate::test_support_paths::tempdir().unwrap();
+    let original = temp.path().join("original");
+    let moved = temp.path().join("moved");
+    fs::create_dir(&original).unwrap();
+    fs::create_dir(&moved).unwrap();
+    create_database(&original.join("provider.sqlite"), "first");
+    let original_authority = retain_parent_in_data_root(data_root.path(), &original);
+    let original_fence = original_authority
+        .observe_replay_fence(OsStr::new("provider.sqlite"))
+        .unwrap();
+    let revision = *original_fence.revision();
+
+    fs::rename(
+        original.join("provider.sqlite"),
+        moved.join("provider.sqlite"),
+    )
+    .unwrap();
+    assert!(matches!(
+        original_fence.revalidate(),
+        Err(SqliteSourceAccessError::SourceChanged)
+    ));
+
+    let moved_authority = retain_parent_in_data_root(data_root.path(), &moved);
+    let moved_fence = moved_authority
+        .observe_replay_fence(OsStr::new("provider.sqlite"))
+        .unwrap();
+    assert_eq!(*moved_fence.revision(), revision);
+    moved_fence.revalidate().unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn physical_replay_fence_rejects_committed_wal_mutation() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let data_root = crate::test_support_paths::tempdir().unwrap();
+    let database = temp.path().join("provider.sqlite");
+    let writer = create_persistent_wal(&database);
+    let authority = retain_parent_in_data_root(data_root.path(), temp.path());
+    let fence = authority
+        .observe_replay_fence(OsStr::new("provider.sqlite"))
+        .unwrap();
+
+    writer
+        .execute("INSERT INTO messages (body) VALUES ('later')", [])
+        .unwrap();
+
+    assert!(matches!(
+        fence.revalidate(),
+        Err(SqliteSourceAccessError::SourceChanged)
+    ));
+    assert_eq!(authority.snapshot_counters(), Default::default());
+    assert_eq!(staging_entries(data_root.path()), 0);
+}
+
+#[test]
+fn physical_replay_fence_rejects_database_leaf_and_parent_replacement() {
+    let data_root = crate::test_support_paths::tempdir().unwrap();
+    let leaf_root = crate::test_support_paths::tempdir().unwrap();
+    let database = leaf_root.path().join("provider.sqlite");
+    create_database(&database, "first");
+    let authority = retain_parent_in_data_root(data_root.path(), leaf_root.path());
+    let fence = authority
+        .observe_replay_fence(OsStr::new("provider.sqlite"))
+        .unwrap();
+    fs::rename(&database, leaf_root.path().join("retired.sqlite")).unwrap();
+    create_database(&database, "first");
+    assert!(matches!(
+        fence.revalidate(),
+        Err(SqliteSourceAccessError::SourceChanged)
+    ));
+
+    let parent_root = crate::test_support_paths::tempdir().unwrap();
+    let parent = parent_root.path().join("source");
+    fs::create_dir(&parent).unwrap();
+    create_database(&parent.join("provider.sqlite"), "first");
+    let authority = retain_parent_in_data_root(data_root.path(), &parent);
+    let fence = authority
+        .observe_replay_fence(OsStr::new("provider.sqlite"))
+        .unwrap();
+    fs::rename(&parent, parent_root.path().join("retired-source")).unwrap();
+    fs::create_dir(&parent).unwrap();
+    create_database(&parent.join("provider.sqlite"), "first");
+    assert!(matches!(
+        fence.revalidate(),
+        Err(SqliteSourceAccessError::SourceChanged)
+    ));
+}
+
 fn directory_file_bytes(path: &Path) -> BTreeMap<OsString, Vec<u8>> {
     fs::read_dir(path)
         .unwrap()


### PR DESCRIPTION
Add a shared SQLite replay fence that separates move-stable content evidence from exact terminal native-object validation.

Reuse certified Hermes, OpenCode, Kilo Code, and MiMoCode sources without snapshot copies or logical rescans, while preserving fail-closed migration, incremental, rename-retirement, and terminal-race behavior.

Fixes #865