### PR TITLE
fix(swift): preserve event payloads, retry errors, and literal queries

### DIFF
--- a/contracts/agent-history-v1/README.md
+++ b/contracts/agent-history-v1/README.md
@@ -87,8 +87,6 @@ Important reusable records:
   `structuredContent` and activity capture values are opaque JSON: keys,
   explicit nulls, arrays, and distinct snake/camel spellings remain unchanged.
   An absent `structuredContent` differs from a present JSON null.
-  Swift retains [compatibility limitations](../../sdks/swift/README.md#compatibility-limitations)
-  for `activity` and `structuredContent` preservation.
 - `McpToolCall`: projection-independent MCP server/tool attribution.
 - `McpExchange`: optional content-governed invocation/response capture. Its
   closed camelCase envelope retains JSON arguments and response payloads as JSON
@@ -108,7 +106,6 @@ Important reusable records:
   and preserve `retryable`. Language-specific broad SDK codes remain separate
   from the producer's code. Non-JSON diagnostics use the process-error fallback;
   adapters do not retry automatically.
-  Swift retains the [legacy producer-error behavior](../../sdks/swift/README.md#compatibility-limitations).
 
 ## CLI Adapter Mapping
 
@@ -123,9 +120,8 @@ them into `agent-history-v1` wrappers:
 - `ctx show event ... --format json`
 - `ctx show session ... --format json`
 
-Rust, TypeScript, Python, Go, JVM and .NET adapters place a supplied query after
-`--`, with all options before it. Swift retains
-[legacy search argument construction](../../sdks/swift/README.md#compatibility-limitations).
+Rust, TypeScript, Python, Go, JVM, Swift and .NET adapters place a supplied query
+after `--`, with all options before it.
 
 This mapping is an adapter detail. SDK consumers should depend on
 `agent-history-v1`, not on CLI rendering or SQLite storage.

--- a/sdks/swift/README.md
+++ b/sdks/swift/README.md
@@ -66,20 +66,11 @@ completeness and selected/redacted/omitted policy metadata. `text` is the sole
 body, and per-event source paths, cursors, source locations, and previews are
 not exposed.
 
-## Compatibility limitations
-
-The Swift package retains three limitations relative to the shared contract:
-
-- Event normalization can rewrite keys within `structuredContent` and discard
-  explicit nulls. `AgentHistoryEventRecord` does not expose `activity`.
-- CLI failures retain standard process diagnostics but do not preserve the
-  producer JSON object under `details.producerError` or its `retryable` value.
-- Search argument construction does not separate a query with `--`; queries
-  beginning with a hyphen can be parsed as options.
-
-The corresponding Swift fixes are deferred. The preservation, producer-error
-and literal-query fixes in Rust, TypeScript, Python, Go, JVM and .NET do not
-establish Swift conformance.
+`AgentHistoryEventRecord.activity` and `structuredContent` preserve opaque JSON,
+including original keys and explicit nulls. A missing field remains distinct
+from a present JSON null. CLI errors retain the producer object in
+`details.producerError` and use its Boolean `retryable` value when supplied.
+Search queries are passed literally after all options and `--`.
 
 ## Local CLI Adapter
 

--- a/sdks/swift/Sources/CtxAgentHistory/AgentHistoryClient.swift
+++ b/sdks/swift/Sources/CtxAgentHistory/AgentHistoryClient.swift
@@ -77,11 +77,8 @@ public struct AgentHistoryClient: Sendable {
         try requireSearchIntent(query: query, options: options)
         try requireCompatibleSearchFilters(options)
         var arguments = ["search"]
-        if let query {
-            arguments.append(query)
-        }
         for term in options.terms {
-            arguments.append(contentsOf: ["--term", term])
+            appendOption(&arguments, "--term", term)
         }
         if let limit = options.limit {
             arguments.append(contentsOf: ["--limit", String(limit)])
@@ -108,6 +105,9 @@ public struct AgentHistoryClient: Sendable {
             arguments.append("--include-current-session")
         }
         arguments.append("--format=json")
+        if let query {
+            arguments.append(contentsOf: ["--", query])
+        }
         return try SearchResponse(envelope: localEnvelope(operation: .search, arguments: arguments))
     }
 
@@ -277,7 +277,7 @@ private func appendSessionLookup(_ arguments: inout [String], id: String?, provi
 
 private func appendOption(_ arguments: inout [String], _ name: String, _ value: String?) {
     if let value, !value.isEmpty {
-        arguments.append(contentsOf: [name, value])
+        arguments.append(contentsOf: value.hasPrefix("-") ? ["\(name)=\(value)"] : [name, value])
     }
 }
 
@@ -642,13 +642,13 @@ private func normalizeEventRecord(_ raw: JSONValue?) throws -> JSONValue? {
     } else {
         exchange = outer.removeValue(forKey: "mcpExchange")
     }
-    let normalized = JSONValue.object(outer)
-        .camelizedPublicJSON()
-        .droppingNulls()
-    guard case let .object(normalizedObject) = normalized else {
-        throw invalidMCPWire("event normalization did not produce an object")
+    var result: [String: JSONValue] = [:]
+    for (key, value) in outer {
+        let canonical = JSONValue.camelizedPublicKey(key)
+        if ["configPath", "itemType", "payloadType", "recordType"].contains(canonical) { continue }
+        result[canonical] = ["content", "citations"].contains(key)
+            ? value.camelizedPublicJSON().droppingNulls() : value
     }
-    var result = normalizedObject
     if result["mcpToolCall"] != nil {
         throw invalidMCPWire("outer member collides with canonical mcpToolCall")
     }

--- a/sdks/swift/Sources/CtxAgentHistory/AgentHistoryDTOs.swift
+++ b/sdks/swift/Sources/CtxAgentHistory/AgentHistoryDTOs.swift
@@ -510,6 +510,7 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
     public var text: String?
     public var mcpToolCall: AgentHistoryMCPToolCall?
     public var mcpExchange: AgentHistoryMCPExchange?
+    public var activity: JSONValue?
     public var structuredContent: JSONValue?
     public var content: CoreContentMetadata?
     public var citations: [AgentHistoryCitation]?
@@ -527,6 +528,7 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         text: String? = nil,
         mcpToolCall: AgentHistoryMCPToolCall? = nil,
         mcpExchange: AgentHistoryMCPExchange? = nil,
+        activity: JSONValue? = nil,
         structuredContent: JSONValue? = nil,
         content: CoreContentMetadata? = nil,
         citations: [AgentHistoryCitation]? = nil
@@ -543,6 +545,7 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         self.text = text
         self.mcpToolCall = mcpToolCall
         self.mcpExchange = mcpExchange
+        self.activity = activity
         self.structuredContent = structuredContent
         self.content = content
         self.citations = citations
@@ -561,6 +564,7 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         case text
         case mcpToolCall
         case mcpExchange
+        case activity
         case structuredContent
         case content
         case citations
@@ -584,7 +588,10 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         mcpExchange = container.contains(.mcpExchange)
             ? try container.decode(AgentHistoryMCPExchange.self, forKey: .mcpExchange)
             : nil
-        structuredContent = try container.decodeIfPresent(JSONValue.self, forKey: .structuredContent)
+        activity = container.contains(.activity)
+            ? try container.decode(JSONValue.self, forKey: .activity) : nil
+        structuredContent = container.contains(.structuredContent)
+            ? try container.decode(JSONValue.self, forKey: .structuredContent) : nil
         content = try container.decodeIfPresent(CoreContentMetadata.self, forKey: .content)
         citations = try container.decodeIfPresent([AgentHistoryCitation].self, forKey: .citations)
         try Self.validateNormalizedResponseBody(text: text, exchange: mcpExchange, codingPath: decoder.codingPath)
@@ -605,6 +612,7 @@ public struct AgentHistoryEventRecord: Codable, Equatable, Sendable {
         try container.encodeIfPresent(text, forKey: .text)
         try container.encodeIfPresent(mcpToolCall, forKey: .mcpToolCall)
         try container.encodeIfPresent(mcpExchange, forKey: .mcpExchange)
+        try container.encodeIfPresent(activity, forKey: .activity)
         try container.encodeIfPresent(structuredContent, forKey: .structuredContent)
         try container.encodeIfPresent(content, forKey: .content)
         try container.encodeIfPresent(citations, forKey: .citations)

--- a/sdks/swift/Sources/CtxAgentHistory/LocalCLIAdapter.swift
+++ b/sdks/swift/Sources/CtxAgentHistory/LocalCLIAdapter.swift
@@ -179,15 +179,26 @@ public struct LocalCLIAdapter: Sendable {
         let stdout = String(data: result.stdout, encoding: .utf8) ?? ""
         let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
         let firstStderrLine = stderr.split(whereSeparator: \.isNewline).first.map(String.init)
+        let producer: JSONValue?
+        if let value = try? JSONDecoder().decode(JSONValue.self, from: result.stderr),
+            let errorCode = value["error_code"]?.stringValue, !errorCode.isEmpty,
+            value["retryable"] == nil || value["retryable"]?.boolValue != nil {
+            producer = value
+        } else {
+            producer = nil
+        }
+        var details: [String: JSONValue] = [
+            "command": .array(([ctxPath] + arguments).map { .string($0) }),
+            "exitCode": .number(Decimal(result.exitCode)),
+            "stdout": .string(stdout),
+            "stderr": .string(stderr)
+        ]
+        details["producerError"] = producer
         return CtxAgentHistorySDKError(
             code: .adapterError,
             message: firstStderrLine.map { "ctx command failed: \($0)" } ?? "ctx command failed",
-            details: .object([
-                "command": .array(([ctxPath] + arguments).map { .string($0) }),
-                "exitCode": .number(Decimal(result.exitCode)),
-                "stdout": .string(stdout),
-                "stderr": .string(stderr)
-            ]),
+            retryable: producer?["retryable"]?.boolValue ?? false,
+            details: .object(details),
             command: [ctxPath] + arguments,
             exitCode: Int(result.exitCode),
             stdout: stdout,

--- a/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
+++ b/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
@@ -2,6 +2,105 @@ import XCTest
 @testable import CtxAgentHistory
 
 final class CtxAgentHistoryTests: XCTestCase {
+    func testPreservesOpaqueEventPayloadsAndExplicitNulls() throws {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+            .deletingLastPathComponent().deletingLastPathComponent()
+            .appendingPathComponent("contracts/agent-history-v1/fixtures/cli/opaque-event.json")
+        let event = try JSONDecoder().decode(JSONValue.self, from: Data(contentsOf: fixtureURL))
+        let values: [JSONValue?] = [
+            event["structured_content"], .array([.null, .object(["snake_key": .bool(false)])]),
+            .string("literal_雪"), .number(42), .bool(false), .null, nil
+        ]
+        var cases = [try XCTUnwrap(event.objectValue)]
+        for value in values {
+            var current = try XCTUnwrap(event.objectValue)
+            current["structured_content"] = value
+            current["activity"] = value
+            cases.append(current)
+        }
+        for current in cases {
+            let raw = JSONValue.object([
+                "event": .object(current), "events": .array([.object(current)]), "session": .object([:])
+            ])
+            let bytes = try JSONEncoder().encode(raw)
+            let runner = CapturingRunner { _ in CommandResult(stdout: bytes) }
+            let client = AgentHistoryClient(adapter: LocalCLIAdapter(runner: runner))
+            let shown = try client.showEvent("event-1").event
+            let single = try XCTUnwrap(shown.event)
+            let window = try XCTUnwrap(shown.events.first)
+            let session = try XCTUnwrap(client.showSession("session-1").session.events.first)
+            for actual in [single, window, session] {
+                XCTAssertEqual(actual.structuredContent, current["structured_content"])
+                // Encoding uses the existing API so this regression also compiles against the old DTO.
+                let encoded = try JSONDecoder().decode(JSONValue.self, from: JSONEncoder().encode(actual))
+                XCTAssertEqual(encoded["activity"], current["activity"])
+                XCTAssertEqual(encoded["structuredContent"], current["structured_content"])
+            }
+        }
+    }
+
+    func testPassesSearchQueriesAndOptionValuesLiterally() throws {
+        for query in ["--help", "--refresh=off", "-needle", "--", "two words", "a'雪"] {
+            let runner = CapturingRunner { _ in CommandResult(stdout: #"{"results":[]}"#) }
+            let client = AgentHistoryClient(adapter: LocalCLIAdapter(runner: runner))
+            _ = try client.search(
+                query, options: SearchOptions(terms: ["-term"], limit: 2, file: "-file", refresh: "off")
+            )
+            XCTAssertEqual(
+                try XCTUnwrap(runner.requests.last).arguments,
+                ["search", "--term=-term", "--limit", "2", "--file=-file", "--refresh", "off", "--format=json", "--", query]
+            )
+        }
+        let runner = CapturingRunner { _ in CommandResult(stdout: #"{"results":[]}"#) }
+        _ = try AgentHistoryClient(adapter: LocalCLIAdapter(runner: runner))
+            .search(options: SearchOptions(terms: ["-term"], file: "-file"))
+        XCTAssertEqual(
+            try XCTUnwrap(runner.requests.last).arguments,
+            ["search", "--term=-term", "--file=-file", "--format=json"]
+        )
+    }
+
+    func testRetainsProducerErrorsAndRetryability() throws {
+        let retryValues: [Bool?] = [false, true, nil]
+        for retryable in retryValues {
+            var producer: [String: JSONValue] = [
+                "error_code": .string("generation_changed"),
+                "details": .object(["snake_key": .array([.null, .string("雪")])])
+            ]
+            producer["retryable"] = retryable.map { .bool($0) }
+            let stderr = String(decoding: try JSONEncoder().encode(JSONValue.object(producer)), as: UTF8.self)
+            let runner = CapturingRunner { _ in CommandResult(stdout: "partial stdout", stderr: stderr, exitCode: 1) }
+            let client = AgentHistoryClient(adapter: LocalCLIAdapter(runner: runner))
+            XCTAssertThrowsError(try client.showEvent("event-1")) { error in
+                let typed = error as? CtxAgentHistorySDKError
+                XCTAssertEqual(typed?.code, .adapterError)
+                XCTAssertEqual(typed?.retryable, retryable ?? false)
+                XCTAssertEqual(typed?.details?["producerError"], .object(producer))
+                XCTAssertEqual(typed?.exitCode, 1)
+                XCTAssertEqual(typed?.stdout, "partial stdout")
+                XCTAssertEqual(typed?.stderr, stderr)
+                XCTAssertEqual(typed?.command, ["ctx", "show", "event", "event-1", "--format", "json"])
+            }
+        }
+        for stderr in [
+            "ordinary stderr", "{}", "[]", "null", #"{"error_code":""}"#,
+            #"{"error_code":7}"#, #"{"error_code":"busy","retryable":null}"#,
+            #"{"error_code":"busy","retryable":"true"}"#,
+            #"{"error_code":"busy","retryable":1}"#,
+            "warning\n{\"error_code\":\"busy\",\"retryable\":true}"
+        ] {
+            let runner = CapturingRunner { _ in CommandResult(stdout: "", stderr: stderr, exitCode: 2) }
+            XCTAssertThrowsError(try AgentHistoryClient(adapter: LocalCLIAdapter(runner: runner)).status()) { error in
+                let typed = error as? CtxAgentHistorySDKError
+                XCTAssertEqual(typed?.code, .adapterError)
+                XCTAssertEqual(typed?.retryable, false)
+                XCTAssertNil(typed?.details?["producerError"])
+                XCTAssertEqual(typed?.stderr, stderr)
+            }
+        }
+    }
+
     func testForcesAnalyticsOffAfterAmbientAndUserEnvironmentMerging() throws {
         #if !os(macOS)
         throw XCTSkip("Darwin process-group execution is macOS-only")
@@ -150,7 +249,7 @@ final class CtxAgentHistoryTests: XCTestCase {
             runner.requests[0].arguments,
             [
                 "--data-root", "/tmp/ctx-sdk-test",
-                "search", "retry handling",
+                "search",
                 "--term", "timeout",
                 "--term", "backoff",
                 "--limit", "5",
@@ -166,7 +265,7 @@ final class CtxAgentHistoryTests: XCTestCase {
                 "--events",
                 "--refresh", "off",
                 "--include-current-session",
-                "--format=json"
+                "--format=json", "--", "retry handling"
             ]
         )
     }
@@ -194,9 +293,9 @@ final class CtxAgentHistoryTests: XCTestCase {
             runner.requests[0].arguments,
             [
                 "--data-root", "/tmp/ctx-sdk-test",
-                "search", "agent history",
+                "search",
                 "--content-scope", "calls",
-                "--format=json"
+                "--format=json", "--", "agent history"
             ]
         )
         XCTAssertEqual(
@@ -247,7 +346,11 @@ final class CtxAgentHistoryTests: XCTestCase {
             switch Array(request.arguments.dropFirst(2).prefix(2)) {
             case ["status", "--format=json"]:
                 return CommandResult(stdout: Self.statusJSON)
-            case ["search", "local agent history"]:
+            case ["search", "--limit"]:
+                XCTAssertEqual(
+                    Array(request.arguments.dropFirst(2)),
+                    ["search", "--limit", "1", "--refresh", "off", "--format=json", "--", "local agent history"]
+                )
                 return CommandResult(stdout: Self.searchJSON)
             case ["show", "event"]:
                 return CommandResult(stdout: Self.eventJSON)


### PR DESCRIPTION
Swift shown events now retain opaque `activity` and `structuredContent` values, including original keys and present JSON nulls. CLI failures preserve the producer error object and its retryability. Search queries follow all options and `--`, and leading-hyphen option values remain literal.

The patch adds regressions at the existing injected-runner and DTO boundaries. The unmodified shared activity fixture is checked through event, window and session responses; malformed producer diagnostics retain the standard process-error fallback.

Validation: the existing XCTest package ran with official Swift 6.1.2 on Linux using native `swift test --jobs 4`. The compilable baseline failed the three new regression tests (56 assertions); the fixed package passed 24 tests with five existing Darwin-only skips. The off-macOS rejection test passed. This validates the portable SDK behavior; it does not qualify Darwin process containment.

Remove the obsolete Swift compatibility exceptions from the Swift and shared contract documentation.
