### PR TITLE
Route stable upgrades through the bridge and complete the first managed pair

### DIFF
--- a/crates/ctx-upgrade-engine/src/upgrade/command.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/command.rs
@@ -577,259 +577,15 @@ fn apply_upgrade<D: DaemonUpgradePort + ?Sized>(
     let attempt = begin_manual_attempt_locked(data_root, &upgrade_lock, "manual_apply")?;
     let result = (|| -> Result<UpgradeOutcome> {
         let plan = build_upgrade_plan(engine, policy, channel_override, true)?;
-        let pair_mode = inspect_plan_under_installation_lock(&plan, upgrade_lock.installation())?;
-        let repairs = classify_repair_requirements(
-            engine.semantic_layout,
-            &plan,
+        apply_planned_upgrade(
+            engine,
             data_root,
-            policy.semantic_enabled,
-        )?;
-        let pair_apply_required = pair_mode.pair_apply_required(&plan);
-        if !plan.update_available && !pair_apply_required && !repairs.any() {
-            write_state_checked_locked(
-                data_root,
-                &upgrade_lock,
-                &attempt,
-                &plan,
-                "up_to_date",
-                policy.interval,
-            )?;
-            let warnings = plan.warnings.clone();
-            return Ok(UpgradeOutcome {
-                command: "upgrade",
-                status: "up_to_date",
-                message: format!("ctx {} is already installed.", plan.current_version),
-                plan: Some(plan),
-                applied: false,
-                dry_run,
-                warnings,
-                attempt_id: Some(attempt.id().to_owned()),
-            });
-        }
-        if plan.update_available && !plan.metadata.self_upgrade_allowed {
-            return Err(anyhow!(
-                "release {} does not allow self-upgrade",
-                plan.latest_version
-            ));
-        }
-        if dry_run {
-            write_state_checked_locked(
-                data_root,
-                &upgrade_lock,
-                &attempt,
-                &plan,
-                "dry_run",
-                policy.interval,
-            )?;
-            let warnings = plan.warnings.clone();
-            return Ok(UpgradeOutcome {
-                command: "upgrade",
-                status: "dry_run",
-                message: if plan.update_available {
-                    format!(
-                        "ctx {} would upgrade to {}.",
-                        plan.current_version, plan.latest_version
-                    )
-                } else if pair_apply_required {
-                    format!(
-                        "ctx {} would repair its signed managed Core/companion installation.",
-                        plan.current_version
-                    )
-                } else if repairs.legacy_runtime {
-                    format!(
-                        "ctx {} would repair its signed legacy ONNX Runtime installation.",
-                        plan.current_version
-                    )
-                } else {
-                    format!(
-                        "ctx {} would provision signed Semantic model and runtime assets.",
-                        plan.current_version
-                    )
-                },
-                plan: Some(plan),
-                applied: false,
-                dry_run: true,
-                warnings,
-                attempt_id: Some(attempt.id().to_owned()),
-            });
-        }
-        let mut core_artifact =
-            download_core_artifact(engine.transport, data_root, &plan, &pair_mode)?;
-        // Supplementary runtime metadata is optional for Core-only releases.
-        // Preserve or repair the legacy runtime only when signed metadata
-        // actually carries that runtime contract.
-        let mut runtime_artifact = if (plan.update_available || repairs.legacy_runtime)
-            && plan.semantic_provisioning.is_none()
-        {
-            match (
-                plan.metadata.onnxruntime.as_ref(),
-                plan.onnxruntime_artifact_url(),
-            ) {
-                (Some(runtime), Some(runtime_url)) => Some(
-                    DownloadedArtifact::download_or_reuse_verified(
-                        engine.transport,
-                        data_root,
-                        &runtime_url,
-                        &runtime.sha256,
-                        RELEASE_ONNXRUNTIME_ARTIFACT_MAX_BYTES as u64,
-                        RELEASE_ARTIFACT_TIMEOUT,
-                    )
-                    .with_context(|| format!("download or reuse {runtime_url}"))?,
-                ),
-                (None, None) => None,
-                _ => return Err(anyhow!("incomplete ONNX Runtime upgrade plan")),
-            }
-        } else {
-            None
-        };
-        let mut semantic_artifacts = Vec::new();
-        if repairs.catalog {
-            let provisioning = plan
-                .semantic_provisioning
-                .as_ref()
-                .ok_or_else(|| anyhow!("Semantic repair has no signed provisioning plan"))?;
-            for asset in &provisioning.assets {
-                let url = plan.semantic_artifact_url(&asset.metadata.artifact);
-                semantic_artifacts.push(
-                    DownloadedArtifact::download_or_reuse_verified(
-                        engine.transport,
-                        data_root,
-                        &url,
-                        &asset.metadata.archive_sha256,
-                        semantic_archive_download_limit(&asset.metadata)?,
-                        RELEASE_ARTIFACT_TIMEOUT,
-                    )
-                    .with_context(|| format!("download or reuse {url}"))?,
-                );
-            }
-        }
-        write_state_phase_locked(&upgrade_lock, &attempt, "quiescing")?;
-        let daemon_handoff = engine.daemon.begin(data_root, attempt.id())?;
-        let daemon_restart = daemon_handoff.replacement_restart();
-        let mut before_publish = || Ok(());
-        let apply_result = match apply_prepared_install(
-            engine.process,
-            engine.semantic_layout,
-            &upgrade_lock,
-            &plan,
-            &pair_mode,
-            &mut core_artifact,
-            runtime_artifact.as_mut(),
-            &mut semantic_artifacts,
-            data_root,
-            &attempt,
-            policy.interval,
-            daemon_restart.map(|restart| (restart.trigger, restart.loop_interval_seconds)),
-            &mut before_publish,
-        ) {
-            Ok(result) => result,
-            Err(error) => {
-                let restart = daemon_handoff.resume_with(&plan.install_path);
-                return match restart {
-                    Ok(()) => Err(error),
-                    Err(restart_error) => Err(error.context(format!(
-                        "also failed to resume daemon lifecycle after upgrade failure: {restart_error:#}"
-                    ))),
-                };
-            }
-        };
-        let mut warnings = plan.warnings.clone();
-        if let ApplyResult::Scheduled { helper_pid } = apply_result {
-            if let Err(error) = daemon_handoff.transfer_to_replacement_helper(helper_pid) {
-                warnings.push(format!(
-                    "replacement helper is ready, but daemon handoff bookkeeping remains pending: {error:#}"
-                ));
-            }
-            record_post_apply_state(
-                data_root,
-                &upgrade_lock,
-                &attempt,
-                &plan,
-                "scheduled",
-                policy.interval,
-                &mut warnings,
-            );
-            let message = if plan.update_available {
-                format!(
-                    "scheduled ctx {} -> {} at {}; replacement will finish after this process exits",
-                    plan.current_version,
-                    plan.latest_version,
-                    plan.install_path.display()
-                )
-            } else if pair_apply_required {
-                "scheduled signed managed Core/companion repair; replacement will finish after this process exits"
-                    .to_owned()
-            } else if repairs.legacy_runtime {
-                "scheduled signed legacy ONNX Runtime repair; replacement will finish after this process exits"
-                    .to_owned()
-            } else {
-                "scheduled signed Semantic asset repair; replacement will finish after this process exits"
-                    .to_owned()
-            };
-            return Ok(UpgradeOutcome {
-                command: "upgrade",
-                status: "scheduled",
-                message,
-                plan: Some(plan),
-                applied: false,
-                dry_run: false,
-                warnings,
-                attempt_id: Some(attempt.id().to_owned()),
-            });
-        }
-        if let Some(warning) = apply_result.cleanup_warning() {
-            warnings.push(warning.to_owned());
-        }
-        record_post_apply_state(
-            data_root,
+            policy,
+            dry_run,
             &upgrade_lock,
             &attempt,
-            &plan,
-            "applied",
-            policy.interval,
-            &mut warnings,
-        );
-        // Filesystem publication is the commit point.  A daemon restart is a
-        // follow-up operation: report it for retry, but never turn a committed
-        // upgrade into scheduler failure/backoff.
-        if let Err(error) = daemon_handoff.resume_with(&plan.install_path) {
-            warnings.push(format!(
-                "ctx upgrade applied, but daemon restart is pending: {error:#}"
-            ));
-        }
-        let message = if plan.update_available {
-            format!(
-                "upgraded ctx {} -> {} at {}",
-                plan.current_version,
-                plan.latest_version,
-                plan.install_path.display()
-            )
-        } else if pair_apply_required {
-            format!(
-                "repaired signed managed Core/companion installation for ctx {}",
-                plan.current_version
-            )
-        } else if repairs.legacy_runtime {
-            format!(
-                "repaired signed legacy ONNX Runtime installation for ctx {}",
-                plan.current_version
-            )
-        } else {
-            format!(
-                "provisioned signed Semantic model and runtime assets for ctx {}",
-                plan.current_version
-            )
-        };
-        Ok(UpgradeOutcome {
-            command: "upgrade",
-            status: "applied",
-            message,
-            plan: Some(plan),
-            applied: true,
-            dry_run: false,
-            warnings,
-            attempt_id: Some(attempt.id().to_owned()),
-        })
+            plan,
+        )
     })();
     if let Err(error) = &result {
         let _ = write_state_error_locked(
@@ -841,6 +597,271 @@ fn apply_upgrade<D: DaemonUpgradePort + ?Sized>(
         );
     }
     result
+}
+
+// The plan has already authenticated hosted ownership and release metadata.
+// Keep staging, daemon handoff and publication together under the same lock.
+fn apply_planned_upgrade<D: DaemonUpgradePort + ?Sized>(
+    engine: &UpgradeEngine<'_, D>,
+    data_root: &Path,
+    policy: UpgradePolicy<'_>,
+    dry_run: bool,
+    upgrade_lock: &UpgradeLock,
+    attempt: &UpgradeAttempt,
+    plan: UpgradePlan,
+) -> Result<UpgradeOutcome> {
+    let pair_mode = inspect_plan_under_installation_lock(&plan, upgrade_lock.installation())?;
+    let repairs = classify_repair_requirements(
+        engine.semantic_layout,
+        &plan,
+        data_root,
+        policy.semantic_enabled,
+    )?;
+    let pair_apply_required = pair_mode.pair_apply_required(&plan);
+    if !plan.update_available && !pair_apply_required && !repairs.any() {
+        write_state_checked_locked(
+            data_root,
+            upgrade_lock,
+            attempt,
+            &plan,
+            "up_to_date",
+            policy.interval,
+        )?;
+        let warnings = plan.warnings.clone();
+        return Ok(UpgradeOutcome {
+            command: "upgrade",
+            status: "up_to_date",
+            message: format!("ctx {} is already installed.", plan.current_version),
+            plan: Some(plan),
+            applied: false,
+            dry_run,
+            warnings,
+            attempt_id: Some(attempt.id().to_owned()),
+        });
+    }
+    if plan.update_available && !plan.metadata.self_upgrade_allowed {
+        return Err(anyhow!(
+            "release {} does not allow self-upgrade",
+            plan.latest_version
+        ));
+    }
+    if dry_run {
+        write_state_checked_locked(
+            data_root,
+            upgrade_lock,
+            attempt,
+            &plan,
+            "dry_run",
+            policy.interval,
+        )?;
+        let warnings = plan.warnings.clone();
+        return Ok(UpgradeOutcome {
+            command: "upgrade",
+            status: "dry_run",
+            message: if plan.update_available {
+                format!(
+                    "ctx {} would upgrade to {}.",
+                    plan.current_version, plan.latest_version
+                )
+            } else if pair_apply_required {
+                format!(
+                    "ctx {} would repair its signed managed Core/companion installation.",
+                    plan.current_version
+                )
+            } else if repairs.legacy_runtime {
+                format!(
+                    "ctx {} would repair its signed legacy ONNX Runtime installation.",
+                    plan.current_version
+                )
+            } else {
+                format!(
+                    "ctx {} would provision signed Semantic model and runtime assets.",
+                    plan.current_version
+                )
+            },
+            plan: Some(plan),
+            applied: false,
+            dry_run: true,
+            warnings,
+            attempt_id: Some(attempt.id().to_owned()),
+        });
+    }
+    let mut core_artifact = download_core_artifact(engine.transport, data_root, &plan, &pair_mode)?;
+    // Supplementary runtime metadata is optional for Core-only releases.
+    // Preserve or repair the legacy runtime only when signed metadata
+    // actually carries that runtime contract.
+    let mut runtime_artifact = if (plan.update_available || repairs.legacy_runtime)
+        && plan.semantic_provisioning.is_none()
+    {
+        match (
+            plan.metadata.onnxruntime.as_ref(),
+            plan.onnxruntime_artifact_url(),
+        ) {
+            (Some(runtime), Some(runtime_url)) => Some(
+                DownloadedArtifact::download_or_reuse_verified(
+                    engine.transport,
+                    data_root,
+                    &runtime_url,
+                    &runtime.sha256,
+                    RELEASE_ONNXRUNTIME_ARTIFACT_MAX_BYTES as u64,
+                    RELEASE_ARTIFACT_TIMEOUT,
+                )
+                .with_context(|| format!("download or reuse {runtime_url}"))?,
+            ),
+            (None, None) => None,
+            _ => return Err(anyhow!("incomplete ONNX Runtime upgrade plan")),
+        }
+    } else {
+        None
+    };
+    let mut semantic_artifacts = Vec::new();
+    if repairs.catalog {
+        let provisioning = plan
+            .semantic_provisioning
+            .as_ref()
+            .ok_or_else(|| anyhow!("Semantic repair has no signed provisioning plan"))?;
+        for asset in &provisioning.assets {
+            let url = plan.semantic_artifact_url(&asset.metadata.artifact);
+            semantic_artifacts.push(
+                DownloadedArtifact::download_or_reuse_verified(
+                    engine.transport,
+                    data_root,
+                    &url,
+                    &asset.metadata.archive_sha256,
+                    semantic_archive_download_limit(&asset.metadata)?,
+                    RELEASE_ARTIFACT_TIMEOUT,
+                )
+                .with_context(|| format!("download or reuse {url}"))?,
+            );
+        }
+    }
+    write_state_phase_locked(upgrade_lock, attempt, "quiescing")?;
+    let daemon_handoff = engine.daemon.begin(data_root, attempt.id())?;
+    let daemon_restart = daemon_handoff.replacement_restart();
+    let mut before_publish = || Ok(());
+    let apply_result = match apply_prepared_install(
+        engine.process,
+        engine.semantic_layout,
+        upgrade_lock,
+        &plan,
+        &pair_mode,
+        &mut core_artifact,
+        runtime_artifact.as_mut(),
+        &mut semantic_artifacts,
+        data_root,
+        attempt,
+        policy.interval,
+        daemon_restart.map(|restart| (restart.trigger, restart.loop_interval_seconds)),
+        &mut before_publish,
+    ) {
+        Ok(result) => result,
+        Err(error) => {
+            let restart = daemon_handoff.resume_with(&plan.install_path);
+            return match restart {
+                Ok(()) => Err(error),
+                Err(restart_error) => Err(error.context(format!(
+                    "also failed to resume daemon lifecycle after upgrade failure: {restart_error:#}"
+                ))),
+            };
+        }
+    };
+    let mut warnings = plan.warnings.clone();
+    if let ApplyResult::Scheduled { helper_pid } = apply_result {
+        if let Err(error) = daemon_handoff.transfer_to_replacement_helper(helper_pid) {
+            warnings.push(format!(
+                "replacement helper is ready, but daemon handoff bookkeeping remains pending: {error:#}"
+            ));
+        }
+        record_post_apply_state(
+            data_root,
+            upgrade_lock,
+            attempt,
+            &plan,
+            "scheduled",
+            policy.interval,
+            &mut warnings,
+        );
+        let message = if plan.update_available {
+            format!(
+                "scheduled ctx {} -> {} at {}; replacement will finish after this process exits",
+                plan.current_version,
+                plan.latest_version,
+                plan.install_path.display()
+            )
+        } else if pair_apply_required {
+            "scheduled signed managed Core/companion repair; replacement will finish after this process exits"
+                .to_owned()
+        } else if repairs.legacy_runtime {
+            "scheduled signed legacy ONNX Runtime repair; replacement will finish after this process exits"
+                .to_owned()
+        } else {
+            "scheduled signed Semantic asset repair; replacement will finish after this process exits"
+                .to_owned()
+        };
+        return Ok(UpgradeOutcome {
+            command: "upgrade",
+            status: "scheduled",
+            message,
+            plan: Some(plan),
+            applied: false,
+            dry_run: false,
+            warnings,
+            attempt_id: Some(attempt.id().to_owned()),
+        });
+    }
+    if let Some(warning) = apply_result.cleanup_warning() {
+        warnings.push(warning.to_owned());
+    }
+    record_post_apply_state(
+        data_root,
+        upgrade_lock,
+        attempt,
+        &plan,
+        "applied",
+        policy.interval,
+        &mut warnings,
+    );
+    // Filesystem publication is the commit point.  A daemon restart is a
+    // follow-up operation: report it for retry, but never turn a committed
+    // upgrade into scheduler failure/backoff.
+    if let Err(error) = daemon_handoff.resume_with(&plan.install_path) {
+        warnings.push(format!(
+            "ctx upgrade applied, but daemon restart is pending: {error:#}"
+        ));
+    }
+    let message = if plan.update_available {
+        format!(
+            "upgraded ctx {} -> {} at {}",
+            plan.current_version,
+            plan.latest_version,
+            plan.install_path.display()
+        )
+    } else if pair_apply_required {
+        format!(
+            "repaired signed managed Core/companion installation for ctx {}",
+            plan.current_version
+        )
+    } else if repairs.legacy_runtime {
+        format!(
+            "repaired signed legacy ONNX Runtime installation for ctx {}",
+            plan.current_version
+        )
+    } else {
+        format!(
+            "provisioned signed Semantic model and runtime assets for ctx {}",
+            plan.current_version
+        )
+    };
+    Ok(UpgradeOutcome {
+        command: "upgrade",
+        status: "applied",
+        message,
+        plan: Some(plan),
+        applied: true,
+        dry_run: false,
+        warnings,
+        attempt_id: Some(attempt.id().to_owned()),
+    })
 }
 
 fn record_post_apply_state(
@@ -950,3 +971,7 @@ fn build_upgrade_plan<D: DaemonUpgradePort + ?Sized>(
         semantic_provisioning,
     })
 }
+
+#[cfg(all(test, unix))]
+#[path = "command/first_pair_tests.rs"]
+mod first_pair_tests;

--- a/crates/ctx-upgrade-engine/src/upgrade/command/daemon/tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/command/daemon/tests.rs
@@ -294,3 +294,5 @@ fn generic_committed_recovery_state_fault_emits_one_truthful_applied_event() {
     assert_eq!(state["latest_version"], "1.1.0");
     assert_eq!(state["update_available"], true);
 }
+
+mod first_pair;

--- a/crates/ctx-upgrade-engine/src/upgrade/command/daemon/tests/first_pair.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/command/daemon/tests/first_pair.rs
@@ -1,0 +1,147 @@
+use super::super::*;
+use crate::upgrade::command::first_pair_tests::{child, Fixture};
+use crate::upgrade::managed_pair::tests::with_fixture_verifier;
+use ctx_companion_bridge::ReleaseChannel;
+use std::{fs, sync::Mutex};
+
+struct Policy(bool);
+impl AutomaticUpgradePolicySnapshot for Policy {
+    fn daemon_maintenance_enabled(&self) -> bool {
+        self.0
+    }
+    fn automatic_upgrade_enabled(&self) -> bool {
+        self.0
+    }
+    fn interval(&self) -> Duration {
+        Duration::from_secs(60)
+    }
+    fn channel(&self) -> &str {
+        "stable"
+    }
+    fn semantic_enabled(&self) -> bool {
+        false
+    }
+}
+impl AutomaticUpgradePolicyProvider for Policy {
+    type Snapshot = Policy;
+    fn reload(&self, _: &Path) -> Result<Policy> {
+        Ok(Policy(self.0))
+    }
+}
+#[derive(Default)]
+struct Observer(Mutex<Vec<(UpgradeTerminalStatus, bool)>>);
+impl UpgradeObserver<Policy> for Observer {
+    fn observe_automatic_terminal(
+        &self,
+        _: &Path,
+        _: &Policy,
+        observation: AutomaticUpgradeObservation<'_>,
+    ) {
+        self.0
+            .lock()
+            .unwrap()
+            .push((observation.status, observation.applied));
+    }
+}
+
+#[test]
+fn first_pair_automatic_owner_and_policy() -> Result<()> {
+    for case in [
+        "automatic_same",
+        "automatic_newer",
+        "automatic_disabled",
+        "automatic_no_handoff",
+        "automatic_off",
+    ] {
+        child(
+            case,
+            "upgrade::command::daemon::tests::first_pair::automatic_pair_probe",
+        )?;
+    }
+    Ok(())
+}
+
+#[test]
+fn automatic_pair_probe() -> Result<()> {
+    let Ok(case) = std::env::var("CTX_FIRST_PAIR_CASE") else {
+        return Ok(());
+    };
+    let f = Fixture::new(&case)?;
+    let observer = Observer::default();
+    if case == "automatic_off" {
+        assert!(f
+            .engine()
+            .prepare_automatic(&Policy(false), &observer, &f.data, &Policy(false))?
+            .is_none());
+        assert!(f.trace.calls.lock().unwrap().is_empty());
+        assert!(f.requests().is_empty());
+        assert_eq!(fs::read(&f.plan.install_path)?, b"installed-core");
+        assert!(!f.root.join("libexec/ctx-pro").exists());
+        return Ok(());
+    }
+    let lock = UpgradeLock::acquire(&f.data)?;
+    let attempt = begin_automatic_attempt_locked(&lock, Duration::from_secs(60))?.unwrap();
+    // Authenticated-plan fixture enters the actual automatic completion owner.
+    // The ordinary prepare owner uses these same mode/download operations.
+    let pair_mode = inspect_plan_under_installation_lock(&f.plan, lock.installation())?;
+    assert!(pair_mode.pair_apply_required(&f.plan));
+    let core = f.verified(|| download_core_artifact(&f.transport, &f.data, &f.plan, &pair_mode))?;
+    write_state_checked_locked(
+        &f.data,
+        &lock,
+        &attempt,
+        &f.plan,
+        "staged",
+        Duration::from_secs(60),
+    )?;
+    let prepared = PreparedAutomaticUpgrade(PreparedAutomaticUpgradeKind::Apply {
+        data_root: f.data.clone(),
+        interval: Duration::from_secs(60),
+        started: Instant::now(),
+        lock,
+        attempt,
+        plan: f.plan.clone(),
+        pair_mode,
+        core,
+        provisioning: PreparedProvisioningArtifacts {
+            runtime: None,
+            semantic: vec![],
+        },
+    });
+    let handoff = if case == "automatic_no_handoff" {
+        None
+    } else {
+        Some(f.trace.begin(&f.data, prepared.attempt_id().unwrap())?)
+    };
+    let result = with_fixture_verifier(
+        ReleaseChannel::Stable,
+        b"opaque-fixture-envelope".to_vec(),
+        f.identity.clone(),
+        || {
+            f.engine().finish_automatic(
+                &Policy(case != "automatic_disabled"),
+                &observer,
+                prepared,
+                handoff,
+            )
+        },
+    );
+    if case == "automatic_no_handoff" {
+        assert!(format!("{:#}", result.unwrap_err()).contains("no daemon lifecycle handoff"));
+        assert!(f.trace.calls.lock().unwrap().is_empty());
+        assert_eq!(fs::read(&f.plan.install_path)?, b"installed-core");
+        assert!(!f.root.join("libexec/ctx-pro").exists());
+    } else {
+        result?;
+        assert_eq!(*f.trace.calls.lock().unwrap(), ["begin", "resume"]);
+        assert_eq!(
+            *observer.0.lock().unwrap(),
+            [if case == "automatic_disabled" {
+                (UpgradeTerminalStatus::Skipped, false)
+            } else {
+                (UpgradeTerminalStatus::Applied, true)
+            }]
+        );
+    }
+    Ok(())
+}

--- a/crates/ctx-upgrade-engine/src/upgrade/command/first_pair_tests.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/command/first_pair_tests.rs
@@ -1,0 +1,611 @@
+//! Opaque pair fixtures exercise the ordinary owner after plan authentication.
+//! Signature negatives below use the real production verifiers, without the
+//! fixture verifier. These are orchestration tests, not signed release proof.
+use super::*;
+use crate::upgrade::{
+    install::{install_marker_path, InstallationLock},
+    managed_pair::{tests::with_fixture_verifier, ReleaseManagedPairVerifier},
+    sha256_hex, ProductBuildIdentity, ReleaseTransport, TEST_RELEASE_PROCESS, TEST_SEMANTIC_LAYOUT,
+};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use ctx_companion_bridge::ReleaseChannel;
+use ctx_history_platform::platform_security::{
+    create_private_directory_all, restrict_private_file,
+};
+use ctx_managed_pair_engine::{
+    ManagedPairComponentIdentity, ManagedPairTarget, ManagedPairVerifier,
+    VerifiedManagedPairIdentity,
+};
+use serde_json::{json, Value};
+use std::{
+    collections::BTreeMap,
+    fs,
+    io::Write as _,
+    os::unix::fs::PermissionsExt as _,
+    sync::{Arc, Mutex},
+};
+
+const CORE: &[u8] = b"installed-core";
+const NEXT_CORE: &[u8] = b"paired-core";
+const COMPANION: &[u8] = b"paired-companion";
+const ENVELOPE: &[u8] = b"opaque-fixture-envelope";
+
+pub(super) struct Fixture {
+    _temp: tempfile::TempDir,
+    pub(super) root: PathBuf,
+    pub(super) data: PathBuf,
+    pub(super) plan: UpgradePlan,
+    pub(super) metadata: Vec<u8>,
+    pub(super) transport: Transport,
+    pub(super) trace: Arc<Trace>,
+    pub(super) identity: VerifiedManagedPairIdentity,
+}
+
+pub(super) struct Transport {
+    pub(super) bytes: BTreeMap<String, Vec<u8>>,
+    log: Arc<Mutex<Vec<String>>>,
+}
+impl ReleaseTransport for Transport {
+    fn get_bytes_limited(&self, endpoint: &str, max: usize) -> Result<Vec<u8>> {
+        self.log.lock().unwrap().push(endpoint.to_owned());
+        let bytes = self
+            .bytes
+            .get(endpoint)
+            .ok_or_else(|| anyhow!("unexpected request {endpoint}"))?;
+        assert!(bytes.len() <= max);
+        Ok(bytes.clone())
+    }
+    fn download_artifact(
+        &self,
+        endpoint: &str,
+        destination: &mut fs::File,
+        max: u64,
+        _: Duration,
+    ) -> Result<u64> {
+        let bytes = self.get_bytes_limited(endpoint, max as usize)?;
+        destination.write_all(&bytes)?;
+        Ok(bytes.len() as u64)
+    }
+}
+
+pub(super) struct Trace {
+    root: PathBuf,
+    core: PathBuf,
+    data: PathBuf,
+    case: String,
+    expected_core: Vec<u8>,
+    pub(super) calls: Mutex<Vec<&'static str>>,
+    downloads: Arc<Mutex<Vec<String>>>,
+}
+impl Trace {
+    fn unchanged(&self) -> Result<()> {
+        assert_eq!(fs::read(&self.core)?, b"installed-core");
+        assert!(!self.root.join("libexec/ctx-pro").exists());
+        assert!(!self.root.join("share/ctx/managed-pair-state.json").exists());
+        Ok(())
+    }
+}
+impl DaemonUpgradeLease for Arc<Trace> {
+    fn wait_for_installation_quiescence(&self) -> Result<()> {
+        Ok(())
+    }
+    fn replacement_restart(&self) -> Option<crate::DaemonRestart<'_>> {
+        Some(crate::DaemonRestart {
+            trigger: "automatic_upgrade",
+            loop_interval_seconds: Some(60),
+        })
+    }
+    fn resume_with(self, executable: &Path) -> Result<()> {
+        assert_eq!(executable, self.core);
+        if self.case == "partial_pair" {
+            assert_eq!(fs::read(&self.core)?, b"installed-core");
+        } else if self.case == "stale_at_handoff" || self.case == "automatic_disabled" {
+            self.unchanged()?;
+        } else {
+            assert_eq!(fs::read(&self.core)?, self.expected_core);
+            assert_eq!(fs::read(self.root.join("libexec/ctx-pro"))?, COMPANION);
+            assert_eq!(
+                fs::read(self.root.join("share/ctx/managed-pair-envelope.json"))?,
+                ENVELOPE
+            );
+            let marker: Value =
+                serde_json::from_slice(&fs::read(install_marker_path(&self.core))?)?;
+            assert_eq!(marker["managed_pair"], true);
+            assert_eq!(
+                crate::upgrade::read_state_json().unwrap()["status"],
+                "applied"
+            );
+            assert!(!self
+                .root
+                .join(ctx_managed_pair_engine::MANAGED_PAIR_ACTIVE_TRANSACTION_RELATIVE_PATH)
+                .exists());
+        }
+        self.calls.lock().unwrap().push("resume");
+        if self.case == "restart_failure" {
+            return Err(anyhow!("injected restart failure"));
+        }
+        Ok(())
+    }
+    fn transfer_to_replacement_helper(self, _: u32) -> Result<()> {
+        unreachable!()
+    }
+    fn release_for_current_format_reexec(self) -> Result<()> {
+        unreachable!()
+    }
+}
+impl DaemonUpgradePort for Arc<Trace> {
+    type Lease = Self;
+    fn begin(&self, root: &Path, _: &str) -> Result<Self> {
+        assert_eq!(root, self.data);
+        if self.case == "partial_pair" {
+            assert_eq!(fs::read(&self.core)?, b"installed-core");
+        } else {
+            self.unchanged()?;
+        }
+        assert!(InstallationLock::try_acquire_at_root(&self.root)?.is_none());
+        let state = crate::upgrade::read_state_json().unwrap();
+        assert_eq!(
+            state["status"],
+            if self.case.starts_with("automatic") {
+                "staged"
+            } else {
+                "quiescing"
+            }
+        );
+        assert_eq!(
+            self.downloads.lock().unwrap().len(),
+            3,
+            "all signed pair inputs must be staged before handoff"
+        );
+        assert!(!self
+            .root
+            .join(ctx_managed_pair_engine::MANAGED_PAIR_ACTIVE_TRANSACTION_RELATIVE_PATH)
+            .exists());
+        self.calls.lock().unwrap().push("begin");
+        if self.case == "handoff_failure" {
+            return Err(anyhow!("injected all-root handoff failure"));
+        }
+        if self.case == "stale_at_handoff" {
+            let path = install_marker_path(&self.core);
+            let mut bytes = fs::read(&path)?;
+            bytes.push(b' ');
+            fs::write(path, bytes)?;
+        }
+        Ok(self.clone())
+    }
+    fn begin_legacy(&self, _: &Path, _: &str, _: &Path) -> Result<Self> {
+        unreachable!()
+    }
+    fn begin_current(&self, _: &Path, _: &str, _: &str, _: Option<u64>) -> Result<Self> {
+        unreachable!()
+    }
+    fn mark_replacement_helper_handoff(&self, _: &Path, _: &str, _: u32) -> Result<()> {
+        unreachable!()
+    }
+    fn replacement_helper_owns_handoff(&self, _: &Path, _: &str, _: u32) -> bool {
+        false
+    }
+    fn complete_replacement_handoff(
+        &self,
+        _: &Path,
+        _: &Path,
+        _: &str,
+        _: Option<crate::DaemonRestart<'_>>,
+    ) -> Result<()> {
+        unreachable!()
+    }
+    fn finish_replacement_handoff(&self, _: &Path, _: &str) -> Result<()> {
+        unreachable!()
+    }
+}
+
+pub(super) fn policy() -> UpgradePolicy<'static> {
+    UpgradePolicy {
+        channel: "stable",
+        interval: Duration::from_secs(60),
+        semantic_enabled: false,
+    }
+}
+impl Fixture {
+    pub(super) fn new(case: &str) -> Result<Self> {
+        let temp = tempfile::tempdir()?;
+        let root = fs::canonicalize(temp.path())?.join("install");
+        let data = temp.path().join("data");
+        let bin = root.join(if case == "custom_geometry" {
+            "custom"
+        } else {
+            "bin"
+        });
+        create_private_directory_all(&bin)?;
+        create_private_directory_all(&data)?;
+        // Only an isolated --exact child enters this fixture.
+        for key in [
+            "HOME",
+            "XDG_CONFIG_HOME",
+            "XDG_DATA_HOME",
+            "XDG_STATE_HOME",
+            "XDG_RUNTIME_DIR",
+            "CTX_DATA_ROOT",
+        ] {
+            let path = temp.path().join(key);
+            create_private_directory_all(&path)?;
+            std::env::set_var(key, path);
+        }
+        let core = bin.join("ctx");
+        fs::write(&core, b"installed-core")?;
+        fs::set_permissions(&core, fs::Permissions::from_mode(0o700))?;
+        std::env::set_var("CTX_UPGRADE_TEST_TARGET", &core);
+        let marker_path = install_marker_path(&core);
+        let platform = platform_key()?;
+        let marker = json!({"schema_version":1,"manager":"ctx-hosted-installer","install_path":core,
+            "platform":platform,"channel":"stable","version":"1.3.2","sha256":sha256_hex(b"installed-core")});
+        fs::write(&marker_path, serde_json::to_vec(&marker)?)?;
+        restrict_private_file(&marker_path)?;
+        let latest = if matches!(case, "newer" | "automatic_newer") {
+            "1.3.3"
+        } else {
+            "1.3.2"
+        };
+        let candidate_core = if latest == "1.3.3" { NEXT_CORE } else { CORE };
+        let core_sha = sha256_hex(candidate_core);
+        let companion_sha = sha256_hex(COMPANION);
+        let base =
+            format!("https://cli.ctx.rs/storage/v1/object/public/releases/artifacts/{latest}");
+        let p = platform.replace('-', "_");
+        let metadata = format!("CTX_RELEASE_SCHEMA_VERSION=1\nCTX_RELEASE_CHANNEL=stable\nCTX_RELEASE_SELF_UPGRADE_ALLOWED=true\nCTX_RELEASE_AUTO_UPGRADE_ALLOWED=true\nCTX_RELEASE_VERSION={latest}\nCTX_RELEASE_BASE_URL={base}\nCTX_RELEASE_ARTIFACT_{p}=ctx\nCTX_RELEASE_SHA256_{p}={core_sha}\nCTX_RELEASE_MANAGED_PAIR_ENVELOPE_{p}=pair.json\nCTX_RELEASE_MANAGED_PAIR_CORE_OBJECT_{p}=sha256/{core_sha}/ctx\nCTX_RELEASE_MANAGED_PAIR_CORE_SHA256_{p}={core_sha}\nCTX_RELEASE_MANAGED_PAIR_COMPANION_OBJECT_{p}=sha256/{companion_sha}/ctx-pro\nCTX_RELEASE_MANAGED_PAIR_COMPANION_SHA256_{p}={companion_sha}\n").into_bytes();
+        let parsed =
+            parse_release_metadata(&metadata, platform, "stable", false, &TEST_SEMANTIC_LAYOUT)?;
+        let pair =
+            project_managed_pair_release(&parsed.base_url, parsed.managed_pair.as_ref())?.unwrap();
+        let mut warnings = vec![];
+        let snapshot = capture_install_snapshot(true, platform, "stable", "1.3.2", &mut warnings)?;
+        let plan = UpgradePlan {
+            current_version: snapshot.marker.version,
+            latest_version: latest.to_owned(),
+            channel: "stable".to_owned(),
+            platform: platform.to_owned(),
+            metadata_url: metadata_url("stable"),
+            artifact_url: format!("{base}/ctx"),
+            artifact_sha256: core_sha.clone(),
+            install_path: core.clone(),
+            install_fingerprint: snapshot.fingerprint,
+            update_available: version_gt(latest, "1.3.2"),
+            managed: warnings.is_empty(),
+            warnings,
+            managed_pair_release: Some(pair.clone()),
+            metadata: parsed,
+            semantic_provisioning: None,
+        };
+        let target = match (std::env::consts::OS, std::env::consts::ARCH) {
+            ("linux", "x86_64") => ManagedPairTarget::LinuxX64,
+            ("linux", "aarch64") => ManagedPairTarget::LinuxArm64,
+            ("macos", "x86_64") => ManagedPairTarget::MacosX64,
+            ("macos", "aarch64") => ManagedPairTarget::MacosArm64,
+            other => return Err(anyhow!("unsupported fixture platform {other:?}")),
+        };
+        let identity = VerifiedManagedPairIdentity::new(
+            format!("ctx-{latest}"),
+            target,
+            1,
+            sha256_hex(b"manifest"),
+            ManagedPairComponentIdentity::new(core_sha, candidate_core.len() as u64)?,
+            ManagedPairComponentIdentity::new(companion_sha, COMPANION.len() as u64)?,
+        )?;
+        let log = Arc::new(Mutex::new(vec![]));
+        let transport = Transport {
+            bytes: BTreeMap::from([
+                (pair.envelope_url, ENVELOPE.to_vec()),
+                (pair.core_object_url, candidate_core.to_vec()),
+                (pair.companion_object_url, COMPANION.to_vec()),
+            ]),
+            log: log.clone(),
+        };
+        let trace = Arc::new(Trace {
+            root: root.clone(),
+            core,
+            data: data.clone(),
+            case: case.to_owned(),
+            expected_core: candidate_core.to_vec(),
+            calls: Mutex::new(vec![]),
+            downloads: log,
+        });
+        Ok(Self {
+            _temp: temp,
+            root,
+            data,
+            plan,
+            metadata,
+            transport,
+            trace,
+            identity,
+        })
+    }
+    pub(super) fn requests(&self) -> Vec<String> {
+        self.transport.log.lock().unwrap().clone()
+    }
+    pub(super) fn engine(&self) -> UpgradeEngine<'_, Arc<Trace>> {
+        UpgradeEngine::new(
+            ProductBuildIdentity::new("1.3.2"),
+            &self.transport,
+            &TEST_RELEASE_PROCESS,
+            &TEST_SEMANTIC_LAYOUT,
+            &self.trace,
+        )
+    }
+    pub(super) fn verified<T>(&self, operation: impl FnOnce() -> T) -> T {
+        with_fixture_verifier(
+            ReleaseChannel::Stable,
+            ENVELOPE.to_vec(),
+            self.identity.clone(),
+            operation,
+        )
+    }
+    fn apply(&self, dry_run: bool) -> Result<UpgradeOutcome> {
+        let lock = UpgradeLock::acquire(&self.data)?;
+        let attempt = begin_manual_attempt_locked(&self.data, &lock, "manual_apply")?;
+        apply_planned_upgrade(
+            &self.engine(),
+            &self.data,
+            policy(),
+            dry_run,
+            &lock,
+            &attempt,
+            self.plan.clone(),
+        )
+    }
+}
+
+pub(super) fn child(case: &str, test: &str) -> Result<()> {
+    let output = std::process::Command::new(std::env::current_exe()?)
+        .args(["--exact", test, "--nocapture"])
+        .env("CTX_FIRST_PAIR_CASE", case)
+        .output()?;
+    assert!(
+        output.status.success(),
+        "{case}: {} {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("1 passed"));
+    Ok(())
+}
+
+#[test]
+fn first_pair_foreground_owner_and_admission() -> Result<()> {
+    for case in [
+        "same",
+        "newer",
+        "dry_run",
+        "source",
+        "custom_geometry",
+        "no_pair_metadata",
+        "older",
+        "build_identity",
+        "invalid_version",
+        "disallowed",
+        "marker_changed",
+        "binary_changed",
+        "wrong_target",
+        "invalid_manager",
+        "wrong_platform",
+        "unsafe_marker",
+        "nonexecutable",
+        "stale_at_handoff",
+        "handoff_failure",
+        "restart_failure",
+        "malformed_envelope",
+        "bad_signature",
+        "metadata_signature",
+        "partial_metadata",
+        "partial_pair",
+    ] {
+        child(case, "upgrade::command::first_pair_tests::first_pair_probe")?;
+    }
+    Ok(())
+}
+
+#[test]
+fn first_pair_probe() -> Result<()> {
+    let Ok(case) = std::env::var("CTX_FIRST_PAIR_CASE") else {
+        return Ok(());
+    };
+    let mut f = Fixture::new(&case)?;
+    let marker = install_marker_path(&f.plan.install_path);
+    match case.as_str() {
+        "source" => {
+            fs::remove_file(&marker)?;
+            let mut warnings = vec![];
+            capture_install_snapshot(false, &f.plan.platform, "stable", "1.3.2", &mut warnings)?;
+            assert!(!warnings.is_empty());
+            f.plan.managed = warnings.is_empty();
+            let lock = InstallationLock::try_acquire_at_root(&f.root)?.unwrap();
+            assert_eq!(
+                inspect_plan_under_installation_lock(&f.plan, &lock)?,
+                ManagedPairMode::CoreOnly
+            );
+            drop(lock);
+            assert!(format!(
+                "{:#}",
+                f.engine()
+                    .apply(&f.data, policy(), None, false)
+                    .unwrap_err()
+            )
+            .contains("not installed by the hosted installer"));
+        }
+        "custom_geometry" | "no_pair_metadata" => {
+            if case == "no_pair_metadata" {
+                f.plan.managed_pair_release = None;
+            }
+            assert_eq!(f.verified(|| f.apply(false))?.status(), "up_to_date");
+        }
+        "metadata_signature" => {
+            f.transport
+                .bytes
+                .insert(f.plan.metadata_url.clone(), f.metadata.clone());
+            f.transport.bytes.insert(
+                metadata_signature_url(&f.plan.metadata_url),
+                BASE64.encode([0u8; 384]).into_bytes(),
+            );
+            assert!(format!(
+                "{:#}",
+                f.engine()
+                    .apply(&f.data, policy(), None, false)
+                    .unwrap_err()
+            )
+            .contains("metadata signature verification failed"));
+        }
+        "partial_metadata" => {
+            let text = String::from_utf8(f.metadata.clone())?;
+            let partial = text
+                .lines()
+                .filter(|line| !line.starts_with("CTX_RELEASE_MANAGED_PAIR_COMPANION_SHA256_"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(format!(
+                "{:#}",
+                parse_release_metadata(
+                    partial.as_bytes(),
+                    &f.plan.platform,
+                    "stable",
+                    false,
+                    &TEST_SEMANTIC_LAYOUT
+                )
+                .unwrap_err()
+            )
+            .contains("is partial"));
+        }
+        "malformed_envelope" | "bad_signature" => {
+            let envelope = if case == "bad_signature" {
+                invalid_signature_envelope()?
+            } else {
+                b"not-json".to_vec()
+            };
+            let expected = if case == "bad_signature" {
+                "detached manifest signature is invalid"
+            } else {
+                "detached envelope"
+            };
+            assert!(format!(
+                "{:#}",
+                ReleaseManagedPairVerifier::for_channel("stable")?
+                    .verify_signed_envelope(&envelope)
+                    .unwrap_err()
+            )
+            .contains(expected));
+            f.transport.bytes.insert(
+                f.plan
+                    .managed_pair_release
+                    .as_ref()
+                    .unwrap()
+                    .envelope_url
+                    .clone(),
+                envelope,
+            );
+            assert!(format!("{:#}", f.apply(false).unwrap_err()).contains(expected));
+        }
+        "older" | "build_identity" | "invalid_version" | "disallowed" | "marker_changed"
+        | "binary_changed" | "wrong_target" | "invalid_manager" | "wrong_platform"
+        | "unsafe_marker" | "nonexecutable" => {
+            match case.as_str() {
+                "older" => f.plan.latest_version = "1.3.1".to_owned(),
+                "build_identity" => f.plan.latest_version = "1.3.2+different".to_owned(),
+                "invalid_version" => f.plan.latest_version = "invalid".to_owned(),
+                "disallowed" => f.plan.metadata.self_upgrade_allowed = false,
+                "marker_changed" => {
+                    let mut bytes = fs::read(&marker)?;
+                    bytes.push(b' ');
+                    fs::write(&marker, bytes)?;
+                }
+                "binary_changed" => fs::write(&f.plan.install_path, b"different-core")?,
+                "wrong_target" => {
+                    std::env::set_var("CTX_UPGRADE_TEST_TARGET", std::env::current_exe()?)
+                }
+                "invalid_manager" | "wrong_platform" => {
+                    let mut value: Value = serde_json::from_slice(&fs::read(&marker)?)?;
+                    value[if case == "invalid_manager" {
+                        "manager"
+                    } else {
+                        "platform"
+                    }] = json!("other");
+                    fs::write(&marker, serde_json::to_vec(&value)?)?;
+                }
+                "unsafe_marker" => fs::set_permissions(&marker, fs::Permissions::from_mode(0o666))?,
+                "nonexecutable" => {
+                    fs::set_permissions(&f.plan.install_path, fs::Permissions::from_mode(0o600))?
+                }
+                _ => unreachable!(),
+            }
+            assert!(f.verified(|| f.apply(false)).is_err(), "{case}");
+            assert!(f.transport.log.lock().unwrap().is_empty());
+        }
+        "partial_pair" => {
+            create_private_directory_all(&f.root.join("libexec"))?;
+            let companion = f.root.join("libexec/ctx-pro");
+            fs::write(&companion, b"orphan-companion")?;
+            fs::set_permissions(&companion, fs::Permissions::from_mode(0o700))?;
+            let result = f.verified(|| f.apply(false));
+            assert!(format!("{:#}", result.unwrap_err())
+                .contains("no valid rollback-generation witness"));
+            assert_eq!(fs::read(companion)?, b"orphan-companion");
+            return Ok(());
+        }
+        _ => {
+            let result = f.verified(|| f.apply(case == "dry_run"));
+            match case.as_str() {
+                "handoff_failure" => {
+                    assert!(
+                        format!("{:#}", result.unwrap_err()).contains("all-root handoff failure")
+                    );
+                    assert_eq!(*f.trace.calls.lock().unwrap(), ["begin"]);
+                }
+                "stale_at_handoff" => {
+                    assert!(format!("{:#}", result.unwrap_err())
+                        .contains("changed after this upgrade plan"));
+                    assert_eq!(*f.trace.calls.lock().unwrap(), ["begin", "resume"]);
+                }
+                "dry_run" => {
+                    assert_eq!(result?.status(), "dry_run");
+                    assert!(f.transport.log.lock().unwrap().is_empty());
+                }
+                _ => {
+                    let outcome = result?;
+                    assert!(outcome.applied());
+                    assert_eq!(
+                        outcome.plan().unwrap().latest_version(),
+                        f.plan.latest_version
+                    );
+                    assert_eq!(*f.trace.calls.lock().unwrap(), ["begin", "resume"]);
+                    if case == "restart_failure" {
+                        assert!(outcome
+                            .warnings()
+                            .iter()
+                            .any(|w| w.contains("restart is pending")));
+                    }
+                    return Ok(());
+                }
+            }
+        }
+    }
+    if case != "binary_changed" {
+        f.trace.unchanged()?;
+    }
+    if !matches!(case.as_str(), "handoff_failure" | "stale_at_handoff") {
+        assert!(f.trace.calls.lock().unwrap().is_empty());
+    }
+    Ok(())
+}
+
+fn invalid_signature_envelope() -> Result<Vec<u8>> {
+    let build = json!({"component":"core","rust_target":"target","source_revision":"revision","build_fingerprint":"fingerprint"});
+    let component = json!({"artifact_name":"ctx","object_key":"object","sha256":sha256_hex(CORE),"size_bytes":CORE.len(),"install_slot":"bin/ctx","build_identity":build});
+    let manifest = json!({"contract":"ctx-managed-pair-manifest","schema_version":1,"channel":"stable",
+        "release_authority_key_id":"ctx-pro-release-stable-2026-07-27","release_name":"ctx-1.3.2",
+        "target":{"id":"linux-x64","os":"linux","arch":"x64","core_rust_target":"target","companion_rust_target":"target"},
+        "install_geometry":{"install_root":"root","managed_bin_dir":"bin","core_slot":"bin/ctx","companion_slot":"libexec/ctx-pro"},
+        "target_matrix_sha256":sha256_hex(b"matrix"),"rollback_generation":1,"snapshot":{"contract":"snapshot","fingerprint":"fingerprint"},
+        "compatibility":{"invocation_fingerprint":"fingerprint","core_capability_fingerprint":"fingerprint"},
+        "components":{"core":component,"companion":component}});
+    Ok(serde_json::to_vec(
+        &json!({"schema_version":1,"manifest_base64":BASE64.encode(serde_json::to_vec(&manifest)?),"signature_base64":BASE64.encode([0u8;384])}),
+    )?)
+}

--- a/crates/ctx-upgrade-engine/src/upgrade/managed_pair.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/managed_pair.rs
@@ -297,7 +297,7 @@ impl ReleaseManagedPairVerifier {
 
 pub(super) fn inspect_plan_under_installation_lock(
     plan: &UpgradePlan,
-    _installation_lock: &InstallationLock,
+    installation_lock: &InstallationLock,
 ) -> Result<ManagedPairMode> {
     let Some(install_root) = install_root_for_executable(&plan.install_path) else {
         return Ok(ManagedPairMode::CoreOnly);
@@ -305,7 +305,33 @@ pub(super) fn inspect_plan_under_installation_lock(
     let verifier = ReleaseManagedPairVerifier::for_channel(&plan.channel)?;
     let status = inspect_managed_pair_under_installation_lock(&install_root, &verifier)?;
     Ok(match status {
-        ManagedPairInstallationStatus::Absent => ManagedPairMode::CoreOnly,
+        ManagedPairInstallationStatus::Absent => {
+            // Hosted installations predating the paired distribution have no
+            // pair evidence yet. Complete their first pair through the same
+            // verified download, daemon handoff and publication owner as repair.
+            // A source/unmanaged plan or a Core-only release grants no such work.
+            if !plan.managed || plan.managed_pair_release.is_none() {
+                return Ok(ManagedPairMode::CoreOnly);
+            }
+            install::revalidate_plan_snapshot_under_installation_lock(plan, installation_lock)?;
+            let current = super::version::parse_semver(&plan.current_version)?;
+            let latest = super::version::parse_semver(&plan.latest_version)?;
+            if !latest.cmp_precedence(&current).is_gt()
+                && plan.latest_version != plan.current_version
+            {
+                bail!("managed-pair completion requires a newer release or the exact installed Core version");
+            }
+            if !plan.metadata.self_upgrade_allowed {
+                bail!(
+                    "release {} does not allow self-upgrade",
+                    plan.latest_version
+                );
+            }
+            ManagedPairMode::Paired {
+                install_root,
+                repair_required: true,
+            }
+        }
         ManagedPairInstallationStatus::Healthy { .. } => ManagedPairMode::Paired {
             install_root,
             repair_required: false,

--- a/crates/ctx-upgrade-engine/src/upgrade/metadata.rs
+++ b/crates/ctx-upgrade-engine/src/upgrade/metadata.rs
@@ -86,7 +86,12 @@ pub(super) fn metadata_url(channel: &str) -> String {
     if let Some(url) = qualification_env("CTX_RELEASE_METADATA_URL") {
         return url;
     }
-    format!("{RELEASE_METADATA_BASE_URL}/releases/{channel}/ctx-release-metadata.env")
+    let base_url = if channel == "stable" {
+        "https://cli.ctx.rs/functions/v2"
+    } else {
+        RELEASE_METADATA_BASE_URL
+    };
+    format!("{base_url}/releases/{channel}/ctx-release-metadata.env")
 }
 
 pub(super) fn metadata_signature_url(metadata_url: &str) -> String {
@@ -626,11 +631,20 @@ CTX_RELEASE_SHA256_linux_x64={}
 
         assert_eq!(
             metadata,
-            "https://cli.ctx.rs/functions/v1/releases/stable/ctx-release-metadata.env"
+            "https://cli.ctx.rs/functions/v2/releases/stable/ctx-release-metadata.env"
         );
         assert_eq!(
             metadata_signature_url(&metadata),
-            "https://cli.ctx.rs/functions/v1/releases/stable/ctx-release-metadata.env.sig"
+            "https://cli.ctx.rs/functions/v2/releases/stable/ctx-release-metadata.env.sig"
+        );
+        let staging_metadata = metadata_url("staging");
+        assert_eq!(
+            staging_metadata,
+            "https://cli.ctx.rs/functions/v1/releases/staging/ctx-release-metadata.env"
+        );
+        assert_eq!(
+            metadata_signature_url(&staging_metadata),
+            "https://cli.ctx.rs/functions/v1/releases/staging/ctx-release-metadata.env.sig"
         );
         let key = public_key_der().expect("decode embedded production release key");
         assert_eq!(


### PR DESCRIPTION
Stable clients use the v2 update endpoint so the original endpoint can remain on a frozen bridge release. Staging keeps its existing route and signature verification uses the existing trust key.

Hosted installations that reached the bridge without a companion can now finish their first managed pair through ordinary upgrade, including when the offered version equals the installed version. The existing installation lock, authenticated downloads, daemon handoff and pair publication remain responsible. Unmanaged installs remain unchanged; older releases and conflicting same-version identities are rejected.

Validation: physical Rust crate-size checks and the 450-target Clippy build passed. All 115 selected affected targets have passing results: 113 in the original run and two after removing a harness override of their Gemini fixture directory. The original failures are retained. Independent review approved the combined source. This source change does not publish or qualify a bridge release.
