### PR TITLE
Keep refresh requests pending until terminal results persist

### DIFF
--- a/crates/ctx-daemon-service/src/daemon_scheduler_tests/refresh_retry.rs
+++ b/crates/ctx-daemon-service/src/daemon_scheduler_tests/refresh_retry.rs
@@ -4,6 +4,9 @@ use ctx_client_observability::analytics::PublicEventV1;
 #[path = "refresh_retry/durable_retry.rs"]
 mod durable_retry;
 
+#[path = "refresh_retry/terminal_status.rs"]
+mod terminal_status;
+
 fn enqueue_synthetic_refresh_successor(
     coordinator: &CoreRefreshEngine,
     data_root: &Path,

--- a/crates/ctx-daemon-service/src/daemon_scheduler_tests/refresh_retry/terminal_status.rs
+++ b/crates/ctx-daemon-service/src/daemon_scheduler_tests/refresh_retry/terminal_status.rs
@@ -180,6 +180,7 @@ fn terminal_status_persistence_failure_replays_same_request_after_process_loss()
         .to_owned();
     fixture.restore_journal();
     let request_id = fixture.request_id.clone();
+    let replay_request_id = request_id.clone();
     // Retain the filesystem, but discard all in-memory terminal retry state.
     let TerminalPersistenceFixture {
         temp: _temp,
@@ -203,6 +204,15 @@ fn terminal_status_persistence_failure_replays_same_request_after_process_loss()
     assert!(restarted
         .recover_interrupted_publication(&data_root)
         .unwrap());
+    assert_eq!(
+        restarted.status(&replay_request_id).unwrap()["request_state"],
+        "admission_pending"
+    );
+    // Recovery re-admits the retained request. Reuse the fixture's bounded
+    // admission instead of discovering providers through the shared test config.
+    restarted
+        .complete_pending_admission_for_test(&data_root, &replay_request_id, BTreeMap::new())
+        .unwrap();
     let replay = restarted.run_next(&data_root).unwrap();
     assert!(!replay.failed, "{:#}", replay.job);
     assert!(!replay.terminal_persistence_pending);

--- a/crates/ctx-daemon-service/src/daemon_scheduler_tests/refresh_retry/terminal_status.rs
+++ b/crates/ctx-daemon-service/src/daemon_scheduler_tests/refresh_retry/terminal_status.rs
@@ -1,0 +1,214 @@
+use super::*;
+
+struct TerminalPersistenceFixture {
+    temp: tempfile::TempDir,
+    coordinator: CoreRefreshEngine,
+    request_id: String,
+    executions: Arc<AtomicUsize>,
+}
+
+impl TerminalPersistenceFixture {
+    fn new(provider_fails: bool) -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let data_root = temp.path().join("data");
+        ctx_history_platform::platform_security::establish_private_data_root(&data_root).unwrap();
+        publish_empty_core_generation(&data_root);
+        let status_path = daemon_core_refresh_job_path(&data_root);
+        let saved_status = temp.path().join("running.json");
+        let executions = Arc::new(AtomicUsize::new(0));
+        let execution_count = Arc::clone(&executions);
+        let coordinator = CoreRefreshEngine::with_executor(Arc::new(
+            move |execution: SourceBackedRefreshExecution<'_>| {
+                execution_count.fetch_add(1, Ordering::SeqCst);
+                let result = if provider_fails {
+                    Err(anyhow::anyhow!("provider capture failed"))
+                } else {
+                    Ok(publish_empty_authoritative_generation(&execution))
+                };
+                // Preserve the real running journal and obstruct only its replacement.
+                // The production journal, not a callback returning a synthetic error,
+                // must reject the directory at its regular status-file destination.
+                std::fs::rename(&status_path, &saved_status)?;
+                std::fs::create_dir(&status_path)?;
+                result
+            },
+        ));
+        let queued = coordinator.enqueue_periodic(&data_root).unwrap();
+        let request_id = queued["request_id"].as_str().unwrap().to_owned();
+        coordinator
+            .complete_pending_admission_for_test(&data_root, &request_id, BTreeMap::new())
+            .unwrap();
+        Self {
+            temp,
+            coordinator,
+            request_id,
+            executions,
+        }
+    }
+
+    fn data_root(&self) -> std::path::PathBuf {
+        self.temp.path().join("data")
+    }
+
+    fn restore_journal(&self) {
+        let path = daemon_core_refresh_job_path(&self.data_root());
+        std::fs::remove_dir(&path).unwrap();
+        std::fs::rename(self.temp.path().join("running.json"), path).unwrap();
+    }
+
+    fn status(&self) -> Value {
+        self.coordinator
+            .handle_ipc_request(
+                &self.data_root(),
+                &json!({"op": "source_refresh_status", "request_id": self.request_id}),
+            )
+            .unwrap()
+            .unwrap()
+    }
+}
+
+fn assert_waiting_for_terminal(status: Value, request_id: &str) {
+    assert_eq!(status["request_id"], request_id);
+    assert_eq!(status["request_state"], "running");
+    assert_eq!(status["logical_phase"], "direct");
+    assert_eq!(status["physical_attempt_state"], "running");
+    assert_eq!(status["progress_owner_attempt_state"], "running");
+    assert_eq!(status["progress"]["phase"], "persisting_terminal");
+    assert_eq!(status["progress"]["whole_run_stage"], "activation");
+    for field in [
+        "receipt",
+        "outcome",
+        "structured_outcome",
+        "finished_at_ms",
+        "last_error",
+    ] {
+        assert!(
+            status.get(field).is_none(),
+            "premature terminal field {field}"
+        );
+    }
+    let parsed = ctx_history_refresh::RefreshStatus::parse_schema_v1(status).unwrap();
+    assert!(!parsed.kind().unwrap().request_state().is_terminal());
+    assert!(parsed.kind().unwrap().terminal_outcome().is_none());
+}
+
+#[test]
+fn terminal_status_waits_for_real_journal_replacement_and_scheduler_retry() {
+    for provider_fails in [false, true] {
+        let fixture = TerminalPersistenceFixture::new(provider_fails);
+        let data_root = fixture.data_root();
+        let mut runtime = source_refresh_only_runtime();
+        let notification = FailingGenerationPublished::default();
+        let first = run_pending_core_refresh(
+            &data_root,
+            &mut runtime,
+            Some(&fixture.coordinator),
+            true,
+            &notification,
+            &crate::test_support::OBSERVATION,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(first.failed);
+        assert!(!first.did_work);
+        assert!(first.provider_refresh_events.is_empty());
+        assert_eq!(notification.calls.load(Ordering::SeqCst), 0);
+        assert!(fixture.coordinator.has_pending_request());
+        assert_waiting_for_terminal(fixture.status(), &fixture.request_id);
+
+        let generation = ctx_history_refresh::pin_published_generation(&data_root)
+            .unwrap()
+            .unwrap();
+        let published_id = generation.verified_index().generation_id().to_owned();
+        // This exercises the verified lexical reader while completion is pending.
+        assert!(complete_lexical_candidates(generation.verified_index(), "missing", 1).is_empty());
+        assert_eq!(fixture.status()["published_generation"], published_id);
+        assert_eq!(fixture.executions.load(Ordering::SeqCst), 1);
+
+        fixture.restore_journal();
+        let retry = run_pending_core_refresh(
+            &data_root,
+            &mut runtime,
+            Some(&fixture.coordinator),
+            true,
+            &notification,
+            &crate::test_support::OBSERVATION,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(retry.failed, provider_fails);
+        assert_eq!(fixture.executions.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            notification.calls.load(Ordering::SeqCst),
+            usize::from(!provider_fails)
+        );
+        assert!(!fixture.coordinator.has_pending_request());
+        let status = fixture.status();
+        let durable = read_daemon_job_status(&daemon_core_refresh_job_path(&data_root)).unwrap();
+        assert_eq!(
+            status["request_state"],
+            if provider_fails {
+                "failed"
+            } else {
+                "published"
+            }
+        );
+        for field in [
+            "request_id",
+            "request_state",
+            "published_generation",
+            "receipt",
+            "structured_outcome",
+        ] {
+            assert_eq!(status[field], durable[field], "terminal {field}");
+        }
+        assert_eq!(status["published_generation"], published_id);
+    }
+}
+
+#[test]
+fn terminal_status_persistence_failure_replays_same_request_after_process_loss() {
+    let fixture = TerminalPersistenceFixture::new(false);
+    let data_root = fixture.data_root();
+    let mut runtime = source_refresh_only_runtime();
+    let iteration = run_source_refresh_cycle(&data_root, &mut runtime, &fixture.coordinator);
+    assert!(iteration.failed);
+    assert_waiting_for_terminal(fixture.status(), &fixture.request_id);
+    let generation_id = fixture.status()["published_generation"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    fixture.restore_journal();
+    let request_id = fixture.request_id.clone();
+    // Retain the filesystem, but discard all in-memory terminal retry state.
+    let TerminalPersistenceFixture {
+        temp: _temp,
+        coordinator,
+        ..
+    } = fixture;
+    drop(coordinator);
+    let restarted = CoreRefreshEngine::with_executor(Arc::new(
+        move |execution: SourceBackedRefreshExecution<'_>| {
+            assert_eq!(execution.request_id, request_id);
+            assert_eq!(
+                ctx_history_refresh::pin_published_generation(&data_root)?
+                    .unwrap()
+                    .generation_id(),
+                generation_id,
+            );
+            Ok(publish_empty_authoritative_generation(&execution))
+        },
+    ));
+    let data_root = _temp.path().join("data");
+    assert!(restarted
+        .recover_interrupted_publication(&data_root)
+        .unwrap());
+    let replay = restarted.run_next(&data_root).unwrap();
+    assert!(!replay.failed, "{:#}", replay.job);
+    assert!(!replay.terminal_persistence_pending);
+    assert_eq!(replay.job["request_state"], "published");
+    assert_eq!(
+        read_daemon_job_status(&daemon_core_refresh_job_path(&data_root)).unwrap()["request_id"],
+        replay.job["request_id"],
+    );
+}

--- a/crates/ctx-history-refresh/src/engine/read_model.rs
+++ b/crates/ctx-history-refresh/src/engine/read_model.rs
@@ -509,7 +509,48 @@ pub(super) fn projected_status_json(
     request_id: &str,
 ) -> Option<Value> {
     let attempt = find_attempt(state, request_id)?;
-    Some(apply_read_projection(attempt, attempt.to_json(), false))
+    let mut status = apply_read_projection(attempt, attempt.to_json(), false);
+    if state
+        .pending_terminal_persistence
+        .as_ref()
+        .is_some_and(|pending| pending.request_id == request_id)
+    {
+        // The generation is queryable, but the request result is not durable
+        // yet. Keep the exact terminal job internal to the existing retry.
+        let fields = status.as_object_mut()?;
+        for field in [
+            "request_state",
+            "physical_attempt_state",
+            "progress_owner_attempt_state",
+        ] {
+            fields.insert(
+                field.to_owned(),
+                json!(SourceBackedRefreshState::Running.as_str()),
+            );
+        }
+        fields.insert("logical_phase".to_owned(), json!("direct"));
+        for field in [
+            "finished_at_ms",
+            "receipt",
+            "outcome",
+            "structured_outcome",
+            "generation_changed",
+            "failure_type",
+            "error_code",
+            "reason",
+            "last_error",
+            "automatic_retry",
+        ] {
+            fields.remove(field);
+        }
+        let mut progress = attempt.live_progress();
+        progress.phase = "persisting_terminal".to_owned();
+        fields.insert(
+            "progress".to_owned(),
+            progress.to_json_with_total_known(attempt.progress_total_sources_known, None),
+        );
+    }
+    Some(status)
 }
 
 pub(super) fn projected_job_json(

--- a/crates/ctx-history-refresh/src/engine/tests/additional.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/additional.rs
@@ -1221,17 +1221,24 @@ fn newer_event_during_confirmation_attempt_is_not_paused_by_stale_admission() {
     let stale = running.join().unwrap();
     assert!(stale.terminal_persistence_pending, "{:#}", stale.job);
     assert_eq!(journal.terminal_store_count(), 2);
-    let terminal = coordinator
+    let pending = coordinator
         .status(stale.job["request_id"].as_str().unwrap())
         .unwrap();
-    assert_eq!(terminal["structured_outcome"]["retryable"], true);
-    assert!(terminal.get("automatic_retry").is_none());
+    assert_eq!(pending["request_state"], "running");
+    assert!(pending.get("structured_outcome").is_none());
+    assert_eq!(stale.job["structured_outcome"]["retryable"], true);
+    assert!(pending.get("automatic_retry").is_none());
     assert!(!coordinator.route_is_permanently_blocked_for_test(&route));
     let persisted = coordinator
         .run_next(&data_root)
         .expect("retry terminal persistence");
     assert!(!persisted.terminal_persistence_pending);
     assert_eq!(persisted.job["request_state"], "failed");
+    let terminal = coordinator
+        .status(stale.job["request_id"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(terminal["structured_outcome"]["retryable"], true);
+    assert!(terminal.get("automatic_retry").is_none());
     assert_eq!(journal.terminal_store_count(), 3);
     drop(coordinator);
 

--- a/crates/ctx-history-refresh/src/engine/tests/publication_lifecycle.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/publication_lifecycle.rs
@@ -729,6 +729,16 @@ fn failed_post_commit_probe_is_not_reopened_in_the_same_cycle() {
 fn terminal_persist_failure_retries_exact_receipt_without_reexecuting_refresh() {
     let coordinator = CoreRefreshEngine::new();
     let failed_callbacks = AtomicUsize::new(0);
+    let earlier = coordinator.enqueue(None);
+    let earlier_id = request_id(&earlier);
+    coordinator
+        .run_next_with(
+            |_, _| Ok(test_publication("generation-a")),
+            || Ok(Some("generation-a".to_owned())),
+            |_| Ok(()),
+            |_| Ok(()),
+        )
+        .unwrap();
     let request = coordinator.enqueue(Some("generation-a".to_owned()));
     let request_id = request_id(&request);
 
@@ -751,16 +761,46 @@ fn terminal_persist_failure_retries_exact_receipt_without_reexecuting_refresh() 
     assert_eq!(run.job["progress"]["phase"], "published");
     assert!(run.job.get("last_error").is_none());
     assert_eq!(failed_callbacks.load(Ordering::SeqCst), 0);
+    let pending = coordinator.status(&request_id).unwrap();
+    assert_eq!(pending["request_state"], "running");
+    assert_eq!(pending["progress"]["phase"], "persisting_terminal");
+    assert_eq!(pending["published_generation"], "generation-b");
+    assert!(pending.get("receipt").is_none());
+    assert!(pending.get("structured_outcome").is_none());
+    assert!(!RefreshStatus::parse_schema_v1(pending.clone())
+        .unwrap()
+        .kind()
+        .unwrap()
+        .request_state()
+        .is_terminal());
     assert_eq!(
-        coordinator.status(&request_id).unwrap()["request_state"],
+        coordinator.status(&earlier_id).unwrap()["request_state"],
         "published"
     );
+    assert!(coordinator.status("unknown-request").is_none());
+
+    let still_pending = coordinator
+        .run_next_with(
+            |_, _| panic!("terminal persistence retry must not execute capture"),
+            || panic!("terminal persistence retry must not reopen Core"),
+            |job| {
+                assert_eq!(job, &run.job);
+                Err(anyhow!("terminal persistence is still unavailable"))
+            },
+            |_| Ok(()),
+        )
+        .unwrap();
+    assert!(still_pending.terminal_persistence_pending);
+    assert_eq!(coordinator.status(&request_id).unwrap(), pending);
 
     let retry = coordinator
         .run_next_with(
             |_, _| panic!("terminal persistence retry must not execute capture"),
             || panic!("terminal persistence retry must not reopen Core"),
-            |_| Ok(()),
+            |job| {
+                assert_eq!(job, &run.job);
+                Ok(())
+            },
             |_| Ok(()),
         )
         .expect("terminal persistence retry");
@@ -771,6 +811,9 @@ fn terminal_persist_failure_retries_exact_receipt_without_reexecuting_refresh() 
     assert_eq!(retry.job["request_state"], "published");
     assert!(retry.job.get("failure_type").is_none());
     assert!(retry.job.get("last_error").is_none());
+    let published = coordinator.status(&request_id).unwrap();
+    assert_eq!(published["request_state"], "published");
+    assert_eq!(published["receipt"], run.job["receipt"]);
 }
 
 #[test]
@@ -791,6 +834,27 @@ fn failed_terminal_persistence_retries_and_survives_restart_without_recapture() 
     assert!(first.failed);
     assert!(first.terminal_persistence_pending);
     assert!(coordinator.has_pending_request());
+    let request_id = first.job["request_id"].as_str().unwrap();
+    let pending = coordinator.status(request_id).unwrap();
+    assert_eq!(pending["request_state"], "running");
+    assert_eq!(pending["progress"]["phase"], "persisting_terminal");
+    for field in [
+        "structured_outcome",
+        "last_error",
+        "failure_type",
+        "finished_at_ms",
+    ] {
+        assert!(
+            pending.get(field).is_none(),
+            "premature terminal field {field}"
+        );
+    }
+    assert!(!RefreshStatus::parse_schema_v1(pending)
+        .unwrap()
+        .kind()
+        .unwrap()
+        .request_state()
+        .is_terminal());
 
     let status_path = daemon_source_backed_refresh_job_path(&data_root);
     let retry = coordinator
@@ -805,6 +869,10 @@ fn failed_terminal_persistence_retries_and_survives_restart_without_recapture() 
     assert!(!retry.terminal_persistence_pending);
     assert!(!coordinator.has_pending_request());
     assert_eq!(retry.job["request_state"], "failed");
+    assert_eq!(
+        coordinator.status(request_id).unwrap()["request_state"],
+        "failed"
+    );
     assert!(retry.job["last_error"]
         .as_str()
         .is_some_and(|error| error.contains("typed provider refresh failure")));


### PR DESCRIPTION
Project requests awaiting terminal journal persistence as running, keeping the published Core generation readable. Retry the retained result through the existing journal path before exposing terminal status. Add success/failure persistence, scheduler, queryability and restart regression coverage.

Validation: all 190 engine and 239 daemon-service tests pass under the CI configuration, including Clippy.