### PR TITLE
test(performance): measure startup-owned cold refresh

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -535,6 +535,7 @@ py_test(
 py_test(
     name = "performance_sanity_tests",
     srcs = [
+        "scripts/tests/performance_cold_start_test.py",
         "scripts/tests/performance_family_fixtures.py",
         "scripts/tests/performance_family_runtime_test.py",
         "scripts/tests/performance_sanity_test.py",

--- a/scripts/tests/performance_cold_start_test.py
+++ b/scripts/tests/performance_cold_start_test.py
@@ -1,0 +1,264 @@
+"""Bounded regressions for startup-owned cold performance measurements."""
+
+from contextlib import ExitStack
+import copy
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+import performance_sanity_support as support
+
+
+def cold_job():
+    return {
+        "request_id": "startup-P", "owner": "daemon", "trigger": "periodic",
+        "trigger_provenance": "daemon_scheduler", "previous_generation": None,
+        "status": "completed", "request_state": "published",
+        "published_generation": "G", "generation_changed": True,
+        "timings_us": {"scan_stage": 10},
+        "receipt": {
+            "outcome": "completed", "generation_changed": True,
+            "published_generation": "G",
+            "current": {"current_indexed_documents": 12},
+        },
+    }
+
+
+def cold_status():
+    return {
+        "daemon": {"mode": "source-refresh-only", "jobs": {"core_refresh": cold_job()}},
+        "lexical": {"generation_id": "G", "indexed_documents": 12},
+    }
+
+
+class ColdStartupOwnershipTest(unittest.TestCase):
+    def test_first_cold_identity_cannot_be_replaced_by_later_changed_job(self):
+        job = cold_job()
+        job.update(status="running", receipt=None)
+        self.assertFalse(support.cold_job_completed(job, "startup-P"))
+        self.assertTrue(support.cold_job_completed(cold_job(), "startup-P"))
+        with self.assertRaisesRegex(RuntimeError, "identity"):
+            support.cold_job_completed(cold_job(), "other-request")
+
+    def test_cold_receipt_rejects_warm_noop_failed_and_missing_facts(self):
+        changes = (
+            {"request_id": None}, {"owner": "client"}, {"trigger": "search"},
+            {"previous_generation": "older"}, {"generation_changed": False},
+            {"status": "failed"}, {"status": "retry_backoff"},
+            {"request_state": "running"}, {"receipt": None},
+            {"published_generation": "other"}, {"timings_us": {}},
+        )
+        for change in changes:
+            with self.subTest(change=change), self.assertRaises(RuntimeError):
+                support.cold_job_completed({**cold_job(), **change}, "startup-P")
+        for change in (
+            {"outcome": "failed"}, {"previous_generation": "old"},
+            {"generation_changed": False}, {"published_generation": "other"},
+            {"current": None},
+        ):
+            job = cold_job()
+            job["receipt"].update(change)
+            with self.subTest(receipt=change), self.assertRaises(RuntimeError):
+                support.cold_job_completed(job, "startup-P")
+
+    def test_search_noop_keeps_cold_receipt_and_checks_live_generation(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            lexical = root / "search/lexical"
+            meta = lexical / "index-generations/G/meta.json"
+            meta.parent.mkdir(parents=True)
+            meta.write_text(json.dumps({"opstamp": 1, "segments": [{"segment_id": "one"}]}))
+            manifest = lexical / "ctx-generations/G.json"
+            manifest.parent.mkdir()
+            manifest.write_text("{}")
+            pointer = lexical / "active-generation.json"
+            pointer.write_text(json.dumps({"active": {"generation_id": "G", "directory": "G"}}))
+            retained = cold_status()
+            live = copy.deepcopy(retained)
+            live["daemon"]["jobs"]["core_refresh"].update(
+                request_id="search-S", trigger="search", previous_generation="G",
+                generation_changed=False,
+            )
+            search = {"retrieval": {"generation_id": "G", "indexed_documents": 12}}
+            with patch.object(support, "run_json", return_value=live):
+                snapshot = support.refresh_snapshot(
+                    search, root, {"CTX_DATA_ROOT": str(root)}, cold_status=retained,
+                )
+                self.assertEqual(snapshot.request_id, "startup-P")
+                self.assertTrue(snapshot.generation_changed)
+                self.assertIsNone(snapshot.previous_generation)
+                self.assertEqual(snapshot.manifest.body, b"{}")
+                self.assertEqual(snapshot.segments, ("one",))
+                self.assertEqual(live["daemon"]["jobs"]["core_refresh"]["request_id"], "search-S")
+                live["lexical"]["generation_id"] = "other"
+                with self.assertRaisesRegex(RuntimeError, "disagree"):
+                    support.refresh_snapshot(search, root, {"CTX_DATA_ROOT": str(root)}, cold_status=retained)
+                live["lexical"]["generation_id"] = "G"
+                retained["daemon"]["jobs"]["core_refresh"]["receipt"]["current"]["current_indexed_documents"] = 11
+                with self.assertRaisesRegex(RuntimeError, "disagree"):
+                    support.refresh_snapshot(search, root, {"CTX_DATA_ROOT": str(root)}, cold_status=retained)
+                retained["daemon"]["jobs"]["core_refresh"]["receipt"]["current"]["current_indexed_documents"] = 12
+                pointer.write_text(json.dumps({"active": {"generation_id": "other", "directory": "G"}}))
+                with self.assertRaisesRegex(RuntimeError, "pointer disagrees"):
+                    support.refresh_snapshot(search, root, {"CTX_DATA_ROOT": str(root)}, cold_status=retained)
+
+    def test_completion_before_readiness_includes_launch_and_lifetime_cpu(self):
+        with tempfile.TemporaryDirectory() as temporary, ExitStack() as stack:
+            root = Path(temporary)
+            env = {"CTX_DATA_ROOT": str(root / "data")}
+            clock = [0.0]
+            daemon = Mock(pid=123)
+            daemon.poll.return_value = None
+            outputs = (io.BytesIO(), io.BytesIO())
+
+            def launch(*args):
+                self.assertEqual(clock[0], 0.0)
+                journal = root / "data/daemon/jobs/core-refresh.json"
+                journal.parent.mkdir(parents=True)
+                journal.write_text(json.dumps(cold_job()))
+                clock[0] = 2.0  # Cold work can complete before Popen returns.
+                return daemon, *outputs
+
+            def ready(*args):
+                self.assertEqual(args[-1], support.COMMAND_TIMEOUT_SECONDS)
+                clock[0] = 9.0  # Readiness must not extend the cold sample.
+
+            stack.enter_context(patch.object(support.time, "monotonic", side_effect=lambda: clock[0]))
+            stack.enter_context(patch.object(support, "launch_daemon", side_effect=launch))
+            stack.enter_context(patch.object(support, "wait_daemon_ready", side_effect=ready))
+            stack.enter_context(patch.object(support, "run_json", return_value=cold_status()))
+            stack.enter_context(patch.object(support, "linux_process_cpu_ticks", return_value=300))
+            stack.enter_context(patch.object(support.os, "sysconf", return_value=100))
+            stack.enter_context(patch.object(support, "linux_source_worker_cpu_ticks", return_value={(1, "ctx-src-scan00"): 40}))
+            stack.enter_context(patch.object(support, "linux_open_fd_count", return_value=4))
+            stack.enter_context(patch.object(support, "linux_open_fd_summary", return_value=()))
+            stack.enter_context(patch.object(support, "linux_peak_rss_bytes", return_value=100))
+            result = support.start_cold_daemon(root, env)
+            sample = result[3]
+            self.assertEqual(sample.elapsed_seconds, 2.0)
+            self.assertEqual(sample.cpu_seconds, 3.0)
+            self.assertEqual(sample.source_workers[0].cpu_ticks, 40)
+            self.assertEqual(sample.packet["request_id"], "startup-P")
+            self.assertEqual(result[4], cold_status())
+            for output in outputs:
+                output.close()
+
+    def test_command_sampler_keeps_existing_delta_baselines(self):
+        with patch.object(support, "linux_process_cpu_ticks", side_effect=[100, 300]), patch.object(
+            support, "linux_source_worker_cpu_ticks",
+            side_effect=[{(1, "ctx-src-scan00"): 20}, {(1, "ctx-src-scan00"): 50}],
+        ), patch.object(support, "linux_open_fd_count", return_value=4), patch.object(
+            support, "linux_open_fd_summary", return_value=(),
+        ), patch.object(support, "linux_peak_rss_bytes", return_value=100), patch.object(
+            support.time, "monotonic", return_value=12.0,
+        ), patch.object(support.os, "sysconf", return_value=100):
+            sampler = support.DaemonSampler(123, 10.0)
+            sampler.sample()
+            result = sampler.finish({"command": "unchanged"})
+            self.assertEqual(result.elapsed_seconds, 2.0)
+            self.assertEqual(result.cpu_seconds, 2.0)
+            self.assertEqual(result.source_workers[0].cpu_ticks, 30)
+
+    def test_readiness_status_uses_only_remaining_launch_deadline(self):
+        clock = [28.0]
+        process = Mock()
+        process.poll.return_value = None
+
+        def status(*args, **kwargs):
+            self.assertEqual(kwargs["timeout_seconds"], 2.0)
+            clock[0] = 31.0
+            return {"daemon": {"running": True, "core_refresh_endpoint": {"available": True}}}
+
+        with patch.object(support.time, "monotonic", side_effect=lambda: clock[0]), patch.object(
+            support, "run_json", side_effect=status,
+        ), patch.object(support.time, "sleep"), self.assertRaises(TimeoutError):
+            support.wait_daemon_ready(
+                process, io.BytesIO(), io.BytesIO(), Path("."), {}, 30.0,
+            )
+
+    def test_existing_generation_or_journal_cannot_launch_a_cold_run(self):
+        for relative in ("search/lexical/active-generation.json", "daemon/jobs/core-refresh.json"):
+            with self.subTest(relative=relative), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                existing = root / relative
+                existing.parent.mkdir(parents=True)
+                existing.write_text("{}")
+                with patch.object(support, "launch_daemon") as launch, self.assertRaises(RuntimeError):
+                    support.start_cold_daemon(root, {"CTX_DATA_ROOT": str(root)})
+                launch.assert_not_called()
+
+    def test_failed_readiness_observation_and_timeout_close_owned_daemon(self):
+        for phase in ("readiness", "missing", "failed", "exited"):
+            with self.subTest(phase=phase), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                process = Mock(pid=123)
+                process.poll.return_value = 1 if phase == "exited" else None
+                outputs = (io.BytesIO(), io.BytesIO())
+                env = {"CTX_DATA_ROOT": str(root / "data")}
+
+                def launch(*args):
+                    if phase == "failed":
+                        journal = root / "data/daemon/jobs/core-refresh.json"
+                        journal.parent.mkdir(parents=True)
+                        journal.write_text(json.dumps({**cold_job(), "status": "failed"}))
+                    return process, *outputs
+
+                with patch.object(support, "launch_daemon", side_effect=launch), patch.object(
+                    support, "terminate_daemon_process"
+                ) as stop, patch.object(support, "DaemonSampler"), patch.object(
+                    support, "wait_daemon_ready", side_effect=TimeoutError("not ready")
+                ):
+                    with self.assertRaises((RuntimeError, TimeoutError)):
+                        if phase == "readiness":
+                            support.start_daemon(root, env)
+                        else:
+                            support.start_cold_daemon(root, env, timeout_seconds=0.01)
+                    stop.assert_called_once_with(process)
+                    self.assertTrue(all(output.closed for output in outputs))
+
+    @unittest.skipUnless(sys.platform == "linux", "Linux caller-thread affinity")
+    def test_affinity_is_inherited_before_exec_and_parent_restored(self):
+        original = os.sched_getaffinity(0)
+        selected = {min(original)}
+        popen = subprocess.Popen
+        with tempfile.TemporaryDirectory() as temporary:
+            def child(argv, **kwargs):
+                self.assertEqual(os.sched_getaffinity(0), selected)
+                return popen([sys.executable, "-c", "import os; print(sorted(os.sched_getaffinity(0)))"], **kwargs)
+
+            with patch.object(support.subprocess, "Popen", side_effect=child):
+                process, stdout, stderr = support.launch_daemon(
+                    Path(temporary), {support.TASK_BINARY_ENV: sys.executable}, selected,
+                )
+            try:
+                self.assertEqual(os.sched_getaffinity(0), original)
+                self.assertEqual(process.wait(timeout=5), 0)
+                stdout.seek(0)
+                self.assertEqual(json.loads(stdout.read()), sorted(selected))
+            finally:
+                support.close_daemon(process, stdout, stderr)
+
+    @unittest.skipUnless(sys.platform == "linux", "Linux caller-thread affinity")
+    def test_failed_launch_restores_affinity_and_closes_captures(self):
+        original = os.sched_getaffinity(0)
+        captures = []
+
+        def fail(argv, **kwargs):
+            captures.extend((kwargs["stdout"], kwargs["stderr"]))
+            self.assertEqual(os.sched_getaffinity(0), {min(original)})
+            raise OSError("inert launch failure")
+
+        with tempfile.TemporaryDirectory() as temporary, patch.object(
+            support.subprocess, "Popen", side_effect=fail,
+        ), self.assertRaises(OSError):
+            support.launch_daemon(
+                Path(temporary), {support.TASK_BINARY_ENV: sys.executable}, {min(original)},
+            )
+        self.assertEqual(os.sched_getaffinity(0), original)
+        self.assertTrue(all(output.closed for output in captures))

--- a/scripts/tests/performance_sanity_support.py
+++ b/scripts/tests/performance_sanity_support.py
@@ -175,14 +175,17 @@ def command_failure(
     )
 
 
-def run_checked(args: list[str], env: dict[str, str], cwd: Path) -> bytes:
+def run_checked(
+    args: list[str], env: dict[str, str], cwd: Path,
+    *, timeout_seconds: float = COMMAND_TIMEOUT_SECONDS,
+) -> bytes:
     completed = subprocess.run(
         [task_binary(env), *args],
         cwd=cwd,
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        timeout=COMMAND_TIMEOUT_SECONDS,
+        timeout=timeout_seconds,
         check=False,
     )
     if completed.returncode != 0:
@@ -192,8 +195,11 @@ def run_checked(args: list[str], env: dict[str, str], cwd: Path) -> bytes:
     return completed.stdout
 
 
-def run_json(args: list[str], env: dict[str, str], cwd: Path) -> dict[str, object]:
-    packet = json.loads(run_checked(args, env, cwd))
+def run_json(
+    args: list[str], env: dict[str, str], cwd: Path,
+    *, timeout_seconds: float = COMMAND_TIMEOUT_SECONDS,
+) -> dict[str, object]:
+    packet = json.loads(run_checked(args, env, cwd, timeout_seconds=timeout_seconds))
     if not isinstance(packet, dict):
         raise RuntimeError(f"{' '.join(args)} did not return a JSON object")
     return packet
@@ -315,6 +321,60 @@ def require_parallel_source_workers(
     return workers
 
 
+class DaemonSampler:
+    """One sampler for command deltas and fresh-process lifetime measurements."""
+
+    def __init__(self, pid: int, started: float, *, lifetime: bool = False):
+        self.pid = pid
+        self.started = started
+        self.initial_cpu_ticks = 0 if lifetime else linux_process_cpu_ticks(pid)
+        self.initial_worker_ticks = (
+            {} if lifetime else linux_source_worker_cpu_ticks(pid)
+        )
+        self.baseline_open_fds = linux_open_fd_count(pid)
+        self.peak_open_fds = self.baseline_open_fds
+        self.peak_open_fd_summary = linux_open_fd_summary(pid)
+        self.peak_rss_bytes = linux_peak_rss_bytes(pid)
+        self.worker_cpu_deltas: dict[tuple[int, str], int] = {}
+
+    def sample(self) -> None:
+        open_fds = linux_open_fd_count(self.pid)
+        if open_fds > self.peak_open_fds:
+            self.peak_open_fds = open_fds
+            self.peak_open_fd_summary = linux_open_fd_summary(self.pid)
+        self.peak_rss_bytes = max(
+            self.peak_rss_bytes, linux_peak_rss_bytes(self.pid)
+        )
+        for worker, ticks in linux_source_worker_cpu_ticks(self.pid).items():
+            delta = max(0, ticks - self.initial_worker_ticks.get(worker, 0))
+            self.worker_cpu_deltas[worker] = max(
+                self.worker_cpu_deltas.get(worker, 0), delta
+            )
+
+    def finish(self, packet: dict[str, object]) -> RefreshPerformanceSample:
+        elapsed_seconds = time.monotonic() - self.started
+        cpu_seconds = (
+            linux_process_cpu_ticks(self.pid) - self.initial_cpu_ticks
+        ) / os.sysconf("SC_CLK_TCK")
+        return RefreshPerformanceSample(
+            packet=packet,
+            elapsed_seconds=elapsed_seconds,
+            cpu_seconds=cpu_seconds,
+            cpu_per_wall=cpu_seconds / elapsed_seconds,
+            baseline_open_fds=self.baseline_open_fds,
+            peak_open_fds=self.peak_open_fds,
+            peak_open_fd_summary=self.peak_open_fd_summary,
+            peak_rss_bytes=self.peak_rss_bytes,
+            source_workers=tuple(
+                SourceWorkerCpu(tid=tid, name=name, cpu_ticks=ticks)
+                for (tid, name), ticks in sorted(
+                    self.worker_cpu_deltas.items(),
+                    key=lambda item: (item[0][1], item[0][0]),
+                )
+            ),
+        )
+
+
 def run_refresh_measured(
     args: list[str],
     env: dict[str, str],
@@ -323,27 +383,7 @@ def run_refresh_measured(
     timeout_seconds: float = COMMAND_TIMEOUT_SECONDS,
 ) -> RefreshPerformanceSample:
     started = time.monotonic()
-    initial_cpu_ticks = linux_process_cpu_ticks(daemon_pid)
-    initial_worker_ticks = linux_source_worker_cpu_ticks(daemon_pid)
-    baseline_open_fds = linux_open_fd_count(daemon_pid)
-    peak_open_fds = baseline_open_fds
-    peak_open_fd_summary = linux_open_fd_summary(daemon_pid)
-    peak_rss_bytes = linux_peak_rss_bytes(daemon_pid)
-    worker_cpu_deltas: dict[tuple[int, str], int] = {}
-
-    def sample_daemon() -> None:
-        nonlocal peak_open_fds, peak_open_fd_summary, peak_rss_bytes
-        open_fds = linux_open_fd_count(daemon_pid)
-        if open_fds > peak_open_fds:
-            peak_open_fds = open_fds
-            peak_open_fd_summary = linux_open_fd_summary(daemon_pid)
-        peak_rss_bytes = max(peak_rss_bytes, linux_peak_rss_bytes(daemon_pid))
-        for worker, ticks in linux_source_worker_cpu_ticks(daemon_pid).items():
-            delta = max(0, ticks - initial_worker_ticks.get(worker, 0))
-            worker_cpu_deltas[worker] = max(
-                worker_cpu_deltas.get(worker, 0), delta
-            )
-
+    sampler = DaemonSampler(daemon_pid, started)
     with tempfile.TemporaryFile(mode="w+b", dir=cwd) as stdout_file, (
         tempfile.TemporaryFile(mode="w+b", dir=cwd)
     ) as stderr_file:
@@ -356,7 +396,7 @@ def run_refresh_measured(
         )
         deadline = started + timeout_seconds
         while True:
-            sample_daemon()
+            sampler.sample()
             if process.poll() is not None:
                 break
             if time.monotonic() >= deadline:
@@ -379,28 +419,7 @@ def run_refresh_measured(
     packet = json.loads(stdout)
     if not isinstance(packet, dict):
         raise RuntimeError(f"{' '.join(args)} did not return a JSON object")
-    elapsed_seconds = time.monotonic() - started
-    clock_ticks = os.sysconf("SC_CLK_TCK")
-    cpu_seconds = (
-        linux_process_cpu_ticks(daemon_pid) - initial_cpu_ticks
-    ) / clock_ticks
-    source_workers = tuple(
-        SourceWorkerCpu(tid=tid, name=name, cpu_ticks=ticks)
-        for (tid, name), ticks in sorted(
-            worker_cpu_deltas.items(), key=lambda item: (item[0][1], item[0][0])
-        )
-    )
-    return RefreshPerformanceSample(
-        packet=packet,
-        elapsed_seconds=elapsed_seconds,
-        cpu_seconds=cpu_seconds,
-        cpu_per_wall=cpu_seconds / elapsed_seconds,
-        baseline_open_fds=baseline_open_fds,
-        peak_open_fds=peak_open_fds,
-        peak_open_fd_summary=peak_open_fd_summary,
-        peak_rss_bytes=peak_rss_bytes,
-        source_workers=source_workers,
-    )
+    return sampler.finish(packet)
 
 
 def published_file_state(path: Path) -> PublishedFileState:
@@ -600,14 +619,16 @@ def active_generation_meta_path(index_root: Path, expected_generation: str) -> P
 
 
 def refresh_snapshot(
-    search: dict[str, object], root: Path, env: dict[str, str]
+    search: dict[str, object], root: Path, env: dict[str, str],
+    *, cold_status: dict[str, object] | None = None,
 ) -> RefreshSnapshot:
     retrieval = search["retrieval"]
     generation_id = retrieval["generation_id"]
     indexed_documents = retrieval["indexed_documents"]
     deadline = time.monotonic() + COMMAND_TIMEOUT_SECONDS
     while True:
-        status = run_json(["status", "--format=json"], env, root)
+        live_status = run_json(["status", "--format=json"], env, root)
+        status = live_status if cold_status is None else cold_status
         daemon = status["daemon"]
         job = daemon["jobs"]["core_refresh"]
         if (
@@ -622,6 +643,8 @@ def refresh_snapshot(
             raise RuntimeError(
                 f"refresh failed before publishing the queried generation: {job!r}"
             )
+        if cold_status is not None:
+            raise RuntimeError("retained cold publication disagrees with search")
         if time.monotonic() >= deadline:
             raise RuntimeError(
                 "refresh did not settle on the queried generation through the "
@@ -636,6 +659,8 @@ def refresh_snapshot(
         job["published_generation"] != generation_id
         or receipt["published_generation"] != generation_id
         or status["lexical"]["generation_id"] != generation_id
+        or live_status["lexical"]["generation_id"] != generation_id
+        or live_status["lexical"]["indexed_documents"] != indexed_documents
         or current["current_indexed_documents"] != indexed_documents
     ):
         raise RuntimeError(
@@ -675,32 +700,44 @@ def refresh_snapshot(
     )
 
 
-def start_daemon(
+def launch_daemon(
     root: Path,
     env: dict[str, str],
     affinity: set[int] | None = None,
 ) -> tuple[subprocess.Popen[bytes], object, object]:
     stdout_file = (root / "daemon.stdout").open("w+b")
-    stderr_file = (root / "daemon.stderr").open("w+b")
-    process = subprocess.Popen(
-        [
-            task_binary(env),
-            "daemon",
-            "run",
-            "--force",
-            "--loop-interval-seconds",
-            "300",
-            "--format=json",
-        ],
-        cwd=root,
-        env=env,
-        stdout=stdout_file,
-        stderr=stderr_file,
-        start_new_session=os.name == "posix",
-    )
-    if affinity is not None:
-        os.sched_setaffinity(process.pid, affinity)
-    deadline = time.monotonic() + COMMAND_TIMEOUT_SECONDS
+    stderr_file = None
+    process = None
+    try:
+        stderr_file = (root / "daemon.stderr").open("w+b")
+        # Linux affinity is per calling thread and inherited across fork/exec.
+        # Set it before Popen, not on a child that may already have made workers.
+        original_affinity = os.sched_getaffinity(0) if affinity is not None else None
+        try:
+            if affinity is not None:
+                os.sched_setaffinity(0, affinity)
+            process = subprocess.Popen(
+                [task_binary(env), "daemon", "run", "--force",
+                 "--loop-interval-seconds", "300", "--format=json"],
+                cwd=root, env=env, stdout=stdout_file, stderr=stderr_file,
+                start_new_session=os.name == "posix",
+            )
+        finally:
+            if original_affinity is not None:
+                os.sched_setaffinity(0, original_affinity)
+        return process, stdout_file, stderr_file
+    except BaseException:
+        try:
+            if process is not None:
+                terminate_daemon_process(process)
+        finally:
+            stdout_file.close()
+            if stderr_file is not None:
+                stderr_file.close()
+        raise
+
+
+def wait_daemon_ready(process, stdout_file, stderr_file, root, env, deadline):
     last_status: object = None
     while time.monotonic() < deadline:
         if process.poll() is not None:
@@ -712,12 +749,12 @@ def start_daemon(
                 stdout_file.read(),
                 stderr_file.read(),
             )
-            stdout_file.close()
-            stderr_file.close()
-            terminate_daemon_process(process)
             raise error
         try:
-            status = run_json(["daemon", "status", "--format=json"], env, root)
+            status = run_json(
+                ["daemon", "status", "--format=json"], env, root,
+                timeout_seconds=max(0.0, deadline - time.monotonic()),
+            )
             last_status = status
         except (RuntimeError, subprocess.TimeoutExpired, json.JSONDecodeError):
             time.sleep(0.02)
@@ -728,10 +765,10 @@ def start_daemon(
             if isinstance(daemon, dict)
             else {}
         )
-        if daemon.get("running") is True and endpoint.get("available") is True:
-            return process, stdout_file, stderr_file
+        if (daemon.get("running") is True and endpoint.get("available") is True
+                and time.monotonic() < deadline):
+            return
         time.sleep(0.02)
-    terminate_daemon_process(process)
     stdout_file.seek(0)
     stderr_file.seek(0)
     error = TimeoutError(
@@ -740,9 +777,109 @@ def start_daemon(
         f"stdout:\n{stdout_file.read().decode(errors='replace')}\n"
         f"stderr:\n{stderr_file.read().decode(errors='replace')}"
     )
-    stdout_file.close()
-    stderr_file.close()
     raise error
+
+
+def close_daemon(process, stdout_file, stderr_file) -> None:
+    try:
+        terminate_daemon_process(process)
+    finally:
+        stdout_file.close()
+        stderr_file.close()
+
+
+def start_daemon(root, env, affinity=None):
+    process, stdout_file, stderr_file = launch_daemon(root, env, affinity)
+    try:
+        wait_daemon_ready(
+            process, stdout_file, stderr_file, root, env,
+            time.monotonic() + COMMAND_TIMEOUT_SECONDS,
+        )
+        return process, stdout_file, stderr_file
+    except BaseException:
+        close_daemon(process, stdout_file, stderr_file)
+        raise
+
+
+def cold_job_completed(job: dict[str, object], request_id: str) -> bool:
+    if (
+        not isinstance(request_id, str) or not request_id
+        or job.get("request_id") != request_id
+        or job.get("owner") != "daemon" or job.get("trigger") != "periodic"
+        or job.get("trigger_provenance") != "daemon_scheduler"
+        or job.get("previous_generation") is not None
+    ):
+        raise RuntimeError(f"cold startup request identity changed or is warm: {job!r}")
+    if job.get("status") in {"failed", "retry_backoff", "cancelled", "canceled"}:
+        raise RuntimeError(f"cold startup request failed: {job!r}")
+    if job.get("status") != "completed":
+        return False
+    receipt = job.get("receipt")
+    if (
+        job.get("request_state") != "published"
+        or job.get("generation_changed") is not True
+        or not isinstance(receipt, dict)
+        or receipt.get("outcome") != "completed"
+        or receipt.get("previous_generation") is not None
+        or receipt.get("generation_changed") is not True
+        or not job.get("published_generation")
+        or receipt.get("published_generation") != job["published_generation"]
+        or not isinstance(receipt.get("current"), dict)
+        or job.get("timings_us", {}).get("scan_stage", 0) <= 0
+    ):
+        raise RuntimeError(f"cold startup omitted a changed publication receipt: {job!r}")
+    return True
+
+
+def start_cold_daemon(root, env, affinity=None, *, timeout_seconds=COMMAND_TIMEOUT_SECONDS):
+    data = Path(env["CTX_DATA_ROOT"])
+    journal = data / "daemon/jobs/core-refresh.json"
+    if (data / "search/lexical/active-generation.json").exists() or journal.exists():
+        raise RuntimeError("cold startup requires a fresh generation and job root")
+    started = time.monotonic()
+    process, stdout_file, stderr_file = launch_daemon(root, env, affinity)
+    try:
+        sampler = DaemonSampler(process.pid, started, lifetime=True)
+        request_id = None
+        deadline = started + timeout_seconds
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                raise RuntimeError("daemon exited before cold publication")
+            sampler.sample()
+            try:
+                job = json.loads(journal.read_bytes())
+            except FileNotFoundError:
+                if request_id is not None:
+                    raise RuntimeError("observed cold startup request disappeared")
+            else:
+                if request_id is None:
+                    request_id = job.get("request_id")
+                if cold_job_completed(job, request_id):
+                    cold = sampler.finish(job)
+                    break
+            time.sleep(0.002)
+        else:
+            raise TimeoutError("cold startup did not complete its first publication")
+        # Observe publication even if it precedes endpoint readiness. No blocking
+        # readiness command may hide startup CPU or extend the cold interval.
+        wait_daemon_ready(process, stdout_file, stderr_file, root, env, deadline)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("cold startup exhausted its launch deadline")
+        status = run_json(
+            ["status", "--format=json"], env, root, timeout_seconds=remaining,
+        )
+        if time.monotonic() >= deadline:
+            raise TimeoutError("cold status exceeded its launch deadline")
+        selected = status["daemon"]["jobs"]["core_refresh"]
+        if (status["daemon"]["mode"] != "source-refresh-only"
+                or not cold_job_completed(selected, request_id)
+                or selected["receipt"] != job["receipt"]):
+            raise RuntimeError("ready status lost the observed cold publication")
+        return process, stdout_file, stderr_file, cold, status
+    except BaseException:
+        close_daemon(process, stdout_file, stderr_file)
+        raise
 
 
 def terminate_daemon_process(process: subprocess.Popen[bytes]) -> None:
@@ -798,9 +935,7 @@ def stop_daemon(
     env: dict[str, str],
 ) -> None:
     daemon_pid = process.pid
-    terminate_daemon_process(process)
-    stdout_file.close()
-    stderr_file.close()
+    close_daemon(process, stdout_file, stderr_file)
     status = run_json(["daemon", "status", "--format=json"], env, root)
     daemon = status.get("daemon", {})
     if isinstance(daemon, dict) and daemon.get("running") is True:

--- a/scripts/tests/performance_sanity_test.py
+++ b/scripts/tests/performance_sanity_test.py
@@ -33,11 +33,13 @@ from performance_sanity_support import (
     run_json,
     run_json_timed,
     run_refresh_measured,
+    start_cold_daemon,
     start_daemon,
     stop_daemon,
     task_binary,
 )
 from performance_family_runtime_test import SourceFamilyColdRefreshPerformanceTest
+from performance_cold_start_test import ColdStartupOwnershipTest
 
 
 EVENT_COUNT = 64
@@ -788,6 +790,7 @@ class TopProviderColdRefreshPerformanceTest(unittest.TestCase):
         root: Path,
         env: dict[str, str],
         corpus: RepresentativeCorpus,
+        cold_status: dict[str, object],
     ) -> RefreshSnapshot:
         self.assertEqual(
             search["freshness"],
@@ -797,7 +800,7 @@ class TopProviderColdRefreshPerformanceTest(unittest.TestCase):
                 "status": "completed",
             },
         )
-        snapshot = refresh_snapshot(search, root, env)
+        snapshot = refresh_snapshot(search, root, env, cold_status=cold_status)
         status = snapshot.status
         job = snapshot.job
         self.assertEqual(job["status"], "completed")
@@ -808,6 +811,7 @@ class TopProviderColdRefreshPerformanceTest(unittest.TestCase):
         self.assertEqual(progress["total_sources_known"], True)
         self.assertEqual(progress["completed_sources"], progress["total_sources"])
         self.assertTrue(job["generation_changed"])
+        self.assertIsNone(snapshot.previous_generation)
         self.assertEqual(job["certified_source_count"], corpus.source_count)
         self.assertEqual(job["certified_source_bytes"], corpus.fixture_bytes)
         expected_current = {
@@ -987,11 +991,16 @@ class TopProviderColdRefreshPerformanceTest(unittest.TestCase):
                 env,
                 root,
             )
-            daemon, daemon_stdout, daemon_stderr = start_daemon(
-                root, env, daemon_affinity
+            daemon, daemon_stdout, daemon_stderr, cold, cold_status = start_cold_daemon(
+                root, env, daemon_affinity,
+                timeout_seconds=(
+                    SERIAL_CONTROL_TIMEOUT_SECONDS
+                    if force_single_cpu
+                    else COMMAND_TIMEOUT_SECONDS
+                ),
             )
             try:
-                cold = run_refresh_measured(
+                search = run_json(
                     [
                         "search",
                         TOP_PROVIDER_QUERY,
@@ -1003,15 +1012,9 @@ class TopProviderColdRefreshPerformanceTest(unittest.TestCase):
                     ],
                     env,
                     root,
-                    daemon.pid,
-                    timeout_seconds=(
-                        SERIAL_CONTROL_TIMEOUT_SECONDS
-                        if force_single_cpu
-                        else COMMAND_TIMEOUT_SECONDS
-                    ),
                 )
                 snapshot = self.assert_representative_refresh(
-                    cold.packet, root, env, corpus
+                    search, root, env, corpus, cold_status
                 )
                 if verify_core_content:
                     self.assert_complete_core_content(root, env, corpus)


### PR DESCRIPTION
## What changed

Measure the first startup-owned cold refresh from before daemon launch through its completed publication. A search queued behind that work may legitimately finish as a same-generation no-op; it must not replace the cold job being measured.

The test now binds the cold request and receipt, corroborates them with status, and checks the later search against the same live generation and full corpus. CPU affinity is inherited at launch so the serial comparison is serial from the start. Existing corpus, worker, CPU-overlap and speedup assertions remain; no product scheduler or refresh behavior changes.

Adds ten focused regressions and their existing Bazel target input. Continuous-family callers retain their measurement behavior.

## Validation

- Uncached performance suite passed: 18 checks passed, one existing filesystem-dependent skip. The cold test passed with 2.18x parallel speedup.
- Uncached continuous-family suite passed all three checks.
- The separate forced-serial control failed the intended parallel-worker assertion.
- Full canonical CI passed: size preflight, CI build and all 211 selected tests, all executed. No release qualification or publication is claimed by this PR.
