### PR TITLE
fix(release): align Windows imports with post-bridge source

### DIFF
--- a/scripts/check-release-binary-compat.sh
+++ b/scripts/check-release-binary-compat.sh
@@ -574,6 +574,8 @@ check_windows() {
 
   # The locked platform TLS verifier uses the native Windows certificate store,
   # which imports crypt32.dll. Keep every DLL exact so unrelated imports fail.
+  # Current releases no longer import the retired pre-bridge Process Status
+  # and Restart Manager helpers (psapi.dll and rstrtmgr.dll).
   assert_exact_lines "PE imported DLLs" "$(pe_imports)" "advapi32.dll
 api-ms-win-crt-environment-l1-1-0.dll
 api-ms-win-crt-heap-l1-1-0.dll
@@ -591,8 +593,6 @@ crypt32.dll
 kernel32.dll
 ntdll.dll
 ole32.dll
-psapi.dll
-rstrtmgr.dll
 shell32.dll
 userenv.dll
 ws2_32.dll"

--- a/scripts/tests/check-release-binary-compat-test.sh
+++ b/scripts/tests/check-release-binary-compat-test.sh
@@ -399,12 +399,6 @@ Import {
   Name: ole32.dll
 }
 Import {
-  Name: psapi.dll
-}
-Import {
-  Name: rstrtmgr.dll
-}
-Import {
   Name: shell32.dll
 }
 Import {
@@ -657,7 +651,8 @@ mutate_and_fail windows_missing_high_entropy_va windows-x64 "${windows}" \
 mutate_and_fail windows_subsystem windows-x64 "${windows}" 's/IMAGE_SUBSYSTEM_WINDOWS_CUI/IMAGE_SUBSYSTEM_WINDOWS_GUI/'
 mutate_and_fail windows_version windows-x64 "${windows}" 's/MajorOperatingSystemVersion: 10/MajorOperatingSystemVersion: 11/'
 mutate_and_fail windows_subsystem_version windows-x64 "${windows}" 's/MajorSubsystemVersion: 6/MajorSubsystemVersion: 11/'
-mutate_and_fail windows_missing_restart_manager windows-x64 "${windows}" '/Name: rstrtmgr.dll/d'
+mutate_and_fail windows_retired_restart_manager windows-x64 "${windows}" 's/Name: shell32.dll/Name: shell32.dll\nName: rstrtmgr.dll/'
+mutate_and_fail windows_retired_process_status windows-x64 "${windows}" 's/Name: shell32.dll/Name: shell32.dll\nName: psapi.dll/'
 mutate_and_fail windows_crypt32_sibling windows-x64 "${windows}" 's/crypt32.dll/cryptnet.dll/'
 mutate_and_fail windows_dll windows-x64 "${windows}" 's/ws2_32.dll/winhttp.dll/'
 mutate_and_fail windows_static_symbols windows-x64 "${windows}" 's/Import {/Symbols [\n  Symbol {\n    Name: main (1)\n  }\n]\nImport {/'


### PR DESCRIPTION
Remove the retired Process Status and Restart Manager DLLs from the exact Windows release import inventory. Update the fixture to reject reintroduced imports while preserving checks for unexpected DLLs.