### PR TITLE
fix(terminal): restore raw output ownership

### DIFF
--- a/crates/ctx-cli/src/core_capability.rs
+++ b/crates/ctx-cli/src/core_capability.rs
@@ -109,10 +109,12 @@ pub(crate) fn intercept(arguments: &[std::ffi::OsString]) -> Option<ExitCode> {
         .get(1)
         .is_some_and(|value| value == MANAGED_PAIR_APPLY_INVOCATION)
     {
-        return Some(match managed_pair_apply::run(arguments) {
+        let result =
+            crate::output::with_stdout_writer(|writer| managed_pair_apply::run(arguments, writer));
+        return Some(match result {
             Ok(()) => ExitCode::SUCCESS,
             Err(error) => {
-                eprintln!("{error:#}");
+                crate::output::write_stderr_line(format_args!("{error:#}"));
                 ExitCode::FAILURE
             }
         });
@@ -122,10 +124,13 @@ pub(crate) fn intercept(arguments: &[std::ffi::OsString]) -> Option<ExitCode> {
         .get(1)
         .is_some_and(|value| value == MANAGED_PAIR_RECONCILE_INVOCATION)
     {
-        return Some(match managed_pair_reconcile::run(arguments) {
+        let result = crate::output::with_stdout_writer(|writer| {
+            managed_pair_reconcile::run(arguments, writer)
+        });
+        return Some(match result {
             Ok(()) => ExitCode::SUCCESS,
             Err(error) => {
-                eprintln!("{error:#}");
+                crate::output::write_stderr_line(format_args!("{error:#}"));
                 ExitCode::FAILURE
             }
         });
@@ -137,7 +142,7 @@ pub(crate) fn intercept(arguments: &[std::ffi::OsString]) -> Option<ExitCode> {
         return Some(match run_hosted_uninstall_post_exit(arguments) {
             Ok(()) => ExitCode::SUCCESS,
             Err(error) => {
-                eprintln!("{error:#}");
+                crate::output::write_stderr_line(format_args!("{error:#}"));
                 ExitCode::FAILURE
             }
         });
@@ -169,7 +174,9 @@ fn capability_exit_code(result: Result<()>) -> ExitCode {
 }
 
 fn run() -> Result<()> {
-    run_with_protocol_io(std::io::stdin().lock(), std::io::stdout().lock(), execute)
+    crate::output::with_stdout_writer(|writer| {
+        run_with_protocol_io(std::io::stdin().lock(), writer, execute)
+    })
 }
 
 fn run_with_protocol_io(

--- a/crates/ctx-cli/src/core_capability/managed_pair_apply.rs
+++ b/crates/ctx-cli/src/core_capability/managed_pair_apply.rs
@@ -97,13 +97,13 @@ pub(super) fn managed_core_destination(install_root: &Path) -> PathBuf {
     install_root.join(executable)
 }
 
-pub(super) fn run(arguments: &[std::ffi::OsString]) -> Result<()> {
+pub(super) fn run(arguments: &[std::ffi::OsString], writer: impl std::io::Write) -> Result<()> {
     let request = ApplyRequest::parse(arguments)?;
     request.require_running_core(
         &std::env::current_exe().context("resolve running managed-pair candidate Core")?,
     )?;
     apply(&request)?;
-    write_response_frame(std::io::stdout().lock(), SUCCESS_RECEIPT)
+    write_response_frame(writer, SUCCESS_RECEIPT)
 }
 
 fn apply(request: &ApplyRequest) -> Result<()> {

--- a/crates/ctx-cli/src/core_capability/managed_pair_reconcile.rs
+++ b/crates/ctx-cli/src/core_capability/managed_pair_reconcile.rs
@@ -24,7 +24,7 @@ pub(super) const fn success_receipt() -> &'static [u8] {
     SUCCESS_RECEIPT
 }
 
-pub(super) fn run(arguments: &[std::ffi::OsString]) -> Result<()> {
+pub(super) fn run(arguments: &[std::ffi::OsString], writer: impl std::io::Write) -> Result<()> {
     if arguments.len() != ARGUMENT_COUNT || arguments[3] != OsStr::new("-") {
         bail!("invalid managed-pair reconciliation invocation");
     }
@@ -67,5 +67,5 @@ pub(super) fn run(arguments: &[std::ffi::OsString]) -> Result<()> {
         bail!("managed-pair reconciliation requires an installed signed pair");
     }
     reconcile_managed_pair_integration_under_installation_lock(&install_root, &integration)?;
-    write_response_frame(std::io::stdout().lock(), success_receipt())
+    write_response_frame(writer, success_receipt())
 }

--- a/crates/ctx-cli/src/upgrade/ports.rs
+++ b/crates/ctx-cli/src/upgrade/ports.rs
@@ -279,6 +279,31 @@ impl AutomaticUpgradePolicyProvider for CliAutomaticUpgradePolicy {
 pub(crate) struct CliUpgradeObserver;
 
 impl UpgradeObserver<ctx_daemon_cli::DaemonConfigSnapshot> for CliUpgradeObserver {
+    fn observe_automatic_warnings(
+        &self,
+        _data_root: &Path,
+        _config: &ctx_daemon_cli::DaemonConfigSnapshot,
+        warnings: &[String],
+    ) {
+        let mut ui = crate::ui::Ui::stdio(crate::ui::ColorMode::Auto);
+        for warning in warnings {
+            let document = crate::ui::diagnostic(
+                ui.stderr_context(),
+                crate::ui::Diagnostic {
+                    level: crate::ui::DiagnosticLevel::Warning,
+                    summary: warning,
+                    detail: None,
+                    fields: &[],
+                    action: None,
+                },
+            );
+            if ui.write_stderr(&document).is_err() {
+                return;
+            }
+        }
+        let _ = ui.flush();
+    }
+
     fn observe_automatic_terminal(
         &self,
         data_root: &Path,

--- a/crates/ctx-terminal/src/output.rs
+++ b/crates/ctx-terminal/src/output.rs
@@ -201,14 +201,12 @@ impl<W: Write> Write for MeasuredWriter<W> {
 
 fn write_stream(stream: StreamKind, arguments: fmt::Arguments<'_>, newline: bool) {
     let result = match stream {
-        StreamKind::Stdout => {
-            let stdout = io::stdout();
-            let mut writer = MeasuredWriter::current(stdout.lock(), stream);
+        StreamKind::Stdout => with_stdout_writer(|writer| {
             writer
                 .write_fmt(arguments)
                 .and_then(|()| newline.then(|| writer.write_all(b"\n")).transpose())
                 .map(|_| ())
-        }
+        }),
         StreamKind::Stderr => {
             let stderr = io::stderr();
             let mut writer = MeasuredWriter::current(stderr.lock(), stream);
@@ -231,6 +229,12 @@ pub fn write_stdout_line(arguments: fmt::Arguments<'_>) {
 
 pub fn write_stderr_line(arguments: fmt::Arguments<'_>) {
     write_stream(StreamKind::Stderr, arguments, true);
+}
+
+pub fn with_stdout_writer<T>(operation: impl FnOnce(&mut dyn Write) -> T) -> T {
+    let stdout = io::stdout();
+    let mut writer = MeasuredWriter::current(stdout.lock(), StreamKind::Stdout);
+    operation(&mut writer)
 }
 
 pub fn stderr_writer() -> impl Write {

--- a/crates/ctx-terminal/tests/raw_output_policy.rs
+++ b/crates/ctx-terminal/tests/raw_output_policy.rs
@@ -38,14 +38,6 @@ const DIRECT_OUTPUT_BOUNDARIES: &[(&str, &[(&str, usize)])] = &[
     ),
     ("crates/ctx-cli/src/companion.rs", &[("stderr()", 3)]),
     (
-        "crates/ctx-cli/src/core_capability.rs",
-        &[("eprintln!", 2), ("stdout()", 1)],
-    ),
-    (
-        "crates/ctx-cli/src/core_capability/managed_pair_apply.rs",
-        &[("stdout()", 1)],
-    ),
-    (
         "crates/ctx-cli/src/dispatch.rs",
         &[("eprintln!", 2), ("stdout()", 1), ("stderr()", 1)],
     ),
@@ -487,11 +479,11 @@ fn forbidden_direct_output_mutations_are_detected() {
     );
     assert_eq!(
         direct_output_counts("std::io::stdout();"),
-        approved_direct_output_counts("crates/ctx-cli/src/core_capability/managed_pair_apply.rs")
+        approved_direct_output_counts("crates/ctx-cli/src/mcp.rs")
     );
     assert_ne!(
         direct_output_counts("std::io::stdout(); std::io::stdout();"),
-        approved_direct_output_counts("crates/ctx-cli/src/core_capability/managed_pair_apply.rs"),
+        approved_direct_output_counts("crates/ctx-cli/src/mcp.rs"),
         "an additional call inside an approved path must be rejected"
     );
 }

--- a/crates/ctx-upgrade-engine/src/upgrade.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade.rs
@@ -237,6 +237,8 @@ pub struct AutomaticUpgradeObservation<'a> {
 }
 
 pub trait UpgradeObserver<S: AutomaticUpgradePolicySnapshot> {
+    fn observe_automatic_warnings(&self, _data_root: &Path, _policy: &S, _warnings: &[String]) {}
+
     fn observe_automatic_terminal(
         &self,
         data_root: &Path,

--- a/crates/ctx-upgrade-engine/src/upgrade/command/daemon/finalization.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/command/daemon/finalization.rs
@@ -59,9 +59,7 @@ where
             started.elapsed(),
         );
     }
-    for warning in warnings {
-        eprintln!("warning: {warning}");
-    }
+    observer.observe_automatic_warnings(data_root, current, &warnings);
     Ok(())
 }
 
@@ -95,18 +93,22 @@ where
     drop(lock);
     let restart = handoff.resume_with(install_path);
     if committed {
+        let mut warnings = Vec::new();
         let automatic = match terminal {
             Ok(automatic) => automatic,
             Err(error) => {
-                eprintln!(
-                    "warning: ctx upgrade is applied, but applied-state recovery is pending: {error:#}"
-                );
+                warnings.push(format!(
+                    "ctx upgrade is applied, but applied-state recovery is pending: {error:#}"
+                ));
                 observe_without_retry_evidence
             }
         };
         if let Err(error) = restart {
-            eprintln!("warning: ctx upgrade is applied, but daemon restart is pending: {error:#}");
+            warnings.push(format!(
+                "ctx upgrade is applied, but daemon restart is pending: {error:#}"
+            ));
         }
+        observer.observe_automatic_warnings(data_root, current, &warnings);
         if automatic {
             send_daemon_upgrade_terminal(
                 observer,

--- a/crates/ctx-upgrade-engine/src/upgrade/command/daemon/tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/command/daemon/tests.rs
@@ -14,6 +14,12 @@ use std::{fs, os::unix::fs::PermissionsExt as _, sync::Mutex};
 
 static APPLIED_STATE_WRITE_ENV_LOCK: Mutex<()> = Mutex::new(());
 
+#[derive(Default)]
+struct RecordingObserver {
+    terminals: Mutex<Vec<(String, UpgradeTerminalStatus, bool)>>,
+    warnings: Mutex<Vec<String>>,
+}
+
 impl AutomaticUpgradePolicySnapshot for () {
     fn daemon_maintenance_enabled(&self) -> bool {
         true
@@ -32,14 +38,18 @@ impl AutomaticUpgradePolicySnapshot for () {
     }
 }
 
-impl UpgradeObserver<()> for Mutex<Vec<(String, UpgradeTerminalStatus, bool)>> {
+impl UpgradeObserver<()> for RecordingObserver {
+    fn observe_automatic_warnings(&self, _data_root: &Path, _policy: &(), warnings: &[String]) {
+        self.warnings.lock().unwrap().extend_from_slice(warnings);
+    }
+
     fn observe_automatic_terminal(
         &self,
         _data_root: &Path,
         _policy: &(),
         observation: AutomaticUpgradeObservation<'_>,
     ) {
-        self.lock().unwrap().push((
+        self.terminals.lock().unwrap().push((
             observation.attempt_id.to_owned(),
             observation.status,
             observation.applied,
@@ -168,7 +178,7 @@ fn post_apply_state_and_restart_faults_recover_one_truthful_applied_event() {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let (_temp, data_root, install, lock, attempt, plan) = automatic_fixture(true);
-    let observer = Mutex::new(Vec::new());
+    let observer = RecordingObserver::default();
     let fault_key = "CTX_UPGRADE_FAIL_APPLIED_STATE_WRITE_FOR_TESTS";
     let previous_fault = std::env::var_os(fault_key);
     std::env::set_var(fault_key, attempt.id());
@@ -189,7 +199,7 @@ fn post_apply_state_and_restart_faults_recover_one_truthful_applied_event() {
         Some(value) => std::env::set_var(fault_key, value),
         None => std::env::remove_var(fault_key),
     }
-    assert!(observer.lock().unwrap().is_empty());
+    assert!(observer.terminals.lock().unwrap().is_empty());
     assert_eq!(state_value(&install)["status"], "applying");
 
     let installation = InstallationLock::try_acquire(&install).unwrap().unwrap();
@@ -212,12 +222,20 @@ fn post_apply_state_and_restart_faults_recover_one_truthful_applied_event() {
     .unwrap();
 
     assert_eq!(
-        *observer.lock().unwrap(),
+        *observer.terminals.lock().unwrap(),
         [(
             attempt.id().to_owned(),
             UpgradeTerminalStatus::Applied,
             true
         )]
+    );
+    assert_eq!(
+        *observer.warnings.lock().unwrap(),
+        [
+            "ctx upgrade is applied, but applied-state finalization is pending: injected applied-state write failure",
+            "ctx upgrade is applied, but daemon restart is pending: injected daemon restart failure",
+            "ctx upgrade is applied, but daemon restart is pending: injected recovery restart failure",
+        ]
     );
     let state = state_value(&install);
     assert_eq!(state["status"], "applied");
@@ -232,7 +250,7 @@ fn generic_committed_recovery_state_fault_emits_one_truthful_applied_event() {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let (_temp, data_root, install, lock, attempt, _plan) = automatic_fixture(false);
-    let observer = Mutex::new(Vec::new());
+    let observer = RecordingObserver::default();
     let fault_key = "CTX_UPGRADE_FAIL_APPLIED_STATE_WRITE_FOR_TESTS";
     let previous_fault = std::env::var_os(fault_key);
     std::env::set_var(fault_key, attempt.id());
@@ -256,12 +274,19 @@ fn generic_committed_recovery_state_fault_emits_one_truthful_applied_event() {
         None => std::env::remove_var(fault_key),
     }
     assert_eq!(
-        *observer.lock().unwrap(),
+        *observer.terminals.lock().unwrap(),
         [(
             attempt.id().to_owned(),
             UpgradeTerminalStatus::Applied,
             true
         )]
+    );
+    assert_eq!(
+        *observer.warnings.lock().unwrap(),
+        [
+            "ctx upgrade is applied, but applied-state recovery is pending: injected applied-state write failure",
+            "ctx upgrade is applied, but daemon restart is pending: injected daemon restart failure",
+        ]
     );
     let state = state_value(&install);
     assert_eq!(state["status"], "applying");


### PR DESCRIPTION
## Summary\n\n- route managed-pair protocol stdout through the measured terminal writer\n- render managed upgrade warnings through the observer/presentation boundary\n- remove raw-output allowlist entries without raising any threshold\n\n## Validation\n\n- full CI: 450 build targets and 211 test targets passed\n- affected tests: 89/89 passed\n- repository policy, crate-size/LOC, rustfmt, and diff checks passed\n- independent final review: no findings