### PR TITLE
Simplify refresh compatibility and close dogfood gaps

### DIFF
--- a/crates/ctx-cli/src/companion.rs
+++ b/crates/ctx-cli/src/companion.rs
@@ -377,13 +377,14 @@ fn mcp_limits() -> Result<BridgeLimits, CompanionRouteError> {
 
 fn paid_family_arguments(arguments: &[OsString]) -> Option<Vec<OsString>> {
     let explicit_pro = has_explicit_pro_selector(arguments);
+    let mut router_selector_index = None;
     let mut index = 1;
     while let Some(argument) = arguments.get(index) {
         if is_global_help_or_version(argument) {
             return arguments[1..index]
                 .iter()
                 .any(|candidate| candidate == "--pro")
-                .then(|| arguments[1..].to_vec());
+                .then(|| forwarded_paid_arguments(arguments, router_selector_index));
         }
         if argument == "--" {
             index += 1;
@@ -391,6 +392,11 @@ fn paid_family_arguments(arguments: &[OsString]) -> Option<Vec<OsString>> {
         }
         if argument == "--data-root" || argument == "--color" {
             index = index.saturating_add(2);
+            continue;
+        }
+        if argument == "--pro" {
+            router_selector_index.get_or_insert(index);
+            index += 1;
             continue;
         }
         if argument == "--quiet"
@@ -405,7 +411,7 @@ fn paid_family_arguments(arguments: &[OsString]) -> Option<Vec<OsString>> {
                 .iter()
                 .any(|family| argument == family)
         {
-            return Some(arguments[1..].to_vec());
+            return Some(forwarded_paid_arguments(arguments, router_selector_index));
         }
         if argument == "help"
             && arguments.get(index + 1).is_some_and(|candidate| {
@@ -430,19 +436,30 @@ fn paid_family_arguments(arguments: &[OsString]) -> Option<Vec<OsString>> {
                 })
             })
         {
-            return Some(arguments[1..].to_vec());
+            return Some(forwarded_paid_arguments(arguments, router_selector_index));
         }
         return None;
     }
     if explicit_pro {
-        return Some(arguments[1..].to_vec());
+        return Some(forwarded_paid_arguments(arguments, router_selector_index));
     }
     arguments.get(index).and_then(|argument| {
         ["pro", "blame", "referral"]
             .iter()
             .any(|family| argument == family)
-            .then(|| arguments[1..].to_vec())
+            .then(|| forwarded_paid_arguments(arguments, router_selector_index))
     })
+}
+
+fn forwarded_paid_arguments(
+    arguments: &[OsString],
+    router_selector_index: Option<usize>,
+) -> Vec<OsString> {
+    let mut forwarded = arguments[1..].to_vec();
+    if let Some(index) = router_selector_index {
+        forwarded.remove(index - 1);
+    }
+    forwarded
 }
 
 /// Resolves only the public wrapper facts needed to persist a completed Blame

--- a/crates/ctx-cli/src/companion/contract_tests.rs
+++ b/crates/ctx-cli/src/companion/contract_tests.rs
@@ -67,19 +67,22 @@ fn paid_cli_environment(forwards_core_setup: bool) -> CompanionEnvironment {
 }
 
 #[test]
-fn paid_gate_forwards_the_original_arguments_without_paid_parsing() {
-    let arguments = [
-        OsString::from("ctx"),
-        OsString::from("--data-root"),
-        OsString::from("opaque-root"),
-        OsString::from("blame"),
-        OsString::from("--private-option"),
-        OsString::from("opaque-value"),
-    ];
-    assert_eq!(
-        paid_family_arguments(&arguments),
-        Some(arguments[1..].to_vec())
-    );
+fn paid_gate_forwards_ordinary_paid_families_without_parsing() {
+    for family in ["pro", "blame", "referral"] {
+        let arguments = [
+            OsString::from("ctx"),
+            OsString::from("--data-root"),
+            OsString::from("opaque-root"),
+            OsString::from(family),
+            OsString::from("--private-option"),
+            OsString::from("opaque-value"),
+        ];
+        assert_eq!(
+            paid_family_arguments(&arguments),
+            Some(arguments[1..].to_vec()),
+            "{family}"
+        );
+    }
 }
 
 #[test]
@@ -100,12 +103,38 @@ fn core_routes_never_enter_the_companion_gate() {
 }
 
 #[test]
-fn explicit_pro_selector_routes_setup_and_other_core_families() {
+fn router_owned_pro_selector_is_removed_before_companion_forwarding() {
+    for (arguments, expected) in [
+        (
+            vec!["ctx", "--pro", "status", "--format", "json"],
+            vec!["status", "--format", "json"],
+        ),
+        (
+            vec!["ctx", "--data-root", "opaque-root", "--pro", "status"],
+            vec!["--data-root", "opaque-root", "status"],
+        ),
+        (vec!["ctx", "--pro", "setup"], vec!["setup"]),
+        (vec!["ctx", "--pro", "pro"], vec!["pro"]),
+        (vec!["ctx", "--pro", "blame"], vec!["blame"]),
+        (vec!["ctx", "--pro", "referral"], vec!["referral"]),
+        (vec!["ctx", "--pro", "--help"], vec!["--help"]),
+    ] {
+        let arguments = arguments
+            .into_iter()
+            .map(OsString::from)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            paid_family_arguments(&arguments),
+            Some(expected.into_iter().map(OsString::from).collect())
+        );
+    }
+}
+
+#[test]
+fn command_owned_setup_pro_is_preserved() {
     for arguments in [
-        vec!["ctx", "--pro", "setup"],
-        vec!["ctx", "setup", "--pro"],
-        vec!["ctx", "--pro", "status"],
-        vec!["ctx", "--pro", "--help"],
+        vec!["ctx", "setup", "--pro", "--format", "json"],
+        vec!["ctx", "--data-root", "opaque-root", "setup", "--pro"],
         vec!["ctx", "help", "setup", "--pro"],
     ] {
         let arguments = arguments

--- a/crates/ctx-daemon-service/src/daemon/tests.rs
+++ b/crates/ctx-daemon-service/src/daemon/tests.rs
@@ -909,7 +909,7 @@ fn forced_watcher_recovery_adds_no_scans_after_startup_reconciliation() -> Resul
                     "schema_version": 1,
                     "op": "source_refresh_request",
                     "mode": "background",
-                    "operation": "refresh",
+                    "refresh_intent": {"kind": "automatic_maintenance"},
                 }),
             )?
             .expect("background maintenance wake");

--- a/crates/ctx-daemon-service/src/daemon_scheduler_tests/refresh_retry.rs
+++ b/crates/ctx-daemon-service/src/daemon_scheduler_tests/refresh_retry.rs
@@ -340,8 +340,10 @@ fn terminal_admission_fence_failure_releases_root_before_exact_dirty_route_runs(
                 "op": "source_refresh_request",
                 "request_id": request_id,
                 "mode": "wait",
-                "operation": "refresh",
-                "fresh_after_admitted_snapshot": true,
+                "refresh_intent": {
+                    "kind": "selected_import",
+                    "selection": {"kind": "all"},
+                },
             }),
         )
         .unwrap()
@@ -450,8 +452,10 @@ fn persistent_admission_status_failure_uses_scheduler_backoff() {
                 "op": "source_refresh_request",
                 "request_id": request_id,
                 "mode": "wait",
-                "operation": "refresh",
-                "fresh_after_admitted_snapshot": true,
+                "refresh_intent": {
+                    "kind": "selected_import",
+                    "selection": {"kind": "all"},
+                },
             }),
         )
         .unwrap()

--- a/crates/ctx-daemon-service/src/daemon_scheduler_tests/refresh_retry/durable_retry.rs
+++ b/crates/ctx-daemon-service/src/daemon_scheduler_tests/refresh_retry/durable_retry.rs
@@ -276,7 +276,7 @@ fn stale_global_backoff_cannot_overwrite_durable_same_id_admission() {
         "op": "source_refresh_request",
         "request_id": request_id,
         "mode": "wait",
-        "operation": "refresh",
+        "refresh_intent": {"kind": "automatic_maintenance"},
     });
     let admitted = coordinator
         .handle_ipc_request(&data_root, &request)

--- a/crates/ctx-daemon-service/src/daemon_wakeup/tests.rs
+++ b/crates/ctx-daemon-service/src/daemon_wakeup/tests.rs
@@ -761,8 +761,10 @@ fn callback_channel_overflow_leaves_terminal_owner_and_queues_distinct_maintenan
                 "op": "source_refresh_request",
                 "request_id": request_id,
                 "mode": "wait",
-                "operation": "refresh",
-                "fresh_after_admitted_snapshot": true,
+                "refresh_intent": {
+                    "kind": "selected_import",
+                    "selection": {"kind": "all"},
+                },
             }),
         )?
         .expect("wait admission");

--- a/crates/ctx-daemon-service/src/query_service_transport_tests.rs
+++ b/crates/ctx-daemon-service/src/query_service_transport_tests.rs
@@ -1032,7 +1032,7 @@ fn query_service_coalesces_source_refresh_requests_on_one_daemon_ticket() -> Res
                 "schema_version": 1,
                 "op": "source_refresh_request",
                 "mode": "wait",
-                "operation": "refresh",
+                "refresh_intent": {"kind": "automatic_maintenance"},
             })),
             StdDuration::from_secs(1),
             64 * 1024,

--- a/crates/ctx-daemon-service/src/source_backed_refresh_adapter/wire.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_adapter/wire.rs
@@ -1,11 +1,9 @@
-use std::{collections::BTreeSet, path::Path};
+use std::path::Path;
 
 use anyhow::{anyhow, bail, Context, Result};
-use ctx_history_core::CaptureProvider;
-use ctx_history_index::SourceRouteIdentity;
 use ctx_history_refresh::{
-    AdmissionResponseBarrier, ExplicitSourceCatalogAuthority, RefreshEngine, RefreshIntent,
-    RefreshOperation, RefreshRequest, RefreshRequestTrigger, RefreshSelection, RefreshStatus,
+    AdmissionResponseBarrier, RefreshEngine, RefreshIntent, RefreshRequest, RefreshRequestTrigger,
+    RefreshStatus,
 };
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -15,7 +13,6 @@ use crate::source_backed_refresh_coordinator::CoreRefreshEngine;
 
 const SOURCE_REFRESH_REQUEST_OP: &str = "source_refresh_request";
 const SOURCE_REFRESH_STATUS_OP: &str = "source_refresh_status";
-const SOURCE_REFRESH_RECOVERY_ROUTE_LIMIT: usize = 256;
 
 #[derive(Debug)]
 pub(crate) struct WireResponse {
@@ -124,173 +121,49 @@ enum WireRefreshAction {
     Submit(RefreshRequest),
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum WireRefreshSelector {
-    AllAutomatic,
-    AutomaticProvider(CaptureProvider),
-    ExplicitCatalog,
-}
-
-impl WireRefreshSelector {
-    fn from_json(value: &Value) -> Result<Self> {
-        let fields = value
-            .as_object()
-            .ok_or_else(|| anyhow!("source refresh selector is not an object"))?;
-        match fields.get("kind").and_then(Value::as_str) {
-            Some("all_automatic") if fields.len() == 1 => Ok(Self::AllAutomatic),
-            Some("automatic_provider") if fields.len() == 2 => {
-                let provider = fields
-                    .get("provider")
-                    .and_then(Value::as_str)
-                    .ok_or_else(|| anyhow!("automatic provider selector has no provider"))?
-                    .parse()
-                    .context("parse automatic provider selector")?;
-                if provider == CaptureProvider::Unknown {
-                    bail!("automatic provider selector has an unknown provider");
-                }
-                Ok(Self::AutomaticProvider(provider))
-            }
-            Some("explicit_catalog") if fields.len() == 1 => Ok(Self::ExplicitCatalog),
-            Some(kind) => bail!("source refresh selector `{kind}` is malformed"),
-            None => bail!("source refresh selector kind is missing"),
-        }
-    }
-
-    const fn is_scoped(self) -> bool {
-        !matches!(self, Self::AllAutomatic)
-    }
-}
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum WireRefreshScope {
-    All,
-    Exact,
-}
-
 fn refresh_action(request: &Value) -> Result<WireRefreshAction> {
     let mode = request.get("mode").and_then(Value::as_str).unwrap_or("");
     if !matches!(mode, "background" | "wait") {
         return Err(anyhow!("invalid daemon source refresh mode `{mode}`"));
     }
-    if let Some(intent_json) = request.get("refresh_intent") {
-        for legacy_field in [
-            "operation",
-            "refresh_selector",
-            "explicit_source_catalog",
-            "fresh_after_admitted_snapshot",
-            "refresh_scope",
-        ] {
-            if request.get(legacy_field).is_some() {
-                bail!(
-                    "canonical daemon source refresh request also carries legacy `{legacy_field}`"
-                );
-            }
+    let intent_json = request
+        .get("refresh_intent")
+        .ok_or_else(|| anyhow!("daemon source refresh intent is missing"))?;
+    for retired_field in [
+        "operation",
+        "refresh_selector",
+        "explicit_source_catalog",
+        "fresh_after_admitted_snapshot",
+        "refresh_scope",
+    ] {
+        if request.get(retired_field).is_some() {
+            bail!("canonical daemon source refresh request carries retired `{retired_field}`");
         }
-        let intent = RefreshIntent::from_json(intent_json)
-            .context("parse canonical daemon source refresh intent")?;
-        let trigger = request
-            .get("trigger")
-            .and_then(Value::as_str)
-            .map(str::parse::<RefreshRequestTrigger>)
-            .transpose()?
-            .unwrap_or(match &intent {
-                RefreshIntent::AutomaticMaintenance => RefreshRequestTrigger::Search,
-                RefreshIntent::SelectedImport(_) => RefreshRequestTrigger::Import,
-            });
-        if !matches!(
-            (&intent, trigger),
-            (
-                RefreshIntent::AutomaticMaintenance,
-                RefreshRequestTrigger::Setup
-                    | RefreshRequestTrigger::Search
-                    | RefreshRequestTrigger::Import
-            ) | (
-                RefreshIntent::SelectedImport(_),
-                RefreshRequestTrigger::Import
-            )
-        ) {
-            bail!("daemon source refresh trigger does not match its intent");
-        }
-        let request_id = match request.get("request_id") {
-            Some(Value::String(request_id)) if !request_id.is_empty() => {
-                Uuid::parse_str(request_id)
-                    .context("daemon source refresh logical request ID must be a UUID")?;
-                request_id.clone()
-            }
-            None => Uuid::now_v7().to_string(),
-            Some(_) => bail!("daemon source refresh logical request ID is invalid"),
-        };
-        if mode == "background" {
-            if intent != RefreshIntent::AutomaticMaintenance {
-                bail!("selected import requires daemon refresh mode `wait`");
-            }
-            return Ok(WireRefreshAction::MaintenanceWake { request_id });
-        }
-        return Ok(WireRefreshAction::Submit(RefreshRequest::new(
-            request_id, intent, trigger,
-        )));
     }
-
-    // Decode the pre-canonical schema for compatibility. Legacy physical
-    // scope remains rejected; it is never converted into executable authority.
-    let operation = request
-        .get("operation")
-        .and_then(Value::as_str)
-        .ok_or_else(|| anyhow!("daemon source refresh request operation is missing"))
-        .and_then(str::parse)?;
+    let intent = RefreshIntent::from_json(intent_json)
+        .context("parse canonical daemon source refresh intent")?;
     let trigger = request
         .get("trigger")
         .and_then(Value::as_str)
         .map(str::parse::<RefreshRequestTrigger>)
         .transpose()?
-        .unwrap_or(match operation {
-            RefreshOperation::Refresh => RefreshRequestTrigger::Search,
-            RefreshOperation::Import => RefreshRequestTrigger::Import,
+        .unwrap_or(match &intent {
+            RefreshIntent::AutomaticMaintenance => RefreshRequestTrigger::Search,
+            RefreshIntent::SelectedImport(_) => RefreshRequestTrigger::Import,
         });
     if !matches!(
-        (operation, trigger),
+        (&intent, trigger),
         (
-            RefreshOperation::Refresh,
+            RefreshIntent::AutomaticMaintenance,
             RefreshRequestTrigger::Setup
                 | RefreshRequestTrigger::Search
                 | RefreshRequestTrigger::Import
-        ) | (RefreshOperation::Import, RefreshRequestTrigger::Import)
+        ) | (
+            RefreshIntent::SelectedImport(_),
+            RefreshRequestTrigger::Import
+        )
     ) {
-        bail!("daemon source refresh trigger does not match its operation");
-    }
-    let explicit_catalog = request.get("explicit_source_catalog");
-    let has_typed_selector = request.get("refresh_selector").is_some();
-    let selector = match request.get("refresh_selector") {
-        Some(value) => {
-            WireRefreshSelector::from_json(value).context("parse daemon source refresh selector")?
-        }
-        None => match (operation, explicit_catalog.is_some()) {
-            (RefreshOperation::Refresh, false) => WireRefreshSelector::AllAutomatic,
-            // Legacy untyped import requests still name one exact source.
-            // Normalize that old shape to the canonical exact-source intent.
-            (RefreshOperation::Import, true) => WireRefreshSelector::ExplicitCatalog,
-            _ => bail!("daemon source refresh selector is missing"),
-        },
-    };
-    if operation == RefreshOperation::Import && mode == "background" {
-        bail!("import operation requires daemon refresh mode `wait`");
-    }
-    if operation == RefreshOperation::Refresh && selector != WireRefreshSelector::AllAutomatic {
-        bail!("refresh operation requires the all-automatic source selector");
-    }
-    match (selector, explicit_catalog.is_some()) {
-        (WireRefreshSelector::AllAutomatic, false)
-        | (WireRefreshSelector::AutomaticProvider(_), false)
-        | (WireRefreshSelector::ExplicitCatalog, true) => {}
-        (WireRefreshSelector::ExplicitCatalog, false) => {
-            bail!("explicit-catalog source refresh selector has no catalog authority")
-        }
-        (WireRefreshSelector::AutomaticProvider(_), true) => {
-            bail!("automatic provider source refresh selector carries explicit catalog authority")
-        }
-        (WireRefreshSelector::AllAutomatic, true) => {
-            bail!("all-automatic source refresh selector carries explicit catalog authority")
-        }
+        bail!("daemon source refresh trigger does not match its intent");
     }
     let request_id = match request.get("request_id") {
         Some(Value::String(request_id)) if !request_id.is_empty() => {
@@ -301,89 +174,15 @@ fn refresh_action(request: &Value) -> Result<WireRefreshAction> {
         None => Uuid::now_v7().to_string(),
         Some(_) => bail!("daemon source refresh logical request ID is invalid"),
     };
-    let fresh_after_admitted_snapshot = match request.get("fresh_after_admitted_snapshot") {
-        None | Some(Value::Bool(false)) => false,
-        Some(Value::Bool(true)) => true,
-        Some(_) => {
-            bail!("daemon source refresh fresh-after-admitted-snapshot requirement must be boolean")
-        }
-    };
-    if operation == RefreshOperation::Refresh
-        && mode == "background"
-        && fresh_after_admitted_snapshot
-    {
-        bail!("background source refresh cannot require a fresh admission snapshot");
-    }
-    if has_typed_selector && selector.is_scoped() && !fresh_after_admitted_snapshot {
-        bail!("scoped source refresh selector requires a fresh admission snapshot");
-    }
-    let requested_catalog = explicit_catalog
-        .map(ExplicitSourceCatalogAuthority::from_json)
-        .transpose()?;
-    let requested_refresh_scope = request
-        .get("refresh_scope")
-        .filter(|value| !value.is_null());
-    if selector.is_scoped() && requested_refresh_scope.is_some() {
-        bail!("scoped source refresh selector cannot carry a physical refresh scope");
-    }
-    let refresh_scope = requested_refresh_scope
-        .map(refresh_scope_from_json)
-        .transpose()?
-        .unwrap_or(WireRefreshScope::All);
-    if refresh_scope == WireRefreshScope::Exact {
-        bail!("physical exact refresh scope is reserved for engine-owned recovery");
-    }
-
     if mode == "background" {
+        if intent != RefreshIntent::AutomaticMaintenance {
+            bail!("selected import requires daemon refresh mode `wait`");
+        }
         return Ok(WireRefreshAction::MaintenanceWake { request_id });
     }
-
-    let intent = match selector {
-        WireRefreshSelector::AllAutomatic if fresh_after_admitted_snapshot => {
-            RefreshIntent::SelectedImport(RefreshSelection::All)
-        }
-        WireRefreshSelector::AllAutomatic => RefreshIntent::AutomaticMaintenance,
-        WireRefreshSelector::AutomaticProvider(provider) => {
-            RefreshIntent::SelectedImport(RefreshSelection::Provider(provider))
-        }
-        WireRefreshSelector::ExplicitCatalog => {
-            RefreshIntent::SelectedImport(RefreshSelection::ExactSource(
-                requested_catalog.expect("validated exact-source catalog authority"),
-            ))
-        }
-    };
     Ok(WireRefreshAction::Submit(RefreshRequest::new(
         request_id, intent, trigger,
     )))
-}
-
-fn refresh_scope_from_json(value: &Value) -> Result<WireRefreshScope> {
-    match value.get("kind").and_then(Value::as_str) {
-        Some("all") => Ok(WireRefreshScope::All),
-        Some("exact") => {
-            let routes = value
-                .get("routes")
-                .and_then(Value::as_array)
-                .ok_or_else(|| anyhow!("exact source refresh recovery scope has no route list"))?;
-            if routes.is_empty() || routes.len() > SOURCE_REFRESH_RECOVERY_ROUTE_LIMIT {
-                bail!(
-                    "exact source refresh recovery scope must contain 1..={SOURCE_REFRESH_RECOVERY_ROUTE_LIMIT} routes"
-                );
-            }
-            let _routes = routes
-                .iter()
-                .map(|route| {
-                    let route = route.as_str().ok_or_else(|| {
-                        anyhow!("exact source refresh recovery route is not a string")
-                    })?;
-                    SourceRouteIdentity::from_sha256(route.to_owned()).map_err(Into::into)
-                })
-                .collect::<Result<BTreeSet<_>>>()?;
-            Ok(WireRefreshScope::Exact)
-        }
-        Some(kind) => bail!("unknown source refresh recovery scope kind `{kind}`"),
-        None => bail!("source refresh recovery scope kind is missing"),
-    }
 }
 
 fn render_status(status: &RefreshStatus) -> Value {
@@ -411,20 +210,8 @@ fn unknown_refresh_request_response(request_id: &str) -> Value {
 mod tests {
     use super::*;
 
-    fn admitted_job(request: Value) -> Value {
-        let temp = tempfile::tempdir().unwrap();
-        let engine = super::super::refresh_engine(&crate::test_support::SOURCE_REFRESH_CONFIG);
-        handle_ipc_request(&engine, temp.path(), &request)
-            .unwrap()
-            .expect("source refresh response");
-        crate::paths_status::read_daemon_job_status(
-            &crate::paths_status::daemon_source_backed_refresh_job_path(temp.path()),
-        )
-        .expect("persisted source refresh job")
-    }
-
     #[test]
-    fn refresh_request_requires_a_typed_operation() {
+    fn refresh_request_requires_a_canonical_intent() {
         let temp = tempfile::tempdir().unwrap();
         let engine = super::super::refresh_engine(&crate::test_support::CONFIG);
         let missing = handle_ipc_request(
@@ -433,7 +220,7 @@ mod tests {
             &json!({"op": SOURCE_REFRESH_REQUEST_OP, "mode": "wait"}),
         )
         .unwrap_err();
-        assert!(format!("{missing:#}").contains("request operation is missing"));
+        assert!(format!("{missing:#}").contains("refresh intent is missing"));
 
         let invalid = handle_ipc_request(
             &engine,
@@ -441,11 +228,11 @@ mod tests {
             &json!({
                 "op": SOURCE_REFRESH_REQUEST_OP,
                 "mode": "wait",
-                "operation": "strict_import",
+                "refresh_intent": {"kind": "strict_import"},
             }),
         )
         .unwrap_err();
-        assert!(format!("{invalid:#}").contains("invalid source refresh operation"));
+        assert!(format!("{invalid:#}").contains("refresh intent `strict_import` is malformed"));
         assert!(!engine.has_pending_request());
     }
 
@@ -470,7 +257,7 @@ mod tests {
             &json!({
                 "op": SOURCE_REFRESH_REQUEST_OP,
                 "mode": "wait",
-                "operation": "refresh",
+                "refresh_intent": {"kind": "automatic_maintenance"},
             }),
         )
         .unwrap()
@@ -499,8 +286,8 @@ mod tests {
             &json!({
                 "op": SOURCE_REFRESH_REQUEST_OP,
                 "mode": "wait",
-                "operation": "refresh",
                 "trigger": "setup",
+                "refresh_intent": {"kind": "automatic_maintenance"},
             }),
         )
         .unwrap()
@@ -517,294 +304,14 @@ mod tests {
     }
 
     #[test]
-    fn legacy_automatic_import_normalizes_to_selected_import_intent() {
-        let temp = tempfile::tempdir().unwrap();
-        let engine = super::super::refresh_engine(&crate::test_support::SOURCE_REFRESH_CONFIG);
-
-        let response = handle_ipc_request(
-            &engine,
-            temp.path(),
-            &json!({
-                "op": SOURCE_REFRESH_REQUEST_OP,
-                "mode": "wait",
-                "operation": "refresh",
-                "trigger": "import",
-                "fresh_after_admitted_snapshot": true,
-            }),
-        )
-        .unwrap()
-        .expect("automatic import refresh response");
-
-        assert_eq!(response.value["operation"], "import");
-        assert_eq!(response.value["trigger"], "import");
-        assert_eq!(response.value["trigger_provenance"], "import_command");
-    }
-
-    #[test]
-    fn typed_import_selectors_remain_distinct_after_wire_admission() {
-        let all = admitted_job(json!({
-            "op": SOURCE_REFRESH_REQUEST_OP,
-            "mode": "wait",
-            "operation": "refresh",
-            "trigger": "import",
-            "refresh_selector": {"kind": "all_automatic"},
-            "fresh_after_admitted_snapshot": true,
-        }));
-        let provider = admitted_job(json!({
-            "op": SOURCE_REFRESH_REQUEST_OP,
-            "mode": "wait",
-            "operation": "import",
-            "trigger": "import",
-            "refresh_selector": {
-                "kind": "automatic_provider",
-                "provider": "codex",
-            },
-            "fresh_after_admitted_snapshot": true,
-        }));
-        let authority = ctx_history_refresh::explicit_source_catalog_authority_for_test(0);
-        let catalog = admitted_job(json!({
-            "op": SOURCE_REFRESH_REQUEST_OP,
-            "mode": "wait",
-            "operation": "import",
-            "trigger": "import",
-            "refresh_selector": {"kind": "explicit_catalog"},
-            "explicit_source_catalog": authority.to_json(),
-            "fresh_after_admitted_snapshot": true,
-        }));
-
-        assert_eq!(
-            all["refresh_intent"],
-            json!({"kind": "selected_import", "selection": {"kind": "all"}})
-        );
-        assert_eq!(
-            provider["refresh_intent"],
-            json!({
-                "kind": "selected_import",
-                "selection": {"kind": "provider", "provider": "codex"},
-            })
-        );
-        assert_ne!(provider["refresh_intent"], all["refresh_intent"]);
-        assert_eq!(
-            catalog["refresh_intent"]["selection"]["kind"],
-            "exact_source"
-        );
-        assert_eq!(
-            catalog["refresh_intent"]["selection"]["authority"],
-            authority.to_json()
-        );
-    }
-
-    #[test]
-    fn selector_wire_validation_fails_closed() {
-        let authority = ctx_history_refresh::explicit_source_catalog_authority_for_test(0);
-        let invalid = [
-            json!({
-                "op": SOURCE_REFRESH_REQUEST_OP,
-                "mode": "wait",
-                "operation": "import",
-                "trigger": "import",
-                "refresh_selector": {"kind": "provider"},
-            }),
-            json!({
-                "op": SOURCE_REFRESH_REQUEST_OP,
-                "mode": "wait",
-                "operation": "import",
-                "trigger": "import",
-                "refresh_selector": {"kind": "automatic_provider"},
-            }),
-            json!({
-                "op": SOURCE_REFRESH_REQUEST_OP,
-                "mode": "wait",
-                "operation": "import",
-                "trigger": "import",
-                "refresh_selector": {
-                    "kind": "automatic_provider",
-                    "provider": "unknown",
-                },
-            }),
-            json!({
-                "op": SOURCE_REFRESH_REQUEST_OP,
-                "mode": "wait",
-                "operation": "refresh",
-                "trigger": "search",
-                "refresh_selector": {
-                    "kind": "automatic_provider",
-                    "provider": "codex",
-                },
-            }),
-            json!({
-                "op": SOURCE_REFRESH_REQUEST_OP,
-                "mode": "background",
-                "operation": "import",
-                "trigger": "import",
-                "refresh_selector": {
-                    "kind": "automatic_provider",
-                    "provider": "codex",
-                },
-            }),
-            json!({
-                "op": SOURCE_REFRESH_REQUEST_OP,
-                "mode": "wait",
-                "operation": "import",
-                "trigger": "import",
-                "refresh_selector": {"kind": "all_automatic"},
-                "explicit_source_catalog": authority.to_json(),
-            }),
-            json!({
-                "op": SOURCE_REFRESH_REQUEST_OP,
-                "mode": "wait",
-                "operation": "import",
-                "trigger": "import",
-                "refresh_selector": {"kind": "explicit_catalog"},
-            }),
-            json!({
-                "op": SOURCE_REFRESH_REQUEST_OP,
-                "mode": "wait",
-                "operation": "import",
-                "trigger": "import",
-                "refresh_selector": {
-                    "kind": "automatic_provider",
-                    "provider": "codex",
-                },
-            }),
-            json!({
-                "op": SOURCE_REFRESH_REQUEST_OP,
-                "mode": "wait",
-                "operation": "import",
-                "trigger": "import",
-                "refresh_selector": {"kind": "explicit_catalog"},
-                "explicit_source_catalog": authority.to_json(),
-                "fresh_after_admitted_snapshot": false,
-            }),
-            json!({
-                "op": SOURCE_REFRESH_REQUEST_OP,
-                "mode": "wait",
-                "operation": "import",
-                "trigger": "import",
-                "refresh_selector": {
-                    "kind": "automatic_provider",
-                    "provider": "codex",
-                },
-                "refresh_scope": {"kind": "all"},
-            }),
-            json!({
-                "op": SOURCE_REFRESH_REQUEST_OP,
-                "mode": "wait",
-                "operation": "import",
-                "trigger": "import",
-            }),
-        ];
-
-        for (index, request) in invalid.into_iter().enumerate() {
-            let temp = tempfile::tempdir().unwrap();
-            let engine = super::super::refresh_engine(&crate::test_support::SOURCE_REFRESH_CONFIG);
-            assert!(
-                handle_ipc_request(&engine, temp.path(), &request).is_err(),
-                "invalid selector request {index} was accepted"
-            );
-            assert!(!engine.has_pending_request());
-        }
-    }
-
-    #[test]
-    fn omitted_selector_normalizes_legacy_request_shapes_once() {
-        let legacy_all = admitted_job(json!({
-            "op": SOURCE_REFRESH_REQUEST_OP,
-            "mode": "wait",
-            "operation": "refresh",
-            "trigger": "import",
-            "fresh_after_admitted_snapshot": true,
-        }));
-        let authority = ctx_history_refresh::explicit_source_catalog_authority_for_test(0);
-        let legacy_catalog = admitted_job(json!({
-            "op": SOURCE_REFRESH_REQUEST_OP,
-            "mode": "wait",
-            "operation": "import",
-            "trigger": "import",
-            "explicit_source_catalog": authority.to_json(),
-            "fresh_after_admitted_snapshot": true,
-        }));
-
-        assert_eq!(
-            legacy_all["refresh_intent"],
-            json!({"kind": "selected_import", "selection": {"kind": "all"}})
-        );
-        assert_eq!(
-            legacy_catalog["refresh_intent"]["selection"]["kind"],
-            "exact_source"
-        );
-        assert_eq!(
-            legacy_catalog["refresh_intent"]["selection"]["authority"],
-            authority.to_json()
-        );
-    }
-
-    #[test]
-    fn wire_fields_decode_to_one_canonical_request() {
-        let authority = ctx_history_refresh::explicit_source_catalog_authority_for_test(0);
-        let cases = [
-            (
-                json!({
-                    "op": SOURCE_REFRESH_REQUEST_OP,
-                    "request_id": "019fcaaa-0000-7000-8000-000000000510",
-                    "mode": "wait",
-                    "operation": "refresh",
-                    "trigger": "import",
-                    "refresh_selector": {"kind": "all_automatic"},
-                    "fresh_after_admitted_snapshot": true,
-                    "refresh_scope": {"kind": "all"},
-                }),
-                RefreshIntent::SelectedImport(RefreshSelection::All),
-            ),
-            (
-                json!({
-                    "op": SOURCE_REFRESH_REQUEST_OP,
-                    "request_id": "019fcaaa-0000-7000-8000-000000000511",
-                    "mode": "wait",
-                    "operation": "import",
-                    "trigger": "import",
-                    "refresh_selector": {
-                        "kind": "automatic_provider",
-                        "provider": "codex",
-                    },
-                    "fresh_after_admitted_snapshot": true,
-                }),
-                RefreshIntent::SelectedImport(RefreshSelection::Provider(CaptureProvider::Codex)),
-            ),
-            (
-                json!({
-                    "op": SOURCE_REFRESH_REQUEST_OP,
-                    "request_id": "019fcaaa-0000-7000-8000-000000000512",
-                    "mode": "wait",
-                    "operation": "import",
-                    "trigger": "import",
-                    "explicit_source_catalog": authority.to_json(),
-                }),
-                RefreshIntent::SelectedImport(RefreshSelection::ExactSource(authority)),
-            ),
-        ];
-
-        for (wire, expected_intent) in cases {
-            let WireRefreshAction::Submit(request) = refresh_action(&wire).unwrap() else {
-                panic!("wait request decoded as maintenance wake");
-            };
-            assert_eq!(Some(request.request_id()), wire["request_id"].as_str());
-            assert_eq!(request.intent(), &expected_intent);
-            assert_eq!(request.trigger(), RefreshRequestTrigger::Import);
-        }
-    }
-
-    #[test]
     fn background_wire_request_decodes_as_maintenance_wake() {
         let request_id = "019fcaaa-0000-7000-8000-000000000513";
         let action = refresh_action(&json!({
             "op": SOURCE_REFRESH_REQUEST_OP,
             "request_id": request_id,
             "mode": "background",
-            "operation": "refresh",
             "trigger": "search",
-            "refresh_selector": {"kind": "all_automatic"},
-            "fresh_after_admitted_snapshot": false,
+            "refresh_intent": {"kind": "automatic_maintenance"},
         }))
         .unwrap();
 
@@ -817,11 +324,11 @@ mod tests {
     }
 
     #[test]
-    fn physical_exact_scope_cannot_widen_through_ipc() {
+    fn canonical_request_rejects_retired_physical_scope() {
         let error = refresh_action(&json!({
             "op": SOURCE_REFRESH_REQUEST_OP,
             "mode": "wait",
-            "operation": "refresh",
+            "refresh_intent": {"kind": "automatic_maintenance"},
             "refresh_scope": {
                 "kind": "exact",
                 "routes": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
@@ -829,6 +336,6 @@ mod tests {
         }))
         .unwrap_err();
 
-        assert!(format!("{error:#}").contains("reserved for engine-owned recovery"));
+        assert!(format!("{error:#}").contains("carries retired `refresh_scope`"));
     }
 }

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/restart_recovery_tests.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/restart_recovery_tests.rs
@@ -110,8 +110,13 @@ fn interrupted_wait_request_keeps_exact_identity_across_restart() {
             &json!({
                 "op": SOURCE_REFRESH_REQUEST_OP,
                 "mode": "wait",
-                "operation": "import",
-                "explicit_source_catalog": authority.to_json(),
+                "refresh_intent": {
+                    "kind": "selected_import",
+                    "selection": {
+                        "kind": "exact_source",
+                        "authority": authority.to_json(),
+                    },
+                },
             }),
         )
         .unwrap()

--- a/crates/ctx-history-index-generation/src/certification.rs
+++ b/crates/ctx-history-index-generation/src/certification.rs
@@ -349,31 +349,28 @@ pub fn verify_physical_integrity_read_only(
         return Err(IndexError::ChecksumMismatch);
     }
     let current_pointer = load_current_pointer(root)?;
-    let retained_alias_directories = std::iter::once(current_pointer.active().directory())
-        .chain(current_pointer.previous().map(GenerationSlot::directory))
-        .chain(std::iter::once(slot.directory()))
-        .map(str::to_owned)
-        .collect::<HashSet<_>>();
+    let pointer_fence = ActiveGenerationPointerFence::capture(root, Some(&current_pointer))?;
+    let alias_authority = CertificationAliasAuthority::capture(root, &pointer_fence, slot)?;
     for expected in &certification.artifacts {
         let current = capture_artifact_with_retained_aliases(
             root,
             &generation_path,
             Path::new(&expected.artifact.path),
-            &retained_alias_directories,
+            alias_authority.directories(),
         )?;
         if current != expected.artifact {
-            return verify_certified_previous_after_publication(
+            verify_certified_previous_after_publication(
                 root,
                 slot,
                 index,
                 &generation_path,
                 &current_pointer,
-            );
+            )?;
+            alias_authority.validate(root, &pointer_fence)?;
+            return Ok(());
         }
     }
-    if load_current_pointer(root)? != current_pointer {
-        return Err(IndexError::ConcurrentGenerationChange);
-    }
+    alias_authority.validate(root, &pointer_fence)?;
     Ok(())
 }
 
@@ -971,7 +968,7 @@ mod candidate;
 mod install;
 mod pointer_fence;
 mod sidecar;
-use candidate::certification_digest_matches_slot;
+use candidate::{certification_digest_matches_slot, CertificationAliasAuthority};
 pub use candidate::{
     certify_candidate_physical_integrity, verify_candidate_physical_integrity_read_only,
 };

--- a/crates/ctx-history-index-generation/src/certification/candidate.rs
+++ b/crates/ctx-history-index-generation/src/certification/candidate.rs
@@ -1,13 +1,13 @@
 use super::*;
 
-struct CandidateAliasAuthority {
+pub(super) struct CertificationAliasAuthority {
     directories: HashSet<String>,
     retention_lease: Option<GenerationRetentionLease>,
     _process_read_authorities: Vec<ExistingGenerationDirectoryReadAuthority>,
 }
 
-impl CandidateAliasAuthority {
-    fn capture(
+impl CertificationAliasAuthority {
+    pub(super) fn capture(
         root: &Path,
         predecessor_fence: &ActiveGenerationPointerFence,
         slot: &GenerationSlot,
@@ -55,7 +55,11 @@ impl CandidateAliasAuthority {
         Ok(authority)
     }
 
-    fn validate(
+    pub(super) fn directories(&self) -> &HashSet<String> {
+        &self.directories
+    }
+
+    pub(super) fn validate(
         &self,
         root: &Path,
         predecessor_fence: &ActiveGenerationPointerFence,
@@ -107,13 +111,13 @@ pub fn verify_candidate_physical_integrity_read_only(
     {
         return Err(IndexError::ChecksumMismatch);
     }
-    let alias_authority = CandidateAliasAuthority::capture(root, predecessor_fence, slot)?;
+    let alias_authority = CertificationAliasAuthority::capture(root, predecessor_fence, slot)?;
     for expected in &certification.artifacts {
         let current = capture_artifact_with_retained_aliases(
             root,
             &generation_path,
             Path::new(&expected.artifact.path),
-            &alias_authority.directories,
+            alias_authority.directories(),
         )?;
         if current != expected.artifact {
             return Err(IndexError::ChecksumMismatch);

--- a/crates/ctx-history-index-generation/src/certification/tests.rs
+++ b/crates/ctx-history-index-generation/src/certification/tests.rs
@@ -240,30 +240,51 @@ fn read_only_certification_rejects_restored_metadata_byte_mutation() {
 
 #[cfg(unix)]
 #[test]
-fn read_only_certification_rejects_unretained_alias_and_restored_metadata_mutation() {
+fn read_only_certification_rejects_unretained_alias_in_rebuilt_certification() {
     use std::os::unix::fs::MetadataExt as _;
 
     let fixture = read_only_certification_fixture();
+    let root = fixture.root();
     let artifact_path = fixture.artifact_path();
-    let attacker_generation = generation(fixture.root(), 'd');
+    fs::remove_file(certification_path(root, &fixture.slot)).unwrap();
+    let attacker_generation = generation(root, 'd');
     let external_alias = attacker_generation.join(&fixture.relative_artifact_path);
     fs::create_dir_all(external_alias.parent().unwrap()).unwrap();
     fs::hard_link(&artifact_path, &external_alias).unwrap();
+    let pointer = load_current_pointer(root).unwrap();
+    let generation_path = slot_path(root, &fixture.slot);
+    let audit = physical_integrity_audit(&fixture.index, &generation_path, Some(&pointer)).unwrap();
+    install_certification(
+        root,
+        Some(&pointer),
+        None,
+        &fixture.slot,
+        &fixture.index,
+        &audit,
+        CertificationInstallPolicy::ACTIVE_CACHE,
+    )
+    .unwrap();
+    let certification: GenerationIntegrityCertification = serde_json::from_slice(
+        &read_certification(&certification_path(root, &fixture.slot)).unwrap(),
+    )
+    .unwrap();
+    let certified_artifact = certification
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.artifact.path == fixture.relative_artifact_path.to_str().unwrap())
+        .unwrap();
     assert_eq!(
-        fs::metadata(&artifact_path).unwrap().nlink(),
+        certified_artifact.artifact.identity.link_count(),
         fixture.certified_artifact.identity.link_count() + 1
     );
-
-    let (before, after) = mutate_same_length_and_restore_metadata(&artifact_path);
-    assert_eq!(after.len(), before.len());
-    assert_eq!(after.modified().unwrap(), before.modified().unwrap());
-    assert_eq!(after.mode(), before.mode());
-    assert!(after.permissions().readonly());
-    assert_eq!(after.nlink(), before.nlink());
+    assert_eq!(
+        fs::metadata(&artifact_path).unwrap().nlink(),
+        certified_artifact.artifact.identity.link_count()
+    );
 
     crate::reset_physical_verification_activity();
     assert!(matches!(
-        verify_physical_integrity_read_only(fixture.root(), &fixture.slot, &fixture.index),
+        verify_physical_integrity_read_only(root, &fixture.slot, &fixture.index),
         Err(IndexError::ChecksumMismatch)
     ));
     assert_eq!(crate::checksum_walks(), 0);

--- a/crates/ctx-history-index-generation/src/retention.rs
+++ b/crates/ctx-history-index-generation/src/retention.rs
@@ -151,7 +151,11 @@ pub fn acquire_generation_retention_lease(
 pub fn load_generation_retention_lease(
     root: impl AsRef<Path>,
 ) -> Result<Option<GenerationRetentionLease>> {
-    let path = lease_path(root.as_ref());
+    let root = root.as_ref();
+    if let Some(opened) = crate::read_root::registered_read_directory(root)? {
+        return load_generation_retention_lease_from_opened_root(&opened);
+    }
+    let path = lease_path(root);
     let metadata = match fs::symlink_metadata(&path) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -177,7 +181,7 @@ pub fn load_generation_retention_lease(
         return Err(IndexError::InvalidGenerationRetentionLease);
     }
     lease.validate()?;
-    let target = slot_path(root.as_ref(), lease.target());
+    let target = slot_path(root, lease.target());
     let target_metadata =
         fs::symlink_metadata(target).map_err(|_| IndexError::InvalidGenerationRetentionLease)?;
     if !target_metadata.is_dir() || target_metadata.file_type().is_symlink() {
@@ -188,6 +192,12 @@ pub fn load_generation_retention_lease(
 
 fn load_generation_retention_lease_from_read_root(
     root: &GenerationReadRoot,
+) -> Result<Option<GenerationRetentionLease>> {
+    load_generation_retention_lease_from_opened_root(root.opened())
+}
+
+fn load_generation_retention_lease_from_opened_root(
+    root: &crate::read_root::OpenedDirectory,
 ) -> Result<Option<GenerationRetentionLease>> {
     let file = match root.open_file(Path::new(GENERATION_RETENTION_LEASE_FILE)) {
         Ok(file) => file,
@@ -213,8 +223,7 @@ fn load_generation_retention_lease_from_read_root(
         return Err(IndexError::InvalidGenerationRetentionLease);
     }
     lease.validate()?;
-    root.opened()
-        .open_directory(&Path::new(INDEX_GENERATIONS_DIRECTORY).join(lease.target().directory()))
+    root.open_directory(&Path::new(INDEX_GENERATIONS_DIRECTORY).join(lease.target().directory()))
         .map_err(|_| IndexError::InvalidGenerationRetentionLease)?;
     Ok(Some(lease))
 }

--- a/crates/ctx-history-index-generation/src/retention/read_lease.rs
+++ b/crates/ctx-history-index-generation/src/retention/read_lease.rs
@@ -13,8 +13,10 @@ use sha2::{Digest as _, Sha256};
 
 use super::{load_generation_retention_lease_from_read_root, GenerationRetentionLease};
 use crate::{
-    is_generation_id, read_root::DirectoryIdentity, sha256_hex, GenerationError as IndexError,
-    GenerationReadRoot, GenerationSlot, Result, INDEX_GENERATIONS_DIRECTORY, MANIFEST_DIRECTORY,
+    is_generation_id,
+    read_root::{DirectoryIdentity, OpenedDirectory},
+    sha256_hex, GenerationError as IndexError, GenerationReadRoot, GenerationSlot, Result,
+    INDEX_GENERATIONS_DIRECTORY, MANIFEST_DIRECTORY,
 };
 
 mod platform;
@@ -230,8 +232,10 @@ pub(crate) fn acquire_existing_generation_directory_read_authority(
     if !GenerationSlot::names_are_valid(&"0".repeat(64), directory) {
         return Err(IndexError::InvalidActiveGenerationPointer);
     }
-    let root = GenerationReadRoot::open_index_root(root)?;
-    let coordinator = coordinator(&root, true)?;
+    let coordinator = match crate::read_root::registered_read_directory(root)? {
+        Some(opened) => coordinator_for_opened(opened.registry_identity(), &opened, true)?,
+        None => coordinator(&GenerationReadRoot::open_index_root(root)?, true)?,
+    };
     let keys = directory_keys(directory);
     if let Some(uncontended) =
         RangeLeaseGuard::try_exclusive(Arc::clone(&coordinator), keys.clone())?
@@ -417,6 +421,14 @@ static COORDINATORS: OnceLock<Mutex<CoordinatorRegistry>> = OnceLock::new();
 static COORDINATOR_REGISTRY_PROCESS_ID: AtomicU32 = AtomicU32::new(0);
 
 fn coordinator(root: &GenerationReadRoot, create: bool) -> Result<Arc<LeaseCoordinator>> {
+    coordinator_for_opened(root.identity(), root.opened(), create)
+}
+
+fn coordinator_for_opened(
+    root_identity: DirectoryIdentity,
+    root: &OpenedDirectory,
+    create: bool,
+) -> Result<Arc<LeaseCoordinator>> {
     let process_id = std::process::id();
     let registry = COORDINATORS.get_or_init(|| Mutex::new(CoordinatorRegistry::new(process_id)));
     let registered_process_id = COORDINATOR_REGISTRY_PROCESS_ID.load(Ordering::Acquire);
@@ -438,7 +450,7 @@ fn coordinator(root: &GenerationReadRoot, create: bool) -> Result<Arc<LeaseCoord
 
     if let Some(existing) = registry
         .coordinators
-        .get(&root.identity())
+        .get(&root_identity)
         .and_then(Weak::upgrade)
     {
         drop(registry);
@@ -447,7 +459,7 @@ fn coordinator(root: &GenerationReadRoot, create: bool) -> Result<Arc<LeaseCoord
     }
 
     let opened = platform::OpenedCoordinator::open(
-        root.opened(),
+        root,
         COORDINATOR_FILE,
         COORDINATOR_INITIALIZATION_FILE,
         COORDINATOR_MAGIC,
@@ -461,7 +473,7 @@ fn coordinator(root: &GenerationReadRoot, create: bool) -> Result<Arc<LeaseCoord
     });
     registry
         .coordinators
-        .insert(root.identity(), Arc::downgrade(&coordinator));
+        .insert(root_identity, Arc::downgrade(&coordinator));
     drop(registry);
     coordinator.verify_binding()?;
     Ok(coordinator)

--- a/crates/ctx-history-refresh-execution/src/receipt_parse.rs
+++ b/crates/ctx-history-refresh-execution/src/receipt_parse.rs
@@ -578,23 +578,23 @@ fn required_catalog_route_bindings_shape(
             if !is_sha256_identity(route_identity) {
                 bail!("published daemon source refresh catalog binding route is invalid");
             }
-            let route_result = route_results
-                .iter()
-                .find(|result| result.route_identity == route_identity)
-                .ok_or_else(|| {
-                    anyhow!(
-                        "published daemon source refresh catalog binding route is absent from route_results"
-                    )
-                })?;
-            if !expected_catalog_lineages.contains(catalog_lineage)
-                && !matches!(
+            if !expected_catalog_lineages.contains(catalog_lineage) {
+                let route_result = route_results
+                    .iter()
+                    .find(|result| result.route_identity == route_identity)
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "published daemon source refresh catalog binding route is absent from route_results"
+                        )
+                    })?;
+                if !matches!(
                     route_result.outcome,
                     SourceBackedRefreshRouteOutcome::Failed { .. }
-                )
-            {
-                bail!(
-                    "published daemon source refresh unretained catalog binding has no terminal failure"
-                );
+                ) {
+                    bail!(
+                        "published daemon source refresh unretained catalog binding has no terminal failure"
+                    );
+                }
             }
             Ok(ExplicitSourceCatalogRouteBinding {
                 catalog_lineage: catalog_lineage.clone(),

--- a/crates/ctx-history-refresh-execution/src/tests/receipt.rs
+++ b/crates/ctx-history-refresh-execution/src/tests/receipt.rs
@@ -73,6 +73,38 @@ fn recovery_receipt_catalog_binding_requires_a_receipt_route_and_terminal_failur
 }
 
 #[test]
+fn recovery_receipt_accepts_a_published_catalog_binding_retained_outside_the_request() {
+    let (temp, mut response, _verified) = terminal_receipt_fixture();
+    let data_root = temp.path().join("data");
+    let source_path = temp.path().join("session.jsonl");
+    fs::write(
+        &source_path,
+        br#"{"timestamp":"2026-09-03T12:00:00Z","type":"session_meta","payload":{"id":"01a06800-0000-7000-8000-000000000001","cwd":"/workspace","source":"cli"}}
+"#,
+    )
+    .unwrap();
+    let source = provider_source_for_path(CaptureProvider::Codex, source_path);
+    let request = upsert_explicit_source(&data_root, &source).unwrap();
+    let lineage = request.catalog_lineage_hex();
+    let route = "59".repeat(32);
+    response["receipt"]["published_explicit_source_catalog"] = request.authority.to_json();
+    response["receipt"]["catalog_route_bindings"] = json!({
+        (lineage.clone()): route.clone()
+    });
+
+    let receipt = published_refresh_receipt_for_recovery(&response)
+        .expect("a published catalog may retain a route outside the current request partition");
+
+    assert_eq!(
+        receipt.catalog_route_bindings,
+        vec![ExplicitSourceCatalogRouteBinding {
+            catalog_lineage: lineage,
+            route_identity: route,
+        }]
+    );
+}
+
+#[test]
 fn verified_receipt_keeps_retryable_binding_for_a_retained_route_failure() {
     let (_temp, _response, verified) = terminal_receipt_fixture();
     let route = verified.manifest().source_routes()[0]

--- a/crates/ctx-history-refresh/src/engine/admission_tests.rs
+++ b/crates/ctx-history-refresh/src/engine/admission_tests.rs
@@ -1189,41 +1189,9 @@ fn durable_recovery_preserves_intent_separately_from_physical_scope() {
     assert_eq!(recovered.intent, attempt.intent);
     assert_eq!(recovered.refresh_scope, scope);
 
-    let mut legacy = job.clone();
-    legacy.as_object_mut().unwrap().remove("refresh_intent");
-    legacy["refresh_selector"] = json!({ "kind": "automatic_provider", "provider": "codex" });
-    let recovered_legacy = recover_queued_root(&legacy, None).unwrap();
-    assert_eq!(
-        recovered_legacy.intent,
-        RefreshIntent::SelectedImport(RefreshSelection::Provider(CaptureProvider::Codex))
-    );
-    assert_eq!(recovered_legacy.refresh_scope, attempt.refresh_scope);
-
-    let legacy_authority = crate::explicit_source_catalog_authority_for_test(1);
-    let mut legacy_explicit = new_refresh_attempt(
-        None,
-        SourceRefreshRuntimeMetadata {
-            operation: SourceBackedRefreshOperation::Import,
-            daemon_mode: "full".to_owned(),
-            trigger: "import",
-            trigger_provenance: "explicit_source_catalog",
-        },
-        RefreshIntent::SelectedImport(RefreshSelection::ExactSource(legacy_authority.clone())),
-        SourceBackedRefreshScope::All,
-    )
-    .job_json();
-    legacy_explicit
-        .as_object_mut()
-        .unwrap()
-        .remove("refresh_intent");
-    legacy_explicit["requested_explicit_source_catalog"] = legacy_authority.to_json();
-    let recovered_explicit = recover_queued_root(&legacy_explicit, None).unwrap();
-    assert_eq!(
-        recovered_explicit.intent,
-        RefreshIntent::SelectedImport(RefreshSelection::ExactSource(
-            crate::explicit_source_catalog_authority_for_test(1),
-        ))
-    );
+    let mut missing = job.clone();
+    missing.as_object_mut().unwrap().remove("refresh_intent");
+    assert!(recover_queued_root(&missing, None).is_err());
 
     let mut malformed = job.clone();
     malformed["refresh_intent"] = json!({

--- a/crates/ctx-history-refresh/src/engine/attempt_helpers.rs
+++ b/crates/ctx-history-refresh/src/engine/attempt_helpers.rs
@@ -693,108 +693,25 @@ pub(super) fn recover_reconciliation_demand(
 pub(super) fn recover_refresh_intent(
     job: &Value,
     operation: SourceBackedRefreshOperation,
-    allow_legacy_terminal_catalog_omission: bool,
-    ignore_obsolete_root_catalog: bool,
 ) -> Result<RefreshIntent> {
-    if let Some(value) = job.get("refresh_intent") {
-        let intent = RefreshIntent::from_json(value)?;
-        if intent.operation() != operation {
-            bail!("durable source refresh intent disagrees with its operation");
-        }
-        if let Some(legacy_catalog) = job
-            .get("requested_explicit_source_catalog")
-            .filter(|value| !value.is_null())
-            .map(ExplicitSourceCatalogAuthority::from_json)
-            .transpose()?
-        {
-            if intent.explicit_source_authority() != Some(&legacy_catalog) {
-                bail!("durable source refresh intent disagrees with its legacy exact-source authority");
-            }
-        }
-        return Ok(intent);
+    let intent = RefreshIntent::from_json(
+        job.get("refresh_intent")
+            .ok_or_else(|| anyhow!("durable source refresh intent is missing"))?,
+    )?;
+    if intent.operation() != operation {
+        bail!("durable source refresh intent disagrees with its operation");
     }
-
-    // One isolated decoder for pre-canonical durable jobs. Legacy fields are
-    // normalized immediately and never enter scheduling or execution as an
-    // independent request representation.
-    // Pre-overlay periodic roots can carry obsolete catalog-shaped data. It
-    // was never request authority for refresh operations, so retain that
-    // compatibility without weakening import or successor validation.
-    let explicit_catalog = if ignore_obsolete_root_catalog
-        && operation == SourceBackedRefreshOperation::Refresh
-        && job.get("refresh_selector").is_none()
+    if let Some(catalog) = job
+        .get("requested_explicit_source_catalog")
+        .filter(|value| !value.is_null())
+        .map(ExplicitSourceCatalogAuthority::from_json)
+        .transpose()?
     {
-        None
-    } else {
-        job.get("requested_explicit_source_catalog")
-            .filter(|value| !value.is_null())
-            .map(ExplicitSourceCatalogAuthority::from_json)
-            .transpose()?
-    };
-    let explicit_catalog = explicit_catalog.as_ref();
-    let has_explicit_catalog = explicit_catalog.is_some();
-    let fresh = job
-        .get("fresh_after_admitted_snapshot")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let Some(selector) = job.get("refresh_selector") else {
-        return match (operation, explicit_catalog) {
-            (SourceBackedRefreshOperation::Refresh, Some(_)) => {
-                bail!("durable refresh carries legacy explicit source authority")
-            }
-            (SourceBackedRefreshOperation::Import, Some(authority)) => Ok(
-                RefreshIntent::SelectedImport(RefreshSelection::ExactSource(authority.clone())),
-            ),
-            (SourceBackedRefreshOperation::Import, None)
-                if !allow_legacy_terminal_catalog_omission =>
-            {
-                bail!("durable import source refresh has no explicit source authority")
-            }
-            (_, None) if fresh || operation == SourceBackedRefreshOperation::Import => {
-                Ok(RefreshIntent::SelectedImport(RefreshSelection::All))
-            }
-            (_, None) => Ok(RefreshIntent::AutomaticMaintenance),
-        };
-    };
-    let fields = selector
-        .as_object()
-        .ok_or_else(|| anyhow!("durable source refresh selector is not an object"))?;
-    match fields.get("kind").and_then(Value::as_str) {
-        Some("all_automatic") if fields.len() == 1 => match explicit_catalog {
-            Some(authority) if operation == SourceBackedRefreshOperation::Import => Ok(
-                RefreshIntent::SelectedImport(RefreshSelection::ExactSource(authority.clone())),
-            ),
-            Some(_) => bail!("durable refresh carries explicit source authority"),
-            None if fresh => Ok(RefreshIntent::SelectedImport(RefreshSelection::All)),
-            None => Ok(RefreshIntent::AutomaticMaintenance),
-        },
-        Some("automatic_provider") if fields.len() == 2 && !has_explicit_catalog => {
-            let provider = fields
-                .get("provider")
-                .and_then(Value::as_str)
-                .ok_or_else(|| anyhow!("durable provider selector has no provider"))?
-                .parse()
-                .context("parse durable provider selector")?;
-            if provider == CaptureProvider::Unknown {
-                bail!("durable provider selector has an unknown provider");
-            }
-            Ok(RefreshIntent::SelectedImport(RefreshSelection::Provider(
-                provider,
-            )))
+        if intent.explicit_source_authority() != Some(&catalog) {
+            bail!("durable source refresh intent disagrees with its exact-source authority");
         }
-        Some("explicit_catalog") if fields.len() == 1 => Ok(RefreshIntent::SelectedImport(
-            RefreshSelection::ExactSource(
-                explicit_catalog
-                    .cloned()
-                    .ok_or_else(|| anyhow!("durable exact-source refresh has no authority"))?,
-            ),
-        )),
-        Some("automatic_provider") if has_explicit_catalog => {
-            bail!("durable provider selector carries explicit source authority")
-        }
-        Some(kind) => bail!("durable source refresh selector `{kind}` is malformed"),
-        None => bail!("durable source refresh selector kind is missing"),
     }
+    Ok(intent)
 }
 
 pub(super) fn recover_admission_durability(job: &Value, context: &str) -> Result<bool> {

--- a/crates/ctx-history-refresh/src/engine/durable_queue.rs
+++ b/crates/ctx-history-refresh/src/engine/durable_queue.rs
@@ -453,7 +453,7 @@ fn recover_pending_attempt(
         .ok_or_else(|| anyhow!("durable source refresh {role} has no request ID"))?;
     let operation = SourceBackedRefreshOperation::from_request_json(job)
         .with_context(|| format!("recover durable source refresh {role} operation"))?;
-    let intent = recover_refresh_intent(job, operation, false, is_root)
+    let intent = recover_refresh_intent(job, operation)
         .with_context(|| format!("recover durable source refresh {role} intent"))?;
     let daemon_mode = job
         .get("daemon_mode")

--- a/crates/ctx-history-refresh/src/engine/request_lifecycle/recovery.rs
+++ b/crates/ctx-history-refresh/src/engine/request_lifecycle/recovery.rs
@@ -311,7 +311,7 @@ fn recover_terminal_attempt(
             "commit_payload",
         ],
     )?;
-    let intent = recover_refresh_intent(job, operation, true, false)
+    let intent = recover_refresh_intent(job, operation)
         .context("recover durable terminal source refresh intent")?;
     let previous_generation = optional_generation(job.get("previous_generation"))?;
     let mut attempt = new_refresh_attempt(

--- a/crates/ctx-history-refresh/src/engine/tests.rs
+++ b/crates/ctx-history-refresh/src/engine/tests.rs
@@ -1139,9 +1139,10 @@ fn manual_all_request_without_catalog(coordinator: &CoreRefreshEngine, data_root
                 "op": SOURCE_REFRESH_REQUEST_OP,
                 "request_id": Uuid::now_v7().to_string(),
                 "mode": "wait",
-                "operation": "import",
-                "refresh_selector": {"kind": "all_automatic"},
-                "fresh_after_admitted_snapshot": true,
+                "refresh_intent": {
+                    "kind": "selected_import",
+                    "selection": {"kind": "all"},
+                },
             }),
             observations,
         )

--- a/crates/ctx-history-refresh/src/engine/tests/additional.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/additional.rs
@@ -1287,8 +1287,13 @@ fn differing_catalog_authority_queues_one_successor_behind_a_running_refresh() {
                     "op": SOURCE_REFRESH_REQUEST_OP,
                     "request_id": logical_request_id,
                     "mode": "wait",
-                    "operation": "import",
-                    "explicit_source_catalog": authority.to_json(),
+                    "refresh_intent": {
+                        "kind": "selected_import",
+                        "selection": {
+                            "kind": "exact_source",
+                            "authority": authority.to_json(),
+                        },
+                    },
                 }),
             )
             .unwrap()
@@ -1377,8 +1382,13 @@ fn active_and_pending_refreshes_are_bounded_with_a_typed_busy_response() {
                     "schema_version": 1,
                     "op": SOURCE_REFRESH_REQUEST_OP,
                     "mode": "wait",
-                    "operation": "import",
-                    "explicit_source_catalog": authority.to_json(),
+                    "refresh_intent": {
+                        "kind": "selected_import",
+                        "selection": {
+                            "kind": "exact_source",
+                            "authority": authority.to_json(),
+                        },
+                    },
                 }),
             )
             .unwrap()

--- a/crates/ctx-history-refresh/src/engine/tests/harness.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/harness.rs
@@ -119,32 +119,13 @@ fn test_refresh_submission_from_json(request: &Value) -> Result<RefreshRequest> 
     if !matches!(mode, "background" | "wait") {
         bail!("invalid daemon source refresh mode `{mode}`");
     }
-    let operation = request
-        .get("operation")
-        .and_then(Value::as_str)
-        .ok_or_else(|| anyhow!("daemon source refresh request operation is missing"))
-        .and_then(|operation| match operation {
-            "refresh" => Ok(RefreshOperation::Refresh),
-            "import" => Ok(RefreshOperation::Import),
-            operation => bail!("invalid daemon source refresh operation `{operation}`"),
-        })?;
-    let explicit_catalog = request.get("explicit_source_catalog");
-    let all_selection = request
-        .get("refresh_selector")
-        .and_then(|selector| selector.get("kind"))
-        .and_then(Value::as_str)
-        == Some("all_automatic");
-    match (operation, mode, explicit_catalog) {
-        (RefreshOperation::Refresh, _, Some(_)) => {
-            bail!("refresh operation cannot carry explicit source catalog authority")
-        }
-        (RefreshOperation::Import, "background", _) => {
-            bail!("import operation requires daemon refresh mode `wait`")
-        }
-        (RefreshOperation::Import, _, None) if !all_selection => {
-            bail!("import operation requires explicit source catalog authority")
-        }
-        _ => {}
+    let intent = RefreshIntent::from_json(
+        request
+            .get("refresh_intent")
+            .ok_or_else(|| anyhow!("daemon source refresh intent is missing"))?,
+    )?;
+    if mode == "background" && intent != RefreshIntent::AutomaticMaintenance {
+        bail!("selected import requires daemon refresh mode `wait`");
     }
     let request_id = match request.get("request_id") {
         Some(Value::String(request_id)) if !request_id.is_empty() => {
@@ -155,41 +136,12 @@ fn test_refresh_submission_from_json(request: &Value) -> Result<RefreshRequest> 
         None => Uuid::now_v7().to_string(),
         Some(_) => bail!("daemon source refresh logical request ID is invalid"),
     };
-    let fresh_after_admitted_snapshot = match request.get("fresh_after_admitted_snapshot") {
-        None | Some(Value::Bool(false)) => false,
-        Some(Value::Bool(true)) => true,
-        Some(_) => {
-            bail!("daemon source refresh fresh-after-admitted-snapshot requirement must be boolean")
-        }
-    };
-    if operation == RefreshOperation::Refresh
-        && mode == "background"
-        && fresh_after_admitted_snapshot
-    {
-        bail!("background source refresh cannot require a fresh admission snapshot");
-    }
-    let requested_catalog = explicit_catalog
-        .map(ExplicitSourceCatalogAuthority::from_json)
-        .transpose()?;
-    let intent = match (operation, requested_catalog, fresh_after_admitted_snapshot) {
-        (RefreshOperation::Import, Some(authority), _) => {
-            RefreshIntent::SelectedImport(RefreshSelection::ExactSource(authority))
-        }
-        (RefreshOperation::Import, None, _) => RefreshIntent::SelectedImport(RefreshSelection::All),
-        (RefreshOperation::Refresh, None, true) => {
-            RefreshIntent::SelectedImport(RefreshSelection::All)
-        }
-        (RefreshOperation::Refresh, None, false) => RefreshIntent::AutomaticMaintenance,
-        (RefreshOperation::Refresh, Some(_), _) => {
-            unreachable!("validated request authority")
-        }
-    };
     let trigger = request
         .get("trigger")
         .and_then(Value::as_str)
         .map(str::parse)
         .transpose()?
-        .unwrap_or(match intent {
+        .unwrap_or(match &intent {
             RefreshIntent::AutomaticMaintenance => RefreshRequestTrigger::Search,
             RefreshIntent::SelectedImport(_) => RefreshRequestTrigger::Import,
         });

--- a/crates/ctx-history-refresh/src/engine/tests/receipt.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/receipt.rs
@@ -15,8 +15,13 @@ fn mismatched_request_overlay_is_not_recorded_as_verified() {
                 "schema_version": 1,
                 "op": SOURCE_REFRESH_REQUEST_OP,
                 "mode": "wait",
-                "operation": "import",
-                "explicit_source_catalog": requested.to_json(),
+                "refresh_intent": {
+                    "kind": "selected_import",
+                    "selection": {
+                        "kind": "exact_source",
+                        "authority": requested.to_json(),
+                    },
+                },
             }),
             BTreeMap::new(),
         )

--- a/crates/ctx-history-refresh/src/engine/tests/request_coalescing.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/request_coalescing.rs
@@ -256,7 +256,7 @@ fn concurrent_refresh_request_uses_active_generation_without_reopening_inflight_
             &json!({
                 "op": SOURCE_REFRESH_REQUEST_OP,
                 "mode": "wait",
-                "operation": "refresh",
+                "refresh_intent": {"kind": "automatic_maintenance"},
             }),
         )
         .unwrap()
@@ -281,8 +281,13 @@ fn selected_import_requests_remain_distinct_before_execution() {
                     "op": SOURCE_REFRESH_REQUEST_OP,
                     "request_id": request_id,
                     "mode": "wait",
-                    "operation": "import",
-                    "explicit_source_catalog": authority.to_json(),
+                    "refresh_intent": {
+                        "kind": "selected_import",
+                        "selection": {
+                            "kind": "exact_source",
+                            "authority": authority.to_json(),
+                        },
+                    },
                 }),
             )
             .unwrap()

--- a/crates/ctx-history-snapshot-reader/src/tests.rs
+++ b/crates/ctx-history-snapshot-reader/src/tests.rs
@@ -925,6 +925,70 @@ fn overlapping_readers_retain_a_real_generation_until_the_last_close() {
     assert!(!first_path.exists());
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn active_snapshot_opens_while_an_older_reader_retains_reused_artifacts() {
+    use std::os::unix::fs::MetadataExt as _;
+
+    let _clone = CloneTestHookGuard::set(
+        CloneTestOptions {
+            force_reflink_fallback: true,
+            ..CloneTestOptions::default()
+        },
+        |_, _| Ok(()),
+    );
+    let fixture = Fixture::new();
+    let first_source = source("retained-alias-active-open-first");
+    let first_id = publish(
+        &fixture.index_root,
+        1,
+        &[(
+            first_source.clone(),
+            vec![record(&first_source, 1, "first")],
+        )],
+    );
+    let first = open(&fixture, &first_id);
+    let second_source = source("retained-alias-active-open-second");
+    publish(
+        &fixture.index_root,
+        2,
+        &[(
+            second_source.clone(),
+            vec![record(&second_source, 1, "second")],
+        )],
+    );
+    let third_source = source("retained-alias-active-open-third");
+    let active_id = publish(
+        &fixture.index_root,
+        3,
+        &[(
+            third_source.clone(),
+            vec![record(&third_source, 1, "third")],
+        )],
+    );
+    let active_slot = load_active_generation_pointer(&fixture.index_root)
+        .unwrap()
+        .unwrap()
+        .active()
+        .clone();
+    let active_path = slot_path(&fixture.index_root, &active_slot);
+    let active_index = open_slot_index(&fixture.index_root, &active_slot).unwrap();
+    assert!(
+        active_index_files(&active_index)
+            .unwrap()
+            .iter()
+            .any(|path| {
+                fs::metadata(active_path.join(path)).is_ok_and(|metadata| metadata.nlink() >= 3)
+            }),
+        "fixture did not retain a reused artifact across all three generations"
+    );
+
+    let active = open(&fixture, &active_id);
+    assert_eq!(active.generation_id(), active_id);
+    drop(active);
+    drop(first);
+}
+
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn leased_certified_generation_rejects_net_zero_hardlink_churn_without_hashing() {

--- a/docs/contracts/json.md
+++ b/docs/contracts/json.md
@@ -287,6 +287,14 @@ nullable may be omitted when unavailable:
 therefore report history refresh as confirming, paused, or partially paused
 without reporting the daemon process itself as stopped.
 
+Its schema-1 request/status projection still emits
+`coalesced_into_request_id: null` and `coalesced_logical_demands: 0` after
+cross-request-ID coalescing was removed. Those keys may disappear only in an
+explicit successor schema after schema 1 is outside the supported client floor.
+`request_fingerprint` is not a compatibility placeholder: explicit stable
+request IDs still use it to reject a conflicting payload. No successor schema
+or calendar sunset is scheduled.
+
 `config_reload.status` is `applied`, `pending`, `failed`,
 `activation_failed`, or `unknown`. `requested` reflects the current effective
 daemon/semantic configuration read by the status command. `applied` is the last

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -196,6 +196,17 @@ missing selection, or widen selected work. Interrupted requests persist their
 logical intent and are re-admitted through the same resolver before execution,
 so missing or changed selected routes fail closed.
 
+The pre-canonical durable selector/catalog decoder and matching daemon IPC
+adapter existed only between v0.25.0 and v1.0.0 and were never part of a
+supported release, so current readers require canonical `refresh_intent`.
+Schema-1 jobs and status still retain released physical-attempt, coalescing, and
+legacy terminal fields. Those fields can be removed only after a successor
+schema is released and schema 1 is outside the supported upgrade floor; neither
+that release nor a date has been assigned. The removed publication-metadata
+version-1-through-version-4 decoder likewise has no release support floor
+because those formats were never released and immutable generations now own
+the state.
+
 Request receipts describe only the routes and rejections observed by that
 request. Generation metadata separately describes the complete retained
 publication. A selected no-op can therefore report its own rejection outcome

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -196,16 +196,32 @@ missing selection, or widen selected work. Interrupted requests persist their
 logical intent and are re-admitted through the same resolver before execution,
 so missing or changed selected routes fail closed.
 
-The pre-canonical durable selector/catalog decoder and matching daemon IPC
-adapter existed only between v0.25.0 and v1.0.0 and were never part of a
-supported release, so current readers require canonical `refresh_intent`.
+Every v1.0.0-through-v1.3.1 binary carried the pre-canonical durable
+selector/catalog decoder and matching daemon IPC adapter. In those same
+released tags, however, daemon clients and durable job writers emitted canonical
+`refresh_intent`, and request fingerprints were computed from that canonical
+intent plus its trigger. No supported release producer emitted the retired
+request shape or a fingerprint of that shape. Current readers therefore require
+canonical `refresh_intent`; removing the old decoder does not discard a released
+producer format.
+
 Schema-1 jobs and status still retain released physical-attempt, coalescing, and
 legacy terminal fields. Those fields can be removed only after a successor
 schema is released and schema 1 is outside the supported upgrade floor; neither
-that release nor a date has been assigned. The removed publication-metadata
-version-1-through-version-4 decoder likewise has no release support floor
-because those formats were never released and immutable generations now own
-the state.
+that release nor a date has been assigned.
+
+Publication metadata has a different release history. v1.0.0 through v1.1.1
+wrote metadata version 3, while v1.2.0 through v1.3.1 wrote version 4. Those
+released generations used manifest version 8 or 10 and commit payload version
+2; the current format uses manifest version 11 and commit payload version 3.
+Core is disposable derived storage, so an unsupported predecessor generation
+remains opaque and authoritative while ctx rebuilds a complete current
+candidate from provider sources, verifies it, and atomically replaces the old
+generation. The upgrade path neither migrates the predecessor nor decodes its
+old metadata; when required source history is unavailable, ctx reports it as
+unavailable instead of recovering content from the predecessor. The version-3
+and version-4 metadata decoder therefore remains deleted under the documented
+source-authoritative rebuild policy, not because those formats were unreleased.
 
 Request receipts describe only the routes and rejections observed by that
 request. Generation metadata separately describes the complete retained


### PR DESCRIPTION
## Summary

- remove pre-canonical internal refresh replay decoders and document released predecessor rebuild behavior
- recover retained catalog bindings after restart
- normalize the router-owned explicit Pro selector before companion forwarding
- verify reused hardlinks through bounded pointer, retention-lease, and live-reader authority

## Size

420 insertions, 824 deletions; net -404 lines.

## Validation

- affected selection: 116/116 passed
- full CI: 450 build targets and 211/211 test targets passed
- focused index-generation tests: 59 passed
- focused snapshot-reader tests: 14 passed
- assembled isolated Core/Pro process smoke: `ctx --pro status --format json` passed
- LOC, crate-size, formatting, repository-policy, and public-disclosure gates passed
- independent aggregate review: ship, no findings