### PR TITLE
Refresh managed skills after ctx upgrades

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -575,7 +575,7 @@
           "FILE:@@//crates/ctx-history-read-application/Cargo.toml f34a1bd70159bee58951e815600f110138f4e6d2649f683870d5e82f62e8e0ab",
           "FILE:@@//crates/ctx-terminal/Cargo.toml 313f5c2df8c96fa7384349af631e1679981cafa7a0ad378e68b931b963869b51",
           "FILE:@@//crates/ctx-history-ingest-application/Cargo.toml 0fdad960edeb31222f10d474799875b20a90e5a789989c8eebe745a8f129917a",
-          "FILE:@@//crates/ctx-cli-contract-tests/Cargo.toml a946ba841f232d82d7d65d5bbf3004b2e5f2cc9efabdd9cb1333fa1df18383c5",
+          "FILE:@@//crates/ctx-cli-contract-tests/Cargo.toml 1d7777e2c5edbb0bbe8a78f69c83aeb67a7d5a24d6dba0c04d161330afce40f8",
           "FILE:@@//crates/ctx-cli-qualification/Cargo.toml 2558dd357a1b5445d3f601cd394a4960cfa632c3770162758b27db86d3688c06",
           "FILE:@@//crates/ctx-history-capture-composition-qualification/Cargo.toml f5592cadb3de3c83311395ee8bbf924cb9ba2a1f27f90d8756609ab7faf6df9c",
           "FILE:@@//crates/ctx-history-index-qualification/Cargo.toml 5c38fb44ed3bde6c243085c9e927daab28fec34516f05545eaec25f8a6e03e14",

--- a/crates/ctx-agent-integrations/src/skill/install.rs
+++ b/crates/ctx-agent-integrations/src/skill/install.rs
@@ -271,7 +271,7 @@ fn inspect_discovered_skill_path(
 }
 
 #[cfg(windows)]
-fn is_windows_reparse_point(metadata: &fs::Metadata) -> bool {
+pub(super) fn is_windows_reparse_point(metadata: &fs::Metadata) -> bool {
     use std::os::windows::fs::MetadataExt as _;
 
     const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
@@ -279,7 +279,7 @@ fn is_windows_reparse_point(metadata: &fs::Metadata) -> bool {
 }
 
 #[cfg(not(windows))]
-fn is_windows_reparse_point(_metadata: &fs::Metadata) -> bool {
+pub(super) fn is_windows_reparse_point(_metadata: &fs::Metadata) -> bool {
     false
 }
 
@@ -317,6 +317,9 @@ pub fn install_target(
         });
     }
     if current_content {
+        if !metadata_is_current(previous.metadata.as_ref(), product_version) {
+            write_metadata(target, product_version)?;
+        }
         if migrates_legacy {
             remove_legacy_skill_files(
                 target,
@@ -325,9 +328,6 @@ pub fn install_target(
                     .as_ref()
                     .expect("legacy status has a snapshot"),
             )?;
-        }
-        if !metadata_is_current(previous.metadata.as_ref(), product_version) {
-            write_metadata(target, product_version)?;
         }
         return Ok(InstallResult {
             target: target.clone(),
@@ -342,24 +342,15 @@ pub fn install_target(
         });
     }
     if migrates_legacy {
-        let prior_body = read_optional_regular_file(&target.skill_dir.join("SKILL.md"))?;
         write_skill_body(target)?;
-        if let Err(cleanup) = remove_legacy_skill_files(
+        write_metadata(target, product_version)?;
+        remove_legacy_skill_files(
             target,
             previous
                 .legacy_snapshot
                 .as_ref()
                 .expect("legacy status has a snapshot"),
-        ) {
-            if let Err(rollback) = rollback_skill_body(target, prior_body.as_deref()) {
-                return Err(anyhow!(
-                    "{cleanup:#}; failed to roll back {} after migration cleanup failed: {rollback:#}",
-                    target.skill_dir.join("SKILL.md").display()
-                ));
-            }
-            return Err(cleanup);
-        }
-        write_metadata(target, product_version)?;
+        )?;
     } else {
         write_skill_files(target, product_version)?;
     }
@@ -436,19 +427,18 @@ fn inspect_legacy_skill(skill_dir: &Path) -> Result<Option<LegacySkillSnapshot>>
         return Ok(None);
     };
     let installed_hash = sha256_hex(&body);
-    let metadata_body = read_optional_regular_file(&skill_dir.join(METADATA_FILE))
-        .ok()
-        .flatten();
+    let metadata_body = read_optional_regular_file(&skill_dir.join(METADATA_FILE))?;
     let metadata = metadata_body
         .as_deref()
         .and_then(|body| serde_json::from_slice(body).ok());
     let metadata_is_managed = metadata_manages_legacy_hash(metadata.as_ref(), &installed_hash);
-    let status =
-        if LEGACY_BUNDLED_SKILL_HASHES.contains(&installed_hash.as_str()) || metadata_is_managed {
-            SkillInstallStatus::Stale
-        } else {
-            SkillInstallStatus::Modified
-        };
+    let metadata_free_released_legacy =
+        metadata_body.is_none() && LEGACY_BUNDLED_SKILL_HASHES.contains(&installed_hash.as_str());
+    let status = if metadata_is_managed || metadata_free_released_legacy {
+        SkillInstallStatus::Stale
+    } else {
+        SkillInstallStatus::Modified
+    };
     Ok(Some(LegacySkillSnapshot {
         status,
         body,
@@ -527,22 +517,6 @@ pub(super) fn read_optional_regular_file(path: &Path) -> Result<Option<Vec<u8>>>
         Ok(_) => Err(anyhow!("target is not a regular file: {}", path.display())),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
         Err(error) => Err(error).with_context(|| format!("inspect {}", path.display())),
-    }
-}
-
-fn rollback_skill_body(target: &SkillTarget, prior_body: Option<&[u8]>) -> Result<()> {
-    let path = target.skill_dir.join("SKILL.md");
-    match prior_body {
-        Some(prior_body) => atomic_update(&path, |existing| {
-            if existing != Some(BUNDLED_SKILL_BODY.as_bytes()) {
-                return Err(anyhow!(
-                    "refusing to overwrite concurrently changed target {}",
-                    path.display()
-                ));
-            }
-            Ok(prior_body.to_vec())
-        }),
-        None => atomic_remove_if_unchanged(&path, BUNDLED_SKILL_BODY.as_bytes()).map(|_| ()),
     }
 }
 
@@ -890,11 +864,8 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
-    fn failed_legacy_cleanup_rolls_back_the_new_skill_body() {
-        use std::os::unix::fs::PermissionsExt as _;
-
+    fn failed_legacy_cleanup_keeps_the_published_current_skill() {
         let root = tempfile::tempdir().unwrap();
         let context = super::super::PathContext::for_tests(
             root.path().join("home"),
@@ -904,14 +875,26 @@ mod tests {
             super::super::single_target(super::super::SkillAgentArg::Universal, false, &context)
                 .unwrap();
         let legacy_dir = write_managed_legacy_skill(&target, b"managed legacy\n");
-        fs::set_permissions(&legacy_dir, fs::Permissions::from_mode(0o555)).unwrap();
+        fs::create_dir(legacy_dir.join(".SKILL.md.ctx-agent-integrations.lock")).unwrap();
 
         let error = install_target(&target, false, true, "1.0.0").unwrap_err();
 
-        fs::set_permissions(&legacy_dir, fs::Permissions::from_mode(0o755)).unwrap();
         assert!(format!("{error:#}").contains("transaction lock"));
         assert!(legacy_dir.join("SKILL.md").is_file());
-        assert!(!target.skill_dir.join("SKILL.md").exists());
+        assert_eq!(
+            fs::read(target.skill_dir.join("SKILL.md")).unwrap(),
+            BUNDLED_SKILL_BODY.as_bytes()
+        );
+        assert_eq!(
+            status_target(&target).unwrap().status,
+            SkillInstallStatus::Stale,
+            "the retained legacy copy still requires cleanup"
+        );
+        let metadata: SkillMetadata =
+            serde_json::from_slice(&fs::read(target.skill_dir.join(METADATA_FILE)).unwrap())
+                .unwrap();
+        assert_eq!(metadata.ctx_cli_version, "1.0.0");
+        assert_eq!(metadata.skill_hash, bundled_hash());
     }
 
     #[test]

--- a/crates/ctx-agent-integrations/src/skill/mod.rs
+++ b/crates/ctx-agent-integrations/src/skill/mod.rs
@@ -1,6 +1,7 @@
 mod agents;
 mod install;
 mod paths;
+mod refresh;
 mod remove;
 mod selection;
 mod target;
@@ -12,6 +13,7 @@ pub use install::{
     SkillStatusReceipt, SkillStatusRequest, StatusResult,
 };
 pub use paths::{bundled_hash, ensure_path_inside, sanitize_skill_name, sha256_hex, PathContext};
+pub use refresh::{existing_managed_skill_refresh_required, refresh_existing_managed_skills};
 pub use remove::{
     execute_remove, remove_target, SkillRemoveReceipt, SkillRemoveRequest, SkillRemoveResult,
 };

--- a/crates/ctx-agent-integrations/src/skill/paths.rs
+++ b/crates/ctx-agent-integrations/src/skill/paths.rs
@@ -20,6 +20,14 @@ pub struct PathContext {
 
 impl PathContext {
     pub fn from_env() -> Result<Self> {
+        Self::from_env_with_agent_override_policy(false)
+    }
+
+    pub fn from_env_best_effort() -> Result<Self> {
+        Self::from_env_with_agent_override_policy(true)
+    }
+
+    fn from_env_with_agent_override_policy(ignore_invalid_agent_overrides: bool) -> Result<Self> {
         let home = home_dir().context("resolve home directory")?;
         let xdg_config_home =
             non_empty_env_path("XDG_CONFIG_HOME").unwrap_or_else(|| home.join(".config"));
@@ -29,10 +37,16 @@ impl PathContext {
                 env_overrides.insert(key.to_owned(), path);
             }
         }
-        if let Some(path) = non_empty_absolute_env_path("MIMOCODE_HOME")? {
+        if let Some(path) = agent_home_override(
+            non_empty_absolute_env_path("MIMOCODE_HOME"),
+            ignore_invalid_agent_overrides,
+        )? {
             env_overrides.insert("MIMOCODE_HOME".to_owned(), path);
         }
-        if let Some(path) = absolute_env_path_if_present("GROK_HOME")? {
+        if let Some(path) = agent_home_override(
+            absolute_env_path_if_present("GROK_HOME"),
+            ignore_invalid_agent_overrides,
+        )? {
             env_overrides.insert("GROK_HOME".to_owned(), path);
         }
         if let Some(path) = non_empty_env_path("MIMOCODE_CONFIG_DIR") {
@@ -129,6 +143,16 @@ fn absolute_env_path_if_present(key: &str) -> Result<Option<PathBuf>> {
     validate_absolute_env_path(key, env::var_os(key))
 }
 
+fn agent_home_override(
+    override_path: Result<Option<PathBuf>>,
+    ignore_invalid: bool,
+) -> Result<Option<PathBuf>> {
+    match override_path {
+        Err(_) if ignore_invalid => Ok(None),
+        result => result,
+    }
+}
+
 fn validate_absolute_env_path(key: &str, value: Option<OsString>) -> Result<Option<PathBuf>> {
     let Some(value) = value else {
         return Ok(None);
@@ -208,5 +232,20 @@ mod env_path_tests {
             Some(PathBuf::from("/grok-home"))
         );
         assert_eq!(validate_absolute_env_path("GROK_HOME", None).unwrap(), None);
+    }
+
+    #[test]
+    fn best_effort_policy_ignores_only_invalid_agent_home_overrides() {
+        let invalid = || validate_absolute_env_path("GROK_HOME", Some("relative".into()));
+        assert!(agent_home_override(invalid(), false).is_err());
+        assert_eq!(agent_home_override(invalid(), true).unwrap(), None);
+        assert_eq!(
+            agent_home_override(
+                validate_absolute_env_path("GROK_HOME", Some("/grok-home".into())),
+                true,
+            )
+            .unwrap(),
+            Some(PathBuf::from("/grok-home"))
+        );
     }
 }

--- a/crates/ctx-agent-integrations/src/skill/refresh.rs
+++ b/crates/ctx-agent-integrations/src/skill/refresh.rs
@@ -1,0 +1,550 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Result;
+
+use super::{
+    bundled_hash,
+    install::{
+        is_windows_reparse_point, legacy_skill_dir, metadata_manages_hash,
+        read_optional_regular_file,
+    },
+    install_target, single_target, status_target, PathContext, SkillAgentArg, SkillInstallStatus,
+    SkillTarget, METADATA_FILE,
+};
+
+const MAX_AUTOMATIC_SKILL_BYTES: u64 = 1024 * 1024;
+const MAX_AUTOMATIC_METADATA_BYTES: u64 = 64 * 1024;
+
+pub fn existing_managed_skill_refresh_required(context: &PathContext) -> bool {
+    distinct_global_targets(context)
+        .iter()
+        .any(|target| target_refresh_required(target).unwrap_or(false))
+}
+
+pub fn refresh_existing_managed_skills(context: &PathContext, product_version: &str) {
+    for target in distinct_global_targets(context) {
+        if !target_refresh_required(&target).unwrap_or(false) {
+            continue;
+        }
+        let _ = install_target(&target, false, false, product_version);
+    }
+}
+
+fn distinct_global_targets(context: &PathContext) -> Vec<SkillTarget> {
+    let mut skill_dirs = Vec::<PathBuf>::new();
+    let mut targets = Vec::new();
+    for agent in SkillAgentArg::ALL.iter().copied() {
+        let Ok(target) = single_target(agent, false, context) else {
+            continue;
+        };
+        if skill_dirs.contains(&target.skill_dir) {
+            continue;
+        }
+        skill_dirs.push(target.skill_dir.clone());
+        targets.push(target);
+    }
+    targets
+}
+
+fn target_refresh_required(target: &SkillTarget) -> Result<bool> {
+    if !automatic_target_files_are_bounded(target) {
+        return Ok(false);
+    }
+    let status = status_target(target)?;
+    if status.legacy_status == Some(SkillInstallStatus::Modified) {
+        return Ok(false);
+    }
+    let has_managed_legacy = status.legacy_status == Some(SkillInstallStatus::Stale);
+    let metadata_path = target.skill_dir.join(METADATA_FILE);
+    let current_metadata_absent = read_optional_regular_file(&metadata_path)?.is_none();
+    let Some(installed_hash) = status.installed_hash.as_deref() else {
+        // A current-name metadata file without its body is an ambiguous pair,
+        // even when a legacy copy could otherwise authorize migration.
+        return Ok(current_metadata_absent && has_managed_legacy);
+    };
+    if !metadata_manages_hash(status.metadata.as_ref(), installed_hash) {
+        // This is the one unambiguous journal-free recovery state: migration
+        // published the exact current body, metadata publication failed, and
+        // the recognized legacy copy remains to authorize a retry.
+        return Ok(current_metadata_absent
+            && has_managed_legacy
+            && installed_hash == bundled_hash());
+    }
+    Ok(installed_hash != bundled_hash() || has_managed_legacy)
+}
+
+fn automatic_target_files_are_bounded(target: &SkillTarget) -> bool {
+    let Ok(legacy_dir) = legacy_skill_dir(target) else {
+        return false;
+    };
+    [
+        (target.skill_dir.join("SKILL.md"), MAX_AUTOMATIC_SKILL_BYTES),
+        (
+            target.skill_dir.join(METADATA_FILE),
+            MAX_AUTOMATIC_METADATA_BYTES,
+        ),
+        (legacy_dir.join("SKILL.md"), MAX_AUTOMATIC_SKILL_BYTES),
+        (legacy_dir.join(METADATA_FILE), MAX_AUTOMATIC_METADATA_BYTES),
+    ]
+    .into_iter()
+    .all(|(path, max_bytes)| optional_regular_file_is_bounded(&path, max_bytes))
+}
+
+fn optional_regular_file_is_bounded(path: &Path, max_bytes: u64) -> bool {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            metadata.file_type().is_file()
+                && !is_windows_reparse_point(&metadata)
+                && metadata.len() <= max_bytes
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => true,
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+    use crate::skill::{
+        sha256_hex, SkillMetadata, BUNDLED_SKILL_BODY, BUNDLED_SKILL_NAME,
+        LEGACY_BUNDLED_SKILL_NAME,
+    };
+
+    const RELEASED_LEGACY_SKILL_V0_17_0: &[u8] = include_bytes!("testdata/legacy_skill_v0_17_0.md");
+    const TEST_PRODUCT_VERSION: &str = "1.2.3";
+
+    fn test_context(root: &tempfile::TempDir) -> PathContext {
+        PathContext::for_tests(root.path().join("home"), root.path().join("repo"))
+    }
+
+    fn metadata_body(
+        installer: &str,
+        skill_name: &str,
+        managed_body: &[u8],
+        padding_bytes: usize,
+    ) -> Vec<u8> {
+        let metadata = SkillMetadata {
+            schema_version: 1,
+            installer: installer.to_owned(),
+            skill_name: skill_name.to_owned(),
+            skill_hash: sha256_hex(managed_body),
+            ctx_cli_version: "0.1.0".to_owned(),
+            installed_at: "2026-01-01T00:00:00Z".to_owned(),
+        };
+        let mut value = serde_json::to_value(metadata).unwrap();
+        if padding_bytes > 0 {
+            value.as_object_mut().unwrap().insert(
+                "padding".to_owned(),
+                serde_json::Value::String("x".repeat(padding_bytes)),
+            );
+        }
+        serde_json::to_vec_pretty(&value).unwrap()
+    }
+
+    fn write_owned_current(target: &SkillTarget, body: &[u8]) {
+        fs::create_dir_all(&target.skill_dir).unwrap();
+        fs::write(target.skill_dir.join("SKILL.md"), body).unwrap();
+        fs::write(
+            target.skill_dir.join(METADATA_FILE),
+            metadata_body("ctx-cli", BUNDLED_SKILL_NAME, body, 0),
+        )
+        .unwrap();
+    }
+
+    fn write_owned_legacy(target: &SkillTarget, body: &[u8], padding_bytes: usize) -> PathBuf {
+        let legacy_dir = target.base_dir.join(LEGACY_BUNDLED_SKILL_NAME);
+        fs::create_dir_all(&legacy_dir).unwrap();
+        fs::write(legacy_dir.join("SKILL.md"), body).unwrap();
+        fs::write(
+            legacy_dir.join(METADATA_FILE),
+            metadata_body("ctx-cli", LEGACY_BUNDLED_SKILL_NAME, body, padding_bytes),
+        )
+        .unwrap();
+        legacy_dir
+    }
+
+    fn managed_file_paths(target: &SkillTarget) -> Vec<PathBuf> {
+        let legacy_dir = target.base_dir.join(LEGACY_BUNDLED_SKILL_NAME);
+        vec![
+            target.skill_dir.join("SKILL.md"),
+            target.skill_dir.join(METADATA_FILE),
+            legacy_dir.join("SKILL.md"),
+            legacy_dir.join(METADATA_FILE),
+        ]
+    }
+
+    fn optional_test_file(path: &Path) -> Option<Vec<u8>> {
+        match fs::read(path) {
+            Ok(body) => Some(body),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => panic!("read {}: {error}", path.display()),
+        }
+    }
+
+    fn assert_automatic_refresh_preserves(
+        context: &PathContext,
+        target: &SkillTarget,
+        scenario: &str,
+    ) {
+        let paths = managed_file_paths(target);
+        let before = paths
+            .iter()
+            .map(|path| optional_test_file(path))
+            .collect::<Vec<_>>();
+
+        assert!(
+            !existing_managed_skill_refresh_required(context),
+            "{scenario}"
+        );
+        refresh_existing_managed_skills(context, TEST_PRODUCT_VERSION);
+
+        let after = paths
+            .iter()
+            .map(|path| optional_test_file(path))
+            .collect::<Vec<_>>();
+        assert_eq!(after, before, "{scenario}");
+        for path in paths {
+            let lock_name = format!(
+                ".{}.ctx-agent-integrations.lock",
+                path.file_name().unwrap().to_string_lossy()
+            );
+            assert!(!path.with_file_name(lock_name).exists(), "{scenario}");
+        }
+    }
+
+    #[test]
+    fn stale_owned_current_skill_is_refreshed() {
+        let root = tempfile::tempdir().unwrap();
+        let context = test_context(&root);
+        let target = single_target(SkillAgentArg::Universal, false, &context).unwrap();
+        write_owned_current(&target, b"previous managed skill\n");
+
+        assert!(existing_managed_skill_refresh_required(&context));
+        refresh_existing_managed_skills(&context, TEST_PRODUCT_VERSION);
+
+        assert_eq!(
+            fs::read(target.skill_dir.join("SKILL.md")).unwrap(),
+            BUNDLED_SKILL_BODY.as_bytes()
+        );
+        let metadata: SkillMetadata =
+            serde_json::from_slice(&fs::read(target.skill_dir.join(METADATA_FILE)).unwrap())
+                .unwrap();
+        assert_eq!(metadata.skill_hash, bundled_hash());
+        assert_eq!(metadata.ctx_cli_version, TEST_PRODUCT_VERSION);
+        assert!(!existing_managed_skill_refresh_required(&context));
+    }
+
+    #[test]
+    fn released_metadata_free_legacy_skill_is_migrated() {
+        let root = tempfile::tempdir().unwrap();
+        let context = test_context(&root);
+        let target = single_target(SkillAgentArg::Universal, false, &context).unwrap();
+        let legacy_dir = target.base_dir.join(LEGACY_BUNDLED_SKILL_NAME);
+        fs::create_dir_all(&legacy_dir).unwrap();
+        fs::write(legacy_dir.join("SKILL.md"), RELEASED_LEGACY_SKILL_V0_17_0).unwrap();
+
+        assert!(existing_managed_skill_refresh_required(&context));
+        refresh_existing_managed_skills(&context, TEST_PRODUCT_VERSION);
+
+        assert_eq!(
+            fs::read(target.skill_dir.join("SKILL.md")).unwrap(),
+            BUNDLED_SKILL_BODY.as_bytes()
+        );
+        let metadata: SkillMetadata =
+            serde_json::from_slice(&fs::read(target.skill_dir.join(METADATA_FILE)).unwrap())
+                .unwrap();
+        assert_eq!(metadata.ctx_cli_version, TEST_PRODUCT_VERSION);
+        assert!(!legacy_dir.join("SKILL.md").exists());
+    }
+
+    #[test]
+    fn released_legacy_with_untrusted_metadata_is_preserved() {
+        let cases = [
+            ("malformed", b"{not-json\n".to_vec()),
+            (
+                "foreign",
+                metadata_body(
+                    "another-installer",
+                    LEGACY_BUNDLED_SKILL_NAME,
+                    RELEASED_LEGACY_SKILL_V0_17_0,
+                    0,
+                ),
+            ),
+            (
+                "mismatched",
+                metadata_body(
+                    "ctx-cli",
+                    LEGACY_BUNDLED_SKILL_NAME,
+                    b"different legacy body\n",
+                    0,
+                ),
+            ),
+        ];
+
+        for (scenario, metadata) in cases {
+            let root = tempfile::tempdir().unwrap();
+            let context = test_context(&root);
+            let target = single_target(SkillAgentArg::Universal, false, &context).unwrap();
+            let legacy_dir = target.base_dir.join(LEGACY_BUNDLED_SKILL_NAME);
+            fs::create_dir_all(&legacy_dir).unwrap();
+            fs::write(legacy_dir.join("SKILL.md"), RELEASED_LEGACY_SKILL_V0_17_0).unwrap();
+            fs::write(legacy_dir.join(METADATA_FILE), &metadata).unwrap();
+
+            assert_eq!(
+                status_target(&target).unwrap().legacy_status,
+                Some(SkillInstallStatus::Modified),
+                "{scenario}"
+            );
+            let explicit = install_target(&target, false, true, TEST_PRODUCT_VERSION).unwrap();
+            assert!(!explicit.success, "{scenario}");
+            assert_automatic_refresh_preserves(&context, &target, scenario);
+        }
+    }
+
+    #[test]
+    fn missing_skill_roots_are_not_created() {
+        let root = tempfile::tempdir().unwrap();
+        let context = test_context(&root);
+        assert!(!context.home.exists());
+
+        assert!(!existing_managed_skill_refresh_required(&context));
+        refresh_existing_managed_skills(&context, TEST_PRODUCT_VERSION);
+
+        assert!(!context.home.exists());
+        assert!(!context.cwd.exists());
+    }
+
+    #[test]
+    fn metadata_free_and_mismatched_current_skills_are_preserved() {
+        let root = tempfile::tempdir().unwrap();
+        let context = test_context(&root);
+        let metadata_free = single_target(SkillAgentArg::Universal, false, &context).unwrap();
+        fs::create_dir_all(&metadata_free.skill_dir).unwrap();
+        fs::write(metadata_free.skill_dir.join("SKILL.md"), BUNDLED_SKILL_BODY).unwrap();
+
+        let mismatched = single_target(SkillAgentArg::Codex, false, &context).unwrap();
+        fs::create_dir_all(&mismatched.skill_dir).unwrap();
+        fs::write(mismatched.skill_dir.join("SKILL.md"), b"local body\n").unwrap();
+        let mismatched_metadata = SkillMetadata {
+            schema_version: 1,
+            installer: "ctx-cli".to_owned(),
+            skill_name: BUNDLED_SKILL_NAME.to_owned(),
+            skill_hash: sha256_hex(b"different body\n"),
+            ctx_cli_version: "0.1.0".to_owned(),
+            installed_at: "2026-01-01T00:00:00Z".to_owned(),
+        };
+        let mismatched_metadata_body = serde_json::to_vec_pretty(&mismatched_metadata).unwrap();
+        fs::write(
+            mismatched.skill_dir.join(METADATA_FILE),
+            &mismatched_metadata_body,
+        )
+        .unwrap();
+
+        assert!(!existing_managed_skill_refresh_required(&context));
+        refresh_existing_managed_skills(&context, TEST_PRODUCT_VERSION);
+
+        assert_eq!(
+            fs::read(metadata_free.skill_dir.join("SKILL.md")).unwrap(),
+            BUNDLED_SKILL_BODY.as_bytes()
+        );
+        assert!(!metadata_free.skill_dir.join(METADATA_FILE).exists());
+        assert_eq!(
+            fs::read(mismatched.skill_dir.join("SKILL.md")).unwrap(),
+            b"local body\n"
+        );
+        assert_eq!(
+            fs::read(mismatched.skill_dir.join(METADATA_FILE)).unwrap(),
+            mismatched_metadata_body
+        );
+    }
+
+    #[test]
+    fn malformed_orphaned_current_metadata_blocks_legacy_migration() {
+        let root = tempfile::tempdir().unwrap();
+        let context = test_context(&root);
+        let target = single_target(SkillAgentArg::Universal, false, &context).unwrap();
+        fs::create_dir_all(&target.skill_dir).unwrap();
+        let malformed_metadata = b"{not-json\n";
+        fs::write(target.skill_dir.join(METADATA_FILE), malformed_metadata).unwrap();
+        let legacy_dir = target.base_dir.join(LEGACY_BUNDLED_SKILL_NAME);
+        fs::create_dir_all(&legacy_dir).unwrap();
+        fs::write(legacy_dir.join("SKILL.md"), RELEASED_LEGACY_SKILL_V0_17_0).unwrap();
+
+        assert!(!existing_managed_skill_refresh_required(&context));
+        refresh_existing_managed_skills(&context, TEST_PRODUCT_VERSION);
+
+        assert!(!target.skill_dir.join("SKILL.md").exists());
+        assert_eq!(
+            fs::read(target.skill_dir.join(METADATA_FILE)).unwrap(),
+            malformed_metadata
+        );
+        assert_eq!(
+            fs::read(legacy_dir.join("SKILL.md")).unwrap(),
+            RELEASED_LEGACY_SKILL_V0_17_0
+        );
+    }
+
+    #[test]
+    fn present_untrusted_current_metadata_blocks_interrupted_migration_recovery() {
+        let cases = [
+            ("malformed", b"{not-json\n".to_vec()),
+            (
+                "mismatched",
+                metadata_body(
+                    "ctx-cli",
+                    BUNDLED_SKILL_NAME,
+                    b"different current body\n",
+                    0,
+                ),
+            ),
+        ];
+
+        for (scenario, metadata) in cases {
+            let root = tempfile::tempdir().unwrap();
+            let context = test_context(&root);
+            let target = single_target(SkillAgentArg::Universal, false, &context).unwrap();
+            fs::create_dir_all(&target.skill_dir).unwrap();
+            fs::write(target.skill_dir.join("SKILL.md"), BUNDLED_SKILL_BODY).unwrap();
+            fs::write(target.skill_dir.join(METADATA_FILE), metadata).unwrap();
+            let legacy_dir = target.base_dir.join(LEGACY_BUNDLED_SKILL_NAME);
+            fs::create_dir_all(&legacy_dir).unwrap();
+            fs::write(legacy_dir.join("SKILL.md"), RELEASED_LEGACY_SKILL_V0_17_0).unwrap();
+
+            assert_automatic_refresh_preserves(&context, &target, scenario);
+        }
+    }
+
+    #[test]
+    fn interrupted_migration_converges_on_the_second_refresh() {
+        let root = tempfile::tempdir().unwrap();
+        let context = test_context(&root);
+        let target = single_target(SkillAgentArg::Universal, false, &context).unwrap();
+        let legacy_dir = write_owned_legacy(&target, b"previous managed legacy\n", 0);
+        fs::create_dir_all(&target.skill_dir).unwrap();
+        let metadata_lock = target
+            .skill_dir
+            .join(format!(".{METADATA_FILE}.ctx-agent-integrations.lock"));
+        fs::create_dir(&metadata_lock).unwrap();
+
+        assert!(existing_managed_skill_refresh_required(&context));
+        refresh_existing_managed_skills(&context, TEST_PRODUCT_VERSION);
+
+        assert_eq!(
+            fs::read(target.skill_dir.join("SKILL.md")).unwrap(),
+            BUNDLED_SKILL_BODY.as_bytes()
+        );
+        assert!(!target.skill_dir.join(METADATA_FILE).exists());
+        assert!(legacy_dir.join("SKILL.md").is_file());
+
+        fs::remove_dir(&metadata_lock).unwrap();
+        assert!(existing_managed_skill_refresh_required(&context));
+        refresh_existing_managed_skills(&context, TEST_PRODUCT_VERSION);
+
+        let metadata: SkillMetadata =
+            serde_json::from_slice(&fs::read(target.skill_dir.join(METADATA_FILE)).unwrap())
+                .unwrap();
+        assert_eq!(metadata.skill_hash, bundled_hash());
+        assert_eq!(metadata.ctx_cli_version, TEST_PRODUCT_VERSION);
+        assert!(!legacy_dir.join("SKILL.md").exists());
+        assert!(!existing_managed_skill_refresh_required(&context));
+    }
+
+    #[test]
+    fn oversized_automatic_candidates_are_preserved_without_creating_files() {
+        for scenario in 0..4 {
+            let root = tempfile::tempdir().unwrap();
+            let context = test_context(&root);
+            let target = single_target(SkillAgentArg::Universal, false, &context).unwrap();
+            let scenario_name = match scenario {
+                0 => {
+                    let body = vec![b'c'; MAX_AUTOMATIC_SKILL_BYTES as usize + 1];
+                    write_owned_current(&target, &body);
+                    "oversized current skill"
+                }
+                1 => {
+                    let body = b"previous managed current\n";
+                    fs::create_dir_all(&target.skill_dir).unwrap();
+                    fs::write(target.skill_dir.join("SKILL.md"), body).unwrap();
+                    fs::write(
+                        target.skill_dir.join(METADATA_FILE),
+                        metadata_body(
+                            "ctx-cli",
+                            BUNDLED_SKILL_NAME,
+                            body,
+                            MAX_AUTOMATIC_METADATA_BYTES as usize,
+                        ),
+                    )
+                    .unwrap();
+                    "oversized current metadata"
+                }
+                2 => {
+                    let body = vec![b'l'; MAX_AUTOMATIC_SKILL_BYTES as usize + 1];
+                    write_owned_legacy(&target, &body, 0);
+                    "oversized legacy skill"
+                }
+                3 => {
+                    write_owned_legacy(
+                        &target,
+                        RELEASED_LEGACY_SKILL_V0_17_0,
+                        MAX_AUTOMATIC_METADATA_BYTES as usize,
+                    );
+                    "oversized legacy metadata"
+                }
+                _ => unreachable!(),
+            };
+
+            assert_automatic_refresh_preserves(&context, &target, scenario_name);
+        }
+    }
+
+    #[test]
+    fn identical_global_skill_directories_are_deduplicated() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let shared_agent_root = home.join(".agents");
+        let context = PathContext::for_tests(home, root.path().join("repo"))
+            .with_env_override("CODEX_HOME", shared_agent_root);
+        let duplicate_dir = single_target(SkillAgentArg::Universal, false, &context)
+            .unwrap()
+            .skill_dir;
+
+        let duplicate_count = distinct_global_targets(&context)
+            .iter()
+            .filter(|target| target.skill_dir == duplicate_dir)
+            .count();
+
+        assert_eq!(duplicate_count, 1);
+    }
+
+    #[test]
+    fn refresh_continues_after_one_target_fails() {
+        let root = tempfile::tempdir().unwrap();
+        let context = test_context(&root);
+        let blocked = single_target(SkillAgentArg::Universal, false, &context).unwrap();
+        let succeeding = single_target(SkillAgentArg::Codex, false, &context).unwrap();
+        write_owned_current(&blocked, b"blocked stale skill\n");
+        write_owned_current(&succeeding, b"refreshable stale skill\n");
+        fs::create_dir(
+            blocked
+                .skill_dir
+                .join(".SKILL.md.ctx-agent-integrations.lock"),
+        )
+        .unwrap();
+
+        refresh_existing_managed_skills(&context, TEST_PRODUCT_VERSION);
+
+        assert_eq!(
+            fs::read(blocked.skill_dir.join("SKILL.md")).unwrap(),
+            b"blocked stale skill\n"
+        );
+        assert_eq!(
+            fs::read(succeeding.skill_dir.join("SKILL.md")).unwrap(),
+            BUNDLED_SKILL_BODY.as_bytes()
+        );
+    }
+}

--- a/crates/ctx-cli-contract-tests/BUILD.bazel
+++ b/crates/ctx-cli-contract-tests/BUILD.bazel
@@ -119,6 +119,19 @@ ctx_cli_contract_test(
 )
 
 ctx_cli_contract_test(
+    name = "managed_skill_refresh_tests",
+    src = "tests/contracts/managed_skill_refresh.rs",
+    extra_compile_data = [
+        "//crates/ctx-agent-integrations:src/skill/testdata/legacy_skill_v0_17_0.md",
+    ],
+    tags = ["cli-contract"],
+    test_support = [
+        "base",
+        "upgrade",
+    ],
+)
+
+ctx_cli_contract_test(
     name = "test_targets_minimal_fixture",
     src = "tests/build_support/minimal.rs",
     extra_crates = ["serde_yaml"],

--- a/crates/ctx-cli-contract-tests/Cargo.toml
+++ b/crates/ctx-cli-contract-tests/Cargo.toml
@@ -25,6 +25,10 @@ name = "hosted_uninstall_fence"
 path = "tests/contracts/hosted_uninstall_fence.rs"
 
 [[test]]
+name = "managed_skill_refresh"
+path = "tests/contracts/managed_skill_refresh.rs"
+
+[[test]]
 name = "native_provider_real_shapes"
 path = "tests/contracts/native_provider_real_shapes.rs"
 

--- a/crates/ctx-cli-contract-tests/tests/contracts/managed_skill_refresh.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/managed_skill_refresh.rs
@@ -1,0 +1,231 @@
+#![cfg(unix)]
+
+mod support;
+
+use support::*;
+
+const CURRENT_BUNDLED_SKILL: &[u8] = include_bytes!("../../../../skills/ctx/SKILL.md");
+const RELEASED_LEGACY_SKILL: &[u8] =
+    include_bytes!("../../../ctx-agent-integrations/src/skill/testdata/legacy_skill_v0_17_0.md");
+const METADATA_FILE: &str = ".ctx-skill.json";
+
+#[derive(Debug)]
+struct IsolatedAgentRoots {
+    codex: PathBuf,
+    grok: PathBuf,
+    claude: PathBuf,
+    mimocode_home: PathBuf,
+    mimocode_config: PathBuf,
+    xdg_config: PathBuf,
+}
+
+impl IsolatedAgentRoots {
+    fn new(temp: &TempDir) -> Self {
+        let root = temp.path().join("agent-roots");
+        Self {
+            codex: root.join("codex"),
+            grok: root.join("grok"),
+            claude: root.join("claude"),
+            mimocode_home: root.join("mimocode-home"),
+            mimocode_config: root.join("mimocode-config"),
+            xdg_config: root.join("xdg-config"),
+        }
+    }
+
+    fn absent_skill_bases(&self, temp: &TempDir) -> Vec<PathBuf> {
+        vec![
+            self.grok.join("skills"),
+            self.claude.join("skills"),
+            temp.path().join(".cursor/skills"),
+            self.xdg_config.join("opencode/skills"),
+            self.mimocode_config.join("skills"),
+            self.xdg_config.join("agents/skills"),
+            temp.path().join(".gemini/skills"),
+            temp.path().join(".gemini/antigravity/skills"),
+            temp.path().join(".gemini/antigravity-cli/skills"),
+            temp.path().join(".copilot/skills"),
+            temp.path().join(".pi/agent/skills"),
+            self.xdg_config.join("goose/skills"),
+        ]
+    }
+}
+
+#[derive(Debug)]
+struct SkillSnapshot {
+    body: Vec<u8>,
+    metadata: Vec<u8>,
+}
+
+fn isolated_ctx(temp: &TempDir, binary: &Path, roots: &IsolatedAgentRoots) -> Command {
+    let mut command = ctx_from_binary(temp, binary);
+    command
+        .env("CODEX_HOME", &roots.codex)
+        .env("GROK_HOME", &roots.grok)
+        .env("CLAUDE_CONFIG_DIR", &roots.claude)
+        .env("MIMOCODE_HOME", &roots.mimocode_home)
+        .env("MIMOCODE_CONFIG_DIR", &roots.mimocode_config)
+        .env("XDG_CONFIG_HOME", &roots.xdg_config)
+        .env("USERPROFILE", temp.path())
+        .env("CTX_UPGRADE_OFF", "1");
+    command
+}
+
+fn write_stale_managed_skill(skill_dir: &Path) -> SkillSnapshot {
+    let body = b"stale metadata-owned ctx skill\n".to_vec();
+    let metadata = serde_json::to_vec_pretty(&json!({
+        "schema_version": 1,
+        "installer": "ctx-cli",
+        "skill_name": "ctx",
+        "skill_hash": format!("sha256:{}", sha256_hex(&body)),
+        "ctx_cli_version": "0.9.0",
+        "installed_at": "2026-01-01T00:00:00Z",
+    }))
+    .unwrap();
+    fs::create_dir_all(skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), &body).unwrap();
+    fs::write(skill_dir.join(METADATA_FILE), &metadata).unwrap();
+    SkillSnapshot { body, metadata }
+}
+
+fn assert_current_skill(skill_dir: &Path) {
+    assert_eq!(
+        fs::read(skill_dir.join("SKILL.md")).unwrap(),
+        CURRENT_BUNDLED_SKILL
+    );
+    let metadata: Value =
+        serde_json::from_slice(&fs::read(skill_dir.join(METADATA_FILE)).unwrap()).unwrap();
+    assert_eq!(metadata["schema_version"], 1);
+    assert_eq!(metadata["installer"], "ctx-cli");
+    assert_eq!(metadata["skill_name"], "ctx");
+    assert_eq!(
+        metadata["skill_hash"],
+        format!("sha256:{}", sha256_hex(CURRENT_BUNDLED_SKILL))
+    );
+    assert_eq!(metadata["ctx_cli_version"], env!("CARGO_PKG_VERSION"));
+}
+
+fn assert_skill_unchanged(skill_dir: &Path, before: &SkillSnapshot) {
+    assert_eq!(fs::read(skill_dir.join("SKILL.md")).unwrap(), before.body);
+    assert_eq!(
+        fs::read(skill_dir.join(METADATA_FILE)).unwrap(),
+        before.metadata
+    );
+}
+
+fn assert_skill_base_absent(base: &Path) {
+    assert!(!base.join("ctx").exists(), "{}", base.display());
+    assert!(
+        !base.join("ctx-agent-history-search").exists(),
+        "{}",
+        base.display()
+    );
+}
+
+#[test]
+fn first_mutation_eligible_startup_refreshes_current_and_migrates_one_legacy() {
+    let temp = tempdir();
+    let binary = managed_candidate(&temp, "managed_skill_refresh_startup");
+    let roots = IsolatedAgentRoots::new(&temp);
+
+    let universal_skill = temp.path().join(".agents/skills/ctx");
+    write_stale_managed_skill(&universal_skill);
+
+    let codex_skills = roots.codex.join("skills");
+    let legacy_skill = codex_skills.join("ctx-agent-history-search");
+    fs::create_dir_all(&legacy_skill).unwrap();
+    fs::write(legacy_skill.join("SKILL.md"), RELEASED_LEGACY_SKILL).unwrap();
+
+    let absent_skill_bases = roots.absent_skill_bases(&temp);
+    for base in &absent_skill_bases {
+        assert_skill_base_absent(base);
+    }
+
+    isolated_ctx(&temp, &binary, &roots)
+        .args(["setup", "--no-daemon", "--progress", "plain"])
+        .assert()
+        .success();
+
+    assert_current_skill(&universal_skill);
+    assert_current_skill(&codex_skills.join("ctx"));
+    assert!(!legacy_skill.join("SKILL.md").exists());
+    for base in &absent_skill_bases {
+        assert_skill_base_absent(base);
+    }
+}
+
+#[test]
+fn absent_corrupt_and_wrong_version_markers_prevent_startup_mutation() {
+    let temp = tempdir();
+    let binary = managed_candidate(&temp, "managed_skill_refresh_marker_gate");
+    let marker_path = install_marker_path(&binary);
+    let valid_marker = fs::read(&marker_path).unwrap();
+    let roots = IsolatedAgentRoots::new(&temp);
+    let skill_dir = temp.path().join(".agents/skills/ctx");
+    let before = write_stale_managed_skill(&skill_dir);
+
+    fs::remove_file(&marker_path).unwrap();
+    isolated_ctx(&temp, &binary, &roots)
+        .args(["setup", "--no-daemon", "--progress", "plain"])
+        .assert()
+        .success();
+    assert!(!marker_path.exists());
+    assert_skill_unchanged(&skill_dir, &before);
+
+    let corrupt_marker = b"{not-json";
+    fs::write(&marker_path, corrupt_marker).unwrap();
+    isolated_ctx(&temp, &binary, &roots)
+        .args(["setup", "--no-daemon", "--progress", "plain"])
+        .assert()
+        .success();
+    assert_eq!(fs::read(&marker_path).unwrap(), corrupt_marker);
+    assert_skill_unchanged(&skill_dir, &before);
+
+    let mut wrong_version_marker: Value = serde_json::from_slice(&valid_marker).unwrap();
+    wrong_version_marker["version"] = json!("999.999.999");
+    let wrong_version_marker = serde_json::to_vec_pretty(&wrong_version_marker).unwrap();
+    fs::write(&marker_path, &wrong_version_marker).unwrap();
+    isolated_ctx(&temp, &binary, &roots)
+        .args(["setup", "--no-daemon", "--progress", "plain"])
+        .assert()
+        .success();
+    assert_eq!(fs::read(&marker_path).unwrap(), wrong_version_marker);
+    assert_skill_unchanged(&skill_dir, &before);
+}
+
+#[test]
+fn automatic_refresh_failure_does_not_fail_the_requested_command() {
+    let temp = tempdir();
+    let binary = managed_candidate(&temp, "managed_skill_refresh_failure_isolation");
+    let roots = IsolatedAgentRoots::new(&temp);
+    let skill_dir = temp.path().join(".agents/skills/ctx");
+    let before = write_stale_managed_skill(&skill_dir);
+    fs::create_dir(skill_dir.join(".SKILL.md.ctx-agent-integrations.lock")).unwrap();
+
+    isolated_ctx(&temp, &binary, &roots)
+        .args(["setup", "--no-daemon", "--progress", "plain"])
+        .assert()
+        .success();
+
+    assert_skill_unchanged(&skill_dir, &before);
+}
+
+#[test]
+fn observational_status_and_refresh_off_search_leave_owned_skill_unchanged() {
+    let temp = tempdir();
+    let binary = managed_candidate(&temp, "managed_skill_refresh_observational");
+    let roots = IsolatedAgentRoots::new(&temp);
+    let skill_dir = temp.path().join(".agents/skills/ctx");
+    let before = write_stale_managed_skill(&skill_dir);
+
+    isolated_ctx(&temp, &binary, &roots)
+        .args(["status", "--format=json"])
+        .assert()
+        .success();
+    assert_skill_unchanged(&skill_dir, &before);
+
+    isolated_ctx(&temp, &binary, &roots)
+        .args(["search", "needle", "--refresh", "off", "--format=json"])
+        .assert()
+        .failure();
+    assert_skill_unchanged(&skill_dir, &before);
+}

--- a/crates/ctx-cli/src/dispatch.rs
+++ b/crates/ctx-cli/src/dispatch.rs
@@ -171,6 +171,7 @@ pub(crate) fn run_cli() -> Result<()> {
     let started = Instant::now();
     let output_measurement = OutputMeasurement::start();
     let cli = parse_cli_from(env::args_os())?;
+    integrations::refresh_existing_managed_skills_on_startup(&cli.command);
     let mut ui = Ui::stdio(cli.color.into());
     let json_output = command_json_output(&cli.command);
     let machine_output = command_machine_readable_output(&cli.command, json_output);

--- a/crates/ctx-cli/src/integrations/managed_skill_refresh.rs
+++ b/crates/ctx-cli/src/integrations/managed_skill_refresh.rs
@@ -1,0 +1,138 @@
+use ctx_agent_integrations::skill::{
+    existing_managed_skill_refresh_required, refresh_existing_managed_skills, PathContext,
+};
+use ctx_cli_presentation::commands::SemanticCommand;
+use ctx_upgrade_engine::{managed_install_marker_for_current_exe, ManagedInstallMarker};
+
+use crate::{
+    cli::{CommandRoot, DaemonCommand},
+    commands::{search::CliRefreshArg, sources::SourcesCommand},
+};
+
+pub(crate) fn refresh_existing_managed_skills_on_startup(command: &CommandRoot) {
+    if !command_is_refresh_eligible(command) {
+        return;
+    }
+    let Ok(context) = PathContext::from_env_best_effort() else {
+        return;
+    };
+    if !existing_managed_skill_refresh_required(&context) {
+        return;
+    }
+    let Ok(ManagedInstallMarker::Valid(marker)) = managed_install_marker_for_current_exe() else {
+        return;
+    };
+    if marker.version != env!("CARGO_PKG_VERSION") {
+        return;
+    }
+    refresh_existing_managed_skills(&context, env!("CARGO_PKG_VERSION"));
+}
+
+fn command_is_refresh_eligible(command: &CommandRoot) -> bool {
+    match command {
+        CommandRoot::Pro | CommandRoot::Blame | CommandRoot::Setup(_) | CommandRoot::Import(_) => {
+            true
+        }
+        CommandRoot::Semantic(args) => !matches!(&args.command, SemanticCommand::Status(_)),
+        CommandRoot::Sources(args) => matches!(
+            &args.command,
+            Some(SourcesCommand::Add { .. } | SourcesCommand::Remove { .. })
+        ),
+        CommandRoot::Search(args) => args.refresh != CliRefreshArg::Off,
+        CommandRoot::Daemon(args) => matches!(
+            &args.command,
+            DaemonCommand::Run(_) | DaemonCommand::Enable(_)
+        ),
+        CommandRoot::Referral
+        | CommandRoot::Status(_)
+        | CommandRoot::Stats(_)
+        | CommandRoot::Index(_)
+        | CommandRoot::Show(_)
+        | CommandRoot::List(_)
+        | CommandRoot::Locate(_)
+        | CommandRoot::Docs(_)
+        | CommandRoot::Integrations(_)
+        | CommandRoot::Mcp(_)
+        | CommandRoot::Upgrade(_)
+        | CommandRoot::Doctor(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser as _;
+
+    use super::*;
+    use crate::Cli;
+
+    fn eligible(arguments: &[&str]) -> bool {
+        let cli = Cli::try_parse_from(arguments).expect("test command should parse");
+        command_is_refresh_eligible(&cli.command)
+    }
+
+    #[test]
+    fn ordinary_mutation_startups_are_refresh_eligible() {
+        for arguments in [
+            &["ctx", "setup"][..],
+            &["ctx", "pro"][..],
+            &["ctx", "blame"][..],
+            &["ctx", "import", "--all"][..],
+            &["ctx", "search", "needle"][..],
+            &["ctx", "search", "needle", "--refresh", "wait"][..],
+            &["ctx", "semantic", "enable"][..],
+            &["ctx", "semantic", "disable"][..],
+            &[
+                "ctx",
+                "sources",
+                "add",
+                "work",
+                "--provider",
+                "codex",
+                "--root",
+                "/tmp/codex",
+            ][..],
+            &["ctx", "sources", "remove", "work"][..],
+            &["ctx", "daemon", "run"][..],
+            &["ctx", "daemon", "enable"][..],
+        ] {
+            assert!(
+                eligible(arguments),
+                "expected eligibility for {arguments:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn observational_and_specialized_commands_do_not_refresh() {
+        for arguments in [
+            &["ctx", "status"][..],
+            &["ctx", "status", "--usage", "enable"][..],
+            &["ctx", "stats"][..],
+            &["ctx", "index"][..],
+            &["ctx", "sources"][..],
+            &["ctx", "show", "event", "deadbeef"][..],
+            &["ctx", "list", "events"][..],
+            &["ctx", "locate", "event", "deadbeef"][..],
+            &["ctx", "docs", "list"][..],
+            &["ctx", "integrations", "status", "skill"][..],
+            &["ctx", "mcp", "serve"][..],
+            &["ctx", "daemon", "status"][..],
+            &["ctx", "daemon", "disable"][..],
+            &["ctx", "upgrade", "check"][..],
+            &["ctx", "upgrade", "enable"][..],
+            &["ctx", "upgrade", "disable"][..],
+            &["ctx", "doctor"][..],
+            &["ctx", "semantic", "status"][..],
+        ] {
+            assert!(
+                !eligible(arguments),
+                "unexpected eligibility for {arguments:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn search_refresh_off_is_observational() {
+        assert!(!eligible(&["ctx", "search", "needle", "--refresh", "off",]));
+    }
+}

--- a/crates/ctx-cli/src/integrations/mod.rs
+++ b/crates/ctx-cli/src/integrations/mod.rs
@@ -1,1 +1,4 @@
+mod managed_skill_refresh;
+
 pub(crate) use ctx_cli_presentation::integrations::*;
+pub(crate) use managed_skill_refresh::refresh_existing_managed_skills_on_startup;

--- a/docs/agent-skill-install.md
+++ b/docs/agent-skill-install.md
@@ -23,6 +23,16 @@ installer setup was skipped, or when refreshing the skill after an upgrade:
 ctx integrations install skill
 ```
 
+A hosted-managed ctx install also refreshes existing ctx-managed global skill
+copies on the first ordinary maintenance-capable run of a new CLI version. This
+is best effort: it never creates a skill for a new agent, preserves content
+that inspection identifies as local or otherwise unowned, and never changes
+the requested command's result. If refresh cannot complete, the existing copy
+remains stale (or a migration may temporarily leave both names present). A
+later eligible run retries while ownership remains provable; an ambiguous state
+requires an explicit install. Source builds and package-manager installs do not
+perform this automatic maintenance.
+
 By default this opens a small picker in an interactive terminal, with the
 universal `~/.agents/skills/ctx` location selected plus detected
 agent-specific folders for clients that need them. Safe existing `ctx` or
@@ -80,10 +90,11 @@ writes `.ctx-skill.json` beside `SKILL.md` so ctx can distinguish managed copies
 from local edits. Without target flags, status uses the same default maintenance
 set as install, including safe existing copies in recognized folders.
 
-The 1.0 installer performs a one-way migration from the former
-`ctx-agent-history-search` directory. It removes a recognized managed copy and
-installs `ctx`; it never leaves both skills active. A locally modified former
-skill is preserved unless `--force` is provided.
+The installer performs a one-way migration from the former
+`ctx-agent-history-search` directory. It publishes `ctx` before removing a
+recognized managed legacy copy, so a cleanup failure can leave both names
+temporarily active instead of rolling back the current skill. A locally
+modified former skill is preserved unless `--force` is provided.
 
 Removal is idempotent. It removes current and stale files that valid ctx
 metadata identifies as managed. Locally modified or otherwise unowned files are

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -216,14 +216,22 @@ modified skill files unless you pass `--force`. The command only manages the
 bundled ctx skill and does not fetch arbitrary remote skills. Without target
 flags, status uses the same default maintenance set as install.
 
+After a hosted-managed CLI upgrade, the first ordinary maintenance-capable run
+also makes a best-effort refresh of existing managed global copies. It does not
+install into missing agent folders, adopt local files, update plugins, emit
+user-facing output, or affect the requested command's result. Failed refreshes
+stay stale; a later eligible run retries when ownership remains provable, and
+an explicit install repairs ambiguous states.
+
 `integrations remove skill` removes current or stale ctx-managed copies and is
 an idempotent no-op when they are absent. Modified or unowned files are
 preserved unless `--force` is passed. Removal never deletes the parent skill
 directory, unrelated files, or plugin-manager-owned copies.
 
-The 1.0 installer performs a one-way migration from a managed
+The installer performs a one-way, current-first migration from a managed
 `ctx-agent-history-search` directory to `ctx`. It preserves a locally edited
-legacy skill unless `--force` is passed.
+legacy skill unless `--force` is passed; failed legacy cleanup may temporarily
+leave both names present.
 
 ## Integrations
 

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -8,18 +8,27 @@ the local retrieval product.
 - `ctx setup` reads supported provider history and writes only under the
   configured ctx data root: Core/Tantivy generations, optional semantic data,
   config data, and optional persistent daemon lock/status/job state when
-  automatic autostart runs. Manual setup starts no worker.
+  automatic autostart runs. Manual setup starts no worker. As an independent
+  maintenance exception, an eligible command from a hosted-managed binary may
+  best-effort refresh an existing metadata-owned ctx skill in a recognized
+  global agent skill directory; it does not create a missing integration or
+  make an unowned copy managed.
 - `ctx sources` listing writes nothing in local-only security mode.
   `ctx sources add [--replace]` and `ctx sources remove` write only the locked,
-  durably replaced `config.toml`; they never modify provider history.
+  durably replaced `config.toml` as their core effect; the managed-skill
+  maintenance exception above may also apply. They never modify provider
+  history.
 - `ctx import` writes only under the configured ctx data root: Core generations,
   optional semantic data, config data, and optional daemon lock/status/job
-  state when a persistent daemon or finite Core worker runs.
+  state when a persistent daemon or finite Core worker runs, apart from the
+  managed-skill maintenance exception above.
 - Automatic background search and explicit search `--refresh wait` may request
   a bounded daemon-owned refresh of discovered native provider history before
   querying the active Core generation. Manual background search and
   `--refresh off` must not start or wake a process. The query process does not
-  write Core generations. In manual mode, an opted-in semantic or nonzero-weight
+  write Core generations. An eligible search may use the same hosted-managed
+  existing-skill maintenance exception; `--refresh off` may not. In manual
+  mode, an opted-in semantic or nonzero-weight
   hybrid `--refresh wait` may use the selected executor and write semantic
   projection data only after finite Core publication for the exact pinned
   generation. Without semantic opt-in, default search must not download

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -347,7 +347,12 @@ generation; a failed refresh leaves the prior verified generation active.
 This table describes core command effects. It excludes the independent
 best-effort daily aggregate upsert to `usage.sqlite` and the optional
 first-party analytics marker described under network behavior. Disable the
-local upsert as described above.
+local upsert as described above. It also excludes hosted-managed skill
+maintenance: an eligible ordinary command may silently refresh an existing
+metadata-owned ctx skill in a recognized global agent directory. That
+maintenance does not install missing integrations, adopt unowned content, or
+change the command result; `status` and `search --refresh off` remain
+observational.
 
 | Command | Reads | Writes |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary

- refresh existing ctx-managed skills on the first eligible invocation after a managed binary update
- preserve missing, modified, foreign, and ambiguous installations while keeping refresh failures nonfatal
- migrate released legacy skill installations current-first without adding a worker, journal, or plugin updater

## Validation

- focused integration, CLI unit, and CLI contract tests
- formatting and documentation checks
- complete CI build with warnings denied
- independent correctness and simplification review