### PR TITLE
Remove generic locality fields from status and all seven SDKs

### DIFF
--- a/contracts/agent-history-v1/README.md
+++ b/contracts/agent-history-v1/README.md
@@ -21,7 +21,23 @@ release tooling, or raw Rust crate shapes as their public API.
 - Current schema version: `1`
 - SDKs expose their own SDK version separately from `contractVersion`.
 - Unknown JSON fields are additive and must be ignored or preserved.
-- Required fields can only change in a future contract id.
+- Required fields normally change only in a future contract id. The removal
+  below is a breaking exception while this in-repo SDK contract is experimental.
+
+The generic status property `localOnly` has been removed from all seven SDKs,
+including `status()` and `init()` responses. Callers must remove reads,
+constructor arguments, and required-field checks for this property. The contract
+id remains `agent-history-v1` and `schemaVersion` remains `1`; this change is not
+backward compatible with callers that require the old property. SDK normalizers
+also discard top-level `localOnly` and `local_only` from older status payloads.
+Nested semantic diagnostics and opaque event data remain intact.
+
+CLI status and setup JSON now use `schema_version: 3`; generic usage/error,
+index, and daemon command envelopes use `schema_version: 2`. Readers that check
+these versions must update their accepted versions and stop requiring the
+removed generic field. Semantic-only execution diagnostics, standalone stats,
+uninstall receipts, and stored visibility/sync values have separate contracts
+and retain their locality fields.
 
 ## Public Operations
 

--- a/contracts/agent-history-v1/fixtures/cli/opaque-event.json
+++ b/contracts/agent-history-v1/fixtures/cli/opaque-event.json
@@ -3,6 +3,8 @@
   "ctx_session_id": "session-1",
   "text": "body",
   "structured_content": {
+    "local_only": false,
+    "localOnly": null,
     "customer_id": 7,
     "customerId": 9,
     "target": "orders",
@@ -31,6 +33,8 @@
       "arguments": {
         "capture_status": "present",
         "value": {
+          "local_only": false,
+          "localOnly": null,
           "customer_id": 7,
           "customerId": 9,
           "target": "orders",
@@ -59,6 +63,8 @@
       "structured_content": {
         "capture_status": "present",
         "value": {
+          "local_only": false,
+          "localOnly": null,
           "customer_id": 7,
           "customerId": 9,
           "target": "orders",

--- a/contracts/agent-history-v1/fixtures/init.success.json
+++ b/contracts/agent-history-v1/fixtures/init.success.json
@@ -8,7 +8,6 @@
   },
   "status": {
     "initialized": true,
-    "localOnly": true,
     "dataRoot": "/tmp/ctx-sdk-fixture",
     "indexedItems": 0,
     "indexedSessions": 0,

--- a/contracts/agent-history-v1/fixtures/status.counter-boundary.json
+++ b/contracts/agent-history-v1/fixtures/status.counter-boundary.json
@@ -8,7 +8,6 @@
   },
   "status": {
     "initialized": true,
-    "localOnly": true,
     "dataRoot": "/tmp/ctx-sdk-fixture",
     "indexedItems": 9007199254740991,
     "indexedSessions": 9007199254740991,

--- a/contracts/agent-history-v1/fixtures/status.ready.json
+++ b/contracts/agent-history-v1/fixtures/status.ready.json
@@ -8,7 +8,6 @@
   },
   "status": {
     "initialized": true,
-    "localOnly": true,
     "readOnly": true,
     "dataRoot": "/tmp/ctx-sdk-fixture",
     "indexedItems": 3,

--- a/contracts/agent-history-v1/schema.json
+++ b/contracts/agent-history-v1/schema.json
@@ -45,10 +45,9 @@
     },
     "status": {
       "type": "object",
-      "required": ["initialized", "localOnly"],
+      "required": ["initialized"],
       "properties": {
         "initialized": { "type": "boolean" },
-        "localOnly": { "type": "boolean" },
         "readOnly": { "type": "boolean" },
         "dataRoot": { "type": ["string", "null"] },
         "indexedItems": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 },

--- a/crates/ctx-agent-application/tests/contracts/mcp.rs
+++ b/crates/ctx-agent-application/tests/contracts/mcp.rs
@@ -277,7 +277,9 @@ fn mcp_startup_health_checks_enabled_daemon_before_status_and_tools_list() {
         })
     );
     let status = &responses[2]["result"]["structuredContent"];
-    assert_eq!(status["schema_version"], 2);
+    assert_eq!(status["schema_version"], 3);
+    assert!(status.get("local_only").is_none());
+    assert!(status.get("localOnly").is_none());
     let initialized = status["initialized"].as_bool().expect("initialized flag");
     assert!(
         status["indexed_sessions"].is_null() || status["indexed_sessions"] == 0,
@@ -320,6 +322,9 @@ fn mcp_startup_health_checks_enabled_daemon_before_status_and_tools_list() {
     assert_eq!(status["daemon"]["core_refresh_endpoint"]["available"], true);
     assert_eq!(status["daemon"]["start_mode"], "auto");
     assert_eq!(status["daemon"]["supervisor"]["status"], "fallback");
+    assert!(!responses[2]["result"]["content"]
+        .to_string()
+        .contains("local_only:"));
     let initialized_text = format!("initialized: {initialized}");
     assert_useful_mcp_text(
         &responses[2]["result"],
@@ -330,7 +335,6 @@ fn mcp_startup_health_checks_enabled_daemon_before_status_and_tools_list() {
             "lexical: status=",
             "source_refresh: status=",
             "read_only: true",
-            "local_only: true",
             "semantic: status=disabled",
             "flat_f32: status=",
             "semantic_path:",

--- a/crates/ctx-agent-application/tests/contracts/mcp/input_validation.rs
+++ b/crates/ctx-agent-application/tests/contracts/mcp/input_validation.rs
@@ -210,7 +210,7 @@ fn mcp_tool_input_validation_returns_stable_invalid_request_and_server_recovers(
 
     let recovered = &responses[cases.len() + 2]["result"];
     assert!(recovered["isError"].is_null());
-    assert_eq!(recovered["structuredContent"]["schema_version"], 2);
+    assert_eq!(recovered["structuredContent"]["schema_version"], 3);
     assert_eq!(recovered["structuredContent"]["read_only"], true);
 }
 

--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration/additional.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/import_orchestration/additional.rs
@@ -703,7 +703,7 @@ fn fresh_setup_publishes_provider_sources_to_core() {
 
     let setup = ready_setup(&temp);
 
-    assert_eq!(setup["schema_version"], 2, "{setup:#}");
+    assert_eq!(setup["schema_version"], 3, "{setup:#}");
     assert_eq!(setup["mode"], "ready", "{setup:#}");
     assert_eq!(setup["history_epoch"]["status"], "ready", "{setup:#}");
     assert_eq!(setup["lexical"]["status"], "ready", "{setup:#}");
@@ -739,7 +739,7 @@ fn mixed_setup_publishes_each_provider_once() {
     let _daemon = start_full_source_refresh_daemon(&temp);
 
     let setup = ready_setup(&temp);
-    assert_eq!(setup["schema_version"], 2, "{setup:#}");
+    assert_eq!(setup["schema_version"], 3, "{setup:#}");
     assert_eq!(setup["mode"], "ready", "{setup:#}");
     assert_eq!(setup["refresh_request"]["status"], "published", "{setup:#}");
     assert_eq!(setup["refresh_request"]["source_count"], 2, "{setup:#}");

--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle.rs
@@ -771,9 +771,10 @@ fn status_missing_source_epoch_is_read_only_and_does_not_initialize_files() {
             .args(["status", "--format=json"])
             .env("CTX_DATA_ROOT", &data_root),
     );
-    assert_eq!(status["schema_version"], 2);
+    assert_eq!(status["schema_version"], 3);
     assert_eq!(status["initialized"], false);
-    assert_eq!(status["local_only"], true);
+    assert!(status.get("local_only").is_none());
+    assert!(status.get("localOnly").is_none());
     assert_eq!(status["read_only"], true);
     assert_eq!(status["history_epoch"]["status"], "unavailable");
     assert_eq!(
@@ -851,7 +852,9 @@ fn setup_wait_publishes_setup_status_contract() {
 
     let setup =
         json_output(ctx(&temp).args(["setup", "--wait", "--format=json", "--progress", "none"]));
-    assert_eq!(setup["schema_version"], 2, "{setup:#}");
+    assert_eq!(setup["schema_version"], 3, "{setup:#}");
+    assert!(setup.get("local_only").is_none());
+    assert!(setup.get("localOnly").is_none());
     assert_eq!(setup["deprecated_catalog_only_ignored"], false, "{setup:#}");
     assert!(setup.get("read_only").is_none(), "{setup:#}");
     assert_eq!(setup["mode"], "ready", "{setup:#}");
@@ -911,7 +914,9 @@ fn quiet_setup_suppresses_success_output_but_not_json() {
     let temp = daemon_test_root();
     let setup =
         json_output(ctx(&temp).args(["--quiet", "setup", "--format=json", "--progress", "none"]));
-    assert_eq!(setup["schema_version"], 2);
+    assert_eq!(setup["schema_version"], 3);
+    assert!(setup.get("local_only").is_none());
+    assert!(setup.get("localOnly").is_none());
     assert_eq!(setup["deprecated_catalog_only_ignored"], false, "{setup:#}");
 }
 
@@ -945,7 +950,7 @@ fn quiet_status_suppresses_success_output_but_not_json() {
         .stdout(predicate::str::contains("History status: failed"));
 
     let status = json_output(ctx(&temp).args(["--quiet", "status", "--format=json"]));
-    assert_eq!(status["schema_version"], 2);
+    assert_eq!(status["schema_version"], 3);
     assert_eq!(status["initialized"], false);
     assert!(status["inventory_source_bytes"].is_null());
     assert!(status["lexical_index_estimate_seconds"].is_null());
@@ -957,7 +962,9 @@ fn setup_background_refresh_and_wait_publish_the_same_codex_source() {
     write_codex_setup_session(&temp);
 
     let setup = json_output(ctx(&temp).args(["setup", "--format=json", "--progress", "none"]));
-    assert_eq!(setup["schema_version"], 2, "{setup:#}");
+    assert_eq!(setup["schema_version"], 3, "{setup:#}");
+    assert!(setup.get("local_only").is_none());
+    assert!(setup.get("localOnly").is_none());
     assert_eq!(setup["daemon_autostart"]["requested"], true, "{setup:#}");
     assert!(
         matches!(
@@ -1043,7 +1050,9 @@ fn setup_no_daemon_is_one_run_opt_out_and_keeps_semantic_disabled() {
         "--progress",
         "none",
     ]));
-    assert_eq!(setup["schema_version"], 2, "{setup:#}");
+    assert_eq!(setup["schema_version"], 3, "{setup:#}");
+    assert!(setup.get("local_only").is_none());
+    assert!(setup.get("localOnly").is_none());
     assert_eq!(setup["deprecated_catalog_only_ignored"], false, "{setup:#}");
     assert!(setup.get("background_indexing").is_none(), "{setup:#}");
     assert_eq!(
@@ -1131,7 +1140,9 @@ fn setup_all_invalid_source_publishes_a_verified_empty_generation() {
 
     let setup =
         json_output(ctx(&temp).args(["setup", "--wait", "--format=json", "--progress", "none"]));
-    assert_eq!(setup["schema_version"], 2, "{setup:#}");
+    assert_eq!(setup["schema_version"], 3, "{setup:#}");
+    assert!(setup.get("local_only").is_none());
+    assert!(setup.get("localOnly").is_none());
     assert_eq!(setup["mode"], "ready", "{setup:#}");
     assert_eq!(setup["lexical"]["certified_sources"], 1, "{setup:#}");
     assert_eq!(setup["lexical"]["indexed_documents"], 0, "{setup:#}");

--- a/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle/additional.rs
+++ b/crates/ctx-cli-contract-tests/tests/contracts/setup_sources_import/lifecycle/additional.rs
@@ -52,7 +52,9 @@ fn installer_style_setup_succeeds_with_a_genuinely_empty_source_catalog() {
     let temp = daemon_test_root();
 
     let setup = json_output(ctx(&temp).args(["setup", "--format=json", "--progress", "none"]));
-    assert_eq!(setup["schema_version"], 2, "{setup:#}");
+    assert_eq!(setup["schema_version"], 3, "{setup:#}");
+    assert!(setup.get("local_only").is_none());
+    assert!(setup.get("localOnly").is_none());
     assert_empty_catalog_default_background_setup(&setup);
 
     let status = json_output(ctx(&temp).args(["status", "--format=json"]));
@@ -299,7 +301,9 @@ fn machine_readable_setup_uses_v2_top_level_persistent_daemon_contract() {
     let temp = daemon_test_root();
 
     let setup = json_output(ctx(&temp).args(["setup", "--format=json", "--progress", "none"]));
-    assert_eq!(setup["schema_version"], 2, "{setup:#}");
+    assert_eq!(setup["schema_version"], 3, "{setup:#}");
+    assert!(setup.get("local_only").is_none());
+    assert!(setup.get("localOnly").is_none());
     assert!(setup.get("background_indexing").is_none(), "{setup:#}");
     assert_eq!(setup["daemon_autostart"]["status"], "degraded", "{setup:#}");
     assert_eq!(setup["daemon_autostart"]["requested"], true, "{setup:#}");
@@ -358,7 +362,7 @@ fn setup_wait_progress_json_uses_stderr_and_keeps_final_json_on_stdout() {
         .clone();
 
     let stdout: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(stdout["schema_version"], 2, "{stdout:#}");
+    assert_eq!(stdout["schema_version"], 3, "{stdout:#}");
     let events = String::from_utf8(output.stderr)
         .unwrap()
         .lines()
@@ -759,7 +763,9 @@ fn clean_multisource_setup_imports_hermes_and_preserves_source_bytes() {
         .to_owned();
     let status = wait_for_core_generation(&temp, &generation);
 
-    assert_eq!(setup["schema_version"], 2, "{setup:#}");
+    assert_eq!(setup["schema_version"], 3, "{setup:#}");
+    assert!(setup.get("local_only").is_none());
+    assert!(setup.get("localOnly").is_none());
     assert_eq!(setup["mode"], "ready", "{setup:#}");
     assert_eq!(status["lexical"]["generation_id"], generation, "{status:#}");
     assert!(status.get("relational").is_none(), "{status:#}");

--- a/crates/ctx-cli-presentation/src/commands/index.rs
+++ b/crates/ctx-cli-presentation/src/commands/index.rs
@@ -642,16 +642,14 @@ fn index_wait_json(
     wait_status: &str,
     read_only: bool,
 ) -> Value {
-    let local_only = status["local_only"].as_bool().unwrap_or(true);
     compact_json(json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "status": wait_status,
         "selection": {
             "lexical": selection.lexical,
             "semantic": selection.semantic,
         },
         "readiness": status,
-        "local_only": local_only,
         "read_only": read_only,
     }))
 }

--- a/crates/ctx-cli-presentation/src/commands/index_tests.rs
+++ b/crates/ctx-cli-presentation/src/commands/index_tests.rs
@@ -14,7 +14,7 @@ fn readiness(
     daemon_running: bool,
 ) -> serde_json::Value {
     let mut status = json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "initialized": true,
         "lexical": {
             "status": "ready",
@@ -67,7 +67,6 @@ fn readiness(
             "running": daemon_running,
             "jobs": {"semantic_index": {"status": "disabled"}},
         },
-        "local_only": true,
         "read_only": true,
     });
     if refresh_status != "ready" {

--- a/crates/ctx-cli-presentation/src/commands/status_usage.rs
+++ b/crates/ctx-cli-presentation/src/commands/status_usage.rs
@@ -23,31 +23,28 @@ pub fn compact_usage_health_json(report: &UsageReport) -> Value {
 
 pub fn malformed_status_config_json() -> Value {
     json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "local_usage": compact_usage_health_json(&local_usage::UsageReport::config_error()),
-        "local_only": true,
         "read_only": true,
     })
 }
 
 pub fn removed_cloud_config_json() -> Value {
     json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "error": {
             "code": "removed_config_key",
             "config_key": "cloud.mode",
             "message": "cloud history configuration is no longer supported",
         },
-        "local_only": true,
         "read_only": true,
     })
 }
 
 pub fn usage_action_json(action: &Map<String, Value>) -> Value {
     json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "local_usage_action": action,
-        "local_only": true,
         "read_only": false,
     })
 }
@@ -58,7 +55,7 @@ pub fn usage_action_error_json(
     message: &'static str,
 ) -> Value {
     json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "local_usage_action": {
             "action": mode.as_str(),
             "ok": false,
@@ -67,7 +64,6 @@ pub fn usage_action_error_json(
                 "message": message,
             },
         },
-        "local_only": true,
         "read_only": false,
     })
 }
@@ -220,6 +216,26 @@ mod tests {
     }
 
     #[test]
+    fn generic_status_usage_and_error_producers_omit_locality() {
+        let outputs = [
+            malformed_status_config_json(),
+            removed_cloud_config_json(),
+            usage_action_json(&action(json!({"action": "enable", "ok": true}))),
+            usage_action_error_json(UsageStatusMode::Enable, "config_error", "invalid config"),
+        ];
+        for output in outputs {
+            assert!(output.get("local_only").is_none(), "{output}");
+            assert!(output.get("localOnly").is_none(), "{output}");
+            assert_eq!(output["schema_version"], 2);
+            assert!(output["read_only"].is_boolean());
+        }
+        assert_eq!(
+            malformed_status_config_json()["local_usage"]["schema_version"],
+            3
+        );
+    }
+
+    #[test]
     fn usage_actions_are_outcome_first_and_hide_machine_field_names() {
         let cases = [
             (
@@ -309,7 +325,7 @@ mod tests {
         assert_eq!(
             malformed_status_config_json(),
             json!({
-                "schema_version": 1,
+                "schema_version": 2,
                 "local_usage": {
                     "schema_version": 3,
                     "enabled": false,
@@ -321,7 +337,6 @@ mod tests {
                         "message": "local usage configuration could not be read",
                     },
                 },
-                "local_only": true,
                 "read_only": true,
             })
         );
@@ -357,7 +372,7 @@ mod tests {
         assert_eq!(
             usage_action_json(&success),
             json!({
-                "schema_version": 1,
+                "schema_version": 2,
                 "local_usage_action": {
                     "action": "enable",
                     "ok": true,
@@ -365,7 +380,6 @@ mod tests {
                     "effective_enabled": true,
                     "environment_override": "none",
                 },
-                "local_only": true,
                 "read_only": false,
             })
         );
@@ -376,7 +390,7 @@ mod tests {
                 "local usage could not be reset",
             ),
             json!({
-                "schema_version": 1,
+                "schema_version": 2,
                 "local_usage_action": {
                     "action": "reset",
                     "ok": false,
@@ -385,7 +399,6 @@ mod tests {
                         "message": "local usage could not be reset",
                     },
                 },
-                "local_only": true,
                 "read_only": false,
             })
         );

--- a/crates/ctx-cli-presentation/src/mcp_text.rs
+++ b/crates/ctx-cli-presentation/src/mcp_text.rs
@@ -72,7 +72,6 @@ fn render_status_text(value: &Value) -> String {
         );
     }
     push_key_value(&mut out, "read_only", value.get("read_only"));
-    push_key_value(&mut out, "local_only", value.get("local_only"));
     push_status_semantic_summary(&mut out, value.get("semantic"));
     push_status_daemon_summary(&mut out, value.get("daemon"));
     out

--- a/crates/ctx-cli-qualification/tests/index.rs
+++ b/crates/ctx-cli-qualification/tests/index.rs
@@ -98,13 +98,18 @@ fn index_status_and_mode_have_one_coherent_public_surface() {
     let temp = daemon_test_root();
 
     let status = json_output(ctx(&temp).args(["index", "--format=json"]));
+    assert_eq!(status["schema_version"], 2);
     assert_eq!(status["indexing"]["mode"], "auto");
-    assert_eq!(status["local_only"], true);
+    assert!(status.get("local_only").is_none());
+    assert!(status.get("localOnly").is_none());
     assert_eq!(status["read_only"], true);
 
     let default_mode = json_output(ctx(&temp).args(["index", "--format=json", "mode"]));
     assert_eq!(default_mode["indexing"]["mode"], "auto");
     assert_eq!(default_mode["read_only"], true);
+    assert_eq!(default_mode["schema_version"], 2);
+    assert!(default_mode.get("local_only").is_none());
+    assert!(default_mode.get("localOnly").is_none());
     assert!(!data_root(&temp).join("config.toml").exists());
 
     let manual = json_output(ctx(&temp).args(["index", "mode", "manual", "--format=json"]));
@@ -117,6 +122,22 @@ fn index_status_and_mode_have_one_coherent_public_surface() {
     let current = json_output(ctx(&temp).args(["index", "mode", "--format=json"]));
     assert_eq!(current["indexing"]["mode"], "manual");
     assert_eq!(current["read_only"], true);
+}
+
+#[test]
+fn generic_daemon_receipts_omit_locality() {
+    let temp = daemon_test_root();
+    for command in ["status", "enable", "disable"] {
+        // The fixture owns this override: test each receipt without installing supervision.
+        let output = json_output(
+            ctx(&temp)
+                .args(["daemon", command, "--format=json"])
+                .env("CTX_DAEMON_ENABLED", "false"),
+        );
+        assert_eq!(output["schema_version"], 2, "{output}");
+        assert!(output.get("local_only").is_none(), "{output}");
+        assert!(output.get("localOnly").is_none(), "{output}");
+    }
 }
 
 #[test]
@@ -399,7 +420,7 @@ fn index_wait_lexical_reports_ready_after_import() {
         "--interval-seconds",
         "1",
     ]));
-    assert_eq!(wait["schema_version"], 1);
+    assert_eq!(wait["schema_version"], 2);
     assert_eq!(wait["status"], "ready");
     assert_eq!(wait["selection"]["lexical"], true);
     assert_eq!(wait["selection"]["semantic"], false);
@@ -410,7 +431,8 @@ fn index_wait_lexical_reports_ready_after_import() {
             .unwrap()
             > 0
     );
-    assert_eq!(wait["local_only"], true);
+    assert!(wait.get("local_only").is_none());
+    assert!(wait.get("localOnly").is_none());
     assert_eq!(wait["read_only"], true);
 }
 
@@ -556,7 +578,7 @@ fn index_wait_default_skips_semantic_when_disabled_after_import() {
         "--interval-seconds",
         "1",
     ]));
-    assert_eq!(wait["schema_version"], 1);
+    assert_eq!(wait["schema_version"], 2);
     assert_eq!(wait["status"], "ready");
     assert_eq!(wait["selection"]["lexical"], true);
     assert_eq!(wait["selection"]["semantic"], false);
@@ -613,7 +635,7 @@ fn index_wait_semantic_stays_strict_when_semantic_is_disabled() {
         .clone();
     let stdout: Value = serde_json::from_slice(&output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
-    assert_eq!(stdout["schema_version"], 1);
+    assert_eq!(stdout["schema_version"], 2);
     assert_eq!(stdout["status"], "blocked");
     assert_eq!(stdout["selection"]["lexical"], false);
     assert_eq!(stdout["selection"]["semantic"], true);
@@ -643,7 +665,7 @@ fn index_wait_all_stays_strict_when_semantic_is_disabled() {
         .clone();
     let stdout: Value = serde_json::from_slice(&output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
-    assert_eq!(stdout["schema_version"], 1);
+    assert_eq!(stdout["schema_version"], 2);
     assert_eq!(stdout["status"], "blocked");
     assert_eq!(stdout["selection"]["lexical"], true);
     assert_eq!(stdout["selection"]["semantic"], true);

--- a/crates/ctx-cli/src/commands/index.rs
+++ b/crates/ctx-cli/src/commands/index.rs
@@ -76,12 +76,11 @@ fn index_mode_report(
     update: Option<ctx_daemon_cli::IndexingModeUpdate>,
 ) -> Value {
     let mut report = json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "indexing": {
             "mode": mode,
         },
         "config_path": data_root.join(CONFIG_FILE),
-        "local_only": true,
         "read_only": update.is_none(),
     });
     if let Some(requested_mode) = requested_mode {
@@ -107,7 +106,7 @@ fn index_readiness_snapshot(data_root: &Path) -> Result<Value> {
     let semantic_flat = &source_semantic["flat_f32"];
     let source_daemon = &source.report["daemon"];
     Ok(compact_json(json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "initialized": source.initialized,
         "indexing": {
             "mode": config.indexing.mode.as_str(),
@@ -155,7 +154,6 @@ fn index_readiness_snapshot(data_root: &Path) -> Result<Value> {
                 "semantic_index": source_daemon.get("jobs").and_then(|jobs| jobs.get("semantic_index")),
             },
         },
-        "local_only": true,
         "read_only": true,
     })))
 }

--- a/crates/ctx-cli/tests/status_store_cutover.rs
+++ b/crates/ctx-cli/tests/status_store_cutover.rs
@@ -12,7 +12,7 @@ fn pristine_status_doctor_and_mcp_status_create_nothing() {
             .args(["status", "--format=json"])
             .env("CTX_DATA_ROOT", &data_root),
     );
-    assert_eq!(status["schema_version"], 2);
+    assert_eq!(status["schema_version"], 3);
     assert_eq!(status["indexing"]["mode"], "auto");
     assert_eq!(status["initialized"], false);
     assert_eq!(
@@ -31,7 +31,7 @@ fn pristine_status_doctor_and_mcp_status_create_nothing() {
             .env("CTX_DATA_ROOT", &data_root),
     );
     assert_eq!(doctor["schema_version"], 1);
-    assert_eq!(doctor["source_epoch"]["schema_version"], 2);
+    assert_eq!(doctor["source_epoch"]["schema_version"], 3);
     assert!(!data_root.exists(), "doctor created a pristine data root");
 
     let data_root_text = data_root.to_string_lossy().into_owned();
@@ -58,7 +58,11 @@ fn pristine_status_doctor_and_mcp_status_create_nothing() {
         &[("CTX_DATA_ROOT", data_root_text.as_str())],
     );
     let mcp_status = &responses[1]["result"]["structuredContent"];
-    assert_eq!(mcp_status["schema_version"], 2);
+    assert_eq!(mcp_status["schema_version"], 3);
+    for report in [&status, &doctor["source_epoch"], mcp_status] {
+        assert!(report.get("local_only").is_none(), "{report}");
+        assert!(report.get("localOnly").is_none(), "{report}");
+    }
     assert!(
         !data_root.exists(),
         "MCP status created a pristine data root"

--- a/crates/ctx-daemon-cli/src/daemon/control.rs
+++ b/crates/ctx-daemon-cli/src/daemon/control.rs
@@ -61,9 +61,8 @@ pub(super) fn run_daemon_status(
         super::super::paths_status::daemon_report_with_application(application, &data_root, true);
     if args.format.is_json() {
         print_json(json!({
-            "schema_version": 1,
+            "schema_version": 2,
             "daemon": daemon,
-            "local_only": true,
         }))?;
     } else {
         let document =
@@ -89,14 +88,13 @@ pub(super) fn run_daemon_enabled_update(
     let config_path = data_root.join(CONFIG_FILE);
     if args.format.is_json() {
         print_json(json!({
-            "schema_version": 1,
+            "schema_version": 2,
             "daemon_enabled": effective_enabled,
             "running": running,
             "pid": pid,
             "persistent": persistent,
             "supervisor": supervisor,
             "config_path": config_path,
-            "local_only": true,
         }))?;
     } else if effective_enabled {
         let document = render_daemon_enable_receipt(

--- a/crates/ctx-daemon-cli/src/source_status.rs
+++ b/crates/ctx-daemon-cli/src/source_status.rs
@@ -111,7 +111,7 @@ pub fn source_epoch_status_report(
         .transpose()?;
 
     let mut report = compact_json(json!({
-        "schema_version": 2,
+        "schema_version": 3,
         "initialized": initialized,
         "data_root": data_root,
         "config_path": data_root.join(ctx_app_config::CONFIG_FILE),
@@ -125,7 +125,6 @@ pub fn source_epoch_status_report(
         "indexed_sessions": indexed_sessions,
         "indexed_events": indexed_events,
         "indexed_sources": indexed_sources,
-        "local_only": true,
         "read_only": true,
     }));
     if config.semantic_builtin_throttling_effective().is_none() {

--- a/crates/ctx-daemon-cli/tests/contracts/daemon_config_reload.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/daemon_config_reload.rs
@@ -329,7 +329,7 @@ mod unix {
 
         write_config(&temp, true);
         let setup = run_supported_setup(&temp, &binary);
-        assert_eq!(setup["schema_version"], 2);
+        assert_eq!(setup["schema_version"], 3);
         assert_eq!(setup["daemon_autostart"]["status"], "degraded");
         assert_eq!(setup["daemon_autostart"]["pid"], original_pid);
 

--- a/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle.rs
@@ -151,7 +151,7 @@ mod native {
 
         fn setup_wait(&self) -> String {
             let setup = self.json(&["setup", "--wait", "--format=json", "--progress", "none"]);
-            assert_eq!(setup["schema_version"], 2, "{setup:#}");
+            assert_eq!(setup["schema_version"], 3, "{setup:#}");
             assert_eq!(setup["mode"], "ready", "{setup:#}");
             setup["lexical"]["generation_id"]
                 .as_str()

--- a/crates/ctx-history-read-application/tests/support/search_show/search_flows.rs
+++ b/crates/ctx-history-read-application/tests/support/search_show/search_flows.rs
@@ -26,7 +26,7 @@ fn fresh_home_search_mvp_flow() {
     );
 
     let setup_json = json_output(ctx(&temp).args(["setup", "--format=json"]));
-    assert_eq!(setup_json["schema_version"], 2);
+    assert_eq!(setup_json["schema_version"], 3);
     assert_eq!(setup_json["network_required"], false);
     assert_eq!(setup_json["repo_writes"], false);
     assert!(
@@ -337,7 +337,7 @@ fn fresh_home_search_mvp_flow() {
     );
 
     let status = json_output(ctx(&temp).args(["status", "--format=json"]));
-    assert_eq!(status["schema_version"], 2);
+    assert_eq!(status["schema_version"], 3);
     assert!(status["indexed_items"].as_u64().unwrap() > 0);
     assert_eq!(status["semantic"]["status"], "disabled");
     assert_eq!(status["semantic"]["reason"], "semantic_disabled");

--- a/crates/ctx-protocol/src/lib.rs
+++ b/crates/ctx-protocol/src/lib.rs
@@ -351,7 +351,6 @@ pub struct Freshness {
 #[serde(rename_all = "camelCase")]
 pub struct AgentHistoryStatus {
     pub initialized: bool,
-    pub local_only: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -394,8 +393,35 @@ pub struct AgentHistoryStatus {
     pub semantic: Option<JsonObject>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub daemon: Option<JsonObject>,
-    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(
+        flatten,
+        default,
+        deserialize_with = "deserialize_status_extensions",
+        serialize_with = "serialize_status_extensions",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
     pub extra: JsonObject,
+}
+
+fn deserialize_status_extensions<'de, D>(deserializer: D) -> Result<JsonObject, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut extensions = JsonObject::deserialize(deserializer)?;
+    extensions.remove("localOnly");
+    extensions.remove("local_only");
+    Ok(extensions)
+}
+
+fn serialize_status_extensions<S>(extensions: &JsonObject, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.collect_map(
+        extensions
+            .iter()
+            .filter(|(key, _)| !matches!(key.as_str(), "localOnly" | "local_only")),
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/ctx-protocol/src/tests.rs
+++ b/crates/ctx-protocol/src/tests.rs
@@ -10,6 +10,31 @@ fn fixture_root() -> PathBuf {
 }
 
 #[test]
+fn generic_status_discards_retired_extensions_only_at_status_root() {
+    for flags in [
+        serde_json::json!({"localOnly": true, "local_only": false}),
+        serde_json::json!({}),
+        serde_json::json!({"localOnly": null, "local_only": "legacy"}),
+    ] {
+        let mut raw = flags;
+        raw["initialized"] = Value::Bool(true);
+        raw["semantic"] = serde_json::json!({"local_only": false, "localOnly": null});
+        raw["futureField"] = serde_json::json!({"local_only": "kept"});
+        let mut status: AgentHistoryStatus = serde_json::from_value(raw.clone()).unwrap();
+        assert!(!status.extra.contains_key("localOnly"));
+        assert!(!status.extra.contains_key("local_only"));
+        // Public extension maps must not reintroduce either removed spelling on encode.
+        status.extra.insert("localOnly".into(), Value::Bool(true));
+        status.extra.insert("local_only".into(), Value::Null);
+        let output = serde_json::to_value(status).unwrap();
+        assert!(output.get("localOnly").is_none(), "{output}");
+        assert!(output.get("local_only").is_none(), "{output}");
+        assert_eq!(output["semantic"], raw["semantic"]);
+        assert_eq!(output["futureField"], raw["futureField"]);
+    }
+}
+
+#[test]
 fn parses_all_shared_fixtures_into_typed_envelopes() {
     let mut seen = 0;
     for entry in fs::read_dir(fixture_root()).unwrap() {
@@ -116,7 +141,6 @@ fn preserves_additive_fields() {
         "operation": "status",
         "status": {
             "initialized": true,
-            "localOnly": true,
             "futureField": {"enabled": true}
         },
         "futureEnvelopeField": "kept"
@@ -433,7 +457,6 @@ fn mcp_exchange_direct_decode_rejects_duplicate_captured_json_and_bad_event_text
 fn status_counters_accept_the_exact_cross_sdk_maximum() {
     let status: AgentHistoryStatus = serde_json::from_value(serde_json::json!({
         "initialized": true,
-        "localOnly": true,
         "indexedItems": MAX_SAFE_STATUS_COUNTER,
         "indexedSessions": MAX_SAFE_STATUS_COUNTER,
         "indexedEvents": MAX_SAFE_STATUS_COUNTER,
@@ -453,7 +476,6 @@ fn status_counters_reject_values_above_the_exact_cross_sdk_maximum() {
     for rejected in [MAX_SAFE_STATUS_COUNTER + 2, u64::MAX] {
         let error = serde_json::from_value::<AgentHistoryStatus>(serde_json::json!({
             "initialized": true,
-            "localOnly": true,
             "indexedItems": rejected
         }))
         .unwrap_err();
@@ -464,8 +486,7 @@ fn status_counters_reject_values_above_the_exact_cross_sdk_maximum() {
     }
 
     let mut status: AgentHistoryStatus = serde_json::from_value(serde_json::json!({
-        "initialized": true,
-        "localOnly": true
+        "initialized": true
     }))
     .unwrap();
     status.indexed_items = Some(MAX_SAFE_STATUS_COUNTER + 2);

--- a/crates/ctx-sdk/src/lib.rs
+++ b/crates/ctx-sdk/src/lib.rs
@@ -726,7 +726,6 @@ fn normalize_status(raw: &Value) -> Result<AgentHistoryStatus, AgentHistoryError
                 .is_some(),
         )
     });
-    status.insert("localOnly".to_owned(), Value::Bool(true));
     decode_payload(Value::Object(status), "status")
 }
 

--- a/crates/ctx-sdk/src/tests.rs
+++ b/crates/ctx-sdk/src/tests.rs
@@ -64,9 +64,10 @@ fn generic_status_omits_retired_flags_without_changing_nested_semantics() {
             raw["schema_version"] = json!(2);
             raw["lexical"] = json!({"generation_id": "ready"});
             raw["semantic"] = json!({"local_only": false, "diagnostics": {"localOnly": null}});
-            let output =
-                serde_json::to_value(normalize(operation.clone(), BackendInfo::local(None), raw).unwrap())
-                    .unwrap();
+            let output = serde_json::to_value(
+                normalize(operation.clone(), BackendInfo::local(None), raw).unwrap(),
+            )
+            .unwrap();
             let status = &output["status"];
             assert!(status.get("localOnly").is_none(), "{status}");
             assert!(status.get("local_only").is_none(), "{status}");

--- a/crates/ctx-sdk/src/tests.rs
+++ b/crates/ctx-sdk/src/tests.rs
@@ -52,6 +52,37 @@ fn run_json_shell(body: &str, timeout: Duration) -> Result<Value, AgentHistoryEr
 }
 
 #[test]
+fn generic_status_omits_retired_flags_without_changing_nested_semantics() {
+    for operation in [AgentHistoryOperation::Status, AgentHistoryOperation::Init] {
+        for flags in [
+            json!({}),
+            json!({"local_only": true}),
+            json!({"localOnly": false}),
+            json!({"local_only": null, "localOnly": "legacy"}),
+        ] {
+            let mut raw = flags;
+            raw["schema_version"] = json!(2);
+            raw["lexical"] = json!({"generation_id": "ready"});
+            raw["semantic"] = json!({"local_only": false, "diagnostics": {"localOnly": null}});
+            let output =
+                serde_json::to_value(normalize(operation.clone(), BackendInfo::local(None), raw).unwrap())
+                    .unwrap();
+            let status = &output["status"];
+            assert!(status.get("localOnly").is_none(), "{status}");
+            assert!(status.get("local_only").is_none(), "{status}");
+            assert_eq!(status["initialized"], true);
+            assert_eq!(status["semantic"]["localOnly"], false);
+            assert_eq!(
+                status["semantic"]["diagnostics"].get("localOnly"),
+                Some(&Value::Null)
+            );
+        }
+    }
+    let fallback = serde_json::to_value(normalize_status(&json!({})).unwrap()).unwrap();
+    assert_eq!(fallback, json!({"initialized": false}));
+}
+
+#[test]
 fn reads_shared_search_fixture() {
     let value: AgentHistoryEnvelope = serde_json::from_str(include_str!(
         "../../../contracts/agent-history-v1/fixtures/search.results.json"

--- a/crates/ctx-sdk/src/tests/additional.rs
+++ b/crates/ctx-sdk/src/tests/additional.rs
@@ -438,7 +438,10 @@ fn init_normalizes_real_setup_json_into_status_contract() {
     assert_eq!(envelope.operation, AgentHistoryOperation::Init);
     let status = envelope.status.unwrap();
     assert!(status.initialized);
-    assert!(status.local_only);
+    assert!(serde_json::to_value(&status)
+        .unwrap()
+        .get("localOnly")
+        .is_none());
     assert_eq!(status.data_root.as_deref(), Some("/tmp/ctx"));
     assert_eq!(status.indexed_items, Some(2_147_483_648));
     assert_eq!(status.indexed_sessions, Some(2_147_483_649));
@@ -533,7 +536,10 @@ printf '%s\n' '{"initialized":true,"local_only":true}'
     });
 
     let status = client.status().unwrap().status.unwrap();
-    assert!(status.local_only);
+    assert!(serde_json::to_value(&status)
+        .unwrap()
+        .get("localOnly")
+        .is_none());
 }
 
 #[test]
@@ -796,7 +802,10 @@ exit 2
     let status = client.status().unwrap();
     let status_body = status.status.unwrap();
     assert!(status_body.initialized);
-    assert!(status_body.local_only);
+    assert!(serde_json::to_value(&status_body)
+        .unwrap()
+        .get("localOnly")
+        .is_none());
     assert_eq!(
         status_body.data_root.as_deref(),
         Some(data_root.to_string_lossy().as_ref())

--- a/docs/contracts/json.md
+++ b/docs/contracts/json.md
@@ -7,7 +7,10 @@ a user reviews it.
 Command result JSON uses `schema_version: 1` except for
 `ctx setup --format json`, `ctx stats --format json`,
 `ctx import --format json`, `ctx search --format json`,
-`ctx status --format json`, `ctx daemon status`, and MCP `status`.
+`ctx status --format json` (including usage controls and errors), all `ctx index`
+JSON modes, `ctx daemon status`, `ctx daemon enable`, `ctx daemon disable`, and
+MCP `status`. Generic daemon command JSON uses version 2; uninstall-quiescence
+receipts retain their separate schema.
 Progress-event JSON is stderr progress output and does not include
 `schema_version`.
 
@@ -24,7 +27,7 @@ ctx setup --format json
 ctx setup --format json --no-daemon
 ```
 
-Writes local storage and returns schema version 2:
+Writes local storage and returns schema version 3:
 
 - `schema_version`;
 - `data_root`;
@@ -88,7 +91,7 @@ ctx status --format json
 
 Reads local storage state and returns:
 
-- `schema_version: 2`;
+- `schema_version: 3`;
 - `initialized`;
 - `data_root`;
 - `config_path`;
@@ -105,12 +108,17 @@ Reads local storage state and returns:
 - `upgrade`;
 - compact `local_usage` health (`enabled`, state, and a content-free error when
   unavailable), without aggregates, estimates, or operation details;
-- `local_only: true`;
 - `read_only: true`.
 
 For status, `read_only: true` means the command does not mutate canonical
 history or Core search generations. Usage control modes return a separate
-action-focused JSON shape with `read_only: false` and do not read Core status.
+action-focused JSON shape with `schema_version: 2` and `read_only: false`, and
+do not read Core status. Generic status configuration errors also use version 2.
+
+Status and setup version 3, and usage/error, index, and daemon command version 2,
+remove the generic `local_only` property. Callers must update version checks and
+stop requiring or reading that property. Semantic executor diagnostics,
+standalone stats, and uninstall receipts retain their separate locality fields.
 
 `history_epoch` and `lexical` identify the verified searchable Core generation.
 `refresh` reports the latest observed daemon-owned refresh request and its exact
@@ -214,8 +222,8 @@ ctx index wait --format json
 ```
 
 `ctx index --format json` returns the one-shot readiness snapshot. Each watch
-line uses the same read-only shape: `schema_version`, `initialized`, `indexing`,
-`lexical`, `refresh`, `semantic`, `daemon`, `local_only`, and `read_only`.
+line uses the same read-only shape: `schema_version: 2`, `initialized`, `indexing`,
+`lexical`, `refresh`, `semantic`, `daemon`, and `read_only`.
 `indexing.mode` is `auto` or `manual`. Lexical counts and certified source bytes
 describe the currently verified generation. Refresh progress contains only
 values reported by the active refresh job; no synthetic work units, failure
@@ -223,8 +231,8 @@ counts, rates, or remaining time are added. The one-shot and watch snapshots
 preserve `refresh.structured_outcome` and `refresh.automatic_retry` with the
 same shapes and status meanings as `ctx status --format json`.
 
-`ctx index mode --format json` returns `schema_version`, `indexing.mode`,
-`config_path`, `local_only`, and `read_only: true`. Supplying `auto` or `manual`
+`ctx index mode --format json` returns `schema_version: 2`, `indexing.mode`,
+`config_path`, and `read_only: true`. Supplying `auto` or `manual`
 persists the mode and returns `read_only: false` plus
 `indexing.requested_mode`, `indexing.overridden`, `daemon.running`, optional
 `daemon.pid`, `daemon.persistent`, and `daemon.supervisor`. `overridden` is true
@@ -234,8 +242,8 @@ installs or repairs supervision and starts the persistent daemon; manual mode
 stops it and removes persistent supervision. Explicit import and search
 `--refresh wait` can still use finite workers.
 
-Wait returns one object with `schema_version`, `status` (`ready`, `blocked`, or
-`timeout`), `selection`, the final `readiness` snapshot, `local_only`, and
+Wait returns one object with `schema_version: 2`, `status` (`ready`, `blocked`, or
+`timeout`), `selection`, the final `readiness` snapshot, and
 `read_only`. Use `ctx status --format json` for the complete health contract,
 including daemon and supervisor diagnostics.
 

--- a/docs/contracts/json.md
+++ b/docs/contracts/json.md
@@ -1399,7 +1399,9 @@ Citations can include:
 ctx doctor --format json
 ```
 
-Reads local storage and returns findings:
+Reads local storage and returns findings. The outer `schema_version` remains 1.
+Its `source_epoch` contains the status report at schema version 3, without the
+removed generic `local_only` property.
 
 - `schema_version`;
 - `ok`;

--- a/sdks/dotnet/examples/LocalAgentHistorySmoke/Program.cs
+++ b/sdks/dotnet/examples/LocalAgentHistorySmoke/Program.cs
@@ -106,7 +106,7 @@ internal sealed class FakeAgentHistoryTransport : IAgentHistoryTransport
     private static JsonObject Status()
     {
         var payload = Base();
-        payload["local_only"] = true;
+        payload["schema_version"] = 3;
         payload["data_root"] = DataRoot;
         payload["indexed_items"] = 1;
         payload["indexed_sources"] = 1;

--- a/sdks/dotnet/src/Ctx.AgentHistory/AgentHistoryContract.cs
+++ b/sdks/dotnet/src/Ctx.AgentHistory/AgentHistoryContract.cs
@@ -22,7 +22,8 @@ internal static class AgentHistoryContract
     public static void EnsureSupportedSchema(JsonObject raw, string operation)
     {
         var schema = JsonHelpers.GetInt(raw, "schema_version") ?? JsonHelpers.GetInt(raw, "schemaVersion");
-        if (schema is not null && schema != 1 && schema != 2)
+        if (schema is not null && schema != 1 && schema != 2
+            && !(schema == 3 && operation is "status" or "init"))
         {
             throw new CtxAgentHistoryProtocolException(
                 $"unsupported ctx schema version {schema}",
@@ -42,7 +43,6 @@ internal static class AgentHistoryContract
         {
             ["initialized"] = JsonHelpers.GetBool(current, "initialized")
                 ?? !string.IsNullOrWhiteSpace(JsonHelpers.GetString(lexical ?? new JsonObject(), "generationId")),
-            ["localOnly"] = true
         };
         foreach (var key in new[]
         {

--- a/sdks/dotnet/src/Ctx.AgentHistory/Responses.cs
+++ b/sdks/dotnet/src/Ctx.AgentHistory/Responses.cs
@@ -14,6 +14,10 @@ public abstract record AgentHistoryResponse
         ContractVersion = JsonHelpers.GetString(envelope, "contractVersion") ?? CtxAgentHistoryVersions.ContractVersion;
         SchemaVersion = JsonHelpers.GetInt(envelope, "schemaVersion") ?? CtxAgentHistoryVersions.SchemaVersion;
         Operation = JsonHelpers.GetString(envelope, "operation") ?? "";
+        if (Operation is "status" or "init" && _json["status"] is JsonObject status)
+        {
+            _json["status"] = AgentHistoryStatus.WithoutLocality(status);
+        }
         Backend = AgentHistoryBackend.FromJson(envelope["backend"] as JsonObject);
     }
 
@@ -130,9 +134,8 @@ public sealed record AgentHistoryStatus
 
     private AgentHistoryStatus(JsonObject json)
     {
-        _json = JsonHelpers.CloneObject(json);
+        _json = WithoutLocality(json);
         Initialized = JsonHelpers.GetBool(json, "initialized") ?? false;
-        LocalOnly = JsonHelpers.GetBool(json, "localOnly") ?? true;
         ReadOnly = JsonHelpers.GetBool(json, "readOnly");
         DataRoot = JsonHelpers.GetString(json, "dataRoot");
         IndexedItems = JsonHelpers.GetUInt64(json, "indexedItems");
@@ -147,7 +150,6 @@ public sealed record AgentHistoryStatus
     }
 
     public bool Initialized { get; }
-    public bool LocalOnly { get; }
     public bool? ReadOnly { get; }
     public string? DataRoot { get; }
     public ulong? IndexedItems { get; }
@@ -161,6 +163,14 @@ public sealed record AgentHistoryStatus
     public JsonObject Daemon { get; }
 
     public JsonObject ToJsonObject() => JsonHelpers.CloneObject(_json);
+
+    internal static JsonObject WithoutLocality(JsonObject json)
+    {
+        var status = JsonHelpers.CloneObject(json);
+        status.Remove("localOnly");
+        status.Remove("local_only");
+        return status;
+    }
 
     internal static AgentHistoryStatus FromJson(JsonObject? json) => new(json ?? new JsonObject());
 }

--- a/sdks/dotnet/tests/Ctx.AgentHistory.Tests/Program.cs
+++ b/sdks/dotnet/tests/Ctx.AgentHistory.Tests/Program.cs
@@ -49,6 +49,7 @@ internal static class Program
         var tests = new (string Name, Func<Task> Body)[]
         {
             ("preserves current payloads and producer errors", CurrentPayloadsAndProducerErrors),
+            ("removes generic status locality and accepts status schema three", DropsGenericStatusLocality),
             ("wraps status as agent-history-v1", WrapsStatus),
             ("filters status to the current readiness contract", FiltersStatusFields),
             ("preserves legitimate source semantics", PreservesLegitimateSourceSemantics),
@@ -563,6 +564,36 @@ internal static class Program
         }
     }
 
+    private static async Task DropsGenericStatusLocality()
+    {
+        foreach (var flags in new[] { "", ",\"local_only\":true", ",\"localOnly\":false", ",\"local_only\":null,\"localOnly\":\"legacy\"" })
+        {
+            foreach (var schema in new[] { 2, 3 })
+            {
+                var wire = "{\"schema_version\":" + schema
+                    + ",\"initialized\":true,\"semantic\":{\"local_only\":false,\"diagnostics\":{\"localOnly\":null}}"
+                    + flags + "}";
+                var client = new AgentHistoryClient(new RecordingTransport(wire));
+                var status = await client.StatusAsync();
+                var init = await client.InitAsync();
+                foreach (var output in new[] { status.ToJsonObject()["status"]!.AsObject(),
+                    status.Status.ToJsonObject(), init.ToJsonObject()["status"]!.AsObject(), init.Status.ToJsonObject() })
+                {
+                    Equal(false, output.ContainsKey("localOnly"));
+                    Equal(false, output.ContainsKey("local_only"));
+                    Equal(true, output["initialized"]!.GetValue<bool>());
+                    Equal(false, output["semantic"]!["localOnly"]!.GetValue<bool>());
+                    Equal(true, output["semantic"]!["diagnostics"]!.AsObject().ContainsKey("localOnly"));
+                    Equal(true, output["semantic"]!["diagnostics"]!["localOnly"] is null);
+                }
+            }
+        }
+        var unsupported = new AgentHistoryClient(new RecordingTransport("""{"schema_version":3,"sources":[]}"""));
+        await ThrowsAsync<CtxAgentHistoryProtocolException>(() => unsupported.SourcesAsync());
+        var fallback = await new AgentHistoryClient(new RecordingTransport("{}")).StatusAsync();
+        Equal("{\"initialized\":false}", fallback.Status.ToJsonObject().ToJsonString());
+    }
+
     private static async Task NormalizesSetupInitStatus()
     {
         var transport = new RecordingTransport("""{"schema_version":2,"initialized":true,"data_root":"/tmp/ctx","mode":"ready","indexed_items":9007199254740991,"indexed_sessions":9007199254740991,"indexed_events":9007199254740991,"indexed_sources":9007199254740991,"lexical":{"status":"ready","generation_id":"gen-64"},"refresh":{"status":"ready","generation_id":"gen-64"},"network_required":false}""");
@@ -572,7 +603,8 @@ internal static class Program
 
         Equal("init", response.Operation);
         Equal(true, response.Status.Initialized);
-        Equal(true, response.Status.LocalOnly);
+        Equal(false, response.Status.ToJsonObject().ContainsKey("localOnly"));
+        Equal(false, response.Status.ToJsonObject().ContainsKey("local_only"));
         Equal(9007199254740991UL, response.Status.IndexedItems ?? 0UL);
         Equal(9007199254740991UL, response.Status.IndexedSessions ?? 0UL);
         Equal(9007199254740991UL, response.Status.IndexedEvents ?? 0UL);

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -13,6 +13,39 @@ import (
 	"testing"
 )
 
+func TestStatusDropsRetiredRootKeysFromRawAndCanonicalPayloads(t *testing.T) {
+	for _, flags := range []string{``, `,"local_only":true`, `,"localOnly":false`, `,"local_only":null,"localOnly":"legacy"`} {
+		for _, operation := range []string{"status", "init"} {
+			for _, canonical := range []bool{false, true} {
+				wire := `{"initialized":true,"semantic":{"local_only":false,"diagnostics":{"localOnly":null}}` + flags + `}`
+				if canonical {
+					wire = `{"contractVersion":"agent-history-v1","schemaVersion":1,"operation":"` + operation + `","status":` + wire + `,"futureField":{"local_only":"kept"}}`
+				}
+				payload, err := normalizePayload(Operation{Name: operation}, []byte(wire))
+				if err != nil { t.Fatal(err) }
+				var response map[string]any
+				if err := json.Unmarshal(payload, &response); err != nil { t.Fatal(err) }
+				status := response["status"].(map[string]any)
+				for _, key := range []string{"localOnly", "local_only"} {
+					if _, exists := status[key]; exists { t.Fatalf("retired status key %s in %s", key, payload) }
+				}
+				semantic := status["semantic"].(map[string]any)
+				key := "localOnly"
+				if canonical { key = "local_only" }
+				if value, exists := semantic[key]; !exists || value != false { t.Fatalf("nested semantics lost: %s", payload) }
+				if !reflect.DeepEqual(semantic["diagnostics"], map[string]any{"localOnly": nil}) { t.Fatalf("nested null lost: %s", payload) }
+				if canonical && !reflect.DeepEqual(response["futureField"], map[string]any{"local_only": "kept"}) { t.Fatalf("extension lost: %s", payload) }
+			}
+		}
+	}
+	client := NewClient(WithTransport(fakeTransport{response: `{}`}))
+	response, err := client.Status(context.Background())
+	if err != nil { t.Fatal(err) }
+	payload, err := json.Marshal(response.Status)
+	if err != nil { t.Fatal(err) }
+	if string(payload) != `{"initialized":false}` { t.Fatalf("fallback status: %s", payload) }
+}
+
 func TestStatusDecodesAgentHistoryV1(t *testing.T) {
 	client := NewClient(WithTransport(fakeTransport{
 		response: `{
@@ -38,7 +71,7 @@ func TestStatusDecodesAgentHistoryV1(t *testing.T) {
 	}
 	if !status.Status.Initialized || status.Status.IndexedItems != 7 ||
 		status.Status.IndexedSessions != 3 || status.Status.IndexedEvents != 4 ||
-		status.Status.Lexical["generationId"] != "gen-7" || !status.Status.LocalOnly {
+		status.Status.Lexical["generationId"] != "gen-7" {
 		t.Fatalf("unexpected status: %+v", status)
 	}
 }

--- a/sdks/go/examples/dogfood/main.go
+++ b/sdks/go/examples/dogfood/main.go
@@ -130,7 +130,6 @@ func (fakeTransport) Do(_ context.Context, op ctxagenthistory.Operation) ([]byte
 	case "status", "init":
 		envelope["status"] = map[string]any{
 			"initialized":  true,
-			"localOnly":    true,
 			"dataRoot":     "/tmp/ctx-sdk-dogfood",
 			"indexedItems": 1,
 		}

--- a/sdks/go/normalize.go
+++ b/sdks/go/normalize.go
@@ -22,6 +22,13 @@ func normalizePayload(op Operation, payload []byte) ([]byte, error) {
 	}
 	if object, ok := raw.(map[string]any); ok {
 		if _, hasContractVersion := object["contractVersion"]; hasContractVersion {
+			if op.Name == "status" || op.Name == "init" {
+				if status, ok := object["status"].(map[string]any); ok {
+					delete(status, "localOnly")
+					delete(status, "local_only")
+					return json.Marshal(object)
+				}
+			}
 			return payload, nil
 		}
 	}
@@ -521,7 +528,7 @@ func scanExactJSONValue(decoder *json.Decoder) error {
 
 func normalizeStatus(value any) map[string]any {
 	status, _ := value.(map[string]any)
-	out := map[string]any{"localOnly": true}
+	out := map[string]any{}
 	for _, key := range []string{
 		"dataRoot", "indexedItems", "indexedSessions", "indexedEvents", "indexedSources",
 		"historyEpoch", "lexical", "refresh", "semantic", "daemon", "readOnly",

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -138,7 +138,6 @@ type StatusResponse struct {
 // StatusRecord describes local index state.
 type StatusRecord struct {
 	Initialized     bool   `json:"initialized"`
-	LocalOnly       bool   `json:"localOnly"`
 	ReadOnly        bool   `json:"readOnly,omitempty"`
 	DataRoot        string `json:"dataRoot,omitempty"`
 	IndexedItems    uint64 `json:"indexedItems,omitempty"`

--- a/sdks/jvm/examples/ToyAgentHistoryApp.java
+++ b/sdks/jvm/examples/ToyAgentHistoryApp.java
@@ -34,9 +34,8 @@ public final class ToyAgentHistoryApp {
 
         FakeAgentHistoryTransport() {
             responses.put("status", "{"
-                    + "\"schema_version\":1,"
+                    + "\"schema_version\":3,"
                     + "\"initialized\":true,"
-                    + "\"local_only\":true,"
                     + "\"indexed_items\":1,"
                     + "\"indexed_sources\":1"
                     + "}");

--- a/sdks/jvm/src/main/java/rs/ctx/agenthistory/AgentHistoryEnvelope.java
+++ b/sdks/jvm/src/main/java/rs/ctx/agenthistory/AgentHistoryEnvelope.java
@@ -18,6 +18,10 @@ public class AgentHistoryEnvelope {
     private final Map<String, Object> envelope;
 
     AgentHistoryEnvelope(Map<String, Object> canonical) {
+        if ("status".equals(canonical.get("operation")) || "init".equals(canonical.get("operation"))) {
+            canonical = new LinkedHashMap<>(canonical);
+            canonical.put("status", StatusRecord.withoutLocality(AgentHistoryValue.objectAt(canonical, "status")));
+        }
         this.contractVersion = AgentHistoryValue.string(canonical.get("contractVersion"));
         Integer version = AgentHistoryValue.integer(canonical.get("schemaVersion"));
         this.schemaVersion = version == null ? SCHEMA_VERSION : version.intValue();
@@ -144,7 +148,6 @@ public class AgentHistoryEnvelope {
             status.put("initialized", Boolean.valueOf(
                     lexical != null && AgentHistoryValue.string(lexical.get("generationId")) != null));
         }
-        status.put("localOnly", Boolean.TRUE);
         return status;
     }
 

--- a/sdks/jvm/src/main/java/rs/ctx/agenthistory/StatusRecord.java
+++ b/sdks/jvm/src/main/java/rs/ctx/agenthistory/StatusRecord.java
@@ -17,7 +17,14 @@ public final class StatusRecord {
         }) {
             validateCounter(fields, key);
         }
-        this.fields = AgentHistoryValue.copyObject(fields);
+        this.fields = withoutLocality(fields);
+    }
+
+    static Map<String, Object> withoutLocality(Map<String, Object> fields) {
+        Map<String, Object> status = new LinkedHashMap<>(fields);
+        status.remove("localOnly");
+        status.remove("local_only");
+        return AgentHistoryValue.copyObject(status);
     }
 
     private static void validateCounter(Map<String, Object> fields, String key) {
@@ -65,14 +72,6 @@ public final class StatusRecord {
 
     public Boolean initialized() {
         return getInitialized();
-    }
-
-    public Boolean getLocalOnly() {
-        return AgentHistoryValue.bool(fields.get("localOnly"));
-    }
-
-    public Boolean localOnly() {
-        return getLocalOnly();
     }
 
     public Boolean getReadOnly() {

--- a/sdks/jvm/src/test/java/rs/ctx/agenthistory/AgentHistoryClientTest.java
+++ b/sdks/jvm/src/test/java/rs/ctx/agenthistory/AgentHistoryClientTest.java
@@ -23,6 +23,7 @@ public final class AgentHistoryClientTest {
 
     public static void main(String[] args) throws Exception {
         currentOpaquePayloadsAndProducerErrors();
+        dropsGenericStatusLocality();
         wrapsRawStatusAsTypedEnvelope();
         normalizesSetupJsonAsInitStatus();
         rejectsStatusCountersOutsideExactCrossSDKDomain();
@@ -53,6 +54,33 @@ public final class AgentHistoryClientTest {
         localCliDeadlineOwnsPipeDescendantsAndForcesCleanup();
         searchRequiresIntent();
         hostedIsExplicitlyUnsupported();
+    }
+
+    private static void dropsGenericStatusLocality() {
+        for (String flags : List.of("", ",\"local_only\":true", ",\"localOnly\":false",
+                ",\"local_only\":null,\"localOnly\":\"legacy\"")) {
+            String status = "{\"initialized\":true,\"semantic\":{\"local_only\":false,\"diagnostics\":{\"localOnly\":null}}" + flags + "}";
+            for (String operation : List.of("status", "init")) {
+                for (boolean canonical : List.of(false, true)) {
+                    String wire = canonical ? "{\"contractVersion\":\"agent-history-v1\",\"schemaVersion\":1,\"operation\":\""
+                            + operation + "\",\"status\":" + status + ",\"futureField\":{\"local_only\":\"kept\"}}" : status;
+                    AgentHistoryClient client = AgentHistoryClient.withTransport(new FakeTransport("local-cli", wire));
+                    AgentHistoryEnvelope response = "status".equals(operation) ? client.status() : client.init();
+                    Map<String, Object> output = AgentHistoryValue.objectAt(response.asMap(), "status");
+                    StatusRecord typed = StatusRecord.from(response.payload("status"));
+                    for (Map<String, Object> fields : List.of(output, typed.asMap())) {
+                        assertEquals(false, fields.containsKey("localOnly"));
+                        assertEquals(false, fields.containsKey("local_only"));
+                        Map<String, Object> semantic = AgentHistoryValue.objectAt(fields, "semantic");
+                        assertEquals(Boolean.FALSE, semantic.get(canonical ? "local_only" : "localOnly"));
+                        assertEquals(Json.parseObject("{\"localOnly\":null}"), semantic.get("diagnostics"));
+                    }
+                    if (canonical) assertEquals(Map.of("local_only", "kept"), response.payload("futureField"));
+                }
+            }
+        }
+        AgentHistoryClient fallback = AgentHistoryClient.withTransport(new FakeTransport("local-cli", "{}"));
+        assertEquals(Map.of("initialized", Boolean.FALSE), fallback.status().getStatus().asMap());
     }
 
     private static void currentOpaquePayloadsAndProducerErrors() throws Exception {
@@ -527,7 +555,8 @@ public final class AgentHistoryClientTest {
 
         assertEquals("init", response.operation());
         assertEquals(Boolean.TRUE, response.getStatus().getInitialized());
-        assertEquals(Boolean.TRUE, response.getStatus().getLocalOnly());
+        assertEquals(false, response.getStatus().asMap().containsKey("localOnly"));
+        assertEquals(false, response.getStatus().asMap().containsKey("local_only"));
         assertEquals(Long.valueOf(StatusRecord.MAX_SAFE_COUNTER), response.getStatus().getIndexedItems());
         assertEquals(Long.valueOf(StatusRecord.MAX_SAFE_COUNTER), response.getStatus().getIndexedSessions());
         assertEquals(Long.valueOf(StatusRecord.MAX_SAFE_COUNTER), response.getStatus().getIndexedEvents());
@@ -576,7 +605,8 @@ public final class AgentHistoryClientTest {
         assertEquals("status", response.operation());
         assertEquals("local", response.getBackend().getKind());
         assertEquals(Boolean.TRUE, response.getStatus().getInitialized());
-        assertEquals(Boolean.TRUE, response.getStatus().getLocalOnly());
+        assertEquals(false, response.getStatus().asMap().containsKey("localOnly"));
+        assertEquals(false, response.getStatus().asMap().containsKey("local_only"));
         assertEquals(Long.valueOf(2), response.getStatus().getIndexedItems());
         assertEquals(Long.valueOf(2), AgentHistoryValue.longValue(response.asMap().get("status") instanceof Map
                 ? ((Map<?, ?>) response.asMap().get("status")).get("indexedItems")

--- a/sdks/python/src/ctx_agent_history/agent_history_v1.py
+++ b/sdks/python/src/ctx_agent_history/agent_history_v1.py
@@ -56,7 +56,13 @@ def envelope(operation: str, backend: Mapping[str, Any], **payload: Any) -> Json
             }
         )
     )
+    if operation in ("status", "init") and isinstance(result.get("status"), Mapping):
+        result["status"] = without_status_locality(result["status"])
     return result
+
+
+def without_status_locality(status: Mapping[str, Any]) -> Status:
+    return cast(Status, {key: value for key, value in status.items() if key not in ("localOnly", "local_only")})
 
 
 def normalize_status(raw: Mapping[str, Any]) -> Status:
@@ -73,7 +79,6 @@ def normalize_status(raw: Mapping[str, Any]) -> Status:
         _drop_none(
             {
                 "initialized": initialized,
-                "localOnly": True,
                 **{
                     key: current.get(key)
                     for key in (

--- a/sdks/python/src/ctx_agent_history/client.py
+++ b/sdks/python/src/ctx_agent_history/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Mapping, Optional, Sequence, Union
 
+from .agent_history_v1 import without_status_locality
 from .config import HostedConfig, LocalConfig
 from .transport import (
     AgentHistoryTransport,
@@ -91,10 +92,12 @@ class AgentHistoryClient:
         return self._transport
 
     def status(self) -> StatusResponse:
-        return self._transport.status()
+        response = self._transport.status()
+        return {**response, "status": without_status_locality(response["status"])}
 
     def init(self, *, progress: Optional[str] = None) -> InitResponse:
-        return self._transport.init(progress=progress)
+        response = self._transport.init(progress=progress)
+        return {**response, "status": without_status_locality(response["status"])}
 
     def sources(self) -> SourcesResponse:
         return self._transport.sources()

--- a/sdks/python/src/ctx_agent_history/types.py
+++ b/sdks/python/src/ctx_agent_history/types.py
@@ -56,7 +56,6 @@ class Freshness(TypedDict, total=False):
 
 class _StatusRequired(TypedDict):
     initialized: bool
-    localOnly: bool
 
 
 class Status(_StatusRequired, total=False):

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -40,6 +40,33 @@ import dogfood_local
 
 
 class LocalCliAdapterTests(unittest.TestCase):
+    def test_status_removes_both_generic_spellings_and_preserves_nested_values(self) -> None:
+        for flags in ({}, {"local_only": True}, {"localOnly": False}, {"local_only": None, "localOnly": "legacy"}):
+            raw = {"schema_version": 2, **flags, "lexical": {"generation_id": "ready"},
+                   "semantic": {"local_only": False, "diagnostics": {"localOnly": "nested"}}}
+            completed = subprocess.CompletedProcess([], 0, stdout=json.dumps(raw), stderr="")
+            with mock.patch("ctx_agent_history.transport.run_local_cli", return_value=completed):
+                client = AgentHistoryClient.local(ctx_binary="ctx")
+                for response in (client.status(), client.init()):
+                    self.assertNotIn("localOnly", response["status"])
+                    self.assertNotIn("local_only", response["status"])
+                    self.assertTrue(response["status"]["initialized"])
+                    self.assertEqual(response["status"]["semantic"], {"localOnly": False, "diagnostics": {"localOnly": "nested"}})
+            canonical = {"contractVersion": "agent-history-v1", "schemaVersion": 1,
+                         "status": {"initialized": True, **flags, "semantic": raw["semantic"]},
+                         "futureEnvelopeField": {"local_only": "kept"}}
+            transport = mock.Mock()
+            transport.status.return_value = canonical
+            transport.init.return_value = canonical
+            client = AgentHistoryClient(transport)
+            for response in (client.status(), client.init()):
+                self.assertNotIn("localOnly", response["status"])
+                self.assertNotIn("local_only", response["status"])
+                self.assertEqual(response["status"]["semantic"], raw["semantic"])
+                self.assertEqual(response["futureEnvelopeField"], {"local_only": "kept"})
+                self.assertEqual(canonical["status"], {"initialized": True, **flags, "semantic": raw["semantic"]})
+        self.assertEqual(normalize_status({}), {"initialized": False})
+
     def test_sources_and_import_preserve_legitimate_nested_source_semantics(self) -> None:
         acquisition = {
             "source": "local_scan",
@@ -309,7 +336,8 @@ class LocalCliAdapterTests(unittest.TestCase):
         self.assertEqual(result["operation"], "status")
         self.assertEqual(result["backend"], {"kind": "local", "dataRoot": "/tmp/ctx-data"})
         self.assertTrue(result["status"]["initialized"])
-        self.assertTrue(result["status"]["localOnly"])
+        self.assertNotIn("localOnly", result["status"])
+        self.assertNotIn("local_only", result["status"])
         self.assertEqual(result["status"]["lexical"]["generationId"], "gen-1")
         self.assertNotIn("futureField", result["status"])
 
@@ -897,7 +925,7 @@ def assert_agent_history_v1_envelope(test: unittest.TestCase, payload: object) -
     test.assertIsInstance(value, list if operation == "sources" else dict)
 
     if operation in {"status", "init"}:
-        _assert_required_keys(test, value, {"initialized", "localOnly"})
+        _assert_required_keys(test, value, {"initialized"})
     elif operation == "sources":
         for source in value:
             _assert_required_keys(test, source, {"provider", "path", "status", "importable"})

--- a/sdks/swift/Examples/LocalAgentHistorySmoke/main.swift
+++ b/sdks/swift/Examples/LocalAgentHistorySmoke/main.swift
@@ -92,7 +92,7 @@ private final class FakeSmokeRunner: CommandRunner, @unchecked Sendable {
         let arguments = request.arguments.filter { $0 != "--data-root" && $0 != "/tmp/ctx-swift-local-agent-history-smoke" }
         switch Array(arguments.prefix(2)) {
         case ["status", "--format=json"]:
-            return CommandResult(stdout: #"{"initialized":true,"local_only":true,"data_root":"/tmp/ctx-swift-local-agent-history-smoke","indexed_items":3,"indexed_sessions":1,"indexed_events":2,"indexed_sources":1,"lexical":{"status":"ready","generation_id":"gen-3"},"refresh":{"status":"ready","generation_id":"gen-3"}}"#)
+            return CommandResult(stdout: #"{"initialized":true,"data_root":"/tmp/ctx-swift-local-agent-history-smoke","indexed_items":3,"indexed_sessions":1,"indexed_events":2,"indexed_sources":1,"lexical":{"status":"ready","generation_id":"gen-3"},"refresh":{"status":"ready","generation_id":"gen-3"}}"#)
         case ["setup", "--format=json"]:
             return CommandResult(stdout: #"{"schema_version":1,"data_root":"/tmp/ctx-swift-local-agent-history-smoke","indexed_items":3,"lexical":{"status":"ready","generation_id":"gen-3"},"refresh":{"status":"ready","generation_id":"gen-3"},"network_required":false}"#)
         case ["import", "--format=json"]:

--- a/sdks/swift/Sources/CtxAgentHistory/AgentHistoryClient.swift
+++ b/sdks/swift/Sources/CtxAgentHistory/AgentHistoryClient.swift
@@ -507,13 +507,12 @@ private func backendWithRawDataRoot(_ backend: AgentHistoryBackend, _ raw: JSONV
 
 private func normalizeStatus(_ raw: JSONValue) throws -> JSONValue {
     guard case let .object(current) = raw.camelizedPublicJSON().droppingNulls() else {
-        return .object(["initialized": .bool(false), "localOnly": .bool(true)])
+        return .object(["initialized": .bool(false)])
     }
     let initialized = current["initialized"]
         ?? .bool(current["lexical"]?["generationId"]?.stringValue != nil)
     var status: [String: JSONValue] = [
         "initialized": initialized,
-        "localOnly": .bool(true)
     ]
     for key in [
         "dataRoot", "readOnly", "indexedItems", "indexedSessions", "indexedEvents",

--- a/sdks/swift/Sources/CtxAgentHistory/AgentHistoryDTOs.swift
+++ b/sdks/swift/Sources/CtxAgentHistory/AgentHistoryDTOs.swift
@@ -4,7 +4,6 @@ public struct AgentHistoryStatus: Codable, Equatable, Sendable {
     public static let maximumExactCounter = 9_007_199_254_740_991
 
     public var initialized: Bool
-    public var localOnly: Bool
     public var readOnly: Bool?
     public var dataRoot: String?
     public var indexedItems: Int?
@@ -19,7 +18,6 @@ public struct AgentHistoryStatus: Codable, Equatable, Sendable {
 
     public init(
         initialized: Bool,
-        localOnly: Bool,
         readOnly: Bool? = nil,
         dataRoot: String? = nil,
         indexedItems: Int? = nil,
@@ -33,7 +31,6 @@ public struct AgentHistoryStatus: Codable, Equatable, Sendable {
         daemon: JSONValue? = nil
     ) {
         self.initialized = initialized
-        self.localOnly = localOnly
         self.readOnly = readOnly
         self.dataRoot = dataRoot
         self.indexedItems = indexedItems
@@ -49,7 +46,6 @@ public struct AgentHistoryStatus: Codable, Equatable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case initialized
-        case localOnly
         case readOnly
         case dataRoot
         case indexedItems
@@ -66,7 +62,6 @@ public struct AgentHistoryStatus: Codable, Equatable, Sendable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         initialized = try container.decode(Bool.self, forKey: .initialized)
-        localOnly = try container.decode(Bool.self, forKey: .localOnly)
         readOnly = try container.decodeIfPresent(Bool.self, forKey: .readOnly)
         dataRoot = try container.decodeIfPresent(String.self, forKey: .dataRoot)
         indexedItems = try Self.decodeCounter(.indexedItems, from: container)
@@ -83,7 +78,6 @@ public struct AgentHistoryStatus: Codable, Equatable, Sendable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(initialized, forKey: .initialized)
-        try container.encode(localOnly, forKey: .localOnly)
         try container.encodeIfPresent(readOnly, forKey: .readOnly)
         try container.encodeIfPresent(dataRoot, forKey: .dataRoot)
         try Self.encodeCounter(indexedItems, forKey: .indexedItems, to: &container)

--- a/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
+++ b/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
@@ -8,7 +8,11 @@ final class CtxAgentHistoryTests: XCTestCase {
         for flags in variants {
             var raw = flags
             raw["initialized"] = .bool(true)
-            raw["semantic"] = .object(["local_only": .bool(false), "diagnostics": .object(["localOnly": .null])])
+            raw["semantic"] = .object([
+                "local_only": .bool(false),
+                "executor": .object(["kind": .string("http"), "scope": .string("loopback"),
+                                     "content_leaves_machine": .bool(false)])
+            ])
             let bytes = try JSONEncoder().encode(JSONValue.object(raw))
             let runner = CapturingRunner { _ in CommandResult(stdout: bytes) }
             let client = AgentHistoryClient(adapter: LocalCLIAdapter(runner: runner))
@@ -21,12 +25,10 @@ final class CtxAgentHistoryTests: XCTestCase {
                 XCTAssertEqual(output["initialized"], .bool(true))
                 let key = index == 2 ? "local_only" : "localOnly"
                 XCTAssertEqual(output["semantic"]?[key], .bool(false))
-                // Raw status keeps its existing null omission; direct Codable retains explicit null.
-                if index == 2 {
-                    XCTAssertEqual(output["semantic"]?["diagnostics"]?["localOnly"], .null)
-                } else {
-                    XCTAssertNil(output["semantic"]?["diagnostics"]?["localOnly"])
-                }
+                XCTAssertEqual(output["semantic"]?["executor"]?["kind"], .string("http"))
+                XCTAssertEqual(output["semantic"]?["executor"]?["scope"], .string("loopback"))
+                let boundaryKey = index == 2 ? "content_leaves_machine" : "contentLeavesMachine"
+                XCTAssertEqual(output["semantic"]?["executor"]?[boundaryKey], .bool(false))
             }
         }
         let runner = CapturingRunner { _ in CommandResult(stdout: "{}") }

--- a/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
+++ b/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
@@ -21,7 +21,12 @@ final class CtxAgentHistoryTests: XCTestCase {
                 XCTAssertEqual(output["initialized"], .bool(true))
                 let key = index == 2 ? "local_only" : "localOnly"
                 XCTAssertEqual(output["semantic"]?[key], .bool(false))
-                XCTAssertEqual(output["semantic"]?["diagnostics"]?["localOnly"], .null)
+                // Raw status keeps its existing null omission; direct Codable retains explicit null.
+                if index == 2 {
+                    XCTAssertEqual(output["semantic"]?["diagnostics"]?["localOnly"], .null)
+                } else {
+                    XCTAssertNil(output["semantic"]?["diagnostics"]?["localOnly"])
+                }
             }
         }
         let runner = CapturingRunner { _ in CommandResult(stdout: "{}") }

--- a/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
+++ b/sdks/swift/Tests/CtxAgentHistoryTests/CtxAgentHistoryTests.swift
@@ -2,6 +2,34 @@ import XCTest
 @testable import CtxAgentHistory
 
 final class CtxAgentHistoryTests: XCTestCase {
+    func testStatusDropsRetiredLocalityFromRawAndCanonicalValues() throws {
+        let variants: [[String: JSONValue]] = [[:], ["local_only": .bool(true)],
+            ["localOnly": .bool(false)], ["local_only": .null, "localOnly": .string("legacy")]]
+        for flags in variants {
+            var raw = flags
+            raw["initialized"] = .bool(true)
+            raw["semantic"] = .object(["local_only": .bool(false), "diagnostics": .object(["localOnly": .null])])
+            let bytes = try JSONEncoder().encode(JSONValue.object(raw))
+            let runner = CapturingRunner { _ in CommandResult(stdout: bytes) }
+            let client = AgentHistoryClient(adapter: LocalCLIAdapter(runner: runner))
+            let direct = try JSONDecoder().decode(AgentHistoryStatus.self, from: bytes)
+            let statuses = [try client.status().status, try client.initialize().status, direct]
+            for (index, status) in statuses.enumerated() {
+                let output = try JSONDecoder().decode(JSONValue.self, from: JSONEncoder().encode(status))
+                XCTAssertNil(output["localOnly"])
+                XCTAssertNil(output["local_only"])
+                XCTAssertEqual(output["initialized"], .bool(true))
+                let key = index == 2 ? "local_only" : "localOnly"
+                XCTAssertEqual(output["semantic"]?[key], .bool(false))
+                XCTAssertEqual(output["semantic"]?["diagnostics"]?["localOnly"], .null)
+            }
+        }
+        let runner = CapturingRunner { _ in CommandResult(stdout: "{}") }
+        let status = try AgentHistoryClient(adapter: LocalCLIAdapter(runner: runner)).status().status
+        let output = try JSONDecoder().decode(JSONValue.self, from: JSONEncoder().encode(status))
+        XCTAssertEqual(output, .object(["initialized": .bool(false)]))
+    }
+
     func testPreservesOpaqueEventPayloadsAndExplicitNulls() throws {
         let fixtureURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
@@ -187,7 +215,6 @@ final class CtxAgentHistoryTests: XCTestCase {
 
         let invalid = AgentHistoryStatus(
             initialized: true,
-            localOnly: true,
             indexedItems: maximum + 2
         )
         XCTAssertThrowsError(try JSONEncoder().encode(invalid))

--- a/sdks/typescript/examples/dogfood-toy.js
+++ b/sdks/typescript/examples/dogfood-toy.js
@@ -68,7 +68,6 @@ function mockResponse(args) {
   if (command === "status") {
     return {
       initialized: true,
-      local_only: true,
       data_root: "/tmp/ctx-sdk-dogfood",
       indexed_items: 1,
       indexed_sources: 1,

--- a/sdks/typescript/src/index.d.ts
+++ b/sdks/typescript/src/index.d.ts
@@ -179,7 +179,6 @@ export interface Freshness {
 
 export interface AgentHistoryStatus {
   initialized: boolean;
-  localOnly: boolean;
   readOnly?: boolean;
   dataRoot?: string | null;
   /** Exact operational counter in the inclusive range 0..Number.MAX_SAFE_INTEGER. */

--- a/sdks/typescript/src/index.js
+++ b/sdks/typescript/src/index.js
@@ -841,7 +841,6 @@ function normalizeStatus(raw) {
     }
   }
   status.initialized ??= typeof current.lexical?.generationId === "string";
-  status.localOnly = true;
   return status;
 }
 

--- a/sdks/typescript/test/client.test.js
+++ b/sdks/typescript/test/client.test.js
@@ -38,6 +38,21 @@ function mockClient(handler) {
   return { client, calls };
 }
 
+test("removes generic status locality from old CLI values and fallback status", async () => {
+  for (const flags of [{}, { local_only: true }, { localOnly: false }, { local_only: null, localOnly: "legacy" }]) {
+    const raw = { schema_version: 2, ...flags, lexical: { generation_id: "ready" },
+      semantic: { local_only: false, diagnostics: { localOnly: null } } };
+    const { client } = mockClient(() => ({ stdout: JSON.stringify(raw) }));
+    for (const response of [await client.status(), await client.init()]) {
+      assert.equal(Object.hasOwn(response.status, "localOnly"), false);
+      assert.equal(Object.hasOwn(response.status, "local_only"), false);
+      assert.equal(response.status.initialized, true);
+      assert.deepEqual(response.status.semantic, { localOnly: false, diagnostics: { localOnly: null } });
+    }
+  }
+  assert.deepEqual(toAgentHistoryEnvelope("status", {}).status, { initialized: false });
+});
+
 test("wraps status, init, sources, import, and sync CLI commands", async () => {
   const { client, calls } = mockClient(({ args }) => ({
     stdout: JSON.stringify({ initialized: true, sources: [{ provider: "codex" }], args }),
@@ -1040,7 +1055,8 @@ function assertFixturePayload(entry, fixture) {
     case "status":
     case "init":
       assert.equal(typeof fixture.status.initialized, "boolean", `${entry} status.initialized`);
-      assert.equal(typeof fixture.status.localOnly, "boolean", `${entry} status.localOnly`);
+      assert.equal(Object.hasOwn(fixture.status, "localOnly"), false, `${entry} status.localOnly`);
+      assert.equal(Object.hasOwn(fixture.status, "local_only"), false, `${entry} status.local_only`);
       break;
     case "sources":
       assert.ok(Array.isArray(fixture.sources), `${entry} sources`);


### PR DESCRIPTION
Generic status returned a `local_only`/`localOnly` property even though status alone cannot establish where configured semantic execution runs. Remove that property from CLI/MCP status and setup, usage/error receipts, index readiness/mode/wait, daemon command receipts, and all seven SDK DTOs and normalizers. Older status payloads lose both spellings only at the generic status root; semantic diagnostics and opaque captured JSON retain their existing handling.

This is a breaking cleanup. Raw status/setup moves to schema 3; the affected usage/error, index, and daemon envelopes move to schema 2. The experimental in-repo `agent-history-v1` contract retains schema 1 with an explicit documented exception to its required-field rule. Callers must remove property reads, constructor arguments, and required-field checks, and update CLI schema-version checks. Standalone semantic execution diagnostics, stats, uninstall receipts, stored visibility/sync values, and privacy controls retain their separate contracts.

Validation: three targeted baseline regressions compiled and failed at the intended CLI/SDK/protocol assertions. Fixed Rust/protocol/presentation and both Go owners passed; TypeScript passed 39 tests plus typecheck, Python passed 40 tests, and ordinary JVM and .NET owning suites passed. Native Swift XCTest passed 25 tests with five existing Darwin-only skips. The normal affected selector chose 88 tests. The initial run passed 83; five suites had stale schema expectations. Those expectations were corrected, and all five owning suites plus four docs/policy/format checks passed. The final selector chose the same 88 targets; unaffected passing evidence was retained. Doctor keeps outer schema 1 with its nested status report at schema 3.