### PR TITLE
Complete the immutable snapshot reader boundary

### DIFF
--- a/crates/ctx-history-index-generation/src/generation.rs
+++ b/crates/ctx-history-index-generation/src/generation.rs
@@ -193,11 +193,10 @@ pub(crate) fn load_active_generation_pointer_from_read_root(
     parse_active_generation_pointer(bytes).map(Some)
 }
 
-/// Loads only the active generation ID below an already opened and validated
-/// lexical root.
+/// Loads only the active generation ID below a caller-validated lexical root.
 ///
-/// This keeps callers on the handle-anchored read path without exposing the
-/// publication pointer or its physical slot details.
+/// This does not grant mutation authority or expose the publication pointer or
+/// its physical slot details.
 pub fn load_active_generation_id_from_read_root(
     root: &crate::GenerationReadRoot,
 ) -> Result<Option<String>> {

--- a/crates/ctx-history-index-generation/src/generation.rs
+++ b/crates/ctx-history-index-generation/src/generation.rs
@@ -193,6 +193,18 @@ pub(crate) fn load_active_generation_pointer_from_read_root(
     parse_active_generation_pointer(bytes).map(Some)
 }
 
+/// Loads only the active generation ID below an already opened and validated
+/// lexical root.
+///
+/// This keeps callers on the handle-anchored read path without exposing the
+/// publication pointer or its physical slot details.
+pub fn load_active_generation_id_from_read_root(
+    root: &crate::GenerationReadRoot,
+) -> Result<Option<String>> {
+    load_active_generation_pointer_from_read_root(root)
+        .map(|pointer| pointer.map(|pointer| pointer.active().generation_id().to_owned()))
+}
+
 fn parse_active_generation_pointer(bytes: Vec<u8>) -> Result<ActiveGenerationPointer> {
     #[derive(Deserialize)]
     struct PointerVersion {

--- a/crates/ctx-history-index-generation/src/lib.rs
+++ b/crates/ctx-history-index-generation/src/lib.rs
@@ -55,8 +55,8 @@ pub use error::{GenerationError, Result};
 #[cfg(windows)]
 pub use generation::publish_active_generation_pointer_validated_predecessor_fence;
 pub use generation::{
-    create_candidate_generation, lexical_index_settings, load_active_generation_pointer,
-    open_slot_index, publish_active_generation_pointer,
+    create_candidate_generation, lexical_index_settings, load_active_generation_id_from_read_root,
+    load_active_generation_pointer, open_slot_index, publish_active_generation_pointer,
     publish_active_generation_pointer_validated, reclaim_inactive_generation_directories,
     slot_path, sync_directory, sync_generation, ActiveGenerationPointer, CandidateGeneration,
     GenerationSlot, PointerPublicationOutcome,

--- a/crates/ctx-history-snapshot-reader/src/lib.rs
+++ b/crates/ctx-history-snapshot-reader/src/lib.rs
@@ -6,10 +6,13 @@
 //! byte-range locks; they never refresh, migrate, repair, or select a replacement
 //! generation.
 
-use std::{collections::VecDeque, path::Path};
+use std::{
+    collections::{HashSet, VecDeque},
+    path::Path,
+};
 
 use ctx_history_core::{
-    CoreRecord, SourceKey, StableEntityId, CORE_RECORD_VERSION, IDENTITY_VERSION,
+    CoreRecord, SourceKey, StableEntityId, StableEntityKind, CORE_RECORD_VERSION, IDENTITY_VERSION,
 };
 use ctx_history_index_format::{
     current_core_record_contract_fingerprint, current_source_generation_policy_hash,
@@ -17,15 +20,25 @@ use ctx_history_index_format::{
     LEXICAL_ANALYZER_VERSION, LEXICAL_SCHEMA_VERSION,
 };
 use ctx_history_index_generation::{
-    acquire_generation_read_lease_from_root, acquire_retained_generation_read_lease_from_root,
-    GenerationReadLease, GenerationReadRoot, GenerationRetentionLease,
+    acquire_generation_read_lease_from_root,
+    acquire_generation_retention_lease as acquire_canonical_retention_lease,
+    acquire_retained_generation_read_lease_from_root, load_active_generation_id_from_read_root,
+    load_generation_retention_lease as load_canonical_retention_lease,
+    release_generation_retention_lease as release_canonical_retention_lease, GenerationReadLease,
+    GenerationReadRoot,
 };
 use ctx_history_index_query::{
-    CoreEventPageBudget, IndexError, SourceEventCursor, VerifiedIndex,
-    DEFAULT_CORE_EVENT_PAGE_BUDGET, MAX_SOURCE_EVENT_PAGE_ITEMS,
+    IndexError, SourceEventCursor, VerifiedIndex, MAX_SOURCE_EVENT_PAGE_ITEMS,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+pub use ctx_history_index_generation::GenerationRetentionLease as SnapshotRetentionLease;
+pub use ctx_history_index_query::{
+    CoreEventPageBudget as SnapshotPageBudget,
+    DEFAULT_CORE_EVENT_PAGE_BUDGET as DEFAULT_SNAPSHOT_PAGE_BUDGET,
+    MAX_SOURCE_EVENT_PAGE_ITEMS as MAX_CORE_RECORD_BATCH_ITEMS,
+};
 
 pub const MAX_SOURCE_MANIFEST_PAGE_ITEMS: usize = 256;
 pub const MAX_SOURCE_DELTA_PAGE_ITEMS: usize = 256;
@@ -104,6 +117,46 @@ pub enum SnapshotError {
 
 pub type Result<T> = std::result::Result<T, SnapshotError>;
 
+/// Loads the active generation ID below `data_root/search/lexical` without
+/// exposing or reopening the publication pointer.
+pub fn load_active_generation_id(data_root: impl AsRef<Path>) -> Result<Option<String>> {
+    let root = GenerationReadRoot::open_data_root(data_root).map_err(map_generation_root_error)?;
+    load_active_generation_id_from_read_root(&root)
+        .map_err(|error| map_generation_error(error, "active generation"))
+}
+
+/// Acquires the sole durable retention authority for one currently retained
+/// generation. Exact replay by the same owner is idempotent.
+pub fn acquire_snapshot_retention_lease(
+    data_root: impl AsRef<Path>,
+    generation_id: &str,
+    owner_kind: &str,
+    owner_id: &str,
+) -> Result<SnapshotRetentionLease> {
+    let root = GenerationReadRoot::open_data_root(data_root).map_err(map_generation_root_error)?;
+    acquire_canonical_retention_lease(root.path(), generation_id, owner_kind, owner_id)
+        .map_err(|error| map_generation_error(error, generation_id))
+}
+
+/// Loads and validates the sole durable retention authority, if one exists.
+pub fn load_snapshot_retention_lease(
+    data_root: impl AsRef<Path>,
+) -> Result<Option<SnapshotRetentionLease>> {
+    let root = GenerationReadRoot::open_data_root(data_root).map_err(map_generation_root_error)?;
+    load_canonical_retention_lease(root.path())
+        .map_err(|error| map_generation_error(error, "retention lease"))
+}
+
+/// Releases exactly the observed durable retention authority.
+pub fn release_snapshot_retention_lease(
+    data_root: impl AsRef<Path>,
+    expected: &SnapshotRetentionLease,
+) -> Result<bool> {
+    let root = GenerationReadRoot::open_data_root(data_root).map_err(map_generation_root_error)?;
+    release_canonical_retention_lease(root.path(), expected)
+        .map_err(|error| map_generation_error(error, expected.generation_id()))
+}
+
 pub struct CoreSnapshot {
     index: VerifiedIndex,
     contract: SnapshotContract,
@@ -134,7 +187,7 @@ impl CoreSnapshot {
     /// path performs one full read-only physical audit before opening.
     pub fn open_retained(
         data_root: impl AsRef<Path>,
-        authority: &GenerationRetentionLease,
+        authority: &SnapshotRetentionLease,
         expected: &SnapshotContract,
     ) -> Result<Self> {
         let generation_id = authority.generation_id();
@@ -342,7 +395,7 @@ impl CoreSnapshot {
         source: &SourceKey,
         cursor: Option<&CoreRecordPageCursor>,
         limit: usize,
-        budget: CoreEventPageBudget,
+        budget: SnapshotPageBudget,
     ) -> Result<CoreRecordPage> {
         if !(1..=MAX_SOURCE_EVENT_PAGE_ITEMS).contains(&limit) {
             return Err(SnapshotError::Bounds(format!(
@@ -398,11 +451,82 @@ impl CoreSnapshot {
         })
     }
 
+    /// Resolves a bounded exact-ID set from this immutable generation.
+    ///
+    /// The complete batch is returned in requested order only when every ID
+    /// exists and both the aggregate and each individual record fit their
+    /// strict byte ceilings. Otherwise a missing or over-budget batch returns
+    /// `None`; no partial records are exposed.
+    pub fn core_records_by_ids(
+        &self,
+        event_ids: &[StableEntityId],
+        aggregate_budget: SnapshotPageBudget,
+        per_record_budget: SnapshotPageBudget,
+    ) -> Result<Option<CoreRecordBatch>> {
+        if event_ids.len() > MAX_CORE_RECORD_BATCH_ITEMS {
+            return Err(SnapshotError::Bounds(format!(
+                "Core record batch size {} exceeds {MAX_CORE_RECORD_BATCH_ITEMS}",
+                event_ids.len()
+            )));
+        }
+        let mut unique = HashSet::with_capacity(event_ids.len());
+        let mut compact_ids = Vec::with_capacity(event_ids.len());
+        for event_id in event_ids {
+            event_id
+                .validate_contract()
+                .map_err(|error| SnapshotError::Bounds(error.to_string()))?;
+            if event_id.entity_kind() != StableEntityKind::Event {
+                return Err(SnapshotError::Bounds(
+                    "Core record batch IDs must identify events".to_owned(),
+                ));
+            }
+            if !unique.insert(*event_id) {
+                return Err(SnapshotError::Bounds(format!(
+                    "Core record batch contains duplicate event {}",
+                    event_id.as_uuid()
+                )));
+            }
+            compact_ids.push(event_id.as_uuid());
+        }
+
+        let Some(batch) = self
+            .index
+            .core_events_by_ids_with_strict_per_record_budget(
+                &compact_ids,
+                MAX_CORE_RECORD_BATCH_ITEMS,
+                aggregate_budget,
+                per_record_budget,
+            )
+            .map_err(|error| map_index_error(error, self.generation_id(), self.contract()))?
+        else {
+            return Ok(None);
+        };
+        let records = batch
+            .items
+            .into_iter()
+            .zip(event_ids)
+            .map(|(item, expected)| {
+                if item.core_record.event_id != *expected {
+                    return Err(SnapshotError::Corrupt(
+                        "Core record batch identity does not match the requested full identity"
+                            .to_owned(),
+                    ));
+                }
+                Ok(item.core_record)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Some(CoreRecordBatch {
+            records,
+            encoded_core_bytes: batch.encoded_core_bytes,
+            content_bytes: batch.content_bytes,
+        }))
+    }
+
     pub fn records<'a>(
         &'a self,
         source: SourceKey,
         page_items: usize,
-        budget: CoreEventPageBudget,
+        budget: SnapshotPageBudget,
     ) -> Result<CoreRecordStream<'a>> {
         if !(1..=MAX_SOURCE_EVENT_PAGE_ITEMS).contains(&page_items) {
             return Err(SnapshotError::Bounds(format!(
@@ -422,7 +546,7 @@ impl CoreSnapshot {
     }
 
     pub fn records_with_default_bounds(&self, source: SourceKey) -> Result<CoreRecordStream<'_>> {
-        self.records(source, 64, DEFAULT_CORE_EVENT_PAGE_BUDGET)
+        self.records(source, 64, DEFAULT_SNAPSHOT_PAGE_BUDGET)
     }
 
     fn source_state(&self, index: usize) -> Result<SourceState> {
@@ -589,11 +713,20 @@ pub struct CoreRecordPage {
     pub terminal: bool,
 }
 
+/// Canonical Core records from one exact requested-ID lookup plus the exact
+/// retained byte totals enforced by the reader.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoreRecordBatch {
+    pub records: Vec<CoreRecord>,
+    pub encoded_core_bytes: usize,
+    pub content_bytes: usize,
+}
+
 pub struct CoreRecordStream<'a> {
     snapshot: &'a CoreSnapshot,
     source: SourceKey,
     page_items: usize,
-    budget: CoreEventPageBudget,
+    budget: SnapshotPageBudget,
     cursor: Option<CoreRecordPageCursor>,
     buffered: VecDeque<CoreRecord>,
     terminal: bool,

--- a/crates/ctx-history-snapshot-reader/src/lib.rs
+++ b/crates/ctx-history-snapshot-reader/src/lib.rs
@@ -37,9 +37,11 @@ pub use ctx_history_index_generation::GenerationRetentionLease as SnapshotRetent
 pub use ctx_history_index_query::{
     CoreEventPageBudget as SnapshotPageBudget,
     DEFAULT_CORE_EVENT_PAGE_BUDGET as DEFAULT_SNAPSHOT_PAGE_BUDGET,
-    MAX_SOURCE_EVENT_PAGE_ITEMS as MAX_CORE_RECORD_BATCH_ITEMS,
 };
 
+/// Maximum records in one exact-ID lookup. This small, reader-owned cap keeps
+/// preview reads independently bounded from source-record paging.
+pub const MAX_EXACT_CORE_RECORD_BATCH_ITEMS: usize = 3;
 pub const MAX_SOURCE_MANIFEST_PAGE_ITEMS: usize = 256;
 pub const MAX_SOURCE_DELTA_PAGE_ITEMS: usize = 256;
 pub const MAX_SOURCE_DELTA_SCANNED_ITEMS: usize = 1_024;
@@ -120,13 +122,17 @@ pub type Result<T> = std::result::Result<T, SnapshotError>;
 /// Loads the active generation ID below `data_root/search/lexical` without
 /// exposing or reopening the publication pointer.
 pub fn load_active_generation_id(data_root: impl AsRef<Path>) -> Result<Option<String>> {
-    let root = GenerationReadRoot::open_data_root(data_root).map_err(map_generation_root_error)?;
+    let Some(root) = open_data_root_if_present(data_root)? else {
+        return Ok(None);
+    };
     load_active_generation_id_from_read_root(&root)
         .map_err(|error| map_generation_error(error, "active generation"))
 }
 
 /// Acquires the sole durable retention authority for one currently retained
-/// generation. Exact replay by the same owner is idempotent.
+/// generation. Exact replay by the same owner is idempotent. After validating
+/// the private lexical root, this delegates to index-generation's established
+/// path-based retention operation.
 pub fn acquire_snapshot_retention_lease(
     data_root: impl AsRef<Path>,
     generation_id: &str,
@@ -142,17 +148,23 @@ pub fn acquire_snapshot_retention_lease(
 pub fn load_snapshot_retention_lease(
     data_root: impl AsRef<Path>,
 ) -> Result<Option<SnapshotRetentionLease>> {
-    let root = GenerationReadRoot::open_data_root(data_root).map_err(map_generation_root_error)?;
+    let Some(root) = open_data_root_if_present(data_root)? else {
+        return Ok(None);
+    };
     load_canonical_retention_lease(root.path())
         .map_err(|error| map_generation_error(error, "retention lease"))
 }
 
-/// Releases exactly the observed durable retention authority.
+/// Releases exactly the observed durable retention authority. After validating
+/// the private lexical root, this delegates to index-generation's established
+/// path-based retention operation.
 pub fn release_snapshot_retention_lease(
     data_root: impl AsRef<Path>,
     expected: &SnapshotRetentionLease,
 ) -> Result<bool> {
-    let root = GenerationReadRoot::open_data_root(data_root).map_err(map_generation_root_error)?;
+    let Some(root) = open_data_root_if_present(data_root)? else {
+        return Ok(false);
+    };
     release_canonical_retention_lease(root.path(), expected)
         .map_err(|error| map_generation_error(error, expected.generation_id()))
 }
@@ -457,19 +469,20 @@ impl CoreSnapshot {
     /// exists and both the aggregate and each individual record fit their
     /// strict byte ceilings. Otherwise a missing or over-budget batch returns
     /// `None`; no partial records are exposed.
-    pub fn core_records_by_ids(
+    pub fn core_records_by_ids_if_bounded(
         &self,
         event_ids: &[StableEntityId],
         aggregate_budget: SnapshotPageBudget,
         per_record_budget: SnapshotPageBudget,
     ) -> Result<Option<CoreRecordBatch>> {
-        if event_ids.len() > MAX_CORE_RECORD_BATCH_ITEMS {
+        if event_ids.len() > MAX_EXACT_CORE_RECORD_BATCH_ITEMS {
             return Err(SnapshotError::Bounds(format!(
-                "Core record batch size {} exceeds {MAX_CORE_RECORD_BATCH_ITEMS}",
+                "Core record batch size {} exceeds {MAX_EXACT_CORE_RECORD_BATCH_ITEMS}",
                 event_ids.len()
             )));
         }
         let mut unique = HashSet::with_capacity(event_ids.len());
+        let mut unique_compact_ids = HashSet::with_capacity(event_ids.len());
         let mut compact_ids = Vec::with_capacity(event_ids.len());
         for event_id in event_ids {
             event_id
@@ -486,6 +499,9 @@ impl CoreSnapshot {
                     event_id.as_uuid()
                 )));
             }
+            if !unique_compact_ids.insert(event_id.as_uuid()) {
+                return Ok(None);
+            }
             compact_ids.push(event_id.as_uuid());
         }
 
@@ -493,7 +509,7 @@ impl CoreSnapshot {
             .index
             .core_events_by_ids_with_strict_per_record_budget(
                 &compact_ids,
-                MAX_CORE_RECORD_BATCH_ITEMS,
+                MAX_EXACT_CORE_RECORD_BATCH_ITEMS,
                 aggregate_budget,
                 per_record_budget,
             )
@@ -501,20 +517,16 @@ impl CoreSnapshot {
         else {
             return Ok(None);
         };
-        let records = batch
-            .items
-            .into_iter()
-            .zip(event_ids)
-            .map(|(item, expected)| {
-                if item.core_record.event_id != *expected {
-                    return Err(SnapshotError::Corrupt(
-                        "Core record batch identity does not match the requested full identity"
-                            .to_owned(),
-                    ));
-                }
-                Ok(item.core_record)
-            })
-            .collect::<Result<Vec<_>>>()?;
+        let mut records = Vec::with_capacity(event_ids.len());
+        for (item, expected) in batch.items.into_iter().zip(event_ids) {
+            if item.core_record.event_id != *expected {
+                return Ok(None);
+            }
+            records.push(item.core_record);
+        }
+        if records.len() != event_ids.len() {
+            return Ok(None);
+        }
         Ok(Some(CoreRecordBatch {
             records,
             encoded_core_bytes: batch.encoded_core_bytes,
@@ -778,6 +790,16 @@ fn map_generation_root_error(
     SnapshotError::UnsafePath(error.to_string())
 }
 
+fn open_data_root_if_present(data_root: impl AsRef<Path>) -> Result<Option<GenerationReadRoot>> {
+    match GenerationReadRoot::open_data_root(data_root) {
+        Ok(root) => Ok(Some(root)),
+        Err(ctx_history_index_generation::GenerationError::MissingActiveGenerationPointer) => {
+            Ok(None)
+        }
+        Err(error) => Err(map_generation_root_error(error)),
+    }
+}
+
 fn map_generation_error(
     error: ctx_history_index_generation::GenerationError,
     generation_id: &str,
@@ -788,7 +810,8 @@ fn map_generation_error(
         | GenerationError::GenerationRetentionLeaseTargetNotRetained { .. }
         | GenerationError::MissingActiveGenerationPointer
         | GenerationError::MissingManifest(_) => SnapshotError::NotFound(generation_id.to_owned()),
-        GenerationError::GenerationRetentionLeaseConflict { .. } => {
+        GenerationError::GenerationRetentionLeaseConflict { .. }
+        | GenerationError::GenerationRetentionLeaseOwnerMismatch => {
             SnapshotError::LeaseConflict(generation_id.to_owned())
         }
         error @ GenerationError::ConcurrentGenerationChange => {
@@ -810,7 +833,8 @@ fn map_index_error(
         IndexError::MissingActiveGenerationPointer
         | IndexError::PinnedGenerationNotRetained { .. }
         | IndexError::MissingManifest(_) => SnapshotError::NotFound(generation_id.to_owned()),
-        IndexError::GenerationRetentionLeaseConflict { .. } => {
+        IndexError::GenerationRetentionLeaseConflict { .. }
+        | IndexError::GenerationRetentionLeaseOwnerMismatch => {
             SnapshotError::LeaseConflict(generation_id.to_owned())
         }
         error @ IndexError::ConcurrentGenerationChange => {

--- a/crates/ctx-history-snapshot-reader/src/tests.rs
+++ b/crates/ctx-history-snapshot-reader/src/tests.rs
@@ -70,6 +70,21 @@ fn concurrent_publication_is_not_reported_as_corruption() {
         ),
         SnapshotError::ConcurrentGenerationChange(_)
     ));
+    assert!(matches!(
+        map_generation_error(
+            ctx_history_index_generation::GenerationError::GenerationRetentionLeaseOwnerMismatch,
+            &"c".repeat(64),
+        ),
+        SnapshotError::LeaseConflict(_)
+    ));
+    assert!(matches!(
+        map_index_error(
+            ctx_history_index_query::IndexError::GenerationRetentionLeaseOwnerMismatch,
+            &"d".repeat(64),
+            &SnapshotContract::current().unwrap(),
+        ),
+        SnapshotError::LeaseConflict(_)
+    ));
 }
 
 #[test]
@@ -409,6 +424,14 @@ fn certificate(source: &SourceKey, revision: u8, records: usize) -> CertifiedSou
     .unwrap()
 }
 
+fn colliding_full_event_identity(event_id: StableEntityId) -> StableEntityId {
+    let mut encoded = event_id.encode_canonical().unwrap();
+    // The compact UUID is derived from the first 16 digest bytes. Change a
+    // later digest byte so this remains a contract-valid, distinct full ID.
+    encoded[3 + 16] ^= 1;
+    StableEntityId::decode_canonical(&encoded).unwrap()
+}
+
 fn publish(
     index_root: &std::path::Path,
     revision: u8,
@@ -660,7 +683,7 @@ fn manifest_delta_and_replayable_exact_json_pages_use_neutral_bounded_state() {
 }
 
 #[test]
-fn exact_record_batch_preserves_full_identity_order_totals_and_strict_bounds() {
+fn exact_record_batch_requires_full_identities_and_returns_complete_or_absent() {
     let fixture = Fixture::new();
     let source = source("exact-batch");
     let records = vec![
@@ -698,36 +721,16 @@ fn exact_record_batch_preserves_full_identity_order_totals_and_strict_bounds() {
         SnapshotPageBudget::new(maximum_record_encoded_bytes, maximum_record_content_bytes);
 
     let batch = snapshot
-        .core_records_by_ids(&event_ids, aggregate_budget, per_record_budget)
+        .core_records_by_ids_if_bounded(&event_ids, aggregate_budget, per_record_budget)
         .unwrap()
         .unwrap();
     assert_eq!(batch.records, expected);
     assert_eq!(batch.encoded_core_bytes, encoded_core_bytes);
     assert_eq!(batch.content_bytes, content_bytes);
 
-    assert!(snapshot
-        .core_records_by_ids(
-            &event_ids,
-            SnapshotPageBudget::new(encoded_core_bytes - 1, content_bytes),
-            per_record_budget,
-        )
-        .unwrap()
-        .is_none());
-    assert!(snapshot
-        .core_records_by_ids(
-            &event_ids,
-            aggregate_budget,
-            SnapshotPageBudget::new(
-                maximum_record_encoded_bytes - 1,
-                maximum_record_content_bytes,
-            ),
-        )
-        .unwrap()
-        .is_none());
-
     let missing = record(&source, 99, "not published").event_id;
     assert!(snapshot
-        .core_records_by_ids(
+        .core_records_by_ids_if_bounded(
             &[event_ids[0], missing],
             aggregate_budget,
             per_record_budget,
@@ -735,7 +738,7 @@ fn exact_record_batch_preserves_full_identity_order_totals_and_strict_bounds() {
         .unwrap()
         .is_none());
     assert!(matches!(
-        snapshot.core_records_by_ids(
+        snapshot.core_records_by_ids_if_bounded(
             &[event_ids[0], event_ids[0]],
             aggregate_budget,
             per_record_budget,
@@ -743,7 +746,7 @@ fn exact_record_batch_preserves_full_identity_order_totals_and_strict_bounds() {
         Err(SnapshotError::Bounds(_))
     ));
     assert!(matches!(
-        snapshot.core_records_by_ids(
+        snapshot.core_records_by_ids_if_bounded(
             &[records[0].session_id],
             aggregate_budget,
             per_record_budget,
@@ -751,17 +754,28 @@ fn exact_record_batch_preserves_full_identity_order_totals_and_strict_bounds() {
         Err(SnapshotError::Bounds(_))
     ));
     assert!(matches!(
-        snapshot.core_records_by_ids(
-            &vec![event_ids[0]; MAX_CORE_RECORD_BATCH_ITEMS + 1],
+        snapshot.core_records_by_ids_if_bounded(
+            &vec![event_ids[0]; MAX_EXACT_CORE_RECORD_BATCH_ITEMS + 1],
             aggregate_budget,
             per_record_budget,
         ),
         Err(SnapshotError::Bounds(_))
     ));
-    assert!(matches!(
-        snapshot.core_records_by_ids(&event_ids, SnapshotPageBudget::new(0, 1), per_record_budget,),
-        Err(SnapshotError::Bounds(_))
-    ));
+    let colliding = colliding_full_event_identity(event_ids[0]);
+    assert_ne!(colliding, event_ids[0]);
+    assert_eq!(colliding.as_uuid(), event_ids[0].as_uuid());
+    assert!(snapshot
+        .core_records_by_ids_if_bounded(&[colliding], aggregate_budget, per_record_budget)
+        .unwrap()
+        .is_none());
+    assert!(snapshot
+        .core_records_by_ids_if_bounded(
+            &[event_ids[0], colliding],
+            aggregate_budget,
+            per_record_budget,
+        )
+        .unwrap()
+        .is_none());
 }
 
 #[test]
@@ -999,4 +1013,35 @@ fn active_generation_lookup_uses_the_core_data_root_and_reports_absence() {
         load_active_generation_id(&fixture.data_root).unwrap(),
         Some(second)
     );
+}
+
+#[test]
+fn missing_root_components_are_normal_absence_for_lookup_load_and_release() {
+    let roots = tempdir().unwrap();
+    let missing_data = roots.path().join("missing-data");
+    let data_only = roots.path().join("data-only");
+    fs::create_dir(&data_only).unwrap();
+    restrict_private_directory(&data_only).unwrap();
+    let search_only = roots.path().join("search-only");
+    fs::create_dir(&search_only).unwrap();
+    restrict_private_directory(&search_only).unwrap();
+    let search = search_only.join("search");
+    fs::create_dir(&search).unwrap();
+    restrict_private_directory(&search).unwrap();
+
+    let fixture = Fixture::new();
+    let generation_id = publish(&fixture.index_root, 1, &[]);
+    let lease = acquire_snapshot_retention_lease(
+        &fixture.data_root,
+        &generation_id,
+        "restartable_catchup",
+        &"a".repeat(64),
+    )
+    .unwrap();
+
+    for root in [&missing_data, &data_only, &search_only] {
+        assert_eq!(load_active_generation_id(root).unwrap(), None);
+        assert_eq!(load_snapshot_retention_lease(root).unwrap(), None);
+        assert!(!release_snapshot_retention_lease(root, &lease).unwrap());
+    }
 }

--- a/crates/ctx-history-snapshot-reader/src/tests.rs
+++ b/crates/ctx-history-snapshot-reader/src/tests.rs
@@ -15,14 +15,11 @@ use ctx_history_index_generation::{
     CloneTestOptions,
 };
 use ctx_history_index_generation::{
-    acquire_generation_retention_lease, certification_file_for_active, checksum_walks,
-    load_active_generation_pointer, release_generation_retention_lease,
+    certification_file_for_active, checksum_walks, load_active_generation_pointer,
     reset_physical_verification_activity, slot_path, GenerationRootTraversalStage,
     GenerationRootTraversalTestHookGuard,
 };
-use ctx_history_index_query::{
-    CoreEventPageBudget, DEFAULT_CORE_EVENT_PAGE_BUDGET, MAX_SOURCE_EVENT_PAGE_ITEMS,
-};
+use ctx_history_index_query::MAX_SOURCE_EVENT_PAGE_ITEMS;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use ctx_history_index_query::{IndexError, VerifiedIndex};
 use ctx_history_platform::platform_security::restrict_private_directory;
@@ -84,13 +81,40 @@ fn durable_exact_target_opens_after_more_than_two_publications() {
         1,
         &[(source.clone(), vec![record(&source, 1, "retained")])],
     );
-    let authority = acquire_generation_retention_lease(
-        &fixture.index_root,
+    assert_eq!(
+        load_snapshot_retention_lease(&fixture.data_root).unwrap(),
+        None
+    );
+    let authority = acquire_snapshot_retention_lease(
+        &fixture.data_root,
         &retained_id,
         "restartable_catchup",
         &"a".repeat(64),
     )
     .unwrap();
+    assert_eq!(
+        acquire_snapshot_retention_lease(
+            &fixture.data_root,
+            &retained_id,
+            "restartable_catchup",
+            &"a".repeat(64),
+        )
+        .unwrap(),
+        authority
+    );
+    assert_eq!(
+        load_snapshot_retention_lease(&fixture.data_root).unwrap(),
+        Some(authority.clone())
+    );
+    assert!(matches!(
+        acquire_snapshot_retention_lease(
+            &fixture.data_root,
+            &retained_id,
+            "restartable_catchup",
+            &"b".repeat(64),
+        ),
+        Err(SnapshotError::LeaseConflict(_))
+    ));
     for revision in 2..=5 {
         publish(
             &fixture.index_root,
@@ -125,7 +149,7 @@ fn durable_exact_target_opens_after_more_than_two_publications() {
     assert_eq!(retained.generation_id(), retained_id);
     assert_eq!(
         retained
-            .record_page(&source, None, 8, DEFAULT_CORE_EVENT_PAGE_BUDGET)
+            .record_page(&source, None, 8, DEFAULT_SNAPSHOT_PAGE_BUDGET)
             .unwrap()
             .items[0]
             .core_record
@@ -135,7 +159,12 @@ fn durable_exact_target_opens_after_more_than_two_publications() {
     );
     drop(retained);
 
-    assert!(release_generation_retention_lease(&fixture.index_root, &authority).unwrap());
+    assert!(release_snapshot_retention_lease(&fixture.data_root, &authority).unwrap());
+    assert!(!release_snapshot_retention_lease(&fixture.data_root, &authority).unwrap());
+    assert_eq!(
+        load_snapshot_retention_lease(&fixture.data_root).unwrap(),
+        None
+    );
     assert!(CoreSnapshot::open_retained(
         &fixture.data_root,
         &authority,
@@ -200,6 +229,14 @@ fn symlinked_search_component_is_rejected() {
             &generation_id,
             &SnapshotContract::current().unwrap()
         ),
+        Err(SnapshotError::UnsafePath(_))
+    ));
+    assert!(matches!(
+        load_active_generation_id(&fixture.data_root),
+        Err(SnapshotError::UnsafePath(_))
+    ));
+    assert!(matches!(
+        load_snapshot_retention_lease(&fixture.data_root),
         Err(SnapshotError::UnsafePath(_))
     ));
 }
@@ -558,7 +595,7 @@ fn manifest_delta_and_replayable_exact_json_pages_use_neutral_bounded_state() {
     assert_eq!(changes.get(&removed.identity().digest()), Some(&"removed"));
 
     let first = target
-        .record_page(&replaced, None, 1, DEFAULT_CORE_EVENT_PAGE_BUDGET)
+        .record_page(&replaced, None, 1, DEFAULT_SNAPSHOT_PAGE_BUDGET)
         .unwrap();
     assert_eq!(first.items.len(), 1);
     assert!(!first.terminal);
@@ -593,10 +630,10 @@ fn manifest_delta_and_replayable_exact_json_pages_use_neutral_bounded_state() {
     assert_eq!(cursor.generation_id(), target_id);
     assert!(cursor.source().exact_descriptor_eq(&replaced));
     let second = target
-        .record_page(&replaced, Some(&cursor), 1, DEFAULT_CORE_EVENT_PAGE_BUDGET)
+        .record_page(&replaced, Some(&cursor), 1, DEFAULT_SNAPSHOT_PAGE_BUDGET)
         .unwrap();
     let replay = target
-        .record_page(&replaced, Some(&cursor), 1, DEFAULT_CORE_EVENT_PAGE_BUDGET)
+        .record_page(&replaced, Some(&cursor), 1, DEFAULT_SNAPSHOT_PAGE_BUDGET)
         .unwrap();
     assert_eq!(second, replay);
     for item in &second.items {
@@ -620,6 +657,111 @@ fn manifest_delta_and_replayable_exact_json_pages_use_neutral_bounded_state() {
     let mut expected = expected_replacement;
     expected.sort_by_key(|record| record.event_id.digest());
     assert_eq!(observed, expected);
+}
+
+#[test]
+fn exact_record_batch_preserves_full_identity_order_totals_and_strict_bounds() {
+    let fixture = Fixture::new();
+    let source = source("exact-batch");
+    let records = vec![
+        record(&source, 1, "first"),
+        record(&source, 2, "second body"),
+        record(&source, 3, "third body is longest"),
+    ];
+    let generation_id = publish(&fixture.index_root, 1, &[(source.clone(), records.clone())]);
+    let snapshot = open(&fixture, &generation_id);
+    let expected = vec![records[2].clone(), records[0].clone(), records[1].clone()];
+    let event_ids = expected
+        .iter()
+        .map(|record| record.event_id)
+        .collect::<Vec<_>>();
+    let encoded_core_bytes = expected
+        .iter()
+        .map(|record| record.encode_stored().unwrap().len())
+        .sum::<usize>();
+    let content_bytes = expected
+        .iter()
+        .map(|record| core_content_bytes(&record.content).unwrap())
+        .sum::<usize>();
+    let maximum_record_encoded_bytes = expected
+        .iter()
+        .map(|record| record.encode_stored().unwrap().len())
+        .max()
+        .unwrap();
+    let maximum_record_content_bytes = expected
+        .iter()
+        .map(|record| core_content_bytes(&record.content).unwrap())
+        .max()
+        .unwrap();
+    let aggregate_budget = SnapshotPageBudget::new(encoded_core_bytes, content_bytes);
+    let per_record_budget =
+        SnapshotPageBudget::new(maximum_record_encoded_bytes, maximum_record_content_bytes);
+
+    let batch = snapshot
+        .core_records_by_ids(&event_ids, aggregate_budget, per_record_budget)
+        .unwrap()
+        .unwrap();
+    assert_eq!(batch.records, expected);
+    assert_eq!(batch.encoded_core_bytes, encoded_core_bytes);
+    assert_eq!(batch.content_bytes, content_bytes);
+
+    assert!(snapshot
+        .core_records_by_ids(
+            &event_ids,
+            SnapshotPageBudget::new(encoded_core_bytes - 1, content_bytes),
+            per_record_budget,
+        )
+        .unwrap()
+        .is_none());
+    assert!(snapshot
+        .core_records_by_ids(
+            &event_ids,
+            aggregate_budget,
+            SnapshotPageBudget::new(
+                maximum_record_encoded_bytes - 1,
+                maximum_record_content_bytes,
+            ),
+        )
+        .unwrap()
+        .is_none());
+
+    let missing = record(&source, 99, "not published").event_id;
+    assert!(snapshot
+        .core_records_by_ids(
+            &[event_ids[0], missing],
+            aggregate_budget,
+            per_record_budget,
+        )
+        .unwrap()
+        .is_none());
+    assert!(matches!(
+        snapshot.core_records_by_ids(
+            &[event_ids[0], event_ids[0]],
+            aggregate_budget,
+            per_record_budget,
+        ),
+        Err(SnapshotError::Bounds(_))
+    ));
+    assert!(matches!(
+        snapshot.core_records_by_ids(
+            &[records[0].session_id],
+            aggregate_budget,
+            per_record_budget,
+        ),
+        Err(SnapshotError::Bounds(_))
+    ));
+    assert!(matches!(
+        snapshot.core_records_by_ids(
+            &vec![event_ids[0]; MAX_CORE_RECORD_BATCH_ITEMS + 1],
+            aggregate_budget,
+            per_record_budget,
+        ),
+        Err(SnapshotError::Bounds(_))
+    ));
+    assert!(matches!(
+        snapshot.core_records_by_ids(&event_ids, SnapshotPageBudget::new(0, 1), per_record_budget,),
+        Err(SnapshotError::Bounds(_))
+    ));
 }
 
 #[test]
@@ -659,7 +801,7 @@ fn schema_fingerprint_certification_and_bounds_fail_with_typed_errors_without_ha
         Err(SnapshotError::Bounds(_))
     ));
     assert!(matches!(
-        snapshot.record_page(&source, None, 0, DEFAULT_CORE_EVENT_PAGE_BUDGET),
+        snapshot.record_page(&source, None, 0, DEFAULT_SNAPSHOT_PAGE_BUDGET),
         Err(SnapshotError::Bounds(_))
     ));
     assert!(matches!(
@@ -667,12 +809,12 @@ fn schema_fingerprint_certification_and_bounds_fail_with_typed_errors_without_ha
             &source,
             None,
             MAX_SOURCE_EVENT_PAGE_ITEMS + 1,
-            DEFAULT_CORE_EVENT_PAGE_BUDGET
+            DEFAULT_SNAPSHOT_PAGE_BUDGET
         ),
         Err(SnapshotError::Bounds(_))
     ));
     assert!(matches!(
-        snapshot.record_page(&source, None, 1, CoreEventPageBudget::new(0, 1)),
+        snapshot.record_page(&source, None, 1, SnapshotPageBudget::new(0, 1)),
         Err(SnapshotError::Bounds(_))
     ));
     drop(snapshot);
@@ -840,4 +982,21 @@ fn current_contract_and_path_validation_are_explicit() {
         CoreSnapshot::open("relative", &"a".repeat(64), &contract),
         Err(SnapshotError::UnsafePath(_))
     ));
+}
+
+#[test]
+fn active_generation_lookup_uses_the_core_data_root_and_reports_absence() {
+    let fixture = Fixture::new();
+    assert_eq!(load_active_generation_id(&fixture.data_root).unwrap(), None);
+
+    let first = publish(&fixture.index_root, 1, &[]);
+    assert_eq!(
+        load_active_generation_id(&fixture.data_root).unwrap(),
+        Some(first)
+    );
+    let second = publish(&fixture.index_root, 2, &[]);
+    assert_eq!(
+        load_active_generation_id(&fixture.data_root).unwrap(),
+        Some(second)
+    );
 }


### PR DESCRIPTION
## Summary

- expose active-generation and durable-retention operations through the snapshot reader
- add a strictly bounded exact-record lookup using full stable identities
- expose canonical budget and lease types through reader-owned names
- preserve typed missing, conflict, unsafe-path, concurrent-change, and bounds behavior

## Validation

- `//crates/ctx-history-snapshot-reader:unit_tests`
- `//crates/ctx-history-index-generation:unit_tests`
- repository policy and Rust LOC checks
- `cargo fmt --all -- --check`
- `git diff --check`