### PR TITLE
test(cli): stabilize daemon contract harness

### DIFF
--- a/crates/ctx-cli-contract-tests/tests/contracts/support/daemon.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/support/daemon.rs
@@ -392,10 +392,16 @@ fn queued_payloads(analytics_root: &Path) -> Result<Vec<ObservedAnalyticsPayload
     unix,
     any(all(test, not(ctx_cli_bazel_test)), ctx_cli_test_support_upgrade)
 ))]
+type TerminalEventRecord = (String, Option<Vec<u8>>, Value);
+
+#[cfg(all(
+    unix,
+    any(all(test, not(ctx_cli_bazel_test)), ctx_cli_test_support_upgrade)
+))]
 fn matching_terminal_events(
     payloads: Vec<ObservedAnalyticsPayload>,
     attempt_id: &str,
-) -> Result<Vec<(String, Option<Vec<u8>>, Value)>, String> {
+) -> Result<Vec<TerminalEventRecord>, String> {
     let mut matches = Vec::new();
     for payload in payloads {
         let Some(events) = payload.value["events"].as_array() else {

--- a/crates/ctx-cli-contract-tests/tests/contracts/support/daemon.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/support/daemon.rs
@@ -663,6 +663,15 @@ fn stop_test_owned_daemon(
     expected_pid: Option<u32>,
 ) -> Result<(), String> {
     let binary = test_binary_copy_path(temp);
+    stop_test_owned_daemon_for_binary(temp, daemon_data_root, &binary, expected_pid)
+}
+
+pub(crate) fn stop_test_owned_daemon_for_binary(
+    temp: &TempDir,
+    daemon_data_root: &Path,
+    binary: &Path,
+    expected_pid: Option<u32>,
+) -> Result<(), String> {
     if !binary.is_file() {
         if expected_pid.is_some() {
             return Err("cannot attribute replacement daemon without its test binary".into());
@@ -674,7 +683,7 @@ fn stop_test_owned_daemon(
         if expected_pid.is_some() {
             return Err("cannot attribute replacement daemon without an active lock".into());
         }
-        return remove_released_test_daemon_artifacts(daemon_data_root, &binary);
+        return remove_released_test_daemon_artifacts(daemon_data_root, binary);
     };
     if let Some(expected_pid) = expected_pid {
         if expected_pid != initial.pid {
@@ -682,17 +691,17 @@ fn stop_test_owned_daemon(
                 "observed replacement pid {expected_pid} does not match test daemon lock {initial:?}"
             ));
         }
-        verify_live_daemon_identity(daemon_data_root, &binary, &initial)?;
+        verify_live_daemon_identity(daemon_data_root, binary, &initial)?;
     } else if process_is_running(initial.pid) {
-        verify_live_daemon_identity(daemon_data_root, &binary, &initial)?;
-    } else if !same_file(&initial.binary, &binary)? {
+        verify_live_daemon_identity(daemon_data_root, binary, &initial)?;
+    } else if !same_file(&initial.binary, binary)? {
         return Err(format!(
             "daemon lock binary {} is not the test copy {}",
             initial.binary.display(),
             binary.display()
         ));
     }
-    let mut prepared = ctx_from_binary(temp, &binary);
+    let mut prepared = ctx_from_binary(temp, binary);
     prepared
         .env("CTX_DATA_ROOT", daemon_data_root)
         .env("CTX_DAEMON_AUTOSTART_OFF", "1")
@@ -712,11 +721,11 @@ fn stop_test_owned_daemon(
         if wait_for_process_exit(initial.pid, cooperative_wait) {
             return assert_daemon_released(daemon_data_root, &initial);
         }
-        verify_live_daemon_identity(daemon_data_root, &binary, &initial)?;
+        verify_live_daemon_identity(daemon_data_root, binary, &initial)?;
         terminate_process(initial.pid, false)
             .map_err(|error| format!("terminate verified test daemon {}: {error}", initial.pid))?;
         if !wait_for_process_exit(initial.pid, Duration::from_secs(1)) {
-            verify_live_daemon_identity(daemon_data_root, &binary, &initial)?;
+            verify_live_daemon_identity(daemon_data_root, binary, &initial)?;
             terminate_process(initial.pid, true).map_err(|error| {
                 format!(
                     "force-terminate verified test daemon {}: {error}",

--- a/crates/ctx-daemon-cli/tests/contracts/auto_upgrade_acceptance/invalid_marker.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/auto_upgrade_acceptance/invalid_marker.rs
@@ -1,3 +1,42 @@
+fn run_live_test_owned_daemon_until(
+    description: &str,
+    temp: &tempfile::TempDir,
+    command: &assert_cmd::Command,
+    mut condition: impl FnMut() -> bool,
+) -> std::process::Output {
+    let mut child = spawn_persistent_daemon(command);
+    let deadline = Instant::now() + Duration::from_secs(45);
+    loop {
+        if condition() {
+            break;
+        }
+        if child.try_wait().unwrap().is_some() {
+            let output = child.wait_with_output().unwrap();
+            panic!(
+                "daemon exited before {description}: status={} stderr={}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        if Instant::now() >= deadline {
+            let output = stop_persistent_daemon(child);
+            panic!(
+                "timed out waiting for {description}: stderr={}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    stop_test_owned_daemon_for_binary(
+        temp,
+        &data_root(temp),
+        Path::new(command.get_program()),
+        Some(child.id()),
+    )
+    .unwrap_or_else(|error| panic!("stop observed test-owned daemon: {error}"));
+    child.wait_with_output().unwrap()
+}
+
 #[test]
 fn corrupt_marker_keeps_persistent_daemon_automatic_scheduler_dormant() {
     let temp = tempdir();
@@ -7,8 +46,9 @@ fn corrupt_marker_keeps_persistent_daemon_automatic_scheduler_dormant() {
     let daemon_root = data_root(&temp);
     let mut ready_at = None;
 
-    let output = run_daemon_until(
+    let output = run_live_test_owned_daemon_until(
         "corrupt-marker daemon observation",
+        &temp,
         &managed_daemon(&temp, &release, &binary),
         || {
             if running_daemon_pid(&daemon_root, None).is_some() {
@@ -38,8 +78,9 @@ fn hash_mismatched_marker_keeps_persistent_daemon_automatic_scheduler_dormant() 
     let daemon_root = data_root(&temp);
     let mut ready_at = None;
 
-    let output = run_daemon_until(
+    let output = run_live_test_owned_daemon_until(
         "hash-mismatched-marker daemon observation",
+        &temp,
         &managed_daemon(&temp, &release, &binary),
         || {
             if running_daemon_pid(&daemon_root, None).is_some() {


### PR DESCRIPTION
## Summary

- name the terminal-event tuple type so strict Clippy accepts the contract harness
- stop only the two live invalid-marker daemon observations through the existing ownership-aware bounded disable path
- preserve raw signal behavior for dedicated signal and ownership-loss cases

This changes test support only; product and runtime behavior are unchanged.

## Validation

- exact reviewed head: 748c3b6697e718f90a1ffd8d79dc9ead35919e88
- exact tree: 1a1cd44ffbae8b3b27b70143f52f830a504cd0bf
- exact base: 76eddce2220ba7758f55b7eb68cb1f626ad4e1d4
- strict CI and Clippy build passed
- corrupt-marker selector passed
- hash-mismatch selector passed twice
- full uncached auto-upgrade contract target: 26 passed, 0 failed, 1 intentionally ignored
- terminal-event behavior selector passed
- formatting, diff, repository policy, and LOC gates passed
- public disclosure push guard passed
- independent exact-tree review: SHIP, no findings