### PR TITLE
Bound refresh reader lifetime during generation replacement

### DIFF
--- a/crates/ctx-history-capture-composition/src/source_backed/publication.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/publication.rs
@@ -44,6 +44,37 @@ type SourceBackedGenerationStateFactory<'factory> =
             -> ctx_history_index::Result<ctx_history_index::GenerationStateEnvelope>
         + 'factory;
 
+enum SourceBackedBaseGenerationExpectation<'a> {
+    Unchecked,
+    Exact(Option<&'a ctx_history_index::VerifiedGenerationSnapshot>),
+}
+
+struct SourceBackedWriterOpen<'a> {
+    options: WriterOptions,
+    base_generation_expectation: SourceBackedBaseGenerationExpectation<'a>,
+}
+
+impl SourceBackedWriterOpen<'_> {
+    fn unchecked(options: WriterOptions) -> Self {
+        Self {
+            options,
+            base_generation_expectation: SourceBackedBaseGenerationExpectation::Unchecked,
+        }
+    }
+}
+
+impl<'a> SourceBackedWriterOpen<'a> {
+    fn exact(
+        options: WriterOptions,
+        expected: Option<&'a ctx_history_index::VerifiedGenerationSnapshot>,
+    ) -> Self {
+        Self {
+            options,
+            base_generation_expectation: SourceBackedBaseGenerationExpectation::Exact(expected),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 struct SourceBackedRefreshExecutionBudget {
     discovery_duration: Duration,
@@ -160,7 +191,7 @@ impl SourceBackedRefreshExecutor {
         refresh_source_backed_generation_with_detailed_progress_and_discovery_timing(
             index_root,
             &self.registry,
-            self.writer_options.clone(),
+            SourceBackedWriterOpen::unchecked(self.writer_options.clone()),
             SourceBackedRefreshExecutionBudget::new(self.discovery_duration, self.work_budget),
             (
                 SourceBackedRefreshPlan::isolate(SourceBackedRefreshScope::All),
@@ -184,7 +215,7 @@ impl SourceBackedRefreshExecutor {
         refresh_source_backed_generation_with_detailed_progress_and_discovery_timing(
             index_root,
             &self.registry,
-            self.writer_options.clone(),
+            SourceBackedWriterOpen::unchecked(self.writer_options.clone()),
             SourceBackedRefreshExecutionBudget::new(self.discovery_duration, self.work_budget),
             (
                 SourceBackedRefreshPlan::isolate(SourceBackedRefreshScope::All),
@@ -205,7 +236,7 @@ impl SourceBackedRefreshExecutor {
         refresh_source_backed_generation_with_detailed_progress_and_discovery_timing(
             index_root,
             &self.registry,
-            self.writer_options.clone(),
+            SourceBackedWriterOpen::unchecked(self.writer_options.clone()),
             SourceBackedRefreshExecutionBudget::new(self.discovery_duration, self.work_budget),
             (
                 SourceBackedRefreshPlan::isolate(scope),
@@ -230,7 +261,7 @@ impl SourceBackedRefreshExecutor {
         refresh_source_backed_generation_with_detailed_progress_and_discovery_timing(
             index_root,
             &self.registry,
-            self.writer_options.clone(),
+            SourceBackedWriterOpen::unchecked(self.writer_options.clone()),
             SourceBackedRefreshExecutionBudget::new(self.discovery_duration, self.work_budget),
             (
                 SourceBackedRefreshPlan::isolate(scope),
@@ -251,7 +282,7 @@ impl SourceBackedRefreshExecutor {
         refresh_source_backed_generation_with_detailed_progress_and_discovery_timing(
             index_root,
             &self.registry,
-            self.writer_options.clone(),
+            SourceBackedWriterOpen::unchecked(self.writer_options.clone()),
             SourceBackedRefreshExecutionBudget::new(self.discovery_duration, self.work_budget),
             (
                 SourceBackedRefreshPlan::isolate(scope)
@@ -281,7 +312,48 @@ impl SourceBackedRefreshExecutor {
         refresh_source_backed_generation_with_detailed_progress_and_discovery_timing(
             index_root,
             &self.registry,
-            self.writer_options.clone(),
+            SourceBackedWriterOpen::unchecked(self.writer_options.clone()),
+            SourceBackedRefreshExecutionBudget::new(self.discovery_duration, self.work_budget),
+            (
+                SourceBackedRefreshPlan::isolate(physical_scope)
+                    .with_publication_scope(publication_scope)
+                    .with_reconciliation_demand(reconciliation_demand)
+                    .with_route_worksets(route_worksets)
+                    .with_attempt_history_progress(self.attempt_history_progress.clone()),
+                &self.base_route_controls,
+            ),
+            report_progress,
+            Some(&mut generation_state_factory),
+        )
+    }
+
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn refresh_physical_scope_with_detailed_progress_and_base_generation_expectation(
+        &self,
+        index_root: impl AsRef<Path>,
+        physical_scope: SourceBackedRefreshScope,
+        publication_scope: SourceBackedRefreshScope,
+        reconciliation_demand: SourceBackedReconciliationDemand,
+        expected_base_generation: Option<&ctx_history_index::VerifiedGenerationSnapshot>,
+        exact_base_generation: bool,
+        route_worksets: BTreeMap<SourceRouteIdentity, BTreeSet<PathBuf>>,
+        report_progress: impl FnMut(SourceBackedDetailedRefreshProgress) -> SourceBackedRouteResult<()>,
+        mut generation_state_factory: impl for<'a> FnMut(
+            SourceBackedGenerationStateContext<'a>,
+        ) -> ctx_history_index::Result<
+            ctx_history_index::GenerationStateEnvelope,
+        >,
+    ) -> SourceBackedCoordinatorResult<SourceBackedRefreshReceipt> {
+        let writer_open = if exact_base_generation {
+            SourceBackedWriterOpen::exact(self.writer_options.clone(), expected_base_generation)
+        } else {
+            SourceBackedWriterOpen::unchecked(self.writer_options.clone())
+        };
+        refresh_source_backed_generation_with_detailed_progress_and_discovery_timing(
+            index_root,
+            &self.registry,
+            writer_open,
             SourceBackedRefreshExecutionBudget::new(self.discovery_duration, self.work_budget),
             (
                 SourceBackedRefreshPlan::isolate(physical_scope)
@@ -317,7 +389,7 @@ pub(crate) fn refresh_source_backed_generation_with_work_budget_for_test(
     refresh_source_backed_generation_with_detailed_progress_and_discovery_timing(
         index_root,
         registry,
-        writer_options,
+        SourceBackedWriterOpen::unchecked(writer_options),
         SourceBackedRefreshExecutionBudget::new(Duration::ZERO, work_budget),
         (
             SourceBackedRefreshPlan::isolate(SourceBackedRefreshScope::All),
@@ -340,7 +412,7 @@ pub(crate) fn refresh_source_backed_generation_with_resource_limits_for_test(
     refresh_source_backed_generation_with_detailed_progress_and_discovery_timing(
         index_root,
         registry,
-        writer_options,
+        SourceBackedWriterOpen::unchecked(writer_options),
         SourceBackedRefreshExecutionBudget::new(Duration::ZERO, work_budget),
         (
             SourceBackedRefreshPlan::isolate(SourceBackedRefreshScope::All)
@@ -363,7 +435,7 @@ pub fn refresh_source_backed_generation_with_progress(
     refresh_source_backed_generation_with_detailed_progress_and_discovery_timing(
         index_root,
         registry,
-        writer_options,
+        SourceBackedWriterOpen::unchecked(writer_options),
         SourceBackedRefreshExecutionBudget::new(Duration::ZERO, work_budget),
         (
             SourceBackedRefreshPlan::isolate(SourceBackedRefreshScope::All),
@@ -389,7 +461,7 @@ pub fn refresh_source_backed_generation_with_detailed_progress(
     refresh_source_backed_generation_with_detailed_progress_and_discovery_timing(
         index_root,
         registry,
-        writer_options,
+        SourceBackedWriterOpen::unchecked(writer_options),
         SourceBackedRefreshExecutionBudget::new(Duration::ZERO, work_budget),
         (
             SourceBackedRefreshPlan::isolate(SourceBackedRefreshScope::All),
@@ -410,7 +482,7 @@ pub fn refresh_source_backed_generation_for_routes(
     refresh_source_backed_generation_with_detailed_progress_and_discovery_timing(
         index_root,
         registry,
-        writer_options,
+        SourceBackedWriterOpen::unchecked(writer_options),
         SourceBackedRefreshExecutionBudget::new(Duration::ZERO, work_budget),
         (
             SourceBackedRefreshPlan::isolate(SourceBackedRefreshScope::exact(route_identities)),

--- a/crates/ctx-history-capture-composition/src/source_backed/publication/execution.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/publication/execution.rs
@@ -16,7 +16,7 @@ use route_controls::successful_route_controls;
 pub(super) fn refresh_source_backed_generation_with_detailed_progress_and_discovery_timing(
     index_root: impl AsRef<Path>,
     registry: &SourceBackedProviderRegistry,
-    writer_options: WriterOptions,
+    writer_open: SourceBackedWriterOpen<'_>,
     execution: SourceBackedRefreshExecutionBudget,
     selection: (
         SourceBackedRefreshPlan,
@@ -25,6 +25,10 @@ pub(super) fn refresh_source_backed_generation_with_detailed_progress_and_discov
     mut emit_progress: impl FnMut(SourceBackedDetailedRefreshProgress) -> SourceBackedRouteResult<()>,
     mut generation_state_factory: Option<&mut SourceBackedGenerationStateFactory<'_>>,
 ) -> SourceBackedCoordinatorResult<SourceBackedRefreshReceipt> {
+    let SourceBackedWriterOpen {
+        options: writer_options,
+        base_generation_expectation,
+    } = writer_open;
     let (plan, base_route_controls) = selection;
     let SourceBackedRefreshExecutionBudget {
         discovery_duration,
@@ -70,7 +74,18 @@ pub(super) fn refresh_source_backed_generation_with_detailed_progress_and_discov
         mut route_controls,
         verified_publication,
     ) = {
-        let open = IndexCaptureLifecycle::open(index_root, writer_options)?;
+        let open = match base_generation_expectation {
+            SourceBackedBaseGenerationExpectation::Unchecked => {
+                IndexCaptureLifecycle::open(index_root, writer_options)?
+            }
+            SourceBackedBaseGenerationExpectation::Exact(expected) => {
+                IndexCaptureLifecycle::open_with_expected_base_generation(
+                    index_root,
+                    writer_options,
+                    expected,
+                )?
+            }
+        };
         let mut lifecycle = match open {
             CaptureLifecycleOpenOutcome::Ready(lifecycle) => lifecycle,
             CaptureLifecycleOpenOutcome::RecoveryRequired { recovery } => {

--- a/crates/ctx-history-capture-composition/src/source_backed/runtime_adapter.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/runtime_adapter.rs
@@ -14,7 +14,8 @@ use ctx_history_index::{
     GenerationBaseCertifiedSource, GenerationManifest, GenerationStateEnvelope, GenerationWriter,
     GenerationWriterOpenOutcome, IndexError, PreparedCoreRecord, PreparedCoreRecordDraft,
     PreparedCoreRecordMaterialization, PublicationDisposition, PublicationStage,
-    PublishedGeneration, RevalidationTarget, SourceRouteSnapshot, VerifiedIndex, WriterOptions,
+    PublishedGeneration, RevalidationTarget, SourceRouteSnapshot, VerifiedGenerationSnapshot,
+    VerifiedIndex, WriterOptions,
 };
 use std::{collections::BTreeSet, path::Path, sync::Arc};
 use uuid::Uuid;
@@ -154,6 +155,41 @@ pub const fn automatic_route_deletion_missing_observations_for_test() -> u32 {
 #[repr(transparent)]
 pub struct IndexCaptureLifecycle(GenerationWriter);
 
+impl IndexCaptureLifecycle {
+    pub(crate) fn open_with_expected_base_generation(
+        root: &Path,
+        options: WriterOptions,
+        expected_base_generation: Option<&VerifiedGenerationSnapshot>,
+    ) -> IndexCaptureResult<CaptureLifecycleOpenOutcome<Self>> {
+        capture_lifecycle_open_outcome(GenerationWriter::open_with_expected_base_generation(
+            root,
+            options,
+            expected_base_generation.map(VerifiedGenerationSnapshot::generation_id),
+        )?)
+    }
+}
+
+fn capture_lifecycle_open_outcome(
+    outcome: GenerationWriterOpenOutcome,
+) -> IndexCaptureResult<CaptureLifecycleOpenOutcome<IndexCaptureLifecycle>> {
+    Ok(match outcome {
+        GenerationWriterOpenOutcome::Ready(writer) => {
+            CaptureLifecycleOpenOutcome::Ready(IndexCaptureLifecycle(writer))
+        }
+        GenerationWriterOpenOutcome::RecoveredCommittedMigration { writer, .. } => {
+            CaptureLifecycleOpenOutcome::Ready(IndexCaptureLifecycle(writer))
+        }
+        GenerationWriterOpenOutcome::CommittedMigrationRecoveryRequired { recovery } => {
+            CaptureLifecycleOpenOutcome::RecoveryRequired {
+                recovery: CaptureLifecycleRecovery::new(
+                    recovery.generation_id().to_owned(),
+                    recovery.detail().to_owned(),
+                ),
+            }
+        }
+    })
+}
+
 impl CaptureLifecycleSink for IndexCaptureLifecycle {
     type Error = IndexError;
     type OpenOptions = WriterOptions;
@@ -172,22 +208,7 @@ impl CaptureLifecycleSink for IndexCaptureLifecycle {
         root: &Path,
         options: Self::OpenOptions,
     ) -> IndexCaptureResult<CaptureLifecycleOpenOutcome<Self>> {
-        Ok(match GenerationWriter::open(root, options)? {
-            GenerationWriterOpenOutcome::Ready(writer) => {
-                CaptureLifecycleOpenOutcome::Ready(Self(writer))
-            }
-            GenerationWriterOpenOutcome::RecoveredCommittedMigration { writer, .. } => {
-                CaptureLifecycleOpenOutcome::Ready(Self(writer))
-            }
-            GenerationWriterOpenOutcome::CommittedMigrationRecoveryRequired { recovery } => {
-                CaptureLifecycleOpenOutcome::RecoveryRequired {
-                    recovery: CaptureLifecycleRecovery::new(
-                        recovery.generation_id().to_owned(),
-                        recovery.detail().to_owned(),
-                    ),
-                }
-            }
-        })
+        capture_lifecycle_open_outcome(GenerationWriter::open(root, options)?)
     }
 
     fn base_snapshot(&self) -> Option<Self::Snapshot<'_>> {

--- a/crates/ctx-history-index-generation/src/clone/portable/windows.rs
+++ b/crates/ctx-history-index-generation/src/clone/portable/windows.rs
@@ -31,7 +31,7 @@ use windows_sys::{
             FILE_DISPOSITION_INFO, FILE_DISPOSITION_INFO_EX, FILE_FLAG_BACKUP_SEMANTICS,
             FILE_FLAG_OPEN_REPARSE_POINT, FILE_GENERIC_READ, FILE_GENERIC_WRITE,
             FILE_LIST_DIRECTORY, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ,
-            FILE_SHARE_WRITE, FILE_WRITE_ATTRIBUTES, SYNCHRONIZE,
+            FILE_SHARE_WRITE, FILE_WRITE_ATTRIBUTES, READ_CONTROL, SYNCHRONIZE, WRITE_DAC,
         },
         System::IO::IO_STATUS_BLOCK,
     },
@@ -96,7 +96,13 @@ pub(super) fn create_directory_at(
     nt_open_at(
         parent,
         name,
-        FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES | DELETE | SYNCHRONIZE,
+        FILE_LIST_DIRECTORY
+            | FILE_READ_ATTRIBUTES
+            | FILE_WRITE_ATTRIBUTES
+            | READ_CONTROL
+            | WRITE_DAC
+            | DELETE
+            | SYNCHRONIZE,
         FILE_CREATE,
         FILE_ATTRIBUTE_DIRECTORY,
         FILE_DIRECTORY_FILE,
@@ -308,9 +314,8 @@ fn wide_path(path: &OsStr) -> io::Result<Vec<u16>> {
     Ok(wide)
 }
 
-pub(super) fn restrict_destination_directory(_file: &File) -> io::Result<()> {
-    // The candidate inherits the already-private managed generations ACL.
-    Ok(())
+pub(super) fn restrict_destination_directory(file: &File) -> io::Result<()> {
+    ctx_history_platform::platform_security::restrict_private_directory_handle(file)
 }
 
 pub(super) fn sync_directory(_file: &File) -> io::Result<()> {
@@ -381,6 +386,31 @@ fn delete_by_handle(file: &File) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn inherited_destination_acl_is_protected_through_retained_handle() -> io::Result<()> {
+        use ctx_history_platform::platform_security::{
+            ensure_private_directory, verify_private_directory, verify_private_directory_handle,
+        };
+
+        let temporary = tempfile::tempdir()?;
+        ensure_private_directory(temporary.path())?;
+        let parent = open_directory_path(temporary.path())?;
+        let generation_name = Path::new("generation-inherited-acl");
+        let destination = create_directory_at(&parent, temporary.path(), generation_name)?;
+
+        let inherited_error = verify_private_directory_handle(&destination).unwrap_err();
+        assert_eq!(
+            inherited_error.kind(),
+            io::ErrorKind::PermissionDenied,
+            "new inherited directory should initially lack a protected private DACL: {inherited_error}"
+        );
+
+        restrict_destination_directory(&destination)?;
+        verify_private_directory_handle(&destination)?;
+        drop(destination);
+        verify_private_directory(&temporary.path().join(generation_name))
+    }
 
     #[test]
     fn proof_capture_handle_blocks_destination_substitution() -> io::Result<()> {

--- a/crates/ctx-history-index-query/src/lib.rs
+++ b/crates/ctx-history-index-query/src/lib.rs
@@ -9,13 +9,13 @@ pub use contract::*;
 pub use ctx_history_index_format::{IndexError, Result};
 pub use event_range::*;
 use filtering::*;
-pub use reader::VerifiedIndex;
 #[cfg(any(test, feature = "test-support"))]
 #[doc(hidden)]
 pub use reader::{
     reset_verified_index_publication_construction_count, reset_verified_index_reopen_count,
     verified_index_publication_construction_count, verified_index_reopen_count,
 };
+pub use reader::{VerifiedGenerationSnapshot, VerifiedIndex};
 pub(crate) use records::stored_event_record;
 use records::{
     core_event_fast_preflight, core_event_identity_fast_preflight, stored_core_event_record,

--- a/crates/ctx-history-index-query/src/reader.rs
+++ b/crates/ctx-history-index-query/src/reader.rs
@@ -49,11 +49,58 @@ pub struct VerifiedIndex {
     _reader_leases: Option<ReaderLeaseBundle>,
 }
 
+/// Metadata-only authority for one fully verified generation.
+///
+/// Unlike [`VerifiedIndex`], this snapshot owns no Tantivy searcher or
+/// generation read lease. It keeps the exact generation identity and the
+/// already decoded immutable manifest available to refresh orchestration.
+#[derive(Clone)]
+pub struct VerifiedGenerationSnapshot {
+    generation_id: String,
+    manifest: Arc<GenerationManifest>,
+}
+
+impl VerifiedGenerationSnapshot {
+    pub fn generation_id(&self) -> &str {
+        &self.generation_id
+    }
+
+    pub fn manifest(&self) -> &GenerationManifest {
+        &self.manifest
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn test_shared_manifest(&self) -> &Arc<GenerationManifest> {
+        &self.manifest
+    }
+}
+
 /// Query-reader authority for the selected generation and its one retained
 /// peer. A query reader owns this bundle for its whole lifetime.
 struct ReaderLeaseBundle {
     target: GenerationReadLease,
     peer: Option<GenerationReadLease>,
+}
+
+// Keep the target reclamation lease alive until every generation-backed
+// resource and peer authority has completed destruction. Explicit `drop`
+// calls make this independent of struct field declaration order.
+fn drop_generation_backed_resources_before_target_lease<
+    TantivyResources,
+    SemanticResources,
+    PeerLease,
+    TargetLease,
+>(
+    tantivy_resources: TantivyResources,
+    semantic_resources: SemanticResources,
+    peer_lease: PeerLease,
+    target_lease: TargetLease,
+) {
+    drop(tantivy_resources);
+    drop(semantic_resources);
+    drop(peer_lease);
+    drop(target_lease);
 }
 
 struct ReaderGenerationSelection {
@@ -602,6 +649,34 @@ impl VerifiedIndex {
         &self.generation_id
     }
 
+    /// Consumes this verified reader and retains only generation metadata.
+    ///
+    /// Reader leases and Tantivy handles are dropped before the snapshot is
+    /// returned, so a subsequent writer open cannot overlap their FD lifetime.
+    pub fn into_generation_snapshot(self) -> VerifiedGenerationSnapshot {
+        let Self {
+            searcher,
+            manifest,
+            generation_id,
+            semantic_eligibility_postings,
+            _reader_leases,
+        } = self;
+        let (peer_lease, target_lease) = match _reader_leases {
+            Some(ReaderLeaseBundle { target, peer }) => (peer, Some(target)),
+            None => (None, None),
+        };
+        drop_generation_backed_resources_before_target_lease(
+            searcher,
+            semantic_eligibility_postings,
+            peer_lease,
+            target_lease,
+        );
+        VerifiedGenerationSnapshot {
+            generation_id,
+            manifest,
+        }
+    }
+
     pub fn manifest(&self) -> &GenerationManifest {
         &self.manifest
     }
@@ -659,4 +734,47 @@ pub fn reset_verified_index_publication_construction_count() {
 #[cfg(any(test, feature = "test-support"))]
 pub fn verified_index_publication_construction_count() -> usize {
     VERIFIED_INDEX_PUBLICATION_CONSTRUCTION_COUNT.with(std::cell::Cell::get)
+}
+
+#[cfg(test)]
+mod drop_order_tests {
+    use super::drop_generation_backed_resources_before_target_lease;
+    use std::cell::RefCell;
+
+    struct DropTrace<'a> {
+        events: &'a RefCell<Vec<&'static str>>,
+        event: &'static str,
+    }
+
+    impl Drop for DropTrace<'_> {
+        fn drop(&mut self) {
+            self.events.borrow_mut().push(self.event);
+        }
+    }
+
+    #[test]
+    fn target_lease_drops_after_all_generation_backed_resources() {
+        let events = RefCell::new(Vec::new());
+        let traced = |event| DropTrace {
+            events: &events,
+            event,
+        };
+
+        drop_generation_backed_resources_before_target_lease(
+            traced("tantivy searcher and mappings"),
+            traced("semantic postings"),
+            Some(traced("peer lease")),
+            Some(traced("target lease")),
+        );
+
+        assert_eq!(
+            *events.borrow(),
+            [
+                "tantivy searcher and mappings",
+                "semantic postings",
+                "peer lease",
+                "target lease",
+            ]
+        );
+    }
 }

--- a/crates/ctx-history-index-query/tests/writer_integration/pinned_generation.rs
+++ b/crates/ctx-history-index-query/tests/writer_integration/pinned_generation.rs
@@ -502,6 +502,47 @@ fn active_reader_lease_retains_generation_until_drop() {
 }
 
 #[test]
+fn generation_snapshot_releases_handles_before_lease_and_reclaims_retired_generation() {
+    let temp = tempdir().unwrap();
+    let source = source("metadata-snapshot-reclamation.jsonl");
+    let first = publish_pinned_test_generation(temp.path(), &source, 1, "first body");
+    let first_path = active_generation_path(temp.path());
+    let reader = VerifiedIndex::open_pinned(temp.path()).unwrap();
+    let shared_manifest = Arc::clone(reader.test_shared_manifest());
+    let snapshot = reader.into_generation_snapshot();
+
+    assert_eq!(snapshot.generation_id(), first.generation_id);
+    assert!(Arc::ptr_eq(
+        &shared_manifest,
+        snapshot.test_shared_manifest()
+    ));
+    drop(shared_manifest);
+
+    let second = publish_pinned_test_generation(temp.path(), &source, 2, "second body");
+    let third = publish_pinned_test_generation(temp.path(), &source, 3, "third body");
+    let fourth = publish_pinned_test_generation(temp.path(), &source, 4, "fourth body");
+    let pointer = load_active_generation_pointer(temp.path())
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(pointer.active().generation_id(), fourth.generation_id);
+    assert_eq!(
+        pointer.previous().unwrap().generation_id(),
+        third.generation_id
+    );
+    assert_ne!(second.generation_id, first.generation_id);
+    assert!(
+        !first_path.exists(),
+        "snapshot conversion left a protected handle live after releasing its target lease"
+    );
+    assert_eq!(
+        snapshot.manifest().generation_id().unwrap(),
+        first.generation_id
+    );
+    assert_eq!(snapshot.manifest().sources.len(), 1);
+}
+
+#[test]
 fn reader_owned_peer_lease_survives_parent_drop_after_integrity_verification() {
     let temp = tempdir().unwrap();
     let source = source("leased-verification-pointer-race.jsonl");

--- a/crates/ctx-history-index/src/lib.rs
+++ b/crates/ctx-history-index/src/lib.rs
@@ -88,7 +88,6 @@ pub mod test_support {
     }
 }
 pub(crate) use ctx_history_index_generation::{hex, is_generation_id, MANIFEST_DIRECTORY};
-pub use ctx_history_index_query::VerifiedIndex;
 pub use ctx_history_index_query::{
     AgentScope, CompiledSearchFilter, CopiedEventLineage, CopiedEventLineageOccurrence,
     CopiedEventLineagePolicy, CopiedEventLineageRelationshipCount, CopiedEventLineageResolution,
@@ -107,6 +106,7 @@ pub use ctx_history_index_query::{
     MAX_SESSION_EVENT_COORDINATE_PREFIX_ITEMS, MAX_SESSION_EVENT_COORDINATE_WINDOW_ITEMS,
     MAX_SESSION_EVENT_PAGE_ITEMS, MAX_SOURCE_EVENT_PAGE_ITEMS, SHOW_COPIED_EVENT_LINEAGE_POLICY,
 };
+pub use ctx_history_index_query::{VerifiedGenerationSnapshot, VerifiedIndex};
 pub(crate) use identity::{
     prior_session_identity_facts, register_compact_identity, BaseWitnessSource,
 };

--- a/crates/ctx-history-index/src/tests/integrity_certification.rs
+++ b/crates/ctx-history-index/src/tests/integrity_certification.rs
@@ -463,7 +463,10 @@ fn windows_validation_failure_after_terminal_seal_keeps_predecessor() {
         )
         .unwrap();
     let error = append.commit(|_| true).unwrap_err();
-    assert!(matches!(error, IndexError::ChecksumMismatch));
+    assert!(
+        matches!(&error, IndexError::ManifestDigestMismatch { .. }),
+        "terminal manifest mutation must fail with ManifestDigestMismatch, got {error:?}"
+    );
     let predecessor = VerifiedIndex::open_pinned(temp.path()).unwrap();
     assert_eq!(predecessor.generation_id(), baseline.generation_id);
     assert_eq!(predecessor.count_term("body").unwrap(), 1);

--- a/crates/ctx-history-index/src/tests/recovery.rs
+++ b/crates/ctx-history-index/src/tests/recovery.rs
@@ -308,11 +308,8 @@ fn terminal_activation_fence_rejects_candidate_manifest_replacement() {
 
     let error = candidate.commit(|_| true).unwrap_err();
     assert!(
-        matches!(
-            error,
-            IndexError::ChecksumMismatch | IndexError::ManifestDigestMismatch { .. }
-        ),
-        "{error:?}"
+        matches!(&error, IndexError::ManifestDigestMismatch { .. }),
+        "candidate manifest replacement must fail with ManifestDigestMismatch, got {error:?}"
     );
     assert_eq!(
         fs::read(temp.path().join("active-generation.json")).unwrap(),

--- a/crates/ctx-history-index/src/tests/writer.rs
+++ b/crates/ctx-history-index/src/tests/writer.rs
@@ -79,6 +79,129 @@ fn commit_binds_manifest_and_searchable_documents() {
 }
 
 #[test]
+fn checked_writer_open_requires_the_exact_captured_base_generation() {
+    let temp = tempdir().unwrap();
+    let source = source("expected-writer-base.jsonl");
+
+    let cold = GenerationWriter::open_with_expected_base_generation(
+        temp.path(),
+        WriterOptions::default(),
+        None,
+    )
+    .unwrap()
+    .into_writer()
+    .unwrap();
+    assert_eq!(cold.base_generation_id(), None);
+    drop(cold);
+
+    let mut first_writer = GenerationWriter::open(temp.path(), WriterOptions::default())
+        .unwrap()
+        .into_writer()
+        .unwrap();
+    first_writer.begin_source(source.clone()).unwrap();
+    first_writer
+        .add_core_record(document(&source, 1, "first base"))
+        .unwrap();
+    first_writer
+        .certify_source(certificate(&source, 1, 1))
+        .unwrap();
+    let first = first_writer.commit(|_| true).unwrap();
+
+    assert!(matches!(
+        GenerationWriter::open_with_expected_base_generation(
+            temp.path(),
+            WriterOptions::default(),
+            None,
+        ),
+        Err(IndexError::ConcurrentGenerationChange)
+    ));
+    let matching = GenerationWriter::open_with_expected_base_generation(
+        temp.path(),
+        WriterOptions::default(),
+        Some(&first.generation_id),
+    )
+    .unwrap()
+    .into_writer()
+    .unwrap();
+    assert_eq!(
+        matching.base_generation_id(),
+        Some(first.generation_id.as_str())
+    );
+    drop(matching);
+
+    let mut second_writer = GenerationWriter::open(temp.path(), WriterOptions::default())
+        .unwrap()
+        .into_writer()
+        .unwrap();
+    second_writer.begin_source(source.clone()).unwrap();
+    second_writer
+        .add_core_record(document(&source, 2, "second base"))
+        .unwrap();
+    second_writer
+        .certify_source(certificate(&source, 2, 1))
+        .unwrap();
+    let second = second_writer.commit(|_| true).unwrap();
+
+    assert!(matches!(
+        GenerationWriter::open_with_expected_base_generation(
+            temp.path(),
+            WriterOptions::default(),
+            Some(&first.generation_id),
+        ),
+        Err(IndexError::ConcurrentGenerationChange)
+    ));
+    assert!(matches!(
+        GenerationWriter::open_with_expected_base_generation(
+            temp.path(),
+            WriterOptions::default(),
+            Some("not-a-generation-id"),
+        ),
+        Err(IndexError::InvalidGenerationId)
+    ));
+
+    let standalone = GenerationWriter::open(temp.path(), WriterOptions::default())
+        .unwrap()
+        .into_writer()
+        .unwrap();
+    assert_eq!(
+        standalone.base_generation_id(),
+        Some(second.generation_id.as_str())
+    );
+    drop(standalone);
+
+    let pointer = load_active_generation_pointer(temp.path())
+        .unwrap()
+        .unwrap();
+    let unsupported_pointer = serde_json::json!({
+        "version": 1,
+        "active": {
+            "generation_id": pointer.active().generation_id(),
+            "directory": pointer.active().directory(),
+        },
+        "previous": null,
+    });
+    fs::write(
+        temp.path().join("active-generation.json"),
+        serde_json::to_vec(&unsupported_pointer).unwrap(),
+    )
+    .unwrap();
+    assert!(matches!(
+        GenerationWriter::open_with_expected_base_generation(
+            temp.path(),
+            WriterOptions::default(),
+            None,
+        ),
+        Err(IndexError::ConcurrentGenerationChange)
+    ));
+
+    let rebuild = GenerationWriter::open(temp.path(), WriterOptions::default())
+        .unwrap()
+        .into_writer()
+        .unwrap();
+    assert_eq!(rebuild.base_generation_id(), None);
+}
+
+#[test]
 fn prepared_core_draft_retries_final_encoding_under_a_caller_permit() {
     let temp = tempdir().unwrap();
     let source = source("bounded-materialization.jsonl");

--- a/crates/ctx-history-index/src/writer_open.rs
+++ b/crates/ctx-history-index/src/writer_open.rs
@@ -1,5 +1,10 @@
 use super::*;
 
+enum BaseGenerationExpectation<'a> {
+    Unchecked,
+    Exact(Option<&'a str>),
+}
+
 impl GenerationWriter {
     /// Captures an exact event-identity lookup pinned to this writer's base generation.
     pub fn base_event_identity_lookup(&self) -> BaseEventIdentityLookup {
@@ -16,6 +21,34 @@ impl GenerationWriter {
     pub fn open(
         root: impl AsRef<Path>,
         options: WriterOptions,
+    ) -> Result<GenerationWriterOpenOutcome> {
+        Self::open_inner(root, options, BaseGenerationExpectation::Unchecked)
+    }
+
+    /// Opens a writer only when the publication authority still names the
+    /// exact generation observed by the caller.
+    ///
+    /// `None` means that no compatible active publication was observed. The
+    /// ordinary [`Self::open`] API deliberately remains unchecked.
+    pub fn open_with_expected_base_generation(
+        root: impl AsRef<Path>,
+        options: WriterOptions,
+        expected_generation_id: Option<&str>,
+    ) -> Result<GenerationWriterOpenOutcome> {
+        if expected_generation_id.is_some_and(|generation_id| !is_generation_id(generation_id)) {
+            return Err(IndexError::InvalidGenerationId);
+        }
+        Self::open_inner(
+            root,
+            options,
+            BaseGenerationExpectation::Exact(expected_generation_id),
+        )
+    }
+
+    fn open_inner(
+        root: impl AsRef<Path>,
+        options: WriterOptions,
+        base_generation_expectation: BaseGenerationExpectation<'_>,
     ) -> Result<GenerationWriterOpenOutcome> {
         ctx_history_platform::raise_open_file_soft_limit();
         let indexer_threads = options.indexer_threads.clamp(1, 8);
@@ -52,12 +85,24 @@ impl GenerationWriter {
         )?;
         ctx_history_index_format::clear_manifest_cache_for_root(&root)?;
 
-        let (active_authority, mut pointer_requires_rebuild) =
+        let (active_authority, mut pointer_requires_rebuild, incompatible_active_present) =
             match load_active_publication_authority(&root) {
-                Ok(pointer) => (pointer, false),
-                Err(error) if generation_incompatibility_requires_rebuild(&error) => (None, true),
+                Ok(pointer) => (pointer, false, false),
+                Err(error) if generation_incompatibility_requires_rebuild(&error) => {
+                    (None, true, true)
+                }
                 Err(error) => return Err(error),
             };
+        if let BaseGenerationExpectation::Exact(expected_generation_id) =
+            base_generation_expectation
+        {
+            let active_generation_id = active_authority
+                .as_ref()
+                .map(|authority| authority.pointer().active().generation_id());
+            if incompatible_active_present || expected_generation_id != active_generation_id {
+                return Err(IndexError::ConcurrentGenerationChange);
+            }
+        }
         if !pointer_requires_rebuild {
             if let Some(authority) = active_authority.as_ref() {
                 let schema_check = open_slot_index(&root, authority.pointer().active())

--- a/crates/ctx-history-platform/src/platform_security.rs
+++ b/crates/ctx-history-platform/src/platform_security.rs
@@ -286,6 +286,13 @@ pub fn restrict_private_file_handle(handle: &std::fs::File) -> io::Result<()> {
     }
 }
 
+/// Applies and verifies the private Windows directory policy through an
+/// already-open handle without changing ownership.
+#[cfg(windows)]
+pub fn restrict_private_directory_handle(handle: &std::fs::File) -> io::Result<()> {
+    windows_acl::restrict_private_directory_handle(handle)
+}
+
 /// Applies and verifies owner-only executable-file permissions.
 pub fn restrict_private_executable(path: &Path) -> io::Result<()> {
     #[cfg(unix)]

--- a/crates/ctx-history-platform/src/platform_security/windows_acl.rs
+++ b/crates/ctx-history-platform/src/platform_security/windows_acl.rs
@@ -208,6 +208,9 @@ pub(super) fn restrict_private_file(path: &Path) -> io::Result<()> {
     restrict(path, ObjectKind::File)
 }
 
+pub(super) fn restrict_private_directory_handle(handle: &File) -> io::Result<()> {
+    restrict_handle(handle, ObjectKind::Directory)
+}
 pub(super) fn restrict_private_file_handle(handle: &File) -> io::Result<()> {
     restrict_handle(handle, ObjectKind::File)
 }
@@ -282,9 +285,8 @@ fn restrict_handle_with_identities(
 ) -> io::Result<()> {
     verify_handle_admissible_owner(handle, identities)?;
     let mut acl = private_acl(identities, kind)?;
-    // SAFETY: the retained handle owns WRITE_DAC and was verified as a regular
-    // object. The ACL remains live for this synchronous call. SetSecurityInfo
-    // receives no owner SID and therefore cannot transfer ownership.
+    // SAFETY: the verified handle owns WRITE_DAC; the ACL remains live for this
+    // call, which receives no owner SID and therefore cannot transfer ownership.
     let result = unsafe {
         SetSecurityInfo(
             handle.as_raw_handle().cast(),
@@ -318,8 +320,7 @@ fn verify_handle_admissible_owner(handle: &File, identities: &PrivateIdentities)
 }
 
 fn verify_admissible_owner(owner: PSID, identities: &PrivateIdentities) -> io::Result<()> {
-    // SAFETY: all SIDs remain backed by live security descriptors or token
-    // information buffers for these comparisons.
+    // SAFETY: all SIDs remain backed by live descriptors or token buffers.
     if unsafe { EqualSid(owner, identities.user_sid()) } != 0
         || unsafe { EqualSid(owner, identities.token_owner_sid()) } != 0
     {
@@ -623,8 +624,7 @@ fn private_security_descriptor(
     {
         return Err(last_error());
     }
-    // Prevent creation from merging inherited permissive entries.
-    // SAFETY: descriptor is initialized and remains live.
+    // SAFETY: the live descriptor is protected from merging inherited entries.
     if unsafe {
         SetSecurityDescriptorControl(
             (&raw mut descriptor).cast(),

--- a/crates/ctx-history-refresh-execution/src/execution.rs
+++ b/crates/ctx-history-refresh-execution/src/execution.rs
@@ -21,7 +21,8 @@ pub(super) struct MergedSourceBackedRegistry {
     previous_explicit_source_catalog: Option<ExplicitSourceCatalogAuthority>,
     previous_catalog_route_bindings: Vec<ExplicitSourceCatalogRouteBinding>,
     requested_explicit_source_catalog: Option<ExplicitSourceCatalogAuthority>,
-    pub(super) retained_generation: Option<VerifiedIndex>,
+    pub(super) retained_generation: Option<VerifiedGenerationSnapshot>,
+    pub(super) exact_base_generation: bool,
     pub(super) requested_catalog_route_bindings: Vec<ExplicitSourceCatalogRouteBinding>,
     previous_route_controls: BTreeMap<SourceRouteIdentity, Vec<u8>>,
 }

--- a/crates/ctx-history-refresh-execution/src/execution/publication.rs
+++ b/crates/ctx-history-refresh-execution/src/execution/publication.rs
@@ -18,13 +18,13 @@ pub fn exclusive_scan_stage_duration(
 pub(super) fn preserve_carried_rejection_diagnostics(
     route_results: &mut [SourceBackedRefreshRouteResult],
     snapshot: &(impl ImmutableCaptureSnapshot + ?Sized),
-    retained_generation: Option<&VerifiedIndex>,
+    retained_generation: Option<&VerifiedGenerationSnapshot>,
 ) -> Result<Vec<SourceBackedRefreshRecordRejection>> {
     let authority = current_rejection_authority(snapshot)?;
     let (previous_diagnostics, stable_sources) = match retained_generation {
         Some(retained_generation) => {
             let state =
-                SourceBackedGenerationState::decode_from_verified_index(retained_generation)?;
+                SourceBackedGenerationState::decode_from_manifest(retained_generation.manifest())?;
             (
                 state.committed_rejection_diagnostics().to_vec(),
                 stable_source_identities(snapshot, retained_generation),
@@ -112,7 +112,7 @@ fn current_rejection_authority(
 
 fn stable_source_identities(
     snapshot: &(impl ImmutableCaptureSnapshot + ?Sized),
-    retained_generation: &VerifiedIndex,
+    retained_generation: &VerifiedGenerationSnapshot,
 ) -> BTreeSet<String> {
     let retained_certificates = retained_generation
         .manifest()

--- a/crates/ctx-history-refresh-execution/src/execution/registry_merge.rs
+++ b/crates/ctx-history-refresh-execution/src/execution/registry_merge.rs
@@ -29,11 +29,16 @@ pub(super) fn build_merged_source_backed_registry_with_automatic_routes(
     published_state: &dyn PublishedSourceBackedStatePort,
 ) -> Result<MergedSourceBackedRegistry> {
     let PublishedSourceBackedState {
-        verified_index: retained_generation,
+        generation: published_generation,
         explicit_source_catalog: previous_explicit_source_catalog,
         catalog_route_bindings: previous_catalog_route_bindings,
         route_controls: previous_route_controls,
     } = published_state.open_published_state(data_root)?;
+    let (retained_generation, exact_base_generation) = match published_generation {
+        PublishedSourceBackedGeneration::Missing => (None, true),
+        PublishedSourceBackedGeneration::RebuildRequired => (None, false),
+        PublishedSourceBackedGeneration::Verified(generation) => (Some(generation), true),
+    };
     let retained_provider_roots =
         configured_retained_provider_roots(discovery, retained_generation.as_ref())?;
     let mut build = build_automatic_source_backed_registry_from_report_with_retained_roots(
@@ -208,6 +213,7 @@ pub(super) fn build_merged_source_backed_registry_with_automatic_routes(
         previous_catalog_route_bindings,
         requested_explicit_source_catalog: explicit_source_catalog.cloned(),
         retained_generation,
+        exact_base_generation,
         requested_catalog_route_bindings,
         previous_route_controls,
     })
@@ -217,7 +223,7 @@ pub(super) fn provider_root_publication_scope(
     requested: &SourceBackedRefreshScope,
     physical: &SourceBackedRefreshScope,
     registry: &ctx_history_capture::SourceBackedProviderRegistry,
-    retained: Option<&VerifiedIndex>,
+    retained: Option<&VerifiedGenerationSnapshot>,
 ) -> SourceBackedRefreshScope {
     let changed = matches!(requested, SourceBackedRefreshScope::All)
         && retained.zip(registry.applied_provider_roots()).is_some_and(

--- a/crates/ctx-history-refresh-execution/src/execution/route_local.rs
+++ b/crates/ctx-history-refresh-execution/src/execution/route_local.rs
@@ -36,6 +36,7 @@ pub(super) fn refresh_all_provider_sources_route_local_with_reconciliation(
         previous_catalog_route_bindings,
         requested_explicit_source_catalog,
         retained_generation,
+        exact_base_generation,
         requested_catalog_route_bindings,
         previous_route_controls,
     } = build_merged_source_backed_registry_with_automatic_routes(
@@ -205,11 +206,13 @@ pub(super) fn refresh_all_provider_sources_route_local_with_reconciliation(
     let mut terminal_coverage_error = None;
     let mut reconciliation_required = false;
     let refresh_result = executor
-        .refresh_physical_scope_with_detailed_progress_generation_state_reconciliation_and_worksets(
+        .refresh_physical_scope_with_detailed_progress_and_base_generation_expectation(
             index_root,
             physical_scope,
             publication_scope,
             reconciliation_demand,
+            retained_generation.as_ref(),
+            exact_base_generation,
             route_worksets.clone(),
             &mut report_attempt_progress,
             |context| {
@@ -300,7 +303,9 @@ pub(super) fn refresh_all_provider_sources_route_local_with_reconciliation(
                 }
                 let mut route_observations = retained_generation
                     .as_ref()
-                    .map(SourceBackedGenerationState::decode_from_verified_index)
+                    .map(|generation| {
+                        SourceBackedGenerationState::decode_from_manifest(generation.manifest())
+                    })
                     .transpose()
                     .map_err(|_| IndexError::InvalidGenerationStateEnvelope)?
                     .map(|state| state.route_observations().clone())
@@ -448,7 +453,7 @@ pub(super) fn refresh_all_provider_sources_route_local_with_reconciliation(
 
 fn register_automatic_hermes_profile_rename_retirements(
     build: &mut ctx_history_capture::SourceBackedAutomaticRegistryBuild,
-    retained_generation: Option<&VerifiedIndex>,
+    retained_generation: Option<&VerifiedGenerationSnapshot>,
     previous_catalog_route_bindings: &[ExplicitSourceCatalogRouteBinding],
     previous_route_controls: &BTreeMap<SourceRouteIdentity, Vec<u8>>,
 ) -> Result<()> {

--- a/crates/ctx-history-refresh-execution/src/explicit_source_catalog.rs
+++ b/crates/ctx-history-refresh-execution/src/explicit_source_catalog.rs
@@ -33,7 +33,7 @@ use ctx_history_capture_model::{
     ProviderSourceKind, ProviderSourceStatus,
 };
 use ctx_history_core::{CaptureProvider, CertifiedSource, SourceAnchor, TypedKey};
-use ctx_history_index::VerifiedIndex;
+use ctx_history_index::VerifiedGenerationSnapshot;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -516,7 +516,7 @@ fn validate_explicit_source_catalog_snapshot_roots(
 
 fn register_explicit_source_catalog_snapshot_routes(
     data_root: &Path,
-    base_generation: Option<&VerifiedIndex>,
+    base_generation: Option<&VerifiedGenerationSnapshot>,
     build: &mut SourceBackedAutomaticRegistryBuild,
     snapshot: &ExplicitSourceCatalogSnapshot,
 ) -> Result<Vec<ExplicitSourceCatalogRouteBinding>> {

--- a/crates/ctx-history-refresh-execution/src/explicit_source_catalog/catalog_merge.rs
+++ b/crates/ctx-history-refresh-execution/src/explicit_source_catalog/catalog_merge.rs
@@ -74,7 +74,7 @@ impl ExplicitSourceCatalogAuthority {
     pub(crate) fn register_routes_after_discovery_merge(
         &self,
         data_root: &Path,
-        base_generation: Option<&VerifiedIndex>,
+        base_generation: Option<&VerifiedGenerationSnapshot>,
         build: &mut SourceBackedAutomaticRegistryBuild,
     ) -> Result<Vec<ExplicitSourceCatalogRouteBinding>> {
         let snapshot = self.snapshot();

--- a/crates/ctx-history-refresh-execution/src/lib.rs
+++ b/crates/ctx-history-refresh-execution/src/lib.rs
@@ -49,7 +49,8 @@ use ctx_history_core::{CaptureProvider, CertifiedSource, ScannedSourceCounts};
 #[cfg(test)]
 use ctx_history_index::GenerationWriter;
 use ctx_history_index::{
-    GenerationManifest, IndexError, SourceRouteIdentity, VerifiedIndex, WriterOptions,
+    GenerationManifest, IndexError, SourceRouteIdentity, VerifiedGenerationSnapshot, VerifiedIndex,
+    WriterOptions,
 };
 use serde_json::{json, Value};
 
@@ -105,10 +106,11 @@ pub use route_result::{
     SourceBackedRefreshSourceFailure,
 };
 pub use types::{
-    nonzero_duration_micros, AdmittedRefresh, AdmittedRefreshCoverage, PublishedSourceBackedState,
-    PublishedSourceBackedStatePort, RefreshOperation, SourceBackedAdmittedDiscovery,
-    SourceBackedCurrentSourceProgress, SourceBackedCurrentSourceProgressStage,
-    SourceBackedExactScanProgress, SourceBackedRefreshExecution, SourceBackedRefreshProgressUpdate,
+    nonzero_duration_micros, AdmittedRefresh, AdmittedRefreshCoverage,
+    PublishedSourceBackedGeneration, PublishedSourceBackedState, PublishedSourceBackedStatePort,
+    RefreshOperation, SourceBackedAdmittedDiscovery, SourceBackedCurrentSourceProgress,
+    SourceBackedCurrentSourceProgressStage, SourceBackedExactScanProgress,
+    SourceBackedRefreshExecution, SourceBackedRefreshProgressUpdate,
     SourceBackedRefreshPublication, SourceBackedRefreshTimings, SourceBackedRefreshWorkset,
     SourceBackedZeroSourceAuthority, SourceBackedZeroSourceAuthorityKind,
 };
@@ -263,7 +265,7 @@ pub fn source_backed_watch_catalog(
         .context("validate provider roots before deriving source watch catalog")?;
     let index_root = source_backed_index_root(data_root);
     let retained_generation = match VerifiedIndex::open_pinned(&index_root) {
-        Ok(index) => Some(index),
+        Ok(index) => Some(index.into_generation_snapshot()),
         Err(IndexError::MissingActiveGenerationPointer) => None,
         Err(error) => return Err(error.into()),
     };
@@ -281,7 +283,7 @@ pub fn source_backed_watch_catalog(
 
 fn configured_retained_provider_roots(
     discovery: &DiscoveryContext,
-    retained_generation: Option<&VerifiedIndex>,
+    retained_generation: Option<&VerifiedGenerationSnapshot>,
 ) -> Result<BTreeMap<String, RetainedProviderRootAuthority>> {
     let roots = discovery.configured_provider_roots();
     let mut root_ids = BTreeSet::new();

--- a/crates/ctx-history-refresh-execution/src/registry_issues.rs
+++ b/crates/ctx-history-refresh-execution/src/registry_issues.rs
@@ -89,7 +89,7 @@ pub fn reject_blocking_automatic_registry_issues(
 #[doc(hidden)]
 pub fn automatic_registry_route_failures(
     issues: &[SourceBackedAutomaticRegistryIssue],
-    retained_generation: Option<&VerifiedIndex>,
+    retained_generation: Option<&VerifiedGenerationSnapshot>,
 ) -> Result<Vec<ctx_history_capture::SourceBackedFailedRoute>> {
     let mut failures = BTreeMap::new();
     for issue in issues {

--- a/crates/ctx-history-refresh-execution/src/tests.rs
+++ b/crates/ctx-history-refresh-execution/src/tests.rs
@@ -22,25 +22,35 @@ impl PublishedSourceBackedStatePort for TestPublishedState {
         let index_root = source_backed_index_root(data_root);
         if !index_root.is_dir() {
             return Ok(PublishedSourceBackedState {
-                verified_index: None,
+                generation: PublishedSourceBackedGeneration::Missing,
                 explicit_source_catalog: None,
                 catalog_route_bindings: Vec::new(),
                 route_controls: BTreeMap::new(),
             });
         }
-        let verified_index = match VerifiedIndex::open_pinned(&index_root) {
-            Ok(index) => Some(index),
-            Err(IndexError::MissingActiveGenerationPointer) => None,
+        let generation = match VerifiedIndex::open_pinned(&index_root) {
+            Ok(index) => {
+                PublishedSourceBackedGeneration::Verified(index.into_generation_snapshot())
+            }
+            Err(IndexError::MissingActiveGenerationPointer) => {
+                PublishedSourceBackedGeneration::Missing
+            }
             Err(error)
                 if ctx_history_index::generation_incompatibility_requires_rebuild(&error) =>
             {
-                None
+                PublishedSourceBackedGeneration::RebuildRequired
             }
             Err(error) => return Err(error.into()),
         };
+        let verified_generation = match &generation {
+            PublishedSourceBackedGeneration::Verified(generation) => Some(generation),
+            PublishedSourceBackedGeneration::Missing
+            | PublishedSourceBackedGeneration::RebuildRequired => None,
+        };
         let (explicit_source_catalog, catalog_route_bindings, route_controls) =
-            if let Some(index) = verified_index.as_ref() {
-                let state = SourceBackedGenerationState::decode_from_verified_index(index)?;
+            if let Some(generation) = verified_generation.as_ref() {
+                let state =
+                    SourceBackedGenerationState::decode_from_manifest(generation.manifest())?;
                 (
                     state.applied_explicit_source_catalog().cloned(),
                     state.catalog_route_bindings().to_vec(),
@@ -50,10 +60,25 @@ impl PublishedSourceBackedStatePort for TestPublishedState {
                 (None, Vec::new(), BTreeMap::new())
             };
         Ok(PublishedSourceBackedState {
-            verified_index,
+            generation,
             explicit_source_catalog,
             catalog_route_bindings,
             route_controls,
+        })
+    }
+}
+
+struct FixedPublishedState {
+    verified_generation: VerifiedGenerationSnapshot,
+}
+
+impl PublishedSourceBackedStatePort for FixedPublishedState {
+    fn open_published_state(&self, _data_root: &Path) -> Result<PublishedSourceBackedState> {
+        Ok(PublishedSourceBackedState {
+            generation: PublishedSourceBackedGeneration::Verified(self.verified_generation.clone()),
+            explicit_source_catalog: None,
+            catalog_route_bindings: Vec::new(),
+            route_controls: BTreeMap::new(),
         })
     }
 }
@@ -352,6 +377,59 @@ fn publish_pin_source(index_root: &Path, source: SourceKey) -> String {
         .certify_source(publication_pin_certificate(&source))
         .unwrap();
     writer.commit(|_| true).unwrap().generation_id
+}
+
+#[test]
+fn route_local_rejects_a_stale_verified_generation_before_staging() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    let index_root = temp.path().join("index");
+    let (_, _, discovery) = discovery_fixture(temp.path());
+    let first = publish_pin_source(&index_root, publication_pin_source_with_anchor(0x91));
+    let verified_generation = VerifiedIndex::open_pinned(&index_root)
+        .unwrap()
+        .into_generation_snapshot();
+    assert_eq!(verified_generation.generation_id(), first);
+    let second = publish_pin_source(&index_root, publication_pin_source_with_anchor(0x93));
+    assert_ne!(second, first);
+    let published_state = FixedPublishedState {
+        verified_generation,
+    };
+    let mut progress =
+        |_: CaptureSourceBackedDetailedRefreshProgress| Ok::<(), SourceBackedRouteError>(());
+
+    let error = refresh_all_provider_sources_route_local(
+        &discovery,
+        DiscoveryReport::default(),
+        StdDuration::ZERO,
+        "stale-generation-test",
+        RefreshOperation::Refresh,
+        &data_root,
+        &index_root,
+        None,
+        SourceBackedRefreshScope::All,
+        &published_state,
+        &mut progress,
+    )
+    .unwrap_err();
+
+    assert!(
+        error.chain().any(|cause| {
+            matches!(
+                cause.downcast_ref::<SourceBackedCoordinatorError>(),
+                Some(SourceBackedCoordinatorError::Index(
+                    IndexError::ConcurrentGenerationChange
+                ))
+            )
+        }),
+        "{error:#}"
+    );
+    assert_eq!(
+        VerifiedIndex::open_pinned(&index_root)
+            .unwrap()
+            .generation_id(),
+        second
+    );
 }
 
 fn test_publication(generation_id: impl Into<String>) -> SourceBackedRefreshPublication {

--- a/crates/ctx-history-refresh-execution/src/tests/registry_policy.rs
+++ b/crates/ctx-history-refresh-execution/src/tests/registry_policy.rs
@@ -230,10 +230,28 @@ fn warm_automatic_hermes_profile_rename_retires_the_old_route_and_remains_refres
     assert!(!warm_state.route_controls().contains_key(&alpha_route));
     assert!(warm_state.route_controls().contains_key(&beta_route));
 
+    let warm_snapshot = VerifiedIndex::open_pinned(&index_root)
+        .unwrap()
+        .into_generation_snapshot();
+    assert_eq!(warm_snapshot.generation_id(), warm_index.generation_id());
+    let manifest_state =
+        SourceBackedGenerationState::decode_from_manifest(warm_snapshot.manifest()).unwrap();
+    assert_eq!(manifest_state.route_controls(), warm_state.route_controls());
+    assert_eq!(
+        manifest_state.route_observations(),
+        warm_state.route_observations()
+    );
+    assert_eq!(
+        manifest_state.catalog_route_bindings(),
+        warm_state.catalog_route_bindings()
+    );
+
     let subsequent = run_report(&discovery, warm_report(), &data_root, &index_root).unwrap();
+    assert_eq!(subsequent.generation_id, warm.generation_id);
     let subsequent = subsequent.verified_index.as_ref().unwrap();
     assert!(subsequent.manifest().source_route(&alpha_route).is_none());
     assert!(subsequent.manifest().source_route(&beta_route).is_some());
+    assert!(warm_index.manifest().source_route(&beta_route).is_some());
 }
 
 fn registry_policy_automatic_route_identity(source: &ProviderSource) -> SourceRouteIdentity {
@@ -448,7 +466,9 @@ fn distinct_nanoclaw_registry_failures_match_retained_automatic_routes() {
     }
     writer.set_present_source_routes(retained_routes).unwrap();
     writer.commit(|_| true).unwrap();
-    let retained = VerifiedIndex::open_pinned(&index_root).unwrap();
+    let retained = VerifiedIndex::open_pinned(&index_root)
+        .unwrap()
+        .into_generation_snapshot();
 
     let issues = sources.map(|source| SourceBackedAutomaticRegistryIssue::Unavailable {
         source,

--- a/crates/ctx-history-refresh-execution/src/types.rs
+++ b/crates/ctx-history-refresh-execution/src/types.rs
@@ -287,8 +287,14 @@ impl fmt::Debug for SourceBackedRefreshPublication {
     }
 }
 
+pub enum PublishedSourceBackedGeneration {
+    Missing,
+    RebuildRequired,
+    Verified(VerifiedGenerationSnapshot),
+}
+
 pub struct PublishedSourceBackedState {
-    pub verified_index: Option<VerifiedIndex>,
+    pub generation: PublishedSourceBackedGeneration,
     pub explicit_source_catalog: Option<ExplicitSourceCatalogAuthority>,
     pub catalog_route_bindings: Vec<ExplicitSourceCatalogRouteBinding>,
     pub route_controls: BTreeMap<SourceRouteIdentity, Vec<u8>>,

--- a/crates/ctx-history-refresh/src/orchestration.rs
+++ b/crates/ctx-history-refresh/src/orchestration.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::publication::{open_published_generation_for_recovery, PublishedGenerationOpen};
+use ctx_history_refresh_execution::PublishedSourceBackedGeneration;
 
 mod catalog_witness;
 use catalog_witness::retained_generation_state;
@@ -9,11 +11,24 @@ pub(crate) struct RetainedPublishedState<'a> {
 
 impl PublishedSourceBackedStatePort for RetainedPublishedState<'_> {
     fn open_published_state(&self, data_root: &Path) -> Result<PublishedSourceBackedState> {
-        let verified_index = open_published_generation(data_root, self.journal)?;
+        let generation = match open_published_generation_for_recovery(data_root, self.journal)? {
+            PublishedGenerationOpen::Missing => PublishedSourceBackedGeneration::Missing,
+            PublishedGenerationOpen::RebuildRequired => {
+                PublishedSourceBackedGeneration::RebuildRequired
+            }
+            PublishedGenerationOpen::Verified(index) => {
+                PublishedSourceBackedGeneration::Verified((*index).into_generation_snapshot())
+            }
+        };
+        let verified_generation = match &generation {
+            PublishedSourceBackedGeneration::Verified(generation) => Some(generation),
+            PublishedSourceBackedGeneration::Missing
+            | PublishedSourceBackedGeneration::RebuildRequired => None,
+        };
         let (explicit_source_catalog, catalog_route_bindings, route_controls) =
-            retained_generation_state(verified_index.as_ref())?;
+            retained_generation_state(verified_generation)?;
         Ok(PublishedSourceBackedState {
-            verified_index,
+            generation,
             explicit_source_catalog,
             catalog_route_bindings,
             route_controls,

--- a/crates/ctx-history-refresh/src/orchestration/catalog_witness.rs
+++ b/crates/ctx-history-refresh/src/orchestration/catalog_witness.rs
@@ -1,4 +1,5 @@
 use super::*;
+use ctx_history_index::VerifiedGenerationSnapshot;
 
 pub(super) type RetainedGenerationState = (
     Option<ExplicitSourceCatalogAuthority>,
@@ -7,12 +8,12 @@ pub(super) type RetainedGenerationState = (
 );
 
 pub(super) fn retained_generation_state(
-    retained_generation: Option<&VerifiedIndex>,
+    retained_generation: Option<&VerifiedGenerationSnapshot>,
 ) -> Result<RetainedGenerationState> {
     let Some(generation) = retained_generation else {
         return Ok((None, Vec::new(), BTreeMap::new()));
     };
-    let state = SourceBackedGenerationState::decode_from_verified_index(generation)
+    let state = SourceBackedGenerationState::decode_from_manifest(generation.manifest())
         .context("decode retained source-backed generation state")?;
     Ok((
         state.applied_explicit_source_catalog().cloned(),

--- a/scripts/tests/provider_family_continuous_refresh_test.py
+++ b/scripts/tests/provider_family_continuous_refresh_test.py
@@ -3,11 +3,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import json
 import os
 from pathlib import Path
 import sys
 import tempfile
+import threading
 import time
 import unittest
 
@@ -39,6 +41,117 @@ MAX_OPEN_FD_DELTA = 96
 MAX_INCREMENTAL_SEGMENT_OVERHEAD_BYTES = 256 * 1024
 MUTATION_CADENCE_SECONDS = 0.1
 STARTUP_REFRESH_QUIET_SECONDS = 2.5
+FD_SAMPLE_INTERVAL_SECONDS = 0.005
+
+
+class ContinuousFdSampler:
+    def __init__(
+        self,
+        sample: Callable[[], int],
+        interval_seconds: float = FD_SAMPLE_INTERVAL_SECONDS,
+    ) -> None:
+        self._sample = sample
+        self._interval_seconds = interval_seconds
+        self._stop = threading.Event()
+        self._ready = threading.Event()
+        self._peak: int | None = None
+        self._failure: Exception | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            raise RuntimeError("continuous FD sampler already started")
+        self._thread = threading.Thread(
+            target=self._sample_until_stopped,
+            name="ctx-continuous-fd-sampler",
+            daemon=True,
+        )
+        self._thread.start()
+        if not self._ready.wait(COMMAND_TIMEOUT_SECONDS):
+            self._stop.set()
+            self._join()
+            raise AssertionError("continuous FD sampler did not produce its first sample")
+        if self._failure is not None:
+            self._join()
+            self._raise_failure()
+
+    def stop(self) -> int:
+        if self._thread is None:
+            raise RuntimeError("continuous FD sampler was not started")
+        self._stop.set()
+        self._join()
+        self._raise_failure()
+        if self._peak is None:
+            raise AssertionError("continuous FD sampler stopped without a sample")
+        return self._peak
+
+    def _join(self) -> None:
+        assert self._thread is not None
+        self._thread.join(COMMAND_TIMEOUT_SECONDS)
+        if self._thread.is_alive():
+            raise AssertionError("continuous FD sampler did not stop")
+
+    def _raise_failure(self) -> None:
+        if self._failure is not None:
+            raise RuntimeError("continuous FD sampler failed") from self._failure
+
+    def _sample_until_stopped(self) -> None:
+        try:
+            while not self._stop.is_set():
+                observed = self._sample()
+                self._peak = observed if self._peak is None else max(self._peak, observed)
+                self._ready.set()
+                self._stop.wait(self._interval_seconds)
+        except Exception as error:  # sampler failures must fail the qualification
+            self._failure = error
+            self._ready.set()
+
+
+class ContinuousFdSamplerTest(unittest.TestCase):
+    def test_records_a_peak_before_search_polling_begins(self) -> None:
+        sample_count = 0
+        pre_search_peak_sampled = threading.Event()
+        search_polling_started = threading.Event()
+
+        def sample() -> int:
+            nonlocal sample_count
+            sample_count += 1
+            if sample_count == 1:
+                return 11
+            if not search_polling_started.is_set():
+                pre_search_peak_sampled.set()
+                return 107
+            return 11
+
+        sampler = ContinuousFdSampler(sample)
+        sampler.start()
+        self.assertTrue(
+            pre_search_peak_sampled.wait(COMMAND_TIMEOUT_SECONDS),
+            "sampler did not observe the synchronized pre-search phase",
+        )
+        search_polling_started.set()
+
+        self.assertEqual(sampler.stop(), 107)
+
+    def test_propagates_sampling_failures_after_joining(self) -> None:
+        sample_count = 0
+        failure_sampled = threading.Event()
+
+        def sample() -> int:
+            nonlocal sample_count
+            sample_count += 1
+            if sample_count == 1:
+                return 11
+            failure_sampled.set()
+            raise OSError("injected sampler failure")
+
+        sampler = ContinuousFdSampler(sample)
+        sampler.start()
+        self.assertTrue(failure_sampled.wait(COMMAND_TIMEOUT_SECONDS))
+        with self.assertRaisesRegex(RuntimeError, "continuous FD sampler failed"):
+            sampler.stop()
+        assert sampler._thread is not None
+        self.assertFalse(sampler._thread.is_alive())
 
 
 def continuous_mutation_count() -> int:
@@ -282,22 +395,17 @@ class ProviderFamilyContinuousRefreshTest(unittest.TestCase):
                             corpus.cold_query, corpus, env, root, daemon.pid, resources
                         )
                         cold = refresh_snapshot(cold_search, root, env)
-                        if corpus.family == SQLITE_WAL_FAMILY:
-                            # SQLite online backup can produce delayed native
-                            # watcher observations. A valid scheduler batch for
-                            # those routes is unrelated to the next controlled
-                            # fixture mutation, so establish a quiet terminal
-                            # baseline before making the exact one-route causal
-                            # assertion below.
-                            cold_search, cold = (
-                                self.wait_for_isolated_continuous_baseline(
-                                    corpus, env, root, daemon.pid, resources
-                                )
+                        cold_search, cold = (
+                            self.wait_for_isolated_continuous_baseline(
+                                corpus, env, root, daemon.pid, resources
                             )
+                        )
                         self.assert_counts(cold, corpus, [])
                         self.assert_result(cold_search, corpus, corpus.cold_body, env, root)
                         mutations: list[FamilyMutation] = []
                         previous = cold
+                        resources["baseline_open_fds"] = linux_open_fd_count(daemon.pid)
+                        resources["peak_open_fds"] = resources["baseline_open_fds"]
                         for iteration in range(1, mutation_count + 1):
                             time.sleep(MUTATION_CADENCE_SECONDS)
                             if corpus.family == SQLITE_WAL_FAMILY:
@@ -312,51 +420,67 @@ class ProviderFamilyContinuousRefreshTest(unittest.TestCase):
                                     )
                                 )
                                 self.assert_counts(previous, corpus, mutations)
-                            source_before = immutable_tree_snapshot(corpus.source_root)
-                            mutation = corpus.continuous_mutation(iteration)
-                            mutations.append(mutation)
-                            source_after_mutation = immutable_tree_snapshot(corpus.source_root)
-                            self.assertNotEqual(source_after_mutation, source_before)
-
-                            search = self.wait_for_searchable(
-                                mutation.query,
-                                corpus,
-                                env,
-                                root,
-                                daemon.pid,
-                                resources,
+                            fd_sampler = ContinuousFdSampler(
+                                lambda: linux_open_fd_count(daemon.pid)
                             )
-                            snapshot = refresh_snapshot(search, root, env)
-                            self.assertEqual(
-                                immutable_tree_snapshot(corpus.source_root),
-                                source_after_mutation,
-                                "the provider source changed after the controlled "
-                                "harness mutation",
-                            )
-                            self.assert_counts(snapshot, corpus, mutations)
-                            self.assert_incremental_watcher_job(
-                                snapshot, previous, env, corpus
-                            )
-                            self.assert_result(search, corpus, mutation.body, env, root)
-                            if mutation.previous_query is not None:
-                                self.assert_absent(
-                                    mutation.previous_query, corpus, env, root
+                            fd_sampler.start()
+                            try:
+                                source_before = immutable_tree_snapshot(corpus.source_root)
+                                mutation = corpus.continuous_mutation(iteration)
+                                mutations.append(mutation)
+                                source_after_mutation = immutable_tree_snapshot(
+                                    corpus.source_root
                                 )
-                            self.assertGreaterEqual(len(snapshot.manifest_names), 1)
-                            self.assertLessEqual(
-                                len(snapshot.manifest_names),
-                                len(cold.manifest_names) + iteration,
-                            )
-                            self.assertLessEqual(
-                                len(snapshot.segments), len(cold.segments) + iteration
-                            )
-                            storage_limit = cold.index_bytes + sum(
-                                item.storage_payload_bytes
-                                + MAX_INCREMENTAL_SEGMENT_OVERHEAD_BYTES
-                                for item in mutations
-                            )
-                            self.assertLessEqual(snapshot.index_bytes, storage_limit)
-                            previous = snapshot
+                                self.assertNotEqual(
+                                    source_after_mutation, source_before
+                                )
+
+                                search = self.wait_for_searchable(
+                                    mutation.query,
+                                    corpus,
+                                    env,
+                                    root,
+                                    daemon.pid,
+                                    resources,
+                                )
+                                snapshot = refresh_snapshot(search, root, env)
+                                self.assertEqual(
+                                    immutable_tree_snapshot(corpus.source_root),
+                                    source_after_mutation,
+                                    "the provider source changed after the controlled "
+                                    "harness mutation",
+                                )
+                                self.assert_counts(snapshot, corpus, mutations)
+                                self.assert_incremental_watcher_job(
+                                    snapshot, previous, env, corpus
+                                )
+                                self.assert_result(
+                                    search, corpus, mutation.body, env, root
+                                )
+                                if mutation.previous_query is not None:
+                                    self.assert_absent(
+                                        mutation.previous_query, corpus, env, root
+                                    )
+                                self.assertGreaterEqual(len(snapshot.manifest_names), 1)
+                                self.assertLessEqual(
+                                    len(snapshot.manifest_names),
+                                    len(cold.manifest_names) + iteration,
+                                )
+                                self.assertLessEqual(
+                                    len(snapshot.segments),
+                                    len(cold.segments) + iteration,
+                                )
+                                storage_limit = cold.index_bytes + sum(
+                                    item.storage_payload_bytes
+                                    + MAX_INCREMENTAL_SEGMENT_OVERHEAD_BYTES
+                                    for item in mutations
+                                )
+                                self.assertLessEqual(snapshot.index_bytes, storage_limit)
+                                previous = snapshot
+                            finally:
+                                resources["peak_open_fds"] = max(
+                                    resources["peak_open_fds"], fd_sampler.stop()
+                                )
 
                         self.assertLessEqual(
                             resources["peak_open_fds"]
@@ -370,6 +494,8 @@ class ProviderFamilyContinuousRefreshTest(unittest.TestCase):
                             "provider-family continuous refresh:"
                             f" provider={corpus.provider}"
                             f" mutations={mutation_count}"
+                            f" baseline_open_fds={resources['baseline_open_fds']}"
+                            f" peak_open_fds={resources['peak_open_fds']}"
                             f" peak_fd_delta="
                             f"{resources['peak_open_fds'] - resources['baseline_open_fds']}"
                             f" peak_rss_bytes={resources['peak_rss_bytes']}"


### PR DESCRIPTION
Root cause: refresh retained a full verified query reader after it only needed predecessor generation metadata. During candidate publication this overlapped two complete Tantivy reader sets and exceeded the continuous-refresh descriptor limit.

Fix:
- consume the predecessor reader into a metadata-only generation snapshot before opening the writer
- keep the exact manifest and generation ID, but explicitly drop searcher mappings, semantic postings, peer lease, then target lease
- fence writer open against the exact captured base generation before staging
- preserve standalone unchecked opens and incompatible-format rebuild behavior
- continuously sample daemon descriptors from before mutation through publication

Exact candidate:
- base aa062102e2a2b686788986a39674a616b18b60e5
- production b0cca07d6d8179d87181187100069a41210272bc
- head c101e4d403165f225a8562d21bbbc2abb82843ef
- tree f422be666c6f7c4791fd4ccc62ac3d749c3349e5

Qualification:
- affected suites: index-query 9 unit, 136 integration, 1 doctest; index 177 plus child process and doctests; capture composition 147; refresh execution 93; refresh 189
- strict all-target all-feature Clippy and Windows GNU cross-check passed
- exact drop-order and three-successor reclamation tests passed
- continuous sampler tests passed
- unchanged 96 descriptor gate passed uncached: DeepSeek 84, Lingma 63, Cline 61, OpenHands 61
- formatting, policy, LOC, and diff checks passed
- two independent exact-head reviews SHIP with no findings

Native Windows execution of the enabled three-successor reclamation selector remains required before merge and release. Do not merge until that exact receipt is attached to this head.

Native Windows x64 gate: PASSED on exact head c101e4d403165f225a8562d21bbbc2abb82843ef and tree f422be666c6f7c4791fd4ccc62ac3d749c3349e5. Windows 11 build 26200, stable-x86_64-pc-windows-msvc, rustc 1.97.1. Exact three-successor reclamation selector: 1 passed, 0 failed in 0.71s. Request req-e06c5ab6509a46a9; session session-15d6fce417b6403a; governor lease 0b148a51e32e4dc4840b9fd7e1c422c1; feedback 2004 smooth. Clean checkout remained clean and VM/scratch cleanup completed.

Restacked after main advanced through #908/#909. Current exact base 9391ba9050958ad69625e5834bf197b259b3ef4a; production dd78c853a2badf0f50f357892e618f6ef2776df3; head d3922ae693c8c26899c1abcbb8031fdc2239aab4; tree e02e3c8996eec60f4cb485a020eb4ee7f055be77. Range-diff marks both patches equivalent. Combined affected suites, #909 certification/reclamation tests, strict Clippy, Windows cross-check, policy, and continuous FD gate passed; deltas 84/62/62/62 under unchanged 96. Prior Windows pass applies to the isolated pre-restack patch; a fresh combined-head native Windows receipt is required before merge.

Final assertion correction (test-only): native Windows diagnostics on the combined candidate proved the terminal manifest mutation returns the precise fail-closed ManifestDigestMismatch before the later fallback classification. Both Windows and platform-neutral tests now require that deterministic error; no production code changed.

Current exact candidate:
- base 9391ba9050958ad69625e5834bf197b259b3ef4a
- production dd78c853a2badf0f50f357892e618f6ef2776df3
- harness d3922ae693c8c26899c1abcbb8031fdc2239aab4
- final test-only head 553bc187da2ebd2dc62dfdeb155bf23a4a38fe8c
- tree 50c91cf8cd8f74edb041b6e9ac5f9da0c948d362

The exact Linux recovery selector, full ctx-history-index suite, Windows GNU cross-check, formatting, policy, LOC, and diff checks passed. Independent exact-head review SHIP with no findings. Final native Windows six-selector qualification is running and remains required before merge.

Final Windows ACL correction:
- root cause: the parent-relative portable clone inherited the exact private ACEs but not the protected-DACL flag, so the authoritative fresh-open verifier correctly rejected the new generation directory before serving it
- fix: request READ_CONTROL and WRITE_DAC on the already authenticated creation handle, install and verify the exact protected current-user/SYSTEM directory DACL through that same retained handle, and keep failure before content copy/certification/pointer publication
- no manifest, hashing, pointer, certification, reader, or wire-format behavior changed
- native regression proves inherited-unprotected state, retained-handle repair, and pathname verification after closing the creation handle

Final reviewed head: 5a96dcf8a15bd3fff34c304c26918c91be1f6b6f
Final tree: 0d383e7a785bc46cc4dc5a03b0cec77931600bce
Parent: 553bc187da2ebd2dc62dfdeb155bf23a4a38fe8c
Independent exact-commit security review: SHIP, no findings. Local affected suites, strict Clippy, Windows GNU cross-check, formatting, diff, policy, and LOC passed. The final exact native Windows seven-selector qualification remains required before merge.

Final native Windows x64 qualification: PASSED all seven exact selectors on head 5a96dcf8a15bd3fff34c304c26918c91be1f6b6f, tree 0d383e7a785bc46cc4dc5a03b0cec77931600bce, Windows 11 build 26200, stable-x86_64-pc-windows-msvc, rustc/cargo 1.97.1. Request req-4c2647830ee340a7; session session-81ecf1d8569840db; governor lease d1f56feaeff24804b3c57509a6ffa2d5; feedback 2010. Qualification receipt SHA-256 4a500b92e4d309e3ea39302d3ad33cf03296bd53a0948fee9cd7ad0059feca91. No cleanup deletion was required. Final live head/base/tree, mergeability, push-guard, policy, and receipt checks passed.