### PR TITLE
fix: resolve inherited strict Clippy violations

### DIFF
--- a/crates/ctx-cli/src/mcp.rs
+++ b/crates/ctx-cli/src/mcp.rs
@@ -309,7 +309,7 @@ mod tests {
         assert_eq!(event["event_origin"], shown["event_origin"]);
         assert_eq!(event["text"], shown["text"]);
         assert_eq!(
-            render_tool_text_for_test(&page),
+            render_tool_text_for_test(page),
             format!(
                 "ctx query_events\nevents: {}\ngeneration_id: {}\nterminal: true\ntruncated: false\n",
                 page["events"].as_array().unwrap().len(),

--- a/crates/ctx-history-refresh/src/engine/tests.rs
+++ b/crates/ctx-history-refresh/src/engine/tests.rs
@@ -459,11 +459,11 @@ fn newer_exhaustive_marker_survives_post_publication_coverage_fence() {
             publish_pin_fixture_with_observations(
                 &execution,
                 false,
-                first_execution
-                    .then(|| {
-                        BTreeMap::from([(executor_route.clone(), executor_observation.clone())])
-                    })
-                    .unwrap_or_default(),
+                if first_execution {
+                    BTreeMap::from([(executor_route.clone(), executor_observation.clone())])
+                } else {
+                    BTreeMap::new()
+                },
             )
         });
     let coordinator = Arc::new(CoreRefreshEngine::with_executor_and_admitted_routes(
@@ -844,21 +844,20 @@ fn publish_selected_routes(
     .collect::<BTreeMap<_, _>>();
     let catalog_route_bindings =
         synthetic_catalog_route_bindings(execution.explicit_source_catalog, selected);
-    let zero_source_authority = retained_route
-        .is_none()
-        .then(|| {
-            route_results
-                .iter()
-                .filter(|result| result.outcome.is_success())
-                .map(|result| {
-                    (
-                        SourceRouteIdentity::from_sha256(result.route_identity.clone()).unwrap(),
-                        SourceBackedZeroSourceAuthorityKind::CompleteEmptyInventory,
-                    )
-                })
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
+    let zero_source_authority = if retained_route.is_none() {
+        route_results
+            .iter()
+            .filter(|result| result.outcome.is_success())
+            .map(|result| {
+                (
+                    SourceRouteIdentity::from_sha256(result.route_identity.clone()).unwrap(),
+                    SourceBackedZeroSourceAuthorityKind::CompleteEmptyInventory,
+                )
+            })
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
     let commit = commit_source_backed_test_generation_with_facts(
         writer,
         SourceBackedTestGenerationFacts {

--- a/crates/ctx-history-refresh/src/orchestration/catalog_witness.rs
+++ b/crates/ctx-history-refresh/src/orchestration/catalog_witness.rs
@@ -1,12 +1,14 @@
 use super::*;
 
-pub(super) fn retained_generation_state(
-    retained_generation: Option<&VerifiedIndex>,
-) -> Result<(
+pub(super) type RetainedGenerationState = (
     Option<ExplicitSourceCatalogAuthority>,
     Vec<ExplicitSourceCatalogRouteBinding>,
     BTreeMap<SourceRouteIdentity, Vec<u8>>,
-)> {
+);
+
+pub(super) fn retained_generation_state(
+    retained_generation: Option<&VerifiedIndex>,
+) -> Result<RetainedGenerationState> {
     let Some(generation) = retained_generation else {
         return Ok((None, Vec::new(), BTreeMap::new()));
     };

--- a/crates/ctx-history-refresh/src/publication.rs
+++ b/crates/ctx-history-refresh/src/publication.rs
@@ -77,7 +77,7 @@ pub(super) fn published_generation_id(
 pub(super) enum PublishedGenerationOpen {
     Missing,
     RebuildRequired,
-    Verified(VerifiedIndex),
+    Verified(Box<VerifiedIndex>),
 }
 
 pub(super) fn prepare_generation_control_state(data_root: &Path) -> Result<()> {
@@ -97,7 +97,7 @@ pub(super) fn open_published_generation(
     Ok(
         match open_published_generation_for_recovery(data_root, journal)? {
             PublishedGenerationOpen::Missing | PublishedGenerationOpen::RebuildRequired => None,
-            PublishedGenerationOpen::Verified(index) => Some(index),
+            PublishedGenerationOpen::Verified(index) => Some(*index),
         },
     )
 }
@@ -117,7 +117,7 @@ pub(super) fn open_published_generation_for_recovery(
         return Ok(PublishedGenerationOpen::Missing);
     }
     match open_verified_index(&index_root) {
-        Ok(index) => Ok(PublishedGenerationOpen::Verified(index)),
+        Ok(index) => Ok(PublishedGenerationOpen::Verified(Box::new(index))),
         Err(IndexError::MissingActiveGenerationPointer) => {
             if let Some(generation_id) = published_generation_receipt(data_root, journal)? {
                 bail!(


### PR DESCRIPTION
## Summary

- box only the large `VerifiedIndex` payload in `PublishedGenerationOpen`
- name the retained-generation-state return tuple with a local `RetainedGenerationState` alias
- replace two boolean-to-default test fixture expressions with direct `if`/`else`
- remove one redundant reference in the MCP query-events renderer test

The Box is moved back out at the remaining `open_published_generation` ownership boundary and adds one transient allocation only on verified generation opens. The type alias and test-expression rewrites change no representation, evaluation order, or behavior. After #894, this PR does not restore the removed recovery publication path.

## Validation

- `ctx-build-governor exec -- scripts/bazelw build //... --config=ci` (452 targets, 440 Clippy aspect applications, 3,204 actions)
- `scripts/bazelw test //crates/ctx-history-refresh:unit_tests --config=test --test_arg=newer_exhaustive_marker_survives_post_publication_coverage_fence --test_output=all` (1 passed)
- `scripts/bazelw test //crates/ctx-history-refresh:unit_tests --config=test --test_arg=publication_lifecycle --test_output=all` (28 passed)
- focused `rustfmt --check` on `crates/ctx-history-refresh/src/engine/tests.rs`
- `scripts/check-repository-policy.sh`
- `scripts/bazel-test.sh source_diff_check`

All commands ran under the host build governor and passed. The full test tier was not run.