### PR TITLE
fix(release): harden v1.3.2 factory harnesses

### DIFF
--- a/crates/ctx-cli/src/analytics_outbox.rs
+++ b/crates/ctx-cli/src/analytics_outbox.rs
@@ -777,8 +777,18 @@ fn open_lock_file(path: &Path) -> Result<fs::File> {
     #[cfg(windows)]
     {
         use std::os::windows::fs::OpenOptionsExt as _;
-        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+        use windows_sys::Win32::{
+            Foundation::{GENERIC_READ, GENERIC_WRITE},
+            Storage::FileSystem::{
+                FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ, FILE_SHARE_WRITE, READ_CONTROL,
+                WRITE_DAC,
+            },
+        };
+
+        options
+            .access_mode(GENERIC_READ | GENERIC_WRITE | READ_CONTROL | WRITE_DAC)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
     }
     let file = options.open(path).context("open analytics outbox lock")?;
     restrict_private_file_handle(&file).context("protect analytics outbox lock")?;
@@ -826,6 +836,21 @@ fn write_private_file_durably(path: &Path, body: &[u8]) -> Result<()> {
         {
             use std::os::unix::fs::OpenOptionsExt as _;
             options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt as _;
+            use windows_sys::Win32::{
+                Foundation::{GENERIC_READ, GENERIC_WRITE},
+                Storage::FileSystem::{
+                    FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ, READ_CONTROL, WRITE_DAC,
+                },
+            };
+
+            options
+                .access_mode(GENERIC_READ | GENERIC_WRITE | READ_CONTROL | WRITE_DAC)
+                .share_mode(FILE_SHARE_READ)
+                .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
         }
         let mut file = options
             .open(&temp)

--- a/crates/ctx-cli/src/analytics_outbox/tests.rs
+++ b/crates/ctx-cli/src/analytics_outbox/tests.rs
@@ -558,6 +558,30 @@ fn unsafe_state_path_still_fails_closed() {
     assert!(AnalyticsOutbox::open_at(path, NOW).is_err());
 }
 
+#[cfg(windows)]
+#[test]
+fn windows_lock_handle_hardens_its_acl() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("outbox.lock");
+
+    let lock = open_lock_file(&path).unwrap();
+
+    verify_private_file(&path).unwrap();
+    drop(lock);
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_temporary_handle_hardens_its_acl_before_publish() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("outbox.json");
+
+    write_private_file_durably(&path, b"{}\n").unwrap();
+
+    assert_eq!(fs::read(&path).unwrap(), b"{}\n");
+    verify_private_file(&path).unwrap();
+}
+
 #[cfg(unix)]
 #[test]
 fn unsafe_state_permissions_still_fail_closed() {

--- a/crates/ctx-daemon-runtime/src/ipc/client/unix_response.rs
+++ b/crates/ctx-daemon-runtime/src/ipc/client/unix_response.rs
@@ -524,7 +524,7 @@ mod cancellation_tests {
 
     #[test]
     fn cancellation_during_response_wait_preserves_submission_evidence() {
-        let temp = tempfile::tempdir().unwrap();
+        let temp = tempfile::tempdir_in("/tmp").unwrap();
         let socket = temp.path().join("ipc.sock");
         let listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
         let cancelled = Arc::new(AtomicBool::new(false));

--- a/crates/ctx-history-index-query/tests/writer_integration/pinned_generation.rs
+++ b/crates/ctx-history-index-query/tests/writer_integration/pinned_generation.rs
@@ -1,6 +1,7 @@
 use super::*;
 use ctx_history_index_generation::{
-    checksum_walks, hashed_artifact_bytes, reset_physical_verification_activity,
+    certification_file_for_active, checksum_walks, hashed_artifact_bytes,
+    reset_physical_verification_activity,
 };
 
 fn publish_pinned_test_generation(
@@ -547,6 +548,7 @@ fn reader_owned_peer_lease_survives_parent_drop_after_integrity_verification() {
     let temp = tempdir().unwrap();
     let source = source("leased-verification-pointer-race.jsonl");
     let first = publish_pinned_test_generation(temp.path(), &source, 1, "first evidence");
+    let first_certification = certification_file_for_active(temp.path()).unwrap();
     let second = publish_pinned_test_generation(temp.path(), &source, 2, "second evidence");
     #[cfg(not(windows))]
     let first_path = {
@@ -559,6 +561,17 @@ fn reader_owned_peer_lease_survives_parent_drop_after_integrity_verification() {
     };
     let mut reader =
         VerifiedIndex::open_pinned_generation(temp.path(), &second.generation_id).unwrap();
+    let mut second_reader =
+        VerifiedIndex::open_pinned_generation(temp.path(), &second.generation_id).unwrap();
+    let cached_peer = second_reader
+        .take_retained_generation_peer_for_reader()
+        .unwrap()
+        .expect("the cache-warming peer was not retained");
+    assert_eq!(cached_peer.generation_id(), first.generation_id);
+    drop((cached_peer, second_reader));
+    // Make the checksum-walk assertions independent of a matching prior cache.
+    assert!(first_certification.is_file());
+    fs::remove_file(first_certification).unwrap();
     let mut second_reader =
         VerifiedIndex::open_pinned_generation(temp.path(), &second.generation_id).unwrap();
 

--- a/scripts/attest-macos-runtime-release-archive.sh
+++ b/scripts/attest-macos-runtime-release-archive.sh
@@ -122,6 +122,7 @@ notary_submit="${evidence_dir}/ctx-onnxruntime-${platform}.notary-submit.json"
 
 umask 077
 work_dir="$(mktemp -d "${TMPDIR:-/tmp}/ctx-macos-runtime-attestation.XXXXXX")"
+chmod 00700 "${work_dir}"
 complete=0
 cleanup() {
   rm -rf "${work_dir}" >/dev/null 2>&1 || true

--- a/scripts/native-execution-proof.py
+++ b/scripts/native-execution-proof.py
@@ -18,6 +18,18 @@ PLATFORMS = {
     "macos-x64",
     "windows-x64",
 }
+REQUIRED_SMOKE_STEPS = frozenset(
+    {
+        "version",
+        "setup",
+        "import",
+        "search",
+        "read_only",
+        "released_defaults",
+        "explicit_opt_outs",
+        "semantic_offline_fail_closed",
+    }
+)
 
 
 def regular(path: Path, label: str, maximum: int) -> bytes:
@@ -46,6 +58,11 @@ def load_passed_smoke(path: Path) -> tuple[bytes, str]:
         or value.get("status") != "passed"
     ):
         raise ValueError("native smoke result is not passed")
+    steps = value.get("steps")
+    if not isinstance(steps, dict) or any(
+        steps.get(step) != "passed" for step in REQUIRED_SMOKE_STEPS
+    ):
+        raise ValueError("native smoke result is missing required passed steps")
     return payload, hashlib.sha256(payload).hexdigest()
 
 

--- a/scripts/run-macos-release-signing.sh
+++ b/scripts/run-macos-release-signing.sh
@@ -157,7 +157,7 @@ fi
 
 umask 077
 secret_root="$(mktemp -d "${TMPDIR:-/tmp}/ctx-macos-signing-launcher.XXXXXX")"
-chmod 0700 "${secret_root}"
+chmod 00700 "${secret_root}"
 cleanup() {
   rm -rf "${secret_root}" >/dev/null 2>&1 || true
 }

--- a/scripts/run-native-candidate-smoke.ps1
+++ b/scripts/run-native-candidate-smoke.ps1
@@ -144,6 +144,10 @@ $cacheRoot = Join-Path $root "cache"
 $stateRoot = Join-Path $root "state"
 $tmpRoot = Join-Path $root "tmp"
 $workRoot = Join-Path $root "work"
+$analyticsDefaultEvents = Join-Path $root "analytics-default.jsonl"
+$analyticsOptOutEvents = Join-Path $root "analytics-opt-out.jsonl"
+$analyticsDefaultEndpoint = ([System.Uri]::new($analyticsDefaultEvents)).AbsoluteUri
+$analyticsOptOutEndpoint = ([System.Uri]::new($analyticsOptOutEvents)).AbsoluteUri
 foreach ($path in @($profile, $dataRoot, $configRoot, $cacheRoot, $stateRoot, $tmpRoot, $workRoot)) {
     New-Item -ItemType Directory -Path $path -Force | Out-Null
 }
@@ -213,10 +217,12 @@ $isolation = [ordered]@{
     TMP = $tmpRoot
     CTX_DATA_ROOT = $dataRoot
     CTX_ANALYTICS_ENABLED = "false"
+    CTX_ANALYTICS_ENDPOINT = $analyticsDefaultEndpoint
     CTX_UPGRADE_AUTO = "off"
     CTX_DAEMON_AUTOSTART_OFF = "1"
     CTX_DAEMON_AUTOSTART_LOOP_INTERVAL_SECONDS = "1"
     CTX_DAEMON_ENABLED = "false"
+    CTX_DAEMON_MODE = "source-refresh-only"
     CTX_SEARCH_SEMANTIC = "0"
     CTX_SEMANTIC_CACHE_DIR = (Join-Path $root "semantic-cache")
     HF_HOME = (Join-Path $root "huggingface")
@@ -277,7 +283,10 @@ function Wait-TaskUntil(
     }
 }
 
-function Invoke-CtxRaw([string[]]$Arguments) {
+function Invoke-CtxRaw(
+    [string[]]$Arguments,
+    [string]$CompletionPath = ""
+) {
     $start = New-Object System.Diagnostics.ProcessStartInfo
     $start.UseShellExecute = $false
     $start.RedirectStandardOutput = $true
@@ -315,7 +324,22 @@ function Invoke-CtxRaw([string[]]$Arguments) {
         $timeoutPhase = $null
         $rootExitCode = $null
         $cleanupAfterExit = $false
-        if (-not (Wait-ProcessUntil $process $commandClock $timeoutMilliseconds)) {
+        if (-not [string]::IsNullOrWhiteSpace($CompletionPath)) {
+            while ((Get-RemainingMilliseconds $commandClock $timeoutMilliseconds) -gt 0) {
+                $completion = Get-Item -LiteralPath $CompletionPath -ErrorAction SilentlyContinue
+                if ($null -ne $completion -and $completion.Length -gt 0) {
+                    $cleanupAfterExit = $true
+                    break
+                }
+                if ($process.HasExited) {
+                    break
+                }
+                Start-Sleep -Milliseconds 100
+            }
+            if (-not $cleanupAfterExit) {
+                $timeoutPhase = "analytics delivery"
+            }
+        } elseif (-not (Wait-ProcessUntil $process $commandClock $timeoutMilliseconds)) {
             $timeoutPhase = "process exit"
         } else {
             # Preserve the root result before terminating any descendants that
@@ -424,6 +448,33 @@ function Invoke-Ctx([string[]]$Arguments) {
     return $result.Text
 }
 
+function Get-StatusAnalyticsEventId([string]$Path, [bool]$Outbox) {
+    try {
+        if ($Outbox) {
+            $document = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+            if ($document.schema_version -ne 2) { throw "unexpected outbox schema" }
+            $payloads = @($document.entries | Where-Object { $_.kind -ceq "ordinary" } |
+                ForEach-Object { $_.payload | ConvertFrom-Json })
+        } else {
+            $payloads = @(Get-Content -LiteralPath $Path |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                ForEach-Object { $_ | ConvertFrom-Json })
+        }
+        $ids = @($payloads.events | Where-Object {
+            $_.event_name -ceq "operation_completed" -and $_.event_version -eq 1 -and
+            $_.surface -ceq "cli" -and $_.operation -ceq "status" -and
+            $_.outcome -ceq "success"
+        } | ForEach-Object { [string]$_.event_id })
+    } catch {
+        Fail "candidate produced malformed analytics evidence"
+    }
+    if ($ids.Count -ne 1 -or $ids[0] -cnotmatch
+        '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$') {
+        Fail "analytics evidence does not contain exactly one status UUIDv4"
+    }
+    return $ids[0]
+}
+
 try {
     foreach ($name in $isolation.Keys) {
         $savedEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
@@ -517,28 +568,98 @@ try {
         }
     }
 
-    $env:CTX_SEARCH_SEMANTIC = $null
+    # Empty-config foreground work must append durably without delivery. The
+    # isolated daemon then owns bounded delivery to this local file endpoint.
+    $env:CTX_ANALYTICS_ENABLED = $null
+    $env:CTX_UPGRADE_AUTO = $null
     $env:CTX_DAEMON_ENABLED = $null
+    $env:CTX_SEARCH_SEMANTIC = $null
     try {
         $status = Invoke-Ctx @("status", "--format=json")
     } finally {
+        $env:CTX_ANALYTICS_ENABLED = "false"
+        $env:CTX_UPGRADE_AUTO = "off"
         $env:CTX_SEARCH_SEMANTIC = "0"
         $env:CTX_DAEMON_ENABLED = "false"
     }
-    if ($status -notmatch '"read_only"\s*:\s*true') {
+    try {
+        $statusValue = $status | ConvertFrom-Json
+    } catch {
+        Fail "read-only status command returned malformed JSON"
+    }
+    if ($statusValue.read_only -ne $true) {
         Fail "read-only status command returned an unexpected payload"
     }
+    if ($statusValue.daemon.enabled -ne $true) {
+        Fail "candidate does not report daemon maintenance as enabled by default"
+    }
     if ($pairMode -and
-        ($status -notmatch '"auto"\s*:\s*"apply"' -or
-         $status -notmatch '"auto_enabled"\s*:\s*true')) {
+        ($statusValue.upgrade.auto -cne "apply" -or
+         $statusValue.upgrade.auto_enabled -ne $true)) {
         Fail "candidate does not enable managed auto-upgrade by default"
     }
-    if ($status -notmatch '"config_source"\s*:\s*"default"' -or
-        $status -notmatch '"reason"\s*:\s*"semantic_disabled"') {
+    if (-not $pairMode -and
+        ($statusValue.upgrade.auto -cne "off" -or
+         $statusValue.upgrade.auto_enabled -ne $false)) {
+        Fail "candidate does not disable auto-upgrade in the unmanaged validation layout"
+    }
+    if ($statusValue.semantic.config_source -cne "default" -or
+        $statusValue.semantic.reason -cne "semantic_disabled") {
         Fail "native candidate does not report semantic search as disabled by default"
     }
-    if ($status -match '"source"\s*:\s*"unsupported"') {
+    if ($statusValue.semantic.embed_policy.source -ceq "unsupported") {
         Fail "native candidate unexpectedly reports semantic search as unsupported"
+    }
+    if (Test-Path -LiteralPath $analyticsDefaultEvents) {
+        Fail "foreground CLI delivered analytics before daemon ownership"
+    }
+    $analyticsOutboxes = @(Get-ChildItem -LiteralPath $root -Recurse -File |
+        Where-Object { $_.Name -ceq "analytics-outbox-v1.json" })
+    if ($analyticsOutboxes.Count -ne 1) {
+        Fail "candidate did not create exactly one durable analytics outbox"
+    }
+    $analyticsOutboxBeforeDaemon = Join-Path $root "analytics-outbox-before-daemon.json"
+    Copy-Item -LiteralPath $analyticsOutboxes[0].FullName -Destination $analyticsOutboxBeforeDaemon
+
+    $env:CTX_ANALYTICS_ENABLED = $null
+    $env:CTX_UPGRADE_AUTO = "off"
+    $env:CTX_DAEMON_ENABLED = "true"
+    $env:CTX_DAEMON_MODE = "source-refresh-only"
+    $env:CTX_SEARCH_SEMANTIC = "0"
+    try {
+        [void](Invoke-CtxRaw @(
+            "daemon", "run", "--force", "--loop-interval-seconds", "600", "--format", "json"
+        ) $analyticsDefaultEvents)
+    } finally {
+        $env:CTX_ANALYTICS_ENABLED = "false"
+        $env:CTX_UPGRADE_AUTO = "off"
+        $env:CTX_DAEMON_ENABLED = "false"
+    }
+
+    $queuedStatusId = Get-StatusAnalyticsEventId $analyticsOutboxBeforeDaemon $true
+    $deliveredStatusId = Get-StatusAnalyticsEventId $analyticsDefaultEvents $false
+    if ($queuedStatusId -cne $deliveredStatusId) {
+        Fail "daemon did not deliver the queued status analytics UUID"
+    }
+
+    $env:CTX_ANALYTICS_ENDPOINT = $analyticsOptOutEndpoint
+    $optOutStatus = Invoke-Ctx @("status", "--format=json")
+    try {
+        $optOutStatusValue = $optOutStatus | ConvertFrom-Json
+    } catch {
+        Fail "explicit opt-out status returned malformed JSON"
+    } finally {
+        $env:CTX_ANALYTICS_ENDPOINT = $analyticsDefaultEndpoint
+    }
+    if ($optOutStatusValue.daemon.enabled -ne $false) {
+        Fail "candidate daemon opt-out did not override the released default"
+    }
+    if ($optOutStatusValue.upgrade.auto -cne "off" -or
+        $optOutStatusValue.upgrade.auto_enabled -ne $false) {
+        Fail "candidate upgrade opt-out did not override the released default"
+    }
+    if (Test-Path -LiteralPath $analyticsOptOutEvents) {
+        Fail "candidate analytics opt-out did not override the released default"
     }
 
     # Semantic search is supported but opt-in. Without a provisioned model, an
@@ -585,6 +706,8 @@ try {
         import = "passed"
         search = "passed"
         read_only = "passed"
+        released_defaults = "passed"
+        explicit_opt_outs = "passed"
         semantic_offline_fail_closed = "passed"
     }
     if ($pairMode) {
@@ -596,6 +719,8 @@ try {
             import = "passed"
             search = "passed"
             read_only = "passed"
+            released_defaults = "passed"
+            explicit_opt_outs = "passed"
             semantic_offline_fail_closed = "passed"
         }
     }

--- a/scripts/run-native-candidate-smoke.ps1
+++ b/scripts/run-native-candidate-smoke.ps1
@@ -607,7 +607,7 @@ try {
         $statusValue.semantic.reason -cne "semantic_disabled") {
         Fail "native candidate does not report semantic search as disabled by default"
     }
-    if ($statusValue.semantic.embed_policy.source -ceq "unsupported") {
+    if ($status -match '"source"\s*:\s*"unsupported"') {
         Fail "native candidate unexpectedly reports semantic search as unsupported"
     }
     if (Test-Path -LiteralPath $analyticsDefaultEvents) {

--- a/scripts/run-native-candidate-smoke.ps1
+++ b/scripts/run-native-candidate-smoke.ps1
@@ -204,11 +204,20 @@ if (-not [int]::TryParse($timeoutText, [ref]$timeoutSeconds) -or
     $timeoutSeconds -lt 1 -or $timeoutSeconds -gt 900) {
     Fail "timeout must be a whole number of seconds between 1 and 900"
 }
+$deprecatedControlNames = @(
+    "ANALYTICS_OFF",
+    "DISABLE_ANALYTICS",
+    "INSTALL_DIAGNOSTICS_OFF",
+    "DAEMON_OFF",
+    "DISABLE_DAEMON",
+    "UPGRADE_OFF",
+    "DISABLE_AUTO_UPGRADE"
+) | ForEach-Object { "CTX_$_" }
 $isolation = [ordered]@{
     HOME = $profile
     USERPROFILE = $profile
     APPDATA = $configRoot
-    LOCALAPPDATA = $dataRoot
+    LOCALAPPDATA = $stateRoot
     XDG_CONFIG_HOME = $configRoot
     XDG_CACHE_HOME = $cacheRoot
     XDG_DATA_HOME = (Join-Path $root "xdg-data")
@@ -242,6 +251,9 @@ $isolation = [ordered]@{
     MIMOCODE_DISABLE_CHANNEL_DB = "1"
     FORGE_CONFIG = (Join-Path $profile "forge.json")
     VIBE_HOME = (Join-Path $profile ".vibe")
+}
+foreach ($name in $deprecatedControlNames) {
+    $isolation[$name] = $null
 }
 
 function Get-RemainingMilliseconds(
@@ -478,7 +490,7 @@ function Get-StatusAnalyticsEventId([string]$Path, [bool]$Outbox) {
 try {
     foreach ($name in $isolation.Keys) {
         $savedEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
-        [Environment]::SetEnvironmentVariable($name, [string]$isolation[$name], "Process")
+        [Environment]::SetEnvironmentVariable($name, $isolation[$name], "Process")
     }
     Set-Location -LiteralPath $workRoot
 

--- a/scripts/run-native-candidate-smoke.sh
+++ b/scripts/run-native-candidate-smoke.sh
@@ -44,6 +44,11 @@ sha256_file() {
   fi
 }
 
+make_private_directories() {
+  chmod 0700 "$@"
+  chmod u-s,g-s,o-t "$@"
+}
+
 pair_mode=false
 binary="$(absolute_path "$1")"
 if [ "$#" -eq 6 ]; then
@@ -102,6 +107,10 @@ if ! command -v ps >/dev/null 2>&1; then
   printf 'candidate smoke requires ps for survivor detection\n' >&2
   exit 127
 fi
+if ! command -v python3 >/dev/null 2>&1; then
+  printf 'candidate smoke requires python3 for exact analytics evidence\n' >&2
+  exit 127
+fi
 if ! printf '%s\n' "${expected_version}" \
   | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
   printf 'candidate smoke expected version is invalid: %s\n' "${expected_version}" >&2
@@ -124,6 +133,7 @@ root="$(mktemp -d "${TMPDIR:-/tmp}/ctx-native-candidate-smoke.XXXXXX")"
 # macOS exposes /tmp as a symlink to /private/tmp. Resolve the private root
 # before passing its descendants to ctx's no-follow directory traversal.
 root="$(CDPATH= cd -- "${root}" && pwd -P)"
+make_private_directories "${root}"
 cleanup_candidate_processes() {
   [ -n "${candidate_binary:-}" ] || return 0
 
@@ -181,6 +191,9 @@ tmp_root="${root}/tmp"
 work_root="${root}/work"
 mkdir -p "${profile}" "${data_root}" "${config_root}" "${cache_root}" \
   "${state_root}" "${tmp_root}" "${work_root}"
+make_private_directories \
+  "${profile}" "${data_root}" "${config_root}" "${cache_root}" \
+  "${state_root}" "${tmp_root}" "${work_root}"
 candidate_dir="${root}/candidate"
 if [ "${pair_mode}" = true ]; then
   case "$(uname -s):$(uname -m)" in
@@ -202,13 +215,14 @@ if [ "${pair_mode}" = true ]; then
   marker_source="${root}/ctx.install.json"
   binary_sha256="$(sha256_file "${binary}")"
   mkdir -p "${candidate_dir}"
+  make_private_directories "${install_root}" "${candidate_dir}"
   cat > "${marker_source}" <<EOF
 {"schema_version":1,"manager":"ctx-hosted-installer","managed_pair":true,"install_attempt_id":"ia_native_smoke_$$","install_path":"$(json_escape "${candidate_dir}/ctx")","platform":"${pair_platform}","channel":"${pair_channel}","version":"$(json_escape "${expected_version}")","sha256":"${binary_sha256}","staging_dogfood":${staging_dogfood},"metadata_url":"native-candidate-smoke","artifact_url":"native-candidate-smoke","installed_at":"1970-01-01T00:00:00Z"}
 EOF
 else
   candidate_binary="${candidate_dir}/${binary##*/}"
   mkdir -p "${candidate_dir}"
-  chmod 0700 "${root}" "${candidate_dir}"
+  make_private_directories "${candidate_dir}"
   if ! cp "${binary}" "${candidate_binary}" \
     || [ ! -f "${candidate_binary}" ] \
     || [ -L "${candidate_binary}" ]; then
@@ -484,9 +498,9 @@ if [ "${analytics_default}" != true ] \
   exit 1
 fi
 
-# This is the public empty-config runtime-default gate. The analytics endpoint
-# is a local file transport, so the probe exercises the default without using
-# the network or the user's real state.
+# This is the public empty-config runtime-default gate. Foreground commands
+# must append durably without delivery; an isolated persistent daemon then owns
+# delivery to the local file transport without using the network or user state.
 analytics_default_events="${root}/analytics-default.jsonl"
 run_bounded "${root}/status.json" "${root}/status.err" clean_env \
   CTX_ANALYTICS_ENDPOINT="file://${analytics_default_events}" \
@@ -518,8 +532,97 @@ else
     exit 1
   fi
 fi
+if [ -e "${analytics_default_events}" ]; then
+  printf 'candidate foreground CLI delivered analytics before daemon ownership\n' >&2
+  exit 1
+fi
+analytics_outbox_paths="${root}/analytics-outbox.paths"
+find "${root}" -type f -name analytics-outbox-v1.json -print \
+  > "${analytics_outbox_paths}"
+if [ "$(awk 'END { print NR + 0 }' "${analytics_outbox_paths}")" -ne 1 ]; then
+  printf 'candidate did not create exactly one durable analytics outbox\n' >&2
+  exit 1
+fi
+analytics_outbox="$(sed -n '1p' "${analytics_outbox_paths}")"
+analytics_outbox_before="${root}/analytics-outbox-before-daemon.json"
+cp "${analytics_outbox}" "${analytics_outbox_before}"
+
+clean_env \
+  CTX_ANALYTICS_ENDPOINT="file://${analytics_default_events}" \
+  CTX_UPGRADE_AUTO=off \
+  CTX_DAEMON_ENABLED=true \
+  CTX_DAEMON_MODE=source-refresh-only \
+  CTX_SEARCH_SEMANTIC=0 \
+  "${candidate_binary}" daemon run --force --loop-interval-seconds 600 \
+  --format json > "${root}/analytics-daemon.out" \
+  2> "${root}/analytics-daemon.err" &
+analytics_daemon_pid=$!
+analytics_waited=0
+while [ ! -s "${analytics_default_events}" ] \
+  && [ "${analytics_waited}" -lt "${command_timeout_seconds}" ]; do
+  if ! kill -0 "${analytics_daemon_pid}" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+  analytics_waited=$((analytics_waited + 1))
+done
 if [ ! -s "${analytics_default_events}" ]; then
-  printf 'candidate did not exercise default-on analytics through the local endpoint\n' >&2
+  cat "${root}/analytics-daemon.err" >&2
+  printf 'candidate daemon did not deliver queued status analytics within %s seconds\n' \
+    "${command_timeout_seconds}" >&2
+  exit 1
+fi
+if ! cleanup_candidate_processes; then
+  printf 'candidate analytics daemon did not stop after bounded delivery\n' >&2
+  exit 1
+fi
+wait "${analytics_daemon_pid}" 2>/dev/null || true
+if ! python3 -I - "${analytics_outbox_before}" \
+  "${analytics_default_events}" <<'PY'
+import json
+from pathlib import Path
+import sys
+import uuid
+
+outbox = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if outbox.get("schema_version") != 2 or not isinstance(outbox.get("entries"), list):
+    raise SystemExit("analytics outbox has an unexpected schema")
+queued = [
+    json.loads(entry["payload"])
+    for entry in outbox["entries"]
+    if isinstance(entry, dict)
+    and entry.get("kind") == "ordinary"
+    and isinstance(entry.get("payload"), str)
+]
+delivered = [
+    json.loads(line)
+    for line in Path(sys.argv[2]).read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+
+def status_ids(payloads):
+    return [
+        event.get("event_id")
+        for payload in payloads
+        if isinstance(payload, dict) and isinstance(payload.get("events"), list)
+        for event in payload["events"]
+        if isinstance(event, dict)
+        and event.get("event_name") == "operation_completed"
+        and event.get("event_version") == 1
+        and event.get("surface") == "cli"
+        and event.get("operation") == "status"
+        and event.get("outcome") == "success"
+    ]
+
+queued_ids = status_ids(queued)
+delivered_ids = status_ids(delivered)
+if len(queued_ids) != 1 or delivered_ids.count(queued_ids[0]) != 1:
+    raise SystemExit("queued status analytics was not delivered exactly once")
+if uuid.UUID(queued_ids[0]).version != 4:
+    raise SystemExit("status analytics event does not have a UUIDv4")
+PY
+then
+  printf 'candidate did not preserve exact status analytics across daemon delivery\n' >&2
   exit 1
 fi
 

--- a/scripts/run-native-candidate-smoke.sh
+++ b/scripts/run-native-candidate-smoke.sh
@@ -134,6 +134,70 @@ root="$(mktemp -d "${TMPDIR:-/tmp}/ctx-native-candidate-smoke.XXXXXX")"
 # before passing its descendants to ctx's no-follow directory traversal.
 root="$(CDPATH= cd -- "${root}" && pwd -P)"
 make_private_directories "${root}"
+analytics_daemon_pid=""
+process_ids_for_binary() {
+  [ -n "${candidate_binary:-}" ] || return 0
+
+  candidate_process_snapshot="${root}/candidate-processes.snapshot"
+  ps -axo pid=,command= > "${candidate_process_snapshot}" 2>/dev/null || return 0
+  awk -v executable="${candidate_binary}" '
+    {
+      pid = $1
+      sub(/^[[:space:]]*[0-9]+[[:space:]]+/, "", $0)
+      start = index($0, executable)
+      after = start + length(executable)
+      if (start > 0 \
+          && (start == 1 || substr($0, start - 1, 1) == " ") \
+          && (after > length($0) || substr($0, after, 1) == " ")) {
+        print pid
+      }
+    }
+  ' "${candidate_process_snapshot}" | LC_ALL=C sort -n
+}
+
+candidate_pid_reapable() {
+  candidate_pid_state="$(
+    ps -o stat= -p "$1" 2>/dev/null | awk 'NR == 1 { print $1 }'
+  )"
+  case "${candidate_pid_state}" in
+    ''|Z*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+terminate_and_reap_analytics_daemon() {
+  known_analytics_pid="${analytics_daemon_pid:-}"
+  [ -n "${known_analytics_pid}" ] || return 0
+  analytics_daemon_pid=""
+
+  if ! candidate_pid_reapable "${known_analytics_pid}"; then
+    kill -TERM "${known_analytics_pid}" 2>/dev/null || true
+  fi
+  termination_waited=0
+  while ! candidate_pid_reapable "${known_analytics_pid}" \
+    && [ "${termination_waited}" -lt 3 ]; do
+    sleep 1
+    termination_waited=$((termination_waited + 1))
+  done
+
+  if ! candidate_pid_reapable "${known_analytics_pid}"; then
+    kill -KILL "${known_analytics_pid}" 2>/dev/null || true
+  fi
+  termination_waited=0
+  while ! candidate_pid_reapable "${known_analytics_pid}" \
+    && [ "${termination_waited}" -lt 2 ]; do
+    sleep 1
+    termination_waited=$((termination_waited + 1))
+  done
+
+  if ! candidate_pid_reapable "${known_analytics_pid}"; then
+    printf 'candidate cleanup could not terminate analytics daemon PID: %s\n' \
+      "${known_analytics_pid}" >&2
+    return 1
+  fi
+  wait "${known_analytics_pid}" 2>/dev/null || true
+}
+
 cleanup_candidate_processes() {
   [ -n "${candidate_binary:-}" ] || return 0
 
@@ -162,11 +226,17 @@ cleanup_candidate_processes() {
     "${cleanup_pids}" >&2
   return 1
 }
+cleanup_analytics_processes() {
+  analytics_cleanup_status=0
+  terminate_and_reap_analytics_daemon || analytics_cleanup_status=1
+  cleanup_candidate_processes || analytics_cleanup_status=1
+  return "${analytics_cleanup_status}"
+}
 cleanup() {
   cleanup_status=$?
   trap - 0
   trap '' 1 2 15
-  if ! cleanup_candidate_processes; then
+  if ! cleanup_analytics_processes; then
     printf 'candidate smoke retained private root for survivor diagnosis: %s\n' \
       "${root}" >&2
     rm -f "${result_tmp}" "${result_path}" || true
@@ -241,7 +311,7 @@ fi
 # analytics and upgrades below. The released-default probes instead redirect
 # analytics to an isolated file and use status, which cannot schedule work.
 clean_env() {
-  env -i \
+  exec env -i \
     PATH="${PATH:-/usr/bin:/bin}" \
     HOME="${profile}" \
     USER="${USER:-ctx-smoke}" \
@@ -369,13 +439,6 @@ if [ "${pair_mode}" = true ]; then
     exit 1
   fi
 fi
-
-process_ids_for_binary() {
-  ps -axo pid=,command= 2>/dev/null \
-    | awk -v executable="${candidate_binary}" \
-      '$2 == executable || $3 == executable { print $1 }' \
-    | LC_ALL=C sort -n
-}
 
 baseline_processes="${root}/baseline-processes"
 final_processes="${root}/final-processes"
@@ -572,11 +635,10 @@ if [ ! -s "${analytics_default_events}" ]; then
     "${command_timeout_seconds}" >&2
   exit 1
 fi
-if ! cleanup_candidate_processes; then
-  printf 'candidate analytics daemon did not stop after bounded delivery\n' >&2
+if ! cleanup_analytics_processes; then
+  printf 'candidate analytics daemon did not stop and reap after bounded delivery\n' >&2
   exit 1
 fi
-wait "${analytics_daemon_pid}" 2>/dev/null || true
 if ! python3 -I - "${analytics_outbox_before}" \
   "${analytics_default_events}" <<'PY'
 import json

--- a/scripts/sign-notarize-macos-release-artifact.sh
+++ b/scripts/sign-notarize-macos-release-artifact.sh
@@ -340,6 +340,7 @@ rm -f "${submit_json}" "${submit_stderr}" "${log_json}" "${log_stderr}" \
 
 umask 077
 secret_root="$(mktemp -d "${TMPDIR:-/tmp}/ctx-macos-signing.XXXXXX")"
+chmod 00700 "${secret_root}"
 cleanup() {
   rm -rf "${secret_root}" >/dev/null 2>&1 || true
 }

--- a/scripts/smoke-daemon-semantic-release.sh
+++ b/scripts/smoke-daemon-semantic-release.sh
@@ -259,7 +259,7 @@ if [[ -n "${data_root_parent}" ]]; then
 else
   run_root="$(mktemp -d "${TMPDIR:-/tmp}/ctx-semantic-smoke.XXXXXX")"
 fi
-chmod 700 "${run_root}"
+chmod 00700 "${run_root}"
 run_root="$(cd -- "${run_root}" && pwd -P)"
 data_root="${run_root}/data"
 mkdir -p -- "${data_root}"

--- a/scripts/tests/macos-release-signing-test.sh
+++ b/scripts/tests/macos-release-signing-test.sh
@@ -7,6 +7,7 @@ test_root="$(mktemp -d "${TMPDIR:-/tmp}/ctx-macos-signing-test.XXXXXX")"
 trap 'rm -rf "${test_root}"' EXIT
 fake_bin="${test_root}/bin"
 mkdir -p "${fake_bin}" "${test_root}/tmp"
+chmod 02700 "${test_root}/tmp"
 
 fail() {
   printf 'macOS signing contract test failed: %s\n' "$*" >&2
@@ -27,6 +28,8 @@ case "${1:-}" in
       shift
     done
     [[ -n "${output}" ]]
+    [[ "$(stat -c '%a' "$(dirname "${output}")" 2>/dev/null || \
+      stat -f '%Lp' "$(dirname "${output}")")" == "700" ]]
     printf '%s\n' 'fake certificate or key' >"${output}"
     ;;
   dgst)

--- a/scripts/tests/native-execution-proof-test.py
+++ b/scripts/tests/native-execution-proof-test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 import tempfile
 import unittest
@@ -15,8 +16,33 @@ assert spec is not None and spec.loader is not None
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 
+REQUIRED_SMOKE_STEPS = frozenset(
+    {
+        "version",
+        "setup",
+        "import",
+        "search",
+        "read_only",
+        "released_defaults",
+        "explicit_opt_outs",
+        "semantic_offline_fail_closed",
+    }
+)
+
 
 class NativeExecutionProofTest(unittest.TestCase):
+    @staticmethod
+    def passed_smoke() -> dict[str, object]:
+        return {
+            "kind": "ctx-native-candidate-smoke",
+            "schema_version": 1,
+            "status": "passed",
+            "steps": {step: "passed" for step in REQUIRED_SMOKE_STEPS},
+        }
+
+    def test_required_smoke_steps_match_receipt_contract(self) -> None:
+        self.assertEqual(module.REQUIRED_SMOKE_STEPS, REQUIRED_SMOKE_STEPS)
+
     def test_proof_binds_exact_artifact_and_passed_smoke(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -24,10 +50,7 @@ class NativeExecutionProofTest(unittest.TestCase):
             smoke = root / "candidate-smoke.json"
             proof = root / "ctx-linux-x64.native-execution.json"
             artifact.write_bytes(b"candidate bytes")
-            smoke.write_text(
-                '{"kind":"ctx-native-candidate-smoke","schema_version":1,"status":"passed"}\n',
-                encoding="utf-8",
-            )
+            smoke.write_text(json.dumps(self.passed_smoke()) + "\n", encoding="utf-8")
             module.create("linux-x64", artifact, smoke, proof)
             module.verify("linux-x64", artifact, proof)
             artifact.write_bytes(b"changed candidate bytes")
@@ -47,6 +70,20 @@ class NativeExecutionProofTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "not passed"):
                 module.create("linux-x64", artifact, smoke, root / "proof.json")
 
+    def test_every_platform_requires_complete_passed_smoke_steps(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact = root / "ctx"
+            smoke = root / "candidate-smoke.json"
+            artifact.write_bytes(b"candidate bytes")
+            for platform in module.PLATFORMS:
+                for missing in REQUIRED_SMOKE_STEPS:
+                    with self.subTest(platform=platform, missing=missing):
+                        value = self.passed_smoke()
+                        del value["steps"][missing]
+                        smoke.write_text(json.dumps(value) + "\n", encoding="utf-8")
+                        with self.assertRaisesRegex(ValueError, "missing required"):
+                            module.create(platform, artifact, smoke, root / "proof.json")
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/run-native-candidate-smoke-test.ps1
+++ b/scripts/tests/run-native-candidate-smoke-test.ps1
@@ -105,7 +105,12 @@ if not "%CTX_SEARCH_SEMANTIC%"=="" exit /b 89
 if /I "%~n0"=="ctx-foreground-analytics" goto foreground_delivery
 if not exist "%XDG_STATE_HOME%\ctx" mkdir "%XDG_STATE_HOME%\ctx"
 > "%XDG_STATE_HOME%\ctx\analytics-outbox-v1.json" echo {"schema_version":2,"entries":[{"schema_version":2,"entry_id":"22222222-2222-4222-8222-222222222222","endpoint_fingerprint":"fixture","queued_at_epoch_seconds":1800000000,"attempts":0,"next_attempt_at_epoch_seconds":0,"kind":"ordinary","payload":"{\"events\":[{\"event_name\":\"operation_completed\",\"event_version\":1,\"surface\":\"cli\",\"operation\":\"status\",\"outcome\":\"success\",\"event_id\":\"11111111-1111-4111-8111-111111111111\"}]}"}],"retry_attempts":0,"dropped":0,"failure_sequence":0,"last_failure_class":null,"observation_due":false}
+if /I "%~n0"=="ctx-no-embed-policy" goto status_without_embed_policy
 echo {"read_only":true,"daemon":{"enabled":true},"upgrade":{"auto":"off","auto_enabled":false},"semantic":{"config_source":"default","enabled":false,"reason":"semantic_disabled","embed_policy":{"source":"dynamic_quiet"}}}
+exit /b 0
+
+:status_without_embed_policy
+echo {"read_only":true,"daemon":{"enabled":true},"upgrade":{"auto":"off","auto_enabled":false},"semantic":{"config_source":"default","enabled":false,"reason":"semantic_disabled"}}
 exit /b 0
 
 :foreground_delivery
@@ -162,6 +167,15 @@ exit /b %errorlevel%
         if ($parsed.steps.$key -ne "passed") {
             throw "candidate smoke step did not pass: $key"
         }
+    }
+
+    $noEmbedPolicyFake = Join-Path $root "ctx-no-embed-policy.cmd"
+    Copy-Item -LiteralPath $fake -Destination $noEmbedPolicyFake
+    $noEmbedPolicyResult = Join-Path $root "no-embed-policy-result.json"
+    & $smoke -Binary $noEmbedPolicyFake -Fixture $fixture `
+        -ExpectedVersion 0.25.0 -ResultPath $noEmbedPolicyResult | Out-Null
+    if ((Get-Content -LiteralPath $noEmbedPolicyResult -Raw | ConvertFrom-Json).status -ne "passed") {
+        throw "candidate smoke rejected an omitted optional semantic embed policy"
     }
 
     $foregroundAnalyticsFake = Join-Path $root "ctx-foreground-analytics.cmd"

--- a/scripts/tests/run-native-candidate-smoke-test.ps1
+++ b/scripts/tests/run-native-candidate-smoke-test.ps1
@@ -21,6 +21,15 @@ $unrelated = $null
 $unrelatedLauncher = $null
 $pipeHolderPidPath = $null
 $unrelatedPidPath = $null
+$deprecatedControlNames = @(
+    "CTX_ANALYTICS_OFF",
+    "CTX_DISABLE_ANALYTICS",
+    "CTX_INSTALL_DIAGNOSTICS_OFF",
+    "CTX_DAEMON_OFF",
+    "CTX_DISABLE_DAEMON",
+    "CTX_UPGRADE_OFF",
+    "CTX_DISABLE_AUTO_UPGRADE"
+)
 $testEnvironmentNames = @(
     "CTX_NATIVE_CANDIDATE_TEST_PIPE_HOLDER",
     "CTX_NATIVE_CANDIDATE_TEST_PIPE_HOLDER_PID",
@@ -30,7 +39,8 @@ $testEnvironmentNames = @(
     "CTX_NATIVE_CANDIDATE_TEST_ROOT_EXIT_CODE",
     "CTX_NATIVE_CANDIDATE_TEST_ANALYTICS_DAEMON_PID",
     "CTX_NATIVE_CANDIDATE_COMMAND_TIMEOUT_SECONDS",
-    "CTX_FAKE_MANAGED_PAIR_EXTRA_OUTPUT",
+    "CTX_FAKE_MANAGED_PAIR_EXTRA_OUTPUT"
+) + $deprecatedControlNames + @(
     "TEMP",
     "TMP"
 )
@@ -40,6 +50,9 @@ foreach ($name in $testEnvironmentNames) {
 }
 $env:TEMP = $root
 $env:TMP = $root
+foreach ($name in $deprecatedControlNames) {
+    [Environment]::SetEnvironmentVariable($name, "1", "Process")
+}
 
 try {
     $fake = Join-Path $root "ctx.cmd"
@@ -49,6 +62,13 @@ if "%HOME%"=="" exit /b 94
 if "%USERPROFILE%"=="" exit /b 95
 if not "%CI%"=="" exit /b 97
 if not "%CTX_DAEMON_AUTOSTART_OFF%"=="1" exit /b 93
+if defined CTX_ANALYTICS_OFF exit /b 84
+if defined CTX_DISABLE_ANALYTICS exit /b 84
+if defined CTX_INSTALL_DIAGNOSTICS_OFF exit /b 84
+if defined CTX_DAEMON_OFF exit /b 84
+if defined CTX_DISABLE_DAEMON exit /b 84
+if defined CTX_UPGRADE_OFF exit /b 84
+if defined CTX_DISABLE_AUTO_UPGRADE exit /b 84
 if /I "%1"=="status" goto status
 if /I "%1"=="daemon" goto daemon
 if not "%CTX_ANALYTICS_ENABLED%"=="false" exit /b 91
@@ -103,8 +123,9 @@ if not "%CTX_UPGRADE_AUTO%"=="" exit /b 92
 if not "%CTX_DAEMON_ENABLED%"=="" exit /b 90
 if not "%CTX_SEARCH_SEMANTIC%"=="" exit /b 89
 if /I "%~n0"=="ctx-foreground-analytics" goto foreground_delivery
-if not exist "%XDG_STATE_HOME%\ctx" mkdir "%XDG_STATE_HOME%\ctx"
-> "%XDG_STATE_HOME%\ctx\analytics-outbox-v1.json" echo {"schema_version":2,"entries":[{"schema_version":2,"entry_id":"22222222-2222-4222-8222-222222222222","endpoint_fingerprint":"fixture","queued_at_epoch_seconds":1800000000,"attempts":0,"next_attempt_at_epoch_seconds":0,"kind":"ordinary","payload":"{\"events\":[{\"event_name\":\"operation_completed\",\"event_version\":1,\"surface\":\"cli\",\"operation\":\"status\",\"outcome\":\"success\",\"event_id\":\"11111111-1111-4111-8111-111111111111\"}]}"}],"retry_attempts":0,"dropped":0,"failure_sequence":0,"last_failure_class":null,"observation_due":false}
+if /I "%LOCALAPPDATA%"=="%CTX_DATA_ROOT%" exit /b 85
+if not exist "%LOCALAPPDATA%\ctx" mkdir "%LOCALAPPDATA%\ctx"
+> "%LOCALAPPDATA%\ctx\analytics-outbox-v1.json" echo {"schema_version":2,"entries":[{"schema_version":2,"entry_id":"22222222-2222-4222-8222-222222222222","endpoint_fingerprint":"fixture","queued_at_epoch_seconds":1800000000,"attempts":0,"next_attempt_at_epoch_seconds":0,"kind":"ordinary","payload":"{\"events\":[{\"event_name\":\"operation_completed\",\"event_version\":1,\"surface\":\"cli\",\"operation\":\"status\",\"outcome\":\"success\",\"event_id\":\"11111111-1111-4111-8111-111111111111\"}]}"}],"retry_attempts":0,"dropped":0,"failure_sequence":0,"last_failure_class":null,"observation_due":false}
 if /I "%~n0"=="ctx-no-embed-policy" goto status_without_embed_policy
 echo {"read_only":true,"daemon":{"enabled":true},"upgrade":{"auto":"off","auto_enabled":false},"semantic":{"config_source":"default","enabled":false,"reason":"semantic_disabled","embed_policy":{"source":"dynamic_quiet"}}}
 exit /b 0
@@ -253,7 +274,7 @@ public static class CtxManagedPairFake {
     }
 
     private static void WriteOutbox() {
-        string root = Path.Combine(Environment.GetEnvironmentVariable("XDG_STATE_HOME"), "ctx");
+        string root = Path.Combine(Environment.GetEnvironmentVariable("LOCALAPPDATA"), "ctx");
         Directory.CreateDirectory(root);
         File.WriteAllText(Path.Combine(root, "analytics-outbox-v1.json"), "{\"schema_version\":2,\"entries\":[{\"kind\":\"ordinary\",\"payload\":" + Quote(AnalyticsPayload) + "}]}");
     }
@@ -498,7 +519,7 @@ public static class CtxPipeOwner {
         }
         if (mode == "status") {
             if (Environment.GetEnvironmentVariable("CTX_ANALYTICS_ENABLED") == null) {
-                string state = Path.Combine(Environment.GetEnvironmentVariable("XDG_STATE_HOME"), "ctx");
+                string state = Path.Combine(Environment.GetEnvironmentVariable("LOCALAPPDATA"), "ctx");
                 Directory.CreateDirectory(state);
                 File.WriteAllText(Path.Combine(state, "analytics-outbox-v1.json"), "{\"schema_version\":2,\"entries\":[{\"kind\":\"ordinary\",\"payload\":\"{\\\"events\\\":[{\\\"event_name\\\":\\\"operation_completed\\\",\\\"event_version\\\":1,\\\"surface\\\":\\\"cli\\\",\\\"operation\\\":\\\"status\\\",\\\"outcome\\\":\\\"success\\\",\\\"event_id\\\":\\\"11111111-1111-4111-8111-111111111111\\\"}]}\"}]}");
                 Console.WriteLine("{\"read_only\":true,\"daemon\":{\"enabled\":true},\"upgrade\":{\"auto\":\"off\",\"auto_enabled\":false},\"semantic\":{\"config_source\":\"default\",\"reason\":\"semantic_disabled\",\"embed_policy\":{\"source\":\"dynamic_quiet\"}}}");

--- a/scripts/tests/run-native-candidate-smoke-test.ps1
+++ b/scripts/tests/run-native-candidate-smoke-test.ps1
@@ -13,7 +13,7 @@ if ($smokeSource -notmatch [regex]::Escape("--ctx-core-managed-pair-apply-v1") -
     $installerSource -notmatch [regex]::Escape('$markerPath = "$installPath.install.json"')) {
     throw "Windows candidate smoke does not use the single Core managed-pair authority"
 }
-$root = Join-Path ([System.IO.Path]::GetTempPath()) ("ctx-native-smoke-test-" + [Guid]::NewGuid().ToString("n"))
+$root = Join-Path ([System.IO.Path]::GetTempPath()) ("ctx native smoke test " + [Guid]::NewGuid().ToString("n"))
 New-Item -ItemType Directory -Path $root | Out-Null
 $savedCI = $env:CI
 $env:CI = "true"
@@ -28,24 +28,31 @@ $testEnvironmentNames = @(
     "CTX_NATIVE_CANDIDATE_TEST_BINARY",
     "CTX_NATIVE_CANDIDATE_TEST_UNRELATED_PID",
     "CTX_NATIVE_CANDIDATE_TEST_ROOT_EXIT_CODE",
+    "CTX_NATIVE_CANDIDATE_TEST_ANALYTICS_DAEMON_PID",
     "CTX_NATIVE_CANDIDATE_COMMAND_TIMEOUT_SECONDS",
-    "CTX_FAKE_MANAGED_PAIR_EXTRA_OUTPUT"
+    "CTX_FAKE_MANAGED_PAIR_EXTRA_OUTPUT",
+    "TEMP",
+    "TMP"
 )
 $savedTestEnvironment = @{}
 foreach ($name in $testEnvironmentNames) {
     $savedTestEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
 }
+$env:TEMP = $root
+$env:TMP = $root
 
 try {
     $fake = Join-Path $root "ctx.cmd"
-    @'
+@'
 @echo off
-if not "%CTX_ANALYTICS_ENABLED%"=="false" exit /b 91
-if not "%CTX_UPGRADE_AUTO%"=="off" exit /b 92
-if not "%CTX_DAEMON_AUTOSTART_OFF%"=="1" exit /b 93
 if "%HOME%"=="" exit /b 94
 if "%USERPROFILE%"=="" exit /b 95
 if not "%CI%"=="" exit /b 97
+if not "%CTX_DAEMON_AUTOSTART_OFF%"=="1" exit /b 93
+if /I "%1"=="status" goto status
+if /I "%1"=="daemon" goto daemon
+if not "%CTX_ANALYTICS_ENABLED%"=="false" exit /b 91
+if not "%CTX_UPGRADE_AUTO%"=="off" exit /b 92
 set "CTX_FAKE_VERSION=0.25.0"
 if /I "%~n0"=="ctx-v1" set "CTX_FAKE_VERSION=1.0.0"
 echo %* | findstr /c:"--backend semantic" >nul
@@ -81,13 +88,49 @@ if "%1"=="search" (
   echo {"retrieval":{"requested_mode":"lexical","effective_mode":"lexical"},"results":[{"text":"Add a parser test."}]}
   exit /b 0
 )
-if "%1"=="status" (
-  if not "%CTX_SEARCH_SEMANTIC%"=="" exit /b 89
-  if not "%CTX_DAEMON_ENABLED%"=="" exit /b 90
-  echo {"read_only":true,"semantic":{"config_source":"default","enabled":false,"reason":"semantic_disabled","embed_policy":{"source":"dynamic_quiet"}}}
-  exit /b 0
-)
 exit /b 99
+
+:status
+if "%CTX_ANALYTICS_ENABLED%"=="" goto status_default
+if not "%CTX_ANALYTICS_ENABLED%"=="false" exit /b 91
+if not "%CTX_UPGRADE_AUTO%"=="off" exit /b 92
+if not "%CTX_DAEMON_ENABLED%"=="false" exit /b 90
+echo {"read_only":true,"daemon":{"enabled":false},"upgrade":{"auto":"off","auto_enabled":false},"semantic":{"config_source":"default","enabled":false,"reason":"semantic_disabled","embed_policy":{"source":"dynamic_quiet"}}}
+exit /b 0
+
+:status_default
+if not "%CTX_UPGRADE_AUTO%"=="" exit /b 92
+if not "%CTX_DAEMON_ENABLED%"=="" exit /b 90
+if not "%CTX_SEARCH_SEMANTIC%"=="" exit /b 89
+if /I "%~n0"=="ctx-foreground-analytics" goto foreground_delivery
+if not exist "%XDG_STATE_HOME%\ctx" mkdir "%XDG_STATE_HOME%\ctx"
+> "%XDG_STATE_HOME%\ctx\analytics-outbox-v1.json" echo {"schema_version":2,"entries":[{"schema_version":2,"entry_id":"22222222-2222-4222-8222-222222222222","endpoint_fingerprint":"fixture","queued_at_epoch_seconds":1800000000,"attempts":0,"next_attempt_at_epoch_seconds":0,"kind":"ordinary","payload":"{\"events\":[{\"event_name\":\"operation_completed\",\"event_version\":1,\"surface\":\"cli\",\"operation\":\"status\",\"outcome\":\"success\",\"event_id\":\"11111111-1111-4111-8111-111111111111\"}]}"}],"retry_attempts":0,"dropped":0,"failure_sequence":0,"last_failure_class":null,"observation_due":false}
+echo {"read_only":true,"daemon":{"enabled":true},"upgrade":{"auto":"off","auto_enabled":false},"semantic":{"config_source":"default","enabled":false,"reason":"semantic_disabled","embed_policy":{"source":"dynamic_quiet"}}}
+exit /b 0
+
+:foreground_delivery
+call :write_analytics || exit /b 86
+echo {"read_only":true,"daemon":{"enabled":true},"upgrade":{"auto":"off","auto_enabled":false},"semantic":{"config_source":"default","enabled":false,"reason":"semantic_disabled","embed_policy":{"source":"dynamic_quiet"}}}
+exit /b 0
+
+:daemon
+if not "%2"=="run" exit /b 88
+if not "%CTX_ANALYTICS_ENABLED%"=="" exit /b 91
+if not "%CTX_UPGRADE_AUTO%"=="off" exit /b 92
+if not "%CTX_DAEMON_ENABLED%"=="true" exit /b 90
+if not "%CTX_DAEMON_MODE%"=="source-refresh-only" exit /b 87
+if not "%CTX_SEARCH_SEMANTIC%"=="0" exit /b 96
+if /I "%~n0"=="ctx-no-analytics-delivery" goto daemon_wait
+call :write_analytics || exit /b 86
+:daemon_wait
+if not "%CTX_NATIVE_CANDIDATE_TEST_ANALYTICS_DAEMON_PID%"=="" powershell.exe -NoLogo -NoProfile -NonInteractive -Command "[IO.File]::WriteAllText($env:CTX_NATIVE_CANDIDATE_TEST_ANALYTICS_DAEMON_PID, [string]$PID); Start-Sleep -Seconds 30"
+ping -n 30 127.0.0.1 >nul
+exit /b 0
+
+:write_analytics
+set "CTX_FAKE_ANALYTICS_PAYLOAD={"events":[{"event_name":"operation_completed","event_version":1,"surface":"cli","operation":"status","outcome":"success","event_id":"11111111-1111-4111-8111-111111111111"}]}"
+powershell.exe -NoLogo -NoProfile -NonInteractive -Command "[IO.File]::WriteAllText(([Uri]$env:CTX_ANALYTICS_ENDPOINT).LocalPath, $env:CTX_FAKE_ANALYTICS_PAYLOAD + [Environment]::NewLine)"
+exit /b %errorlevel%
 '@ | Set-Content -LiteralPath $fake -Encoding Ascii
 
     $fixture = Join-Path $root "fixture.jsonl"
@@ -112,13 +155,64 @@ exit /b 99
         throw "candidate smoke result contains unexpected top-level keys"
     }
     $stepKeys = @($parsed.steps.PSObject.Properties.Name)
-    if (($stepKeys -join ",") -ne "version,setup,import,search,read_only,semantic_offline_fail_closed") {
+    if (($stepKeys -join ",") -ne "version,setup,import,search,read_only,released_defaults,explicit_opt_outs,semantic_offline_fail_closed") {
         throw "candidate smoke result contains unexpected step keys"
     }
     foreach ($key in $stepKeys) {
         if ($parsed.steps.$key -ne "passed") {
             throw "candidate smoke step did not pass: $key"
         }
+    }
+
+    $foregroundAnalyticsFake = Join-Path $root "ctx-foreground-analytics.cmd"
+    Copy-Item -LiteralPath $fake -Destination $foregroundAnalyticsFake
+    $foregroundAnalyticsResult = Join-Path $root "foreground-analytics-result.json"
+    try {
+        & $smoke -Binary $foregroundAnalyticsFake -Fixture $fixture `
+            -ExpectedVersion 0.25.0 -ResultPath $foregroundAnalyticsResult 2>$null | Out-Null
+        throw "candidate smoke accepted foreground analytics delivery"
+    } catch {
+        if ($_.Exception.Message -notmatch "foreground CLI delivered analytics before daemon ownership") {
+            throw
+        }
+    }
+    if (Test-Path -LiteralPath $foregroundAnalyticsResult) {
+        throw "candidate smoke wrote evidence after foreground analytics delivery"
+    }
+
+    $noAnalyticsDeliveryFake = Join-Path $root "ctx-no-analytics-delivery.cmd"
+    Copy-Item -LiteralPath $fake -Destination $noAnalyticsDeliveryFake
+    $noAnalyticsDeliveryResult = Join-Path $root "no-analytics-delivery-result.json"
+    $analyticsDaemonPidPath = Join-Path $root "analytics-daemon.pid"
+    $savedTimeout = $env:CTX_NATIVE_CANDIDATE_COMMAND_TIMEOUT_SECONDS
+    $env:CTX_NATIVE_CANDIDATE_COMMAND_TIMEOUT_SECONDS = "3"
+    $env:CTX_NATIVE_CANDIDATE_TEST_ANALYTICS_DAEMON_PID = $analyticsDaemonPidPath
+    $started = Get-Date
+    try {
+        & $smoke -Binary $noAnalyticsDeliveryFake -Fixture $fixture `
+            -ExpectedVersion 0.25.0 -ResultPath $noAnalyticsDeliveryResult 2>$null | Out-Null
+        throw "candidate smoke accepted an analytics daemon that did not deliver"
+    } catch {
+        if ($_.Exception.Message -notmatch
+            "exceeded 3 seconds during analytics delivery; owned tree termination completed; final drain completed") {
+            throw
+        }
+    } finally {
+        $env:CTX_NATIVE_CANDIDATE_COMMAND_TIMEOUT_SECONDS = $savedTimeout
+        $env:CTX_NATIVE_CANDIDATE_TEST_ANALYTICS_DAEMON_PID = $null
+    }
+    if (((Get-Date) - $started).TotalSeconds -ge 10) {
+        throw "candidate analytics delivery timeout was not bounded"
+    }
+    if (Test-Path -LiteralPath $noAnalyticsDeliveryResult) {
+        throw "candidate smoke wrote evidence after analytics delivery timeout"
+    }
+    if (-not (Test-Path -LiteralPath $analyticsDaemonPidPath -PathType Leaf)) {
+        throw "analytics daemon survivor fixture did not start"
+    }
+    $analyticsDaemonPid = [int](Get-Content -LiteralPath $analyticsDaemonPidPath -Raw)
+    if ($null -ne (Get-Process -Id $analyticsDaemonPid -ErrorAction SilentlyContinue)) {
+        throw "candidate smoke left the timed-out analytics daemon tree running"
     }
 
     $freshEpochFake = Join-Path $root "ctx-v1.cmd"
@@ -135,10 +229,23 @@ exit /b 99
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 
 public static class CtxManagedPairFake {
+    private const string AnalyticsPayload = "{\"events\":[{\"event_name\":\"operation_completed\",\"event_version\":1,\"surface\":\"cli\",\"operation\":\"status\",\"outcome\":\"success\",\"event_id\":\"11111111-1111-4111-8111-111111111111\"}]}";
+
     private static bool Has(string[] args, string value) {
         return Array.IndexOf(args, value) >= 0;
+    }
+
+    private static void WriteOutbox() {
+        string root = Path.Combine(Environment.GetEnvironmentVariable("XDG_STATE_HOME"), "ctx");
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "analytics-outbox-v1.json"), "{\"schema_version\":2,\"entries\":[{\"kind\":\"ordinary\",\"payload\":" + Quote(AnalyticsPayload) + "}]}");
+    }
+
+    private static string Quote(string value) {
+        return "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
     }
 
     public static int Main(string[] args) {
@@ -181,8 +288,19 @@ public static class CtxManagedPairFake {
             Console.WriteLine("{\"retrieval\":{\"requested_mode\":\"lexical\",\"effective_mode\":\"lexical\"},\"results\":[{\"text\":\"Add a parser test.\"}]}");
             return 0;
         }
+        if (args.Length > 1 && args[0] == "daemon" && args[1] == "run") {
+            File.WriteAllText(new Uri(Environment.GetEnvironmentVariable("CTX_ANALYTICS_ENDPOINT")).LocalPath, AnalyticsPayload + Environment.NewLine);
+            Thread.Sleep(30000);
+            return 0;
+        }
         if (args.Length > 0 && args[0] == "status") {
-            Console.WriteLine("{\"read_only\":true,\"managed_upgrade\":{\"auto\":\"apply\",\"auto_enabled\":true},\"semantic\":{\"config_source\":\"default\",\"reason\":\"semantic_disabled\"}}");
+            if (Environment.GetEnvironmentVariable("CTX_ANALYTICS_ENABLED") == null) {
+                if (Environment.GetEnvironmentVariable("CTX_DAEMON_AUTOSTART_OFF") != "1") return 97;
+                WriteOutbox();
+                Console.WriteLine("{\"read_only\":true,\"daemon\":{\"enabled\":true},\"upgrade\":{\"auto\":\"apply\",\"auto_enabled\":true},\"semantic\":{\"config_source\":\"default\",\"reason\":\"semantic_disabled\",\"embed_policy\":{\"source\":\"dynamic_quiet\"}}}");
+            } else {
+                Console.WriteLine("{\"read_only\":true,\"daemon\":{\"enabled\":false},\"upgrade\":{\"auto\":\"off\",\"auto_enabled\":false},\"semantic\":{\"config_source\":\"default\",\"reason\":\"semantic_disabled\",\"embed_policy\":{\"source\":\"dynamic_quiet\"}}}");
+            }
             return 0;
         }
         return 99;
@@ -293,6 +411,8 @@ using System.IO;
 using System.Threading;
 
 public static class CtxPipeOwner {
+    private const string AnalyticsPayload = "{\"events\":[{\"event_name\":\"operation_completed\",\"event_version\":1,\"surface\":\"cli\",\"operation\":\"status\",\"outcome\":\"success\",\"event_id\":\"11111111-1111-4111-8111-111111111111\"}]}";
+
     private static bool HasArgument(string[] args, string expected) {
         foreach (string arg in args) {
             if (String.Equals(arg, expected, StringComparison.OrdinalIgnoreCase)) {
@@ -308,8 +428,10 @@ public static class CtxPipeOwner {
             Thread.Sleep(30000);
             return 0;
         }
-        if (Environment.GetEnvironmentVariable("CTX_ANALYTICS_ENABLED") != "false") return 91;
-        if (Environment.GetEnvironmentVariable("CTX_UPGRADE_AUTO") != "off") return 92;
+        if (mode != "status" && mode != "daemon" &&
+            Environment.GetEnvironmentVariable("CTX_ANALYTICS_ENABLED") != "false") return 91;
+        if (mode != "status" && mode != "daemon" &&
+            Environment.GetEnvironmentVariable("CTX_UPGRADE_AUTO") != "off") return 92;
         if (Environment.GetEnvironmentVariable("CTX_DAEMON_AUTOSTART_OFF") != "1") return 93;
         if (String.IsNullOrEmpty(Environment.GetEnvironmentVariable("HOME"))) return 94;
         if (String.IsNullOrEmpty(Environment.GetEnvironmentVariable("USERPROFILE"))) return 95;
@@ -355,10 +477,20 @@ public static class CtxPipeOwner {
             Console.WriteLine("{\"retrieval\":{\"requested_mode\":\"lexical\",\"effective_mode\":\"lexical\"},\"results\":[{\"text\":\"Add a parser test.\"}]}");
             return 0;
         }
+        if (mode == "daemon") {
+            File.WriteAllText(new Uri(Environment.GetEnvironmentVariable("CTX_ANALYTICS_ENDPOINT")).LocalPath, AnalyticsPayload + Environment.NewLine);
+            Thread.Sleep(30000);
+            return 0;
+        }
         if (mode == "status") {
-            if (Environment.GetEnvironmentVariable("CTX_SEARCH_SEMANTIC") != null) return 89;
-            if (Environment.GetEnvironmentVariable("CTX_DAEMON_ENABLED") != null) return 90;
-            Console.WriteLine("{\"read_only\":true,\"semantic\":{\"config_source\":\"default\",\"enabled\":false,\"reason\":\"semantic_disabled\",\"embed_policy\":{\"source\":\"dynamic_quiet\"}}}");
+            if (Environment.GetEnvironmentVariable("CTX_ANALYTICS_ENABLED") == null) {
+                string state = Path.Combine(Environment.GetEnvironmentVariable("XDG_STATE_HOME"), "ctx");
+                Directory.CreateDirectory(state);
+                File.WriteAllText(Path.Combine(state, "analytics-outbox-v1.json"), "{\"schema_version\":2,\"entries\":[{\"kind\":\"ordinary\",\"payload\":\"{\\\"events\\\":[{\\\"event_name\\\":\\\"operation_completed\\\",\\\"event_version\\\":1,\\\"surface\\\":\\\"cli\\\",\\\"operation\\\":\\\"status\\\",\\\"outcome\\\":\\\"success\\\",\\\"event_id\\\":\\\"11111111-1111-4111-8111-111111111111\\\"}]}\"}]}");
+                Console.WriteLine("{\"read_only\":true,\"daemon\":{\"enabled\":true},\"upgrade\":{\"auto\":\"off\",\"auto_enabled\":false},\"semantic\":{\"config_source\":\"default\",\"reason\":\"semantic_disabled\",\"embed_policy\":{\"source\":\"dynamic_quiet\"}}}");
+            } else {
+                Console.WriteLine("{\"read_only\":true,\"daemon\":{\"enabled\":false},\"upgrade\":{\"auto\":\"off\",\"auto_enabled\":false},\"semantic\":{\"config_source\":\"default\",\"reason\":\"semantic_disabled\",\"embed_policy\":{\"source\":\"dynamic_quiet\"}}}");
+            }
             return 0;
         }
         return 99;

--- a/scripts/tests/run-native-candidate-smoke-test.sh
+++ b/scripts/tests/run-native-candidate-smoke-test.sh
@@ -82,9 +82,37 @@ snapshot_tree() {
 }
 
 process_ids_for_command_path() {
-  ps -axo pid=,command= 2>/dev/null \
-    | awk -v executable="$1" '$2 == executable || $3 == executable { print $1 }' \
-    | LC_ALL=C sort -n
+  ps -axo pid=,command= > "${tmp}/processes.snapshot" 2>/dev/null
+  awk -v executable="$1" '
+    {
+      pid = $1
+      sub(/^[[:space:]]*[0-9]+[[:space:]]+/, "", $0)
+      start = index($0, executable)
+      after = start + length(executable)
+      if (start > 0 \
+          && (start == 1 || substr($0, start - 1, 1) == " ") \
+          && (after > length($0) || substr($0, after, 1) == " ")) {
+        print pid
+      }
+    }
+  ' "${tmp}/processes.snapshot" | LC_ALL=C sort -n
+}
+
+assert_no_candidate_processes_in_tmpdir() {
+  local candidate_root_fragment="$1"
+  local remaining
+  ps -axo pid=,command= > "${tmp}/processes.snapshot" 2>/dev/null
+  remaining="$(
+    awk -v fragment="${candidate_root_fragment}" \
+      'index($0, fragment) { print $1 }' "${tmp}/processes.snapshot" \
+      | LC_ALL=C sort -n
+  )"
+  if [[ -n "${remaining}" ]]; then
+    kill -KILL ${remaining} 2>/dev/null || true
+    printf 'candidate smoke left space-path processes running: %s\n' \
+      "${remaining}" >&2
+    exit 1
+  fi
 }
 
 cat > "${fake_template}" <<'EOF'
@@ -302,10 +330,13 @@ JSON
     test "${2:-}" = run
     analytics_outbox="${XDG_STATE_HOME}/ctx/analytics-outbox-v1.json"
     test -s "${analytics_outbox}"
-    trap 'exit 0' 1 2 15
     case "${0##*/}" in
-      *no-analytics-delivery*) ;;
+      *no-analytics-delivery*)
+        trap '' 1 2 15
+        while :; do :; done
+        ;;
       *)
+        trap 'exit 0' 1 2 15
         analytics_path="${CTX_ANALYTICS_ENDPOINT#file://}"
         printf '%s\n' '{"events":[{"event_name":"operation_completed","event_version":1,"surface":"cli","operation":"status","outcome":"success","event_id":"11111111-1111-4111-8111-111111111111"}]}' \
           > "${analytics_path}"
@@ -342,13 +373,15 @@ result="${tmp}/result.json"
 "${smoke}" "${fake}" "${tmp}/fixture.jsonl" 0.25.0 "${result}" >/dev/null
 assert_passed_result "${result}"
 
-setgid_tmp="${tmp}/setgid-task-parent"
-mkdir -p "${setgid_tmp}"
-chmod 2700 "${setgid_tmp}"
-setgid_result="${tmp}/setgid-result.json"
-TMPDIR="${setgid_tmp}" "${smoke}" \
-  "${fake}" "${tmp}/fixture.jsonl" 0.25.0 "${setgid_result}" >/dev/null
-assert_passed_result "${setgid_result}"
+space_tmp="${tmp}/setgid task parent"
+mkdir -p "${space_tmp}"
+chmod 2700 "${space_tmp}"
+space_result="${tmp}/space-result.json"
+TMPDIR="${space_tmp}" "${smoke}" \
+  "${fake}" "${tmp}/fixture.jsonl" 0.25.0 "${space_result}" >/dev/null
+assert_passed_result "${space_result}"
+assert_no_candidate_processes_in_tmpdir \
+  "${space_tmp}/ctx-native-candidate-smoke."
 
 foreground_analytics_fake="${tmp}/ctx-foreground-analytics"
 make_fake "${foreground_analytics_fake}"
@@ -367,7 +400,8 @@ no_analytics_delivery_fake="${tmp}/ctx-no-analytics-delivery"
 make_fake "${no_analytics_delivery_fake}"
 no_analytics_delivery_result="${tmp}/no-analytics-delivery-result.json"
 started="$(date +%s)"
-if CTX_NATIVE_CANDIDATE_COMMAND_TIMEOUT_SECONDS=1 "${smoke}" \
+if TMPDIR="${space_tmp}" CTX_NATIVE_CANDIDATE_COMMAND_TIMEOUT_SECONDS=1 \
+  "${smoke}" \
   "${no_analytics_delivery_fake}" "${tmp}/fixture.jsonl" 0.25.0 \
   "${no_analytics_delivery_result}" >"${tmp}/no-analytics-delivery.out" \
   2>"${tmp}/no-analytics-delivery.err"; then
@@ -382,6 +416,8 @@ elapsed="$(( $(date +%s) - started ))"
 grep -Fq 'daemon did not deliver queued status analytics within 1 seconds' \
   "${tmp}/no-analytics-delivery.err"
 test ! -e "${no_analytics_delivery_result}"
+assert_no_candidate_processes_in_tmpdir \
+  "${space_tmp}/ctx-native-candidate-smoke."
 
 ctx_v1_parent="${tmp}/ctx-v1-parent"
 mkdir -p "${ctx_v1_parent}"

--- a/scripts/tests/run-native-candidate-smoke-test.sh
+++ b/scripts/tests/run-native-candidate-smoke-test.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
+umask 077
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 smoke="${repo_root}/scripts/run-native-candidate-smoke.sh"
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/ctx-native-smoke-test.XXXXXX")"
+chmod 0700 "${tmp}"
+chmod u-s,g-s,o-t "${tmp}"
 
 cleanup_survivor_fixture() {
   local survivor_pids
@@ -112,12 +115,19 @@ test -n "${HOME:-}"
 test -n "${XDG_CONFIG_HOME:-}"
 test -n "${XDG_CACHE_HOME:-}"
 test "${HOME}" != "${ORIGINAL_HOME:-not-in-clean-env}"
-if data_root_mode="$(stat -c '%a' "${CTX_DATA_ROOT}" 2>/dev/null)"; then
-  :
-else
-  data_root_mode="$(stat -f '%Lp' "${CTX_DATA_ROOT}")"
-fi
-test "${data_root_mode}" = 700
+for private_dir in "${CTX_DATA_ROOT%/*}" "${CTX_DATA_ROOT}" "${HOME}" \
+  "${XDG_CONFIG_HOME}" "${XDG_CACHE_HOME}" "${XDG_STATE_HOME}" "${TMPDIR}" "${PWD}"; do
+  if private_mode="$(stat -c '%a' "${private_dir}" 2>/dev/null)"; then
+    :
+  else
+    private_mode="$(stat -f '%Lp' "${private_dir}")"
+  fi
+  if test "${private_mode}" != 700; then
+    printf 'private candidate directory is mode %s, not 700: %s\n' \
+      "${private_mode}" "${private_dir}" >&2
+    exit 1
+  fi
+done
 
 case "${0##*/}" in
   *ctx-hang*)
@@ -149,6 +159,13 @@ case " $* " in
     test "${CTX_DAEMON_ENABLED:-}" = 1
     printf '%s\n' 'semantic-only search will not initialize or download intfloat/multilingual-e5-small during search' >&2
     exit 1
+    ;;
+  *" daemon run "*)
+    test "${CTX_ANALYTICS_ENABLED+x}" != x
+    test "${CTX_UPGRADE_AUTO:-}" = off
+    test "${CTX_DAEMON_ENABLED:-}" = true
+    test "${CTX_DAEMON_MODE:-}" = source-refresh-only
+    test "${CTX_SEARCH_SEMANTIC:-}" = 0
     ;;
   *" status --format json "*)
     test -z "${CTX_SEARCH_SEMANTIC:-}"
@@ -208,7 +225,20 @@ case "${1:-}" in
   status)
     if test "${CTX_ANALYTICS_ENABLED+x}" != x; then
       analytics_path="${CTX_ANALYTICS_ENDPOINT#file://}"
-      printf '%s\n' '{"events":[{"event_name":"operation_completed"}]}' > "${analytics_path}"
+      analytics_payload='{"events":[{"event_name":"operation_completed","event_version":1,"surface":"cli","operation":"status","outcome":"success","event_id":"11111111-1111-4111-8111-111111111111"}]}'
+      case "${0##*/}" in
+        *foreground-analytics*)
+          printf '%s\n' "${analytics_payload}" > "${analytics_path}"
+          ;;
+        *)
+          analytics_outbox="${XDG_STATE_HOME}/ctx/analytics-outbox-v1.json"
+          mkdir -p "${analytics_outbox%/*}"
+          chmod 0700 "${analytics_outbox%/*}"
+          printf '%s\n' '{"schema_version":2,"entries":[{"schema_version":2,"entry_id":"22222222-2222-4222-8222-222222222222","endpoint_fingerprint":"fixture","queued_at_epoch_seconds":1800000000,"attempts":0,"next_attempt_at_epoch_seconds":0,"kind":"ordinary","payload":"{\"events\":[{\"event_name\":\"operation_completed\",\"event_version\":1,\"surface\":\"cli\",\"operation\":\"status\",\"outcome\":\"success\",\"event_id\":\"11111111-1111-4111-8111-111111111111\"}]}"}],"retry_attempts":0,"dropped":0,"failure_sequence":0,"last_failure_class":null,"observation_due":false}' \
+            > "${analytics_outbox}"
+          chmod 0600 "${analytics_outbox}"
+          ;;
+      esac
       upgrade_auto=off
       upgrade_enabled=false
       if test -f "$0.install.json"; then
@@ -268,6 +298,21 @@ JSON
 JSON
     fi
     ;;
+  daemon)
+    test "${2:-}" = run
+    analytics_outbox="${XDG_STATE_HOME}/ctx/analytics-outbox-v1.json"
+    test -s "${analytics_outbox}"
+    trap 'exit 0' 1 2 15
+    case "${0##*/}" in
+      *no-analytics-delivery*) ;;
+      *)
+        analytics_path="${CTX_ANALYTICS_ENDPOINT#file://}"
+        printf '%s\n' '{"events":[{"event_name":"operation_completed","event_version":1,"surface":"cli","operation":"status","outcome":"success","event_id":"11111111-1111-4111-8111-111111111111"}]}' \
+          > "${analytics_path}"
+        ;;
+    esac
+    while :; do sleep 1; done
+    ;;
   --survivor-child)
     sleep 30
     ;;
@@ -296,6 +341,47 @@ make_fake "${fake}"
 result="${tmp}/result.json"
 "${smoke}" "${fake}" "${tmp}/fixture.jsonl" 0.25.0 "${result}" >/dev/null
 assert_passed_result "${result}"
+
+setgid_tmp="${tmp}/setgid-task-parent"
+mkdir -p "${setgid_tmp}"
+chmod 2700 "${setgid_tmp}"
+setgid_result="${tmp}/setgid-result.json"
+TMPDIR="${setgid_tmp}" "${smoke}" \
+  "${fake}" "${tmp}/fixture.jsonl" 0.25.0 "${setgid_result}" >/dev/null
+assert_passed_result "${setgid_result}"
+
+foreground_analytics_fake="${tmp}/ctx-foreground-analytics"
+make_fake "${foreground_analytics_fake}"
+foreground_analytics_result="${tmp}/foreground-analytics-result.json"
+if "${smoke}" "${foreground_analytics_fake}" "${tmp}/fixture.jsonl" 0.25.0 \
+  "${foreground_analytics_result}" >"${tmp}/foreground-analytics.out" \
+  2>"${tmp}/foreground-analytics.err"; then
+  printf 'candidate smoke accepted foreground analytics delivery\n' >&2
+  exit 1
+fi
+grep -Fq 'foreground CLI delivered analytics before daemon ownership' \
+  "${tmp}/foreground-analytics.err"
+test ! -e "${foreground_analytics_result}"
+
+no_analytics_delivery_fake="${tmp}/ctx-no-analytics-delivery"
+make_fake "${no_analytics_delivery_fake}"
+no_analytics_delivery_result="${tmp}/no-analytics-delivery-result.json"
+started="$(date +%s)"
+if CTX_NATIVE_CANDIDATE_COMMAND_TIMEOUT_SECONDS=1 "${smoke}" \
+  "${no_analytics_delivery_fake}" "${tmp}/fixture.jsonl" 0.25.0 \
+  "${no_analytics_delivery_result}" >"${tmp}/no-analytics-delivery.out" \
+  2>"${tmp}/no-analytics-delivery.err"; then
+  printf 'candidate smoke accepted an analytics daemon that did not deliver\n' >&2
+  exit 1
+fi
+elapsed="$(( $(date +%s) - started ))"
+[[ "${elapsed}" -lt 10 ]] || {
+  printf 'candidate analytics delivery timeout was not bounded: %ss\n' "${elapsed}" >&2
+  exit 1
+}
+grep -Fq 'daemon did not deliver queued status analytics within 1 seconds' \
+  "${tmp}/no-analytics-delivery.err"
+test ! -e "${no_analytics_delivery_result}"
 
 ctx_v1_parent="${tmp}/ctx-v1-parent"
 mkdir -p "${ctx_v1_parent}"

--- a/scripts/tests/smoke-daemon-semantic-release-test.sh
+++ b/scripts/tests/smoke-daemon-semantic-release-test.sh
@@ -455,6 +455,8 @@ grep -Fq -- \
   "${tmp}/non-authoritative.err"
 
 run_parent="${tmp}/runs"
+mkdir -p "${run_parent}"
+chmod 02700 "${run_parent}"
 coreml_bind_log="${tmp}/coreml-bind.log"
 CTX_TEST_RUNTIME_EVIDENCE=macos-arm64-native-virtualized \
 CTX_TEST_COREML_BIND_LOG="${coreml_bind_log}" "${smoke}" \
@@ -482,13 +484,16 @@ grep -Fq -- \
   'archive_sha256=25fbf333d1e72f5c075973ef968dfa1446459f61f3ac63ef3690d9865435af17' \
   "${tmp}/coreml.out"
 [[ ! -e "${run_root}/data/runtime/onnxruntime" ]]
-python3 -I - "${run_root}/installed/bin" <<'PY'
+python3 -I - "${run_root}" "${run_root}/installed/bin" <<'PY'
 import os
 import stat
 import sys
 
-path = sys.argv[1]
-mode = stat.S_IMODE(os.stat(path).st_mode)
+run_root, executable_directory = sys.argv[1:]
+mode = stat.S_IMODE(os.stat(run_root).st_mode)
+if mode != 0o700:
+    raise SystemExit(f"semantic smoke run root mode is not canonical: {mode:o}")
+mode = stat.S_IMODE(os.stat(executable_directory).st_mode)
 if mode & 0o022:
     raise SystemExit(f"semantic smoke executable directory is not owner-safe: {mode:o}")
 PY
@@ -589,16 +594,51 @@ artifact.with_name(f"{artifact.name}.build-info.json").write_text(
 )
 PY
 
-runtime_payload="${tmp}/runtime-payload"
+runtime_parent="${tmp}/runtime-parent"
+mkdir -p "${runtime_parent}"
+chmod 02700 "${runtime_parent}"
+runtime_payload="${runtime_parent}/runtime-payload"
 mkdir -p "${runtime_payload}/lib"
+python3 -I - "${runtime_payload}/lib" <<'PY'
+import os
+import stat
+import sys
+
+mode = stat.S_IMODE(os.stat(sys.argv[1]).st_mode)
+if not mode & stat.S_ISGID:
+    raise SystemExit(f"semantic archive fixture did not inherit setgid: {mode:o}")
+PY
 printf 'license\n' > "${runtime_payload}/LICENSE"
 printf 'notices\n' > "${runtime_payload}/ThirdPartyNotices.txt"
 printf '1.27.0\n' > "${runtime_payload}/VERSION_NUMBER"
 printf 'synthetic-commit\n' > "${runtime_payload}/GIT_COMMIT_ID"
 printf 'synthetic runtime\n' > "${runtime_payload}/lib/libonnxruntime.so"
+chmod 00644 \
+  "${runtime_payload}/LICENSE" \
+  "${runtime_payload}/ThirdPartyNotices.txt" \
+  "${runtime_payload}/VERSION_NUMBER" \
+  "${runtime_payload}/GIT_COMMIT_ID"
+chmod 00755 "${runtime_payload}/lib" "${runtime_payload}/lib/libonnxruntime.so"
 runtime_archive="${tmp}/ctx-onnxruntime-linux-x64.tar.gz"
 tar --no-recursion -C "${runtime_payload}" -czf "${runtime_archive}" \
   LICENSE ThirdPartyNotices.txt VERSION_NUMBER GIT_COMMIT_ID lib lib/libonnxruntime.so
+python3 -I - "${runtime_archive}" <<'PY'
+import sys
+import tarfile
+
+expected = {
+    "LICENSE": 0o644,
+    "ThirdPartyNotices.txt": 0o644,
+    "VERSION_NUMBER": 0o644,
+    "GIT_COMMIT_ID": 0o644,
+    "lib": 0o755,
+    "lib/libonnxruntime.so": 0o755,
+}
+with tarfile.open(sys.argv[1], "r:gz") as bundle:
+    actual = {member.name: member.mode for member in bundle.getmembers()}
+if actual != expected:
+    raise SystemExit(f"semantic runtime archive modes are not canonical: {actual!r}")
+PY
 if command -v sha256sum >/dev/null 2>&1; then
   sha256sum "${runtime_archive}" | awk '{ print $1 }' > "${runtime_archive}.sha256"
 else

--- a/scripts/tests/stage-github-release-assets-test.sh
+++ b/scripts/tests/stage-github-release-assets-test.sh
@@ -188,7 +188,7 @@ for platform in linux-x64 linux-aarch64 macos-arm64 macos-x64 windows-x64; do
   [[ "${platform}" == "linux-x64" ]] && binary="ctx"
   [[ "${platform}" == "windows-x64" ]] && binary="ctx.exe"
   mkdir -p "${proof_root}/${platform}"
-  printf '%s\n' '{"kind":"ctx-native-candidate-smoke","schema_version":1,"status":"passed"}' \
+  printf '%s\n' '{"kind":"ctx-native-candidate-smoke","schema_version":1,"status":"passed","steps":{"version":"passed","setup":"passed","import":"passed","search":"passed","read_only":"passed","released_defaults":"passed","explicit_opt_outs":"passed","semantic_offline_fail_closed":"passed"}}' \
     > "${proof_root}/${platform}/candidate-smoke.json"
   CTX_NATIVE_PROOF_ARTIFACT="${matrix}/${binary}" \
     "${real_python3}" -I "${source_root}/scripts/native-execution-proof.py" create \


### PR DESCRIPTION
## Summary

- make Unix and Windows native candidate smoke deterministic, lifecycle-bounded, and independent of ambient analytics/test state
- bound Unix response socket fixture paths, canonicalize release/signing fixture modes, and isolate generation cache tests
- harden Windows analytics outbox replacement so restricted directories retain a usable WRITE_DAC path

## Validation

- focused corrections: 8/8 targets
- affected suite: 90/90 targets
- public CI: 211/211 targets, 209/209 test cases
- public nightly and release: 221/221 targets, 219/219 test cases each
- policy/disclosure: 12/12 targets; exact-candidate LOC gate passed
- native Windows smoke passed against the unchanged product and Windows source tree

Follow-up to the release-contract work in #147. This does not change version or release metadata and does not publish a release.