### PR TITLE
Confirm terminal refresh journal durability before completion

### DIFF
--- a/crates/ctx-daemon-runtime/src/private_fs.rs
+++ b/crates/ctx-daemon-runtime/src/private_fs.rs
@@ -4,13 +4,30 @@ use std::{fs, path::Path};
 use std::os::unix::fs::OpenOptionsExt;
 
 use anyhow::{Context, Result};
-use ctx_history_platform::platform_security::{restrict_private_directory, restrict_private_file};
+use ctx_history_platform::platform_security::{
+    establish_private_data_root, restrict_private_directory, restrict_private_file,
+};
 
 pub fn create_private_dir_all(path: &Path) -> Result<()> {
-    fs::create_dir_all(path)
+    // The existing platform owner creates missing components privately and
+    // repairs only the final directory, never external pre-existing ancestors.
+    establish_private_data_root(path)
         .with_context(|| format!("create private directory {}", path.display()))?;
-    secure_private_dir_permissions(path)?;
     Ok(())
+}
+
+/// Establishes one journal directory and confirms its final containing link.
+/// Call at journal initialization, including retries: existence alone does not
+/// confirm a prior creator's last link. Ordinary mutable status uses the
+/// existing-directory path above without these extra flushes.
+pub fn create_private_dir_all_before_ack(path: &Path) -> Result<()> {
+    create_private_dir_all(path)?;
+    #[cfg(not(windows))]
+    fs::File::open(path)
+        .with_context(|| format!("open private directory {}", path.display()))?
+        .sync_all()
+        .with_context(|| format!("sync private directory {}", path.display()))?;
+    crate::sync_private_file_parent(path)
 }
 
 pub fn private_create_new_file(path: &Path) -> std::io::Result<fs::File> {
@@ -106,3 +123,6 @@ pub fn secure_private_file_permissions(path: &Path) -> Result<()> {
         .with_context(|| format!("secure private file {}", path.display()))?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/ctx-daemon-runtime/src/private_fs/tests.rs
+++ b/crates/ctx-daemon-runtime/src/private_fs/tests.rs
@@ -1,0 +1,87 @@
+use super::*;
+
+fn isolated_root() -> Result<tempfile::TempDir> {
+    #[cfg(target_os = "linux")]
+    let parent = std::path::PathBuf::from("/tmp");
+    #[cfg(not(target_os = "linux"))]
+    let parent = std::env::temp_dir();
+    Ok(tempfile::Builder::new()
+        .prefix("ctx-private-directory-")
+        .tempdir_in(parent)?)
+}
+
+#[cfg(target_os = "linux")]
+mod creation_race;
+#[cfg(target_os = "linux")]
+mod syscalls;
+
+#[test]
+fn missing_components_are_private_and_external_ancestors_are_unchanged() -> Result<()> {
+    let temp = isolated_root()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(temp.path(), fs::Permissions::from_mode(0o755))?;
+    }
+    let root = temp.path().join("data");
+    let jobs = root.join("daemon/jobs");
+    create_private_dir_all_before_ack(&jobs)?;
+    for path in [&root, &root.join("daemon"), &jobs] {
+        ctx_history_platform::platform_security::verify_private_directory(path)?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        for path in [&root, &root.join("daemon"), &jobs] {
+            assert_eq!(fs::metadata(path)?.permissions().mode() & 0o777, 0o700);
+        }
+        assert_eq!(
+            fs::metadata(temp.path())?.permissions().mode() & 0o777,
+            0o755
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn concurrent_creators_and_retry_preserve_the_same_private_directory() -> Result<()> {
+    let temp = isolated_root()?;
+    let jobs = temp.path().join("data/daemon/jobs");
+    let barrier = std::sync::Barrier::new(4);
+    std::thread::scope(|scope| {
+        let threads = (0..4)
+            .map(|_| {
+                scope.spawn(|| {
+                    barrier.wait();
+                    create_private_dir_all(&jobs)
+                })
+            })
+            .collect::<Vec<_>>();
+        for thread in threads {
+            thread.join().unwrap().unwrap();
+        }
+    });
+    let marker = jobs.join("retained");
+    fs::write(&marker, "retained")?;
+    assert!(create_private_dir_all(&marker.join("blocked")).is_err());
+    create_private_dir_all_before_ack(&jobs)?;
+    assert_eq!(fs::read_to_string(&marker)?, "retained");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn preexisting_readonly_ancestor_is_not_repaired() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let temp = isolated_root()?;
+    let external = temp.path().join("external");
+    let jobs = external.join("data/daemon/jobs");
+    create_private_dir_all(&jobs)?;
+    fs::set_permissions(&external, fs::Permissions::from_mode(0o500))?;
+    let result = create_private_dir_all(&jobs);
+    let mode = fs::metadata(&external)?.permissions().mode() & 0o777;
+    fs::set_permissions(&external, fs::Permissions::from_mode(0o700))?;
+    result?;
+    assert_eq!(mode, 0o500);
+    Ok(())
+}

--- a/crates/ctx-daemon-runtime/src/private_fs/tests/creation_race.rs
+++ b/crates/ctx-daemon-runtime/src/private_fs/tests/creation_race.rs
@@ -1,0 +1,108 @@
+use super::*;
+use std::{
+    process::Command,
+    time::{Duration, Instant},
+};
+
+const CHILD: &str = "private_fs::tests::syscalls::private_directory_syscall_child";
+
+#[test]
+fn visible_unsynced_directory_is_confirmed_by_second_creator_before_descent() -> Result<()> {
+    let temp = isolated_root()?;
+    let trace_a = temp.path().join("creator-a.trace");
+    let trace_b = temp.path().join("creator-b.trace");
+    // Pause at the actual new-directory inode fsync after mkdir(a) has
+    // returned, without a production hook. The second owner must see a via
+    // its initial open, not mkdir/EEXIST, and repair its link before mkdir(b).
+    let mut first = Command::new("/usr/bin/strace")
+        .args([
+            "-f",
+            "-yy",
+            "-e",
+            "trace=fsync,mkdirat",
+            "--inject=fsync:delay_enter=5s:when=3",
+            "-o",
+        ])
+        .arg(&trace_a)
+        .arg(std::env::current_exe()?)
+        .args(["--exact", CHILD, "--test-threads=1"])
+        .env("CTX_DIRECTORY_SYSCALL_CASE", "paused_creator")
+        .env("CTX_DIRECTORY_SYSCALL_ROOT", temp.path())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()?;
+    let result = (|| -> Result<String> {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while !temp.path().join("a").exists() {
+            anyhow::ensure!(Instant::now() < deadline, "creator a did not reach mkdir");
+            anyhow::ensure!(
+                first.try_wait()?.is_none(),
+                "creator a exited before visibility"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        anyhow::ensure!(first.try_wait()?.is_none(), "creator a was not paused");
+        let second = Command::new("/usr/bin/strace")
+            .args(["-f", "-yy", "-e", "trace=fsync,mkdirat", "-o"])
+            .arg(&trace_b)
+            .arg(std::env::current_exe()?)
+            .args(["--exact", CHILD, "--test-threads=1"])
+            .env("CTX_DIRECTORY_SYSCALL_CASE", "cold")
+            .env("CTX_DIRECTORY_SYSCALL_ROOT", temp.path())
+            .output()?;
+        anyhow::ensure!(
+            second.status.success(),
+            "second creator: {}",
+            String::from_utf8_lossy(&second.stderr)
+        );
+        anyhow::ensure!(
+            first.try_wait()?.is_none(),
+            "pause ended before second creator finished"
+        );
+        Ok(fs::read_to_string(&trace_b)?)
+    })();
+    let first_output = first.wait_with_output()?;
+    let trace = result?;
+    assert!(
+        first_output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&first_output.stderr)
+    );
+    let calls = trace
+        .lines()
+        .filter(|line| line.contains("fsync(") || line.contains("mkdirat("))
+        .collect::<Vec<_>>();
+    assert!(
+        calls[0].contains("fsync(") && calls[0].contains("/a>") && calls[0].ends_with("= 0"),
+        "{trace}"
+    );
+    assert!(
+        calls[1].contains("fsync(")
+            && calls[1].contains(&format!("<{}>", temp.path().display()))
+            && calls[1].ends_with("= 0"),
+        "{trace}"
+    );
+    assert!(
+        calls[2].contains("mkdirat(") && calls[2].contains("\"b\""),
+        "{trace}"
+    );
+    assert!(
+        !calls
+            .iter()
+            .any(|line| line.contains("mkdirat(") && line.contains("\"a\"")),
+        "{trace}"
+    );
+    for directory in [
+        temp.path().join("a"),
+        temp.path().join("a/b"),
+        temp.path().join("a/b/data"),
+    ] {
+        ctx_history_platform::platform_security::verify_private_directory(&directory)?;
+    }
+    let first_trace = fs::read_to_string(trace_a)?;
+    assert!(first_trace.contains("DELAYED"), "{first_trace}");
+    eprintln!(
+        "directory_durability forced_visible_before_sync first={first_trace:?} second={trace:?}"
+    );
+    Ok(())
+}

--- a/crates/ctx-daemon-runtime/src/private_fs/tests/syscalls.rs
+++ b/crates/ctx-daemon-runtime/src/private_fs/tests/syscalls.rs
@@ -1,0 +1,145 @@
+use super::*;
+
+#[test]
+fn private_directory_syscall_child() -> Result<()> {
+    let Ok(case) = std::env::var("CTX_DIRECTORY_SYSCALL_CASE") else {
+        return Ok(());
+    };
+    let temp = std::path::PathBuf::from(std::env::var_os("CTX_DIRECTORY_SYSCALL_ROOT").unwrap());
+    if case == "paused_creator" {
+        return create_private_dir_all_before_ack(&temp.join("a"));
+    }
+    let target = temp.join("a/b/data");
+    if case == "generic_create" || case == "generic_ensure" {
+        if case == "generic_create" {
+            ctx_history_platform::platform_security::create_private_directory_all(&target)?;
+        } else {
+            ctx_history_platform::platform_security::ensure_private_directory(&target)?;
+        }
+        ctx_history_platform::platform_security::verify_private_directory(&target)?;
+        return Ok(());
+    }
+    if matches!(case.as_str(), "sync_error" | "inode_error" | "mkdir_error") {
+        assert!(create_private_dir_all_before_ack(&target).is_err());
+        assert!(temp.join("a").is_dir());
+        assert!(!temp.join("a/b").exists(), "failure must stop descent");
+    } else if case == "existing_error" {
+        assert!(create_private_dir_all_before_ack(&target).is_err());
+        assert!(target.is_dir());
+    }
+    create_private_dir_all_before_ack(&target)?;
+    ctx_history_platform::platform_security::verify_private_directory(&target)?;
+    // The ordinary existing-directory path adds no durability work.
+    create_private_dir_all(&target)?;
+    Ok(())
+}
+
+#[test]
+fn directory_syscalls_confirm_cold_links_before_descent_and_retry_errors() -> Result<()> {
+    for (case, fault) in [
+        ("cold", None),
+        ("sync_error", Some("fsync:error=EIO:when=4")),
+        ("inode_error", Some("fsync:error=EIO:when=3")),
+        ("mkdir_error", Some("mkdirat:error=EIO:when=2")),
+        ("existing_error", Some("fsync:error=EIO:when=2")),
+        ("generic_create", None),
+        ("generic_ensure", None),
+    ] {
+        let temp = isolated_root()?;
+        if case == "existing_error" {
+            create_private_dir_all_before_ack(&temp.path().join("a/b/data"))?;
+        }
+        let trace_path = temp.path().join("trace.log");
+        let mut command = std::process::Command::new("/usr/bin/strace");
+        command
+            .args(["-f", "-yy", "-e", "trace=fsync,mkdirat", "-o"])
+            .arg(&trace_path);
+        if let Some(fault) = fault {
+            command.arg(format!("--inject={fault}"));
+        }
+        let output = command
+            .arg(std::env::current_exe()?)
+            .args([
+                "--exact",
+                "private_fs::tests::syscalls::private_directory_syscall_child",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env("CTX_DIRECTORY_SYSCALL_CASE", case)
+            .env("CTX_DIRECTORY_SYSCALL_ROOT", temp.path())
+            .output()?;
+        let trace = fs::read_to_string(&trace_path)?;
+        assert!(
+            output.status.success(),
+            "{case}: {} {}\n{trace}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let calls = trace
+            .lines()
+            .filter(|line| line.contains("fsync(") || line.contains("mkdirat("))
+            .collect::<Vec<_>>();
+        if case == "generic_create" || case == "generic_ensure" {
+            assert_eq!(calls.len(), 3, "{trace}");
+            assert!(
+                calls.iter().all(|line| line.contains("mkdirat(")),
+                "{trace}"
+            );
+        } else if case == "existing_error" {
+            assert_eq!(calls.len(), 4, "{trace}");
+            assert!(calls[0].contains("/a/b/data>"), "{trace}");
+            assert!(
+                calls[1].contains("/a/b>") && calls[1].contains("EIO"),
+                "{trace}"
+            );
+            assert!(calls[2].contains("/a/b/data>"), "{trace}");
+            assert!(
+                calls[3].contains("/a/b>") && calls[3].ends_with("= 0"),
+                "{trace}"
+            );
+        } else {
+            let a = calls
+                .iter()
+                .position(|line| line.contains("mkdirat(") && line.contains("\"a\""))
+                .unwrap();
+            let b = calls
+                .iter()
+                .rposition(|line| line.contains("mkdirat(") && line.contains("\"b\""))
+                .unwrap();
+            let data = calls
+                .iter()
+                .position(|line| line.contains("mkdirat(") && line.contains("\"data\""))
+                .unwrap();
+            assert!(
+                calls[a + 1..b]
+                    .iter()
+                    .any(|line| line.contains("/a>") && line.ends_with("= 0")),
+                "{trace}"
+            );
+            assert!(
+                calls[a + 1..b].iter().any(|line| line
+                    .contains(&format!("<{}>", temp.path().display()))
+                    && line.ends_with("= 0")),
+                "{trace}"
+            );
+            assert!(
+                calls[b + 1..data]
+                    .iter()
+                    .any(|line| line.contains("/a/b>") && line.ends_with("= 0")),
+                "{trace}"
+            );
+            assert!(
+                calls[b + 1..data]
+                    .iter()
+                    .any(|line| line.contains("/a>") && line.ends_with("= 0")),
+                "{trace}"
+            );
+        }
+        assert!(!calls.iter().any(|line| line.contains("</>")), "{trace}");
+        eprintln!(
+            "directory_durability case={case} calls={} trace={calls:?}",
+            calls.len()
+        );
+    }
+    Ok(())
+}

--- a/crates/ctx-daemon-runtime/src/private_json.rs
+++ b/crates/ctx-daemon-runtime/src/private_json.rs
@@ -205,3 +205,6 @@ pub fn read_daemon_job_status_strict(path: &Path) -> Result<Option<Value>> {
         .with_context(|| format!("decode durable daemon job status {}", path.display()))
         .map(Some)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/ctx-daemon-runtime/src/private_json/tests.rs
+++ b/crates/ctx-daemon-runtime/src/private_json/tests.rs
@@ -1,0 +1,84 @@
+use super::*;
+use ctx_history_platform::platform_security::{verify_private_directory, verify_private_file};
+use serde_json::json;
+
+fn isolated_root() -> Result<tempfile::TempDir> {
+    #[cfg(target_os = "linux")]
+    let parent = std::path::PathBuf::from("/tmp");
+    #[cfg(not(target_os = "linux"))]
+    let parent = std::env::temp_dir();
+    Ok(tempfile::Builder::new()
+        .prefix("ctx-private-json-")
+        .tempdir_in(parent)?)
+}
+
+#[test]
+fn cold_and_existing_private_json_replacements_preserve_exact_content() -> Result<()> {
+    let temp = isolated_root()?;
+    let root = temp.path().join("data");
+    let path = root.join("daemon/jobs/status.json");
+    for value in [
+        json!({"state":"running"}),
+        json!({"state":"published","receipt":"é"}),
+    ] {
+        write_private_json_file(&path, &value)?;
+        sync_private_file_parent(&path)?;
+        assert_eq!(read_daemon_job_status_strict(&path)?, Some(value));
+        verify_private_file(&path)?;
+        for directory in [&root, &root.join("daemon"), &root.join("daemon/jobs")] {
+            verify_private_directory(directory)?;
+        }
+    }
+    assert_eq!(fs::read_dir(path.parent().unwrap())?.count(), 1);
+    Ok(())
+}
+
+#[test]
+fn private_json_obstruction_errors_preserve_content_and_allow_retry() -> Result<()> {
+    let temp = isolated_root()?;
+    let blocked = temp.path().join("blocked");
+    fs::write(&blocked, "original")?;
+    let path = blocked.join("jobs/status.json");
+    assert!(write_private_json_file(&path, &json!({"new":true})).is_err());
+    assert_eq!(fs::read_to_string(&blocked)?, "original");
+    fs::remove_file(&blocked)?;
+    create_private_dir_all(path.parent().unwrap())?;
+    // A directory at the target causes an actual OS replacement error, after
+    // the temporary file was written. Its sentinel and cleanup must survive.
+    fs::create_dir(&path)?;
+    fs::write(path.join("retained"), "retained")?;
+    let value = json!({"new":true});
+    assert!(write_private_json_file(&path, &value).is_err());
+    assert_eq!(fs::read_to_string(path.join("retained"))?, "retained");
+    assert_eq!(fs::read_dir(path.parent().unwrap())?.count(), 1);
+    fs::remove_dir_all(&path)?;
+    write_private_json_file(&path, &value)?;
+    sync_private_file_parent(&path)?;
+    assert_eq!(read_daemon_job_status_strict(&path)?, Some(value));
+    verify_private_file(&path)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_no_delete_sharing_preserves_old_json_until_handle_closes() -> Result<()> {
+    use std::os::windows::fs::OpenOptionsExt;
+    use windows_sys::Win32::Storage::FileSystem::{FILE_SHARE_READ, FILE_SHARE_WRITE};
+    let temp = isolated_root()?;
+    let path = temp.path().join("status.json");
+    let old = json!({"old":true});
+    let new = json!({"new":true});
+    write_private_json_file(&path, &old)?;
+    let held = fs::OpenOptions::new()
+        .read(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .open(&path)?;
+    assert!(write_private_json_file(&path, &new).is_err());
+    assert_eq!(read_daemon_job_status_strict(&path)?, Some(old));
+    assert_eq!(fs::read_dir(temp.path())?.count(), 1);
+    drop(held);
+    write_private_json_file(&path, &new)?;
+    assert_eq!(read_daemon_job_status_strict(&path)?, Some(new));
+    verify_private_file(&path)?;
+    Ok(())
+}

--- a/crates/ctx-daemon-service/src/source_backed_refresh_adapter.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_adapter.rs
@@ -14,7 +14,7 @@ use super::source_backed_refresh_coordinator::CoreRefreshEngine;
 #[cfg(not(test))]
 pub(super) fn refresh_engine(config: &'static dyn crate::DaemonConfigPort) -> RefreshEngine {
     RefreshEngine::new(
-        Arc::new(journal::DaemonRefreshJournal),
+        Arc::new(journal::DaemonRefreshJournal::default()),
         Arc::new(runtime::DaemonRefreshRuntime::new(config)),
     )
 }

--- a/crates/ctx-daemon-service/src/source_backed_refresh_adapter/journal.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_adapter/journal.rs
@@ -1,16 +1,22 @@
-use std::path::Path;
+use std::{
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
 
 use anyhow::Result;
 use ctx_history_refresh::{DurableAdmissionPersistence, RefreshJournal};
 use serde_json::Value;
 
 use crate::paths_status::{
+    create_private_dir_all_before_ack, daemon_jobs_path, daemon_root_path,
     daemon_source_backed_refresh_job_path, read_daemon_job_status, read_daemon_job_status_strict,
     sync_private_file_parent, write_daemon_job_status,
 };
 
 #[derive(Debug, Default)]
-pub(crate) struct DaemonRefreshJournal;
+pub(crate) struct DaemonRefreshJournal {
+    initialized_root: Mutex<Option<PathBuf>>,
+}
 
 impl RefreshJournal for DaemonRefreshJournal {
     fn load(&self, data_root: &Path) -> Result<Option<Value>> {
@@ -22,8 +28,46 @@ impl RefreshJournal for DaemonRefreshJournal {
     }
 
     fn store_before_ack(&self, data_root: &Path, value: &Value) -> DurableAdmissionPersistence {
+        self.store_with_parent_sync(data_root, value, sync_private_file_parent)
+    }
+}
+
+impl DaemonRefreshJournal {
+    fn initialize(&self, data_root: &Path) -> Result<()> {
+        let data_root = std::path::absolute(data_root)?;
+        let mut initialized = self
+            .initialized_root
+            .lock()
+            .map_err(|_| anyhow::anyhow!("refresh journal initialization lock poisoned"))?;
+        if initialized.as_ref() == Some(&data_root) {
+            return Ok(());
+        }
+        // The platform directory owner confirms cold-created ancestor links
+        // before descent. Confirm our three existing boundaries too, including
+        // retries after another creator or a failed initialization. Remember
+        // success only after all of them complete; no per-progress flush.
+        for directory in [
+            &data_root,
+            &daemon_root_path(&data_root),
+            &daemon_jobs_path(&data_root),
+        ] {
+            create_private_dir_all_before_ack(directory)?;
+        }
+        *initialized = Some(data_root);
+        Ok(())
+    }
+
+    fn store_with_parent_sync(
+        &self,
+        data_root: &Path,
+        value: &Value,
+        sync_parent: impl FnOnce(&Path) -> Result<()>,
+    ) -> DurableAdmissionPersistence {
         let path = daemon_source_backed_refresh_job_path(data_root);
-        if let Err(error) = write_daemon_job_status(&path, value) {
+        if let Err(error) = self
+            .initialize(data_root)
+            .and_then(|()| write_daemon_job_status(&path, value))
+        {
             return if error
                 .downcast_ref::<crate::paths_status::PrivateJsonReplacementError>()
                 .is_some()
@@ -34,7 +78,7 @@ impl RefreshJournal for DaemonRefreshJournal {
                 DurableAdmissionPersistence::Failed(error)
             };
         }
-        match sync_private_file_parent(&path) {
+        match sync_parent(&path) {
             Ok(()) => DurableAdmissionPersistence::Confirmed,
             Err(error) => DurableAdmissionPersistence::Retained(error),
         }
@@ -50,7 +94,7 @@ mod tests {
     fn authoritative_load_distinguishes_absence_from_decode_and_read_errors() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let path = daemon_source_backed_refresh_job_path(temp.path());
-        let journal = DaemonRefreshJournal;
+        let journal = DaemonRefreshJournal::default();
         assert_eq!(journal.load(temp.path())?, None);
 
         fs::create_dir_all(path.parent().unwrap())?;
@@ -83,7 +127,7 @@ mod tests {
     #[test]
     fn authoritative_load_preserves_valid_json_without_new_schema_policy() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let journal = DaemonRefreshJournal;
+        let journal = DaemonRefreshJournal::default();
         // The engine, not this persistence adapter, owns parsed-state policy.
         let value = serde_json::json!({"request_state": "unknown", "retained": null});
         journal.store(temp.path(), &value)?;
@@ -91,3 +135,6 @@ mod tests {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod terminal_durability_tests;

--- a/crates/ctx-daemon-service/src/source_backed_refresh_adapter/journal/terminal_durability_tests.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_adapter/journal/terminal_durability_tests.rs
@@ -1,0 +1,447 @@
+use super::*;
+use ctx_history_refresh::{
+    RefreshEngine, RefreshOperation, RefreshRuntime, RefreshRuntimeMetadata,
+    SourceBackedRefreshExecution,
+};
+use serde_json::json;
+use std::sync::{
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    Arc, Mutex,
+};
+
+fn isolated_data_root() -> Result<tempfile::TempDir> {
+    // Explicit Linux experiment root avoids build-wrapper TMPDIR conventions.
+    #[cfg(target_os = "linux")]
+    let parent = std::path::PathBuf::from("/tmp");
+    #[cfg(not(target_os = "linux"))]
+    let parent = std::env::temp_dir();
+    Ok(tempfile::Builder::new()
+        .prefix("ctx-terminal-durability-")
+        .tempdir_in(parent)?)
+}
+
+#[derive(Default)]
+struct FaultJournal {
+    inner: DaemonRefreshJournal,
+    fail_parent: AtomicBool,
+    events: Mutex<Vec<String>>,
+    writes: AtomicUsize,
+    bytes: AtomicUsize,
+}
+impl RefreshJournal for FaultJournal {
+    fn load(&self, root: &Path) -> Result<Option<Value>> {
+        self.inner.load(root)
+    }
+    fn store(&self, root: &Path, value: &Value) -> Result<()> {
+        self.events
+            .lock()
+            .unwrap()
+            .push(format!("ordinary:{}", value["request_state"]));
+        self.inner.store(root, value)?;
+        self.writes.fetch_add(1, Ordering::SeqCst);
+        self.bytes.fetch_add(
+            std::fs::metadata(daemon_source_backed_refresh_job_path(root))?.len() as usize,
+            Ordering::SeqCst,
+        );
+        Ok(())
+    }
+    fn store_before_ack(&self, root: &Path, value: &Value) -> DurableAdmissionPersistence {
+        self.inner.store_with_parent_sync(root, value, |path| {
+            // The real adapter has written/synced/replaced the real file before this boundary.
+            assert_eq!(read_daemon_job_status_strict(path)?.as_ref(), Some(value));
+            self.writes.fetch_add(1, Ordering::SeqCst);
+            self.bytes
+                .fetch_add(std::fs::metadata(path)?.len() as usize, Ordering::SeqCst);
+            self.events
+                .lock()
+                .unwrap()
+                .push(format!("visible:{}", value["request_state"]));
+            if self.fail_parent.swap(false, Ordering::SeqCst) {
+                anyhow::bail!("injected parent sync failure after visible replacement");
+            }
+            sync_private_file_parent(path)?;
+            self.events
+                .lock()
+                .unwrap()
+                .push(format!("parent_synced:{}", value["request_state"]));
+            Ok(())
+        })
+    }
+}
+struct IsolatedRuntime;
+impl RefreshRuntime for IsolatedRuntime {
+    fn metadata(&self, _: &Path, operation: RefreshOperation) -> RefreshRuntimeMetadata {
+        RefreshRuntimeMetadata {
+            operation,
+            ..Default::default()
+        }
+    }
+    fn discovery_context(&self, root: &Path) -> Result<ctx_history_capture::DiscoveryContext> {
+        Ok(ctx_history_capture::DiscoveryContext::new(
+            root.join("empty-provider-home"),
+            root.join("empty-cwd"),
+            ctx_history_capture::DiscoveryPlatform::Linux,
+            ctx_history_capture::DiscoveryPlatformDirs::default(),
+        ))
+    }
+}
+fn fixture(
+    journal: Arc<FaultJournal>,
+    executions: Arc<AtomicUsize>,
+    fail_capture: bool,
+) -> RefreshEngine {
+    RefreshEngine::with_executor(
+        journal,
+        Arc::new(IsolatedRuntime),
+        Arc::new(move |execution: SourceBackedRefreshExecution<'_>| {
+            executions.fetch_add(1, Ordering::SeqCst);
+            if fail_capture {
+                anyhow::bail!("bounded provider failure");
+            }
+            crate::source_backed_refresh_coordinator::publish_authoritative_empty_generation_for_test(
+            execution.index_root, execution.request_id, execution.operation,
+            execution.admitted_refresh().publication_scope().clone(), execution.explicit_source_catalog.cloned())
+        }),
+    )
+}
+
+#[test]
+fn terminal_durability_visible_failure_stays_pending_and_retry_does_not_recapture() -> Result<()> {
+    for fail_capture in [false, true] {
+        let root = isolated_data_root()?;
+        ctx_history_platform::platform_security::establish_private_data_root(root.path())?;
+        let journal = Arc::new(FaultJournal::default());
+        let executions = Arc::new(AtomicUsize::new(0));
+        let engine = fixture(journal.clone(), executions.clone(), fail_capture);
+        let request = engine.enqueue_for_test(None);
+        let id = request["request_id"].as_str().unwrap();
+        let successor = engine.enqueue_manual_all_demand_for_test(
+            root.path(),
+            None,
+            uuid::Uuid::now_v7().to_string(),
+        )?;
+        let successor_id = successor["request_id"].as_str().unwrap();
+        journal.fail_parent.store(true, Ordering::SeqCst);
+        let run = engine
+            .run_next_with_coverage_fence_for_test(root.path(), |_, _| Ok(Default::default()))
+            .expect("real owner runs");
+        assert!(
+            run.terminal_persistence_pending,
+            "unconfirmed terminal must remain pending"
+        );
+        assert!(!run.did_work);
+        assert_eq!(
+            run.failed, fail_capture,
+            "unexpected execution outcome: {}",
+            run.job
+        );
+        assert_eq!(
+            engine.status(successor_id).unwrap()["request_state"],
+            "admission_pending"
+        );
+        let expected = if fail_capture { "failed" } else { "published" };
+        assert_eq!(
+            journal.load(root.path())?.unwrap()["request_state"],
+            expected
+        );
+        let status = engine.status(id).unwrap();
+        assert_eq!(status["request_state"], "running");
+        assert_eq!(status["progress"]["phase"], "persisting_terminal");
+        assert!(status.schema_v1_fields().get("receipt").is_none());
+        let wire_status = super::super::wire::handle_ipc_request_for_test(
+            &engine,
+            root.path(),
+            &json!({"op":"source_refresh_status", "request_id":id}),
+        )?
+        .unwrap();
+        assert_eq!(wire_status["request_state"], "running");
+        for field in ["receipt", "result", "finished_at", "structured_outcome"] {
+            assert!(wire_status.get(field).is_none(), "{wire_status}");
+        }
+        assert!(engine.has_pending_request());
+        assert_eq!(executions.load(Ordering::SeqCst), 1);
+        // Every later ordinary owner write must preserve the pending image and its flush boundary.
+        journal.fail_parent.store(true, Ordering::SeqCst);
+        assert!(engine
+            .persist_scheduler_status(root.path(), json!({"status":"retrying"}))
+            .is_err());
+        assert_eq!(engine.status(id).unwrap()["request_state"], "running");
+        let retry = engine
+            .run_next_with_coverage_fence_for_test(root.path(), |_, _| Ok(Default::default()))
+            .expect("terminal retry");
+        assert!(!retry.terminal_persistence_pending);
+        assert_eq!(engine.status(id).unwrap()["request_state"], expected);
+        let wire_status = super::super::wire::handle_ipc_request_for_test(
+            &engine,
+            root.path(),
+            &json!({"op":"source_refresh_status", "request_id":id}),
+        )?
+        .unwrap();
+        assert_eq!(wire_status["request_state"], expected);
+        assert_eq!(executions.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            engine.status(successor_id).unwrap()["request_state"],
+            "admission_pending"
+        );
+        let events = journal.events.lock().unwrap().clone();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| e.starts_with("parent_synced:"))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events.iter().filter(|e| e.starts_with("visible:")).count(),
+            3
+        );
+        eprintln!("terminal_durability fail_capture={fail_capture} captures=1 writes={} serialized_file_bytes={} events={events:?}", journal.writes.load(Ordering::SeqCst), journal.bytes.load(Ordering::SeqCst));
+    }
+    Ok(())
+}
+
+#[test]
+fn terminal_durability_every_overlay_flushes_but_running_status_does_not() -> Result<()> {
+    let root = isolated_data_root()?;
+    ctx_history_platform::platform_security::establish_private_data_root(root.path())?;
+    let journal = Arc::new(FaultJournal::default());
+    let engine = fixture(journal.clone(), Arc::new(AtomicUsize::new(0)), false);
+    let request = engine.enqueue_for_test(None);
+    let id = request["request_id"].as_str().unwrap();
+    engine.persist_job_status_for_test(root.path(), id)?;
+    assert!(journal
+        .events
+        .lock()
+        .unwrap()
+        .iter()
+        .all(|e| e.starts_with("ordinary:")));
+    let terminal = engine
+        .run_next_with_coverage_fence_for_test(root.path(), |_, _| Ok(Default::default()))
+        .unwrap();
+    assert!(!terminal.terminal_persistence_pending);
+    journal.events.lock().unwrap().clear();
+    engine.persist_job_status_for_test(root.path(), id)?;
+    engine.persist_retry_status(root.path(), terminal.job.clone())?;
+    engine.persist_scheduler_status(root.path(), terminal.job.clone())?;
+    let events = journal.events.lock().unwrap().clone();
+    assert_eq!(
+        events,
+        vec![
+            "visible:\"published\"",
+            "parent_synced:\"published\"",
+            "visible:\"published\"",
+            "parent_synced:\"published\"",
+            "visible:\"published\"",
+            "parent_synced:\"published\""
+        ]
+    );
+    eprintln!("terminal_durability overlay_writes=3 added_parent_flushes=3 lifecycle_writes={} serialized_file_bytes={} events={events:?}", journal.writes.load(Ordering::SeqCst), journal.bytes.load(Ordering::SeqCst));
+    Ok(())
+}
+
+#[test]
+fn cold_daemon_root_established_before_journal_keeps_durable_terminal() -> Result<()> {
+    let temp = isolated_data_root()?;
+    let root = temp.path().join("new-parent/data");
+    let owner = crate::paths_status::DaemonLock::acquire(&root)?.expect("isolated daemon lock");
+    assert!(root.is_dir());
+    let journal = DaemonRefreshJournal::default();
+    let terminal = json!({"request_state":"published", "request_id":"cold-root"});
+    assert!(matches!(
+        journal.store_before_ack(&root, &terminal),
+        DurableAdmissionPersistence::Confirmed
+    ));
+    drop(owner);
+    assert_eq!(DaemonRefreshJournal::default().load(&root)?, Some(terminal));
+    for directory in [&root, &root.join("daemon"), &root.join("daemon/jobs")] {
+        ctx_history_platform::platform_security::verify_private_directory(directory)?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn terminal_durability_syscall_child() -> Result<()> {
+    let Ok(case) = std::env::var("CTX_STORAGE_SYSCALL_CASE") else {
+        return Ok(());
+    };
+    let root = std::path::PathBuf::from(std::env::var_os("CTX_STORAGE_SYSCALL_ROOT").unwrap());
+    let value = json!({"request_state":"published", "request_id":"syscall-new"});
+    let journal = DaemonRefreshJournal::default();
+    // Exercise one live owner: initialization is repeated only after failure.
+    if case == "init_sync" {
+        assert!(matches!(
+            journal.store_before_ack(&root, &value),
+            DurableAdmissionPersistence::Failed(_)
+        ));
+        assert!(journal.initialized_root.lock().unwrap().is_none());
+        assert!(matches!(
+            journal.store_before_ack(&root, &value),
+            DurableAdmissionPersistence::Confirmed
+        ));
+        return Ok(());
+    }
+    journal.initialize(&root)?;
+    if case == "running" {
+        eprintln!("CTX_WARM_WRITE_BEGIN");
+        journal.store(
+            &root,
+            &json!({"request_state":"running", "request_id":"syscall-new"}),
+        )?;
+        eprintln!("CTX_WARM_WRITE_END");
+        return Ok(());
+    }
+    let result = journal.store_before_ack(&root, &value);
+    match case.as_str() {
+        "normal" => assert!(matches!(result, DurableAdmissionPersistence::Confirmed)),
+        "file_sync" | "rename" => assert!(matches!(result, DurableAdmissionPersistence::Failed(_))),
+        "parent_sync" => assert!(matches!(result, DurableAdmissionPersistence::Retained(_))),
+        _ => panic!("unknown bounded syscall case"),
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn terminal_durability_real_adapter_syscall_order_and_failures() -> Result<()> {
+    let child = "source_backed_refresh_adapter::journal::terminal_durability_tests::terminal_durability_syscall_child";
+    for (case, fault) in [
+        ("normal", None),
+        ("running", None),
+        ("init_sync", Some("fsync:error=EIO:when=2")),
+        ("file_sync", Some("fsync:error=EIO:when=7")),
+        ("rename", Some("rename:error=EIO:when=1")),
+        ("parent_sync", Some("fsync:error=EIO:when=8")),
+    ] {
+        let root = isolated_data_root()?;
+        let original = json!({"request_state":"published", "request_id":"syscall-old"});
+        assert!(matches!(
+            DaemonRefreshJournal::default().store_before_ack(root.path(), &original),
+            DurableAdmissionPersistence::Confirmed
+        ));
+        let trace_path = root.path().join("trace.log");
+        let mut command = std::process::Command::new("/usr/bin/strace");
+        command
+            .args([
+                "-f",
+                "-yy",
+                "-e",
+                "trace=fsync,rename,openat,newfstatat,statx,fchmod,chmod,close,write",
+                "-o",
+            ])
+            .arg(&trace_path);
+        if let Some(fault) = fault {
+            command.arg(format!("--inject={fault}"));
+        }
+        let output = command
+            .arg(std::env::current_exe()?)
+            .args(["--exact", child, "--nocapture", "--test-threads=1"])
+            .env("CTX_STORAGE_SYSCALL_CASE", case)
+            .env("CTX_STORAGE_SYSCALL_ROOT", root.path())
+            .output()?;
+        assert!(
+            output.status.success(),
+            "{case}: {} {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let trace = std::fs::read_to_string(trace_path)?;
+        if case == "running" {
+            let warm = trace
+                .split("CTX_WARM_WRITE_BEGIN")
+                .nth(1)
+                .unwrap()
+                .split("CTX_WARM_WRITE_END")
+                .next()
+                .unwrap();
+            let counts = [
+                "openat",
+                "newfstatat",
+                "statx",
+                "fchmod",
+                "chmod",
+                "close",
+                "fsync",
+                "rename",
+            ]
+            .map(|call| {
+                (
+                    call,
+                    warm.lines()
+                        .filter(|line| line.contains(&format!(" {call}(")))
+                        .count(),
+                )
+            });
+            assert_eq!(
+                counts.iter().find(|(call, _)| *call == "fsync").unwrap().1,
+                1,
+                "{warm}"
+            );
+            assert_eq!(
+                counts.iter().find(|(call, _)| *call == "rename").unwrap().1,
+                1,
+                "{warm}"
+            );
+            eprintln!(
+                "terminal_durability warm_path={} syscall_counts={counts:?} trace={warm:?}",
+                root.path().display()
+            );
+        }
+        let calls = trace
+            .lines()
+            .filter(|line| line.contains("fsync(") || line.contains("rename("))
+            .collect::<Vec<_>>();
+        let initialization_calls = if case == "init_sync" { 8 } else { 6 };
+        assert_eq!(
+            calls.len(),
+            initialization_calls
+                + match case {
+                    "file_sync" => 1,
+                    "rename" | "running" => 2,
+                    _ => 3,
+                },
+            "{trace}"
+        );
+        let replacements = &calls[initialization_calls..];
+        assert!(
+            replacements[0].contains("fsync(") && replacements[0].contains(".tmp>"),
+            "{trace}"
+        );
+        if case != "file_sync" {
+            assert!(replacements[1].contains("rename("), "{trace}");
+        }
+        if replacements.len() == 3 {
+            assert!(
+                replacements[2].contains("fsync(") && replacements[2].contains("/daemon/jobs>"),
+                "{trace}"
+            );
+        }
+        // No root walk: initializer visits only the selected root's containing
+        // link and its daemon/jobs chain. Running replacement adds no dir sync.
+        assert!(
+            calls[..initialization_calls]
+                .iter()
+                .all(|line| !line.contains("</>")),
+            "{trace}"
+        );
+        let expected_id = if matches!(case, "file_sync" | "rename") {
+            "syscall-old"
+        } else {
+            "syscall-new"
+        };
+        assert_eq!(
+            DaemonRefreshJournal::default().load(root.path())?.unwrap()["request_id"],
+            expected_id
+        );
+        let path = daemon_source_backed_refresh_job_path(root.path());
+        assert!(
+            std::fs::read_dir(path.parent().unwrap())?.all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .ends_with(".tmp"))
+        );
+        eprintln!("terminal_durability syscall_case={case} calls={} final_id={expected_id} trace={calls:?}", calls.len());
+    }
+    Ok(())
+}

--- a/crates/ctx-daemon-service/src/source_backed_refresh_adapter/wire.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_adapter/wire.rs
@@ -346,7 +346,7 @@ mod tests {
         let engine = super::super::refresh_engine(&crate::test_support::CONFIG);
         let id = "019fcaaa-0000-7000-8000-000000000514";
         let request = background_request(id);
-        let journal = super::super::journal::DaemonRefreshJournal;
+        let journal = super::super::journal::DaemonRefreshJournal::default();
 
         let first = handle_ipc_request(&engine, temp.path(), &request)
             .unwrap()
@@ -390,11 +390,11 @@ mod tests {
 
     impl ctx_history_refresh::RefreshJournal for AdmissionFaultJournal {
         fn load(&self, root: &Path) -> Result<Option<Value>> {
-            super::super::journal::DaemonRefreshJournal.load(root)
+            super::super::journal::DaemonRefreshJournal::default().load(root)
         }
 
         fn store(&self, root: &Path, value: &Value) -> Result<()> {
-            super::super::journal::DaemonRefreshJournal.store(root, value)
+            super::super::journal::DaemonRefreshJournal::default().store(root, value)
         }
 
         fn store_before_ack(
@@ -407,7 +407,8 @@ mod tests {
             if fault == 1 {
                 return Persistence::Failed(anyhow!("injected pre-replacement failure"));
             }
-            let result = super::super::journal::DaemonRefreshJournal.store_before_ack(root, value);
+            let result = super::super::journal::DaemonRefreshJournal::default()
+                .store_before_ack(root, value);
             if fault == 2 && matches!(result, Persistence::Confirmed) {
                 return Persistence::Retained(anyhow!("injected durability uncertainty"));
             }

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator.rs
@@ -308,14 +308,14 @@ impl CoreRefreshEngine {
 
     pub(crate) fn with_config(config: &'static dyn crate::DaemonConfigPort) -> Self {
         Self(ctx_history_refresh::RefreshEngine::new(
-            Arc::new(DaemonRefreshJournal),
+            Arc::new(DaemonRefreshJournal::default()),
             Arc::new(CliTestRefreshRuntime { config }),
         ))
     }
 
     pub(crate) fn with_executor(executor: Arc<dyn SourceBackedRefreshExecutor>) -> Self {
         Self(ctx_history_refresh::RefreshEngine::with_executor(
-            Arc::new(DaemonRefreshJournal),
+            Arc::new(DaemonRefreshJournal::default()),
             Arc::new(CliTestRefreshRuntime {
                 config: &crate::test_support::CONFIG,
             }),
@@ -370,7 +370,7 @@ impl CoreRefreshEngine {
         );
         Self(
             ctx_history_refresh::RefreshEngine::with_admission_fence_for_test(
-                Arc::new(DaemonRefreshJournal),
+                Arc::new(DaemonRefreshJournal::default()),
                 Arc::new(CliTestRefreshRuntime {
                     config: &crate::test_support::CONFIG,
                 }),
@@ -517,7 +517,7 @@ pub fn published_explicit_source_relocation_authority(
     ctx_history_refresh::published_explicit_source_relocation_authority(
         data_root,
         old_path,
-        &DaemonRefreshJournal,
+        &DaemonRefreshJournal::default(),
     )
 }
 

--- a/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/discovered_batch_tests.rs
+++ b/crates/ctx-daemon-service/src/source_backed_refresh_coordinator/discovered_batch_tests.rs
@@ -4,16 +4,17 @@ use ctx_history_refresh::{DurableAdmissionPersistence, RefreshJournal, RefreshRu
 #[derive(Default)]
 struct AdmissionJournal {
     writes: Mutex<Vec<Value>>,
+    inner: DaemonRefreshJournal,
 }
 impl RefreshJournal for AdmissionJournal {
     fn load(&self, root: &Path) -> Result<Option<Value>> {
-        DaemonRefreshJournal.load(root)
+        self.inner.load(root)
     }
     fn store(&self, root: &Path, value: &Value) -> Result<()> {
-        DaemonRefreshJournal.store(root, value)
+        self.inner.store(root, value)
     }
     fn store_before_ack(&self, root: &Path, value: &Value) -> DurableAdmissionPersistence {
-        let outcome = DaemonRefreshJournal.store_before_ack(root, value);
+        let outcome = self.inner.store_before_ack(root, value);
         self.writes.lock().unwrap().push(value.clone());
         outcome
     }
@@ -295,7 +296,17 @@ fn assert_burst(background: bool) -> Result<()> {
     assert_eq!(accepted.len(), 8);
     assert_eq!(rejected, if background { 8 } else { 0 });
     assert_eq!(
-        fixture.journal.writes.lock().unwrap().len(),
+        fixture
+            .journal
+            .writes
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|job| matches!(
+                job["request_state"].as_str(),
+                Some("admission_pending" | "queued")
+            ))
+            .count(),
         16,
         "two writes per admission"
     );
@@ -325,6 +336,26 @@ fn assert_burst(background: bool) -> Result<()> {
         1,
         "eight callers share one physical capture"
     );
+    let writes = fixture.journal.writes.lock().unwrap();
+    assert_eq!(
+        writes
+            .iter()
+            .filter(|job| job["request_state"] == "published")
+            .count(),
+        8
+    );
+    assert_eq!(
+        writes.len(),
+        24,
+        "sixteen admission and eight terminal durable writes"
+    );
+    let bytes: usize = writes
+        .iter()
+        .map(|job| serde_json::to_vec_pretty(job).unwrap().len() + 1)
+        .sum();
+    eprintln!("terminal_durability shared_capture=1 caller_ids=8 admission_writes=16 terminal_writes=8 durable_serialized_bytes={bytes}");
+    drop(writes);
+
     assert!(!fixture.engine.has_pending_request());
     let runs = runs.lock().unwrap();
     assert_eq!(runs.len(), 1);
@@ -471,7 +502,7 @@ fn background_marker_recovery_progresses_without_caller_replay() -> Result<()> {
     drop(fixture.engine);
     // Restore the actual first persisted image to exercise restart before the
     // marker-clear write. This is journal recovery, not power-loss simulation.
-    DaemonRefreshJournal.store(fixture.data_root.path(), &marker)?;
+    DaemonRefreshJournal::default().store(fixture.data_root.path(), &marker)?;
     let restarted = CoreRefreshEngine(ctx_history_refresh::RefreshEngine::new(
         fixture.journal.clone(),
         fixture.runtime.clone(),

--- a/crates/ctx-history-platform/src/platform_security/unix_private_directory.rs
+++ b/crates/ctx-history-platform/src/platform_security/unix_private_directory.rs
@@ -90,6 +90,11 @@ fn walk_private_directory_nofollow(
     };
     let mut created_private_ancestor = false;
     let mut saw_component = false;
+    let mut containing_directory: Option<File> = None;
+    let mut current_link_confirmed = false;
+    // Generic private scratch/staging creation has no persistence contract.
+    // Root establishment owns the cold ancestry needed by durable consumers.
+    let confirm_created_links = matches!(existing_final, ExistingFinalPolicy::EstablishExact);
 
     while let Some(component) = components.next() {
         let Component::Normal(name) = component else {
@@ -97,7 +102,19 @@ fn walk_private_directory_nofollow(
         };
         saw_component = true;
         let is_final = components.peek().is_none();
-        let (next, created, raced_existing) = open_or_create_directory(&current, name)?;
+        let (next, created, raced_existing) =
+            open_or_create_directory_after_missing(&current, name, || {
+                // An interrupted creator can leave its last directory visible
+                // before syncing its link. Repair that deepest existing prefix
+                // before extending it; earlier links precede descent below.
+                if confirm_created_links && !current_link_confirmed {
+                    if let Some(parent) = containing_directory.as_ref() {
+                        current.sync_all()?;
+                        parent.sync_all()?;
+                    }
+                }
+                Ok(())
+            })?;
         if created {
             clear_extended_acl(&next)?;
             verify_exact_private_directory(&next.metadata()?)?;
@@ -111,6 +128,14 @@ fn walk_private_directory_nofollow(
         } else if created_private_ancestor || raced_existing {
             verify_owner_only_directory(&next.metadata()?)?;
         }
+        if confirm_created_links && (created || raced_existing) {
+            // Confirm private metadata and the new name before descending.
+            // A concurrent creator's visible name carries the same obligation.
+            next.sync_all()?;
+            current.sync_all()?;
+        }
+        current_link_confirmed = created || raced_existing;
+        containing_directory = Some(current);
         current = next;
     }
 
@@ -217,10 +242,6 @@ pub(super) fn verify_no_extended_acl(file: &File) -> io::Result<()> {
 #[cfg(not(target_os = "macos"))]
 pub(super) fn verify_no_extended_acl(_file: &File) -> io::Result<()> {
     Ok(())
-}
-
-fn open_or_create_directory(parent: &File, name: &OsStr) -> io::Result<(File, bool, bool)> {
-    open_or_create_directory_after_missing(parent, name, || Ok(()))
 }
 
 fn open_or_create_directory_after_missing(

--- a/crates/ctx-history-refresh/src/engine/durable_queue.rs
+++ b/crates/ctx-history-refresh/src/engine/durable_queue.rs
@@ -40,7 +40,21 @@ impl CoreRefreshEngine {
     }
 
     pub(super) fn write_status(&self, data_root: &Path, job: &Value) -> Result<()> {
-        self.journal.store(data_root, job)
+        let terminal = job
+            .get("request_state")
+            .and_then(Value::as_str)
+            .and_then(|state| state.parse::<SourceBackedRefreshState>().ok())
+            .is_some_and(SourceBackedRefreshState::is_terminal);
+        if !terminal {
+            return self.journal.store(data_root, job);
+        }
+        // A later overlay replaces terminal authority too. Reuse the existing
+        // durable writer, but retained/indeterminate is not terminal success.
+        match self.journal.store_before_ack(data_root, job) {
+            DurableAdmissionPersistence::Confirmed => Ok(()),
+            DurableAdmissionPersistence::Retained(error)
+            | DurableAdmissionPersistence::Failed(error) => Err(error),
+        }
     }
 
     pub(super) fn write_durable_admission_status(

--- a/crates/ctx-history-refresh/src/journal.rs
+++ b/crates/ctx-history-refresh/src/journal.rs
@@ -1,11 +1,11 @@
 use super::*;
 
-/// Outcome of persisting the admission journal at the pre-ack boundary.
+/// Outcome of persisting the request journal at a durable boundary.
 ///
 /// A retained outcome means replacement is visible or its durability is
-/// indeterminate, so the stable request identity must remain admitted and be
-/// acknowledged. A failed outcome is known to precede replacement and may be
-/// rolled back.
+/// indeterminate, so an admission keeps its stable request identity and retries
+/// confirmation before acknowledgement. A failed admission may be rolled back.
+/// At terminal completion both errors leave the exact terminal pending.
 pub enum DurableAdmissionPersistence {
     Confirmed,
     Retained(anyhow::Error),
@@ -14,9 +14,10 @@ pub enum DurableAdmissionPersistence {
 
 /// Durable queue storage supplied by the hosting process.
 ///
-/// `store_before_ack` is the sole admission durability boundary. Implementors
-/// may perform stronger directory durability there than for later mutable
-/// status updates, while preserving one identical journal document contract.
+/// `store_before_ack` is the durability boundary for admissions and every
+/// terminal-bearing replacement, including later overlays. Only Confirmed
+/// permits acknowledgement or terminal completion. Mutable nonterminal status
+/// uses `store`, preserving one identical journal document contract.
 pub trait RefreshJournal: Send + Sync {
     fn load(&self, data_root: &Path) -> Result<Option<Value>>;
 


### PR DESCRIPTION
Terminal refresh results now wait for confirmed journal persistence before completion. Later status overlays use the same boundary, and failed persistence retries keep the exact result pending without repeating capture or advancing queued work.

On Unix, the existing data-root creator confirms new directory links before descending, and journal initialization confirms its owned directory boundaries. Failed synchronization remains retryable. After initialization, running updates in existing directories retain file sync and replacement without an added directory flush.

Validation: owning refresh, daemon, and platform tests; Linux filesystem syscall ordering, error/retry and concurrent creation cases.