### PR TITLE
Scope queued analytics to each data root's consent

### DIFF
--- a/crates/ctx-cli/src/analytics_outbox.rs
+++ b/crates/ctx-cli/src/analytics_outbox.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, HashSet},
     fs,
     io::{Read as _, Write as _},
     path::{Path, PathBuf},
@@ -17,8 +17,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest as _, Sha256};
 
-const RELEASED_OUTBOX_SCHEMA_VERSION: u16 = 1;
-const OUTBOX_SCHEMA_VERSION: u16 = 2;
+const OUTBOX_SCHEMA_VERSION: u16 = 3;
 const OUTBOX_MAX_BYTES: u64 = 2 * 1024 * 1024;
 const OUTBOX_MAX_BODY_BYTES: usize = 512 * 1024;
 const OUTBOX_MAX_ENTRIES: usize = 128;
@@ -41,6 +40,7 @@ enum OutboxEntryKind {
 struct OutboxEntry {
     schema_version: u16,
     entry_id: String,
+    data_root_id: String,
     endpoint_fingerprint: String,
     queued_at_epoch_seconds: i64,
     attempts: u16,
@@ -54,6 +54,12 @@ struct OutboxEntry {
 struct OutboxState {
     schema_version: u16,
     entries: Vec<OutboxEntry>,
+    roots: BTreeMap<String, RootDeliveryState>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RootDeliveryState {
     retry_attempts: u64,
     dropped: u64,
     failure_sequence: u64,
@@ -61,55 +67,10 @@ struct OutboxState {
     observation_due: bool,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct ReleasedOutboxEntryV1 {
-    schema_version: u16,
-    endpoint_fingerprint: String,
-    queued_at_epoch_seconds: i64,
-    attempts: u16,
-    payload: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct ReleasedOutboxStateV1 {
-    schema_version: u16,
-    entries: Vec<ReleasedOutboxEntryV1>,
-    retry_attempts: u64,
-    dropped: u64,
-    failure_sequence: u64,
-    last_failure_class: Option<AnalyticsDeliveryFailureClass>,
-}
-
-impl OutboxState {
-    fn empty() -> Self {
-        Self {
-            schema_version: OUTBOX_SCHEMA_VERSION,
-            entries: Vec::new(),
-            retry_attempts: 0,
-            dropped: 0,
-            failure_sequence: 0,
-            last_failure_class: None,
-            observation_due: false,
-        }
-    }
-
-    fn recovered() -> Self {
-        Self {
-            dropped: 1,
-            failure_sequence: 1,
-            last_failure_class: Some(AnalyticsDeliveryFailureClass::LocalIo),
-            ..Self::empty()
-        }
-    }
-
+impl RootDeliveryState {
     fn record_failure(&mut self, class: AnalyticsDeliveryFailureClass) {
         self.failure_sequence = self.failure_sequence.saturating_add(1);
         self.last_failure_class = Some(class);
-        // A later success must precede any observation that includes this
-        // failure. This also coalesces an interrupted recovery with the next
-        // one instead of reporting a failure as though it had recovered.
         self.observation_due = false;
     }
 
@@ -118,21 +79,49 @@ impl OutboxState {
         self.record_failure(class);
     }
 
+    fn has_counters(&self) -> bool {
+        self.retry_attempts != 0 || self.dropped != 0 || self.last_failure_class.is_some()
+    }
+}
+
+impl OutboxState {
+    fn empty() -> Self {
+        Self {
+            schema_version: OUTBOX_SCHEMA_VERSION,
+            entries: Vec::new(),
+            roots: BTreeMap::new(),
+        }
+    }
+
+    fn root(&self, data_root_id: &str) -> RootDeliveryState {
+        self.roots.get(data_root_id).copied().unwrap_or_default()
+    }
+
+    fn root_mut(&mut self, data_root_id: &str) -> &mut RootDeliveryState {
+        self.roots.entry(data_root_id.to_owned()).or_default()
+    }
+
+    fn recovered(data_root_id: &str) -> Self {
+        let mut state = Self::empty();
+        state
+            .root_mut(data_root_id)
+            .record_ordinary_drop(AnalyticsDeliveryFailureClass::LocalIo);
+        state
+    }
+
     fn prune_expired(&mut self, now_epoch_seconds: i64) -> bool {
         let cutoff = now_epoch_seconds.saturating_sub(OUTBOX_MAX_AGE_SECONDS);
-        let mut ordinary_dropped = 0_u64;
         let before = self.entries.len();
         self.entries.retain(|entry| {
             let keep = entry.queued_at_epoch_seconds >= cutoff;
             if !keep && entry.kind == OutboxEntryKind::Ordinary {
-                ordinary_dropped = ordinary_dropped.saturating_add(1);
+                self.roots
+                    .entry(entry.data_root_id.clone())
+                    .or_default()
+                    .record_ordinary_drop(AnalyticsDeliveryFailureClass::LocalIo);
             }
             keep
         });
-        if ordinary_dropped != 0 {
-            self.dropped = self.dropped.saturating_add(ordinary_dropped);
-            self.record_failure(AnalyticsDeliveryFailureClass::LocalIo);
-        }
         self.entries.len() != before
     }
 
@@ -140,19 +129,43 @@ impl OutboxState {
         let latest_retry = now_epoch_seconds.saturating_add(RETRY_MAX_SECONDS as i64);
         let mut normalized = false;
         for entry in &mut self.entries {
-            if entry.queued_at_epoch_seconds > now_epoch_seconds {
-                entry.queued_at_epoch_seconds = now_epoch_seconds;
+            let changed = entry.queued_at_epoch_seconds > now_epoch_seconds
+                || entry.next_attempt_at_epoch_seconds > latest_retry;
+            entry.queued_at_epoch_seconds = entry.queued_at_epoch_seconds.min(now_epoch_seconds);
+            entry.next_attempt_at_epoch_seconds =
+                entry.next_attempt_at_epoch_seconds.min(latest_retry);
+            if changed {
+                self.roots
+                    .entry(entry.data_root_id.clone())
+                    .or_default()
+                    .record_failure(AnalyticsDeliveryFailureClass::LocalIo);
                 normalized = true;
             }
-            if entry.next_attempt_at_epoch_seconds > latest_retry {
-                entry.next_attempt_at_epoch_seconds = latest_retry;
-                normalized = true;
-            }
-        }
-        if normalized {
-            self.record_failure(AnalyticsDeliveryFailureClass::LocalIo);
         }
         normalized
+    }
+
+    fn trim_root_metadata(&mut self) {
+        let queued_roots: HashSet<_> = self
+            .entries
+            .iter()
+            .map(|entry| entry.data_root_id.as_str())
+            .collect();
+        self.roots
+            .retain(|id, state| queued_roots.contains(id.as_str()) || state.has_counters());
+        // Every root with entries retains its counters. Counter-only records
+        // are best effort and cannot turn root churn into unbounded storage.
+        let excess = self.roots.len().saturating_sub(OUTBOX_MAX_ENTRIES);
+        let evicted: Vec<_> = self
+            .roots
+            .keys()
+            .filter(|id| !queued_roots.contains(id.as_str()))
+            .take(excess)
+            .cloned()
+            .collect();
+        for id in evicted {
+            self.roots.remove(&id);
+        }
     }
 
     fn enforce_bounds(&mut self) -> Result<()> {
@@ -160,6 +173,7 @@ impl OutboxState {
             self.drop_oldest_for_bound();
         }
         loop {
+            self.trim_root_metadata();
             let body = serde_json::to_vec(self).context("serialize analytics outbox")?;
             if body.len() as u64 <= OUTBOX_MAX_BYTES {
                 return Ok(());
@@ -174,7 +188,8 @@ impl OutboxState {
     fn drop_oldest_for_bound(&mut self) {
         let entry = self.entries.remove(0);
         if entry.kind == OutboxEntryKind::Ordinary {
-            self.record_ordinary_drop(AnalyticsDeliveryFailureClass::LocalIo);
+            self.root_mut(&entry.data_root_id)
+                .record_ordinary_drop(AnalyticsDeliveryFailureClass::LocalIo);
         }
     }
 }
@@ -192,6 +207,7 @@ enum StoredOutbox {
 }
 
 pub(crate) struct OutboxObservation {
+    data_root_id: String,
     pub(crate) event: AnalyticsDeliveryObservationV1,
     retry_attempts: u64,
     dropped: u64,
@@ -201,6 +217,7 @@ pub(crate) struct OutboxObservation {
 #[derive(Debug, Clone)]
 pub(crate) struct SnapshotEntry {
     entry_id: String,
+    data_root_id: String,
     endpoint_fingerprint: String,
     payload: String,
     attempts: u16,
@@ -214,6 +231,7 @@ impl SnapshotEntry {
 
     fn matches(&self, entry: &OutboxEntry) -> bool {
         entry.entry_id == self.entry_id
+            && entry.data_root_id == self.data_root_id
             && entry.endpoint_fingerprint == self.endpoint_fingerprint
             && entry.payload == self.payload
             && entry.attempts == self.attempts
@@ -235,6 +253,7 @@ pub(crate) enum DeliveryDisposition {
 
 pub(crate) struct AnalyticsOutbox {
     path: PathBuf,
+    data_root_id: String,
 }
 
 pub(crate) struct UploaderLease {
@@ -242,17 +261,21 @@ pub(crate) struct UploaderLease {
 }
 
 impl AnalyticsOutbox {
-    pub(crate) fn open(path: PathBuf) -> Result<Self> {
-        Self::open_at(path, utc_now().timestamp())
+    pub(crate) fn open(path: PathBuf, data_root_id: &str) -> Result<Self> {
+        Self::open_at(path, data_root_id, utc_now().timestamp())
     }
 
-    fn open_at(path: PathBuf, now_epoch_seconds: i64) -> Result<Self> {
+    fn open_at(path: PathBuf, data_root_id: &str, now_epoch_seconds: i64) -> Result<Self> {
+        validate_root_id(data_root_id)?;
         let parent = path
             .parent()
             .context("analytics outbox path has no parent")?
             .to_path_buf();
         fs::create_dir_all(&parent).context("create analytics outbox directory")?;
-        let outbox = Self { path };
+        let outbox = Self {
+            path,
+            data_root_id: data_root_id.to_owned(),
+        };
         let _lock = OutboxLock::acquire(&outbox.state_lock_path())?;
         if cleanup_orphan_temps(&parent)? {
             sync_parent(&parent)?;
@@ -264,7 +287,7 @@ impl AnalyticsOutbox {
         Ok(outbox)
     }
 
-    pub(crate) fn purge(path: &Path) -> Result<()> {
+    pub(crate) fn purge(path: &Path, data_root_id: Option<&str>) -> Result<()> {
         let Some(parent) = path.parent() else {
             bail!("analytics outbox path has no parent");
         };
@@ -276,6 +299,20 @@ impl AnalyticsOutbox {
         }
         let _lock = OutboxLock::acquire(&path.with_extension("lock"))?;
         let mut changed = cleanup_orphan_temps(parent)?;
+        if let StoredOutbox::State(mut state, _) = read_state(path)? {
+            if validate_state(&state).is_ok() {
+                state
+                    .entries
+                    .retain(|entry| Some(entry.data_root_id.as_str()) != data_root_id);
+                if let Some(id) = data_root_id {
+                    state.roots.remove(id);
+                }
+                if !state.entries.is_empty() || !state.roots.is_empty() {
+                    let body = serde_json::to_vec(&state).context("serialize analytics outbox")?;
+                    return write_private_file_durably(path, &body);
+                }
+            }
+        }
         match fs::remove_file(path) {
             Ok(()) => changed = true,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
@@ -306,13 +343,16 @@ impl AnalyticsOutbox {
         if body.len() > OUTBOX_MAX_BODY_BYTES {
             loaded
                 .state
+                .root_mut(&self.data_root_id)
                 .record_ordinary_drop(AnalyticsDeliveryFailureClass::LocalIo);
+            loaded.state.enforce_bounds()?;
             self.persist(&loaded.state)?;
             bail!("analytics payload exceeds the outbox body bound");
         }
         loaded.state.entries.push(OutboxEntry {
             schema_version: OUTBOX_SCHEMA_VERSION,
             entry_id: uuid::Uuid::new_v4().to_string(),
+            data_root_id: self.data_root_id.clone(),
             endpoint_fingerprint: endpoint_fingerprint(endpoint),
             queued_at_epoch_seconds: now_epoch_seconds,
             attempts: 0,
@@ -340,12 +380,14 @@ impl AnalyticsOutbox {
             .entries
             .iter()
             .filter(|entry| {
-                entry.endpoint_fingerprint == fingerprint
+                entry.data_root_id == self.data_root_id
+                    && entry.endpoint_fingerprint == fingerprint
                     && entry.next_attempt_at_epoch_seconds <= now_epoch_seconds
             })
             .take(OUTBOX_MAX_FLUSH_PER_CALL)
             .map(|entry| SnapshotEntry {
                 entry_id: entry.entry_id.clone(),
+                data_root_id: entry.data_root_id.clone(),
                 endpoint_fingerprint: entry.endpoint_fingerprint.clone(),
                 payload: entry.payload.clone(),
                 attempts: entry.attempts,
@@ -362,6 +404,9 @@ impl AnalyticsOutbox {
     }
 
     pub(crate) fn contains_snapshot(&self, snapshot: &SnapshotEntry) -> Result<bool> {
+        if snapshot.data_root_id != self.data_root_id {
+            return Ok(false);
+        }
         let _lock = OutboxLock::acquire(&self.state_lock_path())?;
         let loaded = self.load_normalized(utc_now().timestamp())?;
         if loaded.dirty {
@@ -389,6 +434,9 @@ impl AnalyticsOutbox {
             return Ok(());
         }
         for (snapshot, disposition) in attempts {
+            if snapshot.data_root_id != self.data_root_id {
+                bail!("analytics snapshot belongs to another data root");
+            }
             let Some(index) = loaded
                 .state
                 .entries
@@ -404,18 +452,16 @@ impl AnalyticsOutbox {
             match *disposition {
                 DeliveryDisposition::Accepted => {
                     let accepted = loaded.state.entries.remove(index);
-                    if accepted.kind == OutboxEntryKind::Ordinary
-                        && (loaded.state.retry_attempts != 0
-                            || loaded.state.dropped != 0
-                            || loaded.state.last_failure_class.is_some())
-                    {
-                        loaded.state.observation_due = true;
+                    let root = loaded.state.root_mut(&self.data_root_id);
+                    if accepted.kind == OutboxEntryKind::Ordinary && root.has_counters() {
+                        root.observation_due = true;
                     }
                 }
                 DeliveryDisposition::Retry { class, retry_after } => {
                     if snapshot.kind == OutboxEntryKind::Ordinary {
-                        loaded.state.retry_attempts = loaded.state.retry_attempts.saturating_add(1);
-                        loaded.state.record_failure(class);
+                        let root = loaded.state.root_mut(&self.data_root_id);
+                        root.retry_attempts = root.retry_attempts.saturating_add(1);
+                        root.record_failure(class);
                     }
                     let entry = &mut loaded.state.entries[index];
                     entry.attempts = entry.attempts.saturating_add(1);
@@ -426,7 +472,10 @@ impl AnalyticsOutbox {
                 DeliveryDisposition::Permanent { class } => {
                     let rejected = loaded.state.entries.remove(index);
                     if rejected.kind == OutboxEntryKind::Ordinary {
-                        loaded.state.record_ordinary_drop(class);
+                        loaded
+                            .state
+                            .root_mut(&self.data_root_id)
+                            .record_ordinary_drop(class);
                     }
                 }
             }
@@ -442,29 +491,29 @@ impl AnalyticsOutbox {
     fn pending_observation_at(&self, now_epoch_seconds: i64) -> Result<Option<OutboxObservation>> {
         let _lock = OutboxLock::acquire(&self.state_lock_path())?;
         let mut loaded = self.load_normalized(now_epoch_seconds)?;
-        let health_pending = loaded
-            .state
-            .entries
-            .iter()
-            .any(|entry| entry.kind == OutboxEntryKind::DeliveryObservation);
-        let has_counters = loaded.state.retry_attempts != 0
-            || loaded.state.dropped != 0
-            || loaded.state.last_failure_class.is_some();
-        if loaded.state.observation_due && !has_counters {
-            loaded.state.observation_due = false;
+        let health_pending = loaded.state.entries.iter().any(|entry| {
+            entry.data_root_id == self.data_root_id
+                && entry.kind == OutboxEntryKind::DeliveryObservation
+        });
+        let root = loaded.state.root(&self.data_root_id);
+        let has_counters = root.has_counters();
+        if root.observation_due && !has_counters {
+            loaded.state.root_mut(&self.data_root_id).observation_due = false;
             loaded.dirty = true;
         }
         if loaded.dirty {
             self.persist(&loaded.state)?;
         }
-        if !loaded.state.observation_due || health_pending || !has_counters {
+        if !root.observation_due || health_pending || !has_counters {
             return Ok(None);
         }
         let oldest_age_seconds = loaded
             .state
             .entries
             .iter()
-            .filter(|entry| entry.kind == OutboxEntryKind::Ordinary)
+            .filter(|entry| {
+                entry.data_root_id == self.data_root_id && entry.kind == OutboxEntryKind::Ordinary
+            })
             .map(|entry| {
                 now_epoch_seconds
                     .saturating_sub(entry.queued_at_epoch_seconds)
@@ -473,24 +522,26 @@ impl AnalyticsOutbox {
             .max()
             .unwrap_or(0);
         Ok(Some(OutboxObservation {
+            data_root_id: self.data_root_id.clone(),
             event: AnalyticsDeliveryObservationV1::new(
                 loaded
                     .state
                     .entries
                     .iter()
-                    .filter(|entry| entry.kind == OutboxEntryKind::Ordinary)
+                    .filter(|entry| {
+                        entry.data_root_id == self.data_root_id
+                            && entry.kind == OutboxEntryKind::Ordinary
+                    })
                     .count() as u64,
-                loaded.state.retry_attempts,
-                loaded.state.dropped,
+                root.retry_attempts,
+                root.dropped,
                 Duration::from_secs(oldest_age_seconds),
-                loaded
-                    .state
-                    .last_failure_class
+                root.last_failure_class
                     .unwrap_or(AnalyticsDeliveryFailureClass::None),
             ),
-            retry_attempts: loaded.state.retry_attempts,
-            dropped: loaded.state.dropped,
-            failure_sequence: loaded.state.failure_sequence,
+            retry_attempts: root.retry_attempts,
+            dropped: root.dropped,
+            failure_sequence: root.failure_sequence,
         }))
     }
 
@@ -510,29 +561,31 @@ impl AnalyticsOutbox {
         observation: &OutboxObservation,
         now_epoch_seconds: i64,
     ) -> Result<()> {
+        if observation.data_root_id != self.data_root_id {
+            bail!("analytics observation belongs to another data root");
+        }
         let payload = validate_payload(body)?;
         if body.len() > OUTBOX_MAX_BODY_BYTES {
             bail!("analytics delivery observation exceeds the outbox body bound");
         }
         let _lock = OutboxLock::acquire(&self.state_lock_path())?;
         let mut loaded = self.load_normalized(now_epoch_seconds)?;
-        if !loaded.state.observation_due
-            || loaded
-                .state
-                .entries
-                .iter()
-                .any(|entry| entry.kind == OutboxEntryKind::DeliveryObservation)
+        let root = loaded.state.root(&self.data_root_id);
+        if !root.observation_due
+            || loaded.state.entries.iter().any(|entry| {
+                entry.data_root_id == self.data_root_id
+                    && entry.kind == OutboxEntryKind::DeliveryObservation
+            })
         {
             return Ok(());
         }
-        if loaded.state.retry_attempts < observation.retry_attempts
-            || loaded.state.dropped < observation.dropped
-        {
+        if root.retry_attempts < observation.retry_attempts || root.dropped < observation.dropped {
             bail!("analytics delivery observation is stale");
         }
         loaded.state.entries.push(OutboxEntry {
             schema_version: OUTBOX_SCHEMA_VERSION,
             entry_id: uuid::Uuid::new_v4().to_string(),
+            data_root_id: self.data_root_id.clone(),
             endpoint_fingerprint: endpoint_fingerprint(endpoint),
             queued_at_epoch_seconds: now_epoch_seconds,
             attempts: 0,
@@ -540,20 +593,22 @@ impl AnalyticsOutbox {
             kind: OutboxEntryKind::DeliveryObservation,
             payload,
         });
-        loaded.state.retry_attempts = loaded
-            .state
+        let root = loaded.state.root_mut(&self.data_root_id);
+        root.retry_attempts = root
             .retry_attempts
             .saturating_sub(observation.retry_attempts);
-        loaded.state.dropped = loaded.state.dropped.saturating_sub(observation.dropped);
-        if loaded.state.failure_sequence == observation.failure_sequence {
-            loaded.state.last_failure_class = None;
-            loaded.state.observation_due = false;
+        root.dropped = root.dropped.saturating_sub(observation.dropped);
+        if root.failure_sequence == observation.failure_sequence {
+            root.last_failure_class = None;
+            root.observation_due = false;
         } else {
-            loaded.state.observation_due = true;
+            root.observation_due = true;
         }
         loaded.state.enforce_bounds()?;
-        if loaded.state.failure_sequence != observation.failure_sequence {
-            loaded.state.observation_due = true;
+        if let Some(root) = loaded.state.roots.get_mut(&self.data_root_id) {
+            if root.failure_sequence != observation.failure_sequence {
+                root.observation_due = true;
+            }
         }
         self.persist(&loaded.state)
     }
@@ -565,11 +620,11 @@ impl AnalyticsOutbox {
     fn load_normalized(&self, now_epoch_seconds: i64) -> Result<LoadedState> {
         let (mut state, mut dirty, missing) = match read_state(&self.path)? {
             StoredOutbox::Missing => (OutboxState::empty(), false, true),
-            StoredOutbox::Corrupt => (OutboxState::recovered(), true, false),
+            StoredOutbox::Corrupt => (OutboxState::recovered(&self.data_root_id), true, false),
             StoredOutbox::State(state, migrated) => (state, migrated, false),
         };
         if validate_state(&state).is_err() {
-            state = OutboxState::recovered();
+            state = OutboxState::recovered(&self.data_root_id);
             dirty = true;
         }
         if state.normalize_timestamps(now_epoch_seconds) {
@@ -637,10 +692,19 @@ fn validate_state(state: &OutboxState) -> Result<()> {
         bail!("analytics outbox exceeds its entry bound");
     }
     let mut ids = HashSet::with_capacity(state.entries.len());
-    let mut health_entries = 0_usize;
+    if state.roots.len() > OUTBOX_MAX_ENTRIES {
+        bail!("analytics outbox exceeds its root metadata bound");
+    }
+    for id in state.roots.keys() {
+        validate_root_id(id)?;
+    }
+    let mut health_roots = HashSet::new();
     for entry in &state.entries {
-        if entry.kind == OutboxEntryKind::DeliveryObservation {
-            health_entries = health_entries.saturating_add(1);
+        validate_root_id(&entry.data_root_id)?;
+        if entry.kind == OutboxEntryKind::DeliveryObservation
+            && !health_roots.insert(&entry.data_root_id)
+        {
+            bail!("analytics outbox contains multiple delivery observations for a root");
         }
         if entry.schema_version != OUTBOX_SCHEMA_VERSION
             || uuid::Uuid::parse_str(&entry.entry_id).is_err()
@@ -655,9 +719,6 @@ fn validate_state(state: &OutboxState) -> Result<()> {
         {
             bail!("analytics outbox entry is invalid");
         }
-    }
-    if health_entries > 1 {
-        bail!("analytics outbox contains multiple delivery observations");
     }
     Ok(())
 }
@@ -696,46 +757,19 @@ fn read_state(path: &Path) -> Result<StoredOutbox> {
         Some(OUTBOX_SCHEMA_VERSION) => Ok(serde_json::from_value(value)
             .map(|state| StoredOutbox::State(state, false))
             .unwrap_or(StoredOutbox::Corrupt)),
-        Some(RELEASED_OUTBOX_SCHEMA_VERSION) => Ok(serde_json::from_value(value)
-            .ok()
-            .and_then(migrate_released_v1)
-            .map(|state| StoredOutbox::State(state, true))
-            .unwrap_or(StoredOutbox::Corrupt)),
+        // Older shared entries and counters have no consent owner. Do not
+        // infer ownership from their payloads or replay them under this root.
+        Some(1 | 2) => Ok(StoredOutbox::State(OutboxState::empty(), true)),
         _ => Ok(StoredOutbox::Corrupt),
     }
 }
 
-fn migrate_released_v1(released: ReleasedOutboxStateV1) -> Option<OutboxState> {
-    if released.schema_version != RELEASED_OUTBOX_SCHEMA_VERSION
-        || released
-            .entries
-            .iter()
-            .any(|entry| entry.schema_version != RELEASED_OUTBOX_SCHEMA_VERSION)
-    {
-        return None;
+fn validate_root_id(id: &str) -> Result<()> {
+    let parsed = uuid::Uuid::parse_str(id).context("parse analytics root identity")?;
+    if parsed.is_nil() || parsed.to_string() != id {
+        bail!("analytics root identity is invalid");
     }
-    Some(OutboxState {
-        schema_version: OUTBOX_SCHEMA_VERSION,
-        entries: released
-            .entries
-            .into_iter()
-            .map(|entry| OutboxEntry {
-                schema_version: OUTBOX_SCHEMA_VERSION,
-                entry_id: uuid::Uuid::new_v4().to_string(),
-                endpoint_fingerprint: entry.endpoint_fingerprint,
-                queued_at_epoch_seconds: entry.queued_at_epoch_seconds,
-                attempts: entry.attempts,
-                next_attempt_at_epoch_seconds: 0,
-                kind: OutboxEntryKind::Ordinary,
-                payload: entry.payload,
-            })
-            .collect(),
-        retry_attempts: released.retry_attempts,
-        dropped: released.dropped,
-        failure_sequence: released.failure_sequence,
-        last_failure_class: released.last_failure_class,
-        observation_due: false,
-    })
+    Ok(())
 }
 
 struct OutboxLock(fs::File);

--- a/crates/ctx-cli/src/analytics_outbox/tests.rs
+++ b/crates/ctx-cli/src/analytics_outbox/tests.rs
@@ -5,6 +5,8 @@ use ctx_client_observability::analytics::CountBucket;
 use super::*;
 
 const ENDPOINT: &str = "https://cli.ctx.rs/functions/v1/analytics";
+const ROOT: &str = "00000000-0000-4000-8000-000000000002";
+const OTHER_ROOT: &str = "00000000-0000-4000-8000-000000000003";
 const NOW: i64 = 1_800_000_000;
 
 fn body(event_id: &str) -> Vec<u8> {
@@ -23,11 +25,11 @@ fn event_id(index: usize) -> String {
 fn test_outbox() -> (tempfile::TempDir, PathBuf, AnalyticsOutbox) {
     let root = tempfile::tempdir().unwrap();
     let path = root.path().join("outbox.json");
-    let outbox = AnalyticsOutbox::open_at(path.clone(), NOW).unwrap();
+    let outbox = AnalyticsOutbox::open_at(path.clone(), ROOT, NOW).unwrap();
     (root, path, outbox)
 }
 
-fn read_v2(path: &Path) -> OutboxState {
+fn read_current(path: &Path) -> OutboxState {
     serde_json::from_slice(&fs::read(path).unwrap()).unwrap()
 }
 
@@ -39,37 +41,49 @@ fn retry(class: AnalyticsDeliveryFailureClass) -> DeliveryDisposition {
 }
 
 #[test]
-fn released_v1_migrates_without_changing_payload_or_endpoint_fingerprint() {
+fn legacy_shared_bodies_and_counters_are_discarded_without_guessing_ownership() {
     let root = tempfile::tempdir().unwrap();
     let path = root.path().join("outbox.json");
-    let payload = "{ \"events\" : [{\"event_id\":\"preserved\"}] }";
-    let fingerprint = endpoint_fingerprint(ENDPOINT);
-    let released = serde_json::json!({
-        "schema_version": 1,
-        "entries": [{
-            "schema_version": 1,
-            "endpoint_fingerprint": fingerprint,
+    for version in [1, 2] {
+        let mut entry = serde_json::json!({
+            "schema_version": version,
+            "endpoint_fingerprint": endpoint_fingerprint(ENDPOINT),
             "queued_at_epoch_seconds": NOW,
             "attempts": 3,
-            "payload": payload,
-        }],
-        "retry_attempts": 7,
-        "dropped": 2,
-        "failure_sequence": 4,
-        "last_failure_class": "transport",
-    });
-    write_private_file_durably(&path, &serde_json::to_vec(&released).unwrap()).unwrap();
+            "payload": String::from_utf8(body(&event_id(1))).unwrap(),
+        });
+        let mut state = serde_json::json!({
+            "schema_version": version, "entries": [], "retry_attempts": 7,
+            "dropped": 2, "failure_sequence": 4, "last_failure_class": "transport",
+        });
+        if version == 2 {
+            entry["entry_id"] = event_id(1).into();
+            entry["next_attempt_at_epoch_seconds"] = 0.into();
+            entry["kind"] = "ordinary".into();
+            state["observation_due"] = true.into();
+        }
+        state["entries"] = serde_json::json!([entry]);
+        write_private_file_durably(&path, &serde_json::to_vec(&state).unwrap()).unwrap();
+        let outbox = AnalyticsOutbox::open_at(path.clone(), ROOT, NOW).unwrap();
+        assert!(outbox.snapshot_at(ENDPOINT, NOW).unwrap().is_empty());
+        assert!(outbox.pending_observation_at(NOW).unwrap().is_none());
+        assert!(read_current(&path).roots.is_empty());
+        outbox
+            .append_at(ENDPOINT, &body(&event_id(2)), NOW)
+            .unwrap();
+        let snapshot = outbox.snapshot_at(ENDPOINT, NOW).unwrap();
+        outbox
+            .reconcile_at(&[(snapshot[0].clone(), DeliveryDisposition::Accepted)], NOW)
+            .unwrap();
+        assert!(outbox.pending_observation_at(NOW).unwrap().is_none());
 
-    let outbox = AnalyticsOutbox::open_at(path.clone(), NOW).unwrap();
-    let state = read_v2(&path);
-    let snapshot = outbox.snapshot_at(ENDPOINT, NOW).unwrap();
-
-    assert_eq!(state.schema_version, OUTBOX_SCHEMA_VERSION);
-    assert_eq!(state.entries[0].payload, payload);
-    assert_eq!(state.entries[0].endpoint_fingerprint, fingerprint);
-    assert_eq!(state.entries[0].attempts, 3);
-    assert_eq!(snapshot[0].payload(), payload.as_bytes());
-    assert!(uuid::Uuid::parse_str(&snapshot[0].entry_id).is_ok());
+        write_private_file_durably(&path, &serde_json::to_vec(&state).unwrap()).unwrap();
+        AnalyticsOutbox::purge(&path, None).unwrap();
+        assert!(
+            !path.exists(),
+            "opt-out without an identity also discards legacy state"
+        );
+    }
 }
 
 #[test]
@@ -84,7 +98,7 @@ fn snapshot_releases_state_lock_and_uploader_lease_does_not_block_foreground_app
 
     let (sent, received) = mpsc::channel();
     let writer = thread::spawn(move || {
-        let concurrent = AnalyticsOutbox::open_at(path, NOW).unwrap();
+        let concurrent = AnalyticsOutbox::open_at(path, ROOT, NOW).unwrap();
         concurrent
             .append_at(ENDPOINT, &body(&event_id(2)), NOW)
             .unwrap();
@@ -101,7 +115,7 @@ fn snapshot_releases_state_lock_and_uploader_lease_does_not_block_foreground_app
 #[test]
 fn uploader_mutex_is_device_global_and_nonblocking() {
     let (_root, path, first) = test_outbox();
-    let second = AnalyticsOutbox::open_at(path, NOW).unwrap();
+    let second = AnalyticsOutbox::open_at(path, ROOT, NOW).unwrap();
     let lease = first.try_begin_upload().unwrap().unwrap();
     assert!(second.try_begin_upload().unwrap().is_none());
     drop(lease);
@@ -116,7 +130,7 @@ fn restart_replays_the_same_outbox_id_payload_and_event_id() {
     let before = outbox.snapshot_at(ENDPOINT, NOW).unwrap().remove(0);
     drop(outbox);
 
-    let reopened = AnalyticsOutbox::open_at(path, NOW + 1).unwrap();
+    let reopened = AnalyticsOutbox::open_at(path, ROOT, NOW + 1).unwrap();
     let after = reopened.snapshot_at(ENDPOINT, NOW + 1).unwrap().remove(0);
 
     assert_eq!(after.entry_id, before.entry_id);
@@ -132,7 +146,7 @@ fn crash_after_server_acceptance_replays_instead_of_guessing() {
     let accepted_but_unreconciled = outbox.snapshot_at(ENDPOINT, NOW).unwrap().remove(0);
     drop(outbox);
 
-    let reopened = AnalyticsOutbox::open_at(path, NOW + 1).unwrap();
+    let reopened = AnalyticsOutbox::open_at(path, ROOT, NOW + 1).unwrap();
     let replay = reopened.snapshot_at(ENDPOINT, NOW + 1).unwrap().remove(0);
 
     assert_eq!(replay.entry_id, accepted_but_unreconciled.entry_id);
@@ -186,13 +200,13 @@ fn retry_is_retained_with_backoff_while_permanent_rejection_is_dropped() {
         )
         .unwrap();
 
-    let state = read_v2(&path);
+    let state = read_current(&path);
     assert_eq!(state.entries.len(), 1);
     assert_eq!(state.entries[0].entry_id, snapshot[0].entry_id);
     assert_eq!(state.entries[0].attempts, 1);
     assert!(state.entries[0].next_attempt_at_epoch_seconds > NOW);
-    assert_eq!(state.retry_attempts, 1);
-    assert_eq!(state.dropped, 1);
+    assert_eq!(state.root(ROOT).retry_attempts, 1);
+    assert_eq!(state.root(ROOT).dropped, 1);
     assert!(outbox.snapshot_at(ENDPOINT, NOW).unwrap().is_empty());
 }
 
@@ -223,14 +237,14 @@ fn expired_entries_are_dropped_at_the_clock_seam() {
     drop(outbox);
 
     let reopened =
-        AnalyticsOutbox::open_at(path.clone(), NOW + OUTBOX_MAX_AGE_SECONDS + 1).unwrap();
-    let state = read_v2(&path);
+        AnalyticsOutbox::open_at(path.clone(), ROOT, NOW + OUTBOX_MAX_AGE_SECONDS + 1).unwrap();
+    let state = read_current(&path);
 
     assert!(reopened
         .snapshot_at(ENDPOINT, NOW + OUTBOX_MAX_AGE_SECONDS + 1)
         .unwrap()
         .is_empty());
-    assert_eq!(state.dropped, 1);
+    assert_eq!(state.root(ROOT).dropped, 1);
 }
 
 #[test]
@@ -240,6 +254,7 @@ fn corrupted_future_timestamps_are_bounded_and_cannot_evade_expiry() {
     state.entries.push(OutboxEntry {
         schema_version: OUTBOX_SCHEMA_VERSION,
         entry_id: uuid::Uuid::new_v4().to_string(),
+        data_root_id: ROOT.to_owned(),
         endpoint_fingerprint: endpoint_fingerprint(ENDPOINT),
         queued_at_epoch_seconds: i64::MAX,
         attempts: 1,
@@ -250,20 +265,21 @@ fn corrupted_future_timestamps_are_bounded_and_cannot_evade_expiry() {
     outbox.persist(&state).unwrap();
     drop(outbox);
 
-    let normalized = AnalyticsOutbox::open_at(path.clone(), NOW).unwrap();
-    let state = read_v2(&path);
+    let normalized = AnalyticsOutbox::open_at(path.clone(), ROOT, NOW).unwrap();
+    let state = read_current(&path);
     assert_eq!(state.entries[0].queued_at_epoch_seconds, NOW);
     assert_eq!(
         state.entries[0].next_attempt_at_epoch_seconds,
         NOW + RETRY_MAX_SECONDS as i64
     );
     assert_eq!(
-        state.last_failure_class,
+        state.root(ROOT).last_failure_class,
         Some(AnalyticsDeliveryFailureClass::LocalIo)
     );
     drop(normalized);
 
-    let expired = AnalyticsOutbox::open_at(path.clone(), NOW + OUTBOX_MAX_AGE_SECONDS + 1).unwrap();
+    let expired =
+        AnalyticsOutbox::open_at(path.clone(), ROOT, NOW + OUTBOX_MAX_AGE_SECONDS + 1).unwrap();
     assert!(expired
         .snapshot_at(ENDPOINT, NOW + OUTBOX_MAX_AGE_SECONDS + 1)
         .unwrap()
@@ -276,13 +292,13 @@ fn corrupt_private_state_recovers_and_reports_one_safe_drop() {
     let path = root.path().join("outbox.json");
     write_private_file_durably(&path, b"not-json").unwrap();
 
-    let outbox = AnalyticsOutbox::open_at(path.clone(), NOW).unwrap();
-    let state = read_v2(&path);
+    let outbox = AnalyticsOutbox::open_at(path.clone(), ROOT, NOW).unwrap();
+    let state = read_current(&path);
 
     assert!(state.entries.is_empty());
-    assert_eq!(state.dropped, 1);
+    assert_eq!(state.root(ROOT).dropped, 1);
     assert_eq!(
-        state.last_failure_class,
+        state.root(ROOT).last_failure_class,
         Some(AnalyticsDeliveryFailureClass::LocalIo)
     );
     assert!(outbox.pending_observation_at(NOW).unwrap().is_none());
@@ -296,6 +312,7 @@ fn count_and_total_byte_bounds_drop_oldest_entries() {
         state.entries.push(OutboxEntry {
             schema_version: OUTBOX_SCHEMA_VERSION,
             entry_id: uuid::Uuid::new_v4().to_string(),
+            data_root_id: ROOT.to_owned(),
             endpoint_fingerprint: endpoint_fingerprint(ENDPOINT),
             queued_at_epoch_seconds: NOW,
             attempts: 0,
@@ -309,17 +326,17 @@ fn count_and_total_byte_bounds_drop_oldest_entries() {
     outbox
         .append_at(ENDPOINT, &body(&event_id(999)), NOW)
         .unwrap();
-    let bounded = read_v2(&path);
+    let bounded = read_current(&path);
     assert_eq!(bounded.entries.len(), OUTBOX_MAX_ENTRIES);
     assert!(!bounded.entries.iter().any(|entry| entry.entry_id == oldest));
-    assert_eq!(bounded.dropped, 1);
+    assert_eq!(bounded.root(ROOT).dropped, 1);
 
     let large = serde_json::to_vec(&serde_json::json!({"padding": "x".repeat(400_000)})).unwrap();
     for _ in 0..6 {
         outbox.append_at(ENDPOINT, &large, NOW).unwrap();
     }
     assert!(fs::metadata(&path).unwrap().len() <= OUTBOX_MAX_BYTES);
-    assert!(read_v2(&path).entries.len() <= OUTBOX_MAX_ENTRIES);
+    assert!(read_current(&path).entries.len() <= OUTBOX_MAX_ENTRIES);
 }
 
 #[test]
@@ -330,9 +347,9 @@ fn per_entry_bound_is_enforced_and_counted() {
     }))
     .unwrap();
     assert!(outbox.append_at(ENDPOINT, &oversized, NOW).is_err());
-    let state = read_v2(&path);
+    let state = read_current(&path);
     assert!(state.entries.is_empty());
-    assert_eq!(state.dropped, 1);
+    assert_eq!(state.root(ROOT).dropped, 1);
 }
 
 #[test]
@@ -376,7 +393,7 @@ fn health_is_created_only_after_retry_recovery_and_never_recurses() {
         .unwrap();
     assert!(outbox.pending_observation_at(NOW).unwrap().is_none());
 
-    let retry_at = read_v2(&path).entries[0].next_attempt_at_epoch_seconds;
+    let retry_at = read_current(&path).entries[0].next_attempt_at_epoch_seconds;
     let recovered = outbox.snapshot_at(ENDPOINT, retry_at).unwrap().remove(0);
     outbox
         .reconcile_at(&[(recovered, DeliveryDisposition::Accepted)], retry_at)
@@ -403,10 +420,10 @@ fn health_is_created_only_after_retry_recovery_and_never_recurses() {
         )
         .unwrap();
 
-    let state = read_v2(&path);
-    assert_eq!(state.retry_attempts, 0);
-    assert_eq!(state.dropped, 0);
-    assert!(!state.observation_due);
+    let state = read_current(&path);
+    assert_eq!(state.root(ROOT).retry_attempts, 0);
+    assert_eq!(state.root(ROOT).dropped, 0);
+    assert!(!state.root(ROOT).observation_due);
     assert!(outbox.pending_observation_at(retry_at).unwrap().is_none());
 
     let health_retry_at = state.entries[0].next_attempt_at_epoch_seconds;
@@ -425,11 +442,11 @@ fn health_is_created_only_after_retry_recovery_and_never_recurses() {
             health_retry_at,
         )
         .unwrap();
-    let state = read_v2(&path);
+    let state = read_current(&path);
     assert!(state.entries.is_empty());
-    assert_eq!(state.retry_attempts, 0);
-    assert_eq!(state.dropped, 0);
-    assert!(!state.observation_due);
+    assert_eq!(state.root(ROOT).retry_attempts, 0);
+    assert_eq!(state.root(ROOT).dropped, 0);
+    assert!(!state.root(ROOT).observation_due);
 }
 
 #[test]
@@ -482,7 +499,7 @@ fn a_later_failure_defers_coalesced_health_until_another_success() {
         .unwrap();
     assert!(outbox.pending_observation_at(NOW).unwrap().is_none());
 
-    let retry_at = read_v2(&path).entries[0].next_attempt_at_epoch_seconds;
+    let retry_at = read_current(&path).entries[0].next_attempt_at_epoch_seconds;
     let recovered = outbox.snapshot_at(ENDPOINT, retry_at).unwrap().remove(0);
     outbox
         .reconcile_at(&[(recovered, DeliveryDisposition::Accepted)], retry_at)
@@ -494,15 +511,15 @@ fn a_later_failure_defers_coalesced_health_until_another_success() {
 fn purge_removes_payload_and_does_not_create_missing_state() {
     let root = tempfile::tempdir().unwrap();
     let missing = root.path().join("missing").join("outbox.json");
-    AnalyticsOutbox::purge(&missing).unwrap();
+    AnalyticsOutbox::purge(&missing, None).unwrap();
     assert!(!missing.parent().unwrap().exists());
 
     let path = root.path().join("outbox.json");
-    let outbox = AnalyticsOutbox::open_at(path.clone(), NOW).unwrap();
+    let outbox = AnalyticsOutbox::open_at(path.clone(), ROOT, NOW).unwrap();
     outbox
         .append_at(ENDPOINT, &body(&event_id(1)), NOW)
         .unwrap();
-    AnalyticsOutbox::purge(&path).unwrap();
+    AnalyticsOutbox::purge(&path, Some(ROOT)).unwrap();
     assert!(!path.exists());
 }
 
@@ -516,7 +533,7 @@ fn open_and_purge_reclaim_crash_orphaned_temporary_payloads() {
     ));
     fs::write(&orphan, body(&event_id(1))).unwrap();
 
-    let outbox = AnalyticsOutbox::open_at(path.clone(), NOW).unwrap();
+    let outbox = AnalyticsOutbox::open_at(path.clone(), ROOT, NOW).unwrap();
     assert!(!orphan.exists());
     outbox
         .append_at(ENDPOINT, &body(&event_id(2)), NOW)
@@ -527,7 +544,7 @@ fn open_and_purge_reclaim_crash_orphaned_temporary_payloads() {
     ));
     fs::write(&orphan, body(&event_id(3))).unwrap();
 
-    AnalyticsOutbox::purge(&path).unwrap();
+    AnalyticsOutbox::purge(&path, Some(ROOT)).unwrap();
 
     assert!(!path.exists());
     assert!(!orphan.exists());
@@ -540,7 +557,7 @@ fn purge_wins_over_in_flight_reconciliation() {
         .append_at(ENDPOINT, &body(&event_id(1)), NOW)
         .unwrap();
     let snapshot = outbox.snapshot_at(ENDPOINT, NOW).unwrap().remove(0);
-    AnalyticsOutbox::purge(&path).unwrap();
+    AnalyticsOutbox::purge(&path, Some(ROOT)).unwrap();
     assert!(!outbox.contains_snapshot(&snapshot).unwrap());
 
     outbox
@@ -555,7 +572,7 @@ fn unsafe_state_path_still_fails_closed() {
     let root = tempfile::tempdir().unwrap();
     let path = root.path().join("outbox.json");
     fs::create_dir(&path).unwrap();
-    assert!(AnalyticsOutbox::open_at(path, NOW).is_err());
+    assert!(AnalyticsOutbox::open_at(path, ROOT, NOW).is_err());
 }
 
 #[cfg(windows)]
@@ -591,5 +608,260 @@ fn unsafe_state_permissions_still_fail_closed() {
     let path = root.path().join("outbox.json");
     write_private_file_durably(&path, b"not-json").unwrap();
     fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
-    assert!(AnalyticsOutbox::open_at(path, NOW).is_err());
+    assert!(AnalyticsOutbox::open_at(path, ROOT, NOW).is_err());
+}
+
+#[test]
+fn root_scope_owns_snapshots_purge_reconciliation_and_recovery_counters() {
+    let (_dir, path, a) = test_outbox();
+    let b = AnalyticsOutbox::open_at(path.clone(), OTHER_ROOT, NOW).unwrap();
+    a.append_at(ENDPOINT, &body(&event_id(1)), NOW).unwrap();
+    b.append_at(ENDPOINT, &body(&event_id(2)), NOW).unwrap();
+    let a_snapshot = a.snapshot_at(ENDPOINT, NOW).unwrap().remove(0);
+    let b_snapshot = b.snapshot_at(ENDPOINT, NOW).unwrap().remove(0);
+    assert_eq!(a_snapshot.payload(), body(&event_id(1)));
+    assert_eq!(b_snapshot.payload(), body(&event_id(2)));
+    assert!(!b.contains_snapshot(&a_snapshot).unwrap());
+    assert!(b
+        .reconcile_at(&[(a_snapshot.clone(), DeliveryDisposition::Accepted)], NOW)
+        .is_err());
+
+    a.reconcile_at(
+        &[(a_snapshot, retry(AnalyticsDeliveryFailureClass::Transport))],
+        NOW,
+    )
+    .unwrap();
+    b.reconcile_at(&[(b_snapshot, DeliveryDisposition::Accepted)], NOW)
+        .unwrap();
+    assert!(
+        b.pending_observation_at(NOW).unwrap().is_none(),
+        "B must not recover A's retry"
+    );
+    let retry_at = read_current(&path).entries[0].next_attempt_at_epoch_seconds;
+    let a_retry = a.snapshot_at(ENDPOINT, retry_at).unwrap().remove(0);
+    a.reconcile_at(&[(a_retry, DeliveryDisposition::Accepted)], retry_at)
+        .unwrap();
+    let health = a.pending_observation_at(retry_at).unwrap().unwrap();
+    assert_eq!(health.event.retry_attempts, CountBucket::One);
+    assert!(b
+        .queue_observation_at(ENDPOINT, &body(&event_id(3)), &health, retry_at)
+        .is_err());
+    a.queue_observation_at(ENDPOINT, &body(&event_id(3)), &health, retry_at)
+        .unwrap();
+    b.append_at(ENDPOINT, &body(&event_id(4)), retry_at)
+        .unwrap();
+    let before_b = b.snapshot_at(ENDPOINT, retry_at).unwrap().remove(0);
+    let before_a = a.snapshot_at(ENDPOINT, retry_at).unwrap().remove(0);
+
+    AnalyticsOutbox::purge(&path, Some(ROOT)).unwrap();
+    a.reconcile_at(
+        &[(before_a, retry(AnalyticsDeliveryFailureClass::Transport))],
+        retry_at,
+    )
+    .unwrap();
+    assert!(a.snapshot_at(ENDPOINT, retry_at).unwrap().is_empty());
+    let after_b = b.snapshot_at(ENDPOINT, retry_at).unwrap().remove(0);
+    assert_eq!(before_b.entry_id, after_b.entry_id);
+    assert_eq!(before_b.payload(), after_b.payload());
+    assert!(!read_current(&path).roots.contains_key(ROOT));
+
+    let before = fs::read(&path).unwrap();
+    AnalyticsOutbox::purge(&path, None).unwrap();
+    assert_eq!(
+        before,
+        fs::read(&path).unwrap(),
+        "an absent identity owns no current entries"
+    );
+}
+
+#[test]
+fn aggregate_bounds_and_counter_cardinality_hold_across_root_churn() {
+    let (_dir, path, a) = test_outbox();
+    let b = AnalyticsOutbox::open_at(path.clone(), OTHER_ROOT, NOW).unwrap();
+    for index in 0..OUTBOX_MAX_ENTRIES {
+        a.append_at(ENDPOINT, &body(&event_id(index)), NOW).unwrap();
+    }
+    b.append_at(ENDPOINT, &body(&event_id(999)), NOW).unwrap();
+    let state = read_current(&path);
+    assert_eq!(
+        state.entries.len(),
+        128,
+        "entry bound is aggregate, not per root"
+    );
+    assert_eq!(state.root(ROOT).dropped, 1);
+    assert_eq!(state.root(OTHER_ROOT).dropped, 0);
+    assert!(!state
+        .entries
+        .iter()
+        .any(|entry| entry.payload == String::from_utf8(body(&event_id(0))).unwrap()));
+
+    let large = serde_json::to_vec(&serde_json::json!({"padding": "x".repeat(400_000)})).unwrap();
+    for outbox in [&a, &b, &a, &b, &a, &b] {
+        outbox.append_at(ENDPOINT, &large, NOW).unwrap();
+        assert!(fs::metadata(&path).unwrap().len() <= 2 * 1024 * 1024);
+    }
+    assert!(read_current(&path).root(ROOT).dropped > 1);
+
+    // Failed oversized appends create only counters, so no queued-entry bound
+    // can incidentally bound this path. Preserve counters for queued roots.
+    let oversized =
+        serde_json::to_vec(&serde_json::json!({"padding": "x".repeat(OUTBOX_MAX_BODY_BYTES)}))
+            .unwrap();
+    let a_drops = read_current(&path).root(ROOT).dropped;
+    for index in 1000..(1000 + 2 * OUTBOX_MAX_ENTRIES) {
+        let id = event_id(index);
+        let outbox = AnalyticsOutbox::open_at(path.clone(), &id, NOW).unwrap();
+        assert!(outbox.append_at(ENDPOINT, &oversized, NOW).is_err());
+        let state = read_current(&path);
+        assert!(
+            state.roots.len() <= 128,
+            "counter-only root records grew without bound"
+        );
+        assert!(state.entries.len() <= 128);
+        assert!(fs::metadata(&path).unwrap().len() <= 2 * 1024 * 1024);
+        assert_eq!(state.root(ROOT).dropped, a_drops);
+        validate_state(&state).unwrap();
+    }
+    assert_eq!(read_current(&path).roots.len(), 128);
+}
+
+#[test]
+fn expiration_and_recovery_observations_remain_owned_by_each_root() {
+    let (_dir, path, a) = test_outbox();
+    let b = AnalyticsOutbox::open_at(path.clone(), OTHER_ROOT, NOW).unwrap();
+    a.append_at(ENDPOINT, &body(&event_id(1)), NOW).unwrap();
+    b.append_at(ENDPOINT, &body(&event_id(2)), NOW + 1).unwrap();
+    let after_expiry = NOW + OUTBOX_MAX_AGE_SECONDS + 1;
+    assert_eq!(b.snapshot_at(ENDPOINT, after_expiry).unwrap().len(), 1);
+    assert!(a.snapshot_at(ENDPOINT, after_expiry).unwrap().is_empty());
+    assert_eq!(read_current(&path).root(ROOT).dropped, 1);
+    assert_eq!(read_current(&path).root(OTHER_ROOT).dropped, 0);
+
+    for outbox in [&a, &b] {
+        outbox
+            .append_at(ENDPOINT, &body(&event_id(3)), after_expiry)
+            .unwrap();
+        let snapshot = outbox.snapshot_at(ENDPOINT, after_expiry).unwrap();
+        outbox
+            .reconcile_at(
+                &[(
+                    snapshot[0].clone(),
+                    DeliveryDisposition::Permanent {
+                        class: AnalyticsDeliveryFailureClass::ClientRejection,
+                    },
+                )],
+                after_expiry,
+            )
+            .unwrap();
+        outbox
+            .append_at(ENDPOINT, &body(&event_id(4)), after_expiry)
+            .unwrap();
+        let snapshot = outbox.snapshot_at(ENDPOINT, after_expiry).unwrap();
+        outbox
+            .reconcile_at(
+                &[(snapshot[0].clone(), DeliveryDisposition::Accepted)],
+                after_expiry,
+            )
+            .unwrap();
+        let observation = outbox
+            .pending_observation_at(after_expiry)
+            .unwrap()
+            .unwrap();
+        outbox
+            .queue_observation_at(ENDPOINT, &body(&event_id(5)), &observation, after_expiry)
+            .unwrap();
+    }
+    let state = read_current(&path);
+    validate_state(&state).unwrap();
+    assert_eq!(
+        state
+            .entries
+            .iter()
+            .filter(|entry| entry.kind == OutboxEntryKind::DeliveryObservation)
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn full_queued_owner_capacity_preserves_surviving_counters_after_sole_entry_eviction() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("outbox.json");
+    let owners = (1..=129).map(event_id).collect::<Vec<_>>();
+    let check_bounds = || {
+        let state = read_current(&path);
+        assert!(state.entries.len() <= 128);
+        assert!(state.roots.len() <= 128);
+        assert!(fs::metadata(&path).unwrap().len() <= 2 * 1024 * 1024);
+        validate_state(&state).unwrap();
+    };
+    for (index, owner) in owners.iter().take(128).enumerate() {
+        let outbox = AnalyticsOutbox::open_at(path.clone(), owner, NOW).unwrap();
+        outbox
+            .append_at(ENDPOINT, &body(&event_id(1000 + index)), NOW)
+            .unwrap();
+        check_bounds();
+        let snapshot = outbox.snapshot_at(ENDPOINT, NOW).unwrap().remove(0);
+        outbox
+            .reconcile_at(
+                &[(snapshot, retry(AnalyticsDeliveryFailureClass::Transport))],
+                NOW,
+            )
+            .unwrap();
+        check_bounds();
+    }
+    let full = read_current(&path);
+    assert_eq!(full.entries.len(), 128);
+    assert_eq!(full.roots.len(), 128);
+    let last = AnalyticsOutbox::open_at(path.clone(), &owners[128], NOW).unwrap();
+    last.append_at(ENDPOINT, &body(&event_id(2000)), NOW)
+        .unwrap();
+    check_bounds();
+    let state = read_current(&path);
+    assert!(!state
+        .entries
+        .iter()
+        .any(|entry| entry.data_root_id == owners[0]));
+    assert_eq!(state.root(&owners[128]).retry_attempts, 0);
+    assert_eq!(state.root(&owners[128]).dropped, 0);
+    let snapshot = last.snapshot_at(ENDPOINT, NOW).unwrap().remove(0);
+    last.reconcile_at(
+        &[(snapshot, retry(AnalyticsDeliveryFailureClass::Transport))],
+        NOW,
+    )
+    .unwrap();
+    check_bounds();
+    for owner in owners.iter().skip(1) {
+        let reopened = AnalyticsOutbox::open_at(path.clone(), owner, NOW).unwrap();
+        check_bounds();
+        let state = read_current(&path);
+        let counters = state.root(owner);
+        assert_eq!(
+            counters.retry_attempts, 1,
+            "surviving owner's retry count changed"
+        );
+        assert_eq!(counters.dropped, 0, "evicted owner's drop was reassigned");
+        assert_eq!(counters.failure_sequence, 1);
+        assert_eq!(
+            counters.last_failure_class,
+            Some(AnalyticsDeliveryFailureClass::Transport)
+        );
+        assert!(!counters.observation_due);
+        assert_eq!(
+            state
+                .entries
+                .iter()
+                .filter(|entry| &entry.data_root_id == owner)
+                .count(),
+            1
+        );
+        drop(reopened);
+    }
+    let state = read_current(&path);
+    assert_eq!(state.entries.len(), 128);
+    assert_eq!(state.roots.len(), 128);
+    assert!(
+        !state.roots.contains_key(&owners[0]),
+        "the evicted sole-entry owner's counter-only record can be discarded"
+    );
 }

--- a/crates/ctx-cli/src/identity.rs
+++ b/crates/ctx-cli/src/identity.rs
@@ -36,7 +36,6 @@ pub(crate) fn installation_id(data_root: &Path) -> Result<String> {
 }
 
 /// Loads the root identity without creating it or the data root.
-#[cfg(test)]
 pub(crate) fn existing_installation_id(data_root: &Path) -> Result<Option<String>> {
     access_installation_id(data_root, false)
 }

--- a/crates/ctx-cli/src/observability_composition.rs
+++ b/crates/ctx-cli/src/observability_composition.rs
@@ -66,15 +66,29 @@ fn resolve_analytics_policy(data_root: &Path) -> anyhow::Result<ResolvedAnalytic
     })
 }
 
+fn resolve_analytics_policy_for_owner(
+    data_root: &Path,
+    data_root_id: &str,
+) -> anyhow::Result<ResolvedAnalyticsPolicy> {
+    let policy = resolve_analytics_policy(data_root)?;
+    if crate::identity::existing_installation_id(data_root)?.as_deref() != Some(data_root_id) {
+        anyhow::bail!("analytics consent owner is no longer available at this data root");
+    }
+    Ok(policy)
+}
+
+fn purge_analytics_outbox(data_root: &Path, outbox_path: &Path) -> anyhow::Result<()> {
+    let data_root_id = crate::identity::existing_installation_id(data_root)?;
+    crate::analytics_outbox::AnalyticsOutbox::purge(outbox_path, data_root_id.as_deref())
+}
+
 pub(crate) fn append_analytics_batch(
     data_root: &Path,
     events: &[PublicEventV1],
 ) -> anyhow::Result<()> {
     let outbox_path = crate::identity::device_state_path(ANALYTICS_OUTBOX_FILE, data_root)?;
     match resolve_analytics_policy(data_root)? {
-        ResolvedAnalyticsPolicy::Purge => {
-            return crate::analytics_outbox::AnalyticsOutbox::purge(&outbox_path)
-        }
+        ResolvedAnalyticsPolicy::Purge => return purge_analytics_outbox(data_root, &outbox_path),
         ResolvedAnalyticsPolicy::DryRun => return Ok(()),
         ResolvedAnalyticsPolicy::Active(_) if events.is_empty() => return Ok(()),
         ResolvedAnalyticsPolicy::Active(_) => {}
@@ -102,11 +116,12 @@ pub(crate) fn append_analytics_batch(
             .map(|marker| marker.install_attempt_id.as_str()),
         capability_snapshot,
     };
-    let outbox = crate::analytics_outbox::AnalyticsOutbox::open(outbox_path.clone())?;
+    let outbox =
+        crate::analytics_outbox::AnalyticsOutbox::open(outbox_path.clone(), &data_root_id)?;
     ctx_client_observability::analytics::deliver_batch(&mut authority, events, |body| {
-        match resolve_analytics_policy(data_root)? {
+        match resolve_analytics_policy_for_owner(data_root, &data_root_id)? {
             ResolvedAnalyticsPolicy::Purge => {
-                crate::analytics_outbox::AnalyticsOutbox::purge(&outbox_path)?;
+                crate::analytics_outbox::AnalyticsOutbox::purge(&outbox_path, Some(&data_root_id))?;
                 anyhow::bail!("analytics was disabled before durable append")
             }
             ResolvedAnalyticsPolicy::DryRun => {
@@ -122,22 +137,25 @@ pub(crate) fn append_analytics_batch(
 pub(crate) fn drain_analytics_outbox(data_root: &Path, timeout: Duration) -> anyhow::Result<()> {
     let outbox_path = crate::identity::device_state_path(ANALYTICS_OUTBOX_FILE, data_root)?;
     let config = match resolve_analytics_policy(data_root)? {
-        ResolvedAnalyticsPolicy::Purge => {
-            return crate::analytics_outbox::AnalyticsOutbox::purge(&outbox_path)
-        }
+        ResolvedAnalyticsPolicy::Purge => return purge_analytics_outbox(data_root, &outbox_path),
         ResolvedAnalyticsPolicy::DryRun => return Ok(()),
         ResolvedAnalyticsPolicy::Active(config) => config,
     };
-    let outbox = crate::analytics_outbox::AnalyticsOutbox::open(outbox_path.clone())?;
+    let data_root_id = crate::identity::installation_id(data_root)?;
+    let outbox =
+        crate::analytics_outbox::AnalyticsOutbox::open(outbox_path.clone(), &data_root_id)?;
     let Some(_uploader) = outbox.try_begin_upload()? else {
         return Ok(());
     };
     let snapshot = outbox.snapshot(&config.analytics.endpoint)?;
     let mut attempted = Vec::with_capacity(snapshot.len());
     for entry in snapshot {
-        let current = match resolve_analytics_policy(data_root)? {
+        let current = match resolve_analytics_policy_for_owner(data_root, &data_root_id)? {
             ResolvedAnalyticsPolicy::Purge => {
-                return crate::analytics_outbox::AnalyticsOutbox::purge(&outbox_path)
+                return crate::analytics_outbox::AnalyticsOutbox::purge(
+                    &outbox_path,
+                    Some(&data_root_id),
+                )
             }
             ResolvedAnalyticsPolicy::DryRun => return Ok(()),
             ResolvedAnalyticsPolicy::Active(current) => current,
@@ -172,19 +190,23 @@ pub(crate) fn drain_analytics_outbox(data_root: &Path, timeout: Duration) -> any
             break;
         }
     }
-    let config = match resolve_analytics_policy(data_root)? {
+    let config = match resolve_analytics_policy_for_owner(data_root, &data_root_id)? {
         ResolvedAnalyticsPolicy::Purge => {
-            return crate::analytics_outbox::AnalyticsOutbox::purge(&outbox_path)
+            return crate::analytics_outbox::AnalyticsOutbox::purge(
+                &outbox_path,
+                Some(&data_root_id),
+            )
         }
         ResolvedAnalyticsPolicy::DryRun => return Ok(()),
         ResolvedAnalyticsPolicy::Active(current) => current,
     };
     outbox.reconcile(&attempted)?;
-    queue_pending_delivery_observation(data_root, &config, &outbox)
+    queue_pending_delivery_observation(data_root, &data_root_id, &config, &outbox)
 }
 
 fn queue_pending_delivery_observation(
     data_root: &Path,
+    data_root_id: &str,
     config: &AppConfig,
     outbox: &crate::analytics_outbox::AnalyticsOutbox,
 ) -> anyhow::Result<()> {
@@ -192,18 +214,32 @@ fn queue_pending_delivery_observation(
         return Ok(());
     };
     let client_profile_id = crate::identity::device_id(data_root)?;
-    let data_root_id = crate::identity::installation_id(data_root)?;
     let authority = AnalyticsDeliveryAuthority {
         app_version: env!("CARGO_PKG_VERSION"),
         client_profile_id: &client_profile_id,
-        data_root_id: &data_root_id,
+        data_root_id,
         install_attempt_id: None,
         capability_snapshot: None,
     };
     ctx_client_observability::analytics::deliver_delivery_observation(
         &authority,
         observation.event,
-        |body| outbox.queue_observation(&config.analytics.endpoint, body, &observation),
+        |body| match resolve_analytics_policy_for_owner(data_root, data_root_id)? {
+            ResolvedAnalyticsPolicy::Purge => {
+                let path = crate::identity::device_state_path(ANALYTICS_OUTBOX_FILE, data_root)?;
+                crate::analytics_outbox::AnalyticsOutbox::purge(&path, Some(data_root_id))?;
+                anyhow::bail!("analytics was disabled before recovery observation append")
+            }
+            ResolvedAnalyticsPolicy::DryRun => {
+                anyhow::bail!("analytics dry-run was enabled before recovery observation append")
+            }
+            ResolvedAnalyticsPolicy::Active(current) => {
+                if current.analytics.endpoint != config.analytics.endpoint {
+                    anyhow::bail!("analytics endpoint changed before recovery observation append");
+                }
+                outbox.queue_observation(&current.analytics.endpoint, body, &observation)
+            }
+        },
     )
 }
 
@@ -304,21 +340,21 @@ mod tests {
 
     use crate::analytics::{DaemonOperationV1, OperationCompletedV1, Outcome};
 
-    use super::*;
+    use super::{consent_tests::isolate_analytics_environment, *};
 
-    struct RestoreEnvironment {
+    pub(super) struct RestoreEnvironment {
         key: &'static str,
         previous: Option<OsString>,
     }
 
     impl RestoreEnvironment {
-        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        pub(super) fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
             let previous = std::env::var_os(key);
             std::env::set_var(key, value);
             Self { key, previous }
         }
 
-        fn remove(key: &'static str) -> Self {
+        pub(super) fn remove(key: &'static str) -> Self {
             let previous = std::env::var_os(key);
             std::env::remove_var(key);
             Self { key, previous }
@@ -335,12 +371,85 @@ mod tests {
         }
     }
 
-    fn daemon_event() -> PublicEventV1 {
+    pub(super) fn daemon_event() -> PublicEventV1 {
         PublicEventV1::OperationCompleted(OperationCompletedV1::for_daemon(
             DaemonOperationV1::Status,
             Outcome::Success,
             Duration::ZERO,
         ))
+    }
+
+    #[test]
+    fn enabled_root_cannot_deliver_a_disabled_roots_queued_batch() {
+        let _env_lock = ctx_app_config::TEST_LOCAL_USAGE_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let sandbox = tempfile::tempdir().unwrap();
+        let _environment = isolate_analytics_environment(sandbox.path());
+        let root_a = sandbox.path().join("root-a");
+        let root_b = sandbox.path().join("root-b");
+        let received = sandbox.path().join("received.jsonl");
+        let endpoint = url::Url::from_file_path(&received).unwrap().to_string();
+        let _endpoint = RestoreEnvironment::set("CTX_ANALYTICS_ENDPOINT", &endpoint);
+
+        append_analytics_batch(&root_a, &[daemon_event()]).unwrap();
+        append_analytics_batch(&root_b, &[daemon_event()]).unwrap();
+        let id_a = crate::identity::installation_id(&root_a).unwrap();
+        let id_b = crate::identity::installation_id(&root_b).unwrap();
+        assert_ne!(id_a, id_b);
+        let path = crate::identity::device_state_path(ANALYTICS_OUTBOX_FILE, &root_a).unwrap();
+        assert!(!path.starts_with(&root_a) && !path.starts_with(&root_b));
+        ctx_history_platform::platform_security::verify_private_file(&path).unwrap();
+        let outbox_b = crate::analytics_outbox::AnalyticsOutbox::open(path.clone(), &id_b).unwrap();
+        let queued_b = outbox_b.snapshot(&endpoint).unwrap().remove(0);
+        fs::write(
+            AppConfig::config_path(&root_a),
+            "[analytics]\nenabled = false\n",
+        )
+        .unwrap();
+
+        // The file transport exercises the production drain without a daemon or network.
+        drain_analytics_outbox(&root_b, Duration::from_secs(1)).unwrap();
+        let bodies = fs::read_to_string(&received).unwrap();
+        assert!(
+            !bodies.contains(&id_a),
+            "enabled B uploaded opted-out A's batch"
+        );
+        assert!(
+            bodies.contains(&id_b),
+            "enabled B must deliver its own batch"
+        );
+        assert_eq!(bodies.trim_end().as_bytes(), queued_b.payload());
+        assert!(!bodies.contains(&sandbox.path().to_string_lossy().to_string()));
+
+        append_analytics_batch(&root_b, &[daemon_event()]).unwrap();
+        let next_b = outbox_b.snapshot(&endpoint).unwrap().remove(0);
+        drain_analytics_outbox(&root_a, Duration::from_secs(1)).unwrap();
+        assert_eq!(bodies, fs::read_to_string(&received).unwrap());
+        assert_eq!(
+            outbox_b.snapshot(&endpoint).unwrap()[0].payload(),
+            next_b.payload()
+        );
+        let outbox_a = crate::analytics_outbox::AnalyticsOutbox::open(path, &id_a).unwrap();
+        assert!(outbox_a.snapshot(&endpoint).unwrap().is_empty());
+        assert_eq!(
+            crate::identity::existing_installation_id(&root_a)
+                .unwrap()
+                .as_deref(),
+            Some(id_a.as_str())
+        );
+
+        let absent_root = sandbox.path().join("absent-root");
+        let _disabled = RestoreEnvironment::set("CTX_ANALYTICS_ENABLED", "false");
+        drain_analytics_outbox(&absent_root, Duration::from_secs(1)).unwrap();
+        assert!(
+            !absent_root.exists(),
+            "opt-out must not create a root identity"
+        );
+        assert_eq!(
+            outbox_b.snapshot(&endpoint).unwrap()[0].payload(),
+            next_b.payload()
+        );
     }
 
     #[test]
@@ -366,10 +475,7 @@ mod tests {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let data_root = tempfile::tempdir().unwrap();
         let device_root = tempfile::tempdir().unwrap();
-        let _state = RestoreEnvironment::set("XDG_STATE_HOME", device_root.path());
-        let _home = RestoreEnvironment::set("HOME", device_root.path());
-        let _enabled = RestoreEnvironment::set("CTX_ANALYTICS_ENABLED", "true");
-        let _dry_run = RestoreEnvironment::remove("CTX_ANALYTICS_DRY_RUN");
+        let _environment = isolate_analytics_environment(device_root.path());
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         listener.set_nonblocking(true).unwrap();
         let endpoint = format!("http://{}/events", listener.local_addr().unwrap());
@@ -382,18 +488,25 @@ mod tests {
         );
         let path =
             crate::identity::device_state_path(ANALYTICS_OUTBOX_FILE, data_root.path()).unwrap();
-        let outbox = crate::analytics_outbox::AnalyticsOutbox::open(path.clone()).unwrap();
+        let outbox = crate::analytics_outbox::AnalyticsOutbox::open(
+            path.clone(),
+            &crate::identity::installation_id(data_root.path()).unwrap(),
+        )
+        .unwrap();
         assert_eq!(outbox.snapshot(&endpoint).unwrap().len(), 1);
 
         let _dry_run = RestoreEnvironment::set("CTX_ANALYTICS_DRY_RUN", "1");
-        crate::analytics_outbox::AnalyticsOutbox::purge(&path).unwrap();
+        purge_analytics_outbox(data_root.path(), &path).unwrap();
         append_analytics_batch(data_root.path(), &[daemon_event()]).unwrap();
         assert!(!path.exists());
 
-        drop(_enabled);
         let _disabled = RestoreEnvironment::set("CTX_ANALYTICS_ENABLED", "false");
-        fs::write(&path, b"must be purged").unwrap();
+        crate::identity::write_private_file(&path, b"must be purged").unwrap();
         append_analytics_batch(data_root.path(), &[daemon_event()]).unwrap();
         assert!(!path.exists(), "opt-out must purge even during dry-run");
     }
 }
+
+#[cfg(test)]
+#[path = "observability_composition/consent_tests.rs"]
+mod consent_tests;

--- a/crates/ctx-cli/src/observability_composition/consent_tests.rs
+++ b/crates/ctx-cli/src/observability_composition/consent_tests.rs
@@ -1,0 +1,351 @@
+use std::{
+    io::{BufRead as _, BufReader, Read as _, Write as _},
+    net::{TcpListener, TcpStream},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
+    thread,
+    time::Instant,
+};
+
+use super::{
+    tests::{daemon_event, RestoreEnvironment},
+    *,
+};
+use crate::analytics_outbox::{AnalyticsOutbox, DeliveryDisposition};
+use std::fs;
+
+pub(super) fn isolate_analytics_environment(root: &Path) -> Vec<RestoreEnvironment> {
+    let mut guards = [
+        "HOME",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "XDG_STATE_HOME",
+        "XDG_RUNTIME_DIR",
+        "LOCALAPPDATA",
+        "APPDATA",
+        "CODEX_HOME",
+        "CLAUDE_CONFIG_DIR",
+        "CTX_DATA_ROOT",
+    ]
+    .into_iter()
+    .map(|key| RestoreEnvironment::set(key, root))
+    .collect::<Vec<_>>();
+    guards.extend(
+        [
+            "CTX_ANALYTICS_OFF",
+            "CTX_DISABLE_ANALYTICS",
+            "CTX_INSTALL_DIAGNOSTICS_OFF",
+            "CTX_ANALYTICS_DRY_RUN",
+            "CTX_ANALYTICS_ENDPOINT",
+        ]
+        .into_iter()
+        .map(RestoreEnvironment::remove),
+    );
+    guards.push(RestoreEnvironment::set("CTX_ANALYTICS_ENABLED", "true"));
+    guards.push(RestoreEnvironment::set("CTX_UPGRADE_AUTO", "off"));
+    guards
+}
+
+fn configure(root: &Path, enabled: bool, endpoint: &str) {
+    let endpoint = serde_json::to_string(endpoint).unwrap();
+    fs::write(
+        AppConfig::config_path(root),
+        format!("[analytics]\nenabled = {enabled}\nendpoint = {endpoint}\n"),
+    )
+    .unwrap();
+}
+
+fn request_body(stream: &mut TcpStream) -> Vec<u8> {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    let mut reader = BufReader::new(stream);
+    let mut content_length = None;
+    let mut header_bytes = 0;
+    loop {
+        let mut line = String::new();
+        assert!(reader.read_line(&mut line).unwrap() > 0);
+        header_bytes += line.len();
+        assert!(header_bytes <= 16 * 1024);
+        if line == "\r\n" {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            if name.eq_ignore_ascii_case("content-length") {
+                content_length = Some(value.trim().parse::<usize>().unwrap());
+            }
+        }
+    }
+    let length = content_length.expect("bounded telemetry Content-Length");
+    assert!(length <= 512 * 1024);
+    let mut body = vec![0; length];
+    reader.read_exact(&mut body).unwrap();
+    body
+}
+
+// Hold the first real HTTP response until the root mutation has completed.
+// Continue answering unexpected later requests so the pre-fix failure reports
+// the sent bodies, rather than relying on a timeout to hide a second send.
+fn drain_across_barrier(
+    root: &Path,
+    listener: TcpListener,
+    mutate: impl FnOnce(),
+) -> (anyhow::Result<()>, Vec<Vec<u8>>) {
+    listener.set_nonblocking(true).unwrap();
+    let done = AtomicBool::new(false);
+    let (arrived, first) = mpsc::sync_channel(1);
+    let (release, released) = mpsc::sync_channel(1);
+    thread::scope(|scope| {
+        let done = &done;
+        let server = scope.spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(15);
+            let mut bodies = Vec::new();
+            while !done.load(Ordering::SeqCst) {
+                assert!(Instant::now() < deadline, "barrier transport did not finish");
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        bodies.push(request_body(&mut stream));
+                        if bodies.len() == 1 {
+                            arrived.send(()).unwrap();
+                            released.recv_timeout(Duration::from_secs(5)).unwrap();
+                        }
+                        stream.set_write_timeout(Some(Duration::from_secs(5))).unwrap();
+                        stream.write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n").unwrap();
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => thread::sleep(Duration::from_millis(1)),
+                    Err(error) => panic!("accept loopback telemetry: {error}"),
+                }
+            }
+            bodies
+        });
+        let drain = scope.spawn(|| drain_analytics_outbox(root, Duration::from_secs(10)));
+        first
+            .recv_timeout(Duration::from_secs(5))
+            .expect("first A request must reach the response barrier");
+        mutate();
+        release.send(()).unwrap();
+        let result = drain.join().unwrap();
+        done.store(true, Ordering::SeqCst);
+        (result, server.join().unwrap())
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Change {
+    MoveRoot,
+    MissingIdentity,
+    CorruptIdentity,
+    Endpoint,
+    OptOut,
+}
+
+fn drain_transition(change: Change) {
+    let _env_lock = ctx_app_config::TEST_LOCAL_USAGE_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let sandbox = tempfile::tempdir().unwrap();
+    let _environment = isolate_analytics_environment(sandbox.path());
+    let a = sandbox.path().join("a");
+    let b = sandbox.path().join("b");
+    let moved_a = sandbox.path().join("moved-a");
+    let id_a = crate::identity::installation_id(&a).unwrap();
+    let id_b = crate::identity::installation_id(&b).unwrap();
+    let b_identity = fs::read(crate::identity::install_path(&b)).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let endpoint = format!("http://{}/events", listener.local_addr().unwrap());
+    let other_sink = sandbox.path().join("unexpected.jsonl");
+    let other_endpoint = url::Url::from_file_path(&other_sink).unwrap().to_string();
+    configure(&a, true, &endpoint);
+    configure(&b, true, &endpoint);
+    append_analytics_batch(&a, &[daemon_event()]).unwrap();
+    append_analytics_batch(&a, &[daemon_event()]).unwrap();
+    append_analytics_batch(&b, &[daemon_event()]).unwrap();
+    let path = crate::identity::device_state_path(ANALYTICS_OUTBOX_FILE, &a).unwrap();
+    let outbox_a = AnalyticsOutbox::open(path.clone(), &id_a).unwrap();
+    let outbox_b = AnalyticsOutbox::open(path.clone(), &id_b).unwrap();
+    let queued_a = outbox_a.snapshot(&endpoint).unwrap();
+    assert_eq!(queued_a.len(), 2);
+    let queued_b = outbox_b.snapshot(&endpoint).unwrap();
+    let (result, sent) = drain_across_barrier(&a, listener, || match change {
+        Change::MoveRoot => {
+            fs::rename(&a, &moved_a).unwrap();
+            configure(&moved_a, false, &endpoint);
+            fs::rename(&b, &a).unwrap();
+        }
+        Change::MissingIdentity => fs::remove_file(crate::identity::install_path(&a)).unwrap(),
+        Change::CorruptIdentity => {
+            fs::write(crate::identity::install_path(&a), b"invalid identity").unwrap()
+        }
+        Change::Endpoint => configure(&a, true, &other_endpoint),
+        Change::OptOut => configure(&a, false, &endpoint),
+    });
+    assert_eq!(
+        sent.len(),
+        1,
+        "stale owner authorized a second A batch after {change:?}"
+    );
+    assert_eq!(sent[0], queued_a[0].payload());
+    assert!(!other_sink.exists());
+    assert_eq!(
+        outbox_b.snapshot(&endpoint).unwrap()[0].payload(),
+        queued_b[0].payload()
+    );
+    let b_now = if matches!(change, Change::MoveRoot) {
+        &a
+    } else {
+        &b
+    };
+    assert_eq!(
+        fs::read(crate::identity::install_path(b_now)).unwrap(),
+        b_identity
+    );
+    match change {
+        Change::MissingIdentity => {
+            assert!(result.is_err());
+            assert!(!crate::identity::install_path(&a).exists());
+        }
+        Change::CorruptIdentity => {
+            assert!(result.is_err());
+            assert_eq!(
+                fs::read(crate::identity::install_path(&a)).unwrap(),
+                b"invalid identity"
+            );
+        }
+        Change::MoveRoot => {
+            assert!(result.is_err());
+            assert_eq!(
+                crate::identity::existing_installation_id(&moved_a)
+                    .unwrap()
+                    .as_deref(),
+                Some(id_a.as_str())
+            );
+        }
+        Change::Endpoint => {
+            result.unwrap();
+            let remaining = outbox_a.snapshot(&endpoint).unwrap();
+            assert_eq!(remaining.len(), 1);
+            assert_eq!(remaining[0].payload(), queued_a[1].payload());
+        }
+        Change::OptOut => {
+            result.unwrap();
+            assert!(outbox_a.snapshot(&endpoint).unwrap().is_empty());
+        }
+    }
+}
+
+#[test]
+fn moved_owner_stops_later_requests_at_the_response_barrier() {
+    drain_transition(Change::MoveRoot);
+}
+#[test]
+fn missing_owner_stops_later_requests_at_the_response_barrier() {
+    drain_transition(Change::MissingIdentity);
+}
+#[test]
+fn corrupt_owner_stops_later_requests_at_the_response_barrier() {
+    drain_transition(Change::CorruptIdentity);
+}
+#[test]
+fn endpoint_change_stops_later_requests_at_the_response_barrier() {
+    drain_transition(Change::Endpoint);
+}
+#[test]
+fn opt_out_purges_only_its_owner_at_the_response_barrier() {
+    drain_transition(Change::OptOut);
+}
+
+#[test]
+fn opt_out_without_original_identity_preserves_other_owners_and_creates_no_identity() {
+    let _env_lock = ctx_app_config::TEST_LOCAL_USAGE_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    for corrupt in [false, true] {
+        let sandbox = tempfile::tempdir().unwrap();
+        let _environment = isolate_analytics_environment(sandbox.path());
+        let a = sandbox.path().join("a");
+        let b = sandbox.path().join("b");
+        let id_a = crate::identity::installation_id(&a).unwrap();
+        let id_b = crate::identity::installation_id(&b).unwrap();
+        let sink = sandbox.path().join("unexpected.jsonl");
+        let endpoint = url::Url::from_file_path(&sink).unwrap().to_string();
+        configure(&a, true, &endpoint);
+        configure(&b, true, &endpoint);
+        append_analytics_batch(&a, &[daemon_event()]).unwrap();
+        append_analytics_batch(&b, &[daemon_event()]).unwrap();
+        let path = crate::identity::device_state_path(ANALYTICS_OUTBOX_FILE, &a).unwrap();
+        let original_queue = fs::read(&path).unwrap();
+        let b_identity = fs::read(crate::identity::install_path(&b)).unwrap();
+        configure(&a, false, &endpoint);
+        if corrupt {
+            fs::write(crate::identity::install_path(&a), b"invalid identity").unwrap();
+        } else {
+            fs::remove_file(crate::identity::install_path(&a)).unwrap();
+        }
+        assert_eq!(
+            append_analytics_batch(&a, &[daemon_event()]).is_err(),
+            corrupt
+        );
+        assert_eq!(
+            drain_analytics_outbox(&a, Duration::from_secs(1)).is_err(),
+            corrupt
+        );
+        assert_eq!(fs::read(&path).unwrap(), original_queue);
+        assert_eq!(
+            fs::read(crate::identity::install_path(&b)).unwrap(),
+            b_identity
+        );
+        assert!(!sink.exists());
+        if corrupt {
+            assert_eq!(
+                fs::read(crate::identity::install_path(&a)).unwrap(),
+                b"invalid identity"
+            );
+        } else {
+            assert!(!crate::identity::install_path(&a).exists());
+        }
+        let b_outbox = AnalyticsOutbox::open(path.clone(), &id_b).unwrap();
+        assert_eq!(b_outbox.snapshot(&endpoint).unwrap().len(), 1);
+        let a_outbox = AnalyticsOutbox::open(path, &id_a).unwrap();
+        assert_eq!(a_outbox.snapshot(&endpoint).unwrap().len(), 1);
+    }
+}
+
+#[test]
+fn recovery_queueing_rechecks_the_captured_owner_without_creating_a_replacement() {
+    let _env_lock = ctx_app_config::TEST_LOCAL_USAGE_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let sandbox = tempfile::tempdir().unwrap();
+    let _environment = isolate_analytics_environment(sandbox.path());
+    let a = sandbox.path().join("a");
+    let id_a = crate::identity::installation_id(&a).unwrap();
+    let endpoint = url::Url::from_file_path(sandbox.path().join("sink.jsonl"))
+        .unwrap()
+        .to_string();
+    configure(&a, true, &endpoint);
+    let config = AppConfig::load(&a).unwrap();
+    append_analytics_batch(&a, &[daemon_event()]).unwrap();
+    append_analytics_batch(&a, &[daemon_event()]).unwrap();
+    let path = crate::identity::device_state_path(ANALYTICS_OUTBOX_FILE, &a).unwrap();
+    let outbox = AnalyticsOutbox::open(path.clone(), &id_a).unwrap();
+    let snapshot = outbox.snapshot(&endpoint).unwrap();
+    outbox
+        .reconcile(&[
+            (
+                snapshot[0].clone(),
+                DeliveryDisposition::Permanent {
+                    class: crate::analytics::AnalyticsDeliveryFailureClass::ClientRejection,
+                },
+            ),
+            (snapshot[1].clone(), DeliveryDisposition::Accepted),
+        ])
+        .unwrap();
+    assert!(outbox.pending_observation().unwrap().is_some());
+    let before = fs::read(&path).unwrap();
+    fs::remove_file(crate::identity::install_path(&a)).unwrap();
+    assert!(queue_pending_delivery_observation(&a, &id_a, &config, &outbox).is_err());
+    assert!(!crate::identity::install_path(&a).exists());
+    assert_eq!(fs::read(&path).unwrap(), before);
+}

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -960,8 +960,12 @@ content-free batch body, and durably append that body to
 `analytics-outbox-v1.json` in the same OS user-state directory. The file is
 owner-private, is never stored under the ctx data root, and contains no response
 body or raw error. It stores a one-way endpoint fingerprint plus queue time and
-attempt bookkeeping so a payload is not replayed to a different endpoint. If
-the persistent daemon is disabled or absent, entries remain local until a later
+attempt bookkeeping so a payload is not replayed to a different endpoint. Each
+entry belongs to the existing random data-root identifier. Enqueue, delivery,
+purge, and delivery counters use that same owner: an enabled root cannot upload
+another root's entries. Older shared outboxes without this ownership are
+discarded, including their counters, rather than replayed under another root's
+consent. If the persistent daemon is disabled or absent, entries remain local until a later
 daemon run delivers them or the bounds below expire them.
 
 The enabled persistent daemon is the sole telemetry network uploader. It drains
@@ -976,12 +980,16 @@ exponential backoff with jitter. A valid bounded `Retry-After` can extend the
 delay. Other permanent HTTP rejections are dropped, and daemon shutdown appends
 its terminal event without starting another request.
 
-Delivery retry, drop, age, and failure counters are coalesced into one closed
+Each root's delivery retry, drop, age, and failure counters are coalesced into
+one closed
 `analytics_delivery_observation@1` only after an ordinary payload is accepted.
 Failure to deliver that health event never recursively creates another health
-event. The outbox is bounded to 128 entries, 2 MiB total, 512 KiB per batch, and
-30 days. Oldest entries are dropped when a bound is reached. If this
-owner-private file is malformed or oversized, ctx replaces it with an empty
+event. Across all roots, the shared outbox is bounded to 128 entries, 2 MiB
+total, 512 KiB per batch, and 30 days. Oldest entries are dropped when a bound
+is reached, with drops charged to their owning root. At most 128 root counter
+records are retained; under metadata capacity pressure, counter-only records
+may be discarded while counters for roots with queued entries are preserved. If
+this owner-private file is malformed or oversized, ctx replaces it with an empty
 valid outbox and reports one `local_io` drop after delivery recovers. Unsafe
 paths, links, and permissions still fail closed instead of being replaced.
 
@@ -1005,8 +1013,15 @@ export CTX_ANALYTICS_ENABLED=false
 
 Either explicit opt-out disables CLI analytics. A config opt-out wins over
 `CTX_ANALYTICS_ENABLED=true` and over an endpoint override. The next ctx process
-that opens analytics state removes any existing analytics outbox without
-creating an analytics identity or making a telemetry request.
+that opens analytics state removes that root's queued entries and counters
+when the original root identity is still readable, without creating an analytics
+identity or making a telemetry request. If that identity is missing, invalid,
+or replaced, entries whose owner cannot be identified remain subject to the
+normal bounded expiry and eviction. They are never reassigned to another
+identity. Other roots' permitted entries remain queued. Before each request,
+ctx checks that the current root identity still matches the captured owner;
+a missing, invalid, or different identity stops further delivery. An opt-out
+cannot recall a request already sent.
 
 ### Installer diagnostics
 


### PR DESCRIPTION
Each queued analytics batch is now owned by the existing random data-root identifier. Enqueue, delivery, targeted purge, and delivery-health counters use that owner. The uploader rechecks the current identity and consent before each request, so an enabled root only delivers its own batches. An in-flight request may finish.

The content-free outbox remains owner-private and shared across roots, with aggregate storage and retry bounds and bounded root counter metadata. Legacy batches without an established owner are discarded. Targeted opt-out cleanup requires the original readable identity; unidentifiable entries remain subject to bounded expiry and eviction during queue maintenance and are never reassigned. Telemetry payload fields are unchanged.

Validation: isolated two-root, response-barrier, identity-loss and full-capacity counter regressions passed. All 249 CLI unit tests passed on 421811c8; setup 108, companion 28 and partial-refresh 7 passed on 2ba6f3e4. The earlier affected selection passed 79 of 81 targets, with both failed owners subsequently passing on their recorded inputs. Bounded review of the current base's SDK, daemon, plugin, lexical and managed-pair changes found no unresolved interaction with the unchanged consent patch. Current repository policy and diff checks pass. These runtime results retain their original identities; they are not a full-suite run on this head.