### PR TITLE
fix(show): preserve opaque structured JSON nulls

### DIFF
--- a/crates/ctx-history-cli/src/source_index/render.rs
+++ b/crates/ctx-history-cli/src/source_index/render.rs
@@ -236,15 +236,16 @@ fn render_show_jsonl(value: &Value) -> Result<String> {
         .iter()
         .map(|event| {
             if value["target"] == "session" {
-                serde_json::to_string(&compact_json(json!({
+                let mut line = compact_json(json!({
                     "schema_version": 1,
                     "payload_type": "session_transcript_event",
                     "mode": value["mode"],
                     "ctx_session_id": value["ctx_session_id"],
                     "provider": value["provider"],
                     "provider_session_id": value["provider_session_id"],
-                    "event": event,
-                })))
+                }));
+                line["event"] = event.clone();
+                serde_json::to_string(&line)
             } else {
                 serde_json::to_string(event)
             }

--- a/crates/ctx-history-cli/src/source_index/show.rs
+++ b/crates/ctx-history-cli/src/source_index/show.rs
@@ -548,7 +548,7 @@ impl<'a> SessionStreamRenderer<'a> {
                 fragment
             }
             OutputFormat::Jsonl => {
-                let line = compact_json(json!({
+                let mut line = compact_json(json!({
                     "schema_version": 1,
                     "payload_type": "session_transcript_event",
                     "mode": self.metadata["mode"],
@@ -557,8 +557,8 @@ impl<'a> SessionStreamRenderer<'a> {
                     "provider_key": self.metadata["provider_key"],
                     "source_id": self.metadata["source_id"],
                     "provider_session_id": self.metadata["provider_session_id"],
-                    "event": value,
                 }));
+                line["event"] = value;
                 let mut fragment = serde_json::to_vec(&line)?;
                 fragment.push(b'\n');
                 fragment

--- a/crates/ctx-history-cli/src/source_index/tests/activity.rs
+++ b/crates/ctx-history-cli/src/source_index/tests/activity.rs
@@ -91,3 +91,107 @@ fn absent_activity_is_omitted() {
     );
     assert!(render_event_value(&event).get("activity").is_none());
 }
+
+#[test]
+fn show_and_list_preserve_structured_nulls_exactly() {
+    for payload in [
+        json!([null, {"value": null}, [null, {"nested": null}]]),
+        json!({"argument": null, "nested": {"unset": null},
+            "items": [null, {"value": null}], "snake_key": 1, "snakeKey": 2}),
+    ] {
+        let temp = tempdir().unwrap();
+        write_test_generation(temp.path());
+        let event = fixture_event(CaptureProvider::Codex, "codex_session_jsonl", 96, 1);
+        let mut stored = fixture_core_event(&event, "structured response");
+        stored.core_record.content.structured_content = Some(payload.clone());
+        stored.core_record.content.activity = Some(complete_activity());
+        stored.core_record.validate_contract().unwrap();
+        append_fixture_session(temp.path(), std::slice::from_ref(&stored), 96);
+        let activity = serde_json::to_value(complete_activity()).unwrap();
+
+        let rendered = render_event_value(&stored);
+        assert!(rendered.get("parent_ctx_session_id").is_none());
+        assert!(rendered.get("occurred_at").is_none());
+        let listed = crate::list_events::render_event(
+            &stored,
+            crate::list_events::EventContentProjection::Full,
+        )
+        .unwrap();
+        let shown = mcp_fixture_show_event(temp.path(), &stored);
+        let session = mcp_show_session(
+            temp.path(),
+            &stored.session_id.as_uuid().to_string(),
+            TranscriptMode::Log,
+            10,
+            None,
+            crate::presentation_limit::CLI_PRESENTATION_MAX_OUTPUT_BYTES,
+        )
+        .unwrap();
+        for value in [
+            &rendered,
+            &listed,
+            &shown["event"],
+            &shown["events"][0],
+            &session["events"][0],
+        ] {
+            assert_eq!(value.get("structured_content"), Some(&payload));
+            assert_eq!(value["activity"], activity);
+            assert_eq!(value["content"]["complete"], true);
+        }
+
+        let mut buffered = Vec::new();
+        super::super::render::write_show_value(
+            session,
+            OutputFormat::Jsonl,
+            None,
+            stored.event_id.as_uuid(),
+            &mut buffered,
+        )
+        .unwrap();
+        let (mut ui, stdout) = test_ui();
+        stream_cli_session(
+            temp.path(),
+            Some(stored.session_id.to_string()),
+            None,
+            None,
+            None,
+            None,
+            TranscriptMode::Log,
+            OutputFormat::Jsonl,
+            None,
+            None,
+            &mut ui,
+        )
+        .unwrap();
+        ui.flush().unwrap();
+        for bytes in [buffered, stdout.bytes()] {
+            let lines = bytes
+                .split(|byte| *byte == b'\n')
+                .filter(|line| !line.is_empty())
+                .map(|line| serde_json::from_slice::<Value>(line).unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(lines[0]["payload_type"], "session_transcript_event");
+            assert_eq!(lines[0]["event"]["structured_content"], payload);
+            assert_eq!(lines[0]["event"]["activity"], activity);
+            assert_eq!(lines[0]["event"]["content"]["complete"], true);
+        }
+    }
+}
+
+#[test]
+fn show_renderer_distinguishes_explicit_null_from_absent_content() {
+    let mut absent = fixture_core_event(
+        &fixture_event(CaptureProvider::Codex, "codex_session_jsonl", 97, 1),
+        "no structured content",
+    );
+    absent.core_record.content.structured_content = None;
+    assert!(render_event_value(&absent)
+        .get("structured_content")
+        .is_none());
+    // This tests renderer input only, not a stored round trip.
+    absent.core_record.content.structured_content = Some(Value::Null);
+    assert_eq!(
+        render_event_value(&absent).get("structured_content"),
+        Some(&Value::Null)
+    );
+}

--- a/crates/ctx-history-read-application/src/show_read_model.rs
+++ b/crates/ctx-history-read-application/src/show_read_model.rs
@@ -212,13 +212,15 @@ pub fn render_show_event_read_model(event: &CoreEventRecord) -> Value {
         "role": event.role,
         "occurred_at": view.occurred_at.as_deref(),
         "text": content.normalized_body.as_deref(),
-        "structured_content": content.structured_content.as_ref(),
         "content": {
             "complete": policy.complete,
             "policy_status": policy.status,
             "policy_reason": policy.reason,
         },
     }));
+    if let Some(structured_content) = &content.structured_content {
+        rendered["structured_content"] = structured_content.clone();
+    }
     if let Some(activity) = &content.activity {
         rendered["activity"] = json!(activity);
     }


### PR DESCRIPTION
Event and session show preserve null members inside captured structured objects and arrays, including session JSONL output. Stored-record tests check JSON and both JSONL paths; separate direct-renderer coverage distinguishes an explicit null from an absent field.