### PR TITLE
fix(release): isolate lzma and retain active build inputs

### DIFF
--- a/scripts/release/build-public-candidate-on-linux.sh
+++ b/scripts/release/build-public-candidate-on-linux.sh
@@ -346,7 +346,11 @@ fi
 mkdir -p "$(dirname "${output_dir}")"
 [[ ! -e "${output_dir}" ]] || die "output directory already exists: ${output_dir}"
 stage_dir="$(mktemp -d "${TMPDIR:-/tmp}/ctx-linux-release-factory.XXXXXX")"
+pids=()
 cleanup() {
+  # Other targets can still be reading shared inputs after one build fails.
+  local pid
+  for pid in "${pids[@]}"; do wait "$pid" || true; done
   rm -rf "${stage_dir:-}" "${sdk_cleanup:-}" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
@@ -394,6 +398,8 @@ build_target() {
     notify_args=(--config "${stage_dir}/notify/config.toml")
   fi
   build_env=(
+    # Build locked lzma sources; the host library can exceed the target ABI.
+    "LZMA_API_STATIC=1"
     "CARGO_TARGET_DIR=${target_dir}"
     "CTX_RELEASE_BUILD_SOURCE_COMMIT=${source_commit}"
     "CTX_RELEASE_BUILD_CARGO_LOCK_SHA256=${cargo_lock_sha256}"
@@ -421,7 +427,6 @@ build_target() {
     printf 'not run on this host: %s\n' "${platform}" >"${artifact_stage}/${binary}.version"
   fi
 }
-pids=()
 for target_id in "${target_ids[@]}"; do
   build_target "${target_id}" &
   pids+=("$!")

--- a/scripts/tests/linux-release-factory-test.py
+++ b/scripts/tests/linux-release-factory-test.py
@@ -39,6 +39,33 @@ sealer = load(SEALER, "seal_linux_factory_candidate")
 
 
 class LinuxReleaseFactoryTest(unittest.TestCase):
+    def test_factory_builds_pinned_lzma_instead_of_host_library(self) -> None:
+        source = (ROOT / "scripts/release/build-public-candidate-on-linux.sh").read_text()
+        start = source.index("build_target()")
+        build = source[start : source.index("\nfor target_id in", start)]
+        self.assertIn('"LZMA_API_STATIC=1"', build)
+
+    def test_cleanup_waits_for_started_builds_and_preserves_failure(self) -> None:
+        source = (ROOT / "scripts/release/build-public-candidate-on-linux.sh").read_text()
+        cleanup = source[source.index("cleanup() {") : source.index("trap cleanup EXIT")]
+        with tempfile.TemporaryDirectory() as directory:
+            script = '''set -euo pipefail
+stage_dir="$1/stage"
+sdk_cleanup="$1/sdk"
+mkdir "$stage_dir" "$sdk_cleanup"
+touch "$stage_dir/config.toml"
+'''+ cleanup + '''trap cleanup EXIT
+(sleep 0.2; test -f "$stage_dir/config.toml"; touch "$1/worker-finished") &
+pids=("$!")
+exit 23
+'''
+            result = subprocess.run(["bash", "-c", script, "test", directory],
+                                    capture_output=True, text=True, timeout=5)
+            self.assertEqual(result.returncode, 23, result.stderr)
+            self.assertTrue((Path(directory) / "worker-finished").is_file())
+            self.assertFalse((Path(directory) / "stage").exists())
+            self.assertFalse((Path(directory) / "sdk").exists())
+
     def test_selected_graph_uses_only_reachable_packages(self) -> None:
         metadata = {
             "packages": [


### PR DESCRIPTION
## Changes

- Build the locked bundled lzma source instead of selecting a host library that can exceed the target GLIBC requirement.
- Wait for all started target builds before deleting shared temporary inputs on failure.
- Add regressions that check static source selection and exercise cleanup with a live child while preserving the original failure status.

## Verification

- Both new tests fail against the prior factory and pass with this change; all29factory cases and the notify source tests pass.
- Full release suite:223/223tests passed; strict build checks passed.
- Actual isolated unsigned Linux x64 construction and the unchanged binary compatibility check pass. This diagnostic is not signed-release or native-matrix qualification.

No dependency version, compatibility threshold, signing requirement or publication gate changes.
