### PR TITLE
test(daemon): stabilize terminal upgrade event observation

### DIFF
--- a/crates/ctx-cli-contract-tests/tests/contracts/support/daemon.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/support/daemon.rs
@@ -3,18 +3,52 @@ use std::{
     fs,
     ops::Deref,
     path::{Path, PathBuf},
+    process::{Child, Command as StdCommand, ExitStatus, Stdio},
     thread,
     time::{Duration, Instant},
 };
 use tempfile::TempDir;
 
+#[cfg(unix)]
+use super::analytics_outbox_paths;
 use super::runner::{
     ctx, ctx_from_binary, data_root, json_output, tempdir, test_binary_copy_path,
     PERSISTENT_DAEMON_TEST_ROOT_MARKER,
 };
-
+const DAEMON_DISABLE_COMMAND_TIMEOUT: Duration = Duration::from_secs(12);
+const DAEMON_DISABLE_REAP_TIMEOUT: Duration = Duration::from_secs(1);
 const DAEMON_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 const DAEMON_STOP_POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+#[cfg(unix)]
+pub(crate) struct TerminalUpgradeObservation {
+    pub(crate) state: Value,
+    pub(crate) events: Vec<Value>,
+}
+
+#[cfg(unix)]
+impl TerminalUpgradeObservation {
+    pub(crate) fn assert_applied_auto_upgrade(self) {
+        assert_eq!(self.events.len(), 1);
+        let event = &self.events[0];
+        assert_eq!(event["event_name"], "operation_completed");
+        assert_eq!(event["event_version"], 1);
+        assert_eq!(event["surface"], "cli");
+        assert_eq!(event["operation"], "upgrade");
+        assert_eq!(event["outcome"], "success");
+        assert!(event["event_id"].as_str().is_some_and(|value| {
+            uuid::Uuid::parse_str(value).is_ok_and(|id| id.get_version_num() == 4)
+        }));
+        let properties = event["properties"].as_object().unwrap();
+        assert_eq!(properties["upgrade_mode"], "auto");
+        assert_eq!(properties["upgrade_status"], "applied");
+        assert_eq!(properties["upgrade_applied"], true);
+        assert_eq!(
+            properties["upgrade_attempt_id"],
+            self.state["attempt_id"].as_str().unwrap()
+        );
+    }
+}
 
 /// A temporary CLI root that owns every daemon started from its copied binary.
 ///
@@ -24,17 +58,96 @@ const DAEMON_STOP_POLL_INTERVAL: Duration = Duration::from_millis(20);
 /// signal. A PID alone is never sufficient authority.
 pub(crate) struct DaemonTestRoot {
     temp: TempDir,
+    daemon_data_root: PathBuf,
 }
 
 impl DaemonTestRoot {
     fn new() -> Self {
         let temp = tempdir();
+        let daemon_data_root = data_root(&temp);
+        Self::with_temp_and_data_root(temp, daemon_data_root)
+    }
+
+    fn with_data_root_name(name: &str) -> Self {
+        let temp = tempdir();
+        let relative = Path::new(name);
+        let mut components = relative.components();
+        assert!(
+            matches!(components.next(), Some(std::path::Component::Normal(_)))
+                && components.next().is_none(),
+            "daemon test data root must be one relative path component"
+        );
+        let daemon_data_root = temp.path().join(relative);
+        Self::with_temp_and_data_root(temp, daemon_data_root)
+    }
+
+    fn with_temp_and_data_root(temp: TempDir, daemon_data_root: PathBuf) -> Self {
         fs::write(
             temp.path().join(PERSISTENT_DAEMON_TEST_ROOT_MARKER),
             b"test-owned persistent daemon root\n",
         )
         .unwrap();
-        Self { temp }
+        Self {
+            temp,
+            daemon_data_root,
+        }
+    }
+
+    pub(crate) fn daemon_data_root(&self) -> &Path {
+        &self.daemon_data_root
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn observe_terminal_upgrade_handoff(
+        &self,
+        child: Child,
+        state_path: &Path,
+        events_path: &Path,
+        timeout: Duration,
+    ) -> TerminalUpgradeObservation {
+        let mut child = TestOwnedDaemonChild::new(self, child);
+        let original_pid = child.id();
+        let deadline = Instant::now() + timeout;
+        let (mut state, mut replacement_pid, mut event, mut status) = (None, None, None, None);
+        loop {
+            state = state.or_else(|| read_applied_upgrade_state(state_path));
+            replacement_pid = replacement_pid
+                .or_else(|| running_replacement_daemon_pid(&self.daemon_data_root, original_pid));
+            if event.is_none() {
+                event = state.as_ref().and_then(|state| {
+                    terminal_upgrade_event(events_path, self.path(), state["attempt_id"].as_str()?)
+                        .unwrap_or_else(|error| panic!("observe terminal upgrade event: {error}"))
+                });
+            }
+            if status.is_none() {
+                status = child.try_wait().unwrap();
+            }
+            if state.is_some() && replacement_pid.is_some() && event.is_some() && status.is_some() {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for durable state, replacement daemon, terminal event, and original daemon exit"
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
+        assert!(status.unwrap().success(), "original upgrade daemon failed");
+
+        let replacement_pid = replacement_pid.unwrap();
+        stop_test_owned_daemon(&self.temp, &self.daemon_data_root, Some(replacement_pid))
+            .unwrap_or_else(|error| panic!("stop test-owned replacement daemon: {error}"));
+        reap_exited_process_if_child(replacement_pid)
+            .unwrap_or_else(|error| panic!("reap replacement daemon: {error}"));
+        let state = state.unwrap();
+        let events = terminal_upgrade_event(
+            events_path,
+            self.path(),
+            state["attempt_id"].as_str().unwrap(),
+        )
+        .unwrap_or_else(|error| panic!("observe stopped terminal upgrade event: {error}"))
+        .into_iter()
+        .collect();
+        TerminalUpgradeObservation { state, events }
     }
 }
 
@@ -54,7 +167,7 @@ impl AsRef<Path> for DaemonTestRoot {
 
 impl Drop for DaemonTestRoot {
     fn drop(&mut self) {
-        if let Err(error) = stop_test_owned_daemon(&self.temp) {
+        if let Err(error) = stop_test_owned_daemon(&self.temp, &self.daemon_data_root, None) {
             if thread::panicking() {
                 eprintln!("test-owned daemon teardown also failed: {error}");
             } else {
@@ -66,6 +179,300 @@ impl Drop for DaemonTestRoot {
 
 pub(crate) fn daemon_test_root() -> DaemonTestRoot {
     DaemonTestRoot::new()
+}
+
+pub(crate) fn daemon_test_root_with_data_root(name: &str) -> DaemonTestRoot {
+    DaemonTestRoot::with_data_root_name(name)
+}
+
+#[cfg(unix)]
+struct TestOwnedDaemonChild<'a> {
+    root: &'a DaemonTestRoot,
+    child: Option<Child>,
+}
+
+#[cfg(unix)]
+impl<'a> TestOwnedDaemonChild<'a> {
+    fn new(root: &'a DaemonTestRoot, child: Child) -> Self {
+        Self {
+            root,
+            child: Some(child),
+        }
+    }
+
+    fn id(&self) -> u32 {
+        self.child.as_ref().expect("daemon child was reaped").id()
+    }
+
+    fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>> {
+        let status = self
+            .child
+            .as_mut()
+            .expect("daemon child was reaped")
+            .try_wait()?;
+        if status.is_some() {
+            self.child.take();
+        }
+        Ok(status)
+    }
+}
+
+#[cfg(unix)]
+impl Drop for TestOwnedDaemonChild<'_> {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        let stop = stop_test_owned_daemon(&self.root.temp, &self.root.daemon_data_root, None);
+        let deadline = Instant::now() + DAEMON_STOP_TIMEOUT;
+        let reap = loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break Ok(()),
+                Ok(None) if Instant::now() < deadline => thread::sleep(DAEMON_STOP_POLL_INTERVAL),
+                Ok(None) => break Err("timed out reaping daemon child".to_owned()),
+                Err(error) => break Err(format!("reap daemon child: {error}")),
+            }
+        };
+        let result = match (stop, reap) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+            (Err(stop), Err(reap)) => Err(format!("{stop}; {reap}")),
+        };
+        if let Err(error) = result {
+            if thread::panicking() {
+                eprintln!("test-owned daemon child teardown also failed: {error}");
+            } else {
+                panic!("test-owned daemon child teardown failed: {error}");
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+fn read_applied_upgrade_state(path: &Path) -> Option<Value> {
+    let state: Value = serde_json::from_slice(&fs::read(path).ok()?).ok()?;
+    (state["status"] == "applied" && state["attempt_id"].as_str().is_some()).then_some(state)
+}
+
+#[cfg(unix)]
+fn running_replacement_daemon_pid(root: &Path, original_pid: u32) -> Option<u32> {
+    let status: Value =
+        serde_json::from_slice(&fs::read(root.join("daemon/status.json")).ok()?).ok()?;
+    let pid = status["pid"]
+        .as_u64()
+        .and_then(|pid| u32::try_from(pid).ok())?;
+    (status["status"] == "running" && pid != original_pid).then_some(pid)
+}
+
+#[cfg(unix)]
+#[derive(Clone)]
+struct ObservedAnalyticsPayload {
+    raw: Option<Vec<u8>>,
+    value: Value,
+}
+
+#[cfg(unix)]
+fn delivered_payloads(events_path: &Path) -> Result<Option<Vec<ObservedAnalyticsPayload>>, String> {
+    let bytes = match fs::read(events_path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Some(Vec::new())),
+        Err(error) => return Err(format!("read {}: {error}", events_path.display())),
+    };
+    // The file transport writes each body and its newline separately. Retry a
+    // snapshot ending in an in-flight body instead of parsing its partial JSON.
+    if bytes.last().is_some_and(|byte| *byte != b'\n') {
+        return Ok(None);
+    }
+    bytes
+        .split(|byte| *byte == b'\n')
+        .filter(|line| !line.iter().all(u8::is_ascii_whitespace))
+        .map(|line| {
+            let value = serde_json::from_slice(line).map_err(|error| {
+                format!(
+                    "parse complete record in {}: {error}",
+                    events_path.display()
+                )
+            })?;
+            Ok(ObservedAnalyticsPayload {
+                raw: Some(line.to_vec()),
+                value,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
+}
+
+#[cfg(unix)]
+fn queued_payloads(analytics_root: &Path) -> Result<Vec<ObservedAnalyticsPayload>, String> {
+    let mut payloads = Vec::new();
+    for outbox in analytics_outbox_paths(analytics_root) {
+        let bytes = match fs::read(&outbox) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(format!(
+                    "read analytics outbox {}: {error}",
+                    outbox.display()
+                ))
+            }
+        };
+        let state: Value = serde_json::from_slice(&bytes)
+            .map_err(|error| format!("parse analytics outbox {}: {error}", outbox.display()))?;
+        let entries = state["entries"]
+            .as_array()
+            .ok_or_else(|| format!("analytics outbox has no entries array: {state:#}"))?;
+        for entry in entries {
+            let body = entry
+                .get("payload")
+                .or_else(|| entry.get("body"))
+                .ok_or_else(|| format!("analytics outbox entry has no payload body: {entry:#}"))?;
+            let payload = match body {
+                Value::String(body) => ObservedAnalyticsPayload {
+                    raw: Some(body.as_bytes().to_vec()),
+                    value: serde_json::from_str(body).map_err(|error| {
+                        format!(
+                            "parse queued analytics payload in {}: {error}",
+                            outbox.display()
+                        )
+                    })?,
+                },
+                Value::Object(_) => ObservedAnalyticsPayload {
+                    raw: None,
+                    value: body.clone(),
+                },
+                _ => {
+                    return Err(format!(
+                        "analytics outbox payload is not JSON text: {entry:#}"
+                    ))
+                }
+            };
+            payloads.push(payload);
+        }
+    }
+    Ok(payloads)
+}
+
+#[cfg(unix)]
+fn matching_terminal_events(
+    payloads: Vec<ObservedAnalyticsPayload>,
+    attempt_id: &str,
+) -> Result<Vec<(String, Option<Vec<u8>>, Value)>, String> {
+    let mut matches = Vec::new();
+    for payload in payloads {
+        let Some(events) = payload.value["events"].as_array() else {
+            continue;
+        };
+        for event in events {
+            if event["event_name"] == "operation_completed"
+                && event["surface"] == "cli"
+                && event["operation"] == "upgrade"
+                && event["properties"]["upgrade_attempt_id"] == attempt_id
+            {
+                let id = event["event_id"]
+                    .as_str()
+                    .filter(|id| !id.is_empty())
+                    .ok_or_else(|| "matching terminal upgrade event has no event_id".to_owned())?;
+                matches.push((id.to_owned(), payload.raw.clone(), event.clone()));
+            }
+        }
+    }
+    Ok(matches)
+}
+
+#[cfg(unix)]
+fn terminal_upgrade_event(
+    events_path: &Path,
+    analytics_root: &Path,
+    attempt_id: &str,
+) -> Result<Option<Value>, String> {
+    // A successful delivery is flushed before its durable entry is removed.
+    // Queue-first observation therefore cannot see a false zero during drain.
+    let queued = matching_terminal_events(queued_payloads(analytics_root)?, attempt_id)?;
+    let Some(delivered) = delivered_payloads(events_path)? else {
+        return Ok(None);
+    };
+    let delivered = matching_terminal_events(delivered, attempt_id)?;
+    if delivered.len() > 1 || queued.len() > 1 {
+        return Err(format!(
+            "terminal upgrade event count by source was delivered={} queued={}",
+            delivered.len(),
+            queued.len()
+        ));
+    }
+    match (delivered.first(), queued.first()) {
+        (None, None) => Ok(None),
+        (Some(event), None) | (None, Some(event)) => Ok(Some(event.2.clone())),
+        (Some(delivered), Some(queued))
+            if delivered.0 == queued.0
+                && delivered
+                    .1
+                    .as_deref()
+                    .zip(queued.1.as_deref())
+                    .is_some_and(|(delivered, queued)| delivered == queued) =>
+        {
+            Ok(Some(delivered.2.clone()))
+        }
+        (Some(delivered), Some(queued)) => Err(format!(
+            "conflicting delivered/queued terminal events {} and {}",
+            delivered.0, queued.0
+        )),
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn assert_terminal_upgrade_raw_overlap_contract() {
+    const ATTEMPT_ID: &str = "attempt-1";
+    const DELIVERED: &[u8] = br#"{"events":[{"event_id":"event-1","event_name":"operation_completed","surface":"cli","operation":"upgrade","properties":{"upgrade_attempt_id":"attempt-1"}}]}"#;
+    const REENCODED: &[u8] = br#"{ "events": [ { "operation": "upgrade", "surface": "cli", "event_name": "operation_completed", "event_id": "event-1", "properties": { "upgrade_attempt_id": "attempt-1" } } ] }"#;
+
+    assert_eq!(
+        serde_json::from_slice::<Value>(DELIVERED).unwrap(),
+        serde_json::from_slice::<Value>(REENCODED).unwrap()
+    );
+    let temp = tempdir();
+    let events_path = temp.path().join("analytics.jsonl");
+    let outbox_path = temp.path().join("analytics-outbox-v1.json");
+    let mut delivered_record = DELIVERED.to_vec();
+    delivered_record.push(b'\n');
+    fs::write(&events_path, delivered_record).unwrap();
+    let queue = |raw: &[u8]| {
+        let raw = std::str::from_utf8(raw).unwrap();
+        fs::write(
+            &outbox_path,
+            serde_json::to_vec(&serde_json::json!({"entries": [{"payload": raw}]})).unwrap(),
+        )
+        .unwrap();
+    };
+
+    queue(DELIVERED);
+    assert!(
+        terminal_upgrade_event(&events_path, temp.path(), ATTEMPT_ID)
+            .unwrap()
+            .is_some()
+    );
+    queue(REENCODED);
+    let error = terminal_upgrade_event(&events_path, temp.path(), ATTEMPT_ID).unwrap_err();
+    assert!(error.contains("conflicting delivered/queued terminal events"));
+}
+
+#[cfg(unix)]
+fn reap_exited_process_if_child(pid: u32) -> Result<(), String> {
+    let raw_pid = libc::pid_t::try_from(pid).map_err(|error| format!("invalid pid: {error}"))?;
+    let mut status = 0;
+    let result = unsafe { libc::waitpid(raw_pid, &mut status, libc::WNOHANG) };
+    if result == raw_pid {
+        (!process_is_running(pid))
+            .then_some(())
+            .ok_or_else(|| format!("reaped replacement daemon pid {pid} was reused"))
+    } else if result == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ECHILD) {
+        (!process_is_running(pid))
+            .then_some(())
+            .ok_or_else(|| format!("replacement daemon {pid} was not a child and remained live"))
+    } else if result == 0 {
+        Err(format!("replacement daemon {pid} remained live"))
+    } else {
+        Err(std::io::Error::last_os_error().to_string())
+    }
 }
 
 pub(crate) fn wait_for_test_lexical_projection(temp: &TempDir, generation: &str) {
@@ -92,70 +499,200 @@ struct DaemonIdentity {
     binary: PathBuf,
 }
 
-fn stop_test_owned_daemon(temp: &TempDir) -> Result<(), String> {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BoundedCommandExit {
+    Exited,
+    KilledAndReaped,
+}
+
+fn std_command_from_assert(prepared: &assert_cmd::Command) -> StdCommand {
+    let mut command = StdCommand::new(prepared.get_program());
+    command.args(prepared.get_args());
+    for (name, value) in prepared.get_envs() {
+        match value {
+            Some(value) => {
+                command.env(name, value);
+            }
+            None => {
+                command.env_remove(name);
+            }
+        }
+    }
+    if let Some(directory) = prepared.get_current_dir() {
+        command.current_dir(directory);
+    }
+    command
+}
+
+fn poll_child_until(
+    child: &mut Child,
+    deadline: Instant,
+    label: &str,
+) -> Result<Option<ExitStatus>, String> {
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(Some(status)),
+            Ok(None) => {}
+            Err(error) => return Err(format!("poll {label}: {error}")),
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            return Ok(None);
+        }
+        thread::sleep(DAEMON_STOP_POLL_INTERVAL.min(deadline.saturating_duration_since(now)));
+    }
+}
+
+fn kill_and_reap_child_bounded(
+    child: &mut Child,
+    timeout: Duration,
+    label: &str,
+) -> Result<(), String> {
+    let kill_error = child.kill().err();
+    match poll_child_until(child, Instant::now() + timeout, label) {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => Err(format!(
+            "{label} did not exit within {timeout:?} after Child::kill{}",
+            kill_error
+                .map(|error| format!(" failed: {error}"))
+                .unwrap_or_default()
+        )),
+        Err(reap_error) => Err(match kill_error {
+            Some(kill_error) => format!("kill {label}: {kill_error}; {reap_error}"),
+            None => reap_error,
+        }),
+    }
+}
+
+fn run_child_bounded(
+    command: &mut StdCommand,
+    timeout: Duration,
+    reap_timeout: Duration,
+    label: &str,
+) -> Result<BoundedCommandExit, String> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("start {label}: {error}"))?;
+    match poll_child_until(&mut child, Instant::now() + timeout, label) {
+        Ok(Some(_)) => Ok(BoundedCommandExit::Exited),
+        Ok(None) => {
+            kill_and_reap_child_bounded(&mut child, reap_timeout, label)?;
+            Ok(BoundedCommandExit::KilledAndReaped)
+        }
+        Err(poll_error) => match kill_and_reap_child_bounded(&mut child, reap_timeout, label) {
+            Ok(()) => Err(poll_error),
+            Err(cleanup_error) => Err(format!("{poll_error}; {cleanup_error}")),
+        },
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn assert_bounded_disable_command_timeout(fixture: &str) {
+    let mut command = StdCommand::new(std::env::current_exe().unwrap());
+    command.args(["--exact", fixture, "--ignored"]);
+    let started = Instant::now();
+    let exit = run_child_bounded(
+        &mut command,
+        Duration::from_millis(100),
+        DAEMON_DISABLE_REAP_TIMEOUT,
+        "stalled disable fixture",
+    )
+    .unwrap();
+    assert_eq!(exit, BoundedCommandExit::KilledAndReaped);
+    assert!(started.elapsed() < Duration::from_secs(2));
+}
+
+fn stop_test_owned_daemon(
+    temp: &TempDir,
+    daemon_data_root: &Path,
+    expected_pid: Option<u32>,
+) -> Result<(), String> {
     let binary = test_binary_copy_path(temp);
     if !binary.is_file() {
+        if expected_pid.is_some() {
+            return Err("cannot attribute replacement daemon without its test binary".into());
+        }
         return Ok(());
     }
 
-    let initial = read_daemon_identity(temp)?;
-    if let Some(identity) = initial.as_ref() {
-        if process_is_running(identity.pid) {
-            verify_live_daemon_identity(temp, &binary, identity)?;
-        } else if !same_file(&identity.binary, &binary)? {
+    let Some(initial) = read_daemon_identity(daemon_data_root)? else {
+        if expected_pid.is_some() {
+            return Err("cannot attribute replacement daemon without an active lock".into());
+        }
+        return remove_released_test_daemon_artifacts(daemon_data_root, &binary);
+    };
+    if let Some(expected_pid) = expected_pid {
+        if expected_pid != initial.pid {
             return Err(format!(
-                "daemon lock binary {} is not the test copy {}",
-                identity.binary.display(),
-                binary.display()
+                "observed replacement pid {expected_pid} does not match test daemon lock {initial:?}"
             ));
         }
+        verify_live_daemon_identity(daemon_data_root, &binary, &initial)?;
+    } else if process_is_running(initial.pid) {
+        verify_live_daemon_identity(daemon_data_root, &binary, &initial)?;
+    } else if !same_file(&initial.binary, &binary)? {
+        return Err(format!(
+            "daemon lock binary {} is not the test copy {}",
+            initial.binary.display(),
+            binary.display()
+        ));
     }
-    let output = ctx_from_binary(temp, &binary)
+    let mut prepared = ctx_from_binary(temp, &binary);
+    prepared
+        .env("CTX_DATA_ROOT", daemon_data_root)
         .env("CTX_DAEMON_AUTOSTART_OFF", "1")
-        .args(["daemon", "disable", "--format=json"])
-        .output()
-        .map_err(|error| format!("run daemon disable with {}: {error}", binary.display()))?;
-
-    if let Some(identity) = initial.as_ref() {
-        if wait_for_process_exit(identity.pid, DAEMON_STOP_TIMEOUT) {
-            return assert_daemon_released(temp, identity);
+        .args(["daemon", "disable", "--format=json"]);
+    let disable = run_child_bounded(
+        &mut std_command_from_assert(&prepared),
+        DAEMON_DISABLE_COMMAND_TIMEOUT,
+        DAEMON_DISABLE_REAP_TIMEOUT,
+        "test daemon disable command",
+    );
+    let cooperative_wait = if matches!(&disable, Ok(BoundedCommandExit::Exited)) {
+        DAEMON_STOP_TIMEOUT
+    } else {
+        Duration::ZERO
+    };
+    let fallback = (|| {
+        if wait_for_process_exit(initial.pid, cooperative_wait) {
+            return assert_daemon_released(daemon_data_root, &initial);
         }
-        verify_live_daemon_identity(temp, &binary, identity)?;
-        terminate_process(identity.pid, false)
-            .map_err(|error| format!("terminate verified test daemon {}: {error}", identity.pid))?;
-        if !wait_for_process_exit(identity.pid, Duration::from_secs(1)) {
-            verify_live_daemon_identity(temp, &binary, identity)?;
-            terminate_process(identity.pid, true).map_err(|error| {
+        verify_live_daemon_identity(daemon_data_root, &binary, &initial)?;
+        terminate_process(initial.pid, false)
+            .map_err(|error| format!("terminate verified test daemon {}: {error}", initial.pid))?;
+        if !wait_for_process_exit(initial.pid, Duration::from_secs(1)) {
+            verify_live_daemon_identity(daemon_data_root, &binary, &initial)?;
+            terminate_process(initial.pid, true).map_err(|error| {
                 format!(
                     "force-terminate verified test daemon {}: {error}",
-                    identity.pid
+                    initial.pid
                 )
             })?;
         }
-        if !wait_for_process_exit(identity.pid, DAEMON_STOP_TIMEOUT) {
+        if !wait_for_process_exit(initial.pid, DAEMON_STOP_TIMEOUT) {
             return Err(format!(
                 "verified test daemon {} remained alive after teardown",
-                identity.pid
+                initial.pid
             ));
         }
-        return assert_daemon_released(temp, identity);
+        assert_daemon_released(daemon_data_root, &initial)
+    })();
+    match (disable, fallback) {
+        (Ok(_), result) => result,
+        (Err(disable), Ok(())) => Err(disable),
+        (Err(disable), Err(fallback)) => Err(format!("{disable}; {fallback}")),
     }
-
-    if output.status.success() {
-        return remove_released_test_daemon_artifacts(temp, &binary);
-    }
-    Err(format!(
-        "daemon disable failed without an attributable lock ({}): {}",
-        output.status,
-        String::from_utf8_lossy(&output.stderr)
-    ))
 }
 
 fn remove_released_test_daemon_artifacts(
-    temp: &TempDir,
+    daemon_data_root: &Path,
     expected_binary: &Path,
 ) -> Result<(), String> {
-    let path = data_root(temp).join("daemon/daemon.lock");
+    let path = daemon_data_root.join("daemon/daemon.lock");
     if let Ok(bytes) = fs::read(&path) {
         let value: Value = serde_json::from_slice(&bytes)
             .map_err(|error| format!("parse released daemon lock {}: {error}", path.display()))?;
@@ -168,11 +705,11 @@ fn remove_released_test_daemon_artifacts(
             .as_str()
             .map(Path::new)
             .ok_or_else(|| format!("released daemon lock has no data root: {value:#}"))?;
-        if !same_path(recorded_data_root, &data_root(temp)) {
+        if !same_path(recorded_data_root, daemon_data_root) {
             return Err(format!(
                 "released daemon lock data root {} does not match test root {}",
                 recorded_data_root.display(),
-                data_root(temp).display()
+                daemon_data_root.display()
             ));
         }
         let recorded_binary = value["binary"]
@@ -196,11 +733,11 @@ fn remove_released_test_daemon_artifacts(
             ));
         }
     }
-    remove_test_daemon_artifacts(temp)
+    remove_test_daemon_artifacts(daemon_data_root)
 }
 
-fn read_daemon_identity(temp: &TempDir) -> Result<Option<DaemonIdentity>, String> {
-    let path = data_root(temp).join("daemon/daemon.lock");
+fn read_daemon_identity(daemon_data_root: &Path) -> Result<Option<DaemonIdentity>, String> {
+    let path = daemon_data_root.join("daemon/daemon.lock");
     let Some(bytes) = fs::read(&path)
         .map(Some)
         .or_else(|error| {
@@ -232,11 +769,11 @@ fn read_daemon_identity(temp: &TempDir) -> Result<Option<DaemonIdentity>, String
         .as_str()
         .map(Path::new)
         .ok_or_else(|| format!("daemon lock has no data-root identity: {value:#}"))?;
-    if !same_path(recorded_data_root, &data_root(temp)) {
+    if !same_path(recorded_data_root, daemon_data_root) {
         return Err(format!(
             "daemon lock data root {} does not match test root {}",
             recorded_data_root.display(),
-            data_root(temp).display()
+            daemon_data_root.display()
         ));
     }
     let binary = value["binary"]
@@ -251,11 +788,11 @@ fn read_daemon_identity(temp: &TempDir) -> Result<Option<DaemonIdentity>, String
 }
 
 fn verify_live_daemon_identity(
-    temp: &TempDir,
+    daemon_data_root: &Path,
     expected_binary: &Path,
     expected: &DaemonIdentity,
 ) -> Result<(), String> {
-    let current = read_daemon_identity(temp)?
+    let current = read_daemon_identity(daemon_data_root)?
         .ok_or_else(|| "daemon lock was released while its process remained alive".to_owned())?;
     if &current != expected {
         return Err(format!(
@@ -286,11 +823,14 @@ fn verify_live_daemon_identity(
     Ok(())
 }
 
-fn assert_daemon_released(temp: &TempDir, expected: &DaemonIdentity) -> Result<(), String> {
+fn assert_daemon_released(
+    daemon_data_root: &Path,
+    expected: &DaemonIdentity,
+) -> Result<(), String> {
     if process_is_running(expected.pid) {
         return Err(format!("test daemon {} is still running", expected.pid));
     }
-    let path = data_root(temp).join("daemon/daemon.lock");
+    let path = daemon_data_root.join("daemon/daemon.lock");
     if let Ok(bytes) = fs::read(&path) {
         let value: Value = serde_json::from_slice(&bytes)
             .map_err(|error| format!("parse released daemon lock {}: {error}", path.display()))?;
@@ -302,10 +842,10 @@ fn assert_daemon_released(temp: &TempDir, expected: &DaemonIdentity) -> Result<(
             ));
         }
     }
-    remove_test_daemon_artifacts(temp)
+    remove_test_daemon_artifacts(daemon_data_root)
 }
 
-fn assert_no_endpoint_identity(temp: &TempDir) -> Result<(), String> {
+fn assert_no_endpoint_identity(daemon_data_root: &Path) -> Result<(), String> {
     for name in [
         "daemon.lock",
         "daemon.guard",
@@ -314,7 +854,7 @@ fn assert_no_endpoint_identity(temp: &TempDir) -> Result<(), String> {
         "query.sock",
         "source-refresh.sock",
     ] {
-        let path = data_root(temp).join("daemon").join(name);
+        let path = daemon_data_root.join("daemon").join(name);
         if path.exists() {
             return Err(format!(
                 "test daemon artifact remained after teardown: {}",
@@ -325,7 +865,7 @@ fn assert_no_endpoint_identity(temp: &TempDir) -> Result<(), String> {
     Ok(())
 }
 
-fn remove_test_daemon_artifacts(temp: &TempDir) -> Result<(), String> {
+fn remove_test_daemon_artifacts(daemon_data_root: &Path) -> Result<(), String> {
     for name in [
         "query-endpoint.json",
         "source-refresh-endpoint.json",
@@ -334,7 +874,7 @@ fn remove_test_daemon_artifacts(temp: &TempDir) -> Result<(), String> {
         "daemon.lock",
         "daemon.guard",
     ] {
-        let path = data_root(temp).join("daemon").join(name);
+        let path = daemon_data_root.join("daemon").join(name);
         match fs::remove_file(&path) {
             Ok(()) => {}
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
@@ -346,7 +886,7 @@ fn remove_test_daemon_artifacts(temp: &TempDir) -> Result<(), String> {
             }
         }
     }
-    assert_no_endpoint_identity(temp)
+    assert_no_endpoint_identity(daemon_data_root)
 }
 
 fn wait_for_process_exit(pid: u32, timeout: Duration) -> bool {

--- a/crates/ctx-daemon-cli/tests/contracts/auto_upgrade_acceptance.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/auto_upgrade_acceptance.rs
@@ -3,7 +3,6 @@ mod support;
 #[cfg(unix)]
 mod unix {
     use std::{
-        collections::BTreeMap,
         fs,
         os::unix::{ffi::OsStrExt as _, fs::PermissionsExt as _},
         path::{Path, PathBuf},
@@ -451,54 +450,6 @@ mod unix {
         unsafe {
             libc::kill(pid as libc::pid_t, libc::SIGTERM);
         }
-    }
-
-    fn stop_and_reap_daemon(pid: u32) {
-        stop_daemon(pid);
-        wait_for(
-            "replacement daemon reaping",
-            TERMINAL_UPGRADE_OBSERVATION_TIMEOUT,
-            || !process_is_running(pid),
-        );
-    }
-
-    fn terminal_upgrade_events_for_attempt(
-        events_path: &Path,
-        analytics_root: &Path,
-        attempt_id: &str,
-    ) -> Vec<Value> {
-        let mut payloads = if events_path.exists() {
-            read_delivered_analytics_events(events_path)
-        } else {
-            Vec::new()
-        };
-        // The analytics outbox is the durable publication state while delivery
-        // races with the replacement daemon's startup.
-        payloads.extend(read_queued_analytics_events(analytics_root));
-
-        let mut events_by_id = BTreeMap::new();
-        for payload in payloads {
-            let Some(events) = payload["events"].as_array() else {
-                continue;
-            };
-            for event in events {
-                if event["event_name"] != "operation_completed"
-                    || event["surface"] != "cli"
-                    || event["operation"] != "upgrade"
-                    || event["outcome"] != "success"
-                    || event["properties"]["upgrade_attempt_id"] != attempt_id
-                {
-                    continue;
-                }
-                let event_id = event["event_id"]
-                    .as_str()
-                    .expect("matching terminal upgrade event missing event_id");
-                events_by_id
-                    .entry(event_id.to_owned())
-                    .or_insert_with(|| event.clone());
-            }
-        }
-        events_by_id.into_values().collect()
     }
 
     fn seed_authoritative_codex_source(home: &Path) {
@@ -1348,13 +1299,31 @@ mod unix {
     }
 
     #[test]
+    #[ignore = "spawned only by the bounded disable-command contract"]
+    fn bounded_disable_stall_fixture() {
+        std::thread::sleep(Duration::from_secs(30));
+    }
+
+    #[test]
+    fn review_guard_disable_timeout_contract() {
+        assert_bounded_disable_command_timeout("unix::bounded_disable_stall_fixture");
+    }
+
+    #[test]
+    fn review_guard_raw_overlap_contract() {
+        assert_terminal_upgrade_raw_overlap_contract();
+    }
+
+    #[test]
     fn daemon_reports_one_terminal_upgrade_event_after_durable_state() {
-        let temp = daemon_test_root();
+        let temp = daemon_test_root_with_data_root("data");
         let mut release = fake_release(&temp, FIXTURE_TARGET_VERSION);
-        let binary = managed_hook_candidate(&temp, "ia_daemon_telemetry");
+        // Keep the managed executable at the identity checked by
+        // DaemonTestRoot's panic-safe process guard.
+        let binary = managed_bound_hook_candidate(&temp, "ia_daemon_telemetry");
         patch_release_artifact_with_next_ctx(&mut release, &binary, FIXTURE_TARGET_VERSION);
         let events_path = temp.path().join("analytics.jsonl");
-        let data_root = temp.path().join("data");
+        let data_root = temp.daemon_data_root();
         let home = temp.path().join("home");
         let state_root = temp.path().join("state");
         fs::create_dir(&home).unwrap();
@@ -1362,89 +1331,20 @@ mod unix {
 
         let mut command = managed_daemon(&temp, &release, &binary);
         command
-            .env("CTX_DATA_ROOT", &data_root)
+            .env("CTX_DATA_ROOT", data_root)
             .env("HOME", &home)
             .env("XDG_STATE_HOME", &state_root)
             .env("LOCALAPPDATA", &state_root)
             .env_remove("CTX_ANALYTICS_ENABLED")
             .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
             .env_remove("CTX_DAEMON_AUTOSTART_OFF");
-        let mut original_daemon = spawn_persistent_daemon(&command);
-        let original_pid = original_daemon.id();
-        let mut state = None;
-        let mut replacement_pid = None;
-        wait_for(
-            "durable applied upgrade state",
-            TERMINAL_UPGRADE_OBSERVATION_TIMEOUT,
-            || {
-                let Ok(bytes) = fs::read(scheduler_state_path(&binary)) else {
-                    return false;
-                };
-                let Ok(observed_state) = serde_json::from_slice::<Value>(&bytes) else {
-                    return false;
-                };
-                if observed_state["status"] != "applied"
-                    || observed_state["attempt_id"].as_str().is_none()
-                {
-                    return false;
-                }
-                state = Some(observed_state);
-                true
-            },
-        );
-        wait_for(
-            "replacement daemon",
-            TERMINAL_UPGRADE_OBSERVATION_TIMEOUT,
-            || {
-                replacement_pid = running_daemon_pid(&data_root, Some(original_pid));
-                replacement_pid.is_some()
-            },
-        );
-        wait_for(
-            "replacement terminal upgrade event",
-            TERMINAL_UPGRADE_OBSERVATION_TIMEOUT,
-            || {
-                let attempt_id = state.as_ref().unwrap()["attempt_id"].as_str().unwrap();
-                !terminal_upgrade_events_for_attempt(&events_path, temp.path(), attempt_id)
-                    .is_empty()
-            },
-        );
-        let mut original_status = None;
-        wait_for(
-            "original daemon exit after replacement",
-            TERMINAL_UPGRADE_OBSERVATION_TIMEOUT,
-            || {
-                original_status = original_daemon.try_wait().unwrap();
-                original_status.is_some()
-            },
-        );
-        assert!(original_status.unwrap().success());
-        stop_and_reap_daemon(replacement_pid.unwrap());
-
-        let state = state.unwrap();
-        let upgrades = terminal_upgrade_events_for_attempt(
+        temp.observe_terminal_upgrade_handoff(
+            spawn_persistent_daemon(&command),
+            &scheduler_state_path(&binary),
             &events_path,
-            temp.path(),
-            state["attempt_id"].as_str().unwrap(),
-        );
-        assert_eq!(upgrades.len(), 1);
-        let event = &upgrades[0];
-        assert_eq!(event["event_name"], "operation_completed");
-        assert_eq!(event["event_version"], 1);
-        assert_eq!(event["surface"], "cli");
-        assert_eq!(event["operation"], "upgrade");
-        assert_eq!(event["outcome"], "success");
-        assert!(event["event_id"].as_str().is_some_and(|value| {
-            uuid::Uuid::parse_str(value).is_ok_and(|id| id.get_version_num() == 4)
-        }));
-        let properties = event["properties"].as_object().unwrap();
-        assert_eq!(properties["upgrade_mode"], "auto");
-        assert_eq!(properties["upgrade_status"], "applied");
-        assert_eq!(properties["upgrade_applied"], true);
-        assert_eq!(
-            properties["upgrade_attempt_id"],
-            state["attempt_id"].as_str().unwrap()
-        );
+            TERMINAL_UPGRADE_OBSERVATION_TIMEOUT,
+        )
+        .assert_applied_auto_upgrade();
     }
 
     #[test]

--- a/crates/ctx-daemon-cli/tests/contracts/auto_upgrade_acceptance.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/auto_upgrade_acceptance.rs
@@ -3,6 +3,7 @@ mod support;
 #[cfg(unix)]
 mod unix {
     use std::{
+        collections::BTreeMap,
         fs,
         os::unix::{ffi::OsStrExt as _, fs::PermissionsExt as _},
         path::{Path, PathBuf},
@@ -16,6 +17,7 @@ mod unix {
 
     const FIXTURE_TARGET_VERSION: &str = "9.9.9";
     const FIXTURE_QUIESCENCE_TIMEOUT: Duration = Duration::from_secs(45);
+    const TERMINAL_UPGRADE_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(45);
 
     fn installation_sibling(binary: &Path, suffix: &str) -> PathBuf {
         let name = binary
@@ -449,6 +451,54 @@ mod unix {
         unsafe {
             libc::kill(pid as libc::pid_t, libc::SIGTERM);
         }
+    }
+
+    fn stop_and_reap_daemon(pid: u32) {
+        stop_daemon(pid);
+        wait_for(
+            "replacement daemon reaping",
+            TERMINAL_UPGRADE_OBSERVATION_TIMEOUT,
+            || !process_is_running(pid),
+        );
+    }
+
+    fn terminal_upgrade_events_for_attempt(
+        events_path: &Path,
+        analytics_root: &Path,
+        attempt_id: &str,
+    ) -> Vec<Value> {
+        let mut payloads = if events_path.exists() {
+            read_delivered_analytics_events(events_path)
+        } else {
+            Vec::new()
+        };
+        // The analytics outbox is the durable publication state while delivery
+        // races with the replacement daemon's startup.
+        payloads.extend(read_queued_analytics_events(analytics_root));
+
+        let mut events_by_id = BTreeMap::new();
+        for payload in payloads {
+            let Some(events) = payload["events"].as_array() else {
+                continue;
+            };
+            for event in events {
+                if event["event_name"] != "operation_completed"
+                    || event["surface"] != "cli"
+                    || event["operation"] != "upgrade"
+                    || event["outcome"] != "success"
+                    || event["properties"]["upgrade_attempt_id"] != attempt_id
+                {
+                    continue;
+                }
+                let event_id = event["event_id"]
+                    .as_str()
+                    .expect("matching terminal upgrade event missing event_id");
+                events_by_id
+                    .entry(event_id.to_owned())
+                    .or_insert_with(|| event.clone());
+            }
+        }
+        events_by_id.into_values().collect()
     }
 
     fn seed_authoritative_codex_source(home: &Path) {
@@ -1299,7 +1349,7 @@ mod unix {
 
     #[test]
     fn daemon_reports_one_terminal_upgrade_event_after_durable_state() {
-        let temp = tempdir();
+        let temp = daemon_test_root();
         let mut release = fake_release(&temp, FIXTURE_TARGET_VERSION);
         let binary = managed_hook_candidate(&temp, "ia_daemon_telemetry");
         patch_release_artifact_with_next_ctx(&mut release, &binary, FIXTURE_TARGET_VERSION);
@@ -1310,38 +1360,84 @@ mod unix {
         fs::create_dir(&home).unwrap();
         seed_authoritative_codex_source(&home);
 
-        let output = managed_daemon(&temp, &release, &binary)
+        let mut command = managed_daemon(&temp, &release, &binary);
+        command
             .env("CTX_DATA_ROOT", &data_root)
             .env("HOME", &home)
             .env("XDG_STATE_HOME", &state_root)
             .env("LOCALAPPDATA", &state_root)
             .env_remove("CTX_ANALYTICS_ENABLED")
             .env("CTX_ANALYTICS_ENDPOINT", file_url(&events_path))
-            .env("CTX_DAEMON_AUTOSTART_OFF", "1")
-            .output()
-            .unwrap();
-        assert!(output.status.success(), "{output:?}");
-        assert!(
-            events_path.exists(),
-            "daemon emitted no telemetry file; stderr={}",
-            String::from_utf8_lossy(&output.stderr)
+            .env_remove("CTX_DAEMON_AUTOSTART_OFF");
+        let mut original_daemon = spawn_persistent_daemon(&command);
+        let original_pid = original_daemon.id();
+        let mut state = None;
+        let mut replacement_pid = None;
+        wait_for(
+            "durable applied upgrade state",
+            TERMINAL_UPGRADE_OBSERVATION_TIMEOUT,
+            || {
+                let Ok(bytes) = fs::read(scheduler_state_path(&binary)) else {
+                    return false;
+                };
+                let Ok(observed_state) = serde_json::from_slice::<Value>(&bytes) else {
+                    return false;
+                };
+                if observed_state["status"] != "applied"
+                    || observed_state["attempt_id"].as_str().is_none()
+                {
+                    return false;
+                }
+                state = Some(observed_state);
+                true
+            },
         );
+        wait_for(
+            "replacement daemon",
+            TERMINAL_UPGRADE_OBSERVATION_TIMEOUT,
+            || {
+                replacement_pid = running_daemon_pid(&data_root, Some(original_pid));
+                replacement_pid.is_some()
+            },
+        );
+        wait_for(
+            "replacement terminal upgrade event",
+            TERMINAL_UPGRADE_OBSERVATION_TIMEOUT,
+            || {
+                let attempt_id = state.as_ref().unwrap()["attempt_id"].as_str().unwrap();
+                !terminal_upgrade_events_for_attempt(&events_path, temp.path(), attempt_id)
+                    .is_empty()
+            },
+        );
+        let mut original_status = None;
+        wait_for(
+            "original daemon exit after replacement",
+            TERMINAL_UPGRADE_OBSERVATION_TIMEOUT,
+            || {
+                original_status = original_daemon.try_wait().unwrap();
+                original_status.is_some()
+            },
+        );
+        assert!(original_status.unwrap().success());
+        stop_and_reap_daemon(replacement_pid.unwrap());
 
-        let state: Value =
-            serde_json::from_slice(&fs::read(scheduler_state_path(&binary)).unwrap()).unwrap();
-        assert_eq!(state["status"], "applied");
-        let events = read_analytics_events(&events_path);
-        let upgrades = events
-            .iter()
-            .filter(|batch| {
-                batch["events"].as_array().is_some_and(|events| {
-                    events.iter().any(|event| event["operation"] == "upgrade")
-                })
-            })
-            .collect::<Vec<_>>();
+        let state = state.unwrap();
+        let upgrades = terminal_upgrade_events_for_attempt(
+            &events_path,
+            temp.path(),
+            state["attempt_id"].as_str().unwrap(),
+        );
         assert_eq!(upgrades.len(), 1);
-        assert_operation_event(upgrades[0], "upgrade", "success");
-        let properties = analytics_event_properties(upgrades[0]);
+        let event = &upgrades[0];
+        assert_eq!(event["event_name"], "operation_completed");
+        assert_eq!(event["event_version"], 1);
+        assert_eq!(event["surface"], "cli");
+        assert_eq!(event["operation"], "upgrade");
+        assert_eq!(event["outcome"], "success");
+        assert!(event["event_id"].as_str().is_some_and(|value| {
+            uuid::Uuid::parse_str(value).is_ok_and(|id| id.get_version_num() == 4)
+        }));
+        let properties = event["properties"].as_object().unwrap();
         assert_eq!(properties["upgrade_mode"], "auto");
         assert_eq!(properties["upgrade_status"], "applied");
         assert_eq!(properties["upgrade_applied"], true);


### PR DESCRIPTION
## Summary
- replace the one-shot sink read with one shared-deadline observation of durable applied state, replacement ownership, the attempt-matched terminal event, and original-child exit
- retain exact `count == 1`: reject duplicate matches within either transport and accept one delivered/outbox overlap only for the same nonempty event ID and exact complete raw JSON record bytes
- bound the test-owned `ctx daemon disable` child with explicit spawn, `try_wait`, direct-child kill, and reap deadlines before continuing through the identity-verified daemon fallback
- use one explicit daemon data root for launch, observation, identity verification, disable, fallback signals, panic cleanup, and artifact cleanup
- explicitly stop and prove the replacement dead before the final event recount
- test-only change; no runtime, daemon, upgrade, release, pipeline, threshold, or unrelated-test behavior changes

## Root cause
`finalize_automatic_applied` durably records `applied`, resumes the daemon handoff, and only afterward emits the terminal upgrade event. Event emission durably appends the batch to the analytics outbox. The replacement drains that outbox asynchronously; the file transport writes the body and newline separately, flushes, and only then can reconciliation remove the queued entry.

The old harness read analytics once. Its sink-first fallback could let an already-created sink mask the attempt terminal event still in the durable queue. A queue-to-sink transition could also be sampled between those states, while a concurrent body/newline append could expose partial JSON. This is a harness observation race; production behavior is unchanged.

## Final independent findings closed
1. The cleanup path no longer calls unbounded `.output()`. It converts the prepared test command to a direct `std::process::Command` with null stdio, polls its owned `Child` for 12s, calls `Child::kill()` on expiry, and polls for at most 1s to reap it. Spawn, poll, kill, or reap failure is explicit. Even when that bounded command fails or times out, cleanup continues through the existing daemon fallback. The fallback verifies current lock owner, data root, recorded binary, and live executable before TERM and re-verifies before KILL; there is no unverified PID-only signal path.
2. Delivered records retain the exact complete line bytes while also parsing JSON for event matching. String-backed outbox entries retain the exact queued payload bytes while parsing separately. A delivered/queued overlap collapses only when both event IDs are identical and nonempty and both exact raw byte sequences match. A legacy object-backed queue entry has no recoverable original byte sequence and therefore cannot collapse against a delivered record. Same-source duplicates remain errors. The focused contract proves that semantically equal JSON with different key order and whitespace is rejected.

## Previously closed safeguards retained
- `DaemonTestRoot` owns `<temp>/data`; replacement status, active lock identity, disable, guarded TERM/KILL, Drop, and artifact removal all use that stored root.
- The observed replacement PID must equal the active lock PID and its live executable must match `ctx-test-copy` before normal cleanup.
- `waitpid(WNOHANG)` reaps only a child. `ECHILD` is accepted only after an independent liveness check proves the already identity-checked PID is gone.
- Delivered-file observation retries a snapshot with a partial trailing record. Queue-first observation remains race-safe because successful delivery flushes before outbox reconciliation.
- The final terminal-event recount occurs only after replacement stop and death/reap proof.

## Truthful timeout bounds
All harness polling waits are finite. The main durable-state/replacement/event/original-exit observation uses one shared 45s deadline.

For normal cleanup, the bounded disable child contributes at most 12s, plus at most 1s only when it must be killed and reaped. A normally exited disable command can be followed by at most 5s cooperative daemon-exit wait, 1s after identity-verified TERM, and 5s after identity-reverified KILL. Those branches make the maximum configured normal cleanup wait 23s, so observation plus normal cleanup is at most 68s of configured waits.

If disable is stuck acquiring `DaemonLifecycleControlLock`, it is killed and reaped by 13s and skips the cooperative 5s wait; the verified TERM/KILL fallback adds at most 6s, for a 19s configured stuck-lock cleanup bound. The immediate ECHILD liveness proof adds no wait. The panic worst case is 45s observation + 23s first guard cleanup + 5s direct-child reap + 23s root-guard retry = 96s of configured waits. The Bazel target has a 900s medium timeout.

## Exact revision
- base: `f576ed37e309b7b61d1331f65075cc740bdafa30`
- head: `c7e2cdab3e12a6b52b3cce6c4075edff861235d2`
- tree: `9f8db364742a3d8c70a8ba2e2be4d021da1bbd7b`
- parent: `c4a0109993eaef300fd262ddeb9e24566a0eafa5`
- correction from prior PR head `dd9bf58ad5f7f3f04df1cbe5a359e5ac833a4c63`: 2 test files, +306/-59
- full base delta: 2 test files, +631/-95
- acceptance test file: 1,489 lines under the 1,500-line test policy

## Verification
- focused raw-byte overlap contract, exact: heavy lease `776524f765604fc2a9e2b2645b663ad1`, passed
- focused bounded disable-child timeout/kill/reap contract, exact: heavy lease `2158211d8c024b19bc427ea30dccfa8c`, passed
- compile and focused-filter smoke: heavy lease `b52fc148e6a644e7ac01dc44bb4c81c2`, passed
- `ctx-build-governor exec -- bazel test //crates/ctx-daemon-cli:auto_upgrade_acceptance_tests --config=test --test_arg=unix::daemon_reports_one_terminal_upgrade_event_after_durable_state --test_arg=--exact --runs_per_test=5 --nocache_test_results --test_output=errors`
  - heavy lease `82c2b3e87e9d481998159de3c73b2b69`
  - 5/5 passed; min 31.6s, max 32.2s, average 32.0s
- formatting: light lease `b18ab989af444bf7b45b5dcdb0e77e43`, passed
- source diff check: light lease `a2ac2f06bc844378a9405a489ac568c6`, passed
- repository policy and LOC: light lease `9b38ff9e6fc646a2ade404e152cb2d99`, passed
- post-commit parent diff check: light lease `2c25bd75b20e4e578c0c4abab369d5f8`, passed

Ready for exact re-review. Do not merge yet.