### PR TITLE
Preserve durable refresh identity and pending setup status

### DIFF
--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle.rs
@@ -1162,12 +1162,29 @@ fn validate_empty_catalog_refresh_request(refresh_request: &Value) -> Result<(),
     }
 }
 
+fn validate_empty_catalog_setup_mode(setup: &Value) -> Result<(), &'static str> {
+    validate_empty_catalog_refresh_request(&setup["refresh_request"])?;
+    match setup["refresh"]["status"].as_str() {
+        Some("ready") if setup["mode"] == "ready" => Ok(()),
+        Some("pending")
+            if setup["mode"] == "pending"
+                && setup["refresh"]["reason"] == "core_refresh_pending"
+                && matches!(
+                    setup["refresh_request"]["status"].as_str(),
+                    Some("admission_pending" | "queued" | "running")
+                ) =>
+        {
+            Ok(())
+        }
+        _ => Err("empty-catalog setup mode must match its captured refresh health"),
+    }
+}
+
 fn assert_empty_catalog_default_background_setup(setup: &Value) {
-    assert_eq!(setup["mode"], "ready", "{setup:#}");
     assert_eq!(setup["lexical"]["status"], "ready", "{setup:#}");
     assert_eq!(setup["lexical"]["certified_sources"], 0, "{setup:#}");
     assert_eq!(setup["lexical"]["indexed_documents"], 0, "{setup:#}");
-    if let Err(error) = validate_empty_catalog_refresh_request(&setup["refresh_request"]) {
+    if let Err(error) = validate_empty_catalog_setup_mode(setup) {
         panic!("{error}: {setup:#}");
     }
 }
@@ -1203,6 +1220,31 @@ fn empty_catalog_default_background_oracle_is_status_sensitive() {
         "receipt": null,
     }))
     .is_err());
+}
+
+#[test]
+fn empty_catalog_setup_mode_oracle_rejects_premature_readiness() {
+    for state in ["admission_pending", "queued", "running"] {
+        let mut setup = json!({
+            "mode":"pending",
+            "refresh":{"status":"pending","reason":"core_refresh_pending"},
+            "refresh_request":{"status":state,"source_count":0,"receipt":null},
+        });
+        assert_eq!(validate_empty_catalog_setup_mode(&setup), Ok(()));
+        setup["mode"] = json!("ready");
+        assert!(validate_empty_catalog_setup_mode(&setup).is_err());
+        setup["refresh"]["status"] = json!("ready");
+        assert_eq!(validate_empty_catalog_setup_mode(&setup), Ok(()));
+        setup["refresh_request"]["receipt"] = json!({
+            "selected_route_total":0,"successful_route_total":0,"source_failure_total":0,
+        });
+        assert!(validate_empty_catalog_setup_mode(&setup).is_err());
+        setup["refresh_request"]["status"] = json!("published");
+        assert_eq!(validate_empty_catalog_setup_mode(&setup), Ok(()));
+        setup["mode"] = json!("pending");
+        setup["refresh"]["status"] = json!("pending");
+        assert!(validate_empty_catalog_setup_mode(&setup).is_err());
+    }
 }
 
 #[path = "lifecycle/additional.rs"]

--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle/additional.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle/additional.rs
@@ -99,7 +99,6 @@ fn operational_systemd_installer_style_setup_verifies_an_empty_noop_core() {
         fs::read_to_string(temp.path().join("fake-systemd-daemon.stderr")).unwrap_or_default(),
     );
     let setup: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(setup["mode"], "ready", "{setup:#}");
     assert_eq!(setup["daemon_autostart"]["status"], "verified", "{setup:#}");
     assert_eq!(setup["daemon_autostart"]["persistent"], true, "{setup:#}");
     assert_eq!(
@@ -176,7 +175,6 @@ fn hosted_setup_recovers_when_the_new_systemd_service_first_exits_cleanly() {
         fs::read_to_string(temp.path().join("fake-systemd-daemon.stderr")).unwrap_or_default(),
     );
     let setup: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(setup["mode"], "ready", "{setup:#}");
     assert_eq!(setup["daemon_autostart"]["status"], "verified", "{setup:#}");
     assert_eq!(setup["daemon_autostart"]["persistent"], true, "{setup:#}");
     assert_eq!(
@@ -214,7 +212,6 @@ fn unavailable_systemd_installer_style_setup_starts_a_persistent_fallback() {
         .env("PATH", &path)
         .env_remove("CTX_DAEMON_AUTOSTART_OFF");
     let setup = json_output(setup_command.args(["setup", "--format=json", "--progress", "none"]));
-    assert_eq!(setup["mode"], "ready", "{setup:#}");
     assert_eq!(setup["daemon_autostart"]["status"], "degraded", "{setup:#}");
     assert_eq!(setup["daemon_autostart"]["persistent"], true, "{setup:#}");
     assert!(

--- a/crates/ctx-cli/src/commands/setup.rs
+++ b/crates/ctx-cli/src/commands/setup.rs
@@ -220,7 +220,14 @@ fn setup_mode(
         "ready" if refresh_health_status == "ready" => "ready",
         "pending" => "pending",
         "stale" => "stale",
-        _ if refresh_status == "pending" => "pending",
+        _ if refresh_status == "pending"
+            || (refresh_health_status == "pending"
+                && refresh_status
+                    .parse::<ctx_history_refresh::RefreshRequestState>()
+                    .is_ok_and(ctx_history_refresh::RefreshRequestState::is_active)) =>
+        {
+            "pending"
+        }
         _ => "unavailable",
     }
 }
@@ -411,6 +418,22 @@ mod tests {
             "unavailable"
         );
         assert_eq!(setup_mode("ready", "published", "stale"), "unavailable");
+    }
+
+    #[test]
+    fn admitted_background_refresh_preserves_the_source_health_snapshot() {
+        for state in ["admission_pending", "queued", "running"] {
+            assert_eq!(setup_mode("ready", state, "pending"), "pending");
+            assert_eq!(setup_mode("ready", state, "ready"), "ready");
+            assert_eq!(setup_mode("unavailable", state, "pending"), "pending");
+            assert_eq!(setup_mode("stale", state, "pending"), "stale");
+            for health in ["partial", "stale", "unavailable"] {
+                assert_eq!(setup_mode("ready", state, health), "unavailable");
+            }
+        }
+        for state in ["published", "failed", "admission_rejected", "unknown"] {
+            assert_eq!(setup_mode("ready", state, "pending"), "unavailable");
+        }
     }
 
     #[test]

--- a/crates/ctx-daemon-service/src/daemon/tests.rs
+++ b/crates/ctx-daemon-service/src/daemon/tests.rs
@@ -905,18 +905,11 @@ fn forced_watcher_recovery_adds_no_scans_after_startup_reconciliation() -> Resul
     assert!(!coordinator.has_scheduled_route_work());
     assert!(!coordinator.enqueue_next_dirty_route(&fixture.data_root, u64::MAX)?);
     for _ in 0..3 {
-        let response = coordinator
-            .handle_ipc_request(
-                &fixture.data_root,
-                &json!({
-                    "schema_version": 1,
-                    "op": "source_refresh_request",
-                    "mode": "background",
-                    "refresh_intent": {"kind": "automatic_maintenance"},
-                }),
-            )?
-            .expect("background maintenance wake");
-        assert_eq!(response["maintenance_wake"], true);
+        // Internal maintenance notification stays lightweight. Caller-bearing
+        // background IPC now owns durable admission and is covered separately.
+        let response =
+            coordinator.maintenance_wake(&fixture.data_root, uuid::Uuid::now_v7().to_string())?;
+        assert_eq!(response.schema_v1_fields()["maintenance_wake"], true);
         assert!(!coordinator.has_pending_request());
     }
     assert_eq!(

--- a/crates/ctx-daemon-service/src/query_service_transport_tests.rs
+++ b/crates/ctx-daemon-service/src/query_service_transport_tests.rs
@@ -1022,7 +1022,7 @@ fn semantic_query_protocol_rejects_incompatible_requests_before_model_access() -
 
 #[cfg(any(unix, windows))]
 #[test]
-fn query_service_coalesces_source_refresh_requests_on_one_daemon_ticket() -> Result<()> {
+fn query_service_retains_distinct_source_refresh_requests_on_one_daemon() -> Result<()> {
     let temp = tempfile::tempdir()?;
     let (service, source_refresh) = start_test_source_refresh_service(temp.path())?;
     let request = || {
@@ -1040,20 +1040,24 @@ fn query_service_coalesces_source_refresh_requests_on_one_daemon_ticket() -> Res
     };
 
     let first = request()?.expect("first source refresh response");
-    let second = request()?.expect("coalesced source refresh response");
+    let second = request()?.expect("second source refresh response");
 
     assert_eq!(first["request_state"], "admission_pending");
     assert_eq!(second["request_state"], "admission_pending");
-    assert_eq!(first["request_id"], second["request_id"]);
+    assert_ne!(first["request_id"], second["request_id"]);
     assert_eq!(first["coalesced_requests"], 0);
-    assert_eq!(second["coalesced_requests"], 1);
+    assert_eq!(second["coalesced_requests"], 0);
     assert!(source_refresh.has_pending_request());
     let job = read_daemon_job_status(&daemon_source_backed_refresh_job_path(temp.path()))
         .expect("admission-pending source refresh job status");
     assert_eq!(job["owner"], "daemon");
     assert_eq!(job["request_state"], "admission_pending");
     assert_eq!(job["request_id"], first["request_id"]);
-    assert_eq!(job["coalesced_requests"], 1);
+    assert_eq!(job["coalesced_requests"], 0);
+    assert_eq!(
+        job["queued_successors"][0]["request_id"],
+        second["request_id"]
+    );
     drop(service);
     Ok(())
 }

--- a/crates/ctx-daemon-service/src/source_backed_refresh_adapter/wire.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_adapter/wire.rs
@@ -27,21 +27,24 @@ pub(crate) fn handle_ipc_request(
 ) -> Result<Option<WireResponse>> {
     match request.get("op").and_then(Value::as_str) {
         Some(SOURCE_REFRESH_REQUEST_OP) => {
-            let response = match refresh_action(request)? {
-                WireRefreshAction::MaintenanceWake { request_id } => WireResponse {
-                    value: render_status(&engine.maintenance_wake(data_root, request_id)?),
-                    response_barrier: None,
-                },
-                WireRefreshAction::Submit(request) => {
-                    let admission = engine.submit(data_root, request)?;
-                    let (status, response_barrier) = admission.into_parts();
-                    WireResponse {
-                        value: render_status(&status),
-                        response_barrier,
-                    }
-                }
-            };
-            Ok(Some(response))
+            let admission = engine.submit(data_root, refresh_request(request)?)?;
+            let (status, response_barrier) = admission.into_parts();
+            let mut value = render_status(&status);
+            if value.get("admission_durability").is_some() {
+                // A retained replacement may survive restart, but it has not
+                // confirmed durability. Preserve its ID and response barrier
+                // without acknowledging successful admission to the caller.
+                value["ok"] = json!(false);
+                value["error_code"] = json!("source_refresh_admission_unconfirmed");
+                value["retryable"] = json!(true);
+                value["error"] = json!(
+                    "source refresh admission durability is unconfirmed; retry the same request ID"
+                );
+            }
+            Ok(Some(WireResponse {
+                value,
+                response_barrier,
+            }))
         }
         Some(SOURCE_REFRESH_STATUS_OP) => {
             let request_id = request
@@ -115,13 +118,7 @@ pub(crate) fn handle_ipc_request_for_test(
     Ok(Some(value))
 }
 
-#[derive(Debug)]
-enum WireRefreshAction {
-    MaintenanceWake { request_id: String },
-    Submit(RefreshRequest),
-}
-
-fn refresh_action(request: &Value) -> Result<WireRefreshAction> {
+fn refresh_request(request: &Value) -> Result<RefreshRequest> {
     let mode = request.get("mode").and_then(Value::as_str).unwrap_or("");
     if !matches!(mode, "background" | "wait") {
         return Err(anyhow!("invalid daemon source refresh mode `{mode}`"));
@@ -174,15 +171,12 @@ fn refresh_action(request: &Value) -> Result<WireRefreshAction> {
         None => Uuid::now_v7().to_string(),
         Some(_) => bail!("daemon source refresh logical request ID is invalid"),
     };
-    if mode == "background" {
-        if intent != RefreshIntent::AutomaticMaintenance {
-            bail!("selected import requires daemon refresh mode `wait`");
-        }
-        return Ok(WireRefreshAction::MaintenanceWake { request_id });
+    if mode == "background" && intent != RefreshIntent::AutomaticMaintenance {
+        bail!("selected import requires daemon refresh mode `wait`");
     }
-    Ok(WireRefreshAction::Submit(RefreshRequest::new(
-        request_id, intent, trigger,
-    )))
+    // Every IPC caller gets a durable identity. ID-less scheduler wakes use
+    // the engine's internal enqueue path and do not cross this boundary.
+    Ok(RefreshRequest::new(request_id, intent, trigger))
 }
 
 fn render_status(status: &RefreshStatus) -> Value {
@@ -198,9 +192,8 @@ fn unknown_refresh_request_response(request_id: &str) -> Value {
         "request_state": "request_unknown",
         "error_code": "source_refresh_request_unknown",
         "reason": "request_not_retained_after_restart",
-        // This request's durable terminal outcome is no longer observable
-        // after a daemon restart.  Re-enqueuing equivalent work would create
-        // a new request, not recover this one.
+        // The old outcome is no longer observable. This exact typed response
+        // lets a waiter readmit its original request once under the same ID.
         "retryable": false,
         "error": "source refresh request outcome is no longer observable after daemon restart",
     }))
@@ -209,6 +202,7 @@ fn unknown_refresh_request_response(request_id: &str) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ctx_history_refresh::RefreshJournal;
 
     #[test]
     fn refresh_request_requires_a_canonical_intent() {
@@ -304,9 +298,9 @@ mod tests {
     }
 
     #[test]
-    fn background_wire_request_decodes_as_maintenance_wake() {
+    fn background_wire_request_decodes_as_durable_submission() {
         let request_id = "019fcaaa-0000-7000-8000-000000000513";
-        let action = refresh_action(&json!({
+        let action = refresh_request(&json!({
             "op": SOURCE_REFRESH_REQUEST_OP,
             "request_id": request_id,
             "mode": "background",
@@ -315,17 +309,14 @@ mod tests {
         }))
         .unwrap();
 
-        assert!(matches!(
-            action,
-            WireRefreshAction::MaintenanceWake {
-                request_id: decoded
-            } if decoded == request_id
-        ));
+        assert_eq!(action.request_id(), request_id);
+        assert_eq!(action.intent(), &RefreshIntent::AutomaticMaintenance);
+        assert_eq!(action.trigger(), RefreshRequestTrigger::Search);
     }
 
     #[test]
     fn canonical_request_rejects_retired_physical_scope() {
-        let error = refresh_action(&json!({
+        let error = refresh_request(&json!({
             "op": SOURCE_REFRESH_REQUEST_OP,
             "mode": "wait",
             "refresh_intent": {"kind": "automatic_maintenance"},
@@ -337,5 +328,129 @@ mod tests {
         .unwrap_err();
 
         assert!(format!("{error:#}").contains("carries retired `refresh_scope`"));
+    }
+
+    fn background_request(request_id: &str) -> Value {
+        json!({
+            "op": SOURCE_REFRESH_REQUEST_OP,
+            "request_id": request_id,
+            "mode": "background",
+            "trigger": "search",
+            "refresh_intent": {"kind": "automatic_maintenance"},
+        })
+    }
+
+    #[test]
+    fn background_acknowledgement_is_durable_before_response_and_duplicate_survives_restart() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = super::super::refresh_engine(&crate::test_support::CONFIG);
+        let id = "019fcaaa-0000-7000-8000-000000000514";
+        let request = background_request(id);
+        let journal = super::super::journal::DaemonRefreshJournal;
+
+        let first = handle_ipc_request(&engine, temp.path(), &request)
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.value["ok"], true);
+        assert_eq!(first.value["request_id"], id);
+        assert_eq!(first.value["request_state"], "admission_pending");
+        let durable = journal.load(temp.path()).unwrap().unwrap();
+        assert_eq!(durable["request_id"], id);
+        assert!(durable.get("admission_durability").is_none());
+        assert!(!engine.prepare_next_pending_admission(temp.path()).unwrap());
+
+        let duplicate = handle_ipc_request(&engine, temp.path(), &request)
+            .unwrap()
+            .unwrap();
+        assert_eq!(duplicate.value, first.value);
+        assert_eq!(journal.load(temp.path()).unwrap(), Some(durable.clone()));
+        first.response_barrier.unwrap().release(&engine);
+        assert!(!engine.prepare_next_pending_admission(temp.path()).unwrap());
+        duplicate.response_barrier.unwrap().release(&engine);
+        drop(engine);
+
+        let restarted = super::super::refresh_engine(&crate::test_support::CONFIG);
+        assert!(restarted
+            .recover_interrupted_publication(temp.path())
+            .unwrap());
+        let response = handle_ipc_request(&restarted, temp.path(), &request)
+            .unwrap()
+            .unwrap();
+        assert_eq!(response.value["ok"], true);
+        assert_eq!(response.value["request_id"], id);
+        assert_eq!(
+            response.value["requested_at_ms"],
+            durable["requested_at_ms"]
+        );
+        assert_eq!(response.value["coalesced_requests"], 0);
+        response.response_barrier.unwrap().release(&restarted);
+    }
+
+    struct AdmissionFaultJournal(std::sync::atomic::AtomicU8);
+
+    impl ctx_history_refresh::RefreshJournal for AdmissionFaultJournal {
+        fn load(&self, root: &Path) -> Result<Option<Value>> {
+            super::super::journal::DaemonRefreshJournal.load(root)
+        }
+
+        fn store(&self, root: &Path, value: &Value) -> Result<()> {
+            super::super::journal::DaemonRefreshJournal.store(root, value)
+        }
+
+        fn store_before_ack(
+            &self,
+            root: &Path,
+            value: &Value,
+        ) -> ctx_history_refresh::DurableAdmissionPersistence {
+            use ctx_history_refresh::DurableAdmissionPersistence as Persistence;
+            let fault = self.0.swap(0, std::sync::atomic::Ordering::SeqCst);
+            if fault == 1 {
+                return Persistence::Failed(anyhow!("injected pre-replacement failure"));
+            }
+            let result = super::super::journal::DaemonRefreshJournal.store_before_ack(root, value);
+            if fault == 2 && matches!(result, Persistence::Confirmed) {
+                return Persistence::Retained(anyhow!("injected durability uncertainty"));
+            }
+            result
+        }
+    }
+
+    #[test]
+    fn background_failed_or_indeterminate_persistence_is_not_successfully_acknowledged() {
+        use std::sync::{atomic::AtomicU8, Arc};
+        for fault in [1, 2] {
+            let temp = tempfile::tempdir().unwrap();
+            let engine = RefreshEngine::new(
+                Arc::new(AdmissionFaultJournal(AtomicU8::new(fault))),
+                Arc::new(super::super::runtime::DaemonRefreshRuntime::new(
+                    &crate::test_support::CONFIG,
+                )),
+            );
+            let id = "019fcaaa-0000-7000-8000-000000000515";
+            let request = background_request(id);
+            let first = handle_ipc_request(&engine, temp.path(), &request);
+            if fault == 1 {
+                assert!(first.is_err());
+                assert!(engine.status(id).is_none());
+            } else {
+                let first = first.unwrap().unwrap();
+                assert_eq!(first.value["ok"], false);
+                assert_eq!(first.value["retryable"], true);
+                assert_eq!(first.value["request_id"], id);
+                assert_eq!(
+                    first.value["error_code"],
+                    "source_refresh_admission_unconfirmed"
+                );
+                assert!(engine.status(id).is_some());
+                first.response_barrier.unwrap().release(&engine);
+            }
+            let replay = handle_ipc_request(&engine, temp.path(), &request)
+                .unwrap()
+                .unwrap();
+            assert_eq!(replay.value["ok"], true);
+            assert_eq!(replay.value["request_id"], id);
+            assert!(replay.value.get("admission_durability").is_none());
+            replay.response_barrier.unwrap().release(&engine);
+        }
     }
 }

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client.rs
@@ -923,6 +923,7 @@ pub(super) fn source_refresh_request_is_unknown(
             == Some(SOURCE_REFRESH_UNKNOWN_REQUEST_STATE)
         && response.get("reason").and_then(Value::as_str)
             == Some("request_not_retained_after_restart")
+        && !has_retained_request_authority(response)
         // The missing outcome itself is not retryable. This exact typed
         // response authorizes one same-request readmission; text does not.
         && response.get("retryable").and_then(Value::as_bool) == Some(false);

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client.rs
@@ -8,8 +8,6 @@ mod response;
 mod types;
 #[cfg(feature = "test-support")]
 pub use observation_recovery::SourceRefreshObservationRecoveryFailed;
-#[cfg(test)]
-use observation_recovery::DISCONNECT_POLICY;
 use observation_recovery::{
     request_bound_status_with_outage_budget_cancellable, retained_request_unobservable,
 };
@@ -159,7 +157,7 @@ where
                 .downcast_ref::<DaemonSourceRefreshServiceUnavailable>()
                 .is_some() =>
         {
-            return Err(error)
+            return Err(error);
         }
         Err(error) => return Err(error),
     }
@@ -449,15 +447,14 @@ fn coordinate_source_backed_refresh_with_policy(
         }
         availability.checkpoint()?;
     };
+    if let Some(observation) =
+        background_admission_rejected_fallback(data_root, mode, &intent, retain_peer, &response)?
+    {
+        return Ok(observation);
+    }
     validate_daemon_refresh_response(&response)?;
-    let accepted_request_id = response_request_id(&response, "daemon source refresh response")?;
-    let request_id = if intent.is_selected_import() {
-        validate_source_refresh_status_response_authority(&response, &logical_request_id)?;
-        logical_request_id
-    } else {
-        validate_source_refresh_status_response_authority(&response, &accepted_request_id)?;
-        accepted_request_id
-    };
+    validate_source_refresh_status_response_authority(&response, &logical_request_id)?;
+    let request_id = logical_request_id;
     let protocol = source_refresh_protocol_status(&response)?;
 
     if mode == SourceBackedRefreshMode::Background {
@@ -576,7 +573,7 @@ struct PublishedGenerationWait<'progress> {
 fn wait_for_published_generation_inner(
     availability: &dyn crate::DaemonAvailabilityPort,
     data_root: &Path,
-    mut request_id: String,
+    request_id: String,
     wait: PublishedGenerationWait<'_>,
 ) -> Result<SourceBackedRefreshObservation> {
     let PublishedGenerationWait {
@@ -587,6 +584,8 @@ fn wait_for_published_generation_inner(
         retain_peer,
         mut report_progress,
     } = wait;
+    let mut owner_recovery_attempted = false;
+    let mut forgotten_request_replayed = false;
     let mut last_reported_status = None;
     let mut last_reported_at = None;
     loop {
@@ -613,11 +612,15 @@ fn wait_for_published_generation_inner(
         ) {
             Ok(Some(response)) => response,
             Ok(None) => {
-                if !allow_daemon_autostart {
-                    return Err(retained_request_unobservable(&request_id, 0));
+                if !allow_daemon_autostart || owner_recovery_attempted {
+                    return Err(retained_request_unobservable(
+                        &request_id,
+                        usize::from(owner_recovery_attempted),
+                    ));
                 }
+                owner_recovery_attempted = true;
                 availability.checkpoint()?;
-                request_id = recover_wait_refresh_request(
+                recover_wait_refresh_request(
                     availability,
                     data_root,
                     &request_id,
@@ -634,11 +637,15 @@ fn wait_for_published_generation_inner(
                     .downcast_ref::<DaemonSourceRefreshServiceUnavailable>()
                     .is_some() =>
             {
-                if !allow_daemon_autostart {
-                    return Err(retained_request_unobservable(&request_id, 0));
+                if !allow_daemon_autostart || owner_recovery_attempted {
+                    return Err(retained_request_unobservable(
+                        &request_id,
+                        usize::from(owner_recovery_attempted),
+                    ));
                 }
+                owner_recovery_attempted = true;
                 availability.checkpoint()?;
-                request_id = recover_wait_refresh_request(
+                recover_wait_refresh_request(
                     availability,
                     data_root,
                     &request_id,
@@ -653,16 +660,25 @@ fn wait_for_published_generation_inner(
                 continue;
             }
             Err(error) => {
-                return Err(error.context("wait for daemon-owned source-backed refresh publication"))
+                return Err(
+                    error.context("wait for daemon-owned source-backed refresh publication")
+                );
             }
         };
         availability.checkpoint()?;
         if source_refresh_request_is_unknown(&response, &request_id)? {
-            // Reaching this wait loop means the client already received an
-            // admission acknowledgement. A subsequent typed unknown response
-            // cannot safely distinguish a lost retained request from daemon
-            // state loss, so never replay equivalent work under its UUID.
-            return Err(retained_request_unobservable(&request_id, 0));
+            if forgotten_request_replayed {
+                return Err(retained_request_unobservable(&request_id, 1));
+            }
+            forgotten_request_replayed = true;
+            enqueue_equivalent_wait_refresh_request(
+                availability,
+                data_root,
+                &request_id,
+                intent.clone(),
+                trigger,
+            )?;
+            continue;
         }
         validate_source_refresh_status_response_authority(&response, &request_id)?;
         validate_daemon_refresh_response(&response)?;
@@ -808,11 +824,8 @@ pub(super) fn recover_wait_refresh_request(
             bail!("daemon was disabled while waiting for source refresh");
         }
         availability.checkpoint()?;
-        // The acknowledged request may be a command waiter coalesced onto a
-        // periodic/search attempt. Restarting and immediately re-submitting
-        // the command payload under that physical ID would be a genuine
-        // idempotency conflict. Re-observe the durable ID; a typed unknown
-        // after acknowledgement is terminal and must not re-admit it.
+        // Restore observation first. Only a typed matching-ID unknown
+        // response authorizes readmission with the original request authority.
         Ok(request_id.to_owned())
     })();
     recovery.map_err(|error| {
@@ -826,36 +839,34 @@ pub(super) fn recover_wait_refresh_request(
     })
 }
 
-#[cfg(test)]
 fn enqueue_equivalent_wait_refresh_request(
+    availability: &dyn crate::DaemonAvailabilityPort,
     data_root: &Path,
     request_id: &str,
     intent: RefreshIntent,
     trigger: RefreshRequestTrigger,
 ) -> Result<String> {
-    let selected_import = intent.is_selected_import();
     let canonical_request = RefreshRequest::new(request_id.to_owned(), intent, trigger);
     let request = wait_authority_request_json(SourceBackedRefreshMode::Wait, &canonical_request)?;
-    let response = request_admission_with_recovery(request_id, std::thread::sleep, || {
-        daemon_source_refresh_request(
-            data_root,
-            request.clone(),
-            SOURCE_REFRESH_IPC_TIMEOUT,
-            SOURCE_REFRESH_RESPONSE_MAX_BYTES,
-        )
-    })?
-    .ok_or_else(|| retained_request_unobservable(request_id, 0))?;
+    let response = request_admission_with_recovery_cancellable(
+        request_id,
+        |duration| availability.pause(duration),
+        || availability.checkpoint(),
+        || {
+            daemon_source_refresh_request_with_cancellation(
+                availability,
+                data_root,
+                request.clone(),
+                SOURCE_REFRESH_IPC_TIMEOUT,
+                SOURCE_REFRESH_RESPONSE_MAX_BYTES,
+            )
+        },
+    )?
+    .ok_or_else(|| retained_request_unobservable(request_id, 1))?;
     validate_daemon_refresh_response(&response)?;
-    let accepted_request_id = response_request_id(&response, "daemon source refresh response")?;
-    let request_id = if selected_import {
-        validate_source_refresh_status_response_authority(&response, request_id)?;
-        request_id.to_owned()
-    } else {
-        validate_source_refresh_status_response_authority(&response, &accepted_request_id)?;
-        accepted_request_id
-    };
+    validate_source_refresh_status_response_authority(&response, request_id)?;
     source_refresh_protocol_state(&response)?;
-    Ok(request_id)
+    Ok(request_id.to_owned())
 }
 
 fn wait_authority_request_json(
@@ -865,16 +876,6 @@ fn wait_authority_request_json(
     SourceBackedRefreshRequest::new(mode, request).to_json()
 }
 
-fn response_request_id(response: &Value, label: &str) -> Result<String> {
-    response
-        .get("request_id")
-        .and_then(Value::as_str)
-        .filter(|request_id| !request_id.is_empty())
-        .map(str::to_owned)
-        .ok_or_else(|| anyhow!("{label} has no request ID"))
-}
-
-#[cfg(test)]
 fn source_refresh_protocol_state(response: &Value) -> Result<RefreshRequestState> {
     Ok(source_refresh_protocol_status(response)?.request_state())
 }
@@ -920,10 +921,10 @@ pub(super) fn source_refresh_request_is_unknown(
         && response.get("request_id").and_then(Value::as_str) == Some(expected_request_id)
         && response.get("request_state").and_then(Value::as_str)
             == Some(SOURCE_REFRESH_UNKNOWN_REQUEST_STATE)
-        // `request_not_retained_after_restart` is terminal from the
-        // requester's perspective: the original outcome cannot be observed
-        // and an equivalent enqueue would be new work.  Keep this strict so
-        // a malformed or pre-contract response cannot trigger recovery.
+        && response.get("reason").and_then(Value::as_str)
+            == Some("request_not_retained_after_restart")
+        // The missing outcome itself is not retryable. This exact typed
+        // response authorizes one same-request readmission; text does not.
         && response.get("retryable").and_then(Value::as_bool) == Some(false);
     if exact {
         Ok(true)

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client/response.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client/response.rs
@@ -60,6 +60,59 @@ pub(super) fn daemon_unavailable_fallback(
     Err(SourceBackedRefreshDaemonUnavailable::new(error.map(|error| format!("{error:#}"))).into())
 }
 
+pub(super) fn background_admission_rejected_fallback(
+    data_root: &Path,
+    mode: SourceBackedRefreshMode,
+    intent: &RefreshIntent,
+    retain_peer: bool,
+    response: &Value,
+) -> Result<Option<SourceBackedRefreshObservation>> {
+    // Only an explicit rejection can skip optional refresh. An uncertain
+    // acknowledgement may already own durable work and is not a rejection.
+    let rejected = mode == SourceBackedRefreshMode::Background
+        && *intent == RefreshIntent::AutomaticMaintenance
+        && response.get("ok").and_then(Value::as_bool) == Some(false)
+        && response.get("schema_version").and_then(Value::as_u64) == Some(1)
+        && response.get("owner").and_then(Value::as_str) == Some("daemon")
+        && response.get("status").and_then(Value::as_str) == Some("busy")
+        && response.get("error_code").and_then(Value::as_str) == Some("source_refresh_queue_full")
+        && response.get("reason").and_then(Value::as_str) == Some("queue_full")
+        && response.get("retryable").and_then(Value::as_bool) == Some(true)
+        && response.get("request_id").is_none()
+        && response.get("request_state").is_none()
+        && response.get("admission_durability").is_none()
+        && response.get("admission_acknowledgement").is_none()
+        && response
+            .get("active_pending_requests")
+            .and_then(Value::as_u64)
+            .zip(
+                response
+                    .get("max_active_pending_requests")
+                    .and_then(Value::as_u64),
+            )
+            .is_some_and(|(active, limit)| limit > 0 && active == limit);
+    if !rejected {
+        return Ok(None);
+    }
+    let pin = if retain_peer {
+        pin_published_generation_with_retained_peer(data_root)?
+    } else {
+        pin_published_generation(data_root)?
+    };
+    Ok(pin.map(|pin| SourceBackedRefreshObservation {
+        mode,
+        status: "admission_rejected".to_owned(),
+        request_id: None,
+        daemon_available: true,
+        source_count: 0,
+        request_previous_generation: None,
+        request_generation_changed: false,
+        scanned_routes: None,
+        receipt: None,
+        pin,
+    }))
+}
+
 pub(super) fn validate_daemon_refresh_response(response: &Value) -> Result<()> {
     if response.get("ok").and_then(Value::as_bool) == Some(true) {
         return Ok(());

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client/response.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client/response.rs
@@ -60,6 +60,24 @@ pub(super) fn daemon_unavailable_fallback(
     Err(SourceBackedRefreshDaemonUnavailable::new(error.map(|error| format!("{error:#}"))).into())
 }
 
+// Both rejection and forgotten-result recovery must exclude contradictory
+// retained request authority. Informational extension fields remain allowed.
+pub(super) fn has_retained_request_authority(response: &Value) -> bool {
+    [
+        "admission_durability",
+        "admission_acknowledgement",
+        "receipt",
+        "published_generation",
+        "previous_generation",
+        "generation_changed",
+        "outcome",
+        "structured_outcome",
+        "finished_at_ms",
+    ]
+    .iter()
+    .any(|field| response.get(field).is_some())
+}
+
 pub(super) fn background_admission_rejected_fallback(
     data_root: &Path,
     mode: SourceBackedRefreshMode,
@@ -80,8 +98,7 @@ pub(super) fn background_admission_rejected_fallback(
         && response.get("retryable").and_then(Value::as_bool) == Some(true)
         && response.get("request_id").is_none()
         && response.get("request_state").is_none()
-        && response.get("admission_durability").is_none()
-        && response.get("admission_acknowledgement").is_none()
+        && !has_retained_request_authority(response)
         && response
             .get("active_pending_requests")
             .and_then(Value::as_u64)

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client_transport_recovery_tests.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client_transport_recovery_tests.rs
@@ -617,6 +617,22 @@ fn foreground_unknown_recovery_is_bounded_and_rejects_mismatched_identity() -> R
         Some(("retryable", json!(true))),
         Some(("retryable", Value::Null)),
         Some(("error_code", Value::Null)),
+        Some((
+            "admission_durability",
+            json!("replacement_visible_or_indeterminate"),
+        )),
+        Some((
+            "admission_acknowledgement",
+            json!("retained_after_durability_error"),
+        )),
+        Some(("receipt", json!({}))),
+        Some(("receipt", Value::Null)),
+        Some(("published_generation", json!("generation"))),
+        Some(("previous_generation", json!("previous"))),
+        Some(("generation_changed", json!(false))),
+        Some(("outcome", json!("published"))),
+        Some(("structured_outcome", json!({}))),
+        Some(("finished_at_ms", json!(123))),
     ] {
         let malformed = mutation.is_some();
         let data_root = short_data_root()?;
@@ -630,7 +646,8 @@ fn foreground_unknown_recovery_is_bounded_and_rejects_mismatched_identity() -> R
                     let mut response = json!({"ok":false,"owner":"daemon","request_id":id,
                         "request_state":"request_unknown","error_code":"source_refresh_request_unknown",
                         "reason":"request_not_retained_after_restart","retryable":false,"schema_version":1,
-                        "error":"arbitrary human text cannot authorize recovery"});
+                        "error":"arbitrary human text cannot authorize recovery",
+                        "diagnostic_extension":"informational"});
                     if let Some((field, value)) = &mutation {
                         response[*field] = value.clone();
                     }
@@ -885,6 +902,14 @@ fn optional_background_rejects_malformed_or_indeterminate_admission_denials() ->
         ("active_pending_requests", json!(7)),
         ("max_active_pending_requests", Value::Null),
         ("error_code", json!("source_refresh_admission_unconfirmed")),
+        ("receipt", json!({})),
+        ("receipt", Value::Null),
+        ("published_generation", json!("generation")),
+        ("previous_generation", json!("previous")),
+        ("generation_changed", json!(false)),
+        ("outcome", json!("published")),
+        ("structured_outcome", json!({})),
+        ("finished_at_ms", json!(123)),
     ] {
         let mut response = queue_full_response_for_test();
         response[field] = value;
@@ -900,6 +925,16 @@ fn optional_background_rejects_malformed_or_indeterminate_admission_denials() ->
             "{field}: {response}"
         );
     }
+    let mut extended = queue_full_response_for_test();
+    extended["diagnostic_extension"] = json!("informational");
+    assert!(background_admission_rejected_fallback(
+        data_root.path(),
+        SourceBackedRefreshMode::Background,
+        &RefreshIntent::AutomaticMaintenance,
+        false,
+        &extended,
+    )?
+    .is_some());
     assert!(background_admission_rejected_fallback(
         data_root.path(),
         SourceBackedRefreshMode::Background,

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client_transport_recovery_tests.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/client_transport_recovery_tests.rs
@@ -50,7 +50,7 @@ fn source_refresh_endpoint(socket_path: &Path) -> DaemonQueryEndpoint {
 }
 
 #[test]
-fn background_maintenance_wake_is_accepted_through_client_and_coordinator() -> Result<()> {
+fn background_durable_request_is_accepted_through_client_and_coordinator() -> Result<()> {
     let data_root = short_data_root()?;
     ctx_history_platform::platform_security::establish_private_data_root(data_root.path())?;
     let generation = super::publish_authoritative_empty_generation_for_test(
@@ -89,11 +89,18 @@ fn background_maintenance_wake_is_accepted_through_client_and_coordinator() -> R
     )?;
 
     assert_eq!(observation.mode, SourceBackedRefreshMode::Background);
-    assert_eq!(observation.status, "queued");
+    assert_eq!(observation.status, "admission_pending");
     assert!(observation.daemon_available);
     assert!(observation.request_id.is_some());
     assert_eq!(observation.pin.generation_id(), generation);
-    assert!(!coordinator.has_pending_request());
+    assert!(coordinator.has_pending_request());
+    let request_id = observation.request_id.as_deref().context("background ID")?;
+    assert!(coordinator.status(request_id).is_some());
+    let durable = crate::paths_status::read_daemon_job_status(
+        &crate::paths_status::daemon_source_backed_refresh_job_path(data_root.path()),
+    )
+    .context("background durable admission")?;
+    assert_eq!(durable["request_id"], request_id);
     drop(service);
     Ok(())
 }
@@ -162,6 +169,7 @@ fn same_id_reenqueue_replays_the_exact_payload_after_a_lost_ack() -> Result<()> 
     });
 
     let recovered = enqueue_equivalent_wait_refresh_request(
+        &crate::test_support::AVAILABILITY,
         data_root.path(),
         request_id,
         RefreshIntent::SelectedImport(RefreshSelection::Provider(CaptureProvider::Codex)),
@@ -372,6 +380,7 @@ fn exhausted_post_submission_disconnects_return_typed_ambiguous_admission() -> R
     });
 
     let error = enqueue_equivalent_wait_refresh_request(
+        &crate::test_support::AVAILABILITY,
         data_root.path(),
         request_id,
         RefreshIntent::AutomaticMaintenance,
@@ -397,158 +406,510 @@ fn exhausted_post_submission_disconnects_return_typed_ambiguous_admission() -> R
     Ok(())
 }
 
-#[test]
-fn acknowledged_typed_unknown_does_not_reenqueue_equivalent_work() -> Result<()> {
-    let data_root = short_data_root()?;
-    let socket_path = data_root.path().join("acknowledged-typed-unknown.sock");
+// Real client transport with a controlled daemon-side state transition. The
+// listener records the independently constructed request and actual wire response.
+fn foreground_transport_fixture<T>(
+    data_root: &Path,
+    mut respond: impl FnMut(&Value) -> Result<Value> + Send + 'static,
+    client: impl FnOnce() -> T,
+) -> Result<(T, Vec<(Value, Value)>)> {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    let socket_path = data_root.join("identity.sock");
     let listener = UnixListener::bind(&socket_path)?;
+    listener.set_nonblocking(true)?;
     write_daemon_service_endpoint(
-        data_root.path(),
+        data_root,
         DaemonIpcService::SourceRefresh,
         &source_refresh_endpoint(&socket_path),
     )?;
-    let request_id = "019fcaaa-0000-7000-8000-000000000307";
-    let server = std::thread::spawn(move || -> Result<Vec<u8>> {
-        let (mut stream, _) = listener.accept()?;
-        let mut request = Vec::new();
-        stream.read_to_end(&mut request)?;
-        stream.write_all(
-            format!(
-                "{{\"ok\":false,\"owner\":\"daemon\",\"request_id\":\"{request_id}\",\"request_state\":\"request_unknown\",\"error_code\":\"source_refresh_request_unknown\",\"reason\":\"request_not_retained_after_restart\",\"retryable\":false,\"schema_version\":1}}\n"
-            )
-            .as_bytes(),
-        )?;
-        Ok(request)
+    let finished = Arc::new(AtomicBool::new(false));
+    let stop = finished.clone();
+    let server = std::thread::spawn(move || -> Result<Vec<(Value, Value)>> {
+        let deadline = StdInstant::now() + StdDuration::from_secs(30);
+        let mut exchanges = Vec::new();
+        while !stop.load(Ordering::Acquire) {
+            let (mut stream, _) = match listener.accept() {
+                Ok(connection) => connection,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if StdInstant::now() >= deadline {
+                        bail!("identity fixture exceeded its bounded wait");
+                    }
+                    std::thread::sleep(StdDuration::from_millis(1));
+                    continue;
+                }
+                Err(error) => return Err(error.into()),
+            };
+            stream.set_read_timeout(Some(StdDuration::from_secs(2)))?;
+            stream.set_write_timeout(Some(StdDuration::from_secs(2)))?;
+            let mut bytes = Vec::new();
+            stream.read_to_end(&mut bytes)?;
+            let request: Value = serde_json::from_slice(&bytes)?;
+            let response = respond(&request).map_err(|error| {
+                eprintln!(
+                    "foreground fixture server failed for {}: {error:#}",
+                    request["op"]
+                );
+                error
+            })?;
+            serde_json::to_writer(&mut stream, &response)?;
+            stream.write_all(b"\n")?;
+            exchanges.push((request, response));
+        }
+        Ok(exchanges)
     });
-
-    let error = match wait_for_published_generation(
-        data_root.path(),
-        request_id.to_owned(),
-        SourceBackedRefreshMode::Wait,
-        ctx_history_refresh::RefreshOperation::Refresh,
-        None,
-        false,
-    ) {
-        Ok(_) => panic!("typed unknown after acknowledgement must not publish or reenqueue"),
-        Err(error) => error,
-    };
-    let request = server.join().expect("typed-unknown test server panicked")?;
-
-    let typed = error
-        .downcast_ref::<SourceRefreshObservationRecoveryFailed>()
-        .expect("post-ack typed unknown must remain request-bound and unobservable");
-    assert_eq!(typed.request_id, request_id);
-    assert_eq!(typed.recovery_attempts, 0);
-    assert_eq!(typed.disconnect_policy, DISCONNECT_POLICY);
-
-    let request: Value = serde_json::from_slice(&request)?;
-    assert_eq!(request["op"], SOURCE_REFRESH_STATUS_OP);
-    assert_eq!(request["request_id"], request_id);
-    Ok(())
+    let result = client();
+    finished.store(true, Ordering::Release);
+    Ok((
+        result,
+        server.join().expect("identity fixture server panicked")?,
+    ))
 }
 
 #[test]
-fn autostarted_wait_acknowledgement_then_restart_unknown_is_not_replayed() -> Result<()> {
+fn foreground_client_ids_survive_admission_and_status_beside_periodic_work() -> Result<()> {
     let data_root = short_data_root()?;
-    let socket_path = data_root.path().join("acknowledged-restart-unknown.sock");
-    let listener = UnixListener::bind(&socket_path)?;
-    write_daemon_service_endpoint(
+    ctx_history_platform::platform_security::establish_private_data_root(data_root.path())?;
+    let engine = Arc::new(CoreRefreshEngine::new());
+    let periodic = engine.enqueue_periodic(data_root.path())?;
+    let server_engine = engine.clone();
+    let server_root = data_root.path().to_owned();
+    let (errors, exchanges) = foreground_transport_fixture(
         data_root.path(),
-        DaemonIpcService::SourceRefresh,
-        &source_refresh_endpoint(&socket_path),
-    )?;
-    let server = std::thread::spawn(move || -> Result<[Value; 2]> {
-        let mut requests = Vec::with_capacity(2);
-        for attempt in 0..2 {
-            let (mut stream, _) = listener.accept()?;
-            let mut request = Vec::new();
-            stream.read_to_end(&mut request)?;
-            let request: Value = serde_json::from_slice(&request)?;
-            let request_id = request["request_id"]
-                .as_str()
-                .context("source refresh request had no request ID")?;
-            if attempt == 0 {
-                stream.write_all(
-                    format!(
-                        "{{\"ok\":true,\"owner\":\"daemon\",\"request_id\":\"{request_id}\",\"request_state\":\"admission_pending\",\"schema_version\":1}}\n"
-                    )
-                    .as_bytes(),
-                )?;
-            } else {
-                stream.write_all(
-                    format!(
-                        "{{\"ok\":false,\"owner\":\"daemon\",\"request_id\":\"{request_id}\",\"request_state\":\"request_unknown\",\"error_code\":\"source_refresh_request_unknown\",\"reason\":\"request_not_retained_after_restart\",\"retryable\":false,\"error\":\"source refresh request outcome is no longer observable after daemon restart\",\"schema_version\":1}}\n"
-                    )
-                    .as_bytes(),
-                )?;
-            }
-            requests.push(request);
-        }
-        requests
-            .try_into()
-            .map_err(|_| anyhow!("test server did not observe exactly two requests"))
-    });
-    let availability = RecordingAvailability::default();
-
-    let error = match coordinate_source_backed_refresh_with_policy(
-        &availability,
-        data_root.path(),
-        SourceBackedRefreshMode::Wait,
-        SourceBackedRefreshRequestPolicy {
-            intent: RefreshIntent::AutomaticMaintenance,
-            trigger: RefreshRequestTrigger::Search,
-            allow_daemon_autostart: true,
+        move |request| {
+            server_engine
+                .handle_ipc_request(&server_root, request)?
+                .context("wire response")
         },
-        false,
-        None,
-    ) {
-        Ok(_) => {
-            panic!("an acknowledged request that is not retained after restart is unobservable")
-        }
-        Err(error) => error,
-    };
-    let [admission, status] = server
-        .join()
-        .expect("restart-unknown test server panicked")?;
+        || {
+            (0..2)
+                .map(|_| {
+                    coordinate_source_backed_refresh_with_progress(
+                        &RecordingAvailability::default(),
+                        data_root.path(),
+                        SourceBackedRefreshMode::Wait,
+                        &mut |_| bail!("stop after observing admitted status"),
+                    )
+                    .err()
+                    .expect("reporter ends the wait after real admission and status")
+                })
+                .collect::<Vec<_>>()
+        },
+    )?;
+    for error in errors {
+        assert!(format!("{error:#}").contains("stop after observing admitted status"));
+    }
+    assert_eq!(exchanges.len(), 4);
+    let mut ids = BTreeSet::new();
+    for pair in exchanges.chunks_exact(2) {
+        let (admission, accepted) = &pair[0];
+        let (status_request, status) = &pair[1];
+        assert_eq!(admission["op"], SOURCE_REFRESH_REQUEST_OP);
+        assert_eq!(admission["mode"], "wait");
+        assert_eq!(admission["trigger"], "search");
+        assert_eq!(admission["refresh_intent"]["kind"], "automatic_maintenance");
+        let id = admission["request_id"].as_str().context("client UUID")?;
+        Uuid::parse_str(id)?;
+        assert!(ids.insert(id.to_owned()));
+        assert_ne!(admission["request_id"], periodic["request_id"]);
+        assert_eq!(accepted["request_id"], admission["request_id"]);
+        assert_eq!(status_request["op"], SOURCE_REFRESH_STATUS_OP);
+        assert_eq!(status_request["request_id"], admission["request_id"]);
+        assert_eq!(status["request_id"], admission["request_id"]);
+        assert!(engine.status(id).is_some());
+    }
+    Ok(())
+}
 
-    let unknown = error
-        .downcast_ref::<SourceRefreshObservationRecoveryFailed>()
-        .expect("post-ack restart unknown remains request-bound and unobservable");
-    assert_eq!(unknown.recovery_attempts, 0);
-    assert_eq!(unknown.disconnect_policy, DISCONNECT_POLICY);
-    let wording = unknown.to_string();
-    assert!(
-        wording.contains("is no longer observable"),
-        "unexpected observation-recovery wording: {wording}"
-    );
-    assert!(
-        wording.contains("outcome is unknown"),
-        "unexpected observation-recovery wording: {wording}"
-    );
-
-    assert_eq!(admission["op"], SOURCE_REFRESH_REQUEST_OP);
-    assert_eq!(status["op"], SOURCE_REFRESH_STATUS_OP);
-    let request_id = admission["request_id"]
-        .as_str()
-        .expect("admission response has a request ID");
-    assert_eq!(status["request_id"].as_str(), Some(request_id));
-    assert_eq!(unknown.request_id, request_id);
-    assert!(Uuid::parse_str(request_id).is_ok());
-    assert_eq!(admission["mode"], "wait");
-    assert_eq!(admission["trigger"], "search");
+#[test]
+fn foreground_forgotten_request_replays_exact_authority_and_pins_terminal_generation() -> Result<()>
+{
+    let data_root = short_data_root()?;
+    ctx_history_platform::platform_security::establish_private_data_root(data_root.path())?;
+    let source = tempfile::tempdir()?;
+    let source_path = source.path().join("source.jsonl");
+    std::fs::write(
+        &source_path,
+        "{\"record_type\":\"manifest\",\"schema_version\":\"ctx-history-jsonl-v2\"}\n",
+    )?;
+    let source =
+        ctx_history_refresh::explicit_source_for_path(data_root.path(), &source_path, None, true)?;
+    let authority =
+        ctx_history_refresh::upsert_explicit_source(data_root.path(), &source)?.authority;
+    let server_root = data_root.path().to_owned();
+    let mut engine = CoreRefreshEngine::new();
+    let mut step = 0;
+    let availability = RecordingAvailability::default();
+    let (observation, exchanges) = foreground_transport_fixture(
+        data_root.path(),
+        move |request| {
+            step += 1;
+            if step == 2 {
+                // Inject the supported forgotten-state boundary. Ordinary
+                // restart normally restores the journal; this deliberately
+                // tests the response when this ID is no longer retained.
+                engine = CoreRefreshEngine::new();
+            }
+            if step == 4 {
+                assert!(engine.prepare_next_pending_admission(&server_root)?);
+                let run = engine
+                    .run_next(&server_root)
+                    .context("readmitted refresh run")?;
+                assert!(!run.failed, "{:#}", run.job);
+            }
+            engine
+                .handle_ipc_request(&server_root, request)?
+                .context("wire response")
+        },
+        || {
+            coordinate_source_backed_refresh_with_policy(
+                &availability,
+                data_root.path(),
+                SourceBackedRefreshMode::Wait,
+                SourceBackedRefreshRequestPolicy::import(
+                    RefreshSelection::ExactSource(authority.clone()),
+                    false,
+                ),
+                false,
+                None,
+            )
+        },
+    )?;
+    let observation = observation?;
+    assert_eq!(exchanges.len(), 4);
+    assert_eq!(exchanges[0].0, exchanges[2].0);
+    assert_eq!(exchanges[1].0, exchanges[3].0);
     assert_eq!(
-        admission["refresh_intent"],
-        json!({"kind": "automatic_maintenance"})
+        exchanges[1].1["error_code"],
+        SOURCE_REFRESH_UNKNOWN_REQUEST_ERROR_CODE
+    );
+    assert_eq!(exchanges[3].1["request_state"], "published");
+    assert_eq!(
+        observation.request_id.as_deref(),
+        exchanges[0].0["request_id"].as_str()
     );
     assert_eq!(
-        *availability
-            .0
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner),
-        [(
-            crate::DaemonTrigger::Search,
-            crate::DaemonAvailabilityDemand::ExplicitWait,
-        )]
+        observation.pin.generation_id(),
+        exchanges[3].1["published_generation"].as_str().unwrap()
+    );
+    let receipt = observation.receipt.context("terminal receipt")?;
+    assert_eq!(
+        receipt.published_generation,
+        observation.pin.generation_id()
+    );
+    assert_eq!(receipt.published_explicit_source_catalog, Some(authority));
+    assert!(
+        availability.0.lock().unwrap().is_empty(),
+        "healthy no-start recovery must not start a worker"
     );
     Ok(())
 }
+
+#[test]
+fn foreground_unknown_recovery_is_bounded_and_rejects_mismatched_identity() -> Result<()> {
+    for mutation in [
+        None,
+        Some(("request_id", json!("different-request"))),
+        Some(("owner", json!("different-owner"))),
+        Some(("schema_version", json!(2))),
+        Some(("ok", json!(true))),
+        Some(("request_state", json!("failed"))),
+        Some(("reason", json!("unrecognized-reason"))),
+        Some(("retryable", json!(true))),
+        Some(("retryable", Value::Null)),
+        Some(("error_code", Value::Null)),
+    ] {
+        let malformed = mutation.is_some();
+        let data_root = short_data_root()?;
+        let (error, exchanges) = foreground_transport_fixture(
+            data_root.path(),
+            move |request| {
+                let id = request["request_id"].as_str().context("client ID")?;
+                Ok(if request["op"] == SOURCE_REFRESH_REQUEST_OP {
+                    json!({"ok":true,"owner":"daemon","request_id":id,"request_state":"admission_pending","schema_version":1})
+                } else {
+                    let mut response = json!({"ok":false,"owner":"daemon","request_id":id,
+                        "request_state":"request_unknown","error_code":"source_refresh_request_unknown",
+                        "reason":"request_not_retained_after_restart","retryable":false,"schema_version":1,
+                        "error":"arbitrary human text cannot authorize recovery"});
+                    if let Some((field, value)) = &mutation {
+                        response[*field] = value.clone();
+                    }
+                    response
+                })
+            },
+            || {
+                coordinate_source_backed_refresh(
+                    &RecordingAvailability::default(),
+                    data_root.path(),
+                    SourceBackedRefreshMode::Wait,
+                )
+                .err()
+                .expect("unobservable or mismatched request must fail")
+            },
+        )?;
+        assert_eq!(exchanges.len(), if malformed { 2 } else { 4 });
+        if !malformed {
+            assert_eq!(exchanges[0].0, exchanges[2].0);
+            let typed = error
+                .downcast_ref::<SourceRefreshObservationRecoveryFailed>()
+                .expect("bounded unknown recovery");
+            assert_eq!(
+                typed.request_id,
+                exchanges[0].0["request_id"].as_str().unwrap()
+            );
+            assert_eq!(typed.recovery_attempts, 1);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn manual_background_reads_published_generation_without_ipc_admission() -> Result<()> {
+    struct ManualAvailability;
+    impl crate::DaemonAvailabilityPort for ManualAvailability {
+        fn ensure_available(
+            &self,
+            _data_root: &Path,
+            trigger: crate::DaemonTrigger,
+            demand: crate::DaemonAvailabilityDemand,
+        ) -> Result<crate::DaemonAvailability> {
+            assert_eq!(trigger, crate::DaemonTrigger::Search);
+            assert_eq!(demand, crate::DaemonAvailabilityDemand::Background);
+            Ok(crate::DaemonAvailability::Disabled)
+        }
+    }
+    let data_root = short_data_root()?;
+    ctx_history_platform::platform_security::establish_private_data_root(data_root.path())?;
+    let generation = super::publish_authoritative_empty_generation_for_test(
+        &source_backed_index_root(data_root.path()),
+        "manual-background-fixture",
+        ctx_history_refresh::RefreshOperation::Refresh,
+        ctx_history_capture::SourceBackedRefreshScope::All,
+        None,
+    )?
+    .generation_id;
+    let (observation, exchanges) = foreground_transport_fixture(
+        data_root.path(),
+        |_| bail!("manual background must not contact the endpoint"),
+        || {
+            coordinate_source_backed_refresh(
+                &ManualAvailability,
+                data_root.path(),
+                SourceBackedRefreshMode::Background,
+            )
+        },
+    )?;
+    let observation = observation?;
+    assert!(exchanges.is_empty());
+    assert!(observation.request_id.is_none());
+    assert!(!observation.daemon_available);
+    assert_eq!(observation.pin.generation_id(), generation);
+    assert!(!crate::paths_status::daemon_source_backed_refresh_job_path(data_root.path()).exists());
+    Ok(())
+}
+
+#[test]
+fn optional_background_queue_full_reads_pin_without_acceptance() -> Result<()> {
+    for retain_peer in [false, true] {
+        let data_root = short_data_root()?;
+        ctx_history_platform::platform_security::establish_private_data_root(data_root.path())?;
+        let generation = super::publish_authoritative_empty_generation_for_test(
+            &source_backed_index_root(data_root.path()),
+            "background-overload-fixture",
+            ctx_history_refresh::RefreshOperation::Refresh,
+            ctx_history_capture::SourceBackedRefreshScope::All,
+            None,
+        )?
+        .generation_id;
+        let engine = Arc::new(CoreRefreshEngine::new());
+        for index in 0..8 {
+            let response = engine
+                .handle_ipc_request(
+                    data_root.path(),
+                    &json!({
+                        "op": SOURCE_REFRESH_REQUEST_OP, "mode": "background", "trigger": "search",
+                        "request_id": format!("019fcaaa-0000-7000-8000-{index:012}"),
+                        "refresh_intent": {"kind": "automatic_maintenance"},
+                    }),
+                )?
+                .context("background admission")?;
+            assert_eq!(response["ok"], true);
+        }
+        let job_path = crate::paths_status::daemon_source_backed_refresh_job_path(data_root.path());
+        let before = std::fs::read(&job_path)?;
+        let server_engine = Arc::clone(&engine);
+        let server_root = data_root.path().to_owned();
+        let availability = RecordingAvailability::default();
+        let (outcome, exchanges) = foreground_transport_fixture(
+            data_root.path(),
+            move |request| {
+                server_engine
+                    .handle_ipc_request(&server_root, request)?
+                    .context("wire response")
+            },
+            || {
+                coordinate_source_backed_refresh_with_policy(
+                    &availability,
+                    data_root.path(),
+                    SourceBackedRefreshMode::Background,
+                    SourceBackedRefreshRequestPolicy::refresh(RefreshRequestTrigger::Search),
+                    retain_peer,
+                    None,
+                )
+            },
+        )?;
+        let outcome = outcome?;
+        assert_eq!(
+            exchanges.len(),
+            1,
+            "rejected optional work does not retry or poll"
+        );
+        assert_eq!(exchanges[0].1["error_code"], "source_refresh_queue_full");
+        assert!(engine
+            .status(exchanges[0].0["request_id"].as_str().unwrap())
+            .is_none());
+        assert_eq!(outcome.status, "admission_rejected");
+        assert_eq!(outcome.mode, SourceBackedRefreshMode::Background);
+        assert!(outcome.daemon_available);
+        assert!(outcome.request_id.is_none());
+        assert!(outcome.receipt.is_none());
+        assert!(outcome.scanned_routes.is_none());
+        assert!(!outcome.request_generation_changed);
+        assert_eq!(outcome.pin.generation_id(), generation);
+        assert_eq!(std::fs::read(&job_path)?, before);
+        assert_eq!(availability.0.lock().unwrap().len(), 1);
+    }
+    Ok(())
+}
+
+fn queue_full_response_for_test() -> Value {
+    json!({
+        "ok": false, "schema_version": 1, "owner": "daemon", "status": "busy",
+        "error_code": "source_refresh_queue_full", "reason": "queue_full", "retryable": true,
+        "active_pending_requests": 8, "max_active_pending_requests": 8,
+        "error": "source refresh queue is full",
+    })
+}
+
+#[test]
+fn optional_background_does_not_hide_cold_or_wait_import_overload() -> Result<()> {
+    for (warm, mode, intent, trigger) in [
+        (
+            false,
+            SourceBackedRefreshMode::Background,
+            RefreshIntent::AutomaticMaintenance,
+            RefreshRequestTrigger::Search,
+        ),
+        (
+            true,
+            SourceBackedRefreshMode::Wait,
+            RefreshIntent::AutomaticMaintenance,
+            RefreshRequestTrigger::Search,
+        ),
+        (
+            true,
+            SourceBackedRefreshMode::Wait,
+            RefreshIntent::SelectedImport(RefreshSelection::All),
+            RefreshRequestTrigger::Import,
+        ),
+    ] {
+        let data_root = short_data_root()?;
+        ctx_history_platform::platform_security::establish_private_data_root(data_root.path())?;
+        if warm {
+            super::publish_authoritative_empty_generation_for_test(
+                &source_backed_index_root(data_root.path()),
+                "overload-control-fixture",
+                ctx_history_refresh::RefreshOperation::Refresh,
+                ctx_history_capture::SourceBackedRefreshScope::All,
+                None,
+            )?;
+        }
+        let (outcome, exchanges) = foreground_transport_fixture(
+            data_root.path(),
+            |_| Ok(queue_full_response_for_test()),
+            || {
+                coordinate_source_backed_refresh_with_policy(
+                    &RecordingAvailability::default(),
+                    data_root.path(),
+                    mode,
+                    SourceBackedRefreshRequestPolicy {
+                        intent,
+                        trigger,
+                        allow_daemon_autostart: false,
+                    },
+                    false,
+                    None,
+                )
+            },
+        )?;
+        let error = outcome.err().context("overload must remain an error")?;
+        assert!(error.to_string().contains("source refresh queue is full"));
+        assert!(error
+            .downcast_ref::<SourceBackedRefreshPendingPublication>()
+            .is_none());
+        assert_eq!(exchanges.len(), 1);
+        assert_eq!(exchanges[0].1["error_code"], "source_refresh_queue_full");
+    }
+    Ok(())
+}
+
+#[test]
+fn optional_background_rejects_malformed_or_indeterminate_admission_denials() -> Result<()> {
+    let data_root = short_data_root()?;
+    ctx_history_platform::platform_security::establish_private_data_root(data_root.path())?;
+    super::publish_authoritative_empty_generation_for_test(
+        &source_backed_index_root(data_root.path()),
+        "malformed-overload-fixture",
+        ctx_history_refresh::RefreshOperation::Refresh,
+        ctx_history_capture::SourceBackedRefreshScope::All,
+        None,
+    )?;
+    for (field, value) in [
+        ("owner", json!("other")),
+        ("schema_version", json!(2)),
+        ("ok", json!(true)),
+        ("status", json!("queued")),
+        ("error_code", Value::Null),
+        ("reason", json!("unknown")),
+        ("retryable", json!(false)),
+        ("request_id", json!("different-request")),
+        ("request_state", json!("admission_pending")),
+        (
+            "admission_durability",
+            json!("replacement_visible_or_indeterminate"),
+        ),
+        (
+            "admission_acknowledgement",
+            json!("retained_after_durability_error"),
+        ),
+        ("active_pending_requests", json!(7)),
+        ("max_active_pending_requests", Value::Null),
+        ("error_code", json!("source_refresh_admission_unconfirmed")),
+    ] {
+        let mut response = queue_full_response_for_test();
+        response[field] = value;
+        assert!(
+            background_admission_rejected_fallback(
+                data_root.path(),
+                SourceBackedRefreshMode::Background,
+                &RefreshIntent::AutomaticMaintenance,
+                false,
+                &response,
+            )?
+            .is_none(),
+            "{field}: {response}"
+        );
+    }
+    assert!(background_admission_rejected_fallback(
+        data_root.path(),
+        SourceBackedRefreshMode::Background,
+        &RefreshIntent::SelectedImport(RefreshSelection::All),
+        false,
+        &queue_full_response_for_test(),
+    )?
+    .is_none());
+    Ok(())
+}
+
+#[path = "discovered_batch_tests.rs"]
+mod discovered_batch_tests;

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/discovered_batch_tests.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/discovered_batch_tests.rs
@@ -1,0 +1,482 @@
+use super::*;
+use ctx_history_refresh::{DurableAdmissionPersistence, RefreshJournal, RefreshRuntime};
+
+#[derive(Default)]
+struct AdmissionJournal {
+    writes: Mutex<Vec<Value>>,
+}
+impl RefreshJournal for AdmissionJournal {
+    fn load(&self, root: &Path) -> Result<Option<Value>> {
+        DaemonRefreshJournal.load(root)
+    }
+    fn store(&self, root: &Path, value: &Value) -> Result<()> {
+        DaemonRefreshJournal.store(root, value)
+    }
+    fn store_before_ack(&self, root: &Path, value: &Value) -> DurableAdmissionPersistence {
+        let outcome = DaemonRefreshJournal.store_before_ack(root, value);
+        self.writes.lock().unwrap().push(value.clone());
+        outcome
+    }
+}
+
+struct DiscoveredRuntime {
+    discovery: ctx_history_capture::DiscoveryContext,
+    after_capture: Mutex<Option<Box<dyn FnOnce() + Send>>>,
+    captures: std::sync::atomic::AtomicUsize,
+}
+impl RefreshRuntime for DiscoveredRuntime {
+    fn metadata(
+        &self,
+        data_root: &Path,
+        operation: ctx_history_refresh::RefreshOperation,
+    ) -> ctx_history_refresh::RefreshRuntimeMetadata {
+        DaemonRefreshRuntime::new(&crate::test_support::CONFIG).metadata(data_root, operation)
+    }
+    fn discovery_context(&self, _: &Path) -> Result<ctx_history_capture::DiscoveryContext> {
+        Ok(self.discovery.clone())
+    }
+    fn refresh_execution_finished(&self) {
+        self.captures
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if let Some(hook) = self.after_capture.lock().unwrap().take() {
+            hook();
+        }
+    }
+}
+
+struct DiscoveredFixture {
+    data_root: tempfile::TempDir,
+    _providers: tempfile::TempDir,
+    source_path: std::path::PathBuf,
+    fixture_routes: BTreeSet<ctx_history_index::SourceRouteIdentity>,
+    input_bytes: u64,
+    runtime: Arc<DiscoveredRuntime>,
+    journal: Arc<AdmissionJournal>,
+    engine: Arc<CoreRefreshEngine>,
+    generation: String,
+}
+impl DiscoveredFixture {
+    fn new() -> Result<Self> {
+        let data_root = short_data_root()?;
+        ctx_history_platform::platform_security::establish_private_data_root(data_root.path())?;
+        let providers = tempfile::tempdir()?;
+        let home = providers.path().join("home");
+        let cwd = providers.path().join("cwd");
+        let codex_home = home.join(".codex");
+        std::fs::create_dir_all(codex_home.join("sessions"))?;
+        std::fs::create_dir_all(&cwd)?;
+        let discovery = ctx_history_capture::DiscoveryContext::new(
+            &home,
+            &cwd,
+            ctx_history_capture::DiscoveryPlatform::Linux,
+            ctx_history_capture::DiscoveryPlatformDirs::default(),
+        )
+        .with_env("CODEX_HOME", codex_home.as_os_str());
+        let source_path =
+            codex_home.join("sessions/rollout-019f1111-1111-7111-8111-111111111111.jsonl");
+        // Synthetic Core input: this exercises discovery and refresh, not a
+        // provider harness's native output or conformance.
+        let mut input = format!(
+            "{}\n",
+            json!({"timestamp":"2026-07-30T12:00:00Z","type":"session_meta",
+            "payload":{"id":"019f1111-1111-7111-8111-111111111111","timestamp":"2026-07-30T12:00:00Z",
+                "cwd":"/fixed-refresh-workspace","originator":"codex_cli_rs","cli_version":"0.20.0",
+                "source":"cli","model_provider":"openai"}})
+        );
+        for index in 0..128 {
+            input.push_str(&format!(
+                "{}\n",
+                json!({"timestamp":"2026-07-30T12:00:01Z","type":"response_item",
+                "payload":{"type":"message","role":"user","content":[{"type":"input_text",
+                    "text":format!("message {index}: {}", "bounded refresh work ".repeat(200))}]}})
+            ));
+        }
+        std::fs::write(&source_path, &input)?;
+        let catalog =
+            ctx_history_refresh::source_backed_watch_catalog(data_root.path(), &discovery)?;
+        let fixture_routes = catalog.routes_overlapping_path(&source_path);
+        assert!(
+            !fixture_routes.is_empty(),
+            "source must belong to automatic catalog"
+        );
+        let runtime = Arc::new(DiscoveredRuntime {
+            discovery,
+            after_capture: Mutex::new(None),
+            captures: Default::default(),
+        });
+        let journal = Arc::new(AdmissionJournal::default());
+        let engine = Arc::new(CoreRefreshEngine(ctx_history_refresh::RefreshEngine::new(
+            journal.clone(),
+            runtime.clone(),
+        )));
+        engine.install_watch_catalog(catalog);
+        let accepted = engine
+            .handle_ipc_request(
+                data_root.path(),
+                &json!({
+                    "op":SOURCE_REFRESH_REQUEST_OP,"mode":"wait","trigger":"search",
+                    "refresh_intent":{"kind":"automatic_maintenance"}
+                }),
+            )?
+            .context("warm admission")?;
+        assert_eq!(accepted["ok"], true);
+        let warm = engine
+            .run_next(data_root.path())
+            .context("warm publication")?;
+        assert!(!warm.failed, "{:#}", warm.job);
+        let generation = warm.job["published_generation"]
+            .as_str()
+            .context("warm generation")?
+            .to_owned();
+        let fixture = Self {
+            data_root,
+            _providers: providers,
+            source_path,
+            fixture_routes,
+            input_bytes: input.len() as u64,
+            runtime,
+            journal,
+            engine,
+            generation,
+        };
+        fixture.assert_capture(&warm.job, 128)?;
+        fixture
+            .runtime
+            .captures
+            .store(0, std::sync::atomic::Ordering::SeqCst);
+        fixture.journal.writes.lock().unwrap().clear();
+        Ok(fixture)
+    }
+    fn assert_capture(&self, job: &Value, documents: u64) -> Result<()> {
+        for route in &self.fixture_routes {
+            assert!(
+                job["receipt"]["route_results"]
+                    .get(route.as_str())
+                    .is_some(),
+                "fixture route omitted"
+            );
+        }
+        assert_eq!(
+            job["receipt"]["current"]["current_indexed_documents"],
+            documents
+        );
+        assert_eq!(
+            job["progress"]["processed_bytes"],
+            std::fs::metadata(&self.source_path)?.len()
+        );
+        Ok(())
+    }
+    fn captures(&self) -> usize {
+        self.runtime
+            .captures
+            .load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+fn assert_burst(background: bool) -> Result<()> {
+    let fixture = DiscoveredFixture::new()?;
+    let callers = if background { 16 } else { 8 };
+    let mode = if background {
+        SourceBackedRefreshMode::Background
+    } else {
+        SourceBackedRefreshMode::Wait
+    };
+    let engine = fixture.engine.clone();
+    let root = fixture.data_root.path().to_owned();
+    let runs = Arc::new(Mutex::new(Vec::new()));
+    let server_runs = runs.clone();
+    let mut admitted = 0;
+    let (observations, exchanges) = foreground_transport_fixture(
+        fixture.data_root.path(),
+        move |request| {
+            if request["op"] == SOURCE_REFRESH_REQUEST_OP {
+                admitted += 1;
+            } else if !background && admitted == callers && engine.has_pending_request() {
+                let run = engine.run_next(&root).context("burst publication")?;
+                assert!(!run.failed, "{:#}", run.job);
+                server_runs.lock().unwrap().push(run.job);
+            }
+            engine
+                .handle_ipc_request(&root, request)?
+                .context("burst response")
+        },
+        || {
+            if background {
+                (0..callers)
+                    .map(|_| {
+                        coordinate_source_backed_refresh(
+                            &RecordingAvailability::default(),
+                            fixture.data_root.path(),
+                            mode,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                std::thread::scope(|scope| {
+                    let clients = (0..callers)
+                        .map(|_| {
+                            scope.spawn(|| {
+                                coordinate_source_backed_refresh(
+                                    &RecordingAvailability::default(),
+                                    fixture.data_root.path(),
+                                    mode,
+                                )
+                            })
+                        })
+                        .collect::<Vec<_>>();
+                    clients
+                        .into_iter()
+                        .map(|client| client.join().unwrap())
+                        .collect()
+                })
+            }
+        },
+    )?;
+    let mut accepted = BTreeSet::new();
+    let mut rejected = 0;
+    for observation in observations {
+        let observation = observation?;
+        assert_eq!(observation.pin.generation_id(), fixture.generation);
+        assert!(observation.daemon_available);
+        if observation.status == "admission_rejected" {
+            assert!(observation.request_id.is_none() && observation.receipt.is_none());
+            rejected += 1;
+        } else {
+            assert!(accepted.insert(observation.request_id.context("accepted identity")?));
+        }
+    }
+    assert_eq!(accepted.len(), 8);
+    assert_eq!(rejected, if background { 8 } else { 0 });
+    assert_eq!(
+        fixture.journal.writes.lock().unwrap().len(),
+        16,
+        "two writes per admission"
+    );
+    for (request, response) in exchanges
+        .iter()
+        .filter(|(q, _)| q["op"] == SOURCE_REFRESH_REQUEST_OP)
+    {
+        if response["ok"] == true {
+            assert_eq!(request["request_id"], response["request_id"]);
+        }
+    }
+    if background {
+        assert_eq!(
+            fixture.captures(),
+            0,
+            "background only admits before returning"
+        );
+        let run = fixture
+            .engine
+            .run_next(fixture.data_root.path())
+            .context("background publication")?;
+        assert!(!run.failed, "{:#}", run.job);
+        runs.lock().unwrap().push(run.job);
+    }
+    assert_eq!(
+        fixture.captures(),
+        1,
+        "eight callers share one physical capture"
+    );
+    assert!(!fixture.engine.has_pending_request());
+    let runs = runs.lock().unwrap();
+    assert_eq!(runs.len(), 1);
+    fixture.assert_capture(&runs[0], 128)?;
+    for id in accepted {
+        let status = fixture.engine.status(&id).context("retained caller")?;
+        assert_eq!(status["request_state"], "published");
+        assert_eq!(status["published_generation"], fixture.generation);
+        assert_eq!(status["receipt"], runs[0]["receipt"]);
+    }
+    assert_eq!(
+        std::fs::metadata(&fixture.source_path)?.len(),
+        fixture.input_bytes
+    );
+    Ok(())
+}
+
+#[test]
+fn discovered_wait_burst_keeps_eight_ids_and_one_capture() -> Result<()> {
+    assert_burst(false)
+}
+#[test]
+fn discovered_background_burst_admits_eight_and_rejects_overflow() -> Result<()> {
+    assert_burst(true)
+}
+
+fn assert_late_publication(append: bool) -> Result<()> {
+    let fixture = DiscoveredFixture::new()?;
+    let data_root = &fixture.data_root;
+    let engine = &fixture.engine;
+    let warm_generation = &fixture.generation;
+    let source_path = &fixture.source_path;
+    let fixture_routes = &fixture.fixture_routes;
+    let request = |id: String| json!({"op":SOURCE_REFRESH_REQUEST_OP,"mode":"background","trigger":"search", "request_id":id,"refresh_intent":{"kind":"automatic_maintenance"}});
+    let first_id = Uuid::now_v7().to_string();
+    let peer_id = Uuid::now_v7().to_string();
+    let late_id = Uuid::now_v7().to_string();
+    for id in [&first_id, &peer_id] {
+        let response = engine
+            .handle_ipc_request(data_root.path(), &request(id.clone()))?
+            .context("late fixture admission")?;
+        assert_eq!(response["ok"], true);
+    }
+    while engine.prepare_next_pending_admission(data_root.path())? {}
+    let hook_engine = engine.clone();
+    let hook_root = data_root.path().to_owned();
+    let hook_source = source_path.clone();
+    let hook_late_id = late_id.clone();
+    let hook_routes = fixture_routes.clone();
+    *fixture.runtime.after_capture.lock().unwrap() = Some(Box::new(move || {
+        if append {
+            let mut file = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&hook_source)
+                .unwrap();
+            writeln!(file, "{}", json!({"timestamp":"2026-07-30T12:00:02Z","type":"response_item",
+                "payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"late source content must have its own newer generation"}]}})).unwrap();
+        }
+        if append {
+            hook_engine.record_watch_routes_requiring_exhaustive_reconciliation(
+                hook_routes
+                    .iter()
+                    .cloned()
+                    .map(|route| (route, EventWatermark::new(10_000, 1))),
+                10_000,
+            );
+            assert!(hook_routes.is_subset(&hook_engine.scheduled_route_ids_for_test()));
+        }
+        // Existing runtime boundary always runs after real capture returns,
+        // including catalogs with no bounded watcher-observation tokens.
+        let response = hook_engine
+            .handle_ipc_request(
+                &hook_root,
+                &json!({
+                    "op":SOURCE_REFRESH_REQUEST_OP,"mode":"background","trigger":"search",
+                    "request_id":hook_late_id,"refresh_intent":{"kind":"automatic_maintenance"},
+                }),
+            )
+            .unwrap()
+            .expect("late actual admission");
+        assert_eq!(response["ok"], true);
+    }));
+    let first = engine
+        .run_next(data_root.path())
+        .context("first real publication")?;
+    assert!(!first.failed, "{:#}", first.job);
+    assert_eq!(first.job["published_generation"], *warm_generation);
+    for id in [&first_id, &peer_id] {
+        assert_eq!(
+            engine.status(id).context("first peer status")?["request_state"],
+            "published"
+        );
+    }
+    assert_eq!(
+        engine.status(&late_id).context("late retained status")?["request_state"],
+        "admission_pending"
+    );
+    let second = engine
+        .run_next(data_root.path())
+        .context("late real execution")?;
+    assert!(!second.failed, "{:#}", second.job);
+    assert_eq!(second.job["request_id"], late_id);
+    for route in fixture_routes {
+        assert!(
+            first.job["receipt"]["route_results"]
+                .get(route.as_str())
+                .is_some(),
+            "first fixture route omitted"
+        );
+        assert!(
+            second.job["receipt"]["route_results"]
+                .get(route.as_str())
+                .is_some(),
+            "second fixture route omitted"
+        );
+    }
+    assert_eq!(
+        second.job["receipt"]["current"]["current_indexed_documents"],
+        if append { 129 } else { 128 }
+    );
+    assert_eq!(second.job["generation_changed"], append);
+    let late_generation = second.job["published_generation"]
+        .as_str()
+        .context("late generation")?;
+    assert_eq!(late_generation != warm_generation.as_str(), append);
+    // Earlier callers remain bound to the earlier terminal, even after the
+    // current pointer advances for the late request.
+    for id in [&first_id, &peer_id] {
+        assert_eq!(
+            engine.status(id).unwrap()["published_generation"],
+            warm_generation.as_str()
+        );
+    }
+    assert!(!engine.has_pending_request());
+    assert_eq!(fixture.captures(), 2);
+    assert_eq!(
+        first.job["progress"]["processed_bytes"],
+        fixture.input_bytes
+    );
+    fixture.assert_capture(&second.job, if append { 129 } else { 128 })?;
+    Ok(())
+}
+
+#[test]
+fn discovered_late_callers_require_a_new_capture_and_keep_earlier_pins() -> Result<()> {
+    assert_late_publication(false)?;
+    assert_late_publication(true)
+}
+#[test]
+fn background_marker_recovery_progresses_without_caller_replay() -> Result<()> {
+    let fixture = DiscoveredFixture::new()?;
+    let id = Uuid::now_v7().to_string();
+    let response = fixture
+        .engine
+        .handle_ipc_request(
+            fixture.data_root.path(),
+            &json!({
+                "op":SOURCE_REFRESH_REQUEST_OP,"mode":"background","trigger":"search",
+                "request_id":id,"refresh_intent":{"kind":"automatic_maintenance"}
+            }),
+        )?
+        .context("marker admission")?;
+    assert_eq!(response["ok"], true);
+    let writes = fixture.journal.writes.lock().unwrap();
+    assert_eq!(writes.len(), 2);
+    let marker = writes[0].clone();
+    drop(writes);
+    assert_eq!(marker["request_id"], id);
+    assert_eq!(
+        marker["admission_durability"],
+        "replacement_visible_or_indeterminate"
+    );
+    let fingerprint = marker["request_fingerprint"].clone();
+    drop(fixture.engine);
+    // Restore the actual first persisted image to exercise restart before the
+    // marker-clear write. This is journal recovery, not power-loss simulation.
+    DaemonRefreshJournal.store(fixture.data_root.path(), &marker)?;
+    let restarted = CoreRefreshEngine(ctx_history_refresh::RefreshEngine::new(
+        fixture.journal.clone(),
+        fixture.runtime.clone(),
+    ));
+    assert!(restarted.recover(fixture.data_root.path())?);
+    let recovered = restarted.status(&id).context("recovered marker identity")?;
+    assert_eq!(recovered["request_fingerprint"], fingerprint);
+    assert_eq!(recovered["request_state"], "admission_pending");
+    let run = restarted
+        .run_next(fixture.data_root.path())
+        .context("marker recovery")?;
+    assert!(!run.failed, "{:#}", run.job);
+    assert!(!restarted.has_pending_request());
+    assert_eq!(run.job["request_id"], id);
+    assert_eq!(run.job["published_generation"], fixture.generation);
+    assert_eq!(restarted.status(&id).unwrap()["request_state"], "published");
+    assert_eq!(
+        fixture
+            .runtime
+            .captures
+            .load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+    Ok(())
+}

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/discovered_batch_tests.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/discovered_batch_tests.rs
@@ -21,7 +21,7 @@ impl RefreshJournal for AdmissionJournal {
 
 struct DiscoveredRuntime {
     discovery: ctx_history_capture::DiscoveryContext,
-    after_capture: Mutex<Option<Box<dyn FnOnce() + Send>>>,
+    after_capture: Mutex<Option<LateAdmission>>,
     captures: std::sync::atomic::AtomicUsize,
 }
 impl RefreshRuntime for DiscoveredRuntime {
@@ -39,8 +39,55 @@ impl RefreshRuntime for DiscoveredRuntime {
         self.captures
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         if let Some(hook) = self.after_capture.lock().unwrap().take() {
-            hook();
+            hook.run();
         }
+    }
+}
+
+struct LateAdmission {
+    engine: std::sync::Weak<CoreRefreshEngine>,
+    data_root: std::path::PathBuf,
+    source_path: std::path::PathBuf,
+    routes: BTreeSet<ctx_history_index::SourceRouteIdentity>,
+    request_id: String,
+    append: bool,
+}
+impl LateAdmission {
+    fn run(self) {
+        let engine = self.engine.upgrade().expect("capture owner remains alive");
+        if self.append {
+            let mut file = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&self.source_path)
+                .unwrap();
+            writeln!(file, "{}", json!({"timestamp":"2026-07-30T12:00:02Z","type":"response_item",
+                "payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"late source content must have its own newer generation"}]}})).unwrap();
+        }
+        if self.append {
+            engine.record_watch_routes_requiring_exhaustive_reconciliation(
+                self.routes
+                    .iter()
+                    .cloned()
+                    .map(|route| (route, EventWatermark::new(10_000, 1))),
+                10_000,
+            );
+            assert!(self
+                .routes
+                .is_subset(&engine.scheduled_route_ids_for_test()));
+        }
+        // Existing runtime boundary always runs after real capture returns,
+        // including catalogs with no bounded watcher-observation tokens.
+        let response = engine
+            .handle_ipc_request(
+                &self.data_root,
+                &json!({
+                    "op":SOURCE_REFRESH_REQUEST_OP,"mode":"background","trigger":"search",
+                    "request_id":self.request_id,"refresh_intent":{"kind":"automatic_maintenance"},
+                }),
+            )
+            .unwrap()
+            .expect("late actual admission");
+        assert_eq!(response["ok"], true);
     }
 }
 
@@ -322,44 +369,14 @@ fn assert_late_publication(append: bool) -> Result<()> {
         assert_eq!(response["ok"], true);
     }
     while engine.prepare_next_pending_admission(data_root.path())? {}
-    let hook_engine = engine.clone();
-    let hook_root = data_root.path().to_owned();
-    let hook_source = source_path.clone();
-    let hook_late_id = late_id.clone();
-    let hook_routes = fixture_routes.clone();
-    *fixture.runtime.after_capture.lock().unwrap() = Some(Box::new(move || {
-        if append {
-            let mut file = std::fs::OpenOptions::new()
-                .append(true)
-                .open(&hook_source)
-                .unwrap();
-            writeln!(file, "{}", json!({"timestamp":"2026-07-30T12:00:02Z","type":"response_item",
-                "payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"late source content must have its own newer generation"}]}})).unwrap();
-        }
-        if append {
-            hook_engine.record_watch_routes_requiring_exhaustive_reconciliation(
-                hook_routes
-                    .iter()
-                    .cloned()
-                    .map(|route| (route, EventWatermark::new(10_000, 1))),
-                10_000,
-            );
-            assert!(hook_routes.is_subset(&hook_engine.scheduled_route_ids_for_test()));
-        }
-        // Existing runtime boundary always runs after real capture returns,
-        // including catalogs with no bounded watcher-observation tokens.
-        let response = hook_engine
-            .handle_ipc_request(
-                &hook_root,
-                &json!({
-                    "op":SOURCE_REFRESH_REQUEST_OP,"mode":"background","trigger":"search",
-                    "request_id":hook_late_id,"refresh_intent":{"kind":"automatic_maintenance"},
-                }),
-            )
-            .unwrap()
-            .expect("late actual admission");
-        assert_eq!(response["ok"], true);
-    }));
+    *fixture.runtime.after_capture.lock().unwrap() = Some(LateAdmission {
+        engine: Arc::downgrade(engine),
+        data_root: data_root.path().to_owned(),
+        source_path: source_path.clone(),
+        routes: fixture_routes.clone(),
+        request_id: late_id.clone(),
+        append,
+    });
     let first = engine
         .run_next(data_root.path())
         .context("first real publication")?;

--- a/crates/ctx-history-cli/src/source_index/search.rs
+++ b/crates/ctx-history-cli/src/source_index/search.rs
@@ -70,8 +70,7 @@ const SEMANTIC_GENERATION_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 type RefreshArg = RefreshMode;
 pub(super) const MISSING_INDEX_ERROR: &str =
     "the Core index does not exist; retry with daemon refresh enabled";
-const QUEUED_WITHOUT_GENERATION_ERROR: &str =
-    "daemon source refresh was queued but no published generation exists; retry with --refresh wait";
+const QUEUED_WITHOUT_GENERATION_ERROR: &str = "daemon source refresh was queued but no published generation exists; retry with --refresh wait";
 
 #[derive(Debug)]
 pub(super) enum SourceSearchFailure {
@@ -882,6 +881,9 @@ where
     }
     let status = match mode {
         SourceBackedRefreshMode::Off => "existing_generation",
+        SourceBackedRefreshMode::Background if observation.status == "admission_rejected" => {
+            "admission_rejected"
+        }
         SourceBackedRefreshMode::Background if observation.daemon_available => "daemon_background",
         SourceBackedRefreshMode::Background => "daemon_unavailable",
         SourceBackedRefreshMode::Wait => "completed",
@@ -948,3 +950,6 @@ pub(super) fn collect_search_hits_with_semantic_availability(
         &crate::semantic::SemanticQueryAdapter::new(data_root),
     )
 }
+
+#[cfg(test)]
+mod admission_rejected_tests;

--- a/crates/ctx-history-cli/src/source_index/search/admission_rejected_tests.rs
+++ b/crates/ctx-history-cli/src/source_index/search/admission_rejected_tests.rs
@@ -1,0 +1,84 @@
+use super::*;
+
+#[test]
+fn rejected_background_admission_renders_honest_freshness_on_existing_generation() {
+    let temp = tempfile::tempdir().unwrap();
+    let generation = crate::test_query_authority::publish_empty_generation(temp.path());
+    let request = SourceSearchRequest {
+        query: "available history".to_owned(),
+        terms: Vec::new(),
+        limit: 10,
+        provider: None,
+        history_source: None,
+        provider_key: None,
+        source_id: None,
+        source_format: None,
+        source_roots: Vec::new(),
+        source_groups: Vec::new(),
+        workspace: None,
+        since: None,
+        primary_only: false,
+        content_scope: ctx_history_index::SearchContentScope::All,
+        event_type: None,
+        file: None,
+        session: None,
+        exclude_sessions: Vec::new(),
+        events: false,
+        include_current_session: true,
+        backend: Some(SearchBackend::Lexical),
+        semantic_weight: 0.0,
+    };
+    let pin = ctx_daemon_cli::pin_active_verified_generation(temp.path()).unwrap();
+    let refresh = refresh_for_search_with(
+        &request,
+        RefreshArg::Background,
+        temp.path(),
+        |_root, mode| {
+            Ok(SourceBackedRefreshObservation {
+                mode,
+                status: "admission_rejected".to_owned(),
+                request_id: None,
+                daemon_available: true,
+                source_count: 0,
+                request_previous_generation: None,
+                request_generation_changed: false,
+                scanned_routes: None,
+                receipt: None,
+                pin,
+            })
+        },
+    )
+    .unwrap();
+    assert_eq!(refresh.status, "admission_rejected");
+    let plan = ctx_history_read_application::plan_search(
+        request,
+        ctx_history_read_application::SearchPolicy {
+            default_backend: SearchBackend::Lexical,
+            semantic: SemanticAvailability::Unavailable(SemanticReason::PolicyDisabled),
+        },
+    )
+    .unwrap();
+    let mut observation = initial_search_observation();
+    let (value, result) = search_pinned_generation(
+        plan,
+        temp.path(),
+        RefreshArg::Background,
+        refresh,
+        false,
+        &crate::semantic::SemanticQueryAdapter::new(temp.path()),
+        None,
+        &mut observation,
+    )
+    .unwrap();
+    assert_eq!(result.index().generation_id(), generation);
+    assert_eq!(value["retrieval"]["generation_id"], generation);
+    assert_eq!(value["freshness"]["mode"], "background");
+    assert_eq!(value["freshness"]["status"], "admission_rejected");
+    assert_eq!(value["freshness"]["source_count"], 0);
+    assert!(value["freshness"].get("request_id").is_none());
+    assert!(value["freshness"].get("receipt").is_none());
+    assert!(
+        observation.failure_phase.is_none(),
+        "search itself succeeded"
+    );
+}

--- a/crates/ctx-history-cli/src/source_index/search/observation.rs
+++ b/crates/ctx-history-cli/src/source_index/search/observation.rs
@@ -25,6 +25,7 @@ fn search_refresh_status(status: &str) -> SearchRefreshStatus {
         "existing_generation" => SearchRefreshStatus::ExistingGeneration,
         "daemon_background" => SearchRefreshStatus::DaemonBackground,
         "daemon_unavailable" => SearchRefreshStatus::DaemonUnavailable,
+        "admission_rejected" => SearchRefreshStatus::Failed,
         _ => SearchRefreshStatus::Completed,
     }
 }
@@ -129,4 +130,25 @@ pub(super) fn search_existing_generation_with_port<P: HistorySemanticPort>(
     )?;
     observation.failure_phase = None;
     Ok((value, result))
+}
+
+#[cfg(test)]
+mod admission_rejected_tests {
+    use super::*;
+
+    #[test]
+    fn rejected_optional_admission_is_failed_refresh_not_completed_telemetry() {
+        assert_eq!(
+            search_refresh_status("admission_rejected"),
+            SearchRefreshStatus::Failed
+        );
+        assert_eq!(
+            search_refresh_status("daemon_background"),
+            SearchRefreshStatus::DaemonBackground
+        );
+        assert_eq!(
+            search_refresh_status("completed"),
+            SearchRefreshStatus::Completed
+        );
+    }
 }

--- a/crates/ctx-history-refresh/src/engine/admission.rs
+++ b/crates/ctx-history-refresh/src/engine/admission.rs
@@ -1,5 +1,6 @@
 use super::*;
 use sha2::{Digest as _, Sha256};
+mod queued_admission;
 mod state_helpers;
 use state_helpers::*;
 #[derive(Clone)]
@@ -674,32 +675,6 @@ impl CoreRefreshEngine {
         })
     }
 
-    fn claim_active_pending_admission(&self) -> Option<PendingAdmissionClaim> {
-        let mut state = self.lock_state();
-        if state.watch_uncertain_through.is_some() {
-            return None;
-        }
-        let request_id = state.active_request_id.clone()?;
-        let attempt = find_attempt(&state, &request_id)?;
-        if attempt.state != SourceBackedRefreshState::AdmissionPending
-            || state.unacknowledged_admissions.contains_key(&request_id)
-            || state.admission_resolutions_in_flight.contains(&request_id)
-        {
-            return None;
-        }
-        let claim = PendingAdmissionClaim {
-            request_id: request_id.clone(),
-            intent: attempt.intent.clone(),
-            persisted_scope: attempt.refresh_scope.clone(),
-            watch_catalog_revision: state.watch_catalog_revision,
-            route_event_watermarks: state.route_event_watermarks.clone(),
-        };
-        state
-            .admission_resolutions_in_flight
-            .insert(request_id.clone());
-        Some(claim)
-    }
-
     #[cfg(any(test, feature = "test-support"))]
     fn claim_next_pending_admission(&self) -> Option<PendingAdmissionClaim> {
         let mut state = self.lock_state();
@@ -784,6 +759,11 @@ impl CoreRefreshEngine {
                 Ok(None)
             }
             Err(error) => {
+                if state.active_request_id.as_deref() != Some(claim.request_id.as_str()) {
+                    // A speculative batch peer still owns a queued turn. Its
+                    // normal active resolution owns failure and retry handoff.
+                    return Ok(None);
+                }
                 self.persist_failed_admission(data_root, &mut state, &claim.request_id, error)
             }
         }

--- a/crates/ctx-history-refresh/src/engine/admission/queued_admission.rs
+++ b/crates/ctx-history-refresh/src/engine/admission/queued_admission.rs
@@ -1,0 +1,92 @@
+use super::*;
+
+impl CoreRefreshEngine {
+    /// Prepare one bounded automatic prefix through ordinary per-request
+    /// admission. Only successfully persisted Queued members can later share
+    /// capture; a blocked or failed peer keeps its normal turn at the root.
+    pub(in crate::engine) fn prepare_queued_batch_admissions(&self, data_root: &Path) {
+        let request_ids = {
+            let state = self.lock_state();
+            let Some(root) = state
+                .active_request_id
+                .as_deref()
+                .and_then(|id| find_attempt(&state, id))
+            else {
+                return;
+            };
+            if root.state != SourceBackedRefreshState::Queued
+                || root.intent != RefreshIntent::AutomaticMaintenance
+                || root.refresh_scope != SourceBackedRefreshScope::All
+            {
+                return;
+            }
+            state
+                .pending_request_ids
+                .iter()
+                .take(SOURCE_REFRESH_ACTIVE_PENDING_LIMIT.saturating_sub(1))
+                .map_while(|id| {
+                    let peer = find_attempt(&state, id)?;
+                    (peer.intent == root.intent
+                        && peer.refresh_scope == root.refresh_scope
+                        && peer.reconciliation_demand == root.reconciliation_demand
+                        && matches!(
+                            peer.state,
+                            SourceBackedRefreshState::AdmissionPending
+                                | SourceBackedRefreshState::Queued
+                        ))
+                    .then(|| id.clone())
+                })
+                .collect::<Vec<_>>()
+        };
+        for request_id in request_ids {
+            if find_attempt(&self.lock_state(), &request_id)
+                .is_some_and(|peer| peer.state == SourceBackedRefreshState::Queued)
+            {
+                continue;
+            }
+            let Some(claim) = self.claim_pending_admission(&request_id) else {
+                break;
+            };
+            let resolution = self.resolve_pending_admission_claim(data_root, &claim);
+            if self
+                .complete_claimed_pending_admission(data_root, &claim, resolution)
+                .is_err()
+                || find_attempt(&self.lock_state(), &request_id)
+                    .is_none_or(|peer| peer.state != SourceBackedRefreshState::Queued)
+            {
+                break;
+            }
+        }
+    }
+
+    pub(super) fn claim_active_pending_admission(&self) -> Option<PendingAdmissionClaim> {
+        let request_id = self.lock_state().active_request_id.clone()?;
+        self.claim_pending_admission(&request_id)
+    }
+
+    fn claim_pending_admission(&self, request_id: &str) -> Option<PendingAdmissionClaim> {
+        let mut state = self.lock_state();
+        if state.watch_uncertain_through.is_some() {
+            return None;
+        }
+        let request_id = request_id.to_owned();
+        let attempt = find_attempt(&state, &request_id)?;
+        if attempt.state != SourceBackedRefreshState::AdmissionPending
+            || state.unacknowledged_admissions.contains_key(&request_id)
+            || state.admission_resolutions_in_flight.contains(&request_id)
+        {
+            return None;
+        }
+        let claim = PendingAdmissionClaim {
+            request_id: request_id.clone(),
+            intent: attempt.intent.clone(),
+            persisted_scope: attempt.refresh_scope.clone(),
+            watch_catalog_revision: state.watch_catalog_revision,
+            route_event_watermarks: state.route_event_watermarks.clone(),
+        };
+        state
+            .admission_resolutions_in_flight
+            .insert(request_id.clone());
+        Some(claim)
+    }
+}

--- a/crates/ctx-history-refresh/src/engine/generation_authority.rs
+++ b/crates/ctx-history-refresh/src/engine/generation_authority.rs
@@ -67,6 +67,14 @@ pub(super) enum CoreRefreshTerminalSuccess {
 }
 
 impl CoreRefreshTerminalSuccess {
+    pub(super) fn receipt(&self) -> &SourceBackedRefreshReceipt {
+        match self {
+            Self::Verified(authority) => &authority.receipt,
+            #[cfg(any(test, feature = "test-support"))]
+            Self::StateOnly(receipt) => receipt,
+        }
+    }
+
     pub(super) fn bind(
         receipt: SourceBackedRefreshReceipt,
         verified_index: Arc<VerifiedIndex>,

--- a/crates/ctx-history-refresh/src/engine/request_lifecycle.rs
+++ b/crates/ctx-history-refresh/src/engine/request_lifecycle.rs
@@ -1,7 +1,9 @@
 use super::*;
 mod admission_scope;
+mod queued_batch;
 mod recovery;
 mod resolution;
+use queued_batch::QueuedRefreshBatch;
 pub(in crate::engine) use recovery::recover_automatic_retry_checkpoints;
 
 impl CoreRefreshEngine {
@@ -305,7 +307,7 @@ impl CoreRefreshEngine {
             return projected_status_json(state, &existing.request_id)
                 .ok_or_else(|| anyhow!("existing source refresh request disappeared"));
         }
-        if intent == RefreshIntent::AutomaticMaintenance {
+        if logical_request_id.is_none() && intent == RefreshIntent::AutomaticMaintenance {
             let coalesced_request_id = state
                 .active_request_id
                 .iter()
@@ -366,7 +368,7 @@ impl CoreRefreshEngine {
         execute: Execute,
         probe: Probe,
         terminal: Terminal,
-        published: Published,
+        mut published: Published,
         failed: Failed,
     ) -> Option<SourceBackedRefreshRun>
     where
@@ -379,7 +381,7 @@ impl CoreRefreshEngine {
             CoreRefreshTerminalSuccess,
             PostPublicationRouteCoverageFence,
         )>,
-        Published: FnOnce(&Value) -> Result<()>,
+        Published: FnMut(&Value) -> Result<()>,
         Failed: FnOnce(&str) -> Result<()>,
     {
         let mut state = self.lock_state();
@@ -453,9 +455,10 @@ impl CoreRefreshEngine {
         }
         drop(state);
 
-        let (request_id, previous_generation, requested_catalog, refresh_scope) = {
+        let (request_id, previous_generation, requested_catalog, refresh_scope, queued_batch) = {
             let mut state = self.lock_state();
             let request_id = state.active_request_id.clone()?;
+            let queued_batch = QueuedRefreshBatch::snapshot(&state, &request_id);
             let attempt = find_attempt_mut(&mut state, &request_id)?;
             if attempt.state != SourceBackedRefreshState::Queued {
                 return None;
@@ -472,6 +475,7 @@ impl CoreRefreshEngine {
                 attempt.previous_generation.clone(),
                 attempt.requested_explicit_source_catalog().cloned(),
                 attempt.refresh_scope.clone(),
+                queued_batch,
             )
         };
 
@@ -532,10 +536,13 @@ impl CoreRefreshEngine {
                 };
                 (verified, Some(observed))
             }
-            (Ok(publication), Ok(observed)) => (Err(format!(
-                "source-backed refresh returned generation {}, but the verified published generation is {observed:?}",
-                publication.generation_id
-            )), observed),
+            (Ok(publication), Ok(observed)) => (
+                Err(format!(
+                    "source-backed refresh returned generation {}, but the verified published generation is {observed:?}",
+                    publication.generation_id
+                )),
+                observed,
+            ),
             (Ok(publication), Err(error)) => (
                 Err(format!(
                     "source-backed refresh returned generation {}, but publication verification failed: {error:#}",
@@ -546,10 +553,13 @@ impl CoreRefreshEngine {
             (Err(error), Ok(observed)) => {
                 (Err(source_backed_refresh_error_summary(&error)), observed)
             }
-            (Err(error), Err(probe_error)) => (Err(format!(
-                "{}; verifying the retained generation also failed: {probe_error:#}",
-                source_backed_refresh_error_summary(&error)
-            )), None),
+            (Err(error), Err(probe_error)) => (
+                Err(format!(
+                    "{}; verifying the retained generation also failed: {probe_error:#}",
+                    source_backed_refresh_error_summary(&error)
+                )),
+                None,
+            ),
         };
         let verified = match verified {
             Ok((observed, publication)) => {
@@ -614,8 +624,11 @@ impl CoreRefreshEngine {
             attempt.attempt_history_progress = None;
         }
         let mut terminal_persistence_pending = false;
-        let (failed_run, did_work, coverage_certificate, terminal_job) = match verified {
+        let mut covered_batch = None;
+        let (failed_run, did_work, mut coverage_certificate, mut terminal_job) = match verified {
             Ok((observed, publication, receipt, terminal, coverage_fence)) => {
+                covered_batch = queued_batch
+                    .and_then(|batch| batch.bind_capture(&state, &request_id, &terminal));
                 let request_source_count = terminal.request_source_count(&receipt);
                 let did_work = {
                     let attempt = find_attempt_mut(&mut state, &request_id)?;
@@ -714,6 +727,19 @@ impl CoreRefreshEngine {
                 .and_then(|attempt| attempt.published_generation.clone())
                 .or(observed_for_status);
             advance_after_terminal_attempt(&mut state, &request_id, published_generation);
+            if let Some(batch) = covered_batch {
+                if let Some(run) = batch.publish_covered_members(
+                    &mut state,
+                    &request_id,
+                    coverage_certificate.as_ref(),
+                    did_work,
+                    &mut published,
+                ) {
+                    terminal_job = run.job;
+                    coverage_certificate = run.coverage_certificate;
+                    terminal_persistence_pending = run.terminal_persistence_pending;
+                }
+            }
         }
         trim_terminal_attempt_history(&mut state);
         drop(state);
@@ -740,7 +766,7 @@ impl CoreRefreshEngine {
     where
         Execute: FnOnce(&str, &Self) -> Result<SourceBackedRefreshPublication>,
         Probe: FnOnce() -> Result<Option<String>>,
-        Published: FnOnce(&Value) -> Result<()>,
+        Published: FnMut(&Value) -> Result<()>,
         Failed: FnOnce(&str) -> Result<()>,
     {
         let run = self.run_next_with_terminal_success(

--- a/crates/ctx-history-refresh/src/engine/request_lifecycle/queued_batch.rs
+++ b/crates/ctx-history-refresh/src/engine/request_lifecycle/queued_batch.rs
@@ -1,0 +1,213 @@
+use super::*;
+
+/// One call's bounded, already-admitted queue prefix. Recovery never restores
+/// this optimization: each durable logical request is admitted again normally.
+pub(super) struct QueuedRefreshBatch {
+    members: Vec<(String, Option<String>)>,
+    routes: BTreeMap<SourceRouteIdentity, Option<EventWatermark>>,
+}
+
+impl QueuedRefreshBatch {
+    pub(super) fn snapshot(state: &CoreRefreshEngineState, request_id: &str) -> Option<Self> {
+        if state.watch_uncertain_through.is_some() {
+            return None;
+        }
+        let root = find_attempt(state, request_id)?;
+        let authority = batch_authority(state, root)?;
+        let routes = authority
+            .exact_routes()
+            .iter()
+            .map(|route| {
+                (
+                    route.clone(),
+                    state.route_event_watermarks.get(route).copied(),
+                )
+            })
+            .collect();
+        let members = state
+            .pending_request_ids
+            .iter()
+            .take(SOURCE_REFRESH_ACTIVE_PENDING_LIMIT.saturating_sub(1))
+            .map_while(|request_id| {
+                let member = find_attempt(state, request_id)?;
+                let other = batch_authority(state, member)?;
+                let discovery = authority.discovery();
+                let other_discovery = other.discovery();
+                (member.reconciliation_demand == root.reconciliation_demand
+                    && member.route_observations == root.route_observations
+                    && other.exact_routes() == authority.exact_routes()
+                    && other_discovery.report() == discovery.report()
+                    && other_discovery.watch_catalog() == discovery.watch_catalog()
+                    && other_discovery.configured_provider_roots()
+                        == discovery.configured_provider_roots()
+                    && other_discovery.automatic_provider_discovery()
+                        == discovery.automatic_provider_discovery())
+                .then(|| (request_id.clone(), member.previous_generation.clone()))
+            })
+            .collect::<Vec<_>>();
+        (!members.is_empty()).then_some(Self { members, routes })
+    }
+
+    /// Bind this pre-capture membership to the physical admission and the
+    /// verified full-catalog terminal. Optional warm-skip observations cannot
+    /// replace or invalidate this new capture's exact route accounting.
+    pub(super) fn bind_capture(
+        self,
+        state: &CoreRefreshEngineState,
+        request_id: &str,
+        terminal: &CoreRefreshTerminalSuccess,
+    ) -> Option<CoveredQueuedRefreshBatch> {
+        let root = find_attempt(state, request_id)?;
+        let admitted = state.route_admission_watermarks.get(request_id)?;
+        let receipt = terminal.receipt();
+        if root.state != SourceBackedRefreshState::Running
+            || receipt.route_results.len() != self.routes.len()
+            || !receipt.route_results.iter().all(|result| {
+                SourceRouteIdentity::from_sha256(result.route_identity.clone())
+                    .ok()
+                    .is_some_and(|route| self.routes.contains_key(&route))
+                    && result.outcome.is_success()
+                    && source_backed_route_retry_disposition(result).is_none()
+            })
+            || !self.routes.iter().all(|(route, required)| {
+                admitted
+                    .get(route)
+                    .is_some_and(|captured| required.is_none_or(|required| *captured >= required))
+            })
+        {
+            return None;
+        }
+        Some(CoveredQueuedRefreshBatch {
+            members: self.members,
+            receipt: receipt.clone(),
+        })
+    }
+}
+
+/// Request completion from one newly verified capture, separate from a dirty
+/// route certificate. This proof grants no warm skip or watcher acknowledgement.
+/// Its members were admitted before capture began, including routes for which
+/// the watcher has no bounded observation token. Unknown remains unknown.
+pub(super) struct CoveredQueuedRefreshBatch {
+    members: Vec<(String, Option<String>)>,
+    receipt: SourceBackedRefreshReceipt,
+}
+
+impl CoveredQueuedRefreshBatch {
+    pub(super) fn publish_covered_members<Published>(
+        self,
+        state: &mut CoreRefreshEngineState,
+        root_request_id: &str,
+        certificate: Option<&SourceBackedRefreshCoverageCertificate>,
+        did_work: bool,
+        published: &mut Published,
+    ) -> Option<SourceBackedRefreshRun>
+    where
+        Published: FnMut(&Value) -> Result<()>,
+    {
+        let certificate = certificate?;
+        let root = find_attempt(state, root_request_id)?.clone();
+        let receipt = &self.receipt;
+        if root.receipt.as_ref() != Some(receipt)
+            || certificate.request_id != root_request_id
+            || certificate.published_generation != receipt.published_generation
+        {
+            return None;
+        }
+
+        let mut last = None;
+        for (request_id, previous_generation) in self.members {
+            // Only this pre-capture prefix may consume the proof. New arrivals
+            // and admission-pending requests always keep their own next run.
+            if state.active_request_id.as_deref() != Some(request_id.as_str())
+                || find_attempt(state, &request_id)
+                    .is_none_or(|attempt| batch_authority(state, attempt).is_none())
+            {
+                break;
+            }
+            let attempt = find_attempt_mut(state, &request_id)?;
+            let mut receipt = receipt.clone();
+            receipt.previous_generation = previous_generation.clone();
+            receipt.generation_changed =
+                previous_generation.as_deref() != Some(receipt.published_generation.as_str());
+            // Carry only verified execution results. Identity, fingerprint,
+            // trigger and admission acknowledgement remain member-owned.
+            attempt.previous_generation = previous_generation;
+            attempt.published_generation = Some(receipt.published_generation.clone());
+            attempt.started_at_ms = root.started_at_ms;
+            attempt.finished_at_ms = root.finished_at_ms;
+            attempt.state = SourceBackedRefreshState::Published;
+            attempt.progress = root.progress.clone();
+            attempt.progress_total_sources_known = root.progress_total_sources_known;
+            attempt.scanned_routes = root.scanned_routes;
+            attempt.unsupported_routes = root.unsupported_routes;
+            attempt.request_source_count = root.request_source_count;
+            attempt.certified_source_count = root.certified_source_count;
+            attempt.certified_source_bytes = root.certified_source_bytes;
+            attempt.receipt = Some(receipt);
+            attempt.route_observations = root.route_observations.clone();
+            attempt.timings = root.timings;
+            attempt.last_error = None;
+            update_automatic_retry_after_publication(state, &request_id);
+            // The physical owner already finalized the dirty-route ledger.
+            // Rebinding this exact proof must not acknowledge a newer event.
+            let mut coverage = certificate.clone();
+            coverage.request_id = request_id.clone();
+            let job = durable_job_json(state, &request_id)?;
+            let pending = published(&job).is_err();
+            if pending {
+                state.pending_terminal_persistence = Some(PendingTerminalPersistence {
+                    request_id: request_id.clone(),
+                    terminal_job: job.clone(),
+                    outcome: PendingTerminalOutcome::Published {
+                        did_work,
+                        coverage_certificate: Some(coverage.clone()),
+                    },
+                });
+            } else {
+                advance_after_terminal_attempt(
+                    state,
+                    &request_id,
+                    Some(coverage.published_generation.clone()),
+                );
+            }
+            last = Some(SourceBackedRefreshRun {
+                job,
+                did_work: did_work && !pending,
+                failed: false,
+                terminal_persistence_pending: pending,
+                scope: root.refresh_scope.clone(),
+                coverage_certificate: (!pending).then_some(coverage),
+            });
+            if pending {
+                break;
+            }
+        }
+        last
+    }
+}
+
+fn batch_authority<'a>(
+    state: &CoreRefreshEngineState,
+    attempt: &'a SourceBackedRefreshAttempt,
+) -> Option<&'a ctx_history_refresh_execution::AdmittedRefresh> {
+    if attempt.state != SourceBackedRefreshState::Queued
+        || attempt.intent != RefreshIntent::AutomaticMaintenance
+        || attempt.refresh_scope != SourceBackedRefreshScope::All
+        || attempt.admission_durability_indeterminate
+        || state
+            .unacknowledged_admissions
+            .contains_key(&attempt.request_id)
+        || state
+            .admission_resolutions_in_flight
+            .contains(&attempt.request_id)
+        || state.route_admissions.contains_key(&attempt.request_id)
+    {
+        return None;
+    }
+    attempt.admitted_authority.as_ref().filter(|authority| {
+        authority.coverage()
+            == ctx_history_refresh_execution::AdmittedRefreshCoverage::CompleteCatalog
+            && authority.route_worksets().is_empty()
+    })
+}

--- a/crates/ctx-history-refresh/src/engine/request_lifecycle/resolution.rs
+++ b/crates/ctx-history-refresh/src/engine/request_lifecycle/resolution.rs
@@ -27,6 +27,7 @@ impl CoreRefreshEngine {
         if self.active_request_admission_pending() {
             return None;
         }
+        self.prepare_queued_batch_admissions(data_root);
         self.run_next_with_verified_index_opener(data_root, |index_root| {
             Ok(Arc::new(open_verified_index(index_root)?))
         })

--- a/crates/ctx-history-refresh/src/engine/tests/queued_batch.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/queued_batch.rs
@@ -1,0 +1,526 @@
+use super::*;
+
+fn submit_automatic(coordinator: &CoreRefreshEngine, data_root: &Path) -> RefreshRequest {
+    let request =
+        RefreshRequest::automatic(Uuid::now_v7().to_string(), RefreshRequestTrigger::Search);
+    let admission = coordinator.submit(data_root, request.clone()).unwrap();
+    let (status, barrier) = admission.into_parts();
+    assert_eq!(status.request_id(), Some(request.request_id()));
+    barrier.unwrap().release(coordinator);
+    request
+}
+
+fn queued_automatic(
+    coordinator: &CoreRefreshEngine,
+    data_root: &Path,
+    observation: &str,
+) -> RefreshRequest {
+    let request = submit_automatic(coordinator, data_root);
+    coordinator
+        .complete_pending_admission_for_test(
+            data_root,
+            request.request_id(),
+            BTreeMap::from([(route_identity(0x71), Some(observation.to_owned()))]),
+        )
+        .unwrap();
+    request
+}
+
+fn certified_run<Before, Persist>(
+    coordinator: &CoreRefreshEngine,
+    generation: &str,
+    observation: &str,
+    before: Before,
+    persist: Persist,
+) -> SourceBackedRefreshRun
+where
+    Before: FnOnce(&super::super::super::CoreRefreshEngine),
+    Persist: FnMut(&Value) -> Result<()>,
+{
+    coordinator
+        .run_next_with(
+            |id, engine| {
+                engine.admit_refresh_scope_for_test(id, &SourceBackedRefreshScope::All)?;
+                before(engine);
+                engine.set_route_observations_for_test(
+                    id,
+                    BTreeMap::from([(route_identity(0x71), observation.to_owned())]),
+                );
+                let mut publication = test_publication(generation);
+                publication.route_results = vec![SourceBackedRefreshRouteResult::succeeded(
+                    route_identity(0x71).as_str().to_owned(),
+                    true,
+                )];
+                Ok(publication)
+            },
+            || Ok(Some(generation.to_owned())),
+            persist,
+            |_| Ok(()),
+        )
+        .unwrap()
+}
+
+#[test]
+fn queued_batch_keeps_eight_ids_fingerprints_receipts_and_bounded_replay() {
+    let temp = tempfile::tempdir().unwrap();
+    let engine = CoreRefreshEngine::new();
+    let observation = "72".repeat(32);
+    let requests = (0..SOURCE_REFRESH_ACTIVE_PENDING_LIMIT)
+        .map(|_| queued_automatic(&engine, temp.path(), &observation))
+        .collect::<Vec<_>>();
+    let fingerprints = requests
+        .iter()
+        .map(|request| engine.status(request.request_id()).unwrap()["request_fingerprint"].clone())
+        .collect::<Vec<_>>();
+    let duplicate = engine.submit(temp.path(), requests[3].clone()).unwrap();
+    assert_eq!(
+        duplicate.status().request_id(),
+        Some(requests[3].request_id())
+    );
+    assert!(duplicate.into_parts().1.is_none());
+    let overloaded = engine
+        .submit(
+            temp.path(),
+            RefreshRequest::automatic(Uuid::now_v7().to_string(), RefreshRequestTrigger::Search),
+        )
+        .unwrap();
+    assert_eq!(
+        overloaded.status()["error_code"],
+        "source_refresh_queue_full"
+    );
+    let conflicting = engine
+        .submit(
+            temp.path(),
+            requests[3]
+                .clone()
+                .with_trigger(RefreshRequestTrigger::Setup),
+        )
+        .unwrap();
+    assert_eq!(conflicting.status()["error_code"], "request_id_conflict");
+    let mut persisted = Vec::new();
+    let run = certified_run(
+        &engine,
+        "batch-generation",
+        &observation,
+        |_| {},
+        |job| {
+            persisted.push(job.clone());
+            Ok(())
+        },
+    );
+    assert!(!run.failed, "{:?}", run.job);
+    assert!(!engine.has_pending_request());
+    assert_eq!(persisted.len(), requests.len());
+    for ((request, fingerprint), job) in requests.iter().zip(fingerprints).zip(persisted) {
+        let status = engine.status(request.request_id()).unwrap();
+        assert_eq!(status["request_state"], "published");
+        assert_eq!(status["request_id"], job["request_id"]);
+        assert_eq!(status["request_fingerprint"], fingerprint);
+        assert_eq!(status["published_generation"], "batch-generation");
+        assert_eq!(
+            status["receipt"]["published_generation"],
+            "batch-generation"
+        );
+        assert_eq!(status["receipt"]["generation_changed"], true);
+        assert!(status["receipt"].get("previous_generation").is_none());
+        assert!(status["coalesced_into_request_id"].is_null());
+        RefreshStatus::parse_schema_v1(status).unwrap();
+    }
+    assert_eq!(
+        run.coverage_certificate().unwrap().request_id(),
+        requests.last().unwrap().request_id()
+    );
+}
+
+#[test]
+fn queued_batch_late_arrival_with_newer_observation_keeps_its_next_run() {
+    let temp = tempfile::tempdir().unwrap();
+    let engine = CoreRefreshEngine::new();
+    let route = route_identity(0x71);
+    let old = "72".repeat(32);
+    let new = "73".repeat(32);
+    engine.initialize_watch_route_authority([route.clone()]);
+    engine.record_watch_routes([(route.clone(), EventWatermark::new(91, 1))], 0);
+    let first = queued_automatic(&engine, temp.path(), &old);
+    let peer = queued_automatic(&engine, temp.path(), &old);
+    let mut late = None;
+    let run = certified_run(
+        &engine,
+        "old-generation",
+        &old,
+        |owner| {
+            owner.record_watch_routes([(route.clone(), EventWatermark::new(91, 2))], 0);
+            late = Some(queued_automatic(&engine, temp.path(), &new));
+        },
+        |_| Ok(()),
+    );
+    assert!(!run.failed);
+    for request in [first, peer] {
+        assert_eq!(
+            engine.status(request.request_id()).unwrap()["published_generation"],
+            "old-generation"
+        );
+    }
+    let late = late.unwrap();
+    assert_eq!(
+        engine.status(late.request_id()).unwrap()["request_state"],
+        "queued"
+    );
+    assert!(engine.has_scheduled_route_work());
+    assert_eq!(
+        run.coverage_certificate()
+            .unwrap()
+            .exact_route_boundaries()
+            .next()
+            .unwrap()
+            .1,
+        EventWatermark::new(91, 1)
+    );
+    let next = certified_run(&engine, "new-generation", &new, |_| {}, |_| Ok(()));
+    assert!(!next.failed);
+    assert_eq!(next.job["request_id"], late.request_id());
+    assert_eq!(next.job["published_generation"], "new-generation");
+}
+
+#[test]
+fn queued_batch_rejects_unproven_coverage_and_different_admission_authority() {
+    for mismatch in [
+        "observation",
+        "omitted_outcome",
+        "failed_outcome",
+        "extra_outcome",
+        "absent_admission",
+        "watermark",
+        "config",
+        "demand",
+        "unobserved",
+    ] {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = CoreRefreshEngine::new();
+        let old = "72".repeat(32);
+        let new = "73".repeat(32);
+        let _first = queued_automatic(&engine, temp.path(), &old);
+        let peer = queued_automatic(
+            &engine,
+            temp.path(),
+            if mismatch == "observation" {
+                &new
+            } else {
+                &old
+            },
+        );
+        {
+            let mut state = engine.lock_state();
+            let member = find_attempt_mut(&mut state, peer.request_id()).unwrap();
+            match mismatch {
+                "config" => {
+                    member.admitted_authority = member.admitted_authority.take().map(|authority| {
+                        authority.with_automatic_provider_discovery_for_test(false)
+                    })
+                }
+                "demand" => {
+                    member.reconciliation_demand = SourceBackedReconciliationDemand::Exhaustive
+                }
+                "unobserved" => member.route_observations.clear(),
+                _ => {}
+            }
+            if mismatch == "watermark" {
+                state
+                    .route_event_watermarks
+                    .insert(route_identity(0x71), EventWatermark::new(92, 2));
+            }
+        }
+        let run = engine
+            .run_next_with(
+                |id, owner| {
+                    owner.admit_refresh_scope_for_test(id, &SourceBackedRefreshScope::All)?;
+                    if mismatch == "watermark" {
+                        owner
+                            .lock_state()
+                            .route_admission_watermarks
+                            .values_mut()
+                            .for_each(|routes| {
+                                routes.insert(route_identity(0x71), EventWatermark::new(92, 1));
+                            });
+                    }
+                    if mismatch == "absent_admission" {
+                        owner.lock_state().route_admission_watermarks.remove(id);
+                    }
+                    let mut publication = test_publication("generation");
+                    if mismatch != "omitted_outcome" {
+                        publication
+                            .route_results
+                            .push(if mismatch == "failed_outcome" {
+                                SourceBackedRefreshRouteResult::failed(
+                                    route_identity(0x71).as_str().to_owned(),
+                                    "unavailable".to_owned(),
+                                    false,
+                                )
+                            } else {
+                                SourceBackedRefreshRouteResult::succeeded(
+                                    route_identity(0x71).as_str().to_owned(),
+                                    true,
+                                )
+                            });
+                    }
+                    if mismatch == "extra_outcome" {
+                        publication
+                            .route_results
+                            .push(SourceBackedRefreshRouteResult::succeeded(
+                                route_identity(0x74).as_str().to_owned(),
+                                true,
+                            ));
+                    }
+                    Ok(publication)
+                },
+                || Ok(Some("generation".to_owned())),
+                |_| Ok(()),
+                |_| Ok(()),
+            )
+            .unwrap();
+        assert!(!run.failed, "{mismatch}: {:?}", run.job);
+        assert_eq!(
+            engine.status(peer.request_id()).unwrap()["request_state"],
+            "queued",
+            "{mismatch}"
+        );
+    }
+}
+
+#[test]
+fn queued_batch_terminal_partial_failure_keeps_pending_gate_and_restart_queue() {
+    for fail_at in [1, 2, 3] {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = CoreRefreshEngine::new();
+        let observation = "72".repeat(32);
+        let requests = (0..4)
+            .map(|_| queued_automatic(&engine, temp.path(), &observation))
+            .collect::<Vec<_>>();
+        let mut writes = 0;
+        let run = certified_run(
+            &engine,
+            "generation",
+            &observation,
+            |_| {},
+            |job| {
+                writes += 1;
+                if writes == fail_at {
+                    bail!("injected partial batch terminal failure");
+                }
+                engine.journal.store(temp.path(), job)
+            },
+        );
+        assert!(run.terminal_persistence_pending);
+        assert!(!run.did_work);
+        assert!(run.coverage_certificate().is_none());
+        let pending_id = requests[fail_at - 1].request_id();
+        let pending = engine.status(pending_id).unwrap();
+        assert_eq!(pending["request_state"], "running");
+        assert_eq!(pending["progress"]["phase"], "persisting_terminal");
+        assert!(pending.get("receipt").is_none());
+        assert!(pending.get("structured_outcome").is_none());
+        assert_eq!(
+            engine.status(requests[fail_at].request_id()).unwrap()["request_state"],
+            "queued"
+        );
+        let retry = engine
+            .run_next_with(
+                |_, _| panic!("persistence retry must not capture"),
+                || panic!("persistence retry must not reopen Core"),
+                |job| engine.journal.store(temp.path(), job),
+                |_| Ok(()),
+            )
+            .unwrap();
+        assert!(!retry.terminal_persistence_pending);
+        assert_eq!(retry.job["request_id"], pending_id);
+        assert_eq!(
+            engine.status(pending_id).unwrap()["request_state"],
+            "published"
+        );
+        let restarted = super::super::super::CoreRefreshEngine::with_journal_for_test(
+            Arc::clone(&engine.journal),
+            test_refresh_runtime(),
+            Arc::new(|_: SourceBackedRefreshExecution<'_>| panic!("restart must not execute")),
+        );
+        assert!(restarted
+            .recover_interrupted_publication(temp.path())
+            .unwrap());
+        assert_eq!(
+            restarted.status(pending_id).unwrap()["request_state"],
+            "published"
+        );
+        for request in &requests[fail_at..] {
+            assert_eq!(
+                restarted.status(request.request_id()).unwrap()["request_state"],
+                "admission_pending"
+            );
+        }
+    }
+}
+
+#[test]
+fn queued_batch_failed_capture_leaves_peers_for_their_own_attempt() {
+    let temp = tempfile::tempdir().unwrap();
+    let engine = CoreRefreshEngine::new();
+    let observation = "72".repeat(32);
+    queued_automatic(&engine, temp.path(), &observation);
+    let peer = queued_automatic(&engine, temp.path(), &observation);
+    let run = engine
+        .run_next_with(
+            |_, _| Err(anyhow!("capture failed")),
+            || Ok(None),
+            |_| Ok(()),
+            |_| Ok(()),
+        )
+        .unwrap();
+    assert!(run.failed);
+    assert_eq!(
+        engine.status(peer.request_id()).unwrap()["request_state"],
+        "queued"
+    );
+}
+
+#[test]
+fn queued_batch_production_run_resolves_pending_peers_and_pins_one_publication() {
+    let temp = tempfile::tempdir().unwrap();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let counted = Arc::clone(&calls);
+    let engine = CoreRefreshEngine::with_executor_and_admitted_routes(
+        Arc::new(move |execution: SourceBackedRefreshExecution<'_>| {
+            counted.fetch_add(1, Ordering::SeqCst);
+            publish_pin_fixture(&execution, false)
+        }),
+        [route_identity(0x71)],
+    );
+    let requests = (0..4)
+        .map(|_| submit_automatic(&engine, temp.path()))
+        .collect::<Vec<_>>();
+    let run = engine.run_next(temp.path()).unwrap();
+    assert_eq!(run.job["certified_source_count"], 1);
+    assert_eq!(
+        run.coverage_certificate()
+            .unwrap()
+            .exact_route_boundaries()
+            .len(),
+        0
+    );
+    assert!(!run.failed, "{:?}", run.job);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert!(!engine.has_pending_request());
+    let pinned = engine.pinned_core_publication().unwrap();
+    for request in requests {
+        let status = engine.status(request.request_id()).unwrap();
+        assert_eq!(status["request_state"], "published");
+        assert_eq!(status["published_generation"], pinned.generation_id());
+        assert_eq!(
+            status["receipt"]["published_generation"],
+            pinned.generation_id()
+        );
+    }
+}
+
+#[test]
+fn queued_batch_follower_admission_failure_keeps_the_root_and_pending_peer() {
+    let temp = tempfile::tempdir().unwrap();
+    let journal = Arc::new(TestRefreshJournal::default());
+    let engine = CoreRefreshEngine(
+        super::super::super::CoreRefreshEngine::with_runtime_for_test(
+            journal.clone(),
+            test_refresh_runtime(),
+            Arc::new(|_: SourceBackedRefreshExecution<'_>| panic!("static admission witness")),
+            Arc::new(|_, _, _, _| Err(anyhow!("follower discovery failed"))),
+        ),
+    );
+    let root = queued_automatic(&engine, temp.path(), &"72".repeat(32));
+    let peer = submit_automatic(&engine, temp.path());
+    engine.prepare_queued_batch_admissions(temp.path());
+    assert_eq!(
+        engine.status(root.request_id()).unwrap()["request_state"],
+        "queued"
+    );
+    assert_eq!(
+        engine.status(peer.request_id()).unwrap()["request_state"],
+        "admission_pending"
+    );
+    let stored = journal.load(temp.path()).unwrap().unwrap();
+    assert_eq!(stored["request_id"], root.request_id());
+    assert_eq!(
+        stored["queued_successors"][0]["request_id"],
+        peer.request_id()
+    );
+    assert_eq!(
+        stored["queued_successors"][0]["request_state"],
+        "admission_pending"
+    );
+    assert!(!engine
+        .lock_state()
+        .admission_resolutions_in_flight
+        .contains(peer.request_id()));
+    certified_run(
+        &engine,
+        "generation",
+        &"72".repeat(32),
+        |_| {},
+        |job| journal.store(temp.path(), job),
+    );
+    let failure = engine
+        .resolve_pending_admission(temp.path())
+        .unwrap()
+        .unwrap();
+    assert!(failure.failed);
+    assert_eq!(failure.job["request_id"], peer.request_id());
+    assert!(!engine.has_pending_request());
+}
+
+#[test]
+fn queued_batch_restart_retains_all_admissions_but_only_last_drained_terminal() {
+    let temp = tempfile::tempdir().unwrap();
+    let engine = CoreRefreshEngine::new();
+    let observation = "72".repeat(32);
+    let requests = (0..SOURCE_REFRESH_ACTIVE_PENDING_LIMIT)
+        .map(|_| queued_automatic(&engine, temp.path(), &observation))
+        .collect::<Vec<_>>();
+    let before = engine.journal.load(temp.path()).unwrap().unwrap();
+    let before_journal = Arc::new(TestRefreshJournal::default());
+    before_journal.store(temp.path(), &before).unwrap();
+    let before_restart = super::super::super::CoreRefreshEngine::with_journal_for_test(
+        before_journal,
+        test_refresh_runtime(),
+        Arc::new(|_: SourceBackedRefreshExecution<'_>| panic!("restart does not capture")),
+    );
+    assert!(before_restart
+        .recover_interrupted_publication(temp.path())
+        .unwrap());
+    for request in &requests {
+        let status = before_restart.status(request.request_id()).unwrap();
+        assert_eq!(status["request_state"], "admission_pending");
+        assert_eq!(
+            status["request_fingerprint"],
+            engine.status(request.request_id()).unwrap()["request_fingerprint"]
+        );
+    }
+    certified_run(
+        &engine,
+        "generation",
+        &observation,
+        |_| {},
+        |job| engine.journal.store(temp.path(), job),
+    );
+    let after_restart = super::super::super::CoreRefreshEngine::with_journal_for_test(
+        Arc::clone(&engine.journal),
+        test_refresh_runtime(),
+        Arc::new(|_: SourceBackedRefreshExecution<'_>| panic!("restart does not capture")),
+    );
+    assert!(!after_restart
+        .recover_interrupted_publication(temp.path())
+        .unwrap());
+    for request in &requests[..requests.len() - 1] {
+        assert!(after_restart.status(request.request_id()).is_none());
+    }
+    assert_eq!(
+        after_restart
+            .status(requests.last().unwrap().request_id())
+            .unwrap()["request_state"],
+        "published"
+    );
+}

--- a/crates/ctx-history-refresh/src/engine/tests/request_coalescing.rs
+++ b/crates/ctx-history-refresh/src/engine/tests/request_coalescing.rs
@@ -31,7 +31,7 @@ fn enqueue_ordinary_attempt(
 }
 
 #[test]
-fn setup_refresh_claims_periodic_and_search_attempts_without_ordinary_overwrite() {
+fn setup_refresh_retains_its_identity_beside_internal_maintenance() {
     for ordinary in ["periodic", "search"] {
         let temp = tempfile::tempdir().unwrap();
         let data_root = temp.path().join("data");
@@ -40,14 +40,12 @@ fn setup_refresh_claims_periodic_and_search_attempts_without_ordinary_overwrite(
         let initial = enqueue_ordinary_attempt(&coordinator, &data_root, ordinary);
         let physical_request_id = request_id(&initial);
 
-        let claimed = coordinator
-            .submit(
-                &data_root,
-                command_refresh_submission(RefreshRequestTrigger::Setup, false),
-            )
-            .unwrap();
-        assert_eq!(claimed.status()["request_id"], physical_request_id);
-        let claimed = status_value(&coordinator, &physical_request_id);
+        let setup = command_refresh_submission(RefreshRequestTrigger::Setup, false);
+        let setup_id = setup.request_id().to_owned();
+        let claimed = coordinator.submit(&data_root, setup).unwrap();
+        assert_eq!(claimed.status()["request_id"], setup_id);
+        assert_ne!(setup_id, physical_request_id);
+        let claimed = status_value(&coordinator, &setup_id);
         assert_eq!(claimed["operation"], "refresh");
         assert_eq!(claimed["trigger"], "setup");
         assert_eq!(claimed["trigger_provenance"], "setup_command");
@@ -59,7 +57,7 @@ fn setup_refresh_claims_periodic_and_search_attempts_without_ordinary_overwrite(
                 command_refresh_submission(RefreshRequestTrigger::Search, false),
             )
             .unwrap();
-        let retained = status_value(&coordinator, &physical_request_id);
+        let retained = status_value(&coordinator, &setup_id);
         assert_eq!(retained["trigger"], "setup");
         assert_eq!(retained["trigger_provenance"], "setup_command");
     }
@@ -250,7 +248,7 @@ fn concurrent_refresh_request_uses_active_generation_without_reopening_inflight_
     std::fs::create_dir_all(&inactive).unwrap();
     std::fs::write(inactive.join("meta.json"), b"in-flight metadata").unwrap();
 
-    let coalesced = coordinator
+    let admitted = coordinator
         .handle_ipc_request(
             temp.path(),
             &json!({
@@ -260,10 +258,13 @@ fn concurrent_refresh_request_uses_active_generation_without_reopening_inflight_
             }),
         )
         .unwrap()
-        .expect("coalesced refresh response");
-    assert_eq!(coalesced["request_id"], request["request_id"]);
-    assert_eq!(coalesced["coalesced_requests"], 1);
+        .expect("distinct refresh response");
+    assert_ne!(admitted["request_id"], request["request_id"]);
+    assert_eq!(admitted["coalesced_requests"], 0);
 }
+
+#[path = "queued_batch.rs"]
+mod queued_batch_tests;
 
 #[test]
 fn selected_import_requests_remain_distinct_before_execution() {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -744,7 +744,12 @@ ctx search "incident follow-up" --source-group work
 
 `search` defaults to `--refresh background`, which serves the published
 Tantivy generation. In automatic indexing mode it may start or wake the
-persistent daemon for lexical publication and optional semantic catch-up. In
+persistent daemon for lexical publication and optional semantic catch-up.
+Each accepted refresh keeps its own durable request ID. If the automatic
+refresh queue is full, background search can still read an existing generation;
+JSON freshness reports `admission_rejected` with no accepted request ID or
+publication receipt. This does not apply to `--refresh wait`, explicit import,
+or a search with no readable generation: those requests fail on overload. In
 manual mode, background refresh uses only the last published generation and
 does not contact, start, or wake a ctx daemon or worker; there is no hidden foreground
 bootstrap or importer. A direct CLI semantic or hybrid query may read an


### PR DESCRIPTION
Concurrent refresh callers could receive another caller's ID, and automatic background responses could appear accepted without a durable request. Each accepted caller now retains its original identity. Compatible callers admitted before a full-catalog capture share its verified publication, with durable completion recorded separately for each caller.

A strictly typed forgotten response permits one retry with the original ID and parameters. Optional background search can read an existing committed generation when the eight-request queue is full, reporting `admission_rejected` without an accepted ID or receipt. Wait/import and searches without a readable generation still fail on overload; malformed or unconfirmed responses remain errors. Setup reports active background work as pending when its captured freshness is pending.

Validation: `bash scripts/check.sh --mode=ci` passed the physical Rust crate-size preflight, Clippy build, and all 211 CI test targets (207 executed, four cached). Owning regressions cover real discovered-source captures, distinct caller IDs, late appends and generation pins, persistence failures and restart, bounded recovery, overload, and setup readiness. Durable admission adds per-caller persistence work; restart can repeat physical work within the existing receipt-retention bounds.
