### PR TITLE
Fix supervisor test isolation and document lexical output search

### DIFF
--- a/crates/ctx-daemon-application/src/supervisor/tests/additional.rs
+++ b/crates/ctx-daemon-application/src/supervisor/tests/additional.rs
@@ -940,21 +940,16 @@ fn native_disable_failure_does_not_claim_an_unavailable_launch_probe_is_healthy(
 
 #[test]
 fn canonical_supervisor_root_is_independent_of_ctx_data_root_override() {
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-    let _guard = ENV_LOCK.lock().unwrap();
-    let previous = env::var_os("CTX_DATA_ROOT");
+    let _env_lock = crate::test_environment_lock()
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    let _restore = RestoreTestEnvironment::capture(&["CTX_DATA_ROOT"]);
     let canonical = ctx_history_platform::managed_data_root().unwrap();
     let custom = canonical.with_file_name("ctx-custom-supervisor-test");
     env::set_var("CTX_DATA_ROOT", &custom);
 
     assert!(is_canonical_managed_data_root(&canonical).unwrap());
     assert!(!is_canonical_managed_data_root(&custom).unwrap());
-
-    if let Some(previous) = previous {
-        env::set_var("CTX_DATA_ROOT", previous);
-    } else {
-        env::remove_var("CTX_DATA_ROOT");
-    }
 }
 
 #[test]

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -67,8 +67,11 @@ shipped.
 ## Search Semantics
 
 - Search quality depends on what providers expose and what importers index.
-- Command and tool result bodies are not searchable; only compact typed
-  outcome/evidence metadata is indexed.
+- Admitted command and tool result bodies are searchable lexically. Outputs
+  are downweighted in the default `all` scope; use `--content-scope outputs`
+  to search them at ordinary lexical strength. Provider availability and
+  content policy still limit which bodies are indexed. Output-only semantic
+  search is unsupported; hybrid output searches fall back to lexical retrieval.
 - Ranking is deterministic for the same local database and options, but it is
   not a claim of semantic understanding.
 - Empty or punctuation-only search is invalid. Broad valid queries can still


### PR DESCRIPTION
The supervisor root test now uses the shared environment mutex and existing restoration guard, so it cannot race HOME changes in adjacent tests and restores its data-root override on unwind. The limitations topic describes lexical search of admitted command and tool outputs, including scope weighting and the semantic-only output limitation.

Validation included 39 focused supervisor tests and all 114 daemon-application tests, which passed with four threads. The documentation check passed. All 76 selected affected targets executed on the earlier candidate: 73 passed and three failed.

Follow-up runs passed all 4 uninstall tests and all 14 DeepSeek tests with fixture-owned daemon settings. All 108 setup tests passed on commit 82329 after the upstream setup correction.

Later daemon, plugin-header and SDK inputs were mapped to actual owning proof: 572 daemon tests; 217 plugin CLI unit tests, 5 binary tests and 4 parity tests from completed targets; and six SDK compatibility targets on commit 866555, including 108 setup tests and 36 search/show tests.

The exact reviewed two-file diff is unchanged. All results retain their recorded source and environment identities. Setup and the full affected set were not rerun on this head.

On this candidate, one selected upgrade dispatch test passed all 12 internal recovery scenarios, with 164 other unit tests filtered out. All 26 managed-pair unit tests passed, including the permission-denied cleanup case. Both targets executed with normal build cache reuse and no test-result cache hits.