### PR TITLE
fix(semantic): prevent tokenizer truncation of document chunks

### DIFF
--- a/crates/ctx-daemon-cli/src/query_adapter.rs
+++ b/crates/ctx-daemon-cli/src/query_adapter.rs
@@ -352,6 +352,11 @@ struct PassiveSemanticExecutorUnavailable {
 }
 
 impl SemanticBatchEmbedder for ForegroundSemanticEmbedder<'_> {
+    fn document_fits(&mut self, text: &str) -> Result<bool> {
+        ensure_foreground_executor(self.executor)?;
+        self.executor.executor().document_fits(text)
+    }
+
     fn embed_chunks(&mut self, chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
         ensure_foreground_executor(self.executor)?;
         let texts = chunks
@@ -494,6 +499,10 @@ fn reconcile_foreground_source_backed_semantic_with_checkpoint(
 struct EmptyForegroundSemanticEmbedder;
 
 impl SemanticBatchEmbedder for EmptyForegroundSemanticEmbedder {
+    fn document_fits(&mut self, _text: &str) -> Result<bool> {
+        anyhow::bail!("unexpected semantic input assessment")
+    }
+
     fn embed_chunks(&mut self, _chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
         anyhow::bail!("zero-eligible semantic reconciliation requested embeddings")
     }

--- a/crates/ctx-daemon-cli/src/query_adapter/tests.rs
+++ b/crates/ctx-daemon-cli/src/query_adapter/tests.rs
@@ -159,6 +159,10 @@ impl SemanticDocumentBuilder for RejectingSemanticPorts {
 }
 
 impl SemanticBatchEmbedder for RejectingSemanticPorts {
+    fn document_fits(&mut self, _text: &str) -> Result<bool> {
+        anyhow::bail!("unexpected semantic input assessment")
+    }
+
     fn embed_chunks(&mut self, _chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
         Err(anyhow!(
             "empty semantic fixture unexpectedly requested embeddings"
@@ -795,6 +799,10 @@ struct FixtureSemanticEmbedder {
 }
 
 impl SemanticBatchEmbedder for FixtureSemanticEmbedder {
+    fn document_fits(&mut self, _text: &str) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+
     fn embed_chunks(&mut self, chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
         Ok(chunks
             .iter()

--- a/crates/ctx-daemon-cli/src/semantic_completion/tests.rs
+++ b/crates/ctx-daemon-cli/src/semantic_completion/tests.rs
@@ -807,6 +807,10 @@ impl SemanticDocumentBuilder for RejectingEmptySemanticPorts {
 }
 
 impl SemanticBatchEmbedder for RejectingEmptySemanticPorts {
+    fn document_fits(&mut self, _text: &str) -> Result<bool> {
+        anyhow::bail!("unexpected semantic input assessment")
+    }
+
     fn embed_chunks(&mut self, _chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
         panic!("empty generation must not request embeddings")
     }

--- a/crates/ctx-daemon-cli/src/source_status_tests.rs
+++ b/crates/ctx-daemon-cli/src/source_status_tests.rs
@@ -107,6 +107,10 @@ impl SemanticDocumentBuilder for StatusSemanticBuilder {
 struct StatusSemanticEmbedder;
 
 impl SemanticBatchEmbedder for StatusSemanticEmbedder {
+    fn document_fits(&mut self, _text: &str) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+
     fn embed_chunks(&mut self, chunks: &[SemanticChunkDocument]) -> anyhow::Result<Vec<Vec<f32>>> {
         Ok(chunks
             .iter()

--- a/crates/ctx-daemon-service/src/daemon_worker.rs
+++ b/crates/ctx-daemon-service/src/daemon_worker.rs
@@ -137,7 +137,7 @@ where
             return Ok(daemon_semantic_model_acquisition_error(
                 last_run_at_ms,
                 error,
-            ))
+            ));
         }
     };
     let mut acquire_cpu_fallback = Some(acquire_cpu_fallback);
@@ -163,7 +163,7 @@ where
                         return Ok(daemon_semantic_model_acquisition_error(
                             last_run_at_ms,
                             error,
-                        ))
+                        ));
                     }
                 };
             }
@@ -637,12 +637,20 @@ struct RuntimeSourceSemanticEmbedder<'a> {
 struct EmptySourceSemanticEmbedder;
 
 impl SemanticBatchEmbedder for EmptySourceSemanticEmbedder {
+    fn document_fits(&mut self, _text: &str) -> Result<bool> {
+        anyhow::bail!("unexpected semantic input assessment")
+    }
+
     fn embed_chunks(&mut self, _chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
         anyhow::bail!("zero-eligible semantic reconciliation requested embeddings")
     }
 }
 
 impl SemanticBatchEmbedder for RuntimeSourceSemanticEmbedder<'_> {
+    fn document_fits(&mut self, text: &str) -> Result<bool> {
+        self.executor.document_fits(text)
+    }
+
     fn embed_chunks(&mut self, chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
         let texts = chunks
             .iter()

--- a/crates/ctx-daemon-service/src/daemon_worker_tests.rs
+++ b/crates/ctx-daemon-service/src/daemon_worker_tests.rs
@@ -92,6 +92,10 @@ impl DaemonConfigPort for RejectingSemanticAuthConfig {
 }
 
 impl SemanticBatchEmbedder for RejectingEmptySemanticEmbedder {
+    fn document_fits(&mut self, _text: &str) -> Result<bool> {
+        anyhow::bail!("unexpected semantic input assessment")
+    }
+
     fn embed_chunks(&mut self, _chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
         panic!("an empty semantic generation must not request embeddings")
     }
@@ -112,6 +116,10 @@ fn acknowledge_empty_semantic_generation(
 }
 
 impl SemanticEmbeddingExecutor for RecordingSemanticExecutor {
+    fn document_fits(&self, _text: &str) -> Result<bool> {
+        Ok(true)
+    }
+
     fn contract(&self) -> &SemanticModelContract {
         &self.contract
     }
@@ -476,7 +484,10 @@ fn ready_empty_v2_generation_is_observed_without_constructing_an_executor() -> R
 #[test]
 fn bounded_zero_eligible_reconciliation_advances_one_boundary_without_executor() -> Result<()> {
     let fixture = CoreFixture::new();
-    let record_count = MAX_SOURCE_EVENT_PAGE_ITEMS + 1;
+    // The semantic page budget is512; the Core reader's larger maximum is
+    // not the selected semantic work-unit size.
+    const SEMANTIC_PAGE_RECORDS: usize = 512;
+    let record_count = SEMANTIC_PAGE_RECORDS + 1;
     let mut records = Vec::with_capacity(record_count);
     for sequence in 0..record_count as u64 {
         let mut record = fixture.record(sequence, EventRole::User, "excluded retrieval result");
@@ -500,7 +511,7 @@ fn bounded_zero_eligible_reconciliation_advances_one_boundary_without_executor()
     assert_eq!(first["status"], "budget_exhausted", "{first:#}");
     assert_eq!(first["semantic_progress_sequence"], 1, "{first:#}");
     assert_eq!(
-        first["source_records_decoded"], MAX_SOURCE_EVENT_PAGE_ITEMS,
+        first["source_records_decoded"], SEMANTIC_PAGE_RECORDS,
         "{first:#}"
     );
     assert!(runtime.semantic_executor.is_none());

--- a/crates/ctx-history-index-format/src/policy.rs
+++ b/crates/ctx-history-index-format/src/policy.rs
@@ -17,7 +17,7 @@ pub const SOURCE_EVENT_PROJECTOR_REVISION: u32 = 9;
 pub const LEXICAL_INDEXED_BODY_LIMIT: LexicalIndexedBodyLimit =
     LexicalIndexedBodyLimit::ProviderValidatedFullText;
 pub const SEMANTIC_ELIGIBILITY_REVISION: u32 = 6;
-pub const SEMANTIC_CHUNKING_REVISION: u32 = 1;
+pub const SEMANTIC_CHUNKING_REVISION: u32 = 2;
 pub const SEMANTIC_CHUNK_TARGET_CHARS: usize = 1_200;
 pub const SEMANTIC_CHUNK_OVERLAP_CHARS: usize = 200;
 pub const SEMANTIC_SOURCE_MAX_CHARS: usize = 64 * 1024;
@@ -242,7 +242,13 @@ pub fn semantic_generation_policy(
             SemanticCoreContentFilter::PolicySelectedCompleteContentAndBoundedLiteralFactsV3,
         provider_native_event_copy:
             SemanticEventCopyFilter::IncludeAllOccurrencesDirectCopyNeutralV1,
-        chunking_revision: SEMANTIC_CHUNKING_REVISION,
+        // HTTP keeps its historical endpoint-owned chunk inputs. Its receipt
+        // must not certify local tokenizer-fitted spans, even for fixed-E5 V1.
+        chunking_revision: if model_contract.external_http_endpoint().is_some() {
+            1
+        } else {
+            SEMANTIC_CHUNKING_REVISION
+        },
         chunk_target_chars: SEMANTIC_CHUNK_TARGET_CHARS as u32,
         chunk_overlap_chars: SEMANTIC_CHUNK_OVERLAP_CHARS as u32,
         source_max_chars: SEMANTIC_SOURCE_MAX_CHARS as u32,
@@ -358,7 +364,7 @@ mod tests {
 
     #[test]
     fn semantic_policy_persisted_bytes_and_model_authority_are_frozen() {
-        const EXPECTED: &str = "{\"eligibility_revision\":6,\"candidate_event_classes\":[\"message\"],\"candidate_roles\":[\"user\"],\"core_content_filter\":\"policy_selected_complete_content_and_bounded_literal_facts_v3\",\"provider_native_event_copy\":\"include_all_occurrences_direct_copy_neutral_v1\",\"chunking_revision\":1,\"chunk_target_chars\":1200,\"chunk_overlap_chars\":200,\"source_max_chars\":65536,\"embedding\":{\"contract_revision\":2,\"model\":\"intfloat/multilingual-e5-small\",\"model_revision\":\"614241f622f53c4eeff9890bdc4f31cfecc418b3\",\"dimensions\":384,\"normalization\":\"l2\"}}";
+        const EXPECTED: &str = "{\"eligibility_revision\":6,\"candidate_event_classes\":[\"message\"],\"candidate_roles\":[\"user\"],\"core_content_filter\":\"policy_selected_complete_content_and_bounded_literal_facts_v3\",\"provider_native_event_copy\":\"include_all_occurrences_direct_copy_neutral_v1\",\"chunking_revision\":2,\"chunk_target_chars\":1200,\"chunk_overlap_chars\":200,\"source_max_chars\":65536,\"embedding\":{\"contract_revision\":2,\"model\":\"intfloat/multilingual-e5-small\",\"model_revision\":\"614241f622f53c4eeff9890bdc4f31cfecc418b3\",\"dimensions\":384,\"normalization\":\"l2\"}}";
         let policy = current_semantic_generation_policy();
         let contract = ctx_semantic_model::semantic_model_contract();
         let persisted = serde_json::to_string(&policy).unwrap();
@@ -367,7 +373,7 @@ mod tests {
         assert_eq!(persisted, EXPECTED);
         assert_eq!(
             policy.canonical_sha256().unwrap(),
-            "e8d31418a1da20200d75580348b8b2e7ee4f97c58f34a46900fc6d87daa83ccf"
+            "d161ce104fc4b705c68ccc1aafd60f80e1254b166c4a79128e3a3aa2cb954baf"
         );
         assert_eq!(
             policy.embedding.contract_revision,

--- a/crates/ctx-semantic-index/src/indexing.rs
+++ b/crates/ctx-semantic-index/src/indexing.rs
@@ -14,6 +14,7 @@ pub(super) fn semantic_source_text(text: &str) -> String {
     text.chars().take(SEMANTIC_SOURCE_MAX_CHARS).collect()
 }
 
+#[cfg(test)]
 pub(super) fn semantic_chunks_for_document(
     doc: &SemanticEventDocument,
     source_text: &str,
@@ -36,6 +37,9 @@ pub(super) fn semantic_chunks_for_document(
         )
         .collect()
 }
+
+mod token_fit;
+pub(super) use token_fit::semantic_chunks_for_document_with_fit;
 
 pub(super) fn semantic_document_hash(
     model_contract: &SemanticModelContract,
@@ -137,6 +141,7 @@ pub(super) fn semantic_header_value(value: &str, max_chars: usize) -> String {
     output
 }
 
+#[cfg(test)]
 pub(super) fn semantic_text_chunks(text: &str) -> Vec<(usize, usize, String)> {
     let chars = text.chars().collect::<Vec<_>>();
     if chars.is_empty() {

--- a/crates/ctx-semantic-index/src/indexing/token_fit.rs
+++ b/crates/ctx-semantic-index/src/indexing/token_fit.rs
@@ -1,0 +1,143 @@
+use anyhow::Result;
+
+use super::*;
+use crate::vector_store_schema::SemanticVectorStoreError;
+
+// A derived header may be shortened to leave useful room for original text.
+const BODY_RESERVE_CHARS: usize = 256;
+const MAX_DOCUMENT_CHUNKS: usize = 1_024;
+const FIT_REFINEMENT_STEPS: usize = 2;
+// Includes the original window, header reservation, shrinking and refinement.
+const MAX_WINDOW_ASSESSMENTS: usize = 28;
+
+/// Finalize source spans only after the selected executor accepts the complete
+/// header/body input. Each candidate is tested; token-count monotonicity is not
+/// assumed and this bounded refinement does not promise the largest fit.
+pub(crate) fn semantic_chunks_for_document_with_fit(
+    doc: &SemanticEventDocument,
+    source_text: &str,
+    source_text_hash: &str,
+    fits: &mut dyn FnMut(&str) -> Result<bool>,
+) -> Result<Vec<SemanticChunkDocument>> {
+    let chars: Vec<char> = source_text
+        .chars()
+        .take(SEMANTIC_SOURCE_MAX_CHARS + 1)
+        .collect();
+    if chars.len() > SEMANTIC_SOURCE_MAX_CHARS {
+        return Err(SemanticVectorStoreError::unavailable(
+            "semantic source exceeds its chunking bound",
+        )
+        .into());
+    }
+    let header: Vec<char> = semantic_document_header(doc).chars().collect();
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < chars.len() {
+        if chunks.len() == MAX_DOCUMENT_CHUNKS {
+            return Err(SemanticVectorStoreError::unavailable(
+                "semantic document exceeds the token-fit chunk limit",
+            )
+            .into());
+        }
+        let mut assessments = 0;
+        let mut assess = |input: &str| {
+            if assessments == MAX_WINDOW_ASSESSMENTS {
+                return Err(SemanticVectorStoreError::unavailable(
+                    "semantic document exhausted its bounded token-fit assessment budget",
+                )
+                .into());
+            }
+            assessments += 1;
+            fits(input)
+        };
+        let mut end = (start + SEMANTIC_CHUNK_TARGET_CHARS).min(chars.len());
+        if end < chars.len() {
+            let floor = end.saturating_sub(150).max(start + 1);
+            if let Some(index) = (floor..end).rev().find(|&i| chars[i].is_whitespace()) {
+                end = index + 1;
+            }
+        }
+        let mut header_len = header.len();
+        let mut input = input_text(&header[..header_len], &chars[start..end]);
+        if !assess(&input)? {
+            // Retain the header when it can accompany a useful body prefix.
+            // Dense optional facts must not permanently consume the body budget.
+            let reserve_end = (start + BODY_RESERVE_CHARS).min(end);
+            let reserve_fits = loop {
+                let fit = assess(&input_text(
+                    &header[..header_len],
+                    &chars[start..reserve_end],
+                ))?;
+                if fit || header_len == 0 {
+                    break fit;
+                }
+                header_len /= 2;
+            };
+            let mut rejected_end = end;
+            loop {
+                input = input_text(&header[..header_len], &chars[start..end]);
+                if assess(&input)? {
+                    break;
+                }
+                rejected_end = end;
+                if end == start + 1 {
+                    return Err(SemanticVectorStoreError::unavailable("semantic document has no fitting source window within the bounded token-fit plan").into());
+                }
+                let mut next_end = start + (end - start) / 2;
+                if reserve_fits {
+                    next_end = next_end.max(reserve_end);
+                }
+                if next_end >= end {
+                    return Err(SemanticVectorStoreError::unavailable(
+                        "semantic document fit changed before a source window could be finalized",
+                    )
+                    .into());
+                }
+                end = next_end;
+            }
+            // Recover some spare capacity without an exact-max search. Failed
+            // probes only choose the next candidate; accepted spans always fit.
+            for _ in 0..FIT_REFINEMENT_STEPS {
+                let candidate = end + (rejected_end - end) / 2;
+                if candidate <= end {
+                    break;
+                }
+                let refined = input_text(&header[..header_len], &chars[start..candidate]);
+                if assess(&refined)? {
+                    end = candidate;
+                    input = refined;
+                } else {
+                    rejected_end = candidate;
+                }
+            }
+        }
+        chunks.push(SemanticChunkDocument {
+            event_id: doc.event_id,
+            seq: doc.seq,
+            chunk_index: chunks.len(),
+            source_text_hash: source_text_hash.to_owned(),
+            text: input,
+            start_char: start,
+            end_char: end,
+        });
+        if end == chars.len() {
+            break;
+        }
+        // Retain desired overlap for normal windows; cap it for short fits so
+        // every iteration advances and no original source position is skipped.
+        start = end - SEMANTIC_CHUNK_OVERLAP_CHARS.min((end - start) / 2);
+    }
+    Ok(chunks)
+}
+
+fn input_text(header: &[char], body: &[char]) -> String {
+    let mut text: String = header.iter().collect();
+    if !header.is_empty() {
+        text.push_str("\n\n");
+    }
+    text.extend(body);
+    text
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ctx-semantic-index/src/indexing/token_fit/tests.rs
+++ b/crates/ctx-semantic-index/src/indexing/token_fit/tests.rs
@@ -1,0 +1,179 @@
+use super::*;
+use ctx_history_core::{EventRole, EventType, LiteralFactKind, ProviderDeclaredFact};
+use uuid::Uuid;
+
+fn document(body: &str) -> SemanticEventDocument {
+    SemanticEventDocument::new(
+        Uuid::from_u128(1),
+        Some(Uuid::from_u128(2)),
+        7,
+        0,
+        EventType::Message,
+        Some(EventRole::User),
+        "lite_turn".to_owned(),
+        None,
+        None,
+        None,
+        Vec::new(),
+        body.to_owned(),
+    )
+}
+
+fn body(input: &str) -> &str {
+    input.split_once("\n\n").map_or(input, |(_, body)| body)
+}
+
+fn check_spans(doc: &SemanticEventDocument, chunks: &[SemanticChunkDocument]) {
+    let source: Vec<char> = doc.text.chars().collect();
+    let mut covered = vec![false; source.len()];
+    let mut previous_start = None;
+    for (index, chunk) in chunks.iter().enumerate() {
+        assert_eq!(chunk.event_id, doc.event_id);
+        assert_eq!(chunk.seq, 7);
+        assert_eq!(chunk.source_text_hash, "source-hash");
+        assert_eq!(chunk.chunk_index, index);
+        assert!(chunk.start_char < chunk.end_char && chunk.end_char <= source.len());
+        if let Some(previous) = previous_start {
+            assert!(chunk.start_char > previous);
+        }
+        previous_start = Some(chunk.start_char);
+        assert_eq!(
+            body(&chunk.text),
+            source[chunk.start_char..chunk.end_char]
+                .iter()
+                .collect::<String>()
+        );
+        covered[chunk.start_char..chunk.end_char].fill(true);
+    }
+    assert!(covered.iter().all(|c| *c));
+}
+
+#[test]
+fn fitting_inputs_preserve_existing_windows_and_exact_metadata() -> Result<()> {
+    let doc = document(&"ordinary code and conversation ".repeat(160));
+    let old = semantic_chunks_for_document(&doc, &doc.text, "source-hash");
+    let new =
+        semantic_chunks_for_document_with_fit(&doc, &doc.text, "source-hash", &mut |_| Ok(true))?;
+    assert_eq!(old.len(), new.len());
+    for (old, new) in old.iter().zip(&new) {
+        assert_eq!(
+            (old.start_char, old.end_char, &old.text),
+            (new.start_char, new.end_char, &new.text)
+        );
+    }
+    check_spans(&doc, &new);
+    Ok(())
+}
+
+#[test]
+fn dense_body_refines_a_tested_fit_and_preserves_unicode_source_coverage() -> Result<()> {
+    let doc = document(&"世界🌍".repeat(1500));
+    let mut calls = 0;
+    let chunks =
+        semantic_chunks_for_document_with_fit(&doc, &doc.text, "source-hash", &mut |input| {
+            calls += 1;
+            Ok(body(input).chars().count() <= 810)
+        })?;
+    assert_eq!(
+        chunks[0].end_char, 750,
+        "bounded refinement recovers capacity above600"
+    );
+    assert!(chunks.iter().all(|c| body(&c.text).chars().count() <= 810));
+    assert!(calls <= chunks.len() * MAX_WINDOW_ASSESSMENTS);
+    check_spans(&doc, &chunks);
+    Ok(())
+}
+
+#[test]
+fn dense_metadata_yields_to_original_body_without_changing_core_document() -> Result<()> {
+    let mut doc = document(&"x".repeat(3000));
+    doc.literal_facts = (0..10)
+        .map(|_| ProviderDeclaredFact {
+            kind: LiteralFactKind::Workspace,
+            value: "世界".repeat(120),
+        })
+        .collect();
+    let original = doc.clone();
+    let header = semantic_document_header(&doc);
+    assert!(header.chars().count() > 500);
+    let chunks =
+        semantic_chunks_for_document_with_fit(&doc, &doc.text, "source-hash", &mut |input| {
+            Ok(input.chars().count() <= 512)
+        })?;
+    assert!(chunks.iter().all(|c| c.text.chars().count() <= 512));
+    assert!(body(&chunks[0].text).chars().count() >= BODY_RESERVE_CHARS);
+    assert_eq!(doc, original);
+    check_spans(&doc, &chunks);
+    Ok(())
+}
+
+#[test]
+fn nonmonotone_fit_accepts_only_tested_candidates_and_retains_viable_reserve() -> Result<()> {
+    let doc = document(&"z".repeat(3000));
+    let chunks =
+        semantic_chunks_for_document_with_fit(&doc, &doc.text, "source-hash", &mut |input| {
+            let n = body(input).len();
+            Ok(n == 256 || n <= 80)
+        })?;
+    assert_eq!(chunks[0].end_char, 256);
+    assert!(chunks
+        .iter()
+        .all(|c| body(&c.text).len() == 256 || body(&c.text).len() <= 80));
+    check_spans(&doc, &chunks);
+    Ok(())
+}
+
+#[test]
+fn empty_input_has_no_fit_calls_and_impossible_input_fails_with_a_finite_bound() -> Result<()> {
+    let empty = document("");
+    assert!(
+        semantic_chunks_for_document_with_fit(&empty, "", "source-hash", &mut |_| panic!(
+            "empty fit"
+        ))?
+        .is_empty()
+    );
+    let doc = document(&"x".repeat(1200));
+    let mut calls = 0;
+    let error = semantic_chunks_for_document_with_fit(&doc, &doc.text, "source-hash", &mut |_| {
+        calls += 1;
+        Ok(false)
+    })
+    .unwrap_err();
+    assert_eq!(
+        crate::semantic_vector_failure_kind(&error),
+        Some(crate::SemanticVectorFailureKind::Unavailable)
+    );
+    assert!(calls <= MAX_WINDOW_ASSESSMENTS);
+    Ok(())
+}
+
+#[test]
+fn excessive_tiny_windows_fail_before_unbounded_chunk_amplification() {
+    let doc = document(&"x".repeat(MAX_DOCUMENT_CHUNKS + 1));
+    let mut calls = 0;
+    let result =
+        semantic_chunks_for_document_with_fit(&doc, &doc.text, "source-hash", &mut |input| {
+            calls += 1;
+            Ok(body(input).len() == 1)
+        });
+    assert!(result.is_err());
+    assert!(calls <= MAX_DOCUMENT_CHUNKS * MAX_WINDOW_ASSESSMENTS);
+}
+
+#[test]
+fn changing_fit_cannot_stall_at_a_previously_accepted_reserve() {
+    let doc = document(&"x".repeat(1200));
+    let mut calls = 0;
+    let result = semantic_chunks_for_document_with_fit(&doc, &doc.text, "source-hash", &mut |_| {
+        calls += 1;
+        // The original window fails, its reserve fits once, then authority changes.
+        Ok(calls == 2)
+    });
+    let error = result.unwrap_err();
+    assert_eq!(
+        crate::semantic_vector_failure_kind(&error),
+        Some(crate::SemanticVectorFailureKind::Unavailable)
+    );
+    assert!(calls <= MAX_WINDOW_ASSESSMENTS);
+    assert!(error.to_string().contains("fit changed"));
+}

--- a/crates/ctx-semantic-index/src/vector_store/source_projection.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection.rs
@@ -22,7 +22,9 @@ use super::flat_segments::{
 };
 use super::{SemanticChunkDocument, SemanticVectorStore};
 use crate::{
-    indexing::{semantic_chunks_for_document, semantic_document_hash, semantic_source_text},
+    indexing::{
+        semantic_chunks_for_document_with_fit, semantic_document_hash, semantic_source_text,
+    },
     vector_store_schema::SemanticVectorStoreError,
     SemanticEventDocument,
 };
@@ -35,15 +37,15 @@ mod state;
 
 pub use embedding::SemanticBatchEmbedder;
 use embedding::{
-    embed_chunks_in_bounded_batches, external_embedding_chunk_limit, source_event_page_limit,
-    ResolvedSourceDocument, SourceProjectionWorkers,
+    embed_chunks_in_bounded_batches, source_event_page_limit, ResolvedSourceDocument,
+    SourceProjectionWorkers,
 };
 #[cfg(test)]
 use manifest::SOURCE_CONTRACT_VERSION;
 use manifest::{
     source_contract_fingerprint, source_contract_fingerprint_with_authority, validate_generation,
-    validate_page, validate_resolved_document, SourceProjectionFrontier, SourceTraversalPhase,
-    SOURCE_INPUT_LEXICAL_SCHEMA_VERSION,
+    validate_page, validate_resolved_document, validate_stored_event, SourceProjectionFrontier,
+    SourceTraversalPhase, SOURCE_INPUT_LEXICAL_SCHEMA_VERSION,
 };
 use outcome::merge_outcome;
 pub use outcome::SourceBackedSemanticOutcome;
@@ -501,7 +503,7 @@ impl SemanticVectorStore {
         progress: &mut dyn FnMut(u64) -> Result<()>,
     ) -> Result<SourceBackedSemanticOutcome> {
         let model_contract = self.contract().clone();
-        let embedding_chunk_limit = external_embedding_chunk_limit(&model_contract);
+        let embedding_chunk_limit = source_event_page_limit(&model_contract);
         let after = frontier
             .after_identity
             .as_deref()
@@ -562,6 +564,22 @@ impl SemanticVectorStore {
                 ..SourceBackedSemanticOutcome::default()
             });
         }
+        // Read the same bounded page's existing authority before planning. A
+        // policy-compatible unchanged document needs no tokenizer or model load.
+        let eligible_event_ids = page
+            .records
+            .iter()
+            .filter(|record| generation.includes(record))
+            .map(|record| record.event_id.as_uuid())
+            .collect::<Vec<_>>();
+        let existing_events = self
+            .flat
+            .source_reconciliation_events(&eligible_event_ids)
+            .map_err(anyhow::Error::new)?
+            .into_iter()
+            .zip(eligible_event_ids)
+            .filter_map(|(event, event_id)| event.map(|event| (event_id, event)))
+            .collect::<HashMap<_, _>>();
         let mut outcome = SourceBackedSemanticOutcome {
             records_decoded,
             record_bytes_decoded,
@@ -580,12 +598,17 @@ impl SemanticVectorStore {
                 processed_page_records = processed_page_records.saturating_add(1);
                 continue;
             }
-            // Stop on a record boundary once this external work unit has filled
+            // Stop on a record boundary once this work unit has filled
             // its embedding budget. A first record is always admitted below so
             // one valid document that expands past the limit still progresses.
-            if embedding_chunk_limit.is_some_and(|limit| projected_chunks >= limit) {
+            if projected_chunks >= embedding_chunk_limit {
                 break;
             }
+            validate_stored_event(
+                record,
+                source,
+                existing_events.get(&record.event_id.as_uuid()),
+            )?;
             let next_semantic_records = semantic_records.checked_add(1).ok_or_else(|| {
                 SemanticVectorStoreError::reset_required(
                     "source-backed semantic candidate count overflowed",
@@ -623,8 +646,21 @@ impl SemanticVectorStore {
                 &source_text,
                 &frontier.semantic_policy_fingerprint,
             );
-            let chunks = semantic_chunks_for_document(&document, &source_text, &source_text_sha256);
-            if chunks.is_empty() {
+            let reusable = frontier.vector_reuse_allowed
+                && existing_events
+                    .get(&record.event_id.as_uuid())
+                    .is_some_and(|event| event.source_text_hash.to_hex() == source_text_sha256);
+            let chunks = if reusable {
+                Vec::new()
+            } else {
+                semantic_chunks_for_document_with_fit(
+                    &document,
+                    &source_text,
+                    &source_text_sha256,
+                    &mut |text| workers.embedder.document_fits(text),
+                )?
+            };
+            if !reusable && chunks.is_empty() {
                 return Err(anyhow!(
                     "Core semantic projection produced an empty document for {}",
                     record.event_id
@@ -635,9 +671,7 @@ impl SemanticVectorStore {
                     "source-backed semantic embedding chunk count overflowed",
                 )
             })?;
-            if projected_chunks != 0
-                && embedding_chunk_limit.is_some_and(|limit| generated_chunks > limit)
-            {
+            if projected_chunks != 0 && generated_chunks > embedding_chunk_limit {
                 break;
             }
             projected_chunks = generated_chunks;
@@ -673,40 +707,6 @@ impl SemanticVectorStore {
                 "source-backed semantic source page count disagrees with its Core aggregate",
             )
             .into());
-        }
-        let eligible_event_ids = page
-            .records
-            .iter()
-            .filter(|record| generation.includes(record))
-            .map(|record| record.event_id.as_uuid())
-            .collect::<Vec<_>>();
-        let existing_events = self
-            .flat
-            .source_reconciliation_events(&eligible_event_ids)
-            .map_err(anyhow::Error::new)?
-            .into_iter()
-            .zip(eligible_event_ids)
-            .filter_map(|(event, event_id)| event.map(|event| (event_id, event)))
-            .collect::<HashMap<_, _>>();
-        for record in page
-            .records
-            .iter()
-            .filter(|record| generation.includes(record))
-        {
-            let stable_identity = record.event_id.encode_canonical()?;
-            let stable_identity_hash = Sha256::digest(stable_identity);
-            if let Some(prior) = existing_events.get(&record.event_id.as_uuid()) {
-                if (prior.stable_identity_hash != [0; 32]
-                    && prior.stable_identity_hash != stable_identity_hash.as_slice())
-                    || prior.source_identity_digest != source.aggregate.source_identity_digest()
-                {
-                    return Err(SemanticVectorStoreError::storage_conflict(format!(
-                        "source-backed semantic compact identity collision at {}",
-                        record.event_id.as_uuid()
-                    ))
-                    .into());
-                }
-            }
         }
         let existing_lookup = FlatActiveEventLookup::from_events(
             page.records
@@ -780,7 +780,7 @@ impl SemanticVectorStore {
                 workers.embedder,
                 pending_chunks,
                 model_contract.dimensions(),
-                embedding_chunk_limit,
+                Some(embedding_chunk_limit),
             )?;
             outcome.records_embedded = outcome.records_embedded.saturating_add(pending_documents);
         }

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/embedding.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/embedding.rs
@@ -1,6 +1,10 @@
 use super::*;
 
 pub trait SemanticBatchEmbedder {
+    /// Assesses raw ctx header/body text with the selected executor's preparation.
+    /// It must not publish vectors or mutate source progress.
+    fn document_fits(&mut self, text: &str) -> Result<bool>;
+
     fn embed_chunks(&mut self, chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>>;
 }
 
@@ -26,8 +30,10 @@ pub(super) fn external_embedding_chunk_limit(
         .map(|space| space.max_inputs_per_request())
 }
 
+const DEFAULT_EMBEDDING_PAGE_CHUNKS: usize = 512;
+
 pub(super) fn source_event_page_limit(model_contract: &SemanticModelContract) -> usize {
-    external_embedding_chunk_limit(model_contract).unwrap_or(MAX_SOURCE_EVENT_PAGE_ITEMS)
+    external_embedding_chunk_limit(model_contract).unwrap_or(DEFAULT_EMBEDDING_PAGE_CHUNKS)
 }
 
 pub(super) fn embed_chunks_in_bounded_batches(

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/manifest.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/manifest.rs
@@ -7,10 +7,10 @@ use ctx_semantic_model::SemanticModelContract;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use super::{SourceBackedSemanticGeneration, SourceBackedSemanticPage};
+use super::{SourceBackedSemanticGeneration, SourceBackedSemanticPage, SourceBackedSemanticSource};
 use crate::{
     vector_store::flat_segments::{
-        FlatPublicationToken, FlatSourceStagingToken, PinnedFlatGeneration,
+        FlatActiveEvent, FlatPublicationToken, FlatSourceStagingToken, PinnedFlatGeneration,
     },
     SemanticEventDocument,
 };
@@ -185,6 +185,29 @@ pub(super) fn validate_page(
             ));
         }
         previous = Some(encoded.to_vec());
+    }
+    Ok(())
+}
+
+// Validate stored identity before its hash can avoid model work.
+pub(super) fn validate_stored_event(
+    record: &CoreEventRecord,
+    source: &SourceBackedSemanticSource,
+    prior: Option<&FlatActiveEvent>,
+) -> Result<()> {
+    let stable_identity = record.event_id.encode_canonical()?;
+    let stable_identity_hash = Sha256::digest(stable_identity);
+    if let Some(prior) = prior {
+        if (prior.stable_identity_hash != [0; 32]
+            && prior.stable_identity_hash != stable_identity_hash.as_slice())
+            || prior.source_identity_digest != source.aggregate.source_identity_digest()
+        {
+            return Err(super::SemanticVectorStoreError::storage_conflict(format!(
+                "source-backed semantic compact identity collision at {}",
+                record.event_id.as_uuid()
+            ))
+            .into());
+        }
     }
     Ok(())
 }

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests.rs
@@ -39,6 +39,7 @@ mod proportionality;
 mod provider_native;
 mod recovery;
 mod retrieval_exclusion;
+mod token_fit;
 
 const TAIL_TOKEN: &str = "semantic-tail-token-7f0d";
 const EMPTY_DOCUMENT_TOKEN: &str = "semantic-empty-document-fixture-7f0d";
@@ -96,11 +97,17 @@ impl SemanticDocumentBuilder for CoreBuilder {
 
 #[derive(Default)]
 struct MarkerEmbedder {
+    fit_calls: usize,
     chunks: usize,
     calls: usize,
 }
 
 impl SemanticBatchEmbedder for MarkerEmbedder {
+    fn document_fits(&mut self, _text: &str) -> anyhow::Result<bool> {
+        self.fit_calls += 1;
+        Ok(true)
+    }
+
     fn embed_chunks(&mut self, chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
         self.calls = self.calls.saturating_add(1);
         self.chunks = self.chunks.saturating_add(chunks.len());
@@ -132,6 +139,10 @@ impl DimensionEmbedder {
 }
 
 impl SemanticBatchEmbedder for DimensionEmbedder {
+    fn document_fits(&mut self, _text: &str) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+
     fn embed_chunks(&mut self, chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
         self.chunks = self.chunks.saturating_add(chunks.len());
         self.batch_sizes.push(chunks.len());
@@ -892,51 +903,6 @@ fn four_event_source_work_is_independent_of_740k_equivalent_corpus() -> Result<(
 }
 
 #[test]
-fn sequence_only_core_change_updates_authority_without_embedding() -> Result<()> {
-    let fixture = Fixture::new(1)?;
-    let initial = fixture.publish_with_event_sequences(
-        "sequence-a",
-        &[(0, vec![(1, "same semantic body".to_owned())])],
-    )?;
-    let target = fixture.publish_with_event_sequences(
-        "sequence-b",
-        &[(0, vec![(91, "same semantic body".to_owned())])],
-    )?;
-    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
-    let mut builder = CoreBuilder::default();
-    let mut embedder = MarkerEmbedder::default();
-    reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
-    let embedded_before = embedder.chunks;
-
-    let outcome = reconcile_all(&mut store, &target, &mut builder, &mut embedder)?;
-    assert_eq!(outcome.records_decoded, 1);
-    assert_eq!(outcome.records_reused, 1);
-    assert_eq!(outcome.records_embedded, 0);
-    assert_eq!(outcome.vectors_touched, 0);
-    assert_eq!(outcome.vector_bytes_touched, 0);
-    assert!(outcome.metadata_records_touched < 32);
-    assert_eq!(embedder.chunks, embedded_before);
-    assert!(matches!(
-        store.source_backed_generation_pin_exact(initial.generation_id(), 1)?,
-        SourceBackedGenerationPin::NotReady
-    ));
-    let pin = match store.source_backed_generation_pin_exact(target.generation_id(), 1)? {
-        SourceBackedGenerationPin::Ready(pin) => pin,
-        SourceBackedGenerationPin::NotReady | SourceBackedGenerationPin::ReadyEmpty => {
-            return Err(anyhow!("sequence-only target did not produce an exact pin"));
-        }
-    };
-    let chunk = pin
-        .scan_segments()
-        .iter()
-        .flat_map(|segment| segment.chunks())
-        .next()
-        .ok_or_else(|| anyhow!("sequence-only target lost its vector"))?;
-    assert_eq!(chunk.seq, 91);
-    Ok(())
-}
-
-#[test]
 fn multi_page_reconciliation_constructs_one_flat_view() -> Result<()> {
     let fixture = Fixture::new(1)?;
     let record_count = MAX_SOURCE_EVENT_PAGE_ITEMS + 4;
@@ -963,7 +929,8 @@ fn multi_page_reconciliation_constructs_one_flat_view() -> Result<()> {
     assert_eq!(pin.stats().active_events, record_count);
     assert!(
         pin.stats().segment_count
-            <= segments_before + record_count.div_ceil(MAX_SOURCE_EVENT_PAGE_ITEMS),
+            <= segments_before
+                + record_count.div_ceil(source_event_page_limit(semantic_model_contract())),
         "one reconciliation may retain at most one durable delta per bounded Core page"
     );
     assert_eq!(
@@ -1090,7 +1057,7 @@ fn multi_page_restart_reconstructs_one_view_for_remaining_pages() -> Result<()> 
             .ok_or_else(|| anyhow!("resumed reconciliation lost its flat generation"))?
             .stats()
             .segment_count
-            <= record_count.div_ceil(MAX_SOURCE_EVENT_PAGE_ITEMS) + 1,
+            <= record_count.div_ceil(source_event_page_limit(semantic_model_contract())) + 1,
         "the staged pages and source receipt retain bounded scoped segments"
     );
     assert_eq!(projection_snapshot(&restarted)?, expected);

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/bounded_reconciliation.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/bounded_reconciliation.rs
@@ -30,7 +30,7 @@ fn empty_full_rebuild_transition_continues_to_a_sequenced_boundary() -> Result<(
 #[test]
 fn one_durable_boundary_per_call_resumes_a_multi_page_source() -> Result<()> {
     let fixture = Fixture::new(1)?;
-    let record_count = MAX_SOURCE_EVENT_PAGE_ITEMS + 1;
+    let record_count = source_event_page_limit(semantic_model_contract()) + 1;
     let index = fixture.publish(
         "bounded-multi-page",
         &[(0, bodies("bounded", record_count))],
@@ -54,8 +54,14 @@ fn one_durable_boundary_per_call_resumes_a_multi_page_source() -> Result<()> {
     assert!(!first.ready());
     assert!(first.work_remaining());
     assert_eq!(first.semantic_progress_sequence(), Some(1));
-    assert_eq!(first.records_decoded(), MAX_SOURCE_EVENT_PAGE_ITEMS);
-    assert_eq!(builder.calls.len(), MAX_SOURCE_EVENT_PAGE_ITEMS);
+    assert_eq!(
+        first.records_decoded(),
+        source_event_page_limit(semantic_model_contract())
+    );
+    assert_eq!(
+        builder.calls.len(),
+        source_event_page_limit(semantic_model_contract())
+    );
     assert_eq!(sequences, vec![1]);
 
     let second = store
@@ -116,7 +122,7 @@ fn one_durable_boundary_per_call_resumes_a_multi_page_source() -> Result<()> {
 #[test]
 fn ordinary_reconciliation_still_drains_a_multi_page_source() -> Result<()> {
     let fixture = Fixture::new(1)?;
-    let record_count = MAX_SOURCE_EVENT_PAGE_ITEMS + 1;
+    let record_count = source_event_page_limit(semantic_model_contract()) + 1;
     let index = fixture.publish(
         "ordinary-multi-page",
         &[(0, bodies("ordinary", record_count))],

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/policy_rebuild.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/policy_rebuild.rs
@@ -17,10 +17,7 @@ fn high_odd_dimension_external_projection_preserves_full_ordinary_batches() -> R
         .max_inputs_per_request();
     assert_eq!(page_limit, 64);
     assert_eq!(source_event_page_limit(&contract), page_limit);
-    assert_eq!(
-        source_event_page_limit(semantic_model_contract()),
-        MAX_SOURCE_EVENT_PAGE_ITEMS
-    );
+    assert_eq!(source_event_page_limit(semantic_model_contract()), 512);
     let record_count = page_limit + 1;
     let index = fixture.publish(
         "external-high-dimension-pages",
@@ -126,6 +123,10 @@ impl InterruptingDimensionEmbedder {
 }
 
 impl SemanticBatchEmbedder for InterruptingDimensionEmbedder {
+    fn document_fits(&mut self, _text: &str) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+
     fn embed_chunks(&mut self, chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
         self.calls = self.calls.saturating_add(1);
         self.requested_batch_sizes.push(chunks.len());
@@ -654,7 +655,7 @@ fn fixed_e5_http_migrates_legacy_receipts_without_reembedding_across_restart() -
     );
     let legacy = SourceBackedSemanticGeneration::from_verified_index_with_authority(
         &index,
-        current_semantic_generation_policy(),
+        semantic_generation_policy(model_contract),
         legacy_descriptor.to_owned(),
     )?;
     let current = SourceBackedSemanticGeneration::from_verified_index(&index, model_contract)?;

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/proportionality.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/proportionality.rs
@@ -53,6 +53,7 @@ fn changed_logical_source_replay_work_is_measured_for_jsonl_and_sqlite() -> Resu
         let mut embedder = MarkerEmbedder::default();
         reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
 
+        embedder.fit_calls = 0;
         let append = reconcile_all(&mut store, &appended, &mut builder, &mut embedder)?;
         let append_bytes = encoded_record_bytes(&fixture, 0, &appended_bodies, 0)?;
         let appended_event_bytes = encoded_record_bytes(
@@ -65,6 +66,10 @@ fn changed_logical_source_replay_work_is_measured_for_jsonl_and_sqlite() -> Resu
         assert_eq!(append.record_bytes_decoded, append_bytes);
         assert_eq!(append.records_reused, LONG_SOURCE_RECORDS);
         assert_eq!(append.records_embedded, 1);
+        assert_eq!(
+            embedder.fit_calls, 1,
+            "only the appended document needs token fitting"
+        );
         assert!(append_bytes / appended_event_bytes >= 128);
         eprintln!(
             "semantic format={source_format} transition=one_event_append changed_events=1 decoded_records={} decoded_bytes={append_bytes} changed_record_bytes={appended_event_bytes} byte_amplification={}x",
@@ -75,13 +80,16 @@ fn changed_logical_source_replay_work_is_measured_for_jsonl_and_sqlite() -> Resu
         drop(store);
         let mut store =
             SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
+        embedder.fit_calls = 0;
         let restarted = reconcile_all(&mut store, &appended, &mut builder, &mut embedder)?;
         assert_eq!(restarted.records_decoded, 0);
+        assert_eq!(embedder.fit_calls, 0);
         assert_eq!(restarted.record_bytes_decoded, 0);
         eprintln!(
             "semantic format={source_format} transition=completed_restart decoded_records=0 decoded_bytes=0"
         );
 
+        embedder.fit_calls = 0;
         let replacement_outcome =
             reconcile_all(&mut store, &replacement, &mut builder, &mut embedder)?;
         let replacement_bytes = encoded_record_bytes(&fixture, 0, &replacement_bodies, 0)?;
@@ -96,6 +104,10 @@ fn changed_logical_source_replay_work_is_measured_for_jsonl_and_sqlite() -> Resu
         assert_eq!(replacement_outcome.record_bytes_decoded, replacement_bytes);
         assert_eq!(replacement_outcome.records_reused, LONG_SOURCE_RECORDS);
         assert_eq!(replacement_outcome.records_embedded, 1);
+        assert_eq!(
+            embedder.fit_calls, 1,
+            "only the replaced document needs token fitting"
+        );
         assert!(replacement_bytes / replaced_record_bytes >= 128);
         eprintln!(
             "semantic format={source_format} transition=one_record_replacement changed_events=1 decoded_records={} decoded_bytes={replacement_bytes} changed_record_bytes={replaced_record_bytes} byte_amplification={}x",

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/recovery.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/recovery.rs
@@ -30,6 +30,10 @@ enum InvalidEmbeddingBatch {
 struct InvalidEmbedder(InvalidEmbeddingBatch);
 
 impl SemanticBatchEmbedder for InvalidEmbedder {
+    fn document_fits(&mut self, _text: &str) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+
     fn embed_chunks(&mut self, chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
         let dimensions = semantic_model_contract().dimensions();
         let unit = || {

--- a/crates/ctx-semantic-index/src/vector_store/source_projection/tests/token_fit.rs
+++ b/crates/ctx-semantic-index/src/vector_store/source_projection/tests/token_fit.rs
@@ -1,0 +1,256 @@
+use super::*;
+
+struct BudgetEmbedder {
+    body_limit: usize,
+    marker: MarkerEmbedder,
+    batches: Vec<usize>,
+}
+
+impl SemanticBatchEmbedder for BudgetEmbedder {
+    fn document_fits(&mut self, input: &str) -> Result<bool> {
+        let body = input.split_once("\n\n").map_or(input, |(_, body)| body);
+        Ok(body.chars().count() <= self.body_limit)
+    }
+
+    fn embed_chunks(&mut self, chunks: &[SemanticChunkDocument]) -> Result<Vec<Vec<f32>>> {
+        self.batches.push(chunks.len());
+        self.marker.embed_chunks(chunks)
+    }
+}
+
+#[test]
+fn token_fit_failure_does_not_publish_or_acknowledge_and_resumes_after_restart() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let index = fixture.publish("fit-failure", &[(0, vec!["世界".repeat(800)])])?;
+    let core_generation = index.generation_id().to_owned();
+    let mut store = open_store(&fixture.semantic_path)?;
+    let baseline = store
+        .flat
+        .active_publication_token()
+        .map_err(anyhow::Error::new)?;
+    let mut embedder = BudgetEmbedder {
+        body_limit: 0,
+        marker: MarkerEmbedder::default(),
+        batches: Vec::new(),
+    };
+    let mut sequences = Vec::new();
+    let error = store
+        .reconcile_source_backed_index_with_checkpoint_and_progress(
+            &index,
+            &mut CoreBuilder::default(),
+            &mut embedder,
+            &mut || Ok(()),
+            &mut |sequence| {
+                sequences.push(sequence);
+                Ok(())
+            },
+        )
+        .unwrap_err();
+    assert_eq!(
+        crate::semantic_vector_failure_kind(&error),
+        Some(crate::SemanticVectorFailureKind::Unavailable)
+    );
+    assert!(sequences.is_empty());
+    assert_eq!(embedder.marker.calls, 0);
+    assert!(store.source_acknowledgement()?.is_none());
+    assert_eq!(
+        store
+            .flat
+            .active_publication_token()
+            .map_err(anyhow::Error::new)?,
+        baseline
+    );
+    let frontier = store.source_frontier()?.expect("retry frontier");
+    assert_eq!(frontier.processed_source_documents, 0);
+    assert!(frontier.after_identity.is_none());
+    drop(store);
+    let mut store = open_store(&fixture.semantic_path)?;
+    embedder.body_limit = 700;
+    let outcome = reconcile_all(
+        &mut store,
+        &index,
+        &mut CoreBuilder::default(),
+        &mut embedder,
+    )?;
+    assert!(outcome.ready());
+    assert_eq!(outcome.records_embedded, 1);
+    assert!(store.source_acknowledgement()?.is_some());
+    assert_eq!(index.generation_id(), core_generation);
+    Ok(())
+}
+
+#[test]
+fn first_document_can_exceed_page_budget_once_and_complete_without_skipping() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let index = fixture.publish(
+        "fit-first-document",
+        &[(0, vec!["x".repeat(1800), "small".to_owned()])],
+    )?;
+    let mut store = open_store(&fixture.semantic_path)?;
+    let mut embedder = BudgetEmbedder {
+        body_limit: 4,
+        marker: MarkerEmbedder::default(),
+        batches: Vec::new(),
+    };
+    let outcome = reconcile_all(
+        &mut store,
+        &index,
+        &mut CoreBuilder::default(),
+        &mut embedder,
+    )?;
+    assert!(outcome.ready());
+    assert_eq!(outcome.records_embedded, 2);
+    assert_eq!(active_events(&store)?, 2);
+    // A single admitted document may exceed512, but never the1024 document cap.
+    // Embedding calls are independently split to the page bound.
+    assert!(embedder.marker.chunks > 512 && embedder.marker.chunks <= 1028);
+    assert!(embedder.batches.iter().all(|n| *n <= 512));
+    assert!(store.source_acknowledgement()?.is_some());
+    Ok(())
+}
+
+#[test]
+fn chunking_revision_rebuilds_vectors_with_core_generation_unchanged() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let index = fixture.publish("fit-policy", &[(0, bodies("stable", 2))])?;
+    let core_generation = index.generation_id().to_owned();
+    let mut store = open_store(&fixture.semantic_path)?;
+    let mut old_policy = current_semantic_generation_policy();
+    assert_eq!(old_policy.chunking_revision, 2);
+    old_policy.chunking_revision = 1;
+    let old = SourceBackedSemanticGeneration::from_verified_index_with_policy(
+        &index,
+        old_policy,
+        semantic_model_contract(),
+    )?;
+    reconcile_generation(
+        &mut store,
+        &index,
+        &old,
+        &mut CoreBuilder::default(),
+        &mut MarkerEmbedder::default(),
+    )?;
+    let old_fingerprint = store
+        .source_acknowledgement()?
+        .expect("old receipt")
+        .semantic_policy_fingerprint;
+    let rebuilt = reconcile_all(
+        &mut store,
+        &index,
+        &mut CoreBuilder::default(),
+        &mut MarkerEmbedder::default(),
+    )?;
+    assert!(rebuilt.ready());
+    assert_eq!(rebuilt.records_embedded, 2);
+    assert_eq!(rebuilt.records_reused, 0);
+    assert_ne!(
+        store
+            .source_acknowledgement()?
+            .expect("fitted receipt")
+            .semantic_policy_fingerprint,
+        old_fingerprint
+    );
+    assert_eq!(index.generation_id(), core_generation);
+    Ok(())
+}
+
+#[test]
+fn legacy_http_receipt_cannot_certify_fitted_builtin_spans() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let index = fixture.publish("fit-legacy-route", &[(0, vec!["世界".repeat(800)])])?;
+    let legacy = legacy_fixed_http_semantic_model_contract("http://127.0.0.1:43123")?;
+    let legacy_policy = semantic_generation_policy(&legacy);
+    assert_eq!(legacy_policy.chunking_revision, 1);
+    assert_eq!(
+        legacy_policy.canonical_sha256()?,
+        "e8d31418a1da20200d75580348b8b2e7ee4f97c58f34a46900fc6d87daa83ccf"
+    );
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, &legacy)?;
+    reconcile_all(
+        &mut store,
+        &index,
+        &mut CoreBuilder::default(),
+        &mut MarkerEmbedder::default(),
+    )?;
+    let legacy_fingerprint = store
+        .source_acknowledgement()?
+        .expect("HTTP receipt")
+        .semantic_policy_fingerprint;
+    drop(store);
+    let mut store = open_store(&fixture.semantic_path)?;
+    let mut embedder = BudgetEmbedder {
+        body_limit: 700,
+        marker: MarkerEmbedder::default(),
+        batches: Vec::new(),
+    };
+    let outcome = reconcile_all(
+        &mut store,
+        &index,
+        &mut CoreBuilder::default(),
+        &mut embedder,
+    )?;
+    assert_eq!(outcome.records_reused, 0);
+    assert_eq!(outcome.records_embedded, 1);
+    assert!(
+        embedder.marker.chunks > 2,
+        "the old acknowledged receipt must not bypass fitting"
+    );
+    assert_ne!(
+        store
+            .source_acknowledgement()?
+            .expect("built-in receipt")
+            .semantic_policy_fingerprint,
+        legacy_fingerprint
+    );
+    Ok(())
+}
+
+#[test]
+fn sequence_only_core_change_updates_authority_without_embedding() -> Result<()> {
+    let fixture = Fixture::new(1)?;
+    let initial = fixture.publish_with_event_sequences(
+        "sequence-a",
+        &[(0, vec![(1, "same semantic body".to_owned())])],
+    )?;
+    let target = fixture.publish_with_event_sequences(
+        "sequence-b",
+        &[(0, vec![(91, "same semantic body".to_owned())])],
+    )?;
+    let mut store = SemanticVectorStore::open(&fixture.semantic_path, semantic_model_contract())?;
+    let mut builder = CoreBuilder::default();
+    let mut embedder = MarkerEmbedder::default();
+    reconcile_all(&mut store, &initial, &mut builder, &mut embedder)?;
+    let embedded_before = embedder.chunks;
+    let fits_before = embedder.fit_calls;
+
+    let outcome = reconcile_all(&mut store, &target, &mut builder, &mut embedder)?;
+    assert_eq!(outcome.records_decoded, 1);
+    assert_eq!(outcome.records_reused, 1);
+    assert_eq!(outcome.records_embedded, 0);
+    assert_eq!(outcome.vectors_touched, 0);
+    assert_eq!(outcome.vector_bytes_touched, 0);
+    assert!(outcome.metadata_records_touched < 32);
+    assert_eq!(embedder.chunks, embedded_before);
+    assert_eq!(
+        embedder.fit_calls, fits_before,
+        "sequence-only reuse must not require a model"
+    );
+    assert!(matches!(
+        store.source_backed_generation_pin_exact(initial.generation_id(), 1)?,
+        SourceBackedGenerationPin::NotReady
+    ));
+    let pin = match store.source_backed_generation_pin_exact(target.generation_id(), 1)? {
+        SourceBackedGenerationPin::Ready(pin) => pin,
+        SourceBackedGenerationPin::NotReady | SourceBackedGenerationPin::ReadyEmpty => {
+            return Err(anyhow!("sequence-only target did not produce an exact pin"));
+        }
+    };
+    let chunk = pin
+        .scan_segments()
+        .iter()
+        .flat_map(|segment| segment.chunks())
+        .next()
+        .ok_or_else(|| anyhow!("sequence-only target lost its vector"))?;
+    assert_eq!(chunk.seq, 91);
+    Ok(())
+}

--- a/crates/ctx-semantic-model/src/embedding_executor.rs
+++ b/crates/ctx-semantic-model/src/embedding_executor.rs
@@ -265,6 +265,11 @@ impl SemanticEmbeddingExecutorConfig {
 pub trait SemanticEmbeddingExecutor: Send + Sync {
     fn contract(&self) -> &SemanticModelContract;
 
+    /// Checks the complete document input before its source span is finalized.
+    /// `text` is raw ctx header/body text; the executor owns model preparation.
+    /// Endpoint-owned executors impose no local tokenizer policy.
+    fn document_fits(&self, text: &str) -> Result<bool>;
+
     fn embed_query(&self, query: PreparedSemanticQuery) -> Result<Vec<f32>>;
 
     /// Embeds one atomic document page.
@@ -317,6 +322,21 @@ impl BuiltinSemanticEmbeddingExecutor {
 impl SemanticEmbeddingExecutor for BuiltinSemanticEmbeddingExecutor {
     fn contract(&self) -> &SemanticModelContract {
         self.contract()
+    }
+
+    fn document_fits(&self, text: &str) -> Result<bool> {
+        #[cfg(ctx_semantic_fastembed)]
+        {
+            self.runtime
+                .document_fits(&self.contract.document_text(text))
+        }
+        #[cfg(not(ctx_semantic_fastembed))]
+        {
+            let _ = text;
+            Err(anyhow!(
+                "semantic embedding model {SEMANTIC_MODEL_ID} is not supported on this platform"
+            ))
+        }
     }
 
     fn embed_query(&self, query: PreparedSemanticQuery) -> Result<Vec<f32>> {
@@ -520,6 +540,10 @@ mod tests {
     }
 
     impl SemanticEmbeddingExecutor for TestExecutor {
+        fn document_fits(&self, _text: &str) -> Result<bool> {
+            Ok(true)
+        }
+
         fn contract(&self) -> &SemanticModelContract {
             &self.contract
         }

--- a/crates/ctx-semantic-model/src/http_embedding_executor.rs
+++ b/crates/ctx-semantic-model/src/http_embedding_executor.rs
@@ -831,6 +831,13 @@ impl SemanticEmbeddingExecutor for HttpSemanticEmbeddingExecutor {
         &self.contract
     }
 
+    fn document_fits(&self, _text: &str) -> Result<bool> {
+        // Both accepted opaque spaces and retained V1 HTTP own preprocessing.
+        // This check neither sends text nor loads a local E5 tokenizer.
+        self.fail_if_permanently_failed()?;
+        Ok(true)
+    }
+
     fn embed_query(&self, query: PreparedSemanticQuery) -> Result<Vec<f32>> {
         self.fail_if_permanently_failed()?;
         ensure_prepared_contract(query.contract_fingerprint(), self.contract())?;

--- a/crates/ctx-semantic-model/src/http_embedding_executor_tests.rs
+++ b/crates/ctx-semantic-model/src/http_embedding_executor_tests.rs
@@ -617,6 +617,8 @@ fn query_and_documents_send_exact_raw_text_and_protocol_assertions() {
     ]);
     let executor =
         super::HttpSemanticEmbeddingExecutor::new(&server.base_url, accepted.clone()).unwrap();
+    // No local E5 fit policy or extra request is imposed on opaque spaces.
+    assert!(executor.document_fits(&"世界".repeat(1200)).unwrap());
     assert_eq!(
         executor
             .embed_query(

--- a/crates/ctx-semantic-model/src/model_runtime.rs
+++ b/crates/ctx-semantic-model/src/model_runtime.rs
@@ -504,27 +504,6 @@ impl SemanticEmbeddingBackend {
             .ok_or_else(|| anyhow!("semantic query embedding was empty"))
     }
 
-    pub(super) fn embed_prepared_documents(
-        &mut self,
-        documents: Vec<String>,
-        batch_size: usize,
-    ) -> Result<Vec<Vec<f32>>> {
-        let expected = documents.len();
-        if expected == 0 {
-            return Ok(Vec::new());
-        }
-        let raw = match self {
-            Self::Ort { model, .. } => {
-                model.embed(documents, Some(batch_size)).with_context(|| {
-                    format!("embed documents with semantic model {SEMANTIC_MODEL_ID}")
-                })?
-            }
-            #[cfg(target_os = "macos")]
-            Self::CoreMl(model) => model.embed_documents(documents)?,
-        };
-        normalize_and_validate_embeddings(raw, expected)
-    }
-
     pub(super) fn kind(&self) -> SemanticBackendKind {
         match self {
             Self::Ort { kind, .. } => *kind,
@@ -960,6 +939,8 @@ use coreml::{
 #[cfg(all(test, ctx_semantic_fastembed))]
 pub(super) use coreml::{pad_texts_to_exact_batch, semantic_fixed_shape_from_values};
 mod cache;
+#[cfg(ctx_semantic_fastembed)]
+mod input_fit;
 mod onnx;
 mod passive;
 mod windows_ml;

--- a/crates/ctx-semantic-model/src/model_runtime/coreml.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/coreml.rs
@@ -342,6 +342,17 @@ impl CoreMlE5Embedder {
         Ok(embeddings)
     }
 
+    pub(super) fn document_fits(&self, prepared: &str) -> Result<bool> {
+        if self.tokenizer.get_truncation().map(|p| p.max_length) != Some(self.sequence_length) {
+            return Err(anyhow!("Core ML tokenizer has an unexpected input limit"));
+        }
+        let encoding = self
+            .tokenizer
+            .encode(prepared, true)
+            .map_err(|error| anyhow!("assess Core ML document input: {error}"))?;
+        Ok(encoding.get_overflowing().is_empty())
+    }
+
     pub(super) fn embed_batch(
         &self,
         model: &coreml_native::Model,

--- a/crates/ctx-semantic-model/src/model_runtime/document_batches.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/document_batches.rs
@@ -42,6 +42,9 @@ impl SharedSemanticRuntime {
                 .embed_prepared_documents(batch.clone());
             let batch_embeddings = match first {
                 Ok(embeddings) => embeddings,
+                Err(error) if error.is::<super::input_fit::SemanticDocumentInputTooLarge>() => {
+                    return Err(error);
+                }
                 Err(first_error) => {
                     let runtime = embedder
                         .as_ref()
@@ -53,15 +56,23 @@ impl SharedSemanticRuntime {
                     let mut replacement = reacquire_semantic_embedder(config, &runtime).context(
                         "reinitialize semantic embedder after document inference failure",
                     )?;
-                    let retry = replacement
-                        .embed_prepared_documents(batch)
-                        .with_context(|| {
-                        format!(
-                            "semantic document inference failed twice; first failure: {first_error:#}"
-                        )
-                    })?;
-                    *embedder = Some(replacement);
-                    retry
+                    match replacement.embed_prepared_documents(batch) {
+                        Err(error)
+                            if error.is::<super::input_fit::SemanticDocumentInputTooLarge>() =>
+                        {
+                            // Only the replacement's input budget rejected this plan.
+                            // Keep the healthy runtime for the next fitting document.
+                            *embedder = Some(replacement);
+                            return Err(error);
+                        }
+                        retry => {
+                            let embeddings = retry.with_context(|| {
+                                format!("semantic document inference failed twice; first failure: {first_error:#}")
+                            })?;
+                            *embedder = Some(replacement);
+                            embeddings
+                        }
+                    }
                 }
             };
             let quiet_policy = embedder

--- a/crates/ctx-semantic-model/src/model_runtime/input_fit.rs
+++ b/crates/ctx-semantic-model/src/model_runtime/input_fit.rs
@@ -1,0 +1,79 @@
+use super::*;
+use crate::model_contract::SEMANTIC_MAX_SEQUENCE_LENGTH;
+
+// Existing maximum header + body UTF-8 bytes, separators and passage prefix.
+const MAX_PREPARED_DOCUMENT_BYTES: usize = 9_611;
+
+#[derive(Debug)]
+pub(super) struct SemanticDocumentInputTooLarge;
+
+impl fmt::Display for SemanticDocumentInputTooLarge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("semantic document does not fit the selected tokenizer input limit")
+    }
+}
+impl std::error::Error for SemanticDocumentInputTooLarge {}
+
+impl SharedSemanticRuntime {
+    pub(crate) fn document_fits(&self, prepared: &str) -> Result<bool> {
+        self.lock()?
+            .as_ref()
+            .ok_or_else(|| anyhow!("semantic embedder was not initialized"))?
+            .backend
+            .document_fits(prepared)
+    }
+}
+
+impl SemanticEmbeddingBackend {
+    pub(super) fn embed_prepared_documents(
+        &mut self,
+        documents: Vec<String>,
+        batch_size: usize,
+    ) -> Result<Vec<Vec<f32>>> {
+        let expected = documents.len();
+        if expected == 0 {
+            return Ok(Vec::new());
+        }
+        // Recheck with the backend that will actually infer, including after
+        // recovery/fallback. A changed tokenizer cannot silently truncate spans.
+        for document in &documents {
+            if !self.document_fits(document)? {
+                return Err(SemanticDocumentInputTooLarge.into());
+            }
+        }
+        let raw = match self {
+            Self::Ort { model, .. } => {
+                model.embed(documents, Some(batch_size)).with_context(|| {
+                    format!("embed documents with semantic model {SEMANTIC_MODEL_ID}")
+                })?
+            }
+            #[cfg(target_os = "macos")]
+            Self::CoreMl(model) => model.embed_documents(documents)?,
+        };
+        normalize_and_validate_embeddings(raw, expected)
+    }
+
+    pub(super) fn document_fits(&self, prepared: &str) -> Result<bool> {
+        if prepared.len() > MAX_PREPARED_DOCUMENT_BYTES {
+            return Err(SemanticDocumentInputTooLarge.into());
+        }
+        match self {
+            Self::Ort { model, .. } => {
+                if model.tokenizer.get_truncation().map(|p| p.max_length)
+                    != Some(SEMANTIC_MAX_SEQUENCE_LENGTH)
+                {
+                    return Err(anyhow!("semantic tokenizer has an unexpected input limit"));
+                }
+                let encoding = model
+                    .tokenizer
+                    .encode(prepared, true)
+                    .map_err(|error| anyhow!("assess semantic document input: {error}"))?;
+                // tokenizers reserves special tokens before truncation and keeps
+                // every removed sequence in overflowing. Padding adds no overflow.
+                Ok(encoding.get_overflowing().is_empty())
+            }
+            #[cfg(target_os = "macos")]
+            Self::CoreMl(model) => model.document_fits(prepared),
+        }
+    }
+}

--- a/docs/semantic-executors.md
+++ b/docs/semantic-executors.md
@@ -57,6 +57,27 @@ identity, ctx stops semantic indexing and querying until the user reruns
 deletes and rebuilds only the derived semantic index. Imported history and the
 lexical index remain intact.
 
+## Built-in document coverage
+
+The built-in executor checks each complete document input, including the derived
+metadata header, passage prefix and special tokens, against its loaded
+tokenizer's 512-token limit. It retains the existing 1,200-character windows and
+200-character overlap when they fit. Otherwise it shortens optional repeated
+metadata and tests smaller body windows. Stored spans retain their original
+source coordinates and cover the body within the existing 65,536-character
+source cap. Original Core records are unchanged.
+
+Planning has finite input, trial and chunk limits. If no fitting window can be
+established within those limits, semantic work returns an input-budget failure
+without acknowledging that page as complete; lexical search remains available.
+The backend checks inputs again before inference, including after runtime
+recovery. This changes the built-in semantic chunking policy and rebuilds its derived
+semantic vectors without reimporting history or rebuilding the lexical index.
+Query truncation is unchanged. HTTP executors retain their endpoint-owned
+preprocessing and chunking policy; ctx does not impose the built-in tokenizer on
+V2 spaces. Switching between retained fixed-E5 HTTP and built-in execution
+rebuilds semantic vectors because their document chunk policies now differ.
+
 ## Built-in indexing throttling
 
 The built-in executor deliberately paces semantic document indexing by


### PR DESCRIPTION
Semantic indexing split documents by character count, allowing complete prepared inputs to exceed the built-in model's 512-token limit and lose body text to tokenizer truncation.

Fit built-in chunks against the loaded tokenizer, preserve fitting windows, and use bounded smaller windows when needed. Check again before inference, reuse compatible vectors before fitting, and rebuild derived built-in semantic indexes under the revised policy. Original history and HTTP executor preprocessing remain unchanged.

Validated owning and affected tests and actual-model coverage regressions.