### PR TITLE
fix(upgrade): make managed pair finalization crash safe

### DIFF
--- a/crates/ctx-cli/src/core_capability.rs
+++ b/crates/ctx-cli/src/core_capability.rs
@@ -25,6 +25,8 @@ use sha2::{Digest as _, Sha256};
 
 mod failure;
 mod managed_pair_apply;
+#[cfg(unix)]
+mod managed_pair_reconcile;
 mod progress_events;
 mod setup_options;
 mod setup_refresh;
@@ -42,6 +44,8 @@ use setup_refresh::{
 
 const INVOCATION: &str = "--ctx-core-capability-v1";
 const MANAGED_PAIR_APPLY_INVOCATION: &str = "--ctx-core-managed-pair-apply-v1";
+#[cfg(unix)]
+const MANAGED_PAIR_RECONCILE_INVOCATION: &str = "--ctx-core-managed-pair-reconcile-integration-v1";
 const HOSTED_UNINSTALL_POST_EXIT_INVOCATION: &str = "--ctx-core-hosted-uninstall-after-parent-v1";
 const DISABLE_MAN_PAGES_INVOCATION: &str = "--ctx-core-disable-managed-man-pages-v1";
 const MAX_FRAME_BYTES: usize = 64 * 1024;
@@ -106,6 +110,19 @@ pub(crate) fn intercept(arguments: &[std::ffi::OsString]) -> Option<ExitCode> {
         .is_some_and(|value| value == MANAGED_PAIR_APPLY_INVOCATION)
     {
         return Some(match managed_pair_apply::run(arguments) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(error) => {
+                eprintln!("{error:#}");
+                ExitCode::FAILURE
+            }
+        });
+    }
+    #[cfg(unix)]
+    if arguments
+        .get(1)
+        .is_some_and(|value| value == MANAGED_PAIR_RECONCILE_INVOCATION)
+    {
+        return Some(match managed_pair_reconcile::run(arguments) {
             Ok(()) => ExitCode::SUCCESS,
             Err(error) => {
                 eprintln!("{error:#}");

--- a/crates/ctx-cli/src/core_capability/contract_tests/managed_pair_apply_contract_tests.rs
+++ b/crates/ctx-cli/src/core_capability/contract_tests/managed_pair_apply_contract_tests.rs
@@ -133,6 +133,8 @@ impl ArgFixture {
 #[test]
 fn only_the_exact_apply_argv_is_intercepted() {
     assert!(intercept(&["ctx".into(), MANAGED_PAIR_APPLY_INVOCATION.into()]).is_some());
+    #[cfg(unix)]
+    assert!(intercept(&["ctx".into(), MANAGED_PAIR_RECONCILE_INVOCATION.into(),]).is_some());
     for removed in [
         "--ctx-core-hosted-pair-install-v1",
         "--ctx-core-managed-pair-swap-v1",
@@ -142,6 +144,18 @@ fn only_the_exact_apply_argv_is_intercepted() {
     }
     assert!(intercept(&["ctx".into(), "--ctx-core-managed-pair-apply-v1=x".into(),]).is_none());
     assert!(intercept(&["ctx".into(), INVOCATION.into()]).is_some());
+}
+
+#[cfg(unix)]
+#[test]
+fn reconciliation_receipt_is_the_exact_bounded_typed_json_object() {
+    let expected = br#"{"schema_version":1,"command":"managed_pair_reconcile_integration","ok":true,"status":"committed"}"#;
+    let receipt = super::super::managed_pair_reconcile::success_receipt();
+    assert_eq!(receipt, expected);
+    assert!(receipt.len() < MAX_RESPONSE_BYTES);
+    let mut stdout = Vec::new();
+    write_response_frame(&mut stdout, receipt).unwrap();
+    assert_eq!(stdout, [expected.as_slice(), b"\n"].concat());
 }
 
 #[test]

--- a/crates/ctx-cli/src/core_capability/managed_pair_apply.rs
+++ b/crates/ctx-cli/src/core_capability/managed_pair_apply.rs
@@ -243,7 +243,7 @@ fn read_bounded_regular_file(path: &Path, maximum: u64, label: &str) -> Result<V
     fs::read(path).with_context(|| format!("read {label}"))
 }
 
-fn normalized_absolute_path(value: &OsStr, label: &str) -> Result<PathBuf> {
+pub(super) fn normalized_absolute_path(value: &OsStr, label: &str) -> Result<PathBuf> {
     if value.as_encoded_bytes().len() > MAX_PATH_BYTES || value.as_encoded_bytes().contains(&0) {
         bail!("managed-pair {label} path exceeds its bound");
     }
@@ -263,7 +263,7 @@ fn normalized_absolute_path(value: &OsStr, label: &str) -> Result<PathBuf> {
     Ok(path)
 }
 
-fn require_directory(path: &Path, label: &str) -> Result<()> {
+pub(super) fn require_directory(path: &Path, label: &str) -> Result<()> {
     let metadata = fs::symlink_metadata(path).with_context(|| format!("inspect {label}"))?;
     if !metadata.is_dir() || metadata.file_type().is_symlink() {
         bail!("managed-pair {label} must be a directory");
@@ -271,7 +271,7 @@ fn require_directory(path: &Path, label: &str) -> Result<()> {
     Ok(())
 }
 
-fn require_regular_file(path: &Path, label: &str) -> Result<()> {
+pub(super) fn require_regular_file(path: &Path, label: &str) -> Result<()> {
     let metadata = fs::symlink_metadata(path).with_context(|| format!("inspect {label}"))?;
     if !metadata.is_file() || metadata.file_type().is_symlink() {
         bail!("managed-pair {label} must be a regular file");

--- a/crates/ctx-cli/src/core_capability/managed_pair_reconcile.rs
+++ b/crates/ctx-cli/src/core_capability/managed_pair_reconcile.rs
@@ -1,0 +1,71 @@
+use std::ffi::OsStr;
+
+use anyhow::{anyhow, bail, Context as _, Result};
+use ctx_upgrade_engine::{
+    ensure_hosted_transaction_inactive_under_installation_lock,
+    inspect_managed_pair_under_installation_lock, managed_install_marker_for_current_exe,
+    reconcile_managed_pair_integration_under_installation_lock,
+    try_acquire_managed_installation_mutation_at_root, ManagedInstallMarker,
+    ManagedPairInstallationStatus,
+};
+
+use super::{
+    managed_pair_apply::{
+        managed_core_destination, marker_channel, normalized_absolute_path, require_directory,
+        require_regular_file,
+    },
+    write_response_frame, CoreManagedPairVerifier,
+};
+
+const ARGUMENT_COUNT: usize = 5;
+const SUCCESS_RECEIPT: &[u8] = br#"{"schema_version":1,"command":"managed_pair_reconcile_integration","ok":true,"status":"committed"}"#;
+
+pub(super) const fn success_receipt() -> &'static [u8] {
+    SUCCESS_RECEIPT
+}
+
+pub(super) fn run(arguments: &[std::ffi::OsString]) -> Result<()> {
+    if arguments.len() != ARGUMENT_COUNT || arguments[3] != OsStr::new("-") {
+        bail!("invalid managed-pair reconciliation invocation");
+    }
+    let install_root = normalized_absolute_path(&arguments[2], "install root")?;
+    let integration = normalized_absolute_path(&arguments[4], "integration ownership")?;
+    require_directory(&install_root, "install root")?;
+    require_regular_file(&integration, "integration ownership")?;
+    let current = std::env::current_exe().context("resolve running managed Core")?;
+    if !ctx_upgrade_engine::managed_install_path_identity_matches(
+        &current,
+        &managed_core_destination(&install_root),
+    ) {
+        bail!("managed-pair reconciliation must run from the installed Core");
+    }
+    let _guard = try_acquire_managed_installation_mutation_at_root(&install_root)?
+        .ok_or_else(|| anyhow!("managed-pair installation is busy"))?;
+    let active_marker = match managed_install_marker_for_current_exe()? {
+        ManagedInstallMarker::Valid(marker)
+            if ctx_upgrade_engine::managed_install_path_identity_matches(
+                &marker.install_path,
+                &managed_core_destination(&install_root),
+            ) =>
+        {
+            marker
+        }
+        ManagedInstallMarker::Valid(_) => {
+            bail!("managed-pair reconciliation install root does not own the running Core")
+        }
+        ManagedInstallMarker::Absent => bail!("managed Core install marker is absent"),
+        ManagedInstallMarker::Invalid { reason } => bail!(reason),
+    };
+    let verifier = CoreManagedPairVerifier::for_channel(marker_channel(&active_marker)?);
+    ensure_hosted_transaction_inactive_under_installation_lock(&managed_core_destination(
+        &install_root,
+    ))?;
+    if !matches!(
+        inspect_managed_pair_under_installation_lock(&install_root, &verifier)?,
+        ManagedPairInstallationStatus::Healthy { .. }
+    ) {
+        bail!("managed-pair reconciliation requires an installed signed pair");
+    }
+    reconcile_managed_pair_integration_under_installation_lock(&install_root, &integration)?;
+    write_response_frame(std::io::stdout().lock(), success_receipt())
+}

--- a/crates/ctx-managed-pair-engine/src/filesystem.rs
+++ b/crates/ctx-managed-pair-engine/src/filesystem.rs
@@ -23,6 +23,8 @@ pub(super) enum Slot {
     Marker,
     Envelope,
     State,
+    #[cfg(unix)]
+    Integration,
 }
 
 impl Slot {
@@ -41,6 +43,8 @@ impl Slot {
             Self::Marker => "managed Core install marker",
             Self::Envelope => "managed-pair signed envelope",
             Self::State => "managed-pair state marker",
+            #[cfg(unix)]
+            Self::Integration => "managed integration ownership",
         }
     }
 
@@ -53,6 +57,8 @@ impl Slot {
             Self::Marker => MANAGED_CORE_INSTALL_MARKER_RELATIVE_PATH,
             Self::Envelope => MANAGED_PAIR_ENVELOPE_RELATIVE_PATH,
             Self::State => MANAGED_PAIR_STATE_RELATIVE_PATH,
+            #[cfg(unix)]
+            Self::Integration => "bin/ctx.install-integrations",
         }
     }
 }
@@ -84,7 +90,7 @@ impl Entry {
         })
     }
 
-    fn sibling(&self, name: OsString) -> Self {
+    pub(super) fn sibling(&self, name: OsString) -> Self {
         Self {
             path: self.path.with_file_name(&name),
             name,
@@ -191,6 +197,8 @@ impl Layout {
     pub(super) fn target(&self, slot: Slot) -> Entry {
         let directory = match slot {
             Slot::Core | Slot::Marker => Arc::clone(&self.bin_directory),
+            #[cfg(unix)]
+            Slot::Integration => Arc::clone(&self.bin_directory),
             Slot::Companion => Arc::clone(&self.libexec_directory),
             Slot::Envelope | Slot::State => Arc::clone(&self.ctx_directory),
         };
@@ -570,6 +578,14 @@ pub(super) fn protect_regular(entry: &Entry, executable: bool, label: &str) -> R
 
 pub(super) fn stamp_optional(entry: &Entry, max: u64, label: &str) -> Result<Option<FileStamp>> {
     stamp_optional_impl(entry, max, label, false)
+}
+
+pub(super) fn stamp_temporary_optional(
+    entry: &Entry,
+    max: u64,
+    label: &str,
+) -> Result<Option<FileStamp>> {
+    stamp_optional_impl(entry, max, label, true)
 }
 
 fn stamp_optional_impl(

--- a/crates/ctx-managed-pair-engine/src/fix_forward.rs
+++ b/crates/ctx-managed-pair-engine/src/fix_forward.rs
@@ -117,13 +117,13 @@ impl ManagedPairApplyOutcome {
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-struct ContentIdentity {
-    sha256: String,
-    size_bytes: u64,
+pub(super) struct ContentIdentity {
+    pub(super) sha256: String,
+    pub(super) size_bytes: u64,
 }
 
 impl ContentIdentity {
-    fn from_observed(observed: &ObservedFile) -> Self {
+    pub(super) fn from_observed(observed: &ObservedFile) -> Self {
         Self {
             sha256: observed.stamp.sha256.clone(),
             size_bytes: observed.stamp.size_bytes,
@@ -144,7 +144,7 @@ impl ContentIdentity {
         })
     }
 
-    fn matches(&self, stamp: &FileStamp) -> bool {
+    pub(super) fn matches(&self, stamp: &FileStamp) -> bool {
         self.size_bytes == stamp.size_bytes && self.sha256 == stamp.sha256
     }
 

--- a/crates/ctx-managed-pair-engine/src/lib.rs
+++ b/crates/ctx-managed-pair-engine/src/lib.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 
 mod filesystem;
 mod fix_forward;
+#[cfg(unix)]
+mod reconciliation;
 
 pub use fix_forward::{
     apply_or_resume_managed_pair_under_installation_lock,
@@ -18,6 +20,11 @@ pub use fix_forward::{
     resume_pending_managed_pair_under_installation_lock,
     stage_managed_pair_under_installation_lock, ManagedPairApplyInput, ManagedPairApplyOutcome,
     ManagedPairInstallationStatus, ManagedPairStageOutcome,
+};
+#[cfg(unix)]
+pub use reconciliation::{
+    publish_managed_pair_integration_generation_under_installation_lock,
+    remove_managed_pair_integration_binding_under_installation_lock,
 };
 
 pub const MANAGED_PAIR_ENVELOPE_RELATIVE_PATH: &str = "share/ctx/managed-pair-envelope.json";
@@ -38,6 +45,8 @@ const MAX_COMPONENT_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_ENVELOPE_BYTES: u64 = 2 * 1024 * 1024;
 const MAX_MARKER_BYTES: u64 = 64 * 1024;
 const MAX_STATE_BYTES: u64 = 64 * 1024;
+#[cfg(unix)]
+const MAX_INTEGRATION_BYTES: u64 = 1024 * 1024;
 
 /// The fixed release target returned by a trusted signed-envelope verifier.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
@@ -288,6 +297,8 @@ fn max_bytes(slot: filesystem::Slot) -> u64 {
     match slot {
         filesystem::Slot::Core | filesystem::Slot::Companion => MAX_COMPONENT_BYTES,
         filesystem::Slot::Marker => MAX_MARKER_BYTES,
+        #[cfg(unix)]
+        filesystem::Slot::Integration => MAX_INTEGRATION_BYTES,
         filesystem::Slot::Envelope => MAX_ENVELOPE_BYTES,
         filesystem::Slot::State => MAX_STATE_BYTES,
     }

--- a/crates/ctx-managed-pair-engine/src/reconciliation.rs
+++ b/crates/ctx-managed-pair-engine/src/reconciliation.rs
@@ -1,0 +1,149 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Result};
+
+use super::{
+    filesystem::{self, Entry, Layout, Slot},
+    fix_forward::ContentIdentity,
+    validate_sha256, MAX_INTEGRATION_BYTES,
+};
+
+/// Publishes opaque integration ownership as an immutable digest generation.
+///
+/// The caller holds the canonical installation lock. Marker authority stays
+/// with the upgrade engine: this operation only makes the bytes available for
+/// a later atomic marker update.
+pub fn publish_managed_pair_integration_generation_under_installation_lock(
+    install_root: &Path,
+    integration_source: &Path,
+) -> Result<(PathBuf, String)> {
+    filesystem::validate_absolute_root(install_root, "managed-pair install root")?;
+    let layout = Layout::open(install_root, false)?;
+    let source = filesystem::external_entry(integration_source, "managed integration ownership")?;
+    let observed = filesystem::read_regular(
+        &source,
+        MAX_INTEGRATION_BYTES,
+        "managed integration ownership",
+    )?;
+    let expected = ContentIdentity::from_observed(&observed);
+    let base = layout.target(Slot::Integration);
+    let generation = base.sibling(
+        format!(
+            "{}.{}",
+            base.file_name().unwrap().to_string_lossy(),
+            expected.sha256
+        )
+        .into(),
+    );
+    publish_generation(&layout, &source, &generation, &expected)?;
+    Ok((generation.as_ref().to_path_buf(), expected.sha256))
+}
+
+/// Removes only the exact prior marker-bound integration object.
+///
+/// The caller holds the canonical installation lock and has already replaced
+/// marker authority with another generation.
+pub fn remove_managed_pair_integration_binding_under_installation_lock(
+    install_root: &Path,
+    prior_path: &Path,
+    prior_sha256: &str,
+) -> Result<()> {
+    filesystem::validate_absolute_root(install_root, "managed-pair install root")?;
+    validate_sha256(prior_sha256, "managed integration ownership")?;
+    let layout = Layout::open(install_root, false)?;
+    let fixed = layout.target(Slot::Integration);
+    let generation = fixed.sibling(
+        format!(
+            "{}.{}",
+            fixed.file_name().unwrap().to_string_lossy(),
+            prior_sha256
+        )
+        .into(),
+    );
+    let prior = if prior_path == fixed.as_ref() {
+        fixed
+    } else if prior_path == generation.as_ref() {
+        generation
+    } else {
+        bail!("prior managed integration ownership path is not canonical")
+    };
+    let label = "prior managed integration ownership";
+    let Some(stamp) = filesystem::stamp_optional(&prior, MAX_INTEGRATION_BYTES, label)? else {
+        return Ok(());
+    };
+    if stamp.sha256 != prior_sha256 {
+        bail!("prior managed integration ownership changed");
+    }
+    filesystem::remove_if_exact(&prior, &stamp, MAX_INTEGRATION_BYTES, label)?;
+    layout.revalidate()
+}
+
+fn publish_generation(
+    layout: &Layout,
+    source: &Entry,
+    generation: &Entry,
+    expected: &ContentIdentity,
+) -> Result<()> {
+    let label = "managed integration ownership generation";
+    if let Some(stamp) = filesystem::stamp_optional(generation, MAX_INTEGRATION_BYTES, label)? {
+        if !expected.matches(&stamp) {
+            bail!("managed integration ownership generation changed");
+        }
+        filesystem::protect_regular(generation, false, label)?;
+        return layout.revalidate();
+    }
+
+    let temporary = generation
+        .sibling(format!(".{}.new", generation.file_name().unwrap().to_string_lossy()).into());
+    let stamp = match filesystem::stamp_temporary_optional(
+        &temporary,
+        MAX_INTEGRATION_BYTES,
+        "managed integration ownership generation temporary",
+    )? {
+        Some(stamp) if expected.matches(&stamp) => stamp,
+        Some(stamp) => {
+            filesystem::remove_temporary_exact(
+                &temporary,
+                &stamp,
+                MAX_INTEGRATION_BYTES,
+                "managed integration ownership generation temporary",
+            )?;
+            copy_generation_source(source, &temporary, expected, label)?
+        }
+        None => copy_generation_source(source, &temporary, expected, label)?,
+    };
+    filesystem::durable_replace(&temporary, generation, &stamp, MAX_INTEGRATION_BYTES, label)?;
+    filesystem::protect_regular(generation, false, label)?;
+    if !filesystem::stamp_optional(generation, MAX_INTEGRATION_BYTES, label)?
+        .as_ref()
+        .is_some_and(|actual| expected.matches(actual))
+    {
+        bail!("published managed integration ownership generation changed");
+    }
+    layout.revalidate()
+}
+
+fn copy_generation_source(
+    source: &Entry,
+    temporary: &Entry,
+    expected: &ContentIdentity,
+    label: &str,
+) -> Result<filesystem::FileStamp> {
+    let source_stamp = filesystem::stamp_optional(
+        source,
+        MAX_INTEGRATION_BYTES,
+        "managed integration ownership",
+    )?
+    .ok_or_else(|| anyhow!("managed integration ownership source disappeared"))?;
+    if !expected.matches(&source_stamp) {
+        bail!("managed integration ownership source changed");
+    }
+    filesystem::copy_exact(
+        source,
+        temporary,
+        &source_stamp,
+        MAX_INTEGRATION_BYTES,
+        false,
+        label,
+    )
+}

--- a/crates/ctx-managed-pair-engine/src/tests.rs
+++ b/crates/ctx-managed-pair-engine/src/tests.rs
@@ -236,6 +236,8 @@ fn assert_cleanup(fixture: &Fixture, attempt_id: &str) {
 }
 
 mod fix_forward;
+#[cfg(unix)]
+mod reconciliation;
 
 #[test]
 fn managed_core_marker_uses_the_platform_install_marker_name() {

--- a/crates/ctx-managed-pair-engine/src/tests/reconciliation.rs
+++ b/crates/ctx-managed-pair-engine/src/tests/reconciliation.rs
@@ -1,0 +1,51 @@
+use std::fs;
+
+use super::*;
+
+#[test]
+fn integration_generation_is_idempotent_and_recovers_stale_temporaries() {
+    let fixture = Fixture::new();
+    let candidate = fixture.candidate("pair", 1, b"core", b"companion", b"pair-marker");
+    let verifier = TestVerifier::new([(candidate.envelope.clone(), candidate.identity.clone())]);
+    apply(&fixture, &candidate, &verifier);
+
+    let integration = fixture.candidates.join("integrations.json");
+    let bytes = br#"{"schema_version":1,"owners":[]}"#;
+    fs::write(&integration, bytes).unwrap();
+    let expected = fixture
+        .install
+        .join(format!("bin/ctx.install-integrations.{}", digest(bytes)));
+
+    for _ in 0..2 {
+        let (generation, sha256) = under_installation_lock(&fixture.install, || {
+            publish_managed_pair_integration_generation_under_installation_lock(
+                &fixture.install,
+                &integration,
+            )
+            .unwrap()
+        });
+        assert_eq!(generation, expected);
+        assert_eq!(sha256, digest(bytes));
+    }
+    assert_eq!(fs::read(&expected).unwrap(), bytes);
+    assert!(!fixture
+        .install
+        .join("bin/ctx.install-integrations")
+        .exists());
+    let temporary = fixture.install.join("bin").join(format!(
+        ".{}.new",
+        expected.file_name().unwrap().to_string_lossy()
+    ));
+    for stale in [bytes.as_slice(), b"changed temporary", b""] {
+        fs::remove_file(&expected).unwrap();
+        fs::write(&temporary, stale).unwrap();
+        under_installation_lock(&fixture.install, || {
+            publish_managed_pair_integration_generation_under_installation_lock(
+                &fixture.install,
+                &integration,
+            )
+            .unwrap()
+        });
+        assert_eq!(fs::read(&expected).unwrap(), bytes);
+    }
+}

--- a/crates/ctx-upgrade-engine/src/lib.rs
+++ b/crates/ctx-upgrade-engine/src/lib.rs
@@ -17,6 +17,8 @@ pub use ctx_managed_pair_engine::{
 pub use install_marker::{
     current_exe_install_marker, current_exe_is_staging_dogfood, ActiveInstallAttribution,
 };
+#[cfg(unix)]
+pub use upgrade::reconcile_managed_pair_integration_under_installation_lock;
 pub use upgrade::{
     active_installation_upgrade_attempt_id, current_exe_has_managed_install_marker_hint,
     current_exe_is_unmanaged, current_install_path, disable_current_man_pages,

--- a/crates/ctx-upgrade-engine/src/upgrade.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade.rs
@@ -26,6 +26,8 @@ pub use command::{PreparedAutomaticUpgrade, UpgradeOutcome};
 pub use diagnostics::{
     managed_install_executable, upgrade_diagnostics, ManagedInstallDiagnostic, UpgradeDiagnostics,
 };
+#[cfg(unix)]
+pub use install::reconcile_managed_pair_integration_under_installation_lock;
 pub use install::{
     current_exe_has_managed_install_marker_hint, current_exe_is_unmanaged, current_install_path,
     disable_current_man_pages, ensure_hosted_transaction_inactive_under_installation_lock,

--- a/crates/ctx-upgrade-engine/src/upgrade/command/daemon.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/command/daemon.rs
@@ -2,6 +2,9 @@
 
 use super::*;
 
+mod finalization;
+use finalization::{finalize_automatic_applied, finalize_automatic_recovery};
+
 /// Downloaded and verified automatic-upgrade inputs held under the one
 /// installation lease. The daemon keeps serving while these are staged, then
 /// drains its services before handing the value to
@@ -518,33 +521,22 @@ where
                             return Err(with_automatic_cleanup_errors(error, None, restart_error));
                         }
                     };
-                    reconcile_replacement_terminal_locked(
-                        &lock,
+                    return finalize_automatic_recovery(
+                        lock,
+                        &recovery.data_root,
+                        &recovery.install_path,
                         &recovery.attempt_id,
+                        recovery.interval,
                         applied,
                         (!applied).then_some(
                             "managed-pair recovery record disappeared before publication",
                         ),
-                        recovery.interval,
-                    )?;
-                    drop(lock);
-                    let resumed = handoff.resume_with(&recovery.install_path);
-                    send_daemon_upgrade_terminal(
+                        false,
+                        handoff,
                         observer,
-                        &recovery.data_root,
                         &current,
-                        None,
-                        &recovery.attempt_id,
-                        if applied {
-                            UpgradeTerminalStatus::Applied
-                        } else {
-                            UpgradeTerminalStatus::Failed
-                        },
-                        applied,
-                        (!applied).then_some(UpgradeFailureKind::ApplyFailed),
-                        started.elapsed(),
+                        started,
                     );
-                    return resumed;
                 }
             }
             PreparedAutomaticUpgradeKind::Recover {
@@ -634,48 +626,20 @@ where
                         &recovery.install_path,
                         anyhow!("interrupted ctx installation recovery disappeared while owned"),
                     ),
-                    InstallRecovery::Recovered { committed } => {
-                        let detail = (!committed).then_some(CURRENT_FORMAT_ROLLBACK_DETAIL);
-                        let automatic = match reconcile_replacement_terminal_locked(
-                            &lock,
-                            &recovery.attempt_id,
-                            committed,
-                            detail,
-                            interval,
-                        ) {
-                            Ok(automatic) => automatic,
-                            Err(error) => {
-                                return fail_automatic_before_apply(
-                                    &recovery.data_root,
-                                    lock,
-                                    attempt,
-                                    handoff,
-                                    &recovery.install_path,
-                                    error,
-                                );
-                            }
-                        };
-                        drop(lock);
-                        let resumed = handoff.resume_with(&recovery.install_path);
-                        if automatic {
-                            send_daemon_upgrade_terminal(
-                                observer,
-                                &recovery.data_root,
-                                &current,
-                                None,
-                                &recovery.attempt_id,
-                                if committed {
-                                    UpgradeTerminalStatus::Applied
-                                } else {
-                                    UpgradeTerminalStatus::Failed
-                                },
-                                committed,
-                                (!committed).then_some(UpgradeFailureKind::ApplyFailed),
-                                started.elapsed(),
-                            );
-                        }
-                        resumed
-                    }
+                    InstallRecovery::Recovered { committed } => finalize_automatic_recovery(
+                        lock,
+                        &recovery.data_root,
+                        &recovery.install_path,
+                        &recovery.attempt_id,
+                        interval,
+                        committed,
+                        (!committed).then_some(CURRENT_FORMAT_ROLLBACK_DETAIL),
+                        true,
+                        handoff,
+                        observer,
+                        &current,
+                        started,
+                    ),
                     #[cfg(windows)]
                     InstallRecovery::Scheduled { helper_pid, .. } => {
                         handoff.transfer_to_replacement_helper(helper_pid)
@@ -809,38 +773,18 @@ where
             handoff.transfer_to_replacement_helper(helper_pid)?;
             Ok(())
         }
-        Ok(result) => {
-            let mut warnings = plan.warnings.clone();
-            if let Some(warning) = result.cleanup_warning() {
-                warnings.push(warning.to_owned());
-            }
-            if let Err(error) =
-                write_state_checked_locked(&data_root, &lock, &attempt, &plan, "applied", interval)
-            {
-                return fail_automatic_before_apply(
-                    &data_root,
-                    lock,
-                    attempt,
-                    handoff,
-                    &plan.install_path,
-                    error,
-                );
-            }
-            drop(lock);
-            let restart = handoff.resume_with(&plan.install_path);
-            send_daemon_upgrade_terminal(
-                observer,
-                &data_root,
-                &current,
-                Some(&plan),
-                attempt.id(),
-                UpgradeTerminalStatus::Applied,
-                true,
-                None,
-                started.elapsed(),
-            );
-            restart
-        }
+        Ok(result) => finalize_automatic_applied(
+            &data_root,
+            interval,
+            started,
+            lock,
+            &attempt,
+            &plan,
+            &current,
+            observer,
+            handoff,
+            result.cleanup_warning(),
+        ),
         Err(error) => {
             let durable = matches!(
                 write_state_error_locked(
@@ -954,3 +898,6 @@ fn send_daemon_upgrade_terminal<S, O>(
         },
     );
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/ctx-upgrade-engine/src/upgrade/command/daemon/finalization.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/command/daemon/finalization.rs
@@ -1,0 +1,140 @@
+use super::*;
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn finalize_automatic_applied<L, S, O>(
+    data_root: &Path,
+    interval: Duration,
+    started: Instant,
+    lock: UpgradeLock,
+    attempt: &UpgradeAttempt,
+    plan: &UpgradePlan,
+    current: &S,
+    observer: &O,
+    handoff: L,
+    cleanup_warning: Option<&str>,
+) -> Result<()>
+where
+    L: DaemonUpgradeLease,
+    S: AutomaticUpgradePolicySnapshot,
+    O: UpgradeObserver<S>,
+{
+    let mut warnings = plan.warnings.clone();
+    if let Some(warning) = cleanup_warning {
+        warnings.push(warning.to_owned());
+    }
+    let state_durable = match write_state_checked_locked(
+        data_root, &lock, attempt, plan, "applied", interval,
+    ) {
+        Ok(true) => true,
+        Ok(false) => {
+            warnings.push(
+                "ctx upgrade is applied, but applied-state finalization is pending: automatic upgrade attempt changed before finalization"
+                    .to_owned(),
+            );
+            false
+        }
+        Err(error) => {
+            warnings.push(format!(
+                "ctx upgrade is applied, but applied-state finalization is pending: {error:#}"
+            ));
+            false
+        }
+    };
+    drop(lock);
+    if let Err(error) = handoff.resume_with(&plan.install_path) {
+        warnings.push(format!(
+            "ctx upgrade is applied, but daemon restart is pending: {error:#}"
+        ));
+    }
+    if state_durable {
+        send_daemon_upgrade_terminal(
+            observer,
+            data_root,
+            current,
+            Some(plan),
+            attempt.id(),
+            UpgradeTerminalStatus::Applied,
+            true,
+            None,
+            started.elapsed(),
+        );
+    }
+    for warning in warnings {
+        eprintln!("warning: {warning}");
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn finalize_automatic_recovery<L, S, O>(
+    lock: UpgradeLock,
+    data_root: &Path,
+    install_path: &Path,
+    attempt_id: &str,
+    interval: Duration,
+    committed: bool,
+    failure_detail: Option<&str>,
+    observe_without_retry_evidence: bool,
+    handoff: L,
+    observer: &O,
+    current: &S,
+    started: Instant,
+) -> Result<()>
+where
+    L: DaemonUpgradeLease,
+    S: AutomaticUpgradePolicySnapshot,
+    O: UpgradeObserver<S>,
+{
+    let terminal = reconcile_replacement_terminal_locked(
+        &lock,
+        attempt_id,
+        committed,
+        failure_detail,
+        interval,
+    );
+    drop(lock);
+    let restart = handoff.resume_with(install_path);
+    if committed {
+        let automatic = match terminal {
+            Ok(automatic) => automatic,
+            Err(error) => {
+                eprintln!(
+                    "warning: ctx upgrade is applied, but applied-state recovery is pending: {error:#}"
+                );
+                observe_without_retry_evidence
+            }
+        };
+        if let Err(error) = restart {
+            eprintln!("warning: ctx upgrade is applied, but daemon restart is pending: {error:#}");
+        }
+        if automatic {
+            send_daemon_upgrade_terminal(
+                observer,
+                data_root,
+                current,
+                None,
+                attempt_id,
+                UpgradeTerminalStatus::Applied,
+                true,
+                None,
+                started.elapsed(),
+            );
+        }
+        return Ok(());
+    }
+    let automatic = terminal?;
+    if automatic {
+        send_daemon_upgrade_terminal(
+            observer,
+            data_root,
+            current,
+            None,
+            attempt_id,
+            UpgradeTerminalStatus::Failed,
+            false,
+            Some(UpgradeFailureKind::ApplyFailed),
+            started.elapsed(),
+        );
+    }
+    restart
+}

--- a/crates/ctx-upgrade-engine/src/upgrade/command/daemon/tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/command/daemon/tests.rs
@@ -1,0 +1,271 @@
+#![cfg(unix)]
+
+use super::*;
+use crate::upgrade::{
+    install::{install_marker_path, InstallFingerprint, InstallationLock},
+    metadata::{ManagedPairReleaseMetadata, ReleaseMetadata},
+    sha256_hex,
+    state::{managed_pair_recovery_locked, write_managed_pair_attempt_locked},
+};
+use crate::DaemonRestart;
+use anyhow::anyhow as anyhow_error;
+use serde_json::Value;
+use std::{fs, os::unix::fs::PermissionsExt as _, sync::Mutex};
+
+static APPLIED_STATE_WRITE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+impl AutomaticUpgradePolicySnapshot for () {
+    fn daemon_maintenance_enabled(&self) -> bool {
+        true
+    }
+    fn automatic_upgrade_enabled(&self) -> bool {
+        true
+    }
+    fn interval(&self) -> Duration {
+        Duration::from_secs(60)
+    }
+    fn channel(&self) -> &str {
+        "stable"
+    }
+    fn semantic_enabled(&self) -> bool {
+        false
+    }
+}
+
+impl UpgradeObserver<()> for Mutex<Vec<(String, UpgradeTerminalStatus, bool)>> {
+    fn observe_automatic_terminal(
+        &self,
+        _data_root: &Path,
+        _policy: &(),
+        observation: AutomaticUpgradeObservation<'_>,
+    ) {
+        self.lock().unwrap().push((
+            observation.attempt_id.to_owned(),
+            observation.status,
+            observation.applied,
+        ));
+    }
+}
+
+impl DaemonUpgradeLease for Result<()> {
+    fn wait_for_installation_quiescence(&self) -> Result<()> {
+        Ok(())
+    }
+    fn replacement_restart(&self) -> Option<DaemonRestart<'_>> {
+        None
+    }
+    fn resume_with(self, _executable: &Path) -> Result<()> {
+        self
+    }
+    fn transfer_to_replacement_helper(self, _helper_pid: u32) -> Result<()> {
+        unreachable!()
+    }
+    fn release_for_current_format_reexec(self) -> Result<()> {
+        unreachable!()
+    }
+}
+
+fn automatic_fixture(
+    managed_pair: bool,
+) -> (
+    tempfile::TempDir,
+    PathBuf,
+    PathBuf,
+    UpgradeLock,
+    UpgradeAttempt,
+    UpgradePlan,
+) {
+    let temp = tempfile::tempdir().unwrap();
+    fs::set_permissions(temp.path(), fs::Permissions::from_mode(0o700)).unwrap();
+    let install = temp.path().join("ctx");
+    let data_root = temp.path().join("data");
+    fs::create_dir(&data_root).unwrap();
+    fs::write(&install, b"applied core").unwrap();
+    fs::set_permissions(&install, fs::Permissions::from_mode(0o700)).unwrap();
+    let marker_path = install_marker_path(&install);
+    fs::write(&marker_path, b"marker").unwrap();
+    let plan = UpgradePlan {
+        current_version: "1.0.0".to_owned(),
+        latest_version: "1.1.0".to_owned(),
+        channel: "stable".to_owned(),
+        platform: platform_key().unwrap().to_owned(),
+        metadata_url: "metadata".to_owned(),
+        artifact_url: "artifact".to_owned(),
+        artifact_sha256: sha256_hex(b"applied core"),
+        install_path: install.clone(),
+        install_fingerprint: InstallFingerprint {
+            binary_sha256: sha256_hex(b"applied core"),
+            marker_sha256: sha256_hex(b"marker"),
+        },
+        update_available: true,
+        managed: true,
+        warnings: Vec::new(),
+        managed_pair_release: managed_pair.then(|| ManagedPairReleaseMetadata {
+            envelope_url: "pair-envelope".to_owned(),
+            core_object_url: "pair-core".to_owned(),
+            core_sha256: "a".repeat(64),
+            companion_object_url: "pair-companion".to_owned(),
+            companion_sha256: "c".repeat(64),
+        }),
+        metadata: ReleaseMetadata {
+            version: "1.1.0".to_owned(),
+            base_url: "releases".to_owned(),
+            artifact: "ctx".to_owned(),
+            sha256: sha256_hex(b"applied core"),
+            source_commit: None,
+            published_at: None,
+            self_upgrade_allowed: true,
+            auto_upgrade_allowed: true,
+            store_schema_version: None,
+            managed_pair: None,
+            onnxruntime: None,
+            semantic: None,
+        },
+        semantic_provisioning: None,
+    };
+    let installation = InstallationLock::try_acquire(&install).unwrap().unwrap();
+    let lock = UpgradeLock::from_installation_for_test(install.clone(), installation);
+    let attempt = begin_automatic_attempt_locked(&lock, ().interval())
+        .unwrap()
+        .unwrap();
+    if managed_pair {
+        assert!(write_managed_pair_attempt_locked(
+            &data_root,
+            &lock,
+            &attempt,
+            &plan,
+            "applying",
+            ().interval(),
+            None,
+            &"b".repeat(64),
+        )
+        .unwrap());
+    } else {
+        assert!(write_state_checked_locked(
+            &data_root,
+            &lock,
+            &attempt,
+            &plan,
+            "applying",
+            ().interval(),
+        )
+        .unwrap());
+    }
+    (temp, data_root, install, lock, attempt, plan)
+}
+
+fn state_value(install: &Path) -> Value {
+    let name = install.file_name().unwrap().to_string_lossy();
+    serde_json::from_slice(
+        &fs::read(install.with_file_name(format!(".{name}.upgrade-state.json"))).unwrap(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn post_apply_state_and_restart_faults_recover_one_truthful_applied_event() {
+    let _env_lock = APPLIED_STATE_WRITE_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let (_temp, data_root, install, lock, attempt, plan) = automatic_fixture(true);
+    let observer = Mutex::new(Vec::new());
+    let fault_key = "CTX_UPGRADE_FAIL_APPLIED_STATE_WRITE_FOR_TESTS";
+    let previous_fault = std::env::var_os(fault_key);
+    std::env::set_var(fault_key, attempt.id());
+    finalize_automatic_applied(
+        &data_root,
+        ().interval(),
+        Instant::now(),
+        lock,
+        &attempt,
+        &plan,
+        &(),
+        &observer,
+        Err(anyhow_error!("injected daemon restart failure")),
+        None,
+    )
+    .unwrap();
+    match previous_fault {
+        Some(value) => std::env::set_var(fault_key, value),
+        None => std::env::remove_var(fault_key),
+    }
+    assert!(observer.lock().unwrap().is_empty());
+    assert_eq!(state_value(&install)["status"], "applying");
+
+    let installation = InstallationLock::try_acquire(&install).unwrap().unwrap();
+    let recovery_lock = UpgradeLock::from_installation_for_test(install.clone(), installation);
+    let recovery = managed_pair_recovery_locked(&recovery_lock, attempt.id()).unwrap();
+    finalize_automatic_recovery(
+        recovery_lock,
+        &recovery.data_root,
+        &recovery.install_path,
+        &recovery.attempt_id,
+        recovery.interval,
+        true,
+        None,
+        false,
+        Err(anyhow_error!("injected recovery restart failure")),
+        &observer,
+        &(),
+        Instant::now(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        *observer.lock().unwrap(),
+        [(
+            attempt.id().to_owned(),
+            UpgradeTerminalStatus::Applied,
+            true
+        )]
+    );
+    let state = state_value(&install);
+    assert_eq!(state["status"], "applied");
+    assert_eq!(state["current_version"], "1.1.0");
+    assert_eq!(state["latest_version"], "1.1.0");
+    assert_eq!(state["update_available"], false);
+}
+
+#[test]
+fn generic_committed_recovery_state_fault_emits_one_truthful_applied_event() {
+    let _env_lock = APPLIED_STATE_WRITE_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let (_temp, data_root, install, lock, attempt, _plan) = automatic_fixture(false);
+    let observer = Mutex::new(Vec::new());
+    let fault_key = "CTX_UPGRADE_FAIL_APPLIED_STATE_WRITE_FOR_TESTS";
+    let previous_fault = std::env::var_os(fault_key);
+    std::env::set_var(fault_key, attempt.id());
+    finalize_automatic_recovery(
+        lock,
+        &data_root,
+        &install,
+        attempt.id(),
+        ().interval(),
+        true,
+        None,
+        true,
+        Err(anyhow_error!("injected daemon restart failure")),
+        &observer,
+        &(),
+        Instant::now(),
+    )
+    .unwrap();
+    match previous_fault {
+        Some(value) => std::env::set_var(fault_key, value),
+        None => std::env::remove_var(fault_key),
+    }
+    assert_eq!(
+        *observer.lock().unwrap(),
+        [(
+            attempt.id().to_owned(),
+            UpgradeTerminalStatus::Applied,
+            true
+        )]
+    );
+    let state = state_value(&install);
+    assert_eq!(state["status"], "applying");
+    assert_eq!(state["current_version"], "1.0.0");
+    assert_eq!(state["latest_version"], "1.1.0");
+    assert_eq!(state["update_available"], true);
+}

--- a/crates/ctx-upgrade-engine/src/upgrade/install.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install.rs
@@ -38,6 +38,8 @@ pub(in crate::upgrade) use marker::classify_install_marker_at;
 pub(in crate::upgrade) use marker::install_marker_path;
 pub(in crate::upgrade) use marker::installation_is_unmanaged_at;
 pub use marker::is_valid_install_attempt_id;
+#[cfg(unix)]
+pub use marker::reconcile_managed_pair_integration_under_installation_lock;
 pub(super) use marker::InstallFingerprint;
 pub use marker::{
     current_exe_has_managed_install_marker_hint, current_exe_is_unmanaged, current_install_path,

--- a/crates/ctx-upgrade-engine/src/upgrade/install/hosted_transaction.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/hosted_transaction.rs
@@ -727,28 +727,7 @@ fn validate_helper_caller(current: &Path, journal: &Journal) -> Result<()> {
     )
 }
 
-fn verify_recorded_ownership(journal: &Journal) -> Result<()> {
-    if let (Some(path), Some(digest)) = (
-        journal.ownership_path.as_ref(),
-        journal.ownership_sha256.as_ref(),
-    ) {
-        verify_file_digest(
-            path,
-            digest,
-            MAX_OWNERSHIP_BYTES,
-            "managed integration ownership",
-        )
-        .with_context(|| {
-            format!(
-                "integration ownership at {} changed; restore the transaction-owned sidecar or move the changed file aside, then retry hosted uninstall",
-                path.display()
-            )
-        })?;
-    }
-    Ok(())
-}
-
-fn read_recorded_ownership(
+pub(super) fn read_recorded_ownership(
     marker: &str,
     install_path: &Path,
 ) -> Result<Option<(PathBuf, String, Vec<u8>)>> {
@@ -759,12 +738,13 @@ fn read_recorded_ownership(
     ) {
         (None, None) => Ok(None),
         (Some(Value::String(path)), Some(Value::String(digest))) => {
-            let expected_path = ownership_path(install_path);
-            if !managed_install_path_identity_matches(&expected_path, Path::new(path))
-                || !is_normalized_sha256(digest)
-            {
+            if !is_normalized_sha256(digest) {
                 bail!("managed marker has invalid integration ownership identity");
             }
+            let expected_path = recorded_ownership_path(install_path, Path::new(path), digest)
+                .ok_or_else(|| {
+                    anyhow!("managed marker has invalid integration ownership identity")
+                })?;
             let body = read_bounded(
                 &expected_path,
                 MAX_OWNERSHIP_BYTES,
@@ -904,9 +884,12 @@ fn validate_journal(journal: &Journal, install_path: &Path, kind: TransactionKin
     ) {
         (None, None, None) => {}
         (Some(path), Some(digest), Some(body))
-            if path == &ownership_path(install_path)
-                && normalized_sha256(digest)? == *digest
-                && sha256_hex(body) == *digest => {}
+            if normalized_sha256(digest)? == *digest
+                && sha256_hex(body) == *digest
+                && (path == &ownership_path(install_path)
+                    || (kind == TransactionKind::Uninstall
+                        && recorded_ownership_path(install_path, path, digest).as_ref()
+                            == Some(path))) => {}
         _ => bail!("hosted transaction journal ownership identity is invalid"),
     }
     let marker: Value = serde_json::from_str(&journal.marker_body)?;

--- a/crates/ctx-upgrade-engine/src/upgrade/install/hosted_transaction/filesystem.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/hosted_transaction/filesystem.rs
@@ -7,7 +7,9 @@ use std::{
 use anyhow::{anyhow, bail, Context, Result};
 use uuid::Uuid;
 
-use super::{Journal, JOURNAL_SUFFIX, MAX_BINARY_BYTES};
+use super::{Journal, JOURNAL_SUFFIX, MAX_BINARY_BYTES, MAX_OWNERSHIP_BYTES};
+#[cfg(unix)]
+use crate::upgrade::install::managed_install_path_identity_matches;
 #[cfg(windows)]
 use crate::upgrade::install::{
     lock::validate_windows_path_leaf, path_identity::windows_disk_path_identity,
@@ -126,6 +128,49 @@ pub(super) fn ownership_path(install_path: &Path) -> PathBuf {
     let mut name = install_path.file_name().unwrap_or_default().to_os_string();
     name.push(".install-integrations");
     install_path.with_file_name(name)
+}
+
+pub(super) fn recorded_ownership_path(
+    install_path: &Path,
+    claimed: &Path,
+    digest: &str,
+) -> Option<PathBuf> {
+    let fixed = ownership_path(install_path);
+    if super::managed_install_path_identity_matches(&fixed, claimed) {
+        return Some(fixed);
+    }
+    #[cfg(unix)]
+    {
+        let mut name = fixed.file_name()?.to_os_string();
+        name.push(".");
+        name.push(digest);
+        let generation = fixed.with_file_name(name);
+        if managed_install_path_identity_matches(&generation, claimed) {
+            return Some(generation);
+        }
+    }
+    None
+}
+
+pub(super) fn verify_recorded_ownership(journal: &Journal) -> Result<()> {
+    if let (Some(path), Some(digest)) = (
+        journal.ownership_path.as_ref(),
+        journal.ownership_sha256.as_ref(),
+    ) {
+        verify_file_digest(
+            path,
+            digest,
+            MAX_OWNERSHIP_BYTES,
+            "managed integration ownership",
+        )
+        .with_context(|| {
+            format!(
+                "integration ownership at {} changed; restore the transaction-owned sidecar or move the changed file aside, then retry hosted uninstall",
+                path.display()
+            )
+        })?;
+    }
+    Ok(())
 }
 
 pub(in crate::upgrade) fn uninstall_helper_path(install_path: &Path) -> PathBuf {

--- a/crates/ctx-upgrade-engine/src/upgrade/install/hosted_transaction/tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/hosted_transaction/tests.rs
@@ -8,7 +8,7 @@ use std::{fs, os::unix::fs::PermissionsExt as _, process::Command, time::Duratio
 
 use crate::upgrade::{
     download::DownloadedArtifact,
-    install::InstallFingerprint,
+    install::{InstallFingerprint, InstallationLock},
     managed_pair::{apply_prepared_install, ManagedPairMode, PreparedCoreArtifact},
     metadata::ReleaseMetadata,
     state::{begin_manual_attempt_locked, UpgradeLock},
@@ -17,6 +17,7 @@ use crate::upgrade::{
 
 const OLD_OWNERSHIP: &[u8] = b"CTX_INSTALL_INTEGRATIONS_V1\nrecords_sha256\told\n";
 const NEW_OWNERSHIP: &[u8] = b"CTX_INSTALL_INTEGRATIONS_V1\nrecords_sha256\tnew\n";
+const THIRD_OWNERSHIP: &[u8] = b"CTX_INSTALL_INTEGRATIONS_V1\nrecords_sha256\tthird\n";
 const SELF_UPGRADE_CHILD_TARGET_ENV: &str = "CTX_SELF_UPGRADE_FENCE_CHILD_TARGET";
 
 #[derive(Clone)]
@@ -118,6 +119,11 @@ fn pair_fixture() -> PairFixture {
     fs::write(
         install_marker_path(&install),
         paired_marker(&install, &sha256_hex(core_bytes)),
+    )
+    .unwrap();
+    fs::set_permissions(
+        install_marker_path(&install),
+        fs::Permissions::from_mode(0o600),
     )
     .unwrap();
     PairFixture {
@@ -252,6 +258,112 @@ fn arm_pair_uninstall(fixture: &PairFixture) -> (PathBuf, PathBuf, Journal) {
     let path = journal_path(&fixture.install);
     write_initial_journal(&path, &journal).unwrap();
     (helper, path, journal)
+}
+
+#[test]
+fn integration_reconciliation_crash_retries_and_uninstalls_from_one_marker_authority() {
+    let fixture = pair_fixture();
+    let old_source = fixture.root.join("old-integrations");
+    let new_source = fixture.root.join("new-integrations");
+    fs::write(&old_source, OLD_OWNERSHIP).unwrap();
+    fs::write(&new_source, NEW_OWNERSHIP).unwrap();
+
+    let installation = InstallationLock::try_acquire(&fixture.install)
+        .unwrap()
+        .unwrap();
+    super::super::marker::reconcile_managed_pair_integration_under_installation_lock(
+        &fixture.root,
+        &old_source,
+    )
+    .unwrap();
+    drop(installation);
+    let marker_path = install_marker_path(&fixture.install);
+    let old_marker = fs::read(&marker_path).unwrap();
+    let old_value: Value = serde_json::from_slice(&old_marker).unwrap();
+    let old_generation = PathBuf::from(old_value["integrations_path"].as_str().unwrap());
+    assert_eq!(fs::read(&old_generation).unwrap(), OLD_OWNERSHIP);
+    let new_generation = fixture.root.join(format!(
+        "bin/ctx.install-integrations.{}",
+        sha256_hex(NEW_OWNERSHIP)
+    ));
+
+    let mut stale = old_value.clone();
+    stale["sha256"] = json!("0".repeat(64));
+    fs::write(&marker_path, serde_json::to_vec_pretty(&stale).unwrap()).unwrap();
+    let installation = InstallationLock::try_acquire(&fixture.install)
+        .unwrap()
+        .unwrap();
+    let stale_error =
+        super::super::marker::reconcile_managed_pair_integration_under_installation_lock(
+            &fixture.root,
+            &new_source,
+        )
+        .unwrap_err();
+    drop(installation);
+    assert!(stale_error.to_string().contains("hash mismatch"));
+    assert!(!new_generation.exists());
+    fs::write(&marker_path, &old_marker).unwrap();
+
+    let installation = InstallationLock::try_acquire(&fixture.install)
+        .unwrap()
+        .unwrap();
+    let error = super::super::marker::reconcile_managed_pair_integration_with_fault(
+        &fixture.root,
+        &new_source,
+        &mut || bail!("injected after generation publication"),
+    )
+    .unwrap_err();
+    drop(installation);
+    assert!(error.to_string().contains("injected after generation"));
+    assert_eq!(fs::read(&marker_path).unwrap(), old_marker);
+    assert_eq!(fs::read(&old_generation).unwrap(), OLD_OWNERSHIP);
+    assert_eq!(fs::read(&new_generation).unwrap(), NEW_OWNERSHIP);
+
+    let installation = InstallationLock::try_acquire(&fixture.install)
+        .unwrap()
+        .unwrap();
+    super::super::marker::reconcile_managed_pair_integration_under_installation_lock(
+        &fixture.root,
+        &new_source,
+    )
+    .unwrap();
+    drop(installation);
+    let new_value: Value = serde_json::from_slice(&fs::read(&marker_path).unwrap()).unwrap();
+    let mut expected = old_value;
+    expected["integrations_path"] = json!(new_generation);
+    expected["integrations_sha256"] = json!(sha256_hex(NEW_OWNERSHIP));
+    assert_eq!(new_value, expected);
+    assert!(!old_generation.exists());
+
+    let third_source = fixture.root.join("third-integrations");
+    fs::write(&third_source, THIRD_OWNERSHIP).unwrap();
+    let installation = InstallationLock::try_acquire(&fixture.install)
+        .unwrap()
+        .unwrap();
+    super::super::marker::reconcile_managed_pair_integration_under_installation_lock(
+        &fixture.root,
+        &third_source,
+    )
+    .unwrap();
+    drop(installation);
+    let third_marker: Value = serde_json::from_slice(&fs::read(&marker_path).unwrap()).unwrap();
+    let third_generation = PathBuf::from(third_marker["integrations_path"].as_str().unwrap());
+    assert_eq!(fs::read(&third_generation).unwrap(), THIRD_OWNERSHIP);
+    assert!(!new_generation.exists());
+
+    let (helper, path, mut uninstall) = arm_pair_uninstall(&fixture);
+    complete_uninstall_commit(&helper, &path, &mut uninstall, &mut |_| Ok(())).unwrap();
+    remove_journal(&path).unwrap();
+    assert!(!third_generation.exists());
+    assert!(!marker_path.exists());
+    assert!(!fixture.install.exists());
+    assert!(fs::read_dir(fixture.root.join("bin"))
+        .unwrap()
+        .all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with("ctx.install-integrations.")));
 }
 
 fn ordinary_upgrade_plan(install: &Path, next_core: &[u8]) -> UpgradePlan {

--- a/crates/ctx-upgrade-engine/src/upgrade/install/lock_marker_tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/lock_marker_tests.rs
@@ -12,7 +12,7 @@ use std::{ffi::OsString, os::windows::ffi::OsStringExt as _, path::PathBuf, proc
 use super::{
     absent_install_marker_error, classify_install_marker_at, install_fingerprint,
     install_marker_path, installation_is_unmanaged_at, invalid_install_marker_recovery_guidance,
-    is_valid_install_attempt_id, preserve_man_pages_from_existing_marker,
+    is_valid_install_attempt_id, preserve_owned_extensions_from_existing_marker,
     unmanaged_install_conversion_guidance, ManagedInstallMarker,
 };
 use crate::upgrade::sha256_hex;
@@ -211,26 +211,36 @@ fn valid_marker_uses_the_canonical_executable_path() -> Result<()> {
 }
 
 #[test]
-fn upgraded_marker_preserves_only_the_man_page_receipt_extension() -> Result<()> {
+fn upgraded_marker_preserves_validated_owned_extensions() -> Result<()> {
     let fixture = tempdir()?;
-    let existing_path = fixture.path().join("ctx.install.json");
+    let install_path = fixture.path().join("ctx");
+    let existing_path = install_marker_path(&install_path);
     let receipt = json!({"schema_version": 1, "status": "installed"});
+    let ownership = b"owned integrations";
+    let ownership_digest = sha256_hex(ownership);
+    let ownership_path = fixture
+        .path()
+        .join(format!("ctx.install-integrations.{ownership_digest}"));
+    fs::write(&ownership_path, ownership)?;
     fs::write(
         &existing_path,
         serde_json::to_vec(&json!({
             "man_pages": receipt,
-            "integrations_path": "old-sidecar",
+            "integrations_path": ownership_path,
+            "integrations_sha256": ownership_digest,
         }))?,
     )?;
-    let mut replacement = json!({
-        "manager": "ctx-hosted-installer",
-        "integrations_path": "new-sidecar",
-    });
+    let mut replacement = json!({"manager": "ctx-hosted-installer"});
 
-    preserve_man_pages_from_existing_marker(&mut replacement, &existing_path)?;
+    preserve_owned_extensions_from_existing_marker(
+        &mut replacement,
+        &existing_path,
+        &install_path,
+    )?;
 
     assert_eq!(replacement["man_pages"], receipt);
-    assert_eq!(replacement["integrations_path"], "new-sidecar");
+    assert_eq!(replacement["integrations_path"], json!(ownership_path));
+    assert_eq!(replacement["integrations_sha256"], ownership_digest);
     Ok(())
 }
 

--- a/crates/ctx-upgrade-engine/src/upgrade/install/marker.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/marker.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use ctx_history_core::utc_now;
 use serde_json::{json, Value};
 
@@ -107,7 +107,15 @@ fn read_install_marker_at(path: &Path) -> Result<Option<InstallMarker>> {
     let Some(bytes) = read_install_marker_bytes(&marker_path)? else {
         return Ok(None);
     };
-    let value: Value = serde_json::from_slice(&bytes)
+    parse_install_marker(path, &marker_path, &bytes).map(|(marker, _)| Some(marker))
+}
+
+fn parse_install_marker(
+    path: &Path,
+    marker_path: &Path,
+    bytes: &[u8],
+) -> Result<(InstallMarker, Value)> {
+    let value: Value = serde_json::from_slice(bytes)
         .with_context(|| format!("parse ctx install marker {}", marker_path.display()))?;
     let manager = value
         .get("manager")
@@ -134,14 +142,17 @@ fn read_install_marker_at(path: &Path) -> Result<Option<InstallMarker>> {
             path.display()
         ));
     }
-    Ok(Some(InstallMarker {
-        install_path: certified_path,
-        platform: string_field(&value, "platform")?,
-        channel: string_field(&value, "channel")?,
-        version: string_field(&value, "version")?,
-        sha256: string_field(&value, "sha256")?,
-        staging_dogfood: is_staging_dogfood_marker(&value),
-    }))
+    Ok((
+        InstallMarker {
+            install_path: certified_path,
+            platform: string_field(&value, "platform")?,
+            channel: string_field(&value, "channel")?,
+            version: string_field(&value, "version")?,
+            sha256: string_field(&value, "sha256")?,
+            staging_dogfood: is_staging_dogfood_marker(&value),
+        },
+        value,
+    ))
 }
 
 pub(in crate::upgrade) fn install_marker_for_plan(
@@ -263,6 +274,70 @@ fn verify_install_marker(marker: &InstallMarker, platform: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+pub fn reconcile_managed_pair_integration_under_installation_lock(
+    install_root: &Path,
+    integration_source: &Path,
+) -> Result<()> {
+    reconcile_managed_pair_integration_impl(install_root, integration_source, &mut || Ok(()))
+}
+
+#[cfg(all(test, unix))]
+pub(in crate::upgrade) fn reconcile_managed_pair_integration_with_fault(
+    install_root: &Path,
+    integration_source: &Path,
+    fault: &mut dyn FnMut() -> Result<()>,
+) -> Result<()> {
+    reconcile_managed_pair_integration_impl(install_root, integration_source, fault)
+}
+
+#[cfg(unix)]
+fn reconcile_managed_pair_integration_impl(
+    install_root: &Path,
+    integration_source: &Path,
+    fault: &mut dyn FnMut() -> Result<()>,
+) -> Result<()> {
+    let install_path = install_root.join("bin/ctx");
+    let marker_path = install_marker_path(&install_path);
+    let previous = read_install_marker_bytes(&marker_path)?
+        .ok_or_else(|| anyhow!("managed Core install marker disappeared"))?;
+    let (marker, mut value) = parse_install_marker(&install_path, &marker_path, &previous)?;
+    verify_install_marker(&marker, platform_key()?)?;
+    let previous_text = std::str::from_utf8(&previous)
+        .context("decode managed Core install marker integration ownership")?;
+    let previous_ownership =
+        super::hosted_transaction::read_recorded_ownership(previous_text, &install_path)?;
+
+    let (generation, digest) =
+        ctx_managed_pair_engine::publish_managed_pair_integration_generation_under_installation_lock(
+            install_root,
+            integration_source,
+        )?;
+    fault()?;
+    if read_install_marker_bytes(&marker_path)?.as_deref() != Some(previous.as_slice()) {
+        bail!("managed Core install marker changed during integration reconciliation");
+    }
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("managed Core install marker is not an object"))?;
+    object.insert(
+        "integrations_path".to_owned(),
+        Value::String(generation.to_string_lossy().into_owned()),
+    );
+    object.insert("integrations_sha256".to_owned(), Value::String(digest));
+    atomic_write_json(&marker_path, &value)?;
+    if let Some((prior_path, prior_digest, _)) = previous_ownership {
+        if prior_path != generation {
+            ctx_managed_pair_engine::remove_managed_pair_integration_binding_under_installation_lock(
+                install_root,
+                &prior_path,
+                &prior_digest,
+            )?;
+        }
+    }
+    Ok(())
+}
+
 pub(super) fn write_install_marker_to(
     marker_path: &Path,
     existing_marker_path: &Path,
@@ -318,15 +393,20 @@ fn install_marker_value(
         }
     }
     // The runtime owns this receipt and upgrades replace the marker atomically.
-    // Preserve only man-page ownership; integration ownership follows its
-    // pre-existing installer transaction path.
-    preserve_man_pages_from_existing_marker(&mut body, existing_marker_path)?;
+    // Keep the validated prior integration binding authoritative until Unix
+    // reconciliation publishes and binds its replacement.
+    preserve_owned_extensions_from_existing_marker(
+        &mut body,
+        existing_marker_path,
+        &plan.install_path,
+    )?;
     Ok(body)
 }
 
-pub(super) fn preserve_man_pages_from_existing_marker(
+pub(super) fn preserve_owned_extensions_from_existing_marker(
     body: &mut Value,
     existing_marker_path: &Path,
+    install_path: &Path,
 ) -> Result<()> {
     let bytes = read_install_marker_bytes(existing_marker_path)?
         .ok_or_else(|| anyhow!("existing managed install marker disappeared"))?;
@@ -336,6 +416,18 @@ pub(super) fn preserve_man_pages_from_existing_marker(
         if let Some(value) = previous.get("man_pages") {
             object.insert("man_pages".to_owned(), value.clone());
         }
+    }
+    let previous_text =
+        std::str::from_utf8(&bytes).context("decode existing managed integration ownership")?;
+    if let Some((path, digest, _)) =
+        super::hosted_transaction::read_recorded_ownership(previous_text, install_path)?
+    {
+        let object = body.as_object_mut().expect("install marker is an object");
+        object.insert(
+            "integrations_path".to_owned(),
+            Value::String(path.to_string_lossy().into_owned()),
+        );
+        object.insert("integrations_sha256".to_owned(), Value::String(digest));
     }
     Ok(())
 }

--- a/crates/ctx-upgrade-engine/src/upgrade/state.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/state.rs
@@ -520,10 +520,7 @@ pub(super) fn write_state_checked_locked(
     {
         return Err(anyhow!("injected upgrade state write failure"));
     }
-    if crate::upgrade::test_harness_enabled()
-        && status == "applied"
-        && super::env_flag("CTX_UPGRADE_FAIL_APPLIED_STATE_WRITE_FOR_TESTS")
-    {
+    if status == "applied" && applied_state_write_failure_injected(attempt.id()) {
         return Err(anyhow!("injected applied-state write failure"));
     }
     let mut state = read_state_object(&lock.install_path);
@@ -566,6 +563,9 @@ pub(super) fn reconcile_replacement_terminal_locked(
     warning_or_error: Option<&str>,
     interval: Duration,
 ) -> Result<bool> {
+    if applied && applied_state_write_failure_injected(attempt_id) {
+        return Err(anyhow!("injected applied-state write failure"));
+    }
     let mut state = read_state_object(&lock.install_path);
     let automatic = state.attempt_id.as_deref() == Some(attempt_id)
         && state
@@ -583,6 +583,12 @@ pub(super) fn reconcile_replacement_terminal_locked(
     };
     if applied {
         state.terminal(&attempt, "applied", interval, now_unix_s());
+        if let Some(latest) = state.plan.get("latest_version").cloned() {
+            state.plan.insert("current_version".to_owned(), latest);
+        }
+        state
+            .plan
+            .insert("update_available".to_owned(), Value::Bool(false));
         if let Some(warning) = warning_or_error {
             state.plan.insert("warning".to_owned(), json!(warning));
         }
@@ -595,6 +601,16 @@ pub(super) fn reconcile_replacement_terminal_locked(
     }
     write_state_object_locked(lock, state)?;
     Ok(automatic)
+}
+
+fn applied_state_write_failure_injected(attempt_id: &str) -> bool {
+    crate::upgrade::test_harness_enabled()
+        && std::env::var("CTX_UPGRADE_FAIL_APPLIED_STATE_WRITE_FOR_TESTS").is_ok_and(|value| {
+            value == attempt_id
+                || (!value.starts_with("ua_")
+                    && !["", "0", "false", "no", "off"]
+                        .contains(&value.trim().to_ascii_lowercase().as_str()))
+        })
 }
 
 fn write_plan(state: &mut UpgradeState, plan: &UpgradePlan, applied: bool) {

--- a/crates/ctx-upgrade-engine/src/upgrade/state/tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/state/tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-
 fn daemon_due_hint_install(temp: &tempfile::TempDir) -> PathBuf {
     let install = temp.path().join("ctx");
     fs::write(&install, b"test executable").unwrap();


### PR DESCRIPTION
## What changed

Core now owns lock-held integration generation publication and marker rebinding for managed pairs. A crash before the marker commit leaves the prior install valid; retry can adopt the staged generation. Once files are committed, later state or restart failures report an applied upgrade with bounded warnings instead of a false failure.

This consolidates authority without adding another journal, state machine, or parser authority.

## Validation

- 8 uncached CI-mode Bazel targets passed, including upgrade engine, CLI, installer/native smoke, LOC, source-diff, and Clippy coverage
- 158 upgrade-engine tests passed in final review
- independent review found no remaining P0-P3 issue
- source and test LOC caps pass unchanged

Native Windows PowerShell execution remains a required merge gate on this PR.