### PR TITLE
fix(release): honor semantic smoke import timeout

### DIFF
--- a/scripts/smoke-daemon-semantic-release.sh
+++ b/scripts/smoke-daemon-semantic-release.sh
@@ -31,7 +31,14 @@ runtime_archive=""
 coreml_archive=""
 runtime_platform=""
 runtime_version="1.27.0"
-timeout_seconds="${CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS:-900}"
+timeout_max_seconds=900
+if [[ "${CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS+x}" == "x" ]]; then
+  timeout_seconds="${CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS}"
+  timeout_source="CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS"
+else
+  timeout_seconds=900
+  timeout_source="--timeout-seconds"
+fi
 keep_root=0
 coreml_mode=0
 require_authoritative=0
@@ -67,6 +74,7 @@ while (($# > 0)); do
     --timeout-seconds)
       shift
       timeout_seconds="${1:-}"
+      timeout_source="--timeout-seconds"
       ;;
     --keep-root)
       keep_root=1
@@ -91,8 +99,16 @@ if [[ -z "${runtime_platform}" ]]; then
   echo "error: --runtime-platform is required" >&2
   exit 2
 fi
-if [[ ! "${timeout_seconds}" =~ ^[0-9]+$ ]] || ((timeout_seconds < 30)); then
-  echo "error: --timeout-seconds must be an integer >= 30" >&2
+timeout_is_valid=1
+if [[ ! "${timeout_seconds}" =~ ^[1-9][0-9]*$ ]]; then
+  timeout_is_valid=0
+elif ((${#timeout_seconds} > 3)); then
+  timeout_is_valid=0
+elif ((timeout_seconds < 30 || timeout_seconds > timeout_max_seconds)); then
+  timeout_is_valid=0
+fi
+if [[ "${timeout_is_valid}" != "1" ]]; then
+  echo "error: ${timeout_source} must be a canonical integer between 30 and 900 seconds" >&2
   exit 2
 fi
 
@@ -187,16 +203,68 @@ fi
 unset LD_LIBRARY_PATH DYLD_LIBRARY_PATH LD_PRELOAD DYLD_INSERT_LIBRARIES \
   DYLD_FORCE_FLAT_NAMESPACE DYLD_FALLBACK_LIBRARY_PATH
 
+nanoseconds_per_second=1000000000
+monotonic_ns() {
+  python3 -I -c 'import time; print(time.monotonic_ns())'
+}
+
+deadline_after_seconds() {
+  local duration_seconds="$1"
+  local maximum_deadline_ns="${2:-}"
+  local now_ns
+  local result_ns
+
+  now_ns="$(monotonic_ns)"
+  if [[ ! "${now_ns}" =~ ^[1-9][0-9]*$ ]] || ((${#now_ns} > 18)); then
+    echo "error: monotonic clock returned an invalid value" >&2
+    return 1
+  fi
+  result_ns=$((now_ns + duration_seconds * nanoseconds_per_second))
+  if [[ -n "${maximum_deadline_ns}" ]] && ((result_ns > maximum_deadline_ns)); then
+    result_ns="${maximum_deadline_ns}"
+  fi
+  printf '%s\n' "${result_ns}"
+}
+
+remaining_ns() {
+  local deadline_ns="$1"
+  local now_ns
+
+  now_ns="$(monotonic_ns)"
+  if [[ ! "${now_ns}" =~ ^[1-9][0-9]*$ ]] || ((${#now_ns} > 18)); then
+    echo "error: monotonic clock returned an invalid value" >&2
+    return 1
+  fi
+  if ((now_ns >= deadline_ns)); then
+    printf '0\n'
+  else
+    printf '%s\n' "$((deadline_ns - now_ns))"
+  fi
+}
+
+decimal_seconds_from_ns() {
+  local duration_ns="$1"
+  printf '%d.%09d\n' \
+    "$((duration_ns / nanoseconds_per_second))" \
+    "$((duration_ns % nanoseconds_per_second))"
+}
+
 run_bounded() {
-  local limit_seconds="$1"
+  local deadline_ns="$1"
   shift
-  python3 -I - "${limit_seconds}" "$@" <<'PY'
+  python3 -I - "${deadline_ns}" "$@" <<'PY'
 import subprocess
 import os
 import re
 import sys
+import time
 
-limit = int(sys.argv[1])
+deadline_ns = int(sys.argv[1])
+remaining_ns = deadline_ns - time.monotonic_ns()
+if remaining_ns <= 0:
+    print("error: smoke command exceeded monotonic deadline", file=sys.stderr)
+    raise SystemExit(124)
+limit = remaining_ns / 1_000_000_000
 command = sys.argv[2:]
 pass_fds = set()
 for argument in command:
@@ -212,7 +280,7 @@ try:
         pass_fds=tuple(sorted(pass_fds)),
     )
 except subprocess.TimeoutExpired:
-    print(f"error: smoke command exceeded {limit} seconds", file=sys.stderr)
+    print("error: smoke command exceeded monotonic deadline", file=sys.stderr)
     raise SystemExit(124)
 raise SystemExit(result.returncode)
 PY
@@ -310,7 +378,8 @@ fi
   echo "error: ctx binary is not executable: ${ctx_source}" >&2
   exit 1
 }
-ctx_version="$(run_bounded 30 "${ctx_source}" --version | awk 'NR == 1 { print $2 }')"
+version_deadline_ns="$(deadline_after_seconds 30)"
+ctx_version="$(run_bounded "${version_deadline_ns}" "${ctx_source}" --version | awk 'NR == 1 { print $2 }')"
 [[ -n "${ctx_version}" ]] || {
   echo "error: could not determine ctx version from ${ctx_source}" >&2
   exit 1
@@ -539,8 +608,16 @@ else
   ctx_env+=(CTX_INTERNAL_SEMANTIC_BACKEND=cpu)
 fi
 
+deadline_ns="$(deadline_after_seconds "${timeout_seconds}")"
 run_ctx() {
-  run_bounded 30 "${ctx_env[@]}" "${ctx_bin}" --data-root "${data_root}" "$@"
+  local operation_remaining_ns
+  operation_remaining_ns="$(remaining_ns "${deadline_ns}")"
+  if ((operation_remaining_ns <= 0)); then
+    echo "error: semantic smoke exceeded ${timeout_seconds} seconds" >&2
+    return 124
+  fi
+  run_bounded "${deadline_ns}" \
+    "${ctx_env[@]}" "${ctx_bin}" --data-root "${data_root}" "$@"
 }
 
 printf 'ctx semantic smoke: isolated_home=%s\n' "${smoke_home}"
@@ -609,9 +686,13 @@ if endpoint.get("transport") not in {"unix", "windows_named_pipe"}:
 PY
 }
 
-startup_deadline=$((SECONDS + 30))
+startup_deadline_ns="$(deadline_after_seconds 30 "${deadline_ns}")"
 daemon_started=0
-while ((SECONDS < startup_deadline)); do
+while :; do
+  startup_remaining_ns="$(remaining_ns "${startup_deadline_ns}")"
+  if ((startup_remaining_ns <= 0)); then
+    break
+  fi
   if ! kill -0 "${daemon_pid}" >/dev/null 2>&1; then
     echo "ctx semantic smoke: daemon exited before source-refresh admission" >&2
     cat "${daemon_log}" >&2 || true
@@ -622,8 +703,20 @@ while ((SECONDS < startup_deadline)); do
     daemon_startup_matches; then
     daemon_started=1
     break
+  else
+    startup_status=$?
+    if [[ "${startup_status}" == "124" ]]; then
+      cat "${daemon_startup_error}" >&2 2>/dev/null || true
+      exit 124
+    fi
   fi
-  sleep 0.1
+  startup_remaining_ns="$(remaining_ns "${startup_deadline_ns}")"
+  if ((startup_remaining_ns <= 0)); then
+    break
+  elif ((startup_remaining_ns > 100000000)); then
+    startup_remaining_ns=100000000
+  fi
+  sleep "$(decimal_seconds_from_ns "${startup_remaining_ns}")"
 done
 if [[ "${daemon_started}" != "1" ]]; then
   echo "ctx semantic smoke: daemon did not expose its source-refresh endpoint" >&2
@@ -633,10 +726,8 @@ if [[ "${daemon_started}" != "1" ]]; then
   exit 1
 fi
 
-run_bounded "${timeout_seconds}" "${ctx_env[@]}" "${ctx_bin}" --data-root "${data_root}" \
-  import --no-daemon --input-format ctx-history-jsonl-v2 --path "${fixture_path}" >/dev/null
+run_ctx import --no-daemon --input-format ctx-history-jsonl-v2 --path "${fixture_path}" >/dev/null
 
-deadline=$((SECONDS + timeout_seconds))
 last_output=""
 last_search_error=""
 last_status_output=""
@@ -721,7 +812,11 @@ if not any(marker in text for result in results for text in strings(result)):
 PY
 }
 
-while ((SECONDS < deadline)); do
+while :; do
+  operation_remaining_ns="$(remaining_ns "${deadline_ns}")"
+  if ((operation_remaining_ns <= 0)); then
+    break
+  fi
   if ! kill -0 "${daemon_pid}" >/dev/null 2>&1; then
     echo "ctx semantic smoke: daemon exited before search succeeded" >&2
     cat "${daemon_log}" >&2 || true
@@ -740,6 +835,12 @@ while ((SECONDS < deadline)); do
         cat "${daemon_status_json}" >&2 || true
         exit 1
       fi
+    fi
+  else
+    status_check=$?
+    if [[ "${status_check}" == "124" ]]; then
+      cat "${daemon_status_error}" >&2 2>/dev/null || true
+      exit 124
     fi
   fi
 
@@ -760,7 +861,10 @@ while ((SECONDS < deadline)); do
         exit 0
       else
         status_check=$?
-        if [[ "${status_check}" == "2" ]]; then
+        if [[ "${status_check}" == "124" ]]; then
+          cat "${daemon_status_error}" >&2 2>/dev/null || true
+          exit 124
+        elif [[ "${status_check}" == "2" ]]; then
           cat "${daemon_status_json}" >&2 || true
           exit 1
         fi
@@ -773,11 +877,23 @@ while ((SECONDS < deadline)); do
       fi
     fi
   else
+    search_status=$?
+    if [[ "${search_status}" == "124" ]]; then
+      cat "${search_error}" >&2 2>/dev/null || true
+      exit 124
+    fi
     last_output="$(cat "${search_json}" 2>/dev/null || true)"
     last_search_error="$(cat "${search_error}" 2>/dev/null || true)"
   fi
 
-  sleep 5
+  operation_remaining_ns="$(remaining_ns "${deadline_ns}")"
+  if ((operation_remaining_ns <= 0)); then
+    break
+  fi
+  if ((operation_remaining_ns > 5000000000)); then
+    operation_remaining_ns=5000000000
+  fi
+  sleep "$(decimal_seconds_from_ns "${operation_remaining_ns}")"
 done
 
 echo "ctx semantic smoke failed: semantic search did not find fixture before timeout" >&2

--- a/scripts/smoke-daemon-semantic-release.sh
+++ b/scripts/smoke-daemon-semantic-release.sh
@@ -539,8 +539,15 @@ else
   ctx_env+=(CTX_INTERNAL_SEMANTIC_BACKEND=cpu)
 fi
 
+deadline=$((SECONDS + timeout_seconds))
 run_ctx() {
-  run_bounded 30 "${ctx_env[@]}" "${ctx_bin}" --data-root "${data_root}" "$@"
+  local remaining_seconds=$((deadline - SECONDS))
+  if ((remaining_seconds <= 0)); then
+    echo "error: semantic smoke exceeded ${timeout_seconds} seconds" >&2
+    return 124
+  fi
+  run_bounded "${remaining_seconds}" \
+    "${ctx_env[@]}" "${ctx_bin}" --data-root "${data_root}" "$@"
 }
 
 printf 'ctx semantic smoke: isolated_home=%s\n' "${smoke_home}"
@@ -610,6 +617,9 @@ PY
 }
 
 startup_deadline=$((SECONDS + 30))
+if ((startup_deadline > deadline)); then
+  startup_deadline="${deadline}"
+fi
 daemon_started=0
 while ((SECONDS < startup_deadline)); do
   if ! kill -0 "${daemon_pid}" >/dev/null 2>&1; then
@@ -622,6 +632,12 @@ while ((SECONDS < startup_deadline)); do
     daemon_startup_matches; then
     daemon_started=1
     break
+  else
+    startup_status=$?
+    if [[ "${startup_status}" == "124" ]]; then
+      cat "${daemon_startup_error}" >&2 2>/dev/null || true
+      exit 124
+    fi
   fi
   sleep 0.1
 done
@@ -635,7 +651,6 @@ fi
 
 run_ctx import --no-daemon --input-format ctx-history-jsonl-v2 --path "${fixture_path}" >/dev/null
 
-deadline=$((SECONDS + timeout_seconds))
 last_output=""
 last_search_error=""
 last_status_output=""
@@ -740,6 +755,12 @@ while ((SECONDS < deadline)); do
         exit 1
       fi
     fi
+  else
+    status_check=$?
+    if [[ "${status_check}" == "124" ]]; then
+      cat "${daemon_status_error}" >&2 2>/dev/null || true
+      exit 124
+    fi
   fi
 
   if [[ "${daemon_status_ready}" == "1" ]] && \
@@ -759,7 +780,10 @@ while ((SECONDS < deadline)); do
         exit 0
       else
         status_check=$?
-        if [[ "${status_check}" == "2" ]]; then
+        if [[ "${status_check}" == "124" ]]; then
+          cat "${daemon_status_error}" >&2 2>/dev/null || true
+          exit 124
+        elif [[ "${status_check}" == "2" ]]; then
           cat "${daemon_status_json}" >&2 || true
           exit 1
         fi
@@ -772,11 +796,24 @@ while ((SECONDS < deadline)); do
       fi
     fi
   else
+    search_status=$?
+    if [[ "${search_status}" == "124" ]]; then
+      cat "${search_error}" >&2 2>/dev/null || true
+      exit 124
+    fi
     last_output="$(cat "${search_json}" 2>/dev/null || true)"
     last_search_error="$(cat "${search_error}" 2>/dev/null || true)"
   fi
 
-  sleep 5
+  remaining_before_retry=$((deadline - SECONDS))
+  if ((remaining_before_retry <= 0)); then
+    break
+  fi
+  retry_delay=5
+  if ((retry_delay > remaining_before_retry)); then
+    retry_delay="${remaining_before_retry}"
+  fi
+  sleep "${retry_delay}"
 done
 
 echo "ctx semantic smoke failed: semantic search did not find fixture before timeout" >&2

--- a/scripts/smoke-daemon-semantic-release.sh
+++ b/scripts/smoke-daemon-semantic-release.sh
@@ -633,7 +633,8 @@ if [[ "${daemon_started}" != "1" ]]; then
   exit 1
 fi
 
-run_ctx import --no-daemon --input-format ctx-history-jsonl-v2 --path "${fixture_path}" >/dev/null
+run_bounded "${timeout_seconds}" "${ctx_env[@]}" "${ctx_bin}" --data-root "${data_root}" \
+  import --no-daemon --input-format ctx-history-jsonl-v2 --path "${fixture_path}" >/dev/null
 
 deadline=$((SECONDS + timeout_seconds))
 last_output=""

--- a/scripts/smoke-daemon-semantic-release.sh
+++ b/scripts/smoke-daemon-semantic-release.sh
@@ -31,14 +31,7 @@ runtime_archive=""
 coreml_archive=""
 runtime_platform=""
 runtime_version="1.27.0"
-timeout_max_seconds=900
-if [[ "${CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS+x}" == "x" ]]; then
-  timeout_seconds="${CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS}"
-  timeout_source="CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS"
-else
-  timeout_seconds=900
-  timeout_source="--timeout-seconds"
-fi
+timeout_seconds="${CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS:-900}"
 keep_root=0
 coreml_mode=0
 require_authoritative=0
@@ -74,7 +67,6 @@ while (($# > 0)); do
     --timeout-seconds)
       shift
       timeout_seconds="${1:-}"
-      timeout_source="--timeout-seconds"
       ;;
     --keep-root)
       keep_root=1
@@ -99,16 +91,8 @@ if [[ -z "${runtime_platform}" ]]; then
   echo "error: --runtime-platform is required" >&2
   exit 2
 fi
-timeout_is_valid=1
-if [[ ! "${timeout_seconds}" =~ ^[1-9][0-9]*$ ]]; then
-  timeout_is_valid=0
-elif ((${#timeout_seconds} > 3)); then
-  timeout_is_valid=0
-elif ((timeout_seconds < 30 || timeout_seconds > timeout_max_seconds)); then
-  timeout_is_valid=0
-fi
-if [[ "${timeout_is_valid}" != "1" ]]; then
-  echo "error: ${timeout_source} must be a canonical integer between 30 and 900 seconds" >&2
+if [[ ! "${timeout_seconds}" =~ ^[0-9]+$ ]] || ((timeout_seconds < 30)); then
+  echo "error: --timeout-seconds must be an integer >= 30" >&2
   exit 2
 fi
 
@@ -203,68 +187,16 @@ fi
 unset LD_LIBRARY_PATH DYLD_LIBRARY_PATH LD_PRELOAD DYLD_INSERT_LIBRARIES \
   DYLD_FORCE_FLAT_NAMESPACE DYLD_FALLBACK_LIBRARY_PATH
 
-nanoseconds_per_second=1000000000
-monotonic_ns() {
-  python3 -I -c 'import time; print(time.monotonic_ns())'
-}
-
-deadline_after_seconds() {
-  local duration_seconds="$1"
-  local maximum_deadline_ns="${2:-}"
-  local now_ns
-  local result_ns
-
-  now_ns="$(monotonic_ns)"
-  if [[ ! "${now_ns}" =~ ^[1-9][0-9]*$ ]] || ((${#now_ns} > 18)); then
-    echo "error: monotonic clock returned an invalid value" >&2
-    return 1
-  fi
-  result_ns=$((now_ns + duration_seconds * nanoseconds_per_second))
-  if [[ -n "${maximum_deadline_ns}" ]] && ((result_ns > maximum_deadline_ns)); then
-    result_ns="${maximum_deadline_ns}"
-  fi
-  printf '%s\n' "${result_ns}"
-}
-
-remaining_ns() {
-  local deadline_ns="$1"
-  local now_ns
-
-  now_ns="$(monotonic_ns)"
-  if [[ ! "${now_ns}" =~ ^[1-9][0-9]*$ ]] || ((${#now_ns} > 18)); then
-    echo "error: monotonic clock returned an invalid value" >&2
-    return 1
-  fi
-  if ((now_ns >= deadline_ns)); then
-    printf '0\n'
-  else
-    printf '%s\n' "$((deadline_ns - now_ns))"
-  fi
-}
-
-decimal_seconds_from_ns() {
-  local duration_ns="$1"
-  printf '%d.%09d\n' \
-    "$((duration_ns / nanoseconds_per_second))" \
-    "$((duration_ns % nanoseconds_per_second))"
-}
-
 run_bounded() {
-  local deadline_ns="$1"
+  local limit_seconds="$1"
   shift
-  python3 -I - "${deadline_ns}" "$@" <<'PY'
+  python3 -I - "${limit_seconds}" "$@" <<'PY'
 import subprocess
 import os
 import re
 import sys
-import time
 
-deadline_ns = int(sys.argv[1])
-remaining_ns = deadline_ns - time.monotonic_ns()
-if remaining_ns <= 0:
-    print("error: smoke command exceeded monotonic deadline", file=sys.stderr)
-    raise SystemExit(124)
-limit = remaining_ns / 1_000_000_000
+limit = int(sys.argv[1])
 command = sys.argv[2:]
 pass_fds = set()
 for argument in command:
@@ -280,7 +212,7 @@ try:
         pass_fds=tuple(sorted(pass_fds)),
     )
 except subprocess.TimeoutExpired:
-    print("error: smoke command exceeded monotonic deadline", file=sys.stderr)
+    print(f"error: smoke command exceeded {limit} seconds", file=sys.stderr)
     raise SystemExit(124)
 raise SystemExit(result.returncode)
 PY
@@ -378,8 +310,7 @@ fi
   echo "error: ctx binary is not executable: ${ctx_source}" >&2
   exit 1
 }
-version_deadline_ns="$(deadline_after_seconds 30)"
-ctx_version="$(run_bounded "${version_deadline_ns}" "${ctx_source}" --version | awk 'NR == 1 { print $2 }')"
+ctx_version="$(run_bounded 30 "${ctx_source}" --version | awk 'NR == 1 { print $2 }')"
 [[ -n "${ctx_version}" ]] || {
   echo "error: could not determine ctx version from ${ctx_source}" >&2
   exit 1
@@ -608,16 +539,8 @@ else
   ctx_env+=(CTX_INTERNAL_SEMANTIC_BACKEND=cpu)
 fi
 
-deadline_ns="$(deadline_after_seconds "${timeout_seconds}")"
 run_ctx() {
-  local operation_remaining_ns
-  operation_remaining_ns="$(remaining_ns "${deadline_ns}")"
-  if ((operation_remaining_ns <= 0)); then
-    echo "error: semantic smoke exceeded ${timeout_seconds} seconds" >&2
-    return 124
-  fi
-  run_bounded "${deadline_ns}" \
-    "${ctx_env[@]}" "${ctx_bin}" --data-root "${data_root}" "$@"
+  run_bounded 30 "${ctx_env[@]}" "${ctx_bin}" --data-root "${data_root}" "$@"
 }
 
 printf 'ctx semantic smoke: isolated_home=%s\n' "${smoke_home}"
@@ -686,13 +609,9 @@ if endpoint.get("transport") not in {"unix", "windows_named_pipe"}:
 PY
 }
 
-startup_deadline_ns="$(deadline_after_seconds 30 "${deadline_ns}")"
+startup_deadline=$((SECONDS + 30))
 daemon_started=0
-while :; do
-  startup_remaining_ns="$(remaining_ns "${startup_deadline_ns}")"
-  if ((startup_remaining_ns <= 0)); then
-    break
-  fi
+while ((SECONDS < startup_deadline)); do
   if ! kill -0 "${daemon_pid}" >/dev/null 2>&1; then
     echo "ctx semantic smoke: daemon exited before source-refresh admission" >&2
     cat "${daemon_log}" >&2 || true
@@ -703,20 +622,8 @@ while :; do
     daemon_startup_matches; then
     daemon_started=1
     break
-  else
-    startup_status=$?
-    if [[ "${startup_status}" == "124" ]]; then
-      cat "${daemon_startup_error}" >&2 2>/dev/null || true
-      exit 124
-    fi
   fi
-  startup_remaining_ns="$(remaining_ns "${startup_deadline_ns}")"
-  if ((startup_remaining_ns <= 0)); then
-    break
-  elif ((startup_remaining_ns > 100000000)); then
-    startup_remaining_ns=100000000
-  fi
-  sleep "$(decimal_seconds_from_ns "${startup_remaining_ns}")"
+  sleep 0.1
 done
 if [[ "${daemon_started}" != "1" ]]; then
   echo "ctx semantic smoke: daemon did not expose its source-refresh endpoint" >&2
@@ -726,8 +633,10 @@ if [[ "${daemon_started}" != "1" ]]; then
   exit 1
 fi
 
-run_ctx import --no-daemon --input-format ctx-history-jsonl-v2 --path "${fixture_path}" >/dev/null
+run_bounded "${timeout_seconds}" "${ctx_env[@]}" "${ctx_bin}" --data-root "${data_root}" \
+  import --no-daemon --input-format ctx-history-jsonl-v2 --path "${fixture_path}" >/dev/null
 
+deadline=$((SECONDS + timeout_seconds))
 last_output=""
 last_search_error=""
 last_status_output=""
@@ -812,11 +721,7 @@ if not any(marker in text for result in results for text in strings(result)):
 PY
 }
 
-while :; do
-  operation_remaining_ns="$(remaining_ns "${deadline_ns}")"
-  if ((operation_remaining_ns <= 0)); then
-    break
-  fi
+while ((SECONDS < deadline)); do
   if ! kill -0 "${daemon_pid}" >/dev/null 2>&1; then
     echo "ctx semantic smoke: daemon exited before search succeeded" >&2
     cat "${daemon_log}" >&2 || true
@@ -835,12 +740,6 @@ while :; do
         cat "${daemon_status_json}" >&2 || true
         exit 1
       fi
-    fi
-  else
-    status_check=$?
-    if [[ "${status_check}" == "124" ]]; then
-      cat "${daemon_status_error}" >&2 2>/dev/null || true
-      exit 124
     fi
   fi
 
@@ -861,10 +760,7 @@ while :; do
         exit 0
       else
         status_check=$?
-        if [[ "${status_check}" == "124" ]]; then
-          cat "${daemon_status_error}" >&2 2>/dev/null || true
-          exit 124
-        elif [[ "${status_check}" == "2" ]]; then
+        if [[ "${status_check}" == "2" ]]; then
           cat "${daemon_status_json}" >&2 || true
           exit 1
         fi
@@ -877,23 +773,11 @@ while :; do
       fi
     fi
   else
-    search_status=$?
-    if [[ "${search_status}" == "124" ]]; then
-      cat "${search_error}" >&2 2>/dev/null || true
-      exit 124
-    fi
     last_output="$(cat "${search_json}" 2>/dev/null || true)"
     last_search_error="$(cat "${search_error}" 2>/dev/null || true)"
   fi
 
-  operation_remaining_ns="$(remaining_ns "${deadline_ns}")"
-  if ((operation_remaining_ns <= 0)); then
-    break
-  fi
-  if ((operation_remaining_ns > 5000000000)); then
-    operation_remaining_ns=5000000000
-  fi
-  sleep "$(decimal_seconds_from_ns "${operation_remaining_ns}")"
+  sleep 5
 done
 
 echo "ctx semantic smoke failed: semantic search did not find fixture before timeout" >&2

--- a/scripts/tests/smoke-daemon-semantic-release-test.sh
+++ b/scripts/tests/smoke-daemon-semantic-release-test.sh
@@ -342,8 +342,7 @@ case "${command}" in
       > "${data_root}/fake-marker"
     if [[ -n "${CTX_TEST_IMPORT_DELAY_SECONDS:-}" ]]; then
       [[ "${CTX_TEST_IMPORT_DELAY_SECONDS}" =~ ^[0-9]+$ ]]
-      import_delay_deadline=$((SECONDS + CTX_TEST_IMPORT_DELAY_SECONDS))
-      while ((SECONDS < import_delay_deadline)); do :; done
+      exec sleep "${CTX_TEST_IMPORT_DELAY_SECONDS}"
     fi
     ;;
   daemon)
@@ -416,7 +415,7 @@ slow_import_parent="${tmp}/slow-import-runs"
 mkdir -p "${slow_import_parent}"
 if ! CTX_TEST_RUNTIME_EVIDENCE=macos-arm64-native-virtualized \
   CTX_TEST_COREML_BIND_LOG="${tmp}/slow-import-coreml-bind.log" \
-  CTX_TEST_IMPORT_DELAY_SECONDS=4 \
+  CTX_TEST_IMPORT_DELAY_SECONDS=2 \
   "${scaled_smoke}" "${scaled_smoke_args[@]}" \
     --data-root "${slow_import_parent}" \
     --timeout-seconds 5 \

--- a/scripts/tests/smoke-daemon-semantic-release-test.sh
+++ b/scripts/tests/smoke-daemon-semantic-release-test.sh
@@ -156,59 +156,6 @@ EOF
 chmod 0755 "${release_root}/scripts/public-cli-host-runtime-evidence.sh"
 smoke="${release_root}/scripts/smoke-daemon-semantic-release.sh"
 runtime_authority="${release_root}/scripts/public-cli-runtime-authority.sh"
-real_python3="$(command -v python3)"
-"${real_python3}" -I - "${smoke}" <<'PY'
-from pathlib import Path
-import re
-import sys
-
-source = Path(sys.argv[1]).read_text(encoding="utf-8")
-if source.count("time.monotonic_ns()") < 2:
-    raise SystemExit("semantic smoke deadlines are not based on time.monotonic_ns()")
-if re.search(r"\bSECONDS\b", source):
-    raise SystemExit("semantic smoke contains the Bash SECONDS clock")
-for forbidden in ("time.time(", "datetime", "$(date", "`date"):
-    if forbidden in source:
-        raise SystemExit(f"semantic smoke contains a wall-clock deadline source: {forbidden}")
-PY
-bounded_python_dir="${tmp}/bounded-python"
-mkdir -p "${bounded_python_dir}"
-cat > "${bounded_python_dir}/python3" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [[ "\${1:-}" == "-I" && "\${2:-}" == "-" && "\${3:-}" =~ ^[0-9]+$ ]]; then
-  bounded_command=""
-  for argument in "\${@:4}"; do
-    case "\${argument}" in
-      import|daemon|search)
-        bounded_command="\${argument}"
-        break
-        ;;
-    esac
-  done
-  if [[ -n "\${bounded_command}" && -n "\${CTX_TEST_BOUNDED_LOG:-}" ]]; then
-    bounded_now_ns="\$("${real_python3}" -I -c 'import time; print(time.monotonic_ns())')"
-    bounded_remaining_ns=\$((\${3} - bounded_now_ns))
-    printf '%s\t%s\t%s\n' \
-      "\${bounded_command}" "\${3}" "\${bounded_remaining_ns}" \
-      >> "\${CTX_TEST_BOUNDED_LOG}"
-    if [[ "\${CTX_TEST_BOUNDED_MODE:-}" == "record" && \
-          ! -e "\${CTX_TEST_BOUNDED_DELAY_MARKER:?}" ]]; then
-      touch "\${CTX_TEST_BOUNDED_DELAY_MARKER}"
-      sleep 2
-    elif [[ "\${CTX_TEST_BOUNDED_MODE:-}" == "timeout-import" && \
-            "\${bounded_command}" == "import" && \
-            ! -e "\${CTX_TEST_BOUNDED_TIMEOUT_MARKER:?}" ]]; then
-      touch "\${CTX_TEST_BOUNDED_TIMEOUT_MARKER}"
-      printf 'error: smoke command exceeded monotonic deadline\n' >&2
-      exit 124
-    fi
-  fi
-fi
-exec "${real_python3}" "\$@"
-EOF
-chmod 0755 "${bounded_python_dir}/python3"
 
 expect_runtime_authority() {
   local name="$1"
@@ -393,6 +340,10 @@ case "${command}" in
     esac
     grep -Eo 'ctx-release-semantic-smoke-[0-9a-f]+' "${fixture}" | head -1 \
       > "${data_root}/fake-marker"
+    if [[ -n "${CTX_TEST_IMPORT_DELAY_SECONDS:-}" ]]; then
+      [[ "${CTX_TEST_IMPORT_DELAY_SECONDS}" =~ ^[0-9]+$ ]]
+      exec sleep "${CTX_TEST_IMPORT_DELAY_SECONDS}"
+    fi
     ;;
   daemon)
     subcommand="${1:-}"
@@ -445,6 +396,58 @@ EOF
 chmod 755 "${fake_ctx}"
 fake_ctx="$(cd -- "$(dirname -- "${fake_ctx}")" && pwd -P)/$(basename -- "${fake_ctx}")"
 
+# Scale only the harness's 30-second minimum and short command bounds so the
+# import timeout contract executes quickly without adding a production seam.
+scaled_smoke="${release_root}/scripts/smoke-daemon-semantic-release-scaled-test.sh"
+sed \
+  -e 's/timeout_seconds < 30/timeout_seconds < 1/' \
+  -e 's/run_bounded 30/run_bounded 1/g' \
+  "${smoke}" > "${scaled_smoke}"
+chmod 0755 "${scaled_smoke}"
+scaled_smoke_args=(
+  --coreml
+  --runtime-platform macos-arm64
+  --coreml-archive "${coreml_archive}"
+  --ctx "${fake_ctx}"
+)
+
+slow_import_parent="${tmp}/slow-import-runs"
+mkdir -p "${slow_import_parent}"
+if ! CTX_TEST_RUNTIME_EVIDENCE=macos-arm64-native-virtualized \
+  CTX_TEST_COREML_BIND_LOG="${tmp}/slow-import-coreml-bind.log" \
+  CTX_TEST_IMPORT_DELAY_SECONDS=2 \
+  "${scaled_smoke}" "${scaled_smoke_args[@]}" \
+    --data-root "${slow_import_parent}" \
+    --timeout-seconds 5 \
+    > "${tmp}/slow-import.out" 2> "${tmp}/slow-import.err"; then
+  cat "${tmp}/slow-import.out" >&2
+  cat "${tmp}/slow-import.err" >&2
+  exit 1
+fi
+grep -Fq 'ctx semantic smoke ok:' "${tmp}/slow-import.out"
+
+timed_out_import_parent="${tmp}/timed-out-import-runs"
+timed_out_import_pid="${tmp}/timed-out-import-daemon.pid"
+mkdir -p "${timed_out_import_parent}"
+if CTX_TEST_RUNTIME_EVIDENCE=macos-arm64-native-virtualized \
+  CTX_TEST_COREML_BIND_LOG="${tmp}/timed-out-import-coreml-bind.log" \
+  CTX_TEST_IMPORT_DELAY_SECONDS=4 \
+  CTX_TEST_DAEMON_PID_LOG="${timed_out_import_pid}" \
+  "${scaled_smoke}" "${scaled_smoke_args[@]}" \
+    --data-root "${timed_out_import_parent}" \
+    --timeout-seconds 1 \
+    > "${tmp}/timed-out-import.out" 2> "${tmp}/timed-out-import.err"; then
+  printf 'semantic smoke unexpectedly accepted a timed-out import\n' >&2
+  exit 1
+else
+  timed_out_import_status=$?
+fi
+[[ "${timed_out_import_status}" == "124" ]]
+grep -Fq 'error: smoke command exceeded 1 seconds' \
+  "${tmp}/timed-out-import.err"
+! kill -0 "$(cat "${timed_out_import_pid}")" >/dev/null 2>&1
+test -z "$(find "${timed_out_import_parent}" -mindepth 1 -print -quit)"
+
 expect_usage_failure() {
   local name="$1"
   local expected="$2"
@@ -487,39 +490,6 @@ expect_usage_failure retired_proof_output \
   'Usage:' \
   --coreml --runtime-platform macos-arm64 --proof-output "${tmp}/proof" \
   --ctx "${fake_ctx}"
-
-invalid_timeout_values=(
-  ''
-  090
-  030
-  0
-  -1
-  30s
-  901
-  999999999999999999999999999999999999
-)
-for timeout_index in "${!invalid_timeout_values[@]}"; do
-  invalid_timeout="${invalid_timeout_values[timeout_index]}"
-  expect_usage_failure "timeout_cli_${timeout_index}" \
-    '--timeout-seconds must be a canonical integer between 30 and 900 seconds' \
-    --coreml --runtime-platform macos-arm64 --ctx "${fake_ctx}" \
-    --timeout-seconds "${invalid_timeout}"
-  if CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS="${invalid_timeout}" \
-    "${smoke}" --coreml --runtime-platform macos-arm64 --ctx "${fake_ctx}" \
-    > "${tmp}/timeout_env_${timeout_index}.out" \
-    2> "${tmp}/timeout_env_${timeout_index}.err"; then
-    printf 'expected environment timeout failure: %s\n' "${invalid_timeout}" >&2
-    exit 1
-  fi
-  grep -Fq -- \
-    'CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS must be a canonical integer between 30 and 900 seconds' \
-    "${tmp}/timeout_env_${timeout_index}.err" || {
-    printf 'unexpected environment timeout failure for %s\n' \
-      "${invalid_timeout}" >&2
-    cat "${tmp}/timeout_env_${timeout_index}.err" >&2
-    exit 1
-  }
-done
 
 if CTX_TEST_RUNTIME_EVIDENCE=macos-arm64-generic-virtualized "${smoke}" \
   --coreml \
@@ -734,96 +704,23 @@ else
   shasum -a 256 "${runtime_archive}" | awk '{ print $1 }' > "${runtime_archive}.sha256"
 fi
 
-bounded_deadline_log="${tmp}/bounded-deadline.log"
-if ! PATH="${bounded_python_dir}:${PATH}" \
-  CTX_TEST_BOUNDED_LOG="${bounded_deadline_log}" \
-  CTX_TEST_BOUNDED_MODE=record \
-  CTX_TEST_BOUNDED_DELAY_MARKER="${tmp}/bounded-delay-complete" \
-  CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS=300 \
-  "${smoke}" \
+if ! "${smoke}" \
   --runtime-archive "${runtime_archive}" \
   --runtime-platform linux-x64 \
   --ctx "${cpu_ctx}" \
   --data-root "${tmp}/onnx-runs" \
   --require-authoritative \
+  --timeout-seconds 30 \
   > "${tmp}/onnx.out" 2> "${tmp}/onnx.err"; then
   cat "${tmp}/onnx.out" >&2
   cat "${tmp}/onnx.err" >&2
   exit 1
 fi
 grep -Fq 'ctx semantic smoke ok:' "${tmp}/onnx.out"
-mapfile -t bounded_deadlines < <(cut -f2 "${bounded_deadline_log}")
-mapfile -t bounded_remaining < <(cut -f3 "${bounded_deadline_log}")
-if ((${#bounded_deadlines[@]} < 4)); then
-  printf 'semantic smoke did not bound every expected ctx operation\n' >&2
-  cat "${bounded_deadline_log}" >&2
-  exit 1
-fi
-for bounded_index in "${!bounded_deadlines[@]}"; do
-  bounded_deadline="${bounded_deadlines[bounded_index]}"
-  operation_remaining="${bounded_remaining[bounded_index]}"
-  if [[ ! "${bounded_deadline}" =~ ^[1-9][0-9]*$ ]] || \
-    [[ "${bounded_deadline}" != "${bounded_deadlines[0]}" ]]; then
-    printf 'ctx operations did not share one monotonic deadline: %s\n' \
-      "${bounded_deadline}" >&2
-    exit 1
-  fi
-  if [[ ! "${operation_remaining}" =~ ^[0-9]+$ ]] || \
-    ((operation_remaining <= 30000000000 || \
-      operation_remaining > 300000000000)); then
-    printf 'ctx operation ignored the monotonic smoke budget: %s\n' \
-      "${operation_remaining}" >&2
-    exit 1
-  fi
-done
-last_bounded_index=$((${#bounded_remaining[@]} - 1))
-if ((bounded_remaining[last_bounded_index] >= bounded_remaining[0])); then
-  printf 'ctx operation bounds did not consume the whole-smoke deadline\n' >&2
-  cat "${bounded_deadline_log}" >&2
-  exit 1
-fi
 if find "${tmp}/onnx-runs" -name packaged-runtime-proof.txt -print -quit | grep -q .; then
   printf 'semantic smoke emitted a retired proof artifact\n' >&2
   exit 1
 fi
-
-bounded_timeout_log="${tmp}/bounded-timeout.log"
-bounded_timeout_daemon_pid="${tmp}/bounded-timeout-daemon.pid"
-set +e
-PATH="${bounded_python_dir}:${PATH}" \
-CTX_TEST_BOUNDED_LOG="${bounded_timeout_log}" \
-CTX_TEST_BOUNDED_MODE=timeout-import \
-CTX_TEST_BOUNDED_TIMEOUT_MARKER="${tmp}/bounded-timeout-complete" \
-CTX_TEST_DAEMON_PID_LOG="${bounded_timeout_daemon_pid}" \
-  "${smoke}" \
-  --runtime-archive "${runtime_archive}" \
-  --runtime-platform linux-x64 \
-  --ctx "${cpu_ctx}" \
-  --data-root "${tmp}/bounded-timeout-runs" \
-  --require-authoritative \
-  --timeout-seconds 300 \
-  > "${tmp}/bounded-timeout.out" 2> "${tmp}/bounded-timeout.err"
-bounded_timeout_status=$?
-set -e
-if [[ "${bounded_timeout_status}" != "124" ]]; then
-  printf 'semantic smoke did not propagate bounded ctx timeout: %s\n' \
-    "${bounded_timeout_status}" >&2
-  cat "${tmp}/bounded-timeout.err" >&2
-  exit 1
-fi
-bounded_timeout_remaining="$(awk -F '\t' '$1 == "import" { print $3; exit }' \
-  "${bounded_timeout_log}")"
-if [[ ! "${bounded_timeout_remaining}" =~ ^[0-9]+$ ]] || \
-  ((bounded_timeout_remaining <= 30000000000 || \
-    bounded_timeout_remaining > 300000000000)); then
-  printf 'semantic smoke timeout was not constrained by its remaining budget: %s\n' \
-    "${bounded_timeout_remaining}" >&2
-  exit 1
-fi
-grep -Fq -- 'error: smoke command exceeded monotonic deadline' \
-  "${tmp}/bounded-timeout.err"
-! kill -0 "$(cat "${bounded_timeout_daemon_pid}")" >/dev/null 2>&1
-test -z "$(find "${tmp}/bounded-timeout-runs" -mindepth 1 -print -quit)"
 
 candidate="${tmp}/nested-inputs"
 mkdir "${candidate}"

--- a/scripts/tests/smoke-daemon-semantic-release-test.sh
+++ b/scripts/tests/smoke-daemon-semantic-release-test.sh
@@ -156,6 +156,59 @@ EOF
 chmod 0755 "${release_root}/scripts/public-cli-host-runtime-evidence.sh"
 smoke="${release_root}/scripts/smoke-daemon-semantic-release.sh"
 runtime_authority="${release_root}/scripts/public-cli-runtime-authority.sh"
+real_python3="$(command -v python3)"
+"${real_python3}" -I - "${smoke}" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+if source.count("time.monotonic_ns()") < 2:
+    raise SystemExit("semantic smoke deadlines are not based on time.monotonic_ns()")
+if re.search(r"\bSECONDS\b", source):
+    raise SystemExit("semantic smoke contains the Bash SECONDS clock")
+for forbidden in ("time.time(", "datetime", "$(date", "`date"):
+    if forbidden in source:
+        raise SystemExit(f"semantic smoke contains a wall-clock deadline source: {forbidden}")
+PY
+bounded_python_dir="${tmp}/bounded-python"
+mkdir -p "${bounded_python_dir}"
+cat > "${bounded_python_dir}/python3" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "\${1:-}" == "-I" && "\${2:-}" == "-" && "\${3:-}" =~ ^[0-9]+$ ]]; then
+  bounded_command=""
+  for argument in "\${@:4}"; do
+    case "\${argument}" in
+      import|daemon|search)
+        bounded_command="\${argument}"
+        break
+        ;;
+    esac
+  done
+  if [[ -n "\${bounded_command}" && -n "\${CTX_TEST_BOUNDED_LOG:-}" ]]; then
+    bounded_now_ns="\$("${real_python3}" -I -c 'import time; print(time.monotonic_ns())')"
+    bounded_remaining_ns=\$((\${3} - bounded_now_ns))
+    printf '%s\t%s\t%s\n' \
+      "\${bounded_command}" "\${3}" "\${bounded_remaining_ns}" \
+      >> "\${CTX_TEST_BOUNDED_LOG}"
+    if [[ "\${CTX_TEST_BOUNDED_MODE:-}" == "record" && \
+          ! -e "\${CTX_TEST_BOUNDED_DELAY_MARKER:?}" ]]; then
+      touch "\${CTX_TEST_BOUNDED_DELAY_MARKER}"
+      sleep 2
+    elif [[ "\${CTX_TEST_BOUNDED_MODE:-}" == "timeout-import" && \
+            "\${bounded_command}" == "import" && \
+            ! -e "\${CTX_TEST_BOUNDED_TIMEOUT_MARKER:?}" ]]; then
+      touch "\${CTX_TEST_BOUNDED_TIMEOUT_MARKER}"
+      printf 'error: smoke command exceeded monotonic deadline\n' >&2
+      exit 124
+    fi
+  fi
+fi
+exec "${real_python3}" "\$@"
+EOF
+chmod 0755 "${bounded_python_dir}/python3"
 
 expect_runtime_authority() {
   local name="$1"
@@ -340,10 +393,6 @@ case "${command}" in
     esac
     grep -Eo 'ctx-release-semantic-smoke-[0-9a-f]+' "${fixture}" | head -1 \
       > "${data_root}/fake-marker"
-    if [[ -n "${CTX_TEST_IMPORT_DELAY_SECONDS:-}" ]]; then
-      [[ "${CTX_TEST_IMPORT_DELAY_SECONDS}" =~ ^[0-9]+$ ]]
-      exec sleep "${CTX_TEST_IMPORT_DELAY_SECONDS}"
-    fi
     ;;
   daemon)
     subcommand="${1:-}"
@@ -396,58 +445,6 @@ EOF
 chmod 755 "${fake_ctx}"
 fake_ctx="$(cd -- "$(dirname -- "${fake_ctx}")" && pwd -P)/$(basename -- "${fake_ctx}")"
 
-# Scale only the harness's 30-second minimum and short command bounds so the
-# import timeout contract executes quickly without adding a production seam.
-scaled_smoke="${release_root}/scripts/smoke-daemon-semantic-release-scaled-test.sh"
-sed \
-  -e 's/timeout_seconds < 30/timeout_seconds < 1/' \
-  -e 's/run_bounded 30/run_bounded 1/g' \
-  "${smoke}" > "${scaled_smoke}"
-chmod 0755 "${scaled_smoke}"
-scaled_smoke_args=(
-  --coreml
-  --runtime-platform macos-arm64
-  --coreml-archive "${coreml_archive}"
-  --ctx "${fake_ctx}"
-)
-
-slow_import_parent="${tmp}/slow-import-runs"
-mkdir -p "${slow_import_parent}"
-if ! CTX_TEST_RUNTIME_EVIDENCE=macos-arm64-native-virtualized \
-  CTX_TEST_COREML_BIND_LOG="${tmp}/slow-import-coreml-bind.log" \
-  CTX_TEST_IMPORT_DELAY_SECONDS=2 \
-  "${scaled_smoke}" "${scaled_smoke_args[@]}" \
-    --data-root "${slow_import_parent}" \
-    --timeout-seconds 5 \
-    > "${tmp}/slow-import.out" 2> "${tmp}/slow-import.err"; then
-  cat "${tmp}/slow-import.out" >&2
-  cat "${tmp}/slow-import.err" >&2
-  exit 1
-fi
-grep -Fq 'ctx semantic smoke ok:' "${tmp}/slow-import.out"
-
-timed_out_import_parent="${tmp}/timed-out-import-runs"
-timed_out_import_pid="${tmp}/timed-out-import-daemon.pid"
-mkdir -p "${timed_out_import_parent}"
-if CTX_TEST_RUNTIME_EVIDENCE=macos-arm64-native-virtualized \
-  CTX_TEST_COREML_BIND_LOG="${tmp}/timed-out-import-coreml-bind.log" \
-  CTX_TEST_IMPORT_DELAY_SECONDS=4 \
-  CTX_TEST_DAEMON_PID_LOG="${timed_out_import_pid}" \
-  "${scaled_smoke}" "${scaled_smoke_args[@]}" \
-    --data-root "${timed_out_import_parent}" \
-    --timeout-seconds 1 \
-    > "${tmp}/timed-out-import.out" 2> "${tmp}/timed-out-import.err"; then
-  printf 'semantic smoke unexpectedly accepted a timed-out import\n' >&2
-  exit 1
-else
-  timed_out_import_status=$?
-fi
-[[ "${timed_out_import_status}" == "124" ]]
-grep -Fq 'error: smoke command exceeded 1 seconds' \
-  "${tmp}/timed-out-import.err"
-! kill -0 "$(cat "${timed_out_import_pid}")" >/dev/null 2>&1
-test -z "$(find "${timed_out_import_parent}" -mindepth 1 -print -quit)"
-
 expect_usage_failure() {
   local name="$1"
   local expected="$2"
@@ -490,6 +487,39 @@ expect_usage_failure retired_proof_output \
   'Usage:' \
   --coreml --runtime-platform macos-arm64 --proof-output "${tmp}/proof" \
   --ctx "${fake_ctx}"
+
+invalid_timeout_values=(
+  ''
+  090
+  030
+  0
+  -1
+  30s
+  901
+  999999999999999999999999999999999999
+)
+for timeout_index in "${!invalid_timeout_values[@]}"; do
+  invalid_timeout="${invalid_timeout_values[timeout_index]}"
+  expect_usage_failure "timeout_cli_${timeout_index}" \
+    '--timeout-seconds must be a canonical integer between 30 and 900 seconds' \
+    --coreml --runtime-platform macos-arm64 --ctx "${fake_ctx}" \
+    --timeout-seconds "${invalid_timeout}"
+  if CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS="${invalid_timeout}" \
+    "${smoke}" --coreml --runtime-platform macos-arm64 --ctx "${fake_ctx}" \
+    > "${tmp}/timeout_env_${timeout_index}.out" \
+    2> "${tmp}/timeout_env_${timeout_index}.err"; then
+    printf 'expected environment timeout failure: %s\n' "${invalid_timeout}" >&2
+    exit 1
+  fi
+  grep -Fq -- \
+    'CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS must be a canonical integer between 30 and 900 seconds' \
+    "${tmp}/timeout_env_${timeout_index}.err" || {
+    printf 'unexpected environment timeout failure for %s\n' \
+      "${invalid_timeout}" >&2
+    cat "${tmp}/timeout_env_${timeout_index}.err" >&2
+    exit 1
+  }
+done
 
 if CTX_TEST_RUNTIME_EVIDENCE=macos-arm64-generic-virtualized "${smoke}" \
   --coreml \
@@ -704,23 +734,96 @@ else
   shasum -a 256 "${runtime_archive}" | awk '{ print $1 }' > "${runtime_archive}.sha256"
 fi
 
-if ! "${smoke}" \
+bounded_deadline_log="${tmp}/bounded-deadline.log"
+if ! PATH="${bounded_python_dir}:${PATH}" \
+  CTX_TEST_BOUNDED_LOG="${bounded_deadline_log}" \
+  CTX_TEST_BOUNDED_MODE=record \
+  CTX_TEST_BOUNDED_DELAY_MARKER="${tmp}/bounded-delay-complete" \
+  CTX_SEMANTIC_SMOKE_TIMEOUT_SECONDS=300 \
+  "${smoke}" \
   --runtime-archive "${runtime_archive}" \
   --runtime-platform linux-x64 \
   --ctx "${cpu_ctx}" \
   --data-root "${tmp}/onnx-runs" \
   --require-authoritative \
-  --timeout-seconds 30 \
   > "${tmp}/onnx.out" 2> "${tmp}/onnx.err"; then
   cat "${tmp}/onnx.out" >&2
   cat "${tmp}/onnx.err" >&2
   exit 1
 fi
 grep -Fq 'ctx semantic smoke ok:' "${tmp}/onnx.out"
+mapfile -t bounded_deadlines < <(cut -f2 "${bounded_deadline_log}")
+mapfile -t bounded_remaining < <(cut -f3 "${bounded_deadline_log}")
+if ((${#bounded_deadlines[@]} < 4)); then
+  printf 'semantic smoke did not bound every expected ctx operation\n' >&2
+  cat "${bounded_deadline_log}" >&2
+  exit 1
+fi
+for bounded_index in "${!bounded_deadlines[@]}"; do
+  bounded_deadline="${bounded_deadlines[bounded_index]}"
+  operation_remaining="${bounded_remaining[bounded_index]}"
+  if [[ ! "${bounded_deadline}" =~ ^[1-9][0-9]*$ ]] || \
+    [[ "${bounded_deadline}" != "${bounded_deadlines[0]}" ]]; then
+    printf 'ctx operations did not share one monotonic deadline: %s\n' \
+      "${bounded_deadline}" >&2
+    exit 1
+  fi
+  if [[ ! "${operation_remaining}" =~ ^[0-9]+$ ]] || \
+    ((operation_remaining <= 30000000000 || \
+      operation_remaining > 300000000000)); then
+    printf 'ctx operation ignored the monotonic smoke budget: %s\n' \
+      "${operation_remaining}" >&2
+    exit 1
+  fi
+done
+last_bounded_index=$((${#bounded_remaining[@]} - 1))
+if ((bounded_remaining[last_bounded_index] >= bounded_remaining[0])); then
+  printf 'ctx operation bounds did not consume the whole-smoke deadline\n' >&2
+  cat "${bounded_deadline_log}" >&2
+  exit 1
+fi
 if find "${tmp}/onnx-runs" -name packaged-runtime-proof.txt -print -quit | grep -q .; then
   printf 'semantic smoke emitted a retired proof artifact\n' >&2
   exit 1
 fi
+
+bounded_timeout_log="${tmp}/bounded-timeout.log"
+bounded_timeout_daemon_pid="${tmp}/bounded-timeout-daemon.pid"
+set +e
+PATH="${bounded_python_dir}:${PATH}" \
+CTX_TEST_BOUNDED_LOG="${bounded_timeout_log}" \
+CTX_TEST_BOUNDED_MODE=timeout-import \
+CTX_TEST_BOUNDED_TIMEOUT_MARKER="${tmp}/bounded-timeout-complete" \
+CTX_TEST_DAEMON_PID_LOG="${bounded_timeout_daemon_pid}" \
+  "${smoke}" \
+  --runtime-archive "${runtime_archive}" \
+  --runtime-platform linux-x64 \
+  --ctx "${cpu_ctx}" \
+  --data-root "${tmp}/bounded-timeout-runs" \
+  --require-authoritative \
+  --timeout-seconds 300 \
+  > "${tmp}/bounded-timeout.out" 2> "${tmp}/bounded-timeout.err"
+bounded_timeout_status=$?
+set -e
+if [[ "${bounded_timeout_status}" != "124" ]]; then
+  printf 'semantic smoke did not propagate bounded ctx timeout: %s\n' \
+    "${bounded_timeout_status}" >&2
+  cat "${tmp}/bounded-timeout.err" >&2
+  exit 1
+fi
+bounded_timeout_remaining="$(awk -F '\t' '$1 == "import" { print $3; exit }' \
+  "${bounded_timeout_log}")"
+if [[ ! "${bounded_timeout_remaining}" =~ ^[0-9]+$ ]] || \
+  ((bounded_timeout_remaining <= 30000000000 || \
+    bounded_timeout_remaining > 300000000000)); then
+  printf 'semantic smoke timeout was not constrained by its remaining budget: %s\n' \
+    "${bounded_timeout_remaining}" >&2
+  exit 1
+fi
+grep -Fq -- 'error: smoke command exceeded monotonic deadline' \
+  "${tmp}/bounded-timeout.err"
+! kill -0 "$(cat "${bounded_timeout_daemon_pid}")" >/dev/null 2>&1
+test -z "$(find "${tmp}/bounded-timeout-runs" -mindepth 1 -print -quit)"
 
 candidate="${tmp}/nested-inputs"
 mkdir "${candidate}"

--- a/scripts/tests/smoke-daemon-semantic-release-test.sh
+++ b/scripts/tests/smoke-daemon-semantic-release-test.sh
@@ -156,6 +156,41 @@ EOF
 chmod 0755 "${release_root}/scripts/public-cli-host-runtime-evidence.sh"
 smoke="${release_root}/scripts/smoke-daemon-semantic-release.sh"
 runtime_authority="${release_root}/scripts/public-cli-runtime-authority.sh"
+real_python3="$(command -v python3)"
+bounded_python_dir="${tmp}/bounded-python"
+mkdir -p "${bounded_python_dir}"
+cat > "${bounded_python_dir}/python3" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "\${1:-}" == "-I" && "\${2:-}" == "-" && "\${3:-}" =~ ^[0-9]+$ ]]; then
+  bounded_command=""
+  for argument in "\${@:4}"; do
+    case "\${argument}" in
+      import|daemon|search)
+        bounded_command="\${argument}"
+        break
+        ;;
+    esac
+  done
+  if [[ -n "\${bounded_command}" && -n "\${CTX_TEST_BOUNDED_LOG:-}" ]]; then
+    printf '%s\t%s\n' "\${bounded_command}" "\${3}" >> "\${CTX_TEST_BOUNDED_LOG}"
+    if [[ "\${CTX_TEST_BOUNDED_MODE:-}" == "record" && \
+          ! -e "\${CTX_TEST_BOUNDED_DELAY_MARKER:?}" ]]; then
+      touch "\${CTX_TEST_BOUNDED_DELAY_MARKER}"
+      sleep 2
+    elif [[ "\${CTX_TEST_BOUNDED_MODE:-}" == "timeout-search" && \
+            "\${bounded_command}" == "search" && \
+            ! -e "\${CTX_TEST_BOUNDED_TIMEOUT_MARKER:?}" ]]; then
+      touch "\${CTX_TEST_BOUNDED_TIMEOUT_MARKER}"
+      printf 'error: smoke command exceeded %s seconds\n' "\${3}" >&2
+      exit 124
+    fi
+  fi
+fi
+exec "${real_python3}" "\$@"
+EOF
+chmod 0755 "${bounded_python_dir}/python3"
 
 expect_runtime_authority() {
   local name="$1"
@@ -645,23 +680,81 @@ else
   shasum -a 256 "${runtime_archive}" | awk '{ print $1 }' > "${runtime_archive}.sha256"
 fi
 
-if ! "${smoke}" \
+bounded_deadline_log="${tmp}/bounded-deadline.log"
+if ! PATH="${bounded_python_dir}:${PATH}" \
+  CTX_TEST_BOUNDED_LOG="${bounded_deadline_log}" \
+  CTX_TEST_BOUNDED_MODE=record \
+  CTX_TEST_BOUNDED_DELAY_MARKER="${tmp}/bounded-delay-complete" \
+  "${smoke}" \
   --runtime-archive "${runtime_archive}" \
   --runtime-platform linux-x64 \
   --ctx "${cpu_ctx}" \
   --data-root "${tmp}/onnx-runs" \
   --require-authoritative \
-  --timeout-seconds 30 \
+  --timeout-seconds 300 \
   > "${tmp}/onnx.out" 2> "${tmp}/onnx.err"; then
   cat "${tmp}/onnx.out" >&2
   cat "${tmp}/onnx.err" >&2
   exit 1
 fi
 grep -Fq 'ctx semantic smoke ok:' "${tmp}/onnx.out"
+mapfile -t bounded_limits < <(cut -f2 "${bounded_deadline_log}")
+if ((${#bounded_limits[@]} < 4)); then
+  printf 'semantic smoke did not bound every expected ctx operation\n' >&2
+  cat "${bounded_deadline_log}" >&2
+  exit 1
+fi
+for bounded_limit in "${bounded_limits[@]}"; do
+  if [[ ! "${bounded_limit}" =~ ^[0-9]+$ ]] || \
+    ((bounded_limit <= 30 || bounded_limit > 300)); then
+    printf 'ctx operation ignored the remaining smoke budget: %s\n' \
+      "${bounded_limit}" >&2
+    exit 1
+  fi
+done
+last_bounded_index=$((${#bounded_limits[@]} - 1))
+if ((bounded_limits[last_bounded_index] >= bounded_limits[0])); then
+  printf 'ctx operation bounds did not consume the whole-smoke deadline\n' >&2
+  cat "${bounded_deadline_log}" >&2
+  exit 1
+fi
 if find "${tmp}/onnx-runs" -name packaged-runtime-proof.txt -print -quit | grep -q .; then
   printf 'semantic smoke emitted a retired proof artifact\n' >&2
   exit 1
 fi
+
+bounded_timeout_log="${tmp}/bounded-timeout.log"
+set +e
+PATH="${bounded_python_dir}:${PATH}" \
+CTX_TEST_BOUNDED_LOG="${bounded_timeout_log}" \
+CTX_TEST_BOUNDED_MODE=timeout-search \
+CTX_TEST_BOUNDED_TIMEOUT_MARKER="${tmp}/bounded-timeout-complete" \
+  "${smoke}" \
+  --runtime-archive "${runtime_archive}" \
+  --runtime-platform linux-x64 \
+  --ctx "${cpu_ctx}" \
+  --data-root "${tmp}/bounded-timeout-runs" \
+  --require-authoritative \
+  --timeout-seconds 300 \
+  > "${tmp}/bounded-timeout.out" 2> "${tmp}/bounded-timeout.err"
+bounded_timeout_status=$?
+set -e
+if [[ "${bounded_timeout_status}" != "124" ]]; then
+  printf 'semantic smoke did not propagate bounded ctx timeout: %s\n' \
+    "${bounded_timeout_status}" >&2
+  cat "${tmp}/bounded-timeout.err" >&2
+  exit 1
+fi
+bounded_timeout_limit="$(awk -F '\t' '$1 == "search" { print $2; exit }' \
+  "${bounded_timeout_log}")"
+if [[ ! "${bounded_timeout_limit}" =~ ^[0-9]+$ ]] || \
+  ((bounded_timeout_limit <= 30 || bounded_timeout_limit > 300)); then
+  printf 'semantic smoke timeout was not constrained by its remaining budget: %s\n' \
+    "${bounded_timeout_limit}" >&2
+  exit 1
+fi
+grep -Fq -- "error: smoke command exceeded ${bounded_timeout_limit} seconds" \
+  "${tmp}/bounded-timeout.err"
 
 candidate="${tmp}/nested-inputs"
 mkdir "${candidate}"

--- a/scripts/tests/smoke-daemon-semantic-release-test.sh
+++ b/scripts/tests/smoke-daemon-semantic-release-test.sh
@@ -340,6 +340,11 @@ case "${command}" in
     esac
     grep -Eo 'ctx-release-semantic-smoke-[0-9a-f]+' "${fixture}" | head -1 \
       > "${data_root}/fake-marker"
+    if [[ -n "${CTX_TEST_IMPORT_DELAY_SECONDS:-}" ]]; then
+      [[ "${CTX_TEST_IMPORT_DELAY_SECONDS}" =~ ^[0-9]+$ ]]
+      import_delay_deadline=$((SECONDS + CTX_TEST_IMPORT_DELAY_SECONDS))
+      while ((SECONDS < import_delay_deadline)); do :; done
+    fi
     ;;
   daemon)
     subcommand="${1:-}"
@@ -351,6 +356,9 @@ case "${command}" in
           exit 1
         }
         printf '%s\n' "$$" > "${data_root}/fake-daemon-pid"
+        if [[ -n "${CTX_TEST_DAEMON_PID_LOG:-}" ]]; then
+          printf '%s\n' "$$" > "${CTX_TEST_DAEMON_PID_LOG}"
+        fi
         mkdir -p "${data_root}/daemon"
         printf '{"schema_version":1,"pid":%s,"transport":"unix","path":"/tmp/fake-ctx-semantic-smoke.sock","token":"0123456789abcdef0123456789abcdef"}\n' "$$" \
           > "${data_root}/daemon/source-refresh-endpoint.json"
@@ -388,6 +396,58 @@ esac
 EOF
 chmod 755 "${fake_ctx}"
 fake_ctx="$(cd -- "$(dirname -- "${fake_ctx}")" && pwd -P)/$(basename -- "${fake_ctx}")"
+
+# Scale only the harness's 30-second minimum and short command bounds so the
+# import timeout contract executes quickly without adding a production seam.
+scaled_smoke="${release_root}/scripts/smoke-daemon-semantic-release-scaled-test.sh"
+sed \
+  -e 's/timeout_seconds < 30/timeout_seconds < 1/' \
+  -e 's/run_bounded 30/run_bounded 1/g' \
+  "${smoke}" > "${scaled_smoke}"
+chmod 0755 "${scaled_smoke}"
+scaled_smoke_args=(
+  --coreml
+  --runtime-platform macos-arm64
+  --coreml-archive "${coreml_archive}"
+  --ctx "${fake_ctx}"
+)
+
+slow_import_parent="${tmp}/slow-import-runs"
+mkdir -p "${slow_import_parent}"
+if ! CTX_TEST_RUNTIME_EVIDENCE=macos-arm64-native-virtualized \
+  CTX_TEST_COREML_BIND_LOG="${tmp}/slow-import-coreml-bind.log" \
+  CTX_TEST_IMPORT_DELAY_SECONDS=4 \
+  "${scaled_smoke}" "${scaled_smoke_args[@]}" \
+    --data-root "${slow_import_parent}" \
+    --timeout-seconds 5 \
+    > "${tmp}/slow-import.out" 2> "${tmp}/slow-import.err"; then
+  cat "${tmp}/slow-import.out" >&2
+  cat "${tmp}/slow-import.err" >&2
+  exit 1
+fi
+grep -Fq 'ctx semantic smoke ok:' "${tmp}/slow-import.out"
+
+timed_out_import_parent="${tmp}/timed-out-import-runs"
+timed_out_import_pid="${tmp}/timed-out-import-daemon.pid"
+mkdir -p "${timed_out_import_parent}"
+if CTX_TEST_RUNTIME_EVIDENCE=macos-arm64-native-virtualized \
+  CTX_TEST_COREML_BIND_LOG="${tmp}/timed-out-import-coreml-bind.log" \
+  CTX_TEST_IMPORT_DELAY_SECONDS=4 \
+  CTX_TEST_DAEMON_PID_LOG="${timed_out_import_pid}" \
+  "${scaled_smoke}" "${scaled_smoke_args[@]}" \
+    --data-root "${timed_out_import_parent}" \
+    --timeout-seconds 1 \
+    > "${tmp}/timed-out-import.out" 2> "${tmp}/timed-out-import.err"; then
+  printf 'semantic smoke unexpectedly accepted a timed-out import\n' >&2
+  exit 1
+else
+  timed_out_import_status=$?
+fi
+[[ "${timed_out_import_status}" == "124" ]]
+grep -Fq 'error: smoke command exceeded 1 seconds' \
+  "${tmp}/timed-out-import.err"
+! kill -0 "$(cat "${timed_out_import_pid}")" >/dev/null 2>&1
+test -z "$(find "${timed_out_import_parent}" -mindepth 1 -print -quit)"
 
 expect_usage_failure() {
   local name="$1"


### PR DESCRIPTION
## Summary

- use the configured semantic smoke timeout for `ctx import` only
- retain the existing 30-second command bounds for `ctx --version`, daemon status, and semantic search
- cover a 2-second delayed successful import under a 5-second allowance and a delayed import rejected by the preserved 1-second timeout case
- use `exec sleep` for the synthetic delay so the test does not spin a CPU

## Root cause

[`ctx-public-ci` build 148](https://buildkite.com/luca-king/ctx-public-ci/builds/148#01a06cf5-38d2-4274-86f4-545b720cde44) configured the semantic smoke with a longer operation timeout, but foreground import still ran through the fixed 30-second helper. The macOS x64 import was still reconciling semantic work when that inner bound returned 124.

## Scope correction

This PR previously proposed applying one shared deadline to daemon startup, import, status, and search. The current head transparently supersedes that broad proposal with the minimal import-only fix. The branch was updated by a normal fast-forward merge that preserves the prior proposal in history; the final diff changes only the semantic smoke script and its focused test.

## Validation

- `bash scripts/tests/smoke-daemon-semantic-release-test.sh`
- `scripts/bazelw test //:semantic_release_smoke_tests --config=test --test_output=errors`
- `scripts/bazel-affected.sh origin/main` (17/17 selected targets passed)
- Bash syntax and `git diff --check`
- standalone LOC and repository-policy checks
- exact-tree and reachable-history Pro disclosure final gate: clean, zero findings
- managed public push guard: clean

## Issue linkage

This is a release-CI regression correction and does not close a public issue. No issue was created solely to satisfy linkage policy.