### PR TITLE
Fix Windows managed-pair qualification

### DIFF
--- a/crates/ctx-cli/src/core_capability/contract_tests/managed_pair_apply_contract_tests.rs
+++ b/crates/ctx-cli/src/core_capability/contract_tests/managed_pair_apply_contract_tests.rs
@@ -280,6 +280,10 @@ fn apply_marker_requires_managed_pair_provenance() {
 #[test]
 fn canonical_root_lock_contends_and_persists() {
     let fixture = ArgFixture::new();
+    ctx_history_platform::platform_security::restrict_private_directory(
+        &fixture.install.join("bin"),
+    )
+    .unwrap();
     let first = try_acquire_managed_installation_mutation_at_root(&fixture.install)
         .unwrap()
         .unwrap();

--- a/crates/ctx-managed-pair-engine/src/filesystem.rs
+++ b/crates/ctx-managed-pair-engine/src/filesystem.rs
@@ -571,7 +571,26 @@ pub(super) fn verify_content(
 }
 
 pub(super) fn protect_regular(entry: &Entry, executable: bool, label: &str) -> Result<()> {
+    #[cfg(windows)]
+    let file = {
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_GENERIC_READ, FILE_SHARE_READ, READ_CONTROL, SYNCHRONIZE, WRITE_DAC,
+        };
+
+        entry
+            .directory
+            .open_relative(
+                &entry.name,
+                FILE_GENERIC_READ | READ_CONTROL | WRITE_DAC | SYNCHRONIZE,
+                FILE_SHARE_READ,
+                windows_sys::Wdk::Storage::FileSystem::FILE_OPEN,
+            )
+            .with_context(|| format!("open mutable {label} {}", entry.display()))?
+    };
+    #[cfg(not(windows))]
     let file = open_owner_regular(entry, label)?;
+    // Reject hard links before changing their shared security descriptor.
+    validate_open_owner_regular(entry, &file, label)?;
     protect_file_handle(&file, executable)?;
     validate_open_owner_regular(entry, &file, label)
 }

--- a/crates/ctx-managed-pair-engine/src/filesystem/candidate.rs
+++ b/crates/ctx-managed-pair-engine/src/filesystem/candidate.rs
@@ -46,18 +46,23 @@ pub(crate) fn remove_apply_candidate(layout: &Layout) -> Result<()> {
             None => {}
         }
     }
-    candidate
-        .share_directory
-        .remove_directory(OsStr::new("ctx"))?;
-    candidate
-        .root_directory
-        .remove_directory(OsStr::new("share"))?;
-    candidate
-        .root_directory
-        .remove_directory(OsStr::new("libexec"))?;
-    candidate
-        .root_directory
-        .remove_directory(OsStr::new("bin"))?;
+    let Layout {
+        root_directory,
+        bin_directory,
+        libexec_directory,
+        share_directory,
+        ctx_directory,
+        ..
+    } = candidate;
+    drop(ctx_directory);
+    share_directory.remove_directory(OsStr::new("ctx"))?;
+    drop(share_directory);
+    drop(libexec_directory);
+    drop(bin_directory);
+    root_directory.remove_directory(OsStr::new("share"))?;
+    root_directory.remove_directory(OsStr::new("libexec"))?;
+    root_directory.remove_directory(OsStr::new("bin"))?;
+    drop(root_directory);
     layout
         .ctx_directory
         .remove_directory(OsStr::new(APPLY_CANDIDATE_DIRECTORY))?;

--- a/crates/ctx-managed-pair-engine/src/filesystem/platform.rs
+++ b/crates/ctx-managed-pair-engine/src/filesystem/platform.rs
@@ -90,8 +90,11 @@ pub(super) fn durable_rename(
         mem::size_of,
         os::windows::{ffi::OsStrExt as _, io::AsRawHandle as _},
     };
-    use windows_sys::Win32::Storage::FileSystem::{
-        FileRenameInfo, SetFileInformationByHandle, FILE_RENAME_INFO,
+    use windows_sys::{
+        Wdk::Storage::FileSystem::{
+            FileRenameInformation, NtSetInformationFile, FILE_RENAME_INFORMATION,
+        },
+        Win32::{Foundation::RtlNtStatusToDosError, System::IO::IO_STATUS_BLOCK},
     };
 
     let file = open_owner_regular_for_delete(source, label)?;
@@ -105,14 +108,15 @@ pub(super) fn durable_rename(
         .checked_mul(size_of::<u16>())
         .ok_or_else(|| anyhow!("managed-pair target name is too long"))?;
     // Windows documents FileNameLength without the terminator, while the
-    // FILE_RENAME_INFO buffer itself must include its trailing WCHAR storage.
+    // FILE_RENAME_INFORMATION buffer itself must include its trailing WCHAR
+    // storage.
     // The zero-filled tail therefore supplies the required terminator.
-    let total_bytes = size_of::<FILE_RENAME_INFO>()
+    let total_bytes = size_of::<FILE_RENAME_INFORMATION>()
         .checked_add(name_bytes)
         .ok_or_else(|| anyhow!("managed-pair rename buffer is too large"))?;
     let words = total_bytes.div_ceil(size_of::<usize>());
     let mut buffer = vec![0_usize; words];
-    let information = buffer.as_mut_ptr().cast::<FILE_RENAME_INFO>();
+    let information = buffer.as_mut_ptr().cast::<FILE_RENAME_INFORMATION>();
     unsafe {
         (*information).Anonymous.ReplaceIfExists = replace;
         (*information).RootDirectory = target.directory.file.as_raw_handle().cast();
@@ -123,18 +127,22 @@ pub(super) fn durable_rename(
             name.len(),
         );
     }
-    if unsafe {
-        SetFileInformationByHandle(
+    let mut status_block = IO_STATUS_BLOCK::default();
+    let status = unsafe {
+        NtSetInformationFile(
             file.as_raw_handle().cast(),
-            FileRenameInfo,
+            &mut status_block,
             information.cast(),
             u32::try_from(total_bytes)?,
+            FileRenameInformation,
         )
-    } == 0
-    {
-        return Err(std::io::Error::last_os_error()).context("rename managed-pair file by handle");
+    };
+    if status < 0 {
+        return Err(std::io::Error::from_raw_os_error(
+            unsafe { RtlNtStatusToDosError(status) } as i32,
+        ))
+        .context("rename managed-pair file by handle");
     }
-    file.sync_all()?;
     Ok(())
 }
 
@@ -149,6 +157,7 @@ pub(crate) fn durable_replace(
     require_stamp(source, expected, max, label)?;
     durable_rename(source, target, expected, label, true)?;
     require_stamp(target, expected, max, label)
+        .with_context(|| format!("revalidate renamed managed-pair {label}"))
 }
 
 #[cfg(unix)]

--- a/crates/ctx-upgrade-engine/src/upgrade/install/lock_marker_tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/lock_marker_tests.rs
@@ -210,6 +210,7 @@ fn valid_marker_uses_the_canonical_executable_path() -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
 #[test]
 fn upgraded_marker_preserves_validated_owned_extensions() -> Result<()> {
     let fixture = tempdir()?;

--- a/crates/ctx-upgrade-engine/src/upgrade/install/lock_tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/lock_tests.rs
@@ -47,6 +47,7 @@ fn fresh_root_and_installed_executable_share_the_persistent_lock() -> Result<()>
     let fixture = tempdir()?;
     let bin = fixture.path().join("bin");
     fs::create_dir(&bin)?;
+    ctx_history_platform::platform_security::restrict_private_directory(&bin)?;
 
     let root_lock =
         InstallationLock::try_acquire_at_root(fixture.path())?.expect("fresh root lock");
@@ -86,7 +87,7 @@ fn windows_candidate_contends_with_base_version_lock() -> Result<()> {
 
     assert_eq!(
         installation_lock_path(&canonical_executable(&executable)?)?,
-        base_lock_path
+        fs::canonicalize(&base_lock_path)?
     );
     assert!(
         InstallationLock::try_acquire(&executable)?.is_none(),

--- a/crates/ctx-upgrade-engine/src/upgrade/install/transaction/journal.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/transaction/journal.rs
@@ -661,9 +661,17 @@ fn validate_identity(journal: &InstallTransactionJournal) -> Result<()> {
 
 #[cfg(windows)]
 fn validate_windows_private_root(path: &Path, label: &str) -> Result<()> {
+    use super::super::path_identity::windows_disk_path_identity;
+
     let canonical = fs::canonicalize(path)
         .with_context(|| format!("canonicalize {label} {}", path.display()))?;
-    if canonical != path {
+    if !matches!(
+        (
+            windows_disk_path_identity(path),
+            windows_disk_path_identity(&canonical)
+        ),
+        (Some(path), Some(canonical)) if path == canonical
+    ) {
         return Err(anyhow!("{label} is not canonical: {}", path.display()));
     }
     ctx_history_platform::platform_security::verify_private_directory(path)

--- a/crates/ctx-upgrade-engine/src/upgrade/install/transaction/tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/transaction/tests.rs
@@ -154,6 +154,7 @@ fn empty_publication_transaction_remains_invalid() {
     );
 }
 
+#[cfg(not(windows))]
 #[test]
 fn coreml_clean_install_journals_exact_fallback_composition_and_paths() {
     let temp = tempfile::tempdir().unwrap();
@@ -180,6 +181,7 @@ fn coreml_clean_install_journals_exact_fallback_composition_and_paths() {
     );
 }
 
+#[cfg(not(windows))]
 #[test]
 fn coreml_clean_install_rejects_every_path_outside_its_authority_root() {
     let temp = tempfile::tempdir().unwrap();

--- a/crates/ctx-upgrade-engine/src/upgrade/install/transaction/windows/tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/install/transaction/windows/tests.rs
@@ -222,12 +222,14 @@ fn binary_publication_retains_the_fingerprint_revalidation_exemption() {
 #[test]
 fn failed_replace_repairs_missing_executable_before_any_wait() {
     let temp = tempfile::tempdir().unwrap();
+    ctx_history_platform::platform_security::restrict_private_directory(temp.path()).unwrap();
     let target = temp.path().join("ctx");
-    let staged = temp.path().join("ctx.new");
-    let backup = temp.path().join("ctx.backup");
+    let staged = temp.path().join(".ctx-upgrade-attempt.new");
+    let backup = journal::transaction_backup_path(&target, "attempt", "binary");
     fs::write(&target, b"old").unwrap();
     fs::write(&staged, b"new").unwrap();
     fs::write(&backup, b"old").unwrap();
+    ctx_history_platform::platform_security::restrict_private_file(&backup).unwrap();
     let path = path_record(
         "ctx binary",
         &staged,
@@ -235,7 +237,15 @@ fn failed_replace_repairs_missing_executable_before_any_wait() {
         &backup,
         JournalPathState::BackedUp,
     );
-    let mut transaction = transaction(temp.path(), vec![path.clone()]);
+    let marker_target = crate::upgrade::install::install_marker_path(&target);
+    let marker_path = path_record(
+        "ctx install marker",
+        &temp.path().join(".ctx-upgrade-attempt.install.json.new"),
+        &marker_target,
+        &journal::transaction_backup_path(&marker_target, "attempt", "marker"),
+        JournalPathState::Staged,
+    );
+    let mut transaction = transaction(temp.path(), vec![path.clone(), marker_path]);
     let waits = Cell::new(0);
     let error = layout::replace_binary_with_repair(
         &mut transaction,
@@ -248,7 +258,10 @@ fn failed_replace_repairs_missing_executable_before_any_wait() {
         || waits.set(waits.get() + 1),
     )
     .unwrap_err();
-    assert!(format!("{error:#}").contains("injected"));
+    assert!(
+        format!("{error:#}").contains("injected"),
+        "unexpected replacement error: {error:#}"
+    );
     assert_eq!(waits.get(), 0);
     assert_eq!(fs::read(&target).unwrap(), b"old");
     assert_eq!(transaction.paths[0].state, JournalPathState::Staged);


### PR DESCRIPTION
## Summary

- use the native Windows rename API required for directory-relative atomic replacement
- validate file identity before ACL repair and open the retained handle with the required permission
- release retained directory handles before candidate cleanup
- compare stable Windows disk identity instead of path spelling and correct platform-specific test setup

## Validation

- native Windows: managed-pair engine 11/11, upgrade engine 110/110, CLI managed-pair capability 8/8
- Linux Bazel: `//crates/ctx-managed-pair-engine:unit_tests`, `//crates/ctx-upgrade-engine:unit_tests`, `//crates/ctx-cli:unit_tests`
- `cargo fmt --all --check` and `git diff --check`
- repository LOC and Cargo/Bazel ownership policy gates
- public push disclosure guard
- independent final review: no findings

All affected suites passed on exact head `cb1881862b263dc28cdc2dbfc8573641f499f94c`.