### PR TITLE
Bound history-source header reads before buffering

### DIFF
--- a/crates/ctx-history-cli/src/history_source_plugins/source_backed.rs
+++ b/crates/ctx-history-cli/src/history_source_plugins/source_backed.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File,
-    io::{BufRead, BufReader},
+    io::{BufRead, BufReader, Read},
     path::Path,
 };
 
@@ -100,14 +100,25 @@ fn validate_provider_owned_source(
             source_path.display()
         )
     })?;
-    let mut reader = BufReader::new(file);
+    validate_header(source, source_path, BufReader::new(file))
+}
+
+fn validate_header(
+    source: &HistorySourcePluginSource,
+    source_path: &Path,
+    mut reader: impl BufRead,
+) -> Result<()> {
     let mut total_bytes = 0_usize;
     let mut manifest_seen = false;
     let mut source_seen = false;
     let mut line = Vec::new();
     for line_number in 1..=MAX_HEADER_RECORDS {
         line.clear();
+        let remaining = (MAX_HEADER_BYTES - total_bytes).min(MAX_HEADER_LINE_BYTES);
+        // Read one sentinel byte to detect overflow without draining the source.
         let bytes = reader
+            .by_ref()
+            .take((remaining + 1) as u64)
             .read_until(b'\n', &mut line)
             .with_context(|| format!("read {}", source_path.display()))?;
         if bytes == 0 {
@@ -182,7 +193,7 @@ mod tests {
 
     use super::*;
 
-    fn source(path: PathBuf) -> HistorySourcePluginSource {
+    pub(super) fn source(path: PathBuf) -> HistorySourcePluginSource {
         HistorySourcePluginSource {
             plugin_name: "example".to_owned(),
             plugin_display_name: None,
@@ -309,3 +320,9 @@ mod tests {
         assert!(prepare_source_backed_history_source(matched, false).is_ok());
     }
 }
+
+#[cfg(test)]
+mod header_tests;
+
+#[cfg(test)]
+mod import_tests;

--- a/crates/ctx-history-cli/src/history_source_plugins/source_backed/header_tests.rs
+++ b/crates/ctx-history-cli/src/history_source_plugins/source_backed/header_tests.rs
@@ -1,0 +1,179 @@
+use std::io::{self, Read};
+
+use super::{tests::source, *};
+
+struct CountingReader<R> {
+    inner: R,
+    bytes_read: usize,
+}
+
+impl<R: Read> Read for CountingReader<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        let bytes = self.inner.read(buffer)?;
+        self.bytes_read += bytes;
+        Ok(bytes)
+    }
+}
+
+fn validate(input: impl Read) -> (Result<()>, usize, usize, usize) {
+    let path = Path::new("counted-history.jsonl");
+    let mut reader = BufReader::new(CountingReader {
+        inner: input,
+        bytes_read: 0,
+    });
+    let result = validate_header(&source(path.into()), path, &mut reader);
+    let read = reader.get_ref().bytes_read;
+    let consumed = read - reader.buffer().len();
+    (result, consumed, read, reader.capacity())
+}
+
+fn manifest() -> Vec<u8> {
+    format!(
+        "{}\n",
+        serde_json::json!({"record_type":"manifest","schema_version":PUBLIC_HISTORY_SCHEMA_VERSION})
+    )
+    .into_bytes()
+}
+
+fn identity(bytes: usize, newline: bool) -> Vec<u8> {
+    let mut line = br#"{"record_type":"source","provider_key":"example","source_id":"default","source_format":"example-v1"}"#.to_vec();
+    assert!(line.len() < bytes);
+    line.resize(bytes, b' ');
+    if newline {
+        *line.last_mut().unwrap() = b'\n';
+    }
+    line
+}
+
+fn bounded_error(result: Result<()>) {
+    let error = result.unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("header exceeds the bounded validation window"),
+        "{error:#}"
+    );
+}
+
+#[test]
+fn oversized_line_stops_after_one_sentinel_without_draining() {
+    for input_bytes in [2 * MAX_HEADER_BYTES, 8 * MAX_HEADER_BYTES] {
+        let input = io::repeat(b' ').take(input_bytes as u64);
+        let (result, consumed, read, prefetch) = validate(input);
+        bounded_error(result);
+        println!(
+            "oversized input={input_bytes} consumed={consumed} read={read} prefetch={prefetch}"
+        );
+        assert_eq!(consumed, MAX_HEADER_LINE_BYTES + 1);
+        assert!(read <= MAX_HEADER_LINE_BYTES + 1 + prefetch);
+    }
+}
+
+#[test]
+fn cumulative_budget_limits_the_next_line_before_reading() {
+    let mut prefix = Vec::new();
+    for bytes in [
+        MAX_HEADER_LINE_BYTES,
+        MAX_HEADER_LINE_BYTES,
+        MAX_HEADER_LINE_BYTES,
+        128 * 1024,
+    ] {
+        prefix.extend(vec![b' '; bytes - 1]);
+        prefix.push(b'\n');
+    }
+    let input = io::Cursor::new(prefix).chain(io::repeat(b' ').take(MAX_HEADER_BYTES as u64));
+    let (result, consumed, read, prefetch) = validate(input);
+    bounded_error(result);
+    println!("cumulative consumed={consumed} read={read} prefetch={prefetch}");
+    assert_eq!(consumed, MAX_HEADER_BYTES + 1);
+    assert!(read <= MAX_HEADER_BYTES + 1 + prefetch);
+}
+
+#[test]
+fn line_boundary_accepts_exact_bytes_and_rejects_one_more_with_or_without_newline() {
+    for newline in [false, true] {
+        for overflow in [false, true] {
+            let mut input = manifest();
+            input.extend(identity(
+                MAX_HEADER_LINE_BYTES + usize::from(overflow),
+                newline,
+            ));
+            let expected = input.len();
+            let (result, consumed, read, _) = validate(input.as_slice());
+            if overflow {
+                bounded_error(result);
+            } else {
+                result.unwrap();
+            }
+            assert_eq!(consumed, expected);
+            assert_eq!(read, expected);
+        }
+    }
+}
+
+#[test]
+fn total_boundary_accepts_exact_bytes_and_rejects_one_more_with_or_without_newline() {
+    for newline in [false, true] {
+        for overflow in [false, true] {
+            let mut input = manifest();
+            for _ in 0..3 {
+                input.extend(vec![b' '; MAX_HEADER_LINE_BYTES - 1]);
+                input.push(b'\n');
+            }
+            let remaining = MAX_HEADER_BYTES - input.len();
+            input.extend(identity(remaining + usize::from(overflow), newline));
+            let (result, consumed, read, _) = validate(input.as_slice());
+            if overflow {
+                bounded_error(result);
+            } else {
+                result.unwrap();
+            }
+            assert_eq!(consumed, input.len());
+            assert_eq!(read, input.len());
+        }
+    }
+}
+
+#[test]
+fn eof_at_total_budget_is_missing_header_but_another_byte_is_over_budget() {
+    let mut input = Vec::new();
+    for _ in 0..4 {
+        input.extend(vec![b' '; MAX_HEADER_LINE_BYTES - 1]);
+        input.push(b'\n');
+    }
+    let (result, consumed, read, _) = validate(input.as_slice());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("must declare its manifest"));
+    assert_eq!(consumed, MAX_HEADER_BYTES);
+    assert_eq!(read, MAX_HEADER_BYTES);
+    input.push(b' ');
+    let (result, consumed, read, _) = validate(input.as_slice());
+    bounded_error(result);
+    assert_eq!(consumed, MAX_HEADER_BYTES + 1);
+    assert_eq!(read, MAX_HEADER_BYTES + 1);
+}
+
+#[test]
+fn empty_eof_reports_missing_manifest() {
+    let (result, consumed, read, _) = validate(io::empty());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("must declare its manifest"));
+    assert_eq!((consumed, read), (0, 0));
+}
+
+#[test]
+fn valid_early_header_does_not_scan_large_body() {
+    let mut input = manifest();
+    input.extend(identity(256, true));
+    let header_bytes = input.len();
+    input.resize(header_bytes + 8 * MAX_HEADER_BYTES, b'x');
+    let (result, consumed, read, prefetch) = validate(input.as_slice());
+    result.unwrap();
+    println!("valid early header consumed={consumed} read={read} prefetch={prefetch}");
+    assert_eq!(consumed, header_bytes);
+    assert!(read <= header_bytes + prefetch);
+}

--- a/crates/ctx-history-cli/src/history_source_plugins/source_backed/import_tests.rs
+++ b/crates/ctx-history-cli/src/history_source_plugins/source_backed/import_tests.rs
@@ -1,0 +1,162 @@
+use std::{fs, io};
+
+use ctx_history_ingest_application::{IngestPublication, RefreshSelection};
+use ctx_history_refresh::ExplicitSourceCatalogUpsert;
+use ctx_terminal::{RenderContext, StreamKind, TestContext, Ui};
+
+use super::*;
+use crate::{
+    run_import_application, HistoryCliConfig, HistoryConfigSnapshotPort, ImportApplicationPort,
+    ImportRequest, OutputFormat, ProgressMode, ProgressReporter,
+};
+
+#[derive(Default)]
+struct ImportHost {
+    preparations: usize,
+    admissions: usize,
+}
+
+impl ImportApplicationPort for ImportHost {
+    fn protect_data_root(&mut self, data_root: &Path) -> Result<()> {
+        fs::create_dir_all(data_root)?;
+        Ok(())
+    }
+
+    fn explicit_source(
+        &self,
+        _: &Path,
+        _: &Path,
+        _: Option<CaptureProvider>,
+        _: bool,
+    ) -> Result<ProviderSource> {
+        panic!("plugin import must use plugin preparation")
+    }
+
+    fn prepare_plugin(
+        &mut self,
+        source: &HistorySourcePluginSource,
+        reset_cursor: bool,
+    ) -> Result<ProviderSource> {
+        self.preparations += 1;
+        Ok(
+            prepare_source_backed_history_source(source.clone(), reset_cursor)?
+                .provider_source()
+                .clone(),
+        )
+    }
+
+    fn admit_exact(
+        &mut self,
+        _: &Path,
+        _: &ProviderSource,
+        _: Option<&Path>,
+    ) -> Result<ExplicitSourceCatalogUpsert> {
+        self.admissions += 1;
+        bail!("test stopped at source admission")
+    }
+
+    fn source_failure_identity(&self, _: &ProviderSource) -> Result<String> {
+        panic!("plugin preflight must not resolve a refresh failure")
+    }
+
+    fn refresh(
+        &mut self,
+        _: &Path,
+        _: RefreshSelection,
+        _: bool,
+        _: &mut ProgressReporter<'_>,
+    ) -> Result<IngestPublication> {
+        panic!("plugin preflight must not reach refresh")
+    }
+}
+
+struct Config;
+
+impl HistoryConfigSnapshotPort for Config {
+    fn snapshot(&self) -> HistoryCliConfig {
+        HistoryCliConfig {
+            daemon_enabled: false,
+            semantic_search_enabled: false,
+            semantic_executor: Default::default(),
+            local_usage_enabled: false,
+            automatic_provider_discovery: false,
+            provider_roots: Vec::new(),
+        }
+    }
+}
+
+#[test]
+fn plugin_header_rejection_precedes_source_admission_and_refresh() {
+    let temp = tempfile::tempdir().unwrap();
+    let source_path = temp.path().join("history.jsonl");
+    let manifest_path = temp.path().join("ctx-history-plugin.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "schema_version":1,"name":"example","history_sources":[{
+                "id":"default","source_format":"example-v1","path":source_path
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let request = ImportRequest {
+        provider: None,
+        path: None,
+        relocate_from: None,
+        history_source: None,
+        history_source_manifests: vec![manifest_path],
+        reset_cursor: false,
+        input_format: None,
+        all: false,
+        resume: false,
+        no_daemon: true,
+        format: OutputFormat::Json,
+        progress: ProgressMode::None,
+    };
+    let mut host = ImportHost::default();
+    let mut ui = Ui::with_writers(
+        io::sink(),
+        RenderContext::for_test(TestContext::pipe(StreamKind::Stdout)),
+        io::sink(),
+        RenderContext::for_test(TestContext::pipe(StreamKind::Stderr)),
+    );
+    fs::write(&source_path, vec![b' '; 2 * MAX_HEADER_BYTES]).unwrap();
+    let error = run_import_application(
+        request.clone(),
+        &temp.path().join("ctx-data"),
+        Some(temp.path().into()),
+        &Config,
+        &mut host,
+        &mut ui,
+    )
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("header exceeds the bounded validation window"),
+        "{error:#}"
+    );
+    assert_eq!((host.preparations, host.admissions), (1, 0));
+
+    fs::write(&source_path, concat!(
+        "{\"record_type\":\"manifest\",\"schema_version\":\"ctx-history-jsonl-v2\"}\n",
+        "{\"record_type\":\"source\",\"provider_key\":\"example\",\"source_id\":\"default\",\"source_format\":\"example-v1\"}\n",
+    )).unwrap();
+    let error = run_import_application(
+        request,
+        &temp.path().join("ctx-data"),
+        Some(temp.path().into()),
+        &Config,
+        &mut host,
+        &mut ui,
+    )
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("test stopped at source admission"),
+        "{error:#}"
+    );
+    assert_eq!((host.preparations, host.admissions), (2, 1));
+}

--- a/crates/ctx-history-ingest-application/tests/contracts/history_source_plugins.rs
+++ b/crates/ctx-history-ingest-application/tests/contracts/history_source_plugins.rs
@@ -269,6 +269,33 @@ fn all_rejected_plugin_fails_even_when_unrelated_history_is_retained() {
 }
 
 #[test]
+fn oversized_plugin_header_is_rejected_without_core_publication() {
+    let temp = tempdir();
+    let (manifest_dir, source_path) = write_durable_plugin(&temp);
+    fs::write(&source_path, vec![b' '; 2 * 1024 * 1024]).unwrap();
+
+    let error = failure_stderr(
+        ctx(&temp).timeout(Duration::from_secs(20)).args([
+            "import",
+            "--history-source-manifest",
+            manifest_dir
+                .join("ctx-history-plugin.json")
+                .to_str()
+                .unwrap(),
+            "--no-daemon",
+            "--progress",
+            "none",
+        ]),
+    );
+    assert!(
+        error.contains("header exceeds the bounded validation window"),
+        "{error}"
+    );
+    assert!(!data_root(&temp).join("search/lexical").exists());
+    assert_eq!(fs::metadata(source_path).unwrap().len(), 2 * 1024 * 1024);
+}
+
+#[test]
 fn durable_plugin_manifest_rejects_command_runtime_options() {
     let temp = tempdir();
     let (manifest_dir, _) = write_durable_plugin(&temp);


### PR DESCRIPTION
History-source imports could buffer an entire oversized header line before
rejecting it. Cap each read at the smaller of the remaining 1 MiB header
budget and the 256 KiB line budget, plus one byte to detect overflow. Rejection
stops reading immediately; a valid early header still permits a large export.

Counting-reader tests exercise the production validation loop, including exact
and overflowing line/total boundaries, EOF, and an early header with an 8 MiB
body. Application-port and CLI tests verify rejection before source admission
and without Core publication.

Validation: the old loop failed the two byte-consumption regressions while 215
CLI unit cases passed. With the cap, all 217 CLI units, four request-parity
cases, and five plugin CLI contracts passed. The oversized-line case now
consumes 262,145 bytes, with at most one fixed buffer of physical prefetch.
The retained history CLI Cargo, Bazel, and source boundary check also passed.
All 78 normal graph-selected targets passed across preserved admitted runs.
The SDK package passed its exact default-Debug retry; an upgrade fixture retry
passed after removing the artifact harness's global semantic-runtime override.
Both original failures and the environment-only correction are retained in the
validation packet; no product assertions or source were changed for those retries.
