### PR TITLE
refactor(history): share neutral event projection

### DIFF
--- a/crates/ctx-cli/src/mcp.rs
+++ b/crates/ctx-cli/src/mcp.rs
@@ -182,7 +182,7 @@ fn usage_invocation(usage: McpUsage) -> Option<McpInvocation> {
 }
 
 #[cfg(test)]
-pub(crate) fn query_events_for_test(arguments: &Value, data_root: &Path) -> Result<Value> {
+fn query_events_mcp_result_for_test(arguments: &Value, data_root: &Path) -> Result<Value> {
     let request = json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -197,14 +197,10 @@ pub(crate) fn query_events_for_test(arguments: &Value, data_root: &Path) -> Resu
         .value
         .and_then(|response| response.get("result").cloned())
         .ok_or_else(|| anyhow::anyhow!("MCP query_events returned no result"))?;
-    let structured = result
-        .get("structuredContent")
-        .cloned()
-        .ok_or_else(|| anyhow::anyhow!("MCP query_events returned no structured content"))?;
     if result.get("isError").and_then(Value::as_bool) == Some(true) {
-        return Err(anyhow::anyhow!(serde_json::to_string(&structured)?));
+        return Err(anyhow::anyhow!(serde_json::to_string(&result)?));
     }
-    Ok(structured)
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -214,7 +210,7 @@ pub(crate) fn render_tool_text_for_test(value: &Value) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{query_events_for_test, render_tool_text_for_test};
+    use super::{query_events_mcp_result_for_test, render_tool_text_for_test};
     use ctx_history_capture::{
         provider_source_for_path, refresh_source_backed_generation,
         register_landed_source_backed_route, SourceBackedProviderRegistry,
@@ -283,8 +279,14 @@ mod tests {
         let temp = tempdir().unwrap();
         write_query_events_fixture(temp.path());
 
-        let page =
-            query_events_for_test(&json!({"content": "full", "limit": 100}), temp.path()).unwrap();
+        let result = query_events_mcp_result_for_test(
+            &json!({"content": "full", "limit": 100}),
+            temp.path(),
+        )
+        .unwrap();
+        let page = result
+            .get("structuredContent")
+            .expect("MCP query_events returns the event page as structured content");
         assert_eq!(page["payload_type"], "event_range_page");
         let event = page["events"]
             .as_array()

--- a/crates/ctx-history-cli/src/source_index/search.rs
+++ b/crates/ctx-history-cli/src/source_index/search.rs
@@ -799,7 +799,7 @@ pub(super) fn search_context_observation(
         .result_window
         .hits
         .iter()
-        .map(|hit| hit.event.session_id)
+        .map(|hit| hit.event.session_id.as_uuid())
         .collect::<BTreeSet<_>>();
     let mut matched_normalized_session_bytes = 0_usize;
     for session_id in session_ids {

--- a/crates/ctx-history-cli/src/source_index/tests.rs
+++ b/crates/ctx-history-cli/src/source_index/tests.rs
@@ -689,7 +689,7 @@ fn search_schema_v1_snapshot_reads_snippets_and_citations_from_core() {
         result_window: SearchResultWindow {
             limit: 1,
             hits: vec![SearchHit {
-                event: SearchEventMetadata::from(&event),
+                event: event.clone(),
                 score: 1.0,
                 more_matches_in_session: 0,
             }],
@@ -819,12 +819,12 @@ fn search_json_rank_tracks_non_monotonic_shaped_result_order() {
             limit: 2,
             hits: vec![
                 SearchHit {
-                    event: SearchEventMetadata::from(&first),
+                    event: first.clone(),
                     score: 0.25,
                     more_matches_in_session: 0,
                 },
                 SearchHit {
-                    event: SearchEventMetadata::from(&second),
+                    event: second.clone(),
                     score: 9.5,
                     more_matches_in_session: 0,
                 },

--- a/crates/ctx-history-cli/src/source_index/tests/additional.rs
+++ b/crates/ctx-history-cli/src/source_index/tests/additional.rs
@@ -214,7 +214,7 @@ fn search_context_bytes_use_core_snippets_and_indexed_complete_session_sizes_not
         .iter()
         .map(|result| result["snippet"].as_str().unwrap().len())
         .sum::<usize>();
-    let session_id = collection.result_window.hits[0].event.session_id;
+    let session_id = collection.result_window.hits[0].event.session_id.as_uuid();
     let complete_bytes = index
         .core_events_for_session(session_id)
         .unwrap()

--- a/crates/ctx-history-cli/src/source_index/tests/fixtures.rs
+++ b/crates/ctx-history-cli/src/source_index/tests/fixtures.rs
@@ -222,7 +222,7 @@ fn fixture_search_presentation(
         .expect("search fixture needs normalized body")
         .clone();
     SearchPresentation {
-        event_id: event.event_id,
+        event_id: event.event_id.as_uuid(),
         snippet,
         snippet_truncated,
     }

--- a/crates/ctx-history-cli/src/source_index/tests/show_lineage.rs
+++ b/crates/ctx-history-cli/src/source_index/tests/show_lineage.rs
@@ -89,7 +89,7 @@ fn copied_event_show_list_and_search_metadata_preserve_direct_claims() {
     let listed =
         crate::list_events::render_event(&copied, crate::list_events::EventContentProjection::Full)
             .unwrap();
-    let search = SearchEventMetadata::from(&copied.event);
+    let search = copied.event.clone();
 
     for value in [&shown, &listed] {
         assert_eq!(value["session_relationship"], "forked");

--- a/crates/ctx-history-read-application/src/application_tests.rs
+++ b/crates/ctx-history-read-application/src/application_tests.rs
@@ -52,7 +52,7 @@ use crate::{
     SessionEventMode, ShowEventApplicationRequest, ShowEventRequest, ShowSessionApplicationRequest,
     ShowSessionPageRequest, ShowSessionStreamCallback, ShowSessionStreamControl,
     ShowSessionStreamPage, ShowSessionStreamRequest, ShowSessionStreamStart,
-    StructuredOutputFormat, StructuredTranscriptMode, UuidPrefixError, SEARCH_SNIPPET_MAX_CHARS,
+    StructuredOutputFormat, StructuredTranscriptMode, UuidPrefixError,
 };
 
 struct UnusedSemanticPort;

--- a/crates/ctx-history-read-application/src/application_tests.rs
+++ b/crates/ctx-history-read-application/src/application_tests.rs
@@ -35,8 +35,9 @@ use crate::{
     event_query_receipt, event_query_wire_request, event_window_with_lineage_read_model,
     execute_list_events_stream, execute_locate, execute_search_observed, execute_show_event,
     execute_show_session_page, execute_show_session_stream, history_health_report,
-    normalize_search_request, normalize_uuid_prefix, paginated_session_transcript_read_model,
-    plan_search, render_event_read_model, render_search_json, retain_structured_session_page,
+    locate_read_model, normalize_search_request, normalize_uuid_prefix,
+    paginated_session_transcript_read_model, plan_search, render_event_read_model,
+    render_search_json, render_show_event_read_model, retain_structured_session_page,
     ActiveSessionExclusion, CompactPresentationProjection, CompactRefResolver,
     EventContentProjection, EventWindowBudget, GenerationRead, GenerationReadPort,
     GenerationReadRequest, GenerationReadTarget, HistorySemanticBatch, HistorySemanticError,
@@ -46,12 +47,12 @@ use crate::{
     NormalizedSearchQuery, PinnedHistoryQuery, RetainedPeerRead, SearchApplicationError,
     SearchApplicationReadModelInput, SearchApplicationRequest, SearchApplicationResult,
     SearchBackend, SearchCollection, SearchDiversificationStatus, SearchExecutionResult,
-    SearchFailurePhase, SearchJsonInput, SearchPolicy, SearchRenderMetrics, SearchRequest,
-    SearchResultCommands, SemanticAvailability, SemanticReason, SessionEventMode,
-    ShowEventApplicationRequest, ShowEventRequest, ShowSessionApplicationRequest,
+    SearchFailurePhase, SearchHit, SearchJsonInput, SearchPolicy, SearchPresentation,
+    SearchRenderMetrics, SearchRequest, SearchResultCommands, SemanticAvailability, SemanticReason,
+    SessionEventMode, ShowEventApplicationRequest, ShowEventRequest, ShowSessionApplicationRequest,
     ShowSessionPageRequest, ShowSessionStreamCallback, ShowSessionStreamControl,
     ShowSessionStreamPage, ShowSessionStreamRequest, ShowSessionStreamStart,
-    StructuredOutputFormat, StructuredTranscriptMode, UuidPrefixError,
+    StructuredOutputFormat, StructuredTranscriptMode, UuidPrefixError, SEARCH_SNIPPET_MAX_CHARS,
 };
 
 struct UnusedSemanticPort;
@@ -876,11 +877,11 @@ fn rendered_semantic_result_preserves_exact_ids() {
     assert_eq!(search.collection.result_window.hits.len(), 1);
     assert_eq!(
         search.collection.result_window.hits[0].event.event_id,
-        semantic_event.event_id.as_uuid()
+        semantic_event.event_id
     );
     assert_eq!(
         search.collection.result_window.hits[0].event.session_id,
-        semantic_event.session_id.as_uuid()
+        semantic_event.session_id
     );
     assert_eq!(
         search.collection.diversification.status,

--- a/crates/ctx-history-read-application/src/application_tests/pinned_workflows.rs
+++ b/crates/ctx-history-read-application/src/application_tests/pinned_workflows.rs
@@ -608,22 +608,26 @@ fn structured_read_models_are_composed_from_pinned_query_results() {
 }
 
 #[test]
-fn event_projection_commands_preserve_exact_json_bytes_and_legacy_citations() {
-    fn assert_exact_json(actual: &Value, expected: Value) {
-        assert_eq!(actual, &expected);
-        assert_eq!(
-            serde_json::to_vec(actual).unwrap(),
-            serde_json::to_vec(&expected).unwrap()
-        );
-    }
-
+fn event_projections_share_published_custom_metadata_and_absent_semantics() {
     let temp = tempdir().unwrap();
-    let (index, records) = publish(temp.path());
-    let mut event = index
-        .core_event_by_id(records[1].event_id.as_uuid())
-        .unwrap()
-        .unwrap();
-    event.event.native_event_id = Some(
+    let source = SourceKey::derive(
+        "custom",
+        "ctx_history_jsonl",
+        "catalog",
+        1,
+        SourceAnchor::CatalogLineage([42; 32]),
+    )
+    .unwrap();
+    let mut record = record_for_session(
+        &source,
+        "fixture-session",
+        2,
+        "assistant",
+        "fixture projection body",
+    );
+    record.provider_session_id = None;
+    record.occurred_at_unix_ms = None;
+    record.native_event_id = Some(
         TypedKey::composite(vec![
             TypedKey::utf8("fixture-provider").unwrap(),
             TypedKey::utf8("fixture-source").unwrap(),
@@ -631,12 +635,24 @@ fn event_projection_commands_preserve_exact_json_bytes_and_legacy_citations() {
         ])
         .unwrap(),
     );
+    let mut writer = GenerationWriter::open(temp.path(), WriterOptions::default())
+        .unwrap()
+        .into_writer()
+        .unwrap();
+    writer.begin_source(source.clone()).unwrap();
+    writer.add_core_record(record.clone()).unwrap();
+    writer.certify_source(certificate(&source, 1)).unwrap();
+    writer.commit(|_| true).unwrap();
+
+    let index = VerifiedIndex::open_pinned(temp.path()).unwrap();
+    let event = index
+        .core_event_by_id(record.event_id.as_uuid())
+        .unwrap()
+        .unwrap();
+    assert_eq!(event.core_record, record);
 
     let event_id = event.event_id.as_uuid();
     let session_id = event.session_id.as_uuid();
-    let source_id = event.source.identity().as_uuid();
-    let native_event_id = event.native_event_id.clone().unwrap();
-    let occurred_at = "1970-01-01T00:00:01.002Z";
 
     let search = crate::search_result_json(
         &SearchHit {
@@ -646,7 +662,7 @@ fn event_projection_commands_preserve_exact_json_bytes_and_legacy_citations() {
         },
         &SearchPresentation {
             event_id,
-            snippet: "needle reply".to_owned(),
+            snippet: "fixture projection body".to_owned(),
             snippet_truncated: false,
         },
         "event",
@@ -656,156 +672,39 @@ fn event_projection_commands_preserve_exact_json_bytes_and_legacy_citations() {
         },
     )
     .unwrap();
-    assert_exact_json(
-        &search,
-        json!({
-            "item_id": event_id,
-            "result_type": "event",
-            "ctx_event_id": event_id,
-            "ctx_session_id": session_id,
-            "session_id": session_id,
-            "event_id": event_id,
-            "event_seq": 2,
-            "title": "custom assistant message",
-            "snippet": "needle reply",
-            "snippet_truncated": false,
-            "snippet_max_chars": SEARCH_SNIPPET_MAX_CHARS,
-            "rank": 1,
-            "retrieval_score": 0.75,
-            "result_scope": "event",
-            "provider": "custom",
-            "provider_key": "fixture-provider",
-            "source_id": "fixture-source",
-            "provider_session_id": "pinned-session",
-            "source_format": "application_query_test",
-            "agent_scope": "primary",
-            "timestamp": occurred_at,
-            "suggested_next_commands": ["adapter fixture command"],
-            "citations": [{
-                "item_id": event_id,
-                "target_type": "event",
-                "ctx_event_id": event_id,
-                "ctx_session_id": session_id,
-                "provider": "custom",
-                "session_id": session_id,
-                "event_seq": 2,
-            }],
-            "visibility": "local",
-        }),
-    );
 
     let shown = render_show_event_read_model(&event);
-    assert_exact_json(
-        &shown,
-        json!({
-            "ctx_event_id": event_id,
-            "item_id": event_id,
-            "record_type": "event",
-            "ctx_session_id": session_id,
-            "provider": "custom",
-            "provider_key": "fixture-provider",
-            "source_id": "fixture-source",
-            "provider_session_id": "pinned-session",
-            "source_format": "application_query_test",
-            "agent_scope": "primary",
-            "sequence": 2,
-            "event_type": "message",
-            "role": "assistant",
-            "occurred_at": occurred_at,
-            "text": "needle reply",
-            "content": {
-                "complete": true,
-                "policy_status": "selected",
-            },
-        }),
-    );
-
     let listed = render_event_read_model(&event, EventContentProjection::Text).unwrap();
-    let expected_listed = json!({
-        "schema_version": 1,
-        "record_version": event.core_record.record_version,
-        "ctx_event_id": event_id,
-        "ctx_source_id": source_id,
-        "ctx_session_id": session_id,
-        "parent_ctx_session_id": null,
-        "root_ctx_session_id": null,
-        "session_relationship": null,
-        "event_copy": null,
-        "occurred_at": occurred_at,
-        "occurred_at_ms": 1002,
-        "sequence": 2,
-        "provider": "custom",
-        "provider_key": "fixture-provider",
-        "source_id": "fixture-source",
-        "source_format": "application_query_test",
-        "source": event.source,
-        "provider_session_id": "pinned-session",
-        "native_event_id": native_event_id,
-        "agent_scope": "primary",
-        "event_type": "message",
-        "role": "assistant",
-        "parser_revision": "application-query-test-v1",
-        "normalization_revision": event.core_record.normalization_revision,
-        "text": "needle reply",
-        "structured_content": null,
-        "content": {
-            "complete": true,
-            "policy_revision": event.core_record.content.policy_revision,
-            "policy_status": "selected",
-            "policy_reason": null,
-        },
-        "citations": [{
-            "target_type": "event",
-            "ctx_event_id": event_id,
-            "ctx_session_id": session_id,
-            "label": "message",
-            "time": occurred_at,
-            "provider": "custom",
-            "session_id": "pinned-session",
-            "event_seq": 2,
-        }],
-        "content_projection": "text",
-    });
-    assert_exact_json(&listed, expected_listed.clone());
-
-    let mcp_event = event_query_event_read_model("fixture-generation", 3, listed);
-    assert_exact_json(
-        &mcp_event,
-        json!({
-            "schema_version": 1,
-            "record_type": "event_range_event",
-            "generation_id": "fixture-generation",
-            "ordinal": 3,
-            "event": expected_listed,
-        }),
-    );
-
     let located = locate_read_model(&LocateResult::Event(Box::new(event.clone())));
-    assert_exact_json(
-        &located,
-        json!({
-            "schema_version": 1,
-            "target": "event",
-            "payload_type": "event_location",
-            "ctx_event_id": event_id,
-            "ctx_session_id": session_id,
-            "provider": "custom",
-            "provider_key": "fixture-provider",
-            "source_id": "fixture-source",
-            "provider_session_id": "pinned-session",
-            "provider_event_id": event.native_event_id,
-            "sequence": 2,
-            "event_type": "message",
-            "role": "assistant",
-            "occurred_at": occurred_at,
-            "source": {
-                "ctx_source_id": source_id,
-                "source_format": "application_query_test",
-                "schema_variant": "session",
-                "provider_identity_version": 1,
-            },
-        }),
-    );
+
+    for (field, expected) in [
+        ("ctx_event_id", json!(event_id)),
+        ("ctx_session_id", json!(session_id)),
+        ("provider", json!("custom")),
+        ("provider_key", json!("fixture-provider")),
+        ("source_id", json!("fixture-source")),
+    ] {
+        for (surface, value) in [
+            ("search", &search),
+            ("show", &shown),
+            ("event query", &listed),
+            ("locate", &located),
+        ] {
+            assert_eq!(value[field], expected, "{surface} {field}");
+        }
+    }
+
+    assert_eq!(search["citations"][0]["session_id"], json!(session_id));
+    assert!(listed["provider_session_id"].is_null());
+    assert!(listed["occurred_at"].is_null());
+    assert!(listed["citations"][0]["time"].is_null());
+    assert!(listed["citations"][0]["session_id"].is_null());
+    assert!(search.get("provider_session_id").is_none());
+    assert!(search.get("timestamp").is_none());
+    for value in [&shown, &located] {
+        assert!(value.get("provider_session_id").is_none());
+        assert!(value.get("occurred_at").is_none());
+    }
 }
 
 #[test]

--- a/crates/ctx-history-read-application/src/application_tests/pinned_workflows.rs
+++ b/crates/ctx-history-read-application/src/application_tests/pinned_workflows.rs
@@ -303,8 +303,8 @@ fn semantic_and_hybrid_recall_filtered_copy_with_absent_ancestor_end_to_end() {
         let hits = &application.query().collection.result_window.hits;
         assert_eq!(hits.len(), 2);
         assert!(application.query().collection.result_window.more_available);
-        assert_eq!(hits[0].event.event_id, copied.event_id.as_uuid());
-        assert_eq!(hits[0].event.session_id, copied.session_id.as_uuid());
+        assert_eq!(hits[0].event.event_id, copied.event_id);
+        assert_eq!(hits[0].event.session_id, copied.session_id);
         assert_eq!(
             hits[0].event.provider_session_id.as_deref(),
             Some("copied-occurrence")
@@ -313,8 +313,8 @@ fn semantic_and_hybrid_recall_filtered_copy_with_absent_ancestor_end_to_end() {
             hits[0].event.event_copy.as_ref(),
             copied.event_copy.as_ref()
         );
-        assert_eq!(hits[1].event.event_id, independent.event_id.as_uuid());
-        assert_eq!(hits[1].event.session_id, independent.session_id.as_uuid());
+        assert_eq!(hits[1].event.event_id, independent.event_id);
+        assert_eq!(hits[1].event.session_id, independent.session_id);
 
         let commands = hits
             .iter()
@@ -605,6 +605,207 @@ fn structured_read_models_are_composed_from_pinned_query_results() {
     assert_eq!(record["record_type"], "event_range_event");
     assert_eq!(record["ordinal"], 0);
     assert_eq!(record["event"]["text"], "needle first");
+}
+
+#[test]
+fn event_projection_commands_preserve_exact_json_bytes_and_legacy_citations() {
+    fn assert_exact_json(actual: &Value, expected: Value) {
+        assert_eq!(actual, &expected);
+        assert_eq!(
+            serde_json::to_vec(actual).unwrap(),
+            serde_json::to_vec(&expected).unwrap()
+        );
+    }
+
+    let temp = tempdir().unwrap();
+    let (index, records) = publish(temp.path());
+    let mut event = index
+        .core_event_by_id(records[1].event_id.as_uuid())
+        .unwrap()
+        .unwrap();
+    event.event.native_event_id = Some(
+        TypedKey::composite(vec![
+            TypedKey::utf8("fixture-provider").unwrap(),
+            TypedKey::utf8("fixture-source").unwrap(),
+            TypedKey::utf8("fixture-event").unwrap(),
+        ])
+        .unwrap(),
+    );
+
+    let event_id = event.event_id.as_uuid();
+    let session_id = event.session_id.as_uuid();
+    let source_id = event.source.identity().as_uuid();
+    let native_event_id = event.native_event_id.clone().unwrap();
+    let occurred_at = "1970-01-01T00:00:01.002Z";
+
+    let search = crate::search_result_json(
+        &SearchHit {
+            event: event.event.clone(),
+            score: 0.75,
+            more_matches_in_session: 0,
+        },
+        &SearchPresentation {
+            event_id,
+            snippet: "needle reply".to_owned(),
+            snippet_truncated: false,
+        },
+        "event",
+        1,
+        &SearchResultCommands {
+            suggested_next_commands: vec!["adapter fixture command".to_owned()],
+        },
+    )
+    .unwrap();
+    assert_exact_json(
+        &search,
+        json!({
+            "item_id": event_id,
+            "result_type": "event",
+            "ctx_event_id": event_id,
+            "ctx_session_id": session_id,
+            "session_id": session_id,
+            "event_id": event_id,
+            "event_seq": 2,
+            "title": "custom assistant message",
+            "snippet": "needle reply",
+            "snippet_truncated": false,
+            "snippet_max_chars": SEARCH_SNIPPET_MAX_CHARS,
+            "rank": 1,
+            "retrieval_score": 0.75,
+            "result_scope": "event",
+            "provider": "custom",
+            "provider_key": "fixture-provider",
+            "source_id": "fixture-source",
+            "provider_session_id": "pinned-session",
+            "source_format": "application_query_test",
+            "agent_scope": "primary",
+            "timestamp": occurred_at,
+            "suggested_next_commands": ["adapter fixture command"],
+            "citations": [{
+                "item_id": event_id,
+                "target_type": "event",
+                "ctx_event_id": event_id,
+                "ctx_session_id": session_id,
+                "provider": "custom",
+                "session_id": session_id,
+                "event_seq": 2,
+            }],
+            "visibility": "local",
+        }),
+    );
+
+    let shown = render_show_event_read_model(&event);
+    assert_exact_json(
+        &shown,
+        json!({
+            "ctx_event_id": event_id,
+            "item_id": event_id,
+            "record_type": "event",
+            "ctx_session_id": session_id,
+            "provider": "custom",
+            "provider_key": "fixture-provider",
+            "source_id": "fixture-source",
+            "provider_session_id": "pinned-session",
+            "source_format": "application_query_test",
+            "agent_scope": "primary",
+            "sequence": 2,
+            "event_type": "message",
+            "role": "assistant",
+            "occurred_at": occurred_at,
+            "text": "needle reply",
+            "content": {
+                "complete": true,
+                "policy_status": "selected",
+            },
+        }),
+    );
+
+    let listed = render_event_read_model(&event, EventContentProjection::Text).unwrap();
+    let expected_listed = json!({
+        "schema_version": 1,
+        "record_version": event.core_record.record_version,
+        "ctx_event_id": event_id,
+        "ctx_source_id": source_id,
+        "ctx_session_id": session_id,
+        "parent_ctx_session_id": null,
+        "root_ctx_session_id": null,
+        "session_relationship": null,
+        "event_copy": null,
+        "occurred_at": occurred_at,
+        "occurred_at_ms": 1002,
+        "sequence": 2,
+        "provider": "custom",
+        "provider_key": "fixture-provider",
+        "source_id": "fixture-source",
+        "source_format": "application_query_test",
+        "source": event.source,
+        "provider_session_id": "pinned-session",
+        "native_event_id": native_event_id,
+        "agent_scope": "primary",
+        "event_type": "message",
+        "role": "assistant",
+        "parser_revision": "application-query-test-v1",
+        "normalization_revision": event.core_record.normalization_revision,
+        "text": "needle reply",
+        "structured_content": null,
+        "content": {
+            "complete": true,
+            "policy_revision": event.core_record.content.policy_revision,
+            "policy_status": "selected",
+            "policy_reason": null,
+        },
+        "citations": [{
+            "target_type": "event",
+            "ctx_event_id": event_id,
+            "ctx_session_id": session_id,
+            "label": "message",
+            "time": occurred_at,
+            "provider": "custom",
+            "session_id": "pinned-session",
+            "event_seq": 2,
+        }],
+        "content_projection": "text",
+    });
+    assert_exact_json(&listed, expected_listed.clone());
+
+    let mcp_event = event_query_event_read_model("fixture-generation", 3, listed);
+    assert_exact_json(
+        &mcp_event,
+        json!({
+            "schema_version": 1,
+            "record_type": "event_range_event",
+            "generation_id": "fixture-generation",
+            "ordinal": 3,
+            "event": expected_listed,
+        }),
+    );
+
+    let located = locate_read_model(&LocateResult::Event(Box::new(event.clone())));
+    assert_exact_json(
+        &located,
+        json!({
+            "schema_version": 1,
+            "target": "event",
+            "payload_type": "event_location",
+            "ctx_event_id": event_id,
+            "ctx_session_id": session_id,
+            "provider": "custom",
+            "provider_key": "fixture-provider",
+            "source_id": "fixture-source",
+            "provider_session_id": "pinned-session",
+            "provider_event_id": event.native_event_id,
+            "sequence": 2,
+            "event_type": "message",
+            "role": "assistant",
+            "occurred_at": occurred_at,
+            "source": {
+                "ctx_source_id": source_id,
+                "source_format": "application_query_test",
+                "schema_variant": "session",
+                "provider_identity_version": 1,
+            },
+        }),
+    );
 }
 
 #[test]

--- a/crates/ctx-history-read-application/src/application_tests/search_execution.rs
+++ b/crates/ctx-history-read-application/src/application_tests/search_execution.rs
@@ -17,7 +17,7 @@ fn dense_limit_windows_preserve_exact_order_more_available_and_winner_only_hydra
         .result_window
         .hits
         .iter()
-        .map(|hit| hit.event.event_id)
+        .map(|hit| hit.event.event_id.as_uuid())
         .collect::<Vec<_>>();
     assert_eq!(exact_order.len(), records.len());
 
@@ -40,7 +40,7 @@ fn dense_limit_windows_preserve_exact_order_more_available_and_winner_only_hydra
                 .result_window
                 .hits
                 .iter()
-                .map(|hit| hit.event.event_id)
+                .map(|hit| hit.event.event_id.as_uuid())
                 .collect::<Vec<_>>(),
             exact_order[..limit]
         );
@@ -446,7 +446,7 @@ fn provider_root_and_group_selectors_share_one_source_predicate_across_backends(
                 .result_window
                 .hits
                 .iter()
-                .map(|hit| hit.event.event_id)
+                .map(|hit| hit.event.event_id.as_uuid())
                 .collect::<Vec<_>>();
             selected_events.sort();
             assert_eq!(selected_events, expected_events);
@@ -454,7 +454,7 @@ fn provider_root_and_group_selectors_share_one_source_predicate_across_backends(
                 .result_window
                 .hits
                 .iter()
-                .map(|hit| hit.event.session_id)
+                .map(|hit| hit.event.session_id.as_uuid())
                 .collect::<Vec<_>>();
             selected_sessions.sort();
             assert_eq!(selected_sessions, expected_sessions);

--- a/crates/ctx-history-read-application/src/event_read_model.rs
+++ b/crates/ctx-history-read-application/src/event_read_model.rs
@@ -1,7 +1,7 @@
-use ctx_history_core::CoreContentPolicyStatus;
+use ctx_history_core::{CoreContent, CoreContentPolicyStatus};
 use ctx_history_index_query::{
     CoreEventRangeDirection, CoreEventRangeDomain, CoreEventRangeScope, CoreEventRangeSelection,
-    CoreEventRecord, VerifiedIndex,
+    CoreEventRecord, EventRecord, VerifiedIndex,
 };
 use serde::Serialize;
 use serde_json::{json, Map, Value};
@@ -15,6 +15,85 @@ pub const EVENT_QUERY_PAGE_BYTES: usize = 1024 * 1024;
 /// Keep a fixed envelope allowance while retaining a deterministic upper bound.
 pub const MAX_EVENT_QUERY_WIRE_RECORD_BYTES: usize =
     ctx_history_core::MAX_ENCODED_CORE_RECORD_BYTES * 6 + 1024 * 1024;
+
+pub(crate) struct EventReadView<'a> {
+    pub event: &'a EventRecord,
+    pub provider_key: Option<&'a str>,
+    pub source_id: Option<&'a str>,
+    pub occurred_at: Option<String>,
+}
+
+impl<'a> EventReadView<'a> {
+    pub fn new(event: &'a EventRecord) -> Self {
+        let (provider_key, source_id) = event
+            .custom_source_identity()
+            .map_or((None, None), |(provider_key, source_id)| {
+                (Some(provider_key), Some(source_id))
+            });
+        Self {
+            event,
+            provider_key,
+            source_id,
+            occurred_at: timestamp_json(event.occurred_at_unix_ms),
+        }
+    }
+
+    pub fn search_citation(&self) -> Value {
+        let event = self.event;
+        json!({
+            "item_id": event.event_id.as_uuid(),
+            "target_type": "event",
+            "ctx_event_id": event.event_id.as_uuid(),
+            "ctx_session_id": event.session_id.as_uuid(),
+            "provider": event.provider,
+            // Preserve Search's released compatibility mapping to the ctx session ID.
+            "session_id": event.session_id.as_uuid(),
+            "event_seq": event.event_sequence,
+        })
+    }
+
+    pub fn event_query_citation(&self) -> Value {
+        let event = self.event;
+        json!({
+            "target_type": "event",
+            "ctx_event_id": event.event_id.as_uuid(),
+            "ctx_session_id": event.session_id.as_uuid(),
+            "label": event.event_type,
+            "time": self.occurred_at.as_deref(),
+            "provider": event.provider,
+            // Preserve event enumeration's provider-session compatibility mapping.
+            "session_id": event.provider_session_id,
+            "event_seq": event.event_sequence,
+        })
+    }
+}
+
+pub(crate) struct EventContentPolicyView<'a> {
+    pub complete: bool,
+    pub revision: u32,
+    pub status: &'static str,
+    pub reason: Option<&'a str>,
+}
+
+impl<'a> EventContentPolicyView<'a> {
+    pub fn new(content: &'a CoreContent) -> Self {
+        let (status, reason, complete) = match &content.policy_status {
+            CoreContentPolicyStatus::Selected => ("selected", None, true),
+            CoreContentPolicyStatus::Redacted { reason } => {
+                ("redacted", Some(reason.as_str()), false)
+            }
+            CoreContentPolicyStatus::Omitted { reason } => {
+                ("omitted", Some(reason.as_str()), false)
+            }
+        };
+        Self {
+            complete,
+            revision: content.policy_revision,
+            status,
+            reason,
+        }
+    }
+}
 
 /// Stored Core is already JSON escaped. Reserving seven eighths of the MCP
 /// envelope covers event projection, receipt fields, and JSON-RPC framing
@@ -340,11 +419,8 @@ pub fn render_event_read_model(
 ) -> serde_json::Result<Value> {
     let record = &event.core_record;
     let content = &record.content;
-    let (policy_status, policy_reason, complete) = match &content.policy_status {
-        CoreContentPolicyStatus::Selected => ("selected", None, true),
-        CoreContentPolicyStatus::Redacted { reason } => ("redacted", Some(reason.as_str()), false),
-        CoreContentPolicyStatus::Omitted { reason } => ("omitted", Some(reason.as_str()), false),
-    };
+    let view = EventReadView::new(event);
+    let policy = EventContentPolicyView::new(content);
     let text = (projection != EventContentProjection::None)
         .then_some(content.normalized_body.as_ref())
         .flatten();
@@ -354,12 +430,6 @@ pub fn render_event_read_model(
     let activity = (projection == EventContentProjection::Full)
         .then_some(content.activity.as_ref())
         .flatten();
-    let (provider_key, source_id) = event
-        .custom_source_identity()
-        .map_or((None, None), |(provider_key, source_id)| {
-            (Some(provider_key), Some(source_id))
-        });
-    let occurred_at = timestamp_json(event.occurred_at_unix_ms);
     let mut rendered = json!({
         "schema_version": EVENT_QUERY_SCHEMA_VERSION,
         "record_version": record.record_version,
@@ -370,12 +440,12 @@ pub fn render_event_read_model(
         "root_ctx_session_id": event.root_session_id.map(|id| id.as_uuid()),
         "session_relationship": event.session_relationship,
         "event_copy": event_copy_json(event.event_copy.as_ref()),
-        "occurred_at": occurred_at,
+        "occurred_at": view.occurred_at.as_deref(),
         "occurred_at_ms": event.occurred_at_unix_ms,
         "sequence": event.event_sequence,
         "provider": event.provider,
-        "provider_key": provider_key,
-        "source_id": source_id,
+        "provider_key": view.provider_key,
+        "source_id": view.source_id,
         "source_format": event.source_format,
         "source": event.source,
         "provider_session_id": event.provider_session_id,
@@ -388,21 +458,12 @@ pub fn render_event_read_model(
         "text": text,
         "structured_content": structured_content,
         "content": {
-            "complete": complete,
-            "policy_revision": content.policy_revision,
-            "policy_status": policy_status,
-            "policy_reason": policy_reason,
+            "complete": policy.complete,
+            "policy_revision": policy.revision,
+            "policy_status": policy.status,
+            "policy_reason": policy.reason,
         },
-        "citations": [{
-            "target_type": "event",
-            "ctx_event_id": event.event_id.as_uuid(),
-            "ctx_session_id": event.session_id.as_uuid(),
-            "label": event.event_type,
-            "time": occurred_at,
-            "provider": event.provider,
-            "session_id": event.provider_session_id,
-            "event_seq": event.event_sequence,
-        }],
+        "citations": [view.event_query_citation()],
         "content_projection": projection.as_str(),
     });
     if let Some(activity) = activity {

--- a/crates/ctx-history-read-application/src/locate.rs
+++ b/crates/ctx-history-read-application/src/locate.rs
@@ -3,6 +3,7 @@ use ctx_history_core::{CaptureProvider, SourceKey};
 use ctx_history_index_query::{CoreEventRecord, EventRecord, SessionRecord};
 use serde_json::{json, Value};
 
+use crate::event_read_model::EventReadView;
 use crate::generation::PinnedGenerationRead;
 use crate::json::compact_json;
 use crate::{
@@ -188,11 +189,7 @@ fn locate_session_read_model(session: &SessionRecord, first_event: &EventRecord)
 }
 
 fn locate_event_read_model(event: &CoreEventRecord) -> Value {
-    let (provider_key, source_id) = event
-        .custom_source_identity()
-        .map_or((None, None), |(provider_key, source_id)| {
-            (Some(provider_key), Some(source_id))
-        });
+    let view = EventReadView::new(event);
     compact_json(json!({
         "schema_version": 1,
         "target": "event",
@@ -200,14 +197,14 @@ fn locate_event_read_model(event: &CoreEventRecord) -> Value {
         "ctx_event_id": event.event_id.as_uuid(),
         "ctx_session_id": event.session_id.as_uuid(),
         "provider": event.provider,
-        "provider_key": provider_key,
-        "source_id": source_id,
+        "provider_key": view.provider_key,
+        "source_id": view.source_id,
         "provider_session_id": event.provider_session_id,
         "provider_event_id": event.native_event_id,
         "sequence": event.event_sequence,
         "event_type": event.event_type,
         "role": event.role,
-        "occurred_at": timestamp_json(event.occurred_at_unix_ms),
+        "occurred_at": view.occurred_at.as_deref(),
         "source": source_read_model(&event.source),
     }))
 }

--- a/crates/ctx-history-read-application/src/presentation/hydration.rs
+++ b/crates/ctx-history-read-application/src/presentation/hydration.rs
@@ -4,7 +4,8 @@ use anyhow::{anyhow, Result};
 use ctx_history_core::{MAX_CORE_CONTENT_BYTES, MAX_ENCODED_CORE_RECORD_BYTES};
 use ctx_history_index_format::search_projection::project_search_content;
 use ctx_history_index_query::{
-    CompiledSearchFilter, CoreEventPageBudget, CoreEventRecord, RankedEventRef, VerifiedIndex,
+    CompiledSearchFilter, CoreEventPageBudget, CoreEventRecord, EventRecord, RankedEventRef,
+    VerifiedIndex,
 };
 use uuid::Uuid;
 
@@ -13,9 +14,7 @@ use super::{
     SEARCH_SNIPPET_MAX_BYTES,
 };
 use crate::search::RankedSearchCollection;
-use crate::{
-    NormalizedSearchQuery, SearchCollection, SearchEventMetadata, SearchHit, SearchResultWindow,
-};
+use crate::{NormalizedSearchQuery, SearchCollection, SearchHit, SearchResultWindow};
 
 const SEARCH_CORE_RECORD_BUDGET: CoreEventPageBudget =
     CoreEventPageBudget::new(MAX_ENCODED_CORE_RECORD_BYTES, MAX_CORE_CONTENT_BYTES);
@@ -180,7 +179,7 @@ fn ranked_search_projection(
     expected: &RankedEventRef,
     query_terms: &AnalyzedQueryTerms,
     filter: &CompiledSearchFilter,
-) -> Result<(SearchEventMetadata, SearchPresentation, usize)> {
+) -> Result<(EventRecord, SearchPresentation, usize)> {
     if !filter.matches_core(&record)? {
         return Err(anyhow!(
             "pinned Core lookup no longer matches the compiled Search filter for event {}",
@@ -211,10 +210,9 @@ fn ranked_search_projection(
     })?;
     let (snippet, snippet_truncated) = search_excerpt(&projection, query_terms);
     let retained_snippet_bytes = snippet.len();
-    let metadata = SearchEventMetadata::from(&event);
     drop(projection);
     Ok((
-        metadata,
+        event,
         SearchPresentation {
             event_id: expected.event_id,
             snippet,

--- a/crates/ctx-history-read-application/src/search.rs
+++ b/crates/ctx-history-read-application/src/search.rs
@@ -1,8 +1,7 @@
 use anyhow::{anyhow, Result};
-use ctx_history_core::{
-    AgentScope, CaptureProvider, EventType, ProviderNativeEventCopy,
-    ProviderNativeSessionRelationship,
-};
+#[cfg(test)]
+use ctx_history_core::AgentScope;
+use ctx_history_core::{CaptureProvider, EventType};
 #[cfg(test)]
 use ctx_history_index_query::SearchContentScope;
 use ctx_history_index_query::{
@@ -213,53 +212,8 @@ pub struct SearchHit<Event = SearchEventMetadata> {
 pub(crate) type RankedSearchCollection = SearchCollection<RankedEventRef>;
 pub(crate) type RankedSearchResultWindow = SearchResultWindow<RankedEventRef>;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SearchEventMetadata {
-    pub event_id: Uuid,
-    pub session_id: Uuid,
-    pub parent_session_id: Option<Uuid>,
-    pub root_session_id: Option<Uuid>,
-    pub session_relationship: Option<ProviderNativeSessionRelationship>,
-    pub event_copy: Option<ProviderNativeEventCopy>,
-    pub provider: String,
-    pub provider_key: Option<String>,
-    pub source_id: Option<String>,
-    pub source_format: String,
-    pub provider_session_id: Option<String>,
-    pub agent_scope: Option<AgentScope>,
-    pub event_sequence: u64,
-    pub occurred_at_unix_ms: Option<i64>,
-    pub event_type: String,
-    pub role: Option<String>,
-}
-
-impl From<&EventRecord> for SearchEventMetadata {
-    fn from(event: &EventRecord) -> Self {
-        let (provider_key, source_id) = event
-            .custom_source_identity()
-            .map_or((None, None), |(provider_key, source_id)| {
-                (Some(provider_key.to_owned()), Some(source_id.to_owned()))
-            });
-        Self {
-            event_id: event.event_id.as_uuid(),
-            session_id: event.session_id.as_uuid(),
-            parent_session_id: event.parent_session_id.map(|id| id.as_uuid()),
-            root_session_id: event.root_session_id.map(|id| id.as_uuid()),
-            session_relationship: event.session_relationship,
-            event_copy: event.event_copy.clone(),
-            provider: event.provider.clone(),
-            provider_key,
-            source_id,
-            source_format: event.source_format.clone(),
-            provider_session_id: event.provider_session_id.clone(),
-            agent_scope: event.agent_scope,
-            event_sequence: event.event_sequence,
-            occurred_at_unix_ms: event.occurred_at_unix_ms,
-            event_type: event.event_type.clone(),
-            role: event.role.clone(),
-        }
-    }
-}
+/// Compatibility name for the directly retained Core event metadata.
+pub type SearchEventMetadata = EventRecord;
 
 fn collect_search_hits_with_receipt<P: HistorySemanticPort>(
     request: &SearchRequest,

--- a/crates/ctx-history-read-application/src/search_read_model.rs
+++ b/crates/ctx-history-read-application/src/search_read_model.rs
@@ -4,7 +4,8 @@ use anyhow::{anyhow, Result};
 use ctx_history_index_query::{EventSearchFilters, SearchDiversificationStatus, VerifiedIndex};
 use serde_json::{json, Value};
 
-use crate::json::{compact_json, event_copy_json, timestamp_json};
+use crate::event_read_model::EventReadView;
+use crate::json::{compact_json, event_copy_json};
 use crate::{
     NormalizedSearchQuery, SearchCollection, SearchHit, SearchPresentation, SearchRequest,
     SEARCH_SNIPPET_MAX_CHARS,
@@ -82,7 +83,7 @@ pub fn render_search_json(input: SearchJsonInput<'_>) -> Result<Value> {
         .zip(commands)
         .enumerate()
         .map(|(offset, ((hit, presentation), commands))| {
-            if presentation.event_id != hit.event.event_id {
+            if presentation.event_id != hit.event.event_id.as_uuid() {
                 return Err(anyhow!(
                     "out-of-order search presentation for event {}",
                     presentation.event_id
@@ -209,9 +210,10 @@ pub fn search_result_json(
     commands: &SearchResultCommands,
 ) -> Result<Value> {
     let (snippet, snippet_truncated) = search_snippet(presentation);
-    let event = &hit.event;
-    let event_id = event.event_id;
-    let session_id = event.session_id;
+    let view = EventReadView::new(&hit.event);
+    let event = view.event;
+    let event_id = event.event_id.as_uuid();
+    let session_id = event.session_id.as_uuid();
     let item_id = if result_scope == "session" {
         session_id
     } else {
@@ -240,26 +242,18 @@ pub fn search_result_json(
         "more_matches_in_session": (result_scope == "session")
             .then_some(hit.more_matches_in_session),
         "provider": event.provider,
-        "provider_key": event.provider_key,
-        "source_id": event.source_id,
+        "provider_key": view.provider_key,
+        "source_id": view.source_id,
         "provider_session_id": event.provider_session_id,
         "source_format": event.source_format,
-        "parent_ctx_session_id": event.parent_session_id,
-        "root_ctx_session_id": event.root_session_id,
+        "parent_ctx_session_id": event.parent_session_id.map(|id| id.as_uuid()),
+        "root_ctx_session_id": event.root_session_id.map(|id| id.as_uuid()),
         "session_relationship": event.session_relationship,
         "event_copy": event_copy_json(event.event_copy.as_ref()),
         "agent_scope": event.agent_scope,
-        "timestamp": timestamp_json(event.occurred_at_unix_ms),
+        "timestamp": view.occurred_at.as_deref(),
         "suggested_next_commands": commands.suggested_next_commands,
-        "citations": [{
-            "item_id": event_id,
-            "target_type": "event",
-            "ctx_event_id": event_id,
-            "ctx_session_id": session_id,
-            "provider": event.provider,
-            "session_id": session_id,
-            "event_seq": event.event_sequence,
-        }],
+        "citations": [view.search_citation()],
         "visibility": "local",
     })))
 }

--- a/crates/ctx-history-read-application/src/show_read_model.rs
+++ b/crates/ctx-history-read-application/src/show_read_model.rs
@@ -2,14 +2,14 @@ use std::fmt;
 
 use anyhow::{anyhow, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-use ctx_history_core::CoreContentPolicyStatus;
 use ctx_history_index_query::{
     CopiedEventLineage, CoreEventRecord, IndexError, SessionEventCursor, SessionRecord,
 };
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use crate::json::{compact_json, event_copy_json, timestamp_json};
+use crate::event_read_model::{EventContentPolicyView, EventReadView};
+use crate::json::{compact_json, event_copy_json};
 use crate::{copied_lineage_read_model, ShowSessionEvent};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -190,24 +190,16 @@ pub fn render_event_read_model_values(
 
 pub fn render_show_event_read_model(event: &CoreEventRecord) -> Value {
     let content = &event.core_record.content;
-    let (policy_status, policy_reason, complete) = match &content.policy_status {
-        CoreContentPolicyStatus::Selected => ("selected", None, true),
-        CoreContentPolicyStatus::Redacted { reason } => ("redacted", Some(reason.as_str()), false),
-        CoreContentPolicyStatus::Omitted { reason } => ("omitted", Some(reason.as_str()), false),
-    };
-    let (provider_key, source_id) = event
-        .custom_source_identity()
-        .map_or((None, None), |(provider_key, source_id)| {
-            (Some(provider_key), Some(source_id))
-        });
+    let view = EventReadView::new(event);
+    let policy = EventContentPolicyView::new(content);
     let mut rendered = compact_json(json!({
         "ctx_event_id": event.event_id.as_uuid(),
         "item_id": event.event_id.as_uuid(),
         "record_type": "event",
         "ctx_session_id": event.session_id.as_uuid(),
         "provider": event.provider,
-        "provider_key": provider_key,
-        "source_id": source_id,
+        "provider_key": view.provider_key,
+        "source_id": view.source_id,
         "provider_session_id": event.provider_session_id,
         "source_format": event.source_format,
         "parent_ctx_session_id": event.parent_session_id.map(|id| id.as_uuid()),
@@ -218,13 +210,13 @@ pub fn render_show_event_read_model(event: &CoreEventRecord) -> Value {
         "sequence": event.event_sequence,
         "event_type": event.event_type,
         "role": event.role,
-        "occurred_at": timestamp_json(event.occurred_at_unix_ms),
+        "occurred_at": view.occurred_at.as_deref(),
         "text": content.normalized_body.as_deref(),
         "structured_content": content.structured_content.as_ref(),
         "content": {
-            "complete": complete,
-            "policy_status": policy_status,
-            "policy_reason": policy_reason,
+            "complete": policy.complete,
+            "policy_status": policy.status,
+            "policy_reason": policy.reason,
         },
     }));
     if let Some(activity) = &content.activity {


### PR DESCRIPTION
## Summary

- retain the owning index-query `EventRecord` directly in hydrated search results instead of cloning a duplicate metadata DTO
- share one crate-private borrowed event/policy view for neutral IDs, timestamps, custom-source identity, content policy, and citations across search, show, list/event-query, locate, and MCP passthrough results
- preserve every command-specific schema, null/omission rule, and legacy citation `session_id` mapping
- use a compact exact-value matrix for search, show, list, MCP event wrapping, and locate without sharing expected answers with production code

## Size

- 264 insertions, 165 deletions
- net +99 lines; production code is net -4 and the increase is independent cross-surface contract coverage

## Validation

- independent exact-patch review: ship
- exact equivalent rebases onto current main verified by `git range-diff`
- `//crates/ctx-history-read-application:unit_tests`: passed
- `//crates/ctx-history-cli:unit_tests`: passed
- `//crates/ctx-cli:unit_tests`: passed
- repository push policy, LOC, Cargo/Bazel ownership, rustfmt, and `git diff --check`: passed

## Deliberate non-change

`CoreActivity` is richer than the released protocol `mcp_tool_call` `{server, tool}` shape. Converting between them would change product/schema semantics, so that distinct contract remains unchanged.