### PR TITLE
Repair interrupted managed-pair publication copies

### DIFF
--- a/crates/ctx-managed-pair-engine/src/filesystem.rs
+++ b/crates/ctx-managed-pair-engine/src/filesystem.rs
@@ -489,6 +489,35 @@ pub(super) fn copy_exact(
     Ok(copied)
 }
 
+/// Compare an incomplete copy with a prefix of its already verified source.
+/// This is bounded by the observed temporary length and never collects payloads.
+pub(super) fn matches_source_prefix(
+    source: &Entry,
+    expected: &FileStamp,
+    prefix: &FileStamp,
+    label: &str,
+) -> Result<bool> {
+    if prefix.size_bytes >= expected.size_bytes {
+        return Ok(false);
+    }
+    let file = open_owner_regular(source, label)?;
+    require_file_identity(&file, expected, label)?;
+    let mut limited = file.take(prefix.size_bytes);
+    let mut hasher = Sha256::new();
+    let mut total = 0_u64;
+    let mut buffer = [0_u8; 128 * 1024];
+    loop {
+        let count = limited.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        total += u64::try_from(count)?;
+        hasher.update(&buffer[..count]);
+    }
+    require_named_identity(source, expected, label)?;
+    Ok(total == prefix.size_bytes && format!("{:x}", hasher.finalize()) == prefix.sha256)
+}
+
 pub(super) fn write_new(
     entry: &Entry,
     bytes: &[u8],

--- a/crates/ctx-managed-pair-engine/src/fix_forward.rs
+++ b/crates/ctx-managed-pair-engine/src/fix_forward.rs
@@ -777,70 +777,70 @@ fn publish_exact(
     source: Option<(&Entry, &FileStamp)>,
     derived_bytes: Option<&[u8]>,
 ) -> Result<()> {
+    let label = slot.label();
     let executable = matches!(slot, Slot::Core | Slot::Companion);
     let max = super::max_bytes(slot);
     let target = layout.target(slot);
     let temporary = layout.staged(slot, &pending.attempt_id);
-    if content_matches(&target, expected, max, slot.label())? {
-        filesystem::protect_regular(&target, executable, slot.label())?;
-        remove_matching_temporary(&temporary, expected, max, slot.label())?;
+    let mut temporary_stamp = filesystem::stamp_temporary_optional(
+        &temporary,
+        max,
+        &format!("{label} publication temporary"),
+    )?;
+    if let Some(stamp) = temporary_stamp
+        .as_ref()
+        .filter(|stamp| !expected.matches(stamp))
+    {
+        let is_prefix = match (source, derived_bytes) {
+            (Some((source, source_stamp)), None) => {
+                filesystem::matches_source_prefix(source, source_stamp, stamp, label)?
+            }
+            (None, Some(bytes)) if stamp.size_bytes < expected.size_bytes => {
+                let prefix_len = usize::try_from(stamp.size_bytes)?;
+                bytes
+                    .get(..prefix_len)
+                    .is_some_and(|prefix| format!("{:x}", Sha256::digest(prefix)) == stamp.sha256)
+            }
+            _ => false,
+        };
+        if !is_prefix {
+            bail!("managed-pair {label} publication temporary changed");
+        }
+        // Only the fixed pending attempt's safe, uniquely linked partial copy
+        // may be discarded. Retained signed inputs were verified before entry.
+        filesystem::remove_temporary_exact(&temporary, stamp, max, label)?;
+        temporary_stamp = None;
+    }
+    if content_matches(&target, expected, max, label)? {
+        filesystem::protect_regular(&target, executable, label)?;
+        if let Some(stamp) = temporary_stamp {
+            filesystem::remove_if_exact(&temporary, &stamp, max, label)?;
+        }
         return Ok(());
     }
 
-    let temporary_stamp = match filesystem::stamp_optional(
-        &temporary,
-        max,
-        &format!("{} publication temporary", slot.label()),
-    )? {
+    let temporary_stamp = match temporary_stamp {
         Some(stamp) => {
-            if !expected.matches(&stamp) {
-                bail!(
-                    "managed-pair {} publication temporary changed",
-                    slot.label()
-                );
-            }
-            filesystem::protect_regular(&temporary, executable, slot.label())?;
+            filesystem::protect_regular(&temporary, executable, label)?;
             stamp
         }
         None => match (source, derived_bytes) {
-            (Some((source, source_stamp)), None) => filesystem::copy_exact(
-                source,
-                &temporary,
-                source_stamp,
-                max,
-                executable,
-                slot.label(),
-            )?,
-            (None, Some(bytes)) => {
-                filesystem::write_new(&temporary, bytes, executable, slot.label())?
+            (Some((source, source_stamp)), None) => {
+                filesystem::copy_exact(source, &temporary, source_stamp, max, executable, label)?
             }
+            (None, Some(bytes)) => filesystem::write_new(&temporary, bytes, executable, label)?,
             _ => bail!("managed-pair publication source is invalid"),
         },
     };
     // This rejects symlink, reparse-point, and hardlink targets immediately
     // before the handle-relative atomic replacement.
-    let _ = filesystem::stamp_optional(&target, max, slot.label())?;
-    filesystem::durable_replace(&temporary, &target, &temporary_stamp, max, slot.label())?;
-    filesystem::protect_regular(&target, executable, slot.label())?;
-    if !content_matches(&target, expected, max, slot.label())? {
-        bail!("published managed-pair {} changed", slot.label());
+    let _ = filesystem::stamp_optional(&target, max, label)?;
+    filesystem::durable_replace(&temporary, &target, &temporary_stamp, max, label)?;
+    filesystem::protect_regular(&target, executable, label)?;
+    if !content_matches(&target, expected, max, label)? {
+        bail!("published managed-pair {label} changed");
     }
     layout.revalidate()
-}
-
-fn remove_matching_temporary(
-    temporary: &Entry,
-    expected: &ContentIdentity,
-    max: u64,
-    label: &str,
-) -> Result<()> {
-    let Some(stamp) = filesystem::stamp_optional(temporary, max, label)? else {
-        return Ok(());
-    };
-    if !expected.matches(&stamp) {
-        bail!("managed-pair {label} publication temporary changed");
-    }
-    filesystem::remove_if_exact(temporary, &stamp, max, label)
 }
 
 fn write_pending(layout: &Layout, pending: &PendingApply) -> Result<()> {

--- a/crates/ctx-managed-pair-engine/src/tests.rs
+++ b/crates/ctx-managed-pair-engine/src/tests.rs
@@ -236,6 +236,7 @@ fn assert_cleanup(fixture: &Fixture, attempt_id: &str) {
 }
 
 mod fix_forward;
+mod partial_copy;
 #[cfg(unix)]
 mod reconciliation;
 

--- a/crates/ctx-managed-pair-engine/src/tests/partial_copy.rs
+++ b/crates/ctx-managed-pair-engine/src/tests/partial_copy.rs
@@ -1,0 +1,306 @@
+use super::*;
+
+fn pending_after_publication(
+    fixture: &Fixture,
+    candidate: &Candidate,
+    verifier: &TestVerifier,
+) -> String {
+    let interrupted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        apply_with_fault(fixture, candidate, verifier, &|point| {
+            if point == "publish_state" {
+                panic!("interrupt before pending cleanup");
+            }
+        })
+    }));
+    assert!(interrupted.is_err());
+    let pending: serde_json::Value = serde_json::from_slice(
+        &fs::read(
+            fixture
+                .install
+                .join(MANAGED_PAIR_ACTIVE_TRANSACTION_RELATIVE_PATH),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    pending["attempt_id"].as_str().unwrap().to_owned()
+}
+
+fn write_private(path: &Path, bytes: &[u8]) {
+    fs::write(path, bytes).unwrap();
+    ctx_history_platform::platform_security::restrict_private_file(path).unwrap();
+}
+
+#[test]
+fn partial_publication_copies_resume_each_slot_from_retained_candidate() {
+    for slot in filesystem::Slot::ALL {
+        // The last case exercises reuse/cleanup of a complete temporary too.
+        for length in [0, 1, 5, usize::MAX] {
+            for target_current in [false, true] {
+                let fixture = Fixture::new();
+                let candidate = fixture.candidate(
+                    "partial",
+                    1,
+                    b"new-core-bytes",
+                    b"new-pro-bytes",
+                    b"new-marker",
+                );
+                let verifier =
+                    TestVerifier::new([(candidate.envelope.clone(), candidate.identity.clone())]);
+                let attempt = pending_after_publication(&fixture, &candidate, &verifier);
+                let layout = filesystem::Layout::open(&fixture.install, false).unwrap();
+                let target = layout.target(slot);
+                let bytes = fs::read(&target).unwrap();
+                let length = length.min(bytes.len());
+                let temporary = layout.staged(slot, &attempt);
+                write_private(&temporary, &bytes[..length]);
+                if !target_current {
+                    fs::remove_file(&target).unwrap();
+                }
+                let unrelated = layout.staged(slot, "00000000000000000000000000000000");
+                write_private(&unrelated, b"unrelated attempt");
+                // Recovery must use retained inputs, with no new download/source access.
+                fs::remove_dir_all(&fixture.candidates).unwrap();
+                let resumed = under_installation_lock(&fixture.install, || {
+                    resume_pending_managed_pair_under_installation_lock(&fixture.install, &verifier)
+                });
+                assert!(
+                    resumed.is_ok(),
+                    "slot={slot:?}, length={length}, target_current={target_current}: {resumed:?}"
+                );
+                let resumed = resumed.unwrap().unwrap();
+                assert_eq!(resumed.attempt_id(), Some(attempt.as_str()));
+                assert_eq!(fs::read(&target).unwrap(), bytes);
+                assert_eq!(fs::read(&unrelated).unwrap(), b"unrelated attempt");
+                assert_active(&fixture, &candidate, &verifier);
+                assert_cleanup(&fixture, &attempt);
+            }
+        }
+    }
+}
+
+#[test]
+fn partial_publication_preserves_unrelated_or_unsafe_temporaries() {
+    for kind in [
+        "unrelated",
+        "wrong-full",
+        "oversized",
+        "directory",
+        "hardlink",
+        "symlink",
+    ] {
+        for target_current in [false, true] {
+            if kind == "symlink" && !cfg!(unix) {
+                continue;
+            }
+            let fixture = Fixture::new();
+            let candidate = fixture.candidate(
+                "protected",
+                1,
+                b"new-core-bytes",
+                b"new-pro-bytes",
+                b"new-marker",
+            );
+            let verifier =
+                TestVerifier::new([(candidate.envelope.clone(), candidate.identity.clone())]);
+            let attempt = pending_after_publication(&fixture, &candidate, &verifier);
+            let layout = filesystem::Layout::open(&fixture.install, false).unwrap();
+            let slot = filesystem::Slot::Companion;
+            let target = layout.target(slot);
+            let temporary = layout.staged(slot, &attempt);
+            let victim = fixture._temp.path().join("unrelated-file");
+            write_private(&victim, &candidate.companion[..5]);
+            match kind {
+                "unrelated" => write_private(&temporary, b"other"),
+                "wrong-full" => write_private(&temporary, &vec![b'x'; candidate.companion.len()]),
+                "oversized" => write_private(
+                    &temporary,
+                    &[candidate.companion.as_slice(), b"extra"].concat(),
+                ),
+                "directory" => fs::create_dir(&temporary).unwrap(),
+                "hardlink" => fs::hard_link(&victim, &temporary).unwrap(),
+                #[cfg(unix)]
+                "symlink" => std::os::unix::fs::symlink(&victim, &temporary).unwrap(),
+                _ => unreachable!(),
+            }
+            if !target_current {
+                fs::remove_file(&target).unwrap();
+            }
+            let pending_path = fixture
+                .install
+                .join(MANAGED_PAIR_ACTIVE_TRANSACTION_RELATIVE_PATH);
+            let pending = fs::read(&pending_path).unwrap();
+            let before = fs::symlink_metadata(&temporary).unwrap();
+            let before_bytes = (!before.is_dir()).then(|| fs::read(&temporary).unwrap());
+            let victim_metadata = fs::metadata(&victim).unwrap();
+            let result = under_installation_lock(&fixture.install, || {
+                resume_pending_managed_pair_under_installation_lock(&fixture.install, &verifier)
+            });
+            assert!(
+                result.is_err(),
+                "kind={kind}, target_current={target_current}"
+            );
+            assert_eq!(fs::read(&victim).unwrap(), &candidate.companion[..5]);
+            let after = fs::symlink_metadata(&temporary).unwrap();
+            assert_eq!(before.file_type(), after.file_type());
+            assert_eq!(before.len(), after.len());
+            if let Some(bytes) = before_bytes {
+                assert_eq!(fs::read(&temporary).unwrap(), bytes);
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::MetadataExt as _;
+                assert_eq!(
+                    (before.ino(), before.mode(), before.nlink()),
+                    (after.ino(), after.mode(), after.nlink())
+                );
+                let after_victim = fs::metadata(&victim).unwrap();
+                assert_eq!(
+                    (
+                        victim_metadata.ino(),
+                        victim_metadata.mode(),
+                        victim_metadata.nlink()
+                    ),
+                    (
+                        after_victim.ino(),
+                        after_victim.mode(),
+                        after_victim.nlink()
+                    )
+                );
+            }
+            #[cfg(not(unix))]
+            assert_eq!(
+                victim_metadata.permissions().readonly(),
+                fs::metadata(&victim).unwrap().permissions().readonly()
+            );
+            assert_eq!(fs::read(&pending_path).unwrap(), pending);
+            assert_eq!(target.exists(), target_current);
+            if target_current {
+                assert_eq!(fs::read(&target).unwrap(), candidate.companion);
+            }
+        }
+    }
+}
+
+#[test]
+fn partial_publication_requires_verified_retained_source_before_removal() {
+    for corrupt in [
+        filesystem::Slot::Envelope,
+        filesystem::Slot::Core,
+        filesystem::Slot::Companion,
+        filesystem::Slot::Marker,
+    ] {
+        let fixture = Fixture::new();
+        let candidate = fixture.candidate(
+            "corrupt",
+            1,
+            b"new-core-bytes",
+            b"new-pro-bytes",
+            b"new-marker",
+        );
+        let verifier =
+            TestVerifier::new([(candidate.envelope.clone(), candidate.identity.clone())]);
+        let attempt = pending_after_publication(&fixture, &candidate, &verifier);
+        let layout = filesystem::Layout::open(&fixture.install, false).unwrap();
+        let temporary = layout.staged(filesystem::Slot::Companion, &attempt);
+        write_private(&temporary, &candidate.companion[..5]);
+        let retained = layout.open_apply_candidate().unwrap();
+        write_private(&retained.target(corrupt), b"corrupt-retained-source");
+        let result = under_installation_lock(&fixture.install, || {
+            resume_pending_managed_pair_under_installation_lock(&fixture.install, &verifier)
+        });
+        assert!(result.is_err());
+        assert_eq!(fs::read(&temporary).unwrap(), &candidate.companion[..5]);
+        assert!(layout.active_transaction().exists());
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn partial_publication_copy_process_death_resumes_retained_candidate() {
+    use std::os::unix::process::{CommandExt as _, ExitStatusExt as _};
+    const COPY_BUFFER: usize = 128 * 1024;
+    const CHILD_ROOT: &str = "CTX_PAIR_COPY_DEATH_ROOT";
+    let core = vec![b'c'; COPY_BUFFER * 3];
+    let companion = vec![b'p'; COPY_BUFFER * 3];
+    if let Some(root) = std::env::var_os(CHILD_ROOT) {
+        let root = PathBuf::from(root);
+        let verifier = TestVerifier::new([(
+            b"signed-envelope:killed-copy:1\n".to_vec(),
+            identity("killed-copy", 1, &core, &companion),
+        )]);
+        under_installation_lock(&root, || {
+            resume_pending_managed_pair_under_installation_lock(&root, &verifier).unwrap();
+        });
+        panic!("copy should have been terminated by the file-size limit");
+    }
+
+    let fixture = Fixture::new();
+    let candidate = fixture.candidate("killed-copy", 1, &core, &companion, b"marker");
+    let verifier = TestVerifier::new([(candidate.envelope.clone(), candidate.identity.clone())]);
+    let staged = under_installation_lock(&fixture.install, || {
+        stage_managed_pair_under_installation_lock(&fixture.install, &input(&candidate), &verifier)
+            .unwrap()
+    });
+    let ManagedPairStageOutcome::Staged { attempt_id, .. } = staged else {
+        panic!("candidate should be staged");
+    };
+    fs::remove_dir_all(&fixture.candidates).unwrap();
+    let mut child = std::process::Command::new(std::env::current_exe().unwrap());
+    child
+        .args([
+            "--exact",
+            "tests::partial_copy::partial_publication_copy_process_death_resumes_retained_candidate",
+            "--nocapture",
+        ])
+        .env(CHILD_ROOT, &fixture.install);
+    // The kernel terminates the child during copy_exact's second write. This
+    // bypasses Rust error cleanup without adding a production fault hook.
+    unsafe {
+        child.pre_exec(|| {
+            let limit = libc::rlimit {
+                rlim_cur: COPY_BUFFER as libc::rlim_t,
+                rlim_max: COPY_BUFFER as libc::rlim_t,
+            };
+            if libc::setrlimit(libc::RLIMIT_FSIZE, &limit) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            libc::signal(libc::SIGXFSZ, libc::SIG_DFL);
+            let no_core = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            if libc::setrlimit(libc::RLIMIT_CORE, &no_core) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let output = child.output().unwrap();
+    assert_eq!(output.status.signal(), Some(libc::SIGXFSZ), "{output:?}");
+    let layout = filesystem::Layout::open(&fixture.install, false).unwrap();
+    let temporary = layout.staged(filesystem::Slot::Companion, &attempt_id);
+    let partial = fs::read(&temporary).unwrap();
+    assert_eq!(partial.len(), COPY_BUFFER);
+    assert_eq!(partial, companion[..COPY_BUFFER]);
+    assert!(layout.active_transaction().exists());
+    assert!(!layout.target(filesystem::Slot::Companion).exists());
+    assert_eq!(
+        fs::read(layout.target(filesystem::Slot::Envelope)).unwrap(),
+        candidate.envelope
+    );
+    eprintln!(
+        "kernel SIGXFSZ interrupted production copy: {} of {} bytes; retained pending attempt {}",
+        partial.len(),
+        companion.len(),
+        attempt_id
+    );
+
+    let resumed = under_installation_lock(&fixture.install, || {
+        resume_pending_managed_pair_under_installation_lock(&fixture.install, &verifier)
+    })
+    .unwrap()
+    .unwrap();
+    assert_eq!(resumed.attempt_id(), Some(attempt_id.as_str()));
+    assert_active(&fixture, &candidate, &verifier);
+    assert_cleanup(&fixture, &attempt_id);
+}

--- a/crates/ctx-managed-pair-engine/src/tests/partial_copy.rs
+++ b/crates/ctx-managed-pair-engine/src/tests/partial_copy.rs
@@ -182,6 +182,42 @@ fn partial_publication_preserves_unrelated_or_unsafe_temporaries() {
 }
 
 #[test]
+fn partial_publication_preserves_unrelated_state_temporary() {
+    for target_current in [false, true] {
+        let fixture = Fixture::new();
+        let candidate = fixture.candidate("state-negative", 1, b"core", b"pro", b"marker");
+        let verifier =
+            TestVerifier::new([(candidate.envelope.clone(), candidate.identity.clone())]);
+        let attempt = pending_after_publication(&fixture, &candidate, &verifier);
+        let layout = filesystem::Layout::open(&fixture.install, false).unwrap();
+        let target = layout.target(filesystem::Slot::State);
+        let installed = fs::read(&target).unwrap();
+        let temporary = layout.staged(filesystem::Slot::State, &attempt);
+        let unrelated = b"other";
+        assert!(unrelated.len() < installed.len());
+        assert!(!installed.starts_with(unrelated));
+        write_private(&temporary, unrelated);
+        if !target_current {
+            fs::remove_file(&target).unwrap();
+        }
+        let pending_path = layout.active_transaction();
+        let pending = fs::read(&pending_path).unwrap();
+
+        let error = under_installation_lock(&fixture.install, || {
+            resume_pending_managed_pair_under_installation_lock(&fixture.install, &verifier)
+        })
+        .unwrap_err();
+        assert!(error.to_string().contains("publication temporary changed"));
+        assert_eq!(fs::read(&temporary).unwrap(), unrelated);
+        assert_eq!(fs::read(&pending_path).unwrap(), pending);
+        assert_eq!(target.exists(), target_current);
+        if target_current {
+            assert_eq!(fs::read(&target).unwrap(), installed);
+        }
+    }
+}
+
+#[test]
 fn partial_publication_requires_verified_retained_source_before_removal() {
     for corrupt in [
         filesystem::Slot::Envelope,


### PR DESCRIPTION
A process interruption during managed-pair publication can leave a partial temporary file that prevents every repair retry. Recovery now recreates empty or matching-prefix temporaries from retained verified inputs under the installation lock, while retaining rejection of unrelated content, links, and unsafe files.

Validated with the owning 18-test suite and a Linux process-termination regression: the baseline retains a 128-KiB partial copy and fails recovery; the candidate completes the same retained attempt. Coverage includes every publication slot, already-current targets, invalid retained inputs, and temporary-file rejection. This does not claim Windows/macOS native or power-loss qualification.
