### PR TITLE
fix(build): narrow history source label checks

### DIFF
--- a/crates/ctx-agent-application/BUILD.bazel
+++ b/crates/ctx-agent-application/BUILD.bazel
@@ -66,7 +66,6 @@ ctx_rust_test(
     aliases = aliases(normal_dev = True, proc_macro_dev = True),
     deps = all_crate_deps(normal = True, normal_dev = True) + CTX_AGENT_APPLICATION_DEPS + [
         "//crates/ctx-history-core:lib",
-        "//crates/ctx-history-index:lib",
     ],
     proc_macro_deps = all_crate_deps(proc_macro = True, proc_macro_dev = True),
     rustc_env = COMMON_RUSTC_ENV,

--- a/tools/bazel/check_rust_target_inventory.py
+++ b/tools/bazel/check_rust_target_inventory.py
@@ -15,15 +15,15 @@ from typing import Any
 
 DEPENDENCY_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")
 TARGET_KINDS = ("bin", "test", "example", "bench")
-VISIBILITY_RESTRICTED_LOCAL_DEPENDENCIES = {
-    "ctx-history-capture",
-    "ctx-history-index",
-    "ctx-history-index-format",
-    "ctx-history-index-generation",
-    "ctx-history-index-query",
-    "ctx-history-provider-native-jsonl",
-    "ctx-history-jsonl",
-    "ctx-history-source-sqlite",
+VISIBILITY_RESTRICTED_LOCAL_LABELS = {
+    "ctx-history-jsonl": {
+        "//crates/ctx-history-jsonl:lib",
+        "//crates/ctx-history-jsonl:test_support_lib",
+    },
+    "ctx-history-source-sqlite": {
+        "//crates/ctx-history-source-sqlite:lib",
+        "//crates/ctx-history-source-sqlite:test_support_lib",
+    },
 }
 
 
@@ -203,18 +203,13 @@ def cargo_targets(package_dir: Path, data: dict[str, Any]) -> dict[str, Path]:
 
 
 def package_bazel_modules(root: Path, package_dir: Path) -> list[ast.Module]:
-    files = [package_dir / "BUILD.bazel", *sorted(package_dir.glob("*.bzl"))]
-    if not files[0].is_file():
+    path = package_dir / "BUILD.bazel"
+    if not path.is_file():
         fail(f"Cargo package has no BUILD.bazel: {package_dir.relative_to(root)}")
-    modules: list[ast.Module] = []
-    for path in files:
-        if not path.is_file():
-            continue
-        try:
-            modules.append(ast.parse(path.read_text(encoding="utf-8"), path.as_posix()))
-        except (OSError, UnicodeError, SyntaxError) as error:
-            fail(f"cannot parse Bazel metadata {path.relative_to(root)}: {error}")
-    return modules
+    try:
+        return [ast.parse(path.read_text(encoding="utf-8"), path.as_posix())]
+    except (OSError, UnicodeError, SyntaxError) as error:
+        fail(f"cannot parse Bazel metadata {path.relative_to(root)}: {error}")
 
 
 def assignments(module: ast.Module) -> dict[str, ast.AST]:
@@ -613,13 +608,11 @@ def local_graph(
                 has_explicit_label = any(
                     label.startswith(package_label) for label in dependency_labels
                 )
-                if (
-                    target in VISIBILITY_RESTRICTED_LOCAL_DEPENDENCIES
-                    and not has_explicit_label
-                ):
+                protected_labels = VISIBILITY_RESTRICTED_LOCAL_LABELS.get(target)
+                if protected_labels and not protected_labels & dependency_labels:
                     fail(
                         f"{name} Bazel {cargo_target} must explicitly declare "
-                        "visibility-restricted "
+                        "the visibility-restricted library label for "
                         f"Cargo path dependency {target}"
                     )
                 if not has_explicit_label and required_flag not in dependency_flags:

--- a/tools/bazel/check_rust_target_inventory_test.py
+++ b/tools/bazel/check_rust_target_inventory_test.py
@@ -77,16 +77,7 @@ class RustTargetInventoryTest(unittest.TestCase):
         }
 
         packages: dict[str, tuple[Path, dict[str, object]]] = {"consumer": (consumer, consumer_data)}
-        for name in (
-            "ctx-history-capture",
-            "ctx-history-index",
-            "ctx-history-index-format",
-            "ctx-history-index-generation",
-            "ctx-history-index-query",
-            "ctx-history-provider-native-jsonl",
-            "ctx-history-jsonl",
-            "ctx-history-source-sqlite",
-        ):
+        for name in ("ctx-history-jsonl", "ctx-history-source-sqlite"):
             directory = root / "crates" / name
             directory.mkdir(parents=True)
             directory.joinpath("Cargo.toml").write_text(
@@ -96,54 +87,113 @@ class RustTargetInventoryTest(unittest.TestCase):
             packages[name] = (directory, {"package": {"name": name}})
         return root, packages
 
-    def test_workspace_inherited_renamed_local_edge_needs_an_explicit_bazel_label(self) -> None:
-        root, packages = self.local_edge_fixture(
-            dependency_definition="[dependencies]\nhistory_sqlite.workspace = true\n",
-            workspace_dependencies=(
-                "[workspace.dependencies]\n"
-                'history_sqlite = { package = "ctx-history-source-sqlite", path = "crates/ctx-history-source-sqlite" }\n'
-            ),
-        )
-        with self.assertRaisesRegex(InventoryError, "explicitly declare.*ctx-history-source-sqlite"):
-            local_graph(root, packages)
-
-    def test_local_edges_require_explicit_labels_in_every_dependency_table(self) -> None:
+    def test_source_family_edges_require_their_explicit_library_labels(self) -> None:
         cases = (
             (
-                "dev-dependencies",
-                "ctx-history-index",
+                "normal direct JSONL",
+                "ctx-history-jsonl",
+                "[dependencies]\n"
+                'ctx-history-jsonl = { path = "../crates/ctx-history-jsonl" }\n',
+                "",
+                "//crates/ctx-history-jsonl:lib",
+                {"ctx-history-jsonl"},
+            ),
+            (
+                "normal inherited renamed SQLite",
+                "ctx-history-source-sqlite",
+                "[dependencies]\nhistory_sqlite.workspace = true\n",
+                "[workspace.dependencies]\n"
+                'history_sqlite = { package = "ctx-history-source-sqlite", path = "crates/ctx-history-source-sqlite" }\n',
+                "//crates/ctx-history-source-sqlite:lib",
+                {"ctx-history-source-sqlite"},
+            ),
+            (
+                "dev direct SQLite",
+                "ctx-history-source-sqlite",
                 "[dev-dependencies]\n"
-                'ctx-history-index = { path = "../crates/ctx-history-index" }\n',
+                'ctx-history-source-sqlite = { path = "../crates/ctx-history-source-sqlite" }\n',
+                "",
+                "//crates/ctx-history-source-sqlite:test_support_lib",
+                set(),
             ),
             (
-                "build-dependencies",
-                "ctx-history-provider-native-jsonl",
+                "dev renamed JSONL",
+                "ctx-history-jsonl",
+                "[dev-dependencies]\n"
+                'history_jsonl = { package = "ctx-history-jsonl", path = "../crates/ctx-history-jsonl" }\n',
+                "",
+                "//crates/ctx-history-jsonl:test_support_lib",
+                set(),
+            ),
+            (
+                "build direct SQLite",
+                "ctx-history-source-sqlite",
                 "[build-dependencies]\n"
-                'ctx-history-provider-native-jsonl = { path = "../crates/ctx-history-provider-native-jsonl" }\n',
+                'ctx-history-source-sqlite = { path = "../crates/ctx-history-source-sqlite" }\n',
+                "",
+                "//crates/ctx-history-source-sqlite:lib",
+                {"ctx-history-source-sqlite"},
             ),
             (
-                "target-specific dependencies",
-                "ctx-history-index-query",
+                "build inherited renamed JSONL",
+                "ctx-history-jsonl",
+                "[build-dependencies]\nhistory_jsonl.workspace = true\n",
+                "[workspace.dependencies]\n"
+                'history_jsonl = { package = "ctx-history-jsonl", path = "crates/ctx-history-jsonl" }\n',
+                "//crates/ctx-history-jsonl:lib",
+                {"ctx-history-jsonl"},
+            ),
+            (
+                "target-specific direct JSONL",
+                "ctx-history-jsonl",
                 "[target.'cfg(unix)'.dependencies]\n"
-                'ctx-history-index-query = { path = "../crates/ctx-history-index-query" }\n',
+                'ctx-history-jsonl = { path = "../crates/ctx-history-jsonl" }\n',
+                "",
+                "//crates/ctx-history-jsonl:lib",
+                {"ctx-history-jsonl"},
+            ),
+            (
+                "target-specific inherited renamed SQLite",
+                "ctx-history-source-sqlite",
+                "[target.'cfg(unix)'.dependencies]\nhistory_sqlite.workspace = true\n",
+                "[workspace.dependencies]\n"
+                'history_sqlite = { package = "ctx-history-source-sqlite", path = "crates/ctx-history-source-sqlite" }\n',
+                "//crates/ctx-history-source-sqlite:lib",
+                {"ctx-history-source-sqlite"},
             ),
         )
-        for table, package, dependency_definition in cases:
-            with self.subTest(table=table, package=package):
+        for (
+            edge,
+            package,
+            dependency_definition,
+            workspace_dependencies,
+            label,
+            expected_graph,
+        ) in cases:
+            with self.subTest(edge=edge):
                 root, packages = self.local_edge_fixture(
                     dependency_definition=dependency_definition,
+                    workspace_dependencies=workspace_dependencies,
                 )
                 with self.assertRaisesRegex(InventoryError, f"explicitly declare.*{package}"):
                     local_graph(root, packages)
 
                 root, packages = self.local_edge_fixture(
                     dependency_definition=dependency_definition,
-                    labels=(f"//crates/{package}:lib",),
+                    workspace_dependencies=workspace_dependencies,
+                    labels=(label,),
                 )
-                self.assertEqual(
-                    local_graph(root, packages)["consumer"],
-                    set() if table == "dev-dependencies" else {package},
-                )
+                self.assertEqual(local_graph(root, packages)["consumer"], expected_graph)
+
+        root, packages = self.local_edge_fixture(
+            dependency_definition=(
+                "[dependencies]\n"
+                'ctx-history-jsonl = { path = "../crates/ctx-history-jsonl" }\n'
+            ),
+            labels=("//crates/ctx-history-jsonl:other",),
+        )
+        with self.assertRaisesRegex(InventoryError, "explicitly declare.*ctx-history-jsonl"):
+            local_graph(root, packages)
 
     def test_explicit_target_does_not_hide_implicit_targets(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

This is the final review correction following #881.

- Remove the spurious `ctx-history-index` unit-test edge.
- Limit explicit-label enforcement to `ctx-history-jsonl` and `ctx-history-source-sqlite`.
- Inspect package `BUILD.bazel` files only while retaining Cargo workspace, path, and rename resolution.

## Verification

- Exact pre-rebase commit `b95747c082ddcb9f676c037c63e4515de3911be4` (base `0b016e0fa534537d1a8943e98edea42e4172f77f`) passed the strict build and 219/219 tests; independent review returned SHIP with no findings.
- Clean equivalent rebases onto the advancing `main` produced current head `e3e862075942046aa2095987cb21cc23cbb75fd7` on base `541890a9c7dfc59d0530dd8962b73f848987bf05`; stable patch ID remained `2fbb0086071d4421de7e10a3f7f3ce4dfa485908`, and both `git range-diff` comparisons reported exact equivalence.
- Post-rebase repository policy and `git diff --check` pass.