### PR TITLE
refactor(refresh): centralize engine request-state authority

### DIFF
--- a/crates/ctx-cli/src/core_capability/progress_events.rs
+++ b/crates/ctx-cli/src/core_capability/progress_events.rs
@@ -2,8 +2,7 @@ use std::io::Write;
 
 use anyhow::Result;
 use ctx_history_refresh::{
-    RefreshLogicalPhase, RefreshRequestState, RefreshStatus, RefreshStatusKind,
-    RefreshTerminalOutcome,
+    RefreshLogicalPhase, RefreshStatus, RefreshStatusKind, RefreshTerminalOutcome,
 };
 use serde_json::{json, Value};
 
@@ -125,7 +124,7 @@ fn refresh_event_frame(
         "processed_sessions": progress.processed_sessions,
         "processed_tool_calls": progress.processed_tool_calls,
         "providers": progress.providers.iter().map(|provider| neutral_dynamic_text(provider)).collect::<Vec<_>>(),
-        "request_state": request_state_name(kind.request_state()),
+        "request_state": kind.request_state().as_str(),
         "total_sources": u64::try_from(progress.total_sources)?,
         "total_sources_known": status.total_sources_known()?,
         "whole_run_stage": status.whole_run_stage()?.as_str(),
@@ -156,12 +155,11 @@ fn append_typed_status(refresh: &mut Value, kind: &RefreshStatusKind) {
             refresh["logical_phase"] = json!(logical_phase_name(logical.logical_phase));
             refresh["physical_attempt_id"] =
                 json!(neutral_dynamic_text(&logical.physical_attempt_id));
-            refresh["physical_attempt_state"] =
-                json!(request_state_name(logical.physical_attempt_state));
+            refresh["physical_attempt_state"] = json!(logical.physical_attempt_state.as_str());
             refresh["progress_owner_request_id"] =
                 json!(neutral_dynamic_text(&logical.progress_owner_request_id));
             refresh["progress_owner_attempt_state"] =
-                json!(request_state_name(logical.progress_owner_attempt_state));
+                json!(logical.progress_owner_attempt_state.as_str());
             if let Some(outcome) = logical.structured_outcome.as_ref() {
                 refresh["terminal_state"] = terminal_state(outcome);
             }
@@ -195,16 +193,6 @@ pub(super) fn terminal_details(outcome: &RefreshTerminalOutcome) -> Value {
 fn remove_null_fields(value: &mut Value) {
     if let Value::Object(fields) = value {
         fields.retain(|_, value| !value.is_null());
-    }
-}
-
-fn request_state_name(state: RefreshRequestState) -> &'static str {
-    match state {
-        RefreshRequestState::AdmissionPending => "admission_pending",
-        RefreshRequestState::Queued => "queued",
-        RefreshRequestState::Running => "running",
-        RefreshRequestState::Published => "published",
-        RefreshRequestState::Failed => "failed",
     }
 }
 

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client.rs
@@ -460,14 +460,14 @@ fn coordinate_source_backed_refresh_with_policy(
         let Some(pin) = pin_published_generation(data_root)? else {
             return Err(SourceBackedRefreshPendingPublication::new(
                 request_id,
-                refresh_request_state_name(request_state).to_owned(),
+                request_state.as_str().to_owned(),
                 source_count,
             )
             .into());
         };
         return Ok(SourceBackedRefreshObservation {
             mode,
-            status: refresh_request_state_name(request_state).to_owned(),
+            status: request_state.as_str().to_owned(),
             request_id: Some(request_id),
             daemon_available: true,
             source_count,
@@ -833,16 +833,6 @@ fn response_request_id(response: &Value, label: &str) -> Result<String> {
 #[cfg(test)]
 fn source_refresh_protocol_state(response: &Value) -> Result<RefreshRequestState> {
     Ok(source_refresh_protocol_status(response)?.request_state())
-}
-
-fn refresh_request_state_name(state: RefreshRequestState) -> &'static str {
-    match state {
-        RefreshRequestState::AdmissionPending => "admission_pending",
-        RefreshRequestState::Queued => "queued",
-        RefreshRequestState::Running => "running",
-        RefreshRequestState::Published => "published",
-        RefreshRequestState::Failed => "failed",
-    }
 }
 
 fn source_refresh_protocol_status(response: &Value) -> Result<RefreshStatusKind> {

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client.rs
@@ -715,7 +715,7 @@ fn published_refresh_observation(
         .ok_or_else(|| anyhow!("published daemon source refresh has no scanned route count"))?;
     Ok(SourceBackedRefreshObservation {
         mode,
-        status: "published".to_owned(),
+        status: RefreshRequestState::Published.as_str().to_owned(),
         request_id: Some(request_id),
         daemon_available: true,
         source_count,

--- a/crates/ctx-history-cli/src/progress.rs
+++ b/crates/ctx-history-cli/src/progress.rs
@@ -347,6 +347,15 @@ mod tests {
     }
 
     #[test]
+    fn terminal_projection_preserves_all_engine_request_state_names() {
+        use EngineRequestState::*;
+
+        for state in [AdmissionPending, Queued, Running, Published, Failed] {
+            assert_eq!(presentation_request_state(state).as_str(), state.as_str());
+        }
+    }
+
+    #[test]
     fn provider_names_use_products_and_preserve_unknown_fallbacks() {
         for (provider, expected) in [
             ("claude", "Claude Code"),

--- a/crates/ctx-history-refresh/src/engine/admission.rs
+++ b/crates/ctx-history-refresh/src/engine/admission.rs
@@ -112,7 +112,7 @@ impl CoreRefreshEngine {
             }
         };
         let response_barrier = (response.get("request_state").and_then(Value::as_str)
-            == Some("admission_pending"))
+            == Some(SourceBackedRefreshState::AdmissionPending.as_str()))
         .then(|| {
             response
                 .get("request_id")

--- a/crates/ctx-history-refresh/src/engine/durable_queue.rs
+++ b/crates/ctx-history-refresh/src/engine/durable_queue.rs
@@ -385,14 +385,11 @@ pub(super) fn recover_queued_successors(job: &Value) -> Result<Vec<SourceBackedR
     let successors = successors
         .as_array()
         .ok_or_else(|| anyhow!("durable source refresh successors must be an array"))?;
-    let root_state = job
-        .get("request_state")
+    job.get("request_state")
         .and_then(Value::as_str)
-        .ok_or_else(|| anyhow!("durable source refresh job has no request state"))?;
-    match root_state {
-        "admission_pending" | "queued" | "running" | "failed" | "published" => {}
-        _ => bail!("durable source refresh job has an invalid request state"),
-    }
+        .ok_or_else(|| anyhow!("durable source refresh job has no request state"))?
+        .parse::<SourceBackedRefreshState>()
+        .map_err(|_| anyhow!("durable source refresh job has an invalid request state"))?;
     if successors.len().saturating_add(1) > SOURCE_REFRESH_ACTIVE_PENDING_LIMIT {
         bail!("durable source refresh successor queue exceeds its bounded capacity");
     }
@@ -434,9 +431,15 @@ fn recover_pending_attempt(
     role: &str,
     is_root: bool,
 ) -> Result<SourceBackedRefreshAttempt> {
-    let request_state = job.get("request_state").and_then(Value::as_str);
-    if !(matches!(request_state, Some("admission_pending" | "queued"))
-        || is_root && request_state == Some("running"))
+    let request_state = job
+        .get("request_state")
+        .and_then(Value::as_str)
+        // Preserve the bounded not-queued error for missing or unknown states.
+        .and_then(|state| state.parse::<SourceBackedRefreshState>().ok());
+    if !(matches!(
+        request_state,
+        Some(SourceBackedRefreshState::AdmissionPending | SourceBackedRefreshState::Queued)
+    ) || is_root && request_state == Some(SourceBackedRefreshState::Running))
     {
         bail!("durable source refresh {role} is not queued");
     }
@@ -489,7 +492,7 @@ fn recover_pending_attempt(
     attempt.request_id = request_id.to_owned();
     attempt.reconciliation_demand = recover_reconciliation_demand(job, operation)?;
     let _legacy_physical_attempt_id = optional_pending_string(job, "physical_attempt_id")?;
-    attempt.state = if request_state == Some("admission_pending") {
+    attempt.state = if request_state == Some(SourceBackedRefreshState::AdmissionPending) {
         SourceBackedRefreshState::AdmissionPending
     } else {
         SourceBackedRefreshState::Queued
@@ -590,7 +593,7 @@ pub(super) fn install_recovered_successors(
 }
 
 #[cfg(test)]
-mod cadence_tests {
+mod tests {
     use super::*;
 
     #[test]
@@ -616,5 +619,20 @@ mod cadence_tests {
             "request-a",
             started + DURABLE_PROGRESS_PERSIST_INTERVAL,
         ));
+    }
+
+    #[test]
+    fn malformed_successor_state_keeps_bounded_recovery_error() {
+        let job = json!({
+            "request_state": SourceBackedRefreshState::Queued.as_str(),
+            "request_id": "root",
+            "queued_successors": [{ "request_state": "unknown" }],
+        });
+
+        let error = recover_queued_successors(&job).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "durable source refresh successor is not queued"
+        );
     }
 }

--- a/crates/ctx-history-refresh/src/engine/progress_model.rs
+++ b/crates/ctx-history-refresh/src/engine/progress_model.rs
@@ -46,30 +46,7 @@ impl SourceBackedRefreshStage {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub(super) enum SourceBackedRefreshState {
-    AdmissionPending,
-    Queued,
-    Running,
-    Published,
-    Failed,
-}
-
-impl SourceBackedRefreshState {
-    pub(super) fn as_str(self) -> &'static str {
-        match self {
-            Self::AdmissionPending => "admission_pending",
-            Self::Queued => "queued",
-            Self::Running => "running",
-            Self::Published => "published",
-            Self::Failed => "failed",
-        }
-    }
-
-    pub(super) fn is_active(self) -> bool {
-        matches!(self, Self::AdmissionPending | Self::Queued | Self::Running)
-    }
-}
+pub(super) type SourceBackedRefreshState = RefreshRequestState;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SourceBackedRefreshProgress {
     pub phase: String,

--- a/crates/ctx-history-refresh/src/engine/request_lifecycle/recovery.rs
+++ b/crates/ctx-history-refresh/src/engine/request_lifecycle/recovery.rs
@@ -31,9 +31,10 @@ impl CoreRefreshEngine {
         let request_state = job
             .get("request_state")
             .and_then(Value::as_str)
-            .unwrap_or("unknown");
+            // Unknown top-level states remain non-recoverable, not errors.
+            .and_then(|state| state.parse::<SourceBackedRefreshState>().ok());
 
-        if request_state == "published" {
+        if request_state == Some(SourceBackedRefreshState::Published) {
             let attempt = recover_published_attempt(&job)?;
             let receipt = attempt
                 .receipt
@@ -62,9 +63,9 @@ impl CoreRefreshEngine {
             return Ok(has_successors);
         }
 
-        let interrupted_running = request_state == "running";
+        let interrupted_running = request_state == Some(SourceBackedRefreshState::Running);
 
-        if request_state == "failed" {
+        if request_state == Some(SourceBackedRefreshState::Failed) {
             let terminal_progress_needs_normalization = job
                 .get("progress")
                 .and_then(Value::as_object)
@@ -134,7 +135,7 @@ impl CoreRefreshEngine {
             return Ok(has_successors);
         }
 
-        if !matches!(request_state, "admission_pending" | "queued" | "running") {
+        if !request_state.is_some_and(SourceBackedRefreshState::is_active) {
             if let Some(verified) = verified {
                 self.lock_state().current_published_generation =
                     Some(verified.generation_id().to_owned());
@@ -233,7 +234,11 @@ fn require_scoped_rehydration(attempt: &mut SourceBackedRefreshAttempt) -> Resul
 }
 
 fn recover_published_attempt(job: &Value) -> Result<SourceBackedRefreshAttempt> {
-    require_terminal_state(job, "published", "completed")?;
+    require_terminal_state(
+        job,
+        SourceBackedRefreshState::Published.as_str(),
+        "completed",
+    )?;
     let receipt = published_refresh_receipt_for_recovery(job)
         .context("recover durable terminal source refresh receipt")?;
     validate_terminal_receipt_fields(job, &receipt)?;
@@ -266,7 +271,7 @@ fn validate_terminal_receipt_fields(
 }
 
 fn recover_failed_attempt(job: &Value) -> Result<SourceBackedRefreshAttempt> {
-    require_terminal_state(job, "failed", "failed")?;
+    require_terminal_state(job, SourceBackedRefreshState::Failed.as_str(), "failed")?;
     if job.get("receipt").is_some() {
         bail!("durable failed source refresh unexpectedly contains a terminal receipt");
     }

--- a/crates/ctx-history-refresh/src/engine/route_admission.rs
+++ b/crates/ctx-history-refresh/src/engine/route_admission.rs
@@ -171,7 +171,7 @@ impl CoreRefreshEngine {
             "owner": "daemon",
             "request_id": request_id,
             "logical_request_id": request_id,
-            "request_state": "queued",
+            "request_state": SourceBackedRefreshState::Queued.as_str(),
             "logical_phase": "waiting",
             "previous_generation": published_generation.clone(),
             "published_generation": published_generation,

--- a/crates/ctx-history-refresh/src/engine/tests/durable_receipt.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/durable_receipt.rs
@@ -36,6 +36,24 @@ fn publish_synthetic_terminal(
 }
 
 #[test]
+fn unknown_top_level_request_state_is_ignored_for_recovery() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    ctx_history_platform::platform_security::establish_private_data_root(&data_root).unwrap();
+    write_daemon_job_status(
+        &daemon_source_backed_refresh_job_path(&data_root),
+        &json!({ "request_state": "unknown" }),
+    )
+    .unwrap();
+
+    let restarted = test_refresh_engine();
+    assert!(!restarted
+        .recover_interrupted_publication(&data_root)
+        .unwrap());
+    assert!(!restarted.has_pending_request());
+}
+
+#[test]
 fn published_terminal_without_generation_recovers_from_the_journal() {
     let temp = tempfile::tempdir().unwrap();
     let data_root = temp.path().join("data");

--- a/crates/ctx-history-refresh/src/publication.rs
+++ b/crates/ctx-history-refresh/src/publication.rs
@@ -231,7 +231,9 @@ fn published_generation_receipt(
     let Some(job) = journal.load(data_root)? else {
         return Ok(None);
     };
-    if job.get("request_state").and_then(Value::as_str) != Some("published") {
+    if job.get("request_state").and_then(Value::as_str)
+        != Some(RefreshRequestState::Published.as_str())
+    {
         return Ok(None);
     }
     Ok(job

--- a/crates/ctx-history-refresh/src/request.rs
+++ b/crates/ctx-history-refresh/src/request.rs
@@ -244,16 +244,14 @@ mod refresh_request_state_tests {
 
     #[test]
     fn wire_names_and_lifecycle_partitions_are_canonical() {
+        use RefreshRequestState::*;
+
         let cases = [
-            (
-                RefreshRequestState::AdmissionPending,
-                "admission_pending",
-                true,
-            ),
-            (RefreshRequestState::Queued, "queued", true),
-            (RefreshRequestState::Running, "running", true),
-            (RefreshRequestState::Published, "published", false),
-            (RefreshRequestState::Failed, "failed", false),
+            (AdmissionPending, "admission_pending", true),
+            (Queued, "queued", true),
+            (Running, "running", true),
+            (Published, "published", false),
+            (Failed, "failed", false),
         ];
 
         for (state, wire_name, active) in cases {

--- a/crates/ctx-history-refresh/src/request.rs
+++ b/crates/ctx-history-refresh/src/request.rs
@@ -204,6 +204,20 @@ pub enum RefreshRequestState {
 }
 
 impl RefreshRequestState {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::AdmissionPending => "admission_pending",
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Published => "published",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub const fn is_active(self) -> bool {
+        matches!(self, Self::AdmissionPending | Self::Queued | Self::Running)
+    }
+
     pub const fn is_terminal(self) -> bool {
         matches!(self, Self::Published | Self::Failed)
     }
@@ -220,6 +234,33 @@ impl std::str::FromStr for RefreshRequestState {
             "published" => Ok(Self::Published),
             "failed" => Ok(Self::Failed),
             _ => bail!("source refresh response has unknown typed state `{value}`"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod refresh_request_state_tests {
+    use super::RefreshRequestState;
+
+    #[test]
+    fn wire_names_and_lifecycle_partitions_are_canonical() {
+        let cases = [
+            (
+                RefreshRequestState::AdmissionPending,
+                "admission_pending",
+                true,
+            ),
+            (RefreshRequestState::Queued, "queued", true),
+            (RefreshRequestState::Running, "running", true),
+            (RefreshRequestState::Published, "published", false),
+            (RefreshRequestState::Failed, "failed", false),
+        ];
+
+        for (state, wire_name, active) in cases {
+            assert_eq!(state.as_str(), wire_name);
+            assert_eq!(wire_name.parse::<RefreshRequestState>().unwrap(), state);
+            assert_eq!(state.is_active(), active);
+            assert_eq!(state.is_terminal(), !active);
         }
     }
 }

--- a/crates/ctx-terminal/src/ui/components/refresh_progress.rs
+++ b/crates/ctx-terminal/src/ui/components/refresh_progress.rs
@@ -212,6 +212,7 @@ impl RefreshProgressSnapshot {
     }
 }
 
+/// Terminal-neutral presentation projection of engine refresh request state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RefreshRequestState {
     AdmissionPending,


### PR DESCRIPTION
## Summary

- make `ctx_history_refresh::RefreshRequestState` own the five engine/daemon request-state wire names and active/terminal lifecycle classification
- use that type directly in the refresh engine through its internal alias, and route daemon/Core capability output through its canonical names
- keep `ctx-terminal` dependency-neutral with its existing public presentation DTO, with a five-state boundary test proving name parity

## Behavior preserved

- exact five wire strings, serde shape, state transitions, active-state meaning, public APIs, and progress output
- unknown top-level durable states still produce no recovery
- malformed queued successors retain the bounded `durable source refresh successor is not queued` error
- `ctx-terminal` keeps its public enum and field types without a dependency on `ctx-history-refresh`

## Validation

- `scripts/bazelw test //:rustfmt_check --config=test`
- `scripts/bazelw test //:terminal_dependency_boundary_check --config=test`
- focused durable-recovery and terminal-projection tests in `ctx-history-refresh` and `ctx-history-cli`
- `scripts/bazelw test //crates/ctx-daemon-service:unit_tests --config=test --test_filter=source_backed_refresh_coordinator::`
- `scripts/bazelw test //crates/ctx-cli:unit_tests --config=test --test_filter=core_capability::tests::`
- `bash scripts/check-repository-policy.sh`
- `scripts/bazel-affected.sh origin/main` (89/89 targets)
- `scripts/check.sh --mode=ci` (450 build targets; 211/211 test targets)
