### PR TITLE
fix(index): recognize released payloads for source rebuild

### DIFF
--- a/crates/ctx-history-index-format/src/manifest.rs
+++ b/crates/ctx-history-index-format/src/manifest.rs
@@ -23,6 +23,9 @@ use crate::{
 use ctx_history_core::CertifiedSource;
 
 const MAX_COMMIT_PAYLOAD_BYTES: usize = 256;
+// Payload v2 carried up to 48 KiB of opaque metadata encoded as base64.
+const MAX_RELEASED_V2_METADATA_ENCODED_BYTES: usize = 64 * 1024;
+const MAX_RELEASED_V2_COMMIT_PAYLOAD_BYTES: usize = MAX_RELEASED_V2_METADATA_ENCODED_BYTES + 256;
 const MANIFEST_FLAT_DELTA_STORAGE: &str = "ctx-manifest-flat-delta-v1";
 const MANIFEST_FLAT_DELTA_PREFIX: &[u8] = br#"{"storage_format":"ctx-manifest-flat-delta-v1","#;
 const MAX_MANIFEST_DELTA_CHANGES: usize = 64;
@@ -150,6 +153,16 @@ struct BorrowedCommitPayload<'a> {
     version: u32,
     #[serde(borrow)]
     generation_id: &'a str,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BorrowedReleasedV2CommitPayload<'a> {
+    version: u32,
+    #[serde(borrow)]
+    generation_id: &'a str,
+    #[serde(borrow)]
+    publication_metadata: Option<&'a str>,
 }
 
 #[derive(Debug)]
@@ -393,6 +406,9 @@ pub fn canonical_commit_payload(generation_id: &str) -> Result<String> {
 }
 
 fn decode_commit_payload(encoded: &str) -> Result<DecodedCommitPayload> {
+    if is_released_v2_commit_payload(encoded) {
+        return Err(IndexError::UnsupportedCommitPayload(2));
+    }
     if encoded.len() > MAX_COMMIT_PAYLOAD_BYTES {
         return Err(IndexError::CommitPayloadTooLarge {
             actual: encoded.len(),
@@ -412,6 +428,24 @@ fn decode_commit_payload(encoded: &str) -> Result<DecodedCommitPayload> {
     Ok(DecodedCommitPayload {
         generation_id: payload.generation_id.to_owned(),
     })
+}
+
+fn is_released_v2_commit_payload(encoded: &str) -> bool {
+    // Only recognize the released v2 envelope for source rebuild. Its
+    // removed metadata stays opaque, and current payload validation is unchanged.
+    if encoded.len() > MAX_RELEASED_V2_COMMIT_PAYLOAD_BYTES
+        || !encoded.starts_with(r#"{"version":2,"#)
+    {
+        return false;
+    }
+    let Ok(payload) = serde_json::from_str::<BorrowedReleasedV2CommitPayload<'_>>(encoded) else {
+        return false;
+    };
+    payload.version == 2
+        && is_generation_id(payload.generation_id)
+        && payload
+            .publication_metadata
+            .is_none_or(|metadata| metadata.len() <= MAX_RELEASED_V2_METADATA_ENCODED_BYTES)
 }
 
 pub fn reconcile_commit_error(

--- a/crates/ctx-history-index-format/src/manifest/tests.rs
+++ b/crates/ctx-history-index-format/src/manifest/tests.rs
@@ -9,6 +9,138 @@ use ctx_history_core::{
     SourceObservation, TypedKey,
 };
 
+fn released_v2_payload(metadata_json: &str) -> String {
+    format!(
+        r#"{{"version":2,"generation_id":"{}","publication_metadata":{metadata_json}}}"#,
+        "a".repeat(64)
+    )
+}
+
+#[test]
+fn released_v2_envelopes_are_typed_incompatible() {
+    // Literal envelopes reproduce the released writer's field order and null
+    // handling, independently of either current or historical serializers.
+    for metadata in [
+        "null".to_owned(),
+        r#""""#.to_owned(),
+        r#""AQID""#.to_owned(),
+        format!("\"{}\"", "AAAA".repeat(64)),
+        format!("\"{}\"", "AAAA".repeat(16 * 1024)),
+    ] {
+        let encoded = released_v2_payload(&metadata);
+        assert!(matches!(
+            decode_commit_payload(&encoded),
+            Err(IndexError::UnsupportedCommitPayload(2))
+        ));
+    }
+    let encoded = released_v2_payload(&format!("\"{}\"", "AAAA".repeat(64)));
+    assert!(encoded.len() > 256);
+}
+
+#[test]
+fn malformed_v2_envelopes_do_not_gain_rebuild_classification() {
+    let canonical = released_v2_payload("null");
+    for encoded in [
+        released_v2_payload("42"),
+        released_v2_payload("{}"),
+        released_v2_payload("[]"),
+        canonical.replace("\"version\":2", "\"version\":2,\"version\":3"),
+        canonical.replace("\"publication_metadata\":null", "\"unknown\":null"),
+        canonical.replace(
+            "\"publication_metadata\":null",
+            "\"publication_metadata\":null,\"publication_metadata\":null",
+        ),
+        canonical.replace(&"a".repeat(64), &"z".repeat(64)),
+        format!("{canonical}{{}}"),
+        canonical[..canonical.len() - 1].to_owned(),
+    ] {
+        assert!(
+            matches!(decode_commit_payload(&encoded), Err(IndexError::Json(_))),
+            "unexpected classification for {encoded}"
+        );
+    }
+}
+
+#[test]
+fn oversized_v2_envelopes_keep_the_size_error() {
+    // One byte beyond the old base64 budget still fits the envelope budget.
+    // Beyond either bound, this is not a recognized released envelope.
+    for metadata_bytes in [64 * 1024 + 1, 64 * 1024 + 256] {
+        let encoded = released_v2_payload(&format!("\"{}\"", "A".repeat(metadata_bytes)));
+        assert!(matches!(
+            decode_commit_payload(&encoded),
+            Err(IndexError::CommitPayloadTooLarge { actual, maximum: 256 })
+                if actual == encoded.len()
+        ));
+    }
+}
+
+#[test]
+fn current_commit_payload_stays_strict_and_canonical() {
+    let generation_id = "a".repeat(64);
+    let canonical = format!(r#"{{"version":3,"generation_id":"{generation_id}"}}"#);
+    assert_eq!(
+        decode_commit_payload(&canonical).unwrap().generation_id,
+        generation_id
+    );
+    assert_eq!(canonical_commit_payload(&generation_id).unwrap(), canonical);
+
+    for encoded in [
+        format!(" {canonical}"),
+        format!("{canonical}\n"),
+        format!(r#"{{"generation_id":"{generation_id}","version":3}}"#),
+    ] {
+        assert!(matches!(
+            decode_commit_payload(&encoded),
+            Err(IndexError::NonCanonicalCommitPayload)
+        ));
+    }
+    assert!(matches!(
+        decode_commit_payload(&canonical.replace(&generation_id, &"z".repeat(64))),
+        Err(IndexError::InvalidGenerationId)
+    ));
+}
+
+#[test]
+fn malformed_current_and_unknown_envelopes_stay_json_errors() {
+    let canonical = format!(r#"{{"version":3,"generation_id":"{}"}}"#, "a".repeat(64));
+    for encoded in [
+        "{".to_owned(),
+        canonical.replace("\"version\":3", "\"version\":\"3\""),
+        canonical.replace("\"version\":3", "\"version\":null"),
+        canonical.replace("\"version\":3,", ""),
+        canonical.replace("\"version\":3", "\"version\":3,\"version\":2"),
+        canonical.replace("\"version\":3", "\"version\":3,\"unknown\":true"),
+        format!("{canonical}{{}}"),
+        released_v2_payload("null").replace("\"version\":2", "\"version\":3"),
+        released_v2_payload("null").replace("\"version\":2", "\"version\":4"),
+    ] {
+        assert!(
+            matches!(decode_commit_payload(&encoded), Err(IndexError::Json(_))),
+            "unexpected classification for {encoded}"
+        );
+    }
+}
+
+#[test]
+fn oversized_current_payloads_keep_the_256_byte_limit() {
+    let canonical = format!(r#"{{"version":3,"generation_id":"{}"}}"#, "a".repeat(64));
+    for total_bytes in [257, 64 * 1024 + 256, 64 * 1024 + 257] {
+        let encoded = format!("{canonical}{}", " ".repeat(total_bytes - canonical.len()));
+        assert!(matches!(
+            decode_commit_payload(&encoded),
+            Err(IndexError::CommitPayloadTooLarge { actual, maximum: 256 })
+                if actual == total_bytes
+        ));
+    }
+    let encoded = released_v2_payload(&format!("\"{}\"", "AAAA".repeat(64)))
+        .replace("\"version\":2", "\"version\":3");
+    assert!(matches!(
+        decode_commit_payload(&encoded),
+        Err(IndexError::CommitPayloadTooLarge { maximum: 256, .. })
+    ));
+}
+
 fn route(byte: &str) -> SourceRouteIdentity {
     SourceRouteIdentity::from_sha256(byte.repeat(64)).unwrap()
 }

--- a/crates/ctx-history-index/src/tests/recovery.rs
+++ b/crates/ctx-history-index/src/tests/recovery.rs
@@ -991,3 +991,4 @@ fn explicit_deep_scrub_rejects_incremental_injected_copied_body_posting() {
 }
 
 mod additional;
+mod commit_payload;

--- a/crates/ctx-history-index/src/tests/recovery/additional.rs
+++ b/crates/ctx-history-index/src/tests/recovery/additional.rs
@@ -545,7 +545,7 @@ fn stale_schema_manifest_fails_closed_at_generation_boundary() {
     ));
 }
 
-fn assert_active_meta_incompatibility_is_rebuilt(
+pub(super) fn assert_active_meta_incompatibility_is_rebuilt(
     source_name: &str,
     mutate_meta: impl FnOnce(&mut serde_json::Value),
     assert_incompatibility: impl FnOnce(&IndexError),

--- a/crates/ctx-history-index/src/tests/recovery/commit_payload.rs
+++ b/crates/ctx-history-index/src/tests/recovery/commit_payload.rs
@@ -1,0 +1,168 @@
+use super::*;
+
+fn assert_released_payload_is_rebuilt(publication_metadata: Option<&str>) {
+    additional::assert_active_meta_incompatibility_is_rebuilt(
+        "released-payload.jsonl",
+        |meta| {
+            let payload: serde_json::Value =
+                serde_json::from_str(meta["payload"].as_str().unwrap()).unwrap();
+            // v1.3.1 serialized these three fields in this order, including None.
+            // The metadata was opaque standard unpadded base64 at this boundary.
+            let released = format!(
+                "{{\"version\":2,\"generation_id\":{},\"publication_metadata\":{}}}",
+                payload["generation_id"],
+                serde_json::to_string(&publication_metadata).unwrap(),
+            );
+            if publication_metadata.is_some() {
+                assert!(released.len() > 256);
+                assert!(released.len() <= 65_792);
+            } else {
+                assert!(released.len() <= 256);
+            }
+            meta["payload"] = serde_json::Value::String(released);
+        },
+        |error| {
+            assert!(
+                matches!(error, IndexError::UnsupportedCommitPayload(2)),
+                "released envelope must be incompatible, got {error:?}"
+            );
+            assert!(generation_incompatibility_requires_rebuild(error));
+            assert!(generation_incompatibility_requires_recovery_rebuild(error));
+        },
+    );
+}
+
+#[test]
+fn released_v2_null_metadata_rebuilds_from_source() {
+    assert_released_payload_is_rebuilt(None);
+}
+
+#[test]
+fn released_v2_non_null_metadata_over_current_bound_rebuilds_from_source() {
+    // "YWJj" is standard unpadded base64 for b"abc". The released writer
+    // accepted arbitrary opaque bytes, including this 192-byte metadata body.
+    let encoded_metadata = "YWJj".repeat(64);
+    assert_released_payload_is_rebuilt(Some(&encoded_metadata));
+}
+
+fn assert_current_payload_is_rejected(
+    encode_payload: impl FnOnce(&str) -> String,
+    assert_error: impl Fn(&IndexError),
+) {
+    let temp = tempdir().unwrap();
+    let source = source("current-payload-corruption.jsonl");
+    let mut initial = GenerationWriter::open(temp.path(), WriterOptions::default())
+        .unwrap()
+        .into_writer()
+        .unwrap();
+    initial.begin_source(source.clone()).unwrap();
+    initial
+        .add_core_record(document(&source, 1, "retained source body"))
+        .unwrap();
+    initial.certify_source(certificate(&source, 1, 1)).unwrap();
+    let baseline = initial.commit(|_| true).unwrap();
+    let pointer_path = temp.path().join("active-generation.json");
+    let pointer_before = fs::read(&pointer_path).unwrap();
+    let generation_path = active_generation_path(temp.path());
+    let meta_path = generation_path.join("meta.json");
+    let mut meta: serde_json::Value =
+        serde_json::from_slice(&fs::read(&meta_path).unwrap()).unwrap();
+    meta["payload"] = serde_json::Value::String(encode_payload(&baseline.generation_id));
+    let corrupt_meta = serde_json::to_vec(&meta).unwrap();
+    fs::write(&meta_path, &corrupt_meta).unwrap();
+
+    let reader_error = match VerifiedIndex::open(temp.path()) {
+        Ok(_) => panic!("corrupt current payload unexpectedly opened"),
+        Err(error) => error,
+    };
+    assert_error(&reader_error);
+    assert!(!generation_incompatibility_requires_rebuild(&reader_error));
+    assert!(!generation_incompatibility_requires_recovery_rebuild(
+        &reader_error
+    ));
+    let writer_error = match GenerationWriter::open(temp.path(), WriterOptions::default()) {
+        Ok(_) => panic!("corrupt current payload unexpectedly started a replacement"),
+        Err(error) => error,
+    };
+    assert_error(&writer_error);
+    assert!(!generation_incompatibility_requires_rebuild(&writer_error));
+    assert!(!generation_incompatibility_requires_recovery_rebuild(
+        &writer_error
+    ));
+    assert_eq!(fs::read(&pointer_path).unwrap(), pointer_before);
+    assert_eq!(active_generation_path(temp.path()), generation_path);
+    assert_eq!(fs::read(&meta_path).unwrap(), corrupt_meta);
+}
+
+#[test]
+fn current_payload_with_removed_metadata_field_remains_a_json_error() {
+    assert_current_payload_is_rejected(
+        |generation_id| {
+            format!(
+                "{{\"version\":{COMMIT_PAYLOAD_VERSION},\"generation_id\":\"{generation_id}\",\"publication_metadata\":null}}"
+            )
+        },
+        |error| assert!(matches!(error, IndexError::Json(_)), "{error:?}"),
+    );
+}
+
+#[test]
+fn truncated_current_payload_remains_a_json_error() {
+    assert_current_payload_is_rejected(
+        |generation_id| {
+            format!("{{\"version\":{COMMIT_PAYLOAD_VERSION},\"generation_id\":\"{generation_id}\"")
+        },
+        |error| assert!(matches!(error, IndexError::Json(_)), "{error:?}"),
+    );
+}
+
+#[test]
+fn current_payload_with_invalid_generation_id_remains_rejected() {
+    assert_current_payload_is_rejected(
+        |_| format!("{{\"version\":{COMMIT_PAYLOAD_VERSION},\"generation_id\":\"invalid\"}}"),
+        |error| {
+            assert!(
+                matches!(error, IndexError::InvalidGenerationId),
+                "{error:?}"
+            )
+        },
+    );
+}
+
+#[test]
+fn noncanonical_current_payload_remains_rejected() {
+    assert_current_payload_is_rejected(
+        |generation_id| {
+            format!(
+                " {{\"version\":{COMMIT_PAYLOAD_VERSION},\"generation_id\":\"{generation_id}\"}}"
+            )
+        },
+        |error| {
+            assert!(
+                matches!(error, IndexError::NonCanonicalCommitPayload),
+                "{error:?}"
+            );
+        },
+    );
+}
+
+#[test]
+fn oversized_current_payload_keeps_the_current_size_limit() {
+    assert_current_payload_is_rejected(
+        |generation_id| {
+            let payload = format!(
+                "{{\"version\":{COMMIT_PAYLOAD_VERSION},\"generation_id\":\"{generation_id}\"}}{}",
+                " ".repeat(256),
+            );
+            assert!(payload.len() > 256);
+            assert!(payload.len() < 65_792);
+            payload
+        },
+        |error| {
+            assert!(
+                matches!(error, IndexError::CommitPayloadTooLarge { actual, maximum: 256 } if *actual > 256),
+                "{error:?}"
+            );
+        },
+    );
+}


### PR DESCRIPTION
Released payload-v2 envelopes include publication metadata and can exceed the current payload limit. The current decoder rejects those envelopes before reporting their unsupported version, preventing source-authoritative index recovery.

Recognize the bounded released envelope as an unsupported payload so the existing recovery path builds a current generation from provider sources. Keep malformed current payloads rejected and leave predecessor metadata opaque. Regression tests exercise the real verified reader and source-rebuild path alongside current-format rejection.

Validation: the history-index-format and history-index unit suites, plus the affected history-index-query and history-refresh suites, passed with `--config=ci`.
