### PR TITLE
refactor(refresh): canonicalize terminal outcomes

### DIFF
--- a/crates/ctx-cli/src/commands/import/core_refresh.rs
+++ b/crates/ctx-cli/src/commands/import/core_refresh.rs
@@ -84,7 +84,7 @@ fn import_terminal_core_success(status: &crate::semantic::RefreshStatus) -> Resu
     Ok(status
         .kind()?
         .terminal_outcome()
-        .is_some_and(|outcome| !outcome.code.is_failure()))
+        .is_some_and(|outcome| !outcome.code().is_failure()))
 }
 
 /// The import application turns this one Core terminal outcome into its
@@ -93,14 +93,14 @@ fn import_rerenders_terminal_missing_path(status: &crate::semantic::RefreshStatu
     Ok(status
         .kind()?
         .terminal_outcome()
-        .is_some_and(|outcome| outcome.code == RefreshOutcomeCode::ExplicitSourcePathMissing))
+        .is_some_and(|outcome| outcome.code() == RefreshOutcomeCode::ExplicitSourcePathMissing))
 }
 
 pub(super) fn is_terminal_missing_import_path(error: &anyhow::Error) -> bool {
     error
         .chain()
         .find_map(|cause| cause.downcast_ref::<crate::semantic::SourceBackedRefreshTerminalError>())
-        .map(|terminal| terminal.outcome().code)
+        .map(|terminal| terminal.outcome().code())
         == Some(RefreshOutcomeCode::ExplicitSourcePathMissing)
 }
 
@@ -111,21 +111,26 @@ mod tests {
     use super::*;
 
     fn terminal_status(code: &str, class: &str) -> crate::semantic::RefreshStatus {
+        let published = matches!(code, "completed" | "completed_with_rejections");
+        let request_state = if published { "published" } else { "failed" };
+        let published_generation = published.then_some("generation");
         let (retryable, retry_advice) = match code {
             "completed" | "completed_with_rejections" => (false, None),
             "explicit_source_path_missing" => (true, Some("inspect_sources")),
             "source_unavailable" => (true, Some("retry_affected_routes")),
             _ => panic!("unknown terminal status fixture `{code}`"),
         };
+        let detail = (code != "completed").then_some("content-bearing raw terminal detail");
         crate::semantic::RefreshStatus::parse_schema_v1(json!({
             "request_id": "logical-request",
-            "request_state": "failed",
+            "request_state": request_state,
             "logical_request_id": "logical-request",
             "logical_phase": "terminal",
             "physical_attempt_id": "physical-attempt",
-            "physical_attempt_state": "failed",
+            "physical_attempt_state": request_state,
             "progress_owner_request_id": "physical-attempt",
-            "progress_owner_attempt_state": "failed",
+            "progress_owner_attempt_state": request_state,
+            "published_generation": published_generation,
             "structured_outcome": {
                 "code": code,
                 "class": class,
@@ -134,16 +139,16 @@ mod tests {
                 "retryable_routes": [],
                 "blocked_routes": [],
                 "physical_attempt_id": "physical-attempt",
+                "published_generation": published_generation,
                 "retry_advice": retry_advice,
-                "detail": "content-bearing raw terminal detail"
+                "detail": detail
             },
             "progress": {
-                "phase": "failed",
+                "phase": request_state,
                 "completed_sources": 0,
                 "total_sources": 1,
                 "total_sources_known": true
-            },
-            "whole_run_stage": "failed"
+            }
         }))
         .unwrap()
     }

--- a/crates/ctx-cli/src/commands/import/entry.rs
+++ b/crates/ctx-cli/src/commands/import/entry.rs
@@ -110,8 +110,8 @@ fn record_terminal_import_failure(
     let outcome = terminal.outcome();
     provider_refreshes.record_terminal_core_failure(
         ProviderRefreshTrigger::Import,
-        Some(outcome.code),
-        outcome.retryable,
+        Some(outcome.code()),
+        outcome.retryable(),
     );
     true
 }
@@ -232,7 +232,7 @@ fn record_application_facts(
 mod tests {
     use std::collections::BTreeSet;
 
-    use ctx_history_refresh::{RefreshOutcomeClass, RefreshOutcomeCode, RefreshTerminalOutcome};
+    use ctx_history_refresh::{RefreshOutcomeCode, RefreshTerminalOutcome};
 
     use crate::analytics::{
         Outcome, ProviderCoreResult, ProviderRefreshFailureScope, ProviderRefreshFailureType,
@@ -241,24 +241,22 @@ mod tests {
 
     use super::*;
 
-    fn terminal_error(
-        code: RefreshOutcomeCode,
-        class: RefreshOutcomeClass,
-        retryable: bool,
-    ) -> anyhow::Error {
-        crate::semantic::SourceBackedRefreshTerminalError::from(RefreshTerminalOutcome {
-            code,
-            class,
-            retryable,
-            affected_routes: BTreeSet::new(),
-            retryable_routes: BTreeSet::new(),
-            blocked_routes: BTreeSet::new(),
-            physical_attempt_id: "physical-attempt".to_owned(),
-            retained_generation: None,
-            published_generation: None,
-            retry_advice: None,
-            detail: Some("content-bearing raw terminal detail".to_owned()),
-        })
+    fn terminal_error(code: RefreshOutcomeCode, retryable: bool) -> anyhow::Error {
+        crate::semantic::SourceBackedRefreshTerminalError::from(
+            RefreshTerminalOutcome::new(
+                code,
+                retryable,
+                BTreeSet::new(),
+                BTreeSet::new(),
+                BTreeSet::new(),
+                uuid::Uuid::nil().to_string(),
+                None,
+                None,
+                None,
+                Some("content-bearing raw terminal detail".to_owned()),
+            )
+            .unwrap(),
+        )
         .into()
     }
 
@@ -275,11 +273,7 @@ mod tests {
 
     #[test]
     fn explicit_import_terminal_failure_emits_one_cli_owned_bounded_event() {
-        let error = terminal_error(
-            RefreshOutcomeCode::MalformedSource,
-            RefreshOutcomeClass::Unreadable,
-            false,
-        );
+        let error = terminal_error(RefreshOutcomeCode::MalformedSource, false);
         let mut collector = ProviderRefreshCollector::default();
 
         assert!(record_terminal_import_failure(&mut collector, &error));
@@ -307,11 +301,7 @@ mod tests {
 
     #[test]
     fn automatic_import_terminal_failure_emits_one_retryable_unknown_source_event() {
-        let error = terminal_error(
-            RefreshOutcomeCode::SourceFailures,
-            RefreshOutcomeClass::Mixed,
-            true,
-        );
+        let error = terminal_error(RefreshOutcomeCode::SourceFailures, true);
         let mut collector = ProviderRefreshCollector::default();
 
         assert!(record_terminal_import_failure(&mut collector, &error));

--- a/crates/ctx-cli/src/core_capability/contract_tests.rs
+++ b/crates/ctx-cli/src/core_capability/contract_tests.rs
@@ -6,9 +6,7 @@ use super::hosted_pair_install::{
 use super::progress_events::{CapabilityEventSink, IgnoreEvents, ProtocolEventWriter};
 use super::*;
 use ctx_history_index::SourceRouteIdentity;
-use ctx_history_refresh::{
-    RefreshOutcomeClass, RefreshOutcomeCode, RefreshRetryAdvice, RefreshTerminalOutcome,
-};
+use ctx_history_refresh::{RefreshOutcomeCode, RefreshRetryAdvice, RefreshTerminalOutcome};
 
 #[cfg(test)]
 #[path = "contract_tests/failure_contract_tests.rs"]
@@ -554,86 +552,34 @@ fn setup_receipt_does_not_embed_unbounded_source_diagnostics() {
     assert!(canonical(&facts).unwrap().len() < MAX_RESPONSE_BYTES);
 }
 
-fn terminal_failure_with_blocked_routes(route_count: usize) -> RefreshTerminalOutcome {
-    let routes = (0..route_count)
-        .map(|index| SourceRouteIdentity::from_sha256(format!("{index:064x}")).unwrap())
-        .collect::<BTreeSet<_>>();
-    RefreshTerminalOutcome {
-        code: RefreshOutcomeCode::IndexCorruption,
-        class: RefreshOutcomeClass::Corruption,
-        retryable: false,
-        affected_routes: routes.clone(),
-        retryable_routes: BTreeSet::new(),
-        blocked_routes: routes,
-        physical_attempt_id: "00000000-0000-0000-0000-000000000123".to_owned(),
-        retained_generation: Some("cd".repeat(32)),
-        published_generation: None,
-        retry_advice: Some(RefreshRetryAdvice::RebuildIndex),
-        detail: Some("arbitrary source detail must not cross the boundary".to_owned()),
-    }
-}
-
-fn retryable_terminal_failure() -> RefreshTerminalOutcome {
-    let route = SourceRouteIdentity::from_sha256("ab".repeat(32)).unwrap();
-    RefreshTerminalOutcome {
-        code: RefreshOutcomeCode::SourceUnavailable,
-        class: RefreshOutcomeClass::Unavailable,
-        retryable: true,
-        affected_routes: BTreeSet::from([route.clone()]),
-        retryable_routes: BTreeSet::from([route]),
-        blocked_routes: BTreeSet::new(),
-        physical_attempt_id: "00000000-0000-0000-0000-000000000123".to_owned(),
-        retained_generation: Some("cd".repeat(32)),
-        published_generation: None,
-        retry_advice: Some(RefreshRetryAdvice::RetryAffectedRoutes),
-        detail: None,
-    }
-}
-
 fn source_unclaimed_terminal_failure(retryable: bool) -> RefreshTerminalOutcome {
     let blocked = SourceRouteIdentity::from_sha256("ab".repeat(32)).unwrap();
     let retryable_route = SourceRouteIdentity::from_sha256("cd".repeat(32)).unwrap();
-    RefreshTerminalOutcome {
-        code: RefreshOutcomeCode::SourceUnclaimed,
-        class: RefreshOutcomeClass::Coverage,
+    RefreshTerminalOutcome::new(
+        RefreshOutcomeCode::SourceUnclaimed,
         retryable,
-        affected_routes: if retryable {
+        if retryable {
             BTreeSet::from([blocked.clone(), retryable_route.clone()])
         } else {
             BTreeSet::from([blocked.clone()])
         },
-        retryable_routes: if retryable {
+        if retryable {
             BTreeSet::from([retryable_route])
         } else {
             BTreeSet::new()
         },
-        blocked_routes: BTreeSet::from([blocked]),
-        physical_attempt_id: "00000000-0000-0000-0000-000000000123".to_owned(),
-        retained_generation: Some("cd".repeat(32)),
-        published_generation: None,
-        retry_advice: Some(if retryable {
+        BTreeSet::from([blocked]),
+        "00000000-0000-0000-0000-000000000123".to_owned(),
+        Some("cd".repeat(32)),
+        None,
+        Some(if retryable {
             RefreshRetryAdvice::RetryRetryableRoutesAndInspectBlocked
         } else {
             RefreshRetryAdvice::InspectSources
         }),
-        detail: None,
-    }
-}
-
-fn mutated_terminal_failure(
-    mutate: impl FnOnce(&mut RefreshTerminalOutcome),
-) -> crate::semantic::SourceBackedRefreshTerminalError {
-    let mut outcome = terminal_failure_with_blocked_routes(1);
-    mutate(&mut outcome);
-    crate::semantic::SourceBackedRefreshTerminalError::from(outcome)
-}
-
-fn mutated_retryable_terminal_failure(
-    mutate: impl FnOnce(&mut RefreshTerminalOutcome),
-) -> crate::semantic::SourceBackedRefreshTerminalError {
-    let mut outcome = retryable_terminal_failure();
-    mutate(&mut outcome);
-    crate::semantic::SourceBackedRefreshTerminalError::from(outcome)
+        None,
+    )
+    .unwrap()
 }
 
 fn run_terminal_failure(
@@ -999,21 +945,22 @@ fn recognized_terminal_failure_writes_one_exact_frame_and_exits_nonzero() {
     let route = SourceRouteIdentity::from_sha256("ab".repeat(32)).unwrap();
     let physical_attempt_id = "01234567-89ab-cdef-0123-456789abcdef";
     let retained_generation = "cd".repeat(32);
-    let terminal: anyhow::Error =
-        crate::semantic::SourceBackedRefreshTerminalError::from(RefreshTerminalOutcome {
-            code: RefreshOutcomeCode::IndexCorruption,
-            class: RefreshOutcomeClass::Corruption,
-            retryable: false,
-            affected_routes: BTreeSet::from([route.clone()]),
-            retryable_routes: BTreeSet::new(),
-            blocked_routes: BTreeSet::from([route]),
-            physical_attempt_id: physical_attempt_id.to_owned(),
-            retained_generation: Some(retained_generation.clone()),
-            published_generation: None,
-            retry_advice: Some(RefreshRetryAdvice::RebuildIndex),
-            detail: Some("arbitrary source detail must not cross the boundary".to_owned()),
-        })
-        .into();
+    let terminal: anyhow::Error = crate::semantic::SourceBackedRefreshTerminalError::from(
+        RefreshTerminalOutcome::new(
+            RefreshOutcomeCode::IndexCorruption,
+            false,
+            BTreeSet::from([route.clone()]),
+            BTreeSet::new(),
+            BTreeSet::from([route]),
+            physical_attempt_id.to_owned(),
+            Some(retained_generation.clone()),
+            None,
+            Some(RefreshRetryAdvice::RebuildIndex),
+            Some("arbitrary source detail must not cross the boundary".to_owned()),
+        )
+        .unwrap(),
+    )
+    .into();
     let terminal = terminal.context("arbitrary internal context must not cross the boundary");
     let mut output = Vec::new();
 
@@ -1031,6 +978,40 @@ fn recognized_terminal_failure_writes_one_exact_frame_and_exits_nonzero() {
     assert!(!output.contains(&0x1b));
     let response: Value = serde_json::from_slice(output.strip_suffix(b"\n").unwrap()).unwrap();
     assert_eq!(canonical(&response).unwrap(), output[..output.len() - 1]);
+    assert_eq!(
+        response
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([
+            "details",
+            "error_code",
+            "ok",
+            "operation",
+            "protocol_version",
+            "retryable",
+            "schema_version",
+        ])
+    );
+    assert_eq!(
+        response["details"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([
+            "affected_routes",
+            "blocked_routes",
+            "class",
+            "physical_attempt_id",
+            "retained_generation",
+            "retry_advice",
+            "retryable_routes",
+        ])
+    );
     assert_eq!(response["error_code"], "index_corruption");
     assert_eq!(response["retryable"], false);
     assert_eq!(
@@ -1042,195 +1023,6 @@ fn recognized_terminal_failure_writes_one_exact_frame_and_exits_nonzero() {
         retained_generation
     );
     assert!(!String::from_utf8(output).unwrap().contains('\u{009b}'));
-}
-
-#[test]
-fn event_terminal_state_and_final_failure_are_ordered_and_typed_the_same() {
-    let root = tempfile::tempdir().unwrap();
-    let request = json!({
-        "data_root": root.path(),
-        "operation": "RefreshAndWait",
-        "options": {"progress": "events"},
-        "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
-        "schema_version": 1,
-    });
-    let mut input = canonical(&request).unwrap();
-    input.push(b'\n');
-    let route_text = "ab".repeat(32);
-    let retained = "cd".repeat(32);
-    let physical_attempt_id = "01234567-89ab-cdef-0123-456789abcdef";
-    let status = crate::semantic::RefreshStatus::parse_schema_v1(json!({
-        "request_id": "logical-request",
-        "request_state": "failed",
-        "logical_request_id": "logical-request",
-        "logical_phase": "terminal",
-        "physical_attempt_id": physical_attempt_id,
-        "physical_attempt_state": "failed",
-        "progress_owner_request_id": physical_attempt_id,
-        "progress_owner_attempt_state": "failed",
-        "progress": {
-            "phase": "failed",
-            "completed_sources": 0,
-            "total_sources": 1,
-            "total_sources_known": true,
-            "whole_run_stage": "failed"
-        },
-        "structured_outcome": {
-            "code": "index_corruption",
-            "class": "corruption",
-            "retryable": false,
-            "affected_routes": [route_text],
-            "retryable_routes": [],
-            "blocked_routes": [route_text],
-            "physical_attempt_id": physical_attempt_id,
-            "retained_generation": retained,
-            "published_generation": null,
-            "retry_advice": "rebuild_index"
-        }
-    }))
-    .unwrap();
-    let route = SourceRouteIdentity::from_sha256(route_text).unwrap();
-    let terminal: anyhow::Error =
-        crate::semantic::SourceBackedRefreshTerminalError::from(RefreshTerminalOutcome {
-            code: RefreshOutcomeCode::IndexCorruption,
-            class: RefreshOutcomeClass::Corruption,
-            retryable: false,
-            affected_routes: BTreeSet::from([route.clone()]),
-            retryable_routes: BTreeSet::new(),
-            blocked_routes: BTreeSet::from([route]),
-            physical_attempt_id: physical_attempt_id.to_owned(),
-            retained_generation: Some(retained),
-            published_generation: None,
-            retry_advice: Some(RefreshRetryAdvice::RebuildIndex),
-            detail: Some("private terminal detail".to_owned()),
-        })
-        .into();
-    let mut output = Vec::new();
-
-    let exit = capability_exit_code(run_with_protocol_io(
-        std::io::Cursor::new(input),
-        &mut output,
-        |_request, events| {
-            events.refresh(&status)?;
-            Err(terminal)
-        },
-    ));
-
-    assert_eq!(exit, ExitCode::FAILURE);
-    let frames = output
-        .split(|byte| *byte == b'\n')
-        .filter(|frame| !frame.is_empty())
-        .map(|frame| serde_json::from_slice::<Value>(frame).unwrap())
-        .collect::<Vec<_>>();
-    assert_eq!(frames.len(), 2);
-    assert_eq!(frames[0]["event"], "refresh");
-    assert_eq!(frames[0]["refresh"]["request_state"], "failed");
-    assert_eq!(frames[1]["ok"], false);
-    assert_eq!(
-        frames[0]["refresh"]["terminal_state"]["error_code"],
-        frames[1]["error_code"]
-    );
-    assert_eq!(
-        frames[0]["refresh"]["terminal_state"]["retryable"],
-        frames[1]["retryable"]
-    );
-    assert_eq!(
-        frames[0]["refresh"]["terminal_state"]["details"],
-        frames[1]["details"]
-    );
-    assert!(!String::from_utf8(output)
-        .unwrap()
-        .contains("private terminal detail"));
-}
-
-#[test]
-fn inconsistent_typed_failures_remain_silent_and_nonzero() {
-    let other = SourceRouteIdentity::from_sha256("11".repeat(32)).unwrap();
-    let cases = [
-        (
-            "code_class_mismatch",
-            mutated_terminal_failure(|outcome| {
-                outcome.class = RefreshOutcomeClass::Unavailable;
-            }),
-        ),
-        (
-            "code_retryability_mismatch",
-            mutated_terminal_failure(|outcome| {
-                outcome.affected_routes.clear();
-                outcome.blocked_routes.clear();
-                outcome.retryable = true;
-                outcome.retry_advice = None;
-            }),
-        ),
-        (
-            "retryable_not_affected",
-            mutated_retryable_terminal_failure(|outcome| {
-                outcome.retryable_routes = BTreeSet::from([other.clone()]);
-            }),
-        ),
-        (
-            "overlapping_dispositions",
-            mutated_retryable_terminal_failure(|outcome| {
-                outcome.blocked_routes = outcome.affected_routes.clone();
-            }),
-        ),
-        (
-            "undisposed_route",
-            mutated_terminal_failure(|outcome| {
-                outcome.affected_routes.insert(other.clone());
-            }),
-        ),
-        (
-            "route_retryability_mismatch",
-            mutated_terminal_failure(|outcome| {
-                outcome.code = RefreshOutcomeCode::SourceFailures;
-                outcome.class = RefreshOutcomeClass::Mixed;
-                outcome.retryable = true;
-                outcome.retry_advice = None;
-            }),
-        ),
-        (
-            "advice_retryability_mismatch",
-            mutated_terminal_failure(|outcome| {
-                outcome.retry_advice = Some(RefreshRetryAdvice::RetryRequest);
-            }),
-        ),
-        (
-            "known_but_wrong_advice",
-            mutated_terminal_failure(|outcome| {
-                outcome.retry_advice = Some(RefreshRetryAdvice::InspectSources);
-            }),
-        ),
-        ("source_unclaimed_without_advice", {
-            let mut outcome = source_unclaimed_terminal_failure(false);
-            outcome.retry_advice = None;
-            crate::semantic::SourceBackedRefreshTerminalError::from(outcome)
-        }),
-        ("source_unclaimed_without_blocked_culprit", {
-            let mut outcome = source_unclaimed_terminal_failure(true);
-            outcome.blocked_routes.clear();
-            outcome.affected_routes = outcome.retryable_routes.clone();
-            crate::semantic::SourceBackedRefreshTerminalError::from(outcome)
-        }),
-        (
-            "malformed_attempt_identity",
-            mutated_terminal_failure(|outcome| {
-                outcome.physical_attempt_id = "00000000-0000-0000-0000-00000000\n123".to_owned();
-            }),
-        ),
-        (
-            "malformed_generation_identity",
-            mutated_terminal_failure(|outcome| {
-                outcome.retained_generation = Some("AB".repeat(32));
-            }),
-        ),
-    ];
-
-    for (name, terminal) in cases {
-        let (status, output) = run_terminal_failure(terminal);
-        assert_eq!(status, ExitCode::FAILURE, "{name}");
-        assert!(output.is_empty(), "{name}: {output:?}");
-    }
 }
 
 #[test]

--- a/crates/ctx-cli/src/core_capability/contract_tests/failure_contract_tests.rs
+++ b/crates/ctx-cli/src/core_capability/contract_tests/failure_contract_tests.rs
@@ -37,18 +37,16 @@ fn source_unclaimed_failure_writes_the_singleton_and_mixed_contracts() {
 
 #[test]
 fn paused_failure_raw_wire_matches_progress_and_final_response() {
-    for (wire_code, code, wire_class, class) in [
+    for (wire_code, code, wire_class) in [
         (
             "source_refresh_failed",
             RefreshOutcomeCode::SourceRefreshFailed,
             "internal",
-            RefreshOutcomeClass::Internal,
         ),
         (
             "all_provider_terminal_coverage_unavailable",
             RefreshOutcomeCode::AllProviderTerminalCoverageUnavailable,
             "coverage",
-            RefreshOutcomeClass::Coverage,
         ),
     ] {
         let root = tempfile::tempdir().unwrap();
@@ -97,21 +95,22 @@ fn paused_failure_raw_wire_matches_progress_and_final_response() {
         }))
         .unwrap();
         let route = SourceRouteIdentity::from_sha256(route_text).unwrap();
-        let terminal: anyhow::Error =
-            crate::semantic::SourceBackedRefreshTerminalError::from(RefreshTerminalOutcome {
+        let terminal: anyhow::Error = crate::semantic::SourceBackedRefreshTerminalError::from(
+            RefreshTerminalOutcome::new(
                 code,
-                class,
-                retryable: false,
-                affected_routes: BTreeSet::from([route.clone()]),
-                retryable_routes: BTreeSet::new(),
-                blocked_routes: BTreeSet::from([route]),
-                physical_attempt_id: physical_attempt_id.to_owned(),
-                retained_generation: Some(retained),
-                published_generation: None,
-                retry_advice: Some(RefreshRetryAdvice::InspectSources),
-                detail: Some(private_detail.clone()),
-            })
-            .into();
+                false,
+                BTreeSet::from([route.clone()]),
+                BTreeSet::new(),
+                BTreeSet::from([route]),
+                physical_attempt_id.to_owned(),
+                Some(retained),
+                None,
+                Some(RefreshRetryAdvice::InspectSources),
+                Some(private_detail.clone()),
+            )
+            .unwrap(),
+        )
+        .into();
         let mut output = Vec::new();
 
         let exit = capability_exit_code(run_with_protocol_io(
@@ -143,37 +142,4 @@ fn paused_failure_raw_wire_matches_progress_and_final_response() {
         assert_eq!(frames[1]["retryable"], false);
         assert!(!String::from_utf8(output).unwrap().contains(&private_detail));
     }
-}
-
-#[test]
-fn maximum_valid_failure_frame_writes_and_route_cap_fails_closed() {
-    let (status, output) = run_terminal_failure(
-        terminal_failure_with_blocked_routes(failure::MAX_FAILURE_ROUTES).into(),
-    );
-    assert_eq!(status, ExitCode::FAILURE);
-    assert_eq!(output.last(), Some(&b'\n'));
-    assert_eq!(output.iter().filter(|byte| **byte == b'\n').count(), 1);
-    let frame = &output[..output.len() - 1];
-    assert!(frame.len() <= MAX_RESPONSE_BYTES);
-    let response: Value = serde_json::from_slice(frame).unwrap();
-    assert_eq!(
-        response["details"]["affected_routes"]
-            .as_array()
-            .unwrap()
-            .len(),
-        failure::MAX_FAILURE_ROUTES
-    );
-    assert_eq!(
-        response["details"]["blocked_routes"]
-            .as_array()
-            .unwrap()
-            .len(),
-        failure::MAX_FAILURE_ROUTES
-    );
-
-    let (status, output) = run_terminal_failure(
-        terminal_failure_with_blocked_routes(failure::MAX_FAILURE_ROUTES + 1).into(),
-    );
-    assert_eq!(status, ExitCode::FAILURE);
-    assert!(output.is_empty());
 }

--- a/crates/ctx-cli/src/core_capability/failure.rs
+++ b/crates/ctx-cli/src/core_capability/failure.rs
@@ -1,8 +1,4 @@
 use super::*;
-use ctx_history_index::SourceRouteIdentity;
-use ctx_history_refresh::{RefreshOutcomeCode, RefreshRetryAdvice};
-
-pub(super) const MAX_FAILURE_ROUTES: usize = 256;
 
 pub(super) fn produce_response(
     input: Vec<u8>,
@@ -25,97 +21,24 @@ pub(super) fn produce_response(
 }
 
 fn terminal_failure_response(operation: Operation, error: &anyhow::Error) -> Option<Value> {
-    use super::progress_events::neutral_dynamic_text;
+    use super::progress_events::terminal_details;
 
     let terminal = error.chain().find_map(|cause| {
         cause.downcast_ref::<crate::semantic::SourceBackedRefreshTerminalError>()
     })?;
-    if !valid_terminal_failure(terminal) {
+    let outcome = terminal.outcome();
+    if !outcome.code().is_failure() {
         return None;
     }
-    let outcome = terminal.outcome();
     // Keep arbitrary display/detail text behind the boundary. Only the
     // terminal type's validated structured fields enter the failure frame.
     Some(json!({
-        "details": {
-            "affected_routes": route_names(&outcome.affected_routes),
-            "blocked_routes": route_names(&outcome.blocked_routes),
-            "class": outcome.class.as_str(),
-            "physical_attempt_id": neutral_dynamic_text(&outcome.physical_attempt_id),
-            "retained_generation": outcome.retained_generation.as_deref().map(neutral_dynamic_text),
-            "retry_advice": outcome.retry_advice.map(RefreshRetryAdvice::as_str),
-            "retryable_routes": route_names(&outcome.retryable_routes),
-        },
-        "error_code": outcome.code.as_str(),
+        "details": terminal_details(outcome),
+        "error_code": outcome.code().as_str(),
         "ok": false,
         "operation": operation.name(),
         "protocol_version": CORE_PRO_PROTOCOL_VERSION.get(),
-        "retryable": outcome.retryable,
+        "retryable": outcome.retryable(),
         "schema_version": 1,
     }))
-}
-
-fn valid_terminal_failure(terminal: &crate::semantic::SourceBackedRefreshTerminalError) -> bool {
-    let outcome = terminal.outcome();
-    supported_failure_code(outcome.code)
-        && outcome.validate().is_ok()
-        && valid_route_set(&outcome.affected_routes)
-        && valid_route_set(&outcome.retryable_routes)
-        && valid_route_set(&outcome.blocked_routes)
-        && valid_physical_attempt_id(&outcome.physical_attempt_id)
-        && outcome
-            .retained_generation
-            .as_deref()
-            .is_none_or(valid_lower_hex)
-}
-
-const fn supported_failure_code(code: RefreshOutcomeCode) -> bool {
-    match code {
-        RefreshOutcomeCode::SourceUnavailable
-        | RefreshOutcomeCode::SourceChanged
-        | RefreshOutcomeCode::MalformedSource
-        | RefreshOutcomeCode::UnsupportedSchema
-        | RefreshOutcomeCode::SourceFailures
-        | RefreshOutcomeCode::LogicalSourceFailures
-        | RefreshOutcomeCode::SourceUnclaimed
-        | RefreshOutcomeCode::SourceRefreshFailed
-        | RefreshOutcomeCode::SourceRefreshInternal
-        | RefreshOutcomeCode::ResourceUnavailable
-        | RefreshOutcomeCode::IndexIncompatible
-        | RefreshOutcomeCode::IndexCorruption
-        | RefreshOutcomeCode::SourceRefreshAdmissionFailed
-        | RefreshOutcomeCode::AllProviderTerminalCoverageUnavailable => true,
-        RefreshOutcomeCode::Completed
-        | RefreshOutcomeCode::CompletedWithRejections
-        | RefreshOutcomeCode::CompletedWithSourceFailures
-        | RefreshOutcomeCode::CompletedWithRejectionsAndSourceFailures
-        | RefreshOutcomeCode::ExplicitSourcePathMissing => false,
-    }
-}
-
-fn valid_lower_hex(value: &str) -> bool {
-    value.len() == 64
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
-}
-
-fn valid_physical_attempt_id(value: &str) -> bool {
-    let bytes = value.as_bytes();
-    bytes.len() == 36
-        && bytes.iter().enumerate().all(|(index, byte)| match index {
-            8 | 13 | 18 | 23 => *byte == b'-',
-            _ => byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'),
-        })
-}
-
-fn valid_route_set(routes: &BTreeSet<SourceRouteIdentity>) -> bool {
-    routes.len() <= MAX_FAILURE_ROUTES && routes.iter().all(|route| valid_lower_hex(route.as_str()))
-}
-
-fn route_names(routes: &BTreeSet<SourceRouteIdentity>) -> Vec<&str> {
-    routes
-        .iter()
-        .map(SourceRouteIdentity::as_str)
-        .collect::<Vec<_>>()
 }

--- a/crates/ctx-cli/src/core_capability/progress_events.rs
+++ b/crates/ctx-cli/src/core_capability/progress_events.rs
@@ -133,7 +133,7 @@ fn refresh_event_frame(
     if let Some(request_id) = status.request_id() {
         refresh["request_id"] = json!(neutral_dynamic_text(request_id));
     }
-    append_typed_status(&mut refresh, &kind)?;
+    append_typed_status(&mut refresh, &kind);
     Ok(json!({
         "event": "refresh",
         "operation": operation.name(),
@@ -145,7 +145,7 @@ fn refresh_event_frame(
     }))
 }
 
-fn append_typed_status(refresh: &mut Value, kind: &RefreshStatusKind) -> Result<()> {
+fn append_typed_status(refresh: &mut Value, kind: &RefreshStatusKind) {
     match kind {
         RefreshStatusKind::Legacy { .. } => {}
         RefreshStatusKind::BackgroundMaintenanceWake(_) => {
@@ -163,31 +163,33 @@ fn append_typed_status(refresh: &mut Value, kind: &RefreshStatusKind) -> Result<
             refresh["progress_owner_attempt_state"] =
                 json!(request_state_name(logical.progress_owner_attempt_state));
             if let Some(outcome) = logical.structured_outcome.as_ref() {
-                refresh["terminal_state"] = terminal_state(outcome)?;
+                refresh["terminal_state"] = terminal_state(outcome);
             }
         }
     }
-    Ok(())
 }
 
-fn terminal_state(outcome: &RefreshTerminalOutcome) -> Result<Value> {
-    outcome.validate()?;
+fn terminal_state(outcome: &RefreshTerminalOutcome) -> Value {
+    json!({
+        "details": terminal_details(outcome),
+        "error_code": outcome.code().as_str(),
+        "retryable": outcome.retryable(),
+    })
+}
+
+pub(super) fn terminal_details(outcome: &RefreshTerminalOutcome) -> Value {
     let mut details = json!({
-        "affected_routes": outcome.affected_routes.iter().map(|route| route.as_str()).collect::<Vec<_>>(),
-        "blocked_routes": outcome.blocked_routes.iter().map(|route| route.as_str()).collect::<Vec<_>>(),
-        "class": outcome.class.as_str(),
-        "physical_attempt_id": neutral_dynamic_text(&outcome.physical_attempt_id),
-        "published_generation": outcome.published_generation.as_deref().map(neutral_dynamic_text),
-        "retained_generation": outcome.retained_generation.as_deref().map(neutral_dynamic_text),
-        "retry_advice": outcome.retry_advice.map(|advice| advice.as_str()),
-        "retryable_routes": outcome.retryable_routes.iter().map(|route| route.as_str()).collect::<Vec<_>>(),
+        "affected_routes": outcome.affected_routes().iter().map(|route| route.as_str()).collect::<Vec<_>>(),
+        "blocked_routes": outcome.blocked_routes().iter().map(|route| route.as_str()).collect::<Vec<_>>(),
+        "class": outcome.class().as_str(),
+        "physical_attempt_id": neutral_dynamic_text(outcome.physical_attempt_id()),
+        "published_generation": outcome.published_generation().map(neutral_dynamic_text),
+        "retained_generation": outcome.retained_generation().map(neutral_dynamic_text),
+        "retry_advice": outcome.retry_advice().map(|advice| advice.as_str()),
+        "retryable_routes": outcome.retryable_routes().iter().map(|route| route.as_str()).collect::<Vec<_>>(),
     });
     remove_null_fields(&mut details);
-    Ok(json!({
-        "details": details,
-        "error_code": outcome.code.as_str(),
-        "retryable": outcome.retryable,
-    }))
+    details
 }
 
 fn remove_null_fields(value: &mut Value) {

--- a/crates/ctx-daemon-cli/src/daemon_service_ports/provider_refresh.rs
+++ b/crates/ctx-daemon-cli/src/daemon_service_ports/provider_refresh.rs
@@ -101,11 +101,11 @@ fn failed_provider_refresh_event(
         return None;
     };
     let outcome = logical.structured_outcome?;
-    if !outcome.code.is_failure() {
+    if !outcome.code().is_failure() {
         return None;
     }
-    let retained_previous_generation = outcome.retained_generation.is_some();
-    let (failure_scope, failure_type) = terminal_failure(outcome.code);
+    let retained_previous_generation = outcome.retained_generation().is_some();
+    let (failure_scope, failure_type) = terminal_failure(outcome.code());
     let counts = provider
         .map(|_| ProviderRefreshCountsV1::sparse(None, progress_u64(job, "processed_bytes")));
     Some(PublicEventV1::ProviderRefreshCompleted(
@@ -121,9 +121,9 @@ fn failed_provider_refresh_event(
                 core_result: ProviderCoreResult::Failure,
                 failure_scope,
                 failure_type,
-                failure_code: terminal_failure_code(outcome.code),
-                retryable: outcome.retryable,
-                work_remaining: successor_pending || outcome.retryable,
+                failure_code: terminal_failure_code(outcome.code()),
+                retryable: outcome.retryable(),
+                work_remaining: successor_pending || outcome.retryable(),
                 counts,
             },
         )

--- a/crates/ctx-daemon-service/src/daemon_scheduler.rs
+++ b/crates/ctx-daemon-service/src/daemon_scheduler.rs
@@ -866,7 +866,7 @@ fn record_source_refresh_retry(
     let status = RefreshStatus::classify_schema_v1(&job)?;
     if status
         .terminal_outcome()
-        .and_then(|outcome| outcome.retry_advice)
+        .and_then(|outcome| outcome.retry_advice())
         == Some(RefreshRetryAdvice::RetryAdmission)
     {
         let request_id = job

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client/progress_poll_tests.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client/progress_poll_tests.rs
@@ -1,3 +1,7 @@
+//! Progress and publication-authority coverage for the refresh client.
+
+use std::collections::BTreeSet;
+
 use super::*;
 use ctx_history_core::{
     CertifiedSource, ScannedSourceCounts, SourceAnchor, SourceKey, SourceObservation,
@@ -81,6 +85,35 @@ fn typed_terminal_status() -> Value {
             "detail": "typed mixed route outcome",
         },
     })
+}
+
+fn set_terminal_state(response: &mut Value, state: &str) {
+    response["request_state"] = json!(state);
+    response["physical_attempt_state"] = json!(state);
+    response["progress_owner_attempt_state"] = json!(state);
+}
+
+fn typed_published_status() -> Value {
+    let generation = "c1".repeat(32);
+    let mut response = typed_terminal_status();
+    set_terminal_state(&mut response, "published");
+    response["published_generation"] = json!(generation);
+    response["structured_outcome"] = json!({
+        "code": "completed",
+        "class": "completed",
+        "retryable": false,
+        "affected_routes": [],
+        "retryable_routes": [],
+        "blocked_routes": [],
+        "physical_attempt_id": Uuid::from_u128(0x294_0101).to_string(),
+        "published_generation": generation,
+    });
+    response
+}
+
+fn assert_protocol_error(response: &Value, expected: &str) {
+    let error = source_refresh_protocol_status(response).unwrap_err();
+    assert_eq!(error.root_cause().to_string(), expected);
 }
 
 #[test]
@@ -289,28 +322,28 @@ fn structured_terminal_error_preserves_engine_route_dispositions() {
         .expect("typed terminal error");
     let outcome = terminal.outcome();
 
-    assert_eq!(outcome.code, RefreshOutcomeCode::SourceFailures);
-    assert_eq!(outcome.class, RefreshOutcomeClass::Mixed);
-    assert!(outcome.retryable);
-    assert_eq!(outcome.affected_routes.len(), 2);
+    assert_eq!(outcome.code(), RefreshOutcomeCode::SourceFailures);
+    assert_eq!(outcome.class(), RefreshOutcomeClass::Mixed);
+    assert!(outcome.retryable());
+    assert_eq!(outcome.affected_routes().len(), 2);
     assert_eq!(
-        outcome.retryable_routes,
-        BTreeSet::from([SourceRouteIdentity::from_sha256("a1".repeat(32)).unwrap()])
+        outcome.retryable_routes(),
+        &BTreeSet::from([SourceRouteIdentity::from_sha256("a1".repeat(32)).unwrap()])
     );
     assert_eq!(
-        outcome.blocked_routes,
-        BTreeSet::from([SourceRouteIdentity::from_sha256("a2".repeat(32)).unwrap()])
+        outcome.blocked_routes(),
+        &BTreeSet::from([SourceRouteIdentity::from_sha256("a2".repeat(32)).unwrap()])
     );
     assert_eq!(
-        outcome.physical_attempt_id,
+        outcome.physical_attempt_id(),
         Uuid::from_u128(0x294_0101).to_string()
     );
     assert_eq!(
-        outcome.retained_generation.as_deref(),
+        outcome.retained_generation(),
         Some("b1".repeat(32).as_str())
     );
     assert_eq!(
-        outcome.retry_advice,
+        outcome.retry_advice(),
         Some(RefreshRetryAdvice::RetryAffectedRoutes)
     );
     assert_eq!(
@@ -346,11 +379,14 @@ fn explicit_path_disappearance_code_survives_the_daemon_boundary() {
         .expect("typed terminal error");
     let outcome = terminal.outcome();
 
-    assert_eq!(outcome.code, RefreshOutcomeCode::ExplicitSourcePathMissing);
-    assert_eq!(outcome.class, RefreshOutcomeClass::Unavailable);
-    assert!(outcome.retryable);
     assert_eq!(
-        outcome.retry_advice,
+        outcome.code(),
+        RefreshOutcomeCode::ExplicitSourcePathMissing
+    );
+    assert_eq!(outcome.class(), RefreshOutcomeClass::Unavailable);
+    assert!(outcome.retryable());
+    assert_eq!(
+        outcome.retry_advice(),
         Some(RefreshRetryAdvice::InspectSources)
     );
 }
@@ -372,19 +408,19 @@ fn source_unclaimed_terminal_error_preserves_the_culprit_and_retryable_peer() {
         .expect("typed terminal error");
     let outcome = terminal.outcome();
 
-    assert_eq!(outcome.code, RefreshOutcomeCode::SourceUnclaimed);
-    assert_eq!(outcome.class, RefreshOutcomeClass::Coverage);
-    assert!(outcome.retryable);
+    assert_eq!(outcome.code(), RefreshOutcomeCode::SourceUnclaimed);
+    assert_eq!(outcome.class(), RefreshOutcomeClass::Coverage);
+    assert!(outcome.retryable());
     assert_eq!(
-        outcome.retryable_routes,
-        BTreeSet::from([SourceRouteIdentity::from_sha256("a1".repeat(32)).unwrap()])
+        outcome.retryable_routes(),
+        &BTreeSet::from([SourceRouteIdentity::from_sha256("a1".repeat(32)).unwrap()])
     );
     assert_eq!(
-        outcome.blocked_routes,
-        BTreeSet::from([SourceRouteIdentity::from_sha256("a2".repeat(32)).unwrap()])
+        outcome.blocked_routes(),
+        &BTreeSet::from([SourceRouteIdentity::from_sha256("a2".repeat(32)).unwrap()])
     );
     assert_eq!(
-        outcome.retry_advice,
+        outcome.retry_advice(),
         Some(RefreshRetryAdvice::RetryRetryableRoutesAndInspectBlocked)
     );
 }
@@ -407,6 +443,22 @@ fn present_structured_fields_are_strictly_validated() {
     )
     .contains("inconsistent route dispositions"));
 
+    let mut wrong_class = typed_terminal_status();
+    wrong_class["structured_outcome"]["class"] = json!("internal");
+    assert!(format!(
+        "{:#}",
+        source_refresh_protocol_status(&wrong_class).unwrap_err()
+    )
+    .contains("inconsistent code and class"));
+
+    let mut failed_with_publication = typed_terminal_status();
+    failed_with_publication["structured_outcome"]["published_generation"] = json!("c1".repeat(32));
+    assert!(format!(
+        "{:#}",
+        source_refresh_protocol_status(&failed_with_publication).unwrap_err()
+    )
+    .contains("failed source refresh outcome has a published generation"));
+
     let mut partial = typed_terminal_status();
     partial.as_object_mut().unwrap().remove("logical_phase");
     assert!(format!(
@@ -414,6 +466,34 @@ fn present_structured_fields_are_strictly_validated() {
         source_refresh_protocol_status(&partial).unwrap_err()
     )
     .contains("partial typed logical status"));
+}
+
+#[test]
+fn published_status_rejects_a_failure_outcome() {
+    let mut response = typed_terminal_status();
+    set_terminal_state(&mut response, "published");
+    response["published_generation"] = json!("c1".repeat(32));
+
+    assert_protocol_error(&response, "published source refresh has a failure outcome");
+}
+
+#[test]
+fn failed_status_rejects_a_nonfailure_outcome() {
+    let mut response = typed_published_status();
+    set_terminal_state(&mut response, "failed");
+
+    assert_protocol_error(&response, "failed source refresh has a nonfailure outcome");
+}
+
+#[test]
+fn published_status_requires_matching_outer_and_outcome_generations() {
+    let mut response = typed_published_status();
+    response["published_generation"] = json!("d1".repeat(32));
+
+    assert_protocol_error(
+        &response,
+        "published source refresh generation disagrees with its outcome",
+    );
 }
 
 #[test]

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client/types.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client/types.rs
@@ -69,27 +69,27 @@ impl fmt::Display for SourceBackedRefreshTerminalError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let outcome = self.outcome();
         let affected_routes = outcome
-            .affected_routes
+            .affected_routes()
             .iter()
             .map(|route| route.as_str())
             .collect::<Vec<_>>();
         let retryable_routes = outcome
-            .retryable_routes
+            .retryable_routes()
             .iter()
             .map(|route| route.as_str())
             .collect::<Vec<_>>();
         let blocked_routes = outcome
-            .blocked_routes
+            .blocked_routes()
             .iter()
             .map(|route| route.as_str())
             .collect::<Vec<_>>();
         write!(
             formatter,
             "daemon-owned source-backed refresh failed (code={}, class={}, retryable={}, attempt={}",
-            outcome.code.as_str(),
-            outcome.class.as_str(),
-            outcome.retryable,
-            outcome.physical_attempt_id
+            outcome.code().as_str(),
+            outcome.class().as_str(),
+            outcome.retryable(),
+            outcome.physical_attempt_id()
         )?;
         write!(
             formatter,
@@ -99,10 +99,10 @@ impl fmt::Display for SourceBackedRefreshTerminalError {
         write!(
             formatter,
             ", retained_generation={:?}, retry_advice={:?})",
-            outcome.retained_generation,
-            outcome.retry_advice.map(|advice| advice.as_str())
+            outcome.retained_generation(),
+            outcome.retry_advice().map(|advice| advice.as_str())
         )?;
-        if let Some(detail) = outcome.detail.as_deref() {
+        if let Some(detail) = outcome.detail() {
             write!(formatter, ": {detail}")?;
         }
         Ok(())
@@ -119,18 +119,18 @@ impl std::error::Error for SourceBackedRefreshTerminalError {
 
 impl From<RefreshTerminalOutcome> for SourceBackedRefreshTerminalError {
     fn from(outcome: RefreshTerminalOutcome) -> Self {
-        let capture_error = match outcome.class {
+        let capture_error = match outcome.class() {
             RefreshOutcomeClass::Incompatible => Some(CaptureError::UnsupportedSchema(
                 outcome
-                    .detail
-                    .clone()
-                    .unwrap_or_else(|| outcome.code.as_str().to_owned()),
+                    .detail()
+                    .map(str::to_owned)
+                    .unwrap_or_else(|| outcome.code().as_str().to_owned()),
             )),
             RefreshOutcomeClass::Unreadable => Some(CaptureError::InvalidPayload(
                 outcome
-                    .detail
-                    .clone()
-                    .unwrap_or_else(|| outcome.code.as_str().to_owned()),
+                    .detail()
+                    .map(str::to_owned)
+                    .unwrap_or_else(|| outcome.code().as_str().to_owned()),
             )),
             _ => None,
         };

--- a/crates/ctx-history-cli/src/progress.rs
+++ b/crates/ctx-history-cli/src/progress.rs
@@ -11,7 +11,8 @@ use ctx_history_refresh::{
 use ctx_terminal::{
     RefreshCurrentSourceProgress, RefreshCurrentSourceProgressStage, RefreshLogicalPhase,
     RefreshLogicalStatus, RefreshProgress, RefreshProgressSnapshot, RefreshRequestState,
-    RefreshStatusKind, RefreshStructuredOutcome, RefreshWholeRunStage, Ui,
+    RefreshStatusKind, RefreshStructuredOutcome, RefreshTerminalPresentation, RefreshWholeRunStage,
+    Ui,
 };
 
 pub use ctx_terminal::{format_bytes, format_count, ProgressWriterError};
@@ -136,33 +137,41 @@ pub fn presentation_snapshot(status: &RefreshStatus) -> anyhow::Result<RefreshPr
                 logical.progress_owner_attempt_state,
             ),
             structured_outcome: logical.structured_outcome.map(|outcome| {
+                let presentation = match outcome.code() {
+                    code if code.is_failure() => RefreshTerminalPresentation::Failed,
+                    ctx_history_refresh::RefreshOutcomeCode::Completed
+                    | ctx_history_refresh::RefreshOutcomeCode::CompletedWithRejections => {
+                        RefreshTerminalPresentation::Complete
+                    }
+                    _ => RefreshTerminalPresentation::CompleteWithIssues,
+                };
                 Box::new(RefreshStructuredOutcome {
-                    code: outcome.code.as_str().to_owned(),
-                    class: outcome.class.as_str().to_owned(),
-                    retryable: outcome.retryable,
+                    code: outcome.code().as_str().to_owned(),
+                    class: outcome.class().as_str().to_owned(),
+                    retryable: outcome.retryable(),
                     affected_routes: outcome
-                        .affected_routes
+                        .affected_routes()
                         .iter()
                         .map(|route| route.as_str().to_owned())
                         .collect(),
                     retryable_routes: outcome
-                        .retryable_routes
+                        .retryable_routes()
                         .iter()
                         .map(|route| route.as_str().to_owned())
                         .collect(),
                     blocked_routes: outcome
-                        .blocked_routes
+                        .blocked_routes()
                         .iter()
                         .map(|route| route.as_str().to_owned())
                         .collect(),
-                    physical_attempt_id: outcome.physical_attempt_id,
-                    retained_generation: outcome.retained_generation,
-                    published_generation: outcome.published_generation,
+                    physical_attempt_id: outcome.physical_attempt_id().to_owned(),
+                    retained_generation: outcome.retained_generation().map(str::to_owned),
+                    published_generation: outcome.published_generation().map(str::to_owned),
                     retry_advice: outcome
-                        .retry_advice
+                        .retry_advice()
                         .map(|advice| advice.as_str().to_owned()),
-                    detail: outcome.detail,
-                    failure: outcome.code.is_failure(),
+                    detail: outcome.detail().map(str::to_owned),
+                    presentation,
                 })
             }),
         }),

--- a/crates/ctx-history-refresh/src/engine.rs
+++ b/crates/ctx-history-refresh/src/engine.rs
@@ -40,7 +40,7 @@ use progress_model::{status_progress_total_sources_known, SourceBackedRefreshSta
 pub use progress_model::{SourceBackedRefreshProgress, SourceBackedRefreshStage};
 use read_model::{
     projected_job_json, projected_status_json, SourceBackedAutomaticRetryCheckpoint,
-    SourceBackedRefreshAttempt, SourceBackedRefreshFailureOutcome,
+    SourceBackedRefreshAttempt,
 };
 use runtime_metadata::{canonical_daemon_mode, SourceRefreshRuntimeMetadata};
 pub use runtime_metadata::{RefreshRuntime, RefreshRuntimeMetadata};

--- a/crates/ctx-history-refresh/src/engine/admission.rs
+++ b/crates/ctx-history-refresh/src/engine/admission.rs
@@ -1,9 +1,7 @@
 use super::*;
 use sha2::{Digest as _, Sha256};
-
 mod state_helpers;
 use state_helpers::*;
-
 #[derive(Clone)]
 struct PendingAdmissionClaim {
     request_id: String,
@@ -12,13 +10,11 @@ struct PendingAdmissionClaim {
     watch_catalog_revision: u64,
     route_event_watermarks: BTreeMap<SourceRouteIdentity, EventWatermark>,
 }
-
 pub(super) struct AdmissionObservationFence {
     watch_catalog_revision: u64,
     route_event_watermarks: BTreeMap<SourceRouteIdentity, Option<EventWatermark>>,
     route_observations: BTreeMap<SourceRouteIdentity, String>,
 }
-
 impl AdmissionObservationFence {
     pub(super) fn still_matches(&self, state: &CoreRefreshEngineState) -> bool {
         self.watch_catalog_revision == state.watch_catalog_revision
@@ -882,26 +878,38 @@ impl CoreRefreshEngine {
                 SourceBackedRefreshScope::Exact(routes) => Some(routes.clone()),
             })
             .unwrap_or_default();
-        let failure_type = source_backed_refresh_failure_type(&error);
-        let classified_outcome = source_backed_refresh_failure_outcome(&error, &attempted_routes);
-        let failure_outcome = if classified_outcome.code == RefreshOutcomeCode::SourceRefreshFailed
-            && classified_outcome.class == RefreshOutcomeClass::Internal
-        {
-            SourceBackedRefreshFailureOutcome::new(
-                RefreshOutcomeCode::SourceRefreshAdmissionFailed,
-                RefreshOutcomeClass::ControlPlane,
-                true,
-                BTreeSet::new(),
-                Some(RefreshRetryAdvice::RetryAdmission),
-            )
-        } else {
-            classified_outcome
-        };
-        let retry_admission = failure_outcome.code
+        let classified_outcome =
+            source_backed_refresh_failure_outcome(&error, &attempted_routes, request_id)?;
+        let failure_outcome =
+            if classified_outcome.code() == RefreshOutcomeCode::SourceRefreshFailed {
+                RefreshTerminalOutcome::with_uniform_route_disposition(
+                    RefreshOutcomeCode::SourceRefreshAdmissionFailed,
+                    true,
+                    BTreeSet::new(),
+                    request_id.to_owned(),
+                    None,
+                    None,
+                    Some(RefreshRetryAdvice::RetryAdmission),
+                    None,
+                )?
+            } else {
+                classified_outcome
+            };
+        let retained_generation = find_attempt(state, request_id).and_then(|attempt| {
+            attempt
+                .published_generation
+                .clone()
+                .or_else(|| attempt.previous_generation.clone())
+        });
+        let failure_outcome = failure_outcome.with_failure_context(
+            retained_generation,
+            Some(format!("source refresh admission fence failed: {error:#}")),
+        )?;
+        let retry_admission = failure_outcome.code()
             == RefreshOutcomeCode::SourceRefreshAdmissionFailed
-            && failure_outcome.retry_advice == Some(RefreshRetryAdvice::RetryAdmission);
-        let retryable_routes = failure_outcome.retryable_routes.clone();
-        let blocked_routes = failure_outcome.blocked_routes.clone();
+            && failure_outcome.retry_advice() == Some(RefreshRetryAdvice::RetryAdmission);
+        let retryable_routes = failure_outcome.retryable_routes().clone();
+        let blocked_routes = failure_outcome.blocked_routes().clone();
         let (scope, last_error) = {
             let attempt = find_attempt_mut(state, request_id)
                 .ok_or_else(|| anyhow!("source refresh request `{request_id}` is unknown"))?;
@@ -909,8 +917,8 @@ impl CoreRefreshEngine {
             attempt.state = SourceBackedRefreshState::Failed;
             attempt.finished_at_ms = Some(utc_now().timestamp_millis());
             attempt.progress.phase = "failed".to_owned();
-            attempt.failure_type = failure_type;
-            attempt.failure_outcome = Some(failure_outcome);
+            attempt.failure_type = source_backed_refresh_failure_type(&error);
+            attempt.terminal_outcome = Some(failure_outcome);
             attempt.last_error = Some(last_error.clone());
             (attempt.refresh_scope.clone(), last_error)
         };

--- a/crates/ctx-history-refresh/src/engine/attempt_helpers.rs
+++ b/crates/ctx-history-refresh/src/engine/attempt_helpers.rs
@@ -89,17 +89,21 @@ pub(super) fn source_backed_refresh_error_summary(error: &anyhow::Error) -> Stri
 pub(super) fn source_backed_refresh_failure_outcome(
     error: &anyhow::Error,
     attempted_routes: &BTreeSet<SourceRouteIdentity>,
-) -> SourceBackedRefreshFailureOutcome {
+    physical_attempt_id: &str,
+) -> Result<RefreshTerminalOutcome> {
     if error
         .chain()
         .any(|cause| cause.downcast_ref::<ExplicitSourcePathMissing>().is_some())
     {
-        return SourceBackedRefreshFailureOutcome::new(
+        return RefreshTerminalOutcome::with_uniform_route_disposition(
             RefreshOutcomeCode::ExplicitSourcePathMissing,
-            RefreshOutcomeClass::Unavailable,
             true,
             attempted_routes.clone(),
+            physical_attempt_id.to_owned(),
+            None,
+            None,
             Some(RefreshRetryAdvice::InspectSources),
+            None,
         );
     }
     if let Some(registration_failures) = error
@@ -115,12 +119,15 @@ pub(super) fn source_backed_refresh_failure_outcome(
             .iter()
             .any(|failure| failure.kind() == SourceBackedRouteErrorKind::Internal)
         {
-            return SourceBackedRefreshFailureOutcome::new(
+            return RefreshTerminalOutcome::with_uniform_route_disposition(
                 RefreshOutcomeCode::SourceRefreshFailed,
-                RefreshOutcomeClass::Internal,
                 true,
                 affected_routes,
+                physical_attempt_id.to_owned(),
+                None,
+                None,
                 Some(RefreshRetryAdvice::RetryRequest),
+                None,
             );
         }
         let (retryable_routes, blocked_routes): (BTreeSet<_>, BTreeSet<_>) = failures
@@ -142,37 +149,19 @@ pub(super) fn source_backed_refresh_failure_outcome(
             .any(|failure| failure.kind() == SourceBackedRouteErrorKind::ResourceUnavailable);
         let first_kind = failures[0].kind();
         let homogeneous = failures.iter().all(|failure| failure.kind() == first_kind);
-        let (code, class) = if resource_unavailable {
-            (
-                RefreshOutcomeCode::ResourceUnavailable,
-                RefreshOutcomeClass::ResourceUnavailable,
-            )
+        let code = if resource_unavailable {
+            RefreshOutcomeCode::ResourceUnavailable
         } else if homogeneous {
             match first_kind {
-                SourceBackedRouteErrorKind::Unavailable => (
-                    RefreshOutcomeCode::SourceUnavailable,
-                    RefreshOutcomeClass::Unavailable,
-                ),
-                SourceBackedRouteErrorKind::SourceChanged => (
-                    RefreshOutcomeCode::SourceChanged,
-                    RefreshOutcomeClass::SourceChanged,
-                ),
-                SourceBackedRouteErrorKind::InvalidSource => (
-                    RefreshOutcomeCode::MalformedSource,
-                    RefreshOutcomeClass::Unreadable,
-                ),
-                SourceBackedRouteErrorKind::Unsupported => (
-                    RefreshOutcomeCode::UnsupportedSchema,
-                    RefreshOutcomeClass::Incompatible,
-                ),
+                SourceBackedRouteErrorKind::Unavailable => RefreshOutcomeCode::SourceUnavailable,
+                SourceBackedRouteErrorKind::SourceChanged => RefreshOutcomeCode::SourceChanged,
+                SourceBackedRouteErrorKind::InvalidSource => RefreshOutcomeCode::MalformedSource,
+                SourceBackedRouteErrorKind::Unsupported => RefreshOutcomeCode::UnsupportedSchema,
                 SourceBackedRouteErrorKind::ResourceUnavailable
                 | SourceBackedRouteErrorKind::Internal => unreachable!(),
             }
         } else {
-            (
-                RefreshOutcomeCode::SourceFailures,
-                RefreshOutcomeClass::Mixed,
-            )
+            RefreshOutcomeCode::SourceFailures
         };
         let retryable = !retryable_routes.is_empty();
         let retry_advice = if retryable {
@@ -182,13 +171,16 @@ pub(super) fn source_backed_refresh_failure_outcome(
         } else {
             RefreshRetryAdvice::InspectSources
         };
-        return SourceBackedRefreshFailureOutcome::with_route_dispositions(
+        return RefreshTerminalOutcome::with_route_dispositions(
             code,
-            class,
             retryable,
             retryable_routes,
             blocked_routes,
+            physical_attempt_id.to_owned(),
+            None,
+            None,
             Some(retry_advice),
+            None,
         );
     }
     if error.chain().any(|cause| {
@@ -196,12 +188,15 @@ pub(super) fn source_backed_refresh_failure_outcome(
             .downcast_ref::<ZeroSourcePublicationBlocked>()
             .is_some()
     }) {
-        return SourceBackedRefreshFailureOutcome::new(
+        return RefreshTerminalOutcome::with_uniform_route_disposition(
             RefreshOutcomeCode::AllProviderTerminalCoverageUnavailable,
-            RefreshOutcomeClass::Coverage,
             true,
             attempted_routes.clone(),
+            physical_attempt_id.to_owned(),
+            None,
+            None,
             Some(RefreshRetryAdvice::RetryRequest),
+            None,
         );
     }
     if let Some(failed_routes) = error.chain().find_map(|cause| {
@@ -221,27 +216,9 @@ pub(super) fn source_backed_refresh_failure_outcome(
         .into_iter()
         .filter(|class| failed_routes.class_total(*class) != 0)
         .collect::<Vec<_>>();
-        let (code, class) = match classes.as_slice() {
-            [SourceBackedSourceFailureClass::Unavailable] => (
-                RefreshOutcomeCode::SourceUnavailable,
-                RefreshOutcomeClass::Unavailable,
-            ),
-            [SourceBackedSourceFailureClass::SourceChanged] => (
-                RefreshOutcomeCode::SourceChanged,
-                RefreshOutcomeClass::SourceChanged,
-            ),
-            [SourceBackedSourceFailureClass::Unreadable] => (
-                RefreshOutcomeCode::MalformedSource,
-                RefreshOutcomeClass::Unreadable,
-            ),
-            [SourceBackedSourceFailureClass::Incompatible] => (
-                RefreshOutcomeCode::UnsupportedSchema,
-                RefreshOutcomeClass::Incompatible,
-            ),
-            _ => (
-                RefreshOutcomeCode::SourceFailures,
-                RefreshOutcomeClass::Mixed,
-            ),
+        let code = match classes.as_slice() {
+            [class] => source_failure_code(*class),
+            _ => RefreshOutcomeCode::SourceFailures,
         };
         let retryable = classes.iter().any(|class| {
             matches!(
@@ -262,17 +239,20 @@ pub(super) fn source_backed_refresh_failure_outcome(
         });
         let (retryable_routes, blocked_routes) =
             authoritative_route_dispositions(attempted_routes, known, retryable);
-        return SourceBackedRefreshFailureOutcome::with_route_dispositions(
+        return RefreshTerminalOutcome::with_route_dispositions(
             code,
-            class,
             retryable,
             retryable_routes,
             blocked_routes,
+            physical_attempt_id.to_owned(),
+            None,
+            None,
             Some(if retryable {
                 RefreshRetryAdvice::RetryAffectedRoutes
             } else {
                 RefreshRetryAdvice::InspectSources
             }),
+            None,
         );
     }
 
@@ -307,13 +287,10 @@ pub(super) fn source_backed_refresh_failure_outcome(
                         | SourceBackedSourceFailureClass::SourceChanged
                 )
             });
-        let (code, class) = if diagnostics_complete && retained_classes.len() == 1 {
-            source_failure_code_and_class(retained_classes[0])
+        let code = if diagnostics_complete && retained_classes.len() == 1 {
+            source_failure_code(retained_classes[0])
         } else {
-            (
-                RefreshOutcomeCode::LogicalSourceFailures,
-                RefreshOutcomeClass::Mixed,
-            )
+            RefreshOutcomeCode::LogicalSourceFailures
         };
         let known = failed_sources.failures().iter().map(|failure| {
             (
@@ -327,17 +304,20 @@ pub(super) fn source_backed_refresh_failure_outcome(
         });
         let (retryable_routes, blocked_routes) =
             authoritative_route_dispositions(attempted_routes, known, retryable);
-        return SourceBackedRefreshFailureOutcome::with_route_dispositions(
+        return RefreshTerminalOutcome::with_route_dispositions(
             code,
-            class,
             retryable,
             retryable_routes,
             blocked_routes,
+            physical_attempt_id.to_owned(),
+            None,
+            None,
             Some(if retryable {
                 RefreshRetryAdvice::RetryAffectedRoutes
             } else {
                 RefreshRetryAdvice::InspectSources
             }),
+            None,
         );
     }
 
@@ -345,50 +325,47 @@ pub(super) fn source_backed_refresh_failure_outcome(
         .chain()
         .find_map(|cause| cause.downcast_ref::<SourceBackedRouteError>())
     {
-        let (code, class, retryable, retry_advice) = match route_error.kind {
+        let (code, retryable, retry_advice) = match route_error.kind {
             SourceBackedRouteErrorKind::Unavailable => (
                 RefreshOutcomeCode::SourceUnavailable,
-                RefreshOutcomeClass::Unavailable,
                 true,
                 RefreshRetryAdvice::RetryAffectedRoutes,
             ),
             SourceBackedRouteErrorKind::SourceChanged => (
                 RefreshOutcomeCode::SourceChanged,
-                RefreshOutcomeClass::SourceChanged,
                 true,
                 RefreshRetryAdvice::RetryAffectedRoutes,
             ),
             SourceBackedRouteErrorKind::InvalidSource => (
                 RefreshOutcomeCode::MalformedSource,
-                RefreshOutcomeClass::Unreadable,
                 false,
                 RefreshRetryAdvice::InspectSources,
             ),
             SourceBackedRouteErrorKind::Unsupported => (
                 RefreshOutcomeCode::UnsupportedSchema,
-                RefreshOutcomeClass::Incompatible,
                 false,
                 RefreshRetryAdvice::UpgradeOrReconfigure,
             ),
             SourceBackedRouteErrorKind::ResourceUnavailable => (
                 RefreshOutcomeCode::ResourceUnavailable,
-                RefreshOutcomeClass::ResourceUnavailable,
                 true,
                 RefreshRetryAdvice::RetryAffectedRoutes,
             ),
             SourceBackedRouteErrorKind::Internal => (
                 RefreshOutcomeCode::SourceRefreshFailed,
-                RefreshOutcomeClass::Internal,
                 true,
                 RefreshRetryAdvice::RetryRequest,
             ),
         };
-        return SourceBackedRefreshFailureOutcome::new(
+        return RefreshTerminalOutcome::with_uniform_route_disposition(
             code,
-            class,
             retryable,
             attempted_routes.clone(),
+            physical_attempt_id.to_owned(),
+            None,
+            None,
             Some(retry_advice),
+            None,
         );
     }
 
@@ -396,10 +373,9 @@ pub(super) fn source_backed_refresh_failure_outcome(
         .chain()
         .find_map(|cause| cause.downcast_ref::<IndexError>())
     {
-        let (code, class, retryable, retry_advice) = match index_error {
+        let (code, retryable, retry_advice) = match index_error {
             IndexError::SourceInvalidated(_) | IndexError::CompleteInventoryInvalidated { .. } => (
                 RefreshOutcomeCode::SourceChanged,
-                RefreshOutcomeClass::SourceChanged,
                 true,
                 RefreshRetryAdvice::RetryAffectedRoutes,
             ),
@@ -407,35 +383,34 @@ pub(super) fn source_backed_refresh_failure_outcome(
             | IndexError::IndexMemoryTooSmall { .. }
             | IndexError::VerificationScratchLimitExceeded { .. } => (
                 RefreshOutcomeCode::ResourceUnavailable,
-                RefreshOutcomeClass::ResourceUnavailable,
                 true,
                 RefreshRetryAdvice::RetryRequest,
             ),
             corruption if index_error_is_corruption(corruption) => (
                 RefreshOutcomeCode::IndexCorruption,
-                RefreshOutcomeClass::Corruption,
                 false,
                 RefreshRetryAdvice::RebuildIndex,
             ),
             incompatible if generation_incompatibility_requires_rebuild(incompatible) => (
                 RefreshOutcomeCode::IndexIncompatible,
-                RefreshOutcomeClass::Incompatible,
                 false,
                 RefreshRetryAdvice::RebuildIndex,
             ),
             _ => (
                 RefreshOutcomeCode::SourceRefreshFailed,
-                RefreshOutcomeClass::Internal,
                 true,
                 RefreshRetryAdvice::RetryRequest,
             ),
         };
-        return SourceBackedRefreshFailureOutcome::new(
+        return RefreshTerminalOutcome::with_uniform_route_disposition(
             code,
-            class,
             retryable,
             attempted_routes.clone(),
+            physical_attempt_id.to_owned(),
+            None,
+            None,
             Some(retry_advice),
+            None,
         );
     }
 
@@ -468,65 +443,70 @@ pub(super) fn source_backed_refresh_failure_outcome(
             let (retryable_routes, blocked_routes) =
                 authoritative_route_dispositions(attempted_routes, known, true);
             let retryable = !retryable_routes.is_empty();
-            return SourceBackedRefreshFailureOutcome::with_route_dispositions(
+            return RefreshTerminalOutcome::with_route_dispositions(
                 RefreshOutcomeCode::SourceUnclaimed,
-                RefreshOutcomeClass::Coverage,
                 retryable,
                 retryable_routes,
                 blocked_routes,
+                physical_attempt_id.to_owned(),
+                None,
+                None,
                 Some(if retryable {
                     RefreshRetryAdvice::RetryRetryableRoutesAndInspectBlocked
                 } else {
                     RefreshRetryAdvice::InspectSources
                 }),
+                None,
             );
         }
-        let (code, class, retryable, retry_advice) = match coordinator_error {
+        let (code, retryable, retry_advice) = match coordinator_error {
             SourceBackedCoordinatorError::Index(error) if index_error_is_corruption(error) => (
                 RefreshOutcomeCode::IndexCorruption,
-                RefreshOutcomeClass::Corruption,
                 false,
                 RefreshRetryAdvice::RebuildIndex,
             ),
             SourceBackedCoordinatorError::UnavailableRoute { .. } => (
                 RefreshOutcomeCode::SourceUnavailable,
-                RefreshOutcomeClass::Unavailable,
                 true,
                 RefreshRetryAdvice::RetryAffectedRoutes,
             ),
             SourceBackedCoordinatorError::InvalidRoute { .. }
             | SourceBackedCoordinatorError::InvalidRefreshScope { .. } => (
                 RefreshOutcomeCode::UnsupportedSchema,
-                RefreshOutcomeClass::Incompatible,
                 false,
                 RefreshRetryAdvice::UpgradeOrReconfigure,
             ),
             _ => (
                 RefreshOutcomeCode::SourceRefreshFailed,
-                RefreshOutcomeClass::Internal,
                 true,
                 RefreshRetryAdvice::RetryRequest,
             ),
         };
-        return SourceBackedRefreshFailureOutcome::new(
+        return RefreshTerminalOutcome::with_uniform_route_disposition(
             code,
-            class,
             retryable,
             attempted_routes.clone(),
+            physical_attempt_id.to_owned(),
+            None,
+            None,
             Some(retry_advice),
+            None,
         );
     }
 
-    SourceBackedRefreshFailureOutcome::new(
+    RefreshTerminalOutcome::with_uniform_route_disposition(
         RefreshOutcomeCode::SourceRefreshFailed,
-        RefreshOutcomeClass::Internal,
         true,
         attempted_routes.clone(),
+        physical_attempt_id.to_owned(),
+        None,
+        None,
         Some(if attempted_routes.is_empty() {
             RefreshRetryAdvice::RetryRequest
         } else {
             RefreshRetryAdvice::RetryAffectedRoutes
         }),
+        None,
     )
 }
 
@@ -553,26 +533,12 @@ fn source_failure_class_is_retryable(class: SourceBackedSourceFailureClass) -> b
     )
 }
 
-fn source_failure_code_and_class(
-    class: SourceBackedSourceFailureClass,
-) -> (RefreshOutcomeCode, RefreshOutcomeClass) {
+fn source_failure_code(class: SourceBackedSourceFailureClass) -> RefreshOutcomeCode {
     match class {
-        SourceBackedSourceFailureClass::Unavailable => (
-            RefreshOutcomeCode::SourceUnavailable,
-            RefreshOutcomeClass::Unavailable,
-        ),
-        SourceBackedSourceFailureClass::SourceChanged => (
-            RefreshOutcomeCode::SourceChanged,
-            RefreshOutcomeClass::SourceChanged,
-        ),
-        SourceBackedSourceFailureClass::Unreadable => (
-            RefreshOutcomeCode::MalformedSource,
-            RefreshOutcomeClass::Unreadable,
-        ),
-        SourceBackedSourceFailureClass::Incompatible => (
-            RefreshOutcomeCode::UnsupportedSchema,
-            RefreshOutcomeClass::Incompatible,
-        ),
+        SourceBackedSourceFailureClass::Unavailable => RefreshOutcomeCode::SourceUnavailable,
+        SourceBackedSourceFailureClass::SourceChanged => RefreshOutcomeCode::SourceChanged,
+        SourceBackedSourceFailureClass::Unreadable => RefreshOutcomeCode::MalformedSource,
+        SourceBackedSourceFailureClass::Incompatible => RefreshOutcomeCode::UnsupportedSchema,
     }
 }
 
@@ -704,7 +670,7 @@ pub(super) fn new_refresh_attempt(
         trigger: metadata.trigger,
         trigger_provenance: metadata.trigger_provenance,
         failure_type: None,
-        failure_outcome: None,
+        terminal_outcome: None,
         last_error: None,
     }
 }

--- a/crates/ctx-history-refresh/src/engine/attempt_helpers/tests.rs
+++ b/crates/ctx-history-refresh/src/engine/attempt_helpers/tests.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+fn classify(
+    error: &anyhow::Error,
+    routes: &BTreeSet<SourceRouteIdentity>,
+) -> RefreshTerminalOutcome {
+    source_backed_refresh_failure_outcome(error, routes, &uuid::Uuid::nil().to_string()).unwrap()
+}
+
 #[test]
 fn bounded_failure_diagnostics_do_not_bound_affected_routes_or_retryability() {
     let attempted_routes = (0..70)
@@ -26,12 +33,12 @@ fn bounded_failure_diagnostics_do_not_bound_affected_routes_or_retryability() {
     let error: anyhow::Error =
         SourceBackedCoordinatorError::NoUsableSourceRoutes { failed_routes }.into();
 
-    let outcome = source_backed_refresh_failure_outcome(&error, &attempted_routes);
+    let outcome = classify(&error, &attempted_routes);
 
-    assert_eq!(outcome.affected_routes, attempted_routes);
-    assert!(outcome.retryable);
-    assert_eq!(outcome.blocked_routes.len(), 64);
-    assert_eq!(outcome.retryable_routes.len(), 6);
+    assert_eq!(outcome.affected_routes(), &attempted_routes);
+    assert!(outcome.retryable());
+    assert_eq!(outcome.blocked_routes().len(), 64);
+    assert_eq!(outcome.retryable_routes().len(), 6);
 }
 
 #[test]
@@ -46,15 +53,15 @@ fn unclaimed_base_source_is_terminal_and_not_retryable() {
     }
     .into();
 
-    let mut outcome = source_backed_refresh_failure_outcome(&error, &attempted_routes);
+    let mut outcome = classify(&error, &attempted_routes);
 
-    assert_eq!(outcome.code, RefreshOutcomeCode::SourceUnclaimed);
-    assert_eq!(outcome.class, RefreshOutcomeClass::Coverage);
-    assert!(!outcome.retryable);
-    assert_eq!(outcome.blocked_routes, BTreeSet::from([route.clone()]));
-    assert!(outcome.retryable_routes.is_empty());
+    assert_eq!(outcome.code(), RefreshOutcomeCode::SourceUnclaimed);
+    assert_eq!(outcome.class(), RefreshOutcomeClass::Coverage);
+    assert!(!outcome.retryable());
+    assert_eq!(outcome.blocked_routes(), &BTreeSet::from([route.clone()]));
+    assert!(outcome.retryable_routes().is_empty());
     assert_eq!(
-        outcome.retry_advice,
+        outcome.retry_advice(),
         Some(RefreshRetryAdvice::InspectSources)
     );
 
@@ -86,18 +93,18 @@ fn unclaimed_base_source_preserves_peer_route_dispositions() {
     }
     .into();
 
-    let outcome = source_backed_refresh_failure_outcome(&error, &attempted_routes);
+    let outcome = classify(&error, &attempted_routes);
 
-    assert_eq!(outcome.code, RefreshOutcomeCode::SourceUnclaimed);
-    assert_eq!(outcome.class, RefreshOutcomeClass::Coverage);
-    assert!(outcome.retryable);
-    assert_eq!(outcome.retryable_routes, BTreeSet::from([healthy]));
+    assert_eq!(outcome.code(), RefreshOutcomeCode::SourceUnclaimed);
+    assert_eq!(outcome.class(), RefreshOutcomeClass::Coverage);
+    assert!(outcome.retryable());
+    assert_eq!(outcome.retryable_routes(), &BTreeSet::from([healthy]));
     assert_eq!(
-        outcome.blocked_routes,
-        BTreeSet::from([culprit, incompatible])
+        outcome.blocked_routes(),
+        &BTreeSet::from([culprit, incompatible])
     );
     assert_eq!(
-        outcome.retry_advice,
+        outcome.retry_advice(),
         Some(RefreshRetryAdvice::RetryRetryableRoutesAndInspectBlocked)
     );
 }
@@ -176,9 +183,9 @@ fn route_index_and_internal_failures_have_stable_retry_classes() {
     ];
 
     for (error, code, class, retryable) in cases {
-        let outcome = source_backed_refresh_failure_outcome(&error, &attempted_routes);
-        assert_eq!(outcome.code, code);
-        assert_eq!(outcome.class, class);
-        assert_eq!(outcome.retryable, retryable);
+        let outcome = classify(&error, &attempted_routes);
+        assert_eq!(outcome.code(), code);
+        assert_eq!(outcome.class(), class);
+        assert_eq!(outcome.retryable(), retryable);
     }
 }

--- a/crates/ctx-history-refresh/src/engine/durable_queue.rs
+++ b/crates/ctx-history-refresh/src/engine/durable_queue.rs
@@ -130,9 +130,9 @@ impl CoreRefreshEngine {
         let attempt = find_attempt(&state, request_id)
             .ok_or_else(|| anyhow!("source refresh request `{request_id}` is unknown"))?;
         let retry_admission = attempt.state == SourceBackedRefreshState::Failed
-            && attempt.failure_outcome.as_ref().is_some_and(|outcome| {
-                outcome.code == RefreshOutcomeCode::SourceRefreshAdmissionFailed
-                    && outcome.retry_advice == Some(RefreshRetryAdvice::RetryAdmission)
+            && attempt.terminal_outcome.as_ref().is_some_and(|outcome| {
+                outcome.code() == RefreshOutcomeCode::SourceRefreshAdmissionFailed
+                    && outcome.retry_advice() == Some(RefreshRetryAdvice::RetryAdmission)
             });
         if !retry_admission {
             bail!("source refresh request `{request_id}` has no terminal retry-admission handoff");
@@ -301,8 +301,8 @@ fn authoritative_route_terminal_job(
     request_id: &str,
 ) -> Option<Value> {
     let attempt = find_attempt(state, request_id)?;
-    let outcome = attempt.failure_outcome.as_ref()?;
-    if outcome.affected_routes.is_empty() {
+    let outcome = attempt.terminal_outcome.as_ref()?;
+    if outcome.affected_routes().is_empty() {
         return None;
     }
     durable_job_json(state, request_id)

--- a/crates/ctx-history-refresh/src/engine/read_model.rs
+++ b/crates/ctx-history-refresh/src/engine/read_model.rs
@@ -27,7 +27,7 @@ pub(super) struct SourceBackedAutomaticRetryCheckpoint {
 
 impl SourceBackedAutomaticRetryCheckpoint {
     pub(super) fn confirming(
-        outcome: &SourceBackedRefreshFailureOutcome,
+        outcome: &RefreshTerminalOutcome,
         route: &SourceRouteIdentity,
         source_observation: &str,
         terminal_error: &str,
@@ -74,7 +74,7 @@ impl SourceBackedAutomaticRetryCheckpoint {
 }
 
 fn automatic_retry_failure_fingerprint(
-    outcome: &SourceBackedRefreshFailureOutcome,
+    outcome: &RefreshTerminalOutcome,
     route: &SourceRouteIdentity,
     source_observation: &str,
     build_version: &str,
@@ -82,8 +82,8 @@ fn automatic_retry_failure_fingerprint(
 ) -> String {
     let mut digest = Sha256::new();
     for (label, value) in [
-        ("code", outcome.code.as_str().as_bytes()),
-        ("class", outcome.class.as_str().as_bytes()),
+        ("code", outcome.code().as_str().as_bytes()),
+        ("class", outcome.class().as_str().as_bytes()),
         ("route", route.as_str().as_bytes()),
         ("source_observation", source_observation.as_bytes()),
         ("build_version", build_version.as_bytes()),
@@ -143,138 +143,6 @@ fn automatic_retry_json(
         "resume_on": ["source_change", "ctx_upgrade", "manual_import"],
     }))
 }
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub(super) struct SourceBackedRefreshFailureOutcome {
-    pub(super) code: RefreshOutcomeCode,
-    pub(super) class: RefreshOutcomeClass,
-    pub(super) retryable: bool,
-    pub(super) affected_routes: BTreeSet<SourceRouteIdentity>,
-    pub(super) retryable_routes: BTreeSet<SourceRouteIdentity>,
-    pub(super) blocked_routes: BTreeSet<SourceRouteIdentity>,
-    pub(super) retry_advice: Option<RefreshRetryAdvice>,
-}
-
-impl SourceBackedRefreshFailureOutcome {
-    pub(super) fn is_automatic_retry_eligible(&self) -> bool {
-        RefreshTerminalOutcome::automatic_retry_disposition(self.code, self.class, false).is_some()
-    }
-
-    pub(super) fn pause_automatic_retry_routes(&mut self, routes: &BTreeSet<SourceRouteIdentity>) {
-        if !self.is_automatic_retry_eligible() {
-            return;
-        }
-        let mut changed = false;
-        for route in routes {
-            if self.retryable_routes.remove(route) {
-                self.blocked_routes.insert(route.clone());
-                changed = true;
-            }
-        }
-        if changed {
-            self.refresh_automatic_retry_disposition();
-        }
-    }
-
-    pub(super) fn rearm_automatic_retry_routes(&mut self, routes: &BTreeSet<SourceRouteIdentity>) {
-        if !self.is_automatic_retry_eligible() {
-            return;
-        }
-        let mut changed = false;
-        for route in routes {
-            if self.blocked_routes.remove(route) {
-                self.retryable_routes.insert(route.clone());
-                changed = true;
-            }
-        }
-        if changed {
-            self.refresh_automatic_retry_disposition();
-        }
-    }
-
-    fn refresh_automatic_retry_disposition(&mut self) {
-        let Some((retryable, retry_advice)) = RefreshTerminalOutcome::automatic_retry_disposition(
-            self.code,
-            self.class,
-            !self.retryable_routes.is_empty(),
-        ) else {
-            return;
-        };
-        self.retryable = retryable;
-        self.retry_advice = Some(retry_advice);
-    }
-
-    pub(super) fn new(
-        code: RefreshOutcomeCode,
-        class: RefreshOutcomeClass,
-        retryable: bool,
-        affected_routes: BTreeSet<SourceRouteIdentity>,
-        retry_advice: Option<RefreshRetryAdvice>,
-    ) -> Self {
-        let (retryable_routes, blocked_routes) = if retryable {
-            (affected_routes.clone(), BTreeSet::new())
-        } else {
-            (BTreeSet::new(), affected_routes.clone())
-        };
-        Self::with_route_dispositions(
-            code,
-            class,
-            retryable,
-            retryable_routes,
-            blocked_routes,
-            retry_advice,
-        )
-    }
-
-    pub(super) fn with_route_dispositions(
-        code: RefreshOutcomeCode,
-        class: RefreshOutcomeClass,
-        retryable: bool,
-        retryable_routes: BTreeSet<SourceRouteIdentity>,
-        blocked_routes: BTreeSet<SourceRouteIdentity>,
-        retry_advice: Option<RefreshRetryAdvice>,
-    ) -> Self {
-        let affected_routes = retryable_routes.union(&blocked_routes).cloned().collect();
-        Self {
-            code,
-            class,
-            retryable,
-            affected_routes,
-            retryable_routes,
-            blocked_routes,
-            retry_advice,
-        }
-    }
-
-    fn to_json(
-        &self,
-        physical_attempt_id: &str,
-        retained_generation: Option<&str>,
-        detail: Option<&str>,
-    ) -> Value {
-        compact_json(json!({
-            "code": self.code.as_str(),
-            "class": self.class.as_str(),
-            "retryable": self.retryable,
-            "affected_routes": self.affected_routes
-                .iter()
-                .map(SourceRouteIdentity::as_str)
-                .collect::<Vec<_>>(),
-            "retryable_routes": self.retryable_routes
-                .iter()
-                .map(SourceRouteIdentity::as_str)
-                .collect::<Vec<_>>(),
-            "blocked_routes": self.blocked_routes
-                .iter()
-                .map(SourceRouteIdentity::as_str)
-                .collect::<Vec<_>>(),
-            "physical_attempt_id": physical_attempt_id,
-            "retained_generation": retained_generation,
-            "retry_advice": self.retry_advice.map(RefreshRetryAdvice::as_str),
-            "detail": detail,
-        }))
-    }
-}
-
 /// Exact vocabulary of the durable legacy `failure_type` field.
 ///
 /// Structured outcomes use the broader `RefreshOutcomeCode`; keeping this
@@ -372,7 +240,9 @@ pub(super) struct SourceBackedRefreshAttempt {
     pub(super) trigger: &'static str,
     pub(super) trigger_provenance: &'static str,
     pub(super) failure_type: Option<SourceBackedRefreshFailureType>,
-    pub(super) failure_outcome: Option<SourceBackedRefreshFailureOutcome>,
+    /// Canonical terminal outcome for failures. Published attempts retain only
+    /// their typed receipt and project a success outcome from it at read time.
+    pub(super) terminal_outcome: Option<RefreshTerminalOutcome>,
     pub(super) last_error: Option<String>,
 }
 
@@ -432,17 +302,17 @@ impl SourceBackedRefreshAttempt {
     }
 
     fn failure_code(&self) -> Option<&'static str> {
-        self.failure_outcome
+        self.terminal_outcome
             .as_ref()
-            .map(|outcome| outcome.code.as_str())
+            .map(|outcome| outcome.code().as_str())
     }
 
     fn failure_reason(&self) -> Option<&'static str> {
-        self.failure_outcome.as_ref().map(|outcome| {
-            if outcome.code == RefreshOutcomeCode::AllProviderTerminalCoverageUnavailable {
+        self.terminal_outcome.as_ref().map(|outcome| {
+            if outcome.code() == RefreshOutcomeCode::AllProviderTerminalCoverageUnavailable {
                 "provider_terminal_coverage_unavailable"
             } else {
-                outcome.class.as_str()
+                outcome.class().as_str()
             }
         })
     }
@@ -468,53 +338,19 @@ impl SourceBackedRefreshAttempt {
     }
 
     fn structured_outcome_json(&self) -> Option<Value> {
-        if let Some(receipt) = self.receipt.as_ref() {
-            let code = receipt.terminal_outcome();
-            let (retryable_routes, blocked_routes) = receipt.route_retry_dispositions();
-            let retryable = !retryable_routes.is_empty();
-            let affected_routes = receipt
-                .route_results
-                .iter()
-                .filter(|result| {
-                    result.outcome.is_failure()
-                        || result.source_failure_total != 0
-                        || result.rejected_record_total != 0
-                })
-                .map(|result| result.route_identity.as_str())
-                .collect::<Vec<_>>();
-            return Some(compact_json(json!({
-                "code": code,
-                "class": if retryable {
-                    "completed_with_retryable_failures"
-                } else if code == "completed" {
-                    "completed"
-                } else {
-                    "completed_with_diagnostics"
-                },
-                "retryable": retryable,
-                "affected_routes": affected_routes,
-                "retryable_routes": retryable_routes
-                    .iter()
-                    .map(SourceRouteIdentity::as_str)
-                    .collect::<Vec<_>>(),
-                "blocked_routes": blocked_routes
-                    .iter()
-                    .map(SourceRouteIdentity::as_str)
-                    .collect::<Vec<_>>(),
-                "physical_attempt_id": self.physical_attempt_id(),
-                "retained_generation": (code != "completed" || !receipt.generation_changed)
-                    .then_some(receipt.published_generation.as_str()),
-                "published_generation": receipt.published_generation,
-                "retry_advice": retryable.then_some("retry_affected_routes"),
-            })));
+        match self.state {
+            SourceBackedRefreshState::Published => self.receipt.as_ref().map(|receipt| {
+                RefreshTerminalOutcome::from_published_receipt(receipt, self.physical_attempt_id())
+                    .to_json()
+            }),
+            SourceBackedRefreshState::Failed => self
+                .terminal_outcome
+                .as_ref()
+                .map(RefreshTerminalOutcome::to_json),
+            SourceBackedRefreshState::AdmissionPending
+            | SourceBackedRefreshState::Queued
+            | SourceBackedRefreshState::Running => None,
         }
-        self.failure_outcome.as_ref().map(|outcome| {
-            outcome.to_json(
-                self.physical_attempt_id(),
-                self.published_generation.as_deref(),
-                self.last_error.as_deref(),
-            )
-        })
     }
 
     fn apply_base_read_fields(&self, mut value: Value) -> Value {

--- a/crates/ctx-history-refresh/src/engine/request_lifecycle.rs
+++ b/crates/ctx-history-refresh/src/engine/request_lifecycle.rs
@@ -501,7 +501,17 @@ impl CoreRefreshEngine {
         let execution_failure_outcome = execution
             .as_ref()
             .err()
-            .map(|error| source_backed_refresh_failure_outcome(error, &attempted_routes));
+            .map(|error| {
+                source_backed_refresh_failure_outcome(error, &attempted_routes, &request_id)
+            })
+            .transpose()
+            .ok()?;
+        let verification_failure_outcome = source_backed_refresh_failure_outcome(
+            &anyhow!("terminal source refresh verification failed"),
+            &attempted_routes,
+            &request_id,
+        )
+        .ok()?;
         let observed_generation = probe();
         let (verified, observed_for_status) = match (execution, observed_generation) {
             (Ok(publication), Ok(Some(observed))) if publication.generation_id == observed => {
@@ -629,7 +639,7 @@ impl CoreRefreshEngine {
                     attempt.receipt = Some(receipt.clone());
                     attempt.timings = Some(publication.timings);
                     attempt.failure_type = None;
-                    attempt.failure_outcome = None;
+                    attempt.terminal_outcome = None;
                     attempt.last_error = None;
                     attempt.published_generation != previous_generation
                 };
@@ -657,6 +667,10 @@ impl CoreRefreshEngine {
                 (false, did_work, finish.coverage_certificate, terminal_job)
             }
             Err(error) => {
+                let terminal_outcome = execution_failure_outcome
+                    .unwrap_or(verification_failure_outcome)
+                    .with_failure_context(observed_for_status.clone(), Some(error.clone()))
+                    .ok()?;
                 {
                     let attempt = find_attempt_mut(&mut state, &request_id)?;
                     attempt.finished_at_ms = Some(utc_now().timestamp_millis());
@@ -671,13 +685,7 @@ impl CoreRefreshEngine {
                     attempt.state = SourceBackedRefreshState::Failed;
                     attempt.progress.phase = "failed".to_owned();
                     attempt.failure_type = execution_failure_type;
-                    attempt.failure_outcome =
-                        Some(execution_failure_outcome.unwrap_or_else(|| {
-                            source_backed_refresh_failure_outcome(
-                                &anyhow!("terminal source refresh verification failed"),
-                                &attempted_routes,
-                            )
-                        }));
+                    attempt.terminal_outcome = Some(terminal_outcome);
                     attempt.last_error = Some(error);
                 }
                 update_automatic_retry_after_failure(&mut state, &request_id);
@@ -780,7 +788,7 @@ fn update_automatic_retry_after_publication(state: &mut CoreRefreshEngineState, 
 fn update_automatic_retry_after_failure(state: &mut CoreRefreshEngineState, request_id: &str) {
     let Some((outcome, observations, terminal_error)) =
         find_attempt(state, request_id).and_then(|attempt| {
-            let outcome = attempt.failure_outcome.as_ref()?;
+            let outcome = attempt.terminal_outcome.as_ref()?;
             Some((
                 outcome.clone(),
                 attempt.route_observations.clone(),
@@ -793,7 +801,7 @@ fn update_automatic_retry_after_failure(state: &mut CoreRefreshEngineState, requ
 
     let mut newly_paused = BTreeSet::new();
     if outcome.is_automatic_retry_eligible() {
-        for route in &outcome.retryable_routes {
+        for route in outcome.retryable_routes() {
             let Some(observation) = observations.get(route) else {
                 continue;
             };
@@ -823,7 +831,7 @@ fn update_automatic_retry_after_failure(state: &mut CoreRefreshEngineState, requ
 
     let checkpoints = state.automatic_retry_checkpoints.clone();
     if let Some(attempt) = find_attempt_mut(state, request_id) {
-        if let Some(outcome) = attempt.failure_outcome.as_mut() {
+        if let Some(outcome) = attempt.terminal_outcome.as_mut() {
             outcome.pause_automatic_retry_routes(&newly_paused);
         }
         attempt.automatic_retry_checkpoints = checkpoints;
@@ -842,7 +850,7 @@ pub(in crate::engine) fn rearm_build_changed_automatic_retry_checkpoints(
     for route in &rearmed {
         attempt.automatic_retry_checkpoints.remove(route);
     }
-    if let Some(outcome) = attempt.failure_outcome.as_mut() {
+    if let Some(outcome) = attempt.terminal_outcome.as_mut() {
         outcome.rearm_automatic_retry_routes(&rearmed);
     }
     rearmed

--- a/crates/ctx-history-refresh/src/engine/request_lifecycle/recovery.rs
+++ b/crates/ctx-history-refresh/src/engine/request_lifecycle/recovery.rs
@@ -77,11 +77,11 @@ impl CoreRefreshEngine {
                 .transpose()?
                 .unwrap_or_default();
             let recovery_rearmed_routes = failed
-                .failure_outcome
+                .terminal_outcome
                 .as_ref()
                 .map(|outcome| {
                     durable_blocked_routes
-                        .difference(&outcome.blocked_routes)
+                        .difference(outcome.blocked_routes())
                         .cloned()
                         .collect::<BTreeSet<_>>()
                 })
@@ -89,10 +89,10 @@ impl CoreRefreshEngine {
             let failed_request_id = failed.request_id.clone();
             let failed_intent = failed.intent.clone();
             let failed_reconciliation_demand = failed.reconciliation_demand;
-            let failure_route_dispositions = failed.failure_outcome.as_ref().map(|outcome| {
+            let failure_route_dispositions = failed.terminal_outcome.as_ref().map(|outcome| {
                 (
-                    outcome.retryable_routes.clone(),
-                    outcome.blocked_routes.clone(),
+                    outcome.retryable_routes().clone(),
+                    outcome.blocked_routes().clone(),
                 )
             });
             {
@@ -242,7 +242,7 @@ fn recover_published_attempt(job: &Value) -> Result<SourceBackedRefreshAttempt> 
     attempt.published_generation = Some(receipt.published_generation.clone());
     attempt.receipt = Some(receipt);
     attempt.failure_type = None;
-    attempt.failure_outcome = None;
+    attempt.terminal_outcome = None;
     attempt.last_error = None;
     Ok(attempt)
 }
@@ -357,26 +357,33 @@ fn recover_terminal_attempt(
     attempt.timings = timings;
     attempt.publication_probe_us = publication_probe_us;
     attempt.failure_type = recover_optional_failure_type(job)?;
-    attempt.failure_outcome = if state == SourceBackedRefreshState::Failed {
-        recover_failure_outcome(job, &attempt.refresh_scope, attempt.failure_type)?
+    attempt.last_error = optional_string(job, "last_error")?;
+    attempt.terminal_outcome = if state == SourceBackedRefreshState::Failed {
+        recover_failure_outcome(
+            job,
+            &attempt.refresh_scope,
+            attempt.failure_type,
+            &attempt.request_id,
+            attempt.published_generation.clone(),
+            attempt.last_error.clone(),
+        )?
     } else {
         None
     };
-    attempt.last_error = optional_string(job, "last_error")?;
     attempt.automatic_retry_checkpoints = recover_automatic_retry_checkpoints(job)?;
     if let Some(outcome) = attempt
-        .failure_outcome
+        .terminal_outcome
         .as_ref()
         .filter(|outcome| outcome.is_automatic_retry_eligible())
     {
         for (route, checkpoint) in &attempt.automatic_retry_checkpoints {
-            if !outcome.affected_routes.contains(route) {
+            if !outcome.affected_routes().contains(route) {
                 continue;
             }
             let disposition_matches = if checkpoint.is_paused() {
-                outcome.blocked_routes.contains(route)
+                outcome.blocked_routes().contains(route)
             } else {
-                outcome.retryable_routes.contains(route)
+                outcome.retryable_routes().contains(route)
             };
             if !disposition_matches {
                 bail!("durable source refresh automatic retry disposition is inconsistent");
@@ -384,12 +391,12 @@ fn recover_terminal_attempt(
         }
     }
     let checkpointless_pauses = attempt
-        .failure_outcome
+        .terminal_outcome
         .as_ref()
         .filter(|outcome| outcome.is_automatic_retry_eligible())
         .map(|outcome| {
             outcome
-                .blocked_routes
+                .blocked_routes()
                 .iter()
                 .filter(|route| {
                     !attempt
@@ -401,7 +408,7 @@ fn recover_terminal_attempt(
                 .collect::<BTreeSet<_>>()
         })
         .unwrap_or_default();
-    if let Some(outcome) = attempt.failure_outcome.as_mut() {
+    if let Some(outcome) = attempt.terminal_outcome.as_mut() {
         outcome.rearm_automatic_retry_routes(&checkpointless_pauses);
     }
     rearm_build_changed_automatic_retry_checkpoints(&mut attempt);
@@ -414,11 +421,22 @@ fn recover_failure_outcome(
     job: &Value,
     scope: &SourceBackedRefreshScope,
     legacy_failure_type: Option<SourceBackedRefreshFailureType>,
-) -> Result<Option<SourceBackedRefreshFailureOutcome>> {
+    physical_attempt_id: &str,
+    retained_generation: Option<String>,
+    detail: Option<String>,
+) -> Result<Option<RefreshTerminalOutcome>> {
     let Some(value) = job.get("structured_outcome") else {
-        return Ok(
-            legacy_failure_type.map(|failure_type| legacy_failure_outcome(failure_type, scope))
-        );
+        return legacy_failure_type
+            .map(|failure_type| {
+                legacy_failure_outcome(
+                    failure_type,
+                    scope,
+                    physical_attempt_id,
+                    retained_generation,
+                    detail,
+                )
+            })
+            .transpose();
     };
     let fields = value
         .as_object()
@@ -467,26 +485,25 @@ fn recover_failure_outcome(
         (None, None) => (BTreeSet::new(), affected_routes.clone()),
         _ => bail!("durable terminal source refresh outcome has incomplete route disposition"),
     };
-    RefreshTerminalOutcome::validate_components(
+    let outcome_attempt_id = required_outcome_text(fields, "physical_attempt_id")?;
+    if outcome_attempt_id != physical_attempt_id {
+        bail!("durable terminal source refresh outcome names a different physical attempt");
+    }
+    let outcome = RefreshTerminalOutcome::new(
         code,
-        class,
         retryable,
-        &affected_routes,
-        &retryable_routes,
-        &blocked_routes,
+        affected_routes,
+        retryable_routes,
+        blocked_routes,
+        outcome_attempt_id.to_owned(),
+        optional_outcome_text(fields, "retained_generation")?,
+        optional_outcome_text(fields, "published_generation")?,
         retry_advice,
+        optional_outcome_text(fields, "detail")?,
     )
     .context("validate durable terminal source refresh outcome")?;
-    Ok(Some(
-        SourceBackedRefreshFailureOutcome::with_route_dispositions(
-            code,
-            class,
-            retryable,
-            retryable_routes,
-            blocked_routes,
-            retry_advice,
-        ),
-    ))
+    outcome.validate_declared_class(class)?;
+    Ok(Some(outcome))
 }
 
 fn recover_outcome_routes(
@@ -528,52 +545,53 @@ fn required_outcome_text<'a>(
         .ok_or_else(|| anyhow!("durable terminal source refresh outcome has invalid `{field}`"))
 }
 
+fn optional_outcome_text(
+    fields: &serde_json::Map<String, Value>,
+    field: &str,
+) -> Result<Option<String>> {
+    match fields.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) if !value.is_empty() => Ok(Some(value.clone())),
+        _ => bail!("durable terminal source refresh outcome has invalid `{field}`"),
+    }
+}
+
 fn legacy_failure_outcome(
     failure_type: SourceBackedRefreshFailureType,
     scope: &SourceBackedRefreshScope,
-) -> SourceBackedRefreshFailureOutcome {
-    let (class, retryable, retry_advice) = match failure_type {
-        SourceBackedRefreshFailureType::UnsupportedSchema => (
-            RefreshOutcomeClass::Incompatible,
-            false,
-            RefreshRetryAdvice::UpgradeOrReconfigure,
-        ),
-        SourceBackedRefreshFailureType::MalformedSource => (
-            RefreshOutcomeClass::Unreadable,
-            false,
-            RefreshRetryAdvice::InspectSources,
-        ),
-        SourceBackedRefreshFailureType::SourceUnavailable => (
-            RefreshOutcomeClass::Unavailable,
-            true,
-            RefreshRetryAdvice::RetryAffectedRoutes,
-        ),
-        SourceBackedRefreshFailureType::SourceChanged => (
-            RefreshOutcomeClass::SourceChanged,
-            true,
-            RefreshRetryAdvice::RetryAffectedRoutes,
-        ),
-        SourceBackedRefreshFailureType::SourceFailures => (
-            RefreshOutcomeClass::Mixed,
-            true,
-            RefreshRetryAdvice::RetryAffectedRoutes,
-        ),
-        SourceBackedRefreshFailureType::AllProviderTerminalCoverageUnavailable => (
-            RefreshOutcomeClass::Coverage,
-            true,
-            RefreshRetryAdvice::RetryRequest,
-        ),
+    physical_attempt_id: &str,
+    retained_generation: Option<String>,
+    detail: Option<String>,
+) -> Result<RefreshTerminalOutcome> {
+    let (retryable, retry_advice) = match failure_type {
+        SourceBackedRefreshFailureType::UnsupportedSchema => {
+            (false, RefreshRetryAdvice::UpgradeOrReconfigure)
+        }
+        SourceBackedRefreshFailureType::MalformedSource => {
+            (false, RefreshRetryAdvice::InspectSources)
+        }
+        SourceBackedRefreshFailureType::SourceUnavailable
+        | SourceBackedRefreshFailureType::SourceChanged
+        | SourceBackedRefreshFailureType::SourceFailures => {
+            (true, RefreshRetryAdvice::RetryAffectedRoutes)
+        }
+        SourceBackedRefreshFailureType::AllProviderTerminalCoverageUnavailable => {
+            (true, RefreshRetryAdvice::RetryRequest)
+        }
     };
     let affected_routes = match scope {
         SourceBackedRefreshScope::All => BTreeSet::new(),
         SourceBackedRefreshScope::Exact(routes) => routes.clone(),
     };
-    SourceBackedRefreshFailureOutcome::new(
+    RefreshTerminalOutcome::with_uniform_route_disposition(
         failure_type.outcome_code(),
-        class,
         retryable,
         affected_routes,
+        physical_attempt_id.to_owned(),
+        retained_generation,
+        None,
         Some(retry_advice),
+        detail,
     )
 }
 

--- a/crates/ctx-history-refresh/src/engine/request_lifecycle/recovery/failure_outcome_scope_tests.rs
+++ b/crates/ctx-history-refresh/src/engine/request_lifecycle/recovery/failure_outcome_scope_tests.rs
@@ -4,59 +4,11 @@ fn route(byte: char) -> SourceRouteIdentity {
     SourceRouteIdentity::from_sha256(byte.to_string().repeat(64)).unwrap()
 }
 
-fn exact_scope(route: &SourceRouteIdentity) -> SourceBackedRefreshScope {
-    SourceBackedRefreshScope::Exact(BTreeSet::from([route.clone()]))
-}
-
 #[test]
-fn exact_recovery_rejects_out_of_scope_retryable_disposition() {
-    let admitted = route('a');
-    let peer = route('b');
-    let job = json!({
-        "structured_outcome": {
-            "code": "source_changed",
-            "class": "source_changed",
-            "retryable": true,
-            "affected_routes": [peer.as_str()],
-            "retryable_routes": [peer.as_str()],
-            "blocked_routes": [],
-            "retry_advice": "retry_automatically"
-        }
-    });
-
-    let error = recover_failure_outcome(&job, &exact_scope(&admitted), None)
-        .expect_err("out-of-scope retryable route must fail closed");
-
-    assert!(format!("{error:#}").contains("exceeds its exact scope"));
-}
-
-#[test]
-fn exact_recovery_rejects_out_of_scope_blocked_disposition() {
-    let admitted = route('a');
-    let peer = route('b');
-    let job = json!({
-        "structured_outcome": {
-            "code": "malformed_source",
-            "class": "unreadable",
-            "retryable": false,
-            "affected_routes": [peer.as_str()],
-            "retryable_routes": [],
-            "blocked_routes": [peer.as_str()],
-            "retry_advice": "repair_source"
-        }
-    });
-
-    let error = recover_failure_outcome(&job, &exact_scope(&admitted), None)
-        .expect_err("out-of-scope blocked route must fail closed");
-
-    assert!(format!("{error:#}").contains("exceeds its exact scope"));
-}
-
-#[test]
-fn exact_recovery_preserves_mixed_source_unclaimed_dispositions() {
+fn recovery_preserves_valid_mixed_dispositions_and_rejects_scope_escape() {
     let culprit = route('a');
     let peer = route('b');
-    let scope = SourceBackedRefreshScope::Exact(BTreeSet::from([culprit.clone(), peer.clone()]));
+    let attempt_id = uuid::Uuid::nil().to_string();
     let job = json!({
         "structured_outcome": {
             "code": "source_unclaimed",
@@ -65,166 +17,22 @@ fn exact_recovery_preserves_mixed_source_unclaimed_dispositions() {
             "affected_routes": [culprit.as_str(), peer.as_str()],
             "retryable_routes": [peer.as_str()],
             "blocked_routes": [culprit.as_str()],
+            "physical_attempt_id": attempt_id,
             "retry_advice": "retry_retryable_routes_and_inspect_blocked"
         }
     });
-
-    let outcome = recover_failure_outcome(&job, &scope, None)
+    let scope = SourceBackedRefreshScope::Exact(BTreeSet::from([culprit.clone(), peer.clone()]));
+    let outcome = recover_failure_outcome(&job, &scope, None, &attempt_id, None, None)
         .unwrap()
-        .expect("typed source-unclaimed outcome");
+        .expect("typed terminal outcome");
+    assert_eq!(outcome.code(), RefreshOutcomeCode::SourceUnclaimed);
+    assert_eq!(outcome.retryable_routes(), &BTreeSet::from([peer]));
+    assert_eq!(outcome.blocked_routes(), &BTreeSet::from([culprit]));
 
-    assert_eq!(outcome.code, RefreshOutcomeCode::SourceUnclaimed);
-    assert_eq!(outcome.class, RefreshOutcomeClass::Coverage);
-    assert!(outcome.retryable);
-    assert_eq!(outcome.retryable_routes, BTreeSet::from([peer]));
-    assert_eq!(outcome.blocked_routes, BTreeSet::from([culprit]));
-    assert_eq!(
-        outcome.retry_advice,
-        Some(RefreshRetryAdvice::RetryRetryableRoutesAndInspectBlocked)
-    );
-}
-
-#[test]
-fn recovery_rejects_source_unclaimed_without_its_blocked_culprit() {
-    let peer = route('b');
-    let job = json!({
-        "structured_outcome": {
-            "code": "source_unclaimed",
-            "class": "coverage",
-            "retryable": true,
-            "affected_routes": [peer.as_str()],
-            "retryable_routes": [peer.as_str()],
-            "blocked_routes": [],
-            "retry_advice": "retry_retryable_routes_and_inspect_blocked"
-        }
-    });
-
-    let error = recover_failure_outcome(&job, &exact_scope(&peer), None)
-        .expect_err("source-unclaimed recovery requires a blocked culprit");
-
-    assert!(format!("{error:#}").contains("source-unclaimed outcome is inconsistent"));
-}
-
-#[test]
-fn recovery_accepts_paused_automatic_retry_outcomes() {
-    let route = route('a');
-    for (code, class) in [
-        ("source_refresh_failed", "internal"),
-        ("all_provider_terminal_coverage_unavailable", "coverage"),
-    ] {
-        let job = json!({
-            "structured_outcome": {
-                "code": code,
-                "class": class,
-                "retryable": false,
-                "affected_routes": [route.as_str()],
-                "retryable_routes": [],
-                "blocked_routes": [route.as_str()],
-                "retry_advice": "inspect_sources"
-            }
-        });
-
-        let outcome = recover_failure_outcome(&job, &exact_scope(&route), None)
-            .unwrap()
-            .expect("paused terminal outcome");
-
-        assert!(!outcome.retryable, "{code}");
-        assert_eq!(outcome.blocked_routes, BTreeSet::from([route.clone()]));
-        assert_eq!(
-            outcome.retry_advice,
-            Some(RefreshRetryAdvice::InspectSources),
-            "{code}",
-        );
-    }
-}
-
-#[test]
-fn recovery_accepts_aggregate_unsupported_source_advice() {
-    let route = route('a');
-    let job = json!({
-        "structured_outcome": {
-            "code": "unsupported_schema",
-            "class": "incompatible",
-            "retryable": false,
-            "affected_routes": [route.as_str()],
-            "retryable_routes": [],
-            "blocked_routes": [route.as_str()],
-            "retry_advice": "inspect_sources"
-        }
-    });
-
-    let outcome = recover_failure_outcome(&job, &exact_scope(&route), None)
-        .unwrap()
-        .expect("aggregate unsupported-source outcome");
-
-    assert_eq!(outcome.code, RefreshOutcomeCode::UnsupportedSchema);
-    assert_eq!(outcome.class, RefreshOutcomeClass::Incompatible);
-    assert!(!outcome.retryable);
-    assert_eq!(outcome.blocked_routes, BTreeSet::from([route]));
-    assert_eq!(
-        outcome.retry_advice,
-        Some(RefreshRetryAdvice::InspectSources)
-    );
-}
-
-#[test]
-fn crash_image_failed_exhaustive_attempt_rearms_retryable_route_ownership() {
-    let temp = tempfile::tempdir().unwrap();
-    let data_root = temp.path().join("data");
-    ctx_history_platform::platform_security::establish_private_data_root(&data_root).unwrap();
-    let route = route('a');
-    let first = test_refresh_engine();
-    first.initialize_watch_route_authority([route.clone()]);
-    first.record_watch_routes_requiring_exhaustive_reconciliation(
-        [(route.clone(), EventWatermark::new(1, 1))],
-        source_route_ledger_now_ms().saturating_sub(1_000),
-    );
-    assert!(first
-        .enqueue_next_dirty_route(&data_root, source_route_ledger_now_ms())
-        .unwrap());
-    let request_id = first.lock_state().active_request_id.clone().unwrap();
-    assert!(first.prepare_next_pending_admission(&data_root).unwrap());
-    assert_eq!(
-        first.reconciliation_demand(&request_id),
-        Some(SourceBackedReconciliationDemand::Exhaustive)
-    );
-
-    let status_path = daemon_source_backed_refresh_job_path(&data_root);
-    let crash = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let _ = first.run_next_with(
-            |active_request_id, engine| {
-                engine.admit_refresh_scope_for_test(
-                    active_request_id,
-                    &SourceBackedRefreshScope::Exact(BTreeSet::from([route.clone()])),
-                )?;
-                Err(anyhow!(
-                    "injected failed terminal before route finalization"
-                ))
-            },
-            || Ok(None),
-            |job| {
-                write_daemon_job_status(&status_path, job)?;
-                panic!("injected crash after durable failed terminal");
-            },
-            |_| Ok(()),
-        );
-    }));
-    assert!(crash.is_err());
-    assert_eq!(
-        read_daemon_job_status(&status_path).unwrap()["request_state"],
-        "failed"
-    );
-    drop(first);
-
-    let recovered = test_refresh_engine();
-    assert!(!recovered
-        .recover_interrupted_publication(&data_root)
-        .unwrap());
-    assert!(recovered
-        .enqueue_next_dirty_route(&data_root, u64::MAX)
-        .unwrap());
-    assert_eq!(
-        recovered.active_reconciliation_demand_for_test(),
-        Some(SourceBackedReconciliationDemand::Exhaustive)
-    );
+    let out_of_scope = route('c');
+    let mut escaped = job;
+    escaped["structured_outcome"]["affected_routes"] = json!([out_of_scope.as_str()]);
+    escaped["structured_outcome"]["retryable_routes"] = json!([out_of_scope.as_str()]);
+    escaped["structured_outcome"]["blocked_routes"] = json!([]);
+    assert!(recover_failure_outcome(&escaped, &scope, None, &attempt_id, None, None).is_err());
 }

--- a/crates/ctx-history-refresh/src/engine/route_admission.rs
+++ b/crates/ctx-history-refresh/src/engine/route_admission.rs
@@ -228,18 +228,20 @@ impl CoreRefreshEngine {
             if terminal_failed {
                 let blocked = attempt
                     .as_ref()
-                    .and_then(|attempt| attempt.failure_outcome.as_ref())
-                    .is_some_and(|outcome| outcome.blocked_routes.contains(admission.route()));
+                    .and_then(|attempt| attempt.terminal_outcome.as_ref())
+                    .is_some_and(|outcome| outcome.blocked_routes().contains(admission.route()));
                 if blocked {
                     state.route_retry_intents.remove(admission.route());
                     let actually_paused = state.dirty_routes.permanent_failure(&admission);
                     let automatic_pause = attempt.as_ref().is_some_and(|attempt| {
-                        attempt.failure_outcome.as_ref().is_some_and(
-                            SourceBackedRefreshFailureOutcome::is_automatic_retry_eligible,
-                        ) && attempt
-                            .automatic_retry_checkpoints
-                            .get(admission.route())
-                            .is_some_and(SourceBackedAutomaticRetryCheckpoint::is_paused)
+                        attempt
+                            .terminal_outcome
+                            .as_ref()
+                            .is_some_and(RefreshTerminalOutcome::is_automatic_retry_eligible)
+                            && attempt
+                                .automatic_retry_checkpoints
+                                .get(admission.route())
+                                .is_some_and(SourceBackedAutomaticRetryCheckpoint::is_paused)
                     });
                     if automatic_pause && !actually_paused {
                         stale_automatic_pauses.insert(admission.route().clone());
@@ -363,7 +365,7 @@ impl CoreRefreshEngine {
             }
             let checkpoints = state.automatic_retry_checkpoints.clone();
             if let Some(attempt) = find_attempt_mut(state, request_id) {
-                if let Some(outcome) = attempt.failure_outcome.as_mut() {
+                if let Some(outcome) = attempt.terminal_outcome.as_mut() {
                     outcome.rearm_automatic_retry_routes(&stale_automatic_pauses);
                 }
                 attempt.automatic_retry_checkpoints = checkpoints;
@@ -375,8 +377,8 @@ impl CoreRefreshEngine {
         {
             if attempt
                 .as_ref()
-                .and_then(|attempt| attempt.failure_outcome.as_ref())
-                .is_some_and(|outcome| !outcome.affected_routes.is_empty())
+                .and_then(|attempt| attempt.terminal_outcome.as_ref())
+                .is_some_and(|outcome| !outcome.affected_routes().is_empty())
                 && state.pending_scheduler_retry_root_id.as_deref() == Some(request_id)
             {
                 state.pending_scheduler_retry_root_id = None;

--- a/crates/ctx-history-refresh/src/engine/tests.rs
+++ b/crates/ctx-history-refresh/src/engine/tests.rs
@@ -118,13 +118,19 @@ fn diagnostic_text_cannot_override_the_typed_terminal_outcome() {
         SourceBackedRefreshScope::All,
     );
     attempt.state = SourceBackedRefreshState::Failed;
-    attempt.failure_outcome = Some(SourceBackedRefreshFailureOutcome::new(
-        RefreshOutcomeCode::SourceRefreshFailed,
-        RefreshOutcomeClass::Internal,
-        true,
-        BTreeSet::new(),
-        Some(RefreshRetryAdvice::RetryRequest),
-    ));
+    attempt.terminal_outcome = Some(
+        RefreshTerminalOutcome::with_uniform_route_disposition(
+            RefreshOutcomeCode::SourceRefreshFailed,
+            true,
+            BTreeSet::new(),
+            uuid::Uuid::nil().to_string(),
+            None,
+            None,
+            Some(RefreshRetryAdvice::RetryRequest),
+            None,
+        )
+        .unwrap(),
+    );
     attempt.last_error = Some(format!(
         "diagnostic mentions {} but is not classification authority",
         RefreshOutcomeCode::AllProviderTerminalCoverageUnavailable.as_str()

--- a/crates/ctx-history-refresh/src/engine/tests/additional.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/additional.rs
@@ -5,6 +5,25 @@ use ctx_history_capture::{
     SourceBackedSelectorAuthority,
 };
 use ctx_history_capture_model::ProviderSourceStatus;
+
+fn retryable_internal_outcome(
+    retryable_routes: BTreeSet<SourceRouteIdentity>,
+    blocked_routes: BTreeSet<SourceRouteIdentity>,
+) -> RefreshTerminalOutcome {
+    RefreshTerminalOutcome::with_route_dispositions(
+        RefreshOutcomeCode::SourceRefreshFailed,
+        true,
+        retryable_routes,
+        blocked_routes,
+        uuid::Uuid::nil().to_string(),
+        None,
+        None,
+        Some(RefreshRetryAdvice::RetryAffectedRoutes),
+        None,
+    )
+    .unwrap()
+}
+
 #[test]
 fn ordinary_manual_all_still_scans_every_current_route() {
     let temp = tempfile::tempdir().unwrap();
@@ -489,14 +508,7 @@ fn mixed_automatic_retry_serialization_round_trips_through_recovery() {
     let observation = "ab".repeat(32);
     let retryable_routes = BTreeSet::from([confirming_route.clone()]);
     let blocked_routes = BTreeSet::from([paused_route.clone()]);
-    let outcome = SourceBackedRefreshFailureOutcome::with_route_dispositions(
-        RefreshOutcomeCode::SourceRefreshFailed,
-        RefreshOutcomeClass::Internal,
-        true,
-        retryable_routes,
-        blocked_routes,
-        Some(RefreshRetryAdvice::RetryAffectedRoutes),
-    );
+    let outcome = retryable_internal_outcome(retryable_routes, blocked_routes);
     let mut paused = SourceBackedAutomaticRetryCheckpoint::confirming(
         &outcome,
         &paused_route,
@@ -521,7 +533,7 @@ fn mixed_automatic_retry_serialization_round_trips_through_recovery() {
         SourceBackedRefreshScope::exact([paused_route, confirming_route]),
     );
     attempt.state = SourceBackedRefreshState::Failed;
-    attempt.failure_outcome = Some(outcome);
+    attempt.terminal_outcome = Some(outcome);
     attempt.last_error = Some("stable internal failure".to_owned());
     attempt.automatic_retry_checkpoints = expected.clone();
 
@@ -559,13 +571,8 @@ fn cold_scheduler_does_not_widen_around_an_unchanged_paused_route() {
     registry.register(healthy_source);
     let catalog = registry.watch_catalog();
     let observation = catalog.certify_route_observation(&paused_route).unwrap();
-    let outcome = SourceBackedRefreshFailureOutcome::new(
-        RefreshOutcomeCode::SourceRefreshFailed,
-        RefreshOutcomeClass::Internal,
-        true,
-        BTreeSet::from([paused_route.clone()]),
-        Some(RefreshRetryAdvice::RetryAffectedRoutes),
-    );
+    let outcome =
+        retryable_internal_outcome(BTreeSet::from([paused_route.clone()]), BTreeSet::new());
     let mut checkpoint = SourceBackedAutomaticRetryCheckpoint::confirming(
         &outcome,
         &paused_route,
@@ -629,13 +636,8 @@ fn periodic_catalog_refresh_excludes_an_unchanged_paused_route() {
     registry.register(healthy_source);
     let catalog = registry.watch_catalog();
     let observation = catalog.certify_route_observation(&paused_route).unwrap();
-    let outcome = SourceBackedRefreshFailureOutcome::new(
-        RefreshOutcomeCode::SourceRefreshFailed,
-        RefreshOutcomeClass::Internal,
-        true,
-        BTreeSet::from([paused_route.clone()]),
-        Some(RefreshRetryAdvice::RetryAffectedRoutes),
-    );
+    let outcome =
+        retryable_internal_outcome(BTreeSet::from([paused_route.clone()]), BTreeSet::new());
     let mut checkpoint = SourceBackedAutomaticRetryCheckpoint::confirming(
         &outcome,
         &paused_route,
@@ -854,10 +856,6 @@ fn automatic_terminal_coverage_retry_confirms_once_then_pauses() {
     assert_eq!(
         first.job["structured_outcome"]["code"],
         "all_provider_terminal_coverage_unavailable"
-    );
-    assert_eq!(
-        first.job["reason"],
-        "provider_terminal_coverage_unavailable"
     );
     assert_eq!(first.job["automatic_retry"]["state"], "confirming");
     assert_eq!(

--- a/crates/ctx-history-refresh/src/engine/tests/durable_receipt.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/durable_receipt.rs
@@ -167,6 +167,14 @@ fn lone_failed_terminal_recovers_without_reenqueue() {
         .expect("failed terminal");
     assert!(failed.failed);
     assert!(!failed.terminal_persistence_pending);
+    let status_path = daemon_source_backed_refresh_job_path(&data_root);
+    let mut legacy_failure = read_daemon_job_status(&status_path).unwrap();
+    legacy_failure
+        .as_object_mut()
+        .unwrap()
+        .remove("structured_outcome");
+    legacy_failure["failure_type"] = json!("source_failures");
+    write_daemon_job_status(&status_path, &legacy_failure).unwrap();
     drop(first);
 
     let restarted = test_refresh_engine();
@@ -178,6 +186,14 @@ fn lone_failed_terminal_recovers_without_reenqueue() {
     assert_eq!(recovered["request_id"], request_id);
     assert_eq!(recovered["request_state"], "failed");
     assert_eq!(recovered["last_error"], "exact lone terminal failure");
+    assert_eq!(
+        recovered["structured_outcome"]["detail"],
+        "exact lone terminal failure"
+    );
+    let kind = recovered.kind().unwrap();
+    let outcome = kind.terminal_outcome().unwrap();
+    assert_eq!(outcome.code(), RefreshOutcomeCode::SourceFailures);
+    assert_eq!(outcome.detail(), Some("exact lone terminal failure"));
 }
 
 #[test]

--- a/crates/ctx-history-refresh/src/request.rs
+++ b/crates/ctx-history-refresh/src/request.rs
@@ -2,6 +2,8 @@ use super::*;
 
 mod terminal_outcome;
 
+pub use terminal_outcome::RefreshTerminalOutcome;
+
 pub use ctx_history_refresh_execution::RefreshOperation;
 pub(crate) type SourceBackedRefreshOperation = RefreshOperation;
 
@@ -64,6 +66,49 @@ impl RefreshOutcomeCode {
                 | Self::CompletedWithSourceFailures
                 | Self::CompletedWithRejectionsAndSourceFailures
         )
+    }
+
+    pub const fn class(self, retryable: bool) -> RefreshOutcomeClass {
+        match self {
+            Self::Completed => RefreshOutcomeClass::Completed,
+            Self::CompletedWithRejections
+            | Self::CompletedWithSourceFailures
+            | Self::CompletedWithRejectionsAndSourceFailures => {
+                if retryable {
+                    RefreshOutcomeClass::CompletedWithRetryableFailures
+                } else {
+                    RefreshOutcomeClass::CompletedWithDiagnostics
+                }
+            }
+            Self::SourceUnavailable | Self::ExplicitSourcePathMissing => {
+                RefreshOutcomeClass::Unavailable
+            }
+            Self::SourceChanged => RefreshOutcomeClass::SourceChanged,
+            Self::MalformedSource => RefreshOutcomeClass::Unreadable,
+            Self::UnsupportedSchema | Self::IndexIncompatible => RefreshOutcomeClass::Incompatible,
+            Self::SourceFailures | Self::LogicalSourceFailures => RefreshOutcomeClass::Mixed,
+            Self::SourceUnclaimed | Self::AllProviderTerminalCoverageUnavailable => {
+                RefreshOutcomeClass::Coverage
+            }
+            Self::SourceRefreshFailed | Self::SourceRefreshInternal => {
+                RefreshOutcomeClass::Internal
+            }
+            Self::ResourceUnavailable => RefreshOutcomeClass::ResourceUnavailable,
+            Self::IndexCorruption => RefreshOutcomeClass::Corruption,
+            Self::SourceRefreshAdmissionFailed => RefreshOutcomeClass::ControlPlane,
+        }
+    }
+
+    pub(crate) fn from_receipt(receipt: &SourceBackedRefreshReceipt) -> Self {
+        match (
+            receipt.source_failure_total() != 0,
+            receipt.rejected_record_total() != 0,
+        ) {
+            (false, false) => Self::Completed,
+            (false, true) => Self::CompletedWithRejections,
+            (true, false) => Self::CompletedWithSourceFailures,
+            (true, true) => Self::CompletedWithRejectionsAndSourceFailures,
+        }
     }
 
     /// Returns the bounded observability classification owned by the Core
@@ -203,21 +248,6 @@ impl std::str::FromStr for RefreshLogicalPhase {
             _ => bail!("source refresh response has invalid logical phase"),
         }
     }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct RefreshTerminalOutcome {
-    pub code: RefreshOutcomeCode,
-    pub class: RefreshOutcomeClass,
-    pub retryable: bool,
-    pub affected_routes: BTreeSet<SourceRouteIdentity>,
-    pub retryable_routes: BTreeSet<SourceRouteIdentity>,
-    pub blocked_routes: BTreeSet<SourceRouteIdentity>,
-    pub physical_attempt_id: String,
-    pub retained_generation: Option<String>,
-    pub published_generation: Option<String>,
-    pub retry_advice: Option<RefreshRetryAdvice>,
-    pub detail: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -615,11 +645,21 @@ impl RefreshStatus {
         if request_state.is_terminal() != structured_outcome.is_some() {
             bail!("source refresh terminal state has no structured outcome");
         }
-        if structured_outcome
-            .as_ref()
-            .is_some_and(|outcome| outcome.physical_attempt_id != physical_attempt_id)
-        {
-            bail!("source refresh outcome names a different physical attempt");
+        if let Some(outcome) = structured_outcome.as_ref() {
+            if outcome.physical_attempt_id() != physical_attempt_id {
+                bail!("source refresh outcome names a different physical attempt");
+            }
+            if request_state == RefreshRequestState::Published {
+                if outcome.code().is_failure() {
+                    bail!("published source refresh has a failure outcome");
+                }
+                let published_generation = optional_status_string(fields, "published_generation")?;
+                if published_generation.as_deref() != outcome.published_generation() {
+                    bail!("published source refresh generation disagrees with its outcome");
+                }
+            } else if request_state == RefreshRequestState::Failed && !outcome.code().is_failure() {
+                bail!("failed source refresh has a nonfailure outcome");
+            }
         }
         Ok(RefreshStatusKind::Logical(RefreshLogicalStatus {
             request_state,
@@ -703,20 +743,19 @@ fn parse_terminal_outcome(value: &Value) -> Result<RefreshTerminalOutcome> {
         Some(value) => Some(value.parse()?),
         None => None,
     };
-    let outcome = RefreshTerminalOutcome {
+    let outcome = RefreshTerminalOutcome::new(
         code,
-        class,
         retryable,
         affected_routes,
         retryable_routes,
         blocked_routes,
         physical_attempt_id,
-        retained_generation: optional_outcome_string(fields, "retained_generation")?,
-        published_generation: optional_outcome_string(fields, "published_generation")?,
+        optional_outcome_string(fields, "retained_generation")?,
+        optional_outcome_string(fields, "published_generation")?,
         retry_advice,
-        detail: optional_outcome_string(fields, "detail")?,
-    };
-    outcome.validate()?;
+        optional_outcome_string(fields, "detail")?,
+    )?;
+    outcome.validate_declared_class(class)?;
     Ok(outcome)
 }
 

--- a/crates/ctx-history-refresh/src/request/terminal_outcome.rs
+++ b/crates/ctx-history-refresh/src/request/terminal_outcome.rs
@@ -1,94 +1,379 @@
 use super::*;
 
+/// The validated terminal result shared by daemon state, recovery, progress,
+/// and Core capability failures. Construction is deliberately the only way to
+/// assemble one, so no downstream layer can invent a legal-looking outcome.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RefreshTerminalOutcome {
+    code: RefreshOutcomeCode,
+    retryable: bool,
+    affected_routes: BTreeSet<SourceRouteIdentity>,
+    retryable_routes: BTreeSet<SourceRouteIdentity>,
+    blocked_routes: BTreeSet<SourceRouteIdentity>,
+    physical_attempt_id: String,
+    retained_generation: Option<String>,
+    published_generation: Option<String>,
+    retry_advice: Option<RefreshRetryAdvice>,
+    detail: Option<String>,
+}
+
 impl RefreshTerminalOutcome {
-    pub fn validate(&self) -> Result<()> {
-        Self::validate_components(
+    pub(crate) fn from_published_receipt(
+        receipt: &SourceBackedRefreshReceipt,
+        physical_attempt_id: &str,
+    ) -> Self {
+        let code = RefreshOutcomeCode::from_receipt(receipt);
+        let (retryable_routes, blocked_routes) = receipt.route_retry_dispositions();
+        let retryable = !retryable_routes.is_empty();
+        let affected_routes = receipt
+            .route_results
+            .iter()
+            .filter(|result| {
+                result.outcome.is_failure()
+                    || result.source_failure_total != 0
+                    || result.rejected_record_total != 0
+            })
+            .map(|result| {
+                SourceRouteIdentity::from_sha256(result.route_identity.clone())
+                    .expect("validated refresh receipt route identity")
+            })
+            .collect();
+        Self::new(
+            code,
+            retryable,
+            affected_routes,
+            retryable_routes,
+            blocked_routes,
+            physical_attempt_id.to_owned(),
+            (code != RefreshOutcomeCode::Completed || !receipt.generation_changed)
+                .then_some(receipt.published_generation.clone()),
+            Some(receipt.published_generation.clone()),
+            retryable.then_some(RefreshRetryAdvice::RetryAffectedRoutes),
+            None,
+        )
+        .expect("validated refresh receipt has a valid terminal projection")
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        code: RefreshOutcomeCode,
+        retryable: bool,
+        affected_routes: BTreeSet<SourceRouteIdentity>,
+        retryable_routes: BTreeSet<SourceRouteIdentity>,
+        blocked_routes: BTreeSet<SourceRouteIdentity>,
+        physical_attempt_id: String,
+        retained_generation: Option<String>,
+        published_generation: Option<String>,
+        retry_advice: Option<RefreshRetryAdvice>,
+        detail: Option<String>,
+    ) -> Result<Self> {
+        validate_components(
+            code,
+            retryable,
+            &affected_routes,
+            &retryable_routes,
+            &blocked_routes,
+            &physical_attempt_id,
+            retained_generation.as_deref(),
+            published_generation.as_deref(),
+            retry_advice,
+            detail.as_deref(),
+        )?;
+        Ok(Self {
+            code,
+            retryable,
+            affected_routes,
+            retryable_routes,
+            blocked_routes,
+            physical_attempt_id,
+            retained_generation,
+            published_generation,
+            retry_advice,
+            detail,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn with_uniform_route_disposition(
+        code: RefreshOutcomeCode,
+        retryable: bool,
+        affected_routes: BTreeSet<SourceRouteIdentity>,
+        physical_attempt_id: String,
+        retained_generation: Option<String>,
+        published_generation: Option<String>,
+        retry_advice: Option<RefreshRetryAdvice>,
+        detail: Option<String>,
+    ) -> Result<Self> {
+        let (retryable_routes, blocked_routes) = if retryable {
+            (affected_routes.clone(), BTreeSet::new())
+        } else {
+            (BTreeSet::new(), affected_routes.clone())
+        };
+        Self::new(
+            code,
+            retryable,
+            affected_routes,
+            retryable_routes,
+            blocked_routes,
+            physical_attempt_id,
+            retained_generation,
+            published_generation,
+            retry_advice,
+            detail,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn with_route_dispositions(
+        code: RefreshOutcomeCode,
+        retryable: bool,
+        retryable_routes: BTreeSet<SourceRouteIdentity>,
+        blocked_routes: BTreeSet<SourceRouteIdentity>,
+        physical_attempt_id: String,
+        retained_generation: Option<String>,
+        published_generation: Option<String>,
+        retry_advice: Option<RefreshRetryAdvice>,
+        detail: Option<String>,
+    ) -> Result<Self> {
+        let affected_routes = retryable_routes.union(&blocked_routes).cloned().collect();
+        Self::new(
+            code,
+            retryable,
+            affected_routes,
+            retryable_routes,
+            blocked_routes,
+            physical_attempt_id,
+            retained_generation,
+            published_generation,
+            retry_advice,
+            detail,
+        )
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        validate_components(
             self.code,
-            self.class,
             self.retryable,
             &self.affected_routes,
             &self.retryable_routes,
             &self.blocked_routes,
+            &self.physical_attempt_id,
+            self.retained_generation.as_deref(),
+            self.published_generation.as_deref(),
             self.retry_advice,
+            self.detail.as_deref(),
         )
     }
 
-    pub(crate) fn validate_components(
-        code: RefreshOutcomeCode,
-        class: RefreshOutcomeClass,
-        retryable: bool,
-        affected_routes: &BTreeSet<SourceRouteIdentity>,
-        retryable_routes: &BTreeSet<SourceRouteIdentity>,
-        blocked_routes: &BTreeSet<SourceRouteIdentity>,
-        retry_advice: Option<RefreshRetryAdvice>,
-    ) -> Result<()> {
-        if affected_routes.len() > SOURCE_REFRESH_TERMINAL_ROUTE_LIMIT
-            || retryable_routes.len() > SOURCE_REFRESH_TERMINAL_ROUTE_LIMIT
-            || blocked_routes.len() > SOURCE_REFRESH_TERMINAL_ROUTE_LIMIT
-            || !retryable_routes.is_disjoint(blocked_routes)
-            || !retryable_routes.is_subset(affected_routes)
-            || !blocked_routes.is_subset(affected_routes)
-            || (code.is_failure()
-                && retryable_routes
-                    .union(blocked_routes)
-                    .ne(affected_routes.iter()))
-            || (!affected_routes.is_empty() && retryable == retryable_routes.is_empty())
-        {
-            bail!("source refresh structured outcome has inconsistent route dispositions");
-        }
-        if code == RefreshOutcomeCode::SourceUnclaimed
-            && (class != RefreshOutcomeClass::Coverage
-                || blocked_routes.is_empty()
-                || retry_advice
-                    != Some(if retryable {
-                        RefreshRetryAdvice::RetryRetryableRoutesAndInspectBlocked
-                    } else {
-                        RefreshRetryAdvice::InspectSources
-                    }))
-        {
-            bail!("source refresh source-unclaimed outcome is inconsistent");
-        }
-        if !valid_code_class(code, class) {
+    pub const fn code(&self) -> RefreshOutcomeCode {
+        self.code
+    }
+    pub const fn class(&self) -> RefreshOutcomeClass {
+        self.code.class(self.retryable)
+    }
+    pub(crate) fn validate_declared_class(&self, class: RefreshOutcomeClass) -> Result<()> {
+        if class != self.class() {
             bail!("source refresh structured outcome has inconsistent code and class");
-        }
-        if !valid_retry_contract(code, class, retryable, retry_advice) {
-            bail!("source refresh structured outcome has inconsistent retry disposition");
         }
         Ok(())
     }
-
-    pub(crate) const fn automatic_retry_disposition(
-        code: RefreshOutcomeCode,
-        class: RefreshOutcomeClass,
-        retryable_routes_present: bool,
-    ) -> Option<(bool, RefreshRetryAdvice)> {
-        if !matches!(
-            (code, class),
-            (
-                RefreshOutcomeCode::SourceRefreshFailed,
-                RefreshOutcomeClass::Internal,
-            ) | (
-                RefreshOutcomeCode::AllProviderTerminalCoverageUnavailable,
-                RefreshOutcomeClass::Coverage,
-            )
-        ) {
-            return None;
-        }
-        Some(if retryable_routes_present {
-            (true, RefreshRetryAdvice::RetryAffectedRoutes)
-        } else {
-            (false, RefreshRetryAdvice::InspectSources)
-        })
+    pub const fn retryable(&self) -> bool {
+        self.retryable
     }
+    pub fn affected_routes(&self) -> &BTreeSet<SourceRouteIdentity> {
+        &self.affected_routes
+    }
+    pub fn retryable_routes(&self) -> &BTreeSet<SourceRouteIdentity> {
+        &self.retryable_routes
+    }
+    pub fn blocked_routes(&self) -> &BTreeSet<SourceRouteIdentity> {
+        &self.blocked_routes
+    }
+    pub fn physical_attempt_id(&self) -> &str {
+        &self.physical_attempt_id
+    }
+    pub fn retained_generation(&self) -> Option<&str> {
+        self.retained_generation.as_deref()
+    }
+    pub fn published_generation(&self) -> Option<&str> {
+        self.published_generation.as_deref()
+    }
+    pub const fn retry_advice(&self) -> Option<RefreshRetryAdvice> {
+        self.retry_advice
+    }
+    pub fn detail(&self) -> Option<&str> {
+        self.detail.as_deref()
+    }
+
+    pub(crate) fn with_failure_context(
+        mut self,
+        retained_generation: Option<String>,
+        detail: Option<String>,
+    ) -> Result<Self> {
+        self.retained_generation = retained_generation;
+        self.detail = detail;
+        self.validate()?;
+        Ok(self)
+    }
+
+    pub(crate) fn to_json(&self) -> Value {
+        compact_json(json!({
+            "code": self.code.as_str(),
+            "class": self.class().as_str(),
+            "retryable": self.retryable,
+            "affected_routes": route_names(&self.affected_routes),
+            "retryable_routes": route_names(&self.retryable_routes),
+            "blocked_routes": route_names(&self.blocked_routes),
+            "physical_attempt_id": self.physical_attempt_id,
+            "retained_generation": self.retained_generation,
+            "published_generation": self.published_generation,
+            "retry_advice": self.retry_advice.map(RefreshRetryAdvice::as_str),
+            "detail": self.detail,
+        }))
+    }
+
+    pub(crate) fn is_automatic_retry_eligible(&self) -> bool {
+        automatic_retry_disposition(self.code, false).is_some()
+    }
+
+    pub(crate) fn pause_automatic_retry_routes(&mut self, routes: &BTreeSet<SourceRouteIdentity>) {
+        self.move_automatic_retry_routes(routes, true);
+    }
+
+    pub(crate) fn rearm_automatic_retry_routes(&mut self, routes: &BTreeSet<SourceRouteIdentity>) {
+        self.move_automatic_retry_routes(routes, false);
+    }
+
+    fn move_automatic_retry_routes(&mut self, routes: &BTreeSet<SourceRouteIdentity>, pause: bool) {
+        if !self.is_automatic_retry_eligible() {
+            return;
+        }
+        let (from, to) = if pause {
+            (&mut self.retryable_routes, &mut self.blocked_routes)
+        } else {
+            (&mut self.blocked_routes, &mut self.retryable_routes)
+        };
+        let mut changed = false;
+        for route in routes {
+            if from.remove(route) {
+                to.insert(route.clone());
+                changed = true;
+            }
+        }
+        if !changed {
+            return;
+        }
+        if let Some((retryable, advice)) =
+            automatic_retry_disposition(self.code, !self.retryable_routes.is_empty())
+        {
+            self.retryable = retryable;
+            self.retry_advice = Some(advice);
+        }
+        debug_assert!(self.validate().is_ok());
+    }
+}
+
+fn route_names(routes: &BTreeSet<SourceRouteIdentity>) -> Vec<String> {
+    routes
+        .iter()
+        .map(|route| route.as_str().to_owned())
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_components(
+    code: RefreshOutcomeCode,
+    retryable: bool,
+    affected_routes: &BTreeSet<SourceRouteIdentity>,
+    retryable_routes: &BTreeSet<SourceRouteIdentity>,
+    blocked_routes: &BTreeSet<SourceRouteIdentity>,
+    physical_attempt_id: &str,
+    retained_generation: Option<&str>,
+    published_generation: Option<&str>,
+    retry_advice: Option<RefreshRetryAdvice>,
+    detail: Option<&str>,
+) -> Result<()> {
+    if physical_attempt_id.is_empty()
+        || physical_attempt_id.chars().any(char::is_control)
+        || retained_generation.is_some_and(invalid_identity)
+        || published_generation.is_some_and(invalid_identity)
+    {
+        bail!("source refresh structured outcome has invalid identity");
+    }
+    match (code.is_failure(), published_generation.is_some()) {
+        (true, true) => bail!("failed source refresh outcome has a published generation"),
+        (false, false) => bail!("successful source refresh outcome has no published generation"),
+        _ => {}
+    }
+    if affected_routes.len() > SOURCE_REFRESH_TERMINAL_ROUTE_LIMIT
+        || retryable_routes.len() > SOURCE_REFRESH_TERMINAL_ROUTE_LIMIT
+        || blocked_routes.len() > SOURCE_REFRESH_TERMINAL_ROUTE_LIMIT
+        || !retryable_routes.is_disjoint(blocked_routes)
+        || !retryable_routes.is_subset(affected_routes)
+        || !blocked_routes.is_subset(affected_routes)
+        || (code.is_failure()
+            && retryable_routes
+                .union(blocked_routes)
+                .ne(affected_routes.iter()))
+        || (!affected_routes.is_empty() && retryable == retryable_routes.is_empty())
+    {
+        bail!("source refresh structured outcome has inconsistent route dispositions");
+    }
+    if code == RefreshOutcomeCode::Completed
+        && (retryable
+            || !affected_routes.is_empty()
+            || !retryable_routes.is_empty()
+            || !blocked_routes.is_empty()
+            || retry_advice.is_some()
+            || detail.is_some())
+    {
+        bail!("completed source refresh outcome carries failure facts");
+    }
+    if code == RefreshOutcomeCode::SourceUnclaimed
+        && (blocked_routes.is_empty()
+            || retry_advice
+                != Some(if retryable {
+                    RefreshRetryAdvice::RetryRetryableRoutesAndInspectBlocked
+                } else {
+                    RefreshRetryAdvice::InspectSources
+                }))
+    {
+        bail!("source refresh source-unclaimed outcome is inconsistent");
+    }
+    if !valid_retry_contract(code, retryable, retry_advice) {
+        bail!("source refresh structured outcome has inconsistent retry disposition");
+    }
+    Ok(())
+}
+
+fn invalid_identity(value: &str) -> bool {
+    value.is_empty() || value.chars().any(char::is_control)
+}
+
+pub(crate) const fn automatic_retry_disposition(
+    code: RefreshOutcomeCode,
+    retryable_routes_present: bool,
+) -> Option<(bool, RefreshRetryAdvice)> {
+    if !matches!(
+        code,
+        RefreshOutcomeCode::SourceRefreshFailed
+            | RefreshOutcomeCode::AllProviderTerminalCoverageUnavailable
+    ) {
+        return None;
+    }
+    Some(if retryable_routes_present {
+        (true, RefreshRetryAdvice::RetryAffectedRoutes)
+    } else {
+        (false, RefreshRetryAdvice::InspectSources)
+    })
 }
 
 fn valid_retry_contract(
     code: RefreshOutcomeCode,
-    class: RefreshOutcomeClass,
     retryable: bool,
     retry_advice: Option<RefreshRetryAdvice>,
 ) -> bool {
-    if let Some(paused) = RefreshTerminalOutcome::automatic_retry_disposition(code, class, false) {
+    if let Some(paused) = automatic_retry_disposition(code, false) {
         if Some(paused) == retry_advice.map(|advice| (retryable, advice)) {
             return true;
         }
@@ -98,18 +383,8 @@ fn valid_retry_contract(
         RefreshOutcomeCode::CompletedWithRejections
         | RefreshOutcomeCode::CompletedWithSourceFailures
         | RefreshOutcomeCode::CompletedWithRejectionsAndSourceFailures => matches!(
-            (class, retryable, retry_advice),
-            (RefreshOutcomeClass::CompletedWithDiagnostics, false, None)
-                | (
-                    RefreshOutcomeClass::CompletedWithRetryableFailures,
-                    true,
-                    None,
-                )
-                | (
-                    RefreshOutcomeClass::CompletedWithRetryableFailures,
-                    true,
-                    Some(RefreshRetryAdvice::RetryAffectedRoutes),
-                )
+            (retryable, retry_advice),
+            (false, None) | (true, None) | (true, Some(RefreshRetryAdvice::RetryAffectedRoutes))
         ),
         RefreshOutcomeCode::SourceUnavailable | RefreshOutcomeCode::SourceChanged => {
             retryable
@@ -134,20 +409,18 @@ fn valid_retry_contract(
                     )
                 })
         }
-        RefreshOutcomeCode::SourceFailures | RefreshOutcomeCode::LogicalSourceFailures => {
-            matches!(
-                (retryable, retry_advice),
-                (true, None)
-                    | (true, Some(RefreshRetryAdvice::RetryAffectedRoutes))
-                    | (false, None)
-                    | (false, Some(RefreshRetryAdvice::InspectSources))
-            )
-        }
+        RefreshOutcomeCode::SourceFailures | RefreshOutcomeCode::LogicalSourceFailures => matches!(
+            (retryable, retry_advice),
+            (true, None)
+                | (true, Some(RefreshRetryAdvice::RetryAffectedRoutes))
+                | (false, None)
+                | (false, Some(RefreshRetryAdvice::InspectSources))
+        ),
         RefreshOutcomeCode::SourceUnclaimed => matches!(
             (retryable, retry_advice),
             (
                 true,
-                Some(RefreshRetryAdvice::RetryRetryableRoutesAndInspectBlocked),
+                Some(RefreshRetryAdvice::RetryRetryableRoutesAndInspectBlocked)
             ) | (false, Some(RefreshRetryAdvice::InspectSources))
         ),
         RefreshOutcomeCode::SourceRefreshFailed => matches!(
@@ -181,43 +454,6 @@ fn valid_retry_contract(
     }
 }
 
-const fn valid_code_class(code: RefreshOutcomeCode, class: RefreshOutcomeClass) -> bool {
-    match code {
-        RefreshOutcomeCode::Completed => matches!(class, RefreshOutcomeClass::Completed),
-        RefreshOutcomeCode::CompletedWithRejections
-        | RefreshOutcomeCode::CompletedWithSourceFailures
-        | RefreshOutcomeCode::CompletedWithRejectionsAndSourceFailures => matches!(
-            class,
-            RefreshOutcomeClass::CompletedWithRetryableFailures
-                | RefreshOutcomeClass::CompletedWithDiagnostics
-        ),
-        RefreshOutcomeCode::SourceUnavailable | RefreshOutcomeCode::ExplicitSourcePathMissing => {
-            matches!(class, RefreshOutcomeClass::Unavailable)
-        }
-        RefreshOutcomeCode::SourceChanged => matches!(class, RefreshOutcomeClass::SourceChanged),
-        RefreshOutcomeCode::MalformedSource => matches!(class, RefreshOutcomeClass::Unreadable),
-        RefreshOutcomeCode::UnsupportedSchema | RefreshOutcomeCode::IndexIncompatible => {
-            matches!(class, RefreshOutcomeClass::Incompatible)
-        }
-        RefreshOutcomeCode::SourceFailures | RefreshOutcomeCode::LogicalSourceFailures => {
-            matches!(class, RefreshOutcomeClass::Mixed)
-        }
-        RefreshOutcomeCode::SourceUnclaimed
-        | RefreshOutcomeCode::AllProviderTerminalCoverageUnavailable => {
-            matches!(class, RefreshOutcomeClass::Coverage)
-        }
-        RefreshOutcomeCode::SourceRefreshFailed | RefreshOutcomeCode::SourceRefreshInternal => {
-            matches!(class, RefreshOutcomeClass::Internal)
-        }
-        RefreshOutcomeCode::ResourceUnavailable => {
-            matches!(class, RefreshOutcomeClass::ResourceUnavailable)
-        }
-        RefreshOutcomeCode::IndexCorruption => matches!(class, RefreshOutcomeClass::Corruption),
-        RefreshOutcomeCode::SourceRefreshAdmissionFailed => {
-            matches!(class, RefreshOutcomeClass::ControlPlane)
-        }
-    }
-}
-
 #[cfg(test)]
+#[path = "terminal_outcome/tests.rs"]
 mod tests;

--- a/crates/ctx-history-refresh/src/request/terminal_outcome/tests.rs
+++ b/crates/ctx-history-refresh/src/request/terminal_outcome/tests.rs
@@ -1,75 +1,105 @@
 use super::*;
 
-fn nonretryable_outcome(
-    code: RefreshOutcomeCode,
-    class: RefreshOutcomeClass,
-) -> RefreshTerminalOutcome {
-    let route = SourceRouteIdentity::from_sha256("ab".repeat(32)).unwrap();
-    RefreshTerminalOutcome {
+fn route(byte: &str) -> SourceRouteIdentity {
+    SourceRouteIdentity::from_sha256(byte.repeat(32)).unwrap()
+}
+
+fn paused(code: RefreshOutcomeCode) -> Result<RefreshTerminalOutcome> {
+    RefreshTerminalOutcome::with_uniform_route_disposition(
         code,
-        class,
-        retryable: false,
-        affected_routes: BTreeSet::from([route.clone()]),
-        retryable_routes: BTreeSet::new(),
-        blocked_routes: BTreeSet::from([route]),
-        physical_attempt_id: "physical-attempt".to_owned(),
-        retained_generation: None,
-        published_generation: None,
-        retry_advice: Some(RefreshRetryAdvice::InspectSources),
-        detail: None,
+        false,
+        BTreeSet::from([route("ab")]),
+        uuid::Uuid::nil().to_string(),
+        None,
+        None,
+        Some(RefreshRetryAdvice::InspectSources),
+        None,
+    )
+}
+
+#[test]
+fn paused_automatic_terminal_outcomes_and_aggregate_schema_advice_are_valid() {
+    assert!(paused(RefreshOutcomeCode::SourceRefreshFailed).is_ok());
+    assert!(paused(RefreshOutcomeCode::AllProviderTerminalCoverageUnavailable).is_ok());
+    for advice in [
+        RefreshRetryAdvice::InspectSources,
+        RefreshRetryAdvice::UpgradeOrReconfigure,
+    ] {
+        assert!(RefreshTerminalOutcome::with_uniform_route_disposition(
+            RefreshOutcomeCode::UnsupportedSchema,
+            false,
+            BTreeSet::from([route("ab")]),
+            uuid::Uuid::nil().to_string(),
+            None,
+            None,
+            Some(advice),
+            None,
+        )
+        .is_ok());
     }
 }
 
 #[test]
-fn automatic_retry_pause_contract_is_closed() {
-    for (code, class) in [
-        (
-            RefreshOutcomeCode::SourceRefreshFailed,
-            RefreshOutcomeClass::Internal,
-        ),
-        (
-            RefreshOutcomeCode::AllProviderTerminalCoverageUnavailable,
-            RefreshOutcomeClass::Coverage,
-        ),
-    ] {
-        assert_eq!(
-            RefreshTerminalOutcome::automatic_retry_disposition(code, class, false),
-            Some((false, RefreshRetryAdvice::InspectSources)),
-        );
-        assert_eq!(
-            RefreshTerminalOutcome::automatic_retry_disposition(code, class, true),
-            Some((true, RefreshRetryAdvice::RetryAffectedRoutes)),
-        );
-        assert!(nonretryable_outcome(code, class).validate().is_ok());
-    }
-
-    assert_eq!(
-        RefreshTerminalOutcome::automatic_retry_disposition(
-            RefreshOutcomeCode::SourceRefreshInternal,
-            RefreshOutcomeClass::Internal,
-            false,
-        ),
+fn retry_route_moves_ignore_empty_and_unrelated_sets() {
+    let affected = route("ab");
+    let unrelated = BTreeSet::from([route("cd")]);
+    let mut outcome = RefreshTerminalOutcome::with_uniform_route_disposition(
+        RefreshOutcomeCode::SourceRefreshFailed,
+        true,
+        BTreeSet::from([affected.clone()]),
+        uuid::Uuid::nil().to_string(),
         None,
-    );
-    assert!(nonretryable_outcome(
-        RefreshOutcomeCode::SourceRefreshInternal,
-        RefreshOutcomeClass::Internal,
+        None,
+        Some(RefreshRetryAdvice::RetryAffectedRoutes),
+        None,
     )
-    .validate()
+    .unwrap();
+
+    let retryable = outcome.clone();
+    outcome.pause_automatic_retry_routes(&BTreeSet::new());
+    outcome.pause_automatic_retry_routes(&unrelated);
+    assert_eq!(outcome, retryable);
+
+    outcome.pause_automatic_retry_routes(&BTreeSet::from([affected]));
+    let paused = outcome.clone();
+    outcome.rearm_automatic_retry_routes(&BTreeSet::new());
+    outcome.rearm_automatic_retry_routes(&unrelated);
+    assert_eq!(outcome, paused);
+}
+
+#[test]
+fn completed_outcomes_reject_failure_facts_at_the_boundary() {
+    assert!(RefreshTerminalOutcome::new(
+        RefreshOutcomeCode::Completed,
+        false,
+        BTreeSet::from([route("ab")]),
+        BTreeSet::new(),
+        BTreeSet::from([route("ab")]),
+        uuid::Uuid::nil().to_string(),
+        None,
+        Some("generation".to_owned()),
+        Some(RefreshRetryAdvice::InspectSources),
+        Some("not a completed outcome".to_owned()),
+    )
     .is_err());
 }
 
 #[test]
-fn unsupported_schema_accepts_direct_and_aggregate_advice() {
-    let mut outcome = nonretryable_outcome(
-        RefreshOutcomeCode::UnsupportedSchema,
-        RefreshOutcomeClass::Incompatible,
+fn successful_outcomes_require_a_published_generation() {
+    let error = RefreshTerminalOutcome::with_uniform_route_disposition(
+        RefreshOutcomeCode::Completed,
+        false,
+        BTreeSet::new(),
+        uuid::Uuid::nil().to_string(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "successful source refresh outcome has no published generation"
     );
-    for advice in [
-        RefreshRetryAdvice::UpgradeOrReconfigure,
-        RefreshRetryAdvice::InspectSources,
-    ] {
-        outcome.retry_advice = Some(advice);
-        assert!(outcome.validate().is_ok(), "{advice:?}");
-    }
 }

--- a/crates/ctx-terminal/src/progress/tests.rs
+++ b/crates/ctx-terminal/src/progress/tests.rs
@@ -108,7 +108,7 @@ fn terminal_status() -> RefreshProgressSnapshot {
         crate::ui::RefreshRequestState::Published,
         "completed",
         "completed",
-        false,
+        crate::ui::RefreshTerminalPresentation::Complete,
     )
 }
 
@@ -116,7 +116,7 @@ fn terminal_status_with(
     state: crate::ui::RefreshRequestState,
     code: &str,
     class: &str,
-    failure: bool,
+    presentation: crate::ui::RefreshTerminalPresentation,
 ) -> RefreshProgressSnapshot {
     RefreshProgressSnapshot::new(
         Some("logical-request".to_owned()),
@@ -139,7 +139,7 @@ fn terminal_status_with(
                 published_generation: None,
                 retry_advice: None,
                 detail: None,
-                failure,
+                presentation,
             })),
         }),
         crate::ui::RefreshProgress {
@@ -373,7 +373,7 @@ fn failed_setup_snapshot_is_failed_in_json_and_live_presentation() {
         crate::ui::RefreshRequestState::Failed,
         "source_refresh_failed",
         "internal",
-        true,
+        crate::ui::RefreshTerminalPresentation::Failed,
     );
     snapshot.use_setup_live_presentation();
     let context = crate::ui::RenderContext::for_test(crate::ui::TestContext::tty(

--- a/crates/ctx-terminal/src/ui/components/mod.rs
+++ b/crates/ctx-terminal/src/ui/components/mod.rs
@@ -23,7 +23,8 @@ pub use progress::{progress, Progress};
 pub use refresh_progress::{
     refresh_progress, RefreshCurrentSourceProgress, RefreshCurrentSourceProgressStage,
     RefreshLogicalPhase, RefreshLogicalStatus, RefreshProgress, RefreshProgressSnapshot,
-    RefreshRequestState, RefreshStatusKind, RefreshStructuredOutcome, RefreshWholeRunStage,
+    RefreshRequestState, RefreshStatusKind, RefreshStructuredOutcome, RefreshTerminalPresentation,
+    RefreshWholeRunStage,
 };
 pub use section::section;
 pub use table::{table, Table};

--- a/crates/ctx-terminal/src/ui/components/refresh_progress.rs
+++ b/crates/ctx-terminal/src/ui/components/refresh_progress.rs
@@ -294,13 +294,16 @@ pub struct RefreshStructuredOutcome {
     pub published_generation: Option<String>,
     pub retry_advice: Option<String>,
     pub detail: Option<String>,
-    pub failure: bool,
+    pub presentation: RefreshTerminalPresentation,
 }
-impl RefreshStructuredOutcome {
-    fn is_failure(&self) -> bool {
-        self.failure
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefreshTerminalPresentation {
+    Complete,
+    CompleteWithIssues,
+    Failed,
+}
 
+impl RefreshStructuredOutcome {
     fn to_json(&self) -> Value {
         let mut value = json!({
             "code": self.code,
@@ -727,17 +730,12 @@ fn terminal_label(logical: &RefreshLogicalStatus) -> &'static str {
     logical
         .structured_outcome
         .as_ref()
-        .map(|outcome| {
-            if outcome.is_failure() {
-                "History refresh failed"
-            } else if matches!(
-                outcome.code.as_str(),
-                "completed" | "completed_with_rejections"
-            ) {
-                "History refresh complete"
-            } else {
+        .map(|outcome| match outcome.presentation {
+            RefreshTerminalPresentation::Complete => "History refresh complete",
+            RefreshTerminalPresentation::CompleteWithIssues => {
                 "History refresh complete with issues"
             }
+            RefreshTerminalPresentation::Failed => "History refresh failed",
         })
         .unwrap_or("History refresh complete")
 }

--- a/crates/ctx-terminal/src/ui/components/refresh_progress/tests.rs
+++ b/crates/ctx-terminal/src/ui/components/refresh_progress/tests.rs
@@ -49,7 +49,7 @@ fn terminal_status(
     state: RefreshRequestState,
     code: &str,
     class: &str,
-    failure: bool,
+    presentation: RefreshTerminalPresentation,
 ) -> RefreshProgressSnapshot {
     RefreshProgressSnapshot::new(
         Some("logical-request".to_owned()),
@@ -72,7 +72,7 @@ fn terminal_status(
                 published_generation: None,
                 retry_advice: None,
                 detail: None,
-                failure,
+                presentation,
             })),
         }),
         RefreshProgress {
@@ -309,7 +309,7 @@ fn presentation_eta_honors_usefulness_floor_and_terminal_state() {
         RefreshRequestState::Published,
         "completed",
         "completed",
-        false,
+        RefreshTerminalPresentation::Complete,
     );
     terminal.progress.elapsed_millis = Some(1_000);
     terminal.progress.estimated_remaining_millis = Some(2_100);
@@ -327,7 +327,7 @@ fn setup_terminal_reconciles_empty_refresh_counters_with_committed_history() {
         RefreshRequestState::Published,
         "completed",
         "completed",
-        false,
+        RefreshTerminalPresentation::Complete,
     );
     terminal.set_presentation_agent_histories(Some(vec!["Codex".to_owned()]));
     terminal.set_terminal_history_totals(2, 5, 1, 2_346);
@@ -416,7 +416,7 @@ fn terminal_state_ignores_stale_activity_and_preserves_authoritative_counters() 
         RefreshRequestState::Published,
         "completed",
         "completed",
-        false,
+        RefreshTerminalPresentation::Complete,
     );
     snapshot.progress.current_source_progress = Some(RefreshCurrentSourceProgress {
         stage: RefreshCurrentSourceProgressStage::IndexWriting,
@@ -490,7 +490,7 @@ fn setup_terminal_omits_stale_estimated_remaining_row() {
         RefreshRequestState::Published,
         "completed",
         "completed",
-        false,
+        RefreshTerminalPresentation::Complete,
     );
     snapshot.progress.estimated_remaining_millis = Some(5_000);
     snapshot.set_presentation_agent_histories(Some(vec!["Codex".to_owned()]));
@@ -539,26 +539,33 @@ fn structured_terminal_outcome_alone_decides_done() {
             RefreshRequestState::Published,
             "completed",
             "completed",
-            false,
+            RefreshTerminalPresentation::Complete,
             "History refresh complete",
         ),
         (
             RefreshRequestState::Published,
             "completed_with_rejections",
             "completed_with_diagnostics",
-            false,
+            RefreshTerminalPresentation::Complete,
             "History refresh complete",
+        ),
+        (
+            RefreshRequestState::Published,
+            "completed_with_source_failures",
+            "completed_with_diagnostics",
+            RefreshTerminalPresentation::CompleteWithIssues,
+            "History refresh complete with issues",
         ),
         (
             RefreshRequestState::Failed,
             "source_refresh_failed",
             "internal",
-            true,
+            RefreshTerminalPresentation::Failed,
             "History refresh failed",
         ),
     ];
-    for (state, code, class, failure, label) in cases {
-        let snapshot = terminal_status(state, code, class, failure);
+    for (state, code, class, presentation, label) in cases {
+        let snapshot = terminal_status(state, code, class, presentation);
         assert!(snapshot.is_terminal());
         assert_eq!(machine_refresh_label(&snapshot), label);
     }

--- a/crates/ctx-terminal/src/ui/mod.rs
+++ b/crates/ctx-terminal/src/ui/mod.rs
@@ -20,7 +20,7 @@ pub use components::{
     Outcome, OutcomeState, Progress, RefreshCurrentSourceProgress,
     RefreshCurrentSourceProgressStage, RefreshLogicalPhase, RefreshLogicalStatus, RefreshProgress,
     RefreshProgressSnapshot, RefreshRequestState, RefreshStatusKind, RefreshStructuredOutcome,
-    RefreshWholeRunStage, Table,
+    RefreshTerminalPresentation, RefreshWholeRunStage, Table,
 };
 pub use context::{ColorMode, RenderContext, StreamKind, TestContext};
 pub use document::{sanitize_untrusted_history_body_for_terminal, Document, Line, Span};


### PR DESCRIPTION
Follow up #876 by making `RefreshTerminalOutcome` the only failure-semantic owner across the engine, recovery, progress, final Core responses, and terminal presentation. This removes the parallel engine failure object, duplicate class/legality/projection machinery, and 290 net test lines. Successful publication remains owned by its verified receipt and is projected infallibly rather than stored twice.

The existing wire inventory is byte-identical. The change also closes review-found gaps in retry no-op behavior, legacy detail recovery, final response keys, and Published/Failed state-to-outcome generation consistency.

LOC versus main:
- production: 813 additions, 772 deletions (+41)
- tests: 393 additions, 683 deletions (-290)
- total: 1,206 additions, 1,455 deletions (-249)

Validation:
- six owning Bazel suites: 1,155 passed, 2 ignored
- focused canonical outcome, recovery, daemon boundary, parity, inventory, import, and terminal presentation tests
- strict Clippy on affected crates and ctx
- repository LOC/Cargo-Bazel ownership and exact-head size gates
- cargo fmt --check and git diff --check
- independent exact-head review: SHIP