### PR TITLE
fix(retention): reclaim released generations promptly

### DIFF
--- a/crates/ctx-daemon-cli/src/lib.rs
+++ b/crates/ctx-daemon-cli/src/lib.rs
@@ -293,7 +293,10 @@ pub use ctx_semantic_index::SemanticNotReady;
 #[allow(unused_imports)]
 pub use runtime_limits::SEMANTIC_WORKER_BATCH_MAX;
 mod query_adapter;
-pub use query_adapter::{wait_for_daemon_semantic_generation, SemanticQueryAdapter};
+pub use query_adapter::{
+    wait_for_daemon_semantic_generation, wait_for_daemon_semantic_generation_with_retained_peer,
+    SemanticQueryAdapter,
+};
 mod semantic_completion;
 pub use semantic_completion::{
     complete_semantic_generation_foreground,
@@ -317,7 +320,9 @@ mod source_backed_refresh_coordinator;
 pub use source_backed_refresh_coordinator::{
     coordinate_import_source_backed_refresh_with_progress,
     coordinate_setup_source_backed_refresh_with_progress, coordinate_source_backed_refresh,
-    coordinate_source_backed_refresh_with_progress, pin_active_verified_generation,
+    coordinate_source_backed_refresh_with_progress,
+    coordinate_source_backed_refresh_with_retained_peer, pin_active_verified_generation,
+    pin_active_verified_generation_with_retained_peer,
     published_explicit_source_relocation_authority, PinnedSourceBackedGeneration, RefreshStatus,
     SourceBackedRefreshDaemonUnavailable, SourceBackedRefreshMode, SourceBackedRefreshObservation,
     SourceBackedRefreshPendingPublication, SourceBackedRefreshTerminalError,

--- a/crates/ctx-daemon-cli/src/query_adapter.rs
+++ b/crates/ctx-daemon-cli/src/query_adapter.rs
@@ -67,6 +67,25 @@ pub fn wait_for_daemon_semantic_generation(
     )
 }
 
+/// Preserves compact-reference authority when semantic coverage supersedes a
+/// generation. The supplied pin must already own its requested peer; every
+/// replacement captures a new pair, while an unchanged generation keeps the
+/// original pair.
+pub fn wait_for_daemon_semantic_generation_with_retained_peer(
+    data_root: &Path,
+    pin: PinnedSourceBackedGeneration,
+    timeout: StdDuration,
+) -> Result<PinnedSourceBackedGeneration> {
+    wait_for_daemon_semantic_generation_with(
+        data_root,
+        pin,
+        timeout,
+        || crate::pin_active_verified_generation_with_retained_peer(data_root),
+        super::finite_worker_owner::checkpoint,
+        thread::sleep,
+    )
+}
+
 fn wait_for_daemon_semantic_generation_with<Repin, Checkpoint, Pause>(
     data_root: &Path,
     mut pin: PinnedSourceBackedGeneration,

--- a/crates/ctx-daemon-cli/src/query_adapter/tests.rs
+++ b/crates/ctx-daemon-cli/src/query_adapter/tests.rs
@@ -35,6 +35,7 @@ use super::*;
 
 mod cancellation;
 mod passive_v2;
+mod retained_peer;
 
 fn semantic_tempdir() -> Result<tempfile::TempDir> {
     let temporary = tempfile::tempdir()?;

--- a/crates/ctx-daemon-cli/src/query_adapter/tests/retained_peer.rs
+++ b/crates/ctx-daemon-cli/src/query_adapter/tests/retained_peer.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+#[test]
+fn semantic_supersession_preserves_the_requested_reader_pair_policy() -> Result<()> {
+    for retain_peer in [false, true] {
+        let temp = semantic_tempdir()?;
+        let root = ctx_history_refresh::source_backed_index_root(temp.path());
+        let (first, _) = semantic_index_revision_at(&root, 1, true)?;
+        let first_id = first.generation_id().to_owned();
+        let (second, _) = semantic_index_revision_at(&root, 2, true)?;
+        let second_id = second.generation_id().to_owned();
+        drop(second);
+        let initial = PinnedSourceBackedGeneration::from_index(first);
+        let pin = if retain_peer {
+            wait_for_daemon_semantic_generation_with_retained_peer(
+                temp.path(),
+                initial,
+                Duration::ZERO,
+            )?
+        } else {
+            wait_for_daemon_semantic_generation(temp.path(), initial, Duration::ZERO)?
+        };
+        assert_eq!(pin.generation_id(), second_id);
+
+        let (_third, _) = semantic_index_revision_at(&root, 3, true)?;
+        let mut index = pin.into_index();
+        let peer = index.take_retained_generation_peer_for_reader()?;
+        if retain_peer {
+            assert_eq!(peer.unwrap().generation_id(), first_id);
+        } else {
+            assert!(peer.is_none());
+            assert!(VerifiedIndex::open_pinned_generation(&root, &first_id).is_err());
+        }
+    }
+    Ok(())
+}

--- a/crates/ctx-daemon-cli/src/source_backed_refresh_coordinator.rs
+++ b/crates/ctx-daemon-cli/src/source_backed_refresh_coordinator.rs
@@ -6,10 +6,10 @@ use ctx_history_refresh::RefreshSelection;
 use super::daemon_service_ports::AVAILABILITY;
 
 pub use ctx_daemon_service::{
-    pin_active_verified_generation, published_explicit_source_relocation_authority,
-    PinnedSourceBackedGeneration, RefreshStatus, SourceBackedRefreshDaemonUnavailable,
-    SourceBackedRefreshMode, SourceBackedRefreshObservation, SourceBackedRefreshPendingPublication,
-    SourceBackedRefreshTerminalError,
+    pin_active_verified_generation, pin_active_verified_generation_with_retained_peer,
+    published_explicit_source_relocation_authority, PinnedSourceBackedGeneration, RefreshStatus,
+    SourceBackedRefreshDaemonUnavailable, SourceBackedRefreshMode, SourceBackedRefreshObservation,
+    SourceBackedRefreshPendingPublication, SourceBackedRefreshTerminalError,
 };
 pub use ctx_history_refresh::open_verified_index;
 
@@ -18,6 +18,17 @@ pub fn coordinate_source_backed_refresh(
     mode: SourceBackedRefreshMode,
 ) -> Result<SourceBackedRefreshObservation> {
     ctx_daemon_service::coordinate_source_backed_refresh(&AVAILABILITY, data_root, mode)
+}
+
+pub fn coordinate_source_backed_refresh_with_retained_peer(
+    data_root: &Path,
+    mode: SourceBackedRefreshMode,
+) -> Result<SourceBackedRefreshObservation> {
+    ctx_daemon_service::coordinate_source_backed_refresh_with_retained_peer(
+        &AVAILABILITY,
+        data_root,
+        mode,
+    )
 }
 
 pub fn coordinate_source_backed_refresh_with_progress(

--- a/crates/ctx-daemon-service/src/lib.rs
+++ b/crates/ctx-daemon-service/src/lib.rs
@@ -91,7 +91,9 @@ pub use semantic_completion::{
 pub use source_backed_refresh_coordinator::{
     coordinate_import_source_backed_refresh_with_progress,
     coordinate_setup_source_backed_refresh_with_progress, coordinate_source_backed_refresh,
-    coordinate_source_backed_refresh_with_progress, pin_active_verified_generation,
+    coordinate_source_backed_refresh_with_progress,
+    coordinate_source_backed_refresh_with_retained_peer, pin_active_verified_generation,
+    pin_active_verified_generation_with_retained_peer,
     published_explicit_source_relocation_authority, PinnedSourceBackedGeneration, RefreshSelection,
     RefreshStatus, SourceBackedCurrentSourceProgress, SourceBackedRefreshDaemonUnavailable,
     SourceBackedRefreshMode, SourceBackedRefreshObservation, SourceBackedRefreshPendingPublication,

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator.rs
@@ -412,7 +412,8 @@ impl CoreRefreshEngine {
 pub use client::{
     coordinate_import_source_backed_refresh_with_progress,
     coordinate_setup_source_backed_refresh_with_progress, coordinate_source_backed_refresh,
-    coordinate_source_backed_refresh_with_progress, SourceBackedRefreshDaemonUnavailable,
+    coordinate_source_backed_refresh_with_progress,
+    coordinate_source_backed_refresh_with_retained_peer, SourceBackedRefreshDaemonUnavailable,
     SourceBackedRefreshObservation, SourceBackedRefreshPendingPublication,
     SourceBackedRefreshTerminalError,
 };
@@ -458,8 +459,24 @@ pub(crate) fn pin_published_generation(
     Ok(ctx_history_refresh::pin_published_generation(data_root)?.map(PinnedSourceBackedGeneration))
 }
 
+pub(crate) fn pin_published_generation_with_retained_peer(
+    data_root: &Path,
+) -> Result<Option<PinnedSourceBackedGeneration>> {
+    Ok(
+        ctx_history_refresh::pin_published_generation_with_retained_peer(data_root)?
+            .map(PinnedSourceBackedGeneration),
+    )
+}
+
 pub fn pin_active_verified_generation(data_root: &Path) -> Result<PinnedSourceBackedGeneration> {
     ctx_history_refresh::pin_active_verified_generation(data_root).map(PinnedSourceBackedGeneration)
+}
+
+pub fn pin_active_verified_generation_with_retained_peer(
+    data_root: &Path,
+) -> Result<PinnedSourceBackedGeneration> {
+    ctx_history_refresh::pin_active_verified_generation_with_retained_peer(data_root)
+        .map(PinnedSourceBackedGeneration)
 }
 
 pub(crate) fn pin_retained_generation(
@@ -467,6 +484,14 @@ pub(crate) fn pin_retained_generation(
     generation_id: &str,
 ) -> Result<PinnedSourceBackedGeneration> {
     ctx_history_refresh::pin_retained_generation(data_root, generation_id)
+        .map(PinnedSourceBackedGeneration)
+}
+
+pub(crate) fn pin_retained_generation_with_retained_peer(
+    data_root: &Path,
+    generation_id: &str,
+) -> Result<PinnedSourceBackedGeneration> {
+    ctx_history_refresh::pin_retained_generation_with_retained_peer(data_root, generation_id)
         .map(PinnedSourceBackedGeneration)
 }
 

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client.rs
@@ -207,7 +207,17 @@ pub fn coordinate_source_backed_refresh(
     data_root: &Path,
     mode: SourceBackedRefreshMode,
 ) -> Result<SourceBackedRefreshObservation> {
-    coordinate_source_backed_refresh_inner(availability, data_root, mode, None)
+    coordinate_source_backed_refresh_inner(availability, data_root, mode, false, None)
+}
+
+/// Coordinates source-backed refresh and atomically pins the returned
+/// generation together with its retained pointer peer when one is available.
+pub fn coordinate_source_backed_refresh_with_retained_peer(
+    availability: &dyn crate::DaemonAvailabilityPort,
+    data_root: &Path,
+    mode: SourceBackedRefreshMode,
+) -> Result<SourceBackedRefreshObservation> {
+    coordinate_source_backed_refresh_inner(availability, data_root, mode, true, None)
 }
 
 pub fn coordinate_source_backed_refresh_with_progress(
@@ -216,7 +226,13 @@ pub fn coordinate_source_backed_refresh_with_progress(
     mode: SourceBackedRefreshMode,
     report_progress: &mut dyn FnMut(&RefreshStatus) -> Result<()>,
 ) -> Result<SourceBackedRefreshObservation> {
-    coordinate_source_backed_refresh_inner(availability, data_root, mode, Some(report_progress))
+    coordinate_source_backed_refresh_inner(
+        availability,
+        data_root,
+        mode,
+        false,
+        Some(report_progress),
+    )
 }
 
 pub fn coordinate_setup_source_backed_refresh_with_progress(
@@ -230,6 +246,7 @@ pub fn coordinate_setup_source_backed_refresh_with_progress(
         data_root,
         mode,
         RefreshRequestTrigger::Setup,
+        false,
         Some(report_progress),
     )
 }
@@ -238,6 +255,7 @@ fn coordinate_source_backed_refresh_inner(
     availability: &dyn crate::DaemonAvailabilityPort,
     data_root: &Path,
     mode: SourceBackedRefreshMode,
+    retain_peer: bool,
     report_progress: Option<SourceBackedRefreshProgressReporter<'_>>,
 ) -> Result<SourceBackedRefreshObservation> {
     coordinate_source_backed_refresh_inner_with_trigger(
@@ -245,6 +263,7 @@ fn coordinate_source_backed_refresh_inner(
         data_root,
         mode,
         RefreshRequestTrigger::Search,
+        retain_peer,
         report_progress,
     )
 }
@@ -254,6 +273,7 @@ fn coordinate_source_backed_refresh_inner_with_trigger(
     data_root: &Path,
     mode: SourceBackedRefreshMode,
     trigger: RefreshRequestTrigger,
+    retain_peer: bool,
     report_progress: Option<SourceBackedRefreshProgressReporter<'_>>,
 ) -> Result<SourceBackedRefreshObservation> {
     coordinate_source_backed_refresh_with_policy(
@@ -261,6 +281,7 @@ fn coordinate_source_backed_refresh_inner_with_trigger(
         data_root,
         mode,
         SourceBackedRefreshRequestPolicy::refresh(trigger),
+        retain_peer,
         report_progress,
     )
 }
@@ -296,6 +317,7 @@ fn coordinate_import_source_backed_refresh_inner(
         data_root,
         mode,
         SourceBackedRefreshRequestPolicy::import(selection, allow_daemon_autostart),
+        false,
         report_progress,
     )
 }
@@ -305,6 +327,7 @@ fn coordinate_source_backed_refresh_with_policy(
     data_root: &Path,
     mode: SourceBackedRefreshMode,
     policy: SourceBackedRefreshRequestPolicy,
+    retain_peer: bool,
     report_progress: Option<SourceBackedRefreshProgressReporter<'_>>,
 ) -> Result<SourceBackedRefreshObservation> {
     let SourceBackedRefreshRequestPolicy {
@@ -317,7 +340,11 @@ fn coordinate_source_backed_refresh_with_policy(
         if intent.operation() == ctx_history_refresh::RefreshOperation::Import {
             bail!("explicit source catalog imports require daemon refresh mode `wait`");
         }
-        let pin = pin_active_verified_generation(data_root)?;
+        let pin = if retain_peer {
+            pin_active_verified_generation_with_retained_peer(data_root)?
+        } else {
+            pin_active_verified_generation(data_root)?
+        };
         return Ok(SourceBackedRefreshObservation {
             mode,
             status: "off".to_owned(),
@@ -350,7 +377,7 @@ fn coordinate_source_backed_refresh_with_policy(
             .context("start or recover daemon before source-backed refresh")?
             == crate::DaemonAvailability::Disabled
     {
-        return daemon_unavailable_fallback(data_root, mode, None);
+        return daemon_unavailable_fallback(data_root, mode, retain_peer, None);
     }
     // Availability may synchronously launch and retain a finite worker. Catch
     // an interrupt from that work before admission can reach IPC.
@@ -387,7 +414,7 @@ fn coordinate_source_backed_refresh_with_policy(
             {
                 None
             }
-            Ok(None) => return daemon_unavailable_fallback(data_root, mode, None),
+            Ok(None) => return daemon_unavailable_fallback(data_root, mode, retain_peer, None),
             Err(error)
                 if error
                     .downcast_ref::<DaemonSourceRefreshServiceUnavailable>()
@@ -403,7 +430,7 @@ fn coordinate_source_backed_refresh_with_policy(
                     .downcast_ref::<DaemonSourceRefreshServiceUnavailable>()
                     .is_some() =>
             {
-                return daemon_unavailable_fallback(data_root, mode, Some(error));
+                return daemon_unavailable_fallback(data_root, mode, retain_peer, Some(error));
             }
             Err(error) => return Err(error),
         };
@@ -418,7 +445,7 @@ fn coordinate_source_backed_refresh_with_policy(
             .context("recover daemon after source refresh endpoint retirement")?
             == crate::DaemonAvailability::Disabled
         {
-            return daemon_unavailable_fallback(data_root, mode, retirement_error);
+            return daemon_unavailable_fallback(data_root, mode, retain_peer, retirement_error);
         }
         availability.checkpoint()?;
     };
@@ -447,6 +474,7 @@ fn coordinate_source_backed_refresh_with_policy(
                     request_id,
                     mode,
                     intent.explicit_source_authority(),
+                    retain_peer,
                 );
             }
             RefreshRequestState::Failed => {
@@ -457,7 +485,12 @@ fn coordinate_source_backed_refresh_with_policy(
             | RefreshRequestState::Running => {}
         }
         let source_count = response_source_count(&response);
-        let Some(pin) = pin_published_generation(data_root)? else {
+        let pin = if retain_peer {
+            pin_published_generation_with_retained_peer(data_root)?
+        } else {
+            pin_published_generation(data_root)?
+        };
+        let Some(pin) = pin else {
             return Err(SourceBackedRefreshPendingPublication::new(
                 request_id,
                 request_state.as_str().to_owned(),
@@ -488,6 +521,7 @@ fn coordinate_source_backed_refresh_with_policy(
             intent,
             trigger,
             allow_daemon_autostart,
+            retain_peer,
             report_progress,
         },
     )
@@ -524,6 +558,7 @@ pub(super) fn wait_for_published_generation(
                 ctx_history_refresh::RefreshOperation::Import => RefreshRequestTrigger::Import,
             },
             allow_daemon_autostart,
+            retain_peer: false,
             report_progress: None,
         },
     )
@@ -534,6 +569,7 @@ struct PublishedGenerationWait<'progress> {
     intent: RefreshIntent,
     trigger: RefreshRequestTrigger,
     allow_daemon_autostart: bool,
+    retain_peer: bool,
     report_progress: Option<SourceBackedRefreshProgressReporter<'progress>>,
 }
 
@@ -548,6 +584,7 @@ fn wait_for_published_generation_inner(
         intent,
         trigger,
         allow_daemon_autostart,
+        retain_peer,
         mut report_progress,
     } = wait;
     let mut last_reported_status = None;
@@ -655,6 +692,7 @@ fn wait_for_published_generation_inner(
                     request_id,
                     mode,
                     intent.explicit_source_authority(),
+                    retain_peer,
                 );
             }
             RefreshRequestState::Failed => {
@@ -675,12 +713,18 @@ fn published_refresh_observation(
     request_id: String,
     mode: SourceBackedRefreshMode,
     expected_catalog: Option<&ExplicitSourceCatalogAuthority>,
+    retain_peer: bool,
 ) -> Result<SourceBackedRefreshObservation> {
     let expected = response
         .get("published_generation")
         .and_then(Value::as_str)
         .ok_or_else(|| anyhow!("published daemon source refresh has no generation ID"))?;
-    let pin = pin_retained_generation(data_root, expected).with_context(|| {
+    let pin = if retain_peer {
+        pin_retained_generation_with_retained_peer(data_root, expected)
+    } else {
+        pin_retained_generation(data_root, expected)
+    }
+    .with_context(|| {
         format!(
             "daemon published Core generation {expected}, but its retained terminal generation cannot be opened"
         )

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client/response.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client/response.rs
@@ -33,10 +33,16 @@ fn legacy_failed_refresh_response(response: &Value) -> Result<SourceBackedRefres
 pub(super) fn daemon_unavailable_fallback(
     data_root: &Path,
     mode: SourceBackedRefreshMode,
+    retain_peer: bool,
     error: Option<anyhow::Error>,
 ) -> Result<SourceBackedRefreshObservation> {
     if mode == SourceBackedRefreshMode::Background {
-        if let Some(pin) = pin_published_generation(data_root)? {
+        let pin = if retain_peer {
+            pin_published_generation_with_retained_peer(data_root)?
+        } else {
+            pin_published_generation(data_root)?
+        };
+        if let Some(pin) = pin {
             return Ok(SourceBackedRefreshObservation {
                 mode,
                 status: "daemon_unavailable".to_owned(),

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client_admission_recovery_tests.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client_admission_recovery_tests.rs
@@ -186,6 +186,7 @@ fn missing_endpoint_before_any_roundtrip_remains_genuinely_unavailable() {
     let Err(error) = daemon_unavailable_fallback(
         Path::new("unused-for-wait-mode"),
         SourceBackedRefreshMode::Wait,
+        false,
         None,
     ) else {
         panic!("wait mode must reject a genuinely missing daemon endpoint");

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client_transport_recovery_tests.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client_transport_recovery_tests.rs
@@ -84,6 +84,7 @@ fn background_maintenance_wake_is_accepted_through_client_and_coordinator() -> R
             trigger: RefreshRequestTrigger::Search,
             allow_daemon_autostart: false,
         },
+        false,
         None,
     )?;
 
@@ -331,6 +332,7 @@ fn background_lost_ack_terminal_replay_is_not_reported_as_pending() -> Result<()
             trigger: RefreshRequestTrigger::Search,
             allow_daemon_autostart: false,
         },
+        false,
         None,
     ) {
         Ok(_) => panic!("terminal failed replay must remain a failure"),
@@ -497,6 +499,7 @@ fn autostarted_wait_acknowledgement_then_restart_unknown_is_not_replayed() -> Re
             trigger: RefreshRequestTrigger::Search,
             allow_daemon_autostart: true,
         },
+        false,
         None,
     ) {
         Ok(_) => {

--- a/crates/ctx-history-cli/src/semantic.rs
+++ b/crates/ctx-history-cli/src/semantic.rs
@@ -1,5 +1,6 @@
 //! Daemon-owned semantic and refresh adapters exposed without final CLI types.
 
 pub use ctx_daemon_cli::{
-    coordinate_source_backed_refresh, SemanticNotReady, SemanticQueryAdapter,
+    coordinate_source_backed_refresh, coordinate_source_backed_refresh_with_retained_peer,
+    SemanticNotReady, SemanticQueryAdapter,
 };

--- a/crates/ctx-history-cli/src/source_index/compact_presentation.rs
+++ b/crates/ctx-history-cli/src/source_index/compact_presentation.rs
@@ -23,10 +23,18 @@ pub(crate) fn open_generation_read(
 ) -> Result<GenerationRead> {
     let root = super::shared::index_root(data_root);
     let index = match &request.target {
-        GenerationReadTarget::Active => super::shared::open_index(data_root)?,
-        GenerationReadTarget::Exact(generation_id) => {
-            VerifiedIndex::open_pinned_generation(&root, generation_id)?
-        }
+        GenerationReadTarget::Active => match request.retained_peer {
+            RetainedPeerRead::Omit => super::shared::open_index(data_root)?,
+            RetainedPeerRead::IfAvailable => {
+                super::shared::open_index_with_retained_peer(data_root)?
+            }
+        },
+        GenerationReadTarget::Exact(generation_id) => match request.retained_peer {
+            RetainedPeerRead::Omit => VerifiedIndex::open_pinned_generation(&root, generation_id)?,
+            RetainedPeerRead::IfAvailable => {
+                VerifiedIndex::open_pinned_generation_with_retained_peer(&root, generation_id)?
+            }
+        },
     };
     generation_read(index, request)
 }

--- a/crates/ctx-history-cli/src/source_index/locate.rs
+++ b/crates/ctx-history-cli/src/source_index/locate.rs
@@ -14,9 +14,9 @@ use crate::{
 };
 
 use super::{
-    compact_presentation::generation_read,
+    compact_presentation::open_generation_read,
     render::{pretty_json_stdout_bytes, render_locate_document},
-    shared::{externalize_query_error, open_index},
+    shared::externalize_query_error,
 };
 
 pub fn run_locate(
@@ -46,7 +46,7 @@ pub fn run_locate(
         ),
     };
     let mut generation = |read: &ctx_history_read_application::GenerationReadRequest| {
-        generation_read(open_index(&data_root)?, read)
+        open_generation_read(&data_root, read)
     };
     let result = execute_locate(
         LocateApplicationRequest {

--- a/crates/ctx-history-cli/src/source_index/search.rs
+++ b/crates/ctx-history-cli/src/source_index/search.rs
@@ -20,7 +20,9 @@ use crate::{
     config,
     local_usage::{CliUsage, ResultObservationAction, SearchContextObservation},
     output::JsonOutputFormat,
-    semantic::coordinate_source_backed_refresh,
+    semantic::{
+        coordinate_source_backed_refresh, coordinate_source_backed_refresh_with_retained_peer,
+    },
     ui::{
         canonical_human_output_bytes, diagnostic, Action, Diagnostic, DiagnosticLevel, Document,
         RenderContext, Ui,
@@ -29,8 +31,8 @@ use crate::{
 };
 use ctx_daemon_cli::{
     wait_for_daemon_query_service_cancellable, wait_for_daemon_semantic_generation,
-    PinnedSourceBackedGeneration, SourceBackedRefreshDaemonUnavailable, SourceBackedRefreshMode,
-    SourceBackedRefreshObservation,
+    wait_for_daemon_semantic_generation_with_retained_peer, PinnedSourceBackedGeneration,
+    SourceBackedRefreshDaemonUnavailable, SourceBackedRefreshMode, SourceBackedRefreshObservation,
 };
 
 use super::{
@@ -40,7 +42,7 @@ use super::{
         render_active_generation_race, ActiveGenerationRaceCommand,
     },
 };
-use ctx_history_read_application::SearchBackend;
+use ctx_history_read_application::{RetainedPeerRead, SearchBackend};
 
 pub(in crate::source_index) use hydration::SearchPresentation;
 use observation::{
@@ -60,7 +62,7 @@ use test_support::collect_search_hits_with_port;
 #[cfg(test)]
 pub(super) use test_support::{
     collect_search_hits_with_backend, collect_search_hits_with_backend_using,
-    search_existing_generation,
+    search_existing_generation, search_existing_generation_with_compact_projection,
 };
 
 const MAX_USAGE_CONTEXT_EVENTS_PER_SESSION: usize = 256;
@@ -401,6 +403,8 @@ fn run_search_inner<P: HistorySemanticPort>(
     let compact_projection = compact_search_projection(json_output, verbose);
     let plan = ctx_history_read_application::plan_search(request, policy)?;
     let request = plan.request();
+    let retained_peer =
+        ctx_history_read_application::retained_peer_read_for_search(request, compact_projection);
     let requested_backend = request.backend.unwrap_or(policy.default_backend);
     observation.backend_requested = Some(requested_backend);
     let semantic_weight = request.semantic_weight;
@@ -413,13 +417,28 @@ fn run_search_inner<P: HistorySemanticPort>(
     if should_wait_for_daemon_query_service(refresh_mode, config.daemon.enabled) && needs_semantic {
         let _ = wait_for_daemon_query_service_cancellable(&data_root, Duration::from_secs(3))?;
     }
-    let mut refresh = observed_refresh_for_search(request, refresh_mode, &data_root, observation)?;
+    let mut refresh = observed_refresh_for_search(
+        request,
+        refresh_mode,
+        &data_root,
+        retained_peer,
+        observation,
+    )?;
     if refresh_mode == RefreshArg::Wait && config.daemon.enabled && needs_semantic {
-        refresh.pin = wait_for_daemon_semantic_generation(
-            &data_root,
-            refresh.pin,
-            SEMANTIC_GENERATION_WAIT_TIMEOUT,
-        )?;
+        refresh.pin = match retained_peer {
+            RetainedPeerRead::Omit => wait_for_daemon_semantic_generation(
+                &data_root,
+                refresh.pin,
+                SEMANTIC_GENERATION_WAIT_TIMEOUT,
+            )?,
+            RetainedPeerRead::IfAvailable => {
+                wait_for_daemon_semantic_generation_with_retained_peer(
+                    &data_root,
+                    refresh.pin,
+                    SEMANTIC_GENERATION_WAIT_TIMEOUT,
+                )?
+            }
+        };
     }
     let search_result = search_pinned_generation(
         plan,
@@ -721,8 +740,15 @@ fn mcp_search_inner<P: HistorySemanticPort>(
     let plan = ctx_history_read_application::plan_search(request, policy)?;
     let requested_backend = plan.request().backend.unwrap_or(policy.default_backend);
     observation.backend_requested = Some(requested_backend);
-    let refresh =
-        observed_refresh_for_search(plan.request(), RefreshArg::Off, data_root, observation)?;
+    let retained_peer =
+        ctx_history_read_application::retained_peer_read_for_search(plan.request(), true);
+    let refresh = observed_refresh_for_search(
+        plan.request(),
+        RefreshArg::Off,
+        data_root,
+        retained_peer,
+        observation,
+    )?;
     let result = search_pinned_generation(
         plan,
         data_root,
@@ -813,13 +839,22 @@ pub(super) fn refresh_for_search(
     request: &SourceSearchRequest,
     refresh: RefreshArg,
     data_root: &Path,
+    retained_peer: RetainedPeerRead,
 ) -> SourceSearchResult<RefreshOutcome> {
-    refresh_for_search_with(
-        request,
-        refresh,
-        data_root,
-        coordinate_source_backed_refresh,
-    )
+    match retained_peer {
+        RetainedPeerRead::Omit => refresh_for_search_with(
+            request,
+            refresh,
+            data_root,
+            coordinate_source_backed_refresh,
+        ),
+        RetainedPeerRead::IfAvailable => refresh_for_search_with(
+            request,
+            refresh,
+            data_root,
+            coordinate_source_backed_refresh_with_retained_peer,
+        ),
+    }
 }
 
 pub(super) fn refresh_for_search_with<Coordinate>(

--- a/crates/ctx-history-cli/src/source_index/search/observation.rs
+++ b/crates/ctx-history-cli/src/source_index/search/observation.rs
@@ -2,7 +2,7 @@ use std::{path::Path, time::Instant};
 
 use ctx_history_index::VerifiedIndex;
 use ctx_history_read_application::{
-    SearchCollection, SearchFailurePhase as ApplicationFailurePhase,
+    RetainedPeerRead, SearchCollection, SearchFailurePhase as ApplicationFailurePhase,
 };
 use serde_json::Value;
 
@@ -33,11 +33,12 @@ pub(super) fn observed_refresh_for_search(
     request: &SourceSearchRequest,
     mode: RefreshArg,
     data_root: &Path,
+    retained_peer: RetainedPeerRead,
     observation: &mut SearchExecutionObservation,
 ) -> SourceSearchResult<RefreshOutcome> {
     observation.failure_phase = Some(SearchFailurePhase::Refresh);
     let started = Instant::now();
-    let result = refresh_for_search(request, mode, data_root);
+    let result = refresh_for_search(request, mode, data_root, retained_peer);
     observation.refresh_duration = Some(started.elapsed());
     match result {
         Ok(refresh) => {

--- a/crates/ctx-history-cli/src/source_index/search/test_support.rs
+++ b/crates/ctx-history-cli/src/source_index/search/test_support.rs
@@ -52,6 +52,39 @@ pub(in crate::source_index) fn search_existing_generation(
     .map_err(SourceSearchFailure::into_anyhow)
 }
 
+pub(in crate::source_index) fn search_existing_generation_with_compact_projection(
+    request: &SourceSearchRequest,
+    index: VerifiedIndex,
+    data_root: &Path,
+) -> Result<(Value, Value, VerifiedIndex)> {
+    let policy = ctx_history_read_application::SearchPolicy {
+        default_backend: request.backend.unwrap_or(SearchBackend::Lexical),
+        semantic: SemanticAvailability::Available,
+    };
+    let plan = ctx_history_read_application::plan_search(request.clone(), policy)
+        .map_err(SourceSearchFailure::from)
+        .map_err(SourceSearchFailure::into_anyhow)?;
+    let mut observation = initial_search_observation();
+    let (value, application) = search_existing_generation_with_port(
+        plan,
+        index,
+        data_root,
+        SearchRefreshContext {
+            mode: RefreshArg::Off,
+            status: "existing_generation",
+            source_count: 1,
+        },
+        true,
+        &crate::semantic::SemanticQueryAdapter::new(data_root),
+        None,
+        &mut observation,
+    )
+    .map_err(SourceSearchFailure::into_anyhow)?;
+    let compact = application.project_read_model(&value)?;
+    let (_, index) = application.into_parts();
+    Ok((value, compact, index))
+}
+
 pub(in crate::source_index) fn collect_search_hits_with_backend(
     request: &SourceSearchRequest,
     data_root: &Path,
@@ -82,7 +115,15 @@ pub(super) fn collect_search_hits_with_port<P: HistorySemanticPort>(
     let plan = ctx_history_read_application::plan_search(planned, policy)
         .map_err(SourceSearchFailure::from)
         .map_err(SourceSearchFailure::into_anyhow)?;
-    let index = VerifiedIndex::open_pinned(index_root(data_root))?;
+    let index =
+        match ctx_history_read_application::retained_peer_read_for_search(plan.request(), false) {
+            ctx_history_read_application::RetainedPeerRead::Omit => {
+                VerifiedIndex::open_pinned(index_root(data_root))?
+            }
+            ctx_history_read_application::RetainedPeerRead::IfAvailable => {
+                VerifiedIndex::open_pinned_with_retained_peer(index_root(data_root))?
+            }
+        };
     let mut observation = initial_search_observation();
     let (_, application) = search_existing_generation_with_port(
         plan,

--- a/crates/ctx-history-cli/src/source_index/shared.rs
+++ b/crates/ctx-history-cli/src/source_index/shared.rs
@@ -287,8 +287,20 @@ pub(super) fn render_missing_lookup(
 }
 
 pub(super) fn open_index(data_root: &Path) -> Result<VerifiedIndex> {
+    open_index_with(data_root, false)
+}
+
+pub(super) fn open_index_with_retained_peer(data_root: &Path) -> Result<VerifiedIndex> {
+    open_index_with(data_root, true)
+}
+
+fn open_index_with(data_root: &Path, retain_peer: bool) -> Result<VerifiedIndex> {
     let root = index_root(data_root);
-    let index = match VerifiedIndex::open_pinned(&root) {
+    let index = match if retain_peer {
+        VerifiedIndex::open_pinned_with_retained_peer(&root)
+    } else {
+        VerifiedIndex::open_pinned(&root)
+    } {
         Ok(index) => index,
         Err(ctx_history_index::IndexError::MissingActiveGenerationPointer) => {
             return Err(anyhow!(

--- a/crates/ctx-history-cli/src/source_index/tests.rs
+++ b/crates/ctx-history-cli/src/source_index/tests.rs
@@ -209,7 +209,8 @@ fn retained_compact_peer_opens_its_exact_verified_generation() {
         "legacy nonempty retained peer successor",
     );
     append_fixture_session(nonempty.path(), &[successor], 94);
-    let current = open_index(nonempty.path()).unwrap();
+    let current =
+        VerifiedIndex::open_pinned_with_retained_peer(index_root(nonempty.path())).unwrap();
     assert_ne!(current.generation_id(), peer_generation);
     let compact = generation_with_retained_peer(current).unwrap();
     assert!(compact.retained_peer().is_some());
@@ -226,7 +227,7 @@ fn retained_compact_peer_opens_its_exact_verified_generation() {
     let temp = tempdir().unwrap();
     let peer_generation = publish_empty_generation(temp.path());
     write_test_generation(temp.path());
-    let current = open_index(temp.path()).unwrap();
+    let current = VerifiedIndex::open_pinned_with_retained_peer(index_root(temp.path())).unwrap();
     assert_ne!(current.generation_id(), peer_generation);
     let compact = generation_with_retained_peer(current).unwrap();
     assert_eq!(

--- a/crates/ctx-history-cli/src/source_index/tests.rs
+++ b/crates/ctx-history-cli/src/source_index/tests.rs
@@ -1,4 +1,5 @@
 mod activity;
+mod compact_authority;
 mod semantic_fallback;
 mod show_lineage;
 
@@ -23,7 +24,8 @@ use ctx_history_core::{
     CoreContentPolicyStatus, CoreRecord, EventIdentityInput, LiteralFactKind, NativeItemKey,
     NativeSessionKey, ProviderDeclaredFact, ProviderNativeCopyProof, ProviderNativeEventCopy,
     ProviderNativeSessionRelationship, ScannedSourceCounts, SessionIdentityInput, SourceAnchor,
-    SourceKey, SourceObservation, TypedKey, CORE_ACTIVITY_REVISION, MAX_CORE_CONTENT_BYTES,
+    SourceKey, SourceObservation, StableEntityId, TypedKey, CORE_ACTIVITY_REVISION,
+    MAX_CORE_CONTENT_BYTES,
 };
 use ctx_history_index::{
     CompiledSearchFilter, EventSearchCandidate, EventSearchFilters, GenerationWriter, IndexError,
@@ -48,8 +50,9 @@ use super::{
         render_show_document, search_json, SEARCH_SNIPPET_MAX_BYTES, SEARCH_SNIPPET_MAX_CHARS,
     },
     search::{
-        resolve_source_search_backend, semantic_reason_code, NormalizedSearchQuery,
-        SearchCollection, SearchEventMetadata, SearchHit, SearchPresentation, SearchResultWindow,
+        resolve_source_search_backend, search_existing_generation_with_compact_projection,
+        semantic_reason_code, NormalizedSearchQuery, SearchCollection, SearchEventMetadata,
+        SearchHit, SearchPresentation, SearchResultWindow,
     },
     show::{
         canonical_show_output_bytes, event_window_value, mcp_show_event, mcp_show_session,

--- a/crates/ctx-history-cli/src/source_index/tests/additional.rs
+++ b/crates/ctx-history-cli/src/source_index/tests/additional.rs
@@ -5,8 +5,13 @@ fn refresh_off_uses_the_existing_generation_without_activation() {
     let temp = tempdir().unwrap();
     write_test_generation(temp.path());
 
-    let outcome =
-        refresh_for_search(&request(RefreshArg::Off), RefreshArg::Off, temp.path()).unwrap();
+    let outcome = refresh_for_search(
+        &request(RefreshArg::Off),
+        RefreshArg::Off,
+        temp.path(),
+        ctx_history_read_application::RetainedPeerRead::Omit,
+    )
+    .unwrap();
 
     assert_eq!(outcome.status, "existing_generation");
     assert_eq!(
@@ -66,8 +71,9 @@ fn two_rotations_keep_machine_compact_and_human_reads_pinned() {
     let temp = tempdir().unwrap();
     write_test_generation(temp.path());
     let machine_pin = open_index(temp.path()).unwrap();
-    let compact_pin = open_index(temp.path()).unwrap();
-    let human_pin = open_index(temp.path()).unwrap();
+    let compact_pin =
+        VerifiedIndex::open_pinned_with_retained_peer(index_root(temp.path())).unwrap();
+    let human_pin = VerifiedIndex::open_pinned_with_retained_peer(index_root(temp.path())).unwrap();
     let session_id = machine_pin
         .sessions_by_provider_session_id(TEST_SESSION_ID, Some("codex"), None, None)
         .unwrap()[0]

--- a/crates/ctx-history-cli/src/source_index/tests/compact_authority.rs
+++ b/crates/ctx-history-cli/src/source_index/tests/compact_authority.rs
@@ -1,0 +1,293 @@
+use super::*;
+
+#[test]
+fn human_search_lengths_ids_against_colliding_retained_generation() {
+    let temp = tempdir().unwrap();
+    write_test_generation(temp.path());
+    let (_, active) = compact_collision_pair(temp.path(), "compact authority search needle");
+    let event = active.event.event_id.as_uuid().simple().to_string();
+    let session = active.event.session_id.as_uuid().simple().to_string();
+    let (mut ui, stdout) = test_ui();
+    let mut usage = CliUsage::excluded();
+    let mut args = lexical_search_args();
+    args.query = Some("compact authority search needle".to_owned());
+    let mut observation = None;
+
+    run_search(
+        args,
+        temp.path().to_path_buf(),
+        history_snapshot(false, false),
+        &mut usage,
+        &mut ui,
+        |value| observation = Some(value),
+    )
+    .unwrap();
+    ui.flush().unwrap();
+
+    assert_eq!(observation.unwrap().result_count, Some(1));
+    let rendered = String::from_utf8(stdout.bytes()).unwrap();
+    assert!(rendered.lines().any(|line| {
+        line.trim_start()
+            .strip_prefix("Session")
+            .is_some_and(|value| value.trim() == &session[..9])
+    }));
+    assert!(rendered.lines().any(|line| {
+        line.trim_start()
+            .strip_prefix("Event")
+            .is_some_and(|value| value.trim() == &event[..9])
+    }));
+    assert!(!rendered.contains(&active.event.event_id.as_uuid().to_string()));
+    assert!(!rendered.contains(&active.event.session_id.as_uuid().to_string()));
+}
+
+#[test]
+fn mcp_compact_search_lengths_ids_against_colliding_retained_generation() {
+    let temp = tempdir().unwrap();
+    write_test_generation(temp.path());
+    let (_, active) = compact_collision_pair(temp.path(), "mcp compact authority needle");
+    let event = active.event.event_id.as_uuid();
+    let session = active.event.session_id.as_uuid();
+    let mut request = request(RefreshArg::Off);
+    request.query = "mcp compact authority needle".to_owned();
+
+    let (full, _, compact, observation) =
+        mcp_search_with_compact(request, temp.path(), history_snapshot(false, false)).unwrap();
+
+    assert_eq!(observation.result_count, Some(1));
+    assert_eq!(full["results"][0]["ctx_event_id"], event.to_string());
+    assert_eq!(full["results"][0]["ctx_session_id"], session.to_string());
+    assert_eq!(
+        compact["results"][0]["ctx_event_id"],
+        event.simple().to_string()[..9]
+    );
+    assert_eq!(
+        compact["results"][0]["ctx_session_id"],
+        session.simple().to_string()[..9]
+    );
+    assert_eq!(
+        full["results"][0]["citations"][0]["item_id"],
+        event.to_string()
+    );
+    assert_eq!(
+        compact["results"][0]["citations"][0]["item_id"],
+        event.to_string()
+    );
+    assert_eq!(
+        compact["results"][0]["citations"][0]["ctx_event_id"],
+        event.simple().to_string()[..9]
+    );
+    assert_eq!(
+        compact["results"][0]["citations"][0]["ctx_session_id"],
+        session.simple().to_string()[..9]
+    );
+    let commands =
+        serde_json::to_string(&compact["results"][0]["suggested_next_commands"]).unwrap();
+    assert!(commands.contains(&event.simple().to_string()[..9]));
+    assert!(!commands.contains(&event.to_string()));
+    assert!(!commands.contains(&session.to_string()));
+}
+
+#[test]
+fn locate_compact_output_and_selectors_use_retained_generation() {
+    let temp = tempdir().unwrap();
+    write_test_generation(temp.path());
+    let (retained, active) = compact_collision_pair(temp.path(), "locate compact authority");
+    let active_event = active.event.event_id.as_uuid().simple().to_string();
+    let active_session = active.event.session_id.as_uuid().simple().to_string();
+
+    for format in [JsonOutputFormat::Text, JsonOutputFormat::Json] {
+        for (target, retained_id, active_id) in [
+            (
+                crate::LocateTarget::Event(crate::LocateEventArgs {
+                    id: active_event[..8].to_owned(),
+                    format,
+                }),
+                retained.event.event_id.as_uuid(),
+                active.event.event_id.as_uuid(),
+            ),
+            (
+                crate::LocateTarget::Session(crate::LocateSessionArgs {
+                    id: Some(active_session[..8].to_owned()),
+                    provider: None,
+                    provider_session: None,
+                    provider_key: None,
+                    source_id: None,
+                    format,
+                }),
+                retained.event.session_id.as_uuid(),
+                active.event.session_id.as_uuid(),
+            ),
+        ] {
+            let (mut ui, _) = test_ui();
+            let mut usage = CliUsage::excluded();
+            let error = run_locate(
+                crate::LocateArgs { target },
+                temp.path().to_path_buf(),
+                &mut usage,
+                &mut ui,
+            )
+            .unwrap_err();
+            let detail = error.to_string();
+            assert!(detail.contains("ambiguous"), "{detail}");
+            assert!(detail.contains(&retained_id.to_string()), "{detail}");
+            assert!(detail.contains(&active_id.to_string()), "{detail}");
+        }
+    }
+
+    for full_id in [false, true] {
+        let event_id = if full_id {
+            active.event.event_id.to_string()
+        } else {
+            active_event[..9].to_owned()
+        };
+        let session_id = if full_id {
+            active.event.session_id.to_string()
+        } else {
+            active_session[..9].to_owned()
+        };
+        for target in [
+            crate::LocateTarget::Event(crate::LocateEventArgs {
+                id: event_id,
+                format: JsonOutputFormat::Text,
+            }),
+            crate::LocateTarget::Session(crate::LocateSessionArgs {
+                id: Some(session_id),
+                provider: None,
+                provider_session: None,
+                provider_key: None,
+                source_id: None,
+                format: JsonOutputFormat::Text,
+            }),
+        ] {
+            let is_event = matches!(target, crate::LocateTarget::Event(_));
+            let (mut ui, stdout) = test_ui();
+            run_locate(
+                crate::LocateArgs { target },
+                temp.path().to_path_buf(),
+                &mut CliUsage::excluded(),
+                &mut ui,
+            )
+            .unwrap();
+            ui.flush().unwrap();
+            let rendered = String::from_utf8(stdout.bytes()).unwrap();
+            if is_event {
+                assert!(rendered.contains(&active_event[..9]), "{rendered}");
+            }
+            assert!(rendered.contains(&active_session[..9]), "{rendered}");
+        }
+    }
+}
+
+#[test]
+fn compact_search_keeps_original_refresh_pair_across_pointer_rotation() {
+    let temp = tempdir().unwrap();
+    write_test_generation(temp.path());
+    let (_, active) = compact_collision_pair(temp.path(), "rotationcompactauthorityneedle");
+    let mut request = request(RefreshArg::Off);
+    request.query = "rotationcompactauthorityneedle".to_owned();
+    let refresh = refresh_for_search(
+        &request,
+        RefreshArg::Off,
+        temp.path(),
+        ctx_history_read_application::retained_peer_read_for_search(&request, true),
+    )
+    .unwrap();
+    let pinned_generation = refresh.pin.generation_id().to_owned();
+    let event = active.event.event_id.as_uuid().simple().to_string();
+    let session = active.event.session_id.as_uuid().simple().to_string();
+
+    let rotated = fixture_core_event(
+        &fixture_event(CaptureProvider::Codex, "codex_session_jsonl", 89, 3),
+        "new pointer generation",
+    );
+    append_fixture_session(temp.path(), std::slice::from_ref(&rotated), 91);
+    assert_ne!(
+        open_index(temp.path()).unwrap().generation_id(),
+        pinned_generation
+    );
+
+    let (full, compact, index) = search_existing_generation_with_compact_projection(
+        &request,
+        refresh.pin.into_index(),
+        temp.path(),
+    )
+    .unwrap();
+
+    assert_eq!(index.generation_id(), pinned_generation);
+    assert_eq!(full["results"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        full["results"][0]["ctx_event_id"],
+        active.event.event_id.to_string()
+    );
+    assert_eq!(compact["results"][0]["ctx_event_id"], event[..9]);
+    assert_eq!(compact["results"][0]["ctx_session_id"], session[..9]);
+}
+
+#[test]
+fn search_compact_filters_require_peer_even_with_full_id_output() {
+    let temp = tempdir().unwrap();
+    write_test_generation(temp.path());
+    let (retained, active) = compact_collision_pair(temp.path(), "selector authority needle");
+    let session = active.event.session_id.as_uuid().simple().to_string();
+    for exclude in [false, true] {
+        for format in [JsonOutputFormat::Json, JsonOutputFormat::Text] {
+            let mut args = lexical_search_args();
+            args.query = Some("selector authority needle".to_owned());
+            args.format = format;
+            args.verbose = true;
+            if exclude {
+                args.exclude_sessions = vec![session[..8].to_owned()];
+            } else {
+                args.session = Some(session[..8].to_owned());
+            }
+            let (mut ui, _) = test_ui();
+            let error = run_search(
+                args,
+                temp.path().to_path_buf(),
+                history_snapshot(false, false),
+                &mut CliUsage::excluded(),
+                &mut ui,
+                |_| {},
+            )
+            .unwrap_err();
+            let detail = error.to_string();
+            assert!(detail.contains("ambiguous"), "{detail}");
+            assert!(
+                detail.contains(&retained.event.session_id.to_string()),
+                "{detail}"
+            );
+            assert!(
+                detail.contains(&active.event.session_id.to_string()),
+                "{detail}"
+            );
+        }
+    }
+
+    for selector in [active.event.session_id.to_string(), session[..9].to_owned()] {
+        let mut args = lexical_search_args();
+        args.query = Some("selector authority needle".to_owned());
+        args.format = JsonOutputFormat::Json;
+        args.session = Some(selector);
+        let (mut ui, stdout) = test_ui();
+        run_search(
+            args,
+            temp.path().to_path_buf(),
+            history_snapshot(false, false),
+            &mut CliUsage::excluded(),
+            &mut ui,
+            |_| {},
+        )
+        .unwrap();
+        ui.flush().unwrap();
+        let full: Value = serde_json::from_slice(&stdout.bytes()).unwrap();
+        assert_eq!(full["results"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            full["results"][0]["ctx_event_id"],
+            active.event.event_id.to_string()
+        );
+        assert_eq!(
+            full["results"][0]["citations"][0]["ctx_session_id"],
+            active.event.session_id.to_string()
+        );
+    }
+}

--- a/crates/ctx-history-cli/src/source_index/tests/fixtures.rs
+++ b/crates/ctx-history-cli/src/source_index/tests/fixtures.rs
@@ -197,6 +197,79 @@ fn fixture_core_event(event: &EventRecord, body: impl Into<String>) -> CoreEvent
     }
 }
 
+fn stable_id_with_compact_prefix(
+    identity: StableEntityId,
+    prefix: [u8; 4],
+    discriminator: u8,
+) -> StableEntityId {
+    const DIGEST_OFFSET: usize = 3;
+    const UUID_OFFSET: usize = StableEntityId::CANONICAL_LEN - 16;
+
+    let mut encoded = identity.encode_canonical().unwrap();
+    encoded[DIGEST_OFFSET..DIGEST_OFFSET + prefix.len()].copy_from_slice(&prefix);
+    encoded[DIGEST_OFFSET + prefix.len()] = discriminator;
+    let mut uuid = [0_u8; 16];
+    uuid.copy_from_slice(&encoded[DIGEST_OFFSET..DIGEST_OFFSET + 16]);
+    uuid[6] = 0x80 | (uuid[6] & 0x0f);
+    uuid[8] = 0x80 | (uuid[8] & 0x3f);
+    encoded[UUID_OFFSET..].copy_from_slice(&uuid);
+    StableEntityId::decode_canonical(&encoded).unwrap()
+}
+
+fn force_compact_identity_prefix(
+    event: &mut CoreEventRecord,
+    prefix: [u8; 4],
+    discriminator: u8,
+) {
+    let event_id = stable_id_with_compact_prefix(event.event.event_id, prefix, discriminator);
+    let session_id = stable_id_with_compact_prefix(
+        event.event.session_id,
+        prefix,
+        discriminator.wrapping_add(1),
+    );
+    event.event.event_id = event_id;
+    event.event.session_id = session_id;
+    event.core_record.event_id = event_id;
+    event.core_record.session_id = session_id;
+    event.core_record.validate_contract().unwrap();
+}
+
+fn compact_collision_pair(data_root: &Path, body: &str) -> (CoreEventRecord, CoreEventRecord) {
+    const PREFIX: [u8; 4] = [0xca, 0xfe, 0xba, 0xbe];
+
+    let mut retained = fixture_core_event(
+        &fixture_event(CaptureProvider::Codex, "codex_session_jsonl", 89, 1),
+        "retained compact-prefix collider",
+    );
+    force_compact_identity_prefix(&mut retained, PREFIX, 0x10);
+    append_fixture_session(data_root, std::slice::from_ref(&retained), 89);
+
+    let mut active = fixture_core_event(
+        &fixture_event(CaptureProvider::Codex, "codex_session_jsonl", 89, 2),
+        body,
+    );
+    force_compact_identity_prefix(&mut active, PREFIX, 0x20);
+    append_fixture_session(data_root, std::slice::from_ref(&active), 90);
+
+    assert_eq!(
+        &retained.event.event_id.as_uuid().simple().to_string()[..8],
+        &active.event.event_id.as_uuid().simple().to_string()[..8]
+    );
+    assert_eq!(
+        &retained.event.session_id.as_uuid().simple().to_string()[..8],
+        &active.event.session_id.as_uuid().simple().to_string()[..8]
+    );
+    assert_ne!(retained.event.event_id, active.event.event_id);
+    assert_ne!(retained.event.session_id, active.event.session_id);
+    let mut current = VerifiedIndex::open_pinned_with_retained_peer(index_root(data_root)).unwrap();
+    let previous = current.take_retained_generation_peer_for_reader().unwrap().unwrap();
+    assert_eq!(current.event_ids_by_id_prefix("cafebabe").unwrap(), vec![active.event.event_id.as_uuid()]);
+    assert_eq!(previous.event_ids_by_id_prefix("cafebabe").unwrap(), vec![retained.event.event_id.as_uuid()]);
+    assert_eq!(current.session_ids_by_id_prefix("cafebabe").unwrap(), vec![active.event.session_id.as_uuid()]);
+    assert_eq!(previous.session_ids_by_id_prefix("cafebabe").unwrap(), vec![retained.event.session_id.as_uuid()]);
+    (retained, active)
+}
+
 fn mcp_fixture_show_event(root: &Path, event: &CoreEventRecord) -> Value {
     mcp_show_event(
         root,

--- a/crates/ctx-history-cli/src/source_index/tests/fixtures.rs
+++ b/crates/ctx-history-cli/src/source_index/tests/fixtures.rs
@@ -216,11 +216,7 @@ fn stable_id_with_compact_prefix(
     StableEntityId::decode_canonical(&encoded).unwrap()
 }
 
-fn force_compact_identity_prefix(
-    event: &mut CoreEventRecord,
-    prefix: [u8; 4],
-    discriminator: u8,
-) {
+fn force_compact_identity_prefix(event: &mut CoreEventRecord, prefix: [u8; 4], discriminator: u8) {
     let event_id = stable_id_with_compact_prefix(event.event.event_id, prefix, discriminator);
     let session_id = stable_id_with_compact_prefix(
         event.event.session_id,
@@ -262,11 +258,26 @@ fn compact_collision_pair(data_root: &Path, body: &str) -> (CoreEventRecord, Cor
     assert_ne!(retained.event.event_id, active.event.event_id);
     assert_ne!(retained.event.session_id, active.event.session_id);
     let mut current = VerifiedIndex::open_pinned_with_retained_peer(index_root(data_root)).unwrap();
-    let previous = current.take_retained_generation_peer_for_reader().unwrap().unwrap();
-    assert_eq!(current.event_ids_by_id_prefix("cafebabe").unwrap(), vec![active.event.event_id.as_uuid()]);
-    assert_eq!(previous.event_ids_by_id_prefix("cafebabe").unwrap(), vec![retained.event.event_id.as_uuid()]);
-    assert_eq!(current.session_ids_by_id_prefix("cafebabe").unwrap(), vec![active.event.session_id.as_uuid()]);
-    assert_eq!(previous.session_ids_by_id_prefix("cafebabe").unwrap(), vec![retained.event.session_id.as_uuid()]);
+    let previous = current
+        .take_retained_generation_peer_for_reader()
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        current.event_ids_by_id_prefix("cafebabe").unwrap(),
+        vec![active.event.event_id.as_uuid()]
+    );
+    assert_eq!(
+        previous.event_ids_by_id_prefix("cafebabe").unwrap(),
+        vec![retained.event.event_id.as_uuid()]
+    );
+    assert_eq!(
+        current.session_ids_by_id_prefix("cafebabe").unwrap(),
+        vec![active.event.session_id.as_uuid()]
+    );
+    assert_eq!(
+        previous.session_ids_by_id_prefix("cafebabe").unwrap(),
+        vec![retained.event.session_id.as_uuid()]
+    );
     (retained, active)
 }
 

--- a/crates/ctx-history-index-generation/src/retention.rs
+++ b/crates/ctx-history-index-generation/src/retention.rs
@@ -228,8 +228,16 @@ fn load_generation_retention_lease_from_opened_root(
     Ok(Some(lease))
 }
 
-/// Releases exactly the observed owner under the publication lock. The next
-/// writer open/publication performs ordinary bounded reclamation.
+/// Releases exactly the observed owner under the publication lock, then makes
+/// a best-effort pass over the now-unretained physical state before releasing
+/// that lock.
+///
+/// Removing the durable lease is the authoritative operation. Reclamation is
+/// deliberately best effort: a crash or reclaim error after the durable
+/// removal can leave obsolete bytes for a later writer, but must not turn a
+/// successful owner release into an ambiguous retry or retain authority that
+/// was already removed. Every reclamation primitive independently fences live
+/// process readers with its generation lock.
 pub fn release_generation_retention_lease(
     root: impl AsRef<Path>,
     expected: &GenerationRetentionLease,
@@ -251,7 +259,25 @@ pub fn release_generation_retention_lease(
         return Err(IndexError::GenerationRetentionLeaseOwnerMismatch);
     }
     remove_lease_file(&root)?;
+    reclaim_unretained_generation_state_with_writer_lock_held(&root);
     Ok(true)
+}
+
+/// Reclaims generation data that is no longer rooted by the active/previous
+/// pointer pair or the sole durable lease. The caller already holds the
+/// generation writer lock.
+fn reclaim_unretained_generation_state_with_writer_lock_held(root: &Path) {
+    let Ok(pointer) = load_active_generation_pointer(root) else {
+        return;
+    };
+    let retained_generation_ids = pointer
+        .iter()
+        .flat_map(|pointer| std::iter::once(pointer.active()).chain(pointer.previous()))
+        .map(|slot| slot.generation_id().to_owned())
+        .collect::<Vec<_>>();
+    let _ = crate::reclaim_inactive_generation_directories(root, pointer.as_ref(), None);
+    let _ = crate::reclaim_unreferenced_manifests(root, &retained_generation_ids);
+    let _ = crate::reclaim_unreferenced_certifications(root, pointer.as_ref(), None);
 }
 
 fn canonical_index_root(root: &Path) -> Result<PathBuf> {

--- a/crates/ctx-history-index-generation/src/retention.rs
+++ b/crates/ctx-history-index-generation/src/retention.rs
@@ -867,4 +867,73 @@ mod tests {
         assert!(!certification_path(root.path(), &old).exists());
         assert!(root.path().join(read_lease::COORDINATOR_FILE).is_file());
     }
+
+    #[test]
+    fn durable_release_respects_cross_process_reader_then_later_reclaims() {
+        let root = tempdir().unwrap();
+        let old = create_slot(root.path(), 'd');
+        publish_active_generation_pointer(
+            root.path(),
+            &ActiveGenerationPointer::new(old.clone(), None).unwrap(),
+        )
+        .unwrap();
+        let durable = acquire_generation_retention_lease(
+            root.path(),
+            old.generation_id(),
+            "pro_core_finalization",
+            &"e".repeat(64),
+        )
+        .unwrap();
+
+        let marker = root.path().join("durable-release-child-ready");
+        let mut child = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("retention::tests::generation_read_lease_crash_child")
+            .arg("--nocapture")
+            .env(CHILD_ROOT, root.path())
+            .env(CHILD_GENERATION, old.generation_id())
+            .env(CHILD_MARKER, &marker)
+            .spawn()
+            .unwrap();
+        for _ in 0..250 {
+            if marker.is_file() {
+                break;
+            }
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "lease child exited early"
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            marker.is_file(),
+            "lease child did not acquire its shared lock"
+        );
+
+        let previous = create_slot(root.path(), 'e');
+        let active = create_slot(root.path(), 'f');
+        let pointer = ActiveGenerationPointer::new(active.clone(), Some(previous.clone())).unwrap();
+        publish_active_generation_pointer(root.path(), &pointer).unwrap();
+
+        assert!(release_generation_retention_lease(root.path(), &durable).unwrap());
+        assert!(load_generation_retention_lease(root.path())
+            .unwrap()
+            .is_none());
+        assert!(slot_path(root.path(), &old).is_dir());
+        assert!(manifest_path(root.path(), old.generation_id()).is_file());
+        assert!(certification_path(root.path(), &old).is_file());
+
+        child.kill().unwrap();
+        child.wait().unwrap();
+        let retained = vec![
+            active.generation_id().to_owned(),
+            previous.generation_id().to_owned(),
+        ];
+        reclaim_inactive_generation_directories(root.path(), Some(&pointer), None).unwrap();
+        reclaim_unreferenced_manifests(root.path(), &retained).unwrap();
+        reclaim_unreferenced_certifications(root.path(), Some(&pointer), None).unwrap();
+        assert!(!slot_path(root.path(), &old).exists());
+        assert!(!manifest_path(root.path(), old.generation_id()).exists());
+        assert!(!certification_path(root.path(), &old).exists());
+    }
 }

--- a/crates/ctx-history-index-query/src/reader.rs
+++ b/crates/ctx-history-index-query/src/reader.rs
@@ -76,8 +76,8 @@ impl VerifiedGenerationSnapshot {
     }
 }
 
-/// Query-reader authority for the selected generation and its one retained
-/// peer. A query reader owns this bundle for its whole lifetime.
+/// Query-reader authority for the selected generation and, only when the
+/// caller explicitly requested a stable pair, its one retained peer.
 struct ReaderLeaseBundle {
     target: GenerationReadLease,
     peer: Option<GenerationReadLease>,
@@ -173,9 +173,26 @@ impl VerifiedIndex {
     /// publication-time O(document-count) identity audit is not repeated for
     /// current generations.
     pub fn open_pinned(root: impl AsRef<Path>) -> Result<Self> {
-        Self::open_pinned_with_loader(root.as_ref(), |root| {
-            load_active_generation_pointer(root).map_err(IndexError::from)
-        })
+        Self::open_pinned_with_peer(root, false)
+    }
+
+    /// Opens the active generation and retains its current pointer peer for
+    /// the reader lifetime when one is available.
+    ///
+    /// Callers that present compact-generation references must use this paired
+    /// open instead of acquiring an ordinary reader and asking for a peer
+    /// later. Acquiring both locks from one observed pointer preserves a
+    /// stable active/previous pair across concurrent publication.
+    pub fn open_pinned_with_retained_peer(root: impl AsRef<Path>) -> Result<Self> {
+        Self::open_pinned_with_peer(root, true)
+    }
+
+    fn open_pinned_with_peer(root: impl AsRef<Path>, retain_peer: bool) -> Result<Self> {
+        Self::open_pinned_with_loader(
+            root.as_ref(),
+            |root| load_active_generation_pointer(root).map_err(IndexError::from),
+            retain_peer,
+        )
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -186,10 +203,14 @@ impl VerifiedIndex {
     where
         F: FnMut(&Path) -> Result<Option<ActiveGenerationPointer>>,
     {
-        Self::open_pinned_with_loader(root.as_ref(), load_pointer)
+        Self::open_pinned_with_loader(root.as_ref(), load_pointer, false)
     }
 
-    fn open_pinned_with_loader<F>(root: &Path, mut load_pointer: F) -> Result<Self>
+    fn open_pinned_with_loader<F>(
+        root: &Path,
+        mut load_pointer: F,
+        retain_peer: bool,
+    ) -> Result<Self>
     where
         F: FnMut(&Path) -> Result<Option<ActiveGenerationPointer>>,
     {
@@ -203,6 +224,7 @@ impl VerifiedIndex {
                 })
             },
             None,
+            retain_peer,
         )
     }
 
@@ -211,6 +233,7 @@ impl VerifiedIndex {
         load_pointer: &mut F,
         mut select: S,
         expected_generation_id: Option<&str>,
+        retain_peer: bool,
     ) -> Result<Self>
     where
         F: FnMut(&Path) -> Result<Option<ActiveGenerationPointer>>,
@@ -236,6 +259,7 @@ impl VerifiedIndex {
                     &first_pointer,
                     selection,
                     expected_generation_id,
+                    retain_peer,
                 )
             })
         };
@@ -253,6 +277,7 @@ impl VerifiedIndex {
                     &retry_pointer,
                     selection,
                     expected_generation_id,
+                    retain_peer,
                 )
             })
         };
@@ -267,8 +292,9 @@ impl VerifiedIndex {
         pointer: &ActiveGenerationPointer,
         selection: ReaderGenerationSelection,
         expected_generation_id: Option<&str>,
+        retain_peer: bool,
     ) -> Result<Self> {
-        let leases = Self::acquire_reader_leases(root, pointer, &selection)?;
+        let leases = Self::acquire_reader_leases(root, pointer, &selection, retain_peer)?;
         let target = &leases.target;
         let (mut index, recertified) = target
             .with_root_access(|root| {
@@ -304,22 +330,26 @@ impl VerifiedIndex {
         root: &Path,
         pointer: &ActiveGenerationPointer,
         selection: &ReaderGenerationSelection,
+        retain_peer: bool,
     ) -> Result<ReaderLeaseBundle> {
         let target = match selection.durable_authority.as_ref() {
             Some(authority) => acquire_retained_generation_read_lease(root, authority)?,
             None => acquire_generation_read_lease(root, selection.target.generation_id())?,
         };
-        let peer = if selection.target.generation_id() == pointer.active().generation_id() {
-            pointer.previous()
-        } else if pointer
-            .previous()
-            .is_some_and(|slot| slot.generation_id() == selection.target.generation_id())
-        {
-            Some(pointer.active())
-        } else {
-            None
-        };
-        let peer = peer
+        let peer = retain_peer
+            .then(|| {
+                if selection.target.generation_id() == pointer.active().generation_id() {
+                    pointer.previous()
+                } else if pointer
+                    .previous()
+                    .is_some_and(|slot| slot.generation_id() == selection.target.generation_id())
+                {
+                    Some(pointer.active())
+                } else {
+                    None
+                }
+            })
+            .flatten()
             .map(|peer| acquire_generation_read_lease(root, peer.generation_id()))
             .transpose()?;
         Ok(ReaderLeaseBundle { target, peer })
@@ -385,9 +415,29 @@ impl VerifiedIndex {
         root: impl AsRef<Path>,
         expected_generation_id: &str,
     ) -> Result<Self> {
-        Self::open_pinned_generation_with_loader(root.as_ref(), expected_generation_id, |root| {
-            load_active_generation_pointer(root).map_err(IndexError::from)
-        })
+        Self::open_pinned_generation_with_peer(root, expected_generation_id, false)
+    }
+
+    /// Opens exactly the requested retained generation and its current pointer
+    /// peer as one stable reader pair when available.
+    pub fn open_pinned_generation_with_retained_peer(
+        root: impl AsRef<Path>,
+        expected_generation_id: &str,
+    ) -> Result<Self> {
+        Self::open_pinned_generation_with_peer(root, expected_generation_id, true)
+    }
+
+    fn open_pinned_generation_with_peer(
+        root: impl AsRef<Path>,
+        expected_generation_id: &str,
+        retain_peer: bool,
+    ) -> Result<Self> {
+        Self::open_pinned_generation_with_loader(
+            root.as_ref(),
+            expected_generation_id,
+            |root| load_active_generation_pointer(root).map_err(IndexError::from),
+            retain_peer,
+        )
     }
 
     /// Opens exactly the generation held by a process-scoped read lease using
@@ -506,6 +556,7 @@ impl VerifiedIndex {
             root.as_ref(),
             expected_generation_id,
             load_pointer,
+            false,
         )
     }
 
@@ -513,6 +564,7 @@ impl VerifiedIndex {
         root: &Path,
         expected_generation_id: &str,
         mut load_pointer: F,
+        retain_peer: bool,
     ) -> Result<Self>
     where
         F: FnMut(&Path) -> Result<Option<ActiveGenerationPointer>>,
@@ -551,6 +603,7 @@ impl VerifiedIndex {
                 })
             },
             Some(expected_generation_id),
+            retain_peer,
         )
     }
 

--- a/crates/ctx-history-index-query/tests/writer_integration/pinned_generation.rs
+++ b/crates/ctx-history-index-query/tests/writer_integration/pinned_generation.rs
@@ -559,10 +559,16 @@ fn reader_owned_peer_lease_survives_parent_drop_after_integrity_verification() {
             .join(INDEX_GENERATIONS_DIRECTORY)
             .join(pointer.previous().unwrap().directory())
     };
-    let mut reader =
-        VerifiedIndex::open_pinned_generation(temp.path(), &second.generation_id).unwrap();
-    let mut second_reader =
-        VerifiedIndex::open_pinned_generation(temp.path(), &second.generation_id).unwrap();
+    let mut reader = VerifiedIndex::open_pinned_generation_with_retained_peer(
+        temp.path(),
+        &second.generation_id,
+    )
+    .unwrap();
+    let mut second_reader = VerifiedIndex::open_pinned_generation_with_retained_peer(
+        temp.path(),
+        &second.generation_id,
+    )
+    .unwrap();
     let cached_peer = second_reader
         .take_retained_generation_peer_for_reader()
         .unwrap()
@@ -572,8 +578,11 @@ fn reader_owned_peer_lease_survives_parent_drop_after_integrity_verification() {
     // Make the checksum-walk assertions independent of a matching prior cache.
     assert!(first_certification.is_file());
     fs::remove_file(first_certification).unwrap();
-    let mut second_reader =
-        VerifiedIndex::open_pinned_generation(temp.path(), &second.generation_id).unwrap();
+    let mut second_reader = VerifiedIndex::open_pinned_generation_with_retained_peer(
+        temp.path(),
+        &second.generation_id,
+    )
+    .unwrap();
 
     reset_physical_verification_activity();
     let peer = reader
@@ -623,8 +632,11 @@ fn reader_owned_peer_rejects_corrupt_physical_integrity() {
     let source = source("leased-verification-corrupt-peer.jsonl");
     let _first = publish_pinned_test_generation(temp.path(), &source, 1, "first evidence");
     let second = publish_pinned_test_generation(temp.path(), &source, 2, "second evidence");
-    let mut reader =
-        VerifiedIndex::open_pinned_generation(temp.path(), &second.generation_id).unwrap();
+    let mut reader = VerifiedIndex::open_pinned_generation_with_retained_peer(
+        temp.path(),
+        &second.generation_id,
+    )
+    .unwrap();
     let pointer = load_active_generation_pointer(temp.path())
         .unwrap()
         .unwrap();

--- a/crates/ctx-history-index/src/tests/generation_retention.rs
+++ b/crates/ctx-history-index/src/tests/generation_retention.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    time::Instant,
 };
 
 use ctx_history_index_generation::acquire_retained_generation_read_lease;
@@ -26,7 +27,8 @@ fn retained_generation_peer_is_limited_to_the_current_pointer_pair() {
     let source = source("retained-generation-peer.jsonl");
     let first = publish(temp.path(), &source, 1, "first peer");
     let mut first_reader =
-        VerifiedIndex::open_pinned_generation(temp.path(), &first.generation_id).unwrap();
+        VerifiedIndex::open_pinned_generation_with_retained_peer(temp.path(), &first.generation_id)
+            .unwrap();
     assert!(first_reader
         .take_retained_generation_peer_for_reader()
         .unwrap()
@@ -34,15 +36,19 @@ fn retained_generation_peer_is_limited_to_the_current_pointer_pair() {
     drop(first_reader);
 
     let second = publish(temp.path(), &source, 2, "second peer");
-    let mut second_reader =
-        VerifiedIndex::open_pinned_generation(temp.path(), &second.generation_id).unwrap();
+    let mut second_reader = VerifiedIndex::open_pinned_generation_with_retained_peer(
+        temp.path(),
+        &second.generation_id,
+    )
+    .unwrap();
     let previous = second_reader
         .take_retained_generation_peer_for_reader()
         .unwrap()
         .unwrap();
     assert_eq!(previous.generation_id(), first.generation_id);
     let mut first_reader =
-        VerifiedIndex::open_pinned_generation(temp.path(), &first.generation_id).unwrap();
+        VerifiedIndex::open_pinned_generation_with_retained_peer(temp.path(), &first.generation_id)
+            .unwrap();
     let active = first_reader
         .take_retained_generation_peer_for_reader()
         .unwrap()
@@ -55,8 +61,11 @@ fn retained_generation_peer_is_limited_to_the_current_pointer_pair() {
         VerifiedIndex::open_pinned_generation(temp.path(), &first.generation_id),
         Err(IndexError::PinnedGenerationNotRetained { .. })
     ));
-    let mut second_reader =
-        VerifiedIndex::open_pinned_generation(temp.path(), &second.generation_id).unwrap();
+    let mut second_reader = VerifiedIndex::open_pinned_generation_with_retained_peer(
+        temp.path(),
+        &second.generation_id,
+    )
+    .unwrap();
     let active = second_reader
         .take_retained_generation_peer_for_reader()
         .unwrap()
@@ -94,20 +103,33 @@ fn one_durable_lease_retains_an_exact_old_generation_without_changing_peer_slots
         .take_retained_generation_peer_for_reader()
         .unwrap()
         .is_none());
-    let mut fourth_reader =
+    let fourth_reader =
         VerifiedIndex::open_pinned_generation(temp.path(), &fourth.generation_id).unwrap();
-    let peer = fourth_reader
-        .take_retained_generation_peer_for_reader()
-        .unwrap()
-        .unwrap();
-    assert_eq!(peer.generation_id(), third.generation_id);
     assert_eq!(generation_directories(temp.path()).len(), 3);
     assert_ne!(second.generation_id, third.generation_id);
 
-    drop((peer, fourth_reader, leased));
+    drop((fourth_reader, leased));
+    let allocated_before_release = allocated_bytes(temp.path());
+    let release_started = Instant::now();
     assert!(release_generation_retention_lease(temp.path(), &lease).unwrap());
-    let fifth = publish(temp.path(), &source, 5, "fifth");
-    assert_ne!(fifth.generation_id, fourth.generation_id);
+    let release_elapsed = release_started.elapsed();
+    let allocated_after_release = allocated_bytes(temp.path());
+    eprintln!(
+        "immediate durable-lease reclamation: allocated_bytes_before={allocated_before_release} allocated_bytes_after={allocated_after_release} elapsed_ms={}",
+        release_elapsed.as_millis(),
+    );
+    #[cfg(unix)]
+    assert!(allocated_after_release < allocated_before_release);
+    assert_eq!(generation_directories(temp.path()).len(), 2);
+    let pointer = load_active_generation_pointer(temp.path())
+        .unwrap()
+        .unwrap();
+    for generation_id in [
+        pointer.active().generation_id(),
+        pointer.previous().unwrap().generation_id(),
+    ] {
+        assert!(VerifiedIndex::open_pinned_generation(temp.path(), generation_id).is_ok());
+    }
     assert!(matches!(
         VerifiedIndex::open_pinned_generation(temp.path(), &first.generation_id),
         Err(IndexError::PinnedGenerationNotRetained { .. })
@@ -145,6 +167,7 @@ fn candidate_certification_accepts_aliases_held_by_a_process_reader() {
     );
     let process_lease = acquire_retained_generation_read_lease(temp.path(), &lease).unwrap();
     assert!(release_generation_retention_lease(temp.path(), &lease).unwrap());
+    assert_eq!(generation_directories(temp.path()).len(), 3);
 
     publish(
         temp.path(),
@@ -161,6 +184,44 @@ fn candidate_certification_accepts_aliases_held_by_a_process_reader() {
         "fifth",
     );
     assert_eq!(generation_directories(temp.path()).len(), 2);
+}
+
+#[test]
+fn ordinary_reader_does_not_retain_the_previous_generation() {
+    let temp = tempdir().unwrap();
+    let source = source("ordinary-reader-does-not-retain-previous.jsonl");
+    let first = publish(temp.path(), &source, 1, "first ordinary reader");
+    let second = publish(temp.path(), &source, 2, "second ordinary reader");
+    let first_path = temp.path().join(INDEX_GENERATIONS_DIRECTORY).join(
+        load_active_generation_pointer(temp.path())
+            .unwrap()
+            .unwrap()
+            .previous()
+            .unwrap()
+            .directory(),
+    );
+    let mut ordinary = VerifiedIndex::open_pinned(temp.path()).unwrap();
+    assert!(ordinary
+        .take_retained_generation_peer_for_reader()
+        .unwrap()
+        .is_none());
+
+    let third = publish(temp.path(), &source, 3, "third ordinary reader");
+
+    assert_eq!(ordinary.generation_id(), second.generation_id);
+    assert_eq!(ordinary.count_term("second").unwrap(), 1);
+    assert!(!first_path.exists());
+    assert!(matches!(
+        VerifiedIndex::open_pinned_generation(temp.path(), &first.generation_id),
+        Err(IndexError::PinnedGenerationNotRetained { .. })
+    ));
+    assert_eq!(ordinary.generation_id(), second.generation_id);
+    assert_eq!(
+        third.generation_id,
+        VerifiedIndex::open_pinned(temp.path())
+            .unwrap()
+            .generation_id()
+    );
 }
 
 #[test]
@@ -232,4 +293,34 @@ fn generation_directories(root: &Path) -> Vec<PathBuf> {
         .collect::<Vec<_>>();
     directories.sort();
     directories
+}
+
+#[cfg(unix)]
+fn allocated_bytes(root: &Path) -> u64 {
+    use std::{collections::HashSet, os::unix::fs::MetadataExt as _};
+
+    fn walk(root: &Path, seen: &mut HashSet<(u64, u64)>) -> u64 {
+        let metadata = fs::symlink_metadata(root).unwrap();
+        let identity = (metadata.dev(), metadata.ino());
+        let own_blocks = seen
+            .insert(identity)
+            .then_some(metadata.blocks().saturating_mul(512))
+            .unwrap_or_default();
+        if !metadata.is_dir() {
+            return own_blocks;
+        }
+        own_blocks.saturating_add(
+            fs::read_dir(root)
+                .unwrap()
+                .map(|entry| walk(&entry.unwrap().path(), seen))
+                .sum(),
+        )
+    }
+
+    walk(root, &mut HashSet::new())
+}
+
+#[cfg(not(unix))]
+fn allocated_bytes(_root: &Path) -> u64 {
+    0
 }

--- a/crates/ctx-history-index/src/tests/generation_retention.rs
+++ b/crates/ctx-history-index/src/tests/generation_retention.rs
@@ -1,6 +1,10 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::Instant,
 };
 
@@ -19,6 +23,13 @@ fn publish(root: &Path, source: &SourceKey, revision: u8, body: &str) -> CommitR
         .certify_source(appendable_certificate(source, revision, 1, 10))
         .unwrap();
     writer.commit(|_| true).unwrap()
+}
+
+fn publish_manifest_base(root: &Path, source: &SourceKey) -> PathBuf {
+    // Later flat deltas still require this manifest, even after its physical
+    // generation is obsolete. The leased delta itself must be reclaimable.
+    let base = publish(root, source, 0, "retained manifest base");
+    crate::publication::manifest_path(root, &base.generation_id)
 }
 
 #[test]
@@ -77,7 +88,16 @@ fn retained_generation_peer_is_limited_to_the_current_pointer_pair() {
 fn one_durable_lease_retains_an_exact_old_generation_without_changing_peer_slots() {
     let temp = tempdir().unwrap();
     let source = source("generation-retention-lease.jsonl");
+    let base_manifest = publish_manifest_base(temp.path(), &source);
     let first = publish(temp.path(), &source, 1, "leased first");
+    let first_slot = load_active_generation_pointer(temp.path())
+        .unwrap()
+        .unwrap()
+        .active()
+        .clone();
+    let first_manifest = crate::publication::manifest_path(temp.path(), &first.generation_id);
+    let first_certification =
+        crate::publication::certification_file_for_active(temp.path()).unwrap();
     let lease = acquire_generation_retention_lease(
         temp.path(),
         &first.generation_id,
@@ -106,6 +126,8 @@ fn one_durable_lease_retains_an_exact_old_generation_without_changing_peer_slots
     let fourth_reader =
         VerifiedIndex::open_pinned_generation(temp.path(), &fourth.generation_id).unwrap();
     assert_eq!(generation_directories(temp.path()).len(), 3);
+    assert!(first_manifest.is_file());
+    assert!(first_certification.is_file());
     assert_ne!(second.generation_id, third.generation_id);
 
     drop((fourth_reader, leased));
@@ -121,6 +143,10 @@ fn one_durable_lease_retains_an_exact_old_generation_without_changing_peer_slots
     #[cfg(unix)]
     assert!(allocated_after_release < allocated_before_release);
     assert_eq!(generation_directories(temp.path()).len(), 2);
+    assert!(!crate::publication::slot_path(temp.path(), &first_slot).exists());
+    assert!(!first_manifest.exists());
+    assert!(!first_certification.exists());
+    assert!(base_manifest.is_file());
     let pointer = load_active_generation_pointer(temp.path())
         .unwrap()
         .unwrap();
@@ -128,6 +154,7 @@ fn one_durable_lease_retains_an_exact_old_generation_without_changing_peer_slots
         pointer.active().generation_id(),
         pointer.previous().unwrap().generation_id(),
     ] {
+        assert!(crate::publication::manifest_path(temp.path(), generation_id).is_file());
         assert!(VerifiedIndex::open_pinned_generation(temp.path(), generation_id).is_ok());
     }
     assert!(matches!(
@@ -135,6 +162,161 @@ fn one_durable_lease_retains_an_exact_old_generation_without_changing_peer_slots
         Err(IndexError::PinnedGenerationNotRetained { .. })
     ));
     assert_eq!(generation_directories(temp.path()).len(), 2);
+}
+
+#[test]
+fn durable_release_stays_successful_when_best_effort_directory_gc_fails() {
+    use crate::publication::{ReclamationStage, ReclamationTestHookGuard};
+
+    let temp = tempdir().unwrap();
+    let source = source("generation-retention-release-fault.jsonl");
+    let base_manifest = publish_manifest_base(temp.path(), &source);
+    let first = publish(temp.path(), &source, 1, "fault retained first");
+    let first_slot = load_active_generation_pointer(temp.path())
+        .unwrap()
+        .unwrap()
+        .active()
+        .clone();
+    let first_directory = crate::publication::slot_path(temp.path(), &first_slot);
+    let first_manifest = crate::publication::manifest_path(temp.path(), &first.generation_id);
+    let first_certification =
+        crate::publication::certification_file_for_active(temp.path()).unwrap();
+    let lease = acquire_generation_retention_lease(
+        temp.path(),
+        &first.generation_id,
+        "pro_core_finalization",
+        &"d".repeat(64),
+    )
+    .unwrap();
+
+    publish(temp.path(), &source, 2, "fault second");
+    publish(temp.path(), &source, 3, "fault third");
+    publish(temp.path(), &source, 4, "fault fourth");
+
+    let root = temp.path().to_path_buf();
+    let injected_directory = first_directory.clone();
+    let reached_after_release = Arc::new(AtomicBool::new(false));
+    let reached_after_release_for_hook = Arc::clone(&reached_after_release);
+    let hook = ReclamationTestHookGuard::set(move |stage, path| {
+        if stage == ReclamationStage::AfterCandidateRetained && path == injected_directory {
+            assert!(load_generation_retention_lease(&root).unwrap().is_none());
+            reached_after_release_for_hook.store(true, Ordering::SeqCst);
+            return Err(ctx_history_index_generation::GenerationError::ConcurrentGenerationChange);
+        }
+        Ok(())
+    });
+
+    assert!(release_generation_retention_lease(temp.path(), &lease).unwrap());
+    assert!(reached_after_release.load(Ordering::SeqCst));
+    assert!(load_generation_retention_lease(temp.path())
+        .unwrap()
+        .is_none());
+    assert!(first_directory.is_dir());
+    assert!(!first_manifest.exists());
+    assert!(!first_certification.exists());
+    assert!(base_manifest.is_file());
+    let pointer = load_active_generation_pointer(temp.path())
+        .unwrap()
+        .unwrap();
+    assert!(
+        VerifiedIndex::open_pinned_generation(temp.path(), pointer.active().generation_id())
+            .is_ok()
+    );
+    assert!(VerifiedIndex::open_pinned_generation(
+        temp.path(),
+        pointer.previous().unwrap().generation_id()
+    )
+    .is_ok());
+
+    drop(hook);
+    publish(temp.path(), &source, 5, "fault fifth");
+    assert!(!first_directory.exists());
+}
+
+const RELEASE_CRASH_ROOT: &str = "CTX_RETENTION_RELEASE_CRASH_TEST_ROOT";
+const RELEASE_CRASH_EXIT: i32 = 86;
+
+#[test]
+fn durable_release_crash_child() {
+    let Ok(root) = std::env::var(RELEASE_CRASH_ROOT) else {
+        return;
+    };
+    let root = PathBuf::from(root);
+    let lease = load_generation_retention_lease(&root).unwrap().unwrap();
+    let root_for_hook = root.clone();
+    let _hook = crate::publication::ReclamationTestHookGuard::set(move |_, _| {
+        assert!(load_generation_retention_lease(&root_for_hook)
+            .unwrap()
+            .is_none());
+        std::process::exit(RELEASE_CRASH_EXIT);
+    });
+    release_generation_retention_lease(&root, &lease).unwrap();
+    panic!("durable release crash checkpoint was not reached");
+}
+
+#[test]
+fn crash_after_durable_release_preserves_authority_and_next_writer_reclaims() {
+    let temp = tempdir().unwrap();
+    let source = source("generation-retention-release-crash.jsonl");
+    let base_manifest = publish_manifest_base(temp.path(), &source);
+    let first = publish(temp.path(), &source, 1, "crash first");
+    let first_certification =
+        crate::publication::certification_file_for_active(temp.path()).unwrap();
+    let first_manifest = crate::publication::manifest_path(temp.path(), &first.generation_id);
+    let lease = acquire_generation_retention_lease(
+        temp.path(),
+        &first.generation_id,
+        "pro_core_finalization",
+        &"f".repeat(64),
+    )
+    .unwrap();
+    publish(temp.path(), &source, 2, "crash second");
+    let third = publish(temp.path(), &source, 3, "crash third");
+    let fourth = publish(temp.path(), &source, 4, "crash fourth");
+    let status = std::process::Command::new(std::env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "tests::generation_retention::durable_release_crash_child",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env(RELEASE_CRASH_ROOT, temp.path())
+        .status()
+        .unwrap();
+
+    assert_eq!(status.code(), Some(RELEASE_CRASH_EXIT));
+    assert!(load_generation_retention_lease(temp.path())
+        .unwrap()
+        .is_none());
+    assert!(!release_generation_retention_lease(temp.path(), &lease).unwrap());
+    assert_eq!(generation_directories(temp.path()).len(), 3);
+    assert!(first_manifest.is_file());
+    assert!(first_certification.is_file());
+    let pointer = load_active_generation_pointer(temp.path())
+        .unwrap()
+        .unwrap();
+    assert_eq!(pointer.active().generation_id(), fourth.generation_id);
+    assert_eq!(
+        pointer.previous().unwrap().generation_id(),
+        third.generation_id
+    );
+    for (id, term) in [
+        (&fourth.generation_id, "fourth"),
+        (&third.generation_id, "third"),
+    ] {
+        assert_eq!(
+            VerifiedIndex::open_pinned_generation(temp.path(), id)
+                .unwrap()
+                .count_term(term)
+                .unwrap(),
+            1
+        );
+    }
+    publish(temp.path(), &source, 5, "crash fifth");
+    assert_eq!(generation_directories(temp.path()).len(), 2);
+    assert!(!first_manifest.exists());
+    assert!(!first_certification.exists());
+    assert!(base_manifest.is_file());
 }
 
 #[test]
@@ -283,6 +465,62 @@ fn generation_retention_lease_is_single_owner_private_and_fail_closed() {
     ));
 }
 
+#[test]
+fn stale_owner_cannot_release_a_remaining_durable_lease() {
+    let temp = tempdir().unwrap();
+    let source = source("generation-retention-replaced-owner.jsonl");
+    let base_manifest = publish_manifest_base(temp.path(), &source);
+    let first = publish(temp.path(), &source, 1, "first owner");
+    let first_manifest = crate::publication::manifest_path(temp.path(), &first.generation_id);
+    let first_certification =
+        crate::publication::certification_file_for_active(temp.path()).unwrap();
+    let stale = acquire_generation_retention_lease(
+        temp.path(),
+        &first.generation_id,
+        "pro_core_finalization",
+        &"a".repeat(64),
+    )
+    .unwrap();
+    assert!(release_generation_retention_lease(temp.path(), &stale).unwrap());
+    assert_eq!(generation_directories(temp.path()).len(), 2);
+    assert!(first_manifest.is_file());
+    assert!(first_certification.is_file());
+    assert!(VerifiedIndex::open_pinned(temp.path()).is_ok());
+    let remaining = acquire_generation_retention_lease(
+        temp.path(),
+        &first.generation_id,
+        "pro_core_finalization",
+        &"b".repeat(64),
+    )
+    .unwrap();
+    publish(temp.path(), &source, 2, "second owner");
+    publish(temp.path(), &source, 3, "third owner");
+    publish(temp.path(), &source, 4, "fourth owner");
+    assert!(matches!(
+        release_generation_retention_lease(temp.path(), &stale),
+        Err(IndexError::GenerationRetentionLeaseOwnerMismatch)
+    ));
+    assert_eq!(
+        load_generation_retention_lease(temp.path()).unwrap(),
+        Some(remaining.clone())
+    );
+    assert_eq!(generation_directories(temp.path()).len(), 3);
+    assert!(first_manifest.is_file());
+    assert!(first_certification.is_file());
+    assert_eq!(
+        VerifiedIndex::open_pinned_generation(temp.path(), &first.generation_id)
+            .unwrap()
+            .count_term("first")
+            .unwrap(),
+        1
+    );
+    assert!(release_generation_retention_lease(temp.path(), &remaining).unwrap());
+    assert_eq!(generation_directories(temp.path()).len(), 2);
+    assert!(!first_manifest.exists());
+    assert!(!first_certification.exists());
+    assert!(base_manifest.is_file());
+}
+
 fn generation_directories(root: &Path) -> Vec<PathBuf> {
     let mut directories = fs::read_dir(root.join(INDEX_GENERATIONS_DIRECTORY))
         .unwrap()
@@ -302,10 +540,11 @@ fn allocated_bytes(root: &Path) -> u64 {
     fn walk(root: &Path, seen: &mut HashSet<(u64, u64)>) -> u64 {
         let metadata = fs::symlink_metadata(root).unwrap();
         let identity = (metadata.dev(), metadata.ino());
-        let own_blocks = seen
-            .insert(identity)
-            .then_some(metadata.blocks().saturating_mul(512))
-            .unwrap_or_default();
+        let own_blocks = if seen.insert(identity) {
+            metadata.blocks().saturating_mul(512)
+        } else {
+            0
+        };
         if !metadata.is_dir() {
             return own_blocks;
         }

--- a/crates/ctx-history-index/src/tests/integrity_certification.rs
+++ b/crates/ctx-history-index/src/tests/integrity_certification.rs
@@ -621,7 +621,7 @@ fn managed_three_generation_reclamation_preserves_retained_certifications() {
         "the third publication must reclaim its unretained first generation"
     );
     crate::publication::reset_verification_activity();
-    let mut active = VerifiedIndex::open_pinned(temp.path()).unwrap();
+    let mut active = VerifiedIndex::open_pinned_with_retained_peer(temp.path()).unwrap();
     let previous = active
         .take_retained_generation_peer_for_reader()
         .unwrap()

--- a/crates/ctx-history-read-application/src/application.rs
+++ b/crates/ctx-history-read-application/src/application.rs
@@ -138,23 +138,28 @@ pub struct SearchApplicationRequest {
 
 impl SearchApplicationRequest {
     fn retained_peer_read(&self) -> RetainedPeerRead {
-        let compact_selector = self
-            .plan
-            .request()
-            .session
-            .as_deref()
-            .is_some_and(reference_needs_retained_peer)
-            || self
-                .plan
-                .request()
-                .exclude_sessions
-                .iter()
-                .any(|selector| reference_needs_retained_peer(selector));
-        if self.compact_projection || compact_selector {
-            RetainedPeerRead::IfAvailable
-        } else {
-            RetainedPeerRead::Omit
-        }
+        retained_peer_read_for_search(self.plan.request(), self.compact_projection)
+    }
+}
+
+/// Selects the authority needed by both refresh-time pinning and query execution.
+/// Compact output and compact selectors must capture their peer with the target.
+pub fn retained_peer_read_for_search(
+    request: &SearchRequest,
+    compact_projection: bool,
+) -> RetainedPeerRead {
+    let compact_selector = request
+        .session
+        .as_deref()
+        .is_some_and(reference_needs_retained_peer)
+        || request
+            .exclude_sessions
+            .iter()
+            .any(|selector| reference_needs_retained_peer(selector));
+    if compact_projection || compact_selector {
+        RetainedPeerRead::IfAvailable
+    } else {
+        RetainedPeerRead::Omit
     }
 }
 

--- a/crates/ctx-history-read-application/src/lib.rs
+++ b/crates/ctx-history-read-application/src/lib.rs
@@ -28,9 +28,10 @@ mod show_read_model;
 mod application_tests;
 
 pub use application::{
-    execute_search_observed, plan_search, ObservedSearchApplicationError, PinnedHistoryQuery,
-    PlannedSearch, SearchApplicationError, SearchApplicationReadModelInput,
-    SearchApplicationRequest, SearchApplicationResult, SearchQueryResult,
+    execute_search_observed, plan_search, retained_peer_read_for_search,
+    ObservedSearchApplicationError, PinnedHistoryQuery, PlannedSearch, SearchApplicationError,
+    SearchApplicationReadModelInput, SearchApplicationRequest, SearchApplicationResult,
+    SearchQueryResult,
 };
 pub use compact_presentation::{
     normalize_uuid_prefix, reference_needs_retained_peer, CompactPresentationProjection,

--- a/crates/ctx-history-refresh/src/engine/tests/publication_lifecycle.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/publication_lifecycle.rs
@@ -426,6 +426,67 @@ fn terminal_generation_can_be_pinned_after_one_successor_advances_active() {
 }
 
 #[test]
+fn publication_readers_acquire_retained_peers_only_on_explicit_request() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_root = temp.path().join("data");
+    let index_root = source_backed_index_root(&data_root);
+    let first = publish_pin_source(&index_root, publication_pin_source());
+    let second = publish_pin_source(&index_root, publication_pin_source_with_anchor(0x93));
+    let mut ordinary = crate::pin_active_verified_generation(&data_root)
+        .unwrap()
+        .into_index();
+    assert!(ordinary
+        .take_retained_generation_peer_for_reader()
+        .unwrap()
+        .is_none());
+    let mut ordinary = crate::pin_published_generation(&data_root)
+        .unwrap()
+        .unwrap()
+        .into_index();
+    assert!(ordinary
+        .take_retained_generation_peer_for_reader()
+        .unwrap()
+        .is_none());
+    let mut ordinary = crate::pin_retained_generation(&data_root, &first)
+        .unwrap()
+        .into_index();
+    assert!(ordinary
+        .take_retained_generation_peer_for_reader()
+        .unwrap()
+        .is_none());
+
+    let (paired, opens) = crate::count_verified_index_opens(|| {
+        [
+            crate::pin_active_verified_generation_with_retained_peer(&data_root).unwrap(),
+            crate::pin_published_generation_with_retained_peer(&data_root)
+                .unwrap()
+                .unwrap(),
+            crate::pin_retained_generation_with_retained_peer(&data_root, &first).unwrap(),
+        ]
+    });
+    assert_eq!(
+        opens, 3,
+        "pair acquisition must not repin after an ordinary open"
+    );
+    for (pin, (expected_target, expected_peer)) in
+        paired
+            .into_iter()
+            .zip([(&second, &first), (&second, &first), (&first, &second)])
+    {
+        let mut index = pin.into_index();
+        assert_eq!(index.generation_id(), expected_target);
+        assert_eq!(
+            index
+                .take_retained_generation_peer_for_reader()
+                .unwrap()
+                .unwrap()
+                .generation_id(),
+            expected_peer
+        );
+    }
+}
+
+#[test]
 fn cold_dirty_routes_are_published_in_one_all_route_generation() {
     let temp = tempfile::tempdir().unwrap();
     let data_root = temp.path().join("data");

--- a/crates/ctx-history-refresh/src/lib.rs
+++ b/crates/ctx-history-refresh/src/lib.rs
@@ -88,9 +88,10 @@ pub use journal::{DurableAdmissionPersistence, RefreshJournal};
 pub use publication::count_verified_index_opens;
 pub use publication::{
     explicit_catalog_request_is_accounted_for, open_verified_index, pin_active_verified_generation,
-    pin_published_generation, pin_retained_generation,
-    published_explicit_source_relocation_authority, published_refresh_receipt,
-    MissingActiveGeneration, PinnedSourceBackedGeneration,
+    pin_active_verified_generation_with_retained_peer, pin_published_generation,
+    pin_published_generation_with_retained_peer, pin_retained_generation,
+    pin_retained_generation_with_retained_peer, published_explicit_source_relocation_authority,
+    published_refresh_receipt, MissingActiveGeneration, PinnedSourceBackedGeneration,
 };
 pub use request::{
     AdmissionResponseBarrier, RefreshAdmission, RefreshIntent, RefreshLogicalPhase,

--- a/crates/ctx-history-refresh/src/publication.rs
+++ b/crates/ctx-history-refresh/src/publication.rs
@@ -11,13 +11,24 @@ thread_local! {
 }
 
 pub fn open_verified_index(index_root: &Path) -> std::result::Result<VerifiedIndex, IndexError> {
+    open_verified_index_with_peer(index_root, false)
+}
+
+fn open_verified_index_with_peer(
+    index_root: &Path,
+    retain_peer: bool,
+) -> std::result::Result<VerifiedIndex, IndexError> {
     #[cfg(any(test, feature = "test-support"))]
     VERIFIED_INDEX_OPEN_COUNT.with(|count| {
         if let Some(current) = count.get() {
             count.set(Some(current.saturating_add(1)));
         }
     });
-    VerifiedIndex::open_pinned(index_root)
+    if retain_peer {
+        VerifiedIndex::open_pinned_with_retained_peer(index_root)
+    } else {
+        VerifiedIndex::open_pinned(index_root)
+    }
 }
 
 /// The refresh authority has no active verified Core generation to pin.
@@ -40,6 +51,7 @@ impl std::error::Error for MissingActiveGeneration {}
 fn open_retained_verified_index(
     index_root: &Path,
     generation_id: &str,
+    retain_peer: bool,
 ) -> std::result::Result<VerifiedIndex, IndexError> {
     #[cfg(any(test, feature = "test-support"))]
     VERIFIED_INDEX_OPEN_COUNT.with(|count| {
@@ -47,7 +59,11 @@ fn open_retained_verified_index(
             count.set(Some(current.saturating_add(1)));
         }
     });
-    VerifiedIndex::open_pinned_generation(index_root, generation_id)
+    if retain_peer {
+        VerifiedIndex::open_pinned_generation_with_retained_peer(index_root, generation_id)
+    } else {
+        VerifiedIndex::open_pinned_generation(index_root, generation_id)
+    }
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -335,8 +351,22 @@ pub fn published_explicit_source_relocation_authority(
 }
 
 pub fn pin_published_generation(data_root: &Path) -> Result<Option<PinnedSourceBackedGeneration>> {
+    pin_published_generation_with_peer(data_root, false)
+}
+
+/// Pins the published target and its optional pointer peer in one verified open.
+pub fn pin_published_generation_with_retained_peer(
+    data_root: &Path,
+) -> Result<Option<PinnedSourceBackedGeneration>> {
+    pin_published_generation_with_peer(data_root, true)
+}
+
+fn pin_published_generation_with_peer(
+    data_root: &Path,
+    retain_peer: bool,
+) -> Result<Option<PinnedSourceBackedGeneration>> {
     let index_root = source_backed_index_root(data_root);
-    match open_verified_index(&index_root) {
+    match open_verified_index_with_peer(&index_root, retain_peer) {
         Ok(index) => Ok(Some(PinnedSourceBackedGeneration { index })),
         Err(IndexError::MissingActiveGenerationPointer) => Ok(None),
         Err(error) => Err(error).context("open active verified Core generation"),
@@ -347,19 +377,50 @@ pub fn pin_retained_generation(
     data_root: &Path,
     generation_id: &str,
 ) -> Result<PinnedSourceBackedGeneration> {
+    pin_retained_generation_with_peer(data_root, generation_id, false)
+}
+
+/// Pins the exact retained target and its optional pointer peer in one verified open.
+pub fn pin_retained_generation_with_retained_peer(
+    data_root: &Path,
+    generation_id: &str,
+) -> Result<PinnedSourceBackedGeneration> {
+    pin_retained_generation_with_peer(data_root, generation_id, true)
+}
+
+fn pin_retained_generation_with_peer(
+    data_root: &Path,
+    generation_id: &str,
+    retain_peer: bool,
+) -> Result<PinnedSourceBackedGeneration> {
     let index_root = source_backed_index_root(data_root);
-    let index = open_retained_verified_index(&index_root, generation_id).with_context(|| {
-        format!(
-            "open retained Core generation {generation_id} from {}",
-            index_root.display()
-        )
-    })?;
+    let index = open_retained_verified_index(&index_root, generation_id, retain_peer)
+        .with_context(|| {
+            format!(
+                "open retained Core generation {generation_id} from {}",
+                index_root.display()
+            )
+        })?;
     Ok(PinnedSourceBackedGeneration { index })
 }
 
 pub fn pin_active_verified_generation(data_root: &Path) -> Result<PinnedSourceBackedGeneration> {
+    pin_active_verified_generation_with_peer(data_root, false)
+}
+
+/// Pins the active target and its optional pointer peer in one verified open.
+pub fn pin_active_verified_generation_with_retained_peer(
+    data_root: &Path,
+) -> Result<PinnedSourceBackedGeneration> {
+    pin_active_verified_generation_with_peer(data_root, true)
+}
+
+fn pin_active_verified_generation_with_peer(
+    data_root: &Path,
+    retain_peer: bool,
+) -> Result<PinnedSourceBackedGeneration> {
     let index_root = source_backed_index_root(data_root);
-    let index = match open_verified_index(&index_root) {
+    let index = match open_verified_index_with_peer(&index_root, retain_peer) {
         Ok(index) => index,
         Err(IndexError::MissingActiveGenerationPointer) => {
             return Err(anyhow::Error::new(MissingActiveGeneration));


### PR DESCRIPTION
## Summary

- Reclaim obsolete physical generations and metadata immediately after durable lease release while preserving active, previous, durable-owner, live-reader, required-delta, and certification roots.
- Make ordinary readers target-only and explicitly retain the peer for compact Search and Locate authority.
- Cover cross-generation collisions, pointer rotation, release faults and crashes, and reader fencing.

## Validation

- `scripts/bazel-affected.sh origin/main` — 115/115 selected targets passed.
- `scripts/check.sh --mode=ci` — crate-size preflight, 450 build targets with strict Clippy, and 211/211 routine tests passed.
- Repository policy and guarded disclosure scan passed.
- Prior focused qualification: 1,365 passed and one existing nightly ignore across 15 affected targets; bounded runtime and RSS measurements showed no regression signal.

## Residual risk

One initial `NonCanonicalManifest` refresh failure remains unattributed and was not reproduced by three isolated reruns, ten alternating candidate runs, ten alternating base runs, or the final 190/190 refresh suite. It is documented and was judged non-blocking.