### PR TITLE
test(daemon): capture lifecycle output without pipe backpressure

### DIFF
--- a/crates/ctx-daemon-cli/BUILD.bazel
+++ b/crates/ctx-daemon-cli/BUILD.bazel
@@ -216,6 +216,8 @@ daemon_cli_binary_contract(
     },
     extra_srcs = [
         "tests/contracts/native/process_control.rs",
+        "tests/contracts/persistent_daemon_lifecycle/capture.rs",
+        "tests/contracts/persistent_daemon_lifecycle/capture_tests.rs",
         "tests/contracts/persistent_daemon_lifecycle/lifecycle_regressions.rs",
     ],
     tags = [

--- a/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle.rs
@@ -30,6 +30,10 @@ mod native {
 
     static TEST_SERIAL: Mutex<()> = Mutex::new(());
 
+    #[path = "../persistent_daemon_lifecycle/capture.rs"]
+    mod capture;
+    use capture::CapturedChild;
+
     struct Harness {
         temp: TempDir,
         binary: PathBuf,
@@ -88,7 +92,7 @@ mod native {
             command
         }
 
-        fn spawn(&self, args: &[&str], input: Option<&[u8]>) -> Child {
+        fn spawn(&self, args: &[&str], input: Option<&[u8]>) -> CapturedChild {
             let mut command = self.std_command();
             command
                 .args(args)
@@ -96,19 +100,11 @@ mod native {
                     Stdio::piped()
                 } else {
                     Stdio::null()
-                })
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped());
-            let mut child = command
-                .spawn()
+                });
+            let mut child = CapturedChild::spawn(&mut command, self.temp.path())
                 .unwrap_or_else(|error| panic!("spawn ctx {:?}: {error}", args));
             if let Some(input) = input {
-                child
-                    .stdin
-                    .take()
-                    .expect("piped ctx stdin")
-                    .write_all(input)
-                    .expect("write ctx stdin");
+                child.write_input(input).expect("write ctx stdin");
             }
             child
         }
@@ -940,31 +936,10 @@ mod native {
         })
     }
 
-    fn wait_for_output(mut child: Child, timeout: Duration, args: &[&str]) -> Output {
-        let deadline = Instant::now() + timeout;
-        loop {
-            match child.try_wait() {
-                Ok(Some(_)) => return child.wait_with_output().expect("collect ctx output"),
-                Ok(None) if Instant::now() < deadline => {
-                    thread::sleep(Duration::from_millis(20));
-                }
-                Ok(None) => {
-                    let pid = child.id();
-                    let _ = child.kill();
-                    let output = child
-                        .wait_with_output()
-                        .expect("collect timed-out ctx output");
-                    panic!(
-                        "ctx {:?} pid {pid} exceeded {:?}:\nstdout:\n{}\nstderr:\n{}",
-                        args,
-                        timeout,
-                        String::from_utf8_lossy(&output.stdout),
-                        String::from_utf8_lossy(&output.stderr)
-                    );
-                }
-                Err(error) => panic!("poll ctx {:?}: {error}", args),
-            }
-        }
+    fn wait_for_output(child: CapturedChild, timeout: Duration, args: &[&str]) -> Output {
+        child
+            .output(timeout)
+            .unwrap_or_else(|error| panic!("ctx {:?}: {error}", args))
     }
 
     fn wait_for_output_best_effort(mut child: Child, timeout: Duration) -> Option<Output> {

--- a/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle/capture.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle/capture.rs
@@ -1,0 +1,140 @@
+use std::{
+    fs::File,
+    io::{self, Read, Write},
+    path::Path,
+    process::{Child, Command, Output},
+    thread,
+    time::{Duration, Instant},
+};
+
+use tempfile::NamedTempFile;
+
+use super::super::support::terminate_and_reap_test_child;
+
+// Bound snapshots and diagnostics, not instantaneous disk usage by an unpolled child.
+const MAX_CAPTURE_BYTES: u64 = 8 * 1024 * 1024;
+
+pub(super) struct CapturedChild {
+    child: Option<Child>,
+    stdout: NamedTempFile,
+    stderr: NamedTempFile,
+}
+
+impl CapturedChild {
+    pub(super) fn spawn(command: &mut Command, root: &Path) -> io::Result<Self> {
+        let stdout = NamedTempFile::new_in(root)?;
+        let stderr = NamedTempFile::new_in(root)?;
+        // Capture starts before spawn, including children collected in a later phase.
+        command.stdout(stdout.reopen()?).stderr(stderr.reopen()?);
+        Ok(Self {
+            child: Some(command.spawn()?),
+            stdout,
+            stderr,
+        })
+    }
+
+    pub(super) fn id(&self) -> u32 {
+        self.child.as_ref().expect("owned capture child").id()
+    }
+
+    pub(super) fn write_input(&mut self, input: &[u8]) -> io::Result<()> {
+        self.child
+            .as_mut()
+            .expect("owned capture child")
+            .stdin
+            .take()
+            .expect("piped capture stdin")
+            .write_all(input)
+    }
+
+    pub(super) fn terminate(&mut self) -> Result<(), String> {
+        terminate_and_reap_test_child(&mut self.child, "captured lifecycle command").map(|_| ())
+    }
+
+    pub(super) fn output(mut self, timeout: Duration) -> Result<Output, String> {
+        // Shutdown callers deliberately begin their deadline after a later signal.
+        let deadline = Instant::now() + timeout;
+        loop {
+            capture_len(&self.stdout).map_err(|error| format!("stdout capture: {error}"))?;
+            capture_len(&self.stderr).map_err(|error| format!("stderr capture: {error}"))?;
+            match self
+                .child
+                .as_mut()
+                .expect("owned capture child")
+                .try_wait()
+                .map_err(|error| format!("poll captured child: {error}"))?
+            {
+                Some(status) => {
+                    self.child.take(); // try_wait reaped this exact child's exit status.
+                    let (stdout, stderr) = self.snapshots()?;
+                    return Ok(Output {
+                        status,
+                        stdout,
+                        stderr,
+                    });
+                }
+                None if Instant::now() < deadline => thread::sleep(Duration::from_millis(20)),
+                None => {
+                    let pid = self.id();
+                    self.terminate()?;
+                    let (stdout, stderr) = self.snapshots()?;
+                    return Err(format!(
+                        "pid {pid} exceeded {timeout:?}:\nstdout:\n{}\nstderr:\n{}",
+                        String::from_utf8_lossy(&stdout),
+                        String::from_utf8_lossy(&stderr)
+                    ));
+                }
+            }
+        }
+    }
+
+    fn snapshots(&self) -> Result<(Vec<u8>, Vec<u8>), String> {
+        let stdout = snapshot(&self.stdout).map_err(|error| format!("stdout capture: {error}"))?;
+        let stderr = snapshot(&self.stderr).map_err(|error| format!("stderr capture: {error}"))?;
+        Ok((stdout, stderr))
+    }
+}
+
+impl Drop for CapturedChild {
+    fn drop(&mut self) {
+        if let Err(error) = self.terminate() {
+            if thread::panicking() {
+                eprintln!("capture teardown also failed: {error}");
+            } else {
+                panic!("capture teardown failed: {error}");
+            }
+        }
+    }
+}
+
+fn capture_len(file: &NamedTempFile) -> io::Result<u64> {
+    let len = file.as_file().metadata()?.len();
+    if len > MAX_CAPTURE_BYTES {
+        return Err(io::Error::other(format!(
+            "capture exceeds {MAX_CAPTURE_BYTES} bytes"
+        )));
+    }
+    Ok(len)
+}
+
+fn snapshot(file: &NamedTempFile) -> io::Result<Vec<u8>> {
+    let len = capture_len(file)?;
+    // Reopen independently: a seek on a cloned writer could change its offset.
+    read_snapshot(file.reopen()?, len)
+}
+
+fn read_snapshot(reader: File, len: u64) -> io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    reader.take(len).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 != len {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "capture shrank while reading",
+        ));
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+#[path = "capture_tests.rs"]
+mod tests;

--- a/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle/capture_tests.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle/capture_tests.rs
@@ -1,0 +1,273 @@
+use super::*;
+use std::{fs, io::Seek, process::Stdio};
+
+use super::super::{process_is_running, tempdir};
+
+const PAYLOAD_BYTES: usize = 2 * 1024 * 1024;
+const FIXTURE_TIMEOUT: Duration = Duration::from_secs(5);
+const MODE: &str = "CTX_TEST_FINITE_CAPTURE_MODE";
+const ROOT: &str = "CTX_TEST_FINITE_CAPTURE_ROOT";
+
+fn fixture_command(root: &Path, mode: &str, exit_code: i32) -> Command {
+    let mut command = Command::new(std::env::current_exe().unwrap());
+    command
+        .env_clear()
+        .args([
+            "--exact",
+            "native::capture::tests::output_fixture",
+            "--nocapture",
+        ])
+        .env(MODE, mode)
+        .env(ROOT, root)
+        .env("CTX_TEST_FINITE_CAPTURE_EXIT", exit_code.to_string())
+        .current_dir(root)
+        .stdin(Stdio::null());
+    #[cfg(windows)]
+    if let Some(value) = std::env::var_os("SystemRoot") {
+        command.env("SystemRoot", value);
+    }
+    command
+}
+
+fn wait_for_marker(root: &Path, name: &str) {
+    let deadline = Instant::now() + FIXTURE_TIMEOUT;
+    while !root.join(name).is_file() {
+        assert!(
+            Instant::now() < deadline,
+            "inert child did not write {name}"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn write_payload(mut writer: impl Write, byte: u8, tail: &[u8]) {
+    let chunk = [byte; 4096];
+    for _ in 0..PAYLOAD_BYTES / chunk.len() {
+        writer.write_all(&chunk).unwrap();
+    }
+    writer.write_all(tail).unwrap();
+    writer.flush().unwrap();
+}
+
+#[test]
+fn output_fixture() {
+    let Ok(mode) = std::env::var(MODE) else {
+        return;
+    };
+    let root = std::path::PathBuf::from(std::env::var_os(ROOT).unwrap());
+    let code: i32 = std::env::var("CTX_TEST_FINITE_CAPTURE_EXIT")
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert!(matches!(code, 0 | 7));
+    if mode == "stall" {
+        io::stdout().write_all(b"timeout stdout prefix\n").unwrap();
+        io::stdout().flush().unwrap();
+        io::stderr().write_all(b"timeout stderr prefix\n").unwrap();
+        io::stderr().flush().unwrap();
+    }
+    fs::write(root.join("ready"), b"ready").unwrap();
+    match mode.as_str() {
+        "stdout-first" => {
+            write_payload(io::stdout().lock(), b'O', b"\nstdout-tail\n");
+            write_payload(io::stderr().lock(), b'E', b"\nstderr-tail\n");
+        }
+        "stderr-first" => {
+            write_payload(io::stderr().lock(), b'E', b"\nstderr-tail\n");
+            write_payload(io::stdout().lock(), b'O', b"\nstdout-tail\n");
+        }
+        "stall" | "hold" => loop {
+            thread::sleep(Duration::from_secs(60));
+        },
+        _ => panic!("unknown inert capture fixture mode"),
+    }
+    fs::write(root.join("finished"), b"finished").unwrap();
+    std::process::exit(code);
+}
+
+fn assert_payload(bytes: &[u8], byte: u8, tail: &[u8]) {
+    assert!(bytes.ends_with(tail));
+    let end = bytes.len() - tail.len();
+    assert!(end >= PAYLOAD_BYTES);
+    assert!(bytes[end - PAYLOAD_BYTES..end]
+        .iter()
+        .all(|value| *value == byte));
+    // Only the libtest startup prelude may precede the exact fixture payload.
+    assert!(end - PAYLOAD_BYTES < 512);
+}
+
+fn assert_large_output(output: &Output, code: i32) {
+    assert_eq!(output.status.code(), Some(code));
+    assert_payload(&output.stdout, b'O', b"\nstdout-tail\n");
+    assert_payload(&output.stderr, b'E', b"\nstderr-tail\n");
+}
+
+#[test]
+fn captures_both_large_streams_from_spawn_with_original_exit_status() {
+    let mut children = Vec::new();
+    for (mode, code) in [("stdout-first", 0), ("stderr-first", 7)] {
+        let root = tempdir();
+        let child =
+            CapturedChild::spawn(&mut fixture_command(root.path(), mode, code), root.path())
+                .unwrap();
+        // Tuple drop order must reap the child before removing its temporary root.
+        children.push((child, root, code));
+    }
+    // Neither child has been waited/drained: both must finish despite large output.
+    for (_, root, _) in &children {
+        wait_for_marker(root.path(), "finished");
+    }
+    for (child, _root, code) in children.into_iter().rev() {
+        assert_large_output(&child.output(FIXTURE_TIMEOUT).unwrap(), code);
+    }
+}
+
+#[test]
+fn timeout_cancel_drop_and_unwind_reap_the_direct_child() {
+    for action in ["timeout", "cancel", "drop", "unwind"] {
+        let root = tempdir();
+        let mut child =
+            CapturedChild::spawn(&mut fixture_command(root.path(), "stall", 0), root.path())
+                .unwrap();
+        let pid = child.id();
+        wait_for_marker(root.path(), "ready");
+        match action {
+            "timeout" => {
+                let started = Instant::now();
+                let error = child.output(Duration::from_millis(100)).unwrap_err();
+                assert!(error.contains("exceeded 100ms"), "{error}");
+                assert!(error.contains("timeout stdout prefix"), "{error}");
+                assert!(error.contains("timeout stderr prefix"), "{error}");
+                assert!(started.elapsed() < FIXTURE_TIMEOUT);
+            }
+            "cancel" => child.terminate().unwrap(),
+            "drop" => drop(child),
+            "unwind" => {
+                assert!(std::panic::catch_unwind(move || {
+                    let _owned = child;
+                    panic!("inert owner unwind");
+                })
+                .is_err());
+            }
+            _ => unreachable!(),
+        }
+        assert!(
+            !process_is_running(pid),
+            "{action} left its direct child alive"
+        );
+    }
+}
+
+#[test]
+fn oversized_capture_fails_and_reaps_instead_of_returning_a_prefix() {
+    let root = tempdir();
+    let child =
+        CapturedChild::spawn(&mut fixture_command(root.path(), "stall", 0), root.path()).unwrap();
+    let pid = child.id();
+    wait_for_marker(root.path(), "ready");
+    child
+        .stdout
+        .as_file()
+        .set_len(MAX_CAPTURE_BYTES + 1)
+        .unwrap();
+    let error = child.output(FIXTURE_TIMEOUT).unwrap_err();
+    assert!(error.contains("stdout capture: capture exceeds"), "{error}");
+    assert!(!process_is_running(pid));
+}
+
+#[test]
+fn snapshots_have_independent_offsets_finite_lengths_and_read_errors() {
+    let root = tempdir();
+    let file = NamedTempFile::new_in(root.path()).unwrap();
+    let mut writer = file.reopen().unwrap();
+    writer.write_all(b"abcdef").unwrap();
+    assert_eq!(snapshot(&file).unwrap(), b"abcdef");
+    assert_eq!(writer.stream_position().unwrap(), 6);
+    assert_eq!(read_snapshot(file.reopen().unwrap(), 3).unwrap(), b"abc");
+    assert_eq!(
+        read_snapshot(file.reopen().unwrap(), 7).unwrap_err().kind(),
+        io::ErrorKind::UnexpectedEof
+    );
+    let write_only = File::create(root.path().join("write-only")).unwrap();
+    assert!(read_snapshot(write_only, 1).is_err());
+}
+
+// Only the legacy-pipe and retained-writer controls need a raw direct child.
+struct FixtureChild(Option<Child>);
+
+impl Drop for FixtureChild {
+    fn drop(&mut self) {
+        if let Err(error) = terminate_and_reap_test_child(&mut self.0, "inert capture control") {
+            if thread::panicking() {
+                eprintln!("{error}");
+            } else {
+                panic!("{error}");
+            }
+        }
+    }
+}
+
+#[test]
+fn a_live_output_handle_does_not_hold_capture_open() {
+    let root = tempdir();
+    let child = CapturedChild::spawn(
+        &mut fixture_command(root.path(), "stdout-first", 0),
+        root.path(),
+    )
+    .unwrap();
+    wait_for_marker(root.path(), "finished");
+    let holder_root = tempdir();
+    let mut command = fixture_command(holder_root.path(), "hold", 0);
+    let mut stdout = child.stdout.reopen().unwrap();
+    let mut stderr = child.stderr.reopen().unwrap();
+    stdout.seek(io::SeekFrom::End(0)).unwrap();
+    stderr.seek(io::SeekFrom::End(0)).unwrap();
+    command.stdout(stdout).stderr(stderr);
+    // Model a surviving inherited writer, but retain direct ownership for cleanup.
+    let mut holder = FixtureChild(Some(command.spawn().unwrap()));
+    wait_for_marker(holder_root.path(), "ready");
+    let expected_stdout = fs::read(child.stdout.path()).unwrap();
+    let expected_stderr = fs::read(child.stderr.path()).unwrap();
+    let started = Instant::now();
+    let output = child.output(FIXTURE_TIMEOUT).unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(output.stdout, expected_stdout);
+    assert_eq!(output.stderr, expected_stderr);
+    assert!(started.elapsed() < FIXTURE_TIMEOUT);
+    assert!(holder.0.as_mut().unwrap().try_wait().unwrap().is_none());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn legacy_wait_before_drain_blocks_on_either_full_pipe() {
+    use std::os::fd::AsRawFd;
+
+    for mode in ["stdout-first", "stderr-first"] {
+        let root = tempdir();
+        let mut command = fixture_command(root.path(), mode, 0);
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let mut legacy = FixtureChild(Some(command.spawn().unwrap()));
+        let child = legacy.0.as_mut().unwrap();
+        for fd in [
+            child.stdout.as_ref().unwrap().as_raw_fd(),
+            child.stderr.as_ref().unwrap().as_raw_fd(),
+        ] {
+            // SAFETY: both owned pipe descriptors remain live throughout this query.
+            let capacity = unsafe { libc::fcntl(fd, libc::F_GETPIPE_SZ) };
+            assert!(capacity > 0 && (capacity as usize) < PAYLOAD_BYTES);
+        }
+        wait_for_marker(root.path(), "ready");
+        let deadline = Instant::now() + Duration::from_millis(100);
+        while Instant::now() < deadline {
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "legacy control unexpectedly exited"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(!root.path().join("finished").exists());
+        let pid = child.id();
+        drop(legacy); // Kill/reap without ever waiting for pipe EOF.
+        assert!(!process_is_running(pid));
+    }
+}

--- a/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle/lifecycle_regressions.rs
+++ b/crates/ctx-daemon-cli/tests/contracts/persistent_daemon_lifecycle/lifecycle_regressions.rs
@@ -161,8 +161,7 @@ fn active_daemon_work_exits_within_the_process_signal_deadline() {
             None,
         );
         let marker_result = wait_for_marker(&blocked, "daemon active refresh cycle");
-        let _ = refresh_wait.kill();
-        let _ = refresh_wait.wait_with_output();
+        refresh_wait.terminate().expect("cancel and reap refresh wait");
         marker_result.unwrap_or_else(|error| panic!("{error}"));
         assert_eq!(snapshot_file(&pointer_path), retained_pointer);
 


### PR DESCRIPTION
## What changed

The persistent-daemon lifecycle harness waited for a child to exit before reading its stdout and stderr. A full pipe could therefore stop the child from exiting and cause a test timeout.

Finite command output is now captured to owned temporary files from launch and read through bounded, independent snapshots. The original nine lifecycle cases, command and signal deadlines, interactive MCP pipes, and daemon behavior remain unchanged. Cleanup reuses the existing child-termination helper.

New regressions cover both large output streams and their tails, exit codes, concurrently launched children, timeout/cancellation cleanup, oversized capture, read failures, and retained output handles. A Linux control reproduces the old wait-before-drain blockage.

## Validation

- The uncached owning target passed all 16 checks, including the original failing lifecycle case and the old-pipe control.
- Canonical CI passed: size preflight, build, and all 211 selected tests (29 executed and 182 cache hits).
- No factory or release qualification is claimed by this change.
