### PR TITLE
fix(snapshot-reader): reopen retained predecessor

### DIFF
--- a/crates/ctx-history-index-generation/src/certification.rs
+++ b/crates/ctx-history-index-generation/src/certification.rs
@@ -304,14 +304,16 @@ pub fn verify_or_certify_physical_integrity(
 }
 
 /// Verifies one immutable generation from its existing publication-time
-/// certification without hashing artifact bodies or changing durable state.
+/// certification without changing durable state.
 ///
 /// The certification remains bound to the exact slot, manifest file, artifact
 /// path set, and exact native files after the active pointer moves on. Any
 /// metadata transition invalidates the inherited SHA authority because a
 /// later link/unlink can mask an intervening same-size, restored-mtime write.
-/// Missing, malformed, stale, or otherwise unsupported certification fails
-/// closed without hashing artifact bodies.
+/// Missing, malformed, or otherwise unsupported certification fails closed.
+/// A previous generation whose artifact metadata changed while its certified
+/// successor was published is checked against its full expected digest;
+/// all other stale certifications fail closed without hashing artifact bodies.
 pub fn verify_physical_integrity_read_only(
     root: &Path,
     slot: &GenerationSlot,
@@ -370,10 +372,49 @@ pub fn verify_physical_integrity_read_only(
             &retained_alias_directories,
         )?;
         if current != expected.artifact {
-            return Err(IndexError::ChecksumMismatch);
+            return verify_certified_previous_after_publication(
+                root,
+                slot,
+                index,
+                &generation_path,
+                &current_pointer,
+            );
         }
     }
     if load_current_pointer(root)? != current_pointer {
+        return Err(IndexError::ConcurrentGenerationChange);
+    }
+    Ok(())
+}
+
+fn verify_certified_previous_after_publication(
+    root: &Path,
+    slot: &GenerationSlot,
+    index: &tantivy::Index,
+    generation_path: &Path,
+    pointer: &ActiveGenerationPointer,
+) -> Result<()> {
+    if pointer.previous() != Some(slot) {
+        return Err(IndexError::ChecksumMismatch);
+    }
+    let active_index =
+        crate::open_slot_index(root, pointer.active()).map_err(|_| IndexError::ChecksumMismatch)?;
+    verify_physical_integrity_read_only(root, pointer.active(), &active_index).map_err(
+        |error| {
+            if matches!(error, IndexError::ConcurrentGenerationChange) {
+                error
+            } else {
+                IndexError::ChecksumMismatch
+            }
+        },
+    )?;
+    crate::verify_physical_integrity(
+        index,
+        generation_path,
+        Some(pointer),
+        slot.physical_integrity_digest(),
+    )?;
+    if load_current_pointer(root)? != *pointer {
         return Err(IndexError::ConcurrentGenerationChange);
     }
     Ok(())

--- a/crates/ctx-history-snapshot-reader/src/tests.rs
+++ b/crates/ctx-history-snapshot-reader/src/tests.rs
@@ -88,6 +88,34 @@ fn concurrent_publication_is_not_reported_as_corruption() {
 }
 
 #[test]
+fn retained_previous_generation_reopens_after_publication_metadata_changes() {
+    let fixture = Fixture::new();
+    let source = source("retained-previous");
+    let previous_record = record(&source, 1, "previous");
+    let previous_id = publish(
+        &fixture.index_root,
+        1,
+        &[(source.clone(), vec![previous_record.clone()])],
+    );
+    publish(
+        &fixture.index_root,
+        2,
+        &[(source.clone(), vec![record(&source, 1, "active")])],
+    );
+
+    let snapshot = CoreSnapshot::open(
+        &fixture.data_root,
+        &previous_id,
+        &SnapshotContract::current().unwrap(),
+    )
+    .unwrap();
+    let page = snapshot
+        .record_page(&source, None, 1, DEFAULT_SNAPSHOT_PAGE_BUDGET)
+        .unwrap();
+    assert_eq!(page.items[0].core_record, previous_record);
+}
+
+#[test]
 fn durable_exact_target_opens_after_more_than_two_publications() {
     let fixture = Fixture::new();
     let source = source("durable-retained");


### PR DESCRIPTION
## Summary
- allow the read-only snapshot boundary to verify the pointer-retained predecessor after legitimate publication hardlink metadata changes
- require the active successor certification before the bounded full-digest fallback
- preserve fail-closed behavior for missing, malformed, unretained, or tampered certifications
- add a regression test that reopens and reads the previous generation

## Validation
- `bazel test --config=ci //crates/ctx-history-snapshot-reader:unit_tests //crates/ctx-history-index-generation:unit_tests`
- `bazel test --config=ci //crates/ctx-history-index:unit_tests` (238 passed, one transient lock-busy failure; the failed test passed when rerun alone)
- `bash scripts/check-repository-policy.sh`
- `cargo fmt --all -- --check`
- `git diff --check`