### PR TITLE
Preserve JSON payloads, retry errors, and literal queries in six SDKs

### DIFF
--- a/contracts/agent-history-v1/README.md
+++ b/contracts/agent-history-v1/README.md
@@ -87,6 +87,8 @@ Important reusable records:
   `structuredContent` and activity capture values are opaque JSON: keys,
   explicit nulls, arrays, and distinct snake/camel spellings remain unchanged.
   An absent `structuredContent` differs from a present JSON null.
+  Swift retains [compatibility limitations](../../sdks/swift/README.md#compatibility-limitations)
+  for `activity` and `structuredContent` preservation.
 - `McpToolCall`: projection-independent MCP server/tool attribution.
 - `McpExchange`: optional content-governed invocation/response capture. Its
   closed camelCase envelope retains JSON arguments and response payloads as JSON
@@ -106,6 +108,7 @@ Important reusable records:
   and preserve `retryable`. Language-specific broad SDK codes remain separate
   from the producer's code. Non-JSON diagnostics use the process-error fallback;
   adapters do not retry automatically.
+  Swift retains the [legacy producer-error behavior](../../sdks/swift/README.md#compatibility-limitations).
 
 ## CLI Adapter Mapping
 
@@ -119,6 +122,10 @@ them into `agent-history-v1` wrappers:
 - `ctx search <query>|--term <term>|--file <path> --format json`
 - `ctx show event ... --format json`
 - `ctx show session ... --format json`
+
+Rust, TypeScript, Python, Go, JVM and .NET adapters place a supplied query after
+`--`, with all options before it. Swift retains
+[legacy search argument construction](../../sdks/swift/README.md#compatibility-limitations).
 
 This mapping is an adapter detail. SDK consumers should depend on
 `agent-history-v1`, not on CLI rendering or SQLite storage.

--- a/contracts/agent-history-v1/README.md
+++ b/contracts/agent-history-v1/README.md
@@ -6,8 +6,9 @@ than a mirror of ctx storage internals.
 
 The contract supports two backends:
 
-- `local`: shells out to a local `ctx` CLI and never performs network calls,
-  provider API calls, or transcript uploads.
+- `local`: invokes a local `ctx` CLI. The CLI honors explicitly configured
+  external semantic execution, which can send bounded query text and document
+  chunks to the selected executor.
 - `hosted`: reserved for a future hosted ctx API. Current SDKs accept hosted
   configuration but return a structured `not_supported` error for operations.
 
@@ -39,8 +40,9 @@ All operations return JSON objects with `contractVersion: "agent-history-v1"` an
 
 ## Privacy
 
-Local mode is local-first. SDKs must not make network calls in local mode and
-must not upload transcript content. CLI stderr progress can contain local paths
+The local SDK adapter invokes `ctx`; it makes no provider API calls or transcript
+uploads of its own. The CLI honors explicitly configured external semantic
+execution. CLI stderr progress can contain local paths
 and is not included in successful SDK responses unless a language exposes it as
 debug metadata outside this contract.
 

--- a/contracts/agent-history-v1/README.md
+++ b/contracts/agent-history-v1/README.md
@@ -80,6 +80,11 @@ Important reusable records:
 - `CoreContentMetadata`: whether a shown event has complete Core content, the
   selected/redacted/omitted policy status, and an optional policy reason. `text`
   is the only textual body; there is no alternate `preview` body.
+- Shown events retain `activity` as the versioned, literal Core JSON envelope,
+  including its original inner field names and typed provider call identity.
+  `structuredContent` and activity capture values are opaque JSON: keys,
+  explicit nulls, arrays, and distinct snake/camel spellings remain unchanged.
+  An absent `structuredContent` differs from a present JSON null.
 - `McpToolCall`: projection-independent MCP server/tool attribution.
 - `McpExchange`: optional content-governed invocation/response capture. Its
   closed camelCase envelope retains JSON arguments and response payloads as JSON
@@ -94,7 +99,11 @@ Important reusable records:
   when Core retained the provider-owned session identity. For Codex, this is
   the resume UUID used by Codex tooling.
 - Structured error: `code`, `message`, `retryable`, optional `details`, and
-  optional `cause`.
+  optional `cause`. CLI/MCP producer errors retain their original object in
+  `details.producerError`, including `error_code`, `failure_kind`, and `detail`,
+  and preserve `retryable`. Language-specific broad SDK codes remain separate
+  from the producer's code. Non-JSON diagnostics use the process-error fallback;
+  adapters do not retry automatically.
 
 ## CLI Adapter Mapping
 

--- a/contracts/agent-history-v1/fixtures/cli/opaque-event.json
+++ b/contracts/agent-history-v1/fixtures/cli/opaque-event.json
@@ -1,0 +1,93 @@
+{
+  "ctx_event_id": "event-1",
+  "ctx_session_id": "session-1",
+  "text": "body",
+  "structured_content": {
+    "customer_id": 7,
+    "customerId": 9,
+    "target": "orders",
+    "optional": null,
+    "schema_version": "api-v2",
+    "record_type": "audit",
+    "config_path": "settings.json",
+    "__proto__": {
+      "literal_key": true
+    },
+    "items": [
+      null,
+      {
+        "snake_key": null
+      },
+      "雪"
+    ]
+  },
+  "activity": {
+    "revision": 1,
+    "provider_call_id": {
+      "Utf8": "call-1"
+    },
+    "invocation": {
+      "tool": "lookup",
+      "arguments": {
+        "capture_status": "present",
+        "value": {
+          "customer_id": 7,
+          "customerId": 9,
+          "target": "orders",
+          "optional": null,
+          "schema_version": "api-v2",
+          "record_type": "audit",
+          "config_path": "settings.json",
+          "__proto__": {
+            "literal_key": true
+          },
+          "items": [
+            null,
+            {
+              "snake_key": null
+            },
+            "雪"
+          ]
+        }
+      }
+    },
+    "result": {
+      "status": "ok",
+      "text": {
+        "capture_status": "absent"
+      },
+      "structured_content": {
+        "capture_status": "present",
+        "value": {
+          "customer_id": 7,
+          "customerId": 9,
+          "target": "orders",
+          "optional": null,
+          "schema_version": "api-v2",
+          "record_type": "audit",
+          "config_path": "settings.json",
+          "__proto__": {
+            "literal_key": true
+          },
+          "items": [
+            null,
+            {
+              "snake_key": null
+            },
+            "雪"
+          ]
+        }
+      }
+    },
+    "facts": [
+      {
+        "kind": "provider_disposition",
+        "value": "literal"
+      }
+    ]
+  },
+  "content": {
+    "complete": true,
+    "policy_status": "selected"
+  }
+}

--- a/contracts/agent-history-v1/fixtures/cli/producer-errors.json
+++ b/contracts/agent-history-v1/fixtures/cli/producer-errors.json
@@ -1,0 +1,42 @@
+[
+  {
+    "error_code": "generation_changed",
+    "failure_kind": "active_generation_race",
+    "retryable": true,
+    "detail": "producer detail",
+    "error": "generation_changed",
+    "extra": {
+      "snake_key": null
+    }
+  },
+  {
+    "error_code": "semantic_executor_unavailable",
+    "failure_kind": "executor_unavailable",
+    "retryable": true,
+    "detail": "producer detail",
+    "error": "semantic_executor_unavailable",
+    "extra": {
+      "snake_key": null
+    }
+  },
+  {
+    "error_code": "cursor_stale",
+    "failure_kind": "stale",
+    "retryable": false,
+    "detail": "producer detail",
+    "error": "cursor_stale",
+    "extra": {
+      "snake_key": null
+    }
+  },
+  {
+    "error_code": "not_found",
+    "failure_kind": "missing_event",
+    "retryable": false,
+    "detail": "producer detail",
+    "error": "not_found",
+    "extra": {
+      "snake_key": null
+    }
+  }
+]

--- a/contracts/agent-history-v1/schema.json
+++ b/contracts/agent-history-v1/schema.json
@@ -272,6 +272,9 @@
         "text": { "type": ["string", "null"] },
         "mcpToolCall": { "$ref": "#/$defs/mcpToolCall" },
         "mcpExchange": { "$ref": "#/$defs/mcpExchange" },
+        "activity": {
+          "description": "Optional versioned Core activity JSON. Preserve its original inner keys and captured values, including explicit nulls."
+        },
         "structuredContent": {
           "description": "Optional Core structured content. Any JSON value, including null, is preserved without a narrowed SDK-specific schema."
         },

--- a/crates/ctx-cli-presentation/src/commands/search.rs
+++ b/crates/ctx-cli-presentation/src/commands/search.rs
@@ -369,6 +369,28 @@ mod tests {
         search: SearchArgs,
     }
 
+    #[test]
+    fn literal_query_terminator_preserves_configured_search_options() {
+        for query in ["--help", "--refresh=off", "-needle", "two words", "a'雪"] {
+            let parsed = TestCli::try_parse_from([
+                "ctx",
+                "--session",
+                "session-1",
+                "--refresh",
+                "off",
+                "--term=--help",
+                "--",
+                query,
+            ])
+            .unwrap()
+            .search;
+            assert_eq!(parsed.query.as_deref(), Some(query));
+            assert_eq!(parsed.session.as_deref(), Some("session-1"));
+            assert_eq!(parsed.term, ["--help"]);
+            assert!(matches!(parsed.refresh, CliRefreshArg::Off));
+        }
+    }
+
     fn telemetry() -> SearchTelemetry {
         SearchTelemetry {
             has_query: true,

--- a/crates/ctx-history-cli/src/source_index/render.rs
+++ b/crates/ctx-history-cli/src/source_index/render.rs
@@ -153,7 +153,7 @@ fn search_result_commands(
             }
             if !query_arguments.is_empty() {
                 suggested_next_commands.push(format!(
-                    "{command_prefix} search {query_arguments} --session {session_id}"
+                    "{command_prefix} search --session {session_id} {query_arguments}"
                 ));
             }
             ctx_history_read_application::SearchResultCommands {
@@ -186,11 +186,11 @@ fn semantic_fallback_detail(
 
 fn search_query_command_arguments(query: &NormalizedSearchQuery) -> String {
     let mut arguments = Vec::new();
-    if let Some(positional) = query.positional() {
-        arguments.push(shell_quote_arg(positional));
-    }
     for term in query.terms() {
         arguments.push(format!("--term={}", shell_quote_arg(term)));
+    }
+    if let Some(positional) = query.positional() {
+        arguments.push(format!("-- {}", shell_quote_arg(positional)));
     }
     arguments.join(" ")
 }

--- a/crates/ctx-history-cli/src/source_index/tests.rs
+++ b/crates/ctx-history-cli/src/source_index/tests.rs
@@ -720,7 +720,11 @@ fn search_schema_v1_snapshot_reads_snippets_and_citations_from_core() {
             format!(
                 r#"ctx --data-root '/tmp/ctx root/owner'\''s history' search --session {} --term='term with spaces' -- {}"#,
                 result["ctx_session_id"].as_str().unwrap(),
-                query,
+                if query.contains('=') {
+                    format!("'{query}'")
+                } else {
+                    query.to_owned()
+                },
             )
         );
     }

--- a/crates/ctx-history-cli/src/source_index/tests.rs
+++ b/crates/ctx-history-cli/src/source_index/tests.rs
@@ -697,7 +697,7 @@ fn search_schema_v1_snapshot_reads_snippets_and_citations_from_core() {
             result["ctx_session_id"].as_str().unwrap()
         )
     );
-    for query in ["--help", "--refresh=off", "-needle"] {
+    for query in ["--help", "--refresh=off", "-needle", "two words", "a'雪"] {
         source_request.query = query.to_owned();
         let value = search_json(
             &source_request,
@@ -715,18 +715,39 @@ fn search_schema_v1_snapshot_reads_snippets_and_citations_from_core() {
             std::time::Duration::ZERO,
         )
         .unwrap();
-        assert_eq!(
-            value["results"][0]["suggested_next_commands"][2],
-            format!(
-                r#"ctx --data-root '/tmp/ctx root/owner'\''s history' search --session {} --term='term with spaces' -- {}"#,
-                result["ctx_session_id"].as_str().unwrap(),
-                if query.contains('=') {
-                    format!("'{query}'")
-                } else {
-                    query.to_owned()
-                },
-            )
-        );
+        #[cfg(unix)]
+        {
+            // Execute the generated POSIX command with a test-only ctx function.
+            // NUL-delimited argv preserves spaces and apostrophes without calling ctx.
+            let command = value["results"][0]["suggested_next_commands"][2]
+                .as_str()
+                .unwrap();
+            let output = std::process::Command::new("/bin/sh")
+                .arg("-c")
+                .arg(format!(r#"ctx() {{ printf '%s\0' "$@"; }}; {command}"#))
+                .output()
+                .unwrap();
+            assert!(output.status.success());
+            let argv = String::from_utf8(output.stdout).unwrap();
+            assert_eq!(
+                argv.strip_suffix('\0')
+                    .unwrap()
+                    .split('\0')
+                    .collect::<Vec<_>>(),
+                [
+                    "--data-root",
+                    follow_up_root.to_str().unwrap(),
+                    "search",
+                    "--session",
+                    result["ctx_session_id"].as_str().unwrap(),
+                    "--term=term with spaces",
+                    "--",
+                    query,
+                ]
+            );
+        }
+        #[cfg(not(unix))]
+        let _ = value;
     }
 }
 

--- a/crates/ctx-history-cli/src/source_index/tests.rs
+++ b/crates/ctx-history-cli/src/source_index/tests.rs
@@ -621,7 +621,7 @@ fn search_schema_v1_snapshot_reads_snippets_and_citations_from_core() {
         &EventSearchFilters::default(),
         &[fixture_search_presentation(
             &collection.result_window.hits[0].event,
-            core_event,
+            core_event.clone(),
             false,
         )],
         "existing_generation",
@@ -693,10 +693,37 @@ fn search_schema_v1_snapshot_reads_snippets_and_citations_from_core() {
     assert_eq!(
         result["suggested_next_commands"][2],
         format!(
-            r#"ctx --data-root '/tmp/ctx root/owner'\''s history' search 'primary query' --term='term with spaces' --session {}"#,
+            r#"ctx --data-root '/tmp/ctx root/owner'\''s history' search --session {} --term='term with spaces' -- 'primary query'"#,
             result["ctx_session_id"].as_str().unwrap()
         )
     );
+    for query in ["--help", "--refresh=off", "-needle"] {
+        source_request.query = query.to_owned();
+        let value = search_json(
+            &source_request,
+            follow_up_root,
+            &index,
+            &collection,
+            &EventSearchFilters::default(),
+            &[fixture_search_presentation(
+                &collection.result_window.hits[0].event,
+                core_event.clone(),
+                false,
+            )],
+            "existing_generation",
+            1,
+            std::time::Duration::ZERO,
+        )
+        .unwrap();
+        assert_eq!(
+            value["results"][0]["suggested_next_commands"][2],
+            format!(
+                r#"ctx --data-root '/tmp/ctx root/owner'\''s history' search --session {} --term='term with spaces' -- {}"#,
+                result["ctx_session_id"].as_str().unwrap(),
+                query,
+            )
+        );
+    }
 }
 
 #[test]

--- a/crates/ctx-history-read-application/tests/support/search_show/search_flows.rs
+++ b/crates/ctx-history-read-application/tests/support/search_show/search_flows.rs
@@ -296,7 +296,10 @@ fn fresh_home_search_mvp_flow() {
     assert!(verbose_search.contains("Retrieval score"));
     assert!(verbose_search.contains(" show session "));
     assert!(verbose_search.contains(" show event "));
-    assert!(verbose_search.contains(" search onboarding --session"));
+    assert!(
+        verbose_search.contains(&format!(" search --session {ctx_session_id} -- onboarding")),
+        "{verbose_search}"
+    );
     assert!(!human_search.contains("work_record"));
     assert!(!human_search.contains("history_record"));
 

--- a/crates/ctx-protocol/src/lib.rs
+++ b/crates/ctx-protocol/src/lib.rs
@@ -656,7 +656,11 @@ struct AgentHistoryEventWire {
         skip_serializing_if = "Option::is_none"
     )]
     mcp_exchange: Option<McpExchange>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_present_json",
+        skip_serializing_if = "Option::is_none"
+    )]
     structured_content: Option<Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     content: Option<CoreContentMetadata>,
@@ -664,6 +668,12 @@ struct AgentHistoryEventWire {
     citations: Vec<Citation>,
     #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
     extra: JsonObject,
+}
+
+fn deserialize_present_json<'de, D: serde::Deserializer<'de>>(
+    decoder: D,
+) -> Result<Option<Value>, D::Error> {
+    Value::deserialize(decoder).map(Some)
 }
 
 impl AgentHistoryEvent {
@@ -869,6 +879,17 @@ pub fn camelize_object_keys(value: &Value) -> Value {
         }
         _ => value.clone(),
     }
+}
+
+/// Converts only the ctx-owned outer keys, leaving values opaque.
+pub fn camelize_envelope_keys(object: &Map<String, Value>) -> Map<String, Value> {
+    object
+        .iter()
+        .filter_map(|(key, value)| {
+            let key = snake_to_camel(key);
+            (!omitted_public_key(&key)).then(|| (key, value.clone()))
+        })
+        .collect()
 }
 
 fn omitted_public_key(key: &str) -> bool {

--- a/crates/ctx-protocol/src/tests.rs
+++ b/crates/ctx-protocol/src/tests.rs
@@ -503,3 +503,23 @@ fn camelizes_private_cli_keys_recursively() {
     assert_eq!(camel["results"][0]["citations"][0]["targetType"], "event");
     assert_eq!(camel["results"][0]["sourceFormat"], "codex_session_jsonl");
 }
+
+#[test]
+fn event_structured_json_preserves_present_null() {
+    for source in [
+        serde_json::json!({"structuredContent":null}),
+        serde_json::json!({}),
+    ] {
+        let event: AgentHistoryEvent = serde_json::from_value(source.clone()).unwrap();
+        assert_eq!(
+            event.structured_content.as_ref(),
+            source.get("structuredContent")
+        );
+        assert_eq!(
+            serde_json::to_value(event)
+                .unwrap()
+                .get("structuredContent"),
+            source.get("structuredContent")
+        );
+    }
+}

--- a/crates/ctx-sdk/README.md
+++ b/crates/ctx-sdk/README.md
@@ -22,8 +22,9 @@ let results = client.search(SearchOptions {
 
 ## Backends
 
-- Local backend: shells out to `ctx` JSON commands and never performs network
-  calls or provider API calls.
+- Local backend: invokes `ctx` JSON commands. The CLI honors explicitly
+  configured external semantic execution, which can send bounded semantic text
+  to the selected executor. See [SDK locality](../../docs/sdks.md#local-and-hosted-backends).
 - Hosted backend: Hosted SDK placeholders are deprecated and will be removed in
   the next breaking SDK revision; hosted operations remain unsupported. Valid
   operations continue to return a structured `not_supported` error.

--- a/crates/ctx-sdk/src/lib.rs
+++ b/crates/ctx-sdk/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-use ctx_protocol::{camel_alias_object, camelize_object_keys, JsonObject};
+use ctx_protocol::{camel_alias_object, camelize_envelope_keys, camelize_object_keys, JsonObject};
 pub use ctx_protocol::{
     AgentHistoryEnvelope, AgentHistoryErrorBody, AgentHistoryErrorCode, AgentHistoryEvent,
     AgentHistoryOperation, AgentHistoryStatus, BackendInfo, BackendKind, CoreContentMetadata,
@@ -26,7 +26,9 @@ use serde_json::{json, Map, Value};
 use thiserror::Error;
 
 mod exact_json;
+mod producer_error;
 mod subprocess;
+use producer_error::{cli_failure, structured_producer_error};
 
 #[cfg(test)]
 use exact_json::decode_json_value_exact;
@@ -321,12 +323,8 @@ impl AgentHistoryClient {
         }
         let mut owned = Vec::<String>::new();
         owned.push("search".to_owned());
-        if let Some(query) = options.query {
-            owned.push(query);
-        }
         for term in options.terms {
-            owned.push("--term".to_owned());
-            owned.push(term);
+            push_opt(&mut owned, "--term", Some(term));
         }
         owned.extend(["--limit".to_owned(), options.limit.to_string()]);
         push_opt(&mut owned, "--backend", options.backend);
@@ -362,6 +360,9 @@ impl AgentHistoryClient {
             owned.push("--include-current-session".to_owned());
         }
         owned.push("--format=json".to_owned());
+        if let Some(query) = options.query {
+            owned.extend(["--".to_owned(), query]);
+        }
         self.local_json_owned(AgentHistoryOperation::Search, owned)
     }
 
@@ -488,8 +489,12 @@ impl AgentHistoryClient {
 
 fn push_opt(args: &mut Vec<String>, name: &str, value: Option<String>) {
     if let Some(value) = value {
-        args.push(name.to_owned());
-        args.push(value);
+        if value.starts_with('-') {
+            args.push(format!("{name}={value}"));
+        } else {
+            args.push(name.to_owned());
+            args.push(value);
+        }
     }
 }
 
@@ -586,11 +591,7 @@ fn run_ctx_mcp_show_session(
     let output = collect_ctx_mcp_output(child, stdin_bytes, config.timeout)?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(AgentHistoryError::new(
-            classify_stderr(&stderr),
-            stderr.trim().to_owned(),
-            false,
-        ));
+        return Err(cli_failure(&stderr));
     }
     let response = output.tool_response.ok_or_else(|| {
         AgentHistoryError::new(
@@ -619,6 +620,9 @@ fn run_ctx_mcp_show_session(
             .get("structuredContent")
             .cloned()
             .unwrap_or(Value::Null);
+        if let Some(error) = structured_producer_error(&structured) {
+            return Err(error);
+        }
         let message = structured
             .get("error")
             .and_then(Value::as_str)
@@ -768,13 +772,13 @@ fn normalize_event(raw: &Value) -> Result<EventResult, AgentHistoryError> {
 fn normalize_session(raw: &Value) -> Result<SessionResult, AgentHistoryError> {
     let events = normalize_event_records(raw.get("events").unwrap_or(&Value::Null))?;
     let value = json!({
-        "session": raw.get("session").cloned(),
+        "session": raw.get("session").map(camelize_object_keys),
         "events": events,
         "mode": raw.get("mode").cloned(),
         "format": raw.get("format").cloned(),
-        "pagination": raw.get("pagination").cloned()
+        "pagination": raw.get("pagination").map(camelize_object_keys)
     });
-    decode_payload(camelize_object_keys(&value), "session")
+    decode_payload(value, "session")
 }
 
 fn normalize_event_records(raw: &Value) -> Result<Value, AgentHistoryError> {
@@ -812,11 +816,12 @@ fn normalize_event_record(raw: &Value) -> Result<Value, AgentHistoryError> {
     outer.remove("mcpToolCall");
     outer.remove("mcp_exchange");
     outer.remove("mcpExchange");
-    let Value::Object(mut normalized) = camelize_object_keys(&Value::Object(outer)) else {
-        return Err(invalid_mcp_wire(
-            "event normalization did not produce an object",
-        ));
-    };
+    let mut normalized = camelize_envelope_keys(&outer);
+    for key in ["content", "citations"] {
+        if let Some(value) = normalized.get_mut(key) {
+            *value = camelize_object_keys(value);
+        }
+    }
     if normalized.contains_key("mcpToolCall") {
         return Err(invalid_mcp_wire(
             "outer member collides with the canonical mcpToolCall key",

--- a/crates/ctx-sdk/src/producer_error.rs
+++ b/crates/ctx-sdk/src/producer_error.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+pub(super) fn structured_producer_error(value: &Value) -> Option<AgentHistoryError> {
+    let code = value
+        .get("error_code")?
+        .as_str()
+        .filter(|code| !code.is_empty())?;
+    let retryable = match value.get("retryable") {
+        Some(value) => value.as_bool()?,
+        None => false,
+    };
+    let broad_code = serde_json::from_value(Value::String(code.to_owned()))
+        .unwrap_or(AgentHistoryErrorCode::AdapterError);
+    let message = value
+        .get("detail")
+        .and_then(Value::as_str)
+        .or_else(|| value.get("error").and_then(Value::as_str))
+        .unwrap_or(code);
+    let mut error = AgentHistoryError::new(broad_code, message, retryable);
+    error.body.details = Some(BTreeMap::from([(
+        "producerError".to_owned(),
+        value.clone(),
+    )]));
+    Some(error)
+}
+
+pub(super) fn cli_failure(stderr: &str) -> AgentHistoryError {
+    exact_json::parse_json_value_exact(stderr.as_bytes())
+        .ok()
+        .and_then(|value| structured_producer_error(&value))
+        .unwrap_or_else(|| AgentHistoryError::new(classify_stderr(stderr), stderr.trim(), false))
+        .with_cause(stderr)
+}

--- a/crates/ctx-sdk/src/subprocess.rs
+++ b/crates/ctx-sdk/src/subprocess.rs
@@ -12,9 +12,7 @@ use std::os::windows::process::CommandExt as _;
 
 use serde_json::Value;
 
-use super::{
-    classify_stderr, exact_json::parse_json_value_exact, AgentHistoryError, AgentHistoryErrorCode,
-};
+use super::{exact_json::parse_json_value_exact, AgentHistoryError, AgentHistoryErrorCode};
 
 #[cfg(windows)]
 mod windows;
@@ -186,11 +184,7 @@ pub(super) fn collect_ctx_json(
     };
     if !status.success() {
         let stderr = String::from_utf8_lossy(&stderr);
-        return Err(AgentHistoryError::new(
-            classify_stderr(&stderr),
-            stderr.trim().to_owned(),
-            false,
-        ));
+        return Err(super::cli_failure(&stderr));
     }
 
     match stdout.map_err(|_| {

--- a/crates/ctx-sdk/src/tests.rs
+++ b/crates/ctx-sdk/src/tests.rs
@@ -860,3 +860,6 @@ fn local_json_timeout_kills_and_reaps_the_child() {
 }
 
 mod additional;
+
+#[cfg(unix)]
+mod fidelity;

--- a/crates/ctx-sdk/src/tests/additional.rs
+++ b/crates/ctx-sdk/src/tests/additional.rs
@@ -611,7 +611,6 @@ exit 2
         argv,
         vec![
             "search",
-            "agent history",
             "--limit",
             "7",
             "--backend",
@@ -624,6 +623,8 @@ exit 2
             "--refresh",
             "off",
             "--format=json",
+            "--",
+            "agent history",
         ]
     );
 
@@ -642,7 +643,6 @@ exit 2
         argv.lines().collect::<Vec<_>>(),
         vec![
             "search",
-            "agent history",
             "--limit",
             "4",
             "--event-type",
@@ -650,6 +650,8 @@ exit 2
             "--refresh",
             "wait",
             "--format=json",
+            "--",
+            "agent history",
         ]
     );
 }

--- a/crates/ctx-sdk/src/tests/fidelity.rs
+++ b/crates/ctx-sdk/src/tests/fidelity.rs
@@ -1,0 +1,125 @@
+use super::*;
+
+fn event_fixture() -> Value {
+    serde_json::from_str(include_str!(
+        "../../../../contracts/agent-history-v1/fixtures/cli/opaque-event.json"
+    ))
+    .unwrap()
+}
+
+fn fixture_client(root: &Path, raw: &Value, mcp: bool, is_error: bool) -> AgentHistoryClient {
+    let output = if mcp {
+        json!({"jsonrpc":"2.0","id":2,"result":{"isError":is_error,"structuredContent":raw}})
+    } else {
+        raw.clone()
+    };
+    fs::write(root.join("response.json"), output.to_string()).unwrap();
+    let script = root.join("ctx-fixture");
+    let body = if mcp {
+        "cat >/dev/null\ncat \"$CTX_DATA_ROOT/response.json\""
+    } else if is_error {
+        "cat \"$CTX_DATA_ROOT/response.json\" >&2\nexit 1"
+    } else {
+        "printf '%s\\n' \"$@\" > \"$CTX_DATA_ROOT/argv\"\ncat \"$CTX_DATA_ROOT/response.json\""
+    };
+    fs::write(&script, format!("#!/bin/sh\nset -eu\n{body}\n")).unwrap();
+    make_test_executable(&script);
+    AgentHistoryClient::local(LocalBackendConfig {
+        ctx_binary: script,
+        data_root: Some(root.to_owned()),
+        env: BTreeMap::new(),
+        timeout: Duration::from_secs(10),
+    })
+}
+
+#[test]
+fn current_payloads_survive_complete_and_paged_public_operations() {
+    let temp = tempfile::tempdir().unwrap();
+    let fixture = event_fixture();
+    for content in [
+        Some(fixture["structured_content"].clone()),
+        Some(Value::Null),
+        None,
+    ] {
+        let mut event = fixture.clone();
+        event.as_object_mut().unwrap().remove("structured_content");
+        if let Some(value) = &content {
+            event["structured_content"] = value.clone();
+        }
+        let raw = json!({"event":event,"events":[event],"session":{"ctx_session_id":"session-1"}});
+        for paged in [false, true] {
+            let client = fixture_client(temp.path(), &raw, paged, false);
+            let options = ShowSessionOptions {
+                limit: paged.then_some(1),
+                ..Default::default()
+            };
+            let response = client.show_session("session-1", options).unwrap();
+            let actual = &response.session.unwrap().events[0];
+            assert_eq!(actual.structured_content, content);
+            assert_eq!(actual.extra["activity"], fixture["activity"]);
+            let encoded = serde_json::to_value(actual).unwrap();
+            assert_eq!(encoded.get("structuredContent"), content.as_ref());
+            if !paged {
+                let actual = client
+                    .show_event("event-1", Default::default())
+                    .unwrap()
+                    .event
+                    .unwrap()
+                    .event
+                    .unwrap();
+                assert_eq!(actual.structured_content, content);
+                assert_eq!(actual.extra["activity"], fixture["activity"]);
+            }
+        }
+    }
+}
+
+#[test]
+fn typed_errors_survive_cli_and_mcp() {
+    let errors: Vec<Value> = serde_json::from_str(include_str!(
+        "../../../../contracts/agent-history-v1/fixtures/cli/producer-errors.json"
+    ))
+    .unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    for producer in errors {
+        for mcp in [false, true] {
+            let client = fixture_client(temp.path(), &producer, mcp, true);
+            let result = if mcp {
+                client.show_session(
+                    "session-1",
+                    ShowSessionOptions {
+                        limit: Some(1),
+                        ..Default::default()
+                    },
+                )
+            } else {
+                client.show_event("event-1", Default::default())
+            };
+            let error = result.unwrap_err();
+            assert_eq!(
+                error.body.retryable,
+                producer["retryable"].as_bool().unwrap()
+            );
+            assert_eq!(error.body.details.unwrap()["producerError"], producer);
+        }
+    }
+}
+
+#[test]
+fn literal_search_query_follows_all_options() {
+    let temp = tempfile::tempdir().unwrap();
+    for query in ["--help", "--refresh=off", "-needle", "two words", "a'雪"] {
+        let client = fixture_client(temp.path(), &json!({"results":[]}), false, false);
+        client
+            .search(SearchOptions {
+                query: Some(query.to_owned()),
+                terms: vec!["--help".to_owned()],
+                ..Default::default()
+            })
+            .unwrap();
+        let argv = fs::read_to_string(temp.path().join("argv")).unwrap();
+        let args = argv.lines().collect::<Vec<_>>();
+        assert_eq!(&args[args.len() - 2..], &["--", query]);
+        assert!(args.contains(&"--term=--help"));
+    }
+}

--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -64,8 +64,10 @@ sessions, events, and provider-owned session IDs. For Codex,
 
 Shown events can include full-content `activity` with exact typed provider call
 identity, invocation and/or result channels, and literal provider facts. It is
-an additive event field; keys inside captured JSON arguments and structured
-results remain unchanged. See
+an additive event field carried with its original versioned inner field names;
+keys inside captured JSON arguments and structured results remain unchanged.
+`structuredContent` also preserves exact JSON, including an explicit null
+that is distinct from an absent field. See
 [`mcp-exchange-capture.md`](mcp-exchange-capture.md).
 
 ## Local and hosted backends
@@ -76,6 +78,10 @@ upload transcripts on its own. The local CLI stays on-machine with the built-in
 executor, but a search can use the network and send raw query text and eligible
 ctx-created document chunks when the data root has an explicitly selected
 external semantic executor.
+
+Typed CLI/MCP errors preserve retryability and the original producer diagnostic
+under `details.producerError`; the SDK does not retry automatically. Literal
+search queries, including `--help`, are passed as query data after CLI options.
 
 Hosted client configuration is reserved for future ctx service support. Until a
 hosted service exists, hosted operations fail before network I/O with a

--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -69,6 +69,8 @@ keys inside captured JSON arguments and structured results remain unchanged.
 `structuredContent` also preserves exact JSON, including an explicit null
 that is distinct from an absent field. See
 [`mcp-exchange-capture.md`](mcp-exchange-capture.md).
+Swift retains [compatibility limitations](../sdks/swift/README.md#compatibility-limitations)
+for `activity` and `structuredContent` preservation.
 
 ## Local and hosted backends
 
@@ -82,6 +84,7 @@ external semantic executor.
 Typed CLI/MCP errors preserve retryability and the original producer diagnostic
 under `details.producerError`; the SDK does not retry automatically. Literal
 search queries, including `--help`, are passed as query data after CLI options.
+Swift retains [legacy producer-error and search argument behavior](../sdks/swift/README.md#compatibility-limitations).
 
 Hosted client configuration is reserved for future ctx service support. Until a
 hosted service exists, hosted operations fail before network I/O with a

--- a/sdks/dotnet/README.md
+++ b/sdks/dotnet/README.md
@@ -2,8 +2,9 @@
 
 Experimental C# SDK for the `agent-history-v1` ctx contract. The SDK is local-first by
 default: it shells out to the `ctx` CLI, reads JSON from stdout, and wraps the
-result in agent-history-v1 envelopes. Local mode does not make network calls or upload
-transcripts.
+result in agent-history-v1 envelopes. The CLI honors explicitly configured
+external semantic execution, which can send bounded semantic text to the
+selected executor. See [SDK locality](../../docs/sdks.md#local-and-hosted-backends).
 
 `AgentHistoryClient.Hosted(HostedAgentHistoryConfig)` is a hosted SDK placeholder.
 Hosted SDK placeholders are deprecated and will be removed in the next breaking SDK

--- a/sdks/dotnet/src/Ctx.AgentHistory/AgentHistoryClient.cs
+++ b/sdks/dotnet/src/Ctx.AgentHistory/AgentHistoryClient.cs
@@ -73,10 +73,6 @@ public sealed class AgentHistoryClient
         RequireSearchIntent(options);
         RequireCompatibleSearchFilters(options);
         var args = new List<string> { "search" };
-        if (!string.IsNullOrWhiteSpace(options.Query))
-        {
-            args.Add(options.Query);
-        }
         foreach (var term in options.Terms ?? [])
         {
             AddOption(args, "--term", term);
@@ -112,6 +108,7 @@ public sealed class AgentHistoryClient
         }
         args.Add("--format=json");
 
+        if (options.Query is not null) { args.Add("--"); args.Add(options.Query); }
         var raw = await InvokeAsync("search", args, cancellationToken).ConfigureAwait(false);
         var envelope = AgentHistoryContract.Envelope("search", _transport.Backend(raw), "search", AgentHistoryContract.NormalizeSearch(raw));
         return new SearchResponse(envelope);
@@ -272,8 +269,8 @@ public sealed class AgentHistoryClient
     {
         if (!string.IsNullOrWhiteSpace(value))
         {
-            args.Add(flag);
-            args.Add(value);
+            if (value.StartsWith("-", StringComparison.Ordinal)) args.Add($"{flag}={value}");
+            else { args.Add(flag); args.Add(value); }
         }
     }
 

--- a/sdks/dotnet/src/Ctx.AgentHistory/AgentHistoryContract.cs
+++ b/sdks/dotnet/src/Ctx.AgentHistory/AgentHistoryContract.cs
@@ -234,10 +234,13 @@ internal static class AgentHistoryContract
             {
                 throw InvalidMcpExchangeWire($"outer member {pair.Key} collides with canonical mcpExchange");
             }
-            outer[pair.Key] = JsonHelpers.Clone(pair.Value);
+            var key = SnakeToCamel(pair.Key);
+            if (key is "schemaVersion" or "contractVersion" or "operation" or "backend" or "target" or "itemType" or "payloadType" or "recordType") continue;
+            outer[key] = pair.Key is "content" or "citations"
+                ? CamelizePublic(pair.Value) : JsonHelpers.Clone(pair.Value);
         }
 
-        var normalized = (JsonObject)CamelizePublic(outer)!;
+        var normalized = outer;
         if (hasSnake || hasCamel)
         {
             normalized["mcpToolCall"] = McpToolCall.FromJson(hasSnake ? snake : camel).ToJsonObject();

--- a/sdks/dotnet/src/Ctx.AgentHistory/Errors.cs
+++ b/sdks/dotnet/src/Ctx.AgentHistory/Errors.cs
@@ -45,12 +45,13 @@ public sealed class CtxAgentHistoryCliException : CtxAgentHistoryException
         string stderr,
         string code = "adapter_error",
         bool retryable = false,
-        Exception? innerException = null)
+        Exception? innerException = null,
+        JsonObject? producerError = null)
         : base(
             message,
             code,
             retryable: retryable,
-            details: BuildDetails(command, exitCode, stdout, stderr),
+            details: BuildDetails(command, exitCode, stdout, stderr, producerError),
             innerException)
     {
         Command = command.ToArray();
@@ -64,14 +65,15 @@ public sealed class CtxAgentHistoryCliException : CtxAgentHistoryException
     public string Stdout { get; }
     public string Stderr { get; }
 
-    private static JsonObject BuildDetails(IReadOnlyList<string> command, int exitCode, string stdout, string stderr)
+    private static JsonObject BuildDetails(IReadOnlyList<string> command, int exitCode, string stdout, string stderr, JsonObject? producerError)
     {
         return new JsonObject
         {
             ["command"] = JsonHelpers.ToJsonArray(command),
             ["exitCode"] = exitCode,
             ["stdout"] = stdout,
-            ["stderr"] = stderr
+            ["stderr"] = stderr,
+            ["producerError"] = producerError?.DeepClone()
         };
     }
 }

--- a/sdks/dotnet/src/Ctx.AgentHistory/LocalCliAdapter.cs
+++ b/sdks/dotnet/src/Ctx.AgentHistory/LocalCliAdapter.cs
@@ -222,7 +222,17 @@ public sealed class LocalCliAdapter : IAgentHistoryTransport
         if (process.ExitCode != 0)
         {
             var outText = Encoding.UTF8.GetString(stdoutBytes);
-            throw new CtxAgentHistoryCliException("ctx CLI command failed", command, process.ExitCode, outText, errText);
+            JsonObject? producer = null;
+            try
+            {
+                if (JsonNode.Parse(errText) is JsonObject candidate
+                    && candidate["error_code"] is JsonValue code && code.TryGetValue<string>(out var codeText) && codeText.Length > 0
+                    && (!candidate.ContainsKey("retryable") || candidate["retryable"] is JsonValue retry && retry.TryGetValue<bool>(out _)))
+                    producer = candidate;
+            }
+            catch (JsonException) { }
+            throw new CtxAgentHistoryCliException("ctx CLI command failed", command, process.ExitCode, outText, errText,
+                retryable: JsonHelpers.GetBool(producer ?? new JsonObject(), "retryable") ?? false, producerError: producer);
         }
         if (stdoutCapture.Truncated)
         {

--- a/sdks/dotnet/tests/Ctx.AgentHistory.Tests/Program.cs
+++ b/sdks/dotnet/tests/Ctx.AgentHistory.Tests/Program.cs
@@ -17,6 +17,11 @@ internal static class Program
 
     private static async Task<int> Main(string[] args)
     {
+        if (Environment.GetEnvironmentVariable("CTX_SDK_TEST_PRODUCER_ERROR") is { } producerError)
+        {
+            Console.Error.Write(producerError);
+            return 1;
+        }
         if (Environment.GetEnvironmentVariable(ProcessFixtureMode) is { } processFixture)
         {
             return await RunMcp289ProcessFixture(processFixture);
@@ -43,6 +48,7 @@ internal static class Program
 
         var tests = new (string Name, Func<Task> Body)[]
         {
+            ("preserves current payloads and producer errors", CurrentPayloadsAndProducerErrors),
             ("wraps status as agent-history-v1", WrapsStatus),
             ("filters status to the current readiness contract", FiltersStatusFields),
             ("preserves legitimate source semantics", PreservesLegitimateSourceSemantics),
@@ -92,6 +98,45 @@ internal static class Program
         }
 
         return failures == 0 ? 0 : 1;
+    }
+
+    private static async Task CurrentPayloadsAndProducerErrors()
+    {
+        var fixture = JsonNode.Parse(File.ReadAllText(Path.Combine(FindFixtures(), "cli/opaque-event.json")))!.AsObject();
+        for (int variant = 0; variant < 3; variant++)
+        {
+            var current = fixture.DeepClone().AsObject();
+            if (variant == 1) current["structured_content"] = null;
+            if (variant == 2) current.Remove("structured_content");
+            var raw = new JsonObject { ["event"] = current.DeepClone(), ["events"] = new JsonArray(current.DeepClone()), ["session"] = new JsonObject() };
+            var client = ClientFor(raw);
+            var single = (await client.ShowEventAsync("event-1")).Event.Event!.ToJsonObject();
+            var session = (await client.ShowSessionAsync("session-1")).Session.Events[0].ToJsonObject();
+            foreach (var actual in new[] { single, session })
+            {
+                True(JsonNode.DeepEquals(actual["activity"], fixture["activity"]), "activity changed");
+                Equal(current.ContainsKey("structured_content"), actual.ContainsKey("structuredContent"));
+                True(JsonNode.DeepEquals(actual["structuredContent"], current["structured_content"]), "structured content changed");
+            }
+        }
+        foreach (var query in new[] { "--help", "--refresh=off", "-needle", "two words", "a'雪" })
+        {
+            var transport = new RecordingTransport("{\"results\":[]}");
+            await new AgentHistoryClient(transport).SearchAsync(new SearchOptions { Query = query });
+            True(transport.Calls[0].TakeLast(2).SequenceEqual(new[] { "--", query }), "unsafe argv");
+        }
+        foreach (var producer in JsonNode.Parse(File.ReadAllText(Path.Combine(FindFixtures(), "cli/producer-errors.json")))!.AsArray())
+        {
+            var adapter = new LocalCliAdapter(new LocalAgentHistoryConfig {
+                CtxBinary = TestExecutable(), Environment = new Dictionary<string, string?> { ["CTX_SDK_TEST_PRODUCER_ERROR"] = producer!.ToJsonString() }
+            });
+            try { await new AgentHistoryClient(adapter).ShowEventAsync("event-1"); throw new Exception("expected producer failure"); }
+            catch (CtxAgentHistoryCliException error)
+            {
+                Equal(producer!["retryable"]!.GetValue<bool>(), error.Retryable);
+                True(JsonNode.DeepEquals(producer, error.Details["producerError"]), "producer detail changed");
+            }
+        }
     }
 
     private static async Task<int> RunMcp289ProcessFixture(string mode)
@@ -633,7 +678,7 @@ internal static class Program
             IncludeCurrentSession = true
         });
 
-        Equal("search retry --term timeout --term backoff --limit 5 --backend hybrid --semantic-weight 0.35 --provider codex --workspace ctx --since 30d --primary-only --event-type message --file src/lib.rs --session session-1 --events --refresh off --include-current-session --format=json", Join(transport.Calls[0]));
+        Equal("search --term timeout --term backoff --limit 5 --backend hybrid --semantic-weight 0.35 --provider codex --workspace ctx --since 30d --primary-only --event-type message --file src/lib.rs --session session-1 --events --refresh off --include-current-session --format=json -- retry", Join(transport.Calls[0]));
         Equal("search", response.Operation);
         Equal("retry", response.Search.Query ?? "");
         Equal("off", response.Search.Freshness!.Mode ?? "");

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -3,7 +3,10 @@
 Experimental Go SDK for the local `ctx` agent-history-v1 JSON contract.
 
 The SDK has no third-party dependencies and defaults to the local `ctx` CLI. It
-does not require network access or API keys.
+does not require network access or API keys with built-in semantic execution.
+The CLI honors explicitly configured external semantic execution, which can send
+bounded semantic text to the selected executor. See
+[SDK locality](../../docs/sdks.md#local-and-hosted-backends).
 
 ```go
 package main

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -164,11 +164,19 @@ func (c *Client) Search(ctx context.Context, opts SearchOptions) (*SearchRespons
 		args = append(args, "--limit", strconv.Itoa(opts.Limit))
 	}
 	for _, term := range opts.Terms {
-		if strings.HasPrefix(term, "-") { args = append(args, "--term="+term) } else { args = append(args, "--term", term) }
+		if strings.HasPrefix(term, "-") {
+			args = append(args, "--term="+term)
+		} else {
+			args = append(args, "--term", term)
+		}
 	}
 	appendStringFlag := func(name, value string) {
 		if value != "" {
-			if strings.HasPrefix(value, "-") { args = append(args, name+"="+value) } else { args = append(args, name, value) }
+			if strings.HasPrefix(value, "-") {
+				args = append(args, name+"="+value)
+			} else {
+				args = append(args, name, value)
+			}
 		}
 	}
 	appendStringFlag("--backend", opts.Backend)
@@ -192,7 +200,9 @@ func (c *Client) Search(ctx context.Context, opts SearchOptions) (*SearchRespons
 	if opts.IncludeCurrentSession {
 		args = append(args, "--include-current-session")
 	}
-	if opts.Query != "" { args = append(args, "--", opts.Query) }
+	if opts.Query != "" {
+		args = append(args, "--", opts.Query)
+	}
 	var out SearchResponse
 	if err := c.do(ctx, Operation{Name: "search", Args: args}, &out); err != nil {
 		return nil, err

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -159,19 +159,16 @@ func (c *Client) Search(ctx context.Context, opts SearchOptions) (*SearchRespons
 		return nil, sdkError(ErrorKindInvalidArgument, "search requires a query, term, or file option", nil)
 	}
 	args := []string{"search"}
-	if opts.Query != "" {
-		args = append(args, opts.Query)
-	}
 	args = append(args, "--format=json")
 	if opts.Limit > 0 {
 		args = append(args, "--limit", strconv.Itoa(opts.Limit))
 	}
 	for _, term := range opts.Terms {
-		args = append(args, "--term", term)
+		if strings.HasPrefix(term, "-") { args = append(args, "--term="+term) } else { args = append(args, "--term", term) }
 	}
 	appendStringFlag := func(name, value string) {
 		if value != "" {
-			args = append(args, name, value)
+			if strings.HasPrefix(value, "-") { args = append(args, name+"="+value) } else { args = append(args, name, value) }
 		}
 	}
 	appendStringFlag("--backend", opts.Backend)
@@ -195,6 +192,7 @@ func (c *Client) Search(ctx context.Context, opts SearchOptions) (*SearchRespons
 	if opts.IncludeCurrentSession {
 		args = append(args, "--include-current-session")
 	}
+	if opts.Query != "" { args = append(args, "--", opts.Query) }
 	var out SearchResponse
 	if err := c.do(ctx, Operation{Name: "search", Args: args}, &out); err != nil {
 		return nil, err

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -147,7 +147,7 @@ func TestSearchBuildsAgentHistoryV1Operation(t *testing.T) {
 		"--primary-only",
 		"--events",
 		"--include-current-session",
-        "--", "panic",
+		"--", "panic",
 	}
 	if !reflect.DeepEqual(transport.op.Args, want) {
 		t.Fatalf("args mismatch\nwant: %#v\n got: %#v", want, transport.op.Args)
@@ -1117,53 +1117,80 @@ func environmentValue(values []string, name string) (string, bool) {
 	return value, found
 }
 
-
 func TestCurrentOpaquePayloadsThroughClient(t *testing.T) {
-    encoded, err := os.ReadFile("../../contracts/agent-history-v1/fixtures/cli/opaque-event.json")
-    if err != nil { t.Fatal(err) }
-    var fixture map[string]json.RawMessage
-    if err := json.Unmarshal(encoded, &fixture); err != nil { t.Fatal(err) }
-    for _, content := range []json.RawMessage{fixture["structured_content"], json.RawMessage("null"), nil} {
-        event := make(map[string]json.RawMessage)
-        for key, value := range fixture { event[key] = value }
-        delete(event, "structured_content")
-        if content != nil { event["structured_content"] = content }
-        raw, _ := json.Marshal(map[string]any{"event":event,"events":[]any{event},"session":map[string]any{"ctx_session_id":"session-1"}})
-        client := NewClient(WithTransport(fakeTransport{response:string(raw)}))
-        single, err := client.ShowEvent(context.Background(), ShowEventOptions{ID:"event-1"})
-        if err != nil { t.Fatal(err) }
-        session, err := client.ShowSession(context.Background(), ShowSessionOptions{ID:"session-1"})
-        if err != nil { t.Fatal(err) }
-        for _, actual := range []*Event{single.Event.Event, &session.Session.Events[0]} {
-            var want, got any
-            json.Unmarshal(fixture["activity"], &want); json.Unmarshal(actual.Activity, &got)
-            if !reflect.DeepEqual(want, got) { t.Fatalf("activity changed: %s", actual.Activity) }
-            if (content == nil) != (actual.StructuredContent == nil) { t.Fatal("content presence changed") }
-            want, got = nil, nil
-            json.Unmarshal(content, &want); json.Unmarshal(actual.StructuredContent, &got)
-            if !reflect.DeepEqual(want, got) { t.Fatalf("content changed: %s", actual.StructuredContent) }
-        }
-    }
+	encoded, err := os.ReadFile("../../contracts/agent-history-v1/fixtures/cli/opaque-event.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fixture); err != nil {
+		t.Fatal(err)
+	}
+	for _, content := range []json.RawMessage{fixture["structured_content"], json.RawMessage("null"), nil} {
+		event := make(map[string]json.RawMessage)
+		for key, value := range fixture {
+			event[key] = value
+		}
+		delete(event, "structured_content")
+		if content != nil {
+			event["structured_content"] = content
+		}
+		raw, _ := json.Marshal(map[string]any{"event": event, "events": []any{event}, "session": map[string]any{"ctx_session_id": "session-1"}})
+		client := NewClient(WithTransport(fakeTransport{response: string(raw)}))
+		single, err := client.ShowEvent(context.Background(), ShowEventOptions{ID: "event-1"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		session, err := client.ShowSession(context.Background(), ShowSessionOptions{ID: "session-1"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, actual := range []*Event{single.Event.Event, &session.Session.Events[0]} {
+			var want, got any
+			json.Unmarshal(fixture["activity"], &want)
+			json.Unmarshal(actual.Activity, &got)
+			if !reflect.DeepEqual(want, got) {
+				t.Fatalf("activity changed: %s", actual.Activity)
+			}
+			if (content == nil) != (actual.StructuredContent == nil) {
+				t.Fatal("content presence changed")
+			}
+			want, got = nil, nil
+			json.Unmarshal(content, &want)
+			json.Unmarshal(actual.StructuredContent, &got)
+			if !reflect.DeepEqual(want, got) {
+				t.Fatalf("content changed: %s", actual.StructuredContent)
+			}
+		}
+	}
 }
 
 func TestProducerErrorsAndLiteralQueries(t *testing.T) {
-    encoded, err := os.ReadFile("../../contracts/agent-history-v1/fixtures/cli/producer-errors.json")
-    if err != nil { t.Fatal(err) }
-    var failures []map[string]any
-    json.Unmarshal(encoded, &failures)
-    for _, producer := range failures {
-        payload, _ := json.Marshal(producer)
-        adapter := NewLocalCLIAdapter()
-        adapter.runner = fakeRunner{result: commandResult{ExitCode:1, Stderr:payload}}
-        _, err := NewClient(WithTransport(adapter)).ShowEvent(context.Background(), ShowEventOptions{ID:"event-1"})
-        var typed *Error
-        if !errors.As(err, &typed) || typed.Retryable != producer["retryable"].(bool) || !reflect.DeepEqual(typed.Details["producerError"], producer) { t.Fatalf("producer error changed: %#v", err) }
-    }
-    for _, query := range []string{"--help", "--refresh=off", "-needle", "two words", "a'雪"} {
-        transport := &recordingTransport{response:`{"results":[]}`}
-        _, err := NewClient(WithTransport(transport)).Search(context.Background(), SearchOptions{Query:query, Terms:[]string{"--help"}})
-        if err != nil { t.Fatal(err) }
-        args := transport.op.Args
-        if !reflect.DeepEqual(args[len(args)-2:], []string{"--", query}) || !contains(args, "--term=--help") { t.Fatalf("unsafe argv: %#v", args) }
-    }
+	encoded, err := os.ReadFile("../../contracts/agent-history-v1/fixtures/cli/producer-errors.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var failures []map[string]any
+	json.Unmarshal(encoded, &failures)
+	for _, producer := range failures {
+		payload, _ := json.Marshal(producer)
+		adapter := NewLocalCLIAdapter()
+		adapter.runner = fakeRunner{result: commandResult{ExitCode: 1, Stderr: payload}}
+		_, err := NewClient(WithTransport(adapter)).ShowEvent(context.Background(), ShowEventOptions{ID: "event-1"})
+		var typed *Error
+		if !errors.As(err, &typed) || typed.Retryable != producer["retryable"].(bool) || !reflect.DeepEqual(typed.Details["producerError"], producer) {
+			t.Fatalf("producer error changed: %#v", err)
+		}
+	}
+	for _, query := range []string{"--help", "--refresh=off", "-needle", "two words", "a'雪"} {
+		transport := &recordingTransport{response: `{"results":[]}`}
+		_, err := NewClient(WithTransport(transport)).Search(context.Background(), SearchOptions{Query: query, Terms: []string{"--help"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		args := transport.op.Args
+		if !reflect.DeepEqual(args[len(args)-2:], []string{"--", query}) || !contains(args, "--term=--help") {
+			t.Fatalf("unsafe argv: %#v", args)
+		}
+	}
 }

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -133,7 +133,7 @@ func TestSearchBuildsAgentHistoryV1Operation(t *testing.T) {
 	}
 
 	want := []string{
-		"search", "panic", "--format=json", "--limit", "5",
+		"search", "--format=json", "--limit", "5",
 		"--term", "sqlite", "--term", "retry",
 		"--backend", "hybrid",
 		"--semantic-weight", "0.35",
@@ -147,6 +147,7 @@ func TestSearchBuildsAgentHistoryV1Operation(t *testing.T) {
 		"--primary-only",
 		"--events",
 		"--include-current-session",
+        "--", "panic",
 	}
 	if !reflect.DeepEqual(transport.op.Args, want) {
 		t.Fatalf("args mismatch\nwant: %#v\n got: %#v", want, transport.op.Args)
@@ -189,7 +190,7 @@ func TestSearchForwardsContentScopeOnce(t *testing.T) {
 		t.Fatalf("Search returned error: %v", err)
 	}
 
-	want := []string{"search", "agent history", "--format=json", "--content-scope", "calls"}
+	want := []string{"search", "--format=json", "--content-scope", "calls", "--", "agent history"}
 	if !reflect.DeepEqual(transport.op.Args, want) {
 		t.Fatalf("args mismatch\nwant: %#v\n got: %#v", want, transport.op.Args)
 	}
@@ -1114,4 +1115,55 @@ func environmentValue(values []string, name string) (string, bool) {
 		}
 	}
 	return value, found
+}
+
+
+func TestCurrentOpaquePayloadsThroughClient(t *testing.T) {
+    encoded, err := os.ReadFile("../../contracts/agent-history-v1/fixtures/cli/opaque-event.json")
+    if err != nil { t.Fatal(err) }
+    var fixture map[string]json.RawMessage
+    if err := json.Unmarshal(encoded, &fixture); err != nil { t.Fatal(err) }
+    for _, content := range []json.RawMessage{fixture["structured_content"], json.RawMessage("null"), nil} {
+        event := make(map[string]json.RawMessage)
+        for key, value := range fixture { event[key] = value }
+        delete(event, "structured_content")
+        if content != nil { event["structured_content"] = content }
+        raw, _ := json.Marshal(map[string]any{"event":event,"events":[]any{event},"session":map[string]any{"ctx_session_id":"session-1"}})
+        client := NewClient(WithTransport(fakeTransport{response:string(raw)}))
+        single, err := client.ShowEvent(context.Background(), ShowEventOptions{ID:"event-1"})
+        if err != nil { t.Fatal(err) }
+        session, err := client.ShowSession(context.Background(), ShowSessionOptions{ID:"session-1"})
+        if err != nil { t.Fatal(err) }
+        for _, actual := range []*Event{single.Event.Event, &session.Session.Events[0]} {
+            var want, got any
+            json.Unmarshal(fixture["activity"], &want); json.Unmarshal(actual.Activity, &got)
+            if !reflect.DeepEqual(want, got) { t.Fatalf("activity changed: %s", actual.Activity) }
+            if (content == nil) != (actual.StructuredContent == nil) { t.Fatal("content presence changed") }
+            want, got = nil, nil
+            json.Unmarshal(content, &want); json.Unmarshal(actual.StructuredContent, &got)
+            if !reflect.DeepEqual(want, got) { t.Fatalf("content changed: %s", actual.StructuredContent) }
+        }
+    }
+}
+
+func TestProducerErrorsAndLiteralQueries(t *testing.T) {
+    encoded, err := os.ReadFile("../../contracts/agent-history-v1/fixtures/cli/producer-errors.json")
+    if err != nil { t.Fatal(err) }
+    var failures []map[string]any
+    json.Unmarshal(encoded, &failures)
+    for _, producer := range failures {
+        payload, _ := json.Marshal(producer)
+        adapter := NewLocalCLIAdapter()
+        adapter.runner = fakeRunner{result: commandResult{ExitCode:1, Stderr:payload}}
+        _, err := NewClient(WithTransport(adapter)).ShowEvent(context.Background(), ShowEventOptions{ID:"event-1"})
+        var typed *Error
+        if !errors.As(err, &typed) || typed.Retryable != producer["retryable"].(bool) || !reflect.DeepEqual(typed.Details["producerError"], producer) { t.Fatalf("producer error changed: %#v", err) }
+    }
+    for _, query := range []string{"--help", "--refresh=off", "-needle", "two words", "a'雪"} {
+        transport := &recordingTransport{response:`{"results":[]}`}
+        _, err := NewClient(WithTransport(transport)).Search(context.Background(), SearchOptions{Query:query, Terms:[]string{"--help"}})
+        if err != nil { t.Fatal(err) }
+        args := transport.op.Args
+        if !reflect.DeepEqual(args[len(args)-2:], []string{"--", query}) || !contains(args, "--term=--help") { t.Fatalf("unsafe argv: %#v", args) }
+    }
 }

--- a/sdks/go/errors.go
+++ b/sdks/go/errors.go
@@ -2,6 +2,8 @@ package ctxagenthistory
 
 import (
 	"errors"
+ "encoding/json"
+ "strings"
 	"fmt"
 )
 
@@ -25,6 +27,8 @@ const (
 
 // Error is the structured error returned by the SDK.
 type Error struct {
+	Retryable bool
+    Details map[string]any
 	Kind     ErrorKind
 	Message  string
 	Command  []string
@@ -81,7 +85,22 @@ func commandError(command []string, exitCode int, stdout, stderr string, err err
 	} else if err != nil {
 		message = fmt.Sprintf("%s: %s", message, err.Error())
 	}
-	return &Error{
+    var producer map[string]any
+    var details map[string]any
+    retryable := false
+    decoder := json.NewDecoder(strings.NewReader(stderr))
+    decoder.UseNumber()
+    if rejectDuplicateJSONMembers([]byte(stderr)) == nil && decoder.Decode(&producer) == nil {
+        code, codeOK := producer["error_code"].(string)
+        retry, retryOK := producer["retryable"].(bool)
+        _, hasRetry := producer["retryable"]
+        if codeOK && code != "" && (!hasRetry || retryOK) {
+            details = map[string]any{"producerError": producer}
+            retryable = retry
+        }
+    }
+    return &Error{
+        Retryable: retryable, Details: details,
 		Kind:     ErrorKindCommandFailed,
 		Message:  message,
 		Command:  append([]string(nil), command...),

--- a/sdks/go/errors.go
+++ b/sdks/go/errors.go
@@ -1,41 +1,41 @@
 package ctxagenthistory
 
 import (
+	"encoding/json"
 	"errors"
- "encoding/json"
- "strings"
 	"fmt"
+	"strings"
 )
 
 // ErrorKind classifies SDK and adapter failures.
 type ErrorKind string
 
 const (
-	ErrorKindInvalidArgument       ErrorKind = "invalid_request"
-	ErrorKindNotFound              ErrorKind = "not_found"
-	ErrorKindNotInitialized        ErrorKind = "not_initialized"
-	ErrorKindCommandFailed         ErrorKind = "adapter_error"
-	ErrorKindDecode                ErrorKind = "decode_error"
-	ErrorKindTimeout               ErrorKind = "timeout"
-	ErrorKindCancelled             ErrorKind = "cancelled"
-	ErrorKindUnavailable           ErrorKind = "backend_unavailable"
-	ErrorKindHostedNotImplemented  ErrorKind = "not_supported"
-	ErrorKindUnknown               ErrorKind = "unknown"
-	ErrorKindUnsupportedSchema     ErrorKind = "unsupported_schema"
-	ErrorKindTransportUnavailable  ErrorKind = "transport_unavailable"
+	ErrorKindInvalidArgument      ErrorKind = "invalid_request"
+	ErrorKindNotFound             ErrorKind = "not_found"
+	ErrorKindNotInitialized       ErrorKind = "not_initialized"
+	ErrorKindCommandFailed        ErrorKind = "adapter_error"
+	ErrorKindDecode               ErrorKind = "decode_error"
+	ErrorKindTimeout              ErrorKind = "timeout"
+	ErrorKindCancelled            ErrorKind = "cancelled"
+	ErrorKindUnavailable          ErrorKind = "backend_unavailable"
+	ErrorKindHostedNotImplemented ErrorKind = "not_supported"
+	ErrorKindUnknown              ErrorKind = "unknown"
+	ErrorKindUnsupportedSchema    ErrorKind = "unsupported_schema"
+	ErrorKindTransportUnavailable ErrorKind = "transport_unavailable"
 )
 
 // Error is the structured error returned by the SDK.
 type Error struct {
 	Retryable bool
-    Details map[string]any
-	Kind     ErrorKind
-	Message  string
-	Command  []string
-	ExitCode int
-	Stdout   string
-	Stderr   string
-	Err      error
+	Details   map[string]any
+	Kind      ErrorKind
+	Message   string
+	Command   []string
+	ExitCode  int
+	Stdout    string
+	Stderr    string
+	Err       error
 }
 
 func (e *Error) Error() string {
@@ -85,22 +85,22 @@ func commandError(command []string, exitCode int, stdout, stderr string, err err
 	} else if err != nil {
 		message = fmt.Sprintf("%s: %s", message, err.Error())
 	}
-    var producer map[string]any
-    var details map[string]any
-    retryable := false
-    decoder := json.NewDecoder(strings.NewReader(stderr))
-    decoder.UseNumber()
-    if rejectDuplicateJSONMembers([]byte(stderr)) == nil && decoder.Decode(&producer) == nil {
-        code, codeOK := producer["error_code"].(string)
-        retry, retryOK := producer["retryable"].(bool)
-        _, hasRetry := producer["retryable"]
-        if codeOK && code != "" && (!hasRetry || retryOK) {
-            details = map[string]any{"producerError": producer}
-            retryable = retry
-        }
-    }
-    return &Error{
-        Retryable: retryable, Details: details,
+	var producer map[string]any
+	var details map[string]any
+	retryable := false
+	decoder := json.NewDecoder(strings.NewReader(stderr))
+	decoder.UseNumber()
+	if rejectDuplicateJSONMembers([]byte(stderr)) == nil && decoder.Decode(&producer) == nil {
+		code, codeOK := producer["error_code"].(string)
+		retry, retryOK := producer["retryable"].(bool)
+		_, hasRetry := producer["retryable"]
+		if codeOK && code != "" && (!hasRetry || retryOK) {
+			details = map[string]any{"producerError": producer}
+			retryable = retry
+		}
+	}
+	return &Error{
+		Retryable: retryable, Details: details,
 		Kind:     ErrorKindCommandFailed,
 		Message:  message,
 		Command:  append([]string(nil), command...),

--- a/sdks/go/local_cli.go
+++ b/sdks/go/local_cli.go
@@ -87,7 +87,9 @@ func (a *LocalCLIAdapter) Do(ctx context.Context, op Operation) ([]byte, error) 
 		}
 		err := commandError(append([]string{a.path}, args...), result.ExitCode, string(result.Stdout), string(result.Stderr), result.Err)
 		err.Kind = kind
-        if kind == ErrorKindTimeout { err.Retryable = true }
+		if kind == ErrorKindTimeout {
+			err.Retryable = true
+		}
 		return nil, err
 	}
 	stdout := bytes.TrimSpace(result.Stdout)

--- a/sdks/go/local_cli.go
+++ b/sdks/go/local_cli.go
@@ -76,7 +76,7 @@ func (a *LocalCLIAdapter) Do(ctx context.Context, op Operation) ([]byte, error) 
 	}
 	env = append(env, analyticsEnabledEnvironment+"=false")
 	result := a.runner.Run(ctx, a.path, args, env)
-	if result.Err != nil {
+	if result.Err != nil || result.ExitCode != 0 {
 		kind := ErrorKindCommandFailed
 		if errors.Is(result.Err, context.DeadlineExceeded) {
 			kind = ErrorKindTimeout
@@ -87,6 +87,7 @@ func (a *LocalCLIAdapter) Do(ctx context.Context, op Operation) ([]byte, error) 
 		}
 		err := commandError(append([]string{a.path}, args...), result.ExitCode, string(result.Stdout), string(result.Stderr), result.Err)
 		err.Kind = kind
+        if kind == ErrorKindTimeout { err.Retryable = true }
 		return nil, err
 	}
 	stdout := bytes.TrimSpace(result.Stdout)

--- a/sdks/go/normalize.go
+++ b/sdks/go/normalize.go
@@ -40,10 +40,10 @@ func normalizePayload(op Operation, payload []byte) ([]byte, error) {
 		"operation":       operation,
 		"backend":         map[string]any{"kind": "local"},
 	}
-    camel := raw
-    if operation != "showEvent" && operation != "showSession" {
-        camel = camelize(raw)
-    }
+	camel := raw
+	if operation != "showEvent" && operation != "showSession" {
+		camel = camelize(raw)
+	}
 
 	switch operation {
 	case "status":
@@ -81,11 +81,11 @@ func normalizeEventPayload(operation string, value any) (any, error) {
 	}
 	out := make(map[string]any, len(object))
 	for key, nested := range object {
-        if key != "event" && key != "events" {
-            out[snakeToCamel(key)] = camelize(nested)
-        }
-    }
-    if operation == "showEvent" {
+		if key != "event" && key != "events" {
+			out[snakeToCamel(key)] = camelize(nested)
+		}
+	}
+	if operation == "showEvent" {
 		if event, exists := object["event"]; exists {
 			normalized, err := normalizeEventRecord(event)
 			if err != nil {
@@ -147,12 +147,16 @@ func normalizeEventRecord(value any) (any, error) {
 		if snakeToCamel(key) == "mcpExchange" {
 			return nil, fmt.Errorf("event member %q collides with canonical mcpExchange", key)
 		}
-        canonical := snakeToCamel(key)
-        if canonical == "configPath" || canonical == "itemType" || canonical == "payloadType" || canonical == "recordType" { continue }
-        if key == "content" || key == "citations" { nested = camelize(nested) }
-        out[canonical] = nested
-    }
-    if hasSnake || hasCamel {
+		canonical := snakeToCamel(key)
+		if canonical == "configPath" || canonical == "itemType" || canonical == "payloadType" || canonical == "recordType" {
+			continue
+		}
+		if key == "content" || key == "citations" {
+			nested = camelize(nested)
+		}
+		out[canonical] = nested
+	}
+	if hasSnake || hasCamel {
 		call := snake
 		if hasCamel {
 			call = camel

--- a/sdks/go/normalize.go
+++ b/sdks/go/normalize.go
@@ -40,7 +40,10 @@ func normalizePayload(op Operation, payload []byte) ([]byte, error) {
 		"operation":       operation,
 		"backend":         map[string]any{"kind": "local"},
 	}
-	camel := camelize(raw)
+    camel := raw
+    if operation != "showEvent" && operation != "showSession" {
+        camel = camelize(raw)
+    }
 
 	switch operation {
 	case "status":
@@ -78,9 +81,11 @@ func normalizeEventPayload(operation string, value any) (any, error) {
 	}
 	out := make(map[string]any, len(object))
 	for key, nested := range object {
-		out[key] = nested
-	}
-	if operation == "showEvent" {
+        if key != "event" && key != "events" {
+            out[snakeToCamel(key)] = camelize(nested)
+        }
+    }
+    if operation == "showEvent" {
 		if event, exists := object["event"]; exists {
 			normalized, err := normalizeEventRecord(event)
 			if err != nil {
@@ -142,9 +147,12 @@ func normalizeEventRecord(value any) (any, error) {
 		if snakeToCamel(key) == "mcpExchange" {
 			return nil, fmt.Errorf("event member %q collides with canonical mcpExchange", key)
 		}
-		out[key] = nested
-	}
-	if hasSnake || hasCamel {
+        canonical := snakeToCamel(key)
+        if canonical == "configPath" || canonical == "itemType" || canonical == "payloadType" || canonical == "recordType" { continue }
+        if key == "content" || key == "citations" { nested = camelize(nested) }
+        out[canonical] = nested
+    }
+    if hasSnake || hasCamel {
 		call := snake
 		if hasCamel {
 			call = camel
@@ -176,10 +184,6 @@ func normalizeEventRecord(value any) (any, error) {
 	}
 	return out, nil
 }
-
-type opaqueCapturedJSON struct{ value any }
-
-func (value opaqueCapturedJSON) MarshalJSON() ([]byte, error) { return json.Marshal(value.value) }
 
 func normalizeMCPExchange(value any) (map[string]any, error) {
 	exchange, err := normalizeClosedMCPObject(value, "exchange", map[string]string{
@@ -294,7 +298,6 @@ func normalizeMCPCapture(value any, context string, argumentsCapture, textCaptur
 				return nil, fmt.Errorf("present MCP invocation arguments must be a JSON object")
 			}
 		}
-		capture["value"] = opaqueCapturedJSON{value: capture["value"]}
 	case "normalized_body":
 		if !textCapture {
 			return nil, fmt.Errorf("%s cannot use normalized_body", context)

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -384,6 +384,7 @@ type Event struct {
 	Text              string               `json:"text,omitempty"`
 	MCPToolCall       *MCPToolCall         `json:"mcpToolCall,omitempty"`
 	MCPExchange       *MCPExchange         `json:"mcpExchange,omitempty"`
+	Activity          json.RawMessage      `json:"activity,omitempty"`
 	StructuredContent json.RawMessage      `json:"structuredContent,omitempty"`
 	Content           *CoreContentMetadata `json:"content,omitempty"`
 	Citations         []Citation           `json:"citations,omitempty"`

--- a/sdks/jvm/README.md
+++ b/sdks/jvm/README.md
@@ -33,8 +33,9 @@ source-location objects, and preview bodies are not exposed.
 
 All data responses extend `AgentHistoryEnvelope`, with `contractVersion`,
 `schemaVersion`, `operation`, backend metadata, `asMap()`, and operation payload
-access. Local mode shells out to the `ctx` CLI and performs no network calls or
-provider API calls.
+access. Local mode invokes the `ctx` CLI. The CLI honors explicitly configured
+external semantic execution, which can send bounded semantic text to the
+selected executor. See [SDK locality](../../docs/sdks.md#local-and-hosted-backends).
 
 The local adapter currently supports POSIX systems with either `setsid` or
 `bash` available for race-free process-group ownership (including standard

--- a/sdks/jvm/src/main/java/rs/ctx/agenthistory/AgentHistoryClient.java
+++ b/sdks/jvm/src/main/java/rs/ctx/agenthistory/AgentHistoryClient.java
@@ -93,9 +93,6 @@ public class AgentHistoryClient {
         requireCompatibleSearchFilters(safe);
         List<String> args = new ArrayList<>();
         args.add("search");
-        if (safe.query() != null && !safe.query().isEmpty()) {
-            args.add(safe.query());
-        }
         args.add("--format=json");
         if (safe.limit() != null) {
             args.add("--limit");
@@ -107,8 +104,7 @@ public class AgentHistoryClient {
             args.add(String.valueOf(safe.semanticWeight()));
         }
         for (String term : safe.terms()) {
-            args.add("--term");
-            args.add(term);
+            add(args, "--term", term);
         }
         add(args, "--provider", safe.provider());
         add(args, "--workspace", safe.workspace());
@@ -123,6 +119,7 @@ public class AgentHistoryClient {
         if (safe.primaryOnly()) args.add("--primary-only");
         if (safe.events()) args.add("--events");
         if (safe.includeCurrentSession()) args.add("--include-current-session");
+        if (safe.query() != null && !safe.query().isEmpty()) { args.add("--"); args.add(safe.query()); }
         return new SearchResponse(executeEnvelope("search", args));
     }
 
@@ -239,8 +236,8 @@ public class AgentHistoryClient {
 
     private static void add(List<String> args, String flag, String value) {
         if (value != null && !value.isEmpty()) {
-            args.add(flag);
-            args.add(value);
+            if (value.startsWith("-")) args.add(flag + "=" + value);
+            else { args.add(flag); args.add(value); }
         }
     }
 

--- a/sdks/jvm/src/main/java/rs/ctx/agenthistory/AgentHistoryEnvelope.java
+++ b/sdks/jvm/src/main/java/rs/ctx/agenthistory/AgentHistoryEnvelope.java
@@ -94,7 +94,8 @@ public class AgentHistoryEnvelope {
         if ("showEvent".equals(operation) || "showSession".equals(operation)) {
             normalizable = normalizeEventPayload(operation, raw);
         }
-        Map<String, Object> camel = new LinkedHashMap<>(AgentHistoryValue.camelizeObject(normalizable));
+        Map<String, Object> camel = new LinkedHashMap<>(
+                normalizable == raw ? AgentHistoryValue.camelizeObject(raw) : normalizable);
         Map<String, Object> fields = new LinkedHashMap<>();
         switch (operation) {
             case "status":
@@ -185,7 +186,12 @@ public class AgentHistoryEnvelope {
     private static Map<String, Object> normalizeEventPayload(
             String operation,
             Map<String, Object> raw) {
-        Map<String, Object> out = new LinkedHashMap<>(raw);
+        Map<String, Object> out = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : raw.entrySet()) {
+            if (!"event".equals(entry.getKey()) && !"events".equals(entry.getKey())) {
+                out.put(AgentHistoryValue.snakeToCamel(entry.getKey()), AgentHistoryValue.camelize(entry.getValue()));
+            }
+        }
         if ("showEvent".equals(operation) && raw.containsKey("event")) {
             out.put("event", normalizeEventRecord(raw.get("event")));
         }
@@ -236,7 +242,10 @@ public class AgentHistoryEnvelope {
                 throw invalidMcpExchangeWire(
                         "outer member " + key + " collides with canonical mcpExchange");
             }
-            out.put(key, entry.getValue());
+            String canonical = AgentHistoryValue.snakeToCamel(key);
+            if (java.util.Arrays.asList("configPath", "itemType", "payloadType", "recordType").contains(canonical)) continue;
+            out.put(canonical, "content".equals(key) || "citations".equals(key)
+                    ? AgentHistoryValue.camelize(entry.getValue()) : AgentHistoryValue.copy(entry.getValue()));
         }
         if (hasSnake || hasCamel) {
             Object call = hasSnake ? event.get("mcp_tool_call") : event.get("mcpToolCall");
@@ -248,7 +257,7 @@ public class AgentHistoryEnvelope {
                     : event.get("mcpExchange");
             out.put(
                     "mcpExchange",
-                    AgentHistoryValue.opaqueJson(McpExchange.normalizeWire(exchange)));
+                    McpExchange.normalizeWire(exchange));
         }
         return out;
     }

--- a/sdks/jvm/src/main/java/rs/ctx/agenthistory/AgentHistoryValue.java
+++ b/sdks/jvm/src/main/java/rs/ctx/agenthistory/AgentHistoryValue.java
@@ -133,9 +133,6 @@ final class AgentHistoryValue {
     }
 
     static Object camelize(Object value) {
-        if (value instanceof OpaqueJson) {
-            return copy(((OpaqueJson) value).value);
-        }
         if (value instanceof Map<?, ?>) {
             Map<?, ?> map = (Map<?, ?>) value;
             Map<String, Object> out = new LinkedHashMap<>();
@@ -160,18 +157,6 @@ final class AgentHistoryValue {
             return Collections.unmodifiableList(out);
         }
         return value;
-    }
-
-    static Object opaqueJson(Object value) {
-        return new OpaqueJson(value);
-    }
-
-    private static final class OpaqueJson {
-        private final Object value;
-
-        private OpaqueJson(Object value) {
-            this.value = value;
-        }
     }
 
     static String snakeToCamel(String value) {

--- a/sdks/jvm/src/main/java/rs/ctx/agenthistory/CtxAgentHistoryException.java
+++ b/sdks/jvm/src/main/java/rs/ctx/agenthistory/CtxAgentHistoryException.java
@@ -94,7 +94,14 @@ public class CtxAgentHistoryException extends RuntimeException {
                 String stdout,
                 String stderr,
                 Throwable cause) {
-            super(code, message, retryable, cliDetails(command, args, exitCode, stdout, stderr), cause);
+            this(code, message, retryable, command, args, exitCode, stdout, stderr, cause, producerError(stderr));
+        }
+
+        private Cli(String code, String message, boolean retryable, String command,
+                java.util.List<String> args, int exitCode, String stdout, String stderr,
+                Throwable cause, Map<String, Object> producer) {
+            super(code, message, retryable || Boolean.TRUE.equals(producer.get("retryable")),
+                    cliDetails(command, args, exitCode, stdout, stderr, producer), cause);
             this.command = command;
             this.args = Collections.unmodifiableList(new java.util.ArrayList<>(args));
             this.exitCode = exitCode;
@@ -122,13 +129,23 @@ public class CtxAgentHistoryException extends RuntimeException {
             return stderr;
         }
 
+        private static Map<String, Object> producerError(String stderr) {
+            try {
+                Map<String, Object> producer = Json.parseObject(stderr);
+                Object code = producer.get("error_code");
+                if (code instanceof String && !((String) code).isEmpty() && (!producer.containsKey("retryable") || producer.get("retryable") instanceof Boolean)) return producer;
+            } catch (RuntimeException malformed) { /* Plain diagnostic fallback. */ }
+            return Collections.emptyMap();
+        }
+
         private static Map<String, Object> cliDetails(
                 String command,
                 java.util.List<String> args,
                 int exitCode,
                 String stdout,
-                String stderr) {
+                String stderr, Map<String, Object> producer) {
             Map<String, Object> details = new LinkedHashMap<>();
+            if (!producer.isEmpty()) details.put("producerError", producer);
             details.put("command", command);
             details.put("args", new java.util.ArrayList<>(args));
             details.put("exitCode", exitCode);

--- a/sdks/jvm/src/test/java/rs/ctx/agenthistory/AgentHistoryClientTest.java
+++ b/sdks/jvm/src/test/java/rs/ctx/agenthistory/AgentHistoryClientTest.java
@@ -962,7 +962,8 @@ public final class AgentHistoryClientTest {
 
         assertEquals("search", transport.lastOperation.name());
         assertContainsInOrder(transport.lastOperation.args(), "search", "--format=json");
-        assertContainsInOrder(transport.lastOperation.args(), "--format=json", "--", "agent history");
+        List<String> args = transport.lastOperation.args();
+        assertEquals(List.of("--", "agent history"), args.subList(args.size() - 2, args.size()));
         assertContainsInOrder(transport.lastOperation.args(), "--limit", "5");
         assertContainsInOrder(transport.lastOperation.args(), "--backend", "hybrid");
         assertContainsInOrder(transport.lastOperation.args(), "--semantic-weight", "0.35");

--- a/sdks/jvm/src/test/java/rs/ctx/agenthistory/AgentHistoryClientTest.java
+++ b/sdks/jvm/src/test/java/rs/ctx/agenthistory/AgentHistoryClientTest.java
@@ -961,7 +961,8 @@ public final class AgentHistoryClientTest {
                 .refresh("off"));
 
         assertEquals("search", transport.lastOperation.name());
-        assertContainsInOrder(transport.lastOperation.args(), "search", "--format=json", "--", "agent history");
+        assertContainsInOrder(transport.lastOperation.args(), "search", "--format=json");
+        assertContainsInOrder(transport.lastOperation.args(), "--format=json", "--", "agent history");
         assertContainsInOrder(transport.lastOperation.args(), "--limit", "5");
         assertContainsInOrder(transport.lastOperation.args(), "--backend", "hybrid");
         assertContainsInOrder(transport.lastOperation.args(), "--semantic-weight", "0.35");

--- a/sdks/jvm/src/test/java/rs/ctx/agenthistory/AgentHistoryClientTest.java
+++ b/sdks/jvm/src/test/java/rs/ctx/agenthistory/AgentHistoryClientTest.java
@@ -22,6 +22,7 @@ public final class AgentHistoryClientTest {
     private static final String PROCESS_FIXTURE_PIPE_RELEASE = "CTX_MCP289_JVM_PROCESS_FIXTURE_PIPE_RELEASE";
 
     public static void main(String[] args) throws Exception {
+        currentOpaquePayloadsAndProducerErrors();
         wrapsRawStatusAsTypedEnvelope();
         normalizesSetupJsonAsInitStatus();
         rejectsStatusCountersOutsideExactCrossSDKDomain();
@@ -52,6 +53,48 @@ public final class AgentHistoryClientTest {
         localCliDeadlineOwnsPipeDescendantsAndForcesCleanup();
         searchRequiresIntent();
         hostedIsExplicitlyUnsupported();
+    }
+
+    private static void currentOpaquePayloadsAndProducerErrors() throws Exception {
+        Map<String, Object> event = Json.parseObject(readFixture("cli/opaque-event.json"));
+        for (int variant = 0; variant < 3; variant++) {
+            Map<String, Object> current = new LinkedHashMap<>(event);
+            if (variant == 1) current.put("structured_content", null);
+            if (variant == 2) current.remove("structured_content");
+            String eventJson = readFixture("cli/opaque-event.json");
+            if (variant != 0) {
+                // Keep activity exact; replace only the structured-content member by slicing at its known fixture boundary.
+                int start = eventJson.indexOf("  \"structured_content\":");
+                int end = eventJson.indexOf("  \"activity\":", start);
+                eventJson = eventJson.substring(0, start) + (variant == 1 ? "  \"structured_content\": null,\n" : "") + eventJson.substring(end);
+            }
+            String wire = "{\"event\":" + eventJson + ",\"events\":[" + eventJson + "],\"session\":{}}";
+            AgentHistoryClient client = AgentHistoryClient.withTransport(new FakeTransport("local-cli", wire));
+            Map<String, Object> actual = client.showEvent("event-1").getEvent().getEvent().asMap();
+            assertEquals(event.get("activity"), actual.get("activity"));
+            assertEquals(current.containsKey("structured_content"), actual.containsKey("structuredContent"));
+            assertEquals(current.get("structured_content"), actual.get("structuredContent"));
+            actual = client.showSession("session-1").getSession().getEvents().get(0).asMap();
+            assertEquals(event.get("activity"), actual.get("activity"));
+            assertEquals(current.get("structured_content"), actual.get("structuredContent"));
+        }
+        for (String query : List.of("--help", "--refresh=off", "-needle", "two words", "a'雪")) {
+            CommandRequest[] request = new CommandRequest[1];
+            LocalCliConfig config = LocalCliConfig.builder().runner(r -> { request[0] = r; return new CommandResult("{\"results\":[]}", "", 0); }).build();
+            AgentHistoryClient client = AgentHistoryClient.local(config);
+            client.search(query);
+            List<String> args = request[0].args();
+            assertEquals(List.of("--", query), args.subList(args.size()-2, args.size()));
+        }
+        for (boolean retryable : new boolean[]{false, true}) {
+            String stderr = "{\"error_code\":\"generation_changed\",\"failure_kind\":\"active_generation_race\",\"retryable\":" + retryable + "}";
+            AgentHistoryClient client = AgentHistoryClient.local(LocalCliConfig.builder().runner(r -> new CommandResult("", stderr, 1)).build());
+            try { client.showEvent("event-1"); throw new AssertionError("expected producer failure"); }
+            catch (CtxAgentHistoryException error) {
+                assertEquals(retryable, error.retryable());
+                assertEquals(Json.parseObject(stderr), error.details().get("producerError"));
+            }
+        }
     }
 
     private static void localCliForcesAnalyticsOffAfterAmbientAndUserEnvironment() {
@@ -918,7 +961,7 @@ public final class AgentHistoryClientTest {
                 .refresh("off"));
 
         assertEquals("search", transport.lastOperation.name());
-        assertContainsInOrder(transport.lastOperation.args(), "search", "agent history", "--format=json");
+        assertContainsInOrder(transport.lastOperation.args(), "search", "--format=json", "--", "agent history");
         assertContainsInOrder(transport.lastOperation.args(), "--limit", "5");
         assertContainsInOrder(transport.lastOperation.args(), "--backend", "hybrid");
         assertContainsInOrder(transport.lastOperation.args(), "--semantic-weight", "0.35");

--- a/sdks/python/src/ctx_agent_history/agent_history_v1.py
+++ b/sdks/python/src/ctx_agent_history/agent_history_v1.py
@@ -219,13 +219,15 @@ def _normalize_event_record(value: Any) -> Any:
                 details={"member": key},
             )
 
-    normalized = _camelize_public(
-        {
-            key: nested
-            for key, nested in value.items()
-            if key not in wire_keys and key not in exchange_wire_keys
-        }
-    )
+    normalized = {
+        _snake_to_camel(key): (
+            _camelize_public(nested) if key in {"content", "citations"} else nested
+        )
+        for key, nested in value.items()
+        if key not in wire_keys and key not in exchange_wire_keys
+        and key not in {"schema_version", "target", "item_type", "itemType",
+                        "payload_type", "payloadType", "record_type", "recordType"}
+    }
     if wire_keys:
         normalized["mcpToolCall"] = _validate_mcp_tool_call(value[wire_keys[0]])
     if exchange_wire_keys:

--- a/sdks/python/src/ctx_agent_history/errors.py
+++ b/sdks/python/src/ctx_agent_history/errors.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from typing import Any, Mapping, Optional, Sequence
 
 
@@ -47,6 +49,13 @@ class CtxAgentHistoryCliError(CtxAgentHistoryError):
         stdout: str = "",
         cause: Optional[BaseException] = None,
     ) -> None:
+        try:
+            producer = json.loads(stderr)
+        except (ValueError, TypeError):
+            producer = None
+        if not (isinstance(producer, dict) and isinstance(producer.get("error_code"), str)
+                and producer["error_code"] and isinstance(producer.get("retryable", False), bool)):
+            producer = None
         self.command = list(command)
         self.exit_code = exit_code
         self.stderr = stderr
@@ -59,8 +68,9 @@ class CtxAgentHistoryCliError(CtxAgentHistoryError):
                 "exit_code": exit_code,
                 "stderr": stderr,
                 "stdout": stdout,
+                **({"producerError": producer} if producer is not None else {}),
             },
-            retryable=False,
+            retryable=producer.get("retryable", False) if producer is not None else False,
             cause=cause,
         )
 

--- a/sdks/python/src/ctx_agent_history/transport.py
+++ b/sdks/python/src/ctx_agent_history/transport.py
@@ -277,8 +277,6 @@ class LocalCliAdapter:
         _validate_search_class_filters(content_scope=content_scope, event_type=event_type)
         validate_search_intent(query=query, terms=terms, file=file)
         args = ["search", "--format=json"]
-        if query is not None:
-            args.append(query)
         _extend_option(args, "--provider", provider)
         _extend_option(args, "--workspace", workspace)
         _extend_option(args, "--since", since)
@@ -287,7 +285,7 @@ class LocalCliAdapter:
         _extend_option(args, "--file", file)
         _extend_option(args, "--session", session)
         for term in terms or []:
-            args.extend(["--term", term])
+            args.extend([f"--term={term}"] if term.startswith("-") else ["--term", term])
         if events:
             args.append("--events")
         _extend_option(args, "--backend", backend)
@@ -300,6 +298,8 @@ class LocalCliAdapter:
         _extend_option(args, "--refresh", refresh)
         if include_current_session:
             args.append("--include-current-session")
+        if query is not None:
+            args.extend(["--", query])
         raw = self._json(args)
         return cast(
             SearchResponse,
@@ -471,4 +471,4 @@ class HostedAdapter:
 
 def _extend_option(args: list[str], flag: str, value: Optional[str]) -> None:
     if value is not None:
-        args.extend([flag, value])
+        args.extend([f"{flag}={value}"] if value.startswith("-") else [flag, value])

--- a/sdks/python/src/ctx_agent_history/types.py
+++ b/sdks/python/src/ctx_agent_history/types.py
@@ -281,6 +281,7 @@ class Event(TypedDict, total=False):
     text: Optional[str]
     mcpToolCall: McpToolCall
     mcpExchange: McpExchange
+    activity: Any
     structuredContent: Any
     content: CoreContentMetadata
     citations: list[Citation]

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -423,13 +423,14 @@ class LocalCliAdapterTests(unittest.TestCase):
             [
                 "search",
                 "--format=json",
-                "semantic override",
                 "--backend",
                 "hybrid",
                 "--semantic-weight",
                 "0.8",
                 "--refresh",
                 "off",
+                "--",
+                "semantic override",
             ],
         )
 

--- a/sdks/python/tests/test_fidelity.py
+++ b/sdks/python/tests/test_fidelity.py
@@ -8,6 +8,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from ctx_agent_history import AgentHistoryClient
 from ctx_agent_history.errors import CtxAgentHistoryCliError
+from ctx_agent_history._subprocess import run_local_cli
 
 FIXTURES = Path(__file__).resolve().parents[3] / "contracts/agent-history-v1/fixtures/cli"
 
@@ -42,16 +43,22 @@ class FidelityTests(unittest.TestCase):
                 self.assertIn("--term=--help", args)
 
     def test_producer_errors(self):
-        for producer in json.loads((FIXTURES / "producer-errors.json").read_text()):
-            result = subprocess.CompletedProcess([], 1, stdout="", stderr=json.dumps(producer))
-            with mock.patch("ctx_agent_history.transport.run_local_cli", return_value=result):
+        producers = json.loads((FIXTURES / "producer-errors.json").read_text())
+        for producer in [*producers, None]:
+            stderr = json.dumps(producer) if producer is not None else "not JSON"
+
+            def failing_process(command, **options):
+                return run_local_cli(
+                    [sys.executable, "-c", "import sys; sys.stderr.write(sys.argv[1]); sys.exit(1)", stderr],
+                    **options,
+                )
+
+            with mock.patch("ctx_agent_history.transport.run_local_cli", side_effect=failing_process):
                 with self.assertRaises(CtxAgentHistoryCliError) as caught:
                     AgentHistoryClient.local().show_event("event-1")
-            self.assertEqual(caught.exception.retryable, producer["retryable"])
-            self.assertEqual(caught.exception.details["producerError"], producer)
-        result = subprocess.CompletedProcess([], 1, stdout="", stderr="not JSON")
-        with mock.patch("ctx_agent_history.transport.run_local_cli", return_value=result):
-            with self.assertRaises(CtxAgentHistoryCliError) as caught:
-                AgentHistoryClient.local().show_event("event-1")
-        self.assertFalse(caught.exception.retryable)
-        self.assertEqual(caught.exception.stderr, "not JSON")
+            if producer is not None:
+                self.assertEqual(caught.exception.retryable, producer["retryable"])
+                self.assertEqual(caught.exception.details["producerError"], producer)
+            else:
+                self.assertFalse(caught.exception.retryable)
+                self.assertEqual(caught.exception.stderr, stderr)

--- a/sdks/python/tests/test_fidelity.py
+++ b/sdks/python/tests/test_fidelity.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from ctx_agent_history import AgentHistoryClient
+from ctx_agent_history.errors import CtxAgentHistoryCliError
+
+FIXTURES = Path(__file__).resolve().parents[3] / "contracts/agent-history-v1/fixtures/cli"
+
+
+class FidelityTests(unittest.TestCase):
+    def test_current_event_and_session_payloads(self):
+        event = json.loads((FIXTURES / "opaque-event.json").read_text())
+        for value in [event["structured_content"], None, "absent"]:
+            current = dict(event)
+            if value == "absent":
+                current.pop("structured_content")
+            else:
+                current["structured_content"] = value
+            raw = {"event": current, "events": [current], "session": {"ctx_session_id": "session-1"}}
+            result = subprocess.CompletedProcess([], 0, stdout=json.dumps(raw), stderr="")
+            with mock.patch("ctx_agent_history.transport.run_local_cli", return_value=result):
+                client = AgentHistoryClient.local()
+                for actual in [client.show_event("event-1")["event"]["event"], client.show_session("session-1")["session"]["events"][0]]:
+                    self.assertEqual(actual["activity"], event["activity"])
+                    self.assertEqual("structuredContent" in actual, value != "absent")
+                    if value != "absent":
+                        self.assertEqual(actual["structuredContent"], value)
+                    self.assertEqual(actual["content"]["policyStatus"], "selected")
+
+    def test_literal_query_argv(self):
+        result = subprocess.CompletedProcess([], 0, stdout='{"results":[]}', stderr="")
+        for query in ["--help", "--refresh=off", "-needle", "two words", "a'雪"]:
+            with mock.patch("ctx_agent_history.transport.run_local_cli", return_value=result) as run:
+                AgentHistoryClient.local().search(query, refresh="off", terms=["--help"])
+                args = run.call_args.args[0]
+                self.assertEqual(args[-2:], ["--", query])
+                self.assertIn("--term=--help", args)
+
+    def test_producer_errors(self):
+        for producer in json.loads((FIXTURES / "producer-errors.json").read_text()):
+            result = subprocess.CompletedProcess([], 1, stdout="", stderr=json.dumps(producer))
+            with mock.patch("ctx_agent_history.transport.run_local_cli", return_value=result):
+                with self.assertRaises(CtxAgentHistoryCliError) as caught:
+                    AgentHistoryClient.local().show_event("event-1")
+            self.assertEqual(caught.exception.retryable, producer["retryable"])
+            self.assertEqual(caught.exception.details["producerError"], producer)
+        result = subprocess.CompletedProcess([], 1, stdout="", stderr="not JSON")
+        with mock.patch("ctx_agent_history.transport.run_local_cli", return_value=result):
+            with self.assertRaises(CtxAgentHistoryCliError) as caught:
+                AgentHistoryClient.local().show_event("event-1")
+        self.assertFalse(caught.exception.retryable)
+        self.assertEqual(caught.exception.stderr, "not JSON")

--- a/sdks/swift/README.md
+++ b/sdks/swift/README.md
@@ -66,10 +66,25 @@ completeness and selected/redacted/omitted policy metadata. `text` is the sole
 body, and per-event source paths, cursors, source locations, and previews are
 not exposed.
 
+## Compatibility limitations
+
+The Swift package retains three limitations relative to the shared contract:
+
+- Event normalization can rewrite keys within `structuredContent` and discard
+  explicit nulls. `AgentHistoryEventRecord` does not expose `activity`.
+- CLI failures retain standard process diagnostics but do not preserve the
+  producer JSON object under `details.producerError` or its `retryable` value.
+- Search argument construction does not separate a query with `--`; queries
+  beginning with a hyphen can be parsed as options.
+
+The corresponding Swift fixes are deferred. The preservation, producer-error
+and literal-query fixes in Rust, TypeScript, Python, Go, JVM and .NET do not
+establish Swift conformance.
+
 ## Local CLI Adapter
 
-`AgentHistoryClient.local(...)` shells out to a local `ctx` binary and never performs
-network calls:
+`AgentHistoryClient.local(...)` invokes a local `ctx` binary. The CLI honors
+explicitly configured external semantic execution:
 
 ```swift
 let client = AgentHistoryClient.local(

--- a/sdks/swift/Sources/CtxAgentHistory/AgentHistoryClient.swift
+++ b/sdks/swift/Sources/CtxAgentHistory/AgentHistoryClient.swift
@@ -77,8 +77,11 @@ public struct AgentHistoryClient: Sendable {
         try requireSearchIntent(query: query, options: options)
         try requireCompatibleSearchFilters(options)
         var arguments = ["search"]
+        if let query {
+            arguments.append(query)
+        }
         for term in options.terms {
-            appendOption(&arguments, "--term", term)
+            arguments.append(contentsOf: ["--term", term])
         }
         if let limit = options.limit {
             arguments.append(contentsOf: ["--limit", String(limit)])
@@ -105,7 +108,6 @@ public struct AgentHistoryClient: Sendable {
             arguments.append("--include-current-session")
         }
         arguments.append("--format=json")
-        if let query { arguments.append(contentsOf: ["--", query]) }
         return try SearchResponse(envelope: localEnvelope(operation: .search, arguments: arguments))
     }
 
@@ -275,7 +277,7 @@ private func appendSessionLookup(_ arguments: inout [String], id: String?, provi
 
 private func appendOption(_ arguments: inout [String], _ name: String, _ value: String?) {
     if let value, !value.isEmpty {
-        arguments.append(contentsOf: value.hasPrefix("-") ? ["\(name)=\(value)"] : [name, value])
+        arguments.append(contentsOf: [name, value])
     }
 }
 
@@ -640,13 +642,13 @@ private func normalizeEventRecord(_ raw: JSONValue?) throws -> JSONValue? {
     } else {
         exchange = outer.removeValue(forKey: "mcpExchange")
     }
-    var result: [String: JSONValue] = [:]
-    for (key, value) in outer {
-        let canonical = JSONValue.camelizedPublicKey(key)
-        if ["configPath", "itemType", "payloadType", "recordType"].contains(canonical) { continue }
-        result[canonical] = ["content", "citations"].contains(key)
-            ? value.camelizedPublicJSON().droppingNulls() : value
+    let normalized = JSONValue.object(outer)
+        .camelizedPublicJSON()
+        .droppingNulls()
+    guard case let .object(normalizedObject) = normalized else {
+        throw invalidMCPWire("event normalization did not produce an object")
     }
+    var result = normalizedObject
     if result["mcpToolCall"] != nil {
         throw invalidMCPWire("outer member collides with canonical mcpToolCall")
     }

--- a/sdks/swift/Sources/CtxAgentHistory/AgentHistoryClient.swift
+++ b/sdks/swift/Sources/CtxAgentHistory/AgentHistoryClient.swift
@@ -77,11 +77,8 @@ public struct AgentHistoryClient: Sendable {
         try requireSearchIntent(query: query, options: options)
         try requireCompatibleSearchFilters(options)
         var arguments = ["search"]
-        if let query {
-            arguments.append(query)
-        }
         for term in options.terms {
-            arguments.append(contentsOf: ["--term", term])
+            appendOption(&arguments, "--term", term)
         }
         if let limit = options.limit {
             arguments.append(contentsOf: ["--limit", String(limit)])
@@ -108,6 +105,7 @@ public struct AgentHistoryClient: Sendable {
             arguments.append("--include-current-session")
         }
         arguments.append("--format=json")
+        if let query { arguments.append(contentsOf: ["--", query]) }
         return try SearchResponse(envelope: localEnvelope(operation: .search, arguments: arguments))
     }
 
@@ -277,7 +275,7 @@ private func appendSessionLookup(_ arguments: inout [String], id: String?, provi
 
 private func appendOption(_ arguments: inout [String], _ name: String, _ value: String?) {
     if let value, !value.isEmpty {
-        arguments.append(contentsOf: [name, value])
+        arguments.append(contentsOf: value.hasPrefix("-") ? ["\(name)=\(value)"] : [name, value])
     }
 }
 
@@ -642,13 +640,13 @@ private func normalizeEventRecord(_ raw: JSONValue?) throws -> JSONValue? {
     } else {
         exchange = outer.removeValue(forKey: "mcpExchange")
     }
-    let normalized = JSONValue.object(outer)
-        .camelizedPublicJSON()
-        .droppingNulls()
-    guard case let .object(normalizedObject) = normalized else {
-        throw invalidMCPWire("event normalization did not produce an object")
+    var result: [String: JSONValue] = [:]
+    for (key, value) in outer {
+        let canonical = JSONValue.camelizedPublicKey(key)
+        if ["configPath", "itemType", "payloadType", "recordType"].contains(canonical) { continue }
+        result[canonical] = ["content", "citations"].contains(key)
+            ? value.camelizedPublicJSON().droppingNulls() : value
     }
-    var result = normalizedObject
     if result["mcpToolCall"] != nil {
         throw invalidMCPWire("outer member collides with canonical mcpToolCall")
     }

--- a/sdks/swift/Sources/CtxAgentHistory/AgentHistoryDTOs.swift
+++ b/sdks/swift/Sources/CtxAgentHistory/AgentHistoryDTOs.swift
@@ -510,6 +510,7 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
     public var text: String?
     public var mcpToolCall: AgentHistoryMCPToolCall?
     public var mcpExchange: AgentHistoryMCPExchange?
+    public var activity: JSONValue?
     public var structuredContent: JSONValue?
     public var content: CoreContentMetadata?
     public var citations: [AgentHistoryCitation]?
@@ -527,6 +528,7 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         text: String? = nil,
         mcpToolCall: AgentHistoryMCPToolCall? = nil,
         mcpExchange: AgentHistoryMCPExchange? = nil,
+        activity: JSONValue? = nil,
         structuredContent: JSONValue? = nil,
         content: CoreContentMetadata? = nil,
         citations: [AgentHistoryCitation]? = nil
@@ -543,6 +545,7 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         self.text = text
         self.mcpToolCall = mcpToolCall
         self.mcpExchange = mcpExchange
+        self.activity = activity
         self.structuredContent = structuredContent
         self.content = content
         self.citations = citations
@@ -561,6 +564,7 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         case text
         case mcpToolCall
         case mcpExchange
+        case activity
         case structuredContent
         case content
         case citations
@@ -584,7 +588,10 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         mcpExchange = container.contains(.mcpExchange)
             ? try container.decode(AgentHistoryMCPExchange.self, forKey: .mcpExchange)
             : nil
-        structuredContent = try container.decodeIfPresent(JSONValue.self, forKey: .structuredContent)
+        activity = container.contains(.activity)
+            ? try container.decode(JSONValue.self, forKey: .activity) : nil
+        structuredContent = container.contains(.structuredContent)
+            ? try container.decode(JSONValue.self, forKey: .structuredContent) : nil
         content = try container.decodeIfPresent(CoreContentMetadata.self, forKey: .content)
         citations = try container.decodeIfPresent([AgentHistoryCitation].self, forKey: .citations)
         try Self.validateNormalizedResponseBody(text: text, exchange: mcpExchange, codingPath: decoder.codingPath)
@@ -605,6 +612,7 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         try container.encodeIfPresent(text, forKey: .text)
         try container.encodeIfPresent(mcpToolCall, forKey: .mcpToolCall)
         try container.encodeIfPresent(mcpExchange, forKey: .mcpExchange)
+        try container.encodeIfPresent(activity, forKey: .activity)
         try container.encodeIfPresent(structuredContent, forKey: .structuredContent)
         try container.encodeIfPresent(content, forKey: .content)
         try container.encodeIfPresent(citations, forKey: .citations)

--- a/sdks/swift/Sources/CtxAgentHistory/AgentHistoryDTOs.swift
+++ b/sdks/swift/Sources/CtxAgentHistory/AgentHistoryDTOs.swift
@@ -510,7 +510,6 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
     public var text: String?
     public var mcpToolCall: AgentHistoryMCPToolCall?
     public var mcpExchange: AgentHistoryMCPExchange?
-    public var activity: JSONValue?
     public var structuredContent: JSONValue?
     public var content: CoreContentMetadata?
     public var citations: [AgentHistoryCitation]?
@@ -528,7 +527,6 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         text: String? = nil,
         mcpToolCall: AgentHistoryMCPToolCall? = nil,
         mcpExchange: AgentHistoryMCPExchange? = nil,
-        activity: JSONValue? = nil,
         structuredContent: JSONValue? = nil,
         content: CoreContentMetadata? = nil,
         citations: [AgentHistoryCitation]? = nil
@@ -545,7 +543,6 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         self.text = text
         self.mcpToolCall = mcpToolCall
         self.mcpExchange = mcpExchange
-        self.activity = activity
         self.structuredContent = structuredContent
         self.content = content
         self.citations = citations
@@ -564,7 +561,6 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         case text
         case mcpToolCall
         case mcpExchange
-        case activity
         case structuredContent
         case content
         case citations
@@ -588,10 +584,7 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         mcpExchange = container.contains(.mcpExchange)
             ? try container.decode(AgentHistoryMCPExchange.self, forKey: .mcpExchange)
             : nil
-        activity = container.contains(.activity)
-            ? try container.decode(JSONValue.self, forKey: .activity) : nil
-        structuredContent = container.contains(.structuredContent)
-            ? try container.decode(JSONValue.self, forKey: .structuredContent) : nil
+        structuredContent = try container.decodeIfPresent(JSONValue.self, forKey: .structuredContent)
         content = try container.decodeIfPresent(CoreContentMetadata.self, forKey: .content)
         citations = try container.decodeIfPresent([AgentHistoryCitation].self, forKey: .citations)
         try Self.validateNormalizedResponseBody(text: text, exchange: mcpExchange, codingPath: decoder.codingPath)
@@ -612,7 +605,6 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         try container.encodeIfPresent(text, forKey: .text)
         try container.encodeIfPresent(mcpToolCall, forKey: .mcpToolCall)
         try container.encodeIfPresent(mcpExchange, forKey: .mcpExchange)
-        try container.encodeIfPresent(activity, forKey: .activity)
         try container.encodeIfPresent(structuredContent, forKey: .structuredContent)
         try container.encodeIfPresent(content, forKey: .content)
         try container.encodeIfPresent(citations, forKey: .citations)

--- a/sdks/swift/Sources/CtxAgentHistory/LocalCLIAdapter.swift
+++ b/sdks/swift/Sources/CtxAgentHistory/LocalCLIAdapter.swift
@@ -179,15 +179,19 @@ public struct LocalCLIAdapter: Sendable {
         let stdout = String(data: result.stdout, encoding: .utf8) ?? ""
         let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
         let firstStderrLine = stderr.split(whereSeparator: \.isNewline).first.map(String.init)
+        var producer = try? JSONDecoder().decode(JSONValue.self, from: result.stderr)
+        if producer?["error_code"]?.stringValue?.isEmpty != false ||
+            (producer?["retryable"] != nil && producer?["retryable"]?.boolValue == nil) { producer = nil }
+        var details: [String: JSONValue] = [
+            "command": .array(([ctxPath] + arguments).map { .string($0) }),
+            "exitCode": .number(Decimal(result.exitCode)), "stdout": .string(stdout), "stderr": .string(stderr)
+        ]
+        details["producerError"] = producer
         return CtxAgentHistorySDKError(
             code: .adapterError,
             message: firstStderrLine.map { "ctx command failed: \($0)" } ?? "ctx command failed",
-            details: .object([
-                "command": .array(([ctxPath] + arguments).map { .string($0) }),
-                "exitCode": .number(Decimal(result.exitCode)),
-                "stdout": .string(stdout),
-                "stderr": .string(stderr)
-            ]),
+            retryable: producer?["retryable"]?.boolValue ?? false,
+            details: .object(details),
             command: [ctxPath] + arguments,
             exitCode: Int(result.exitCode),
             stdout: stdout,

--- a/sdks/swift/Sources/CtxAgentHistory/LocalCLIAdapter.swift
+++ b/sdks/swift/Sources/CtxAgentHistory/LocalCLIAdapter.swift
@@ -179,19 +179,15 @@ public struct LocalCLIAdapter: Sendable {
         let stdout = String(data: result.stdout, encoding: .utf8) ?? ""
         let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
         let firstStderrLine = stderr.split(whereSeparator: \.isNewline).first.map(String.init)
-        var producer = try? JSONDecoder().decode(JSONValue.self, from: result.stderr)
-        if producer?["error_code"]?.stringValue?.isEmpty != false ||
-            (producer?["retryable"] != nil && producer?["retryable"]?.boolValue == nil) { producer = nil }
-        var details: [String: JSONValue] = [
-            "command": .array(([ctxPath] + arguments).map { .string($0) }),
-            "exitCode": .number(Decimal(result.exitCode)), "stdout": .string(stdout), "stderr": .string(stderr)
-        ]
-        details["producerError"] = producer
         return CtxAgentHistorySDKError(
             code: .adapterError,
             message: firstStderrLine.map { "ctx command failed: \($0)" } ?? "ctx command failed",
-            retryable: producer?["retryable"]?.boolValue ?? false,
-            details: .object(details),
+            details: .object([
+                "command": .array(([ctxPath] + arguments).map { .string($0) }),
+                "exitCode": .number(Decimal(result.exitCode)),
+                "stdout": .string(stdout),
+                "stderr": .string(stderr)
+            ]),
             command: [ctxPath] + arguments,
             exitCode: Int(result.exitCode),
             stdout: stdout,

--- a/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
+++ b/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
@@ -2,6 +2,43 @@ import XCTest
 @testable import CtxAgentHistory
 
 final class CtxAgentHistoryTests: XCTestCase {
+    func testCurrentOpaquePayloadsAndRetryErrors() throws {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+            .deletingLastPathComponent().deletingLastPathComponent()
+            .appendingPathComponent("contracts/agent-history-v1/fixtures/cli/opaque-event.json")
+        let event = try JSONDecoder().decode(JSONValue.self, from: Data(contentsOf: fixtureURL))
+        for content in [event["structured_content"], JSONValue.null, nil] {
+            var current = try XCTUnwrap(event.objectValue)
+            current["structured_content"] = content
+            let raw = JSONValue.object(["event": .object(current), "events": .array([.object(current)]), "session": .object([:])])
+            let bytes = try JSONEncoder().encode(raw)
+            let client = AgentHistoryClient(adapter: LocalCLIAdapter(runner: CapturingRunner { _ in CommandResult(stdout: bytes) }))
+            let single = try XCTUnwrap(client.showEvent("event-1").event.event)
+            let session = try XCTUnwrap(client.showSession("session-1").session.events.first)
+            for actual in [single, session] {
+                XCTAssertEqual(actual.activity, event["activity"])
+                XCTAssertEqual(actual.structuredContent, content)
+                let encoded = try JSONDecoder().decode(JSONValue.self, from: JSONEncoder().encode(actual))
+                XCTAssertEqual(encoded["structuredContent"], content)
+            }
+        }
+        for query in ["--help", "--refresh=off", "-needle", "two words", "a'雪"] {
+            let runner = CapturingRunner { _ in CommandResult(stdout: #"{"results":[]}"#) }
+            _ = try AgentHistoryClient(adapter: LocalCLIAdapter(runner: runner)).search(query)
+            XCTAssertEqual(Array(try XCTUnwrap(runner.requests.last).arguments.suffix(2)), ["--", query])
+        }
+        for retryable in [false, true] {
+            let stderr = "{\"error_code\":\"generation_changed\",\"retryable\":\(retryable)}"
+            let client = AgentHistoryClient(adapter: LocalCLIAdapter(runner: CapturingRunner { _ in CommandResult(stdout: "", stderr: stderr, exitCode: 1) }))
+            XCTAssertThrowsError(try client.showEvent("event-1")) { error in
+                let typed = error as? CtxAgentHistorySDKError
+                XCTAssertEqual(typed?.retryable, retryable)
+                XCTAssertEqual(typed?.details?["producerError"]?["error_code"], .string("generation_changed"))
+            }
+        }
+    }
+
     func testForcesAnalyticsOffAfterAmbientAndUserEnvironmentMerging() throws {
         #if !os(macOS)
         throw XCTSkip("Darwin process-group execution is macOS-only")
@@ -150,7 +187,7 @@ final class CtxAgentHistoryTests: XCTestCase {
             runner.requests[0].arguments,
             [
                 "--data-root", "/tmp/ctx-sdk-test",
-                "search", "retry handling",
+                "search",
                 "--term", "timeout",
                 "--term", "backoff",
                 "--limit", "5",
@@ -166,7 +203,7 @@ final class CtxAgentHistoryTests: XCTestCase {
                 "--events",
                 "--refresh", "off",
                 "--include-current-session",
-                "--format=json"
+                "--format=json", "--", "retry handling"
             ]
         )
     }
@@ -194,9 +231,9 @@ final class CtxAgentHistoryTests: XCTestCase {
             runner.requests[0].arguments,
             [
                 "--data-root", "/tmp/ctx-sdk-test",
-                "search", "agent history",
+                "search",
                 "--content-scope", "calls",
-                "--format=json"
+                "--format=json", "--", "agent history"
             ]
         )
         XCTAssertEqual(
@@ -247,7 +284,7 @@ final class CtxAgentHistoryTests: XCTestCase {
             switch Array(request.arguments.dropFirst(2).prefix(2)) {
             case ["status", "--format=json"]:
                 return CommandResult(stdout: Self.statusJSON)
-            case ["search", "local agent history"]:
+            case ["search", "--format=json"]:
                 return CommandResult(stdout: Self.searchJSON)
             case ["show", "event"]:
                 return CommandResult(stdout: Self.eventJSON)

--- a/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
+++ b/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
@@ -2,43 +2,6 @@ import XCTest
 @testable import CtxAgentHistory
 
 final class CtxAgentHistoryTests: XCTestCase {
-    func testCurrentOpaquePayloadsAndRetryErrors() throws {
-        let fixtureURL = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
-            .deletingLastPathComponent().deletingLastPathComponent()
-            .appendingPathComponent("contracts/agent-history-v1/fixtures/cli/opaque-event.json")
-        let event = try JSONDecoder().decode(JSONValue.self, from: Data(contentsOf: fixtureURL))
-        for content in [event["structured_content"], JSONValue.null, nil] {
-            var current = try XCTUnwrap(event.objectValue)
-            current["structured_content"] = content
-            let raw = JSONValue.object(["event": .object(current), "events": .array([.object(current)]), "session": .object([:])])
-            let bytes = try JSONEncoder().encode(raw)
-            let client = AgentHistoryClient(adapter: LocalCLIAdapter(runner: CapturingRunner { _ in CommandResult(stdout: bytes) }))
-            let single = try XCTUnwrap(client.showEvent("event-1").event.event)
-            let session = try XCTUnwrap(client.showSession("session-1").session.events.first)
-            for actual in [single, session] {
-                XCTAssertEqual(actual.activity, event["activity"])
-                XCTAssertEqual(actual.structuredContent, content)
-                let encoded = try JSONDecoder().decode(JSONValue.self, from: JSONEncoder().encode(actual))
-                XCTAssertEqual(encoded["structuredContent"], content)
-            }
-        }
-        for query in ["--help", "--refresh=off", "-needle", "two words", "a'雪"] {
-            let runner = CapturingRunner { _ in CommandResult(stdout: #"{"results":[]}"#) }
-            _ = try AgentHistoryClient(adapter: LocalCLIAdapter(runner: runner)).search(query)
-            XCTAssertEqual(Array(try XCTUnwrap(runner.requests.last).arguments.suffix(2)), ["--", query])
-        }
-        for retryable in [false, true] {
-            let stderr = "{\"error_code\":\"generation_changed\",\"retryable\":\(retryable)}"
-            let client = AgentHistoryClient(adapter: LocalCLIAdapter(runner: CapturingRunner { _ in CommandResult(stdout: "", stderr: stderr, exitCode: 1) }))
-            XCTAssertThrowsError(try client.showEvent("event-1")) { error in
-                let typed = error as? CtxAgentHistorySDKError
-                XCTAssertEqual(typed?.retryable, retryable)
-                XCTAssertEqual(typed?.details?["producerError"]?["error_code"], .string("generation_changed"))
-            }
-        }
-    }
-
     func testForcesAnalyticsOffAfterAmbientAndUserEnvironmentMerging() throws {
         #if !os(macOS)
         throw XCTSkip("Darwin process-group execution is macOS-only")
@@ -187,7 +150,7 @@ final class CtxAgentHistoryTests: XCTestCase {
             runner.requests[0].arguments,
             [
                 "--data-root", "/tmp/ctx-sdk-test",
-                "search",
+                "search", "retry handling",
                 "--term", "timeout",
                 "--term", "backoff",
                 "--limit", "5",
@@ -203,7 +166,7 @@ final class CtxAgentHistoryTests: XCTestCase {
                 "--events",
                 "--refresh", "off",
                 "--include-current-session",
-                "--format=json", "--", "retry handling"
+                "--format=json"
             ]
         )
     }
@@ -231,9 +194,9 @@ final class CtxAgentHistoryTests: XCTestCase {
             runner.requests[0].arguments,
             [
                 "--data-root", "/tmp/ctx-sdk-test",
-                "search",
+                "search", "agent history",
                 "--content-scope", "calls",
-                "--format=json", "--", "agent history"
+                "--format=json"
             ]
         )
         XCTAssertEqual(
@@ -284,7 +247,7 @@ final class CtxAgentHistoryTests: XCTestCase {
             switch Array(request.arguments.dropFirst(2).prefix(2)) {
             case ["status", "--format=json"]:
                 return CommandResult(stdout: Self.statusJSON)
-            case ["search", "--format=json"]:
+            case ["search", "local agent history"]:
                 return CommandResult(stdout: Self.searchJSON)
             case ["show", "event"]:
                 return CommandResult(stdout: Self.eventJSON)

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -2,7 +2,9 @@
 
 Experimental in-repo TypeScript/JavaScript client for the `agent-history-v1` ctx API.
 The SDK currently talks to a local `ctx` CLI binary and does not require network
-access or API keys.
+access or API keys with built-in semantic execution. The CLI honors explicitly
+configured external semantic execution, which can send bounded semantic text to
+the selected executor. See [SDK locality](../../docs/sdks.md#local-and-hosted-backends).
 
 ```js
 import { createLocalAgentHistoryClient } from "@ctx/agent-history";

--- a/sdks/typescript/examples/dogfood-toy.js
+++ b/sdks/typescript/examples/dogfood-toy.js
@@ -75,8 +75,9 @@ function mockResponse(args) {
     };
   }
   if (command === "search") {
+    const terminator = args.indexOf("--");
     return {
-      query: args[1] ?? null,
+      query: terminator < 0 ? null : args[terminator + 1] ?? null,
       generated_at: "2026-07-01T12:00:00Z",
       freshness: { mode: "off", status: "skipped", source_count: 0, totals: {} },
       results: [

--- a/sdks/typescript/src/arguments.js
+++ b/sdks/typescript/src/arguments.js
@@ -118,19 +118,19 @@ export function appendSessionLookupArgs(args, options) {
 function appendRepeated(args, flag, value) {
   const values = Array.isArray(value) ? value : value ? [value] : [];
   for (const item of values) {
-    args.push(flag, item);
+    appendOptional(args, flag, item);
   }
 }
 
 function appendOptional(args, flag, value) {
   if (value !== undefined && value !== null && value !== false) {
-    args.push(flag, value);
+    args.push(...(typeof value === "string" && value.startsWith("-") ? [`${flag}=${value}`] : [flag, value]));
   }
 }
 
 export function appendOptionalNumber(args, flag, value) {
   if (value !== undefined && value !== null) {
-    args.push(flag, String(value));
+    args.push(...(String(value).startsWith("-") ? [`${flag}=${value}`] : [flag, String(value)]));
   }
 }
 

--- a/sdks/typescript/src/errors.js
+++ b/sdks/typescript/src/errors.js
@@ -4,6 +4,7 @@ export class CtxError extends Error {
     this.name = "CtxError";
     this.code = options.code ?? "CTX_ERROR";
     this.details = options.details;
+    this.retryable = options.retryable ?? false;
   }
 }
 
@@ -11,6 +12,7 @@ export class CtxCliError extends CtxError {
   constructor(message, options = {}) {
     super(message, {
       code: options.code ?? "CTX_CLI_ERROR",
+      retryable: options.retryable,
       details: {
         command: options.command,
         args: options.args,
@@ -69,6 +71,7 @@ export class CtxTimeoutError extends CtxError {
   constructor(message, options = {}) {
     super(message, {
       code: options.code ?? "timeout",
+      retryable: true,
       details: options.details,
       cause: options.cause,
     });

--- a/sdks/typescript/src/index.d.ts
+++ b/sdks/typescript/src/index.d.ts
@@ -354,6 +354,7 @@ export interface AgentHistoryEvent {
   text?: string | null;
   mcpToolCall?: McpToolCall;
   mcpExchange?: McpExchange;
+  activity?: JsonValue;
   structuredContent?: JsonValue;
   content?: CoreContentMetadata;
   citations?: Citation[];
@@ -469,8 +470,9 @@ export interface VersionInfo {
 
 export declare class CtxError extends Error {
   code: string;
+  retryable: boolean;
   details?: unknown;
-  constructor(message: string, options?: { code?: string; details?: unknown; cause?: unknown });
+  constructor(message: string, options?: { code?: string; retryable?: boolean; details?: unknown; cause?: unknown });
 }
 
 export declare class CtxCliError extends CtxError {

--- a/sdks/typescript/src/index.js
+++ b/sdks/typescript/src/index.js
@@ -116,11 +116,9 @@ export class LocalAgentHistoryClient {
         : { ...queryOrOptions };
     validateSearchOptions(options);
     const args = ["search"];
-    if (options.query) {
-      args.push(options.query);
-    }
     appendSearchArgs(args, options);
     args.push("--format=json");
+    if (options.query !== undefined && options.query !== null) args.push("--", options.query);
     return this.#agentHistoryJson("search", args);
   }
 
@@ -557,10 +555,15 @@ function normalizeEventRecord(value) {
         member: key,
       });
     }
-    outer[key] = item;
+    const camelKey = snakeToCamel(key);
+    if (["configPath", "itemType", "payloadType", "recordType"].includes(camelKey)) continue;
+    Object.defineProperty(outer, camelKey, {
+      value: ["content", "citations"].includes(key) ? camelizeKeys(item) : item,
+      enumerable: true, writable: true, configurable: true,
+    });
   }
 
-  const event = camelizeKeys(outer);
+  const event = outer;
   if (hasSnake || hasCamel) {
     event.mcpToolCall = validateMcpToolCall(
       hasSnake ? value.mcp_tool_call : value.mcpToolCall,
@@ -888,7 +891,14 @@ function snakeToCamel(value) {
 
 
 function cliError(message, result) {
+  let producer;
+  try { producer = JSON.parse(result.stderr); } catch { /* Plain diagnostic fallback. */ }
+  if (!producer || typeof producer !== "object" || Array.isArray(producer) ||
+      typeof producer.error_code !== "string" || !producer.error_code ||
+      (producer.retryable !== undefined && typeof producer.retryable !== "boolean")) producer = undefined;
   return new CtxCliError(message, {
+    retryable: producer?.retryable ?? false,
+    details: producer ? { producerError: producer } : undefined,
     command: result.command,
     args: result.args,
     exitCode: result.exitCode,

--- a/sdks/typescript/test/client.test.js
+++ b/sdks/typescript/test/client.test.js
@@ -273,7 +273,6 @@ test("builds search flags and normalizes nested CLI search output", async () => 
     "--data-root",
     "/tmp/ctx-sdk-test",
     "search",
-    "retry handling",
     "--term",
     "timeout",
     "--term",
@@ -302,6 +301,8 @@ test("builds search flags and normalizes nested CLI search output", async () => 
     "off",
     "--include-current-session",
     "--format=json",
+    "--",
+    "retry handling",
   ]);
 });
 

--- a/sdks/typescript/test/fidelity.test.js
+++ b/sdks/typescript/test/fidelity.test.js
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { createLocalAgentHistoryClient } from "../src/index.js";
+
+const fixture = async (name) => JSON.parse(await readFile(new URL(`../../../../contracts/agent-history-v1/fixtures/cli/${name}`, import.meta.url), "utf8"));
+
+test("current event and session preserve exact opaque JSON and presence", async () => {
+  const event = await fixture("opaque-event.json");
+  for (const value of [event.structured_content, null, undefined]) {
+    const current = { ...event, structured_content: value };
+    const raw = { event: current, events: [current], session: { ctx_session_id: "session-1" } };
+    const client = createLocalAgentHistoryClient({ runner: async () => ({ stdout: JSON.stringify(raw) }) });
+    for (const actual of [(await client.showEvent("event-1")).event.event, (await client.showSession("session-1")).session.events[0]]) {
+      assert.deepEqual(actual.activity, event.activity);
+      assert.equal(Object.hasOwn(actual, "structuredContent"), value !== undefined);
+      assert.deepEqual(actual.structuredContent, value);
+      assert.equal(actual.content.policyStatus, "selected");
+    }
+  }
+});
+
+test("literal queries follow every option", async () => {
+  for (const query of ["--help", "--refresh=off", "-needle", "two words", "a'雪"]) {
+    let args;
+    const client = createLocalAgentHistoryClient({ runner: async (request) => { args = request.args; return { stdout: '{"results":[]}' }; } });
+    await client.search(query, { refresh: "off", terms: ["--help"] });
+    assert.deepEqual(args.slice(-2), ["--", query]);
+    assert.ok(args.includes("--term=--help"));
+  }
+});
+
+test("producer retry decisions and details survive CLI errors", async () => {
+  for (const producer of await fixture("producer-errors.json")) {
+    const client = createLocalAgentHistoryClient({ runner: async () => ({ exitCode: 1, stderr: JSON.stringify(producer) }) });
+    await assert.rejects(client.showEvent("event-1"), error => {
+      assert.equal(error.retryable, producer.retryable);
+      assert.deepEqual(error.details.producerError, producer);
+      return true;
+    });
+  }
+  const client = createLocalAgentHistoryClient({ runner: async () => ({ exitCode: 1, stderr: "not JSON" }) });
+  await assert.rejects(client.showEvent("event-1"), error => error.retryable === false && error.stderr === "not JSON");
+});

--- a/sdks/typescript/test/fidelity.test.js
+++ b/sdks/typescript/test/fidelity.test.js
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { createLocalAgentHistoryClient } from "../src/index.js";
 
-const fixture = async (name) => JSON.parse(await readFile(new URL(`../../../../contracts/agent-history-v1/fixtures/cli/${name}`, import.meta.url), "utf8"));
+const fixture = async (name) => JSON.parse(await readFile(new URL(`../../../contracts/agent-history-v1/fixtures/cli/${name}`, import.meta.url), "utf8"));
 
 test("current event and session preserve exact opaque JSON and presence", async () => {
   const event = await fixture("opaque-event.json");


### PR DESCRIPTION
Shown activity and structured content can lose application keys or explicit nulls during SDK normalization. Preserve those values in the Rust, TypeScript, Python, Go, JVM and .NET SDKs, including Rust complete and paged session paths. Rust protocol decoding now distinguishes a present JSON null from an absent field.

Preserve producer retry decisions and structured diagnostics under details.producerError. Place search options before the literal query terminator in SDK arguments and generated CLI followups. Clarify that ctx honors explicitly configured external semantic execution.

The corresponding Swift changes are deferred pending native owning-suite qualification. Its implementation and tests remain unchanged; compatibility notes beside the shared contract claims describe the remaining JSON, retry-error and query limitations. Pagination expansion and runtime locality metadata changes are deferred.

Validation: owning Rust SDK39/protocol9, CLI parser145, renderer209, Python39, TypeScript38 plus typecheck, JVM compile/tests/example, .NET31, Go SDK/dogfood and shared contracts pass on preserved relevant inputs. All83 selected affected targets executed:81passed and two failed. The generated-command assertion is corrected and its36-case search/show suite passed. Six current-base checks executed and passed, including CLI240, setup108, refresh193, search-refresh21 and docs. The remaining pipeline failure was reproduced as an injected required-group override affecting an optional-group fixture; its unchanged owner passed with that override omitted, using the same consumed inputs in a separate worktree. Mandatory SDK group checks remained enabled. No Swift runtime pass is claimed.