### PR TITLE
Clean up failed rebuild candidates and report observed disk pressure

### DIFF
--- a/crates/ctx-history-index-format/src/contracts.rs
+++ b/crates/ctx-history-index-format/src/contracts.rs
@@ -135,6 +135,14 @@ pub enum IndexError {
     )]
     CurrentRepublishInsufficientHeadroom { required: u64, available: u64 },
     #[error(
+        "indexing failed with {available} bytes observed free on the index volume; free space and retry; underlying error: {cause}"
+    )]
+    CandidateFailureWithLowSpace {
+        available: u64,
+        #[source]
+        cause: Box<IndexError>,
+    },
+    #[error(
         "Core record revisions do not match the active generation policy: normalization {normalization}/{expected_normalization}, content {content}/{expected_content}"
     )]
     CoreRecordPolicyRevisionMismatch {

--- a/crates/ctx-history-index-generation/src/clone.rs
+++ b/crates/ctx-history-index-generation/src/clone.rs
@@ -40,6 +40,29 @@ const REPUBLISH_HEADROOM_RESERVE_BYTES: u64 = 16 * 1024 * 1024;
 const MANAGED_FILE: &str = ".managed.json";
 const TANTIVY_LOCK_FILES: [&str; 2] = [".tantivy-meta.lock", ".tantivy-writer.lock"];
 
+/// Observe this candidate volume using the same platform probe as clone admission.
+pub(crate) fn candidate_available_bytes(root: &Path) -> Result<u64> {
+    #[cfg(any(test, feature = "test-support"))]
+    if portable::forced_for_test() {
+        return portable::candidate_available_bytes(root);
+    }
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        unix::candidate_available_bytes(root)
+    }
+    #[cfg(any(target_os = "windows", target_os = "freebsd"))]
+    {
+        portable::candidate_available_bytes(root)
+    }
+}
+
+/// Diagnostic observation only; failure to sample must preserve the original error.
+pub fn observed_low_candidate_space(root: &Path) -> Option<u64> {
+    candidate_available_bytes(root)
+        .ok()
+        .filter(|available| *available < REPUBLISH_HEADROOM_RESERVE_BYTES)
+}
+
 pub fn create_authenticated_candidate_generation(
     root: &Path,
     predecessor_pointer: &ActiveGenerationPointer,

--- a/crates/ctx-history-index-generation/src/clone/portable.rs
+++ b/crates/ctx-history-index-generation/src/clone/portable.rs
@@ -18,6 +18,11 @@ use crate::{
     GenerationError as IndexError, Result, INDEX_GENERATIONS_DIRECTORY,
 };
 
+pub(super) fn candidate_available_bytes(root: &Path) -> Result<u64> {
+    let directory = BoundDirectory::open_path(root)?;
+    available_bytes(&directory, false)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum EntryKind {
     Regular,

--- a/crates/ctx-history-index-generation/src/clone/unix.rs
+++ b/crates/ctx-history-index-generation/src/clone/unix.rs
@@ -38,6 +38,11 @@ use crate::{
 };
 pub(super) use guard::CandidateGuard;
 
+pub(super) fn candidate_available_bytes(root: &Path) -> Result<u64> {
+    let directory = BoundDirectory::open_path(root)?;
+    available_bytes(&directory.file, false)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct FileIdentity {
     device: u64,

--- a/crates/ctx-history-index-generation/src/lib.rs
+++ b/crates/ctx-history-index-generation/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod certification;
 mod clone;
+pub use clone::observed_low_candidate_space;
 mod durable_directory;
 mod error;
 mod generation;

--- a/crates/ctx-history-index-qualification/BUILD.bazel
+++ b/crates/ctx-history-index-qualification/BUILD.bazel
@@ -16,7 +16,10 @@ filegroup(
 ctx_rust_test(
     name = "source_backed_recovery_tests",
     testonly = True,
-    srcs = ["tests/source_backed_recovery.rs"],
+    srcs = [
+        "tests/manifest_failure.rs",
+        "tests/source_backed_recovery.rs",
+    ],
     crate_name = "ctx_history_index_qualification",
     crate_root = "tests/source_backed_recovery.rs",
     edition = crate_edition(),

--- a/crates/ctx-history-index-qualification/tests/manifest_failure.rs
+++ b/crates/ctx-history-index-qualification/tests/manifest_failure.rs
@@ -1,0 +1,101 @@
+use super::*;
+
+#[test]
+#[ignore = "requires scripts/source-backed-recovery/run-linux-fault-tests.sh"]
+fn manifest_failure_reclaims_only_its_candidate_and_preserves_visible_publication() {
+    let shim = required_fault_shim();
+    let make_incompatible = |root: &Path| {
+        let path = active_generation_path(root).join("meta.json");
+        let mut meta: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        meta["index_settings"]["docstore_blocksize"] = (64 * 1024).into();
+        fs::write(path, serde_json::to_vec(&meta).unwrap()).unwrap();
+        assert!(matches!(
+            VerifiedIndex::open_pinned(root),
+            Err(IndexError::IndexSettingsMismatch(_))
+        ));
+    };
+    let fixture = RecoveryFixture::new();
+    make_incompatible(&fixture.root);
+    let pointer_before = fs::read(fixture.root.join("active-generation.json")).unwrap();
+    let predecessor = active_generation_path(&fixture.root);
+    let payloads = fs::read_dir(&predecessor)
+        .unwrap()
+        .map(|entry| {
+            let path = entry.unwrap().path();
+            let bytes = fs::read(&path).unwrap();
+            (path, bytes)
+        })
+        .collect::<Vec<_>>();
+    let unrelated = fixture.root.join("index-generations").join("unrelated");
+    fs::create_dir(&unrelated).unwrap();
+    fs::write(unrelated.join("keep"), b"unrelated residue").unwrap();
+    for _ in 0..2 {
+        let output = fixture.run_fault_child(
+            &shim,
+            "commit_expect_error",
+            FaultCase::fail("write", "manifest_temp", "ENOSPC", None),
+        );
+        assert!(output.status.success(), "{output:?}");
+        assert!(
+            fixture.marker.is_file(),
+            "manifest write fault was not reached"
+        );
+        let error = fs::read_to_string(&fixture.result).unwrap();
+        assert!(
+            error.contains("StorageFull") || error.contains("No space left"),
+            "{error}"
+        );
+        assert_eq!(
+            fs::read(fixture.root.join("active-generation.json")).unwrap(),
+            pointer_before
+        );
+        for (path, bytes) in &payloads {
+            assert_eq!(&fs::read(path).unwrap(), bytes);
+        }
+        assert_eq!(
+            inactive_generation_directories(&fixture.root),
+            vec![unrelated.clone()]
+        );
+        assert_eq!(
+            fs::read(unrelated.join("keep")).unwrap(),
+            b"unrelated residue"
+        );
+    }
+    let receipt = staged_replacement(&fixture.root).commit(|_| true).unwrap();
+    assert_generation(
+        &fixture.root,
+        &receipt.generation_id,
+        "candidate",
+        "previous",
+    );
+
+    // The pointer is already visible when its parent-directory sync fails.
+    // Both cold creation and incompatible rebuild must retain that generation.
+    for cold in [true, false] {
+        let fixture = RecoveryFixture::new();
+        if cold {
+            fs::remove_dir_all(&fixture.root).unwrap();
+        } else {
+            make_incompatible(&fixture.root);
+        }
+        let output = fixture.run_fault_child(
+            &shim,
+            "commit_expect_error",
+            FaultCase::fail("sync", "root_dir", "EIO", Some("pointer_rename")),
+        );
+        assert!(output.status.success(), "{output:?}");
+        assert!(
+            fixture.marker.is_file(),
+            "post-rename sync fault was not reached"
+        );
+        let error = fs::read_to_string(&fixture.result).unwrap();
+        assert!(
+            error.contains("CommittedGenerationNeedsRecovery"),
+            "{error}"
+        );
+        let index = VerifiedIndex::open_pinned(&fixture.root).unwrap();
+        assert_reader_terms(&index, "candidate", "previous");
+        assert_eq!(index.manifest().indexed_documents, 1);
+    }
+}

--- a/crates/ctx-history-index-qualification/tests/source_backed_recovery.rs
+++ b/crates/ctx-history-index-qualification/tests/source_backed_recovery.rs
@@ -1,5 +1,7 @@
 #![cfg(target_os = "linux")]
 
+mod manifest_failure;
+
 use std::{
     collections::HashSet,
     env,

--- a/crates/ctx-history-index/src/lib.rs
+++ b/crates/ctx-history-index/src/lib.rs
@@ -739,7 +739,9 @@ impl GenerationWriter {
         {
             document.add_session_authority(self.fields);
         }
-        self.writer_mut()?.add_document(document)?;
+        self.writer_mut()?.add_document(document).map_err(|error| {
+            writer_publication::observe_candidate_failure(&self.root, error.into())
+        })?;
         if first_for_candidate {
             self.changed_sessions.insert(session_uuid, merged);
             if let Some(checkpoint) = self.active_source_route_stage.as_mut() {

--- a/crates/ctx-history-index/src/tests/mod.rs
+++ b/crates/ctx-history-index/src/tests/mod.rs
@@ -87,7 +87,7 @@ fn source_for_provider(provider: &str, source_format: &str, name: &str) -> Sourc
     .unwrap()
 }
 
-fn certificate(source: &SourceKey, revision: u8, documents: u64) -> CertifiedSource {
+pub(super) fn certificate(source: &SourceKey, revision: u8, documents: u64) -> CertifiedSource {
     let opening =
         SourceObservation::new(source.clone(), "regular-file-v1", vec![revision]).unwrap();
     CertifiedSource::certify(

--- a/crates/ctx-history-index/src/writer_publication.rs
+++ b/crates/ctx-history-index/src/writer_publication.rs
@@ -7,6 +7,22 @@ use ctx_history_index_format::{
 };
 use std::collections::BTreeMap;
 
+#[cfg(test)]
+#[path = "writer_publication_tests.rs"]
+mod tests;
+
+pub(super) fn observe_candidate_failure(root: &Path, error: IndexError) -> IndexError {
+    if matches!(error, IndexError::Tantivy(_)) {
+        if let Some(available) = ctx_history_index_generation::observed_low_candidate_space(root) {
+            return IndexError::CandidateFailureWithLowSpace {
+                available,
+                cause: Box::new(error),
+            };
+        }
+    }
+    error
+}
+
 #[cfg(any(test, feature = "test-support"))]
 thread_local! {
     static BASE_MANIFEST_SOURCE_MATERIALIZATIONS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
@@ -339,7 +355,8 @@ impl GenerationWriter {
             .ok_or(IndexError::WriterInvariant(
                 "mutating commit is missing its lazy writer",
             ))?
-            .prepare_commit()?;
+            .prepare_commit()
+            .map_err(|error| observe_candidate_failure(&root, error.into()))?;
         for pending in self.pending.values() {
             let certificate = pending.certificate.as_ref().ok_or_else(|| {
                 IndexError::SourceNotCertified(pending.source.identity().to_string())
@@ -383,7 +400,10 @@ impl GenerationWriter {
             }
         };
         if let Err(error) = write_prepared_manifest(&root, &prepared_manifest) {
-            let _ = prepared.abort();
+            // Keep the original writer: abort() replaces it and would lose the
+            // handle needed to establish completion of its existing merge work.
+            drop(prepared);
+            self.discard_after_manifest_failure();
             return Err(error);
         }
         prepared.set_payload(&payload);
@@ -407,7 +427,9 @@ impl GenerationWriter {
         let writer = self.writer.take().ok_or(IndexError::WriterInvariant(
             "candidate commit is missing its lazy writer",
         ))?;
-        writer.wait_merging_threads()?;
+        writer
+            .wait_merging_threads()
+            .map_err(|error| observe_candidate_failure(&root, error.into()))?;
         let (opstamp, reconciled_commit_error) = match commit_result {
             Ok(opstamp) => (opstamp, None),
             Err(error) => {
@@ -805,6 +827,26 @@ impl GenerationWriter {
                     "candidate generation directory is missing",
                 ))?;
         Ok(self.root.join(INDEX_GENERATIONS_DIRECTORY).join(directory))
+    }
+
+    // Called only before candidate commit/pointer publication, with no prepared
+    // borrow remaining. Failure to establish quiescence leaves safe residue.
+    fn discard_after_manifest_failure(mut self) {
+        let Some(writer) = self.writer.take() else {
+            return;
+        };
+        if writer.wait_merging_threads().is_err() {
+            return;
+        }
+        let fence = self.candidate_activation_fence.take();
+        let writer_lock = self.preflight_lock.take();
+        drop(self);
+        if writer_lock.is_some() {
+            if let Some(fence) = fence {
+                fence.discard();
+            }
+        }
+        drop(writer_lock);
     }
 
     fn discard_candidate(&mut self) -> Result<()> {

--- a/crates/ctx-history-index/src/writer_publication_tests.rs
+++ b/crates/ctx-history-index/src/writer_publication_tests.rs
@@ -1,0 +1,176 @@
+use super::*;
+use crate::tests::{document, source};
+use ctx_history_index_generation::{PortableCloneTestGuard, PortableCloneTestOptions};
+use tempfile::tempdir;
+
+fn worker_error() -> IndexError {
+    tantivy::TantivyError::ErrorInThread("index worker failed".to_owned()).into()
+}
+
+#[test]
+fn low_space_diagnostic_preserves_the_original_cause_and_probe_failures() {
+    let temp = tempdir().unwrap();
+    for available in [0, 16 * 1024 * 1024 - 1, 16 * 1024 * 1024, u64::MAX] {
+        let _probe = PortableCloneTestGuard::set(
+            PortableCloneTestOptions {
+                available_bytes: Some(available),
+                ..Default::default()
+            },
+            |_, _| Ok(()),
+        );
+        let error = observe_candidate_failure(temp.path(), worker_error());
+        if available < 16 * 1024 * 1024 {
+            assert!(matches!(
+                &error,
+                IndexError::CandidateFailureWithLowSpace { available: actual, cause }
+                    if *actual == available && matches!(**cause, IndexError::Tantivy(_))
+            ));
+            assert!(error.to_string().contains("bytes observed free"));
+            let cause = std::error::Error::source(&error).unwrap();
+            assert_eq!(cause.to_string(), worker_error().to_string());
+            assert!(!error.to_string().contains("ENOSPC"));
+        } else {
+            assert!(matches!(error, IndexError::Tantivy(_)));
+        }
+        assert!(matches!(
+            observe_candidate_failure(&temp.path().join("missing"), worker_error()),
+            IndexError::Tantivy(_)
+        ));
+        assert!(matches!(
+            observe_candidate_failure(temp.path(), IndexError::ConcurrentGenerationChange),
+            IndexError::ConcurrentGenerationChange
+        ));
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn native_probe_observes_space_without_restricting_a_successful_cold_commit() {
+    use ctx_history_index_generation::{CloneTestHookGuard, CloneTestOptions};
+    let temp = tempdir().unwrap();
+    let _probe = CloneTestHookGuard::set(
+        CloneTestOptions {
+            available_bytes: Some(0),
+            ..Default::default()
+        },
+        |_, _| Ok(()),
+    );
+    assert!(matches!(
+        observe_candidate_failure(temp.path(), worker_error()),
+        IndexError::CandidateFailureWithLowSpace { available: 0, .. }
+    ));
+    let source = source("cold-commit.jsonl");
+    let mut writer = GenerationWriter::open(temp.path(), WriterOptions::default())
+        .unwrap()
+        .into_writer()
+        .unwrap();
+    writer.begin_source(source.clone()).unwrap();
+    writer
+        .add_core_record(document(&source, 1, "retained content"))
+        .unwrap();
+    writer
+        .certify_source(crate::tests::certificate(&source, 1, 1))
+        .unwrap();
+    writer.commit(|_| true).unwrap();
+    assert_eq!(
+        VerifiedIndex::open(temp.path())
+            .unwrap()
+            .manifest()
+            .indexed_documents,
+        1
+    );
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn unsuccessful_worker_join_preserves_the_candidate() {
+    use ctx_history_index_generation::{CloneStage, CloneTestHookGuard, CloneTestOptions};
+    use std::os::unix::fs::PermissionsExt;
+    unsafe extern "C" {
+        fn geteuid() -> u32;
+    }
+    if unsafe { geteuid() } == 0 {
+        eprintln!("permission fault requires a non-root test process");
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let source = source("worker-failure.jsonl");
+    let mut writer = GenerationWriter::open(temp.path(), WriterOptions::default())
+        .unwrap()
+        .into_writer()
+        .unwrap();
+    writer.begin_source(source.clone()).unwrap();
+    writer.writer_mut().unwrap();
+    let candidate = writer.candidate_path().unwrap();
+    let permissions = fs::metadata(&candidate).unwrap().permissions();
+    fs::set_permissions(&candidate, fs::Permissions::from_mode(0o500)).unwrap();
+    assert_eq!(
+        fs::write(candidate.join("permission-check"), b"")
+            .unwrap_err()
+            .kind(),
+        std::io::ErrorKind::PermissionDenied
+    );
+    let _hook = CloneTestHookGuard::set(CloneTestOptions::default(), |stage, _| {
+        assert_ne!(
+            stage,
+            CloneStage::BeforeCleanup,
+            "failed join reached discard"
+        );
+        Ok(())
+    });
+    // The queued document must flush when the original writer is joined. Its
+    // directory cannot accept the segment, so completion cannot be established.
+    writer
+        .add_core_record(document(&source, 1, "cannot flush"))
+        .unwrap();
+    writer.discard_after_manifest_failure();
+    assert!(
+        candidate.is_dir(),
+        "failed join authorized candidate removal"
+    );
+    fs::set_permissions(&candidate, permissions).unwrap();
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn manifest_cleanup_holds_root_lock_and_respects_candidate_binding() {
+    use ctx_history_index_generation::{CloneStage, CloneTestHookGuard, CloneTestOptions};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+    use tantivy::directory::{error::LockError, Directory, Lock};
+    let temp = tempdir().unwrap();
+    let mut writer = GenerationWriter::open(temp.path(), WriterOptions::default())
+        .unwrap()
+        .into_writer()
+        .unwrap();
+    writer.writer_mut().unwrap();
+    let candidate = writer.candidate_path().unwrap();
+    let moved = temp.path().join("moved-candidate");
+    let root = temp.path().to_owned();
+    let called = Arc::new(AtomicBool::new(false));
+    let reached = Arc::clone(&called);
+    let _hook = CloneTestHookGuard::set(CloneTestOptions::default(), move |stage, name| {
+        if stage == CloneStage::BeforeCleanup {
+            let directory = DurableMmapDirectory::open(&root).unwrap();
+            assert!(matches!(
+                directory.acquire_lock(&Lock {
+                    filepath: GENERATION_WRITER_LOCK_FILE.into(),
+                    is_blocking: false,
+                }),
+                Err(LockError::LockBusy)
+            ));
+            let path = root.join(INDEX_GENERATIONS_DIRECTORY).join(name);
+            fs::rename(&path, root.join("moved-candidate")).unwrap();
+            fs::create_dir(&path).unwrap();
+            fs::write(path.join("foreign"), b"preserve").unwrap();
+            reached.store(true, Ordering::SeqCst);
+        }
+        Ok(())
+    });
+    writer.discard_after_manifest_failure();
+    assert!(called.load(Ordering::SeqCst));
+    assert_eq!(fs::read(candidate.join("foreign")).unwrap(), b"preserve");
+    assert!(moved.join("meta.json").is_file());
+}

--- a/crates/ctx-history-refresh/src/engine/attempt_helpers.rs
+++ b/crates/ctx-history-refresh/src/engine/attempt_helpers.rs
@@ -380,6 +380,7 @@ pub(super) fn source_backed_refresh_failure_outcome(
                 RefreshRetryAdvice::RetryAffectedRoutes,
             ),
             IndexError::Io(_)
+            | IndexError::CandidateFailureWithLowSpace { .. }
             | IndexError::IndexMemoryTooSmall { .. }
             | IndexError::VerificationScratchLimitExceeded { .. } => (
                 RefreshOutcomeCode::ResourceUnavailable,

--- a/crates/ctx-history-refresh/src/engine/tests.rs
+++ b/crates/ctx-history-refresh/src/engine/tests.rs
@@ -145,6 +145,26 @@ fn diagnostic_text_cannot_override_the_typed_terminal_outcome() {
 }
 
 #[test]
+fn observed_low_space_is_a_retryable_resource_failure() {
+    let error = anyhow::Error::new(IndexError::CandidateFailureWithLowSpace {
+        available: 0,
+        cause: Box::new(IndexError::WriterInvariant("original worker failure")),
+    });
+    let outcome = source_backed_refresh_failure_outcome(
+        &error,
+        &BTreeSet::new(),
+        &uuid::Uuid::nil().to_string(),
+    )
+    .unwrap();
+    assert_eq!(outcome.code(), RefreshOutcomeCode::ResourceUnavailable);
+    assert!(outcome.retryable());
+    assert_eq!(
+        outcome.retry_advice(),
+        Some(RefreshRetryAdvice::RetryRequest)
+    );
+}
+
+#[test]
 fn active_status_overlays_worker_facts_and_snapshots_them_on_failure() {
     let temp = tempfile::tempdir().unwrap();
     let data_root = temp.path().join("data");

--- a/scripts/source-backed-recovery/BUILD.bazel
+++ b/scripts/source-backed-recovery/BUILD.bazel
@@ -145,10 +145,25 @@ sh_test(
 test_suite(
     name = "fault_qualification",
     tests = [
+        ":manifest_failure_reclaims_only_its_candidate_and_preserves_visible_publication",
         ":inactive_generation_and_atomic_pointer_process_death_matrix",
         ":injected_enospc_and_write_sync_failures_preserve_previous_generation",
         ":retry_after_pre_pointer_crash_reclaims_inactive_generation",
         ":retry_republishes_a_reclaimed_manifest_before_pointer_publication",
         ":writer_reopen_reclaims_abandoned_atomic_write_files",
     ],
+)
+
+sh_test(
+    name = "manifest_failure_reclaims_only_its_candidate_and_preserves_visible_publication",
+    srcs = ["run-bazel-linux-fault-test.sh"],
+    args = [
+        "$(rootpath //crates/ctx-history-index-qualification:source_backed_recovery_tests)",
+        "$(rootpath :libctx_source_recovery_fault.so)",
+        "manifest_failure::manifest_failure_reclaims_only_its_candidate_and_preserves_visible_publication",
+    ],
+    data = SOURCE_BACKED_RECOVERY_FAULT_RUNFILES,
+    size = "medium",
+    tags = SOURCE_BACKED_RECOVERY_FAULT_TAGS,
+    target_compatible_with = ["@platforms//os:linux"],
 )

--- a/scripts/source-backed-recovery/fault_shim.c
+++ b/scripts/source-backed-recovery/fault_shim.c
@@ -313,6 +313,7 @@ static bool perform_action(void) {
         return false;
     }
     if (env_equals("CTX_RECOVERY_FAULT_ACTION", "fail")) {
+        write_marker();
         errno = configured_errno();
         return true;
     }


### PR DESCRIPTION
When a rebuild fails while writing its manifest, wait for the original index writer to finish and remove only that unpublished candidate while retaining the writer lock. Preserve the original failure and leave the candidate intact if completion or directory ownership cannot be established. Generations already made visible remain available after a durability error.

Selected indexing failures now include observed low free space while retaining their original cause and retry behavior. Admission is unchanged; successful indexing performs no new capacity queries.

Validation: the affected Bazel CI graph with Clippy ran 211 tests: 209 passed, and two size-policy checks caught an oversized test file. After moving the regression into a sibling module, all seven focused policy/format/qualification checks passed. The explicit manifest-failure fault test passed before and after that move; unaffected passing results were retained.
