### PR TITLE
fix(import): preserve direct JSONL order and valid result records

### DIFF
--- a/crates/ctx-cli-contract-tests/tests/contracts/native_providers/factory_retry.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/native_providers/factory_retry.rs
@@ -65,11 +65,16 @@ fn import_factory_result(temp: &TempDir, path: &str) -> Value {
 }
 
 fn import_factory(temp: &TempDir, path: &str) -> Value {
+    import_factory_with_rejections(temp, path, 0)
+}
+
+fn import_factory_with_rejections(temp: &TempDir, path: &str, rejected_records: u64) -> Value {
     let imported = import_factory_result(temp, path);
-    assert_explicit_source_publication(
+    assert_explicit_source_publication_with_rejections(
         &imported,
         "factory_ai_droid",
         "factory_ai_droid_sessions_jsonl",
+        rejected_records,
     );
     imported
 }
@@ -176,7 +181,7 @@ fn factory_droid_import_preserves_result_order_and_record_local_rejections() {
     .unwrap();
     writeln!(appended, "{}", message("tail", "valid tail")).unwrap();
     drop(appended);
-    let append = import_factory(&temp, path);
+    let append = import_factory_with_rejections(&temp, path, 1);
     assert_eq!(
         append["totals"]["current_rejected_records"], 1,
         "{append:#}"
@@ -187,7 +192,7 @@ fn factory_droid_import_preserves_result_order_and_record_local_rejections() {
     for (body, id) in &ids {
         assert_eq!(appended_ids[body], *id);
     }
-    let repeat = import_factory(&temp, path);
+    let repeat = import_factory_with_rejections(&temp, path, 1);
     assert_eq!(
         repeat["totals"]["current_rejected_records"], 1,
         "{repeat:#}"
@@ -200,7 +205,7 @@ fn factory_droid_import_preserves_result_order_and_record_local_rejections() {
     rewritten.insert(2, message(&"y".repeat(65_536), "composite key overflow"));
     rewritten.push(message("tail", "valid tail"));
     write_jsonl(&file, &rewritten);
-    let replacement = import_factory(&temp, path);
+    let replacement = import_factory_with_rejections(&temp, path, 1);
     assert_eq!(
         replacement["totals"]["current_rejected_records"], 1,
         "{replacement:#}"

--- a/crates/ctx-cli-contract-tests/tests/contracts/native_providers/factory_retry.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/native_providers/factory_retry.rs
@@ -94,6 +94,231 @@ fn factory_record_ids(temp: &TempDir) -> BTreeSet<(String, String)> {
 }
 
 #[test]
+fn factory_droid_import_preserves_result_order_and_record_local_rejections() {
+    let temp = tempdir();
+    let root = temp.path().join("droid-order/sessions/project");
+    fs::create_dir_all(&root).unwrap();
+    let file = root.join("ordered.jsonl");
+    let path = root.parent().unwrap().to_str().unwrap();
+    let message = |id: &str, body: &str| {
+        json!({
+            "type": "message", "id": id, "role": "assistant", "content": body
+        })
+    };
+    let mut result = factory_result(
+        "result",
+        None,
+        &[("call-one", "result one"), ("call-two", "result two")],
+    );
+    // A non-result block leaves the first retained result at native index one.
+    result["message"]["content"]
+        .as_array_mut()
+        .unwrap()
+        .insert(0, json!({"type": "text", "text": "context"}));
+    let initial = vec![
+        factory_header("ordered"),
+        message("before", "before"),
+        result,
+        message("after", "after"),
+    ];
+    write_jsonl(&file, &initial);
+    let _daemon = start_isolated_provider_daemon(&temp);
+    let cold = import_factory(&temp, path);
+    assert_eq!(cold["totals"]["current_rejected_records"], 0);
+    let ids = factory_event_ids(&temp);
+    let session = provider_core_records(&data_root(&temp), "factory_ai_droid")[0]
+        .session_id
+        .as_uuid()
+        .to_string();
+    let shown = json_output(ctx(&temp).args([
+        "show",
+        "session",
+        &session,
+        "--mode",
+        "log",
+        "--format=json",
+    ]));
+    let bodies = shown["events"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|event| event["text"].as_str())
+        .filter(|text| *text != "notice")
+        .collect::<Vec<_>>();
+    assert_eq!(bodies, ["before", "result one", "result two", "after"]);
+    let window = json_output(ctx(&temp).args([
+        "show",
+        "event",
+        &ids["result one"],
+        "--window",
+        "1",
+        "--format=json",
+    ]));
+    assert_eq!(
+        window["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|event| event["text"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        ["before", "result one", "result two"]
+    );
+
+    let noop = import_factory(&temp, path);
+    assert_noop_publication(&noop);
+    assert_eq!(factory_event_ids(&temp), ids);
+    let mut appended = fs::OpenOptions::new().append(true).open(&file).unwrap();
+    writeln!(
+        appended,
+        "{}",
+        message(&"x".repeat(65_537), "invalid identity")
+    )
+    .unwrap();
+    writeln!(appended, "{}", message("tail", "valid tail")).unwrap();
+    drop(appended);
+    let append = import_factory(&temp, path);
+    assert_eq!(
+        append["totals"]["current_rejected_records"], 1,
+        "{append:#}"
+    );
+    let appended_ids = factory_event_ids(&temp);
+    assert!(appended_ids.contains_key("valid tail"));
+    assert!(!appended_ids.contains_key("invalid identity"));
+    for (body, id) in &ids {
+        assert_eq!(appended_ids[body], *id);
+    }
+    let repeat = import_factory(&temp, path);
+    assert_eq!(
+        repeat["totals"]["current_rejected_records"], 1,
+        "{repeat:#}"
+    );
+    assert_noop_publication(&repeat);
+    assert_eq!(factory_event_ids(&temp), appended_ids);
+
+    // Replace the source with the same valid records around a malformed key.
+    let mut rewritten = initial;
+    rewritten.insert(2, message(&"y".repeat(65_536), "composite key overflow"));
+    rewritten.push(message("tail", "valid tail"));
+    write_jsonl(&file, &rewritten);
+    let replacement = import_factory(&temp, path);
+    assert_eq!(
+        replacement["totals"]["current_rejected_records"], 1,
+        "{replacement:#}"
+    );
+    assert_eq!(factory_event_ids(&temp), appended_ids);
+    let search = json_output(ctx(&temp).args([
+        "search",
+        "valid tail",
+        "--provider",
+        "factory-ai-droid",
+        "--refresh",
+        "off",
+        "--format=json",
+    ]));
+    assert!(!search["results"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn factory_droid_empty_completion_is_stored_and_showable() {
+    let temp = tempdir();
+    let root = temp.path().join("droid-empty/sessions/project");
+    fs::create_dir_all(&root).unwrap();
+    let file = root.join("empty.jsonl");
+    let path = root.parent().unwrap().to_str().unwrap();
+    let result = factory_result("empty-result", None, &[("call-empty", "")]);
+    write_jsonl(&file, &[factory_header("empty"), result.clone()]);
+    let _daemon = start_isolated_provider_daemon(&temp);
+    let cold = import_factory(&temp, path);
+    assert_eq!(cold["totals"]["current_rejected_records"], 0);
+    let records = provider_core_records(&data_root(&temp), "factory_ai_droid");
+    let stored = records
+        .iter()
+        .find(|record| record.event_type == "tool_output")
+        .unwrap();
+    assert_eq!(stored.content.normalized_body, None);
+    assert_eq!(stored.content.structured_content.as_ref(), Some(&result));
+    let id = stored.event_id.as_uuid().to_string();
+    let shown = json_output(ctx(&temp).args(["show", "event", &id, "--format=json"]));
+    assert!(shown["event"].get("text").is_none());
+    assert_eq!(shown["event"]["structured_content"], result);
+    assert_eq!(shown["event"]["content"]["complete"], true);
+    assert_eq!(
+        shown["event"]["activity"]["provider_call_id"],
+        json!({"Utf8": "call-empty"})
+    );
+    let noop = import_factory(&temp, path);
+    assert_noop_publication(&noop);
+    assert_eq!(
+        factory_record_ids(&temp),
+        records
+            .iter()
+            .map(|record| (record.session_id.to_string(), record.event_id.to_string()))
+            .collect()
+    );
+}
+
+#[test]
+fn factory_droid_invalid_optional_parent_preserves_child_history() {
+    let temp = tempdir();
+    let root = temp.path().join("droid-parent/sessions/project");
+    fs::create_dir_all(&root).unwrap();
+    let cases = [
+        ("self-child", "parent", "self-child".to_owned()),
+        ("large-child", "parent", "x".repeat(65_537)),
+        (
+            "encoded-bound-child",
+            "callingSessionId",
+            "x".repeat(65_536),
+        ),
+        ("unresolved-child", "parent", "unresolved-parent".to_owned()),
+    ];
+    for (child, field, parent) in &cases {
+        let mut header = factory_header(child);
+        header[*field] = json!(parent);
+        write_jsonl(
+            &root.join(format!("{child}.jsonl")),
+            &[
+                header,
+                json!({"type": "message", "id": format!("{child}-message"), "role": "assistant", "content": format!("retained {child}")}),
+            ],
+        );
+    }
+    let _daemon = start_isolated_provider_daemon(&temp);
+    let path = root.parent().unwrap().to_str().unwrap();
+    let cold = import_factory(&temp, path);
+    assert_eq!(cold["totals"]["current_rejected_records"], 0, "{cold:#}");
+    let records = provider_core_records(&data_root(&temp), "factory_ai_droid");
+    assert_eq!(records.len(), 8);
+    for (child, _, _) in &cases {
+        let record = records
+            .iter()
+            .find(|record| {
+                record.content.normalized_body.as_deref() == Some(&format!("retained {child}"))
+            })
+            .unwrap();
+        assert_eq!(
+            record.parent_session_id.is_some(),
+            *child == "unresolved-child"
+        );
+        assert_eq!(
+            record.session_relationship.is_some(),
+            *child == "unresolved-child"
+        );
+        let shown = json_output(ctx(&temp).args([
+            "show",
+            "event",
+            &record.event_id.as_uuid().to_string(),
+            "--format=json",
+        ]));
+        assert_eq!(shown["event"]["text"], format!("retained {child}"));
+    }
+    let ids = factory_record_ids(&temp);
+    let noop = import_factory(&temp, path);
+    assert_noop_publication(&noop);
+    assert_eq!(factory_record_ids(&temp), ids);
+}
+
+#[test]
 fn factory_droid_default_source_imports_searches_and_reimports_without_identity_drift() {
     let temp = tempdir();
     let query = "factory-default-discovery-oracle";

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/antigravity.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/antigravity.rs
@@ -2,7 +2,7 @@ use ctx_history_core::CaptureProvider;
 
 use crate::{NativeJsonlRuntime, ANTIGRAVITY_CLI_SOURCE_FORMAT};
 
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v6-optional-activity-admission";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v7-record-admission-order";
 
 pub const fn antigravity_source_backed_adapter<R: NativeJsonlRuntime>(
 ) -> super::DirectJsonlFamilyAdapter<R> {

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/copilot.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/copilot.rs
@@ -10,12 +10,12 @@ use serde_json::{value::RawValue, Map, Number, Value};
 use crate::{NativeJsonlRuntime, COPILOT_CLI_SOURCE_FORMAT};
 
 pub(super) const COPILOT_DIRECT_NATIVE_JSONL_PARSER_REVISION: &str =
-    "copilot-cli-direct-native-jsonl-v8-optional-activity-admission";
+    "copilot-cli-direct-native-jsonl-v9-record-admission-order";
 
 const COPILOT_EVENT_TYPE_MAX_BYTES: usize = 64;
 const COPILOT_CALL_ID_MAX_BYTES: usize = 64 * 1024;
 const COPILOT_ACTIVITY_COMPONENT_MAX_BYTES: usize = 64 * 1024;
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v6-optional-activity-admission";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v7-record-admission-order";
 
 pub const fn copilot_source_backed_adapter<R: NativeJsonlRuntime>(
 ) -> super::DirectJsonlFamilyAdapter<R> {

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/factory_ai_droid.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/factory_ai_droid.rs
@@ -13,7 +13,7 @@ use super::super::result_content::{
     extract_direct_result_content, NativeJsonlResultExtractionError, NativeJsonlResultSubrecord,
 };
 
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v6-optional-activity-admission";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v7-record-admission-order";
 
 pub const fn factory_droid_source_backed_adapter<R: NativeJsonlRuntime>(
 ) -> super::DirectJsonlFamilyAdapter<R> {

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/factory_ai_droid_records.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/factory_ai_droid_records.rs
@@ -56,6 +56,13 @@ pub(crate) fn factory_droid_session_relationships(
     } else {
         Some(AgentScope::Primary)
     };
+    // A malformed optional parent must not invalidate the child's own records.
+    let parent = parent.filter(|parent| {
+        parent != native_session_id
+            && ctx_history_core::TypedKey::utf8(parent.as_str())
+                .and_then(|key| key.validate_contract())
+                .is_ok()
+    });
     let relationship = parent
         .as_ref()
         .map(|_| ProviderNativeSessionRelationship::Delegated);

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/grok_build.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/grok_build.rs
@@ -9,7 +9,7 @@ use crate::NativeJsonlRuntime;
 
 pub const GROK_BUILD_SOURCE_FORMAT: &str = "grok_build_session_updates_jsonl";
 
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v8-grok-closed-content-admission";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v9-record-admission-order";
 
 pub const fn grok_build_source_backed_adapter<R: NativeJsonlRuntime>(
 ) -> super::DirectJsonlFamilyAdapter<R> {

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/qoder.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/qoder.rs
@@ -2,7 +2,7 @@ use ctx_history_core::CaptureProvider;
 
 use crate::{NativeJsonlRuntime, QODER_SOURCE_FORMAT};
 
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v6-optional-activity-admission";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v7-record-admission-order";
 
 pub const fn qoder_source_backed_adapter<R: NativeJsonlRuntime>(
 ) -> super::DirectJsonlFamilyAdapter<R> {

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/qwen_code.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/qwen_code.rs
@@ -11,7 +11,7 @@ use super::super::result_content::{
     extract_direct_result_content, NativeJsonlResultExtractionError, NativeJsonlResultSubrecord,
 };
 
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v6-optional-activity-admission";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v7-record-admission-order";
 
 pub const fn qwen_code_source_backed_adapter<R: NativeJsonlRuntime>(
 ) -> super::DirectJsonlFamilyAdapter<R> {

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/reader_projection.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/reader_projection.rs
@@ -245,10 +245,11 @@ impl DirectJsonlProjector {
                 .content
                 .as_deref()
                 .filter(|content| !content.trim().is_empty());
-            let retain_contentless_completion = matches!(
-                self.provider,
-                CaptureProvider::CopilotCli | CaptureProvider::GrokBuild
-            ) && subrecord.call_id.is_some();
+            // Qoder's None also represents unknown result shapes with no selected
+            // content. Preserve that abstention until its parser distinguishes them.
+            let retain_contentless_completion = content.is_none()
+                && (self.provider != CaptureProvider::Qoder || subrecord.content.is_some())
+                && admit_optional_provider_call_id(subrecord.call_id.map(str::to_owned)).is_some();
             let contentless_grok_completion =
                 self.provider == CaptureProvider::GrokBuild && content.is_none();
             if content.is_none() && !retain_contentless_completion {
@@ -304,7 +305,11 @@ fn native_result_activity(
     else {
         return Ok(None);
     };
-    let text = if subrecord.content.is_some() {
+    let text = if subrecord
+        .content
+        .as_deref()
+        .is_some_and(|text| !text.trim().is_empty())
+    {
         ActivityTextCapture::NormalizedBody
     } else {
         ActivityTextCapture::Absent
@@ -481,11 +486,6 @@ fn direct_event(
     {
         lexical_text = event_type.as_str().to_owned();
     }
-    if result.is_some() && lexical_text.trim().is_empty() {
-        return Err(CaptureError::InvalidPayload(
-            "direct JSONL result record has no meaningful selected content".to_owned(),
-        ));
-    }
     let positional_event_index = direct_jsonl_event_sequence(raw_ordinal, sub_ordinal)?;
     let native_record_id = direct_jsonl_native_event_identity(provider, value);
     let stable_retry_discriminator = match provider {
@@ -553,15 +553,6 @@ fn direct_event(
 
 fn direct_jsonl_event_sequence(raw_ordinal: u64, sub_ordinal: u32) -> Result<u64> {
     const SUBRECORD_STRIDE: u64 = 65_536;
-    const SUBRECORD_SEQUENCE_BASE: u64 = 1_u64 << 62;
-
-    if sub_ordinal == 0 {
-        return i64::try_from(raw_ordinal)
-            .map(|_| raw_ordinal)
-            .map_err(|_| {
-                CaptureError::SystemInvariant("direct JSONL provider event sequence overflowed")
-            });
-    }
     let sub_ordinal = u64::from(sub_ordinal);
     if sub_ordinal >= SUBRECORD_STRIDE {
         return Err(CaptureError::SystemInvariant(
@@ -571,8 +562,7 @@ fn direct_jsonl_event_sequence(raw_ordinal: u64, sub_ordinal: u32) -> Result<u64
     raw_ordinal
         .checked_mul(SUBRECORD_STRIDE)
         .and_then(|index| index.checked_add(sub_ordinal))
-        .filter(|index| *index < SUBRECORD_SEQUENCE_BASE)
-        .map(|index| index | SUBRECORD_SEQUENCE_BASE)
+        .filter(|index| *index <= i64::MAX as u64)
         .ok_or(CaptureError::SystemInvariant(
             "direct JSONL provider event sequence overflowed",
         ))
@@ -701,10 +691,10 @@ mod event_sequence_tests {
         let second = direct_jsonl_event_sequence(2, 0).unwrap();
         let second_result = direct_jsonl_event_sequence(2, 1).unwrap();
 
-        assert!(first < second);
-        assert!(second < first_result);
+        assert!(first < first_result);
         assert!(first_result < last_first_result);
-        assert!(last_first_result < second_result);
+        assert!(last_first_result < second);
+        assert!(second < second_result);
         assert!(second_result <= i64::MAX as u64);
     }
 
@@ -712,6 +702,12 @@ mod event_sequence_tests {
     fn direct_jsonl_event_sequence_rejects_unrepresentable_coordinates() {
         assert!(direct_jsonl_event_sequence(1, u32::from(u16::MAX) + 1).is_err());
         assert!(direct_jsonl_event_sequence(i64::MAX as u64 + 1, 0).is_err());
-        assert!(direct_jsonl_event_sequence((1_u64 << 46) + 1, 1).is_err());
+        let maximum_ordinal = (i64::MAX as u64) / 65_536;
+        assert_eq!(
+            direct_jsonl_event_sequence(maximum_ordinal, u16::MAX.into()).unwrap(),
+            i64::MAX as u64
+        );
+        assert!(direct_jsonl_event_sequence(maximum_ordinal + 1, 0).is_err());
+        assert!(direct_jsonl_event_sequence(u64::MAX, 1).is_err());
     }
 }

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/source_backed.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/source_backed.rs
@@ -45,6 +45,10 @@ const DIRECT_JSONL_SOURCE_IDENTITY_VERSION: u32 = 1;
 const DIRECT_JSONL_MAX_DIRECTORY_DEPTH: usize = 128;
 const DIRECT_JSONL_EVENT_IDENTITY_REVISION: &str = "direct-jsonl-content-occurrence-v2";
 
+#[path = "source_backed_identity.rs"]
+mod identity;
+use identity::{native_event_key, validate_provider_event_key};
+
 #[derive(Debug, Error)]
 enum DirectJsonlAdapterError {
     #[error(transparent)]
@@ -711,6 +715,14 @@ impl<R: NativeJsonlRuntime> JsonlFamilyProjector for DirectJsonlFamilyProjector<
             return Err(capture_error(DirectJsonlAdapterError::CountMismatch));
         }
         let mut records = Vec::with_capacity(projected.events.len());
+        // Admit every subrecord's provider key before assigning fallback occurrences
+        // or accepting IDs from any part of this physical record.
+        for event in &projected.events {
+            if let Err(error) = validate_provider_event_key(event) {
+                self.reject_record(event.raw_ordinal, error.to_string())?;
+                return Ok(());
+            }
+        }
         for event in projected.events {
             records.push(
                 project_event(
@@ -820,16 +832,7 @@ fn project_event<R: NativeJsonlRuntime>(
         native_item_key: &native_item_key,
         subrecord_selector: subrecord_selector.as_ref(),
     })?;
-    let native_subrecord_key = match &event.stable_retry_discriminator {
-        Some(DirectJsonlRetryDiscriminator::FactoryDroidToolResult { tool_use_id }) => {
-            TypedKey::composite(vec![
-                TypedKey::utf8("factory-ai-droid.retry-tool-result")?,
-                TypedKey::utf8(tool_use_id)?,
-            ])?
-        }
-        None => TypedKey::U64(u64::from(event.sub_ordinal)),
-    };
-    let native_event_key = TypedKey::composite(vec![native_record_key, native_subrecord_key])?;
+    let native_event_key = native_event_key(&event, native_record_key)?;
     let parent_session_id = session
         .parent_provider_session_id
         .as_deref()

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/source_backed_identity.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/source_backed_identity.rs
@@ -1,0 +1,32 @@
+use super::{DirectJsonlEvent, DirectJsonlRetryDiscriminator, ProjectionContractError, TypedKey};
+
+// These constructors validate only provider-origin key material. Source binding,
+// fallback occurrence lookup, and storage errors remain at their fatal boundaries.
+pub(super) fn validate_provider_event_key(
+    event: &DirectJsonlEvent,
+) -> Result<(), ProjectionContractError> {
+    let key = TypedKey::utf8(
+        event
+            .native_record_id
+            .as_deref()
+            .unwrap_or(&event.provider_event_hash),
+    )?;
+    native_event_key(event, key)?;
+    Ok(())
+}
+
+pub(super) fn native_event_key(
+    event: &DirectJsonlEvent,
+    native_record_key: TypedKey,
+) -> Result<TypedKey, ProjectionContractError> {
+    let native_subrecord_key = match &event.stable_retry_discriminator {
+        Some(DirectJsonlRetryDiscriminator::FactoryDroidToolResult { tool_use_id }) => {
+            TypedKey::composite(vec![
+                TypedKey::utf8("factory-ai-droid.retry-tool-result")?,
+                TypedKey::utf8(tool_use_id)?,
+            ])?
+        }
+        None => TypedKey::U64(u64::from(event.sub_ordinal)),
+    };
+    TypedKey::composite(vec![native_record_key, native_subrecord_key])
+}

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/source_backed_result_tests.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/source_backed_result_tests.rs
@@ -129,7 +129,7 @@ fn native_subrecord_index(record: &CoreRecord) -> u64 {
     *index
 }
 
-fn project_all(provider: CaptureProvider, values: &[Value]) -> (Vec<CoreRecord>, u64) {
+fn test_projector(provider: CaptureProvider) -> DirectJsonlFamilyProjector<NativeJsonlTestRuntime> {
     let adapter = adapter(provider);
     let session = session(provider);
     let source_path = "direct-jsonl-identity-contract.jsonl";
@@ -145,7 +145,7 @@ fn project_all(provider: CaptureProvider, values: &[Value]) -> (Vec<CoreRecord>,
         Some(session.clone()),
     )
     .unwrap();
-    let mut projector = DirectJsonlFamilyProjector {
+    DirectJsonlFamilyProjector {
         adapter,
         fallback_identities: fallback_identities(adapter, &source, session_id),
         source,
@@ -157,7 +157,11 @@ fn project_all(provider: CaptureProvider, values: &[Value]) -> (Vec<CoreRecord>,
         accepted_event_ids: HashSet::new(),
         append_base_event_lookup: None,
         source_selector: source_path.to_owned(),
-    };
+    }
+}
+
+fn project_all(provider: CaptureProvider, values: &[Value]) -> (Vec<CoreRecord>, u64) {
+    let mut projector = test_projector(provider);
     let mut records = Vec::new();
     let mut worker = JsonlFamilyWorkerContext::default();
     for (ordinal, value) in values.iter().enumerate() {
@@ -186,6 +190,123 @@ fn event_ids_by_body(records: &[CoreRecord]) -> BTreeMap<String, String> {
             )
         })
         .collect()
+}
+
+#[test]
+fn provider_event_key_bounds_reject_only_the_bad_physical_record() {
+    let message = |id: &str, body: &str| json!({"type": "message", "id": id, "role": "assistant", "content": body});
+    // Composite tag/count (5), UTF-8 tag/length (9), and ordinal tag/value (9).
+    let maximum_native_id = 65_536 - 23;
+    for bytes in [maximum_native_id + 1, 65_536, 65_537] {
+        let (records, rejected) = project_all(
+            CaptureProvider::FactoryAiDroid,
+            &[
+                message("before", "before"),
+                message(&"x".repeat(bytes), "bad"),
+                message("after", "after"),
+            ],
+        );
+        assert_eq!(rejected, 1);
+        assert_eq!(
+            records
+                .iter()
+                .map(|record| record.content.normalized_body.as_deref().unwrap())
+                .collect::<Vec<_>>(),
+            ["before", "after"]
+        );
+    }
+    let (records, rejected) = project_all(
+        CaptureProvider::FactoryAiDroid,
+        &[message(&"x".repeat(maximum_native_id), "boundary")],
+    );
+    assert_eq!(rejected, 0);
+    assert_eq!(records.len(), 1);
+}
+
+#[test]
+fn bad_keys_do_not_accept_ids_and_sink_failures_remain_fatal() {
+    let mut projector = test_projector(CaptureProvider::FactoryAiDroid);
+    let mut worker = JsonlFamilyWorkerContext::default();
+    let bad =
+        serde_json::to_vec(&json!({"type": "message", "id": "x".repeat(65_537), "content": "bad"}))
+            .unwrap();
+    JsonlFamilyProjector::project(
+        &mut projector,
+        JsonlRecordRef::for_test(&bad, 0),
+        &mut worker,
+        &mut |_| panic!("invalid key reached sink"),
+    )
+    .unwrap();
+    assert_eq!(projector.rejected_records(), 1);
+    assert!(projector.accepted_event_ids.is_empty());
+
+    let multi = serde_json::to_vec(&json!({
+        "type": "message", "id": "shared", "parentId": "shared", "role": "user",
+        "content": [
+            {"type": "tool_result", "tool_use_id": "good", "content": "first"},
+            {"type": "tool_result", "tool_use_id": "x".repeat(65_537), "content": "second"}
+        ]
+    }))
+    .unwrap();
+    JsonlFamilyProjector::project(
+        &mut projector,
+        JsonlRecordRef::for_test(&multi, 1),
+        &mut worker,
+        &mut |_| panic!("partially valid record reached sink"),
+    )
+    .unwrap();
+    assert_eq!(projector.rejected_records(), 2);
+    assert!(projector.accepted_event_ids.is_empty());
+
+    let mut projector = test_projector(CaptureProvider::FactoryAiDroid);
+    let valid =
+        serde_json::to_vec(&json!({"type": "message", "id": "valid", "content": "valid"})).unwrap();
+    let result = JsonlFamilyProjector::project(
+        &mut projector,
+        JsonlRecordRef::for_test(&valid, 0),
+        &mut worker,
+        &mut |_| Err(CaptureError::SystemInvariant("injected sink failure")),
+    );
+    assert!(matches!(
+        result,
+        Err(CaptureError::SystemInvariant("injected sink failure"))
+    ));
+    assert_eq!(projector.rejected_records(), 0);
+}
+
+#[test]
+fn recognized_empty_droid_completions_preserve_literal_evidence_without_a_body() {
+    use ctx_history_core::ActivityTextCapture;
+    for content in [json!(""), json!(" \n\t"), json!(null)] {
+        let value = json!({"type": "message", "id": "result", "role": "user", "content": [{"type": "tool_result", "tool_use_id": "call", "content": content, "is_error": false}]});
+        let (records, rejected) = project(CaptureProvider::FactoryAiDroid, &value);
+        assert_eq!(rejected, 0);
+        assert_eq!(records.len(), 1);
+        let record = &records[0];
+        assert_eq!(record.content.normalized_body, None);
+        assert_eq!(record.content.structured_content.as_ref(), Some(&value));
+        let activity = record.content.activity.as_ref().unwrap();
+        assert_eq!(
+            activity.provider_call_id,
+            Some(TypedKey::utf8("call").unwrap())
+        );
+        assert_eq!(
+            activity.result.as_ref().unwrap().text,
+            ActivityTextCapture::Absent
+        );
+        assert_eq!(activity.result.as_ref().unwrap().status, None);
+    }
+    for result in [
+        json!({"type": "tool_result", "content": ""}),
+        json!({"type": "tool_result", "tool_use_id": "call", "content": "", "redacted": true}),
+    ] {
+        let (records, rejected) = project(
+            CaptureProvider::FactoryAiDroid,
+            &json!({"type": "message", "id": "result", "role": "user", "content": [result]}),
+        );
+        assert_eq!(rejected, 0);
+        assert!(records.is_empty());
+    }
 }
 
 #[test]
@@ -283,7 +404,7 @@ fn direct_provider_revision_matrix_matches_the_neutral_projection_and_identity_i
     let parser_cases = [
         (
             CaptureProvider::Antigravity,
-            "direct-native-jsonl-parser-v6-optional-activity-admission",
+            "direct-native-jsonl-parser-v7-record-admission-order",
         ),
         (
             CaptureProvider::CopilotCli,
@@ -291,23 +412,23 @@ fn direct_provider_revision_matrix_matches_the_neutral_projection_and_identity_i
         ),
         (
             CaptureProvider::FactoryAiDroid,
-            "direct-native-jsonl-parser-v6-optional-activity-admission",
+            "direct-native-jsonl-parser-v7-record-admission-order",
         ),
         (
             CaptureProvider::GrokBuild,
-            "direct-native-jsonl-parser-v8-grok-closed-content-admission",
+            "direct-native-jsonl-parser-v9-record-admission-order",
         ),
         (
             CaptureProvider::Qoder,
-            "direct-native-jsonl-parser-v6-optional-activity-admission",
+            "direct-native-jsonl-parser-v7-record-admission-order",
         ),
         (
             CaptureProvider::QwenCode,
-            "direct-native-jsonl-parser-v6-optional-activity-admission",
+            "direct-native-jsonl-parser-v7-record-admission-order",
         ),
         (
             CaptureProvider::Tabnine,
-            "direct-native-jsonl-parser-v6-optional-activity-admission",
+            "direct-native-jsonl-parser-v7-record-admission-order",
         ),
     ];
     for (provider, parser_revision) in parser_cases {
@@ -447,7 +568,7 @@ fn copilot_replay_preserves_current_revision_ids_and_records() {
         "c1ebd99c-7338-859b-891d-1c7e04d9ae9d",
         "5ff93a01-4aa3-82f8-8d9e-784490016567",
         "8d4627ce-c12c-8d64-af2d-d85ac722121f",
-        "242c534cc04212dd8babe58be9810c1c91b3bced3be22056c3bc1ff66e3e9739",
+        "f6a71b5c32b37c914988ac58609a52a5d16e291dd048c9e3145147039b3273bf",
     )];
 
     for (provider, value, event_id, session_id, source_id, record_leaf) in cases {
@@ -456,10 +577,8 @@ fn copilot_replay_preserves_current_revision_ids_and_records() {
             CaptureProvider::CopilotCli => {
                 super::copilot::COPILOT_DIRECT_NATIVE_JSONL_PARSER_REVISION
             }
-            CaptureProvider::GrokBuild => {
-                "direct-native-jsonl-parser-v8-grok-closed-content-admission"
-            }
-            _ => "direct-native-jsonl-parser-v6-optional-activity-admission",
+            CaptureProvider::GrokBuild => "direct-native-jsonl-parser-v9-record-admission-order",
+            _ => "direct-native-jsonl-parser-v7-record-admission-order",
         };
         assert_eq!(
             JsonlFamilyAdapter::parser_revision(&adapter),
@@ -485,6 +604,15 @@ fn copilot_replay_preserves_current_revision_ids_and_records() {
             core_record_leaf_sha256(record).unwrap(),
             record_leaf,
             "{provider:?}"
+        );
+        // The pinned IDs above do not rotate. Only the recorded parser revision
+        // changes this ordinal-zero record's released leaf digest.
+        let mut released = record.clone();
+        released.parser_revision =
+            "copilot-cli-direct-native-jsonl-v8-optional-activity-admission".to_owned();
+        assert_eq!(
+            core_record_leaf_sha256(&released).unwrap(),
+            "242c534cc04212dd8babe58be9810c1c91b3bced3be22056c3bc1ff66e3e9739"
         );
     }
 }
@@ -868,6 +996,39 @@ fn supported_family_members_retain_complete_result_bodies_in_core() {
             None,
             "{provider:?}"
         );
+        if provider != CaptureProvider::CopilotCli {
+            let content_path = if provider == CaptureProvider::Tabnine {
+                "/toolCalls/0/result/content"
+            } else {
+                "/message/content/0/content"
+            };
+            for empty in [json!(""), json!(" \n\t"), json!(null)] {
+                let qoder_unresolved_null = provider == CaptureProvider::Qoder && empty.is_null();
+                let mut empty_result = value.clone();
+                *empty_result.pointer_mut(content_path).unwrap() = empty;
+                let (records, rejected) = project(provider, &empty_result);
+                assert_eq!(rejected, 0, "{provider:?}");
+                if qoder_unresolved_null {
+                    assert!(records.is_empty());
+                    continue;
+                }
+                assert_eq!(records.len(), 1, "{provider:?}");
+                assert_eq!(records[0].content.normalized_body, None, "{provider:?}");
+                assert_eq!(
+                    records[0].content.structured_content.as_ref(),
+                    Some(&empty_result)
+                );
+                assert_eq!(
+                    records[0]
+                        .content
+                        .activity
+                        .as_ref()
+                        .unwrap()
+                        .provider_call_id,
+                    Some(TypedKey::utf8(expected_call_id).unwrap())
+                );
+            }
+        }
     }
 }
 

--- a/crates/ctx-history-provider-native-jsonl/src/native_path/tabnine.rs
+++ b/crates/ctx-history-provider-native-jsonl/src/native_path/tabnine.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 
 use crate::{NativeJsonlRuntime, TABNINE_CLI_SOURCE_FORMAT};
 
-const PARSER_REVISION: &str = "direct-native-jsonl-parser-v6-optional-activity-admission";
+const PARSER_REVISION: &str = "direct-native-jsonl-parser-v7-record-admission-order";
 
 pub const fn tabnine_source_backed_adapter<R: NativeJsonlRuntime>(
 ) -> super::DirectJsonlFamilyAdapter<R> {


### PR DESCRIPTION
Direct JSONL session order follows physical records and result-block order while event identities remain stable. Oversized native event keys reject their physical record without stopping valid neighboring history. Supported linked results retain literal evidence when output is empty, with Qoder null-only and unknown-content shapes still deferred. Invalid self or overbound selected Droid parent claims are omitted without discarding child history; broader alias and scope semantics are unchanged. Parser revisions rebuild affected sources. Focused tests cover ordering, key bounds, fatal sink errors, importer/show behavior, and repeat/append/replacement identity.