### PR TITLE
Preserve refresh journal errors and report effective retry status

### DIFF
--- a/crates/ctx-cli-presentation/src/commands/status_health.rs
+++ b/crates/ctx-cli-presentation/src/commands/status_health.rs
@@ -71,7 +71,12 @@ pub(super) fn status_next_command(
     pending: usize,
     unhealthy: usize,
 ) -> Option<&'static str> {
-    if automatic_retry_pause(report).is_some() {
+    if automatic_retry_pause(report).is_some()
+        || matches!(
+            report["refresh"]["reason"].as_str(),
+            Some("refresh_requires_explicit_request" | "automatic_retry_daemon_unavailable")
+        )
+    {
         return Some("ctx import --all");
     }
     match health {
@@ -89,10 +94,14 @@ pub(super) fn status_next_command(
 }
 
 pub(super) fn automatic_retry_state(report: &Value) -> Option<&str> {
-    report["refresh"]
-        .pointer("/automatic_retry/state")
-        .and_then(Value::as_str)
-        .filter(|state| matches!(*state, "confirming" | "paused" | "mixed"))
+    // Current scheduling is projected by the refresh owner. The retained
+    // checkpoint is diagnostic history and cannot promise new work by itself.
+    match report["refresh"]["reason"].as_str() {
+        Some("automatic_retry_confirming") => Some("confirming"),
+        Some("automatic_retry_paused") => Some("paused"),
+        Some("automatic_retry_partially_paused") => Some("mixed"),
+        _ => None,
+    }
 }
 
 pub(super) fn automatic_retry_pause(report: &Value) -> Option<&str> {

--- a/crates/ctx-cli-presentation/src/commands/status_presentation.rs
+++ b/crates/ctx-cli-presentation/src/commands/status_presentation.rs
@@ -779,7 +779,16 @@ mod tests {
         ] {
             for checkpoint in ["confirming", "paused", "mixed"] {
                 let mut report = status_report(true, "ready", status);
+                report["daemon"] = json!({
+                    "enabled": reason == "automatic_retry_daemon_unavailable",
+                    "running": status == "pending",
+                    "status": if status == "pending" { "running" } else { "stopped" },
+                });
                 report["refresh"]["reason"] = json!(reason);
+                // The projection can retain a terminal root while an admitted
+                // successor runs. Historical fields must not override its advice.
+                report["refresh"]["request_state"] = json!("published");
+                report["refresh"]["last_error"] = json!("retained failure");
                 report["refresh"]["automatic_retry"] = json!({"state": checkpoint});
                 for width in [32, 48, 80, 120] {
                     let render_context = context(width, ColorMode::Never);
@@ -796,6 +805,8 @@ mod tests {
                     );
                     if status == "partial" {
                         assert!(!rendered.contains("ctx index watch"), "{rendered}");
+                    } else {
+                        assert!(!rendered.contains("ctx import --all"), "{rendered}");
                     }
                     assert_fits(&document, &render_context);
                 }

--- a/crates/ctx-cli-presentation/src/commands/status_presentation.rs
+++ b/crates/ctx-cli-presentation/src/commands/status_presentation.rs
@@ -45,6 +45,33 @@ pub fn render_status_human(
     let last_verified_searchable = matches!(lexical_status, "ready" | "stale");
     let (state, title, detail) = match health {
         StatusHealth::Healthy => (OutcomeState::Success, "ctx is healthy", None),
+        _ if matches!(
+            report["refresh"]["reason"].as_str(),
+            Some("refresh_requires_explicit_request" | "automatic_retry_daemon_unavailable")
+        ) =>
+        {
+            (
+                if last_verified_searchable {
+                    OutcomeState::Warning
+                } else {
+                    OutcomeState::Error
+                },
+                "ctx needs attention",
+                Some(format!(
+                    "{} {}",
+                    if report["refresh"]["reason"] == "refresh_requires_explicit_request" {
+                        "History refresh needs an explicit request."
+                    } else {
+                        "Automatic history refresh is waiting for a running daemon."
+                    },
+                    if last_verified_searchable {
+                        "The last verified history remains searchable."
+                    } else {
+                        "No verified history is searchable yet."
+                    },
+                )),
+            )
+        }
         _ if automatic_retry_pause == Some("paused") => (
             if last_verified_searchable {
                 OutcomeState::Warning
@@ -649,7 +676,10 @@ mod tests {
                 let rendered = document.render_plain();
                 let normalized = rendered.split_whitespace().collect::<Vec<_>>().join(" ");
 
-                assert!(rendered.starts_with("! ctx needs attention\n"), "{rendered}");
+                assert!(
+                    rendered.starts_with("! ctx needs attention\n"),
+                    "{rendered}"
+                );
                 assert!(normalized.contains(expected_detail), "{rendered}");
                 assert!(normalized.contains("Refresh"), "{rendered}");
                 assert!(normalized.contains(refresh_status), "{rendered}");
@@ -661,7 +691,11 @@ mod tests {
                     normalized.contains("Hint: Retry after fixing the source or updating ctx."),
                     "{rendered}"
                 );
-                assert_eq!(rendered.matches("ctx import --all").count(), 1, "{rendered}");
+                assert_eq!(
+                    rendered.matches("ctx import --all").count(),
+                    1,
+                    "{rendered}"
+                );
                 assert!(!rendered.contains("--no-daemon"), "{rendered}");
                 assert!(!rendered.contains("/tmp/private/source"), "{rendered}");
                 assert!(!rendered.contains(&"dd".repeat(32)), "{rendered}");
@@ -719,6 +753,54 @@ mod tests {
             !rendered.contains("history refresh is paused"),
             "{rendered}"
         );
+    }
+
+    #[test]
+    fn retained_retry_checkpoint_does_not_promise_unscheduled_work() {
+        for (reason, status, expected_detail, expected_action) in [
+            (
+                "refresh_requires_explicit_request",
+                "partial",
+                "History refresh needs an explicit request.",
+                "ctx import --all",
+            ),
+            (
+                "automatic_retry_daemon_unavailable",
+                "partial",
+                "Automatic history refresh is waiting for a running daemon.",
+                "ctx import --all",
+            ),
+            (
+                "core_refresh_pending",
+                "pending",
+                "1 history service is catching up",
+                "ctx index watch",
+            ),
+        ] {
+            for checkpoint in ["confirming", "paused", "mixed"] {
+                let mut report = status_report(true, "ready", status);
+                report["refresh"]["reason"] = json!(reason);
+                report["refresh"]["automatic_retry"] = json!({"state": checkpoint});
+                for width in [32, 48, 80, 120] {
+                    let render_context = context(width, ColorMode::Never);
+                    let document = render_report(&render_context, &report);
+                    let rendered = document.render_plain();
+                    let normalized = rendered.split_whitespace().collect::<Vec<_>>().join(" ");
+                    assert!(normalized.contains(expected_detail), "{rendered}");
+                    assert!(rendered.contains(expected_action), "{rendered}");
+                    assert!(!rendered.contains("will retry"), "{rendered}");
+                    assert!(!rendered.contains("An automatic retry will"), "{rendered}");
+                    assert!(
+                        !rendered.contains("history refresh is paused"),
+                        "{rendered}"
+                    );
+                    if status == "partial" {
+                        assert!(!rendered.contains("ctx index watch"), "{rendered}");
+                    }
+                    assert_fits(&document, &render_context);
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/ctx-daemon-cli/src/source_status.rs
+++ b/crates/ctx-daemon-cli/src/source_status.rs
@@ -229,7 +229,23 @@ fn refresh_report(job: Option<&Value>, generation_id: Option<&str>, daemon: &Val
         .get("automatic_retry")
         .and_then(|automatic_retry| automatic_retry.get("state"))
         .and_then(Value::as_str);
+    let daemon_enabled = daemon.get("enabled").and_then(Value::as_bool) == Some(true);
+    let daemon_running = daemon.get("running").and_then(Value::as_bool) == Some(true);
     let (status, reason) = match automatic_retry_state {
+        Some("confirming" | "paused" | "mixed") if !daemon_enabled || !daemon_running => {
+            if daemon_running
+                && matches!(
+                    request_state,
+                    Some("admission_pending" | "queued" | "running")
+                )
+            {
+                ("pending", Some("core_refresh_pending"))
+            } else if daemon_enabled {
+                ("partial", Some("automatic_retry_daemon_unavailable"))
+            } else {
+                ("partial", Some("refresh_requires_explicit_request"))
+            }
+        }
         Some("confirming") => ("pending", Some("automatic_retry_confirming")),
         Some("paused") if current_internal_failure_is_fully_paused(job) => {
             ("paused", Some("automatic_retry_paused"))

--- a/crates/ctx-daemon-cli/src/source_status.rs
+++ b/crates/ctx-daemon-cli/src/source_status.rs
@@ -234,10 +234,22 @@ fn refresh_report(job: Option<&Value>, generation_id: Option<&str>, daemon: &Val
     let (status, reason) = match automatic_retry_state {
         Some("confirming" | "paused" | "mixed") if !daemon_enabled || !daemon_running => {
             if daemon_running
-                && matches!(
+                && (matches!(
                     request_state,
                     Some("admission_pending" | "queued" | "running")
-                )
+                ) || job
+                    .get("queued_successors")
+                    .and_then(Value::as_array)
+                    .is_some_and(|successors| {
+                        // Terminal roots retain admitted successors until the
+                        // finite owner advances; the root alone is historical.
+                        successors.iter().any(|successor| {
+                            matches!(
+                                successor.get("request_state").and_then(Value::as_str),
+                                Some("admission_pending" | "queued")
+                            )
+                        })
+                    }))
             {
                 ("pending", Some("core_refresh_pending"))
             } else if daemon_enabled {

--- a/crates/ctx-daemon-cli/src/source_status_tests.rs
+++ b/crates/ctx-daemon-cli/src/source_status_tests.rs
@@ -448,12 +448,71 @@ fn refresh_report_preserves_automatic_retry_and_projects_its_attention_state() {
             "automatic_retry": automatic_retry,
         });
 
-        let report = refresh_report(Some(&job), Some("generation-1"), &json!({"running": true}));
+        let report = refresh_report(
+            Some(&job),
+            Some("generation-1"),
+            &json!({"enabled": true, "running": true}),
+        );
 
         assert_eq!(report["status"], expected_status, "state={state}");
         assert_eq!(report["reason"], expected_reason, "state={state}");
         assert_eq!(report["structured_outcome"], structured_outcome);
         assert_eq!(report["automatic_retry"], automatic_retry);
+    }
+}
+
+#[test]
+fn retained_retry_checkpoint_follows_current_policy_and_runtime_ownership() {
+    for checkpoint in ["confirming", "paused", "mixed"] {
+        let mut job = json!({
+            "request_state": "failed",
+            "last_error": "retained failure",
+            "automatic_retry": {"state": checkpoint, "routes": {}},
+        });
+        for (enabled, running, request_state, expected_status, expected_reason) in [
+            (
+                false,
+                false,
+                "failed",
+                "partial",
+                "refresh_requires_explicit_request",
+            ),
+            (
+                false,
+                true,
+                "failed",
+                "partial",
+                "refresh_requires_explicit_request",
+            ),
+            (false, true, "running", "pending", "core_refresh_pending"),
+            (
+                false,
+                true,
+                "admission_pending",
+                "pending",
+                "core_refresh_pending",
+            ),
+            (false, true, "queued", "pending", "core_refresh_pending"),
+            (
+                true,
+                false,
+                "failed",
+                "partial",
+                "automatic_retry_daemon_unavailable",
+            ),
+        ] {
+            job["request_state"] = json!(request_state);
+            let report = refresh_report(
+                Some(&job),
+                Some("generation-1"),
+                &json!({"enabled": enabled, "running": running}),
+            );
+            assert_eq!(report["status"], expected_status, "{report:#}");
+            assert_eq!(report["reason"], expected_reason, "{report:#}");
+            assert_eq!(report["automatic_retry"], job["automatic_retry"]);
+            assert_eq!(report["last_error"], job["last_error"]);
+            assert_eq!(report["request_state"], job["request_state"]);
+        }
     }
 }
 
@@ -480,7 +539,11 @@ fn paused_route_does_not_claim_an_unrelated_active_refresh_is_fully_paused() {
         "automatic_retry": automatic_retry,
     });
 
-    let report = refresh_report(Some(&job), Some("generation-1"), &json!({"running": true}));
+    let report = refresh_report(
+        Some(&job),
+        Some("generation-1"),
+        &json!({"enabled": true, "running": true}),
+    );
 
     assert_eq!(report["status"], "partial");
     assert_eq!(report["reason"], "automatic_retry_partially_paused");

--- a/crates/ctx-daemon-cli/src/source_status_tests.rs
+++ b/crates/ctx-daemon-cli/src/source_status_tests.rs
@@ -517,6 +517,50 @@ fn retained_retry_checkpoint_follows_current_policy_and_runtime_ownership() {
 }
 
 #[test]
+fn retained_retry_checkpoint_terminal_root_keeps_admitted_successors_pending() {
+    for checkpoint in ["confirming", "paused", "mixed"] {
+        for terminal in ["published", "failed"] {
+            for successor_state in ["admission_pending", "queued", "failed"] {
+                let job = json!({
+                    "request_id": "019fcaaa-0000-7000-8000-000000000321",
+                    "request_state": terminal,
+                    "published_generation": "generation-1",
+                    "last_error": "retained failure",
+                    "automatic_retry": {"state": checkpoint, "routes": {}},
+                    "queued_successors": [{
+                        "request_id": "019fcaaa-0000-7000-8000-000000000322",
+                        "request_state": successor_state,
+                        "trigger": "import",
+                        "refresh_intent": {
+                            "kind": "selected_import",
+                            "selection": {"kind": "all"},
+                        },
+                    }],
+                });
+                for running in [true, false] {
+                    let report = refresh_report(
+                        Some(&job),
+                        Some("generation-1"),
+                        &json!({"enabled": false, "running": running}),
+                    );
+                    let (status, reason) = if running && successor_state != "failed" {
+                        ("pending", "core_refresh_pending")
+                    } else {
+                        ("partial", "refresh_requires_explicit_request")
+                    };
+                    assert_eq!(report["status"], status, "{job:#}: {report:#}");
+                    assert_eq!(report["reason"], reason, "{job:#}: {report:#}");
+                    assert_eq!(report["request_id"], job["request_id"]);
+                    assert_eq!(report["request_state"], job["request_state"]);
+                    assert_eq!(report["automatic_retry"], job["automatic_retry"]);
+                    assert_eq!(report["last_error"], job["last_error"]);
+                }
+            }
+        }
+    }
+}
+
+#[test]
 fn paused_route_does_not_claim_an_unrelated_active_refresh_is_fully_paused() {
     let route = "aa".repeat(32);
     let automatic_retry = json!({

--- a/crates/ctx-daemon-service/src/daemon/tests/startup_recovery.rs
+++ b/crates/ctx-daemon-service/src/daemon/tests/startup_recovery.rs
@@ -1,6 +1,109 @@
 use super::*;
 use crate::compact_json;
 
+#[test]
+fn journal_read_failure_blocks_startup_and_preserves_accepted_queue() -> Result<()> {
+    for unreadable in [false, true] {
+        let temp = tempfile::tempdir()?;
+        let data_root = temp.path().join("data");
+        ctx_history_platform::platform_security::establish_private_data_root(&data_root)?;
+        let journal_path = daemon_core_refresh_job_path(&data_root);
+        let interrupted = CoreRefreshEngine::new();
+        let mut accepted = Vec::new();
+        for request_id in [
+            "019fcaaa-0000-7000-8000-000000000319",
+            "019fcaaa-0000-7000-8000-000000000320",
+        ] {
+            let response = interrupted
+                .handle_ipc_request(
+                    &data_root,
+                    &json!({
+                        "op": "source_refresh_request",
+                        "request_id": request_id,
+                        "mode": "wait",
+                        "refresh_intent": {
+                            "kind": "selected_import",
+                            "selection": {"kind": "all"},
+                        },
+                    }),
+                )?
+                .expect("durable import admission");
+            assert_eq!(response["request_id"], request_id);
+            accepted.push(response);
+        }
+        let original = fs::read(&journal_path)?;
+        let durable: Value = serde_json::from_slice(&original)?;
+        assert_eq!(durable["request_id"], accepted[0]["request_id"]);
+        assert_eq!(
+            durable["queued_successors"][0]["request_id"],
+            accepted[1]["request_id"]
+        );
+        drop(interrupted);
+
+        let retained_path = journal_path.with_extension("retained");
+        if unreadable {
+            fs::rename(&journal_path, &retained_path)?;
+            // A directory gives a real read error even under privileged test runners.
+            fs::create_dir(&journal_path)?;
+        } else {
+            fs::write(&journal_path, b"{\"request_id\":")?;
+        }
+        let mut runtime = DaemonRuntime::default();
+        let result = recover_source_refresh_coordinator_before_ipc(
+            &mut runtime,
+            &data_root,
+            &crate::test_support::CONFIG,
+        );
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("unknown journal authority must block startup"),
+        };
+        assert!(
+            error.to_string().contains("before daemon readiness"),
+            "{error:#}"
+        );
+        assert!(runtime.source_refresh_coordinator.is_none());
+        assert!(
+            !daemon_service_endpoint_path(&data_root, DaemonIpcService::SourceRefresh).exists()
+        );
+        if unreadable {
+            assert!(journal_path.is_dir());
+            assert_eq!(fs::read(&retained_path)?, original);
+            fs::remove_dir(&journal_path)?;
+            fs::rename(&retained_path, &journal_path)?;
+        } else {
+            assert_eq!(fs::read(&journal_path)?, b"{\"request_id\":");
+            // Simulate operator restoration; startup itself must not repair unknown bytes.
+            fs::write(&journal_path, &original)?;
+        }
+
+        let recovered = recover_source_refresh_coordinator_before_ipc(
+            &mut runtime,
+            &data_root,
+            &crate::test_support::CONFIG,
+        )?;
+        for acknowledgement in accepted {
+            let request_id = acknowledgement["request_id"].as_str().unwrap();
+            let status = recovered
+                .status(request_id)
+                .expect("accepted identity recovered");
+            assert_eq!(status["request_id"], acknowledgement["request_id"]);
+            assert_eq!(
+                status["requested_at_ms"],
+                acknowledgement["requested_at_ms"]
+            );
+            assert_eq!(status["request_state"], "admission_pending");
+        }
+        let restored = read_daemon_job_status(&journal_path).expect("restored queue");
+        assert_eq!(restored["request_id"], durable["request_id"]);
+        assert_eq!(
+            restored["queued_successors"][0]["request_id"],
+            durable["queued_successors"][0]["request_id"]
+        );
+    }
+    Ok(())
+}
+
 #[cfg(any(unix, windows))]
 #[test]
 fn interrupted_queue_is_recovered_before_endpoint_accepts_a_new_admission() -> Result<()> {

--- a/crates/ctx-daemon-service/src/source_backed_refresh_adapter/journal.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_adapter/journal.rs
@@ -5,8 +5,8 @@ use ctx_history_refresh::{DurableAdmissionPersistence, RefreshJournal};
 use serde_json::Value;
 
 use crate::paths_status::{
-    daemon_source_backed_refresh_job_path, read_daemon_job_status, sync_private_file_parent,
-    write_daemon_job_status,
+    daemon_source_backed_refresh_job_path, read_daemon_job_status, read_daemon_job_status_strict,
+    sync_private_file_parent, write_daemon_job_status,
 };
 
 #[derive(Debug, Default)]
@@ -14,9 +14,7 @@ pub(crate) struct DaemonRefreshJournal;
 
 impl RefreshJournal for DaemonRefreshJournal {
     fn load(&self, data_root: &Path) -> Result<Option<Value>> {
-        Ok(read_daemon_job_status(
-            &daemon_source_backed_refresh_job_path(data_root),
-        ))
+        read_daemon_job_status_strict(&daemon_source_backed_refresh_job_path(data_root))
     }
 
     fn store(&self, data_root: &Path, value: &Value) -> Result<()> {
@@ -40,5 +38,56 @@ impl RefreshJournal for DaemonRefreshJournal {
             Ok(()) => DurableAdmissionPersistence::Confirmed,
             Err(error) => DurableAdmissionPersistence::Retained(error),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn authoritative_load_distinguishes_absence_from_decode_and_read_errors() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = daemon_source_backed_refresh_job_path(temp.path());
+        let journal = DaemonRefreshJournal;
+        assert_eq!(journal.load(temp.path())?, None);
+
+        fs::create_dir_all(path.parent().unwrap())?;
+        for bytes in [b"{\"request_id\":".as_slice(), &[0xff]] {
+            fs::write(&path, bytes)?;
+            let error = journal
+                .load(temp.path())
+                .expect_err("invalid journal must fail");
+            assert!(
+                error.downcast_ref::<serde_json::Error>().is_some(),
+                "{error:#}"
+            );
+            assert_eq!(fs::read(&path)?, bytes);
+            assert_eq!(read_daemon_job_status(&path), None);
+        }
+
+        fs::remove_file(&path)?;
+        fs::create_dir(&path)?;
+        let error = journal
+            .load(temp.path())
+            .expect_err("unreadable journal must fail");
+        assert!(
+            error.downcast_ref::<std::io::Error>().is_some(),
+            "{error:#}"
+        );
+        assert!(path.is_dir());
+        Ok(())
+    }
+
+    #[test]
+    fn authoritative_load_preserves_valid_json_without_new_schema_policy() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let journal = DaemonRefreshJournal;
+        // The engine, not this persistence adapter, owns parsed-state policy.
+        let value = serde_json::json!({"request_state": "unknown", "retained": null});
+        journal.store(temp.path(), &value)?;
+        assert_eq!(journal.load(temp.path())?, Some(value));
+        Ok(())
     }
 }


### PR DESCRIPTION
Unreadable or malformed refresh journals now propagate an error during recovery instead of being treated as an absent queue. This preserves unknown admitted work until the journal can be read again, using the existing strict reader.

Status and retry advice now reflect the current indexing policy and running owner. With a running manual worker, status recognizes already-admitted work, including queued successors retained beneath a terminal root. When no worker is running, it recommends an explicit request. Historical retry checkpoints remain available without promising unscheduled automatic work.

Validation: the original journal/status failures and the terminal-root successor regression reproduced before the fixes. The three owning suites passed 570 tests, and owning Clippy passed. The changes add no scheduler or new persistence protocol.
