### PR TITLE
fix(index): preserve retained generation certification

### DIFF
--- a/crates/ctx-history-index-format/src/verification.rs
+++ b/crates/ctx-history-index-format/src/verification.rs
@@ -357,6 +357,7 @@ impl VerifiedPublication {
 pub struct VerifiedCandidatePublication {
     publication: VerifiedPublication,
     physical_integrity_audit: PhysicalIntegrityAudit,
+    predecessor_physical_integrity: Option<CertifiedPhysicalIntegrity>,
 }
 
 impl VerifiedCandidatePublication {
@@ -368,6 +369,11 @@ impl VerifiedCandidatePublication {
     #[doc(hidden)]
     pub fn physical_integrity_audit(&self) -> &PhysicalIntegrityAudit {
         &self.physical_integrity_audit
+    }
+
+    #[doc(hidden)]
+    pub fn predecessor_physical_integrity(&self) -> Option<&CertifiedPhysicalIntegrity> {
+        self.predecessor_physical_integrity.as_ref()
     }
 
     #[doc(hidden)]
@@ -486,7 +492,7 @@ where
         candidate_physical_proof,
     )
     .map_err(|error| CandidatePublicationVerificationError::Candidate(error.into()))?;
-    if let Some(base) = base {
+    let predecessor_physical_integrity = if let Some(base) = base {
         let (root, pointer, slot) = base_authority.ok_or({
             CandidatePublicationVerificationError::Candidate(IndexError::WriterInvariant(
                 "incremental candidate verification lacks active base authority",
@@ -499,8 +505,10 @@ where
             base,
             Some(&physical_integrity_audit),
         )
-        .map_err(CandidatePublicationVerificationError::Reusable)?;
-    }
+        .map_err(CandidatePublicationVerificationError::Reusable)?
+    } else {
+        None
+    };
     report_logical_verification().map_err(CandidatePublicationVerificationError::Candidate)?;
     verify_publication_candidate(&searcher, &manifest, base.map(PinnedPublication::searcher))
         .map_err(CandidatePublicationVerificationError::Candidate)?;
@@ -511,6 +519,7 @@ where
             generation_id,
         },
         physical_integrity_audit,
+        predecessor_physical_integrity,
     })
 }
 
@@ -531,7 +540,7 @@ pub fn verify_pinned_publication_authority(
     slot: &GenerationSlot,
     publication: &PinnedPublication,
     candidate_audit: Option<&PhysicalIntegrityAudit>,
-) -> std::result::Result<(), ReusablePublicationError> {
+) -> std::result::Result<Option<CertifiedPhysicalIntegrity>, ReusablePublicationError> {
     if slot.generation_id() != publication.generation_id {
         return Err(ReusablePublicationError::Binding(
             IndexError::ConcurrentGenerationChange,

--- a/crates/ctx-history-index-generation/src/certification.rs
+++ b/crates/ctx-history-index-generation/src/certification.rs
@@ -757,79 +757,6 @@ fn matching_certification(
     Ok(Some(certification))
 }
 
-/// Preserves the active sidecar across reclamation; failures retain safe hashing.
-pub(crate) fn reclaim_with_active_certification(
-    root: &Path,
-    pointer: &ActiveGenerationPointer,
-    reclaimed_directory: &str,
-    remove: impl FnOnce() -> Result<()>,
-) -> Result<()> {
-    let certification = prepare_reclaim(root, pointer, reclaimed_directory).unwrap_or_default();
-    remove()?;
-    if let Some(mut certification) = certification {
-        let _ = (|| {
-            let generation_path = slot_path(root, pointer.active());
-            for expected in &mut certification.artifacts {
-                let current = capture_artifact(
-                    root,
-                    &generation_path,
-                    Path::new(&expected.artifact.path),
-                    Some(pointer),
-                )?;
-                if current != expected.artifact
-                    && (!current
-                        .identity
-                        .same_payload_identity(&expected.artifact.identity)
-                        || current.identity.link_count().checked_add(1)
-                            != Some(expected.artifact.identity.link_count()))
-                {
-                    return Err(IndexError::ChecksumMismatch);
-                }
-                expected.artifact = current;
-            }
-            let index = crate::open_slot_index(root, pointer.active())?;
-            install_certification_sidecar(
-                root,
-                Some(pointer),
-                None,
-                pointer.active(),
-                &index,
-                &certification,
-                false,
-            )
-        })();
-    }
-    Ok(())
-}
-
-fn prepare_reclaim(
-    root: &Path,
-    pointer: &ActiveGenerationPointer,
-    reclaimed_directory: &str,
-) -> Result<Option<GenerationIntegrityCertification>> {
-    let Some(certification) = load_structurally_valid_certification(root, pointer.active())? else {
-        return Ok(None);
-    };
-    let aliases = std::iter::once(pointer.active().directory())
-        .chain(pointer.previous().map(GenerationSlot::directory))
-        .chain(std::iter::once(reclaimed_directory))
-        .map(str::to_owned)
-        .collect::<HashSet<_>>();
-    let generation_path = slot_path(root, pointer.active());
-    for expected in &certification.artifacts {
-        if capture_artifact_with_retained_aliases(
-            root,
-            &generation_path,
-            Path::new(&expected.artifact.path),
-            &aliases,
-        )? != expected.artifact
-        {
-            return Ok(None);
-        }
-    }
-    Ok(Some(certification))
-}
-
 fn load_structurally_valid_certification(
     root: &Path,
     slot: &GenerationSlot,
@@ -862,7 +789,7 @@ pub fn verify_certified_physical_integrity(
     slot: &GenerationSlot,
     certified: &CertifiedPhysicalIntegrity,
     candidate_audit: Option<&PhysicalIntegrityAudit>,
-) -> Result<()> {
+) -> Result<Option<CertifiedPhysicalIntegrity>> {
     let certification = &certified.certification;
     if certification.slot != *slot {
         return Err(IndexError::ConcurrentGenerationChange);
@@ -881,7 +808,10 @@ pub fn verify_certified_physical_integrity(
         return Err(IndexError::ConcurrentGenerationChange);
     }
 
-    for expected in &certification.artifacts {
+    let mut refreshed = certification.clone();
+    let mut refresh_is_complete = true;
+    let mut identity_changed = false;
+    for expected in &mut refreshed.artifacts {
         let current = capture_artifact(
             root,
             &generation_path,
@@ -902,7 +832,9 @@ pub fn verify_certified_physical_integrity(
         }
         let Some(candidate_file) = candidate_file else {
             // This segment is absent from the candidate and therefore cannot
-            // be used as an exhaustive-verification exclusion.
+            // be used as an exhaustive-verification exclusion or to refresh
+            // a changed predecessor identity.
+            refresh_is_complete &= current == expected.artifact;
             continue;
         };
         if candidate_file.sha256 != expected.sha256 {
@@ -914,11 +846,18 @@ pub fn verify_certified_physical_integrity(
         {
             return Err(IndexError::ChecksumMismatch);
         }
+        identity_changed |= current != expected.artifact;
+        expected.artifact = current;
     }
     if load_current_pointer(root)? != *pointer {
         return Err(IndexError::ConcurrentGenerationChange);
     }
-    Ok(())
+    Ok(
+        (refresh_is_complete && identity_changed).then_some(CertifiedPhysicalIntegrity {
+            certification: refreshed,
+            recertified: true,
+        }),
+    )
 }
 
 fn load_current_pointer(root: &Path) -> Result<ActiveGenerationPointer> {
@@ -967,6 +906,7 @@ pub(crate) use artifact_io::{
 mod candidate;
 mod install;
 mod pointer_fence;
+mod reclaim;
 mod sidecar;
 use candidate::{certification_digest_matches_slot, CertificationAliasAuthority};
 pub use candidate::{
@@ -977,6 +917,7 @@ use install::{install_certification, install_certification_sidecar, Certificatio
 pub use pointer_fence::ActiveGenerationPointerFence;
 #[cfg(windows)]
 pub(crate) use pointer_fence::ValidatedPredecessorPointer;
+pub(crate) use reclaim::reclaim_with_pointer_certifications;
 
 #[cfg(any(test, feature = "test-support"))]
 pub use sidecar::certification_file_for_active;

--- a/crates/ctx-history-index-generation/src/certification/reclaim.rs
+++ b/crates/ctx-history-index-generation/src/certification/reclaim.rs
@@ -1,0 +1,84 @@
+use super::*;
+
+/// Preserves pointer-retained sidecars across reclamation; failures retain safe hashing.
+pub(crate) fn reclaim_with_pointer_certifications(
+    root: &Path,
+    pointer: &ActiveGenerationPointer,
+    reclaimed_directory: &str,
+    remove: impl FnOnce() -> Result<()>,
+) -> Result<()> {
+    let certifications = [Some(pointer.active()), pointer.previous()]
+        .into_iter()
+        .flatten()
+        .filter_map(|slot| {
+            prepare_reclaim(root, pointer, slot, reclaimed_directory)
+                .ok()
+                .flatten()
+        })
+        .collect::<Vec<_>>();
+    remove()?;
+    for mut certification in certifications {
+        let _ = (|| {
+            let slot = certification.slot.clone();
+            let generation_path = slot_path(root, &slot);
+            for expected in &mut certification.artifacts {
+                let current = capture_artifact(
+                    root,
+                    &generation_path,
+                    Path::new(&expected.artifact.path),
+                    Some(pointer),
+                )?;
+                if current != expected.artifact
+                    && (!current
+                        .identity
+                        .same_payload_identity(&expected.artifact.identity)
+                        || current.identity.link_count().checked_add(1)
+                            != Some(expected.artifact.identity.link_count()))
+                {
+                    return Err(IndexError::ChecksumMismatch);
+                }
+                expected.artifact = current;
+            }
+            let index = crate::open_slot_index(root, &slot)?;
+            install_certification_sidecar(
+                root,
+                Some(pointer),
+                None,
+                &slot,
+                &index,
+                &certification,
+                false,
+            )
+        })();
+    }
+    Ok(())
+}
+
+fn prepare_reclaim(
+    root: &Path,
+    pointer: &ActiveGenerationPointer,
+    slot: &GenerationSlot,
+    reclaimed_directory: &str,
+) -> Result<Option<GenerationIntegrityCertification>> {
+    let Some(certification) = load_structurally_valid_certification(root, slot)? else {
+        return Ok(None);
+    };
+    let aliases = std::iter::once(pointer.active().directory())
+        .chain(pointer.previous().map(GenerationSlot::directory))
+        .chain(std::iter::once(reclaimed_directory))
+        .map(str::to_owned)
+        .collect::<HashSet<_>>();
+    let generation_path = slot_path(root, slot);
+    for expected in &certification.artifacts {
+        if capture_artifact_with_retained_aliases(
+            root,
+            &generation_path,
+            Path::new(&expected.artifact.path),
+            &aliases,
+        )? != expected.artifact
+        {
+            return Ok(None);
+        }
+    }
+    Ok(Some(certification))
+}

--- a/crates/ctx-history-index-generation/src/generation.rs
+++ b/crates/ctx-history-index-generation/src/generation.rs
@@ -437,7 +437,7 @@ fn remove_reclaimed_generation_directory(
         pointer,
         candidate.path().file_name().and_then(|name| name.to_str()),
     ) {
-        return crate::certification::reclaim_with_active_certification(
+        return crate::certification::reclaim_with_pointer_certifications(
             root, pointer, directory, remove,
         );
     }

--- a/crates/ctx-history-index/src/tests/integrity_certification.rs
+++ b/crates/ctx-history-index/src/tests/integrity_certification.rs
@@ -596,7 +596,7 @@ fn append_reports_nonreflink_fallback_without_faking_hardlink_availability() {
 
 #[cfg(target_os = "linux")]
 #[test]
-fn managed_three_generation_reclamation_preserves_active_certification() {
+fn managed_three_generation_reclamation_preserves_retained_certifications() {
     let (temp, source, _) = published_fixture("managed-reclamation-certification.jsonl");
     let first_directory = active_generation_path(temp.path());
     let guard = CloneTestHookGuard::set(
@@ -607,7 +607,7 @@ fn managed_three_generation_reclamation_preserves_active_certification() {
         |_, _| Ok(()),
     );
 
-    append_record(temp.path(), &source, 2).unwrap();
+    let second = append_record(temp.path(), &source, 2).unwrap();
     append_record(temp.path(), &source, 3).unwrap();
     let metrics = crate::publication::candidate_clone_metrics();
     drop(guard);
@@ -618,7 +618,13 @@ fn managed_three_generation_reclamation_preserves_active_certification() {
         "the third publication must reclaim its unretained first generation"
     );
     crate::publication::reset_verification_activity();
-    drop(VerifiedIndex::open_pinned(temp.path()).unwrap());
+    let mut active = VerifiedIndex::open_pinned(temp.path()).unwrap();
+    let previous = active
+        .take_retained_generation_peer_for_reader()
+        .unwrap()
+        .expect("the active generation did not retain its predecessor");
+    assert_eq!(previous.generation_id(), second.generation_id);
+    drop((previous, active));
     assert_eq!(crate::publication::verification_activity().0, 0);
     assert_eq!(crate::publication::hashed_artifact_bytes(), 0);
 }

--- a/crates/ctx-history-index/src/writer_publication.rs
+++ b/crates/ctx-history-index/src/writer_publication.rs
@@ -573,6 +573,19 @@ impl GenerationWriter {
         if let Some(hook) = self.after_pointer_switch.take() {
             hook(&candidate_path);
         }
+        if let (Some(previous), Some(base), Some(certified)) = (
+            next_pointer.previous(),
+            self.base_publication.as_ref(),
+            verified.publication.predecessor_physical_integrity(),
+        ) {
+            let _ = ctx_history_index_generation::cache_recertified_physical_integrity(
+                &root,
+                &next_pointer,
+                previous,
+                base.searcher().index(),
+                certified,
+            );
+        }
         // The durable pointer is authoritative now. Writer open retries every
         // cleanup below, so treat each attempt independently and never turn a
         // published generation into a failed refresh because reclamation was


### PR DESCRIPTION
## Summary
- carry the old active generation’s verified file identities through publication when the candidate audit proves the same hard-linked bytes
- refresh the predecessor certificate only after the new active pointer is durable, then keep both active and previous certificates current when an older generation is reclaimed
- keep reader verification strict; incomplete proof or any failed best-effort cache update still falls back to hashing
- move reclamation certification handling into a focused submodule instead of raising the 1,000-line file cap

## Regression
A forced-hard-link three-generation publication now opens both the active and retained previous generation with zero checksum walks and zero artifact bytes read after reclamation. Existing corruption and fallback tests remain intact.

## Verification
- focused generation, format, writer, and query suites passed
- post-rebase affected graph: 111/111 targets passed
- formatting, LOC, package audits, dependency boundaries, and independent review passed

Fixes #905