### PR TITLE
fix(codex): preserve distinct item and call identities

### DIFF
--- a/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence.rs
+++ b/crates/ctx-history-capture-composition-qualification/tests/provider_lifecycle/codex_child_independence.rs
@@ -19,7 +19,7 @@ use ctx_history_index::{
     GenerationStateEnvelope, GenerationWriter, RevalidationTarget, WriterOptions,
 };
 
-const CURRENT_PARSER_REVISION: &str = "codex-nativepath-core-activity-v10-item-completed-plan";
+const CURRENT_PARSER_REVISION: &str = "codex-nativepath-core-activity-v11-item-call-identity";
 
 #[path = "codex_child_independence/quarantine.rs"]
 mod quarantine;

--- a/crates/ctx-history-capture-composition/src/source_backed/registration/families/jsonl/codex/tests.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/registration/families/jsonl/codex/tests.rs
@@ -62,3 +62,5 @@ fn codex_session_tree_registration_does_not_inventory_the_root() {
     let targets = catalog.route_targets().next().unwrap().1;
     assert!(targets.contains(&archived_sessions));
 }
+
+mod typed_activity;

--- a/crates/ctx-history-capture-composition/src/source_backed/registration/families/jsonl/codex/tests/typed_activity.rs
+++ b/crates/ctx-history-capture-composition/src/source_backed/registration/families/jsonl/codex/tests/typed_activity.rs
@@ -1,0 +1,192 @@
+use super::*;
+use crate::provider::source_backed::refresh_source_backed_generation;
+use ctx_history_core::{ActivityTextCapture, CoreRecord, TypedKey};
+use ctx_history_index::{VerifiedIndex, WriterOptions};
+use std::{fs, path::Path};
+
+fn records(root: &Path, source: &ctx_history_core::SourceKey) -> Vec<CoreRecord> {
+    let index = VerifiedIndex::open_pinned(root).unwrap();
+    let page = index.core_source_event_page(source, None, 8).unwrap();
+    let mut records: Vec<_> = page
+        .items
+        .into_iter()
+        .map(|item| item.core_record)
+        .collect();
+    records.sort_by_key(|record| record.event_sequence);
+    records
+}
+
+fn registry(source_path: &Path) -> SourceBackedProviderRegistry {
+    let mut registry = SourceBackedProviderRegistry::new();
+    register_codex_explicit_session_route(
+        &mut registry,
+        ProviderSource {
+            provider: CaptureProvider::Codex,
+            path: source_path.to_path_buf(),
+            exists: true,
+            source_format: "codex_session_jsonl",
+            source_kind: ProviderSourceKind::NativeHistory,
+            import_support: ProviderImportSupport::Native,
+            catalog_support: ProviderCatalogSupport::None,
+            status: ProviderSourceStatus::Available,
+            unsupported_reason: None,
+            route_provenance: Default::default(),
+        },
+        SourceBackedRouteSelection::ExplicitManual,
+    )
+    .unwrap();
+    registry
+}
+
+#[test]
+fn dual_item_ids_retain_tool_output_and_rewrite_removes_previous_events() {
+    let temp = crate::test_support_paths::tempdir().unwrap();
+    let source_path = temp.path().join("rollout.jsonl");
+    let index_root = temp.path().join("index");
+    // Synthetic neutral input exercises the complete supported scanner and store.
+    let header = r#"{"timestamp":"2026-08-01T00:00:00Z","type":"session_meta","payload":{"id":"019fb000-0000-7000-8000-0000000000a1","cwd":"/fixture"}}"#;
+    let call = r#"{"timestamp":"2026-08-01T00:00:01Z","type":"response_item","payload":{"type":"function_call","id":"item-call","call_id":"shared-call","name":"exec_command","arguments":"{\"cmd\":\"echo sample\"}"}}"#;
+    let output = r#"{"timestamp":"2026-08-01T00:00:02Z","type":"response_item","payload":{"type":"function_call_output","id":"item-output","call_id":"shared-call","output":"  complete result\nlast line\n"}}"#;
+    let bytes = format!("{header}\n{call}\n{output}\n");
+    fs::write(&source_path, &bytes).unwrap();
+    let registry = registry(&source_path);
+    let first =
+        refresh_source_backed_generation(&index_root, &registry, WriterOptions::default()).unwrap();
+    assert!(first.failed_routes.is_empty());
+    assert_eq!(first.sources.len(), 1);
+    let source = first.sources[0].observation().source();
+    let initial = records(&index_root, source);
+    assert_eq!(initial.len(), 2);
+    assert_eq!(initial[0].event_type, "tool_call");
+    assert_eq!(initial[1].event_type, "tool_output");
+    for (record, item_id) in initial.iter().zip(["item-call", "item-output"]) {
+        assert_eq!(
+            record.parser_revision,
+            "codex-nativepath-core-activity-v11-item-call-identity"
+        );
+        assert!(
+            serde_json::to_string(record.native_event_id.as_ref().unwrap())
+                .unwrap()
+                .contains(item_id)
+        );
+        assert_eq!(
+            record.content.activity.as_ref().unwrap().provider_call_id,
+            Some(TypedKey::utf8("shared-call").unwrap())
+        );
+        assert!(record.event_copy.is_none());
+    }
+    assert_ne!(initial[0].event_id, initial[1].event_id);
+    assert!(initial[0]
+        .content
+        .activity
+        .as_ref()
+        .unwrap()
+        .invocation
+        .is_some());
+    assert_eq!(
+        initial[1].content.normalized_body.as_deref(),
+        Some("  complete result\nlast line\n")
+    );
+    assert_eq!(
+        initial[1]
+            .content
+            .activity
+            .as_ref()
+            .unwrap()
+            .result
+            .as_ref()
+            .unwrap()
+            .text,
+        ActivityTextCapture::Present {
+            value: "  complete result\nlast line\n".to_owned()
+        }
+    );
+    let repeated =
+        refresh_source_backed_generation(&index_root, &registry, WriterOptions::default()).unwrap();
+    assert_eq!(first.commit.generation_id, repeated.commit.generation_id);
+    assert_eq!(initial, records(&index_root, source));
+    assert_eq!(fs::read_to_string(&source_path).unwrap(), bytes);
+
+    fs::write(
+        &source_path,
+        format!(
+            "{header}\n{call}\n{}\n",
+            output
+                .replace("item-output", "replacement-output")
+                .replace("complete result", "replacement result")
+        ),
+    )
+    .unwrap();
+    let changed =
+        refresh_source_backed_generation(&index_root, &registry, WriterOptions::default()).unwrap();
+    assert!(changed.failed_routes.is_empty());
+    assert_ne!(changed.commit.generation_id, first.commit.generation_id);
+    let current = records(&index_root, source);
+    assert_eq!(current.len(), 2);
+    assert_eq!(current[0].event_id, initial[0].event_id);
+    assert_ne!(current[1].event_id, initial[1].event_id);
+    assert!(VerifiedIndex::open_pinned(&index_root)
+        .unwrap()
+        .core_record_by_id(initial[1].event_id.as_uuid())
+        .unwrap()
+        .is_none());
+    let repeated =
+        refresh_source_backed_generation(&index_root, &registry, WriterOptions::default()).unwrap();
+    assert_eq!(changed.commit.generation_id, repeated.commit.generation_id);
+}
+
+#[test]
+fn item_only_and_dual_id_calls_preserve_existing_pending_policy() {
+    for (fields, pending) in [
+        (serde_json::json!({"id":"shared-call"}), false),
+        (
+            serde_json::json!({"id":"item-call","call_id":"shared-call"}),
+            false,
+        ),
+        (serde_json::json!({"call_id":"shared-call"}), true),
+    ] {
+        let temp = crate::test_support_paths::tempdir().unwrap();
+        let source_path = temp.path().join("rollout.jsonl");
+        let index_root = temp.path().join("index");
+        let mut call = serde_json::json!({"type":"function_call", "name":"exec_command", "arguments":"{\"cmd\":\"ctx search example\"}"});
+        call.as_object_mut()
+            .unwrap()
+            .extend(fields.as_object().unwrap().clone());
+        let output = "Chunk ID: abc123\nWall time: 0.1 seconds\nProcess exited with code 0\nFinal output:\nsearch result";
+        let values = [
+            serde_json::json!({"type":"session_meta", "timestamp":"2026-08-01T00:00:00Z", "payload":{"id":"019fb000-0000-7000-8000-0000000000a1", "forked_from_id":"019fb000-0000-7000-8000-0000000000a0", "cwd":"/fixture"}}),
+            serde_json::json!({"type":"response_item", "timestamp":"2026-08-01T00:00:01Z", "payload":call}),
+            serde_json::json!({"type":"response_item", "timestamp":"2026-08-01T00:00:02Z", "payload":{"type":"function_call_output", "call_id":"shared-call", "output":output}}),
+        ];
+        fs::write(
+            &source_path,
+            values
+                .iter()
+                .map(|value| format!("{value}\n"))
+                .collect::<String>(),
+        )
+        .unwrap();
+        let registry = registry(&source_path);
+        let receipt =
+            refresh_source_backed_generation(&index_root, &registry, WriterOptions::default())
+                .unwrap();
+        assert!(receipt.failed_routes.is_empty());
+        let rows = records(&index_root, receipt.sources[0].observation().source());
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows[1].event_type,
+            if pending {
+                "command_output"
+            } else {
+                "tool_output"
+            }
+        );
+        assert_eq!(rows[1].event_copy.is_some(), pending);
+        assert_eq!(rows[1].content.discovery_exclusion.is_some(), pending);
+        assert_eq!(rows[1].content.normalized_body.as_deref(), Some(output));
+        assert_eq!(
+            rows[0].content.activity.as_ref().unwrap().provider_call_id,
+            rows[1].content.activity.as_ref().unwrap().provider_call_id
+        );
+    }
+}

--- a/crates/ctx-history-jsonl/src/family/route/tests/behavior/parallel_revalidation.rs
+++ b/crates/ctx-history-jsonl/src/family/route/tests/behavior/parallel_revalidation.rs
@@ -582,4 +582,14 @@ fn parser_revision_forces_unchanged_source_replacement() {
         upgraded_receipt.manifest().sources[0].parser_revision(),
         "identity-revision-test-parser-v2"
     );
+    let (repeated, activity) = capture_parallel_test_generation(&upgraded, &root, &index, 1);
+    assert_eq!(
+        repeated.manifest().sources,
+        upgraded_receipt.manifest().sources
+    );
+    assert_eq!(
+        activity,
+        JsonlFamilyScannerActivity::default(),
+        "revision replay runs once"
+    );
 }

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/raw_json.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/raw_json.rs
@@ -12,6 +12,8 @@ const MAX_RECOGNIZED_FACT_KEYS_PER_OBJECT: usize = 64;
 pub(crate) enum SelectorGroup {
     Type,
     CallId,
+    ItemId,
+    CallIdAlias,
     ToolName,
     Arguments,
     Result,
@@ -290,8 +292,22 @@ impl<'de> Visitor<'de> for AuditVisitor<'_> {
         let mut seen_fact_keys = Vec::<String>::new();
         while let Some(key) = map.next_key::<String>()? {
             if let Some(group) = selector_group(&key) {
-                if seen_selectors & group.bit() != 0 {
-                    audit.mark_duplicate(group);
+                // callId remains an audited, unsupported alias. It conflicts
+                // with either the selected call_id or its id-only fallback.
+                let conflicts = match group {
+                    SelectorGroup::ItemId | SelectorGroup::CallId => {
+                        group.bit() | SelectorGroup::CallIdAlias.bit()
+                    }
+                    SelectorGroup::CallIdAlias => {
+                        group.bit() | SelectorGroup::CallId.bit() | SelectorGroup::ItemId.bit()
+                    }
+                    _ => group.bit(),
+                };
+                if seen_selectors & conflicts != 0 {
+                    audit.mark_duplicate(match group {
+                        SelectorGroup::CallIdAlias => SelectorGroup::CallId,
+                        _ => group,
+                    });
                 }
                 seen_selectors |= group.bit();
             }

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/rows.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/rows.rs
@@ -228,9 +228,10 @@ pub(super) fn build_source_backed_event_row(
     Ok(Ok(CodexSourceBackedBuiltRowV0 {
         row: CodexCoreRecordDraft {
             raw_ordinal,
-            provider_event_identity: (!audit.selector_ambiguous(SelectorGroup::CallId))
-                .then_some(provider_event_identity)
-                .flatten(),
+            provider_event_identity: (!audit.selector_ambiguous(SelectorGroup::CallId)
+                && !audit.selector_ambiguous(SelectorGroup::ItemId))
+            .then_some(provider_event_identity)
+            .flatten(),
             provider_event_copy: None,
             occurred_at,
             event_type: semantic.event_type,
@@ -288,9 +289,10 @@ pub(super) fn build_source_backed_sparse_output_row(
         .flatten();
     Ok(Some(CodexCoreRecordDraft {
         raw_ordinal,
-        provider_event_identity: (!audit.selector_ambiguous(SelectorGroup::CallId))
-            .then_some(provider_event_identity)
-            .flatten(),
+        provider_event_identity: (!audit.selector_ambiguous(SelectorGroup::CallId)
+            && !audit.selector_ambiguous(SelectorGroup::ItemId))
+        .then_some(provider_event_identity)
+        .flatten(),
         provider_event_copy,
         occurred_at,
         event_type: result_event_type,
@@ -312,6 +314,7 @@ fn codex_invocation_activity(
 ) -> Option<CoreActivity> {
     let facts = audit.facts().to_vec();
     if audit.selector_ambiguous(SelectorGroup::CallId)
+        || audit.selector_ambiguous(SelectorGroup::ItemId)
         || audit.selector_ambiguous(SelectorGroup::ToolName)
         || audit.selector_ambiguous(SelectorGroup::McpTool)
     {
@@ -364,7 +367,9 @@ fn codex_result_activity(
     occurred_at: DateTime<Utc>,
 ) -> Option<CoreActivity> {
     let facts = audit.facts().to_vec();
-    if audit.selector_ambiguous(SelectorGroup::CallId) {
+    if audit.selector_ambiguous(SelectorGroup::CallId)
+        || audit.selector_ambiguous(SelectorGroup::ItemId)
+    {
         return facts_only_activity(facts);
     }
     let call_id = call_id
@@ -494,7 +499,10 @@ pub(super) fn audit_codex_record(raw_record: &[u8]) -> serde_json::Result<RawJso
 fn codex_selector_group(key: &str) -> Option<SelectorGroup> {
     match key {
         "type" => Some(SelectorGroup::Type),
-        "id" | "call_id" | "callId" => Some(SelectorGroup::CallId),
+        // Response-item identity and invocation linkage are independent fields.
+        "id" => Some(SelectorGroup::ItemId),
+        "call_id" => Some(SelectorGroup::CallId),
+        "callId" => Some(SelectorGroup::CallIdAlias),
         "name" => Some(SelectorGroup::ToolName),
         "arguments" | "input" | "args" => Some(SelectorGroup::Arguments),
         "output" | "result" => Some(SelectorGroup::Result),

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/rows/tests.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/rows/tests.rs
@@ -1006,3 +1006,5 @@ fn duplicate_selectors_withhold_linkage_and_preserve_raw_fact_order() {
         ]
     );
 }
+
+mod item_call_identity;

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/rows/tests/item_call_identity.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/rows/tests/item_call_identity.rs
@@ -1,0 +1,149 @@
+//! Supplemental neutral selector cases; strings here are synthetic.
+use super::*;
+
+fn invocation(raw: &[u8]) -> CodexCoreRecordDraft {
+    let payload: Value = serde_json::from_slice(raw).unwrap();
+    let record = CodexDecodedRecord {
+        occurred_at: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+        payload,
+    };
+    build_source_backed_event_row(0, CodexRetainedKind::ToolCall, "session", &record, raw)
+        .unwrap()
+        .unwrap()
+        .row
+}
+
+fn result(raw: &[u8]) -> CodexCoreRecordDraft {
+    let payload: Value = serde_json::from_slice(raw).unwrap();
+    build_source_backed_sparse_output_row(
+        1,
+        provider_event_identity(&payload),
+        None,
+        None,
+        true,
+        EventType::ToolOutput,
+        payload.get("call_id").and_then(Value::as_str),
+        DateTime::<Utc>::from_timestamp(1, 0).unwrap(),
+        payload["output"].as_str().unwrap().to_owned(),
+        Some(payload.clone()),
+        payload.get("output"),
+        raw,
+        &payload,
+        None,
+    )
+    .unwrap()
+    .unwrap()
+}
+
+#[test]
+fn distinct_item_ids_preserve_common_call_and_complete_payloads() {
+    let call = br#"{"type":"function_call","id":"item-call","call_id":"shared-call","name":"exec_command","arguments":"{\"cmd\":\"echo sample\"}"}"#;
+    let output = br#"{"type":"function_call_output","id":"item-output","call_id":"shared-call","output":"  complete result\nlast line\n"}"#;
+    for (raw, row, item_id, is_call) in [
+        (call.as_slice(), invocation(call), "item-call", true),
+        (output.as_slice(), result(output), "item-output", false),
+    ] {
+        let identity = row.provider_event_identity.unwrap();
+        assert_eq!(identity.kind, CodexProviderEventIdentityKindV0::Id);
+        assert_eq!(identity.value, item_id);
+        let payload: Value = serde_json::from_slice(raw).unwrap();
+        assert_eq!(row.structured_content, Some(payload.clone()));
+        let activity = row.activity.unwrap();
+        assert_eq!(
+            activity.provider_call_id,
+            Some(TypedKey::utf8("shared-call").unwrap())
+        );
+        assert_eq!(activity.invocation.is_some(), is_call);
+        assert_eq!(activity.result.is_some(), !is_call);
+        if let Some(result) = activity.result {
+            assert_eq!(row.lexical_body, "  complete result\nlast line\n");
+            assert_eq!(
+                result.text,
+                ActivityTextCapture::Present {
+                    value: row.lexical_body
+                }
+            );
+            assert_eq!(
+                result.structured_content,
+                ActivityJsonCapture::Present {
+                    value: payload["output"].clone()
+                }
+            );
+        }
+    }
+}
+
+#[test]
+fn id_only_invocation_fallback_and_call_id_precedence_remain_bounded() {
+    for length in [
+        MAX_CODEX_DURABLE_METADATA_BYTES,
+        MAX_CODEX_DURABLE_METADATA_BYTES + 1,
+    ] {
+        let id = "i".repeat(length);
+        let payload =
+            serde_json::json!({"type":"function_call", "id":id, "name":"tool", "arguments":{}});
+        let raw = serde_json::to_vec(&payload).unwrap();
+        let row = invocation(&raw);
+        assert_eq!(row.provider_event_identity.unwrap().value, id);
+        assert_eq!(
+            row.activity.is_some(),
+            length == MAX_CODEX_DURABLE_METADATA_BYTES
+        );
+        if let Some(activity) = row.activity {
+            assert_eq!(
+                activity.provider_call_id,
+                Some(TypedKey::utf8(&id).unwrap())
+            );
+        }
+    }
+    for call_id in [
+        Value::Null,
+        serde_json::json!(7),
+        serde_json::json!(""),
+        serde_json::json!("c".repeat(MAX_CODEX_DURABLE_METADATA_BYTES + 1)),
+    ] {
+        let raw = serde_json::to_vec(&serde_json::json!({"type":"function_call", "id":"fallback", "call_id":call_id, "name":"tool"})).unwrap();
+        assert!(
+            invocation(&raw).activity.is_none(),
+            "present invalid call_id cannot select fallback id"
+        );
+    }
+}
+
+#[test]
+fn literal_duplicate_ids_and_call_aliases_still_withhold_linkage() {
+    for selectors in [
+        r#""id":"one","id":"one""#,
+        r#""id":"one","id":"two""#,
+        r#""id":"one","\u0069d":"two""#,
+        r#""call_id":"one","call_id":"one""#,
+        r#""call_id":"one","call_id":"two""#,
+        r#""call_id":"one","callId":"two""#,
+        r#""call_id":"one","callId":"one""#,
+        r#""id":"one","id":"two","call_id":"valid""#,
+        r#""callId":"one","callId":"two""#,
+        r#""id":"one","callId":"two""#,
+        r#""id":"one","callId":"one""#,
+        r#""callId":"one","id":"two""#,
+        r#""callId":"one","id":"one""#,
+        r#""callId":"one","call_id":"two""#,
+    ] {
+        let call = format!(
+            r#"{{"type":"function_call",{selectors},"name":"tool","arguments":{{"command":"literal"}}}}"#
+        );
+        let output =
+            format!(r#"{{"type":"function_call_output",{selectors},"output":"retained result"}}"#);
+        for row in [invocation(call.as_bytes()), result(output.as_bytes())] {
+            assert!(row.provider_event_identity.is_none(), "{selectors}");
+            assert!(row.structured_content.is_none(), "{selectors}");
+            assert!(
+                row.activity
+                    .is_none_or(|activity| activity.provider_call_id.is_none()
+                        && activity.invocation.is_none()
+                        && activity.result.is_none()),
+                "{selectors}"
+            );
+        }
+        assert_eq!(result(output.as_bytes()).lexical_body, "retained result");
+    }
+}

--- a/crates/ctx-history-provider-codex/src/codex/nativepath/source_backed.rs
+++ b/crates/ctx-history-provider-codex/src/codex/nativepath/source_backed.rs
@@ -43,7 +43,7 @@ const CODEX_NATIVE_SESSION_NAMESPACE: &str = "codex.session";
 const CODEX_LOGICAL_SESSION_KIND: &str = "codex-session";
 const CODEX_LOGICAL_EVENT_KIND: &str = "codex-event";
 const CODEX_SOURCE_SCHEMA_VARIANT: &str = "codex-nativepath-jsonl-v0";
-const CODEX_PARSER_REVISION: &str = "codex-nativepath-core-activity-v10-item-completed-plan";
+const CODEX_PARSER_REVISION: &str = "codex-nativepath-core-activity-v11-item-call-identity";
 
 type CodexSessionPlanV0 = (CodexCatalogSource, SourceKey, String);
 


### PR DESCRIPTION
Codex tool calls and results can carry distinct response-item IDs alongside their shared call ID. Preserve both typed activity envelopes and the native item identities while retaining id-only fallback and duplicate/conflicting-selector rejection.

Rotate the parser revision so importing unchanged session files replaces the previous normalized records once, followed by a no-op.

Validation: Codex provider unit tests, scanner/store identity and rewrite regressions, and the JSONL parser-revision replay test.
