### PR TITLE
Use positive filters to skip unrelated lexical postings

### DIFF
--- a/crates/ctx-history-index-query/src/contract/lexical.rs
+++ b/crates/ctx-history-index-query/src/contract/lexical.rs
@@ -118,6 +118,7 @@ pub const MAX_LEXICAL_QUERY_RESULTS: usize = 4_096;
 pub struct LexicalWorkBudget {
     pub maximum_segments: u64,
     pub maximum_candidate_docs: u64,
+    /// Body cursor movements, including positive-filter seeks and advances.
     pub maximum_body_posting_advances: u64,
     pub maximum_exact_filter_terms: u64,
     pub maximum_filter_input_bytes: u64,
@@ -166,6 +167,7 @@ pub const LEXICAL_WORK_BUDGET_V1: LexicalWorkBudget = LexicalWorkBudget {
 pub struct LexicalWorkCounters {
     pub segments: u64,
     pub candidate_docs: u64,
+    /// Body cursor movements, including positive-filter seeks and advances.
     pub body_posting_advances: u64,
     pub analyzed_tokens: u64,
     pub exact_filter_terms: u64,

--- a/crates/ctx-history-index-query/src/execution/search.rs
+++ b/crates/ctx-history-index-query/src/execution/search.rs
@@ -117,20 +117,32 @@ impl SegmentFilters {
             || self.file.as_ref().is_some_and(|bitmap| !bitmap.any)
     }
 
-    fn accepts(
+    /// Returns `doc` when every required group admits it, or a proven
+    /// lower bound from the first rejecting group. `TERMINATED` means no
+    /// later match is possible; `None` means posting work exhausted.
+    fn next_required_doc(
+        &mut self,
+        doc: DocId,
+        meter: &mut LexicalWorkMeter,
+        segment: &LexicalSegmentContext,
+    ) -> Option<DocId> {
+        for group in &mut self.required {
+            let next = posting_group_next(group, doc, meter, segment)?;
+            if next != doc {
+                return Some(next);
+            }
+        }
+        Some(doc)
+    }
+
+    /// Required groups have already admitted this candidate. Negative groups
+    /// and substring probes cannot supply a forward traversal bound.
+    fn accepts_remaining(
         &mut self,
         doc: DocId,
         meter: &mut LexicalWorkMeter,
         segment: &LexicalSegmentContext,
     ) -> Result<Option<bool>> {
-        for group in &mut self.required {
-            let Some(matches) = posting_group_contains(group, doc, meter, segment) else {
-                return Ok(None);
-            };
-            if !matches {
-                return Ok(Some(false));
-            }
-        }
         for group in &mut self.prohibited {
             let Some(matches) = posting_group_contains(group, doc, meter, segment) else {
                 return Ok(None);
@@ -735,12 +747,23 @@ fn posting_group_contains(
     meter: &mut LexicalWorkMeter,
     segment: &LexicalSegmentContext,
 ) -> Option<bool> {
+    Some(posting_group_next(postings, doc, meter, segment)? == doc)
+}
+
+fn posting_group_next(
+    postings: &mut [SegmentPostings],
+    doc: DocId,
+    meter: &mut LexicalWorkMeter,
+    segment: &LexicalSegmentContext,
+) -> Option<DocId> {
+    let mut next = TERMINATED;
     for postings in postings {
         if posting_contains(postings, doc, meter, segment)? {
-            return Some(true);
+            return Some(doc);
         }
+        next = next.min(postings.doc());
     }
-    Some(false)
+    Some(next)
 }
 
 fn posting_contains(

--- a/crates/ctx-history-index-query/src/execution/search/executor.rs
+++ b/crates/ctx-history-index-query/src/execution/search/executor.rs
@@ -114,7 +114,8 @@ impl VerifiedIndex {
     /// filter.
     ///
     /// Segments are visited by ascending immutable Tantivy segment ID. Within
-    /// each segment, body postings are merged by ascending document ID, so an
+    /// each segment, body postings intersect required positive groups in
+    /// ascending document ID. Skipped intervals provably cannot match; an
     /// incomplete result describes one deterministic fully examined prefix.
     pub fn execute_lexical(
         &self,
@@ -210,6 +211,38 @@ impl VerifiedIndex {
             match mode {
                 LexicalMode::Search(_) => {
                     while let Some(doc) = next_body_doc(&prepared.body_postings) {
+                        let deleted = reader.is_deleted(doc);
+                        if !deleted {
+                            let Some(next) = prepared.filters.next_required_doc(
+                                doc,
+                                &mut meter,
+                                &prepared.context,
+                            ) else {
+                                break 'segments;
+                            };
+                            if next == TERMINATED {
+                                break;
+                            }
+                            if next != doc {
+                                // Only a required positive group proves this
+                                // interval cannot match. Charge every body seek
+                                // just like an advance, before moving its cursor.
+                                for postings in prepared.body_postings.iter_mut().flatten() {
+                                    if postings.doc() < next {
+                                        if !meter.charge(
+                                            LexicalWorkCounter::BodyPostingAdvances,
+                                            1,
+                                            Some(&prepared.context),
+                                            Some(next),
+                                        ) {
+                                            break 'segments;
+                                        }
+                                        postings.seek(next);
+                                    }
+                                }
+                                continue;
+                            }
+                        }
                         if !meter.charge(
                             LexicalWorkCounter::CandidateDocs,
                             1,
@@ -230,7 +263,7 @@ impl VerifiedIndex {
                                     .term_freq();
                             }
                         }
-                        if !reader.is_deleted(doc) {
+                        if !deleted {
                             let outcome = self.examine_manual_candidate(
                                 &mut prepared,
                                 doc,
@@ -279,6 +312,16 @@ impl VerifiedIndex {
                             break 'segments;
                         }
                         if reader.is_deleted(doc) {
+                            continue;
+                        }
+                        let Some(next) =
+                            prepared
+                                .filters
+                                .next_required_doc(doc, &mut meter, &prepared.context)
+                        else {
+                            break 'segments;
+                        };
+                        if next != doc {
                             continue;
                         }
                         let outcome = self.examine_manual_candidate(
@@ -496,7 +539,9 @@ impl VerifiedIndex {
         meter: &mut LexicalWorkMeter,
     ) -> Result<CandidateExamination> {
         let Some(matches_exact_filters) =
-            prepared.filters.accepts(doc, meter, &prepared.context)?
+            prepared
+                .filters
+                .accepts_remaining(doc, meter, &prepared.context)?
         else {
             return Ok(CandidateExamination::Exhausted);
         };

--- a/crates/ctx-history-index-query/tests/writer_integration/query/lexical.rs
+++ b/crates/ctx-history-index-query/tests/writer_integration/query/lexical.rs
@@ -3,6 +3,9 @@ use super::*;
 #[path = "lexical_segment_boundaries.rs"]
 mod segment_boundaries;
 
+#[path = "lexical_selective.rs"]
+mod selective;
+
 fn publish_records(temp: &TempDir, source: &SourceKey, records: Vec<CoreRecord>) -> VerifiedIndex {
     let document_count = u64::try_from(records.len()).unwrap();
     let mut writer = GenerationWriter::open(temp.path(), WriterOptions::default())
@@ -32,6 +35,7 @@ fn publish_records_in_one_segment(
     drop(searcher);
     let directory = DurableMmapDirectory::open(active_generation_path(temp.path())).unwrap();
     let tantivy_index = Index::open(directory).unwrap();
+    let mut sessions = HashSet::new();
     publish_unchecked_generation(
         temp.path(),
         &tantivy_index,
@@ -39,15 +43,15 @@ fn publish_records_in_one_segment(
         std::slice::from_ref(source),
         records
             .into_iter()
-            .enumerate()
-            .map(|(index, record)| {
+            .map(|record| {
+                let first_in_session = sessions.insert(record.session_id);
                 let authority = ctx_history_index_format::SessionAuthorityKey::exact(
                     record.session_id,
                     record.source.identity(),
                 )
                 .unwrap();
                 let mut document = indexed_document(record);
-                if index == 0 {
+                if first_in_session {
                     let fields = fields_from_schema(&lexical_schema()).unwrap();
                     document.add_bytes(fields.session_authority, authority.as_bytes());
                 }
@@ -1004,7 +1008,11 @@ fn manual_executor_charges_each_material_budget_before_work() {
     budget.maximum_candidate_docs = 0;
     let batch = run(budget);
     assert_exhausted_at(&batch, LexicalWorkCounter::CandidateDocs, 0, 0);
-    assert_eq!(batch.counters.filter_probes, 0);
+    assert!(
+        batch.counters.filter_probes > 0,
+        "positive intersection is separately metered"
+    );
+    assert_eq!(batch.counters.retained_candidates, 0);
 
     let mut budget = ctx_history_index_query::LEXICAL_WORK_BUDGET_V1;
     budget.maximum_filter_probes = 0;

--- a/crates/ctx-history-index-query/tests/writer_integration/query/lexical_selective.rs
+++ b/crates/ctx-history-index-query/tests/writer_integration/query/lexical_selective.rs
@@ -1,0 +1,398 @@
+use super::*;
+
+#[test]
+fn selective_session_seeks_past_unrelated_body_matches_with_a_small_candidate_budget() {
+    let temp = tempdir().unwrap();
+    let source = source("selective-session.jsonl");
+    let mut records = (1..=16)
+        .map(|sequence| document_for_session(&source, "unrelated", sequence, "scopeneedle"))
+        .collect::<Vec<_>>();
+    let selected = document_for_session(&source, "selected", 17, "scopeneedle");
+    let expected = selected.event_id.as_uuid();
+    let filters = EventSearchFilters {
+        session_id: Some(selected.session_id.as_uuid()),
+        ..EventSearchFilters::default()
+    };
+    records.push(selected);
+    let index = publish_records_in_one_segment(&temp, &source, records);
+    let (searcher, _) = open_unverified_generation(temp.path());
+    assert_eq!(searcher.segment_readers().len(), 1);
+    assert_eq!(searcher.segment_readers()[0].max_doc(), 17);
+    assert_eq!(
+        decoded_stored_core(&searcher, tantivy::DocAddress::new(0, 16))
+            .event_id
+            .as_uuid(),
+        expected,
+        "the only scoped match must follow the unrelated body matches"
+    );
+
+    let broad =
+        lexical_search_batch(&index, &["scopeneedle"], &EventSearchFilters::default(), 20).unwrap();
+    assert!(broad.complete && broad.candidate_set_exhaustive);
+    assert_eq!(broad.candidates.len(), 17);
+    assert_eq!(broad.counters.candidate_docs, 17);
+    assert_eq!(broad.counters.body_posting_advances, 17);
+    let full = lexical_search_batch(&index, &["scopeneedle"], &filters, 20).unwrap();
+    assert!(full.complete && full.candidate_set_exhaustive);
+    assert_eq!(full.candidates.len(), 1);
+    assert_eq!(full.candidates[0].event.event_id, expected);
+
+    let budget = ctx_history_index_query::LexicalWorkBudget {
+        maximum_candidate_docs: 2,
+        ..ctx_history_index_query::LEXICAL_WORK_BUDGET_V1
+    };
+    let small =
+        lexical_search_batch_with_budget(&index, &["scopeneedle"], &filters, 20, budget).unwrap();
+    eprintln!(
+        "broad={:?}; selective full={:?}; small={:?}; exhaustion={:?}",
+        broad.counters, full.counters, small.counters, small.exhaustion
+    );
+    assert!(small.complete, "{:?}", small.exhaustion);
+    assert!(small.candidate_set_exhaustive);
+    assert_eq!(small.candidates.len(), 1);
+    assert_eq!(small.candidates[0].event.event_id, expected);
+    assert_eq!(small.candidates, full.candidates);
+    assert_eq!(small.counters.candidate_docs, 1);
+    assert_eq!(small.counters.body_posting_advances, 2);
+}
+
+#[test]
+fn selective_positive_or_groups_preserve_exclusions_substrings_and_ranking() {
+    let temp = tempdir().unwrap();
+    let source = source("selective-or-groups.jsonl");
+    // Independently authored membership: 1, 2, 3, 9 and 10 satisfy every
+    // predicate. Each other row violates the indicated predicate.
+    let rows = [
+        ("tool_call", "alpha", "user"), // class
+        ("summary", "beta", "user"),
+        ("message", "alpha beta", "user"),
+        ("summary", "beta", "user"),
+        ("message", "alpha", "user"),   // excluded session
+        ("summary", "beta", "user"),    // workspace
+        ("message", "alpha", "user"),   // file
+        ("summary", "beta", "user"),    // timestamp
+        ("message", "neither", "user"), // body
+        ("message", "alpha beta", "user"),
+        ("summary", "beta", "user"),
+        ("tool_output", "alpha beta", "user"), // class
+        ("summary", "beta", "assistant"),      // role
+    ];
+    let records = rows
+        .iter()
+        .enumerate()
+        .map(|(index, (event_type, body, role))| {
+            let mut record =
+                document_for_session(&source, &format!("session-{index}"), index as u64 + 1, body);
+            record.event_type = (*event_type).to_owned();
+            record.role = Some((*role).to_owned());
+            record.occurred_at_unix_ms = Some(if index == 7 { 1 } else { 100 });
+            add_literal_fact(
+                &mut record,
+                LiteralFactKind::Workspace,
+                if index == 5 {
+                    "/other"
+                } else {
+                    "/Work/Selected"
+                },
+            );
+            add_literal_fact(
+                &mut record,
+                LiteralFactKind::File,
+                if index == 6 {
+                    "other.rs"
+                } else {
+                    "src/Selected.rs"
+                },
+            );
+            record.validate_contract().unwrap();
+            record
+        })
+        .collect::<Vec<_>>();
+    let expected = [1, 2, 3, 9, 10].map(|index| records[index].event_id.as_uuid());
+    let filter = EventSearchFilters {
+        allowed_source_keys: Some(vec![source_token(&source), "absent-source".to_owned()]),
+        provider: Some("codex".to_owned()),
+        content_scope: SearchContentScope::Transcript,
+        role: Some("user".to_owned()),
+        excluded_session_ids: vec![records[4].session_id.as_uuid()],
+        workspace: Some("SELECTED".to_owned()),
+        file: Some("selected.RS".to_owned()),
+        since_unix_ms: Some(50),
+        ..EventSearchFilters::default()
+    };
+    let index = publish_records_in_one_segment(&temp, &source, records);
+    let broad = lexical_search_batch(
+        &index,
+        &["alpha", "beta"],
+        &EventSearchFilters::default(),
+        20,
+    )
+    .unwrap();
+    let filtered = lexical_search_batch(&index, &["alpha", "beta"], &filter, 20).unwrap();
+    assert!(broad.complete && broad.candidate_set_exhaustive);
+    assert!(filtered.complete && filtered.candidate_set_exhaustive);
+    assert_eq!(
+        filtered
+            .candidates
+            .iter()
+            .map(|candidate| candidate.event.event_id)
+            .collect::<HashSet<_>>(),
+        HashSet::from(expected)
+    );
+    // Broad retrieval supplies only score/order parity, never membership.
+    let expected_ranked = broad
+        .candidates
+        .into_iter()
+        .filter(|candidate| expected.contains(&candidate.event.event_id))
+        .collect::<Vec<_>>();
+    assert_eq!(filtered.candidates, expected_ranked);
+    assert!(filtered.candidates[..2]
+        .iter()
+        .all(|candidate| candidate.coverage.matched_terms == 2));
+}
+
+#[test]
+fn selective_traversal_precharges_posting_work_and_preserves_negative_candidate_bounds() {
+    use ctx_history_index_query::{LexicalWorkBudget, LexicalWorkCounter, LEXICAL_WORK_BUDGET_V1};
+
+    let temp = tempdir().unwrap();
+    let source = source("selective-work-bounds.jsonl");
+    let mut records = (1..=16)
+        .map(|sequence| document_for_session(&source, "unrelated", sequence, "scopeneedle"))
+        .collect::<Vec<_>>();
+    let unrelated_session = records[0].session_id.as_uuid();
+    let mut selected = document_for_session(&source, "selected", 17, "scopeneedle");
+    let expected = selected.event_id.as_uuid();
+    let selected_session = selected.session_id.as_uuid();
+    add_literal_fact(&mut selected, LiteralFactKind::Workspace, "/selected");
+    records.push(selected);
+    let index = publish_records_in_one_segment(&temp, &source, records);
+    let positive = EventSearchFilters {
+        session_id: Some(selected_session),
+        ..EventSearchFilters::default()
+    };
+    let run = |filters: &EventSearchFilters, budget| {
+        lexical_search_batch_with_budget(&index, &["scopeneedle"], filters, 20, budget).unwrap()
+    };
+    for (budget, counter) in [
+        (
+            LexicalWorkBudget {
+                maximum_body_posting_advances: 0,
+                ..LEXICAL_WORK_BUDGET_V1
+            },
+            LexicalWorkCounter::BodyPostingAdvances,
+        ),
+        (
+            LexicalWorkBudget {
+                maximum_filter_probes: 0,
+                ..LEXICAL_WORK_BUDGET_V1
+            },
+            LexicalWorkCounter::FilterProbes,
+        ),
+        (
+            LexicalWorkBudget {
+                maximum_filter_seeks: 0,
+                ..LEXICAL_WORK_BUDGET_V1
+            },
+            LexicalWorkCounter::FilterSeeks,
+        ),
+        (
+            LexicalWorkBudget {
+                maximum_candidate_docs: 0,
+                ..LEXICAL_WORK_BUDGET_V1
+            },
+            LexicalWorkCounter::CandidateDocs,
+        ),
+    ] {
+        let batch = run(&positive, budget);
+        assert_exhausted_at(&batch, counter, 0, 0);
+        assert_eq!(batch.counters.candidate_docs, 0);
+        assert_eq!(batch.counters.retained_candidates, 0);
+        assert!(batch.candidates.is_empty());
+        assert_eq!(
+            batch,
+            run(&positive, budget),
+            "first blocked operation is deterministic"
+        );
+    }
+    let one_movement = run(
+        &positive,
+        LexicalWorkBudget {
+            maximum_body_posting_advances: 1,
+            ..LEXICAL_WORK_BUDGET_V1
+        },
+    );
+    assert_exhausted_at(&one_movement, LexicalWorkCounter::BodyPostingAdvances, 1, 1);
+    assert_eq!(one_movement.counters.candidate_docs, 1);
+    assert_eq!(one_movement.candidates.len(), 1);
+    assert_eq!(one_movement.candidates[0].event.event_id, expected);
+
+    let small = LexicalWorkBudget {
+        maximum_candidate_docs: 2,
+        ..LEXICAL_WORK_BUDGET_V1
+    };
+    for filters in [
+        EventSearchFilters {
+            excluded_session_ids: vec![unrelated_session],
+            ..EventSearchFilters::default()
+        },
+        EventSearchFilters {
+            workspace: Some("selected".to_owned()),
+            ..EventSearchFilters::default()
+        },
+    ] {
+        let batch = run(&filters, small);
+        assert_exhausted_at(&batch, LexicalWorkCounter::CandidateDocs, 2, 2);
+        assert!(
+            batch.candidates.is_empty(),
+            "arbitrary rejection cannot hide candidate work"
+        );
+    }
+    let excluded = run(
+        &EventSearchFilters {
+            excluded_session_ids: vec![selected_session],
+            ..positive
+        },
+        small,
+    );
+    assert!(excluded.complete && excluded.candidate_set_exhaustive);
+    assert_eq!(excluded.counters.candidate_docs, 1);
+    assert!(excluded.candidates.is_empty());
+}
+
+#[test]
+fn selective_or_and_bounds_converge_or_exhaust_before_candidate_admission() {
+    use ctx_history_index_query::{LexicalWorkCounter, LEXICAL_WORK_BUDGET_V1};
+
+    let temp = tempdir().unwrap();
+    let source = source("selective-convergence.jsonl");
+    // The class OR admits doc 0, but role advances to 1. Class then advances
+    // to 2, and role to 3, forcing the earlier OR group to be checked again.
+    let records = [
+        ("message", "assistant"),
+        ("tool_call", "user"),
+        ("summary", "assistant"),
+        ("message", "user"),
+        ("summary", "user"),
+    ]
+    .into_iter()
+    .enumerate()
+    .map(|(index, (event_type, role))| {
+        let mut record = document(&source, index as u64 + 1, "convergenceneedle");
+        record.event_type = event_type.to_owned();
+        record.role = Some(role.to_owned());
+        record
+    })
+    .collect::<Vec<_>>();
+    let expected = [records[3].event_id.as_uuid(), records[4].event_id.as_uuid()];
+    let index = publish_records_in_one_segment(&temp, &source, records);
+    let filters = EventSearchFilters {
+        content_scope: SearchContentScope::Transcript,
+        role: Some("user".to_owned()),
+        ..EventSearchFilters::default()
+    };
+    let run = |budget| {
+        lexical_search_batch_with_budget(&index, &["convergenceneedle"], &filters, 10, budget)
+            .unwrap()
+    };
+    let complete = run(LEXICAL_WORK_BUDGET_V1);
+    assert!(complete.complete && complete.candidate_set_exhaustive);
+    assert_eq!(
+        complete
+            .candidates
+            .iter()
+            .map(|candidate| candidate.event.event_id)
+            .collect::<HashSet<_>>(),
+        HashSet::from(expected)
+    );
+    assert_eq!(complete.counters.candidate_docs, 2);
+    assert_eq!(complete.counters.body_posting_advances, 5);
+
+    for (counter, limit) in [
+        (LexicalWorkCounter::FilterProbes, 6),
+        (LexicalWorkCounter::FilterSeeks, 1),
+    ] {
+        let mut budget = LEXICAL_WORK_BUDGET_V1;
+        match counter {
+            LexicalWorkCounter::FilterProbes => budget.maximum_filter_probes = limit,
+            LexicalWorkCounter::FilterSeeks => budget.maximum_filter_seeks = limit,
+            _ => unreachable!(),
+        }
+        let partial = run(budget);
+        assert_exhausted_at(&partial, counter, limit, limit);
+        assert!(partial.candidates.is_empty());
+        assert_eq!(partial.counters.candidate_docs, 0);
+        assert_eq!(partial.counters.retained_candidates, 0);
+        assert_eq!(partial.counters.body_posting_advances, 2);
+        assert_eq!(partial.counters.filter_seeks, 1);
+        let exhaustion = partial.exhaustion.as_ref().unwrap();
+        assert_eq!(exhaustion.next_doc, Some(2));
+        assert_eq!(exhaustion.segment.as_ref().unwrap().stable_segment_index, 0);
+    }
+}
+
+#[test]
+fn selective_disjoint_and_missing_positive_groups_finish_without_candidates() {
+    let temp = tempdir().unwrap();
+    let source = source("selective-empty-intersection.jsonl");
+    let records = [
+        ("message", "assistant"),
+        ("tool_call", "user"),
+        ("summary", "assistant"),
+        ("tool_call", "user"),
+    ]
+    .into_iter()
+    .enumerate()
+    .map(|(index, (event_type, role))| {
+        let mut record = document(&source, index as u64 + 1, "disjointneedle");
+        record.event_type = event_type.to_owned();
+        record.role = Some(role.to_owned());
+        record
+    })
+    .collect::<Vec<_>>();
+    let expected_class = [records[0].event_id.as_uuid(), records[2].event_id.as_uuid()];
+    let expected_role = [records[1].event_id.as_uuid(), records[3].event_id.as_uuid()];
+    let index = publish_records_in_one_segment(&temp, &source, records);
+    let class = EventSearchFilters {
+        content_scope: SearchContentScope::Transcript,
+        ..EventSearchFilters::default()
+    };
+    let role = EventSearchFilters {
+        role: Some("user".to_owned()),
+        ..EventSearchFilters::default()
+    };
+    for (filters, expected) in [(&class, expected_class), (&role, expected_role)] {
+        let group = lexical_search_batch(&index, &["disjointneedle"], filters, 10).unwrap();
+        assert!(group.complete && group.candidate_set_exhaustive);
+        assert_eq!(
+            group
+                .candidates
+                .iter()
+                .map(|candidate| candidate.event.event_id)
+                .collect::<HashSet<_>>(),
+            HashSet::from(expected)
+        );
+    }
+    let disjoint = EventSearchFilters {
+        role: role.role,
+        ..class
+    };
+    let empty = lexical_search_batch(&index, &["disjointneedle"], &disjoint, 10).unwrap();
+    assert!(empty.complete && empty.candidate_set_exhaustive);
+    assert!(empty.candidates.is_empty());
+    assert_eq!(empty.counters.candidate_docs, 0);
+    assert_eq!(empty.counters.body_posting_advances, 3);
+    assert_eq!(empty.counters.filter_seeks, 3);
+
+    let missing = EventSearchFilters {
+        allowed_source_keys: Some(vec!["missing-a".to_owned(), "missing-b".to_owned()]),
+        ..disjoint
+    };
+    let empty = lexical_search_batch(&index, &["disjointneedle"], &missing, 10).unwrap();
+    assert!(empty.complete && empty.candidate_set_exhaustive);
+    assert!(empty.candidates.is_empty());
+    assert_eq!(empty.counters.candidate_docs, 0);
+    assert_eq!(empty.counters.body_posting_advances, 0);
+    assert_eq!(empty.counters.filter_probes, 0);
+    assert_eq!(empty.counters.filter_seeks, 0);
+}


### PR DESCRIPTION
A lexical search scoped to a small session could exhaust its candidate budget on earlier body matches outside that session in the same index segment. Required positive filter postings now supply a lower bound for metered body seeks, so unrelated intervals do not consume the candidate budget. In a 17-document single-segment fixture with normal budgets, the selected-session query examines 17→1 candidates and makes 17→2 body cursor movements; broad-query work is unchanged. With CandidateDocs capped at two, the baseline instead admits two candidates and returns empty with budget exhaustion; the fix admits one candidate and returns the expected scoped event exhaustively.

Preserve OR membership within each positive group, intersections across fields, negative and substring predicates, corpus-wide scoring, deterministic ordering, and all existing work ceilings. Every posting probe, seek and advance remains charged before execution. Five focused tests cover independent expected membership, early OR/AND convergence, disjoint and missing groups, ranking parity, and finite posting/candidate exhaustion boundaries.

Validation: the test-only baseline reproduced the small-budget failure after physical topology and normal-budget membership controls passed. The fix passed nine query unit tests and 141 writer integration tests with strict Clippy. All 108 graph-selected targets passed on the original tested inputs. Both later rebases preserve the complete query crate and patch bytes; seven direct consumers passed on the intermediate base, and four CLI/setup/refresh targets passed on the latest base. Independent source review found no interaction between the later setup, companion-routing or refresh-terminal changes and the preserved lexical traversal evidence.
